### PR TITLE
Typo fix in FFT docs

### DIFF
--- a/numpy/fft/info.py
+++ b/numpy/fft/info.py
@@ -113,7 +113,7 @@ The inverse DFT is defined as
 
 .. math::
    a_m = \\frac{1}{n}\\sum_{k=0}^{n-1}A_k\\exp\\left\\{2\\pi i{mk\\over n}\\right\\}
-   \\qquad n = 0,\\ldots,n-1.
+   \\qquad m = 0,\\ldots,n-1.
 
 It differs from the forward transform by the sign of the exponential
 argument and the normalization by :math:`1/n`.


### PR DESCRIPTION
This commit fixes a typo in the numpy.fft docs [1], where an index in the formula for the inverse DFT was wrong (should be 'm' instead of 'n').

[1] http://docs.scipy.org/doc/numpy/reference/routines.fft.html
