### PR TITLE
BUG: Fix segfault in np.result_type for None input.

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2875,7 +2875,7 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *args)
                                 "too many arguments");
                 goto finish;
             }
-            if (!PyArray_DescrConverter2(obj, &dtypes[ndtypes])) {
+            if (!PyArray_DescrConverter(obj, &dtypes[ndtypes])) {
                 goto finish;
             }
             ++ndtypes;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -465,6 +465,7 @@ class TestTypes(TestCase):
 
     def test_result_type(self):
         self.check_promotion_cases(np.result_type)
+        assert_(np.result_type(None) == np.dtype(None))
 
     def test_promote_types_endian(self):
         # promote_types should always return native-endian types


### PR DESCRIPTION
Makes behavior identical to np.dtype(None), which fits to how
the function works.
## 

This is just a mini fix for a segfault due to `PyArray_DescrConverter2` returning `NULL` for `None`. `PyArray_DescrConverter` does the correct thing for this function.
