### PR TITLE
Handle empty inputs in cov and corrcoef.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1947,7 +1947,7 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
     X = array(m, ndmin=2, dtype=float)
     if X.size == 0:
         # handle empty arrays
-        return np.array([])
+        return np.array(m)
     if X.shape[0] == 1:
         rowvar = 1
     if rowvar:
@@ -2031,7 +2031,7 @@ def corrcoef(x, y=None, rowvar=1, bias=0, ddof=None):
     c = cov(x, y, rowvar, bias, ddof)
     if c.size == 0:
         # handle empty arrays
-        return np.array([])
+        return c
     try:
         d = diag(c)
     except ValueError: # scalar covariance

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1945,6 +1945,9 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         raise ValueError("ddof must be integer")
 
     X = array(m, ndmin=2, dtype=float)
+    if X.size == 0:
+        # handle empty arrays
+        return np.array([])
     if X.shape[0] == 1:
         rowvar = 1
     if rowvar:
@@ -1992,7 +1995,7 @@ def corrcoef(x, y=None, rowvar=1, bias=0, ddof=None):
 
     Parameters
     ----------
-    m : array_like
+    x : array_like
         A 1-D or 2-D array containing multiple variables and observations.
         Each row of `m` represents a variable, and each column a single
         observation of all those variables. Also see `rowvar` below.
@@ -2026,6 +2029,9 @@ def corrcoef(x, y=None, rowvar=1, bias=0, ddof=None):
 
     """
     c = cov(x, y, rowvar, bias, ddof)
+    if c.size == 0:
+        # handle empty arrays
+        return np.array([])
     try:
         d = diag(c)
     except ValueError: # scalar covariance

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -908,6 +908,18 @@ class TestCorrCoef(TestCase):
         assert_almost_equal(corrcoef(self.A, ddof=-1), self.res1)
         assert_almost_equal(corrcoef(self.A, self.B, ddof=-1), self.res2)
 
+    def test_empty(self):
+        assert_equal(corrcoef(np.array([])).size, 0)
+
+
+class TestCov(TestCase):
+    def test_basic(self):
+        x = np.array([[0, 2], [1, 1], [2, 0]]).T
+        assert_allclose(np.cov(x), np.array([[ 1.,-1.], [-1.,1.]]))
+
+    def test_empty(self):
+        assert_equal(cov(np.array([])).size, 0)
+
 
 class Test_i0(TestCase):
     def test_simple(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -910,6 +910,7 @@ class TestCorrCoef(TestCase):
 
     def test_empty(self):
         assert_equal(corrcoef(np.array([])).size, 0)
+        assert_equal(corrcoef(np.array([]).reshape(0, 2)).shape, (0, 2))
 
 
 class TestCov(TestCase):
@@ -919,6 +920,7 @@ class TestCov(TestCase):
 
     def test_empty(self):
         assert_equal(cov(np.array([])).size, 0)
+        assert_equal(cov(np.array([]).reshape(0, 2)).shape, (0, 2))
 
 
 class Test_i0(TestCase):


### PR DESCRIPTION
Empty inputs to cov and corrcoef now result in warnings, and return 0 and 1 respectively. This is correct for scalar input but makes no sense for empty input. Raising an exception is also not appreciated usually, so just doing: empty in -> empty out, seems like the most straightforward thing.

Also fixes a minor doc bug and adds a few tests.

Closes #1773.
