### PR TITLE
Py3 warning fixes

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -258,6 +258,19 @@ npy_PyFile_OpenFile(PyObject *filename, char *mode)
     return PyObject_CallFunction(open, "Os", filename, mode);
 }
 
+static NPY_INLINE PyObject*
+npy_PyFile_CloseFile(PyObject *file)
+{
+    PyObject *ret;
+
+    ret = PyObject_CallMethod(file, "close", NULL);
+    if (ret == NULL) {
+        return -1;
+    }
+    Py_DECREF(ret);
+    return 0;
+}
+
 /*
  * PyObject_Cmp
  */

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -203,8 +203,10 @@ class memmap(ndarray):
 
         if hasattr(filename,'read'):
             fid = filename
+            own_file = False
         else:
             fid = open(filename, (mode == 'c' and 'r' or mode)+'b')
+            own_file = True
 
         if (mode == 'w+') and shape is None:
             raise ValueError("shape must be given")
@@ -262,6 +264,9 @@ class memmap(ndarray):
             self.filename = os.path.abspath(filename)
         elif hasattr(filename, "name"):
             self.filename = os.path.abspath(filename.name)
+
+        if own_file:
+            fid.close()
 
         return self
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2163,7 +2163,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     Py_ssize_t nin = -1;
     static char *kwlist[] = {"file", "dtype", "count", "sep", NULL};
     PyArray_Descr *type = NULL;
-    int ok, own;
+    int own;
     FILE *fp;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2159,12 +2159,12 @@ static PyObject *
 array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
 {
     PyObject *file = NULL, *ret;
-    int ok;
-    FILE *fp;
     char *sep = "";
     Py_ssize_t nin = -1;
     static char *kwlist[] = {"file", "dtype", "count", "sep", NULL};
     PyArray_Descr *type = NULL;
+    int ok, own;
+    FILE *fp;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,
                 "O|O&" NPY_SSIZE_T_PYFMT "s", kwlist,
@@ -2177,9 +2177,11 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
         if (file == NULL) {
             return NULL;
         }
+        own = 1;
     }
     else {
         Py_INCREF(file);
+        own = 0;
     }
     fp = npy_PyFile_Dup(file, "rb");
     if (fp == NULL) {
@@ -2192,13 +2194,20 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
         type = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
     ret = PyArray_FromFile(fp, type, (npy_intp) nin, sep);
-    ok = npy_PyFile_DupClose(file, fp);
-    Py_DECREF(file);
-    if (ok < 0) {
-        Py_DECREF(ret);
-        return NULL;
+
+    if (npy_PyFile_DupClose(file, fp) < 0) {
+        goto fail;
     }
+    if (own && npy_PyFile_CloseFile(file) < 0) {
+        goto fail;
+    }
+    Py_DECREF(file);
     return ret;
+
+fail:
+    Py_DECREF(file);
+    Py_DECREF(ret);
+    return NULL;
 }
 
 static PyObject *

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -43,6 +43,7 @@ class TestFromrecords(TestCase):
         r = np.rec.fromfile(fd, formats='f8,i4,a5', shape=3, byteorder='big')
         fd.seek(2880 * 2)
         r = np.rec.array(fd, formats='f8,i4,a5', shape=3, byteorder='big')
+        fd.close()
 
     def test_recarray_from_obj(self):
         count = 10

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -882,9 +882,13 @@ class TestRegression(TestCase):
         data_dir = path.join(path.dirname(__file__), 'data')
         filename = path.join(data_dir, "astype_copy.pkl")
         if sys.version_info[0] >= 3:
-            xp = pickle.load(open(filename, 'rb'), encoding='latin1')
+            f = open(filename, 'rb')
+            xp = pickle.load(f, encoding='latin1')
+            f.close()
         else:
-            xp = pickle.load(open(filename))
+            f = open(filename)
+            xp = pickle.load(f)
+            f.close()
         xpd = xp.astype(np.float64)
         assert_((xp.__array_interface__['data'][0] !=
                 xpd.__array_interface__['data'][0]))

--- a/numpy/linalg/tests/test_build.py
+++ b/numpy/linalg/tests/test_build.py
@@ -13,7 +13,8 @@ class FindDependenciesLdd(object):
         self.cmd = ['ldd']
 
         try:
-            st = call(self.cmd, stdout=PIPE, stderr=PIPE)
+            p = Popen(self.cmd, stdout=PIPE, stderr=PIPE)
+            stdout, stderr = p.communicate()
         except OSError:
             raise RuntimeError("command %s cannot be run" % self.cmd)
 


### PR DESCRIPTION
Python3  when run with  the "-W all" option complains about open files with reference count 0 like so

```
ResourceWarning: unclosed file
```

I suspect that this is just Python being helpful, but these patches explicitly close the relevant files before they go bye-bye. One warning, which seems to originate in nose, remains. These warnings were not present before the recent changes to the numpy.test warning levels.

These patches should probably be squashed into one before being merged to master.
