### PR TITLE
MAINT: silence DeprecationWarning in np.safe_eval().

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1136,11 +1136,21 @@ def safe_eval(source):
     SyntaxError: Unsupported source construct: compiler.ast.CallFunc
 
     """
-    # Local import to speed up numpy's import time.
+    # Local imports to speed up numpy's import time.
+    import warnings
+    from numpy.testing.utils import WarningManager
+    warn_ctx = WarningManager()
+    warn_ctx.__enter__()
     try:
-        import compiler
-    except ImportError:
-        import ast as compiler
+        # compiler package is deprecated for 3.x, which is already solved here
+        warnings.simplefilter('ignore', DeprecationWarning)
+        try:
+            import compiler
+        except ImportError:
+            import ast as compiler
+    finally:
+        warn_ctx.__exit__()
+
     walker = SafeEval()
     try:
         ast = compiler.parse(source, mode="eval")


### PR DESCRIPTION
It comes from the Python compiler package, which isn't available on Python 3.x.
We already handle that issue by instead importing the ast module.

Should also be applied to 1.7.x.
