### PR TITLE
Backport nditer fix op axes initialization

### DIFF
--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -629,35 +629,6 @@ Construction and Destruction
             returns true from the corresponding element in the ARRAYMASK
             operand.
 
-        .. cvar:: NPY_ITER_USE_MASKNA
-
-            .. versionadded:: 1.7
-
-            Adds a new operand to the end of the operand list which
-            iterates over the mask of this operand. If this operand has
-            no mask and is read-only, it broadcasts a constant
-            one-valued mask to indicate every value is valid. If this
-            operand has no mask and is writeable, an error is raised.
-
-            Each operand which has this flag applied to it causes
-            an additional operand to be tacked on the end of the operand
-            list, in an order matching that of the operand array.
-            For example, if there are four operands, and operands with index
-            one and three have the flag :cdata:`NPY_ITER_USE_MASKNA`
-            specified, there will be six operands total, and they will
-            look like [op0, op1, op2, op3, op1_mask, op3_mask].
-
-        .. cvar:: NPY_ITER_IGNORE_MASKNA
-
-            .. versionadded:: 1.7
-
-            Under some circumstances, code doing an iteration will
-            have already called :cfunc:`PyArray_ContainsNA` on an
-            operand which has a mask, and seen that its return value
-            was false. When this occurs, it is safe to do the iteration
-            without simultaneously iterating over the mask, and this
-            flag allows that to be done.
-
 .. cfunction:: NpyIter* NpyIter_AdvancedNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
 
     Extends :cfunc:`NpyIter_MultiNew` with several advanced options providing

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -786,7 +786,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     if (itershape.len > 0) {
         if (oa_ndim == 0) {
             oa_ndim = itershape.len;
-            memset(op_axes, 0, sizeof(op_axes[0])*oa_ndim);
+            memset(op_axes, 0, sizeof(op_axes[0]) * nop);
         }
         else if (oa_ndim != itershape.len) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -598,6 +598,8 @@ def test_iter_itershape():
                             [['readonly'], ['writeonly','allocate']],
                             op_axes=[[0,1,None], None],
                             itershape=(-1,1,4))
+    # Test bug that for no op_axes but itershape, they are NULLed correctly
+    i = np.nditer([np.ones(2), None, None], itershape=(2,))
 
 def test_iter_broadcasting_errors():
     # Check that errors are thrown for bad broadcasting shapes


### PR DESCRIPTION
Backports gh-3102. I also stapled on a commit removing the documentation of mask NA iteration flags, which I understand correctly was pulled out of 1.7 but forgotten.
