### PR TITLE
bugfix for #2045

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1037,6 +1037,11 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
     PyObject *obj = NULL;
     PyArray_CopySwapFunc *copyswap;
 
+    if (val == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                        "cannot delete array elements");
+        return -1;
+    }
 
     if (ind == Py_Ellipsis) {
         ind = PySlice_New(NULL, NULL, NULL);


### PR DESCRIPTION
Simply check that val is not NULL as is done in array_ass_sub (mapping.c) and array_ass_slice(sequence.c). Is there anywhere else this check is missing?
