### PR TITLE
Index error info

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3527,7 +3527,8 @@ static int
         for (i = 0; i < n_outer; i++) {
             for (j = 0; j < m_middle; j++) {
                 tmp = indarray[j];
-                if (check_and_adjust_index(&tmp, nindarray, (int) j) < 0)
+                /* We don't know what axis we're operating on, so don't report it in case of an error. */
+                if (check_and_adjust_index(&tmp, nindarray, -1) < 0)
                     return 1;
                 if (nelem == 1) {
                     *dest++ = *(src + tmp);

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3527,13 +3527,14 @@ static int
         for (i = 0; i < n_outer; i++) {
             for (j = 0; j < m_middle; j++) {
                 tmp = indarray[j];
+                if ((tmp < -nindarray) || (tmp >= nindarray)) {
+                    PyErr_Format(PyExc_IndexError,
+                                 "index %"NPY_INTP_FMT" out of bounds in dimension %"NPY_INTP_FMT,
+                                 tmp, j);
+                    return 1;
+                }
                 if (tmp < 0) {
                     tmp = tmp + nindarray;
-                }
-                if ((tmp < 0) || (tmp >= nindarray)) {
-                    PyErr_SetString(PyExc_IndexError,
-                            "index out of range for array");
-                    return 1;
                 }
                 if (nelem == 1) {
                     *dest++ = *(src + tmp);

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3527,15 +3527,8 @@ static int
         for (i = 0; i < n_outer; i++) {
             for (j = 0; j < m_middle; j++) {
                 tmp = indarray[j];
-                if ((tmp < -nindarray) || (tmp >= nindarray)) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index %"NPY_INTP_FMT" out of bounds in dimension %"NPY_INTP_FMT,
-                                 tmp, j);
+                if (check_and_adjust_index(&tmp, nindarray, (int) j) < 0)
                     return 1;
-                }
-                if (tmp < 0) {
-                    tmp = tmp + nindarray;
-                }
                 if (nelem == 1) {
                     *dest++ = *(src + tmp);
                 }

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -510,6 +510,7 @@ NPY_NO_EXPORT char *
 index2ptr(PyArrayObject *mp, npy_intp i)
 {
     npy_intp dim0;
+    npy_intp orig_i = i;  /* in case of error. */
 
     if (PyArray_NDIM(mp) == 0) {
         PyErr_SetString(PyExc_IndexError, "0-d arrays can't be indexed");
@@ -525,7 +526,7 @@ index2ptr(PyArrayObject *mp, npy_intp i)
     if (i > 0 && i < dim0) {
         return PyArray_DATA(mp)+i*PyArray_STRIDES(mp)[0];
     }
-    PyErr_SetString(PyExc_IndexError,"index out of bounds");
+    PyErr_Format(PyExc_IndexError, "index %"NPY_INTP_FMT" out of bounds in dimension 0", orig_i);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -41,6 +41,15 @@ _array_find_python_scalar_type(PyObject *op);
 NPY_NO_EXPORT PyArray_Descr *
 _array_typedescr_fromstr(char *str);
 
+/* 
+ * Returns -1 and sets an exception if *index is an invalid index for
+ * an array of size max_item, otherwise adjusts it in place to be
+ * 0 <= *index < max_item, and returns 0.
+ * If axis >= 0, it will be reported as part of the exception.
+ */
+NPY_NO_EXPORT int
+check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis);
+
 NPY_NO_EXPORT char *
 index2ptr(PyArrayObject *mp, npy_intp i);
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2925,6 +2925,7 @@ PyArray_CheckAxis(PyArrayObject *arr, int *axis, int flags)
 {
     PyObject *temp1, *temp2;
     int n = PyArray_NDIM(arr);
+    int axis_orig = *axis;
 
     if (*axis == NPY_MAXDIMS || n == 0) {
         if (n != 1) {
@@ -2967,7 +2968,7 @@ PyArray_CheckAxis(PyArrayObject *arr, int *axis, int flags)
     }
     if ((*axis < 0) || (*axis >= n)) {
         PyErr_Format(PyExc_ValueError,
-                     "axis(=%d) out of bounds", *axis);
+                     "axis(=%d) out of bounds", axis_orig);
         Py_DECREF(temp2);
         return NULL;
     }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3383,17 +3383,18 @@ descr_subscript(PyArray_Descr *self, PyObject *op)
         PyObject *name;
         int size = PyTuple_GET_SIZE(self->names);
         int value = PyArray_PyIntAsInt(op);
+        int orig_value = value;
 
         if (PyErr_Occurred()) {
             return NULL;
         }
-        if (value < -size || value >= size) {
-            PyErr_Format(PyExc_IndexError,
-                         "Field index %d out of range.", value);
-            return NULL;
-        }
         if (value < 0) {
             value += size;
+        }
+        if (value < 0 || value >= size) {
+            PyErr_Format(PyExc_IndexError,
+                         "Field index %d out of range.", orig_value);
+            return NULL;
         }
         name = PyTuple_GET_ITEM(self->names, value);
         retval = descr_subscript(self, name);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3387,13 +3387,13 @@ descr_subscript(PyArray_Descr *self, PyObject *op)
         if (PyErr_Occurred()) {
             return NULL;
         }
+        if (value < -size || value >= size) {
+            PyErr_Format(PyExc_IndexError,
+                         "Field index %d out of range.", value);
+            return NULL;
+        }
         if (value < 0) {
             value += size;
-        }
-        if (value < 0 || value >= size) {
-            PyErr_Format(PyExc_IndexError,
-                    "Field index out of range.");
-            return NULL;
         }
         name = PyTuple_GET_ITEM(self->names, value);
         retval = descr_subscript(self, name);

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -174,14 +174,15 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             for (i = 0; i < n; i++) {
                 for (j = 0; j < m; j++) {
                     tmp = ((npy_intp *)(PyArray_DATA(indices)))[j];
-                    if (tmp < 0) {
-                        tmp = tmp + max_item;
-                    }
-                    if ((tmp < 0) || (tmp >= max_item)) {
-                        PyErr_SetString(PyExc_IndexError,
-                                "index out of range for array");
+                    if ((tmp < -max_item) || (tmp >= max_item)) {
+                        PyErr_Format(PyExc_IndexError,
+                                     "index %"NPY_INTP_FMT" out of range for array in dimension %"NPY_INTP_FMT,
+                                     tmp, axis);
                         NPY_AUXDATA_FREE(transferdata);
                         goto fail;
+                    }
+                    if (tmp < 0) {
+                        tmp = tmp + max_item;
                     }
                     maskedstransfer(dest, itemsize,
                                     src + tmp*chunk, itemsize,
@@ -252,14 +253,15 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             for (i = 0; i < n; i++) {
                 for (j = 0; j < m; j++) {
                     tmp = ((npy_intp *)(PyArray_DATA(indices)))[j];
+                    if ((tmp < -max_item) || (tmp >= max_item)) {
+                        PyErr_Format(PyExc_IndexError,
+                                     "index %"NPY_INTP_FMT" out of range for "
+                                     "array in dimension %"NPY_INTP_FMT,
+                                     tmp, axis);
+                        goto fail;
+                    }
                     if (tmp < 0) {
                         tmp = tmp + max_item;
-                    }
-                    if ((tmp < 0) || (tmp >= max_item)) {
-                        PyErr_SetString(PyExc_IndexError,
-                                "index out of range "\
-                                "for array");
-                        goto fail;
                     }
                     memmove(dest, src + tmp*chunk, chunk);
                     dest += chunk;
@@ -393,6 +395,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
                     tmp = tmp + max_item;
                 }
                 if ((tmp < 0) || (tmp >= max_item)) {
+                    /* TODO: should report out-of-range indices with axis */
                     PyErr_SetString(PyExc_IndexError,
                             "index out of " \
                             "range for array");
@@ -449,6 +452,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
                     tmp = tmp + max_item;
                 }
                 if ((tmp < 0) || (tmp >= max_item)) {
+                    /* TODO: should report out-of-range indices with axis */
                     PyErr_SetString(PyExc_IndexError,
                             "index out of " \
                             "range for array");
@@ -2531,7 +2535,9 @@ PyArray_MultiIndexGetItem(PyArrayObject *self, npy_intp *multi_index)
             }
 
             if (ind < 0 || ind >= shapevalue) {
-                PyErr_SetString(PyExc_ValueError, "index out of bounds");
+                PyErr_Format(PyExc_IndexError,
+                             "index %"NPY_INTP_FMT" out of bounds in dimension %d",
+                             multi_index[idim], idim);
                 return NULL;
             }
 
@@ -2560,7 +2566,9 @@ PyArray_MultiIndexGetItem(PyArrayObject *self, npy_intp *multi_index)
             }
 
             if (ind < 0 || ind >= shapevalue) {
-                PyErr_SetString(PyExc_ValueError, "index out of bounds");
+                PyErr_Format(PyExc_IndexError,
+                             "index %"NPY_INTP_FMT" out of bounds in dimension %d",
+                             multi_index[idim], idim);
                 return NULL;
             }
 
@@ -2608,7 +2616,9 @@ PyArray_MultiIndexSetItem(PyArrayObject *self, npy_intp *multi_index,
             }
 
             if (ind < 0 || ind >= shapevalue) {
-                PyErr_SetString(PyExc_ValueError, "index out of bounds");
+                PyErr_Format(PyExc_IndexError,
+                             "index %"NPY_INTP_FMT" out of bounds in dimension %d",
+                             multi_index[idim], idim);
                 return -1;
             }
 
@@ -2650,7 +2660,9 @@ PyArray_MultiIndexSetItem(PyArrayObject *self, npy_intp *multi_index,
             }
 
             if (ind < 0 || ind >= shapevalue) {
-                PyErr_SetString(PyExc_ValueError, "index out of bounds");
+                PyErr_Format(PyExc_IndexError,
+                             "index %"NPY_INTP_FMT" out of bounds in dimension %d",
+                             multi_index[idim], idim);
                 return -1;
             }
 

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -73,6 +73,7 @@ parse_index_entry(PyObject *op, npy_intp *step_size,
             i += max;
         }
         if (i >= max || i < 0) {
+            /* TODO: should report out-of-range indices with axis */
             PyErr_SetString(PyExc_IndexError, "invalid index");
             goto fail;
         }

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -975,6 +975,9 @@ iter_ass_sub_int(PyArrayIterObject *self, PyArrayObject *ind,
     copyswap = PyArray_DESCR(self->ao)->f->copyswap;
     if (PyArray_NDIM(ind) == 0) {
         num = *((npy_intp *)PyArray_DATA(ind));
+        if (check_and_adjust_index(&num, self->size, -1) < 0) {
+            return -1;
+        }
         PyArray_ITER_GOTO1D(self, num);
         copyswap(self->dataptr, val->dataptr, swap, self->ao);
         return 0;
@@ -1060,10 +1063,7 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
         PyErr_Clear();
     }
     else {
-        if (start < -self->size || start >= self->size) {
-            PyErr_Format(PyExc_ValueError,
-                         "index (%" NPY_INTP_FMT \
-                         ") out of range", start);
+        if (check_and_adjust_index(&start, self->size, -1) < 0) {
             goto finish;
         }
         retval = 0;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -57,14 +57,8 @@ array_big_item(PyArrayObject *self, npy_intp i)
 
     /* Bounds check and get the data pointer */
     dim0 = PyArray_DIM(self, 0);
-    if (i < -dim0 || i >= dim0) {
-        PyErr_Format(PyExc_IndexError,
-                     "index %"NPY_INTP_FMT" out of bounds in dimension 0",
-                     i);
+    if (check_and_adjust_index(&i, dim0, 0) < 0) {
         return NULL;
-    }
-    if (i < 0) {
-        i += dim0;
     }
     item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 
@@ -123,14 +117,8 @@ array_item_nice(PyArrayObject *self, Py_ssize_t i)
 
         /* Bounds check and get the data pointer */
         dim0 = PyArray_DIM(self, 0);
-        if (i < -dim0 || i >= dim0) {
-            PyErr_Format(PyExc_IndexError,
-                         "index %"NPY_INTP_FMT" out of bounds in dimension 0",
-                         i);
+        if (check_and_adjust_index(&i, dim0, 0) < 0) {
             return NULL;
-        }
-        if (i < 0) {
-            i += dim0;
         }
         item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 
@@ -206,14 +194,8 @@ array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
 
     /* Bounds check and get the data pointer */
     dim0 = PyArray_DIM(self, 0);
-    if (i < -dim0 || i >= dim0) {
-        PyErr_Format(PyExc_IndexError,
-                     "index %"NPY_INTP_FMT" out of bounds in dimension 0",
-                     i);
+    if (check_and_adjust_index(&i, dim0, 0) < 0) {
         return -1;
-    }
-    if (i < 0) {
-        i += dim0;
     }
     item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 
@@ -1610,19 +1592,10 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         if (!PyArray_HASMASKNA(self)) {
             for (idim = 0; idim < ndim; idim++) {
                 npy_intp v = vals[idim];
-                if (v < 0) {
-                    v += shape[idim];
-                }
-                if (v < 0 || v >= shape[idim]) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index (%"NPY_INTP_FMT") out of range "\
-                                 "(0<=index<%"NPY_INTP_FMT") in dimension %d",
-                                 vals[idim], PyArray_DIMS(self)[idim], idim);
+                if (check_and_adjust_index(&v, shape[idim], idim) < 0) {
                     return -1;
                 }
-                else {
-                    item += v * strides[idim];
-                }
+                item += v * strides[idim];
             }
             return PyArray_DESCR(self)->f->setitem(op, item, self);
         }
@@ -1633,20 +1606,11 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
 
             for (idim = 0; idim < ndim; idim++) {
                 npy_intp v = vals[idim];
-                if (v < 0) {
-                    v += shape[idim];
-                }
-                if (v < 0 || v >= shape[idim]) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index (%"NPY_INTP_FMT") out of range "\
-                                 "(0<=index<%"NPY_INTP_FMT") in dimension %d",
-                                 vals[idim], PyArray_DIMS(self)[idim], idim);
+                if (check_and_adjust_index(&v, shape[idim], idim) < 0) {
                     return -1;
                 }
-                else {
-                    item += v * strides[idim];
-                    maskna_item += v * maskna_strides[idim];
-                }
+                item += v * strides[idim];
+                maskna_item += v * maskna_strides[idim];
             }
             na = NpyNA_FromObject(op, 1);
             if (na == NULL) {
@@ -1768,19 +1732,10 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
         if (!PyArray_HASMASKNA(self)) {
             for (idim = 0; idim < ndim; idim++) {
                 npy_intp v = vals[idim];
-                if (v < 0) {
-                    v += shape[idim];
-                }
-                if (v < 0 || v >= shape[idim]) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index (%"NPY_INTP_FMT") out of range "\
-                                 "(0<=index<%"NPY_INTP_FMT") in dimension %d",
-                                 vals[idim], PyArray_DIMS(self)[idim], idim);
+                if (check_and_adjust_index(&v, shape[idim], idim) < 0) { 
                     return NULL;
                 }
-                else {
-                    item += v * strides[idim];
-                }
+                item += v * strides[idim];
             }
             return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
         }
@@ -1790,20 +1745,11 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
 
             for (idim = 0; idim < ndim; idim++) {
                 npy_intp v = vals[idim];
-                if (v < 0) {
-                    v += shape[idim];
-                }
-                if (v < 0 || v >= shape[idim]) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index (%"NPY_INTP_FMT") out of range "\
-                                 "(0<=index<%"NPY_INTP_FMT") in dimension %d",
-                                 vals[idim], PyArray_DIMS(self)[idim], idim);
+                if (check_and_adjust_index(&v, shape[idim], idim) < 0) {
                     return NULL;
                 }
-                else {
-                    item += v * strides[idim];
-                    maskna_item += v * maskna_strides[idim];
-                }
+                item += v * strides[idim];
+                maskna_item += v * maskna_strides[idim];
             }
             if (NpyMaskValue_IsExposed((npy_mask)*maskna_item)) {
                 return PyArray_Scalar(item, PyArray_DESCR(self),
@@ -2141,7 +2087,7 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
 
     subnd = PyArray_NDIM(arr) - mit->numiter;
     if (subnd < 0) {
-        PyErr_SetString(PyExc_ValueError,
+        PyErr_SetString(PyExc_IndexError,
                         "too many indices for array");
         return;
     }
@@ -2270,14 +2216,7 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
         while (it->index < it->size) {
             indptr = ((npy_intp *)it->dataptr);
             indval = *indptr;
-            if (indval < 0) {
-                indval += dimsize;
-            }
-            if (indval < 0 || indval >= dimsize) {
-                PyErr_Format(PyExc_IndexError,
-                             "index (%"NPY_INTP_FMT") out of range "\
-                             "(0<=index<%"NPY_INTP_FMT") in dimension %d",
-                             indval, (dimsize-1), mit->iteraxes[i]);
+            if (check_and_adjust_index(&indval, dimsize, mit->iteraxes[i]) < 0) {
                 goto fail;
             }
             PyArray_ITER_NEXT(it);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2203,7 +2203,7 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
         goto fail;
     }
     if (mit->ait->size == 0 && mit->size != 0) {
-        PyErr_SetString(PyExc_ValueError,
+        PyErr_SetString(PyExc_IndexError,
                         "invalid index into a 0-size array");
         goto fail;
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -57,12 +57,14 @@ array_big_item(PyArrayObject *self, npy_intp i)
 
     /* Bounds check and get the data pointer */
     dim0 = PyArray_DIM(self, 0);
+    if (i < -dim0 || i >= dim0) {
+        PyErr_Format(PyExc_IndexError,
+                     "index %"NPY_INTP_FMT" out of bounds in dimension 0",
+                     i);
+        return NULL;
+    }
     if (i < 0) {
         i += dim0;
-    }
-    if (i < 0 || i >= dim0) {
-        PyErr_SetString(PyExc_IndexError,"index out of bounds");
-        return NULL;
     }
     item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 
@@ -121,12 +123,14 @@ array_item_nice(PyArrayObject *self, Py_ssize_t i)
 
         /* Bounds check and get the data pointer */
         dim0 = PyArray_DIM(self, 0);
+        if (i < -dim0 || i >= dim0) {
+            PyErr_Format(PyExc_IndexError,
+                         "index %"NPY_INTP_FMT" out of bounds in dimension 0",
+                         i);
+            return NULL;
+        }
         if (i < 0) {
             i += dim0;
-        }
-        if (i < 0 || i >= dim0) {
-            PyErr_SetString(PyExc_IndexError,"index out of bounds");
-            return NULL;
         }
         item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 
@@ -202,12 +206,14 @@ array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
 
     /* Bounds check and get the data pointer */
     dim0 = PyArray_DIM(self, 0);
+    if (i < -dim0 || i >= dim0) {
+        PyErr_Format(PyExc_IndexError,
+                     "index %"NPY_INTP_FMT" out of bounds in dimension 0",
+                     i);
+        return -1;
+    }
     if (i < 0) {
         i += dim0;
-    }
-    if (i < 0 || i >= dim0) {
-        PyErr_SetString(PyExc_IndexError,"index out of bounds");
-        return -1;
     }
     item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -109,8 +109,11 @@ _array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
 
 /* contains optimization for 1-d arrays */
 NPY_NO_EXPORT PyObject *
-array_item_nice(PyArrayObject *self, Py_ssize_t i)
+array_item_nice(PyArrayObject *self, Py_ssize_t _i)
 {
+    /* Workaround Python 2.4: Py_ssize_t not the same as npyint_p */
+    npy_intp i = _i;
+
     if (PyArray_NDIM(self) == 1) {
         char *item;
         npy_intp dim0;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -697,14 +697,7 @@ array_toscalar(PyArrayObject *self, PyObject *args)
             return NULL;
         }
 
-        /* Negative indexing */
-        if (value < 0) {
-            value += size;
-        }
-
-        if (value < 0 || value >= size) {
-            PyErr_SetString(PyExc_ValueError,
-                    "index out of bounds");
+        if (check_and_adjust_index(&value, size, -1) < 0) {
             return NULL;
         }
 
@@ -783,14 +776,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
             return NULL;
         }
 
-        /* Negative indexing */
-        if (value < 0) {
-            value += size;
-        }
-
-        if (value < 0 || value >= size) {
-            PyErr_SetString(PyExc_ValueError,
-                    "index out of bounds");
+        if (check_and_adjust_index(&value, size, -1) < 0) {
             return NULL;
         }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -320,6 +320,7 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis)
     PyArrayObject *ret = NULL;
     PyArrayObject_fields *sliding_view = NULL;
     int has_maskna;
+    int orig_axis = axis;
 
     if (narrays <= 0) {
         PyErr_SetString(PyExc_ValueError,
@@ -342,7 +343,7 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis)
     }
     if (axis < 0 || axis >= ndim) {
         PyErr_Format(PyExc_IndexError,
-                        "axis %d out of bounds [0, %d)", axis, ndim);
+                     "axis %d out of bounds [0, %d)", orig_axis, ndim);
         return NULL;
     }
 

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -1,0 +1,149 @@
+import numpy as np
+from numpy.testing import TestCase, run_module_suite, assert_raises, assert_equal, assert_
+import sys
+
+class TestIndexErrors(TestCase):
+    '''Tests to exercise indexerrors not covered by other tests.'''
+
+    def test_arraytypes_fasttake(self):
+        'take from a 0-length dimension'
+        x = np.empty((2, 3, 0, 4))
+        assert_raises(IndexError, x.take, [0], axis=2)
+        assert_raises(IndexError, x.take, [1], axis=2)
+
+    def test_maskna_take_1D(self):
+        # Check exception taking from masked array
+        a = np.array([1, np.NA, 2, np.NA], maskna=True)
+        assert_raises(IndexError, a.take, [6])
+        a = np.array(np.NA, maskna=True)
+        assert_raises(IndexError, a.take, [6])
+
+        # Check exception taking from masked 0-d array
+        d = np.empty((5, 0), maskna=True)
+        assert_raises(IndexError, d.take, [1], axis=1)
+        assert_raises(IndexError, d.take, [0], axis=1)
+        assert_raises(IndexError, d.take, [0])
+
+    def test_take_from_object(self):
+        # Check exception taking from object array
+        d = np.zeros(5, dtype=object)
+        assert_raises(IndexError, d.take, [6])
+
+        # Check exception taking from 0-d array
+        d = np.zeros((5, 0), dtype=object)
+        assert_raises(IndexError, d.take, [1], axis=1)
+        assert_raises(IndexError, d.take, [0], axis=1)
+        assert_raises(IndexError, d.take, [0])
+
+    def test_multiindex_exceptions(self):
+        a = np.empty(5, dtype=object)
+        assert_raises(IndexError, a.item, 20)
+        a = np.empty((5, 0), dtype=object)
+        assert_raises(IndexError, a.item, (0, 0))
+        a = np.empty(5, dtype=object, maskna=True)
+        assert_raises(IndexError, a.item, 20)
+        a = np.empty((5, 0), dtype=object, maskna=True)
+        assert_raises(IndexError, a.item, (0, 0))
+
+        a = np.empty(5, dtype=object)
+        assert_raises(IndexError, a.itemset, 20, 0)
+        a = np.empty((5, 0), dtype=object)
+        assert_raises(IndexError, a.itemset, (0, 0), 0)
+        a = np.empty(5, dtype=object, maskna=True)
+        assert_raises(IndexError, a.itemset, 20, 0)
+        a = np.empty((5, 0), dtype=object, maskna=True)
+        assert_raises(IndexError, a.itemset, (0, 0), 0)
+
+    def test_put_exceptions(self):
+        a = np.zeros((5, 5))
+        assert_raises(IndexError, a.put, 100, 0)
+        a = np.zeros((5, 5), dtype=object)
+        assert_raises(IndexError, a.put, 100, 0)
+        a = np.zeros((5, 5, 0))
+        assert_raises(IndexError, a.put, 100, 0)
+        a = np.zeros((5, 5, 0), dtype=object)
+        assert_raises(IndexError, a.put, 100, 0)
+
+    def test_iterators_exceptions(self):
+        "cases in iterators.c"
+        def assign(obj, ind, val):
+            obj[ind] = val
+
+        a = np.zeros([1,2,3])
+        assert_raises(IndexError, lambda: a[0,5,None,2])
+        assert_raises(IndexError, lambda: a[0,5,0,2])
+        assert_raises(IndexError, lambda: assign(a, (0,5,None,2), 1))
+        assert_raises(IndexError, lambda: assign(a, (0,5,0,2),  1))
+
+        a = np.zeros([1,0,3])
+        assert_raises(IndexError, lambda: a[0,0,None,2])
+        assert_raises(IndexError, lambda: assign(a, (0,0,None,2), 1))
+
+        a = np.zeros([1,2,3])
+        assert_raises(IndexError, lambda: a.flat[10])
+        assert_raises(IndexError, lambda: assign(a.flat, 10, 5))
+        a = np.zeros([1,0,3])
+        assert_raises(IndexError, lambda: a.flat[10])
+        assert_raises(IndexError, lambda: assign(a.flat, 10, 5))
+
+        a = np.zeros([1,2,3])
+        assert_raises(IndexError, lambda: a.flat[np.array(10)])
+        assert_raises(IndexError, lambda: assign(a.flat, np.array(10), 5))
+        a = np.zeros([1,0,3])
+        assert_raises(IndexError, lambda: a.flat[np.array(10)])
+        assert_raises(IndexError, lambda: assign(a.flat, np.array(10), 5))
+
+        a = np.zeros([1,2,3])
+        assert_raises(IndexError, lambda: a.flat[np.array([10])])
+        assert_raises(IndexError, lambda: assign(a.flat, np.array([10]), 5))
+        a = np.zeros([1,0,3])
+        assert_raises(IndexError, lambda: a.flat[np.array([10])])
+        assert_raises(IndexError, lambda: assign(a.flat, np.array([10]), 5))
+
+    def test_mapping(self):
+        "cases from mapping.c"
+
+        def assign(obj, ind, val):
+            obj[ind] = val
+
+        a = np.zeros((0, 10))
+        assert_raises(IndexError, lambda: a[12])
+
+        a = np.zeros((3,5))
+        assert_raises(IndexError, lambda: a[(10, 20)])
+        assert_raises(IndexError, lambda: assign(a, (10, 20), 1))
+        a = np.zeros((3,0))
+        assert_raises(IndexError, lambda: a[(1, 0)])
+        assert_raises(IndexError, lambda: assign(a, (1, 0), 1))
+
+        a = np.zeros((3,5), maskna=True)
+        assert_raises(IndexError, lambda: a[(10, 20)])
+        assert_raises(IndexError, lambda: assign(a, (10, 20), 1))
+        a = np.zeros((3,0), maskna=True)
+        assert_raises(IndexError, lambda: a[(1, 0)])
+        assert_raises(IndexError, lambda: assign(a, (1, 0), 1))
+
+        a = np.zeros((10,))
+        assert_raises(IndexError, lambda: assign(a, 10, 1))
+        a = np.zeros((0,))
+        assert_raises(IndexError, lambda: assign(a, 10, 1))
+
+        a = np.zeros((3,5))
+        assert_raises(IndexError, lambda: a[(1, [1, 20])])
+        assert_raises(IndexError, lambda: assign(a, (1, [1, 20]), 1))
+        a = np.zeros((3,0))
+        assert_raises(IndexError, lambda: a[(1, [0, 1])])
+        assert_raises(IndexError, lambda: assign(a, (1, [0, 1]), 1))
+
+    def test_methods(self):
+        "cases from methods.c"
+
+        a = np.zeros((3, 3))
+        assert_raises(IndexError, lambda: a.item(100))
+        assert_raises(IndexError, lambda: a.itemset(100, 1))
+        a = np.zeros((0, 3))
+        assert_raises(IndexError, lambda: a.item(100))
+        assert_raises(IndexError, lambda: a.itemset(100, 1))
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Adds a check_and_adjust_index function in common.c that is used to verify indices and adjust them for negative indexing.  Invalid indexes produce an IndexError, and the function returns -1.  Otherwise, the index is adjusted in-place (for negative indices), and the function returns 0.

The IndexError produced by this function includes information about the invalid value, the array axis where it caused a problem, and the valid range (when this information is available).

Nearly all such indexing adjustment and validation in the numpy source have been replaced by calls to this function, and a few cases of ValueError in indexing have been replaced by IndexError for consistency.

A couple of open questions:
- In arraytypes.c.src:...fasttake(), there's no way to know the axis in the call to check_and_adjust_index(), so it can't report the axis in the case of an invalid index.  Adding an argument to fasttake would allow it to be reported.  I wasn't sure this was an acceptable change.
- In cases of operations that implicitly operate on a flattened array, the IndexError reports that bad indices are out of bound on axis=0, which might be confusing in some cases.  One solution would be to add an argument to check_and_adjust_index() indicating whether the array being indexed was 1-dimensional, and not report an axis in this case.
