### PR TITLE
Backport of #2897 (ndindex failing)

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2079,11 +2079,6 @@ PyArray_FromInterface(PyObject *origin)
     /* Case for data access through pointer */
     if (attr && PyTuple_Check(attr)) {
         PyObject *dataptr;
-        if (n == 0) {
-            PyErr_SetString(PyExc_ValueError,
-                    "__array_interface__ shape must be at least size 1");
-            goto fail;
-        }
         if (PyTuple_GET_SIZE(attr) != 2) {
             PyErr_SetString(PyExc_TypeError,
                     "__array_interface__ data must be a 2-tuple with "

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2835,6 +2835,13 @@ def test_array_interface():
     f.iface['shape'] = (2,)
     assert_raises(ValueError, np.array, f)
 
+    # test scalar with no shape
+    class ArrayLike(object):
+        array = np.array(1)
+        __array_interface__ = array.__array_interface__
+    assert_equal(np.array(ArrayLike()), 1)
+
+
 def test_flat_element_deletion():
     it = np.ones(3).flat
     try:

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -236,6 +236,16 @@ def test_diag_indices_from():
     assert_array_equal(r, np.arange(4))
     assert_array_equal(c, np.arange(4))
 
+    x = list(np.ndindex((1, 2, 3)))
+    assert_array_equal(x, expected)
+
+    # Make sure size argument is optional
+    x = list(np.ndindex())
+    assert_equal(x, [()])
+
+    x = list(np.ndindex(()))
+    assert_equal(x, [()])    
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -236,6 +236,11 @@ def test_diag_indices_from():
     assert_array_equal(r, np.arange(4))
     assert_array_equal(c, np.arange(4))
 
+def test_ndindex():
+    x = list(np.ndindex(1, 2, 3))
+    expected = [ix for ix, e in np.ndenumerate(np.zeros((1, 2, 3)))]
+    assert_array_equal(x, expected)
+
     x = list(np.ndindex((1, 2, 3)))
     assert_array_equal(x, expected)
 


### PR DESCRIPTION
This backports all relevant changes from:

https://github.com/numpy/numpy/pull/2897

I squashed them into just one commit.
