### PR TITLE
2to3: Skip buffer fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -47,7 +47,7 @@ EXTRA_2TO3_FLAGS = {
 FIXES_TO_SKIP = [
     'apply',
 #    'basestring',
-#    'buffer',
+    'buffer',
     'callable',
     'dict',
     'exec',


### PR DESCRIPTION
The buffer object is replaced by memoryview in Python >= 3. The memoryview object has also been backported to Python 2.7. However, the only use of buffer / memoryview is in `numpy/core/tests/test_unicode.py`
and there it is already version dependent: memoryview is used if the
Python version is >= 3 and buffer is used otherwise.

Closes #3043.
