### PR TITLE
TST: filter ImportWarnings in NoseTester.

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -360,6 +360,9 @@ class NoseTester(object):
             # If deprecation warnings are not set to 'error' below,
             # at least set them to 'warn'.
             warnings.filterwarnings('always', category=DeprecationWarning)
+            warnings.filterwarnings('ignore',
+                                    message='Not importing directory',
+                                    category=ImportWarning)
             # Force the requested warnings to raise
             for warningtype in raise_warnings:
                 warnings.filterwarnings('error', category=warningtype)


### PR DESCRIPTION
Warnings show up when a directory with the same name as a Python file or
compiled extension is seen which doesn't have an **init**.py file in it.  This
situation is very common, for example in SciPy where many extensions are
created from source files located under a directory with the same name.

This filter is located within a context manager, so only filters when running
tests.

See thread http://mail.python.org/pipermail/python-dev/2006-June/066364.html for history.
