### PR TITLE
FIX: remove a spurious check in get_cast_transfer_function

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -1475,14 +1475,6 @@ get_cast_transfer_function(int aligned,
     npy_intp src_itemsize = src_dtype->elsize,
             dst_itemsize = dst_dtype->elsize;
 
-    if (src_dtype->type_num == dst_dtype->type_num &&
-            src_dtype->type_num != NPY_DATETIME &&
-            src_dtype->type_num != NPY_TIMEDELTA) {
-        PyErr_SetString(PyExc_ValueError,
-                "low level cast function is for unequal type numbers");
-        return NPY_FAIL;
-    }
-
     if (get_nbo_cast_transfer_function(aligned,
                             src_stride, dst_stride,
                             src_dtype, dst_dtype,

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -443,6 +443,9 @@ class TestString(TestCase):
         # Pull request #376
         dt = np.dtype('(1L,)i4')
 
+    def test_base_dtype_with_object_type(self):
+        # Issue gh-2798
+        a = np.array(['a'], dtype="O").astype(("O", [("name", "O")]))
 
 class TestDtypeAttributeDeletion(object):
 


### PR DESCRIPTION
At least, I hope it's spurious. Certainly it's creating a spurious
error message, is unexpected by callers (one of whom specifically
makes the _opposite_ check before calling get_cast_transfer_function),
and even if it is a useful check for some reason I can't see, it
certainly doesn't belong in this function (which is otherwise just
taking care of byte-swapping and alignment issues and doesn't know
anything about dtypes). And worst case, we'll have turned an exception
into a crash; even if I'm wrong, this shouldn't cause any code to go
from working to not working, just from broken to slightly-more-broken.

Test and original diagnosis by @cgohlke.

Fixes gh-2798.
