### PR TITLE
[FIX] Add missing header so separate compilation works again

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -6,6 +6,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
+#include "arrayobject.h"
 
 #include "npy_config.h"
 


### PR DESCRIPTION
(Broken by PR #350.)

Should be applied to maintenance/1.7.x as well.
