### PR TITLE
FIX: use py24-compatible version of virtualenv on Travis

### DIFF
--- a/.travis-make-py24-virtualenv.sh
+++ b/.travis-make-py24-virtualenv.sh
@@ -15,4 +15,11 @@ EOF
 ./configure --prefix=$PWD/install
 make
 make install
-virtualenv -p install/bin/python2.4 --distribute $VIRTENV
+# This is the last version of virtualenv to support python 2.4:
+curl -O https://raw.github.com/pypa/virtualenv/1.7.2/virtualenv.py
+# And this is the last version of pip to support python 2.4. If
+# there's a file matching "^pip-.*(zip|tar.gz|tar.bz2|tgz|tbz)$" in
+# the current directory then virtualenv will take that as the pip
+# source distribution to install
+curl -O http://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz
+install/bin/python2.4 ./virtualenv.py --distribute $VIRTENV


### PR DESCRIPTION
Travis recently upgraded to virtualenv 1.8, which has dropped support
for Python 2.4. So, in our Python 2.4 setup script, we need to
explicitly fetch and use virtualenv 1.7.

File imported from the already-fixed version for patsy:
  https://github.com/pydata/patsy/blob/ed4073adaf88463b67a1c1e2b0f02aa1eba2b944/.travis-make-py24-virtualenv.sh
