### PR TITLE
Fix setting of fill_value for string columns in Python 3

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -414,7 +414,7 @@ def _check_fill_value(fill_value, ndtype):
             fill_value = np.array(_recursive_set_fill_value(fill_value, descr),
                                   dtype=ndtype)
     else:
-        if isinstance(fill_value, basestring) and (ndtype.char not in 'SV'):
+        if isinstance(fill_value, basestring) and (ndtype.char not in 'SVU'):
             fill_value = default_fill_value(ndtype)
         else:
             # In case we want to convert 1e+20 to int...

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -44,6 +44,11 @@ class TestRegression(TestCase):
         assert_(a.mask.ndim == 1)
         assert_(b.mask.ndim == 2)
 
+    def test_set_fill_value_unicode_py3(self):
+        """Ticket #2733"""
+        a = np.ma.masked_array(['a', 'b', 'c'], mask=[1, 0, 0])
+        a.fill_value = 'X'
+        assert a.fill_value == 'X'
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -48,7 +48,7 @@ class TestRegression(TestCase):
         """Ticket #2733"""
         a = np.ma.masked_array(['a', 'b', 'c'], mask=[1, 0, 0])
         a.fill_value = 'X'
-        assert a.fill_value == 'X'
+        assert_(a.fill_value == 'X')
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
As first discovered in astropy/astropy#451 by @taldcroft, there is a bug with setting the fill value of a string array in MaskedArray with Python 3.x:

``` python
In [37]: d = ma.array(['w', 'y', 'z'], mask=[1,0,0])

In [38]: d
Out[38]: 
masked_array(data = [-- y z],
             mask = [ True False False],
       fill_value = N/A)


In [39]: d.fill_value='X'

In [40]: d
Out[40]: 
masked_array(data = [-- y z],
             mask = [ True False False],
       fill_value = N/A)
```

The attached code fixes this.
