### PR TITLE
BUG: '-framework Python' is not needed and can interfere.

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -111,7 +111,7 @@ class IntelFCompiler(BaseIntelFCompiler):
                 opt.remove('-shared')
             except ValueError:
                 idx = 0
-            opt[idx:idx] = ['-dynamiclib', '-Wl,-undefined,dynamic_lookup', '-Wl,-framework,Python']
+            opt[idx:idx] = ['-dynamiclib', '-Wl,-undefined,dynamic_lookup']
         return opt
 
 class IntelItaniumFCompiler(IntelFCompiler):


### PR DESCRIPTION
In particular, when the Python framework building the extension is not named "Python". It then links with Apple's system Python framework and raises an error when the module is loaded.
