### PR TITLE
Pandas fix

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -824,11 +824,13 @@ discover_dimensions(PyObject *s, int *maxndim, npy_intp *d, int check_it,
 
         if ((e = PySequence_GetItem(s, 0)) == NULL) {
             /*
-             * This should probably be an error but we suppress
-             * it to maintain backwards compatibility with pandas
-             * and possibly other existing applications. The making
-             * of the object type instead of a straght return might
-             * cause other errors not to occur.
+             * PySequence_Check looks for the presence of the __getitem__
+             * attribute to detect a sequence. Consequently, dictionaries
+             * and other objects that implement that method may show up
+             * here and the PySequence_GetItem call can fail in those
+             * cases.  Consequently we truncate the dimensions and set the
+             * object creation flag. Raising an error is another option but
+             * it might break backward compatibility.
              */
             *maxndim = 0;
             *out_is_object = 1;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -823,7 +823,13 @@ discover_dimensions(PyObject *s, int *maxndim, npy_intp *d, int check_it,
         int j, maxndim_m1 = *maxndim - 1;
 
         if ((e = PySequence_GetItem(s, 0)) == NULL) {
-            /* not a list */
+            /*
+             * This should probably be an error but we suppress
+             * it to maintain backwards compatibility with pandas
+             * and possibly other existing applications. The making
+             * of the object type instead of a straght return might
+             * cause other errors not to occur.
+             */
             *maxndim = 0;
             *out_is_object = 1;
             PyErr_Clear();
@@ -843,7 +849,7 @@ discover_dimensions(PyObject *s, int *maxndim, npy_intp *d, int check_it,
         for (i = 1; i < n; ++i) {
             /* Get the dimensions of the first item */
             if ((e = PySequence_GetItem(s, 0)) == NULL) {
-                /* not a list */
+                /* see comment above */
                 *maxndim = 0;
                 *out_is_object = 1;
                 PyErr_Clear();

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -647,7 +647,6 @@ discover_itemsize(PyObject *s, int nd, int *itemsize)
  * Take an arbitrary object and discover how many dimensions it
  * has, filling in the dimensions as we go.
  */
-#include <stdio.h>
 static int
 discover_dimensions(PyObject *s, int *maxndim, npy_intp *d, int check_it,
                                     int stop_at_string, int stop_at_tuple,

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -825,6 +825,7 @@ discover_dimensions(PyObject *s, int *maxndim, npy_intp *d, int check_it,
         if ((e = PySequence_GetItem(s, 0)) == NULL) {
             /* not a list */
             *maxndim = 0;
+            *out_is_object = 1;
             PyErr_Clear();
             return 0;
         }
@@ -844,6 +845,7 @@ discover_dimensions(PyObject *s, int *maxndim, npy_intp *d, int check_it,
             if ((e = PySequence_GetItem(s, 0)) == NULL) {
                 /* not a list */
                 *maxndim = 0;
+                *out_is_object = 1;
                 PyErr_Clear();
                 return 0;
             }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -305,21 +305,30 @@ class TestCreation(TestCase):
     def test_non_sequence_sequence(self):
         """Should not segfault.
 
-        Class Foo breaks the sequence protocol for new style classes, i.e.,
-        those derived from object. At some point we may raise a warning in
-        this case.
+        Class Fail breaks the sequence protocol for new style classes, i.e.,
+        those derived from object. Class Map is a mapping type indicated by
+        raising a ValueError. At some point we may raise a warning instead
+        of an error in the Fail case.
 
         """
-        class Foo(object):
+        class Fail(object):
             def __len__(self):
                 return 1
 
-            def __getitem__(self):
-                raise ValueError('hi there')
+            def __getitem__(self, index):
+                raise ValueError()
 
-        a = np.array([Foo()])
+        class Map(object):
+            def __len__(self):
+                return 1
+
+            def __getitem__(self, index):
+                raise KeyError()
+
+        a = np.array([Map()])
         assert_(a.shape == (1,))
         assert_(a.dtype == np.dtype(object))
+        assert_raises(ValueError, np.array, [Fail()])
 
 
 class TestStructured(TestCase):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -303,15 +303,21 @@ class TestCreation(TestCase):
             assert_equal(array(nstr, dtype=type), result, err_msg=msg)
 
     def test_non_sequence_sequence(self):
-        """Should not segfault."""
-        class x(object):
+        """Should not segfault.
+
+        Class Foo breaks the sequence protocol for new style classes, i.e.,
+        those derived from object. At some point we may raise a warning in
+        this case.
+
+        """
+        class Foo(object):
             def __len__(self):
                 return 1
 
             def __getitem__(self):
                 raise ValueError('hi there')
 
-        a = np.array([x()])
+        a = np.array([Foo()])
         assert_(a.shape == (1,))
         assert_(a.dtype == np.dtype(object))
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -302,6 +302,20 @@ class TestCreation(TestCase):
             msg = 'String conversion for %s' % type
             assert_equal(array(nstr, dtype=type), result, err_msg=msg)
 
+    def test_non_sequence_sequence(self):
+        """Should not segfault."""
+        class x(object):
+            def __len__(self):
+                return 1
+
+            def __getitem__(self):
+                raise ValueError('hi there')
+
+        a = np.array([x()])
+        assert_(a.shape == (1,))
+        assert_(a.dtype == np.dtype(object))
+
+
 class TestStructured(TestCase):
     def test_subarray_field_access(self):
         a = np.zeros((3, 5), dtype=[('a', ('i4', (2, 2)))])


### PR DESCRIPTION
This fixes the pandas segfault and all except one of the pandas tests pass. I don't think it is complete, however. In particular the error return (-1) is just passed back up the call chain whereas it should perhaps be caught at the first level where it is the return value. Mark, any comments about that?
