### PR TITLE
Fix segfault on OS X 64 bit

### DIFF
--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -3029,7 +3029,7 @@ static inline void
                    npy_intp* dimensions,
                    npy_intp* steps)
 {
-    ptrdiff_t outer_steps[3];
+    ptrdiff_t outer_steps[4];
     int error_occurred = get_fp_invalid_and_clear();
     size_t iter;
     size_t outer_dim = *dimensions++;


### PR DESCRIPTION
numpy/linalg/test_linalg.py segfaults on OS X 64 bit after changes to linalg tests in commit 9bfa19b1.

outer_steps array should be size 4, not size 3, since op_count can be either 2 or 4
