### PR TITLE
Allow bincount to accept empty arrays

### DIFF
--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -121,11 +121,6 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     type = PyArray_DescrFromType(PyArray_INTP);
     len = PyArray_SIZE(lst);
     if (len < 1) {
-        if (weight != Py_None) {
-            PyErr_SetString(PyExc_ValueError,
-                    "weights should be None if x is empty.");
-            goto fail;
-        }
         if (mlength == Py_None) {
             minlength = 0;
         }

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -118,11 +118,25 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     if (!(lst = PyArray_ContiguousFromAny(list, PyArray_INTP, 1, 1))) {
             goto fail;
     }
+    type = PyArray_DescrFromType(PyArray_INTP);
     len = PyArray_SIZE(lst);
     if (len < 1) {
-        PyErr_SetString(PyExc_ValueError,
-                "The first argument cannot be empty.");
-        goto fail;
+        if (weight != Py_None) {
+            PyErr_SetString(PyExc_ValueError,
+                    "weights should be None if x is empty.");
+            goto fail;
+        }
+        if (mlength == Py_None) {
+            minlength = 0;
+        }
+        else if (!(minlength = PyArray_PyIntAsIntp(mlength))) {
+            goto fail;
+        }
+        if (!(ans = PyArray_Zeros(1, &minlength, type, 0))){
+            goto fail;
+        }
+    Py_DECREF(lst);
+    return ans;
     }
     numbers = (intp *) PyArray_DATA(lst);
     mxi = mxx(numbers, len);
@@ -147,7 +161,6 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
             ans_size = minlength;
         }
     }
-    type = PyArray_DescrFromType(PyArray_INTP);
     if (weight == Py_None) {
         if (!(ans = PyArray_Zeros(1, &ans_size, type, 0))) {
             goto fail;

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1100,6 +1100,26 @@ class TestBincount(TestCase):
         y = np.bincount(x, w, 8)
         assert_array_equal(y, np.array([0, 0.2, 0.5, 0, 0.5, 0.1, 0, 0]))
 
+    def test_empty(self):
+        x = np.array([], dtype=int)
+        y = np.bincount(x)
+        assert_array_equal(x,y)
+
+    def test_empty_with_minlength(self):
+        x = np.array([], dtype=int)
+        y = np.bincount(x, minlength=5)
+        assert_array_equal(y, np.zeros(5, dtype=int))
+
+    def test_empty_with_weights(self):
+        x = np.array([], dtype=int)
+        w = np.array([0.2, 0.3, 0.5, 0.1, 0.2])
+        assert_raises(ValueError, np.bincount, x, weights=w)
+
+    def test_empty_with_minlength_and_weights(self):
+        x = np.array([], dtype=int)
+        w = np.array([0.2, 0.3, 0.5, 0.1, 0.2])
+        assert_raises(ValueError, np.bincount, x, minlength=5, weights=w)
+
 class TestInterp(TestCase):
     def test_exceptions(self):
         assert_raises(ValueError, interp, 0, [], [])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1110,15 +1110,6 @@ class TestBincount(TestCase):
         y = np.bincount(x, minlength=5)
         assert_array_equal(y, np.zeros(5, dtype=int))
 
-    def test_empty_with_weights(self):
-        x = np.array([], dtype=int)
-        w = np.array([0.2, 0.3, 0.5, 0.1, 0.2])
-        assert_raises(ValueError, np.bincount, x, weights=w)
-
-    def test_empty_with_minlength_and_weights(self):
-        x = np.array([], dtype=int)
-        w = np.array([0.2, 0.3, 0.5, 0.1, 0.2])
-        assert_raises(ValueError, np.bincount, x, minlength=5, weights=w)
 
 class TestInterp(TestCase):
     def test_exceptions(self):

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -169,10 +169,6 @@ class TestRegression(TestCase):
             sys.stdout.close()
             sys.stdout = oldstdout
 
-    def test_bincount_empty(self):
-        """Ticket #1387: empty array as input for bincount."""
-        assert_raises(ValueError, lambda : np.bincount(np.array([], dtype=np.intp)))
-
     def test_include_dirs(self):
         """As a sanity check, just test that get_include and
         get_numarray_include include something reasonable.  Somewhat


### PR DESCRIPTION
Following this discussion [1], this patch allows bincount to accept empty arrays. Closes ticket 1387 [2].

[1] http://thread.gmane.org/gmane.comp.python.numeric.general/44172
[2] http://projects.scipy.org/numpy/ticket/1387
