### PR TITLE
BUG:py3k: fix error with recarry. Patch by C. Gohlke. Closes #1843.

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -23,7 +23,7 @@ if sys.version_info[0] >= 3:
             return s
         return s.decode('latin1')
     def isfileobj(f):
-        return isinstance(f, io.FileIO)
+        return isinstance(f, (io.FileIO, io.BufferedReader))
     def open_latin1(filename, mode='r'):
         return open(filename, mode=mode, encoding='iso-8859-1')
     strchar = 'U'

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -41,6 +41,8 @@ class TestFromrecords(TestCase):
         fd = open(filename, 'rb')
         fd.seek(2880 * 2)
         r = np.rec.fromfile(fd, formats='f8,i4,a5', shape=3, byteorder='big')
+        fd.seek(2880 * 2)
+        r = np.rec.array(fd, formats='f8,i4,a5', shape=3, byteorder='big')
 
     def test_recarray_from_obj(self):
         count = 10


### PR DESCRIPTION
Works for me.  Can go into 1.6.x too.
