### PR TITLE
sphinxext cleanup

### DIFF
--- a/doc/sphinxext/LICENSE.txt
+++ b/doc/sphinxext/LICENSE.txt
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
     The files
     - numpydoc.py
-    - autosummary.py
-    - autosummary_generate.py
     - docscrape.py
     - docscrape_sphinx.py
     - phantom_import.py
@@ -71,10 +69,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 -------------------------------------------------------------------------------
-    The files
-    - only_directives.py
+    The file
     - plot_directive.py
-    originate from Matplotlib (http://matplotlib.sf.net/) which has
+    originates from Matplotlib (http://matplotlib.sf.net/) which has
     the following license:
 
 Copyright (c) 2002-2008 John D. Hunter; All Rights Reserved.

--- a/doc/sphinxext/setup.py
+++ b/doc/sphinxext/setup.py
@@ -1,13 +1,11 @@
 from distutils.core import setup
-import setuptools
-import sys, os
 
 version = "0.4"
 
 setup(
     name="numpydoc",
     packages=["numpydoc"],
-    package_dir={"numpydoc": ""},
+    package_dir={"numpydoc": "."},
     version=version,
     description="Sphinx extension to support docstrings in Numpy format",
     # classifiers from http://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -20,12 +18,6 @@ setup(
     author_email="pav@iki.fi",
     url="http://github.com/numpy/numpy/tree/master/doc/sphinxext",
     license="BSD",
-    zip_safe=False,
-    install_requires=["Sphinx >= 1.0.1"],
-    package_data={'numpydoc': 'tests', '': ''},
-    entry_points={
-        "console_scripts": [
-            "autosummary_generate = numpydoc.autosummary_generate:main",
-        ],
-    },
+    requires=["sphinx (>= 1.0.1)"],
+    package_data={'numpydoc': ['tests/test_*.py']},
 )


### PR DESCRIPTION
Some changes concerning Numpy's Sphinx extension. Obsolete entries in `setup.py` are dropped, which allows to use only distutils (and not setuptools). Also update the license file.
