### PR TITLE
2to3: Apply `repr` fixer.

### DIFF
--- a/numpy/_import_tools.py
+++ b/numpy/_import_tools.py
@@ -337,7 +337,7 @@ class PackageLoaderDebug(PackageLoader):
     def _execcmd(self,cmdstr):
         """ Execute command in parent_frame."""
         frame = self.parent_frame
-        print('Executing',`cmdstr`,'...', end=' ')
+        print('Executing',repr(cmdstr),'...', end=' ')
         sys.stdout.flush()
         exec (cmdstr, frame.f_globals,frame.f_locals)
         print('ok')

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -176,7 +176,7 @@ class format_parser:
             elif (type(names) == str):
                 names = names.split(',')
             else:
-                raise NameError("illegal input names %s" % `names`)
+                raise NameError("illegal input names %s" % repr(names))
 
             self._names = [n.strip() for n in names[:self._nfields]]
         else:
@@ -533,7 +533,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
                 raise ValueError("item in the array list must be an ndarray.")
             formats += _typestr[obj.dtype.type]
             if issubclass(obj.dtype.type, nt.flexible):
-                formats += `obj.itemsize`
+                formats += repr(obj.itemsize)
             formats += ','
         formats = formats[:-1]
 

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -50,9 +50,9 @@ class TestGpaths(TestCase):
     def test_gpaths(self):
         local_path = minrelpath(join(dirname(__file__),'..'))
         ls = gpaths('command/*.py', local_path)
-        assert_(join(local_path,'command','build_src.py') in ls,`ls`)
+        assert_(join(local_path,'command','build_src.py') in ls,repr(ls))
         f = gpaths('system_info.py', local_path)
-        assert_(join(local_path,'system_info.py')==f[0],`f`)
+        assert_(join(local_path,'system_info.py')==f[0],repr(f))
 
 
 if __name__ == "__main__":

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -499,12 +499,12 @@ def getmultilineblock(rout,blockname,comment=1,counter=0):
         r = r[counter]
     if r[:3]=="'''":
         if comment:
-            r = '\t/* start ' + blockname + ' multiline ('+`counter`+') */\n' + r[3:]
+            r = '\t/* start ' + blockname + ' multiline ('+repr(counter)+') */\n' + r[3:]
         else:
             r = r[3:]
         if r[-3:]=="'''":
             if comment:
-                r = r[:-3] + '\n\t/* end multiline ('+`counter`+')*/'
+                r = r[:-3] + '\n\t/* end multiline ('+repr(counter)+')*/'
             else:
                 r = r[:-3]
         else:
@@ -703,7 +703,7 @@ def applyrules(rules,d,var={}):
                             else: i=''
                         ret[k].append(replace(i,d))
         else:
-            errmess('applyrules: ignoring rule %s.\n'%`rules[k]`)
+            errmess('applyrules: ignoring rule %s.\n'%repr(rules[k]))
         if type(ret[k])==types.ListType:
             if len(ret[k])==1:
                 ret[k]=ret[k][0]

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -273,7 +273,7 @@ def getstrlength(var):
         else:
             errmess('getstrlength: function %s has no return value?!\n'%a)
     if not isstring(var):
-        errmess('getstrlength: expected a signature of a string but got: %s\n'%(`var`))
+        errmess('getstrlength: expected a signature of a string but got: %s\n'%(repr(var)))
     len='1'
     if 'charselector' in var:
         a=var['charselector']
@@ -284,7 +284,7 @@ def getstrlength(var):
     if re.match(r'\(\s*([*]|[:])\s*\)',len) or re.match(r'([*]|[:])',len):
     #if len in ['(*)','*','(:)',':']:
         if isintent_hide(var):
-            errmess('getstrlength:intent(hide): expected a string with defined length but got: %s\n'%(`var`))
+            errmess('getstrlength:intent(hide): expected a string with defined length but got: %s\n'%(repr(var)))
         len='-1'
     return len
 
@@ -304,11 +304,11 @@ def getarrdims(a,var,verbose=0):
 #             var['dimension'].reverse()
         dim=copy.copy(var['dimension'])
         ret['size']='*'.join(dim)
-        try: ret['size']=`eval(ret['size'])`
+        try: ret['size']=repr(eval(ret['size']))
         except: pass
         ret['dims']=','.join(dim)
-        ret['rank']=`len(dim)`
-        ret['rank*[-1]']=`len(dim)*[-1]`[1:-1]
+        ret['rank']=repr(len(dim))
+        ret['rank*[-1]']=repr(len(dim)*[-1])[1:-1]
         for i in range(len(dim)): # solve dim for dependecies
             v=[]
             if dim[i] in depargs: v=[dim[i]]
@@ -336,7 +336,7 @@ def getarrdims(a,var,verbose=0):
                         % (d))
                 ret['cbsetdims']='%s#varname#_Dims[%d]=%s,'%(ret['cbsetdims'],i,0)
             elif verbose :
-                errmess('getarrdims: If in call-back function: array argument %s must have bounded dimensions: got %s\n'%(`a`,`d`))
+                errmess('getarrdims: If in call-back function: array argument %s must have bounded dimensions: got %s\n'%(repr(a),repr(d)))
         if ret['cbsetdims']: ret['cbsetdims']=ret['cbsetdims'][:-1]
 #         if not isintent_c(var):
 #             var['dimension'].reverse()
@@ -385,7 +385,7 @@ def getpydocsign(a,var):
         sigout='%s : string(len=%s)'%(out_a,getstrlength(var))
     elif isarray(var):
         dim=var['dimension']
-        rank=`len(dim)`
+        rank=repr(len(dim))
         sig='%s : %s rank-%s array(\'%s\') with bounds (%s)%s'%(a,opt,rank,
                                              c2pycode_map[ctype],
                                              ','.join(dim), init)
@@ -416,7 +416,7 @@ def getarrdocsign(a,var):
                                             c2pycode_map[ctype],)
     elif isarray(var):
         dim=var['dimension']
-        rank=`len(dim)`
+        rank=repr(len(dim))
         sig='%s : rank-%s array(\'%s\') with bounds (%s)'%(a,rank,
                                                            c2pycode_map[ctype],
                                                            ','.join(dim))
@@ -590,7 +590,7 @@ def routsign2map(rout):
             #else:
             #    errmess('routsign2map: cb_map does not contain module "%s" used in "use" statement.\n'%(u))
     elif 'externals' in rout and rout['externals']:
-        errmess('routsign2map: Confused: function %s has externals %s but no "use" statement.\n'%(ret['name'],`rout['externals']`))
+        errmess('routsign2map: Confused: function %s has externals %s but no "use" statement.\n'%(ret['name'],repr(rout['externals'])))
     ret['callprotoargument'] = getcallprotoargument(rout,lcb_map) or ''
     if isfunction(rout):
         if 'result' in rout:
@@ -607,7 +607,7 @@ def routsign2map(rout):
             ret['rformat']=c2buildvalue_map[ret['ctype']]
         else:
             ret['rformat']='O'
-            errmess('routsign2map: no c2buildvalue key for type %s\n'%(`ret['ctype']`))
+            errmess('routsign2map: no c2buildvalue key for type %s\n'%(repr(ret['ctype'])))
         if debugcapi(rout):
             if ret['ctype'] in cformat_map:
                 ret['routdebugshowvalue']='debug-capi:%s=%s'%(a,cformat_map[ret['ctype']])
@@ -616,7 +616,7 @@ def routsign2map(rout):
         if isstringfunction(rout):
             ret['rlength']=getstrlength(rout['vars'][a])
             if ret['rlength']=='-1':
-                errmess('routsign2map: expected explicit specification of the length of the string returned by the fortran function %s; taking 10.\n'%(`rout['name']`))
+                errmess('routsign2map: expected explicit specification of the length of the string returned by the fortran function %s; taking 10.\n'%(repr(rout['name'])))
                 ret['rlength']='10'
     if hasnote(rout):
         ret['note']=rout['note']
@@ -744,8 +744,8 @@ void
                 nofargs=nofargs+1
                 if isoptional(var):
                     nofoptargs=nofoptargs+1
-    ret['maxnofargs']=`nofargs`
-    ret['nofoptargs']=`nofoptargs`
+    ret['maxnofargs']=repr(nofargs)
+    ret['nofoptargs']=repr(nofoptargs)
     if hasnote(rout) and isfunction(rout) and 'result' in rout:
         ret['routnote']=rout['note']
         rout['note']=['See elsewhere.']

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1154,7 +1154,7 @@ def append_needs(need,flag=1):
         elif need in commonhooks:
             n = 'commonhooks'
         else:
-            errmess('append_needs: unknown need %s\n'%(`need`))
+            errmess('append_needs: unknown need %s\n'%(repr(need)))
             return
         if need in outneeds[n]: return
         if flag:
@@ -1189,7 +1189,7 @@ def append_needs(need,flag=1):
             tmp[n].append(need)
             return tmp
     else:
-        errmess('append_needs: expected list or string but got :%s\n'%(`need`))
+        errmess('append_needs: expected list or string but got :%s\n'%(repr(need)))
 
 def get_needs():
     global outneeds,needs

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -314,7 +314,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
             if strictf77: beginpattern=beginpattern77
             else: beginpattern=beginpattern90
             outmess('\tReading file %s (format:%s%s)\n'\
-                    %(`currentfilename`,sourcecodeform,
+                    %(repr(currentfilename),sourcecodeform,
                       strictf77 and ',strict' or ''))
 
         l=l.expandtabs().replace('\xa0',' ')
@@ -346,7 +346,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
             if not (l[0] in spacedigits):
                 raise Exception('readfortrancode: Found non-(space,digit) char '
                                 'in the first column.\n\tAre you sure that '
-                                'this code is in fix form?\n\tline=%s' % `l`)
+                                'this code is in fix form?\n\tline=%s' % repr(l))
 
             if (not cont or strictf77) and (len(l)>5 and not l[5]==' '):
                 # Continuation of a previous line
@@ -401,7 +401,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
                 ll=l
             cont=(r is not None)
         else:
-            raise ValueError("Flag sourcecodeform must be either 'fix' or 'free': %s"%`sourcecodeform`)
+            raise ValueError("Flag sourcecodeform must be either 'fix' or 'free': %s"%repr(sourcecodeform))
         filepositiontext='Line #%d in %s:"%s"\n\t' % (fin.filelineno()-1,currentfilename,l1)
         m=includeline.match(origfinalline)
         if m:
@@ -418,7 +418,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
                         readfortrancode(fn1,dowithline=dowithline,istop=0)
                         break
                 if not foundfile:
-                    outmess('readfortrancode: could not find include file %s in %s. Ignoring.\n'%(`fn`, os.pathsep.join(include_dirs)))
+                    outmess('readfortrancode: could not find include file %s in %s. Ignoring.\n'%(repr(fn), os.pathsep.join(include_dirs)))
         else:
             dowithline(finalline)
         l1=ll
@@ -442,7 +442,7 @@ def readfortrancode(ffile,dowithline=show,istop=1):
                     readfortrancode(fn1,dowithline=dowithline,istop=0)
                     break
             if not foundfile:
-                outmess('readfortrancode: could not find include file %s in %s. Ignoring.\n'%(`fn`, os.pathsep.join(include_dirs)))
+                outmess('readfortrancode: could not find include file %s in %s. Ignoring.\n'%(repr(fn), os.pathsep.join(include_dirs)))
     else:
         dowithline(finalline)
     filepositiontext=''
@@ -521,7 +521,7 @@ def crackline(line,reset=0):
     if ';' in line and not (f2pyenhancementspattern[0].match(line) or
                             multilinepattern[0].match(line)):
         for l in line.split(';'):
-            assert reset==0,`reset` # XXX: non-zero reset values need testing
+            assert reset==0,repr(reset) # XXX: non-zero reset values need testing
             crackline(l,reset)
         return
     if reset<0:
@@ -540,7 +540,7 @@ def crackline(line,reset=0):
         fl=0
         if f77modulename and neededmodule==groupcounter: fl=2
         while groupcounter>fl:
-            outmess('crackline: groupcounter=%s groupname=%s\n'%(`groupcounter`,`groupname`))
+            outmess('crackline: groupcounter=%s groupname=%s\n'%(repr(groupcounter),repr(groupname)))
             outmess('crackline: Mismatch of blocks encountered. Trying to fix it by assuming "end" statement.\n')
             grouplist[groupcounter-1].append(groupcache[groupcounter])
             grouplist[groupcounter-1][-1]['body']=grouplist[groupcounter]
@@ -594,7 +594,7 @@ def crackline(line,reset=0):
                     else: line='callfun %s(%s)'%(name,a)
                     m = callfunpattern[0].match(line)
                     if not m:
-                        outmess('crackline: could not resolve function call for line=%s.\n'%`line`)
+                        outmess('crackline: could not resolve function call for line=%s.\n'%repr(line))
                         return
                     analyzeline(m,'callfun',line)
                     return
@@ -614,7 +614,7 @@ def crackline(line,reset=0):
         if (m1) and (not m1.group('this')==groupname[groupcounter]):
             raise Exception('crackline: End group %s does not match with '
                             'previous Begin group %s\n\t%s' % \
-                            (`m1.group('this')`, `groupname[groupcounter]`,
+                            (repr(m1.group('this')), repr(groupname[groupcounter]),
                              filepositiontext)
                             )
         if skipblocksuntil==groupcounter:
@@ -671,7 +671,7 @@ def markoutercomma(line,comma=','):
             l=l+'@'+comma+'@'
             continue
         l=l+c
-    assert not f,`f,line,l,cc`
+    assert not f,repr((f,line,l,cc))
     return l
 def unmarkouterparen(line):
     r = line.replace('@(@','(').replace('@)@',')')
@@ -797,7 +797,7 @@ def analyzeline(m,case,line):
         grouplist[groupcounter]=[]
         if needmodule:
             if verbose>1:
-                outmess('analyzeline: Creating module block %s\n'%`f77modulename`,0)
+                outmess('analyzeline: Creating module block %s\n'%repr(f77modulename),0)
             groupname[groupcounter]='module'
             groupcache[groupcounter]['block']='python module'
             groupcache[groupcounter]['name']=f77modulename
@@ -890,7 +890,7 @@ def analyzeline(m,case,line):
             if args:
                 args=rmbadname([x.strip() for x in markoutercomma(args).split('@,@')])
             else: args=[]
-            assert result is None,`result`
+            assert result is None,repr(result)
             groupcache[groupcounter]['entry'][name] = args
             previous_context = ('entry',name,groupcounter)
     elif case=='type':
@@ -923,7 +923,7 @@ def analyzeline(m,case,line):
                 if case in ['public','private']: k=''
                 else:
                     print(m.groupdict())
-                    outmess('analyzeline: no name pattern found in %s statement for %s. Skipping.\n'%(case,`e`))
+                    outmess('analyzeline: no name pattern found in %s statement for %s. Skipping.\n'%(case,repr(e)))
                     continue
             else:
                 k=rmbadname1(m1.group('name'))
@@ -1151,7 +1151,7 @@ def analyzeline(m,case,line):
                         m2=re.match(r'\A\s*(?P<local>\b[\w]+\b)\s*=\s*>\s*(?P<use>\b[\w]+\b)\s*\Z',l,re.I)
                         if m2: rl[m2.group('local').strip()]=m2.group('use').strip()
                         else:
-                            outmess('analyzeline: Not local=>use pattern found in %s\n'%`l`)
+                            outmess('analyzeline: Not local=>use pattern found in %s\n'%repr(l))
                     else:
                         rl[l]=l
                     groupcache[groupcounter]['use'][name]['map']=rl
@@ -1271,7 +1271,7 @@ def updatevars(typespec,selector,attrspec,entitydecl):
     for e in el1:
         m=namepattern.match(e)
         if not m:
-            outmess('updatevars: no name pattern found for entity=%s. Skipping.\n'%(`e`))
+            outmess('updatevars: no name pattern found for entity=%s. Skipping.\n'%(repr(e)))
             continue
         ename=rmbadname1(m.group('name'))
         edecl={}
@@ -1381,7 +1381,7 @@ def cracktypespec(typespec,selector):
         if typespec in ['complex','integer','logical','real']:
             kindselect=kindselector.match(selector)
             if not kindselect:
-                outmess('cracktypespec: no kindselector pattern found for %s\n'%(`selector`))
+                outmess('cracktypespec: no kindselector pattern found for %s\n'%(repr(selector)))
                 return
             kindselect=kindselect.groupdict()
             kindselect['*']=kindselect['kind2']
@@ -1393,7 +1393,7 @@ def cracktypespec(typespec,selector):
         elif typespec=='character':
             charselect=charselector.match(selector)
             if not charselect:
-                outmess('cracktypespec: no charselector pattern found for %s\n'%(`selector`))
+                outmess('cracktypespec: no charselector pattern found for %s\n'%(repr(selector)))
                 return
             charselect=charselect.groupdict()
             charselect['*']=charselect['charlen']
@@ -1414,9 +1414,9 @@ def cracktypespec(typespec,selector):
         elif typespec=='type':
             typename=re.match(r'\s*\(\s*(?P<name>\w+)\s*\)',selector,re.I)
             if typename: typename=typename.group('name')
-            else: outmess('cracktypespec: no typename found in %s\n'%(`typespec+selector`))
+            else: outmess('cracktypespec: no typename found in %s\n'%(repr(typespec+selector)))
         else:
-            outmess('cracktypespec: no selector used for %s\n'%(`selector`))
+            outmess('cracktypespec: no selector used for %s\n'%(repr(selector)))
     return kindselect,charselect,typename
 ######
 def setattrspec(decl,attr,force=0):
@@ -1511,7 +1511,7 @@ def get_useparameters(block, param_map=None):
         for k,v in list(params.items()):
             if k in param_map:
                 outmess('get_useparameters: overriding parameter %s with'\
-                        ' value from module %s' % (`k`,`usename`))
+                        ' value from module %s' % (repr(k),repr(usename)))
             param_map[k] = v
 
     return param_map
@@ -1750,7 +1750,7 @@ def buildimplicitrules(block):
         if block['implicit'] is None:
             implicitrules=None
             if verbose>1:
-                outmess('buildimplicitrules: no implicit rules for routine %s.\n'%`block['name']`)
+                outmess('buildimplicitrules: no implicit rules for routine %s.\n'%repr(block['name']))
         else:
             for k in list(block['implicit'].keys()):
                 if block['implicit'][k].get('typespec') not in ['static','automatic']:
@@ -1827,12 +1827,12 @@ def getarrlen(dl,args,star='*'):
         if p1==0: d='-(%s)' % (dl[0])
         else: d='%s-(%s)' % (p1,dl[0])
     else: d = '%s-(%s)+1'%(dl[1],dl[0])
-    try: return `myeval(d,{},{})`,None,None
+    try: return repr(myeval(d,{},{})),None,None
     except: pass
     d1,d2=getlincoef(dl[0],args),getlincoef(dl[1],args)
     if None not in [d1[0],d2[0]]:
         if (d1[0],d2[0])==(0,0):
-            return `d2[1]-d1[1]+1`,None,None
+            return repr(d2[1]-d1[1]+1),None,None
         b = d2[1] - d1[1] + 1
         d1 = (d1[0],0,d1[2])
         d2 = (d2[0],b,d2[2])
@@ -1847,7 +1847,7 @@ def getarrlen(dl,args,star='*'):
             else: return '%s * %s'%(-d1[0],d1[2]),d1[2],')/(%s)'%(-d1[0])
         if d1[2]==d2[2] and d1[2] in args:
             a = d2[0] - d1[0]
-            if not a: return `b`,None,None
+            if not a: return repr(b),None,None
             if b<0: return '%s * %s - %s'%(a,d1[2],-b),d2[2],'+%s)/(%s)'%(-b,a)
             elif b: return '%s * %s + %s'%(a,d1[2],b),d2[2],'-%s)/(%s)'%(b,a)
             else: return '%s * %s'%(a,d1[2]),d2[2],')/(%s)'%(a)
@@ -1928,7 +1928,7 @@ def _get_depend_dict(name, vars, deps):
                 if w not in words:
                     words.append(w)
     else:
-        outmess('_get_depend_dict: no dependence info for %s\n' % (`name`))
+        outmess('_get_depend_dict: no dependence info for %s\n' % (repr(name)))
         words = []
     deps[name] = words
     return words
@@ -2039,7 +2039,7 @@ def get_parameters(vars, global_params={}):
             except Exception as msg:
                 params[n] = v
                 #print params
-                outmess('get_parameters: got "%s" on %s\n' % (msg,`v`))
+                outmess('get_parameters: got "%s" on %s\n' % (msg,repr(v)))
             if isstring(vars[n]) and type(params[n]) is type(0):
                 params[n] = chr(params[n])
             nl = n.lower()
@@ -2047,7 +2047,7 @@ def get_parameters(vars, global_params={}):
                 params[nl] = params[n]
         else:
             print(vars[n])
-            outmess('get_parameters:parameter %s does not have value?!\n'%(`n`))
+            outmess('get_parameters:parameter %s does not have value?!\n'%(repr(n)))
     return params
 
 def _eval_length(length,params):
@@ -2124,7 +2124,7 @@ def analyzevars(block):
                             for l in implicitrules[ln0][k]:
                                 vars[n]=setattrspec(vars[n],l)
                 elif n in block['args']:
-                    outmess('analyzevars: typespec of variable %s is not defined in routine %s.\n'%(`n`,block['name']))
+                    outmess('analyzevars: typespec of variable %s is not defined in routine %s.\n'%(repr(n),block['name']))
 
         if 'charselector' in vars[n]:
             if 'len' in vars[n]['charselector']:
@@ -2359,7 +2359,7 @@ def analyzevars(block):
                         if ispure: vars[n]=setattrspec(vars[n],'pure')
                         if isrec: vars[n]=setattrspec(vars[n],'recursive')
                     else:
-                        outmess('analyzevars: prefix (%s) were not used\n'%`block['prefix']`)
+                        outmess('analyzevars: prefix (%s) were not used\n'%repr(block['prefix']))
     if not block['block'] in ['module','pythonmodule','python module','block data']:
         if 'commonvars' in block:
             neededvars=copy.copy(block['args']+block['commonvars'])
@@ -2462,7 +2462,7 @@ def _ensure_exprdict(r):
         return {'typespec':'real'}
     if type(r) is type(0j):
         return {'typespec':'complex'}
-    assert type(r) is type({}),`r`
+    assert type(r) is type({}),repr(r)
     return r
 
 def determineexprtype(expr,vars,rules={}):
@@ -2474,12 +2474,12 @@ def determineexprtype(expr,vars,rules={}):
     m=determineexprtype_re_2.match(expr)
     if m:
         if 'name' in m.groupdict() and m.group('name'):
-            outmess('determineexprtype: selected kind types not supported (%s)\n'%`expr`)
+            outmess('determineexprtype: selected kind types not supported (%s)\n'%repr(expr))
         return {'typespec':'integer'}
     m = determineexprtype_re_3.match(expr)
     if m:
         if 'name' in m.groupdict() and m.group('name'):
-            outmess('determineexprtype: selected kind types not supported (%s)\n'%`expr`)
+            outmess('determineexprtype: selected kind types not supported (%s)\n'%repr(expr))
         return {'typespec':'real'}
     for op in ['+','-','*','/']:
         for e in [x.strip() for x in markoutercomma(expr,comma=op).split('@'+op+'@')]:
@@ -2501,7 +2501,7 @@ def determineexprtype(expr,vars,rules={}):
     if expr[0] in '\'"':
         return {'typespec':'character','charselector':{'*':'*'}}
     if not t:
-        outmess('determineexprtype: could not determine expressions (%s) type.\n'%(`expr`))
+        outmess('determineexprtype: could not determine expressions (%s) type.\n'%(repr(expr)))
     return t
 
 ######
@@ -2796,7 +2796,7 @@ if __name__ == "__main__":
         elif l=='-m':
             f3=1
         elif l[0]=='-':
-            errmess('Unknown option %s\n'%`l`)
+            errmess('Unknown option %s\n'%repr(l))
         elif f2:
             f2=0
             pyffilename=l
@@ -2821,7 +2821,7 @@ if __name__ == "__main__":
 
     postlist=crackfortran(files,funcs)
     if pyffilename:
-        outmess('Writing fortran code to file %s\n'%`pyffilename`,0)
+        outmess('Writing fortran code to file %s\n'%repr(pyffilename),0)
         pyf=crack2fortran(postlist)
         f=open(pyffilename,'w')
         f.write(pyf)

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -225,7 +225,7 @@ def scaninputline(inputline):
         elif l[:15] in '--include-paths':
             f7=1
         elif l[0]=='-':
-            errmess('Unknown option %s\n'%`l`)
+            errmess('Unknown option %s\n'%repr(l))
             sys.exit()
         elif f2: f2=0;signsfile=l
         elif f3: f3=0;modulename=l
@@ -382,7 +382,7 @@ def run_main(comline_list):
         if postlist[i]['block']!='python module':
             if 'python module' not in options:
                 errmess('Tip: If your original code is Fortran source then you must use -m option.\n')
-            raise TypeError('All blocks must be python module blocks but got %s'%(`postlist[i]['block']`))
+            raise TypeError('All blocks must be python module blocks but got %s'%(repr(postlist[i]['block'])))
     auxfuncs.debugoptions=options['debug']
     f90mod_rules.options=options
     auxfuncs.wrapfuncs=options['wrapfuncs']
@@ -485,7 +485,7 @@ def run_compile():
         for s in del_list:
             i = flib_flags.index(s)
             del flib_flags[i]
-        assert len(flib_flags)<=2,`flib_flags`
+        assert len(flib_flags)<=2,repr(flib_flags)
 
     _reg5 = re.compile(r'[-][-](verbose)')
     setup_flags = [_m for _m in sys.argv[1:] if _reg5.match(_m)]
@@ -565,7 +565,7 @@ def run_compile():
             i = get_info(n)
             if not i:
                 outmess('No %s resources found in system'\
-                        ' (try `f2py --help-link`)\n' % (`n`))
+                        ' (try `f2py --help-link`)\n' % (repr(n)))
             dict_append(ext_args,**i)
 
     ext = Extension(**ext_args)

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1243,7 +1243,7 @@ def buildmodule(m,um):
             elif k in cfuncs.commonhooks:
                 c=cfuncs.commonhooks[k]
             else:
-                errmess('buildmodule: unknown need %s.\n'%(`k`));continue
+                errmess('buildmodule: unknown need %s.\n'%(repr(k)));continue
             code[n].append(c)
     mod_rules.append(code)
     for r in mod_rules:
@@ -1355,10 +1355,10 @@ def buildapi(rout):
             if not isintent_hide(var[a]):
                 if not isoptional(var[a]):
                     nth=nth+1
-                    vrd['nth']=`nth`+stnd[nth%10]+' argument'
+                    vrd['nth']=repr(nth)+stnd[nth%10]+' argument'
                 else:
                     nthk=nthk+1
-                    vrd['nth']=`nthk`+stnd[nthk%10]+' keyword'
+                    vrd['nth']=repr(nthk)+stnd[nthk%10]+' keyword'
             else: vrd['nth']='hidden'
         savevrd[a]=vrd
         for r in _rules:

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -179,14 +179,14 @@ class Array(object):
         # arr.dtypechar may be different from typ.dtypechar
         self.arr = wrap.call(typ.type_num,dims,intent.flags,obj)
 
-        assert_(isinstance(self.arr, ndarray),`type(self.arr)`)
+        assert_(isinstance(self.arr, ndarray),repr(type(self.arr)))
 
         self.arr_attr = wrap.array_attrs(self.arr)
 
         if len(dims)>1:
             if self.intent.is_intent('c'):
                 assert_(intent.flags & wrap.F2PY_INTENT_C)
-                assert_(not self.arr.flags['FORTRAN'],`self.arr.flags,getattr(obj,'flags',None)`)
+                assert_(not self.arr.flags['FORTRAN'],repr((self.arr.flags,getattr(obj,'flags',None))))
                 assert_(self.arr.flags['CONTIGUOUS'])
                 assert_(not self.arr_attr[6] & wrap.FORTRAN)
             else:
@@ -201,14 +201,14 @@ class Array(object):
             return
 
         if intent.is_intent('cache'):
-            assert_(isinstance(obj,ndarray),`type(obj)`)
+            assert_(isinstance(obj,ndarray),repr(type(obj)))
             self.pyarr = array(obj).reshape(*dims).copy()
         else:
             self.pyarr = array(array(obj,
                                      dtype = typ.dtypechar).reshape(*dims),
                                order=self.intent.is_intent('c') and 'C' or 'F')
             assert_(self.pyarr.dtype == typ, \
-                   `self.pyarr.dtype,typ`)
+                   repr((self.pyarr.dtype,typ)))
         assert_(self.pyarr.flags['OWNDATA'], (obj, intent))
         self.pyarr_attr = wrap.array_attrs(self.pyarr)
 
@@ -227,18 +227,18 @@ class Array(object):
         assert_(self.arr_attr[2]==self.pyarr_attr[2]) # dimensions
         if self.arr_attr[1]<=1:
             assert_(self.arr_attr[3]==self.pyarr_attr[3],\
-                   `self.arr_attr[3],self.pyarr_attr[3],self.arr.tostring(),self.pyarr.tostring()`) # strides
+                   repr((self.arr_attr[3],self.pyarr_attr[3],self.arr.tostring(),self.pyarr.tostring()))) # strides
         assert_(self.arr_attr[5][-2:]==self.pyarr_attr[5][-2:],\
-               `self.arr_attr[5],self.pyarr_attr[5]`) # descr
+               repr((self.arr_attr[5],self.pyarr_attr[5]))) # descr
         assert_(self.arr_attr[6]==self.pyarr_attr[6],\
-               `self.arr_attr[6],self.pyarr_attr[6],flags2names(0*self.arr_attr[6]-self.pyarr_attr[6]),flags2names(self.arr_attr[6]),intent`) # flags
+               repr((self.arr_attr[6],self.pyarr_attr[6],flags2names(0*self.arr_attr[6]-self.pyarr_attr[6]),flags2names(self.arr_attr[6]),intent))) # flags
 
         if intent.is_intent('cache'):
             assert_(self.arr_attr[5][3]>=self.type.elsize,\
-                   `self.arr_attr[5][3],self.type.elsize`)
+                   repr((self.arr_attr[5][3],self.type.elsize)))
         else:
             assert_(self.arr_attr[5][3]==self.type.elsize,\
-                   `self.arr_attr[5][3],self.type.elsize`)
+                   repr((self.arr_attr[5][3],self.type.elsize)))
         assert_(self.arr_equal(self.pyarr,self.arr))
 
         if isinstance(self.obj,ndarray):
@@ -288,9 +288,9 @@ class _test_shared_memory:
             obj = array(self.num2seq,dtype=t.dtype)
             a = self.array([len(self.num2seq)],intent.in_,obj)
             if t.elsize==self.type.elsize:
-                assert_(a.has_shared_memory(),`self.type.dtype,t.dtype`)
+                assert_(a.has_shared_memory(),repr((self.type.dtype,t.dtype)))
             else:
-                assert_(not a.has_shared_memory(),`t.dtype`)
+                assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_inout_2seq(self):
         obj = array(self.num2seq,dtype=self.type.dtype)
@@ -331,7 +331,7 @@ class _test_shared_memory:
         for t in self.type.cast_types():
             obj = array(self.num2seq,dtype=t.dtype)
             a = self.array([len(self.num2seq)],intent.in_.copy,obj)
-            assert_(not a.has_shared_memory(),`t.dtype`)
+            assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_c_in_from_23seq(self):
         a = self.array([len(self.num23seq),len(self.num23seq[0])],
@@ -343,7 +343,7 @@ class _test_shared_memory:
             obj = array(self.num23seq,dtype=t.dtype)
             a = self.array([len(self.num23seq),len(self.num23seq[0])],
                            intent.in_,obj)
-            assert_(not a.has_shared_memory(),`t.dtype`)
+            assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_f_in_from_23casttype(self):
         for t in self.type.cast_types():
@@ -351,9 +351,9 @@ class _test_shared_memory:
             a = self.array([len(self.num23seq),len(self.num23seq[0])],
                            intent.in_,obj)
             if t.elsize==self.type.elsize:
-                assert_(a.has_shared_memory(),`t.dtype`)
+                assert_(a.has_shared_memory(),repr(t.dtype))
             else:
-                assert_(not a.has_shared_memory(),`t.dtype`)
+                assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_c_in_from_23casttype(self):
         for t in self.type.cast_types():
@@ -361,23 +361,23 @@ class _test_shared_memory:
             a = self.array([len(self.num23seq),len(self.num23seq[0])],
                            intent.in_.c,obj)
             if t.elsize==self.type.elsize:
-                assert_(a.has_shared_memory(),`t.dtype`)
+                assert_(a.has_shared_memory(),repr(t.dtype))
             else:
-                assert_(not a.has_shared_memory(),`t.dtype`)
+                assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_f_copy_in_from_23casttype(self):
         for t in self.type.cast_types():
             obj = array(self.num23seq,dtype=t.dtype,order='F')
             a = self.array([len(self.num23seq),len(self.num23seq[0])],
                            intent.in_.copy,obj)
-            assert_(not a.has_shared_memory(),`t.dtype`)
+            assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_c_copy_in_from_23casttype(self):
         for t in self.type.cast_types():
             obj = array(self.num23seq,dtype=t.dtype)
             a = self.array([len(self.num23seq),len(self.num23seq[0])],
                            intent.in_.c.copy,obj)
-            assert_(not a.has_shared_memory(),`t.dtype`)
+            assert_(not a.has_shared_memory(),repr(t.dtype))
 
     def test_in_cache_from_2casttype(self):
         for t in self.type.all_types():
@@ -386,17 +386,17 @@ class _test_shared_memory:
             obj = array(self.num2seq,dtype=t.dtype)
             shape = (len(self.num2seq),)
             a = self.array(shape,intent.in_.c.cache,obj)
-            assert_(a.has_shared_memory(),`t.dtype`)
+            assert_(a.has_shared_memory(),repr(t.dtype))
 
             a = self.array(shape,intent.in_.cache,obj)
-            assert_(a.has_shared_memory(),`t.dtype`)
+            assert_(a.has_shared_memory(),repr(t.dtype))
 
             obj = array(self.num2seq,dtype=t.dtype,order='F')
             a = self.array(shape,intent.in_.c.cache,obj)
-            assert_(a.has_shared_memory(),`t.dtype`)
+            assert_(a.has_shared_memory(),repr(t.dtype))
 
             a = self.array(shape,intent.in_.cache,obj)
-            assert_(a.has_shared_memory(),`t.dtype`)
+            assert_(a.has_shared_memory(),repr(t.dtype))
 
             try:
                 a = self.array(shape,intent.in_.cache,obj[::-1])
@@ -505,9 +505,9 @@ class _test_shared_memory:
         assert_(not obj.flags['FORTRAN'] and obj.flags['CONTIGUOUS'])
         shape = obj.shape
         a = self.array(shape,intent.inplace,obj)
-        assert_(obj[1][2]==a.arr[1][2],`obj,a.arr`)
+        assert_(obj[1][2]==a.arr[1][2],repr((obj,a.arr)))
         a.arr[1][2]=54
-        assert_(obj[1][2]==a.arr[1][2]==array(54,dtype=self.type.dtype),`obj,a.arr`)
+        assert_(obj[1][2]==a.arr[1][2]==array(54,dtype=self.type.dtype),repr((obj,a.arr)))
         assert_(a.arr is obj)
         assert_(obj.flags['FORTRAN']) # obj attributes are changed inplace!
         assert_(not obj.flags['CONTIGUOUS'])
@@ -522,9 +522,9 @@ class _test_shared_memory:
             assert_(not obj.flags['FORTRAN'] and obj.flags['CONTIGUOUS'])
             shape = obj.shape
             a = self.array(shape,intent.inplace,obj)
-            assert_(obj[1][2]==a.arr[1][2],`obj,a.arr`)
+            assert_(obj[1][2]==a.arr[1][2],repr((obj,a.arr)))
             a.arr[1][2]=54
-            assert_(obj[1][2]==a.arr[1][2]==array(54,dtype=self.type.dtype),`obj,a.arr`)
+            assert_(obj[1][2]==a.arr[1][2]==array(54,dtype=self.type.dtype),repr((obj,a.arr)))
             assert_(a.arr is obj)
             assert_(obj.flags['FORTRAN']) # obj attributes are changed inplace!
             assert_(not obj.flags['CONTIGUOUS'])

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -21,16 +21,16 @@ class TestAssumedShapeSumExample(util.F2PyTest):
     @dec.slow
     def test_all(self):
         r = self.module.fsum([1,2])
-        assert_(r==3,`r`)
+        assert_(r==3,repr(r))
         r = self.module.sum([1,2])
-        assert_(r==3,`r`)
+        assert_(r==3,repr(r))
         r = self.module.sum_with_use([1,2])
-        assert_(r==3,`r`)
+        assert_(r==3,repr(r))
 
         r = self.module.mod.sum([1,2])
-        assert_(r==3,`r`)
+        assert_(r==3,repr(r))
         r = self.module.mod.fsum([1,2])
-        assert_(r==3,`r`)
+        assert_(r==3,repr(r))
 
 if __name__ == "__main__":
     import nose

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -74,24 +74,24 @@ cf2py  intent(out) a
     def check_function(self, name):
         t = getattr(self.module, name)
         r = t(lambda : 4)
-        assert_( r==4,`r`)
+        assert_( r==4,repr(r))
         r = t(lambda a:5,fun_extra_args=(6,))
-        assert_( r==5,`r`)
+        assert_( r==5,repr(r))
         r = t(lambda a:a,fun_extra_args=(6,))
-        assert_( r==6,`r`)
+        assert_( r==6,repr(r))
         r = t(lambda a:5+a,fun_extra_args=(7,))
-        assert_( r==12,`r`)
+        assert_( r==12,repr(r))
         r = t(lambda a:math.degrees(a),fun_extra_args=(math.pi,))
-        assert_( r==180,`r`)
+        assert_( r==180,repr(r))
         r = t(math.degrees,fun_extra_args=(math.pi,))
-        assert_( r==180,`r`)
+        assert_( r==180,repr(r))
 
         r = t(self.module.func, fun_extra_args=(6,))
-        assert_( r==17,`r`)
+        assert_( r==17,repr(r))
         r = t(self.module.func0)
-        assert_( r==11,`r`)
+        assert_( r==11,repr(r))
         r = t(self.module.func0._cpointer)
-        assert_( r==11,`r`)
+        assert_( r==11,repr(r))
         class A(object):
             def __call__(self):
                 return 7
@@ -99,9 +99,9 @@ cf2py  intent(out) a
                 return 9
         a = A()
         r = t(a)
-        assert_( r==7,`r`)
+        assert_( r==7,repr(r))
         r = t(a.mth)
-        assert_( r==9,`r`)
+        assert_( r==9,repr(r))
 
 if __name__ == "__main__":
     import nose

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -10,17 +10,17 @@ class TestReturnCharacter(util.F2PyTest):
         tname = t.__doc__.split()[0]
         if tname in ['t0','t1','s0','s1']:
             assert_( t(23)==asbytes('2'))
-            r = t('ab');assert_( r==asbytes('a'),`r`)
-            r = t(array('ab'));assert_( r==asbytes('a'),`r`)
-            r = t(array(77,'u1'));assert_( r==asbytes('M'),`r`)
+            r = t('ab');assert_( r==asbytes('a'),repr(r))
+            r = t(array('ab'));assert_( r==asbytes('a'),repr(r))
+            r = t(array(77,'u1'));assert_( r==asbytes('M'),repr(r))
             #assert_(_raises(ValueError, t, array([77,87])))
             #assert_(_raises(ValueError, t, array(77)))
         elif tname in ['ts','ss']:
-            assert_( t(23)==asbytes('23        '),`t(23)`)
+            assert_( t(23)==asbytes('23        '),repr(t(23)))
             assert_( t('123456789abcdef')==asbytes('123456789a'))
         elif tname in ['t5','s5']:
-            assert_( t(23)==asbytes('23   '),`t(23)`)
-            assert_( t('ab')==asbytes('ab   '),`t('ab')`)
+            assert_( t(23)==asbytes('23   '),repr(t(23)))
+            assert_( t('ab')==asbytes('ab   '),repr(t('ab')))
             assert_( t('123456789abcdef')==asbytes('12345'))
         else:
             raise NotImplementedError

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -45,7 +45,7 @@ class TestReturnComplex(util.F2PyTest):
 
         try:
             r = t(10l**400)
-            assert_( `r` in ['(inf+0j)','(Infinity+0j)'],`r`)
+            assert_( repr(r) in ['(inf+0j)','(Infinity+0j)'],repr(r))
         except OverflowError:
             pass
 

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -6,7 +6,7 @@ import util
 
 class TestReturnInteger(util.F2PyTest):
     def check_function(self, t):
-        assert_( t(123)==123,`t(123)`)
+        assert_( t(123)==123,repr(t(123)))
         assert_( t(123.6)==123)
         assert_( t(123l)==123)
         assert_( t('123')==123)

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -6,8 +6,8 @@ import util
 
 class TestReturnLogical(util.F2PyTest):
     def check_function(self, t):
-        assert_( t(True)==1,`t(True)`)
-        assert_( t(False)==0,`t(False)`)
+        assert_( t(True)==1,repr(t(True)))
+        assert_( t(False)==0,repr(t(False)))
         assert_( t(0)==0)
         assert_( t(None)==0)
         assert_( t(0.0)==0)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -43,7 +43,7 @@ class TestReturnReal(util.F2PyTest):
 
         try:
             r = t(10l**400)
-            assert_( `r` in ['inf','Infinity'],`r`)
+            assert_( repr(r) in ['inf','Infinity'],repr(r))
         except OverflowError:
             pass
 

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -18,29 +18,29 @@ class TestSizeSumExample(util.F2PyTest):
     @dec.slow
     def test_all(self):
         r = self.module.foo([[1,2]])
-        assert_equal(r, [3],`r`)
+        assert_equal(r, [3],repr(r))
 
         r = self.module.foo([[1,2],[3,4]])
-        assert_equal(r, [3,7],`r`)
+        assert_equal(r, [3,7],repr(r))
 
         r = self.module.foo([[1,2],[3,4],[5,6]])
-        assert_equal(r, [3,7,11],`r`)
+        assert_equal(r, [3,7,11],repr(r))
 
     @dec.slow
     def test_transpose(self):
         r = self.module.trans([[1,2]])
-        assert_equal(r, [[1],[2]],`r`)
+        assert_equal(r, [[1],[2]],repr(r))
 
         r = self.module.trans([[1,2,3],[4,5,6]])
-        assert_equal(r, [[1,4],[2,5],[3,6]],`r`)
+        assert_equal(r, [[1,4],[2,5],[3,6]],repr(r))
 
     @dec.slow
     def test_flatten(self):
         r = self.module.flatten([[1,2]])
-        assert_equal(r, [1,2],`r`)
+        assert_equal(r, [1,2],repr(r))
 
         r = self.module.flatten([[1,2,3],[4,5,6]])
-        assert_equal(r, [1,2,3,4,5,6],`r`)
+        assert_equal(r, [1,2,3,4,5,6],repr(r))
 
 if __name__ == "__main__":
     import nose

--- a/numpy/f2py/use_rules.py
+++ b/numpy/f2py/use_rules.py
@@ -99,7 +99,7 @@ def buildusevar(name,realname,vars,usemodulename):
     nummap={0:'Ro',1:'Ri',2:'Rii',3:'Riii',4:'Riv',5:'Rv',6:'Rvi',7:'Rvii',8:'Rviii',9:'Rix'}
     vrd['texnamename']=name
     for i in nummap.keys():
-        vrd['texnamename']=vrd['texnamename'].replace(`i`,nummap[i])
+        vrd['texnamename']=vrd['texnamename'].replace(repr(i),nummap[i])
     if hasnote(vars[realname]): vrd['note']=vars[realname]['note']
     rd=dictappend({},vrd)
     var=vars[realname]

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -55,7 +55,7 @@ def _getformats(data):
         obj = np.asarray(obj)
         formats += _typestr[obj.dtype.type]
         if issubclass(obj.dtype.type, ntypes.flexible):
-            formats += `obj.itemsize`
+            formats += repr(obj.itemsize)
         formats += ','
     return formats[:-1]
 
@@ -74,7 +74,7 @@ If the argument `names` is not None, updates the field names to valid names.
         elif isinstance(names, str):
             new_names = names.split(',')
         else:
-            raise NameError("illegal input names %s" % `names`)
+            raise NameError("illegal input names %s" % repr(names))
         nnames = len(new_names)
         if nnames < ndescr:
             new_names += default_names[nnames:]

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -919,9 +919,9 @@ def assert_string_equal(actual, desired):
     import difflib
 
     if not isinstance(actual, str) :
-        raise AssertionError(`type(actual)`)
+        raise AssertionError(repr(type(actual)))
     if not isinstance(desired, str):
-        raise AssertionError(`type(desired)`)
+        raise AssertionError(repr(type(desired)))
     if re.match(r'\A'+desired+r'\Z', actual, re.M): return
     diff = list(difflib.Differ().compare(actual.splitlines(1), desired.splitlines(1)))
     diff_list = []
@@ -936,7 +936,7 @@ def assert_string_equal(actual, desired):
                 l.append(d2)
                 d2 = diff.pop(0)
             if not d2.startswith('+ ') :
-                raise AssertionError(`d2`)
+                raise AssertionError(repr(d2))
             l.append(d2)
             d3 = diff.pop(0)
             if d3.startswith('? '):
@@ -947,7 +947,7 @@ def assert_string_equal(actual, desired):
                 continue
             diff_list.extend(l)
             continue
-        raise AssertionError(`d1`)
+        raise AssertionError(repr(d1))
     if not diff_list:
         return
     msg = 'Differences in strings:\n%s' % (''.join(diff_list)).rstrip()

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -73,6 +73,7 @@ FIXES_TO_SKIP = [
     'imports2',
     'print',
     'dict',
+    'repr',
 ]
 
 skip_fixes= []


### PR DESCRIPTION
This replaces python backtics with repr(...). The backtics were mostly
used to generate strings for printing with a string format and it is
tempting to replace `'%s' % repr(x)` with `'%r' % x`. That would work
except where `x` happened to be a tuple or a dictionary but, because it
would be significant work to guarantee that and because there are not
many places where backtics are used, the safe path is to let the repr
replacements stand.

Closes #3083.
