### PR TITLE
Change doc config to remove duplicate module indices

### DIFF
--- a/doc/sphinxext/numpydoc.py
+++ b/doc/sphinxext/numpydoc.py
@@ -135,6 +135,7 @@ class NumpyPythonDomain(ManglingDomainBase, PythonDomain):
         'staticmethod': 'function',
         'attribute': 'attribute',
     }
+    indices = []
 
 class NumpyCDomain(ManglingDomainBase, CDomain):
     name = 'np-c'


### PR DESCRIPTION
The numpy docs seem to have duplicate links to the `Python Module Index`.  There are two `modules` links  in the upper right hand corner of each page in the [html docs](http://docs.scipy.org/doc/numpy-1.6.0/reference/).

This is caused by using both the numpydoc and the sphinx python domains which both generate the same index page.

These changes make the numpydoc domains override the sphinx domains and thus prevent the duplicate entries.
