### PR TITLE
BUG: PyArray_{Get,Set}Map counter types are "int", should be "npy_intp"

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -299,7 +299,7 @@ PyArray_GetMap(PyArrayMapIterObject *mit)
 
     PyArrayObject *ret, *temp;
     PyArrayIterObject *it;
-    int counter;
+    npy_intp counter;
     int swap;
     PyArray_CopySwapFunc *copyswap;
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -359,7 +359,7 @@ PyArray_SetMap(PyArrayMapIterObject *mit, PyObject *op)
 {
     PyArrayObject *arr = NULL;
     PyArrayIterObject *it;
-    int counter;
+    npy_intp counter;
     int swap;
     PyArray_CopySwapFunc *copyswap;
     PyArray_Descr *descr;


### PR DESCRIPTION
Leads to premature end to loop when working with gigantic arrays.
