### PR TITLE
ENH (WIP): ufunc: Add an attribute to the ufunc that enables the autogeneration of the function signature in the docstring.

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -374,8 +374,9 @@ possess. None of the attributes can be set.
 
 
 ============  =================================================================
-**__doc__**   A docstring for each ufunc. The first part of the docstring is
-              dynamically generated from the number of outputs, the name, and
+**__doc__**   A docstring for each ufunc.  If the attribute
+              *autogen_docstring_sig* is True, the first part of the docstring
+              is dynamically generated from the number of outputs, the name, and
               the number of inputs. The second part of the docstring is
               provided at creation time and stored with the ufunc.
 
@@ -391,6 +392,7 @@ possess. None of the attributes can be set.
    ufunc.ntypes
    ufunc.types
    ufunc.identity
+   ufunc.autogen_docstring_sig
 
 Methods
 -------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5384,6 +5384,25 @@ add_newdoc('numpy.core', 'ufunc', ('types',
 
     """))
 
+add_newdoc('numpy.core', 'ufunc', ('autogen_docstring_sig',
+    r"""
+    Flag to enable autogeneration of the function signature in the docstring.
+
+    This boolean property enables the automatic generation of the function
+    signature in the docstring.
+
+    Examples
+    --------
+    >>> np.sin.autogen_docstring_sig
+    True
+    >>> np.sin.__doc__[:28]
+    'sin(x[, out])\n\nTrigonometric'
+    >>> np.sin.autogen_docstring_sig = False
+    >>> np.sin.__doc__[:28]
+    'Trigonometric sine, element-'
+
+    """))
+
 
 ##############################################################################
 #

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -212,6 +212,13 @@ typedef struct _tagPyUFuncObject {
          * A function which returns a masked inner loop for the ufunc.
          */
         PyUFunc_MaskedInnerLoopSelectionFunc *masked_inner_loop_selector;
+        /*
+         * 1 to autogenerate the function signature in the docstring
+         * (e.g. "funcname(x[, out])" or "funcname(x1,x2[,out])");
+         * 0 to not generate it, on the assumption that the user will
+         * include the signature in the user-added docstring.
+         */
+        int autogen_docstring_sig;
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -771,5 +771,18 @@ class TestUfunc(TestCase):
         assert_no_warnings(np.add, a, 1.1, out=a, casting="unsafe")
         assert_array_equal(a, [4, 5, 6])
 
+    def test_autogen_docstring_sig(self):
+        # By default, autogen_docstring_sig should be True
+        assert_(np.sin.autogen_docstring_sig)
+        assert_(np.sin.__doc__.startswith('sin(x[, out])\n\n'))
+        np.sin.autogen_docstring_sig = False
+        assert_(not np.sin.autogen_docstring_sig)
+        assert_(np.sin.__doc__.startswith('Trigonometric sine'))
+        np.sin.autogen_docstring_sig = True
+        # Back to where we started?
+        assert_(np.sin.autogen_docstring_sig)
+        assert_(np.sin.__doc__.startswith('sin(x[, out])\n\n'))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
(I don't think anyone is rushing to merge this, but just in case: don't merge this PR.  This is just a "proof of concept" implementation.  The issue is being discussed on the mailing list.)

This PR adds a flag to the ufunc so that the automatic generation of the function signature in the docstring can be disabled.  This will allow a library such as scipy to give a signature in the docstring that has more meaningful variable names, without having a duplicate signature with just 'x' or 'x1, x2' as the variable names.

For example:

```
In [6]: print np.arctan2.__doc__[:90]
arctan2(x1, x2[, out])

Element-wise arc tangent of ``x1/x2`` choosing the quadrant correc

In [7]: np.arctan2.autogen_docstring_sig = False

In [8]: print np.arctan2.__doc__[:90]
Element-wise arc tangent of ``x1/x2`` choosing the quadrant correctly.

The quadrant (i.e.

In [9]: 
```

Here's the issue that came up in a scipy pull request that motivated this change: https://github.com/scipy/scipy/pull/459#issuecomment-14543536
