### PR TITLE
Fixed bug in numpy.piecewise() for 0-d array handling

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -673,21 +673,11 @@ def piecewise(x, condlist, funclist, *args, **kw):
     """
     x = asanyarray(x)
     n2 = len(funclist)
-    if isscalar(condlist) or \
-           not (isinstance(condlist[0], list) or
-                isinstance(condlist[0], ndarray)):
+    if isscalar(condlist):
         condlist = [condlist]
     condlist = [asarray(c, dtype=bool) for c in condlist]
     n = len(condlist)
-    if n == n2-1:  # compute the "otherwise" condition.
-        totlist = condlist[0]
-        for k in range(1, n):
-            totlist |= condlist[k]
-        condlist.append(~totlist)
-        n += 1
-    if (n != n2):
-        raise ValueError(
-                "function list and condition list must be the same")
+
     zerod = False
     # This is a hack to work around problems with NumPy's
     #  handling of 0-d arrays and boolean indexing with
@@ -703,6 +693,16 @@ def piecewise(x, condlist, funclist, *args, **kw):
                 condition = condlist[k]
             newcondlist.append(condition)
         condlist = newcondlist
+
+    if n == n2-1:  # compute the "otherwise" condition.
+        totlist = condlist[0]
+        for k in range(1, n):
+            totlist |= condlist[k]
+        condlist.append(~totlist)
+        n += 1
+    if (n != n2):
+        raise ValueError(
+                "function list and condition list must be the same")
 
     y = zeros(x.shape, x.dtype)
     for k in range(n):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -673,7 +673,9 @@ def piecewise(x, condlist, funclist, *args, **kw):
     """
     x = asanyarray(x)
     n2 = len(funclist)
-    if isscalar(condlist):
+    if isscalar(condlist) or \
+            (isinstance(condlist, np.ndarray) and condlist.ndim == 0) or \
+            (x.ndim > 0 and condlist[0].ndim == 0):
         condlist = [condlist]
     condlist = [asarray(c, dtype=bool) for c in condlist]
     n = len(condlist)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -675,7 +675,8 @@ def piecewise(x, condlist, funclist, *args, **kw):
     n2 = len(funclist)
     if isscalar(condlist) or \
             (isinstance(condlist, np.ndarray) and condlist.ndim == 0) or \
-            (x.ndim > 0 and condlist[0].ndim == 0):
+            (x.ndim > 0 and (isscalar(condlist[0]) or \
+                (isinstance(condlist, np.ndarray) and condlist[0].ndim == 0))):
         condlist = [condlist]
     condlist = [asarray(c, dtype=bool) for c in condlist]
     n = len(condlist)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1179,49 +1179,150 @@ class TestMeshgrid(TestCase):
 
 
 class TestPiecewise(TestCase):
+    def test_0d(self):
+        # Input: scalar
+        x = 5
+
+        # Condition: scalar bool
+        y = piecewise(x, x < 7, [1])
+        assert(y.ndim == 0)
+        assert(y == 1)
+
+        # Condition: singleton list of scalar bool
+        y = piecewise(x, [x < 7], [1])
+        assert(y == 1)
+
+        # Condition: 0-d array of bool
+        y = piecewise(x, np.array(x < 7), [1])
+        assert(y == 1)
+
+        # Condition: 1-d array of bool
+        y = piecewise(x, np.array([x < 7]), [1])
+        assert(y == 1)
+
+        # Condition: singleton list of 0-d array of bool
+        y = piecewise(x, [np.array(x < 7)], [1])
+        assert(y == 1)
+
+        # Condition: singleton list of 1-d array of bool
+        y = piecewise(x, [np.array([x < 7])], [1])
+        assert(y == 1)
+
+        # Condition: scalar int
+        y = piecewise(x, 1, [1])
+        assert(y == 1)
+
+        # Condition: singleton list of int
+        y = piecewise(x, [1], [1])
+        assert(y == 1)
+
+        # Condition: 1-d list of bools
+        y = piecewise(x, [x < 7, x >= 7], [1, 2])
+        assert(y == 1)
+
+        # Condition: 1-d list of bools (test alternative)
+        y = piecewise(x, [x >= 7, x < 7], [1, 2])
+        assert(y == 2)
+
+        # Condition: 1-d list of 0-d arrays of bools
+        y = piecewise(x, [np.array(x < 7), np.array(x >= 7)], [1, 2])
+        assert(y == 1)
+
+        # Input: 0-d array
+        x = np.array(5)
+
+        y = piecewise(x, x < 7, [1])
+        assert(y.ndim == 0)
+        assert(y == 1)
+
     def test_simple(self):
-        # Condition is single bool list
-        x = piecewise([0, 0], [True, False], [1])
-        assert_array_equal(x, [1, 0])
+        # Input: 1-d array
+        x = np.array([3,5])
 
-        # List of conditions: single bool list
-        x = piecewise([0, 0], [[True, False]], [1])
-        assert_array_equal(x, [1, 0])
+        # Condition: bare array of bool
+        y = piecewise(x, x < 7, [1])
+        assert_array_equal(y, [1, 1])
 
-        # Conditions is single bool array
-        x = piecewise([0, 0], np.array([True, False]), [1])
-        assert_array_equal(x, [1, 0])
+        # Make sure callables are called
+        y = piecewise(x, x < 7, [(lambda x: -x)])
+        assert_array_equal(y, [-3, -5])
 
-        # Condition is single int array
-        x = piecewise([0, 0], np.array([1, 0]), [1])
-        assert_array_equal(x, [1, 0])
+        # Condition: singleton list of array of bool
+        y = piecewise(x, [x < 7], [1])
+        assert_array_equal(y, [1, 1])
 
-        # List of conditions: int array
-        x = piecewise([0, 0], [np.array([1, 0])], [1])
-        assert_array_equal(x, [1, 0])
+        # Condition: (1,2) array of bool
+        y = piecewise(x, np.array([x < 7]), [1])
+        assert_array_equal(y, [1, 1])
 
+        # Condition: list of array of bool
+        y = piecewise(x, [x >= 4, x < 4], [1, 2])
+        assert_array_equal(y, [2, 1])
 
-        x = piecewise([0, 0], [[False, True]], [lambda x:-1])
-        assert_array_equal(x, [0, -1])
+        y = piecewise(x, [x > 7, x <= 7], [1, 2])
+        assert_array_equal(y, [2, 2])
 
-        x = piecewise([1, 2], [[True, False], [False, True]], [3, 4])
-        assert_array_equal(x, [3, 4])
+        y = piecewise(x, [x < 4, x >= 4], [1, 2])
+        assert_array_equal(y, [1, 2])
+
+        y = piecewise(x, np.array([x < 4, x >= 4]), [1, 2])
+        assert_array_equal(y, [1, 2])
 
     def test_default(self):
-        # No value specified for x[1], should be 0
-        x = piecewise([1, 2], [True, False], [2])
-        assert_array_equal(x, [2, 0])
+        # Input: scalar
+        x = 5
 
-        # Should set x[1] to 3
-        x = piecewise([1, 2], [True, False], [2, 3])
-        assert_array_equal(x, [2, 3])
+        # built-in no-match: 0
 
-    def test_0d(self):
-        x = np.array(3)
-        y = piecewise(x, x > 3, [4, 0])
-        assert_(y.ndim == 0)
-        assert_(y == 0)
+        # Condition: scalar bool
+        y = piecewise(x, x > 7, [1])
+        assert_array_equal(y, 0)
 
+        # Condition: scalar int
+        y = piecewise(x, 0, [1])
+        assert_array_equal(y, 0)
+
+        # custom no-match
+
+        y = piecewise(x, x < 7, [1, 2])
+        assert_array_equal(y, [1])
+
+        y = piecewise(x, x > 7, [1, 2])
+        assert_array_equal(y, [2])
+
+        # Condition: scalar int
+        y = piecewise(x, 0, [1, 2])
+        assert_array_equal(y, [2])
+
+        # Input: 1-d array
+        x = np.array([3,5])
+
+        # built-in no-match: 0
+
+        y = piecewise(x, x > 7, [1])
+        assert_array_equal(y, [0,0])
+
+        y = piecewise(x, x < 4, [1])
+        assert_array_equal(y, [1, 0])
+
+        # custom no-match
+
+        y = piecewise(x, x < 7, [1, 2])
+        assert_array_equal(y, [1, 1])
+
+        y = piecewise(x, x > 7, [1, 2])
+        assert_array_equal(y, [2, 2])
+
+        y = piecewise(x, x < 4, [1, 2])
+        assert_array_equal(y, [1, 2])
+
+        # Condition: list of array of bool
+        y = piecewise(x, [x < 4], [1, 2])
+        assert_array_equal(y, [1, 2])
+
+        # Condition: (1,2) array of bool
+        y = piecewise(x, np.array([x < 4]), [1, 2])
+        assert_array_equal(y, [1, 2])
 
 class TestBincount(TestCase):
     def test_simple(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1179,150 +1179,52 @@ class TestMeshgrid(TestCase):
 
 
 class TestPiecewise(TestCase):
-    def test_0d(self):
-        # Input: scalar
-        x = 5
-
-        # Condition: scalar bool
-        y = piecewise(x, x < 7, [1])
-        assert(y.ndim == 0)
-        assert(y == 1)
-
-        # Condition: singleton list of scalar bool
-        y = piecewise(x, [x < 7], [1])
-        assert(y == 1)
-
-        # Condition: 0-d array of bool
-        y = piecewise(x, np.array(x < 7), [1])
-        assert(y == 1)
-
-        # Condition: 1-d array of bool
-        y = piecewise(x, np.array([x < 7]), [1])
-        assert(y == 1)
-
-        # Condition: singleton list of 0-d array of bool
-        y = piecewise(x, [np.array(x < 7)], [1])
-        assert(y == 1)
-
-        # Condition: singleton list of 1-d array of bool
-        y = piecewise(x, [np.array([x < 7])], [1])
-        assert(y == 1)
-
-        # Condition: scalar int
-        y = piecewise(x, 1, [1])
-        assert(y == 1)
-
-        # Condition: singleton list of int
-        y = piecewise(x, [1], [1])
-        assert(y == 1)
-
-        # Condition: 1-d list of bools
-        y = piecewise(x, [x < 7, x >= 7], [1, 2])
-        assert(y == 1)
-
-        # Condition: 1-d list of bools (test alternative)
-        y = piecewise(x, [x >= 7, x < 7], [1, 2])
-        assert(y == 2)
-
-        # Condition: 1-d list of 0-d arrays of bools
-        y = piecewise(x, [np.array(x < 7), np.array(x >= 7)], [1, 2])
-        assert(y == 1)
-
-        # Input: 0-d array
-        x = np.array(5)
-
-        y = piecewise(x, x < 7, [1])
-        assert(y.ndim == 0)
-        assert(y == 1)
-
     def test_simple(self):
-        # Input: 1-d array
-        x = np.array([3,5])
+        # Condition is single bool list
+        x = piecewise([0, 0], [True, False], [1])
+        assert_array_equal(x, [1, 0])
 
-        # Condition: bare array of bool
-        y = piecewise(x, x < 7, [1])
-        assert_array_equal(y, [1, 1])
+        # List of conditions: single bool list
+        x = piecewise([0, 0], [[True, False]], [1])
+        assert_array_equal(x, [1, 0])
 
-        # Make sure callables are called
-        y = piecewise(x, x < 7, [(lambda x: -x)])
-        assert_array_equal(y, [-3, -5])
+        # Conditions is single bool array
+        x = piecewise([0, 0], np.array([True, False]), [1])
+        assert_array_equal(x, [1, 0])
 
-        # Condition: singleton list of array of bool
-        y = piecewise(x, [x < 7], [1])
-        assert_array_equal(y, [1, 1])
+        # Condition is single int array
+        x = piecewise([0, 0], np.array([1, 0]), [1])
+        assert_array_equal(x, [1, 0])
 
-        # Condition: (1,2) array of bool
-        y = piecewise(x, np.array([x < 7]), [1])
-        assert_array_equal(y, [1, 1])
+        # List of conditions: int array
+        x = piecewise([0, 0], [np.array([1, 0])], [1])
+        assert_array_equal(x, [1, 0])
 
-        # Condition: list of array of bool
-        y = piecewise(x, [x >= 4, x < 4], [1, 2])
-        assert_array_equal(y, [2, 1])
 
-        y = piecewise(x, [x > 7, x <= 7], [1, 2])
-        assert_array_equal(y, [2, 2])
+        x = piecewise([0, 0], [[False, True]], [lambda x:-1])
+        assert_array_equal(x, [0, -1])
 
-        y = piecewise(x, [x < 4, x >= 4], [1, 2])
-        assert_array_equal(y, [1, 2])
-
-        y = piecewise(x, np.array([x < 4, x >= 4]), [1, 2])
-        assert_array_equal(y, [1, 2])
+        x = piecewise([1, 2], [[True, False], [False, True]], [3, 4])
+        assert_array_equal(x, [3, 4])
 
     def test_default(self):
-        # Input: scalar
-        x = 5
+        # No value specified for x[1], should be 0
+        x = piecewise([1, 2], [True, False], [2])
+        assert_array_equal(x, [2, 0])
 
-        # built-in no-match: 0
+        # Should set x[1] to 3
+        x = piecewise([1, 2], [True, False], [2, 3])
+        assert_array_equal(x, [2, 3])
 
-        # Condition: scalar bool
-        y = piecewise(x, x > 7, [1])
-        assert_array_equal(y, 0)
+    def test_0d(self):
+        x = np.array(3)
+        y = piecewise(x, x > 3, [4, 0])
+        assert_(y.ndim == 0)
+        assert_(y == 0)
 
-        # Condition: scalar int
-        y = piecewise(x, 0, [1])
-        assert_array_equal(y, 0)
-
-        # custom no-match
-
-        y = piecewise(x, x < 7, [1, 2])
-        assert_array_equal(y, [1])
-
-        y = piecewise(x, x > 7, [1, 2])
-        assert_array_equal(y, [2])
-
-        # Condition: scalar int
-        y = piecewise(x, 0, [1, 2])
-        assert_array_equal(y, [2])
-
-        # Input: 1-d array
-        x = np.array([3,5])
-
-        # built-in no-match: 0
-
-        y = piecewise(x, x > 7, [1])
-        assert_array_equal(y, [0,0])
-
-        y = piecewise(x, x < 4, [1])
-        assert_array_equal(y, [1, 0])
-
-        # custom no-match
-
-        y = piecewise(x, x < 7, [1, 2])
-        assert_array_equal(y, [1, 1])
-
-        y = piecewise(x, x > 7, [1, 2])
-        assert_array_equal(y, [2, 2])
-
-        y = piecewise(x, x < 4, [1, 2])
-        assert_array_equal(y, [1, 2])
-
-        # Condition: list of array of bool
-        y = piecewise(x, [x < 4], [1, 2])
-        assert_array_equal(y, [1, 2])
-
-        # Condition: (1,2) array of bool
-        y = piecewise(x, np.array([x < 4]), [1, 2])
-        assert_array_equal(y, [1, 2])
+        y = piecewise(x, [True, False], [1, 0])
+        assert_(y.ndim == 0)
+        assert_(y == 1)
 
 class TestBincount(TestCase):
     def test_simple(self):


### PR DESCRIPTION
Updated numpy/lib/function_base.py to fix bug in numpy.piecewise() for 0-d array handling and boolean indexing with scalars.

Bug test case:

```
>>> numpy.piecewise(5, [True, False], [1, 0])
Traceback (most recent call last):
    [...]
    y[condlist[k]] = item
ValueError: boolean index array has too many values
```

After fix:

```
>>> numpy.piecewise(5, [True, False], [1, 0])
array(1)
```
