### PR TITLE
2to3: apply `execfile` fixer results.

### DIFF
--- a/setupegg.py
+++ b/setupegg.py
@@ -21,4 +21,4 @@ if sys.version_info[0] >= 3:
     setupfile = imp.load_source('setupfile', 'setup.py')
     setupfile.setup_package()
 else:
-    execfile('setup.py')
+    exec(compile(open('setup.py').read(), 'setup.py', 'exec'))


### PR DESCRIPTION
The execfile command is gone in Python 3. The fix is to read the file,
then compile and exec the result. Closes #3051 .
