### PR TITLE
DEP: Fix some functions now deprecated in Python 3.

### DIFF
--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -209,6 +209,7 @@ def test_array_maskna_astype():
             a[1] = np.NA
             for dt2 in dtdst:
                 msg = 'type %s to %s conversion' % (dt1, dt2)
+                print msg, a
                 b = a.astype(dt2)
                 assert_(b.flags.maskna, msg)
                 assert_(b.flags.ownmaskna, msg)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -209,7 +209,6 @@ def test_array_maskna_astype():
             a[1] = np.NA
             for dt2 in dtdst:
                 msg = 'type %s to %s conversion' % (dt1, dt2)
-                print msg, a
                 b = a.astype(dt2)
                 assert_(b.flags.maskna, msg)
                 assert_(b.flags.ownmaskna, msg)

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -42,8 +42,8 @@ class TestMemmap(TestCase):
         mode = "w+"
         fp = memmap(self.tmpfp, dtype=self.dtype, mode=mode,
                     shape=self.shape, offset=offset)
-        self.assertEquals(offset, fp.offset)
-        self.assertEquals(mode, fp.mode)
+        self.assertEqual(offset, fp.offset)
+        self.assertEqual(mode, fp.mode)
         del fp
 
     def test_filename(self):
@@ -52,9 +52,9 @@ class TestMemmap(TestCase):
                        shape=self.shape)
         abspath = os.path.abspath(tmpname)
         fp[:] = self.data[:]
-        self.assertEquals(abspath, fp.filename)
+        self.assertEqual(abspath, fp.filename)
         b = fp[:1]
-        self.assertEquals(abspath, b.filename)
+        self.assertEqual(abspath, b.filename)
         del b
         del fp
         os.unlink(tmpname)
@@ -62,7 +62,7 @@ class TestMemmap(TestCase):
     def test_filename_fileobj(self):
         fp = memmap(self.tmpfp, dtype=self.dtype, mode="w+",
                     shape=self.shape)
-        self.assertEquals(fp.filename, self.tmpfp.name)
+        self.assertEqual(fp.filename, self.tmpfp.name)
 
     def test_flush(self):
         fp = memmap(self.tmpfp, dtype=self.dtype, mode='w+',

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -44,10 +44,10 @@ class TestNdpointer(TestCase):
     def test_dtype(self):
         dt = np.intc
         p = ndpointer(dtype=dt)
-        self.assert_(p.from_param(np.array([1], dt)))
+        self.assertTrue(p.from_param(np.array([1], dt)))
         dt = '<i4'
         p = ndpointer(dtype=dt)
-        self.assert_(p.from_param(np.array([1], dt)))
+        self.assertTrue(p.from_param(np.array([1], dt)))
         dt = np.dtype('>i4')
         p = ndpointer(dtype=dt)
         p.from_param(np.array([1], dt))
@@ -58,41 +58,41 @@ class TestNdpointer(TestCase):
         dtdescr = {'names' : dtnames, 'formats' : dtformats}
         dt = np.dtype(dtdescr)
         p = ndpointer(dtype=dt)
-        self.assert_(p.from_param(np.zeros((10,), dt)))
+        self.assertTrue(p.from_param(np.zeros((10,), dt)))
         samedt = np.dtype(dtdescr)
         p = ndpointer(dtype=samedt)
-        self.assert_(p.from_param(np.zeros((10,), dt)))
+        self.assertTrue(p.from_param(np.zeros((10,), dt)))
         dt2 = np.dtype(dtdescr, align=True)
         if dt.itemsize != dt2.itemsize:
             self.assertRaises(TypeError, p.from_param, np.zeros((10,), dt2))
         else:
-            self.assert_(p.from_param(np.zeros((10,), dt2)))
+            self.assertTrue(p.from_param(np.zeros((10,), dt2)))
 
     def test_ndim(self):
         p = ndpointer(ndim=0)
-        self.assert_(p.from_param(np.array(1)))
+        self.assertTrue(p.from_param(np.array(1)))
         self.assertRaises(TypeError, p.from_param, np.array([1]))
         p = ndpointer(ndim=1)
         self.assertRaises(TypeError, p.from_param, np.array(1))
-        self.assert_(p.from_param(np.array([1])))
+        self.assertTrue(p.from_param(np.array([1])))
         p = ndpointer(ndim=2)
-        self.assert_(p.from_param(np.array([[1]])))
+        self.assertTrue(p.from_param(np.array([[1]])))
 
     def test_shape(self):
         p = ndpointer(shape=(1,2))
-        self.assert_(p.from_param(np.array([[1,2]])))
+        self.assertTrue(p.from_param(np.array([[1,2]])))
         self.assertRaises(TypeError, p.from_param, np.array([[1],[2]]))
         p = ndpointer(shape=())
-        self.assert_(p.from_param(np.array(1)))
+        self.assertTrue(p.from_param(np.array(1)))
 
     def test_flags(self):
         x = np.array([[1,2,3]], order='F')
         p = ndpointer(flags='FORTRAN')
-        self.assert_(p.from_param(x))
+        self.assertTrue(p.from_param(x))
         p = ndpointer(flags='CONTIGUOUS')
         self.assertRaises(TypeError, p.from_param, x)
         p = ndpointer(flags=x.flags.num)
-        self.assert_(p.from_param(x))
+        self.assertTrue(p.from_param(x))
         self.assertRaises(TypeError, p.from_param, np.array([[1,2,3]]))
 
 


### PR DESCRIPTION
The functions are assertEquals and assert_ (Python's TestCase, not ours).
