### PR TITLE
A fix for the PyUnicodeObject Python 3.3

### DIFF
--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -645,6 +645,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
     if (type_num == NPY_UNICODE) {
         PyObject *u, *args;
         char *buffer;
+
         if (swap) {
             buffer = malloc(itemsize);
             if (buffer == NULL) {
@@ -653,7 +654,8 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             }
             memcpy(buffer, data, itemsize);
             byte_swap_vector(buffer, itemsize >> 2, 4);
-        } else {
+        }
+        else {
             buffer = data;
         }
         u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buffer,
@@ -778,7 +780,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
 #endif
             return obj;
         }
-#endif // PY_VERSION_HEX < 0x03030000
+#endif /* PY_VERSION_HEX < 0x03030000 */
         else {
             PyVoidScalarObject *vobj = (PyVoidScalarObject *)obj;
             vobj->base = NULL;

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -644,25 +644,18 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
 #if PY_VERSION_HEX >= 0x03030000
     if (type_num == NPY_UNICODE) {
         PyObject *u, *args;
-        char *buffer;
+        int byteorder;
 
-        if (swap) {
-            buffer = malloc(itemsize);
-            if (buffer == NULL) {
-                PyErr_NoMemory();
-                return NULL;
-            }
-            memcpy(buffer, data, itemsize);
-            byte_swap_vector(buffer, itemsize >> 2, 4);
-        }
-        else {
-            buffer = data;
-        }
-        u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buffer,
-                itemsize >> 2);
-        if (swap) {
-            free(buffer);
-        }
+#if NPY_BYTE_ORDER == NPY_LITTLE_ENDIAN
+        byteorder = -1;
+#elif NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+        byteorder = +1;
+#else
+        #error Endianness undefined ?
+#endif
+        if (swap) byteorder *= -1;
+
+        u = PyUnicode_DecodeUTF32(data, itemsize, NULL, &byteorder);
         if (u == NULL) {
             return NULL;
         }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -641,6 +641,40 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             itemsize = (((itemsize - 1) >> 2) + 1) << 2;
         }
     }
+#if PY_VERSION_HEX >= 0x03030000
+    if (type_num == NPY_UNICODE) {
+        PyObject *u, *args;
+        char *buffer;
+        if (swap) {
+            buffer = malloc(itemsize);
+            if (buffer == NULL) {
+                PyErr_NoMemory();
+                return NULL;
+            }
+            memcpy(buffer, data, itemsize);
+            byte_swap_vector(buffer, itemsize >> 2, 4);
+        } else {
+            buffer = data;
+        }
+        u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buffer,
+                itemsize >> 2);
+        if (swap) {
+            free(buffer);
+        }
+        if (u == NULL) {
+            return NULL;
+        }
+        args = Py_BuildValue("(O)", u);
+        if (args == NULL) {
+            Py_DECREF(u);
+            return NULL;
+        }
+        obj = type->tp_new(type, args, NULL);
+        Py_DECREF(u);
+        Py_DECREF(args);
+        return obj;
+    }
+#endif
     if (type->tp_itemsize != 0) {
         /* String type */
         obj = type->tp_alloc(type, itemsize);
@@ -672,6 +706,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             memcpy(destptr, data, itemsize);
             return obj;
         }
+#if PY_VERSION_HEX < 0x03030000
         else if (type_num == NPY_UNICODE) {
             /* tp_alloc inherited from Python PyBaseObject_Type */
             PyUnicodeObject *uni = (PyUnicodeObject*)obj;
@@ -743,6 +778,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
 #endif
             return obj;
         }
+#endif // PY_VERSION_HEX < 0x03030000
         else {
             PyVoidScalarObject *vobj = (PyVoidScalarObject *)obj;
             vobj->base = NULL;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2592,7 +2592,11 @@ finish:
     *((npy_@name@ *)dest) = *((npy_@name@ *)src);
 #elif @default@ == 1 /* unicode and strings */
     if (itemsize == 0) { /* unicode */
+#if PY_VERSION_HEX >= 0x03030000
+        itemsize = PyUnicode_GetLength(robj) * PyUnicode_KIND(robj);
+#else
         itemsize = ((PyUnicodeObject *)robj)->length * sizeof(Py_UNICODE);
+#endif
     }
     memcpy(dest, src, itemsize);
     /* @default@ == 2 won't get here */

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -26,10 +26,12 @@ else:
             return len(arr.data)
         return len(buffer(arr))
 
+# In both cases below we need to make sure that the byte swapped value (as
+# UCS4) is still a valid unicode:
 # Value that can be represented in UCS2 interpreters
-ucs2_value = u'\uFFFF'
+ucs2_value = u'\u0900'
 # Value that cannot be represented in UCS2 interpreters (but can in UCS4)
-ucs4_value = u'\U0010FFFF'
+ucs4_value = u'\U00100900'
 
 
 ############################################################


### PR DESCRIPTION
This is the polished fix from #366. The same approach is used, except that no hacks are necessary, we simply swap the buffer if needed, then call PyUnicode_FromKindAndData() and that's it.

There is a bug in tests, that sometime they produce invalid unicode. This is also fixed. See the description of the individual commits for more details.
