### PR TITLE
FIX: Fixes the msvcr problem in MinGW

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -91,11 +91,11 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         build_import_library()
 
         # Check for custom msvc runtime library on Windows. Build if it doesn't exist.
-        msvcr_success = build_msvcr_library()
-        msvcr_dbg_success = build_msvcr_library(debug=True)
-        if msvcr_success or msvcr_dbg_success:
-            # add preprocessor statement for using customized msvcr lib
-            self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
+        #msvcr_success = build_msvcr_library()
+        #msvcr_dbg_success = build_msvcr_library(debug=True)
+        #if msvcr_success or msvcr_dbg_success:
+        #    # add preprocessor statement for using customized msvcr lib
+        #    self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
 
         # Define the MSVC version as hint for MinGW
         msvcr_version = '0x%03i0' % int(msvc_runtime_library().lstrip('msvcr'))


### PR DESCRIPTION
See this thread for more information:

http://mail.scipy.org/pipermail/numpy-discussion/2012-July/063381.html

I think this should go in before the release, because otherwise the sources don't build out of the box using MinGW. The 1.6.2 release builds just fine using the same Windows setup.

/cc @teoliphant, @charris, @rgommers
