### PR TITLE
Numpy alloc logging

### DIFF
--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -346,6 +346,9 @@ multiarray_funcs_api = {
     'PyArray_OutputAllowNAConverter':       306,
     'PyArray_FailUnlessWriteable':          307,
     'PyArray_SetUpdateIfCopyBase':          308,
+    'PyDataMem_NEW':                        309,
+    'PyDataMem_FREE':                       310,
+    'PyDataMem_RENEW':                      311,
 }
 
 ufunc_types_api = {

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -357,10 +357,7 @@ NpyMaskValue_Create(npy_bool exposed, npy_uint8 payload)
    * allocated.
    */
 
-  /* Data buffer */
-#define PyDataMem_NEW(size) ((char *)malloc(size))
-#define PyDataMem_FREE(ptr)  free(ptr)
-#define PyDataMem_RENEW(ptr,size) ((char *)realloc(ptr,size))
+  /* Data buffer - PyDataMem_NEW/FREE/RENEW are in multiarraymodule.c */
 
 #define NPY_USE_PYMEM 1
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3659,6 +3659,39 @@ test_interrupt(PyObject *NPY_UNUSED(self), PyObject *args)
     return PyInt_FromLong(a);
 }
 
+/*NUMPY_API
+ * Allocates memory for array data.
+ */
+NPY_NO_EXPORT char *
+PyDataMem_NEW(size_t size)
+{
+    void *result;
+
+    result = malloc(size);
+    return (char *)result;
+}
+
+/*NUMPY_API
+ * Free memory for array data.
+ */
+NPY_NO_EXPORT void
+PyDataMem_FREE(void *ptr)
+{
+    free(ptr);
+}
+
+/*NUMPY_API
+ * Reallocate/resize memory for array data.
+ */
+NPY_NO_EXPORT char *
+PyDataMem_RENEW(void *ptr, size_t size)
+{
+    void *result;
+
+    result = realloc(ptr, size);
+    return (char *)result;
+}
+
 static struct PyMethodDef array_module_methods[] = {
     {"_get_ndarray_c_version",
         (PyCFunction)array__get_ndarray_c_version,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3784,7 +3784,6 @@ static PyObject *
 alloc_log_fetch(PyObject *NPY_UNUSED(module))
 {
     PyObject *ret, *event;
-    PyObject *inptr, *outptr, *size;
     int i, count;
     _alloc_event *buffer;
 
@@ -3803,29 +3802,12 @@ alloc_log_fetch(PyObject *NPY_UNUSED(module))
     }
 
     for (i = 0; i < count; i++) {
-        inptr = PyLong_FromVoidPtr(buffer[i].inptr);
-        if (inptr == NULL) {
-            goto fail;
-        }
-        outptr = PyLong_FromVoidPtr(buffer[i].outptr);
-        if (outptr == NULL) {
-            Py_DECREF(inptr);
-            goto fail;
-        }
-        size = PyLong_FromSsize_t(buffer[i].size);
-        if (size == NULL) {
-            Py_DECREF(inptr);
-            Py_DECREF(outptr);
-            goto fail;
-        }
-        /* Steal references to inptr, outptr, and size. */
         event = Py_BuildValue("sNNN",
                               buffer[i].type,
-                              inptr, outptr, size);
+                              PyLong_FromVoidPtr(buffer[i].inptr),
+                              PyLong_FromVoidPtr(buffer[i].outptr),
+                              PyLong_FromSsize_t(buffer[i].size));
         if (event == NULL) {
-            Py_DECREF(inptr);
-            Py_DECREF(outptr);
-            Py_DECREF(size);
             goto fail;
         }
         PyList_SET_ITEM(ret, i, event);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3719,7 +3719,7 @@ _alloc_log_event(char *type, void *inptr, void *outptr, size_t size)
 /*NUMPY_API
  * Allocates memory for array data.
  */
-NPY_NO_EXPORT char *
+NPY_NO_EXPORT void *
 PyDataMem_NEW(size_t size)
 {
     void *result;
@@ -3728,7 +3728,7 @@ PyDataMem_NEW(size_t size)
     if (_alloc_log_enabled) {
         _alloc_log_event("malloc", NULL, result, size);
     }
-    return (char *)result;
+    return result;
 }
 
 /*NUMPY_API
@@ -3746,7 +3746,7 @@ PyDataMem_FREE(void *ptr)
 /*NUMPY_API
  * Reallocate/resize memory for array data.
  */
-NPY_NO_EXPORT char *
+NPY_NO_EXPORT void *
 PyDataMem_RENEW(void *ptr, size_t size)
 {
     void *result;
@@ -3755,7 +3755,7 @@ PyDataMem_RENEW(void *ptr, size_t size)
     if (_alloc_log_enabled) {
         _alloc_log_event("realloc", ptr, result, size);
     }
-    return (char *)result;
+    return result;
 }
 
 static PyObject *

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3659,6 +3659,63 @@ test_interrupt(PyObject *NPY_UNUSED(self), PyObject *args)
     return PyInt_FromLong(a);
 }
 
+/* Array memory management and allocation logging.
+ *
+ * When allocation logging is enabled, we use a dynamic buffer to
+ * record each malloc/free/realloc.  This buffer can be fetched using
+ * the alloc_log_fetch() python function, and cleared with
+ * alloc_log_clear().
+ */
+
+typedef struct {
+    char *type;   /* "malloc", "free", "realloc" */
+    void *inptr;  /* NULL for malloc */
+    void *outptr; /* NULL for free */
+    size_t size;  /* 0 for FREE */
+} _alloc_event;
+
+static int _alloc_log_enabled = 0;
+static _alloc_event *_alloc_log_buffer = NULL;
+static int _alloc_log_count = 0;
+static int _alloc_log_size = 0;
+
+static void
+_alloc_log_event(char *type, void *inptr, void *outptr, size_t size)
+{
+    /* Locking provided by the GIL. */
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
+    if (_alloc_log_count == _alloc_log_size) {
+        /* buffer is full, or not yet allocated. */
+        int new_size = (_alloc_log_size == 0 ? 1000 : 2 * _alloc_log_size);
+        _alloc_event *new_buffer;
+        new_buffer = (_alloc_event *) realloc((void *)_alloc_log_buffer,
+                                              new_size * sizeof(_alloc_event));
+        if (new_buffer == NULL) {
+            /* We leave the buffer in its current state, but disable logging. */
+            _alloc_log_enabled = 0;
+
+            /* We can't go into python to report the error. */
+            fprintf(stderr,
+                    "Numpy allocation log of size %d bytes could not be allocated.\n"
+                    "Disabling allocation logging.\n",
+                    new_size * sizeof(_alloc_event));
+            goto end;
+        }
+        _alloc_log_buffer = new_buffer;
+        _alloc_log_size = new_size;
+    }
+
+    _alloc_log_buffer[_alloc_log_count].type = type;
+    _alloc_log_buffer[_alloc_log_count].inptr = inptr;
+    _alloc_log_buffer[_alloc_log_count].outptr = outptr;
+    _alloc_log_buffer[_alloc_log_count].size = size;
+    _alloc_log_count++;
+
+ end:
+    PyGILState_Release(gilstate);
+}
+
 /*NUMPY_API
  * Allocates memory for array data.
  */
@@ -3668,6 +3725,9 @@ PyDataMem_NEW(size_t size)
     void *result;
 
     result = malloc(size);
+    if (_alloc_log_enabled) {
+        _alloc_log_event("malloc", NULL, result, size);
+    }
     return (char *)result;
 }
 
@@ -3678,6 +3738,9 @@ NPY_NO_EXPORT void
 PyDataMem_FREE(void *ptr)
 {
     free(ptr);
+    if (_alloc_log_enabled) {
+        _alloc_log_event("free", ptr, NULL, 0);
+    }
 }
 
 /*NUMPY_API
@@ -3689,7 +3752,103 @@ PyDataMem_RENEW(void *ptr, size_t size)
     void *result;
 
     result = realloc(ptr, size);
+    if (_alloc_log_enabled) {
+        _alloc_log_event("realloc", ptr, result, size);
+    }
     return (char *)result;
+}
+
+static PyObject *
+alloc_log_enable(PyObject *NPY_UNUSED(module), PyObject *noargs)
+{
+    _alloc_log_enabled = 1;
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject *
+alloc_log_disable(PyObject *NPY_UNUSED(module), PyObject *noargs)
+{
+    _alloc_log_enabled = 0;
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject *
+alloc_log_isenabled(PyObject *NPY_UNUSED(module), PyObject *noargs)
+{
+    return PyBool_FromLong((long)_alloc_log_enabled);
+}
+
+static PyObject *
+alloc_log_fetch(PyObject *NPY_UNUSED(module))
+{
+    PyObject *ret, *event;
+    PyObject *inptr, *outptr, *size;
+    int i, count;
+    _alloc_event *buffer;
+
+    /* Reset the global buffer. Any events caused by a gc() during the
+     * calls below will start a new log.
+     */
+    count = _alloc_log_count;
+    buffer = _alloc_log_buffer;
+    _alloc_log_buffer = NULL;
+    _alloc_log_size = 0;
+    _alloc_log_count = 0;
+
+    ret = PyList_New(count);
+    if (ret == NULL) {
+        goto fail;
+    }
+
+    for (i = 0; i < count; i++) {
+        inptr = PyLong_FromVoidPtr(buffer[i].inptr);
+        if (inptr == NULL) {
+            goto fail;
+        }
+        outptr = PyLong_FromVoidPtr(buffer[i].outptr);
+        if (outptr == NULL) {
+            Py_DECREF(inptr);
+            goto fail;
+        }
+        size = PyLong_FromSsize_t(buffer[i].size);
+        if (size == NULL) {
+            Py_DECREF(inptr);
+            Py_DECREF(outptr);
+            goto fail;
+        }
+        /* Steal references to inptr, outptr, and size. */
+        event = Py_BuildValue("sNNN",
+                              buffer[i].type,
+                              inptr, outptr, size);
+        if (event == NULL) {
+            Py_DECREF(inptr);
+            Py_DECREF(outptr);
+            Py_DECREF(size);
+            goto fail;
+        }
+        PyList_SET_ITEM(ret, i, event);
+    }
+
+    free(buffer);
+    return ret;
+
+ fail:
+    free(buffer);
+    Py_XDECREF(ret);
+    return NULL;
+}
+
+static PyObject *
+alloc_log_clear(PyObject *NPY_UNUSED(module))
+{
+    free(_alloc_log_buffer);
+    _alloc_log_buffer = NULL;
+    _alloc_log_size = 0;
+    _alloc_log_count = 0;
+    Py_INCREF(Py_None);
+    return Py_None;
 }
 
 static struct PyMethodDef array_module_methods[] = {
@@ -3838,6 +3997,21 @@ static struct PyMethodDef array_module_methods[] = {
     {"test_interrupt",
         (PyCFunction)test_interrupt,
         METH_VARARGS, NULL},
+    {"alloc_log_enable",
+        (PyCFunction)alloc_log_enable,
+        METH_NOARGS,  NULL},
+    {"alloc_log_disable",
+        (PyCFunction)alloc_log_disable,
+        METH_NOARGS,  NULL},
+    {"alloc_log_isenabled",
+        (PyCFunction)alloc_log_isenabled,
+        METH_NOARGS,  NULL},
+    {"alloc_log_fetch",
+        (PyCFunction)alloc_log_fetch,
+        METH_NOARGS,  NULL},
+    {"alloc_log_clear",
+        (PyCFunction)alloc_log_clear,
+        METH_NOARGS,  NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/core/src/npysort/sort.c.src
+++ b/numpy/core/src/npysort/sort.c.src
@@ -38,6 +38,9 @@
 #define SMALL_MERGESORT 20
 #define SMALL_STRING 16
 
+/* XXX - These have moved to the numpy API */
+#define PyDataMem_NEW(size) ((char *)malloc(size))
+#define PyDataMem_FREE(ptr)  free(ptr)
 
 /*
  *****************************************************************************

--- a/numpy/core/src/npysort/sort.c.src
+++ b/numpy/core/src/npysort/sort.c.src
@@ -38,9 +38,12 @@
 #define SMALL_MERGESORT 20
 #define SMALL_STRING 16
 
-/* XXX - These have moved to the numpy API */
-#define PyDataMem_NEW(size) ((char *)malloc(size))
-#define PyDataMem_FREE(ptr)  free(ptr)
+/* These should be changed to PyDataMem_NEW/FREE if npysort is moved
+ *  to the multiarray directory.
+ */
+#define NpySortArray_malloc(size) ((char *)malloc(size))
+#define NpySortArray_free(ptr)  free(ptr)
+
 
 /*
  *****************************************************************************
@@ -338,14 +341,14 @@ mergesort_@suff@(@type@ *start, npy_intp num, void *NOT_USED)
 
     pl = start;
     pr = pl + num;
-    pw = (@type@ *) PyDataMem_NEW((num/2)*sizeof(@type@));
+    pw = (@type@ *) NpySortArray_malloc((num/2)*sizeof(@type@));
     if (!pw) {
         PyErr_NoMemory();
         return -1;
     }
     mergesort0_@suff@(pl, pr, pw);
 
-    PyDataMem_FREE(pw);
+    NpySortArray_free(pw);
     return 0;
 }
 
@@ -479,13 +482,13 @@ mergesort_@suff@(@type@ *start, npy_intp num, PyArrayObject *arr)
 
     pl = start;
     pr = pl + num*len;
-    pw = (@type@ *) PyDataMem_NEW((num/2)*elsize);
+    pw = (@type@ *) NpySortArray_malloc((num/2)*elsize);
     if (!pw) {
         PyErr_NoMemory();
         err = -1;
         goto fail_0;
     }
-    vp = (@type@ *) PyDataMem_NEW(elsize);
+    vp = (@type@ *) NpySortArray_malloc(elsize);
     if (!vp) {
         PyErr_NoMemory();
         err = -1;
@@ -493,9 +496,9 @@ mergesort_@suff@(@type@ *start, npy_intp num, PyArrayObject *arr)
     }
     mergesort0_@suff@(pl, pr, pw, vp, len);
 
-    PyDataMem_FREE(vp);
+    NpySortArray_free(vp);
 fail_1:
-    PyDataMem_FREE(pw);
+    NpySortArray_free(pw);
 fail_0:
     return err;
 }

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -670,7 +670,10 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
     /* only pre-calculate slopes if there are relatively few of them. */
     if (lenxp <= lenx) {
-        slopes = (double *) PyDataMem_NEW((lenxp - 1)*sizeof(double));
+        slopes = (double *) PyArray_malloc((lenxp - 1)*sizeof(double));
+        if (! slopes) {
+            goto fail;
+        }
         NPY_BEGIN_ALLOW_THREADS;
         for (i = 0; i < lenxp - 1; i++) {
             slopes[i] = (dy[i + 1] - dy[i])/(dx[i + 1] - dx[i]);
@@ -692,7 +695,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             }
         }
         NPY_END_ALLOW_THREADS;
-        PyDataMem_FREE(slopes);
+        PyArray_free(slopes);
     }
     else {
         NPY_BEGIN_ALLOW_THREADS;


### PR DESCRIPTION
A simpler version of the numpy allocation logging facility.  This is pure C in the malloc/free/realloc functions, with a dynamic logging buffer that python code can fetch on demand.

It still lacks documentation for the C allocation and python logging-related functions, and a home in the namespace.  numpy.testing?
