### PR TITLE
BUG: ticket #2028: ...

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -36,17 +36,17 @@ _array_find_python_scalar_type(PyObject *op)
         /* if integer can fit into a longlong then return that*/
         if ((PyLong_AsLongLong(op) == -1) && PyErr_Occurred()) {
             PyErr_Clear();
-	    if((PyLong_AsUnsignedLongLong(op) == -1) && PyErr_Occurred()){
-	        PyErr_Clear();
-	    } 
-	    else {
-	        return PyArray_DescrFromType(NPY_ULONGLONG);
-	    }
+        if((PyLong_AsUnsignedLongLong(op) == -1) && PyErr_Occurred()){
+            PyErr_Clear();
+        } 
+        else {
+            return PyArray_DescrFromType(NPY_ULONGLONG);
+        }
             return PyArray_DescrFromType(NPY_OBJECT);
-        } 	
+        }
         else {
             return PyArray_DescrFromType(NPY_LONGLONG);
-	}
+        }
     }
     return NULL;
 }

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -45,7 +45,7 @@ _array_find_python_scalar_type(PyObject *op)
             return PyArray_DescrFromType(NPY_OBJECT);
         } 	
         else {
-	    return PyArray_DescrFromType(NPY_LONGLONG);
+            return PyArray_DescrFromType(NPY_LONGLONG);
 	}
     }
     return NULL;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -36,9 +36,15 @@ _array_find_python_scalar_type(PyObject *op)
         /* if integer can fit into a longlong then return that*/
         if ((PyLong_AsLongLong(op) == -1) && PyErr_Occurred()) {
             PyErr_Clear();
+	    if((PyLong_AsUnsignedLongLong(op) == -1) && PyErr_Occurred()){
+	      PyErr_Clear();
+	    } else {
+	      return PyArray_DescrFromType(NPY_ULONGLONG);
+	    }
             return PyArray_DescrFromType(NPY_OBJECT);
-        }
-        return PyArray_DescrFromType(NPY_LONGLONG);
+        } else {
+	  return PyArray_DescrFromType(NPY_LONGLONG);
+	}
     }
     return NULL;
 }

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -37,13 +37,15 @@ _array_find_python_scalar_type(PyObject *op)
         if ((PyLong_AsLongLong(op) == -1) && PyErr_Occurred()) {
             PyErr_Clear();
 	    if((PyLong_AsUnsignedLongLong(op) == -1) && PyErr_Occurred()){
-	      PyErr_Clear();
-	    } else {
-	      return PyArray_DescrFromType(NPY_ULONGLONG);
+	        PyErr_Clear();
+	    } 
+	    else {
+	        return PyArray_DescrFromType(NPY_ULONGLONG);
 	    }
             return PyArray_DescrFromType(NPY_OBJECT);
-        } else {
-	  return PyArray_DescrFromType(NPY_LONGLONG);
+        } 	
+        else {
+	    return PyArray_DescrFromType(NPY_LONGLONG);
 	}
     }
     return NULL;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -36,8 +36,9 @@ _array_find_python_scalar_type(PyObject *op)
         /* if integer can fit into a longlong then return that*/
         if ((PyLong_AsLongLong(op) == -1) && PyErr_Occurred()) {
             PyErr_Clear();
-        if((PyLong_AsUnsignedLongLong(op) == -1) && PyErr_Occurred()){
-            PyErr_Clear();
+            if ((PyLong_AsUnsignedLongLong(op) == (unsigned long long) -1) 
+                    && PyErr_Occurred()){
+                PyErr_Clear();
         } 
         else {
             return PyArray_DescrFromType(NPY_ULONGLONG);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2377,6 +2377,29 @@ class TestWarnings(object):
         finally:
             warn_ctx.__exit__()
 
+class TestMinScalarType(object):
+    def test_usigned_shortshort(self):
+        dt = np.min_scalar_type(2**8-1)
+        wanted = np.dtype('uint8')
+        assert_equal(wanted, dt)
+    def test_usigned_short(self):
+        dt = np.min_scalar_type(2**16-1)
+        wanted = np.dtype('uint16')
+        assert_equal(wanted, dt)    
+    def test_usigned_int(self):
+        dt = np.min_scalar_type(2**32-1)
+        wanted = np.dtype('uint32')
+        assert_equal(wanted, dt)    
+    def test_usigned_longlong(self):
+        dt = np.min_scalar_type(2**63-1)
+        wanted = np.dtype('uint64')
+        assert_equal(wanted, dt)    
+    def test_object(self):
+        dt = np.min_scalar_type(2**64)
+        wanted = np.dtype('O')
+        assert_equal(wanted, dt)
+        
+
 if sys.version_info >= (2, 6):
 
     if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
When min_scalar was not checking to see if numbers could fit into unsigned long longs. This was fixed by adding an extra case to function to check if the passed number could fit into a unsigned long long if it could not fit into anything else. Additionaly, regression tests were added.

Cleaned up version of previous pull request
