### PR TITLE
FIX: remove log line causing warning from disutils

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -249,11 +249,9 @@ def gpaths(paths, local_path='', include_non_existing=True):
 
 _temporary_directory = None
 def clean_up_temporary_directory():
-    from numpy.distutils import log
     global _temporary_directory
     if not _temporary_directory:
         return
-    log.debug('removing %s', _temporary_directory)
     try:
         shutil.rmtree(_temporary_directory)
     except OSError:


### PR DESCRIPTION
Using numpy.distutils through easy_install caused a RuntimeWarning
because of a failed import of numpy.distutils.

Discussion here:
http://thread.gmane.org/gmane.comp.python.numeric.general/51719

The conclusion seemed to be that the safest fix is to remove the one
line of logging in the relevant callback.

Thanks to Ralf Gommers for the suggestion.
