### PR TITLE
Fix for issues #392 and #378

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3591,19 +3591,21 @@ def insert(arr, obj, values, axis=None):
     slobj = [slice(None)]*ndim
     N = arr.shape[axis]
     newshape = list(arr.shape)
-    if isinstance(obj, (int, long, integer)):
 
+    if isinstance(obj, (int, long, integer)):
         if (obj < 0): obj += N
         if obj < 0 or obj > N:
             raise ValueError(
                     "index (%d) out of range (0<=index<=%d) "\
                     "in dimension %d" % (obj, N, axis))
-          
-        if isinstance(values, (int, long, integer)):            
-            obj = [obj]           
+        if isscalar(values):
+            obj = [obj]
         else:
-            obj = [obj] * len(values) 
-
+            values = asarray(values)
+            if ndim > values.ndim:
+                obj = [obj]
+            else:
+                obj = [obj] * len(values)
 
     elif isinstance(obj, slice):
         # turn it into a range object

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -147,6 +147,13 @@ class TestInsert(TestCase):
         assert_equal(insert(a, [1, 1, 1], [1, 2, 3]), [1, 1, 2, 3, 2, 3])
         assert_equal(insert(a, 1,[1,2,3]), [1, 1, 2, 3, 2, 3])
         assert_equal(insert(a,[1,2,3],9),[1,9,2,9,3,9])
+    def test_multidim(self):
+        a = [[1, 1, 1]]
+        r = [[2, 2, 2],
+             [1, 1, 1]]
+        assert_equal(insert(a, 0, [2, 2, 2], axis=0), r)
+        assert_equal(insert(a, 0, 2, axis=0), r)
+        assert_equal(insert(a, 2, 2, axis=1), [[1, 1, 2, 1]])
 
 class TestAmax(TestCase):
     def test_basic(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -147,6 +147,8 @@ class TestInsert(TestCase):
         assert_equal(insert(a, [1, 1, 1], [1, 2, 3]), [1, 1, 2, 3, 2, 3])
         assert_equal(insert(a, 1,[1,2,3]), [1, 1, 2, 3, 2, 3])
         assert_equal(insert(a,[1,2,3],9),[1,9,2,9,3,9])
+        b = np.array([0, 1], dtype=np.float64)
+        assert_equal(insert(b, 0, b[0]), [0., 0., 1.])
     def test_multidim(self):
         a = [[1, 1, 1]]
         r = [[2, 2, 2],


### PR DESCRIPTION
Hi, I made an attempt to fix the current issues with insert() (#378 and #392). It should now work with all scalar types (not only integer types) and also with multidimensional inserts when the axis parameter is specified. (And added a few extra tests.)
