### PR TITLE
in place fancy indexing for ufuncs

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -188,9 +188,9 @@ computations.
 In place fancy indexing for ufuncs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The function ``at`` has been added to ufunc objects to allow in place
-ufuncs using fancy indexing with no buffering. For example, the following
-will increment the first and second items in the array, and will increment
-the third item twice:
+ufuncs with no buffering when fancy indexing is used. For example, the
+following will increment the first and second items in the array, and will
+increment the third item twice:
 numpy.add.at(array, [0, 1, 2, 2], 1)
 
 This is similar to doing array[[0, 1, 2, 2]] += 1

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -185,6 +185,16 @@ New nan aware statistical functions are added. In these functions the
 results are what would be obtained if nan values were ommited from all
 computations.
 
+In place fancy indexing for ufuncs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The function ``at`` has been added to ufunc objects to allow in place
+ufuncs using fancy indexing with no buffering. For example, the following
+will increment the first and second items in the array, and will increment
+the third item twice:
+numpy.add.at(array, [0, 1, 2, 2], 1)
+
+This is similar to doing array[[0, 1, 2, 2]] += 1
+
 C-API
 ~~~~~
 

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -418,9 +418,10 @@ an integer (or Boolean) data-type and smaller than the size of the
 (or :class:`uint`) data-type.
 
 Ufuncs also have a fifth method that allows in place operations to be
-performed using fancy indexing. No buffering is used, so the fancy index
-can list an item more than once and the operation will be performed on the
-result of the previous operation for that item.
+performed using fancy indexing. No buffering is used on the dimensions where
+fancy indexing is used, so the fancy index can list an item more than once and
+the operation will be performed on the result of the previous operation for
+that item.
 
 .. index::
    pair: ufunc; methods

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -417,6 +417,11 @@ an integer (or Boolean) data-type and smaller than the size of the
 :class:`int_` data type, it will be internally upcast to the :class:`int_`
 (or :class:`uint`) data-type.
 
+Ufuncs also have a fifth method that allows in place operations to be
+performed using fancy indexing. No buffering is used, so the fancy index
+can list an item more than once and the operation will be performed on the
+result of the previous operation for that item.
+
 .. index::
    pair: ufunc; methods
 
@@ -427,6 +432,7 @@ an integer (or Boolean) data-type and smaller than the size of the
    ufunc.accumulate
    ufunc.reduceat
    ufunc.outer
+   ufunc.at
 
 
 .. warning::

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5820,11 +5820,14 @@ add_newdoc('numpy.core', 'ufunc', ('at',
     at(a, indices, b=None)
 
     Performs operation in place on array for items specified by indices.
-    Items can be listed more than once and operation will be performed
-    on result of operation on previous item.
-
-    Equivalent to a[indices] += b for addition ufunc, except that results
-    are accumulated for indices listed more than once.
+    For addition ufunc, this method is equivalent to a[indices] += b,
+    except that results are accumulated for indices listed more than once.
+    This solves the problem with a[indices] += b where each time a duplicate
+    index is encounted, the increment is performed on the original element.
+    As a result, an element that appears three times in the fancy indexing
+    list will only be incremented once in the final result, whereas with the
+    new 'at' method the original element will be incremented by three in the
+    final result.
 
     Parameters
     ----------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5815,6 +5815,47 @@ add_newdoc('numpy.core', 'ufunc', ('outer',
 
     """))
 
+add_newdoc('numpy.core', 'ufunc', ('at',
+    """
+    at(a, indices, b=None)
+
+    Performs operation in place on array for items specified by indices.
+    Items can be listed more than once and operation will be performed
+    on result of operation on previous item.
+
+    Equivalent to a[indices] += b for addition ufunc, except that results
+    are accumulated for indices listed more than once.
+
+    Parameters
+    ----------
+    a : array_like
+        The array to act on.
+    indices : array_like
+        Paired indices, comma separated (not colon), specifying slices to
+        reduce.
+    b : array_like or scalar
+        Second operation for ufuncs requiring two operands.
+
+    Examples
+    --------
+    Set items 0 and 1 to their negative values:
+
+    np.negative.at(a, [0, 1])
+
+    ::
+
+    Increment items 0 and 1, and increment item 2 twice:
+
+    np.add.at(a, [0, 1, 2, 2], 1)
+
+    ::
+
+    Add items 0 and 1 in first array to second array,
+    and store results in first array:
+
+    np.add.at(a, [0, 1], b)
+
+    """))
 
 ##############################################################################
 #

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5844,7 +5844,7 @@ add_newdoc('numpy.core', 'ufunc', ('at',
 
     >>> a = np.array([1, 2, 3, 4])
     >>> np.negative.at(a, [0, 1])
-    >>> print a
+    >>> print(a)
     array([-1, -2, 3, 4])
 
     ::
@@ -5853,7 +5853,7 @@ add_newdoc('numpy.core', 'ufunc', ('at',
 
     >>> a = np.array([1, 2, 3, 4])
     >>> np.add.at(a, [0, 1, 2, 2], 1)
-    >>> print a
+    >>> print(a)
     array([2, 3, 5, 4])
 
     ::
@@ -5864,7 +5864,7 @@ add_newdoc('numpy.core', 'ufunc', ('at',
     >>> a = np.array([1, 2, 3, 4])
     >>> b = np.array([1, 2])
     >>> np.add.at(a, [0, 1], b)
-    >>> print a
+    >>> print(a)
     array([2, 4, 3, 4])
 
     """))

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5844,6 +5844,7 @@ add_newdoc('numpy.core', 'ufunc', ('at',
 
     >>> a = np.array([1, 2, 3, 4])
     >>> np.negative.at(a, [0, 1])
+    >>> print a
     array([-1, -2, 3, 4])
 
     ::
@@ -5852,6 +5853,7 @@ add_newdoc('numpy.core', 'ufunc', ('at',
 
     >>> a = np.array([1, 2, 3, 4])
     >>> np.add.at(a, [0, 1, 2, 2], 1)
+    >>> print a
     array([2, 3, 5, 4])
 
     ::
@@ -5862,6 +5864,7 @@ add_newdoc('numpy.core', 'ufunc', ('at',
     >>> a = np.array([1, 2, 3, 4])
     >>> b = np.array([1, 2])
     >>> np.add.at(a, [0, 1], b)
+    >>> print a
     array([2, 4, 3, 4])
 
     """))

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5819,44 +5819,50 @@ add_newdoc('numpy.core', 'ufunc', ('at',
     """
     at(a, indices, b=None)
 
-    Performs operation in place on array for items specified by indices.
-    For addition ufunc, this method is equivalent to a[indices] += b,
-    except that results are accumulated for indices listed more than once.
-    This solves the problem with a[indices] += b where each time a duplicate
-    index is encounted, the increment is performed on the original element.
-    As a result, an element that appears three times in the fancy indexing
-    list will only be incremented once in the final result, whereas with the
-    new 'at' method the original element will be incremented by three in the
-    final result.
+    Performs unbuffered in place operation on operand 'a' for elements
+    specified by 'indices'. For addition ufunc, this method is equivalent to
+    `a[indices] += b`, except that results are accumulated for elements that
+    are indexed more than once. For example, `a[[0,0]] += 1` will only
+    increment the first element once because of buffering, whereas
+    `add.at(a, [0,0], 1)` will increment the first element twice.
 
     Parameters
     ----------
     a : array_like
-        The array to act on.
-    indices : array_like
-        Paired indices, comma separated (not colon), specifying slices to
-        reduce.
-    b : array_like or scalar
-        Second operation for ufuncs requiring two operands.
+        The array to perform in place operation on.
+    indices : array_like or tuple
+        Array like index object or slice object for indexing into first
+        operand. If first operand has multiple dimensions, indices can be a
+        tuple of array like index objects or slice objects.
+    b : array_like
+        Second operand for ufuncs requiring two operands. Operand must be
+        broadcastable over first operand after indexing or slicing.
 
     Examples
     --------
     Set items 0 and 1 to their negative values:
 
-    np.negative.at(a, [0, 1])
+    >>> a = np.array([1, 2, 3, 4])
+    >>> np.negative.at(a, [0, 1])
+    array([-1, -2, 3, 4])
 
     ::
 
     Increment items 0 and 1, and increment item 2 twice:
 
-    np.add.at(a, [0, 1, 2, 2], 1)
+    >>> a = np.array([1, 2, 3, 4])
+    >>> np.add.at(a, [0, 1, 2, 2], 1)
+    array([2, 3, 5, 4])
 
     ::
 
     Add items 0 and 1 in first array to second array,
     and store results in first array:
 
-    np.add.at(a, [0, 1], b)
+    >>> a = np.array([1, 2, 3, 4])
+    >>> b = np.array([1, 2])
+    >>> np.add.at(a, [0, 1], b)
+    array([2, 4, 3, 4])
 
     """))
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1790,16 +1790,6 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
         goto fail;
     }
 
-    /* Set up default iteraxes array values */
-    n = PyArray_NDIM(arr);
-    for (i = 0; i < n; i++) {
-        mit->iteraxes[i] = i;
-    }
-    /* no subspace iteration needed.  Finish up and Return */
-    if (subnd == 0) {
-        goto finish;
-    }
-
     /*
      * all indexing arrays have been converted to 0
      * therefore we can extract the subspace with a simple

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1699,7 +1699,7 @@ PyArray_MapIterReset(PyArrayMapIterObject *mit)
     return;
 }
 
-/*NUMPY_API
+/*
  * This function needs to update the state of the map iterator
  * and point mit->dataptr to the memory-location of the next object
  */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1653,6 +1653,7 @@ _convert_obj(PyObject *obj, PyArrayIterObject **iter)
 }
 
 /* Reset the map iterator to the beginning */
+/*NUMPY_API*/
 NPY_NO_EXPORT void
 PyArray_MapIterReset(PyArrayMapIterObject *mit)
 {
@@ -1700,6 +1701,7 @@ PyArray_MapIterReset(PyArrayMapIterObject *mit)
  * This function needs to update the state of the map iterator
  * and point mit->dataptr to the memory-location of the next object
  */
+/*NUMPY_API*/
 NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit)
 {
@@ -1762,6 +1764,7 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
  * Let's do it at bind time and also convert all <0 values to >0 here
  * as well.
  */
+/*NUMPY_API*/
 NPY_NO_EXPORT int
 PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
 {
@@ -1947,6 +1950,7 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
 }
 
 
+/*NUMPY_API*/
 NPY_NO_EXPORT PyObject *
 PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
 {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1793,6 +1793,16 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
         goto fail;
     }
 
+    /* Set up default iteraxes array values */
+    n = PyArray_NDIM(arr);
+    for (i = 0; i < n; i++) {
+        mit->iteraxes[i] = i;
+    }
+    /* no subspace iteration needed.  Finish up and Return */
+    if (subnd == 0) {
+        goto finish;
+    }
+
     /*
      * all indexing arrays have been converted to 0
      * therefore we can extract the subspace with a simple

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1653,7 +1653,6 @@ _convert_obj(PyObject *obj, PyArrayIterObject **iter)
 }
 
 /* Reset the map iterator to the beginning */
-/*NUMPY_API*/
 NPY_NO_EXPORT void
 PyArray_MapIterReset(PyArrayMapIterObject *mit)
 {
@@ -1699,11 +1698,10 @@ PyArray_MapIterReset(PyArrayMapIterObject *mit)
     return;
 }
 
-/*
+/*NUMPY_API
  * This function needs to update the state of the map iterator
  * and point mit->dataptr to the memory-location of the next object
  */
-/*NUMPY_API*/
 NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit)
 {
@@ -1770,7 +1768,6 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
  * Let's do it at bind time and also convert all <0 values to >0 here
  * as well.
  */
-/*NUMPY_API*/
 NPY_NO_EXPORT int
 PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
 {
@@ -1966,7 +1963,6 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
 }
 
 
-/*NUMPY_API*/
 NPY_NO_EXPORT PyObject *
 PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
 {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1663,7 +1663,9 @@ PyArray_MapIterReset(PyArrayMapIterObject *mit)
 
     mit->index = 0;
 
-    copyswap = PyArray_DESCR(mit->iters[0]->ao)->f->copyswap;
+    if (mit->numiter > 0) {
+        copyswap = PyArray_DESCR(mit->iters[0]->ao)->f->copyswap;
+    }
 
     if (mit->subspace != NULL) {
         memcpy(coord, mit->bscoord, sizeof(npy_intp)*PyArray_NDIM(mit->ait->ao));
@@ -1714,7 +1716,11 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
     if (mit->index >= mit->size) {
         return;
     }
-    copyswap = PyArray_DESCR(mit->iters[0]->ao)->f->copyswap;
+
+    if (mit->numiter > 0) {
+        copyswap = PyArray_DESCR(mit->iters[0]->ao)->f->copyswap;
+    }
+
     /* Sub-space iteration */
     if (mit->subspace != NULL) {
         PyArray_ITER_NEXT(mit->subspace);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4930,11 +4930,9 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
          * iterated over correctly
          */
         if ((iter->subspace != NULL) && (iter->consec)) {
-            if (iter->iteraxes[0] > 0) {
-                PyArray_MapIterSwapAxes(iter, &op2_array, 0);
-                if (op2_array == NULL) {
-                    goto fail;
-                }
+            PyArray_MapIterSwapAxes(iter, &op2_array, 0);
+            if (op2_array == NULL) {
+                goto fail;
             }
         }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4986,16 +4986,19 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     count[0] = 1;
     stride[0] = 1;
 
+    Py_INCREF(PyArray_DESCR(op1_array));
     array_operands[0] = PyArray_NewFromDescr(&PyArray_Type,
                                        PyArray_DESCR(op1_array),
                                        1, dims, NULL, iter->dataptr,
                                        NPY_ARRAY_WRITEABLE, NULL);
     if (iter2 != NULL) {
+        Py_INCREF(PyArray_DESCR(op2_array));
         array_operands[1] = PyArray_NewFromDescr(&PyArray_Type,
                                            PyArray_DESCR(op2_array), 
                                            1, dims, NULL,
                                            PyArray_ITER_DATA(iter2),
                                            NPY_ARRAY_WRITEABLE, NULL);
+        Py_INCREF(PyArray_DESCR(op1_array));
         array_operands[2] = PyArray_NewFromDescr(&PyArray_Type,
                                            PyArray_DESCR(op1_array),
                                            1, dims, NULL,
@@ -5003,6 +5006,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
                                            NPY_ARRAY_WRITEABLE, NULL);
     }
     else {
+        Py_INCREF(PyArray_DESCR(op1_array));
         array_operands[1] = PyArray_NewFromDescr(&PyArray_Type,
                                            PyArray_DESCR(op1_array),
                                            1, dims, NULL,
@@ -5128,6 +5132,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     Py_XDECREF(array_operands[0]);
     Py_XDECREF(array_operands[1]);
     Py_XDECREF(array_operands[2]);
+    Py_XDECREF(errobj);
 
     Py_RETURN_NONE;
 
@@ -5139,6 +5144,7 @@ fail:
     Py_XDECREF(array_operands[0]);
     Py_XDECREF(array_operands[1]);
     Py_XDECREF(array_operands[2]);
+    Py_XDECREF(errobj);
 
     return NULL;
 }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5051,7 +5051,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
                         NPY_ITER_DELAY_BUFALLOC,
                         NPY_KEEPORDER, NPY_UNSAFE_CASTING,
                         op_flags, dtypes,
-                        0, NULL, NULL, buffersize);
+                        -1, NULL, NULL, buffersize);
 
     if (iter_buffer == NULL) {
         goto fail;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4851,7 +4851,7 @@ ufunc_reduceat(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
 
 /* Call ufunc only on selected array items and store result in first operand */
 static PyObject *
-ufunc_select(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
+ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"op1", "idx", "op2"};
     PyObject *op1 = NULL;
@@ -4995,8 +4995,8 @@ static struct PyMethodDef ufunc_methods[] = {
     {"outer",
         (PyCFunction)ufunc_outer,
         METH_VARARGS | METH_KEYWORDS, NULL},
-    {"select",
-        (PyCFunction)ufunc_select,
+    {"at",
+        (PyCFunction)ufunc_at,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {NULL, NULL, 0, NULL}           /* sentinel */
 };

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5123,12 +5123,9 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
 fail:
 
-    if (op2_array != NULL)
-        Py_DECREF(op2_array);
-    if (iter != NULL)
-        Py_DECREF(iter);
-    if (iter2 != NULL)
-        Py_DECREF(iter2);
+    Py_XDECREF(op2_array);
+    Py_XDECREF(iter);
+    Py_XDECREF(iter2);
     return NULL;
 }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5103,14 +5103,17 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         NpyIter_ResetBasePointers(iter_buffer, dataptr, NULL);
         buffer_dataptr = NpyIter_GetDataPtrArray(iter_buffer);
 
+        innerloop(buffer_dataptr, count, stride, innerloopdata);
+
+        if (needs_api && PyErr_Occurred()) {
+            break;
+        }
+
         /* 
-         * Even though we'll never loop more than once, call to iternext
-         * triggers copy from buffer back to output array after innerloop
-         * puts result in buffer.
+         * Call to iternext triggers copy from buffer back to output array
+         * after innerloop puts result in buffer.
          */
-        do {
-            innerloop(buffer_dataptr, count, stride, innerloopdata);
-        } while (iternext(iter_buffer));
+        iternext(iter_buffer);
 
         PyArray_MapIterNext(iter);
         if (iter2 != NULL) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5134,7 +5134,12 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     Py_XDECREF(array_operands[2]);
     Py_XDECREF(errobj);
 
-    Py_RETURN_NONE;
+    if (needs_api && PyErr_Occurred()) {
+        return NULL;
+    }
+    else {
+        Py_RETURN_NONE;
+    }
 
 fail:
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5001,8 +5001,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
 
 fail:
 
-    if (op1_array != NULL)
-        Py_DECREF(op1_array);
     if (op2_array != NULL)
         Py_DECREF(op2_array);
     if (iter != NULL)

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4883,6 +4883,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     int nop;
     
     NpyIter *iter_buffer;
+    NpyIter_IterNextFunc *iternext;
     npy_uint32 op_flags[NPY_MAXARGS];
     int buffersize;
     int errormask = 0;
@@ -5059,6 +5060,12 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     
     needs_api = NpyIter_IterationNeedsAPI(iter_buffer);
 
+    iternext = NpyIter_GetIterNext(iter_buffer, NULL);
+    if (iternext == NULL) {
+        NpyIter_Deallocate(iter_buffer);
+        goto fail;
+    }
+
     /*
      * Iterate over first and second operands and call ufunc
      * for each pair of inputs
@@ -5066,7 +5073,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     i = iter->size;
     while (i > 0)
     {
-        NpyIter_IterNextFunc *iternext;
         char *dataptr[3];
         char **buffer_dataptr;
 
@@ -5084,12 +5090,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
             dataptr[2] = NULL;
         }
         
-        iternext = NpyIter_GetIterNext(iter_buffer, NULL);
-        if (iternext == NULL) {
-            NpyIter_Deallocate(iter_buffer);
-            goto fail;
-        }
-
         /* Reset NpyIter data pointers which will trigger a buffer copy */
         NpyIter_ResetBasePointers(iter_buffer, dataptr, NULL);
         buffer_dataptr = NpyIter_GetDataPtrArray(iter_buffer);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4902,16 +4902,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         goto fail;
     }
 
-    /*
-     * If second operand exists, we need to broadcast it to 
-     * the shape of the indices applied to the first operand.
-     * This will produce an iterator that will match up with
-     * the iterator for the first operand.
-     */
+    /* Create second operand from number array if needed. */
     if (op2 != NULL) {
-        iter_descr = PyArray_DESCR(iter->ait->ao);
-        op2_array = (PyArrayObject *)PyArray_FromAny(op2, iter_descr,
-                                0, 0, NPY_ARRAY_FORCECAST, NULL);
+        op2_array = (PyArrayObject *)PyArray_FromAny(op2, NULL,
+                                0, 0, 0, NULL);
         if (op2_array == NULL) {
             goto fail;
         }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4883,13 +4883,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     int nop;
     
     NpyIter *iter_buffer;
-    NpyIter_IterNextFunc *iternext;
     npy_uint32 op_flags[NPY_MAXARGS];
     int buffersize;
     int errormask = 0;
     PyObject *errobj = NULL;    
-    char *dataptr[3];
-    char **buffer_dataptr;
 
     if (ufunc->nin > 2) {
         PyErr_SetString(PyExc_ValueError,
@@ -5071,6 +5068,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     i = iter->size;
     while (i > 0)
     {
+        NpyIter_IterNextFunc *iternext;
+        char *dataptr[3];
+        char **buffer_dataptr;
+
         /*
          * Set up data pointers for either one or two input operands.
          * The output data pointer points to the first operand data.

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4913,16 +4913,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         goto fail;
     }
 
-    iter = (PyArrayMapIterObject*)PyArray_MapIterNew(idx, 0, 1);
+    iter = PyArray_MapIterArray(op1_array, idx);
     if (iter == NULL) {
         goto fail;
     }
-
-    PyArray_MapIterBind(iter, op1_array);
-    if (iter->ait == NULL) {
-        goto fail;
-    }
-    PyArray_MapIterReset(iter);
 
     /*
      * If second operand exists, we need to broadcast it to 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4974,7 +4974,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         nop = 2;
     }
 
-    if (ufunc->type_resolver(ufunc, NPY_DEFAULT_ASSIGN_CASTING,
+    if (ufunc->type_resolver(ufunc, NPY_UNSAFE_CASTING,
                             operands, NULL, dtypes) < 0) {
         goto fail;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4953,7 +4953,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
 
         /*
          * Be sure values array is "broadcastable"
-         * to shape of mit->dimensions, mit->nd
+         * to shape of iter->dimensions, iter->nd
          */
         if ((iter2 = (PyArrayIterObject *)\
              PyArray_BroadcastToShape((PyObject *)op2_array,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4875,6 +4875,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     char *dataptr[3];
     npy_intp count[1], stride[1];
     int i, j;
+    int ndim;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwlist,
                                 &op1, &idx, &op2)) {
@@ -4895,6 +4896,20 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
 
     op1_array = (PyArrayObject *)PyArray_FromAny(op1, NULL, 0, 0, 0, NULL);
     if (op1_array == NULL) {
+        goto fail;
+    }
+
+    ndim = PyArray_NDIM(op1_array);
+    if (PyTuple_Check(idx)) {
+        if (PyTuple_GET_SIZE(idx) != ndim) {
+            PyErr_SetString(PyExc_ValueError,
+                "number of dimensions in index must match number of dimensions in first operand");
+            goto fail;
+        }
+    }
+    else if (ndim > 1) {
+        PyErr_SetString(PyExc_ValueError,
+            "number of dimensions in index must match number of dimensions in first operand");
         goto fail;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4896,6 +4896,9 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     }
 
     PyArray_MapIterBind(iter, op1_array);
+    if (iter->ait == NULL) {
+        return NULL;
+    }
     PyArray_MapIterReset(iter);
 
     /* If second operand is an array, create MapIter object for it */
@@ -4911,12 +4914,17 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         }
 
         PyArray_MapIterBind(iter2, op2_array);
+        if (iter->ait == NULL) {
+            return NULL;
+        }
         PyArray_MapIterReset(iter2);
     }
     /* If second operand is a scalar, create 0 dim array from it */
     else if (op2 != NULL && PyArray_IsAnyScalar(op2)) {
         op2_array = (PyArrayObject *)PyArray_FromAny(op2, NULL, 0, 0, 0, NULL);
         if (op2_array == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                "could not convert scalar to array");
             return NULL;
         }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4897,20 +4897,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     op1_array = op1;
     
-    ndim = PyArray_NDIM(op1_array);
-    if (PyTuple_Check(idx)) {
-        if (PyTuple_GET_SIZE(idx) != ndim) {
-            PyErr_SetString(PyExc_ValueError,
-                "number of dimensions in index must match number of dimensions in first operand");
-            goto fail;
-        }
-    }
-    else if (ndim > 1) {
-        PyErr_SetString(PyExc_ValueError,
-            "number of dimensions in index must match number of dimensions in first operand");
-        goto fail;
-    }
-
     iter = PyArray_MapIterArray(op1_array, idx);
     if (iter == NULL) {
         goto fail;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4924,34 +4924,35 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     }
     PyArray_MapIterReset(iter);
 
-    /* If second operand is a scalar, create 0 dim array from it */
-    if (op2 != NULL && PyArray_IsAnyScalar(op2)) {
-        op2_array = (PyArrayObject *)PyArray_FromAny(op2, NULL, 0, 0, 0, NULL);
-        if (op2_array == NULL) {
-            PyErr_SetString(PyExc_TypeError,
-                "could not convert scalar to array");
-            goto fail;
-        }
-
-        iter2 = NULL;
-        first_item[0] = 0;
-    }
-    /* If second operand is an array like object,
-       create MapIter object for it */
-    else if (op2 != NULL) {
-        op2_array = (PyArrayObject *)PyArray_FromAny(op2, NULL, 0, 0, 0, NULL);
+    /* If second operand exists, we need to broadcast it to 
+       the shape of the indices applied to the first operand.
+       This will produce an iterator that will match up with
+       the iterator for the first operand. */
+    if (op2 != NULL) {
+        PyArray_Descr *descr = PyArray_DESCR(iter->ait->ao);
+        Py_INCREF(descr);
+        op2_array = (PyArrayObject *)PyArray_FromAny(op2, descr,
+                                0, 0, NPY_ARRAY_FORCECAST, NULL);
         if (op2_array == NULL) {
             goto fail;
         }
-
-        int ndims = PyArray_NDIM(op1_array);
-        npy_intp *dims = PyArray_DIMS(op1_array);
-        iter2 = PyArray_BroadcastToShape(op2_array, iter->dimensions, iter->nd);
-        if (iter2 == NULL) {
-            goto fail;
+        if ((iter->subspace != NULL) && (iter->consec)) {
+            if (iter->iteraxes[0] > 0) {  /* then we need to swap */
+                PyArray_MapIterSwapAxes(iter, &op2_array, 0);
+                if (op2_array == NULL) {
+                    goto fail;
+                }
+            }
         }
 
-        PyArray_ITER_RESET(iter2);
+        /* Be sure values array is "broadcastable"
+           to shape of mit->dimensions, mit->nd */
+
+        if ((iter2 = (PyArrayIterObject *)\
+             PyArray_BroadcastToShape((PyObject *)op2_array,
+                                        iter->dimensions, iter->nd))==NULL) {
+            goto fail;
+        }
     }
 
     /* Create dtypes array for either one or two input operands.
@@ -4983,10 +4984,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         dataptr[0] = iter->dataptr;
         if (iter2 != NULL) {
             dataptr[1] = PyArray_ITER_DATA(iter2);
-            dataptr[2] = iter->dataptr;
-        }
-        else if (op2_array != NULL) {
-            dataptr[1] = PyArray_GetPtr(op2_array, first_item);
             dataptr[2] = iter->dataptr;
         }
         else {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4929,9 +4929,13 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
             }
         }
 
-        /*
-         * Be sure values array is "broadcastable"
-         * to shape of iter->dimensions, iter->nd
+        /* 
+         * Create array iter object for second operand that
+         * "matches" the map iter object for the first operand.
+         * Then we can just iterate over the first and second
+         * operands at the same time and not have to worry about
+         * picking the correct elements from each operand to apply
+         * the ufunc to.
          */
         if ((iter2 = (PyArrayIterObject *)\
              PyArray_BroadcastToShape((PyObject *)op2_array,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4860,9 +4860,8 @@ ufunc_reduceat(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
  *       over first operand.
  */
 static PyObject *
-ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
+ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 {
-    static char *kwlist[] = {"op1", "idx", "op2"};
     PyObject *op1 = NULL;
     PyObject *idx = NULL;
     PyObject *op2 = NULL;
@@ -4880,8 +4879,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     int ndim;
     int i;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwlist,
-                                &op1, &idx, &op2)) {
+    if (!PyArg_ParseTuple(args, "OO|O", &op1, &idx, &op2)) {
         return NULL;
     }
 
@@ -5038,7 +5036,7 @@ static struct PyMethodDef ufunc_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"at",
         (PyCFunction)ufunc_at,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5118,6 +5118,8 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
         i--;
     }
+    
+    NpyIter_Deallocate(iter_buffer);
 
     return op1;
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4870,14 +4870,25 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     PyArrayMapIterObject *iter = NULL;
     PyArrayIterObject *iter2 = NULL;
     PyArray_Descr *iter_descr = NULL;
-    PyArray_Descr *dtypes[3];
+    PyArray_Descr *dtypes[3] = {NULL, NULL, NULL};
+    PyArrayObject *operands[3] = {NULL, NULL, NULL};
     int needs_api;
     PyUFuncGenericFunction innerloop;
     void *innerloopdata;
     char *dataptr[3];
     npy_intp count[1], stride[1];
-    int ndim;
+    npy_intp dims[1];
     int i;
+    int buffersize = 0;
+    int errormask = 0;
+    PyObject *errobj = NULL;
+    PyObject *arr_prep[NPY_MAXARGS];
+    PyObject *arr_prep_args;
+    
+    PyUFunc_GetPyValues(ufunc->name, &buffersize, &errormask, &errobj);
+    for (i = 0; i < ufunc->nin + ufunc->nout; ++i) {
+        arr_prep[i] = NULL;
+    } 
 
     if (!PyArg_ParseTuple(args, "OO|O", &op1, &idx, &op2)) {
         return NULL;
@@ -4938,20 +4949,24 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         }
     }
 
-    /*
-     * Create dtypes array for either one or two input operands.
-     * The output operand is set to the first input operand
-     */
-    dtypes[0] = PyArray_DESCR(op1_array);
+    operands[0] = op1_array;
+    dtypes[0] = PyArray_DESCR(operands[0]);
     if (op2_array != NULL) {
-        dtypes[1] = PyArray_DESCR(op2_array);
-        dtypes[2] = dtypes[0];
+        operands[1] = op2_array;
+        operands[2] = op1_array;
+        dtypes[1] = PyArray_DESCR(operands[1]);
+        dtypes[2] = PyArray_DESCR(operands[2]);
     }
     else {
-        dtypes[1] = dtypes[0];
-        dtypes[2] = NULL;
+        operands[1] = op1_array;
+        dtypes[1] = PyArray_DESCR(operands[1]);
     }
 
+    if (ufunc->type_resolver(ufunc, NPY_DEFAULT_ASSIGN_CASTING,
+                            operands, NULL, dtypes) < 0) {
+        goto fail;
+    }
+    
     if (ufunc->legacy_inner_loop_selector(ufunc, dtypes,
         &innerloop, &innerloopdata, &needs_api) < 0) {
         goto fail;
@@ -4965,23 +4980,41 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
      * for each pair of inputs
      */
     i = iter->size;
+    dims[0] = 1;
     while (i > 0)
     {
-        /*
-         * Set up data pointers for either one or two input operands.
-         * The output data pointer points to the first operand data.
-         */
-        dataptr[0] = iter->dataptr;
+        /* Set up operands for call to iterator_loop */
+        operands[0] = PyArray_NewFromDescr(&PyArray_Type,
+                                            PyArray_DESCR(op1_array),
+                                            1, dims, NULL, iter->dataptr,
+                                            NPY_ARRAY_WRITEABLE, NULL);
         if (iter2 != NULL) {
-            dataptr[1] = PyArray_ITER_DATA(iter2);
-            dataptr[2] = iter->dataptr;
+            operands[1] = PyArray_NewFromDescr(&PyArray_Type,
+                                                PyArray_DESCR(op2_array), 
+                                                1, dims, NULL,
+                                                PyArray_ITER_DATA(iter2),
+                                                NPY_ARRAY_WRITEABLE, NULL);
+            operands[2] = PyArray_NewFromDescr(&PyArray_Type,
+                                                PyArray_DESCR(op1_array),
+                                                1, dims, NULL,
+                                                iter->dataptr,
+                                                NPY_ARRAY_WRITEABLE, NULL);
         }
         else {
-            dataptr[1] = iter->dataptr;
-            dataptr[2] = NULL;
+            operands[1] = PyArray_NewFromDescr(&PyArray_Type,
+                                                PyArray_DESCR(op1_array),
+                                                1, dims, NULL,
+                                                iter->dataptr,
+                                                NPY_ARRAY_WRITEABLE, NULL);
+            operands[2] = NULL;
         }
 
-        innerloop(dataptr, count, stride, innerloopdata);
+        /* Call iterator_loop which will call ufunc and handle any buffering */
+        if (iterator_loop(ufunc, operands, dtypes, NPY_KEEPORDER,
+                        buffersize, arr_prep, arr_prep_args,
+                        innerloop, innerloopdata) < 0) {
+            goto fail;
+        }
 
         PyArray_MapIterNext(iter);
         if (iter2 != NULL) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4871,6 +4871,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     PyArrayIterObject *iter2 = NULL;
     PyArray_Descr *dtypes[3] = {NULL, NULL, NULL};
     PyArrayObject *operands[3] = {NULL, NULL, NULL};
+    PyArrayObject *array_operands[3] = {NULL, NULL, NULL};
     npy_intp dims[1] = {1};    
 
     int needs_api;
@@ -4985,29 +4986,29 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     count[0] = 1;
     stride[0] = 1;
 
-    operands[0] = PyArray_NewFromDescr(&PyArray_Type,
+    array_operands[0] = PyArray_NewFromDescr(&PyArray_Type,
                                        PyArray_DESCR(op1_array),
                                        1, dims, NULL, iter->dataptr,
                                        NPY_ARRAY_WRITEABLE, NULL);
     if (iter2 != NULL) {
-        operands[1] = PyArray_NewFromDescr(&PyArray_Type,
+        array_operands[1] = PyArray_NewFromDescr(&PyArray_Type,
                                            PyArray_DESCR(op2_array), 
                                            1, dims, NULL,
                                            PyArray_ITER_DATA(iter2),
                                            NPY_ARRAY_WRITEABLE, NULL);
-        operands[2] = PyArray_NewFromDescr(&PyArray_Type,
+        array_operands[2] = PyArray_NewFromDescr(&PyArray_Type,
                                            PyArray_DESCR(op1_array),
                                            1, dims, NULL,
                                            iter->dataptr,
                                            NPY_ARRAY_WRITEABLE, NULL);
     }
     else {
-        operands[1] = PyArray_NewFromDescr(&PyArray_Type,
+        array_operands[1] = PyArray_NewFromDescr(&PyArray_Type,
                                            PyArray_DESCR(op1_array),
                                            1, dims, NULL,
                                            iter->dataptr,
                                            NPY_ARRAY_WRITEABLE, NULL);
-        operands[2] = NULL;
+        array_operands[2] = NULL;
     }
 
     /* Set up the flags */
@@ -5043,7 +5044,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
      * pointers from the NpyIter object will then be passed to the inner loop
      * function.
      */
-    iter_buffer = NpyIter_AdvancedNew(nop, operands,
+    iter_buffer = NpyIter_AdvancedNew(nop, array_operands,
                         NPY_ITER_EXTERNAL_LOOP|
                         NPY_ITER_REFS_OK|
                         NPY_ITER_ZEROSIZE_OK|
@@ -5121,13 +5122,24 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
    
     NpyIter_Deallocate(iter_buffer);
 
-    return op1;
+    Py_XDECREF(op2_array);
+    Py_XDECREF(iter);
+    Py_XDECREF(iter2);
+    Py_XDECREF(array_operands[0]);
+    Py_XDECREF(array_operands[1]);
+    Py_XDECREF(array_operands[2]);
+
+    Py_RETURN_NONE;
 
 fail:
 
     Py_XDECREF(op2_array);
     Py_XDECREF(iter);
     Py_XDECREF(iter2);
+    Py_XDECREF(array_operands[0]);
+    Py_XDECREF(array_operands[1]);
+    Py_XDECREF(array_operands[2]);
+
     return NULL;
 }
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -866,7 +866,6 @@ class TestUfunc(TestCase):
         assert_(MyThing.getitem_count <= 2, MyThing.getitem_count)
 
     def test_inplace_fancy_indexing(self):
-        # 'at' method is equivalent to a[:,idx] += b
 
         a = np.arange(10)
         indices = np.array([2,5,2])

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -968,9 +968,9 @@ class TestUfunc(TestCase):
         assert_raises(IndexError, np.add.at, a, [], 1)
 
         # Test mixed dtypes
-        a = np.arange(10, dtype='i8')
+        a = np.arange(10, dtype='u8')
         np.power.at(a, [1,2,3,2], 3.5)
-        assert_equal(a, [0, 1, 4414, 46, 4, 5, 6, 7, 8, 9])
+        assert_equal(a, np.array([0, 1, 4414, 46, 4, 5, 6, 7, 8, 9], dtype='u8'))
 
         # Test boolean indexing and boolean ufuncs
         a = np.arange(10)

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -968,9 +968,9 @@ class TestUfunc(TestCase):
         assert_raises(IndexError, np.add.at, a, [], 1)
 
         # Test mixed dtypes
-        a = np.arange(10, dtype='u8')
+        a = np.arange(10)
         np.power.at(a, [1,2,3,2], 3.5)
-        assert_equal(a, np.array([0, 1, 4414, 46, 4, 5, 6, 7, 8, 9], dtype='u8'))
+        assert_equal(a, np.array([0, 1, 4414, 46, 4, 5, 6, 7, 8, 9]))
 
         # Test boolean indexing and boolean ufuncs
         a = np.arange(10)

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -972,6 +972,11 @@ class TestUfunc(TestCase):
         np.power.at(a, [1,2,3,2], 3.5)
         assert_equal(a, [0, 1, 4414, 46, 4, 5, 6, 7, 8, 9])
 
+        # Test boolean indexing and boolean ufuncs
+        a = np.arange(10)
+        index = a % 2 == 0
+        np.equal.at(a, index, [0, 2, 4, 6, 8])
+        assert_equal(a, [1, 1, 1, 3, 1, 5, 1, 7, 1, 9])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -939,6 +939,22 @@ class TestUfunc(TestCase):
               [21,  22, 23],
               [24,  25, 26]]])
 
+        a = np.arange(27).reshape(3,3,3)
+        b = np.array([100,200,300])
+        np.add.at(a, (slice(None), slice(None), slice(None)), b)
+        assert_equal(a,
+            [[[100,201,302], 
+              [103,204,305], 
+              [106,207,308]],
+              
+             [[109,210,311],  
+              [112,213,314], 
+              [115,216,317]],
+
+             [[118,219,320],
+              [121,222,323],
+              [124,225,326]]])
+
         a = np.arange(10)
         np.negative.at(a, [2,5,2])
         assert_equal(a, [0, 1, 2, 3, 4, -5, 6, 7, 8, 9])

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -866,18 +866,41 @@ class TestUfunc(TestCase):
         assert_(MyThing.getitem_count <= 2, MyThing.getitem_count)
 
     def test_inplace_fancy_indexing(self):
-        a = np.array([1, 2, 3])
-        np.negative.at(a, [0, 0, 1, 2])
-        assert_equal(a, [1, -2, -3])
+        # 'at' method is equivalent to a[:,idx] += b
 
-        a = np.array([1, 2, 3])
-        np.add.at(a, [0, 1, 1, 2], 1)
-        assert_equal(a, [2, 4, 4])
+        a = np.arange(10)
+        indices = np.array([2,5,2])
+        np.add.at(a, indices, 1)
+        assert_equal(a, [0, 1, 4, 3, 4, 6, 6, 7, 8, 9])
 
-        a = np.array([1, 2, 3])
-        np.add.at(a, [0, 1, 2, 2], np.array([1, 2, 3]))
-        assert_equal(a, [2, 4, 9])
+        a = np.arange(10)
+        b = np.array([100,100,100])
+        indices = np.array([2,5,2])
+        np.add.at(a, indices, b)
+        assert_equal(a, [0, 1, 202, 3, 4, 105, 6, 7, 8, 9])
 
-        
+        a = np.arange(9)
+        a.shape = (3,3)
+        b = np.array([[100,100,100],[200,200,200],[300,300,300]])
+        indices = np.array([1,2,1])
+        np.add.at(a, indices, b)
+        assert_equal(a, [[0,401,202], [3,404,205], [6,407,208]])
+
+        a = np.arange(27)
+        a.shape = (3,3,3)
+        b = np.array([100,200,300])
+        indices = np.array([1,2,1])
+        np.add.at(a, indices, b)
+        assert_equal(a,
+            [[[0,201,102], [3,404,205], [6,607,308]],
+            [[9,210,111], [12,413,214], [15,616,317]],
+            [[18,219,120], [21,422,223], [24,625,326]]])
+
+        a = np.arange(10)
+        indices = np.array([2,5,2])
+        np.negative.at(a, indices)
+        assert_equal(a, [0, 1, 2, 3, 4, -5, 6, 7, 8, 9])
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -959,11 +959,13 @@ class TestUfunc(TestCase):
         np.negative.at(a, [2,5,2])
         assert_equal(a, [0, 1, 2, 3, 4, -5, 6, 7, 8, 9])
 
-        # test exception when indices dimensions < first operand dimensions
-        a = np.arange(27).reshape(3,3,3)
-        b = np.array([100,200,300])
-        assert_raises(ValueError, np.add.at, a, [1,2,1], b)
-        assert_raises(ValueError, np.add.at, a, ([1,2,1],), b)
+        # Test 0-dim array
+        a = np.array(0)
+        np.add.at(a, (), 1)
+        assert_equal(a, 1)
+
+        assert_raises(IndexError, np.add.at, a, 0, 1)
+        assert_raises(IndexError, np.add.at, a, [], 1)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -968,7 +968,7 @@ class TestUfunc(TestCase):
         assert_raises(IndexError, np.add.at, a, [], 1)
 
         # Test mixed dtypes
-        a = np.arange(10, dtype='u8')
+        a = np.arange(10, dtype='i8')
         np.power.at(a, [1,2,3,2], 3.5)
         assert_equal(a, [0, 1, 4414, 46, 4, 5, 6, 7, 8, 9])
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -983,6 +983,11 @@ class TestUfunc(TestCase):
         np.invert.at(a, [2, 5, 2])
         assert_equal(a, [0, 1, 2, 3, 4, 5 ^ 0xffffffff, 6, 7, 8, 9])
 
+        # Test empty subspace
+        orig = np.arange(4)
+        a = orig[:,None][:,0:0]
+        np.add.at(a, [0,1], 3)
+        assert_array_equal(orig, np.arange(4))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -868,36 +868,79 @@ class TestUfunc(TestCase):
     def test_inplace_fancy_indexing(self):
 
         a = np.arange(10)
-        indices = np.array([2,5,2])
-        np.add.at(a, indices, 1)
+        np.add.at(a, [2,5,2], 1)
         assert_equal(a, [0, 1, 4, 3, 4, 6, 6, 7, 8, 9])
 
         a = np.arange(10)
         b = np.array([100,100,100])
-        indices = np.array([2,5,2])
-        np.add.at(a, indices, b)
+        np.add.at(a, [2,5,2], b)
         assert_equal(a, [0, 1, 202, 3, 4, 105, 6, 7, 8, 9])
 
-        a = np.arange(9)
-        a.shape = (3,3)
+        a = np.arange(9).reshape(3,3)
         b = np.array([[100,100,100],[200,200,200],[300,300,300]])
-        indices = np.array([1,2,1])
-        np.add.at(a, indices, b)
-        assert_equal(a, [[0,401,202], [3,404,205], [6,407,208]])
+        np.add.at(a, (slice(None), [1,2,1]), b)
+        assert_equal(a, [[0,201,102], [3,404,205], [6,607,308]])
 
-        a = np.arange(27)
-        a.shape = (3,3,3)
+        a = np.arange(27).reshape(3,3,3)
         b = np.array([100,200,300])
-        indices = np.array([1,2,1])
-        np.add.at(a, indices, b)
+        np.add.at(a, (slice(None), slice(None), [1,2,1]), b)
         assert_equal(a,
-            [[[0,201,102], [3,404,205], [6,607,308]],
-            [[9,210,111], [12,413,214], [15,616,317]],
-            [[18,219,120], [21,422,223], [24,625,326]]])
+            [[[0,401,202], 
+              [3,404,205], 
+              [6,407,208]],
+              
+             [[9, 410,211],  
+              [12,413,214], 
+              [15,416,217]],
+
+             [[18,419,220],
+              [21,422,223],
+              [24,425,226]]])
+
+        a = np.arange(9).reshape(3,3)
+        b = np.array([[100,100,100],[200,200,200],[300,300,300]])
+        np.add.at(a, ([1,2,1], slice(None)), b)
+        assert_equal(a, [[0,1,2], [403,404,405], [206,207,208]])
+
+        a = np.arange(27).reshape(3,3,3)
+        b = np.array([100,200,300])
+        np.add.at(a, (slice(None), [1,2,1], slice(None)), b)
+        assert_equal(a,
+            [[[0,  1,  2  ], 
+              [203,404,605], 
+              [106,207,308]],
+              
+             [[9,  10, 11 ],  
+              [212,413,614], 
+              [115,216,317]],
+
+             [[18, 19, 20 ],
+              [221,422,623],
+              [124,225,326]]])
+
+        a = np.arange(9).reshape(3,3)
+        b = np.array([100,200,300])
+        np.add.at(a, (0, [1,2,1]), b)
+        assert_equal(a, [[0,401,202], [3,4,5], [6,7,8]])
+
+        a = np.arange(27).reshape(3,3,3)
+        b = np.array([100,200,300])
+        np.add.at(a, ([1,2,1], 0, slice(None)), b)
+        assert_equal(a,
+            [[[0,  1,  2], 
+              [3,  4,  5], 
+              [6,  7,  8]],
+              
+             [[209,410,611],  
+              [12,  13, 14], 
+              [15,  16, 17]],
+
+             [[118,219,320],
+              [21,  22, 23],
+              [24,  25, 26]]])
 
         a = np.arange(10)
-        indices = np.array([2,5,2])
-        np.negative.at(a, indices)
+        np.negative.at(a, [2,5,2])
         assert_equal(a, [0, 1, 2, 3, 4, -5, 6, 7, 8, 9])
 
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -865,5 +865,19 @@ class TestUfunc(TestCase):
         assert_(MyThing.rmul_count == 1, MyThing.rmul_count)
         assert_(MyThing.getitem_count <= 2, MyThing.getitem_count)
 
+    def test_inplace_fancy_indexing(self):
+        a = np.array([1, 2, 3])
+        np.negative.at(a, [0, 0, 1, 2])
+        assert_equal(a, [1, -2, -3])
+
+        a = np.array([1, 2, 3])
+        np.add.at(a, [0, 1, 1, 2], 1)
+        assert_equal(a, [2, 4, 4])
+
+        a = np.array([1, 2, 3])
+        np.add.at(a, [0, 1, 2, 2], np.array([1, 2, 3]))
+        assert_equal(a, [2, 4, 9])
+
+        
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -943,6 +943,12 @@ class TestUfunc(TestCase):
         np.negative.at(a, [2,5,2])
         assert_equal(a, [0, 1, 2, 3, 4, -5, 6, 7, 8, 9])
 
+        # test exception when indices dimensions < first operand dimensions
+        a = np.arange(27).reshape(3,3,3)
+        b = np.array([100,200,300])
+        assert_raises(ValueError, np.add.at, a, [1,2,1], b)
+        assert_raises(ValueError, np.add.at, a, ([1,2,1],), b)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -989,5 +989,11 @@ class TestUfunc(TestCase):
         np.add.at(a, [0,1], 3)
         assert_array_equal(orig, np.arange(4))
 
+        dt = np.dtype(np.intp).newbyteorder()
+        index = np.array([1,2,3], dt)
+        dt = np.dtype(np.float_).newbyteorder()
+        values = np.array([1,2,3,4], dt)
+        np.add.at(values, index, 3)
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -967,6 +967,11 @@ class TestUfunc(TestCase):
         assert_raises(IndexError, np.add.at, a, 0, 1)
         assert_raises(IndexError, np.add.at, a, [], 1)
 
+        # Test mixed dtypes
+        a = np.arange(10, dtype='u8')
+        np.power.at(a, [1,2,3,2], 3.5)
+        assert_equal(a, [0, 1, 4414, 46, 4, 5, 6, 7, 8, 9])
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -995,5 +995,10 @@ class TestUfunc(TestCase):
         np.add.at(values, index, 3)
         assert_array_equal(values, [1,8,6,4])
 
+        # Test exception thrown
+        values = np.array(['a', 1], dtype=np.object)
+        self.assertRaises(TypeError, np.add.at, values, [0,1], 1)
+        assert_array_equal(values, np.array(['a', 1], dtype=np.object))
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -989,11 +989,11 @@ class TestUfunc(TestCase):
         np.add.at(a, [0,1], 3)
         assert_array_equal(orig, np.arange(4))
 
-        dt = np.dtype(np.intp).newbyteorder()
-        index = np.array([1,2,3], dt)
-        dt = np.dtype(np.float_).newbyteorder()
-        values = np.array([1,2,3,4], dt)
+        # Test with swapped byte order
+        index = np.array([1,2,1], np.dtype('i').newbyteorder())
+        values = np.array([1,2,3,4], np.dtype('f').newbyteorder())
         np.add.at(values, index, 3)
+        assert_array_equal(values, [1,8,6,4])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -978,5 +978,11 @@ class TestUfunc(TestCase):
         np.equal.at(a, index, [0, 2, 4, 6, 8])
         assert_equal(a, [1, 1, 1, 3, 1, 5, 1, 7, 1, 9])
 
+        # Test unary operator
+        a = np.arange(10, dtype='u4')
+        np.invert.at(a, [2, 5, 2])
+        assert_equal(a, [0, 1, 2, 3, 4, 5 ^ 0xffffffff, 6, 7, 8, 9])
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Currently when doing something like a[idx] += 1 where idx is a fancy index, and the fancy index lists an element more than once, the increment is performed on each element's original value instead of accumulating the increments. This is because the first operand is buffered, and the ufunc operates on the buffered operand. 

This pull request adds a new method called 'at' to ufunc object for in place fancy indexing with no buffering.  This allows a ufunc operation to be performed on an element more than once, with the result of each operation being stored in place before the next operation is performed. This is equivalent to doing a[idx] += b with no buffering for operand 'a'. For example:

a = np.array([0,1,2,3])
# second element is incremented twice
np.add.at(a, [0,1,1], 1)
a
>>> array([1, 3, 2, 3)]

The 'at' method also supports slicing. For example:

a = np.array([0,1,2,3])
np.add.at(a, (slice(None),), 1)
a
>>> array([1, 2, 3, 4)]

A more complicated example:

a = np.arange(27).reshape(3,3,3)
b = np.array([100,200,300])
np.add.at(a, (slice(None), slice(None), [1,2,1]), b)
a
>>> array([[[0,401,202], 
      [3,404,205], 
      [6,407,208]],
     [[9, 410,211],  
      [12,413,214], 
      [15,416,217]],
     [[18,419,220],
      [21,422,223],
      [24,425,226]]])

The 'at' method can be used with all ufuncs, including unary ufuncs:

a = np.array([0, 1, 2, 3])
np.negative.at(a, [0,1])
a
>>> array([0, -1, 2, 3])
