### PR TITLE
2to3: Skip isinstance fixer.

### DIFF
--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -64,7 +64,7 @@ FIXES_TO_SKIP = [
     'imports2',
     'input',
     'intern',
-#    'isinstance',
+    'isinstance',
     'itertools',
     'itertools_imports',
     'long',


### PR DESCRIPTION
The isinstance fixer removes duplicate types in the second argument of
isinstance(). For example, isinstance(x, (int, int)) is converted to
isinstance(x, (int)). This would certainly apply if we let the long
fixer replace long by int, but as is it does nothing.

Duplicate entries are supposedly deprecated in Python 3, I'm not sure
why or how, but it does not seem to be a problem at this point. If it
ever becomes so, we can deal with it then.

Closes #3065
