### PR TITLE
repr's for iinfo, finfo (with tests)

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -180,6 +180,14 @@ nexp  =%(nexp)6s   min=        -max
 ---------------------------------------------------------------------
 ''' % self.__dict__
 
+    def __repr__(self):
+        c = self.__class__.__name__
+        d = self.__dict__.copy()
+        d['klass'] = c
+        return ("%(klass)s(resolution=%(resolution)s, min=-%(_str_max)s," \
+               + " max=%(_str_max)s, dtype=%(dtype)s)") \
+                % d
+
 
 class iinfo(object):
     """
@@ -280,6 +288,9 @@ max = %(max)s
 ---------------------------------------------------------------------
 ''' % {'dtype': self.dtype, 'min': self.min, 'max': self.max}
 
+    def __repr__(self):
+        return "%s(min=%s, max=%s, dtype=%s)" % (self.__class__.__name__,
+                                    self.min, self.max, self.dtype)
 
 if __name__ == '__main__':
     f = finfo(ntypes.single)

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -55,6 +55,15 @@ class TestIinfo(TestCase):
         for T in types:
             assert_equal(iinfo(T).max, T(-1))
 
+class TestRepr(TestCase):
+    def test_iinfo_repr(self):
+        expected = "iinfo(min=-32768, max=32767, dtype=int16)"
+        assert_equal(repr(np.iinfo(np.int16)), expected)
+
+    def test_finfo_repr(self):
+        expected = "finfo(resolution=1e-06, min=-3.4028235e+38," + \
+                   " max=3.4028235e+38, dtype=float32)"
+        assert_equal(repr(np.finfo(np.float32)), expected)
 
 def test_instances():
     iinfo(10)


### PR DESCRIPTION
numpy.iinfo and numpy.finfo do not currently have a repr defined. This commit makes them appear as:

``` python
iinfo(min=-32768, max=32767, dtype=int16)
```

and

``` python
finfo(resolution=1e-06, min=-3.4028235e+38  max=3.4028235e+38, dtype=float32)
```
