### PR TITLE
TST: Fix f2py ``test_kind.py`` for many compilers

### DIFF
--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -1,5 +1,6 @@
 import os
 import math
+import subprocess
 
 from numpy.testing import *
 from numpy import array
@@ -25,7 +26,21 @@ class TestKind(util.F2PyTest):
             assert_(selectedintkind(i) in [selected_int_kind(i),-1],\
                     'selectedintkind(%s): expected %r but got %r' %  (i, selected_int_kind(i), selectedintkind(i)))
 
-        for i in range(20):
+        max_real_kind = 15
+        try:
+            subprocess.check_call(['gfortran', '--version'],
+                    stdout=subprocess.PIPE)
+            max_real_kind = 20
+        except OSError:
+            # gfortran does not exist, so it is not the compiler used.
+            # Other compilers behave differently for kind numbers > 8.
+            # This includes Intel, PGI, Cray, and Pathscale.
+            # NAG behaves completely different, using 1, 2, 3 as its "kind"s.
+            # Details:
+            # https://gist.github.com/2767436
+            pass
+
+        for i in range(max_real_kind):
             assert_(selectedrealkind(i) in [selected_real_kind(i),-1],\
                     'selectedrealkind(%s): expected %r but got %r' %  (i, selected_real_kind(i), selectedrealkind(i)))
 


### PR DESCRIPTION
...ding 15 for all compilers (save for the NAG compiler). For gfortran it works for precision up to and including 20.

I suppose the selectedrealkind() function should be rewritten, otherwise f2py might use incorrect kind values for non-gfortran compilers. However, if there is no reliable way of detecting which compiler is being used, there is no way to know what the correct kind values are. An alternative is to not return kind values above 8, or to state more clearly that f2py does not support kinds above 8, or equivalently, selected_real_kind(p) for values p > 15.

I was forced to uninstall and reinstall both ifort and gfortran to run the tests properly. It turned out that the error I got previously was because numpy was very clever at finding my ifort installation, even after I removed the PATH modifications in .bash_profile...

(Some comments are related to an offline discussion with Ralf.)
