### PR TITLE
MAINT: Cleanup 1.8.0-notes.rst.

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -2,6 +2,10 @@
 NumPy 1.8.0 Release Notes
 =========================
 
+This release supports  Python 2.6 -2.7 and 3.1 - 3.3. Support for  Python
+2.4 and 2.5 has been dropped.
+
+
 
 Highlights
 ==========
@@ -10,120 +14,26 @@ Highlights
 Compatibility notes
 ===================
 
-numpy.diag, np.diagonal, and the diagonal method of ndarrays return
-a view onto the original array, instead of producing a copy.
+numpy.diag, np.diagonal, and the diagonal method of ndarrays return a view
+onto the original array, instead of producing a copy.
 
 selecting multiple fields out of an array also produces a view.
 
-The hash function of numpy.void scalars has been changed.  
-Previously the pointer to the data was hashed as an integer.
-Now, the hash function uses the tuple-hash algorithm to combine
-the hash functions of the elements of the scalar, but only if 
-the scalar is read-only.
+The hash function of numpy.void scalars has been changed.  Previously the
+pointer to the data was hashed as an integer.  Now, the hash function uses
+the tuple-hash algorithm to combine the hash functions of the elements of
+the scalar, but only if the scalar is read-only.
 
 New features
 ============
 
-Masked-arrays
-----------------------------
 
-Preliminary support for NA missing values similar to those in R has
-been implemented.  This was done by adding an NA mask to an array sub-type
-
-.. note:: The NA API is *experimental*, and may undergo changes in future
-   versions of NumPy.  The current implementation based on masks will 
-   likely be supplemented by a second one based on bit-patterns, and it 
-   is possible that a difference will be made between missing and 
-   ignored data.
-
-While a significant amount of the NumPy functionality has been extended to
-support NA masks, not everything is yet supported. Here is an (incomplete)
-list of things that do and do not work with NA values:
-
-What works with NA:
-    * Basic indexing and slicing, as well as full boolean mask indexing.
-    * All element-wise ufuncs.
-    * All UFunc.reduce methods, with a new skipna parameter.
-    * np.all and np.any satisfy the rules NA | True == True and
-      NA & False == False
-    * The nditer object.
-    * Array methods:
-       + ndarray.clip, ndarray.min, ndarray.max, ndarray.sum, ndarray.prod,
-         ndarray.conjugate, ndarray.diagonal, ndarray.flatten
-       + numpy.concatenate, numpy.column_stack, numpy.hstack,
-         numpy.vstack, numpy.dstack, numpy.squeeze, numpy.mean, numpy.std,
-         numpy.var
-
-What doesn't work with NA:
-    * Fancy indexing, such as with lists and partial boolean masks.
-    * ndarray.flat and any other methods that use the old iterator
-      mechanism instead of the newer nditer.
-    * Struct dtypes, which will have corresponding struct masks with
-      one mask value per primitive field of the struct dtype.
-    * UFunc.accumulate, UFunc.reduceat.
-    * Ufunc calls with both NA masks and a where= mask at the same time.
-    * File I/O has not been extended to support NA-masks.
-    * np.logical_and and np.logical_or don't satisfy the
-      rules NA | True == True and NA & False == False yet.
-    * Array methods:
-       + ndarray.argmax, ndarray.argmin,
-       + numpy.repeat, numpy.delete (relies on fancy indexing),
-         numpy.append, numpy.insert (relies on fancy indexing),
-         numpy.where,
-
-Differences with R:
-    * R's parameter rm.na=T is spelled skipna=True in NumPy.
-    * np.isna(nan) is False, but R's is.na(nan) is TRUE. This is because
-      NumPy's NA is treated independently of the underlying data type.
-    * Boolean indexing, where the result is compressed to just
-      the elements with true in the mask, raises if the boolean mask
-      has an NA value in it. This is because that value could be either
-      True or False, meaning the count of the output array is actually
-      NA. R treats this case in a manner inconsistent with the NA model,
-      returning NA values in the spots where the boolean index has NA.
-      This may have a practical advantage in spite of violating the
-      NA theoretical model, so NumPy could adopt the behavior if necessary
-
-
-New argument to searchsorted
-----------------------------
-
-The function searchsorted now accepts a 'sorter' argument that is a
-permuation array that sorts the array to search.
-
-C API
------
-
-New function ``PyArray_RequireWriteable`` provides a consistent
-interface for checking array writeability -- any C code which works
-with arrays whose WRITEABLE flag is not known to be True a priori,
-should make sure to call this function before writing.
 
 Changes
 =======
 
 General
 -------
-
-The function np.concatenate tries to match the layout of its input
-arrays. Previously, the layout did not follow any particular reason,
-and depended in an undesirable way on the particular axis chosen for
-concatenation. A bug was also fixed which silently allowed out of bounds
-axis arguments.
-
-The ufuncs logical_or, logical_and, and logical_not now follow Python's
-behavior with object arrays, instead of trying to call methods on the
-objects. For example the expression (3 and 'test') produces the string
-'test', and now np.logical_and(np.array(3, 'O'), np.array('test', 'O'))
-produces 'test' as well.
-
-
-DATETIME
---------
-
-There have been a lot of fixes and enhancements to datetime64. The notes
-in doc/source/reference/arrays.datetime.rst or in the generated
-documentation should be consulted for the details.
 
 
 Deprecations
@@ -132,24 +42,9 @@ Deprecations
 General
 -------
 
-Specifying a custom string formatter with a `_format` array attribute is
-deprecated. The new `formatter` keyword in ``numpy.set_printoptions`` or
-``numpy.array2string`` can be used instead.
-
-The deprecated imports in the polynomial package have been removed.
+Use of non-integer indices has been deprecated. Previously float indices
+were truncated to integers without warning.
 
 C-API
 -----
 
-Direct access to the fields of PyArrayObject* has been deprecated. Direct
-access has been recommended against for many releases. Expect similar
-deprecations for PyArray_Descr* and other core objects in the future as
-preparation for NumPy 2.0.
-
-The macros in old_defines.h are deprecated and will be removed in the next
-major release (>= 2.0). The sed script tools/replace_old_macros.sed can
-be used to replace these macros with the newer versions.
-
-You can test your code against the deprecated C API by #defining
-NPY_NO_DEPRECATED_API to the target version number, for example
-NPY_1_7_API_VERSION, before including any NumPy headers.

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -27,6 +27,8 @@ the scalar, but only if the scalar is read-only.
 New features
 ============
 
+Euler's constant is now exposed in numpy as euler_gamma.
+
 
 
 Changes


### PR DESCRIPTION
Remove contents of 1.7.0-notes that were left when it was copied,
note that support for Python 2.4 - 2.5 has been dropped, and note
deprecation of non-integer indices.
