### PR TITLE
BUG: Fix bad call of internal function and fix usage of PyField_Names

### DIFF
--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -502,7 +502,7 @@ PyArray_FieldNames(PyObject *fields)
     if (_numpy_internal == NULL) {
         return NULL;
     }
-    tup = PyObject_CallMethod(_numpy_internal, "_makenames_list", "O", fields);
+    tup = PyObject_CallMethod(_numpy_internal, "_makenames_list", "OO", fields, Py_False);
     Py_DECREF(_numpy_internal);
     if (tup == NULL) {
         return NULL;
@@ -561,16 +561,15 @@ PyArray_DescrFromScalar(PyObject *sc)
 #endif
         }
         else {
-            descr->elsize = Py_SIZE((PyVoidScalarObject *)sc);
-            descr->fields = PyObject_GetAttrString(sc, "fields");
-            if (!descr->fields
-                    || !PyDict_Check(descr->fields)
-                    || (descr->fields == Py_None)) {
-                Py_XDECREF(descr->fields);
-                descr->fields = NULL;
-            }
-            if (descr->fields) {
-                descr->names = PyArray_FieldNames(descr->fields);
+            PyArray_Descr *dtype;
+            dtype = (PyArray_Descr *)PyObject_GetAttrString(sc, "dtype");
+            if (dtype != NULL) {
+                descr->elsize = dtype->elsize;
+                descr->fields = dtype->fields;
+                Py_XINCREF(dtype->fields);
+                descr->names = dtype->names;
+                Py_XINCREF(dtype->names);
+                Py_DECREF(dtype);
             }
             PyErr_Clear();
         }


### PR DESCRIPTION
This Pull request fixes an error in the internal call to _makenames_list raised by #2771.   The PyField_Names API call was never being called and an obvious error in it was removed by re-writing the implementation. 
