### PR TITLE
Backport gh-3006

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -633,6 +633,7 @@ array_toscalar(PyArrayObject *self, PyObject *args)
         else {
             PyErr_SetString(PyExc_ValueError,
                     "can only convert an array of size 1 to a Python scalar");
+            return NULL;
         }
     }
     /* Special case of C-order flat indexing... :| */

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1032,6 +1032,11 @@ class TestRegression(TestCase):
         assert_( a[0].tolist() == b[0])
         assert_( a[1].tolist() == b[1])
 
+    def test_nonscalar_item_method(self):
+        # Make sure that .item() fails graciously when it should
+        a = np.arange(5)
+        assert_raises(ValueError, a.item)
+
     def test_char_array_creation(self, level=rlevel):
         a = np.array('123', dtype='c')
         b = np.array(asbytes_nested(['1','2','3']))


### PR DESCRIPTION
Appearently .item() for arrays with size != 1 correctly returned an error
in 1.6., but failed to raise the error (due to missing return) in 1.7.
## 

gh-3006 backport
