### PR TITLE
Release Commits for 1.7.0rc1

### DIFF
--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -10,4 +10,4 @@
 # PyArray_CountNonzero, PyArray_NewLikeArray and PyArray_MatrixProduct2.
 0x00000006 = e61d5dc51fa1c6459328266e215d6987
 # Version 7 (NumPy 1.7) improved datetime64, misc utilities.
-0x00000007 = e396ba3912dcf052eaee1b0b203a7724
+0x00000007 = 89a262ae563c2600955fb468ee4e02c7

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ PLATFORMS           = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"]
 MAJOR               = 1
 MINOR               = 7
 MICRO               = 0
-ISRELEASED          = False
+ISRELEASED          = True
 VERSION             = '%d.%d.%drc1' % (MAJOR, MINOR, MICRO)
 
 # Return the git revision as a string


### PR DESCRIPTION
@rgommers or @charris or @njsmith, would you mind reviewing these commits? Especially the C API change. I just changed the latest hash --- should I rather create a new line and a version number instead?

I also created the new tag. If you give this +1, I'll just push this in manually, so that we don't get the "merge" commit from github.

After these patches are in, I am going to generate/upload the binaries to sourceforge. I fixed all the issues with python 3.3, so all is working now.
