### PR TITLE
Fix asarray_chkfinite to take dtype and order arguments, as advertised

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -524,7 +524,7 @@ def average(a, axis=None, weights=None, returned=False):
     else:
         return avg
 
-def asarray_chkfinite(a):
+def asarray_chkfinite(a, dtype=None, order=None):
     """
     Convert the input to an array, checking for NaNs or Infs.
 
@@ -570,8 +570,8 @@ def asarray_chkfinite(a):
     ``asarray_chkfinite`` is identical to ``asarray``.
 
     >>> a = [1, 2]
-    >>> np.asarray_chkfinite(a)
-    array([1, 2])
+    >>> np.asarray_chkfinite(a, dtype=float)
+    array([1., 2.])
 
     Raises ValueError if array_like contains Nans or Infs.
 
@@ -584,7 +584,7 @@ def asarray_chkfinite(a):
     ValueError
 
     """
-    a = asarray(a)
+    a = asarray(a, dtype=dtype, order=order)
     if (a.dtype.char in typecodes['AllFloat']) \
            and (_nx.isnan(a).any() or _nx.isinf(a).any()):
         raise ValueError(

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -793,6 +793,12 @@ class TestCheckFinite(TestCase):
         assert_raises(ValueError, numpy.lib.asarray_chkfinite, b)
         assert_raises(ValueError, numpy.lib.asarray_chkfinite, c)
 
+    def test_dtype_order(self):
+        """Regression test for missing dtype and order arguments"""
+        a = [1, 2, 3]
+        a = numpy.lib.asarray_chkfinite(a, order='F', dtype=numpy.float64)
+        assert_(a.dtype == numpy.float64)
+
 
 class TestNaNFuncts(TestCase):
     def setUp(self):


### PR DESCRIPTION
I noticed this bug while hacking on scikit-learn. `asarray_chkfinite` hasn't implemented its specification for a long time.
