### PR TITLE
BLD: do not install swig/cython/pyrex files. See #1791.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,6 @@ include doc/Makefile doc/postprocess.py
 recursive-include doc/release *
 recursive-include doc/source *
 recursive-include doc/sphinxext *
+recursive-include doc/cython *
+recursive-include doc/pyrex *
+recursive-include doc/swig *

--- a/setup.py
+++ b/setup.py
@@ -141,12 +141,6 @@ def configuration(parent_package='',top_path=None):
 
     config.add_subpackage('numpy')
 
-    # we want these files also in binaries/installed files, so it belongs here
-    # instead of in Manifest.in
-    config.add_data_files(('doc/cython/'),
-                          ('doc/pyrex/'),
-                          ('doc/swig/'))
-
     config.get_version('numpy/version.py') # sets config.version
 
     return config


### PR DESCRIPTION
Some comments on ticket 1791 about where those files should be installed to in the binary installers would be nice. I don't have a very good idea.
