### PR TITLE
DOC: point to the github issues page

### DIFF
--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -36,7 +36,9 @@ Our main means of communication are:
 
 - `Mailing lists <http://scipy.org/Mailing_Lists>`__
 
-- `Numpy Trac <http://projects.scipy.org/numpy>`__ (bug "tickets" go here)
+- `Numpy Issues <https://github.com/numpy/numpy/issues>`__ (bug reports go here)
+
+- `Old Numpy Trac <http://projects.scipy.org/numpy>`__ (deprecated)
 
 More information about the development of Numpy can be found at
 http://scipy.org/Developer_Zone

--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -38,7 +38,7 @@ Our main means of communication are:
 
 - `Numpy Issues <https://github.com/numpy/numpy/issues>`__ (bug reports go here)
 
-- `Old Numpy Trac <http://projects.scipy.org/numpy>`__ (deprecated)
+- `Old Numpy Trac <http://projects.scipy.org/numpy>`__ (no longer used)
 
 More information about the development of Numpy can be found at
 http://scipy.org/Developer_Zone

--- a/doc/source/bugs.rst
+++ b/doc/source/bugs.rst
@@ -3,21 +3,17 @@ Reporting bugs
 **************
 
 File bug reports or feature requests, and make contributions
-(e.g. code patches), by submitting a "ticket" on the Trac pages:
+(e.g. code patches), by submitting a "ticket" on GitHub:
 
-- Numpy Trac: http://scipy.org/scipy/numpy
+- Numpy Issues: http://github.com/numpy/numpy/issues
 
-Because of spam abuse, you must create an account on our Trac in order
-to submit a ticket, then click on the "New Ticket" tab that only
-appears when you have logged in. Please give as much information as
-you can in the ticket. It is extremely useful if you can supply a
-small self-contained code snippet that reproduces the problem. Also
-specify the component, the version you are referring to and the
-milestone.
+Please give as much information as you can in the ticket. It is extremely
+useful if you can supply a small self-contained code snippet that reproduces
+the problem. Also specify the component, the version you are referring to and
+the milestone.
 
-Report bugs to the appropriate Trac instance (there is one for NumPy
-and a different one for SciPy). There are also read-only mailing lists
-for tracking the status of your bug ticket.
+Report bugs to the appropriate GitHub project (there is one for NumPy
+and a different one for SciPy).
 
 More information can be found on the http://scipy.org/Developer_Zone
 website.

--- a/doc/source/bugs.rst
+++ b/doc/source/bugs.rst
@@ -3,7 +3,7 @@ Reporting bugs
 **************
 
 File bug reports or feature requests, and make contributions
-(e.g. code patches), by submitting a "ticket" on GitHub:
+(e.g. code patches), by opening a "new issue" on GitHub:
 
 - Numpy Issues: http://github.com/numpy/numpy/issues
 


### PR DESCRIPTION
following up on numpy/numpy.org#1, I've updated the docs to point to the new place to file bugs (github issues).

The only thing I'm uncertain about is if it's appropriate to refer to the old Trac instance as being "deprecated". 
