### PR TITLE
TST,WRN: Add a parameter to control which warnings raise during testing

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -195,8 +195,7 @@ version this is not desired.  Therefore any known warnings should be solved or
 explicitly silenced before making the release branch, then when the branch is
 made, the default behavior should be switched to not raise errors.  This is
 done in the constructor of the NoseTester class in numpy/testing/nosetester.py,
-by replacing ``raise_warnings=(DeprecationWarning, RuntimeWarning)`` with 
-``raise_warnings=()``.
+by replacing ``raise_warnings="develop"`` with ``raise_warnings="release"``.
 
 Make sure current trunk builds a package correctly
 --------------------------------------------------

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -187,6 +187,17 @@ Check the buildbot
 ------------------
 The buildbot is located at `<http://buildbot.scipy.org/>`_.
 
+Handle test warnings
+--------------------
+The default behavior of the test suite in the master branch is to report errors
+for DeprecationWarnings and RuntimeWarnings that are issued.  For a released
+version this is not desired.  Therefore any known warnings should be solved or
+explicitly silenced before making the release branch, then when the branch is
+made, the default behavior should be switched to not raise errors.  This is
+done in the constructor of the NoseTester class in numpy/testing/nosetester.py,
+by replacing ``raise_warnings=(DeprecationWarning, RuntimeWarning)`` with 
+``raise_warnings=()``.
+
 Make sure current trunk builds a package correctly
 --------------------------------------------------
 ::

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -41,13 +41,6 @@ follows::
   >>> import numpy
   >>> numpy.test()
 
-Note that for Python >= 2.7 deprecation warnings are silent by default. They
-can be turned on (recommended after installation and before upgrading) by
-starting the interpreter with the -Wd switch, or by::
-
-  >>> import warnings
-  >>> warnings.simplefilter('always', DeprecationWarning)
-
 The test method may take two or more arguments; the first is a string
 label specifying what should be tested and the second is an integer
 giving the level of output verbosity. See the docstring for numpy.test

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -338,6 +338,9 @@ class NoseTester(object):
             # Reset the warning filters to the default state,
             # so that running the tests is more repeatable.
             warnings.resetwarnings()
+            # If deprecation warnings are not set to 'error' below,
+            # at least set them to 'warn'
+            warnings.filterwarnings('always', category=DeprecationWarning)
             # Force the requested warnings to raise
             for warningtype in raisewarnings:
                 warnings.filterwarnings('error', category=warningtype)

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -156,7 +156,7 @@ class NoseTester(object):
             package_name = get_package_name(package_path)
         self.package_name = package_name
 
-        # Set to empty tuple in constructor in maintenance branches.
+        # Set to "release" in constructor in maintenance branches.
         self.raise_warnings = raise_warnings
 
     def _test_argv(self, label, verbose, extra_argv):

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -108,18 +108,22 @@ class NoseTester(object):
         The package to test. If a string, this should be the full path to
         the package. If None (default), `package` is set to the module from
         which `NoseTester` is initialized.
-    raise_warnings : sequence of warnings, optional
+    raise_warnings : str or sequence of warnings, optional
         This specifies which warnings to configure as 'raise' instead
-        of 'warn' during the test execution. To disable this feature,
-        pass an empty tuple.  See Notes for more details.
+        of 'warn' during the test execution.  Valid strings are:
+
+          - "develop" : equals ``(DeprecationWarning, RuntimeWarning)``
+          - "release" : equals ``()``, don't raise on any warnings.
+
+        See Notes for more details.
 
     Notes
     -----
     The default for `raise_warnings` is ``(DeprecationWarning, RuntimeWarning)``
-    for the master branch of NumPy, and ``()`` for released versions.  The
-    purpose of this switching behavior is to catch as many warnings as possible
-    during development, but not give problems for packaging of released
-    versions.
+    for the master branch of NumPy, and ``()`` for maintenance branches and
+    released versions.  The purpose of this switching behavior is to catch as
+    many warnings as possible during development, but not give problems for
+    packaging of released versions.
 
     """
     # Stuff to exclude from tests. These are from numpy.distutils
@@ -129,8 +133,7 @@ class NoseTester(object):
                 'pyrex_ext',
                 'swig_ext']
 
-    def __init__(self, package=None,
-                 raise_warnings=(DeprecationWarning, RuntimeWarning)):
+    def __init__(self, package=None, raise_warnings="develop"):
         package_name = None
         if package is None:
             f = sys._getframe(1)
@@ -287,13 +290,12 @@ class NoseTester(object):
             If True, report coverage of NumPy code. Default is False.
             (This requires the `coverage module:
              <http://nedbatchelder.com/code/modules/coverage.html>`_).
-        raise_warnings : sequence of warnings, optional
+        raise_warnings : str or sequence of warnings, optional
             This specifies which warnings to configure as 'raise' instead
-            of 'warn' during the test execution. To disable this feature,
-            pass an empty sequence.
-            The default (None) is determined by the `NoseTester` constructor.
-            For NumPy it is set to ``(DeprecationWarning, RuntimeWarning)``
-            during development, and to ``()`` for released versions.
+            of 'warn' during the test execution.  Valid strings are:
+
+              - "develop" : equals ``(DeprecationWarning, RuntimeWarning)``
+              - "release" : equals ``()``, don't raise on any warnings.
 
         Returns
         -------
@@ -342,6 +344,11 @@ class NoseTester(object):
 
         if raise_warnings is None:
             raise_warnings = self.raise_warnings
+
+        _warn_opts = dict(develop=(DeprecationWarning, RuntimeWarning),
+                          release=())
+        if raise_warnings in _warn_opts.keys():
+            raise_warnings = _warn_opts[raise_warnings]
 
         # Preserve the state of the warning filters
         warn_ctx = numpy.testing.utils.WarningManager()

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -252,8 +252,9 @@ class NoseTester(object):
                 argv += ['--with-' + plug.name]
         return argv, plugins
 
-    def test(self, label='fast', verbose=1, extra_argv=None, doctests=False,
-             coverage=False):
+    def test(self, label='fast', verbose=1, extra_argv=None,
+            doctests=False, coverage=False,
+            raisewarnings=(DeprecationWarning, RuntimeWarning)):
         """
         Run tests for module using nose.
 
@@ -279,6 +280,11 @@ class NoseTester(object):
             If True, report coverage of NumPy code. Default is False.
             (This requires the `coverage module:
              <http://nedbatchelder.com/code/modules/coverage.html>`_).
+        raisewarnings : tuple of warnings, optional
+            This specifies which warnings to configure as 'raise' instead
+            of 'warn' during the test execution. To disable this feature,
+            pass an empty tuple. The default is (DeprecationWarning,
+            RuntimeWarning).
 
         Returns
         -------
@@ -329,11 +335,12 @@ class NoseTester(object):
         warn_ctx = numpy.testing.utils.WarningManager()
         warn_ctx.__enter__()
         try:
-
-            # Force deprecation warnings to raise
-            warnings.filterwarnings('error', category=DeprecationWarning)
-            # Force runtime warnings to raise
-            warnings.filterwarnings('error', category=RuntimeWarning)
+            # Reset the warning filters to the default state,
+            # so that running the tests is more repeatable.
+            warnings.resetwarnings()
+            # Force the requested warnings to raise
+            for warningtype in raisewarnings:
+                warnings.filterwarnings('error', category=warningtype)
 
             argv, plugins = self.prepare_test_args(label, verbose, extra_argv,
                                                    doctests, coverage)


### PR DESCRIPTION
The default is set to (RuntimeWarning, DeprecationWarning), and
the intent is to leave it as this on master, but change it to ()
immediately after branching for 1.7 in that branch.
