### PR TITLE
BUG: np.insert must copy index array

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3694,7 +3694,8 @@ def insert(arr, obj, values, axis=None):
         # turn it into a range object
         indices = arange(*obj.indices(N),**{'dtype':intp})
     else:
-        indices = np.asarray(obj)
+        # need to copy obj, because indices will be changed in-place
+        indices = np.array(obj)
         if indices.dtype == bool:
             # See also delete
             warnings.warn("in the future insert will treat boolean arrays "

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -231,6 +231,10 @@ class TestInsert(TestCase):
         a = np.array(1).view(SubClass)
         assert_(isinstance(np.insert(a, 0, [0]), SubClass))
 
+    def test_index_array_copied(self):
+        x = np.array([1, 1, 1])
+        np.insert([0, 1, 2], x, [3, 4, 5])
+        assert_equal(x, np.array([1, 1, 1]))
 
 class TestAmax(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Otherwise it would do in-place changes to it. Fixes gh-3279.
