### PR TITLE
MAINT: Remove unnecessary 0-d special case.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2008,18 +2008,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_NO_BROADCAST;
     }
 
-    /*
-     * If there are no iteration dimensions, create a fake one
-     * so that the scalar edge case works right.
-     */
-    if (iter_ndim == 0) {
-        iter_ndim = 1;
-        iter_shape[0] = 1;
-        for (i = 0; i < nop; ++i) {
-            op_axes[i][0] = -1;
-        }
-    }
-
     iter_flags = ufunc->iter_flags |
                  NPY_ITER_MULTI_INDEX |
                  NPY_ITER_REFS_OK |

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -795,5 +795,11 @@ class TestUfunc(TestCase):
         assert_equal(a, np.array([[0,2,4,3],[7,9,11,7],
             [14,16,18,11],[12,13,14,15]], dtype='i8'))
 
+        a = np.array(0)
+        opflag_tests.inplace_add(a, 3)
+        assert_equal(a, 3)
+        opflag_tests.inplace_add(a, [3, 4])
+        assert_equal(a, 10)
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This special case was made unnecessary by changes to the nditer.

Tiny fixup for gh-356, I can't see anything going bad with the special case removed, or am I missing something with the test?
