### PR TITLE
MAINT: explicitly check for NaNs in allclose().  Closes #1905.

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1969,6 +1969,10 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     `atol` are added together to compare against the absolute difference
     between `a` and `b`.
 
+    If either array contains one or more NaNs, False is returned.
+    Infs are treated as equal if they are in the same place and of the same
+    sign in both arrays.
+
     Parameters
     ----------
     a, b : array_like
@@ -1982,8 +1986,7 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     -------
     allclose : bool
         Returns True if the two arrays are equal within the given
-        tolerance; False otherwise. If either array contains NaN, then
-        False is returned.
+        tolerance; False otherwise.
 
     See Also
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2012,26 +2012,26 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     False
 
     """
-    def within_tol(x, y, atol, rtol):
-        err = seterr(invalid='ignore')
-        try:
-            result = less_equal(abs(x-y), atol + rtol * abs(y))
-        finally:
-            seterr(**err)
-        return result
-
     x = array(a, copy=False, ndmin=1)
     y = array(b, copy=False, ndmin=1)
+
+    if any(isnan(x)) or any(isnan(y)):
+        return False
+
     xinf = isinf(x)
-    if not all(xinf == isinf(y)):
-        return False
-    if not any(xinf):
-        return all(within_tol(x, y, atol, rtol))
-    if not all(x[xinf] == y[xinf]):
-        return False
-    x = x[~xinf]
-    y = y[~xinf]
-    return all(within_tol(x, y, atol, rtol))
+    yinf = isinf(y)
+    if any(xinf) or any(yinf):
+        # Check that x and y have inf's only in the same positions
+        if not all(xinf == yinf):
+            return False
+        # Check that sign of inf's in x and y is the same
+        if not all(x[xinf] == y[xinf]):
+            return False
+
+        x = x[~xinf]
+        y = y[~xinf]
+
+    return all(less_equal(abs(x-y), atol + rtol * abs(y)))
 
 def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """


### PR DESCRIPTION
Also clean up the logic behind handling infs.

The removed seterr call becomes unnecessary when explicitly checking for NaNs.
It was introduced only recently in c4c0e985.
