### PR TITLE
BUG: Fix memory leak in ndarray construction from strings (gh-2927)

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -485,9 +485,11 @@ promote_types:
     /* Set 'out_dtype' if it's NULL */
     if (*out_dtype == NULL) {
         if (!string_type && dtype->type_num == NPY_STRING) {
+            Py_DECREF(dtype);
             return RETRY_WITH_STRING;
         }
         if (!string_type && dtype->type_num == NPY_UNICODE) {
+            Py_DECREF(dtype);
             return RETRY_WITH_UNICODE;
         }
         *out_dtype = dtype;
@@ -500,17 +502,19 @@ promote_types:
         if (res_dtype == NULL) {
             return -1;
         }
-        Py_DECREF(*out_dtype);
         if (!string_type &&
                 res_dtype->type_num == NPY_UNICODE &&
                 (*out_dtype)->type_num != NPY_UNICODE) {
+            Py_DECREF(res_dtype);
             return RETRY_WITH_UNICODE;
         }
         if (!string_type &&
                 res_dtype->type_num == NPY_STRING &&
                 (*out_dtype)->type_num != NPY_STRING) {
+            Py_DECREF(res_dtype);
             return RETRY_WITH_STRING;
         }
+        Py_DECREF(*out_dtype);
         *out_dtype = res_dtype;
         return 0;
     }


### PR DESCRIPTION
This patch fixes the memory leak in issue gh-2927. The issue appears in both 1.7 and master, so the fix should be backported.
