### PR TITLE
2to3: Apply zip fixer.

### DIFF
--- a/doc/sphinxext/numpydoc/compiler_unparse.py
+++ b/doc/sphinxext/numpydoc/compiler_unparse.py
@@ -18,7 +18,7 @@ from compiler.ast import Const, Name, Tuple, Div, Mul, Sub, Add
 if sys.version_info[0] >= 3:
     from io import StringIO
 else:
-    from io import StringIO
+    from StringIO import StringIO
 
 def unparse(ast, single_line_functions=False):
     s = StringIO()
@@ -106,13 +106,13 @@ class UnparseCompilerAst:
             if i != len(t.nodes)-1:
                 self._write(") and (")
         self._write(")")
-               
+
     def _AssAttr(self, t):
         """ Handle assigning an attribute of an object
         """
         self._dispatch(t.expr)
         self._write('.'+t.attrname)
- 
+
     def _Assign(self, t):
         """ Expression Assignment such as "a = 1".
 
@@ -150,36 +150,36 @@ class UnparseCompilerAst:
     def _AugAssign(self, t):
         """ +=,-=,*=,/=,**=, etc. operations
         """
-        
+
         self._fill()
         self._dispatch(t.node)
         self._write(' '+t.op+' ')
         self._dispatch(t.expr)
         if not self._do_indent:
             self._write(';')
-            
+
     def _Bitand(self, t):
         """ Bit and operation.
         """
-        
+
         for i, node in enumerate(t.nodes):
             self._write("(")
             self._dispatch(node)
             self._write(")")
             if i != len(t.nodes)-1:
                 self._write(" & ")
-                
+
     def _Bitor(self, t):
         """ Bit or operation
         """
-        
+
         for i, node in enumerate(t.nodes):
             self._write("(")
             self._dispatch(node)
             self._write(")")
             if i != len(t.nodes)-1:
                 self._write(" | ")
-                
+
     def _CallFunc(self, t):
         """ Function call.
         """
@@ -254,7 +254,7 @@ class UnparseCompilerAst:
             self._write(name)
             if asname is not None:
                 self._write(" as "+asname)
-                
+
     def _Function(self, t):
         """ Handle function definitions
         """

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -43,10 +43,10 @@ class TestLongdouble(TestCase):
 
 class TestIinfo(TestCase):
     def test_basic(self):
-        dts = zip(['i1', 'i2', 'i4', 'i8',
+        dts = list(zip(['i1', 'i2', 'i4', 'i8',
                    'u1', 'u2', 'u4', 'u8'],
                   [np.int8, np.int16, np.int32, np.int64,
-                   np.uint8, np.uint16, np.uint32, np.uint64])
+                   np.uint8, np.uint16, np.uint32, np.uint64]))
         for dt1, dt2 in dts:
             assert_equal(iinfo(dt1).min, iinfo(dt2).min)
             assert_equal(iinfo(dt1).max, iinfo(dt2).max)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1572,7 +1572,7 @@ def test_iter_buffering_delayed_alloc():
     assert_equal(i[0], 0)
     i[1] = 1
     assert_equal(i[0:2], [0,1])
-    assert_equal([[x[0][()],x[1][()]] for x in i], zip(list(range(6)), [1]*6))
+    assert_equal([[x[0][()],x[1][()]] for x in i], list(zip(range(6), [1]*6)))
 
 def test_iter_buffered_cast_simple():
     # Test that buffering can handle a simple cast

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -20,7 +20,7 @@ class TestUfunc(TestCase):
     def test_reduceat_shifting_sum(self) :
         L = 6
         x = np.arange(L)
-        idx = np.array(zip(np.arange(L-2), np.arange(L-2)+2)).ravel()
+        idx = np.array(list(zip(np.arange(L - 2), np.arange(L - 2) + 2))).ravel()
         assert_array_equal(np.add.reduceat(x,idx)[::2], [1,3,5,7])
 
     def test_generic_loops(self) :

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -855,7 +855,7 @@ def easy_dtype(ndtype, names=None, defaultfmt="f%i", **validationargs):
             if nbtypes == 0:
                 formats = tuple([ndtype.type] * len(names))
                 names = validate(names, defaultfmt=defaultfmt)
-                ndtype = np.dtype(zip(names, formats))
+                ndtype = np.dtype(list(zip(names, formats)))
             # Structured dtype: just validate the names as needed
             else:
                 ndtype.names = validate(names, nbfields=nbtypes,

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1664,11 +1664,11 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     #        rows[i] = tuple([convert(val)
     #                         for (convert, val) in zip(conversionfuncs, vals)])
     if loose:
-        rows = zip(*[[converter._loose_call(_r) for _r in map(itemgetter(i), rows)]
-                     for (i, converter) in enumerate(converters)])
+        rows = list(zip(*[[converter._loose_call(_r) for _r in map(itemgetter(i), rows)]
+                     for (i, converter) in enumerate(converters)]))
     else:
-        rows = zip(*[[converter._strict_call(_r) for _r in map(itemgetter(i), rows)]
-                     for (i, converter) in enumerate(converters)])
+        rows = list(zip(*[[converter._strict_call(_r) for _r in map(itemgetter(i), rows)]
+                     for (i, converter) in enumerate(converters)]))
     # Reset the dtype
     data = rows
     if dtype is None:
@@ -1693,8 +1693,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                     mdtype = [(defaultfmt % i, np.bool)
                               for (i, dt) in enumerate(column_types)]
         else:
-            ddtype = zip(names, column_types)
-            mdtype = zip(names, [np.bool] * len(column_types))
+            ddtype = list(zip(names, column_types))
+            mdtype = list(zip(names, [np.bool] * len(column_types)))
         output = np.array(data, dtype=ddtype)
         if usemask:
             outputmask = np.array(masks, dtype=mdtype)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -61,8 +61,8 @@ class TestSetOps(TestCase):
 
         # test for structured arrays
         dt = [('', 'i'), ('', 'i')]
-        aa = np.array(zip(a,a), dt)
-        bb = np.array(zip(b,b), dt)
+        aa = np.array(list(zip(a,a)), dt)
+        bb = np.array(list(zip(b,b)), dt)
         check_all(aa, bb, i1, i2, dt)
 
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -517,7 +517,7 @@ class TestLoadTxt(TestCase):
         c = TextIO(data)
         names = ['stid', 'temp']
         dtypes = ['S4', 'f8']
-        arr = np.loadtxt(c, usecols=(0, 2), dtype=zip(names, dtypes))
+        arr = np.loadtxt(c, usecols=(0, 2), dtype=list(zip(names, dtypes)))
         assert_equal(arr['stid'], [b"JOE", b"BOB"])
         assert_equal(arr['temp'], [25.3, 27.9])
 
@@ -1119,7 +1119,7 @@ M   33  21.99
         data = TextIO("JOE 70.1 25.3\nBOB 60.5 27.9")
         names = ['stid', 'temp']
         dtypes = ['S4', 'f8']
-        test = np.ndfromtxt(data, usecols=(0, 2), dtype=zip(names, dtypes))
+        test = np.ndfromtxt(data, usecols=(0, 2), dtype=list(zip(names, dtypes)))
         assert_equal(test['stid'], [b"JOE", b"BOB"])
         assert_equal(test['temp'], [25.3, 27.9])
 

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -543,11 +543,11 @@ class TestStackArrays(TestCase):
 
 class TestJoinBy(TestCase):
     def setUp(self):
-        self.a = np.array(zip(np.arange(10), np.arange(50, 60),
-                        np.arange(100, 110)),
+        self.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
+                        np.arange(100, 110))),
                         dtype=[('a', int), ('b', int), ('c', int)])
-        self.b = np.array(zip(np.arange(5, 15), np.arange(65, 75),
-                        np.arange(100, 110)),
+        self.b = np.array(list(zip(np.arange(5, 15), np.arange(65, 75),
+                        np.arange(100, 110))),
                         dtype=[('a', int), ('b', int), ('d', int)])
     #
     def test_inner_join(self):
@@ -620,11 +620,11 @@ class TestJoinBy(TestCase):
 class TestJoinBy2(TestCase):
     @classmethod
     def setUp(cls):
-        cls.a = np.array(zip(np.arange(10), np.arange(50, 60),
-                        np.arange(100, 110)),
+        cls.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
+                        np.arange(100, 110))),
                         dtype=[('a', int), ('b', int), ('c', int)])
-        cls.b = np.array(zip(np.arange(10), np.arange(65, 75),
-                        np.arange(100, 110)),
+        cls.b = np.array(list(zip(np.arange(10), np.arange(65, 75),
+                        np.arange(100, 110))),
                         dtype=[('a', int), ('b', int), ('d', int)])
 
     def test_no_r1postfix(self):
@@ -660,12 +660,12 @@ class TestJoinBy2(TestCase):
         assert_equal(test, control)
 
     def test_two_keys_two_vars(self):
-        a = np.array(zip(np.tile([10,11],5),np.repeat(np.arange(5),2),
-                        np.arange(50, 60), np.arange(10,20)),
+        a = np.array(list(zip(np.tile([10,11],5),np.repeat(np.arange(5),2),
+                        np.arange(50, 60), np.arange(10,20))),
                         dtype=[('k', int), ('a', int), ('b', int),('c',int)])
 
-        b = np.array(zip(np.tile([10,11],5),np.repeat(np.arange(5),2),
-                        np.arange(65, 75), np.arange(0,10)),
+        b = np.array(list(zip(np.tile([10,11],5),np.repeat(np.arange(5),2),
+                        np.arange(65, 75), np.arange(0,10))),
                         dtype=[('k', int), ('a', int), ('b', int), ('c',int)])
 
         control = np.array([(10, 0, 50, 65, 10, 0), (11, 0, 51, 66, 11, 1),

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -508,7 +508,7 @@ def fromarrays(arraylist, dtype=None, shape=None, formats=None,
                            dtype=dtype, shape=shape, formats=formats,
                            names=names, titles=titles, aligned=aligned,
                            byteorder=byteorder).view(mrecarray)
-    _array._mask.flat = zip(*masklist)
+    _array._mask.flat = list(zip(*masklist))
     if fill_value is not None:
         _array.fill_value = fill_value
     return _array

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -140,8 +140,8 @@ class TestMaskedArray(TestCase):
 
     def test_concatenate_flexible(self):
         "Tests the concatenation on flexible arrays."
-        data = masked_array(zip(np.random.rand(10),
-                                np.arange(10)),
+        data = masked_array(list(zip(np.random.rand(10),
+                                np.arange(10))),
                             dtype=[('a', float), ('b', int)])
         #
         test = concatenate([data[:5], data[5:]])
@@ -1500,7 +1500,7 @@ class TestFillingValues(TestCase):
         "Test setting fill_value on individual fields"
         ndtype = [('a', int), ('b', int)]
         # Explicit fill_value
-        a = array(zip([1, 2, 3], [4, 5, 6]),
+        a = array(list(zip([1, 2, 3], [4, 5, 6])),
                   fill_value=(-999, -999), dtype=ndtype)
         f = a._fill_value
         aa = a['a']
@@ -1510,7 +1510,7 @@ class TestFillingValues(TestCase):
         a.fill_value['b'] = -10
         assert_equal(tuple(a.fill_value), (10, -10))
         # Implicit fill_value
-        t = array(zip([1, 2, 3], [4, 5, 6]), dtype=[('a', int), ('b', int)])
+        t = array(list(zip([1, 2, 3], [4, 5, 6])), dtype=[('a', int), ('b', int)])
         tt = t['a']
         tt.set_fill_value(10)
         assert_equal(tt._fill_value, np.array(10))
@@ -2512,9 +2512,9 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(xlist[2], [8, 9, None, 11])
         assert_equal(xlist, ctrl)
         # ... on structured array w/ masked records
-        x = array(zip([1, 2, 3],
+        x = array(list(zip([1, 2, 3],
                       [1.1, 2.2, 3.3],
-                      ['one', 'two', 'thr']),
+                      ['one', 'two', 'thr'])),
                   dtype=[('a', int), ('b', float), ('c', '|S8')])
         x[-1] = masked
         assert_equal(x.tolist(),
@@ -3384,7 +3384,7 @@ class TestMaskedFields(TestCase):
         ddtype = [('a', int), ('b', float), ('c', '|S8')]
         mdtype = [('a', bool), ('b', bool), ('c', bool)]
         mask = [0, 1, 0, 0, 1]
-        base = array(zip(ilist, flist, slist), mask=mask, dtype=ddtype)
+        base = array(list(zip(ilist, flist, slist)), mask=mask, dtype=ddtype)
         self.data = dict(base=base, mask=mask, ddtype=ddtype, mdtype=mdtype)
 
     def test_set_records_masks(self):
@@ -3461,7 +3461,7 @@ class TestMaskedFields(TestCase):
     #
     def test_view(self):
         "Test view w/ flexible dtype"
-        iterator = zip(np.arange(10), np.random.rand(10))
+        iterator = list(zip(np.arange(10), np.random.rand(10)))
         data = np.array(iterator)
         a = array(iterator, dtype=[('a', float), ('b', float)])
         a.mask[0] = (1, 0)
@@ -3481,9 +3481,9 @@ class TestMaskedFields(TestCase):
     #
     def test_getitem(self):
         ndtype = [('a', float), ('b', float)]
-        a = array(zip(np.random.rand(10), np.arange(10)), dtype=ndtype)
-        a.mask = np.array(zip([0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-                              [1, 0, 0, 0, 0, 0, 0, 0, 1, 0]),
+        a = array(list(zip(np.random.rand(10), np.arange(10))), dtype=ndtype)
+        a.mask = np.array(list(zip([0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+                              [1, 0, 0, 0, 0, 0, 0, 0, 1, 0])),
                           dtype=[('a', bool), ('b', bool)])
         # No mask
         self.assertTrue(isinstance(a[1], MaskedArray))
@@ -3501,7 +3501,7 @@ class TestMaskedFields(TestCase):
 class TestMaskedView(TestCase):
     #
     def setUp(self):
-        iterator = zip(np.arange(10), np.random.rand(10))
+        iterator = list(zip(np.arange(10), np.random.rand(10)))
         data = np.array(iterator)
         a = array(iterator, dtype=[('a', float), ('b', float)])
         a.mask[0] = (1, 0)

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -360,10 +360,10 @@ class TestView(TestCase):
     def setUp(self):
         (a, b) = (np.arange(10), np.random.rand(10))
         ndtype = [('a',np.float), ('b',np.float)]
-        arr = np.array(zip(a,b), dtype=ndtype)
+        arr = np.array(list(zip(a,b)), dtype=ndtype)
         rec = arr.view(np.recarray)
         #
-        marr = ma.array(zip(a,b), dtype=ndtype, fill_value=(-9., -99.))
+        marr = ma.array(list(zip(a,b)), dtype=ndtype, fill_value=(-9., -99.))
         mrec = fromarrays([a,b], dtype=ndtype, fill_value=(-9., -99.))
         mrec.mask[3] = (False, True)
         self.data = (mrec, a, b, arr)
@@ -380,7 +380,7 @@ class TestView(TestCase):
         ntype = (np.float, 2)
         test = mrec.view(ntype)
         self.assertTrue(isinstance(test, ma.MaskedArray))
-        assert_equal(test, np.array(zip(a,b), dtype=np.float))
+        assert_equal(test, np.array(list(zip(a,b)), dtype=np.float))
         self.assertTrue(test[3,1] is ma.masked)
     #
     def test_view_flexible_type(self):

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -94,7 +94,7 @@ FIXES_TO_SKIP = [
 #    'ws_comma',
     'xrange',
     'xreadlines',
-#    'zip',
+    'zip',
 ]
 
 skip_fixes= []


### PR DESCRIPTION
In Python 3 zip returns an iterator instead of a list. Consequently, in
places where an iterator won't do it must be enclosed in list(...).
Lists instead of iterators are also used in array constructors as using
iterators there usually results in an object array containing an
iterator object.

Closes #3094
