### PR TITLE
BUG: don't pollute public namespace with customized PyIndex_Check on Py2.4

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -149,6 +149,14 @@ PyUnicode_Concat2(PyObject **left, PyObject *right)
 #endif
 
 /*
+ * PyIndex_Check
+ */
+#if (PY_VERSION_HEX < 0x02050000)
+#undef PyIndex_Check
+#define PyIndex_Check(o)     0
+#endif
+
+/*
  * PyFile_* compatibility
  */
 #if defined(NPY_PY3K)

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -137,25 +137,6 @@ PyUnicode_Concat2(PyObject **left, PyObject *right)
     *left = newobj;
 }
 
-
-/*
- * Accessing items of ob_base
- */
-
-#if (PY_VERSION_HEX < 0x02060000)
-#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
-#define Py_REFCNT(o)  (((PyObject*)(o))->ob_refcnt)
-#define Py_SIZE(o)    (((PyVarObject*)(o))->ob_size)
-#endif
-
-/*
- * PyIndex_Check
- */
-#if (PY_VERSION_HEX < 0x02050000)
-#undef PyIndex_Check
-#define PyIndex_Check(o)     0
-#endif
-
 /*
  * PyFile_* compatibility
  */

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -48,9 +48,7 @@ typedef Py_uintptr_t npy_uintp;
     #define PY_SSIZE_T_MIN INT_MIN
   #endif
 #define NPY_SSIZE_T_PYFMT "i"
-#undef PyIndex_Check
 #define constchar const char
-#define PyIndex_Check(op) 0
 #else
 #define NPY_SSIZE_T_PYFMT "n"
 #define constchar char

--- a/numpy/core/src/dummymodule.c
+++ b/numpy/core/src/dummymodule.c
@@ -9,7 +9,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include <Python.h>
-#include <numpy/npy_3kcompat.h>
+#include <npy_pycompat.h>
 
 static struct PyMethodDef methods[] = {
     {NULL, NULL, 0, NULL}

--- a/numpy/core/src/multiarray/array_assign.c
+++ b/numpy/core/src/multiarray/array_assign.c
@@ -16,7 +16,7 @@
 #include <numpy/ndarraytypes.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "shape.h"
 

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -15,7 +15,7 @@
 #include <numpy/ndarraytypes.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "convert_datatype.h"
 #include "methods.h"

--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -15,7 +15,7 @@
 #include <numpy/ndarraytypes.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "convert_datatype.h"
 #include "methods.h"

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -32,7 +32,7 @@ maintainer email:  oliphant.travis@ieee.org
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -7,7 +7,7 @@
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 #include "numpy/npy_math.h"
 #include "numpy/halffloat.h"
 

--- a/numpy/core/src/multiarray/boolean_ops.c.src
+++ b/numpy/core/src/multiarray/boolean_ops.c.src
@@ -22,7 +22,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "reduction.h"
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "buffer.h"
 #include "numpyos.h"

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -8,7 +8,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "number.h"

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -6,7 +6,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "usertypes.h"
 

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -9,7 +9,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "arraytypes.h"

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "arrayobject.h"
 #include "mapping.h"

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "scalartypes.h"

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "ctors.h"

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -18,7 +18,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/arrayscalars.h"
 #include "methods.h"

--- a/numpy/core/src/multiarray/datetime_busday.c
+++ b/numpy/core/src/multiarray/datetime_busday.c
@@ -15,7 +15,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/arrayscalars.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -16,7 +16,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/arrayscalars.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -17,7 +17,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/arrayscalars.h"
 #include "methods.h"

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "_datetime.h"
 #include "common.h"

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -19,7 +19,7 @@
 #include <numpy/arrayobject.h>
 #include <numpy/npy_cpu.h>
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "convert_datatype.h"
 #include "_datetime.h"

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -16,7 +16,7 @@
 #define _MULTIARRAYMODULE
 #include <numpy/arrayobject.h>
 #include <numpy/halffloat.h>
-#include <numpy/npy_3kcompat.h>
+#include <npy_pycompat.h>
 
 #include <ctype.h>
 

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -10,7 +10,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "scalartypes.h"

--- a/numpy/core/src/multiarray/hashdescr.c
+++ b/numpy/core/src/multiarray/hashdescr.c
@@ -6,7 +6,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "hashdescr.h"
 

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "arrayobject.h"

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "arrayobject.h"
 #include "iterators.h"

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "iterators.h"

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -10,7 +10,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "ctors.h"

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -2,7 +2,7 @@
 #include <Python.h>
 #include "numpy/arrayobject.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 /*
  * TODO:

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -27,7 +27,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 

--- a/numpy/core/src/multiarray/na_mask.c
+++ b/numpy/core/src/multiarray/na_mask.c
@@ -15,7 +15,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "shape.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/core/src/multiarray/na_object.c
+++ b/numpy/core/src/multiarray/na_object.c
@@ -16,7 +16,7 @@
 #include <numpy/arrayscalars.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "descriptor.h"
 #include "common.h"

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -17,7 +17,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include <numpy/arrayobject.h>
-#include <numpy/npy_3kcompat.h>
+#include <npy_pycompat.h>
 #include "convert_datatype.h"
 
 #include "lowlevel_strided_loops.h"

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -13,11 +13,11 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include <numpy/arrayobject.h>
-#include <numpy/npy_3kcompat.h>
+#include <npy_pycompat.h>
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 typedef struct NewNpyArrayIterObject_tag NewNpyArrayIterObject;
 

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "number.h"
 

--- a/numpy/core/src/multiarray/numpymemoryview.c
+++ b/numpy/core/src/multiarray/numpymemoryview.c
@@ -16,7 +16,7 @@
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpymemoryview.h"
 

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 /*
  * From the C99 standard, section 7.19.6: The exponent always contains at least

--- a/numpy/core/src/multiarray/reduction.c
+++ b/numpy/core/src/multiarray/reduction.c
@@ -15,7 +15,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "lowlevel_strided_loops.h"
 #include "na_mask.h"

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -14,7 +14,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 static void
 _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype);

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "ctors.h"
 #include "descriptor.h"

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -13,7 +13,7 @@
 #include "numpy/halffloat.h"
 #include "numpy/arrayscalars.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "npy_config.h"
 #include "mapping.h"

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "common.h"
 #include "mapping.h"

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "ctors.h"
 

--- a/numpy/core/src/multiarray/ucsnarrow.c
+++ b/numpy/core/src/multiarray/ucsnarrow.c
@@ -12,7 +12,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 /*
  * Functions only needed on narrow builds of Python for converting back and

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -34,7 +34,7 @@ maintainer email:  oliphant.travis@ieee.org
 
 #include "common.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "usertypes.h"
 

--- a/numpy/core/src/private/npy_pycompat.h
+++ b/numpy/core/src/private/npy_pycompat.h
@@ -1,0 +1,24 @@
+#ifndef _NPY_PYCOMPAT_H_
+#define _NPY_PYCOMPAT_H_
+
+#include "numpy/npy_3kcompat.h"
+
+/*
+ * Accessing items of ob_base
+ */
+
+#if (PY_VERSION_HEX < 0x02060000)
+#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
+#define Py_REFCNT(o)  (((PyObject*)(o))->ob_refcnt)
+#define Py_SIZE(o)    (((PyVarObject*)(o))->ob_size)
+#endif
+
+/*
+ * PyIndex_Check
+ */
+#if (PY_VERSION_HEX < 0x02050000)
+#undef PyIndex_Check
+#define PyIndex_Check(o)     0
+#endif
+
+#endif /* _NPY_COMPAT_H_ */

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -13,7 +13,7 @@
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/halffloat.h"
 

--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -7,7 +7,7 @@
  */
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 
 /*

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -16,7 +16,7 @@
 #include "numpy/npy_math.h"
 #include "numpy/halffloat.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "ufunc_object.h"
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -34,7 +34,7 @@
 #define NO_IMPORT_ARRAY
 #endif
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -19,7 +19,7 @@
 #define NO_IMPORT_ARRAY
 #endif
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "numpy/ufuncobject.h"
 #include "ufunc_type_resolution.h"

--- a/numpy/core/src/umath/umath_tests.c.src
+++ b/numpy/core/src/umath/umath_tests.c.src
@@ -11,7 +11,7 @@
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "npy_config.h"
 

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -7,6 +7,10 @@
 #include "numpy/ufuncobject.h"
 #include "string.h"
 
+#if (PY_VERSION_HEX < 0x02060000)
+#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
+#endif
+
 static npy_intp
 incr_slot_(double x, double *bins, npy_intp lbins)
 {


### PR DESCRIPTION
Move compatibility #define for PyIndex_Check on Python 2.4 to a private compat header

The problem is that including the public Numpy header "arrayobject.h" defines a compatibility wrapper for "PyIndex_Check" on Python 2.4. Moreover, this compatibility wrapper functions incorrectly... This #define probably should not be in the public namespace, as it already causes problems with Cython on Py2.4 (which we hit into in Scipy release):
http://permalink.gmane.org/gmane.comp.python.cython.devel/13983

The second commit moves all non Py3-stuff out of npy_3compat.h to another, more private compat header, for stylistic reasons (mainly because #defining `PyIndex_Check` to `0` rather than something like `PyNumber_Check` is possibly not the correct solution, but I didn't want to go changing it inside Numpy for this).

A question with this PR is --- is there 3rd party software out there that relies on Numpy headers defining the otherwise missing PyIndex_Check being defined, and do we care. I'd say we don't care, this seems like a corner case, and the current behavior in Numpy is wrong.
