### PR TITLE
Fix memory leak in concatenate.

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -602,6 +602,7 @@ PyArray_Concatenate(PyObject *op, int axis)
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         Py_DECREF(arrays[iarrays]);
     }
+    PyArray_free(arrays);
 
     return (PyObject *)ret;
 
@@ -610,6 +611,7 @@ fail:
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         Py_DECREF(arrays[iarrays]);
     }
+    PyArray_free(arrays);
 
     return NULL;
 }


### PR DESCRIPTION
Temporary array was not being freed after use.
