### PR TITLE
Nonarray assignment regression for boolean indexing and 1d unsafe casting

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1082,7 +1082,8 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
 
  skip:
     Py_INCREF(type);
-    arrval = (PyArrayObject *)PyArray_FromAny(val, type, 0, 0, 0, NULL);
+    arrval = (PyArrayObject *)PyArray_FromAny(val, type, 0, 0,
+                                              NPY_ARRAY_FORCECAST, NULL);
     if (arrval == NULL) {
         return -1;
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1306,9 +1306,17 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         PyArrayObject *op_arr;
         PyArray_Descr *dtype = NULL;
 
-        op_arr = (PyArrayObject *)PyArray_FromAny(op, dtype, 0, 0, 0, NULL);
-        if (op_arr == NULL) {
-            return -1;
+        if (!PyArray_Check(op)) {
+            dtype = PyArray_DTYPE(self);
+            Py_INCREF(dtype);
+            op_arr = (PyArrayObject *)PyArray_FromAny(op, dtype, 0, 0, 0, NULL);
+            if (op_arr == NULL) {
+                return -1;
+            }
+        }
+        else {
+            op_arr = op;
+            Py_INCREF(op_arr);
         }
 
         if (PyArray_NDIM(op_arr) < 2) {

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -309,10 +309,13 @@ class TestRegression(TestCase):
         # and equivalent unsafe casted array assignment
         a = np.arange(10)
         b = np.ones(10, dtype=bool)
+        r = np.arange(10)
         def assign(a, b, c):
             a[b] = c
         assert_raises(ValueError, assign, a, b, np.nan)
         a[b] = np.array(np.nan) # but not this.
+        assert_raises(ValueError, assign, a, r, np.nan)
+        a[r] = np.array(np.nan)
 
     def test_unpickle_dtype_with_object(self,level=rlevel):
         """Implemented in r2840"""

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -304,6 +304,16 @@ class TestRegression(TestCase):
         self.assertRaises(ValueError, bfa)
         self.assertRaises(ValueError, bfb)
 
+    def test_nonarray_assignment(self):
+        # See also Issue gh-2870, test for nonarray assignment
+        # and equivalent unsafe casted array assignment
+        a = np.arange(10)
+        b = np.ones(10, dtype=bool)
+        def assign(a, b, c):
+            a[b] = c
+        assert_raises(ValueError, assign, a, b, np.nan)
+        a[b] = np.array(np.nan) # but not this.
+
     def test_unpickle_dtype_with_object(self,level=rlevel):
         """Implemented in r2840"""
         dt = np.dtype([('x',int),('y',np.object_),('z','O')])


### PR DESCRIPTION
There are two commits here, the first one is a regression in 1.7. and probably should be backported, the second one gives a special case the same behaviour as (most?) other code branches for index assignments has:
1. Fix a regression that a = np.array([1,2]), b = np.array([True, True]) then a[b] = np.nan fails (but a[b] = np.array(np.nan) does not as it never did)
2. Make 1d special case with r = np.array([0,1]), a[r] = 12.5 use unsafe casting as the rest of the assignments normally use, but still keep make a[r] = np.nan fail as before.
