### PR TITLE
FIX #2029

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -429,17 +429,19 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
         return -1;
     }
 
-    if (PyArray_HASMASKNA(self)) {
-        PyErr_SetString(PyExc_TypeError,   
-                        "Cannot change data-type for NA-masked array.");
-        return -1;
-    }
-
     if (!(PyArray_DescrConverter(arg, &newtype)) ||
         newtype == NULL) {
         PyErr_SetString(PyExc_TypeError, "invalid data-type for array");
         return -1;
     }
+
+    if (PyArray_HASMASKNA(self) &&
+            newtype->elsize != PyArray_DESCR(self)->elsize) {
+        PyErr_SetString(PyExc_TypeError,   
+                        "data-type for NA-masked array muat match itemsize.");
+        return -1;
+    }
+
     if (PyDataType_FLAGCHK(newtype, NPY_ITEM_HASOBJECT) ||
         PyDataType_FLAGCHK(newtype, NPY_ITEM_IS_POINTER) ||
         PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_ITEM_HASOBJECT) ||

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -434,13 +434,20 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
         PyErr_SetString(PyExc_TypeError, "invalid data-type for array");
         return -1;
     }
+
+    if (PyArray_HASMASKNA(self) &&
+            newtype->elsize != PyArray_DESCR(self)->elsize) {
+        PyErr_SetString(PyExc_TypeError,   
+                        "data-type for NA-masked array must match itemsize.");
+        return -1;
+    }
+
     if (PyDataType_FLAGCHK(newtype, NPY_ITEM_HASOBJECT) ||
         PyDataType_FLAGCHK(newtype, NPY_ITEM_IS_POINTER) ||
         PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_ITEM_HASOBJECT) ||
         PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_ITEM_IS_POINTER)) {
-        PyErr_SetString(PyExc_TypeError,                      \
-                        "Cannot change data-type for object " \
-                        "array.");
+        PyErr_SetString(PyExc_TypeError, 
+                        "Cannot change data-type for object array.");
         Py_DECREF(newtype);
         return -1;
     }

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -438,7 +438,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     if (PyArray_HASMASKNA(self) &&
             newtype->elsize != PyArray_DESCR(self)->elsize) {
         PyErr_SetString(PyExc_TypeError,   
-                        "data-type for NA-masked array must match itemsize.");
+                        "data-type for NA-masked array muat match itemsize.");
         return -1;
     }
 

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -409,6 +409,13 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     int i;
     char *msg = "new type not compatible with array.";
 
+    if (PyArray_HASMASKNA(self)) {
+        PyErr_SetString(PyExc_TypeError,                      \
+                        "Cannot change data-type for masked " \
+                        "array.");
+        return -1;
+    }
+
     if (!(PyArray_DescrConverter(arg, &newtype)) ||
         newtype == NULL) {
         PyErr_SetString(PyExc_TypeError, "invalid data-type for array");

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -429,6 +429,13 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
         return -1;
     }
 
+    if (PyArray_HASMASKNA(self)) {
+        PyErr_SetString(PyExc_TypeError,                      \
+                        "Cannot change data-type for masked " \
+                        "array.");
+        return -1;
+    }
+
     if (!(PyArray_DescrConverter(arg, &newtype)) ||
         newtype == NULL) {
         PyErr_SetString(PyExc_TypeError, "invalid data-type for array");

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -430,9 +430,8 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     }
 
     if (PyArray_HASMASKNA(self)) {
-        PyErr_SetString(PyExc_TypeError,                      \
-                        "Cannot change data-type for masked " \
-                        "array.");
+        PyErr_SetString(PyExc_TypeError,   
+                        "Cannot change data-type for NA-masked array.");
         return -1;
     }
 
@@ -445,9 +444,8 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
         PyDataType_FLAGCHK(newtype, NPY_ITEM_IS_POINTER) ||
         PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_ITEM_HASOBJECT) ||
         PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_ITEM_IS_POINTER)) {
-        PyErr_SetString(PyExc_TypeError,                      \
-                        "Cannot change data-type for object " \
-                        "array.");
+        PyErr_SetString(PyExc_TypeError, 
+                        "Cannot change data-type for object array.");
         Py_DECREF(newtype);
         return -1;
     }

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -438,7 +438,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     if (PyArray_HASMASKNA(self) &&
             newtype->elsize != PyArray_DESCR(self)->elsize) {
         PyErr_SetString(PyExc_TypeError,   
-                        "data-type for NA-masked array muat match itemsize.");
+                        "data-type for NA-masked array must match itemsize.");
         return -1;
     }
 

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -3,7 +3,6 @@ from numpy.compat import asbytes
 from numpy.testing import *
 import sys, warnings
 from numpy.testing.utils import WarningManager
-import itertools
 
 def test_array_maskna_flags():
     a = np.arange(3)
@@ -458,28 +457,16 @@ def test_array_maskna_view_function():
     assert_(c.flags.ownmaskna)
 
 def test_array_maskna_view_dtype():
-    tcs = np.typecodes['AllFloat'] + \
-          np.typecodes['AllInteger'] + \
-          np.typecodes['Complex']
-    same_size = []
-    diff_size = []
-    for x in itertools.combinations(tcs, 2): 
-        a            same_size.append(x)
-        else: diff_size.append(x)
+    codes = np.typecodes['AllFloat'] + \
+            np.typecodes['AllInteger'] + \
+            np.typecodes['Complex']
+    tcs = [(x,y) for x in codes for y in codes if x != y]
 
-    for (from_type, to_type) in diff_size:
+    for (from_type, to_type) in tcs:
         a = np.arange(10, dtype=from_type, maskna=True)
 
-        # Ensure that a view of a masked array cannot change to different
-        # sized dtype
+        # Ensure that a view of a masked array cannot change dtype
         assert_raises(TypeError, a.view, to_type)
-
-    for (from_type, to_type) in same_size:
-        a = np.arange(10, dtype=from_type, maskna=True)
-
-        # Ensure that a view of a masked array can change to same
-        # sized dtype
-        b = a.view(dtype=to_type)
 
 def test_array_maskna_array_function_1D():
     a = np.arange(10)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -454,6 +454,17 @@ def test_array_maskna_view_function():
     assert_(c.flags.maskna)
     assert_(c.flags.ownmaskna)
 
+def test_array_maskna_view_dtype():
+    codes = np.typecodes['AllFloat'] + \
+            np.typecodes['AllInteger'] + \
+            np.typecodes['Complex']
+    tcs = [(x,y) for x in codes for y in codes if x != y]
+
+    for (from_type, to_type) in tcs:
+        a = np.arange(10, dtype=from_type, maskna=True)
+
+        # Ensure that a view of a masked array cannot change dtype
+        assert_raises(TypeError, a.view, to_type)
 
 def test_array_maskna_array_function_1D():
     a = np.arange(10)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -3,6 +3,7 @@ from numpy.compat import asbytes
 from numpy.testing import *
 import sys, warnings
 from numpy.testing.utils import WarningManager
+import itertools
 
 def test_array_maskna_flags():
     a = np.arange(3)
@@ -457,16 +458,28 @@ def test_array_maskna_view_function():
     assert_(c.flags.ownmaskna)
 
 def test_array_maskna_view_dtype():
-    codes = np.typecodes['AllFloat'] + \
-            np.typecodes['AllInteger'] + \
-            np.typecodes['Complex']
-    tcs = [(x,y) for x in codes for y in codes if x != y]
+    tcs = np.typecodes['AllFloat'] + \
+          np.typecodes['AllInteger'] + \
+          np.typecodes['Complex']
+    same_size = []
+    diff_size = []
+    for x in itertools.combinations(tcs, 2): 
+        a            same_size.append(x)
+        else: diff_size.append(x)
 
-    for (from_type, to_type) in tcs:
+    for (from_type, to_type) in diff_size:
         a = np.arange(10, dtype=from_type, maskna=True)
 
-        # Ensure that a view of a masked array cannot change dtype
+        # Ensure that a view of a masked array cannot change to different
+        # sized dtype
         assert_raises(TypeError, a.view, to_type)
+
+    for (from_type, to_type) in same_size:
+        a = np.arange(10, dtype=from_type, maskna=True)
+
+        # Ensure that a view of a masked array can change to same
+        # sized dtype
+        b = a.view(dtype=to_type)
 
 def test_array_maskna_array_function_1D():
     a = np.arange(10)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -3,6 +3,7 @@ from numpy.compat import asbytes
 from numpy.testing import *
 import sys, warnings
 from numpy.testing.utils import WarningManager
+import itertools
 
 def test_array_maskna_flags():
     a = np.arange(3)
@@ -457,16 +458,30 @@ def test_array_maskna_view_function():
     assert_(c.flags.ownmaskna)
 
 def test_array_maskna_view_dtype():
-    codes = np.typecodes['AllFloat'] + \
-            np.typecodes['AllInteger'] + \
-            np.typecodes['Complex']
-    tcs = [(x,y) for x in codes for y in codes if x != y]
+    tcs = np.typecodes['AllFloat'] + \
+          np.typecodes['AllInteger'] + \
+          np.typecodes['Complex']
 
-    for (from_type, to_type) in tcs:
+    same_size = []
+    diff_size = []
+    for x in itertools.combinations(tcs, 2):
+        if np.dtype(x[0]).itemsize == np.dtype(x[1]).itemsize: 
+            same_size.append(x)
+        else: diff_size.append(x)
+
+    for (from_type, to_type) in same_size:
         a = np.arange(10, dtype=from_type, maskna=True)
 
-        # Ensure that a view of a masked array cannot change dtype
-        assert_raises(TypeError, a.view, to_type)
+        # Ensure that a view of a masked array cannot change to 
+        # different sized dtype
+        a.view(dtype=to_type)
+
+    for (from_type, to_type) in same_size:
+        a = np.arange(10, dtype=from_type, maskna=True)
+
+        # Ensure that a view of a masked array can change to 
+        # same sized dtype
+        b = a.view(dtype=to_type)
 
 def test_array_maskna_array_function_1D():
     a = np.arange(10)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -469,12 +469,12 @@ def test_array_maskna_view_dtype():
             same_size.append(x)
         else: diff_size.append(x)
 
-    for (from_type, to_type) in same_size:
+    for (from_type, to_type) in diff_size:
         a = np.arange(10, dtype=from_type, maskna=True)
 
         # Ensure that a view of a masked array cannot change to 
         # different sized dtype
-        a.view(dtype=to_type)
+        assert_raises(TypeError, a.view, to_type)
 
     for (from_type, to_type) in same_size:
         a = np.arange(10, dtype=from_type, maskna=True)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -3,6 +3,7 @@ from numpy.compat import asbytes
 from numpy.testing import *
 import sys, warnings
 from numpy.testing.utils import WarningManager
+import itertools
 
 def test_array_maskna_flags():
     a = np.arange(3)
@@ -456,6 +457,31 @@ def test_array_maskna_view_function():
     assert_(c.flags.maskna)
     assert_(c.flags.ownmaskna)
 
+def test_array_maskna_view_dtype():
+    tcs = np.typecodes['AllFloat'] + \
+          np.typecodes['AllInteger'] + \
+          np.typecodes['Complex']
+
+    same_size = []
+    diff_size = []
+    for x in itertools.combinations(tcs, 2):
+        if np.dtype(x[0]).itemsize == np.dtype(x[1]).itemsize: 
+            same_size.append(x)
+        else: diff_size.append(x)
+
+    for (from_type, to_type) in diff_size:
+        a = np.arange(10, dtype=from_type, maskna=True)
+
+        # Ensure that a view of a masked array cannot change to 
+        # different sized dtype
+        assert_raises(TypeError, a.view, to_type)
+
+    for (from_type, to_type) in same_size:
+        a = np.arange(10, dtype=from_type, maskna=True)
+
+        # Ensure that a view of a masked array can change to 
+        # same sized dtype
+        b = a.view(dtype=to_type)
 
 def test_array_maskna_array_function_1D():
     a = np.arange(10)

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -456,6 +456,17 @@ def test_array_maskna_view_function():
     assert_(c.flags.maskna)
     assert_(c.flags.ownmaskna)
 
+def test_array_maskna_view_dtype():
+    codes = np.typecodes['AllFloat'] + \
+            np.typecodes['AllInteger'] + \
+            np.typecodes['Complex']
+    tcs = [(x,y) for x in codes for y in codes if x != y]
+
+    for (from_type, to_type) in tcs:
+        a = np.arange(10, dtype=from_type, maskna=True)
+
+        # Ensure that a view of a masked array cannot change dtype
+        assert_raises(TypeError, a.view, to_type)
 
 def test_array_maskna_array_function_1D():
     a = np.arange(10)


### PR DESCRIPTION
FIX: this is a fix and test for #2029, disallowing dtype changes for masked arrays
