### PR TITLE
Add texinfo build target for document

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -166,3 +166,16 @@ linkcheck: generate
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in build/linkcheck/output.txt."
+
+texinfo:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) build/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in build/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+info:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) build/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C build/texinfo info
+	@echo "makeinfo finished; the Info files are in build/texinfo."

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -215,6 +215,18 @@ latex_use_modindex = False
 
 
 # -----------------------------------------------------------------------------
+# Texinfo output
+# -----------------------------------------------------------------------------
+
+texinfo_documents = [
+  ("contents", 'numpy', 'Numpy Documentation', _stdauthor, 'Numpy',
+   "NumPy: array processing for numbers, strings, records, and objects.",
+   'Programming',
+   1),
+]
+
+
+# -----------------------------------------------------------------------------
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {'http://docs.python.org/dev': None}


### PR DESCRIPTION
Hi, I am trying to build numpy document in info format.  With this patch applied, I can build numpy.texi but compiling numpy.info from that file fails.  Here is the end part of the log.  There were a lot of warnings when building it which I omit here.

```
numpy.texi:196193: Node `Python Module Index' previously defined at line 196161.
/.../numpy/doc/build/texinfo//numpy.texi:196161: Prev field of node `Python Module Index' not pointed to.
/.../numpy/doc/build/texinfo//numpy.texi:196161: This node (Python Module Index) has the bad Next.
/.../numpy/doc/build/texinfo//numpy.texi:195560: Next field of node `Glossary' not pointed to (perhaps incorrect sectioning?).
/.../numpy/doc/build/texinfo//numpy.texi:196161: This node (Python Module Index) has the bad Prev.
makeinfo: Removing output file `numpy.info' due to errors; use --force to preserve.
make[1]: *** [numpy.info] Error 1
make[1]: Leaving directory `/.../numpy/doc/build/texinfo'
make: *** [info] Error 2
```

Any idea of how to fix this?

Note that I can still get (broken) info file if I run `makeinfo --no-split --force -o numpy.info numpy.texi`.  Should I add this to Makefile, instead of the line `make -C build/texinfo info`?
