### PR TITLE
Avoid calls that result on Python exceptions.

### DIFF
--- a/_configtest.exe.manifest
+++ b/_configtest.exe.manifest
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type='win32' name='Microsoft.VC90.CRT' version='9.0.21022.8' processorArchitecture='x86' publicKeyToken='1fc8b3b9a1e18e3b' />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/numpy/core/include/numpy/arrayobject.h
+++ b/numpy/core/include/numpy/arrayobject.h
@@ -8,13 +8,16 @@
 #include "noprefix.h"
 #endif
 
-//Check for exact native types that for sure do not
-//support array related methods. Useful for faster checks when
-//validating if an object supports these methods
+/*
+ * Check for exact native types that for sure do not
+ * support array related methods. Useful for faster checks when
+ * validating if an object supports these methods
+ */
 #define ISEXACT_NATIVE_PYTYPE(op) (PyList_CheckExact(op) ||  (Py_None == op) || PyTuple_CheckExact(op) || PyFloat_CheckExact(op) || PyInt_CheckExact(op) || PyString_CheckExact(op) || PyUnicode_CheckExact(op))
 
-//Check for exact native types that for sure do not
-//support buffer protocol. Useful for faster checks when 
-//validating if an object supports the buffer protocol.
+/* Check for exact native types that for sure do not
+ * support buffer protocol. Useful for faster checks when 
+ * validating if an object supports the buffer protocol.
+ */
 #define NEVERSUPPORTS_BUFFER_PROTOCOL(op) ( PyList_CheckExact(op) ||  (Py_None == op) || PyTuple_CheckExact(op) )
 #endif

--- a/numpy/core/include/numpy/arrayobject.h
+++ b/numpy/core/include/numpy/arrayobject.h
@@ -8,4 +8,13 @@
 #include "noprefix.h"
 #endif
 
+//Check for exact native types that for sure do not
+//support array related methods. Useful for faster checks when
+//validating if an object supports these methods
+#define ISEXACT_NATIVE_PYTYPE(op) (PyList_CheckExact(op) ||  (Py_None == op) || PyTuple_CheckExact(op) || PyFloat_CheckExact(op) || PyInt_CheckExact(op) || PyString_CheckExact(op) || PyUnicode_CheckExact(op))
+
+//Check for exact native types that for sure do not
+//support buffer protocol. Useful for faster checks when 
+//validating if an object supports the buffer protocol.
+#define NEVERSUPPORTS_BUFFER_PROTOCOL(op) ( PyList_CheckExact(op) ||  (Py_None == op) || PyTuple_CheckExact(op) )
 #endif

--- a/numpy/core/include/numpy/arrayobject.h
+++ b/numpy/core/include/numpy/arrayobject.h
@@ -1,6 +1,7 @@
 #ifndef Py_ARRAYOBJECT_H
 #define Py_ARRAYOBJECT_H
 
+#include <Python.h>
 #include "ndarrayobject.h"
 #include "npy_interrupt.h"
 
@@ -13,8 +14,12 @@
  * support array related methods. Useful for faster checks when
  * validating if an object supports these methods
  */
+#if PY_VERSION_HEX >= 0x03000000
+/* PyInt_CheckExact is not in Python 3 */
+#define ISEXACT_NATIVE_PYTYPE(op) (PyList_CheckExact(op) ||  (Py_None == op) || PyTuple_CheckExact(op) || PyFloat_CheckExact(op) || PyString_CheckExact(op) || PyUnicode_CheckExact(op))
+#else
 #define ISEXACT_NATIVE_PYTYPE(op) (PyList_CheckExact(op) ||  (Py_None == op) || PyTuple_CheckExact(op) || PyFloat_CheckExact(op) || PyInt_CheckExact(op) || PyString_CheckExact(op) || PyUnicode_CheckExact(op))
-
+#endif
 /* Check for exact native types that for sure do not
  * support buffer protocol. Useful for faster checks when 
  * validating if an object supports the buffer protocol.

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -316,96 +316,96 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         
     }
     else{
-       if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-           PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+        if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
 
-           PyErr_Clear();
-           dtype = _descriptor_from_pep3118_format(buffer_view.format);
-           PyBuffer_Release(&buffer_view);
-           if (dtype) {
-               goto promote_types;
-           }
-       }
-       else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
 
-           PyErr_Clear();
-           dtype = PyArray_DescrNewFromType(NPY_VOID);
-           dtype->elsize = buffer_view.itemsize;
-           PyBuffer_Release(&buffer_view);
-           goto promote_types;
-       }
-       else {
-           PyErr_Clear();
-       }
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
+            goto promote_types;
+        }
+        else {
+            PyErr_Clear();
+        }
     }
 #endif
 
     if (ISEXACT_NATIVE_PYTYPE(obj)){
-       /* Avoid expensive call to PyObject_GetAttrString*/
-       ip = NULL;
+        /* Avoid expensive call to PyObject_GetAttrString */
+        ip = NULL;
     }
     else{
-       /* The array interface */
-       ip = PyObject_GetAttrString(obj, "__array_interface__");
-       if (ip != NULL) {
-           if (PyDict_Check(ip)) {
-               PyObject *typestr;
-   #if defined(NPY_PY3K)
-               PyObject *tmp = NULL;
-   #endif
-               typestr = PyDict_GetItemString(ip, "typestr");
-   #if defined(NPY_PY3K)
-               /* Allow unicode type strings */
-               if (PyUnicode_Check(typestr)) {
-                   tmp = PyUnicode_AsASCIIString(typestr);
-                   typestr = tmp;
-               }
-   #endif
-               if (typestr && PyBytes_Check(typestr)) {
-                   dtype =_array_typedescr_fromstr(PyBytes_AS_STRING(typestr));
-   #if defined(NPY_PY3K)
-                   if (tmp == typestr) {
-                       Py_DECREF(tmp);
-                   }
-   #endif
-                   Py_DECREF(ip);
-                   if (dtype == NULL) {
-                       goto fail;
-                   }
-                   goto promote_types;
-               }
-           }
-           Py_DECREF(ip);
-       }
-       else {
-           PyErr_Clear();
-       }
+        /* The array interface */
+        ip = PyObject_GetAttrString(obj, "__array_interface__");
+        if (ip != NULL) {
+            if (PyDict_Check(ip)) {
+                PyObject *typestr;
+#if defined(NPY_PY3K)
+                PyObject *tmp = NULL;
+#endif
+                typestr = PyDict_GetItemString(ip, "typestr");
+#if defined(NPY_PY3K)
+                /* Allow unicode type strings */
+                if (PyUnicode_Check(typestr)) {
+                    tmp = PyUnicode_AsASCIIString(typestr);
+                    typestr = tmp;
+                }
+#endif
+                if (typestr && PyBytes_Check(typestr)) {
+                    dtype =_array_typedescr_fromstr(PyBytes_AS_STRING(typestr));
+#if defined(NPY_PY3K)
+                    if (tmp == typestr) {
+                        Py_DECREF(tmp);
+                    }
+#endif
+                    Py_DECREF(ip);
+                    if (dtype == NULL) {
+                        goto fail;
+                    }
+                    goto promote_types;
+                }
+            }
+            Py_DECREF(ip);
+        }
+        else {
+            PyErr_Clear();
+        }
 
-       /* The array struct interface */
-       ip = PyObject_GetAttrString(obj, "__array_struct__");
-       if (ip != NULL) {
-           PyArrayInterface *inter;
-           char buf[40];
+        /* The array struct interface */
+        ip = PyObject_GetAttrString(obj, "__array_struct__");
+        if (ip != NULL) {
+            PyArrayInterface *inter;
+            char buf[40];
 
-           if (NpyCapsule_Check(ip)) {
-               inter = (PyArrayInterface *)NpyCapsule_AsVoidPtr(ip);
-               if (inter->two == 2) {
-                   PyOS_snprintf(buf, sizeof(buf),
-                           "|%c%d", inter->typekind, inter->itemsize);
-                   dtype = _array_typedescr_fromstr(buf);
-                   Py_DECREF(ip);
-                   if (dtype == NULL) {
-                       goto fail;
-                   }
-                   goto promote_types;
-               }
-           }
-           Py_DECREF(ip);
-       }
-       else {
-           PyErr_Clear();
-       }
+            if (NpyCapsule_Check(ip)) {
+                inter = (PyArrayInterface *)NpyCapsule_AsVoidPtr(ip);
+                if (inter->two == 2) {
+                    PyOS_snprintf(buf, sizeof(buf),
+                            "|%c%d", inter->typekind, inter->itemsize);
+                    dtype = _array_typedescr_fromstr(buf);
+                    Py_DECREF(ip);
+                    if (dtype == NULL) {
+                        goto fail;
+                    }
+                    goto promote_types;
+                }
+            }
+            Py_DECREF(ip);
+        }
+        else {
+            PyErr_Clear();
+        }
 
     }
 
@@ -423,23 +423,23 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     if (ISEXACT_NATIVE_PYTYPE(obj)){
-       /* Avoid expensive call to PyObject_HasAttrString*/
+        /* Avoid expensive call to PyObject_HasAttrString */
     }
     else{
-       /* The __array__ attribute */
-       if (PyObject_HasAttrString(obj, "__array__")) {
-           ip = PyObject_CallMethod(obj, "__array__", NULL);
-           if(ip && PyArray_Check(ip)) {
-               dtype = PyArray_DESCR((PyArrayObject *)ip);
-               Py_INCREF(dtype);
-               Py_DECREF(ip);
-               goto promote_types;
-           }
-           Py_XDECREF(ip);
-           if (PyErr_Occurred()) {
-               goto fail;
-           }
-       }
+        /* The __array__ attribute */
+        if (PyObject_HasAttrString(obj, "__array__")) {
+            ip = PyObject_CallMethod(obj, "__array__", NULL);
+            if(ip && PyArray_Check(ip)) {
+                dtype = PyArray_DESCR((PyArrayObject *)ip);
+                Py_INCREF(dtype);
+                Py_DECREF(ip);
+                goto promote_types;
+            }
+            Py_XDECREF(ip);
+            if (PyErr_Occurred()) {
+                goto fail;
+            }
+        }
     }
 
     /* Not exactly sure what this is about... */

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -312,89 +312,101 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
     memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
-            goto promote_types;
-        }
+    if ( NEVERSUPPORTS_BUFFER_PROTOCOL(obj) ){
+        
     }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    else{
+       if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+           PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
 
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+           PyErr_Clear();
+           dtype = _descriptor_from_pep3118_format(buffer_view.format);
+           PyBuffer_Release(&buffer_view);
+           if (dtype) {
+               goto promote_types;
+           }
+       }
+       else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+
+           PyErr_Clear();
+           dtype = PyArray_DescrNewFromType(NPY_VOID);
+           dtype->elsize = buffer_view.itemsize;
+           PyBuffer_Release(&buffer_view);
+           goto promote_types;
+       }
+       else {
+           PyErr_Clear();
+       }
     }
 #endif
 
-    /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
-    if (ip != NULL) {
-        if (PyDict_Check(ip)) {
-            PyObject *typestr;
-#if defined(NPY_PY3K)
-            PyObject *tmp = NULL;
-#endif
-            typestr = PyDict_GetItemString(ip, "typestr");
-#if defined(NPY_PY3K)
-            /* Allow unicode type strings */
-            if (PyUnicode_Check(typestr)) {
-                tmp = PyUnicode_AsASCIIString(typestr);
-                typestr = tmp;
-            }
-#endif
-            if (typestr && PyBytes_Check(typestr)) {
-                dtype =_array_typedescr_fromstr(PyBytes_AS_STRING(typestr));
-#if defined(NPY_PY3K)
-                if (tmp == typestr) {
-                    Py_DECREF(tmp);
-                }
-#endif
-                Py_DECREF(ip);
-                if (dtype == NULL) {
-                    goto fail;
-                }
-                goto promote_types;
-            }
-        }
-        Py_DECREF(ip);
+    if (ISEXACT_NATIVE_PYTYPE(obj)){
+       /* Avoid expensive call to PyObject_GetAttrString*/
+       ip = NULL;
     }
-    else {
-        PyErr_Clear();
-    }
+    else{
+       /* The array interface */
+       ip = PyObject_GetAttrString(obj, "__array_interface__");
+       if (ip != NULL) {
+           if (PyDict_Check(ip)) {
+               PyObject *typestr;
+   #if defined(NPY_PY3K)
+               PyObject *tmp = NULL;
+   #endif
+               typestr = PyDict_GetItemString(ip, "typestr");
+   #if defined(NPY_PY3K)
+               /* Allow unicode type strings */
+               if (PyUnicode_Check(typestr)) {
+                   tmp = PyUnicode_AsASCIIString(typestr);
+                   typestr = tmp;
+               }
+   #endif
+               if (typestr && PyBytes_Check(typestr)) {
+                   dtype =_array_typedescr_fromstr(PyBytes_AS_STRING(typestr));
+   #if defined(NPY_PY3K)
+                   if (tmp == typestr) {
+                       Py_DECREF(tmp);
+                   }
+   #endif
+                   Py_DECREF(ip);
+                   if (dtype == NULL) {
+                       goto fail;
+                   }
+                   goto promote_types;
+               }
+           }
+           Py_DECREF(ip);
+       }
+       else {
+           PyErr_Clear();
+       }
 
-    /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
-    if (ip != NULL) {
-        PyArrayInterface *inter;
-        char buf[40];
+       /* The array struct interface */
+       ip = PyObject_GetAttrString(obj, "__array_struct__");
+       if (ip != NULL) {
+           PyArrayInterface *inter;
+           char buf[40];
 
-        if (NpyCapsule_Check(ip)) {
-            inter = (PyArrayInterface *)NpyCapsule_AsVoidPtr(ip);
-            if (inter->two == 2) {
-                PyOS_snprintf(buf, sizeof(buf),
-                        "|%c%d", inter->typekind, inter->itemsize);
-                dtype = _array_typedescr_fromstr(buf);
-                Py_DECREF(ip);
-                if (dtype == NULL) {
-                    goto fail;
-                }
-                goto promote_types;
-            }
-        }
-        Py_DECREF(ip);
-    }
-    else {
-        PyErr_Clear();
+           if (NpyCapsule_Check(ip)) {
+               inter = (PyArrayInterface *)NpyCapsule_AsVoidPtr(ip);
+               if (inter->two == 2) {
+                   PyOS_snprintf(buf, sizeof(buf),
+                           "|%c%d", inter->typekind, inter->itemsize);
+                   dtype = _array_typedescr_fromstr(buf);
+                   Py_DECREF(ip);
+                   if (dtype == NULL) {
+                       goto fail;
+                   }
+                   goto promote_types;
+               }
+           }
+           Py_DECREF(ip);
+       }
+       else {
+           PyErr_Clear();
+       }
+
     }
 
     /* The old buffer interface */
@@ -410,19 +422,24 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 #endif
 
-    /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
-        ip = PyObject_CallMethod(obj, "__array__", NULL);
-        if(ip && PyArray_Check(ip)) {
-            dtype = PyArray_DESCR((PyArrayObject *)ip);
-            Py_INCREF(dtype);
-            Py_DECREF(ip);
-            goto promote_types;
-        }
-        Py_XDECREF(ip);
-        if (PyErr_Occurred()) {
-            goto fail;
-        }
+    if (ISEXACT_NATIVE_PYTYPE(obj)){
+       /* Avoid expensive call to PyObject_HasAttrString*/
+    }
+    else{
+       /* The __array__ attribute */
+       if (PyObject_HasAttrString(obj, "__array__")) {
+           ip = PyObject_CallMethod(obj, "__array__", NULL);
+           if(ip && PyArray_Check(ip)) {
+               dtype = PyArray_DESCR((PyArrayObject *)ip);
+               Py_INCREF(dtype);
+               Py_DECREF(ip);
+               goto promote_types;
+           }
+           Py_XDECREF(ip);
+           if (PyErr_Occurred()) {
+               goto fail;
+           }
+       }
     }
 
     /* Not exactly sure what this is about... */

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -634,27 +634,27 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         
     }
     else{
-       if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-           PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
-           int nd = buffer_view.ndim;
-           if (nd < *maxndim) {
-               *maxndim = nd;
-           }
-           for (i=0; i<*maxndim; i++) {
-               d[i] = buffer_view.shape[i];
-           }
-           PyBuffer_Release(&buffer_view);
-           return 0;
-       }
-       else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-           d[0] = buffer_view.len;
-           *maxndim = 1;
-           PyBuffer_Release(&buffer_view);
-           return 0;
-       }
-       else {
-           PyErr_Clear();
-       }
+        if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
+            int nd = buffer_view.ndim;
+            if (nd < *maxndim) {
+                *maxndim = nd;
+            }
+            for (i=0; i<*maxndim; i++) {
+                d[i] = buffer_view.shape[i];
+            }
+            PyBuffer_Release(&buffer_view);
+            return 0;
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+            d[0] = buffer_view.len;
+            *maxndim = 1;
+            PyBuffer_Release(&buffer_view);
+            return 0;
+        }
+        else {
+            PyErr_Clear();
+        }
     }
 #endif
 
@@ -663,66 +663,66 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         e = NULL;
     }
     else{
-       if ((e = PyObject_GetAttrString(obj, "__array_struct__")) != NULL) {
-           int nd = -1;
-           if (NpyCapsule_Check(e)) {
-               PyArrayInterface *inter;
-               inter = (PyArrayInterface *)NpyCapsule_AsVoidPtr(e);
-               if (inter->two == 2) {
-                   nd = inter->nd;
-                   if (nd >= 0) {
-                       if (nd < *maxndim) {
-                           *maxndim = nd;
-                       }
-                       for (i=0; i<*maxndim; i++) {
-                           d[i] = inter->shape[i];
-                       }
-                   }
-               }
-           }
-           Py_DECREF(e);
-           if (nd >= 0) {
-               return 0;
-           }
-       }
-       else {
-           PyErr_Clear();
-       }
+        if ((e = PyObject_GetAttrString(obj, "__array_struct__")) != NULL) {
+            int nd = -1;
+            if (NpyCapsule_Check(e)) {
+                PyArrayInterface *inter;
+                inter = (PyArrayInterface *)NpyCapsule_AsVoidPtr(e);
+                if (inter->two == 2) {
+                    nd = inter->nd;
+                    if (nd >= 0) {
+                        if (nd < *maxndim) {
+                            *maxndim = nd;
+                        }
+                        for (i=0; i<*maxndim; i++) {
+                            d[i] = inter->shape[i];
+                        }
+                    }
+                }
+            }
+            Py_DECREF(e);
+            if (nd >= 0) {
+                return 0;
+            }
+        }
+        else {
+            PyErr_Clear();
+        }
     
-       /* obj has the __array_interface__ interface */
-       if ((e = PyObject_GetAttrString(obj, "__array_interface__")) != NULL) {
-           int nd = -1;
-           if (PyDict_Check(e)) {
-               PyObject *new;
-               new = PyDict_GetItemString(e, "shape");
-               if (new && PyTuple_Check(new)) {
-                   nd = PyTuple_GET_SIZE(new);
-                   if (nd < *maxndim) {
-                       *maxndim = nd;
-                   }
-                   for (i=0; i<*maxndim; i++) {
-   #if (PY_VERSION_HEX >= 0x02050000)
-                       d[i] = PyInt_AsSsize_t(PyTuple_GET_ITEM(new, i));
-   #else
-                       d[i] = PyInt_AsLong(PyTuple_GET_ITEM(new, i));
-   #endif
-                       if (d[i] < 0) {
-                           PyErr_SetString(PyExc_RuntimeError,
-                                   "Invalid shape in __array_interface__");
-                           Py_DECREF(e);
-                           return -1;
-                       }
-                   }
-               }
-           }
-           Py_DECREF(e);
-           if (nd >= 0) {
-               return 0;
-           }
-       }
-       else {
-           PyErr_Clear();
-       }
+        /* obj has the __array_interface__ interface */
+        if ((e = PyObject_GetAttrString(obj, "__array_interface__")) != NULL) {
+            int nd = -1;
+            if (PyDict_Check(e)) {
+                PyObject *new;
+                new = PyDict_GetItemString(e, "shape");
+                if (new && PyTuple_Check(new)) {
+                    nd = PyTuple_GET_SIZE(new);
+                    if (nd < *maxndim) {
+                        *maxndim = nd;
+                    }
+                    for (i=0; i<*maxndim; i++) {
+#if (PY_VERSION_HEX >= 0x02050000)
+                        d[i] = PyInt_AsSsize_t(PyTuple_GET_ITEM(new, i));
+#else
+                        d[i] = PyInt_AsLong(PyTuple_GET_ITEM(new, i));
+#endif
+                        if (d[i] < 0) {
+                            PyErr_SetString(PyExc_RuntimeError,
+                                    "Invalid shape in __array_interface__");
+                            Py_DECREF(e);
+                            return -1;
+                        }
+                    }
+                }
+            }
+            Py_DECREF(e);
+            if (nd >= 0) {
+                return 0;
+            }
+        }
+        else {
+            PyErr_Clear();
+        }
     }
 
     n = PySequence_Size(obj);
@@ -1932,11 +1932,11 @@ PyArray_FromStructInterface(PyObject *input)
         return Py_NotImplemented;
     }
     else{
-       attr = PyObject_GetAttrString(input, "__array_struct__");
-       if (attr == NULL) {
-           PyErr_Clear();
-           return Py_NotImplemented;
-       }
+        attr = PyObject_GetAttrString(input, "__array_struct__");
+        if (attr == NULL) {
+            PyErr_Clear();
+            return Py_NotImplemented;
+        }
     }
 
     if (!NpyCapsule_Check(attr)) {
@@ -2013,11 +2013,11 @@ PyArray_FromInterface(PyObject *origin)
         return Py_NotImplemented;
     }
     else{
-       iface = PyObject_GetAttrString(origin, "__array_interface__");
-       if (iface == NULL) {
-           PyErr_Clear();
-           return Py_NotImplemented;
-       }
+        iface = PyObject_GetAttrString(origin, "__array_interface__");
+        if (iface == NULL) {
+            PyErr_Clear();
+            return Py_NotImplemented;
+        }
     }
 
     if (!PyDict_Check(iface)) {
@@ -2237,11 +2237,11 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
         return Py_NotImplemented;
     }
     else{
-       array_meth = PyObject_GetAttrString(op, "__array__");
-       if (array_meth == NULL) {
-           PyErr_Clear();
-           return Py_NotImplemented;
-       }
+        array_meth = PyObject_GetAttrString(op, "__array__");
+        if (array_meth == NULL) {
+            PyErr_Clear();
+            return Py_NotImplemented;
+        }
     }
 
     if (context == NULL) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -70,10 +70,10 @@ PyArray_GetPriority(PyObject *obj, double default_)
         ret = NULL;
     }
     else{
-       ret = PyObject_GetAttrString(obj, "__array_priority__");
-       if (ret != NULL) {
-           priority = PyFloat_AsDouble(ret);
-       }
+        ret = PyObject_GetAttrString(obj, "__array_priority__");
+        if (ret != NULL) {
+            priority = PyFloat_AsDouble(ret);
+        }
     }
     if (PyErr_Occurred()) {
         PyErr_Clear();

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -66,10 +66,14 @@ PyArray_GetPriority(PyObject *obj, double default_)
 
     if (PyArray_CheckExact(obj))
         return priority;
-
-    ret = PyObject_GetAttrString(obj, "__array_priority__");
-    if (ret != NULL) {
-        priority = PyFloat_AsDouble(ret);
+    if (ISEXACT_NATIVE_PYTYPE(obj)){
+        ret = NULL;
+    }
+    else{
+       ret = PyObject_GetAttrString(obj, "__array_priority__");
+       if (ret != NULL) {
+           priority = PyFloat_AsDouble(ret);
+       }
     }
     if (PyErr_Occurred()) {
         PyErr_Clear();


### PR DESCRIPTION
After profiling numpy I found out bottlenecks when doing calls that
result in Python internally raising an error
e.g.
PyObject_GetAttrString(obj, "**array_priority**")
when **array_priority** is not an attribute of obj

The changes are in general,
- avoid calls to PyObject_GetAttrString when I know the type is
  List, None, Tuple, Float, Int, String or Unicode
- avoid calls to PyObject_GetBuffer when I know the type is
  List, None or Tuple

Using Windows Python 2.6, the changes resulted in the following speed up,
    RATIO   TEST
1)  1.1 Array \* Array 
2)  1.1 PyFloat \* Array 
3)  1.1 Float64 \* Array 
4)  1.1 PyFloat + Array 
5)  1.2 Float64 + Array 
6)  1.0 PyFloat \* PyFloat 
7)  1.7 Float64 \* Float64 
8)  2.8 PyFloat \* Float64 
9)  2.1 PyFloat \* vector1[1] 
10) 2.8 PyFloat + Float64 
11) 3.3 PyFloat < Float64 
12) 3.3 if PyFloat < Float64: 
13) 3.2 Create array from list 
14) 1.2 Assign PyFloat to all 
15) 1.2 Assign Float64 to all 
16) 2.9 Float64  \* pyFloat \* pyFloat \* pyFloat \* pyFloat 

where RATIO is defined as the time it took to run before the changes divided by the time it too to run after the changes. The bigger the ratio, the bigger the speedup.
