### PR TITLE
2to3: Remove xreadlines and replace f.readlines() by f where valid.

### DIFF
--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -465,7 +465,7 @@ def get_versions_hash():
     file = os.path.join(os.path.dirname(__file__), 'cversions.txt')
     fid = open(file, 'r')
     try:
-        for line in fid.readlines():
+        for line in fid:
             m = VERRE.match(line)
             if m:
                 d.append((int(m.group(1), 16), m.group(2)))

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -484,7 +484,7 @@ def configuration(parent_package='',top_path=None):
         else:
             mathlibs = []
             target_f = open(target)
-            for line in target_f.readlines():
+            for line in target_f:
                 s = '#define MATHLIB'
                 if line.startswith(s):
                     value = line[len(s):].strip()

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -37,7 +37,7 @@ def subst_vars(target, source, d):
     try:
         ft = open(target, 'w')
         try:
-            for l in fs.readlines():
+            for l in fs:
                 m = var.search(l)
                 if m:
                     ft.write(l.replace('@%s@' % m.group(1), d[m.group(1)]))
@@ -767,9 +767,8 @@ def get_swig_target(source):
 
 def get_swig_modulename(source):
     f = open(source,'r')
-    f_readlines = getattr(f,'xreadlines',f.readlines)
     name = None
-    for line in f_readlines():
+    for line in f:
         m = _swig_module_name_match(line)
         if m:
             name = m.group('name')
@@ -794,8 +793,7 @@ _f2py_user_module_name_match = re.compile(r'\s*python\s*module\s*(?P<name>[\w_]*
 def get_f2py_modulename(source):
     name = None
     f = open(source)
-    f_readlines = getattr(f,'xreadlines',f.readlines)
-    for line in f_readlines():
+    for line in f:
         m = _f2py_module_name_match(line)
         if m:
             if _f2py_user_module_name_match(line): # skip *__user__* names

--- a/numpy/distutils/command/install.py
+++ b/numpy/distutils/command/install.py
@@ -64,7 +64,7 @@ class install(old_install):
             f = open(self.record,'r')
             lines = []
             need_rewrite = False
-            for l in f.readlines():
+            for l in f:
                 l = l.rstrip()
                 if ' ' in l:
                     need_rewrite = True

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -271,7 +271,7 @@ def resolve_includes(source):
     d = os.path.dirname(source)
     fid = open(source)
     lines = []
-    for line in fid.readlines():
+    for line in fid:
         m = include_src_re.match(line)
         if m:
             fn = m.group('name')

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -971,7 +971,7 @@ def get_f77flags(src):
     flags = {}
     f = open_latin1(src,'r')
     i = 0
-    for line in f.readlines():
+    for line in f:
         i += 1
         if i>20: break
         m = _f77flags_re.match(line)

--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -76,7 +76,7 @@ class IBMFCompiler(FCompiler):
             log.info('Creating '+new_cfg)
             fi = open(xlf_cfg,'r')
             crt1_match = re.compile(r'\s*crt\s*[=]\s*(?P<path>.*)/crt1.o').match
-            for line in fi.readlines():
+            for line in fi:
                 m = crt1_match(line)
                 if m:
                     fo.write('crt = %s/bundle1.o\n' % (m.group('path')))

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -209,7 +209,7 @@ def resolve_includes(source):
     d = os.path.dirname(source)
     fid = open(source)
     lines = []
-    for line in fid.readlines():
+    for line in fid:
         m = include_src_re.match(line)
         if m:
             fn = m.group('name')

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -167,7 +167,7 @@ def get_mathlibs(path=None):
     fid = open(config_file)
     mathlibs = []
     s = '#define MATHLIB'
-    for line in fid.readlines():
+    for line in fid:
         if line.startswith(s):
             value = line[len(s):].strip()
             if value:
@@ -394,8 +394,7 @@ def _get_f90_modules(source):
         return []
     modules = []
     f = open(source,'r')
-    f_readlines = getattr(f,'xreadlines',f.readlines)
-    for line in f_readlines():
+    for line in f:
         m = f90_module_name_match(line)
         if m:
             name = m.group('name')

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -904,7 +904,7 @@ class mkl_info(system_info):
         paths = os.environ.get('LD_LIBRARY_PATH', '').split(os.pathsep)
         ld_so_conf = '/etc/ld.so.conf'
         if os.path.isfile(ld_so_conf):
-            for d in open(ld_so_conf, 'r').readlines():
+            for d in open(ld_so_conf, 'r'):
                 d = d.strip()
                 if d:
                     paths.append(d)

--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -58,7 +58,7 @@ class SourceFile:
 
     def write_text(self, fd):
         source = open(self.path, "r")
-        for i, line in enumerate(source.readlines()):
+        for i, line in enumerate(source):
             if i + 1 in self.lines:
                 fd.write("> ")
             else:
@@ -128,7 +128,7 @@ def collect_stats(files, fd, pattern):
 
     current_file = None
     current_function = None
-    for i, line in enumerate(fd.readlines()):
+    for i, line in enumerate(fd):
         if re.match("f[lie]=.+", line):
             path = line.split('=', 2)[1].strip()
             if os.path.exists(path) and re.search(pattern, path):

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -78,7 +78,8 @@ FIXES_TO_SKIP = [
     'callable',
     'apply',
     'input',
-    'raw_input'
+    'raw_input',
+    'xreadlines'
 ]
 
 skip_fixes= []

--- a/tools/win32build/misc/x86analysis.py
+++ b/tools/win32build/misc/x86analysis.py
@@ -100,7 +100,7 @@ def disassemble(filename):
         else:
             inst = line3[0]
         return inst
-    inst = [floupi(i) for i in o.readlines()]
+    inst = [floupi(i) for i in o]
     return inst
 
 def has_set(seq, asm_set):


### PR DESCRIPTION
An open file `f` has been an iterator since python2.3 and
`f.xreadlines()` is no longer needed, so replace it with `f`. Also
replace `f.readlines()` with `f` where an iterator will do. The
replacement of `f.readlines()` is not critical because it is a list in
both python2 and python3, but the code is a bit cleaner.

Closes #3093
