### PR TITLE
BUG: Correctly pass on ddof paramter on inside np.ma.corrcoef

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1402,14 +1402,13 @@ def corrcoef(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
         if rowvar:
             for i in range(n - 1):
                 for j in range(i + 1, n):
-                    _x = mask_cols(vstack((x[i], x[j]))).var(axis=1,
-                                                             ddof=1 - bias)
+                    _x = mask_cols(vstack((x[i], x[j]))).var(axis=1, ddof=ddof)
                     _denom[i, j] = _denom[j, i] = ma.sqrt(ma.multiply.reduce(_x))
         else:
             for i in range(n - 1):
                 for j in range(i + 1, n):
-                    _x = mask_cols(vstack((x[:, i], x[:, j]))).var(axis=1,
-                                                                 ddof=1 - bias)
+                    _x = mask_cols(
+                            vstack((x[:, i], x[:, j]))).var(axis=1, ddof=ddof)
                     _denom[i, j] = _denom[j, i] = ma.sqrt(ma.multiply.reduce(_x))
     return c / _denom
 

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -61,6 +61,14 @@ class TestRegression(TestCase):
         a.var(out=mout)
         assert_(mout._data == 0)
 
+    def test_ddof_corrcoef(self):
+        # See gh-3336
+        x = np.ma.masked_equal([1,2,3,4,5], 4)
+        y = np.array([2,2.5,3.1,3,5])
+        r0 = np.ma.corrcoef(x, y, ddof=0)
+        r1 = np.ma.corrcoef(x, y, ddof=1)
+        # ddof should not have an effect (it gets cancelled out)
+        assert_allclose(r0.data, r1.data)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
While ddof has basically no effect on corrcoef, it exists,
but it was not passed on correctly (instead only bias would
be passed on). Fixes gh-3336
## 

Maybe the whole bias/ddof should be removed/deprecated... but if, that should be synchronized with the np.corrcoef.
