### PR TITLE
BUG: Fix regression for in1d with non-array input

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -324,6 +324,10 @@ def in1d(ar1, ar2, assume_unique=False):
     array([0, 2, 0])
 
     """
+    # Ravel both arrays, behavior for the first array could be different
+    ar1 = np.asarray(ar1).ravel()
+    ar2 = np.asarray(ar2).ravel()
+
     # This code is significantly faster when the condition is satisfied.
     if len(ar2) < 10 * len(ar1) ** 0.145:
         mask = np.zeros(len(ar1), dtype=np.bool)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -189,6 +189,19 @@ class TestSetOps(TestCase):
 
         assert_array_equal(c, ec)
 
+    def test_in1d_ravel(self):
+        # Test that in1d ravels its input arrays. This is not documented
+        # behavior however. The test is to ensure consistentency.
+        a = np.arange(6).reshape(2,3)
+        b = np.arange(3,9).reshape(3,2)
+        long_b = np.arange(3, 63).reshape(30,2)
+        ec = np.array([False, False, False, True, True, True])
+
+        assert_array_equal(in1d(a, b, assume_unique=True), ec)
+        assert_array_equal(in1d(a, b, assume_unique=False), ec)
+        assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
+        assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
+
     def test_union1d( self ):
         a = np.array( [5, 4, 7, 1, 2] )
         b = np.array( [2, 4, 3, 3, 2, 1, 5] )

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -124,8 +124,9 @@ class TestSetOps(TestCase):
         # we use two different sizes for the b array here to test the
         # two different paths in in1d().
         for mult in (1, 10):
-            a = np.array([5, 7, 1, 2])
-            b = np.array([2, 4, 3, 1, 5] * mult)
+            # One check without np.array, to make sure lists are handled correct
+            a = [5, 7, 1, 2]
+            b = [2, 4, 3, 1, 5] * mult
             ec = np.array([True, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)


### PR DESCRIPTION
There was a regression introduced by the speed improvement in commit 6441c2a. This fixes it, and generally ravels the arrays for np.in1d. However it can be argued that at least the first array should
not be ravelled in the future.

Fixes "Issue gh-2755"

Since this seems to have been forgotten and it might be an annoying regression... @certik this should probably be in 1.7. to avoid a regression...

I used `np.asarray` here. In most places in `arraysetops` there is a call to `np.asanyarray` which probably should be replaced as well, since at least for matrices it fails? (Maybe `__array_wrap__` could be used, I am not sure if thats useful or not)
