### PR TITLE
Fix for issue #291

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -309,9 +309,24 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
+#if defined(NPY_PY3K)
+            PyObject *tmp = NULL;
+#endif
             typestr = PyDict_GetItemString(ip, "typestr");
-            if (typestr && PyString_Check(typestr)) {
-                dtype =_array_typedescr_fromstr(PyString_AS_STRING(typestr));
+#if defined(NPY_PY3K)
+            /* Allow unicode type strings */
+            if (PyUnicode_Check(typestr)) {
+                tmp = PyUnicode_AsASCIIString(typestr);
+                typestr = tmp;
+            }
+#endif
+            if (typestr && PyBytes_Check(typestr)) {
+                dtype =_array_typedescr_fromstr(PyBytes_AS_STRING(typestr));
+#if defined(NPY_PY3K)
+                if (tmp == typestr) {
+                    Py_DECREF(tmp);
+                }
+#endif
                 Py_DECREF(ip);
                 if (dtype == NULL) {
                     goto fail;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2066,9 +2066,9 @@ PyArray_FromInterface(PyObject *origin)
     attr = PyDict_GetItemString(iface, "data");
 
     /* Special case for scalars that do not specify data */
-    if ((attr == NULL) && ((n == 0) || ((n == 1) && (dims[0] <= 1)))) {
+    if ((attr == NULL) && ((n == 0))) {
         /* Pointers to data and base should already be NULL! */
-        n = dims[0] = 1;
+        n = dims[0] = 0;
     }
 
     /* Case for data access through pointer */

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2074,6 +2074,11 @@ PyArray_FromInterface(PyObject *origin)
     /* Case for data access through pointer */
     else if (attr && PyTuple_Check(attr)) {
         PyObject *dataptr;
+        if (n == 0) {
+            PyErr_SetString(PyExc_ValueError,
+                    "__array_interface__ shape must be at least size 1");
+            goto fail;
+        }
         if (PyTuple_GET_SIZE(attr) != 2) {
             PyErr_SetString(PyExc_TypeError,
                     "__array_interface__ data must be a 2-tuple with "
@@ -2107,6 +2112,11 @@ PyArray_FromInterface(PyObject *origin)
 
     /* Case for data access through buffer */
     else {
+        if (n == 0) {
+            PyErr_SetString(PyExc_ValueError,
+                    "__array_interface__ shape must be at least size 1");
+            goto fail;
+        }
         if (attr && (attr != Py_None)) {
             base = attr;
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1979,7 +1979,7 @@ PyArray_FromStructInterface(PyObject *input)
 NPY_NO_EXPORT PyObject *
 PyArray_FromInterface(PyObject *origin)
 {
-    PyObject *tmp;
+    PyObject *tmp = NULL;
     PyObject *iface = NULL;
     PyObject *attr = NULL;
     PyObject *base = NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2065,8 +2065,8 @@ PyArray_FromInterface(PyObject *origin)
     /* Get data buffer from interface specification */
     attr = PyDict_GetItemString(iface, "data");
 
-    /* Special case for scalars that do not specify shape or data */
-    if ((attr == NULL) && ((n == 0) || (dims[0] <= 1))) {
+    /* Special case for scalars that do not specify data */
+    if ((attr == NULL) && ((n == 0) || ((n == 1) && (dims[0] <= 1)))) {
         /* Pointers to data and base should already be NULL! */
         n = dims[0] = 1;
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1977,83 +1977,102 @@ PyArray_FromStructInterface(PyObject *input)
 
 /*NUMPY_API*/
 NPY_NO_EXPORT PyObject *
-PyArray_FromInterface(PyObject *input)
+PyArray_FromInterface(PyObject *origin)
 {
-    PyObject *attr = NULL, *item = NULL;
-    PyObject *tstr = NULL, *shape = NULL;
-    PyObject *inter = NULL;
+    PyObject *tmp;
+    PyObject *iface = NULL;
+    PyObject *attr = NULL;
     PyObject *base = NULL;
     PyArrayObject *ret;
-    PyArray_Descr *type=NULL;
-    char *data;
+    PyArray_Descr *dtype = NULL;
+    char *data = NULL;
     Py_ssize_t buffer_len;
     int res, i, n;
     npy_intp dims[NPY_MAXDIMS], strides[NPY_MAXDIMS];
     int dataflags = NPY_ARRAY_BEHAVED;
 
-    /* Get the memory from __array_data__ and __array_offset__ */
-    /* Get the shape */
     /* Get the typestring -- ignore array_descr */
+    /* Get the shape */
+    /* Get the memory from __array_data__ and __array_offset__ */
     /* Get the strides */
 
-    inter = PyObject_GetAttrString(input, "__array_interface__");
-    if (inter == NULL) {
+    iface = PyObject_GetAttrString(origin, "__array_interface__");
+    if (iface == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
     }
-    if (!PyDict_Check(inter)) {
-        Py_DECREF(inter);
+    if (!PyDict_Check(iface)) {
+        Py_DECREF(iface);
         PyErr_SetString(PyExc_ValueError,
                 "Invalid __array_interface__ value, must be a dict");
         return NULL;
     }
-    shape = PyDict_GetItemString(inter, "shape");
-    if (shape == NULL) {
-        Py_DECREF(inter);
-        PyErr_SetString(PyExc_ValueError,
-                "Missing __array_interface__ shape");
-        return NULL;
-    }
-    tstr = PyDict_GetItemString(inter, "typestr");
-    if (tstr == NULL) {
-        Py_DECREF(inter);
+
+    /* Get type string from interface specification */
+    attr = PyDict_GetItemString(iface, "typestr");
+    if (attr == NULL) {
+        Py_DECREF(iface);
         PyErr_SetString(PyExc_ValueError,
                 "Missing __array_interface__ typestr");
         return NULL;
     }
-
-    attr = PyDict_GetItemString(inter, "data");
-    base = input;
-    if ((attr == NULL) || (attr==Py_None) || (!PyTuple_Check(attr))) {
-        if (attr && (attr != Py_None)) {
-            item = attr;
-        }
-        else {
-            item = input;
-        }
-        res = PyObject_AsWriteBuffer(item, (void **)&data, &buffer_len);
-        if (res < 0) {
-            PyErr_Clear();
-            res = PyObject_AsReadBuffer(
-                        item, (const void **)&data, &buffer_len);
-            if (res < 0) {
-                goto fail;
-            }
-            dataflags &= ~NPY_ARRAY_WRITEABLE;
-        }
-        attr = PyDict_GetItemString(inter, "offset");
-        if (attr) {
-            npy_longlong num = PyLong_AsLongLong(attr);
-            if (error_converting(num)) {
-                PyErr_SetString(PyExc_TypeError,
-                        "__array_interface__ offset must be an integer");
-                goto fail;
-            }
-            data += num;
-        }
-        base = item;
+#if defined(NPY_PY3K)
+    /* Allow unicode type strings */
+    if (PyUnicode_Check(attr)) {
+        tmp = PyUnicode_AsASCIIString(attr);
+        attr = tmp;
     }
-    else {
+#endif
+    if (!PyBytes_Check(attr)) {
+        PyErr_SetString(PyExc_TypeError,
+                    "__array_interface__ typestr must be a string");
+        goto fail;
+    }
+    /* Get dtype from type string */
+    dtype = _array_typedescr_fromstr(PyString_AS_STRING(attr));
+#if defined(NPY_PY3K)
+    if (tmp == attr) {
+        Py_DECREF(tmp);
+    }
+#endif
+    if (dtype == NULL) {
+        goto fail;
+    }
+
+    /* Get shape tuple from interface specification */
+    attr = PyDict_GetItemString(iface, "shape");
+    if (attr == NULL) {
+        Py_DECREF(iface);
+        PyErr_SetString(PyExc_ValueError,
+                "Missing __array_interface__ shape");
+        return NULL;
+    }
+    if (!PyTuple_Check(attr)) {
+        PyErr_SetString(PyExc_TypeError,
+                "shape must be a tuple");
+        goto fail;
+    }
+    /* Get dimensions from shape tuple */
+    n = PyTuple_GET_SIZE(attr);
+    for (i = 0; i < n; i++) {
+        tmp = PyTuple_GET_ITEM(attr, i);
+        dims[i] = PyArray_PyIntAsIntp(tmp);
+        if (error_converting(dims[i])) {
+            goto fail;
+        }
+    }
+
+    /* Get data buffer from interface specification */
+    attr = PyDict_GetItemString(iface, "data");
+
+    /* Special case for scalars that do not specify shape or data */
+    if ((attr == NULL) && ((n == 0) || (dims[0] <= 1))) {
+        /* Pointers to data and base should already be NULL! */
+        n = dims[0] = 1;
+    }
+
+    /* Case for data access through pointer */
+    else if (attr && PyTuple_Check(attr)) {
         PyObject *dataptr;
         if (PyTuple_GET_SIZE(attr) != 2) {
             PyErr_SetString(PyExc_TypeError,
@@ -2083,90 +2102,90 @@ PyArray_FromInterface(PyObject *input)
         if (PyObject_IsTrue(PyTuple_GET_ITEM(attr,1))) {
             dataflags &= ~NPY_ARRAY_WRITEABLE;
         }
-    }
-    attr = tstr;
-#if defined(NPY_PY3K)
-    if (PyUnicode_Check(tstr)) {
-        /* Allow unicode type strings */
-        attr = PyUnicode_AsASCIIString(tstr);
-    }
-#endif
-    if (!PyBytes_Check(attr)) {
-        PyErr_SetString(PyExc_TypeError,
-                    "__array_interface__ typestr must be a string");
-        goto fail;
-    }
-    type = _array_typedescr_fromstr(PyString_AS_STRING(attr));
-#if defined(NPY_PY3K)
-    if (attr != tstr) {
-        Py_DECREF(attr);
-    }
-#endif
-    if (type == NULL) {
-        goto fail;
-    }
-    attr = shape;
-    if (!PyTuple_Check(attr)) {
-        PyErr_SetString(PyExc_TypeError,
-                "shape must be a tuple");
-        Py_DECREF(type);
-        goto fail;
-    }
-    n = PyTuple_GET_SIZE(attr);
-    for (i = 0; i < n; i++) {
-        item = PyTuple_GET_ITEM(attr, i);
-        dims[i] = PyArray_PyIntAsIntp(item);
-        if (error_converting(dims[i])) {
-            break;
-        }
+        base = origin;
     }
 
-    ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, type,
+    /* Case for data access through buffer */
+    else {
+        if (attr && (attr != Py_None)) {
+            base = attr;
+        }
+        else {
+            base = origin;
+        }
+        res = PyObject_AsWriteBuffer(base, (void **)&data, &buffer_len);
+        if (res < 0) {
+            PyErr_Clear();
+            res = PyObject_AsReadBuffer(
+                        base, (const void **)&data, &buffer_len);
+            if (res < 0) {
+                goto fail;
+            }
+            dataflags &= ~NPY_ARRAY_WRITEABLE;
+        }
+        /* Get offset number from interface specification */
+        attr = PyDict_GetItemString(origin, "offset");
+        if (attr) {
+            npy_longlong num = PyLong_AsLongLong(attr);
+            if (error_converting(num)) {
+                PyErr_SetString(PyExc_TypeError,
+                        "__array_interface__ offset must be an integer");
+                goto fail;
+            }
+            data += num;
+        }
+    }
+    ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype,
                                                 n, dims,
                                                 NULL, data,
                                                 dataflags, NULL);
     if (ret == NULL) {
-        return NULL;
+        goto fail;
     }
-    Py_INCREF(base);
-    if (PyArray_SetBaseObject(ret, base) < 0) {
-        Py_DECREF(ret);
-        return NULL;
+    if (data == NULL) {
+        if (PyArray_SETITEM(ret, PyArray_DATA(ret), origin) < 0) {
+            Py_DECREF(ret);
+            goto fail;
+        }
     }
-
-    attr = PyDict_GetItemString(inter, "strides");
+    if (base) {
+        Py_INCREF(base);
+        if (PyArray_SetBaseObject(ret, base) < 0) {
+            Py_DECREF(ret);
+            goto fail;
+        }
+    }
+    attr = PyDict_GetItemString(iface, "strides");
     if (attr != NULL && attr != Py_None) {
         if (!PyTuple_Check(attr)) {
             PyErr_SetString(PyExc_TypeError,
                     "strides must be a tuple");
             Py_DECREF(ret);
-            return NULL;
+            goto fail;
         }
         if (n != PyTuple_GET_SIZE(attr)) {
             PyErr_SetString(PyExc_ValueError,
                     "mismatch in length of strides and shape");
             Py_DECREF(ret);
-            return NULL;
+            goto fail;
         }
         for (i = 0; i < n; i++) {
-            item = PyTuple_GET_ITEM(attr, i);
-            strides[i] = PyArray_PyIntAsIntp(item);
+            tmp = PyTuple_GET_ITEM(attr, i);
+            strides[i] = PyArray_PyIntAsIntp(tmp);
             if (error_converting(strides[i])) {
-                break;
+                Py_DECREF(ret);
+                goto fail;
             }
-        }
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
         }
         memcpy(PyArray_STRIDES(ret), strides, n*sizeof(npy_intp));
     }
-    else PyErr_Clear();
     PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
-    Py_DECREF(inter);
+    Py_DECREF(iface);
     return (PyObject *)ret;
 
  fail:
-    Py_XDECREF(inter);
+    Py_XDECREF(dtype);
+    Py_XDECREF(iface);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2150,6 +2150,7 @@ PyArray_FromInterface(PyObject *origin)
             data += num;
         }
     }
+
     ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype,
                                                 n, dims,
                                                 NULL, data,
@@ -2158,6 +2159,12 @@ PyArray_FromInterface(PyObject *origin)
         goto fail;
     }
     if (data == NULL) {
+        if (PyArray_SIZE(ret) > 1) {
+            PyErr_SetString(PyExc_ValueError,
+                    "cannot coerce scalar to array with size > 1");
+            Py_DECREF(ret);
+            goto fail;
+        }
         if (PyArray_SETITEM(ret, PyArray_DATA(ret), origin) < 0) {
             Py_DECREF(ret);
             goto fail;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2809,6 +2809,20 @@ if sys.version_info >= (2, 6):
             for s in attr:
                 assert_raises(AttributeError, delattr, a, s)
 
+def test_array_interface():
+    class Foo(object):
+        def __init__(self, value):
+            self.value = value
+        def __float__(self):
+            return float(self.value)
+        @property
+        def __array_interface__(self):
+            return {'typestr' : '=f8',
+                    'shape' : ()}
+    f = Foo(0.5)
+    assert_equal(np.array(f), [0.5])
+    assert_equal(np.array([f, f]), [0.5, 0.5])
+    assert_equal(np.array(f).dtype, np.dtype('=f8'))
 
 def test_flat_element_deletion():
     it = np.ones(3).flat


### PR DESCRIPTION
Hi, I made an attempt at fixing #291, by redoing part of the array interface. 

It can now accept objects that do not specify their 'data' attribute and have a shape of `()` or a shape of `(1,)`. To accept no shape information at all is a bit dangerous, because it would be prone to errors. 

This now works:

```
class Foo(object):
    def __init__(self, value):
        self.value = value
    def __float__(self):
        return float(self.value)
    @property
    def __array_interface__(self):
        return {'typestr' : '=f8', 'shape' : ()}

>>> f = Foo(0.5)
>>> np.array(f)
array([ 0.5])
```

But without the shape information, it still gives the error:
`ValueError: Missing __array_interface__ shape`

I think enforcing the shape would be the best way to go, because otherwise the array interface can be interpreted wrong when someone _does_ supply the 'data' attribute.
