### PR TITLE
fix numpy.i for python 3

### DIFF
--- a/doc/swig/numpy.i
+++ b/doc/swig/numpy.i
@@ -50,9 +50,11 @@
     if (PyDict_Check(    py_obj)) return "dict"        ;
     if (PyList_Check(    py_obj)) return "list"        ;
     if (PyTuple_Check(   py_obj)) return "tuple"       ;
-    if (PyFile_Check(    py_obj)) return "file"        ;
     if (PyModule_Check(  py_obj)) return "module"      ;
+%#if PY_MAJOR_VERSION < 3
+    if (PyFile_Check(    py_obj)) return "file"        ;
     if (PyInstance_Check(py_obj)) return "instance"    ;
+%#endif
 
     return "unkown type";
   }


### PR DESCRIPTION
PyFile_Check and PyInstance_Check have been removed from the C API
for python 3.  This removes calls to those two functions from
numpy.i for PY_MAJOR_VERSION >= 3 so that it builds with a
python 3 Python.h.
