### PR TITLE
BUG: Allow nditer object to be created with array-dtypes

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2605,20 +2605,21 @@ npyiter_new_temp_array(NpyIter *iter, PyTypeObject *subtype,
 
     PyArrayObject *ret;
 
+    /*
+     * There is an interaction with array-dtypes here, which
+     * generally works. Let's say you make an nditer with an
+     * output dtype of a 2-double array. All-scalar inputs
+     * will result in a 1-dimensional output with shape (2).
+     * Everything still works out in the nditer, because the
+     * new dimension is always added on the end, and it cares
+     * about what happens at the beginning.
+     */
+
     /* If it's a scalar, don't need to check the axes */
     if (op_ndim == 0) {
         Py_INCREF(op_dtype);
         ret = (PyArrayObject *)PyArray_NewFromDescr(subtype, op_dtype, 0,
                                NULL, NULL, NULL, 0, NULL);
-
-        /* Double-check that the subtype didn't mess with the dimensions */
-        if (PyArray_NDIM(ret) != 0) {
-            PyErr_SetString(PyExc_RuntimeError,
-                    "Iterator automatic output has an array subtype "
-                    "which changed the dimensions of the output");
-            Py_DECREF(ret);
-            return NULL;
-        }
 
         return ret;
     }

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2581,6 +2581,23 @@ def test_iter_element_deletion():
     except:
         raise AssertionError
 
+def test_iter_allocated_array_dtypes():
+    # If the dtype of an allocated output has a shape, the shape gets
+    # tacked onto the end of the result.
+    it = np.nditer(([1, 3, 20], None), op_dtypes=[None, ('i4', (2,))])
+    for a, b in it:
+        b[0] = a - 1
+        b[1] = a + 1
+    assert_equal(it.operands[1], [[0,2], [2,4], [19,21]])
+
+    # Make sure this works for scalars too
+    it = np.nditer((10, 2, None), op_dtypes=[None, None, ('i4', (2,2))])
+    for a, b, c in it:
+        c[0,0] = a - b
+        c[0,1] = a + b
+        c[1,0] = a * b
+        c[1,1] = a / b
+    assert_equal(it.operands[2], [[8, 12], [20, 5]])
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
There was an error-check which prevented this for scalar inputs,
but otherwise it already worked. Added a test as well.
