### PR TITLE
Update masked array copy to preserve array order

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3438,12 +3438,12 @@ class MaskedArray(ndarray):
             return np.asanyarray(fill_value)
         #
         if m.dtype.names:
-            result = self._data.copy()
+            result = self._data.copy('K')
             _recursive_filled(result, self._mask, fill_value)
         elif not m.any():
             return self._data
         else:
-            result = self._data.copy()
+            result = self._data.copy('K')
             try:
                 np.copyto(result, fill_value, where=m)
             except (TypeError, AttributeError):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -538,6 +538,15 @@ class TestMaskedArray(TestCase):
         assert_equal(test, control)
 
 
+    def test_filled_w_f_order(self):
+        "Test filled w/ F-contiguous array"
+        a = array(np.array([(0, 1, 2), (4, 5, 6)], order='F'),
+                  mask=np.array([(0, 0, 1), (1, 0, 0)], order='F'),
+                  order='F') # this is currently ignored
+        self.assertTrue(a.flags['F_CONTIGUOUS'])
+        self.assertTrue(a.filled(0).flags['F_CONTIGUOUS'])
+
+
     def test_optinfo_propagation(self):
         "Checks that _optinfo dictionary isn't back-propagated"
         x = array([1, 2, 3, ], dtype=float)


### PR DESCRIPTION
Using 'K' to try to match array order, fixes https://github.com/numpy/numpy/issues/3156
