### PR TITLE
add platform specific python include directories to search paths

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1623,6 +1623,9 @@ class _numpy_info(system_info):
             pass
         py_incl_dir = distutils.sysconfig.get_python_inc()
         include_dirs.append(py_incl_dir)
+        py_pincl_dir = distutils.sysconfig.get_python_inc(plat_specific=True)
+        if py_pincl_dir not in include_dirs:
+            include_dirs.append(py_pincl_dir)
         for d in default_include_dirs:
             d = os.path.join(d, os.path.basename(py_incl_dir))
             if d not in include_dirs:
@@ -1754,12 +1757,15 @@ class boost_python_info(system_info):
                 break
         if not src_dir:
             return
-        py_incl_dir = distutils.sysconfig.get_python_inc()
+        py_incl_dirs = [distutils.sysconfig.get_python_inc()]
+        py_pincl_dir = distutils.sysconfig.get_python_inc(plat_specific=True)
+        if py_pincl_dir not in py_incl_dirs:
+            py_incl_dirs.append(py_pincl_dir)
         srcs_dir = os.path.join(src_dir, 'libs', 'python', 'src')
         bpl_srcs = glob(os.path.join(srcs_dir, '*.cpp'))
         bpl_srcs += glob(os.path.join(srcs_dir, '*', '*.cpp'))
         info = {'libraries': [('boost_python_src',
-                               {'include_dirs': [src_dir, py_incl_dir],
+                               {'include_dirs': [src_dir] + py_incl_dirs,
                                 'sources':bpl_srcs}
                               )],
                 'include_dirs': [src_dir],


### PR DESCRIPTION
the generic and platform specific path diverge in python3.3 in ubuntu 13.04

added the extra path to all get_python_inc calls I could find
