### PR TITLE
DOC/FIX: fix example in ctypeslib module documentation

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -40,8 +40,8 @@ in-place.  For example::
 
 We wrap it using:
 
->>> lib.foo_func.restype = None                 #doctest: +SKIP
->>> lib.foo.argtypes = [array_1d_double, c_int] #doctest: +SKIP
+>>> _lib.foo_func.restype = None                      #doctest: +SKIP
+>>> _lib.foo_func.argtypes = [array_1d_double, c_int] #doctest: +SKIP
 
 Then, we're ready to call ``foo_func``:
 


### PR DESCRIPTION
Fix some inconsistencies in the example. The library is loaded as '_lib' not
'lib' in the rest of the example. Also, the function is called 'foo_func' not
'foo'
