### PR TITLE
ENH: remove obsolete ifort flags

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 
-from numpy.distutils.cpuinfo import cpu
 from numpy.distutils.ccompiler import simple_version_match
 from numpy.distutils.fcompiler import FCompiler, dummy_fortran_file
 
@@ -163,21 +162,10 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
         return ['/4Yb','/d2']
 
     def get_flags_opt(self):
-        return ['/O1']
+        return ['/O2']
 
     def get_flags_arch(self):
-        opt = []
-        if cpu.is_PentiumPro() or cpu.is_PentiumII():
-            opt.extend(['/G6','/Qaxi'])
-        elif cpu.is_PentiumIII():
-            opt.extend(['/G6','/QaxK'])
-        elif cpu.is_Pentium():
-            opt.append('/G5')
-        elif cpu.is_PentiumIV():
-            opt.extend(['/G7','/QaxW'])
-        if cpu.has_mmx():
-            opt.append('/QaxM')
-        return opt
+        return ["/arch:IA-32", "/QaxSSE3"]
 
 class IntelItaniumVisualFCompiler(IntelVisualFCompiler):
     compiler_type = 'intelev'
@@ -203,6 +191,9 @@ class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     description = 'Intel Visual Fortran Compiler for 64-bit apps'
 
     version_match = simple_version_match(start='Intel\(R\).*?64,')
+
+    def get_flags_arch(self):
+        return ["/arch:SSE2"]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I removed obsolete ifort flags on windows (they were so old that I could not find any help on their meaning).

I removed the fragile CPU-specific code, and instead use sensible default (I think): code is generated to work on the most common architecture, with optimized code path generated for relatively recent ones (SSE3 on ia32, no optimization on amd64).

This allowed me to build scipy 0.12.0 and run the test suite without any error on both win32 and win64 (using vs 2008 and ifort + MKL).

David
