### PR TITLE
2to3: apply `dict` fixer.

### DIFF
--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -74,7 +74,7 @@ def main():
 
     # report
     in_sections = {}
-    for name, locations in documented.iteritems():
+    for name, locations in documented.items():
         for (filename, section, keyword, toctree) in locations:
             in_sections.setdefault((filename, section, keyword), []).append(name)
 

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -332,7 +332,7 @@ _pep3118_native_map = {
     'O': 'O',
     'x': 'V', # padding
 }
-_pep3118_native_typechars = ''.join(list(_pep3118_native_map.keys()))
+_pep3118_native_typechars = ''.join(_pep3118_native_map.keys())
 
 _pep3118_standard_map = {
     '?': '?',
@@ -356,7 +356,7 @@ _pep3118_standard_map = {
     'O': 'O',
     'x': 'V', # padding
 }
-_pep3118_standard_typechars = ''.join(list(_pep3118_standard_map.keys()))
+_pep3118_standard_typechars = ''.join(_pep3118_standard_map.keys())
 
 def _dtype_from_pep3118(spec, byteorder='@', is_subdtype=False):
     from numpy.core.multiarray import dtype
@@ -505,7 +505,7 @@ def _dtype_from_pep3118(spec, byteorder='@', is_subdtype=False):
         offset += extra_offset
 
     # Check if this was a simple 1-item type
-    if len(list(fields.keys())) == 1 and not explicit_name and fields['f0'][1] == 0 \
+    if len(fields) == 1 and not explicit_name and fields['f0'][1] == 0 \
            and not is_subdtype:
         ret = fields['f0'][0]
     else:

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -20,7 +20,7 @@ else:
 def _makenames_list(adict, align):
     from .multiarray import dtype
     allfields = []
-    fnames = adict.keys()
+    fnames = list(adict.keys())
     for fname in fnames:
         obj = adict[fname]
         n = len(obj)
@@ -332,7 +332,7 @@ _pep3118_native_map = {
     'O': 'O',
     'x': 'V', # padding
 }
-_pep3118_native_typechars = ''.join(_pep3118_native_map.keys())
+_pep3118_native_typechars = ''.join(list(_pep3118_native_map.keys()))
 
 _pep3118_standard_map = {
     '?': '?',
@@ -356,7 +356,7 @@ _pep3118_standard_map = {
     'O': 'O',
     'x': 'V', # padding
 }
-_pep3118_standard_typechars = ''.join(_pep3118_standard_map.keys())
+_pep3118_standard_typechars = ''.join(list(_pep3118_standard_map.keys()))
 
 def _dtype_from_pep3118(spec, byteorder='@', is_subdtype=False):
     from numpy.core.multiarray import dtype
@@ -505,7 +505,7 @@ def _dtype_from_pep3118(spec, byteorder='@', is_subdtype=False):
         offset += extra_offset
 
     # Check if this was a simple 1-item type
-    if len(fields.keys()) == 1 and not explicit_name and fields['f0'][1] == 0 \
+    if len(list(fields.keys())) == 1 and not explicit_name and fields['f0'][1] == 0 \
            and not is_subdtype:
         ret = fields['f0'][0]
     else:

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -448,7 +448,7 @@ def fullapi_hash(api_dicts):
         def sorted_by_values(d):
             """Sort a dictionary by its values. Assume the dictionary items is of
             the form func_name -> order"""
-            return sorted(list(d.items()), key=lambda x_y: (x_y[1], x_y[0]))
+            return sorted(d.items(), key=lambda x_y: (x_y[1], x_y[0]))
         for name, index in sorted_by_values(d):
             a.extend(name)
             a.extend(str(index))

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -386,7 +386,7 @@ NPY_NO_EXPORT %s %s \\\n       (%s);""" % (self.return_type,
 
 def order_dict(d):
     """Order dict by its values."""
-    o = d.items()
+    o = list(d.items())
     def _key(x):
         return (x[1], x[0])
     return sorted(o, key=_key)
@@ -448,7 +448,7 @@ def fullapi_hash(api_dicts):
         def sorted_by_values(d):
             """Sort a dictionary by its values. Assume the dictionary items is of
             the form func_name -> order"""
-            return sorted(d.items(), key=lambda x_y: (x_y[1], x_y[0]))
+            return sorted(list(d.items()), key=lambda x_y: (x_y[1], x_y[0]))
         for name, index in sorted_by_values(d):
             a.extend(name)
             a.extend(str(index))

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -201,7 +201,7 @@ class memmap(ndarray):
         except KeyError:
             if mode not in valid_filemodes:
                 raise ValueError("mode must be one of %s" %
-                                 (valid_filemodes + mode_equivalents.keys()))
+                                 (valid_filemodes + list(mode_equivalents.keys())))
 
         if hasattr(filename,'read'):
             fid = filename

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -863,7 +863,7 @@ except AttributeError:
     # Py3K
     ScalarType = [int, float, complex, long, bool, bytes, str, memoryview]
 
-ScalarType.extend(list(_sctype2char_dict.keys()))
+ScalarType.extend(_sctype2char_dict.keys())
 ScalarType = tuple(ScalarType)
 for key in _sctype2char_dict.keys():
     cast[key] = lambda x, k=key : array(x, copy=False).astype(k)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -788,7 +788,7 @@ _alignment = _typedict()
 _maxvals = _typedict()
 _minvals = _typedict()
 def _construct_lookups():
-    for name, val in typeinfo.iteritems():
+    for name, val in typeinfo.items():
         if not isinstance(val, tuple):
             continue
         obj = val[-1]
@@ -863,7 +863,7 @@ except AttributeError:
     # Py3K
     ScalarType = [int, float, complex, long, bool, bytes, str, memoryview]
 
-ScalarType.extend(_sctype2char_dict.keys())
+ScalarType.extend(list(_sctype2char_dict.keys()))
 ScalarType = tuple(ScalarType)
 for key in _sctype2char_dict.keys():
     cast[key] = lambda x, k=key : array(x, copy=False).astype(k)

--- a/numpy/core/tests/test_blasdot.py
+++ b/numpy/core/tests/test_blasdot.py
@@ -105,7 +105,7 @@ def test_dot_array_order():
     dtypes_prec = {np.float64: 7, np.float32: 5}
     np.random.seed(7)
 
-    for arr_type, prec in dtypes_prec.iteritems():
+    for arr_type, prec in dtypes_prec.items():
         for a_order in orders:
             a = np.asarray(np.random.randn(a_dim, a_dim),
                 dtype=arr_type, order=a_order)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1502,7 +1502,7 @@ class TestPutmask(object):
         mask = x < 40
 
         for val in [-100,0,15]:
-            for types in np.sctypes.itervalues():
+            for types in np.sctypes.values():
                 for T in types:
                     if T not in unchecked_types:
                         yield self.tst_basic,x.copy().astype(T),T,mask,val
@@ -1549,7 +1549,7 @@ class TestTake(object):
 
         x = np.random.random(24)*100
         x.shape = 2,3,4
-        for types in np.sctypes.itervalues():
+        for types in np.sctypes.values():
             for T in types:
                 if T not in unchecked_types:
                     yield self.tst_basic,x.copy().astype(T)

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -192,7 +192,7 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
     # build any sources in same order as they were originally specified
     #   especially important for fortran .f90 files using modules
     if isinstance(self, FCompiler):
-        objects_to_build = build.keys()
+        objects_to_build = list(build.keys())
         for obj in objects:
             if obj in objects_to_build:
                 src, ext = build[obj]
@@ -255,7 +255,7 @@ replace_method(CCompiler, 'customize_cmd', CCompiler_customize_cmd)
 def _compiler_to_string(compiler):
     props = []
     mx = 0
-    keys = compiler.executables.keys()
+    keys = list(compiler.executables.keys())
     for key in ['version','libraries','library_dirs',
                 'object_switch','compile_switch',
                 'include_dirs','define','undef','rpath','link_objects']:

--- a/numpy/distutils/command/build_py.py
+++ b/numpy/distutils/command/build_py.py
@@ -8,7 +8,7 @@ class build_py(old_build_py):
     def run(self):
         build_src = self.get_finalized_command('build_src')
         if build_src.py_modules_dict and self.packages is None:
-            self.packages = build_src.py_modules_dict.keys ()
+            self.packages = list(build_src.py_modules_dict.keys ())
         old_build_py.run(self)
 
     def find_package_modules(self, package, package_dir):

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -303,7 +303,7 @@ def unique_key(adict):
     # currently it works by appending together n of the letters of the
     #   current keys and increasing n until a unique key is found
     # -- not particularly quick
-    allkeys = adict.keys()
+    allkeys = list(adict.keys())
     done = False
     n = 1
     while not done:

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -195,7 +195,7 @@ def exec_command( command,
     else:
         log.debug('Retaining cwd: %s' % oldcwd)
 
-    oldenv = _preserve_environment( env.keys() )
+    oldenv = _preserve_environment( list(env.keys()) )
     _update_environment( **env )
 
     try:

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -542,7 +542,7 @@ class FCompiler(CCompiler):
     def dump_properties(self):
         """Print out the attributes of a compiler instance."""
         props = []
-        for key in self.executables.keys() + \
+        for key in iter(self.executables.keys()) + \
                 ['version','libraries','library_dirs',
                  'object_switch','compile_switch']:
             if hasattr(self,key):
@@ -848,7 +848,7 @@ def new_fcompiler(plat=None,
         if compiler is not None:
             msg = msg + " with '%s' compiler." % compiler
             msg = msg + " Supported compilers are: %s)" \
-                  % (','.join(fcompiler_class.keys()))
+                  % (','.join(list(fcompiler_class.keys())))
         log.warn(msg)
         failed_fcompiler = True
         return None

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -542,7 +542,7 @@ class FCompiler(CCompiler):
     def dump_properties(self):
         """Print out the attributes of a compiler instance."""
         props = []
-        for key in iter(self.executables.keys()) + \
+        for key in list(self.executables.keys()) + \
                 ['version','libraries','library_dirs',
                  'object_switch','compile_switch']:
             if hasattr(self,key):
@@ -848,7 +848,7 @@ def new_fcompiler(plat=None,
         if compiler is not None:
             msg = msg + " with '%s' compiler." % compiler
             msg = msg + " Supported compilers are: %s)" \
-                  % (','.join(list(fcompiler_class.keys())))
+                  % (','.join(fcompiler_class.keys()))
         log.warn(msg)
         failed_fcompiler = True
         return None

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -111,7 +111,7 @@ def conv(astr):
 
 def unique_key(adict):
     """ Obtain a unique key given a dictionary."""
-    allkeys = adict.keys()
+    allkeys = list(adict.keys())
     done = False
     n = 1
     while not done:

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2208,12 +2208,12 @@ def get_info(name):
     return g.get(name, g.get(name + "_info", {}))
 
 def show():
-    for name,info_dict in globals().iteritems():
+    for name,info_dict in globals().items():
         if name[0] == "_" or type(info_dict) is not type({}): continue
         print(name + ":")
         if not info_dict:
             print("  NOT AVAILABLE")
-        for k,v in info_dict.iteritems():
+        for k,v in info_dict.items():
             v = str(v)
             if k == "sources" and len(v) > 200:
                 v = v[:60] + " ...\n... " + v[-60:]

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2208,12 +2208,12 @@ def get_info(name):
     return g.get(name, g.get(name + "_info", {}))
 
 def show():
-    for name,info_dict in globals().items():
+    for name,info_dict in globals().iteritems():
         if name[0] == "_" or type(info_dict) is not type({}): continue
         print(name + ":")
         if not info_dict:
             print("  NOT AVAILABLE")
-        for k,v in info_dict.items():
+        for k,v in info_dict.iteritems():
             v = str(v)
             if k == "sources" and len(v) > 200:
                 v = v[:60] + " ...\n... " + v[-60:]

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -143,7 +143,7 @@ class LibraryInfo(object):
             The list of section headers.
 
         """
-        return self._sections.keys()
+        return list(self._sections.keys())
 
     def cflags(self, section="default"):
         val = self.vars.interpolate(self._sections[section]['cflags'])
@@ -222,7 +222,7 @@ class VariableSet(object):
             The names of all variables in the `VariableSet` instance.
 
         """
-        return self._raw_data.keys()
+        return list(self._raw_data.keys())
 
     # Emulate a dict to set/get variables values
     def __getitem__(self, name):

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2140,7 +2140,7 @@ def show_all(argv=None):
         show_only.append(n)
     show_all = not show_only
     _gdict_ = globals().copy()
-    for name, c in _gdict_.iteritems():
+    for name, c in _gdict_.items():
         if not inspect.isclass(c):
             continue
         if not issubclass(c, system_info) or c is system_info:

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -613,7 +613,7 @@ def replace(str,d,defaultsep=''):
         return map(lambda d,f=replace,sep=defaultsep,s=str:f(s,d,sep),d)
     if type(str)==types.ListType:
         return map(lambda s,f=replace,sep=defaultsep,d=d:f(s,d,sep),str)
-    for k in 2*d.keys():
+    for k in 2*list(d.keys()):
         if k=='separatorsfor':
             continue
         if 'separatorsfor' in d and k in d['separatorsfor']:

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -192,7 +192,7 @@ if os.path.isfile('.f2py_f2cmap'):
                     f2cmap_all[k][k1] = d[k][k1]
                     outmess('\tMapping "%s(kind=%s)" to "%s"\n' % (k,k1,d[k][k1]))
                 else:
-                    errmess("\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n"%(k,k1,d[k][k1],d[k][k1],c2py_map.keys()))
+                    errmess("\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n"%(k,k1,d[k][k1],d[k][k1],list(c2py_map.keys())))
         outmess('Succesfully applied user defined changes from .f2py_f2cmap\n')
     except Exception as msg:
         errmess('Failed to apply user defined changes from .f2py_f2cmap: %s. Skipping.\n' % (msg))
@@ -491,7 +491,7 @@ def sign2map(a,var):
             ret['cblatexdocstr']=lcb2_map[lcb_map[a]]['latexdocstr']
         else:
             ret['cbname']=a
-            errmess('sign2map: Confused: external %s is not in lcb_map%s.\n'%(a,lcb_map.keys()))
+            errmess('sign2map: Confused: external %s is not in lcb_map%s.\n'%(a,list(lcb_map.keys())))
     if isstring(var):
         ret['length']=getstrlength(var)
     if isarray(var):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -680,7 +680,7 @@ def appenddecl(decl,decl2,force=1):
     if not decl: decl={}
     if not decl2: return decl
     if decl is decl2: return decl
-    for k in decl2.keys():
+    for k in list(decl2.keys()):
         if k=='typespec':
             if force or k not in decl:
                 decl[k]=decl2[k]
@@ -836,7 +836,7 @@ def analyzeline(m,case,line):
                 groupcache[groupcounter]['from']='%s:%s'%(groupcache[groupcounter-1]['from'],currentfilename)
             else:
                 groupcache[groupcounter]['from']='%s:%s'%(groupcache[groupcounter-1]['from'],groupcache[groupcounter-1]['name'])
-        for k in groupcache[groupcounter].keys():
+        for k in list(groupcache[groupcounter].keys()):
             if not groupcache[groupcounter][k]:
                 del groupcache[groupcounter][k]
 
@@ -1031,7 +1031,7 @@ def analyzeline(m,case,line):
                 decl['kindselector']=kindselect
                 decl['charselector']=charselect
                 decl['typename']=typename
-                for k in decl.keys():
+                for k in list(decl.keys()):
                     if not decl[k]: del decl[k]
                 for r in markoutercomma(m1.group('after')).split('@,@'):
                     if '-' in r:
@@ -1205,7 +1205,7 @@ def cracktypespec0(typespec,ll):
         outmess('cracktypespec0: no kind/char_selector pattern found for line.\n')
         return
     d=m1.groupdict()
-    for k in d.keys(): d[k]=unmarkouterparen(d[k])
+    for k in list(d.keys()): d[k]=unmarkouterparen(d[k])
     if typespec in ['complex','integer','logical','real','character','type']:
         selector=d['this']
         ll=d['after']
@@ -1285,7 +1285,7 @@ def updatevars(typespec,selector,attrspec,entitydecl):
             if 'kindselector' not in edecl:
                 edecl['kindselector']=copy.copy(kindselect)
             elif kindselect:
-                for k in kindselect.keys():
+                for k in list(kindselect.keys()):
                     if k in edecl['kindselector'] and (not kindselect[k]==edecl['kindselector'][k]):
                         outmess('updatevars: attempt to change the kindselector "%s" of "%s" ("%s") to "%s". Ignoring.\n' % (k,ename,edecl['kindselector'][k],kindselect[k]))
                     else: edecl['kindselector'][k]=copy.copy(kindselect[k])
@@ -1296,7 +1296,7 @@ def updatevars(typespec,selector,attrspec,entitydecl):
                     errmess('updatevars:%s: attempt to change empty charselector to %r. Ignoring.\n' \
                             %(ename,charselect))
             elif charselect:
-                for k in charselect.keys():
+                for k in list(charselect.keys()):
                     if k in edecl['charselector'] and (not charselect[k]==edecl['charselector'][k]):
                         outmess('updatevars: attempt to change the charselector "%s" of "%s" ("%s") to "%s". Ignoring.\n' % (k,ename,edecl['charselector'][k],charselect[k]))
                     else: edecl['charselector'][k]=copy.copy(charselect[k])
@@ -1322,7 +1322,7 @@ def updatevars(typespec,selector,attrspec,entitydecl):
                 d1=m1.groupdict()
                 for lk in ['len','array','init']:
                     if d1[lk+'2'] is not None: d1[lk]=d1[lk+'2']; del d1[lk+'2']
-                for k in d1.keys():
+                for k in list(d1.keys()):
                     if d1[k] is not None: d1[k]=unmarkouterparen(d1[k])
                     else: del d1[k]
                 if 'len' in d1 and 'array' in d1:
@@ -1364,7 +1364,7 @@ def updatevars(typespec,selector,attrspec,entitydecl):
                         edecl['=']=d1['init']
             else:
                 outmess('updatevars: could not crack entity declaration "%s". Ignoring.\n'%(ename+m.group('after')))
-        for k in edecl.keys():
+        for k in list(edecl.keys()):
             if not edecl[k]:
                 del edecl[k]
         groupcache[groupcounter]['vars'][ename]=edecl
@@ -1386,9 +1386,9 @@ def cracktypespec(typespec,selector):
             kindselect=kindselect.groupdict()
             kindselect['*']=kindselect['kind2']
             del kindselect['kind2']
-            for k in kindselect.keys():
+            for k in list(kindselect.keys()):
                 if not kindselect[k]: del kindselect[k]
-            for k,i in kindselect.items():
+            for k,i in list(kindselect.items()):
                 kindselect[k] = rmbadname1(i)
         elif typespec=='character':
             charselect=charselector.match(selector)
@@ -1407,9 +1407,9 @@ def cracktypespec(typespec,selector):
                     charselect[lk]=lenkind[lk]
                     del lenkind[lk+'2']
             del charselect['lenkind']
-            for k in charselect.keys():
+            for k in list(charselect.keys()):
                 if not charselect[k]: del charselect[k]
-            for k,i in charselect.items():
+            for k,i in list(charselect.items()):
                 charselect[k] = rmbadname1(i)
         elif typespec=='type':
             typename=re.match(r'\s*\(\s*(?P<name>\w+)\s*\)',selector,re.I)
@@ -1449,7 +1449,7 @@ def setkindselector(decl,sel,force=0):
     if 'kindselector' not in decl:
         decl['kindselector']=sel
         return decl
-    for k in sel.keys():
+    for k in list(sel.keys()):
         if force or k not in decl['kindselector']:
             decl['kindselector'][k]=sel[k]
     return decl
@@ -1462,7 +1462,7 @@ def setcharselector(decl,sel,force=0):
     if 'charselector' not in decl:
         decl['charselector']=sel
         return decl
-    for k in sel.keys():
+    for k in list(sel.keys()):
         if force or k not in decl['charselector']:
             decl['charselector'][k]=sel[k]
     return decl
@@ -1496,7 +1496,7 @@ def get_useparameters(block, param_map=None):
     usedict = get_usedict(block)
     if not usedict:
         return param_map
-    for usename,mapping in usedict.items():
+    for usename,mapping in list(usedict.items()):
         usename = usename.lower()
         if usename not in f90modulevars:
             outmess('get_useparameters: no module %s info used by %s\n' % (usename, block.get('name')))
@@ -1508,7 +1508,7 @@ def get_useparameters(block, param_map=None):
         # XXX: apply mapping
         if mapping:
             errmess('get_useparameters: mapping for %s not impl.' % (mapping))
-        for k,v in params.items():
+        for k,v in list(params.items()):
             if k in param_map:
                 outmess('get_useparameters: overriding parameter %s with'\
                         ' value from module %s' % (`k`,`usename`))
@@ -1534,7 +1534,7 @@ def postcrack2(block,tab='',param_map=None):
 
     if param_map is not None and 'vars' in block:
         vars = block['vars']
-        for n in vars.keys():
+        for n in list(vars.keys()):
             var = vars[n]
             if 'kindselector' in var:
                 kind = var['kindselector']
@@ -1587,11 +1587,11 @@ def postcrack(block,args=None,tab=''):
 ##     fromuser = []
     if 'use' in block:
         useblock=block['use']
-        for k in useblock.keys():
+        for k in list(useblock.keys()):
             if '__user__' in k:
                 userisdefined.append(k)
 ##                 if 'map' in useblock[k]:
-##                     for n in useblock[k]['map'].values():
+##                     for n in useblock[k]['map'].itervalues():
 ##                         if n not in fromuser: fromuser.append(n)
     else: useblock={}
     name=''
@@ -1648,7 +1648,7 @@ def postcrack(block,args=None,tab=''):
 def sortvarnames(vars):
     indep = []
     dep = []
-    for v in vars.keys():
+    for v in list(vars.keys()):
         if 'depend' in vars[v] and vars[v]['depend']:
             dep.append(v)
             #print '%s depends on %s'%(v,vars[v]['depend'])
@@ -1682,7 +1682,7 @@ def sortvarnames(vars):
 def analyzecommon(block):
     if not hascommon(block): return block
     commonvars=[]
-    for k in block['common'].keys():
+    for k in list(block['common'].keys()):
         comvars=[]
         for e in block['common'][k]:
             m=re.match(r'\A\s*\b(?P<name>.*?)\b\s*(\((?P<dims>.*?)\)|)\s*\Z',e,re.I)
@@ -1752,7 +1752,7 @@ def buildimplicitrules(block):
             if verbose>1:
                 outmess('buildimplicitrules: no implicit rules for routine %s.\n'%`block['name']`)
         else:
-            for k in block['implicit'].keys():
+            for k in list(block['implicit'].keys()):
                 if block['implicit'][k].get('typespec') not in ['static','automatic']:
                     implicitrules[k]=block['implicit'][k]
                 else:
@@ -1934,7 +1934,7 @@ def _get_depend_dict(name, vars, deps):
     return words
 
 def _calc_depend_dict(vars):
-    names = vars.keys()
+    names = list(vars.keys())
     depend_dict = {}
     for n in names:
         _get_depend_dict(n, vars, depend_dict)
@@ -1945,12 +1945,12 @@ def get_sorted_names(vars):
     """
     depend_dict = _calc_depend_dict(vars)
     names = []
-    for name in depend_dict.keys():
+    for name in list(depend_dict.keys()):
         if not depend_dict[name]:
             names.append(name)
             del depend_dict[name]
     while depend_dict:
-        for name, lst in depend_dict.items():
+        for name, lst in list(depend_dict.items()):
             new_lst = [n for n in lst if n in depend_dict]
             if not new_lst:
                 names.append(name)
@@ -2067,7 +2067,7 @@ def _eval_scalar(value,params):
     except Exception as msg:
         errmess('"%s" in evaluating %r '\
                 '(available names: %s)\n' \
-                % (msg,value,params.keys()))
+                % (msg,value,list(params.keys())))
     return value
 
 def analyzevars(block):
@@ -2081,7 +2081,7 @@ def analyzevars(block):
         del vars['']
         if 'attrspec' in block['vars']['']:
             gen=block['vars']['']['attrspec']
-            for n in vars.keys():
+            for n in list(vars.keys()):
                 for k in ['public','private']:
                     if k in gen:
                         vars[n]=setattrspec(vars[n],k)
@@ -2093,14 +2093,14 @@ def analyzevars(block):
             svars.append(a)
         except KeyError:
             pass
-    for n in vars.keys():
+    for n in list(vars.keys()):
         if n not in args: svars.append(n)
 
     params = get_parameters(vars, get_useparameters(block))
 
     dep_matches = {}
     name_match = re.compile(r'\w[\w\d_$]*').match
-    for v in vars.keys():
+    for v in list(vars.keys()):
         m = name_match(v)
         if m:
             n = v[m.start():m.end()]
@@ -2109,13 +2109,13 @@ def analyzevars(block):
             except KeyError:
                 dep_matches[n] = re.compile(r'.*\b%s\b'%(v),re.I).match
     for n in svars:
-        if n[0] in attrrules.keys():
+        if n[0] in list(attrrules.keys()):
             vars[n]=setattrspec(vars[n],attrrules[n[0]])
         if 'typespec' not in vars[n]:
             if not('attrspec' in vars[n] and 'external' in vars[n]['attrspec']):
                 if implicitrules:
                     ln0 = n[0].lower()
-                    for k in implicitrules[ln0].keys():
+                    for k in list(implicitrules[ln0].keys()):
                         if k=='typespec' and implicitrules[ln0][k]=='undefined':
                             continue
                         if k not in vars[n]:
@@ -2194,7 +2194,7 @@ def analyzevars(block):
                         star=':'
                     if d in params:
                         d = str(params[d])
-                    for p in params.keys():
+                    for p in list(params.keys()):
                         m = re.match(r'(?P<before>.*?)\b'+p+r'\b(?P<after>.*)',d,re.I)
                         if m:
                             #outmess('analyzevars:replacing parameter %s in %s (dimension of %s) with %s\n'%(`p`,`d`,`n`,`params[p]`))
@@ -2208,7 +2208,7 @@ def analyzevars(block):
                         d = '*'
                     if len(dl)==1 and not dl[0]==star: dl = ['1',dl[0]]
                     if len(dl)==2:
-                        d,v,di = getarrlen(dl,block['vars'].keys())
+                        d,v,di = getarrlen(dl,list(block['vars'].keys()))
                         if d[:4] == '1 * ': d = d[4:]
                         if di and di[-4:] == '/(1)': di = di[:-4]
                         if v: savelindims[d] = v,di
@@ -2255,7 +2255,7 @@ def analyzevars(block):
                             d = savelindims[d][0]
                         else:
                             for r in block['args']:
-                            #for r in block['vars'].keys():
+                            #for r in block['vars'].iterkeys():
                                 if r not in vars:
                                     continue
                                 if re.match(r'.*?\b'+r+r'\b',d,re.I):
@@ -2323,13 +2323,13 @@ def analyzevars(block):
                 vars[n]['attrspec'].append('optional')
             if 'depend' not in vars[n]:
                 vars[n]['depend']=[]
-                for v,m in dep_matches.items():
+                for v,m in list(dep_matches.items()):
                     if m(vars[n]['=']): vars[n]['depend'].append(v)
                 if not vars[n]['depend']: del vars[n]['depend']
             if isscalar(vars[n]):
                 vars[n]['='] = _eval_scalar(vars[n]['='],params)
 
-    for n in vars.keys():
+    for n in list(vars.keys()):
         if n==block['name']: # n is block name
             if 'note' in vars[n]:
                 block['note']=vars[n]['note']
@@ -2365,12 +2365,12 @@ def analyzevars(block):
             neededvars=copy.copy(block['args']+block['commonvars'])
         else:
             neededvars=copy.copy(block['args'])
-        for n in vars.keys():
+        for n in list(vars.keys()):
             if l_or(isintent_callback,isintent_aux)(vars[n]):
                 neededvars.append(n)
         if 'entry' in block:
-            neededvars.extend(block['entry'].keys())
-            for k in block['entry'].keys():
+            neededvars.extend(list(block['entry'].keys()))
+            for k in list(block['entry'].keys()):
                 for n in block['entry'][k]:
                     if n not in neededvars:
                         neededvars.append(n)
@@ -2384,8 +2384,8 @@ def analyzevars(block):
             if name in vars and 'intent' in vars[name]:
                 block['intent'] = vars[name]['intent']
         if block['block'] == 'type':
-            neededvars.extend(vars.keys())
-        for n in vars.keys():
+            neededvars.extend(list(vars.keys()))
+        for n in list(vars.keys()):
             if n not in neededvars:
                 del vars[n]
     return vars
@@ -2435,7 +2435,7 @@ def analyzeargs(block):
         args.append(a)
     block['args']=args
     if 'entry' in block:
-        for k,args1 in block['entry'].items():
+        for k,args1 in list(block['entry'].items()):
             for a in args1:
                 if a not in block['vars']:
                     block['vars'][a]={}
@@ -2536,7 +2536,7 @@ def crack2fortrangen(block,tab='\n', as_interface=False):
             args='(%s)'%','.join(argsl)
     f2pyenhancements = ''
     if 'f2pyenhancements' in block:
-        for k in block['f2pyenhancements'].keys():
+        for k in list(block['f2pyenhancements'].keys()):
             f2pyenhancements = '%s%s%s %s'%(f2pyenhancements,tab+tabchar,k,block['f2pyenhancements'][k])
     intent_lst = block.get('intent',[])[:]
     if blocktype=='function' and 'callback' in intent_lst:
@@ -2566,7 +2566,7 @@ def crack2fortrangen(block,tab='\n', as_interface=False):
         mess='! in %s'%block['from']
     if 'entry' in block:
         entry_stmts = ''
-        for k,i in block['entry'].items():
+        for k,i in list(block['entry'].items()):
             entry_stmts = '%s%sentry %s(%s)' \
                           % (entry_stmts,tab+tabchar,k,','.join(i))
         body = body + entry_stmts
@@ -2577,7 +2577,7 @@ def crack2fortrangen(block,tab='\n', as_interface=False):
 
 def common2fortran(common,tab=''):
     ret=''
-    for k in common.keys():
+    for k in list(common.keys()):
         if k=='_BLNK_':
             ret='%s%scommon %s'%(ret,tab,','.join(common[k]))
         else:
@@ -2586,7 +2586,7 @@ def common2fortran(common,tab=''):
 
 def use2fortran(use,tab=''):
     ret=''
-    for m in use.keys():
+    for m in list(use.keys()):
         ret='%s%suse %s,'%(ret,tab,m)
         if use[m]=={}:
             if ret and ret[-1]==',': ret=ret[:-1]
@@ -2595,7 +2595,7 @@ def use2fortran(use,tab=''):
             ret='%s only:'%(ret)
         if 'map' in use[m] and use[m]['map']:
             c=' '
-            for k in use[m]['map'].keys():
+            for k in list(use[m]['map'].keys()):
                 if k==use[m]['map'][k]:
                     ret='%s%s%s'%(ret,c,k); c=','
                 else:
@@ -2637,7 +2637,7 @@ def vars2fortran(block,vars,args,tab='', as_interface=False):
     if 'varnames' in block:
         nout.extend(block['varnames'])
     if not as_interface:
-        for a in vars.keys():
+        for a in list(vars.keys()):
             if a not in nout:
                 nout.append(a)
     for a in nout:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -469,7 +469,7 @@ def run_compile():
             if s[:len(v)]==v:
                 from numpy.distutils import fcompiler
                 fcompiler.load_all_fcompiler_classes()
-                allowed_keys = fcompiler.fcompiler_class.keys()
+                allowed_keys = list(fcompiler.fcompiler_class.keys())
                 nv = ov = s[len(v):].lower()
                 if ov not in allowed_keys:
                     vmap = {} # XXX

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -104,7 +104,7 @@ class _FileOpeners(object):
 
         """
         self._load()
-        return self._file_openers.keys()
+        return list(self._file_openers.keys())
     def __getitem__(self, key):
         self._load()
         return self._file_openers[key]

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -754,7 +754,7 @@ def pad(array, pad_width, mode=None, **kwargs):
                 kwargs[i] = _normalize_shape(narray, kwargs[i])
     elif mode == None:
         raise ValueError('Keyword "mode" must be a function or one of %s.' %
-                          (modefunc.keys(),))
+                          (list(modefunc.keys()),))
     else:
         # User supplied function, I hope
         function = mode

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -344,7 +344,7 @@ def read_array_header_1_0(fp):
     if not isinstance(d, dict):
         msg = "Header is not a dictionary: %r"
         raise ValueError(msg % d)
-    keys = d.keys()
+    keys = list(d.keys())
     keys.sort()
     if keys != ['descr', 'fortran_order', 'shape']:
         msg = "Header does not contain the correct keys: %r"

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -572,7 +572,7 @@ def _savez(file, args, kwds, compress):
     fd, tmpfile = tempfile.mkstemp(suffix='-numpy.npy')
     os.close(fd)
     try:
-        for key, val in namedict.iteritems():
+        for key, val in namedict.items():
             fname = key + '.npy'
             fid = open(tmpfile, 'wb')
             try:
@@ -811,7 +811,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
                 packing = [(N, tuple)]
 
         # By preference, use the converters specified by the user
-        for i, conv in (user_converters or {}).iteritems():
+        for i, conv in (user_converters or {}).items():
             if usecols:
                 try:
                     i = usecols.index(i)

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -317,7 +317,7 @@ def _fix_defaults(output, defaults=None):
     """
     names = output.dtype.names
     (data, mask, fill_value) = (output.data, output.mask, output.fill_value)
-    for (k, v) in (defaults or {}).iteritems():
+    for (k, v) in (defaults or {}).items():
         if k in names:
             fill_value[k] = v
             data[k][mask[k]] = v

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1620,7 +1620,7 @@ def test_npzfile_dict():
     assert_('x' in z.keys())
     assert_('y' in z.keys())
 
-    for f, a in z.iteritems():
+    for f, a in z.items():
         assert_(f in ['x', 'y'])
         assert_equal(a.shape, (3, 3))
 
@@ -1629,7 +1629,7 @@ def test_npzfile_dict():
     for f in z:
         assert_(f in ['x', 'y'])
 
-    assert_('x' in list(z.iterkeys()))
+    assert_('x' in z.keys())
 
 def test_load_refcount():
     # Check that objects returned by np.load are directly freed based on

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -755,7 +755,7 @@ def lookfor(what, module=None, import_modules=True, regenerate=False,
     whats = str(what).lower().split()
     if not whats: return
 
-    for name, (docstring, kind, index) in cache.iteritems():
+    for name, (docstring, kind, index) in cache.items():
         if kind in ('module', 'object'):
             # don't show modules or objects
             continue

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -111,12 +111,12 @@ class FortranLibrary(object):
     def allRoutineNames(self):
         """Return the names of all the routines.
         """
-        return self.names_to_routines.keys()
+        return list(self.names_to_routines.keys())
 
     def allRoutines(self):
         """Return all the routines.
         """
-        return self.names_to_routines.values()
+        return list(self.names_to_routines.values())
 
     def resolveAllDependencies(self):
         """Try to add routines to the library to satisfy all the dependencies

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5536,7 +5536,7 @@ class MaskedArray(ndarray):
         if memo is None:
             memo = {}
         memo[id(self)] = copied
-        for (k, v) in self.__dict__.iteritems():
+        for (k, v) in self.__dict__.items():
             copied.__dict__[k] = deepcopy(v, memo)
         return copied
 

--- a/numpy/numarray/session.py
+++ b/numpy/numarray/session.py
@@ -268,11 +268,11 @@ def save(variables=None, file=SAVEFILE, dictionary=None, verbose=False):
         dictionary = _callers_globals()
 
     if variables is None:
-        keys = dictionary.keys()
+        keys = list(dictionary.keys())
     else:
         keys = variables.split(",")
 
-    source_modules = _callers_modules() + sys.modules.keys()
+    source_modules = _callers_modules() + list(sys.modules.keys())
 
     p = pickle.Pickler(file, protocol=2)
 
@@ -332,7 +332,7 @@ def load(variables=None, file=SAVEFILE, dictionary=None, verbose=False):
             session = dict(zip(o.keys, values))
             _verbose("updating dictionary with session variables.")
             if variables is None:
-                keys = session.keys()
+                keys = list(session.keys())
             else:
                 keys = variables.split(",")
             for k in keys:

--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -110,7 +110,7 @@ class SourceFiles:
 
         fd = open(os.path.join(root, 'index.html'), 'w')
         fd.write("<html>")
-        paths = self.files.keys()
+        paths = list(self.files.keys())
         paths.sort()
         for path in paths:
             fd.write('<p><a href="%s.html">%s</a></p>' %

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -81,6 +81,7 @@ FIXES_TO_SKIP = [
     'imports',
     'imports2',
     'print',
+    'dict',
 ]
 
 skip_fixes= []


### PR DESCRIPTION
In Python3 `dict.items()`, `dict.keys()`, and `dict.values()` are
iterators. This causes problems when a list is needed so the 2to3 fixer
explicitly constructs a list when is finds on of those functions.
However, that is usually not necessary, so a lot of the work here has
been cleaning up those places where the fix is not needed. The big
exception to that is the `numpy/f2py/crackfortran.py` file. The code
there makes extensive use of loops that modify the contents of the
dictionary being looped through, which raises an error. That together
with the obscurity of the code in that file made it safest to let the
`dict` fixer do its worst.

Closes #3050.
