### PR TITLE
BF: a fix for the new X11 directory structure

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -198,11 +198,16 @@ else:
                             '/opt/local/include', '/sw/include',
                             '/usr/include/suitesparse']
     default_src_dirs = ['.','/usr/local/src', '/opt/src','/sw/src']
-
     default_x11_lib_dirs = libpaths(['/usr/X11R6/lib','/usr/X11/lib',
-                                     '/usr/lib'], platform_bits)
+                                        '/usr/lib'], platform_bits)
     default_x11_include_dirs = ['/usr/X11R6/include','/usr/X11/include',
-                                '/usr/include']
+                                    '/usr/include']
+    if os.path.exists('/usr/lib/X11'):
+        x11_so_dir = os.path.join('/', *glob('/usr/lib/*/libX11.so')[0].split('/')[:-1])
+        default_x11_lib_dirs.extend([x11_so_dir, '/usr/lib/X11'])
+        default_x11_include_dirs.append('/usr/lib/X11/include')
+
+
 
 if os.path.join(sys.prefix, 'lib') not in default_lib_dirs:
     default_lib_dirs.insert(0,os.path.join(sys.prefix, 'lib'))


### PR DESCRIPTION
This adds logic for locating the arch specific path to the newly moved libX11.so file and eliminates the need for users to manually modify a config file.
