### PR TITLE
Allow multi-iter objects to handle more iterators.

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1250,7 +1250,7 @@ typedef struct {
         PyArrayIterObject    **iters;                 /* iterators */
 } PyArrayMultiIterObject;
 
-void multiter_allociters(PyArrayMultiIterObject *multi, int n);
+int multiter_allociters(PyArrayMultiIterObject *multi, int n);
 
 
 #define _PyMIT(m) ((PyArrayMultiIterObject *)(m))

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1247,8 +1247,11 @@ typedef struct {
         npy_intp             index;                   /* current index */
         int                  nd;                      /* number of dims */
         npy_intp             dimensions[NPY_MAXDIMS]; /* dimensions */
-        PyArrayIterObject    *iters[NPY_MAXARGS];     /* iterators */
+        PyArrayIterObject    **iters;                 /* iterators */
 } PyArrayMultiIterObject;
+
+void multiter_allociters(PyArrayMultiIterObject *multi, int n);
+
 
 #define _PyMIT(m) ((PyArrayMultiIterObject *)(m))
 #define PyArray_MultiIter_RESET(multi) do {                                   \
@@ -1308,7 +1311,7 @@ typedef struct {
         npy_intp              index;                   /* current index */
         int                   nd;                      /* number of dims */
         npy_intp              dimensions[NPY_MAXDIMS]; /* dimensions */
-        PyArrayIterObject     *iters[NPY_MAXDIMS];     /* index object
+        PyArrayIterObject     **iters;                 /* index object
                                                           iterators */
         PyArrayIterObject     *ait;                    /* flat Iterator for
                                                           underlying array */

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1503,7 +1503,7 @@ PyArray_Broadcast(PyArrayMultiIterObject *mit)
     return 0;
 }
 
-void
+int
 multiter_allociters(PyArrayMultiIterObject *multi, int n)
 {
     int i;
@@ -1512,14 +1512,20 @@ multiter_allociters(PyArrayMultiIterObject *multi, int n)
 
     if (n <= 0) {
         multi->iters = NULL;
-        return;
+        return 0;
     }
 
     multi->iters = PyArray_malloc(n * sizeof(PyArrayIterObject *));
+    if (multi->iters == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
 
     for (i = 0; i < n; i++) {
         multi->iters[i] = NULL;
     }
+
+    return 0;
 }
 
 /*NUMPY_API
@@ -1553,7 +1559,10 @@ PyArray_MultiIterFromObjects(PyObject **mps, int n, int nadd, ...)
     }
     PyObject_Init((PyObject *)multi, &PyArrayMultiIter_Type);
 
-    multiter_allociters(multi, ntot);
+    if (multiter_allociters(multi, ntot) < 0) {
+        /* error already set */
+        return NULL;
+    }
 
     multi->index = 0;
 
@@ -1616,7 +1625,10 @@ PyArray_MultiIterNew(int n, ...)
     }
     PyObject_Init((PyObject *)multi, &PyArrayMultiIter_Type);
 
-    multiter_allociters(multi, n);
+    if (multiter_allociters(multi, n) < 0) {
+        /* error already set */
+        return NULL;
+    }
 
     multi->index = 0;
 
@@ -1676,7 +1688,10 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args, PyObject *k
     }
     PyObject_Init((PyObject *)multi, &PyArrayMultiIter_Type);
 
-    multiter_allociters(multi, n);
+    if (multiter_allociters(multi, n) < 0) {
+        /* error already set */
+        return NULL;
+    }
 
     multi->index = 0;
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2355,7 +2355,9 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
     /* convert all inputs to iterators */
     if (PyArray_Check(indexobj) &&
                     (PyArray_TYPE((PyArrayObject *)indexobj) == NPY_BOOL)) {
-        multiter_allociters((PyArrayMultiIterObject *)mit, _nonzero_indices(indexobj, NULL));
+        if (multiter_allociters((PyArrayMultiIterObject *)mit, _nonzero_indices(indexobj, NULL)) < 0) {
+            goto fail;
+        }
         if (mit->numiter < 0) {
             goto fail;
         }
@@ -2374,7 +2376,9 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
         }
     }
     else if (PyArray_Check(indexobj) || !PyTuple_Check(indexobj)) {
-        multiter_allociters((PyArrayMultiIterObject *)mit, 1);
+        if (multiter_allociters((PyArrayMultiIterObject *)mit, 1) < 0) {
+            goto fail;
+        }
         indtype = PyArray_DescrFromType(NPY_INTP);
         arr = (PyArrayObject *)PyArray_FromAny(indexobj, indtype, 0, 0,
                                 NPY_ARRAY_FORCECAST, NULL);
@@ -2424,7 +2428,9 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
             totniters += numiters;
         }
         /* set up iters */
-        multiter_allociters((PyArrayMultiIterObject *)mit, totniters);
+        if (multiter_allociters((PyArrayMultiIterObject *)mit, totniters) < 0) {
+            goto fail;
+        }
         totniters = 0;
         for (i = 0; i < n; i++) {
             obj = PyTuple_GET_ITEM(indexobj,i);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1910,6 +1910,11 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
         return -1;
     }
     nd = PyArray_NDIM(ba);
+
+    if (iters == NULL) {
+        return nd;  /* just count iters needed */
+    }
+
     for (j = 0; j < nd; j++) {
         iters[j] = NULL;
     }
@@ -1998,7 +2003,7 @@ _convert_obj(PyObject *obj, PyArrayIterObject **iter)
     else if (PyArray_Check(obj) && PyArray_ISBOOL((PyArrayObject *)obj)) {
         return _nonzero_indices(obj, iter);
     }
-    else {
+    else if (iter != NULL) {
         indtype = PyArray_DescrFromType(NPY_INTP);
         arr = PyArray_FromAny(obj, indtype, 0, 0, NPY_ARRAY_FORCECAST, NULL);
         if (arr == NULL) {
@@ -2313,9 +2318,6 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
     if (mit == NULL) {
         return NULL;
     }
-    for (i = 0; i < NPY_MAXDIMS; i++) {
-        mit->iters[i] = NULL;
-    }
     mit->index = 0;
     mit->ait = NULL;
     mit->subspace = NULL;
@@ -2353,8 +2355,11 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
     /* convert all inputs to iterators */
     if (PyArray_Check(indexobj) &&
                     (PyArray_TYPE((PyArrayObject *)indexobj) == NPY_BOOL)) {
-        mit->numiter = _nonzero_indices(indexobj, mit->iters);
+        multiter_allociters((PyArrayMultiIterObject *)mit, _nonzero_indices(indexobj, NULL));
         if (mit->numiter < 0) {
+            goto fail;
+        }
+        if (_nonzero_indices(indexobj, mit->iters) < 0) {
             goto fail;
         }
         mit->nd = 1;
@@ -2369,7 +2374,7 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
         }
     }
     else if (PyArray_Check(indexobj) || !PyTuple_Check(indexobj)) {
-        mit->numiter = 1;
+        multiter_allociters((PyArrayMultiIterObject *)mit, 1);
         indtype = PyArray_DescrFromType(NPY_INTP);
         arr = (PyArrayObject *)PyArray_FromAny(indexobj, indtype, 0, 0,
                                 NPY_ARRAY_FORCECAST, NULL);
@@ -2393,7 +2398,7 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
         PyObject *obj;
         PyArrayIterObject **iterp;
         PyObject *new;
-        int numiters, j, n2;
+        int numiters, j, n2, totniters;
         /*
          * Make a copy of the tuple -- we will be replacing
          * index objects with 0's
@@ -2407,9 +2412,23 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
         started = 0;
         nonindex = 0;
         j = 0;
+        /* count iters */
+        totniters = 0;
         for (i = 0; i < n; i++) {
             obj = PyTuple_GET_ITEM(indexobj,i);
             iterp = mit->iters + mit->numiter;
+            if ((numiters=_convert_obj(obj, NULL)) < 0) {
+                Py_DECREF(new);
+                goto fail;
+            }
+            totniters += numiters;
+        }
+        /* set up iters */
+        multiter_allociters((PyArrayMultiIterObject *)mit, totniters);
+        totniters = 0;
+        for (i = 0; i < n; i++) {
+            obj = PyTuple_GET_ITEM(indexobj,i);
+            iterp = mit->iters + totniters;
             if ((numiters=_convert_obj(obj, iterp)) < 0) {
                 Py_DECREF(new);
                 goto fail;
@@ -2419,7 +2438,7 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
                 if (nonindex) {
                     mit->consec = 0;
                 }
-                mit->numiter += numiters;
+                totniters += numiters;
                 if (numiters == 1) {
                     PyTuple_SET_ITEM(new,j++, PyInt_FromLong(0));
                 }

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3144,6 +3144,16 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(chosen.mask, [1, 0, 0, 1])
 
 
+    def test_choose_big(self):
+        "Test choose with large number of choices"
+        choices = [[0, 1, 2, 3], [10, 11, 12, 13],
+                   [20, 21, 22, 23], [30, 31, 32, 33]]
+        n = 100
+        morechoices = choices * n
+        chosen = choose([2, 3, 1, 0], morechoices)
+        assert_equal(chosen, array([20, 31, 12, 3]))
+
+
     def test_choose_with_out(self):
         "Test choose with an explicit out keyword"
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],


### PR DESCRIPTION
Hi

This is some sort of fix for http://mail.scipy.org/pipermail/numpy-discussion/2011-July/057831.html.

(By the way, the test above runs pretty slowly because of constructing a big array from the inputs).

But after that, it seems to work.

Cheers

Ben
