### PR TITLE
Skip complex function tests on darwin/intel.

### DIFF
--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -19,10 +19,9 @@ try:
 finally:
     np.seterr(**olderr)
 # TODO: replace with a check on whether platform-provided C99 funcs are used
-have_platform_functions = (sys.platform.startswith('sunos') or
-                           (sys.platform == 'darwin' and 'powerpc' in
-                                             platform.processor()))
+have_platform_functions = (sys.platform.startswith('sunos'))
 skip_complex_tests = (sys.platform.startswith('win') or
+                      (sys.platform == 'darwin') or
                       (have_platform_functions and functions_seem_flaky))
 
 def platform_skip(func):


### PR DESCRIPTION
On Mac OS X 10.7, numpy.test() fails with messages
similar to those reported on Windows in trac 1574
( http://projects.scipy.org/numpy/ticket/1574 ).

It seems the platform-provided C99 functions are also
flakey on OS X. According to the logic in trac 1574, these
tests should be skipped since the bug is in the platform
library, not numpy.

This patch skips the tests on darwin/intel, and
makes numpy.test() pass successfully on OS X 10.7.
