### PR TITLE
Fix dtype shape comparison

### DIFF
--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -42,6 +42,33 @@ class TestRecord(TestCase):
         self.assertRaises(TypeError, np.dtype,
             dict(names=['A', 'B'], formats=set(['f8', 'i4'])))
 
+class TestShape(TestCase):
+    def test_equal(self):
+        """Test some data types that are equal"""
+        self.assertEqual(np.dtype('f8'), np.dtype(('f8',tuple())))
+        self.assertEqual(np.dtype('f8'), np.dtype(('f8',1)))
+        self.assertEqual(np.dtype((np.int,2)), np.dtype((np.int,(2,))))
+        self.assertEqual(np.dtype(('<f4',(3,2))), np.dtype(('<f4',(3,2))))
+        d = ([('a','f4',(1,2)),('b','f8',(3,1))],(3,2))
+        self.assertEqual(np.dtype(d), np.dtype(d))
+
+    def test_simple(self):
+        """Test some simple cases that shouldn't be equal"""
+        self.assertNotEqual(np.dtype('f8'), np.dtype(('f8',(1,))))
+        self.assertNotEqual(np.dtype(('f8',(1,))), np.dtype(('f8',(1,1))))
+        self.assertNotEqual(np.dtype(('f4',(3,2))), np.dtype(('f4',(2,3))))
+    
+    def test_monster(self):
+        """Test some more complicated cases that shouldn't be equal"""
+        self.assertNotEqual(np.dtype(([('a','f4',(2,1)), ('b','f8',(1,3))],(2,2))),
+                        np.dtype(([('a','f4',(1,2)), ('b','f8',(1,3))],(2,2))))
+        self.assertNotEqual(np.dtype(([('a','f4',(2,1)), ('b','f8',(1,3))],(2,2))),
+                        np.dtype(([('a','f4',(2,1)), ('b','i8',(1,3))],(2,2))))
+        self.assertNotEqual(np.dtype(([('a','f4',(2,1)), ('b','f8',(1,3))],(2,2))),
+                        np.dtype(([('e','f8',(1,3)), ('d','f4',(2,1))],(2,2))))
+        self.assertNotEqual(np.dtype(([('a',[('a','i4',6)],(2,1)), ('b','f8',(1,3))],(2,2))),
+                        np.dtype(([('a',[('a','u4',6)],(2,1)), ('b','f8',(1,3))],(2,2))))
+
 class TestSubarray(TestCase):
     def test_single_subarray(self):
         a = np.dtype((np.int, (2)))


### PR DESCRIPTION
In the discussion for the 'Fix structured compare' pull request, it turned out that dtype comparison wasn't checking the subarray at all.  It seemed like a separate issue to me, so I made a new branch for it.  I've implemented tests and a fix in the C code for this.  Should I make a ticket, or is just a pull request sufficient?

-Mark
