### PR TITLE
Fix typo in documentation (101 instead of 10). 

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -46,7 +46,7 @@ add_newdoc('numpy.core.umath', 'absolute',
 
     >>> import matplotlib.pyplot as plt
 
-    >>> x = np.linspace(-10, 10, 101)
+    >>> x = np.linspace(-10, 10, 10)
     >>> plt.plot(x, np.absolute(x))
     >>> plt.show()
 


### PR DESCRIPTION
The example "Plot the function over [-10, 10]:" found at the following URL has a typo.
http://docs.scipy.org/doc/numpy/reference/generated/numpy.absolute.html

Examples demonstrate using an array with (-10, 0, 10),
but this specific example has a typo that lists the
last number as 101.
This is reflected in the diagrams having axis labeled
from -10:+10.
