### PR TITLE
Adding floating hex (ala float.fromhex) support to loadtxt converter. (Issue 1924)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ doc/cdoc/build
 ######################
 .gdb_history
 .DS_Store?
+.DS_Store
 ehthumbs.db
 Icon?
 Thumbs.db

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -561,6 +561,12 @@ def _savez(file, args, kwds, compress):
     zip.close()
 
 # Adapted from matplotlib
+def _floatconv(x):
+    try:
+        return float(x)
+    except ValueError:
+        pass
+    return float.fromhex(x)
 
 def _getconv(dtype):
     typ = dtype.type
@@ -573,7 +579,7 @@ def _getconv(dtype):
     if issubclass(typ, np.integer):
         return lambda x: int(float(x))
     elif issubclass(typ, np.floating):
-        return float
+        return _floatconv
     elif issubclass(typ, np.complex):
         return complex
     elif issubclass(typ, np.bytes_):


### PR DESCRIPTION
Add _floatconv to npyio.py as a default floating point converter. This
uses float() as a type conversion with a fallback on (ValueError) to
float.fromhex().

I've never submitted a github style patch to a project before. I hope I'm not jumping the gun by submitting a pull request for a feature without any discussion after my feature request #1924. What's the appropriate etiquette?
