### PR TITLE
Update version match regexp for IBM AIX Fortran compilers

### DIFF
--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -12,7 +12,7 @@ compilers = ['IBMFCompiler']
 class IBMFCompiler(FCompiler):
     compiler_type = 'ibm'
     description = 'IBM XL Fortran Compiler'
-    version_pattern =  r'(xlf\(1\)\s*|)IBM XL Fortran ((Advanced Edition |)Version |Enterprise Edition V)(?P<version>[^\s*]*)'
+    version_pattern =  r'(xlf\(1\)\s*|)IBM XL Fortran ((Advanced Edition |)Version |Enterprise Edition V|for AIX, V)(?P<version>[^\s*]*)'
     #IBM XL Fortran Enterprise Edition V10.1 for AIX \nVersion: 10.01.0000.0004
 
     executables = {


### PR DESCRIPTION
The patched version correctly matches the output of `xlf -qversion` on my AIX platform:

  $ uname -a
  AIX c1t0101 3 5 00CF49B14C00
  $ xlf -qversion
  IBM XL Fortran for AIX, V12.1
  Version: 12.01.0000.0000
  $
