### PR TITLE
Change the default error state to 'warn'

### DIFF
--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -110,9 +110,9 @@ typedef struct {
 
    /* Default user error mode */
 #define UFUNC_ERR_DEFAULT2                               \
-        (UFUNC_ERR_PRINT << UFUNC_SHIFT_DIVIDEBYZERO) +  \
-        (UFUNC_ERR_PRINT << UFUNC_SHIFT_OVERFLOW) +      \
-        (UFUNC_ERR_PRINT << UFUNC_SHIFT_INVALID)
+        (UFUNC_ERR_WARN << UFUNC_SHIFT_DIVIDEBYZERO) +  \
+        (UFUNC_ERR_WARN << UFUNC_SHIFT_OVERFLOW) +      \
+        (UFUNC_ERR_WARN << UFUNC_SHIFT_INVALID)
 
 #if NPY_ALLOW_THREADS
 #define NPY_LOOP_BEGIN_THREADS do {if (!(loop->obj & UFUNC_OBJ_NEEDS_API)) _save = PyEval_SaveThread();} while (0)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2141,8 +2141,8 @@ def geterr():
 
     Examples
     --------
-    >>> np.geterr()  # default is all set to 'ignore'
-    {'over': 'ignore', 'divide': 'ignore', 'invalid': 'ignore',
+    >>> np.geterr()
+    {'over': 'warn', 'divide': 'warn', 'invalid': 'warn',
     'under': 'ignore'}
     >>> np.arange(3.) / np.arange(3.)
     array([ NaN,   1.,   1.])
@@ -2390,7 +2390,7 @@ class errstate(object):
     Outside the context the error handling behavior has not changed:
 
     >>> np.geterr()
-    {'over': 'ignore', 'divide': 'ignore', 'invalid': 'ignore',
+    {'over': 'warn', 'divide': 'warn', 'invalid': 'warn',
     'under': 'ignore'}
 
     """

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -13,15 +13,6 @@ from numpy.random import rand, randint
 from numpy.testing import *
 
 class TestErrstate(TestCase):
-    def test_default(self):
-        err = geterr()
-        self.assertEqual(err, dict(
-            divide='warn',
-            invalid='warn',
-            over='warn',
-            under='ignore',
-        ))
-
     def test_invalid(self):
         with errstate(all='raise', under='ignore'):
             a = -arange(3)

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -13,6 +13,15 @@ from numpy.random import rand, randint
 from numpy.testing import *
 
 class TestErrstate(TestCase):
+    def test_default(self):
+        err = geterr()
+        self.assertEqual(err, dict(
+            divide='warn',
+            invalid='warn',
+            over='warn',
+            under='ignore',
+        ))
+
     def test_invalid(self):
         with errstate(all='raise', under='ignore'):
             a = -arange(3)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -222,16 +222,25 @@ class TestBoolScalar(TestCase):
 
 
 class TestSeterr(TestCase):
+    def test_default(self):
+        err = geterr()
+        self.assertEqual(err, dict(
+            divide='warn',
+            invalid='warn',
+            over='warn',
+            under='ignore',
+        ))
+
     def test_set(self):
         err = seterr()
         try:
-            old = seterr(divide='warn')
+            old = seterr(divide='print')
             self.assertTrue(err == old)
             new = seterr()
-            self.assertTrue(new['divide'] == 'warn')
+            self.assertTrue(new['divide'] == 'print')
             seterr(over='raise')
             self.assertTrue(geterr()['over'] == 'raise')
-            self.assertTrue(new['divide'] == 'warn')
+            self.assertTrue(new['divide'] == 'print')
             seterr(**old)
             self.assertTrue(geterr() == old)
         finally:

--- a/numpy/doc/misc.py
+++ b/numpy/doc/misc.py
@@ -46,24 +46,28 @@ from the results: ::
  >>> np.nansum(x)
  42.0
 
-How numpy handles numerical exceptions
+How numpy handles numerical exceptions:
+------------------------------------------
 
-Default is to "warn"
-But this can be changed, and it can be set individually for different kinds
-of exceptions. The different behaviors are: ::
+The default is to ``'warn'`` for ``invalid``, ``divide``, and ``overflow``
+and ``'ignore'`` for ``underflow``.  But this can be changed, and it can be
+set individually for different kinds of exceptions. The different behaviors
+are:
 
- 'ignore' : ignore completely
- 'warn'   : print a warning (once only)
- 'raise'  : raise an exception
- 'call'   : call a user-supplied function (set using seterrcall())
+ - 'ignore' : Take no action when the exception occurs.
+ - 'warn'   : Print a `RuntimeWarning` (via the Python `warnings` module).
+ - 'raise'  : Raise a `FloatingPointError`.
+ - 'call'   : Call a function specified using the `seterrcall` function.
+ - 'print'  : Print a warning directly to ``stdout``.
+ - 'log'    : Record error in a Log object specified by `seterrcall`.
 
-These behaviors can be set for all kinds of errors or specific ones: ::
+These behaviors can be set for all kinds of errors or specific ones:
 
- all:       apply to all numeric exceptions
- invalid:   when NaNs are generated
- divide:    divide by zero (for integers as well!)
- overflow:  floating point overflows
- underflow: floating point underflows
+ - all       : apply to all numeric exceptions
+ - invalid   : when NaNs are generated
+ - divide    : divide by zero (for integers as well!)
+ - overflow  : floating point overflows
+ - underflow : floating point underflows
 
 Note that integer divide-by-zero is handled by the same machinery.
 These behaviors are set on a per-thread basis.


### PR DESCRIPTION
ENH: Change the default error handling to warn instead of print, except for underflow, which remains ignored.
