### PR TITLE
Restore ability to not include semi-colons.

### DIFF
--- a/doc/source/reference/c-api.deprecations.rst
+++ b/doc/source/reference/c-api.deprecations.rst
@@ -16,11 +16,13 @@ C-API as well as account for compiler technology of the late 90's.
 There is only a small group of volunteers who have had very little
 time to spend on improving this API.    
 
-There is an ongoing effort to improve the API to do things like remove
-a "fortran" macro and ensure that the NPY_ prefixes don't collide with
-names from the PyArray_ prefixes.  It is important in this effort,
-however, to ensure that code that compiles for NumPy 1.X continues to
-compile for NumPy 1.X.  At the same, time certain API's will be marked
+Despite these constraints, there is an ongoing effort to improve the
+API to do things like remove 
+stray macros (e.g. a "fortran" macro) and ensure that the NPY_ prefixes
+don't prepend names that collide with
+names from the PyArray_ prefixes.  It is important in this effort
+to ensure that code that compiles for NumPy 1.X continues to
+compile for NumPy 1.X.  At the same time certain API's will be marked
 as deprecated so that future-looking code can avoid these API's and
 follow better practices. 
 

--- a/doc/source/reference/c-api.deprecations.rst
+++ b/doc/source/reference/c-api.deprecations.rst
@@ -6,18 +6,20 @@ Background
 
 The API exposed by NumPy for third-party extensions has grown over
 years of releases, and has allowed programmers to directly access
-NumPy functionality from C. This API was not originally designed to
-take into account best practices for C APIs, and was maintained by
-a small group of people with very little time to expend on improving
-it.
+NumPy functionality from C. This API can be best described as
+"organic".  The core API originated with Numeric in 1995 and there are
+patterns such as the heavy use of macros written to mimic Python's
+C-API as well as account for compiler technology of the late 90's.
+There is only a small group of volunteers who have had very little
+time to spend on improving this API.   
 
-Starting with NumPy 1.7, we are attempting to make a concerted effort to
-clean up the API. This includes fixing some grave sins, like removing
-the macro *fortran* (which was defined to *fortran_*) as well as
-clarifying some confusing choices caused by designing separate
-subsystems without noticing how they interacted. For example,
-NPY_DEFAULT was a flag controlling ndarray construction, while
-PyArray_DEFAULT was the default dtype enumeration value.
+There is an ongoing effort to improve the API to do things like remove
+a "fortran" macro and ensure that the NPY_ prefixes don't collide with
+names from the PyArray_ prefixes.  It is important in this effort,
+however, to ensure that code that compiles for NumPy 1.X continues to
+compile for NumPy 1.X.  At the same, time certain API's will be marked
+as deprecated so that future-looking code can avoid these API's and
+follow better practices. 
 
 Another important role played by deprecations in the C API is to move
 towards hiding internal details of the NumPy implementation. For those
@@ -25,19 +27,17 @@ needing direct, easy, access to the data of ndarrays, this will not
 remove this ability. Rather, there are many potential performance
 optimizations which require changing the implementation details, and
 NumPy developers have been unable to try them because of the high
-value of preserving ABI compatibility. By deprecating this direct access
-over the course of several releases, we will in the future be able to
-improve NumPy's performance in ways we cannot presently.
+value of preserving ABI compatibility. By deprecating this direct
+access, we will in the future be able to improve NumPy's performance
+in ways we cannot presently.
 
 Deprecation Mechanism NPY_NO_DEPRECATED_API
 -------------------------------------------
 
 In C, there is no equivalent to the deprecation warnings that Python
 supports. One way to do deprecations is to flag them in the documentation
-and release notes, then remove or change the deprecated features in the
-next version. We intend to do this, but also have created a mechanism to help
-third-party developers test that their code does not use any of the
-deprecated features.
+and release notes, then remove or change the deprecated features in a
+future version (NumPy 2.0 and beyond).  
 
 To use the NPY_NO_DEPRECATED_API mechanism, you need to #define it to
 the target API version of NumPy before #including any NumPy headers.

--- a/doc/source/reference/c-api.deprecations.rst
+++ b/doc/source/reference/c-api.deprecations.rst
@@ -7,11 +7,14 @@ Background
 The API exposed by NumPy for third-party extensions has grown over
 years of releases, and has allowed programmers to directly access
 NumPy functionality from C. This API can be best described as
-"organic".  The core API originated with Numeric in 1995 and there are
+"organic".   It has emerged from multiple competing desires and from
+multiple points of view over the years, strongly influenced by the
+desire to make it easy for users to move to NumPy from Numeric and
+Numarray.   The core API originated with Numeric in 1995 and there are
 patterns such as the heavy use of macros written to mimic Python's
 C-API as well as account for compiler technology of the late 90's.
 There is only a small group of volunteers who have had very little
-time to spend on improving this API.   
+time to spend on improving this API.    
 
 There is an ongoing effort to improve the API to do things like remove
 a "fortran" macro and ensure that the NPY_ prefixes don't collide with
@@ -35,9 +38,14 @@ Deprecation Mechanism NPY_NO_DEPRECATED_API
 -------------------------------------------
 
 In C, there is no equivalent to the deprecation warnings that Python
-supports. One way to do deprecations is to flag them in the documentation
-and release notes, then remove or change the deprecated features in a
-future version (NumPy 2.0 and beyond).  
+supports. One way to do deprecations is to flag them in the
+documentation and release notes, then remove or change the deprecated
+features in a future major version (NumPy 2.0 and beyond).  Minor
+versions of NumPy should not have major C-API changes, however, that
+prevent code that worked on a previous minor release.  For example, we
+will do our best to ensure that code that compiled and worked on NumPy
+1.4 should continue to work on NumPy 1.7 (but perhaps with compiler
+warnings). 
 
 To use the NPY_NO_DEPRECATED_API mechanism, you need to #define it to
 the target API version of NumPy before #including any NumPy headers.

--- a/doc/source/reference/c-api.deprecations.rst
+++ b/doc/source/reference/c-api.deprecations.rst
@@ -13,20 +13,17 @@ desire to make it easy for users to move to NumPy from Numeric and
 Numarray.   The core API originated with Numeric in 1995 and there are
 patterns such as the heavy use of macros written to mimic Python's
 C-API as well as account for compiler technology of the late 90's.
-There is only a small group of volunteers who have had very little
+There is also only a small group of volunteers who have had very little
 time to spend on improving this API.    
 
-Despite these constraints, there is an ongoing effort to improve the
-API to do things like remove 
-stray macros (e.g. a "fortran" macro) and ensure that the NPY_ prefixes
-don't prepend names that collide with
-names from the PyArray_ prefixes.  It is important in this effort
+There is an ongoing effort to improve the API.
+It is important in this effort
 to ensure that code that compiles for NumPy 1.X continues to
-compile for NumPy 1.X.  At the same time certain API's will be marked
+compile for NumPy 1.X.  At the same time, certain API's will be marked
 as deprecated so that future-looking code can avoid these API's and
 follow better practices. 
 
-Another important role played by deprecations in the C API is to move
+Another important role played by deprecation markings in the C API is to move
 towards hiding internal details of the NumPy implementation. For those
 needing direct, easy, access to the data of ndarrays, this will not
 remove this ability. Rather, there are many potential performance

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -914,21 +914,21 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #if NPY_ALLOW_THREADS
 #define NPY_BEGIN_ALLOW_THREADS Py_BEGIN_ALLOW_THREADS
 #define NPY_END_ALLOW_THREADS Py_END_ALLOW_THREADS
-#define NPY_BEGIN_THREADS_DEF PyThreadState *_save=NULL
-#define NPY_BEGIN_THREADS do {_save = PyEval_SaveThread();} while (0)
-#define NPY_END_THREADS   do {if (_save) PyEval_RestoreThread(_save);} while (0)
+#define NPY_BEGIN_THREADS_DEF PyThreadState *_save=NULL;
+#define NPY_BEGIN_THREADS do {_save = PyEval_SaveThread();} while (0);
+#define NPY_END_THREADS   do {if (_save) PyEval_RestoreThread(_save);} while (0);
 
 #define NPY_BEGIN_THREADS_DESCR(dtype) \
         do {if (!(PyDataType_FLAGCHK(dtype, NPY_NEEDS_PYAPI))) \
-                NPY_BEGIN_THREADS;} while (0)
+                NPY_BEGIN_THREADS;} while (0);
 
 #define NPY_END_THREADS_DESCR(dtype) \
         do {if (!(PyDataType_FLAGCHK(dtype, NPY_NEEDS_PYAPI))) \
-                NPY_END_THREADS; } while (0)
+                NPY_END_THREADS; } while (0);
 
-#define NPY_ALLOW_C_API_DEF  PyGILState_STATE __save__
-#define NPY_ALLOW_C_API      do {__save__ = PyGILState_Ensure();} while (0)
-#define NPY_DISABLE_C_API    do {PyGILState_Release(__save__);} while (0)
+#define NPY_ALLOW_C_API_DEF  PyGILState_STATE __save__;
+#define NPY_ALLOW_C_API      do {__save__ = PyGILState_Ensure();} while (0);
+#define NPY_DISABLE_C_API    do {PyGILState_Release(__save__);} while (0);
 #else
 #define NPY_BEGIN_ALLOW_THREADS
 #define NPY_END_ALLOW_THREADS

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -257,8 +257,8 @@ typedef struct _tagPyUFuncObject {
         (UFUNC_ERR_WARN << UFUNC_SHIFT_INVALID)
 
 #if NPY_ALLOW_THREADS
-#define NPY_LOOP_BEGIN_THREADS do {if (!(loop->obj & UFUNC_OBJ_NEEDS_API)) _save = PyEval_SaveThread();} while (0)
-#define NPY_LOOP_END_THREADS   do {if (!(loop->obj & UFUNC_OBJ_NEEDS_API)) PyEval_RestoreThread(_save);} while (0)
+#define NPY_LOOP_BEGIN_THREADS do {if (!(loop->obj & UFUNC_OBJ_NEEDS_API)) _save = PyEval_SaveThread();} while (0);
+#define NPY_LOOP_END_THREADS   do {if (!(loop->obj & UFUNC_OBJ_NEEDS_API)) PyEval_RestoreThread(_save);} while (0);
 #else
 #define NPY_LOOP_BEGIN_THREADS
 #define NPY_LOOP_END_THREADS


### PR DESCRIPTION
Consumers of NumPy C-API should not have to use semicolons if they did not previously.   This is an API change.  

This should still work for people that choose to use semicolons and we can leave the changes to the NumPy source code that now use semicolons.   Extra semicolons should not cause issues unless -pedantic is used during compilation which will issue a warning. 
