### PR TITLE
2to3: Replace xrange by range and use list(range(...)) where needed

### DIFF
--- a/doc/neps/missing-data.rst
+++ b/doc/neps/missing-data.rst
@@ -320,7 +320,7 @@ A manual loop through a masked array like::
     >>> a[3] = np.NA
     >>> a
     array([ 0.,  1.,  2., NA,  4.], maskna=True)
-    >>> for i in xrange(len(a)):
+    >>> for i in range(len(a)):
     ...     a[i] = np.log(a[i])
     ...
     __main__:2: RuntimeWarning: divide by zero encountered in log

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -340,7 +340,7 @@ The default iterator of an ndarray object is the default Python
 iterator of a sequence type. Thus, when the array object itself is
 used as an iterator. The default behavior is equivalent to::
 
-    for i in xrange(arr.shape[0]):
+    for i in range(arr.shape[0]):
         val = arr[i]
 
 This default iterator selects a sub-array of dimension :math:`N-1`

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5405,7 +5405,7 @@ add_newdoc('numpy.core', 'ufunc', ('reduce',
     ::
 
      r = op.identity # op = ufunc
-     for i in xrange(len(A)):
+     for i in range(len(A)):
        r = op(r, A[i])
      return r
 
@@ -5486,7 +5486,7 @@ add_newdoc('numpy.core', 'ufunc', ('accumulate',
 
       r = np.empty(len(A))
       t = op.identity        # op = the ufunc being applied to A's  elements
-      for i in xrange(len(A)):
+      for i in range(len(A)):
           t = op(t, A[i])
           r[i] = t
       return r
@@ -5666,8 +5666,8 @@ add_newdoc('numpy.core', 'ufunc', ('outer',
     For `A` and `B` one-dimensional, this is equivalent to::
 
       r = empty(len(A),len(B))
-      for i in xrange(len(A)):
-          for j in xrange(len(B)):
+      for i in range(len(A)):
+          for j in range(len(B)):
               r[i,j] = op(A[i], B[j]) # op = ufunc in question
 
     Parameters

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -414,7 +414,7 @@ def _dtype_from_pep3118(spec, byteorder='@', is_subdtype=False):
         itemsize = 1
         if spec[0].isdigit():
             j = 1
-            for j in xrange(1, len(spec)):
+            for j in range(1, len(spec)):
                 if not spec[j].isdigit():
                     break
             itemsize = int(spec[:j])

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -35,7 +35,7 @@ def _all(a, axis=None, dtype=None, out=None, keepdims=False):
 
 def _count_reduce_items(arr, axis):
     if axis is None:
-        axis = tuple(xrange(arr.ndim))
+        axis = tuple(range(arr.ndim))
     if not isinstance(axis, tuple):
         axis = (axis,)
     items = 1

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -480,14 +480,14 @@ def _formatArray(a, format_function, rank, max_line_len,
     if rank == 1:
         s = ""
         line = next_line_prefix
-        for i in xrange(leading_items):
+        for i in range(leading_items):
             word = format_function(a[i]) + separator
             s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
 
         if summary_insert1:
             s, line = _extendLine(s, line, summary_insert1, max_line_len, next_line_prefix)
 
-        for i in xrange(trailing_items, 1, -1):
+        for i in range(trailing_items, 1, -1):
             word = format_function(a[-i]) + separator
             s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
 
@@ -498,7 +498,7 @@ def _formatArray(a, format_function, rank, max_line_len,
     else:
         s = '['
         sep = separator.rstrip()
-        for i in xrange(leading_items):
+        for i in range(leading_items):
             if i > 0:
                 s += next_line_prefix
             s += _formatArray(a[i], format_function, rank-1, max_line_len,
@@ -509,7 +509,7 @@ def _formatArray(a, format_function, rank, max_line_len,
         if summary_insert1:
             s += next_line_prefix + summary_insert1 + "\n"
 
-        for i in xrange(trailing_items, 1, -1):
+        for i in range(trailing_items, 1, -1):
             if leading_items or i != trailing_items:
                 s += next_line_prefix
             s += _formatArray(a[-i], format_function, rank-1, max_line_len,

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -203,7 +203,7 @@ def find_functions(filename, tag='API'):
     function_name = None
     function_args = []
     doclist = []
-    SCANNING, STATE_DOC, STATE_RETTYPE, STATE_NAME, STATE_ARGS = range(5)
+    SCANNING, STATE_DOC, STATE_RETTYPE, STATE_NAME, STATE_ARGS = list(range(5))
     state = SCANNING
     tagcomment = '/*' + tag
     for lineno, line in enumerate(fo):

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -123,7 +123,7 @@ class MachAr(object):
         # Do we really need to do this?  Aren't they 2 and 2.0?
         # Determine ibeta and beta
         a = one
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             a = a + a
             temp = a + one
             temp1 = temp - a
@@ -132,7 +132,7 @@ class MachAr(object):
         else:
             raise RuntimeError(msg % (_, one.dtype))
         b = one
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             b = b + b
             temp = a + b
             itemp = int_conv(temp-a)
@@ -146,7 +146,7 @@ class MachAr(object):
         # Determine it and irnd
         it = -1
         b = one
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             it = it + 1
             b = b * beta
             temp = b + one
@@ -158,7 +158,7 @@ class MachAr(object):
 
         betah = beta / two
         a = one
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             a = a + a
             temp = a + one
             temp1 = temp - a
@@ -182,7 +182,7 @@ class MachAr(object):
         for i in range(negep):
             a = a * betain
         b = a
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             temp = one - a
             if any(temp-one != zero):
                 break
@@ -201,7 +201,7 @@ class MachAr(object):
         machep = - it - 3
         a = b
 
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             temp = one + a
             if any(temp-one != zero):
                 break
@@ -223,7 +223,7 @@ class MachAr(object):
         z = betain
         t = one + eps
         nxres = 0
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             y = z
             z = y*y
             a = z*one # Check here for underflow
@@ -249,7 +249,7 @@ class MachAr(object):
             mx = iz + iz - 1
 
         # Determine minexp and xmin
-        for _ in xrange(max_iterN):
+        for _ in range(max_iterN):
             xmin = y
             y = y * betain
             a = y * one

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1040,8 +1040,8 @@ def tensordot(a, b, axes=2):
     try:
         iter(axes)
     except:
-        axes_a = range(-axes,0)
-        axes_b = range(0,axes)
+        axes_a = list(range(-axes,0))
+        axes_b = list(range(0,axes))
     else:
         axes_a, axes_b = axes
     try:
@@ -1065,7 +1065,7 @@ def tensordot(a, b, axes=2):
     equal = True
     if (na != nb): equal = False
     else:
-        for k in xrange(na):
+        for k in range(na):
             if as_[axes_a[k]] != bs[axes_b[k]]:
                 equal = False
                 break
@@ -1213,7 +1213,7 @@ def rollaxis(a, axis, start=0):
         start -= 1
     if axis==start:
         return a
-    axes = range(0,n)
+    axes = list(range(0,n))
     axes.remove(axis)
     axes.insert(start, axis)
     return a.transpose(axes)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -112,7 +112,7 @@ if sys.version_info[0] >= 3:
 # "import string" is costly to import!
 # Construct the translation tables directly
 #   "A" = chr(65), "a" = chr(97)
-_all_chars = map(chr, range(256))
+_all_chars = map(chr, list(range(256)))
 _ascii_upper = _all_chars[65:65+26]
 _ascii_lower = _all_chars[97:97+26]
 LOWER_TABLE="".join(_all_chars[:65] + _ascii_lower + _all_chars[65+26:])

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -603,7 +603,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
     nfields = len(recList[0])
     if formats is None and dtype is None:  # slower
         obj = sb.array(recList, dtype=object)
-        arrlist = [sb.array(obj[..., i].tolist()) for i in xrange(nfields)]
+        arrlist = [sb.array(obj[..., i].tolist()) for i in range(nfields)]
         return fromarrays(arrlist, formats=formats, shape=shape, names=names,
                           titles=titles, aligned=aligned, byteorder=byteorder)
 
@@ -622,7 +622,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
         if len(shape) > 1:
             raise ValueError("Can only deal with 1-d array.")
         _array = recarray(shape, descr)
-        for k in xrange(_array.size):
+        for k in range(_array.size):
             _array[k] = tuple(recList[k])
         return _array
     else:

--- a/numpy/core/tests/test_blasdot.py
+++ b/numpy/core/tests/test_blasdot.py
@@ -49,7 +49,7 @@ def test_dot_3args():
     v = np.random.random_sample((16, 32))
 
     r = np.empty((1024, 32))
-    for i in xrange(12):
+    for i in range(12):
         np.dot(f,v,r)
     assert_equal(sys.getrefcount(r), 2)
     r2 = np.dot(f,v,out=None)

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -47,7 +47,7 @@ class TestTake(TestCase):
 
 
     def test_refcounting(self):
-        objects = [object() for i in xrange(10)]
+        objects = [object() for i in range(10)]
         for mode in ('raise', 'clip', 'wrap'):
             a = np.array(objects)
             b = np.array([2, 2, 4, 5, 3, 5])

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -579,7 +579,7 @@ class TestMethods(TestCase):
 
         # test object array sorts.
         a = np.empty((101,), dtype=np.object)
-        a[:] = range(101)
+        a[:] = list(range(101))
         b = a[::-1]
         for kind in ['q', 'h', 'm'] :
             msg = "object sort, kind=%s" % kind
@@ -729,7 +729,7 @@ class TestMethods(TestCase):
 
         # test object array argsorts.
         a = np.empty((101,), dtype=np.object)
-        a[:] = range(101)
+        a[:] = list(range(101))
         b = a[::-1]
         r = np.arange(101)
         rr = r[::-1]
@@ -1059,7 +1059,7 @@ class TestMethods(TestCase):
         # Regression test for a bug that crept in at one point
         a = np.zeros((100, 100))
         assert_(sys.getrefcount(a) < 50)
-        for i in xrange(100):
+        for i in range(100):
             a.diagonal()
         assert_(sys.getrefcount(a) < 50)
 
@@ -1311,10 +1311,10 @@ class TestArgmax(TestCase):
 
     def test_all(self):
         a = np.random.normal(0,1,(4,5,6,7,8))
-        for i in xrange(a.ndim):
+        for i in range(a.ndim):
             amax = a.max(i)
             aargmax = a.argmax(i)
-            axes = range(a.ndim)
+            axes = list(range(a.ndim))
             axes.remove(i)
             assert_(all(amax == aargmax.choose(*a.transpose(i,*axes))))
 
@@ -1379,10 +1379,10 @@ class TestArgmin(TestCase):
 
     def test_all(self):
         a = np.random.normal(0,1,(4,5,6,7,8))
-        for i in xrange(a.ndim):
+        for i in range(a.ndim):
             amin = a.min(i)
             aargmin = a.argmin(i)
-            axes = range(a.ndim)
+            axes = list(range(a.ndim))
             axes.remove(i)
             assert_(all(amin == aargmin.choose(*a.transpose(i,*axes))))
 
@@ -1541,7 +1541,7 @@ class TestPutmask(object):
 
 class TestTake(object):
     def tst_basic(self,x):
-        ind = range(x.shape[0])
+        ind = list(range(x.shape[0]))
         assert_array_equal(x.take(ind, axis=0), x)
 
     def test_ip_types(self):
@@ -2109,7 +2109,7 @@ class TestDot(TestCase):
         v = np.random.random_sample((16, 32))
 
         r = np.empty((1024, 32))
-        for i in xrange(12):
+        for i in range(12):
             dot(f,v,r)
         assert_equal(sys.getrefcount(r), 2)
         r2 = dot(f,v,out=None)
@@ -2532,7 +2532,7 @@ if sys.version_info >= (2, 6):
 
         def test_native_padding(self):
             align = np.dtype('i').alignment
-            for j in xrange(8):
+            for j in range(8):
                 if j == 0:
                     s = 'bi'
                 else:
@@ -2793,7 +2793,7 @@ if sys.version_info >= (2, 6):
                 assert_equal(y.format, '<i')
 
         def test_padding(self):
-            for j in xrange(8):
+            for j in range(8):
                 x = np.array([(1,),(2,)], dtype={'f0': (int, j)})
                 self._check_roundtrip(x)
 

--- a/numpy/core/tests/test_multiarray_assignment.py
+++ b/numpy/core/tests/test_multiarray_assignment.py
@@ -45,7 +45,7 @@ def _indices(ndims):
     # no itertools.product available in Py2.4
 
     res = [[]]
-    for i in xrange(ndims):
+    for i in range(ndims):
         newres = []
         for elem in ind:
             for others in res:

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1435,32 +1435,32 @@ def test_iter_iterindex():
     a = arange(24).reshape(4,3,2)
     for flags in ([], ['buffered']):
         i = nditer(a, flags, buffersize=buffersize)
-        assert_equal(iter_iterindices(i), range(24))
+        assert_equal(iter_iterindices(i), list(range(24)))
         i.iterindex = 2
-        assert_equal(iter_iterindices(i), range(2,24))
+        assert_equal(iter_iterindices(i), list(range(2,24)))
 
         i = nditer(a, flags, order='F', buffersize=buffersize)
-        assert_equal(iter_iterindices(i), range(24))
+        assert_equal(iter_iterindices(i), list(range(24)))
         i.iterindex = 5
-        assert_equal(iter_iterindices(i), range(5,24))
+        assert_equal(iter_iterindices(i), list(range(5,24)))
 
         i = nditer(a[::-1], flags, order='F', buffersize=buffersize)
-        assert_equal(iter_iterindices(i), range(24))
+        assert_equal(iter_iterindices(i), list(range(24)))
         i.iterindex = 9
-        assert_equal(iter_iterindices(i), range(9,24))
+        assert_equal(iter_iterindices(i), list(range(9,24)))
 
         i = nditer(a[::-1,::-1], flags, order='C', buffersize=buffersize)
-        assert_equal(iter_iterindices(i), range(24))
+        assert_equal(iter_iterindices(i), list(range(24)))
         i.iterindex = 13
-        assert_equal(iter_iterindices(i), range(13,24))
+        assert_equal(iter_iterindices(i), list(range(13,24)))
 
         i = nditer(a[::1,::-1], flags, buffersize=buffersize)
-        assert_equal(iter_iterindices(i), range(24))
+        assert_equal(iter_iterindices(i), list(range(24)))
         i.iterindex = 23
-        assert_equal(iter_iterindices(i), range(23,24))
+        assert_equal(iter_iterindices(i), list(range(23,24)))
         i.reset()
         i.iterindex = 2
-        assert_equal(iter_iterindices(i), range(2,24))
+        assert_equal(iter_iterindices(i), list(range(2,24)))
 
 def test_iter_iterrange():
     # Make sure getting and resetting the iterrange works
@@ -1572,7 +1572,7 @@ def test_iter_buffering_delayed_alloc():
     assert_equal(i[0], 0)
     i[1] = 1
     assert_equal(i[0:2], [0,1])
-    assert_equal([[x[0][()],x[1][()]] for x in i], zip(range(6), [1]*6))
+    assert_equal([[x[0][()],x[1][()]] for x in i], zip(list(range(6)), [1]*6))
 
 def test_iter_buffered_cast_simple():
     # Test that buffering can handle a simple cast
@@ -1804,7 +1804,7 @@ def test_iter_buffered_cast_subarray():
                     casting='unsafe',
                     op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
-    for x, count in zip(i, range(6)):
+    for x, count in zip(i, list(range(6))):
         assert_(np.all(x['a'] == count))
 
     # one element -> many -> back (copies it to all)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -520,7 +520,7 @@ class TestTypes(TestCase):
 
 class TestFromiter(TestCase):
     def makegen(self):
-        for x in xrange(24):
+        for x in range(24):
             yield x**2
 
     def test_types(self):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -54,11 +54,11 @@ class TestFromrecords(TestCase):
         b = np.zeros(count, dtype='f8')
         c = np.zeros(count, dtype='f8')
         for i in range(len(a)):
-            a[i] = range(1, 10)
+            a[i] = list(range(1, 10))
 
         mine = np.rec.fromarrays([a, b, c], names='date,data1,data2')
         for i in range(len(a)):
-            assert_((mine.date[i] == range(1, 10)))
+            assert_((mine.date[i] == list(range(1, 10))))
             assert_((mine.data1[i] == 0.0))
             assert_((mine.data2[i] == 0.0))
 
@@ -81,7 +81,7 @@ class TestFromrecords(TestCase):
                        names='c1, c2, c3, c4')
         assert_(ra.dtype == pa.dtype)
         assert_(ra.shape == pa.shape)
-        for k in xrange(len(ra)):
+        for k in range(len(ra)):
             assert_(ra[k].item() == pa[k].item())
 
     def test_recarray_conflict_fields(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -240,7 +240,7 @@ class TestRegression(TestCase):
     def test_argmax(self,level=rlevel):
         """Ticket #119"""
         a = np.random.normal(0,1,(4,5,6,7,8))
-        for i in xrange(a.ndim):
+        for i in range(a.ndim):
             aargmax = a.argmax(i)
 
     def test_mem_divmod(self,level=rlevel):
@@ -675,7 +675,7 @@ class TestRegression(TestCase):
     def test_arr_transpose(self, level=rlevel):
         """Ticket #516"""
         x = np.random.rand(*(2,)*16)
-        y = x.transpose(range(16))
+        y = x.transpose(list(range(16)))
 
     def test_string_mergesort(self, level=rlevel):
         """Ticket #540"""
@@ -1188,7 +1188,7 @@ class TestRegression(TestCase):
         """Ticket #950"""
         for m in [0, 1, 2]:
             for n in [0, 1, 2]:
-                for k in xrange(3):
+                for k in range(3):
                     # Try to ensure that x->data contains non-zero floats
                     x = np.array([123456789e199], dtype=np.float64)
                     x.resize((m, 0))
@@ -1229,8 +1229,8 @@ class TestRegression(TestCase):
 
     def test_fromiter_bytes(self):
         """Ticket #1058"""
-        a = np.fromiter(range(10), dtype='b')
-        b = np.fromiter(range(10), dtype='B')
+        a = np.fromiter(list(range(10)), dtype='b')
+        b = np.fromiter(list(range(10)), dtype='B')
         assert_(np.alltrue(a == np.array([0,1,2,3,4,5,6,7,8,9])))
         assert_(np.alltrue(b == np.array([0,1,2,3,4,5,6,7,8,9])))
 
@@ -1413,8 +1413,8 @@ class TestRegression(TestCase):
         assert_(np.isfinite(np.log1p(np.exp2(-53))))
 
     def test_fromiter_comparison(self, level=rlevel):
-        a = np.fromiter(range(10), dtype='b')
-        b = np.fromiter(range(10), dtype='B')
+        a = np.fromiter(list(range(10)), dtype='b')
+        b = np.fromiter(list(range(10)), dtype='B')
         assert_(np.alltrue(a == np.array([0,1,2,3,4,5,6,7,8,9])))
         assert_(np.alltrue(b == np.array([0,1,2,3,4,5,6,7,8,9])))
 
@@ -1550,7 +1550,7 @@ class TestRegression(TestCase):
         assert_equal(int(np.uint64(x)), x)
 
     def test_duplicate_field_names_assign(self):
-        ra = np.fromiter(((i*3, i*2) for i in xrange(10)), dtype='i8,f8')
+        ra = np.fromiter(((i*3, i*2) for i in range(10)), dtype='i8,f8')
         ra.dtype.names = ('f1', 'f2')
         rep = repr(ra) # should not cause a segmentation fault
         assert_raises(ValueError, setattr, ra.dtype, 'names', ('f1', 'f1'))

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -151,7 +151,7 @@ class TestVstack(TestCase):
 
 def test_concatenate_axis_None():
     a = np.arange(4, dtype=np.float64).reshape((2,2))
-    b = range(3)
+    b = list(range(3))
     c = ['x']
     r = np.concatenate((a, a), axis=None)
     assert_equal(r.dtype, a.dtype)

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -449,7 +449,7 @@ class TestUfunc(TestCase):
             ret = ()
             base = permute_n(n-1)
             for perm in base:
-                for i in xrange(n):
+                for i in range(n):
                     new = perm + [n-1]
                     new[n-1] = new[i]
                     new[i] = n-1

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -400,7 +400,7 @@ class TestCpow(TestCase):
     def test_scalar(self):
         x = np.array([1, 1j,         2,  2.5+.37j, np.inf, np.nan])
         y = np.array([1, 1j, -0.5+1.5j, -0.5+1.5j,      2,      3])
-        lx = range(len(x))
+        lx = list(range(len(x)))
         # Compute the values for complex type in python
         p_r = [complex(x[i]) ** complex(y[i]) for i in lx]
         # Substitute a result allowed by C99 standard
@@ -413,7 +413,7 @@ class TestCpow(TestCase):
     def test_array(self):
         x = np.array([1, 1j,         2,  2.5+.37j, np.inf, np.nan])
         y = np.array([1, 1j, -0.5+1.5j, -0.5+1.5j,      2,      3])
-        lx = range(len(x))
+        lx = list(range(len(x)))
         # Compute the values for complex type in python
         p_r = [complex(x[i]) ** complex(y[i]) for i in lx]
         # Substitute a result allowed by C99 standard

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1047,7 +1047,7 @@ class Configuration(object):
                 pattern_list = allpath(d).split(os.sep)
                 pattern_list.reverse()
                 # /a/*//b/ -> /a/*/b
-                rl = range(len(pattern_list)-1); rl.reverse()
+                rl = list(range(len(pattern_list)-1)); rl.reverse()
                 for i in rl:
                     if not pattern_list[i]:
                         del pattern_list[i]

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -292,7 +292,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
     mline_mark = re.compile(r".*?'''")
     if istop: dowithline('',-1)
     ll,l1='',''
-    spacedigits=[' ']+map(str,range(10))
+    spacedigits=[' ']+map(str,list(range(10)))
     filepositiontext=''
     fin=fileinput.FileInput(ffile)
     while 1:

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -58,7 +58,7 @@ def get_module_dir():
 def get_temp_module_name():
     # Assume single-threaded, and the module dir usable only by this thread
     d = get_module_dir()
-    for j in xrange(5403, 9999999):
+    for j in range(5403, 9999999):
         name = "_test_ext_module_%d" % j
         fn = os.path.join(d, name)
         if name not in sys.modules and not os.path.isfile(fn+'.py'):

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -511,7 +511,7 @@ def _cook_nd_args(a, s=None, axes=None, invreal=0):
         shapeless = 0
     s = list(s)
     if axes is None:
-        axes = range(-len(s), 0)
+        axes = list(range(-len(s), 0))
     if len(s) != len(axes):
         raise ValueError("Shape and axes have different lengths.")
     if invreal and shapeless:
@@ -522,7 +522,7 @@ def _cook_nd_args(a, s=None, axes=None, invreal=0):
 def _raw_fftnd(a, s=None, axes=None, function=fft):
     a = asarray(a)
     s, axes = _cook_nd_args(a, s, axes)
-    itl = range(len(axes))
+    itl = list(range(len(axes)))
     itl.reverse()
     for ii in itl:
         a = function(a, n=s[ii], axis=axes[ii])

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -60,7 +60,7 @@ def fftshift(x, axes=None):
     tmp = asarray(x)
     ndim = len(tmp.shape)
     if axes is None:
-        axes = range(ndim)
+        axes = list(range(ndim))
     elif isinstance(axes, (int, nt.integer)):
         axes = (axes,)
     y = tmp
@@ -108,7 +108,7 @@ def ifftshift(x, axes=None):
     tmp = asarray(x)
     ndim = len(tmp.shape)
     if axes is None:
-        axes = range(ndim)
+        axes = list(range(ndim))
     elif isinstance(axes, (int, nt.integer)):
         axes = (axes,)
     y = tmp

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -760,7 +760,7 @@ def pad(array, pad_width, mode=None, **kwargs):
         function = mode
 
     # Create a new padded array
-    rank = range(len(narray.shape))
+    rank = list(range(len(narray.shape)))
     total_dim_increase = [np.sum(pad_width[i]) for i in rank]
     offset_slices = [slice(pad_width[i][0],
                            pad_width[i][0] + narray.shape[i])

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2589,7 +2589,7 @@ def _chbevl(x, vals):
     b0 = vals[0]
     b1 = 0.0
 
-    for i in xrange(1,len(vals)):
+    for i in range(1,len(vals)):
         b2 = b1
         b1 = b0
         b0 = x*b1 - b2 + vals[i]
@@ -3467,7 +3467,7 @@ def delete(arr, obj, axis=None):
         new[slobj] = arr[slobj2]
     elif isinstance(obj, slice):
         start, stop, step = obj.indices(N)
-        numtodel = len(xrange(start, stop, step))
+        numtodel = len(list(range(start, stop, step)))
         if numtodel <= 0:
             if wrap:
                 return wrap(new)

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -307,7 +307,7 @@ class AxisConcatenator(object):
                         k2 = ndmin-tempobj.ndim
                         if (trans1d < 0):
                             trans1d += k2 + 1
-                        defaxes = range(ndmin)
+                        defaxes = list(range(ndmin))
                         k1 = trans1d
                         axes = defaxes[:k1] + defaxes[k2:] + \
                                defaxes[k1:k2]

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -780,7 +780,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         defconv = _getconv(dtype)
 
         # Skip the first `skiprows` lines
-        for i in xrange(skiprows):
+        for i in range(skiprows):
             fh.next()
 
         # Read until we find a line with some values, and use
@@ -804,7 +804,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             converters = [_getconv(dt) for dt in dtype_types]
         else:
             # All fields have the same dtype
-            converters = [defconv for i in xrange(N)]
+            converters = [defconv for i in range(N)]
             if N > 1:
                 packing = [(N, tuple)]
 
@@ -1339,7 +1339,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             DeprecationWarning)
         skip_header = skiprows
     # Skip the first `skip_header` rows
-    for i in xrange(skip_header):
+    for i in range(skip_header):
         fhd.next()
 
     # Keep on until we find the first valid values

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -74,7 +74,7 @@ def apply_along_axis(func1d,axis,arr,*args):
             % (axis,nd))
     ind = [0]*(nd-1)
     i = zeros(nd,'O')
-    indlist = range(nd)
+    indlist = list(range(nd))
     indlist.remove(axis)
     i[axis] = slice(None,None)
     outshape = asarray(arr.shape).take(indlist)
@@ -754,7 +754,7 @@ def kron(a,b):
             nd = nda
     result = outer(a,b).reshape(as_+bs)
     axis = nd-1
-    for _ in xrange(nd):
+    for _ in range(nd):
         result = concatenate(result, axis=axis)
     wrapper = get_array_prepare(a, b)
     if wrapper is not None:

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -124,15 +124,15 @@ class TestFinancial(TestCase):
         assert_almost_equal(np.nper(0.075,-2000,0,100000.,[0,1]),
                             [ 21.5449442 ,  20.76156441], 4)
 
-        assert_almost_equal(np.ipmt(0.1/12,range(5), 24, 2000),
+        assert_almost_equal(np.ipmt(0.1/12,list(range(5)), 24, 2000),
                             [-17.29165168, -16.66666667, -16.03647345,
                                 -15.40102862, -14.76028842], 4)
 
-        assert_almost_equal(np.ppmt(0.1/12,range(5), 24, 2000),
+        assert_almost_equal(np.ppmt(0.1/12,list(range(5)), 24, 2000),
                             [-74.998201  , -75.62318601, -76.25337923,
                                 -76.88882405, -77.52956425], 4)
 
-        assert_almost_equal(np.ppmt(0.1/12,range(5), 24, 2000, 0,
+        assert_almost_equal(np.ppmt(0.1/12,list(range(5)), 24, 2000, 0,
             [0,0,1,'end','begin']),
                             [-74.998201  , -75.62318601, -75.62318601,
                                 -76.88882405, -76.88882405], 4)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -887,7 +887,7 @@ class TestHistogramdd(TestCase):
         assert_array_equal(H, answer)
 
         Z = np.zeros((5, 5, 5))
-        Z[range(5), range(5), range(5)] = 1.
+        Z[list(range(5)), list(range(5)), list(range(5))] = 1.
         H, edges = histogramdd([np.arange(5), np.arange(5), np.arange(5)], 5)
         assert_array_equal(H, Z)
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -160,7 +160,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
 
         errors = []
         threads = [threading.Thread(target=writer, args=(errors,))
-                   for j in xrange(3)]
+                   for j in range(3)]
         for t in threads:
             t.start()
         for t in threads:

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -191,7 +191,7 @@ class TestHistogram2d(TestCase):
         assert_array_equal(H.T, answer)
         H = histogram2d(x, y, xedges)[0]
         assert_array_equal(H.T, answer)
-        H,xedges,yedges = histogram2d(range(10),range(10))
+        H,xedges,yedges = histogram2d(list(range(10)),list(range(10)))
         assert_array_equal(H, eye(10,10))
         assert_array_equal(xedges, np.linspace(0,9,11))
         assert_array_equal(yedges, np.linspace(0,9,11))

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -226,7 +226,7 @@ def tensorsolve(a, b, axes=None):
     an = a.ndim
 
     if axes is not None:
-        allaxes = range(0, an)
+        allaxes = list(range(0, an))
         for k in axes:
             allaxes.remove(k)
             allaxes.insert(an, k)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -337,7 +337,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
             % (axis, nd))
     ind = [0] * (nd - 1)
     i = np.zeros(nd, 'O')
-    indlist = range(nd)
+    indlist = list(range(nd))
     indlist.remove(axis)
     i[axis] = slice(None, None)
     outshape = np.asarray(arr.shape).take(indlist)
@@ -729,7 +729,7 @@ def compress_rowcols(x, axis=None):
     if m.all():
         return nxarray([])
     # Builds a list of rows/columns indices
-    (idxr, idxc) = (range(len(x)), range(x.shape[1]))
+    (idxr, idxc) = (list(range(len(x))), list(range(x.shape[1])))
     masked = m.nonzero()
     if not axis:
         for i in np.unique(masked[0]):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -381,7 +381,7 @@ class TestMaskedArray(TestCase):
     def test_pickling_subbaseclass(self):
         "Test pickling w/ a subclass of ndarray"
         import cPickle
-        a = array(np.matrix(range(10)), mask=[1, 0, 1, 0, 0] * 2)
+        a = array(np.matrix(list(range(10))), mask=[1, 0, 1, 0, 0] * 2)
         a_pickled = cPickle.loads(a.dumps())
         assert_equal(a_pickled._mask, a._mask)
         assert_equal(a_pickled, a)
@@ -2983,11 +2983,11 @@ class TestMaskedArrayFunctions(TestCase):
 
 
     def test_masked_otherfunctions(self):
-        assert_equal(masked_inside(range(5), 1, 3), [0, 199, 199, 199, 4])
-        assert_equal(masked_outside(range(5), 1, 3), [199, 1, 2, 3, 199])
-        assert_equal(masked_inside(array(range(5), mask=[1, 0, 0, 0, 0]), 1, 3).mask, [1, 1, 1, 1, 0])
-        assert_equal(masked_outside(array(range(5), mask=[0, 1, 0, 0, 0]), 1, 3).mask, [1, 1, 0, 0, 1])
-        assert_equal(masked_equal(array(range(5), mask=[1, 0, 0, 0, 0]), 2).mask, [1, 0, 1, 0, 0])
+        assert_equal(masked_inside(list(range(5)), 1, 3), [0, 199, 199, 199, 4])
+        assert_equal(masked_outside(list(range(5)), 1, 3), [199, 1, 2, 3, 199])
+        assert_equal(masked_inside(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 1, 3).mask, [1, 1, 1, 1, 0])
+        assert_equal(masked_outside(array(list(range(5)), mask=[0, 1, 0, 0, 0]), 1, 3).mask, [1, 1, 0, 0, 1])
+        assert_equal(masked_equal(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 2).mask, [1, 0, 1, 0, 0])
         assert_equal(masked_not_equal(array([2, 2, 1, 2, 1], mask=[1, 0, 0, 0, 0]), 2).mask, [1, 0, 1, 0, 1])
 
 

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -388,13 +388,13 @@ class TestMa(TestCase):
         assert_(eq(masked_where(not_equal(x, 2), x), masked_not_equal(x, 2)))
         assert_(eq(masked_where(equal(x, 2), x), masked_equal(x, 2)))
         assert_(eq(masked_where(not_equal(x, 2), x), masked_not_equal(x, 2)))
-        assert_(eq(masked_inside(range(5), 1, 3), [0, 199, 199, 199, 4]))
-        assert_(eq(masked_outside(range(5), 1, 3), [199, 1, 2, 3, 199]))
-        assert_(eq(masked_inside(array(range(5), mask=[1, 0, 0, 0, 0]), 1, 3).mask,
+        assert_(eq(masked_inside(list(range(5)), 1, 3), [0, 199, 199, 199, 4]))
+        assert_(eq(masked_outside(list(range(5)), 1, 3), [199, 1, 2, 3, 199]))
+        assert_(eq(masked_inside(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 1, 3).mask,
                   [1, 1, 1, 1, 0]))
-        assert_(eq(masked_outside(array(range(5), mask=[0, 1, 0, 0, 0]), 1, 3).mask,
+        assert_(eq(masked_outside(array(list(range(5)), mask=[0, 1, 0, 0, 0]), 1, 3).mask,
                   [1, 1, 0, 0, 1]))
-        assert_(eq(masked_equal(array(range(5), mask=[1, 0, 0, 0, 0]), 2).mask,
+        assert_(eq(masked_equal(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 2).mask,
                   [1, 0, 1, 0, 0]))
         assert_(eq(masked_not_equal(array([2, 2, 1, 2, 1], mask=[1, 0, 0, 0, 0]), 2).mask,
                   [1, 0, 1, 0, 1]))

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -211,13 +211,13 @@ class TestAlgebra(TestCase):
         mA = matrix(A)
 
         B = identity(2)
-        for i in xrange(6):
+        for i in range(6):
             assert_(allclose((mA ** i).A, B))
             B = dot(B, A)
 
         Ainv = linalg.inv(A)
         B = identity(2)
-        for i in xrange(6):
+        for i in range(6):
             assert_(allclose((mA ** -i).A, B))
             B = dot(B, Ainv)
 

--- a/numpy/numarray/functions.py
+++ b/numpy/numarray/functions.py
@@ -155,7 +155,7 @@ class FileSeekWarning(Warning):
     pass
 
 
-STRICT, SLOPPY, WARN = range(3)
+STRICT, SLOPPY, WARN = list(range(3))
 
 _BLOCKSIZE=1024
 
@@ -405,7 +405,7 @@ def put(array, indices, values, axis=0, clipmode=RAISE):
         work[indices] = values
         work = work.swapaxes(0, axis)
     else:
-        def_axes = range(work.ndim)
+        def_axes = list(range(work.ndim))
         for x in axis:
             def_axes.remove(x)
         axis = list(axis)+def_axes
@@ -441,7 +441,7 @@ def take(array, indices, axis=0, outarr=None, clipmode=RAISE):
             return res
         return
     else:
-        def_axes = range(array.ndim)
+        def_axes = list(range(array.ndim))
         for x in axis:
             def_axes.remove(x)
         axis = list(axis) + def_axes

--- a/numpy/oldnumeric/__init__.py
+++ b/numpy/oldnumeric/__init__.py
@@ -11,7 +11,7 @@ def _move_axis_to_0(a, axis):
     n = len(a.shape)
     if axis < 0:
         axis += n
-    axes = range(1, axis+1) + [0,] + range(axis+1, n)
+    axes = list(range(1, axis+1)) + [0,] + list(range(axis+1, n))
     return transpose(a, axes)
 
 # Add these

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -265,7 +265,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = cheb.chebint(tgt, m=1, k=[k])
-                res = cheb.chebint(pol, m=j, k=range(j))
+                res = cheb.chebint(pol, m=j, k=list(range(j)))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
@@ -275,7 +275,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = cheb.chebint(tgt, m=1, k=[k], lbnd=-1)
-                res = cheb.chebint(pol, m=j, k=range(j), lbnd=-1)
+                res = cheb.chebint(pol, m=j, k=list(range(j)), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
@@ -285,7 +285,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = cheb.chebint(tgt, m=1, k=[k], scl=2)
-                res = cheb.chebint(pol, m=j, k=range(j), scl=2)
+                res = cheb.chebint(pol, m=j, k=list(range(j)), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
 
     def test_chebint_axis(self):

--- a/numpy/polynomial/tests/test_hermite.py
+++ b/numpy/polynomial/tests/test_hermite.py
@@ -255,7 +255,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = herm.hermint(tgt, m=1, k=[k])
-                res = herm.hermint(pol, m=j, k=range(j))
+                res = herm.hermint(pol, m=j, k=list(range(j)))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
@@ -265,7 +265,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = herm.hermint(tgt, m=1, k=[k], lbnd=-1)
-                res = herm.hermint(pol, m=j, k=range(j), lbnd=-1)
+                res = herm.hermint(pol, m=j, k=list(range(j)), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
@@ -275,7 +275,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = herm.hermint(tgt, m=1, k=[k], scl=2)
-                res = herm.hermint(pol, m=j, k=range(j), scl=2)
+                res = herm.hermint(pol, m=j, k=list(range(j)), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
 
     def test_hermint_axis(self):

--- a/numpy/polynomial/tests/test_hermite_e.py
+++ b/numpy/polynomial/tests/test_hermite_e.py
@@ -252,7 +252,7 @@ class TestIntegral(TestCase):
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = herme.hermeint(tgt, m=1, k=[k])
-                res = herme.hermeint(pol, m=j, k=range(j))
+                res = herme.hermeint(pol, m=j, k=list(range(j)))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
@@ -262,7 +262,7 @@ class TestIntegral(TestCase):
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = herme.hermeint(tgt, m=1, k=[k], lbnd=-1)
-                res = herme.hermeint(pol, m=j, k=range(j), lbnd=-1)
+                res = herme.hermeint(pol, m=j, k=list(range(j)), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
@@ -272,7 +272,7 @@ class TestIntegral(TestCase):
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = herme.hermeint(tgt, m=1, k=[k], scl=2)
-                res = herme.hermeint(pol, m=j, k=range(j), scl=2)
+                res = herme.hermeint(pol, m=j, k=list(range(j)), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
 
     def test_hermeint_axis(self):

--- a/numpy/polynomial/tests/test_laguerre.py
+++ b/numpy/polynomial/tests/test_laguerre.py
@@ -250,7 +250,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = lag.lagint(tgt, m=1, k=[k])
-                res = lag.lagint(pol, m=j, k=range(j))
+                res = lag.lagint(pol, m=j, k=list(range(j)))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
@@ -260,7 +260,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = lag.lagint(tgt, m=1, k=[k], lbnd=-1)
-                res = lag.lagint(pol, m=j, k=range(j), lbnd=-1)
+                res = lag.lagint(pol, m=j, k=list(range(j)), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
@@ -270,7 +270,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = lag.lagint(tgt, m=1, k=[k], scl=2)
-                res = lag.lagint(pol, m=j, k=range(j), scl=2)
+                res = lag.lagint(pol, m=j, k=list(range(j)), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
 
     def test_lagint_axis(self):

--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -254,7 +254,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = leg.legint(tgt, m=1, k=[k])
-                res = leg.legint(pol, m=j, k=range(j))
+                res = leg.legint(pol, m=j, k=list(range(j)))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
@@ -264,7 +264,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = leg.legint(tgt, m=1, k=[k], lbnd=-1)
-                res = leg.legint(pol, m=j, k=range(j), lbnd=-1)
+                res = leg.legint(pol, m=j, k=list(range(j)), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
@@ -274,7 +274,7 @@ class TestIntegral(TestCase) :
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = leg.legint(tgt, m=1, k=[k], scl=2)
-                res = leg.legint(pol, m=j, k=range(j), scl=2)
+                res = leg.legint(pol, m=j, k=list(range(j)), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
 
     def test_legint_axis(self):

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -253,7 +253,7 @@ class TestIntegral(TestCase):
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = poly.polyint(tgt, m=1, k=[k])
-                res = poly.polyint(pol, m=j, k=range(j))
+                res = poly.polyint(pol, m=j, k=list(range(j)))
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with lbnd
@@ -263,7 +263,7 @@ class TestIntegral(TestCase):
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = poly.polyint(tgt, m=1, k=[k], lbnd=-1)
-                res = poly.polyint(pol, m=j, k=range(j), lbnd=-1)
+                res = poly.polyint(pol, m=j, k=list(range(j)), lbnd=-1)
                 assert_almost_equal(trim(res), trim(tgt))
 
         # check multiple integrations with scaling
@@ -273,7 +273,7 @@ class TestIntegral(TestCase):
                 tgt = pol[:]
                 for k in range(j) :
                     tgt = poly.polyint(tgt, m=1, k=[k], scl=2)
-                res = poly.polyint(pol, m=j, k=range(j), scl=2)
+                res = poly.polyint(pol, m=j, k=list(range(j)), scl=2)
                 assert_almost_equal(trim(res), trim(tgt))
 
     def test_polyint_axis(self):

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -88,7 +88,7 @@ def test_skip_functions_callable():
 def test_skip_generators_hardcoded():
     @dec.knownfailureif(True, "This test is known to fail")
     def g1(x):
-        for i in xrange(x):
+        for i in range(x):
             yield i
 
     try:
@@ -102,7 +102,7 @@ def test_skip_generators_hardcoded():
 
     @dec.knownfailureif(False, "This test is NOT known to fail")
     def g2(x):
-        for i in xrange(x):
+        for i in range(x):
             yield i
         raise DidntSkipException('FAIL')
 
@@ -121,7 +121,7 @@ def test_skip_generators_callable():
 
     @dec.knownfailureif(skip_tester, "This test is known to fail")
     def g1(x):
-        for i in xrange(x):
+        for i in range(x):
             yield i
 
     try:
@@ -136,7 +136,7 @@ def test_skip_generators_callable():
 
     @dec.knownfailureif(skip_tester, "This test is NOT known to fail")
     def g2(x):
-        for i in xrange(x):
+        for i in range(x):
             yield i
         raise DidntSkipException('FAIL')
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -378,7 +378,7 @@ class TestArrayAlmostEqualNulp(unittest.TestCase):
     @dec.knownfailureif(True, "Github issue #347")
     def test_simple(self):
         np.random.seed(12345)
-        for i in xrange(100):
+        for i in range(100):
             dev = np.random.randn(10)
             x = np.ones(10)
             y = x + dev * np.finfo(np.float64).eps

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -80,6 +80,7 @@ FIXES_TO_SKIP = [
     'input',
     'raw_input',
     'xreadlines'
+    'xrange'
 ]
 
 skip_fixes= []

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -79,7 +79,7 @@ FIXES_TO_SKIP = [
     'apply',
     'input',
     'raw_input',
-    'xreadlines'
+    'xreadlines',
     'xrange'
 ]
 


### PR DESCRIPTION
In python3 range is an iterator and `xrange` has been removed. This has
two consequence for code:

```
1) Where a list is needed `list(range(...))` must be used.
2) `xrange` must be replaced by `range`
```

Both of these changes also work in python2 and this patch makes both.

There are three places fixed that do not need it, but I left them in
so that the result would be `xrange` clean.

Closes #3092
