### PR TITLE
BUG: Adapt flexible dtype similarly from array or object

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -522,10 +522,27 @@ discover_itemsize(PyObject *s, int nd, int *itemsize)
 #endif
         PyUnicode_Check(s)) {
 
-        /* If an object has no length, leave it be */
         n = PyObject_Length(s);
         if (n == -1) {
             PyErr_Clear();
+            if (PyBool_Check(s)) {
+                *itemsize = PyArray_MAX(*itemsize, 8);
+            }
+            else if (PyInt_Check(s)) {
+                *itemsize = PyArray_MAX(*itemsize, 24);
+            }
+            else if (PyLong_Check(s)) {
+                *itemsize = PyArray_MAX(*itemsize, 32);
+            }
+            else if (PyFloat_Check(s)) {
+                *itemsize = PyArray_MAX(*itemsize, 32);
+            }
+            else if (PyComplex_Check(s)) {
+                *itemsize = PyArray_MAX(*itemsize, 64);
+            }
+            else {
+                *itemsize = PyArray_MAX(*itemsize, 64);
+            }
         }
         else {
             *itemsize = PyArray_MAX(*itemsize, n);

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -16,7 +16,7 @@ class TestBasic(TestCase):
         A = np.array([['abc', 2],
                       ['long   ', '0123456789']], dtype='O')
         B = np.char.array(A)
-        assert_equal(B.dtype.itemsize, 10)
+        assert_equal(B.dtype.itemsize, 24)
         assert_array_equal(B, asbytes_nested([['abc', '2'],
                                               ['long', '0123456789']]))
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1870,6 +1870,14 @@ class TestRegression(TestCase):
                               order='F')
         assert_array_equal(arr2, data_back)
 
+    def test_consistant_str_dtype(self):
+        # Issue gh-3159: always produce the same dtype despite how a str
+        # array is created.
+        a = np.array(range(12), dtype=str)
+        b = np.array(np.arange(12), dtype=str)
+        c = np.arange(12).astype(str)
+        assert_(a.dtype == b.dtype)
+        assert_(a.dtype == c.dtype)
 
 
 


### PR DESCRIPTION
This is a fix for #3159.   I've updated one test to account for these changes.
