### PR TITLE
Fix unicode repr object

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -308,7 +308,7 @@ def _array2string(a, max_line_width, precision, suppress_small, separator=' ',
         elif issubclass(dtypeobj, _nt.datetime64):
             format_function = formatdict['datetime']
         else:
-            format_function = formatdict['str']
+            format_function = formatdict['numpystr']
 
     # skip over "["
     next_line_prefix = " "

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -147,6 +147,10 @@ class TestPrintOptions:
         np.set_printoptions(formatter={'float_kind':None})
         assert_equal(repr(x), "array([ 0.,  1.,  2.])")
 
+def test_unicode_object_array():
+    x = np.array([u'\xe9'], dtype=object)
+    assert_equal(repr(x), "array([u'\\xe9'], dtype=object)")
+
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import sys
 import numpy as np
 from numpy.testing import *
@@ -148,8 +150,13 @@ class TestPrintOptions:
         assert_equal(repr(x), "array([ 0.,  1.,  2.])")
 
 def test_unicode_object_array():
+    import sys
+    if sys.version_info[0] >= 3:
+        expected = "array(['é'], dtype=object)"
+    else:
+        expected = "array([u'\\xe9'], dtype=object)"
     x = np.array([u'\xe9'], dtype=object)
-    assert_equal(repr(x), "array([u'\\xe9'], dtype=object)")
+    assert_equal(repr(x), expected)
 
 
 


### PR DESCRIPTION
If you try to print an array with unicode in it and an object dtype, it currently fails. This happens often for me working with pandas because it defaults to the object dtype for non-numerical arrays. This is because the fallback for the formatting is str. Is there any reason not to use the numpystr function here that can handle unicode?

Reproduce

``` python
import numpy as np
a = np.array([u"\xe9"], dtype=object)
print a
```
