### PR TITLE
improve speed of asarray_chkfinite

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -586,7 +586,8 @@ def asarray_chkfinite(a, dtype=None, order=None):
 
     """
     a = asarray(a, dtype=dtype, order=order)
-    if a.dtype.char in typecodes['AllFloat'] and not np.isfinite(a).all():
+    if (a.dtype.char in typecodes['AllFloat'] and not np.isfinite(a.sum()) and
+            not np.isfinite(a).all()):
         raise ValueError(
                 "array must not contain infs or NaNs")
     return a

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -792,7 +792,9 @@ class TestCheckFinite(TestCase):
         a = [1, 2, 3]
         b = [1, 2, inf]
         c = [1, 2, nan]
+        d = [numpy.finfo(numpy.float).max] * 10
         numpy.lib.asarray_chkfinite(a)
+        numpy.lib.asarray_chkfinite(d)
         assert_raises(ValueError, numpy.lib.asarray_chkfinite, b)
         assert_raises(ValueError, numpy.lib.asarray_chkfinite, c)
 


### PR DESCRIPTION
the test in asarray_chkfinite is very slow, as it
creates a temporary array. This patch changes this
to look at the sum of the entire array, if it
is finite, the entire array must be finite. If not,
we still have to do the good ole check, which should
be really rarely needed.

Certainly, summing an array that contains NaNs is
slow, but hey, we're raising a ValueError anyways,
so this should not be an issue.
