### PR TITLE
BUG: make genfromtxt work with comments=None.  Closes Github issue 329.

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -203,13 +203,17 @@ class LineSplitter(object):
             self._handyman = _handyman
     #
     def _delimited_splitter(self, line):
-        line = line.split(self.comments)[0].strip(asbytes(" \r\n"))
+        if self.comments is not None:
+            line = line.split(self.comments)[0]
+        line = line.strip(asbytes(" \r\n"))
         if not line:
             return []
         return line.split(self.delimiter)
     #
     def _fixedwidth_splitter(self, line):
-        line = line.split(self.comments)[0].strip(asbytes("\r\n"))
+        if self.comments is not None:
+            line = line.split(self.comments)[0]
+        line = line.strip(asbytes("\r\n"))
         if not line:
             return []
         fixed = self.delimiter
@@ -217,7 +221,8 @@ class LineSplitter(object):
         return [line[s] for s in slices]
     #
     def _variablewidth_splitter(self, line):
-        line = line.split(self.comments)[0]
+        if self.comments is not None:
+            line = line.split(self.comments)[0]
         if not line:
             return []
         slices = self.delimiter

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1291,7 +1291,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     """
     # Py3 data conversions to bytes, for convenience
-    comments = asbytes(comments)
+    if comments is not None:
+        comments = asbytes(comments)
     if isinstance(delimiter, unicode):
         delimiter = asbytes(delimiter)
     if isinstance(missing, unicode):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1426,8 +1426,6 @@ M   33  21.99
                              usecols=("A", "C", "E"), names=True)
         assert_equal(test.dtype.names, ctrl_names)
 
-
-
     def test_fixed_width_names(self):
         "Test fix-width w/ names"
         data = "    A    B   C\n    0    1 2.3\n   45   67   9."
@@ -1451,6 +1449,11 @@ M   33  21.99
         test = np.ndfromtxt(StringIO(data), **kwargs)
         assert_equal(test, ctrl)
 
+    def test_comments_is_none(self):
+        # Github issue 329 (None was previously being converted to 'None').
+        test = np.genfromtxt(StringIO("test1,testNonetherestofthedata"),
+                             dtype=None, comments=None, delimiter=',')
+        assert_equal(test[1], asbytes('testNonetherestofthedata'))
 
     def test_recfromtxt(self):
         #
@@ -1470,7 +1473,6 @@ M   33  21.99
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
         assert_equal(test.A, [0, 2])
-
 
     def test_recfromcsv(self):
         #

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1454,6 +1454,9 @@ M   33  21.99
         test = np.genfromtxt(StringIO("test1,testNonetherestofthedata"),
                              dtype=None, comments=None, delimiter=',')
         assert_equal(test[1], asbytes('testNonetherestofthedata'))
+        test = np.genfromtxt(StringIO("test1, testNonetherestofthedata"),
+                             dtype=None, comments=None, delimiter=',')
+        assert_equal(test[1], asbytes(' testNonetherestofthedata'))
 
     def test_recfromtxt(self):
         #


### PR DESCRIPTION
For discussion see #335. Works on 2.6 and 3.2 for me now.
