### PR TITLE
Backport build fixes to 1.6.x

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -58,7 +58,11 @@ def CCompiler_spawn(self, cmd, display=None):
     if s:
         if is_sequence(cmd):
             cmd = ' '.join(list(cmd))
-        print(o)
+        try:
+            print(o)
+        except UnicodeError:
+            # When installing through pip, `o` can contain non-ascii chars
+            pass
         if re.search('Too many open files', o):
             msg = '\nTry rerunning setup command until build succeeds.'
         else:

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -81,21 +81,23 @@ class build_clib(old_build_clib):
 
         if self.have_f_sources():
             from numpy.distutils.fcompiler import new_fcompiler
-            self.fcompiler = new_fcompiler(compiler=self.fcompiler,
-                                           verbose=self.verbose,
-                                           dry_run=self.dry_run,
-                                           force=self.force,
-                                           requiref90='f90' in languages,
-                                           c_compiler=self.compiler)
-            if self.fcompiler is not None:
-                self.fcompiler.customize(self.distribution)
+            self._f_compiler = new_fcompiler(compiler=self.fcompiler,
+                                               verbose=self.verbose,
+                                               dry_run=self.dry_run,
+                                               force=self.force,
+                                               requiref90='f90' in languages,
+                                               c_compiler=self.compiler)
+            if self._f_compiler is not None:
+                self._f_compiler.customize(self.distribution)
 
                 libraries = self.libraries
                 self.libraries = None
-                self.fcompiler.customize_cmd(self)
+                self._f_compiler.customize_cmd(self)
                 self.libraries = libraries
 
-                self.fcompiler.show_customization()
+                self._f_compiler.show_customization()
+        else:
+            self._f_compiler = None
 
         self.build_libraries(self.libraries)
 
@@ -121,7 +123,7 @@ class build_clib(old_build_clib):
     def build_a_library(self, build_info, lib_name, libraries):
         # default compilers
         compiler = self.compiler
-        fcompiler = self.fcompiler
+        fcompiler = self._f_compiler
 
         sources = build_info.get('sources')
         if sources is None or not is_sequence(sources):
@@ -233,7 +235,7 @@ class build_clib(old_build_clib):
                                                debug=self.debug,
                                                extra_postargs=extra_postargs)
 
-            if requiref90 and self.fcompiler.module_dir_switch is None:
+            if requiref90 and self._f_compiler.module_dir_switch is None:
                 # move new compiled F90 module files to module_build_dir
                 for f in glob('*.mod'):
                     if f in existing_modules:

--- a/numpy/distutils/fcompiler/hpux.py
+++ b/numpy/distutils/fcompiler/hpux.py
@@ -9,17 +9,17 @@ class HPUXFCompiler(FCompiler):
     version_pattern =  r'HP F90 (?P<version>[^\s*,]*)'
 
     executables = {
-        'version_cmd'  : ["<F90>", "+version"],
+        'version_cmd'  : ["f90", "+version"],
         'compiler_f77' : ["f90"],
         'compiler_fix' : ["f90"],
         'compiler_f90' : ["f90"],
-        'linker_so'    : None,
+        'linker_so'    : ["ld", "-b"],
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"]
         }
     module_dir_switch = None #XXX: fix me
     module_include_switch = None #XXX: fix me
-    pic_flags = ['+pic=long']
+    pic_flags = ['+Z']
     def get_flags(self):
         return self.pic_flags + ['+ppu', '+DD64']
     def get_flags_opt(self):

--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -12,7 +12,7 @@ compilers = ['IBMFCompiler']
 class IBMFCompiler(FCompiler):
     compiler_type = 'ibm'
     description = 'IBM XL Fortran Compiler'
-    version_pattern =  r'(xlf\(1\)\s*|)IBM XL Fortran ((Advanced Edition |)Version |Enterprise Edition V)(?P<version>[^\s*]*)'
+    version_pattern =  r'(xlf\(1\)\s*|)IBM XL Fortran ((Advanced Edition |)Version |Enterprise Edition V|for AIX, V)(?P<version>[^\s*]*)'
     #IBM XL Fortran Enterprise Edition V10.1 for AIX \nVersion: 10.01.0000.0004
 
     executables = {

--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -86,7 +86,7 @@ class IBMFCompiler(FCompiler):
         return opt
 
     def get_flags_opt(self):
-        return ['-O5']
+        return ['-O3']
 
 if __name__ == '__main__':
     log.set_verbosity(2)

--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -10,14 +10,14 @@ class PGroupFCompiler(FCompiler):
 
     compiler_type = 'pg'
     description = 'Portland Group Fortran Compiler'
-    version_pattern =  r'\s*pg(f77|f90|hpf) (?P<version>[\d.-]+).*'
+    version_pattern =  r'\s*pg(f77|f90|hpf|fortran) (?P<version>[\d.-]+).*'
 
     if platform == 'darwin':
         executables = {
-        'version_cmd'  : ["<F77>", "-V 2>/dev/null"],
-        'compiler_f77' : ["pgf77", "-dynamiclib"],
-        'compiler_fix' : ["pgf90", "-Mfixed", "-dynamiclib"],
-        'compiler_f90' : ["pgf90", "-dynamiclib"],
+        'version_cmd'  : ["<F77>", "-V"],
+        'compiler_f77' : ["pgfortran", "-dynamiclib"],
+        'compiler_fix' : ["pgfortran", "-Mfixed", "-dynamiclib"],
+        'compiler_f90' : ["pgfortran", "-dynamiclib"],
         'linker_so'    : ["libtool"],
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"]
@@ -25,11 +25,11 @@ class PGroupFCompiler(FCompiler):
         pic_flags = ['']
     else:
         executables = {
-        'version_cmd'  : ["<F77>", "-V 2>/dev/null"],
-        'compiler_f77' : ["pgf77"],
-        'compiler_fix' : ["pgf90", "-Mfixed"],
-        'compiler_f90' : ["pgf90"],
-        'linker_so'    : ["pgf90","-shared","-fpic"],
+        'version_cmd'  : ["<F77>", "-V"],
+        'compiler_f77' : ["pgfortran"],
+        'compiler_fix' : ["pgfortran", "-Mfixed"],
+        'compiler_f90' : ["pgfortran"],
+        'linker_so'    : ["pgfortran","-shared","-fpic"],
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"]
         }

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -194,6 +194,8 @@ else:
                                  '/opt/local/lib','/sw/lib'], platform_bits)
     default_include_dirs = ['/usr/local/include',
                             '/opt/include', '/usr/include',
+                            # path of umfpack under macports
+                            '/opt/local/include/ufsparse',
                             '/opt/local/include', '/sw/include',
                             '/usr/include/suitesparse']
     default_src_dirs = ['.','/usr/local/src', '/opt/src','/sw/src']

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -197,11 +197,18 @@ else:
                             '/opt/local/include', '/sw/include',
                             '/usr/include/suitesparse']
     default_src_dirs = ['.','/usr/local/src', '/opt/src','/sw/src']
-
     default_x11_lib_dirs = libpaths(['/usr/X11R6/lib','/usr/X11/lib',
                                      '/usr/lib'], platform_bits)
     default_x11_include_dirs = ['/usr/X11R6/include','/usr/X11/include',
                                 '/usr/include']
+    if os.path.exists('/usr/lib/X11'):
+        globbed_x11_dir = glob('/usr/lib/*/libX11.so')
+        if globbed_x11_dir:
+            x11_so_dir = os.path.split(globbed_x11_dir[0])[0]
+            default_x11_lib_dirs.extend([x11_so_dir, '/usr/lib/X11'])
+            default_x11_include_dirs.extend(['/usr/lib/X11/include',
+                                             '/usr/include/X11'])
+
 
 if os.path.join(sys.prefix, 'lib') not in default_lib_dirs:
     default_lib_dirs.insert(0,os.path.join(sys.prefix, 'lib'))

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -125,6 +125,7 @@ from distutils.errors import DistutilsError
 from distutils.dist import Distribution
 import distutils.sysconfig
 from distutils import log
+from distutils.util import get_platform
 
 from numpy.distutils.exec_command import \
     find_executable, exec_command, get_pythonexe
@@ -1273,7 +1274,6 @@ Make sure that -lgfortran is used for C++ extensions.
     result = _cached_atlas_version[key] = atlas_version, info
     return result
 
-from distutils.util import get_platform
 
 class lapack_opt_info(system_info):
 
@@ -1284,7 +1284,8 @@ class lapack_opt_info(system_info):
         if sys.platform=='darwin' and not os.environ.get('ATLAS',None):
             args = []
             link_args = []
-            if get_platform()[-4:] == 'i386':
+            if get_platform()[-4:] == 'i386' or 'intel' in get_platform() or \
+                'i386' in platform.platform():
                 intel = 1
             else:
                 intel = 0
@@ -1371,7 +1372,8 @@ class blas_opt_info(system_info):
         if sys.platform=='darwin' and not os.environ.get('ATLAS',None):
             args = []
             link_args = []
-            if get_platform()[-4:] == 'i386':
+            if get_platform()[-4:] == 'i386' or 'intel' in get_platform() or \
+                'i386' in platform.platform():
                 intel = 1
             else:
                 intel = 0

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -17,6 +17,18 @@ else:
 # Note that UnixCCompiler._compile appeared in Python 2.3
 def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
     """Compile a single source files with a Unix-style compiler."""
+    # HP ad-hoc fix, see ticket 1383
+    ccomp = self.compiler_so
+    if ccomp[0] == 'aCC':
+        # remove flags that will trigger ANSI-C mode for aCC
+        if '-Ae' in ccomp:
+            ccomp.remove('-Ae')
+        if '-Aa' in ccomp:
+            ccomp.remove('-Aa')
+        # add flags for (almost) sane C++ handling
+        ccomp += ['-AA']
+        self.compiler_so = ccomp
+
     display = '%s: %s' % (os.path.basename(self.compiler_so[0]),src)
     try:
         self.spawn(self.compiler_so + cc_args + [src, '-o', obj] +

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,12 @@ if not release:
         GIT_REVISION = git_version()
     elif os.path.exists('numpy/version.py'):
         # must be a source distribution, use existing version file
-        from numpy.version import git_revision as GIT_REVISION
+        try:
+            from numpy.version import git_revision as GIT_REVISION
+        except ImportError:
+            raise ImportError("Unable to import git_revision. Try removing " \
+                              "numpy/version.py and the build directory " \
+                              "before building.")
     else:
         GIT_REVISION = "Unknown"
 

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,19 @@ def setup_package():
         if os.path.isfile(site_cfg):
             shutil.copy(site_cfg, src_path)
 
+        # Ugly hack to make pip work with Python 3, see #1857.
+        # Explanation: pip messes with __file__ which interacts badly with the
+        # change in directory due to the 2to3 conversion.  Therefore we restore
+        # __file__ to what it would have been otherwise.
+        global __file__
+        __file__ = os.path.join(os.curdir, os.path.basename(__file__))
+        if '--egg-base' in sys.argv:
+            # Change pip-egg-info entry to absolute path, so pip can find it
+            # after changing directory.
+            idx = sys.argv.index('--egg-base')
+            if sys.argv[idx + 1] == 'pip-egg-info':
+                sys.argv[idx + 1] = os.path.join(local_path, 'pip-egg-info')
+
     old_path = os.getcwd()
     os.chdir(src_path)
     sys.path.insert(0, src_path)


### PR DESCRIPTION
These commits should cover most of what's to be backported for the 1.6.2. release related to build issues. I selected from the union of outputs from 

```
$ git log --grep=BLD* 1.6.x..master
$ git log  1.6.x..master -- numpy/distutils/
```
