### PR TITLE
Create ufunc for struct array

### DIFF
--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -140,13 +140,15 @@ Functions
     in as *arg_types* which must be a pointer to memory at least as
     large as ufunc->nargs.
 
-.. cfunction:: int PyUFunc_RegisterLoopForStructType(PyUFuncObject* ufunc,
+.. cfunction:: int PyUFunc_RegisterLoopByDescr(PyUFuncObject* ufunc,
    PyArray_Descr* userdtype, PyUFuncGenericFunction function,
    PyArray_Descr** arg_dtypes, void* data)
 
    This function behaves like PyUFunc_RegisterLoopForType above, except
-   that it allows the user to register a 1-d loop for structured array
-   data-dtypes instead of scalar data-types.
+   that it allows the user to register a 1-d loop using PyArray_Descr
+   objects instead of dtype type num values. This allows a 1-d loop to be
+   registered for structured array data-dtypes and custom data-types
+   instead of scalar data-types.
 
 .. cfunction:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc,
    PyUFuncGenericFunction newfunc, int* signature,

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -140,6 +140,14 @@ Functions
     in as *arg_types* which must be a pointer to memory at least as
     large as ufunc->nargs.
 
+.. cfunction:: int PyUFunc_RegisterLoopForStructType(PyUFuncObject* ufunc,
+   PyArray_Descr* userdtype, PyUFuncGenericFunction function,
+   PyArray_Descr** arg_dtypes, void* data)
+
+   This function behaves like PyUFunc_RegisterLoopForType above, except
+   that it allows the user to register a 1-d loop for structured array
+   data-dtypes instead of scalar data-types.
+
 .. cfunction:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc,
    PyUFuncGenericFunction newfunc, int* signature,
    PyUFuncGenericFunction* oldfunc)

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -140,7 +140,7 @@ Functions
     in as *arg_types* which must be a pointer to memory at least as
     large as ufunc->nargs.
 
-.. cfunction:: int PyUFunc_RegisterLoopByDescr(PyUFuncObject* ufunc,
+.. cfunction:: int PyUFunc_RegisterLoopForDescr(PyUFuncObject* ufunc,
    PyArray_Descr* userdtype, PyUFuncGenericFunction function,
    PyArray_Descr** arg_dtypes, void* data)
 

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -895,7 +895,7 @@ For the example we show a trivial ufunc for adding two arrays with dtype
 'u8,u8,u8'. The process is a bit different from the other examples since
 a call to PyUFunc_FromFuncAndData doesn't fully register ufuncs for
 custom dtypes and structured array dtypes. We need to also call
-PyUFunc_RegisterLoopByDescr to finish setting up the ufunc.
+PyUFunc_RegisterLoopForDescr to finish setting up the ufunc.
 
 We only give the C code as the setup.py file is exactly the same as
 the setup.py file in `Example Numpy ufunc for one dtype`_, except that
@@ -1033,7 +1033,7 @@ The C file is given below.
             dtypes[2] = dtype;
 
             /* Register ufunc for structured dtype */
-            PyUFunc_RegisterLoopByDescr(add_triplet,
+            PyUFunc_RegisterLoopForDescr(add_triplet,
                                         dtype,
                                         &add_uint64_triplet,
                                         dtypes,

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -895,7 +895,7 @@ For the example we show a trivial ufunc for adding two arrays with dtype
 'u8,u8,u8'. The process is a bit different from the other examples since
 a call to PyUFunc_FromFuncAndData doesn't fully register ufuncs for
 custom dtypes and structured array dtypes. We need to also call
-PyUFunc_RegisterLoopForStructType to finish setting up the ufunc.
+PyUFunc_RegisterLoopByDescr to finish setting up the ufunc.
 
 We only give the C code as the setup.py file is exactly the same as
 the setup.py file in `Example Numpy ufunc for one dtype`_, except that
@@ -1033,11 +1033,11 @@ The C file is given below.
             dtypes[2] = dtype;
 
             /* Register ufunc for structured dtype */
-            PyUFunc_RegisterLoopForStructType(add_triplet,
-                                              dtype,
-                                              &add_uint64_triplet,
-                                              dtypes,
-                                              NULL);
+            PyUFunc_RegisterLoopByDescr(add_triplet,
+                                        dtype,
+                                        &add_uint64_triplet,
+                                        dtypes,
+                                        NULL);
 
             d = PyModule_GetDict(m);
 

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -884,6 +884,171 @@ as well as all other properties of a ufunc.
         }
         #endif
 
+
+.. _`sec:Numpy-struct-dtype`:
+
+Example Numpy ufunc with structured array dtype arguments
+=========================================================
+
+This example shows how to create a ufunc for a structured array dtype.
+For the example we show a trivial ufunc for adding two arrays with dtype
+'u8,u8,u8'. The process is a bit different from the other examples since
+a call to PyUFunc_FromFuncAndData doesn't fully register ufuncs for
+custom dtypes and structured array dtypes. We need to also call
+PyUFunc_RegisterLoopForStructType to finish setting up the ufunc.
+
+We only give the C code as the setup.py file is exactly the same as
+the setup.py file in `Example Numpy ufunc for one dtype`_, except that
+the line
+
+    .. code-block:: python
+
+        config.add_extension('npufunc', ['single_type_logit.c'])
+
+is replaced with
+
+    .. code-block:: python
+
+        config.add_extension('npufunc', ['add_triplet.c'])
+
+The C file is given below.
+
+    .. code-block:: c
+
+        #include "Python.h"
+        #include "math.h"
+        #include "numpy/ndarraytypes.h"
+        #include "numpy/ufuncobject.h"
+        #include "numpy/npy_3kcompat.h"
+
+
+        /*
+         * add_triplet.c
+         * This is the C code for creating your own
+         * Numpy ufunc for a structured array dtype.
+         *
+         * Details explaining the Python-C API can be found under
+         * 'Extending and Embedding' and 'Python/C API' at
+         * docs.python.org .
+         */
+
+        static PyMethodDef StructUfuncTestMethods[] = {
+            {NULL, NULL, 0, NULL}
+        };
+
+        /* The loop definition must precede the PyMODINIT_FUNC. */
+
+        static void add_uint64_triplet(char **args, npy_intp *dimensions,
+                                    npy_intp* steps, void* data)
+        {
+            npy_intp i;
+            npy_intp is1=steps[0];
+            npy_intp is2=steps[1];
+            npy_intp os=steps[2];
+            npy_intp n=dimensions[0];
+            uint64_t *x, *y, *z;
+
+            char *i1=args[0];
+            char *i2=args[1];
+            char *op=args[2];
+
+            for (i = 0; i < n; i++) {
+
+                x = (uint64_t*)i1;
+                y = (uint64_t*)i2;
+                z = (uint64_t*)op;
+
+                z[0] = x[0] + y[0];
+                z[1] = x[1] + y[1];
+                z[2] = x[2] + y[2];
+
+                i1 += is1;
+                i2 += is2;
+                op += os;
+            }
+        }
+
+        /* This a pointer to the above function */
+        PyUFuncGenericFunction funcs[1] = {&add_uint64_triplet};
+
+        /* These are the input and return dtypes of add_uint64_triplet. */
+        static char types[3] = {NPY_UINT64, NPY_UINT64, NPY_UINT64};
+
+        static void *data[1] = {NULL};
+
+        #if defined(NPY_PY3K)
+        static struct PyModuleDef moduledef = {
+            PyModuleDef_HEAD_INIT,
+            "struct_ufunc_test",
+            NULL,
+            -1,
+            StructUfuncTestMethods,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+        };
+        #endif
+
+        #if defined(NPY_PY3K)
+        PyMODINIT_FUNC PyInit_struct_ufunc_test(void)
+        #else
+        PyMODINIT_FUNC initstruct_ufunc_test(void)
+        #endif
+        {
+            PyObject *m, *add_triplet, *d;
+            PyObject *dtype_dict;
+            PyArray_Descr *dtype;
+            PyArray_Descr *dtypes[3];
+
+        #if defined(NPY_PY3K)
+            m = PyModule_Create(&moduledef);
+        #else
+            m = Py_InitModule("struct_ufunc_test", StructUfuncTestMethods);
+        #endif
+
+            if (m == NULL) {
+        #if defined(NPY_PY3K)
+                return NULL;
+        #else
+                return;
+        #endif
+            }
+
+            import_array();
+            import_umath();
+
+            /* Create a new ufunc object */
+            add_triplet = PyUFunc_FromFuncAndData(NULL, NULL, NULL, 0, 2, 1,
+                                            PyUFunc_None, "add_triplet",
+                                            "add_triplet_docstring", 0);
+
+            dtype_dict = Py_BuildValue("[(s, s), (s, s), (s, s)]",
+                "f0", "u8", "f1", "u8", "f2", "u8");
+            PyArray_DescrConverter(dtype_dict, &dtype);
+            Py_DECREF(dtype_dict);
+
+            dtypes[0] = dtype;
+            dtypes[1] = dtype;
+            dtypes[2] = dtype;
+
+            /* Register ufunc for structured dtype */
+            PyUFunc_RegisterLoopForStructType(add_triplet,
+                                              dtype,
+                                              &add_uint64_triplet,
+                                              dtypes,
+                                              NULL);
+
+            d = PyModule_GetDict(m);
+
+            PyDict_SetItemString(d, "add_triplet", add_triplet);
+            Py_DECREF(add_triplet);
+        #if defined(NPY_PY3K)
+            return m;
+        #endif
+        }
+
+
 .. _`sec:PyUFunc-spec`:
 
 PyUFunc_FromFuncAndData Specification

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -384,7 +384,7 @@ ufunc_funcs_api = {
     # End 1.6 API
     'PyUFunc_DefaultTypeResolver':              39,
     'PyUFunc_ValidateCasting':                  40,
-    'PyUFunc_RegisterLoopForStructType':        41,
+    'PyUFunc_RegisterLoopByDescr':              41,
 }
 
 # List of all the dicts which define the C API

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -384,7 +384,7 @@ ufunc_funcs_api = {
     # End 1.6 API
     'PyUFunc_DefaultTypeResolver':              39,
     'PyUFunc_ValidateCasting':                  40,
-    'PyUFunc_RegisterLoopByDescr':              41,
+    'PyUFunc_RegisterLoopForDescr':             41,
 }
 
 # List of all the dicts which define the C API

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -384,6 +384,7 @@ ufunc_funcs_api = {
     # End 1.6 API
     'PyUFunc_DefaultTypeResolver':              39,
     'PyUFunc_ValidateCasting':                  40,
+    'PyUFunc_RegisterLoopForStructType':        41,
 }
 
 # List of all the dicts which define the C API

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -319,6 +319,8 @@ typedef struct _loop1d_info {
         void *data;
         int *arg_types;
         struct _loop1d_info *next;
+        int nargs;
+        PyArray_Descr **arg_dtypes;
 } PyUFunc_Loop1d;
 
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -929,6 +929,13 @@ def configuration(parent_package='',top_path=None):
                     sources = [join('src','umath', 'test_rational.c.src')])
 
     #######################################################################
+    #                        struct_ufunc_test module                     #
+    #######################################################################
+
+    config.add_extension('struct_ufunc_test',
+                    sources = [join('src','umath', 'struct_ufunc_test.c.src')])
+
+    #######################################################################
     #                     multiarray_tests module                         #
     #######################################################################
 

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -48,7 +48,7 @@ static char types[3] = {NPY_UINT64, NPY_UINT64, NPY_UINT64};
 
 static void *data[1] = {NULL};
 
-#if PY_VERSION_HEX >= 0x03000000
+#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "struct_ufunc_test",
@@ -60,40 +60,31 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
+#endif
 
-PyObject *PyInit_struct_ufunc_test(void)
-{
-    PyObject *m, *add_triplet, *d;
-    m = PyModule_Create(&moduledef);
-    if (!m) {
-        return NULL;
-    }
-
-    import_array();
-    import_umath();
-
-    add_triplet = PyUFunc_FromFuncAndData(funcs, data, types, 1, 2, 1,
-                                    PyUFunc_None, "add_triplet",
-                                    "add_triplet_docstring", 0);
-
-    d = PyModule_GetDict(m);
-
-    PyDict_SetItemString(d, "add_triplet", add_triplet);
-    Py_DECREF(add_triplet);
-
-    return m;
-}
+#if defined(NPY_PY3K)
+PyMODINIT_FUNC PyInit_struct_ufunc_test(void)
 #else
 PyMODINIT_FUNC initstruct_ufunc_test(void)
+#endif
 {
     PyObject *m, *add_triplet, *d;
     PyObject *dtype_dict;
     PyArray_Descr *dtype;
     PyArray_Descr *dtypes[3];
 
+#if defined(NPY_PY3K)
+    m = PyModule_Create(&moduledef);
+#else
     m = Py_InitModule("struct_ufunc_test", StructUfuncTestMethods);
+#endif
+
     if (m == NULL) {
+#if defined(NPY_PY3K)
+        return NULL;
+#else
         return;
+#endif
     }
 
     import_array();
@@ -122,5 +113,7 @@ PyMODINIT_FUNC initstruct_ufunc_test(void)
 
     PyDict_SetItemString(d, "add_triplet", add_triplet);
     Py_DECREF(add_triplet);
-}
+#if defined(NPY_PY3K)
+    return m;
 #endif
+}

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -4,8 +4,19 @@
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_3kcompat.h"
 
+
+/*
+ * struct_ufunc_test.c
+ * This is the C code for creating your own
+ * Numpy ufunc for a structured array dtype.
+ *
+ * Details explaining the Python-C API can be found under
+ * 'Extending and Embedding' and 'Python/C API' at
+ * docs.python.org .
+ */
+
 static PyMethodDef StructUfuncTestMethods[] = {
-    {0} /* sentinel */
+    {NULL, NULL, 0, NULL}
 };
 
 /* The loop definition must precede the PyMODINIT_FUNC. */

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -1,0 +1,126 @@
+#include "Python.h"
+#include "math.h"
+#include "numpy/ndarraytypes.h"
+#include "numpy/ufuncobject.h"
+#include "numpy/npy_3kcompat.h"
+
+static PyMethodDef StructUfuncTestMethods[] = {
+    {0} /* sentinel */
+};
+
+/* The loop definition must precede the PyMODINIT_FUNC. */
+
+static void add_uint64_triplet(char **args, npy_intp *dimensions,
+                            npy_intp* steps, void* data)
+{
+    npy_intp i;
+    npy_intp is1=steps[0];
+    npy_intp is2=steps[1];
+    npy_intp os=steps[2];
+    npy_intp n=dimensions[0];
+    uint64_t *x, *y, *z;
+
+    char *i1=args[0];
+    char *i2=args[1];
+    char *op=args[2];
+
+    for (i = 0; i < n; i++) {
+
+        x = (uint64_t*)i1;
+        y = (uint64_t*)i2;
+        z = (uint64_t*)op;
+
+        z[0] = x[0] + y[0];
+        z[1] = x[1] + y[1];
+        z[2] = x[2] + y[2];
+
+        i1 += is1;
+        i2 += is2;
+        op += os;
+    }
+}
+
+/* This a pointer to the above function */
+PyUFuncGenericFunction funcs[1] = {&add_uint64_triplet};
+
+/* These are the input and return dtypes of add_uint64_triplet. */
+static char types[3] = {NPY_UINT64, NPY_UINT64, NPY_UINT64};
+
+static void *data[1] = {NULL};
+
+#if PY_VERSION_HEX >= 0x03000000
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "struct_ufunc_test",
+    NULL,
+    -1,
+    StructUfuncTestMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyObject *PyInit_struct_ufunc_test(void)
+{
+    PyObject *m, *add_triplet, *d;
+    m = PyModule_Create(&moduledef);
+    if (!m) {
+        return NULL;
+    }
+
+    import_array();
+    import_umath();
+
+    add_triplet = PyUFunc_FromFuncAndData(funcs, data, types, 1, 2, 1,
+                                    PyUFunc_None, "add_triplet",
+                                    "add_triplet_docstring", 0);
+
+    d = PyModule_GetDict(m);
+
+    PyDict_SetItemString(d, "add_triplet", add_triplet);
+    Py_DECREF(add_triplet);
+
+    return m;
+}
+#else
+PyMODINIT_FUNC initstruct_ufunc_test(void)
+{
+    PyObject *m, *add_triplet, *d;
+    PyObject *dtype_dict;
+    PyArray_Descr *dtype;
+    PyArray_Descr *dtypes[3];
+
+    m = Py_InitModule("struct_ufunc_test", StructUfuncTestMethods);
+    if (m == NULL) {
+        return;
+    }
+
+    import_array();
+    import_umath();
+
+    add_triplet = PyUFunc_FromFuncAndData(NULL, NULL, NULL, 0, 2, 1,
+                                    PyUFunc_None, "add_triplet",
+                                    "add_triplet_docstring", 0);
+
+    dtype_dict = Py_BuildValue("[(s, s), (s, s), (s, s)]",
+        "f0", "u8", "f1", "u8", "f2", "u8");
+    PyArray_DescrConverter(dtype_dict, &dtype);
+    Py_DECREF(dtype_dict);
+
+    dtypes[0] = dtype;
+    dtypes[1] = dtype;
+    dtypes[2] = dtype;
+
+    PyUFunc_RegisterLoopForStructType(add_triplet,
+                                      dtype,
+                                      &add_uint64_triplet,
+                                      dtypes,
+                                      NULL);
+
+    d = PyModule_GetDict(m);
+
+    PyDict_SetItemString(d, "add_triplet", add_triplet);
+    Py_DECREF(add_triplet);
+}
+#endif

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -106,7 +106,7 @@ PyMODINIT_FUNC initstruct_ufunc_test(void)
     dtypes[1] = dtype;
     dtypes[2] = dtype;
 
-    PyUFunc_RegisterLoopByDescr(add_triplet,
+    PyUFunc_RegisterLoopForDescr(add_triplet,
                                 dtype,
                                 &add_uint64_triplet,
                                 dtypes,

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -51,14 +51,6 @@ static void add_uint64_triplet(char **args, npy_intp *dimensions,
     }
 }
 
-/* This a pointer to the above function */
-PyUFuncGenericFunction funcs[1] = {&add_uint64_triplet};
-
-/* These are the input and return dtypes of add_uint64_triplet. */
-static char types[3] = {NPY_UINT64, NPY_UINT64, NPY_UINT64};
-
-static void *data[1] = {NULL};
-
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -106,11 +106,11 @@ PyMODINIT_FUNC initstruct_ufunc_test(void)
     dtypes[1] = dtype;
     dtypes[2] = dtype;
 
-    PyUFunc_RegisterLoopForStructType(add_triplet,
-                                      dtype,
-                                      &add_uint64_triplet,
-                                      dtypes,
-                                      NULL);
+    PyUFunc_RegisterLoopByDescr(add_triplet,
+                                dtype,
+                                &add_uint64_triplet,
+                                dtypes,
+                                NULL);
 
     d = PyModule_GetDict(m);
 

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1322,7 +1322,7 @@ PyMODINIT_FUNC inittest_rational(void) {
         PyModule_AddObject(m,"test_add",(PyObject*)ufunc);
     }
 
-    /* Create test ufunc with rational types using RegisterLoopByDescr */
+    /* Create test ufunc with rational types using RegisterLoopForDescr */
     {
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
             PyUFunc_None,(char*)"test_add_rationals",
@@ -1333,7 +1333,7 @@ PyMODINIT_FUNC inittest_rational(void) {
         PyArray_Descr* types[3] = {&npyrational_descr,
                                     &npyrational_descr,
                                     &npyrational_descr};
-        if (PyUFunc_RegisterLoopByDescr((PyUFuncObject*)ufunc, &npyrational_descr,
+        if (PyUFunc_RegisterLoopForDescr((PyUFuncObject*)ufunc, &npyrational_descr,
                 rational_ufunc_test_add_rationals, types, 0) < 0) {
             goto fail;
         }

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1323,20 +1323,22 @@ PyMODINIT_FUNC inittest_rational(void) {
     }
 
     /* Create test ufunc with rational types using RegisterLoopByDescr */
-    PyObject* ufunc2 = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
-        PyUFunc_None,(char*)"test_add_rationals",
-        (char*)"add two matrices of rationals and return rational matrix",0);
-    if (!ufunc) {
-        goto fail;
+    {
+        PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
+            PyUFunc_None,(char*)"test_add_rationals",
+            (char*)"add two matrices of rationals and return rational matrix",0);
+        if (!ufunc) {
+            goto fail;
+        }
+        PyArray_Descr* types[3] = {&npyrational_descr,
+                                    &npyrational_descr,
+                                    &npyrational_descr};
+        if (PyUFunc_RegisterLoopByDescr((PyUFuncObject*)ufunc, &npyrational_descr,
+                rational_ufunc_test_add_rationals, types, 0) < 0) {
+            goto fail;
+        }
+        PyModule_AddObject(m,"test_add_rationals",(PyObject*)ufunc);
     }
-    PyArray_Descr* types4[3] = {&npyrational_descr,
-                                &npyrational_descr,
-                                &npyrational_descr};
-    if (PyUFunc_RegisterLoopByDescr((PyUFuncObject*)ufunc, &npyrational_descr,
-            rational_ufunc_test_add_rationals, types4, 0) < 0) {
-        goto fail;
-    }
-    PyModule_AddObject(m,"test_add_rationals",(PyObject*)ufunc);
 
     /* Create numerator and denominator ufuncs */
     #define NEW_UNARY_UFUNC(name,type,doc) { \

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1093,6 +1093,21 @@ rational_ufunc_test_add(char** args, npy_intp* dimensions,
 }
 
 
+static void
+rational_ufunc_test_add_rationals(char** args, npy_intp* dimensions,
+                        npy_intp* steps, void* data) {
+    npy_intp is0 = steps[0], is1 = steps[1], os = steps[2], n = *dimensions;
+    char *i0 = args[0], *i1 = args[1], *o = args[2];
+    int k;
+    for (k = 0; k < n; k++) {
+        rational x = *(rational*)i0;
+        rational y = *(rational*)i1;
+        *(rational*)o = rational_add(x, y);
+        i0 += is0; i1 += is1; o += os;
+    }
+}
+
+
 PyMethodDef module_methods[] = {
     {0} /* sentinel */
 };
@@ -1306,6 +1321,22 @@ PyMODINIT_FUNC inittest_rational(void) {
         }
         PyModule_AddObject(m,"test_add",(PyObject*)ufunc);
     }
+
+    /* Create test ufunc with rational types using RegisterLoopByDescr */
+    PyObject* ufunc2 = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
+        PyUFunc_None,(char*)"test_add_rationals",
+        (char*)"add two matrices of rationals and return rational matrix",0);
+    if (!ufunc) {
+        goto fail;
+    }
+    PyArray_Descr* types4[3] = {&npyrational_descr,
+                                &npyrational_descr,
+                                &npyrational_descr};
+    if (PyUFunc_RegisterLoopByDescr((PyUFuncObject*)ufunc, &npyrational_descr,
+            rational_ufunc_test_add_rationals, types4, 0) < 0) {
+        goto fail;
+    }
+    PyModule_AddObject(m,"test_add_rationals",(PyObject*)ufunc);
 
     /* Create numerator and denominator ufuncs */
     #define NEW_UNARY_UFUNC(name,type,doc) { \

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -725,7 +725,7 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
     PyObject *str_key_obj = NULL;
     char *ufunc_name;
 
-    int any_flexible = 0, any_object = 0;
+    int any_flexible = 0, any_object = 0, any_flexible_userloops = 0;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -764,23 +764,56 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
         if (out_op[i] == NULL) {
             return -1;
         }
+
+        int type_num = PyArray_DESCR(out_op[i])->type_num;
         if (!any_flexible &&
-                PyTypeNum_ISFLEXIBLE(PyArray_DESCR(out_op[i])->type_num)) {
+                PyTypeNum_ISFLEXIBLE(type_num)) {
             any_flexible = 1;
         }
         if (!any_object &&
-                PyTypeNum_ISOBJECT(PyArray_DESCR(out_op[i])->type_num)) {
+                PyTypeNum_ISOBJECT(type_num)) {
             any_object = 1;
+        }
+
+        /*
+         * If any operand is a flexible dtype, check to see if any
+         * struct dtype ufuncs are registered. A ufunc has been registered
+         * for a struct dtype if ufunc's arg_dtypes array is not NULL.
+         */
+        if (PyTypeNum_ISFLEXIBLE(type_num) &&
+            !any_flexible_userloops &&
+            ufunc->userloops != NULL) {
+            PyUFunc_Loop1d *funcdata;
+            PyObject *key, *obj;
+            key = PyInt_FromLong(type_num);
+            if (key == NULL) {
+                continue;
+            }
+            obj = PyDict_GetItem(ufunc->userloops, key);
+            Py_DECREF(key);
+            if (obj == NULL) {
+                continue;
+            }
+            funcdata = (PyUFunc_Loop1d *)NpyCapsule_AsVoidPtr(obj);
+            while (funcdata != NULL) {
+                if (funcdata->arg_dtypes != NULL) {
+                    any_flexible_userloops = 1;
+                    break;
+                }
+
+                funcdata = funcdata->next;
+            }
         }
     }
 
     /*
      * Indicate not implemented if there are flexible objects (structured
-     * type or string) but no object types.
+     * type or string) but no object types and no registered struct
+     * dtype ufuncs.
      *
      * Not sure - adding this increased to 246 errors, 150 failures.
      */
-    if (any_flexible && !any_object) {
+    if (any_flexible && !any_flexible_userloops && !any_object) {
         return -2;
 
     }
@@ -4356,9 +4389,19 @@ cmp_arg_types(int *arg1, int *arg2, int n)
 static NPY_INLINE void
 _free_loop1d_list(PyUFunc_Loop1d *data)
 {
+    int i;
+
     while (data != NULL) {
         PyUFunc_Loop1d *next = data->next;
         PyArray_free(data->arg_types);
+
+        if (data->arg_dtypes != NULL) {
+            for (i = 0; i < data->nargs; i++) {
+                Py_DECREF(data->arg_dtypes[i]);
+            }
+            PyArray_free(data->arg_dtypes);
+        }
+
         PyArray_free(data);
         data = next;
     }
@@ -4383,6 +4426,90 @@ _loop1d_list_free(void *ptr)
 
 /*UFUNC_API*/
 NPY_NO_EXPORT int
+PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
+                            PyArray_Descr *user_dtype,
+                            PyUFuncGenericFunction function,
+                            PyArray_Descr **arg_dtypes,
+                            void *data)
+{
+    int i;
+    int result = 0;
+    int *arg_typenums;
+    PyObject *key, *cobj;
+
+    if (user_dtype == NULL) {
+        PyErr_SetString(PyExc_TypeError, "unknown user defined struct dtype");
+        return -1;
+    }
+
+    key = PyInt_FromLong((long) user_dtype->type_num);
+    if (key == NULL) {
+        return -1;
+    }
+
+    arg_typenums = PyArray_malloc(ufunc->nargs * sizeof(int));
+    if (arg_dtypes != NULL) {
+        for (i = 0; i < ufunc->nargs; i++) {
+            arg_typenums[i] = arg_dtypes[i]->type_num;
+        }
+    }
+    else {
+        for (i = 0; i < ufunc->nargs; i++) {
+            arg_typenums[i] = user_dtype->type_num;
+        }
+    }
+    
+    result = PyUFunc_RegisterLoopForType(ufunc, user_dtype->type_num, function, arg_typenums, data);
+
+    if (result == 0) {
+        cobj = PyDict_GetItem(ufunc->userloops, key);
+        if (cobj == NULL) {
+            PyErr_SetString(PyExc_KeyError, "userloop for user dtype not found");
+            result = -1;
+        }
+        else {
+            PyUFunc_Loop1d *current, *prev = NULL;
+            int cmp = 1;
+            current = (PyUFunc_Loop1d *)NpyCapsule_AsVoidPtr(cobj);
+            while (current != NULL) {
+                cmp = cmp_arg_types(current->arg_types, arg_typenums, ufunc->nargs);
+                if (cmp >= 0 && current->arg_dtypes == NULL) {
+                    break;
+                }
+                prev = current;
+                current = current->next;
+            }
+            if (cmp == 0 && current->arg_dtypes == NULL) {
+                current->arg_dtypes = PyArray_malloc(ufunc->nargs * sizeof(PyArray_Descr*));
+                if (arg_dtypes != NULL) {
+                    for (i = 0; i < ufunc->nargs; i++) {
+                        current->arg_dtypes[i] = arg_dtypes[i];
+                        Py_INCREF(current->arg_dtypes[i]);
+                    }
+                }
+                else {
+                    for (i = 0; i < ufunc->nargs; i++) {
+                        current->arg_dtypes[i] = user_dtype;
+                        Py_INCREF(current->arg_dtypes[i]);
+                    }
+                }
+                current->nargs = ufunc->nargs;
+            }
+            else {
+                result = -1;
+            }
+        }
+    }
+
+    free(arg_typenums);
+
+    Py_DECREF(key);
+
+    return result;
+}
+
+/*UFUNC_API*/
+NPY_NO_EXPORT int
 PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
                             int usertype,
                             PyUFuncGenericFunction function,
@@ -4396,7 +4523,7 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     int *newtypes=NULL;
 
     descr=PyArray_DescrFromType(usertype);
-    if ((usertype < NPY_USERDEF) || (descr==NULL)) {
+    if ((usertype < NPY_USERDEF && usertype != NPY_VOID) || (descr==NULL)) {
         PyErr_SetString(PyExc_TypeError, "unknown user-defined type");
         return -1;
     }
@@ -4432,6 +4559,8 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     funcdata->arg_types = newtypes;
     funcdata->data = data;
     funcdata->next = NULL;
+    funcdata->arg_dtypes = NULL;
+    funcdata->nargs = 0;
 
     /* Get entry for this user-defined type*/
     cobj = PyDict_GetItem(ufunc->userloops, key);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4425,18 +4425,21 @@ _loop1d_list_free(void *ptr)
 
 
 /*
- * This function allows the user to register a 1-d loop for structured arrays
- * with an already created ufunc. The ufunc is called whenever any of it's input
- * arguments match the user_dtype argument.
+ * This function allows the user to register a 1-d loop with an already
+ * created ufunc. This function is similar to RegisterLoopForType except
+ * that it allows a 1-d loop to be registered with PyArray_Descr objects
+ * instead of dtype type num values. This allows a 1-d loop to be registered
+ * for a structured array dtype or a custom dtype. The ufunc is called
+ * whenever any of it's input arguments match the user_dtype argument.
  * ufunc - ufunc object created from call to PyUFunc_FromFuncAndData
- * user_dtype - struct dtype that ufunc will be registered with
+ * user_dtype - dtype that ufunc will be registered with
  * function - 1-d loop function pointer
- * arg_dtypes - array of struct dtype objects describing the ufunc operands
+ * arg_dtypes - array of dtype objects describing the ufunc operands
  * data - arbitrary data pointer passed in to loop function
  */
 /*UFUNC_API*/
 NPY_NO_EXPORT int
-PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
+PyUFunc_RegisterLoopByDescr(PyUFuncObject *ufunc,
                             PyArray_Descr *user_dtype,
                             PyUFuncGenericFunction function,
                             PyArray_Descr **arg_dtypes,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -782,8 +782,8 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
          * for a struct dtype if ufunc's arg_dtypes array is not NULL.
          */
         if (PyTypeNum_ISFLEXIBLE(type_num) &&
-                !any_flexible_userloops &&
-                ufunc->userloops != NULL) {
+                    !any_flexible_userloops &&
+                    ufunc->userloops != NULL) {
                 PyUFunc_Loop1d *funcdata;
                 PyObject *key, *obj;
                 key = PyInt_FromLong(type_num);
@@ -801,7 +801,6 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
                     any_flexible_userloops = 1;
                     break;
                 }
-
                 funcdata = funcdata->next;
             }
         }
@@ -4449,7 +4448,8 @@ PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
     PyObject *key, *cobj;
 
     if (user_dtype == NULL) {
-        PyErr_SetString(PyExc_TypeError, "unknown user defined struct dtype");
+        PyErr_SetString(PyExc_TypeError,
+            "unknown user defined struct dtype");
         return -1;
     }
 
@@ -4470,12 +4470,14 @@ PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
         }
     }
     
-    result = PyUFunc_RegisterLoopForType(ufunc, user_dtype->type_num, function, arg_typenums, data);
+    result = PyUFunc_RegisterLoopForType(ufunc, user_dtype->type_num,
+        function, arg_typenums, data);
 
     if (result == 0) {
         cobj = PyDict_GetItem(ufunc->userloops, key);
         if (cobj == NULL) {
-            PyErr_SetString(PyExc_KeyError, "userloop for user dtype not found");
+            PyErr_SetString(PyExc_KeyError,
+                "userloop for user dtype not found");
             result = -1;
         }
         else {
@@ -4483,7 +4485,8 @@ PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
             int cmp = 1;
             current = (PyUFunc_Loop1d *)NpyCapsule_AsVoidPtr(cobj);
             while (current != NULL) {
-                cmp = cmp_arg_types(current->arg_types, arg_typenums, ufunc->nargs);
+                cmp = cmp_arg_types(current->arg_types,
+                    arg_typenums, ufunc->nargs);
                 if (cmp >= 0 && current->arg_dtypes == NULL) {
                     break;
                 }
@@ -4491,7 +4494,8 @@ PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
                 current = current->next;
             }
             if (cmp == 0 && current->arg_dtypes == NULL) {
-                current->arg_dtypes = PyArray_malloc(ufunc->nargs * sizeof(PyArray_Descr*));
+                current->arg_dtypes = PyArray_malloc(ufunc->nargs *
+                    sizeof(PyArray_Descr*));
                 if (arg_dtypes != NULL) {
                     for (i = 0; i < ufunc->nargs; i++) {
                         current->arg_dtypes[i] = arg_dtypes[i];
@@ -4512,7 +4516,7 @@ PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
         }
     }
 
-    free(arg_typenums);
+    PyArray_free(arg_typenums);
 
     Py_DECREF(key);
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -724,6 +724,7 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
     PyObject *obj, *context;
     PyObject *str_key_obj = NULL;
     char *ufunc_name;
+    int type_num;
 
     int any_flexible = 0, any_object = 0, any_flexible_userloops = 0;
 
@@ -765,7 +766,7 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
             return -1;
         }
 
-        int type_num = PyArray_DESCR(out_op[i])->type_num;
+        type_num = PyArray_DESCR(out_op[i])->type_num;
         if (!any_flexible &&
                 PyTypeNum_ISFLEXIBLE(type_num)) {
             any_flexible = 1;
@@ -781,11 +782,11 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
          * for a struct dtype if ufunc's arg_dtypes array is not NULL.
          */
         if (PyTypeNum_ISFLEXIBLE(type_num) &&
-            !any_flexible_userloops &&
-            ufunc->userloops != NULL) {
-            PyUFunc_Loop1d *funcdata;
-            PyObject *key, *obj;
-            key = PyInt_FromLong(type_num);
+                !any_flexible_userloops &&
+                ufunc->userloops != NULL) {
+                PyUFunc_Loop1d *funcdata;
+                PyObject *key, *obj;
+                key = PyInt_FromLong(type_num);
             if (key == NULL) {
                 continue;
             }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4425,6 +4425,16 @@ _loop1d_list_free(void *ptr)
 
 
 /*UFUNC_API*/
+/*
+ * This function allows the user to register a 1-d loop for structured arrays
+ * with an already created ufunc. The ufunc is called whenever any of it's input
+ * arguments match the user_dtype argument.
+ * ufunc - ufunc object created from call to PyUFunc_FromFuncAndData
+ * user_dtype - struct dtype that ufunc will be registered with
+ * function - 1-d loop function pointer
+ * arg_dtypes - array of struct dtype objects describing the ufunc operands
+ * data - arbitrary data pointer passed in to loop function
+ */
 NPY_NO_EXPORT int
 PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
                             PyArray_Descr *user_dtype,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4424,7 +4424,6 @@ _loop1d_list_free(void *ptr)
 #endif
 
 
-/*UFUNC_API*/
 /*
  * This function allows the user to register a 1-d loop for structured arrays
  * with an already created ufunc. The ufunc is called whenever any of it's input
@@ -4435,6 +4434,7 @@ _loop1d_list_free(void *ptr)
  * arg_dtypes - array of struct dtype objects describing the ufunc operands
  * data - arbitrary data pointer passed in to loop function
  */
+/*UFUNC_API*/
 NPY_NO_EXPORT int
 PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
                             PyArray_Descr *user_dtype,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4439,7 +4439,7 @@ _loop1d_list_free(void *ptr)
  */
 /*UFUNC_API*/
 NPY_NO_EXPORT int
-PyUFunc_RegisterLoopByDescr(PyUFuncObject *ufunc,
+PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
                             PyArray_Descr *user_dtype,
                             PyUFuncGenericFunction function,
                             PyArray_Descr **arg_dtypes,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4459,6 +4459,10 @@ PyUFunc_RegisterLoopForStructType(PyUFuncObject *ufunc,
     }
 
     arg_typenums = PyArray_malloc(ufunc->nargs * sizeof(int));
+    if (arg_typenums == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
     if (arg_dtypes != NULL) {
         for (i = 0; i < ufunc->nargs; i++) {
             arg_typenums[i] = arg_dtypes[i]->type_num;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1188,7 +1188,8 @@ find_userloop(PyUFuncObject *ufunc,
         }
 
         type_num = dtypes[i]->type_num;
-        if (type_num != last_userdef && (PyTypeNum_ISUSERDEF(type_num) || type_num == NPY_VOID)) {
+        if (type_num != last_userdef &&
+                (PyTypeNum_ISUSERDEF(type_num) || type_num == NPY_VOID)) {
             PyObject *key, *obj;
 
             last_userdef = type_num;
@@ -1554,7 +1555,8 @@ set_ufunc_loop_data_types(PyUFuncObject *self, PyArrayObject **op,
          * Copy the dtype from 'op' if the type_num matches,
          * to preserve metadata.
          */
-        } else if (op[i] != NULL && PyArray_DESCR(op[i])->type_num == type_nums[i]) {
+        } else if (op[i] != NULL &&
+                PyArray_DESCR(op[i])->type_num == type_nums[i]) {
             out_dtypes[i] = ensure_dtype_nbo(PyArray_DESCR(op[i]));
             Py_XINCREF(out_dtypes[i]);
         }
@@ -1617,7 +1619,8 @@ linear_search_userloop_type_resolver(PyUFuncObject *self,
         }
 
         type_num = PyArray_DESCR(op[i])->type_num;
-        if (type_num != last_userdef && (PyTypeNum_ISUSERDEF(type_num) || type_num == NPY_VOID)) {
+        if (type_num != last_userdef &&
+                (PyTypeNum_ISUSERDEF(type_num) || type_num == NPY_VOID)) {
             PyObject *key, *obj;
 
             last_userdef = type_num;
@@ -1726,7 +1729,8 @@ type_tuple_userloop_type_resolver(PyUFuncObject *self,
                             &err_dst_typecode)) {
                     /* It works */
                     case 1:
-                        set_ufunc_loop_data_types(self, op, out_dtype, types, NULL);
+                        set_ufunc_loop_data_types(self, op,
+                            out_dtype, types, NULL);
                         return 1;
                     /* Didn't match */
                     case 0:

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1555,8 +1555,9 @@ set_ufunc_loop_data_types(PyUFuncObject *self, PyArrayObject **op,
          * Copy the dtype from 'op' if the type_num matches,
          * to preserve metadata.
          */
-        } else if (op[i] != NULL &&
-                PyArray_DESCR(op[i])->type_num == type_nums[i]) {
+        }
+        else if (op[i] != NULL &&
+                 PyArray_DESCR(op[i])->type_num == type_nums[i]) {
             out_dtypes[i] = ensure_dtype_nbo(PyArray_DESCR(op[i]));
             Py_XINCREF(out_dtypes[i]);
         }

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1188,7 +1188,7 @@ find_userloop(PyUFuncObject *ufunc,
         }
 
         type_num = dtypes[i]->type_num;
-        if (type_num != last_userdef && PyTypeNum_ISUSERDEF(type_num)) {
+        if (type_num != last_userdef && (PyTypeNum_ISUSERDEF(type_num) || type_num == NPY_VOID)) {
             PyObject *key, *obj;
 
             last_userdef = type_num;
@@ -1436,7 +1436,7 @@ ufunc_loop_matches(PyUFuncObject *self,
                     NPY_CASTING output_casting,
                     int any_object,
                     int use_min_scalar,
-                    int *types,
+                    int *types, PyArray_Descr **dtypes,
                     int *out_no_castable_output,
                     char *out_err_src_typecode,
                     char *out_err_dst_typecode)
@@ -1463,7 +1463,18 @@ ufunc_loop_matches(PyUFuncObject *self,
             return 0;
         }
 
-        tmp = PyArray_DescrFromType(types[i]);
+        /*
+         * If type num is NPY_VOID and struct dtypes have been passed in,
+         * use struct dtype object. Otherwise create new dtype object
+         * from type num.
+         */
+        if (types[i] == NPY_VOID && dtypes != NULL) {
+            tmp = dtypes[i];
+            Py_INCREF(tmp);
+        }
+        else {
+            tmp = PyArray_DescrFromType(types[i]);
+        }
         if (tmp == NULL) {
             return -1;
         }
@@ -1525,7 +1536,7 @@ ufunc_loop_matches(PyUFuncObject *self,
 static int
 set_ufunc_loop_data_types(PyUFuncObject *self, PyArrayObject **op,
                     PyArray_Descr **out_dtypes,
-                    int *type_nums)
+                    int *type_nums, PyArray_Descr **dtypes)
 {
     int i, nin = self->nin, nop = nin + self->nout;
 
@@ -1536,11 +1547,14 @@ set_ufunc_loop_data_types(PyUFuncObject *self, PyArrayObject **op,
      * instead of creating a new one, similarly to preserve metadata.
      **/
     for (i = 0; i < nop; ++i) {
+        if (dtypes != NULL) {
+            out_dtypes[i] = dtypes[i];
+            Py_XINCREF(out_dtypes[i]);
         /*
          * Copy the dtype from 'op' if the type_num matches,
          * to preserve metadata.
          */
-        if (op[i] != NULL && PyArray_DESCR(op[i])->type_num == type_nums[i]) {
+        } else if (op[i] != NULL && PyArray_DESCR(op[i])->type_num == type_nums[i]) {
             out_dtypes[i] = ensure_dtype_nbo(PyArray_DESCR(op[i]));
             Py_XINCREF(out_dtypes[i]);
         }
@@ -1603,7 +1617,7 @@ linear_search_userloop_type_resolver(PyUFuncObject *self,
         }
 
         type_num = PyArray_DESCR(op[i])->type_num;
-        if (type_num != last_userdef && PyTypeNum_ISUSERDEF(type_num)) {
+        if (type_num != last_userdef && (PyTypeNum_ISUSERDEF(type_num) || type_num == NPY_VOID)) {
             PyObject *key, *obj;
 
             last_userdef = type_num;
@@ -1623,7 +1637,7 @@ linear_search_userloop_type_resolver(PyUFuncObject *self,
                 switch (ufunc_loop_matches(self, op,
                             input_casting, output_casting,
                             any_object, use_min_scalar,
-                            types,
+                            types, funcdata->arg_dtypes,
                             out_no_castable_output, out_err_src_typecode,
                             out_err_dst_typecode)) {
                     /* Error */
@@ -1631,7 +1645,7 @@ linear_search_userloop_type_resolver(PyUFuncObject *self,
                         return -1;
                     /* Found a match */
                     case 1:
-                        set_ufunc_loop_data_types(self, op, out_dtype, types);
+                        set_ufunc_loop_data_types(self, op, out_dtype, types, funcdata->arg_dtypes);
                         return 1;
                 }
 
@@ -1707,12 +1721,12 @@ type_tuple_userloop_type_resolver(PyUFuncObject *self,
                 switch (ufunc_loop_matches(self, op,
                             casting, casting,
                             any_object, use_min_scalar,
-                            types,
+                            types, NULL,
                             &no_castable_output, &err_src_typecode,
                             &err_dst_typecode)) {
                     /* It works */
                     case 1:
-                        set_ufunc_loop_data_types(self, op, out_dtype, types);
+                        set_ufunc_loop_data_types(self, op, out_dtype, types, NULL);
                         return 1;
                     /* Didn't match */
                     case 0:
@@ -1875,7 +1889,7 @@ linear_search_type_resolver(PyUFuncObject *self,
         switch (ufunc_loop_matches(self, op,
                     input_casting, output_casting,
                     any_object, use_min_scalar,
-                    types,
+                    types, NULL,
                     &no_castable_output, &err_src_typecode,
                     &err_dst_typecode)) {
             /* Error */
@@ -1883,7 +1897,7 @@ linear_search_type_resolver(PyUFuncObject *self,
                 return -1;
             /* Found a match */
             case 1:
-                set_ufunc_loop_data_types(self, op, out_dtype, types);
+                set_ufunc_loop_data_types(self, op, out_dtype, types, NULL);
                 return 0;
         }
     }
@@ -2081,7 +2095,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
         switch (ufunc_loop_matches(self, op,
                     casting, casting,
                     any_object, use_min_scalar,
-                    types,
+                    types, NULL,
                     &no_castable_output, &err_src_typecode,
                     &err_dst_typecode)) {
             /* Error */
@@ -2089,7 +2103,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
                 return -1;
             /* It worked */
             case 1:
-                set_ufunc_loop_data_types(self, op, out_dtype, types);
+                set_ufunc_loop_data_types(self, op, out_dtype, types, NULL);
                 return 0;
             /* Didn't work */
             case 0:

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -813,6 +813,15 @@ class TestUfunc(TestCase):
         assert_equal(a, 3)
         opflag_tests.inplace_add(a, [3, 4])
         assert_equal(a, 10)
+    
+    def test_struct_ufunc(self):
+        import numpy.core.struct_ufunc_test as struct_ufunc
+
+        a = np.array([(1,2,3)], dtype='u8,u8,u8')
+        b = np.array([(1,2,3)], dtype='u8,u8,u8')
+
+        result = struct_ufunc.add_triplet(a, b)
+        assert_equal(result, np.array([(2, 4, 6)], dtype='u8,u8,u8'))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -823,5 +823,16 @@ class TestUfunc(TestCase):
         result = struct_ufunc.add_triplet(a, b)
         assert_equal(result, np.array([(2, 4, 6)], dtype='u8,u8,u8'))
 
+    def test_custom_ufunc(self):
+        a = np.array([rational(1,2), rational(1,3), rational(1,4)],
+            dtype=rational);
+        b = np.array([rational(1,2), rational(1,3), rational(1,4)],
+            dtype=rational);
+
+        result = test_add_rationals(a, b)
+        expected = np.array([rational(1), rational(2,3), rational(1,2)],
+            dtype=rational);
+        assert_equal(result, expected);
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This change allows ufuncs to be registered for structured arrays. For example, a ufunc could be registered to take two arrays of type 'u8,u8,u8' and return an array of type 'u8,u8,u8'.

The following are the key changes:

1) Add new API method called PyUFunc_RegisterLoopForStructType. This method behaves the same as PyUFunc_RegisterLoopForType, except that instead of taking an array of type nums for the ufunc operands, it takes an array of struct dtype objects.

2) Add arg_dtypes array to PyUFunc_Loop1d struct. This stores the dtype objects passed in through call to RegisterLoopForStructType.

3) Add nargs int value to PyUFunc_Loop1d struct. This stores the number of input and output arguments to ufunc, so that dtype objects in PyUFunc_Loop1d struct can be DECREFed when PyUFUnc_Loop1d struct is destroyed.

4) Add logic in ufunc_loop_matches function that checks struct dtype object in arg_dtypes if current operand being checked is type NPY_VOID. 

The following is a trivial 1-d loop function example written in Cython that adds corresponding fields in two arrays of type 'u8,u8,u8':

```
cdef void add_uint64_triplet(char **args,
    npy_intp *dimensions,
    npy_intp *steps,
    void *innerloopdata):

    cdef npy_intp i
    cdef npy_intp is1=steps[0]
    cdef npy_intp is2=steps[1]
    cdef npy_intp os=steps[2]
    cdef npy_intp n=dimensions[0]
    cdef uint64_t *x, *y, *z

    cdef char *i1=args[0], *i2=args[1], *op=args[2]

    for i in range(n):

        # Initialize pointers to each operand
        x = <uint64_t*>i1
        y = <uint64_t*>i2
        z = <uint64_t*>op

        # Add each field in struct array record
        z[0] = x[0] + y[0]
        z[1] = x[1] + y[1]
        z[2] = x[2] + y[2]

        i1 += is1; i2 += is2; op += os


def test_ufunc:
    cdef PyArray_Descr *types[3]
    dtype = np.dtype('u8,u8,u8')

    types[0] = <PyArray_Descr*>dtype
    types[1] = <PyArray_Descr*>dtype
    types[2] = <PyArray_Descr*>dtype

    ufunc = PyUFunc_FromFuncAndData(NULL, NULL, NULL, 0,
                                        2, 1, PyUFunc_None,
                                        NULL, NULL, 0) 

    # Call new method for registering ufunc for struct array
    PyUFunc_RegisterLoopForStructType(<PyUFuncObject*>ufunc,
                                      <PyArray_Descr*>dtype,
                                      &add_uint64_triplet,
                                      <PyArray_Descr**>types,
                                      NULL)

    a = np.array([(1,2,3)], dtype=dtype)
    b = np.array([(1,2,3)], dtype=dtype)

    result = ufunc(a, b)
```
