### PR TITLE
TST: Make deprecation warnings raise exceptions during test run

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -16,11 +16,8 @@ After installation, tests can be run with:
 
 python -c 'import numpy; numpy.test()'
 
-When installing a new version of numpy for the first time or before upgrading
-to a newer version, it is recommended to turn on deprecation warnings when
-running the tests:
-
-python -Wd -c 'import numpy; numpy.test()'
+Starting in NumPy 1.7, deprecation warnings have been set to 'raise' by
+default, so the -Wd command-line option is no longer necessary.
 
 The most current development version is always available from our
 git repository:

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.compat import asbytes
 from numpy.testing import *
 import sys, warnings
-
+from numpy.testing.utils import WarningManager
 
 def test_array_maskna_flags():
     a = np.arange(3)
@@ -200,6 +200,8 @@ def test_array_maskna_astype():
     dtdst.append(np.dtype('datetime64[D]'))
     dtdst.append(np.dtype('timedelta64[s]'))
 
+    warn_ctx = WarningManager()
+    warn_ctx.__enter__()
     try:
         warnings.simplefilter("ignore", np.ComplexWarning)
         for dt1 in dtsrc:
@@ -212,7 +214,7 @@ def test_array_maskna_astype():
                 assert_(b.flags.ownmaskna, msg)
                 assert_(np.isna(b[1]), msg)
     finally:
-        warnings.simplefilter("default", np.ComplexWarning)
+        warn_ctx.__exit__()
 
 
 def test_array_maskna_repr():

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -1,6 +1,5 @@
 from tempfile import NamedTemporaryFile, mktemp
 import os
-import warnings
 
 from numpy import memmap
 from numpy import arange, allclose

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7,6 +7,9 @@ from nose import SkipTest
 from numpy.core import *
 from numpy.core.multiarray_tests import test_neighborhood_iterator, test_neighborhood_iterator_oob
 
+import warnings
+from numpy.testing.utils import WarningManager
+
 # Need to test an object that does not fully implement math interface
 from datetime import timedelta
 
@@ -1996,15 +1999,17 @@ class TestStackedNeighborhoodIter(TestCase):
 
 class TestWarnings(object):
     def test_complex_warning(self):
-        import warnings
-
         x = np.array([1,2])
         y = np.array([1-2j,1+2j])
 
-        warnings.simplefilter("error", np.ComplexWarning)
-        assert_raises(np.ComplexWarning, x.__setitem__, slice(None), y)
-        assert_equal(x, [1,2])
-        warnings.simplefilter("default", np.ComplexWarning)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.simplefilter("error", np.ComplexWarning)
+            assert_raises(np.ComplexWarning, x.__setitem__, slice(None), y)
+            assert_equal(x, [1,2])
+        finally:
+            warn_ctx.__exit__()
 
 if sys.version_info >= (2, 6):
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1406,11 +1406,13 @@ class TestRegression(TestCase):
         for tp in [np.csingle, np.cdouble, np.clongdouble]:
             x = tp(1+2j)
             assert_warns(np.ComplexWarning, float, x)
-            ctx = WarningManager()
-            ctx.__enter__()
-            warnings.simplefilter('ignore')
-            assert_equal(float(x), float(x.real))
-            ctx.__exit__()
+            warn_ctx = WarningManager()
+            warn_ctx.__enter__()
+            try:
+                warnings.simplefilter('ignore')
+                assert_equal(float(x), float(x.real))
+            finally:
+                warn_ctx.__exit__()
 
     def test_complex_scalar_complex_cast(self):
         for tp in [np.csingle, np.cdouble, np.clongdouble]:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -18,6 +18,7 @@ import numpy.ma.core
 from numpy.ma.core import *
 
 from numpy.compat import asbytes, asbytes_nested
+from numpy.testing.utils import WarningManager
 
 pi = np.pi
 
@@ -426,9 +427,13 @@ class TestMaskedArray(TestCase):
         assert_equal(1.0, float(array([[1]])))
         self.assertRaises(TypeError, float, array([1, 1]))
         #
-        warnings.simplefilter('ignore', UserWarning)
-        assert_(np.isnan(float(array([1], mask=[1]))))
-        warnings.simplefilter('default', UserWarning)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.simplefilter('ignore', UserWarning)
+            assert_(np.isnan(float(array([1], mask=[1]))))
+        finally:
+            warn_ctx.__exit__()
         #
         a = array([1, 2, 3], mask=[1, 0, 0])
         self.assertRaises(TypeError, lambda:float(a))

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -22,6 +22,9 @@ from numpy.ma.testutils import *
 import numpy.ma as ma
 from numpy.ma import masked, nomask
 
+import warnings
+from numpy.testing.utils import WarningManager
+
 from numpy.ma.mrecords import MaskedRecords, mrecarray, fromarrays, \
                               fromtextfile, fromrecords, addfield
 
@@ -136,11 +139,15 @@ class TestMRecords(TestCase):
         rdata = data.view(MaskedRecords)
         val = ma.array([10,20,30], mask=[1,0,0])
         #
-        import warnings
-        warnings.simplefilter("ignore")
-        rdata['num'] = val
-        assert_equal(rdata.num, val)
-        assert_equal(rdata.num.mask, [1,0,0])
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.simplefilter("ignore")
+            rdata['num'] = val
+            assert_equal(rdata.num, val)
+            assert_equal(rdata.num.mask, [1,0,0])
+        finally:
+            warn_ctx.__exit__()
 
     def test_set_fields_mask(self):
         "Tests setting the mask of a field."

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -332,6 +332,8 @@ class NoseTester(object):
 
             # Force deprecation warnings to raise
             warnings.filterwarnings('error', category=DeprecationWarning)
+            # Force runtime warnings to raise
+            warnings.filterwarnings('error', category=RuntimeWarning)
 
             argv, plugins = self.prepare_test_args(label, verbose, extra_argv,
                                                    doctests, coverage)


### PR DESCRIPTION
This change was discussed in ticket #1894 (http://projects.scipy.org/numpy/ticket/1894), and I suggested where to implement it, but no one ran with it. I've implemented this simple change, with it raising an exception instead of printing a warning, so any deprecations triggered in the test suite will fail the tests.
