### PR TITLE
Fix for #2895 ndindex failing

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2075,11 +2075,6 @@ PyArray_FromInterface(PyObject *origin)
     /* Case for data access through pointer */
     if (attr && PyTuple_Check(attr)) {
         PyObject *dataptr;
-        if (n == 0) {
-            PyErr_SetString(PyExc_ValueError,
-                    "__array_interface__ shape must be at least size 1");
-            goto fail;
-        }
         if (PyTuple_GET_SIZE(attr) != 2) {
             PyErr_SetString(PyExc_TypeError,
                     "__array_interface__ data must be a 2-tuple with "

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2873,6 +2873,13 @@ def test_array_interface():
     f.iface['shape'] = (2,)
     assert_raises(ValueError, np.array, f)
 
+    # test scalar with no shape
+    class ArrayLike(object):
+        array = np.array(1)
+        __array_interface__ = array.__array_interface__
+    assert_equal(np.array(ArrayLike()), 1)
+
+
 def test_flat_element_deletion():
     it = np.ones(3).flat
     try:

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -542,7 +542,7 @@ class ndindex(object):
                 def __iter__(self):
                     return self
                 def ndincr(self):
-                    return self.next()
+                    self.next()
                 def next(self):
                     if self._N > 0:
                         self._N -= 1

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -539,7 +539,7 @@ class ndindex(object):
                 yield ()
             return zerodim_gen()
         else:
-            return object.__new__(cls, *shape)
+            return super(ndindex, cls).__new__(cls)
             
     def __init__(self, *shape):
         x = as_strided(_nx.zeros(1), shape=shape, strides=_nx.zeros_like(shape))

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -531,16 +531,23 @@ class ndindex(object):
     (2, 1, 0)
 
     """
+    # This is a hack to handle 0-d arrays correctly.
+    # Fixing nditer would be more work but should be done eventually.
+    def __new__(cls, *shape):
+        if len(shape) == 0:
+            def zerodim_gen():
+                yield ()
+            return zerodim_gen()
+        else:
+            return object.__new__(cls, *shape)
+            
     def __init__(self, *shape):
         x = as_strided(_nx.zeros(1), shape=shape, strides=_nx.zeros_like(shape))
         self._it = _nx.nditer(x, flags=['multi_index'], order='C')
-        # This is a patch to handle 0-d arrays correctly on the Python side.
-        # We might want to revisit nditer in the future to handle this         
-        self._zerod = (len(shape)==0)
 
     def __iter__(self):
         return self
-
+        
     def ndincr(self):
         """
         Increment the multi-dimensional index by one.
@@ -560,13 +567,6 @@ class ndindex(object):
 
         """
         self._it.next()
-        # This is a hack with an un-necessary check in every next call
-        # But, it's much simpler than writing another iterator for 0-d arrays
-        #  because the Python iterator protocol does not respect monkey-patching
-        #  the next method on an instance.
-        # Given that we should fix nditer eventually, we do this for now.
-        if self._zerod:
-            return ()
         return self._it.multi_index
 
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -502,7 +502,6 @@ class ndenumerate(object):
     def __iter__(self):
         return self
 
-
 class ndindex(object):
     """
     An N-dimensional iterator object to index arrays.
@@ -535,6 +534,9 @@ class ndindex(object):
     def __init__(self, *shape):
         x = as_strided(_nx.zeros(1), shape=shape, strides=_nx.zeros_like(shape))
         self._it = _nx.nditer(x, flags=['multi_index'], order='C')
+        # This is a patch to handle 0-d arrays correctly on the Python side.
+        # We might want to revisit nditer in the future to handle this         
+        self._zerod = (len(shape)==0)
 
     def __iter__(self):
         return self
@@ -558,6 +560,13 @@ class ndindex(object):
 
         """
         self._it.next()
+        # This is a hack with an un-necessary check in every next call
+        # But, it's much simpler than writing another iterator for 0-d arrays
+        #  because the Python iterator protocol does not respect monkey-patching
+        #  the next method on an instance.
+        # Given that we should fix nditer eventually, we do this for now.
+        if self._zerod:
+            return ()
         return self._it.multi_index
 
 

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -242,6 +242,10 @@ def test_ndindex():
     expected = [ix for ix, e in np.ndenumerate(np.zeros((1, 2, 3)))]
     assert_array_equal(x, expected)
 
+    # Make sure size argument is optional
+    x = list(np.ndindex())
+    assert_equal(x, [(0,)])
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -244,7 +244,7 @@ def test_ndindex():
 
     # Make sure size argument is optional
     x = list(np.ndindex())
-    assert_equal(x, [(0,)])
+    assert_equal(x, [()])
 
 
 if __name__ == "__main__":

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -242,9 +242,15 @@ def test_ndindex():
     expected = [ix for ix, e in np.ndenumerate(np.zeros((1, 2, 3)))]
     assert_array_equal(x, expected)
 
+    x = list(np.ndindex((1, 2, 3)))
+    assert_array_equal(x, expected)
+
     # Make sure size argument is optional
     x = list(np.ndindex())
     assert_equal(x, [()])
+
+    x = list(np.ndindex(()))
+    assert_equal(x, [()])    
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove unnecessary check for size argument which causes ndindex to fail.

This is a fix for issue #2895
