### PR TITLE
BUG: missing incref for metadata of datetime dtypes.

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2531,7 +2531,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
     }
 
     if (PyDataType_ISDATETIME(self) && (metadata != NULL)) {
-        PyObject *new_metadata, *errmsg;
+        PyObject *old_metadata, *errmsg;
         PyArray_DatetimeMetaData temp_dt_data;
 
         if ((! PyTuple_Check(metadata)) || (PyTuple_Size(metadata) != 2)) {
@@ -2547,18 +2547,19 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
             return NULL;
         }
 
-        new_metadata = PyTuple_GET_ITEM(metadata, 0);
-        Py_XINCREF(new_metadata);
-        Py_XDECREF(self->metadata);
-        self->metadata = new_metadata;
+        old_metadata = self->metadata;
+        self->metadata = PyTuple_GET_ITEM(metadata, 0);
+        Py_XINCREF(self->metadata);
+        Py_XDECREF(old_metadata);
         memcpy((char *) &((PyArray_DatetimeDTypeMetaData *)self->c_metadata)->meta,
                (char *) &temp_dt_data,
                sizeof(PyArray_DatetimeMetaData));
     }
     else {
-        Py_XINCREF(metadata);
-        Py_XDECREF(self->metadata);
+        PyObject *old_metadata = self->metadata;
         self->metadata = metadata;
+        Py_XINCREF(self->metadata);
+        Py_XDECREF(old_metadata);
     }
 
     Py_INCREF(Py_None);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2536,6 +2536,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
 
         /* The Python metadata */
         self->metadata = PyTuple_GET_ITEM(metadata, 0);
+        Py_XINCREF(self->metadata);
 
         /* The datetime metadata */
         dt_data = &(((PyArray_DatetimeDTypeMetaData *)self->c_metadata)->meta);

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -547,6 +547,14 @@ class TestDateTime(TestCase):
               "I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
         assert_equal(pickle.loads(asbytes(pkl)), np.dtype('>M8[us]'))
 
+    def test_setstate(self):
+        "Verify that datetime dtype __setstate__ can handle bad arguments"
+        dt = np.dtype('>M8[us]')
+        assert_raises(ValueError, dt.__setstate__, (4, '>', None, None, None, -1, -1, 0, 1))
+        assert (dt.__reduce__()[2] == np.dtype('>M8[us]').__reduce__()[2])
+        assert_raises(TypeError, dt.__setstate__, (4, '>', None, None, None, -1, -1, 0, ({}, 'xxx')))
+        assert (dt.__reduce__()[2] == np.dtype('>M8[us]').__reduce__()[2])
+
     def test_dtype_promotion(self):
         # datetime <op> datetime computes the metadata gcd
         # timedelta <op> timedelta computes the metadata gcd


### PR DESCRIPTION
I'm fairly certain that this is the cause of some sporadic crashes I'm experiencing working on allocation tracking for numpy.

The bug can also be seen by building and running numpy under a python configured with --with-debug, which results in this crash when running nose.test(verbose=2):

```
[.....]
test_divisor_conversion_year (test_datetime.TestDateTime) ... ok
test_dtype_comparison (test_datetime.TestDateTime) ... ok
test_dtype_promotion (test_datetime.TestDateTime) ... ok
test_hours (test_datetime.TestDateTime) ... ok
test_month_truncation (test_datetime.TestDateTime) ... ok
test_pickle (test_datetime.TestDateTime) ... Fatal Python error: numpy/core/src/multiarray/descriptor.c:1564 object at 0x102a36010 has negative ref count -1
Abort trap
```

This is on OSX 10.6.8

```Python 2.7.3 (default, Jun  8 2012, 11:47:57) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

> > > import numpy
> > > [147717 refs]
> > > numpy.version.version
> > > '1.7.0.dev-5013093'
> > > [147719 refs]
> > > 
> > > ```
> > > (the refs lines are from the --with-debug)
> > > ```
