### PR TITLE
DOC -- add another paragraph note to ndarray.view docs

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4460,6 +4460,12 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     (same shape, dtype, etc.)  This does not cause a reinterpretation of the
     memory.
 
+    In cases when ``a.view(some_dtype)`` causes a reinterpretation of the
+    bytes of memory, its behavior cannot necessarily be predicted just from
+    the superficial appearance of ``a`` (shown by ``print(a)``). If ``a`` is
+    C-ordered versus fortran-ordered, versus defined as a transpose, versus
+    defined as a slice, etc., the view may give different results.
+
 
     Examples
     --------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4510,6 +4510,22 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     >>> z[0]
     (9, 10)
 
+    Views that change the dtype size (bytes per entry) should normally be
+    avoided on arrays defined by slices, transposes, fortran-ordering, etc.:
+
+    >>> x = np.array([[1,2,3],[4,5,6]], dtype=np.int16)
+    >>> y = x[:, 0:2]
+    >>> y
+    array([[1, 2],
+           [4, 5]], dtype=int16)
+    >>> y.view(dtype=[('width', np.int16), ('length', np.int16)])
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    ValueError: new type not compatible with array.
+    >>> z = y.copy()
+    >>> z.view(dtype=[('width', np.int16), ('length', np.int16)])
+    array([[(1, 2)],
+           [(4, 5)]], dtype=[('width', '<i2'), ('length', '<i2')])
     """))
 
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4460,11 +4460,14 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     (same shape, dtype, etc.)  This does not cause a reinterpretation of the
     memory.
 
-    In cases when ``a.view(some_dtype)`` causes a reinterpretation of the
-    bytes of memory, its behavior cannot necessarily be predicted just from
-    the superficial appearance of ``a`` (shown by ``print(a)``). If ``a`` is
-    C-ordered versus fortran-ordered, versus defined as a transpose, versus
-    defined as a slice, etc., the view may give different results.
+    For ``a.view(some_dtype)``, if ``some_dtype`` has a different number of
+    bytes per entry than the previous dtype (for example, converting a
+    regular array to a structured array), then the behavior of the view
+    cannot be predicted just from the superficial appearance of ``a`` (shown
+    by ``print(a)``). It also depends on exactly how ``a`` is stored in
+    memory. Therefore if ``a`` is C-ordered versus fortran-ordered, versus
+    defined as a slice or transpose, etc., the view may give different
+    results.
 
 
     Examples

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2889,12 +2889,15 @@ class MaskedArray(ndarray):
         `dtype` is an ndarray sub-class), then the fill value is preserved.
         Finally, if `fill_value` is specified, but `dtype` is not, the fill
         value is set to the specified value.
-        
-        In cases when ``a.view(some_dtype)`` causes a reinterpretation of the
-        bytes of memory, its behavior cannot necessarily be predicted just from
-        the superficial appearance of ``a`` (shown by ``print(a)``). If ``a`` is
-        C-ordered versus fortran-ordered, versus defined as a transpose, versus
-        defined as a slice, etc., the view may give different results.
+
+        For ``a.view(some_dtype)``, if ``some_dtype`` has a different number of
+        bytes per entry than the previous dtype (for example, converting a
+        regular array to a structured array), then the behavior of the view
+        cannot be predicted just from the superficial appearance of ``a`` (shown
+        by ``print(a)``). It also depends on exactly how ``a`` is stored in
+        memory. Therefore if ``a`` is C-ordered versus fortran-ordered, versus
+        defined as a slice or transpose, etc., the view may give different
+        results.
         """
 
         if dtype is None:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2889,6 +2889,12 @@ class MaskedArray(ndarray):
         `dtype` is an ndarray sub-class), then the fill value is preserved.
         Finally, if `fill_value` is specified, but `dtype` is not, the fill
         value is set to the specified value.
+        
+        In cases when ``a.view(some_dtype)`` causes a reinterpretation of the
+        bytes of memory, its behavior cannot necessarily be predicted just from
+        the superficial appearance of ``a`` (shown by ``print(a)``). If ``a`` is
+        C-ordered versus fortran-ordered, versus defined as a transpose, versus
+        defined as a slice, etc., the view may give different results.
         """
 
         if dtype is None:


### PR DESCRIPTION
Since most numpy operations are not sensitive to underlying data structure (C-ordered arrays vs fortran-ordered arrays, versus slices or transposes of arrays, etc.), but structured-array views ARE sensitive to that, it is worth saying it explicitly in the documentation.

See https://github.com/numpy/numpy/issues/2958
