### PR TITLE
Fix `WindowsError: [Error 32]` in test_not_closing_opened_fid (test_io.T...

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -187,6 +187,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
             assert_(not fp.closed)
 
         finally:
+            fp.close()
             os.remove(tmp)
 
     def test_closing_fid(self):


### PR DESCRIPTION
...estSavezLoad)

See http://mail.scipy.org/pipermail/numpy-discussion/2012-July/063354.html
