### PR TITLE
ENH: use intrinsics for isnan, isfinite and isinf

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <math.h>
+#include <npy_config.h>
 #include <numpy/npy_common.h>
 
 /*
@@ -151,7 +152,7 @@ double npy_spacing(double x);
 
 /* use a builtins to avoid function calls in tight loops
  * documented only on 4.4, but available in at least 4.2 */
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
+#if HAVE___BUILTIN_ISNAN
     #define npy_isnan(x) __builtin_isnan(x)
 #else
     #ifndef NPY_HAVE_DECL_ISNAN
@@ -166,7 +167,7 @@ double npy_spacing(double x);
 #endif
 
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
+#if HAVE___BUILTIN_ISFINITE
     #define npy_isfinite(x) __builtin_isfinite(x)
 #else
     #ifndef NPY_HAVE_DECL_ISFINITE
@@ -180,7 +181,7 @@ double npy_spacing(double x);
     #endif
 #endif
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
+#if HAVE___BUILTIN_ISINF
     #define npy_isinf(x) __builtin_isinf(x)
 #else
     #ifndef NPY_HAVE_DECL_ISINF

--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -152,8 +152,8 @@ double npy_spacing(double x);
  * IEEE 754 fpu handling. Those are guaranteed to be macros
  */
 
-/* use a builtins to avoid function calls in tight loops
- * documented only on 4.4, but available in at least 4.2 */
+/* use builtins to avoid function calls in tight loops
+ * only available if npy_config.h is available (= numpys own build) */
 #if HAVE___BUILTIN_ISNAN
     #define npy_isnan(x) __builtin_isnan(x)
 #else
@@ -169,6 +169,7 @@ double npy_spacing(double x);
 #endif
 
 
+/* only available if npy_config.h is available (= numpys own build) */
 #if HAVE___BUILTIN_ISFINITE
     #define npy_isfinite(x) __builtin_isfinite(x)
 #else
@@ -183,6 +184,7 @@ double npy_spacing(double x);
     #endif
 #endif
 
+/* only available if npy_config.h is available (= numpys own build) */
 #if HAVE___BUILTIN_ISINF
     #define npy_isinf(x) __builtin_isinf(x)
 #else

--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -6,7 +6,9 @@ extern "C" {
 #endif
 
 #include <math.h>
+#ifdef NPY_HAVE_CONFIG_H
 #include <npy_config.h>
+#endif
 #include <numpy/npy_common.h>
 
 /*

--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -148,33 +148,49 @@ double npy_spacing(double x);
 /*
  * IEEE 754 fpu handling. Those are guaranteed to be macros
  */
-#ifndef NPY_HAVE_DECL_ISNAN
-    #define npy_isnan(x) ((x) != (x))
+
+/* use a builtins to avoid function calls in tight loops
+ * documented only on 4.4, but available in at least 4.2 */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
+    #define npy_isnan(x) __builtin_isnan(x)
 #else
-    #ifdef _MSC_VER
-        #define npy_isnan(x) _isnan((x))
+    #ifndef NPY_HAVE_DECL_ISNAN
+        #define npy_isnan(x) ((x) != (x))
     #else
-        #define npy_isnan(x) isnan((x))
+        #ifdef _MSC_VER
+            #define npy_isnan(x) _isnan((x))
+        #else
+            #define npy_isnan(x) isnan(x)
+        #endif
     #endif
 #endif
 
-#ifndef NPY_HAVE_DECL_ISFINITE
-    #ifdef _MSC_VER
-        #define npy_isfinite(x) _finite((x))
-    #else
-        #define npy_isfinite(x) !npy_isnan((x) + (-x))
-    #endif
+
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
+    #define npy_isfinite(x) __builtin_isfinite(x)
 #else
-    #define npy_isfinite(x) isfinite((x))
+    #ifndef NPY_HAVE_DECL_ISFINITE
+        #ifdef _MSC_VER
+            #define npy_isfinite(x) _finite((x))
+        #else
+            #define npy_isfinite(x) !npy_isnan((x) + (-x))
+        #endif
+    #else
+        #define npy_isfinite(x) isfinite((x))
+    #endif
 #endif
 
-#ifndef NPY_HAVE_DECL_ISINF
-    #define npy_isinf(x) (!npy_isfinite(x) && !npy_isnan(x))
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
+    #define npy_isinf(x) __builtin_isinf(x)
 #else
-    #ifdef _MSC_VER
-        #define npy_isinf(x) (!_finite((x)) && !_isnan((x)))
+    #ifndef NPY_HAVE_DECL_ISINF
+        #define npy_isinf(x) (!npy_isfinite(x) && !npy_isnan(x))
     #else
-        #define npy_isinf(x) isinf((x))
+        #ifdef _MSC_VER
+            #define npy_isinf(x) (!_finite((x)) && !_isnan((x)))
+        #else
+            #define npy_isinf(x) isinf((x))
+        #endif
     #endif
 #endif
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -161,6 +161,10 @@ def check_math_capabilities(config, moredefs, mathlibs):
 
     check_funcs(OPTIONAL_STDFUNCS)
 
+    for f, args in OPTIONAL_INTRINSICS:
+        if config.check_func(f, decl=False, call=True, call_args=args):
+            moredefs.append((fname2def(f), 1))
+
     # C99 functions: float and long double versions
     check_funcs(C99_FUNCS_SINGLE)
     check_funcs(C99_FUNCS_EXTENDED)

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -606,6 +606,8 @@ def configuration(parent_package='',top_path=None):
     config.add_include_dirs(join('src', 'umath'))
     config.add_include_dirs(join('src', 'npysort'))
 
+    config.add_define_macros([("HAVE_NPY_CONFIG_H", "1")])
+
     config.numpy_include_dirs.extend(config.paths('include'))
 
     deps = [join('src','npymath','_signbit.c'),

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -98,6 +98,7 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "copysign", "nextafter"]
 
 # optional gcc compiler builtins and their call arguments
+# call arguments are required as the compiler will do strict signature checking
 OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        ("__builtin_isinf", '5.'),
                        ("__builtin_isfinite", '5.')]

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -97,6 +97,11 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
         "copysign", "nextafter"]
 
+# optional gcc compiler builtins and their call arguments
+OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
+                       ("__builtin_isinf", '5.'),
+                       ("__builtin_isfinite", '5.')]
+
 # Subset of OPTIONAL_STDFUNCS which may alreay have HAVE_* defined by Python.h
 OPTIONAL_STDFUNCS_MAYBE = ["expm1", "log1p", "acosh", "atanh", "asinh", "hypot",
         "copysign"]

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -671,7 +671,7 @@ class Configuration(object):
 
     _list_keys = ['packages', 'ext_modules', 'data_files', 'include_dirs',
                   'libraries', 'headers', 'scripts', 'py_modules',
-                  'installed_libraries']
+                  'installed_libraries', 'define_macros']
     _dict_keys = ['package_dir', 'installed_pkg_config']
     _extra_keys = ['name', 'version']
 
@@ -1273,6 +1273,22 @@ class Configuration(object):
 
     ### XXX Implement add_py_modules
 
+    def add_define_macros(self, macros):
+        """Add define macros to configuration
+
+        Add the given sequence of macro name and value duples to the beginning
+        of the define_macros list This list will be visible to all extension
+        modules of the current package.
+        """
+        dist = self.get_distribution()
+        if dist is not None:
+            if not hasattr(dist, 'define_macros'):
+                dist.define_macros = []
+            dist.define_macros.extend(macros)
+        else:
+            self.define_macros.extend(macros)
+
+
     def add_include_dirs(self,*paths):
         """Add paths to configuration include directories.
 
@@ -1440,6 +1456,8 @@ class Configuration(object):
             libnames.append(libname)
 
         ext_args['libraries'] = libnames + ext_args['libraries']
+        ext_args['define_macros'] = \
+            self.define_macros + ext_args.get('define_macros', [])
 
         from numpy.distutils.core import Extension
         ext = Extension(**ext_args)


### PR DESCRIPTION
Use of intrinsics avoids expensive function calls in tight loops on x86
cpus where these operations are implemented in hardware while still
retaining same portability.
More than doubles performance of np.isnan/isinf/isfinite.
