### PR TITLE
Deprecate non-integer scalar indices and slice parameters

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -70,6 +70,11 @@ parse_index_entry(PyObject *op, npy_intp *step_size,
         }
         *n_steps = SINGLE_INDEX;
         *step_size = 0;
+        if (!PyIndex_Check_Or_Unsupported(op))
+        {
+            DEPRECATE("non-integer scalar index. In a future numpy "
+                      "release, this will raise an error.");
+        }
         if (check_index) {
             if (check_and_adjust_index(&i, max, axis) < 0) {
             goto fail;

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -71,8 +71,10 @@ parse_index_entry(PyObject *op, npy_intp *step_size,
         *n_steps = SINGLE_INDEX;
         *step_size = 0;
         if (!PyIndex_Check_Or_Unsupported(op)) {
-            DEPRECATE("non-integer scalar index. In a future numpy "
-                      "release, this will raise an error.");
+            if (DEPRECATE("non-integer scalar index. In a future numpy "
+                          "release, this will raise an error.") < 0) {
+                goto fail;
+            }
         }
         if (check_index) {
             if (check_and_adjust_index(&i, max, axis) < 0) {

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -70,8 +70,7 @@ parse_index_entry(PyObject *op, npy_intp *step_size,
         }
         *n_steps = SINGLE_INDEX;
         *step_size = 0;
-        if (!PyIndex_Check_Or_Unsupported(op))
-        {
+        if (!PyIndex_Check_Or_Unsupported(op)) {
             DEPRECATE("non-integer scalar index. In a future numpy "
                       "release, this will raise an error.");
         }

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -229,8 +229,32 @@ slice_coerce_index(PyObject *o, npy_intp *v)
     return 1;
 }
 
-/* This is basically PySlice_GetIndicesEx, but with our coercion
- * of indices to integers (plus, that function is new in Python 2.3) */
+/*
+ * Issue a DeprecationWarning for slice parameters that do not pass a
+ * PyIndex_Check, returning -1 if an error occurs.
+ *
+ * N.B. This function, like slice_GetIndices, will be obsolete once
+ * non-integer slice parameters becomes an error rather than a warning.
+ */
+static NPY_INLINE int
+_validate_slice_parameter(PyObject *o)
+{
+    if (!PyIndex_Check_Or_Unsupported(o)) {
+        if (DEPRECATE("non-integer slice parameter. In a future numpy "
+                      "release, this will raise an error.") < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * This is basically PySlice_GetIndicesEx, but with our coercion
+ * of indices to integers (plus, that function is new in Python 2.3)
+ *
+ * N.B. The coercion to integers is deprecated; once the DeprecationWarning
+ * is changed to an error, it would seem that this is obsolete.
+ */
 NPY_NO_EXPORT int
 slice_GetIndices(PySliceObject *r, npy_intp length,
                  npy_intp *start, npy_intp *stop, npy_intp *step,
@@ -242,6 +266,9 @@ slice_GetIndices(PySliceObject *r, npy_intp length,
         *step = 1;
     }
     else {
+        if (_validate_slice_parameter(r->step) < 0) {
+            return -1;
+        }
         if (!slice_coerce_index(r->step, step)) {
             return -1;
         }
@@ -257,6 +284,9 @@ slice_GetIndices(PySliceObject *r, npy_intp length,
         *start = *step < 0 ? length-1 : 0;
     }
     else {
+        if (_validate_slice_parameter(r->start) < 0) {
+            return -1;
+        }
         if (!slice_coerce_index(r->start, start)) {
             return -1;
         }
@@ -275,6 +305,9 @@ slice_GetIndices(PySliceObject *r, npy_intp length,
         *stop = defstop;
     }
     else {
+        if (_validate_slice_parameter(r->stop) < 0) {
+            return -1;
+        }
         if (!slice_coerce_index(r->stop, stop)) {
             return -1;
         }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1130,7 +1130,7 @@ array_ass_sub_simple(PyArrayObject *self, PyObject *ind, PyObject *op)
 }
 
 /* Check if ind is a tuple and if it has as many elements as arr has axes. */
-static int
+static NPY_INLINE int
 _is_full_index(PyObject *ind, PyArrayObject *arr)
 {
     return PyTuple_Check(ind) && (PyTuple_GET_SIZE(ind) == PyArray_NDIM(arr));

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1393,8 +1393,10 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
     PyErr_Clear();
     if ((PyNumber_Check(op) || PyArray_IsScalar(op, Number)) &&
             !PyIndex_Check_Or_Unsupported(op)) {
-        DEPRECATE("non-integer scalar index. In a future numpy "
-                  "release, this will raise an error.");
+        if (DEPRECATE("non-integer scalar index. In a future numpy "
+                      "release, this will raise an error.") < 0) {
+            return NULL;
+        }
     }
     mp = (PyArrayObject *)array_subscript(self, op);
     /*

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1369,7 +1369,10 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
             return array_item_nice(self, (Py_ssize_t) value);
         }
     }
-    /* optimization for a tuple of integers */
+    /*
+     * Optimization for a tuple of integers that is the same size as the
+     * array's dimension.
+     */
     if (PyArray_NDIM(self) > 1 &&
                 PyTuple_Check(op) &&
                 (PyTuple_GET_SIZE(op) == PyArray_NDIM(self)) &&

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1150,6 +1150,11 @@ _tuple_of_integers(PyObject *seq, npy_intp *vals, int maxvals)
         if (error_converting(temp)) {
             return -1;
         }
+        if (!PyIndex_Check_Or_Unsupported(obj))
+        {
+            DEPRECATE("non-integer scalar index. In a future numpy "
+                      "release, this will raise an error.");
+        }
         vals[i] = temp;
     }
     return 0;
@@ -1384,7 +1389,12 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
         return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
     }
     PyErr_Clear();
-
+    if ((PyNumber_Check(op) || PyArray_IsScalar(op, Number)) &&
+        !PyIndex_Check_Or_Unsupported(op))
+    {
+        DEPRECATE("non-integer scalar index. In a future numpy "
+                  "release, this will raise an error.");
+    }
     mp = (PyArrayObject *)array_subscript(self, op);
     /*
      * mp could be a scalar if op is not an Int, Scalar, Long or other Index

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1129,6 +1129,12 @@ array_ass_sub_simple(PyArrayObject *self, PyObject *ind, PyObject *op)
     return ret;
 }
 
+/* Check if ind is a tuple and if it has as many elements as arr has axes. */
+static int
+_is_full_index(PyObject *ind, PyArrayObject *arr)
+{
+    return PyTuple_Check(ind) && (PyTuple_GET_SIZE(ind) == PyArray_NDIM(arr));
+}
 
 /*
  * Returns 0 if tuple-object seq is not a tuple of integers.
@@ -1266,8 +1272,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
     }
 
     /* Integer-tuple */
-    if (PyTuple_Check(ind) &&
-                (PyTuple_GET_SIZE(ind) == PyArray_NDIM(self)) &&
+    if (_is_full_index(ind, self) &&
                 (ret = _tuple_of_integers(ind, vals, PyArray_NDIM(self)))) {
         int idim, ndim = PyArray_NDIM(self);
         npy_intp *shape = PyArray_DIMS(self);
@@ -1380,9 +1385,7 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
      * Optimization for a tuple of integers that is the same size as the
      * array's dimension.
      */
-    if (PyArray_NDIM(self) > 1 &&
-                PyTuple_Check(op) &&
-                (PyTuple_GET_SIZE(op) == PyArray_NDIM(self)) &&
+    if (PyArray_NDIM(self) > 1 && _is_full_index(op,  self) &&
                 (ret = _tuple_of_integers(op, vals, PyArray_NDIM(self)))) {
         int idim, ndim = PyArray_NDIM(self);
         npy_intp *shape = PyArray_DIMS(self);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1150,8 +1150,7 @@ _tuple_of_integers(PyObject *seq, npy_intp *vals, int maxvals)
         if (error_converting(temp)) {
             return -1;
         }
-        if (!PyIndex_Check_Or_Unsupported(obj))
-        {
+        if (!PyIndex_Check_Or_Unsupported(obj)) {
             DEPRECATE("non-integer scalar index. In a future numpy "
                       "release, this will raise an error.");
         }
@@ -1393,8 +1392,7 @@ array_subscript_nice(PyArrayObject *self, PyObject *op)
     }
     PyErr_Clear();
     if ((PyNumber_Check(op) || PyArray_IsScalar(op, Number)) &&
-        !PyIndex_Check_Or_Unsupported(op))
-    {
+            !PyIndex_Check_Or_Unsupported(op)) {
         DEPRECATE("non-integer scalar index. In a future numpy "
                   "release, this will raise an error.");
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1130,11 +1130,12 @@ array_ass_sub_simple(PyArrayObject *self, PyObject *ind, PyObject *op)
 }
 
 
-/* Returns 0 if tuple-object seq is not a tuple of integers.
-   If the return value is positive, vals will be filled with the elements
-   from the tuple.
-   Returns -1 on error.
-*/
+/*
+ * Returns 0 if tuple-object seq is not a tuple of integers.
+ * If the return value is positive, vals will be filled with the elements
+ * from the tuple.
+ * Returns -1 on error.
+ */
 static int
 _tuple_of_integers(PyObject *seq, npy_intp *vals, int maxvals)
 {

--- a/numpy/core/src/private/npy_pycompat.h
+++ b/numpy/core/src/private/npy_pycompat.h
@@ -19,6 +19,10 @@
 #if (PY_VERSION_HEX < 0x02050000)
 #undef PyIndex_Check
 #define PyIndex_Check(o)     0
+#undef PyIndex_Check_Or_Unsupported
+#define PyIndex_Check_Or_Unsupported(o) 1
+#else
+#define PyIndex_Check_Or_Unsupported(o) PyIndex_Check(o)
 #endif
 
 #endif /* _NPY_COMPAT_H_ */

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -54,16 +54,19 @@ class TestFloatIndexDeprecation(object):
         yield check_for_warning, lambda: a[:, 0.0], DeprecationWarning
         yield check_for_warning, lambda: a[:, 0.0, :], DeprecationWarning
         yield check_for_warning, lambda: a[0.0, :, :], DeprecationWarning
-        # XXX: These do issue DeprecationWarnings but for some reason the
-        # warning filter does not turn them into exceptions. I thought
-        # there was an overzealous PyExc_Clear to blame, but after redefining
-        # it with a macro and making it print, there seems to be none taking
-        # place after that warning state is set. The relevant code is in
-        # _tuple_of_integers in numpy/core/src/multiarray/mapping.c.
-
-        # yield check_for_warning, lambda: a[0, 0, 0.0], DeprecationWarning
-        # yield check_for_warning, lambda: a[0.0, 0, 0], DeprecationWarning
-        # yield check_for_warning, lambda: a[0, 0.0, 0], DeprecationWarning
+        yield check_for_warning, lambda: a[0, 0, 0.0], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0, 0, 0], DeprecationWarning
+        yield check_for_warning, lambda: a[0, 0.0, 0], DeprecationWarning
+        yield check_for_warning, lambda: a[-1.4], DeprecationWarning
+        yield check_for_warning, lambda: a[0, -1.4], DeprecationWarning
+        yield check_for_warning, lambda: a[-1.4, 0], DeprecationWarning
+        yield check_for_warning, lambda: a[-1.4, :], DeprecationWarning
+        yield check_for_warning, lambda: a[:, -1.4], DeprecationWarning
+        yield check_for_warning, lambda: a[:, -1.4, :], DeprecationWarning
+        yield check_for_warning, lambda: a[-1.4, :, :], DeprecationWarning
+        yield check_for_warning, lambda: a[0, 0, -1.4], DeprecationWarning
+        yield check_for_warning, lambda: a[-1.4, 0, 0], DeprecationWarning
+        yield check_for_warning, lambda: a[0, -1.4, 0], DeprecationWarning
 
     def test_valid_not_deprecated(self):
         a = np.array([[[5]]])

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -30,15 +30,17 @@ def check_does_not_raise(f, category):
 
 class TestFloatScalarIndexDeprecation(object):
     """
-    These test that DeprecationWarnings get raised when you
-    try to use scalar indices that are not integers e.g. a[0.0],
-    a[1.5, 0].
+    These test that `DeprecationWarning`s get raised when you
+    try to use scalar indices that are not integers e.g. `a[0.0]`,
+    `a[1.5, 0]`.
 
-    grep PyIndex_Check_Or_Unsupported numpy/core/src/multiarray/* for
-    all the calls to DEPRECATE().
+    grep "non-integer scalar" numpy/core/src/multiarray/* for
+    all the calls to `DEPRECATE()`, except the one inside
+    `_validate_slice_parameter` which handles slicing (but see also
+    `TestFloatSliceParameterDeprecation`).
 
-    When 2.4 support is dropped PyIndex_Check_Or_Unsupported should
-    be removed from npy_pycompat.h and changed to just PyIndex_Check.
+    When 2.4 support is dropped `PyIndex_Check_Or_Unsupported` should
+    be removed from npy_pycompat.h and changed to just `PyIndex_Check`.
     """
     def setUp(self):
         warnings.filterwarnings("error", message="non-integer scalar index",
@@ -92,6 +94,19 @@ class TestFloatScalarIndexDeprecation(object):
 
 
 class TestFloatSliceParameterDeprecation(object):
+    """
+    These test that `DeprecationWarning`s get raised when you
+    try to use  non-integers for slicing, e.g `a[0.0:5]`, `a[::1.5]`,
+    etc.
+
+    When this is changed to an error, `slice_GetIndices` and
+    `_validate_slice_parameter` should probably be removed. Calls to
+    `slice_GetIndices` should be replaced by the standard Python
+    API call `PySlice_GetIndicesEx`, since `slice_GetIndices`
+    implements the same thing but with a) int coercion and b) Python
+    < 2.3 backwards compatibility (which we have long since dropped
+    as of this writing).
+    """
     def setUp(self):
         warnings.filterwarnings("error", message="non-integer slice param",
                                 category=DeprecationWarning)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -28,7 +28,7 @@ def check_does_not_raise(f, category):
     np.testing.assert_(not raised)
 
 
-class TestFloatIndexDeprecation(object):
+class TestFloatScalarIndexDeprecation(object):
     """
     These test that DeprecationWarnings get raised when you
     try to use scalar indices that are not integers e.g. a[0.0],
@@ -41,11 +41,11 @@ class TestFloatIndexDeprecation(object):
     be removed from npy_pycompat.h and changed to just PyIndex_Check.
     """
     def setUp(self):
-        warnings.filterwarnings("error", message="non-integer",
+        warnings.filterwarnings("error", message="non-integer scalar index",
                                 category=DeprecationWarning)
 
     def tearDown(self):
-        warnings.filterwarnings("default", message="non-integer",
+        warnings.filterwarnings("default", message="non-integer scalar index",
                                 category=DeprecationWarning)
 
     def test_deprecations(self):
@@ -72,6 +72,10 @@ class TestFloatIndexDeprecation(object):
         yield check_for_warning, lambda: a[0, 0, -1.4], DeprecationWarning
         yield check_for_warning, lambda: a[-1.4, 0, 0], DeprecationWarning
         yield check_for_warning, lambda: a[0, -1.4, 0], DeprecationWarning
+        # Test that the slice parameter deprecation warning doesn't mask
+        # the scalar index warning.
+        yield check_for_warning, lambda: a[0.0:, 0.0], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0:, 0.0, :], DeprecationWarning
 
     def test_valid_not_deprecated(self):
         a = np.array([[[5]]])
@@ -84,4 +88,65 @@ class TestFloatIndexDeprecation(object):
         yield (check_does_not_raise, lambda: a[:, 0, :],
                DeprecationWarning)
         yield (check_does_not_raise, lambda: a[:, :, :],
+               DeprecationWarning)
+
+
+class TestFloatSliceParameterDeprecation(object):
+    def setUp(self):
+        warnings.filterwarnings("error", message="non-integer slice param",
+                                category=DeprecationWarning)
+
+    def tearDown(self):
+        warnings.filterwarnings("default", message="non-integer slice param",
+                                category=DeprecationWarning)
+
+    def test_deprecations(self):
+        a = np.array([[5]])
+        if sys.version_info[:2] < (2, 5):
+            raise SkipTest()
+        # start as float.
+        yield check_for_warning, lambda: a[0.0:], DeprecationWarning
+        yield check_for_warning, lambda: a[0:, 0.0:2], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0::2, :0], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0:1:2, :], DeprecationWarning
+        yield check_for_warning, lambda: a[:, 0.0:], DeprecationWarning
+        # stop as float.
+        yield check_for_warning, lambda: a[:0.0], DeprecationWarning
+        yield check_for_warning, lambda: a[:0, 1:2.0], DeprecationWarning
+        yield check_for_warning, lambda: a[:0.0:2, :0], DeprecationWarning
+        yield check_for_warning, lambda: a[:0.0, :], DeprecationWarning
+        yield check_for_warning, lambda: a[:, 0:4.0:2], DeprecationWarning
+        # step as float.
+        yield check_for_warning, lambda: a[::1.0], DeprecationWarning
+        yield check_for_warning, lambda: a[0:, :2:2.0], DeprecationWarning
+        yield check_for_warning, lambda: a[1::4.0, :0], DeprecationWarning
+        yield check_for_warning, lambda: a[::5.0, :], DeprecationWarning
+        yield check_for_warning, lambda: a[:, 0:4:2.0], DeprecationWarning
+        # mixed.
+        yield check_for_warning, lambda: a[1.0:2:2.0], DeprecationWarning
+        yield check_for_warning, lambda: a[1.0::2.0], DeprecationWarning
+        yield check_for_warning, lambda: a[0:, :2.0:2.0], DeprecationWarning
+        yield check_for_warning, lambda: a[1.0:1:4.0, :0], DeprecationWarning
+        yield check_for_warning, lambda: a[1.0:5.0:5.0, :], DeprecationWarning
+        yield check_for_warning, lambda: a[:, 0.4:4.0:2.0], DeprecationWarning
+        # should still get the DeprecationWarning if step = 0.
+        yield check_for_warning, lambda: a[::0.0], DeprecationWarning
+
+    def test_valid_not_deprecated(self):
+        a = np.array([[[5]]])
+        yield (check_does_not_raise, lambda: a[::],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[0:],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[:2],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[0:2],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[::2],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[1::2],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[:2:2],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[1:2:2],
                DeprecationWarning)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1,5 +1,5 @@
 """
-"Tests related to deprecation warnings. Also a convenient place
+Tests related to deprecation warnings. Also a convenient place
 to document how deprecations should eventually be turned into errors.
 """
 import numpy as np

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -41,6 +41,14 @@ class TestFloatScalarIndexDeprecation(object):
 
     When 2.4 support is dropped `PyIndex_Check_Or_Unsupported` should
     be removed from npy_pycompat.h and changed to just `PyIndex_Check`.
+
+    As for the deprecation time-frame: via Ralf Gommers,
+
+    "Hard to put that as a version number, since we don't know if the
+    version after 1.8 will be 6 months or 2 years after. I'd say 2
+    years is reasonable."
+
+    I interpret this to mean 2 years after the 1.8 release.
     """
     def setUp(self):
         warnings.filterwarnings("error", message="non-integer scalar index",
@@ -106,6 +114,14 @@ class TestFloatSliceParameterDeprecation(object):
     implements the same thing but with a) int coercion and b) Python
     < 2.3 backwards compatibility (which we have long since dropped
     as of this writing).
+
+    As for the deprecation time-frame: via Ralf Gommers,
+
+    "Hard to put that as a version number, since we don't know if the
+    version after 1.8 will be 6 months or 2 years after. I'd say 2
+    years is reasonable."
+
+    I interpret this to mean 2 years after the 1.8 release.
     """
     def setUp(self):
         warnings.filterwarnings("error", message="non-integer slice param",

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1,0 +1,79 @@
+"""
+"Tests related to deprecation warnings. Also a convenient place
+to document how deprecations should eventually be turned into errors.
+"""
+import numpy as np
+import warnings
+
+
+def check_for_warning(f, category):
+    raised = False
+    try:
+        f()
+    except category:
+        raised = True
+    print np.__file__
+    np.testing.assert_(raised)
+
+
+def check_does_not_raise(f, category):
+    raised = False
+    try:
+        f()
+    except category:
+        raised = True
+    np.testing.assert_(not raised)
+
+
+class TestFloatIndexDeprecation(object):
+    """
+    These test that DeprecationWarnings get raised when you
+    try to use scalar indices that are not integers e.g. a[0.0],
+    a[1.5, 0].
+
+    grep PyIndex_Check_Or_Unsupported numpy/core/src/multiarray/* for
+    all the calls to DEPRECATE().
+
+    When 2.4 support is dropped PyIndex_Check_Or_Unsupported should
+    be removed from npy_pycompat.h and changed to just PyIndex_Check.
+    """
+    def setUp(self):
+        warnings.filterwarnings("error", message="non-integer",
+                                category=DeprecationWarning)
+
+    def tearDown(self):
+        warnings.filterwarnings("default", message="non-integer",
+                                category=DeprecationWarning)
+
+    def test_deprecations(self):
+        a = np.array([[[5]]])
+        yield check_for_warning, lambda: a[0.0], DeprecationWarning
+        yield check_for_warning, lambda: a[0, 0.0], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0, 0], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0, :], DeprecationWarning
+        yield check_for_warning, lambda: a[:, 0.0], DeprecationWarning
+        yield check_for_warning, lambda: a[:, 0.0, :], DeprecationWarning
+        yield check_for_warning, lambda: a[0.0, :, :], DeprecationWarning
+        # XXX: These do issue DeprecationWarnings but for some reason the
+        # warning filter does not turn them into exceptions. I thought
+        # there was an overzealous PyExc_Clear to blame, but after redefining
+        # it with a macro and making it print, there seems to be none taking
+        # place after that warning state is set. The relevant code is in
+        # _tuple_of_integers in numpy/core/src/multiarray/mapping.c.
+
+        # yield check_for_warning, lambda: a[0, 0, 0.0], DeprecationWarning
+        # yield check_for_warning, lambda: a[0.0, 0, 0], DeprecationWarning
+        # yield check_for_warning, lambda: a[0, 0.0, 0], DeprecationWarning
+
+    def test_valid_not_deprecated(self):
+        a = np.array([[[5]]])
+        yield (check_does_not_raise, lambda: a[np.array([0])],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[[0, 0]],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[:, [0, 0]],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[:, 0, :],
+               DeprecationWarning)
+        yield (check_does_not_raise, lambda: a[:, :, :],
+               DeprecationWarning)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -2,8 +2,11 @@
 Tests related to deprecation warnings. Also a convenient place
 to document how deprecations should eventually be turned into errors.
 """
-import numpy as np
+import sys
 import warnings
+
+from nose.plugins.skip import SkipTest
+import numpy as np
 
 
 def check_for_warning(f, category):
@@ -47,6 +50,8 @@ class TestFloatIndexDeprecation(object):
 
     def test_deprecations(self):
         a = np.array([[[5]]])
+        if sys.version_info[:2] < (2, 5):
+            raise SkipTest()
         yield check_for_warning, lambda: a[0.0], DeprecationWarning
         yield check_for_warning, lambda: a[0, 0.0], DeprecationWarning
         yield check_for_warning, lambda: a[0.0, 0], DeprecationWarning


### PR DESCRIPTION
Fixes #2810. Does not address non-integers in list/fancy indices, i.e. #2811.

The relevant (scalar) indexing code basically breaks down into three code paths:
- Single scalar indices
- Indexing an n-dimensional array with a tuple of n scalars
- Everything else

This adds a DeprecationWarning in the right place in each of them. Since the warning string is the same, it'll only trigger once if it's been triggered anywhere.

For slices, this adds checks inside `slice_GetIndices`, which should probably be removed once slicing with floats becomes an error in favor of `PySlice_GetIndicesEx`.
