### PR TITLE
TST: open the TemporaryFile in ASCII mode

### DIFF
--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -69,7 +69,7 @@ def test_exec_command_stdout():
 
 def test_exec_command_stderr():
     # Test posix version:
-    with redirect_stdout(TemporaryFile()):
+    with redirect_stdout(TemporaryFile(mode='w+')):
         with redirect_stderr(StringIO.StringIO()):
             exec_command.exec_command("cd '.'")
 


### PR DESCRIPTION
This should fix gh-3165.

Conflicts:
    numpy/distutils/tests/test_exec_command.py
