### PR TITLE
2to3: Apply `funcattrs` fixer. Closes #3058.

### DIFF
--- a/doc/sphinxext/phantom_import.py
+++ b/doc/sphinxext/phantom_import.py
@@ -129,7 +129,7 @@ def import_phantom_module(xml_file):
                 doc = "%s%s\n\n%s" % (funcname, argspec, doc)
             obj = lambda: 0
             obj.__argspec_is_invalid_ = True
-            obj.func_name = funcname
+            obj.__name__ = funcname
             obj.__name__ = name
             obj.__doc__ = doc
             if inspect.isclass(object_cache[parent]):

--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -128,8 +128,8 @@ def getargspec(func):
         func = func.im_func
     if not isfunction(func):
         raise TypeError('arg is not a Python function')
-    args, varargs, varkw = getargs(func.func_code)
-    return args, varargs, varkw, func.func_defaults
+    args, varargs, varkw = getargs(func.__code__)
+    return args, varargs, varkw, func.__defaults__
 
 def getargvalues(frame):
     """Get information about arguments passed into a particular frame.
@@ -209,8 +209,8 @@ if __name__ == '__main__':
     def foo(x, y, z=None):
         return None
 
-    print inspect.getargs(foo.func_code)
-    print getargs(foo.func_code)
+    print inspect.getargs(foo.__code__)
+    print getargs(foo.__code__)
 
     print inspect.getargspec(foo)
     print getargspec(foo)

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -189,7 +189,7 @@ class build_src(build_ext.build_ext):
                 funcs = filter(lambda f:hasattr(f, '__call__'), files)
                 files = filter(lambda f:not hasattr(f, '__call__'), files)
                 for f in funcs:
-                    if f.func_code.co_argcount==1:
+                    if f.__code__.co_argcount==1:
                         s = f(build_dir)
                     else:
                         s = f()

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -202,7 +202,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         if sys.version_info[0] >= 3:
             func(*args[:func.__code__.co_argcount])
         else:
-            func(*args[:func.im_func.func_code.co_argcount])
+            func(*args[:func.im_func.__code__.co_argcount])
         return
 
     def object_filenames (self,

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -850,7 +850,7 @@ class Configuration(object):
                 pn = dot_join(*([parent_name] + subpackage_name.split('.')[:-1]))
                 args = (pn,)
                 def fix_args_py2(args):
-                    if setup_module.configuration.func_code.co_argcount > 1:
+                    if setup_module.configuration.__code__.co_argcount > 1:
                         args = args + (self.top_path,)
                     return args
                 def fix_args_py3(args):

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -86,8 +86,8 @@ if sys.version_info < (2, 4):
     # Can't set __name__ in 2.3
     import new
     def _set_function_name(func, name):
-        func = new.function(func.func_code, func.func_globals,
-                            name, func.func_defaults, func.func_closure)
+        func = new.function(func.__code__, func.__globals__,
+                            name, func.__defaults__, func.__closure__)
         return func
 else:
     def _set_function_name(func, name):
@@ -122,7 +122,7 @@ class _Deprecate(object):
         import warnings
         if old_name is None:
             try:
-                old_name = func.func_name
+                old_name = func.__name__
             except AttributeError:
                 old_name = func.__name__
         if new_name is None:
@@ -541,7 +541,7 @@ def info(object=None,maxwidth=76,output=sys.stdout,toplevel='numpy'):
             print >> output, "\n     *** Total of %d references found. ***" % numfound
 
     elif inspect.isfunction(object):
-        name = object.func_name
+        name = object.__name__
         arguments = inspect.formatargspec(*inspect.getargspec(object))
 
         if len(name+arguments) > maxwidth:

--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -35,7 +35,7 @@ class NumpyDocTestFinder(doctest.DocTestFinder):
             return True
         elif inspect.isfunction(object):
             #print '_fm C2'  # dbg
-            return module.__dict__ is object.func_globals
+            return module.__dict__ is object.__globals__
         elif inspect.isbuiltin(object):
             #print '_fm C2-1'  # dbg
             return module.__name__ == object.__module__


### PR DESCRIPTION
This replaces the `b.func_xxxx` with newer `__xxxx__` attribute names
For example, `f.__name__`  replaces `f.func_name`
