### PR TITLE
Fix travis heisenbug

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4774,10 +4774,10 @@ class MaskedArray(ndarray):
         ""
         dvar = self.var(axis=axis, dtype=dtype, out=out, ddof=ddof)
         if dvar is not masked:
-            dvar = sqrt(dvar)
             if out is not None:
                 np.power(out, 0.5, out=out, casting='unsafe')
                 return out
+            dvar = sqrt(dvar)
         return dvar
     std.__doc__ = np.std.__doc__
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4749,6 +4749,7 @@ class MaskedArray(ndarray):
             dvar = masked
             if out is not None:
                 if isinstance(out, MaskedArray):
+                    out.flat = 0
                     out.__setmask__(True)
                 elif out.dtype.kind in 'biu':
                     errmsg = "Masked data information would be lost in one or "\

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2718,8 +2718,8 @@ class TestMaskedArrayMathMethods(TestCase):
 
     def test_varstd_specialcases(self):
         "Test a special case for var"
-        nout = np.empty(1, dtype=float)
-        mout = empty(1, dtype=float)
+        nout = np.array(-1, dtype=float)
+        mout = array(-1, dtype=float)
         #
         x = array(arange(10), mask=True)
         for methodname in ('var', 'std'):

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,5 +1,6 @@
 from numpy.testing import *
 import numpy as np
+import numpy.ma as ma
 
 rlevel = 1
 
@@ -49,6 +50,14 @@ class TestRegression(TestCase):
         a = np.ma.masked_array(['a', 'b', 'c'], mask=[1, 0, 0])
         a.fill_value = 'X'
         assert_(a.fill_value == 'X')
+
+    def test_var_sets_maskedarray_scalar(self):
+        """Issue gh-2757"""
+        a = np.ma.array(np.arange(5), mask=True)
+        mout = np.ma.array(-1, dtype=float)
+        a.var(out=mout)
+        assert_(mout._data == 0)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This makes sure that the masked array var method sets the underlying value of a masked 0-d output parameter to zero. That is consistent with the higher dimensional case and also fixes the irrelevant Travisbot Heisenbug with that has plagued us.  
