### PR TITLE
BUG: Convert non-array rhs for boolean assignment with correct dtype

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1282,9 +1282,17 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         PyArrayObject *op_arr;
         PyArray_Descr *dtype = NULL;
 
-        op_arr = (PyArrayObject *)PyArray_FromAny(op, dtype, 0, 0, 0, NULL);
-        if (op_arr == NULL) {
-            return -1;
+        if (!PyArray_Check(op)) {
+            dtype = PyArray_DTYPE(self);
+            Py_INCREF(dtype);
+            op_arr = (PyArrayObject *)PyArray_FromAny(op, dtype, 0, 0, 0, NULL);
+            if (op_arr == NULL) {
+                return -1;
+            }
+        }
+        else {
+            op_arr = op;
+            Py_INCREF(op_arr);
         }
 
         if (PyArray_NDIM(op_arr) < 2) {

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -288,6 +288,8 @@ class TestRegression(TestCase):
         self.assertRaises(ValueError, bfa)
         self.assertRaises(ValueError, bfb)
 
+    @dec.knownfailureif(sys.version_info < (2, 6),
+                        "See #2920 why this fails")
     def test_nonarray_assignment(self):
         # See also Issue gh-2870, test for nonarray assignment
         # and equivalent unsafe casted array assignment

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -288,6 +288,16 @@ class TestRegression(TestCase):
         self.assertRaises(ValueError, bfa)
         self.assertRaises(ValueError, bfb)
 
+    def test_nonarray_assignment(self):
+        # See also Issue gh-2870, test for nonarray assignment
+        # and equivalent unsafe casted array assignment
+        a = np.arange(10)
+        b = np.ones(10, dtype=bool)
+        def assign(a, b, c):
+            a[b] = c
+        assert_raises(ValueError, assign, a, b, np.nan)
+        a[b] = np.array(np.nan) # but not this.
+
     def test_unpickle_dtype_with_object(self,level=rlevel):
         """Implemented in r2840"""
         dt = np.dtype([('x',int),('y',np.object_),('z','O')])


### PR DESCRIPTION
Enforcing the left hand side datatype for a non-array right hand side
argument in index assignments was the behavior before 1.7. and is the
general behaviour here. (note this means a non-array right hand side
checks for NaN, etc. if the left hand side is integer, but an array
right hand side does not)
