### PR TITLE
BUG: Fix reference leak in PyArray_DTypeFromObject

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -318,6 +318,7 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims, int *out_contains_na,
         }
         if (PyArray_DTypeFromObject(ip, maxdims - 1,
                             out_contains_na, out_dtype) < 0) {
+            Py_DECREF(ip);
             goto fail;
         }
         Py_DECREF(ip);


### PR DESCRIPTION
Hi, after the better part of a week I finally found the reference leak that was haunting me.

Maybe it would be a good idea to refactor the dtype detection code sometime in the future.. ;-)
