### PR TITLE
cannot access masked array rows with np.object dtype (Fixes #2432)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5509,8 +5509,7 @@ class mvoid(MaskedArray):
     #
     def __new__(self, data, mask=nomask, dtype=None, fill_value=None):
         dtype = dtype or data.dtype
-        _data = ndarray((), dtype=dtype)
-        _data[()] = data
+        _data = np.array(data, dtype=dtype)
         _data = _data.view(self)
         if mask is not nomask:
             if isinstance(mask, np.void):

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -502,6 +502,18 @@ class TestMRecordsImport(TestCase):
         assert_equal(mrec.f3, d)
         assert_equal(mrec.f3._mask, m)
 
+
+def test_record_array_with_object_field():
+    """
+    Trac #1839
+    """
+    y = ma.masked_array(
+        [(1,'2'), (3, '4')],
+        mask=[(0, 0), (0, 1)],
+        dtype=[('a', int), ('b', np.object)])
+    x = y[1]
+
+
 ###############################################################################
 #------------------------------------------------------------------------------
 if __name__ == "__main__":


### PR DESCRIPTION
In the astropy project we've run into bug #2432.  (See https://github.com/astropy/astropy/issues/465).  

This bug is made more prominent the recent commit 7caac2efd9b2, since `mvoid` arrays are created in all cases, not just when there are masked elements.

The fix here is just to use the Numpy array constructor instead of itemwise assignment, which does handle object fields correctly.

Hope this makes sense -- I can't say I'm an expert on the masked array code.
