### PR TITLE
DEP: Add removal warning to oldnumeric and numarray.

### DIFF
--- a/numpy/numarray/__init__.py
+++ b/numpy/numarray/__init__.py
@@ -13,6 +13,7 @@ import functions
 import ufuncs
 import compat
 import session
+import warnings
 
 __all__ = ['session', 'numerictypes']
 __all__ += util.__all__
@@ -26,6 +27,9 @@ del util
 del functions
 del ufuncs
 del compat
+
+_msg = "oldnumeric will be dropped in 1.8"
+warnings.warn(_msg, DeprecationWarning)
 
 from numpy.testing import Tester
 test = Tester().test

--- a/numpy/oldnumeric/__init__.py
+++ b/numpy/oldnumeric/__init__.py
@@ -26,6 +26,8 @@ import precision
 import functions
 import misc
 import ufuncs
+import warnings
+import sys
 
 import numpy
 __version__ = numpy.__version__
@@ -43,6 +45,12 @@ del functions
 del precision
 del ufuncs
 del misc
+
+if sys.version_info[0] > 2:
+    raise ImportError("oldnumeric is not supported in Python 3.x")
+
+_msg = "oldnumeric will be dropped in numpy 1.8"
+warnings.warn(_msg, DeprecationWarning)
 
 from numpy.testing import Tester
 test = Tester().test


### PR DESCRIPTION
Also raise `ImportError` when oldnumeric is imported into Python 3.

The decision has been made to remove oldnumeric and numarray in some
near future numpy release. I make that the 1.8 here to make the warning
message more of an attention grabber.

closes #2905
closes #3073
closes #3082
