### PR TITLE
Fix for the error while pickling MaskedConstant.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5718,6 +5718,12 @@ class MaskedConstant(MaskedArray):
     def flatten(self):
         return masked_array([self._data], dtype=float, mask=[True])
 
+    def __reduce__(self):
+        """Override of MaskedArray's __reduce__.
+        """
+        return (self.__class__, ())
+
+
 masked = masked_singleton = MaskedConstant()
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -385,6 +385,16 @@ class TestMaskedArray(TestCase):
         assert_equal(a_pickled, a)
         self.assertTrue(isinstance(a_pickled._data, np.matrix))
 
+    def test_pickling_maskedconstant(self):
+        "Test pickling MaskedConstant"
+
+        import cPickle
+        mc = np.ma.masked
+        mc_pickled = cPickle.loads(mc.dumps())
+        assert_equal(mc_pickled._baseclass, mc._baseclass)
+        assert_equal(mc_pickled._mask, mc._mask)
+        assert_equal(mc_pickled._data, mc._data)
+
     def test_pickling_wstructured(self):
         "Tests pickling w/ structured array"
         import cPickle


### PR DESCRIPTION
Pickling an object that contains a MaskedConstant fails with: 
AttributeError: 'MaskedConstant' object has no attribute '_fill_value' .
This is due to an unsupported signature of MaskedConstant.__new__  that subclasses MaskedArray. The **reduce** method has to be adapted for the new signature.
