### PR TITLE
ENH: Make 1-dimensional axes not matter for contiguous flags

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -756,8 +756,9 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_F_CONTIGUOUS    0x0002
 
 /*
- * Note: all 0-d arrays are C_CONTIGUOUS and F_CONTIGUOUS. If a
- * 1-d array is C_CONTIGUOUS it is also F_CONTIGUOUS
+ * Note: all 0-d arrays are C_CONTIGUOUS and F_CONTIGUOUS. An N-d
+ * array that is C_CONTIGUOUS may also be F_CONTIGUOUS if only
+ * one axis has a dimension different from one (ie. a 1x3x1 array).
  */
 
 /*
@@ -1370,7 +1371,7 @@ PyArrayNeighborhoodIter_Next2D(PyArrayNeighborhoodIterObject* iter);
                              PyArray_CHKFLAGS(m, NPY_ARRAY_F_CONTIGUOUS))
 
 #define PyArray_ISFORTRAN(m) (PyArray_CHKFLAGS(m, NPY_ARRAY_F_CONTIGUOUS) && \
-                             (PyArray_NDIM(m) > 1))
+                             (!PyArray_CHKFLAGS(m, NPY_ARRAY_C_CONTIGUOUS)))
 
 #define PyArray_FORTRAN_IF(m) ((PyArray_CHKFLAGS(m, NPY_ARRAY_F_CONTIGUOUS) ? \
                                NPY_ARRAY_F_CONTIGUOUS : 0))

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -757,7 +757,7 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 
 /*
  * Note: all 0-d arrays are C_CONTIGUOUS and F_CONTIGUOUS. An N-d
- * array that is C_CONTIGUOUS may also be F_CONTIGUOUS if only
+ * array that is C_CONTIGUOUS is also F_CONTIGUOUS if only
  * one axis has a dimension different from one (ie. a 1x3x1 array).
  */
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -538,7 +538,7 @@ def require(a, dtype=None, requirements=None):
 def isfortran(a):
     """
     Returns True if array is arranged in Fortran-order in memory
-    and dimension > 1.
+    and not C-order.
 
     Parameters
     ----------
@@ -584,7 +584,7 @@ def isfortran(a):
     >>> np.isfortran(b)
     True
 
-    1-D arrays always evaluate as False.
+    C-ordered arrays evaluate as False even if they are also FORTRAN-ordered.
 
     >>> np.isfortran(np.array([1, 2], order='FORTRAN'))
     False

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -265,8 +265,8 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
     */
 
     numbytes = PyArray_NBYTES(self);
-    if ((PyArray_ISCONTIGUOUS(self) && (order == NPY_CORDER))
-        || (PyArray_ISFORTRAN(self) && (order == NPY_FORTRANORDER))) {
+    if ((PyArray_IS_C_CONTIGUOUS(self) && (order == NPY_CORDER))
+        || (PyArray_IS_F_CONTIGUOUS(self) && (order == NPY_FORTRANORDER))) {
         ret = PyBytes_FromStringAndSize(PyArray_DATA(self), (Py_ssize_t) numbytes);
     }
     else {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1112,7 +1112,6 @@ PyArray_NewLikeArray(PyArrayObject *prototype, NPY_ORDER order,
         int idim;
 
         PyArray_CreateSortedStridePerm(PyArray_NDIM(prototype),
-                                        PyArray_SHAPE(prototype),
                                         PyArray_STRIDES(prototype),
                                         strideperm);
 

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -3921,7 +3921,7 @@ PyArray_PrepareOneRawArrayIter(int ndim, npy_intp *shape,
     }
 
     /* Sort the axes based on the destination strides */
-    PyArray_CreateSortedStridePerm(ndim, shape, strides, strideperm);
+    PyArray_CreateSortedStridePerm(ndim, strides, strideperm);
     for (i = 0; i < ndim; ++i) {
         int iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
@@ -4051,7 +4051,7 @@ PyArray_PrepareTwoRawArrayIter(int ndim, npy_intp *shape,
     }
 
     /* Sort the axes based on the destination strides */
-    PyArray_CreateSortedStridePerm(ndim, shape, stridesA, strideperm);
+    PyArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
     for (i = 0; i < ndim; ++i) {
         int iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
@@ -4185,7 +4185,7 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
     }
 
     /* Sort the axes based on the destination strides */
-    PyArray_CreateSortedStridePerm(ndim, shape, stridesA, strideperm);
+    PyArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
     for (i = 0; i < ndim; ++i) {
         int iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -101,23 +101,7 @@ _UpdateContiguousFlags(PyArrayObject *ap)
     int i;
     npy_bool is_c_contig = 1;
 
-    if (PyArray_NDIM(ap) == 0) {
-        PyArray_ENABLEFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
-        PyArray_ENABLEFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
-        return;
-    }
     sd = PyArray_DESCR(ap)->elsize;
-    if (PyArray_NDIM(ap) == 1) {
-        if (PyArray_DIMS(ap)[0] == 1 || sd == PyArray_STRIDES(ap)[0]) {
-            PyArray_ENABLEFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
-            PyArray_ENABLEFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
-            return;
-        }
-        PyArray_CLEARFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
-        PyArray_CLEARFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
-        return;
-    }
-
     for (i = PyArray_NDIM(ap) - 1; i >= 0; --i) {
         dim = PyArray_DIMS(ap)[i];
         /* contiguous by definition */

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -15,11 +15,8 @@
 
 #include "common.h"
 
-static int
-_IsContiguous(PyArrayObject *ap);
-
-static int
-_IsFortranContiguous(PyArrayObject *ap);
+static void
+_UpdateContiguousFlags(PyArrayObject *ap);
 
 /*NUMPY_API
  *
@@ -62,28 +59,9 @@ PyArray_NewFlagsObject(PyObject *obj)
 NPY_NO_EXPORT void
 PyArray_UpdateFlags(PyArrayObject *ret, int flagmask)
 {
-
-    if (flagmask & NPY_ARRAY_F_CONTIGUOUS) {
-        if (_IsFortranContiguous(ret)) {
-            PyArray_ENABLEFLAGS(ret, NPY_ARRAY_F_CONTIGUOUS);
-            if (PyArray_NDIM(ret) > 1) {
-                PyArray_CLEARFLAGS(ret, NPY_ARRAY_C_CONTIGUOUS);
-            }
-        }
-        else {
-            PyArray_CLEARFLAGS(ret, NPY_ARRAY_F_CONTIGUOUS);
-        }
-    }
-    if (flagmask & NPY_ARRAY_C_CONTIGUOUS) {
-        if (_IsContiguous(ret)) {
-            PyArray_ENABLEFLAGS(ret, NPY_ARRAY_C_CONTIGUOUS);
-            if (PyArray_NDIM(ret) > 1) {
-                PyArray_CLEARFLAGS(ret, NPY_ARRAY_F_CONTIGUOUS);
-            }
-        }
-        else {
-            PyArray_CLEARFLAGS(ret, NPY_ARRAY_C_CONTIGUOUS);
-        }
+    /* Always update both, as its not trivial to guess one from the other */
+    if (flagmask & (NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_C_CONTIGUOUS)) {
+        _UpdateContiguousFlags(ret);
     }
     if (flagmask & NPY_ARRAY_ALIGNED) {
         if (_IsAligned(ret)) {
@@ -110,66 +88,71 @@ PyArray_UpdateFlags(PyArrayObject *ret, int flagmask)
 
 /*
  * Check whether the given array is stored contiguously
- * (row-wise) in memory.
+ * in memory. And update the passed in ap apropriately.
  *
- * 0-strided arrays are not contiguous (even if dimension == 1)
+ * 0-strided arrays are not contiguous. A dimension == 1 is always ok.
  */
-static int
-_IsContiguous(PyArrayObject *ap)
+static void
+_UpdateContiguousFlags(PyArrayObject *ap)
 {
     npy_intp sd;
     npy_intp dim;
     int i;
+    npy_bool is_c_contig = 1;
 
     if (PyArray_NDIM(ap) == 0) {
-        return 1;
+        PyArray_ENABLEFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
+        PyArray_ENABLEFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
+        return;
     }
     sd = PyArray_DESCR(ap)->elsize;
     if (PyArray_NDIM(ap) == 1) {
-        return PyArray_DIMS(ap)[0] == 1 || sd == PyArray_STRIDES(ap)[0];
+        if (PyArray_DIMS(ap)[0] == 1 || sd == PyArray_STRIDES(ap)[0]) {
+            PyArray_ENABLEFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
+            PyArray_ENABLEFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
+            return;
+        }
+        PyArray_CLEARFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
+        PyArray_CLEARFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
+        return;
     }
+
     for (i = PyArray_NDIM(ap) - 1; i >= 0; --i) {
         dim = PyArray_DIMS(ap)[i];
         /* contiguous by definition */
         if (dim == 0) {
-            return 1;
+            PyArray_ENABLEFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
+            PyArray_ENABLEFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
+            return;
         }
-        if (PyArray_STRIDES(ap)[i] != sd) {
-            return 0;
+        if (dim != 1) {
+            if (PyArray_STRIDES(ap)[i] != sd) {
+                is_c_contig = 0;
+            }
+            sd *= dim;
         }
-        sd *= dim;
     }
-    return 1;
-}
-
-
-/* 0-strided arrays are not contiguous (even if dimension == 1) */
-static int
-_IsFortranContiguous(PyArrayObject *ap)
-{
-    npy_intp sd;
-    npy_intp dim;
-    int i;
-
-    if (PyArray_NDIM(ap) == 0) {
-        return 1;
+    if (is_c_contig) {
+        PyArray_ENABLEFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
     }
+    else {
+        PyArray_CLEARFLAGS(ap, NPY_ARRAY_C_CONTIGUOUS);
+    }
+
+    /* check if fortran contiguous */
     sd = PyArray_DESCR(ap)->elsize;
-    if (PyArray_NDIM(ap) == 1) {
-        return PyArray_DIMS(ap)[0] == 1 || sd == PyArray_STRIDES(ap)[0];
-    }
     for (i = 0; i < PyArray_NDIM(ap); ++i) {
         dim = PyArray_DIMS(ap)[i];
-        /* fortran contiguous by definition */
-        if (dim == 0) {
-            return 1;
+        if (dim != 1) {
+            if (PyArray_STRIDES(ap)[i] != sd) {
+                PyArray_CLEARFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
+                return;
+            }
+            sd *= dim;
         }
-        if (PyArray_STRIDES(ap)[i] != sd) {
-            return 0;
-        }
-        sd *= dim;
     }
-    return 1;
+    PyArray_ENABLEFLAGS(ap, NPY_ARRAY_F_CONTIGUOUS);
+    return;
 }
 
 static void

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -88,9 +88,10 @@ PyArray_UpdateFlags(PyArrayObject *ret, int flagmask)
 
 /*
  * Check whether the given array is stored contiguously
- * in memory. And update the passed in ap apropriately.
+ * in memory. And update the passed in ap flags apropriately.
  *
- * 0-strided arrays are not contiguous. A dimension == 1 is always ok.
+ * A dimension == 1 stride is ignored for contiguous flags and a 0-sized array
+ * is always both C- and F-Contiguous. 0-strided arrays are not contiguous.
  */
 static void
 _UpdateContiguousFlags(PyArrayObject *ap)

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1517,26 +1517,18 @@ PyArray_EquivTypenums(int typenum1, int typenum2)
 /*** END C-API FUNCTIONS **/
 
 static PyObject *
-_prepend_ones(PyArrayObject *arr, int nd, int ndmin, NPY_ORDER order)
+_prepend_ones(PyArrayObject *arr, int nd, int ndmin)
 {
     npy_intp newdims[NPY_MAXDIMS];
     npy_intp newstrides[NPY_MAXDIMS];
-    npy_intp newstride;
     int i, k, num;
     PyArrayObject *ret;
     PyArray_Descr *dtype;
 
-    if (order == NPY_FORTRANORDER || PyArray_ISFORTRAN(arr) || PyArray_NDIM(arr) == 0) {
-        newstride = PyArray_DESCR(arr)->elsize;
-    }
-    else {
-        newstride = PyArray_STRIDES(arr)[0] * PyArray_DIMS(arr)[0];
-    }
-
     num = ndmin - nd;
     for (i = 0; i < num; i++) {
         newdims[i] = 1;
-        newstrides[i] = newstride;
+        newstrides[i] = PyArray_DESCR(arr)->elsize;
     }
     for (i = num; i < ndmin; i++) {
         k = i - num;
@@ -1677,7 +1669,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
      * create a new array from the same data with ones in the shape
      * steals a reference to ret
      */
-    return _prepend_ones(ret, nd, ndmin, order);
+    return _prepend_ones(ret, nd, ndmin);
 
 clean_type:
     Py_XDECREF(type);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1566,8 +1566,8 @@ _prepend_ones(PyArrayObject *arr, int nd, int ndmin, NPY_ORDER order)
 #define STRIDING_OK(op, order) \
                 ((order) == NPY_ANYORDER || \
                  (order) == NPY_KEEPORDER || \
-                 ((order) == NPY_CORDER && PyArray_ISCONTIGUOUS(op)) || \
-                 ((order) == NPY_FORTRANORDER && PyArray_ISFORTRAN(op)))
+                 ((order) == NPY_CORDER && PyArray_IS_C_CONTIGUOUS(op)) || \
+                 ((order) == NPY_FORTRANORDER && PyArray_IS_F_CONTIGUOUS(op)))
 
 static PyObject *
 _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -1015,10 +1015,10 @@ PyArray_Ravel(PyArrayObject *arr, NPY_ORDER order)
         }
     }
 
-    if (order == NPY_CORDER && PyArray_ISCONTIGUOUS(arr)) {
+    if (order == NPY_CORDER && PyArray_IS_C_CONTIGUOUS(arr)) {
         return PyArray_Newshape(arr, &newdim, NPY_CORDER);
     }
-    else if (order == NPY_FORTRANORDER && PyArray_ISFORTRAN(arr)) {
+    else if (order == NPY_FORTRANORDER && PyArray_IS_F_CONTIGUOUS(arr)) {
         return PyArray_Newshape(arr, &newdim, NPY_FORTRANORDER);
     }
     /* For KEEPORDER, check if we can make a flattened view */

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -823,7 +823,7 @@ int _npy_stride_sort_item_comparator(const void *a, const void *b)
         bstride = -bstride;
     }
 
-    if (astride == bstride || astride == 0 || bstride == 0) {
+    if (astride == bstride) {
         /*
          * Make the qsort stable by next comparing the perm order.
          * (Note that two perm entries will never be equal)
@@ -835,9 +835,7 @@ int _npy_stride_sort_item_comparator(const void *a, const void *b)
     if (astride > bstride) {
         return -1;
     }
-    else {
-        return 1;
-    }
+    return 1;
 }
 
 /*NUMPY_API
@@ -848,8 +846,7 @@ int _npy_stride_sort_item_comparator(const void *a, const void *b)
  * [(2, 12), (0, 4), (1, -2)].
  */
 NPY_NO_EXPORT void
-PyArray_CreateSortedStridePerm(int ndim, npy_intp *shape,
-                        npy_intp *strides,
+PyArray_CreateSortedStridePerm(int ndim, npy_intp *strides,
                         npy_stride_sort_item *out_strideperm)
 {
     int i;
@@ -857,12 +854,7 @@ PyArray_CreateSortedStridePerm(int ndim, npy_intp *shape,
     /* Set up the strideperm values */
     for (i = 0; i < ndim; ++i) {
         out_strideperm[i].perm = i;
-        if (shape[i] == 1) {
-            out_strideperm[i].stride = 0;
-        }
-        else {
-            out_strideperm[i].stride = strides[i];
-        }
+        out_strideperm[i].stride = strides[i];
     }
 
     /* Sort them */
@@ -1001,7 +993,7 @@ PyArray_Ravel(PyArrayObject *arr, NPY_ORDER order)
         npy_intp stride;
         int i, ndim = PyArray_NDIM(arr);
 
-        PyArray_CreateSortedStridePerm(PyArray_NDIM(arr), PyArray_SHAPE(arr),
+        PyArray_CreateSortedStridePerm(PyArray_NDIM(arr),
                                 PyArray_STRIDES(arr), strideperm);
 
         stride = strideperm[ndim-1].stride;

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -267,32 +267,6 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
             }
         }
     }
-    else if (ndim > 0) {
-        /*
-         * replace any 0-valued strides with
-         * appropriate value to preserve contiguousness
-         */
-        if (order == NPY_FORTRANORDER) {
-            if (dimensions[0] == 1) {
-                strides[0] = PyArray_DESCR(self)->elsize;
-            }
-            for (i = 1; i < ndim; i++) {
-                if (dimensions[i] == 1) {
-                    strides[i] = strides[i-1] * dimensions[i-1];
-                }
-            }
-        }
-        else {
-            if (dimensions[ndim-1] == 1) {
-                strides[ndim-1] = PyArray_DESCR(self)->elsize;
-            }
-            for (i = ndim - 2; i > -1; i--) {
-                if (dimensions[i] == 1) {
-                    strides[i] = strides[i+1] * dimensions[i+1];
-                }
-            }
-        }
-    }
 
     Py_INCREF(PyArray_DESCR(self));
     ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self),
@@ -1164,6 +1138,8 @@ build_shape_string(npy_intp n, npy_intp *vals)
  * WARNING: If an axis flagged for removal has a shape equal to zero,
  *          the array will point to invalid memory. The caller must
  *          validate this!
+ *          If an axis flagged for removal has a shape larger then one,
+ *          the arrays contiguous flags may require updating.
  *
  * For example, this can be used to remove the reduction axes
  * from a reduction result once its computation is complete.
@@ -1186,7 +1162,4 @@ PyArray_RemoveAxesInPlace(PyArrayObject *arr, npy_bool *flags)
 
     /* The final number of dimensions */
     fa->nd = idim_out;
-    
-    /* Update contiguous flags */
-    PyArray_UpdateFlags(arr, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
 }

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -554,7 +554,7 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                     stride = ((PyArray_NDIM(arr) == 0) ? 0 : \
                                     ((PyArray_NDIM(arr) == 1) ? \
                                             PyArray_STRIDE(arr, 0) : \
-                                            PyArray_DESCR(arr)->elsize)) \
+                                            PyArray_ITEMSIZE(arr))) \
 
 
 #define PyArray_TRIVIALLY_ITERABLE_PAIR(arr1, arr2) (\
@@ -577,10 +577,10 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                     data2 = PyArray_BYTES(arr2); \
                     stride1 = (size1 == 1 ? 0 : ((PyArray_NDIM(arr1) == 1) ? \
                                                 PyArray_STRIDE(arr1, 0) : \
-                                                PyArray_DESCR(arr1)->elsize)); \
+                                                PyArray_ITEMSIZE(arr1))); \
                     stride2 = (size2 == 1 ? 0 : ((PyArray_NDIM(arr2) == 1) ? \
                                                 PyArray_STRIDE(arr2, 0) : \
-                                                PyArray_DESCR(arr2)->elsize)); \
+                                                PyArray_ITEMSIZE(arr2))); \
                 }
 
 #define PyArray_TRIVIALLY_ITERABLE_TRIPLE(arr1, arr2, arr3) (\
@@ -618,13 +618,13 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                     data3 = PyArray_BYTES(arr3); \
                     stride1 = (size1 == 1 ? 0 : ((PyArray_NDIM(arr1) == 1) ? \
                                                 PyArray_STRIDE(arr1, 0) : \
-                                                PyArray_DESCR(arr1)->elsize)); \
+                                                PyArray_ITEMSIZE(arr1))); \
                     stride2 = (size2 == 1 ? 0 : ((PyArray_NDIM(arr2) == 1) ? \
                                                 PyArray_STRIDE(arr2, 0) : \
-                                                PyArray_DESCR(arr2)->elsize)); \
+                                                PyArray_ITEMSIZE(arr2))); \
                     stride3 = (size3 == 1 ? 0 : ((PyArray_NDIM(arr3) == 1) ? \
                                                 PyArray_STRIDE(arr3, 0) : \
-                                                PyArray_DESCR(arr3)->elsize)); \
+                                                PyArray_ITEMSIZE(arr3))); \
                 }
 
 #endif

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -552,10 +552,10 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                     count = PyArray_SIZE(arr), \
                     data = PyArray_BYTES(arr), \
                     stride = ((PyArray_NDIM(arr) == 0) ? 0 : \
-                            (PyArray_CHKFLAGS(arr, NPY_ARRAY_F_CONTIGUOUS) ? \
+                                    ((PyArray_NDIM(arr) == 1) ? \
                                             PyArray_STRIDE(arr, 0) : \
-                                            PyArray_STRIDE(arr, \
-                                                PyArray_NDIM(arr)-1)))
+                                            PyArray_DESCR(arr)->elsize)) \
+
 
 #define PyArray_TRIVIALLY_ITERABLE_PAIR(arr1, arr2) (\
                     PyArray_TRIVIALLY_ITERABLE(arr1) && \
@@ -575,16 +575,12 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                     count = ((size1 > size2) || size1 == 0) ? size1 : size2; \
                     data1 = PyArray_BYTES(arr1); \
                     data2 = PyArray_BYTES(arr2); \
-                    stride1 = (size1 == 1 ? 0 : \
-                            (PyArray_CHKFLAGS(arr1, NPY_ARRAY_F_CONTIGUOUS) ? \
-                                            PyArray_STRIDE(arr1, 0) : \
-                                            PyArray_STRIDE(arr1, \
-                                                PyArray_NDIM(arr1)-1))); \
-                    stride2 = (size2 == 1 ? 0 : \
-                            (PyArray_CHKFLAGS(arr2, NPY_ARRAY_F_CONTIGUOUS) ? \
-                                            PyArray_STRIDE(arr2, 0) : \
-                                            PyArray_STRIDE(arr2, \
-                                                PyArray_NDIM(arr2)-1))); \
+                    stride1 = (size1 == 1 ? 0 : ((PyArray_NDIM(arr1) == 1) ? \
+                                                PyArray_STRIDE(arr1, 0) : \
+                                                PyArray_DESCR(arr1)->elsize)); \
+                    stride2 = (size2 == 1 ? 0 : ((PyArray_NDIM(arr2) == 1) ? \
+                                                PyArray_STRIDE(arr2, 0) : \
+                                                PyArray_DESCR(arr2)->elsize)); \
                 }
 
 #define PyArray_TRIVIALLY_ITERABLE_TRIPLE(arr1, arr2, arr3) (\
@@ -620,21 +616,15 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                     data1 = PyArray_BYTES(arr1); \
                     data2 = PyArray_BYTES(arr2); \
                     data3 = PyArray_BYTES(arr3); \
-                    stride1 = (size1 == 1 ? 0 : \
-                            (PyArray_CHKFLAGS(arr1, NPY_ARRAY_F_CONTIGUOUS) ? \
-                                            PyArray_STRIDE(arr1, 0) : \
-                                            PyArray_STRIDE(arr1, \
-                                                PyArray_NDIM(arr1)-1))); \
-                    stride2 = (size2 == 1 ? 0 : \
-                            (PyArray_CHKFLAGS(arr2, NPY_ARRAY_F_CONTIGUOUS) ? \
-                                            PyArray_STRIDE(arr2, 0) : \
-                                            PyArray_STRIDE(arr2, \
-                                                PyArray_NDIM(arr2)-1))); \
-                    stride3 = (size3 == 1 ? 0 : \
-                            (PyArray_CHKFLAGS(arr3, NPY_ARRAY_F_CONTIGUOUS) ? \
-                                            PyArray_STRIDE(arr3, 0) : \
-                                            PyArray_STRIDE(arr3, \
-                                                PyArray_NDIM(arr3)-1))); \
+                    stride1 = (size1 == 1 ? 0 : ((PyArray_NDIM(arr1) == 1) ? \
+                                                PyArray_STRIDE(arr1, 0) : \
+                                                PyArray_DESCR(arr1)->elsize)); \
+                    stride2 = (size2 == 1 ? 0 : ((PyArray_NDIM(arr2) == 1) ? \
+                                                PyArray_STRIDE(arr2, 0) : \
+                                                PyArray_DESCR(arr2)->elsize)); \
+                    stride3 = (size3 == 1 ? 0 : ((PyArray_NDIM(arr3) == 1) ? \
+                                                PyArray_STRIDE(arr3, 0) : \
+                                                PyArray_DESCR(arr3)->elsize)); \
                 }
 
 #endif

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -51,7 +51,7 @@ allocate_reduce_result(PyArrayObject *arr, npy_bool *axis_flags,
         Py_INCREF(dtype);
     }
 
-    PyArray_CreateSortedStridePerm(PyArray_NDIM(arr), PyArray_SHAPE(arr),
+    PyArray_CreateSortedStridePerm(PyArray_NDIM(arr),
                                     PyArray_STRIDES(arr), strideperm);
 
     /* Build the new strides and shape */

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -138,9 +138,9 @@ def test_copyto():
     assert_raises(TypeError, np.copyto, [1,2,3], [2,3,4])
 
 def test_copy_order():
-    a = np.arange(24).reshape(2,3,4)
+    a = np.arange(24).reshape(2,1,3,4)
     b = a.copy(order='F')
-    c = np.arange(24).reshape(2,4,3).swapaxes(1,2)
+    c = np.arange(24).reshape(2,1,4,3).swapaxes(2,3)
 
     def check_copy_result(x, y, ccontig, fcontig, strides=False):
         assert_(not (x is y))

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -61,6 +61,16 @@ class TestRegression(TestCase):
         np.zeros([3], order='C')
         np.zeros([3], int, order='C')
 
+    def test_asarray_with_order(self,level=rlevel):
+        """Check that nothing is done when order='F' and array C/F-contiguous"""
+        a = np.ones(2)
+        assert_(a is np.asarray(a, order='F'))
+
+    def test_ravel_with_order(self,level=rlevel):
+        """Check that ravel works when order='F' and array C/F-contiguous"""
+        a = np.ones(2)
+        assert_(not a.ravel('F').flags.owndata)
+
     def test_sort_bigendian(self,level=rlevel):
         """Ticket #47"""
         a = np.linspace(0, 10, 11)

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -86,14 +86,14 @@ class TestNdpointer(TestCase):
         self.assertTrue(p.from_param(np.array(1)))
 
     def test_flags(self):
-        x = np.array([[1,2,3]], order='F')
+        x = np.array([[1,2],[3,4]], order='F')
         p = ndpointer(flags='FORTRAN')
         self.assertTrue(p.from_param(x))
         p = ndpointer(flags='CONTIGUOUS')
         self.assertRaises(TypeError, p.from_param, x)
         p = ndpointer(flags=x.flags.num)
         self.assertTrue(p.from_param(x))
-        self.assertRaises(TypeError, p.from_param, np.array([[1,2,3]]))
+        self.assertRaises(TypeError, p.from_param, np.array([[1,2],[3,4]]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements that ie. a 1x3x1 array will be both C- and F-Contiguous (or neither). I have mentioned this before and cleaned up the branch a little against current master and I though I am not completly certain I think it should cover the change fully.  I am not sure if the tests should be done differently or more extensive though.

Personally I see only one possible problem with it, and that is external libraries relying on `strides[-1] == itemsize` (for C-contiguous arrays) or `strides[0] == itemsize` (for F-Contiguous arrays). They could break in very bad ways then. I doubt this should be common or even occur, but there was code in numpy itself that relied on it.

I have run `scipy.test()` (admittingly old ubuntu) with this as well and no (new) errors occured even when I filled bogus values for the 1-dim strides in array creation. I have checked numpy test for that as well.

I have also removed some strides cleanup code, I don't really see much of a point to make strides look nice when it doesn't do anything else.

Because I am not sure what the special casing in `CreateSortedStridePerm` was for and I thought it might be to ensure contiguouity of the new array in some cases, I have reverted that change to it to fix Issue #434 with wrong sorting and included it here since the rest of this commit makes that kind of special casing unnecessary (so I am not sure the fix is quite correct outside of this context).
