### PR TITLE
Travis: record some basic information about the build platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     - python: 3.2
       env: NPY_SEPARATE_COMPILATION=0
 before_install:
+  - uname -a
+  - free -m
+  - df -h
+  - ulimit -a
   - mkdir builds
   - pushd builds
   - pip install nose


### PR DESCRIPTION
The question has come up sometimes about how much memory etc. we have available for Travis builds. Let's just log the relevant resource limits at the top of every build log.
