### PR TITLE
Small fix for boolean indexing

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1366,8 +1366,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
     }
 
     /* Boolean indexing special case which supports mask NA */
-    if (PyArray_Check(op) && (PyArray_TYPE((PyArrayObject *)op) == NPY_BOOL)
-                && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))) {
+    if (PyArray_Check(op) && (PyArray_TYPE((PyArrayObject *)op) == NPY_BOOL)) {
         return (PyObject *)array_boolean_subscript(self,
                                         (PyArrayObject *)op, NPY_CORDER);
     }

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -8,15 +8,26 @@ import sys, warnings
 # kind of test suite, making any changes to the underlying code difficult
 # because of its fragility.
 
-# This file is to remedy the test suite part a little bit,
-# but hopefully NumPy indexing can be changed to be more systematic
-# at some point in the future.
-
 def test_boolean_indexing():
-    # Indexing a 2-dimensional array with a length-1 array of 'True'
+    
+    # Indexing a 1-dimensional array with a boolean array
+    a = np.arange(12)
+    b = np.array([True, False, True])
+    assert_raises(ValueError, a.__getitem__, b)
+    b.resize(12)
+    assert_equal(a[b], [0, 2])
+    
+    # Indexing a 2-dimensional array with a boolean array
+    a = np.arange(12).reshape((4,3))
+    b = np.array([True, False, True])
+    assert_raises(ValueError, a.__getitem__, b)
+    b.resize((4,3))
+    assert_equal(a[b], [0, 2])
+    
+    # Indexing and assigning a 2-dimensional array with a boolean array
     a = np.array([[ 0.,  0.,  0.]])
-    b = np.array([ True], dtype=bool)
-    assert_equal(a[b], a)
+    b = np.array([[True, True, True]], dtype=bool)
+    assert_equal(a[b], a.flatten())
 
     a[b] = 1.
     assert_equal(a, [[1., 1., 1.]])


### PR DESCRIPTION
(See also: [Fancy indexing with masks](http://mail.scipy.org/pipermail/numpy-discussion/2011-September/058505.html) and [boolean array indexing and broadcasting rules](http://mail.scipy.org/pipermail/numpy-discussion/2011-July/057870.html).)

This change should make boolean indexing more consistent with the new boolean broadcasting rules. It removes a constraint where `array_boolean_subscript` was only triggered when the index and the target would have the same number of dimensions.
