### PR TITLE
ENH: refactor of docteset plugin management

### DIFF
--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -12,7 +12,7 @@ import nose
 from nose.plugins import doctests as npd
 from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
 from nose.plugins.base import Plugin
-from nose.util import src, getpackage
+from nose.util import src
 import numpy
 from nosetester import get_package_name
 import inspect
@@ -115,27 +115,6 @@ class NumpyDocTestFinder(doctest.DocTestFinder):
                     valname = '%s.%s' % (name, valname)
                     self._find(tests, val, valname, module, source_lines,
                                globs, seen)
-
-
-class NumpyDocTestCase(npd.DocTestCase):
-    """Proxy for DocTestCase: provides an address() method that
-    returns the correct address for the doctest case. Otherwise
-    acts as a proxy to the test case. To provide hints for address(),
-    an obj may also be passed -- this will be used as the test object
-    for purposes of determining the test address, if it is provided.
-    """
-
-    # doctests loaded via find(obj) omit the module name
-    # so we need to override id, __repr__ and shortDescription
-    # bonus: this will squash a 2.3 vs 2.4 incompatiblity
-    def id(self):
-        name = self._dt_test.name
-        filename = self._dt_test.filename
-        if filename is not None:
-            pk = getpackage(filename)
-            if pk is not None and not name.startswith(pk):
-                name = "%s.%s" % (pk, name)
-        return name
 
 
 # second-chance checker; if the default comparison doesn't

--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -196,6 +196,7 @@ class NumpyDoctest(npd.Doctest):
         self.doctest_tests = True
         self.finder = NumpyDocTestFinder()
         self.parser = doctest.DocTestParser()
+        self.doctest_result_var = None # default in npd.Doctest
         if self.enabled:
             # Pull standard doctest out of plugin list; there's no reason to run
             # both.  In practice the Unplugger plugin above would cover us when
@@ -254,7 +255,8 @@ class NumpyDoctest(npd.Doctest):
 
             yield NumpyDocTestCase(test,
                                    optionflags=optionflags,
-                                   checker=NumpyOutputChecker())
+                                   checker=NumpyOutputChecker(),
+                                   result_var = self.doctest_result_var)
 
 
     # Add an afterContext method to nose.plugins.doctests.Doctest in order

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -287,24 +287,23 @@ class NoseTester(object):
         Notes
         -----
         Each NumPy module exposes `test` in its namespace to run all tests for it.
-        For example, to run all tests for numpy.lib::
+        For example, to run all tests for numpy.lib:
 
-          >>> np.lib.test()
+        >>> np.lib.test() #doctest: +SKIP
 
         Examples
         --------
-        >>> result = np.lib.test()
+        >>> result = np.lib.test() #doctest: +SKIP
         Running unit tests for numpy.lib
         ...
         Ran 976 tests in 3.933s
 
         OK
 
-        >>> result.errors
+        >>> result.errors #doctest: +SKIP
         []
-        >>> result.knownfail
+        >>> result.knownfail #doctest: +SKIP
         []
-
         """
 
         # cap verbosity at 3 because nose becomes *very* verbose beyond that
@@ -368,7 +367,7 @@ class NoseTester(object):
 
         Examples
         --------
-        >>> success = np.lib.bench()
+        >>> success = np.lib.bench() #doctest: +SKIP
         Running benchmarks for numpy.lib
         ...
         using 562341 items:
@@ -381,7 +380,7 @@ class NoseTester(object):
         ...
         OK
 
-        >>> success
+        >>> success #doctest: +SKIP
         True
 
         """

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -401,32 +401,3 @@ class NoseTester(object):
 
         return nose.run(argv=argv, addplugins=add_plugins)
 
-
-########################################################################
-# Doctests for NumPy-specific nose/doctest modifications
-
-# try the #random directive on the output line
-def check_random_directive():
-    '''
-    >>> 2+2
-    <BadExample object at 0x084D05AC>  #random: may vary on your system
-    '''
-
-# check the implicit "import numpy as np"
-def check_implicit_np():
-    '''
-    >>> np.array([1,2,3])
-    array([1, 2, 3])
-    '''
-
-# there's some extraneous whitespace around the correct responses
-def check_whitespace_enabled():
-    '''
-    # whitespace after the 3
-    >>> 1+2
-    3
-
-    # whitespace before the 7
-    >>> 3+4
-     7
-    '''

--- a/numpy/testing/tests/test_doctesting.py
+++ b/numpy/testing/tests/test_doctesting.py
@@ -1,0 +1,35 @@
+""" Doctests for NumPy-specific nose/doctest modifications
+"""
+# try the #random directive on the output line
+def check_random_directive():
+    '''
+    >>> 2+2
+    <BadExample object at 0x084D05AC>  #random: may vary on your system
+    '''
+
+# check the implicit "import numpy as np"
+def check_implicit_np():
+    '''
+    >>> np.array([1,2,3])
+    array([1, 2, 3])
+    '''
+
+# there's some extraneous whitespace around the correct responses
+def check_whitespace_enabled():
+    '''
+    # whitespace after the 3
+    >>> 1+2
+    3
+
+    # whitespace before the 7
+    >>> 3+4
+     7
+    '''
+
+
+if __name__ == '__main__':
+    # Run tests outside numpy test rig
+    import nose
+    from numpy.testing.noseclasses import NumpyDoctest
+    argv = ['', __file__, '--with-numpydoctest']
+    nose.core.TestProgram(argv=argv, addplugins=[NumpyDoctest()])

--- a/numpy/testing/tests/test_doctesting.py
+++ b/numpy/testing/tests/test_doctesting.py
@@ -26,6 +26,24 @@ def check_whitespace_enabled():
      7
     '''
 
+def check_empty_output():
+    """ Check that no output does not cause an error.
+
+    This is related to nose bug 445; the numpy plugin changed the
+    doctest-result-variable default and therefore hit this bug:
+    http://code.google.com/p/python-nose/issues/detail?id=445
+
+    >>> a = 10
+    """
+
+def check_skip():
+    """ Check skip directive
+
+    The test below should not run
+
+    >>> 1/0 #doctest: +SKIP
+    """
+
 
 if __name__ == '__main__':
     # Run tests outside numpy test rig

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -954,10 +954,9 @@ def rundocs(filename=None, raise_on_error=True):
     -----
     The doctests can be run by the user/developer by adding the ``doctests``
     argument to the ``test()`` call. For example, to run all tests (including
-    doctests) for `numpy.lib`::
+    doctests) for `numpy.lib`:
 
-      >>> np.lib.test(doctests=True)
-
+    >>> np.lib.test(doctests=True) #doctest: +SKIP
     """
     import doctest, imp
     if filename is None:


### PR DESCRIPTION
We previously had a baroque inheritance scheme to deal with the case
where the user had normal nose doctests enabled in their environment.
However, this scheme didn't deal with bench() routine, and was
complicated. This commit uses a null Unplugger plugin to pull the
doctest plugin off the nose configuration after it has been initialized.
We can use this for bench() and test(), and it allows the doctest module
to be enabled (by the user environment) and then thrown away.

Also rejigged the docstrings and removed the automated docstring
addition as the docstrings have already been copied and adapted in the
code.
