### PR TITLE
Fix a compilation problem introduced with numpy 1.7.

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1477,7 +1477,7 @@ PyArray_SETITEM(PyArrayObject *arr, char *itemptr, PyObject *v)
 
 /* These macros are deprecated as of NumPy 1.7. */
 #define PyArray_NDIM(obj) (((PyArrayObject_fields *)(obj))->nd)
-#define PyArray_BYTES(obj) ((char *)(((PyArrayObject_fields *)(obj))->data))
+#define PyArray_BYTES(obj) ((((PyArrayObject_fields *)(obj))->data))
 #define PyArray_DATA(obj) ((void *)(((PyArrayObject_fields *)(obj))->data))
 #define PyArray_DIMS(obj) (((PyArrayObject_fields *)(obj))->dimensions)
 #define PyArray_STRIDES(obj) (((PyArrayObject_fields *)(obj))->strides)


### PR DESCRIPTION
The problem is strange, the line I change didn't changed in numpy 1.7,
but this fix the compilation of Theano with master.
