### PR TITLE
API Make PyArray_DATA return void*

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1390,8 +1390,14 @@ PyArray_NDIM(const PyArrayObject *arr)
     return ((PyArrayObject_fields *)arr)->nd;
 }
 
-static NPY_INLINE char *
+static NPY_INLINE void *
 PyArray_DATA(PyArrayObject *arr)
+{
+    return ((PyArrayObject_fields *)arr)->data;
+}
+
+static NPY_INLINE char *
+PyArray_BYTES(PyArrayObject *arr)
 {
     return ((PyArrayObject_fields *)arr)->data;
 }
@@ -1470,15 +1476,12 @@ PyArray_SETITEM(PyArrayObject *arr, char *itemptr, PyObject *v)
                                                         v, itemptr, arr);
 }
 
-/* Same as PyArray_DATA */
-#define PyArray_BYTES(arr) PyArray_DATA(arr)
-
 #else
 
 /* These macros are deprecated as of NumPy 1.7. */
 #define PyArray_NDIM(obj) (((PyArrayObject_fields *)(obj))->nd)
 #define PyArray_BYTES(obj) (((PyArrayObject_fields *)(obj))->data)
-#define PyArray_DATA(obj) (((PyArrayObject_fields *)(obj))->data)
+#define PyArray_DATA(obj) ((void *)((PyArrayObject_fields *)(obj))->data)
 #define PyArray_DIMS(obj) (((PyArrayObject_fields *)(obj))->dimensions)
 #define PyArray_STRIDES(obj) (((PyArrayObject_fields *)(obj))->strides)
 #define PyArray_DIM(obj,n) (PyArray_DIMS(obj)[n])

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -131,7 +131,7 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
     if (PyArray_BASE(new) && PyObject_AsReadBuffer(PyArray_BASE(new),
                                            (const void **)&buf,
                                            &buf_len) >= 0) {
-        offset = PyArray_DATA(self) - buf;
+        offset = PyArray_BYTES(self) - buf;
         numbytes = buf_len + offset;
     }
     else {


### PR DESCRIPTION
PyArray_DATA is documented as returning void_. Changing it to return
char_ breaks code such as (in C++)::

```
float* my_floats = static_cast<float*>(PyArray_DATA(my_array));
```

PyArray_BYTES returns char*, but is otherwise the same function.

*

This was previously discussed here: https://github.com/numpy/numpy/commit/abf0489b69496af2c9e19f8bf41356fa511e5f1a
as it caused a compilation error in mahotas:
https://github.com/luispedro/mahotas/issues/26

My main argument is that http://docs.scipy.org/doc/numpy/reference/c-api.array.html clearly states that PyArray_DATA returns `void*` and unless there is a strong reason against changing the public API, it should not change. In this case, there is even a perfect alternative for those who wish to have the `char*`: `PyArray_BYTES`.
