### PR TITLE
Fix invalid typestring size

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1121,6 +1121,7 @@ PyArray_TypestrConvert(int itemsize, int gentype)
         if (temp != NULL) {
             if (temp->elsize != itemsize) {
                 if (DEPRECATE(msg) < 0) {
+                    Py_DECREF(temp);
                     return -1;
                 }
 

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1116,19 +1116,9 @@ PyArray_TypestrConvert(int itemsize, int gentype)
      * This should eventually be changed to an error in
      * future NumPy versions.
      */
-    
-    if (newtype == NPY_NOTYPE)
-    {
-        printf("XXX: gentype=%c\n", gentype);
-    }
     if (newtype == NPY_NOTYPE) {
         temp = PyArray_DescrFromType(gentype);
-
-        if (gentype == 'g')
-            printf("XXX: temp=%x\n", temp);
         if (temp != NULL) {
-            if (gentype == 'g')
-                printf("XXX: elsize=%d itemsize=%d\n", temp->elsize, itemsize);
             if (temp->elsize != itemsize) {
                 if (DEPRECATE(msg) < 0) {
                     Py_DECREF(temp);

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1116,9 +1116,19 @@ PyArray_TypestrConvert(int itemsize, int gentype)
      * This should eventually be changed to an error in
      * future NumPy versions.
      */
+    
+    if (newtype == NPY_NOTYPE)
+    {
+        printf("XXX: gentype=%c\n", gentype);
+    }
     if (newtype == NPY_NOTYPE) {
         temp = PyArray_DescrFromType(gentype);
+
+        if (gentype == 'g')
+            printf("XXX: temp=%x\n", temp);
         if (temp != NULL) {
+            if (gentype == 'g')
+                printf("XXX: elsize=%d itemsize=%d\n", temp->elsize, itemsize);
             if (temp->elsize != itemsize) {
                 if (DEPRECATE(msg) < 0) {
                     Py_DECREF(temp);

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -954,6 +954,7 @@ NPY_NO_EXPORT int
 PyArray_TypestrConvert(int itemsize, int gentype)
 {
     int newtype = NPY_NOTYPE;
+    PyArray_Descr *temp;
 
     switch (gentype) {
         case NPY_GENBOOLLTR:
@@ -1105,7 +1106,28 @@ PyArray_TypestrConvert(int itemsize, int gentype)
                 newtype = NPY_TIMEDELTA;
             }
             break;
+        default:
+            temp = PyArray_DescrFromType(gentype);
+            if (temp != NULL) {
+                if (temp->elsize != itemsize) {
+
+                    const char *msg = "Specified size is invalid for this data type.\n"
+                        "Size will be ignored in NumPy 1.7 but may throw an exception in future versions.";
+                    if (DEPRECATE_FUTUREWARNING(msg) < 0) {
+                        return -1;
+                    }
+
+                    newtype = gentype;
+                }
+                else {
+                    newtype = gentype;
+                }
+
+                Py_DECREF(temp);
+            }
+            break;
     }
+    
     return newtype;
 }
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -48,12 +48,11 @@ class TestDateTime(TestCase):
         assert_raises(TypeError, np.dtype, 'm8[badunit]')
         assert_raises(TypeError, np.dtype, 'M8[YY]')
         assert_raises(TypeError, np.dtype, 'm8[YY]')
-        assert_raises(TypeError, np.dtype, 'M4')
-        assert_raises(TypeError, np.dtype, 'm4')
-        assert_raises(TypeError, np.dtype, 'M7')
-        assert_raises(TypeError, np.dtype, 'm7')
-        assert_raises(TypeError, np.dtype, 'M16')
-        assert_raises(TypeError, np.dtype, 'm16')
+        assert_warns(DeprecationWarning, np.dtype, 'm4')
+        assert_warns(DeprecationWarning, np.dtype, 'M7')
+        assert_warns(DeprecationWarning, np.dtype, 'm7')
+        assert_warns(DeprecationWarning, np.dtype, 'M16')
+        assert_warns(DeprecationWarning, np.dtype, 'm16')
 
     def test_datetime_casting_rules(self):
         # Cannot cast safely/same_kind between timedelta and datetime

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -60,7 +60,11 @@ class TestBuiltin(TestCase):
         assert_warns(DeprecationWarning, np.dtype, 'I5')
         assert_warns(DeprecationWarning, np.dtype, 'e3')
         assert_warns(DeprecationWarning, np.dtype, 'f5')
-        assert_warns(DeprecationWarning, np.dtype, 'g12')
+
+        if np.dtype('g').itemsize == 8 or np.dtype('g').itemsize == 16:
+            assert_warns(DeprecationWarning, np.dtype, 'g12')
+        elif np.dtype('g').itemsize == 12:
+            assert_warns(DeprecationWarning, np.dtype, 'g16')
 
         if np.dtype('l').itemsize == 8:
             assert_warns(DeprecationWarning, np.dtype, 'l4')

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -47,13 +47,16 @@ class TestBuiltin(TestCase):
         self.assertTrue(hash(left) == hash(right))
 
     def test_invalid_types(self):
-        # Make sure invalid type strings raise exceptions
-        for typestr in ['O3', 'O5', 'O7', 'b3', 'h4', 'I5', 'l4', 'l8',
-                        'L4', 'L8', 'q8', 'q16', 'Q8', 'Q16', 'e3',
-                        'f5', 'd8', 't8', 'g12', 'g16',
-                        'NA[u4,0xffffffff]']:
+        # Make sure invalid type strings raise exceptions.
+        # For now, display a deprecation warning for invalid 
+        # type sizes. In the future this should be changed 
+        # to an exception.
+        for typestr in ['O3', 'O5', 'O7', 'b3', 'h4', 'I5', 'l4',
+                        'L4', 'q16', 'Q16', 'e3', 'f5', 'g12']:
             #print typestr
-            assert_raises(TypeError, np.dtype, typestr)
+            assert_warns(DeprecationWarning, np.dtype, typestr)
+
+        assert_raises(TypeError, np.dtype, 't8', 'NA[u4,0xffffffff]')
 
     def test_bad_param(self):
         # Can't give a size that's too small

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -47,15 +47,20 @@ class TestBuiltin(TestCase):
         self.assertTrue(hash(left) == hash(right))
 
     def test_invalid_types(self):
-        # Make sure invalid type strings raise exceptions.
+        # Make sure invalid type strings raise a warning.
         # For now, display a deprecation warning for invalid 
         # type sizes. In the future this should be changed 
         # to an exception.
 
-        for typestr in ['O3', 'O5', 'O7', 'b3', 'h4', 'I5',
-                        'e3', 'f5', 'g12']:
-            #print typestr
-            assert_warns(DeprecationWarning, np.dtype, typestr)
+        assert_warns(DeprecationWarning, np.dtype, 'O3')
+        assert_warns(DeprecationWarning, np.dtype, 'O5')
+        assert_warns(DeprecationWarning, np.dtype, 'O7')
+        assert_warns(DeprecationWarning, np.dtype, 'b3')
+        assert_warns(DeprecationWarning, np.dtype, 'h4')
+        assert_warns(DeprecationWarning, np.dtype, 'I5')
+        assert_warns(DeprecationWarning, np.dtype, 'e3')
+        assert_warns(DeprecationWarning, np.dtype, 'f5')
+        assert_warns(DeprecationWarning, np.dtype, 'g12')
 
         if np.dtype('l').itemsize == 8:
             assert_warns(DeprecationWarning, np.dtype, 'l4')
@@ -70,8 +75,6 @@ class TestBuiltin(TestCase):
         else:
             assert_warns(DeprecationWarning, np.dtype, 'q8')
             assert_warns(DeprecationWarning, np.dtype, 'Q8')
-
-        assert_raises(TypeError, np.dtype, 't8', 'NA[u4,0xffffffff]')
 
     def test_bad_param(self):
         # Can't give a size that's too small

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -51,10 +51,25 @@ class TestBuiltin(TestCase):
         # For now, display a deprecation warning for invalid 
         # type sizes. In the future this should be changed 
         # to an exception.
-        for typestr in ['O3', 'O5', 'O7', 'b3', 'h4', 'I5', 'l4',
-                        'L4', 'q16', 'Q16', 'e3', 'f5', 'g12']:
+
+        for typestr in ['O3', 'O5', 'O7', 'b3', 'h4', 'I5',
+                        'e3', 'f5', 'g12']:
             #print typestr
             assert_warns(DeprecationWarning, np.dtype, typestr)
+
+        if np.dtype('l').itemsize == 8:
+            assert_warns(DeprecationWarning, np.dtype, 'l4')
+            assert_warns(DeprecationWarning, np.dtype, 'L4')
+        else:
+            assert_warns(DeprecationWarning, np.dtype, 'l8')
+            assert_warns(DeprecationWarning, np.dtype, 'L8')
+
+        if np.dtype('q').itemsize == 8:
+            assert_warns(DeprecationWarning, np.dtype, 'q4')
+            assert_warns(DeprecationWarning, np.dtype, 'Q4')
+        else:
+            assert_warns(DeprecationWarning, np.dtype, 'q8')
+            assert_warns(DeprecationWarning, np.dtype, 'Q8')
 
         assert_raises(TypeError, np.dtype, 't8', 'NA[u4,0xffffffff]')
 


### PR DESCRIPTION
Revert to pre numpy 1.7 behavior where invalid typestring size was ignored and display future deprecate warning. This warning should eventually be changed to an error in future numpy versions.

Fix for https://github.com/numpy/numpy/issues/294
