### PR TITLE
Memory leaks

### DIFF
--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -44,7 +44,6 @@ static int copy_@type@(PyArrayIterObject *itx, PyArrayNeighborhoodIterObject *ni
             ptr += 1;
         }
 
-        Py_INCREF(aout);
         PyList_Append(*out, (PyObject*)aout);
         Py_DECREF(aout);
         PyArray_ITER_NEXT(itx);
@@ -84,7 +83,6 @@ static int copy_object(PyArrayIterObject *itx, PyArrayNeighborhoodIterObject *ni
             PyArrayNeighborhoodIter_Next(niterx);
         }
 
-        Py_INCREF(aout);
         PyList_Append(*out, (PyObject*)aout);
         Py_DECREF(aout);
         PyArray_ITER_NEXT(itx);
@@ -238,7 +236,6 @@ copy_double_double(PyArrayNeighborhoodIterObject *itx,
             ptr += 1;
             PyArrayNeighborhoodIter_Next(niterx);
         }
-        Py_INCREF(aout);
         PyList_Append(*out, (PyObject*)aout);
         Py_DECREF(aout);
         PyArrayNeighborhoodIter_Next(itx);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4466,6 +4466,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     self->core_signature = NULL;
     if (signature != NULL) {
         if (_parse_signature(self, signature) != 0) {
+            Py_DECREF(self);
             return NULL;
         }
     }

--- a/numpy/core/src/umath/umath_tests.c.src
+++ b/numpy/core/src/umath/umath_tests.c.src
@@ -271,6 +271,7 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
     if (f == NULL) return NULL;
     core_enabled = ((PyUFuncObject*)f)->core_enabled;
+    Py_DECREF(f);
     return Py_BuildValue("i", core_enabled);
 }
 

--- a/numpy/core/src/umath/umathmodule.c.src
+++ b/numpy/core/src/umath/umathmodule.c.src
@@ -94,7 +94,6 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
         fname_len = 1;
         PyErr_Clear();
     }
-    Py_XDECREF(pyname);
 
     /*
      * self->ptr holds a pointer for enough memory for
@@ -119,6 +118,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     self->ptr = _pya_malloc(offset[0] + offset[1] + sizeof(void *) +
                             (fname_len + 14));
     if (self->ptr == NULL) {
+        Py_XDECREF(pyname);
         return PyErr_NoMemory();
     }
     Py_INCREF(function);
@@ -138,6 +138,8 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     memcpy(str, fname, fname_len);
     memcpy(str+fname_len, " (vectorized)", 14);
     self->name = str;
+
+    Py_XDECREF(pyname);
 
     /* Do a better job someday */
     self->doc = "dynamic ufunc based on a python function";

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -53,8 +53,10 @@ static PyObject *f2py_rout_wrap_call(PyObject *capi_self,
     dims[i] = (npy_intp)PyInt_AsLong(PySequence_GetItem(dims_capi,i));
 
   capi_arr_tmp = array_from_pyobj(type_num,dims,rank,intent|F2PY_INTENT_OUT,arr_capi);
-  if (capi_arr_tmp == NULL)
+  if (capi_arr_tmp == NULL) {
+    free(dims);
     return NULL;
+  }
   capi_buildvalue = Py_BuildValue("N",capi_arr_tmp);
   free(dims);
   return capi_buildvalue;


### PR DESCRIPTION
A few reference counting and memory management bugs found by running the nose tests under valgrind.  Some of these only affect running the tests themselves and can be considered a low priority.  However, the one in ufunc_frompyfunc actually caused a segfault for me -- it should probably be fixed in the release candidate before the official release.
