### PR TITLE
Backport fix for np.concatenate with axis=None

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -469,7 +469,8 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
     PyTypeObject *subtype = &PyArray_Type;
     double priority = NPY_PRIORITY;
     int iarrays;
-    npy_intp shape[2], strides[2];
+    npy_intp stride, sizes[NPY_MAXDIMS];
+    npy_intp shape = 0;
     PyArray_Descr *dtype = NULL;
     PyArrayObject *ret = NULL;
     PyArrayObject_fields *sliding_view = NULL;
@@ -480,19 +481,17 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         return NULL;
     }
 
-    /* All the arrays must have the same total number of elements */
-    shape[0] = narrays;
-    shape[1] = PyArray_SIZE(arrays[0]);
-
     /*
      * Figure out the final concatenated shape starting from the first
      * array's shape.
      */
-    for (iarrays = 1; iarrays < narrays; ++iarrays) {
-        if (PyArray_SIZE(arrays[iarrays]) != shape[1]) {
+    for (iarrays = 0; iarrays < narrays; ++iarrays) {
+        shape += sizes[iarrays] = PyArray_SIZE(arrays[iarrays]);
+        /* Check for overflow */
+        if (shape < 0) { 
             PyErr_SetString(PyExc_ValueError,
-                            "all the input arrays must have same "
-                            "number of elements");
+                            "total number of elements "
+                            "too large to concatenate");
             return NULL;
         }
     }
@@ -514,15 +513,14 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         return NULL;
     }
 
-    strides[1] = dtype->elsize;
-    strides[0] = strides[1] * shape[1];
+    stride = dtype->elsize;
 
     /* Allocate the array for the result. This steals the 'dtype' reference. */
     ret = (PyArrayObject *)PyArray_NewFromDescr(subtype,
                                                     dtype,
-                                                    2,
-                                                    shape,
-                                                    strides,
+                                                    1,
+                                                    &shape,
+                                                    &stride,
                                                     NULL,
                                                     0,
                                                     NULL);
@@ -540,9 +538,10 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         Py_DECREF(ret);
         return NULL;
     }
-    /* Each array gets flattened into one slot along 'axis' */
-    sliding_view->dimensions[0] = 1;
+
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
+        /* Adjust the window dimensions for this array */
+        sliding_view->dimensions[0] = sizes[iarrays];
 
         /* Copy the data for this array */
         if (PyArray_CopyAsFlat((PyArrayObject *)sliding_view, arrays[iarrays],
@@ -553,7 +552,7 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         }
 
         /* Slide to the start of the next window */
-        sliding_view->data += sliding_view->strides[0];
+        sliding_view->data += sliding_view->strides[0] * sizes[iarrays];
     }
 
     Py_DECREF(sliding_view);

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -1,7 +1,7 @@
 import warnings
 from numpy.testing import *
 from numpy.core import array, atleast_1d, atleast_2d, atleast_3d, vstack, \
-        hstack, newaxis, concatenate, arange
+        hstack, newaxis, concatenate, arange, float64
 
 class TestAtleast1d(TestCase):
     def test_0D_array(self):
@@ -209,6 +209,20 @@ def test_concatenate_sloppy0():
         warnings.filters.pop(0)
         warnings.filters.pop(0)
 
+def test_concatenate_axis_None():
+    a = arange(4, dtype=float64).reshape((2,2))
+    b = range(3)
+    c = ['x']
+    r = concatenate((a, a), axis=None)
+    assert_equal(r.dtype, a.dtype)
+    assert_equal(r.ndim, 1)
+    r = concatenate((a, b), axis=None)
+    assert_equal(r.size, a.size + len(b))
+    assert_equal(r.dtype, a.dtype)
+    r = concatenate((a, b, c), axis=None)
+    d = array(['0', '1', '2', '3', 
+               '0', '1', '2', 'x'])
+    assert_array_equal(r,d)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
I created a branch off of maintenance/1.7.x and cherry picked two commits from master:

027c3d91b6b5bbc0f7e50cce8a39da439e165d39
7c183a5d03ae31a6369cdcc608b4e4fabf83484f

and resolved the conflicts in the unittest.  I verified the tests run.

See issue https://github.com/numpy/numpy/issues/3274
