### PR TITLE
Cleanup subscript

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1163,12 +1163,12 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
             if NPY_TITLE_KEY(key, value) {
                 continue;
             }
-            a = PyArray_EnsureAnyArray(array_subscript(self, key));
+            a = array_subscript_asarray(self, key);
             if (a == NULL) {
                 Py_XDECREF(res);
                 return NULL;
             }
-            b = array_subscript(other, key);
+            b = array_subscript_asarray(other, key);
             if (b == NULL) {
                 Py_XDECREF(res);
                 Py_DECREF(a);

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1786,7 +1786,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
 
     if (PyArray_Check(op)) {
         for (i = 0; i < n; i++) {
-            mps[i] = (PyArrayObject *) array_big_item((PyArrayObject *)op, i);
+            mps[i] = (PyArrayObject *) array_item_asarray((PyArrayObject *)op, i);
         }
         if (!PyArray_ISCARRAY((PyArrayObject *)op)) {
             for (i = 0; i < n; i++) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -109,7 +109,7 @@ array_item_asarray(PyArrayObject *self, npy_intp i)
 
 /* Get array item at given index */
 NPY_NO_EXPORT PyObject *
-array_item(PyArrayObject *self, Py_ssize_t i)
+array_item(PyArrayObject *self, Py_ssize_t _i)
 {
     /* Workaround Python 2.4: Py_ssize_t not the same as npyint_p */
     npy_intp i = _i;
@@ -962,13 +962,13 @@ static npy_bool
 _check_ellipses(PyObject *op)
 {
     if ((op == Py_Ellipsis) || PyString_Check(op) || PyUnicode_Check(op)) {
-        return TRUE;
+        return NPY_TRUE;
     }
     else if (PyBool_Check(op) || PyArray_IsScalar(op, Bool) ||
              (PyArray_Check(op) &&
                 (PyArray_DIMS((PyArrayObject *)op)==0) &&
                  PyArray_ISBOOL((PyArrayObject *)op))) {
-        return TRUE;
+        return NPY_TRUE;
     }
     else if (PySequence_Check(op)) {
         Py_ssize_t n, i;
@@ -980,13 +980,13 @@ _check_ellipses(PyObject *op)
             temp = PySequence_GetItem(op, i);
             if (temp == Py_Ellipsis) {
                 Py_DECREF(temp);
-                return TRUE;
+                return NPY_TRUE;
             }
             Py_DECREF(temp);
             i++;
         }
     }
-    return FALSE;
+    return NPY_FALSE;
 }
 
 NPY_NO_EXPORT PyObject *

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1152,24 +1152,6 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
             }
             return add_new_axes_0d(self, nd);
         }
-        /* Allow Boolean mask selection also */
-        if ((PyArray_Check(op) && (PyArray_DIMS((PyArrayObject *)op)==0)
-                                && PyArray_ISBOOL((PyArrayObject *)op))) {
-            if (PyObject_IsTrue(op)) {
-                Py_INCREF(self);
-                return (PyObject *)self;
-            }
-            else {
-                npy_intp oned = 0;
-                Py_INCREF(PyArray_DESCR(self));
-                return PyArray_NewFromDescr(Py_TYPE(self),
-                                            PyArray_DESCR(self),
-                                            1, &oned,
-                                            NULL, NULL,
-                                            NPY_ARRAY_DEFAULT,
-                                            NULL);
-            }
-        }
         PyErr_SetString(PyExc_IndexError, "0-dimensional arrays can't be indexed");
         return NULL;
     }
@@ -1193,11 +1175,9 @@ array_subscript(PyArrayObject *self, PyObject *op)
     }
     
     /* Boolean indexing special case */
-    /* The SIZE check might be overly cautious */
-    if (PyArray_Check(op) && (PyArray_TYPE((PyArrayObject *)op) == NPY_BOOL)
-                && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))
-                && (PyArray_SIZE((PyArrayObject *)op) == PyArray_SIZE(self))) {
-        return (PyObject *)array_boolean_subscript(self,
+    else if (PyArray_Check(op) && (PyArray_TYPE((PyArrayObject *)op) == NPY_BOOL)
+                && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))) {
+        ret = (PyObject *)array_boolean_subscript(self,
                                         (PyArrayObject *)op, NPY_CORDER);
     }
     /* Error case when indexing 0-dim array with non-boolean. */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1021,7 +1021,7 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
 }
 
 NPY_NO_EXPORT PyObject *
-array_subscript(PyArrayObject *self, PyObject *op)
+array_subscript_fromobject(PyArrayObject *self, PyObject *op)
 {
     int fancy;
     npy_intp vals[NPY_MAXDIMS];
@@ -1039,7 +1039,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
             return array_item(self, (Py_ssize_t) value);
         }
     }
-    /* Optimization for a tuple of integers */
+    /* optimization for a tuple of integers */
     if (PyArray_NDIM(self) > 1 &&
                 PyTuple_Check(op) &&
                 (PyTuple_GET_SIZE(op) == PyArray_NDIM(self)) &&
@@ -1049,55 +1049,14 @@ array_subscript(PyArrayObject *self, PyObject *op)
         npy_intp *strides = PyArray_STRIDES(self);
         char *item = PyArray_DATA(self);
 
-        if (!PyArray_HASMASKNA(self)) {
-            for (idim = 0; idim < ndim; idim++) {
-                npy_intp v = vals[idim];
-                if (v < 0) {
-                    v += shape[idim];
-                }
-                if (v < 0 || v >= shape[idim]) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index (%"INTP_FMT") out of range "\
-                                 "(0<=index<%"INTP_FMT") in dimension %d",
-                                 vals[idim], PyArray_DIMS(self)[idim], idim);
-                    return NULL;
-                }
-                else {
-                    item += v * strides[idim];
-                }
+        for (idim = 0; idim < ndim; idim++) {
+            npy_intp v = vals[idim];
+            if (check_and_adjust_index(&v, shape[idim], idim) < 0) { 
+              return NULL;
             }
-            return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
+            item += v * strides[idim];
         }
-        else {
-            char *maskna_item = PyArray_MASKNA_DATA(self);
-            npy_intp *maskna_strides = PyArray_MASKNA_STRIDES(self);
-
-            for (idim = 0; idim < ndim; idim++) {
-                npy_intp v = vals[idim];
-                if (v < 0) {
-                    v += shape[idim];
-                }
-                if (v < 0 || v >= shape[idim]) {
-                    PyErr_Format(PyExc_IndexError,
-                                 "index (%"INTP_FMT") out of range "\
-                                 "(0<=index<%"INTP_FMT") in dimension %d",
-                                 vals[idim], PyArray_DIMS(self)[idim], idim);
-                    return NULL;
-                }
-                else {
-                    item += v * strides[idim];
-                    maskna_item += v * maskna_strides[idim];
-                }
-            }
-            if (NpyMaskValue_IsExposed((npy_mask)*maskna_item)) {
-                return PyArray_Scalar(item, PyArray_DESCR(self),
-                                                    (PyObject *)self);
-            }
-            else {
-                return (PyObject *)NpyNA_FromDTypeAndPayload(
-                                        PyArray_DESCR(self), 0, 0);
-            }
-        }
+        return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
     }
 
     /* Check for single field access */
@@ -1214,6 +1173,24 @@ array_subscript(PyArrayObject *self, PyObject *op)
         return NULL;
     }
 
+    fancy = fancy_indexing_check(op);
+    if (fancy != SOBJ_NOTFANCY) {
+        return array_subscript_fancy(self, op, fancy);
+    }
+    else {
+        return array_subscript_simple(self, op);
+    }
+}
+
+NPY_NO_EXPORT PyObject *
+array_subscript(PyArrayObject *self, PyObject *op)
+{
+    int fancy;
+    PyObject *ret = NULL;
+    if (!PyArray_Check(op)) {
+        ret = array_subscript_fromobject(self, op);
+    }
+    
     /* Boolean indexing special case */
     /* The SIZE check might be overly cautious */
     if (PyArray_Check(op) && (PyArray_TYPE((PyArrayObject *)op) == NPY_BOOL)
@@ -1222,13 +1199,35 @@ array_subscript(PyArrayObject *self, PyObject *op)
         return (PyObject *)array_boolean_subscript(self,
                                         (PyArrayObject *)op, NPY_CORDER);
     }
-
-    fancy = fancy_indexing_check(op);
-    if (fancy != SOBJ_NOTFANCY) {
-        return array_subscript_fancy(self, op, fancy);
+    /* Error case when indexing 0-dim array with non-boolean. */
+    else if (PyArray_NDIM(self) == 0) {
+        PyErr_SetString(PyExc_IndexError, "0-dimensional arrays can't be indexed");
+        return NULL;
     }
-
-    return array_subscript_simple(self, op);
+    
+    else {
+        fancy = fancy_indexing_check(op);
+        if (fancy != SOBJ_NOTFANCY) {
+            ret = array_subscript_fancy(self, op, fancy);
+        }
+        else {
+            ret = array_subscript_simple(self, op);
+        }
+    }
+    if (ret == NULL) {
+        return NULL;
+    }
+    
+    if (PyErr_Occurred()) {
+        Py_XDECREF(ret);
+        return NULL;
+    }
+    
+    if (PyArray_Check(ret) && PyArray_NDIM((PyArrayObject *)ret) == 0 
+                                                && !_check_ellipses(op)) {
+        return PyArray_Return((PyArrayObject *)ret);
+    }
+    return ret;
 }
 
 /*
@@ -1468,92 +1467,13 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
     return array_ass_sub_simple(self, ind, op);
 }
 
-
-/*
- * There are places that require that array_subscript return a PyArrayObject
- * and not possibly a scalar.  Thus, this is the function exposed to
- * Python so that 0-dim arrays are passed as scalars
- */
-
-
-static PyObject *
-array_subscript_nice(PyArrayObject *self, PyObject *op)
-{
-
-    PyArrayObject *mp;
-    npy_intp vals[NPY_MAXDIMS];
-
-    if (PyInt_Check(op) || PyArray_IsScalar(op, Integer) ||
-        PyLong_Check(op) || (PyIndex_Check(op) &&
-                             !PySequence_Check(op))) {
-        npy_intp value;
-        value = PyArray_PyIntAsIntp(op);
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
-        }
-        else {
-            return array_item(self, (Py_ssize_t) value);
-        }
-    }
-    /* optimization for a tuple of integers */
-    if (PyArray_NDIM(self) > 1 &&
-                PyTuple_Check(op) &&
-                (PyTuple_GET_SIZE(op) == PyArray_NDIM(self)) &&
-                (_tuple_of_integers(op, vals, PyArray_NDIM(self)) >= 0)) {
-        int idim, ndim = PyArray_NDIM(self);
-        npy_intp *shape = PyArray_DIMS(self);
-        npy_intp *strides = PyArray_STRIDES(self);
-        char *item = PyArray_DATA(self);
-
-        for (idim = 0; idim < ndim; idim++) {
-            npy_intp v = vals[idim];
-            if (check_and_adjust_index(&v, shape[idim], idim) < 0) { 
-              return NULL;
-            }
-            item += v * strides[idim];
-        }
-        return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
-    }
-    PyErr_Clear();
-
-    mp = (PyArrayObject *)array_subscript(self, op);
-    /*
-     * mp could be a scalar if op is not an Int, Scalar, Long or other Index
-     * object and still convertable to an integer (so that the code goes to
-     * array_subscript_simple).  So, this cast is a bit dangerous..
-     */
-
-    if (mp == NULL) {
-        return NULL;
-    }
-
-    if (PyErr_Occurred()) {
-        Py_XDECREF(mp);
-        return NULL;
-    }
-
-    /*
-     * The following adds some additional logic to avoid calling
-     * PyArray_Return if there is an ellipsis.
-     */
-
-    if (PyArray_Check(mp) && PyArray_NDIM(mp) == 0) {
-        if (!_check_ellipses(op)) {
-            return PyArray_Return(mp);
-        }
-    }
-
-    return (PyObject *)mp;
-}
-
-
 NPY_NO_EXPORT PyMappingMethods array_as_mapping = {
 #if PY_VERSION_HEX >= 0x02050000
     (lenfunc)array_length,              /*mp_length*/
 #else
     (inquiry)array_length,              /*mp_length*/
 #endif
-    (binaryfunc)array_subscript_nice,       /*mp_subscript*/
+    (binaryfunc)array_subscript,        /*mp_subscript*/
     (objobjargproc)array_ass_sub,       /*mp_ass_subscript*/
 };
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1013,6 +1013,13 @@ array_subscript_fancy(PyArrayObject *self, PyObject *op, int fancy)
     return other;
 }
 
+/* make sure subscript always returns an array object */
+NPY_NO_EXPORT PyObject *
+array_subscript_asarray(PyArrayObject *self, PyObject *op)
+{
+    return PyArray_EnsureAnyArray(array_subscript(self, op));
+}
+
 NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op)
 {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1023,11 +1023,86 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
 NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op)
 {
-    int nd, fancy;
-    PyObject *obj;
+    int fancy;
+    npy_intp vals[NPY_MAXDIMS];
+    
+    /* Integer index */
+    if (PyInt_Check(op) || PyArray_IsScalar(op, Integer) ||
+        PyLong_Check(op) || (PyIndex_Check(op) &&
+                             !PySequence_Check(op))) {
+        npy_intp value;
+        value = PyArray_PyIntAsIntp(op);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+        }
+        else {
+            return array_item(self, (Py_ssize_t) value);
+        }
+    }
+    /* Optimization for a tuple of integers */
+    if (PyArray_NDIM(self) > 1 &&
+                PyTuple_Check(op) &&
+                (PyTuple_GET_SIZE(op) == PyArray_NDIM(self)) &&
+                (_tuple_of_integers(op, vals, PyArray_NDIM(self)) >= 0)) {
+        int idim, ndim = PyArray_NDIM(self);
+        npy_intp *shape = PyArray_DIMS(self);
+        npy_intp *strides = PyArray_STRIDES(self);
+        char *item = PyArray_DATA(self);
 
+        if (!PyArray_HASMASKNA(self)) {
+            for (idim = 0; idim < ndim; idim++) {
+                npy_intp v = vals[idim];
+                if (v < 0) {
+                    v += shape[idim];
+                }
+                if (v < 0 || v >= shape[idim]) {
+                    PyErr_Format(PyExc_IndexError,
+                                 "index (%"INTP_FMT") out of range "\
+                                 "(0<=index<%"INTP_FMT") in dimension %d",
+                                 vals[idim], PyArray_DIMS(self)[idim], idim);
+                    return NULL;
+                }
+                else {
+                    item += v * strides[idim];
+                }
+            }
+            return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
+        }
+        else {
+            char *maskna_item = PyArray_MASKNA_DATA(self);
+            npy_intp *maskna_strides = PyArray_MASKNA_STRIDES(self);
+
+            for (idim = 0; idim < ndim; idim++) {
+                npy_intp v = vals[idim];
+                if (v < 0) {
+                    v += shape[idim];
+                }
+                if (v < 0 || v >= shape[idim]) {
+                    PyErr_Format(PyExc_IndexError,
+                                 "index (%"INTP_FMT") out of range "\
+                                 "(0<=index<%"INTP_FMT") in dimension %d",
+                                 vals[idim], PyArray_DIMS(self)[idim], idim);
+                    return NULL;
+                }
+                else {
+                    item += v * strides[idim];
+                    maskna_item += v * maskna_strides[idim];
+                }
+            }
+            if (NpyMaskValue_IsExposed((npy_mask)*maskna_item)) {
+                return PyArray_Scalar(item, PyArray_DESCR(self),
+                                                    (PyObject *)self);
+            }
+            else {
+                return (PyObject *)NpyNA_FromDTypeAndPayload(
+                                        PyArray_DESCR(self), 0, 0);
+            }
+        }
+    }
+
+    /* Check for single field access */
     if (PyString_Check(op) || PyUnicode_Check(op)) {
-        PyObject *temp;
+        PyObject *temp, *obj;
 
         if (PyDataType_HASFIELDS(PyArray_DESCR(self))) {
             obj = PyDict_GetItem(PyArray_DESCR(self)->fields, op);
@@ -1048,7 +1123,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
             temp = PyUnicode_AsUnicodeEscapeString(op);
         }
         PyErr_Format(PyExc_ValueError,
-                     "field named %s not found.",
+                     "field named %s not found",
                      PyBytes_AsString(temp));
         if (temp != op) {
             Py_DECREF(temp);
@@ -1061,6 +1136,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
                         PySequence_Check(op) &&
                         !PyTuple_Check(op)) {
         int seqlen, i;
+        PyObject *obj;
         seqlen = PySequence_Size(op);
         for (i = 0; i < seqlen; i++) {
             obj = PySequence_GetItem(op, i);
@@ -1071,7 +1147,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
             Py_DECREF(obj);
         }
         /*
-         * extract multiple fields if all elements in sequence
+         * Extract multiple fields if all elements in sequence
          * are either string or unicode (i.e. no break occurred).
          */
         fancy = ((seqlen > 0) && (i == seqlen));
@@ -1092,15 +1168,19 @@ array_subscript(PyArrayObject *self, PyObject *op)
         }
     }
 
+    /* Check for Ellipsis index */
     if (op == Py_Ellipsis) {
         Py_INCREF(self);
         return (PyObject *)self;
     }
 
     if (PyArray_NDIM(self) == 0) {
+        int nd;
+        /* Check for None index */
         if (op == Py_None) {
             return add_new_axes_0d(self, 1);
         }
+        /* Check for (empty) tuple index */
         if (PyTuple_Check(op)) {
             if (0 == PyTuple_GET_SIZE(op))  {
                 Py_INCREF(self);
@@ -1130,7 +1210,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
                                             NULL);
             }
         }
-        PyErr_SetString(PyExc_IndexError, "0-d arrays can't be indexed.");
+        PyErr_SetString(PyExc_IndexError, "0-dimensional arrays can't be indexed");
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -142,7 +142,7 @@ array_ass_item_object(PyArrayObject *self, npy_intp i, PyObject *v)
 
     if (PyArray_NDIM(self) == 0) {
         PyErr_SetString(PyExc_IndexError,
-                        "0-d arrays can't be indexed.");
+                        "0-d arrays can't be indexed");
         return -1;
     }
 
@@ -563,14 +563,6 @@ array_subscript_simple(PyArrayObject *self, PyObject *op)
 
 
     if (!(PyArray_Check(op) && (PyArray_SIZE((PyArrayObject*)op) > 1))) {
-        /*
-         * PyNumber_Index was introduced in Python 2.5 because of NumPy.
-         * http://www.python.org/dev/peps/pep-0357/
-         * Let's use it for indexing!
-         *
-         * Unfortunately, SciPy and possibly other code seems to rely
-         * on the lenient coercion. :(
-         */
 #if 0 /*PY_VERSION_HEX >= 0x02050000*/
         PyObject *ind = PyNumber_Index(op);
         if (ind != NULL) {
@@ -1186,7 +1178,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
         ret = array_subscript_fromobject(self, op);
     }
     
-    /* Boolean indexing special case which supports mask NA */
+    /* Boolean indexing special case */
     else if (PyArray_ISBOOL((PyArrayObject *)op)
                 && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))) {
         ret = (PyObject *)array_boolean_subscript(self,
@@ -1269,7 +1261,7 @@ array_ass_sub_simple(PyArrayObject *self, PyObject *ind, PyObject *op)
         }
         if (!PyArray_Check(tmp0)) {
             PyErr_SetString(PyExc_RuntimeError,
-                            "Getitem not returning array.");
+                            "Getitem not returning array");
             Py_DECREF(tmp0);
             return -1;
         }
@@ -1362,11 +1354,11 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         }
 #if defined(NPY_PY3K)
         PyErr_Format(PyExc_ValueError,
-                     "field named %S not found.",
+                     "field named %S not found",
                      ind);
 #else
         PyErr_Format(PyExc_ValueError,
-                     "field named %s not found.",
+                     "field named %s not found",
                      PyString_AsString(ind));
 #endif
         return -1;
@@ -1415,7 +1407,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
             }
         }
         PyErr_SetString(PyExc_IndexError,
-                        "0-dimensional arrays can't be indexed.");
+                        "0-dimensional arrays can't be indexed");
         return -1;
     }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1030,10 +1030,11 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
     if (PyInt_Check(op) || PyArray_IsScalar(op, Integer) ||
         PyLong_Check(op) || (PyIndex_Check(op) &&
                              !PySequence_Check(op))) {
-        npy_intp value;
-        value = PyArray_PyIntAsIntp(op);
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
+        npy_intp value = PyArray_PyIntAsIntp(op);
+        if (value == -1 && PyErr_Occurred()) {
+            /* fail on error */
+            PyErr_SetString(PyExc_IndexError, "integer index out of bounds");
+            return NULL;
         }
         else {
             return array_item(self, (Py_ssize_t) value);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -562,31 +562,40 @@ array_subscript_simple(PyArrayObject *self, PyObject *op)
     PyArrayObject *ret;
     npy_intp value;
 
-    /*
-     * PyNumber_Index was introduced in Python 2.5 because of NumPy.
-     * http://www.python.org/dev/peps/pep-0357/
-     * Let's use it for indexing!
-     *
-     * Unfortunately, SciPy and possibly other code seems to rely
-     * on the lenient coercion. :(
-     */
+
+    if (!(PyArray_Check(op) && (PyArray_SIZE((PyArrayObject*)op) > 1))) {
+        /*
+         * PyNumber_Index was introduced in Python 2.5 because of NumPy.
+         * http://www.python.org/dev/peps/pep-0357/
+         * Let's use it for indexing!
+         *
+         * Unfortunately, SciPy and possibly other code seems to rely
+         * on the lenient coercion. :(
+         */
 #if 0 /*PY_VERSION_HEX >= 0x02050000*/
-    PyObject *ind = PyNumber_Index(op);
-    if (ind != NULL) {
-        value = PyArray_PyIntAsIntp(ind);
-        Py_DECREF(ind);
-    }
-    else {
-        value = -1;
-    }
+        PyObject *ind = PyNumber_Index(op);
+        if (ind != NULL) {
+            value = PyArray_PyIntAsIntp(ind);
+            Py_DECREF(ind);
+        }
+        else {
+            value = -1;
+        }
 #else
-    value = PyArray_PyIntAsIntp(op);
+        value = PyArray_PyIntAsIntp(op);
 #endif
-    if (value == -1 && PyErr_Occurred()) {
-        PyErr_Clear();
-    }
-    else {
-        return array_item_asarray(self, value);
+        if (value == -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+                /* Operand is not an integer type */
+                PyErr_Clear();
+            }
+            else {
+                return NULL;
+            }
+        }
+        else {
+            return array_item_asarray(self, value);
+        }
     }
 
     /* Standard (view-based) Indexing */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -42,13 +42,6 @@ array_length(PyArrayObject *self)
     }
 }
 
-
-NPY_NO_EXPORT int
-_array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
-{
-    return array_ass_big_item(self, (npy_intp) i, v);
-}
-
 /* Get array item as scalar type */
 NPY_NO_EXPORT PyObject *
 array_item_asscalar(PyArrayObject *self, npy_intp i)
@@ -130,7 +123,13 @@ array_item(PyArrayObject *self, Py_ssize_t i)
 }
 
 NPY_NO_EXPORT int
-array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
+array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
+{
+    return array_ass_item_object(self, (npy_intp) i, v);
+}
+
+NPY_NO_EXPORT int
+array_ass_item_object(PyArrayObject *self, npy_intp i, PyObject *v)
 {
     PyArrayObject *tmp;
     char *item;
@@ -172,7 +171,7 @@ array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
     }
     item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
 
-    return PyArray_DESCR(self)->f->setitem(v, item, self);
+    return PyArray_SETITEM(self, item, v);
 }
 
 /* -------------------------------------------------------------- */
@@ -1237,7 +1236,7 @@ array_ass_sub_simple(PyArrayObject *self, PyObject *ind, PyObject *op)
 
     value = PyArray_PyIntAsIntp(ind);
     if (!error_converting(value)) {
-        return array_ass_big_item(self, value, op);
+        return array_ass_item_object(self, value, op);
     }
     PyErr_Clear();
 
@@ -1301,7 +1300,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
             PyErr_Clear();
         }
         else {
-            return array_ass_big_item(self, value, op);
+            return array_ass_item_object(self, value, op);
         }
     }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1518,6 +1518,14 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
         return -1;
     }
     nd = PyArray_NDIM(ba);
+
+    if (nd == 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "cannot construct index objects "
+                        "for zero-dimensional array");
+        goto fail;
+    }
+
     for (j = 0; j < nd; j++) {
         iters[j] = NULL;
     }
@@ -1556,6 +1564,7 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
     }
 
     /*
+
      * Loop through the Boolean array  and copy coordinates
      * for non-zero entries
      */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1179,8 +1179,10 @@ array_subscript(PyArrayObject *self, PyObject *op)
     }
     
     /* Boolean indexing special case */
+    /* The SIZE check is to ensure old behaviour for non-matching arrays. */
     else if (PyArray_ISBOOL((PyArrayObject *)op)
-                && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))) {
+                && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op)) 
+                && (PyArray_SIZE((PyArrayObject *)op) == PyArray_SIZE(self))) {
         ret = (PyObject *)array_boolean_subscript(self,
                                         (PyArrayObject *)op, NPY_CORDER);
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -948,6 +948,8 @@ _tuple_of_integers(PyObject *seq, npy_intp *vals, int maxvals)
         }
         temp = PyArray_PyIntAsIntp(obj);
         if (error_converting(temp)) {
+            /* Reject conversion errors */
+            PyErr_Clear();
             return -1;
         }
         vals[i] = temp;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -561,7 +561,14 @@ array_subscript_simple(PyArrayObject *self, PyObject *op)
     PyArrayObject *ret;
     npy_intp value;
 
-
+    /*
+     * PyNumber_Index was introduced in Python 2.5 because of NumPy.
+     * http://www.python.org/dev/peps/pep-0357/
+     * Let's use it for indexing!
+     *
+     * Unfortunately, SciPy and possibly other code seems to rely
+     * on the lenient coercion. :(
+     */
     if (!(PyArray_Check(op) && (PyArray_SIZE((PyArrayObject*)op) > 1))) {
 #if 0 /*PY_VERSION_HEX >= 0x02050000*/
         PyObject *ind = PyNumber_Index(op);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1043,7 +1043,8 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
         npy_intp value = PyArray_PyIntAsIntp(op);
         if (value == -1 && PyErr_Occurred()) {
             /* fail on error */
-            PyErr_SetString(PyExc_IndexError, "integer index out of bounds");
+            PyErr_SetString(PyExc_ValueError,
+                            "cannot convert index to integer");
             return NULL;
         }
         else {
@@ -1162,7 +1163,8 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
             }
             return add_new_axes_0d(self, nd);
         }
-        PyErr_SetString(PyExc_IndexError, "0-dimensional arrays can't be indexed");
+        PyErr_SetString(PyExc_IndexError,
+                        "0-dimensional arrays can't be indexed");
         return NULL;
     }
 
@@ -1192,7 +1194,8 @@ array_subscript(PyArrayObject *self, PyObject *op)
     }
     /* Error case when indexing 0-dim array with non-boolean. */
     else if (PyArray_NDIM(self) == 0) {
-        PyErr_SetString(PyExc_IndexError, "0-dimensional arrays can't be indexed");
+        PyErr_SetString(PyExc_IndexError,
+                        "0-dimensional arrays can't be indexed");
         return NULL;
     }
     
@@ -1331,7 +1334,8 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         npy_intp value = PyArray_PyIntAsIntp(ind);
         if (value == -1 && PyErr_Occurred()) {
             /* fail on error */
-            PyErr_SetString(PyExc_IndexError, "integer index out of bounds");
+            PyErr_SetString(PyExc_ValueError,
+                            "cannot convert index to integer");
             return -1;
         }
         else {
@@ -1410,7 +1414,8 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
                 return 0;
             }
         }
-        PyErr_SetString(PyExc_IndexError, "0-dimensional arrays can't be indexed.");
+        PyErr_SetString(PyExc_IndexError,
+                        "0-dimensional arrays can't be indexed.");
         return -1;
     }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1209,11 +1209,6 @@ array_subscript(PyArrayObject *self, PyObject *op)
         return NULL;
     }
     
-    if (PyErr_Occurred()) {
-        Py_XDECREF(ret);
-        return NULL;
-    }
-    
     if (PyArray_Check(ret) && PyArray_NDIM((PyArrayObject *)ret) == 0 
                                                 && !_check_ellipses(op)) {
         return PyArray_Return((PyArrayObject *)ret);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -42,8 +42,36 @@ array_length(PyArrayObject *self)
     }
 }
 
+
+NPY_NO_EXPORT int
+_array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
+{
+    return array_ass_big_item(self, (npy_intp) i, v);
+}
+
+/* Get array item as scalar type */
 NPY_NO_EXPORT PyObject *
-array_big_item(PyArrayObject *self, npy_intp i)
+array_item_asscalar(PyArrayObject *self, npy_intp i)
+{
+    char *item;
+    npy_intp dim0;
+
+    /* Bounds check and get the data pointer */
+    dim0 = PyArray_DIM(self, 0);
+    if (i < 0) {
+        i += dim0;
+    }
+    if (i < 0 || i >= dim0) {
+        PyErr_SetString(PyExc_IndexError,"index out of bounds");
+        return NULL;
+    }
+    item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
+    return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
+}
+
+/* Get array item as ndarray type */
+NPY_NO_EXPORT PyObject *
+array_item_asarray(PyArrayObject *self, npy_intp i)
 {
     char *item;
     PyArrayObject *ret;
@@ -86,35 +114,18 @@ array_big_item(PyArrayObject *self, npy_intp i)
     return (PyObject *)ret;
 }
 
-NPY_NO_EXPORT int
-_array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
-{
-    return array_ass_big_item(self, (npy_intp) i, v);
-}
-
-/* contains optimization for 1-d arrays */
+/* Get array item at given index */
 NPY_NO_EXPORT PyObject *
-array_item_nice(PyArrayObject *self, Py_ssize_t _i)
+array_item(PyArrayObject *self, Py_ssize_t i)
 {
     /* Workaround Python 2.4: Py_ssize_t not the same as npyint_p */
     npy_intp i = _i;
 
     if (PyArray_NDIM(self) == 1) {
-        char *item;
-        npy_intp dim0;
-
-        /* Bounds check and get the data pointer */
-        dim0 = PyArray_DIM(self, 0);
-        if (check_and_adjust_index(&i, dim0, 0) < 0) {
-            return NULL;
-        }
-        item = PyArray_DATA(self) + i * PyArray_STRIDE(self, 0);
-
-        return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
+        return array_item_asscalar(self, (npy_intp) i);
     }
     else {
-        return PyArray_Return(
-                (PyArrayObject *) array_big_item(self, (npy_intp) i));
+        return array_item_asarray(self, (npy_intp) i);
     }
 }
 
@@ -145,7 +156,7 @@ array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v)
 
     /* For multi-dimensional arrays, use CopyObject */
     if (PyArray_NDIM(self) > 1) {
-        tmp = (PyArrayObject *)array_big_item(self, i);
+        tmp = (PyArrayObject *)array_item_asarray(self, i);
         if(tmp == NULL) {
             return -1;
         }
@@ -575,7 +586,7 @@ array_subscript_simple(PyArrayObject *self, PyObject *op)
         PyErr_Clear();
     }
     else {
-        return array_big_item(self, value);
+        return array_item_asarray(self, value);
     }
 
     /* Standard (view-based) Indexing */
@@ -1358,7 +1369,7 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
             PyErr_Clear();
         }
         else {
-            return array_item_nice(self, (Py_ssize_t) value);
+            return array_item(self, (Py_ssize_t) value);
         }
     }
     /* optimization for a tuple of integers */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1182,8 +1182,8 @@ array_subscript(PyArrayObject *self, PyObject *op)
         ret = array_subscript_fromobject(self, op);
     }
     
-    /* Boolean indexing special case */
-    else if (PyArray_Check(op) && (PyArray_TYPE((PyArrayObject *)op) == NPY_BOOL)
+    /* Boolean indexing special case which supports mask NA */
+    else if (PyArray_ISBOOL((PyArrayObject *)op)
                 && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))) {
         ret = (PyObject *)array_boolean_subscript(self,
                                         (PyArrayObject *)op, NPY_CORDER);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -123,12 +123,6 @@ array_item(PyArrayObject *self, Py_ssize_t i)
 }
 
 NPY_NO_EXPORT int
-array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
-{
-    return array_ass_item_object(self, (npy_intp) i, v);
-}
-
-NPY_NO_EXPORT int
 array_ass_item_object(PyArrayObject *self, npy_intp i, PyObject *v)
 {
     PyArrayObject *tmp;
@@ -311,6 +305,12 @@ PyArray_GetMap(PyArrayMapIterObject *mit)
         }
     }
     return (PyObject *)ret;
+}
+
+NPY_NO_EXPORT int
+array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
+{
+    return array_ass_item_object(self, (npy_intp) i, v);
 }
 
 static int

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -11,10 +11,10 @@ NPY_NO_EXPORT Py_ssize_t
 array_length(PyArrayObject *self);
 
 NPY_NO_EXPORT PyObject *
-array_item_asarray(PyArrayObject *self, intp i);
+array_item_asarray(PyArrayObject *self, npy_intp i);
 
 NPY_NO_EXPORT PyObject *
-array_item_asscalar(PyArrayObject *self, intp i);
+array_item_asscalar(PyArrayObject *self, npy_intp i);
 
 NPY_NO_EXPORT PyObject *
 array_item(PyArrayObject *self, Py_ssize_t i);

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -20,6 +20,9 @@ NPY_NO_EXPORT PyObject *
 array_item(PyArrayObject *self, Py_ssize_t i);
 
 NPY_NO_EXPORT PyObject *
+array_subscript_asarray(PyArrayObject *self, PyObject *op);
+
+NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op);
 
 NPY_NO_EXPORT int

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -7,14 +7,17 @@ extern NPY_NO_EXPORT PyMappingMethods array_as_mapping;
 NPY_NO_EXPORT PyMappingMethods array_as_mapping;
 #endif
 
-NPY_NO_EXPORT PyObject *
-array_big_item(PyArrayObject *self, npy_intp i);
-
 NPY_NO_EXPORT Py_ssize_t
 array_length(PyArrayObject *self);
 
 NPY_NO_EXPORT PyObject *
-array_item_nice(PyArrayObject *self, Py_ssize_t i);
+array_item_asarray(PyArrayObject *self, intp i);
+
+NPY_NO_EXPORT PyObject *
+array_item_asscalar(PyArrayObject *self, intp i);
+
+NPY_NO_EXPORT PyObject *
+array_item(PyArrayObject *self, Py_ssize_t i);
 
 NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op);

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -134,7 +134,7 @@ NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
     (lenfunc)array_length,                  /*sq_length*/
     (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
     (ssizeargfunc)NULL,
-    (ssizeargfunc)array_item_nice,
+    (ssizeargfunc)array_item,
     (ssizessizeargfunc)array_slice,
     (ssizeobjargproc)array_ass_item,        /*sq_ass_item*/
     (ssizessizeobjargproc)array_ass_slice,  /*sq_ass_slice*/
@@ -145,7 +145,7 @@ NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
     (inquiry)array_length,                  /*sq_length*/
     (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
     (intargfunc)NULL,                       /*sq_repeat is handled nb_multiply*/
-    (intargfunc)array_item_nice,            /*sq_item*/
+    (intargfunc)array_item,                 /*sq_item*/
     (intintargfunc)array_slice,             /*sq_slice*/
     (intobjargproc)array_ass_item,          /*sq_ass_item*/
     (intintobjargproc)array_ass_slice,      /*sq_ass_slice*/

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -26,10 +26,12 @@ class TestIndexing(TestCase):
         assert_equal(a[()], a)
         assert_(a[()].base is a)
 
-    def _test_empty_list_index(self):
-        # Empty list index (is buggy!)
+    def test_empty_list_index(self):
+        # Empty list index creates an empty array
+        # with the same dtype (but with weird shape)
         a = np.array([1, 2, 3])
-        assert_equal(a[[]], a)
+        assert_equal(a[[]], [])
+        assert_equal(a[[]].dtype, a.dtype)
 
     def test_empty_array_index(self):
         # Empty array index is illegal
@@ -69,27 +71,48 @@ class TestIndexing(TestCase):
         # Index overflow produces ValueError
         assert_raises(ValueError, a.__getitem__, 1<<64)
 
-    def _test_single_bool_index(self):
-        # Single boolean index (is buggy?)
+    def test_single_bool_index(self):
+        # Single boolean index
         a = np.array([[1, 2, 3],
                       [4 ,5, 6],
                       [7, 8, 9]])
 
-        # Python boolean converts to integer (invalid?)
+        # Python boolean converts to integer
         assert_equal(a[True], a[1])
+        assert_equal(a[False], a[0])
 
-        # NumPy zero-dimensional boolean array (*crashes*)
-        assert_equal(a[np.array(True)], a) # what should be the behaviour?
-        assert_equal(a[np.array(False)], []) # what should be the behaviour?
+        # Same with NumPy boolean scalar
+        assert_equal(a[np.array(True)], a[1])
+        assert_equal(a[np.array(False)], a[0])
 
-    def test_boolean_indexing(self):
-        # Indexing a 2-dimensional array with a length-1 array of 'True'
+    def test_boolean_indexing_onedim(self):
+        # Indexing a 2-dimensional array with 
+        # boolean array of length one
         a = np.array([[ 0.,  0.,  0.]])
         b = np.array([ True], dtype=bool)
         assert_equal(a[b], a)
-
+        # boolean assignment
         a[b] = 1.
         assert_equal(a, [[1., 1., 1.]])
+
+    def test_boolean_indexing_twodim(self):
+        # Indexing a 2-dimensional array with 
+        # 2-dimensional boolean array
+        a = np.array([[1, 2, 3],
+                      [4 ,5, 6],
+                      [7, 8, 9]])
+        b = np.array([[ True, False,  True],
+                      [False,  True, False],
+                      [ True, False,  True]])
+        assert_equal(a[b], [1, 3, 5, 7, 9])
+        assert_equal(a[b[1], [4, 5, 6])
+        assert_equal(a[b[0]], a[b[2]])
+
+        # boolean assignment
+        a[b] = 0
+        assert_equal(a, [[0, 2, 0],
+                         [4, 0, 6],
+                         [0, 8, 0]])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -105,7 +105,7 @@ class TestIndexing(TestCase):
                       [False,  True, False],
                       [ True, False,  True]])
         assert_equal(a[b], [1, 3, 5, 7, 9])
-        assert_equal(a[b[1], [4, 5, 6])
+        assert_equal(a[b[1]], [[4, 5, 6]])
         assert_equal(a[b[0]], a[b[2]])
 
         # boolean assignment

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -12,14 +12,84 @@ import sys, warnings
 # but hopefully NumPy indexing can be changed to be more systematic
 # at some point in the future.
 
-def test_boolean_indexing():
-    # Indexing a 2-dimensional array with a length-1 array of 'True'
-    a = np.array([[ 0.,  0.,  0.]])
-    b = np.array([ True], dtype=bool)
-    assert_equal(a[b], a)
+class TestIndexing(TestCase):
 
-    a[b] = 1.
-    assert_equal(a, [[1., 1., 1.]])
+    def test_none_index(self):
+        # `None` index adds newaxis
+        a = np.array([1, 2, 3])
+        assert_equal(a[None], a[np.newaxis])
+        assert_equal(a[None].ndim, a.ndim + 1)
+
+    def test_empty_tuple_index(self):
+        # Empty tuple index creates a view
+        a = np.array([1, 2, 3])
+        assert_equal(a[()], a)
+        assert_(a[()].base is a)
+
+    def _test_empty_list_index(self):
+        # Empty list index (is buggy!)
+        a = np.array([1, 2, 3])
+        assert_equal(a[[]], a)
+
+    def test_empty_array_index(self):
+        # Empty array index is illegal
+        a = np.array([1, 2, 3])
+        b = np.array([])
+        assert_raises(IndexError, a.__getitem__, b)
+
+    def test_ellipsis_index(self):
+        # Ellipsis index does not create a view
+        a = np.array([[1, 2, 3],
+                      [4 ,5, 6],
+                      [7, 8, 9]])
+        assert_equal(a[...], a)
+        assert_(a[...] is a)
+
+        # Slicing with ellipsis can skip an
+        # arbitrary number of dimensions
+        assert_equal(a[0, ...], a[0])
+        assert_equal(a[0, ...], a[0, :])
+        assert_equal(a[..., 0], a[:, 0])
+
+        # Slicing with ellipsis always results
+        # in an array, not a scalar
+        assert_equal(a[0, ..., 1], np.array(2))
+
+    def test_single_int_index(self):
+        # Single integer index selects one row
+        a = np.array([[1, 2, 3],
+                      [4 ,5, 6],
+                      [7, 8, 9]])
+
+        assert_equal(a[0], [1, 2, 3])
+        assert_equal(a[-1], [7, 8, 9])
+
+        # Index out of bounds produces IndexError
+        assert_raises(IndexError, a.__getitem__, 1<<30)
+        # Index overflow produces ValueError
+        assert_raises(ValueError, a.__getitem__, 1<<64)
+
+    def _test_single_bool_index(self):
+        # Single boolean index (is buggy?)
+        a = np.array([[1, 2, 3],
+                      [4 ,5, 6],
+                      [7, 8, 9]])
+
+        # Python boolean converts to integer (invalid?)
+        assert_equal(a[True], a[1])
+
+        # NumPy zero-dimensional boolean array (*crashes*)
+        assert_equal(a[np.array(True)], a) # what should be the behaviour?
+        assert_equal(a[np.array(False)], []) # what should be the behaviour?
+
+    def test_boolean_indexing(self):
+        # Indexing a 2-dimensional array with a length-1 array of 'True'
+        a = np.array([[ 0.,  0.,  0.]])
+        b = np.array([ True], dtype=bool)
+        assert_equal(a[b], a)
+
+        a[b] = 1.
+        assert_equal(a, [[1., 1., 1.]])
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Hi, this is some older refactor work re-committed against the new master. It was my intention to make the subscript code more readable and a bit cleaner in the handling. I tried to make a distinction between the handling of Python objects, NumPy scalars and NumPy arrays. Mostly its just moving functionality around, but I've tried to take care of the edge-cases and quirks in the code by adding a comprehensive set of test cases.

One test case is disabled, however, because it fails with a segmentation fault. This is also the case for the current master.. something to fix later on. (Update: this has been fixed.)
