### PR TITLE
TST: mark longdouble tests for spacing/nextafter as knownfail on PPC.

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1,8 +1,15 @@
 import sys
+import platform
 
 from numpy.testing import *
 import numpy.core.umath as ncu
 import numpy as np
+
+
+def on_powerpc():
+    """ True if we are running on a Power PC platform."""
+    return platform.processor() == 'powerpc' or \
+           platform.machine().startswith('ppc')
 
 
 class _FilterInvalids(object):
@@ -1118,7 +1125,8 @@ def test_nextafter():
 def test_nextafterf():
     return _test_nextafter(np.float32)
 
-@dec.knownfailureif(sys.platform == 'win32', "Long double support buggy on win32")
+@dec.knownfailureif(sys.platform == 'win32' or on_powerpc(),
+            "Long double support buggy on win32 and PPC, ticket 1664.")
 def test_nextafterl():
     return _test_nextafter(np.longdouble)
 
@@ -1143,7 +1151,8 @@ def test_spacing():
 def test_spacingf():
     return _test_spacing(np.float32)
 
-@dec.knownfailureif(sys.platform == 'win32', "Long double support buggy on win32")
+@dec.knownfailureif(sys.platform == 'win32' or on_powerpc(),
+            "Long double support buggy on win32 and PPC, ticket 1664.")
 def test_spacingl():
     return _test_spacing(np.longdouble)
 


### PR DESCRIPTION
See http://projects.scipy.org/numpy/ticket/1664. This issue keeps on coming back, so should be applied to master. Should be backported to 1.7.x and 1.6.x.
