### PR TITLE
TST: test_umath: fix wrong indent in test_fast_power

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -158,9 +158,9 @@ class TestPower(TestCase):
             assert_complex_equal(np.power(zero, -p), cnan)
         assert_complex_equal(np.power(zero, -1+0.2j), cnan)
 
-        def test_fast_power(self):
-            x=np.array([1,2,3], np.int16)
-            assert (x**2.00001).dtype is (x**2.0).dtype
+    def test_fast_power(self):
+        x = np.array([1,2,3], np.int16)
+        assert_((x**2.00001).dtype is (x**2.0).dtype)
 
 class TestLog2(TestCase):
     def test_log2_values(self) :


### PR DESCRIPTION
The function test_fast_power was indented one level too far, meaning that it was never run.
