### PR TITLE
BUG: Fix bug with size 1-dims in CreateSortedStridePerm

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1112,7 +1112,6 @@ PyArray_NewLikeArray(PyArrayObject *prototype, NPY_ORDER order,
         int idim;
 
         PyArray_CreateSortedStridePerm(PyArray_NDIM(prototype),
-                                        PyArray_SHAPE(prototype),
                                         PyArray_STRIDES(prototype),
                                         strideperm);
 

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -3921,7 +3921,7 @@ PyArray_PrepareOneRawArrayIter(int ndim, npy_intp *shape,
     }
 
     /* Sort the axes based on the destination strides */
-    PyArray_CreateSortedStridePerm(ndim, shape, strides, strideperm);
+    PyArray_CreateSortedStridePerm(ndim, strides, strideperm);
     for (i = 0; i < ndim; ++i) {
         int iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
@@ -4051,7 +4051,7 @@ PyArray_PrepareTwoRawArrayIter(int ndim, npy_intp *shape,
     }
 
     /* Sort the axes based on the destination strides */
-    PyArray_CreateSortedStridePerm(ndim, shape, stridesA, strideperm);
+    PyArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
     for (i = 0; i < ndim; ++i) {
         int iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
@@ -4185,7 +4185,7 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
     }
 
     /* Sort the axes based on the destination strides */
-    PyArray_CreateSortedStridePerm(ndim, shape, stridesA, strideperm);
+    PyArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
     for (i = 0; i < ndim; ++i) {
         int iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -849,7 +849,7 @@ int _npy_stride_sort_item_comparator(const void *a, const void *b)
         bstride = -bstride;
     }
 
-    if (astride == bstride || astride == 0 || bstride == 0) {
+    if (astride == bstride) {
         /*
          * Make the qsort stable by next comparing the perm order.
          * (Note that two perm entries will never be equal)
@@ -861,9 +861,7 @@ int _npy_stride_sort_item_comparator(const void *a, const void *b)
     if (astride > bstride) {
         return -1;
     }
-    else {
-        return 1;
-    }
+    return 1;
 }
 
 /*NUMPY_API
@@ -874,8 +872,7 @@ int _npy_stride_sort_item_comparator(const void *a, const void *b)
  * [(2, 12), (0, 4), (1, -2)].
  */
 NPY_NO_EXPORT void
-PyArray_CreateSortedStridePerm(int ndim, npy_intp *shape,
-                        npy_intp *strides,
+PyArray_CreateSortedStridePerm(int ndim, npy_intp *strides,
                         npy_stride_sort_item *out_strideperm)
 {
     int i;
@@ -883,12 +880,7 @@ PyArray_CreateSortedStridePerm(int ndim, npy_intp *shape,
     /* Set up the strideperm values */
     for (i = 0; i < ndim; ++i) {
         out_strideperm[i].perm = i;
-        if (shape[i] == 1) {
-            out_strideperm[i].stride = 0;
-        }
-        else {
-            out_strideperm[i].stride = strides[i];
-        }
+        out_strideperm[i].stride = strides[i];
     }
 
     /* Sort them */
@@ -1027,7 +1019,7 @@ PyArray_Ravel(PyArrayObject *arr, NPY_ORDER order)
         npy_intp stride;
         int i, ndim = PyArray_NDIM(arr);
 
-        PyArray_CreateSortedStridePerm(PyArray_NDIM(arr), PyArray_SHAPE(arr),
+        PyArray_CreateSortedStridePerm(PyArray_NDIM(arr),
                                 PyArray_STRIDES(arr), strideperm);
 
         stride = strideperm[ndim-1].stride;

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -51,7 +51,7 @@ allocate_reduce_result(PyArrayObject *arr, npy_bool *axis_flags,
         Py_INCREF(dtype);
     }
 
-    PyArray_CreateSortedStridePerm(PyArray_NDIM(arr), PyArray_SHAPE(arr),
+    PyArray_CreateSortedStridePerm(PyArray_NDIM(arr),
                                     PyArray_STRIDES(arr), strideperm);
 
     /* Build the new strides and shape */
@@ -60,7 +60,7 @@ allocate_reduce_result(PyArrayObject *arr, npy_bool *axis_flags,
     for (idim = ndim-1; idim >= 0; --idim) {
         npy_intp i_perm = strideperm[idim].perm;
         if (axis_flags[i_perm]) {
-            strides[i_perm] = 0;
+            strides[i_perm] = stride;
             shape[i_perm] = 1;
         }
         else {

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -138,9 +138,9 @@ def test_copyto():
     assert_raises(TypeError, np.copyto, [1,2,3], [2,3,4])
 
 def test_copy_order():
-    a = np.arange(24).reshape(2,3,4)
+    a = np.arange(24).reshape(2,1,3,4)
     b = a.copy(order='F')
-    c = np.arange(24).reshape(2,4,3).swapaxes(1,2)
+    c = np.arange(24).reshape(2,1,4,3).swapaxes(2,3)
 
     def check_copy_result(x, y, ccontig, fcontig, strides=False):
         assert_(not (x is y))


### PR DESCRIPTION
This changes CreateSortedStridedPerm to not use the shape for special casing 1-dim axis. The cleanup does not seem to be useful in most cases and the current way is buggy. Also insert stride so that reduce with keepdims=1 will keep contiguous arrays contiguous. "Closes Issue #434"

Sorry if a PR against 1.7. is the wrong thing at this point. But to me this seems the easiest way to avoid any headaches.
