### PR TITLE
np.unique: TypeError: requested sort not available for type

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1616,5 +1616,17 @@ class TestRegression(TestCase):
         x = np.arange(0, 4, dtype='datetime64[D]')
         assert_raises(TypeError, x.searchsorted, 1)
 
+    def test_unique_special_comparators(self):
+        # gh-2785
+        # np.unique should not raise an exception for dtypes with
+        # special comparators.
+
+        # Extract the unique rows of the matrix
+        A = np.array([[1, 2], [1, 3], [1, 2]], dtype='i')
+        B, I, J = np.unique(A.view([('', A.dtype)]*A.shape[1]), True, True)
+        B = B.view(A.dtype).reshape((-1, A.shape[1]))
+        assert_equal(A, B[J])
+        assert_equal(A[I], B)
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1611,15 +1611,6 @@ class TestRegression(TestCase):
         a[...] = [[1,2]]
         assert_equal(a, [[1,2], [1,2]])
 
-    def test_unique_stable(self):
-        # Ticket #2063 must always choose stable sort for argsort to
-        # get consistent results
-        v=np.array([0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2]*4)
-        w=np.array([0,0,0,0,0,1,1,1,1,1,1,2,2,2,2])
-        resv = np.unique(v,return_index=True)
-        resw = np.unique(w,return_index=True)
-        assert_equal(resv, resw)
-
     def test_search_sorted_invalid_arguments(self):
         # Ticket #2021, should not segfault.
         x = np.arange(0, 4, dtype='datetime64[D]')

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -112,8 +112,8 @@ def unique(ar, return_index=False, return_inverse=False):
     unique : ndarray
         The sorted unique values.
     unique_indices : ndarray, optional
-        The indices of the first occurrences of the unique values in the
-        (flattened) original array. Only provided if `return_index` is True.
+        The indices of the unique values in the (flattened) original array.
+        Only provided if `return_index` is True.
     unique_inverse : ndarray, optional
         The indices to reconstruct the (flattened) original array from the
         unique array. Only provided if `return_inverse` is True.
@@ -174,10 +174,7 @@ def unique(ar, return_index=False, return_inverse=False):
             return ar
 
     if return_inverse or return_index:
-        if return_index:
-            perm = ar.argsort(kind='mergesort')
-        else:
-            perm = ar.argsort()
+        perm = ar.argsort()
         aux = ar[perm]
         flag = np.concatenate(([True], aux[1:] != aux[:-1]))
         if return_inverse:


### PR DESCRIPTION
Upon recently upgrading from 1.6.1 to 1.6.2, I discovered that the well-intentioned 74b9f5ee introduced a regression in `np.unqiue`:

```
>>> import numpy as np
>>> np.__version__
'1.6.2'
>>> 
>>> def unique_rows(A):
...     A = np.ascontiguousarray(A)
...     assert A.ndim == 2
...     B, I, J = np.unique(A.view([('', A.dtype)]*A.shape[1]), True, True)
...     return B.view(A.dtype).reshape((-1, A.shape[1]), order='C'), I, J
... 
>>> A = np.array([[1, 2], [1, 3], [1, 2]], dtype='i')
>>> 
>>> unique_rows(A)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in unique_rows
  File "/usr/lib/python2.7/dist-packages/numpy/lib/arraysetops.py", line 178, in unique
    perm = ar.argsort(kind='mergesort')
TypeError: requested sort not available for type
```

I filed a bug report against this yesterday (gh-2785) where I learned it was a known issue and has been fixed in 1.7.x.

While I realize a 1.6.3 release is unlikely, there's no harm in reverting this in the `maintenance/1.6.x` branch.  I've attached a pull request which does just that, and adds a regression test.

Of course this should _NOT_ be committed to 1.7.x or master, although the regression test could be cherry-picked onto that branch.
