### PR TITLE
BUG: PyArray_LexSort allocates too much temporary memory.

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1288,11 +1288,11 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                 "need sequence of keys with len > 0 in lexsort");
         return NULL;
     }
-    mps = (PyArrayObject **) PyArray_malloc(n*NPY_SIZEOF_PYARRAYOBJECT);
+    mps = (PyArrayObject **) PyArray_malloc(n * sizeof(PyArrayObject *));
     if (mps == NULL) {
         return PyErr_NoMemory();
     }
-    its = (PyArrayIterObject **) PyArray_malloc(n*sizeof(PyArrayIterObject));
+    its = (PyArrayIterObject **) PyArray_malloc(n * sizeof(PyArrayIterObject *));
     if (its == NULL) {
         PyArray_free(mps);
         return PyErr_NoMemory();


### PR DESCRIPTION
PyArray_LexSort was allocating memory to hold actual PyArrayObject's
and PyArrayIterObject's, but only storing pointers to such objects
in the array.

(backport of #2976)
