### PR TITLE
documentation, tests, and bugs in seterr behavior for integer types

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2194,8 +2194,10 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
     """
     Set how floating-point errors are handled.
 
-    Note that operations on integer scalar types (such as `int16`) are
-    handled like floating point, and are affected by these settings.
+    Note that operations on **scalars** of integer types (such as `int16`) are
+    handled like floating point, and are affected by these settings. However,
+    operations on **arrays** of integer types are currently note handled, see
+    https://github.com/numpy/numpy/issues/593 for details.
 
     Parameters
     ----------
@@ -2258,6 +2260,9 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     FloatingPointError: overflow encountered in short_scalars
+
+    >>> np.int16([32000]) * 3 # arrays don't have error handling see gh-593
+    array([30464], dtype=int16)
 
     >>> old_settings = np.seterr(all='print')
     >>> np.geterr()

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -367,7 +367,7 @@ class TestFloatExceptions(TestCase):
         return errors
 
     def test_seterr_for_arrays_of_ints(self):
-        "Seterr should apply to arrays of integer types, see gh-493"
+        "Seterr should apply to arrays of integer types, see gh-593"
         err = seterr(all='raise')
         raised=[]
         try:

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -267,13 +267,16 @@ class TestSeterr(TestCase):
 class TestFloatExceptions(TestCase):
     def assert_raises_fpe(self, fpeerr, flop, x, y):
         ftype = type(x)
+        if ftype == np.ndarray:
+            ftype = str(ftype) + str(x.dtype)
+
         try:
             flop(x, y)
             assert_(False,
                     "Type %s did not raise fpe error '%s'." % (ftype, fpeerr))
         except FloatingPointError as exc:
-            assert_(str(exc).find(fpeerr) >= 0,
-                    "Type %s raised wrong fpe error '%s'." % (ftype, exc))
+            assert_(str(exc).find(fpeerr) >= 0, "Type %s raised wrong fpe "
+                    "error '%s', not '%s'." % (ftype, exc, fpeerr))
 
     def assert_op_raises_fpe(self, fpeerr, flop, sc1, sc2):
         """Check that fpe exception is raised.


### PR DESCRIPTION
this is a work in progress. it started off as a documentation improvement for the fact, currently captured in #593 that `np.seterr` does not affect error handling behavior for arrays of integers (although it does mostly work for integer scalars).

But in writing a test for this behavior (which I was intending to submit and mark as a KnownFailure),  I discovered two other bugs in the scalar handling. These examples assume that `np.seterr(all='raise')` has already been called.
1. Integer scalar underflow (for all int types) is reported as overflow. Here's a bit of misinformation - should be UNDER-flow, not overflow

```
    In [28]: np.int8(-128) - np.int8(1)
    ---------------------------------------------------------------------------
    FloatingPointError                        Traceback (most recent call last)
    <ipython-input-28-2b810c89b4d5> in <module>()
    ----> 1 np.int8(-128) - np.int8(1)

    FloatingPointError: overflow encountered in byte_scalars
```
1. int64 overflow is ignored  during multiplication

```
    In [14]: d = np.int8; i = np.iinfo(d); d(i.max) * d(2)
    ---------------------------------------------------------------------------
    FloatingPointError                        Traceback (most recent call last)
    <ipython-input-14-3822c5509024> in <module>()
    ----> 1 d = np.int8; i = np.iinfo(d); d(i.max) * d(2)

    FloatingPointError: overflow encountered in byte_scalars

Good, we also get errors for int16,  int32, but not int64
```

```
In [17]: d = np.int64; i = np.iinfo(d); d(i.max) * d(2)
Out[17]: -2
```

```
```
