### PR TITLE
TST: fix string comparison test failures on Windows for Python 2.5.

### DIFF
--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -63,7 +63,18 @@ class TestRepr(TestCase):
     def test_finfo_repr(self):
         expected = "finfo(resolution=1e-06, min=-3.4028235e+38," + \
                    " max=3.4028235e+38, dtype=float32)"
-        assert_equal(repr(np.finfo(np.float32)), expected)
+        # Python 2.5 float formatting on Windows adds an extra 0 to the
+        # exponent.  So test for both.  Once 2.5 compatibility is dropped, this
+        # can simply use `assert_equal(repr(np.finfo(np.float32)), expected)`.
+        expected_win25 = "finfo(resolution=1e-006, min=-3.4028235e+038," + \
+                         " max=3.4028235e+038, dtype=float32)"
+
+        actual = repr(np.finfo(np.float32))
+        if not actual == expected:
+            if not actual == expected_win25:
+                msg = build_err_msg([actual, desired], verbose=True)
+                raise AssertionError(msg)
+
 
 def test_instances():
     iinfo(10)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -287,7 +287,7 @@ class TestSaveTxt(TestCase):
         np.savetxt(c, a, fmt=' %+.3e')
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, asbytes_nested([
+        _assert_floatstr_lines_equal(lines, asbytes_nested([
             ' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n',
             ' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n']))
         # One format for each real and imaginary part
@@ -295,7 +295,7 @@ class TestSaveTxt(TestCase):
         np.savetxt(c, a, fmt='  %+.3e' * 2 * ncols)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, asbytes_nested([
+        _assert_floatstr_lines_equal(lines, asbytes_nested([
             '  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n',
             '  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n']))
         # One format for each complex number
@@ -303,10 +303,29 @@ class TestSaveTxt(TestCase):
         np.savetxt(c, a, fmt=['(%.3e%+.3ej)'] * ncols)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, asbytes_nested([
+        _assert_floatstr_lines_equal(lines, asbytes_nested([
             '(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n',
             '(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n']))
 
+
+def _assert_floatstr_lines_equal(actual_lines, expected_lines):
+    """A string comparison function that also works on Windows + Python 2.5.
+
+    This is necessary because Python 2.5 on Windows inserts an extra 0 in
+    the exponent of the string representation of floating point numbers.
+
+    Only used in TestSaveTxt.test_complex_arrays, no attempt made to make this
+    more generic.
+
+    Once Python 2.5 compatibility is dropped, simply use `assert_equal` instead
+    of this function.
+    """
+    for actual, expected in zip(actual_lines, expected_lines):
+        if not actual == expected:
+            expected_win25 = expected.replace("e+00", "e+000")
+            if not actual == expected_win25:
+                msg = build_err_msg([actual, desired], verbose=True)
+                raise AssertionError(msg)
 
 
 class TestLoadTxt(TestCase):


### PR DESCRIPTION
This is caused by the inconsistent floating point handling of Python itself.
On Windows with 2.5:

> > > "%s" % 1e-6
> > > '1e-006'

With 2.6:

> > > "%s" % 1e-6
> > > '1e-06'

See http://buildbot.scipy.org/builders/Windows_XP_x86/builds/1115/steps/shell_1/logs/stdio for a failure that is fixed by this PR. The finfo one I see, but the buildbot doesn't. 
