### PR TITLE
ENH: add `inverse` parameter to numpy.in1d().

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -66,10 +66,14 @@ without needing to convert to a matrix. The 'economic' mode is simply
 deprecated, there isn't much use for it and it isn't any more efficient
 than the 'raw' mode.
 
+New `invert` argument to `in1d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The function `in1d` now accepts a `invert` argument which, when `True`,
+causes the returned array to be inverted.
 
 C-API
 ~~~~~
-
 
 Changes
 =======

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -190,6 +190,15 @@ class TestSetOps(TestCase):
 
         assert_array_equal(c, ec)
 
+    def test_in1d_invert(self):
+        "Test in1d's invert parameter"
+        # We use two different sizes for the b array here to test the
+        # two different paths in in1d().
+        for mult in (1, 10):
+            a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
+            b = [2, 3, 4] * mult
+            assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
+
     def test_in1d_ravel(self):
         # Test that in1d ravels its input arrays. This is not documented
         # behavior however. The test is to ensure consistentency.

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1121,7 +1121,7 @@ def setxor1d(ar1, ar2, assume_unique=False):
     flag2 = (flag[1:] == flag[:-1])
     return aux[flag2]
 
-def in1d(ar1, ar2, assume_unique=False):
+def in1d(ar1, ar2, assume_unique=False, invert=False):
     """
     Test whether each element of an array is also present in a second
     array.
@@ -1147,8 +1147,11 @@ def in1d(ar1, ar2, assume_unique=False):
     # the values from the second array.
     order = ar.argsort(kind='mergesort')
     sar = ar[order]
-    equal_adj = (sar[1:] == sar[:-1])
-    flag = ma.concatenate((equal_adj, [False]))
+    if invert:
+        bool_ar = (sar[1:] != sar[:-1])
+    else:
+        bool_ar = (sar[1:] == sar[:-1])
+    flag = ma.concatenate((bool_ar, [invert]))
     indx = order.argsort(kind='mergesort')[:len(ar1)]
 
     if assume_unique:

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -810,6 +810,19 @@ class TestArraySetOps(TestCase):
         assert_array_equal([], in1d([], []))
 
 
+    def test_in1d_invert(self):
+        "Test in1d's invert parameter"
+        a = array([1, 2, 5, 7, -1], mask=[0, 0, 0, 0, 1])
+        b = array([1, 2, 3, 4, 5, -1], mask=[0, 0, 0, 0, 0, 1])
+        assert_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
+
+        a = array([5, 5, 2, 1, -1], mask=[0, 0, 0, 0, 1])
+        b = array([1, 5, -1], mask=[0, 0, 1])
+        assert_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
+
+        assert_array_equal([], in1d([], [], invert=True))
+
+
     def test_union1d(self):
         "Test union1d"
         a = array([1, 2, 5, 7, 5, -1], mask=[0, 0, 0, 0, 0, 1])


### PR DESCRIPTION
This is equivalent to doing a 'not in' operation in a way that is faster than doing `np.invert(in1d(a, b))`.

If you think that adding a new `notin1d()` function would be better than adding this new `inverse` parameter to `in1d()`, let me know and I can update the patch (although that will probably require duplicating a lot of code from `in1d()`).

Thanks!
