### PR TITLE
TST: mark test for floating point exceptions as knownfail.  See #1755.

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -285,6 +285,7 @@ class TestFloatExceptions(TestCase):
         self.assert_raises_fpe(fpeerr, flop, sc1, sc2[()]);
         self.assert_raises_fpe(fpeerr, flop, sc1[()], sc2[()]);
 
+    @dec.knownfailureif(True, "See ticket 1755")
     def test_floating_exceptions(self):
         """Test basic arithmetic function errors"""
         oldsettings = np.seterr(all='raise')


### PR DESCRIPTION
Note that this test was marked as knownfail in 1.5.x and 1.6.x; it is reported as failing on many different platforms.
