### PR TITLE
Add a test for data truncation when creating array from sequence of mixed numeric and string values 

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1611,5 +1611,15 @@ class TestRegression(TestCase):
         a[...] = [[1,2]]
         assert_equal(a, [[1,2], [1,2]])
 
+    def test_string_truncation(self):
+        # Ticket #1990 - Data can be truncated in creation of an array from a
+        # mixed sequence of numeric values and strings
+        for numericval in [True, 1234, 123.4, complex(1, 234)]:
+            for stringconversion in [str, unicode, bytes]:
+                b = np.array([numericval, stringconversion('xx')])
+                assert_equal(stringconversion(b[0]), stringconversion(numericval))
+                b = np.array([stringconversion('xx'), numericval])
+                assert_equal(stringconversion(b[1]), stringconversion(numericval))
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This commit adds a not-yet-resolved regression test for bug #1990.  test_regression.py seemed like the most likely test suite to put the test into, as the bug was not present 1.5.1 (see post on numpy-discussion from Pierre Haesig)/.

The test is written such that either of the following fixes would cause the test to pass:
- mixed strings & numerics produce a dtype=object array.
- numerics are used to calculate the required string length during array creation.

(for some reason, github won't let me specify the maintenance/1.6.x branch by name.  I've filed it against the current 1.6.x hash.)
