### PR TITLE
Raise TypeError instead of NotImplementedError for wrong types

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4111,7 +4111,7 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
             return Py_NotImplemented;
         }
         else {
-            PyErr_SetString(PyExc_NotImplementedError,
+            PyErr_SetString(PyExc_TypeError,
                                         "Not implemented for this type");
             return NULL;
         }


### PR DESCRIPTION
I noticed that ufuncs raise a `NotImplementedError` instead of a `TypeError` when they receive an object of the wrong type. I consider this a bug, since `NotImplementedError` is [intended](http://docs.python.org/library/exceptions.html#exceptions.NotImplementedError) to be raised by "abstract methods (...) when they require derived classes to override the method."

The enclosed patch changes the behavior to raising a `TypeError` instead. This makes exception handling a lot simpler as well, since sometimes, ufuncs would already raise a `TypeError`:

```
>>> from numpy import isfinite
>>> isfinite('foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NotImplementedError: Not implemented for this type
>>> isfinite(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: function not supported for these types, and can't coerce safely to supported types
```
