### PR TITLE
Fix array_equal and array_equiv issue

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2137,7 +2137,7 @@ def array_equal(a1, a2):
         return False
     if a1.shape != a2.shape:
         return False
-    return bool(equal(a1,a2).all())
+    return bool((a1 == a2).all())
 
 def array_equiv(a1, a2):
     """
@@ -2179,7 +2179,7 @@ def array_equiv(a1, a2):
     except:
         return False
     try:
-        return bool(equal(a1,a2).all())
+        return bool(asarray(a1 == a2).all())
     except ValueError:
         return False
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2137,7 +2137,7 @@ def array_equal(a1, a2):
         return False
     if a1.shape != a2.shape:
         return False
-    return bool((a1 == a2).all())
+    return bool(asarray(a1 == a2).all())
 
 def array_equiv(a1, a2):
     """

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -656,6 +656,12 @@ class TestArrayComparisons(TestCase):
         res = array_equal(array([1,2]), array([1,3]))
         assert_(not res)
         assert_(type(res) is bool)
+        res = array_equal(array(['a'], dtype='S1'), array(['a'], dtype='S1'))
+        assert_(res)
+        assert_(type(res) is bool)
+        res = array_equal(array([('a',1)], dtype='S1,u4'), array([('a',1)], dtype='S1,u4'))
+        assert_(res)
+        assert_(type(res) is bool)
 
     def test_array_equiv(self):
         res = array_equiv(array([1,2]), array([1,2]))


### PR DESCRIPTION
array_equal() and array_equiv() don't work for string arrays and record arrays. This is because those methods use numpy.equals ufunc for comparison, and there are no equal ufuncs registered for strings and record arrays. Replace numpy.equals with '==' array operation, which handles strings and record arrays. Fixes #3015. Closes #146.
