### PR TITLE
fix ticket #2178: "own" (to close) file handles in load() only if they were not opened before

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -369,6 +369,7 @@ def load(file, mmap_mode=None):
         magic = fid.read(N)
         fid.seek(-N, 1) # back-up
         if magic.startswith(_ZIP_PREFIX):  # zip-file (assume .npz)
+            own_fid = False
             return NpzFile(fid, own_fid=own_fid)
         elif magic == format.MAGIC_PREFIX: # .npy file
             if mmap_mode:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -174,11 +174,11 @@ class TestSavezLoad(RoundtripTest, TestCase):
         fd, tmp = mkstemp(suffix='.npz')
         os.close(fd)
         try:
-            fp = open(tmp, 'w')
+            fp = open(tmp, 'wb')
             np.savez(fp, data='LOVELY LOAD')
             fp.close()
 
-            fp = open(tmp, 'r', 10000)
+            fp = open(tmp, 'rb', 10000)
             fp.seek(0)
             assert_(not fp.closed)
             _ = np.load(fp)['data']
@@ -199,7 +199,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
         os.close(fd)
 
         try:
-            fp = open(tmp, 'w')
+            fp = open(tmp, 'wb')
             np.savez(fp, data='LOVELY LOAD')
             fp.close()
 


### PR DESCRIPTION
See http://projects.scipy.org/numpy/ticket/2178 for more information

Also I am not 100% sure if I have not introduced leaking of file descriptors somehow (although did run that specific added unittest 10000s of time and everything was legit)... otherwise -- now it passes all old tests and the new one
