### PR TITLE
ENH: make array_equal+array_equiv work for record arrays/structured arrays

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1961,7 +1961,15 @@ def array_equal(a1, a2):
         return False
     if a1.shape != a2.shape:
         return False
-    return bool(logical_and.reduce(equal(a1,a2).ravel()))
+    # test for structured arrays
+    if a1.dtype.names:
+        if a1.dtype != a2.dtype:
+            return False
+        return bool( all([ logical_and.reduce(equal(a1[n],a2[n]).ravel())
+                           for n in a1.dtype.names ]) )
+    else:
+        return bool(logical_and.reduce(equal(a1,a2).ravel()))
+
 
 def array_equiv(a1, a2):
     """
@@ -2002,8 +2010,15 @@ def array_equiv(a1, a2):
         a1, a2 = asarray(a1), asarray(a2)
     except:
         return False
+    # test for structured arrays
     try:
-        return bool(logical_and.reduce(equal(a1,a2).ravel()))
+        if a1.dtype.names:
+            if a1.dtype.names != a2.dtype.names:
+                return False
+            return bool( all([ logical_and.reduce(equal(a1[n],a2[n]).ravel())
+                               for n in a1.dtype.names ]) )
+        else:
+            return bool(logical_and.reduce(equal(a1,a2).ravel()))
     except ValueError:
         return False
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1924,7 +1924,8 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
 
 def array_equal(a1, a2):
     """
-    True if two arrays have the same shape and elements, False otherwise.
+    True if two arrays have the same shape and elements, including field
+    names (dtype.names) for structured arrays. False otherwise.
 
     Parameters
     ----------
@@ -1977,6 +1978,8 @@ def array_equiv(a1, a2):
 
     Shape consistent means they are either the same shape, or one input array
     can be broadcasted to create the same shape as the other one.
+    Fields of structured arrays are considered consistent if all fields are
+    consistent (in order of dtype), even if they are differently named.
 
     Parameters
     ----------
@@ -2010,13 +2013,14 @@ def array_equiv(a1, a2):
         a1, a2 = asarray(a1), asarray(a2)
     except:
         return False
-    # test for structured arrays
+    # for structured arrays try to compare all fields,
+    # even if they have different names
     try:
         if a1.dtype.names:
-            if a1.dtype.names != a2.dtype.names:
+            if len(a1.dtype.names) != len(a2.dtype.names):
                 return False
-            return bool( all([ logical_and.reduce(equal(a1[n],a2[n]).ravel())
-                               for n in a1.dtype.names ]) )
+            return bool( all([logical_and.reduce(equal(a1[n],a2[m]).ravel())
+                              for n,m in zip(a1.dtype.names,a2.dtype.names)]) )
         else:
             return bool(logical_and.reduce(equal(a1,a2).ravel()))
     except ValueError:

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -690,7 +690,7 @@ class TestArrayComparisons(TestCase):
         assert_(type(res) is bool)
         res = array_equiv(array((1,2), dtype=[('i','i4'),('v','f8')]),
                           array((1,2), dtype=[('n','i4'),('f','f8')]))
-        assert_(not res)
+        assert_(res)
         assert_(type(res) is bool)
 
 def assert_array_strict_equal(x, y):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -640,7 +640,15 @@ class TestArrayComparisons(TestCase):
         res = array_equal(array([1,2]), array([1,3]))
         assert_(not res)
         assert_(type(res) is bool)
-
+        res = array_equal(array((1,2), dtype=[('i','i4'),('v','f8')]),
+                          array((1,2), dtype=[('i','i4'),('v','f8')]))
+        assert_(res)
+        assert_(type(res) is bool)
+        res = array_equal(array((1,2), dtype=[('i','i4'),('v','f8')]),
+                          array((1,2), dtype=[('n','i4'),('f','f8')]))
+        assert_(not res)
+        assert_(type(res) is bool)
+                
     def test_array_equiv(self):
         res = array_equiv(array([1,2]), array([1,2]))
         assert_(res)
@@ -670,7 +678,20 @@ class TestArrayComparisons(TestCase):
         res = array_equiv(array([1,2]), array([[1,2,3],[4,5,6],[7,8,9]]))
         assert_(not res)
         assert_(type(res) is bool)
-
+        res = array_equiv(array((1,2), dtype=[('i','i4'),('v','f8')]),
+                          array((1,2), dtype=[('i','i4'),('v','f8')]))
+        assert_(res)
+        assert_(type(res) is bool)
+        res = array_equiv(array([(1,2),(3,4)],
+                                dtype=[('i','i4'),('v','f8')]),
+                          array([(1,2),(3,4)],
+                                dtype=[('i','i4'),('v','f8')]).reshape((1,-1)))
+        assert_(res)
+        assert_(type(res) is bool)
+        res = array_equiv(array((1,2), dtype=[('i','i4'),('v','f8')]),
+                          array((1,2), dtype=[('n','i4'),('f','f8')]))
+        assert_(not res)
+        assert_(type(res) is bool)
 
 def assert_array_strict_equal(x, y):
     assert_array_equal(x, y)


### PR DESCRIPTION
Implementation of http://projects.scipy.org/numpy/ticket/1941 with tests. Please comment if the behaviour of array_equiv in commit 4b896f8 or in HEAD is preferred.
