### PR TITLE
BUG: fix potentially infinite recursion in VOID_nonzero. Fixes #3312.

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2321,7 +2321,7 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
              * TODO: temporarily modifying the array like this
              *       is bad coding style, should be changed.
              */
-            ((PyArrayObject_fields *)ap)->descr = descr;
+            ((PyArrayObject_fields *)ap)->descr = new;
             ((PyArrayObject_fields *)ap)->flags = savedflags;
             if ((new->alignment > 1) && !__ALIGNED(ip + offset,
                         new->alignment)) {

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1898,6 +1898,11 @@ class TestRegression(TestCase):
                               order='F')
         assert_array_equal(arr2, data_back)
 
+    def test_structured_count_nonzero(self):
+        arr = np.array([0, 1]).astype('i4, (2)i4')[:1]
+        count = np.count_nonzero(arr)
+        assert_equal(count, 0)
+
 
 
 


### PR DESCRIPTION
Commit https://github.com/numpy/numpy/commit/b7cc20ad3400f650bbc45feb5a0bad041722ef29 contains a typo; the code modifying the array sets `descr` to the saved value instead of the temporary value, giving recursive behaviour that only stops when `VOID_nonzero` walks off the array.
