### PR TITLE
BUG: Fix Ticket #2187

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -295,7 +295,11 @@ def _index_fields(ary, fields):
     view_dtype = {'names':names, 'formats':formats, 'offsets':offsets, 'itemsize':dt.itemsize}
     view = ary.view(dtype=view_dtype)
 
-    return view.copy()
+    # Return a copy for now until behavior is fully deprecated
+    # in favor of returning view
+    copy_dtype = {'names':view_dtype['names'], 'formats':view_dtype['formats']}
+    from numpy import array
+    return array(view, dtype=copy_dtype, copy=True)
 
 # Given a string containing a PEP 3118 format specifier,
 # construct a Numpy dtype

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1956,6 +1956,11 @@ class TestRecord(TestCase):
             assert_equal(b[['f1','f2']][0].tolist(), (2, 3))
             assert_equal(b[['f2','f1']][0].tolist(), (3, 2))
             assert_equal(b[['f1','f3']][0].tolist(), (2, (1,)))
+            # view of subfield view/copy
+            assert_equal(b[['f1','f2']][0].view(('i4',2)).tolist(), (2, 3))
+            assert_equal(b[['f2','f1']][0].view(('i4',2)).tolist(), (3, 2))
+            view_dtype=[('f1', 'i4'),('f3', [('', 'i4')])]
+            assert_equal(b[['f1','f3']][0].view(view_dtype).tolist(), (2, (1,)))
         # non-ascii unicode field indexing is well behaved
         if not is_py3:
             raise SkipTest('non ascii unicode field indexing skipped; '


### PR DESCRIPTION
Fix for ticket #2187.

When indexing with subset of fields, returning a copy is being deprecated in favor of returning a view. For now a copy is still returned, but it's a copy of the view that will be eventually returned. Fix returned copy so that copy of view with offsets copies only fields in view, not all the fields from original array. Also add unit tests to make sure this doesn't break when copy is fully deprecated in favor of returning a view.

Additional changes will need to be made when returning a copy is fully deprecated.
