### PR TITLE
BUG: Add a gap in NPY_DATETIMEUNIT enum where 1.6 had the busday unit

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -229,22 +229,27 @@ typedef enum {
 #define NPY_DATETIME_MAX_ISO8601_STRLEN (21+3*5+1+3*6+6+1)
 
 typedef enum {
-        NPY_FR_Y, /* Years */
-        NPY_FR_M, /* Months */
-        NPY_FR_W, /* Weeks */
-        NPY_FR_D, /* Days */
-        NPY_FR_h, /* hours */
-        NPY_FR_m, /* minutes */
-        NPY_FR_s, /* seconds */
-        NPY_FR_ms,/* milliseconds */
-        NPY_FR_us,/* microseconds */
-        NPY_FR_ns,/* nanoseconds */
-        NPY_FR_ps,/* picoseconds */
-        NPY_FR_fs,/* femtoseconds */
-        NPY_FR_as,/* attoseconds */
-        NPY_FR_GENERIC /* Generic, unbound units, can convert to anything */
+        NPY_FR_Y = 0,  /* Years */
+        NPY_FR_M = 1,  /* Months */
+        NPY_FR_W = 2,  /* Weeks */
+        /* Gap where 1.6 NPY_FR_B (value 3) was */
+        NPY_FR_D = 4,  /* Days */
+        NPY_FR_h = 5,  /* hours */
+        NPY_FR_m = 6,  /* minutes */
+        NPY_FR_s = 7,  /* seconds */
+        NPY_FR_ms = 8, /* milliseconds */
+        NPY_FR_us = 9, /* microseconds */
+        NPY_FR_ns = 10,/* nanoseconds */
+        NPY_FR_ps = 11,/* picoseconds */
+        NPY_FR_fs = 12,/* femtoseconds */
+        NPY_FR_as = 13,/* attoseconds */
+        NPY_FR_GENERIC = 14 /* Generic, unbound units, can convert to anything */
 } NPY_DATETIMEUNIT;
 
+/*
+ * NOTE: With the NPY_FR_B gap for 1.6 ABI compatibility, NPY_DATETIME_NUMUNITS
+ *       is technically one more than the actual number of units.
+ */
 #define NPY_DATETIME_NUMUNITS (NPY_FR_GENERIC + 1)
 #define NPY_DATETIME_DEFAULTUNIT NPY_FR_GENERIC
 

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -41,6 +41,7 @@ NPY_NO_EXPORT char *_datetime_strings[NPY_DATETIME_NUMUNITS] = {
     "Y",
     "M",
     "W",
+    "<invalid>",
     "D",
     "h",
     "m",
@@ -949,6 +950,8 @@ static NPY_DATETIMEUNIT _multiples_table[16][4] = {
     {NPY_FR_W, NPY_FR_D, NPY_FR_h},
     {7,  168, 10080},                         /* NPY_FR_W */
     {NPY_FR_D, NPY_FR_h, NPY_FR_m},
+    {0},                                      /* Gap for removed NPY_FR_B */
+    {0},
     {24, 1440, 86400},                        /* NPY_FR_D */
     {NPY_FR_h, NPY_FR_m, NPY_FR_s},
     {60, 3600},                               /* NPY_FR_h */
@@ -1045,6 +1048,7 @@ _datetime_factors[] = {
     1,  /* Years - not used */
     1,  /* Months - not used */
     7,  /* Weeks -> Days */
+    1,  /* Business Days - was removed but a gap still exists in the enum */
     24, /* Days -> Hours */
     60, /* Hours -> Minutes */
     60, /* Minutes -> Seconds */

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -784,6 +784,7 @@ static char *_datetime_verbose_strings[NPY_DATETIME_NUMUNITS] = {
     "years",
     "months",
     "weeks",
+    "<invalid>",
     "days",
     "hours",
     "minutes",


### PR DESCRIPTION
1.7 doesn't have the business day unit, but instead provides
a separate business day API. For binary compatibility, as
experienced in Pandas use of datetime64, it's a good idea for
the numbers to stay the same.

@wesm, could you take a look and make sure this is good for Pandas?
