### PR TITLE
Deprecate non integer arguments

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -168,8 +168,11 @@ The 'full' and 'economic' modes of qr factorization are deprecated.
 General
 ~~~~~~~
 
-Use of non-integer indices has been deprecated. Previously float indices
-were truncated to integers without warning.
+The use of non-integer for indices and most integer arguments has been
+deprecated. Previously float indices and function arguments such as axes or
+shapes were truncated to integers without warning. For example
+`arr.reshape(3., -1)` or `arr[0.]` will trigger a deprecation warning in
+NumPy 1.8., and in some future version of NumPy they will raise an error.
 
 C-API
 ~~~~~

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -90,7 +90,7 @@ def _get_num_chars(a):
     for a unicode array this is itemsize / 4.
     """
     if issubclass(a.dtype.type, unicode_):
-        return a.itemsize / 4
+        return a.itemsize // 4
     return a.itemsize
 
 
@@ -2593,7 +2593,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
             # to divide by the size of a single Unicode character,
             # which for Numpy is always 4
             if issubclass(obj.dtype.type, unicode_):
-                itemsize /= 4
+                itemsize //= 4
 
         if unicode is None:
             if issubclass(obj.dtype.type, unicode_):

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -96,13 +96,16 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
     if (len == -1) {
         /* Check to see if it is an integer number */
         if (PyNumber_Check(obj)) {
-            /* DEPRECATED: replace PyNumber_Check with PyIndex_Check */
+            /*
+             * After the deprecation the PyNumber_Check could be replaced
+             * by PyIndex_Check.
+             */
             len = 1;
         }
     }
     if (len < 0) {
         PyErr_SetString(PyExc_TypeError,
-                        "expected sequence object with len >= 0 or a single integer");
+                "expected sequence object with len >= 0 or a single integer");
         return NPY_FAIL;
     }
     if (len > NPY_MAXDIMS) {

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -84,7 +84,7 @@ PyArray_OutputConverter(PyObject *object, PyArrayObject **address)
 NPY_NO_EXPORT int
 PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
 {
-    int len;
+    Py_ssize_t len;
     int nd;
 
     seq->ptr = NULL;
@@ -94,14 +94,15 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
     }
     len = PySequence_Size(obj);
     if (len == -1) {
-        /* Check to see if it is a number */
+        /* Check to see if it is an integer number */
         if (PyNumber_Check(obj)) {
+            /* DEPRECATED: replace PyNumber_Check with PyIndex_Check */
             len = 1;
         }
     }
     if (len < 0) {
         PyErr_SetString(PyExc_TypeError,
-                        "expected sequence object with len >= 0");
+                        "expected sequence object with len >= 0 or a single integer");
         return NPY_FAIL;
     }
     if (len > NPY_MAXDIMS) {
@@ -117,7 +118,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
         }
     }
     seq->len = len;
-    nd = PyArray_IntpFromSequence(obj, (npy_intp *)seq->ptr, len);
+    nd = PyArray_IntpFromSequence(obj, (npy_intp *)seq->ptr, (int) len);
     if (nd == -1 || nd != len) {
         PyDimMem_FREE(seq->ptr);
         seq->ptr = NULL;
@@ -187,7 +188,7 @@ PyArray_AxisConverter(PyObject *obj, int *axis)
         *axis = NPY_MAXDIMS;
     }
     else {
-        *axis = (int) PyInt_AsLong(obj);
+        *axis = (int) PyArray_PyIntAsInt(obj);
         if (PyErr_Occurred()) {
             return NPY_FAIL;
         }
@@ -223,9 +224,9 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
         }
         for (i = 0; i < naxes; ++i) {
             PyObject *tmp = PyTuple_GET_ITEM(axis_in, i);
-            long axis = PyInt_AsLong(tmp);
-            long axis_orig = axis;
-            if (axis == -1 && PyErr_Occurred()) {
+            int axis = PyArray_PyIntAsInt(tmp);
+            int axis_orig = axis;
+            if (error_converting(axis)) {
                 return NPY_FAIL;
             }
             if (axis < 0) {
@@ -233,7 +234,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
             }
             if (axis < 0 || axis >= ndim) {
                 PyErr_Format(PyExc_ValueError,
-                        "'axis' entry %ld is out of bounds [-%d, %d)",
+                        "'axis' entry %d is out of bounds [-%d, %d)",
                         axis_orig, ndim, ndim);
                 return NPY_FAIL;
             }
@@ -249,14 +250,14 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
     }
     /* Try to interpret axis as an integer */
     else {
-        long axis, axis_orig;
+        int axis, axis_orig;
 
         memset(out_axis_flags, 0, ndim);
 
-        axis = PyInt_AsLong(axis_in);
+        axis = PyArray_PyIntAsInt(axis_in);
         axis_orig = axis;
-        /* TODO: PyNumber_Index would be good to use here */
-        if (axis == -1 && PyErr_Occurred()) {
+
+        if (error_converting(axis)) {
             return NPY_FAIL;
         }
         if (axis < 0) {
@@ -272,7 +273,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
 
         if (axis < 0 || axis >= ndim) {
             PyErr_Format(PyExc_ValueError,
-                    "'axis' entry %ld is out of bounds [-%d, %d)",
+                    "'axis' entry %d is out of bounds [-%d, %d)",
                     axis_orig, ndim, ndim);
             return NPY_FAIL;
         }
@@ -529,8 +530,8 @@ PyArray_ClipmodeConverter(PyObject *object, NPY_CLIPMODE *val)
         return ret;
     }
     else {
-        int number = PyInt_AsLong(object);
-        if (number == -1 && PyErr_Occurred()) {
+        int number = PyArray_PyIntAsInt(object);
+        if (error_converting(number)) {
             goto fail;
         }
         if (number <= (int) NPY_RAISE
@@ -664,85 +665,11 @@ PyArray_CastingConverter(PyObject *obj, NPY_CASTING *casting)
 NPY_NO_EXPORT int
 PyArray_PyIntAsInt(PyObject *o)
 {
-    long long_value = -1;
-    PyObject *obj;
-    static char *msg = "an integer is required";
-    PyArrayObject *arr;
-    PyArray_Descr *descr;
-    int ret;
+    npy_intp long_value;
+    /* This assumes that NPY_SIZEOF_INTP >= NPY_SIZEOF_INT */
+    long_value = PyArray_PyIntAsIntp(o);
 
-
-    if (!o) {
-        PyErr_SetString(PyExc_TypeError, msg);
-        return -1;
-    }
-    if (PyInt_Check(o)) {
-        long_value = (long) PyInt_AS_LONG(o);
-        goto finish;
-    } else if (PyLong_Check(o)) {
-        long_value = (long) PyLong_AsLong(o);
-        goto finish;
-    }
-
-    descr = &INT_Descr;
-    arr = NULL;
-    if (PyArray_Check(o)) {
-        if (PyArray_SIZE((PyArrayObject *)o)!=1 ||
-                                !PyArray_ISINTEGER((PyArrayObject *)o)) {
-            PyErr_SetString(PyExc_TypeError, msg);
-            return -1;
-        }
-        Py_INCREF(descr);
-        arr = (PyArrayObject *)PyArray_CastToType((PyArrayObject *)o,
-                                                    descr, 0);
-    }
-    if (PyArray_IsScalar(o, Integer)) {
-        Py_INCREF(descr);
-        arr = (PyArrayObject *)PyArray_FromScalar(o, descr);
-    }
-    if (arr != NULL) {
-        ret = *((int *)PyArray_DATA(arr));
-        Py_DECREF(arr);
-        return ret;
-    }
-#if (PY_VERSION_HEX >= 0x02050000)
-    if (PyIndex_Check(o)) {
-        PyObject* value = PyNumber_Index(o);
-        long_value = (npy_longlong) PyInt_AsSsize_t(value);
-        goto finish;
-    }
-#endif
-    if (Py_TYPE(o)->tp_as_number != NULL &&
-        Py_TYPE(o)->tp_as_number->nb_int != NULL) {
-        obj = Py_TYPE(o)->tp_as_number->nb_int(o);
-        if (obj == NULL) {
-            return -1;
-        }
-        long_value = (long) PyLong_AsLong(obj);
-        Py_DECREF(obj);
-    }
-#if !defined(NPY_PY3K)
-    else if (Py_TYPE(o)->tp_as_number != NULL &&
-             Py_TYPE(o)->tp_as_number->nb_long != NULL) {
-        obj = Py_TYPE(o)->tp_as_number->nb_long(o);
-        if (obj == NULL) {
-            return -1;
-        }
-        long_value = (long) PyLong_AsLong(obj);
-        Py_DECREF(obj);
-    }
-#endif
-    else {
-        PyErr_SetString(PyExc_NotImplementedError,"");
-    }
-
- finish:
-    if error_converting(long_value) {
-            PyErr_SetString(PyExc_TypeError, msg);
-            return -1;
-        }
-
-#if (NPY_SIZEOF_LONG > NPY_SIZEOF_INT)
+#if (NPY_SIZEOF_INTP > NPY_SIZEOF_INT)
     if ((long_value < INT_MIN) || (long_value > INT_MAX)) {
         PyErr_SetString(PyExc_ValueError, "integer won't fit into a C int");
         return -1;
@@ -755,99 +682,145 @@ PyArray_PyIntAsInt(PyObject *o)
 NPY_NO_EXPORT npy_intp
 PyArray_PyIntAsIntp(PyObject *o)
 {
+#if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+    npy_long long_value = -1;
+#else
     npy_longlong long_value = -1;
-    PyObject *obj;
+#endif
+    PyObject *obj, *err;
     static char *msg = "an integer is required";
-    PyArrayObject *arr;
-    PyArray_Descr *descr;
-    npy_intp ret;
 
     if (!o) {
         PyErr_SetString(PyExc_TypeError, msg);
         return -1;
     }
-    if (PyInt_Check(o)) {
-        long_value = (npy_longlong) PyInt_AS_LONG(o);
-        goto finish;
-    } else if (PyLong_Check(o)) {
-        long_value = (npy_longlong) PyLong_AsLongLong(o);
-        goto finish;
-    }
 
-#if NPY_SIZEOF_INTP == NPY_SIZEOF_LONG
-    descr = &LONG_Descr;
-#elif NPY_SIZEOF_INTP == NPY_SIZEOF_INT
-    descr = &INT_Descr;
-#else
-    descr = &LONGLONG_Descr;
-#endif
-    arr = NULL;
-
-    if (PyArray_Check(o)) {
-        if (PyArray_SIZE((PyArrayObject *)o)!=1 ||
-                                !PyArray_ISINTEGER((PyArrayObject *)o)) {
-            PyErr_SetString(PyExc_TypeError, msg);
+    /* Be a bit stricter and not allow bools */
+    if (PyBool_Check(o)) {
+        if (DEPRECATE("using a boolean instead of an integer"
+                      " will result in an error in the future") < 0) {
             return -1;
         }
-        Py_INCREF(descr);
-        arr = (PyArrayObject *)PyArray_CastToType((PyArrayObject *)o,
-                                                                descr, 0);
-    }
-    else if (PyArray_IsScalar(o, Integer)) {
-        Py_INCREF(descr);
-        arr = (PyArrayObject *)PyArray_FromScalar(o, descr);
-    }
-    if (arr != NULL) {
-        ret = *((npy_intp *)PyArray_DATA(arr));
-        Py_DECREF(arr);
-        return ret;
     }
 
-#if (PY_VERSION_HEX >= 0x02050000)
-    if (PyIndex_Check(o)) {
-        PyObject* value = PyNumber_Index(o);
-        if (value == NULL) {
-            return -1;
-        }
-        long_value = (npy_longlong) PyInt_AsSsize_t(value);
-        goto finish;
-    }
-#endif
+    /*
+     * Since it is the usual case, first check if o is an integer. This is
+     * an exact check, since otherwise __index__ is used.
+     */
 #if !defined(NPY_PY3K)
-    if (Py_TYPE(o)->tp_as_number != NULL &&                 \
-        Py_TYPE(o)->tp_as_number->nb_long != NULL) {
-        obj = Py_TYPE(o)->tp_as_number->nb_long(o);
-        if (obj != NULL) {
-            long_value = (npy_longlong) PyLong_AsLongLong(obj);
-            Py_DECREF(obj);
-        }
+    if PyInt_CheckExact(o) {
+  #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = (npy_longlong) PyInt_AsLong(o);
+  #else
+        long_value = PyInt_AsLong(o);
+  #endif
+        goto finish;
     }
     else
 #endif
-    if (Py_TYPE(o)->tp_as_number != NULL &&                 \
-             Py_TYPE(o)->tp_as_number->nb_int != NULL) {
-        obj = Py_TYPE(o)->tp_as_number->nb_int(o);
-        if (obj != NULL) {
-            long_value = (npy_longlong) PyLong_AsLongLong(obj);
-            Py_DECREF(obj);
-        }
+    if PyLong_CheckExact(o) {
+#if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(o);
+#else
+        long_value = PyLong_AsLong(o);
+#endif
+        goto finish;
+    }
+    /*
+     * The most general case. PyNumber_Index(o) covers everything
+     * including arrays. In principle it may be possible to replace
+     * the whole function by PyIndex_AsSSize_t after deprecation.
+     */
+    obj = PyNumber_Index(o);
+    if (obj) {
+#if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(obj);
+#else
+        long_value = PyLong_AsLong(obj);
+#endif
+        Py_DECREF(obj);
+        goto finish;
     }
     else {
-        PyErr_SetString(PyExc_NotImplementedError,"");
+        /*
+         * Set the TypeError like PyNumber_Index(o) would after trying
+         * the general case.
+         */
+        PyErr_Clear();
+    }
+
+    /*    
+     * For backward compatibility check the number C-Api number protcol
+     * This should be removed up the finish label after deprecation.
+     */
+    if (Py_TYPE(o)->tp_as_number != NULL &&
+        Py_TYPE(o)->tp_as_number->nb_int != NULL) {
+        obj = Py_TYPE(o)->tp_as_number->nb_int(o);
+        if (obj == NULL) {
+            return -1;
+        }
+ #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(obj);
+ #else
+        long_value = PyLong_AsLong(obj);
+ #endif
+        Py_DECREF(obj);
+    }
+#if !defined(NPY_PY3K)
+    else if (Py_TYPE(o)->tp_as_number != NULL &&
+             Py_TYPE(o)->tp_as_number->nb_long != NULL) {
+        obj = Py_TYPE(o)->tp_as_number->nb_long(o);
+        if (obj == NULL) {
+            return -1;
+        }
+  #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(obj);
+  #else
+        long_value = PyLong_AsLong(obj);
+  #endif
+        Py_DECREF(obj);
+    }
+#endif
+    else {
+        PyErr_SetString(PyExc_TypeError, msg);
+        return -1;
+    }
+    /* Give a deprecation warning, unless there was already an error */
+    if (!error_converting(long_value)) {
+        if (DEPRECATE("using a non-integer number instead of an integer"
+                      " will result in an error in the future") < 0) {
+            return -1;
+        }
     }
 
  finish:
-    if error_converting(long_value) {
-            PyErr_SetString(PyExc_TypeError, msg);
+    if (long_value == -1) {
+        err = PyErr_Occurred();
+        /* Only replace TypeError's here, which are the normal errors. */
+        if (err) {
+            if (PyErr_GivenExceptionMatches(err, PyExc_TypeError)) {
+                PyErr_SetString(PyExc_TypeError, msg);
+            }
             return -1;
         }
+    }
 
-#if (NPY_SIZEOF_LONGLONG > NPY_SIZEOF_INTP)
+#if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+  #if (NPY_SIZEOF_LONGLONG > NPY_SIZEOF_INTP)
     if ((long_value < NPY_MIN_INTP) || (long_value > NPY_MAX_INTP)) {
-        PyErr_SetString(PyExc_ValueError,
-                        "integer won't fit into a C intp");
+        PyErr_SetString(PyExc_OverflowError,
+                        "Python int too large to convert to C numpy.intp");
         return -1;
     }
+  #endif
+#else
+  #if (NPY_SIZEOF_LONG > NPY_SIZEOF_INTP)
+    if ((long_value < NPY_MIN_INTP) || (long_value > NPY_MAX_INTP)) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "Python int too large to convert to C numpy.intp");
+        return -1;
+    }
+  #endif
 #endif
     return (npy_intp) long_value;
 }
@@ -867,29 +840,11 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
      * Check to see if sequence is a single integer first.
      * or, can be made into one
      */
-    if ((nd=PySequence_Length(seq)) == -1) {
+    nd = PySequence_Length(seq);
+    if (nd == -1) {
         if (PyErr_Occurred()) PyErr_Clear();
-#if NPY_SIZEOF_LONG >= NPY_SIZEOF_INTP && !defined(NPY_PY3K)
-        if (!(op = PyNumber_Int(seq))) {
-            return -1;
-        }
-#else
-        if (!(op = PyNumber_Long(seq))) {
-            return -1;
-        }
-#endif
-        nd = 1;
-#if NPY_SIZEOF_LONG >= NPY_SIZEOF_INTP
-        vals[0] = (npy_intp ) PyInt_AsLong(op);
-#else
-        vals[0] = (npy_intp ) PyLong_AsLongLong(op);
-#endif
-        Py_DECREF(op);
 
-        /*
-         * Check wether there was an error - if the error was an overflow, raise
-         * a ValueError instead to be more helpful
-         */
+        vals[0] = PyArray_PyIntAsIntp(seq);
         if(vals[0] == -1) {
             err = PyErr_Occurred();
             if (err  &&
@@ -901,6 +856,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
                 return -1;
             }
         }
+        nd = 1;
     }
     else {
         for (i = 0; i < PyArray_MIN(nd,maxvals); i++) {
@@ -908,18 +864,10 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
             if (op == NULL) {
                 return -1;
             }
-#if NPY_SIZEOF_LONG >= NPY_SIZEOF_INTP
-            vals[i]=(npy_intp )PyInt_AsLong(op);
-#else
-            vals[i]=(npy_intp )PyLong_AsLongLong(op);
-#endif
-            Py_DECREF(op);
 
-            /*
-             * Check wether there was an error - if the error was an overflow,
-             * raise a ValueError instead to be more helpful
-             */
-            if(vals[0] == -1) {
+
+            vals[i] = PyArray_PyIntAsIntp(op);
+            if(vals[i] == -1) {
                 err = PyErr_Occurred();
                 if (err  &&
                     PyErr_GivenExceptionMatches(err, PyExc_OverflowError)) {

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -191,7 +191,7 @@ PyArray_AxisConverter(PyObject *obj, int *axis)
         *axis = NPY_MAXDIMS;
     }
     else {
-        *axis = (int) PyArray_PyIntAsInt(obj);
+        *axis = PyArray_PyIntAsInt(obj);
         if (PyErr_Occurred()) {
             return NPY_FAIL;
         }
@@ -812,7 +812,7 @@ PyArray_PyIntAsIntp(PyObject *o)
   #if (NPY_SIZEOF_LONGLONG > NPY_SIZEOF_INTP)
     if ((long_value < NPY_MIN_INTP) || (long_value > NPY_MAX_INTP)) {
         PyErr_SetString(PyExc_OverflowError,
-                        "Python int too large to convert to C numpy.intp");
+                "Python int too large to convert to C numpy.intp");
         return -1;
     }
   #endif
@@ -820,7 +820,7 @@ PyArray_PyIntAsIntp(PyObject *o)
   #if (NPY_SIZEOF_LONG > NPY_SIZEOF_INTP)
     if ((long_value < NPY_MIN_INTP) || (long_value > NPY_MAX_INTP)) {
         PyErr_SetString(PyExc_OverflowError,
-                        "Python int too large to convert to C numpy.intp");
+                "Python int too large to convert to C numpy.intp");
         return -1;
     }
   #endif
@@ -849,13 +849,15 @@ PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals)
      */
     nd = PySequence_Length(seq);
     if (nd == -1) {
-        if (PyErr_Occurred()) PyErr_Clear();
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+        }
 
         vals[0] = PyArray_PyIntAsIntp(seq);
         if(vals[0] == -1) {
             err = PyErr_Occurred();
-            if (err  &&
-                PyErr_GivenExceptionMatches(err, PyExc_OverflowError)) {
+            if (err &&
+                    PyErr_GivenExceptionMatches(err, PyExc_OverflowError)) {
                 PyErr_SetString(PyExc_ValueError,
                         "Maximum allowed dimension exceeded");
             }
@@ -876,8 +878,8 @@ PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals)
             vals[i] = PyArray_PyIntAsIntp(op);
             if(vals[i] == -1) {
                 err = PyErr_Occurred();
-                if (err  &&
-                    PyErr_GivenExceptionMatches(err, PyExc_OverflowError)) {
+                if (err &&
+                        PyErr_GivenExceptionMatches(err, PyExc_OverflowError)) {
                     PyErr_SetString(PyExc_ValueError,
                             "Maximum allowed dimension exceeded");
                 }
@@ -892,13 +894,13 @@ PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals)
 
 /*NUMPY_API
  * PyArray_IntpFromSequence
- * Returns the number of dimensions or -1 if an error occurred.
+ * Returns the number of integers converted or -1 if an error occurred.
  * vals must be large enough to hold maxvals
  */
 NPY_NO_EXPORT int
 PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
 {
-    return (int)PyArray_IntpFromIndexSequence(seq, vals, (npy_intp)maxvals);
+    return PyArray_IntpFromIndexSequence(seq, vals, (npy_intp)maxvals);
 }
 
 

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -698,7 +698,7 @@ PyArray_PyIntAsIntp(PyObject *o)
         return -1;
     }
 
-    /* Be a bit stricter and not allow bools */
+    /* Be a bit stricter and not allow bools, np.bool_ is handled later */
     if (PyBool_Check(o)) {
         if (DEPRECATE("using a boolean instead of an integer"
                       " will result in an error in the future") < 0) {
@@ -730,6 +730,15 @@ PyArray_PyIntAsIntp(PyObject *o)
 #endif
         return (npy_intp)long_value;
     }
+
+    /* Disallow numpy.bool_. Boolean arrays do not currently support index. */
+    if (PyArray_IsScalar(o, Bool)) {
+        if (DEPRECATE("using a boolean instead of an integer"
+                      " will result in an error in the future") < 0) {
+            return -1;
+        }
+    }
+
     /*
      * The most general case. PyNumber_Index(o) covers everything
      * including arrays. In principle it may be possible to replace

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -121,7 +121,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
         }
     }
     seq->len = len;
-    nd = PyArray_IntpFromSequence(obj, (npy_intp *)seq->ptr, (int) len);
+    nd = PyArray_IntpFromIndexSequence(obj, (npy_intp *)seq->ptr, len);
     if (nd == -1 || nd != len) {
         PyDimMem_FREE(seq->ptr);
         seq->ptr = NULL;
@@ -828,15 +828,19 @@ PyArray_PyIntAsIntp(PyObject *o)
     return (npy_intp) long_value;
 }
 
-/*NUMPY_API
- * PyArray_IntpFromSequence
+
+/*
+ * PyArray_IntpFromIndexSequence
  * Returns the number of dimensions or -1 if an error occurred.
- * vals must be large enough to hold maxvals
+ * vals must be large enough to hold maxvals.
+ * Opposed to PyArray_IntpFromSequence it uses and returns npy_intp
+ * for the number of values.
  */
-NPY_NO_EXPORT int
-PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
+NPY_NO_EXPORT npy_intp
+PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals)
 {
-    int nd, i;
+    Py_ssize_t nd;
+    npy_intp i;
     PyObject *op, *err;
 
     /*
@@ -885,6 +889,18 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
     }
     return nd;
 }
+
+/*NUMPY_API
+ * PyArray_IntpFromSequence
+ * Returns the number of dimensions or -1 if an error occurred.
+ * vals must be large enough to hold maxvals
+ */
+NPY_NO_EXPORT int
+PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
+{
+    return (int)PyArray_IntpFromIndexSequence(seq, vals, (npy_intp)maxvals);
+}
+
 
 /**
  * WARNING: This flag is a bad idea, but was the only way to both

--- a/numpy/core/src/multiarray/conversion_utils.h
+++ b/numpy/core/src/multiarray/conversion_utils.h
@@ -25,6 +25,9 @@ PyArray_PyIntAsInt(PyObject *o);
 NPY_NO_EXPORT npy_intp
 PyArray_PyIntAsIntp(PyObject *o);
 
+NPY_NO_EXPORT npy_intp
+PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals);
+
 NPY_NO_EXPORT int
 PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals);
 

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -70,12 +70,6 @@ parse_index_entry(PyObject *op, npy_intp *step_size,
         }
         *n_steps = SINGLE_INDEX;
         *step_size = 0;
-        if (!PyIndex_Check_Or_Unsupported(op)) {
-            if (DEPRECATE("non-integer scalar index. In a future numpy "
-                          "release, this will raise an error.") < 0) {
-                goto fail;
-            }
-        }
         if (check_index) {
             if (check_and_adjust_index(&i, max, axis) < 0) {
             goto fail;
@@ -204,26 +198,8 @@ parse_index(PyArrayObject *self, PyObject *op,
 static int
 slice_coerce_index(PyObject *o, npy_intp *v)
 {
-    /*
-     * PyNumber_Index was introduced in Python 2.5 because of NumPy.
-     * http://www.python.org/dev/peps/pep-0357/
-     * Let's use it for indexing!
-     *
-     * Unfortunately, SciPy and possibly other code seems to rely
-     * on the lenient coercion. :(
-     */
-#if 0 /*PY_VERSION_HEX >= 0x02050000*/
-    PyObject *ind = PyNumber_Index(o);
-    if (ind != NULL) {
-        *v = PyArray_PyIntAsIntp(ind);
-        Py_DECREF(ind);
-    }
-    else {
-        *v = -1;
-    }
-#else
     *v = PyArray_PyIntAsIntp(o);
-#endif
+
     if ((*v) == -1 && PyErr_Occurred()) {
         PyErr_Clear();
         return 0;
@@ -231,24 +207,6 @@ slice_coerce_index(PyObject *o, npy_intp *v)
     return 1;
 }
 
-/*
- * Issue a DeprecationWarning for slice parameters that do not pass a
- * PyIndex_Check, returning -1 if an error occurs.
- *
- * N.B. This function, like slice_GetIndices, will be obsolete once
- * non-integer slice parameters becomes an error rather than a warning.
- */
-static NPY_INLINE int
-_validate_slice_parameter(PyObject *o)
-{
-    if (!PyIndex_Check_Or_Unsupported(o)) {
-        if (DEPRECATE("non-integer slice parameter. In a future numpy "
-                      "release, this will raise an error.") < 0) {
-            return -1;
-        }
-    }
-    return 0;
-}
 
 /*
  * This is basically PySlice_GetIndicesEx, but with our coercion
@@ -268,9 +226,6 @@ slice_GetIndices(PySliceObject *r, npy_intp length,
         *step = 1;
     }
     else {
-        if (_validate_slice_parameter(r->step) < 0) {
-            return -1;
-        }
         if (!slice_coerce_index(r->step, step)) {
             return -1;
         }
@@ -286,9 +241,6 @@ slice_GetIndices(PySliceObject *r, npy_intp length,
         *start = *step < 0 ? length-1 : 0;
     }
     else {
-        if (_validate_slice_parameter(r->start) < 0) {
-            return -1;
-        }
         if (!slice_coerce_index(r->start, start)) {
             return -1;
         }
@@ -307,9 +259,6 @@ slice_GetIndices(PySliceObject *r, npy_intp length,
         *stop = defstop;
     }
     else {
-        if (_validate_slice_parameter(r->stop) < 0) {
-            return -1;
-        }
         if (!slice_coerce_index(r->stop, stop)) {
             return -1;
         }

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -841,8 +841,8 @@ array_index(PyArrayObject *v)
         return NULL;
     }
     if (PyArray_NDIM(v) != 0) {
-            if (DEPRECATE("converting an array with ndim > 0 to an index"
-                          " will result in an error in the future") < 0) {
+        if (DEPRECATE("converting an array with ndim > 0 to an index"
+                      " will result in an error in the future") < 0) {
             return NULL;
         }
     }

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -840,6 +840,12 @@ array_index(PyArrayObject *v)
                         "one element can be converted to an index");
         return NULL;
     }
+    if (PyArray_NDIM(v) != 0) {
+            if (DEPRECATE("converting an array with ndim > 0 to an index"
+                          " will result in an error in the future") < 0) {
+            return NULL;
+        }
+    }
     return PyArray_DESCR(v)->f->getitem(PyArray_DATA(v), v);
 }
 #endif

--- a/numpy/core/src/private/npy_pycompat.h
+++ b/numpy/core/src/private/npy_pycompat.h
@@ -13,16 +13,4 @@
 #define Py_SIZE(o)    (((PyVarObject*)(o))->ob_size)
 #endif
 
-/*
- * PyIndex_Check
- */
-#if (PY_VERSION_HEX < 0x02050000)
-#undef PyIndex_Check
-#define PyIndex_Check(o)     0
-#undef PyIndex_Check_Or_Unsupported
-#define PyIndex_Check_Or_Unsupported(o) 1
-#else
-#define PyIndex_Check_Or_Unsupported(o) PyIndex_Check(o)
-#endif
-
 #endif /* _NPY_COMPAT_H_ */

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -6,65 +6,127 @@ to document how deprecations should eventually be turned into errors.
 from __future__ import division, absolute_import, print_function
 
 import sys
+
 import warnings
 from nose.plugins.skip import SkipTest
 
 import numpy as np
 from numpy.testing import dec, run_module_suite, assert_raises
+import operator
 
 
-def assert_deprecated(f, *args, **kwargs):
-    """Check if DeprecationWarning raised as error.
+class _DeprecationTestCase(object):
+    # Just as warning: warnings uses re.match, so the start of this message
+    # must match.
+    message = ''
 
-    The warning environment is assumed to have been set up so that the
-    appropriate DeprecationWarning has been turned into an error. We do not
-    use assert_warns here as the desire is to check that an error will be
-    raised if the deprecation is changed to an error and there may be other
-    errors that would override a warning. It is a fine point as to which
-    error should appear first.
+    def setUp(self):
+        self.warn_ctx = warnings.catch_warnings(record=True)
+        self.log = self.warn_ctx.__enter__()
 
-    Parameters
-    ----------
-    f : callable
-       A function that will exhibit the deprecation. It need not be
-       deprecated itself, but can be used to execute deprecated code.
+        # Do *not* ignore other DeprecationWarnings. Ignoring warnings
+        # can give very confusing results because of
+        # http://bugs.python.org/issue4180 and it is probably simplest to
+        # try to keep the tests cleanly giving only the right warning type.
+        # (While checking them set to "error" those are ignored anyway)
+        # We still have them show up, because otherwise they would be raised
+        warnings.filterwarnings("always", category=DeprecationWarning)
+        warnings.filterwarnings("always", message=self.message,
+                                    category=DeprecationWarning)
 
+
+    def tearDown(self):
+        self.warn_ctx.__exit__()
+
+
+    def assert_deprecated(self, function, num=1, ignore_others=False,
+                        function_fails=False,
+                        exceptions=(DeprecationWarning,), args=(), kwargs={}):
+        """Test if DeprecationWarnings are given and raised.
+
+        This first checks if the function when called gives `num`
+        DeprecationWarnings, after that it tries to raise these
+        DeprecationWarnings and compares them with `exceptions`.
+        The exceptions can be different for cases where this code path
+        is simply not anticipated and the exception is replaced.
+
+        Parameters
+        ----------
+        f : callable
+            The function to test
+        num : int
+            Number of DeprecationWarnings to expect. This should normally be 1.
+        ignore_other : bool
+            Whether warnings of the wrong type should be ignored (note that
+            the message is not checked)
+        function_fails : bool
+            If the function would normally fail, setting this will check for
+            warnings inside a try/except block.
+        exceptions : Exception or tuple of Exceptions
+            Exception to expect when turning the warnings into an error.
+            The default checks for DeprecationWarnings. If exceptions is
+            empty the function is expected to run successfull.
+        args : tuple
+            Arguments for `f`
+        kwargs : dict
+            Keyword arguments for `f`
+        """
+        # reset the log
+        self.log[:] = []
+
+        try:
+            function(*args, **kwargs)
+        except (Exception if function_fails else tuple()):
+            pass
+        # just in case, clear the registry
+        num_found = 0
+        for warning in self.log:
+            if warning.category is DeprecationWarning:
+                num_found += 1
+            elif not ignore_others:
+                raise AssertionError("expected DeprecationWarning but %s given"
+                                                            % warning.category)
+        if num_found != num:
+            raise AssertionError("%i warnings found but %i expected"
+                                                        % (len(self.log), num))
+
+        warnings.filterwarnings("error", message=self.message,
+                                    category=DeprecationWarning)
+
+        try:
+            function(*args, **kwargs)
+            if exceptions != tuple():
+                raise AssertionError("No error raised during function call")
+        except exceptions:
+            if exceptions == tuple():
+                raise AssertionError("Error raised during function call")
+        finally:
+            warnings.filters.pop(0)
+
+
+    def assert_not_deprecated(self, function, args=(), kwargs={}):
+        """Test if DeprecationWarnings are given and raised.
+
+        This is just a shorthand for:
+
+        self.assert_deprecated(function, num=0, ignore_others=True,
+                        exceptions=tuple(), args=args, kwargs=kwargs)
+        """
+        self.assert_deprecated(function, num=0, ignore_others=True,
+                        exceptions=tuple(), args=args, kwargs=kwargs)
+
+
+class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
     """
-    assert_raises(DeprecationWarning, f, *args, **kwargs)
+    These test that ``DeprecationWarning`` is given when you try to use
+    non-integers as arguments to for indexing and slicing e.g. ``a[0.0:5]``
+    and ``a[0.5]``, or other functions like ``array.reshape(1., -1)``.
 
-
-def assert_not_deprecated(f, *args, **kwargs):
-    """Check that DeprecationWarning not raised as error.
-
-    The warning environment is assumed to have been set up so that the
-    appropriate DeprecationWarning has been turned into an error. This
-    function checks that no warning is raised when `f` is executed.
-
-    Parameters
-    ----------
-    f : callable
-       A function that will exhibit no deprecation. It can be used to
-       execute code that should not raise DeprecationWarning.
-
-    """
-    try:
-        f(*args, **kwargs)
-    except DeprecationWarning:
-        raise AssertionError()
-
-
-class TestFloatScalarIndexDeprecation(object):
-    """
-    These test that ``DeprecationWarning`` gets raised when you try to use
-    scalar indices that are not integers e.g. ``a[0.0]``, ``a[1.5, 0]``.
-
-    grep "non-integer scalar" numpy/core/src/multiarray/* for all the calls
-    to ``DEPRECATE()``, except the one inside ``_validate_slice_parameter``
-    which handles slicing (but see also
-    `TestFloatSliceParameterDeprecation`).
-
-    When 2.4 support is dropped ``PyIndex_Check_Or_Unsupported`` should be
-    removed from ``npy_pycompat.h`` and changed to just ``PyIndex_Check``.
+    After deprecation, changes need to be done inside conversion_utils.c
+    in PyArray_PyIntAsIntp and possibly PyArray_IntpConverter.
+    In iterators.c the function slice_GetIndices could be removed in favor
+    of its python equivalent and in mapping.c the function _tuple_of_integers
+    can be simplified (iff ``np.array([1]).__index__()`` is also deprecated).
 
     As for the deprecation time-frame: via Ralf Gommers,
 
@@ -72,31 +134,26 @@ class TestFloatScalarIndexDeprecation(object):
     version after 1.8 will be 6 months or 2 years after. I'd say 2
     years is reasonable."
 
-    I interpret this to mean 2 years after the 1.8 release.
+    I interpret this to mean 2 years after the 1.8 release. Possibly
+    giving a PendingDeprecationWarning before that (which is visible
+    by default)
 
     """
+    message = "using a non-integer number instead of an integer " \
+              "will result in an error in the future"
 
-    def setUp(self):
-        warnings.filterwarnings("error", message="non-integer scalar index",
-                                category=DeprecationWarning)
-
-
-    def tearDown(self):
-        warnings.filterwarnings("default", message="non-integer scalar index",
-                                category=DeprecationWarning)
-
-
-    def test_deprecations(self):
+    def test_indexing(self):
         a = np.array([[[5]]])
+        def assert_deprecated(*args, **kwargs):
+            self.assert_deprecated(*args, exceptions=(IndexError,), **kwargs)
 
-        assert_deprecated(lambda: a[0.0])
         assert_deprecated(lambda: a[0.0])
         assert_deprecated(lambda: a[0, 0.0])
         assert_deprecated(lambda: a[0.0, 0])
         assert_deprecated(lambda: a[0.0, :])
         assert_deprecated(lambda: a[:, 0.0])
         assert_deprecated(lambda: a[:, 0.0, :])
-        assert_deprecated(lambda: a[0.0, :, :])
+        assert_deprecated(lambda: a[0.0, :, :], num=2) # [1]
         assert_deprecated(lambda: a[0, 0, 0.0])
         assert_deprecated(lambda: a[0.0, 0, 0])
         assert_deprecated(lambda: a[0, 0.0, 0])
@@ -106,18 +163,21 @@ class TestFloatScalarIndexDeprecation(object):
         assert_deprecated(lambda: a[-1.4, :])
         assert_deprecated(lambda: a[:, -1.4])
         assert_deprecated(lambda: a[:, -1.4, :])
-        assert_deprecated(lambda: a[-1.4, :, :])
+        assert_deprecated(lambda: a[-1.4, :, :], num=2) # [1]
         assert_deprecated(lambda: a[0, 0, -1.4])
         assert_deprecated(lambda: a[-1.4, 0, 0])
         assert_deprecated(lambda: a[0, -1.4, 0])
+        # [1] These are duplicate because of the _tuple_of_integers quick check
+
         # Test that the slice parameter deprecation warning doesn't mask
         # the scalar index warning.
-        assert_deprecated(lambda: a[0.0:, 0.0])
-        assert_deprecated(lambda: a[0.0:, 0.0, :])
+        assert_deprecated(lambda: a[0.0:, 0.0], num=2)
+        assert_deprecated(lambda: a[0.0:, 0.0, :], num=2)
 
 
-    def test_valid_not_deprecated(self):
+    def test_valid_indexing(self):
         a = np.array([[[5]]])
+        assert_not_deprecated = self.assert_not_deprecated
 
         assert_not_deprecated(lambda: a[np.array([0])])
         assert_not_deprecated(lambda: a[[0, 0]])
@@ -126,40 +186,10 @@ class TestFloatScalarIndexDeprecation(object):
         assert_not_deprecated(lambda: a[:, :, :])
 
 
-class TestFloatSliceParameterDeprecation(object):
-    """
-    These test that ``DeprecationWarning`` gets raised when you try to use
-    non-integers for slicing, e.g. ``a[0.0:5]``, ``a[::1.5]``, etc.
-
-    When this is changed to an error, ``slice_GetIndices`` and
-    ``_validate_slice_parameter`` should probably be removed. Calls to
-    ``slice_GetIndices`` should be replaced by the standard Python API call
-    ``PySlice_GetIndicesEx``, since ``slice_GetIndices`` implements the
-    same thing but with int coercion and Python < 2.3 backwards
-    compatibility (which we have long since dropped as of this writing).
-
-    As for the deprecation time-frame: via Ralf Gommers,
-
-    "Hard to put that as a version number, since we don't know if the
-    version after 1.8 will be 6 months or 2 years after. I'd say 2 years is
-    reasonable."
-
-    I interpret this to mean 2 years after the 1.8 release.
-
-    """
-
-    def setUp(self):
-        warnings.filterwarnings("error", message="non-integer slice param",
-                                category=DeprecationWarning)
-
-
-    def tearDown(self):
-        warnings.filterwarnings("default", message="non-integer slice param",
-                                category=DeprecationWarning)
-
-
-    def test_deprecations(self):
+    def test_slicing(self):
         a = np.array([[5]])
+        def assert_deprecated(*args, **kwargs):
+            self.assert_deprecated(*args, exceptions=(IndexError,), **kwargs)
 
         # start as float.
         assert_deprecated(lambda: a[0.0:])
@@ -180,18 +210,19 @@ class TestFloatSliceParameterDeprecation(object):
         assert_deprecated(lambda: a[::5.0, :])
         assert_deprecated(lambda: a[:, 0:4:2.0])
         # mixed.
-        assert_deprecated(lambda: a[1.0:2:2.0])
-        assert_deprecated(lambda: a[1.0::2.0])
-        assert_deprecated(lambda: a[0:, :2.0:2.0])
-        assert_deprecated(lambda: a[1.0:1:4.0, :0])
-        assert_deprecated(lambda: a[1.0:5.0:5.0, :])
-        assert_deprecated(lambda: a[:, 0.4:4.0:2.0])
+        assert_deprecated(lambda: a[1.0:2:2.0], num=2)
+        assert_deprecated(lambda: a[1.0::2.0], num=2)
+        assert_deprecated(lambda: a[0:, :2.0:2.0], num=2)
+        assert_deprecated(lambda: a[1.0:1:4.0, :0], num=2)
+        assert_deprecated(lambda: a[1.0:5.0:5.0, :], num=3)
+        assert_deprecated(lambda: a[:, 0.4:4.0:2.0], num=3)
         # should still get the DeprecationWarning if step = 0.
-        assert_deprecated(lambda: a[::0.0])
+        assert_deprecated(lambda: a[::0.0], function_fails=True)
 
 
-    def test_valid_not_deprecated(self):
+    def test_valid_slicing(self):
         a = np.array([[[5]]])
+        assert_not_deprecated = self.assert_not_deprecated
 
         assert_not_deprecated(lambda: a[::])
         assert_not_deprecated(lambda: a[0:])
@@ -201,6 +232,58 @@ class TestFloatSliceParameterDeprecation(object):
         assert_not_deprecated(lambda: a[1::2])
         assert_not_deprecated(lambda: a[:2:2])
         assert_not_deprecated(lambda: a[1:2:2])
+
+
+    def test_non_integer_argument_deprecations(self):
+        a = np.array([[5]])
+
+        self.assert_deprecated(np.reshape, args=(a, (1., 1., -1)), num=2)
+        self.assert_deprecated(np.reshape, args=(a, (np.array(1.), -1)))
+        self.assert_deprecated(np.take, args=(a, [0], 1.))
+        self.assert_deprecated(np.take, args=(a, [0], np.float64(1.)))
+
+
+class TestBooleanArgumentDeprecation(_DeprecationTestCase):
+    """This tests that using a boolean as integer argument/indexing is
+    deprecated.
+
+    This should be kept in sync with TestFloatNonIntegerArgumentDeprecation
+    and like it is handled in PyArray_PyIntAsIntp.
+    """
+    message = "using a boolean instead of an integer " \
+              "will result in an error in the future"
+
+    def test_bool_as_int_argument(self):
+        a = np.array([[[1]]])
+
+        self.assert_deprecated(np.reshape, args=(a, (True, -1)))
+        self.assert_deprecated(np.take, args=(a, [0], False))
+        self.assert_deprecated(lambda: a[False:True:True], exceptions=IndexError, num=3)
+        self.assert_deprecated(lambda: a[False,0], exceptions=IndexError)
+        self.assert_deprecated(lambda: a[False,0,0], exceptions=IndexError)
+
+
+class TestArrayToIndexDeprecation(_DeprecationTestCase):
+    """This tests that creating an an index from an array is deprecated
+    if the array is not 0d.
+
+    This can probably be deprecated somewhat faster then the integer
+    deprecations. The deprecation period started with NumPy 1.8.
+    For deprecation this needs changing of array_index in number.c
+    """
+    message = "converting an array with ndim \> 0 to an index will result " \
+              "in an error in the future"
+
+    def test_array_to_index_deprecation(self):
+        # This drops into the non-integer deprecation, which is ignored here,
+        # so no exception is expected. The raising is effectively tested above.
+        a = np.array([[[1]]])
+
+        self.assert_deprecated(operator.index, args=(np.array([1]),))
+        self.assert_deprecated(np.reshape, args=(a, (a, -1)), exceptions=())
+        self.assert_deprecated(np.take, args=(a, [0], a), exceptions=())
+        # Check slicing. Normal indexing checks arrays specifically.
+        self.assert_deprecated(lambda: a[a:a:a], exceptions=(), num=3)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -126,7 +126,7 @@ class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
     in PyArray_PyIntAsIntp and possibly PyArray_IntpConverter.
     In iterators.c the function slice_GetIndices could be removed in favor
     of its python equivalent and in mapping.c the function _tuple_of_integers
-    can be simplified (iff ``np.array([1]).__index__()`` is also deprecated).
+    can be simplified (if ``np.array([1]).__index__()`` is also deprecated).
 
     As for the deprecation time-frame: via Ralf Gommers,
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -255,6 +255,10 @@ class TestBooleanArgumentDeprecation(_DeprecationTestCase):
         a = np.array([[[1]]])
 
         self.assert_deprecated(np.reshape, args=(a, (True, -1)))
+        self.assert_deprecated(np.reshape, args=(a, (np.bool_(True), -1)))
+        # Note that operator.index(np.array(True)) does not work, a boolean
+        # array is thus also deprecated, but not with the same message:
+        assert_raises(TypeError, operator.index, np.array(True))
         self.assert_deprecated(np.take, args=(a, [0], False))
         self.assert_deprecated(lambda: a[False:True:True], exceptions=IndexError, num=3)
         self.assert_deprecated(lambda: a[False,0], exceptions=IndexError)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -90,18 +90,17 @@ class _DeprecationTestCase(object):
             raise AssertionError("%i warnings found but %i expected"
                                                         % (len(self.log), num))
 
-        warnings.filterwarnings("error", message=self.message,
-                                    category=DeprecationWarning)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", message=self.message,
+                                        category=DeprecationWarning)
 
-        try:
-            function(*args, **kwargs)
-            if exceptions != tuple():
-                raise AssertionError("No error raised during function call")
-        except exceptions:
-            if exceptions == tuple():
-                raise AssertionError("Error raised during function call")
-        finally:
-            warnings.filters.pop(0)
+            try:
+                function(*args, **kwargs)
+                if exceptions != tuple():
+                    raise AssertionError("No error raised during function call")
+            except exceptions:
+                if exceptions == tuple():
+                    raise AssertionError("Error raised during function call")
 
 
     def assert_not_deprecated(self, function, args=(), kwargs={}):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -6,13 +6,12 @@ to document how deprecations should eventually be turned into errors.
 from __future__ import division, absolute_import, print_function
 
 import sys
-
+import operator
 import warnings
 from nose.plugins.skip import SkipTest
 
 import numpy as np
 from numpy.testing import dec, run_module_suite, assert_raises
-import operator
 
 
 class _DeprecationTestCase(object):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -73,8 +73,9 @@ class TestIndexing(TestCase):
                       [7, 8, 9]])
 
         # Python boolean converts to integer
-        assert_equal(a[True], a[1])
-        assert_equal(a[False], a[0])
+        # These are being deprecated (and test in test_deprecations)
+        #assert_equal(a[True], a[1])
+        #assert_equal(a[False], a[0])
 
         # Same with NumPy boolean scalar
         assert_equal(a[np.array(True)], a[1])

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -157,7 +157,7 @@ class nd_grid(object):
                     size.append(int(abs(step)))
                     typ = float
                 else:
-                    size.append(math.ceil((key[k].stop - start)/(step*1.0)))
+                    size.append(int(math.ceil((key[k].stop - start)/(step*1.0))))
                 if isinstance(step, float) or \
                     isinstance(start, float) or \
                     isinstance(key[k].stop, float):

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -830,5 +830,5 @@ def tile(A, reps):
         dim_in = shape[i]
         dim_out = dim_in*nrep
         shape[i] = dim_out
-        n //= max(dim_in,1)
+        n //= max(dim_in, 1)
     return c.reshape(shape)

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -830,5 +830,5 @@ def tile(A, reps):
         dim_in = shape[i]
         dim_out = dim_in*nrep
         shape[i] = dim_out
-        n /= max(dim_in,1)
+        n //= max(dim_in,1)
     return c.reshape(shape)

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -74,7 +74,7 @@ class TestRegression(TestCase):
             np.random.seed(i)
             m.seed(4321)
             # If m.state is not honored, the result will change
-            assert_array_equal(m.choice(10, size=10, p=np.ones(10.)/10), res)
+            assert_array_equal(m.choice(10, size=10, p=np.ones(10)/10), res)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -74,7 +74,7 @@ class TestRegression(TestCase):
             np.random.seed(i)
             m.seed(4321)
             # If m.state is not honored, the result will change
-            assert_array_equal(m.choice(10, size=10, p=np.ones(10)/10), res)
+            assert_array_equal(m.choice(10, size=10, p=np.ones(10)/10.), res)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is gh-2891 rebased (with slight modifications in mapping.c). So basically all things said there still apply. To wrap it up, this deprecates non-integer usage almost everywhere (which means strides, shapes, axes, indices, slices), by deprecating it in PyArray_PyIntAsIntp.

Also deprecates `__index__` for ndim > 0.

I did go a bit further and deprecated python bools, too. If this starts bugging someone, that should maybe be made indexing specific.

I guess this might still need some love. The deprecation tests are not too great, but when errors get replaced it needs to test both warning and error. And they change, because previously they raised DeprecationWarnings (as errors) and now these are usually replaced.
