### PR TITLE
BUG: Reshape of 0-sized arrays failed to work without copy

### DIFF
--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -187,6 +187,11 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
     if (order == NPY_ANYORDER) {
         order = PyArray_ISFORTRAN(self);
     }
+    else if (order == NPY_KEEPORDER) {
+        PyErr_SetString(PyExc_ValueError,
+                "order 'K' is not permitted for reshaping");
+        return NULL;
+    }
     /*  Quick check to make sure anything actually needs to be done */
     if (ndim == PyArray_NDIM(self)) {
         same = NPY_TRUE;
@@ -230,11 +235,8 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
          * because we can't just re-use the buffer with the
          * data in the order it is in.
          */
-        if (!(PyArray_ISONESEGMENT(self)) ||
-            (((PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS) &&
-               order == NPY_FORTRANORDER) ||
-              (PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS) &&
-                  order == NPY_CORDER)) && (PyArray_NDIM(self) > 1))) {
+        if ((order == NPY_CORDER && !PyArray_IS_C_CONTIGUOUS(self)) ||
+            (order == NPY_FORTRANORDER && !PyArray_IS_F_CONTIGUOUS(self))) {
             int success = 0;
             success = _attempt_nocopy_reshape(self, ndim, dimensions,
                                               newstrides, order);

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -521,6 +521,11 @@ class TestRegression(TestCase):
         a = np.lib.stride_tricks.as_strided(a, shape=(5,), strides=(0,))
         assert_(a.reshape(5,1).strides[0] == 0)
 
+    def test_reshape_zero_size(self, level=rlevel):
+        """Github Issue #2700, setting shape failed for 0-sized arrays"""
+        a = np.ones((0,2))
+        a.shape = (-1,2)
+
     def test_repeat_discont(self, level=rlevel):
         """Ticket #352"""
         a = np.arange(12).reshape(4,3)[:,2]


### PR DESCRIPTION
This also adds a check for order=Keeporder which is not supported. "closes Issue #2700"

I did not do this here, but I think the `PyArray_ISONESEGMENT` really does not need to check the dimensions. These arrays should always be both C- and F-contiguous (now).
