### PR TITLE
2to3: Skip `setliteral` fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -83,7 +83,7 @@ FIXES_TO_SKIP = [
     'reduce',
 #    'renames',
     'repr',
-#    'setliteral',
+    'setliteral',
     'standarderror',
     'sys_exc',
     'throw',


### PR DESCRIPTION
Setliterals are not available in Python 2.6. Because the current usage
in numpy is forward compatible with Python 3 there is no need to run the
fixer.

When Python 2.6 support is dropped the fixer can be run, but that looks
to be several years off. RHEL 6 with Python 2.6 was released in 2010 and
will run for ten years.
