### PR TITLE
2to3: Apply unicode fixer.

### DIFF
--- a/doc/sphinxext/numpydoc/docscrape_sphinx.py
+++ b/doc/sphinxext/numpydoc/docscrape_sphinx.py
@@ -1,6 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import re, inspect, textwrap, pydoc, aya
+import re, inspect, textwrap, pydoc
 import sphinx
 import collections
 from .docscrape import NumpyDocString, FunctionDoc, ClassDoc

--- a/doc/sphinxext/numpydoc/docscrape_sphinx.py
+++ b/doc/sphinxext/numpydoc/docscrape_sphinx.py
@@ -1,9 +1,15 @@
 from __future__ import division, absolute_import, print_function
 
-import re, inspect, textwrap, pydoc
+import re, inspect, textwrap, pydoc, aya
 import sphinx
 import collections
 from .docscrape import NumpyDocString, FunctionDoc, ClassDoc
+
+if sys.version_info[0] >= 3:
+    sixu = lambda s: s
+else:
+    sixu = lambda s: unicode(s, 'unicode_escape')
+
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):
@@ -95,11 +101,11 @@ class SphinxDocString(NumpyDocString):
 
             if others:
                 maxlen_0 = max(3, max([len(x[0]) for x in others]))
-                hdr = u"="*maxlen_0 + u"  " + u"="*10
-                fmt = u'%%%ds  %%s  ' % (maxlen_0,)
+                hdr = sixu("=")*maxlen_0 + sixu("  ") + sixu("=")*10
+                fmt = sixu('%%%ds  %%s  ') % (maxlen_0,)
                 out += ['', hdr]
                 for param, param_type, desc in others:
-                    desc = u" ".join(x.strip() for x in desc).strip()
+                    desc = sixu(" ").join(x.strip() for x in desc).strip()
                     if param_type:
                         desc = "(%s) %s" % (param_type, desc)
                     out += [fmt % (param.strip(), desc)]

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -17,16 +17,22 @@ It will:
 """
 from __future__ import division, absolute_import, print_function
 
+import os, sys, re, pydoc
 import sphinx
+import inspect
 import collections
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
-import os, sys, re, pydoc
 from .docscrape_sphinx import get_doc_object, SphinxDocString
 from sphinx.util.compat import Directive
-import inspect
+
+if sys.version_info[0] >= 3:
+    sixu = lambda s: s
+else:
+    sixu = lambda s: unicode(s, 'unicode_escape')
+
 
 def mangle_docstrings(app, what, name, obj, options, lines,
                       reference_offset=[0]):
@@ -36,32 +42,32 @@ def mangle_docstrings(app, what, name, obj, options, lines,
 
     if what == 'module':
         # Strip top title
-        title_re = re.compile(u'^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*',
+        title_re = re.compile(sixu('^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'),
                               re.I|re.S)
-        lines[:] = title_re.sub(u'', u"\n".join(lines)).split(u"\n")
+        lines[:] = title_re.sub(sixu(''), sixu("\n").join(lines)).split(sixu("\n"))
     else:
-        doc = get_doc_object(obj, what, u"\n".join(lines), config=cfg)
+        doc = get_doc_object(obj, what, sixu("\n").join(lines), config=cfg)
         if sys.version_info[0] >= 3:
             doc = str(doc)
         else:
             doc = str(doc).decode('utf-8')
-        lines[:] = doc.split(u"\n")
+        lines[:] = doc.split(sixu("\n"))
 
     if app.config.numpydoc_edit_link and hasattr(obj, '__name__') and \
            obj.__name__:
         if hasattr(obj, '__module__'):
-            v = dict(full_name=u"%s.%s" % (obj.__module__, obj.__name__))
+            v = dict(full_name=sixu("%s.%s") % (obj.__module__, obj.__name__))
         else:
             v = dict(full_name=obj.__name__)
-        lines += [u'', u'.. htmlonly::', u'']
-        lines += [u'    %s' % x for x in
+        lines += [sixu(''), sixu('.. htmlonly::'), sixu('')]
+        lines += [sixu('    %s') % x for x in
                   (app.config.numpydoc_edit_link % v).split("\n")]
 
     # replace reference numbers so that there are no duplicates
     references = []
     for line in lines:
         line = line.strip()
-        m = re.match(u'^.. \\[([a-z0-9_.-])\\]', line, re.I)
+        m = re.match(sixu('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
         if m:
             references.append(m.group(1))
 
@@ -70,14 +76,14 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     if references:
         for i, line in enumerate(lines):
             for r in references:
-                if re.match(u'^\\d+$', r):
-                    new_r = u"R%d" % (reference_offset[0] + int(r))
+                if re.match(sixu('^\\d+$'), r):
+                    new_r = sixu("R%d") % (reference_offset[0] + int(r))
                 else:
-                    new_r = u"%s%d" % (r, reference_offset[0])
-                lines[i] = lines[i].replace(u'[%s]_' % r,
-                                            u'[%s]_' % new_r)
-                lines[i] = lines[i].replace(u'.. [%s]' % r,
-                                            u'.. [%s]' % new_r)
+                    new_r = sixu("%s%d") % (r, reference_offset[0])
+                lines[i] = lines[i].replace(sixu('[%s]_') % r,
+                                            sixu('[%s]_') % new_r)
+                lines[i] = lines[i].replace(sixu('.. [%s]') % r,
+                                            sixu('.. [%s]') % new_r)
 
     reference_offset[0] += len(references)
 
@@ -93,8 +99,8 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     doc = SphinxDocString(pydoc.getdoc(obj))
     if doc['Signature']:
-        sig = re.sub(u"^[^(]*", u"", doc['Signature'])
-        return sig, u''
+        sig = re.sub(sixu("^[^(]*"), sixu(""), doc['Signature'])
+        return sig, sixu('')
 
 def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):

--- a/doc/sphinxext/numpydoc/tests/test_docscrape.py
+++ b/doc/sphinxext/numpydoc/tests/test_docscrape.py
@@ -7,6 +7,12 @@ from numpydoc.docscrape import NumpyDocString, FunctionDoc, ClassDoc
 from numpydoc.docscrape_sphinx import SphinxDocString, SphinxClassDoc
 from nose.tools import *
 
+if sys.version_info[0] >= 3:
+    sixu = lambda s: s
+else:
+    sixu = lambda s: unicode(s, 'unicode_escape')
+
+
 doc_txt = '''\
   numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
@@ -220,12 +226,12 @@ spam : parrot
 
 Raises
 ------
-RuntimeError : 
+RuntimeError :
     Some error
 
 Warns
 -----
-RuntimeWarning : 
+RuntimeWarning :
     Some warning
 
 Warnings
@@ -324,7 +330,7 @@ of the one-dimensional normal distribution to higher dimensions.
         The drawn samples, arranged according to `shape`.  If the
         shape given is (m,n,...), then the shape of `out` is is
         (m,n,...,N).
-        
+
         In other words, each entry ``out[i,j,...,:]`` is an N-dimensional
         value drawn from the distribution.
 
@@ -333,16 +339,16 @@ of the one-dimensional normal distribution to higher dimensions.
     **spam** : parrot
 
         A parrot off its mortal coil.
- 
+
 :Raises:
 
-    **RuntimeError** : 
+    **RuntimeError** :
 
         Some error
 
 :Warns:
 
-    **RuntimeWarning** : 
+    **RuntimeWarning** :
 
         Some warning
 
@@ -351,12 +357,12 @@ of the one-dimensional normal distribution to higher dimensions.
     Certain warnings apply.
 
 .. seealso::
-    
+
     :obj:`some`, :obj:`other`, :obj:`funcs`
-    
+
     :obj:`otherfunc`
         relationship
-    
+
 .. rubric:: Notes
 
 Instead of specifying the full covariance matrix, popular
@@ -403,7 +409,7 @@ standard deviation:
 [True, True]
 """)
 
-       
+
 doc2 = NumpyDocString("""
     Returns array of indices of the maximum values of along the given axis.
 
@@ -558,9 +564,9 @@ def test_unicode():
     """)
     assert isinstance(doc['Summary'][0], str)
     if sys.version_info[0] >= 3:
-        assert doc['Summary'][0] == u'öäöäöäöäöåååå'
+        assert doc['Summary'][0] == sixu('öäöäöäöäöåååå')
     else:
-        assert doc['Summary'][0] == u'öäöäöäöäöåååå'.encode('utf-8')
+        assert doc['Summary'][0] == sixu('öäöäöäöäöåååå').encode('utf-8')
 
 def test_plot_examples():
     cfg = dict(use_plots=True)
@@ -578,7 +584,7 @@ def test_plot_examples():
     Examples
     --------
     .. plot::
-    
+
        import matplotlib.pyplot as plt
        plt.plot([1,2,3],[4,5,6])
        plt.show()
@@ -695,13 +701,13 @@ def test_class_members_doc():
 
     Methods
     -------
-    a : 
+    a :
 
-    b : 
+    b :
 
-    c : 
+    c :
 
-    .. index:: 
+    .. index::
 
     """)
 
@@ -728,16 +734,16 @@ def test_class_members_doc_sphinx():
     .. rubric:: Attributes
 
     ===  ==========
-      t  (float) Current time.  
-      y  (ndarray) Current variable values.  
+      t  (float) Current time.
+      y  (ndarray) Current variable values.
     ===  ==========
 
     .. rubric:: Methods
 
     ===  ==========
-      a    
-      b    
-      c    
+      a
+      b
+      c
     ===  ==========
 
     """)
@@ -745,4 +751,3 @@ def test_class_members_doc_sphinx():
 if __name__ == "__main__":
     import nose
     nose.run()
-

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -164,7 +164,8 @@ else:
     # Make these accessible from numpy name-space
     #  but not imported in from numpy import *
     if sys.version_info[0] >= 3:
-        from builtins import bool, int, float, complex, object, unicode, str
+        from builtins import bool, int, float, complex, object, str
+        unicode = str
     else:
         from __builtin__ import bool, int, float, complex, object, unicode, str
 

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -6,7 +6,7 @@ from __future__ import division, absolute_import, print_function
 
 __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
-           'asstr', 'open_latin1', 'long', 'basestring']
+           'asstr', 'open_latin1', 'long', 'basestring', 'sixu']
 
 import sys
 
@@ -16,8 +16,8 @@ if sys.version_info[0] >= 3:
     long = int
     integer_types = (int,)
     basestring = str
-    bytes = bytes
     unicode = str
+    bytes = bytes
 
     def asunicode(s):
         if isinstance(s, bytes):
@@ -40,14 +40,17 @@ if sys.version_info[0] >= 3:
     def open_latin1(filename, mode='r'):
         return open(filename, mode=mode, encoding='iso-8859-1')
 
+    def sixu(s):
+        return s
+
     strchar = 'U'
 
 
 else:
     bytes = str
-    unicode = unicode
     long = long
     basestring = basestring
+    unicode = unicode
     integer_types = (int, long)
     asbytes = str
     asstr = str
@@ -64,6 +67,9 @@ else:
 
     def open_latin1(filename, mode='r'):
         return open(filename, mode=mode)
+
+    def sixu(s):
+        return unicode(s, 'unicode_escape')
 
 
 def getexception():

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -102,7 +102,8 @@ from numpy.compat import bytes, long
 # we don't export these for import *, but we do want them accessible
 # as numerictypes.bool, etc.
 if sys.version_info[0] >= 3:
-    from builtins import bool, int, float, complex, object, unicode, str
+    from builtins import bool, int, float, complex, object, str
+    unicode = str
 else:
     from __builtin__ import bool, int, float, complex, object, unicode, str
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -5,6 +5,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import numpy as np
 from numpy.testing import *
+from numpy.compat import sixu
 
 class TestArrayRepr(object):
     def test_nan_inf(self):
@@ -157,7 +158,7 @@ def test_unicode_object_array():
         expected = "array(['é'], dtype=object)"
     else:
         expected = "array([u'\\xe9'], dtype=object)"
-    x = np.array([u'\xe9'], dtype=object)
+    x = np.array([sixu('\xe9')], dtype=object)
     assert_equal(repr(x), expected)
 
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -6,7 +6,7 @@ import numpy as np
 import sys
 from numpy.core.multiarray import _vec_string
 
-from numpy.compat import asbytes, asbytes_nested
+from numpy.compat import asbytes, asbytes_nested, sixu
 
 kw_unicode_true = {'unicode': True} # make 2to3 work properly
 kw_unicode_false = {'unicode': False}
@@ -21,12 +21,12 @@ class TestBasic(TestCase):
                                               ['long', '0123456789']]))
 
     def test_from_object_array_unicode(self):
-        A = np.array([['abc', u'Sigma \u03a3'],
+        A = np.array([['abc', sixu('Sigma \u03a3')],
                       ['long   ', '0123456789']], dtype='O')
         self.assertRaises(ValueError, np.char.array, (A,))
         B = np.char.array(A, **kw_unicode_true)
         assert_equal(B.dtype.itemsize, 10 * np.array('a', 'U').dtype.itemsize)
-        assert_array_equal(B, [['abc', u'Sigma \u03a3'],
+        assert_array_equal(B, [['abc', sixu('Sigma \u03a3')],
                                ['long', '0123456789']])
 
     def test_from_string_array(self):
@@ -47,7 +47,7 @@ class TestBasic(TestCase):
         assert_(C[0,0] == A[0,0])
 
     def test_from_unicode_array(self):
-        A = np.array([['abc', u'Sigma \u03a3'],
+        A = np.array([['abc', sixu('Sigma \u03a3')],
                       ['long   ', '0123456789']])
         assert_equal(A.dtype.type, np.unicode_)
         B = np.char.array(A)
@@ -64,7 +64,7 @@ class TestBasic(TestCase):
 
     def test_unicode_upconvert(self):
         A = np.char.array(['abc'])
-        B = np.char.array([u'\u03a3'])
+        B = np.char.array([sixu('\u03a3')])
         assert_(issubclass((A + B).dtype.type, np.unicode_))
 
     def test_from_string(self):
@@ -74,7 +74,7 @@ class TestBasic(TestCase):
         assert_(issubclass(A.dtype.type, np.string_))
 
     def test_from_unicode(self):
-        A = np.char.array(u'\u03a3')
+        A = np.char.array(sixu('\u03a3'))
         assert_equal(len(A), 1)
         assert_equal(len(A[0]), 1)
         assert_equal(A.itemsize, 4)
@@ -186,9 +186,9 @@ class TestInformation(TestCase):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']]).view(np.chararray)
-        self.B = np.array([[u' \u03a3 ', u''],
-                           [u'12345', u'MixedCase'],
-                           [u'123 \t 345 \0 ', u'UPPER']]).view(np.chararray)
+        self.B = np.array([[sixu(' \u03a3 '), sixu('')],
+                           [sixu('12345'), sixu('MixedCase')],
+                           [sixu('123 \t 345 \0 '), sixu('UPPER')]]).view(np.chararray)
 
     def test_len(self):
         assert_(issubclass(np.char.str_len(self.A).dtype.type, np.integer))
@@ -285,9 +285,9 @@ class TestMethods(TestCase):
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']],
                           dtype='S').view(np.chararray)
-        self.B = np.array([[u' \u03a3 ', u''],
-                           [u'12345', u'MixedCase'],
-                           [u'123 \t 345 \0 ', u'UPPER']]).view(np.chararray)
+        self.B = np.array([[sixu(' \u03a3 '), sixu('')],
+                           [sixu('12345'), sixu('MixedCase')],
+                           [sixu('123 \t 345 \0 '), sixu('UPPER')]]).view(np.chararray)
 
     def test_capitalize(self):
         assert_(issubclass(self.A.capitalize().dtype.type, np.string_))
@@ -297,7 +297,7 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'Upper']]))
         assert_(issubclass(self.B.capitalize().dtype.type, np.unicode_))
         assert_array_equal(self.B.capitalize(), [
-                [u' \u03c3 ', ''],
+                [sixu(' \u03c3 '), ''],
                 ['12345', 'Mixedcase'],
                 ['123 \t 345 \0 ', 'Upper']])
 
@@ -325,7 +325,7 @@ class TestMethods(TestCase):
 
     def test_encode(self):
         B = self.B.encode('unicode_escape')
-        assert_(B[0][0] == asbytes(r' \u03a3 '))
+        assert_(B[0][0] == str(' \\u03a3 ').encode('latin1'))
 
     def test_expandtabs(self):
         T = self.A.expandtabs()
@@ -373,9 +373,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'upper']]))
         assert_(issubclass(self.B.lower().dtype.type, np.unicode_))
         assert_array_equal(self.B.lower(), [
-                [u' \u03c3 ', u''],
-                [u'12345', u'mixedcase'],
-                [u'123 \t 345 \0 ', u'upper']])
+                [sixu(' \u03c3 '), sixu('')],
+                [sixu('12345'), sixu('mixedcase')],
+                [sixu('123 \t 345 \0 '), sixu('upper')]])
 
     def test_lstrip(self):
         assert_(issubclass(self.A.lstrip().dtype.type, np.string_))
@@ -390,7 +390,7 @@ class TestMethods(TestCase):
                 ['23 \t 345 \x00', 'UPPER']]))
         assert_(issubclass(self.B.lstrip().dtype.type, np.unicode_))
         assert_array_equal(self.B.lstrip(), [
-                [u'\u03a3 ', ''],
+                [sixu('\u03a3 '), ''],
                 ['12345', 'MixedCase'],
                 ['123 \t 345 \0 ', 'UPPER']])
 
@@ -414,11 +414,11 @@ class TestMethods(TestCase):
 
         if sys.version_info[0] < 3:
             # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
-            R = self.A.replace(asbytes('a'), u'\u03a3')
+            R = self.A.replace(asbytes('a'), sixu('\u03a3'))
             assert_(issubclass(R.dtype.type, np.unicode_))
             assert_array_equal(R, [
-                    [u' \u03a3bc ', ''],
-                    ['12345', u'MixedC\u03a3se'],
+                    [sixu(' \u03a3bc '), ''],
+                    ['12345', sixu('MixedC\u03a3se')],
                     ['123 \t 345 \x00', 'UPPER']])
 
     def test_rjust(self):
@@ -466,7 +466,7 @@ class TestMethods(TestCase):
                 ['123 \t 345 \x00', 'UPP']]))
         assert_(issubclass(self.B.rstrip().dtype.type, np.unicode_))
         assert_array_equal(self.B.rstrip(), [
-                [u' \u03a3', ''],
+                [sixu(' \u03a3'), ''],
                 ['12345', 'MixedCase'],
                 ['123 \t 345', 'UPPER']])
 
@@ -483,7 +483,7 @@ class TestMethods(TestCase):
                 ['23 \t 345 \x00', 'UPP']]))
         assert_(issubclass(self.B.strip().dtype.type, np.unicode_))
         assert_array_equal(self.B.strip(), [
-                [u'\u03a3', ''],
+                [sixu('\u03a3'), ''],
                 ['12345', 'MixedCase'],
                 ['123 \t 345', 'UPPER']])
 
@@ -509,9 +509,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'upper']]))
         assert_(issubclass(self.B.swapcase().dtype.type, np.unicode_))
         assert_array_equal(self.B.swapcase(), [
-                [u' \u03c3 ', u''],
-                [u'12345', u'mIXEDcASE'],
-                [u'123 \t 345 \0 ', u'upper']])
+                [sixu(' \u03c3 '), sixu('')],
+                [sixu('12345'), sixu('mIXEDcASE')],
+                [sixu('123 \t 345 \0 '), sixu('upper')]])
 
     def test_title(self):
         assert_(issubclass(self.A.title().dtype.type, np.string_))
@@ -521,9 +521,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'Upper']]))
         assert_(issubclass(self.B.title().dtype.type, np.unicode_))
         assert_array_equal(self.B.title(), [
-                [u' \u03a3 ', u''],
-                [u'12345', u'Mixedcase'],
-                [u'123 \t 345 \0 ', u'Upper']])
+                [sixu(' \u03a3 '), sixu('')],
+                [sixu('12345'), sixu('Mixedcase')],
+                [sixu('123 \t 345 \0 '), sixu('Upper')]])
 
     def test_upper(self):
         assert_(issubclass(self.A.upper().dtype.type, np.string_))
@@ -533,9 +533,9 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'UPPER']]))
         assert_(issubclass(self.B.upper().dtype.type, np.unicode_))
         assert_array_equal(self.B.upper(), [
-                [u' \u03a3 ', u''],
-                [u'12345', u'MIXEDCASE'],
-                [u'123 \t 345 \0 ', u'UPPER']])
+                [sixu(' \u03a3 '), sixu('')],
+                [sixu('12345'), sixu('MIXEDCASE')],
+                [sixu('123 \t 345 \0 '), sixu('UPPER')]])
 
     def test_isnumeric(self):
         def fail():

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4,12 +4,12 @@ import tempfile
 import sys
 import os
 import warnings
+
 import numpy as np
 from nose import SkipTest
 from numpy.core import *
-from numpy.compat import asbytes
 from numpy.testing.utils import WarningManager
-from numpy.compat import asbytes, getexception, strchar
+from numpy.compat import asbytes, getexception, strchar, sixu
 from test_print import in_foreign_locale
 from numpy.core.multiarray_tests import (
         test_neighborhood_iterator, test_neighborhood_iterator_oob,
@@ -31,7 +31,7 @@ if sys.version_info[:2] > (3, 2):
     # is an empty tuple instead of None.
     # http://docs.python.org/dev/whatsnew/3.3.html#api-changes
     EMPTY = ()
-else:    
+else:
     EMPTY = None
 
 
@@ -1246,8 +1246,8 @@ class TestStringCompare(TestCase):
 
 
     def test_unicode(self):
-        g1 = array([u"This",u"is",u"example"])
-        g2 = array([u"This",u"was",u"example"])
+        g1 = array([sixu("This"),sixu("is"),sixu("example")])
+        g2 = array([sixu("This"),sixu("was"),sixu("example")])
         assert_array_equal(g1 == g2, [g1[i] == g2[i] for i in [0,1,2]])
         assert_array_equal(g1 != g2, [g1[i] != g2[i] for i in [0,1,2]])
         assert_array_equal(g1 <= g2, [g1[i] <= g2[i] for i in [0,1,2]])
@@ -2000,8 +2000,8 @@ class TestRecord(TestCase):
             raise SkipTest('non ascii unicode field indexing skipped; '
                            'raises segfault on python 2.x')
         else:
-            assert_raises(ValueError, a.__setitem__, u'\u03e0', 1)
-            assert_raises(ValueError, a.__getitem__, u'\u03e0')
+            assert_raises(ValueError, a.__setitem__, sixu('\u03e0'), 1)
+            assert_raises(ValueError, a.__getitem__, sixu('\u03e0'))
 
     def test_field_names_deprecation(self):
         import warnings

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -4,7 +4,7 @@ import sys, warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
-from numpy.compat import asbytes
+from numpy.compat import asbytes, sixu
 from numpy.testing import *
 
 
@@ -2008,7 +2008,7 @@ def test_iter_buffering_string():
     assert_raises(TypeError,nditer,a,['buffered'],['readonly'],
                     op_dtypes='U2')
     i = nditer(a, ['buffered'], ['readonly'], op_dtypes='U6')
-    assert_equal(i[0], u'abc')
+    assert_equal(i[0], sixu('abc'))
     assert_equal(i[0].dtype, np.dtype('U6'))
 
 def test_iter_buffering_growinner():

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -17,7 +17,7 @@ from numpy.testing import (
         assert_raises, assert_warns, dec
         )
 from numpy.testing.utils import _assert_valid_refcount, WarningManager
-from numpy.compat import asbytes, asunicode, asbytes_nested, long
+from numpy.compat import asbytes, asunicode, asbytes_nested, long, sixu
 
 rlevel = 1
 
@@ -138,7 +138,7 @@ class TestRegression(TestCase):
     def test_unicode_swapping(self,level=rlevel):
         """Ticket #79"""
         ulen = 1
-        ucs_value = u'\U0010FFFF'
+        ucs_value = sixu('\U0010FFFF')
         ua = np.array([[[ucs_value*ulen]*2]*3]*4, dtype='U%s' % ulen)
         ua2 = ua.newbyteorder()
 
@@ -1107,7 +1107,7 @@ class TestRegression(TestCase):
         for i in range(1,9) :
             msg = 'unicode offset: %d chars'%i
             t = np.dtype([('a','S%d'%i),('b','U2')])
-            x = np.array([(asbytes('a'),u'b')], dtype=t)
+            x = np.array([(asbytes('a'),sixu('b'))], dtype=t)
             if sys.version_info[0] >= 3:
                 assert_equal(str(x), "[(b'a', 'b')]", err_msg=msg)
             else:
@@ -1314,21 +1314,24 @@ class TestRegression(TestCase):
 
     def test_unicode_to_string_cast(self):
         """Ticket #1240."""
-        a = np.array([[u'abc', u'\u03a3'], [u'asdf', u'erw']], dtype='U')
+        a = np.array(
+                [   [sixu('abc'), sixu('\u03a3')],
+                    [sixu('asdf'), sixu('erw')]
+                ], dtype='U')
         def fail():
             b = np.array(a, 'S4')
         self.assertRaises(UnicodeEncodeError, fail)
 
     def test_mixed_string_unicode_array_creation(self):
-        a = np.array(['1234', u'123'])
+        a = np.array(['1234', sixu('123')])
         assert_(a.itemsize == 16)
-        a = np.array([u'123', '1234'])
+        a = np.array([sixu('123'), '1234'])
         assert_(a.itemsize == 16)
-        a = np.array(['1234', u'123', '12345'])
+        a = np.array(['1234', sixu('123'), '12345'])
         assert_(a.itemsize == 20)
-        a = np.array([u'123', '1234', u'12345'])
+        a = np.array([sixu('123'), '1234', sixu('12345')])
         assert_(a.itemsize == 20)
-        a = np.array([u'123', '1234', u'1234'])
+        a = np.array([sixu('123'), '1234', sixu('1234')])
         assert_(a.itemsize == 16)
 
     def test_misaligned_objects_segfault(self):
@@ -1844,7 +1847,7 @@ class TestRegression(TestCase):
         if sys.version_info[0] >= 3:
             a = np.array(['abcd'])
         else:
-            a = np.array([u'abcd'])
+            a = np.array([sixu('abcd')])
         assert_equal(a.dtype.itemsize, 16)
 
     def test_unique_stable(self):

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -4,7 +4,7 @@ import sys
 
 from numpy.testing import *
 from numpy.core import *
-from numpy.compat import asbytes
+from numpy.compat import asbytes, sixu
 
 # Guess the UCS length for this python interpreter
 if sys.version_info[:2] >= (3, 3):
@@ -31,7 +31,7 @@ elif sys.version_info[0] >= 3:
         else:
             return prod(v.shape) * v.itemsize
 else:
-    if len(buffer(u'u')) == 4:
+    if len(buffer(sixu('u'))) == 4:
         ucs4 = True
     else:
         ucs4 = False
@@ -43,9 +43,9 @@ else:
 # In both cases below we need to make sure that the byte swapped value (as
 # UCS4) is still a valid unicode:
 # Value that can be represented in UCS2 interpreters
-ucs2_value = u'\u0900'
+ucs2_value = sixu('\u0900')
 # Value that cannot be represented in UCS2 interpreters (but can in UCS4)
-ucs4_value = u'\U00100900'
+ucs4_value = sixu('\U00100900')
 
 
 ############################################################
@@ -62,7 +62,7 @@ class create_zeros(object):
         # Check the length of the data buffer
         self.assertTrue(buffer_length(ua) == nbytes)
         # Small check that data in array element is ok
-        self.assertTrue(ua_scalar == u'')
+        self.assertTrue(ua_scalar == sixu(''))
         # Encode to ascii and double check
         self.assertTrue(ua_scalar.encode('ascii') == asbytes(''))
         # Check buffer lengths for scalars

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -11,7 +11,8 @@ import numpy.core.numeric as nx
 from numpy.compat import asbytes, bytes, asbytes_nested, long, basestring
 
 if sys.version_info[0] >= 3:
-    from builtins import bool, int, float, complex, object, unicode, str
+    from builtins import bool, int, float, complex, object,  str
+    unicode = str
 else:
     from __builtin__ import bool, int, float, complex, object, unicode, str
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -14,12 +14,17 @@ from operator import itemgetter
 from ._datasource import DataSource
 from ._compiled_base import packbits, unpackbits
 
-from ._iotools import LineSplitter, NameValidator, StringConverter, \
-                     ConverterError, ConverterLockError, ConversionWarning, \
-                     _is_string_like, has_nested_fields, flatten_dtype, \
-                     easy_dtype, _bytes_to_name
+from ._iotools import (
+        LineSplitter, NameValidator, StringConverter,
+        ConverterError, ConverterLockError, ConversionWarning,
+        _is_string_like, has_nested_fields, flatten_dtype,
+        easy_dtype, _bytes_to_name
+        )
 
-from numpy.compat import asbytes, asstr, asbytes_nested, bytes, basestring
+from numpy.compat import (
+        asbytes, asstr, asbytes_nested, bytes, basestring, unicode
+        )
+
 from io import BytesIO
 
 if sys.version_info[0] >= 3:

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -1,9 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+
+import numpy as np
 from numpy.testing import *
 from numpy.testing.utils import _assert_valid_refcount
-import numpy as np
+from numpy.compat import unicode
 
 rlevel = 1
 

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,8 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 import numpy as np
 import numpy.ma as ma
+from numpy.testing import *
+from numpy.compat import sixu
 
 rlevel = 1
 
@@ -38,7 +39,7 @@ class TestRegression(TestCase):
 
     def test_masked_array_repr_unicode(self):
         """Ticket #1256"""
-        repr(np.ma.array(u"Unicode"))
+        repr(np.ma.array(sixu("Unicode")))
 
     def test_atleast_2d(self):
         """Ticket #1559"""

--- a/tools/py3tool.py
+++ b/tools/py3tool.py
@@ -89,7 +89,7 @@ FIXES_TO_SKIP = [
     'throw',
     'tuple_params',
     'types',
-#    'unicode',
+    'unicode',
     'urllib',
 #    'ws_comma',
     'xrange',


### PR DESCRIPTION
The unicode fixer strips the u from u'hi' and converts the unicode type
to str. The first won't work for Python 2 and instead we replace the u
prefix with the sixu function borrowed from the six compatibility
package. That function calls the unicode constructor with the
'unicode_escape' encoder so that the many tests using escaped unicode
characters like u'\u0900' will be handled correctly. That makes the
sixu function a bit different from the asunicode function currently in
numpy.compat and also provides a target that can be converted back to
the u prefix when support for Python 3.2 is dropped. Python 3.3
reintroduced the u prefix for compatibility.

The unicode fixer also replaces 'unicode' with 'str' as 'unicode' is no
longer a builtin in Python 3. For code compatibility, 'unicode' is
defined either as 'str' or 'unicode' in numpy.compat so that checks like

```
if isinstance(x, unicode):
    ...
```

will work properly for all python versions.

Closes #3089.
