### PR TITLE
When accessing MaskedArray rows, always return an mvoid object

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2948,12 +2948,10 @@ class MaskedArray(ndarray):
             # A record ................
             if isinstance(dout, np.void):
                 mask = _mask[indx]
-# If we can make mvoid a subclass of np.void, that'd be what we'd need
-#                return mvoid(dout, mask=mask)
-                if flatten_mask(mask).any():
-                    dout = mvoid(dout, mask=mask)
-                else:
-                    return dout
+                # We should always re-cast to mvoid, otherwise users can
+                # change masks on rows that already have masked values, but not
+                # on rows that have no masked values, which is inconsistent.
+                dout = mvoid(dout, mask=mask)
             # Just a scalar............
             elif _mask is not nomask and _mask[indx]:
                 return masked

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -626,7 +626,7 @@ class TestMaskedArray(TestCase):
         a = masked_array([(1, 2,), (3, 4)], mask=[(0, 0), (1, 0)], dtype=ndtype)
         # w/o mask
         f = a[0]
-        self.assertTrue(isinstance(f, np.void))
+        self.assertTrue(isinstance(f, mvoid))
         assert_equal((f[0], f['a']), (1, 1))
         assert_equal(f['b'], 2)
         # w/ mask
@@ -3443,7 +3443,7 @@ class TestMaskedFields(TestCase):
                               [1, 0, 0, 0, 0, 0, 0, 0, 1, 0]),
                           dtype=[('a', bool), ('b', bool)])
         # No mask
-        self.assertTrue(isinstance(a[1], np.void))
+        self.assertTrue(isinstance(a[1], MaskedArray))
         # One element masked
         self.assertTrue(isinstance(a[0], MaskedArray))
         assert_equal_records(a[0]._data, a._data[0])
@@ -3503,7 +3503,7 @@ class TestMaskedView(TestCase):
         assert_equal(test['B'], a['b'][0])
         #
         test = a[-1].view([('A', float), ('B', float)])
-        self.assertTrue(not isinstance(test, MaskedArray))
+        self.assertTrue(isinstance(test, MaskedArray))
         assert_equal(test.dtype.names, ('A', 'B'))
         assert_equal(test['A'], a['a'][-1])
         assert_equal(test['B'], a['b'][-1])
@@ -3523,7 +3523,7 @@ class TestMaskedView(TestCase):
         assert_equal(test.mask, (1, 0))
         # View on 1 unmasked element
         test = a[-1].view((float, 2))
-        self.assertTrue(not isinstance(test, MaskedArray))
+        self.assertTrue(isinstance(test, MaskedArray))
         assert_equal(test, data[-1])
     #
     def test_view_to_dtype_and_type(self):


### PR DESCRIPTION
The current behavior of MaskedArray when accessing a row object is that if all masks are `False`, the row is an `np.void` object, and if any are set to `True`, it is a `np.ma.core.mvoid` object. The issue with this is that users can access/modify masks for rows that already have at least one mask set to `True`, but not for rows that have no masks set. For example:

```
In [1]: a = ma.array(zip([1,2,3]), mask=[0,1,0], dtype=[('x', int)])

In [2]: a[0].mask
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-2221dd3fce8c> in <module>()
----> 1 a[0].mask

AttributeError: 'numpy.void' object has no attribute 'mask'

In [3]: a[1].mask
Out[3]: (True,)
```

There is no reason why a row should behave differently whether any values are masked or not, so this PR defaults to always returning an `mvoid` object, otherwise mask values cannot be set for rows that start off with no mask values set.

(Of course, the present implementation in Numpy also has a performance impact - for arrays with many fields, each call to a row has to flatten the mask of the whole record just to check what type to return, which is inefficient. With this PR, row access should be faster for masked arrays. But this is secondary.)
