### PR TITLE
2to3: Skip itertools_imports fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -66,7 +66,7 @@ FIXES_TO_SKIP = [
     'intern',
 #    'isinstance',
 #    'itertools',
-#    'itertools_imports',
+    'itertools_imports',
 #    'long',
     'map',
     'metaclass',


### PR DESCRIPTION
No files are changed by the itertools_imports fixer so skip it.  What
the fixer does is rename imports of imap, ifilter, and izip to map,
filter, and zip since the latter are iterators in Python 3.

Closes #3234
