### PR TITLE
BUG: Fix CheckStrides and strides setter checks for available memory

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1466,31 +1466,20 @@ PyArray_CheckStrides(int elsize, int nd, npy_intp numbytes, npy_intp offset,
     int i;
     npy_intp max_axis_offset;
     npy_intp begin, end;
-    npy_intp min_offset = 0;
-    npy_intp max_offset = 0;
+    npy_intp lower_offset;
+    npy_intp upper_offset;
 
     if (numbytes == 0) {
         numbytes = PyArray_MultiplyList(dims, nd) * elsize;
     }
 
     begin = -offset;
-    end = numbytes - offset - elsize;
-    for (i = 0; i < nd; i++) {
-        if (dims[i] == 0) {
-            /* Empty array. Validate offset in any case */
-            max_offset = 0;
-            min_offset = 0;
-            break;
-        }
-        max_axis_offset = newstrides[i] * (dims[i] - 1);
-        if (max_axis_offset > 0) {
-            max_offset += max_axis_offset;
-        }
-        else {
-            min_offset += max_axis_offset;
-        }
-    }
-    if ((max_offset > end) || (min_offset < begin)) {
+    end = numbytes - offset;
+
+    offset_bounds_from_strides(elsize, nd, dims, newstrides,
+                                        &lower_offset, &upper_offset);
+    
+    if ((upper_offset > end) || (lower_offset < begin)) {
         return NPY_FALSE;
     }
     return NPY_TRUE;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -677,9 +677,9 @@ _IsWriteable(PyArrayObject *ap)
 
 
 NPY_NO_EXPORT void
-offset_bounds_from_strides(int itemsize, int nd, npy_intp *dims,
-                           npy_intp *strides, npy_intp *lower_offset,
-                           npy_intp *upper_offset) {
+offset_bounds_from_strides(const int itemsize, const int nd,
+                           const npy_intp *dims, const npy_intp *strides,
+                           npy_intp *lower_offset, npy_intp *upper_offset) {
     npy_intp max_axis_offset;
     npy_intp lower = 0;
     npy_intp upper = 0;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -674,3 +674,33 @@ _IsWriteable(PyArrayObject *ap)
     }
     return NPY_TRUE;
 }
+
+
+NPY_NO_EXPORT void
+offset_bounds_from_strides(int itemsize, int nd, npy_intp *dims,
+                           npy_intp *strides, npy_intp *lower_offset,
+                           npy_intp *upper_offset) {
+    npy_intp max_axis_offset;
+    npy_intp lower = 0;
+    npy_intp upper = 0;
+    int i;
+
+    for (i = 0; i < nd; i++) {
+        if (dims[i] == 0) {
+            /* Empty array special case */
+            *lower_offset = 0;
+            *upper_offset = 0;
+            return;
+        }
+        max_axis_offset = strides[i] * (dims[i] - 1);
+        if (max_axis_offset > 0) {
+            upper += max_axis_offset;
+        }
+        else {
+            lower += max_axis_offset;
+        }
+    }
+    upper += itemsize;
+    *lower_offset = lower;
+    *upper_offset = upper;
+}

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -58,9 +58,9 @@ NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 
 NPY_NO_EXPORT void
-offset_bounds_from_strides(int itemsize, int nd, npy_intp *dims,
-                           npy_intp *strides, npy_intp *min_offset,
-                           npy_intp *max_offset);
+offset_bounds_from_strides(const int itemsize, const int nd,
+                           const npy_intp *dims, const npy_intp *strides,
+                           npy_intp *lower_offset, npy_intp *upper_offset);
 
 #include "ucsnarrow.h"
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -57,6 +57,11 @@ _IsAligned(PyArrayObject *ap);
 NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 
+NPY_NO_EXPORT void
+offset_bounds_from_strides(int itemsize, int nd, npy_intp *dims,
+                           npy_intp *strides, npy_intp *min_offset,
+                           npy_intp *max_offset);
+
 #include "ucsnarrow.h"
 
 #endif

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -138,7 +138,6 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
     }
     else {
         PyErr_Clear();
-        /* Find the true extent of the base array, similar to CheckStrides */
         offset_bounds_from_strides(PyArray_ITEMSIZE(new), PyArray_NDIM(new),
                                    PyArray_DIMS(new), PyArray_STRIDES(new),
                                    &lower_offset, &upper_offset);

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -102,7 +102,11 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
     PyArrayObject *new;
     npy_intp numbytes = 0;
     npy_intp offset = 0;
+    npy_intp max_axis_offset;
+    npy_intp min_offset = 0;
+    npy_intp max_offset = 0;
     Py_ssize_t buf_len;
+    int i;
     char *buf;
 
     if (obj == NULL) {
@@ -136,12 +140,28 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
     }
     else {
         PyErr_Clear();
-        numbytes = PyArray_MultiplyList(PyArray_DIMS(new),
-                            PyArray_NDIM(new))*PyArray_DESCR(new)->elsize;
-        offset = PyArray_BYTES(self) - PyArray_BYTES(new);
+        /* Find the true extent of the base array, similar to CheckStrides */
+        for (i = 0; i < PyArray_NDIM(new); i++) {
+            if (PyArray_DIMS(new)[i] == 0) {
+                /* Since all arrays must be empty here, this works */
+                max_offset = 0;
+                min_offset = 0;
+                break;
+            }
+            max_axis_offset = PyArray_STRIDES(new)[i] * (PyArray_DIMS(new)[i] - 1);
+            if (max_axis_offset > 0) {
+                max_offset += max_axis_offset;
+            }
+            else {
+                min_offset += max_axis_offset;
+            }
+        }
+
+        offset = -min_offset + PyArray_BYTES(self) - PyArray_BYTES(new);
+        numbytes = max_offset - min_offset + PyArray_ITEMSIZE(new);
     }
 
-    if (!PyArray_CheckStrides(PyArray_DESCR(self)->elsize, PyArray_NDIM(self), numbytes,
+    if (!PyArray_CheckStrides(PyArray_ITEMSIZE(self), PyArray_NDIM(self), numbytes,
                               offset,
                               PyArray_DIMS(self), newstrides.ptr)) {
         PyErr_SetString(PyExc_ValueError, "strides is not "\

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -130,6 +130,14 @@ class TestAttributes(TestCase):
             arr.strides = strides
         self.assertRaises(ValueError, set_strides, x, (10*x.itemsize, x.itemsize))
 
+        # Test for offset calculations:
+        x = np.lib.stride_tricks.as_strided(np.arange(10, dtype=np.int8)[-1],
+                                                    shape=(10,), strides=(-1,))
+        self.assertRaises(ValueError, set_strides, x[::-1], -1)
+        a = x[::-1]
+        a.strides = 1
+        a[::2].strides = 2
+
     def test_fill(self):
         for t in "?bhilqpBHILQPfdgFDGO":
             x = empty((3,2,1), t)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -97,16 +97,17 @@ class TestAttributes(TestCase):
     def test_stridesattr(self):
         x = self.one
         def make_array(size, offset, strides):
-            return ndarray([size], buffer=x, dtype=int,
+            return ndarray(size, buffer=x, dtype=int,
                            offset=offset*x.itemsize,
                            strides=strides*x.itemsize)
         assert_equal(make_array(4, 4, -1), array([4, 3, 2, 1]))
         self.assertRaises(ValueError, make_array, 4, 4, -2)
         self.assertRaises(ValueError, make_array, 4, 2, -1)
         self.assertRaises(ValueError, make_array, 8, 3, 1)
-        #self.assertRaises(ValueError, make_array, 8, 3, 0)
-        #self.assertRaises(ValueError, lambda: ndarray([1], strides=4))
-
+        assert_equal(make_array(8, 3, 0), np.array([3]*8))
+        # Check behavior reported in gh-2503:
+        self.assertRaises(ValueError, make_array, (2, 3), 5, array([-2, -3]))
+        make_array(0, 0, 10)
 
     def test_set_stridesattr(self):
         x = self.one
@@ -122,7 +123,12 @@ class TestAttributes(TestCase):
         self.assertRaises(ValueError, make_array, 4, 4, -2)
         self.assertRaises(ValueError, make_array, 4, 2, -1)
         self.assertRaises(RuntimeError, make_array, 8, 3, 1)
-        #self.assertRaises(ValueError, make_array, 8, 3, 0)
+        # Check that the true extent of the array is used.
+        # Test relies on as_strided base not exposing a buffer.
+        x = np.lib.stride_tricks.as_strided(arange(1), (10,10), (0,0))
+        def set_strides(arr, strides):
+            arr.strides = strides
+        self.assertRaises(ValueError, set_strides, x, (10*x.itemsize, x.itemsize))
 
     def test_fill(self):
         for t in "?bhilqpBHILQPfdgFDGO":


### PR DESCRIPTION
This changes the logic of PyArray_CheckStrides to really check the
full extent the new array will have. It also changes the stride
setting to calculate the full real extent of the underlying array
without assuming (usually correctly) that the strides of the base
array are regular.

Add some tests for cases that previously failed.
This "closes Issue gh-2503"

---

I don't love duplicating that code, but I did not know a great alternative, this will break abuses that explicitly created invalid arrays obviously.
