### PR TITLE
MAINT: Fix python3 ResourceWarning when running test_exec_command.py

### DIFF
--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -18,6 +18,8 @@ class redirect_stdout(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self._stdout.flush()
         sys.stdout = self.old_stdout
+        # note: closing sys.stdout won't close it.
+        self._stdout.close()
 
 class redirect_stderr(object):
     """Context manager to redirect stderr for exec_command test."""
@@ -31,6 +33,8 @@ class redirect_stderr(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self._stderr.flush()
         sys.stderr = self.old_stderr
+        # note: closing sys.stderr won't close it.
+        self._stderr.close()
 
 class emulate_nonposix(object):
     """Context manager to emulate os.name != 'posix' """


### PR DESCRIPTION
The tests in test_exec_command.py used with blocks with a context
manager that could redirect stderr and stdout to temporary files but
those files were not closed on exit from the block.
