### PR TITLE
Make np.savetxt(filename, zip(...)) work in Python 3.x

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -997,6 +997,12 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
     else:
         raise ValueError('fname must be a string or file handle')
 
+    # In Python 2.x, it was possible to do np.savetxt(filename, zip(a,b,c)) -
+    # but in Python 3.x, we need to first convert the zip iterator to a list
+    # of tuples for asarray to work.
+    if sys.version_info[0] >= 3 and isinstance(X, zip):
+        X = list(X)
+
     try:
         X = np.asarray(X)
 


### PR DESCRIPTION
In Python 3, the behavior of `zip` changed - it now returns an iterator instead of a list. Therefore, things like

```
np.savetxt(filename, zip(...))
```

and 

```
np.array(zip([1,2,3],[4,5,6]), dtype=[('a', int), ('b', int)])
```

don't work anymore unless one wraps `list()` around `zip()`. This minor PR ensures that `savetxt` does work with the new `zip()` function, though I'm not sure how to fix the second case since that seems to be handled at the C-level, but I think that if the second could somehow be fixed, this would fix the first, because `savetxt` calls `asarray`, which calls `array`.
