### PR TITLE
Add doc for PyArray_FILLWBYTE to tell the ndarray must be c contiguous.

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -289,6 +289,7 @@ From scratch
 
     Fill the array pointed to by *obj* ---which must be a (subclass
     of) bigndarray---with the contents of *val* (evaluated as a byte).
+    This is a macro that call memset, so obj must be contiguous in memory.
 
 .. cfunction:: PyObject* PyArray_Zeros(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
 

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -289,7 +289,7 @@ From scratch
 
     Fill the array pointed to by *obj* ---which must be a (subclass
     of) bigndarray---with the contents of *val* (evaluated as a byte).
-    This is a macro that call memset, so obj must be contiguous in memory.
+    This macro calls memset, so obj must be contiguous.
 
 .. cfunction:: PyObject* PyArray_Zeros(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
 


### PR DESCRIPTION
This follow the email "PyArray_FILLWBYTE dangerous doc" on numpy-discussion mailing list.
