### PR TITLE
FIX: Issue #380

### DIFF
--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -273,21 +273,21 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
          * appropriate value to preserve contiguousness
          */
         if (order == NPY_FORTRANORDER) {
-            if (strides[0] == 0) {
+            if (dimensions[0] == 1) {
                 strides[0] = PyArray_DESCR(self)->elsize;
             }
             for (i = 1; i < ndim; i++) {
-                if (strides[i] == 0) {
+                if (dimensions[i] == 1) {
                     strides[i] = strides[i-1] * dimensions[i-1];
                 }
             }
         }
         else {
-            if (strides[ndim-1] == 0) {
+            if (dimensions[ndim-1] == 1) {
                 strides[ndim-1] = PyArray_DESCR(self)->elsize;
             }
             for (i = ndim - 2; i > -1; i--) {
-                if (strides[i] == 0) {
+                if (dimensions[i] == 1) {
                     strides[i] = strides[i+1] * dimensions[i+1];
                 }
             }

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -498,6 +498,12 @@ class TestRegression(TestCase):
         b = a[:,1]
         assert_equal(b.reshape(2,2,order='F'), [[2,6],[4,8]])
 
+    def test_reshape_zero_strides(self, level=rlevel):
+        """Issue #380, test reshaping of zero strided arrays"""
+        a = np.ones(1)
+        a = np.lib.stride_tricks.as_strided(a, shape=(5,), strides=(0,))
+        assert_(a.reshape(5,1).strides[0] == 0)
+
     def test_repeat_discont(self, level=rlevel):
         """Ticket #352"""
         a = np.arange(12).reshape(4,3)[:,2]


### PR DESCRIPTION
Fix for Issue #380, since this is a very straightforward fix (You simply cannot overwrite 0-strides if the dimension is not exactly 1), and this exposes a segmentation fault even if it is a rare corner case, I wanted to remind about it, espeacially since numpy seems  to use 0-stride arrays more and more itself.
