### PR TITLE
FIX: Use the NPY_TIME_T macro everywhere

### DIFF
--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -189,7 +189,7 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
      * we drop the seconds value from the npy_datetimestruct, everything
      * is ok for this operation.
      */
-    rawtime = (time_t)get_datetimestruct_days(out_dts_local) * 24 * 60 * 60;
+    rawtime = (NPY_TIME_T)get_datetimestruct_days(out_dts_local) * 24 * 60 * 60;
     rawtime += dts_utc->hour * 60 * 60;
     rawtime += dts_utc->min * 60;
 
@@ -207,7 +207,7 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
 
     /* Extract the timezone offset that was applied */
     rawtime /= 60;
-    localrawtime = (time_t)get_datetimestruct_days(out_dts_local) * 24 * 60;
+    localrawtime = (NPY_TIME_T)get_datetimestruct_days(out_dts_local) * 24 * 60;
     localrawtime += out_dts_local->hour * 60;
     localrawtime += out_dts_local->min;
 


### PR DESCRIPTION
Previously, two (critical) parts of the code used `time_t` instead of
`NPY_TIME_T`. Due to the fact, that most of the time `NPY_TIME_T` was equal to
`time_t`, this bug didn't show up. But in mingw, `NPY_TIME_T` is actually equal
to `__time64_t` and then this causes 64 bit integers to be cast into 32 bit
integers (thus becoming negative), which causes localtime() to fail in mingw.

Fixes gh-568.
