### PR TITLE
Backport lib

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -335,11 +335,11 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
             Found bin edge of size <= 0. Did you specify `bins` with
             non-monotonic sequence?""")
 
+    nbin =  asarray(nbin)
+
     # Handle empty input.
     if N == 0:
-        return np.zeros(D), edges
-
-    nbin =  asarray(nbin)
+        return np.zeros(nbin-2), edges
 
     # Compute the bin number each sample falls into.
     Ncount = {}

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -765,6 +765,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             # End of lines reached
             first_line = ''
             first_vals = []
+            warnings.warn('loadtxt: Empty input file: "%s"' % fname)
         N = len(usecols or first_vals)
 
         dtype_types, packing = flatten_dtype(dtype)
@@ -1299,8 +1300,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                     first_line = asbytes('').join(first_line.split(comments)[1:])
             first_values = split_line(first_line)
     except StopIteration:
-        # might want to return empty array instead of raising error.
-        raise IOError('End-of-file reached before encountering data.')
+        # return an empty array if the datafile is empty
+        first_line = asbytes('')
+        first_values = []
+        warnings.warn('genfromtxt: Empty input file: "%s"' % fname)
 
     # Should we take the first values as names ?
     if names is True:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -9,6 +9,7 @@ import os
 import sys
 import itertools
 import warnings
+import weakref
 from operator import itemgetter
 
 from cPickle import load as _cload, loads
@@ -107,7 +108,8 @@ class BagObj(object):
 
     """
     def __init__(self, obj):
-        self._obj = obj
+        # Use weakref to make NpzFile objects collectable by refcount
+        self._obj = weakref.proxy(obj)
     def __getattribute__(self, key):
         try:
             return object.__getattribute__(self, '_obj')[key]
@@ -205,6 +207,7 @@ class NpzFile(object):
         if self.fid is not None:
             self.fid.close()
             self.fid = None
+        self.f = None # break reference cycle
 
     def __del__(self):
         self.close()

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "structmember.h"
 #include "numpy/noprefix.h"
+#include "numpy/npy_3kcompat.h"
 #include "npy_config.h"
 
 static intp
@@ -1109,8 +1110,8 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
     docstr = PyString_AS_STRING(str);
 #endif
 
-#define _TESTDOC1(typebase) (obj->ob_type == &Py##typebase##_Type)
-#define _TESTDOC2(typebase) (obj->ob_type == Py##typebase##_TypePtr)
+#define _TESTDOC1(typebase) (Py_TYPE(obj) == &Py##typebase##_Type)
+#define _TESTDOC2(typebase) (Py_TYPE(obj) == Py##typebase##_TypePtr)
 #define _ADDDOC(typebase, doc, name) do {                               \
         Py##typebase##Object *new = (Py##typebase##Object *)obj;        \
         if (!(doc)) {                                                   \
@@ -1310,8 +1311,8 @@ pack_or_unpack_bits(PyObject *input, int axis, int unpack)
             new = temp;
         }
         else {
-            ubyte *optr, *iptr;
-            out = PyArray_New(new->ob_type, 0, NULL, NPY_UBYTE,
+            char *optr, *iptr;
+            out = (PyArrayObject *)PyArray_New(Py_TYPE(new), 0, NULL, NPY_UBYTE,
                     NULL, NULL, 0, 0, NULL);
             if (out == NULL) {
                 goto fail;
@@ -1351,8 +1352,9 @@ pack_or_unpack_bits(PyObject *input, int axis, int unpack)
     }
 
     /* Create output array */
-    out = PyArray_New(new->ob_type, PyArray_NDIM(new), outdims, PyArray_UBYTE,
-            NULL, NULL, 0, PyArray_ISFORTRAN(new), NULL);
+    out = (PyArrayObject *)PyArray_New(Py_TYPE(new),
+                        PyArray_NDIM(new), outdims, NPY_UBYTE,
+                        NULL, NULL, 0, PyArray_ISFORTRAN(new), NULL);
     if (out == NULL) {
         goto fail;
     }
@@ -1450,17 +1452,17 @@ define_types(void)
     if (myobj == NULL) {
         return;
     }
-    PyGetSetDescr_TypePtr = myobj->ob_type;
+    PyGetSetDescr_TypePtr = Py_TYPE(myobj);
     myobj = PyDict_GetItemString(tp_dict, "alignment");
     if (myobj == NULL) {
         return;
     }
-    PyMemberDescr_TypePtr = myobj->ob_type;
+    PyMemberDescr_TypePtr = Py_TYPE(myobj);
     myobj = PyDict_GetItemString(tp_dict, "newbyteorder");
     if (myobj == NULL) {
         return;
     }
-    PyMethodDescr_TypePtr = myobj->ob_type;
+    PyMethodDescr_TypePtr = Py_TYPE(myobj);
     return;
 }
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1100,6 +1100,17 @@ class TestBincount(TestCase):
         y = np.bincount(x, w, 8)
         assert_array_equal(y, np.array([0, 0.2, 0.5, 0, 0.5, 0.1, 0, 0]))
 
+    def test_empty(self):
+        x = np.array([], dtype=int)
+        y = np.bincount(x)
+        assert_array_equal(x,y)
+
+    def test_empty_with_minlength(self):
+        x = np.array([], dtype=int)
+        y = np.bincount(x, minlength=5)
+        assert_array_equal(y, np.zeros(5, dtype=int))
+
+
 class TestInterp(TestCase):
     def test_exceptions(self):
         assert_raises(ValueError, interp, 0, [], [])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -749,7 +749,10 @@ class TestHistogramdd(TestCase):
 
     def test_empty(self):
         a, b = histogramdd([[], []], bins=([0,1], [0,1]))
-        assert_array_max_ulp(a, array([ 0., 0.]))
+        assert_array_max_ulp(a, array([[ 0.]]))
+        a, b = np.histogramdd([[], [], []], bins=2)
+        assert_array_max_ulp(a, np.zeros((2, 2, 2)))
+
 
     def test_bins_errors(self):
         """There are two ways to specify bins. Check for the right errors when

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -428,6 +428,7 @@ class TestLoadTxt(TestCase):
         assert_array_equal(x, a)
 
     def test_empty_file(self):
+        warnings.filterwarnings("ignore", message="loadtxt: Empty input file:")
         c = StringIO()
         x = np.loadtxt(c)
         assert_equal(x.shape, (0,))
@@ -987,11 +988,17 @@ M   33  21.99
                              usecols=('a', 'c'), **kwargs)
         assert_equal(test, ctrl)
 
-
     def test_empty_file(self):
-        "Test that an empty file raises the proper exception"
-        data = StringIO()
-        assert_raises(IOError, np.ndfromtxt, data)
+        "Test that an empty file raises the proper warning."
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.filterwarnings("ignore", message="genfromtxt: Empty input file:")
+            data = StringIO()
+            test = np.genfromtxt(data)
+            assert_equal(test, np.array([]))
+        finally:
+            warn_ctx.__exit__()
 
 
     def test_fancy_dtype_alt(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.ma as ma
 from numpy.ma.testutils import (TestCase, assert_equal, assert_array_equal,
     assert_raises, run_module_suite)
-from numpy.testing import assert_warns, assert_
+from numpy.testing import assert_warns, assert_, build_err_msg
 
 import sys
 
@@ -253,7 +253,7 @@ class TestSaveTxt(TestCase):
         np.savetxt(c, a, fmt=' %+.3e')
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, asbytes_nested([
+        _assert_floatstr_lines_equal(lines, asbytes_nested([
             ' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n',
             ' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n']))
         # One format for each real and imaginary part
@@ -261,7 +261,7 @@ class TestSaveTxt(TestCase):
         np.savetxt(c, a, fmt='  %+.3e' * 2 * ncols)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, asbytes_nested([
+        _assert_floatstr_lines_equal(lines, asbytes_nested([
             '  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n',
             '  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n']))
         # One format for each complex number
@@ -269,10 +269,29 @@ class TestSaveTxt(TestCase):
         np.savetxt(c, a, fmt=['(%.3e%+.3ej)'] * ncols)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, asbytes_nested([
+        _assert_floatstr_lines_equal(lines, asbytes_nested([
             '(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n',
             '(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n']))
 
+
+def _assert_floatstr_lines_equal(actual_lines, expected_lines):
+    """A string comparison function that also works on Windows + Python 2.5.
+
+    This is necessary because Python 2.5 on Windows inserts an extra 0 in
+    the exponent of the string representation of floating point numbers.
+
+    Only used in TestSaveTxt.test_complex_arrays, no attempt made to make this
+    more generic.
+
+    Once Python 2.5 compatibility is dropped, simply use `assert_equal` instead
+    of this function.
+    """
+    for actual, expected in zip(actual_lines, expected_lines):
+        if actual != expected:
+            expected_win25 = expected.replace("e+00", "e+000")
+            if actual != expected_win25:
+                msg = build_err_msg([actual, expected], '', verbose=True)
+                raise AssertionError(msg)
 
 
 class TestLoadTxt(TestCase):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -241,6 +241,39 @@ class TestSaveTxt(TestCase):
         finally:
             os.unlink(name)
 
+    def test_complex_arrays(self):
+        ncols = 2
+        nrows = 2
+        a = np.zeros((ncols, nrows), dtype=np.complex128)
+        re = np.pi
+        im = np.e
+        a[:] = re + 1.0j * im
+        # One format only
+        c = StringIO()
+        np.savetxt(c, a, fmt=' %+.3e')
+        c.seek(0)
+        lines = c.readlines()
+        assert_equal(lines, asbytes_nested([
+            ' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n',
+            ' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n']))
+        # One format for each real and imaginary part
+        c = StringIO()
+        np.savetxt(c, a, fmt='  %+.3e' * 2 * ncols)
+        c.seek(0)
+        lines = c.readlines()
+        assert_equal(lines, asbytes_nested([
+            '  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n',
+            '  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n']))
+        # One format for each complex number
+        c = StringIO()
+        np.savetxt(c, a, fmt=['(%.3e%+.3ej)'] * ncols)
+        c.seek(0)
+        lines = c.readlines()
+        assert_equal(lines, asbytes_nested([
+            '(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n',
+            '(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n']))
+
+
 
 class TestLoadTxt(TestCase):
     def test_record(self):

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -169,10 +169,6 @@ class TestRegression(TestCase):
             sys.stdout.close()
             sys.stdout = oldstdout
 
-    def test_bincount_empty(self):
-        """Ticket #1387: empty array as input for bincount."""
-        assert_raises(ValueError, lambda : np.bincount(np.array([], dtype=np.intp)))
-
     def test_include_dirs(self):
         """As a sanity check, just test that get_include and
         get_numarray_include include something reasonable.  Somewhat

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -198,5 +198,25 @@ class TestRegression(TestCase):
         except:
             raise AssertionError()
 
+    def test_loadtxt_fields_subarrays(self):
+        # For ticket #1936
+        from StringIO import StringIO
+        dt = [("a", 'u1', 2), ("b", 'u1', 2)]
+        x = np.loadtxt(StringIO("0 1 2 3"), dtype=dt)
+        assert_equal(x, np.array([((0, 1), (2, 3))], dtype=dt))
+
+        dt = [("a", [("a", 'u1', (1,3)), ("b", 'u1')])]
+        x = np.loadtxt(StringIO("0 1 2 3"), dtype=dt)
+        assert_equal(x, np.array([(((0,1,2), 3),)], dtype=dt))
+
+        dt = [("a", 'u1', (2,2))]
+        x = np.loadtxt(StringIO("0 1 2 3"), dtype=dt)
+        assert_equal(x, np.array([(((0, 1), (2, 3)),)], dtype=dt))
+
+        dt = [("a", 'u1', (2,3,2))]
+        x = np.loadtxt(StringIO("0 1 2 3 4 5 6 7 8 9 10 11"), dtype=dt)
+        data = [((((0,1), (2,3), (4,5)), ((6,7), (8,9), (10,11))),)]
+        assert_equal(x, np.array(data, dtype=dt))
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -224,7 +224,10 @@ class TestHistogram2d(TestCase):
 
     def test_empty(self):
         a, edge1, edge2 = histogram2d([],[], bins=([0,1],[0,1]))
-        assert_array_max_ulp(a, array([ 0., 0.]))
+        assert_array_max_ulp(a, array([[ 0.]]))
+
+        a, edge1, edge2 = histogram2d([], [], bins=4)
+        assert_array_max_ulp(a, np.zeros((4, 4)))
 
 
 class TestTri(TestCase):

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -239,6 +239,18 @@ class TestTri(TestCase):
         assert_array_equal(tri(3,dtype=bool),out.astype(bool))
 
 
+def test_tril_triu():
+    for dtype in np.typecodes['AllFloat'] + np.typecodes['AllInteger']:
+        a = np.ones((2, 2), dtype=dtype)
+        b = np.tril(a)
+        c = np.triu(a)
+        assert_array_equal(b, [[1, 0], [1, 1]])
+        assert_array_equal(c, b.T)
+        # should return the same dtype as the original array
+        assert_equal(b.dtype, a.dtype)
+        assert_equal(c.dtype, a.dtype)
+
+
 def test_mask_indices():
     # simple test without offset
     iu = mask_indices(3, np.triu)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -424,7 +424,7 @@ def tril(m, k=0):
 
     """
     m = asanyarray(m)
-    out = multiply(tri(m.shape[0], m.shape[1], k=k, dtype=int),m)
+    out = multiply(tri(m.shape[0], m.shape[1], k=k, dtype=m.dtype),m)
     return out
 
 def triu(m, k=0):
@@ -450,7 +450,7 @@ def triu(m, k=0):
 
     """
     m = asanyarray(m)
-    out = multiply((1 - tri(m.shape[0], m.shape[1], k - 1, int)), m)
+    out = multiply((1 - tri(m.shape[0], m.shape[1], k - 1, dtype=m.dtype)), m)
     return out
 
 # borrowed from John Hunter and matplotlib


### PR DESCRIPTION
Backports of fixed tickets in numpy.lib for 1.6.2. Some of these could be regarded as enhancements. The change in the way genfromtxt treats empty files in #1793 could be regarded as a change in behavior.

Tested on Fedora 64 bits with python2.4, python2.7, and python3.2. Should probably be applied after the core is updated to avoid a warning.
