### PR TITLE
ENH: Make memmaps return arrays in ufuncs and fancy indexing

### DIFF
--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -3,7 +3,7 @@ from tempfile import NamedTemporaryFile, mktemp
 import os
 
 from numpy import memmap
-from numpy import arange, allclose, asarray
+from numpy import arange, allclose, asarray, add
 from numpy.testing import *
 
 class TestMemmap(TestCase):
@@ -114,6 +114,21 @@ class TestMemmap(TestCase):
         assert(new2.base is fp)
         new_array = asarray(fp)
         assert(new_array.base is fp)
+
+    def test_to_array_conversions(self):
+        class MMSubclass(memmap):
+            pass
+        m = memmap(self.tmpfp, dtype=self.dtype, shape=self.shape)
+        r = m + 1
+        assert_(not isinstance(r, memmap))
+        add(m, 1, out=m)
+        assert_(isinstance(m, memmap))
+        assert_(not isinstance(m[:,[0,1]], memmap))
+        # But for subclasses, preserve in case someone tagged on functions:
+        m = MMSubclass(self.tmpfp, dtype=self.dtype, shape=self.shape)
+        r = m + 1
+        assert_(isinstance(r, MMSubclass))
+        assert_(isinstance(m[:,[0,1]], MMSubclass))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -116,7 +116,11 @@ class TestMemmap(TestCase):
         assert(new_array.base is fp)
 
     def test_to_array_conversions(self):
-        class MMSubclass(memmap):
+        class DummyInerhitance(np.ndarray):
+            def __array_wrap__(self, arr):
+                arr = super(DummyInerhitance, self).__array_wrap__(arr)
+                arr.info = 'set'
+        class MMSubclass(memmap, DummyInerhitance):
             pass
         m = memmap(self.tmpfp, dtype=self.dtype, shape=self.shape)
         r = m + 1
@@ -128,6 +132,7 @@ class TestMemmap(TestCase):
         m = MMSubclass(self.tmpfp, dtype=self.dtype, shape=self.shape)
         r = m + 1
         assert_(isinstance(r, MMSubclass))
+        assert_(hasattr(r, 'info'))
         assert_(isinstance(m[:,[0,1]], MMSubclass))
 
 if __name__ == "__main__":


### PR DESCRIPTION
A long while back when there was some discussion about memmaps, I wondered if this would not make sense... So putting it in a pull request. Of course if someone out there tries to access `_mmap` even though it does not actually have that attribute any more, that would result in an array like that, but I remember finding it annoying that `memmap + 1` would print as `memmap` all the time...

This makes memmeps return an array instead of a memmap instance
for fancy indexing or ufuncs, etc. that use **array_wrap** and
**array_prepare**. The type is preserved for subclasses however.
Also copy is one example that still returns a memmap even if it
does not point to the same memory.
