### PR TITLE
BUG: fix download link in setup.py (which is shown on PyPi).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,14 +48,14 @@ MAINTAINER_EMAIL    = "numpy-discussion@scipy.org"
 DESCRIPTION         = DOCLINES[0]
 LONG_DESCRIPTION    = "\n".join(DOCLINES[2:])
 URL                 = "http://numpy.scipy.org"
-DOWNLOAD_URL        = "http://sourceforge.net/project/showfiles.php?group_id=1369&package_id=175103"
+DOWNLOAD_URL        = "http://sourceforge.net/projects/numpy/files/NumPy/"
 LICENSE             = 'BSD'
 CLASSIFIERS         = filter(None, CLASSIFIERS.split('\n'))
 AUTHOR              = "Travis E. Oliphant, et.al."
 AUTHOR_EMAIL        = "oliphant@enthought.com"
 PLATFORMS           = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"]
-MAJOR               = 1 
-MINOR               = 8 
+MAJOR               = 1
+MINOR               = 8
 MICRO               = 0
 ISRELEASED          = False
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)


### PR DESCRIPTION
Closes Trac ticket 2243.

@certik: should be backported to 1.7.x

I'll upload a new PKGINFO to PyPi for 1.6.2 when this is merged.
