### PR TITLE
MAINT: Cleanup some imports involving reduce.

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -16,6 +16,7 @@ __docformat__ = 'restructuredtext'
 # and by Travis Oliphant  2005-8-22 for numpy
 
 import sys
+from functools import reduce
 from . import numerictypes as _nt
 from .umath import maximum, minimum, absolute, not_equal, isnan, isinf
 from .multiarray import format_longfloat, datetime_as_string, datetime_data
@@ -34,8 +35,6 @@ _nan_str = 'nan'
 _inf_str = 'inf'
 _formatter = None  # formatting function for array elements
 
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 def set_printoptions(precision=None, threshold=None, edgeitems=None,
                      linewidth=None, suppress=None,

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -118,6 +118,7 @@ import re
 import copy
 import warnings
 from glob import glob
+from functools import reduce
 
 if sys.version_info[0] < 3:
     from ConfigParser import NoOptionError, ConfigParser
@@ -137,8 +138,6 @@ from numpy.distutils.misc_util import is_sequence, is_string, \
 from numpy.distutils.command.config import config as cmd_config
 from numpy.distutils.compat import get_exception
 
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 # Determine number of bits
 import platform

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -24,6 +24,7 @@ f2py_version = __version__.version
 import pprint
 import sys
 import types
+from functools import reduce
 from . import cfuncs
 
 
@@ -35,8 +36,6 @@ options={}
 debugoptions=[]
 wrapfuncs = 1
 
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 def outmess(t):
     if options.get('verbose',1):

--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -14,8 +14,7 @@ from operator import mul
 __all__ = ['Arrayterator']
 
 import sys
-if sys.version_info[0] >= 3:
-    from functools import reduce
+from functools import reduce
 
 class Arrayterator(object):
     """

--- a/numpy/lib/tests/test_arrayterator.py
+++ b/numpy/lib/tests/test_arrayterator.py
@@ -1,15 +1,13 @@
 from __future__ import division, absolute_import
 
 from operator import mul
+from functools import reduce
 
 import numpy as np
 from numpy.random import randint
 from numpy.lib import Arrayterator
 from numpy.testing import assert_
 
-import sys
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 def test():
     np.random.seed(np.arange(10))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -24,6 +24,7 @@ from __future__ import division, absolute_import
 
 import sys
 import warnings
+from functools import reduce
 
 import numpy as np
 import numpy.core.umath as umath
@@ -35,7 +36,6 @@ from numpy.compat import getargspec, formatargspec
 from numpy import expand_dims as n_expand_dims
 
 if sys.version_info[0] >= 3:
-    from functools import reduce
     import pickle
 else:
     import cPickle as pickle

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -12,6 +12,7 @@ import types
 import warnings
 import sys
 import pickle
+from functools import reduce
 
 import numpy as np
 import numpy.ma.core
@@ -24,8 +25,6 @@ from numpy.testing.utils import WarningManager
 
 pi = np.pi
 
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 #..............................................................................
 class TestMaskedArray(TestCase):

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -1,15 +1,15 @@
 from __future__ import division, absolute_import
 
-import numpy
+import sys
 import types
+from functools import reduce
+
+import numpy
 from numpy.ma import *
 from numpy.core.numerictypes import float32
 from numpy.ma.core import umath
 from numpy.testing import *
 
-import sys
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 pi = numpy.pi
 def eq(v, w, msg=''):

--- a/numpy/ma/timer_comparison.py
+++ b/numpy/ma/timer_comparison.py
@@ -1,8 +1,8 @@
 from __future__ import division, absolute_import
 
 import timeit
+from functools import reduce
 
-import sys
 import numpy as np
 from numpy import float_
 import np.core.fromnumeric as fromnumeric
@@ -13,8 +13,6 @@ np.seterr(all='ignore')
 
 pi = np.pi
 
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 class moduletester(object):
     def __init__(self, module):

--- a/numpy/oldnumeric/ma.py
+++ b/numpy/oldnumeric/ma.py
@@ -20,9 +20,8 @@ from numpy.core.fromnumeric import amax, amin
 from numpy.core.numerictypes import bool_, typecodes
 import numpy.core.numeric as numeric
 import warnings
+from functools import reduce
 
-if sys.version_info[0] >= 3:
-    from functools import reduce
 
 # Ufunc domain lookup for __array_wrap__
 ufunc_domain = {}

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -40,15 +40,6 @@ EXTRA_2TO3_FLAGS = {
     'numpy/core/defchararray.py': '-x unicode',
     'numpy/compat/py3k.py': '-x unicode',
     'numpy/ma/timer_comparison.py': 'skip',
-    'numpy/distutils/system_info.py': '-x reduce',
-    'numpy/f2py/auxfuncs.py': '-x reduce',
-    'numpy/lib/arrayterator.py': '-x reduce',
-    'numpy/lib/tests/test_arrayterator.py': '-x reduce',
-    'numpy/ma/core.py': '-x reduce',
-    'numpy/ma/tests/test_core.py': '-x reduce',
-    'numpy/ma/tests/test_old_ma.py': '-x reduce',
-    'numpy/ma/timer_comparison.py': '-x reduce',
-    'numpy/oldnumeric/ma.py': '-x reduce',
 }
 
 # Names of fixers to skip when running 2to3


### PR DESCRIPTION
Because reduce has been available in functools since Python 2.6 we
can get rid of the version checks we currently have before we import
it.

Also removes some reduce related skips in tools/py3tool.py. We were
already skipping the reduce fixer so this has no effect other than
cleaning up the code.
