### PR TITLE
BUG: Fill correct strides for ndmin in array creation

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1507,18 +1507,26 @@ PyArray_EquivTypenums(int typenum1, int typenum2)
 /*** END C-API FUNCTIONS **/
 
 static PyObject *
-_prepend_ones(PyArrayObject *arr, int nd, int ndmin)
+_prepend_ones(PyArrayObject *arr, int nd, int ndmin, NPY_ORDER order)
 {
     npy_intp newdims[NPY_MAXDIMS];
     npy_intp newstrides[NPY_MAXDIMS];
+    npy_intp newstride;
     int i, k, num;
     PyArrayObject *ret;
     PyArray_Descr *dtype;
 
+    if (order == NPY_FORTRANORDER || PyArray_ISFORTRAN(arr) || PyArray_NDIM(arr) == 0) {
+        newstride = PyArray_DESCR(arr)->elsize;
+    }
+    else {
+        newstride = PyArray_STRIDES(arr)[0] * PyArray_DIMS(arr)[0];
+    }
+
     num = ndmin - nd;
     for (i = 0; i < num; i++) {
         newdims[i] = 1;
-        newstrides[i] = PyArray_DESCR(arr)->elsize;
+        newstrides[i] = newstride;
     }
     for (i = num; i < ndmin; i++) {
         k = i - num;
@@ -1659,7 +1667,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
      * create a new array from the same data with ones in the shape
      * steals a reference to ret
      */
-    return _prepend_ones(ret, nd, ndmin);
+    return _prepend_ones(ret, nd, ndmin, order);
 
 clean_type:
     Py_XDECREF(type);

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -458,6 +458,13 @@ class TestRegression(TestCase):
         assert_equal(np.array(x,dtype=np.float32,ndmin=2).ndim,2)
         assert_equal(np.array(x,dtype=np.float64,ndmin=2).ndim,2)
 
+    def test_ndmin_order(self, level=rlevel):
+        """Issue #465 and related checks"""
+        assert_(np.array([1,2], order='C', ndmin=3).flags.c_contiguous)
+        assert_(np.array([1,2], order='F', ndmin=3).flags.f_contiguous)
+        assert_(np.array(np.ones((2,2), order='F'), ndmin=3).flags.f_contiguous)
+        assert_(np.array(np.ones((2,2), order='C'), ndmin=3).flags.c_contiguous)
+
     def test_mem_axis_minimization(self, level=rlevel):
         """Ticket #327"""
         data = np.arange(5)


### PR DESCRIPTION
Closes "Issue #465", strides need to be set according to the requested contiguous flags.

I will add tests and maybe another bug fix from my cflags branch which is somewhat related. And just to note in that branch this change would not really matter ;), as these strides do not really matter to contiguous flags.
