### PR TITLE
BUG: Replace unprefixed SIZEOF_* macros with prefixed versions.

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4088,8 +4088,6 @@ set_typeinfo(PyObject *dict)
     infodict = PyDict_New();
     if (infodict == NULL) return -1;
 
-#define BITSOF_INTP CHAR_BIT*SIZEOF_PY_INTPTR_T
-#define BITSOF_BYTE CHAR_BIT
 
     /**begin repeat
      *
@@ -4219,7 +4217,7 @@ set_typeinfo(PyObject *dict)
             s = Py_BuildValue("ciiiNNO", NPY_DATETIMELTR,
 #endif
                 NPY_DATETIME,
-                sizeof(npy_datetime) * CHAR_BIT,
+                NPY_BITSOF_DATETIME,
                 _ALIGN(npy_datetime),
                 MyPyLong_FromInt64(NPY_MAX_DATETIME),
                 MyPyLong_FromInt64(NPY_MIN_DATETIME),
@@ -4232,7 +4230,7 @@ set_typeinfo(PyObject *dict)
             s = Py_BuildValue("ciiiNNO",NPY_TIMEDELTALTR,
 #endif
                 NPY_TIMEDELTA,
-                sizeof(npy_timedelta) * CHAR_BIT,
+                NPY_BITSOF_TIMEDELTA,
                 _ALIGN(npy_timedelta),
                 MyPyLong_FromInt64(NPY_MAX_TIMEDELTA),
                 MyPyLong_FromInt64(NPY_MIN_TIMEDELTA),

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -742,7 +742,7 @@ PyArray_PyIntAsInt(PyObject *o)
             return -1;
         }
 
-#if (SIZEOF_LONG > SIZEOF_INT)
+#if (NPY_SIZEOF_LONG > NPY_SIZEOF_INT)
     if ((long_value < INT_MIN) || (long_value > INT_MAX)) {
         PyErr_SetString(PyExc_ValueError, "integer won't fit into a C int");
         return -1;
@@ -774,9 +774,9 @@ PyArray_PyIntAsIntp(PyObject *o)
         goto finish;
     }
 
-#if NPY_SIZEOF_INTP == SIZEOF_LONG
+#if NPY_SIZEOF_INTP == NPY_SIZEOF_LONG
     descr = &LONG_Descr;
-#elif NPY_SIZEOF_INTP == SIZEOF_INT
+#elif NPY_SIZEOF_INTP == NPY_SIZEOF_INT
     descr = &INT_Descr;
 #else
     descr = &LONGLONG_Descr;
@@ -869,7 +869,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
      */
     if ((nd=PySequence_Length(seq)) == -1) {
         if (PyErr_Occurred()) PyErr_Clear();
-#if SIZEOF_LONG >= NPY_SIZEOF_INTP && !defined(NPY_PY3K)
+#if NPY_SIZEOF_LONG >= NPY_SIZEOF_INTP && !defined(NPY_PY3K)
         if (!(op = PyNumber_Int(seq))) {
             return -1;
         }
@@ -879,7 +879,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
         }
 #endif
         nd = 1;
-#if SIZEOF_LONG >= NPY_SIZEOF_INTP
+#if NPY_SIZEOF_LONG >= NPY_SIZEOF_INTP
         vals[0] = (npy_intp ) PyInt_AsLong(op);
 #else
         vals[0] = (npy_intp ) PyLong_AsLongLong(op);
@@ -908,7 +908,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
             if (op == NULL) {
                 return -1;
             }
-#if SIZEOF_LONG >= NPY_SIZEOF_INTP
+#if NPY_SIZEOF_LONG >= NPY_SIZEOF_INTP
             vals[i]=(npy_intp )PyInt_AsLong(op);
 #else
             vals[i]=(npy_intp )PyLong_AsLongLong(op);
@@ -1153,7 +1153,7 @@ PyArray_IntTupleFromIntp(int len, npy_intp *vals)
         goto fail;
     }
     for (i = 0; i < len; i++) {
-#if NPY_SIZEOF_INTP <= SIZEOF_LONG
+#if NPY_SIZEOF_INTP <= NPY_SIZEOF_LONG
         PyObject *o = PyInt_FromLong((long) vals[i]);
 #else
         PyObject *o = PyLong_FromLongLong((npy_longlong) vals[i]);

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -384,7 +384,7 @@ static PyObject *
 array_size_get(PyArrayObject *self)
 {
     npy_intp size=PyArray_SIZE(self);
-#if NPY_SIZEOF_INTP <= SIZEOF_LONG
+#if NPY_SIZEOF_INTP <= NPY_SIZEOF_LONG
     return PyInt_FromLong((long) size);
 #else
     if (size > NPY_MAX_LONG || size < NPY_MIN_LONG) {
@@ -400,7 +400,7 @@ static PyObject *
 array_nbytes_get(PyArrayObject *self)
 {
     npy_intp nbytes = PyArray_NBYTES(self);
-#if NPY_SIZEOF_INTP <= SIZEOF_LONG
+#if NPY_SIZEOF_INTP <= NPY_SIZEOF_LONG
     return PyInt_FromLong((long) nbytes);
 #else
     if (nbytes > NPY_MAX_LONG || nbytes < NPY_MIN_LONG) {

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1716,7 +1716,7 @@ arraymultiter_dealloc(PyArrayMultiIterObject *multi)
 static PyObject *
 arraymultiter_size_get(PyArrayMultiIterObject *self)
 {
-#if NPY_SIZEOF_INTP <= SIZEOF_LONG
+#if NPY_SIZEOF_INTP <= NPY_SIZEOF_LONG
     return PyInt_FromLong((long) self->size);
 #else
     if (self->size < NPY_MAX_LONG) {
@@ -1731,7 +1731,7 @@ arraymultiter_size_get(PyArrayMultiIterObject *self)
 static PyObject *
 arraymultiter_index_get(PyArrayMultiIterObject *self)
 {
-#if NPY_SIZEOF_INTP <= SIZEOF_LONG
+#if NPY_SIZEOF_INTP <= NPY_SIZEOF_LONG
     return PyInt_FromLong((long) self->index);
 #else
     if (self->size < NPY_MAX_LONG) {

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -23,10 +23,11 @@ NPY_NO_EXPORT int
 array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v);
 
 #if PY_VERSION_HEX < 0x02050000
-        #if SIZEOF_INT == NPY_SIZEOF_INTP
+        #if NPY_SIZEOF_INT == NPY_SIZEOF_INTP
                 #define array_ass_item array_ass_big_item
         #endif
 #else
+        /* SIZEOF_SIZE_T is nowhere defined, Py_ssize_t perhaps?*/
         #if SIZEOF_SIZE_T == NPY_SIZEOF_INTP
                 #define array_ass_item array_ass_big_item
         #endif

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3778,7 +3778,7 @@ setup_scalartypes(PyObject *NPY_UNUSED(dict))
     SINGLE_INHERIT(Bool, Generic);
     SINGLE_INHERIT(Byte, SignedInteger);
     SINGLE_INHERIT(Short, SignedInteger);
-#if SIZEOF_INT == SIZEOF_LONG && !defined(NPY_PY3K)
+#if NPY_SIZEOF_INT == NPY_SIZEOF_LONG && !defined(NPY_PY3K)
     DUAL_INHERIT(Int, Int, SignedInteger);
 #else
     SINGLE_INHERIT(Int, SignedInteger);
@@ -3788,7 +3788,7 @@ setup_scalartypes(PyObject *NPY_UNUSED(dict))
 #else
     SINGLE_INHERIT(Long, SignedInteger);
 #endif
-#if NPY_SIZEOF_LONGLONG == SIZEOF_LONG && !defined(NPY_PY3K)
+#if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG && !defined(NPY_PY3K)
     DUAL_INHERIT(LongLong, Int, SignedInteger);
 #else
     SINGLE_INHERIT(LongLong, SignedInteger);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2939,7 +2939,7 @@ int_arrtype_hash(PyObject *obj)
  * #ext = && (x >= LONG_MIN),#
  */
 #if NPY_SIZEOF_LONG != NPY_SIZEOF_LONGLONG
-/* we assume SIZEOF_LONGLONG=2*SIZEOF_LONG */
+/* we assume NPY_SIZEOF_LONGLONG=2*NPY_SIZEOF_LONG */
 static long
 @char@longlong_arrtype_hash(PyObject *obj)
 {

--- a/numpy/core/src/npymath/_signbit.c
+++ b/numpy/core/src/npymath/_signbit.c
@@ -12,7 +12,7 @@ _npy_signbit_d(double x)
 
     u.d = x;
 
-#if SIZEOF_INT == 4
+#if NPY_SIZEOF_INT == 4
 
 #ifdef WORDS_BIGENDIAN /* defined in pyconfig.h */
     return u.i[0] < 0;
@@ -20,7 +20,7 @@ _npy_signbit_d(double x)
     return u.i[1] < 0;
 #endif
 
-#else  /* SIZEOF_INT != 4 */
+#else  /* NPY_SIZEOF_INT != 4 */
 
 #ifdef WORDS_BIGENDIAN
     return u.s[0] < 0;
@@ -28,5 +28,5 @@ _npy_signbit_d(double x)
     return u.s[3] < 0;
 #endif
 
-#endif  /* SIZEOF_INT */
+#endif  /* NPY_SIZEOF_INT */
 }

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -24,7 +24,7 @@
  * types of the same rank to have the same width.
  */
 
-#if SIZEOF_LONGLONG == 64
+#if NPY_SIZEOF_LONGLONG == 64
 
 static int
 ulonglong_overflow(npy_ulonglong a, npy_ulonglong b)
@@ -72,7 +72,7 @@ slonglong_overflow(npy_longlong a0, npy_longlong b0)
         (((x & mask) + (y & mask) + (w >> 32)) >> 31);
 }
 
-#elif SIZEOF_LONGLONG == 128
+#elif NPY_SIZEOF_LONGLONG == 128
 
 static int
 ulonglong_overflow(npy_ulonglong a, npy_ulonglong b)
@@ -203,8 +203,8 @@ static void
 }
 /**end repeat**/
 
-#ifndef SIZEOF_BYTE
-#define SIZEOF_BYTE 1
+#ifndef NPY_SIZEOF_BYTE
+#define NPY_SIZEOF_BYTE 1
 #endif
 
 /**begin repeat


### PR DESCRIPTION
The sources don't define NPY_NO_PREFIX and consequently none of the
unprefixed macros are defined. Using them can lead to some unexpected
results.

@certik, this complimemts the seberg fix and should be backported after it if you do the backport. Or you could put the two together into one PR.
