### PR TITLE
FIx to _array_find_type

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -169,6 +169,11 @@ class TestDateTime(TestCase):
         assert_raises(TypeError, np.datetime64,
                         datetime.datetime(1920,4,14,13,20), 'D')
 
+    def test_datetime_array_find_type(self):
+        dt = np.datetime64('1970-01-01', 'M')
+        arr = np.array([dt])
+        assert_equal(arr.dtype, np.dtype('M8[M]'))
+
     def test_timedelta_scalar_construction(self):
         # Construct with different units
         assert_equal(np.timedelta64(7, 'D'),


### PR DESCRIPTION
Hi folks

This code was failing:

```
    dt = np.datetime64('1970-01-01', 'M')
    arr = np.array([dt])
    assert_equal(arr.dtype, np.dtype('M8[M]'))
```

It turns out that _array_find_type with no explicit supertype tries to find the common supertype of every list element _and bool_. This worked for datetime until commit 25bcc658 changed _npy_type_promotion_table.

I think the right thing is to stop this "default bool" behaviour.

Cheers

Ben
