### PR TITLE
ENH: add rfftfreq() and DOC: cleanup fft docstrings

### DIFF
--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -297,8 +297,7 @@ def rfft(a, n=None, axis=-1):
     axis of the output is therefore ``n//2+1``.
 
     When ``A = rfft(a)`` and fs is the sampling frequency, ``A[0]`` contains 
-    the zero-frequency term 0*fs, which must be purely real due to the Hermite 
-    symmetry.
+    the zero-frequency term 0*fs, which is real due to Hermitian symmetry.
 
     If `n` is even, ``A[-1]`` contains the term representing both positive 
     and negative Nyquist frequency (+fs/2 and -fs/2), and must also be purely 

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -271,7 +271,8 @@ def rfft(a, n=None, axis=-1):
     out : complex ndarray
         The truncated or zero-padded input, transformed along the axis
         indicated by `axis`, or the last one if `axis` is not specified.
-        The length of the transformed axis is ``n/2+1``.
+        If `n` is even, the length of the transformed axis is ``(n/2)+1``.  
+        If `n` is odd, the length is ``(n+1)/2``.
 
     Raises
     ------
@@ -293,7 +294,7 @@ def rfft(a, n=None, axis=-1):
     conjugates of the corresponding positive-frequency terms, and the
     negative-frequency terms are therefore redundant.  This function does not
     compute the negative frequency terms, and the length of the transformed
-    axis of the output is therefore ``n/2+1``.
+    axis of the output is therefore ``n//2+1``.
 
     When ``A = rfft(a)``, ``A[0]`` contains the zero-frequency term, which
     must be purely real due to the Hermite symmetry.
@@ -343,7 +344,7 @@ def irfft(a, n=None, axis=-1):
         The input array.
     n : int, optional
         Length of the transformed axis of the output.
-        For `n` output points, ``n/2+1`` input points are necessary.  If the
+        For `n` output points, ``n//2+1`` input points are necessary.  If the
         input is longer than this, it is cropped.  If it is shorter than this,
         it is padded with zeros.  If `n` is not given, it is determined from
         the length of the input (along the axis specified by `axis`).

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -296,12 +296,14 @@ def rfft(a, n=None, axis=-1):
     compute the negative frequency terms, and the length of the transformed
     axis of the output is therefore ``n//2+1``.
 
-    When ``A = rfft(a)``, ``A[0]`` contains the zero-frequency term, which
-    must be purely real due to the Hermite symmetry.
+    When ``A = rfft(a)`` and fs is the sampling frequency, ``A[0]`` contains 
+    the zero-frequency term 0*fs, which must be purely real due to the Hermite 
+    symmetry.
 
-    If `n` is even, ``A[-1]`` contains the term for frequencies ``n/2`` and
-    ``-n/2``, and must also be purely real.  If `n` is odd, ``A[-1]``
-    contains the term for frequency ``A[(n-1)/2]``, and is complex in the
+    If `n` is even, ``A[-1]`` contains the term representing both positive 
+    and negative Nyquist frequency (+fs/2 and -fs/2), and must also be purely 
+    real. If `n` is odd, there is no term at fs/2; ``A[-1]`` contains 
+    the largest positive frequency (fs/2*(n-1)/n), and is complex in the 
     general case.
 
     If the input `a` contains an imaginary part, it is silently discarded.

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -121,9 +121,11 @@ def fftfreq(n, d=1.0):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
-    The returned float array contains the frequency bins in
-    cycles/unit (with zero at the start) given a window length `n` and a
-    sample spacing `d`::
+    The returned float array `f` contains the frequency bin centers in cycles 
+    per unit of the sample spacing (with zero at the start).  For instance, if 
+    the sample spacing is in seconds, then the frequency unit is cycles/second.
+
+    Given a window length `n` and a sample spacing `d`::
 
       f = [0, 1, ...,   n/2-1,     -n/2, ..., -1] / (d*n)   if n is even
       f = [0, 1, ..., (n-1)/2, -(n-1)/2, ..., -1] / (d*n)   if n is odd
@@ -133,11 +135,11 @@ def fftfreq(n, d=1.0):
     n : int
         Window length.
     d : scalar, optional
-        Sample spacing. Default is 1.
-
+        Sample spacing (inverse of the sampling rate). Defaults to 1.
+        
     Returns
     -------
-    out : ndarray
+    f : ndarray
         The array of length `n`, containing the sample frequencies.
 
     Examples
@@ -169,9 +171,11 @@ def rfftfreq(n, d=1.0):
     Return the Discrete Fourier Transform sample frequencies 
     (for usage with rfft, irfft).
 
-    The returned float array contains the frequency bins in
-    cycles/unit (with zero at the start) given a window length `n` and a
-    sample spacing `d`::
+    The returned float array `f` contains the frequency bin centers in cycles 
+    per unit of the sample spacing (with zero at the start).  For instance, if 
+    the sample spacing is in seconds, then the frequency unit is cycles/second.
+
+    Given a window length `n` and a sample spacing `d`::
 
       f = [0, 1, ...,     n/2-1,     n/2] / (d*n)   if n is even
       f = [0, 1, ..., (n-1)/2-1, (n-1)/2] / (d*n)   if n is odd
@@ -184,11 +188,11 @@ def rfftfreq(n, d=1.0):
     n : int
         Window length.
     d : scalar, optional
-        Sample spacing. Default is 1.
+        Sample spacing (inverse of the sampling rate). Defaults to 1.
 
     Returns
     -------
-    out : ndarray
+    f : ndarray
         The array of length `n//2+1`, containing the sample frequencies.
 
     Examples

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -151,7 +151,8 @@ def fftfreq(n, d=1.0):
     array([ 0.  ,  1.25,  2.5 ,  3.75, -5.  , -3.75, -2.5 , -1.25])
 
     """
-    assert isinstance(n,types.IntType) or isinstance(n, integer)
+    if not (isinstance(n,types.IntType) or isinstance(n, integer)):
+        raise ValueError("n should be an integer")
     val = 1.0 / (n * d)
     results = empty(n, int)
     N = (n-1)//2 + 1
@@ -204,7 +205,8 @@ def rfftfreq(n, d=1.0):
     array([  0.,  10.,  20.,  30.,  40.,  50.])
 
     """
-    assert isinstance(n,types.IntType) or isinstance(n, integer)
+    if not (isinstance(n,types.IntType) or isinstance(n, integer)):
+        raise ValueError("n should be an integer")
     val = 1.0/(n*d)
     N = n//2 + 1
     results = arange(0, N, dtype=int)

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -140,7 +140,7 @@ def fftfreq(n, d=1.0):
     Returns
     -------
     f : ndarray
-        The array of length `n`, containing the sample frequencies.
+        Array of length `n` containing the sample frequencies.
 
     Examples
     --------
@@ -193,7 +193,7 @@ def rfftfreq(n, d=1.0):
     Returns
     -------
     f : ndarray
-        The array of length `n//2+1`, containing the sample frequencies.
+        Array of length ``n//2 + 1`` containing the sample frequencies.
 
     Examples
     --------

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -189,7 +189,7 @@ def rfftfreq(n, d=1.0):
     Returns
     -------
     out : ndarray
-        The array of length `n`, containing the sample frequencies.
+        The array of length `n//2+1`, containing the sample frequencies.
 
     Examples
     --------

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -3,7 +3,7 @@ Discrete Fourier Transforms - helper.py
 """
 # Created by Pearu Peterson, September 2002
 
-__all__ = ['fftshift','ifftshift','fftfreq']
+__all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
 
 from numpy.core import asarray, concatenate, arange, take, \
     integer, empty
@@ -160,3 +160,51 @@ def fftfreq(n,d=1.0):
     results[N:] = p2
     return results * val
     #return hstack((arange(0,(n-1)/2 + 1), arange(-(n/2),0))) / (n*d)
+
+
+def rfftfreq(n, d=1.0):
+    """
+    Return the Discrete Fourier Transform sample frequencies 
+    (for usage with rfft, irfft).
+
+    The returned float array contains the frequency bins in
+    cycles/unit (with zero at the start) given a window length `n` and a
+    sample spacing `d`::
+
+      f = [0, 1, ...,     n/2-1,     n/2] / (d*n)   if n is even
+      f = [0, 1, ..., (n-1)/2-1, (n-1)/2] / (d*n)   if n is odd
+
+    Unlike `fftfreq` (but like `scipy.fftpack.rfftfreq`)
+    the Nyquist frequency component is considered to be positive.
+
+    Parameters
+    ----------
+    n : int
+        Window length.
+    d : scalar, optional
+        Sample spacing. Default is 1.
+
+    Returns
+    -------
+    out : ndarray
+        The array of length `n`, containing the sample frequencies.
+
+    Examples
+    --------
+    >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5, -3, 4], dtype=float)
+    >>> fourier = np.fft.rfft(signal)
+    >>> n = signal.size
+    >>> sample_rate = 100
+    >>> freq = np.fft.fftfreq(n, d=1./sample_rate)
+    >>> freq
+    array([  0.,  10.,  20.,  30.,  40., -50., -40., -30., -20., -10.])
+    >>> freq = np.fft.rfftfreq(n, d=1./sample_rate)
+    >>> freq
+    array([  0.,  10.,  20.,  30.,  40.,  50.])
+
+    """
+    assert isinstance(n,types.IntType) or isinstance(n, integer)
+    val = 1.0/(n*d)
+    N = n//2 + 1
+    results = arange(0, N, dtype=int)
+    return results * val

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -10,7 +10,7 @@ from numpy.core import asarray, concatenate, arange, take, \
 import numpy.core.numerictypes as nt
 import types
 
-def fftshift(x,axes=None):
+def fftshift(x, axes=None):
     """
     Shift the zero-frequency component to the center of the spectrum.
 
@@ -69,7 +69,7 @@ def fftshift(x,axes=None):
     return y
 
 
-def ifftshift(x,axes=None):
+def ifftshift(x, axes=None):
     """
     The inverse of fftshift.
 
@@ -116,7 +116,8 @@ def ifftshift(x,axes=None):
         y = take(y,mylist,k)
     return y
 
-def fftfreq(n,d=1.0):
+
+def fftfreq(n, d=1.0):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
@@ -124,15 +125,15 @@ def fftfreq(n,d=1.0):
     cycles/unit (with zero at the start) given a window length `n` and a
     sample spacing `d`::
 
-      f = [0, 1, ..., n/2-1, -n/2, ..., -1] / (d*n)         if n is even
+      f = [0, 1, ...,   n/2-1,     -n/2, ..., -1] / (d*n)   if n is even
       f = [0, 1, ..., (n-1)/2, -(n-1)/2, ..., -1] / (d*n)   if n is odd
 
     Parameters
     ----------
     n : int
         Window length.
-    d : scalar
-        Sample spacing.
+    d : scalar, optional
+        Sample spacing. Default is 1.
 
     Returns
     -------
@@ -151,12 +152,12 @@ def fftfreq(n,d=1.0):
 
     """
     assert isinstance(n,types.IntType) or isinstance(n, integer)
-    val = 1.0/(n*d)
+    val = 1.0 / (n * d)
     results = empty(n, int)
     N = (n-1)//2 + 1
-    p1 = arange(0,N,dtype=int)
+    p1 = arange(0, N, dtype=int)
     results[:N] = p1
-    p2 = arange(-(n//2),0,dtype=int)
+    p2 = arange(-(n//2), 0, dtype=int)
     results[N:] = p2
     return results * val
     #return hstack((arange(0,(n-1)/2 + 1), arange(-(n/2),0))) / (n*d)

--- a/numpy/fft/info.py
+++ b/numpy/fft/info.py
@@ -46,6 +46,7 @@ Helper routines
    :toctree: generated/
 
    fftfreq   Discrete Fourier Transform sample frequencies.
+   rfftfreq  DFT sample frequencies (for usage with rfft, irfft).
    fftshift  Shift zero-frequency component to center of spectrum.
    ifftshift Inverse of fftshift.
 

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -49,6 +49,17 @@ class TestFFTFreq(TestCase):
         assert_array_almost_equal(10*pi*fft.fftfreq(10, pi), x)
 
 
+class TestRFFTFreq(TestCase):
+
+    def test_definition(self):
+        x = [0, 1, 2, 3, 4]
+        assert_array_almost_equal(9*fft.rfftfreq(9), x)
+        assert_array_almost_equal(9*pi*fft.rfftfreq(9, pi), x)
+        x = [0, 1, 2, 3, 4, 5]
+        assert_array_almost_equal(10*fft.rfftfreq(10), x)
+        assert_array_almost_equal(10*pi*fft.rfftfreq(10, pi), x)
+
+
 class TestIRFFTN(TestCase):
 
     def test_not_last_axis_success(self):


### PR DESCRIPTION
1. Added an `rfftfreq()` function for numpy's `rfft()`, like scipy's `rfftfreq()` (which works differently)
2. Clarify default value and units of `d`
3. Clarify size and frequencies of odd-length FFTs
4. Don't use `assert` to check types
