### PR TITLE
Py32 cleanup

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -421,7 +421,7 @@ class TestTypes(TestCase):
         assert_(np.can_cast(np.int32, np.int64))
         assert_(np.can_cast(np.float64, np.complex))
         assert_(not np.can_cast(np.complex, np.float))
-        
+
         assert_(np.can_cast('i8', 'f8'))
         assert_(not np.can_cast('i8', 'f4'))
         assert_(np.can_cast('i4', 'S4'))
@@ -1027,7 +1027,7 @@ class TestClip(TestCase):
         a2 = clip(a, m, M, out=a)
         self.clip(a, m, M, ac)
         assert_array_strict_equal(a2, ac)
-        self.assert_(a2 is a)
+        self.assertTrue(a2 is a)
 
 
 class test_allclose_inf(TestCase):
@@ -1150,7 +1150,7 @@ class TestLikeFuncs(TestCase):
             # default (K) order, dtype
             dz = like_function(d, dtype=dtype)
             assert_equal(dz.shape, d.shape)
-            assert_equal(array(dz.strides)*d.dtype.itemsize, 
+            assert_equal(array(dz.strides)*d.dtype.itemsize,
                          array(d.strides)*dz.dtype.itemsize)
             if dtype is None:
                 assert_equal(dz.dtype, d.dtype)

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -104,30 +104,30 @@ class create_zeros(object):
     def test_zeros0D(self):
         """Check creation of 0-dimensional objects"""
         h = np.zeros((), dtype=self._descr)
-        self.assert_(normalize_descr(self._descr) == h.dtype.descr)
-        self.assert_(h.dtype.fields['x'][0].name[:4] == 'void')
-        self.assert_(h.dtype.fields['x'][0].char == 'V')
-        self.assert_(h.dtype.fields['x'][0].type == np.void)
+        self.assertTrue(normalize_descr(self._descr) == h.dtype.descr)
+        self.assertTrue(h.dtype.fields['x'][0].name[:4] == 'void')
+        self.assertTrue(h.dtype.fields['x'][0].char == 'V')
+        self.assertTrue(h.dtype.fields['x'][0].type == np.void)
         # A small check that data is ok
         assert_equal(h['z'], np.zeros((), dtype='u1'))
 
     def test_zerosSD(self):
         """Check creation of single-dimensional objects"""
         h = np.zeros((2,), dtype=self._descr)
-        self.assert_(normalize_descr(self._descr) == h.dtype.descr)
-        self.assert_(h.dtype['y'].name[:4] == 'void')
-        self.assert_(h.dtype['y'].char == 'V')
-        self.assert_(h.dtype['y'].type == np.void)
+        self.assertTrue(normalize_descr(self._descr) == h.dtype.descr)
+        self.assertTrue(h.dtype['y'].name[:4] == 'void')
+        self.assertTrue(h.dtype['y'].char == 'V')
+        self.assertTrue(h.dtype['y'].type == np.void)
         # A small check that data is ok
         assert_equal(h['z'], np.zeros((2,), dtype='u1'))
 
     def test_zerosMD(self):
         """Check creation of multi-dimensional objects"""
         h = np.zeros((2,3), dtype=self._descr)
-        self.assert_(normalize_descr(self._descr) == h.dtype.descr)
-        self.assert_(h.dtype['z'].name == 'uint8')
-        self.assert_(h.dtype['z'].char == 'B')
-        self.assert_(h.dtype['z'].type == np.uint8)
+        self.assertTrue(normalize_descr(self._descr) == h.dtype.descr)
+        self.assertTrue(h.dtype['z'].name == 'uint8')
+        self.assertTrue(h.dtype['z'].char == 'B')
+        self.assertTrue(h.dtype['z'].type == np.uint8)
         # A small check that data is ok
         assert_equal(h['z'], np.zeros((2,3), dtype='u1'))
 
@@ -147,29 +147,29 @@ class create_values(object):
     def test_tuple(self):
         """Check creation from tuples"""
         h = np.array(self._buffer, dtype=self._descr)
-        self.assert_(normalize_descr(self._descr) == h.dtype.descr)
+        self.assertTrue(normalize_descr(self._descr) == h.dtype.descr)
         if self.multiple_rows:
-            self.assert_(h.shape == (2,))
+            self.assertTrue(h.shape == (2,))
         else:
-            self.assert_(h.shape == ())
+            self.assertTrue(h.shape == ())
 
     def test_list_of_tuple(self):
         """Check creation from list of tuples"""
         h = np.array([self._buffer], dtype=self._descr)
-        self.assert_(normalize_descr(self._descr) == h.dtype.descr)
+        self.assertTrue(normalize_descr(self._descr) == h.dtype.descr)
         if self.multiple_rows:
-            self.assert_(h.shape == (1,2))
+            self.assertTrue(h.shape == (1,2))
         else:
-            self.assert_(h.shape == (1,))
+            self.assertTrue(h.shape == (1,))
 
     def test_list_of_list_of_tuple(self):
         """Check creation from list of list of tuples"""
         h = np.array([[self._buffer]], dtype=self._descr)
-        self.assert_(normalize_descr(self._descr) == h.dtype.descr)
+        self.assertTrue(normalize_descr(self._descr) == h.dtype.descr)
         if self.multiple_rows:
-            self.assert_(h.shape == (1,1,2))
+            self.assertTrue(h.shape == (1,1,2))
         else:
-            self.assert_(h.shape == (1,1))
+            self.assertTrue(h.shape == (1,1))
 
 
 class test_create_values_plain_single(create_values, TestCase):
@@ -207,12 +207,12 @@ class read_values_plain(object):
     def test_access_fields(self):
         h = np.array(self._buffer, dtype=self._descr)
         if not self.multiple_rows:
-            self.assert_(h.shape == ())
+            self.assertTrue(h.shape == ())
             assert_equal(h['x'], np.array(self._buffer[0], dtype='i4'))
             assert_equal(h['y'], np.array(self._buffer[1], dtype='f8'))
             assert_equal(h['z'], np.array(self._buffer[2], dtype='u1'))
         else:
-            self.assert_(len(h) == 2)
+            self.assertTrue(len(h) == 2)
             assert_equal(h['x'], np.array([self._buffer[0][0],
                                              self._buffer[1][0]], dtype='i4'))
             assert_equal(h['y'], np.array([self._buffer[0][1],
@@ -241,12 +241,12 @@ class read_values_nested(object):
         """Check reading the top fields of a nested array"""
         h = np.array(self._buffer, dtype=self._descr)
         if not self.multiple_rows:
-            self.assert_(h.shape == ())
+            self.assertTrue(h.shape == ())
             assert_equal(h['x'], np.array(self._buffer[0], dtype='i4'))
             assert_equal(h['y'], np.array(self._buffer[4], dtype='f8'))
             assert_equal(h['z'], np.array(self._buffer[5], dtype='u1'))
         else:
-            self.assert_(len(h) == 2)
+            self.assertTrue(len(h) == 2)
             assert_equal(h['x'], np.array([self._buffer[0][0],
                                            self._buffer[1][0]], dtype='i4'))
             assert_equal(h['y'], np.array([self._buffer[0][4],
@@ -306,19 +306,19 @@ class read_values_nested(object):
     def test_nested1_descriptor(self):
         """Check access nested descriptors of a nested array (1st level)"""
         h = np.array(self._buffer, dtype=self._descr)
-        self.assert_(h.dtype['Info']['value'].name == 'complex128')
-        self.assert_(h.dtype['Info']['y2'].name == 'float64')
+        self.assertTrue(h.dtype['Info']['value'].name == 'complex128')
+        self.assertTrue(h.dtype['Info']['y2'].name == 'float64')
         if sys.version_info[0] >= 3:
-            self.assert_(h.dtype['info']['Name'].name == 'str256')
+            self.assertTrue(h.dtype['info']['Name'].name == 'str256')
         else:
-            self.assert_(h.dtype['info']['Name'].name == 'unicode256')
-        self.assert_(h.dtype['info']['Value'].name == 'complex128')
+            self.assertTrue(h.dtype['info']['Name'].name == 'unicode256')
+        self.assertTrue(h.dtype['info']['Value'].name == 'complex128')
 
     def test_nested2_descriptor(self):
         """Check access nested descriptors of a nested array (2nd level)"""
         h = np.array(self._buffer, dtype=self._descr)
-        self.assert_(h.dtype['Info']['Info2']['value'].name == 'void256')
-        self.assert_(h.dtype['Info']['Info2']['z3'].name == 'void64')
+        self.assertTrue(h.dtype['Info']['Info2']['value'].name == 'void256')
+        self.assertTrue(h.dtype['Info']['Info2']['z3'].name == 'void64')
 
 
 class test_read_values_nested_single(read_values_nested, TestCase):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -160,8 +160,8 @@ class TestRegression(TestCase):
         yb = ((b>2) & (b<6))
         assert_array_almost_equal(xa,ya.nonzero())
         assert_array_almost_equal(xb,yb.nonzero())
-        assert(np.all(a[ya] > 0.5))
-        assert(np.all(b[yb] > 0.5))
+        assert_(np.all(a[ya] > 0.5))
+        assert_(np.all(b[yb] > 0.5))
 
     def test_mem_dot(self,level=rlevel):
         """Ticket #106"""
@@ -183,7 +183,7 @@ class TestRegression(TestCase):
 #        """Ticket #112"""
 #        if np.longfloat(0).itemsize > 8:
 #            a = np.exp(np.array([1000],dtype=np.longfloat))
-#            assert(str(a)[1:9] == str(a[0])[:8])
+#            assert_(str(a)[1:9] == str(a[0])[:8])
 
     def test_argmax(self,level=rlevel):
         """Ticket #119"""
@@ -207,8 +207,8 @@ class TestRegression(TestCase):
         """Ticket #133"""
         a = np.array([3])
         b = np.array(3)
-        assert(type(a.squeeze()) is np.ndarray)
-        assert(type(b.squeeze()) is np.ndarray)
+        assert_(type(a.squeeze()) is np.ndarray)
+        assert_(type(b.squeeze()) is np.ndarray)
 
     def test_add_identity(self,level=rlevel):
         """Ticket #143"""
@@ -347,7 +347,7 @@ class TestRegression(TestCase):
         dt = np.dtype([('one', '<i4'),('two', '<i4')])
         x = np.array((1,2), dtype=dt)
         x = x.byteswap()
-        assert(x['one'] > 1 and x['two'] > 2)
+        assert_(x['one'] > 1 and x['two'] > 2)
 
     def test_method_args(self, level=rlevel):
         # Make sure methods and functions have same default axis
@@ -488,7 +488,7 @@ class TestRegression(TestCase):
                   np.rec.array([(1,2),(3,4)]),
                   np.rec.fromarrays([(1,2),(3,4)],"i4,i4"),
                   np.rec.fromarrays([(1,2),(3,4)])]:
-            assert(a.dtype in [dt0,dt1])
+            assert_(a.dtype in [dt0,dt1])
 
     def test_random_shuffle(self, level=rlevel):
         """Ticket #374"""
@@ -990,8 +990,8 @@ class TestRegression(TestCase):
         buf = np.zeros(40, dtype=np.int8)
         a = np.recarray(2, formats="i4,f8,f8", names="id,x,y", buf=buf)
         b = a.tolist()
-        assert( a[0].tolist() == b[0])
-        assert( a[1].tolist() == b[1])
+        assert_( a[0].tolist() == b[0])
+        assert_( a[1].tolist() == b[1])
 
     def test_char_array_creation(self, level=rlevel):
         a = np.array('123', dtype='c')

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -115,11 +115,11 @@ class TestRegression(TestCase):
         """Ticket #72"""
         a = np.array(['test', 'auto'])
         assert_array_equal(a == 'auto', np.array([False,True]))
-        self.assert_(a[1] == 'auto')
-        self.assert_(a[0] != 'auto')
+        self.assertTrue(a[1] == 'auto')
+        self.assertTrue(a[0] != 'auto')
         b = np.linspace(0, 10, 11)
-        self.assert_(b != 'auto')
-        self.assert_(b[0] != 'auto')
+        self.assertTrue(b != 'auto')
+        self.assertTrue(b[0] != 'auto')
 
     def test_unicode_swapping(self,level=rlevel):
         """Ticket #79"""

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -42,18 +42,18 @@ class create_zeros(object):
     def content_check(self, ua, ua_scalar, nbytes):
 
         # Check the length of the unicode base type
-        self.assert_(int(ua.dtype.str[2:]) == self.ulen)
+        self.assertTrue(int(ua.dtype.str[2:]) == self.ulen)
         # Check the length of the data buffer
-        self.assert_(buffer_length(ua) == nbytes)
+        self.assertTrue(buffer_length(ua) == nbytes)
         # Small check that data in array element is ok
-        self.assert_(ua_scalar == u'')
+        self.assertTrue(ua_scalar == u'')
         # Encode to ascii and double check
-        self.assert_(ua_scalar.encode('ascii') == asbytes(''))
+        self.assertTrue(ua_scalar.encode('ascii') == asbytes(''))
         # Check buffer lengths for scalars
         if ucs4:
-            self.assert_(buffer_length(ua_scalar) == 0)
+            self.assertTrue(buffer_length(ua_scalar) == 0)
         else:
-            self.assert_(buffer_length(ua_scalar) == 0)
+            self.assertTrue(buffer_length(ua_scalar) == 0)
 
     def test_zeros0D(self):
         """Check creation of 0-dimensional objects"""
@@ -94,26 +94,26 @@ class create_values(object):
     def content_check(self, ua, ua_scalar, nbytes):
 
         # Check the length of the unicode base type
-        self.assert_(int(ua.dtype.str[2:]) == self.ulen)
+        self.assertTrue(int(ua.dtype.str[2:]) == self.ulen)
         # Check the length of the data buffer
-        self.assert_(buffer_length(ua) == nbytes)
+        self.assertTrue(buffer_length(ua) == nbytes)
         # Small check that data in array element is ok
-        self.assert_(ua_scalar == self.ucs_value*self.ulen)
+        self.assertTrue(ua_scalar == self.ucs_value*self.ulen)
         # Encode to UTF-8 and double check
-        self.assert_(ua_scalar.encode('utf-8') == \
+        self.assertTrue(ua_scalar.encode('utf-8') == \
                      (self.ucs_value*self.ulen).encode('utf-8'))
         # Check buffer lengths for scalars
         if ucs4:
-            self.assert_(buffer_length(ua_scalar) == 4*self.ulen)
+            self.assertTrue(buffer_length(ua_scalar) == 4*self.ulen)
         else:
             if self.ucs_value == ucs4_value:
                 # In UCS2, the \U0010FFFF will be represented using a
                 # surrogate *pair*
-                self.assert_(buffer_length(ua_scalar) == 2*2*self.ulen)
+                self.assertTrue(buffer_length(ua_scalar) == 2*2*self.ulen)
             else:
                 # In UCS2, the \uFFFF will be represented using a
                 # regular 2-byte word
-                self.assert_(buffer_length(ua_scalar) == 2*self.ulen)
+                self.assertTrue(buffer_length(ua_scalar) == 2*self.ulen)
 
     def test_values0D(self):
         """Check creation of 0-dimensional objects with values"""
@@ -179,26 +179,26 @@ class assign_values(object):
     def content_check(self, ua, ua_scalar, nbytes):
 
         # Check the length of the unicode base type
-        self.assert_(int(ua.dtype.str[2:]) == self.ulen)
+        self.assertTrue(int(ua.dtype.str[2:]) == self.ulen)
         # Check the length of the data buffer
-        self.assert_(buffer_length(ua) == nbytes)
+        self.assertTrue(buffer_length(ua) == nbytes)
         # Small check that data in array element is ok
-        self.assert_(ua_scalar == self.ucs_value*self.ulen)
+        self.assertTrue(ua_scalar == self.ucs_value*self.ulen)
         # Encode to UTF-8 and double check
-        self.assert_(ua_scalar.encode('utf-8') == \
+        self.assertTrue(ua_scalar.encode('utf-8') == \
                      (self.ucs_value*self.ulen).encode('utf-8'))
         # Check buffer lengths for scalars
         if ucs4:
-            self.assert_(buffer_length(ua_scalar) == 4*self.ulen)
+            self.assertTrue(buffer_length(ua_scalar) == 4*self.ulen)
         else:
             if self.ucs_value == ucs4_value:
                 # In UCS2, the \U0010FFFF will be represented using a
                 # surrogate *pair*
-                self.assert_(buffer_length(ua_scalar) == 2*2*self.ulen)
+                self.assertTrue(buffer_length(ua_scalar) == 2*2*self.ulen)
             else:
                 # In UCS2, the \uFFFF will be represented using a
                 # regular 2-byte word
-                self.assert_(buffer_length(ua_scalar) == 2*self.ulen)
+                self.assertTrue(buffer_length(ua_scalar) == 2*self.ulen)
 
     def test_values0D(self):
         """Check assignment of 0-dimensional objects with values"""
@@ -274,7 +274,7 @@ class byteorder_values:
         # This changes the interpretation of the data region (but not the
         #  actual data), therefore the returned scalars are not
         #  the same (they are byte-swapped versions of each other).
-        self.assert_(ua[()] != ua2[()])
+        self.assertTrue(ua[()] != ua2[()])
         ua3 = ua2.newbyteorder()
         # Arrays must be equal after the round-trip
         assert_equal(ua, ua3)
@@ -283,8 +283,8 @@ class byteorder_values:
         """Check byteorder of single-dimensional objects"""
         ua = array([self.ucs_value*self.ulen]*2, dtype='U%s' % self.ulen)
         ua2 = ua.newbyteorder()
-        self.assert_(ua[0] != ua2[0])
-        self.assert_(ua[-1] != ua2[-1])
+        self.assertTrue(ua[0] != ua2[0])
+        self.assertTrue(ua[-1] != ua2[-1])
         ua3 = ua2.newbyteorder()
         # Arrays must be equal after the round-trip
         assert_equal(ua, ua3)
@@ -294,8 +294,8 @@ class byteorder_values:
         ua = array([[[self.ucs_value*self.ulen]*2]*3]*4,
                    dtype='U%s' % self.ulen)
         ua2 = ua.newbyteorder()
-        self.assert_(ua[0,0,0] != ua2[0,0,0])
-        self.assert_(ua[-1,-1,-1] != ua2[-1,-1,-1])
+        self.assertTrue(ua[0,0,0] != ua2[0,0,0])
+        self.assertTrue(ua[-1,-1,-1] != ua2[-1,-1,-1])
         ua3 = ua2.newbyteorder()
         # Arrays must be equal after the round-trip
         assert_equal(ua, ua3)

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -2,7 +2,7 @@ import sys
 if sys.version_info[0] < 3:
     from ConfigParser import SafeConfigParser, NoOptionError
 else:
-    from configparser import SafeConfigParser, NoOptionError
+    from configparser import ConfigParser, SafeConfigParser, NoOptionError
 import re
 import os
 import shlex
@@ -270,7 +270,12 @@ def parse_config(filename, dirs=None):
     else:
         filenames = [filename]
 
-    config = SafeConfigParser()
+    if sys.version[:3] > '3.1':
+        # SafeConfigParser is deprecated in py-3.2 and renamed to ConfigParser
+        config = ConfigParser()
+    else:
+        config = SafeConfigParser()
+
     n = config.read(filenames)
     if not len(n) >= 1:
         raise PkgNotFound("Could not find file(s) %s" % str(filenames))

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -117,9 +117,9 @@ import copy
 import warnings
 from glob import glob
 if sys.version_info[0] < 3:
-    from ConfigParser import SafeConfigParser, NoOptionError, ConfigParser
+    from ConfigParser import NoOptionError, ConfigParser
 else:
-    from configparser import SafeConfigParser, NoOptionError, ConfigParser
+    from configparser import NoOptionError, ConfigParser
 
 from distutils.errors import DistutilsError
 from distutils.dist import Distribution
@@ -1324,7 +1324,7 @@ class lapack_opt_info(system_info):
                    or ('ATLAS_WITHOUT_LAPACK',None) in l:
                 need_lapack = 1
             info = atlas_info
-            
+
         else:
             warnings.warn(AtlasNotFoundError.__doc__)
             need_blas = 1

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -83,7 +83,9 @@ class TestDataSourceOpen(TestCase):
         del self.ds
 
     def test_ValidHTTP(self):
-        assert self.ds.open(valid_httpurl())
+        fh = self.ds.open(valid_httpurl())
+        assert_(fh)
+        fh.close()
 
     def test_InvalidHTTP(self):
         url = invalid_httpurl()
@@ -92,14 +94,16 @@ class TestDataSourceOpen(TestCase):
             self.ds.open(url)
         except IOError, e:
             # Regression test for bug fixed in r4342.
-            assert e.errno is None
+            assert_(e.errno is None)
 
     def test_InvalidHTTPCacheURLError(self):
         self.assertRaises(URLError, self.ds._cache, invalid_httpurl())
 
     def test_ValidFile(self):
         local_file = valid_textfile(self.tmpdir)
-        assert self.ds.open(local_file)
+        fh = self.ds.open(local_file)
+        assert_(fh)
+        fh.close()
 
     def test_InvalidFile(self):
         invalid_file = invalid_textfile(self.tmpdir)
@@ -310,9 +314,13 @@ class TestOpenFunc(TestCase):
     def test_DataSourceOpen(self):
         local_file = valid_textfile(self.tmpdir)
         # Test case where destpath is passed in
-        assert datasource.open(local_file, destpath=self.tmpdir)
+        fp = datasource.open(local_file, destpath=self.tmpdir)
+        assert_(fp)
+        fp.close()
         # Test case where default destpath is used
-        assert datasource.open(local_file)
+        fp = datasource.open(local_file)
+        assert_(fp)
+        fp.close()
 
 
 if __name__ == "__main__":

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -154,7 +154,7 @@ class TestDataSourceExists(TestCase):
         del self.ds
 
     def test_ValidHTTP(self):
-        assert self.ds.exists(valid_httpurl())
+        assert_(self.ds.exists(valid_httpurl()))
 
     def test_InvalidHTTP(self):
         self.assertEqual(self.ds.exists(invalid_httpurl()), False)
@@ -162,11 +162,11 @@ class TestDataSourceExists(TestCase):
     def test_ValidFile(self):
         # Test valid file in destpath
         tmpfile = valid_textfile(self.tmpdir)
-        assert self.ds.exists(tmpfile)
+        assert_(self.ds.exists(tmpfile))
         # Test valid local file not in destpath
         localdir = mkdtemp()
         tmpfile = valid_textfile(localdir)
-        assert self.ds.exists(tmpfile)
+        assert_(self.ds.exists(tmpfile))
         rmtree(localdir)
 
     def test_InvalidFile(self):
@@ -218,13 +218,13 @@ class TestDataSourceAbspath(TestCase):
 
         tmp_path = lambda x: os.path.abspath(self.ds.abspath(x))
 
-        assert tmp_path(valid_httpurl()).startswith(self.tmpdir)
-        assert tmp_path(invalid_httpurl()).startswith(self.tmpdir)
-        assert tmp_path(tmpfile).startswith(self.tmpdir)
-        assert tmp_path(tmpfilename).startswith(self.tmpdir)
+        assert_(tmp_path(valid_httpurl()).startswith(self.tmpdir))
+        assert_(tmp_path(invalid_httpurl()).startswith(self.tmpdir))
+        assert_(tmp_path(tmpfile).startswith(self.tmpdir))
+        assert_(tmp_path(tmpfilename).startswith(self.tmpdir))
         for fn in malicious_files:
-            assert tmp_path(http_path+fn).startswith(self.tmpdir)
-            assert tmp_path(fn).startswith(self.tmpdir)
+            assert_(tmp_path(http_path+fn).startswith(self.tmpdir))
+            assert_(tmp_path(fn).startswith(self.tmpdir))
 
     def test_windows_os_sep(self):
         orig_os_sep = os.sep
@@ -257,10 +257,10 @@ class TestRepositoryAbspath(TestCase):
 
     def test_sandboxing(self):
         tmp_path = lambda x: os.path.abspath(self.repos.abspath(x))
-        assert tmp_path(valid_httpfile()).startswith(self.tmpdir)
+        assert_(tmp_path(valid_httpfile()).startswith(self.tmpdir))
         for fn in malicious_files:
-            assert tmp_path(http_path+fn).startswith(self.tmpdir)
-            assert tmp_path(fn).startswith(self.tmpdir)
+            assert_(tmp_path(http_path+fn).startswith(self.tmpdir))
+            assert_(tmp_path(fn).startswith(self.tmpdir))
 
     def test_windows_os_sep(self):
         orig_os_sep = os.sep
@@ -284,14 +284,14 @@ class TestRepositoryExists(TestCase):
     def test_ValidFile(self):
         # Create local temp file
         tmpfile = valid_textfile(self.tmpdir)
-        assert self.repos.exists(tmpfile)
+        assert_(self.repos.exists(tmpfile))
 
     def test_InvalidFile(self):
         tmpfile = invalid_textfile(self.tmpdir)
         self.assertEqual(self.repos.exists(tmpfile), False)
 
     def test_RemoveHTTPFile(self):
-        assert self.repos.exists(valid_httpurl())
+        assert_(self.repos.exists(valid_httpurl()))
 
     def test_CachedHTTPFile(self):
         localfile = valid_httpurl()
@@ -302,7 +302,7 @@ class TestRepositoryExists(TestCase):
         local_path = os.path.join(self.repos._destpath, netloc)
         os.mkdir(local_path, 0700)
         tmpfile = valid_textfile(local_path)
-        assert self.repos.exists(tmpfile)
+        assert_(self.repos.exists(tmpfile))
 
 class TestOpenFunc(TestCase):
     def setUp(self):

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -463,7 +463,7 @@ def test_memmap_roundtrip():
             # Check that reading the file using memmap works.
             ma = format.open_memmap(nfn, mode='r')
             #yield assert_array_equal, ma, arr
-            #del ma
+            del ma
 
 
 def test_write_version_1_0():

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -70,8 +70,8 @@ class TestRegression(TestCase):
         """Ticket #554"""
         x = np.poly1d([1,2,3])
         y = np.poly1d([3,4])
-        assert x != y
-        assert x == x
+        assert_(x != y)
+        assert_(x == x)
 
     def test_mem_insert(self, level=rlevel):
         """Ticket #572"""
@@ -152,7 +152,7 @@ class TestRegression(TestCase):
     def test_void_coercion(self, level=rlevel):
         dt = np.dtype([('a','f4'),('b','i4')])
         x = np.zeros((1,),dt)
-        assert(np.r_[x,x].dtype == dt)
+        assert_(np.r_[x,x].dtype == dt)
 
     def test_who_with_0dim_array(self, level=rlevel) :
         """ticket #1243"""
@@ -161,6 +161,7 @@ class TestRegression(TestCase):
         sys.stdout = open(os.devnull, 'w')
         try :
             tmp = np.who({'foo' : np.array(1)})
+            sys.stdout.close()
             sys.stdout = sys.__stdout__
         except :
             sys.stdout = sys.__stdout__
@@ -178,8 +179,8 @@ class TestRegression(TestCase):
         include_dirs = [np.get_include(), np.get_numarray_include(),
                         np.get_numpy_include()]
         for path in include_dirs:
-            assert isinstance(path, (str, unicode))
-            assert path != ''
+            assert_(isinstance(path, (str, unicode)))
+            assert_(path != '')
 
     def test_polyder_return_type(self):
         """Ticket #1249"""


### PR DESCRIPTION
Some cleaning of messages from the new and shiny Python 3.2.

There is one ResourceWarning left (see below), I can't see how to fix it.
test_mmap (test_io.TestSaveLoad) ... /Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/numpy/lib/format.py:575: ResourceWarning: unclosed file <_io.BufferedReader name='/var/folders/Uu/UuXfo1NLFae4yyYpsCz-XE+++TI/-Tmp-/tmp37lh1w'>
  mode=mode, offset=offset)
