### PR TITLE
BUG: Avoid regression in np.insert for axis!=0 or None

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3598,14 +3598,9 @@ def insert(arr, obj, values, axis=None):
             raise ValueError(
                     "index (%d) out of range (0<=index<=%d) "\
                     "in dimension %d" % (obj, N, axis))
-        if isscalar(values):
-            obj = [obj]
-        else:
-            values = asarray(values)
-            if ndim > values.ndim:
-                obj = [obj]
-            else:
-                obj = [obj] * len(values)
+        values = array(values, copy=False, ndmin=arr.ndim)
+        values = np.rollaxis(values, 0, axis+1)
+        obj = [obj] * values.shape[axis]
 
     elif isinstance(obj, slice):
         # turn it into a range object

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -155,7 +155,9 @@ class TestInsert(TestCase):
              [1, 1, 1]]
         assert_equal(insert(a, 0, [2, 2, 2], axis=0), r)
         assert_equal(insert(a, 0, 2, axis=0), r)
-        assert_equal(insert(a, 2, 2, axis=1), [[1, 1, 2, 1]])
+        a = np.arange(4).reshape(2,2)
+        assert_equal(insert(a[:,:1], 1, a[:,1], axis=1), a)
+        assert_equal(insert(a[:1,:], 1, a[1,:], axis=0), a)
 
 class TestAmax(TestCase):
     def test_basic(self):


### PR DESCRIPTION
This avoids a regression with insert failing where it worked before when inserting a full array with a scalar and axis!=0. See also Issue #378 and #452. There is a larger explanation in #378. 

I really think that introducing this regression should probably be avoided. A more extensive (compatible) change for development branch in #452. This is a minimal change to make `np.insert` in 1.7. compatible with 1.6.
