### PR TITLE
somes fixes for the roll function

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1186,14 +1186,12 @@ def roll(a, shift, axis=None):
         reshape = False
     if n == 0:
         return a
-    else:
-        shift %= n
-        indexes = concatenate((arange(n-shift,n),arange(n-shift)))
-        res = a.take(indexes, axis)
-        if reshape:
-            return res.reshape(a.shape)
-        else:
-            return res
+    shift %= n
+    indexes = concatenate((arange(n - shift, n), arange(n - shift)))
+    res = a.take(indexes, axis)
+    if reshape:
+        res = res.reshape(a.shape)
+    return res
 
 def rollaxis(a, axis, start=0):
     """

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1184,13 +1184,16 @@ def roll(a, shift, axis=None):
         except IndexError:
             raise ValueError('axis must be >= 0 and < %d' % a.ndim)
         reshape = False
-    shift %= n
-    indexes = concatenate((arange(n-shift,n),arange(n-shift)))
-    res = a.take(indexes, axis)
-    if reshape:
-        return res.reshape(a.shape)
+    if n == 0:
+        return a
     else:
-        return res
+        shift %= n
+        indexes = concatenate((arange(n-shift,n),arange(n-shift)))
+        res = a.take(indexes, axis)
+        if reshape:
+            return res.reshape(a.shape)
+        else:
+            return res
 
 def rollaxis(a, axis, start=0):
     """

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1179,7 +1179,10 @@ def roll(a, shift, axis=None):
         n = a.size
         reshape = True
     else:
-        n = a.shape[axis]
+        try:
+            n = a.shape[axis]
+        except IndexError:
+            raise ValueError('axis must be >= 0 and < %d' % a.ndim)
         reshape = False
     shift %= n
     indexes = concatenate((arange(n-shift,n),arange(n-shift)))

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1570,5 +1570,27 @@ class TestStringFunction(object):
         np.set_string_function(None, repr=False)
         assert_equal(str(a), "[1]")
 
+class TestRoll(TestCase):
+    def test_roll1d(self):
+        x = np.arange(10)
+        xr = np.roll(x, 2)
+        assert_equal(xr, np.array([8, 9, 0, 1, 2, 3, 4, 5, 6, 7]))
+
+    def test_roll2d(self):
+        x2 = np.reshape(np.arange(10), (2,5))
+        x2r = np.roll(x2, 1)
+        assert_equal(x2r, np.array([[9, 0, 1, 2, 3], [4, 5, 6, 7, 8]]))
+
+        x2r = np.roll(x2, 1, axis=0)
+        assert_equal(x2r, np.array([[5, 6, 7, 8, 9], [0, 1, 2, 3, 4]]))
+
+        x2r = np.roll(x2, 1, axis=1)
+        assert_equal(x2r, np.array([[4, 0, 1, 2, 3], [9, 5, 6, 7, 8]]))
+
+    def test_roll_empty(self):
+        x = np.array([])
+        assert_equal(np.roll(x, 1), np.array([]))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
- added tests for roll (based on examples in the docstring)
- raise a `ValueError` when `axis` is out of range
- handle empty arrays (currenlty, `np.roll(np.array([]), 1)` results in a `ZeroDivisionError`)
