### PR TITLE
bugfix in build_ext: check that ext has an attribute before trying to us it

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -297,8 +297,8 @@ class build_ext (old_build_ext):
         else: # in case ext.language is c++, for instance
             fcompiler = self._f90_compiler or self._f77_compiler
         if fcompiler is not None:
-            fcompiler.extra_f77_compile_args = ext.extra_f77_compile_args or []
-            fcompiler.extra_f90_compile_args = ext.extra_f90_compile_args or []
+            fcompiler.extra_f77_compile_args = ext.extra_f77_compile_args or [] if hasattr(ext,'extra_f77_compile_args') else []
+            fcompiler.extra_f90_compile_args = ext.extra_f90_compile_args or [] if hasattr(ext,'extra_f90_compile_args') else []
         cxx_compiler = self._cxx_compiler
 
         # check for the availability of required compilers

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -297,8 +297,8 @@ class build_ext (old_build_ext):
         else: # in case ext.language is c++, for instance
             fcompiler = self._f90_compiler or self._f77_compiler
         if fcompiler is not None:
-            fcompiler.extra_f77_compile_args = ext.extra_f77_compile_args or [] if hasattr(ext,'extra_f77_compile_args') else []
-            fcompiler.extra_f90_compile_args = ext.extra_f90_compile_args or [] if hasattr(ext,'extra_f90_compile_args') else []
+            fcompiler.extra_f77_compile_args = (ext.extra_f77_compile_args or []) if hasattr(ext,'extra_f77_compile_args') else []
+            fcompiler.extra_f90_compile_args = (ext.extra_f90_compile_args or []) if hasattr(ext,'extra_f90_compile_args') else []
         cxx_compiler = self._cxx_compiler
 
         # check for the availability of required compilers


### PR DESCRIPTION
Small fix, but it was noted as a bug here http://chess.eecs.berkeley.edu/ptexternal/wiki/Main/JModelica and I encountered it while trying to install scipy.  There may be a more sensible way to deal with this problem, but this hack is effective.
