### PR TITLE
Fix the path to the release notes

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -98,7 +98,7 @@ finally:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE_NOTES = 'doc/release/2.0.0-notes.rst'
+RELEASE_NOTES = 'doc/release/1.7.0-notes.rst'
 
 # Start/end of the log (from git)
 LOG_START = 'v1.6.0'


### PR DESCRIPTION
This is needed in order to be able to do:

```
paver write_release_and_log
```

which is needed for the release.
