### PR TITLE
2to3: Apply urllib fixer.

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -275,8 +275,12 @@ class DataSource (object):
         """
         # We import these here because importing urllib2 is slow and
         # a significant fraction of numpy's total import time.
-        from urllib2 import urlopen
-        from urllib2 import URLError
+        if sys.version_info[0] >= 3:
+            from urllib.request import urlopen
+            from urllib.error import URLError
+        else:
+            from urllib2 import urlopen
+            from urllib2 import URLError
 
         upath = self.abspath(path)
 
@@ -421,8 +425,12 @@ class DataSource (object):
         """
         # We import this here because importing urllib2 is slow and
         # a significant fraction of numpy's total import time.
-        from urllib2 import urlopen
-        from urllib2 import URLError
+        if sys.version_info[0] >= 3:
+            from urllib.request import urlopen
+            from urllib.error import URLError
+        else:
+            from urllib2 import urlopen
+            from urllib2 import URLError
 
         # Test local path
         if os.path.exists(path):

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -1,20 +1,21 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import urllib2
 import sys
 import numpy.lib._datasource as datasource
 from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
 from shutil import rmtree
-from urllib2 import URLError
 from numpy.compat import asbytes
 from numpy.testing import *
 
-
 if sys.version_info[0] >= 3:
+    import urllib.request as urllib_request
     from urllib.parse import urlparse
+    from urllib.error import URLError
 else:
+    import urllib2 as urllib_request
     from urlparse import urlparse
+    from urllib2 import URLError
 
 def urlopen_stub(url, data=None):
     '''Stub to replace urlopen for testing.'''
@@ -24,14 +25,17 @@ def urlopen_stub(url, data=None):
     else:
         raise URLError('Name or service not known')
 
+# setup and teardown
 old_urlopen = None
+
 def setup():
     global old_urlopen
-    old_urlopen = urllib2.urlopen
-    urllib2.urlopen = urlopen_stub
+
+    old_urlopen = urllib_request.urlopen
+    urllib_request.urlopen = urlopen_stub
 
 def teardown():
-    urllib2.urlopen = old_urlopen
+    urllib_request.urlopen = old_urlopen
 
 # A valid website for more robust testing
 http_path = 'http://www.google.com/'

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -90,7 +90,7 @@ FIXES_TO_SKIP = [
     'tuple_params',
 #    'types',
 #    'unicode',
-#    'urllib',
+    'urllib',
 #    'ws_comma',
     'xrange',
     'xreadlines',


### PR DESCRIPTION
Various functions have been moved around in the stdlib for Python 3,
this fixes that up so that the code is valid in both Python 2 and
Python 3.

Note: monkey patching the stlib urlopen for testing looks a bit hokey
to me, but I don't see an easier, more reliable way to do the test.

Closes #3090.
