### PR TITLE
fromstring() is slow

### DIFF
--- a/fromstr/README
+++ b/fromstr/README
@@ -1,0 +1,3 @@
+Please build with the following command::
+
+    python setup.py build_ext --inplace

--- a/fromstr/fromstr.ipynb
+++ b/fromstr/fromstr.ipynb
@@ -1,0 +1,157 @@
+{
+ "metadata": {
+  "name": "fromstr"
+ },
+ "nbformat": 3,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "import fromstr",
+      "s = \"100.0 \" * 100000",
+      "",
+      "def fromstring(s):",
+      "    data = np.fromstring(s, sep=\" \", dtype=float)",
+      "    return data",
+      "",
+      "def split_and_array(s):",
+      "    rawdata = s.split()",
+      "    data = np.array(rawdata, dtype=float)",
+      "    return data",
+      "",
+      "def comp_and_array(s):",
+      "    rawdata = [float(d) for d in s.split()]",
+      "    data = np.array(rawdata, dtype=float)",
+      "    return data"
+     ],
+     "language": "python",
+     "outputs": [],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# compare pure python functions",
+      "%timeit fromstring(s)",
+      "%timeit split_and_array(s)",
+      "%timeit comp_and_array(s)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10 loops, best of 3: 19.8 ms per loop",
+        "100 loops, best of 3: 13.7 ms per loop"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "",
+        "10 loops, best of 3: 26.7 ms per loop"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# compare cythonized functions",
+      "%timeit fromstr.fromstring(s)",
+      "%timeit fromstr.split_and_array(s)",
+      "%timeit fromstr.comp_and_array(s)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10 loops, best of 3: 19.8 ms per loop",
+        "100 loops, best of 3: 13.7 ms per loop"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "",
+        "100 loops, best of 3: 16.2 ms per loop"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# compare cython functions which use atof()",
+      "# the first still uses str.split() and is ",
+      "# based on this thread: ",
+      "# http://comments.gmane.org/gmane.comp.python.numeric.general/41504",
+      "# the second tokenizes the string rather ",
+      "# than spliting it but may have much higher",
+      "# memory requirements.",
+      "%timeit fromstr.split_atof(s)",
+      "%timeit fromstr.token_atof(s)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "100 loops, best of 3: 10.5 ms per loop",
+        "100 loops, best of 3: 8.31 ms per loop"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      ""
+     ],
+     "language": "python",
+     "outputs": []
+    }
+   ]
+  }
+ ]
+}

--- a/fromstr/fromstr.pyx
+++ b/fromstr/fromstr.pyx
@@ -1,0 +1,76 @@
+from libc.stdlib cimport malloc, free
+
+cimport numpy as np
+import numpy as np
+
+cdef extern from 'stdlib.h':
+    double atof(char*)
+
+
+cdef extern from 'string.h':
+    char* strtok(char*, char*)
+    char* strcpy(char*, char*)
+    void* memcpy(void*, void*, size_t)
+
+
+def fromstring(s):
+    data = np.fromstring(s, sep=" ", dtype=float)
+    return data
+
+
+def split_and_array(s):
+    rawdata = s.split()
+    data = np.array(rawdata, dtype=float)
+    return data
+
+
+def comp_and_array(s):
+    rawdata = [float(d) for d in s.split()]
+    data = np.array(rawdata, dtype=float)
+    return data
+
+
+def split_atof(s):
+    # As per the following thread: 
+    # http://comments.gmane.org/gmane.comp.python.numeric.general/41504
+    cdef char* cstring = ""
+    cdef int i, I
+    cdef np.ndarray[np.float64_t, ndim=1] cdata
+
+    rawdata = s.split()
+    I = len(rawdata)
+    data = np.empty(I, dtype=np.float64)
+    cdata = data
+
+    for i from 0 <= i < I:
+        cstring = rawdata[i]
+        cdata[i] = atof(cstring)
+
+    return data        
+
+
+def token_atof(s):
+    cdef char* cstring
+    cdef char* cs 
+    cdef int i, I
+    cdef np.ndarray[np.float64_t, ndim=1] cdata
+
+    I = len(s)
+    cs = <char *> malloc(I * sizeof(char))
+    strcpy(cs, s)
+
+    I = (I / 2) + 1
+    data = np.empty(I, dtype=np.float64)
+    cdata = data
+
+    i = 0
+    cstring = strtok(cs, " ")
+    while cstring != NULL:
+        cdata[i] = atof(cstring)
+        cstring = strtok(NULL, " ")
+        i += 1
+
+    free(cs)
+
+    data = data[:i].copy()
+    return data        

--- a/fromstr/setup.py
+++ b/fromstr/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
+
+sourcefiles = ['fromstr.pyx',]
+
+setup(
+    cmdclass = {'build_ext': build_ext},
+    ext_modules = [Extension("fromstr", sourcefiles)]
+)


### PR DESCRIPTION
The np.fromstring() function is slow.  Slower than just about anything else but list comprehensions.  This pull request is not meant to be merged.  Rather it is just a place to demonstrate faster, alternative implementations of this function and open an issue for discussion.  

To see the example, first build and then open the `fromstr.ipynb` ipython notebook:

```
cd fromstr/
python setup.py build_ext --inplace
ipython notebook --pylab inline
```
