### PR TITLE
Bug 1990

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -148,10 +148,22 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims, int *out_contains_na,
             }
         }
         else {
-            if ((temp = PyObject_Str(obj)) == NULL) {
-                return -1;
-            }   
-            itemsize = PyString_GET_SIZE(temp);
+            if (string_type == NPY_STRING) {
+                if ((temp = PyObject_Str(obj)) == NULL) {
+                    return -1;
+                }
+                itemsize = PyString_GET_SIZE(temp);
+            }
+            else if (string_type == NPY_UNICODE) {
+#if defined(NPY_PY3K)
+                if ((temp = PyObject_Str(obj)) == NULL) {
+#else
+                if ((temp=PyObject_Unicode(obj)) == NULL) {
+#endif
+                    return -1;
+                }
+                itemsize = PyUnicode_GET_DATA_SIZE(temp);
+            }
             Py_DECREF(temp);
             if (*out_dtype != NULL &&
                 (*out_dtype)->type_num == string_type &&
@@ -174,10 +186,25 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims, int *out_contains_na,
         PyObject *temp;
 
         if (string_type) {
-            if ((temp = PyObject_Str(obj)) == NULL) {
-                return -1;
-            }   
-            itemsize = PyString_GET_SIZE(temp);
+            if (string_type == NPY_STRING) {
+                if ((temp = PyObject_Str(obj)) == NULL) {
+                    return -1;
+                }
+                itemsize = PyString_GET_SIZE(temp);
+            }
+            else if (string_type == NPY_UNICODE) {
+#if defined(NPY_PY3K)
+                if ((temp = PyObject_Str(obj)) == NULL) {
+#else
+                if ((temp=PyObject_Unicode(obj)) == NULL) {
+#endif
+                    return -1;
+                }
+                itemsize = PyUnicode_GET_DATA_SIZE(temp);
+#ifndef Py_UNICODE_WIDE
+                itemsize <<= 1;
+#endif
+            }
             Py_DECREF(temp);
             if (*out_dtype != NULL &&
                 (*out_dtype)->type_num == string_type &&

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -104,23 +104,19 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims, int *out_contains_na,
 {
     int res;
 
-    res = PyArray_DTypeFromObjectHelper(
-            obj, maxdims, out_contains_na, out_dtype, 0
-          );
+    res = PyArray_DTypeFromObjectHelper(obj, maxdims, out_contains_na, 
+                out_dtype, 0);
     if (res == RETRY_WITH_STRING) {
-        res = PyArray_DTypeFromObjectHelper(
-                obj, maxdims, out_contains_na, out_dtype, NPY_STRING
-              );
+        res = PyArray_DTypeFromObjectHelper(obj, maxdims, out_contains_na, 
+                    out_dtype, NPY_STRING);
         if (res == RETRY_WITH_UNICODE) {
-            res = PyArray_DTypeFromObjectHelper(
-                    obj, maxdims, out_contains_na, out_dtype, NPY_UNICODE
-                  );
+            res = PyArray_DTypeFromObjectHelper(obj, maxdims, 
+                        out_contains_na, out_dtype, NPY_UNICODE);
         }
     }
     else if (res == RETRY_WITH_UNICODE) {
-        res = PyArray_DTypeFromObjectHelper(
-                obj, maxdims, out_contains_na, out_dtype, NPY_UNICODE
-              );
+        res = PyArray_DTypeFromObjectHelper(obj, maxdims, out_contains_na, 
+                    out_dtype, NPY_UNICODE);
     }
     return res;
 }
@@ -181,8 +177,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims, int *out_contains_na,
             }
             Py_DECREF(temp);
             if (*out_dtype != NULL &&
-                (*out_dtype)->type_num == string_type &&
-                (*out_dtype)->elsize >= itemsize) {
+                    (*out_dtype)->type_num == string_type &&
+                    (*out_dtype)->elsize >= itemsize) {
                 return 0;
             }
             dtype = PyArray_DescrNewFromType(string_type);
@@ -222,8 +218,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims, int *out_contains_na,
             }
             Py_DECREF(temp);
             if (*out_dtype != NULL &&
-                (*out_dtype)->type_num == string_type &&
-                (*out_dtype)->elsize >= itemsize) {
+                    (*out_dtype)->type_num == string_type &&
+                    (*out_dtype)->elsize >= itemsize) {
                 return 0;
             }
             dtype = PyArray_DescrNewFromType(string_type);
@@ -443,8 +439,12 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims, int *out_contains_na,
 promote_types:
     /* Set 'out_dtype' if it's NULL */
     if (*out_dtype == NULL) {
-        if (!string_type && dtype->type_num == NPY_STRING) return RETRY_WITH_STRING;
-        if (!string_type && dtype->type_num == NPY_UNICODE) return RETRY_WITH_UNICODE;
+        if (!string_type && dtype->type_num == NPY_STRING) {
+            return RETRY_WITH_STRING;
+        }
+        if (!string_type && dtype->type_num == NPY_UNICODE) {
+            return RETRY_WITH_UNICODE;
+        }
         *out_dtype = dtype;
         return 0;
     }

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -27,6 +27,10 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObject(PyObject *obj, int maxdims, int *out_contains_na,
                         PyArray_Descr **out_dtype);
 
+NPY_NO_EXPORT int
+PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims, int *out_contains_na,
+                              PyArray_Descr **out_dtype, int string_status);
+
 /*
  * Returns NULL without setting an exception if no scalar is matched, a
  * new dtype reference otherwise.

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1641,10 +1641,16 @@ class TestRegression(TestCase):
         # Ticket #1990 - Data can be truncated in creation of an array from a
         # mixed sequence of numeric values and strings
         for numericval in [True, 1234, 123.4, complex(1, 234)]:
-            for stringconversion in [str, unicode, bytes]:
+            for stringconversion in [str, asunicode, asbytes]:
                 b = np.array([numericval, stringconversion('xx')])
                 assert_equal(stringconversion(b[0]), stringconversion(numericval))
                 b = np.array([stringconversion('xx'), numericval])
+                assert_equal(stringconversion(b[1]), stringconversion(numericval))
+
+                # test also with longer strings
+                b = np.array([numericval, stringconversion('xxxxxxxxxx')])
+                assert_equal(stringconversion(b[0]), stringconversion(numericval))
+                b = np.array([stringconversion('xxxxxxxxxx'), numericval])
                 assert_equal(stringconversion(b[1]), stringconversion(numericval))
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1637,5 +1637,15 @@ class TestRegression(TestCase):
         x = np.arange(0, 4, dtype='datetime64[D]')
         assert_raises(TypeError, x.searchsorted, 1)
 
+    def test_string_truncation(self):
+        # Ticket #1990 - Data can be truncated in creation of an array from a
+        # mixed sequence of numeric values and strings
+        for numericval in [True, 1234, 123.4, complex(1, 234)]:
+            for stringconversion in [str, unicode, bytes]:
+                b = np.array([numericval, stringconversion('xx')])
+                assert_equal(stringconversion(b[0]), stringconversion(numericval))
+                b = np.array([stringconversion('xx'), numericval])
+                assert_equal(stringconversion(b[1]), stringconversion(numericval))
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is a pull request for #1990 "Data can be truncated in creation of an array from a mixed sequence of numeric values and strings" This fix computes the length of string representations (when necessary) and passes the test in pull request 173, as well as all others in np.test().  I would definitely appreciate any feedback. 
