### PR TITLE
DOC: Document NPY_RELAXED_STRIDES_CHECKING changes

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -42,6 +42,39 @@ case, now indicates a 0-D iteration and ``op_axes`` being NULL and the old
 usage is deprecated. This does not effect the ``NpyIter_New`` or
 ``NpyIter_MultiNew`` functions.
 
+NPY_RELAXED_STRIDES_CHECKING
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+There is a new compile time environment variable
+``NPY_RELAXED_STRIDES_CHECKING``. If this variable is set to 1, then
+numpy will consider more arrays to be C- or F-contiguous -- for
+example, it becomes possible to have a column vector which is
+considered both C- and F-contiguous simultaneously. The new definition
+is more accurate, allows for faster code that makes fewer unnecessary
+copies, and simplifies numpy's code internally. However, it may also
+break third-party libraries that make too-strong assumptions about the
+stride values of C- and F-contiguous arrays. (It is also currently
+known that this breaks Cython code using memoryviews, which will be
+fixed in Cython.) THIS WILL BECOME THE DEFAULT IN A FUTURE RELEASE, SO
+PLEASE TEST YOUR CODE NOW AGAINST NUMPY BUILT WITH::
+
+  NPY_RELAXED_STRIDES_CHECKING=1 python setup.py install
+
+You can check whether NPY_RELAXED_STRIDES_CHECKING is in effect by
+running::
+
+  np.ones((10, 1), order="C").flags.f_contiguous
+
+This will be ``True`` if relaxed strides checking is enabled, and
+``False`` otherwise. The typical problem we've seen so far is C code
+that works with C-contiguous arrays, and assumes that the itemsize can
+be accessed by looking at the last element in the ``PyArray_STRIDES(arr)``
+array. When relaxed strides are in effect, this is not true (and in
+fact, it never was true in some corner cases). Instead, use
+``PyArray_ITEMSIZE(arr)``.
+
+For more information check the "Internal memory layout of an ndarray"
+section in the documentation.
+
 
 New Features
 ============

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1310,11 +1310,21 @@ of the constant names is deprecated in 1.7.
     The data area is in Fortran-style contiguous order (first index varies
     the fastest).
 
-Notice that contiguous 1-d arrays are always both Fortran contiguous
-and C contiguous. Both of these flags can be checked and are convenience
-flags only as whether or not an array is :cdata:`NPY_ARRAY_C_CONTIGUOUS`
-or :cdata:`NPY_ARRAY_F_CONTIGUOUS` can be determined by the ``strides``,
-``dimensions``, and ``itemsize`` attributes.
+.. note::
+
+    Arrays can be both C-style and Fortran-style contiguous simultaneously. 
+    This is clear for 1-dimensional arrays, but can also be true for higher
+    dimensional arrays.
+
+    Even for contiguous arrays a stride for a given dimension
+    ``arr.strides[dim]`` may be *arbitrary* if ``arr.shape[dim] == 1``
+    or the array has no elements.
+    It does *not* generally hold that ``self.strides[-1] == self.itemsize``
+    for C-style contiguous arrays or ``self.strides[0] == self.itemsize`` for
+    Fortran-style contiguous arrays is true. The correct way to access the
+    ``itemsize`` of an array from the C API is ``PyArray_ITEMSIZE(arr)``.
+
+    .. seealso:: :ref:`Internal memory layout of an ndarray <arrays.ndarray>`
 
 .. cvar:: NPY_ARRAY_OWNDATA
 
@@ -1322,7 +1332,7 @@ or :cdata:`NPY_ARRAY_F_CONTIGUOUS` can be determined by the ``strides``,
 
 .. cvar:: NPY_ARRAY_ALIGNED
 
-    The data area is aligned appropriately (for all strides).
+    The data area and all array elements are aligned appropriately.
 
 .. cvar:: NPY_ARRAY_WRITEABLE
 
@@ -1432,13 +1442,19 @@ For all of these macros *arr* must be an instance of a (subclass of)
     :cdata:`NPY_ARRAY_OWNDATA`, :cdata:`NPY_ARRAY_ALIGNED`,
     :cdata:`NPY_ARRAY_WRITEABLE`, :cdata:`NPY_ARRAY_UPDATEIFCOPY`.
 
-.. cfunction:: PyArray_ISCONTIGUOUS(arr)
+.. cfunction:: PyArray_IS_C_CONTIGUOUS(arr)
 
     Evaluates true if *arr* is C-style contiguous.
 
-.. cfunction:: PyArray_ISFORTRAN(arr)
+.. cfunction:: PyArray_IS_F_CONTIGUOUS(arr)
 
     Evaluates true if *arr* is Fortran-style contiguous.
+
+.. cfunction:: PyArray_ISFORTRAN(arr)
+
+    Evaluates true if *arr* is Fortran-style contiguous and *not*
+    C-style contiguous. :cfunc:`PyArray_IS_F_CONTIGUOUS`
+    is the correct way to test for Fortran-style contiguity.
 
 .. cfunction:: PyArray_ISWRITEABLE(arr)
 

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -321,9 +321,9 @@ advanced usage and will not typically be used.
 
     Specifies the calculation iteration order/memory layout of the output array.
     Defaults to 'K'. 'C' means the output should be C-contiguous, 'F' means
-    F-contiguous, 'A' means F-contiguous if the inputs are F-contiguous, C-contiguous
-    otherwise, and 'K' means to match the element ordering of the inputs
-    as closely as possible.
+    F-contiguous, 'A' means F-contiguous if the inputs are F-contiguous and
+    not also not C-contiguous, C-contiguous otherwise, and 'K' means to match
+    the element ordering of the inputs as closely as possible.
 
 *dtype*
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2614,12 +2614,11 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('flags',
         created writeable view onto it.)  Attempting to change a non-writeable
         array raises a RuntimeError exception.
     ALIGNED (A)
-        The data and strides are aligned appropriately for the hardware.
+        The data and all elements are aligned appropriately for the hardware.
     UPDATEIFCOPY (U)
         This array is a copy of some other array. When this array is
         deallocated, the base array will be updated with the contents of
         this array.
-
     FNC
         F_CONTIGUOUS and not C_CONTIGUOUS.
     FORC
@@ -2649,6 +2648,16 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('flags',
       or the ultimate owner of the memory exposes a writeable buffer
       interface or is a string.
 
+    Arrays can be both C-style and Fortran-style contiguous simultaneously. 
+    This is clear for 1-dimensional arrays, but can also be true for higher
+    dimensional arrays.
+
+    Even for contiguous arrays a stride for a given dimension
+    ``arr.strides[dim]`` may be *arbitrary* if ``arr.shape[dim] == 1``
+    or the array has no elements.
+    It does *not* generally hold that ``self.strides[-1] == self.itemsize``
+    for C-style contiguous arrays or ``self.strides[0] == self.itemsize`` for
+    Fortran-style contiguous arrays is true.
     """))
 
 


### PR DESCRIPTION
This includes documentation in the release notes, as well as the
reference guide and smaller corrections.
## 

First try at documenting NPY_RELAXED_STRIDES_CHECKING and related things. I only added info to the general memory layout section and the C-flags as of yet, if there is any section I missed completely please note.
