### PR TITLE
Bugfix(es)

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -102,7 +102,7 @@ PyArray_SetBaseObject(PyArrayObject *arr, PyObject *obj)
      * its own data.
      */
     while (PyArray_Check(obj) && (PyObject *)arr != obj) {
-        PyArrayObject *obj_arr = (PyArrayObject *)arr;
+        PyArrayObject *obj_arr = (PyArrayObject *)obj;
         PyObject *tmp;
 
         /* If this array owns its own data, stop collapsing */

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -481,7 +481,7 @@ def test_array_maskna_array_function_1D():
 
     # Should produce a view with an owned mask with 'ownmaskna=True'
     c = np.array(b_view, copy=False, ownmaskna=True)
-    assert_(c.base is b_view)
+    assert_(c.base is b_view.base)
     assert_(c.flags.ownmaskna)
     assert_(not (c is b_view))
 


### PR DESCRIPTION
Hi, in the process of hunting down a reference leak, I found a bug in PyArray_SetBaseObject which didn't properly find the base object in a loop. 

In the (separate) leaking issue, the process keeps hogging memory in a certain case, but valgrind claims it is still reachable.. 

**Update**: I feel a bit stupid now, because the script did not exactly reproduce the issue. It seems that `np.empty` does not make the os claim memory until it is used by the process. Sorry for the noise.
