### PR TITLE
BUG: Incorrect type in _attempt_nocopy_reshape

### DIFF
--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -355,8 +355,8 @@ _attempt_nocopy_reshape(PyArrayObject *self, int newnd, npy_intp* newdims,
     int oldnd;
     npy_intp olddims[NPY_MAXDIMS];
     npy_intp oldstrides[NPY_MAXDIMS];
+    npy_intp np, op;
     int oi, oj, ok, ni, nj, nk;
-    int np, op;
 
     oldnd = 0;
     for (oi = 0; oi < PyArray_NDIM(self); oi++) {


### PR DESCRIPTION
This caused a segmentation fault for some large reshapes as reported by Terry J. Ligocki on the mailing list.

I am not certain if this can be tested easily, because extremely large arrays would be needed that will not fit into RAM, or worse actually get initialized but just fit into RAM (I guess Linux does not matter if `np.empty` is used, but generally I am not certain).
