### PR TITLE
Fix for http://projects.scipy.org/numpy/ticket/1943

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3610,10 +3610,10 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
         }
     }
 
-    if ((offset < 0) || (offset >= ts)) {
+    if ((offset < 0) || (offset > ts)) {
         PyErr_Format(PyExc_ValueError,
-                     "offset must be non-negative and smaller than buffer "\
-                     "lenth (%" INTP_FMT ")", (npy_intp)ts);
+                     "offset must be non-negative and no greater than buffer "\
+                     "length (%" INTP_FMT ")", (npy_intp)ts);
         Py_DECREF(buf);
         Py_DECREF(type);
         return NULL;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1350,6 +1350,9 @@ class TestFromBuffer(object):
                 buf = x.tostring()
                 yield self.tst_basic,buf,x.flat,{'dtype':dt}
 
+    def test_empty(self):
+        yield self.tst_basic, '', np.array([]), {}
+
 
 class TestResize(TestCase):
     def test_basic(self):


### PR DESCRIPTION
PyArray_FromBuffer: Allow creating arrays from empty buffers or empty slices.
