### PR TITLE
BUG: testing: always enable --exe

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -188,6 +188,14 @@ class NoseTester(object):
                 label = 'not slow'
             argv += ['-A', label]
         argv += ['--verbosity', str(verbose)]
+
+        # When installing with setuptools, and also in some other cases, the
+        # test_*.py files end up marked +x executable. Nose, by default, does
+        # not run files marked with +x as they might be scripts. However, in
+        # our case nose only looks for test_*.py files under the package
+        # directory, which should be safe.
+        argv += ['--exe']
+
         if extra_argv:
             argv += extra_argv
         return argv


### PR DESCRIPTION
Setuptools tends to set +x to the installed test scripts, which makes
numpy.test() to not run any tests. Having --exe always enabled is not
problematic because only files matching 'test_*.py' are looked into.

For instance, if you installed Numpy with `setupegg.py`, you cannot run 
any tests. This issue really should be fixed.

Cases in point:

http://comments.gmane.org/gmane.comp.python.numeric.general/32309
http://mail.scipy.org/pipermail/scipy-dev/2012-May/017591.html
http://permalink.gmane.org/gmane.comp.python.numeric.general/54182

It seems that there has been some discussion about this before, but I don't
believe it is a correct decision to just say "we don't support setuptools, don't
use it" while offering it as a build method.
