### PR TITLE
Improve ndindex execution speed.

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -534,10 +534,18 @@ class ndindex(object):
     """
     def __init__(self, *shape):
         x = as_strided(_nx.zeros(1), shape=shape, strides=_nx.zeros_like(shape))
-        self._it = _nx.nditer(x, flags=['multi_index'])
+        self._it = _nx.nditer(x, flags=['multi_index'], order='C')
 
     def __iter__(self):
         return self
+
+    def ndincr(self):
+        """
+        Increment the multi-dimensional index by one.
+
+        This method is for backward compatibility only: do not use.
+        """
+        self.next()
 
     def next(self):
         """

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -2,7 +2,7 @@ from numpy.testing import *
 import numpy as np
 from numpy import ( array, ones, r_, mgrid, unravel_index, zeros, where,
                     ndenumerate, fill_diagonal, diag_indices,
-                    diag_indices_from, s_, index_exp )
+                    diag_indices_from, s_, index_exp, ndindex )
 
 class TestRavelUnravelIndex(TestCase):
     def test_basic(self):
@@ -235,6 +235,12 @@ def test_diag_indices_from():
     r, c = diag_indices_from(x)
     assert_array_equal(r, np.arange(4))
     assert_array_equal(c, np.arange(4))
+
+
+def test_ndindex():
+    x = list(np.ndindex(1, 2, 3))
+    expected = [ix for ix, e in np.ndenumerate(np.zeros((1, 2, 3)))]
+    assert_array_equal(x, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `ndindex` implementation was quite slow, so I rebuilt it on top of the C-level iterator already exposed in `nd.nditer`.
