### PR TITLE
Fix for issue 3192

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2606,7 +2606,7 @@ def true_intent_list(var):
     ret = []
     for intent in lst:
         try:
-            exec('c = isintent_%s(var)' % intent)
+            c = eval('isintent_%s(var)' % intent)
         except NameError:
             c = 0
         if c:


### PR DESCRIPTION
replace exec by eval to ensure the c variable is defined for all relevant python versions
