### PR TITLE
FIX: Mark a tests knownfail on Hurd

### DIFF
--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -1,3 +1,4 @@
+import sys
 from tempfile import NamedTemporaryFile, mktemp
 import os
 
@@ -64,6 +65,7 @@ class TestMemmap(TestCase):
                     shape=self.shape)
         self.assertEqual(fp.filename, self.tmpfp.name)
 
+    @dec.knownfailureif(sys.platform=='gnu0', "This test is known to fail on hurd")
     def test_flush(self):
         fp = memmap(self.tmpfp, dtype=self.dtype, mode='w+',
                     shape=self.shape)


### PR DESCRIPTION
Fixes gh-415. This test raises "Function not implemented" on Hurd:

```
======================================================================
ERROR: test_flush (test_memmap.TestMemmap)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/buildd-python-numpy_1.7.0~b2-1-hurd-i386-Ws9GSv/python-numpy-1.7.0~b2/debian/tmp/usr/lib/python3/dist-packages/numpy/core/tests/test_memmap.py", line 72, in test_flush
    fp.flush()
  File "/build/buildd-python-numpy_1.7.0~b2-1-hurd-i386-Ws9GSv/python-numpy-1.7.0~b2/debian/tmp/usr/lib/python3/dist-packages/numpy/core/memmap.py", line 301, in flush
    self.base.flush()
mmap.error: [Errno 1073741902] Function not implemented
```

Which seems like a Hurd issue:

http://web.archiveorange.com/archive/v/dpz3Spjqy0ESHmXKVt7c

http://lists.gnu.org/archive/html/bug-hurd/2002-11/msg00243.html

So we mark it as knownfail on that platform.
