### PR TITLE
Add data memory allocation tracing facilities.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -6486,7 +6486,7 @@ add_newdoc('numpy.core.multiarray', 'busday_count',
     53
     """)
 
-add_newdoc('numpy.core.multiarray', 'trace_data_allocations',
+add_newdoc('numpy.core', 'trace_data_allocations',
     """
     trace_data_allocations(malloc_callback=None, free_callback=None, realloc_callback=None)
 
@@ -6501,7 +6501,13 @@ add_newdoc('numpy.core.multiarray', 'trace_data_allocations',
     realloc_callback : function(newptr, oldptr, size)
         Callback for reallocation corresponding to newptr = realloc(oldptr, size).
 
-     Pointers are passed as Python longs.
+     Pointers are passed to callbacks as Python longs.
+
+    Returns
+    -------
+    trace_data_allocations : old_malloc_callback, old_free_callback, old_realloc_callback
+        The previous callbacks, with None for for callbacks that were not
+        active.
 
     Notes
     -----

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -6486,6 +6486,28 @@ add_newdoc('numpy.core.multiarray', 'busday_count',
     53
     """)
 
+add_newdoc('numpy.core.multiarray', 'trace_data_allocations',
+    """
+    trace_data_allocations(malloc_callback=None, free_callback=None, realloc_callback=None)
+
+    Enables tracing of malloc/free/realloc calls for numpy array data.
+
+    Parameters
+    ----------
+    malloc_callback : function(ptr, size)
+        Callback for allocation corresponding to ptr = malloc(size).
+    free_callback : function(ptr)
+        Callback for deallocation corresponding to free(ptr).
+    realloc_callback : function(newptr, oldptr, size)
+        Callback for reallocation corresponding to newptr = realloc(oldptr, size).
+
+     Pointers are passed as Python longs.
+
+    Notes
+    -----
+    Errors in callbacks are printed to stderr, but do not raise errors.
+    """)
+
 ##############################################################################
 #
 # nd_grid instances

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -25,6 +25,8 @@ from fromnumeric import amax as max, amin as min, \
      round_ as round
 from numeric import absolute as abs
 
+from multiarray import trace_data_allocations
+
 __all__ = ['char','rec','memmap']
 __all__ += numeric.__all__
 __all__ += fromnumeric.__all__

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -11,3 +11,5 @@
 0x00000006 = e61d5dc51fa1c6459328266e215d6987
 # Version 7 (NumPy 1.7) added API for NA, improved datetime64.
 0x00000007 = eb54c77ff4149bab310324cd7c0cb176
+# Version 8 (Numpy 1.7) malloc tracing
+0x00000008 = 0600509478f8bed89b108d9ad980c684

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -344,6 +344,10 @@ multiarray_funcs_api = {
     'NpyNA_FromDTypeAndPayload':            304,
     'PyArray_AllowNAConverter':             305,
     'PyArray_OutputAllowNAConverter':       306,
+    'PyDataMem_NEW':                        307,
+    'PyDataMem_FREE':                       308,
+    'PyDataMem_RENEW':                      309,
+
 }
 
 ufunc_types_api = {

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -357,19 +357,7 @@ NpyMaskValue_Create(npy_bool exposed, npy_uint8 payload)
    * allocated.
    */
 
-  /* Data buffer */
-#define NPY_TRACE_DATA_MALLOC 1
-
-#if NPY_TRACE_DATA_MALLOC == 1
-    /* Defined in core/src/multiarray/multiarraymodule.c */
-    extern char *PyDataMem_NEW(size_t size);
-    extern void PyDataMem_FREE(void *ptr);
-    extern char *PyDataMem_RENEW(void *ptr, size_t size);
-#else /* not tracing */
-    #define PyDataMem_NEW(size) ((char *)malloc(size))
-    #define PyDataMem_FREE(ptr)  free(ptr)
-    #define PyDataMem_RENEW(ptr,size) ((char *)realloc(ptr,size))
-#endif /* NPY_TRACE_DATA_MALLOC == 1*/
+  /* Data buffer - PyDataMem_NEW/FREE/RENEW are in multiarraymodule.c */
 
 #define NPY_USE_PYMEM 1
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -358,9 +358,20 @@ NpyMaskValue_Create(npy_bool exposed, npy_uint8 payload)
    */
 
   /* Data buffer */
-#define PyDataMem_NEW(size) ((char *)malloc(size))
-#define PyDataMem_FREE(ptr)  free(ptr)
-#define PyDataMem_RENEW(ptr,size) ((char *)realloc(ptr,size))
+#define NPY_TRACE_DATA_MALLOC 1
+
+#if NPY_TRACE_DATA_MALLOC == 1
+    /* Defined in core/src/multiarray/ctors.c */
+    char *PyDataMem_NEW(size_t size);
+    void PyDataMem_FREE(void *ptr);
+    char *PyDataMem_RENEW(void *ptr, size_t size);
+    /* Defined in core/src/multiarray/multiarraymodule.c */
+    PyObject *trace_data_malloc_callback, *trace_data_free_callback, *trace_data_realloc_callback;
+#else /* not tracing */
+    #define PyDataMem_NEW(size) ((char *)malloc(size))
+    #define PyDataMem_FREE(ptr)  free(ptr)
+    #define PyDataMem_RENEW(ptr,size) ((char *)realloc(ptr,size))
+#endif /* NPY_TRACE_DATA_MALLOC == 1*/
 
 #define NPY_USE_PYMEM 1
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -361,12 +361,10 @@ NpyMaskValue_Create(npy_bool exposed, npy_uint8 payload)
 #define NPY_TRACE_DATA_MALLOC 1
 
 #if NPY_TRACE_DATA_MALLOC == 1
-    /* Defined in core/src/multiarray/ctors.c */
-    char *PyDataMem_NEW(size_t size);
-    void PyDataMem_FREE(void *ptr);
-    char *PyDataMem_RENEW(void *ptr, size_t size);
     /* Defined in core/src/multiarray/multiarraymodule.c */
-    PyObject *trace_data_malloc_callback, *trace_data_free_callback, *trace_data_realloc_callback;
+    extern char *PyDataMem_NEW(size_t size);
+    extern void PyDataMem_FREE(void *ptr);
+    extern char *PyDataMem_RENEW(void *ptr, size_t size);
 #else /* not tracing */
     #define PyDataMem_NEW(size) ((char *)malloc(size))
     #define PyDataMem_FREE(ptr)  free(ptr)

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -29,7 +29,7 @@ C_ABI_VERSION = 0x01000009
 # without breaking binary compatibility.  In this case, only the C_API_VERSION
 # (*not* C_ABI_VERSION) would be increased.  Whenever binary compatibility is
 # broken, both C_API_VERSION and C_ABI_VERSION should be increased.
-C_API_VERSION = 0x00000007
+C_API_VERSION = 0x00000008
 
 class MismatchCAPIWarning(Warning):
     pass

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3659,111 +3659,100 @@ test_interrupt(PyObject *NPY_UNUSED(self), PyObject *args)
     return PyInt_FromLong(a);
 }
 
-/* These functions allow tracing of data buffer allocations from within python. */
-#if NPY_TRACE_DATA_MALLOC == 1
+/* Array data memory allocation/free/reallocation functions, with
+ * hooks for tracing in python functions.
+ */
 
-static PyObject *trace_data_malloc_callback, *trace_data_free_callback, *trace_data_realloc_callback;
+/* Callback functions.  They are either NULL (no tracing for that type
+ * of call) or a Python callable.  They are controlled by
+ * numpy.core.trace_data_allocations, defined below.
+ */
+static PyObject *trace_data_malloc_callback = NULL;
+static PyObject *trace_data_free_callback = NULL;
+static PyObject *trace_data_realloc_callback = NULL;
 
-char *
+/* Core of the callback functions. Note that this function is responsible for DECREFing args. */
+static _trace_data_callback(PyObject *callback, const char *name, PyObject *args)
+{
+    PyObject *ret, *f, *err_type, *err_value, *err_traceback;
+    PyGILState_STATE gstate;
+
+    gstate = PyGILState_Ensure();
+    /* If tracing causes an error, we log it but do not pass it upward
+     * to prevent tracing from interfering with program behavior.
+     */
+    PyErr_Fetch(&err_type, &err_value, &err_traceback);
+    if (args != NULL) {
+        ret = PyObject_CallObject(callback, args);
+        Py_XDECREF(ret);
+    }
+    Py_XDECREF(args);
+    if (PyErr_Occurred()) {
+        f = PySys_GetObject("stderr");
+        if (f != NULL && f != Py_None) {
+            PyFile_WriteString("Exception encountered in ", f);
+            PyFile_WriteString(name, f);
+            PyFile_WriteString(":\n    ", f);
+            PyErr_WriteUnraisable(callback);
+        }
+    }
+    /* Restore any previous error state. */
+    PyErr_Restore(err_type, err_value, err_traceback);
+    PyGILState_Release(gstate);
+}
+
+/*NUMPY_API
+ * Allocates memory for array data, calling the
+ * trace_data_malloc_callback if it's nonzero.
+ */
+NPY_NO_EXPORT char *
 PyDataMem_NEW(size_t size)
 {
     void *result;
-    PyObject *err_type, *err_value, *err_traceback;
-    PyObject *ret;
 
     result = malloc(size);
-    if ((! trace_data_malloc_callback) || (trace_data_malloc_callback == Py_None))
-        goto finish;
-
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
-
-    /* If tracing causes an error, we log it but do not pass it upward
-     *  to prevent tracing from interfering with normal program behavior.
-     */
-    PyErr_Fetch(&err_type, &err_value, &err_traceback);
-    ret = PyObject_CallFunction(trace_data_malloc_callback, "Nl",
-                                PyLong_FromVoidPtr(result), (long) size);
-    Py_XDECREF(ret);
-    if (PyErr_Occurred()) {
-        fprintf(stderr, "Error while tracing numpy data memory malloc:\n");
-        PyErr_PrintEx(0);
+    if (trace_data_malloc_callback) {
+        _trace_data_callback(trace_data_malloc_callback, "trace_data_malloc_callback",
+                             Py_BuildValue("Nl", PyLong_FromVoidPtr(result), (long) size));
     }
-
-    /* Restore any previous error state. */
-    PyErr_Restore(err_type, err_value, err_traceback);
-    PyGILState_Release(gstate);
- finish:
     return (char *)result;
 }
 
-
-void
+/*NUMPY_API
+ * Free memory for array data, calling the
+ * trace_data_free_callback if it's nonzero.
+ */
+NPY_NO_EXPORT void
 PyDataMem_FREE(void *ptr)
 {
-    PyObject *err_type, *err_value, *err_traceback;
-    PyObject *npy, *ret;
-
     free(ptr);
-
-    if ((! trace_data_free_callback) || (trace_data_free_callback == Py_None))
-        goto finish;
-
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
-
-    /* If tracing causes an error, we log it but do not pass it upward
-     *  to prevent tracing from interfering with normal program behavior.
-     */
-    PyErr_Fetch(&err_type, &err_value, &err_traceback);
-    ret = PyObject_CallFunction(trace_data_free_callback, "N",
-                                PyLong_FromVoidPtr(ptr));
-    Py_XDECREF(ret);
-    if (PyErr_Occurred()) {
-        fprintf(stderr, "Error while tracing numpy data memory free:\n");
-        PyErr_PrintEx(0);
+    if (trace_data_free_callback) {
+        _trace_data_callback(trace_data_free_callback, "trace_data_free_callback",
+                             Py_BuildValue("(N)", PyLong_FromVoidPtr(ptr)));
     }
-
-    /* Restore any previous error state. */
-    PyErr_Restore(err_type, err_value, err_traceback);
-    PyGILState_Release(gstate);
- finish:
-    return;
 }
 
-char *
+/*NUMPY_API
+ * Reallocate/resize memory for array data, calling the
+ * trace_data_realloc_callback if it's nonzero.
+ */
+NPY_NO_EXPORT char *
 PyDataMem_RENEW(void *ptr, size_t size)
 {
     void *result;
-    PyObject *err_type, *err_value, *err_traceback;
-    PyObject *ret;
 
     result = realloc(ptr, size);
-    if ((! trace_data_realloc_callback) || (trace_data_realloc_callback == Py_None))
-        goto finish;
-
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
-
-    /* If tracing causes an error, we log it but do not pass it upward
-     *  to prevent tracing from interfering with normal program behavior.
-     */
-    PyErr_Fetch(&err_type, &err_value, &err_traceback);
-    ret = PyObject_CallFunction(trace_data_realloc_callback, "NNl",
-                                PyLong_FromVoidPtr(result), PyLong_FromVoidPtr(ptr), (long) size);
-    Py_XDECREF(ret);
-    if (PyErr_Occurred()) {
-        fprintf(stderr, "Error while tracing numpy data memory realloc:\n");
-        PyErr_PrintEx(0);
+    if (trace_data_realloc_callback) {
+        _trace_data_callback(trace_data_realloc_callback, "trace_data_realloc_callback",
+                             Py_BuildValue("NNl",
+                                           PyLong_FromVoidPtr(result),
+                                           PyLong_FromVoidPtr(ptr),
+                                           (long) size));
     }
-
-    /* Restore any previous error state. */
-    PyErr_Restore(err_type, err_value, err_traceback);
-    PyGILState_Release(gstate);
- finish:
     return (char *)result;
 }
 
+/* Control data allocation/free/reallocation tracing. */
 static PyObject *
 trace_data_allocations(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 {
@@ -3772,36 +3761,38 @@ trace_data_allocations(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *
     PyObject *realloc_cb = Py_None;
     static char *kwlist[] = {"malloc_callback", "free_callback",
                              "realloc_callback", NULL};
-    PyObject *temp_mcb, *temp_fcb, *temp_rcb;
+    PyObject *result;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOO", kwlist,
                                      &malloc_cb, &free_cb, &realloc_cb)) {
         return NULL;
     }
 
-    /* It's possible that a trace callback will happen when we DECREF,
-     * hence the use of temps below to try to keep a consistent state.
-     */
-    temp_mcb = trace_data_malloc_callback;
-    temp_fcb = trace_data_free_callback;
-    temp_rcb = trace_data_realloc_callback;
+    /* old callbacks are returned to caller */
+    result = PyTuple_Pack(3,
+                          trace_data_malloc_callback  ? trace_data_malloc_callback  : Py_None,
+                          trace_data_free_callback    ? trace_data_free_callback    : Py_None,
+                          trace_data_realloc_callback ? trace_data_realloc_callback : Py_None);
+    if (result == NULL)
+        return NULL;
 
-    trace_data_malloc_callback = malloc_cb;
-    trace_data_free_callback = free_cb;
-    trace_data_realloc_callback = realloc_cb;
+    Py_XDECREF(trace_data_malloc_callback);
+    Py_XDECREF(trace_data_free_callback);
+    Py_XDECREF(trace_data_realloc_callback);
 
-    Py_INCREF(trace_data_malloc_callback);
-    Py_INCREF(trace_data_free_callback);
-    Py_INCREF(trace_data_realloc_callback);
+    /* replace None with NULL for the C functions above */
+    trace_data_malloc_callback  = (malloc_cb == Py_None)  ? NULL : malloc_cb;
+    trace_data_free_callback    = (free_cb == Py_None)    ? NULL : free_cb;
+    trace_data_realloc_callback = (realloc_cb == Py_None) ? NULL : realloc_cb;
 
-    Py_DECREF(temp_mcb);
-    Py_DECREF(temp_fcb);
-    Py_DECREF(temp_rcb);
+    Py_XINCREF(trace_data_malloc_callback);
+    Py_XINCREF(trace_data_free_callback);
+    Py_XINCREF(trace_data_realloc_callback);
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_INCREF(result);
+    return result;
 }
-#endif /* NPY_TRACE_DATA_MALLOC == 1 */
+
 
 static struct PyMethodDef array_module_methods[] = {
     {"_get_ndarray_c_version",
@@ -3949,11 +3940,9 @@ static struct PyMethodDef array_module_methods[] = {
     {"test_interrupt",
         (PyCFunction)test_interrupt,
         METH_VARARGS, NULL},
-#if NPY_TRACE_DATA_MALLOC == 1
     {"trace_data_allocations",
         (PyCFunction)trace_data_allocations,
         METH_VARARGS | METH_KEYWORDS, NULL},
-#endif
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 
@@ -4342,15 +4331,6 @@ PyMODINIT_FUNC initmultiarray(void) {
     if (set_typeinfo(d) != 0) {
         goto err;
     }
-
-#if NPY_TRACE_DATA_MALLOC == 1
-    trace_data_malloc_callback = Py_None;
-    trace_data_free_callback = Py_None;
-    trace_data_realloc_callback = Py_None;
-    Py_INCREF(trace_data_malloc_callback);
-    Py_INCREF(trace_data_free_callback);
-    Py_INCREF(trace_data_realloc_callback);
-#endif
 
     return RETVAL;
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3662,7 +3662,7 @@ test_interrupt(PyObject *NPY_UNUSED(self), PyObject *args)
 /* These functions allow tracing of data buffer allocations from within python. */
 #if NPY_TRACE_DATA_MALLOC == 1
 
-PyObject *trace_data_malloc_callback, *trace_data_free_callback, *trace_data_realloc_callback;
+static PyObject *trace_data_malloc_callback, *trace_data_free_callback, *trace_data_realloc_callback;
 
 char *
 PyDataMem_NEW(size_t size)

--- a/numpy/core/src/npysort/sort.c.src
+++ b/numpy/core/src/npysort/sort.c.src
@@ -38,6 +38,8 @@
 #define SMALL_MERGESORT 20
 #define SMALL_STRING 16
 
+#define PyDataMem_NEW(size) ((char *)malloc(size))
+#define PyDataMem_FREE(ptr)  free(ptr)
 
 /*
  *****************************************************************************

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2462,8 +2462,9 @@ class TestAllocationTracing(object):
 
     def test_tracing(self):
         try:
-            np.core.multiarray.trace_data_allocations(malloc_callback=self.remember_allocations,
-                                                      free_callback=self.remember_frees)
+            old = np.core.trace_data_allocations(malloc_callback=self.remember_allocations,
+                                                 free_callback=self.remember_frees)
+            assert_(old == (None, None, None))
             x = np.array([1, 2])  # should cause a malloc
             # we can get the data pointer via the ctypes interface
             ptr = x.ctypes.get_data()
@@ -2472,8 +2473,10 @@ class TestAllocationTracing(object):
             assert_(ptr in self.frees)
         finally:
             # deactivate tracing
-            np.core.multiarray.trace_data_allocations(malloc_callback=None,
-                                                      free_callback=None)
+            old = np.core.multiarray.trace_data_allocations(malloc_callback=None,
+                                                            free_callback=None)
+            assert_(old == (self.remember_allocations, self.remember_frees, None))
+
 
     def test_error_in_callback(self):
         try:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2464,7 +2464,6 @@ class TestAllocationTracing(object):
         try:
             old = np.core.trace_data_allocations(malloc_callback=self.remember_allocations,
                                                  free_callback=self.remember_frees)
-            assert_(old == (None, None, None))
             x = np.array([1, 2])  # should cause a malloc
             # we can get the data pointer via the ctypes interface
             ptr = x.ctypes.get_data()
@@ -2473,20 +2472,18 @@ class TestAllocationTracing(object):
             assert_(ptr in self.frees)
         finally:
             # deactivate tracing
-            old = np.core.multiarray.trace_data_allocations(malloc_callback=None,
-                                                            free_callback=None)
-            assert_(old == (self.remember_allocations, self.remember_frees, None))
-
+            prev = np.core.trace_data_allocations(*old)
+            assert_(prev == (self.remember_allocations, self.remember_frees, None))
 
     def test_error_in_callback(self):
         try:
-            np.core.multiarray.trace_data_allocations(malloc_callback=self.bad_remember_allocations,
-                                                      free_callback=5)
+            old = np.core.trace_data_allocations(malloc_callback=self.bad_remember_allocations,
+                                                 free_callback=5)
             x = np.array([1, 2])  # should cause a malloc, and an error in the callback.
             del x  # should cause an error trying to call the callback.
         finally:
             # deactivate tracing
-            np.core.multiarray.trace_data_allocations(malloc_callback=None)
+            np.core.trace_data_allocations(*old)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -670,7 +670,10 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
     /* only pre-calculate slopes if there are relatively few of them. */
     if (lenxp <= lenx) {
-        slopes = (double *) PyDataMem_NEW((lenxp - 1)*sizeof(double));
+        slopes = (double *) PyArray_malloc((lenxp - 1)*sizeof(double));
+        if (! slopes) {
+            goto fail;
+        }
         NPY_BEGIN_ALLOW_THREADS;
         for (i = 0; i < lenxp - 1; i++) {
             slopes[i] = (dy[i + 1] - dy[i])/(dx[i + 1] - dx[i]);
@@ -692,7 +695,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             }
         }
         NPY_END_ALLOW_THREADS;
-        PyDataMem_FREE(slopes);
+        PyArray_free(slopes);
     }
     else {
         NPY_BEGIN_ALLOW_THREADS;


### PR DESCRIPTION
Add numpy.core.multiarray.trace_data_allocations() function for
controlling tracing malloc/free/realloc for numpy data.  This
functionality is exposed by #defing NPY_TRACE_DATA_MALLOC to 1 in
ndarraytypes.h (the default with this commit).  When enabled,
PyDataMem_NEW/FREE/RENEW become actual functions, defined in
multiarraymodule.c, which call back into Python if callbacks are
registered with trace_data_allocations().

Also added tests, including handling python errors during a
callback,which I think should probably log errors but not actually
raise an exception.
