### PR TITLE
Datetime64s hours more than 24

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -596,7 +596,7 @@ PyArray_DatetimeToDatetimeStruct(npy_datetime val, NPY_DATETIMEUNIT fr,
             ymd = days_to_ymdstruct((val - 86399) / 86400);
             sec = 86399 + (val + 1) % 86400;
         }
-        hms = seconds_to_hmsstruct(val);
+        hms = seconds_to_hmsstruct(sec);
         year   = ymd.year;
         month  = ymd.month;
         day    = ymd.day;

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -12,6 +12,12 @@ class TestDateTime(TestCase):
             dt2 = np.dtype('m8[%s]' % unit)
             assert dt2 == np.dtype('timedelta64[%s]' % unit)
 
+
+    def test_hours(self):
+        t = np.ones(3, dtype='M8[s]')
+        t[0] = 60*60*24 + 60*60*10
+        assert t[0].item().hour == 10 
+
     def test_divisor_conversion_year(self):
         assert np.dtype('M8[Y/4]') == np.dtype('M8[3M]')
         assert np.dtype('M8[Y/13]') == np.dtype('M8[4W]')


### PR DESCRIPTION
Small fix to avoid messed up hours when using M8[s] , with added test  
