### PR TITLE
IPython recarray auto-complete

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -804,3 +804,20 @@ def array(obj, dtype=None, shape=None, offset=0, strides=None, formats=None,
         if issubclass(res.dtype.type, nt.void):
             res.dtype = sb.dtype((record, res.dtype))
         return res
+
+def install_ipython_completers():
+    """Register the recarray type with IPython's tab completion machinery, so
+    that it knows about accessing column names as attributes."""
+    from IPython.utils.generics import complete_object
+
+    @complete_object.when_type(recarray)
+    def complete_recarray_colname(obj, prev_completions):
+        return prev_completions + list(obj.dtype.names)
+
+# Importing IPython brings in about 200 modules, so we want to avoid it unless
+# we're in IPython (when those modules are loaded anyway).
+if "IPython" in sys.modules:
+    try:
+        install_ipython_completers()
+    except Exception:
+        pass


### PR DESCRIPTION
This PR should be very very useful for those doing data analysis in iPython. When users create a recarray, they probably do not want to remember the field names, especially when the recarray comes out from automagic function like pylab's[csv2rec](http://matplotlib.sourceforge.net/api/mlab_api.html#matplotlib.mlab.csv2rec).

Here is some example (in ipython)

``` python
import numpy as np
r = array([(1.5, 2.5), (3.0, 4.0), (1.0, 3.0)],dtype=[('xxx', '<f4'), ('yyy', '<f4')]).view(np.recarray)
r.<TAB>
```

The tab auto complete will have xxx and yyy in the list.

The changes silently ignore if it couldn't add the tab completion to ipython and it will not import IPython unnecessarily. I copied this shamelessly from [here](https://github.com/pydata/pandas/blob/master/pandas/core/frame.py#L4377).
