### PR TITLE
Docstandard

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -424,6 +424,7 @@ Method docstrings
 Document these as you would any other function.  Do not include
 ``self`` in the list of parameters.
 
+
 Documenting class instances
 ---------------------------
 Instances of classes that are part of the Numpy API (for example `np.r_`
@@ -437,6 +438,7 @@ instances a useful docstring, we do the following:
   for each instance are written and assigned to the instances'
   ``__doc__`` attributes at run time. The class is documented as usual, and
   the exposed instances can be mentioned in the Notes and See Also sections.
+
 
 Documenting constants
 ---------------------
@@ -452,6 +454,29 @@ Docstrings for constants will not be visible in text terminals
 (constants are of immutable type, so docstrings can not be assigned
 to them like for for class instances), but will appear in the
 documentation built with Sphinx.
+
+
+Documenting modules
+-------------------
+Each module should have a docstring with at least a summary line. Other
+sections are optional, and should be used in the same order as for documenting
+functions when they are appropriate::
+
+    1. summary
+    2. extended summary
+    3. routine listings
+    4. see also
+    5. notes
+    6. references
+    7. examples
+
+Routine listings are encouraged, especially for large modules, for which it is
+hard to get a good overview of all functionality provided by looking at the
+source file(s) or the __all__ dict.
+
+Note that license and author info, while often included in source files, do not
+belong in docstrings. 
+
 
 Other points to keep in mind
 ----------------------------

--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -420,7 +420,11 @@ Note that `self` is *not* listed as the first parameter of methods.
 Method docstrings
 `````````````````
 Document these as you would any other function.  Do not include
-``self`` in the list of parameters.
+``self`` in the list of parameters.  If a method has an equivalent function
+(which is the case for many ndarray methods for example), the function
+docstring should contain the detailed documentation, and the method docstring
+should refer to it.  Only put brief summary and See Also sections in the method
+docstring.
 
 
 Documenting class instances

--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -307,11 +307,9 @@ The sections of the docstring are:
 
    Referencing sources of a temporary nature, like web pages, is
    discouraged.  References are meant to augment the docstring, but
-   should not be required to understand it.  Follow the `citation
-   format of the IEEE
-   <http://www.ieee.org/pubs/transactions/auinfo03.pdf>`_, which
-   states that references are numbered, starting from one, in the
-   order in which they are cited.
+   should not be required to understand it.  References are numbered, starting
+   from one, in the order in which they are cited.  If references are not
+   referred to in the docstring text, the numbering can be omitted.
 
 10. **Examples**
 

--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -116,7 +116,29 @@ The sections of the docstring are:
 
      """
 
-2. **Extended summary**
+2. **Deprecation warning**
+
+   A section (use if applicable) to warn users that the object is deprecated.
+   Section contents should include: 
+
+   * In what Numpy version the object was deprecated, and when it will be
+     removed.
+
+   * Reason for deprecation  if this is useful information (e.g., object
+     is superseded, duplicates functionality found elsewhere, etc.).
+
+   * New recommended way of obtaining the same functionality. 
+
+   This section should use the note Sphinx directive instead of an
+   underlined section header.
+
+   ::
+
+     .. note:: Deprecated in Numpy 1.6
+               `ndobj_old` will be removed in Numpy 2.0, it is replaced by
+               `ndobj_new` because the latter works also with array subclasses.
+
+3. **Extended summary**
 
    A few sentences giving an extended description.  This section
    should be used to clarify *functionality*, not to discuss
@@ -125,7 +147,7 @@ The sections of the docstring are:
    parameters and the function name, but parameter descriptions still
    belong in the **parameters** section.
 
-3. **Parameters**
+4. **Parameters**
 
    Description of the function arguments, keywords and their
    respective types.
@@ -177,18 +199,18 @@ The sections of the docstring are:
      x1, x2 : array_like
          Input arrays, description of `x1`, `x2`.
 
-4. **Returns**
+5. **Returns**
 
    Explanation of the returned values and their types, of the same
    format as **parameters**.
 
-5. **Other parameters**
+6. **Other parameters**
 
    An optional section used to describe infrequently used parameters.
    It should only be used if a function has a large number of keyword
    prameters, to prevent cluttering the **parameters** section.
 
-6. **Raises**
+7. **Raises**
 
    An optional section detailing which errors get raised and under
    what conditions::
@@ -201,7 +223,7 @@ The sections of the docstring are:
    This section should be used judiciously, i.e only for errors
    that are non-obvious or have a large chance of getting raised.
 
-7. **See Also**
+8. **See Also**
 
    An optional section used to refer to related code.  This section
    can be very useful, but should be used judiciously.  The goal is to
@@ -240,7 +262,7 @@ The sections of the docstring are:
      func_b, func_c_, func_d
      func_e
 
-8. **Notes**
+9. **Notes**
 
    An optional section that provides additional information about the
    code, possibly including a discussion of the algorithm. This
@@ -285,7 +307,7 @@ The sections of the docstring are:
    where filename is a path relative to the reference guide source
    directory.
 
-9. **References**
+10. **References**
 
    References cited in the **notes** section may be listed here,
    e.g. if you cited the article below using the text ``[1]_``,
@@ -311,7 +333,7 @@ The sections of the docstring are:
    from one, in the order in which they are cited.  If references are not
    referred to in the docstring text, the numbering can be omitted.
 
-10. **Examples**
+11. **Examples**
 
    An optional section for examples, using the `doctest
    <http://www.python.org/doc/lib/module-doctest.html>`_ format.
@@ -513,7 +535,7 @@ output. New paragraphs are marked with a blank line.
 Use *italics*, **bold**, and ``courier`` if needed in any explanations
 (but not for variable names and doctest code or multi-line code).
 Variable, module and class names should be written between single
-backticks (```numpy```).
+back-ticks (```numpy```).
 
 A more extensive example of reST markup can be found in `this example
 document <http://docutils.sourceforge.net/docs/user/rst/demo.txt>`_;


### PR DESCRIPTION
Some changes to the docstandard. Closes tickets 1165, 1280, 1501, 1509 and 1524.

For the deprecation section I chose to use the note directive instead of the deprecated directive, because the latter does not seem to work well with the docstring parsing machinery. It concatenates summary line, deprecation message and extended summary.
