### PR TITLE
MAINT: silence Cython warnings about changes dtype/ufunc size.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -169,3 +169,9 @@ else:
     __all__.extend(_mat.__all__)
     __all__.extend(lib.__all__)
     __all__.extend(['linalg', 'fft', 'random', 'ctypeslib', 'ma'])
+
+    # Filter annoying Cython warnings that serve no good purpose.
+    import warnings
+    warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+    warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+


### PR DESCRIPTION
These warnings are visible whenever you import scipy (or another package) that
was compiled against an older numpy than is installed.  For example compiled
against 1.5.1, like current scipy binaries are, and used with 1.7.0.

These warnings aren't useful; if numpy would really break its ABI it would be
noticed in no time without these warnings.
