### PR TITLE
Improve searchsorted

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1983,7 +1983,7 @@ local_argsearch_left(PyArrayObject *arr, PyArrayObject *key,
         npy_intp imax = nelts;
         while (imin < imax) {
             npy_intp imid = imin + ((imax - imin) >> 1);
-            npy_intp indx = *(psorter + sorterstride*imid);
+            npy_intp indx = *(npy_intp *)(psorter + sorterstride * imid);
 
             if (indx < 0 || indx >= nelts) {
                 return -1;
@@ -2037,7 +2037,7 @@ local_argsearch_right(PyArrayObject *arr, PyArrayObject *key,
         npy_intp imax = nelts;
         while (imin < imax) {
             npy_intp imid = imin + ((imax - imin) >> 1);
-            npy_intp indx = *(psorter + sorterstride*imid);
+            npy_intp indx = *(npy_intp *)(psorter + sorterstride * imid);
 
             if (indx < 0 || indx >= nelts) {
                 return -1;
@@ -2117,7 +2117,7 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     /* need ap2 as contiguous array and of right type */
     ap2 = (PyArrayObject *)PyArray_CheckFromAny(op2, dtype,
                                 0, 0,
-                                NPY_ARRAY_DEFAULT | NPY_ARRAY_NOTSWAPPED,
+                                NPY_ARRAY_CARRAY_RO | NPY_ARRAY_NOTSWAPPED,
                                 NULL);
     if (ap2 == NULL) {
         goto fail;

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1866,8 +1866,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
  *
  * For each key use bisection to find the first index i s.t. key <= arr[i].
  * When there is no such index i, set i = len(arr). Return the results in ret.
- * All arrays are assumed contiguous on entry and both arr and key must be of
- * the same comparable type.
+ * Both arr and key must be of the same comparable type.
  *
  * @param arr 1d, strided, sorted array to be searched.
  * @param key contiguous array of keys.
@@ -1910,8 +1909,7 @@ local_search_left(PyArrayObject *arr, PyArrayObject *key, PyArrayObject *ret)
  *
  * For each key use bisection to find the first index i s.t. key < arr[i].
  * When there is no such index i, set i = len(arr). Return the results in ret.
- * All arrays are assumed contiguous on entry and both arr and key must be of
- * the same comparable type.
+ * Both arr and key must be of the same comparable type.
  *
  * @param arr 1d, strided, sorted array to be searched.
  * @param key contiguous array of keys.
@@ -1953,8 +1951,7 @@ local_search_right(PyArrayObject *arr, PyArrayObject *key, PyArrayObject *ret)
  *
  * For each key use bisection to find the first index i s.t. key <= arr[i].
  * When there is no such index i, set i = len(arr). Return the results in ret.
- * All arrays are assumed contiguous on entry and both arr and key must be of
- * the same comparable type.
+ * Both arr and key must be of the same comparable type.
  *
  * @param arr 1d, strided array to be searched.
  * @param key contiguous array of keys.
@@ -2007,8 +2004,7 @@ local_argsearch_left(PyArrayObject *arr, PyArrayObject *key,
  *
  * For each key use bisection to find the first index i s.t. key < arr[i].
  * When there is no such index i, set i = len(arr). Return the results in ret.
- * All arrays are assumed contiguous on entry and both arr and key must be of
- * the same comparable type.
+ * Both arr and key must be of the same comparable type.
  *
  * @param arr 1d, strided array to be searched.
  * @param key contiguous array of keys.
@@ -2115,6 +2111,10 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
         return NULL;
     }
 
+    /*
+     * If the needle (ap2) is larger than the haystack (op1) we copy the
+     * haystack to a continuous array for improved cache utilization.
+     */
     if (PyArray_SIZE(ap2) > PyArray_SIZE(op1)) {
         ap1_flags |= NPY_ARRAY_CARRAY_RO;
     }


### PR DESCRIPTION
This pull request allows `numpy.searchsorted` to search non-contigious arrays without making a copy and it allows `numpy.searchsorted` to search arrays sorted in descending order. This is my first numpy pull request to let me know if I'm doing something wrong in terms of the code or in terms of requesting a PR.
