### PR TITLE
FIX: base always refers to the original subclass

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -168,8 +168,8 @@ PyArray_SetBaseObject(PyArrayObject *arr, PyObject *obj)
         if (tmp == NULL) {
             break;
         }
-        /* Stop the collapse new base would not be of the same type (i.e.
-	 * different subclass).
+        /* Stop the collapse new base when the would not be of the same 
+	 * type (i.e. different subclass).
          */
         if (Py_TYPE(tmp) != Py_TYPE(arr)) {
             break;

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -168,10 +168,10 @@ PyArray_SetBaseObject(PyArrayObject *arr, PyObject *obj)
         if (tmp == NULL) {
             break;
         }
-        /* Stop the collapse for array sub-classes if new base
-         *   would not be of the same type. 
+        /* Stop the collapse new base would not be of the same type (i.e.
+	 * different subclass).
          */
-        if (!(PyArray_CheckExact(arr)) & (Py_TYPE(tmp) != Py_TYPE(arr))) {
+        if (Py_TYPE(tmp) != Py_TYPE(arr)) {
             break;
         }
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -103,7 +103,7 @@ PyArray_SetUpdateIfCopyBase(PyArrayObject *arr, PyArrayObject *base)
     /*
      * Unlike PyArray_SetBaseObject, we do not compress the chain of base
      * references.
-    */
+     */
     ((PyArrayObject_fields *)arr)->base = (PyObject *)base;
     PyArray_ENABLEFLAGS(arr, NPY_ARRAY_UPDATEIFCOPY);
     PyArray_CLEARFLAGS(base, NPY_ARRAY_WRITEABLE);
@@ -169,7 +169,7 @@ PyArray_SetBaseObject(PyArrayObject *arr, PyObject *obj)
             break;
         }
         /* Stop the collapse new base when the would not be of the same 
-	 * type (i.e. different subclass).
+         * type (i.e. different subclass).
          */
         if (Py_TYPE(tmp) != Py_TYPE(arr)) {
             break;

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -3,7 +3,7 @@ from tempfile import NamedTemporaryFile, mktemp
 import os
 
 from numpy import memmap
-from numpy import arange, allclose
+from numpy import arange, allclose, asarray
 from numpy.testing import *
 
 class TestMemmap(TestCase):
@@ -112,6 +112,8 @@ class TestMemmap(TestCase):
         new2 = new1.view()
         assert(new1.base is fp)
         assert(new2.base is fp)
+        new_array = asarray(fp)
+        assert(new_array.base is fp)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Closes #470

The use case is that if b is a memmap, 'np.asarray(b).base' should be a
memmap, and thus we put is to b in such a situation.
