### PR TITLE
BUG: maskna: PEP3118 code wasn't raising an error on NA-masked arrays

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -606,6 +606,10 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
     self = (PyArrayObject*)obj;
 
     /* Check whether we can provide the wanted properties */
+    if (PyArray_HASMASKNA(obj)) {
+        PyErr_SetString(PyExc_TypeError, "NA-masked arrays are not supported by the Python buffer protocol");
+        goto fail;
+    }
     if ((flags & PyBUF_C_CONTIGUOUS) == PyBUF_C_CONTIGUOUS &&
         !PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS)) {
         PyErr_SetString(PyExc_ValueError, "ndarray is not C-contiguous");

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -109,6 +109,14 @@ def test_array_maskna_construction():
     assert_(a.flags.maskna)
     assert_equal(np.isna(a), True)
 
+@dec.skipif(sys.version_info < (2, 6))
+def test_array_maskna_pep3188():
+    if sys.version_info[:2] == (2, 6):
+        from numpy.core.multiarray import memorysimpleview as memoryview
+
+    a = np.array([0, 1, np.NA], maskna=True)
+    # The buffer protocol doesn't support NA masks, should raise an error
+    assert_raises(TypeError, memoryview, a)
 
 def test_array_maskna_asarray():
     a = np.arange(6).reshape(2,3)


### PR DESCRIPTION
When trying out various Cython and C-API things, I discovered the pep3118 exposure wasn't raising exceptions for NA-masked arrays as it should.
