### PR TITLE
Fix datetime endian

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1244,7 +1244,7 @@ PyArray_DescrConverter(PyObject *obj, PyArray_Descr **at)
             return (*at) ? NPY_SUCCEED : NPY_FAIL;
         }
 
-        /* Process the endian character */
+        /* Process the endian character. '|' is replaced by '='*/
         switch (type[0]) {
             case '>':
             case '<':
@@ -1375,8 +1375,8 @@ PyArray_DescrConverter(PyObject *obj, PyArray_Descr **at)
     }
 
 finish:
-    if ((check_num == NPY_NOTYPE + 10)
-        || (*at = PyArray_DescrFromType(check_num)) == NULL) {
+    if ((check_num == NPY_NOTYPE + 10) ||
+            (*at = PyArray_DescrFromType(check_num)) == NULL) {
         PyErr_Clear();
         /* Now check to see if the object is registered in typeDict */
         if (typeDict != NULL) {
@@ -1414,11 +1414,12 @@ finish:
 
 fail:
     if (PyBytes_Check(obj)) {
-        PyErr_Format(PyExc_TypeError, "data type \"%s\" not understood",
-                            PyBytes_AS_STRING(obj));
+        PyErr_Format(PyExc_TypeError,
+                "data type \"%s\" not understood", PyBytes_AS_STRING(obj));
     }
     else {
-        PyErr_SetString(PyExc_TypeError, "data type not understood");
+        PyErr_SetString(PyExc_TypeError,
+                "data type not understood");
     }
 
 error:

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1269,7 +1269,14 @@ PyArray_DescrConverter(PyObject *obj, PyArray_Descr **at)
         /* Check for datetime format */
         if (is_datetime_typestr(type, len)) {
             *at = parse_dtype_from_datetime_typestr(type, len);
-            return (*at) ? NPY_SUCCEED : NPY_FAIL;
+            if (*at == NULL) {
+                return NPY_FAIL;
+            }
+            /* *at has byte order '=' at this point */
+            if (!PyArray_ISNBO(endian)) {
+                (*at)->byteorder = endian;
+            }
+            return NPY_SUCCEED;
         }
 
         /* A typecode like 'd' */

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -25,6 +25,7 @@ class TestDateTime(TestCase):
                 np.dtype("<M8") == np.dtype("M8"))
         assert_(np.dtype(">M8[D]") == np.dtype("M8[D]") or
                 np.dtype("<M8[D]") == np.dtype("M8[D]"))
+        assert_(np.dtype(">M8") != np.dtype("<M8"))
 
         assert_equal(np.dtype("=m8"), np.dtype("m8"))
         assert_equal(np.dtype("=m8[s]"), np.dtype("m8[s]"))
@@ -32,6 +33,7 @@ class TestDateTime(TestCase):
                 np.dtype("<m8") == np.dtype("m8"))
         assert_(np.dtype(">m8[D]") == np.dtype("m8[D]") or
                 np.dtype("<m8[D]") == np.dtype("m8[D]"))
+        assert_(np.dtype(">m8") != np.dtype("<m8"))
 
         # Check that the parser rejects bad datetime types
         assert_raises(TypeError, np.dtype, 'M8[badunit]')


### PR DESCRIPTION
The datetime and timedelta dtype constructor was ignoring the byte order specifier. This fixes that and should get rid of several test errors on SPARC. Fixes ticket #2086.
