### PR TITLE
2to3: Apply next fixer.

### DIFF
--- a/doc/sphinxext/numpydoc/comment_eater.py
+++ b/doc/sphinxext/numpydoc/comment_eater.py
@@ -106,7 +106,7 @@ class CommentBlocker(object):
 
     def new_comment(self, string, start, end, line):
         """ Possibly add a new comment.
-        
+
         Only adds a new comment if this comment is the only thing on the line.
         Otherwise, it extends the noncomment block.
         """

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1,12 +1,13 @@
 from __future__ import division, absolute_import, print_function
 
+import sys, warnings
+
 import numpy as np
 from numpy import array, arange, nditer, all
 from numpy.compat import asbytes
 from numpy.testing import *
-import sys, warnings
 
-import warnings
+
 
 def iter_multi_index(i):
     ret = []
@@ -1210,7 +1211,8 @@ def test_iter_copy():
     assert_equal([x[()] for x in i], [x[()] for x in j])
 
     i.iterrange = (2,18)
-    i.next(); i.next()
+    next(i)
+    next(i)
     j = i.copy()
     assert_equal([x[()] for x in i], [x[()] for x in j])
 
@@ -2528,14 +2530,14 @@ def test_0d_iter():
     # Basic test for iteration of 0-d arrays:
     i = nditer([2, 3], ['multi_index'], [['readonly']]*2)
     assert_equal(i.ndim, 0)
-    assert_equal(i.next(), (2, 3))
+    assert_equal(next(i), (2, 3))
     assert_equal(i.multi_index, ())
     assert_equal(i.iterindex, 0)
-    assert_raises(StopIteration, i.next)
+    assert_raises(StopIteration, next, i)
     # test reset:
     i.reset()
-    assert_equal(i.next(), (2, 3))
-    assert_raises(StopIteration, i.next)
+    assert_equal(next(i), (2, 3))
+    assert_raises(StopIteration, next, i)
 
     # test forcing to 0-d
     i = nditer(np.arange(5), ['multi_index'], [['readonly']], op_axes=[()])
@@ -2548,7 +2550,7 @@ def test_0d_iter():
     a = np.array(0.5, dtype='f4')
     i = nditer(a, ['buffered','refs_ok'], ['readonly'],
                     casting='unsafe', op_dtypes=sdt)
-    vals = i.next()
+    vals = next(i)
     assert_equal(vals['a'], 0.5)
     assert_equal(vals['b'], 0)
     assert_equal(vals['c'], [[(0.5)]*3]*2)

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -487,7 +487,7 @@ class ndenumerate(object):
     def __init__(self, arr):
         self.iter = asarray(arr).flat
 
-    def next(self):
+    def __next__(self):
         """
         Standard iterator method, returns the index tuple and array value.
 
@@ -499,10 +499,13 @@ class ndenumerate(object):
             The array element of the current iteration.
 
         """
-        return self.iter.coords, self.iter.next()
+        return self.iter.coords, next(self.iter)
 
     def __iter__(self):
         return self
+
+    next = __next__
+
 
 class ndindex(object):
     """
@@ -532,7 +535,7 @@ class ndindex(object):
     (2, 0, 0)
     (2, 1, 0)
 
-    """     
+    """
     def __init__(self, *shape):
         if len(shape) == 1 and isinstance(shape[0], tuple):
             shape = shape[0]
@@ -541,16 +544,16 @@ class ndindex(object):
 
     def __iter__(self):
         return self
-        
+
     def ndincr(self):
         """
         Increment the multi-dimensional index by one.
 
         This method is for backward compatibility only: do not use.
         """
-        self.next()
+        next(self)
 
-    def next(self):
+    def __next__(self):
         """
         Standard iterator method, updates the index and returns the index tuple.
 
@@ -560,8 +563,10 @@ class ndindex(object):
             Returns a tuple containing the indices of the current iteration.
 
         """
-        self._it.next()
+        next(self._it)
         return self._it.multi_index
+
+    next =  __next__
 
 
 # You can do all this with slice() plus a few special objects,

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -785,14 +785,14 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
         # Skip the first `skiprows` lines
         for i in range(skiprows):
-            fh.next()
+            next(fh)
 
         # Read until we find a line with some values, and use
         # it to estimate the number of columns, N.
         first_vals = None
         try:
             while not first_vals:
-                first_line = fh.next()
+                first_line = next(fh)
                 first_vals = split_line(first_line)
         except StopIteration:
             # End of lines reached
@@ -1344,13 +1344,13 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         skip_header = skiprows
     # Skip the first `skip_header` rows
     for i in range(skip_header):
-        fhd.next()
+        next(fhd)
 
     # Keep on until we find the first valid values
     first_values = None
     try:
         while not first_values:
-            first_line = fhd.next()
+            first_line = next(fhd)
             if names is True:
                 if comments in first_line:
                     first_line = asbytes('').join(first_line.split(comments)[1:])

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -36,13 +36,18 @@ class LineIterator(object):
         object.__init__(self)
         self.iterable = iter(iterable)
         self.lineno = 0
+
     def __iter__(self):
         return self
-    def next(self):
+
+    def __next__(self):
         self.lineno += 1
-        line = self.iterable.next()
+        line = next(self.iterable)
         line = line.rstrip()
         return line
+
+    next = __next__
+
 
 class PushbackIterator(object):
     """PushbackIterator(iterable)
@@ -59,14 +64,17 @@ class PushbackIterator(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if self.buffer:
             return self.buffer.pop()
         else:
-            return self.iterable.next()
+            return next(self.iterable)
 
     def pushback(self, item):
         self.buffer.append(item)
+
+    next = __next__
+
 
 def fortranSourceLines(fo):
     """Return an iterator over statement lines of a Fortran source file.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2540,7 +2540,7 @@ class MaskedIterator(object):
         if self.maskiter is not None:
             self.maskiter[index] = getmaskarray(value)
 
-    def next(self):
+    def __next__(self):
         """
         Return the next value, or raise StopIteration.
 
@@ -2562,12 +2562,12 @@ class MaskedIterator(object):
         StopIteration
 
         """
-        d = self.dataiter.next()
-        if self.maskiter is not None and self.maskiter.next():
+        d = next(self.dataiter)
+        if self.maskiter is not None and next(self.maskiter):
             d = masked
         return d
 
-
+    next = __next__
 
 
 class MaskedArray(ndarray):

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -72,7 +72,7 @@ FIXES_TO_SKIP = [
     'metaclass',
     'methodattrs',
     'ne',
-#    'next',
+    'next',
     'nonzero',
     'numliterals',
     'operator',


### PR DESCRIPTION
The next builtin has been available since Python 2.6 and allows
`it.next()` to be replaced by `next(it)`. In Python 3 the `next` method
is gone entirely, replaced entirely by the `__next__` method. The next
fixer changes all the `it.next()` calls to the new form and renames the
`next` methods to `__next__`. In order to keep  Numpy code backwards
compatible with Python 2, a `next` method was readded to all the Numpy
iterators after the fixer was run so they all contain both methods. The
presence of the appropriate method could have been made version
dependent, but that looked unduly complicated.

Closes #3072.
