### PR TITLE
BUG: Raise immediate error in ctypes.load_library when library is bad.

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -122,15 +122,16 @@ else:
         else:
             libdir = loader_path
 
-        # Need to save exception when using Python 3k, see PEP 3110.
-        exc = None
         for ln in libname_ext:
-            try:
-                libpath = os.path.join(libdir, ln)
-                return ctypes.cdll[libpath]
-            except OSError as e:
-                exc = e
-        raise exc
+            libpath = os.path.join(libdir, ln)
+            if os.path.exists(libpath):
+                try:
+                    return ctypes.cdll[libpath]
+                except OSError:
+                    ## defective lib file
+                    raise
+        ## if no successful return in the libname_ext loop:
+        raise OSError("no file with expected extension")
 
     ctypes_load_library = deprecate(load_library, 'ctypes_load_library',
                                     'load_library')


### PR DESCRIPTION
This is a fixup of PR #475 due to JeromeRoy. The problem addressed is
that when multiple errors were encountered attempting to import a
library file, only the last one was preserved. The proposed fix is to
raise an error immediately when a file of the correct name fails to
import, and raise a later error if no file is found but no errors are
raised in the search.

Closes #474, #475.
