### PR TITLE
MAINT: remove unsupported Python versions from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 #     - Use pip to install the numpy sdist into the virtualenv
 #     - Run the numpy tests
 # To run against a specific subset of Python versions, use:
-#   tox -e py24,py27
+#   tox -e py27
 
 # Extra arguments will be passed to test-installed-numpy.py. To run
 # the full testsuite:
@@ -22,27 +22,35 @@
 #   tox -- -v
 
 # Tox assumes that you have appropriate Python interpreters already
-# installed and that they can be run as 'python2.4', 'python2.5', etc.
+# installed and that they can be run as 'python2.7', 'python3.3', etc.
 
 [tox]
-envlist = py24,py25,py26,py27,py31,py32,py27-separate,py32-separate
+envlist = py26,py27,py32,py33,py27-monolithic,py33-monolithic,py27-relaxed-strides,py33-relaxed-strides
 
 [testenv]
 deps=
   nose
 changedir={envdir}
-commands=python {toxinidir}/tools/test-installed-numpy.py {posargs:}
+commands={envpython} {toxinidir}/tools/test-installed-numpy.py --mode=full {posargs:}
 
-[testenv:py27-separate]
+[testenv:py27-monolithic]
 basepython=python2.7
-env=NPY_SEPARATE_COMPILATION=1
+env=NPY_SEPARATE_COMPILATION=0
 
-[testenv:py32-separate]
-basepython=python3.2
-env=NPY_SEPARATE_COMPILATION=1
+[testenv:py33-monolithic]
+basepython=python3.3
+env=NPY_SEPARATE_COMPILATION=0
+
+[testenv:py27-relaxed-strides]
+basepython=python2.7
+env=NPY_RELAXED_STRIDES_CHECKING=1
+
+[testenv:py33-relaxed-strides]
+basepython=python3.3
+env=NPY_RELAXED_STRIDES_CHECKING=1
 
 # Not run by default. Set up the way you want then use 'tox -e debug'
 # if you want it:
 [testenv:debug]
-basepython=PYTHON-WITH-DEBUG-INFO
-commands=gdb --args {envpython} {toxinidir}/tools/test-installed-numpy.py {posargs:}
+basepython=python-dbg
+commands=gdb --args {envpython} {toxinidir}/tools/test-installed-numpy.py --mode=full {posargs:}


### PR DESCRIPTION
Drop Python 2.4 and 2.5 from tox.ini
