### PR TITLE
ENH: Remove the need for temporary copies in numpy.dot

### DIFF
--- a/numpy/core/blasdot/_dotblas.c
+++ b/numpy/core/blasdot/_dotblas.c
@@ -770,7 +770,6 @@ dotblas_matrixproduct(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject* kwa
          * using appropriate values of Order, Trans1, and Trans2.
          */
         if (!PyArray_IS_C_CONTIGUOUS(ap2) && !PyArray_IS_F_CONTIGUOUS(ap2)) {
-            printf("AA");
             PyObject *new = PyArray_Copy(ap2);
 
             Py_DECREF(ap2);


### PR DESCRIPTION
in numpy core, modified the blas function call to handle
C and F order arrays without the need for copy.
This brings a significant speed up for matrix multiplication
Added a full test for matrix multiplication in test_blasdot
### Pain point

Users get penalized in speed and memory for matrix multiplication when using non C contiguous arrays.
Current solutions are too involved
http://www.scipy.org/PerformanceTips
http://stackoverflow.com/questions/5990577/speeding-up-numpy-dot
### Approach

Modified dotblas.c to eliminate temporaries and use CblasTrans when appropriate
### Benefits
- Memory: no temporary copies
- Speed
  on a 2K x 2K matrix, float32

> > > In [3]: %timeit np.dot(big, big)
> > > before:>>> 10 loops, best of 3: 138 ms per loop
> > > after: >>> 10 loops, best of 3: 138 ms per loop
> > > 
> > > In [4]: %timeit np.dot(big, big.T)
> > > b:>>> 10 loops, best of 3: 166 ms per loop
> > > a:>>> 10 loops, best of 3: 102 ms per loop
> > > 
> > > In [5]: %timeit np.dot(big.T, big.T)
> > > b:>>> 10 loops, best of 3: 193 ms per loop
> > > a: >>> >>> 10 loops, best of 3: 138 ms per loop
> > > 
> > > In [6]: %timeit np.dot(big.T, big)
> > > b:>>> 10 loops, best of 3: 165 ms per loop
> > > a:>>> 10 loops, best of 3: 104 ms per loop
- No confusion to new users, no direct call to fblas

In the meantime, users can use this python code to get the same benefits:
http://pastebin.com/M8TfbURi
