### PR TITLE
BUG: raise ValueError for nanarg(min|max) for all nan along axis

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1397,6 +1397,9 @@ def _nanop(op, fill, a, axis=None):
         if np.isscalar(res):
             res = np.nan
         else:
+            if not np.issubdtype(res.dtype, np.floating):
+                raise ValueError("all values along the specified axis are "
+                                 "NaN (not a number)")
             res[mask_all_along_axis] = np.nan
 
     return res

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1062,10 +1062,6 @@ class TestNaNFuncts(TestCase):
                                    [ 0.91084584, 0.84386844, 0.37068164]]))
         assert_(np.isnan(nanmax([np.nan, np.nan])))
 
-    def test_nanmin_allnan_on_axis(self):
-        assert_array_equal(np.isnan(nanmin([[np.nan] * 2] * 3, axis=1)),
-                     [True, True, True])
-
     def test_nanmin_masked(self):
         a = np.ma.fix_invalid([[2, 1, 3, np.nan], [5, 2, 3, np.nan]])
         ctrl_mask = a._mask.copy()
@@ -1073,6 +1069,22 @@ class TestNaNFuncts(TestCase):
         assert_equal(test, [1, 2])
         assert_equal(a._mask, ctrl_mask)
         assert_equal(np.isinf(a), np.zeros((2, 4), dtype=bool))
+
+    def test_all_nan_along_axis(self):
+        # test that nanargmax/nanargmin raise ValueErrors
+        # but others give a nan result.
+        a = self.A.copy()
+        a[0,0,:] = np.nan
+        where_nan = np.zeros(a.shape[:2], dtype=bool)
+        where_nan[0,0] = True
+        assert_raises(ValueError, nanargmin, a, axis=-1)
+        assert_raises(ValueError, nanargmax, a, axis=-1)
+        assert_array_equal(np.isnan(nanmin(a, axis=-1)), where_nan)
+        assert_array_equal(np.isnan(nanmax(a, axis=-1)), where_nan)
+        assert_array_equal(np.isnan(nansum(a, axis=-1)), where_nan)
+        # These could plausibly raise a ValueError as well:
+        assert_(np.isnan(nanargmin(a[0,0])))
+        assert_(np.isnan(nanargmax(a[0,0])))
 
 
 class TestNanFunctsIntTypes(TestCase):


### PR DESCRIPTION
The assignment of nan to the non-floating result of these function
always caused a ValueError. This adds a more specific error and removes
relying on the assignment failing.

See also gh-2870
