### PR TITLE
2to3-getcwdu-to-metaclass

### DIFF
--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -147,8 +147,8 @@ def format_in_columns(lst, max_columns):
     Format a list containing strings to a string containing the items
     in columns.
     """
-    lst = map(str, lst)
-    col_len = max(map(len, lst)) + 2
+    lst = list(map(str, lst))
+    col_len = max(list(map(len, lst))) + 2
     ncols = 80//col_len
     if ncols > max_columns:
         ncols = max_columns

--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -150,7 +150,7 @@ def joinseq(seq):
 def strseq(object, convert, join=joinseq):
     """Recursively walk a sequence, stringifying each element."""
     if type(object) in [types.ListType, types.TupleType]:
-        return join(map(lambda o, c=convert, j=join: strseq(o, c, j), object))
+        return join(list(map(lambda o, c=convert, j=join: strseq(o, c, j), object)))
     else:
         return convert(object)
 

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -111,7 +111,7 @@ if sys.version_info[0] >= 3:
 # "import string" is costly to import!
 # Construct the translation tables directly
 #   "A" = chr(65), "a" = chr(97)
-_all_chars = map(chr, range(256))
+_all_chars = list(map(chr, range(256)))
 _ascii_upper = _all_chars[65:65+26]
 _ascii_lower = _all_chars[97:97+26]
 LOWER_TABLE="".join(_all_chars[:65] + _ascii_lower + _all_chars[65+26:])

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -223,7 +223,7 @@ def vstack(tup):
            [4]])
 
     """
-    return _nx.concatenate(map(atleast_2d,tup),0)
+    return _nx.concatenate(list(map(atleast_2d,tup)),0)
 
 def hstack(tup):
     """
@@ -267,7 +267,7 @@ def hstack(tup):
            [3, 4]])
 
     """
-    arrs = map(atleast_1d,tup)
+    arrs = list(map(atleast_1d,tup))
     # As a special case, dimension 0 of 1-dimensional arrays is "horizontal"
     if arrs[0].ndim == 1:
         return _nx.concatenate(arrs, 0)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -88,10 +88,10 @@ class TestConversion(TestCase):
         li = [10**6, 10**12, 10**18, -10**6, -10**12, -10**18]
         for T in [None, np.float64, np.int64]:
             a = np.array(l,dtype=T)
-            assert_equal(map(int,a), li)
+            assert_equal(list(map(int,a)), li)
 
         a = np.array(l[:3], dtype=np.uint64)
-        assert_equal(map(int,a), li[:3])
+        assert_equal(list(map(int,a)), li[:3])
 
 
 #class TestRepr(TestCase):

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -8,26 +8,26 @@ from numpy.core import (array, arange, atleast_1d, atleast_2d, atleast_3d,
 class TestAtleast1d(TestCase):
     def test_0D_array(self):
         a = array(1); b = array(2);
-        res=map(atleast_1d,[a,b])
+        res=list(map(atleast_1d,[a,b]))
         desired = [array([1]),array([2])]
         assert_array_equal(res,desired)
 
     def test_1D_array(self):
         a = array([1,2]); b = array([2,3]);
-        res=map(atleast_1d,[a,b])
+        res=list(map(atleast_1d,[a,b]))
         desired = [array([1,2]),array([2,3])]
         assert_array_equal(res,desired)
 
     def test_2D_array(self):
         a = array([[1,2],[1,2]]); b = array([[2,3],[2,3]]);
-        res=map(atleast_1d,[a,b])
+        res=list(map(atleast_1d,[a,b]))
         desired = [a,b]
         assert_array_equal(res,desired)
 
     def test_3D_array(self):
         a = array([[1,2],[1,2]]); b = array([[2,3],[2,3]]);
         a = array([a,a]);b = array([b,b]);
-        res=map(atleast_1d,[a,b])
+        res=list(map(atleast_1d,[a,b]))
         desired = [a,b]
         assert_array_equal(res,desired)
 
@@ -44,26 +44,26 @@ class TestAtleast1d(TestCase):
 class TestAtleast2d(TestCase):
     def test_0D_array(self):
         a = array(1); b = array(2);
-        res=map(atleast_2d,[a,b])
+        res=list(map(atleast_2d,[a,b]))
         desired = [array([[1]]),array([[2]])]
         assert_array_equal(res,desired)
 
     def test_1D_array(self):
         a = array([1,2]); b = array([2,3]);
-        res=map(atleast_2d,[a,b])
+        res=list(map(atleast_2d,[a,b]))
         desired = [array([[1,2]]),array([[2,3]])]
         assert_array_equal(res,desired)
 
     def test_2D_array(self):
         a = array([[1,2],[1,2]]); b = array([[2,3],[2,3]]);
-        res=map(atleast_2d,[a,b])
+        res=list(map(atleast_2d,[a,b]))
         desired = [a,b]
         assert_array_equal(res,desired)
 
     def test_3D_array(self):
         a = array([[1,2],[1,2]]); b = array([[2,3],[2,3]]);
         a = array([a,a]);b = array([b,b]);
-        res=map(atleast_2d,[a,b])
+        res=list(map(atleast_2d,[a,b]))
         desired = [a,b]
         assert_array_equal(res,desired)
 
@@ -78,26 +78,26 @@ class TestAtleast2d(TestCase):
 class TestAtleast3d(TestCase):
     def test_0D_array(self):
         a = array(1); b = array(2);
-        res=map(atleast_3d,[a,b])
+        res=list(map(atleast_3d,[a,b]))
         desired = [array([[[1]]]),array([[[2]]])]
         assert_array_equal(res,desired)
 
     def test_1D_array(self):
         a = array([1,2]); b = array([2,3]);
-        res=map(atleast_3d,[a,b])
+        res=list(map(atleast_3d,[a,b]))
         desired = [array([[[1],[2]]]),array([[[2],[3]]])]
         assert_array_equal(res,desired)
 
     def test_2D_array(self):
         a = array([[1,2],[1,2]]); b = array([[2,3],[2,3]]);
-        res=map(atleast_3d,[a,b])
+        res=list(map(atleast_3d,[a,b]))
         desired = [a[:,:,newaxis],b[:,:,newaxis]]
         assert_array_equal(res,desired)
 
     def test_3D_array(self):
         a = array([[1,2],[1,2]]); b = array([[2,3],[2,3]]);
         a = array([a,a]);b = array([b,b]);
-        res=map(atleast_3d,[a,b])
+        res=list(map(atleast_3d,[a,b]))
         desired = [a,b]
         assert_array_equal(res,desired)
 

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2070,7 +2070,7 @@ def combine_paths(*args, **kws):
     if not args:
         return []
     if len(args) == 1:
-        result = reduce(lambda a, b: a + b, map(glob, args[0]), [])
+        result = reduce(lambda a, b: a + b, list(map(glob, args[0])), [])
     elif len(args) == 2:
         result = []
         for a0 in args[0]:

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -607,9 +607,9 @@ def stripcomma(s):
 
 def replace(str,d,defaultsep=''):
     if type(d)==types.ListType:
-        return map(lambda d,f=replace,sep=defaultsep,s=str:f(s,d,sep),d)
+        return list(map(lambda d,f=replace,sep=defaultsep,s=str:f(s,d,sep),d))
     if type(str)==types.ListType:
-        return map(lambda s,f=replace,sep=defaultsep,d=d:f(s,d,sep),str)
+        return list(map(lambda s,f=replace,sep=defaultsep,d=d:f(s,d,sep),str))
     for k in 2*d.keys():
         if k=='separatorsfor':
             continue

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1210,7 +1210,7 @@ def get_needs():
                 else:
                     out.append(outneeds[n][0])
                     del outneeds[n][0]
-            if saveout and (0 not in map(lambda x,y:x==y,saveout,outneeds[n])) \
+            if saveout and (0 not in list(map(lambda x,y:x==y,saveout,outneeds[n]))) \
                    and outneeds[n] != []:
                 print n,saveout
                 errmess('get_needs: no progress in sorting needs, probably circular dependence, skipping.\n')

--- a/numpy/f2py/common_rules.py
+++ b/numpy/f2py/common_rules.py
@@ -94,7 +94,7 @@ def buildhooks(m):
             cadd('\t{\"%s\",%s,{{%s}},%s},'%(n,dm['rank'],dms,at))
         cadd('\t{NULL}\n};')
         inames1 = rmbadname(inames)
-        inames1_tps = ','.join(map(lambda s:'char *'+s,inames1))
+        inames1_tps = ','.join(['char *'+s for s in inames1])
         cadd('static void f2py_setup_%s(%s) {'%(name,inames1_tps))
         cadd('\tint i_f2py=0;')
         for n in inames1:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -219,7 +219,7 @@ def rmbadname1(name):
         errmess('rmbadname1: Replacing "%s" with "%s".\n'%(name,badnames[name]))
         return badnames[name]
     return name
-def rmbadname(names): return map(rmbadname1,names)
+def rmbadname(names): return list(map(rmbadname1,names))
 
 def undo_rmbadname1(name):
     if name in invbadnames:
@@ -227,7 +227,7 @@ def undo_rmbadname1(name):
                 %(name,invbadnames[name]))
         return invbadnames[name]
     return name
-def undo_rmbadname(names): return map(undo_rmbadname1,names)
+def undo_rmbadname(names): return list(map(undo_rmbadname1,names))
 
 def getextension(name):
     i=name.rfind('.')
@@ -290,7 +290,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
     mline_mark = re.compile(r".*?'''")
     if istop: dowithline('',-1)
     ll,l1='',''
-    spacedigits=[' ']+map(str,range(10))
+    spacedigits=[' ']+list(map(str,range(10)))
     filepositiontext=''
     fin=fileinput.FileInput(ffile)
     while 1:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -322,7 +322,7 @@ def buildmodules(lst):
     ret = {}
     for i in range(len(mnames)):
         if mnames[i] in isusedby:
-            outmess('\tSkipping module "%s" which is used by %s.\n'%(mnames[i],','.join(map(lambda s:'"%s"'%s,isusedby[mnames[i]]))))
+            outmess('\tSkipping module "%s" which is used by %s.\n'%(mnames[i],','.join(['"%s"'%s for s in isusedby[mnames[i]]])))
         else:
             um=[]
             if 'use' in modules[i]:
@@ -370,7 +370,7 @@ def run_main(comline_list):
         if postlist[i]['block']=='python module' and '__user__' in postlist[i]['name']:
             if postlist[i]['name'] in isusedby:
                 #if not quiet:
-                outmess('Skipping Makefile build for module "%s" which is used by %s\n'%(postlist[i]['name'],','.join(map(lambda s:'"%s"'%s,isusedby[postlist[i]['name']]))))
+                outmess('Skipping Makefile build for module "%s" which is used by %s\n'%(postlist[i]['name'],','.join(['"%s"'%s for s in isusedby[postlist[i]['name']]])))
     if 'signsfile' in options:
         if options['verbose']>1:
             outmess('Stopping. Edit the signature file and then run f2py on the signature file: ')

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -156,7 +156,7 @@ def buildhooks(pymod):
                 fadd('integer flag\n')
                 fhooks[0]=fhooks[0]+fgetdims1
                 dms = eval('range(1,%s+1)'%(dm['rank']))
-                fadd(' allocate(d(%s))\n'%(','.join(map(lambda i:'s(%s)'%i,dms))))
+                fadd(' allocate(d(%s))\n'%(','.join(['s(%s)'%i for i in dms])))
                 fhooks[0]=fhooks[0]+use_fgetdims2
                 fadd('end subroutine %s'%(fargs[-1]))
             else:

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -136,10 +136,10 @@ class Type(object):
         self.dtypechar = typeinfo[self.NAME][0]
 
     def cast_types(self):
-        return map(self.__class__,self._cast_dict[self.NAME])
+        return list(map(self.__class__,self._cast_dict[self.NAME]))
 
     def all_types(self):
-        return map(self.__class__,self._type_names)
+        return list(map(self.__class__,self._type_names))
 
     def smaller_types(self):
         bits = typeinfo[self.NAME][3]

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -712,7 +712,7 @@ class StringConverter(object):
             value = (value,)
         _strict_call = self._strict_call
         try:
-            map(_strict_call, value)
+            list(map(_strict_call, value))
         except ValueError:
             # Raise an exception if we locked the converter...
             if self._locked:

--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -110,7 +110,7 @@ def fv(rate, nper, pmt, pv, when='end'):
 
     """
     when = _convert_when(when)
-    rate, nper, pmt, pv, when = map(np.asarray, [rate, nper, pmt, pv, when])
+    rate, nper, pmt, pv, when = list(map(np.asarray, [rate, nper, pmt, pv, when]))
     temp = (1+rate)**nper
     miter = np.broadcast(rate, nper, pmt, pv, when)
     zer = np.zeros(miter.shape)
@@ -201,7 +201,7 @@ def pmt(rate, nper, pv, fv=0, when='end'):
 
     """
     when = _convert_when(when)
-    rate, nper, pv, fv, when = map(np.asarray, [rate, nper, pv, fv, when])
+    rate, nper, pv, fv, when = list(map(np.asarray, [rate, nper, pv, fv, when]))
     temp = (1+rate)**nper
     miter = np.broadcast(rate, nper, pv, fv, when)
     zer = np.zeros(miter.shape)
@@ -258,7 +258,7 @@ def nper(rate, pmt, pv, fv=0, when='end'):
 
     """
     when = _convert_when(when)
-    rate, pmt, pv, fv, when = map(np.asarray, [rate, pmt, pv, fv, when])
+    rate, pmt, pv, fv, when = list(map(np.asarray, [rate, pmt, pv, fv, when]))
 
     use_zero_rate = False
     old_err = np.seterr(divide="raise")
@@ -497,7 +497,7 @@ def pv(rate, nper, pmt, fv=0.0, when='end'):
 
     """
     when = _convert_when(when)
-    rate, nper, pmt, fv, when = map(np.asarray, [rate, nper, pmt, fv, when])
+    rate, nper, pmt, fv, when = list(map(np.asarray, [rate, nper, pmt, fv, when]))
     temp = (1+rate)**nper
     miter = np.broadcast(rate, nper, pmt, fv, when)
     zer = np.zeros(miter.shape)
@@ -563,7 +563,7 @@ def rate(nper, pmt, pv, fv, when='end', guess=0.10, tol=1e-6, maxiter=100):
 
     """
     when = _convert_when(when)
-    nper, pmt, pv, fv, when = map(np.asarray, [nper, pmt, pv, fv, when])
+    nper, pmt, pv, fv, when = list(map(np.asarray, [nper, pmt, pv, fv, when]))
     rn = guess
     iter = 0
     close = False

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -190,7 +190,7 @@ def read_magic(fp):
         msg = "the magic string is not correct; expected %r, got %r"
         raise ValueError(msg % (MAGIC_PREFIX, magic_str[:-2]))
     if sys.version_info[0] < 3:
-        major, minor = map(ord, magic_str[-2:])
+        major, minor = list(map(ord, magic_str[-2:]))
     else:
         major, minor = magic_str[-2:]
     return major, minor

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -161,8 +161,8 @@ class nd_grid(object):
                     isinstance(key[k].stop, float):
                     typ = float
             if self.sparse:
-                nn = map(lambda x,t: _nx.arange(x, dtype=t), size, \
-                                     (typ,)*len(size))
+                nn = list(map(lambda x,t: _nx.arange(x, dtype=t), size, \
+                                     (typ,)*len(size)))
             else:
                 nn = _nx.indices(size, typ)
             for k in range(len(size)):

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1598,7 +1598,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     # Upgrade the converters (if needed)
     if dtype is None:
         for (i, converter) in enumerate(converters):
-            current_column = map(itemgetter(i), rows)
+            current_column = list(map(itemgetter(i), rows))
             try:
                 converter.iterupgrade(current_column)
             except ConverterLockError:
@@ -1657,10 +1657,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 #        rows[i] = tuple([convert(val)
 #                         for (convert, val) in zip(conversionfuncs, vals)])
     if loose:
-        rows = zip(*[map(converter._loose_call, map(itemgetter(i), rows))
+        rows = zip(*[list(map(converter._loose_call, list(map(itemgetter(i), rows))))
                      for (i, converter) in enumerate(converters)])
     else:
-        rows = zip(*[map(converter._strict_call, map(itemgetter(i), rows))
+        rows = zip(*[list(map(converter._strict_call, list(map(itemgetter(i), rows))))
                      for (i, converter) in enumerate(converters)])
     # Reset the dtype
     data = rows

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -401,7 +401,7 @@ def merge_arrays(seqarrays,
             seqarrays = (seqarrays,)
     else:
         # Make sure we have arrays in the input sequence
-        seqarrays = map(np.asanyarray, seqarrays)
+        seqarrays = list(map(np.asanyarray, seqarrays))
     # Find the sizes of the inputs and their maximum
     sizes = tuple(a.size for a in seqarrays)
     maxlength = max(sizes)

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -343,7 +343,7 @@ def dstack(tup):
            [[3, 4]]])
 
     """
-    return _nx.concatenate(map(atleast_3d,tup),2)
+    return _nx.concatenate(list(map(atleast_3d,tup)),2)
 
 def _replace_zero_by_x_arrays(sub_arys):
     for i in range(len(sub_arys)):

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -66,7 +66,7 @@ def broadcast_arrays(*args):
            [3, 3, 3]])]
 
     """
-    args = map(np.asarray, args)
+    args = list(map(np.asarray, args))
     shapes = [x.shape for x in args]
     if len(set(shapes)) == 1:
         # Common case where nothing needs to be broadcasted.

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -43,7 +43,7 @@ def _convert_from_string(data):
         newrow = []
         for col in trow:
             temp = col.split()
-            newrow.extend(map(_eval,temp))
+            newrow.extend(list(map(_eval,temp)))
         if count == 0:
             Ncols = len(newrow)
         elif len(newrow) != Ncols:

--- a/numpy/oldnumeric/matrix.py
+++ b/numpy/oldnumeric/matrix.py
@@ -37,7 +37,7 @@ def _convert_from_string(data):
         newrow = []
         for col in trow:
             temp = col.split()
-            newrow.extend(map(_eval,temp))
+            newrow.extend(list(map(_eval,temp)))
         if count == 0:
             Ncols = len(newrow)
         elif len(newrow) != Ncols:

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -525,7 +525,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
     """
     import numpy as np
-    actual, desired = map(float, (actual, desired))
+    actual, desired = list(map(float, (actual, desired)))
     if desired==actual:
         return
     # Normalized the numbers to be in range (-10.0,10.0)


### PR DESCRIPTION
Run 2to3 fixers `getcwdu` to `metaclass`. Most made no changes, of those that did, all but map failed for some tests. I think most of the map uses could be replace by list comprehension.

```
passed
----------
getcwdu
has_key  -- already done
input
intern
isinstance
itertools_imports -- none to remove, they are in idioms?
map
metaclass

fail
----
idioms
itertools
long

skipped
-----------
import
imports
import2
```
