### PR TITLE
2to3: Apply renames fixer.

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -22,6 +22,12 @@ from .umath import maximum, minimum, absolute, not_equal, isnan, isinf
 from .multiarray import format_longfloat, datetime_as_string, datetime_data
 from .fromnumeric import ravel
 
+if sys.version_info[0] >= 3:
+    _MAXINT = sys.maxsize
+    _MININT = -sys.maxsize - 1
+else:
+    _MAXINT = sys.maxint
+    _MININT = -sys.maxint - 1
 
 def product(x, y): return x*y
 
@@ -633,8 +639,6 @@ def _digits(x, precision, format):
     return precision - len(s) + len(z)
 
 
-_MAXINT = sys.maxint
-_MININT = -sys.maxint-1
 class IntegerFormat(object):
     def __init__(self, data):
         try:

--- a/numpy/oldnumeric/ma.py
+++ b/numpy/oldnumeric/ma.py
@@ -11,7 +11,10 @@ Adapted for numpy_core 2005 by Travis Oliphant and
 """
 from __future__ import division, absolute_import, print_function
 
-import types, sys
+import sys
+import types
+import warnings
+from functools import reduce
 
 import numpy.core.umath as umath
 import numpy.core.fromnumeric as fromnumeric
@@ -19,8 +22,13 @@ from numpy.core.numeric import newaxis, ndarray, inf
 from numpy.core.fromnumeric import amax, amin
 from numpy.core.numerictypes import bool_, typecodes
 import numpy.core.numeric as numeric
-import warnings
-from functools import reduce
+
+if sys.version_info[0] >= 3:
+    _MAXINT = sys.maxsize
+    _MININT = -sys.maxsize - 1
+else:
+    _MAXINT = sys.maxint
+    _MININT = -sys.maxint - 1
 
 
 # Ufunc domain lookup for __array_wrap__
@@ -114,15 +122,15 @@ def minimum_fill_value (obj):
     if isinstance(obj, types.FloatType):
         return numeric.inf
     elif isinstance(obj, types.IntType) or isinstance(obj, types.LongType):
-        return sys.maxint
+        return _MAXINT
     elif isinstance(obj, MaskedArray) or isinstance(obj, ndarray):
         x = obj.dtype.char
         if x in typecodes['Float']:
             return numeric.inf
         if x in typecodes['Integer']:
-            return sys.maxint
+            return _MAXINT
         if x in typecodes['UnsignedInteger']:
-            return sys.maxint
+            return _MAXINT
     else:
         raise TypeError('Unsuitable type for calculating minimum.')
 
@@ -131,13 +139,13 @@ def maximum_fill_value (obj):
     if isinstance(obj, types.FloatType):
         return -inf
     elif isinstance(obj, types.IntType) or isinstance(obj, types.LongType):
-        return -sys.maxint
+        return -_MAXINT
     elif isinstance(obj, MaskedArray) or isinstance(obj, ndarray):
         x = obj.dtype.char
         if x in typecodes['Float']:
             return -inf
         if x in typecodes['Integer']:
-            return -sys.maxint
+            return -_MAXINT
         if x in typecodes['UnsignedInteger']:
             return 0
     else:

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -81,7 +81,7 @@ FIXES_TO_SKIP = [
     'raise',
     'raw_input',
     'reduce',
-#    'renames',
+    'renames',
     'repr',
     'setliteral',
     'standarderror',


### PR DESCRIPTION
Rename sys.maxint to sys.maxsize when the Python version is >= 3.  This
change was made in Python 3 because all integers are 'long' integers and
their maximum value bears no relationship to the C type that int used to
represent. The new sys.maxsize value is the maximum value of Py_ssize_t.
This change has not led to any reported problems since the numpy 1.5
release.

Closes #3082
