### PR TITLE
TST: fix regression on 64-bit Windows.

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -138,7 +138,8 @@ class TestRegression(TestCase):
         self.assertRaises(TypeError,np.dtype,
                               {'names':['a'],'formats':['foo']},align=1)
 
-    @dec.knownfailureif(sys.version_info[0] >= 3,
+    @dec.knownfailureif((sys.version_info[0] >= 3) or
+                        (sys.platform == "win32" and platform.architecture()[0] == "64bit"),
                         "numpy.intp('0xff', 16) not supported on Py3, "
                         "as it does not inherit from Python int")
     def test_intp(self,level=rlevel):


### PR DESCRIPTION
On win-64 intp does not inherit from int, hence this test fails. It's not clear to me why the fix for http://projects.scipy.org/numpy/ticket/686 was changed again, but this seems like an acceptable solution.
