### PR TITLE
2to3: Apply unicode fixer.

### DIFF
--- a/doc/sphinxext/numpydoc/docscrape_sphinx.py
+++ b/doc/sphinxext/numpydoc/docscrape_sphinx.py
@@ -1,9 +1,14 @@
 from __future__ import division, absolute_import, print_function
 
 import re, inspect, textwrap, pydoc
+import sys
 import sphinx
 import collections
 from .docscrape import NumpyDocString, FunctionDoc, ClassDoc
+
+if sys.version_info[0] >= 3:
+    unicode = str
+
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):
@@ -95,11 +100,11 @@ class SphinxDocString(NumpyDocString):
 
             if others:
                 maxlen_0 = max(3, max([len(x[0]) for x in others]))
-                hdr = u"="*maxlen_0 + u"  " + u"="*10
-                fmt = u'%%%ds  %%s  ' % (maxlen_0,)
+                hdr = unicode("=")*maxlen_0 + unicode("  ") + unicode("=")*10
+                fmt = unicode('%%%ds  %%s  ') % (maxlen_0,)
                 out += ['', hdr]
                 for param, param_type, desc in others:
-                    desc = u" ".join(x.strip() for x in desc).strip()
+                    desc = unicode(" ").join(x.strip() for x in desc).strip()
                     if param_type:
                         desc = "(%s) %s" % (param_type, desc)
                     out += [fmt % (param.strip(), desc)]

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -28,6 +28,10 @@ from .docscrape_sphinx import get_doc_object, SphinxDocString
 from sphinx.util.compat import Directive
 import inspect
 
+if sys.version_info[0] >= 3:
+    unicode = str
+
+
 def mangle_docstrings(app, what, name, obj, options, lines,
                       reference_offset=[0]):
 
@@ -36,32 +40,32 @@ def mangle_docstrings(app, what, name, obj, options, lines,
 
     if what == 'module':
         # Strip top title
-        title_re = re.compile(u'^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*',
+        title_re = re.compile(unicode('^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'),
                               re.I|re.S)
-        lines[:] = title_re.sub(u'', u"\n".join(lines)).split(u"\n")
+        lines[:] = title_re.sub(unicode(''), unicode("\n").join(lines)).split(unicode("\n"))
     else:
-        doc = get_doc_object(obj, what, u"\n".join(lines), config=cfg)
+        doc = get_doc_object(obj, what, unicode("\n").join(lines), config=cfg)
         if sys.version_info[0] >= 3:
             doc = str(doc)
         else:
             doc = str(doc).decode('utf-8')
-        lines[:] = doc.split(u"\n")
+        lines[:] = doc.split(unicode("\n"))
 
     if app.config.numpydoc_edit_link and hasattr(obj, '__name__') and \
            obj.__name__:
         if hasattr(obj, '__module__'):
-            v = dict(full_name=u"%s.%s" % (obj.__module__, obj.__name__))
+            v = dict(full_name=unicode("%s.%s") % (obj.__module__, obj.__name__))
         else:
             v = dict(full_name=obj.__name__)
-        lines += [u'', u'.. htmlonly::', u'']
-        lines += [u'    %s' % x for x in
+        lines += [unicode(''), unicode('.. htmlonly::'), unicode('')]
+        lines += [unicode('    %s') % x for x in
                   (app.config.numpydoc_edit_link % v).split("\n")]
 
     # replace reference numbers so that there are no duplicates
     references = []
     for line in lines:
         line = line.strip()
-        m = re.match(u'^.. \\[([a-z0-9_.-])\\]', line, re.I)
+        m = re.match(unicode('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
         if m:
             references.append(m.group(1))
 
@@ -70,14 +74,14 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     if references:
         for i, line in enumerate(lines):
             for r in references:
-                if re.match(u'^\\d+$', r):
-                    new_r = u"R%d" % (reference_offset[0] + int(r))
+                if re.match(unicode('^\\d+$'), r):
+                    new_r = unicode("R%d") % (reference_offset[0] + int(r))
                 else:
-                    new_r = u"%s%d" % (r, reference_offset[0])
-                lines[i] = lines[i].replace(u'[%s]_' % r,
-                                            u'[%s]_' % new_r)
-                lines[i] = lines[i].replace(u'.. [%s]' % r,
-                                            u'.. [%s]' % new_r)
+                    new_r = unicode("%s%d") % (r, reference_offset[0])
+                lines[i] = lines[i].replace(unicode('[%s]_') % r,
+                                            unicode('[%s]_') % new_r)
+                lines[i] = lines[i].replace(unicode('.. [%s]') % r,
+                                            unicode('.. [%s]') % new_r)
 
     reference_offset[0] += len(references)
 
@@ -93,8 +97,8 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     doc = SphinxDocString(pydoc.getdoc(obj))
     if doc['Signature']:
-        sig = re.sub(u"^[^(]*", u"", doc['Signature'])
-        return sig, u''
+        sig = re.sub(unicode("^[^(]*"), unicode(""), doc['Signature'])
+        return sig, unicode('')
 
 def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):

--- a/doc/sphinxext/numpydoc/tests/test_docscrape.py
+++ b/doc/sphinxext/numpydoc/tests/test_docscrape.py
@@ -7,6 +7,10 @@ from numpydoc.docscrape import NumpyDocString, FunctionDoc, ClassDoc
 from numpydoc.docscrape_sphinx import SphinxDocString, SphinxClassDoc
 from nose.tools import *
 
+if sys.version_info[0] >= 3:
+    unicode = str
+
+
 doc_txt = '''\
   numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
@@ -558,9 +562,9 @@ def test_unicode():
     """)
     assert isinstance(doc['Summary'][0], str)
     if sys.version_info[0] >= 3:
-        assert doc['Summary'][0] == u'öäöäöäöäöåååå'
+        assert doc['Summary'][0] == unicode('öäöäöäöäöåååå')
     else:
-        assert doc['Summary'][0] == u'öäöäöäöäöåååå'.encode('utf-8')
+        assert doc['Summary'][0] == unicode('öäöäöäöäöåååå').encode('utf-8')
 
 def test_plot_examples():
     cfg = dict(use_plots=True)

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -5,6 +5,8 @@ from __future__ import division, absolute_import, print_function
 import sys
 import numpy as np
 from numpy.testing import *
+from numpy.compat import unicode
+
 
 class TestArrayRepr(object):
     def test_nan_inf(self):
@@ -156,8 +158,8 @@ def test_unicode_object_array():
     if sys.version_info[0] >= 3:
         expected = "array(['é'], dtype=object)"
     else:
-        expected = "array([u'\\xe9'], dtype=object)"
-    x = np.array([u'\xe9'], dtype=object)
+        expected = "array([unicode('\\xe9')], dtype=object)"
+    x = np.array([unicode('\xe9')], dtype=object)
     assert_equal(repr(x), expected)
 
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -5,8 +5,7 @@ from numpy.core import *
 import numpy as np
 import sys
 from numpy.core.multiarray import _vec_string
-
-from numpy.compat import asbytes, asbytes_nested
+from numpy.compat import asbytes, asbytes_nested, unicode
 
 kw_unicode_true = {'unicode': True} # make 2to3 work properly
 kw_unicode_false = {'unicode': False}
@@ -21,12 +20,12 @@ class TestBasic(TestCase):
                                               ['long', '0123456789']]))
 
     def test_from_object_array_unicode(self):
-        A = np.array([['abc', u'Sigma \u03a3'],
+        A = np.array([['abc', unicode('Sigma \u03a3')],
                       ['long   ', '0123456789']], dtype='O')
         self.assertRaises(ValueError, np.char.array, (A,))
         B = np.char.array(A, **kw_unicode_true)
         assert_equal(B.dtype.itemsize, 10 * np.array('a', 'U').dtype.itemsize)
-        assert_array_equal(B, [['abc', u'Sigma \u03a3'],
+        assert_array_equal(B, [['abc', unicode('Sigma \u03a3')],
                                ['long', '0123456789']])
 
     def test_from_string_array(self):
@@ -47,7 +46,7 @@ class TestBasic(TestCase):
         assert_(C[0,0] == A[0,0])
 
     def test_from_unicode_array(self):
-        A = np.array([['abc', u'Sigma \u03a3'],
+        A = np.array([['abc', unicode('Sigma \u03a3')],
                       ['long   ', '0123456789']])
         assert_equal(A.dtype.type, np.unicode_)
         B = np.char.array(A)
@@ -64,7 +63,7 @@ class TestBasic(TestCase):
 
     def test_unicode_upconvert(self):
         A = np.char.array(['abc'])
-        B = np.char.array([u'\u03a3'])
+        B = np.char.array([unicode('\u03a3')])
         assert_(issubclass((A + B).dtype.type, np.unicode_))
 
     def test_from_string(self):
@@ -74,7 +73,7 @@ class TestBasic(TestCase):
         assert_(issubclass(A.dtype.type, np.string_))
 
     def test_from_unicode(self):
-        A = np.char.array(u'\u03a3')
+        A = np.char.array(unicode('\u03a3'))
         assert_equal(len(A), 1)
         assert_equal(len(A[0]), 1)
         assert_equal(A.itemsize, 4)
@@ -186,9 +185,9 @@ class TestInformation(TestCase):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']]).view(np.chararray)
-        self.B = np.array([[u' \u03a3 ', u''],
-                           [u'12345', u'MixedCase'],
-                           [u'123 \t 345 \0 ', u'UPPER']]).view(np.chararray)
+        self.B = np.array([[unicode(' \u03a3 '), unicode('')],
+                           [unicode('12345'), unicode('MixedCase')],
+                           [unicode('123 \t 345 \0 '), unicode('UPPER')]]).view(np.chararray)
 
     def test_len(self):
         assert_(issubclass(np.char.str_len(self.A).dtype.type, np.integer))
@@ -285,9 +284,9 @@ class TestMethods(TestCase):
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']],
                           dtype='S').view(np.chararray)
-        self.B = np.array([[u' \u03a3 ', u''],
-                           [u'12345', u'MixedCase'],
-                           [u'123 \t 345 \0 ', u'UPPER']]).view(np.chararray)
+        self.B = np.array([[unicode(' \u03a3 '), unicode('')],
+                           [unicode('12345'), unicode('MixedCase')],
+                           [unicode('123 \t 345 \0 '), unicode('UPPER')]]).view(np.chararray)
 
     def test_capitalize(self):
         assert_(issubclass(self.A.capitalize().dtype.type, np.string_))
@@ -297,7 +296,7 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'Upper']]))
         assert_(issubclass(self.B.capitalize().dtype.type, np.unicode_))
         assert_array_equal(self.B.capitalize(), [
-                [u' \u03c3 ', ''],
+                [unicode(' \u03c3 '), ''],
                 ['12345', 'Mixedcase'],
                 ['123 \t 345 \0 ', 'Upper']])
 
@@ -373,9 +372,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'upper']]))
         assert_(issubclass(self.B.lower().dtype.type, np.unicode_))
         assert_array_equal(self.B.lower(), [
-                [u' \u03c3 ', u''],
-                [u'12345', u'mixedcase'],
-                [u'123 \t 345 \0 ', u'upper']])
+                [unicode(' \u03c3 '), unicode('')],
+                [unicode('12345'), unicode('mixedcase')],
+                [unicode('123 \t 345 \0 '), unicode('upper')]])
 
     def test_lstrip(self):
         assert_(issubclass(self.A.lstrip().dtype.type, np.string_))
@@ -390,7 +389,7 @@ class TestMethods(TestCase):
                 ['23 \t 345 \x00', 'UPPER']]))
         assert_(issubclass(self.B.lstrip().dtype.type, np.unicode_))
         assert_array_equal(self.B.lstrip(), [
-                [u'\u03a3 ', ''],
+                [unicode('\u03a3 '), ''],
                 ['12345', 'MixedCase'],
                 ['123 \t 345 \0 ', 'UPPER']])
 
@@ -414,11 +413,11 @@ class TestMethods(TestCase):
 
         if sys.version_info[0] < 3:
             # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
-            R = self.A.replace(asbytes('a'), u'\u03a3')
+            R = self.A.replace(asbytes('a'), unicode('\u03a3'))
             assert_(issubclass(R.dtype.type, np.unicode_))
             assert_array_equal(R, [
-                    [u' \u03a3bc ', ''],
-                    ['12345', u'MixedC\u03a3se'],
+                    [unicode(' \u03a3bc '), ''],
+                    ['12345', unicode('MixedC\u03a3se')],
                     ['123 \t 345 \x00', 'UPPER']])
 
     def test_rjust(self):
@@ -466,7 +465,7 @@ class TestMethods(TestCase):
                 ['123 \t 345 \x00', 'UPP']]))
         assert_(issubclass(self.B.rstrip().dtype.type, np.unicode_))
         assert_array_equal(self.B.rstrip(), [
-                [u' \u03a3', ''],
+                [unicode(' \u03a3'), ''],
                 ['12345', 'MixedCase'],
                 ['123 \t 345', 'UPPER']])
 
@@ -483,7 +482,7 @@ class TestMethods(TestCase):
                 ['23 \t 345 \x00', 'UPP']]))
         assert_(issubclass(self.B.strip().dtype.type, np.unicode_))
         assert_array_equal(self.B.strip(), [
-                [u'\u03a3', ''],
+                [unicode('\u03a3'), ''],
                 ['12345', 'MixedCase'],
                 ['123 \t 345', 'UPPER']])
 
@@ -509,9 +508,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'upper']]))
         assert_(issubclass(self.B.swapcase().dtype.type, np.unicode_))
         assert_array_equal(self.B.swapcase(), [
-                [u' \u03c3 ', u''],
-                [u'12345', u'mIXEDcASE'],
-                [u'123 \t 345 \0 ', u'upper']])
+                [unicode(' \u03c3 '), unicode('')],
+                [unicode('12345'), unicode('mIXEDcASE')],
+                [unicode('123 \t 345 \0 '), unicode('upper')]])
 
     def test_title(self):
         assert_(issubclass(self.A.title().dtype.type, np.string_))
@@ -521,9 +520,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'Upper']]))
         assert_(issubclass(self.B.title().dtype.type, np.unicode_))
         assert_array_equal(self.B.title(), [
-                [u' \u03a3 ', u''],
-                [u'12345', u'Mixedcase'],
-                [u'123 \t 345 \0 ', u'Upper']])
+                [unicode(' \u03a3 '), unicode('')],
+                [unicode('12345'), unicode('Mixedcase')],
+                [unicode('123 \t 345 \0 '), unicode('Upper')]])
 
     def test_upper(self):
         assert_(issubclass(self.A.upper().dtype.type, np.string_))
@@ -533,9 +532,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'UPPER']]))
         assert_(issubclass(self.B.upper().dtype.type, np.unicode_))
         assert_array_equal(self.B.upper(), [
-                [u' \u03a3 ', u''],
-                [u'12345', u'MIXEDCASE'],
-                [u'123 \t 345 \0 ', u'UPPER']])
+                [unicode(' \u03a3 '), unicode('')],
+                [unicode('12345'), unicode('MIXEDCASE')],
+                [unicode('123 \t 345 \0 '), unicode('UPPER')]])
 
     def test_isnumeric(self):
         def fail():

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7,9 +7,8 @@ import warnings
 import numpy as np
 from nose import SkipTest
 from numpy.core import *
-from numpy.compat import asbytes
 from numpy.testing.utils import WarningManager
-from numpy.compat import asbytes, getexception, strchar
+from numpy.compat import asbytes, getexception, strchar, unicode
 from test_print import in_foreign_locale
 from numpy.core.multiarray_tests import (
         test_neighborhood_iterator, test_neighborhood_iterator_oob,
@@ -31,7 +30,7 @@ if sys.version_info[:2] > (3, 2):
     # is an empty tuple instead of None.
     # http://docs.python.org/dev/whatsnew/3.3.html#api-changes
     EMPTY = ()
-else:    
+else:
     EMPTY = None
 
 
@@ -1246,8 +1245,8 @@ class TestStringCompare(TestCase):
 
 
     def test_unicode(self):
-        g1 = array([u"This",u"is",u"example"])
-        g2 = array([u"This",u"was",u"example"])
+        g1 = array([unicode("This"),unicode("is"),unicode("example")])
+        g2 = array([unicode("This"),unicode("was"),unicode("example")])
         assert_array_equal(g1 == g2, [g1[i] == g2[i] for i in [0,1,2]])
         assert_array_equal(g1 != g2, [g1[i] != g2[i] for i in [0,1,2]])
         assert_array_equal(g1 <= g2, [g1[i] <= g2[i] for i in [0,1,2]])
@@ -2000,8 +1999,8 @@ class TestRecord(TestCase):
             raise SkipTest('non ascii unicode field indexing skipped; '
                            'raises segfault on python 2.x')
         else:
-            assert_raises(ValueError, a.__setitem__, u'\u03e0', 1)
-            assert_raises(ValueError, a.__getitem__, u'\u03e0')
+            assert_raises(ValueError, a.__setitem__, unicode('\u03e0'), 1)
+            assert_raises(ValueError, a.__getitem__, unicode('\u03e0'))
 
     def test_field_names_deprecation(self):
         import warnings

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -4,7 +4,7 @@ import sys, warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
-from numpy.compat import asbytes
+from numpy.compat import asbytes, unicode
 from numpy.testing import *
 
 
@@ -2008,7 +2008,7 @@ def test_iter_buffering_string():
     assert_raises(TypeError,nditer,a,['buffered'],['readonly'],
                     op_dtypes='U2')
     i = nditer(a, ['buffered'], ['readonly'], op_dtypes='U6')
-    assert_equal(i[0], u'abc')
+    assert_equal(i[0], unicode('abc'))
     assert_equal(i[0].dtype, np.dtype('U6'))
 
 def test_iter_buffering_growinner():

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -17,7 +17,9 @@ from numpy.testing import (
         assert_raises, assert_warns, dec
         )
 from numpy.testing.utils import _assert_valid_refcount, WarningManager
-from numpy.compat import asbytes, asunicode, asbytes_nested, long
+from numpy.compat import (
+        asbytes, asunicode, asbytes_nested, long, unicode
+        )
 
 rlevel = 1
 
@@ -138,7 +140,7 @@ class TestRegression(TestCase):
     def test_unicode_swapping(self,level=rlevel):
         """Ticket #79"""
         ulen = 1
-        ucs_value = u'\U0010FFFF'
+        ucs_value = unicode('\U0010FFFF')
         ua = np.array([[[ucs_value*ulen]*2]*3]*4, dtype='U%s' % ulen)
         ua2 = ua.newbyteorder()
 
@@ -1107,11 +1109,11 @@ class TestRegression(TestCase):
         for i in range(1,9) :
             msg = 'unicode offset: %d chars'%i
             t = np.dtype([('a','S%d'%i),('b','U2')])
-            x = np.array([(asbytes('a'),u'b')], dtype=t)
+            x = np.array([(asbytes('a'),unicode('b'))], dtype=t)
             if sys.version_info[0] >= 3:
                 assert_equal(str(x), "[(b'a', 'b')]", err_msg=msg)
             else:
-                assert_equal(str(x), "[('a', u'b')]", err_msg=msg)
+                assert_equal(str(x), "[('a', unicode('b'))]", err_msg=msg)
 
     def test_sign_for_complex_nan(self, level=rlevel):
         """Ticket 794."""
@@ -1314,21 +1316,21 @@ class TestRegression(TestCase):
 
     def test_unicode_to_string_cast(self):
         """Ticket #1240."""
-        a = np.array([[u'abc', u'\u03a3'], [u'asdf', u'erw']], dtype='U')
+        a = np.array([[unicode('abc'), unicode('\u03a3')], [unicode('asdf'), unicode('erw')]], dtype='U')
         def fail():
             b = np.array(a, 'S4')
         self.assertRaises(UnicodeEncodeError, fail)
 
     def test_mixed_string_unicode_array_creation(self):
-        a = np.array(['1234', u'123'])
+        a = np.array(['1234', unicode('123')])
         assert_(a.itemsize == 16)
-        a = np.array([u'123', '1234'])
+        a = np.array([unicode('123'), '1234'])
         assert_(a.itemsize == 16)
-        a = np.array(['1234', u'123', '12345'])
+        a = np.array(['1234', unicode('123'), '12345'])
         assert_(a.itemsize == 20)
-        a = np.array([u'123', '1234', u'12345'])
+        a = np.array([unicode('123'), '1234', unicode('12345')])
         assert_(a.itemsize == 20)
-        a = np.array([u'123', '1234', u'1234'])
+        a = np.array([unicode('123'), '1234', unicode('1234')])
         assert_(a.itemsize == 16)
 
     def test_misaligned_objects_segfault(self):
@@ -1844,7 +1846,7 @@ class TestRegression(TestCase):
         if sys.version_info[0] >= 3:
             a = np.array(['abcd'])
         else:
-            a = np.array([u'abcd'])
+            a = np.array([unicode('abcd')])
         assert_equal(a.dtype.itemsize, 16)
 
     def test_unique_stable(self):

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -4,7 +4,7 @@ import sys
 
 from numpy.testing import *
 from numpy.core import *
-from numpy.compat import asbytes
+from numpy.compat import asbytes, unicode
 
 # Guess the UCS length for this python interpreter
 if sys.version_info[:2] >= (3, 3):
@@ -31,7 +31,7 @@ elif sys.version_info[0] >= 3:
         else:
             return prod(v.shape) * v.itemsize
 else:
-    if len(buffer(u'u')) == 4:
+    if len(buffer(unicode('u'))) == 4:
         ucs4 = True
     else:
         ucs4 = False
@@ -43,9 +43,9 @@ else:
 # In both cases below we need to make sure that the byte swapped value (as
 # UCS4) is still a valid unicode:
 # Value that can be represented in UCS2 interpreters
-ucs2_value = u'\u0900'
+ucs2_value = unicode('\u0900')
 # Value that cannot be represented in UCS2 interpreters (but can in UCS4)
-ucs4_value = u'\U00100900'
+ucs4_value = unicode('\U00100900')
 
 
 ############################################################
@@ -62,7 +62,7 @@ class create_zeros(object):
         # Check the length of the data buffer
         self.assertTrue(buffer_length(ua) == nbytes)
         # Small check that data in array element is ok
-        self.assertTrue(ua_scalar == u'')
+        self.assertTrue(ua_scalar == unicode(''))
         # Encode to ascii and double check
         self.assertTrue(ua_scalar.encode('ascii') == asbytes(''))
         # Check buffer lengths for scalars

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 from numpy.testing import *
+from numpy.compat import unicode
 import numpy as np
 import numpy.ma as ma
 
@@ -38,7 +39,7 @@ class TestRegression(TestCase):
 
     def test_masked_array_repr_unicode(self):
         """Ticket #1256"""
-        repr(np.ma.array(u"Unicode"))
+        repr(np.ma.array(unicode("Unicode")))
 
     def test_atleast_2d(self):
         """Ticket #1559"""

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -89,7 +89,7 @@ FIXES_TO_SKIP = [
     'throw',
     'tuple_params',
 #    'types',
-#    'unicode',
+    'unicode',
     'urllib',
 #    'ws_comma',
     'xrange',


### PR DESCRIPTION
The unicode fixer strip the u from u'hi' and converts the unicode type
to str. The first won't work for Python 2, so unicode from numpy.compat
is used instead of the u prefix. The second fix is also implemented by
importing the unicode type from numpy.compat. The result is that the
official unicode fixer is not actually used for anything.

Closes #3089.
