### PR TITLE
MinGW enhancements for datetime functionality.

### DIFF
--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -12,13 +12,6 @@
 
 #include <time.h>
 
-#if defined(_WIN32) && \
-    defined(__GNUC__) && \
-    (defined(NPY_MINGW_USE_CUSTOM_MSVCR) | \
-    defined(NPY_MINGW_USE_64BIT_MSVCR))
-#define time_t __time64_t
-#endif
-
 #define NPY_NO_DEPRECATED_API
 #define _MULTIARRAYMODULE
 #include <numpy/arrayobject.h>
@@ -55,14 +48,6 @@ get_localtime(NPY_TIME_T *ts, struct tm *tms)
         func_name = "_localtime64_s";
         goto fail;
     }
- #elif defined(__GNUC__) && defined(NPY_MINGW_USE_64BIT_MSVCR)
-    struct tm *tms_tmp;
-    tms_tmp = _localtime64(ts);
-    if (tms_tmp == NULL) {
-        func_name = "_localtime64";
-        goto fail;
-    }
-    memcpy((void*)tms, (void*)tms_tmp, sizeof(struct tm));
  #else
     struct tm *tms_tmp;
     tms_tmp = localtime(ts);
@@ -108,14 +93,6 @@ get_gmtime(NPY_TIME_T *ts, struct tm *tms)
         func_name = "_gmtime64_s";
         goto fail;
     }
- #elif defined(__GNUC__) && defined(NPY_MINGW_USE_64BIT_MSVCR)
-    struct tm *tms_tmp;
-    tms_tmp = _gmtime64(ts);
-    if (tms_tmp == NULL) {
-        func_name = "_gmtime64";
-        goto fail;
-    }
-    memcpy((void*)tms, (void*)tms_tmp, sizeof(struct tm));
  #else
     struct tm *tms_tmp;
     tms_tmp = gmtime(ts);

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -14,7 +14,8 @@
 
 #if defined(_WIN32) && \
     defined(__GNUC__) && \
-    defined(NPY_MINGW_USE_CUSTOM_MSVCR)
+    (defined(NPY_MINGW_USE_CUSTOM_MSVCR) | \
+    defined(NPY_MINGW_USE_64BIT_MSVCR))
 #define time_t __time64_t
 #endif
 
@@ -54,6 +55,14 @@ get_localtime(NPY_TIME_T *ts, struct tm *tms)
         func_name = "_localtime64_s";
         goto fail;
     }
+ #elif defined(__GNUC__) && defined(NPY_MINGW_USE_64BIT_MSVCR)
+    struct tm *tms_tmp;
+    tms_tmp = _localtime64(ts);
+    if (tms_tmp == NULL) {
+        func_name = "_localtime64";
+        goto fail;
+    }
+    memcpy((void*)tms, (void*)tms_tmp, sizeof(struct tm));
  #else
     struct tm *tms_tmp;
     tms_tmp = localtime(ts);
@@ -99,6 +108,14 @@ get_gmtime(NPY_TIME_T *ts, struct tm *tms)
         func_name = "_gmtime64_s";
         goto fail;
     }
+ #elif defined(__GNUC__) && defined(NPY_MINGW_USE_64BIT_MSVCR)
+    struct tm *tms_tmp;
+    tms_tmp = _gmtime64(ts);
+    if (tms_tmp == NULL) {
+        func_name = "_gmtime64";
+        goto fail;
+    }
+    memcpy((void*)tms, (void*)tms_tmp, sizeof(struct tm));
  #else
     struct tm *tms_tmp;
     tms_tmp = gmtime(ts);

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -12,6 +12,12 @@
 
 #include <time.h>
 
+#if defined(_WIN32) && \
+    defined(__GNUC__) && \
+    defined(NPY_MINGW_USE_CUSTOM_MSVCR)
+#define time_t __time64_t
+#endif
+
 #define NPY_NO_DEPRECATED_API
 #define _MULTIARRAYMODULE
 #include <numpy/arrayobject.h>

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -115,7 +115,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         # bad consequences, like using Py_ModuleInit4 instead of
         # Py_ModuleInit4_64, etc... So we add it here
         if get_build_architecture() == 'AMD64':
-            if self.gcc_version < "4.":
+            if self.gcc_version < "4.0":
                 self.set_executables(
                     compiler='gcc -g -DDEBUG -DMS_WIN64 -mno-cygwin -O0 -Wall',
                     compiler_so='gcc -g -DDEBUG -DMS_WIN64 -mno-cygwin -O0 -Wall -Wstrict-prototypes',
@@ -135,7 +135,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
                                      linker_exe='g++ -mno-cygwin',
                                      linker_so='%s -mno-cygwin -mdll -static %s'
                                      % (self.linker, entry_point))
-            elif self.gcc_version < "4.":
+            elif self.gcc_version < "4.0":
                 self.set_executables(compiler='gcc -mno-cygwin -O2 -Wall',
                                      compiler_so='gcc -mno-cygwin -O2 -Wall -Wstrict-prototypes',
                                      linker_exe='g++ -mno-cygwin',

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -175,6 +175,9 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             if not libraries:
                 libraries = []
             libraries.append(runtime_library)
+        if debug:
+            # There is no customized msvcr lib in debug mode
+            self.undefine_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
         args = (self,
                 target_desc,
                 objects,

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -345,6 +345,9 @@ def build_msvcr_library(debug=False):
     cmd = ['dlltool', '-d', def_file, '-l', out_file]
     retcode = subprocess.call(cmd)
 
+    # Clean up symbol definitions
+    os.remove(def_file)
+
     return (not retcode)
 
 def build_import_library():

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -94,6 +94,10 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         if build_msvcr_library() | build_msvcr_library(debug=True):
             # add preprocessor statement for using customized msvcr lib
             self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
+        # Else do a check if the current runtime version is >= VS2005
+        elif int(msvc_runtime_library().lstrip('msvcr')) >= 80:
+            # add preprocessor statement to use 64-bit fallback
+            self.define_macro('NPY_MINGW_USE_64BIT_MSVCR')
 
         # **changes: eric jones 4/11/01
         # 2. increased optimization and turned off all warnings

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -296,13 +296,24 @@ def generate_def(dll, dfile):
     d.close()
 
 def find_dll(dll_name):
+    
+    def _find_dll_in_winsxs(dll_name):
+        # Walk through the WinSxS directory to find the dll.
+        winsxs_path = os.path.join(os.environ['WINDIR'], 'winsxs')
+        if not os.path.exists(winsxs_path):
+            return None
+        for root, dirs, files in os.walk(winsxs_path):
+            if dll_name in files:
+                return os.path.join(root, dll_name)
+        return None
+    
     # First, look in the Python directory, then scan PATH for
-    # the given dll name.
+    # the given dll name. Lastly, look in the WinSxS directory.
     for path in [sys.prefix] + os.environ['PATH'].split(';'):
         filepath = os.path.join(path, dll_name)
         if os.path.exists(filepath):
             return os.path.abspath(filepath)
-    return None
+    return _find_dll_in_winsxs(dll_name)
 
 def build_msvcr_library(debug=False):
     if os.name != 'nt':

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -91,14 +91,16 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         build_import_library()
 
         # Check for custom msvc runtime library on Windows. Build if it doesn't exist.
-        if build_msvcr_library() | build_msvcr_library(debug=True):
+        msvcr_success = build_msvcr_library()
+        msvcr_dbg_success = build_msvcr_library(debug=True)
+        if msvcr_success or msvcr_dbg_success:
             # add preprocessor statement for using customized msvcr lib
             self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
-        # Else do a check if the current runtime version is >= VS2005
-        elif int(msvc_runtime_library().lstrip('msvcr')) >= 80:
-            # add preprocessor statement to use 64-bit fallback
-            self.define_macro('NPY_MINGW_USE_64BIT_MSVCR')
 
+        # Define the MSVC version as hint for MinGW
+        msvcr_version = '0x%03i0' % int(msvc_runtime_library().lstrip('msvcr'))
+        self.define_macro('__MSVCRT_VERSION__', msvcr_version)
+        
         # **changes: eric jones 4/11/01
         # 2. increased optimization and turned off all warnings
         # 3. also added --driver-name g++

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -274,15 +274,14 @@ def generate_def(dll, dfile):
     The .def file will be overwritten"""
     dump = dump_table(dll)
     for i in range(len(dump)):
-        if _START.match(dump[i]):
+        if _START.match(dump[i].decode()):
             break
-
-    if i == len(dump):
+    else:
         raise ValueError("Symbol table not found")
 
     syms = []
     for j in range(i+1, len(dump)):
-        m = _TABLE.match(dump[j])
+        m = _TABLE.match(dump[j].decode())
         if m:
             syms.append((int(m.group(1).strip()), m.group(2)))
         else:
@@ -313,13 +312,15 @@ def find_dll(dll_name):
                 return os.path.join(root, dll_name)
         return None
     
-    # First, look in the Python directory, then scan PATH for
-    # the given dll name. Lastly, look in the WinSxS directory.
-    for path in [sys.prefix] + os.environ['PATH'].split(';'):
-        filepath = os.path.join(path, dll_name)
-        if os.path.exists(filepath):
-            return os.path.abspath(filepath)
-    return _find_dll_in_winsxs(dll_name)
+    def _find_dll_in_path(dll_name):
+        # First, look in the Python directory, then scan PATH for
+        # the given dll name.
+        for path in [sys.prefix] + os.environ['PATH'].split(';'):
+            filepath = os.path.join(path, dll_name)
+            if os.path.exists(filepath):
+                return os.path.abspath(filepath)
+    
+    return _find_dll_in_winsxs(dll_name) or _find_dll_in_path(dll_name)
 
 def build_msvcr_library(debug=False):
     if os.name != 'nt':
@@ -335,18 +336,19 @@ def build_msvcr_library(debug=False):
     if debug:
         msvcr_name += 'd'
     
+    # Skip if custom library already exists
+    out_name = "lib%s.a" % msvcr_name
+    out_file = os.path.join(sys.prefix, 'libs', out_name)
+    if os.path.isfile(out_file):
+        log.debug('Skip building msvcr library: "%s" exists' % (out_file))
+        return True
+
     # Find the msvcr dll
     msvcr_dll_name = msvcr_name + '.dll'
     dll_file = find_dll(msvcr_dll_name)
     if not dll_file:
         log.warn('Cannot build msvcr library: "%s" not found' % msvcr_dll_name)
         return False
-
-    out_name = "lib%s.a" % msvcr_name
-    out_file = os.path.join(sys.prefix, 'libs', out_name)
-    if os.path.isfile(out_file):
-        log.debug('Skip building msvcr library: "%s" exists' % (out_file))
-        return True
 
     def_name = "lib%s.def" % msvcr_name
     def_file = os.path.join(sys.prefix, 'libs', def_name)

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -91,9 +91,9 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         build_import_library()
 
         # Check for custom msvc runtime library on Windows. Build if it doesn't exist.
-        if build_msvcr_library():
+        if build_msvcr_library() | build_msvcr_library(debug=True):
             # add preprocessor statement for using customized msvcr lib
-            self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR', '1')
+            self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
 
         # **changes: eric jones 4/11/01
         # 2. increased optimization and turned off all warnings
@@ -175,9 +175,6 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             if not libraries:
                 libraries = []
             libraries.append(runtime_library)
-        if debug:
-            # There is no customized msvcr lib in debug mode
-            self.undefine_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
         args = (self,
                 target_desc,
                 objects,
@@ -311,17 +308,16 @@ def build_msvcr_library(debug=False):
     if os.name != 'nt':
         return False
 
-    if debug:
-        log.warn('Cannot build msvcr-dbg library: not yet implemented')
-        return False
-
     msvcr_name = msvc_runtime_library()
 
     # Skip using a custom library for versions < MSVC 8.0
-    if int(msvcr_name[-2:]) < 80:
+    if int(msvcr_name.lstrip('msvcr')) < 80:
         log.debug('Skip building msvcr library: custom functionality not present')
         return False
 
+    if debug:
+        msvcr_name += 'd'
+    
     # Find the msvcr dll
     msvcr_dll_name = msvcr_name + '.dll'
     dll_file = find_dll(msvcr_dll_name)


### PR DESCRIPTION
Hi, as a solution for [ticket 1909](http://projects.scipy.org/numpy/ticket/1909) and the issues in [pull request 118](https://github.com/numpy/numpy/pull/118), I made some enhancements (or hacks) to the MinGW compiler class in the NumPy distutils. 

Like for the Python runtime library, it will try to generate a custom version of the MSVC runtime library, which exposes all functionality, for versions of VS2005 and up. 

I had to hack in a preprocessor statement (NPY_MINGW_USE_CUSTOM_MSVCR), to be able to use this functionality safely with a fallback on the conventional (non-threadsafe) functions. It is a bit messy, but hopefully it will fix the issues with MinGW. 
