### PR TITLE
Add 1.6.x release notes

### DIFF
--- a/doc/release/1.6.1-notes.rst
+++ b/doc/release/1.6.1-notes.rst
@@ -1,0 +1,22 @@
+=========================
+NumPy 1.6.1 Release Notes
+=========================
+
+This is a bugfix only release in the 1.6.x series.
+
+
+Issues fixed
+------------
+
+#1834   einsum fails for specific shapes
+#1837   einsum throws nan or freezes python for specific array shapes
+#1838   object <-> structured type arrays regression
+#1851   regression for SWIG based code in 1.6.0
+#1863   Buggy results when operating on array copied with astype()
+#1870   Fix corner case of object array assignment
+#1843   Py3k: fix error with recarray
+#1885   nditer: Error in detecting double reduction loop
+#1874   f2py: fix --include_paths bug
+#1749   Fix ctypes.load_library()
+#1895/1896  iter: writeonly operands weren't always being buffered correctly
+

--- a/doc/release/1.6.2-notes.rst
+++ b/doc/release/1.6.2-notes.rst
@@ -1,0 +1,84 @@
+=========================
+NumPy 1.6.2 Release Notes
+=========================
+
+This is a bugfix release in the 1.6.x series.  Due to the delay of the NumPy
+1.7.0 release, this release contains far more fixes than a regular NumPy bugfix
+release.  It also includes a number of documentation and build improvements.
+
+
+``numpy.core`` issues fixed
+---------------------------
+
+#2063  make unique() return consistent index
+#1138  allow creating arrays from empty buffers or empty slices
+#1446  correct note about correspondence vstack and concatenate
+#1149  make argmin() work for datetime
+#1672  fix allclose() to work for scalar inf
+#1747  make np.median() work for 0-D arrays
+#1776  make complex division by zero to yield inf properly
+#1675  add scalar support for the format() function
+#1905  explicitly check for NaNs in allclose()
+#1952  allow floating ddof in std() and var()
+#1948  fix regression for indexing chararrays with empty list
+#2017  fix type hashing
+#2046  deleting array attributes causes segfault
+#2033  a**2.0 has incorrect type
+#2045  make attribute/iterator_element deletions not segfault
+#2021  fix segfault in searchsorted()
+#2073  fix float16 __array_interface__ bug
+
+
+``numpy.lib`` issues fixed
+--------------------------
+
+#2048  break reference cycle in NpzFile
+#1573  savetxt() now handles complex arrays
+#1387  allow bincount() to accept empty arrays
+#1899  fixed histogramdd() bug with empty inputs
+#1793  fix failing npyio test under py3k
+#1936  fix extra nesting for subarray dtypes
+#1848  make tril/triu return the same dtype as the original array
+#1918  use Py_TYPE to access ob_type, so it works also on Py3
+
+
+``numpy.f2py`` changes
+----------------------
+
+ENH:   Introduce new options extra_f77_compiler_args and extra_f90_compiler_args
+BLD:   Improve reporting of fcompiler value
+BUG:   Fix f2py test_kind.py test
+ 
+
+``numpy.poly`` changes
+----------------------
+
+ENH:   Add some tests for polynomial printing
+ENH:   Add companion matrix functions	
+DOC:   Rearrange the polynomial documents
+BUG:   Fix up links to classes
+DOC:   Add version added to some of the polynomial package modules 	
+DOC:   Document xxxfit functions in the polynomial package modules	
+BUG:   The polynomial convenience classes let different types interact
+DOC:   Document the use of the polynomial convenience classes
+DOC:   Improve numpy reference documentation of polynomial classes
+ENH:   Improve the computation of polynomials from roots 	
+STY:   Code cleanup in polynomial [*]fromroots functions	
+DOC:   Remove references to cast and NA, which were added in 1.7
+
+
+``numy.distutils`` issues fixed
+-------------------------------
+
+#1261  change compile flag on AIX from -O5 to -O3
+#1377  update HP compiler flags
+#1383  provide better support for C++ code on HPUX
+#1857  fix build for py3k + pip
+BLD:   raise a clearer warning in case of building without cleaning up first
+BLD:   follow build_ext coding convention in build_clib
+BLD:   fix up detection of Intel CPU on OS X in system_info.py
+BLD:   add support for the new X11 directory structure on Ubuntu & co.
+BLD:   add ufsparse to the libraries search path. 	
+BLD:   add 'pgfortran' as a valid compiler in the Portland Group 	
+BLD:   update version match regexp for IBM AIX Fortran compilers.
+

--- a/pavement.py
+++ b/pavement.py
@@ -98,7 +98,7 @@ finally:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE_NOTES = 'doc/release/1.6.0-notes.rst'
+RELEASE_NOTES = 'doc/release/1.6.2-notes.rst'
 
 # Start/end of the log (from git)
 LOG_START = 'v1.5.0'


### PR DESCRIPTION
Add notes for 1.6.2, and also the ones for 1.6.1 that were previously only in the email announcement of the release.
