### PR TITLE
The docs should stress that functions that create arrays actually steals a reference to dtype descriptor

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -224,6 +224,8 @@ From scratch
 
 .. cfunction:: PyObject* PyArray_NewFromDescr(PyTypeObject* subtype, PyArray_Descr* descr, int nd, npy_intp* dims, npy_intp* strides, void* data, int flags, PyObject* obj)
 
+    This function steals a reference to *descr* if it is not NULL.
+
     This is the main array creation function. Most new arrays are
     created with this flexible function.
 
@@ -321,6 +323,8 @@ From scratch
     array is indicated by *typenum*.
 
 .. cfunction:: PyObject* PyArray_SimpleNewFromDescr(int nd, npy_intp* dims, PyArray_Descr* descr)
+
+    This function steals a reference to *descr* if it is not NULL.
 
     Create a new array with the provided data-type descriptor, *descr*
     , of the shape deteremined by *nd* and *dims*.


### PR DESCRIPTION
So people in general will need to use a Py_INCREF(descr). Failing to do that could create problems that could be hard to debug (speaking from experience).
