### PR TITLE
ValueError: low level cast function is for unequal type numbers for object types

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -1476,6 +1476,7 @@ get_cast_transfer_function(int aligned,
             dst_itemsize = dst_dtype->elsize;
 
     if (src_dtype->type_num == dst_dtype->type_num &&
+            src_dtype->type_num != NPY_OBJECT &&
             src_dtype->type_num != NPY_DATETIME &&
             src_dtype->type_num != NPY_TIMEDELTA) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -418,6 +418,11 @@ class TestString(TestCase):
         # Pull request #376
         dt = np.dtype('(1L,)i4')
 
+    def test_base_dtype_with_object_type(self):
+        # Issue #2798
+        # ValueError: low level cast function is for unequal type numbers
+        a = np.array(['a'], dtype='O').astype(('O', [('name', 'O')]))
+
 
 class TestDtypeAttributeDeletion(object):
 


### PR DESCRIPTION
This was reported on the [numpy-discussion mailing list](http://comments.gmane.org/gmane.comp.python.numeric.general/52285).

The following code using np.object_ data types works with numpy 1.5.1 but fails with 1.6.2. Other data types, np.float64 for example, seem to work.

```
In [1]: import numpy as np

In [2]: np.array(['a'], dtype='O').astype(('O', [('name', 'O')]))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-f4a62241f13c> in <module>()
----> 1 np.array(['a'], dtype='O').astype(('O', [('name', 'O')]))

ValueError: low level cast function is for unequal type numbers

In [3]: np.array([16], dtype='d').astype(('d', [('name', 'd')]))
Out[3]: array([ 16.])
```

These downstream issues could be related:
- http://code.google.com/p/h5py/issues/detail?id=217
- https://github.com/CellProfiler/CellProfiler/issues/421

I'm not entirely sure the proposed patch is correct/best, but it seems to fix this and the h5py issue.
