### PR TITLE
Allow ufunc operand flags to be set

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -159,3 +159,21 @@ General
 Use of non-integer indices has been deprecated. Previously float indices
 were truncated to integers without warning.
 
+C-API
+~~~~~
+
+New Features
+============
+
+When creating a ufunc, the default ufunc operand flags can be overridden
+via the new op_flags attribute of the ufunc object. For example, to set
+the operand flag for the first input to read/write:
+
+PyObject \*ufunc = PyUFunc_FromFuncAndData(...);
+ufunc->op_flags[0] = NPY_ITER_READWRITE;
+
+This allows a ufunc to perform an operation in place. Also, global nditer flags
+can be overridden via the new iter_flags attribute of the ufunc object.
+For example, to set the reduce flag for a ufunc:
+
+ufunc->iter_flags = NPY_ITER_REDUCE_OK;

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -652,6 +652,8 @@ PyUFunc_Type
           void *ptr;
           PyObject *obj;
           PyObject *userloops;
+          npy_uint32 *op_flags;
+          npy_uint32 *iter_flags;
       } PyUFuncObject;
 
    .. cmacro:: PyUFuncObject.PyObject_HEAD
@@ -754,6 +756,14 @@ PyUFunc_Type
        user-defined type. It is retrieved by type number. User defined type
        numbers are always larger than :cdata:`NPY_USERDEF`.
 
+
+   .. cmember:: npy_uint32 PyUFuncObject.op_flags
+
+       Override the default operand flags for each ufunc operand.
+
+   .. cmember:: npy_uint32 PyUFuncObject.iter_flags
+
+       Override the default nditer flags for the ufunc.
 
 PyArrayIter_Type
 ----------------

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -216,7 +216,7 @@ typedef struct _tagPyUFuncObject {
         /*
          * List of flags for each operand when ufunc is called by nditer object.
          * These flags will be used in addition to the default flags for each
-          * operand set by nditer object.
+         * operand set by nditer object.
          */
         npy_uint32 *op_flags;
 

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -212,6 +212,20 @@ typedef struct _tagPyUFuncObject {
          * A function which returns a masked inner loop for the ufunc.
          */
         PyUFunc_MaskedInnerLoopSelectionFunc *masked_inner_loop_selector;
+       
+        /*
+         * List of flags for each operand when ufunc is called by nditer object.
+         * These flags will be used in addition to the default flags for each
+          * operand set by nditer object.
+         */
+        npy_uint32 *op_flags;
+
+        /*
+         * List of global flags used when ufunc is called by nditer object.
+         * These flags will be used in addition to the default global flags
+         * set by nditer object.
+         */
+        npy_uint32 iter_flags;
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -936,7 +936,7 @@ def configuration(parent_package='',top_path=None):
                     sources = [join('src', 'multiarray', 'multiarray_tests.c.src')])
 
     #######################################################################
-    #                        operand_flag_tests module                           #
+    #                        operand_flag_tests module                    #
     #######################################################################
 
     config.add_extension('operand_flag_tests',

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -935,6 +935,13 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('multiarray_tests',
                     sources = [join('src', 'multiarray', 'multiarray_tests.c.src')])
 
+    #######################################################################
+    #                        operand_flag_tests module                           #
+    #######################################################################
+
+    config.add_extension('operand_flag_tests',
+                    sources = [join('src','umath', 'operand_flag_tests.c.src')])
+
     config.add_data_dir('tests')
     config.add_data_dir('tests/data')
 

--- a/numpy/core/src/umath/operand_flag_tests.c.src
+++ b/numpy/core/src/umath/operand_flag_tests.c.src
@@ -53,13 +53,16 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit_operand_flag_tests(void)
+#define RETVAL m
+PyMODINIT_FUNC PyInit_operand_flag_tests(void)
 {
 #else
+#define RETVAL
 PyMODINIT_FUNC initoperand_flag_tests(void)
 {
 #endif
-    PyObject *m, *ufunc;
+    PyObject *m = NULL;
+    PyObject *ufunc;
 
 #if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
@@ -67,7 +70,7 @@ PyMODINIT_FUNC initoperand_flag_tests(void)
     m = Py_InitModule("operand_flag_tests", TestMethods);
 #endif
     if (m == NULL) {
-        return;
+        goto fail;
     }
 
     import_array();
@@ -77,11 +80,27 @@ PyMODINIT_FUNC initoperand_flag_tests(void)
                                     PyUFunc_None, "inplace_add",
                                     "inplace_add_docstring", 0);
 
-    /* Set flags to turn off buffering for first input operand,
-       so that result can be written back to input operand. */
+    /* 
+     * Set flags to turn off buffering for first input operand,
+     * so that result can be written back to input operand.
+     */
     ((PyUFuncObject*)ufunc)->op_flags[0] = NPY_ITER_READWRITE;
     ((PyUFuncObject*)ufunc)->iter_flags = NPY_ITER_REDUCE_OK;
     PyModule_AddObject(m, "inplace_add", (PyObject*)ufunc);
 
-    return m;
+    return RETVAL;
+
+fail:
+    if (!PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "cannot load operand_flag_tests module.");
+    }
+#if defined(NPY_PY3K)
+    if (m) {
+        Py_DECREF(m);
+        m = NULL;
+    }
+#endif
+    return RETVAL;
+
 }

--- a/numpy/core/src/umath/operand_flag_tests.c.src
+++ b/numpy/core/src/umath/operand_flag_tests.c.src
@@ -1,0 +1,87 @@
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include <stdint.h>
+#include <math.h>
+#include <Python.h>
+#include <structmember.h>
+#include <numpy/arrayobject.h>
+#include <numpy/ufuncobject.h>
+#include "numpy/npy_3kcompat.h"
+
+
+static PyMethodDef TestMethods[] = {
+        {NULL, NULL, 0, NULL}
+};
+
+
+static void
+inplace_add(char **args, npy_intp *dimensions, npy_intp *steps, void *data)
+{
+    npy_intp i;
+    npy_intp n = dimensions[0];
+    char *in1 = args[0];
+    char *in2 = args[1];
+    npy_intp in1_step = steps[0];
+    npy_intp in2_step = steps[1];
+
+    for (i = 0; i < n; i++) {
+        (*(long *)in1) = *(long*)in1 + *(long*)in2;
+        in1 += in1_step;
+        in2 += in2_step;
+    }
+}
+
+
+/*This a pointer to the above function*/
+PyUFuncGenericFunction funcs[1] = {&inplace_add};
+
+/* These are the input and return dtypes of logit.*/
+static char types[2] = {NPY_LONG, NPY_LONG};
+
+static void *data[1] = {NULL};
+
+#if defined(NPY_PY3K)
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "operand_flag_tests",
+    NULL,
+    -1,
+    TestMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyObject *PyInit_operand_flag_tests(void)
+{
+#else
+PyMODINIT_FUNC initoperand_flag_tests(void)
+{
+#endif
+    PyObject *m, *ufunc;
+
+#if defined(NPY_PY3K)
+    m = PyModule_Create(&moduledef);
+#else
+    m = Py_InitModule("operand_flag_tests", TestMethods);
+#endif
+    if (m == NULL) {
+        return;
+    }
+
+    import_array();
+    import_umath();
+
+    ufunc = PyUFunc_FromFuncAndData(funcs, data, types, 1, 2, 0,
+                                    PyUFunc_None, "inplace_add",
+                                    "inplace_add_docstring", 0);
+
+    /* Set flags to turn off buffering for first input operand,
+       so that result can be written back to input operand. */
+    ((PyUFuncObject*)ufunc)->op_flags[0] = NPY_ITER_READWRITE;
+    ((PyUFuncObject*)ufunc)->iter_flags = NPY_ITER_REDUCE_OK;
+    PyModule_AddObject(m, "inplace_add", (PyObject*)ufunc);
+
+    return m;
+}

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1182,12 +1182,22 @@ iterator_loop(PyUFuncObject *ufunc,
 
     PyArrayObject **op_it;
 
+    npy_uint32 iter_flags;
+
     NPY_BEGIN_THREADS_DEF;
 
     /* Set up the flags */
     for (i = 0; i < nin; ++i) {
         op_flags[i] = NPY_ITER_READONLY|
                       NPY_ITER_ALIGNED;
+        /* 
+         * If READWRITE flag has been set for this operand,
+         * then clear default READONLY flag
+         */ 
+        op_flags[i] |= ufunc->op_flags[i];
+        if (op_flags[i] & NPY_ITER_READWRITE) {
+            op_flags[i] ^= NPY_ITER_READONLY;
+        }
     }
     for (i = nin; i < nop; ++i) {
         op_flags[i] = NPY_ITER_WRITEONLY|
@@ -1195,7 +1205,21 @@ iterator_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALLOCATE|
                       NPY_ITER_NO_BROADCAST|
                       NPY_ITER_NO_SUBTYPE;
+
+        if (ufunc->op_flags[i] > 0) {
+            PyErr_SetString(PyExc_ValueError, "manually setting operand flags " \
+                "for output operand is not supported at this time");
+            return -1;
+        }
     }
+
+    iter_flags = ufunc->iter_flags|
+                 NPY_ITER_EXTERNAL_LOOP|
+                 NPY_ITER_REFS_OK|
+                 NPY_ITER_ZEROSIZE_OK|
+                 NPY_ITER_BUFFERED|
+                 NPY_ITER_GROWINNER|
+                 NPY_ITER_DELAY_BUFALLOC;
 
     /*
      * Allocate the iterator.  Because the types of the inputs
@@ -1203,12 +1227,7 @@ iterator_loop(PyUFuncObject *ufunc,
      * is faster to calculate.
      */
     iter = NpyIter_AdvancedNew(nop, op,
-                        NPY_ITER_EXTERNAL_LOOP|
-                        NPY_ITER_REFS_OK|
-                        NPY_ITER_ZEROSIZE_OK|
-                        NPY_ITER_BUFFERED|
-                        NPY_ITER_GROWINNER|
-                        NPY_ITER_DELAY_BUFALLOC,
+                        iter_flags,
                         order, NPY_UNSAFE_CASTING,
                         op_flags, dtype,
                         -1, NULL, NULL, buffersize);
@@ -1463,8 +1482,10 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
 
     PyArrayObject **op_it;
 
-    NPY_BEGIN_THREADS_DEF;
+    npy_uint32 iter_flags;
 
+    NPY_BEGIN_THREADS_DEF;
+    
     if (wheremask != NULL) {
         if (nop + 1 > NPY_MAXARGS) {
             PyErr_SetString(PyExc_ValueError,
@@ -1481,6 +1502,14 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
         op_flags[i] = default_op_in_flags |
                       NPY_ITER_READONLY |
                       NPY_ITER_ALIGNED;
+        /* 
+         * If READWRITE flag has been set for this operand,
+         * then clear default READONLY flag
+         */       
+        op_flags[i] |= ufunc->op_flags[i];
+        if (op_flags[i] & NPY_ITER_READWRITE) {
+            op_flags[i] ^= NPY_ITER_READONLY;
+        }
     }
     for (i = nin; i < nop; ++i) {
         op_flags[i] = default_op_out_flags |
@@ -1489,6 +1518,12 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALLOCATE |
                       NPY_ITER_NO_BROADCAST |
                       NPY_ITER_NO_SUBTYPE;
+        
+        if (ufunc->op_flags[i] > 0) {
+            PyErr_SetString(PyExc_ValueError, "manually setting operand flags " \
+                "for output operand is not supported at this time");
+            return -1;
+        }
     }
     if (wheremask != NULL) {
         op_flags[nop] = NPY_ITER_READONLY | NPY_ITER_ARRAYMASK;
@@ -1496,17 +1531,20 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
 
     NPY_UF_DBG_PRINT("Making iterator\n");
 
+    iter_flags = ufunc->iter_flags|
+                 NPY_ITER_EXTERNAL_LOOP|
+                 NPY_ITER_REFS_OK|
+                 NPY_ITER_ZEROSIZE_OK|
+                 NPY_ITER_BUFFERED|
+                 NPY_ITER_GROWINNER;
+
     /*
      * Allocate the iterator.  Because the types of the inputs
      * were already checked, we use the casting rule 'unsafe' which
      * is faster to calculate.
      */
     iter = NpyIter_AdvancedNew(nop + ((wheremask != NULL) ? 1 : 0), op,
-                        NPY_ITER_EXTERNAL_LOOP |
-                        NPY_ITER_REFS_OK |
-                        NPY_ITER_ZEROSIZE_OK |
-                        NPY_ITER_BUFFERED |
-                        NPY_ITER_GROWINNER,
+                        iter_flags,
                         order, NPY_UNSAFE_CASTING,
                         op_flags, dtypes,
                         -1, NULL, NULL, buffersize);
@@ -1665,6 +1703,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     npy_intp iter_shape[NPY_MAXARGS];
 
     NpyIter *iter = NULL;
+    
+    npy_uint32 iter_flags;
 
     /* These parameters come from extobj= or from a TLS global */
     int buffersize = 0, errormask = 0;
@@ -1967,6 +2007,14 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         op_flags[i] = NPY_ITER_READONLY|
                       NPY_ITER_COPY|
                       NPY_ITER_ALIGNED;
+        /* 
+         * If READWRITE flag has been set for this operand,
+         * then clear default READONLY flag
+         */ 
+        op_flags[i] |= ufunc->op_flags[i];
+        if (op_flags[i] & NPY_ITER_READWRITE) {
+            op_flags[i] ^= NPY_ITER_READONLY;
+        }
     }
     for (i = nin; i < nop; ++i) {
         op_flags[i] = NPY_ITER_READWRITE|
@@ -1974,13 +2022,34 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_ALIGNED|
                       NPY_ITER_ALLOCATE|
                       NPY_ITER_NO_BROADCAST;
+
+        if (ufunc->op_flags[i] > 0) {
+            PyErr_SetString(PyExc_ValueError, "manually setting operand flags " \
+                "for output operand is not supported at this time");
+            return -1;
+        }
     }
 
+    /*
+     * If there are no iteration dimensions, create a fake one
+     * so that the scalar edge case works right.
+     */
+    if (iter_ndim == 0) {
+        iter_ndim = 1;
+        iter_shape[0] = 1;
+        for (i = 0; i < nop; ++i) {
+            op_axes[i][0] = -1;
+        }
+    }
+
+    iter_flags = ufunc->iter_flags|
+                 NPY_ITER_MULTI_INDEX|
+                 NPY_ITER_REFS_OK|
+                 NPY_ITER_REDUCE_OK|
+                 NPY_ITER_ZEROSIZE_OK;
+
     /* Create the iterator */
-    iter = NpyIter_AdvancedNew(nop, op, NPY_ITER_MULTI_INDEX|
-                                      NPY_ITER_REFS_OK|
-                                      NPY_ITER_REDUCE_OK|
-                                      NPY_ITER_ZEROSIZE_OK,
+    iter = NpyIter_AdvancedNew(nop, op, iter_flags,
                            order, NPY_UNSAFE_CASTING, op_flags,
                            dtypes, iter_ndim,
                            op_axes, iter_shape, 0);
@@ -4241,6 +4310,9 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
         ufunc->name = name;
     }
     ufunc->doc = doc;
+
+    ufunc->op_flags = calloc(ufunc->nargs, sizeof(npy_uint32));
+    ufunc->iter_flags = 0;
 
     /* generalized ufunc */
     ufunc->core_enabled = 0;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4291,6 +4291,9 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     ufunc->doc = doc;
 
     ufunc->op_flags = PyArray_malloc(sizeof(npy_uint32)*ufunc->nargs);
+    if (ufunc->op_flags == NULL) {
+        return PyErr_NoMemory();
+    }
     memset(ufunc->op_flags, 0, sizeof(npy_uint32)*ufunc->nargs);
 
     ufunc->iter_flags = 0;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1195,8 +1195,8 @@ iterator_loop(PyUFuncObject *ufunc,
          * then clear default READONLY flag
          */ 
         op_flags[i] |= ufunc->op_flags[i];
-        if (op_flags[i] & NPY_ITER_READWRITE) {
-            op_flags[i] ^= NPY_ITER_READONLY;
+        if (op_flags[i] & (NPY_ITER_READWRITE | NPY_ITER_WRITEONLY)) {
+            op_flags[i] &= ~NPY_ITER_READONLY;
         }
     }
     for (i = nin; i < nop; ++i) {
@@ -1207,8 +1207,8 @@ iterator_loop(PyUFuncObject *ufunc,
                       NPY_ITER_NO_SUBTYPE;
 
         if (ufunc->op_flags[i] > 0) {
-            PyErr_SetString(PyExc_ValueError, "manually setting operand flags " \
-                "for output operand is not supported at this time");
+            PyErr_SetString(PyExc_ValueError, "manually setting ufunc operand " \
+                "flags for output operand is not supported at this time");
             return -1;
         }
     }
@@ -1507,8 +1507,8 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
          * then clear default READONLY flag
          */       
         op_flags[i] |= ufunc->op_flags[i];
-        if (op_flags[i] & NPY_ITER_READWRITE) {
-            op_flags[i] ^= NPY_ITER_READONLY;
+        if (op_flags[i] & (NPY_ITER_READWRITE | NPY_ITER_WRITEONLY)) {
+            op_flags[i] &= ~NPY_ITER_READONLY;
         }
     }
     for (i = nin; i < nop; ++i) {
@@ -1520,8 +1520,8 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                       NPY_ITER_NO_SUBTYPE;
         
         if (ufunc->op_flags[i] > 0) {
-            PyErr_SetString(PyExc_ValueError, "manually setting operand flags " \
-                "for output operand is not supported at this time");
+            PyErr_SetString(PyExc_ValueError, "manually setting ufunc operand " \
+                "flags for output operand is not supported at this time");
             return -1;
         }
     }
@@ -2012,8 +2012,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
          * then clear default READONLY flag
          */ 
         op_flags[i] |= ufunc->op_flags[i];
-        if (op_flags[i] & NPY_ITER_READWRITE) {
-            op_flags[i] ^= NPY_ITER_READONLY;
+        if (op_flags[i] & (NPY_ITER_READWRITE | NPY_ITER_WRITEONLY)) {
+            op_flags[i] &= ~NPY_ITER_READONLY;
         }
     }
     for (i = nin; i < nop; ++i) {
@@ -2024,8 +2024,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_NO_BROADCAST;
 
         if (ufunc->op_flags[i] > 0) {
-            PyErr_SetString(PyExc_ValueError, "manually setting operand flags " \
-                "for output operand is not supported at this time");
+            PyErr_SetString(PyExc_ValueError, "manually setting ufunc operand " \
+                "flags for output operand is not supported at this time");
             return -1;
         }
     }
@@ -4311,7 +4311,9 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     }
     ufunc->doc = doc;
 
-    ufunc->op_flags = calloc(ufunc->nargs, sizeof(npy_uint32));
+    ufunc->op_flags = PyArray_malloc(sizeof(npy_uint32)*ufunc->nargs);
+    memset(ufunc->op_flags, 0, sizeof(npy_uint32)*ufunc->nargs);
+
     ufunc->iter_flags = 0;
 
     /* generalized ufunc */
@@ -4562,6 +4564,9 @@ ufunc_dealloc(PyUFuncObject *ufunc)
     }
     if (ufunc->ptr) {
         PyArray_free(ufunc->ptr);
+    }
+    if (ufunc->op_flags) {
+        PyArray_free(ufunc->op_flags);
     }
     Py_XDECREF(ufunc->userloops);
     Py_XDECREF(ufunc->obj);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1477,7 +1477,7 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
     npy_uint32 iter_flags;
 
     NPY_BEGIN_THREADS_DEF;
-    
+
     if (wheremask != NULL) {
         if (nop + 1 > NPY_MAXARGS) {
             PyErr_SetString(PyExc_ValueError,
@@ -2021,10 +2021,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         }
     }
 
-    iter_flags = ufunc->iter_flags|
-                 NPY_ITER_MULTI_INDEX|
-                 NPY_ITER_REFS_OK|
-                 NPY_ITER_REDUCE_OK|
+    iter_flags = ufunc->iter_flags |
+                 NPY_ITER_MULTI_INDEX |
+                 NPY_ITER_REFS_OK |
+                 NPY_ITER_REDUCE_OK |
                  NPY_ITER_ZEROSIZE_OK;
 
     /* Create the iterator */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1687,7 +1687,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
     npy_uint32 op_flags[NPY_MAXARGS];
     npy_intp iter_shape[NPY_MAXARGS];
-
     NpyIter *iter = NULL;
     npy_uint32 iter_flags;
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1205,12 +1205,6 @@ iterator_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALLOCATE|
                       NPY_ITER_NO_BROADCAST|
                       NPY_ITER_NO_SUBTYPE;
-
-        if (ufunc->op_flags[i] > 0) {
-            PyErr_SetString(PyExc_ValueError, "manually setting ufunc operand " \
-                "flags for output operand is not supported at this time");
-            return -1;
-        }
     }
 
     iter_flags = ufunc->iter_flags|
@@ -1518,12 +1512,6 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALLOCATE |
                       NPY_ITER_NO_BROADCAST |
                       NPY_ITER_NO_SUBTYPE;
-        
-        if (ufunc->op_flags[i] > 0) {
-            PyErr_SetString(PyExc_ValueError, "manually setting ufunc operand " \
-                "flags for output operand is not supported at this time");
-            return -1;
-        }
     }
     if (wheremask != NULL) {
         op_flags[nop] = NPY_ITER_READONLY | NPY_ITER_ARRAYMASK;
@@ -2022,12 +2010,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_ALIGNED|
                       NPY_ITER_ALLOCATE|
                       NPY_ITER_NO_BROADCAST;
-
-        if (ufunc->op_flags[i] > 0) {
-            PyErr_SetString(PyExc_ValueError, "manually setting ufunc operand " \
-                "flags for output operand is not supported at this time");
-            return -1;
-        }
     }
 
     /*

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1181,14 +1181,13 @@ iterator_loop(PyUFuncObject *ufunc,
     npy_intp *count_ptr;
 
     PyArrayObject **op_it;
-
     npy_uint32 iter_flags;
 
     NPY_BEGIN_THREADS_DEF;
 
     /* Set up the flags */
     for (i = 0; i < nin; ++i) {
-        op_flags[i] = NPY_ITER_READONLY|
+        op_flags[i] = NPY_ITER_READONLY |
                       NPY_ITER_ALIGNED;
         /* 
          * If READWRITE flag has been set for this operand,
@@ -1200,19 +1199,19 @@ iterator_loop(PyUFuncObject *ufunc,
         }
     }
     for (i = nin; i < nop; ++i) {
-        op_flags[i] = NPY_ITER_WRITEONLY|
-                      NPY_ITER_ALIGNED|
-                      NPY_ITER_ALLOCATE|
-                      NPY_ITER_NO_BROADCAST|
+        op_flags[i] = NPY_ITER_WRITEONLY |
+                      NPY_ITER_ALIGNED |
+                      NPY_ITER_ALLOCATE |
+                      NPY_ITER_NO_BROADCAST |
                       NPY_ITER_NO_SUBTYPE;
     }
 
-    iter_flags = ufunc->iter_flags|
-                 NPY_ITER_EXTERNAL_LOOP|
-                 NPY_ITER_REFS_OK|
-                 NPY_ITER_ZEROSIZE_OK|
-                 NPY_ITER_BUFFERED|
-                 NPY_ITER_GROWINNER|
+    iter_flags = ufunc->iter_flags |
+                 NPY_ITER_EXTERNAL_LOOP |
+                 NPY_ITER_REFS_OK |
+                 NPY_ITER_ZEROSIZE_OK |
+                 NPY_ITER_BUFFERED |
+                 NPY_ITER_GROWINNER |
                  NPY_ITER_DELAY_BUFALLOC;
 
     /*
@@ -1475,7 +1474,6 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
     npy_intp *countptr;
 
     PyArrayObject **op_it;
-
     npy_uint32 iter_flags;
 
     NPY_BEGIN_THREADS_DEF;
@@ -1519,11 +1517,11 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
 
     NPY_UF_DBG_PRINT("Making iterator\n");
 
-    iter_flags = ufunc->iter_flags|
-                 NPY_ITER_EXTERNAL_LOOP|
-                 NPY_ITER_REFS_OK|
-                 NPY_ITER_ZEROSIZE_OK|
-                 NPY_ITER_BUFFERED|
+    iter_flags = ufunc->iter_flags |
+                 NPY_ITER_EXTERNAL_LOOP |
+                 NPY_ITER_REFS_OK |
+                 NPY_ITER_ZEROSIZE_OK |
+                 NPY_ITER_BUFFERED |
                  NPY_ITER_GROWINNER;
 
     /*
@@ -1691,7 +1689,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     npy_intp iter_shape[NPY_MAXARGS];
 
     NpyIter *iter = NULL;
-    
     npy_uint32 iter_flags;
 
     /* These parameters come from extobj= or from a TLS global */
@@ -1992,8 +1989,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      * can't do buffering, so must COPY or UPDATEIFCOPY.
      */
     for (i = 0; i < nin; ++i) {
-        op_flags[i] = NPY_ITER_READONLY|
-                      NPY_ITER_COPY|
+        op_flags[i] = NPY_ITER_READONLY |
+                      NPY_ITER_COPY |
                       NPY_ITER_ALIGNED;
         /* 
          * If READWRITE flag has been set for this operand,

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -123,7 +123,9 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     self->core_dim_ixs = NULL;
     self->core_offsets = NULL;
     self->core_signature = NULL;
-    self->op_flags = NULL;
+    self->op_flags = PyArray_malloc(sizeof(npy_uint32)*self->nargs);
+    memset(self->op_flags, 0, sizeof(npy_uint32)*self->nargs);
+    self->iter_flags = 0;
 
     self->type_resolver = &object_ufunc_type_resolver;
     self->legacy_inner_loop_selector = &object_ufunc_loop_selector;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -123,6 +123,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     self->core_dim_ixs = NULL;
     self->core_offsets = NULL;
     self->core_signature = NULL;
+    self->op_flags = NULL;
 
     self->type_resolver = &object_ufunc_type_resolver;
     self->legacy_inner_loop_selector = &object_ufunc_loop_selector;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -124,6 +124,9 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     self->core_offsets = NULL;
     self->core_signature = NULL;
     self->op_flags = PyArray_malloc(sizeof(npy_uint32)*self->nargs);
+    if (self->op_flags == NULL) {
+        return PyErr_NoMemory();
+    }
     memset(self->op_flags, 0, sizeof(npy_uint32)*self->nargs);
     self->iter_flags = 0;
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -5,6 +5,7 @@ import sys
 import numpy as np
 from numpy.testing import *
 import numpy.core.umath_tests as umt
+import numpy.core.operand_flag_tests as opflag_tests
 from numpy.compat import asbytes
 from numpy.core.test_rational import *
 
@@ -786,6 +787,13 @@ class TestUfunc(TestCase):
 
         # no output type should raise TypeError
         assert_raises(TypeError, test_add, a, b)
+    
+    def test_operand_flags(self):
+        a = np.arange(16, dtype='i8').reshape(4,4)
+        b = np.arange(9, dtype='i8').reshape(3,3)
+        opflag_tests.inplace_add(a[:-1,:-1], b)
+        assert_equal(a, np.array([[0,2,4,3],[7,9,11,7],
+            [14,16,18,11],[12,13,14,15]], dtype='i8'))
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This change allows ufunc operand flags to be set in addition to the default operand flags set by the nditer object. For example, after calling PyUFunc_FromFuncAndData() to create a ufunc object, the first operand can be set to be read/write like so:

ufunc->op_flags[0] = NPY_ITER_READWRITE

Setting flags for output operands is not supported at this time and will raise an exception.

This change also allows the global nditer flags to be set, so after setting the read/write flag, the reduce ok flag could be set like so:

ufunc->iter_flags = NPY_ITER_REDUCE_OK
