### PR TITLE
Explicit import of modules into the space in core/__init__.py

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -7,7 +7,9 @@ import umath
 import _internal # for freeze programs
 import numerictypes as nt
 multiarray.set_typeDict(nt.sctypeDict)
+import numeric
 from numeric import *
+import fromnumeric
 from fromnumeric import *
 import defchararray as char
 import records as rec
@@ -15,9 +17,13 @@ from records import *
 from memmap import *
 from defchararray import chararray
 import scalarmath
+import function_base
 from function_base import *
+import machar
 from machar import *
+import getlimits
 from getlimits import *
+import shape_base
 from shape_base import *
 del nt
 


### PR DESCRIPTION
Otherwise there is no strict guarantee that they would be available
later on during population of **all**.

This issue was ran into while opening a python file in emacs with python-mode
and ropemacs:

```
Loading pymacs...done
Pymacs loading ropemacs...
File mode specification error: (error "Python: Traceback (most recent call last):
  File \"/usr/lib/python2.7/dist-packages/Pymacs/pymacs.py\", line 146, in loop
    value = eval(text)
  File \"<string>\", line 1, in <module>
  File \"/usr/lib/python2.7/dist-packages/Pymacs/pymacs.py\", line 246, in pymacs_load_helper
    object = __import__(module_name)
  File \"/usr/lib/python2.7/dist-packages/ropemacs/__init__.py\", line 4, in <module>
    import ropemode.interface
  File \"/usr/lib/python2.7/dist-packages/ropemode/interface.py\", line 3, in <module>
    import rope.base.change
  File \"/usr/lib/python2.7/dist-packages/rope/base/change.py\", line 2, in <module>
    import difflib
  File \"/usr/lib/python2.7/difflib.py\", line 36, in <module>
    from collections import namedtuple as _namedtuple
  File \"collections.py\", line 16, in <module>
    import numpy as np
  File \"/usr/lib/pymodules/python2.7/numpy/__init__.py\", line 137, in <module>
    import add_newdocs
  File \"/usr/lib/pymodules/python2.7/numpy/add_newdocs.py\", line 9, in <module>
    from numpy.lib import add_newdoc
  File \"/usr/lib/pymodules/python2.7/numpy/lib/__init__.py\", line 4, in <module>
    from type_check import *
  File \"/usr/lib/pymodules/python2.7/numpy/lib/type_check.py\", line 8, in <module>
    import numpy.core.numeric as _nx
  File \"/usr/lib/pymodules/python2.7/numpy/core/__init__.py\", line 30, in <module>
    __all__ += numeric.__all__
NameError: name numeric is not defined
")
```
