### PR TITLE
ENH: release the GIL in some C library functions.

### DIFF
--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -220,7 +220,7 @@ arr_digitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     int m, i;
     static char *kwlist[] = {"x", "bins", NULL};
     PyArray_Descr *type;
-    int bins_non_monotonic = 0;
+    char bins_non_monotonic = 0;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist, &ox, &obins)) {
         goto fail;

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -159,8 +159,10 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
             goto fail;
         }
         ians = (npy_intp *)(PyArray_DATA(ans));
+        NPY_BEGIN_ALLOW_THREADS;
         for (i = 0; i < len; i++)
             ians [numbers [i]] += 1;
+        NPY_END_ALLOW_THREADS;
         Py_DECREF(lst);
     }
     else {
@@ -181,9 +183,11 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
             goto fail;
         }
         dans = (double *)PyArray_DATA(ans);
+        NPY_BEGIN_ALLOW_THREADS;
         for (i = 0; i < len; i++) {
             dans[numbers[i]] += weights[i];
         }
+        NPY_END_ALLOW_THREADS;
         Py_DECREF(lst);
         Py_DECREF(wts);
     }
@@ -250,6 +254,7 @@ arr_digitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     }
 
     if (lbins == 1)  {
+        NPY_BEGIN_ALLOW_THREADS;
         for (i = 0; i < lx; i++) {
             if (dx [i] >= dbins[0]) {
                 iret[i] = 1;
@@ -258,18 +263,25 @@ arr_digitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
                 iret[i] = 0;
             }
         }
+        NPY_END_ALLOW_THREADS;
     }
     else {
+        NPY_BEGIN_ALLOW_THREADS;
         m = monotonic_ (dbins, lbins);
+        NPY_END_ALLOW_THREADS;
         if ( m == -1 ) {
+            NPY_BEGIN_ALLOW_THREADS;
             for ( i = 0; i < lx; i ++ ) {
                 iret [i] = decr_slot_ ((double)dx[i], dbins, lbins);
             }
+            NPY_END_ALLOW_THREADS;
         }
         else if ( m == 1 ) {
+            NPY_BEGIN_ALLOW_THREADS;
             for ( i = 0; i < lx; i ++ ) {
                 iret [i] = incr_slot_ ((double)dx[i], dbins, lbins);
             }
+            NPY_END_ALLOW_THREADS;
         }
         else {
             PyErr_SetString(PyExc_ValueError,
@@ -548,6 +560,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     }
 
     slopes = (double *) PyDataMem_NEW((lenxp - 1)*sizeof(double));
+    NPY_BEGIN_ALLOW_THREADS;
     for (i = 0; i < lenxp - 1; i++) {
         slopes[i] = (dy[i + 1] - dy[i])/(dx[i + 1] - dx[i]);
     }
@@ -567,6 +580,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
         }
     }
 
+    NPY_END_ALLOW_THREADS;
     PyDataMem_FREE(slopes);
     Py_DECREF(afp);
     Py_DECREF(axp);

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -683,8 +683,10 @@ ravel_multi_index_loop(int ravel_ndim, npy_intp *ravel_dims,
             j = *(npy_intp *)coords[i];
             switch (modes[i]) {
                 case NPY_RAISE:
-                    if (j < 0 || j >= m)
+                    if (j < 0 || j >= m) {
                         invalid = 1;
+                        goto end_while;
+                    }
                     break;
                 case NPY_WRAP:
                     if (j < 0) {
@@ -717,12 +719,10 @@ ravel_multi_index_loop(int ravel_ndim, npy_intp *ravel_dims,
 
             coords[i] += coords_strides[i];
         }
-        if (invalid) {
-            break;
-        }
         *(npy_intp *)coords[ravel_ndim] = raveled;
         coords[ravel_ndim] += coords_strides[ravel_ndim];
     }
+end_while:
     NPY_END_ALLOW_THREADS;
     if (invalid) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -302,6 +302,14 @@ fail:
 
 static char arr_insert__doc__[] = "Insert vals sequentially into equivalent 1-d positions indicated by mask.";
 
+/*
+ * Insert values from an input array into an output array, at positions
+ * indicated by a mask. If the arrays are of dtype object (indicated by
+ * the objarray flag), take care of reference counting.
+ *
+ * This function implements the copying logic of arr_insert() defined
+ * below.
+ */
 static void
 arr_insert_loop(char *mptr, char *vptr, char *input_data, char *zero,
                 char *avals_data, int melsize, int delsize, int objarray,


### PR DESCRIPTION
I noticed that certain functions like `bincount` and `digitize` don't release the GIL when they really could and perhaps ought to do so. This patch carefully adds `NPY_BEGIN_ALLOW_THREADS` and `NPY_END_ALLOW_THREADS` around certain potentially long-running for loops (or calls to helper functions) that don't touch the Python API.
