### PR TITLE
BUG: Do not reuse nditer buffers when not filled enough.

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -2192,6 +2192,11 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
                 break;
             /* Just a copy */
             case 0:
+                /* Do not reuse buffer if it did not exist */
+                if (!(op_itflags[iop] & NPY_OP_ITFLAG_USINGBUFFER) &&
+                                                (prev_dataptrs != NULL)) {
+                    prev_dataptrs[iop] = NULL;
+                }
                 /*
                  * No copyswap or cast was requested, so all we're
                  * doing is copying the data to fill the buffer and
@@ -2235,6 +2240,11 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
                 break;
             /* Just a copy, but with a reduction */
             case NPY_OP_ITFLAG_REDUCE:
+                /* Do not reuse buffer if it did not exist */
+                if (!(op_itflags[iop] & NPY_OP_ITFLAG_USINGBUFFER) &&
+                                                (prev_dataptrs != NULL)) {
+                    prev_dataptrs[iop] = NULL;
+                }
                 if (ad_strides[iop] == 0) {
                     strides[iop] = 0;
                     /* It's all in one stride in the inner loop dimension */

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2024,33 +2024,23 @@ def test_iter_buffered_reduce_reuse():
     a = np.arange(2*3**5)[3**5:3**5+1]
     flags = ['buffered', 'delay_bufalloc', 'multi_index', 'reduce_ok', 'refs_ok']
     op_flags = [('readonly',), ('readwrite','allocate')]
-    op_axes = [(0,1,2), (0,1,-1)]
+    op_axes_list = [[(0,1,2), (0,1,-1)], [(0,1,2), (0,-1,-1)]]
     # wrong dtype to force buffering
     op_dtypes = [np.float, a.dtype]
 
     def get_params():
         for xs in xrange(-3**2, 3**2 + 1):
             for ys in xrange(xs, 3**2 + 1):
-                # last stride is reduced and because of that not
-                # important for this test, as it is the inner stride.
-                strides = (xs * a.itemsize, ys * a.itemsize, a.itemsize)
-                arr = np.lib.stride_tricks.as_strided(a, (3,3,3), strides)
-
-                for bufsize in xrange(0, 3**3):
+                for op_axes in op_axes_list:
+                    # last stride is reduced and because of that not
+                    # important for this test, as it is the inner stride.
+                    strides = (xs * a.itemsize, ys * a.itemsize, a.itemsize)
+                    arr = np.lib.stride_tricks.as_strided(a, (3,3,3), strides)
+ 
                     for skip in [0, 1]:
-                        yield arr, bufsize, skip
+                        yield arr, op_axes, skip
             
-    for arr, bufsize, skip in get_params():
-        nditer1 = np.nditer([arr, None],
-                            op_axes=op_axes, flags=flags, op_flags=op_flags,
-                            buffersize=bufsize, op_dtypes=op_dtypes)
-        nditer1.operands[-1][...] = 0
-        nditer1.reset()
-        nditer1.iterindex = skip
-        
-        for (a1_in, b1_in) in nditer1:
-            b1_in += a1_in.astype(np.int_)
-
+    for arr, op_axes, skip in get_params():
         nditer2 = np.nditer([arr.copy(), None],
                             op_axes=op_axes, flags=flags, op_flags=op_flags,
                             op_dtypes=op_dtypes)
@@ -2061,10 +2051,21 @@ def test_iter_buffered_reduce_reuse():
         for (a2_in, b2_in) in nditer2:
             b2_in += a2_in.astype(np.int_)
 
-        res = nditer1.operands[-1]
         comp_res = nditer2.operands[-1]
 
-        assert_array_equal(res, comp_res)
+        for bufsize in xrange(0, 3**3):
+            nditer1 = np.nditer([arr, None],
+                                op_axes=op_axes, flags=flags, op_flags=op_flags,
+                                buffersize=bufsize, op_dtypes=op_dtypes)
+            nditer1.operands[-1][...] = 0
+            nditer1.reset()
+            nditer1.iterindex = skip
+            
+            for (a1_in, b1_in) in nditer1:
+                b1_in += a1_in.astype(np.int_)
+
+            res = nditer1.operands[-1]
+            assert_array_equal(res, comp_res)
 
 
 def test_iter_no_broadcast():


### PR DESCRIPTION
This checks if the previous time around, the buffers were filled
with as much data as they would be filled this time around. Since
This is difficult for the initial loop before reusing is activated
because in that case the buffer may be larger then just the
first outer reduce dimension. In that case do not allow reuse
unless the index along that dimension was 0.
When the inner reduce index is not 0, then also the reusing of
the buffer is dangerous.
## 

The test is pretty slow since it is a big scan of through parameters (but with the slow decorator a few seconds should be OK I think), and I bet only a small fraction is necessary, etc., but I am a bit tired to try and think of how to best reduce it, so if anyone feels like it, please go ahead, but it seems like an important thing to fix overall.
