### PR TITLE
2to3: Apply `sys_exc` fixes. Closes #3086.

### DIFF
--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -516,7 +516,7 @@ class Win32CPUInfo(CPUInfoBase):
                                     info[-1]["Model"]=int(srch.group("MDL"))
                                     info[-1]["Stepping"]=int(srch.group("STP"))
         except:
-            print(sys.exc_value,'(ignoring)')
+            print(sys.exc_info()[1],'(ignoring)')
         self.__class__.info = info
 
     def _not_impl(self): pass

--- a/numpy/f2py/diagnose.py
+++ b/numpy/f2py/diagnose.py
@@ -29,14 +29,14 @@ def run():
         import numpy
         has_newnumpy = 1
     except ImportError:
-        print 'Failed to import new numpy:', sys.exc_value
+        print 'Failed to import new numpy:', sys.exc_info()[1]
         has_newnumpy = 0
 
     try:
         from numpy.f2py import f2py2e
         has_f2py2e = 1
     except ImportError:
-        print 'Failed to import f2py2e:',sys.exc_value
+        print 'Failed to import f2py2e:',sys.exc_info()[1]
         has_f2py2e = 0
 
     try:
@@ -47,7 +47,7 @@ def run():
             import numpy_distutils
             has_numpy_distutils = 1
         except ImportError:
-            print 'Failed to import numpy_distutils:',sys.exc_value
+            print 'Failed to import numpy_distutils:',sys.exc_info()[1]
             has_numpy_distutils = 0
 
     if has_newnumpy:


### PR DESCRIPTION
This uses sys.exc_info in place of sys.exc_value. The new function
goes back to at least 2002, so should be safe.

Closes #3086 
