### PR TITLE
Update the rwork size in the call to zgesdd to reflect a documentation bugfix in Lapack

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1297,7 +1297,7 @@ def svd(a, full_matrices=1, compute_uv=1):
     iwork = zeros((8*min(m, n),), fortran_int)
     if isComplexType(t):
         lapack_routine = lapack_lite.zgesdd
-        rwork = zeros((5*min(m, n)*min(m, n) + 5*min(m, n),), real_t)
+        rwork = zeros((min(m,n)*max(5*min(m,n)+7,2*max(m,n)+2*min(m,n)+1),), real_t)
         lwork = 1
         work = zeros((lwork,), t)
         results = lapack_routine(option, m, n, a, m, s, u, m, vt, nvt,


### PR DESCRIPTION
Update the rwork size in the call to zgesdd to reflect a documentation bugfix in Lapack SVN revision 729.

See http://www.netlib.org/lapack/lapack-3.2.2.html, bug 00046, or forum topic http://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=2&t=1779
