### PR TITLE
Describe update of C API version in HOWTO_RELEASE

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -104,8 +104,7 @@ Wine
 For building Windows binaries on OS X Wine can be used. In Wine the following
 needs to be installed:
 
-* Python 2.5
-* Python 2.6
+* Python 2.5-2.7 and 3.1-3.2
 * MakeNsis
 * CpuId plugin for MakeNsis : this can be found in the NumPy source tree under
   tools/win32build/cpucaps and has to be built with MinGW (see SConstruct file in 
@@ -162,8 +161,8 @@ What is released
 
 Binaries
 --------
-Windows binaries in "superpack" form for Python 2.5/2.6/2.7/3.1. A superpack
-contains three builds, for SSE2, SSE3 and no SSE.
+Windows binaries in "superpack" form for Python 2.5/2.6/2.7/3.1/3.2.
+A superpack contains three builds, for SSE2, SSE3 and no SSE.
 
 OS X binaries are made in dmg format, targeting only the Python from
 `python.org <http://python.org>`_
@@ -223,6 +222,16 @@ Before the release branch is made, it should be checked that all deprecated
 code that should be removed is actually removed, and all new deprecations say
 in the dostring or deprecation warning at what version the code will be
 removed.
+
+Check the C API version number
+------------------------------
+The C API version number is recorded in core/code_generators/cversions.txt.
+Before every release this number should be updated by running
+core/code_generators/cversions.py, and main changes noted in a comment.  If
+this is done correctly, compiling the release should not give a warning "API
+mismatch detected ..." at the beginning of the build.
+
+The C ABI version number should only be updated for a major release.
 
 Check the release notes
 -----------------------


### PR DESCRIPTION
Updating the version hash every time it changes is not done in practice, and is probably not very useful. So I propose to just update it before every release.
