### PR TITLE
Make numpydoc Python 3 compatible

### DIFF
--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -9,6 +9,14 @@ import pydoc
 from StringIO import StringIO
 from warnings import warn
 
+try:
+    # This works for Python 3
+    from inspect import getfullargspec as inspect_getargspec
+except:
+    # This works for Python 2
+    from inspect import getargspec as inspect_getargspec
+
+
 class Reader(object):
     """A line-based string reader.
 
@@ -424,7 +432,8 @@ class FunctionDoc(NumpyDocString):
             func, func_name = self.get_func()
             try:
                 # try to read signature
-                argspec = inspect.getargspec(func)
+                # Note: inspect_getargspec is different for Python 2 and 3
+                argspec = inspect_getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/doc/sphinxext/setup.py
+++ b/doc/sphinxext/setup.py
@@ -1,5 +1,11 @@
 from distutils.core import setup
 
+# Use 2to3 if using Python 3
+try:
+   from distutils.command.build_py import build_py_2to3 as build_py
+except ImportError:
+   from distutils.command.build_py import build_py
+
 version = "0.4"
 
 setup(
@@ -20,4 +26,5 @@ setup(
     license="BSD",
     requires=["sphinx (>= 1.0.1)"],
     package_data={'numpydoc': ['tests/test_*.py']},
+    cmdclass={'build_py': build_py},
 )

--- a/doc/sphinxext/tests/test_docscrape.py
+++ b/doc/sphinxext/tests/test_docscrape.py
@@ -165,7 +165,7 @@ def test_examples():
 
 def test_index():
     assert_equal(doc['index']['default'], 'random')
-    print doc['index']
+    print(doc['index'])
     assert_equal(len(doc['index']), 2)
     assert_equal(len(doc['index']['refguide']), 2)
 
@@ -556,7 +556,13 @@ def test_unicode():
         äää
 
     """)
-    assert doc['Summary'][0] == u'öäöäöäöäöåååå'.encode('utf-8')
+    if sys.version_info[0] >= 3:
+        # This is for Python 3
+        assert doc['Summary'][0].encode('utf-8') == 'öäöäöäöäöåååå'.encode('utf-8')
+    else:
+        # This is for Python 2
+        # The result of u'öäöäöäöäöåååå'.encode('utf-8') is '\xc3\xb6...'
+        assert doc['Summary'][0] == '\xc3\xb6\xc3\xa4\xc3\xb6\xc3\xa4\xc3\xb6\xc3\xa4\xc3\xb6\xc3\xa4\xc3\xb6\xc3\xa5\xc3\xa5\xc3\xa5\xc3\xa5'
 
 def test_plot_examples():
     cfg = dict(use_plots=True)


### PR DESCRIPTION
Issue #2918: Numpydoc (in doc/sphinxext) does not support Python 3.

This pull request aims to solve this issue at least partially.
- setup.py uses 2to3.
- For Python 3, docscrape.py uses inspect.getfullargspec instead of deprecated inspect.getargspec.
- Unicode tests in test_docscrape.py are written separately for Python 2 and 3.

However, in Python 3, nosetests gives error:
  File "/../docscrape_sphinx.py", line 3, in <module>
    from .docscrape import NumpyDocString, FunctionDoc, ClassDoc
ValueError: Attempted relative import in non-package

I am not sure how to solve this problem.
