### PR TITLE
ENH: Add step argument for linspace (and small fixes for corner cases)

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -73,10 +73,12 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False):
     """
     num = int(num)
     if num <= 0:
-        return array([], float)
+        dtype = _nx.result_type(start, stop, 1.)
+        return array([], dtype)
     if endpoint:
         if num == 1:
-            return array([float(start)])
+            dtype = _nx.result_type(start, stop, 1.)
+            return array([start], dtype)
         step = (stop-start)/float((num-1))
         y = _nx.arange(0, num) * step + start
         y[-1] = stop

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -39,3 +39,11 @@ class TestLinspace(TestCase):
         assert_equal(t1, t2)
         assert_equal(t2, t3)
 
+    def test_step(self):
+        assert_array_equal(linspace(0, 1, 11), linspace(0, 1, step=0.1))
+        assert_array_equal(linspace(1, 0, 11), linspace(1, 0, step=-0.1))
+        assert_raises(ValueError, linspace, 0, 1, step=0.10001)
+        assert_raises(ValueError, linspace, 0, 1, step=0.99999)
+        assert_raises(ValueError, linspace, 1, 0, step=-0.10001)
+        assert_raises(ValueError, linspace, 1, 0, step=-0.99999)
+        assert_raises(ValueError, linspace, 0, 1, step=-0.1)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -1,6 +1,6 @@
 
 from numpy.testing import *
-from numpy import logspace, linspace
+from numpy import logspace, linspace, complex_
 
 class TestLogspace(TestCase):
     def test_basic(self):
@@ -27,6 +27,10 @@ class TestLinspace(TestCase):
         assert_(y == [0.0], y)
         y = list(linspace(0,1,2.5))
         assert_(y == [0.0, 1.0])
+        # preserve complex type for complex corner cases:
+        c = complex_(1j)
+        assert_(linspace(c, 1, 0).dtype.type == complex_)
+        assert_(linspace(0, c, 1).dtype.type == complex_)
 
     def test_type(self):
         t1 = linspace(0,1,0).dtype


### PR DESCRIPTION
This adds a step argument to linspace, however the step argument is only used to determine the integer number of steps. It must be possible to safely determine the number of steps (given floating point accuracy). This was requested in gh-630. Also fixes corner cases where the dtype was not preserved, even though the function supports complex numbers fine.

I kind of like the functionality, but it seems to me like a pure convenience function that, in general code maybe fails unexpectedly (i.e. given very large floats or such), or maybe even works on one computer and not on the next in some examples.
