### PR TITLE
BUG: Fix strides of trailing 1s when reshaping

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -545,6 +545,15 @@ class TestRegression(TestCase):
         a = np.ones((0,2))
         a.shape = (-1,2)
 
+    def test_reshape_trailing_ones_strides(self):
+        # Github issue gh-2949, bad strides for trailing ones of new shape
+        a = np.zeros(12, dtype=np.int32)[::2] # not contiguous
+        strides_c = (16, 8, 8, 8)
+        strides_f = (8, 24, 48, 48)
+        assert_equal(a.reshape(3, 2, 1, 1).strides, strides_c)
+        assert_equal(a.reshape(3, 2, 1, 1, order='F').strides, strides_f)
+        assert_equal(np.array(0, dtype=np.int32).reshape(1,1).strides, (4,4))
+
     def test_repeat_discont(self, level=rlevel):
         """Ticket #352"""
         a = np.arange(12).reshape(4,3)[:,2]


### PR DESCRIPTION
When adding ones to the shape for non contiguous arrays reshapes
(i.e. either the first array is not contiguous or the the reshape
order does not match it). The strides of trailing ones were not
set. For example reshape of (6,) to (6,1,1). Previously this occured
rarely because of removed special handleing when only ones were
added or removed.
## 

Fix for gh-2949, this does not attempt to set strides in a beautiful way to conserve the contiguity of the input array, but that is maybe a bigger matter anyway (and here only interesting in corner cases I guess).
