### PR TITLE
BUG: Fix loading npz files >2GB on 64bit systems

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -80,6 +80,11 @@ fact, it never was true in some corner cases). Instead, use
 For more information check the "Internal memory layout of an ndarray"
 section in the documentation.
 
+IO compatibility with large files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Large NPZ files >2GB can be loaded on 64-bit systems.
+
 
 New Features
 ============
@@ -135,6 +140,11 @@ A simple test runner script ``runtests.py`` was added. It also builds Numpy via
 
 Improvements
 ============
+
+IO performance improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Performance in reading large files was improved by chunking (see also IO compatibility).
 
 Performance improvements to `pad`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -25,8 +25,6 @@ from numpy.compat import (
         asbytes, asstr, asbytes_nested, bytes, basestring, unicode
         )
 
-from io import BytesIO
-
 if sys.version_info[0] >= 3:
     import pickle
 else:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -244,12 +244,14 @@ class NpzFile(object):
             member = 1
             key += '.npy'
         if member:
-            bytes = self.zip.read(key)
-            if bytes.startswith(format.MAGIC_PREFIX):
-                value = BytesIO(bytes)
-                return format.read_array(value)
+            bytes = self.zip.open(key)
+            magic = bytes.read(len(format.MAGIC_PREFIX))
+            bytes.close()
+            if magic == format.MAGIC_PREFIX:
+                bytes = self.zip.open(key)
+                return format.read_array(bytes)
             else:
-                return bytes
+                return self.zip.read(key)
         else:
             raise KeyError("%s is not a file in the archive" % key)
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -43,9 +43,8 @@ class TextIO(BytesIO):
 
 
 MAJVER, MINVER = sys.version_info[:2]
+IS_64BIT = sys.maxsize > 2**32
 
-def is_64bit_platform():
-    return sys.maxsize> 2**32
 
 def strptime(s, fmt=None):
     """This function is available in the datetime module only
@@ -142,11 +141,10 @@ class TestSavezLoad(RoundtripTest, TestCase):
         for n, arr in enumerate(self.arr):
             assert_equal(arr, self.arr_reloaded['arr_%d' % n])
 
-
-    @np.testing.dec.skipif(not is_64bit_platform(), "Works only with 64bit systems")
+    @np.testing.dec.skipif(not IS_64BIT, "Works only with 64bit systems")
     @np.testing.dec.slow
     def test_big_arrays(self):
-        L = 2**31+1
+        L = (1 << 31) + 100000
         tmp = mktemp(suffix='.npz')
         a = np.empty(L, dtype=np.uint8)
         np.savez(tmp, a=a)


### PR DESCRIPTION
Large npz archives >2GB can not be loaded due to a 64-bit compatibility bug in cStringIO and zlib. This is solved by reading the data in small chunks. The size of a chunk is adjusted for optimal reading performance and can be configured via numpy.lib.format.BUFFER_SIZE (default 256 kb). 

This fixes bug #2922 and gives an IO performance bonus.
