### PR TITLE
2to3 remove 2to3 fixer

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -7,6 +7,11 @@ This release supports  Python 2.6 -2.7 and 3.2 - 3.3.
 Highlights
 ==========
 
+Python 2 and Python 3 are supported by the same code base. The
+2to3 fixer is no longer run.
+
+
+
 Dropped Support
 ===============
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -29,10 +29,9 @@ from io import BytesIO
 
 if sys.version_info[0] >= 3:
     import pickle
-    imap = map
 else:
     import cPickle as pickle
-    imap = itertools.imap
+    from future_builtins import map
 
 loads = pickle.loads
 
@@ -1614,7 +1613,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                 converter.iterupgrade(current_column)
             except ConverterLockError:
                 errmsg = "Converter #%i is locked and cannot be upgraded: " % i
-                current_column = imap(itemgetter(i), rows)
+                current_column = map(itemgetter(i), rows)
                 for (j, value) in enumerate(current_column):
                     try:
                         converter.upgrade(value)

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -17,10 +17,8 @@ from numpy.ma.mrecords import MaskedRecords
 from numpy.lib._iotools import _is_string_like
 from numpy.compat import basestring
 
-if sys.version_info[0] >= 3:
-    izip = zip
-else:
-    izip = itertools.izip
+if sys.version_info[0] < 3:
+    from future_builtins import zip
 
 _check_fill_value = np.ma.core._check_fill_value
 
@@ -293,7 +291,7 @@ def izip_records(seqarrays, fill_value=None, flatten=True):
         zipfunc = _izip_fields
     #
     try:
-        for tup in izip(*iters):
+        for tup in zip(*iters):
             yield tuple(zipfunc(tup))
     except IndexError:
         pass
@@ -418,7 +416,7 @@ def merge_arrays(seqarrays,
     seqmask = []
     # If we expect some kind of MaskedArray, make a special loop.
     if usemask:
-        for (a, n) in izip(seqarrays, sizes):
+        for (a, n) in zip(seqarrays, sizes):
             nbmissing = (maxlength - n)
             # Get the data and mask
             data = a.ravel().__array__()
@@ -447,7 +445,7 @@ def merge_arrays(seqarrays,
             output = output.view(MaskedRecords)
     else:
         # Same as before, without the mask we don't need...
-        for (a, n) in izip(seqarrays, sizes):
+        for (a, n) in zip(seqarrays, sizes):
             nbmissing = (maxlength - n)
             data = a.ravel().__array__()
             if nbmissing:

--- a/setup.py
+++ b/setup.py
@@ -154,34 +154,7 @@ def configuration(parent_package='',top_path=None):
 
 def setup_package():
 
-    # Perform 2to3 if needed
-    local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    src_path = local_path
-
-    if sys.version_info[0] == 3:
-        src_path = os.path.join(local_path, 'build', 'py3k')
-        sys.path.insert(0, os.path.join(local_path, 'tools'))
-        import py3tool
-        print("Converting to Python3 via 2to3...")
-        py3tool.sync_2to3('numpy', os.path.join(src_path, 'numpy'))
-
-        site_cfg = os.path.join(local_path, 'site.cfg')
-        if os.path.isfile(site_cfg):
-            shutil.copy(site_cfg, src_path)
-
-        # Ugly hack to make pip work with Python 3, see #1857.
-        # Explanation: pip messes with __file__ which interacts badly with the
-        # change in directory due to the 2to3 conversion.  Therefore we restore
-        # __file__ to what it would have been otherwise.
-        global __file__
-        __file__ = os.path.join(os.curdir, os.path.basename(__file__))
-        if '--egg-base' in sys.argv:
-            # Change pip-egg-info entry to absolute path, so pip can find it
-            # after changing directory.
-            idx = sys.argv.index('--egg-base')
-            if sys.argv[idx + 1] == 'pip-egg-info':
-                sys.argv[idx + 1] = os.path.join(local_path, 'pip-egg-info')
-
+    src_path = os.path.dirname(os.path.abspath(sys.argv[0]))
     old_path = os.getcwd()
     os.chdir(src_path)
     sys.path.insert(0, src_path)


### PR DESCRIPTION
The 2to3 fixer no longer needs to be run.

Closes #3247.
