### PR TITLE
2to3: Fix callable.

### DIFF
--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -8,6 +8,7 @@ import re
 import pydoc
 from StringIO import StringIO
 from warnings import warn
+import collections
 
 class Reader(object):
     """A line-based string reader.
@@ -495,7 +496,7 @@ class ClassDoc(NumpyDocString):
         return [name for name,func in inspect.getmembers(self._cls)
                 if ((not name.startswith('_')
                      or name in self.extra_public_methods)
-                    and callable(func))]
+                    and isinstance(func, collections.Callable))]
 
     @property
     def properties(self):

--- a/doc/sphinxext/docscrape_sphinx.py
+++ b/doc/sphinxext/docscrape_sphinx.py
@@ -1,6 +1,7 @@
 import re, inspect, textwrap, pydoc
 import sphinx
 from docscrape import NumpyDocString, FunctionDoc, ClassDoc
+import collections
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):
@@ -212,7 +213,7 @@ def get_doc_object(obj, what=None, doc=None, config={}):
             what = 'class'
         elif inspect.ismodule(obj):
             what = 'module'
-        elif callable(obj):
+        elif isinstance(obj, collections.Callable):
             what = 'function'
         else:
             what = 'object'

--- a/doc/sphinxext/linkcode.py
+++ b/doc/sphinxext/linkcode.py
@@ -10,6 +10,7 @@
 """
 
 import warnings
+import collections
 warnings.warn("This extension has been submitted to Sphinx upstream. "
               "Use the version from there if it is accepted "
               "https://bitbucket.org/birkenfeld/sphinx/pull-request/47/sphinxextlinkcode",
@@ -29,7 +30,7 @@ def doctree_read(app, doctree):
     env = app.builder.env
 
     resolve_target = getattr(env.config, 'linkcode_resolve', None)
-    if not callable(env.config.linkcode_resolve):
+    if not isinstance(env.config.linkcode_resolve, collections.Callable):
         raise LinkcodeError(
             "Function `linkcode_resolve` is not given in conf.py")
 

--- a/doc/sphinxext/numpydoc.py
+++ b/doc/sphinxext/numpydoc.py
@@ -17,6 +17,7 @@ It will:
 """
 
 import sphinx
+import collections
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
@@ -82,7 +83,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
         'initializes x; see ' in pydoc.getdoc(obj.__init__))):
         return '', ''
 
-    if not (callable(obj) or hasattr(obj, '__argspec_is_invalid_')): return
+    if not (isinstance(obj, collections.Callable) or hasattr(obj, '__argspec_is_invalid_')): return
     if not hasattr(obj, '__doc__'): return
 
     doc = SphinxDocString(pydoc.getdoc(obj))

--- a/doc/sphinxext/traitsdoc.py
+++ b/doc/sphinxext/traitsdoc.py
@@ -25,6 +25,7 @@ from docscrape_sphinx import SphinxClassDoc, SphinxFunctionDoc, SphinxDocString
 import numpydoc
 
 import comment_eater
+import collections
 
 class SphinxTraitsDoc(SphinxClassDoc):
     def __init__(self, cls, modulename='', func_doc=SphinxFunctionDoc):
@@ -117,7 +118,7 @@ def get_doc_object(obj, what=None, config=None):
             what = 'class'
         elif inspect.ismodule(obj):
             what = 'module'
-        elif callable(obj):
+        elif isinstance(obj, collections.Callable):
             what = 'function'
         else:
             what = 'object'

--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -7,6 +7,7 @@ Show a summary about which Numpy functions are documented and which are not.
 """
 
 import os, glob, re, sys, inspect, optparse
+import collections
 sys.path.append(os.path.join(os.path.dirname(__file__), 'sphinxext'))
 from sphinxext.phantom_import import import_phantom_module
 
@@ -134,7 +135,7 @@ def get_undocumented(documented, module, module_name=None, skip=[]):
 
         if full_name in skip: continue
         if full_name.startswith('numpy.') and full_name[6:] in skip: continue
-        if not (inspect.ismodule(obj) or callable(obj) or inspect.isclass(obj)):
+        if not (inspect.ismodule(obj) or isinstance(obj, collections.Callable) or inspect.isclass(obj)):
             continue
 
         if full_name not in documented:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -29,6 +29,7 @@ import umath
 from umath import *
 import numerictypes
 from numerictypes import *
+import collections
 
 
 if sys.version_info[0] < 3:
@@ -2445,8 +2446,8 @@ def seterrcall(func):
     {'over': 'log', 'divide': 'log', 'invalid': 'log', 'under': 'log'}
 
     """
-    if func is not None and not callable(func):
-        if not hasattr(func, 'write') or not callable(func.write):
+    if func is not None and not isinstance(func, collections.Callable):
+        if not hasattr(func, 'write') or not isinstance(func.write, collections.Callable):
             raise ValueError("Only callable can be used as callback")
     pyvals = umath.geterrobj()
     old = geterrcall()

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -4,6 +4,7 @@ from numpy.testing import *
 from numpy.compat import asbytes, asunicode
 
 import warnings
+import collections
 
 
 class TestFromrecords(TestCase):
@@ -94,7 +95,7 @@ class TestFromrecords(TestCase):
         assert_array_equal(ra['shape'], [['A', 'B', 'C']])
         ra.field = 5
         assert_array_equal(ra['field'], [[5, 5, 5]])
-        assert_(callable(ra.field))
+        assert_(isinstance(ra.field, collections.Callable))
 
     def test_fromrecords_with_explicit_dtype(self):
         a = np.rec.fromrecords([(1, 'a'), (2, 'bbb')],

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -30,6 +30,7 @@ from arraysetops import setdiff1d
 from utils import deprecate
 from _compiled_base import add_newdoc_ufunc
 import numpy as np
+import collections
 
 
 def iterable(y):
@@ -707,7 +708,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     y = zeros(x.shape, x.dtype)
     for k in range(n):
         item = funclist[k]
-        if not callable(item):
+        if not isinstance(item, collections.Callable):
             y[condlist[k]] = item
         else:
             vals = x[condlist[k]]

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -4,6 +4,7 @@ from numpy import matrix, asmatrix, bmat
 from numpy.matrixlib.defmatrix import matrix_power
 from numpy.matrixlib import mat
 import numpy as np
+import collections
 
 class TestCtor(TestCase):
     def test_basic(self):
@@ -285,7 +286,7 @@ class TestMatrixReturn(TestCase):
             if attrib.startswith('_') or attrib in excluded_methods:
                 continue
             f = getattr(a, attrib)
-            if callable(f):
+            if isinstance(f, collections.Callable):
                 # reset contents of a
                 a.astype('f8')
                 a.fill(1.0)

--- a/numpy/testing/decorators.py
+++ b/numpy/testing/decorators.py
@@ -18,6 +18,7 @@ import sys
 
 from numpy.testing.utils import \
         WarningManager, WarningMessage
+import collections
 
 def slow(t):
     """
@@ -122,7 +123,7 @@ def skipif(skip_condition, msg=None):
         import nose
 
         # Allow for both boolean or callable skip conditions.
-        if callable(skip_condition):
+        if isinstance(skip_condition, collections.Callable):
             skip_val = lambda : skip_condition()
         else:
             skip_val = lambda : skip_condition
@@ -198,7 +199,7 @@ def knownfailureif(fail_condition, msg=None):
         msg = 'Test skipped due to known failure'
 
     # Allow for both boolean or callable known failure conditions.
-    if callable(fail_condition):
+    if isinstance(fail_condition, collections.Callable):
         fail_val = lambda : fail_condition()
     else:
         fail_val = lambda : fail_condition
@@ -264,7 +265,7 @@ def deprecated(conditional=True):
             finally:
                 ctx.__exit__()
 
-        if callable(conditional):
+        if isinstance(conditional, collections.Callable):
             cond = conditional()
         else:
             cond = conditional


### PR DESCRIPTION
Apply the changes made by 2to3 `callable` filter.

The `callable` builtin is absent from python 3.
