### PR TITLE
Structured dtype cleanup

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5563,7 +5563,8 @@ add_newdoc('numpy.core.multiarray', 'dtype',
     align : bool, optional
         Add padding to the fields to match what a C compiler would output
         for a similar C-struct. Can be ``True`` only if `obj` is a dictionary
-        or a comma-separated string.
+        or a comma-separated string. If a struct dtype is being created,
+        this also sets a sticky alignment flag ``isalignedstruct``.
     copy : bool, optional
         Make a new copy of the data-type object. If ``False``, the result
         may just be a reference to a built-in data-type object.
@@ -5785,6 +5786,14 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('isnative',
     Boolean indicating whether the byte order of this dtype is native
     to the platform.
 
+    """))
+
+add_newdoc('numpy.core.multiarray', 'dtype', ('isalignedstruct',
+    """
+    Boolean indicating whether the dtype is a struct which maintains
+    field alignment. This flag is sticky, so when combining multiple
+    structs together, it is preserved and produces new dtypes which
+    are also aligned.
     """))
 
 add_newdoc('numpy.core.multiarray', 'dtype', ('itemsize',

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -12,7 +12,7 @@ if (sys.byteorder == 'little'):
 else:
     _nbo = asbytes('>')
 
-def _makenames_list(adict):
+def _makenames_list(adict, align):
     from multiarray import dtype
     allfields = []
     fnames = adict.keys()
@@ -26,7 +26,7 @@ def _makenames_list(adict):
         num = int(obj[1])
         if (num < 0):
             raise ValueError("invalid offset.")
-        format = dtype(obj[0])
+        format = dtype(obj[0], align=align)
         if (format.itemsize == 0):
             raise ValueError("all itemsizes must be fixed.")
         if (n > 2):
@@ -53,7 +53,7 @@ def _usefields(adict, align):
     except KeyError:
         names = None
     if names is None:
-        names, formats, offsets, titles = _makenames_list(adict)
+        names, formats, offsets, titles = _makenames_list(adict, align)
     else:
         formats = []
         offsets = []

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1345,6 +1345,7 @@ PyArrayNeighborhoodIter_Next2D(PyArrayNeighborhoodIterObject* iter);
 #define PyDataType_ISEXTENDED(obj) PyTypeNum_ISEXTENDED(((PyArray_Descr*)(obj))->type_num)
 #define PyDataType_ISOBJECT(obj) PyTypeNum_ISOBJECT(((PyArray_Descr*)(obj))->type_num)
 #define PyDataType_HASFIELDS(obj) (((PyArray_Descr *)(obj))->names != NULL)
+#define PyDataType_HASSUBARRAY(dtype) ((dtype)->subarray != NULL)
 
 #define PyArray_ISBOOL(obj) PyTypeNum_ISBOOL(PyArray_TYPE(obj))
 #define PyArray_ISUNSIGNED(obj) PyTypeNum_ISUNSIGNED(PyArray_TYPE(obj))

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -502,7 +502,8 @@ typedef struct {
 #define NPY_USE_GETITEM     0x20
 /* Use f.setitem when setting creating 0-d array from this data-type.*/
 #define NPY_USE_SETITEM     0x40
-/* define NPY_IS_COMPLEX */
+/* A sticky flag specifically for structured arrays */
+#define NPY_ALIGNED_STRUCT  0x80
 
 /*
  *These are inherited for global data-type if any data-types in the

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -544,7 +544,7 @@ VOID_getitem(char *ip, PyArrayObject *ap)
     int itemsize;
 
     descr = ap->descr;
-    if (descr->names != NULL) {
+    if (PyDataType_HASFIELDS(descr)) {
         PyObject *key;
         PyObject *names;
         int i, n;
@@ -3302,10 +3302,14 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_FillWithScalarFunc*)NULL,
 #if @sort@
     {
-        quicksort_@suff@, heapsort_@suff@, mergesort_@suff@
+        (PyArray_SortFunc *)quicksort_@suff@,
+        (PyArray_SortFunc *)heapsort_@suff@,
+        (PyArray_SortFunc *)mergesort_@suff@
     },
     {
-        aquicksort_@suff@, aheapsort_@suff@, amergesort_@suff@
+        (PyArray_ArgSortFunc *)aquicksort_@suff@,
+        (PyArray_ArgSortFunc *)aheapsort_@suff@,
+        (PyArray_ArgSortFunc *)amergesort_@suff@
     },
 #else
     {
@@ -3406,10 +3410,14 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_FillWithScalarFunc*)@from@_fillwithscalar,
 #if @sort@
     {
-        quicksort_@suff@, heapsort_@suff@, mergesort_@suff@
+        (PyArray_SortFunc *)quicksort_@suff@,
+        (PyArray_SortFunc *)heapsort_@suff@,
+        (PyArray_SortFunc *)mergesort_@suff@
     },
     {
-        aquicksort_@suff@, aheapsort_@suff@, amergesort_@suff@
+        (PyArray_ArgSortFunc *)aquicksort_@suff@,
+        (PyArray_ArgSortFunc *)aheapsort_@suff@,
+        (PyArray_ArgSortFunc *)amergesort_@suff@
     },
 #else
     {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1917,7 +1917,7 @@ arraydescr_new(PyTypeObject *NPY_UNUSED(subtype),
 
     static char *kwlist[] = {"dtype", "align", "copy", "metadata", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO&O&O!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O!", kwlist,
                 &odescr,
                 PyArray_BoolConverter, &align,
                 PyArray_BoolConverter, &copy,

--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -10,6 +10,18 @@ array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);
 NPY_NO_EXPORT PyArray_Descr *
 _arraydescr_fromobj(PyObject *obj);
 
+/*
+ * This creates a shorter repr using the 'kind' and 'itemsize',
+ * instead of the longer type name. It also creates the input
+ * for constructing a dtype rather than the full dtype function
+ * call.
+ *
+ * This does not preserve the 'align=True' parameter
+ * for structured arrays like the regular repr does.
+ */
+NPY_NO_EXPORT PyObject *
+arraydescr_short_construction_repr(PyArray_Descr *dtype);
+
 #ifdef NPY_ENABLE_SEPARATE_COMPILATION
 extern NPY_NO_EXPORT char *_datetime_strings[];
 #endif

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -1974,7 +1974,7 @@ get_subarray_transfer_function(int aligned,
     npy_intp src_size = 1, dst_size = 1;
 
     /* Get the subarray shapes and sizes */
-    if (src_dtype->subarray != NULL) {
+    if (PyDataType_HASSUBARRAY(src_dtype)) {
        if (!(PyArray_IntpConverter(src_dtype->subarray->shape,
                                             &src_shape))) {
             PyErr_SetString(PyExc_ValueError,
@@ -1984,7 +1984,7 @@ get_subarray_transfer_function(int aligned,
         src_size = PyArray_MultiplyList(src_shape.ptr, src_shape.len);
         src_dtype = src_dtype->subarray->base;
     }
-    if (dst_dtype->subarray != NULL) {
+    if (PyDataType_HASSUBARRAY(dst_dtype)) {
        if (!(PyArray_IntpConverter(dst_dtype->subarray->shape,
                                             &dst_shape))) {
             if (src_shape.ptr != NULL) {
@@ -2848,7 +2848,7 @@ get_setdstzero_transfer_function(int aligned,
         *out_transferdata = NULL;
     }
     /* If there are subarrays, need to wrap it */
-    else if (dst_dtype->subarray != NULL) {
+    else if (PyDataType_HASSUBARRAY(dst_dtype)) {
         PyArray_Dims dst_shape = {NULL, -1};
         npy_intp dst_size = 1;
         PyArray_StridedTransferFn *contig_stransfer;
@@ -2961,7 +2961,7 @@ get_decsrcref_transfer_function(int aligned,
         return NPY_SUCCEED;
     }
     /* If there are subarrays, need to wrap it */
-    else if (src_dtype->subarray != NULL) {
+    else if (PyDataType_HASSUBARRAY(src_dtype)) {
         PyArray_Dims src_shape = {NULL, -1};
         npy_intp src_size = 1;
         PyArray_StridedTransferFn *stransfer;
@@ -3114,7 +3114,8 @@ PyArray_GetDTypeTransferFunction(int aligned,
     if (src_itemsize == dst_itemsize && src_dtype->kind == dst_dtype->kind &&
                 !PyDataType_HASFIELDS(src_dtype) &&
                 !PyDataType_HASFIELDS(dst_dtype) &&
-                src_dtype->subarray == NULL && dst_dtype->subarray == NULL &&
+                !PyDataType_HASSUBARRAY(src_dtype) &&
+                !PyDataType_HASSUBARRAY(dst_dtype) &&
                 src_type_num != NPY_DATETIME && src_type_num != NPY_TIMEDELTA) {
         /* A custom data type requires that we use its copy/swap */
         if (src_type_num >= NPY_NTYPES || dst_type_num >= NPY_NTYPES) {
@@ -3193,7 +3194,8 @@ PyArray_GetDTypeTransferFunction(int aligned,
     }
 
     /* Handle subarrays */
-    if (src_dtype->subarray != NULL || dst_dtype->subarray != NULL) {
+    if (PyDataType_HASSUBARRAY(src_dtype) ||
+                                PyDataType_HASSUBARRAY(dst_dtype)) {
         return get_subarray_transfer_function(aligned,
                         src_stride, dst_stride,
                         src_dtype, dst_dtype,

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -438,7 +438,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
 
     if ((newtype->elsize != self->descr->elsize) &&
         (self->nd == 0 || !PyArray_ISONESEGMENT(self) ||
-         newtype->subarray)) {
+         PyDataType_HASSUBARRAY(newtype))) {
         goto fail;
     }
     if (PyArray_ISCONTIGUOUS(self)) {
@@ -474,7 +474,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
 
     /* fall through -- adjust type*/
     Py_DECREF(self->descr);
-    if (newtype->subarray) {
+    if (PyDataType_HASSUBARRAY(newtype)) {
         /*
          * create new array object from data and update
          * dimensions, strides and descr from it

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -550,7 +550,7 @@ array_struct_get(PyArrayObject *self)
         inter->strides = NULL;
     }
     inter->data = self->data;
-    if (self->descr->names) {
+    if (PyDataType_HASFIELDS(self->descr)) {
         inter->descr = arraydescr_protocol_descr_get(self->descr);
         if (inter->descr == NULL) {
             PyErr_Clear();

--- a/numpy/core/src/multiarray/hashdescr.c
+++ b/numpy/core/src/multiarray/hashdescr.c
@@ -55,7 +55,7 @@ static int _is_array_descr_builtin(PyArray_Descr* descr)
         if (descr->fields != NULL && descr->fields != Py_None) {
                 return 0;
         }
-        if (descr->subarray != NULL) {
+        if (PyDataType_HASSUBARRAY(descr)) {
                 return 0;
         }
         return 1;
@@ -223,7 +223,7 @@ static int _array_descr_walk(PyArray_Descr* descr, PyObject *l)
                 return -1;
             }
         }
-        if(descr->subarray != NULL) {
+        if(PyDataType_HASSUBARRAY(descr)) {
             st = _array_descr_walk_subarray(descr->subarray, l);
             if (st) {
                 return -1;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -545,7 +545,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
     if (PyString_Check(op) || PyUnicode_Check(op)) {
         PyObject *temp;
 
-        if (self->descr->names) {
+        if (PyDataType_HASFIELDS(self->descr)) {
             obj = PyDict_GetItem(self->descr->fields, op);
             if (obj != NULL) {
                 PyArray_Descr *descr;
@@ -573,7 +573,9 @@ array_subscript(PyArrayObject *self, PyObject *op)
     }
 
     /* Check for multiple field access */
-    if (self->descr->names && PySequence_Check(op) && !PyTuple_Check(op)) {
+    if (PyDataType_HASFIELDS(self->descr) &&
+                        PySequence_Check(op) &&
+                        !PyTuple_Check(op)) {
         int seqlen, i;
         seqlen = PySequence_Size(op);
         for (i = 0; i < seqlen; i++) {
@@ -797,7 +799,7 @@ array_ass_sub(PyArrayObject *self, PyObject *index, PyObject *op)
     }
 
     if (PyString_Check(index) || PyUnicode_Check(index)) {
-        if (self->descr->names) {
+        if (PyDataType_HASFIELDS(self->descr)) {
             PyObject *obj;
 
             obj = PyDict_GetItem(self->descr->fields, index);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1144,7 +1144,7 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
         PyObject *new_name;
         PyObject *_numpy_internal;
         saved = self->descr;
-        if (saved->names == NULL) {
+        if (!PyDataType_HASFIELDS(saved)) {
             PyErr_SetString(PyExc_ValueError, "Cannot specify " \
                             "order when the array has no fields.");
             return NULL;
@@ -1198,7 +1198,7 @@ array_argsort(PyArrayObject *self, PyObject *args, PyObject *kwds)
         PyObject *new_name;
         PyObject *_numpy_internal;
         saved = self->descr;
-        if (saved->names == NULL) {
+        if (!PyDataType_HASFIELDS(saved)) {
             PyErr_SetString(PyExc_ValueError, "Cannot specify " \
                             "order when the array has no fields.");
             return NULL;

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -757,7 +757,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             Py_SIZE(vobj) = itemsize;
             vobj->flags = BEHAVED | OWNDATA;
             swap = 0;
-            if (descr->names) {
+            if (PyDataType_HASFIELDS(descr)) {
                 if (base) {
                     Py_INCREF(base);
                     vobj->base = base;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1955,7 +1955,7 @@ static PyMethodDef @name@type_methods[] = {
 static Py_ssize_t
 voidtype_length(PyVoidScalarObject *self)
 {
-    if (!self->descr->names) {
+    if (!PyDataType_HASFIELDS(self->descr)) {
         return 0;
     }
     else { /* return the number of fields */

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -50,6 +50,11 @@ class TestBuiltin(TestCase):
         assert_raises(ValueError, np.dtype, 'f4, i4', itemsize=7)
         # If alignment is enabled, the alignment (4) must divide the itemsize
         assert_raises(ValueError, np.dtype, 'f4, i1', align=True, itemsize=9)
+        # If alignment is enabled, the individual fields must be aligned
+        assert_raises(ValueError, np.dtype,
+                        {'names':['f0','f1'],
+                         'formats':['i1','f4'],
+                         'offsets':[0,2]}, align=True)
 
 class TestRecord(TestCase):
     def test_equivalent_record(self):
@@ -80,6 +85,18 @@ class TestRecord(TestCase):
             dict(names=set(['A', 'B']), formats=['f8', 'i4']))
         self.assertRaises(TypeError, np.dtype,
             dict(names=['A', 'B'], formats=set(['f8', 'i4'])))
+
+    def test_aligned_size(self):
+        # Check that structured dtypes get padded to an aligned size
+        dt = np.dtype('i4, i1', align=True)
+        assert_equal(dt.itemsize, 8)
+        dt = np.dtype([('f0', 'i4'), ('f1', 'i1')], align=True)
+        assert_equal(dt.itemsize, 8)
+        dt = np.dtype({'names':['f0','f1'], 'formats':['i4', 'u1'],
+                        'offsets':[0,4]}, align=True)
+        assert_equal(dt.itemsize, 8)
+        dt = np.dtype({'f0': ('i4', 0), 'f1':('u1', 4)}, align=True)
+        assert_equal(dt.itemsize, 8)
 
 class TestSubarray(TestCase):
     def test_single_subarray(self):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -92,11 +92,46 @@ class TestRecord(TestCase):
         assert_equal(dt.itemsize, 8)
         dt = np.dtype([('f0', 'i4'), ('f1', 'i1')], align=True)
         assert_equal(dt.itemsize, 8)
-        dt = np.dtype({'names':['f0','f1'], 'formats':['i4', 'u1'],
-                        'offsets':[0,4]}, align=True)
+        dt = np.dtype({'names':['f0','f1'],
+                       'formats':['i4', 'u1'],
+                       'offsets':[0,4]}, align=True)
         assert_equal(dt.itemsize, 8)
         dt = np.dtype({'f0': ('i4', 0), 'f1':('u1', 4)}, align=True)
         assert_equal(dt.itemsize, 8)
+        # Nesting should preserve that alignment
+        dt1 = np.dtype([('f0', 'i4'),
+                       ('f1', [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')]),
+                       ('f2', 'i1')], align=True)
+        assert_equal(dt1.itemsize, 20)
+        dt2 = np.dtype({'names':['f0','f1','f2'],
+                       'formats':['i4',
+                                  [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')],
+                                  'i1'],
+                       'offsets':[0, 4, 16]}, align=True)
+        assert_equal(dt2.itemsize, 20)
+        dt3 = np.dtype({'f0': ('i4', 0),
+                       'f1': ([('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')], 4),
+                       'f2': ('i1', 16)}, align=True)
+        assert_equal(dt3.itemsize, 20)
+        assert_equal(dt1, dt2)
+        assert_equal(dt2, dt3)
+        # Nesting should preserve packing
+        dt1 = np.dtype([('f0', 'i4'),
+                       ('f1', [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')]),
+                       ('f2', 'i1')], align=False)
+        assert_equal(dt1.itemsize, 11)
+        dt2 = np.dtype({'names':['f0','f1','f2'],
+                       'formats':['i4',
+                                  [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')],
+                                  'i1'],
+                       'offsets':[0, 4, 10]}, align=False)
+        assert_equal(dt2.itemsize, 11)
+        dt3 = np.dtype({'f0': ('i4', 0),
+                       'f1': ([('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')], 4),
+                       'f2': ('i1', 10)}, align=False)
+        assert_equal(dt3.itemsize, 11)
+        assert_equal(dt1, dt2)
+        assert_equal(dt2, dt3)
 
     def test_union_struct(self):
         # Should be able to create union dtypes

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -42,14 +42,18 @@ class TestBuiltin(TestCase):
             assert_raises(TypeError, np.dtype, typestr)
 
     def test_bad_param(self):
-        # Can't override the itemsize of a non-struct type
-        assert_raises(ValueError, np.dtype, 'f4', itemsize=6)
-        # Even if you specify the same size
-        assert_raises(ValueError, np.dtype, 'f4', itemsize=4)
         # Can't give a size that's too small
-        assert_raises(ValueError, np.dtype, 'f4, i4', itemsize=7)
+        assert_raises(ValueError, np.dtype,
+                        {'names':['f0','f1'],
+                         'formats':['i4', 'i1'],
+                         'offsets':[0,4],
+                         'itemsize':4})
         # If alignment is enabled, the alignment (4) must divide the itemsize
-        assert_raises(ValueError, np.dtype, 'f4, i1', align=True, itemsize=9)
+        assert_raises(ValueError, np.dtype,
+                        {'names':['f0','f1'],
+                         'formats':['i4', 'i1'],
+                         'offsets':[0,4],
+                         'itemsize':9}, align=True)
         # If alignment is enabled, the individual fields must be aligned
         assert_raises(ValueError, np.dtype,
                         {'names':['f0','f1'],
@@ -71,10 +75,12 @@ class TestRecord(TestCase):
 
     def test_different_titles(self):
         # In theory, they may hash the same (collision) ?
-        a = np.dtype({'names': ['r','b'], 'formats': ['u1', 'u1'],
-            'titles': ['Red pixel', 'Blue pixel']})
-        b = np.dtype({'names': ['r','b'], 'formats': ['u1', 'u1'],
-            'titles': ['RRed pixel', 'Blue pixel']})
+        a = np.dtype({'names': ['r','b'],
+                      'formats': ['u1', 'u1'],
+                      'titles': ['Red pixel', 'Blue pixel']})
+        b = np.dtype({'names': ['r','b'],
+                      'formats': ['u1', 'u1'],
+                      'titles': ['RRed pixel', 'Blue pixel']})
         assert_dtype_not_equal(a, b)
 
     def test_not_lists(self):
@@ -324,13 +330,14 @@ class TestString(TestCase):
 
         dt = np.dtype({'names': ['r','b'], 'formats': ['u1', 'u1'],
                         'offsets': [0, 2],
-                        'titles': ['Red pixel', 'Blue pixel']},
-                        itemsize = 4)
+                        'titles': ['Red pixel', 'Blue pixel'],
+                        'itemsize': 4})
         assert_equal(repr(dt),
                     "dtype({'names':['r','b'], "
                     "'formats':['u1','u1'], "
                     "'offsets':[0,2], "
-                    "'titles':['Red pixel','Blue pixel']}, itemsize=4)")
+                    "'titles':['Red pixel','Blue pixel'], "
+                    "'itemsize':4})")
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -98,6 +98,31 @@ class TestRecord(TestCase):
         dt = np.dtype({'f0': ('i4', 0), 'f1':('u1', 4)}, align=True)
         assert_equal(dt.itemsize, 8)
 
+    def test_union_struct(self):
+        # Should be able to create union dtypes
+        dt = np.dtype({'names':['f0','f1','f2'], 'formats':['<u4', '<u2','<u2'],
+                        'offsets':[0,0,2]}, align=True)
+        assert_equal(dt.itemsize, 4)
+        a = np.array([3], dtype='<u4').view(dt)
+        a['f1'] = 10
+        a['f2'] = 36
+        assert_equal(a['f0'], 10 + 36*256*256)
+        # Should be able to specify fields out of order
+        dt = np.dtype({'names':['f0','f1','f2'], 'formats':['<u4', '<u2','<u2'],
+                        'offsets':[4,0,2]}, align=True)
+        assert_equal(dt.itemsize, 8)
+        dt2 = np.dtype({'names':['f2','f0','f1'],
+                        'formats':['<u2', '<u4','<u2'],
+                        'offsets':[2,4,0]}, align=True)
+        vals = [(0,1,2), (3,-1,4)]
+        vals2 = [(2,0,1), (4,3,-1)]
+        a = np.array(vals, dt)
+        b = np.array(vals2, dt2)
+        assert_equal(a.astype(dt2), b)
+        assert_equal(b.astype(dt), a)
+        assert_equal(a.view(dt2), b)
+        assert_equal(b.view(dt), a)
+
 class TestSubarray(TestCase):
     def test_single_subarray(self):
         a = np.dtype((np.int, (2)))

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -122,6 +122,27 @@ class TestRecord(TestCase):
         assert_equal(b.astype(dt), a)
         assert_equal(a.view(dt2), b)
         assert_equal(b.view(dt), a)
+        # Should not be able to overlap objects with other types
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0','f1'],
+                 'formats':['O', 'i1'],
+                 'offsets':[0,2]})
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0','f1'],
+                 'formats':['i4', 'O'],
+                 'offsets':[0,3]})
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0','f1'],
+                 'formats':[[('a','O')], 'i1'],
+                 'offsets':[0,2]})
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0','f1'],
+                 'formats':['i4', [('a','O')]],
+                 'offsets':[0,3]})
+        # Out of order should still be ok, however
+        dt = np.dtype({'names':['f0','f1'],
+                       'formats':['i1', 'O'],
+                       'offsets':[np.dtype('intp').itemsize, 0]})
 
 class TestSubarray(TestCase):
     def test_single_subarray(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -853,34 +853,6 @@ class TestRegression(TestCase):
         assert_almost_equal(fdouble, 1.234)
         assert_almost_equal(flongdouble, 1.234)
 
-    def test_complex_dtype_printing(self, level=rlevel):
-        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
-                                ('rtile', '>f4', (64, 36))], (3,)),
-                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
-                                   ('bright', '>f4', (8, 36))])])
-        assert_equal(str(dt),
-                     "[('top', [('tiles', ('>f4', (64, 64)), (1,)), "
-                     "('rtile', '>f4', (64, 36))], (3,)), "
-                     "('bottom', [('bleft', ('>f4', (8, 64)), (1,)), "
-                     "('bright', '>f4', (8, 36))])]")
-
-        dt = np.dtype({'names': ['r','g','b'], 'formats': ['u1', 'u1', 'u1'],
-                        'offsets': [0, 1, 2],
-                        'titles': ['Red pixel', 'Green pixel', 'Blue pixel']})
-        assert_equal(str(dt),
-                    "[(('Red pixel', 'r'), 'u1'), "
-                    "(('Green pixel', 'g'), 'u1'), "
-                    "(('Blue pixel', 'b'), 'u1')]")
-
-        dt = np.dtype({'names': ['r','b'], 'formats': ['u1', 'u1'],
-                        'offsets': [0, 2],
-                        'titles': ['Red pixel', 'Blue pixel']})
-        assert_equal(str(dt),
-                    "{'names':['r','b'], "
-                    "'formats':['u1','u1'], "
-                    "'offsets':[0,2], "
-                    "'titles':['Red pixel','Blue pixel']}")
-
     def test_nonnative_endian_fill(self, level=rlevel):
         """ Non-native endian arrays were incorrectly filled with scalars before
         r5034.

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -864,6 +864,23 @@ class TestRegression(TestCase):
                      "('bottom', [('bleft', ('>f4', (8, 64)), (1,)), "
                      "('bright', '>f4', (8, 36))])]")
 
+        dt = np.dtype({'names': ['r','g','b'], 'formats': ['u1', 'u1', 'u1'],
+                        'offsets': [0, 1, 2],
+                        'titles': ['Red pixel', 'Green pixel', 'Blue pixel']})
+        assert_equal(str(dt),
+                    "[(('Red pixel', 'r'), 'u1'), "
+                    "(('Green pixel', 'g'), 'u1'), "
+                    "(('Blue pixel', 'b'), 'u1')]")
+
+        dt = np.dtype({'names': ['r','b'], 'formats': ['u1', 'u1'],
+                        'offsets': [0, 2],
+                        'titles': ['Red pixel', 'Blue pixel']})
+        assert_equal(str(dt),
+                    "{'names':['r','b'], "
+                    "'formats':['u1','u1'], "
+                    "'offsets':[0,2], "
+                    "'titles':['Red pixel','Blue pixel']}")
+
     def test_nonnative_endian_fill(self, level=rlevel):
         """ Non-native endian arrays were incorrectly filled with scalars before
         r5034.


### PR DESCRIPTION
This set of patches cleans up structured dtypes. In particular:
- Round-tripping with repr should work properly now
- Add an itemsize= parameter to the dtype constructor
- There is a new sticky NPY_ALIGNED_STRUCT flag which will be used for type promotion to retain alignment when combining dtypes
- Some issues in ticket #1619 are fixed, but the .npy format still errors as described there
- Ticket #1790 is fixed.
- Add various tests
- Allow union structured dtypes, and out-of-order field specification.
