### PR TITLE
2to3: Apply `methodattrs` fixes.

### DIFF
--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -125,7 +125,7 @@ def getargspec(func):
     """
 
     if ismethod(func):
-        func = func.im_func
+        func = func.__func__
     if not isfunction(func):
         raise TypeError('arg is not a Python function')
     args, varargs, varkw = getargs(func.__code__)

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -199,10 +199,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             func = distutils.cygwinccompiler.CygwinCCompiler.link
         else:
             func = UnixCCompiler.link
-        if sys.version_info[0] >= 3:
-            func(*args[:func.__code__.co_argcount])
-        else:
-            func(*args[:func.im_func.__code__.co_argcount])
+        func(*args[:func.__code__.co_argcount])
         return
 
     def object_filenames (self,

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -557,7 +557,7 @@ def info(object=None,maxwidth=76,output=sys.stdout,toplevel='numpy'):
         arguments = "()"
         try:
             if hasattr(object, '__init__'):
-                arguments = inspect.formatargspec(*inspect.getargspec(object.__init__.im_func))
+                arguments = inspect.formatargspec(*inspect.getargspec(object.__init__.__func__))
                 arglist = arguments.split(', ')
                 if len(arglist) > 1:
                     arglist[1] = "("+arglist[1]
@@ -593,7 +593,7 @@ def info(object=None,maxwidth=76,output=sys.stdout,toplevel='numpy'):
         print >> output, "Instance of class: ", object.__class__.__name__
         print >> output
         if hasattr(object, '__call__'):
-            arguments = inspect.formatargspec(*inspect.getargspec(object.__call__.im_func))
+            arguments = inspect.formatargspec(*inspect.getargspec(object.__call__.__func__))
             arglist = arguments.split(', ')
             if len(arglist) > 1:
                 arglist[1] = "("+arglist[1]
@@ -621,7 +621,7 @@ def info(object=None,maxwidth=76,output=sys.stdout,toplevel='numpy'):
 
     elif inspect.ismethod(object):
         name = object.__name__
-        arguments = inspect.formatargspec(*inspect.getargspec(object.im_func))
+        arguments = inspect.formatargspec(*inspect.getargspec(object.__func__))
         arglist = arguments.split(', ')
         if len(arglist) > 1:
             arglist[1] = "("+arglist[1]

--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -48,7 +48,7 @@ class NumpyDocTestFinder(doctest.DocTestFinder):
             # to make by extension code writers, having this safety in place
             # isn't such a bad idea
             #print '_fm C3-1'  # dbg
-            return module.__name__ == object.im_class.__module__
+            return module.__name__ == object.__self__.__class__.__module__
         elif inspect.getmodule(object) is not None:
             #print '_fm C4'  # dbg
             #print 'C4 mod',module,'obj',object # dbg
@@ -100,7 +100,7 @@ class NumpyDocTestFinder(doctest.DocTestFinder):
                 if isinstance(val, staticmethod):
                     val = getattr(obj, valname)
                 if isinstance(val, classmethod):
-                    val = getattr(obj, valname).im_func
+                    val = getattr(obj, valname).__func__
 
                 # Recurse to methods, properties, and nested classes.
                 if ((isfunction(val) or isclass(val) or


### PR DESCRIPTION
Replaces old style `f.im_func` and `f.im_class` method attributes
with `f.__func__` and `f.__class__`. Closes #3070.
