### PR TITLE
Update Testing Reference Docs

### DIFF
--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -18,6 +18,9 @@ Asserts
    assert_almost_equal
    assert_approx_equal
    assert_array_almost_equal
+   assert_allclose
+   assert_array_almost_equal_nulp
+   assert_array_max_ulp
    assert_array_equal
    assert_array_less
    assert_equal


### PR DESCRIPTION
Added entries for `assert_allclose`, `assert_array_almost_equal_nulp`, and `assert_array_max_ulp` into the numpy testing reference documentation.
