### PR TITLE
TST: also filter Cython warnings in NoseTester.  See PR-432.

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -365,6 +365,8 @@ class NoseTester(object):
             warnings.filterwarnings('error', category=warningtype)
         # Filter out annoying import messages.
         warnings.filterwarnings('ignore', message='Not importing directory')
+        warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+        warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
         try:
             from noseclasses import NumpyTestProgram


### PR DESCRIPTION
There a resetwarnings() call, so need to add back these filters.

Also needs backporting to 1.7.x
