### PR TITLE
ENH: Respect blas_opt and lapack_opt groups in site.cfg.

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1340,9 +1340,15 @@ Make sure that -lgfortran is used for C++ extensions.
 
 class lapack_opt_info(system_info):
 
+    section = 'lapack_opt'
     notfounderror = LapackNotFoundError
 
     def calc_info(self):
+
+        info = self.calc_libraries_info()
+        if info:
+            self.set_info(**info)
+            return
 
         if sys.platform == 'darwin' and not os.environ.get('ATLAS', None):
             args = []
@@ -1429,9 +1435,15 @@ class lapack_opt_info(system_info):
 
 class blas_opt_info(system_info):
 
+    section = 'blas_opt'
     notfounderror = BlasNotFoundError
 
     def calc_info(self):
+
+        info = self.calc_libraries_info()
+        if info:
+            self.set_info(**info)
+            return
 
         if sys.platform == 'darwin' and not os.environ.get('ATLAS', None):
             args = []


### PR DESCRIPTION
_Do not merge (yet)._

Previously blas_opt and lapack_opt would only be merged into the autodetected BLAS and LAPACK libraries. This prevented using custom LAPACK and BLAS implementation if a system installed version of ATLAS (or similar) was present.

Now the presence of a blas_opt or lapack_opt section completely overrides the respective autodetection mechanisms, as the `site.cfg` documentation would already lead you to believe.

I'm opening this for discussion.  There's a lot more backstory and some basic scripts (to be used to test the behavior of the autodetection) in  #2728.  I'm not convinced in any way that this is the "correct" approach to the problem.  Also it doesn't appear that the `language` parameter can be set this way -- but is it even necessary to set?
