### PR TITLE
BUG: Make nansum work with booleans.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1381,8 +1381,10 @@ def _nanop(op, fill, a, axis=None):
     y = array(a, subok=True)
 
     # We only need to take care of NaN's in floating point arrays
-    if np.issubdtype(y.dtype, np.integer):
+    dt = y.dtype
+    if np.issubdtype(dt, np.integer) or np.issubdtype(dt, np.bool_):
         return op(y, axis=axis)
+
     mask = isnan(a)
     # y[mask] = fill
     # We can't use fancy indexing here as it'll mess w/ MaskedArrays

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -218,5 +218,14 @@ class TestRegression(TestCase):
         data = [((((0,1), (2,3), (4,5)), ((6,7), (8,9), (10,11))),)]
         assert_equal(x, np.array(data, dtype=dt))
 
+    def test_nansum_with_boolean(self):
+        # gh-2978
+        a = np.zeros(2, dtype=np.bool)
+        try:
+            np.nansum(a)
+        except:
+            raise AssertionError()
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This broke when function_base._nannop tried to fill a boolean array with
integer zeros, raising a 'safe_casting' error. It looks like nanargmax and
nanargmin would also break, and were probably incorrect for booleans in any
case. The fix is not to use fill values for boolean and integer dtypes.
Previously that was only done for the integer dtypes.
