### PR TITLE
BUG: Fix byteswapping for complex scalars

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -946,9 +946,9 @@ HALF_to_@TYPE@(npy_half *ip, @type@ *op, npy_intp n,
 }
 
 /**end repeat**/
-#if SIZEOF_SHORT == 2
+#if NPY_SIZEOF_SHORT == 2
 #define HALF_to_HALF SHORT_to_SHORT
-#elif SIZEOF_INT == 2
+#elif NPY_SIZEOF_INT == 2
 #define HALF_to_HALF INT_to_INT
 #endif
 
@@ -1612,27 +1612,27 @@ static void
         char *a, *b, c;
 
         a = (char *)dst;
-#if SIZEOF_@fsize@ == 2
+#if NPY_SIZEOF_@fsize@ == 2
         b = a + 1;
         c = *a; *a++ = *b; *b = c;
-#elif SIZEOF_@fsize@ == 4
+#elif NPY_SIZEOF_@fsize@ == 4
         b = a + 3;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 8
+#elif NPY_SIZEOF_@fsize@ == 8
         b = a + 7;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 10
+#elif NPY_SIZEOF_@fsize@ == 10
         b = a + 9;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 12
+#elif NPY_SIZEOF_@fsize@ == 12
         b = a + 11;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
@@ -1640,7 +1640,7 @@ static void
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 16
+#elif NPY_SIZEOF_@fsize@ == 16
         b = a + 15;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
@@ -1744,7 +1744,7 @@ static void
     if (swap) {
         char *a, *b, c;
         a = (char *)dst;
-#if SIZEOF_@fsize@ == 4
+#if NPY_SIZEOF_@fsize@ == 4
         b = a + 3;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
@@ -1752,7 +1752,7 @@ static void
         b = a + 3;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 8
+#elif NPY_SIZEOF_@fsize@ == 8
         b = a + 7;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
@@ -1764,7 +1764,7 @@ static void
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 10
+#elif NPY_SIZEOF_@fsize@ == 10
         b = a + 9;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
@@ -1778,7 +1778,7 @@ static void
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 12
+#elif NPY_SIZEOF_@fsize@ == 12
         b = a + 11;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
@@ -1794,7 +1794,7 @@ static void
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b   = c;
-#elif SIZEOF_@fsize@ == 16
+#elif NPY_SIZEOF_@fsize@ == 16
         b = a + 15;
         c = *a; *a++ = *b; *b-- = c;
         c = *a; *a++ = *b; *b-- = c;
@@ -1825,9 +1825,8 @@ static void
                 *a++ = *b;
                 *b-- = c;
             }
-            a += nn / 2;
+            a += nn;
             b = a + (NPY_SIZEOF_@fsize@ - 1);
-            nn = NPY_SIZEOF_@fsize@ / 2;
             for (i = 0; i < nn; i++) {
                 c = *a;
                 *a++ = *b;

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1296,16 +1296,20 @@ class TestRegression(TestCase):
         np.dot(a['f0'], b['f0'])
 
     def test_byteswap_complex_scalar(self):
-        """Ticket #1259"""
-        z = np.array([-1j], '<c8')
-        x = z[0] # always native-endian
-        y = x.byteswap()
-        if x.dtype.byteorder == z.dtype.byteorder:
-            # little-endian machine
-            assert_equal(x, np.fromstring(y.tostring(), dtype='>c8'))
-        else:
-            # big-endian machine
-            assert_equal(x, np.fromstring(y.tostring(), dtype='<c8'))
+        """Ticket #1259 and gh-441"""
+        for dtype in [np.dtype('<'+t) for t in np.typecodes['Complex']]:
+            z = np.array([2.2-1.1j], dtype)
+            x = z[0] # always native-endian
+            y = x.byteswap()
+            if x.dtype.byteorder == z.dtype.byteorder:
+                # little-endian machine
+                assert_equal(x, np.fromstring(y.tostring(), dtype=dtype.newbyteorder()))
+            else:
+                # big-endian machine
+                assert_equal(x, np.fromstring(y.tostring(), dtype=dtype))
+            # double check real and imaginary parts:
+            assert_equal(x.real, y.real.byteswap())
+            assert_equal(x.imag, y.imag.byteswap())
 
     def test_structured_arrays_with_objects1(self):
         """Ticket #1299"""


### PR DESCRIPTION
During a cleanup, the fast paths were invalidated because SIZEOF_LONGDOUBLE
was not defined anymore and needs to be replaced with NPY_SIZEOF_LONGDOUBLE.
The other SIZEOF macros still existed however so only complex long double
broke because it switched to the already broken fast path.

This commit fixes the fast path, and replaces all SIZEOF_ macros within
arraytypes.c.src with their corresponding NPY_SIZEOF_ macros.

---

This probably fixes issue gh-411 though that still needs checking. Note that there are still many occurrences where these macros need to be replaced. Also I noticed that the `noprefix.h` does not include `SIZEOF_COMPLEX_*`.
