### PR TITLE
gradient() function now supports datetime64 and timedelta64

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -903,7 +903,7 @@ def gradient(f, *varargs):
 
     for axis in range(N):
         # select out appropriate parts for this dimension
-        out = np.zeros(f.shape, dtype=otype)
+        out = np.empty_like(f, dtype=otype)
         slice1[axis] = slice(1, -1)
         slice2[axis] = slice(2, None)
         slice3[axis] = slice(None, -2)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -897,6 +897,9 @@ def gradient(f, *varargs):
     if otype == 'M' :
         # Need to use the full dtype name because it contains unit information
         otype = f.dtype.name.replace('datetime', 'timedelta')
+    elif otype == 'm' :
+        # Needs to keep the specific units, can't be a general unit
+        otype = f.dtype
 
     for axis in range(N):
         # select out appropriate parts for this dimension

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -867,6 +867,7 @@ def gradient(f, *varargs):
            [ 1. ,  1. ,  1. ]])]
 
     """
+    f = np.asanyarray(f)
     N = len(f.shape)  # number of dimensions
     n = len(varargs)
     if n == 0:
@@ -889,12 +890,17 @@ def gradient(f, *varargs):
     slice3 = [slice(None)]*N
 
     otype = f.dtype.char
-    if otype not in ['f', 'd', 'F', 'D']:
+    if otype not in ['f', 'd', 'F', 'D', 'm', 'M']:
         otype = 'd'
+
+    # Difference of datetime64 elements results in timedelta64
+    if otype == 'M' :
+        # Need to use the full dtype name because it contains unit information
+        otype = f.dtype.name.replace('datetime', 'timedelta')
 
     for axis in range(N):
         # select out appropriate parts for this dimension
-        out = np.zeros_like(f).astype(otype)
+        out = np.zeros(f.shape, dtype=otype)
         slice1[axis] = slice(1, -1)
         slice2[axis] = slice(2, None)
         slice3[axis] = slice(None, -2)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -281,6 +281,20 @@ class TestGradient(TestCase):
         x = np.ma.array([[1, 1], [3, 4]])
         assert_equal(type(gradient(x)[0]), type(x))
 
+    def test_datetime64(self):
+        # Make sure gradient() can handle special types like datetime64
+        x = array(['1910-08-16', '1910-08-11', '1910-08-10', '1910-08-12',
+                   '1910-10-12', '1910-12-12', '1912-12-12'],
+                  dtype='datetime64[D]')
+        dx = array([ -5,  -3,   0,  31,  61, 396, 731], dtype='timedelta64[D]')
+        assert_array_equal(gradient(x), dx)
+
+    def test_timedelta64(self):
+        # Make sure gradient() can handle special types like timedelta64
+        x = array([-5, -3, 10, 12, 61, 321, 300], dtype='timedelta64[D]')
+        dx = array([ 2, 7, 7, 25, 154, 119, -21], dtype='timedelta64[D]')
+        assert_array_equal(gradient(x), dx)
+
 
 class TestAngle(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Needed to keep gradient() from changing the output type to floats.
Also allows for an array-like input instead of strictly numpy arrays.

Yes, I know... we need tests...  I will get to that after the mpl release.
