### PR TITLE
Datetime unit from string

### DIFF
--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -182,23 +182,46 @@ append_metastr_to_string(PyArray_DatetimeMetaData *meta,
 NPY_NO_EXPORT int
 get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
 
-
 /*
  * Parses (almost) standard ISO 8601 date strings. The differences are:
  *
+ * + After the date and time, may place a ' ' followed by an event number.
  * + The date "20100312" is parsed as the year 20100312, not as
  *   equivalent to "2010-03-12". The '-' in the dates are not optional.
  * + Only seconds may have a decimal point, with up to 18 digits after it
  *   (maximum attoseconds precision).
  * + Either a 'T' as in ISO 8601 or a ' ' may be used to separate
  *   the date and the time. Both are treated equivalently.
+ * + Doesn't (yet) handle the "YYYY-DDD" or "YYYY-Www" formats.
+ * + Doesn't handle leap seconds (seconds value has 60 in these cases).
+ * + Doesn't handle 24:00:00 as synonym for midnight (00:00:00) tomorrow
+ * + Accepts special values "NaT" (not a time), "Today", (current
+ *   day according to local time) and "Now" (current time in UTC).
  *
  * 'str' must be a NULL-terminated string, and 'len' must be its length.
+ *
+ * 'out' gets filled with the parsed date-time.
+ * 'out_local' gets set to 1 if the parsed time was in local time,
+ *      to 0 otherwise. The values 'now' and 'today' don't get counted
+ *      as local, and neither do UTC +/-#### timezone offsets, because
+ *      they aren't using the computer's local timezone offset.
+ * 'out_bestunit' gives a suggested unit based on the amount of
+ *      resolution provided in the string, or -1 for NaT.
+ * 'out_special' gets set to 1 if the parsed time was 'today',
+ *      'now', or ''/'NaT'. For 'today', the unit recommended is
+ *      'D', for 'now', the unit recommended is 's', and for 'NaT'
+ *      the unit recommended is 'Y'.
+ *
  *
  * Returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT int
-parse_iso_8601_date(char *str, int len, npy_datetimestruct *out);
+parse_iso_8601_date(char *str, int len,
+                    npy_datetimestruct *out,
+                    npy_bool *out_local,
+                    NPY_DATETIMEUNIT *out_bestunit,
+                    npy_bool *out_special);
+
 
 /*
  * Converts an npy_datetimestruct to an (almost) ISO 8601
@@ -221,19 +244,26 @@ NPY_NO_EXPORT int
 make_iso_8601_date(npy_datetimestruct *dts, char *outstr, int outlen,
                     int local, NPY_DATETIMEUNIT base, int tzoffset);
 
-
 /*
  * Tests for and converts a Python datetime.datetime or datetime.date
  * object into a NumPy npy_datetimestruct.
+ *
+ * 'out_bestunit' gives a suggested unit based on whether the object
+ *      was a datetime.date or datetime.datetime object.
  *
  * Returns -1 on error, 0 on success, and 1 (with no error set)
  * if obj doesn't have the neeeded date or datetime attributes.
  */
 NPY_NO_EXPORT int
-convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out);
+convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
+                                     NPY_DATETIMEUNIT *out_bestunit);
 
 /*
- * Converts a PyObject * into a datetime, in any of the input forms supported.
+ * Converts a PyObject * into a datetime, in any of the forms supported.
+ *
+ * If the units metadata isn't known ahead of time, set meta->base
+ * to -1, and this function will populate meta with either default
+ * values or values from the input object.
  *
  * Returns -1 on error, 0 on success.
  */
@@ -243,6 +273,10 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
 /*
  * Converts a PyObject * into a timedelta, in any of the forms supported
+ *
+ * If the units metadata isn't known ahead of time, set meta->base
+ * to -1, and this function will populate meta with either default
+ * values or values from the input object.
  *
  * Returns -1 on error, 0 on success.
  */

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -199,6 +199,8 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  *   day according to local time) and "Now" (current time in UTC).
  *
  * 'str' must be a NULL-terminated string, and 'len' must be its length.
+ * 'unit' should contain -1 if the unit is unknown, or the unit
+ *      which will be used if it is.
  *
  * 'out' gets filled with the parsed date-time.
  * 'out_local' gets set to 1 if the parsed time was in local time,
@@ -217,11 +219,11 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  */
 NPY_NO_EXPORT int
 parse_iso_8601_date(char *str, int len,
+                    NPY_DATETIMEUNIT unit,
                     npy_datetimestruct *out,
                     npy_bool *out_local,
                     NPY_DATETIMEUNIT *out_bestunit,
                     npy_bool *out_special);
-
 
 /*
  * Converts an npy_datetimestruct to an (almost) ISO 8601

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2521,50 +2521,26 @@ static PyObject *
         }
     }
     else {
-        ret->obmeta.base = NPY_DATETIME_DEFAULTUNIT;
-        ret->obmeta.num = 1;
-        ret->obmeta.events = 1;
+        /*
+         * A unit of -1 signals that convert_pyobject_to_datetime
+         * should populate.
+         */
+        ret->obmeta.base = -1;
     }
 
     if (obj == NULL) {
+        if (ret->obmeta.base == -1) {
+            ret->obmeta.base = NPY_DATETIME_DEFAULTUNIT;
+            ret->obmeta.num = 1;
+            ret->obmeta.events = 1;
+        }
+
         ret->obval = 0;
     }
-    /*
-     * If the metadata was unspecified and the input is a datetime/timedelta
-     * scalar, then copy the input's value and metadata exactly.
-     */
-    else if (meta_obj == NULL && PyArray_IsScalar(obj, @Name@)) {
-        ret->obval = ((Py@Name@ScalarObject *)obj)->obval;
-        ret->obmeta = ((Py@Name@ScalarObject *)obj)->obmeta;
-    }
-    /*
-     * If the metadata was unspecified and the input is a datetime/timedelta
-     * zero-dimensional array, then copy the input's value and metadata
-     * directly.
-     */
-    else if (meta_obj == NULL &&
-                    PyArray_Check(obj) &&
-                    PyArray_NDIM(obj) == 0 &&
-                    PyArray_DESCR(obj)->type_num == NPY_@NAME@) {
-        PyArray_DatetimeMetaData *meta;
-
-        meta = get_datetime_metadata_from_dtype(PyArray_DESCR(obj));
-        if (meta == NULL) {
-            Py_DECREF(ret);
-            return NULL;
-        }
-        PyArray_DESCR(obj)->f->copyswap(&ret->obval,
-                                        PyArray_DATA(obj),
-                                        !PyArray_ISNOTSWAPPED(obj),
-                                        obj);
-        ret->obmeta = *meta;
-    }
-    else {
-        if (convert_pyobject_to_@name@(&ret->obmeta, obj, &ret->obval)
+    else if (convert_pyobject_to_@name@(&ret->obmeta, obj, &ret->obval)
                                                                     < 0) {
-            Py_DECREF(ret);
-            return NULL;
-        }
+        Py_DECREF(ret);
+        return NULL;
     }
 
     return (PyObject *)ret;

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -80,6 +80,9 @@ class TestDateTime(TestCase):
         assert_equal(np.datetime64('1950-03-12', 's'),
                      np.datetime64('1950-03-12', 'm'))
 
+        # Default construction means 0
+        assert_equal(np.datetime64(), np.datetime64(0))
+
         # When constructing from a scalar or zero-dimensional array,
         # it either keeps the units or you can override them.
         a = np.datetime64('2000-03-18T16Z', 'h')
@@ -110,13 +113,15 @@ class TestDateTime(TestCase):
                      np.datetime64(datetime.datetime(1980,1,25,
                                                 14,36,22,500000)))
         
-
     def test_timedelta_scalar_construction(self):
         # Construct with different units
         assert_equal(np.timedelta64(7, 'D'),
                      np.timedelta64(1, 'W'))
         assert_equal(np.timedelta64(120, 's'),
                      np.timedelta64(2, 'm'))
+
+        # Default construction means 0
+        assert_equal(np.timedelta64(), np.timedelta64(0))
 
         # When constructing from a scalar or zero-dimensional array,
         # it either keeps the units or you can override them.
@@ -157,6 +162,86 @@ class TestDateTime(TestCase):
                      np.timedelta64(datetime.timedelta(hours=281)))
         assert_equal(np.timedelta64(28, 'W'),
                      np.timedelta64(datetime.timedelta(weeks=28)))
+
+    def test_timedelta_scalar_construction_units(self):
+        # String construction detecting units
+        assert_equal(np.datetime64('2010').dtype,
+                     np.dtype('M8[Y]'))
+        assert_equal(np.datetime64('2010-03').dtype,
+                     np.dtype('M8[M]'))
+        assert_equal(np.datetime64('2010-03-12').dtype,
+                     np.dtype('M8[D]'))
+        assert_equal(np.datetime64('2010-03-12T17').dtype,
+                     np.dtype('M8[h]'))
+        assert_equal(np.datetime64('2010-03-12T17:15Z').dtype,
+                     np.dtype('M8[m]'))
+        assert_equal(np.datetime64('2010-03-12T17:15:08Z').dtype,
+                     np.dtype('M8[s]'))
+
+        assert_equal(np.datetime64('2010-03-12T17:15:08.1Z').dtype,
+                     np.dtype('M8[ms]'))
+        assert_equal(np.datetime64('2010-03-12T17:15:08.12Z').dtype,
+                     np.dtype('M8[ms]'))
+        assert_equal(np.datetime64('2010-03-12T17:15:08.123Z').dtype,
+                     np.dtype('M8[ms]'))
+
+        assert_equal(np.datetime64('2010-03-12T17:15:08.1234Z').dtype,
+                     np.dtype('M8[us]'))
+        assert_equal(np.datetime64('2010-03-12T17:15:08.12345Z').dtype,
+                     np.dtype('M8[us]'))
+        assert_equal(np.datetime64('2010-03-12T17:15:08.123456Z').dtype,
+                     np.dtype('M8[us]'))
+
+        assert_equal(np.datetime64('1970-01-01T00:00:02.1234567Z').dtype,
+                     np.dtype('M8[ns]'))
+        assert_equal(np.datetime64('1970-01-01T00:00:02.12345678Z').dtype,
+                     np.dtype('M8[ns]'))
+        assert_equal(np.datetime64('1970-01-01T00:00:02.123456789Z').dtype,
+                     np.dtype('M8[ns]'))
+
+        assert_equal(np.datetime64('1970-01-01T00:00:02.1234567890Z').dtype,
+                     np.dtype('M8[ps]'))
+        assert_equal(np.datetime64('1970-01-01T00:00:02.12345678901Z').dtype,
+                     np.dtype('M8[ps]'))
+        assert_equal(np.datetime64('1970-01-01T00:00:02.123456789012Z').dtype,
+                     np.dtype('M8[ps]'))
+
+        assert_equal(np.datetime64(
+                     '1970-01-01T00:00:02.1234567890123Z').dtype,
+                     np.dtype('M8[fs]'))
+        assert_equal(np.datetime64(
+                     '1970-01-01T00:00:02.12345678901234Z').dtype,
+                     np.dtype('M8[fs]'))
+        assert_equal(np.datetime64(
+                     '1970-01-01T00:00:02.123456789012345Z').dtype,
+                     np.dtype('M8[fs]'))
+
+        assert_equal(np.datetime64(
+                    '1970-01-01T00:00:02.1234567890123456Z').dtype,
+                     np.dtype('M8[as]'))
+        assert_equal(np.datetime64(
+                    '1970-01-01T00:00:02.12345678901234567Z').dtype,
+                     np.dtype('M8[as]'))
+        assert_equal(np.datetime64(
+                    '1970-01-01T00:00:02.123456789012345678Z').dtype,
+                     np.dtype('M8[as]'))
+
+        # Python date object
+        assert_equal(np.datetime64(datetime.date(2010,4,16)).dtype,
+                     np.dtype('M8[D]'))
+
+        # Python datetime object
+        assert_equal(np.datetime64(
+                        datetime.datetime(2010,4,16,13,45,18)).dtype,
+                     np.dtype('M8[us]'))
+
+        # 'today' special value
+        assert_equal(np.datetime64('today').dtype,
+                     np.dtype('M8[D]'))
+
+        # 'now' special value
+        assert_equal(np.datetime64('now').dtype,
+                     np.dtype('M8[s]'))
 
     def test_datetime_nat_casting(self):
         a = np.array('NaT', dtype='M8[D]')

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -239,9 +239,17 @@ class TestDateTime(TestCase):
         assert_equal(np.datetime64('today').dtype,
                      np.dtype('M8[D]'))
 
+        assert_raises(ValueError, np.datetime64, 'today', 'h')
+        assert_raises(ValueError, np.datetime64, 'today', 's')
+        assert_raises(ValueError, np.datetime64, 'today', 'as')
+
         # 'now' special value
         assert_equal(np.datetime64('now').dtype,
                      np.dtype('M8[s]'))
+
+        assert_raises(ValueError, np.datetime64, 'now', 'Y')
+        assert_raises(ValueError, np.datetime64, 'now', 'M')
+        assert_raises(ValueError, np.datetime64, 'now', 'D')
 
     def test_datetime_nat_casting(self):
         a = np.array('NaT', dtype='M8[D]')
@@ -352,7 +360,7 @@ class TestDateTime(TestCase):
         a = np.array(['2000-01-01', datetime.date(2000, 1, 1)], dtype='M8[s]')
         assert_equal(a[0], a[1])
         # Will fail if the date changes during the exact right moment
-        a = np.array(['today', datetime.date.today()], dtype='M8[s]')
+        a = np.array(['today', datetime.date.today()], dtype='M8[D]')
         assert_equal(a[0], a[1])
         # datetime.datetime.now() returns local time, not UTC
         #a = np.array(['now', datetime.datetime.now()], dtype='M8[s]')
@@ -470,14 +478,10 @@ class TestDateTime(TestCase):
                              np.array('1932-02-17T00:00:00Z', dtype=dt2))
                 assert_equal(np.array('10000-04-27', dtype=dt1),
                              np.array('10000-04-27T00:00:00Z', dtype=dt2))
-                assert_equal(np.array('today', dtype=dt1),
-                             np.array('today', dtype=dt2))
                 assert_equal(np.datetime64('1932-02-17', unit1),
                              np.datetime64('1932-02-17T00:00:00Z', unit2))
                 assert_equal(np.datetime64('10000-04-27', unit1),
                              np.datetime64('10000-04-27T00:00:00Z', unit2))
-                assert_equal(np.datetime64('today', unit1),
-                             np.datetime64('today', unit2))
 
         # Shouldn't be able to compare datetime and timedelta
         # TODO: Changing to 'same_kind' or 'safe' casting in the ufuncs by


### PR DESCRIPTION
Changes to autodetect the datetime unit from the form of the ISO 8601 string. This makes np.datetime64('2011-03-12') have a 'D' unit, for example. Also provide automatic units for 'now' and 'today', and have them throw errors when used with the wrong kind of unit.
