### PR TITLE
MAINT: Remove unneeded version checks.

### DIFF
--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -15,8 +15,7 @@ try:
 except ImportError:
     import md5
     md5new = md5.new
-if sys.version_info[:2] < (2, 6):
-    from sets import Set as set
+
 import textwrap
 
 from os.path import join

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -375,69 +375,42 @@ def capitalize(a):
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'capitalize')
 
-if sys.version_info >= (2, 4):
-    def center(a, width, fillchar=' '):
-        """
-        Return a copy of `a` with its elements centered in a string of
-        length `width`.
 
-        Calls `str.center` element-wise.
+def center(a, width, fillchar=' '):
+    """
+    Return a copy of `a` with its elements centered in a string of
+    length `width`.
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
+    Calls `str.center` element-wise.
 
-        width : int
-            The length of the resulting strings
-        fillchar : str or unicode, optional
-            The padding character to use (default is space).
+    Parameters
+    ----------
+    a : array_like of str or unicode
 
-        Returns
-        -------
-        out : ndarray
-            Output array of str or unicode, depending on input
-            types
+    width : int
+        The length of the resulting strings
+    fillchar : str or unicode, optional
+        The padding character to use (default is space).
 
-        See also
-        --------
-        str.center
+    Returns
+    -------
+    out : ndarray
+        Output array of str or unicode, depending on input
+        types
 
-        """
-        a_arr = numpy.asarray(a)
-        width_arr = numpy.asarray(width)
-        size = long(numpy.max(width_arr.flat))
-        if numpy.issubdtype(a_arr.dtype, numpy.string_):
-            fillchar = asbytes(fillchar)
-        return _vec_string(
-            a_arr, (a_arr.dtype.type, size), 'center', (width_arr, fillchar))
-else:
-    def center(a, width):
-        """
-        Return an array with the elements of `a` centered in a string
-        of length width.
+    See also
+    --------
+    str.center
 
-        Calls `str.center` element-wise.
+    """
+    a_arr = numpy.asarray(a)
+    width_arr = numpy.asarray(width)
+    size = long(numpy.max(width_arr.flat))
+    if numpy.issubdtype(a_arr.dtype, numpy.string_):
+        fillchar = asbytes(fillchar)
+    return _vec_string(
+        a_arr, (a_arr.dtype.type, size), 'center', (width_arr, fillchar))
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
-        width : int
-            The length of the resulting strings
-
-        Returns
-        -------
-        out : ndarray, str or unicode
-            Output array of str or unicode, depending on input types
-
-        See also
-        --------
-        str.center
-        """
-        a_arr = numpy.asarray(a)
-        width_arr = numpy.asarray(width)
-        size = long(numpy.max(width_arr.flat))
-        return _vec_string(
-            a_arr, (a_arr.dtype.type, size), 'center', (width_arr,))
 
 def count(a, sub, start=0, end=None):
     """
@@ -484,6 +457,7 @@ def count(a, sub, start=0, end=None):
     """
     return _vec_string(a, integer, 'count', [sub, start] + _clean_args(end))
 
+
 def decode(a, encoding=None, errors=None):
     """
     Calls `str.decode` element-wise.
@@ -529,6 +503,7 @@ def decode(a, encoding=None, errors=None):
     return _to_string_or_unicode_array(
         _vec_string(a, object_, 'decode', _clean_args(encoding, errors)))
 
+
 def encode(a, encoding=None, errors=None):
     """
     Calls `str.encode` element-wise.
@@ -562,6 +537,7 @@ def encode(a, encoding=None, errors=None):
     """
     return _to_string_or_unicode_array(
         _vec_string(a, object_, 'encode', _clean_args(encoding, errors)))
+
 
 def endswith(a, suffix, start=0, end=None):
     """
@@ -606,6 +582,7 @@ def endswith(a, suffix, start=0, end=None):
     return _vec_string(
         a, bool_, 'endswith', [suffix, start] + _clean_args(end))
 
+
 def expandtabs(a, tabsize=8):
     """
     Return a copy of each string element where all tab characters are
@@ -639,6 +616,7 @@ def expandtabs(a, tabsize=8):
     """
     return _to_string_or_unicode_array(
         _vec_string(a, object_, 'expandtabs', (tabsize,)))
+
 
 def find(a, sub, start=0, end=None):
     """
@@ -674,10 +652,6 @@ def find(a, sub, start=0, end=None):
     return _vec_string(
         a, integer, 'find', [sub, start] + _clean_args(end))
 
-# if sys.version_info >= (2.6):
-#     def format(a, *args, **kwargs):
-#         # _vec_string doesn't support kwargs at present
-#         raise NotImplementedError
 
 def index(a, sub, start=0, end=None):
     """
@@ -901,68 +875,41 @@ def join(sep, seq):
     return _to_string_or_unicode_array(
         _vec_string(sep, object_, 'join', (seq,)))
 
-if sys.version_info >= (2, 4):
-    def ljust(a, width, fillchar=' '):
-        """
-        Return an array with the elements of `a` left-justified in a
-        string of length `width`.
 
-        Calls `str.ljust` element-wise.
+def ljust(a, width, fillchar=' '):
+    """
+    Return an array with the elements of `a` left-justified in a
+    string of length `width`.
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
+    Calls `str.ljust` element-wise.
 
-        width : int
-            The length of the resulting strings
-        fillchar : str or unicode, optional
-            The character to use for padding
+    Parameters
+    ----------
+    a : array_like of str or unicode
 
-        Returns
-        -------
-        out : ndarray
-            Output array of str or unicode, depending on input type
+    width : int
+        The length of the resulting strings
+    fillchar : str or unicode, optional
+        The character to use for padding
 
-        See also
-        --------
-        str.ljust
+    Returns
+    -------
+    out : ndarray
+        Output array of str or unicode, depending on input type
 
-        """
-        a_arr = numpy.asarray(a)
-        width_arr = numpy.asarray(width)
-        size = long(numpy.max(width_arr.flat))
-        if numpy.issubdtype(a_arr.dtype, numpy.string_):
-            fillchar = asbytes(fillchar)
-        return _vec_string(
-            a_arr, (a_arr.dtype.type, size), 'ljust', (width_arr, fillchar))
-else:
-    def ljust(a, width):
-        """
-        Return an array with the elements of `a` left-justified in a
-        string of length `width`.
+    See also
+    --------
+    str.ljust
 
-        Calls `str.ljust` element-wise.
+    """
+    a_arr = numpy.asarray(a)
+    width_arr = numpy.asarray(width)
+    size = long(numpy.max(width_arr.flat))
+    if numpy.issubdtype(a_arr.dtype, numpy.string_):
+        fillchar = asbytes(fillchar)
+    return _vec_string(
+        a_arr, (a_arr.dtype.type, size), 'ljust', (width_arr, fillchar))
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
-        width : int
-            The length of the resulting strings
-
-        Returns
-        -------
-        out : ndarray
-            Output array of str or unicode, depending on input type
-
-        See also
-        --------
-        str.ljust
-        """
-        a_arr = numpy.asarray(a)
-        width_arr = numpy.asarray(width)
-        size = long(numpy.max(width_arr.flat))
-        return _vec_string(
-            a_arr, (a_arr.dtype.type, size), 'ljust', (width_arr,))
 
 def lower(a):
     """
@@ -998,6 +945,7 @@ def lower(a):
     """
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'lower')
+
 
 def lstrip(a, chars=None):
     """
@@ -1055,40 +1003,41 @@ def lstrip(a, chars=None):
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'lstrip', (chars,))
 
-if sys.version_info >= (2, 5):
-    def partition(a, sep):
-        """
-        Partition each element in `a` around `sep`.
 
-        Calls `str.partition` element-wise.
+def partition(a, sep):
+    """
+    Partition each element in `a` around `sep`.
 
-        For each element in `a`, split the element as the first
-        occurrence of `sep`, and return 3 strings containing the part
-        before the separator, the separator itself, and the part after
-        the separator. If the separator is not found, return 3 strings
-        containing the string itself, followed by two empty strings.
+    Calls `str.partition` element-wise.
 
-        Parameters
-        ----------
-        a : array_like, {str, unicode}
-            Input array
-        sep : {str, unicode}
-            Separator to split each string element in `a`.
+    For each element in `a`, split the element as the first
+    occurrence of `sep`, and return 3 strings containing the part
+    before the separator, the separator itself, and the part after
+    the separator. If the separator is not found, return 3 strings
+    containing the string itself, followed by two empty strings.
 
-        Returns
-        -------
-        out : ndarray, {str, unicode}
-            Output array of str or unicode, depending on input type.
-            The output array will have an extra dimension with 3
-            elements per input element.
+    Parameters
+    ----------
+    a : array_like, {str, unicode}
+        Input array
+    sep : {str, unicode}
+        Separator to split each string element in `a`.
 
-        See also
-        --------
-        str.partition
+    Returns
+    -------
+    out : ndarray, {str, unicode}
+        Output array of str or unicode, depending on input type.
+        The output array will have an extra dimension with 3
+        elements per input element.
 
-        """
-        return _to_string_or_unicode_array(
-            _vec_string(a, object_, 'partition', (sep,)))
+    See also
+    --------
+    str.partition
+
+    """
+    return _to_string_or_unicode_array(
+        _vec_string(a, object_, 'partition', (sep,)))
+
 
 def replace(a, old, new, count=None):
     """
@@ -1121,6 +1070,7 @@ def replace(a, old, new, count=None):
         _vec_string(
             a, object_, 'replace', [old, new] +_clean_args(count)))
 
+
 def rfind(a, sub, start=0, end=None):
     """
     For each element in `a`, return the highest index in the string
@@ -1152,6 +1102,7 @@ def rfind(a, sub, start=0, end=None):
     return _vec_string(
         a, integer, 'rfind', [sub, start] + _clean_args(end))
 
+
 def rindex(a, sub, start=0, end=None):
     """
     Like `rfind`, but raises `ValueError` when the substring `sub` is
@@ -1180,140 +1131,113 @@ def rindex(a, sub, start=0, end=None):
     return _vec_string(
         a, integer, 'rindex', [sub, start] + _clean_args(end))
 
-if sys.version_info >= (2, 4):
-    def rjust(a, width, fillchar=' '):
-        """
-        Return an array with the elements of `a` right-justified in a
-        string of length `width`.
 
-        Calls `str.rjust` element-wise.
+def rjust(a, width, fillchar=' '):
+    """
+    Return an array with the elements of `a` right-justified in a
+    string of length `width`.
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
+    Calls `str.rjust` element-wise.
 
-        width : int
-            The length of the resulting strings
-        fillchar : str or unicode, optional
-            The character to use for padding
+    Parameters
+    ----------
+    a : array_like of str or unicode
 
-        Returns
-        -------
-        out : ndarray
-            Output array of str or unicode, depending on input type
+    width : int
+        The length of the resulting strings
+    fillchar : str or unicode, optional
+        The character to use for padding
 
-        See also
-        --------
-        str.rjust
+    Returns
+    -------
+    out : ndarray
+        Output array of str or unicode, depending on input type
 
-        """
-        a_arr = numpy.asarray(a)
-        width_arr = numpy.asarray(width)
-        size = long(numpy.max(width_arr.flat))
-        if numpy.issubdtype(a_arr.dtype, numpy.string_):
-            fillchar = asbytes(fillchar)
-        return _vec_string(
-            a_arr, (a_arr.dtype.type, size), 'rjust', (width_arr, fillchar))
-else:
-    def rjust(a, width):
-        """
-        Return an array with the elements of `a` right-justified in a
-        string of length `width`.
+    See also
+    --------
+    str.rjust
 
-        Calls `str.rjust` element-wise.
+    """
+    a_arr = numpy.asarray(a)
+    width_arr = numpy.asarray(width)
+    size = long(numpy.max(width_arr.flat))
+    if numpy.issubdtype(a_arr.dtype, numpy.string_):
+        fillchar = asbytes(fillchar)
+    return _vec_string(
+        a_arr, (a_arr.dtype.type, size), 'rjust', (width_arr, fillchar))
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
-        width : int
-            The length of the resulting strings
 
-        Returns
-        -------
-        out : ndarray
-            Output array of str or unicode, depending on input type
+def rpartition(a, sep):
+    """
+    Partition (split) each element around the right-most separator.
 
-        See also
-        --------
-        str.rjust
-        """
-        a_arr = numpy.asarray(a)
-        width_arr = numpy.asarray(width)
-        size = long(numpy.max(width_arr.flat))
-        return _vec_string(
-            a_arr, (a_arr.dtype.type, size), 'rjust', (width,))
+    Calls `str.rpartition` element-wise.
 
-if sys.version_info >= (2, 5):
-    def rpartition(a, sep):
-        """
-        Partition (split) each element around the right-most separator.
+    For each element in `a`, split the element as the last
+    occurrence of `sep`, and return 3 strings containing the part
+    before the separator, the separator itself, and the part after
+    the separator. If the separator is not found, return 3 strings
+    containing the string itself, followed by two empty strings.
 
-        Calls `str.rpartition` element-wise.
+    Parameters
+    ----------
+    a : array_like of str or unicode
+        Input array
+    sep : str or unicode
+        Right-most separator to split each element in array.
 
-        For each element in `a`, split the element as the last
-        occurrence of `sep`, and return 3 strings containing the part
-        before the separator, the separator itself, and the part after
-        the separator. If the separator is not found, return 3 strings
-        containing the string itself, followed by two empty strings.
+    Returns
+    -------
+    out : ndarray
+        Output array of string or unicode, depending on input
+        type.  The output array will have an extra dimension with
+        3 elements per input element.
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
-            Input array
-        sep : str or unicode
-            Right-most separator to split each element in array.
+    See also
+    --------
+    str.rpartition
 
-        Returns
-        -------
-        out : ndarray
-            Output array of string or unicode, depending on input
-            type.  The output array will have an extra dimension with
-            3 elements per input element.
+    """
+    return _to_string_or_unicode_array(
+        _vec_string(a, object_, 'rpartition', (sep,)))
 
-        See also
-        --------
-        str.rpartition
 
-        """
-        return _to_string_or_unicode_array(
-            _vec_string(a, object_, 'rpartition', (sep,)))
+def rsplit(a, sep=None, maxsplit=None):
+    """
+    For each element in `a`, return a list of the words in the
+    string, using `sep` as the delimiter string.
 
-if sys.version_info >= (2, 4):
-    def rsplit(a, sep=None, maxsplit=None):
-        """
-        For each element in `a`, return a list of the words in the
-        string, using `sep` as the delimiter string.
+    Calls `str.rsplit` element-wise.
 
-        Calls `str.rsplit` element-wise.
+    Except for splitting from the right, `rsplit`
+    behaves like `split`.
 
-        Except for splitting from the right, `rsplit`
-        behaves like `split`.
+    Parameters
+    ----------
+    a : array_like of str or unicode
 
-        Parameters
-        ----------
-        a : array_like of str or unicode
+    sep : str or unicode, optional
+        If `sep` is not specified or `None`, any whitespace string
+        is a separator.
+    maxsplit : int, optional
+        If `maxsplit` is given, at most `maxsplit` splits are done,
+        the rightmost ones.
 
-        sep : str or unicode, optional
-            If `sep` is not specified or `None`, any whitespace string
-            is a separator.
-        maxsplit : int, optional
-            If `maxsplit` is given, at most `maxsplit` splits are done,
-            the rightmost ones.
+    Returns
+    -------
+    out : ndarray
+       Array of list objects
 
-        Returns
-        -------
-        out : ndarray
-           Array of list objects
+    See also
+    --------
+    str.rsplit, split
 
-        See also
-        --------
-        str.rsplit, split
+    """
+    # This will return an array of lists of different sizes, so we
+    # leave it as an object array
+    return _vec_string(
+        a, object_, 'rsplit', [sep] + _clean_args(maxsplit))
 
-        """
-        # This will return an array of lists of different sizes, so we
-        # leave it as an object array
-        return _vec_string(
-            a, object_, 'rsplit', [sep] + _clean_args(maxsplit))
 
 def rstrip(a, chars=None):
     """
@@ -1358,6 +1282,7 @@ def rstrip(a, chars=None):
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'rstrip', (chars,))
 
+
 def split(a, sep=None, maxsplit=None):
     """
     For each element in `a`, return a list of the words in the
@@ -1391,6 +1316,7 @@ def split(a, sep=None, maxsplit=None):
     return _vec_string(
         a, object_, 'split', [sep] + _clean_args(maxsplit))
 
+
 def splitlines(a, keepends=None):
     """
     For each element in `a`, return a list of the lines in the
@@ -1418,6 +1344,7 @@ def splitlines(a, keepends=None):
     """
     return _vec_string(
         a, object_, 'splitlines', _clean_args(keepends))
+
 
 def startswith(a, prefix, start=0, end=None):
     """
@@ -1448,6 +1375,7 @@ def startswith(a, prefix, start=0, end=None):
     """
     return _vec_string(
         a, bool_, 'startswith', [prefix, start] + _clean_args(end))
+
 
 def strip(a, chars=None):
     """
@@ -1496,6 +1424,7 @@ def strip(a, chars=None):
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'strip', _clean_args(chars))
 
+
 def swapcase(a):
     """
     Return element-wise a copy of the string with
@@ -1531,6 +1460,7 @@ def swapcase(a):
     """
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'swapcase')
+
 
 def title(a):
     """
@@ -1570,6 +1500,7 @@ def title(a):
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'title')
 
+
 def translate(a, table, deletechars=None):
     """
     For each element in `a`, return a copy of the string where all
@@ -1604,6 +1535,7 @@ def translate(a, table, deletechars=None):
     else:
         return _vec_string(
             a_arr, a_arr.dtype, 'translate', [table] + _clean_args(deletechars))
+
 
 def upper(a):
     """
@@ -1640,6 +1572,7 @@ def upper(a):
     a_arr = numpy.asarray(a)
     return _vec_string(a_arr, a_arr.dtype, 'upper')
 
+
 def zfill(a, width):
     """
     Return the numeric string left-filled with zeros
@@ -1668,6 +1601,7 @@ def zfill(a, width):
     size = long(numpy.max(width_arr.flat))
     return _vec_string(
         a_arr, (a_arr.dtype.type, size), 'zfill', (width_arr,))
+
 
 def isnumeric(a):
     """
@@ -1698,6 +1632,7 @@ def isnumeric(a):
     if _use_unicode(a) != unicode_:
         raise TypeError("isnumeric is only available for Unicode strings and arrays")
     return _vec_string(a, bool_, 'isnumeric')
+
 
 def isdecimal(a):
     """
@@ -2079,28 +2014,16 @@ class chararray(ndarray):
         """
         return asarray(capitalize(self))
 
-    if sys.version_info >= (2, 4):
-        def center(self, width, fillchar=' '):
-            """
-            Return a copy of `self` with its elements centered in a
-            string of length `width`.
+    def center(self, width, fillchar=' '):
+        """
+        Return a copy of `self` with its elements centered in a
+        string of length `width`.
 
-            See also
-            --------
-            center
-            """
-            return asarray(center(self, width, fillchar))
-    else:
-        def center(self, width):
-            """
-            Return a copy of `self` with its elements centered in a
-            string of length `width`.
-
-            See also
-            --------
-            center
-            """
-            return asarray(center(self, width))
+        See also
+        --------
+        center
+        """
+        return asarray(center(self, width, fillchar))
 
     def count(self, sub, start=0, end=None):
         """
@@ -2285,29 +2208,17 @@ class chararray(ndarray):
         """
         return join(self, seq)
 
-    if sys.version_info >= (2, 4):
-        def ljust(self, width, fillchar=' '):
-            """
-            Return an array with the elements of `self` left-justified in a
-            string of length `width`.
+    def ljust(self, width, fillchar=' '):
+        """
+        Return an array with the elements of `self` left-justified in a
+        string of length `width`.
 
-            See also
-            --------
-            char.ljust
+        See also
+        --------
+        char.ljust
 
-            """
-            return asarray(ljust(self, width, fillchar))
-    else:
-        def ljust(self, width):
-            """
-            Return an array with the elements of `self` left-justified in a
-            string of length `width`.
-
-            See also
-            --------
-            ljust
-            """
-            return asarray(ljust(self, width))
+        """
+        return asarray(ljust(self, width, fillchar))
 
     def lower(self):
         """
@@ -2333,16 +2244,15 @@ class chararray(ndarray):
         """
         return asarray(lstrip(self, chars))
 
-    if sys.version_info >= (2, 5):
-        def partition(self, sep):
-            """
-            Partition each element in `self` around `sep`.
+    def partition(self, sep):
+        """
+        Partition each element in `self` around `sep`.
 
-            See also
-            --------
-            partition
-            """
-            return asarray(partition(self, sep))
+        See also
+        --------
+        partition
+        """
+        return asarray(partition(self, sep))
 
     def replace(self, old, new, count=None):
         """
@@ -2381,53 +2291,39 @@ class chararray(ndarray):
         """
         return rindex(self, sub, start, end)
 
-    if sys.version_info >= (2, 4):
-        def rjust(self, width, fillchar=' '):
-            """
-            Return an array with the elements of `self`
-            right-justified in a string of length `width`.
+    def rjust(self, width, fillchar=' '):
+        """
+        Return an array with the elements of `self`
+        right-justified in a string of length `width`.
 
-            See also
-            --------
-            char.rjust
+        See also
+        --------
+        char.rjust
 
-            """
-            return asarray(rjust(self, width, fillchar))
-    else:
-        def rjust(self, width):
-            """
-            Return an array with the elements of `self`
-            right-justified in a string of length `width`.
+        """
+        return asarray(rjust(self, width, fillchar))
 
-            See also
-            --------
-            rjust
-            """
-            return asarray(rjust(self, width))
+    def rpartition(self, sep):
+        """
+        Partition each element in `self` around `sep`.
 
-    if sys.version_info >= (2, 5):
-        def rpartition(self, sep):
-            """
-            Partition each element in `self` around `sep`.
+        See also
+        --------
+        rpartition
+        """
+        return asarray(rpartition(self, sep))
 
-            See also
-            --------
-            rpartition
-            """
-            return asarray(rpartition(self, sep))
+    def rsplit(self, sep=None, maxsplit=None):
+        """
+        For each element in `self`, return a list of the words in
+        the string, using `sep` as the delimiter string.
 
-    if sys.version_info >= (2, 4):
-        def rsplit(self, sep=None, maxsplit=None):
-            """
-            For each element in `self`, return a list of the words in
-            the string, using `sep` as the delimiter string.
+        See also
+        --------
+        char.rsplit
 
-            See also
-            --------
-            char.rsplit
-
-            """
-            return rsplit(self, sep, maxsplit)
+        """
+        return rsplit(self, sep, maxsplit)
 
     def rstrip(self, chars=None):
         """

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -248,14 +248,10 @@ class memmap(ndarray):
         else:
             acc = mmap.ACCESS_WRITE
 
-        if sys.version_info[:2] >= (2,6):
-            # The offset keyword in mmap.mmap needs Python >= 2.6
-            start = offset - offset % mmap.ALLOCATIONGRANULARITY
-            bytes -= start
-            offset -= start
-            mm = mmap.mmap(fid.fileno(), bytes, access=acc, offset=start)
-        else:
-            mm = mmap.mmap(fid.fileno(), bytes, access=acc)
+        start = offset - offset % mmap.ALLOCATIONGRANULARITY
+        bytes -= start
+        offset -= start
+        mm = mmap.mmap(fid.fileno(), bytes, access=acc, offset=start)
 
         self = ndarray.__new__(subtype, shape, dtype=descr, buffer=mm,
             offset=offset, order=order)

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -154,11 +154,10 @@ def check_math_capabilities(config, moredefs, mathlibs):
     # config.h in the public namespace, so we have a clash for the common
     # functions we test. We remove every function tested by python's
     # autoconf, hoping their own test are correct
-    if sys.version_info[:2] >= (2, 5):
-        for f in OPTIONAL_STDFUNCS_MAYBE:
-            if config.check_decl(fname2def(f),
-                        headers=["Python.h", "math.h"]):
-                OPTIONAL_STDFUNCS.remove(f)
+    for f in OPTIONAL_STDFUNCS_MAYBE:
+        if config.check_decl(fname2def(f),
+                    headers=["Python.h", "math.h"]):
+            OPTIONAL_STDFUNCS.remove(f)
 
     check_funcs(OPTIONAL_STDFUNCS)
 
@@ -222,19 +221,16 @@ def check_ieee_macros(config):
     # functions we test. We remove every function tested by python's
     # autoconf, hoping their own test are correct
     _macros = ["isnan", "isinf", "signbit", "isfinite"]
-    if sys.version_info[:2] >= (2, 6):
-        for f in _macros:
-            py_symbol = fname2def("decl_%s" % f)
-            already_declared = config.check_decl(py_symbol,
-                    headers=["Python.h", "math.h"])
-            if already_declared:
-                if config.check_macro_true(py_symbol,
-                        headers=["Python.h", "math.h"]):
-                    pub.append('NPY_%s' % fname2def("decl_%s" % f))
-            else:
-                macros.append(f)
-    else:
-        macros = _macros[:]
+    for f in _macros:
+        py_symbol = fname2def("decl_%s" % f)
+        already_declared = config.check_decl(py_symbol,
+                headers=["Python.h", "math.h"])
+        if already_declared:
+            if config.check_macro_true(py_symbol,
+                    headers=["Python.h", "math.h"]):
+                pub.append('NPY_%s' % fname2def("decl_%s" % f))
+        else:
+            macros.append(f)
     # Normally, isnan and isinf are macro (C99), but some platforms only have
     # func, or both func and macro version. Check for macro only, and define
     # replacement ones if not found.

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -395,13 +395,12 @@ class TestMethods(TestCase):
                 ['123 \t 345 \0 ', 'UPPER']])
 
     def test_partition(self):
-        if sys.version_info >= (2, 5):
-            P = self.A.partition(asbytes_nested(['3', 'M']))
-            assert_(issubclass(P.dtype.type, np.string_))
-            assert_array_equal(P, asbytes_nested([
-                    [(' abc ', '', ''), ('', '', '')],
-                    [('12', '3', '45'), ('', 'M', 'ixedCase')],
-                    [('12', '3', ' \t 345 \0 '), ('UPPER', '', '')]]))
+        P = self.A.partition(asbytes_nested(['3', 'M']))
+        assert_(issubclass(P.dtype.type, np.string_))
+        assert_array_equal(P, asbytes_nested([
+                [(' abc ', '', ''), ('', '', '')],
+                [('12', '3', '45'), ('', 'M', 'ixedCase')],
+                [('12', '3', ' \t 345 \0 '), ('UPPER', '', '')]]))
 
     def test_replace(self):
         R = self.A.replace(asbytes_nested(['3', 'a']),
@@ -437,13 +436,12 @@ class TestMethods(TestCase):
                 ['            FOO', '     FOO']]))
 
     def test_rpartition(self):
-        if sys.version_info >= (2, 5):
-            P = self.A.rpartition(asbytes_nested(['3', 'M']))
-            assert_(issubclass(P.dtype.type, np.string_))
-            assert_array_equal(P, asbytes_nested([
-                    [('', '', ' abc '), ('', '', '')],
-                    [('12', '3', '45'), ('', 'M', 'ixedCase')],
-                    [('123 \t ', '3', '45 \0 '), ('', '', 'UPPER')]]))
+        P = self.A.rpartition(asbytes_nested(['3', 'M']))
+        assert_(issubclass(P.dtype.type, np.string_))
+        assert_array_equal(P, asbytes_nested([
+                [('', '', ' abc '), ('', '', '')],
+                [('12', '3', '45'), ('', 'M', 'ixedCase')],
+                [('123 \t ', '3', '45 \0 '), ('', '', 'UPPER')]]))
 
     def test_rsplit(self):
         A = self.A.rsplit(asbytes('3'))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -86,7 +86,6 @@ class TestFloatScalarIndexDeprecation(object):
                                 category=DeprecationWarning)
 
 
-    @dec.skipif(sys.version_info[:2] < (2, 5))
     def test_deprecations(self):
         a = np.array([[[5]]])
 
@@ -159,7 +158,6 @@ class TestFloatSliceParameterDeprecation(object):
                                 category=DeprecationWarning)
 
 
-    @dec.skipif(sys.version_info[:2] < (2, 5))
     def test_deprecations(self):
         a = np.array([[5]])
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -440,7 +440,7 @@ class TestString(TestCase):
         assert_equal(repr(dt),
                     "dtype([('a', '<M8[D]'), ('b', '<m8[us]')])")
 
-    @dec.skipif(sys.version_info[0] > 2)
+    @dec.skipif(sys.version_info[0] >= 3)
     def test_dtype_str_with_long_in_shape(self):
         # Pull request #376
         dt = np.dtype('(1L,)i4')

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -24,11 +24,7 @@ def check_float_type(tp):
         assert_equal(str(tp(1e10)), str(float('1e10')),
                      err_msg='Failed str formatting for type %s' % tp)
     else:
-        if sys.platform == 'win32' and sys.version_info[0] <= 2 and \
-           sys.version_info[1] <= 5:
-            ref = '1e+010'
-        else:
-            ref = '1e+10'
+        ref = '1e+10'
         assert_equal(str(tp(1e10)), ref,
                      err_msg='Failed str formatting for type %s' % tp)
 
@@ -72,11 +68,7 @@ def check_complex_type(tp):
         assert_equal(str(tp(1e10)), str(complex(1e10)),
                      err_msg='Failed str formatting for type %s' % tp)
     else:
-        if sys.platform == 'win32' and sys.version_info[0] <= 2 and \
-           sys.version_info[1] <= 5:
-            ref = '(1e+010+0j)'
-        else:
-            ref = '(1e+10+0j)'
+        ref = '(1e+10+0j)'
         assert_equal(str(tp(1e10)), ref,
                      err_msg='Failed str formatting for type %s' % tp)
 
@@ -93,44 +85,24 @@ def test_complex_types():
 
 def test_complex_inf_nan():
     """Check inf/nan formatting of complex types."""
-    if sys.version_info[:2] >= (2, 6):
-        TESTS = {
-            complex(np.inf, 0): "(inf+0j)",
-            complex(0, np.inf): "inf*j",
-            complex(-np.inf, 0): "(-inf+0j)",
-            complex(0, -np.inf): "-inf*j",
-            complex(np.inf, 1): "(inf+1j)",
-            complex(1, np.inf): "(1+inf*j)",
-            complex(-np.inf, 1): "(-inf+1j)",
-            complex(1, -np.inf): "(1-inf*j)",
-            complex(np.nan, 0): "(nan+0j)",
-            complex(0, np.nan): "nan*j",
-            complex(-np.nan, 0): "(nan+0j)",
-            complex(0, -np.nan): "nan*j",
-            complex(np.nan, 1): "(nan+1j)",
-            complex(1, np.nan): "(1+nan*j)",
-            complex(-np.nan, 1): "(nan+1j)",
-            complex(1, -np.nan): "(1+nan*j)",
-        }
-    else:
-        TESTS = {
-            complex(np.inf, 0): "(inf+0j)",
-            complex(0, np.inf): "infj",
-            complex(-np.inf, 0): "(-inf+0j)",
-            complex(0, -np.inf): "-infj",
-            complex(np.inf, 1): "(inf+1j)",
-            complex(1, np.inf): "(1+infj)",
-            complex(-np.inf, 1): "(-inf+1j)",
-            complex(1, -np.inf): "(1-infj)",
-            complex(np.nan, 0): "(nan+0j)",
-            complex(0, np.nan): "nanj",
-            complex(-np.nan, 0): "(nan+0j)",
-            complex(0, -np.nan): "nanj",
-            complex(np.nan, 1): "(nan+1j)",
-            complex(1, np.nan): "(1+nanj)",
-            complex(-np.nan, 1): "(nan+1j)",
-            complex(1, -np.nan): "(1+nanj)",
-        }
+    TESTS = {
+        complex(np.inf, 0): "(inf+0j)",
+        complex(0, np.inf): "inf*j",
+        complex(-np.inf, 0): "(-inf+0j)",
+        complex(0, -np.inf): "-inf*j",
+        complex(np.inf, 1): "(inf+1j)",
+        complex(1, np.inf): "(1+inf*j)",
+        complex(-np.inf, 1): "(-inf+1j)",
+        complex(1, -np.inf): "(1-inf*j)",
+        complex(np.nan, 0): "(nan+0j)",
+        complex(0, np.nan): "nan*j",
+        complex(-np.nan, 0): "(nan+0j)",
+        complex(0, -np.nan): "nan*j",
+        complex(np.nan, 1): "(nan+1j)",
+        complex(1, np.nan): "(1+nan*j)",
+        complex(-np.nan, 1): "(nan+1j)",
+        complex(1, -np.nan): "(1+nan*j)",
+    }
     for tp in [np.complex64, np.cdouble, np.clongdouble]:
         for c, s in TESTS.items():
             yield _check_complex_inf_nan, c, s, tp
@@ -167,11 +139,7 @@ def check_float_type_print(tp):
     if tp(1e10).itemsize > 4:
         _test_redirected_print(float(1e10), tp)
     else:
-        if sys.platform == 'win32' and sys.version_info[0] <= 2 and \
-           sys.version_info[1] <= 5:
-            ref = '1e+010'
-        else:
-            ref = '1e+10'
+        ref = '1e+10'
         _test_redirected_print(float(1e10), tp, ref)
 
 def check_complex_type_print(tp):
@@ -183,11 +151,7 @@ def check_complex_type_print(tp):
     if tp(1e10).itemsize > 8:
         _test_redirected_print(complex(1e10), tp)
     else:
-        if sys.platform == 'win32' and sys.version_info[0] <= 2 and \
-           sys.version_info[1] <= 5:
-            ref = '(1e+010+0j)'
-        else:
-            ref = '(1e+10+0j)'
+        ref = '(1e+10+0j)'
         _test_redirected_print(complex(1e10), tp, ref)
 
     _test_redirected_print(complex(np.inf, 1), tp, '(inf+1j)')
@@ -204,7 +168,6 @@ def test_complex_type_print():
     for t in [np.complex64, np.cdouble, np.clongdouble] :
         yield check_complex_type_print, t
 
-@dec.skipif(sys.version_info[:2] < (2, 6))
 def test_scalar_format():
     """Test the str.format method with NumPy scalar types"""
     tests = [('{0}', True, np.bool_),

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -447,9 +447,6 @@ class TestLdexp(TestCase):
         self._check_ldexp('i')
         self._check_ldexp('l')
 
-    @dec.knownfailureif(sys.platform == 'win32' and sys.version_info < (2, 6),
-                        "python.org < 2.6 binaries have broken ldexp in the "
-                        "C runtime")
     def test_ldexp_overflow(self):
         # silence warning emitted on overflow
         err = np.seterr(over="ignore")
@@ -916,12 +913,6 @@ class TestComplexFunctions(object):
     def test_against_cmath(self):
         import cmath, sys
 
-        # cmath.asinh is broken in some versions of Python, see
-        # http://bugs.python.org/issue1381
-        broken_cmath_asinh = False
-        if sys.version_info < (2,6):
-            broken_cmath_asinh = True
-
         points = [-1-1j, -1+1j, +1-1j, +1+1j]
         name_map = {'arcsin': 'asin', 'arccos': 'acos', 'arctan': 'atan',
                     'arcsinh': 'asinh', 'arccosh': 'acosh', 'arctanh': 'atanh'}
@@ -936,10 +927,6 @@ class TestComplexFunctions(object):
             for p in points:
                 a = complex(func(np.complex_(p)))
                 b = cfunc(p)
-
-                if cname == 'asinh' and broken_cmath_asinh:
-                    continue
-
                 assert_(abs(a - b) < atol, "%s %s: %s; cmath: %s"%(fname,p,a,b))
 
     def check_loss_of_precision(self, dtype):

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -129,8 +129,7 @@ class BagObj(object):
 
 def zipfile_factory(*args, **kwargs):
     import zipfile
-    if sys.version_info >= (2, 5):
-        kwargs['allowZip64'] = True
+    kwargs['allowZip64'] = True
     return zipfile.ZipFile(*args, **kwargs)
 
 class NpzFile(object):

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -84,17 +84,10 @@ def get_numarray_include(type=None):
         return include_dirs + [get_include()]
 
 
-if sys.version_info < (2, 4):
-    # Can't set __name__ in 2.3
-    import new
-    def _set_function_name(func, name):
-        func = new.function(func.__code__, func.__globals__,
-                            name, func.__defaults__, func.__closure__)
-        return func
-else:
-    def _set_function_name(func, name):
-        func.__name__ = name
-        return func
+def _set_function_name(func, name):
+    func.__name__ = name
+    return func
+
 
 class _Deprecate(object):
     """

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -70,16 +70,6 @@ class PolyBase(object) :
     pass
 
 #
-# We need the any function for python < 2.5
-#
-if sys.version_info[:2] < (2,5) :
-    def any(iterable) :
-        for element in iterable:
-            if element :
-                return True
-        return False
-
-#
 # Helper functions to convert inputs to 1-D arrays
 #
 def trimseq(seq) :


### PR DESCRIPTION
Now that only Python versions 2.6-2.7 and 3.2-3.3 are supported
some version checks are no longer needed. This patch removes them
so as to clean up the code.
