### PR TITLE
Adding np.nanmean(), nanstd(), and nanvar()

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -21,7 +21,8 @@ __all__ = ['take', 'reshape', 'choose', 'repeat', 'put',
            'resize', 'diagonal', 'trace', 'ravel', 'nonzero', 'shape',
            'compress', 'clip', 'sum', 'product', 'prod', 'sometrue', 'alltrue',
            'any', 'all', 'cumsum', 'cumproduct', 'cumprod', 'ptp', 'ndim',
-           'rank', 'size', 'around', 'round_', 'mean', 'std', 'var', 'squeeze',
+           'rank', 'size', 'around', 'round_', 'mean', 'nanmean',
+           'std', 'nanstd', 'var', 'nanvar', 'squeeze',
            'amax', 'amin',
           ]
 
@@ -2454,6 +2455,8 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
     See Also
     --------
     average : Weighted average
+    nanmean : Arithmetic mean while ignoring NaNs
+    var, nanvar
 
     Notes
     -----
@@ -2500,6 +2503,80 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
     return _methods._mean(a, axis=axis, dtype=dtype,
                             out=out, keepdims=keepdims)
 
+def nanmean(a, axis=None, dtype=None, out=None, keepdims=False):
+    """
+    Compute the arithmetic mean along the specified axis, ignoring NaNs.
+
+    Returns the average of the array elements.  The average is taken over
+    the flattened array by default, otherwise over the specified axis.
+    `float64` intermediate and return values are used for integer inputs.
+
+    Parameters
+    ----------
+    a : array_like
+        Array containing numbers whose mean is desired. If `a` is not an
+        array, a conversion is attempted.
+    axis : int, optional
+        Axis along which the means are computed. The default is to compute
+        the mean of the flattened array.
+    dtype : data-type, optional
+        Type to use in computing the mean.  For integer inputs, the default
+        is `float64`; for floating point inputs, it is the same as the
+        input dtype.
+    out : ndarray, optional
+        Alternate output array in which to place the result.  The default
+        is ``None``; if provided, it must have the same shape as the
+        expected output, but the type will be cast if necessary.
+        See `doc.ufuncs` for details.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the original `arr`.
+
+    Returns
+    -------
+    m : ndarray, see dtype parameter above
+        If `out=None`, returns a new array containing the mean values,
+        otherwise a reference to the output array is returned.
+
+    See Also
+    --------
+    average : Weighted average
+    mean : Arithmetic mean taken while not ignoring NaNs
+    var, nanvar
+
+    Notes
+    -----
+    The arithmetic mean is the sum of the non-nan elements along the axis
+    divided by the number of non-nan elements.
+
+    Note that for floating-point input, the mean is computed using the
+    same precision the input has.  Depending on the input data, this can
+    cause the results to be inaccurate, especially for `float32`.
+    Specifying a higher-precision accumulator using the `dtype` keyword
+    can alleviate this issue.
+
+    Examples
+    --------
+    >>> a = np.array([[1, np.nan], [3, 4]])
+    >>> np.nanmean(a)
+    2.6666666666666665
+    >>> np.nanmean(a, axis=0)
+    array([ 2.,  4.])
+    >>> np.nanmean(a, axis=1)
+    array([ 1.,  3.5])
+
+    """
+    if not (type(a) is mu.ndarray):
+        try:
+            mean = a.nanmean
+            return mean(axis=axis, dtype=dtype, out=out)
+        except AttributeError:
+            pass
+
+    return _methods._nanmean(a, axis=axis, dtype=dtype,
+                             out=out, keepdims=keepdims)
+
 
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     """
@@ -2542,6 +2619,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     See Also
     --------
     var, mean
+    nanmean, nanstd
     numpy.doc.ufuncs : Section "Output arguments"
 
     Notes
@@ -2600,6 +2678,97 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
             pass
 
     return _methods._std(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                                keepdims=keepdims)
+
+def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+    """
+    Compute the standard deviation along the specified axis, while
+    ignoring NaNs.
+
+    Returns the standard deviation, a measure of the spread of a distribution,
+    of the non-NaN array elements. The standard deviation is computed for the
+    flattened array by default, otherwise over the specified axis.
+
+    Parameters
+    ----------
+    a : array_like
+        Calculate the standard deviation of the non-NaN values.
+    axis : int, optional
+        Axis along which the standard deviation is computed. The default is
+        to compute the standard deviation of the flattened array.
+    dtype : dtype, optional
+        Type to use in computing the standard deviation. For arrays of
+        integer type the default is float64, for arrays of float types it is
+        the same as the array type.
+    out : ndarray, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output but the type (of the calculated
+        values) will be cast if necessary.
+    ddof : int, optional
+        Means Delta Degrees of Freedom.  The divisor used in calculations
+        is ``N - ddof``, where ``N`` represents the number of elements.
+        By default `ddof` is zero.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the original `arr`.
+
+    Returns
+    -------
+    standard_deviation : ndarray, see dtype parameter above.
+        If `out` is None, return a new array containing the standard deviation,
+        otherwise return a reference to the output array.
+
+    See Also
+    --------
+    var, mean, std
+    nanvar, nanmean
+    numpy.doc.ufuncs : Section "Output arguments"
+
+    Notes
+    -----
+    The standard deviation is the square root of the average of the squared
+    deviations from the mean, i.e., ``std = sqrt(mean(abs(x - x.mean())**2))``.
+
+    The average squared deviation is normally calculated as
+    ``x.sum() / N``, where ``N = len(x)``.  If, however, `ddof` is specified,
+    the divisor ``N - ddof`` is used instead. In standard statistical
+    practice, ``ddof=1`` provides an unbiased estimator of the variance
+    of the infinite population. ``ddof=0`` provides a maximum likelihood
+    estimate of the variance for normally distributed variables. The
+    standard deviation computed in this function is the square root of
+    the estimated variance, so even with ``ddof=1``, it will not be an
+    unbiased estimate of the standard deviation per se.
+
+    Note that, for complex numbers, `std` takes the absolute
+    value before squaring, so that the result is always real and nonnegative.
+
+    For floating-point input, the *std* is computed using the same
+    precision the input has. Depending on the input data, this can cause
+    the results to be inaccurate, especially for float32 (see example below).
+    Specifying a higher-accuracy accumulator using the `dtype` keyword can
+    alleviate this issue.
+
+    Examples
+    --------
+    >>> a = np.array([[1, np.nan], [3, 4]])
+    >>> np.nanstd(a)
+    1.247219128924647
+    >>> np.nanstd(a, axis=0)
+    array([ 1.,  0.])
+    >>> np.nanstd(a, axis=1)
+    array([ 0.,  0.5])
+
+    """
+
+    if not (type(a) is mu.ndarray):
+        try:
+            nanstd = a.nanstd
+            return nanstd(axis=axis, dtype=dtype, out=out, ddof=ddof)
+        except AttributeError:
+            pass
+
+    return _methods._nanstd(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
                                 keepdims=keepdims)
 
 def var(a, axis=None, dtype=None, out=None, ddof=0,
@@ -2704,3 +2873,95 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
 
     return _methods._var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
                                 keepdims=keepdims)
+
+
+def nanvar(a, axis=None, dtype=None, out=None, ddof=0,
+                            keepdims=False):
+    """
+    Compute the variance along the specified axis, while ignoring NaNs.
+
+    Returns the variance of the array elements, a measure of the spread of a
+    distribution.  The variance is computed for the flattened array by
+    default, otherwise over the specified axis.
+
+    Parameters
+    ----------
+    a : array_like
+        Array containing numbers whose variance is desired.  If `a` is not an
+        array, a conversion is attempted.
+    axis : int, optional
+        Axis along which the variance is computed.  The default is to compute
+        the variance of the flattened array.
+    dtype : data-type, optional
+        Type to use in computing the variance.  For arrays of integer type
+        the default is `float32`; for arrays of float types it is the same as
+        the array type.
+    out : ndarray, optional
+        Alternate output array in which to place the result.  It must have
+        the same shape as the expected output, but the type is cast if
+        necessary.
+    ddof : int, optional
+        "Delta Degrees of Freedom": the divisor used in the calculation is
+        ``N - ddof``, where ``N`` represents the number of elements. By
+        default `ddof` is zero.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the original `arr`.
+
+    Returns
+    -------
+    variance : ndarray, see dtype parameter above
+        If ``out=None``, returns a new array containing the variance;
+        otherwise, a reference to the output array is returned.
+
+    See Also
+    --------
+    std : Standard deviation
+    mean : Average
+    var : Variance while not ignoring NaNs
+    nanstd, nanmean
+    numpy.doc.ufuncs : Section "Output arguments"
+
+    Notes
+    -----
+    The variance is the average of the squared deviations from the mean,
+    i.e.,  ``var = mean(abs(x - x.mean())**2)``.
+
+    The mean is normally calculated as ``x.sum() / N``, where ``N = len(x)``.
+    If, however, `ddof` is specified, the divisor ``N - ddof`` is used
+    instead.  In standard statistical practice, ``ddof=1`` provides an
+    unbiased estimator of the variance of a hypothetical infinite population.
+    ``ddof=0`` provides a maximum likelihood estimate of the variance for
+    normally distributed variables.
+
+    Note that for complex numbers, the absolute value is taken before
+    squaring, so that the result is always real and nonnegative.
+
+    For floating-point input, the variance is computed using the same
+    precision the input has.  Depending on the input data, this can cause
+    the results to be inaccurate, especially for `float32` (see example
+    below).  Specifying a higher-accuracy accumulator using the ``dtype``
+    keyword can alleviate this issue.
+
+    Examples
+    --------
+    >>> a = np.array([[1, np.nan], [3, 4]])
+    >>> np.var(a)
+    1.5555555555555554
+    >>> np.nanvar(a, axis=0)
+    array([ 1.,  0.])
+    >>> np.nanvar(a, axis=1)
+    array([ 0.,  0.25])
+
+    """
+
+    if not (type(a) is mu.ndarray):
+        try:
+            nanvar = a.nanvar
+            return nanvar(axis=axis, dtype=dtype, out=out, ddof=ddof)
+        except AttributeError:
+            pass
+
+    return _methods._nanvar(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                            keepdims=keepdims)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1334,6 +1334,19 @@ class TestNaNMean(TestCase):
     def test_basic(self):
         assert_almost_equal(nanmean(self.A),self.real_mean)
 
+    def test_mutation(self):
+        # Because of the "messing around" we do to replace NaNs with zeros
+        # this is meant to ensure we don't actually replace the NaNs in the
+        # actual array.
+        a_copy = self.A.copy()
+        b_copy = self.B.copy()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            a_ret = nanmean(self.A)
+            assert_equal(self.A, a_copy)
+            b_ret = nanmean(self.B)
+            assert_equal(self.B, b_copy)
+
     def test_allnans(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
@@ -1376,6 +1389,19 @@ class TestNaNStdVar(TestCase):
     def test_basic(self):
         assert_almost_equal(nanvar(self.A),self.real_var)
         assert_almost_equal(nanstd(self.A)**2,self.real_var)
+
+    def test_mutation(self):
+        # Because of the "messing around" we do to replace NaNs with zeros
+        # this is meant to ensure we don't actually replace the NaNs in the
+        # actual array.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            a_copy = self.A.copy()
+            b_copy = self.B.copy()
+            a_ret = nanvar(self.A)
+            assert_equal(self.A, a_copy)
+            b_ret = nanstd(self.B)
+            assert_equal(self.B, b_copy)
 
     def test_ddof1(self):
         assert_almost_equal(nanvar(self.A,ddof=1),

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -177,17 +177,35 @@ class TestNonarrayArgs(TestCase):
         assert_(all(mean(A,0) == array([2.5,3.5,4.5])))
         assert_(all(mean(A,1) == array([2.,5.])))
 
+    def test_nanmean(self):
+        A = [[1, nan, nan], [nan, 4, 5]]
+        assert_(nanmean(A) == (10.0 / 3))
+        assert_(all(nanmean(A,0) == array([1, 4, 5])))
+        assert_(all(nanmean(A,1) == array([1, 4.5])))
+
     def test_std(self):
         A = [[1,2,3],[4,5,6]]
         assert_almost_equal(std(A), 1.707825127659933)
         assert_almost_equal(std(A,0), array([1.5, 1.5, 1.5]))
         assert_almost_equal(std(A,1), array([0.81649658, 0.81649658]))
 
+    def test_nanstd(self):
+        A = [[1, nan, nan], [nan, 4, 5]]
+        assert_almost_equal(nanstd(A), 1.699673171197595)
+        assert_almost_equal(nanstd(A,0), array([0.0, 0.0, 0.0]))
+        assert_almost_equal(nanstd(A,1), array([0.0, 0.5]))
+
     def test_var(self):
         A = [[1,2,3],[4,5,6]]
         assert_almost_equal(var(A), 2.9166666666666665)
         assert_almost_equal(var(A,0), array([2.25, 2.25, 2.25]))
         assert_almost_equal(var(A,1), array([0.66666667, 0.66666667]))
+
+    def test_nanvar(self):
+        A = [[1, nan, nan], [nan, 4, 5]]
+        assert_almost_equal(nanvar(A), 2.88888888889)
+        assert_almost_equal(nanvar(A,0), array([0.0, 0.0, 0.0]))
+        assert_almost_equal(nanvar(A,1), array([0.0, 0.25]))
 
 
 class TestBoolScalar(TestCase):
@@ -1291,6 +1309,23 @@ class TestIsclose(object):
         assert_array_equal(x, array([inf, 1]))
         assert_array_equal(y, array([0, inf]))
 
+class TestNaNMean(TestCase):
+    def setUp(self):
+        self.A = array([1,nan,-1,nan,nan,1,-1])
+        self.B = array([nan, nan, nan, nan])
+        self.real_mean = 0
+
+    def test_basic(self):
+        assert_almost_equal(nanmean(self.A),self.real_mean)
+
+    def test_allnans(self):
+        assert_(isnan(nanmean(self.B)))
+
+    def test_empty(self):
+        assert_(isnan(nanmean(array([]))))
+
+
+
 
 class TestStdVar(TestCase):
     def setUp(self):
@@ -1312,6 +1347,36 @@ class TestStdVar(TestCase):
                             self.real_var*len(self.A)/float(len(self.A)-2))
         assert_almost_equal(std(self.A,ddof=2)**2,
                             self.real_var*len(self.A)/float(len(self.A)-2))
+
+class TestNaNStdVar(TestCase):
+    def setUp(self):
+        self.A = array([nan,1,-1,nan,1,nan,-1])
+        self.B = array([nan, nan, nan, nan])
+        self.real_var = 1
+
+    def test_basic(self):
+        assert_almost_equal(nanvar(self.A),self.real_var)
+        assert_almost_equal(nanstd(self.A)**2,self.real_var)
+
+    def test_ddof1(self):
+        assert_almost_equal(nanvar(self.A,ddof=1),
+                self.real_var*sum(~isnan(self.A))/float(sum(~isnan(self.A))-1))
+        assert_almost_equal(nanstd(self.A,ddof=1)**2,
+                self.real_var*sum(~isnan(self.A))/float(sum(~isnan(self.A))-1))
+
+    def test_ddof2(self):
+        assert_almost_equal(nanvar(self.A,ddof=2),
+                self.real_var*sum(~isnan(self.A))/float(sum(~isnan(self.A))-2))
+        assert_almost_equal(nanstd(self.A,ddof=2)**2,
+                self.real_var*sum(~isnan(self.A))/float(sum(~isnan(self.A))-2))
+
+    def test_allnans(self):
+        assert_(isnan(nanvar(self.B)))
+        assert_(isnan(nanstd(self.B)))
+
+    def test_empty(self):
+        assert_(isnan(nanvar(array([]))))
+        assert_(isnan(nanstd(array([]))))
 
 
 class TestStdVarComplex(TestCase):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import platform
 from decimal import Decimal
+import warnings
 
 import numpy as np
 from numpy.core import *
@@ -177,6 +178,11 @@ class TestNonarrayArgs(TestCase):
         assert_(all(mean(A,0) == array([2.5,3.5,4.5])))
         assert_(all(mean(A,1) == array([2.,5.])))
 
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(mean([])))
+            assert_(w[0].category is RuntimeWarning)
+
     def test_nanmean(self):
         A = [[1, nan, nan], [nan, 4, 5]]
         assert_(nanmean(A) == (10.0 / 3))
@@ -189,6 +195,11 @@ class TestNonarrayArgs(TestCase):
         assert_almost_equal(std(A,0), array([1.5, 1.5, 1.5]))
         assert_almost_equal(std(A,1), array([0.81649658, 0.81649658]))
 
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(std([])))
+            assert_(w[0].category is RuntimeWarning)
+
     def test_nanstd(self):
         A = [[1, nan, nan], [nan, 4, 5]]
         assert_almost_equal(nanstd(A), 1.699673171197595)
@@ -200,6 +211,11 @@ class TestNonarrayArgs(TestCase):
         assert_almost_equal(var(A), 2.9166666666666665)
         assert_almost_equal(var(A,0), array([2.25, 2.25, 2.25]))
         assert_almost_equal(var(A,1), array([0.66666667, 0.66666667]))
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(mean([])))
+            assert_(w[0].category is RuntimeWarning)
 
     def test_nanvar(self):
         A = [[1, nan, nan], [nan, 4, 5]]
@@ -1319,13 +1335,16 @@ class TestNaNMean(TestCase):
         assert_almost_equal(nanmean(self.A),self.real_mean)
 
     def test_allnans(self):
-        assert_(isnan(nanmean(self.B)))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(nanmean(self.B)))
+            assert_(w[0].category is RuntimeWarning)
 
     def test_empty(self):
-        assert_(isnan(nanmean(array([]))))
-
-
-
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(nanmean(array([]))))
+            assert_(w[0].category is RuntimeWarning)
 
 class TestStdVar(TestCase):
     def setUp(self):
@@ -1371,13 +1390,18 @@ class TestNaNStdVar(TestCase):
                 self.real_var*sum(~isnan(self.A))/float(sum(~isnan(self.A))-2))
 
     def test_allnans(self):
-        assert_(isnan(nanvar(self.B)))
-        assert_(isnan(nanstd(self.B)))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(nanvar(self.B)))
+            assert_(isnan(nanstd(self.B)))
+            assert_(w[0].category is RuntimeWarning)
 
     def test_empty(self):
-        assert_(isnan(nanvar(array([]))))
-        assert_(isnan(nanstd(array([]))))
-
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_(isnan(nanvar(array([]))))
+            assert_(isnan(nanstd(array([]))))
+            assert_(w[0].category is RuntimeWarning)
 
 class TestStdVarComplex(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Added these functions, but still needs some tests and verification.  I did put these functions in a completely different location than where the nansum(), nanmin(), and family are because the way to do the work more closely matched those in _methods.py rather than in function_base.py.

I will update this PR with some test code soon.
