### PR TITLE
ENH: allow 0-by-0 in linalg.inv and linalg.solve

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -349,10 +349,12 @@ def solve(a, b):
 
     """
     a, _ = _makearray(a)
-    _assertNonEmpty(a)
     _assertRankAtLeast2(a)
     _assertNdSquareness(a)
     b, wrap = _makearray(b)
+    if size(a) == 0:
+        # last two dimensions must be zero
+        return wrap(b.copy())
     t, result_t = _commonType(a, b)
 
     if len(b.shape) == len(a.shape) - 1:
@@ -491,9 +493,11 @@ def inv(a):
 
     """
     a, wrap = _makearray(a)
-    _assertNonEmpty(a)
     _assertRankAtLeast2(a)
     _assertNdSquareness(a)
+    if size(a) == 0:
+        # last two dimensions must be zero
+        return wrap(a.copy())
     t, result_t = _commonType(a)
     signature = 'D->D' if isComplexType(t) else 'd->d'
     extobj = get_linalg_error_extobj(_raise_linalgerror_singular)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -352,10 +352,10 @@ def solve(a, b):
     _assertRankAtLeast2(a)
     _assertNdSquareness(a)
     b, wrap = _makearray(b)
+    t, result_t = _commonType(a, b)
     if size(a) == 0:
         # last two dimensions must be zero
-        return wrap(b.copy())
-    t, result_t = _commonType(a, b)
+        return wrap(b.astype(result_t))
 
     if len(b.shape) == len(a.shape) - 1:
         gufunc = _umath_linalg.solve1
@@ -495,10 +495,10 @@ def inv(a):
     a, wrap = _makearray(a)
     _assertRankAtLeast2(a)
     _assertNdSquareness(a)
+    t, result_t = _commonType(a)
     if size(a) == 0:
         # last two dimensions must be zero
-        return wrap(a.copy())
-    t, result_t = _commonType(a)
+        return wrap(a.astype(result_t))
     signature = 'D->D' if isComplexType(t) else 'd->d'
     extobj = get_linalg_error_extobj(_raise_linalgerror_singular)
     ainv = _umath_linalg.inv(a, signature=signature, extobj=extobj)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -146,6 +146,13 @@ class LinalgNonsquareTestCase(object):
         self.do(a, b)
 
 
+class LinalgZeroShapeTestCase(object):
+    def test_zero(self):
+        a = np.zeros((0,0))
+        b = np.zeros((0,5))
+        self.do(a, b)
+
+
 def _generalized_testcase(new_cls_name, old_cls):
     def get_method(old_name, new_name):
         def method(self):
@@ -190,7 +197,7 @@ def identity_like_generalized(a):
     return identity(a.shape[0])
 
 
-class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase, TestCase):
+class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase, LinalgZeroShapeTestCase, TestCase):
     def do(self, a, b):
         x = linalg.solve(a, b)
         assert_almost_equal(b, dot_generalized(a, x))
@@ -204,7 +211,7 @@ class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase, TestCase):
             yield check, dtype
 
 
-class TestInv(LinalgTestCase, LinalgGeneralizedTestCase, TestCase):
+class TestInv(LinalgTestCase, LinalgGeneralizedTestCase, LinalgZeroShapeTestCase, TestCase):
     def do(self, a, b):
         a_inv = linalg.inv(a)
         assert_almost_equal(dot_generalized(a, a_inv),

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -197,7 +197,8 @@ def identity_like_generalized(a):
     return identity(a.shape[0])
 
 
-class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase, LinalgZeroShapeTestCase, TestCase):
+class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase,
+        LinalgZeroShapeTestCase, TestCase):
     def do(self, a, b):
         x = linalg.solve(a, b)
         assert_almost_equal(b, dot_generalized(a, x))
@@ -211,7 +212,8 @@ class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase, LinalgZeroShapeTestCa
             yield check, dtype
 
 
-class TestInv(LinalgTestCase, LinalgGeneralizedTestCase, LinalgZeroShapeTestCase, TestCase):
+class TestInv(LinalgTestCase, LinalgGeneralizedTestCase,
+        LinalgZeroShapeTestCase, TestCase):
     def do(self, a, b):
         a_inv = linalg.inv(a)
         assert_almost_equal(dot_generalized(a, a_inv),


### PR DESCRIPTION
Allows 0-by-0 matrix in linalg.inv and linalg.solve. The inverse of the 0-by-0
matrix is again the 0-by-0 inverse. Closes #3291.
