### PR TITLE
MAINT: Add FutureWarnings for changes of np.insert/np.delete

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3423,6 +3423,12 @@ def delete(arr, obj, axis=None):
 
     """
     wrap = None
+
+    if isinstance(obj, ndarray) and obj.dtype == bool:
+        warnings.warn("beginning with numpy version 1.8. delete will treat "
+                      "boolean arrays like a boolean index instead of "
+                      "casting it to integer", FutureWarning)
+
     if type(arr) is not ndarray:
         try:
             wrap = arr.__array_wrap__
@@ -3438,6 +3444,9 @@ def delete(arr, obj, axis=None):
         ndim = arr.ndim;
         axis = ndim-1;
     if ndim == 0:
+        warnings.warn("the special handleing of scalars will be removed from "
+                      "delete with numpy version 1.8. and raise an error",
+                      FutureWarning)
         if wrap:
             return wrap(arr)
         else:
@@ -3568,6 +3577,12 @@ def insert(arr, obj, values, axis=None):
 
     """
     wrap = None
+    
+    if isinstance(obj, ndarray) and obj.dtype == bool:
+        warnings.warn("beginning with numpy version 1.8. insert will treat "
+                      "boolean arrays like a boolean index instead of "
+                      "casting it to integer", FutureWarning)
+    
     if type(arr) is not ndarray:
         try:
             wrap = arr.__array_wrap__
@@ -3582,6 +3597,9 @@ def insert(arr, obj, values, axis=None):
         ndim = arr.ndim
         axis = ndim-1
     if (ndim == 0):
+        warnings.warn("the special handleing of scalars will be removed from "
+                      "insert with numpy version 1.8. and raise an error",
+                      FutureWarning)
         arr = arr.copy()
         arr[...] = values
         if wrap:


### PR DESCRIPTION
In numpy 1.8. boolean arrays will be treated like boolean indexing. Also special casing of scalars will be removed from both functions.

@charris wrote some warnings, is this the right way to do those? @certik this adds warnings for changes done in PR gh-452 and would be nice in 1.7. so those can be done in 1.8.

Just to be clear, I removed those scalar special cases, because it just doesn't make any sense to delete/insert from/into a 0-d array if you give an axis that is not `None`, so I really can't see anyone using that, but a warning can't hurt.
