### PR TITLE
Fixing numpy.void pickling.

### DIFF
--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -803,11 +803,13 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             }
             vobj->obval = destptr;
 
-            // No base available for copyswp. Copy item data directly dest.
-            if (!base)
-            {
-              memcpy(destptr, data, itemsize);
-              return obj;
+            /*
+             * No base available for copyswp and no swap required.
+             * Copy data directly into dest.
+             */
+            if (base == NULL) {
+                memcpy(destptr, data, itemsize);
+                return obj;
             }
         }
     }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -802,6 +802,13 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
                 return PyErr_NoMemory();
             }
             vobj->obval = destptr;
+
+            // No base available for copyswp. Copy item data directly dest.
+            if (!base)
+            {
+              memcpy(destptr, data, itemsize);
+              return obj;
+            }
         }
     }
     else {

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1184,6 +1184,25 @@ class TestRegression(TestCase):
         assert_(arr[0][0] == 'john')
         assert_(arr[0][1] == 4)
 
+    def test_void_scalar_constructor(self):
+        """Issue #1550"""
+
+        #Create test string data, construct void scalar from data and assert that void scalar contains original data.
+        test_string = np.array("test")
+        test_string_void_scalar = np.core.multiarray.scalar(np.dtype(("V", test_string.dtype.itemsize)), test_string.tostring())
+
+        assert_(test_string_void_scalar.view(test_string.dtype) == test_string)
+
+        #Create record scalar, construct from data and assert that reconstructed scalar is correct.
+        test_record = np.ones((), "i,i")
+        test_record_void_scalar = np.core.multiarray.scalar(test_record.dtype, test_record.tostring())
+
+        assert_(test_record_void_scalar == test_record)
+
+        #Test pickle and unpickle of void and record scalars
+        assert_(pickle.loads(pickle.dumps(test_string)) == test_string)
+        assert_(pickle.loads(pickle.dumps(test_record)) == test_record)
+
     def test_blasdot_uninitialized_memory(self):
         """Ticket #950"""
         for m in [0, 1, 2]:

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1185,17 +1185,21 @@ class TestRegression(TestCase):
         assert_(arr[0][1] == 4)
 
     def test_void_scalar_constructor(self):
-        """Issue #1550"""
+        #Issue #1550
 
-        #Create test string data, construct void scalar from data and assert that void scalar contains original data.
+        #Create test string data, construct void scalar from data and assert
+        #that void scalar contains original data.
         test_string = np.array("test")
-        test_string_void_scalar = np.core.multiarray.scalar(np.dtype(("V", test_string.dtype.itemsize)), test_string.tostring())
+        test_string_void_scalar = np.core.multiarray.scalar(
+            np.dtype(("V",test_string.dtype.itemsize)), test_string.tostring())
 
         assert_(test_string_void_scalar.view(test_string.dtype) == test_string)
 
-        #Create record scalar, construct from data and assert that reconstructed scalar is correct.
+        #Create record scalar, construct from data and assert that
+        #reconstructed scalar is correct.
         test_record = np.ones((), "i,i")
-        test_record_void_scalar = np.core.multiarray.scalar(test_record.dtype, test_record.tostring())
+        test_record_void_scalar = np.core.multiarray.scalar(
+            test_record.dtype, test_record.tostring())
 
         assert_(test_record_void_scalar == test_record)
 


### PR DESCRIPTION
During call to `PyArray_scalar` a `PyVoidScalarObject` is created, and
it's `obval` field set to a newly allocated block of memory of the
correct item size. With a null `base` member, the subsequent call to
`copyswap` can not determine an item size and returns without copying.
Adding direct copy of input data if no `base` is provided, as no swap is
required.

Adding regression test for constructor and original pickle repro case.

Closes #1550.
