### PR TITLE
DOC: Formatting fixes using regex

### DIFF
--- a/doc/sphinxext/numpydoc/tests/test_docscrape.py
+++ b/doc/sphinxext/numpydoc/tests/test_docscrape.py
@@ -25,7 +25,7 @@ doc_txt = '''\
 
          (1+2+3)/3
 
-  cov : (N,N) ndarray
+  cov : (N, N) ndarray
       Covariance matrix of the distribution.
   shape : tuple of ints
       Given a shape of, for example, (m,n,k), m*n*k samples are
@@ -63,7 +63,6 @@ doc_txt = '''\
 
   Notes
   -----
-
   Instead of specifying the full covariance matrix, popular
   approximations include:
 
@@ -197,7 +196,7 @@ mean : (N,) ndarray
 
        (1+2+3)/3
 
-cov : (N,N) ndarray
+cov : (N, N) ndarray
     Covariance matrix of the distribution.
 shape : tuple of ints
     Given a shape of, for example, (m,n,k), m*n*k samples are

--- a/doc/sphinxext/tests/test_docscrape.py
+++ b/doc/sphinxext/tests/test_docscrape.py
@@ -25,7 +25,7 @@ doc_txt = '''\
 
          (1+2+3)/3
 
-  cov : (N,N) ndarray
+  cov : (N, N) ndarray
       Covariance matrix of the distribution.
   shape : tuple of ints
       Given a shape of, for example, (m,n,k), m*n*k samples are
@@ -63,7 +63,6 @@ doc_txt = '''\
 
   Notes
   -----
-
   Instead of specifying the full covariance matrix, popular
   approximations include:
 
@@ -196,7 +195,7 @@ mean : (N,) ndarray
 
        (1+2+3)/3
 
-cov : (N,N) ndarray
+cov : (N, N) ndarray
     Covariance matrix of the distribution.
 shape : tuple of ints
     Given a shape of, for example, (m,n,k), m*n*k samples are

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -211,7 +211,7 @@ add_newdoc('numpy.core', 'nditer',
     op_dtypes : dtype or tuple of dtype(s), optional
         The required data type(s) of the operands. If copying or buffering
         is enabled, the data will be converted to/from their original types.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Controls the iteration order. 'C' means C order, 'F' means
         Fortran order, 'A' means 'F' order if all the arrays are Fortran
         contiguous, 'C' order otherwise, and 'K' means as close to the
@@ -1503,7 +1503,7 @@ add_newdoc('numpy.core.multiarray', 'lexsort',
 
     Parameters
     ----------
-    keys : (k,N) array or tuple containing k (N,)-shaped sequences
+    keys : (k, N) array or tuple containing k (N,)-shaped sequences
         The `k` different "columns" to be sorted.  The last column (or row if
         `keys` is a 2D array) is the primary sort key.
     axis : int, optional
@@ -1598,7 +1598,6 @@ add_newdoc('numpy.core.multiarray', 'can_cast',
 
     Examples
     --------
-
     Basic examples
 
     >>> np.can_cast(np.int32, np.int64)
@@ -1978,7 +1977,7 @@ add_newdoc('numpy.core', 'einsum',
         If provided, forces the calculation to use the data type specified.
         Note that you may have to also give a more liberal `casting`
         parameter to allow the conversions.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Controls the memory layout of the output. 'C' means it should
         be C contiguous. 'F' means it should be Fortran contiguous,
         'A' means it should be 'F' if the inputs are all 'F', 'C' otherwise.
@@ -3047,7 +3046,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('astype',
     ----------
     dtype : str or dtype
         Typecode or data-type to which the array is cast.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Controls the memory layout order of the result.
         'C' means C order, 'F' means Fortran order, 'A'
         means 'F' order if all the arrays are Fortran contiguous,
@@ -3083,7 +3082,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('astype',
 
     Raises
     ------
-    ComplexWarning :
+    ComplexWarning
         When casting from complex to float or int. To avoid this,
         one should use ``a.real.astype(t)``.
 
@@ -3110,12 +3109,12 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('byteswap',
 
     Parameters
     ----------
-    inplace: bool, optional
+    inplace : bool, optional
         If ``True``, swap bytes in-place, default is ``False``.
 
     Returns
     -------
-    out: ndarray
+    out : ndarray
         The byteswapped array. If `inplace` is ``True``, this is
         a view to self.
 
@@ -5058,7 +5057,6 @@ add_newdoc('numpy.lib._compiled_base', 'add_newdoc_ufunc',
 
     Notes
     -----
-
     This method allocates memory for new_docstring on
     the heap. Technically this creates a mempory leak, since this
     memory will not be reclaimed until the end of the program
@@ -5900,7 +5898,6 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('fields',
 
     Examples
     --------
-
     >>> dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
     >>> print dt.fields
     {'grades': (dtype(('float64',(2,))), 16), 'name': (dtype('|S16'), 0)}
@@ -6008,7 +6005,6 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('names',
 
     Examples
     --------
-
     >>> dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
     >>> dt.names
     ('name', 'grades')

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -207,7 +207,7 @@ add_newdoc('numpy.core', 'nditer',
     op_dtypes : dtype or tuple of dtype(s), optional
         The required data type(s) of the operands. If copying or buffering
         is enabled, the data will be converted to/from their original types.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Controls the iteration order. 'C' means C order, 'F' means
         Fortran order, 'A' means 'F' order if all the arrays are Fortran
         contiguous, 'C' order otherwise, and 'K' means as close to the
@@ -780,7 +780,7 @@ add_newdoc('numpy.core.multiarray', 'empty_like',
         returned array.
     dtype : data-type, optional
         Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Overrides the memory layout of the result. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if ``a`` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of ``a`` as closely
@@ -1497,7 +1497,7 @@ add_newdoc('numpy.core.multiarray', 'lexsort',
 
     Parameters
     ----------
-    keys : (k,N) array or tuple containing k (N,)-shaped sequences
+    keys : (k, N) array or tuple containing k (N,)-shaped sequences
         The `k` different "columns" to be sorted.  The last column (or row if
         `keys` is a 2D array) is the primary sort key.
     axis : int, optional
@@ -1592,7 +1592,6 @@ add_newdoc('numpy.core.multiarray', 'can_cast',
 
     Examples
     --------
-
     Basic examples
 
     >>> np.can_cast(np.int32, np.int64)
@@ -1972,7 +1971,7 @@ add_newdoc('numpy.core', 'einsum',
         If provided, forces the calculation to use the data type specified.
         Note that you may have to also give a more liberal `casting`
         parameter to allow the conversions.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Controls the memory layout of the output. 'C' means it should
         be C contiguous. 'F' means it should be Fortran contiguous,
         'A' means it should be 'F' if the inputs are all 'F', 'C' otherwise.
@@ -3041,7 +3040,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('astype',
     ----------
     dtype : str or dtype
         Typecode or data-type to which the array is cast.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Controls the memory layout order of the result.
         'C' means C order, 'F' means Fortran order, 'A'
         means 'F' order if all the arrays are Fortran contiguous,
@@ -3104,12 +3103,12 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('byteswap',
 
     Parameters
     ----------
-    inplace: bool, optional
+    inplace : bool, optional
         If ``True``, swap bytes in-place, default is ``False``.
 
     Returns
     -------
-    out: ndarray
+    out : ndarray
         The byteswapped array. If `inplace` is ``True``, this is
         a view to self.
 
@@ -5022,7 +5021,6 @@ add_newdoc('numpy.lib._compiled_base', 'add_newdoc_ufunc',
 
     Notes
     -----
-
     This method allocates memory for new_docstring on
     the heap. Technically this creates a mempory leak, since this
     memory will not be reclaimed until the end of the program
@@ -5864,7 +5862,6 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('fields',
 
     Examples
     --------
-
     >>> dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
     >>> print dt.fields
     {'grades': (dtype(('float64',(2,))), 16), 'name': (dtype('|S16'), 0)}
@@ -5972,7 +5969,6 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('names',
 
     Examples
     --------
-
     >>> dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
     >>> dt.names
     ('name', 'grades')

--- a/numpy/build_utils/common.py
+++ b/numpy/build_utils/common.py
@@ -27,13 +27,14 @@ def pyod(filename):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         name of the file to get the dump from.
 
     Returns
     -------
-    out: seq
+    out : seq
         list of lines of od output
+
     Note
     ----
     We only implement enough to get the necessary information for long double

--- a/numpy/build_utils/common.py
+++ b/numpy/build_utils/common.py
@@ -25,13 +25,14 @@ def pyod(filename):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         name of the file to get the dump from.
 
     Returns
     -------
-    out: seq
+    out : seq
         list of lines of od output
+
     Note
     ----
     We only implement enough to get the necessary information for long double

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -399,7 +399,8 @@ def array2string(a, max_line_width=None, precision=None,
 
     Raises
     ------
-    TypeError : if a callable in `formatter` does not return a string.
+    TypeError
+        if a callable in `formatter` does not return a string.
 
     See Also
     --------

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -94,12 +94,11 @@ class Ufunc(object):
 
     Attributes
     ----------
-
-    nin: number of input arguments
-    nout: number of output arguments
-    identity: identity element for a two-argument function
-    docstring: docstring for the ufunc
-    type_descriptions: list of TypeDescription objects
+    nin : number of input arguments
+    nout : number of output arguments
+    identity : identity element for a two-argument function
+    docstring : docstring for the ufunc
+    type_descriptions : list of TypeDescription objects
     """
     def __init__(self, nin, nout, identity, docstring, typereso,
                  *type_descriptions):

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -96,12 +96,11 @@ class Ufunc(object):
 
     Attributes
     ----------
-
-    nin: number of input arguments
-    nout: number of output arguments
-    identity: identity element for a two-argument function
-    docstring: docstring for the ufunc
-    type_descriptions: list of TypeDescription objects
+    nin : number of input arguments
+    nout : number of output arguments
+    identity : identity element for a two-argument function
+    docstring : docstring for the ufunc
+    type_descriptions : list of TypeDescription objects
     """
     def __init__(self, nin, nout, identity, docstring, typereso,
                  *type_descriptions):

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2798,7 +2798,7 @@ add_newdoc('numpy.core.umath', 'signbit',
 
     Parameters
     ----------
-    x: array_like
+    x : array_like
         The input value(s).
     out : ndarray, optional
         Array into which the output is placed. Its type is preserved
@@ -2829,9 +2829,9 @@ add_newdoc('numpy.core.umath', 'copysign',
 
     Parameters
     ----------
-    x1: array_like
+    x1 : array_like
         Values to change the sign of.
-    x2: array_like
+    x2 : array_like
         The sign of `x2` is copied to `x1`.
     out : ndarray, optional
         Array into which the output is placed. Its type is preserved and it
@@ -2894,7 +2894,7 @@ add_newdoc('numpy.core.umath', 'spacing',
 
     Parameters
     ----------
-    x1: array_like
+    x1 : array_like
         Values to find the spacing of.
 
     Returns

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2800,7 +2800,7 @@ add_newdoc('numpy.core.umath', 'signbit',
 
     Parameters
     ----------
-    x: array_like
+    x : array_like
         The input value(s).
     out : ndarray, optional
         Array into which the output is placed. Its type is preserved
@@ -2831,9 +2831,9 @@ add_newdoc('numpy.core.umath', 'copysign',
 
     Parameters
     ----------
-    x1: array_like
+    x1 : array_like
         Values to change the sign of.
-    x2: array_like
+    x2 : array_like
         The sign of `x2` is copied to `x1`.
     out : ndarray, optional
         Array into which the output is placed. Its type is preserved and it
@@ -2896,7 +2896,7 @@ add_newdoc('numpy.core.umath', 'spacing',
 
     Parameters
     ----------
-    x1: array_like
+    x1 : array_like
         Values to find the spacing of.
 
     Returns

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -149,7 +149,6 @@ def reshape(a, newshape, order='C'):
 
     Notes
     -----
-
     It is not always possible to change the shape of an array without
     copying the data. If you want an error to be raise if the data is copied,
     you should assign the new shape to the shape attribute of the array::

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -136,7 +136,6 @@ def reshape(a, newshape, order='C'):
 
     Notes
     -----
-
     It is not always possible to change the shape of an array without
     copying the data. If you want an error to be raise if the data is copied,
     you should assign the new shape to the shape attribute of the array::

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -76,7 +76,7 @@ def zeros_like(a, dtype=None, order='K', subok=True):
         the returned array.
     dtype : data-type, optional
         Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Overrides the memory layout of the result. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
@@ -162,7 +162,7 @@ def ones_like(a, dtype=None, order='K', subok=True):
         the returned array.
     dtype : data-type, optional
         Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
+    order : {'C', 'F', 'A', 'K'}, optional
         Overrides the memory layout of the result. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -163,13 +163,14 @@ def pyod(filename):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         name of the file to get the dump from.
 
     Returns
     -------
-    out: seq
+    out : seq
         list of lines of od output
+
     Note
     ----
     We only implement enough to get the necessary information for long double

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -161,13 +161,14 @@ def pyod(filename):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         name of the file to get the dump from.
 
     Returns
     -------
-    out: seq
+    out : seq
         list of lines of od output
+
     Note
     ----
     We only implement enough to get the necessary information for long double

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -340,7 +340,7 @@ int main ()
 
         Arguments
         ---------
-        funcs: seq
+        funcs : seq
             list of functions to test
         include_dirs : seq
             list of header paths

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -339,7 +339,7 @@ int main ()
 
         Arguments
         ---------
-        funcs: seq
+        funcs : seq
             list of functions to test
         include_dirs : seq
             list of header paths

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -513,10 +513,13 @@ def manifest_rc(name, type='dll'):
     'exe').
 
     Parameters
-    ---------- name: str
+    ----------
+    name : str
             name of the manifest file to embed
-        type: str ('dll', 'exe')
-            type of the binary which will embed the manifest"""
+    type : str {'dll', 'exe'}
+            type of the binary which will embed the manifest
+
+    """
     if type == 'dll':
         rctype = 2
     elif type == 'exe':

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -512,10 +512,13 @@ def manifest_rc(name, type='dll'):
     'exe').
 
     Parameters
-    ---------- name: str
+    ----------
+    name : str
             name of the manifest file to embed
-        type: str ('dll', 'exe')
-            type of the binary which will embed the manifest"""
+    type : str {'dll', 'exe'}
+            type of the binary which will embed the manifest
+
+    """
     if type == 'dll':
         rctype = 2
     elif type == 'exe':

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -921,14 +921,14 @@ class Configuration(object):
 
         Parameters
         ----------
-        subpackage_name: str,None
+        subpackage_name : str or None
             Name of the subpackage to get the configuration. '*' in
             subpackage_name is handled as a wildcard.
-        subpackage_path: str
+        subpackage_path : str
             If None, then the path is assumed to be the local path plus the
             subpackage_name. If a setup.py file is not found in the
             subpackage_path, then a default configuration is used.
-        parent_name: str
+        parent_name : str
             Parent name.
         """
         if subpackage_name is None:
@@ -984,13 +984,13 @@ class Configuration(object):
 
         Parameters
         ----------
-        subpackage_name: str
+        subpackage_name : str
             name of the subpackage
-        subpackage_path: str
+        subpackage_path : str
             if given, the subpackage path such as the subpackage is in
             subpackage_path / subpackage_name. If None,the subpackage is
             assumed to be located in the local path / subpackage_name.
-        standalone: bool
+        standalone : bool
         """
 
         if standalone:
@@ -1028,10 +1028,10 @@ class Configuration(object):
 
         Parameters
         ----------
-        data_path: seq,str
+        data_path : seq or str
             Argument can be either
 
-                * 2-sequence (<datadir suffix>,<path to data directory>)
+                * 2-sequence (<datadir suffix>, <path to data directory>)
                 * path to data directory where python datadir suffix defaults
                   to package dir.
 
@@ -1150,7 +1150,7 @@ class Configuration(object):
 
         Parameters
         ----------
-        files: sequence
+        files : sequence
             Argument(s) can be either
 
                 * 2-sequence (<datadir prefix>,<path to data file(s)>)
@@ -1329,7 +1329,7 @@ class Configuration(object):
 
         Parameters
         ----------
-        files: str, seq
+        files : str or seq
             Argument(s) can be either:
 
                 * 2-sequence (<includedir suffix>,<path to header file(s)>)
@@ -1384,9 +1384,9 @@ class Configuration(object):
 
         Parameters
         ----------
-        name: str
+        name : str
             name of the extension
-        sources: seq
+        sources : seq
             list of the sources. The list of sources may contain functions
             (called source generators) which must take an extension instance
             and a build directory as inputs and return a source file or list of
@@ -1394,28 +1394,28 @@ class Configuration(object):
             generated. If the Extension instance has no sources after
             processing all source generators, then no extension module is
             built.
-        include_dirs:
-        define_macros:
-        undef_macros:
-        library_dirs:
-        libraries:
-        runtime_library_dirs:
-        extra_objects:
-        extra_compile_args:
-        extra_link_args:
-        extra_f77_compile_args:
-        extra_f90_compile_args:
-        export_symbols:
-        swig_opts:
-        depends:
+        include_dirs :
+        define_macros :
+        undef_macros :
+        library_dirs :
+        libraries :
+        runtime_library_dirs :
+        extra_objects :
+        extra_compile_args :
+        extra_link_args :
+        extra_f77_compile_args :
+        extra_f90_compile_args :
+        export_symbols :
+        swig_opts :
+        depends :
             The depends list contains paths to files or directories that the
             sources of the extension module depend on. If any path in the
             depends list is newer than the extension module, then the module
             will be rebuilt.
-        language:
-        f2py_options:
-        module_dirs:
-        extra_info: dict,list
+        language :
+        f2py_options :
+        module_dirs :
+        extra_info : dict or list
             dict or list of dict of keywords to be appended to keywords.
 
         Notes

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -878,14 +878,14 @@ class Configuration(object):
 
         Parameters
         ----------
-        subpackage_name: str,None
+        subpackage_name : str or None
             Name of the subpackage to get the configuration. '*' in
             subpackage_name is handled as a wildcard.
-        subpackage_path: str
+        subpackage_path : str
             If None, then the path is assumed to be the local path plus the
             subpackage_name. If a setup.py file is not found in the
             subpackage_path, then a default configuration is used.
-        parent_name: str
+        parent_name : str
             Parent name.
         """
         if subpackage_name is None:
@@ -941,13 +941,13 @@ class Configuration(object):
 
         Parameters
         ----------
-        subpackage_name: str
+        subpackage_name : str
             name of the subpackage
-        subpackage_path: str
+        subpackage_path : str
             if given, the subpackage path such as the subpackage is in
             subpackage_path / subpackage_name. If None,the subpackage is
             assumed to be located in the local path / subpackage_name.
-        standalone: bool
+        standalone : bool
         """
 
         if standalone:
@@ -985,10 +985,10 @@ class Configuration(object):
 
         Parameters
         ----------
-        data_path: seq,str
+        data_path : seq or str
             Argument can be either
 
-                * 2-sequence (<datadir suffix>,<path to data directory>)
+                * 2-sequence (<datadir suffix>, <path to data directory>)
                 * path to data directory where python datadir suffix defaults
                   to package dir.
 
@@ -1107,7 +1107,7 @@ class Configuration(object):
 
         Parameters
         ----------
-        files: sequence
+        files : sequence
             Argument(s) can be either
 
                 * 2-sequence (<datadir prefix>,<path to data file(s)>)
@@ -1286,7 +1286,7 @@ class Configuration(object):
 
         Parameters
         ----------
-        files: str, seq
+        files : str or seq
             Argument(s) can be either:
 
                 * 2-sequence (<includedir suffix>,<path to header file(s)>)
@@ -1341,9 +1341,9 @@ class Configuration(object):
 
         Parameters
         ----------
-        name: str
+        name : str
             name of the extension
-        sources: seq
+        sources : seq
             list of the sources. The list of sources may contain functions
             (called source generators) which must take an extension instance
             and a build directory as inputs and return a source file or list of
@@ -1351,28 +1351,28 @@ class Configuration(object):
             generated. If the Extension instance has no sources after
             processing all source generators, then no extension module is
             built.
-        include_dirs:
-        define_macros:
-        undef_macros:
-        library_dirs:
-        libraries:
-        runtime_library_dirs:
-        extra_objects:
-        extra_compile_args:
-        extra_link_args:
-        extra_f77_compile_args:
-        extra_f90_compile_args:
-        export_symbols:
-        swig_opts:
-        depends:
+        include_dirs :
+        define_macros :
+        undef_macros :
+        library_dirs :
+        libraries :
+        runtime_library_dirs :
+        extra_objects :
+        extra_compile_args :
+        extra_link_args :
+        extra_f77_compile_args :
+        extra_f90_compile_args :
+        export_symbols :
+        swig_opts :
+        depends :
             The depends list contains paths to files or directories that the
             sources of the extension module depend on. If any path in the
             depends list is newer than the extension module, then the module
             will be rebuilt.
-        language:
-        f2py_options:
-        module_dirs:
-        extra_info: dict,list
+        language :
+        f2py_options :
+        module_dirs :
+        extra_info : dict or list
             dict or list of dict of keywords to be appended to keywords.
 
         Notes

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -87,7 +87,8 @@ def has_nested_fields(ndtype):
 
     Raises
     ------
-    AttributeError : If `ndtype` does not have a `names` attribute.
+    AttributeError
+        If `ndtype` does not have a `names` attribute.
 
     Examples
     --------
@@ -267,7 +268,7 @@ class NameValidator(object):
         * If 'lower', field names are converted to lower case.
 
         The default value is True.
-    replace_space: '_', optional
+    replace_space : '_', optional
         Character(s) used in replacement of white spaces.
 
     Notes

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -617,10 +617,10 @@ def pad(array, pad_width, mode=None, **kwargs):
 
     where
 
-        vector: ndarray
+        vector : ndarray
             A rank 1 array already padded with zeros.  Padded values are
             vector[:pad_tuple[0]] and vector[-pad_tuple[1]:].
-        iaxis_pad_width: tuple
+        iaxis_pad_width : tuple
             A 2-tuple of ints, iaxis_pad_width[0] represents the number of
             values padded at the beginning of vector where
             iaxis_pad_width[1] represents the number of values padded at

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -619,10 +619,10 @@ def pad(array, pad_width, mode=None, **kwargs):
 
     where
 
-        vector: ndarray
+        vector : ndarray
             A rank 1 array already padded with zeros.  Padded values are
             vector[:pad_tuple[0]] and vector[-pad_tuple[1]:].
-        iaxis_pad_width: tuple
+        iaxis_pad_width : tuple
             A 2-tuple of ints, iaxis_pad_width[0] represents the number of
             values padded at the beginning of vector where
             iaxis_pad_width[1] represents the number of values padded at

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -311,7 +311,7 @@ def read_array_header_1_0(fp):
 
     Raises
     ------
-    ValueError :
+    ValueError
         If the data is invalid.
 
     """

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2910,7 +2910,7 @@ def median(a, axis=None, out=None, overwrite_input=False):
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,
         but the type (of the output) will be cast if necessary.
-    overwrite_input : bool optional
+    overwrite_input : bool, optional
        If True, then allow use of memory of input array (a) for
        calculations. The input array will be modified by the call to
        median. This will save memory when you do not need to preserve

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2917,7 +2917,7 @@ def median(a, axis=None, out=None, overwrite_input=False):
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,
         but the type (of the output) will be cast if necessary.
-    overwrite_input : bool optional
+    overwrite_input : bool, optional
        If True, then allow use of memory of input array (a) for
        calculations. The input array will be modified by the call to
        median. This will save memory when you do not need to preserve

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -649,7 +649,8 @@ def fill_diagonal(a, val, wrap=False):
       Value to be written on the diagonal, its type must be compatible with
       that of the array a.
 
-    wrap: bool For tall matrices in NumPy version up to 1.6.2, the
+    wrap : bool 
+      For tall matrices in NumPy version up to 1.6.2, the
       diagonal "wrapped" after N columns. You can have this behavior
       with this option. This affect only tall matrices.
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -675,7 +675,8 @@ def fill_diagonal(a, val, wrap=False):
       Value to be written on the diagonal, its type must be compatible with
       that of the array a.
 
-    wrap: bool For tall matrices in NumPy version up to 1.6.2, the
+    wrap : bool 
+      For tall matrices in NumPy version up to 1.6.2, the
       diagonal "wrapped" after N columns. You can have this behavior
       with this option. This affect only tall matrices.
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -283,7 +283,7 @@ def load(file, mmap_mode=None):
     file : file-like object or string
         The file to read.  It must support ``seek()`` and ``read()`` methods.
         If the filename extension is ``.gz``, the file is first decompressed.
-    mmap_mode: {None, 'r+', 'r', 'w+', 'c'}, optional
+    mmap_mode : {None, 'r+', 'r', 'w+', 'c'}, optional
         If not None, then memory-map the file, using the given mode
         (see `numpy.memmap` for a detailed description of the modes).
         A memory-mapped array is kept on disk. However, it can be accessed

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -169,7 +169,7 @@ def roots(p):
 
     Raises
     ------
-    ValueError :
+    ValueError
         When `p` cannot be converted to a rank-1 array.
 
     See also

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -679,12 +679,10 @@ def kron(a,b):
 
     See Also
     --------
-
     outer : The outer product
 
     Notes
     -----
-
     The function assumes that the number of dimenensions of `a` and `b`
     are the same, if necessary prepending the smallest with ones.
     If `a.shape = (r0,r1,..,rN)` and `b.shape = (s0,s1,...,sN)`,

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -681,12 +681,10 @@ def kron(a,b):
 
     See Also
     --------
-
     outer : The outer product
 
     Notes
     -----
-
     The function assumes that the number of dimenensions of `a` and `b`
     are the same, if necessary prepending the smallest with ones.
     If `a.shape = (r0,r1,..,rN)` and `b.shape = (s0,s1,...,sN)`,

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -833,7 +833,7 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
         Module for which to generate docstring cache
     import_modules : bool
         Whether to import sub-modules in packages.
-    regenerate: bool
+    regenerate : bool
         Re-generate the docstring cache
 
     Returns

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -835,7 +835,7 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
         Module for which to generate docstring cache
     import_modules : bool
         Whether to import sub-modules in packages.
-    regenerate: bool
+    regenerate : bool
         Re-generate the docstring cache
 
     Returns

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1530,7 +1530,7 @@ def make_mask_none(newshape, dtype=None):
     ----------
     newshape : tuple
         A tuple indicating the shape of the mask.
-    dtype: {None, dtype}, optional
+    dtype : {None, dtype}, optional
         If None, use a MaskType instance. Otherwise, use a new datatype with
         the same fields as `dtype`, converted to boolean types.
 
@@ -5650,7 +5650,7 @@ class mvoid(MaskedArray):
 
         Returns
         -------
-        filled_void:
+        filled_void
             A `np.void` object
 
         See Also

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -630,7 +630,6 @@ def getdata(a, subok=True):
 
     Examples
     --------
-
     >>> import numpy.ma as ma
     >>> a = ma.masked_equal([[1,2],[3,4]], 2)
     >>> a
@@ -1263,7 +1262,6 @@ def getmask(a):
 
     Examples
     --------
-
     >>> import numpy.ma as ma
     >>> a = ma.masked_equal([[1,2],[3,4]], 2)
     >>> a
@@ -1325,7 +1323,6 @@ def getmaskarray(arr):
 
     Examples
     --------
-
     >>> import numpy.ma as ma
     >>> a = ma.masked_equal([[1,2],[3,4]], 2)
     >>> a

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -628,7 +628,6 @@ def getdata(a, subok=True):
 
     Examples
     --------
-
     >>> import numpy.ma as ma
     >>> a = ma.masked_equal([[1,2],[3,4]], 2)
     >>> a
@@ -1261,7 +1260,6 @@ def getmask(a):
 
     Examples
     --------
-
     >>> import numpy.ma as ma
     >>> a = ma.masked_equal([[1,2],[3,4]], 2)
     >>> a
@@ -1323,7 +1321,6 @@ def getmaskarray(arr):
 
     Examples
     --------
-
     >>> import numpy.ma as ma
     >>> a = ma.masked_equal([[1,2],[3,4]], 2)
     >>> a

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1296,7 +1296,7 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
 
     Raises
     ------
-    ValueError:
+    ValueError
         Raised if some values are missing and `allow_masked` is False.
 
     See Also

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -586,9 +586,9 @@ class matrix(N.ndarray):
 
         Parameters
         ----------
-        axis: int, optional
+        axis : int, optional
             Axis along which logical OR is performed
-        out: ndarray, optional
+        out : ndarray, optional
             Output to existing array instead of creating new one, must have
             same shape as expected output
 

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -588,9 +588,9 @@ class matrix(N.ndarray):
 
         Parameters
         ----------
-        axis: int, optional
+        axis : int, optional
             Axis along which logical OR is performed
-        out: ndarray, optional
+        out : ndarray, optional
             Output to existing array instead of creating new one, must have
             same shape as expected output
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -878,7 +878,7 @@ def chebder(c, m=1, scl=1, axis=0) :
 
     Parameters
     ----------
-    c: array_like
+    c : array_like
         Array of Chebyshev series coefficients. If c is multidimensional
         the different axis correspond to different variables with the
         degree in each axis given by the corresponding index.
@@ -1437,7 +1437,7 @@ def chebvander(x, deg) :
 
     Returns
     -------
-    vander: ndarray
+    vander : ndarray
         The pseudo Vandermonde matrix. The shape of the returned matrix is
         ``x.shape + (deg + 1,)``, where The last index is the degree of the
         corresponding Chebyshev polynomial.  The dtype will be the same as

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1201,7 +1201,7 @@ def hermvander(x, deg) :
 
     Returns
     -------
-    vander: ndarray
+    vander : ndarray
         The pseudo-Vandermonde matrix. The shape of the returned matrix is
         ``x.shape + (deg + 1,)``, where The last index is the degree of the
         corresponding Hermite polynomial.  The dtype will be the same as

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -646,7 +646,7 @@ def hermeder(c, m=1, scl=1, axis=0) :
 
     Parameters
     ----------
-    c: array_like
+    c : array_like
         Array of Hermite_e series coefficients. If `c` is multidimensional
         the different axis correspond to different variables with the
         degree in each axis given by the corresponding index.
@@ -1198,7 +1198,7 @@ def hermevander(x, deg) :
 
     Returns
     -------
-    vander: ndarray
+    vander : ndarray
         The pseudo-Vandermonde matrix. The shape of the returned matrix is
         ``x.shape + (deg + 1,)``, where The last index is the degree of the
         corresponding HermiteE polynomial.  The dtype will be the same as

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -644,7 +644,7 @@ def lagder(c, m=1, scl=1, axis=0) :
 
     Parameters
     ----------
-    c: array_like
+    c : array_like
         Array of Laguerre series coefficients. If `c` is multidimensional
         the different axis correspond to different variables with the
         degree in each axis given by the corresponding index.
@@ -1201,7 +1201,7 @@ def lagvander(x, deg) :
 
     Returns
     -------
-    vander: ndarray
+    vander : ndarray
         The pseudo-Vandermonde matrix. The shape of the returned matrix is
         ``x.shape + (deg + 1,)``, where The last index is the degree of the
         corresponding Laguerre polynomial.  The dtype will be the same as

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1238,7 +1238,7 @@ def legvander(x, deg) :
 
     Returns
     -------
-    vander: ndarray
+    vander : ndarray
         The pseudo-Vandermonde matrix. The shape of the returned matrix is
         ``x.shape + (deg + 1,)``, where The last index is the degree of the
         corresponding Legendre polynomial.  The dtype will be the same as

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -485,7 +485,7 @@ def polyder(c, m=1, scl=1, axis=0):
 
     Parameters
     ----------
-    c: array_like
+    c : array_like
         Array of polynomial coefficients. If c is multidimensional the
         different axis correspond to different variables with the degree
         in each axis given by the corresponding index.

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -138,7 +138,7 @@ def as_series(alist, trim=True) :
 
     Raises
     ------
-    ValueError :
+    ValueError
         Raised when `as_series` cannot convert its input to 1-d arrays, or at
         least one of the resulting arrays is empty.
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1808,7 +1808,6 @@ cdef class RandomState:
 
         Notes
         -----
-
         The F statistic is used to compare in-group variances to between-group
         variances. Calculating the distribution depends on the sampling, and
         so it is a function of the respective degrees of freedom in the

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1839,7 +1839,6 @@ cdef class RandomState:
 
         Notes
         -----
-
         The F statistic is used to compare in-group variances to between-group
         variances. Calculating the distribution depends on the sampling, and
         so it is a function of the respective degrees of freedom in the

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1296,7 +1296,7 @@ def nulp_diff(x, y, dtype=None):
 
     Returns
     -------
-    nulp: array_like
+    nulp : array_like
         number of representable floating point numbers between each item in x
         and y.
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1298,7 +1298,7 @@ def nulp_diff(x, y, dtype=None):
 
     Returns
     -------
-    nulp: array_like
+    nulp : array_like
         number of representable floating point numbers between each item in x
         and y.
 


### PR DESCRIPTION
Used a regex to find colons missing spaces before them, which render incorrectly on the web documentation ([example](http://docs.scipy.org/doc/numpy/reference/generated/numpy.polynomial.hermite_e.hermeder.html#numpy.polynomial.hermite_e.hermeder)), and also other spacing or formatting issues I saw in the process
