### PR TITLE
TST: test for different line endings in genfromtxt input file

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1313,21 +1313,18 @@ M   33  21.99
 
     def test_gft_filename(self):
         # Test that we can load data from a filename as well as a file object
-        data = '0 1 2\n3 4 5'
         exp_res = np.arange(6).reshape((2,3))
-        assert_array_equal(np.genfromtxt(StringIO(data)), exp_res)
-        f, name = mkstemp()
-        # Thanks to another windows brokeness, we can't use
-        # NamedTemporaryFile: a file created from this function cannot be
-        # reopened by another open call. So we first put the string
-        # of the test reference array, write it to a securely opened file,
-        # which is then read from by the loadtxt function
-        try:
-            os.write(f, asbytes(data))
-            assert_array_equal(np.genfromtxt(name), exp_res)
-        finally:
-            os.close(f)
-            os.unlink(name)
+        for sep in ('\n', '\r', '\r\n'):
+            data = '0 1 2' + sep + '3 4 5'
+            f, name = mkstemp()
+            # We can't use NamedTemporaryFile on windows, because we cannot
+            # reopen the file.
+            try:
+                os.write(f, asbytes(data))
+                assert_array_equal(np.genfromtxt(name), exp_res)
+            finally:
+                os.close(f)
+                os.unlink(name)
 
     def test_gft_generator_source(self):
         def count():

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1,22 +1,21 @@
-import numpy as np
-import numpy.ma as ma
-from numpy.ma.testutils import (TestCase, assert_equal, assert_array_equal,
-    assert_raises, run_module_suite)
-from numpy.testing import assert_warns, assert_
-
 import sys
-
 import gzip
 import os
 import threading
-
 from tempfile import mkstemp, NamedTemporaryFile
 import time
 from datetime import datetime
 
+import numpy as np
+import numpy.ma as ma
 from numpy.lib._iotools import ConverterError, ConverterLockError, \
                                ConversionWarning
 from numpy.compat import asbytes, asbytes_nested, bytes
+
+from nose import SkipTest
+from numpy.ma.testutils import (TestCase, assert_equal, assert_array_equal,
+    assert_raises, run_module_suite)
+from numpy.testing import assert_warns, assert_
 
 if sys.version_info[0] >= 3:
     from io import BytesIO
@@ -1313,15 +1312,18 @@ M   33  21.99
 
     def test_gft_filename(self):
         # Test that we can load data from a filename as well as a file object
-        exp_res = np.arange(6).reshape((2,3))
-        for sep in ('\n', '\r', '\r\n'):
+        wanted = np.arange(6).reshape((2,3))
+        is_py3 = sys.version_info[0] >= 3
+        for sep in ('\n', '\r\n', '\r'):
+            if sep == '\r' and is_py3:
+                raise SkipTest(r'Py3 version does not split lines on \r')
             data = '0 1 2' + sep + '3 4 5'
             f, name = mkstemp()
             # We can't use NamedTemporaryFile on windows, because we cannot
             # reopen the file.
             try:
                 os.write(f, asbytes(data))
-                assert_array_equal(np.genfromtxt(name), exp_res)
+                assert_array_equal(np.genfromtxt(name), wanted)
             finally:
                 os.close(f)
                 os.unlink(name)


### PR DESCRIPTION
Added tests for workaround to variable implementation of Ub mode across pythons.  Include skiptest for currently failing \r test on python 3.2.
