### PR TITLE
don't copy data when changing shape

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -187,7 +187,10 @@ typedef enum {
         /* Fortran order */
         NPY_FORTRANORDER=1,
         /* An order as close to the inputs as possible */
-        NPY_KEEPORDER=2
+        NPY_KEEPORDER=2,
+        /* Don't copy data, so order obviously is kept.
+         * used as special value in PyArray_Newshape */
+        NPY_NOCOPY=3
 } NPY_ORDER;
 
 /* For specifying allowed casting in operations which support it */

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -187,10 +187,7 @@ typedef enum {
         /* Fortran order */
         NPY_FORTRANORDER=1,
         /* An order as close to the inputs as possible */
-        NPY_KEEPORDER=2,
-        /* Don't copy data, so order obviously is kept.
-         * used as special value in PyArray_Newshape */
-        NPY_NOCOPY=3
+        NPY_KEEPORDER=2
 } NPY_ORDER;
 
 /* For specifying allowed casting in operations which support it */

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -48,10 +48,10 @@ array_shape_set(PyArrayObject *self, PyObject *val)
 
     /* Assumes C-order */
     if (!PyArray_IntpConverter(val, &newdims)) {
-	return -1;
+        return -1;
     }
     ret = (PyArrayObject *)PyArray_Newshape_Nocopy(self, &newdims,
-						   PyArray_CORDER);
+                                                   PyArray_CORDER);
     PyDimMem_FREE(newdims.ptr);
 
     if (ret == NULL) {

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -50,8 +50,7 @@ array_shape_set(PyArrayObject *self, PyObject *val)
     if (!PyArray_IntpConverter(val, &newdims)) {
         return -1;
     }
-    ret = (PyArrayObject *)PyArray_Newshape_Nocopy(self, &newdims,
-                                                   PyArray_CORDER);
+    ret = (PyArrayObject *)PyArray_Newshape(self, &newdims, NPY_NOCOPY);
     PyDimMem_FREE(newdims.ptr);
 
     if (ret == NULL) {

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -50,17 +50,11 @@ array_shape_set(PyArrayObject *self, PyObject *val)
     if (!PyArray_IntpConverter(val, &newdims)) {
 	return -1;
     }
-    ret = (PyArrayObject *)PyArray_Newshape(self, &newdims, PyArray_CORDER);
+    ret = (PyArrayObject *)PyArray_Newshape_Nocopy(self, &newdims,
+						   PyArray_CORDER);
     PyDimMem_FREE(newdims.ptr);
 
     if (ret == NULL) {
-        return -1;
-    }
-    if (PyArray_DATA(ret) != PyArray_DATA(self)) {
-        Py_DECREF(ret);
-        PyErr_SetString(PyExc_AttributeError,
-                        "incompatible shape for a non-contiguous "\
-                        "array");
         return -1;
     }
 

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -44,9 +44,15 @@ array_shape_set(PyArrayObject *self, PyObject *val)
 {
     int nd;
     PyArrayObject *ret;
+    PyArray_Dims newdims;
 
     /* Assumes C-order */
-    ret = (PyArrayObject *)PyArray_Reshape(self, val);
+    if (!PyArray_IntpConverter(val, &newdims)) {
+	return -1;
+    }
+    ret = (PyArrayObject *)PyArray_Newshape(self, &newdims, PyArray_CORDER);
+    PyDimMem_FREE(newdims.ptr);
+
     if (ret == NULL) {
         return -1;
     }

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -163,6 +163,12 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
     return Py_None;
 }
 
+/*
+ * Bring array `self` into into new shape `newdims`, 
+ * in order `order`. If `copy`, the array may be copied to
+ * achieve this goal. This function is the gcd of
+ * PyArray_Newshape and PyArray_Newshape_Nocopy.
+ */
 static PyObject *
 _Newshape(PyArrayObject *self, PyArray_Dims *newdims,
                  NPY_ORDER order, int copy)

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -246,11 +246,11 @@ _Newshape(PyArrayObject *self, PyArray_Dims *newdims,
                 flags = PyArray_FLAGS(self);
             }
             else {
-		PyErr_SetString(PyExc_AttributeError,
+                PyErr_SetString(PyExc_AttributeError,
                         "incompatible shape for a non-contiguous "\
                         "array");
-		return NULL;
-	    }
+                return NULL;
+            }
         }
 
         /* We always have to interpret the contiguous buffer correctly */

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -163,19 +163,9 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
     return Py_None;
 }
 
-/*
- * Returns a new array
- * with the new shape from the data
- * in the old array --- order-perspective depends on order argument.
- * copy-only-if-necessary
- */
-
-/*NUMPY_API
- * New shape for an array
- */
-NPY_NO_EXPORT PyObject *
-PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
-                 NPY_ORDER order)
+static PyObject *
+_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
+                 NPY_ORDER order, int copy)
 {
     intp i;
     intp *dimensions = newdims->ptr;
@@ -245,7 +235,7 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
                 strides = newstrides;
                 flags = PyArray_FLAGS(self);
             }
-            else {
+            else if (copy) {
                 PyObject *new;
                 new = PyArray_NewCopy(self, order);
                 if (new == NULL) {
@@ -255,6 +245,12 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
                 self = (PyArrayObject *)new;
                 flags = PyArray_FLAGS(self);
             }
+            else {
+		PyErr_SetString(PyExc_AttributeError,
+                        "incompatible shape for a non-contiguous "\
+                        "array");
+		return NULL;
+	    }
         }
 
         /* We always have to interpret the contiguous buffer correctly */
@@ -327,6 +323,23 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
 }
 
 /*
+ * Returns a new array
+ * with the new shape from the data
+ * in the old array --- order-perspective depends on order argument.
+ * copy-only-if-necessary
+ */
+
+/*NUMPY_API
+ * New shape for an array
+ */
+NPY_NO_EXPORT PyObject *
+PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
+                 NPY_ORDER order)
+{
+    return _Newshape(self, newdims, order, 1);
+}
+
+/*
  * Performs the same operations as PyArray_Newshape,
  * but won't ever copy, instead raises an
  * AttributeError on fail.
@@ -335,149 +348,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_Newshape_Nocopy(PyArrayObject *self, PyArray_Dims *newdims,
                  NPY_ORDER order)
 {
-    intp i;
-    intp *dimensions = newdims->ptr;
-    PyArrayObject *ret;
-    int n = newdims->len;
-    Bool same, incref = TRUE;
-    intp *strides = NULL;
-    intp newstrides[MAX_DIMS];
-    int flags;
-
-    if (order == NPY_ANYORDER) {
-        order = PyArray_ISFORTRAN(self);
-    }
-    /*  Quick check to make sure anything actually needs to be done */
-    if (n == PyArray_NDIM(self)) {
-        same = TRUE;
-        i = 0;
-        while (same && i < n) {
-            if (PyArray_DIM(self,i) != dimensions[i]) {
-                same=FALSE;
-            }
-            i++;
-        }
-        if (same) {
-            return PyArray_View(self, NULL, NULL);
-        }
-    }
-
-    /*
-     * Returns a pointer to an appropriate strides array
-     * if all we are doing is inserting ones into the shape,
-     * or removing ones from the shape
-     * or doing a combination of the two
-     * In this case we don't need to do anything but update strides and
-     * dimensions.  So, we can handle non single-segment cases.
-     */
-    i = _check_ones(self, n, dimensions, newstrides);
-    if (i == 0) {
-        strides = newstrides;
-    }
-    flags = PyArray_FLAGS(self);
-
-    if (strides == NULL) {
-        /*
-         * we are really re-shaping not just adding ones to the shape somewhere
-         * fix any -1 dimensions and check new-dimensions against old size
-         */
-        if (_fix_unknown_dimension(newdims, PyArray_SIZE(self)) < 0) {
-            return NULL;
-        }
-        /*
-         * sometimes we have to create a new copy of the array
-         * in order to get the right orientation and
-         * because we can't just re-use the buffer with the
-         * data in the order it is in.
-         */
-        if (!(PyArray_ISONESEGMENT(self)) ||
-            (((PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS) &&
-               order == NPY_FORTRANORDER) ||
-              (PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS) &&
-                  order == NPY_CORDER)) && (PyArray_NDIM(self) > 1))) {
-            int success = 0;
-            success = _attempt_nocopy_reshape(self,n,dimensions,
-                                              newstrides,order);
-            if (success) {
-                /* no need to copy the array after all */
-                strides = newstrides;
-                flags = PyArray_FLAGS(self);
-            }
-            else {
-		PyErr_SetString(PyExc_AttributeError,
-                        "incompatible shape for a non-contiguous "\
-                        "array");
-		return NULL;
-            }
-        }
-
-        /* We always have to interpret the contiguous buffer correctly */
-
-        /* Make sure the flags argument is set. */
-        if (n > 1) {
-            if (order == NPY_FORTRANORDER) {
-                flags &= ~NPY_ARRAY_C_CONTIGUOUS;
-                flags |= NPY_ARRAY_F_CONTIGUOUS;
-            }
-            else {
-                flags &= ~NPY_ARRAY_F_CONTIGUOUS;
-                flags |= NPY_ARRAY_C_CONTIGUOUS;
-            }
-        }
-    }
-    else if (n > 0) {
-        /*
-         * replace any 0-valued strides with
-         * appropriate value to preserve contiguousness
-         */
-        if (order == NPY_FORTRANORDER) {
-            if (strides[0] == 0) {
-                strides[0] = PyArray_DESCR(self)->elsize;
-            }
-            for (i = 1; i < n; i++) {
-                if (strides[i] == 0) {
-                    strides[i] = strides[i-1] * dimensions[i-1];
-                }
-            }
-        }
-        else {
-            if (strides[n-1] == 0) {
-                strides[n-1] = PyArray_DESCR(self)->elsize;
-            }
-            for (i = n - 2; i > -1; i--) {
-                if (strides[i] == 0) {
-                    strides[i] = strides[i+1] * dimensions[i+1];
-                }
-            }
-        }
-    }
-
-    Py_INCREF(PyArray_DESCR(self));
-    ret = (PyAO *)PyArray_NewFromDescr(Py_TYPE(self),
-                                       PyArray_DESCR(self),
-                                       n, dimensions,
-                                       strides,
-                                       PyArray_DATA(self),
-                                       flags, (PyObject *)self);
-
-    if (ret == NULL) {
-        goto fail;
-    }
-    if (incref) {
-        Py_INCREF(self);
-    }
-    if (PyArray_SetBaseObject(ret, (PyObject *)self)) {
-        Py_DECREF(ret);
-        return NULL;
-    }
-    PyArray_UpdateFlags(ret, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
-    return (PyObject *)ret;
-
- fail:
-    if (!incref) {
-        Py_DECREF(self);
-    }
-    return NULL;
+    return _Newshape(self, newdims, order, 0);
 }
 
 

--- a/numpy/core/src/multiarray/shape.h
+++ b/numpy/core/src/multiarray/shape.h
@@ -15,4 +15,8 @@ NPY_NO_EXPORT void
 PyArray_CreateSortedStridePerm(PyArrayObject *arr,
                            _npy_stride_sort_item *strideperm);
 
+/* Make sure the following value does not coincide with
+ * any value in the enum NPY_ORDER */
+#define NPY_NOCOPY 42
+
 #endif

--- a/numpy/core/src/multiarray/shape.h
+++ b/numpy/core/src/multiarray/shape.h
@@ -14,8 +14,5 @@ typedef struct {
 NPY_NO_EXPORT void
 PyArray_CreateSortedStridePerm(PyArrayObject *arr,
                            _npy_stride_sort_item *strideperm);
-NPY_NO_EXPORT PyObject *
-PyArray_Newshape_Nocopy(PyArrayObject *self, PyArray_Dims *newdims,
-                 NPY_ORDER order);
 
 #endif

--- a/numpy/core/src/multiarray/shape.h
+++ b/numpy/core/src/multiarray/shape.h
@@ -14,5 +14,8 @@ typedef struct {
 NPY_NO_EXPORT void
 PyArray_CreateSortedStridePerm(PyArrayObject *arr,
                            _npy_stride_sort_item *strideperm);
+NPY_NO_EXPORT PyObject *
+PyArray_Newshape_Nocopy(PyArrayObject *self, PyArray_Dims *newdims,
+                 NPY_ORDER order);
 
 #endif


### PR DESCRIPTION
When changing the shape of an array, by writing, say,

> > > a.shape = 10,
> > > an AttributeError is raised if the new shape is incompatible
> > > with the old one. This is the intended behaviour and no
> > > problem.

Under the hood, however, what's happening is that
in this case the array is copied as it would be
if one had written

> > > a = a.reshape((10,))
> > > and once it is realized that this doesn't work, the
> > > result is discarded again, and the said AttributeError
> > > is raised.

I discovered that while working with humongous
matrices, which nearly fill my memory. I used
the a.shape=something method because it
was supposed to be a memory no-op. Unfortunately
it isn't, as numpy tried and failed to copy the array
and raised a MemoryError instead of an AttributeError.

I consider this all a bug, not a feature, so I fixed it.
With this pull request, no data is ever copied when
changing the shape of an array.
