### PR TITLE
Add a little command-line tool for running tests, plus tox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ doc/cdoc/build
 *.egg-info
 # The shelf plugin uses this dir
 ./.shelf
+MANIFEST
 
 # Logs and databases #
 ######################
@@ -88,3 +89,4 @@ numpy/core/include/numpy/__ufunc_api.h
 numpy/core/include/numpy/_numpyconfig.h
 numpy/version.py
 site.cfg
+.tox

--- a/tools/test-installed-numpy.py
+++ b/tools/test-installed-numpy.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# A simple script to test the installed version of numpy by calling
+# 'numpy.test()'. Key features:
+#   -- convenient command-line syntax
+#   -- sets exit status appropriately, useful for automated test environments
+
+# It would be better to set this up as a module in the numpy namespace, so
+# that it could be run as:
+#   python -m numpy.run_tests <args>
+# But, python2.4's -m switch only works with top-level modules, not modules
+# that are inside packages. So, once we drop 2.4 support, maybe...
+
+import sys
+# In case we are run from the source directory, we don't want to import numpy
+# from there, we want to import the installed version:
+sys.path.pop(0)
+
+from optparse import OptionParser
+parser = OptionParser("usage: %prog [options] -- [nosetests options]")
+parser.add_option("-v", "--verbose",
+                  action="count", dest="verbose", default=1,
+                  help="increase verbosity")
+parser.add_option("--doctests",
+                  action="store_true", dest="doctests", default=False,
+                  help="Run doctests in module")
+parser.add_option("--coverage",
+                  action="store_true", dest="coverage", default=False,
+                  help="report coverage of NumPy code (requires 'coverage' module")
+parser.add_option("-m", "--mode",
+                  action="store", dest="mode", default="fast",
+                  help="'fast', 'full', or something that could be "
+                       "passed to nosetests -A [default: %default]")
+(options, args) = parser.parse_args()
+
+import numpy
+result = numpy.test(options.mode,
+                    verbose=options.verbose,
+                    extra_argv=args,
+                    doctests=options.doctests,
+                    coverage=options.coverage)
+
+if result.wasSuccessful():
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+# 'Tox' is a tool for automating sdist/build/test cycles against
+# multiple Python versions:
+#   http://pypi.python.org/pypi/tox
+#   http://tox.testrun.org/
+
+# Running the command 'tox' while in the root of the numpy source
+# directory will:
+#   - Create a numpy source distribution (setup.py sdist)
+#   - Then for every supported version of Python:
+#     - Create a virtualenv in .tox/py$VERSION and install
+#       dependencies. (These virtualenvs are cached across runs unless
+#       you use --recreate.)
+#     - Use pip to install the numpy sdist into the virtualenv
+#     - Run the numpy tests
+# To run against a specific subset of Python versions, use:
+#   tox -e py24,py27
+
+# Extra arguments will be passed to test-installed-numpy.py. To run
+# the full testsuite:
+#   tox full
+# To run with extra verbosity:
+#   tox -- -v
+
+# Tox assumes that you have appropriate Python interpreters already
+# installed and that they can be run as 'python2.4', 'python2.5', etc.
+
+[tox]
+envlist = py24,py25,py26,py27,py31,py32
+
+[testenv]
+deps=
+  nose
+changedir={envdir}
+commands=python {toxinidir}/tools/test-installed-numpy.py {posargs:}
+
+# Not run by default. Set up the way you want then use 'tox -e debug'
+# if you want it:
+[testenv:debug]
+basepython=PYTHON-WITH-DEBUG-INFO
+commands=gdb --args {envpython} {toxinidir}/tools/test-installed-numpy.py {posargs:}


### PR DESCRIPTION
Tox is a handy little tool to make it easier than not to run proper
tests that exercise the build system and are run against multiple
Python versions: http://pypi.python.org/pypi/tox
See comment at the top of tox.ini for hints.

(I got tired of setting up virtualenvs by hand, maybe other people are tired too... and the test runner script will be useful for CI whenever we get that set up.)
