### PR TITLE
BUG: solve issue #2649.

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -334,6 +334,8 @@ class matrix(N.ndarray):
             return N.dot(self, other)
         return NotImplemented
 
+    dot = __mul__
+
     def __rmul__(self, other):
         return N.dot(other, self)
 
@@ -385,6 +387,7 @@ class matrix(N.ndarray):
             return self[0,0]
         else:
             return self
+    
 
     # Necessary because base-class tolist expects dimension
     #  reduction by x[0]


### PR DESCRIPTION
The issue is similar to ticket #473(http://mail.scipy.org/pipermail/numpy-tickets/2007-March/000773.html), multipliaction of a matrix and a
column-vector returns a row-vector. That solution is to convert 1d
array, list, tuple to matrix before multiplying. What causes #2649 is that
matrix will use dot function which is inherited from ndarray. My solution is
to use **mul** function instead. It will throw an error when user try to
multiply a sqaure matrix and a 1d array. Test on Linux is done.
