### PR TITLE
Fixed choice docstring, wrong default size

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -918,7 +918,7 @@ cdef class RandomState:
 
     def choice(self, a, size=None, replace=True, p=None):
         """
-        choice(a, size=1, replace=True, p=None)
+        choice(a, size=None, replace=True, p=None)
 
         Generates a random sample from a given 1-D array
 


### PR DESCRIPTION
Commit acf7421128b9d974d5153759650b7aaee3c2efec introduced a change in the handling of the `size` argument but the docstring wasn't updated accordingly. This commit fixes the issue.
