### PR TITLE
Add convenience functions nans, infs, nans_like, infs_like 

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -117,7 +117,7 @@ It is now possible to use `np.newaxis`/`None` together with index
 arrays instead of only in simple indices. This means that
 ``array[np.newaxis, [0, 1]]`` will now work as expected.
 
-New functions `filled` and `filled_like`
+New functions `full` and `full_like`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New convenience functions to create arrays filled with a specific value;

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -112,9 +112,16 @@ causes the returned array to be inverted.
 
 Advanced indexing using `np.newaxis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 It is now possible to use `np.newaxis`/`None` together with index
 arrays instead of only in simple indices. This means that
 ``array[np.newaxis, [0, 1]]`` will now work as expected.
+
+New functions `filled` and `filled_like`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New convenience functions to create arrays filled with a specific value;
+complementary to the existing `zeros` and `zeros_like` functions.
 
 C-API
 ~~~~~

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -237,15 +237,15 @@ def ones_like(a, dtype=None, order='K', subok=True):
     multiarray.copyto(res, 1, casting='unsafe')
     return res
 
-def filled(shape, val, dtype=None, order='C'):
+def filled(shape, fill_value, dtype=None, order='C'):
     """
-    Return a new array of given shape and type, filled with `val`.
+    Return a new array of given shape and type, filled with `fill_value`.
 
     Parameters
     ----------
     shape : int or sequence of ints
         Shape of the new array, e.g., ``(2, 3)`` or ``2``.
-    val : scalar
+    fill_value : scalar
         Fill value.
     dtype : data-type, optional
         The desired data-type for the array, e.g., `numpy.int8`.  Default is
@@ -257,7 +257,7 @@ def filled(shape, val, dtype=None, order='C'):
     Returns
     -------
     out : ndarray
-        Array of `val` with the given shape, dtype, and order.
+        Array of `fill_value` with the given shape, dtype, and order.
 
     See Also
     --------
@@ -280,10 +280,10 @@ def filled(shape, val, dtype=None, order='C'):
 
     """
     a = empty(shape, dtype, order)
-    multiarray.copyto(a, val, casting='unsafe')
+    multiarray.copyto(a, fill_value, casting='unsafe')
     return a
 
-def filled_like(a, val, dtype=None, order='K', subok=True):
+def filled_like(a, fill_value, dtype=None, order='K', subok=True):
     """
     Return a filled array with the same shape and type as a given array.
 
@@ -292,7 +292,7 @@ def filled_like(a, val, dtype=None, order='K', subok=True):
     a : array_like
         The shape and data-type of `a` define these same attributes of
         the returned array.
-    val : scalar
+    fill_value : scalar
         Fill value.
     dtype : data-type, optional
         Overrides the data type of the result.
@@ -309,7 +309,7 @@ def filled_like(a, val, dtype=None, order='K', subok=True):
     Returns
     -------
     out : ndarray
-        Array of `val` with the same shape and type as `a`.
+        Array of `fill_value` with the same shape and type as `a`.
 
     See Also
     --------
@@ -339,7 +339,7 @@ def filled_like(a, val, dtype=None, order='K', subok=True):
 
     """
     res = empty_like(a, dtype=dtype, order=order, subok=subok)
-    multiarray.copyto(res, val, casting='unsafe')
+    multiarray.copyto(res, fill_value, casting='unsafe')
     return res
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -40,7 +40,7 @@ __all__ = ['newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
            'Inf', 'inf', 'infty', 'Infinity',
            'nan', 'NaN', 'False_', 'True_', 'bitwise_not',
            'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE', 'ALLOW_THREADS',
-           'ComplexWarning', 'may_share_memory', 'filled', 'filled_like']
+           'ComplexWarning', 'may_share_memory', 'full', 'full_like']
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])
@@ -237,7 +237,7 @@ def ones_like(a, dtype=None, order='K', subok=True):
     multiarray.copyto(res, 1, casting='unsafe')
     return res
 
-def filled(shape, fill_value, dtype=None, order='C'):
+def full(shape, fill_value, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with `fill_value`.
 
@@ -264,17 +264,17 @@ def filled(shape, fill_value, dtype=None, order='C'):
     zeros_like : Return an array of zeros with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    filled_like : Fill an array with shape and type of input.
+    full_like : Fill an array with shape and type of input.
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
 
     Examples
     --------
-    >>> np.filled((2, 2), np.inf)
+    >>> np.full((2, 2), np.inf)
     array([[ inf,  inf],
            [ inf,  inf]])
-    >>> np.filled((2, 2), 10, dtype=np.int)
+    >>> np.full((2, 2), 10, dtype=np.int)
     array([[10, 10],
            [10, 10]])
 
@@ -283,9 +283,9 @@ def filled(shape, fill_value, dtype=None, order='C'):
     multiarray.copyto(a, fill_value, casting='unsafe')
     return a
 
-def filled_like(a, fill_value, dtype=None, order='K', subok=True):
+def full_like(a, fill_value, dtype=None, order='K', subok=True):
     """
-    Return a filled array with the same shape and type as a given array.
+    Return a full array with the same shape and type as a given array.
 
     Parameters
     ----------
@@ -319,22 +319,22 @@ def filled_like(a, fill_value, dtype=None, order='K', subok=True):
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
-    filled : Fill a new array.
+    full : Fill a new array.
 
     Examples
     --------
     >>> x = np.arange(6, dtype=np.int)
-    >>> np.filled_like(x, 1)
+    >>> np.full_like(x, 1)
     array([1, 1, 1, 1, 1, 1])
-    >>> np.filled_like(x, 0.1)
+    >>> np.full_like(x, 0.1)
     array([0, 0, 0, 0, 0, 0])
-    >>> np.filled_like(x, 0.1, dtype=np.double)
+    >>> np.full_like(x, 0.1, dtype=np.double)
     array([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
-    >>> np.filled_like(x, np.nan, dtype=np.double)
+    >>> np.full_like(x, np.nan, dtype=np.double)
     array([ nan,  nan,  nan,  nan,  nan,  nan])
 
     >>> y = np.arange(6, dtype=np.double)
-    >>> np.filled_like(y, 0.1)
+    >>> np.full_like(y, 0.1)
     array([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
 
     """

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -259,9 +259,7 @@ def filled(shape, val, dtype=None, order='C'):
 
 def filled_like(a, val, dtype=None, order='K', subok=True):
     """
-    Return an array of nans with the same shape and type as a given array.
-
-    With default parameters, is equivalent to ``a.copy().fill(np.nan)``.
+    Return a filled array with the same shape and type as a given array.
 
     Parameters
     ----------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -223,12 +223,6 @@ def ones_like(a, dtype=None, order='K', subok=True):
     multiarray.copyto(res, 1, casting='unsafe')
     return res
 
-def _check_dtype_nan(dtype):
-    if not issubdtype(dtype, 'float'):
-        raise ValueError('Invalid dtype because only floating point numbers '
-                         'can represent non-numbers as defined in '
-                         'IEEE 754-1985.')
-
 def filled(shape, val, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with `val`.
@@ -251,8 +245,6 @@ def filled(shape, val, dtype=None, order='C'):
     empty : Return a new uninitialized array.
 
     """
-
-    _check_dtype_nan(dtype)
     a = empty(shape, dtype, order)
     multiarray.copyto(a, val, casting='unsafe')
     return a
@@ -292,8 +284,6 @@ def filled_like(a, val, dtype=None, order='K', subok=True):
     filled : Fill a new array.
 
     """
-
-    _check_dtype_nan(dtype)
     res = empty_like(a, dtype=dtype, order=order, subok=subok)
     multiarray.copyto(res, val, casting='unsafe')
     return res

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -40,7 +40,9 @@ __all__ = ['newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
            'Inf', 'inf', 'infty', 'Infinity',
            'nan', 'NaN', 'False_', 'True_', 'bitwise_not',
            'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE', 'ALLOW_THREADS',
-           'ComplexWarning', 'may_share_memory']
+           'ComplexWarning', 'may_share_memory',
+           'nans', 'nans_like', 'infs', 'infs_like']
+
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])
@@ -221,6 +223,142 @@ def ones_like(a, dtype=None, order='K', subok=True):
     """
     res = empty_like(a, dtype=dtype, order=order, subok=subok)
     multiarray.copyto(res, 1, casting='unsafe')
+    return res
+
+def _check_dtype_nan(dtype):
+    if not issubdtype(dtype, 'float'):
+        raise ValueError('Invalid dtype because only floating point numbers '
+                         'can represent non-numbers as defined in '
+                         'IEEE 754-1985.')
+
+def nans(shape, dtype=None, order='C'):
+    """
+    Return a new array of given shape and type, filled with nans.
+
+    Please refer to the documentation for `zeros` for further details.
+
+    See Also
+    --------
+    zeros_like : Return an array of zeros with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    nans_like : Return an array of nans with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+
+    """
+
+    _check_dtype_nan(dtype)
+    a = empty(shape, dtype, order)
+    multiarray.copyto(a, nan, casting='unsafe')
+    return a
+
+def nans_like(a, dtype=None, order='K', subok=True):
+    """
+    Return an array of nans with the same shape and type as a given array.
+
+    With default parameters, is equivalent to ``a.copy().fill(np.nan)``.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of `a` define these same attributes of
+        the returned array.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+    order : {'C', 'F', 'A', or 'K'}, optional
+        Overrides the memory layout of the result. 'C' means C-order,
+        'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
+        'C' otherwise. 'K' means match the layout of `a` as closely
+        as possible.
+
+    Returns
+    -------
+    out : ndarray
+        Array of nans with the same shape and type as `a`.
+
+    See Also
+    --------
+    zeros_like : Return an array of zeros with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+    nans : Return a new array setting values to nan.
+
+    """
+
+    _check_dtype_nan(dtype)
+    res = empty_like(a, dtype=dtype, order=order, subok=subok)
+    multiarray.copyto(res, nan, casting='unsafe')
+    return res
+
+def infs(shape, dtype=None, order='C'):
+    """
+    Return a new array of given shape and type, filled with infs.
+
+    Please refer to the documentation for `zeros` for further details.
+
+    See Also
+    --------
+    zeros_like : Return an array of zeros with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    nans_like : Return an array of nans with shape and type of input.
+    infs_like : Return an array of infs with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+
+    """
+
+    _check_dtype_nan(dtype)
+    a = empty(shape, dtype, order)
+    multiarray.copyto(a, inf, casting='unsafe')
+    return a
+
+def infs_like(a, dtype=None, order='K', subok=True):
+    """
+    Return an array of infs with the same shape and type as a given array.
+
+    With default parameters, is equivalent to ``a.copy().fill(np.inf)``.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of `a` define these same attributes of
+        the returned array.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+    order : {'C', 'F', 'A', or 'K'}, optional
+        Overrides the memory layout of the result. 'C' means C-order,
+        'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
+        'C' otherwise. 'K' means match the layout of `a` as closely
+        as possible.
+
+    Returns
+    -------
+    out : ndarray
+        Array of infs with the same shape and type as `a`.
+
+    See Also
+    --------
+    zeros_like : Return an array of zeros with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    empty_like : Return an empty array with shape and type of input.
+    zeros : Return a new array setting values to zero.
+    ones : Return a new array setting values to one.
+    empty : Return a new uninitialized array.
+    nans : Return a new array setting values to nan.
+    infs : Return a new array setting values to infs.
+
+    """
+
+    _check_dtype_nan(dtype)
+    res = empty_like(a, dtype=dtype, order=order, subok=subok)
+    multiarray.copyto(res, inf, casting='unsafe')
     return res
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -235,7 +235,7 @@ def nans(shape, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with nans.
 
-    Note that only floating point numbers can represent non-numers as defined
+    Note that only floating point numbers can represent non-numbers as defined
     in IEEE 754-1985.
 
     Please refer to the documentation for `zeros` for further details.
@@ -263,7 +263,7 @@ def nans_like(a, dtype=None, order='K', subok=True):
     """
     Return an array of nans with the same shape and type as a given array.
 
-    Note that only floating point numbers can represent non-numers as defined
+    Note that only floating point numbers can represent non-numbers as defined
     in IEEE 754-1985.
 
     With default parameters, is equivalent to ``a.copy().fill(np.nan)``.
@@ -309,7 +309,7 @@ def infs(shape, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with infs.
 
-    Note that only floating point numbers can represent non-numers as defined
+    Note that only floating point numbers can represent non-numbers as defined
     in IEEE 754-1985.
 
     Please refer to the documentation for `zeros` for further details.
@@ -337,7 +337,7 @@ def infs_like(a, dtype=None, order='K', subok=True):
     """
     Return an array of infs with the same shape and type as a given array.
 
-    Note that only floating point numbers can represent non-numers as defined
+    Note that only floating point numbers can represent non-numbers as defined
     in IEEE 754-1985.
 
     With default parameters, is equivalent to ``a.copy().fill(np.inf)``.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -137,7 +137,21 @@ def ones(shape, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with ones.
 
-    Please refer to the documentation for `zeros` for further details.
+    Parameters
+    ----------
+    shape : int or sequence of ints
+        Shape of the new array, e.g., ``(2, 3)`` or ``2``.
+    dtype : data-type, optional
+        The desired data-type for the array, e.g., `numpy.int8`.  Default is
+        `numpy.float64`.
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
+
+    Returns
+    -------
+    out : ndarray
+        Array of ones with the given shape, dtype, and order.
 
     See Also
     --------
@@ -227,12 +241,23 @@ def filled(shape, val, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with `val`.
 
-    Please refer to the documentation for `zeros` for further details.
-
-    Other parameters
-    ----------------
+    Parameters
+    ----------
+    shape : int or sequence of ints
+        Shape of the new array, e.g., ``(2, 3)`` or ``2``.
     val : scalar
         Fill value.
+    dtype : data-type, optional
+        The desired data-type for the array, e.g., `numpy.int8`.  Default is
+        `numpy.float64`.
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
+
+    Returns
+    -------
+    out : ndarray
+        Array of `val` with the given shape, dtype, and order.
 
     See Also
     --------
@@ -267,11 +292,15 @@ def filled_like(a, val, dtype=None, order='K', subok=True):
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
         as possible.
+    subok : bool, optional.
+        If True, then the newly created array will use the sub-class
+        type of 'a', otherwise it will be a base-class array. Defaults
+        to True.
 
     Returns
     -------
     out : ndarray
-        Array of nans with the same shape and type as `a`.
+        Array of `val` with the same shape and type as `a`.
 
     See Also
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -249,7 +249,7 @@ def filled(shape, fill_value, dtype=None, order='C'):
         Fill value.
     dtype : data-type, optional
         The desired data-type for the array, e.g., `numpy.int8`.  Default is
-        `numpy.float64`.
+        is chosen as `np.array(fill_value).dtype`.
     order : {'C', 'F'}, optional
         Whether to store multidimensional data in C- or Fortran-contiguous
         (row- or column-wise) order in memory.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -269,6 +269,15 @@ def filled(shape, val, dtype=None, order='C'):
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
 
+    Examples
+    --------
+    >>> np.filled((2, 2), np.inf)
+    array([[ inf,  inf],
+           [ inf,  inf]])
+    >>> np.filled((2, 2), 10, dtype=np.int)
+    array([[10, 10],
+           [10, 10]])
+
     """
     a = empty(shape, dtype, order)
     multiarray.copyto(a, val, casting='unsafe')
@@ -311,6 +320,22 @@ def filled_like(a, val, dtype=None, order='K', subok=True):
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
     filled : Fill a new array.
+
+    Examples
+    --------
+    >>> x = np.arange(6, dtype=np.int)
+    >>> np.filled_like(x, 1)
+    array([1, 1, 1, 1, 1, 1])
+    >>> np.filled_like(x, 0.1)
+    array([0, 0, 0, 0, 0, 0])
+    >>> np.filled_like(x, 0.1, dtype=np.double)
+    array([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
+    >>> np.filled_like(x, np.nan, dtype=np.double)
+    array([ nan,  nan,  nan,  nan,  nan,  nan])
+
+    >>> y = np.arange(6, dtype=np.double)
+    >>> np.filled_like(y, 0.1)
+    array([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
 
     """
     res = empty_like(a, dtype=dtype, order=order, subok=subok)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -40,9 +40,7 @@ __all__ = ['newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
            'Inf', 'inf', 'infty', 'Infinity',
            'nan', 'NaN', 'False_', 'True_', 'bitwise_not',
            'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE', 'ALLOW_THREADS',
-           'ComplexWarning', 'may_share_memory',
-           'nans', 'nans_like', 'infs', 'infs_like']
-
+           'ComplexWarning', 'may_share_memory', 'filled', 'filled_like']
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])
@@ -231,40 +229,37 @@ def _check_dtype_nan(dtype):
                          'can represent non-numbers as defined in '
                          'IEEE 754-1985.')
 
-def nans(shape, dtype=None, order='C'):
+def filled(shape, val, dtype=None, order='C'):
     """
-    Return a new array of given shape and type, filled with nans.
-
-    Note that only floating point numbers can represent non-numbers as defined
-    in IEEE 754-1985.
+    Return a new array of given shape and type, filled with `val`.
 
     Please refer to the documentation for `zeros` for further details.
+
+    Other parameters
+    ----------------
+    val : scalar
+        Fill value.
 
     See Also
     --------
     zeros_like : Return an array of zeros with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    nans_like : Return an array of nans with shape and type of input.
-    infs_like : Return an array of infs with shape and type of input.
+    filled_like : Fill an array with shape and type of input.
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
-    infs : Return a new array setting values to inf.
 
     """
 
     _check_dtype_nan(dtype)
     a = empty(shape, dtype, order)
-    multiarray.copyto(a, nan, casting='unsafe')
+    multiarray.copyto(a, val, casting='unsafe')
     return a
 
-def nans_like(a, dtype=None, order='K', subok=True):
+def filled_like(a, val, dtype=None, order='K', subok=True):
     """
     Return an array of nans with the same shape and type as a given array.
-
-    Note that only floating point numbers can represent non-numbers as defined
-    in IEEE 754-1985.
 
     With default parameters, is equivalent to ``a.copy().fill(np.nan)``.
 
@@ -273,6 +268,8 @@ def nans_like(a, dtype=None, order='K', subok=True):
     a : array_like
         The shape and data-type of `a` define these same attributes of
         the returned array.
+    val : scalar
+        Fill value.
     dtype : data-type, optional
         Overrides the data type of the result.
     order : {'C', 'F', 'A', or 'K'}, optional
@@ -291,91 +288,16 @@ def nans_like(a, dtype=None, order='K', subok=True):
     zeros_like : Return an array of zeros with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    infs_like : Return an array of infs with shape and type of input.
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
-    nans : Return a new array setting values to nan.
-    infs : Return a new array setting values to inf.
+    filled : Fill a new array.
 
     """
 
     _check_dtype_nan(dtype)
     res = empty_like(a, dtype=dtype, order=order, subok=subok)
-    multiarray.copyto(res, nan, casting='unsafe')
-    return res
-
-def infs(shape, dtype=None, order='C'):
-    """
-    Return a new array of given shape and type, filled with infs.
-
-    Note that only floating point numbers can represent non-numbers as defined
-    in IEEE 754-1985.
-
-    Please refer to the documentation for `zeros` for further details.
-
-    See Also
-    --------
-    zeros_like : Return an array of zeros with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
-    empty_like : Return an empty array with shape and type of input.
-    nans_like : Return an array of nans with shape and type of input.
-    infs_like : Return an array of infs with shape and type of input.
-    zeros : Return a new array setting values to zero.
-    ones : Return a new array setting values to one.
-    empty : Return a new uninitialized array.
-    nans : Return a new array setting values to nan.
-
-    """
-
-    _check_dtype_nan(dtype)
-    a = empty(shape, dtype, order)
-    multiarray.copyto(a, inf, casting='unsafe')
-    return a
-
-def infs_like(a, dtype=None, order='K', subok=True):
-    """
-    Return an array of infs with the same shape and type as a given array.
-
-    Note that only floating point numbers can represent non-numbers as defined
-    in IEEE 754-1985.
-
-    With default parameters, is equivalent to ``a.copy().fill(np.inf)``.
-
-    Parameters
-    ----------
-    a : array_like
-        The shape and data-type of `a` define these same attributes of
-        the returned array.
-    dtype : data-type, optional
-        Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
-        Overrides the memory layout of the result. 'C' means C-order,
-        'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
-        'C' otherwise. 'K' means match the layout of `a` as closely
-        as possible.
-
-    Returns
-    -------
-    out : ndarray
-        Array of infs with the same shape and type as `a`.
-
-    See Also
-    --------
-    zeros_like : Return an array of zeros with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
-    empty_like : Return an empty array with shape and type of input.
-    zeros : Return a new array setting values to zero.
-    ones : Return a new array setting values to one.
-    empty : Return a new uninitialized array.
-    nans : Return a new array setting values to nan.
-    infs : Return a new array setting values to infs.
-
-    """
-
-    _check_dtype_nan(dtype)
-    res = empty_like(a, dtype=dtype, order=order, subok=subok)
-    multiarray.copyto(res, inf, casting='unsafe')
+    multiarray.copyto(res, val, casting='unsafe')
     return res
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -243,9 +243,11 @@ def nans(shape, dtype=None, order='C'):
     ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
     nans_like : Return an array of nans with shape and type of input.
+    infs_like : Return an array of infs with shape and type of input.
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
+    infs : Return a new array setting values to inf.
 
     """
 
@@ -283,10 +285,12 @@ def nans_like(a, dtype=None, order='K', subok=True):
     zeros_like : Return an array of zeros with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
+    infs_like : Return an array of infs with shape and type of input.
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
     nans : Return a new array setting values to nan.
+    infs : Return a new array setting values to inf.
 
     """
 
@@ -311,6 +315,7 @@ def infs(shape, dtype=None, order='C'):
     zeros : Return a new array setting values to zero.
     ones : Return a new array setting values to one.
     empty : Return a new uninitialized array.
+    nans : Return a new array setting values to nan.
 
     """
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -235,6 +235,9 @@ def nans(shape, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with nans.
 
+    Note that only floating point numbers can represent non-numers as defined
+    in IEEE 754-1985.
+
     Please refer to the documentation for `zeros` for further details.
 
     See Also
@@ -259,6 +262,9 @@ def nans(shape, dtype=None, order='C'):
 def nans_like(a, dtype=None, order='K', subok=True):
     """
     Return an array of nans with the same shape and type as a given array.
+
+    Note that only floating point numbers can represent non-numers as defined
+    in IEEE 754-1985.
 
     With default parameters, is equivalent to ``a.copy().fill(np.nan)``.
 
@@ -303,6 +309,9 @@ def infs(shape, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with infs.
 
+    Note that only floating point numbers can represent non-numers as defined
+    in IEEE 754-1985.
+
     Please refer to the documentation for `zeros` for further details.
 
     See Also
@@ -327,6 +336,9 @@ def infs(shape, dtype=None, order='C'):
 def infs_like(a, dtype=None, order='K', subok=True):
     """
     Return an array of infs with the same shape and type as a given array.
+
+    Note that only floating point numbers can represent non-numers as defined
+    in IEEE 754-1985.
 
     With default parameters, is equivalent to ``a.copy().fill(np.inf)``.
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1356,6 +1356,18 @@ class TestLikeFuncs(TestCase):
                 (arange(24).reshape(4,3,2).swapaxes(0,1), '?'),
                      ]
 
+    def compare_array_value(self, dz, value, fill_value):
+        if not value is None:
+            if fill_value:
+                try:
+                    z = dz.dtype.type(value)
+                except OverflowError:
+                    pass
+                else:
+                    assert_(all(dz == z))
+            else:
+                assert_(all(dz == value))
+
     def check_like_function(self, like_function, value, fill_value=False):
         if fill_value:
             fill_kwarg = {'val': value}
@@ -1373,16 +1385,7 @@ class TestLikeFuncs(TestCase):
                 assert_equal(dz.dtype, d.dtype)
             else:
                 assert_equal(dz.dtype, np.dtype(dtype))
-            if not value is None:
-                if fill_value:
-                    try:
-                        z = dz.dtype.type(value)
-                    except OverflowError:
-                        pass
-                    else:
-                        assert_(all(dz == z))
-                else:
-                    assert_(all(dz == value))
+            self.compare_array_value(dz, value, fill_value)
 
             # C order, default dtype
             dz = like_function(d, order='C', dtype=dtype, **fill_kwarg)
@@ -1392,16 +1395,7 @@ class TestLikeFuncs(TestCase):
                 assert_equal(dz.dtype, d.dtype)
             else:
                 assert_equal(dz.dtype, np.dtype(dtype))
-            if not value is None:
-                if fill_value:
-                    try:
-                        z = dz.dtype.type(value)
-                    except OverflowError:
-                        pass
-                    else:
-                        assert_(all(dz == z))
-                else:
-                    assert_(all(dz == value))
+            self.compare_array_value(dz, value, fill_value)
 
             # F order, default dtype
             dz = like_function(d, order='F', dtype=dtype, **fill_kwarg)
@@ -1411,16 +1405,7 @@ class TestLikeFuncs(TestCase):
                 assert_equal(dz.dtype, d.dtype)
             else:
                 assert_equal(dz.dtype, np.dtype(dtype))
-            if not value is None:
-                if fill_value:
-                    try:
-                        z = dz.dtype.type(value)
-                    except OverflowError:
-                        pass
-                    else:
-                        assert_(all(dz == z))
-                else:
-                    assert_(all(dz == value))
+            self.compare_array_value(dz, value, fill_value)
 
             # A order
             dz = like_function(d, order='A', dtype=dtype, **fill_kwarg)
@@ -1433,16 +1418,7 @@ class TestLikeFuncs(TestCase):
                 assert_equal(dz.dtype, d.dtype)
             else:
                 assert_equal(dz.dtype, np.dtype(dtype))
-            if not value is None:
-                if fill_value:
-                    try:
-                        z = dz.dtype.type(value)
-                    except OverflowError:
-                        pass
-                    else:
-                        assert_(all(dz == z))
-                else:
-                    assert_(all(dz == value))
+            self.compare_array_value(dz, value, fill_value)
 
         # Test the 'subok' parameter
         a = np.matrix([[1,2],[3,4]])

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1353,7 +1353,7 @@ class TestCreationFuncs(TestCase):
                                 continue
                             else:
                                 # do not fill void type
-                                if fill_value is not None and type == 'V':
+                                if fill_value is not None and type in 'VSUa':
                                     continue
 
                                 arr = func(shape, order=order, dtype=dtype,

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1357,7 +1357,7 @@ class TestLikeFuncs(TestCase):
                      ]
 
     def compare_array_value(self, dz, value, fill_value):
-        if not value is None:
+        if value is not None:
             if fill_value:
                 try:
                     z = dz.dtype.type(value)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1329,7 +1329,7 @@ class TestStdVarComplex(TestCase):
 
 
 class TestLikeFuncs(TestCase):
-    '''Test ones_like, zeros_like, and empty_like'''
+    '''Test ones_like, zeros_like, empty_like and filled_like'''
 
     def setUp(self):
         self.data = [

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1330,6 +1330,8 @@ class TestStdVarComplex(TestCase):
 
 class TestCreationFuncs(TestCase):
 
+    '''Test ones, zeros, empty and filled'''
+
     def setUp(self):
         self.dtypes = ('b', 'i', 'u', 'f', 'c', 'S', 'a', 'U', 'V')
         self.orders = {'C': 'c_contiguous', 'F': 'f_contiguous'}

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1340,7 +1340,7 @@ class TestCreationFuncs(TestCase):
     def check_function(self, func, fill_value=None):
         fill_kwarg = {}
         if fill_value is not None:
-            fill_kwarg = {'val': fill_value}
+            fill_kwarg = {'fill_value': fill_value}
         for size in (0, 1, 2): # size in one dimension
             for ndims in range(self.ndims): # [], [size], [size, size] etc.
                 shape = ndims * [size]
@@ -1425,7 +1425,7 @@ class TestLikeFuncs(TestCase):
 
     def check_like_function(self, like_function, value, fill_value=False):
         if fill_value:
-            fill_kwarg = {'val': value}
+            fill_kwarg = {'fill_value': value}
         else:
             fill_kwarg = {}
         for d, dtype in self.data:

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1379,12 +1379,12 @@ class TestCreationFuncs(TestCase):
         self.check_function(np.empty)
 
     def test_filled(self):
-        self.check_function(np.filled, 0)
-        self.check_function(np.filled, 1)
+        self.check_function(np.full, 0)
+        self.check_function(np.full, 1)
 
 
 class TestLikeFuncs(TestCase):
-    '''Test ones_like, zeros_like, empty_like and filled_like'''
+    '''Test ones_like, zeros_like, empty_like and full_like'''
 
     def setUp(self):
         self.data = [
@@ -1494,11 +1494,11 @@ class TestLikeFuncs(TestCase):
         self.check_like_function(np.empty_like, None)
 
     def test_filled_like(self):
-        self.check_like_function(np.filled_like, 0, True)
-        self.check_like_function(np.filled_like, 1, True)
-        self.check_like_function(np.filled_like, 1000, True)
-        self.check_like_function(np.filled_like, 123.456, True)
-        self.check_like_function(np.filled_like, np.inf, True)
+        self.check_like_function(np.full_like, 0, True)
+        self.check_like_function(np.full_like, 1, True)
+        self.check_like_function(np.full_like, 1000, True)
+        self.check_like_function(np.full_like, 123.456, True)
+        self.check_like_function(np.full_like, np.inf, True)
 
 class _TestCorrelate(TestCase):
     def _setup(self, dt):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1348,12 +1348,12 @@ class TestCreationFuncs(TestCase):
                     for type in self.dtypes: # bool, int, float etc.
                         for bytes in 2**np.arange(9): # byte size for type
                             try:
-                                dtype = np.dtype('%s%d' % (type, bytes))
+                                dtype = np.dtype('{0}{1}'.format(type, bytes))
                             except TypeError: # dtype combination does not exist
                                 continue
                             else:
                                 # do not fill void type
-                                if fill_value is not None and type in 'VSUa':
+                                if fill_value is not None and type in 'V':
                                     continue
 
                                 arr = func(shape, order=order, dtype=dtype,
@@ -1363,7 +1363,11 @@ class TestCreationFuncs(TestCase):
                                 assert getattr(arr.flags, self.orders[order])
 
                                 if fill_value is not None:
-                                    assert_equal(arr, dtype.type(fill_value))
+                                    if dtype.str.startswith('|S'):
+                                        val = str(fill_value)
+                                    else:
+                                        val = fill_value
+                                    assert_equal(arr, dtype.type(val))
 
     def test_zeros(self):
         self.check_function(np.zeros)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1328,6 +1328,51 @@ class TestStdVarComplex(TestCase):
         assert_almost_equal(std(A)**2,real_var)
 
 
+class TestCreationFuncs(TestCase):
+
+    def setUp(self):
+        self.dtypes = ('b', 'i', 'u', 'f', 'c', 'S', 'a', 'U', 'V')
+        self.orders = {'C': 'c_contiguous', 'F': 'f_contiguous'}
+        self.ndims = 10
+
+    def check_function(self, func, fill_value=None):
+        fill_kwarg = {}
+        if fill_value is not None:
+            fill_kwarg = {'val': fill_value}
+        for size in (0, 1, 2):
+            for ndims in range(self.ndims):
+                shape = ndims * [size]
+                for order in self.orders:
+                    for type in self.dtypes:
+                        for bytes in 2**np.arange(9):
+                            try:
+                                dtype = np.dtype('%s%d' % (type, bytes))
+                            except TypeError:
+                                continue
+                            else:
+                                if fill_value is not None and type == 'V':
+                                    continue
+                                arr = func(shape, order=order, dtype=dtype,
+                                           **fill_kwarg)
+                                assert arr.dtype == dtype
+                                assert getattr(arr.flags, self.orders[order])
+                                if fill_value is not None:
+                                    assert_equal(arr, dtype.type(fill_value))
+
+    def test_zeros(self):
+        self.check_function(np.zeros)
+
+    def test_ones(self):
+        self.check_function(np.zeros)
+
+    def test_empty(self):
+        self.check_function(np.empty)
+
+    def test_filled(self):
+        self.check_function(np.filled, 0)
+        self.check_function(np.filled, 1)
+
+
 class TestLikeFuncs(TestCase):
     '''Test ones_like, zeros_like, empty_like and filled_like'''
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1339,23 +1339,27 @@ class TestCreationFuncs(TestCase):
         fill_kwarg = {}
         if fill_value is not None:
             fill_kwarg = {'val': fill_value}
-        for size in (0, 1, 2):
-            for ndims in range(self.ndims):
+        for size in (0, 1, 2): # size in one dimension
+            for ndims in range(self.ndims): # [], [size], [size, size] etc.
                 shape = ndims * [size]
-                for order in self.orders:
-                    for type in self.dtypes:
-                        for bytes in 2**np.arange(9):
+                for order in self.orders: # C, F
+                    for type in self.dtypes: # bool, int, float etc.
+                        for bytes in 2**np.arange(9): # byte size for type
                             try:
                                 dtype = np.dtype('%s%d' % (type, bytes))
-                            except TypeError:
+                            except TypeError: # dtype combination does not exist
                                 continue
                             else:
+                                # do not fill void type
                                 if fill_value is not None and type == 'V':
                                     continue
+
                                 arr = func(shape, order=order, dtype=dtype,
                                            **fill_kwarg)
+
                                 assert arr.dtype == dtype
                                 assert getattr(arr.flags, self.orders[order])
+
                                 if fill_value is not None:
                                     assert_equal(arr, dtype.type(fill_value))
 


### PR DESCRIPTION
I find myself often in the situation where I type the long version of this:

```
b = np.empty_like(a, dtype=np.double)
b[:] = np.inf
```

Please let me know if you find this useful as well and I will add test cases for those functions.
