### PR TITLE
Fix segfault when PyArray_VOID and no minitype in _array_find_type.

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -286,7 +286,7 @@ _array_find_type(PyObject *op, PyArray_Descr *minitype, int max)
      * unless input was already a VOID
      */
     if (outtype->type_num == PyArray_VOID &&
-        minitype->type_num != PyArray_VOID) {
+        (minitype == NULL || minitype->type_num != PyArray_VOID)) {
         Py_DECREF(outtype);
         return PyArray_DescrFromType(PyArray_OBJECT);
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -327,6 +327,10 @@ class TestCreation(TestCase):
             msg = 'String conversion for %s' % type
             assert_equal(array(nstr, dtype=type), result, err_msg=msg)
 
+    def test_void(self):
+        arr = np.array([np.void(0)], dtype='V')
+        assert_equal(arr.dtype.kind, 'V')
+
     def test_non_sequence_sequence(self):
         """Should not segfault.
 


### PR DESCRIPTION
This is a fix for http://www.mail-archive.com/numpy-discussion@scipy.org/msg33130.html.

Sorry!

Ben
