### PR TITLE
BUG: fix Python 2.4 build with NPY_SEPARATE_COMPILATION

### DIFF
--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -21,7 +21,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 
 #include "lowlevel_strided_loops.h"
 #include "reduction.h"


### PR DESCRIPTION
Trivial fix, missing Py_TYPE compatibility definition on Python 2.4.
