### PR TITLE
Mistake in linalg.eig() documentation

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -946,7 +946,7 @@ def eig(a):
 
     The number `w` is an eigenvalue of `a` if there exists a vector
     `v` such that ``dot(a,v) = w * v``. Thus, the arrays `a`, `w`, and
-    `v` satisfy the equations ``dot(a[i,:], v[i]) = w[i] * v[:,i]``
+    `v` satisfy the equations ``dot(a[:,:], v[:,i]) = w[i] * v[:,i]``
     for :math:`i \\in \\{0,...,M-1\\}`.
 
     The array `v` of eigenvectors may not be of maximum rank, that is, some


### PR DESCRIPTION
Proposed commit fixes a mistake in the formula currently written as dot(a[i,:], v[i]) = w[i] \* v[:,i].  Here is the demonstration that it is incorrect:

> > > a
> > > array([[ 1.0093272 ,  0.73994495,  1.50512547],
> > >        [ 0.73994495,  1.085796  ,  1.33086593],
> > >        [ 1.50512547,  1.33086593,  1.39161296]])
> > > w, v = eig(a)
> > > i = 1
> > > w[i] \* v[:,i]
> > > array([-0.20045129,  0.2535517 , -0.03350537])

but

> > > dot(a[i,:], v[i])
> > > -0.0096475519217383288

On the other hand,

> > > dot(a[:,:], v[:,i])
> > > array([-0.20045129,  0.2535517 , -0.03350537])

Explicit ':' slicing of a is redundant, but I think it makes documentation clearer by emphasizing the rank of a.
