### PR TITLE
FIX: PyErr_SetObject does not steal reference (Ticket 2216)

### DIFF
--- a/numpy/core/src/multiarray/array_assign.c
+++ b/numpy/core/src/multiarray/array_assign.c
@@ -73,6 +73,7 @@ broadcast_error: {
         PyUString_ConcatAndDel(&errmsg,
                 build_shape_string(ndim, shape));
         PyErr_SetObject(PyExc_ValueError, errmsg);
+        Py_DECREF(errmsg);
 
         return -1;
    }

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -284,6 +284,7 @@ PyArray_AssignArray(PyArrayObject *dst, PyArrayObject *src,
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         goto fail;
     }
 

--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -209,6 +209,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1818,6 +1818,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
 
         Py_DECREF(newtype);
         return NULL;

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -1489,6 +1489,7 @@ raise_if_datetime64_metadata_cast_error(char *object_type,
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -1520,6 +1521,7 @@ raise_if_timedelta64_metadata_cast_error(char *object_type,
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -1654,6 +1656,7 @@ incompatible_units: {
                 PyUString_FromString(" because they have "
                     "incompatible nonlinear base time units"));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 units_overflow: {
@@ -1666,6 +1669,7 @@ units_overflow: {
                 PyUString_FromString(" and "));
         errmsg = append_metastr_to_string(meta2, 0, errmsg);
         PyErr_SetObject(PyExc_OverflowError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -1813,6 +1817,7 @@ convert_datetime_metadata_tuple_to_datetime_metadata(PyObject *tuple,
                                       "datetime metadata conversion, not ");
         PyUString_ConcatAndDel(&errmsg, PyObject_Repr(tuple));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2538,6 +2538,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
             errmsg = PyUString_FromString("Invalid datetime dtype (metadata, c_metadata): ");
             PyUString_ConcatAndDel(&errmsg, PyObject_Repr(metadata));
             PyErr_SetObject(PyExc_ValueError, errmsg);
+            Py_DECREF(errmsg);
             return NULL;
         }
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -858,6 +858,7 @@ array_astype(PyArrayObject *self, PyObject *args, PyObject *kwds)
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         Py_DECREF(dtype);
         return NULL;
     }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1337,6 +1337,7 @@ npyiter_check_casting(int nop, PyArrayObject **op,
                         PyUString_FromFormat(" according to the rule %s",
                                 npyiter_casting_to_string(casting)));
                 PyErr_SetObject(PyExc_TypeError, errmsg);
+                Py_DECREF(errmsg);
                 return 0;
             }
             /* Check write (temp -> op) casting */
@@ -1359,6 +1360,7 @@ npyiter_check_casting(int nop, PyArrayObject **op,
                                 (int)iop,
                                 npyiter_casting_to_string(casting)));
                 PyErr_SetObject(PyExc_TypeError, errmsg);
+                Py_DECREF(errmsg);
                 return 0;
             }
 
@@ -1738,6 +1740,7 @@ broadcast_error: {
 
             }
             PyErr_SetObject(PyExc_ValueError, errmsg);
+            Py_DECREF(errmsg);
         }
         else {
             errmsg = PyUString_FromString("operands could not be broadcast "
@@ -1804,6 +1807,7 @@ broadcast_error: {
 
             }
             PyErr_SetObject(PyExc_ValueError, errmsg);
+            Py_DECREF(errmsg);
         }
 
         return 0;
@@ -1890,6 +1894,7 @@ operand_different_than_broadcast: {
         }
 
         PyErr_SetObject(PyExc_ValueError, errmsg);
+        Py_DECREF(errmsg);
 
         return 0;
     }

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -77,6 +77,7 @@ PyUFunc_ValidateCasting(PyUFuncObject *ufunc,
                         PyUString_FromFormat(" with casting rule %s",
                                         npy_casting_to_string(casting)));
                 PyErr_SetObject(PyExc_TypeError, errmsg);
+                Py_DECREF(errmsg);
                 return -1;
             }
         } else if (operands[i] != NULL) {
@@ -95,6 +96,7 @@ PyUFunc_ValidateCasting(PyUFuncObject *ufunc,
                         PyUString_FromFormat(" with casting rule %s",
                                         npy_casting_to_string(casting)));
                 PyErr_SetObject(PyExc_TypeError, errmsg);
+                Py_DECREF(errmsg);
                 return -1;
             }
         }
@@ -725,6 +727,7 @@ type_reso_error: {
         PyUString_ConcatAndDel(&errmsg,
                 PyObject_Repr((PyObject *)PyArray_DESCR(operands[1])));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -895,6 +898,7 @@ type_reso_error: {
         PyUString_ConcatAndDel(&errmsg,
                 PyObject_Repr((PyObject *)PyArray_DESCR(operands[1])));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -1038,6 +1042,7 @@ type_reso_error: {
         PyUString_ConcatAndDel(&errmsg,
                 PyObject_Repr((PyObject *)PyArray_DESCR(operands[1])));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -1157,6 +1162,7 @@ type_reso_error: {
         PyUString_ConcatAndDel(&errmsg,
                 PyObject_Repr((PyObject *)PyArray_DESCR(operands[1])));
         PyErr_SetObject(PyExc_TypeError, errmsg);
+        Py_DECREF(errmsg);
         return -1;
     }
 }
@@ -1273,6 +1279,7 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
         }
     }
     PyErr_SetObject(PyExc_TypeError, errmsg);
+    Py_DECREF(errmsg);
 
     return -1;
 }


### PR DESCRIPTION
It seems that `PyErr_SetObj` is assumed ot steal a references in most parts of numpy, but appearently it does not. I assume that in `/doc/pyrex/numpyx.c` it is correct, but am not quite sure about the occurances in `/numpy/random/mtrand/mtrand.c`.  Seems to also fix Ticket 2125.
