### PR TITLE
Crash in ticket 1895/1896

### DIFF
--- a/numpy/core/src/multiarray/nditer.c.src
+++ b/numpy/core/src/multiarray/nditer.c.src
@@ -5772,7 +5772,9 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
                 reduce_outerptrs[iop] = ptrs[iop];
                 break;
             default:
-                /* In this case, the buffer is being used */
+                /* In this case, the buffer is always being used */
+                any_buffered = 1;
+
                 if (!(op_itflags[iop]&NPY_OP_ITFLAG_REDUCE)) {
                     ptrs[iop] = buffers[iop];
                     strides[iop] = dtypes[iop]->elsize;
@@ -5829,6 +5831,7 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
 
             npy_bool skip_transfer = 0;
 
+            /* If stransfer wasn't set to NULL, buffering is required */
             any_buffered = 1;
 
             /*

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -458,5 +458,19 @@ class TestUfunc(TestCase):
 
         assert_equal(ref, True, err_msg="reference check")
 
+    def test_casting_out_param(self):
+        # Test that it's possible to do casts on output
+        a = np.ones((200,100), np.int64)
+        b = np.ones((200,100), np.int64)
+        c = np.ones((200,100), np.float64)
+        np.add(a, b, out=c)
+        assert_equal(c, 2)
+
+        a = np.zeros(65536)
+        b = np.zeros(65536, dtype=np.float32)
+        np.subtract(a, 0, out=b)
+        assert_equal(b, 0)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
BUG: iter: writeonly operands weren't always being buffered correctly (Ticket #1895/1896)

This interacted with the NPY_ITER_GROWINNER flag which would incorrectly
grow the length because it thought nothing was being buffered.
