### PR TITLE
BUG: copy.(deep)copy should preserve F-contiguity

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1026,6 +1026,16 @@ array_copy(PyArrayObject *self, PyObject *args, PyObject *kwds)
     return PyArray_NewCopy(self, order);
 }
 
+/* Separate from array_copy to make __copy__ preserve Fortran contiguity. */
+static PyObject *
+array_copy_keeporder(PyArrayObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+    return PyArray_NewCopy(self, NPY_KEEPORDER);
+}
+
 #include <stdio.h>
 static PyObject *
 array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
@@ -1290,7 +1300,7 @@ array_deepcopy(PyArrayObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O", &visit)) {
         return NULL;
     }
-    ret = (PyArrayObject *)PyArray_Copy(self);
+    ret = (PyArrayObject *)PyArray_NewCopy(self, NPY_KEEPORDER);
     if (PyDataType_REFCHK(PyArray_DESCR(self))) {
         copy = PyImport_ImportModule("copy");
         if (copy == NULL) {
@@ -2151,8 +2161,8 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
 
     /* for the copy module */
     {"__copy__",
-        (PyCFunction)array_copy,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        (PyCFunction)array_copy_keeporder,
+        METH_VARARGS, NULL},
     {"__deepcopy__",
         (PyCFunction)array_deepcopy,
         METH_VARARGS, NULL},

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -626,6 +626,30 @@ class TestMethods(TestCase):
         d.sort()
         assert_equal(d, c, "test sort with default axis")
 
+    def test_copy(self):
+        def assert_fortran(arr):
+            assert_(arr.flags.fortran)
+            assert_(arr.flags.f_contiguous)
+            assert_(not arr.flags.c_contiguous)
+
+        def assert_c(arr):
+            assert_(not arr.flags.fortran)
+            assert_(not arr.flags.f_contiguous)
+            assert_(arr.flags.c_contiguous)
+
+        a = np.empty((2, 2), order='F')
+        # Test copying a Fortran array
+        assert_c(a.copy())
+        assert_c(a.copy('C'))
+        assert_fortran(a.copy('F'))
+        assert_fortran(a.copy('A'))
+
+        # Now test starting with a C array.
+        a = np.empty((2, 2), order='C')
+        assert_c(a.copy())
+        assert_c(a.copy('C'))
+        assert_fortran(a.copy('F'))
+        assert_c(a.copy('A'))
 
     def test_sort_order(self):
         # Test sorting an array with fields

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1784,5 +1784,15 @@ class TestRegression(TestCase):
         a = np.recarray((2, ), dtype)
         assert_raises(TypeError, np.searchsorted, a, 1)
 
+    def test_copymodule_preserves_f_contiguity(self):
+        a = np.empty((2, 2), order='F')
+        b = copy.copy(a)
+        c = copy.deepcopy(a)
+        assert_(b.flags.fortran)
+        assert_(b.flags.f_contiguous)
+        assert_(c.flags.fortran)
+        assert_(c.flags.f_contiguous)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Currently, copy.deepcopy() on certain objects in scikit-learn results in the copied object being broken, as underlying methods depend on members being F-contiguous. I can think of no reason that F-contiguous arrays should not remain F-contiguous through a copy.copy/copy.deepcopy, therefore this alters the methods to use NPY_KEEPORDER when allocating the copy.
