### PR TITLE
ENH: Give digitize left or right open interval option

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4884,11 +4884,11 @@ add_newdoc('numpy.lib._compiled_base', 'digitize',
     bins : array_like
         Array of bins. It has to be 1-dimensional and monotonic.
     right : bool, optional
-        Indicating whether the intervals include the right or the left bin.
-        Default behavior is (right==False) indicating that the interval
-        includes the left bin and is open on the right. Ie.,
-        bins[i-1] <= x < bins[i] is the default behavior for monotonically
-        increasing bins.
+        Indicating whether the intervals include the right or the left bin
+        edge. Default behavior is (right==False) indicating that the interval
+        does not include the right edge. The left bin and is open in this
+        case. Ie., bins[i-1] <= x < bins[i] is the default behavior for
+        monotonically increasing bins.
 
     Returns
     -------
@@ -4927,6 +4927,12 @@ add_newdoc('numpy.lib._compiled_base', 'digitize',
     2.5 <= 3.0 < 4.0
     1.0 <= 1.6 < 2.5
 
+    >>> x = np.array([1.2, 10.0, 12.4, 15.5, 20.])
+    >>> bins = np.array([0,5,10,15,20])
+    >>> np.digitize(x,bins,right=True)
+    array([1, 2, 3, 4, 4])
+    >>> np.digitize(x,bins,right=False)
+    array([1, 3, 3, 4, 5])
     """)
 
 add_newdoc('numpy.lib._compiled_base', 'bincount',

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4865,14 +4865,17 @@ add_newdoc('numpy.core.umath', 'seterrobj',
 
 add_newdoc('numpy.lib._compiled_base', 'digitize',
     """
-    digitize(x, bins)
+    digitize(x, bins, right=False)
 
     Return the indices of the bins to which each value in input array belongs.
 
     Each index ``i`` returned is such that ``bins[i-1] <= x < bins[i]`` if
     `bins` is monotonically increasing, or ``bins[i-1] > x >= bins[i]`` if
     `bins` is monotonically decreasing. If values in `x` are beyond the
-    bounds of `bins`, 0 or ``len(bins)`` is returned as appropriate.
+    bounds of `bins`, 0 or ``len(bins)`` is returned as appropriate. If right
+    is True, then the right bin is closed so that the index ``i`` is such
+    that ``bins[i-1] < x <= bins[i]`` or bins[i-1] >= x > bins[i]`` if `bins`
+    is monotonically increasing or decreasing, respectively.
 
     Parameters
     ----------
@@ -4880,6 +4883,12 @@ add_newdoc('numpy.lib._compiled_base', 'digitize',
         Input array to be binned. It has to be 1-dimensional.
     bins : array_like
         Array of bins. It has to be 1-dimensional and monotonic.
+    right : bool, optional
+        Indicating whether the intervals include the right or the left bin.
+        Default behavior is (right==False) indicating that the interval
+        includes the left bin and is open on the right. Ie.,
+        bins[i-1] <= x < bins[i] is the default behavior for monotonically
+        increasing bins.
 
     Returns
     -------

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -191,10 +191,10 @@ class TestCumsum(TestCase):
 
             tgt =  np.array([1, 3, 13, 24, 30, 35, 39], ctype)
             assert_array_equal(np.cumsum(a, axis=0), tgt)
-            
+
             tgt = np.array([[1, 2, 3, 4], [6, 8, 10, 13], [16, 11, 14, 18]], ctype)
             assert_array_equal(np.cumsum(a2, axis=0), tgt)
-            
+
             tgt = np.array([[1, 3, 6, 10], [5, 11, 18, 27], [10, 13, 17, 22]], ctype)
             assert_array_equal(np.cumsum(a2, axis=1), tgt)
 
@@ -429,19 +429,27 @@ class TestDigitize(TestCase):
         bin = np.linspace(x.min(), x.max(), 10)
         assert_(np.all(digitize(x, bin) != 0))
 
+    def test_right_basic(self):
+        x = [1,5,4,10,8,11,0]
+        bins = [1,5,10]
+        default_answer = [1,2,1,3,2,3,0]
+        assert_array_equal(digitize(x, bins), default_answer)
+        right_answer = [0,1,1,2,2,3,0]
+        assert_array_equal(digitize(x, bins, True), right_answer)
+
     def test_right_open(self):
-        x = arange(-6, 5)
-        bins = arange(-6, 4)
-        assert_array_equal(digitize(x,bins,True), arange(11))
+        x = np.arange(-6, 5)
+        bins = np.arange(-6, 4)
+        assert_array_equal(digitize(x,bins,True), np.arange(11))
 
     def test_right_open_reverse(self):
-        x = arange(5, -6, -1)
-        bins = arange(4, -6, -1)
-        assert_array_equal(digitize(x, bins, True), arange(11))
+        x = np.arange(5, -6, -1)
+        bins = np.arange(4, -6, -1)
+        assert_array_equal(digitize(x, bins, True), np.arange(11))
 
     def test_right_open_random(self):
         x = rand(10)
-        bins = linspace(x.min(), x.max(), 10)
+        bins = np.linspace(x.min(), x.max(), 10)
         assert_(all(digitize(x, bins, True) != 10))
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -429,6 +429,21 @@ class TestDigitize(TestCase):
         bin = np.linspace(x.min(), x.max(), 10)
         assert_(np.all(digitize(x, bin) != 0))
 
+    def test_right_open(self):
+        x = arange(-6, 5)
+        bins = arange(-6, 4)
+        assert_array_equal(digitize(x,bins,True), arange(11))
+
+    def test_right_open_reverse(self):
+        x = arange(5, -6, -1)
+        bins = arange(4, -6, -1)
+        assert_array_equal(digitize(x, bins, True), arange(11))
+
+    def test_right_open_random(self):
+        x = rand(10)
+        bins = linspace(x.min(), x.max(), 10)
+        assert_(all(digitize(x, bins, True) != 10))
+
 
 class TestUnwrap(TestCase):
     def test_simple(self):


### PR DESCRIPTION
Adds an option to have the left side interval open for bins given to digitize instead of hard-coding the right.
