### PR TITLE
Broadcast arrays fix

### DIFF
--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -276,5 +276,13 @@ def test_contiguous_flags():
     check_contig(a.ravel(), True, True)
     check_contig(np.ones((1,3,1)).squeeze(), True, True)
 
+def test_broadcast_arrays():
+    # Test user defined dtypes
+    a = np.array([(1,2,3)], dtype='u4,u4,u4')
+    b = np.array([(1,2,3),(4,5,6),(7,8,9)], dtype='u4,u4,u4')
+    result = np.broadcast_arrays(a, b)
+    assert_equal(result[0], np.array([(1,2,3),(1,2,3),(1,2,3)], dtype='u4,u4,u4'))
+    assert_equal(result[1], np.array([(1,2,3),(4,5,6),(7,8,9)], dtype='u4,u4,u4'))
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -27,7 +27,10 @@ def as_strided(x, shape=None, strides=None):
         interface['shape'] = tuple(shape)
     if strides is not None:
         interface['strides'] = tuple(strides)
-    return np.asarray(DummyArray(interface, base=x))
+    array = np.asarray(DummyArray(interface, base=x))
+    # Make sure dtype is correct in case of custom dtype
+    array.dtype = x.dtype
+    return array
 
 def broadcast_arrays(*args):
     """


### PR DESCRIPTION
broadcast_arrays() does not handle struct and custom dtypes correctly. Dtype of returned broadcasted arrays is always '|V8'. Fix broadcast_arrays() so that dtype of returned arrays is correct dtype for user defined dtypes.
