### PR TITLE
2to3: Apply types fixer.

### DIFF
--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -151,7 +151,7 @@ def joinseq(seq):
 
 def strseq(object, convert, join=joinseq):
     """Recursively walk a sequence, stringifying each element."""
-    if type(object) in [types.ListType, types.TupleType]:
+    if type(object) in [list, tuple]:
         return join([strseq(_o, convert, join) for _o in object])
     else:
         return convert(object)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3,7 +3,16 @@
 """
 from __future__ import division, absolute_import, print_function
 
-__docformat__ = "restructuredtext en"
+import types
+
+from . import multiarray as mu
+from . import umath as um
+from . import numerictypes as nt
+from .numeric import asarray, array, asanyarray, concatenate
+from . import _methods
+
+_dt_ = nt.sctype2char
+
 
 # functions that are now methods
 __all__ = ['take', 'reshape', 'choose', 'repeat', 'put',
@@ -16,19 +25,11 @@ __all__ = ['take', 'reshape', 'choose', 'repeat', 'put',
            'amax', 'amin',
           ]
 
-from . import multiarray as mu
-from . import umath as um
-from . import numerictypes as nt
-from .numeric import asarray, array, asanyarray, concatenate
-from . import _methods
-_dt_ = nt.sctype2char
-
-import types
 
 try:
     _gentype = types.GeneratorType
 except AttributeError:
-    _gentype = types.NoneType
+    _gentype = type(None)
 
 # save away Python sum
 _sum_ = sum

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -36,17 +36,17 @@ Record arrays allow us to access fields as properties::
 """
 from __future__ import division, absolute_import, print_function
 
-# All of the functions allow formats to be a dtype
-__all__ = ['record', 'recarray', 'format_parser']
+import sys
+import os
 
 from . import numeric as sb
 from .defchararray import chararray
 from . import numerictypes as nt
-import types
-import os
-import sys
-
 from numpy.compat import isfileobj, bytes, long
+
+# All of the functions allow formats to be a dtype
+__all__ = ['record', 'recarray', 'format_parser']
+
 
 ndarray = sb.ndarray
 
@@ -171,7 +171,7 @@ class format_parser:
         attribute """
 
         if (names):
-            if (type(names) in [types.ListType, types.TupleType]):
+            if (type(names) in [list, tuple]):
                 pass
             elif (type(names) == str):
                 names = names.split(',')

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -16,16 +16,15 @@ Pearu Peterson
 """
 from __future__ import division, absolute_import, print_function
 
-__version__ = "$Revision: 1.65 $"[10:-1]
-
-from . import __version__
-f2py_version = __version__.version
-
 import pprint
 import sys
 import types
 from functools import reduce
+
+from . import __version__
 from . import cfuncs
+
+f2py_version = __version__.version
 
 
 errmess=sys.stderr.write
@@ -599,7 +598,7 @@ def gentitle(name):
     return '/*%s %s %s*/'%(l*'*',name,l*'*')
 
 def flatlist(l):
-    if type(l)==types.ListType:
+    if type(l)==list:
         return reduce(lambda x,y,f=flatlist:x+f(y),l,[])
     return [l]
 
@@ -608,9 +607,9 @@ def stripcomma(s):
     return s
 
 def replace(str,d,defaultsep=''):
-    if type(d)==types.ListType:
+    if type(d)==list:
         return [replace(str, _m, defaultsep) for _m in d]
-    if type(str)==types.ListType:
+    if type(str)==list:
         return [replace(_m, d, defaultsep) for _m in str]
     for k in 2*list(d.keys()):
         if k=='separatorsfor':
@@ -619,14 +618,14 @@ def replace(str,d,defaultsep=''):
             sep=d['separatorsfor'][k]
         else:
             sep=defaultsep
-        if type(d[k])==types.ListType:
+        if type(d[k])==list:
             str=str.replace('#%s#'%(k),sep.join(flatlist(d[k])))
         else:
             str=str.replace('#%s#'%(k),d[k])
     return str
 
 def dictappend(rd,ar):
-    if type(ar)==types.ListType:
+    if type(ar)==list:
         for a in ar:
             rd=dictappend(rd,a)
         return rd
@@ -636,13 +635,13 @@ def dictappend(rd,ar):
         if k in rd:
             if type(rd[k])==str:
                 rd[k]=[rd[k]]
-            if type(rd[k])==types.ListType:
-                if type(ar[k])==types.ListType:
+            if type(rd[k])==list:
+                if type(ar[k])==list:
                     rd[k]=rd[k]+ar[k]
                 else:
                     rd[k].append(ar[k])
-            elif type(rd[k])==types.DictType:
-                if type(ar[k])==types.DictType:
+            elif type(rd[k])==dict:
+                if type(ar[k])==dict:
                     if k=='separatorsfor':
                         for k1 in ar[k].keys():
                             if k1 not in rd[k]:
@@ -655,7 +654,7 @@ def dictappend(rd,ar):
 
 def applyrules(rules,d,var={}):
     ret={}
-    if type(rules)==types.ListType:
+    if type(rules)==list:
         for r in rules:
             rr=applyrules(r,d,var)
             ret=dictappend(ret,rr)
@@ -674,7 +673,7 @@ def applyrules(rules,d,var={}):
             ret[k]=rules[k]; continue
         if type(rules[k])==str:
             ret[k]=replace(rules[k],d)
-        elif type(rules[k])==types.ListType:
+        elif type(rules[k])==list:
             ret[k]=[]
             for i in rules[k]:
                 ar=applyrules({k:i},d,var)
@@ -682,13 +681,13 @@ def applyrules(rules,d,var={}):
                     ret[k].append(ar[k])
         elif k[0]=='_':
             continue
-        elif type(rules[k])==types.DictType:
+        elif type(rules[k])==dict:
             ret[k]=[]
             for k1 in rules[k].keys():
                 if type(k1)==types.FunctionType and k1(var):
-                    if type(rules[k][k1])==types.ListType:
+                    if type(rules[k][k1])==list:
                         for i in rules[k][k1]:
-                            if type(i)==types.DictType:
+                            if type(i)==dict:
                                 res=applyrules({'supertext':i},d,var)
                                 if 'supertext' in res:
                                     i=res['supertext']
@@ -696,7 +695,7 @@ def applyrules(rules,d,var={}):
                             ret[k].append(replace(i,d))
                     else:
                         i=rules[k][k1]
-                        if type(i)==types.DictType:
+                        if type(i)==dict:
                             res=applyrules({'supertext':i},d)
                             if 'supertext' in res:
                                 i=res['supertext']
@@ -704,7 +703,7 @@ def applyrules(rules,d,var={}):
                         ret[k].append(replace(i,d))
         else:
             errmess('applyrules: ignoring rule %s.\n'%repr(rules[k]))
-        if type(ret[k])==types.ListType:
+        if type(ret[k])==list:
             if len(ret[k])==1:
                 ret[k]=ret[k][0]
             if ret[k]==[]:

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -15,21 +15,19 @@ Pearu Peterson
 """
 from __future__ import division, absolute_import, print_function
 
-__version__ = "$Revision: 1.53 $"[10:-1]
-
-from . import __version__
-f2py_version = __version__.version
-
-
 import pprint
 import sys
-import types
+
+from . import __version__
+from .auxfuncs import *
+from . import cfuncs
+
+f2py_version = __version__.version
+
 errmess=sys.stderr.write
 outmess=sys.stdout.write
 show=pprint.pprint
 
-from .auxfuncs import *
-from . import cfuncs
 
 ################## Rules for callback function ##############
 
@@ -484,7 +482,7 @@ def buildcallback(rout,um):
 ,
 #endif
 """]
-    if type(rd['docreturn'])==types.ListType:
+    if type(rd['docreturn'])==list:
         rd['docreturn']=stripcomma(replace('#docreturn#',{'docreturn':rd['docreturn']}))
     optargs=stripcomma(replace('#docsignopt#',
                                 {'docsignopt':rd['docsignopt']}
@@ -501,10 +499,10 @@ def buildcallback(rout,um):
     rd['docstrsigns']=[]
     rd['latexdocstrsigns']=[]
     for k in ['docstrreq','docstropt','docstrout','docstrcbs']:
-        if k in rd and type(rd[k])==types.ListType:
+        if k in rd and type(rd[k])==list:
             rd['docstrsigns']=rd['docstrsigns']+rd[k]
         k='latex'+k
-        if k in rd and type(rd[k])==types.ListType:
+        if k in rd and type(rd[k])==list:
             rd['latexdocstrsigns']=rd['latexdocstrsigns']+rd[k][0:1]+\
                                     ['\\begin{description}']+rd[k][1:]+\
                                     ['\\end{description}']

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -16,15 +16,13 @@ Pearu Peterson
 """
 from __future__ import division, absolute_import, print_function
 
-__version__ = "$Revision: 1.75 $"[10:-1]
-
-from . import __version__
-f2py_version = __version__.version
-
-import types
 import sys
 import copy
-errmess=sys.stderr.write
+
+from . import __version__
+
+f2py_version = __version__.version
+errmess = sys.stderr.write
 
 ##################### Definitions ##################
 
@@ -1130,7 +1128,7 @@ def buildcfuncs():
 
 def append_needs(need,flag=1):
     global outneeds,needs
-    if type(need)==types.ListType:
+    if type(need)==list:
         for n in need:
             append_needs(n,flag)
     elif type(need)==str:
@@ -1162,7 +1160,7 @@ def append_needs(need,flag=1):
             if need in needs:
                 for nn in needs[need]:
                     t=append_needs(nn,0)
-                    if type(t)==types.DictType:
+                    if type(t)==dict:
                         for nnn in t.keys():
                             if nnn in tmp:
                                 tmp[nnn]=tmp[nnn]+t[nnn]
@@ -1178,7 +1176,7 @@ def append_needs(need,flag=1):
             if need in needs:
                 for nn in needs[need]:
                     t=append_needs(nn,flag)
-                    if type(t)==types.DictType:
+                    if type(t)==dict:
                         for nnn in t.keys():
                             if nnn in tmp:
                                 tmp[nnn]=t[nnn]+tmp[nnn]

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -140,12 +140,6 @@ TODO:
 """
 from __future__ import division, absolute_import, print_function
 
-__version__ = "$Revision: 1.177 $"[10:-1]
-import platform
-from . import __version__
-f2py_version = __version__.version
-
-#
 import sys
 import string
 import fileinput
@@ -153,7 +147,12 @@ import re
 import pprint
 import os
 import copy
+import platform
+
+from . import __version__
 from .auxfuncs import *
+
+f2py_version = __version__.version
 
 # Global flags:
 strictf77=1          # Ignore `!' comments unless line[0]=='!'
@@ -1523,7 +1522,7 @@ def postcrack2(block,tab='',param_map=None):
     global f90modulevars
     if not f90modulevars:
         return block
-    if type(block)==types.ListType:
+    if type(block)==list:
         ret = []
         for g in block:
             g = postcrack2(g,tab=tab+'\t',param_map=param_map)
@@ -1560,7 +1559,7 @@ def postcrack(block,args=None,tab=''):
           determine expression types if in argument list
     """
     global usermodules,onlyfunctions
-    if type(block)==types.ListType:
+    if type(block)==list:
         gret=[]
         uret=[]
         for g in block:
@@ -1572,7 +1571,7 @@ def postcrack(block,args=None,tab=''):
                 gret.append(g)
         return uret+gret
     setmesstext(block)
-    if (not type(block)==types.DictType) and 'block' not in block:
+    if (not type(block)==dict) and 'block' not in block:
         raise Exception('postcrack: Expected block dictionary instead of ' + \
                         str(block))
     if 'name' in block and not block['name']=='unknown_interface':

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -16,17 +16,10 @@ Pearu Peterson
 """
 from __future__ import division, absolute_import, print_function
 
-from . import __version__
-f2py_version = __version__.version
-
 import sys
 import os
 import pprint
-import types
 import re
-errmess=sys.stderr.write
-#outmess=sys.stdout.write
-show=pprint.pprint
 
 from . import crackfortran
 from . import rules
@@ -34,7 +27,12 @@ from . import cb_rules
 from . import auxfuncs
 from . import cfuncs
 from . import f90mod_rules
+from . import __version__
 
+f2py_version = __version__.version
+errmess = sys.stderr.write
+#outmess=sys.stdout.write
+show = pprint.pprint
 outmess = auxfuncs.outmess
 
 try:
@@ -341,7 +339,7 @@ def dict_append(d_out,d_in):
     for (k,v) in d_in.items():
         if k not in d_out:
             d_out[k] = []
-        if type(v) is types.ListType:
+        if type(v) is list:
             d_out[k] = d_out[k] + v
         else:
             d_out[k].append(v)

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -60,11 +60,7 @@ f2py_version = __version__.version
 import pprint
 import sys
 import time
-import types
 import copy
-errmess=sys.stderr.write
-outmess=sys.stdout.write
-show=pprint.pprint
 
 from .auxfuncs import *
 from . import capi_maps
@@ -74,8 +70,12 @@ from . import common_rules
 from . import use_rules
 from . import f90mod_rules
 from . import func2subr
-options={}
 
+errmess = sys.stderr.write
+outmess = sys.stdout.write
+show = pprint.pprint
+
+options={}
 sepdict={}
 #for k in ['need_cfuncs']: sepdict[k]=','
 for k in ['decl',
@@ -1388,9 +1388,9 @@ def buildapi(rout):
                 vrd['check']=c
                 ar=applyrules(check_rules,vrd,var[a])
                 rd=dictappend(rd,ar)
-    if type(rd['cleanupfrompyobj']) is types.ListType:
+    if type(rd['cleanupfrompyobj']) is list:
         rd['cleanupfrompyobj'].reverse()
-    if type(rd['closepyobjfrom']) is types.ListType:
+    if type(rd['closepyobjfrom']) is list:
         rd['closepyobjfrom'].reverse()
     rd['docsignature']=stripcomma(replace('#docsign##docsignopt##docsignxa#',
                                           {'docsign':rd['docsign'],
@@ -1415,15 +1415,15 @@ def buildapi(rout):
     else:
         rd['callcompaqfortran']=cfs
     rd['callfortran']=cfs
-    if type(rd['docreturn'])==types.ListType:
+    if type(rd['docreturn'])==list:
         rd['docreturn']=stripcomma(replace('#docreturn#',{'docreturn':rd['docreturn']}))+' = '
     rd['docstrsigns']=[]
     rd['latexdocstrsigns']=[]
     for k in ['docstrreq','docstropt','docstrout','docstrcbs']:
-        if k in rd and type(rd[k])==types.ListType:
+        if k in rd and type(rd[k])==list:
             rd['docstrsigns']=rd['docstrsigns']+rd[k]
         k='latex'+k
-        if k in rd and type(rd[k])==types.ListType:
+        if k in rd and type(rd[k])==list:
             rd['latexdocstrsigns']=rd['latexdocstrsigns']+rd[k][0:1]+\
                                     ['\\begin{description}']+rd[k][1:]+\
                                     ['\\end{description}']

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -4,14 +4,15 @@ Discrete Fourier Transforms - helper.py
 """
 from __future__ import division, absolute_import, print_function
 
+import numpy.core.numerictypes as nt
+from numpy.core import (
+        asarray, concatenate, arange, take, integer, empty
+        )
+
 # Created by Pearu Peterson, September 2002
 
 __all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
 
-from numpy.core import asarray, concatenate, arange, take, \
-    integer, empty
-import numpy.core.numerictypes as nt
-import types
 
 def fftshift(x, axes=None):
     """
@@ -156,7 +157,7 @@ def fftfreq(n, d=1.0):
     array([ 0.  ,  1.25,  2.5 ,  3.75, -5.  , -3.75, -2.5 , -1.25])
 
     """
-    if not (isinstance(n,types.IntType) or isinstance(n, integer)):
+    if not (isinstance(n,int) or isinstance(n, integer)):
         raise ValueError("n should be an integer")
     val = 1.0 / (n * d)
     results = empty(n, int)
@@ -212,7 +213,7 @@ def rfftfreq(n, d=1.0):
     array([  0.,  10.,  20.,  30.,  40.,  50.])
 
     """
-    if not (isinstance(n,types.IntType) or isinstance(n, integer)):
+    if not (isinstance(n,int) or isinstance(n, integer)):
         raise ValueError("n should be an integer")
     val = 1.0/(n*d)
     N = n//2 + 1

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -8,7 +8,6 @@ from __future__ import division, absolute_import, print_function
 
 __author__ = "Pierre GF Gerard-Marchant"
 
-import types
 import warnings
 import sys
 import pickle
@@ -836,7 +835,7 @@ class TestMaskedArrayArithmetic(TestCase):
         if sys.version_info[0] >= 3:
             assert_(isinstance(count(ott), np.integer))
         else:
-            assert_(isinstance(count(ott), types.IntType))
+            assert_(isinstance(count(ott), int))
         assert_equal(3, count(ott))
         assert_(getmask(count(ott, 0)) is nomask)
         assert_equal([1, 2], count(ott, 0))

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-import types
 from functools import reduce
 
 import numpy
@@ -166,7 +165,7 @@ class TestMa(TestCase):
         if sys.version_info[0] >= 3:
             self.assertTrue(isinstance(count(ott), numpy.integer))
         else:
-            self.assertTrue(isinstance(count(ott), types.IntType))
+            self.assertTrue(isinstance(count(ott), int))
         self.assertEqual(3, count(ott))
         self.assertEqual(1, count(1))
         self.assertTrue (eq(0, array(1, mask=[1])))
@@ -175,7 +174,7 @@ class TestMa(TestCase):
         if sys.version_info[0] >= 3:
             assert_(isinstance(count(ott), numpy.integer))
         else:
-            assert_(isinstance(count(ott), types.IntType))
+            assert_(isinstance(count(ott), int))
         self.assertTrue (eq(3, count(ott)))
         assert_(getmask(count(ott, 0)) is nomask)
         self.assertTrue (eq([1, 2], count(ott, 0)))

--- a/numpy/oldnumeric/ma.py
+++ b/numpy/oldnumeric/ma.py
@@ -18,10 +18,12 @@ from functools import reduce
 
 import numpy.core.umath as umath
 import numpy.core.fromnumeric as fromnumeric
+import numpy.core.numeric as numeric
 from numpy.core.numeric import newaxis, ndarray, inf
 from numpy.core.fromnumeric import amax, amin
 from numpy.core.numerictypes import bool_, typecodes
 import numpy.core.numeric as numeric
+from numpy.compat import bytes, long
 
 if sys.version_info[0] >= 3:
     _MAXINT = sys.maxsize
@@ -93,13 +95,13 @@ default_object_fill_value = '?'
 
 def default_fill_value (obj):
     "Function to calculate default fill value for an object."
-    if isinstance(obj, types.FloatType):
+    if isinstance(obj, float):
         return default_real_fill_value
-    elif isinstance(obj, types.IntType) or isinstance(obj, types.LongType):
+    elif isinstance(obj, int) or isinstance(obj, long):
         return default_integer_fill_value
-    elif isinstance(obj, types.StringType):
+    elif isinstance(obj, bytes):
         return default_character_fill_value
-    elif isinstance(obj, types.ComplexType):
+    elif isinstance(obj, complex):
         return default_complex_fill_value
     elif isinstance(obj, MaskedArray) or isinstance(obj, ndarray):
         x = obj.dtype.char
@@ -119,9 +121,9 @@ def default_fill_value (obj):
 
 def minimum_fill_value (obj):
     "Function to calculate default fill value suitable for taking minima."
-    if isinstance(obj, types.FloatType):
+    if isinstance(obj, float):
         return numeric.inf
-    elif isinstance(obj, types.IntType) or isinstance(obj, types.LongType):
+    elif isinstance(obj, int) or isinstance(obj, long):
         return _MAXINT
     elif isinstance(obj, MaskedArray) or isinstance(obj, ndarray):
         x = obj.dtype.char
@@ -136,9 +138,9 @@ def minimum_fill_value (obj):
 
 def maximum_fill_value (obj):
     "Function to calculate default fill value suitable for taking maxima."
-    if isinstance(obj, types.FloatType):
+    if isinstance(obj, float):
         return -inf
-    elif isinstance(obj, types.IntType) or isinstance(obj, types.LongType):
+    elif isinstance(obj, int) or isinstance(obj, long):
         return -_MAXINT
     elif isinstance(obj, MaskedArray) or isinstance(obj, ndarray):
         x = obj.dtype.char
@@ -239,7 +241,7 @@ def filled (a, value = None):
         return a.filled(value)
     elif isinstance(a, ndarray) and a.flags['CONTIGUOUS']:
         return a
-    elif isinstance(a, types.DictType):
+    elif isinstance(a, dict):
         return numeric.array(a, 'O')
     else:
         return numeric.array(a)
@@ -1543,7 +1545,7 @@ def new_repeat(a, repeats, axis=None):
        telling how many times to repeat each element.
     """
     af = filled(a)
-    if isinstance(repeats, types.IntType):
+    if isinstance(repeats, int):
         if axis is None:
             num = af.size
         else:
@@ -2153,10 +2155,9 @@ def asarray(data, dtype=None):
 # Add methods to support ndarray interface
 # XXX: I is better to to change the masked_*_operation adaptors
 # XXX: to wrap ndarray methods directly to create ma.array methods.
-from types import MethodType
 
 def _m(f):
-    return MethodType(f, None, array)
+    return types.MethodType(f, None, array)
 
 def not_implemented(*args, **kwds):
     raise NotImplementedError("not yet implemented for numpy.ma arrays")
@@ -2280,7 +2281,7 @@ array.std = _m(_std)
 
 array.view =  _m(not_implemented)
 array.round = _m(around)
-del _m, MethodType, not_implemented
+del _m, not_implemented
 
 
 masked = MaskedArray(0, int, mask=1)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -8,7 +8,6 @@ import os
 import sys
 import re
 import operator
-import types
 import warnings
 from .nosetester import import_nose
 
@@ -54,7 +53,7 @@ def gisnan(x):
     This should be removed once this problem is solved at the Ufunc level."""
     from numpy.core import isnan
     st = isnan(x)
-    if isinstance(st, types.NotImplementedType):
+    if isinstance(st, type(NotImplemented)):
         raise TypeError("isnan not supported for this type")
     return st
 
@@ -73,7 +72,7 @@ def gisfinite(x):
     err = seterr(invalid='ignore')
     try:
         st = isfinite(x)
-        if isinstance(st, types.NotImplementedType):
+        if isinstance(st, type(NotImplemented)):
             raise TypeError("isfinite not supported for this type")
     finally:
         seterr(**err)
@@ -94,7 +93,7 @@ def gisinf(x):
     err = seterr(invalid='ignore')
     try:
         st = isinf(x)
-        if isinstance(st, types.NotImplementedType):
+        if isinstance(st, type(NotImplemented)):
             raise TypeError("isinf not supported for this type")
     finally:
         seterr(**err)

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -88,7 +88,7 @@ FIXES_TO_SKIP = [
     'sys_exc',
     'throw',
     'tuple_params',
-#    'types',
+    'types',
 #    'unicode',
 #    'urllib',
 #    'ws_comma',


### PR DESCRIPTION
Python 3 removes the builtin types from the types module. The types
fixer replaces such references with the builtin types where possible
and also takes care of some special cases:

```
types.TypeNone           <- type(None)
types.NotImplementedType <- type(NotImplemented)
types.EllipsisType       <- type(Ellipsis)
```

The only two tricky substitutions are

```
types.StringType         <- bytes
types.LongType           <- int
```

These are fixed up to support both Python 3 and Python 2 code by
importing the long and bytes types from numpy.compat.

Closes #3240.
