### PR TITLE
BUG: fixed conflict with python2.4 due to calling PyErr_WarnEx() in conversion_utils.c

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -6,6 +6,7 @@
 #define NPY_NO_PREFIX
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
+#include "numpy/ndarrayobject.h"
 
 #include "npy_config.h"
 #include "numpy/npy_3kcompat.h"
@@ -629,7 +630,6 @@ NPY_NO_EXPORT int
 PyArray_TypestrConvert(int itemsize, int gentype)
 {
     int newtype = NPY_NOTYPE;
-    int ret;
 
     switch (gentype) {
         case NPY_GENBOOLLTR:
@@ -737,19 +737,11 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             }
             break;
 
-        case NPY_OBJECTLTR:
-#if PY_VERSION_HEX >= 0x02050000
-            ret = PyErr_WarnEx(PyExc_DeprecationWarning,
-                               "DType strings 'O4' and 'O8' are deprecated "
-                               "because they are platform specific. Use "
-                               "'O' instead", 0); 
-#else
-            ret = PyErr_Warn(PyExc_DeprecationWarning,
-                             "DType strings 'O4' and 'O8' are deprecated "
-                             "because they are platform specific. Use "
-                             "'O' instead"); 
-#endif
-            if (ret == 0 && (itemsize == 4 || itemsize == 8)) {
+        case NPY_OBJECTLTR:  /* raise PyErr_Warn|Ex depending on version */
+            if (DEPRECATE("DType strings 'O4' and 'O8' are deprecated "
+                          "because they are platform specific. Use "
+                          "'O' instead") == 0 && 
+                      (itemsize == 4 || itemsize == 8)) {
                 newtype = NPY_OBJECT;
             }
             break;

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -630,6 +630,7 @@ NPY_NO_EXPORT int
 PyArray_TypestrConvert(int itemsize, int gentype)
 {
     int newtype = NPY_NOTYPE;
+    int ret;
 
     switch (gentype) {
         case NPY_GENBOOLLTR:
@@ -738,10 +739,10 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             break;
 
         case NPY_OBJECTLTR:  /* raise PyErr_Warn|Ex depending on version */
-            if (DEPRECATE("DType strings 'O4' and 'O8' are deprecated "
-                          "because they are platform specific. Use "
-                          "'O' instead") == 0 && 
-                      (itemsize == 4 || itemsize == 8)) {
+            ret = DEPRECATE("DType strings 'O4' and 'O8' are deprecated "
+                            "because they are platform specific. Use "
+                            "'O' instead"); 
+            if (ret == 0 && (itemsize == 4 || itemsize == 8)) {
                 newtype = NPY_OBJECT;
             }
             break;

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -739,15 +739,15 @@ PyArray_TypestrConvert(int itemsize, int gentype)
 
         case NPY_OBJECTLTR:
 #if PY_VERSION_HEX >= 0x02050000
-	    ret = PyErr_WarnEx(PyExc_DeprecationWarning,
-			       "DType strings 'O4' and 'O8' are deprecated "
-			       "because they are platform specific. Use "
-			       "'O' instead", 0); 
+            ret = PyErr_WarnEx(PyExc_DeprecationWarning,
+                               "DType strings 'O4' and 'O8' are deprecated "
+                               "because they are platform specific. Use "
+                               "'O' instead", 0); 
 #else
-	    ret = PyErr_Warn(PyExc_DeprecationWarning,
-			     "DType strings 'O4' and 'O8' are deprecated "
-			     "because they are platform specific. Use "
-			     "'O' instead"); 
+            ret = PyErr_Warn(PyExc_DeprecationWarning,
+                             "DType strings 'O4' and 'O8' are deprecated "
+                             "because they are platform specific. Use "
+                             "'O' instead"); 
 #endif
             if (ret == 0 && (itemsize == 4 || itemsize == 8)) {
                 newtype = NPY_OBJECT;

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -629,6 +629,7 @@ NPY_NO_EXPORT int
 PyArray_TypestrConvert(int itemsize, int gentype)
 {
     int newtype = NPY_NOTYPE;
+    int ret;
 
     switch (gentype) {
         case NPY_GENBOOLLTR:
@@ -737,11 +738,18 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             break;
 
         case NPY_OBJECTLTR:
-            if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                            "DType strings 'O4' and 'O8' are deprecated "
-                            "because they are platform specific. Use "
-                            "'O' instead", 0) == 0 &&
-                        (itemsize == 4 || itemsize == 8)) {
+#if PY_VERSION_HEX >= 0x02050000
+	    ret = PyErr_WarnEx(PyExc_DeprecationWarning,
+			       "DType strings 'O4' and 'O8' are deprecated "
+			       "because they are platform specific. Use "
+			       "'O' instead", 0); 
+#else
+	    ret = PyErr_Warn(PyExc_DeprecationWarning,
+			     "DType strings 'O4' and 'O8' are deprecated "
+			     "because they are platform specific. Use "
+			     "'O' instead"); 
+#endif
+            if (ret == 0 && (itemsize == 4 || itemsize == 8)) {
                 newtype = NPY_OBJECT;
             }
             break;


### PR DESCRIPTION
import numpy failed; need to use PyErr_Warn() for version<2.5, which is now handled with DEPRECATE macro
