### PR TITLE
ENH: delete and insert generalization and speed improvements

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -85,6 +85,14 @@ The function np.take now allows 0-d arrays as indices.
 
 The separate compilation mode is now enabled by default.
 
+The functions np.insert and np.delete now handle out of bound indices like
+normal indexing instead of ignoring them, this strongly affects negative ones.
+FutureWarnings will be raised for boolean indices which will change behaviour.
+Insert allows multiple insertions at single scalar since numpy 1.7. and now
+further allows this for a one item sequence. There are subtle differences
+because the scalar expects N arrays, while the sequence expects size N along
+the axis.
+
 C-API
 ~~~~~
 

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -85,13 +85,19 @@ The function np.take now allows 0-d arrays as indices.
 
 The separate compilation mode is now enabled by default.
 
-The functions np.insert and np.delete now handle out of bound indices like
-normal indexing instead of ignoring them, this strongly affects negative ones.
-FutureWarnings will be raised for boolean indices which will change behaviour.
-Insert allows multiple insertions at single scalar since numpy 1.7. and now
-further allows this for a one item sequence. There are subtle differences
-because the scalar expects N arrays, while the sequence expects size N along
-the axis.
+Several changes to np.insert and np.delete:
+* Previously, negative indices and indices that pointed past the end of
+  the array were simply ignored. Now, this will raise a Future or Deprecation
+  Warning. In the future they will be treated like normal indexing treats
+  them -- negative indices will wrap around, and out-of-bound indices will
+  generate an error.
+* Previously, boolean indices were treated as if they were integers (always
+  referring to either the 0th or 1st item in the array). In the future, they
+  will be treated as masks. In this release, they raise a FutureWarning
+  warning of this coming change.
+* In Numpy 1.7. np.insert already allowed the syntax
+  `np.insert(arr, 3, [1,2,3])` to insert multiple items at a single position.
+  In Numpy 1.8. this is also possible for `np.insert(arr, [3], [1, 2, 3])`.
 
 C-API
 ~~~~~

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -33,6 +33,9 @@ from ._compiled_base import add_newdoc_ufunc
 import numpy as np
 import collections
 
+# Force range to be a generator, for np.delete's usage.
+if sys.version_info[0] < 3:
+    range = xrange
 
 def iterable(y):
     """
@@ -3467,7 +3470,7 @@ def delete(arr, obj, axis=None):
 
     if isinstance(obj, slice):
         start, stop, step = obj.indices(N)
-        xr = xrange(start, stop, step)
+        xr = range(start, stop, step)
         numtodel = len(xr)
 
         if numtodel <= 0:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -214,9 +214,9 @@ class TestInsert(TestCase):
         # This is an error in the future
         a = np.array(1)
         with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', FutureWarning)
+            warnings.filterwarnings('always', '', DeprecationWarning)
             assert_equal(insert(a, [], 2, axis=0), np.array(2))
-            assert_(w[0].category is FutureWarning)
+            assert_(w[0].category is DeprecationWarning)
 
     def test_subclass(self):
         class SubClass(np.ndarray):
@@ -357,14 +357,15 @@ class TestDelete(TestCase):
     def _check_inverse_of_slicing(self, indices):
         a_del = delete(self.a, indices)
         nd_a_del = delete(self.nd_a, indices, axis=1)
+        msg = 'Delete failed for obj: %r' % indices
         # NOTE: The cast should be removed after warning phase for bools
-        if not isinstance(indices, slice):
+        if not isinstance(indices, (slice, int, long, np.integer)):
             indices = np.asarray(indices, dtype=np.intp)
+            indices = indices[(indices >= 0) & (indices < 5)]
         assert_array_equal(setxor1d(a_del, self.a[indices,]), self.a,
-                           err_msg='Delete failed for obj: %r' % indices)
+                           err_msg=msg)
         xor = setxor1d(nd_a_del[0,:,0], self.nd_a[0,indices,0])
-        assert_array_equal(xor, self.nd_a[0,:,0],
-                           err_msg='Delete failed for obj: %r' % indices)
+        assert_array_equal(xor, self.nd_a[0,:,0], err_msg=msg)
 
     def test_slices(self):
         lims = [-6, -2, 0, 1, 2, 4, 5]
@@ -376,11 +377,13 @@ class TestDelete(TestCase):
                     self._check_inverse_of_slicing(s)
 
     def test_fancy(self):
-        self._check_inverse_of_slicing([0, -1, 2, 2])
+        # Deprecation/FutureWarning tests should be kept after change.
         self._check_inverse_of_slicing(np.array([[0,1],[2,1]]))
-        assert_raises(IndexError, delete, self.a, [100])
+        assert_raises(DeprecationWarning, delete, self.a, [100])
+        assert_raises(DeprecationWarning, delete, self.a, [-100])
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', FutureWarning)
+            self._check_inverse_of_slicing([0, -1, 2, 2])
             obj = np.array([True, False, False], dtype=bool)
             self._check_inverse_of_slicing(obj)
             assert_(w[0].category is FutureWarning)
@@ -393,9 +396,9 @@ class TestDelete(TestCase):
     def test_0d(self):
         a = np.array(1)
         with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', FutureWarning)
+            warnings.filterwarnings('always', '', DeprecationWarning)
             assert_equal(delete(a, [], axis=0), a)
-            assert_(w[0].category is FutureWarning)
+            assert_(w[0].category is DeprecationWarning)
 
     def test_subclass(self):
         class SubClass(np.ndarray):


### PR DESCRIPTION
This allows boolean indices for both delete and insert, improves their speed and makes them work with negative indices and in the case of insert unsorted indices as well as some smaller changes.

`np.delete` has some serious issues and the first two things are a serious bugs IMO since it creates plain wrong results (and its not documented):
1. When using slices with negative strides, it does not work (best case) or give even wrong results.
2. When using an index array, it will simply ignore negative indexes.
3. The fact that it uses `setdiff1d` makes it unnecessarily slow and bloated compared to boolean indexing based methods.

This PR fixes these issues. There is one more behaviour change, and that is that out of bound indices now will raise an error, however I consider that a feature. For the negative steps, I guess another option would be to just explicitely raise an error.

I will add tests if this is wanted, and I honestly think this is a very necessary clean up of the `delete` function.

Example for the complete wrong results:

``` python
In [1]: arr = np.arange(4)

In [2]: set(arr) - set(arr[1::-1])
Out[2]: set([2, 3])

In [3]: np.delete(arr, np.s_[1::-1])
Out[3]: array([3, 3])
```
