### PR TITLE
small updates related to numpydoc

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -9,6 +9,26 @@ A Guide to NumPy/SciPy Documentation
    For an accompanying example, see `example.py
    <http://github.com/numpy/numpy/blob/master/doc/example.py>`_.
 
+   When using `Sphinx <http://sphinx.pocoo.org/>`_ in combination with the numpy
+   conventions, you may be interested in the ``numpydoc`` extension, which will
+   handle your docstrings correctly. For example, it will extract the
+   ``Parameters`` section from your docstring and convert this into a field list.
+   It can also help alleviate reStructuredText errors encounterde when using
+   plain sphinx. Sphinx gets confused because the numpy docstrings have section
+   headers (e.g. ``-------------``) which sphinx does not expect to find in
+   docstrings.
+
+   It is available from:
+
+   * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
+   * `numpydoc on GitHub (in main numpy repository)
+     <https://github.com/numpy/numpy/blob/master/doc/sphinxext/numpydoc.py>`_
+
+   Details of how to use it can be found `here
+   <https://github.com/numpy/numpy/blob/master/doc/sphinxext/README.txt>`_ and
+   `here
+   <https://github.com/numpy/numpy/blob/master/doc/HOWTO_BUILD_DOCS.rst.txt>`_
+
 Overview
 --------
 In general, we follow the standard Python style conventions as described here:

--- a/doc/sphinxext/numpydoc.py
+++ b/doc/sphinxext/numpydoc.py
@@ -12,7 +12,7 @@ It will:
 - Renumber references.
 - Extract the signature from the docstring, if it can't be determined otherwise.
 
-.. [1] http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines#docstring-standard
+.. [1] https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 
 """
 


### PR DESCRIPTION
Mention numpydoc.py in numpy docstring guidelines. This should make it easier for people to use the sphinx autodoc to generate API documentation from code that adheres to the numpy docstring conventions.

Also the URL given in the docstring of numpydoc.py was still pointing to the old scipy trac instance. Now points to the HOWTO on GitHub.
