### PR TITLE
REV: 8daf144 and following. Strides must be clean to be contiguous

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -756,9 +756,9 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_F_CONTIGUOUS    0x0002
 
 /*
- * Note: all 0-d arrays are C_CONTIGUOUS and F_CONTIGUOUS. An N-d
- * array that is C_CONTIGUOUS is also F_CONTIGUOUS if only
- * one axis has a dimension different from one (ie. a 1x3x1 array).
+ * Note: all 0-d arrays are C_CONTIGUOUS and F_CONTIGUOUS. If a
+ * 1-d array is C_CONTIGUOUS it is also F_CONTIGUOUS. Higher
+ * dimensional arrays can be both if they have a size of 0 or 1.
  */
 
 /*

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3572,8 +3572,7 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             strides[i] = itemsize;
             itemsize *= dims[i] ? dims[i] : 1;
         }
-        if ((nd != 0) && (strides[0] != strides[nd-1])) {
-            /* Unless all strides are itemsize its not both */
+        if ((nd > 1) && ((strides[0] != strides[nd-1]) || (dims[0] > 2))) {
             *objflags = ((*objflags)|NPY_ARRAY_F_CONTIGUOUS) &
                                             ~NPY_ARRAY_C_CONTIGUOUS;
         }
@@ -3586,7 +3585,7 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             strides[i] = itemsize;
             itemsize *= dims[i] ? dims[i] : 1;
         }
-        if ((nd != 0) && (strides[0] != strides[nd-1])) {
+        if ((nd > 1) && ((strides[0] != strides[nd-1]) || (dims[nd-1] > 2))) {
             *objflags = ((*objflags)|NPY_ARRAY_C_CONTIGUOUS) &
                                             ~NPY_ARRAY_F_CONTIGUOUS;
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3565,33 +3565,15 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
                     int inflag, int *objflags)
 {
     int i;
-    npy_bool not_cf_contig = 0;
-    npy_bool nod = 0; /* A dim != 1 was found */
-
-    /* Check if new array is both F- and C-contiguous */
-    for (i = 0; i < nd; i++) {
-        if (dims[i] != 1) {
-            if (nod) {
-                not_cf_contig = 1;
-                break;
-            }
-            nod = 1;
-        }
-    }
-
     /* Only make Fortran strides if not contiguous as well */
     if ((inflag & (NPY_ARRAY_F_CONTIGUOUS|NPY_ARRAY_C_CONTIGUOUS)) ==
                                             NPY_ARRAY_F_CONTIGUOUS) {
         for (i = 0; i < nd; i++) {
             strides[i] = itemsize;
-            if (dims[i]) {
-                itemsize *= dims[i];
-            }
-            else {
-                not_cf_contig = 0;
-            }
+            itemsize *= dims[i] ? dims[i] : 1;
         }
-        if (not_cf_contig) {
+        if ((nd != 0) && (strides[0] != strides[nd-1])) {
+            /* Unless all strides are itemsize its not both */
             *objflags = ((*objflags)|NPY_ARRAY_F_CONTIGUOUS) &
                                             ~NPY_ARRAY_C_CONTIGUOUS;
         }
@@ -3602,14 +3584,9 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
     else {
         for (i = nd - 1; i >= 0; i--) {
             strides[i] = itemsize;
-            if (dims[i]) {
-                itemsize *= dims[i];
-            }
-            else {
-                not_cf_contig = 0;
-            }
+            itemsize *= dims[i] ? dims[i] : 1;
         }
-        if (not_cf_contig) {
+        if ((nd != 0) && (strides[0] != strides[nd-1])) {
             *objflags = ((*objflags)|NPY_ARRAY_C_CONTIGUOUS) &
                                             ~NPY_ARRAY_F_CONTIGUOUS;
         }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1517,18 +1517,26 @@ PyArray_EquivTypenums(int typenum1, int typenum2)
 /*** END C-API FUNCTIONS **/
 
 static PyObject *
-_prepend_ones(PyArrayObject *arr, int nd, int ndmin)
+_prepend_ones(PyArrayObject *arr, int nd, int ndmin, NPY_ORDER order)
 {
     npy_intp newdims[NPY_MAXDIMS];
     npy_intp newstrides[NPY_MAXDIMS];
+    npy_intp newstride;
     int i, k, num;
     PyArrayObject *ret;
     PyArray_Descr *dtype;
 
+    if (order == NPY_FORTRANORDER || PyArray_ISFORTRAN(arr) || PyArray_NDIM(arr) == 0) {
+        newstride = PyArray_DESCR(arr)->elsize;
+    }
+    else {
+        newstride = PyArray_STRIDES(arr)[0] * PyArray_DIMS(arr)[0];
+    }
+
     num = ndmin - nd;
     for (i = 0; i < num; i++) {
         newdims[i] = 1;
-        newstrides[i] = PyArray_DESCR(arr)->elsize;
+        newstrides[i] = newstride;
     }
     for (i = num; i < ndmin; i++) {
         k = i - num;
@@ -1669,7 +1677,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
      * create a new array from the same data with ones in the shape
      * steals a reference to ret
      */
-    return _prepend_ones(ret, nd, ndmin);
+    return _prepend_ones(ret, nd, ndmin, order);
 
 clean_type:
     Py_XDECREF(type);

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -215,8 +215,9 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
      * because we can't just re-use the buffer with the
      * data in the order it is in.
      */
-    if ((order == NPY_CORDER && !PyArray_IS_C_CONTIGUOUS(self)) ||
-        (order == NPY_FORTRANORDER && !PyArray_IS_F_CONTIGUOUS(self))) {
+    if ((PyArray_SIZE(self) > 1) && 
+        ((order == NPY_CORDER && !PyArray_IS_C_CONTIGUOUS(self)) ||
+         (order == NPY_FORTRANORDER && !PyArray_IS_F_CONTIGUOUS(self)))) {
         int success = 0;
         success = _attempt_nocopy_reshape(self, ndim, dimensions,
                                           newstrides, order);
@@ -1076,8 +1077,6 @@ build_shape_string(npy_intp n, npy_intp *vals)
  * WARNING: If an axis flagged for removal has a shape equal to zero,
  *          the array will point to invalid memory. The caller must
  *          validate this!
- *          If an axis flagged for removal has a shape larger then one,
- *          the arrays contiguous flags may require updating.
  *
  * For example, this can be used to remove the reduction axes
  * from a reduction result once its computation is complete.
@@ -1100,4 +1099,6 @@ PyArray_RemoveAxesInPlace(PyArrayObject *arr, npy_bool *flags)
 
     /* The final number of dimensions */
     fa->nd = idim_out;
+
+    PyArray_UpdateFlags(arr, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
 }

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -204,7 +204,6 @@ def test_copy_order():
 
 def test_contiguous_flags():
     a = np.ones((4,4,1))[::2,:,:]
-    a.strides = a.strides[:2] + (-123,)
     b = np.ones((2,2,1,2,2)).swapaxes(3,4)
 
     def check_contig(a, ccontig, fcontig):
@@ -214,8 +213,8 @@ def test_contiguous_flags():
     # Check if new arrays are correct:
     check_contig(a, False, False)
     check_contig(b, False, False)
-    check_contig(np.empty((2,2,0,2,2)), True, True)
-    check_contig(np.array([[[1],[2]]], order='F'), True, True)
+    check_contig(np.empty((2,2,0,2,2)), True, False)
+    check_contig(np.array([[[1],[2]]], order='F'), False, True)
     check_contig(np.empty((2,2)), True, False)
     check_contig(np.empty((2,2), order='F'), False, True)
 
@@ -224,11 +223,11 @@ def test_contiguous_flags():
     check_contig(np.array(a, copy=False, order='C'), True, False)
     check_contig(np.array(a, ndmin=4, copy=False, order='F'), False, True)
 
-    # Check slicing update of flags and :
-    check_contig(a[0], True, True)
-    check_contig(a[None,::4,...,None], True, True)
-    check_contig(b[0,0,...], False, True)
-    check_contig(b[:,:,0:0,:,:], True, True)
+    # Check slicing update of flags:
+    check_contig(a[0], True, False)
+    # Would be nice if this was C-Contiguous:
+    check_contig(a[None,0,...,None], False, False)
+    check_contig(b[0,0,0,...], False, True)
 
     # Test ravel and squeeze.
     check_contig(a.ravel(), True, True)


### PR DESCRIPTION
This reverts those parts of PR gh-2694 that were directly related to the change in flag logic, since it seems that too much code relies at least on mostly clean strides. See also the discussion there.

Some changes remain:
1. 0-sized arrays are handled somewhat more stricter, forcing them to have matching strides including the dimension of size 0. (This means an array with `itemsize=8`, `strides=(16,)` and `shape=(0,)` is _not_ contiguous). This is mostly so that its really always true that if C-Contiguous then `strides[-1] == itemsize`, and I can't see it hurting, and it "fixes" a corner case in scikits-learn.
2. 0-sized arrays can be both C- and F-Contiguous.
3. 1-sized arrays will be both C- and F-Contiguous (or neither).

Though I would consider 2 and 3 fixes.

On a side note, I think there should be code to clean up strides a little (better). This applies to:
1. Newaxis in slicing operations
2. Copy with Keeporder
3. reduce operations with Keepdims=True

Oh, I think the `ISONESEGMENT` should at least a bit more accurately check for `SIZE < 1`, the `NDIM` check is superfluous anyway.
