### PR TITLE
A quicker way to set mask values.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3087,6 +3087,11 @@ class MaskedArray(ndarray):
             if self._hardmask:
                 current_mask |= mask
             # Softmask: set everything to False
+            # If it's obviously a compatible scalar, use a quick update
+            # method...
+            elif isinstance(mask, (int, float, np.number)):
+                current_mask[...] = mask
+            # ...otherwise fall back to the slower, general purpose way.
             else:
                 current_mask.flat = mask
         # Named fields w/ ............
@@ -3116,6 +3121,11 @@ class MaskedArray(ndarray):
                 for n in idtype.names:
                     current_mask[n] |= mask[n]
             # Softmask: set everything to False
+            # If it's obviously a compatible scalar, use a quick update
+            # method...
+            elif isinstance(mask, (int, float, np.number)):
+                current_mask[...] = mask
+            # ...otherwise fall back to the slower, general purpose way.
             else:
                 current_mask.flat = mask
         # Reshape if needed


### PR DESCRIPTION
Whilst profiling a library which uses NumPy I came across the following:

``` python
data = numpy.ma.zeros(array_shape)
data.mask = True
```

It turns out the assignment to the mask is very slow because MaskedArray.**setmask**() is using the `flat` iterator. For compatible scalars, this pull request swaps that for ellipsis indexing which is much, much faster.

For the record, a workaround in this case is:

``` python
raw_data = numpy.empty(array_shape)
mask = numpy.ones(array_shape, dtype=numpy.bool)
data = numpy.ma.MaskedArray(raw_data, mask=mask)
```
