### PR TITLE
Better chkfinite

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -585,8 +585,7 @@ def asarray_chkfinite(a, dtype=None, order=None):
 
     """
     a = asarray(a, dtype=dtype, order=order)
-    if (a.dtype.char in typecodes['AllFloat']) \
-           and (_nx.isnan(a).any() or _nx.isinf(a).any()):
+    if a.dtype.char in typecodes['AllFloat'] and not np.isfinite(a).all():
         raise ValueError(
                 "array must not contain infs or NaNs")
     return a


### PR DESCRIPTION
Minor change to asarray_chkfinite suggested by Ralf Gommers. It cuts the runtime of asarray_chkfinite roughly in half. This is useful since it it called to verify the input of almost all scipy.linalg functions. 
