### PR TITLE
2to3: Apply `imports2` fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -78,7 +78,8 @@ FIXES_TO_SKIP = [
     'xreadlines',
     'xrange',
     'import',
-    'imports'
+    'imports',
+    'imports2'
 ]
 
 skip_fixes= []

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -79,7 +79,7 @@ FIXES_TO_SKIP = [
     'xrange',
     'import',
     'imports',
-    'imports2'
+    'imports2',
 ]
 
 skip_fixes= []


### PR DESCRIPTION
No files were changed by this fixer, so add it to the list of
fixers to be skipped by 2to3.

Closes #3181.
