### PR TITLE
Fix structured compare

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -331,6 +331,8 @@ class recarray(ndarray):
         occupy in memory).
     offset : int, optional
         Start reading buffer (`buf`) from this offset onwards.
+    order : {'C', 'F'}, optional
+        Row-major or column-major order.
 
     Returns
     -------
@@ -387,7 +389,7 @@ class recarray(ndarray):
     """
     def __new__(subtype, shape, dtype=None, buf=None, offset=0, strides=None,
                 formats=None, names=None, titles=None,
-                byteorder=None, aligned=False):
+                byteorder=None, aligned=False, order='C'):
 
         if dtype is not None:
             descr = sb.dtype(dtype)
@@ -395,11 +397,11 @@ class recarray(ndarray):
             descr = format_parser(formats, names, titles, aligned, byteorder)._descr
 
         if buf is None:
-            self = ndarray.__new__(subtype, shape, (record, descr))
+            self = ndarray.__new__(subtype, shape, (record, descr), order=order)
         else:
             self = ndarray.__new__(subtype, shape, (record, descr),
                                       buffer=buf, offset=offset,
-                                      strides=strides)
+                                      strides=strides, order=order)
         return self
 
     def __getattribute__(self, attr):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -130,7 +130,24 @@ class TestFromrecords(TestCase):
                 b[0].c[i,j] = 10
                 assert_equal(a==b, [False,True])
                 assert_equal(a!=b, [True,False])
-
+        # Check that broadcasting with a subarray works
+        a = np.array([[(0,)],[(1,)]],dtype=[('a','f8')])
+        b = np.array([(0,),(0,),(1,)],dtype=[('a','f8')])
+        assert_equal(a==b, [[True, True, False], [False, False, True]])
+        assert_equal(b==a, [[True, True, False], [False, False, True]])
+        a = np.array([[(0,)],[(1,)]],dtype=[('a','f8',(1,))])
+        b = np.array([(0,),(0,),(1,)],dtype=[('a','f8',(1,))])
+        assert_equal(a==b, [[True, True, False], [False, False, True]])
+        assert_equal(b==a, [[True, True, False], [False, False, True]])
+        a = np.array([[([0,0],)],[([1,1],)]],dtype=[('a','f8',(2,))])
+        b = np.array([([0,0],),([0,1],),([1,1],)],dtype=[('a','f8',(2,))])
+        assert_equal(a==b, [[True, False, False], [False, False, True]])
+        assert_equal(b==a, [[True, False, False], [False, False, True]])
+        # Check that broadcasting Fortran-style arrays with a subarray work
+        a = np.array([[([0,0],)],[([1,1],)]],dtype=[('a','f8',(2,))], order='F')
+        b = np.array([([0,0],),([0,1],),([1,1],)],dtype=[('a','f8',(2,))])
+        assert_equal(a==b, [[True, False, False], [False, False, True]])
+        assert_equal(b==a, [[True, False, False], [False, False, True]])
 
 
 class TestRecord(TestCase):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -108,6 +108,30 @@ class TestFromrecords(TestCase):
         assert_equal(a.b, ['a', 'bbb'])
         assert_equal(a[-1].b, 'bbb')
 
+    def test_record_comparison(self):
+        # Check that comparisons between record arrays with
+        # multi-dimensional field types work properly
+        a = np.rec.fromrecords([([1,2,3],'a', [[1,2],[3,4]]),([3,3,3],'b',[[0,0],[0,0]])],
+                                dtype=[('a', ('f4',3)), ('b', np.object), ('c', ('i4',(2,2)))])
+        b = a.copy()
+        assert_equal(a==b, [True,True])
+        assert_equal(a!=b, [False,False])
+        b[1].b = 'c'
+        assert_equal(a==b, [True,False])
+        assert_equal(a!=b, [False,True])
+        for i in range(3):
+            b[0].a = a[0].a
+            b[0].a[i] = 5
+            assert_equal(a==b, [False,False])
+            assert_equal(a!=b, [True,True])
+        for i in range(2):
+            for j in range(2):
+                b = a.copy()
+                b[0].c[i,j] = 10
+                assert_equal(a==b, [False,True])
+                assert_equal(a!=b, [True,False])
+
+
 
 class TestRecord(TestCase):
     def setUp(self):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -108,6 +108,23 @@ class TestFromrecords(TestCase):
         assert_equal(a.b, ['a', 'bbb'])
         assert_equal(a[-1].b, 'bbb')
 
+    def test_record_subarray(self):
+        a = np.rec.recarray((3,5,), dtype=[('a',('i4',(2,2)))])
+        a['a'] = np.array(range(60)).reshape(3,5,2,2)
+
+        # Since the subarray is always in C-order, these aren't equal
+        assert a['a'].T != a.T['a']
+
+        b = a.copy(order='F')
+        assert_equal(a['a'].shape, b['a'].shape)
+        assert_equal(a, b)
+
+        c = np.rec.recarray((3,5,), dtype=[('a',('i4',(2,2)))], order='F')
+        # In Fortran order, the subarray gets appended
+        # like in all other cases, not prepended as a special case
+        c['a'] = np.array(range(60)).reshape(3,5,2,2)
+        assert_equal(b, c)
+
     def test_record_comparison(self):
         # Check that comparisons between record arrays with
         # multi-dimensional field types work properly


### PR DESCRIPTION
Here's the patch for fixing structured array comparisons with multi-dimensional field types.

http://projects.scipy.org/numpy/ticket/1640

Would it make sense to also target it for 1.5.1 or 1.5.2?

Thanks,
Mark
