### PR TITLE
FIX: Make nditer work for 0-d iterations.

### DIFF
--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -658,15 +658,29 @@ Construction and Destruction
             without simultaneously iterating over the mask, and this
             flag allows that to be done.
 
+        .. cvar:: NPY_ITER_USE_ZERO_OA_NDIM
+
+            .. versionadded:: 1.8
+
+            If this flag is set ``oa_ndim == 0`` is used to signal a scalar
+            iteration. If it is not set zero would mean that ``op_axes``
+            and ``itershape`` are not used. This flag should be used and
+            will become default so -1 should be used to signal that the
+            feature is not used even when the flag is not set.
+
+            When using ``oa_ndim == 0`` you may need to be careful to not
+            pass NULL in ``op_axes`` or for ``itershape``, because for
+            example ``malloc(0)`` may be NULL, but NULL signals unused.
+
 .. cfunction:: NpyIter* NpyIter_AdvancedNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
 
     Extends :cfunc:`NpyIter_MultiNew` with several advanced options providing
     more control over broadcasting and buffering.
 
-    If 0/NULL values are passed to ``oa_ndim``, ``op_axes``, ``itershape``,
+    If -1/NULL values are passed to ``oa_ndim``, ``op_axes``, ``itershape``,
     and ``buffersize``, it is equivalent to :cfunc:`NpyIter_MultiNew`.
 
-    The parameter ``oa_ndim``, when non-zero, specifies the number of
+    The parameter ``oa_ndim``, when not -1, specifies the number of
     dimensions that will be iterated with customized broadcasting.
     If it is provided, ``op_axes`` and/or ``itershape`` must also be provided.
     The ``op_axes`` parameter let you control in detail how the
@@ -701,6 +715,14 @@ Construction and Destruction
 
     Returns NULL if there is an error, otherwise returns the allocated
     iterator.
+    
+    .. note::
+        ``NPY_ITER_USE_ZERO_OA_NDIM`` should be used to allow ``oa_ndim == 0``
+        to signal a scalar iteration. Before NumPy 1.8. ``oa_ndim == 0`` was
+        used to signal that no ``op_axes`` or ``itershape`` were given.
+        If the flag is not set and ``oa_ndim`` is 0 it is interpreted as -1
+        instead for compatibility. Using the flag will make iterations using
+        ``oa_ndim`` work with scalars easier.
 
 .. cfunction:: NpyIter* NpyIter_Copy(NpyIter* iter)
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -980,6 +980,8 @@ typedef void (NpyIter_GetMultiIndexFunc)(NpyIter *iter,
 #define NPY_ITER_DELAY_BUFALLOC             0x00000800
 /* When NPY_KEEPORDER is specified, disable reversing negative-stride axes */
 #define NPY_ITER_DONT_NEGATE_STRIDES        0x00001000
+/* Use oa_ndim == 0 for scalar iteration and oa_ndim == -1 for unspecified */
+#define NPY_ITER_USE_ZERO_OA_NDIM           0x00002000
 
 /*** Per-operand flags that may be passed to the iterator constructors ***/
 

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -3001,6 +3001,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
     /* Allocate the iterator */
     iter = NpyIter_AdvancedNew(nop+1, op, NPY_ITER_EXTERNAL_LOOP|
                 ((dtype != NULL) ? 0 : NPY_ITER_COMMON_DTYPE)|
+                                       NPY_ITER_USE_ZERO_OA_NDIM|
                                        NPY_ITER_BUFFERED|
                                        NPY_ITER_DELAY_BUFALLOC|
                                        NPY_ITER_GROWINNER|

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -967,6 +967,11 @@ PyArray_TransferNDimToStrided(npy_intp ndim,
 {
     npy_intp i, M, N, coord0, shape0, src_stride0, coord1, shape1, src_stride1;
 
+    if (ndim == 0) {
+        stransfer(dst, 0, src, src_itemsize, 1, src_itemsize, data);
+        return 1;
+    }
+
     /* Finish off dimension 0 */
     coord0 = coords[0];
     shape0 = shape[0];
@@ -1085,6 +1090,11 @@ PyArray_TransferStridedToNDim(npy_intp ndim,
                 NpyAuxData *data)
 {
     npy_intp i, M, N, coord0, shape0, dst_stride0, coord1, shape1, dst_stride1;
+
+    if (ndim == 0) {
+        stransfer(dst, 0, src, src_itemsize, 1, src_itemsize, data);
+        return 1;
+    }
 
     /* Finish off dimension 0 */
     coord0 = coords[0];

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1751,6 +1751,8 @@ npyiter_goto_iterindex(NpyIter *iter, npy_intp iterindex)
 
     NIT_ITERINDEX(iter) = iterindex;
 
+    ndim = ndim ? ndim : 1;
+
     if (iterindex == 0) {
         dataptr = NIT_RESETDATAPTR(iter);
 

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -134,12 +134,10 @@ NpyIter_RemoveAxis(NpyIter *iter, int axis)
     axisdata = NIT_INDEX_AXISDATA(axisdata_del, 1);
     memmove(axisdata_del, axisdata, (ndim-1-xdim)*sizeof_axisdata);
 
-    /* If there is more than one dimension, shrink the iterator */
-    if (ndim > 1) {
-        NIT_NDIM(iter) = ndim-1;
-    }
-    /* Otherwise convert it to a singleton dimension */
-    else {
+    /* Shrink the iterator */
+    NIT_NDIM(iter) = ndim - 1;
+    /* If it is now 0-d fill the singleton dimension */
+    if (ndim == 1) {
         npy_intp *strides = NAD_STRIDES(axisdata_del);
         NAD_SHAPE(axisdata_del) = 1;
         for (iop = 0; iop < nop; ++iop) {
@@ -642,6 +640,9 @@ NpyIter_GetIterIndex(NpyIter *iter)
         npy_intp sizeof_axisdata;
 
         iterindex = 0;
+        if (ndim == 0) {
+            return 0;
+        }
         sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
         axisdata = NIT_INDEX_AXISDATA(NIT_AXISDATA(iter), ndim-1);
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -499,7 +499,7 @@ NpyIter_MultiNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
 {
     return NpyIter_AdvancedNew(nop, op_in, flags, order, casting,
                             op_flags, op_request_dtypes,
-                            0, NULL, NULL, 0);
+                            -1, NULL, NULL, 0);
 }
 
 /*NUMPY_API
@@ -516,7 +516,7 @@ NpyIter_New(PyArrayObject *op, npy_uint32 flags,
 
     return NpyIter_AdvancedNew(1, &op, flags, order, casting,
                             &op_flags, &dtype,
-                            0, NULL, NULL, 0);
+                            -1, NULL, NULL, 0);
 }
 
 /*NUMPY_API

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -762,10 +762,6 @@ npyiter_check_op_axes(int nop, int oa_ndim, int **op_axes,
         }
         return 1;
     }
-    else if (oa_ndim == 0) {
-        /* itershape/op_axes are never read, so they can be NULL */
-        return 1;
-    }
     else if (oa_ndim > NPY_MAXDIMS) {
         PyErr_Format(PyExc_ValueError,
                 "Cannot construct an iterator with more than %d dimensions "
@@ -775,7 +771,7 @@ npyiter_check_op_axes(int nop, int oa_ndim, int **op_axes,
     }
     else if (op_axes == NULL) {
         PyErr_Format(PyExc_ValueError,
-                "If 'oa_ndim' is greater than zero in the iterator "
+                "If 'oa_ndim' is zero or greater in the iterator "
                 "constructor, then op_axes cannot be NULL");
         return 0;
     }

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -294,7 +294,7 @@ struct NpyIter_AD {
 #define NIT_SIZEOF_ITERATOR(itflags, ndim, nop) ( \
         sizeof(struct NpyIter_InternalOnly) + \
         NIT_AXISDATA_OFFSET(itflags, ndim, nop) + \
-        NIT_AXISDATA_SIZEOF(itflags, ndim, nop)*(ndim))
+        NIT_AXISDATA_SIZEOF(itflags, ndim, nop)*(ndim ? ndim : 1))
 
 /* Internal helper functions shared between implementation files */
 NPY_NO_EXPORT void

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -786,7 +786,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     if (itershape.len > 0) {
         if (oa_ndim == 0) {
             oa_ndim = itershape.len;
-            memset(op_axes, 0, sizeof(op_axes[0])*oa_ndim);
+            memset(op_axes, 0, sizeof(op_axes[0]) * nop);
         }
         else if (oa_ndim != itershape.len) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -95,7 +95,6 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
     npy_uint32 flag;
 
     if (flags_in == NULL || flags_in == Py_None) {
-        *flags = 0;
         return 1;
     }
 
@@ -526,7 +525,7 @@ npyiter_convert_op_axes(PyObject *op_axes_in, npy_intp nop,
         return 0;
     }
 
-    *oa_ndim = 0;
+    *oa_ndim = -1;
 
     /* Copy the tuples into op_axes */
     for (iop = 0; iop < nop; ++iop) {
@@ -545,13 +544,8 @@ npyiter_convert_op_axes(PyObject *op_axes_in, npy_intp nop,
                 Py_DECREF(a);
                 return 0;
             }
-            if (*oa_ndim == 0) {
+            if (*oa_ndim == -1) {
                 *oa_ndim = PySequence_Size(a);
-                if (*oa_ndim == 0) {
-                    PyErr_SetString(PyExc_ValueError,
-                            "op_axes must have at least one dimension");
-                    return 0;
-                }
                 if (*oa_ndim > NPY_MAXDIMS) {
                     PyErr_SetString(PyExc_ValueError,
                             "Too many dimensions in op_axes");
@@ -575,7 +569,7 @@ npyiter_convert_op_axes(PyObject *op_axes_in, npy_intp nop,
                     op_axes[iop][idim] = -1;
                 }
                 else {
-                    op_axes[iop][idim] = PyInt_AsLong(v);
+                    op_axes[iop][idim] = PyArray_PyIntAsInt(v);
                     if (op_axes[iop][idim]==-1 &&
                                                 PyErr_Occurred()) {
                         Py_DECREF(a);
@@ -589,7 +583,7 @@ npyiter_convert_op_axes(PyObject *op_axes_in, npy_intp nop,
         }
     }
 
-    if (*oa_ndim == 0) {
+    if (*oa_ndim == -1) {
         PyErr_SetString(PyExc_ValueError,
                 "If op_axes is provided, at least one list of axes "
                 "must be contained within it");
@@ -721,12 +715,12 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
 
     int iop, nop = 0;
     PyArrayObject *op[NPY_MAXARGS];
-    npy_uint32 flags = 0;
+    npy_uint32 flags = NPY_ITER_USE_ZERO_OA_NDIM;
     NPY_ORDER order = NPY_KEEPORDER;
     NPY_CASTING casting = NPY_SAFE_CASTING;
     npy_uint32 op_flags[NPY_MAXARGS];
     PyArray_Descr *op_request_dtypes[NPY_MAXARGS];
-    int oa_ndim = 0;
+    int oa_ndim = -1;
     int op_axes_arrays[NPY_MAXARGS][NPY_MAXDIMS];
     int *op_axes[NPY_MAXARGS];
     PyArray_Dims itershape = {NULL, 0};
@@ -784,7 +778,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (itershape.len > 0) {
-        if (oa_ndim == 0) {
+        if (oa_ndim == -1) {
             oa_ndim = itershape.len;
             memset(op_axes, 0, sizeof(op_axes[0]) * nop);
         }
@@ -800,10 +794,9 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
         itershape.ptr = NULL;
     }
 
-
     self->iter = NpyIter_AdvancedNew(nop, op, flags, order, casting, op_flags,
                                   op_request_dtypes,
-                                  oa_ndim, oa_ndim > 0 ? op_axes : NULL,
+                                  oa_ndim, oa_ndim >= 0 ? op_axes : NULL,
                                   itershape.ptr,
                                   buffersize);
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -853,7 +853,7 @@ NpyIter_NestedIters(PyObject *NPY_UNUSED(self),
 
     int iop, nop = 0, inest, nnest = 0;
     PyArrayObject *op[NPY_MAXARGS];
-    npy_uint32 flags = 0, flags_inner = 0;
+    npy_uint32 flags = NPY_ITER_USE_ZERO_OA_NDIM, flags_inner;
     NPY_ORDER order = NPY_KEEPORDER;
     NPY_CASTING casting = NPY_SAFE_CASTING;
     npy_uint32 op_flags[NPY_MAXARGS], op_flags_inner[NPY_MAXARGS];

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -513,7 +513,7 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
                                NPY_KEEPORDER, casting,
                                op_flags,
                                op_dtypes,
-                               0, NULL, NULL, buffersize);
+                               -1, NULL, NULL, buffersize);
     if (iter == NULL) {
         goto fail;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1205,7 +1205,7 @@ iterator_loop(PyUFuncObject *ufunc,
                         NPY_ITER_DELAY_BUFALLOC,
                         order, NPY_UNSAFE_CASTING,
                         op_flags, dtype,
-                        0, NULL, NULL, buffersize);
+                        -1, NULL, NULL, buffersize);
     if (iter == NULL) {
         return -1;
     }
@@ -1503,7 +1503,7 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                         NPY_ITER_GROWINNER,
                         order, NPY_UNSAFE_CASTING,
                         op_flags, dtypes,
-                        0, NULL, NULL, buffersize);
+                        -1, NULL, NULL, buffersize);
     if (iter == NULL) {
         return -1;
     }

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -239,6 +239,7 @@ class TestEinSum(TestCase):
             assert_equal(np.einsum(a, [0,0]), np.trace(a).astype(dtype))
 
         # multiply(a, b)
+        assert_equal(np.einsum("..., ...", 3, 4), 12) # check scalars
         for n in range(1,17):
             a = np.arange(3*n, dtype=dtype).reshape(3,n)
             b = np.arange(2*3*n, dtype=dtype).reshape(2,3,n)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -598,6 +598,8 @@ def test_iter_itershape():
                             [['readonly'], ['writeonly','allocate']],
                             op_axes=[[0,1,None], None],
                             itershape=(-1,1,4))
+    # Test bug that for no op_axes but itershape, they are NULLed correctly
+    i = np.nditer([np.ones(2), None, None], itershape=(2,))
 
 def test_iter_broadcasting_errors():
     # Check that errors are thrown for bad broadcasting shapes

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2482,6 +2482,12 @@ def test_0d_iter():
     assert_(i.next() == (2, 3))
     assert_raises(StopIteration, i.next)
 
+    # test forcing to 0-d
+    i = nditer(np.arange(5), ['multi_index'], [['readonly']]*2, op_axes=[()])
+    assert_(i.ndim == 0)
+    assert_(len(i) == 1)
+    # note that itershape=(), still behaves like None due to the conversions
+
     # Test a more complex buffered casting case (same as another test above)
     sdt = [('a', 'f4'), ('b', 'i8'), ('c', 'c8', (2,3)), ('d', 'O')]
     a = np.array(0.5, dtype='f4')

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2483,7 +2483,7 @@ def test_0d_iter():
     assert_raises(StopIteration, i.next)
 
     # test forcing to 0-d
-    i = nditer(np.arange(5), ['multi_index'], [['readonly']]*2, op_axes=[()])
+    i = nditer(np.arange(5), ['multi_index'], [['readonly']], op_axes=[()])
     assert_(i.ndim == 0)
     assert_(len(i) == 1)
     # note that itershape=(), still behaves like None due to the conversions
@@ -2498,6 +2498,28 @@ def test_0d_iter():
     assert_equal(vals['b'], 0)
     assert_equal(vals['c'], [[(0.5)]*3]*2)
     assert_equal(vals['d'], 0.5)
+
+
+def test_0d_nested_iter():
+    a = np.arange(12).reshape(2,3,2)
+    i, j = np.nested_iters(a, [[],[1,0,2]])
+    vals = []
+    for x in i:
+        vals.append([y for y in j])
+    assert_equal(vals, [[0,1,2,3,4,5,6,7,8,9,10,11]])
+
+    i, j = np.nested_iters(a, [[1,0,2],[]])
+    vals = []
+    for x in i:
+        vals.append([y for y in j])
+    assert_equal(vals, [[0],[1],[2],[3],[4],[5],[6],[7],[8],[9],[10],[11]])
+
+    i, j, k = np.nested_iters(a, [[2,0], [] ,[1]])
+    vals = []
+    for x in i:
+        for y in j:
+            vals.append([z for z in k])
+    assert_equal(vals, [[0,2,4],[1,3,5],[6,8,10],[7,9,11]])
 
 
 if __name__ == "__main__":

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -530,30 +530,7 @@ class ndindex(object):
     (2, 0, 0)
     (2, 1, 0)
 
-    """
-    # This is a hack to handle 0-d arrays correctly.
-    # Fixing nditer would be more work but should be done eventually,
-    #  and then this entire __new__ method can be removed.
-    def __new__(cls, *shape):
-        if len(shape) == 1 and isinstance(shape[0], tuple):
-           shape = shape[0]
-        if len(shape) == 0:
-            class zero_dim_iter(object):
-                def __init__(self):
-                    self._N = 1
-                def __iter__(self):
-                    return self
-                def ndincr(self):
-                    self.next()
-                def next(self):
-                    if self._N > 0:
-                        self._N -= 1
-                        return ()
-                    raise StopIteration
-            return zero_dim_iter()
-        else:
-            return super(ndindex, cls).__new__(cls)
-            
+    """     
     def __init__(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], tuple):
             shape = shape[0]


### PR DESCRIPTION
There are relatively few changes necessare here. However there is a
conceptionally cleaner fix by not using axisdata at all,
sice the 0-d iterator does not have any axisdata, but on first it
seems it would require more thourough fixes for the buffers, and maybe
even more special cases.

This instead uses one axisdata and just makes sure that it is filled
fine, so that later code can assume that at least one axisdata exists and
has correct pointers to the data.

The dtype transfer functions in lowlevel_strided_loops did not support
ndim=0 as well, so a check is added there.
## 

I am really not sure if this is the proper way to fix it or not. Somewhat it would seem nicer to just not use axisdata at all, but thought I would put it out there anyway. Also since the iterator seems to assume that axisdata carries all the important pointers, while they are available elsewhere, that might just be more special cases. (But I mostly reverse engineered which changes made things work, so not sure about the details of nditer). One thing that is not so nice is that probably at some places pointers are carried around inside nditer that must not be used.

These fixes for example:

``` python
>>> np.einsum('...,...', 3, 4)
12
>>> i = np.nditer(np.array(-123), op_axes=[()], flags=['multi_index'])
>>> i.next()
array(-123)
```

and makes that ndindex hack unnecessary. valgrind does not report anything that worries me, but of course thorough tests are missing for now.
