### PR TITLE
FIX: make the test_pareto() robust

### DIFF
--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -360,7 +360,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[  2.46852460439034849e+03,   1.41286880810518346e+03],
                          [  5.28287797029485181e+07,   6.57720981047328785e+07],
                          [  1.40840323350391515e+02,   1.98390255135251704e+05]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        np.testing.assert_array_almost_equal(actual, desired, decimal=6)
 
     def test_poisson(self):
         np.random.seed(self.seed)


### PR DESCRIPTION
Fixes #424

The problem was that in 32bit Ubuntu 12.04, one gets the following:

> /home/njs/numpy/.tox/py27/local/lib/python2.7/site-packages/numpy/random/tests/test_random.py(363)test_pareto()
> -> np.testing.assert_array_almost_equal(actual, desired, decimal=15)
> (Pdb) actual[1, 0]
> 52828779.702948704
> (Pdb) desired[1, 0]
> 52828779.702948518

and the test was comparing the numbers to 1e-14, which obviously failed.
Now we compare them to 1e-6, which works.
