### PR TITLE
Fix unicode tests for flexible string representation on Python 3.3

### DIFF
--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -5,7 +5,19 @@ from numpy.core import *
 from numpy.compat import asbytes
 
 # Guess the UCS length for this python interpreter
-if sys.version_info[0] >= 3:
+if sys.version_info[:2] >= (3, 3):
+    # Python 3.3 uses a flexible string representation
+    ucs4 = False
+    def buffer_length(arr):
+        if isinstance(arr, unicode):
+            arr = str(arr)
+            return (sys.getsizeof(arr+"a") - sys.getsizeof(arr)) * len(arr)
+        v = memoryview(arr)
+        if v.shape is None:
+            return len(v) * v.itemsize
+        else:
+            return prod(v.shape) * v.itemsize
+elif sys.version_info[0] >= 3:
     import array as _array
     ucs4 = (_array.array('u').itemsize == 4)
     def buffer_length(arr):


### PR DESCRIPTION
This fixes issue #2750 for me on Windows (using msvc compilers). Needs testing on other platforms.
