### PR TITLE
Fix memory leak in reduction ufuncs

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3383,6 +3383,9 @@ finish:
     if (iter_inner != NULL) {
         NpyIter_Deallocate(iter_inner);
     }
+
+    Py_XDECREF(errobj);
+
     return (PyObject *)out;
 
 fail:
@@ -3771,6 +3774,9 @@ finish:
     if (iter != NULL) {
         NpyIter_Deallocate(iter);
     }
+
+    Py_XDECREF(errobj);
+
     return (PyObject *)out;
 
 fail:


### PR DESCRIPTION
Fix memory leak in reduction ufuncs -- the error object was not being dereferenced in the non-error case.

To reproduce, run the following with valgrind:

<pre>
import numpy as np

x = np.ones((1000,))
for i in range(10):
    y = np.sum(x)
</pre>
