### PR TITLE
BUG: native but not '=' byte order error in lapack

### DIFF
--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -115,8 +115,7 @@ check_object(PyObject *ob, int t, char *obname,
                      "Parameter %s is not of type %s in lapack_lite.%s",
                      obname, tname, funname);
         return 0;
-    } else if (((PyArrayObject *)ob)->descr->byteorder != '=' &&
-               ((PyArrayObject *)ob)->descr->byteorder != '|') {
+    } else if (PyArray_ISBYTESWAPPED(ob)) {
         PyErr_Format(LapackError,
                      "Parameter %s has non-native byte order in lapack_lite.%s",
                      obname, funname);

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1,5 +1,6 @@
 """ Test functions for linalg module
 """
+import sys
 
 import numpy as np
 from numpy.testing import *
@@ -454,6 +455,23 @@ class TestQR(TestCase):
     def test_qr_empty(self):
         a = np.zeros((0,2))
         self.assertRaises(linalg.LinAlgError, linalg.qr, a)
+
+
+def test_byteorder_check():
+    # Byte order check should pass for native order
+    native_endian = '<' if sys.byteorder == 'little' else '>'
+    for dtt in (np.float32, np.float64):
+        arr = np.eye(4, dtype=dtt)
+        n_arr = arr.newbyteorder(native_endian)
+        sw_arr = arr.newbyteorder('S').byteswap()
+        assert_equal(arr.dtype.byteorder, '=')
+        for routine in (linalg.inv, linalg.det, linalg.pinv):
+            # Normal call
+            res = routine(arr)
+            # Native but not '='
+            assert_array_equal(res, routine(n_arr))
+            # Swapped
+            assert_array_equal(res, routine(sw_arr))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The check_object call in lapack_litemodule was checking if the passed
array was of byteorder '=' or '|', but this check failed for arrays of
specified native byte order ('<' on little-endian).
