### PR TITLE
pgfortran is a Fortran 95 compiler in the Portland Group suite of compilers.

### DIFF
--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -10,14 +10,14 @@ class PGroupFCompiler(FCompiler):
 
     compiler_type = 'pg'
     description = 'Portland Group Fortran Compiler'
-    version_pattern =  r'\s*pg(f77|f90|hpf) (?P<version>[\d.-]+).*'
+    version_pattern =  r'\s*pg(f77|f90|hpf|fortran) (?P<version>[\d.-]+).*'
 
     if platform == 'darwin':
         executables = {
-        'version_cmd'  : ["<F77>", "-V 2>/dev/null"],
-        'compiler_f77' : ["pgf77", "-dynamiclib"],
-        'compiler_fix' : ["pgf90", "-Mfixed", "-dynamiclib"],
-        'compiler_f90' : ["pgf90", "-dynamiclib"],
+        'version_cmd'  : ["<F77>", "-V"],
+        'compiler_f77' : ["pgfortran", "-dynamiclib"],
+        'compiler_fix' : ["pgfortran", "-Mfixed", "-dynamiclib"],
+        'compiler_f90' : ["pgfortran", "-dynamiclib"],
         'linker_so'    : ["libtool"],
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"]
@@ -25,11 +25,11 @@ class PGroupFCompiler(FCompiler):
         pic_flags = ['']
     else:
         executables = {
-        'version_cmd'  : ["<F77>", "-V 2>/dev/null"],
-        'compiler_f77' : ["pgf77"],
-        'compiler_fix' : ["pgf90", "-Mfixed"],
-        'compiler_f90' : ["pgf90"],
-        'linker_so'    : ["pgf90","-shared","-fpic"],
+        'version_cmd'  : ["<F77>", "-V"],
+        'compiler_f77' : ["pgfortran"],
+        'compiler_fix' : ["pgfortran", "-Mfixed"],
+        'compiler_f90' : ["pgfortran"],
+        'linker_so'    : ["pgfortran","-shared","-fpic"],
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"]
         }


### PR DESCRIPTION
Added support for Portland Groups pgfortran compiler.  The pgfortran compiler is a Fortran 95 compiler and is part of the Portland Group suite of compilers.  Adjusted also the version command string since the option that was there wasn't working (at least for version 10.1).
