### PR TITLE
FIX: add ufsparse to the libraries search path.

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -193,6 +193,8 @@ else:
                                  '/opt/local/lib','/sw/lib'], platform_bits)
     default_include_dirs = ['/usr/local/include',
                             '/opt/include', '/usr/include',
+                            # path of umfpack under macports
+                            '/opt/local/include/ufsparse',
                             '/opt/local/include', '/sw/include',
                             '/usr/include/suitesparse']
     default_src_dirs = ['.','/usr/local/src', '/opt/src','/sw/src']


### PR DESCRIPTION
This fixes compilation of scipy under macports in case you have umfpack.

Fixes a build failure on macports when it detected umfpack but was
unable to build the extension module. Solution is equivalent to the
'/usr/include/suitesparse' path under Debian.
