### PR TITLE
Clean up diagonal

### DIFF
--- a/doc/release/2.0.0-notes.rst
+++ b/doc/release/2.0.0-notes.rst
@@ -188,7 +188,7 @@ C API
 
 New function ``PyArray_RequireWriteable`` provides a consistent
 interface for checking array writeability -- any C code which works
-with arrays whose WRITEABLE flag is not know to be True a priori,
+with arrays whose WRITEABLE flag is not known to be True a priori,
 should make sure to call this function before writing.
 
 Changes

--- a/doc/release/2.0.0-notes.rst
+++ b/doc/release/2.0.0-notes.rst
@@ -8,6 +8,41 @@ Highlights
 ==========
 
 
+Compatibility notes
+===================
+
+In a future version of numpy, the functions np.diag, np.diagonal, and
+the diagonal method of ndarrays will return a view onto the original
+array, instead of producing a copy as they do now. This makes a
+difference if you write to the array returned by any of these
+functions. To facilitate this transition, numpy 1.7 produces a
+DeprecationWarning if it detects that you may be attempting to write
+to such an array. See the documentation for np.diagonal for details.
+
+The default casting rule for UFunc out= parameters has been changed from
+'unsafe' to 'same_kind'.  Most usages which violate the 'same_kind'
+rule are likely bugs, so this change may expose previously undetected
+errors in projects that depend on NumPy.
+
+Full-array boolean indexing used to allow boolean arrays with a size
+non-broadcastable to the array size. Now it forces this to be broadcastable.
+Since this affects some legacy code, this change will require discussion
+during alpha or early beta testing, and a decision to either keep the
+stricter behavior, or add in a hack to allow the previous behavior to
+work.
+
+Attempting to write to a read-only array (one with
+``arr.flags.writeable`` set to ``False``) used to raise either a
+RuntimeError, ValueError, or TypeError inconsistently, depending on
+which code path was taken. It now consistently raises a ValueError.
+
+The <ufunc>.reduce functions evaluate some reductions in a different
+order than in previous versions of NumPy, generally providing higher
+performance. Because of the nature of floating-point arithmetic, this
+may subtly change some results, just as linking NumPy to a different
+BLAS implementations such as MKL can.
+
+
 New features
 ============
 
@@ -161,35 +196,6 @@ Changes
 
 General
 -------
-
-The default casting rule for UFunc out= parameters has been changed from
-'unsafe' to 'same_kind'.  Most usages which violate the 'same_kind'
-rule are likely bugs, so this change may expose previously undetected
-errors in projects that depend on NumPy.
-
-Full-array boolean indexing used to allow boolean arrays with a size
-non-broadcastable to the array size. Now it forces this to be broadcastable.
-Since this affects some legacy code, this change will require discussion
-during alpha or early beta testing, and a decision to either keep the
-stricter behavior, or add in a hack to allow the previous behavior to
-work.
-
-Attempting to write to a read-only array (one with
-``arr.flags.writeable`` set to ``False``) used to raise either a
-RuntimeError, ValueError, or TypeError inconsistently, depending on
-which code path was taken. It now consistently raises a ValueError.
-
-The functions np.diag, np.diagonal, and <ndarray>.diagonal now return a
-view into the original array instead of making a copy. This makes these
-functions more consistent with NumPy's general approach of taking views
-where possible, and performs much faster as well. This has the
-potential to break code that assumes a copy is made instead of a view.
-
-The <ufunc>.reduce functions evaluates some reductions in a different
-order than in previous versions of NumPy, generally providing higher
-performance. Because of the nature of floating-point arithmetic, this
-may subtly change some results, just as linking NumPy to a different
-BLAS implementations such as MKL can.
 
 The function np.concatenate tries to match the layout of its input
 arrays. Previously, the layout did not follow any particular reason,

--- a/doc/release/2.0.0-notes.rst
+++ b/doc/release/2.0.0-notes.rst
@@ -148,6 +148,14 @@ New argument to searchsorted
 The function searchsorted now accepts a 'sorter' argument that is a
 permuation array that sorts the array to search.
 
+C API
+-----
+
+New function ``PyArray_RequireWriteable`` provides a consistent
+interface for checking array writeability -- any C code which works
+with arrays whose WRITEABLE flag is not know to be True a priori,
+should make sure to call this function before writing.
+
 Changes
 =======
 
@@ -165,6 +173,11 @@ Since this affects some legacy code, this change will require discussion
 during alpha or early beta testing, and a decision to either keep the
 stricter behavior, or add in a hack to allow the previous behavior to
 work.
+
+Attempting to write to a read-only array (one with
+``arr.flags.writeable`` set to ``False``) used to raise either a
+RuntimeError, ValueError, or TypeError inconsistently, depending on
+which code path was taken. It now consistently raises a ValueError.
 
 The functions np.diag, np.diagonal, and <ndarray>.diagonal now return a
 view into the original array instead of making a copy. This makes these

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -10,4 +10,4 @@
 # PyArray_CountNonzero, PyArray_NewLikeArray and PyArray_MatrixProduct2.
 0x00000006 = e61d5dc51fa1c6459328266e215d6987
 # Version 7 (NumPy 1.7) added API for NA, improved datetime64.
-0x00000007 = eb54c77ff4149bab310324cd7c0cb176
+0x00000007 = cae43cbd22b39c8c7fe4905b6b93f004

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -9,5 +9,5 @@
 # Version 6 (NumPy 1.6) added new iterator, half float and casting functions,
 # PyArray_CountNonzero, PyArray_NewLikeArray and PyArray_MatrixProduct2.
 0x00000006 = e61d5dc51fa1c6459328266e215d6987
-# Version 7 (NumPy 1.7) added API for NA, improved datetime64.
-0x00000007 = cae43cbd22b39c8c7fe4905b6b93f004
+# Version 7 (NumPy 1.7) added API for NA, improved datetime64, misc utilities.
+0x00000007 = 280023b3ecfc2ad0326874917f6f16f9

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -345,6 +345,7 @@ multiarray_funcs_api = {
     'PyArray_AllowNAConverter':             305,
     'PyArray_OutputAllowNAConverter':       306,
     'PyArray_RequireWriteable':             307,
+    'PyArray_SetUpdateIfCopyBase':          308,
 }
 
 ufunc_types_api = {

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -344,6 +344,7 @@ multiarray_funcs_api = {
     'NpyNA_FromDTypeAndPayload':            304,
     'PyArray_AllowNAConverter':             305,
     'PyArray_OutputAllowNAConverter':       306,
+    'PyArray_RequireWriteable':             307,
 }
 
 ufunc_types_api = {

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -344,7 +344,7 @@ multiarray_funcs_api = {
     'NpyNA_FromDTypeAndPayload':            304,
     'PyArray_AllowNAConverter':             305,
     'PyArray_OutputAllowNAConverter':       306,
-    'PyArray_RequireWriteable':             307,
+    'PyArray_FailUnlessWriteable':          307,
     'PyArray_SetUpdateIfCopyBase':          308,
 }
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -932,7 +932,27 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     removing `axis1` and `axis2` and appending an index to the right equal
     to the size of the resulting diagonals.
 
-    As of NumPy 1.7, this function always returns a view into `a`.
+    In versions of NumPy prior to 1.7, this function always returned a new,
+    independent array containing a copy of the values in the diagonal.
+
+    In NumPy 1.7, it continues to return a copy of the diagonal, but depending
+    on this fact is deprecated. Writing to the resulting array continues to
+    work as it used to, but a DeprecationWarning will be issued.
+
+    In NumPy 1.8, it will switch to returning a read-only view on the original
+    array. Attempting to write to the resulting array will produce an error.
+
+    In NumPy 1.9, it will still return a view, but this view will no longer be
+    marked read-only. Writing to the returned array will alter your original
+    array as well.
+
+    If you don't write to the array returned by this function, then you can
+    just ignore all of the above.
+
+    If you depend on the current behavior, then we suggest copying the
+    returned array explicitly, i.e., use ``np.diagonal(a).copy()`` instead of
+    just ``np.diagonal(a)``. This will work with both past and future versions
+    of NumPy.
 
     Parameters
     ----------

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -918,17 +918,9 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_ALLOWNA         0x8000
 
 /*
- * This flag is used to mark arrays which we would like to, in the future,
- * turn into views. It causes a warning to be issued on the first attempt to
- * write to the array (but the write is allowed to succeed).
- *
- * This flag is for internal use only, and may be removed in a future release,
- * which is why the #define is not exposed to user code. Currently it is set
- * on arrays returned by ndarray.diagonal.
+ * NOTE: there are also internal flags defined in multiarray/arrayobject.h,
+ * which start at bit 31 and work down.
  */
-#ifdef _MULTIARRAYMODULE
-#define NPY_ARRAY_WARN_ON_WRITE  0x10000
-#endif
 
 #define NPY_ARRAY_BEHAVED      (NPY_ARRAY_ALIGNED | \
                                 NPY_ARRAY_WRITEABLE)

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -918,14 +918,17 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_ALLOWNA         0x8000
 
 /*
- * This flag is used internally to mark arrays which we would like to, in the
- * future, turn into views. It causes a warning to be issued on the first
- * attempt to write to the array (but the write is allowed to succeed).
+ * This flag is used to mark arrays which we would like to, in the future,
+ * turn into views. It causes a warning to be issued on the first attempt to
+ * write to the array (but the write is allowed to succeed).
  *
- * Currently it is set on arrays returned by ndarray.diagonal.
+ * This flag is for internal use only, and may be removed in a future release,
+ * which is why the #define is not exposed to user code. Currently it is set
+ * on arrays returned by ndarray.diagonal.
  */
+#ifdef _MULTIARRAYMODULE
 #define NPY_ARRAY_WARN_ON_WRITE  0x10000
-
+#endif
 
 #define NPY_ARRAY_BEHAVED      (NPY_ARRAY_ALIGNED | \
                                 NPY_ARRAY_WRITEABLE)

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -917,6 +917,15 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
  */
 #define NPY_ARRAY_ALLOWNA         0x8000
 
+/*
+ * This flag is used internally to mark arrays which we would like to, in the
+ * future, turn into views. It causes a warning to be issued on the first
+ * attempt to write to the array (but the write is allowed to succeed).
+ *
+ * Currently it is set on arrays returned by ndarray.diagonal.
+ */
+#define NPY_ARRAY_WARN_ON_WRITE  0x10000
+
 
 #define NPY_ARRAY_BEHAVED      (NPY_ARRAY_ALIGNED | \
                                 NPY_ARRAY_WRITEABLE)
@@ -1550,7 +1559,7 @@ static NPY_INLINE PyObject *
 PyArray_GETITEM(const PyArrayObject *arr, const char *itemptr)
 {
     return ((PyArrayObject_fields *)arr)->descr->f->getitem(
-					(void *)itemptr, (PyArrayObject *)arr);
+                                        (void *)itemptr, (PyArrayObject *)arr);
 }
 
 static NPY_INLINE int

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1956,9 +1956,8 @@ def identity(n, dtype=None, maskna=False):
            [ 0.,  0.,  1.]])
 
     """
-    a = zeros((n,n), dtype=dtype, maskna=maskna)
-    a.diagonal()[...] = 1
-    return a
+    from numpy import eye
+    return eye(n, dtype=dtype, maskna=maskna)
 
 def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     """

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -449,7 +449,7 @@ PyArray_AssignArray(PyArrayObject *dst, PyArrayObject *src,
         return 0;
     }
 
-    if (PyArray_RequireWriteable(dst, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(dst, "assignment destination") < 0) {
         goto fail;
     }
 

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -449,10 +449,7 @@ PyArray_AssignArray(PyArrayObject *dst, PyArrayObject *src,
         return 0;
     }
 
-    /* Check that 'dst' is writeable */
-    if (!PyArray_ISWRITEABLE(dst)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "cannot assign to a read-only array");
+    if (PyArray_RequireWriteable(dst, NULL) < 0) {
         goto fail;
     }
 

--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -336,10 +336,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
     int allocated_src_data = 0, dst_has_maskna = PyArray_HASMASKNA(dst);
     npy_longlong scalarbuffer[4];
 
-    /* Check that 'dst' is writeable */
-    if (!PyArray_ISWRITEABLE(dst)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "cannot assign a scalar value to a read-only array");
+    if (PyArray_RequireWriteable(dst, "cannot assign to read-only array") < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -336,7 +336,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
     int allocated_src_data = 0, dst_has_maskna = PyArray_HASMASKNA(dst);
     npy_longlong scalarbuffer[4];
 
-    if (PyArray_RequireWriteable(dst, "cannot assign to read-only array") < 0) {
+    if (PyArray_FailUnlessWriteable(dst, "assignment destination") < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -791,10 +791,10 @@ array_might_be_written(PyArrayObject *obj)
 /*NUMPY_API
  *
  * This function does nothing if obj is writeable, and raises an exception
- * (and returns -1) if obj is not writeable. In the future it may also do
- * other house-keeping, such as issuing warnings on arrays which are
- * transitioning to become views. Always call this function at some point
- * before writing to an array.
+ * (and returns -1) if obj is not writeable. It may also do other
+ * house-keeping, such as issuing warnings on arrays which are transitioning
+ * to become views. Always call this function at some point before writing to
+ * an array.
  */
 NPY_NO_EXPORT int
 PyArray_RequireWriteable(PyArrayObject *obj, const char * err)

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -86,8 +86,8 @@ PyArray_SetUpdateIfCopyBase(PyArrayObject *arr, PyArrayObject *base)
                   "Cannot set array with existing base to UPDATEIFCOPY");
         goto fail;
     }
-    const char *msg = "cannot UPDATEIFCOPY to a non-writeable array";
-    if (PyArray_RequireWriteable(base, msg) < 0) {
+    if (PyArray_RequireWriteable(base,
+             "cannot UPDATEIFCOPY to a non-writeable array") < 0) {
         goto fail;
     }
     

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -90,8 +90,7 @@ PyArray_SetUpdateIfCopyBase(PyArrayObject *arr, PyArrayObject *base)
                   "Cannot set array with existing base to UPDATEIFCOPY");
         goto fail;
     }
-    if (PyArray_RequireWriteable(base,
-             "cannot UPDATEIFCOPY to a non-writeable array") < 0) {
+    if (PyArray_FailUnlessWriteable(base, "UPDATEIFCOPY base") < 0) {
         goto fail;
     }
     
@@ -795,15 +794,16 @@ array_might_be_written(PyArrayObject *obj)
  * house-keeping, such as issuing warnings on arrays which are transitioning
  * to become views. Always call this function at some point before writing to
  * an array.
+ *
+ * 'name' is a name for the array, used to give better error
+ * messages. Something like "assignment destination", "output array", or even
+ * just "array".
  */
 NPY_NO_EXPORT int
-PyArray_RequireWriteable(PyArrayObject *obj, const char * err)
+PyArray_FailUnlessWriteable(PyArrayObject *obj, const char *name)
 {
-    if (!err) {
-        err = "array must be writeable (but isn't)";
-    }
     if (!PyArray_ISWRITEABLE(obj)) {
-        PyErr_SetString(PyExc_ValueError, err);
+        PyErr_Format(PyExc_ValueError, "%s is read-only", name);
         return -1;
     }
     if (array_might_be_written(obj) < 0) {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -704,6 +704,27 @@ PyArray_CompareString(char *s1, char *s2, size_t len)
 }
 
 
+/*NUMPY_API
+ *
+ * This function does nothing if obj is writeable, and raises an exception
+ * (and returns -1) if obj is not writeable. In the future it may also do
+ * other house-keeping, such as issuing warnings on arrays which are
+ * transitioning to become views. Always call this function at some point
+ * before writing to an array.
+ */
+NPY_NO_EXPORT int
+PyArray_RequireWriteable(PyArrayObject *obj, const char * err)
+{
+    if (!err) {
+        err = "array must be writeable (but isn't)";
+    }
+    if (!PyArray_ISWRITEABLE(obj)) {
+        PyErr_SetString(PyExc_ValueError, err);
+        return -1;
+    }
+    return 0;
+}
+
 /* This also handles possibly mis-aligned data */
 /* Compare s1 and s2 which are not necessarily NULL-terminated.
    s1 is of length len1

--- a/numpy/core/src/multiarray/arrayobject.h
+++ b/numpy/core/src/multiarray/arrayobject.h
@@ -12,4 +12,7 @@ _strings_richcompare(PyArrayObject *self, PyArrayObject *other, int cmp_op,
 NPY_NO_EXPORT PyObject *
 array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op);
 
+NPY_NO_EXPORT int
+array_might_be_written(PyArrayObject *obj);
+
 #endif

--- a/numpy/core/src/multiarray/arrayobject.h
+++ b/numpy/core/src/multiarray/arrayobject.h
@@ -15,4 +15,15 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op);
 NPY_NO_EXPORT int
 array_might_be_written(PyArrayObject *obj);
 
+/*
+ * This flag is used to mark arrays which we would like to, in the future,
+ * turn into views. It causes a warning to be issued on the first attempt to
+ * write to the array (but the write is allowed to succeed).
+ *
+ * This flag is for internal use only, and may be removed in a future release,
+ * which is why the #define is not exposed to user code. Currently it is set
+ * on arrays returned by ndarray.diagonal.
+ */
+static const int NPY_ARRAY_WARN_ON_WRITE = (1 << 31);
+
 #endif

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -18,6 +18,7 @@
 #include "usertypes.h"
 #include "_datetime.h"
 #include "na_object.h"
+#include "arrayobject.h"
 
 #include "numpyos.h"
 
@@ -649,6 +650,9 @@ VOID_getitem(char *ip, PyArrayObject *ap)
      * current item a view of it
      */
     if (PyArray_ISWRITEABLE(ap)) {
+        if (array_might_be_written(ap) < 0) {
+            return NULL;
+        }
         u = (PyArrayObject *)PyBuffer_FromReadWriteMemory(ip, itemsize);
     }
     else {

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -635,6 +635,14 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
         if (PyArray_RequireWriteable(self, NULL) < 0) {
             goto fail;
         }
+    }
+    /*
+     * If a read-only buffer is requested on a read-write array, we return a
+     * read-write buffer, which is dubious behavior. But that's why this call
+     * is guarded by PyArray_ISWRITEABLE rather than (flags &
+     * PyBUF_WRITEABLE).
+     */
+    if (PyArray_ISWRITEABLE(self)) {
         if (array_might_be_written(self) < 0) {
             goto fail;
         }

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -58,9 +58,7 @@ array_getreadbuf(PyArrayObject *self, Py_ssize_t segment, void **ptrptr)
 static Py_ssize_t
 array_getwritebuf(PyArrayObject *self, Py_ssize_t segment, void **ptrptr)
 {
-    if (PyArray_RequireWriteable(self,
-                                 "cannot get writeable buffer from "
-                                 "non-writeable array") < 0) {
+    if (PyArray_FailUnlessWriteable(self, "buffer source array") < 0) {
         return -1;
     }
     return array_getreadbuf(self, segment, (void **) ptrptr);
@@ -632,7 +630,7 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
         goto fail;
     }
     if ((flags & PyBUF_WRITEABLE) == PyBUF_WRITEABLE) {
-        if (PyArray_RequireWriteable(self, NULL) < 0) {
+        if (PyArray_FailUnlessWriteable(self, "buffer source array") < 0) {
             goto fail;
         }
     }

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -13,6 +13,7 @@
 
 #include "buffer.h"
 #include "numpyos.h"
+#include "arrayobject.h"
 
 /*************************************************************************
  ****************   Implement Buffer Protocol ****************************
@@ -628,6 +629,9 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
     }
     if ((flags & PyBUF_WRITEABLE) == PyBUF_WRITEABLE) {
         if (PyArray_RequireWriteable(self, NULL) < 0) {
+            goto fail;
+        }
+        if (array_might_be_written(self) < 0) {
             goto fail;
         }
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1351,7 +1351,7 @@ PyArray_GetArrayParamsFromObjectEx(PyObject *op,
     /* If op is an array */
     if (PyArray_Check(op)) {
         if (writeable
-            && PyArray_RequireWriteable((PyArrayObject *)op, NULL) < 0) {
+            && PyArray_FailUnlessWriteable((PyArrayObject *)op, "array") < 0) {
             return -1;
         }
         Py_INCREF(op);
@@ -1421,9 +1421,7 @@ PyArray_GetArrayParamsFromObjectEx(PyObject *op,
     if (!PyBytes_Check(op) && !PyUnicode_Check(op) &&
              _array_from_buffer_3118(op, (PyObject **)out_arr) == 0) {
         if (writeable
-            && PyArray_RequireWriteable(*out_arr,
-                                        "PEP 3118 buffer is not writeable")
-               < 0) {
+            && PyArray_FailUnlessWriteable(*out_arr, "PEP 3118 buffer") < 0) {
             Py_DECREF(*out_arr);
             return -1;
         }
@@ -1443,9 +1441,8 @@ PyArray_GetArrayParamsFromObjectEx(PyObject *op,
     }
     if (tmp != Py_NotImplemented) {
         if (writeable
-            && PyArray_RequireWriteable((PyArrayObject *)tmp,
-                                        "array interface object is not "
-                                        "writeable") < 0) {
+            && PyArray_FailUnlessWriteable((PyArrayObject *)tmp,
+                                           "array interface object") < 0) {
             Py_DECREF(tmp);
             return -1;
         }
@@ -1466,9 +1463,8 @@ PyArray_GetArrayParamsFromObjectEx(PyObject *op,
         tmp = PyArray_FromArrayAttr(op, requested_dtype, context);
         if (tmp != Py_NotImplemented) {
             if (writeable
-                && PyArray_RequireWriteable((PyArrayObject *)tmp,
-                                            "array interface object is not "
-                                            "writeable") < 0) {
+                && PyArray_FailUnlessWriteable((PyArrayObject *)tmp,
+                                               "array interface object") < 0) {
                 Py_DECREF(tmp);
                 return -1;
             }
@@ -2036,13 +2032,6 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
             order = NPY_CORDER;
         }
 
-        if (flags & NPY_ARRAY_UPDATEIFCOPY) {
-            const char * msg = "cannot copy back to a read-only array";
-            if (PyArray_RequireWriteable(arr, msg) < 0) {
-                Py_DECREF(newtype);
-                return NULL;
-            }
-        }
         if ((flags & NPY_ARRAY_ENSUREARRAY)) {
             subok = 0;
         }
@@ -2600,7 +2589,7 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
 
     NPY_BEGIN_THREADS_DEF;
 
-    if (PyArray_RequireWriteable(dst, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(dst, "destination array") < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -355,9 +355,12 @@ array_data_set(PyArrayObject *self, PyObject *op)
             PyArray_CLEARFLAGS(self, NPY_ARRAY_UPDATEIFCOPY);
         }
         Py_DECREF(PyArray_BASE(self));
+        ((PyArrayObject_fields *)self)->base = NULL;
     }
     Py_INCREF(op);
-    ((PyArrayObject_fields *)self)->base = op;
+    if (PyArray_SetBaseObject(self, op) < 0) {
+        return -1;
+    }
     ((PyArrayObject_fields *)self)->data = buf;
     ((PyArrayObject_fields *)self)->flags = NPY_ARRAY_CARRAY;
     if (!writeable) {

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -16,6 +16,7 @@
 #include "scalartypes.h"
 #include "descriptor.h"
 #include "getset.h"
+#include "arrayobject.h"
 
 /*******************  array attribute get and set routines ******************/
 
@@ -260,6 +261,10 @@ array_interface_get(PyArrayObject *self)
         return NULL;
     }
 
+    if (array_might_be_written(self) < 0) {
+        return NULL;
+    }
+
     /* dataptr */
     obj = array_dataptr_get(self);
     PyDict_SetItemString(dict, "data", obj);
@@ -302,6 +307,9 @@ array_data_get(PyArrayObject *self)
     }
     nbytes = PyArray_NBYTES(self);
     if (PyArray_ISWRITEABLE(self)) {
+        if (array_might_be_written(self) < 0) {
+            return NULL;
+        }
         return PyBuffer_FromReadWriteObject((PyObject *)self, 0, (Py_ssize_t) nbytes);
     }
     else {
@@ -557,6 +565,11 @@ array_struct_get(PyArrayObject *self)
     PyArrayInterface *inter;
     PyObject *ret;
 
+    if (PyArray_ISWRITEABLE(self)) {
+        if (array_might_be_written(self) < 0) {
+            return NULL;
+        }
+    }
     inter = (PyArrayInterface *)PyArray_malloc(sizeof(PyArrayInterface));
     if (inter==NULL) {
         return PyErr_NoMemory();

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -307,9 +307,6 @@ array_data_get(PyArrayObject *self)
     }
     nbytes = PyArray_NBYTES(self);
     if (PyArray_ISWRITEABLE(self)) {
-        if (array_might_be_written(self) < 0) {
-            return NULL;
-        }
         return PyBuffer_FromReadWriteObject((PyObject *)self, 0, (Py_ssize_t) nbytes);
     }
     else {

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1114,7 +1114,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND which)
         PyErr_Format(PyExc_ValueError, "axis(=%d) out of bounds", axis);
         return -1;
     }
-    if (PyArray_RequireWriteable(op, "attempted sort on read-only array") < 0) {
+    if (PyArray_FailUnlessWriteable(op, "sort array") < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1114,9 +1114,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND which)
         PyErr_Format(PyExc_ValueError, "axis(=%d) out of bounds", axis);
         return -1;
     }
-    if (!PyArray_ISWRITEABLE(op)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "attempted sort on unwriteable array.");
+    if (PyArray_RequireWriteable(op, "attempted sort on read-only array") < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1260,14 +1260,11 @@ iter_array(PyArrayIterObject *it, PyObject *NPY_UNUSED(op))
             Py_DECREF(ret);
             return NULL;
         }
-        /*
-         * Don't use PyArray_SetBaseObject, because that compresses
-         * the chain of bases.
-         */
         Py_INCREF(it->ao);
-        ((PyArrayObject_fields *)ret)->base = (PyObject *)it->ao;
-        PyArray_ENABLEFLAGS(ret, NPY_ARRAY_UPDATEIFCOPY);
-        PyArray_CLEARFLAGS(it->ao, NPY_ARRAY_WRITEABLE);
+        if (PyArray_SetUpdateIfCopyBase(ret, it->ao) < 0) {
+            Py_DECREF(ret);
+            return NULL;
+        }
     }
     return ret;
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -176,7 +176,7 @@ array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
         return -1;
     }
 
-    if (PyArray_RequireWriteable(self, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         return -1;
     }
 
@@ -1500,7 +1500,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
                         "cannot delete array elements");
         return -1;
     }
-    if (PyArray_RequireWriteable(self, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -176,9 +176,7 @@ array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
         return -1;
     }
 
-    if (!PyArray_ISWRITEABLE(self)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "array is not writeable");
+    if (PyArray_RequireWriteable(self, NULL) < 0) {
         return -1;
     }
 
@@ -1502,9 +1500,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
                         "cannot delete array elements");
         return -1;
     }
-    if (!PyArray_ISWRITEABLE(self)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "array is not writeable");
+    if (PyArray_RequireWriteable(self, NULL) < 0) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -532,9 +532,7 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
 
     copyswapn = PyArray_DESCR(self)->f->copyswapn;
     if (inplace) {
-        const char *msg = "Cannot perform in-place byte-swap on a "
-                          "read-only array";
-        if (PyArray_RequireWriteable(self, msg) < 0) {
+        if (PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
             return NULL;
         }
         size = PyArray_SIZE(self);
@@ -747,7 +745,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
                 "itemset must have at least one argument");
         return NULL;
     }
-    if (PyArray_RequireWriteable(self, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1694,6 +1694,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         PyArray_CLEARFLAGS(self, NPY_ARRAY_OWNDATA);
     }
     Py_XDECREF(PyArray_BASE(self));
+    fa->base = NULL;
 
     PyArray_CLEARFLAGS(self, NPY_ARRAY_UPDATEIFCOPY);
 
@@ -1766,7 +1767,9 @@ array_setstate(PyArrayObject *self, PyObject *args)
             Py_DECREF(rawdata);
         }
         else {
-            fa->base = rawdata;
+            if (PyArray_SetBaseObject(self, rawdata) < 0) {
+                return NULL;
+            }
         }
     }
     else {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -532,10 +532,9 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
 
     copyswapn = PyArray_DESCR(self)->f->copyswapn;
     if (inplace) {
-        if (!PyArray_ISWRITEABLE(self)) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "Cannot byte-swap in-place on a " \
-                            "read-only array");
+        const char *msg = "Cannot perform in-place byte-swap on a "
+                          "read-only array";
+        if (PyArray_RequireWriteable(self, msg) < 0) {
             return NULL;
         }
         size = PyArray_SIZE(self);
@@ -748,9 +747,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
                 "itemset must have at least one argument");
         return NULL;
     }
-    if (!PyArray_ISWRITEABLE(self)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "array is not writeable");
+    if (PyArray_RequireWriteable(self, NULL) < 0) {
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1098,11 +1098,11 @@ npyiter_prepare_one_operand(PyArrayObject **op,
     if (PyArray_Check(*op)) {
         npy_uint32 tmp;
 
-        if (((*op_itflags) & NPY_OP_ITFLAG_WRITE) &&
-                    (!PyArray_CHKFLAGS(*op, NPY_ARRAY_WRITEABLE))) {
-            PyErr_SetString(PyExc_ValueError,
-                    "Operand was a non-writeable array, but "
-                    "flagged as writeable");
+        if ((*op_itflags) & NPY_OP_ITFLAG_WRITE
+            && PyArray_RequireWriteable(*op,
+                                        "Operand array is not writeable, "
+                                        "but the iterator write flag is set"
+                ) < 0) {
             return 0;
         }
         if (!(flags & NPY_ITER_ZEROSIZE_OK) && PyArray_SIZE(*op) == 0) {

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1099,10 +1099,8 @@ npyiter_prepare_one_operand(PyArrayObject **op,
         npy_uint32 tmp;
 
         if ((*op_itflags) & NPY_OP_ITFLAG_WRITE
-            && PyArray_RequireWriteable(*op,
-                                        "Operand array is not writeable, "
-                                        "but the iterator write flag is set"
-                ) < 0) {
+            && PyArray_FailUnlessWriteable(*op, "operand array with iterator "
+                                           "write flag set") < 0) {
             return 0;
         }
         if (!(flags & NPY_ITER_ZEROSIZE_OK) && PyArray_SIZE(*op) == 0) {

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -3027,15 +3027,11 @@ npyiter_allocate_arrays(NpyIter *iter,
             }
             /* If the data will be written to, set UPDATEIFCOPY */
             if (op_itflags[iop] & NPY_OP_ITFLAG_WRITE) {
-                /*
-                 * Don't use PyArray_SetBaseObject, because that compresses
-                 * the chain of bases.
-                 */
                 Py_INCREF(op[iop]);
-                ((PyArrayObject_fields *)temp)->base =
-                                                        (PyObject *)op[iop];
-                PyArray_ENABLEFLAGS(temp, NPY_ARRAY_UPDATEIFCOPY);
-                PyArray_CLEARFLAGS(op[iop], NPY_ARRAY_WRITEABLE);
+                if (PyArray_SetUpdateIfCopyBase(temp, op[iop]) < 0) {
+                    Py_DECREF(temp);
+                    return 0;
+                }
             }
 
             Py_DECREF(op[iop]);

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -119,7 +119,7 @@ array_ass_slice(PyArrayObject *self, Py_ssize_t ilow,
                         "cannot delete array elements");
         return -1;
     }
-    if (PyArray_RequireWriteable(self, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         return -1;
     }
     tmp = (PyArrayObject *)array_slice(self, ilow, ihigh);

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -119,9 +119,7 @@ array_ass_slice(PyArrayObject *self, Py_ssize_t ilow,
                         "cannot delete array elements");
         return -1;
     }
-    if (!PyArray_ISWRITEABLE(self)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "array is not writeable");
+    if (PyArray_RequireWriteable(self, NULL) < 0) {
         return -1;
     }
     tmp = (PyArrayObject *)array_slice(self, ilow, ihigh);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -795,8 +795,8 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
         }
         /* If it's an array, can use it */
         if (PyArray_Check(obj)) {
-            const char *msg = "output array not writeable";
-            if (PyArray_RequireWriteable((PyArrayObject *)obj, msg) < 0) {
+            if (PyArray_FailUnlessWriteable((PyArrayObject *)obj,
+                                            "output array") < 0) {
                 return -1;
             }
             Py_INCREF(obj);
@@ -893,9 +893,9 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
                         }
 
                         if (PyArray_Check(value)) {
-                            const char *msg = "output array not writeable";
+                            const char *name = "output array";
                             PyArrayObject *value_arr = (PyArrayObject *)value;
-                            if (PyArray_RequireWriteable(value_arr, msg) < 0) {
+                            if (PyArray_FailUnlessWriteable(value_arr, name) < 0) {
                                 goto fail;
                             }
                             Py_INCREF(value);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -795,9 +795,8 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
         }
         /* If it's an array, can use it */
         if (PyArray_Check(obj)) {
-            if (!PyArray_ISWRITEABLE((PyArrayObject *)obj)) {
-                PyErr_SetString(PyExc_ValueError,
-                                "return array is not writeable");
+            const char *msg = "output array not writeable";
+            if (PyArray_RequireWriteable((PyArrayObject *)obj, msg) < 0) {
                 return -1;
             }
             Py_INCREF(obj);
@@ -894,9 +893,9 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
                         }
 
                         if (PyArray_Check(value)) {
-                            if (!PyArray_ISWRITEABLE((PyArrayObject *)value)) {
-                                PyErr_SetString(PyExc_ValueError,
-                                        "return array is not writeable");
+                            const char *msg = "output array not writeable";
+                            PyArrayObject *value_arr = (PyArrayObject *)value;
+                            if (PyArray_RequireWriteable(value_arr, msg) < 0) {
                                 goto fail;
                             }
                             Py_INCREF(value);

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -1408,11 +1408,9 @@ def test_array_maskna_diagonal():
     a.shape = (2,3)
     a[0,1] = np.NA
 
-    # Should produce a view into a
     res = a.diagonal()
-    assert_(res.base is a)
     assert_(res.flags.maskna)
-    assert_(not res.flags.ownmaskna)
+    assert_(res.flags.ownmaskna)
     assert_equal(res, [0, 4])
 
     res = a.diagonal(-1)
@@ -1584,6 +1582,8 @@ def test_array_maskna_linspace_logspace():
     assert_(b.flags.maskna)
 
 
+from numpy.testing import dec
+@dec.knownfailureif(True, "eye is not implemented for maskna")
 def test_array_maskna_eye_identity():
     # np.eye
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -29,8 +29,8 @@ class TestFlags(TestCase):
     def test_writeable(self):
         mydict = locals()
         self.a.flags.writeable = False
-        self.assertRaises(RuntimeError, runstring, 'self.a[0] = 3', mydict)
-        self.assertRaises(RuntimeError, runstring, 'self.a[0:1].itemset(3)', mydict)
+        self.assertRaises(ValueError, runstring, 'self.a[0] = 3', mydict)
+        self.assertRaises(ValueError, runstring, 'self.a[0:1].itemset(3)', mydict)
         self.a.flags.writeable = True
         self.a[0] = 5
         self.a[0] = 0

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -903,9 +903,10 @@ class TestMethods(TestCase):
         # ro_diag.flags.writeable = False
         # assert_equal(collect_warning_types(getattr, ro_diag,
         #                                     "__array_interface__"), [])
-        ro_diag = a.diagonal()
-        ro_diag.flags.writeable = False
-        assert_equal(collect_warning_types(memoryview, ro_diag), [])
+        if hasattr(__builtins__, "memoryview"):
+            ro_diag = a.diagonal()
+            ro_diag.flags.writeable = False
+            assert_equal(collect_warning_types(memoryview, ro_diag), [])
         ro_diag = a.diagonal()
         ro_diag.flags.writeable = False
         assert_equal(collect_warning_types(getattr, ro_diag,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -870,8 +870,14 @@ class TestMethods(TestCase):
                                     "__array_interface__")
         assert_equal(log, [DeprecationWarning])
         # ctypeslib goes via __array_interface__:
-        log = collect_warning_types(np.ctypeslib.as_ctypes, a.diagonal())
-        assert_equal(log, [DeprecationWarning])
+        try:
+            # may not exist in python 2.4:
+            import ctypes
+        except ImportError:
+            pass
+        else:
+            log = collect_warning_types(np.ctypeslib.as_ctypes, a.diagonal())
+            assert_equal(log, [DeprecationWarning])
         # __array_struct__
         log = collect_warning_types(getattr, a.diagonal(), "__array_struct__")
         assert_equal(log, [DeprecationWarning])

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -792,6 +792,25 @@ class TestMethods(TestCase):
         assert_equal(np.dot(a, b), a.dot(b))
         assert_equal(np.dot(np.dot(a, b), c), a.dot(b).dot(c))
 
+    def test_diagonal(self):
+        a = np.arange(12).reshape((3, 4))
+        assert_equal(a.diagonal(), [0, 5, 10])
+        assert_equal(a.diagonal(0), [0, 5, 10])
+        assert_equal(a.diagonal(1), [1, 6, 11])
+        assert_equal(a.diagonal(-1), [4, 9])
+
+        b = np.arange(8).reshape((2, 2, 2))
+        assert_equal(b.diagonal(), [[0, 6], [1, 7]])
+        assert_equal(b.diagonal(0), [[0, 6], [1, 7]])
+        assert_equal(b.diagonal(1), [[2], [3]])
+        assert_equal(b.diagonal(-1), [[4], [5]])
+        assert_raises(ValueError, b.diagonal, axis1=0, axis2=0)
+        assert_equal(b.diagonal(0, 1, 2), [[0, 3], [4, 7]])
+        assert_equal(b.diagonal(0, 0, 1), [[0, 6], [1, 7]])
+        assert_equal(b.diagonal(offset=1, axis1=0, axis2=2), [[1], [3]])
+        # Order of axis argument doesn't matter:
+        assert_equal(b.diagonal(0, 2, 1), [[0, 3], [4, 7]])
+
     def test_ravel(self):
         a = np.array([[0,1],[2,3]])
         assert_equal(a.ravel(), [0,1,2,3])

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -864,7 +864,13 @@ def test_iter_array_cast():
     i = None
     assert_equal(a[2,1,1], -12.5)
 
-    # Unsafe cast 'f4' -> 'i4'
+from numpy.testing import dec
+@dec.knownfailureif(True,
+                    "When casting is combined with a negative stepsize, "
+                    "nditer tries to assign two different bases to the same "
+                    "array, which was always a memory leak and is now an "
+                    "error.")
+def test_iter_array_cast_buggy():
     a = np.arange(6, dtype='i4')[::-2]
     i = nditer(a, [],
             [['writeonly','updateifcopy']],

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -865,13 +865,6 @@ def test_iter_array_cast():
     i = None
     assert_equal(a[2,1,1], -12.5)
 
-from numpy.testing import dec
-@dec.knownfailureif(True,
-                    "When casting is combined with a negative stepsize, "
-                    "nditer tries to assign two different bases to the same "
-                    "array, which was always a memory leak and is now an "
-                    "error.")
-def test_iter_array_cast_buggy():
     a = np.arange(6, dtype='i4')[::-2]
     i = nditer(a, [],
             [['writeonly','updateifcopy']],

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -223,12 +223,15 @@ def diag(v, k=0):
     """
     Extract a diagonal or construct a diagonal array.
 
-    As of NumPy 1.7, extracting a diagonal always returns a view into `v`.
+    See the more detailed documentation for ``numpy.diagonal`` if you use this
+    function to extract a diagonal and wish to write to the resulting array;
+    whether it returns a copy or a view depends on what version of numpy you
+    are using.
 
     Parameters
     ----------
     v : array_like
-        If `v` is a 2-D array, return a view of its `k`-th diagonal.
+        If `v` is a 2-D array, return a copy of its `k`-th diagonal.
         If `v` is a 1-D array, return a 2-D array with `v` on the `k`-th
         diagonal.
     k : int, optional

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -210,7 +210,13 @@ def eye(N, M=None, k=0, dtype=float, maskna=False):
     if M is None:
         M = N
     m = zeros((N, M), dtype=dtype, maskna=maskna)
-    diagonal(m, k)[...] = 1
+    if k >= M:
+        return m
+    if k >= 0:
+        i = k
+    else:
+        i = (-k) * M
+    m[:M-k].flat[i::M+1] = 1
     return m
 
 def diag(v, k=0):

--- a/numpy/numarray/_capi.c
+++ b/numpy/numarray/_capi.c
@@ -1101,12 +1101,10 @@ NA_OutputArray(PyObject *a, NumarrayType t, int requires)
                                         PyArray_DIMS((PyArrayObject *)a),
                                         dtype, 0);
     Py_INCREF(a);
-    if (PyArray_SetBaseObject(ret, a) < 0) {
+    if (PyArray_SetUpdateIfCopyBase(ret, a) < 0) {
         Py_DECREF(ret);
         return NULL;
     }
-    PyArray_ENABLEFLAGS(ret, NPY_ARRAY_UPDATEIFCOPY);
-    PyArray_CLEARFLAGS((PyArrayObject *)a, NPY_ARRAY_WRITEABLE);
     return ret;
 }
 

--- a/numpy/numarray/_capi.c
+++ b/numpy/numarray/_capi.c
@@ -1082,7 +1082,7 @@ NA_OutputArray(PyObject *a, NumarrayType t, int requires)
                 "NA_OutputArray: only arrays work for output.");
         return NULL;
     }
-    if (PyArray_RequireWriteable((PyArrayObject *)a, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable((PyArrayObject *)a, "output array") < 0) {
         return NULL;
     }
 
@@ -1128,7 +1128,7 @@ NA_IoArray(PyObject *a, NumarrayType t, int requires)
     /* Guard against non-writable, but otherwise satisfying requires.
        In this case,  shadow == a.
        */
-    if (!PyArray_RequireWriteable(shadow, NULL)) {
+    if (!PyArray_FailUnlessWriteable(shadow, "input/output array")) {
         PyArray_XDECREF_ERR(shadow);
         return NULL;
     }
@@ -2487,7 +2487,7 @@ _setFromPythonScalarCore(PyArrayObject *a, long offset, PyObject*value, int entr
 static int
 NA_setFromPythonScalar(PyArrayObject *a, long offset, PyObject *value)
 {
-    if (PyArray_RequireWriteable(a, NULL) < 0) {
+    if (PyArray_FailUnlessWriteable(a, "array") < 0) {
         return -1;
     }
     return _setFromPythonScalarCore(a, offset, value, 0);

--- a/numpy/numarray/_capi.c
+++ b/numpy/numarray/_capi.c
@@ -1077,9 +1077,12 @@ NA_OutputArray(PyObject *a, NumarrayType t, int requires)
     PyArray_Descr *dtype;
     PyArrayObject *ret;
 
-    if (!PyArray_Check(a) || !PyArray_ISWRITEABLE((PyArrayObject *)a)) {
+    if (!PyArray_Check(a)) {
         PyErr_Format(PyExc_TypeError,
-                "NA_OutputArray: only writeable arrays work for output.");
+                "NA_OutputArray: only arrays work for output.");
+        return NULL;
+    }
+    if (PyArray_RequireWriteable((PyArrayObject *)a, NULL) < 0) {
         return NULL;
     }
 
@@ -1127,9 +1130,7 @@ NA_IoArray(PyObject *a, NumarrayType t, int requires)
     /* Guard against non-writable, but otherwise satisfying requires.
        In this case,  shadow == a.
        */
-    if (!PyArray_ISWRITABLE(shadow)) {
-        PyErr_Format(PyExc_TypeError,
-                "NA_IoArray: I/O array must be writable array");
+    if (!PyArray_RequireWriteable(shadow, NULL)) {
         PyArray_XDECREF_ERR(shadow);
         return NULL;
     }
@@ -2488,13 +2489,10 @@ _setFromPythonScalarCore(PyArrayObject *a, long offset, PyObject*value, int entr
 static int
 NA_setFromPythonScalar(PyArrayObject *a, long offset, PyObject *value)
 {
-    if (PyArray_FLAGS(a) & NPY_ARRAY_WRITEABLE)
-        return _setFromPythonScalarCore(a, offset, value, 0);
-    else {
-        PyErr_Format(
-                PyExc_ValueError, "NA_setFromPythonScalar: assigment to readonly array buffer");
+    if (PyArray_RequireWriteable(a, NULL) < 0) {
         return -1;
     }
+    return _setFromPythonScalarCore(a, offset, value, 0);
 }
 
 


### PR DESCRIPTION
This pull request implements a transition scheme so that someday PyArray_Diagonal (and its interfaces numpy.diagonal, ndarray.diagonal, etc.) can return a view rather than a copy.

The proposed scheme is:
- Numpy 1.7: PyArray_Diagonal returns a copy (as before), but writes to this copy produce a DeprecationWarning.
- Numpy 1.8: PyArray_Diagonal returns a view, but writes to this view produce an error.
- Numpy 1.9: PyArray_Diagonal returns an ordinary view, transition complete.

The 1.7 DeprecationWarning is implemented by this pull request, which adds a new hidden flag called NPY_ARRAY_WARN_ON_WRITE ('hidden' in the sense that it isn't exposed to Python by the flagsobject, though you can still see it from Python if you want by checking arr.flags.num & 0x10000). This flag is propagated through views, and, if set, causes a warning to be issued on the first write to an array.

I recommend looking at the individual commit diffs rather than the overall pull-request diff, since each commit is a self-contained unit. In particular the first 3 are generally useful cleanups independently of whatever we do with PyArray_Diagonal, the 4th implements the actual change, and the 5th documents it.
