### PR TITLE
[resubmitted] Add 'minlength' keyword to np.bincount (with docs+tests)

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3796,12 +3796,15 @@ add_newdoc('numpy.lib._compiled_base', 'digitize',
 
 add_newdoc('numpy.lib._compiled_base', 'bincount',
     """
-    bincount(x, weights=None)
+    bincount(x, weights=None, minlength=None)
 
     Count number of occurrences of each value in array of non-negative ints.
 
     The number of bins (of size 1) is one larger than the largest value in
-    `x`. Each bin gives the number of occurrences of its index value in `x`.
+    `x`. If `minlength` is specified, there will be at least this number
+    of bins in the output array (though it will be longer if necessary,
+    depending on the contents of `x`).
+    Each bin gives the number of occurrences of its index value in `x`.
     If `weights` is specified the input array is weighted by it, i.e. if a
     value ``n`` is found at position ``i``, ``out[n] += weight[i]`` instead
     of ``out[n] += 1``.
@@ -3812,6 +3815,8 @@ add_newdoc('numpy.lib._compiled_base', 'bincount',
         Input array.
     weights : array_like, optional
         Weights, array of the same shape as `x`.
+    minlength : integer, optional
+        A minimum number of bins for the output array.
 
     Returns
     -------
@@ -3823,7 +3828,7 @@ add_newdoc('numpy.lib._compiled_base', 'bincount',
     ------
     ValueError
         If the input is not 1-dimensional, or contains elements with negative
-        values.
+        values, or if `minlength` is non-positive.
     TypeError
         If the type of the input is float or complex.
 

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -140,7 +140,7 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
         if (minlength <= 0) {
             /* superfluous, but may catch incorrect usage */
             PyErr_SetString(PyExc_ValueError,
-                    "minlength, if specified, must be positive.");
+                    "minlength must be positive");
             goto fail;
         }
         if (ans_size < minlength) {

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1026,6 +1026,21 @@ class TestBincount(TestCase):
         y = np.bincount(x, w)
         assert_array_equal(y, np.array([0, 0.2, 0.5, 0, 0.5, 0.1]))
 
+    def test_with_minlength(self):
+        x = np.array([0, 1, 0, 1, 1])
+        y = np.bincount(x, minlength=3)
+        assert_array_equal(y, np.array([2, 3, 0]))
+
+    def test_with_minlength_smaller_than_maxvalue(self):
+        x = np.array([0, 1, 1, 2, 2, 3, 3])
+        y = np.bincount(x, minlength=2)
+        assert_array_equal(y, np.array([1, 2, 2, 2]))
+
+    def test_with_minlength_and_weights(self):
+        x = np.array([1, 2, 4, 5, 2])
+        w = np.array([0.2, 0.3, 0.5, 0.1, 0.2])
+        y = np.bincount(x, w, 8)
+        assert_array_equal(y, np.array([0, 0.2, 0.5, 0, 0.5, 0.1, 0, 0]))
 
 class TestInterp(TestCase):
     def test_exceptions(self):


### PR DESCRIPTION
This is a resubmission of [this pull request](https://github.com/numpy/numpy/pull/32) taking into account Chuck's comment about the error message. I'm not sure if there's a way to add commits to a pull request, I couldn't find it; if there is I apologize for opening a second one.

This is an old patch filed as [ticket 1595](http://projects.scipy.org/numpy/ticket/1595). Robert Kern gave a [tentative +1](http://mail.scipy.org/pipermail/numpy-discussion/2010-August/052485.html) to this feature on the mailing list, so I went ahead and implemented it.
