### PR TITLE
Nditer buffer flag

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -771,7 +771,7 @@ NpyIter_RequiresBuffering(NpyIter *iter)
     /*int ndim = NIT_NDIM(iter);*/
     int iop, nop = NIT_NOP(iter);
 
-    char *op_itflags;
+    npyiter_opitflags *op_itflags;
 
     if (!(itflags&NPY_ITFLAG_BUFFER)) {
         return 0;
@@ -1217,7 +1217,7 @@ NpyIter_GetReadFlags(NpyIter *iter, char *outreadflags)
     /*int ndim = NIT_NDIM(iter);*/
     int iop, nop = NIT_NOP(iter);
 
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
 
     for (iop = 0; iop < nop; ++iop) {
         outreadflags[iop] = (op_itflags[iop]&NPY_OP_ITFLAG_READ) != 0;
@@ -1234,7 +1234,7 @@ NpyIter_GetWriteFlags(NpyIter *iter, char *outwriteflags)
     /*int ndim = NIT_NDIM(iter);*/
     int iop, nop = NIT_NOP(iter);
 
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
 
     for (iop = 0; iop < nop; ++iop) {
         outwriteflags[iop] = (op_itflags[iop]&NPY_OP_ITFLAG_WRITE) != 0;
@@ -1330,7 +1330,7 @@ NpyIter_GetInnerFixedStrideArray(NpyIter *iter, npy_intp *out_strides)
 
     if (itflags&NPY_ITFLAG_BUFFER) {
         NpyIter_BufferData *data = NIT_BUFFERDATA(iter);
-        char *op_itflags = NIT_OPITFLAGS(iter);
+        npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
         npy_intp stride, *strides = NBF_STRIDES(data),
                 *ad_strides = NAD_STRIDES(axisdata0);
         PyArray_Descr **dtypes = NIT_DTYPES(iter);
@@ -1751,14 +1751,14 @@ npyiter_allocate_buffers(NpyIter *iter, char **errmsg)
     int iop = 0, nop = NIT_NOP(iter);
 
     npy_intp i;
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
     NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
     PyArray_Descr **op_dtype = NIT_DTYPES(iter);
     npy_intp buffersize = NBF_BUFFERSIZE(bufferdata);
     char *buffer, **buffers = NBF_BUFFERS(bufferdata);
 
     for (iop = 0; iop < nop; ++iop) {
-        char flags = op_itflags[iop];
+        npyiter_opitflags flags = op_itflags[iop];
 
         /*
          * If we have determined that a buffer may be needed,
@@ -1889,7 +1889,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
     int maskop = NIT_MASKOP(iter);
     int first_maskna_op = NIT_FIRST_MASKNA_OP(iter);
 
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
     NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
     NpyIter_AxisData *axisdata = NIT_AXISDATA(iter),
                     *reduce_outeraxisdata = NULL;
@@ -2116,7 +2116,7 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
     int iop, nop = NIT_NOP(iter);
     int first_maskna_op = NIT_FIRST_MASKNA_OP(iter);
 
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
     NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
     NpyIter_AxisData *axisdata = NIT_AXISDATA(iter),
                     *reduce_outeraxisdata = NULL;
@@ -2636,7 +2636,7 @@ npyiter_checkreducesize(NpyIter *iter, npy_intp count,
     npy_intp reducespace = 1, factor;
     npy_bool nonzerocoord;
 
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
     char stride0op[NPY_MAXARGS];
 
     /* Default to no outer axis */

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -27,14 +27,14 @@ static int
 npyiter_calculate_ndim(int nop, PyArrayObject **op_in,
                        int oa_ndim);
 static int
-npyiter_check_per_op_flags(npy_uint32 flags, char *op_itflags);
+npyiter_check_per_op_flags(npy_uint32 flags, npyiter_opitflags *op_itflags);
 static int
 npyiter_prepare_one_operand(PyArrayObject **op,
                         char **op_dataptr,
                         PyArray_Descr *op_request_dtype,
                         PyArray_Descr** op_dtype,
                         npy_uint32 flags,
-                        npy_uint32 op_flags, char *op_itflags);
+                        npy_uint32 op_flags, npyiter_opitflags *op_itflags);
 static int
 npyiter_prepare_operands(int nop, int first_maskna_op,
                     PyArrayObject **op_in,
@@ -43,16 +43,16 @@ npyiter_prepare_operands(int nop, int first_maskna_op,
                     PyArray_Descr **op_request_dtypes,
                     PyArray_Descr **op_dtype,
                     npy_uint32 flags,
-                    npy_uint32 *op_flags, char *op_itflags,
+                    npy_uint32 *op_flags, npyiter_opitflags *op_itflags,
                     npy_int8 *out_maskop,
                     npy_int8 *out_maskna_indices);
 static int
 npyiter_check_casting(int nop, PyArrayObject **op,
                     PyArray_Descr **op_dtype,
                     NPY_CASTING casting,
-                    char *op_itflags);
+                    npyiter_opitflags *op_itflags);
 static int
-npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, char *op_itflags,
+npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itflags,
                     char **op_dataptr,
                     npy_uint32 *op_flags, int **op_axes,
                     npy_intp *itershape,
@@ -74,25 +74,25 @@ static void
 npyiter_find_best_axis_ordering(NpyIter *iter);
 static PyArray_Descr *
 npyiter_get_common_dtype(int first_maskna_op, PyArrayObject **op,
-                        char *op_itflags, PyArray_Descr **op_dtype,
+                        npyiter_opitflags *op_itflags, PyArray_Descr **op_dtype,
                         PyArray_Descr **op_request_dtypes,
                         int only_inputs, int output_scalars);
 static PyArrayObject *
 npyiter_new_temp_array(NpyIter *iter, PyTypeObject *subtype,
-                npy_uint32 flags, char *op_itflags,
+                npy_uint32 flags, npyiter_opitflags *op_itflags,
                 int op_ndim, npy_intp *shape,
                 PyArray_Descr *op_dtype, int *op_axes);
 static int
 npyiter_allocate_arrays(NpyIter *iter,
                         npy_uint32 flags,
                         PyArray_Descr **op_dtype, PyTypeObject *subtype,
-                        npy_uint32 *op_flags, char *op_itflags,
+                        npy_uint32 *op_flags, npyiter_opitflags *op_itflags,
                         int **op_axes, int output_scalars);
 static int
 npyiter_fill_maskna_axisdata(NpyIter *iter, int **op_axes);
 static void
 npyiter_get_priority_subtype(int first_maskna_op, PyArrayObject **op,
-                            char *op_itflags,
+                            npyiter_opitflags *op_itflags,
                             double *subtype_priority, PyTypeObject **subtype);
 static int
 npyiter_allocate_transfer_functions(NpyIter *iter);
@@ -120,7 +120,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
     /* Per-operand values */
     PyArrayObject **op;
     PyArray_Descr **op_dtype;
-    char *op_itflags;
+    npyiter_opitflags *op_itflags;
     char **op_dataptr;
 
     npy_int8 *perm;
@@ -916,7 +916,7 @@ npyiter_calculate_ndim(int nop, PyArrayObject **op_in,
  * Returns 1 on success, 0 on failure.
  */
 static int
-npyiter_check_per_op_flags(npy_uint32 op_flags, char *op_itflags)
+npyiter_check_per_op_flags(npy_uint32 op_flags, npyiter_opitflags *op_itflags)
 {
     if ((op_flags & NPY_ITER_GLOBAL_FLAGS) != 0) {
         PyErr_SetString(PyExc_ValueError,
@@ -1027,7 +1027,7 @@ npyiter_prepare_one_operand(PyArrayObject **op,
                         PyArray_Descr *op_request_dtype,
                         PyArray_Descr **op_dtype,
                         npy_uint32 flags,
-                        npy_uint32 op_flags, char *op_itflags)
+                        npy_uint32 op_flags, npyiter_opitflags *op_itflags)
 {
     /* NULL operands must be automatically allocated outputs */
     if (*op == NULL) {
@@ -1228,7 +1228,7 @@ npyiter_prepare_operands(int nop, int first_maskna_op, PyArrayObject **op_in,
                     PyArray_Descr **op_request_dtypes,
                     PyArray_Descr **op_dtype,
                     npy_uint32 flags,
-                    npy_uint32 *op_flags, char *op_itflags,
+                    npy_uint32 *op_flags, npyiter_opitflags *op_itflags,
                     npy_int8 *out_maskop,
                     npy_int8 *out_maskna_indices)
 {
@@ -1421,7 +1421,7 @@ static int
 npyiter_check_casting(int first_maskna_op, PyArrayObject **op,
                     PyArray_Descr **op_dtype,
                     NPY_CASTING casting,
-                    char *op_itflags)
+                    npyiter_opitflags *op_itflags)
 {
     int iop;
 
@@ -1559,7 +1559,7 @@ check_mask_for_writemasked_reduction(NpyIter *iter, int iop)
  * Returns 1 on success, 0 on failure.
  */
 static int
-npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, char *op_itflags,
+npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itflags,
                     char **op_dataptr,
                     npy_uint32 *op_flags, int **op_axes,
                     npy_intp *itershape,
@@ -2522,7 +2522,7 @@ npyiter_find_best_axis_ordering(NpyIter *iter)
  */
 static PyArray_Descr *
 npyiter_get_common_dtype(int first_maskna_op, PyArrayObject **op,
-                        char *op_itflags, PyArray_Descr **op_dtype,
+                        npyiter_opitflags *op_itflags, PyArray_Descr **op_dtype,
                         PyArray_Descr **op_request_dtypes,
                         int only_inputs, int output_scalars)
 {
@@ -2588,7 +2588,7 @@ npyiter_get_common_dtype(int first_maskna_op, PyArrayObject **op,
  */
 static PyArrayObject *
 npyiter_new_temp_array(NpyIter *iter, PyTypeObject *subtype,
-                npy_uint32 flags, char *op_itflags,
+                npy_uint32 flags, npyiter_opitflags *op_itflags,
                 int op_ndim, npy_intp *shape,
                 PyArray_Descr *op_dtype, int *op_axes)
 {
@@ -2822,7 +2822,7 @@ static int
 npyiter_allocate_arrays(NpyIter *iter,
                         npy_uint32 flags,
                         PyArray_Descr **op_dtype, PyTypeObject *subtype,
-                        npy_uint32 *op_flags, char *op_itflags,
+                        npy_uint32 *op_flags, npyiter_opitflags *op_itflags,
                         int **op_axes, int output_scalars)
 {
     npy_uint32 itflags = NIT_ITFLAGS(iter);
@@ -3157,7 +3157,7 @@ npyiter_fill_maskna_axisdata(NpyIter *iter, int **op_axes)
     int first_maskna_op = NIT_FIRST_MASKNA_OP(iter);
     npy_int8 *perm;
 
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
     npy_int8 *maskna_indices = NIT_MASKNA_INDICES(iter);
     NpyIter_AxisData *axisdata;
     npy_intp sizeof_axisdata;
@@ -3291,7 +3291,7 @@ npyiter_fill_maskna_axisdata(NpyIter *iter, int **op_axes)
  */
 static void
 npyiter_get_priority_subtype(int first_maskna_op, PyArrayObject **op,
-                            char *op_itflags,
+                            npyiter_opitflags *op_itflags,
                             double *subtype_priority,
                             PyTypeObject **subtype)
 {
@@ -3317,7 +3317,7 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
     int first_maskna_op = NIT_FIRST_MASKNA_OP(iter);
 
     npy_intp i;
-    char *op_itflags = NIT_OPITFLAGS(iter);
+    npyiter_opitflags *op_itflags = NIT_OPITFLAGS(iter);
     NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
     NpyIter_AxisData *axisdata = NIT_AXISDATA(iter);
     PyArrayObject **op = NIT_OPERANDS(iter);
@@ -3334,7 +3334,7 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
     int needs_api = 0;
 
     for (iop = 0; iop < nop; ++iop) {
-        char flags = op_itflags[iop];
+        npyiter_opitflags flags = op_itflags[iop];
         /*
          * Reduction operands may be buffered with a different stride,
          * so we must pass NPY_MAX_INTP to the transfer function factory.

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -147,6 +147,8 @@ struct NpyIter_InternalOnly {
 typedef struct NpyIter_AD NpyIter_AxisData;
 typedef struct NpyIter_BD NpyIter_BufferData;
 
+typedef npy_int8 npyiter_opitflags;
+
 /* Byte sizes of the iterator members */
 #define NIT_PERM_SIZEOF(itflags, ndim, nop) \
         NPY_INTP_ALIGNED(NPY_MAXDIMS)
@@ -161,7 +163,7 @@ typedef struct NpyIter_BD NpyIter_BufferData;
 #define NIT_OPERANDS_SIZEOF(itflags, ndim, nop) \
         ((NPY_SIZEOF_INTP)*(nop))
 #define NIT_OPITFLAGS_SIZEOF(itflags, ndim, nop) \
-        (NPY_INTP_ALIGNED(nop))
+        (NPY_INTP_ALIGNED(sizeof(npyiter_opitflags) * nop))
 #define NIT_BUFFERDATA_SIZEOF(itflags, ndim, nop) \
         ((itflags&NPY_ITFLAG_BUFFER) ? ((NPY_SIZEOF_INTP)*(6 + 9*nop)) : 0)
 
@@ -224,8 +226,8 @@ typedef struct NpyIter_BD NpyIter_BufferData;
         &(iter)->iter_flexdata + NIT_BASEOFFSETS_OFFSET(itflags, ndim, nop)))
 #define NIT_OPERANDS(iter) ((PyArrayObject **)( \
         &(iter)->iter_flexdata + NIT_OPERANDS_OFFSET(itflags, ndim, nop)))
-#define NIT_OPITFLAGS(iter) ( \
-        &(iter)->iter_flexdata + NIT_OPITFLAGS_OFFSET(itflags, ndim, nop))
+#define NIT_OPITFLAGS(iter) ((npyiter_opitflags *)( \
+        &(iter)->iter_flexdata + NIT_OPITFLAGS_OFFSET(itflags, ndim, nop)))
 #define NIT_BUFFERDATA(iter) ((NpyIter_BufferData *)( \
         &(iter)->iter_flexdata + NIT_BUFFERDATA_OFFSET(itflags, ndim, nop)))
 #define NIT_AXISDATA(iter) ((NpyIter_AxisData *)( \

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -107,21 +107,23 @@
 /* Internal iterator per-operand iterator flags */
 
 /* The operand will be written to */
-#define NPY_OP_ITFLAG_WRITE        0x01
+#define NPY_OP_ITFLAG_WRITE        0x0001
 /* The operand will be read from */
-#define NPY_OP_ITFLAG_READ         0x02
+#define NPY_OP_ITFLAG_READ         0x0002
 /* The operand needs type conversion/byte swapping/alignment */
-#define NPY_OP_ITFLAG_CAST         0x04
+#define NPY_OP_ITFLAG_CAST         0x0004
 /* The operand never needs buffering */
-#define NPY_OP_ITFLAG_BUFNEVER     0x08
+#define NPY_OP_ITFLAG_BUFNEVER     0x0008
 /* The operand is aligned */
-#define NPY_OP_ITFLAG_ALIGNED      0x10
+#define NPY_OP_ITFLAG_ALIGNED      0x0010
 /* The operand is being reduced */
-#define NPY_OP_ITFLAG_REDUCE       0x20
+#define NPY_OP_ITFLAG_REDUCE       0x0020
 /* The operand is for temporary use, does not have a backing array */
-#define NPY_OP_ITFLAG_VIRTUAL      0x40
+#define NPY_OP_ITFLAG_VIRTUAL      0x0040
 /* The operand requires masking when copying buffer -> array */
-#define NPY_OP_ITFLAG_WRITEMASKED  0x80
+#define NPY_OP_ITFLAG_WRITEMASKED  0x0080
+/* The operand's data pointer is pointing into its buffer */
+#define NPY_OP_ITFLAG_USINGBUFFER  0x0100
 
 /*
  * The data layout of the iterator is fully specified by
@@ -147,7 +149,7 @@ struct NpyIter_InternalOnly {
 typedef struct NpyIter_AD NpyIter_AxisData;
 typedef struct NpyIter_BD NpyIter_BufferData;
 
-typedef npy_int8 npyiter_opitflags;
+typedef npy_int16 npyiter_opitflags;
 
 /* Byte sizes of the iterator members */
 #define NIT_PERM_SIZEOF(itflags, ndim, nop) \


### PR DESCRIPTION
This fixes trac ticket #2144. Adds a per-operand flag to track when a buffer needs to be copied back to its array.
