### PR TITLE
Allow long numbers in numpy.rec.array formats string

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -133,7 +133,7 @@ def _reconstruct(subtype, shape, dtype):
 
 format_re = re.compile(asbytes(
                            r'(?P<order1>[<>|=]?)'
-                           r'(?P<repeats> *[(]?[ ,0-9]*[)]? *)'
+                           r'(?P<repeats> *[(]?[ ,0-9L]*[)]? *)'
                            r'(?P<order2>[<>|=]?)'
                            r'(?P<dtype>[A-Za-z0-9.]*(?:\[[a-zA-Z0-9,.]+\])?)'))
 sep_re = re.compile(asbytes(r'\s*,\s*'))

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -413,6 +413,11 @@ class TestString(TestCase):
         assert_equal(repr(dt),
                     "dtype([('a', '<M8[D]'), ('b', '<m8[us]')])")
 
+    @dec.skipif(sys.version_info[0] > 2)
+    def test_dtype_str_with_long_in_shape(self):
+        # Pull request #376
+        dt = np.dtype('(1L,)i4')
+
 
 class TestDtypeAttributeDeletion(object):
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -1,3 +1,4 @@
+import sys
 from os import path
 import numpy as np
 from numpy.testing import *
@@ -110,6 +111,13 @@ class TestFromrecords(TestCase):
         assert_equal(a[0].a, 1)
         assert_equal(a.b, ['a', 'bbb'])
         assert_equal(a[-1].b, 'bbb')
+
+    @dec.skipif(sys.version_info[0] > 2)
+    def test_recarray_from_long_formats(self):
+        # Pull request #376
+        a = [[1]]
+        ra = np.rec.array(a, shape=1, formats='(1L, 1L)i4')
+        assert_equal(a, ra.f0[0])
 
 
 class TestRecord(TestCase):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -1,4 +1,3 @@
-import sys
 from os import path
 import numpy as np
 from numpy.testing import *
@@ -111,13 +110,6 @@ class TestFromrecords(TestCase):
         assert_equal(a[0].a, 1)
         assert_equal(a.b, ['a', 'bbb'])
         assert_equal(a[-1].b, 'bbb')
-
-    @dec.skipif(sys.version_info[0] > 2)
-    def test_recarray_from_long_formats(self):
-        # Pull request #376
-        a = [[1]]
-        ra = np.rec.array(a, shape=1, formats='(1L, 1L)i4')
-        assert_equal(a, ra.f0[0])
 
 
 class TestRecord(TestCase):


### PR DESCRIPTION
On win-amd64, some [pyfits](http://pypi.python.org/pypi/pyfits) 3.0.9 tests fail because the `np.rec.array` `formats` argument may contain Python long numbers. A reduced example is:

```
>>> import numpy as np
>>> np.rec.array(None, shape=1L, formats='(1L, 1L)i4')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "X:\Python27-x64\lib\site-packages\numpy\core\records.py", line 749, in array
    aligned, byteorder)._descr
  File "X:\Python27-x64\lib\site-packages\numpy\core\records.py", line 143, in __init__
    self._parseFormats(formats, aligned)
  File "X:\Python27-x64\lib\site-packages\numpy\core\records.py", line 157, in _parseFormats
    dtype = sb.dtype(formats, aligned)
  File "X:\Python27-x64\lib\site-packages\numpy\core\_internal.py", line 234, in _commastring
    newitem = (dtype, eval(repeats))
  File "<string>", line 1
    (1
     ^
SyntaxError: unexpected EOF while parsing
```

Tested with numpy 1.6.2 on win-amd64-py2.7 and win32-py2.7. Will work on a unit test later...
