### PR TITLE
Remove the advice to 'import scipy as sp' from the documentation

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -29,9 +29,12 @@ The following import conventions are used throughout the NumPy source
 and documentation::
 
    import numpy as np
-   import scipy as sp
    import matplotlib as mpl
    import matplotlib.pyplot as plt
+
+Do not abbreviate ``scipy``. There is no motivating use case to
+abbreviate it in the real world, so we avoid it in the documentation
+to avoid confusion.
 
 It is not necessary to do ``import numpy as np`` at the beginning of
 an example.  However, some sub-modules, such as ``fft``, are not
@@ -369,9 +372,9 @@ The sections of the docstring are:
    examples work, not for making the examples part of the testing framework.
 
    The examples may assume that ``import numpy as np`` is executed before
-   the example code in *numpy*, and ``import scipy as sp`` in *scipy*.
-   Additional examples may make use of *matplotlib* for plotting, but should
-   import it explicitly, e.g., ``import matplotlib.pyplot as plt``.
+   the example code in *numpy*. Additional examples may make use of
+   *matplotlib* for plotting, but should import it explicitly, e.g.,
+   ``import matplotlib.pyplot as plt``.
 
    
 Documenting classes

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -227,8 +227,10 @@ for numpy.lib::
 >>> np.lib.test(doctests=True)
 
 The doctests are run as if they are in a fresh Python instance which
-has executed ``import numpy as np`` (tests that are part of the SciPy
-package also have an implicit ``import scipy as sp``).
+has executed ``import numpy as np``. Tests that are part of a SciPy
+subpackage will have that subpackage already imported. E.g. for a test
+in ``scipy/linalg/tests/``, the namespace will be created such that 
+``from scipy import linalg`` has already executed.
 
 
 ``tests/``

--- a/doc/example.py
+++ b/doc/example.py
@@ -24,7 +24,6 @@ import os # standard library imports first
 # convention used by NumPy itself::
 
 import numpy as np
-import scipy as sp
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
DOC: Remove the advice to 'import scipy as sp' from the documentation. Correct a statement about how doctest namespaces are initialized in scipy.
