### PR TITLE
FIX: Bug 2063

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1673,6 +1673,14 @@ class TestRegression(TestCase):
             a = np.array([u'abcd'])
         assert_equal(a.dtype.itemsize, 16)
 
+    def test_unique_stable(self):
+        # Ticket #2063 must always choose stable sort for argsort to
+        # get consistent results
+        v=np.array([0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2])
+        w=np.array([0,0,0,0,0,1,1,1,1,1,1,2,2,2,2])
+        resv = np.unique(v,return_index=True)
+        resw = np.unique(w,return_index=True)
+        assert_equal(resv, resw)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -112,8 +112,8 @@ def unique(ar, return_index=False, return_inverse=False):
     unique : ndarray
         The sorted unique values.
     unique_indices : ndarray, optional
-        The indices of the unique values in the (flattened) original array.
-        Only provided if `return_index` is True.
+        The indices of the first occurrences of the unique values in the 
+        (flattened) original array. Only provided if `return_index` is True.
     unique_inverse : ndarray, optional
         The indices to reconstruct the (flattened) original array from the
         unique array. Only provided if `return_inverse` is True.
@@ -174,12 +174,15 @@ def unique(ar, return_index=False, return_inverse=False):
             return ar
 
     if return_inverse or return_index:
-        perm = ar.argsort(kind='mergesort')
+        if return_index:
+            perm = ar.argsort(kind='mergesort')
+        else:
+            perm = ar.argsort()
         aux = ar[perm]
         flag = np.concatenate(([True], aux[1:] != aux[:-1]))
         if return_inverse:
             iflag = np.cumsum(flag) - 1
-            iperm = perm.argsort(kind='mergesort')
+            iperm = perm.argsort()
             if return_index:
                 return aux[flag], perm[flag], iflag[iperm]
             else:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -174,12 +174,12 @@ def unique(ar, return_index=False, return_inverse=False):
             return ar
 
     if return_inverse or return_index:
-        perm = ar.argsort()
+        perm = ar.argsort(kind='mergesort')
         aux = ar[perm]
         flag = np.concatenate(([True], aux[1:] != aux[:-1]))
         if return_inverse:
             iflag = np.cumsum(flag) - 1
-            iperm = perm.argsort()
+            iperm = perm.argsort(kind='mergesort')
             if return_index:
                 return aux[flag], perm[flag], iflag[iperm]
             else:


### PR DESCRIPTION
Here is a fix and a test for #2063. I wonder a bit about the space characteristics of mergesort, but np.in1d takes the same approach.
