### PR TITLE
BUG: gh-2687 make multiarray dot method accept out array and keyword args

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1847,10 +1847,11 @@ array_cumprod(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    PyObject *b;
+    PyObject *b, *out = NULL;
     static PyObject *numpycore = NULL;
+    char * kwords[] = {"b", "out", NULL };
 
-    if (!PyArg_ParseTuple(args, "O", &b)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwords, &b, &out)) { 
         return NULL;
     }
 
@@ -1862,8 +1863,10 @@ array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
     }
-
-    return PyObject_CallMethod(numpycore, "dot", "OO", self, b);
+    if (out == NULL) {
+        return PyObject_CallMethod(numpycore, "dot", "OO", self, b);
+    }
+    return PyObject_CallMethod(numpycore, "dot", "OOO", self, b, out);
 }
 
 
@@ -2222,7 +2225,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"dot",
         (PyCFunction)array_dot,
-        METH_VARARGS, NULL},
+        METH_VARARGS | METH_KEYWORDS, NULL},
     {"fill",
         (PyCFunction)array_fill,
         METH_VARARGS, NULL},

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1847,7 +1847,7 @@ array_cumprod(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    PyObject *b, *out = NULL;
+    PyObject *fname, *ret, *b, *out = NULL;
     static PyObject *numpycore = NULL;
     char * kwords[] = {"b", "out", NULL };
 
@@ -1863,10 +1863,13 @@ array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
     }
+    fname = PyString_FromString("dot");
     if (out == NULL) {
-        return PyObject_CallMethod(numpycore, "dot", "OO", self, b);
+        ret = PyObject_CallMethodObjArgs(numpycore, fname, self, b, NULL);
     }
-    return PyObject_CallMethod(numpycore, "dot", "OOO", self, b, out);
+    ret = PyObject_CallMethodObjArgs(numpycore, fname, self, b, out, NULL);
+    Py_DECREF(fname);
+    return ret;
 }
 
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1863,7 +1863,7 @@ array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
     }
-    fname = PyString_FromString("dot");
+    fname = PyUnicode_FromString("dot");
     if (out == NULL) {
         ret = PyObject_CallMethodObjArgs(numpycore, fname, self, b, NULL);
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1863,7 +1863,7 @@ array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
     }
-    fname = PyUnicode_FromString("dot");
+    fname = PyUString_FromString("dot");
     if (out == NULL) {
         ret = PyObject_CallMethodObjArgs(numpycore, fname, self, b, NULL);
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -902,6 +902,14 @@ class TestMethods(TestCase):
         assert_equal(np.dot(a, b), a.dot(b))
         assert_equal(np.dot(np.dot(a, b), c), a.dot(b).dot(c))
 
+        # test changes from gh-2687 (trac 2096)
+        c = np.zeros_like(a)
+        a.dot(b,c)
+        assert_equal(c, np.dot(a,b))
+        c = np.zeros_like(a)
+        a.dot(b=b,out=c)
+        assert_equal(c, np.dot(a,b))
+
     def test_diagonal(self):
         a = np.arange(12).reshape((3, 4))
         assert_equal(a.diagonal(), [0, 5, 10])

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -902,10 +902,12 @@ class TestMethods(TestCase):
         assert_equal(np.dot(a, b), a.dot(b))
         assert_equal(np.dot(np.dot(a, b), c), a.dot(b).dot(c))
 
-        # test changes from gh-2687 (trac 2096)
+        # test passing in an output array 
         c = np.zeros_like(a)
         a.dot(b,c)
         assert_equal(c, np.dot(a,b))
+        
+        # test keyword args
         c = np.zeros_like(a)
         a.dot(b=b,out=c)
         assert_equal(c, np.dot(a,b))


### PR DESCRIPTION
Fixes #2687 and makes the docs for ndarray.dot be correct.
