### PR TITLE
accept file-like objects in np.load memmap mode

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -39,7 +39,7 @@ Capabilities
   read most ``.npy`` files that he has been given without much
   documentation.
 
-- Allows memory-mapping of the data. See `open_memmep`.
+- Allows memory-mapping of the data. See `open_memmap`.
 
 - Can be read from a filelike stream object instead of an actual file.
 

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -473,15 +473,15 @@ def read_array(fp):
 def open_memmap(filename, mode='r+', dtype=None, shape=None,
                 fortran_order=False, version=(1,0)):
     """
-    Open a .npy file as a memory-mapped array.
+    Open a uncompressed .npy file as a memory-mapped array.
 
     This may be used to read an existing file or create a new one.
 
     Parameters
     ----------
     filename : str
-        The name of the file on disk.  This may *not* be a file-like
-        object.
+        The name of the file on disk.  This may be a memory mappable
+        file-like object which is then seeked to the end of the data.
     mode : str, optional
         The mode in which to open the file; the default is 'r+'.  In
         addition to the standard file modes, 'c' is also accepted to
@@ -519,11 +519,11 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
     memmap
 
     """
-    if not isinstance(filename, basestring):
-        raise ValueError("Filename must be a string.  Memmap cannot use" \
-                         " existing file handles.")
 
     if 'w' in mode:
+        if not isinstance(filename, basestring):
+            raise ValueError("Filename must be a string.  Truncating memmap"
+                             " cannot use existing file handles.")
         # We are creating the file, not reading it.
         # Check if we ought to create the file.
         if version != (1, 0):
@@ -550,7 +550,11 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
             fp.close()
     else:
         # Read the header of the file first.
-        fp = open(filename, 'rb')
+        try:
+            fp = open(filename, 'rb')
+        except TypeError:
+            # assume its already a file-like
+            fp = filename
         try:
             version = read_magic(fp)
             if version != (1, 0):
@@ -562,7 +566,8 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
                 raise ValueError(msg)
             offset = fp.tell()
         finally:
-            fp.close()
+            if fp != filename:
+                fp.close()
 
     if fortran_order:
         order = 'F'

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -458,6 +458,38 @@ def test_memmap_roundtrip():
             del ma
 
 
+def test_memmap_load_file_like():
+    fn = os.path.join(tempdir, "file.npy");
+    d = np.array([1, 2, 3])
+    np.save(fn, d)
+    x = np.load(fn, mmap_mode='r')
+    assert_array_equal(x, d)
+    with open(fn, 'rb') as f:
+        # should not close it
+        x = np.load(f, mmap_mode='r')
+        f.seek(0, 0)
+        x2 = np.load(f)
+        assert_array_equal(x, x2)
+    assert_array_equal(x, d)
+
+
+def test_memmap_load_file_like_write():
+    fn = os.path.join(tempdir, "file.npy");
+    d = np.array([1, 2, 3])
+    np.save(fn, d)
+    x = np.load(fn, mmap_mode='r+')
+    assert_array_equal(x, d)
+    with open(fn, 'r+b') as f:
+        x = np.load(f, mmap_mode='r+')
+        f.seek(0, 0)
+        # change the data in the file (and the reference)
+        x[1] = -1
+        d[1] = -1
+        del x  # sync it
+    loaded = np.load(fn)
+    assert_array_equal(loaded, d)
+
+
 def test_write_version_1_0():
     f = BytesIO()
     arr = np.arange(1)


### PR DESCRIPTION
accept file-like objects in open_memmap

closes gh-3143
