### PR TITLE
Added 'prescan' option to loadtxt for array allocation prior to reading

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -585,7 +585,7 @@ def _getconv(dtype):
 
 def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             converters=None, skiprows=0, usecols=None, unpack=False,
-            ndmin=0):
+            ndmin=0, prescan=False):
     """
     Load data from a text file.
 
@@ -630,6 +630,12 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         Otherwise mono-dimensional axes will be squeezed.
         Legal values: 0 (default), 1 or 2.
         .. versionadded:: 1.6.0
+    prescan : bool, optional
+        If true, read in the entire file in a first pass to determine the
+        size of the returned array and allocate it ahead of reading in the
+        actual data.  This saves considerable memory otherwise used for
+        intermediate data lists, at the expense of typical increases in
+        loading time of 10-40%.  Default is False.
 
     Returns
     -------
@@ -693,7 +699,6 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             fh = iter(fname)
     except TypeError:
         raise ValueError('fname must be a string, file handle, or generator')
-    X = []
 
     def flatten_dtype(dt):
         """Unpack a structured data-type, and produce re-packing info."""
@@ -760,14 +765,18 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         # Read until we find a line with some values, and use
         # it to estimate the number of columns, N.
         first_vals = None
+        first_lno = skiprows
+        n_valid = 1
         try:
             while not first_vals:
                 first_line = fh.next()
                 first_vals = split_line(first_line)
+                first_lno += 1
         except StopIteration:
             # End of lines reached
             first_line = ''
             first_vals = []
+            n_valid = 0
             warnings.warn('loadtxt: Empty input file: "%s"' % fname)
         N = len(usecols or first_vals)
 
@@ -776,9 +785,11 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             # We're dealing with a structured array, each field of
             # the dtype matches a column
             converters = [_getconv(dt) for dt in dtype_types]
+            shape_r = 1
         else:
             # All fields have the same dtype
             converters = [defconv for i in xrange(N)]
+            shape_r = N
             if N > 1:
                 packing = [(N, tuple)]
 
@@ -792,23 +803,64 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
                     continue
             converters[i] = conv
 
-        # Parse each line, including the first
-        for i, line in enumerate(itertools.chain([first_line], fh)):
-            vals = split_line(line)
-            if len(vals) == 0:
-                continue
-            if usecols:
-                vals = [vals[i] for i in usecols]
-            # Convert each value according to its column and store
-            items = [conv(val) for (conv, val) in zip(converters, vals)]
-            # Then pack it according to the dtype's nesting
-            items = pack_items(items, packing)
-            X.append(items)
+        if prescan:
+            # Parse remaining file to count data lines:
+            for line in fh:
+                if len(split_line(line)) > 0:
+                    n_valid += 1
+
+            X = np.empty((n_valid, shape_r), dtype)
+            fh.seek(0)
+            for i in xrange(first_lno):
+                fh.next()
+
+            l = 0
+            try:
+                # Parse each line, including the first
+                for line in itertools.chain([first_line], fh):
+                    vals = split_line(line)
+                    if len(vals) == 0:
+                        continue
+                    if usecols:
+                        vals = [vals[i] for i in usecols]
+                    # Convert each value according to its column and store
+                    items = [conv(val) for (conv, val) in zip(converters, vals)]
+                    # Then pack it according to the dtype's nesting
+                    items = pack_items(items, packing)
+                    X[l] = np.array(items, dtype)
+                    l += 1
+                if l < n_valid:
+                    # Perhaps better negative values for missing data, but
+                    # that's not feasible with structured or char arrays
+                    X[l:] = np.zeros((n_valid-l, shape_r), dtype)
+                    raise IndexError('could only fill %d of %d lines' %
+                                     (l, n_valid))
+
+            except (IndexError), err:
+                # miscounted? what to do?
+                warnings.warn('loadtxt: error parsing %d lines of data: %s' %
+                              (n_valid, err))
+
+        else:
+            X = []
+            # Parse each line, including the first
+            for i, line in enumerate(itertools.chain([first_line], fh)):
+                vals = split_line(line)
+                if len(vals) == 0:
+                    continue
+                if usecols:
+                    vals = [vals[i] for i in usecols]
+                # Convert each value according to its column and store
+                items = [conv(val) for (conv, val) in zip(converters, vals)]
+                # Then pack it according to the dtype's nesting
+                items = pack_items(items, packing)
+                X.append(items)
+            X = np.array(X, dtype)
+            
     finally:
         if fown:
             fh.close()
 
-    X = np.array(X, dtype)
     # Multicolumn data are returned with shape (1, N, M), i.e.
     # (1, 1, M) for a single row - remove the singleton dimension there
     if X.ndim == 3 and X.shape[:2] == (1, 1):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -293,6 +293,9 @@ class TestLoadTxt(TestCase):
                       ('F', 25.0, 60.0)], dtype=mydescriptor)
         y = np.loadtxt(d, dtype=mydescriptor)
         assert_array_equal(y, b)
+        d.seek(0)
+        y = np.loadtxt(d, dtype=mydescriptor, prescan=True)
+        assert_array_equal(y, b)
 
     def test_array(self):
         c = StringIO()
@@ -341,6 +344,11 @@ class TestLoadTxt(TestCase):
             usecols=(1, 3,))
         a = np.array([[2, -999], [7, 9]], int)
         assert_array_equal(x, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=int, delimiter=',', \
+            converters={3:lambda s: int(s or - 999)}, \
+            usecols=(1, 3,), prescan=True)
+        assert_array_equal(x, a)
 
     def test_comments(self):
         c = StringIO()
@@ -358,6 +366,10 @@ class TestLoadTxt(TestCase):
         x = np.loadtxt(c, dtype=int, delimiter=',', \
             skiprows=1)
         a = np.array([1, 2, 3, 5], int)
+        assert_array_equal(x, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=int, delimiter=',', \
+            skiprows=1, prescan=True)
         assert_array_equal(x, a)
 
         c = StringIO()
@@ -398,6 +410,11 @@ class TestLoadTxt(TestCase):
         arr = np.loadtxt(c, usecols=(0, 2), dtype=zip(names, dtypes))
         assert_equal(arr['stid'], asbytes_nested(["JOE", "BOB"]))
         assert_equal(arr['temp'], [25.3, 27.9])
+        c.seek(0)
+        arr = np.loadtxt(c, usecols=(0, 2), dtype=zip(names, dtypes),
+                         prescan=True)
+        assert_equal(arr['stid'], asbytes_nested(["JOE", "BOB"]))
+        assert_equal(arr['temp'], [25.3, 27.9])
 
     def test_fancy_dtype(self):
         c = StringIO()
@@ -416,6 +433,9 @@ class TestLoadTxt(TestCase):
         a = np.array([('aaaa', 1.0, 8.0, [[1, 2, 3], [4, 5, 6]])],
                      dtype=dt)
         assert_array_equal(x, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=dt, prescan=True)
+        assert_array_equal(x, a)
 
     def test_3d_shaped_dtype(self):
         c = StringIO("aaaa  1.0  8.0  1 2 3 4 5 6 7 8 9 10 11 12")
@@ -424,6 +444,9 @@ class TestLoadTxt(TestCase):
         x = np.loadtxt(c, dtype=dt)
         a = np.array([('aaaa', 1.0, 8.0, [[[1, 2, 3], [4, 5, 6]],[[7, 8, 9], [10, 11, 12]]])],
                      dtype=dt)
+        assert_array_equal(x, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=dt, prescan=True)
         assert_array_equal(x, a)
 
     def test_empty_file(self):
@@ -462,6 +485,9 @@ class TestLoadTxt(TestCase):
                              converters=converters)
         control = np.array([(1, datetime(2001, 1, 1)), (2, datetime(2002, 1, 31))],
                            dtype=ndtype)
+        assert_equal(test, control)
+        test = np.loadtxt(StringIO(data), delimiter=";", dtype=ndtype,
+                             converters=converters, prescan=True)
         assert_equal(test, control)
 
     def test_uint64_type(self):
@@ -548,6 +574,16 @@ class TestLoadTxt(TestCase):
         f = StringIO()
         assert_(np.loadtxt(f, ndmin=2).shape == (0, 1,))
         assert_(np.loadtxt(f, ndmin=1).shape == (0,))
+
+    def test_prescan(self):
+        c = StringIO()
+        c.write(asbytes('# Header\n# \n 1 2 3\n    \n\n4  5 6'))
+        c.seek(0)
+        a = np.loadtxt(c)
+        c.seek(0)
+        b = np.loadtxt(c, prescan=True)
+        assert_array_equal(a, b)
+        assert_array_equal(b, np.arange(1,7).reshape((2,3)))
 
     def test_generator_source(self):
         def count():


### PR DESCRIPTION
ENH: implement 2-pass reading in loadtxt to avoid problems with 
excessive memory usage on large data files. The extra parsing 
typically takes 10% of the total read-in time; 30-50% for compressed 
files.

Setting 'prescan=True' will parse the valid data lines of the input
file in a first pass, then allocate an array to read the data directly
into (row by row), bypassing the creation of an input list with the
associated high memory usage.
