### PR TITLE
A generator function to return slices of an array over a given dimension:  iterdim()

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -40,7 +40,7 @@ __all__ = ['newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
            'Inf', 'inf', 'infty', 'Infinity',
            'nan', 'NaN', 'False_', 'True_', 'bitwise_not',
            'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE', 'ALLOW_THREADS',
-           'ComplexWarning']
+           'ComplexWarning','iterdim']
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])
@@ -2183,7 +2183,32 @@ def array_equiv(a1, a2):
     except ValueError:
         return False
 
+def iterdim(a, axis=0):
+    """
+    A generator to return slices of a multi-dimensional array over
+    the specified axis.
 
+    Parameters
+    ----------
+    a : array_like
+        Input data
+    axis : int, optional
+        The axis to iterate over.  By default, it is the first axis,
+        and thus identical to iterating over the original array.
+
+    Yields
+    -------
+    out : ndarray, of diminsion n-1, where n = a.ndim
+        
+    """
+    msg = 'iterdim: %s (%d) must be >=0 and < %d'
+    if not (0 <= axis < a.ndim):
+        raise ValueError, msg % ('axis', axis, a.ndim)
+
+    leading_indices = (slice(None),)*axis
+    for i in range(a.shape[axis]) :
+      yield a[leading_indices+(i,)]
+    
 _errdict = {"ignore":ERR_IGNORE,
             "warn":ERR_WARN,
             "raise":ERR_RAISE,

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2201,6 +2201,7 @@ def iterdim(a, axis=0):
     out : ndarray, of diminsion n-1, where n = a.ndim
         
     """
+    a = np.asarray(a)
     msg = 'iterdim: %s (%d) must be >=0 and < %d'
     if not (0 <= axis < a.ndim):
         raise ValueError, msg % ('axis', axis, a.ndim)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -40,7 +40,7 @@ __all__ = ['newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
            'Inf', 'inf', 'infty', 'Infinity',
            'nan', 'NaN', 'False_', 'True_', 'bitwise_not',
            'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE', 'ALLOW_THREADS',
-           'ComplexWarning','iterdim']
+           'ComplexWarning','iteraxis']
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])
@@ -2183,9 +2183,9 @@ def array_equiv(a1, a2):
     except ValueError:
         return False
 
-def iterdim(a, axis=0):
+def iteraxis(a, axis=0):
     """
-    A generator to return slices of a multi-dimensional array over
+    A iterator to return slices of a multi-dimensional array over
     the specified axis.
 
     Parameters
@@ -2198,17 +2198,16 @@ def iterdim(a, axis=0):
 
     Yields
     -------
-    out : ndarray, of diminsion n-1, where n = a.ndim
+    out : n ndarrays, of diminsion d-1, where n = a.shape[axis]
+          and d = a.ndim
         
     """
-    a = asarray(a)
-    msg = 'iterdim: %s (%d) must be >=0 and < %d'
+    msg = 'iteraxis: %s (%d) must be >=0 and < %d'
     if not (0 <= axis < a.ndim):
         raise ValueError, msg % ('axis', axis, a.ndim)
 
-    leading_indices = (slice(None),)*axis
-    for i in range(a.shape[axis]) :
-      yield a[leading_indices+(i,)]
+    a = asarray(a)
+    return iter(rollaxis(a, axis, 0))
     
 _errdict = {"ignore":ERR_IGNORE,
             "warn":ERR_WARN,

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2201,7 +2201,7 @@ def iterdim(a, axis=0):
     out : ndarray, of diminsion n-1, where n = a.ndim
         
     """
-    a = np.asarray(a)
+    a = asarray(a)
     msg = 'iterdim: %s (%d) must be >=0 and < %d'
     if not (0 <= axis < a.ndim):
         raise ValueError, msg % ('axis', axis, a.ndim)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2204,7 +2204,7 @@ def iteraxis(a, axis=0):
     """
     msg = 'iteraxis: %s (%d) must be >=0 and < %d'
     if not (0 <= axis < a.ndim):
-        raise ValueError, msg % ('axis', axis, a.ndim)
+        raise ValueError(msg % ('axis', axis, a.ndim))
 
     a = asarray(a)
     return iter(rollaxis(a, axis, 0))

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2202,8 +2202,8 @@ def iteraxis(a, axis=0):
           and d = a.ndim
         
     """
-    msg = 'iteraxis: %s (%d) must be >=0 and < %d'
     if not (0 <= axis < a.ndim):
+        msg = 'iteraxis: %s (%d) must be >=0 and < %d'
         raise ValueError(msg % ('axis', axis, a.ndim))
 
     a = asarray(a)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1525,6 +1525,39 @@ class TestRoll(TestCase):
         x = np.array([])
         assert_equal(np.roll(x, 1), np.array([]))
 
+class TestIterdim(TestCase):
+    def test_iterdim1d(self):
+        a = np.arange(10)
+        a_iter = np.iterdim(a)
+        for i, a_slice in enumerate(a_iter):
+            assert_equal(a_slice, ())
+        assert_equal(i, 9)
+    
+    def test_iterdimNd(self):
+        a = np.ones((100,10,3))
+
+        a_iter = np.iterdim(a, 1)
+        for i, a_slice in enumerate(a_iter):
+            assert_equal(a_slice, (10,3))
+        assert_equal(i, 99)
+
+        a_iter = np.iterdim(a, 1)
+        for a_slice in enumerate(a_iter):
+            assert_equal(a_slice, (100,3))
+        assert_equal(i, 9)
+
+        a_iter = np.iterdim(a, 2)
+        for a_slice in enumerate(a_iter):
+            assert_equal(a_slice, (100,10))
+        assert_equal(i, 2)
+                           
+    def test_axis_out_of_bounds_low(self):
+        a = np.ones((100,10))
+        assert_raises(ValueError, np.iterdim(a, -1))
+
+    def test_axis_out_of_bounds_high(self):
+        a = np.ones((100,10))
+        assert_raises(ValueError, np.iterdim(a, 2))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1530,34 +1530,36 @@ class TestIterdim(TestCase):
         a = np.arange(10)
         a_iter = np.iterdim(a)
         for i, a_slice in enumerate(a_iter):
-            assert_equal(a_slice, ())
+            assert_equal(a_slice.shape, ())
         assert_equal(i, 9)
     
     def test_iterdimNd(self):
         a = np.ones((100,10,3))
 
-        a_iter = np.iterdim(a, 1)
+        a_iter = np.iterdim(a, 0)
         for i, a_slice in enumerate(a_iter):
-            assert_equal(a_slice, (10,3))
+            assert_equal(a_slice.shape, (10,3))
         assert_equal(i, 99)
 
         a_iter = np.iterdim(a, 1)
-        for a_slice in enumerate(a_iter):
-            assert_equal(a_slice, (100,3))
+        for i, a_slice in enumerate(a_iter):
+            assert_equal(a_slice.shape, (100,3))
         assert_equal(i, 9)
 
         a_iter = np.iterdim(a, 2)
-        for a_slice in enumerate(a_iter):
-            assert_equal(a_slice, (100,10))
+        for i, a_slice in enumerate(a_iter):
+            assert_equal(a_slice.shape, (100,10))
         assert_equal(i, 2)
                            
     def test_axis_out_of_bounds_low(self):
         a = np.ones((100,10))
-        assert_raises(ValueError, np.iterdim(a, -1))
+        with self.assertRaises(ValueError):
+            np.iterdim(a, -1).next()
 
     def test_axis_out_of_bounds_high(self):
         a = np.ones((100,10))
-        assert_raises(ValueError, np.iterdim(a, 2))
+        with self.assertRaises(ValueError):
+            np.iterdim(a, 2).next()
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1525,28 +1525,28 @@ class TestRoll(TestCase):
         x = np.array([])
         assert_equal(np.roll(x, 1), np.array([]))
 
-class TestIterdim(TestCase):
-    def test_iterdim1d(self):
+class TestIteraxis(TestCase):
+    def test_iteraxis1d(self):
         a = np.arange(10)
-        a_iter = np.iterdim(a)
+        a_iter = np.iteraxis(a)
         for i, a_slice in enumerate(a_iter):
             assert_equal(a_slice.shape, ())
         assert_equal(i, 9)
     
-    def test_iterdimNd(self):
+    def test_iteraxisNd(self):
         a = np.ones((100,10,3))
 
-        a_iter = np.iterdim(a, 0)
+        a_iter = np.iteraxis(a, 0)
         for i, a_slice in enumerate(a_iter):
             assert_equal(a_slice.shape, (10,3))
         assert_equal(i, 99)
 
-        a_iter = np.iterdim(a, 1)
+        a_iter = np.iteraxis(a, 1)
         for i, a_slice in enumerate(a_iter):
             assert_equal(a_slice.shape, (100,3))
         assert_equal(i, 9)
 
-        a_iter = np.iterdim(a, 2)
+        a_iter = np.iteraxis(a, 2)
         for i, a_slice in enumerate(a_iter):
             assert_equal(a_slice.shape, (100,10))
         assert_equal(i, 2)
@@ -1554,12 +1554,12 @@ class TestIterdim(TestCase):
     def test_axis_out_of_bounds_low(self):
         a = np.ones((100,10))
         with self.assertRaises(ValueError):
-            np.iterdim(a, -1).next()
+            np.iteraxis(a, -1).next()
 
     def test_axis_out_of_bounds_high(self):
         a = np.ones((100,10))
         with self.assertRaises(ValueError):
-            np.iterdim(a, 2).next()
+            np.iteraxis(a, 2).next()
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is an addition to numeric.py to generalize the iterator behavior of ndarrays over any dimension.

Currently, using an ndarray as an interator returns slices of an array over the 0th dimension; this allows for use over any valid dimension and works for arrays of ndim >=1

example use:

```
import numpy as np
a = np.ones((100,10,3))
for a_slice in np.iterdim(a, 2):
    print a_slice.shape
```

will return:

```
(100,10)
(100,10)
(100,10)
```

It has been pointed out to me that one could use `np.rollaxis()` to build an iterator of the same functionality, but this is distinct in that it returns a pure iterator, rather than a re-ordered array that can be iterated over in the manner desired.

As this is my first PR to numpy, any advice or comments are welcome.  I've added tests (a first for me, as well) which all pass and seem to capture the behavior well.  One nice feature to add would be to include this as a method to ndarray, but that is currently a bit more complicated than I know how to do.

Thanks

-ag
andrew.giessel@gmail.com
@andrewgiessel
