### PR TITLE
Cope with MSVC v10 aka 2010

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -461,13 +461,16 @@ _MSVCRVER_TO_FULLVER = {}
 if sys.platform == 'win32':
     try:
         import msvcrt
-        if hasattr(msvcrt, "CRT_ASSEMBLY_VERSION"):
-            _MSVCRVER_TO_FULLVER['90'] = msvcrt.CRT_ASSEMBLY_VERSION
-        else:
-            _MSVCRVER_TO_FULLVER['90'] = "9.0.21022.8"
         # I took one version in my SxS directory: no idea if it is the good
         # one, and we can't retrieve it from python
         _MSVCRVER_TO_FULLVER['80'] = "8.0.50727.42"
+        _MSVCRVER_TO_FULLVER['90'] = "9.0.21022.8"
+        # Value from msvcrt.CRT_ASSEMBLY_VERSION under Python 3.3.0 on Windows XP:
+        _MSVCRVER_TO_FULLVER['100'] = "10.0.30319.460"
+        if hasattr(msvcrt, "CRT_ASSEMBLY_VERSION"):
+            major, minor, rest = msvcrt.CRT_ASSEMBLY_VERSION.split(".",2)
+            _MSVCRVER_TO_FULLVER[major + minor] = msvcrt.CRT_ASSEMBLY_VERSION
+            del major, minor, rest
     except ImportError:
         # If we are here, means python was not built with MSVC. Not sure what to do
         # in that case: manifest building will fail, but it should not be used in

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -533,7 +533,10 @@ def check_embedded_msvcr_match_linked(msver):
     # embedding
     msvcv = msvc_runtime_library()
     if msvcv:
-        maj = int(msvcv[5:6])
+        assert msvcv.startswith("msvcr"), msvcv
+        # Dealing with something like "mscvr90" or "mscvr100", the last
+        # last digit is the minor release, want int("9") or int("10"):
+        maj = int(msvcv[5:-1])
         if not maj == int(msver):
             raise ValueError(
                   "Discrepancy between linked msvcr " \

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -359,6 +359,7 @@ def msvc_runtime_library():
                '1310' : 'msvcr71',    # MSVC 7.1
                '1400' : 'msvcr80',    # MSVC 8
                '1500' : 'msvcr90',    # MSVC 9 (VS 2008)
+               '1600' : 'msvcr100',   # MSVC 10 (aka 2010)
               }.get(msc_ver, None)
     else:
         lib = None


### PR DESCRIPTION
FAO of Ralf, following up this mailing list thread:

http://mail.scipy.org/pipermail/numpy-discussion/2012-November/064354.html
...
http://mail.scipy.org/pipermail/numpy-discussion/2012-November/064454.html

These three commits cope with MSCV v10, and allowed me to (eventually) compile NumPy from the trunk under Python 3.3 on Windows XP using mingw32 / gcc 3.4.4 from cygwin.

P.S. Please also consider backporting to the NumPy 1.7 branch.
