### PR TITLE
2to3: Mark legitimate python3 uses of range by using xrange instead.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -1009,7 +1009,7 @@ add_newdoc('numpy.core.multiarray', 'fromiter',
 
     Examples
     --------
-    >>> iterable = (x*x for x in range(5))
+    >>> iterable = (x*x for x in xrange(5))
     >>> np.fromiter(iterable, np.float)
     array([  0.,   1.,   4.,   9.,  16.])
 
@@ -4813,7 +4813,7 @@ add_newdoc('numpy.lib._compiled_base', 'digitize',
     >>> inds = np.digitize(x, bins)
     >>> inds
     array([1, 4, 3, 2])
-    >>> for n in range(x.size):
+    >>> for n in xrange(x.size):
     ...   print bins[inds[n]-1], "<=", x[n], "<", bins[inds[n]]
     ...
     0.0 <= 0.2 < 1.0

--- a/numpy/build_utils/common.py
+++ b/numpy/build_utils/common.py
@@ -43,7 +43,7 @@ def pyod(filename):
         fid = open(filename, 'r')
         try:
             yo = [int(oct(int(binascii.b2a_hex(o), 16))) for o in fid.read()]
-            for i in range(0, len(yo), 16):
+            for i in xrange(0, len(yo), 16):
                 line = ['%07d' % int(oct(i))]
                 line.extend(['%03d' % c for c in yo[i:i+16]])
                 out.append(" ".join(line))
@@ -57,7 +57,7 @@ def pyod(filename):
         fid = open(filename, 'rb')
         try:
             yo2 = [oct(o)[2:] for o in fid.read()]
-            for i in range(0, len(yo2), 16):
+            for i in xrange(0, len(yo2), 16):
                 line = ['%07d' % int(oct(i)[2:])]
                 line.extend(['%03d' % int(c) for c in yo2[i:i+16]])
                 out.append(" ".join(line))

--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -73,7 +73,7 @@ def getargs(co):
     step = 0
 
     # The following acrobatics are for anonymous (tuple) arguments.
-    for i in range(nargs):
+    for i in xrange(nargs):
         if args[i][:1] in ['', '.']:
             stack, remain, count = [], [], []
             while step < len(code):
@@ -169,7 +169,7 @@ def formatargspec(args, varargs=None, varkw=None, defaults=None,
     specs = []
     if defaults:
         firstdefault = len(args) - len(defaults)
-    for i in range(len(args)):
+    for i in xrange(len(args)):
         spec = strseq(args[i], formatarg, join)
         if defaults and i >= firstdefault:
             spec = spec + formatvalue(defaults[i - firstdefault])
@@ -196,7 +196,7 @@ def formatargvalues(args, varargs, varkw, locals,
                 formatarg=formatarg, formatvalue=formatvalue):
         return formatarg(name) + formatvalue(locals[name])
     specs = []
-    for i in range(len(args)):
+    for i in xrange(len(args)):
         specs.append(strseq(args[i], convert, join))
     if varargs:
         specs.append(formatvarargs(varargs) + formatvalue(locals[varargs]))

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -203,12 +203,12 @@ def _leading_trailing(a):
             b = a
     else:
         if len(a) > 2*_summaryEdgeItems:
-            l = [_leading_trailing(a[i]) for i in range(
+            l = [_leading_trailing(a[i]) for i in xrange(
                 min(len(a), _summaryEdgeItems))]
-            l.extend([_leading_trailing(a[-i]) for i in range(
+            l.extend([_leading_trailing(a[-i]) for i in xrange(
                 min(len(a), _summaryEdgeItems),0,-1)])
         else:
-            l = [_leading_trailing(a[i]) for i in range(0, len(a))]
+            l = [_leading_trailing(a[i]) for i in xrange(0, len(a))]
         b = _nc.concatenate(tuple(l))
     return b
 

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -177,7 +177,7 @@ class MachAr(object):
         negep = it + 3
         betain = one / beta
         a = one
-        for i in range(negep):
+        for i in xrange(negep):
             a = a * betain
         b = a
         for _ in xrange(max_iterN):
@@ -285,7 +285,7 @@ class MachAr(object):
             xmax = one - beta*epsneg
         xmax = xmax / (xmin*beta*beta*beta)
         i = maxexp + minexp + 3
-        for j in range(i):
+        for j in xrange(i):
             if ibeta==2:
                 xmax = xmax + xmax
             else:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -975,10 +975,10 @@ def tensordot(a, b, axes=2):
            [ 4928.,  5306.]])
     >>> # A slower but equivalent way of computing the same...
     >>> d = np.zeros((5,2))
-    >>> for i in range(5):
-    ...   for j in range(2):
-    ...     for k in range(3):
-    ...       for n in range(4):
+    >>> for i in xrange(5):
+    ...   for j in xrange(2):
+    ...     for k in xrange(3):
+    ...       for n in xrange(4):
     ...         d[i,j] += a[k,n,i] * b[n,k,j]
     >>> c == d
     array([[ True,  True],
@@ -1075,7 +1075,7 @@ def tensordot(a, b, axes=2):
 
     # Move the axes to sum over to the end of "a"
     # and to the front of "b"
-    notin = [k for k in range(nda) if k not in axes_a]
+    notin = [k for k in xrange(nda) if k not in axes_a]
     newaxes_a = notin + axes_a
     N2 = 1
     for axis in axes_a:
@@ -1083,7 +1083,7 @@ def tensordot(a, b, axes=2):
     newshape_a = (-1, N2)
     olda = [as_[axis] for axis in notin]
 
-    notin = [k for k in range(ndb) if k not in axes_b]
+    notin = [k for k in xrange(ndb) if k not in axes_b]
     newaxes_b = axes_b + notin
     N2 = 1
     for axis in axes_b:

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -74,7 +74,7 @@ _typestr = nt._typestr
 def find_duplicate(list):
     """Find duplication in a list, return a list of duplicated elements"""
     dup = []
-    for i in range(len(list)):
+    for i in xrange(len(list)):
         if (list[i] in list[i + 1:]):
             if (list[i] not in dup):
                 dup.append(list[i])
@@ -184,7 +184,7 @@ class format_parser:
         #  "f0, f1, f2,..."
         # if not enough names are specified, they will be assigned as "f[n],
         # f[n+1],..." etc. where n is the number of specified names..."
-        self._names += ['f%d' % i for i in range(len(self._names),
+        self._names += ['f%d' % i for i in xrange(len(self._names),
                                                  self._nfields)]
         # check for redundant names
         _dup = find_duplicate(self._names)
@@ -562,7 +562,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
     _array = recarray(shape, descr)
 
     # populate the record array (makes a copy)
-    for i in range(len(arrayList)):
+    for i in xrange(len(arrayList)):
         _array[_names[i]] = arrayList[i]
 
     return _array

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -179,7 +179,7 @@ def pyod(filename):
         fid = open(filename, 'rb')
         try:
             yo = [int(oct(int(binascii.b2a_hex(o), 16))) for o in fid.read()]
-            for i in range(0, len(yo), 16):
+            for i in xrange(0, len(yo), 16):
                 line = ['%07d' % int(oct(i))]
                 line.extend(['%03d' % c for c in yo[i:i+16]])
                 out.append(" ".join(line))
@@ -193,7 +193,7 @@ def pyod(filename):
         fid = open(filename, 'rb')
         try:
             yo2 = [oct(o)[2:] for o in fid.read()]
-            for i in range(0, len(yo2), 16):
+            for i in xrange(0, len(yo2), 16):
                 line = ['%07d' % int(oct(i)[2:])]
                 line.extend(['%03d' % int(c) for c in yo2[i:i+16]])
                 out.append(" ".join(line))

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -106,11 +106,11 @@ class TestEinSum(TestCase):
 
         b = np.einsum("ii->i", a)
         assert_(b.base is a)
-        assert_equal(b, [a[i,i] for i in range(3)])
+        assert_equal(b, [a[i,i] for i in xrange(3)])
 
         b = np.einsum(a, [0,0], [0])
         assert_(b.base is a)
-        assert_equal(b, [a[i,i] for i in range(3)])
+        assert_equal(b, [a[i,i] for i in xrange(3)])
 
         # diagonal with various ways of broadcasting an additional dimension
         a = np.arange(27)
@@ -118,62 +118,62 @@ class TestEinSum(TestCase):
 
         b = np.einsum("...ii->...i", a)
         assert_(b.base is a)
-        assert_equal(b, [[x[i,i] for i in range(3)] for x in a])
+        assert_equal(b, [[x[i,i] for i in xrange(3)] for x in a])
 
         b = np.einsum(a, [Ellipsis,0,0], [Ellipsis,0])
         assert_(b.base is a)
-        assert_equal(b, [[x[i,i] for i in range(3)] for x in a])
+        assert_equal(b, [[x[i,i] for i in xrange(3)] for x in a])
 
         b = np.einsum("ii...->...i", a)
         assert_(b.base is a)
-        assert_equal(b, [[x[i,i] for i in range(3)]
+        assert_equal(b, [[x[i,i] for i in xrange(3)]
                          for x in a.transpose(2,0,1)])
 
         b = np.einsum(a, [0,0,Ellipsis], [Ellipsis,0])
         assert_(b.base is a)
-        assert_equal(b, [[x[i,i] for i in range(3)]
+        assert_equal(b, [[x[i,i] for i in xrange(3)]
                          for x in a.transpose(2,0,1)])
 
         b = np.einsum("...ii->i...", a)
         assert_(b.base is a)
-        assert_equal(b, [a[:,i,i] for i in range(3)])
+        assert_equal(b, [a[:,i,i] for i in xrange(3)])
 
         b = np.einsum(a, [Ellipsis,0,0], [0,Ellipsis])
         assert_(b.base is a)
-        assert_equal(b, [a[:,i,i] for i in range(3)])
+        assert_equal(b, [a[:,i,i] for i in xrange(3)])
 
         b = np.einsum("jii->ij", a)
         assert_(b.base is a)
-        assert_equal(b, [a[:,i,i] for i in range(3)])
+        assert_equal(b, [a[:,i,i] for i in xrange(3)])
 
         b = np.einsum(a, [1,0,0], [0,1])
         assert_(b.base is a)
-        assert_equal(b, [a[:,i,i] for i in range(3)])
+        assert_equal(b, [a[:,i,i] for i in xrange(3)])
 
         b = np.einsum("ii...->i...", a)
         assert_(b.base is a)
-        assert_equal(b, [a.transpose(2,0,1)[:,i,i] for i in range(3)])
+        assert_equal(b, [a.transpose(2,0,1)[:,i,i] for i in xrange(3)])
 
         b = np.einsum(a, [0,0,Ellipsis], [0,Ellipsis])
         assert_(b.base is a)
-        assert_equal(b, [a.transpose(2,0,1)[:,i,i] for i in range(3)])
+        assert_equal(b, [a.transpose(2,0,1)[:,i,i] for i in xrange(3)])
 
         b = np.einsum("i...i->i...", a)
         assert_(b.base is a)
-        assert_equal(b, [a.transpose(1,0,2)[:,i,i] for i in range(3)])
+        assert_equal(b, [a.transpose(1,0,2)[:,i,i] for i in xrange(3)])
 
         b = np.einsum(a, [0,Ellipsis,0], [0,Ellipsis])
         assert_(b.base is a)
-        assert_equal(b, [a.transpose(1,0,2)[:,i,i] for i in range(3)])
+        assert_equal(b, [a.transpose(1,0,2)[:,i,i] for i in xrange(3)])
 
         b = np.einsum("i...i->...i", a)
         assert_(b.base is a)
-        assert_equal(b, [[x[i,i] for i in range(3)]
+        assert_equal(b, [[x[i,i] for i in xrange(3)]
                          for x in a.transpose(1,0,2)])
 
         b = np.einsum(a, [0,Ellipsis,0], [Ellipsis,0])
         assert_(b.base is a)
-        assert_equal(b, [[x[i,i] for i in range(3)]
+        assert_equal(b, [[x[i,i] for i in xrange(3)]
                          for x in a.transpose(1,0,2)])
 
         # triple diagonal
@@ -182,11 +182,11 @@ class TestEinSum(TestCase):
 
         b = np.einsum("iii->i", a)
         assert_(b.base is a)
-        assert_equal(b, [a[i,i,i] for i in range(3)])
+        assert_equal(b, [a[i,i,i] for i in xrange(3)])
 
         b = np.einsum(a, [0,0,0], [0])
         assert_(b.base is a)
-        assert_equal(b, [a[i,i,i] for i in range(3)])
+        assert_equal(b, [a[i,i,i] for i in xrange(3)])
 
         # swap axes
         a = np.arange(24)
@@ -204,13 +204,13 @@ class TestEinSum(TestCase):
         # Check various sums.  Does many sizes to exercise unrolled loops.
 
         # sum(a, axis=-1)
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(n, dtype=dtype)
             assert_equal(np.einsum("i->", a), np.sum(a, axis=-1).astype(dtype))
             assert_equal(np.einsum(a, [0], []),
                          np.sum(a, axis=-1).astype(dtype))
 
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(2*3*n, dtype=dtype).reshape(2,3,n)
             assert_equal(np.einsum("...i->...", a),
                          np.sum(a, axis=-1).astype(dtype))
@@ -218,14 +218,14 @@ class TestEinSum(TestCase):
                          np.sum(a, axis=-1).astype(dtype))
 
         # sum(a, axis=0)
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(2*n, dtype=dtype).reshape(2,n)
             assert_equal(np.einsum("i...->...", a),
                          np.sum(a, axis=0).astype(dtype))
             assert_equal(np.einsum(a, [0,Ellipsis], [Ellipsis]),
                          np.sum(a, axis=0).astype(dtype))
 
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(2*3*n, dtype=dtype).reshape(2,3,n)
             assert_equal(np.einsum("i...->...", a),
                          np.sum(a, axis=0).astype(dtype))
@@ -233,13 +233,13 @@ class TestEinSum(TestCase):
                          np.sum(a, axis=0).astype(dtype))
 
         # trace(a)
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(n*n, dtype=dtype).reshape(n,n)
             assert_equal(np.einsum("ii", a), np.trace(a).astype(dtype))
             assert_equal(np.einsum(a, [0,0]), np.trace(a).astype(dtype))
 
         # multiply(a, b)
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(3*n, dtype=dtype).reshape(3,n)
             b = np.arange(2*3*n, dtype=dtype).reshape(2,3,n)
             assert_equal(np.einsum("..., ...", a, b), np.multiply(a, b))
@@ -247,14 +247,14 @@ class TestEinSum(TestCase):
                          np.multiply(a, b))
 
         # inner(a,b)
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(2*3*n, dtype=dtype).reshape(2,3,n)
             b = np.arange(n, dtype=dtype)
             assert_equal(np.einsum("...i, ...i", a, b), np.inner(a, b))
             assert_equal(np.einsum(a, [Ellipsis,0], b, [Ellipsis,0]),
                          np.inner(a, b))
 
-        for n in range(1,11):
+        for n in xrange(1,11):
             a = np.arange(n*3*2, dtype=dtype).reshape(n,3,2)
             b = np.arange(n, dtype=dtype)
             assert_equal(np.einsum("i..., i...", a, b), np.inner(a.T, b.T).T)
@@ -262,7 +262,7 @@ class TestEinSum(TestCase):
                          np.inner(a.T, b.T).T)
 
         # outer(a,b)
-        for n in range(1,17):
+        for n in xrange(1,17):
             a = np.arange(3, dtype=dtype)+1
             b = np.arange(n, dtype=dtype)+1
             assert_equal(np.einsum("i,j", a, b), np.outer(a, b))
@@ -275,7 +275,7 @@ class TestEinSum(TestCase):
             warnings.simplefilter('ignore', np.ComplexWarning)
 
             # matvec(a,b) / a.dot(b) where a is matrix, b is vector
-            for n in range(1,17):
+            for n in xrange(1,17):
                 a = np.arange(4*n, dtype=dtype).reshape(4,n)
                 b = np.arange(n, dtype=dtype)
                 assert_equal(np.einsum("ij, j", a, b), np.dot(a, b))
@@ -294,7 +294,7 @@ class TestEinSum(TestCase):
                             np.dot(a.astype('f8'),
                                    b.astype('f8')).astype(dtype))
 
-            for n in range(1,17):
+            for n in xrange(1,17):
                 a = np.arange(4*n, dtype=dtype).reshape(4,n)
                 b = np.arange(n, dtype=dtype)
                 assert_equal(np.einsum("ji,j", a.T, b.T), np.dot(b.T, a.T))
@@ -313,14 +313,14 @@ class TestEinSum(TestCase):
                                a.T.astype('f8')).astype(dtype))
 
             # matmat(a,b) / a.dot(b) where a is matrix, b is matrix
-            for n in range(1,17):
+            for n in xrange(1,17):
                 if n < 8 or dtype != 'f2':
                     a = np.arange(4*n, dtype=dtype).reshape(4,n)
                     b = np.arange(n*6, dtype=dtype).reshape(n,6)
                     assert_equal(np.einsum("ij,jk", a, b), np.dot(a, b))
                     assert_equal(np.einsum(a, [0,1], b, [1,2]), np.dot(a, b))
 
-            for n in range(1,17):
+            for n in xrange(1,17):
                 a = np.arange(4*n, dtype=dtype).reshape(4,n)
                 b = np.arange(n*6, dtype=dtype).reshape(n,6)
                 c = np.arange(24, dtype=dtype).reshape(4,6)
@@ -397,7 +397,7 @@ class TestEinSum(TestCase):
         assert_equal(np.einsum(a, [0], 3, [], []), 3*np.sum(a))
 
         # Various stride0, contiguous, and SSE aligned variants
-        for n in range(1,25):
+        for n in xrange(1,25):
             a = np.arange(n, dtype=dtype)
             if np.dtype(dtype).itemsize > 1:
                 assert_equal(np.einsum("...,...",a,a), np.multiply(a,a))

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -248,7 +248,7 @@ class TestHalf(TestCase):
 
         # getitem
         a = np.arange(10, dtype=float16)
-        for i in range(10):
+        for i in xrange(10):
             assert_equal(a.item(i),i)
 
     def test_spacing_nextafter(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -423,13 +423,13 @@ class TestStructured(TestCase):
         b[1].b = 'c'
         assert_equal(a==b, [True,False])
         assert_equal(a!=b, [False,True])
-        for i in range(3):
+        for i in xrange(3):
             b[0].a = a[0].a
             b[0].a[i] = 5
             assert_equal(a==b, [False,False])
             assert_equal(a!=b, [True,True])
-        for i in range(2):
-            for j in range(2):
+        for i in xrange(2):
+            for j in xrange(2):
                 b = a.copy()
                 b[0].c[i,j] = 10
                 assert_equal(a==b, [False,True])
@@ -551,7 +551,7 @@ class TestMethods(TestCase):
 
         # test string sorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)])
+        a = np.array([s + chr(i) for i in xrange(101)])
         b = a[::-1].copy()
         for kind in ['q', 'm', 'h'] :
             msg = "string sort, kind=%s" % kind
@@ -564,7 +564,7 @@ class TestMethods(TestCase):
 
         # test unicode sorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode)
+        a = np.array([s + chr(i) for i in xrange(101)], dtype=np.unicode)
         b = a[::-1].copy()
         for kind in ['q', 'm', 'h'] :
             msg = "unicode sort, kind=%s" % kind
@@ -590,7 +590,7 @@ class TestMethods(TestCase):
 
         # test record array sorts.
         dt = np.dtype([('f',float),('i',int)])
-        a = array([(i,i) for i in range(101)], dtype = dt)
+        a = array([(i,i) for i in xrange(101)], dtype = dt)
         b = a[::-1]
         for kind in ['q', 'h', 'm'] :
             msg = "object sort, kind=%s" % kind
@@ -705,7 +705,7 @@ class TestMethods(TestCase):
 
         # test string argsorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)])
+        a = np.array([s + chr(i) for i in xrange(101)])
         b = a[::-1].copy()
         r = np.arange(101)
         rr = r[::-1]
@@ -716,7 +716,7 @@ class TestMethods(TestCase):
 
         # test unicode argsorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode)
+        a = np.array([s + chr(i) for i in xrange(101)], dtype=np.unicode)
         b = a[::-1]
         r = np.arange(101)
         rr = r[::-1]
@@ -738,7 +738,7 @@ class TestMethods(TestCase):
 
         # test structured array argsorts.
         dt = np.dtype([('f',float),('i',int)])
-        a = array([(i,i) for i in range(101)], dtype = dt)
+        a = array([(i,i) for i in xrange(101)], dtype = dt)
         b = a[::-1]
         r = np.arange(101)
         rr = r[::-1]
@@ -788,10 +788,10 @@ class TestMethods(TestCase):
         a = np.zeros(100, dtype=np.complex)
         assert_equal(a.argsort(kind='m'), r)
         # string
-        a = np.array(['aaaaaaaaa' for i in range(100)])
+        a = np.array(['aaaaaaaaa' for i in xrange(100)])
         assert_equal(a.argsort(kind='m'), r)
         # unicode
-        a = np.array(['aaaaaaaaa' for i in range(100)], dtype=np.unicode)
+        a = np.array(['aaaaaaaaa' for i in xrange(100)], dtype=np.unicode)
         assert_equal(a.argsort(kind='m'), r)
 
     def test_searchsorted(self):

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -74,9 +74,9 @@ def test_iter_best_order():
     for shape in [(5,), (3,4), (2,3,4), (2,3,4,3), (2,3,2,2,3)]:
         a = arange(np.prod(shape))
         # Test each combination of positive and negative strides
-        for dirs in range(2**len(shape)):
+        for dirs in xrange(2**len(shape)):
             dirs_index = [slice(None)]*len(shape)
-            for bit in range(len(shape)):
+            for bit in xrange(len(shape)):
                 if ((2**bit)&dirs):
                     dirs_index[bit] = slice(None,None,-1)
             dirs_index = tuple(dirs_index)
@@ -100,9 +100,9 @@ def test_iter_c_order():
     for shape in [(5,), (3,4), (2,3,4), (2,3,4,3), (2,3,2,2,3)]:
         a = arange(np.prod(shape))
         # Test each combination of positive and negative strides
-        for dirs in range(2**len(shape)):
+        for dirs in xrange(2**len(shape)):
             dirs_index = [slice(None)]*len(shape)
-            for bit in range(len(shape)):
+            for bit in xrange(len(shape)):
                 if ((2**bit)&dirs):
                     dirs_index[bit] = slice(None,None,-1)
             dirs_index = tuple(dirs_index)
@@ -127,9 +127,9 @@ def test_iter_f_order():
     for shape in [(5,), (3,4), (2,3,4), (2,3,4,3), (2,3,2,2,3)]:
         a = arange(np.prod(shape))
         # Test each combination of positive and negative strides
-        for dirs in range(2**len(shape)):
+        for dirs in xrange(2**len(shape)):
             dirs_index = [slice(None)]*len(shape)
-            for bit in range(len(shape)):
+            for bit in xrange(len(shape)):
                 if ((2**bit)&dirs):
                     dirs_index[bit] = slice(None,None,-1)
             dirs_index = tuple(dirs_index)
@@ -154,9 +154,9 @@ def test_iter_c_or_f_order():
     for shape in [(5,), (3,4), (2,3,4), (2,3,4,3), (2,3,2,2,3)]:
         a = arange(np.prod(shape))
         # Test each combination of positive and negative strides
-        for dirs in range(2**len(shape)):
+        for dirs in xrange(2**len(shape)):
             dirs_index = [slice(None)]*len(shape)
-            for bit in range(len(shape)):
+            for bit in xrange(len(shape)):
                 if ((2**bit)&dirs):
                     dirs_index[bit] = slice(None,None,-1)
             dirs_index = tuple(dirs_index)
@@ -417,9 +417,9 @@ def test_iter_no_inner_full_coalesce():
         size = np.prod(shape)
         a = arange(size)
         # Test each combination of forward and backwards indexing
-        for dirs in range(2**len(shape)):
+        for dirs in xrange(2**len(shape)):
             dirs_index = [slice(None)]*len(shape)
-            for bit in range(len(shape)):
+            for bit in xrange(len(shape)):
                 if ((2**bit)&dirs):
                     dirs_index[bit] = slice(None,None,-1)
             dirs_index = tuple(dirs_index)
@@ -1568,7 +1568,7 @@ def test_iter_buffering_delayed_alloc():
     assert_equal(i[0], 0)
     i[1] = 1
     assert_equal(i[0:2], [0,1])
-    assert_equal([[x[0][()],x[1][()]] for x in i], zip(range(6), [1]*6))
+    assert_equal([[x[0][()],x[1][()]] for x in i], zip(list(range(6)), [1]*6))
 
 def test_iter_buffered_cast_simple():
     # Test that buffering can handle a simple cast
@@ -1800,7 +1800,7 @@ def test_iter_buffered_cast_subarray():
                     casting='unsafe',
                     op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
-    for x, count in zip(i, range(6)):
+    for x, count in zip(i, xrange(6)):
         assert_(np.all(x['a'] == count))
 
     # one element -> many -> back (copies it to all)

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -50,11 +50,11 @@ class TestFromrecords(TestCase):
         a = np.zeros(count, dtype='O')
         b = np.zeros(count, dtype='f8')
         c = np.zeros(count, dtype='f8')
-        for i in range(len(a)):
+        for i in xrange(len(a)):
             a[i] = range(1, 10)
 
         mine = np.rec.fromarrays([a, b, c], names='date,data1,data2')
-        for i in range(len(a)):
+        for i in xrange(len(a)):
             assert_((mine.date[i] == range(1, 10)))
             assert_((mine.data1[i] == 0.0))
             assert_((mine.data2[i] == 0.0))

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -243,7 +243,7 @@ class TestRegression(TestCase):
 
     def test_mem_divmod(self,level=rlevel):
         """Ticket #126"""
-        for i in range(10):
+        for i in xrange(10):
             divmod(np.array([i])[0],10)
 
 
@@ -1080,7 +1080,7 @@ class TestRegression(TestCase):
 
     def test_unaligned_unicode_access(self, level=rlevel) :
         """Ticket #825"""
-        for i in range(1,9) :
+        for i in xrange(1,9) :
             msg = 'unicode offset: %d chars'%i
             t = np.dtype([('a','S%d'%i),('b','U2')])
             x = np.array([(asbytes('a'),u'b')], dtype=t)
@@ -1664,7 +1664,7 @@ class TestRegression(TestCase):
         """Ticket #1756 """
         s = asbytes('0123456789abcdef')
         a = np.array([s]*5)
-        for i in range(1,17):
+        for i in xrange(1,17):
             a1 = np.array(a, "|S%d"%i)
             a2 = np.array([s[:i]]*5)
             assert_equal(a1, a2)
@@ -1758,7 +1758,7 @@ class TestRegression(TestCase):
 
     def test_memoryleak(self):
         # Ticket #1917 - ensure that array data doesn't leak
-        for i in range(1000):
+        for i in xrange(1000):
             # 100MB times 1000 would give 100GB of memory usage if it leaks
             a = np.empty((100000000,), dtype='i1')
             del a

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -142,7 +142,7 @@ class TestUfunc(TestCase):
         # check unary PyUFunc_O_O_method
         msg = "PyUFunc_O_O_method"
         x = np.zeros(10, dtype=np.object)[0::2]
-        for i in range(len(x)) :
+        for i in xrange(len(x)) :
             x[i] = foo()
         assert_(np.all(np.conjugate(x) == True), msg)
 
@@ -153,7 +153,7 @@ class TestUfunc(TestCase):
         # check binary PyUFunc_OO_O_method
         msg = "PyUFunc_OO_O_method"
         x = np.zeros(10, dtype=np.object)[0::2]
-        for i in range(len(x)) :
+        for i in xrange(len(x)) :
             x[i] = foo()
         assert_(np.all(np.logical_xor(x,x)), msg)
 

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -147,7 +147,7 @@ class TestClog(TestCase):
         x = np.array([1+0j, 1+2j])
         y_r = np.log(np.abs(x)) + 1j * np.angle(x)
         y = np.log(x)
-        for i in range(len(x)):
+        for i in xrange(len(x)):
             assert_almost_equal(y[i], y_r[i])
 
     @platform_skip
@@ -296,7 +296,7 @@ class TestClog(TestCase):
         ya = np.array(yl, dtype=np.complex)
         err = np.seterr(divide='ignore')
         try:
-            for i in range(len(xa)):
+            for i in xrange(len(xa)):
                 assert_almost_equal(np.log(np.conj(xa[i])), np.conj(np.log(xa[i])))
         finally:
             np.seterr(**err)
@@ -392,7 +392,7 @@ class TestCpow(TestCase):
         x = np.array([1+1j, 0+2j, 1+2j, np.inf, np.nan])
         y_r = x ** 2
         y = np.power(x, 2)
-        for i in range(len(x)):
+        for i in xrange(len(x)):
             assert_almost_equal(y[i], y_r[i])
 
     def test_scalar(self):
@@ -432,7 +432,7 @@ class TestCabs(object):
         x = np.array([1+1j, 0+2j, 1+2j, np.inf, np.nan])
         y_r = np.array([np.sqrt(2.), 2, np.sqrt(5), np.inf, np.nan])
         y = np.abs(x)
-        for i in range(len(x)):
+        for i in xrange(len(x)):
             assert_almost_equal(y[i], y_r[i])
 
     def test_fabs(self):
@@ -478,7 +478,7 @@ class TestCabs(object):
             return np.abs(np.complex(a, b))
 
         xa = np.array(x, dtype=np.complex)
-        for i in range(len(xa)):
+        for i in xrange(len(xa)):
             ref = g(x[i], y[i])
             yield check_real_value, f, x[i], y[i], ref
 

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -16,7 +16,7 @@ from numpy.distutils.misc_util import filter_sources, has_f_sources,\
 
 # Fix Python distutils bug sf #1718574:
 _l = old_build_clib.user_options
-for _i in range(len(_l)):
+for _i in xrange(len(_l)):
     if _l[_i][0] in ['build-clib', 'build-temp']:
         _l[_i] = (_l[_i][0]+'=',)+_l[_i][1:]
 #

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -204,7 +204,7 @@ def parse_loop_header(loophead) :
     dlist = []
     if nsub is None :
         raise ValueError("No substitution variables found")
-    for i in range(nsub) :
+    for i in xrange(nsub) :
         tmp = {}
         for name,vals in names :
             tmp[name] = vals[i]

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -101,7 +101,7 @@ item_re = re.compile(r"\A\\(?P<index>\d+)\Z")
 def conv(astr):
     b = astr.split(',')
     l = [x.strip() for x in b]
-    for i in range(len(l)):
+    for i in xrange(len(l)):
         m = item_re.match(l[i])
         if m:
             j = int(m.group('index'))
@@ -177,7 +177,7 @@ def expand_sub(substr,names):
         return rules.get(name,(k+1)*[name])[k]
 
     newstr = ''
-    for k in range(numsubs):
+    for k in xrange(numsubs):
         newstr += template_re.sub(namerepl, substr) + '\n\n'
 
     newstr = newstr.replace('@rightarrow@','>')

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -274,14 +274,14 @@ def generate_def(dll, dfile):
 
     The .def file will be overwritten"""
     dump = dump_table(dll)
-    for i in range(len(dump)):
+    for i in xrange(len(dump)):
         if _START.match(dump[i].decode()):
             break
     else:
         raise ValueError("Symbol table not found")
 
     syms = []
-    for j in range(i+1, len(dump)):
+    for j in xrange(i+1, len(dump)):
         m = _TABLE.match(dump[j].decode())
         if m:
             syms.append((int(m.group(1).strip()), m.group(2)))

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -62,7 +62,7 @@ def quote_args(args):
     # don't used _nt_quote_args as it does not check if
     # args items already have quotes or not.
     args = list(args)
-    for i in range(len(args)):
+    for i in xrange(len(args)):
         a = args[i]
         if ' ' in a and a[0] not in '"\'':
             args[i] = '"%s"' % (a)
@@ -641,7 +641,7 @@ def get_frame(level=0):
         return sys._getframe(level+1)
     except AttributeError:
         frame = sys.exc_info()[2].tb_frame
-        for _ in range(level+1):
+        for _ in xrange(level+1):
             frame = frame.f_back
         return frame
 
@@ -739,7 +739,7 @@ class Configuration(object):
             )
 
         caller_instance = None
-        for i in range(1,3):
+        for i in xrange(1,3):
             try:
                 f = get_frame(i)
             except ValueError:

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -451,14 +451,14 @@ class throw_error:
 
 def l_and(*f):
     l,l2='lambda v',[]
-    for i in range(len(f)):
+    for i in xrange(len(f)):
         l='%s,f%d=f[%d]'%(l,i,i)
         l2.append('f%d(v)'%(i))
     return eval('%s:%s'%(l,' and '.join(l2)))
 
 def l_or(*f):
     l,l2='lambda v',[]
-    for i in range(len(f)):
+    for i in xrange(len(f)):
         l='%s,f%d=f[%d]'%(l,i,i)
         l2.append('f%d(v)'%(i))
     return eval('%s:%s'%(l,' or '.join(l2)))

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -307,7 +307,7 @@ def getarrdims(a,var,verbose=0):
         ret['dims']=','.join(dim)
         ret['rank']=`len(dim)`
         ret['rank*[-1]']=`len(dim)*[-1]`[1:-1]
-        for i in range(len(dim)): # solve dim for dependecies
+        for i in xrange(len(dim)): # solve dim for dependecies
             v=[]
             if dim[i] in depargs: v=[dim[i]]
             else:
@@ -514,7 +514,7 @@ def sign2map(a,var):
             #ismutable,'mutable',l_not(ismutable),'immutable',
             ]
         rl=[]
-        for i in range(0,len(il),2):
+        for i in xrange(0,len(il),2):
             if il[i](var): rl.append(il[i+1])
         if isstring(var):
             rl.append('slen(%s)=%s'%(a,ret['length']))

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1039,7 +1039,7 @@ def analyzeline(m,case,line):
                     else: begc=endc=r.strip()
                     if not len(begc)==len(endc)==1:
                         outmess('analyzeline: expected "<char>-<char>" instead of "%s" in range list of implicit statement (2)\n'%r);continue
-                    for o in range(ord(begc),ord(endc)+1):
+                    for o in xrange(ord(begc),ord(endc)+1):
                         impl[chr(o)]=decl
             groupcache[groupcounter]['implicit']=impl
     elif case=='data':
@@ -1222,7 +1222,7 @@ def removespaces(expr):
     expr=expr.strip()
     if len(expr)<=1: return expr
     expr2=expr[0]
-    for i in range(1,len(expr)-1):
+    for i in xrange(1,len(expr)-1):
         if expr[i]==' ' and \
            ((expr[i+1] in "()[]{}=+-/* ") or (expr[i-1] in "()[]{}=+-/* ")): continue
         expr2=expr2+expr[i]

--- a/numpy/f2py/docs/pytest.py
+++ b/numpy/f2py/docs/pytest.py
@@ -3,8 +3,8 @@ import Numeric
 def foo(a):
     a = Numeric.array(a)
     m,n = a.shape
-    for i in range(m):
-        for j in range(n):
+    for i in xrange(m):
+        for j in xrange(n):
             a[i,j] = a[i,j] + 10*(i+1) + (j+1)
     return a
 #eof

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -308,7 +308,7 @@ def buildmodules(lst):
     cfuncs.buildcfuncs()
     outmess('Building modules...\n')
     modules,mnames,isusedby=[],[],{}
-    for i in range(len(lst)):
+    for i in xrange(len(lst)):
         if '__user__' in lst[i]['name']:
             cb_rules.buildcallbacks(lst[i])
         else:
@@ -320,7 +320,7 @@ def buildmodules(lst):
             modules.append(lst[i])
             mnames.append(lst[i]['name'])
     ret = {}
-    for i in range(len(mnames)):
+    for i in xrange(len(mnames)):
         if mnames[i] in isusedby:
             outmess('\tSkipping module "%s" which is used by %s.\n'%(mnames[i],','.join(map(lambda s:'"%s"'%s,isusedby[mnames[i]]))))
         else:
@@ -360,13 +360,13 @@ def run_main(comline_list):
     auxfuncs.options=options
     postlist=callcrackfortran(files,options)
     isusedby={}
-    for i in range(len(postlist)):
+    for i in xrange(len(postlist)):
         if 'use' in postlist[i]:
             for u in postlist[i]['use'].keys():
                 if u not in isusedby:
                     isusedby[u]=[]
                 isusedby[u].append(postlist[i]['name'])
-    for i in range(len(postlist)):
+    for i in xrange(len(postlist)):
         if postlist[i]['block']=='python module' and '__user__' in postlist[i]['name']:
             if postlist[i]['name'] in isusedby:
                 #if not quiet:
@@ -376,7 +376,7 @@ def run_main(comline_list):
             outmess('Stopping. Edit the signature file and then run f2py on the signature file: ')
             outmess('%s %s\n'%(os.path.basename(sys.argv[0]),options['signsfile']))
         return
-    for i in range(len(postlist)):
+    for i in xrange(len(postlist)):
         if postlist[i]['block']!='python module':
             if 'python module' not in options:
                 errmess('Tip: If your original code is Fortran source then you must use -m option.\n')
@@ -518,7 +518,7 @@ def run_compile():
     define_macros, sources = filter_files('-D','',sources,remove_prefix=1)
     using_numarray = 0
     using_numeric = 0
-    for i in range(len(define_macros)):
+    for i in xrange(len(define_macros)):
         name_value = define_macros[i].split('=',1)
         if len(name_value)==1:
             name_value.append(None)

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -21,11 +21,11 @@ class TestKind(util.F2PyTest):
         selectedrealkind = self.module.selectedrealkind
         selectedintkind = self.module.selectedintkind
 
-        for i in range(40):
+        for i in xrange(40):
             assert_(selectedintkind(i) in [selected_int_kind(i),-1],\
                     'selectedintkind(%s): expected %r but got %r' %  (i, selected_int_kind(i), selectedintkind(i)))
 
-        for i in range(20):
+        for i in xrange(20):
             assert_(selectedrealkind(i) in [selected_real_kind(i),-1],\
                     'selectedrealkind(%s): expected %r but got %r' %  (i, selected_real_kind(i), selectedrealkind(i)))
 

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -959,7 +959,7 @@ def rfftn(a, s=None, axes=None):
     a = asarray(a).astype(float)
     s, axes = _cook_nd_args(a, s, axes)
     a = rfft(a, s[-1], axes[-1])
-    for ii in range(len(axes)-1):
+    for ii in xrange(len(axes)-1):
         a = fft(a, s[ii], axes[ii])
     return a
 
@@ -1079,7 +1079,7 @@ def irfftn(a, s=None, axes=None):
 
     a = asarray(a).astype(complex)
     s, axes = _cook_nd_args(a, s, axes, invreal=1)
-    for ii in range(len(axes)-1):
+    for ii in xrange(len(axes)-1):
         a = ifft(a, s[ii], axes[ii])
     a = irfft(a, s[-1], axes[-1])
     return a

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -217,7 +217,7 @@ class LineSplitter(object):
         if not line:
             return []
         fixed = self.delimiter
-        slices = [slice(i, i + fixed) for i in range(0, len(line), fixed)]
+        slices = [slice(i, i + fixed) for i in xrange(0, len(line), fixed)]
         return [line[s] for s in slices]
     #
     def _variablewidth_splitter(self, line):
@@ -854,7 +854,7 @@ def easy_dtype(ndtype, names=None, defaultfmt="f%i", **validationargs):
         elif (nbtypes > 0):
             validate = NameValidator(**validationargs)
             # Default initial names : should we change the format ?
-            if (ndtype.names == tuple("f%i" % i for i in range(nbtypes))) and \
+            if (ndtype.names == tuple("f%i" % i for i in xrange(nbtypes))) and \
                (defaultfmt != "f%i"):
                 ndtype.names = validate([''] * nbtypes, defaultfmt=defaultfmt)
             # Explicit initial names : just validate

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -344,12 +344,12 @@ def _linear_ramp(vector, pad_tuple, iaxis, kwargs):
 
     before_vector = np.ones((pad_tuple[0], )) * end_values[0]
     before_vector = before_vector.astype(vector.dtype)
-    for i in range(len(before_vector)):
+    for i in xrange(len(before_vector)):
         before_vector[i] = before_vector[i] + i * before_delta
 
     after_vector = np.ones((pad_tuple[1], )) * end_values[1]
     after_vector = after_vector.astype(vector.dtype)
-    for i in range(len(after_vector)):
+    for i in xrange(len(after_vector)):
         after_vector[i] = after_vector[i] + i * after_delta
     after_vector = after_vector[::-1]
 

--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -195,7 +195,7 @@ class Arrayterator(object):
             # running dimension (ie, the dimension along which
             # the blocks will be built from)
             rundim = 0
-            for i in range(ndims-1, -1, -1):
+            for i in xrange(ndims-1, -1, -1):
                 # if count is zero we ran out of elements to read
                 # along higher dimensions, so we read only a single position
                 if count == 0:
@@ -216,7 +216,7 @@ class Arrayterator(object):
             # Update start position, taking care of overflow to
             # other dimensions
             start[rundim] = stop[rundim]  # start where we stopped
-            for i in range(ndims-1, 0, -1):
+            for i in xrange(ndims-1, 0, -1):
                 if start[i] >= self.stop[i]:
                     start[i] = self.start[i]
                     start[i-1] += self.step[i-1]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -681,7 +681,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     n = len(condlist)
     if n == n2-1:  # compute the "otherwise" condition.
         totlist = condlist[0]
-        for k in range(1, n):
+        for k in xrange(1, n):
             totlist |= condlist[k]
         condlist.append(~totlist)
         n += 1
@@ -696,7 +696,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
         x = x[None]
         zerod = True
         newcondlist = []
-        for k in range(n):
+        for k in xrange(n):
             if condlist[k].ndim == 0:
                 condition = condlist[k][None]
             else:
@@ -705,7 +705,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
         condlist = newcondlist
 
     y = zeros(x.shape, x.dtype)
-    for k in range(n):
+    for k in xrange(n):
         item = funclist[k]
         if not callable(item):
             y[condlist[k]] = item
@@ -762,7 +762,7 @@ def select(condlist, choicelist, default=0):
     choicelist = [default] + choicelist
     S = 0
     pfac = 1
-    for k in range(1, n+1):
+    for k in xrange(1, n+1):
         S += k * pfac * asarray(condlist[k-1])
         if k < n:
             pfac *= (1-asarray(condlist[k-1]))
@@ -770,7 +770,7 @@ def select(condlist, choicelist, default=0):
     #  a multi-element choice
     if type(S) in ScalarType or max(asarray(S).shape)==1:
         pfac = asarray(1)
-        for k in range(n2+1):
+        for k in xrange(n2+1):
             pfac = pfac + asarray(choicelist[k])
         if type(S) in ScalarType:
             S = S*ones(asarray(pfac).shape, type(S))
@@ -898,7 +898,7 @@ def gradient(f, *varargs):
         # Needs to keep the specific units, can't be a general unit
         otype = f.dtype
 
-    for axis in range(N):
+    for axis in xrange(N):
         # select out appropriate parts for this dimension
         out = np.empty_like(f, dtype=otype)
         slice1[axis] = slice(1, -1)
@@ -1859,7 +1859,7 @@ class vectorize(object):
             nargs = len(args)
 
             names = [_n for _n in kwargs if _n not in excluded]
-            inds = [_i for _i in range(nargs) if _i not in excluded]
+            inds = [_i for _i in xrange(nargs) if _i not in excluded]
             the_args = list(args)
             def func(*vargs):
                 for _n, _i in enumerate(inds):
@@ -1916,7 +1916,7 @@ class vectorize(object):
                 outputs = (outputs,)
 
             otypes = ''.join([asarray(outputs[_k]).dtype.char
-                              for _k in range(nout)])
+                              for _k in xrange(nout)])
 
             # Performance note: profiling indicates that creating the ufunc is
             # not a significant cost compared with wrapping so it seems not
@@ -3299,13 +3299,13 @@ def meshgrid(*xi, **kwargs):
     code snippet::
 
         xv, yv = meshgrid(x, y, sparse=False, indexing='ij')
-        for i in range(nx):
-            for j in range(ny):
+        for i in xrange(nx):
+            for j in xrange(ny):
                 # treat xv[i,j], yv[i,j]
 
         xv, yv = meshgrid(x, y, sparse=False, indexing='xy')
-        for i in range(nx):
-            for j in range(ny):
+        for i in xrange(nx):
+            for j in xrange(ny):
                 # treat xv[j,i], yv[j,i]
 
     See Also

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -68,7 +68,7 @@ def ix_(*args):
     out = []
     nd = len(args)
     baseshape = [1]*nd
-    for k in range(nd):
+    for k in xrange(nd):
         new = _nx.asarray(args[k])
         if (new.ndim != 1):
             raise ValueError("Cross index must be 1 dimensional")
@@ -146,7 +146,7 @@ class nd_grid(object):
         try:
             size = []
             typ = int
-            for k in range(len(key)):
+            for k in xrange(len(key)):
                 step = key[k].step
                 start = key[k].start
                 if start is None: start=0
@@ -165,7 +165,7 @@ class nd_grid(object):
                                      (typ,)*len(size))
             else:
                 nn = _nx.indices(size, typ)
-            for k in range(len(size)):
+            for k in xrange(len(size)):
                 step = key[k].step
                 start = key[k].start
                 if start is None: start=0
@@ -177,7 +177,7 @@ class nd_grid(object):
                 nn[k] = (nn[k]*step+start)
             if self.sparse:
                 slobj = [_nx.newaxis]*len(size)
-                for k in range(len(size)):
+                for k in xrange(len(size)):
                     slobj[k] = slice(None,None)
                     nn[k] = nn[k][slobj]
                     slobj[k] = _nx.newaxis
@@ -248,7 +248,7 @@ class AxisConcatenator(object):
         scalars = []
         arraytypes = []
         scalartypes = []
-        for k in range(len(key)):
+        for k in xrange(len(key)):
             scalar = False
             if type(key[k]) is slice:
                 step = key[k].step

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -52,7 +52,7 @@ def seek_gzip_factory(f):
                 # for negative seek, rewind and do positive seek
                 self.rewind()
                 count = offset - self.offset
-                for i in range(count // 1024):
+                for i in xrange(count // 1024):
                     self.read(1024)
                 self.read(count % 1024)
 
@@ -1413,7 +1413,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     user_missing_values = missing_values or ()
 
     # Define the list of missing_values (one column: one list)
-    missing_values = [list([asbytes('')]) for _ in range(nbcols)]
+    missing_values = [list([asbytes('')]) for _ in xrange(nbcols)]
 
     # We have a dictionary: process it field by field
     if isinstance(user_missing_values, dict):

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -131,7 +131,7 @@ def poly(seq_of_zeros):
         return 1.0
 
     a = [1]
-    for k in range(len(seq_of_zeros)):
+    for k in xrange(len(seq_of_zeros)):
         a = NX.convolve(a, [1, -seq_of_zeros[k]], mode='full')
 
     if issubclass(a.dtype.type, NX.complexfloating):
@@ -667,7 +667,7 @@ def polyval(p, x):
     else:
         x = NX.asarray(x)
         y = NX.zeros_like(x)
-    for i in range(len(p)):
+    for i in xrange(len(p)):
         y = x * y + p[i]
     return y
 
@@ -887,7 +887,7 @@ def polydiv(u, v):
     scale = 1. / v[0]
     q = NX.zeros((max(m - n + 1, 1),), w.dtype)
     r = u.copy()
-    for k in range(0, m-n+1):
+    for k in xrange(0, m-n+1):
         d = scale * r[k]
         q[k] = d
         r[k:k+n+1] -= d*v
@@ -1077,7 +1077,7 @@ class poly1d(object):
                 s = s[:-5]
             return s
 
-        for k in range(len(coeffs)):
+        for k in xrange(len(coeffs)):
             if not iscomplex(coeffs[k]):
                 coefstr = fmt_float(real(coeffs[k]))
             elif real(coeffs[k]) == 0:
@@ -1156,7 +1156,7 @@ class poly1d(object):
         if not isscalar(val) or int(val) != val or val < 0:
             raise ValueError("Power to non-negative integers only.")
         res = [1]
-        for _ in range(val):
+        for _ in xrange(val):
             res = polymul(self.coeffs, res)
         return poly1d(res)
 

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -346,7 +346,7 @@ def dstack(tup):
     return _nx.concatenate(map(atleast_3d,tup),2)
 
 def _replace_zero_by_x_arrays(sub_arys):
-    for i in range(len(sub_arys)):
+    for i in xrange(len(sub_arys)):
         if len(_nx.shape(sub_arys[i])) == 0:
             sub_arys[i] = _nx.array([])
         elif _nx.sometrue(_nx.equal(_nx.shape(sub_arys[i]),0)):
@@ -392,7 +392,7 @@ def array_split(ary,indices_or_sections,axis = 0):
 
     sub_arys = []
     sary = _nx.swapaxes(ary,axis,0)
-    for i in range(Nsections):
+    for i in xrange(Nsections):
         st = div_points[i]; end = div_points[i+1]
         sub_arys.append(_nx.swapaxes(sary[st:end],axis,0))
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -77,7 +77,7 @@ def broadcast_arrays(*args):
     biggest = max(nds)
     # Go through each array and prepend dimensions of length 1 to each of the
     # shapes in order to make the number of dimensions equal.
-    for i in range(len(args)):
+    for i in xrange(len(args)):
         diff = biggest - nds[i]
         if diff > 0:
             shapes[i] = [1] * diff + shapes[i]
@@ -85,7 +85,7 @@ def broadcast_arrays(*args):
     # Chech each dimension for compatibility. A dimension length of 1 is
     # accepted as compatible with any other length.
     common_shape = []
-    for axis in range(biggest):
+    for axis in xrange(biggest):
         lengths = [s[axis] for s in shapes]
         unique = set(lengths + [1])
         if len(unique) > 2:
@@ -100,7 +100,7 @@ def broadcast_arrays(*args):
             common_shape.append(new_length)
             # For each array, if this axis is being broadcasted from a length of
             # 1, then set its stride to 0 so that it repeats its data.
-            for i in range(len(args)):
+            for i in xrange(len(args)):
                 if shapes[i][axis] == 1:
                     shapes[i][axis] = new_length
                     strides[i][axis] = 0

--- a/numpy/lib/tests/test_arrayterator.py
+++ b/numpy/lib/tests/test_arrayterator.py
@@ -14,7 +14,7 @@ def test():
 
     # Create a random array
     ndims = randint(5)+1
-    shape = tuple(randint(10)+1 for dim in range(ndims))
+    shape = tuple(randint(10)+1 for dim in xrange(ndims))
     els = reduce(mul, shape)
     a = np.arange(els)
     a.shape = shape

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -147,7 +147,7 @@ class TestAverage(TestCase):
 class TestSelect(TestCase):
     def _select(self, cond, values, default=0):
         output = []
-        for m in range(len(cond)):
+        for m in xrange(len(cond)):
             output += [V[m] for V, C in zip(values, cond) if C[m]] or [default]
         return output
 
@@ -1379,7 +1379,7 @@ class TestInterp(TestCase):
 
 
 def compare_results(res, desired):
-    for i in range(len(desired)):
+    for i in xrange(len(desired)):
         assert_array_equal(res[i], desired[i])
 
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -204,7 +204,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
             np.savez(fp, data='LOVELY LOAD')
             fp.close()
 
-            for i in range(1, 1025):
+            for i in xrange(1, 1025):
                 try:
                     np.load(tmp)["data"]
                 except Exception, e:
@@ -666,7 +666,7 @@ class TestLoadTxt(TestCase):
 
     def test_generator_source(self):
         def count():
-            for i in range(10):
+            for i in xrange(10):
                 yield asbytes("%d" % i)
 
         res = np.loadtxt(count())
@@ -778,13 +778,13 @@ class TestFromTxt(TestCase):
         assert_equal(test, control)
 
     def test_skip_footer(self):
-        data = ["# %i" % i for i in range(1, 6)]
+        data = ["# %i" % i for i in xrange(1, 6)]
         data.append("A, B, C")
-        data.extend(["%i,%3.1f,%03s" % (i, i, i) for i in range(51)])
+        data.extend(["%i,%3.1f,%03s" % (i, i, i) for i in xrange(51)])
         data[-1] = "99,99"
         kwargs = dict(delimiter=",", names=True, skip_header=5, skip_footer=10)
         test = np.genfromtxt(StringIO(asbytes("\n".join(data))), **kwargs)
-        ctrl = np.array([("%f" % i, "%f" % i, "%f" % i) for i in range(41)],
+        ctrl = np.array([("%f" % i, "%f" % i, "%f" % i) for i in xrange(41)],
                         dtype=[(_, float) for _ in "ABC"])
         assert_equal(test, ctrl)
 
@@ -1246,7 +1246,7 @@ M   33  21.99
     def test_invalid_raise(self):
         "Test invalid raise"
         data = ["1, 1, 1, 1, 1"] * 50
-        for i in range(5):
+        for i in xrange(5):
             data[10 * i] = "2, 2, 2, 2 2"
         data.insert(0, "a, b, c, d, e")
         mdata = StringIO("\n".join(data))
@@ -1269,7 +1269,7 @@ M   33  21.99
     def test_invalid_raise_with_usecols(self):
         "Test invalid_raise with usecols"
         data = ["1, 1, 1, 1, 1"] * 50
-        for i in range(5):
+        for i in xrange(5):
             data[10 * i] = "2, 2, 2, 2 2"
         data.insert(0, "a, b, c, d, e")
         mdata = StringIO("\n".join(data))
@@ -1289,7 +1289,7 @@ M   33  21.99
         mtest = np.ndfromtxt(mdata, usecols=(0, 1), **kwargs)
         assert_equal(len(mtest), 50)
         control = np.ones(50, dtype=[(_, int) for _ in 'ab'])
-        control[[10 * _ for _ in range(5)]] = (2, 2)
+        control[[10 * _ for _ in xrange(5)]] = (2, 2)
         assert_equal(mtest, control)
 
 
@@ -1527,7 +1527,7 @@ M   33  21.99
 
     def test_gft_using_generator(self):
         def count():
-            for i in range(10):
+            for i in xrange(10):
                 yield asbytes("%d" % i)
 
         res = np.genfromtxt(count())

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -20,7 +20,7 @@ class TestRegression(TestCase):
 
     def test_mem_digitize(self,level=rlevel):
         """Ticket #95"""
-        for i in range(100):
+        for i in xrange(100):
             np.digitize([1,2,3,4],[1,3])
             np.digitize([0,1,2,3,4],[1,3])
 

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -315,7 +315,7 @@ class TestTile(TestCase):
 
 # Utility
 def compare_results(res,desired):
-    for i in range(len(desired)):
+    for i in xrange(len(desired)):
         assert_array_equal(res[i],desired[i])
 
 

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -76,12 +76,12 @@ class TestDiag(TestCase):
     def test_vector(self):
         vals = (100 * arange(5)).astype('l')
         b = zeros((5, 5))
-        for k in range(5):
+        for k in xrange(5):
             b[k, k] = vals[k]
         assert_equal(diag(vals), b)
         b = zeros((7, 7))
         c = b.copy()
-        for k in range(5):
+        for k in xrange(5):
             b[k, k + 2] = vals[k]
             c[k + 2, k] = vals[k]
         assert_equal(diag(vals, k=2), b)
@@ -91,14 +91,14 @@ class TestDiag(TestCase):
         if vals is None:
             vals = (100 * get_mat(5) + 1).astype('l')
         b = zeros((5,))
-        for k in range(5):
+        for k in xrange(5):
             b[k] = vals[k,k]
         assert_equal(diag(vals), b)
         b = b * 0
-        for k in range(3):
+        for k in xrange(3):
             b[k] = vals[k, k + 2]
         assert_equal(diag(vals, 2), b[:3])
-        for k in range(3):
+        for k in xrange(3):
             b[k] = vals[k + 2, k]
         assert_equal(diag(vals, -2), b[:3])
 
@@ -158,13 +158,13 @@ class TestRot90(TestCase):
         b4 = [[0,1,2],
               [3,4,5]]
 
-        for k in range(-3,13,4):
+        for k in xrange(-3,13,4):
             assert_equal(rot90(a,k=k),b1)
-        for k in range(-2,13,4):
+        for k in xrange(-2,13,4):
             assert_equal(rot90(a,k=k),b2)
-        for k in range(-1,13,4):
+        for k in xrange(-1,13,4):
             assert_equal(rot90(a,k=k),b3)
-        for k in range(0,13,4):
+        for k in xrange(0,13,4):
             assert_equal(rot90(a,k=k),b4)
 
     def test_axes(self):

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -484,7 +484,7 @@ def vander(x, N=None):
            [ 9,  3,  1],
            [25,  5,  1]])
 
-    >>> np.column_stack([x**(N-1-i) for i in range(N)])
+    >>> np.column_stack([x**(N-1-i) for i in xrange(N)])
     array([[ 1,  1,  1],
            [ 4,  2,  1],
            [ 9,  3,  1],
@@ -510,7 +510,7 @@ def vander(x, N=None):
     if N is None:
         N=len(x)
     X = ones( (len(x),N), x.dtype)
-    for i in range(N - 1):
+    for i in xrange(N - 1):
         X[:,i] = x**(N - i - 1)
     return X
 

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -375,7 +375,7 @@ def who(vardict=None):
     maxshape = 0
     maxbyte = 0
     totalbytes = 0
-    for k in range(len(sta)):
+    for k in xrange(len(sta)):
         val = sta[k]
         if maxname < len(val[0]):
             maxname = len(val[0])
@@ -393,7 +393,7 @@ def who(vardict=None):
         prval = "Name %s Shape %s Bytes %s Type" % (sp1*' ', sp2*' ', sp3*' ')
         print prval + "\n" + "="*(len(prval)+5) + "\n"
 
-    for k in range(len(sta)):
+    for k in xrange(len(sta)):
         val = sta[k]
         print "%s %s %s %s %s %s %s" % (val[0], ' '*(sp1-len(val[0])+4),
                                         val[1], ' '*(sp2-len(val[1])+5),

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -663,7 +663,7 @@ def qr(a, mode='full'):
 
     #  generate r
     r = _fastCopyAndTranspose(result_t, a[:,:mn])
-    for i in range(mn):
+    for i in xrange(mn):
         r[i,:i].fill(0.0)
 
     #  'r'-mode, that is, calculate only r
@@ -1056,7 +1056,7 @@ def eig(a):
             w = wr+1j*wi
             v = array(vr, w.dtype)
             ind = flatnonzero(wi != 0.0)      # indices of complex e-vals
-            for i in range(len(ind)//2):
+            for i in xrange(len(ind)//2):
                 v[ind[2*i]] = vr[ind[2*i]] + 1j*vr[ind[2*i+1]]
                 v[ind[2*i+1]] = vr[ind[2*i]] - 1j*vr[ind[2*i+1]]
             result_t = _complexType(result_t)
@@ -1575,7 +1575,7 @@ def pinv(a, rcond=1e-15 ):
     m = u.shape[0]
     n = vt.shape[1]
     cutoff = rcond*maximum.reduce(s)
-    for i in range(min(n, m)):
+    for i in xrange(min(n, m)):
         if s[i] > cutoff:
             s[i] = 1./s[i]
         else:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -456,7 +456,7 @@ class TestMatrixRank(object):
 def test_reduced_rank():
     # Test matrices with reduced rank
     rng = np.random.RandomState(20120714)
-    for i in range(100):
+    for i in xrange(100):
         # Make a rank deficient matrix
         X = rng.normal(size=(40, 10))
         X[:, 0] = X[:, 1] + X[:, 2]

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1395,14 +1395,14 @@ def corrcoef(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
         _denom = diagflat(diag)
         n = x.shape[1 - rowvar]
         if rowvar:
-            for i in range(n - 1):
-                for j in range(i + 1, n):
+            for i in xrange(n - 1):
+                for j in xrange(i + 1, n):
                     _x = mask_cols(vstack((x[i], x[j]))).var(axis=1,
                                                              ddof=1 - bias)
                     _denom[i, j] = _denom[j, i] = ma.sqrt(ma.multiply.reduce(_x))
         else:
-            for i in range(n - 1):
-                for j in range(i + 1, n):
+            for i in xrange(n - 1):
+                for j in xrange(i + 1, n):
                     _x = mask_cols(vstack((x[:, i], x[:, j]))).var(axis=1,
                                                                  ddof=1 - bias)
                     _denom[i, j] = _denom[j, i] = ma.sqrt(ma.multiply.reduce(_x))
@@ -1435,7 +1435,7 @@ class MAxisConcatenator(AxisConcatenator):
         objs = []
         scalars = []
         final_dtypedescr = None
-        for k in range(len(key)):
+        for k in xrange(len(key)):
             scalar = False
             if type(key[k]) is slice:
                 step = key[k].step
@@ -1605,8 +1605,8 @@ def notmasked_edges(a, axis=None):
         return flatnotmasked_edges(a)
     m = getmaskarray(a)
     idx = array(np.indices(a.shape), mask=np.asarray([m] * a.ndim))
-    return [tuple([idx[i].min(axis).compressed() for i in range(a.ndim)]),
-            tuple([idx[i].max(axis).compressed() for i in range(a.ndim)]), ]
+    return [tuple([idx[i].min(axis).compressed() for i in xrange(a.ndim)]),
+            tuple([idx[i].max(axis).compressed() for i in xrange(a.ndim)]), ]
 
 
 def flatnotmasked_contiguous(a):
@@ -1716,7 +1716,7 @@ def notmasked_contiguous(a, axis=None):
     idx = [0, 0]
     idx[axis] = slice(None, None)
     #
-    for i in range(a.shape[other]):
+    for i in xrange(a.shape[other]):
         idx[other] = i
         result.append(flatnotmasked_contiguous(a[idx]) or None)
     return result

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -62,7 +62,7 @@ reserved keywords. If this is the case, a default 'f%i' is substituted.
 If the argument `names` is not None, updates the field names to valid names.
     """
     ndescr = len(descr)
-    default_names = ['f%i' % i for i in range(ndescr)]
+    default_names = ['f%i' % i for i in xrange(ndescr)]
     if names is None:
         new_names = default_names
     else:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2700,9 +2700,9 @@ class TestMaskedArrayMathMethods(TestCase):
         assert_equal(mx.ptp(), mx.compressed().ptp())
         rows = np.zeros(n, np.float)
         cols = np.zeros(m, np.float)
-        for k in range(m):
+        for k in xrange(m):
             cols[k] = mX[:, k].compressed().ptp()
-        for k in range(n):
+        for k in xrange(n):
             rows[k] = mX[k].compressed().ptp()
         assert_equal(mX.ptp(0), cols)
         assert_equal(mX.ptp(1), rows)
@@ -2752,7 +2752,7 @@ class TestMaskedArrayMathMethods(TestCase):
         (mXvar0, mXvar1) = (mX.var(axis=0), mX.var(axis=1))
         assert_almost_equal(mX.var(axis=None, ddof=2), mX.compressed().var(ddof=2))
         assert_almost_equal(mX.std(axis=None, ddof=2), mX.compressed().std(ddof=2))
-        for k in range(6):
+        for k in xrange(6):
             assert_almost_equal(mXvar1[k], mX[k].compressed().var())
             assert_almost_equal(mXvar0[k], mX[:, k].compressed().var())
             assert_almost_equal(np.sqrt(mXvar0[k]), mX[:, k].compressed().std())
@@ -2900,7 +2900,7 @@ class TestMaskedArrayMathMethodsComplex(TestCase):
         (mXvar0, mXvar1) = (mX.var(axis=0), mX.var(axis=1))
         assert_almost_equal(mX.var(axis=None, ddof=2), mX.compressed().var(ddof=2))
         assert_almost_equal(mX.std(axis=None, ddof=2), mX.compressed().std(ddof=2))
-        for k in range(6):
+        for k in xrange(6):
             assert_almost_equal(mXvar1[k], mX[k].compressed().var())
             assert_almost_equal(mXvar0[k], mX[:, k].compressed().var())
             assert_almost_equal(np.sqrt(mXvar0[k]), mX[:, k].compressed().std())

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -442,7 +442,7 @@ class TestMedian(TestCase):
         z = masked_array(np.empty((n, p), dtype=float))
         z[:, 0] = x[:]
         idx = np.arange(len(x))
-        for i in range(1, p):
+        for i in xrange(1, p):
             np.random.shuffle(idx)
             z[:, i] = x[idx]
         assert_equal(median(z[:, 0]), 0)

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -790,9 +790,9 @@ class TestArrayMethods(TestCase):
         self.assertEqual(mx.ptp(), mx.compressed().ptp())
         rows = numpy.zeros(n, numpy.float_)
         cols = numpy.zeros(m, numpy.float_)
-        for k in range(m):
+        for k in xrange(m):
             cols[k] = mX[:, k].compressed().ptp()
-        for k in range(n):
+        for k in xrange(n):
             rows[k] = mX[k].compressed().ptp()
         self.assertTrue(eq(mX.ptp(0), cols))
         self.assertTrue(eq(mX.ptp(1), rows))
@@ -826,7 +826,7 @@ class TestArrayMethods(TestCase):
         self.assertTrue(eq(mXX.var(axis=3).shape, XX.var(axis=3).shape))
         self.assertTrue(eq(mX.var().shape, X.var().shape))
         (mXvar0, mXvar1) = (mX.var(axis=0), mX.var(axis=1))
-        for k in range(6):
+        for k in xrange(6):
             self.assertTrue(eq(mXvar1[k], mX[k].compressed().var()))
             self.assertTrue(eq(mXvar0[k], mX[:, k].compressed().var()))
             self.assertTrue(eq(numpy.sqrt(mXvar0[k]),
@@ -874,7 +874,7 @@ def eqmask(m1, m2):
 #    return time.time() - tn0
 
 #def testf(x):
-#    for i in range(25):
+#    for i in xrange(25):
 #        y = x **2 +  2.0 * x - 1.0
 #        w = x **2 +  1.0
 #        z = (y / w) ** 2
@@ -882,7 +882,7 @@ def eqmask(m1, m2):
 #testf.test_name = 'Simple arithmetic'
 
 #def testinplace(x):
-#    for i in range(25):
+#    for i in xrange(25):
 #        y = x**2
 #        y += 2.0*x
 #        y -= 1.0

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -62,7 +62,7 @@ are considered unequal.
 def _assert_equal_on_sequences(actual, desired, err_msg=''):
     "Asserts the equality of two non-array sequences."
     assert_equal(len(actual), len(desired), err_msg)
-    for k in range(len(desired)):
+    for k in xrange(len(desired)):
         assert_equal(actual[k], desired[k], 'item=%r\n%s' % (k, err_msg))
     return
 
@@ -134,7 +134,7 @@ def fail_if_equal(actual, desired, err_msg='',):
         return
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         fail_if_equal(len(actual), len(desired), err_msg)
-        for k in range(len(desired)):
+        for k in xrange(len(desired)):
             fail_if_equal(actual[k], desired[k], 'item=%r\n%s' % (k, err_msg))
         return
     if isinstance(actual, np.ndarray) or isinstance(desired, np.ndarray):

--- a/numpy/ma/timer_comparison.py
+++ b/numpy/ma/timer_comparison.py
@@ -440,7 +440,7 @@ if __name__ == '__main__':
     (nrepeat, nloop) = (10, 10)
 
     if 1:
-        for i in range(1,8):
+        for i in xrange(1,8):
             func = 'tester.test_%i()' % i
 #            new = timeit.Timer(func, setup_new).repeat(nrepeat, nloop*10)
             cur = timeit.Timer(func, setup_cur).repeat(nrepeat, nloop*10)

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -20,7 +20,7 @@ if sys.version_info[0] >= 3:
         return eval(astr.translate(_table))
 else:
     _table = [None]*256
-    for k in range(256):
+    for k in xrange(256):
         _table[k] = chr(k)
     _table = ''.join(_table)
 
@@ -173,7 +173,7 @@ def matrix_power(M,n):
 
     result = M
     if n <= 3:
-        for _ in range(n-1):
+        for _ in xrange(n-1):
             result=N.dot(result,M)
         return result
 
@@ -185,7 +185,7 @@ def matrix_power(M,n):
         Z = N.dot(Z,Z)
         q += 1
     result = Z
-    for k in range(q+1,t):
+    for k in xrange(q+1,t):
         Z = N.dot(Z,Z)
         if beta[t-k-1] == '1':
             result = N.dot(result,Z)
@@ -354,7 +354,7 @@ class matrix(N.ndarray):
         # now, 'matrix' has 6 letters, and 'array' 5, so the columns don't
         # line up anymore. We need to add a space.
         l = s.splitlines()
-        for i in range(1, len(l)):
+        for i in xrange(1, len(l)):
             if l[i]:
                 l[i] = ' ' + l[i]
         return '\n'.join(l)

--- a/numpy/numarray/session.py
+++ b/numpy/numarray/session.py
@@ -166,7 +166,7 @@ def _loadmodule(module):
     if module not in sys.modules:
         modules = module.split(".")
         s = ""
-        for i in range(len(modules)):
+        for i in xrange(len(modules)):
             s = ".".join(modules[:i+1])
             exec "import " + s
     return sys.modules[module]

--- a/numpy/oldnumeric/matrix.py
+++ b/numpy/oldnumeric/matrix.py
@@ -12,7 +12,7 @@ from numpy import matrix as Matrix, squeeze
 # Hidden names that will be the same.
 
 _table = [None]*256
-for k in range(256):
+for k in xrange(256):
     _table[k] = chr(k)
 _table = ''.join(_table)
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -367,7 +367,7 @@ def poly2cheb(pol) :
     [pol] = pu.as_series([pol])
     deg = len(pol) - 1
     res = 0
-    for i in range(deg, -1, -1) :
+    for i in xrange(deg, -1, -1) :
         res = chebadd(chebmulx(res), pol[i])
     return res
 
@@ -426,7 +426,7 @@ def cheb2poly(c) :
         c0 = c[-2]
         c1 = c[-1]
         # i is the current degree of c1
-        for i in range(n - 1, 1, -1) :
+        for i in xrange(n - 1, 1, -1) :
             tmp = c0
             c0 = polysub(c[i - 2], c1)
             c1 = polyadd(tmp, polymulx(c1)*2)
@@ -545,7 +545,7 @@ def chebfromroots(roots) :
         n = len(p)
         while n > 1:
             m, r = divmod(n, 2)
-            tmp = [chebmul(p[i], p[i+m]) for i in range(m)]
+            tmp = [chebmul(p[i], p[i+m]) for i in xrange(m)]
             if r:
                 tmp[0] = chebmul(tmp[0], p[-1])
             p = tmp
@@ -858,7 +858,7 @@ def chebpow(c, pow, maxpower=16) :
         # in the usual way.
         zs = _cseries_to_zseries(c)
         prd = zs
-        for i in range(2, power + 1) :
+        for i in xrange(2, power + 1) :
             prd = np.convolve(prd, zs)
         return _zseries_to_cseries(prd)
 
@@ -947,11 +947,11 @@ def chebder(c, m=1, scl=1, axis=0) :
     if cnt >= n:
         c = c[:1]*0
     else:
-        for i in range(cnt):
+        for i in xrange(cnt):
             n = n - 1
             c *= scl
             der = np.empty((n,) + c.shape[1:], dtype=c.dtype)
-            for j in range(n, 2, -1):
+            for j in xrange(n, 2, -1):
                 der[j - 1] = (2*j)*c[j]
                 c[j - 2] += (j*c[j])/(j - 2)
             if n > 1:
@@ -1072,7 +1072,7 @@ def chebint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
 
     c = np.rollaxis(c, iaxis)
     k = list(k) + [0]*(cnt - len(k))
-    for i in range(cnt) :
+    for i in xrange(cnt) :
         n = len(c)
         c *= scl
         if n == 1 and np.all(c[0] == 0):
@@ -1083,7 +1083,7 @@ def chebint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             tmp[1] = c[0]
             if n > 1:
                 tmp[2] = c[1]/4
-            for j in range(2, n):
+            for j in xrange(2, n):
                 t = c[j]/(2*j + 1)
                 tmp[j + 1] = c[j]/(2*(j + 1))
                 tmp[j - 1] -= c[j]/(2*(j - 1))
@@ -1173,7 +1173,7 @@ def chebval(x, c, tensor=True):
         x2 = 2*x
         c0 = c[-2]
         c1 = c[-1]
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             c0 = c[-i] - c1
             c1 = tmp + c1*x2
@@ -1459,7 +1459,7 @@ def chebvander(x, deg) :
     if ideg > 0 :
         x2 = 2*x
         v[1] = x
-        for i in range(2, ideg + 1) :
+        for i in xrange(2, ideg + 1) :
             v[i] = v[i-1]*x2 - v[i-2]
     return np.rollaxis(v, 0, v.ndim)
 
@@ -1943,7 +1943,7 @@ def chebpts1(npts):
     Chebyshev points of the first kind.
 
     The Chebyshev points of the first kind are the points ``cos(x)``,
-    where ``x = [pi*(k + .5)/npts for k in range(npts)]``.
+    where ``x = [pi*(k + .5)/npts for k in xrange(npts)]``.
 
     Parameters
     ----------
@@ -1980,7 +1980,7 @@ def chebpts2(npts):
     Chebyshev points of the second kind.
 
     The Chebyshev points of the second kind are the points ``cos(x)``,
-    where ``x = [pi*k/(npts - 1) for k in range(npts)]``.
+    where ``x = [pi*k/(npts - 1) for k in xrange(npts)]``.
 
     Parameters
     ----------

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -117,7 +117,7 @@ def poly2herm(pol) :
     [pol] = pu.as_series([pol])
     deg = len(pol) - 1
     res = 0
-    for i in range(deg, -1, -1) :
+    for i in xrange(deg, -1, -1) :
         res = hermadd(hermmulx(res), pol[i])
     return res
 
@@ -173,7 +173,7 @@ def herm2poly(c) :
         c0 = c[-2]
         c1 = c[-1]
         # i is the current degree of c1
-        for i in range(n - 1, 1, -1) :
+        for i in xrange(n - 1, 1, -1) :
             tmp = c0
             c0 = polysub(c[i - 2], c1*(2*(i - 1)))
             c1 = polyadd(tmp, polymulx(c1)*2)
@@ -292,7 +292,7 @@ def hermfromroots(roots) :
         n = len(p)
         while n > 1:
             m, r = divmod(n, 2)
-            tmp = [hermmul(p[i], p[i+m]) for i in range(m)]
+            tmp = [hermmul(p[i], p[i+m]) for i in xrange(m)]
             if r:
                 tmp[0] = hermmul(tmp[0], p[-1])
             p = tmp
@@ -440,7 +440,7 @@ def hermmulx(c):
     prd = np.empty(len(c) + 1, dtype=c.dtype)
     prd[0] = c[0]*0
     prd[1] = c[0]/2
-    for i in range(1, len(c)):
+    for i in xrange(1, len(c)):
         prd[i + 1] = c[i]/2
         prd[i - 1] += c[i]*i
     return prd
@@ -504,7 +504,7 @@ def hermmul(c1, c2):
         nd = len(c)
         c0 = c[-2]*xs
         c1 = c[-1]*xs
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = hermsub(c[-i]*xs, c1*(2*(nd - 1)))
@@ -571,7 +571,7 @@ def hermdiv(c1, c2):
     else :
         quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
         rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
+        for i in xrange(lc1 - lc2, - 1, -1):
             p = hermmul([0]*i + [1], c2)
             q = rem[-1]/p[-1]
             rem = rem[:-1] - q*p[:-1]
@@ -628,7 +628,7 @@ def hermpow(c, pow, maxpower=16) :
         # This can be made more efficient by using powers of two
         # in the usual way.
         prd = c
-        for i in range(2, power + 1) :
+        for i in xrange(2, power + 1) :
             prd = hermmul(prd, c)
         return prd
 
@@ -712,11 +712,11 @@ def hermder(c, m=1, scl=1, axis=0) :
     if cnt >= n:
         c = c[:1]*0
     else :
-        for i in range(cnt):
+        for i in xrange(cnt):
             n = n - 1
             c *= scl
             der = np.empty((n,) + c.shape[1:], dtype=c.dtype)
-            for j in range(n, 0, -1):
+            for j in xrange(n, 0, -1):
                 der[j - 1] = (2*j)*c[j]
             c = der
     c = np.rollaxis(c, 0, iaxis + 1)
@@ -831,7 +831,7 @@ def hermint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
 
     c = np.rollaxis(c, iaxis)
     k = list(k) + [0]*(cnt - len(k))
-    for i in range(cnt) :
+    for i in xrange(cnt) :
         n = len(c)
         c *= scl
         if n == 1 and np.all(c[0] == 0):
@@ -840,7 +840,7 @@ def hermint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             tmp = np.empty((n + 1,) + c.shape[1:], dtype=c.dtype)
             tmp[0] = c[0]*0
             tmp[1] = c[0]/2
-            for j in range(1, n):
+            for j in xrange(1, n):
                 tmp[j + 1] = c[j]/(2*(j + 1))
             tmp[0] += k[i] - hermval(lbnd, tmp)
             c = tmp
@@ -936,7 +936,7 @@ def hermval(x, c, tensor=True):
         nd = len(c)
         c0 = c[-2]
         c1 = c[-1]
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = c[-i] - c1*(2*(nd - 1))
@@ -1231,7 +1231,7 @@ def hermvander(x, deg) :
     if ideg > 0 :
         x2 = x*2
         v[1] = x2
-        for i in range(2, ideg + 1) :
+        for i in xrange(2, ideg + 1) :
             v[i] = (v[i-1]*x2 - v[i-2]*(2*(i - 1)))
     return np.rollaxis(v, 0, v.ndim)
 

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -117,7 +117,7 @@ def poly2herme(pol) :
     [pol] = pu.as_series([pol])
     deg = len(pol) - 1
     res = 0
-    for i in range(deg, -1, -1) :
+    for i in xrange(deg, -1, -1) :
         res = hermeadd(hermemulx(res), pol[i])
     return res
 
@@ -172,7 +172,7 @@ def herme2poly(c) :
         c0 = c[-2]
         c1 = c[-1]
         # i is the current degree of c1
-        for i in range(n - 1, 1, -1) :
+        for i in xrange(n - 1, 1, -1) :
             tmp = c0
             c0 = polysub(c[i - 2], c1*(i - 1))
             c1 = polyadd(tmp, polymulx(c1))
@@ -292,7 +292,7 @@ def hermefromroots(roots) :
         n = len(p)
         while n > 1:
             m, r = divmod(n, 2)
-            tmp = [hermemul(p[i], p[i+m]) for i in range(m)]
+            tmp = [hermemul(p[i], p[i+m]) for i in xrange(m)]
             if r:
                 tmp[0] = hermemul(tmp[0], p[-1])
             p = tmp
@@ -440,7 +440,7 @@ def hermemulx(c):
     prd = np.empty(len(c) + 1, dtype=c.dtype)
     prd[0] = c[0]*0
     prd[1] = c[0]
-    for i in range(1, len(c)):
+    for i in xrange(1, len(c)):
         prd[i + 1] = c[i]
         prd[i - 1] += c[i]*i
     return prd
@@ -504,7 +504,7 @@ def hermemul(c1, c2):
         nd = len(c)
         c0 = c[-2]*xs
         c1 = c[-1]*xs
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = hermesub(c[-i]*xs, c1*(nd - 1))
@@ -569,7 +569,7 @@ def hermediv(c1, c2):
     else :
         quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
         rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
+        for i in xrange(lc1 - lc2, - 1, -1):
             p = hermemul([0]*i + [1], c2)
             q = rem[-1]/p[-1]
             rem = rem[:-1] - q*p[:-1]
@@ -626,7 +626,7 @@ def hermepow(c, pow, maxpower=16) :
         # This can be made more efficient by using powers of two
         # in the usual way.
         prd = c
-        for i in range(2, power + 1) :
+        for i in xrange(2, power + 1) :
             prd = hermemul(prd, c)
         return prd
 
@@ -710,11 +710,11 @@ def hermeder(c, m=1, scl=1, axis=0) :
     if cnt >= n:
         return c[:1]*0
     else :
-        for i in range(cnt):
+        for i in xrange(cnt):
             n = n - 1
             c *= scl
             der = np.empty((n,) + c.shape[1:], dtype=c.dtype)
-            for j in range(n, 0, -1):
+            for j in xrange(n, 0, -1):
                 der[j - 1] = j*c[j]
             c = der
     c = np.rollaxis(c, 0, iaxis + 1)
@@ -829,7 +829,7 @@ def hermeint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
 
     c = np.rollaxis(c, iaxis)
     k = list(k) + [0]*(cnt - len(k))
-    for i in range(cnt) :
+    for i in xrange(cnt) :
         n = len(c)
         c *= scl
         if n == 1 and np.all(c[0] == 0):
@@ -838,7 +838,7 @@ def hermeint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             tmp = np.empty((n + 1,) + c.shape[1:], dtype=c.dtype)
             tmp[0] = c[0]*0
             tmp[1] = c[0]
-            for j in range(1, n):
+            for j in xrange(1, n):
                 tmp[j + 1] = c[j]/(j + 1)
             tmp[0] += k[i] - hermeval(lbnd, tmp)
             c = tmp
@@ -933,7 +933,7 @@ def hermeval(x, c, tensor=True):
         nd = len(c)
         c0 = c[-2]
         c1 = c[-1]
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = c[-i] - c1*(nd - 1)
@@ -1227,7 +1227,7 @@ def hermevander(x, deg) :
     v[0] = x*0 + 1
     if ideg > 0 :
         v[1] = x
-        for i in range(2, ideg + 1) :
+        for i in xrange(2, ideg + 1) :
             v[i] = (v[i-1]*x - v[i-2]*(i - 1))
     return np.rollaxis(v, 0, v.ndim)
 

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -116,7 +116,7 @@ def poly2lag(pol) :
     [pol] = pu.as_series([pol])
     deg = len(pol) - 1
     res = 0
-    for i in range(deg, -1, -1) :
+    for i in xrange(deg, -1, -1) :
         res = lagadd(lagmulx(res), pol[i])
     return res
 
@@ -169,7 +169,7 @@ def lag2poly(c) :
         c0 = c[-2]
         c1 = c[-1]
         # i is the current degree of c1
-        for i in range(n - 1, 1, -1):
+        for i in xrange(n - 1, 1, -1):
             tmp = c0
             c0 = polysub(c[i - 2], (c1*(i - 1))/i)
             c1 = polyadd(tmp, polysub((2*i - 1)*c1, polymulx(c1))/i)
@@ -288,7 +288,7 @@ def lagfromroots(roots) :
         n = len(p)
         while n > 1:
             m, r = divmod(n, 2)
-            tmp = [lagmul(p[i], p[i+m]) for i in range(m)]
+            tmp = [lagmul(p[i], p[i+m]) for i in xrange(m)]
             if r:
                 tmp[0] = lagmul(tmp[0], p[-1])
             p = tmp
@@ -437,7 +437,7 @@ def lagmulx(c):
     prd = np.empty(len(c) + 1, dtype=c.dtype)
     prd[0] = c[0]
     prd[1] = -c[0]
-    for i in range(1, len(c)):
+    for i in xrange(1, len(c)):
         prd[i + 1] = -c[i]*(i + 1)
         prd[i] += c[i]*(2*i + 1)
         prd[i - 1] -= c[i]*i
@@ -502,7 +502,7 @@ def lagmul(c1, c2):
         nd = len(c)
         c0 = c[-2]*xs
         c1 = c[-1]*xs
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = lagsub(c[-i]*xs, (c1*(nd - 1))/nd)
@@ -567,7 +567,7 @@ def lagdiv(c1, c2):
     else :
         quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
         rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
+        for i in xrange(lc1 - lc2, - 1, -1):
             p = lagmul([0]*i + [1], c2)
             q = rem[-1]/p[-1]
             rem = rem[:-1] - q*p[:-1]
@@ -624,7 +624,7 @@ def lagpow(c, pow, maxpower=16) :
         # This can be made more efficient by using powers of two
         # in the usual way.
         prd = c
-        for i in range(2, power + 1) :
+        for i in xrange(2, power + 1) :
             prd = lagmul(prd, c)
         return prd
 
@@ -708,11 +708,11 @@ def lagder(c, m=1, scl=1, axis=0) :
     if cnt >= n:
         c = c[:1]*0
     else :
-        for i in range(cnt):
+        for i in xrange(cnt):
             n = n - 1
             c *= scl
             der = np.empty((n,) + c.shape[1:], dtype=c.dtype)
-            for j in range(n, 1, -1):
+            for j in xrange(n, 1, -1):
                 der[j - 1] = -c[j]
                 c[j - 1] += c[j]
             der[0] = -c[1]
@@ -830,7 +830,7 @@ def lagint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
 
     c = np.rollaxis(c, iaxis)
     k = list(k) + [0]*(cnt - len(k))
-    for i in range(cnt) :
+    for i in xrange(cnt) :
         n = len(c)
         c *= scl
         if n == 1 and np.all(c[0] == 0):
@@ -839,7 +839,7 @@ def lagint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             tmp = np.empty((n + 1,) + c.shape[1:], dtype=c.dtype)
             tmp[0] = c[0]
             tmp[1] = -c[0]
-            for j in range(1, n):
+            for j in xrange(1, n):
                 tmp[j] += c[j]
                 tmp[j + 1] = -c[j]
             tmp[0] += k[i] - lagval(lbnd, tmp)
@@ -936,7 +936,7 @@ def lagval(x, c, tensor=True):
         nd = len(c)
         c0 = c[-2]
         c1 = c[-1]
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = c[-i] - (c1*(nd - 1))/nd
@@ -1230,7 +1230,7 @@ def lagvander(x, deg) :
     v[0] = x*0 + 1
     if ideg > 0 :
         v[1] = 1 - x
-        for i in range(2, ideg + 1) :
+        for i in xrange(2, ideg + 1) :
             v[i] = (v[i-1]*(2*i - 1 - x) - v[i-2]*(i - 1))/i
     return np.rollaxis(v, 0, v.ndim)
 

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -142,7 +142,7 @@ def poly2leg(pol) :
     [pol] = pu.as_series([pol])
     deg = len(pol) - 1
     res = 0
-    for i in range(deg, -1, -1) :
+    for i in xrange(deg, -1, -1) :
         res = legadd(legmulx(res), pol[i])
     return res
 
@@ -201,7 +201,7 @@ def leg2poly(c) :
         c0 = c[-2]
         c1 = c[-1]
         # i is the current degree of c1
-        for i in range(n - 1, 1, -1) :
+        for i in xrange(n - 1, 1, -1) :
             tmp = c0
             c0 = polysub(c[i - 2], (c1*(i - 1))/i)
             c1 = polyadd(tmp, (polymulx(c1)*(2*i - 1))/i)
@@ -319,7 +319,7 @@ def legfromroots(roots) :
         n = len(p)
         while n > 1:
             m, r = divmod(n, 2)
-            tmp = [legmul(p[i], p[i+m]) for i in range(m)]
+            tmp = [legmul(p[i], p[i+m]) for i in xrange(m)]
             if r:
                 tmp[0] = legmul(tmp[0], p[-1])
             p = tmp
@@ -467,7 +467,7 @@ def legmulx(c):
     prd = np.empty(len(c) + 1, dtype=c.dtype)
     prd[0] = c[0]*0
     prd[1] = c[0]
-    for i in range(1, len(c)):
+    for i in xrange(1, len(c)):
         j = i + 1
         k = i - 1
         s = i + j
@@ -536,7 +536,7 @@ def legmul(c1, c2):
         nd = len(c)
         c0 = c[-2]*xs
         c1 = c[-1]*xs
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = legsub(c[-i]*xs, (c1*(nd - 1))/nd)
@@ -604,7 +604,7 @@ def legdiv(c1, c2):
     else :
         quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
         rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
+        for i in xrange(lc1 - lc2, - 1, -1):
             p = legmul([0]*i + [1], c2)
             q = rem[-1]/p[-1]
             rem = rem[:-1] - q*p[:-1]
@@ -658,7 +658,7 @@ def legpow(c, pow, maxpower=16) :
         # This can be made more efficient by using powers of two
         # in the usual way.
         prd = c
-        for i in range(2, power + 1) :
+        for i in xrange(2, power + 1) :
             prd = legmul(prd, c)
         return prd
 
@@ -747,11 +747,11 @@ def legder(c, m=1, scl=1, axis=0) :
     if cnt >= n:
         c = c[:1]*0
     else :
-        for i in range(cnt):
+        for i in xrange(cnt):
             n = n - 1
             c *= scl
             der = np.empty((n,) + c.shape[1:], dtype=c.dtype)
-            for j in range(n, 2, -1):
+            for j in xrange(n, 2, -1):
                 der[j - 1] = (2*j - 1)*c[j]
                 c[j - 2] += c[j]
             if n > 1:
@@ -872,7 +872,7 @@ def legint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
 
     c = np.rollaxis(c, iaxis)
     k = list(k) + [0]*(cnt - len(k))
-    for i in range(cnt) :
+    for i in xrange(cnt) :
         n = len(c)
         c *= scl
         if n == 1 and np.all(c[0] == 0):
@@ -883,7 +883,7 @@ def legint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             tmp[1] = c[0]
             if n > 1:
                 tmp[2] = c[1]/3
-            for j in range(2, n):
+            for j in xrange(2, n):
                 t = c[j]/(2*j + 1)
                 tmp[j + 1] = t
                 tmp[j - 1] -= t
@@ -973,7 +973,7 @@ def legval(x, c, tensor=True):
         nd = len(c)
         c0 = c[-2]
         c1 = c[-1]
-        for i in range(3, len(c) + 1) :
+        for i in xrange(3, len(c) + 1) :
             tmp = c0
             nd =  nd - 1
             c0 = c[-i] - (c1*(nd - 1))/nd
@@ -1260,7 +1260,7 @@ def legvander(x, deg) :
     v[0] = x*0 + 1
     if ideg > 0 :
         v[1] = x
-        for i in range(2, ideg + 1) :
+        for i in xrange(2, ideg + 1) :
             v[i] = (v[i-1]*x*(2*i - 1) - v[i-2]*(i - 1))/i
     return np.rollaxis(v, 0, v.ndim)
 

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -191,7 +191,7 @@ def polyfromroots(roots) :
         n = len(p)
         while n > 1:
             m, r = divmod(n, 2)
-            tmp = [polymul(p[i], p[i+m]) for i in range(m)]
+            tmp = [polymul(p[i], p[i+m]) for i in xrange(m)]
             if r:
                 tmp[0] = polymul(tmp[0], p[-1])
             p = tmp
@@ -466,7 +466,7 @@ def polypow(c, pow, maxpower=None) :
         # This can be made more efficient by using powers of two
         # in the usual way.
         prd = c
-        for i in range(2, power + 1) :
+        for i in xrange(2, power + 1) :
             prd = np.convolve(prd, c)
         return prd
 
@@ -549,11 +549,11 @@ def polyder(c, m=1, scl=1, axis=0):
     if cnt >= n:
         c = c[:1]*0
     else :
-        for i in range(cnt):
+        for i in xrange(cnt):
             n = n - 1
             c *= scl
             der = np.empty((n,) + c.shape[1:], dtype=cdt)
-            for j in range(n, 0, -1):
+            for j in xrange(n, 0, -1):
                 der[j - 1] = j*c[j]
             c = der
     c = np.rollaxis(c, 0, iaxis + 1)
@@ -665,7 +665,7 @@ def polyint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
 
     k = list(k) + [0]*(cnt - len(k))
     c = np.rollaxis(c, iaxis)
-    for i in range(cnt):
+    for i in xrange(cnt):
         n = len(c)
         c *= scl
         if n == 1 and np.all(c[0] == 0):
@@ -674,7 +674,7 @@ def polyint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             tmp = np.empty((n + 1,) + c.shape[1:], dtype=cdt)
             tmp[0] = c[0]*0
             tmp[1] = c[0]
-            for j in range(1, n):
+            for j in xrange(1, n):
                 tmp[j + 1] = c[j]/(j + 1)
             tmp[0] += k[i] - polyval(lbnd, tmp)
             c = tmp
@@ -773,7 +773,7 @@ def polyval(x, c, tensor=True):
         c = c.reshape(c.shape + (1,)*x.ndim)
 
     c0 = c[-1] + x*0
-    for i in range(2, len(c) + 1) :
+    for i in xrange(2, len(c) + 1) :
         c0 = c[-i] + c0*x
     return c0
 
@@ -1059,7 +1059,7 @@ def polyvander(x, deg) :
     v[0] = x*0 + 1
     if ideg > 0 :
         v[1] = x
-        for i in range(2, ideg + 1) :
+        for i in xrange(2, ideg + 1) :
             v[i] = v[i-1]*x
     return np.rollaxis(v, 0, v.ndim)
 

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -106,7 +106,7 @@ def trimseq(seq) :
     if len(seq) == 0 :
         return seq
     else :
-        for i in range(len(seq) - 1, -1, -1) :
+        for i in xrange(len(seq) - 1, -1, -1) :
             if seq[i] != 0 :
                 break
         return seq[:i+1]

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -30,14 +30,14 @@ Tlist = [T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]
 class TestPrivate(TestCase) :
 
     def test__cseries_to_zseries(self) :
-        for i in range(5) :
+        for i in xrange(5) :
             inp = np.array([2] + [1]*i, np.double)
             tgt = np.array([.5]*i + [2] + [.5]*i, np.double)
             res = cheb._cseries_to_zseries(inp)
             assert_equal(res, tgt)
 
     def test__zseries_to_cseries(self) :
-        for i in range(5) :
+        for i in xrange(5) :
             inp = np.array([.5]*i + [2] + [.5]*i, np.double)
             tgt = np.array([2] + [1]*i, np.double)
             res = cheb._zseries_to_cseries(inp)
@@ -62,8 +62,8 @@ class TestConstants(TestCase) :
 class TestArithmetic(TestCase) :
 
     def test_chebadd(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -72,8 +72,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_chebsub(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -84,14 +84,14 @@ class TestArithmetic(TestCase) :
     def test_chebmulx(self):
         assert_equal(cheb.chebmulx([0]), [0])
         assert_equal(cheb.chebmulx([1]), [0,1])
-        for i in range(1, 5):
+        for i in xrange(1, 5):
             ser = [0]*i + [1]
             tgt = [0]*(i - 1) + [.5, 0, .5]
             assert_equal(cheb.chebmulx(ser), tgt)
 
     def test_chebmul(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(i + j + 1)
                 tgt[i + j] += .5
@@ -100,8 +100,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_chebdiv(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 ci = [0]*i + [1]
                 cj = [0]*j + [1]
@@ -129,14 +129,14 @@ class TestEvaluation(TestCase):
         #check normal input)
         x = np.linspace(-1,1)
         y = [polyval(x, c) for c in Tlist]
-        for i in range(10) :
+        for i in xrange(10) :
             msg = "At i=%d" % i
             tgt = y[i]
             res = cheb.chebval(x, [0]*i + [1])
             assert_almost_equal(res, tgt, err_msg=msg)
 
         #check that shape is preserved
-        for i in range(3) :
+        for i in xrange(3) :
             dims = [2]*i
             x = np.zeros(dims)
             assert_equal(cheb.chebval(x, [1]).shape, dims)
@@ -215,13 +215,13 @@ class TestIntegral(TestCase) :
         assert_raises(ValueError, cheb.chebint, [0], 1, [0,0])
 
         # test integration of zero polynomial
-        for i in range(2, 5):
+        for i in xrange(2, 5):
             k = [0]*(i - 2) + [1]
             res = cheb.chebint([0], m=i, k=k)
             assert_almost_equal(res, [0, 1])
 
         # check single integration with integration constant
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [1/scl]
@@ -231,7 +231,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check single integration with integration constant and lbnd
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             chebpol = cheb.poly2cheb(pol)
@@ -239,7 +239,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(cheb.chebval(-1, chebint), i)
 
         # check single integration with integration constant and scaling
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [2/scl]
@@ -249,41 +249,41 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with default k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = cheb.chebint(tgt, m=1)
                 res = cheb.chebint(pol, m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with defined k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = cheb.chebint(tgt, m=1, k=[k])
                 res = cheb.chebint(pol, m=j, k=range(j))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = cheb.chebint(tgt, m=1, k=[k], lbnd=-1)
                 res = cheb.chebint(pol, m=j, k=range(j), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = cheb.chebint(tgt, m=1, k=[k], scl=2)
                 res = cheb.chebint(pol, m=j, k=range(j), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -313,21 +313,21 @@ class TestDerivative(TestCase) :
         assert_raises(ValueError, cheb.chebder, [0], -1)
 
         # check that zeroth deriviative does nothing
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [0]*i + [1]
             res = cheb.chebder(tgt, m=0)
             assert_equal(trim(res), trim(tgt))
 
         # check that derivation is the inverse of integration
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = cheb.chebder(cheb.chebint(tgt, m=j), m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check derivation with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = cheb.chebder(cheb.chebint(tgt, m=j, scl=2), m=j, scl=.5)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -355,7 +355,7 @@ class TestVander(TestCase):
         x = np.arange(3)
         v = cheb.chebvander(x, 3)
         assert_(v.shape == (3, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], cheb.chebval(x, coef))
 
@@ -363,7 +363,7 @@ class TestVander(TestCase):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         v = cheb.chebvander(x, 3)
         assert_(v.shape == (3, 2, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], cheb.chebval(x, coef))
 
@@ -464,7 +464,7 @@ class TestMisc(TestCase) :
     def test_chebfromroots(self) :
         res = cheb.chebfromroots([])
         assert_almost_equal(trim(res), [1])
-        for i in range(1,5) :
+        for i in xrange(1,5) :
             roots = np.cos(np.linspace(-np.pi, 0, 2*i + 1)[1::2])
             tgt = [0]*i + [1]
             res = cheb.chebfromroots(roots)*2**(i-1)
@@ -473,7 +473,7 @@ class TestMisc(TestCase) :
     def test_chebroots(self) :
         assert_almost_equal(cheb.chebroots([1]), [])
         assert_almost_equal(cheb.chebroots([1, 2]), [-.5])
-        for i in range(2,5) :
+        for i in xrange(2,5) :
             tgt = np.linspace(-1, 1, i)
             res = cheb.chebroots(cheb.chebfromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))
@@ -493,11 +493,11 @@ class TestMisc(TestCase) :
         assert_equal(cheb.chebline(3,4), [3, 4])
 
     def test_cheb2poly(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(cheb.cheb2poly([0]*i + [1]), Tlist[i])
 
     def test_poly2cheb(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(cheb.poly2cheb(Tlist[i]), [0]*i + [1])
 
     def test_weight(self):

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -459,7 +459,7 @@ def check_pow(Poly) :
     w = Poly.window + random((2,))*.25
     tgt = Poly([1], domain=d, window=d)
     tst = Poly([1, 2, 3], domain=d, window=d)
-    for i in range(5) :
+    for i in xrange(5) :
         assert_poly_almost_equal(tst**i, tgt)
         tgt = tgt * tst
     assert_raises(ValueError, tgt.__pow__, 1.5)

--- a/numpy/polynomial/tests/test_hermite.py
+++ b/numpy/polynomial/tests/test_hermite.py
@@ -47,8 +47,8 @@ class TestArithmetic(TestCase) :
     x = np.linspace(-3, 3, 100)
 
     def test_hermadd(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -57,8 +57,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_hermsub(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -69,17 +69,17 @@ class TestArithmetic(TestCase) :
     def test_hermmulx(self):
         assert_equal(herm.hermmulx([0]), [0])
         assert_equal(herm.hermmulx([1]), [0,.5])
-        for i in range(1, 5):
+        for i in xrange(1, 5):
             ser = [0]*i + [1]
             tgt = [0]*(i - 1) + [i, 0, .5]
             assert_equal(herm.hermmulx(ser), tgt)
 
     def test_hermmul(self) :
         # check values of result
-        for i in range(5) :
+        for i in xrange(5) :
             pol1 = [0]*i + [1]
             val1 = herm.hermval(self.x, pol1)
-            for j in range(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 pol2 = [0]*j + [1]
                 val2 = herm.hermval(self.x, pol2)
@@ -89,8 +89,8 @@ class TestArithmetic(TestCase) :
                 assert_almost_equal(val3, val1*val2, err_msg=msg)
 
     def test_hermdiv(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 ci = [0]*i + [1]
                 cj = [0]*j + [1]
@@ -118,7 +118,7 @@ class TestEvaluation(TestCase) :
         #check normal input)
         x = np.linspace(-1,1)
         y = [polyval(x, c) for c in Hlist]
-        for i in range(10) :
+        for i in xrange(10) :
             msg = "At i=%d" % i
             ser = np.zeros
             tgt = y[i]
@@ -126,7 +126,7 @@ class TestEvaluation(TestCase) :
             assert_almost_equal(res, tgt, err_msg=msg)
 
         #check that shape is preserved
-        for i in range(3) :
+        for i in xrange(3) :
             dims = [2]*i
             x = np.zeros(dims)
             assert_equal(herm.hermval(x, [1]).shape, dims)
@@ -205,13 +205,13 @@ class TestIntegral(TestCase) :
         assert_raises(ValueError, herm.hermint, [0], 1, [0,0])
 
         # test integration of zero polynomial
-        for i in range(2, 5):
+        for i in xrange(2, 5):
             k = [0]*(i - 2) + [1]
             res = herm.hermint([0], m=i, k=k)
             assert_almost_equal(res, [0, .5])
 
         # check single integration with integration constant
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [1/scl]
@@ -221,7 +221,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check single integration with integration constant and lbnd
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             hermpol = herm.poly2herm(pol)
@@ -229,7 +229,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(herm.hermval(-1, hermint), i)
 
         # check single integration with integration constant and scaling
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [2/scl]
@@ -239,41 +239,41 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with default k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herm.hermint(tgt, m=1)
                 res = herm.hermint(pol, m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with defined k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herm.hermint(tgt, m=1, k=[k])
                 res = herm.hermint(pol, m=j, k=range(j))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herm.hermint(tgt, m=1, k=[k], lbnd=-1)
                 res = herm.hermint(pol, m=j, k=range(j), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herm.hermint(tgt, m=1, k=[k], scl=2)
                 res = herm.hermint(pol, m=j, k=range(j), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -303,21 +303,21 @@ class TestDerivative(TestCase) :
         assert_raises(ValueError, herm.hermder, [0], -1)
 
         # check that zeroth deriviative does nothing
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [0]*i + [1]
             res = herm.hermder(tgt, m=0)
             assert_equal(trim(res), trim(tgt))
 
         # check that derivation is the inverse of integration
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = herm.hermder(herm.hermint(tgt, m=j), m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check derivation with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = herm.hermder(herm.hermint(tgt, m=j, scl=2), m=j, scl=.5)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -345,7 +345,7 @@ class TestVander(TestCase):
         x = np.arange(3)
         v = herm.hermvander(x, 3)
         assert_(v.shape == (3, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], herm.hermval(x, coef))
 
@@ -353,7 +353,7 @@ class TestVander(TestCase):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         v = herm.hermvander(x, 3)
         assert_(v.shape == (3, 2, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], herm.hermval(x, coef))
 
@@ -454,7 +454,7 @@ class TestMisc(TestCase) :
     def test_hermfromroots(self) :
         res = herm.hermfromroots([])
         assert_almost_equal(trim(res), [1])
-        for i in range(1,5) :
+        for i in xrange(1,5) :
             roots = np.cos(np.linspace(-np.pi, 0, 2*i + 1)[1::2])
             pol = herm.hermfromroots(roots)
             res = herm.hermval(roots, pol)
@@ -466,7 +466,7 @@ class TestMisc(TestCase) :
     def test_hermroots(self) :
         assert_almost_equal(herm.hermroots([1]), [])
         assert_almost_equal(herm.hermroots([1, 1]), [-.5])
-        for i in range(2,5) :
+        for i in xrange(2,5) :
             tgt = np.linspace(-1, 1, i)
             res = herm.hermroots(herm.hermfromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))
@@ -486,11 +486,11 @@ class TestMisc(TestCase) :
         assert_equal(herm.hermline(3,4), [3, 2])
 
     def test_herm2poly(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(herm.herm2poly([0]*i + [1]), Hlist[i])
 
     def test_poly2herm(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(herm.poly2herm(Hlist[i]), [0]*i + [1])
 
     def test_weight(self):

--- a/numpy/polynomial/tests/test_hermite_e.py
+++ b/numpy/polynomial/tests/test_hermite_e.py
@@ -44,8 +44,8 @@ class TestArithmetic(TestCase) :
     x = np.linspace(-3, 3, 100)
 
     def test_hermeadd(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -54,8 +54,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_hermesub(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -66,17 +66,17 @@ class TestArithmetic(TestCase) :
     def test_hermemulx(self):
         assert_equal(herme.hermemulx([0]), [0])
         assert_equal(herme.hermemulx([1]), [0,1])
-        for i in range(1, 5):
+        for i in xrange(1, 5):
             ser = [0]*i + [1]
             tgt = [0]*(i - 1) + [i, 0, 1]
             assert_equal(herme.hermemulx(ser), tgt)
 
     def test_hermemul(self) :
         # check values of result
-        for i in range(5) :
+        for i in xrange(5) :
             pol1 = [0]*i + [1]
             val1 = herme.hermeval(self.x, pol1)
-            for j in range(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 pol2 = [0]*j + [1]
                 val2 = herme.hermeval(self.x, pol2)
@@ -86,8 +86,8 @@ class TestArithmetic(TestCase) :
                 assert_almost_equal(val3, val1*val2, err_msg=msg)
 
     def test_hermediv(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 ci = [0]*i + [1]
                 cj = [0]*j + [1]
@@ -115,7 +115,7 @@ class TestEvaluation(TestCase) :
         #check normal input)
         x = np.linspace(-1,1)
         y = [polyval(x, c) for c in Helist]
-        for i in range(10) :
+        for i in xrange(10) :
             msg = "At i=%d" % i
             ser = np.zeros
             tgt = y[i]
@@ -123,7 +123,7 @@ class TestEvaluation(TestCase) :
             assert_almost_equal(res, tgt, err_msg=msg)
 
         #check that shape is preserved
-        for i in range(3) :
+        for i in xrange(3) :
             dims = [2]*i
             x = np.zeros(dims)
             assert_equal(herme.hermeval(x, [1]).shape, dims)
@@ -202,13 +202,13 @@ class TestIntegral(TestCase):
         assert_raises(ValueError, herme.hermeint, [0], 1, [0,0])
 
         # test integration of zero polynomial
-        for i in range(2, 5):
+        for i in xrange(2, 5):
             k = [0]*(i - 2) + [1]
             res = herme.hermeint([0], m=i, k=k)
             assert_almost_equal(res, [0, 1])
 
         # check single integration with integration constant
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [1/scl]
@@ -218,7 +218,7 @@ class TestIntegral(TestCase):
             assert_almost_equal(trim(res), trim(tgt))
 
         # check single integration with integration constant and lbnd
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             hermepol = herme.poly2herme(pol)
@@ -226,7 +226,7 @@ class TestIntegral(TestCase):
             assert_almost_equal(herme.hermeval(-1, hermeint), i)
 
         # check single integration with integration constant and scaling
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [2/scl]
@@ -236,41 +236,41 @@ class TestIntegral(TestCase):
             assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with default k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herme.hermeint(tgt, m=1)
                 res = herme.hermeint(pol, m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with defined k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herme.hermeint(tgt, m=1, k=[k])
                 res = herme.hermeint(pol, m=j, k=range(j))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herme.hermeint(tgt, m=1, k=[k], lbnd=-1)
                 res = herme.hermeint(pol, m=j, k=range(j), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = herme.hermeint(tgt, m=1, k=[k], scl=2)
                 res = herme.hermeint(pol, m=j, k=range(j), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -300,21 +300,21 @@ class TestDerivative(TestCase) :
         assert_raises(ValueError, herme.hermeder, [0], -1)
 
         # check that zeroth deriviative does nothing
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [0]*i + [1]
             res = herme.hermeder(tgt, m=0)
             assert_equal(trim(res), trim(tgt))
 
         # check that derivation is the inverse of integration
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = herme.hermeder(herme.hermeint(tgt, m=j), m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check derivation with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = herme.hermeder(herme.hermeint(tgt, m=j, scl=2), m=j, scl=.5)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -342,7 +342,7 @@ class TestVander(TestCase):
         x = np.arange(3)
         v = herme.hermevander(x, 3)
         assert_(v.shape == (3, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], herme.hermeval(x, coef))
 
@@ -350,7 +350,7 @@ class TestVander(TestCase):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         v = herme.hermevander(x, 3)
         assert_(v.shape == (3, 2, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], herme.hermeval(x, coef))
 
@@ -451,7 +451,7 @@ class TestMisc(TestCase) :
     def test_hermefromroots(self) :
         res = herme.hermefromroots([])
         assert_almost_equal(trim(res), [1])
-        for i in range(1,5) :
+        for i in xrange(1,5) :
             roots = np.cos(np.linspace(-np.pi, 0, 2*i + 1)[1::2])
             pol = herme.hermefromroots(roots)
             res = herme.hermeval(roots, pol)
@@ -463,7 +463,7 @@ class TestMisc(TestCase) :
     def test_hermeroots(self) :
         assert_almost_equal(herme.hermeroots([1]), [])
         assert_almost_equal(herme.hermeroots([1, 1]), [-1])
-        for i in range(2,5) :
+        for i in xrange(2,5) :
             tgt = np.linspace(-1, 1, i)
             res = herme.hermeroots(herme.hermefromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))
@@ -483,11 +483,11 @@ class TestMisc(TestCase) :
         assert_equal(herme.hermeline(3,4), [3, 4])
 
     def test_herme2poly(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(herme.herme2poly([0]*i + [1]), Helist[i])
 
     def test_poly2herme(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(herme.poly2herme(Helist[i]), [0]*i + [1])
 
     def test_weight(self):

--- a/numpy/polynomial/tests/test_laguerre.py
+++ b/numpy/polynomial/tests/test_laguerre.py
@@ -43,8 +43,8 @@ class TestArithmetic(TestCase) :
     x = np.linspace(-3, 3, 100)
 
     def test_lagadd(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -53,8 +53,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_lagsub(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -65,17 +65,17 @@ class TestArithmetic(TestCase) :
     def test_lagmulx(self):
         assert_equal(lag.lagmulx([0]), [0])
         assert_equal(lag.lagmulx([1]), [1,-1])
-        for i in range(1, 5):
+        for i in xrange(1, 5):
             ser = [0]*i + [1]
             tgt = [0]*(i - 1) + [-i, 2*i + 1, -(i + 1)]
             assert_almost_equal(lag.lagmulx(ser), tgt)
 
     def test_lagmul(self) :
         # check values of result
-        for i in range(5) :
+        for i in xrange(5) :
             pol1 = [0]*i + [1]
             val1 = lag.lagval(self.x, pol1)
-            for j in range(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 pol2 = [0]*j + [1]
                 val2 = lag.lagval(self.x, pol2)
@@ -85,8 +85,8 @@ class TestArithmetic(TestCase) :
                 assert_almost_equal(val3, val1*val2, err_msg=msg)
 
     def test_lagdiv(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 ci = [0]*i + [1]
                 cj = [0]*j + [1]
@@ -113,7 +113,7 @@ class TestEvaluation(TestCase) :
         #check normal input)
         x = np.linspace(-1,1)
         y = [polyval(x, c) for c in Llist]
-        for i in range(7) :
+        for i in xrange(7) :
             msg = "At i=%d" % i
             ser = np.zeros
             tgt = y[i]
@@ -121,7 +121,7 @@ class TestEvaluation(TestCase) :
             assert_almost_equal(res, tgt, err_msg=msg)
 
         #check that shape is preserved
-        for i in range(3) :
+        for i in xrange(3) :
             dims = [2]*i
             x = np.zeros(dims)
             assert_equal(lag.lagval(x, [1]).shape, dims)
@@ -200,13 +200,13 @@ class TestIntegral(TestCase) :
         assert_raises(ValueError, lag.lagint, [0], 1, [0,0])
 
         # test integration of zero polynomial
-        for i in range(2, 5):
+        for i in xrange(2, 5):
             k = [0]*(i - 2) + [1]
             res = lag.lagint([0], m=i, k=k)
             assert_almost_equal(res, [1, -1])
 
         # check single integration with integration constant
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [1/scl]
@@ -216,7 +216,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check single integration with integration constant and lbnd
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             lagpol = lag.poly2lag(pol)
@@ -224,7 +224,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(lag.lagval(-1, lagint), i)
 
         # check single integration with integration constant and scaling
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [2/scl]
@@ -234,41 +234,41 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with default k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = lag.lagint(tgt, m=1)
                 res = lag.lagint(pol, m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with defined k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = lag.lagint(tgt, m=1, k=[k])
                 res = lag.lagint(pol, m=j, k=range(j))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = lag.lagint(tgt, m=1, k=[k], lbnd=-1)
                 res = lag.lagint(pol, m=j, k=range(j), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = lag.lagint(tgt, m=1, k=[k], scl=2)
                 res = lag.lagint(pol, m=j, k=range(j), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -298,21 +298,21 @@ class TestDerivative(TestCase) :
         assert_raises(ValueError, lag.lagder, [0], -1)
 
         # check that zeroth deriviative does nothing
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [0]*i + [1]
             res = lag.lagder(tgt, m=0)
             assert_equal(trim(res), trim(tgt))
 
         # check that derivation is the inverse of integration
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = lag.lagder(lag.lagint(tgt, m=j), m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check derivation with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = lag.lagder(lag.lagint(tgt, m=j, scl=2), m=j, scl=.5)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -340,7 +340,7 @@ class TestVander(TestCase):
         x = np.arange(3)
         v = lag.lagvander(x, 3)
         assert_(v.shape == (3, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], lag.lagval(x, coef))
 
@@ -348,7 +348,7 @@ class TestVander(TestCase):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         v = lag.lagvander(x, 3)
         assert_(v.shape == (3, 2, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], lag.lagval(x, coef))
 
@@ -449,7 +449,7 @@ class TestMisc(TestCase) :
     def test_lagfromroots(self) :
         res = lag.lagfromroots([])
         assert_almost_equal(trim(res), [1])
-        for i in range(1,5) :
+        for i in xrange(1,5) :
             roots = np.cos(np.linspace(-np.pi, 0, 2*i + 1)[1::2])
             pol = lag.lagfromroots(roots)
             res = lag.lagval(roots, pol)
@@ -461,7 +461,7 @@ class TestMisc(TestCase) :
     def test_lagroots(self) :
         assert_almost_equal(lag.lagroots([1]), [])
         assert_almost_equal(lag.lagroots([0, 1]), [1])
-        for i in range(2,5) :
+        for i in xrange(2,5) :
             tgt = np.linspace(0, 3, i)
             res = lag.lagroots(lag.lagfromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))
@@ -481,11 +481,11 @@ class TestMisc(TestCase) :
         assert_equal(lag.lagline(3,4), [7, -4])
 
     def test_lag2poly(self) :
-        for i in range(7) :
+        for i in xrange(7) :
             assert_almost_equal(lag.lag2poly([0]*i + [1]), Llist[i])
 
     def test_poly2lag(self) :
-        for i in range(7) :
+        for i in xrange(7) :
             assert_almost_equal(lag.poly2lag(Llist[i]), [0]*i + [1])
 
     def test_weight(self):

--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -46,8 +46,8 @@ class TestArithmetic(TestCase) :
     x = np.linspace(-1, 1, 100)
 
     def test_legadd(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -56,8 +56,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_legsub(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -68,7 +68,7 @@ class TestArithmetic(TestCase) :
     def test_legmulx(self):
         assert_equal(leg.legmulx([0]), [0])
         assert_equal(leg.legmulx([1]), [0,1])
-        for i in range(1, 5):
+        for i in xrange(1, 5):
             tmp = 2*i + 1
             ser = [0]*i + [1]
             tgt = [0]*(i - 1) + [i/tmp, 0, (i + 1)/tmp]
@@ -76,10 +76,10 @@ class TestArithmetic(TestCase) :
 
     def test_legmul(self) :
         # check values of result
-        for i in range(5) :
+        for i in xrange(5) :
             pol1 = [0]*i + [1]
             val1 = leg.legval(self.x, pol1)
-            for j in range(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 pol2 = [0]*j + [1]
                 val2 = leg.legval(self.x, pol2)
@@ -89,8 +89,8 @@ class TestArithmetic(TestCase) :
                 assert_almost_equal(val3, val1*val2, err_msg=msg)
 
     def test_legdiv(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 ci = [0]*i + [1]
                 cj = [0]*j + [1]
@@ -117,7 +117,7 @@ class TestEvaluation(TestCase) :
         #check normal input)
         x = np.linspace(-1,1)
         y = [polyval(x, c) for c in Llist]
-        for i in range(10) :
+        for i in xrange(10) :
             msg = "At i=%d" % i
             ser = np.zeros
             tgt = y[i]
@@ -125,7 +125,7 @@ class TestEvaluation(TestCase) :
             assert_almost_equal(res, tgt, err_msg=msg)
 
         #check that shape is preserved
-        for i in range(3) :
+        for i in xrange(3) :
             dims = [2]*i
             x = np.zeros(dims)
             assert_equal(leg.legval(x, [1]).shape, dims)
@@ -204,13 +204,13 @@ class TestIntegral(TestCase) :
         assert_raises(ValueError, leg.legint, [0], 1, [0,0])
 
         # test integration of zero polynomial
-        for i in range(2, 5):
+        for i in xrange(2, 5):
             k = [0]*(i - 2) + [1]
             res = leg.legint([0], m=i, k=k)
             assert_almost_equal(res, [0, 1])
 
         # check single integration with integration constant
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [1/scl]
@@ -220,7 +220,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check single integration with integration constant and lbnd
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             legpol = leg.poly2leg(pol)
@@ -228,7 +228,7 @@ class TestIntegral(TestCase) :
             assert_almost_equal(leg.legval(-1, legint), i)
 
         # check single integration with integration constant and scaling
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [2/scl]
@@ -238,41 +238,41 @@ class TestIntegral(TestCase) :
             assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with default k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = leg.legint(tgt, m=1)
                 res = leg.legint(pol, m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with defined k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = leg.legint(tgt, m=1, k=[k])
                 res = leg.legint(pol, m=j, k=range(j))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = leg.legint(tgt, m=1, k=[k], lbnd=-1)
                 res = leg.legint(pol, m=j, k=range(j), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = leg.legint(tgt, m=1, k=[k], scl=2)
                 res = leg.legint(pol, m=j, k=range(j), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -302,21 +302,21 @@ class TestDerivative(TestCase) :
         assert_raises(ValueError, leg.legder, [0], -1)
 
         # check that zeroth deriviative does nothing
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [0]*i + [1]
             res = leg.legder(tgt, m=0)
             assert_equal(trim(res), trim(tgt))
 
         # check that derivation is the inverse of integration
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = leg.legder(leg.legint(tgt, m=j), m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check derivation with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = leg.legder(leg.legint(tgt, m=j, scl=2), m=j, scl=.5)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -344,7 +344,7 @@ class TestVander(TestCase):
         x = np.arange(3)
         v = leg.legvander(x, 3)
         assert_(v.shape == (3, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], leg.legval(x, coef))
 
@@ -352,7 +352,7 @@ class TestVander(TestCase):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         v = leg.legvander(x, 3)
         assert_(v.shape == (3, 2, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], leg.legval(x, coef))
 
@@ -452,7 +452,7 @@ class TestMisc(TestCase) :
     def test_legfromroots(self) :
         res = leg.legfromroots([])
         assert_almost_equal(trim(res), [1])
-        for i in range(1,5) :
+        for i in xrange(1,5) :
             roots = np.cos(np.linspace(-np.pi, 0, 2*i + 1)[1::2])
             pol = leg.legfromroots(roots)
             res = leg.legval(roots, pol)
@@ -464,7 +464,7 @@ class TestMisc(TestCase) :
     def test_legroots(self) :
         assert_almost_equal(leg.legroots([1]), [])
         assert_almost_equal(leg.legroots([1, 2]), [-.5])
-        for i in range(2,5) :
+        for i in xrange(2,5) :
             tgt = np.linspace(-1, 1, i)
             res = leg.legroots(leg.legfromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))
@@ -484,11 +484,11 @@ class TestMisc(TestCase) :
         assert_equal(leg.legline(3,4), [3, 4])
 
     def test_leg2poly(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(leg.leg2poly([0]*i + [1]), Llist[i])
 
     def test_poly2leg(self) :
-        for i in range(10) :
+        for i in xrange(10) :
             assert_almost_equal(leg.poly2leg(Llist[i]), [0]*i + [1])
 
     def test_weight(self):

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -44,8 +44,8 @@ class TestConstants(TestCase) :
 class TestArithmetic(TestCase) :
 
     def test_polyadd(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -54,8 +54,8 @@ class TestArithmetic(TestCase) :
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_polysub(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(max(i,j) + 1)
                 tgt[i] += 1
@@ -66,14 +66,14 @@ class TestArithmetic(TestCase) :
     def test_polymulx(self):
         assert_equal(poly.polymulx([0]), [0])
         assert_equal(poly.polymulx([1]), [0, 1])
-        for i in range(1, 5):
+        for i in xrange(1, 5):
             ser = [0]*i + [1]
             tgt = [0]*(i + 1) + [1]
             assert_equal(poly.polymulx(ser), tgt)
 
     def test_polymul(self) :
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 tgt = np.zeros(i + j + 1)
                 tgt[i + j] += 1
@@ -91,8 +91,8 @@ class TestArithmetic(TestCase) :
         assert_equal((quo, rem), ((1,1), 0))
 
         # check rest.
-        for i in range(5) :
-            for j in range(5) :
+        for i in xrange(5) :
+            for j in xrange(5) :
                 msg = "At i=%d, j=%d" % (i,j)
                 ci = [0]*i + [1,2]
                 cj = [0]*j + [1,2]
@@ -119,8 +119,8 @@ class TestEvaluation(TestCase):
 
         #check normal input)
         x = np.linspace(-1,1)
-        y = [x**i for i in range(5)]
-        for i in range(5) :
+        y = [x**i for i in xrange(5)]
+        for i in xrange(5) :
             tgt = y[i]
             res = poly.polyval(x, [0]*i + [1])
             assert_almost_equal(res, tgt)
@@ -129,7 +129,7 @@ class TestEvaluation(TestCase):
         assert_almost_equal(res, tgt)
 
         #check that shape is preserved
-        for i in range(3) :
+        for i in xrange(3) :
             dims = [2]*i
             x = np.zeros(dims)
             assert_equal(poly.polyval(x, [1]).shape, dims)
@@ -208,13 +208,13 @@ class TestIntegral(TestCase):
         assert_raises(ValueError, poly.polyint, [0], 1, [0,0])
 
         # test integration of zero polynomial
-        for i in range(2, 5):
+        for i in xrange(2, 5):
             k = [0]*(i - 2) + [1]
             res = poly.polyint([0], m=i, k=k)
             assert_almost_equal(res, [0, 1])
 
         # check single integration with integration constant
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [1/scl]
@@ -222,14 +222,14 @@ class TestIntegral(TestCase):
             assert_almost_equal(trim(res), trim(tgt))
 
         # check single integration with integration constant and lbnd
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             res = poly.polyint(pol, m=1, k=[i], lbnd=-1)
             assert_almost_equal(poly.polyval(-1, res), i)
 
         # check single integration with integration constant and scaling
-        for i in range(5) :
+        for i in xrange(5) :
             scl = i + 1
             pol = [0]*i + [1]
             tgt = [i] + [0]*i + [2/scl]
@@ -237,41 +237,41 @@ class TestIntegral(TestCase):
             assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with default k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = poly.polyint(tgt, m=1)
                 res = poly.polyint(pol, m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with defined k
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = poly.polyint(tgt, m=1, k=[k])
                 res = poly.polyint(pol, m=j, k=range(j))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = poly.polyint(tgt, m=1, k=[k], lbnd=-1)
                 res = poly.polyint(pol, m=j, k=range(j), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 pol = [0]*i + [1]
                 tgt = pol[:]
-                for k in range(j) :
+                for k in xrange(j) :
                     tgt = poly.polyint(tgt, m=1, k=[k], scl=2)
                 res = poly.polyint(pol, m=j, k=range(j), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -301,21 +301,21 @@ class TestDerivative(TestCase) :
         assert_raises(ValueError, poly.polyder, [0], -1)
 
         # check that zeroth deriviative does nothing
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [0]*i + [1]
             res = poly.polyder(tgt, m=0)
             assert_equal(trim(res), trim(tgt))
 
         # check that derivation is the inverse of integration
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = poly.polyder(poly.polyint(tgt, m=j), m=j)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check derivation with scaling
-        for i in range(5) :
-            for j in range(2,5) :
+        for i in xrange(5) :
+            for j in xrange(2,5) :
                 tgt = [0]*i + [1]
                 res = poly.polyder(poly.polyint(tgt, m=j, scl=2), m=j, scl=.5)
                 assert_almost_equal(trim(res), trim(tgt))
@@ -343,7 +343,7 @@ class TestVander(TestCase):
         x = np.arange(3)
         v = poly.polyvander(x, 3)
         assert_(v.shape == (3, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], poly.polyval(x, coef))
 
@@ -351,7 +351,7 @@ class TestVander(TestCase):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         v = poly.polyvander(x, 3)
         assert_(v.shape == (3, 2, 4))
-        for i in range(4) :
+        for i in xrange(4) :
             coef = [0]*i + [1]
             assert_almost_equal(v[..., i], poly.polyval(x, coef))
 
@@ -388,7 +388,7 @@ class TestMisc(TestCase) :
     def test_polyfromroots(self) :
         res = poly.polyfromroots([])
         assert_almost_equal(trim(res), [1])
-        for i in range(1,5) :
+        for i in xrange(1,5) :
             roots = np.cos(np.linspace(-np.pi, 0, 2*i + 1)[1::2])
             tgt = Tlist[i]
             res = poly.polyfromroots(roots)*2**(i-1)
@@ -397,7 +397,7 @@ class TestMisc(TestCase) :
     def test_polyroots(self) :
         assert_almost_equal(poly.polyroots([1]), [])
         assert_almost_equal(poly.polyroots([1, 2]), [-.5])
-        for i in range(2,5) :
+        for i in xrange(2,5) :
             tgt = np.linspace(-1, 1, i)
             res = poly.polyroots(poly.polyfromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -10,7 +10,7 @@ from numpy.testing import *
 class TestMisc(TestCase) :
 
     def test_trimseq(self) :
-        for i in range(5) :
+        for i in xrange(5) :
             tgt = [1]
             res = pu.trimseq([1] + [0]*5)
             assert_equal(res, tgt)
@@ -22,8 +22,8 @@ class TestMisc(TestCase) :
         assert_raises(ValueError, pu.as_series, [[1],['a']])
         # check common types
         types = ['i', 'd', 'O']
-        for i in range(len(types))  :
-            for j in range(i) :
+        for i in xrange(len(types))  :
+            for j in xrange(i) :
                 ci = np.ones(1, types[i])
                 cj = np.ones(1, types[j])
                 [resi, resj] = pu.as_series([ci, cj])

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -67,7 +67,7 @@ class TestRegression(TestCase):
         # Check that custom RandomState does not call into global state
         m = np.random.RandomState()
         res = np.array([0, 8, 7, 2, 1, 9, 4, 7, 0, 3])
-        for i in range(3):
+        for i in xrange(3):
             np.random.seed(i)
             m.seed(4321)
             # If m.state is not honored, the result will change

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -102,7 +102,7 @@ def rand(*args):
     from numpy.core import zeros, float64
     results = zeros(args, float64)
     f = results.flat
-    for i in range(len(f)):
+    for i in xrange(len(f)):
         f[i] = random.random()
     return results
 
@@ -248,7 +248,7 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
         return
     if isinstance(desired, (list,tuple)) and isinstance(actual, (list,tuple)):
         assert_equal(len(actual),len(desired),err_msg,verbose)
-        for k in range(len(desired)):
+        for k in xrange(len(desired)):
             assert_equal(actual[k], desired[k], 'item=%r\n%s' % (k,err_msg), verbose)
         return
     from numpy.core import ndarray, isscalar, signbit
@@ -1092,7 +1092,7 @@ def measure(code_str,times=1,label=None):
 
     Examples
     --------
-    >>> etime = np.testing.measure('for i in range(1000): np.sqrt(i**2)',
+    >>> etime = np.testing.measure('for i in xrange(1000): np.sqrt(i**2)',
     ...                            times=times)
     >>> print "Time for a single execution : ", etime / times, "s"
     Time for a single execution :  0.005 s
@@ -1125,7 +1125,7 @@ def _assert_valid_refcount(op):
     i = 1
 
     rc = sys.getrefcount(i)
-    for j in range(15):
+    for j in xrange(15):
         d = op(b,c)
 
     assert_(sys.getrefcount(i) >= rc)


### PR DESCRIPTION
The 2to3 conversion will replaces xrange by range, i.e., using range in
this way is legitimate in both python 2 and python 3. The remaining use
of range is then replaced with list(range(*)).

The idea is to get the other fixups done, then replace all xrange with
range to finish the job.
