### PR TITLE
BUG: Fix segfault when tests are run with python 2.7 debug.

### DIFF
--- a/numpy/core/src/multiarray/na_mask.c
+++ b/numpy/core/src/multiarray/na_mask.c
@@ -361,7 +361,7 @@ PyArray_AllocateMaskNA(PyArrayObject *arr,
     }
 
     /* Allocate the mask memory */
-    maskna_data = PyArray_malloc(size * maskna_dtype->elsize);
+    maskna_data = PyDataMem_NEW(size * maskna_dtype->elsize);
     if (maskna_data == NULL) {
         Py_DECREF(maskna_dtype);
         PyErr_NoMemory();

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1692,5 +1692,10 @@ class TestRegression(TestCase):
         a = np.array(['abc'], dtype=np.unicode)[0]
         del a
 
+    def test_maskna_deallocation(self):
+        # This caused a segfault when running under python-debug
+        a = np.array([1]).view(maskna=True)
+        del a
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
I don't know that the crash is python2.7 specific, it may also occur
in earlier versions of python. The cause was mismatched memory
allocation/deallocation of maskna data.

I'd put this one line fix in directly but, while I think PyDataMem_NEW is the right choice, it needs review. The other option is to change the deallocation type.
