### PR TITLE
FIX: Clean strides of arrays requested to be contiguous

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -470,7 +470,10 @@ _buffer_info_new(PyArrayObject *arr, int flags)
                                           * PyArray_NDIM(arr) * 2 + 1);
         info->strides = info->shape + PyArray_NDIM(arr);
 
-        /* If a contiguous buffer was requested, guarantee clean strides */
+        /*
+         * If a contiguous buffer was requested, guarantee that strides
+         * start with itemsize and add up correctly with the dimensions.
+         */
         if ((order & PyBUF_ANY_CONTIGUOUS) == PyBUF_ANY_CONTIGUOUS) {
             /* default to C-Order */
             order = PyArray_IS_C_CONTIGUOUS(arr) ?

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -480,14 +480,14 @@ _buffer_info_new(PyArrayObject *arr, int flags)
             for (k = PyArray_NDIM(arr) - 1; k >= 0; --k) {
                 info->shape[k] = PyArray_DIMS(arr)[k];
                 info->strides[k] = stride;
-                stride *= info->shape[k] ? info->shape[k] : 1;
+                stride *= info->shape[k];
             }
         }
         else if ((order & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS) {
             for (k = 0; k < PyArray_NDIM(arr); ++k) {
                 info->shape[k] = PyArray_DIMS(arr)[k];
                 info->strides[k] = stride;
-                stride *= info->shape[k] ? info->shape[k] : 1;
+                stride *= info->shape[k];
             }
         }
         else {

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -440,11 +440,13 @@ static PyObject *_buffer_info_cache = NULL;
 
 /* Fill in the info structure */
 static _buffer_info_t*
-_buffer_info_new(PyArrayObject *arr)
+_buffer_info_new(PyArrayObject *arr, int flags)
 {
     _buffer_info_t *info;
     _tmp_string_t fmt = {0,0,0};
     int k;
+    int order = flags;
+    Py_ssize_t stride = PyArray_ITEMSIZE(arr);
 
     info = (_buffer_info_t*)malloc(sizeof(_buffer_info_t));
 
@@ -467,9 +469,32 @@ _buffer_info_new(PyArrayObject *arr)
         info->shape = (Py_ssize_t*)malloc(sizeof(Py_ssize_t)
                                           * PyArray_NDIM(arr) * 2 + 1);
         info->strides = info->shape + PyArray_NDIM(arr);
-        for (k = 0; k < PyArray_NDIM(arr); ++k) {
-            info->shape[k] = PyArray_DIMS(arr)[k];
-            info->strides[k] = PyArray_STRIDES(arr)[k];
+
+        /* If a contiguous buffer was requested, guarantee clean strides */
+        if ((order & PyBUF_ANY_CONTIGUOUS) == PyBUF_ANY_CONTIGUOUS) {
+            /* default to C-Order */
+            order = PyArray_IS_C_CONTIGUOUS(arr) ?
+                     PyBUF_C_CONTIGUOUS : PyBUF_F_CONTIGUOUS;
+        }
+        if ((order & PyBUF_C_CONTIGUOUS) == PyBUF_C_CONTIGUOUS) {
+            for (k = PyArray_NDIM(arr) - 1; k >= 0; --k) {
+                info->shape[k] = PyArray_DIMS(arr)[k];
+                info->strides[k] = stride;
+                stride *= info->shape[k] ? info->shape[k] : 1;
+            }
+        }
+        else if ((order & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS) {
+            for (k = 0; k < PyArray_NDIM(arr); ++k) {
+                info->shape[k] = PyArray_DIMS(arr)[k];
+                info->strides[k] = stride;
+                stride *= info->shape[k] ? info->shape[k] : 1;
+            }
+        }
+        else {
+            for (k = 0; k < PyArray_NDIM(arr); ++k) {
+                info->shape[k] = PyArray_DIMS(arr)[k];
+                info->strides[k] = PyArray_STRIDES(arr)[k];
+            }
         }
     }
 
@@ -513,7 +538,7 @@ _buffer_info_free(_buffer_info_t *info)
 
 /* Get buffer info from the global dictionary */
 static _buffer_info_t*
-_buffer_get_info(PyObject *arr)
+_buffer_get_info(PyObject *arr, int flags)
 {
     PyObject *key, *item_list, *item;
     _buffer_info_t *info = NULL, *old_info = NULL;
@@ -526,7 +551,7 @@ _buffer_get_info(PyObject *arr)
     }
 
     /* Compute information */
-    info = _buffer_info_new((PyArrayObject*)arr);
+    info = _buffer_info_new((PyArrayObject*)arr, flags);
     if (info == NULL) {
         return NULL;
     }
@@ -648,7 +673,7 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
     }
 
     /* Fill in information */
-    info = _buffer_get_info(obj);
+    info = _buffer_get_info(obj, flags);
     if (info == NULL) {
         goto fail;
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1883,7 +1883,9 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
         /*
          * Calculate new strides and find out if a view is necessary.
          * This is the case if a contiguous array was requested but the
-         * current array, while contiguous, does not have clean strides.
+         * current array, while contiguous, does not have strides that
+         * start with itemsize and add up correctly with dimensions
+         * because of dimensions of size 1 having no effect on memory layout.
          */
         if (flags & (NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS)) {
             _array_fill_strides(strides, PyArray_DIMS(arr), PyArray_NDIM(arr),

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3617,14 +3617,9 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
                                             NPY_ARRAY_F_CONTIGUOUS) {
         for (i = 0; i < nd; i++) {
             strides[i] = itemsize;
-            if (dims[i]) {
-                itemsize *= dims[i];
-            }
-            else {
-                not_cf_contig = 0;
-            }
+            itemsize *= dims[i];
         }
-        if (not_cf_contig) {
+        if (not_cf_contig && itemsize) {
             *objflags = ((*objflags)|NPY_ARRAY_F_CONTIGUOUS) &
                                             ~NPY_ARRAY_C_CONTIGUOUS;
         }
@@ -3635,14 +3630,9 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
     else {
         for (i = nd - 1; i >= 0; i--) {
             strides[i] = itemsize;
-            if (dims[i]) {
-                itemsize *= dims[i];
-            }
-            else {
-                not_cf_contig = 0;
-            }
+            itemsize *= dims[i];
         }
-        if (not_cf_contig) {
+        if (not_cf_contig && itemsize) {
             *objflags = ((*objflags)|NPY_ARRAY_C_CONTIGUOUS) &
                                             ~NPY_ARRAY_F_CONTIGUOUS;
         }

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -234,5 +234,50 @@ def test_contiguous_flags():
     check_contig(a.ravel(), True, True)
     check_contig(np.ones((1,3,1)).squeeze(), True, True)
 
+def test_clean_strides():
+    # Test that arrays that are explicitely asked to be contiguous
+    # have clean strides, while the flags will ignore for example
+    # axes of shape[axes] == 1 as they do not matter for memory layout. 
+    def check_clean(a, order, check_view=False):
+        """Check that strides are clean. This is slightly more strict
+        then necessary, as for 0-d arrays we probably do not need to
+        care for dimensions that come after a shape[i] == 0.
+        """
+        strides = np.asarray(a.strides)
+        shape = np.asarray(a.shape)
+        if order.lower() == 'c':
+            strides = strides[::-1]
+            shape = shape[::-1]
+        shape[shape == 0] = 1
+        correct_strides = np.ones_like(strides)
+        correct_strides[1:] = np.multiply.accumulate(shape[:-1])
+        correct_strides *= a.itemsize
+        assert_equal(strides, correct_strides)
+        if check_view:
+            assert_(not a.flags.owndata)
+
+    a = np.ones((1,3,1))
+    a = np.lib.stride_tricks.as_strided(a, a.shape, (0, a.itemsize, 0))
+
+    # Various methods for requesting a contiguous array:
+    check_clean(a.copy('F'), 'F')
+    check_clean(a.copy('C'), 'C')
+    check_clean(np.ascontiguousarray(a), 'C', True)
+    check_clean(np.array(a, copy=False, order='C'), 'C', True)
+    check_clean(np.array(a, copy=False, order='F'), 'F', True)
+    check_clean(np.array(a, copy=False, order='C', ndmin=4), 'C', True)
+    check_clean(np.array(a, copy=False, order='F', ndmin=4), 'F', True)
+    # Check that no view is created if a is already clean contiguous:
+    a = a.copy('C')
+    b = a.copy('F')
+    assert_(np.ascontiguousarray(a) is a)
+    assert_(np.array(a, copy=False, order='C') is a)
+    assert_(np.array(b, copy=False, order='F') is b)
+    # Also check for ravel. This should not be necessary though:
+    a = np.ones(1)
+    a.strides = 0
+    check_clean(a.ravel('C'), 'C', True)
+    check_clean(a.ravel('F'), 'C', True)
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -248,7 +248,6 @@ def test_clean_strides():
         if order.lower() == 'c':
             strides = strides[::-1]
             shape = shape[::-1]
-        shape[shape == 0] = 1
         correct_strides = np.ones_like(strides)
         correct_strides[1:] = np.multiply.accumulate(shape[:-1])
         correct_strides *= a.itemsize
@@ -258,21 +257,23 @@ def test_clean_strides():
 
     a = np.ones((1,3,1))
     a = np.lib.stride_tricks.as_strided(a, a.shape, (0, a.itemsize, 0))
+    b = np.lib.stride_tricks.as_strided(a, (4,0,3), (0, a.itemsize, 0))
 
-    # Various methods for requesting a contiguous array:
-    check_clean(a.copy('F'), 'F')
-    check_clean(a.copy('C'), 'C')
-    check_clean(np.ascontiguousarray(a), 'C', True)
-    check_clean(np.array(a, copy=False, order='C'), 'C', True)
-    check_clean(np.array(a, copy=False, order='F'), 'F', True)
-    check_clean(np.array(a, copy=False, order='C', ndmin=4), 'C', True)
-    check_clean(np.array(a, copy=False, order='F', ndmin=4), 'F', True)
-    # Check that no view is created if a is already clean contiguous:
-    a = a.copy('C')
-    b = a.copy('F')
-    assert_(np.ascontiguousarray(a) is a)
-    assert_(np.array(a, copy=False, order='C') is a)
-    assert_(np.array(b, copy=False, order='F') is b)
+    for arr in [a, b]:
+        # Various methods for requesting a contiguous array:
+        check_clean(arr.copy('F'), 'F')
+        check_clean(arr.copy('C'), 'C')
+        check_clean(np.ascontiguousarray(a), 'C', True)
+        check_clean(np.array(arr, copy=False, order='C'), 'C', True)
+        check_clean(np.array(arr, copy=False, order='F'), 'F', True)
+        check_clean(np.array(arr, copy=False, order='C', ndmin=4), 'C', True)
+        check_clean(np.array(arr, copy=False, order='F', ndmin=4), 'F', True)
+        # Check that no view is created if a is already clean contiguous:
+        arrc = arr.copy('C')
+        arrf = arr.copy('F')
+        assert_(np.ascontiguousarray(arrc) is arrc)
+        assert_(np.array(arrc, copy=False, order='C') is arrc)
+        assert_(np.array(arrf, copy=False, order='F') is arrf)
     # Also check for ravel. This should not be necessary though:
     a = np.ones(1)
     a.strides = 0


### PR DESCRIPTION
Sorry if I spam with this PR, but this is the alternative approach for https://github.com/numpy/numpy/pull/2735 that I also mentioned there, and would in a similar form probably also be necessary if it is opted to do a deprecation process to change flags behaviour.

As far as I can see, this should fix all problems found yet, by cleaning up strides when an array (or buffer) is explicitly requested to be contiguous. Of course potentially someone does only check the flags and then relies on clean strides, but at least it is not the case for scipy and sklearn.
It means that some more checks have to be run in these cases, which unfortunately makes `np.array(arr, copy=True, order='C')` a bit slower if `arr` is already clean contiguous, but I doubt that is a big issue.

This still lacks tests for the buffer interface, since it seems necessary to write them in C.
