### PR TITLE
A fix for the PyUnicodeObject Python 3.3

### DIFF
--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -641,6 +641,36 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             itemsize = (((itemsize - 1) >> 2) + 1) << 2;
         }
     }
+#if PY_VERSION_HEX >= 0x03030000
+    if (type_num == NPY_UNICODE) {
+        PyObject *u, *args;
+        if (swap) {
+            // Force PyUnicode_New to use the UCS4 representation:
+            Py_UCS4 max_char = 0x10000;
+            u = PyUnicode_New(itemsize >> 2, max_char);
+            if (u == NULL) {
+                return NULL;
+            }
+            memcpy(PyUnicode_4BYTE_DATA(u), data, itemsize);
+            byte_swap_vector(PyUnicode_4BYTE_DATA(u), itemsize >> 2, 4);
+        } else {
+            u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, data,
+                    itemsize >> 2);
+            if (u == NULL) {
+                return NULL;
+            }
+        }
+        args = Py_BuildValue("(O)", u);
+        if (args == NULL) {
+            Py_DECREF(u);
+            return NULL;
+        }
+        obj = type->tp_new(type, args, NULL);
+        Py_DECREF(u);
+        Py_DECREF(args);
+        return obj;
+    }
+#endif
     if (type->tp_itemsize != 0) {
         /* String type */
         obj = type->tp_alloc(type, itemsize);
@@ -672,6 +702,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             memcpy(destptr, data, itemsize);
             return obj;
         }
+#if PY_VERSION_HEX < 0x03030000
         else if (type_num == NPY_UNICODE) {
             /* tp_alloc inherited from Python PyBaseObject_Type */
             PyUnicodeObject *uni = (PyUnicodeObject*)obj;
@@ -743,6 +774,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
 #endif
             return obj;
         }
+#endif // PY_VERSION_HEX < 0x03030000
         else {
             PyVoidScalarObject *vobj = (PyVoidScalarObject *)obj;
             vobj->base = NULL;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2592,7 +2592,11 @@ finish:
     *((npy_@name@ *)dest) = *((npy_@name@ *)src);
 #elif @default@ == 1 /* unicode and strings */
     if (itemsize == 0) { /* unicode */
+#if PY_VERSION_HEX >= 0x03030000
+        itemsize = PyUnicode_GetLength(robj) * PyUnicode_KIND(robj);
+#else
         itemsize = ((PyUnicodeObject *)robj)->length * sizeof(Py_UNICODE);
+#endif
     }
     memcpy(dest, src, itemsize);
     /* @default@ == 2 won't get here */


### PR DESCRIPTION
**Update**: A better version of this patch is #372. This pull request can be closed.

Currently NumPy fails in Python 3.3 with:

https://gist.github.com/3189711

This PR makes it compile in Python 3.3. Relevant sources of information:

http://www.python.org/dev/peps/pep-0393/
http://docs.python.org/dev/c-api/unicode.html#PyUnicode_FromKindAndData

It compiles in Python 3.2 and all tests pass.

It compiles in Python 3.3 and all PyUnicodeObject related tests seem to pass.
The tests log (as of 17d03e4) is: https://gist.github.com/3199594
There are a few unrelated failures.

Please review carefully the direct `PyUnicode_New()` usage and forcing it to use `UCS4` via the `max_char` trick.
We need this to able to safely call the `byte_swap_vector()`. If we don't need to swap, then we simply call the
`PyUnicode_FromKindAndData()` directly, which internally (depending on the max_char, that is automatically determined) can convert to UCS2 or UCS1, see `Objects/unicodeobject.c:1977` in Python 3.3 sources.

Another way to implement it would be to always call `PyUnicode_FromKindAndData()`, and then depending on the result of `PyUnicode_KIND()`, one would call one of:

```
byte_swap_vector(PyUnicode_4BYTE_DATA(b), itemsize >> 2, 4)
byte_swap_vector(PyUnicode_2BYTE_DATA(b), itemsize >> 2, 2)
byte_swap_vector(PyUnicode_1BYTE_DATA(b), itemsize >> 2, 1)
```

However, I've tried that too, see: https://github.com/certik/numpy/commit/7e6bcfe08eab937c6b77543194f849863795a34b
and there are still test failures for the `PyUnicode_2BYTE_DATA()` case due to byte swapping. I don't know why, but it might be that the tests are not well written and assume that numpy internally is always using `UCS4`.

And as such, the solution in this PR is simply extending the same logic from Python 3.2 to Python 3.3. A separate issue is that swapping the data of the PyUnicodeObject (both in 3.2 and 3.3) is hackish, because it makes the object internal state invalid (and it can raise exceptions in some cases).
