### PR TITLE
Farchs 2.0

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -216,7 +216,7 @@ class GnuFCompiler(FCompiler):
         return arch_flags
 
     def get_flags_arch(self):
-        return self._c_arch_flags()
+        return []
 
 class Gnu95FCompiler(GnuFCompiler):
     compiler_type = 'gnu95'
@@ -265,6 +265,36 @@ class Gnu95FCompiler(GnuFCompiler):
     module_include_switch = '-I'
 
     g2c = 'gfortran'
+
+    def _universal_flags(self, cmd):
+        """Return a list of -arch flags for every supported architecture."""
+        if not sys.platform == 'darwin':
+            return []
+        arch_flags = []
+        # get arches the C compiler gets.
+        c_archs = self._c_arch_flags()
+        if "i386" in c_archs:
+            c_archs[c_archs.index("i386")] = "i686"
+        # check the arches the Fortran compiler supports, and compare with
+        # arch flags from C compiler
+        for arch in ["ppc", "i686", "x86_64", "ppc64"]:
+            if _can_target(cmd, arch) and arch in c_archs:
+                arch_flags.extend(["-arch", arch])
+        return arch_flags
+
+    def get_flags(self):
+        flags = GnuFCompiler.get_flags(self)
+        arch_flags = self._universal_flags(self.compiler_f90)
+        if arch_flags:
+            flags[:0] = arch_flags
+        return flags
+
+    def get_flags_linker_so(self):
+        flags = GnuFCompiler.get_flags_linker_so(self)
+        arch_flags = self._universal_flags(self.linker_so)
+        if arch_flags:
+            flags[:0] = arch_flags
+        return flags
 
     def get_library_dirs(self):
         opt = GnuFCompiler.get_library_dirs(self)


### PR DESCRIPTION
This should fix #1399. The changes revert part of SHA: 4e177d36755ea5ea70f6512d12f7028639612d3e (which was incorrect, resulting in .so files with only a single arch), the diff of both these commits together is:

```
@@ -202,6 +202,19 @@ class GnuFCompiler(FCompiler):
         opt.append('-funroll-loops')
         return opt

+    def _c_arch_flags(self):
+        """ Return detected arch flags from CFLAGS """
+        from distutils import sysconfig
+        try:
+            cflags = sysconfig.get_config_vars()['CFLAGS']
+        except KeyError:
+            return []
+        arch_re = re.compile(r"-arch\s+(\w+)")
+        arch_flags = []
+        for arch in arch_re.findall(cflags):
+            arch_flags += ['-arch', arch]
+        return arch_flags
+
     def get_flags_arch(self):
         return []

@@ -254,8 +267,14 @@ class Gnu95FCompiler(GnuFCompiler):
         if not sys.platform == 'darwin':
             return []
         arch_flags = []
+        # get arches the C compiler gets.
+        c_archs = self._c_arch_flags()
+        if "i386" in c_archs:
+            c_archs[c_archs.index("i386")] = "i686"
+        # check the arches the Fortran compiler supports, and compare with
+        # arch flags from C compiler
         for arch in ["ppc", "i686", "x86_64", "ppc64"]:
-            if _can_target(cmd, arch):
+            if _can_target(cmd, arch) and arch in c_archs:
                 arch_flags.extend(["-arch", arch])
         return arch_flags
```

Will backport to 1.5.x after this is committed.
