### PR TITLE
2to3: Skip `future` fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -55,7 +55,7 @@ FIXES_TO_SKIP = [
     'exitfunc',
     'filter',
 #    'funcattrs',
-#    'future',
+    'future',
     'getcwdu',
     'has_key',
 #    'idioms',


### PR DESCRIPTION
The `future` fixer removes the `from __future__ import ...` statements.
That is fine for Python 3, but we need to keep that statement if we are
shooting for a common code base for both Python 2 and Python 3.
