### PR TITLE
BUG: on Apple platforms changed long long format from "%Ld" to "%lld"

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -48,10 +48,13 @@ typedef unsigned PY_LONG_LONG npy_ulonglong;
 #    define NPY_ULONGLONG_FMT        "I64u"
 #    define NPY_LONGLONG_SUFFIX(x)   (x##i64)
 #    define NPY_ULONGLONG_SUFFIX(x)  (x##Ui64)
-#  elseif defined(__APPLE__)  /* "%Ld" only parses 4 bytes on 32-bit MacOS X */
-     #define LONGLONG_FMT   "lld"
-     #define ULONGLONG_FMT  "llu"
-        /*                         and another possible variant
+#  elif defined __APPLE__   /* "%Ld" only parses 4 bytes on 32-bit MacOS X */
+#    define NPY_LONGLONG_FMT         "lld"
+#    define NPY_ULONGLONG_FMT        "llu"
+#    define NPY_LONGLONG_SUFFIX(x)   (x##LL)
+#    define NPY_ULONGLONG_SUFFIX(x)  (x##ULL)
+        /* 
+	   and another possible variant:
            #define LONGLONG_FMT   "qd"   -- BSD perhaps?
            #define ULONGLONG_FMT   "qu"
         */

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -46,21 +46,23 @@ typedef unsigned PY_LONG_LONG npy_ulonglong;
 #  ifdef _MSC_VER
 #    define NPY_LONGLONG_FMT         "I64d"
 #    define NPY_ULONGLONG_FMT        "I64u"
-#    define NPY_LONGLONG_SUFFIX(x)   (x##i64)
-#    define NPY_ULONGLONG_SUFFIX(x)  (x##Ui64)
-#  elif defined __APPLE__   /* "%Ld" only parses 4 bytes on 32-bit MacOS X */
+#  elif defined(__APPLE__) || defined(__FreeBSD__)
+/*   "%Ld" only parses 4 bytes -- "L" is floating modifier on MacOS X/BSD */
 #    define NPY_LONGLONG_FMT         "lld"
 #    define NPY_ULONGLONG_FMT        "llu"
-#    define NPY_LONGLONG_SUFFIX(x)   (x##LL)
-#    define NPY_ULONGLONG_SUFFIX(x)  (x##ULL)
-        /* 
-	   and another possible variant:
-           #define LONGLONG_FMT   "qd"   -- BSD perhaps?
-           #define ULONGLONG_FMT   "qu"
-        */
+/* 
+     another possible variant -- *quad_t works on *BSD, but is deprecated:
+     #define LONGLONG_FMT   "qd"
+     #define ULONGLONG_FMT   "qu"
+*/
 #  else
 #    define NPY_LONGLONG_FMT         "Ld"
 #    define NPY_ULONGLONG_FMT        "Lu"
+#  endif
+#  ifdef _MSC_VER
+#    define NPY_LONGLONG_SUFFIX(x)   (x##i64)
+#    define NPY_ULONGLONG_SUFFIX(x)  (x##Ui64)
+#  else
 #    define NPY_LONGLONG_SUFFIX(x)   (x##LL)
 #    define NPY_ULONGLONG_SUFFIX(x)  (x##ULL)
 #  endif

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -48,13 +48,14 @@ typedef unsigned PY_LONG_LONG npy_ulonglong;
 #    define NPY_ULONGLONG_FMT        "I64u"
 #    define NPY_LONGLONG_SUFFIX(x)   (x##i64)
 #    define NPY_ULONGLONG_SUFFIX(x)  (x##Ui64)
-#  else
-        /* #define LONGLONG_FMT   "lld"      Another possible variant
-           #define ULONGLONG_FMT  "llu"
-
+#  elseif defined(__APPLE__)  /* "%Ld" only parses 4 bytes on 32-bit MacOS X */
+     #define LONGLONG_FMT   "lld"
+     #define ULONGLONG_FMT  "llu"
+        /*                         and another possible variant
            #define LONGLONG_FMT   "qd"   -- BSD perhaps?
            #define ULONGLONG_FMT   "qu"
         */
+#  else
 #    define NPY_LONGLONG_FMT         "Ld"
 #    define NPY_ULONGLONG_FMT        "Lu"
 #    define NPY_LONGLONG_SUFFIX(x)   (x##LL)


### PR DESCRIPTION
Resolves a test failure on PPC with Mark's recent datetime updates, but should fix print formats on 32bit MacOS X in general, where "%Ld" would only use 4 bytes at a time. For an npy_int64 year=1970 this print 
"%Ld - %Ld", year, year
produced "0 - 1970" on ppc and "1970 - 0" on i386, while "%lld - %lld" prints "1970 - 1970" on both archs. 

"That proves that it's wrong on i386 as well, and it makes perfect sense for big endian and little endian architectures." (-Mark)
