### PR TITLE
Ticket1622 -- prevent a seg. fault triggered by itemset()

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -676,7 +676,7 @@ array_toscalar(PyArrayObject *self, PyObject *args)
         else {
             PyErr_SetString(PyExc_ValueError,
                             "can only convert an array "
-                            " of size 1 to a Python scalar");
+                            "of size 1 to a Python scalar");
         }
     }
     /* Special case of C-order flat indexing... :| */
@@ -739,6 +739,12 @@ array_setscalar(PyArrayObject *self, PyObject *args)
                         "itemset must have at least one argument");
         return NULL;
     }
+    if (!PyArray_ISWRITEABLE(self)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "array is not writeable");
+        return NULL;
+    }
+
     obj = PyTuple_GET_ITEM(args, n);
 
     /* If there is a tuple as a single argument, treat it as the argument */
@@ -756,7 +762,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
         else {
             PyErr_SetString(PyExc_ValueError,
                             "can only convert an array "
-                            " of size 1 to a Python scalar");
+                            "of size 1 to a Python scalar");
         }
     }
     /* Special case of C-order flat indexing... :| */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -22,6 +22,7 @@ class TestFlags(TestCase):
         mydict = locals()
         self.a.flags.writeable = False
         self.assertRaises(RuntimeError, runstring, 'self.a[0] = 3', mydict)
+        self.assertRaises(RuntimeError, runstring, 'self.a[0:1].itemset(3)', mydict)
         self.a.flags.writeable = True
         self.a[0] = 5
         self.a[0] = 0


### PR DESCRIPTION
See http://projects.scipy.org/numpy/ticket/1622

This pull request contains the patch contributed by jpeel, along with a test for itemset() when the array is not writeable.
