### PR TITLE
ENH: np.testing.decorators: Use Py3k compatible raise syntax

### DIFF
--- a/numpy/testing/decorators.py
+++ b/numpy/testing/decorators.py
@@ -210,7 +210,7 @@ def knownfailureif(fail_condition, msg=None):
         from noseclasses import KnownFailureTest
         def knownfailer(*args, **kwargs):
             if fail_val():
-                raise KnownFailureTest, msg
+                raise KnownFailureTest(msg)
             else:
                 return f(*args, **kwargs)
         return nose.tools.make_decorator(f)(knownfailer)


### PR DESCRIPTION
[IPython](https://github.com/ipython/ipython) is currently working towards [improved Py3k support](https://github.com/ipython/ipython/pull/2100) in the master branch (i.e., reducing the number of necessary 2to3 fixes).  As you may know, we maintain a copy of [numpy.testing.decorators](https://github.com/ipython/ipython/blob/master/IPython/external/decorators/_decorators.py) so as to eliminate external dependencies.

It'd be convenient for us if you were to update the `raise` syntax in this one file.  There is only one instance of `raise E, V` (the [rest](https://github.com/numpy/numpy/blob/master/numpy/testing/decorators.py#L259) [use](https://github.com/numpy/numpy/blob/master/numpy/testing/decorators.py#L262) the newer `raise E(V)` syntax) so it's a simple one line update.
