### PR TITLE
Ticket 960 intelccomppiler

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -494,10 +494,13 @@ compiler_class['intel'] = ('intelccompiler','IntelCCompiler',
                            "Intel C Compiler for 32-bit applications")
 compiler_class['intele'] = ('intelccompiler','IntelItaniumCCompiler',
                            "Intel C Itanium Compiler for Itanium-based applications")
+compiler_class['intelem'] = ('intelccompiler','IntelEM64TCCompiler',
+                             "Intel C Compiler for 64-bit applications")
 compiler_class['pathcc'] = ('pathccompiler','PathScaleCCompiler',
                             "PathScale Compiler for SiCortex-based applications")
 ccompiler._default_compilers += (('linux.*','intel'),
                                  ('linux.*','intele'),
+                                 ('linux.*','intelem'),
                                  ('linux.*','pathcc'))
 
 if sys.platform == 'win32':

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -9,9 +9,11 @@ class IntelCCompiler(UnixCCompiler):
 
     compiler_type = 'intel'
     cc_exe = 'icc'
+    cc_args = 'fPIC'
 
     def __init__ (self, verbose=0, dry_run=0, force=0):
         UnixCCompiler.__init__ (self, verbose,dry_run, force)
+        self.cc_exe = 'icc -fPIC'
         compiler = self.cc_exe
         self.set_executables(compiler=compiler,
                              compiler_so=compiler,
@@ -27,3 +29,21 @@ class IntelItaniumCCompiler(IntelCCompiler):
     for cc_exe in map(find_executable,['icc','ecc']):
         if cc_exe:
             break
+
+class IntelEM64TCCompiler(UnixCCompiler):
+
+""" A modified Intel x86_64 compiler compatible with a 64bit gcc built Python.
+    """
+
+    compiler_type = 'intelem'
+    cc_exe = 'icc -m64 -fPIC'
+    cc_args = "-fPIC"
+    def __init__ (self, verbose=0, dry_run=0, force=0):
+        UnixCCompiler.__init__ (self, verbose,dry_run, force)
+        self.cc_exe = 'icc -m64 -fPIC'
+        compiler = self.cc_exe
+        self.set_executables(compiler=compiler,
+                             compiler_so=compiler,
+                             compiler_cxx=compiler,
+                             linker_exe=compiler,
+                             linker_so=compiler + ' -shared')


### PR DESCRIPTION
Adding the 64-bit Intel C compiler seems correct to be and can't break anything. The only thing I'm not sure about is if it's okay to hardcode -fPIC for the 32-bit compiler. I searched the mailing list, and there seem to be only problems when it's missing - it's always required for a shared library. But if this is a problem, then I think the rest can still be applied.
