### PR TITLE
Reset flags when Axes are removed. Array might now be 1D, or removed axe...

### DIFF
--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -1186,4 +1186,7 @@ PyArray_RemoveAxesInPlace(PyArrayObject *arr, npy_bool *flags)
 
     /* The final number of dimensions */
     fa->nd = idim_out;
+    
+    /* Update contiguous flags */
+    PyArray_UpdateFlags(arr, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
 }

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1528,6 +1528,22 @@ class TestRegression(TestCase):
         assert_(np.array(np.float32(1.0)).flags.c_contiguous)
         assert_(np.array(np.float32(1.0)).flags.f_contiguous)
 
+    def test_squeeze_contiguous(self):
+        """Similar to GitHub issue #387"""
+        a = np.zeros((1,2)).squeeze()
+        b = np.zeros((2,2,2), order='F')[:,:,::2].squeeze()
+        assert_(a.flags.c_contiguous)
+        assert_(a.flags.f_contiguous)
+        assert_(b.flags.f_contiguous)
+
+    def test_reduce_contiguous(self):
+        """GitHub issue #387"""
+        a = np.add.reduce(np.zeros((2,1,2)), (0,1))
+        b = np.add.reduce(np.zeros((2,1,2)), 1)
+        assert_(a.flags.c_contiguous)
+        assert_(a.flags.f_contiguous)
+        assert_(b.flags.c_contiguous)
+
     def test_object_array_self_reference(self):
         # Object arrays with references to themselves can cause problems
         a = np.array(0, dtype=object)


### PR DESCRIPTION
This is related to Issue #387, and fixes half of it, the other half is that the strides are still 0 if keepdims=True is used, which means that the flags are unnecessarily False. For this, the strides have to be replaced if they are 0 (similar to what happens in shape.c -> PyArray_Newshape, with the code also related to Issue #380). I will probably add commits here related to this as well, or maybe someone who knows reduction.c well can see if those 0 strides cannot be set to something better easily?

One test for it would be (not sure where to put it, in test_regression?):

``` python
def test_squeeze_contiguous():
    """#Issue 387 related"""
    a = np.array([1,2,3]).reshape(3,1)
    b = a.copy('F')

    sa = a.squeeze()
    sb = b.squeeze()

    assert_(sa.flags.c_contiguous)
    assert_(sb.flags.f_contiguous)
    assert_(sa.flags.c_contiguous)
    assert_(sb.flags.f_contiguous)
```
