### PR TITLE
BUG: Fix complex to bool conversion in lowlevel_strided_loops

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -811,9 +811,17 @@ static void
     dst_value[0] = _CONVERT_FN(src_value[0]);
     dst_value[1] = _CONVERT_FN(src_value[1]);
 #  elif !@aligned@
-    dst_value = _CONVERT_FN(src_value[0]);
+#    if @is_bool2@
+       dst_value = _CONVERT_FN(src_value[0]) || _CONVERT_FN(src_value[1]);
+#    else
+       dst_value = _CONVERT_FN(src_value[0]);
+#    endif
 #  else
-    *(_TYPE2 *)dst = _CONVERT_FN(src_value[0]);
+#    if @is_bool2@
+       *(_TYPE2 *)dst = _CONVERT_FN(src_value[0]) || _CONVERT_FN(src_value[1]);
+#    else
+       *(_TYPE2 *)dst = _CONVERT_FN(src_value[0]);
+#    endif
 #  endif
 #else
 #  if @is_complex2@

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1459,6 +1459,14 @@ class TestRegression(TestCase):
             x = tp(1+2j)
             assert_equal(complex(x), 1+2j)
 
+    def test_complex_boolean_cast(self):
+        """Ticket #2218"""
+        for tp in [np.csingle, np.cdouble, np.clongdouble]:
+            x = np.array([0, 0+0.5j, 0.5+0j], dtype=tp)
+            assert_equal(x.astype(bool), np.array([0, 1, 1], dtype=bool))
+            assert_(np.any(x))
+            assert_(np.all(x[1:]))
+
     def test_uint_int_conversion(self):
         x = 2**64 - 1
         assert_equal(int(np.uint64(x)), x)


### PR DESCRIPTION
This is a fix for Ticket 2218. I am not sure if this is the best way to fix it, but I hunted it down to that place and just implemented the first fix that seemed reasonable.

On a side note, the arraytypes.c.src code seems to handle complex to bool conversion fine, but when does it get called at all?
