### PR TITLE
Multiple reference leak fixes - reprise

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1277,8 +1277,8 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (_res) {
                 Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
-                Py_DECREF(array_other);
             }
+            Py_DECREF(array_other);
             return result;
         }
         /*

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -248,6 +248,7 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
             else {
                 if (PyArray_SIZE(dest) == 1) {
                     Py_DECREF(dtype);
+                    Py_DECREF(src_object);
                     ret = PyArray_DESCR(dest)->f->setitem(src_object,
                                                 PyArray_DATA(dest), dest);
                     /* Unmask the value if necessary */

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2900,12 +2900,13 @@ OBJECT_fill(PyObject **buffer, intp length, void *NPY_UNUSED(ignored))
     intp i;
     PyObject *start = buffer[0];
     PyObject *delta = buffer[1];
+    PyObject *second;
 
     delta = PyNumber_Subtract(delta, start);
     if (!delta) {
         return;
     }
-    start = PyNumber_Add(start, delta);
+    second = start = PyNumber_Add(start, delta);
     if (!start) {
         goto finish;
     }
@@ -2921,6 +2922,7 @@ OBJECT_fill(PyObject **buffer, intp length, void *NPY_UNUSED(ignored))
     }
 
 finish:
+    Py_XDECREF(second);
     Py_DECREF(delta);
     return;
 }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3001,6 +3001,7 @@ PyArray_Zeros(int nd, npy_intp *dims, PyArray_Descr *type, int is_f_order)
         return NULL;
     }
     if (_zerofill(ret) < 0) {
+        Py_DECREF(ret);
         return NULL;
     }
     return (PyObject *)ret;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3698,6 +3698,9 @@ PyArray_FromString(char *data, npy_intp slen, PyArray_Descr *dtype,
 
     if (dtype == NULL) {
         dtype=PyArray_DescrFromType(NPY_DEFAULT_TYPE);
+        if (dtype == NULL) {
+            return NULL;
+        }
     }
     if (PyDataType_FLAGCHK(dtype, NPY_ITEM_IS_POINTER) ||
                     PyDataType_REFCHK(dtype)) {

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -807,6 +807,7 @@ get_datetime_metadata_from_dtype(PyArray_Descr *dtype)
 
     /* Check that the dtype has an NpyCapsule for the metadata */
     meta = (PyArray_DatetimeMetaData *)NpyCapsule_AsVoidPtr(metacobj);
+    Py_DECREF(metacobj);
     if (meta == NULL) {
         PyErr_SetString(PyExc_TypeError,
                 "Datetime type object is invalid, unit metadata is corrupt");

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1706,6 +1706,7 @@ arraymultiter_next(PyArrayMultiIterObject *multi)
         multi->index++;
         return ret;
     }
+    Py_DECREF(ret);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1268,6 +1268,7 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
         newd = PyArray_DescrNew(saved);
+        Py_DECREF(newd->names);
         newd->names = new_name;
         ((PyArrayObject_fields *)self)->descr = newd;
     }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -339,6 +339,7 @@ finish:
     if (outcode->type_num == typecode->type_num) {
         if (!PyTypeNum_ISEXTENDED(typecode->type_num)
                 || (outcode->elsize == typecode->elsize)) {
+            Py_DECREF(outcode);
             return (PyObject *)r;
         }
     }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3357,6 +3357,7 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
     /* Must be a Tuple */
     N = count_new_axes_0d(key);
     if (N < 0) {
+        Py_DECREF(res);
         return NULL;
     }
     ret = add_new_axes_0d((PyArrayObject *)res, N);


### PR DESCRIPTION
I've started porting reference leak fixes from numpy-refactor into the main repository. Unfortunately, the two repositories have diverged substantially, so this work has been done by hand. Other reference leaks have been found using the numpy test scripts and a modified unittest.py that keeps track of reference counts going into and coming out of a test. Nearly every fix is in its own commit so it is easy to roll back if the change has unintended consequences. Commit bee8cc8 is somewhat questionable because it fixes a reference count issue that is not an actual memory leak, and it does so by modifying the PyObject data directly. This fix was necessary to detect real reference leaks, but need not be released. As far as I can tell, it is doing no harm.

This is a redo of the botched pull request #155. I've learned an important lesson about rebasing.
