### PR TITLE
Fix print negative float zero

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -468,7 +468,7 @@ format_@name@(char *buf, size_t buflen, @type@ val, unsigned int prec)
 
     /* If nothing but digits after sign, append ".0" */
     cnt = strlen(buf);
-    for (i = (val < 0) ? 1 : 0; i < cnt; ++i) {
+    for (i = (buf[0] == '-') ? 1 : 0; i < cnt; ++i) {
         if (!isdigit(Py_CHARMASK(buf[i]))) {
             break;
         }

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+""" Test printing of scalar types.
+
+"""
+
+import numpy as np
+from numpy.testing import TestCase, assert_, run_module_suite
+
+
+class TestRealScalars(TestCase):
+    def test_str(self):
+        svals = [0.0, -0.0, 1, -1, np.inf, -np.inf, np.nan]
+        styps = [np.float16, np.float32, np.float64, np.longdouble]
+        actual = [str(f(c)) for c in svals for f in styps]
+        wanted = [
+             '0.0',  '0.0',  '0.0',  '0.0',
+             '-0.0', '-0.0', '-0.0', '-0.0',
+             '1.0',  '1.0',  '1.0',  '1.0',
+             '-1.0', '-1.0', '-1.0', '-1.0',
+             'inf',  'inf',  'inf',  'inf',
+             '-inf', '-inf', '-inf', '-inf',
+             'nan',  'nan',  'nan',  'nan']
+
+        for res, val in zip(actual, wanted):
+            assert_(res == val)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Fixes gh-2935 by directly checking for a leading '-' instead of deducing its presence from the truth of "val < 0". Signed IEEE zeros are treated like plain old zeros in comparisons.
