### PR TITLE
ENH: Use tp_basicsize, not NPY_SIZEOF_PYARRAYOBJECT, for allocation

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1655,7 +1655,7 @@ array_alloc(PyTypeObject *type, Py_ssize_t NPY_UNUSED(nitems))
 {
     PyObject *obj;
     /* nitems will always be 0 */
-    obj = (PyObject *)PyArray_malloc(NPY_SIZEOF_PYARRAYOBJECT);
+    obj = (PyObject *)PyArray_malloc(type->tp_basicsize);
     PyObject_Init(obj, type);
     return obj;
 }


### PR DESCRIPTION
This change allows C-API level subtypes of PyArray_Type without forcing the developer to rewrite the tp_alloc function and only change the amount of memory allocated.
