### PR TITLE
First attempt at BF for 2165 and added better tests for scalarmath pow function

### DIFF
--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -494,16 +494,25 @@ half_ctype_remainder(npy_half a, npy_half b, npy_half *out) {
 /**end repeat**/
 
 /**begin repeat
- * #name = half, float, double, longdouble#
- * #type = npy_half, npy_float, npy_double, npy_longdouble#
+ * #name = float, double, longdouble#
+ * #type = npy_float, npy_double, npy_longdouble#
  */
 static npy_@name@ (*_basic_@name@_pow)(@type@ a, @type@ b);
 
+//called when ** is used (not performing properly)
 static void
 @name@_ctype_power(@type@ a, @type@ b, @type@ *out) {
-    *out = _basic_@name@_pow(a, b);
+  *out = _basic_@name@_pow(a, b);
 }
 /**end repeat**/
+static void
+half_ctype_power(npy_half a,npy_half b, npy_half *out)
+{
+  const npy_float af = npy_half_to_float(a);
+  const npy_float bf = npy_half_to_float(b);
+  const npy_float of = _basic_float_pow(af,bf);
+  *out = npy_float_to_half(of);
+}
 
 /**begin repeat
  * #name = byte, ubyte, short, ushort, int, uint,
@@ -970,7 +979,7 @@ static PyObject *
     int retstatus;
     int first;
     @type@ out = {@zero@, @zero@};
-
+    
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
             break;
@@ -1130,7 +1139,6 @@ static PyObject *
     int first;
 
     @type@ out = @zero@;
-
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
             break;
@@ -1724,7 +1732,6 @@ get_functions(void)
         i += 3;
         j++;
     }
-    _basic_half_pow = funcdata[j - 1];
     _basic_float_pow = funcdata[j];
     _basic_double_pow = funcdata[j + 1];
     _basic_longdouble_pow = funcdata[j + 2];

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -979,7 +979,7 @@ static PyObject *
     int retstatus;
     int first;
     @type@ out = {@zero@, @zero@};
-    
+
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
             break;

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -499,19 +499,19 @@ half_ctype_remainder(npy_half a, npy_half b, npy_half *out) {
  */
 static npy_@name@ (*_basic_@name@_pow)(@type@ a, @type@ b);
 
-//called when ** is used (not performing properly)
 static void
-@name@_ctype_power(@type@ a, @type@ b, @type@ *out) {
-  *out = _basic_@name@_pow(a, b);
+@name@_ctype_power(@type@ a, @type@ b, @type@ *out) 
+{
+    *out = _basic_@name@_pow(a, b);
 }
 /**end repeat**/
 static void
-half_ctype_power(npy_half a,npy_half b, npy_half *out)
+half_ctype_power(npy_half a, npy_half b, npy_half *out)
 {
-  const npy_float af = npy_half_to_float(a);
-  const npy_float bf = npy_half_to_float(b);
-  const npy_float of = _basic_float_pow(af,bf);
-  *out = npy_float_to_half(of);
+    const npy_float af = npy_half_to_float(a);
+    const npy_float bf = npy_half_to_float(b);
+    const npy_float outf = _basic_float_pow(af,bf);
+    *out = npy_float_to_half(outf);
 }
 
 /**begin repeat

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -59,17 +59,20 @@ class TestPower(TestCase):
             else:
                 assert_almost_equal(b, 6765201, err_msg=msg)
     def test_mixed_types(self):
-        typelist = [np.int8,np.int16,np.float16,np.float32,np.float64,np.int8,np.int16,np.int32,np.int64]
+        typelist = [np.int8,np.int16,np.float16,
+                    np.float32,np.float64,np.int8,
+                    np.int16,np.int32,np.int64]
         for t1 in typelist:
             for t2 in typelist:
                 a = t1(3)
                 b = t2(2)
-                o = a**b
-                msg = "error with %r and %r: got %r, expected %r" % (t1,t2,o,9)
-                if np.issubdtype(np.dtype(o),np.integer):
-                    assert_(o == 9,msg)
+                result = a**b
+                msg = ("error with %r and %r:"
+                       "got %r, expected %r") % (t1, t2, result, 9)
+                if np.issubdtype(np.dtype(result), np.integer):
+                    assert_(result == 9, msg)
                 else:
-                    assert_almost_equal(o,9,err_msg=msg)
+                    assert_almost_equal(result, 9, err_msg=msg)
 
 class TestComplexDivision(TestCase):
     def test_zero_division(self):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -44,7 +44,7 @@ class TestTypes(TestCase):
 
 class TestPower(TestCase):
     def test_small_types(self):
-        for t in [np.int8, np.int16]:
+        for t in [np.int8, np.int16, np.float16]:
             a = t(3)
             b = a ** 4
             assert_(b == 81, "error with %r: got %r" % (t,b))
@@ -58,7 +58,18 @@ class TestPower(TestCase):
                 assert_(b == 6765201, msg)
             else:
                 assert_almost_equal(b, 6765201, err_msg=msg)
-
+    def test_mixed_types(self):
+        typelist = [np.int8,np.int16,np.float16,np.float32,np.float64,np.int8,np.int16,np.int32,np.int64]
+        for t1 in typelist:
+            for t2 in typelist:
+                a = t1(3)
+                b = t2(2)
+                o = a**b
+                msg = "error with %r and %r: got %r, expected %r" % (t1,t2,o,9)
+                if np.issubdtype(np.dtype(o),np.integer):
+                    assert_(o == 9,msg)
+                else:
+                    assert_almost_equal(o,9,err_msg=msg)
 
 class TestComplexDivision(TestCase):
     def test_zero_division(self):


### PR DESCRIPTION
This closes #621 but brings up what may be a new nastier bug.

It seems that the type conversions that you can build into ufuncs (for example in the codegen file for the npymath files) only work when you call the ufunc from python, and not when you call the generated function from c.
