### PR TITLE
BUG: initialize op_axes when only itershape is given

### DIFF
--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -786,7 +786,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     if (itershape.len > 0) {
         if (oa_ndim == 0) {
             oa_ndim = itershape.len;
-            memset(op_axes, 0, sizeof(op_axes[0])*oa_ndim);
+            memset(op_axes, 0, sizeof(op_axes[0]) * nop);
         }
         else if (oa_ndim != itershape.len) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -598,6 +598,8 @@ def test_iter_itershape():
                             [['readonly'], ['writeonly','allocate']],
                             op_axes=[[0,1,None], None],
                             itershape=(-1,1,4))
+    # Test bug that for no op_axes but itershape, they are NULLed correctly
+    i = np.nditer([np.ones(2), None, None], itershape=(2,))
 
 def test_iter_broadcasting_errors():
     # Check that errors are thrown for bad broadcasting shapes


### PR DESCRIPTION
In this case, the initialization used the number of dimensions instead
of setting it to NULL for each operand, leading to possible segmentation
faults.
## 

Small bug and very simple fix, I stumbled over when looking at nditer.
