### PR TITLE
Apply patch from ticket #1475.

### DIFF
--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -3,6 +3,13 @@ from numpy.lib import *
 from numpy.core import *
 from numpy.compat import asbytes
 
+try: 
+    import ctypes 
+    _HAS_CTYPE = True 
+except ImportError: 
+    _HAS_CTYPE = False 
+
+    
 def assert_all(x):
     assert(all(x)), x
 
@@ -375,9 +382,9 @@ class TestArrayConversion(TestCase):
         assert_equal(a.__class__,ndarray)
         assert issubdtype(a.dtype,float)
 
-
 class TestDateTimeData:
 
+    @dec.skipif(not _HAS_CTYPE, "ctypes not available on this python installation")
     def test_basic(self):
         a = array(['1980-03-23'], dtype=datetime64)
         assert_equal(datetime_data(a.dtype), (asbytes('us'), 1, 1, 1))


### PR DESCRIPTION
Apply patch by bsouthey in Ticket #1475 to turn off appropriate tests when 
ctypes is not installed.  This is of particular importance to STScI since this
test is breaking our nightly build/test setup.

Thanks for your time and help,
Chris Hanley
chanley@stsci.edu
