### PR TITLE
2to3: Skip `funcattrs` fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -54,7 +54,7 @@ FIXES_TO_SKIP = [
     'execfile',
     'exitfunc',
     'filter',
-#    'funcattrs',
+    'funcattrs',
     'future',
     'getcwdu',
     'has_key',


### PR DESCRIPTION
In Python 3 the func.func_name attribute is replaced by the
func.**name** attribute. The only file affected by this is
doc/sphinxext/numpydoc/phantom_import.py, and there its use
is already version dependent.

Closes #3054.
