### PR TITLE
2to3: Apply basestring fixer.

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -6,14 +6,16 @@ from __future__ import division, absolute_import, print_function
 
 __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
-           'asstr', 'open_latin1', 'long']
+           'asstr', 'open_latin1', 'long', 'basestring']
 
 import sys
 
 if sys.version_info[0] >= 3:
     import io
+
     long = int
     integer_types = (int,)
+    basestring = str
     bytes = bytes
     unicode = str
 
@@ -45,6 +47,7 @@ else:
     bytes = str
     unicode = unicode
     long = long
+    basestring = basestring
     integer_types = (int, long)
     asbytes = str
     asstr = str

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -7,7 +7,7 @@ import sys
 
 import numpy as np
 from .numeric import uint8, ndarray, dtype
-from numpy.compat import long
+from numpy.compat import long, basestring
 
 dtypedescr = dtype
 valid_filemodes = ["r", "c", "r+", "w+"]

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2,15 +2,16 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import warnings
+import collections
 from . import multiarray
 from . import umath
 from .umath import *
 from . import numerictypes
 from .numerictypes import *
-import collections
 
 if sys.version_info[0] >= 3:
     import pickle
+    basestring = str
 else:
     import cPickle as pickle
 

--- a/numpy/distutils/extension.py
+++ b/numpy/distutils/extension.py
@@ -8,11 +8,14 @@ Overridden to support f2py.
 """
 from __future__ import division, absolute_import, print_function
 
-__revision__ = "$Id: extension.py,v 1.1 2005/04/09 19:29:34 pearu Exp $"
-
+import sys
+import re
 from distutils.extension import Extension as old_Extension
 
-import re
+if sys.version_info[0] >= 3:
+    basestring = str
+
+
 cxx_ext_re = re.compile(r'.*[.](cpp|cxx|cc)\Z',re.I).match
 fortran_pyf_ext_re = re.compile(r'.*[.](f90|f95|f77|for|ftn|f|pyf)\Z',re.I).match
 

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -8,13 +8,13 @@ __docformat__ = "restructuredtext en"
 import sys
 import numpy as np
 import numpy.core.numeric as nx
+from numpy.compat import asbytes, bytes, asbytes_nested, long, basestring
 
 if sys.version_info[0] >= 3:
     from builtins import bool, int, float, complex, object, unicode, str
 else:
     from __builtin__ import bool, int, float, complex, object, unicode, str
 
-from numpy.compat import asbytes, bytes, asbytes_nested, long
 
 if sys.version_info[0] >= 3:
     def _bytes_to_complex(s):

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -139,7 +139,7 @@ from __future__ import division, absolute_import, print_function
 import numpy
 import sys
 from numpy.lib.utils import safe_eval
-from numpy.compat import asbytes, isfileobj, long
+from numpy.compat import asbytes, isfileobj, long, basestring
 
 if sys.version_info[0] >= 3:
     import pickle

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -19,7 +19,7 @@ from ._iotools import LineSplitter, NameValidator, StringConverter, \
                      _is_string_like, has_nested_fields, flatten_dtype, \
                      easy_dtype, _bytes_to_name
 
-from numpy.compat import asbytes, asstr, asbytes_nested, bytes
+from numpy.compat import asbytes, asstr, asbytes_nested, bytes, basestring
 from io import BytesIO
 
 if sys.version_info[0] >= 3:

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -15,6 +15,7 @@ from numpy import ndarray, recarray
 from numpy.ma import MaskedArray
 from numpy.ma.mrecords import MaskedRecords
 from numpy.lib._iotools import _is_string_like
+from numpy.compat import basestring
 
 if sys.version_info[0] >= 3:
     izip = zip

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -32,7 +32,7 @@ import numpy.core.numerictypes as ntypes
 from numpy import ndarray, amax, amin, iscomplexobj, bool_
 from numpy import array as narray
 from numpy.lib.function_base import angle
-from numpy.compat import getargspec, formatargspec, long
+from numpy.compat import getargspec, formatargspec, long, basestring
 from numpy import expand_dims as n_expand_dims
 
 if sys.version_info[0] >= 3:

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -20,13 +20,17 @@ from __future__ import division, absolute_import, print_function
 __author__ = "Pierre GF Gerard-Marchant"
 
 import sys
+import warnings
 
 import numpy as np
-from numpy import bool_, dtype, \
-    ndarray, recarray, array as narray
 import numpy.core.numerictypes as ntypes
-from numpy.core.records import fromarrays as recfromarrays, \
-                               fromrecords as recfromrecords
+from numpy.compat import basestring
+from numpy import (
+        bool_, dtype, ndarray, recarray, array as narray
+        )
+from numpy.core.records import (
+        fromarrays as recfromarrays, fromrecords as recfromrecords
+        )
 
 _byteorderconv = np.core.records._byteorderconv
 _typestr = ntypes._typestr
@@ -37,7 +41,6 @@ from numpy.ma import MAError, MaskedArray, masked, nomask, masked_array, \
 
 _check_fill_value = ma.core._check_fill_value
 
-import warnings
 
 __all__ = ['MaskedRecords', 'mrecarray',
            'fromarrays', 'fromrecords', 'fromtextfile', 'addfield',

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -10,6 +10,7 @@ import os
 import sys
 import warnings
 import numpy.testing.utils
+from numpy.compat import basestring
 
 def get_package_name(filepath):
     """

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -46,7 +46,7 @@ EXTRA_2TO3_FLAGS = {
 # available fixers, with fixers not currently skipped commented out.
 FIXES_TO_SKIP = [
     'apply',
-#    'basestring',
+    'basestring',
     'buffer',
     'callable',
     'dict',


### PR DESCRIPTION
The basestring class is not defined in Python 3 and the fixer replaces
it with str. In order to have a common code base we define basestring in
numpy/compat/py3k.py to be str when the Python version is >= 3,
otherwise basestring and import it where needed.  That works for most
cases, but there are a few files where the version dependent define
needs to be in the file.

Closes #3042.
