### PR TITLE
vectorize sqrt ufunc with SSE2

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -207,6 +207,7 @@ cmplx = 'FDG'
 cmplxO = cmplx + O
 cmplxP = cmplx + P
 inexact = flts + cmplx
+inexactvec = 'fd'
 noint = inexact+O
 nointP = inexact+P
 allP = bints+times+flts+cmplxP
@@ -686,6 +687,7 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.sqrt'),
           None,
+          TD(inexactvec),
           TD(inexact, f='sqrt', astype={'e':'f'}),
           TD(P, f='sqrt'),
           ),

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -161,6 +161,11 @@ def check_math_capabilities(config, moredefs, mathlibs):
 
     check_funcs(OPTIONAL_STDFUNCS)
 
+
+    for h in OPTIONAL_HEADERS:
+        if config.check_func("", decl=False, call=False, headers=[h]):
+            moredefs.append((fname2def(h).replace(".", "_"), 1))
+
     for f, args in OPTIONAL_INTRINSICS:
         if config.check_func(f, decl=False, call=True, call_args=args):
             moredefs.append((fname2def(f), 1))

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -98,7 +98,10 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "copysign", "nextafter"]
 
 
-OPTIONAL_HEADERS = ["emmintrin.h" # SSE2, amd64 only
+OPTIONAL_HEADERS = [
+# sse headers only enabled automatically on amd64/x32 builds
+                "xmmintrin.h", # SSE
+                "emmintrin.h", # SSE2
 ]
 
 # optional gcc compiler builtins and their call arguments

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -97,6 +97,10 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
         "copysign", "nextafter"]
 
+
+OPTIONAL_HEADERS = ["emmintrin.h" # SSE2, amd64 only
+]
+
 # optional gcc compiler builtins and their call arguments
 # call arguments are required as the compiler will do strict signature checking
 OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -17,12 +17,13 @@
 #include <numpy/arrayobject.h>
 #include <numpy/halffloat.h>
 #include <npy_pycompat.h>
+#include <npy_config.h>
 
 #include <ctype.h>
 
 #include "convert.h"
 
-#ifdef __SSE__
+#ifdef HAVE_XMMINTRIN_H
 #define EINSUM_USE_SSE1 1
 #else
 #define EINSUM_USE_SSE1 0
@@ -31,7 +32,7 @@
 /*
  * TODO: Only some SSE2 for float64 is implemented.
  */
-#ifdef __SSE2__
+#ifdef HAVE_EMMINTRIN_H
 #define EINSUM_USE_SSE2 1
 #else
 #define EINSUM_USE_SSE2 0

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -1766,8 +1766,14 @@ get_functions(void)
     }
     funcdata = ((PyUFuncObject *)obj)->data;
     signatures = ((PyUFuncObject *)obj)->types;
-    i = 0;
-    j = 0;
+    /*
+     * sqrt ufunc is specialized for double and float loops in
+     * generate_umath.py, the first to go into FLOAT/DOUBLE_sqrt
+     * they have the same signature as the scalar variants so we need to skip
+     * over them
+     */
+    i = 4;
+    j = 2;
     while (signatures[i] != NPY_FLOAT) {
         i += 2; j++;
     }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -15,10 +15,16 @@
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_math.h"
 #include "numpy/halffloat.h"
+#include "lowlevel_strided_loops.h"
 
 #include "npy_pycompat.h"
 
 #include "ufunc_object.h"
+#include <assert.h>
+
+#ifdef HAVE_EMMINTRIN_H
+#include <emmintrin.h>
+#endif
 
 
 /*
@@ -27,9 +33,24 @@
  *****************************************************************************
  */
 
+
+static NPY_INLINE int npy_is_aligned(const void * p, const npy_intp alignment)
+{
+    return ((npy_intp)(p) & ((alignment) - 1)) == 0;
+}
+
 #define IS_BINARY_REDUCE ((args[0] == args[2])\
         && (steps[0] == steps[2])\
         && (steps[0] == 0))
+
+/*
+ * stride is equal to element size and input and destination are equal or
+ * don't overlap within one register
+ */
+#define IS_BLOCKABLE_UNARY(esize, vsize) \
+    (steps[0] == (esize) && steps[0] == steps[1] && \
+     (npy_is_aligned(args[0], esize) && npy_is_aligned(args[1], esize)) && \
+     ((abs(args[1] - args[0]) >= (vsize)) || ((abs(args[1] - args[0]) == 0))))
 
 #define OUTPUT_LOOP\
     char *op1 = args[1];\
@@ -51,6 +72,22 @@
     npy_intp n = dimensions[0];\
     npy_intp i;\
     for(i = 0; i < n; i++, ip1 += is1, op1 += os1, op2 += os2)
+
+/* align output to alignment
+ * store alignment is usually more important than load alignment */
+#define UNARY_LOOP_BLOCK_ALIGN_OUT(type, alignment)\
+    type *ip1 = (type *)args[0], *op1 = (type *)args[1];\
+    npy_intp n = dimensions[0];\
+    npy_intp i, peel = npy_aligned_block_offset(op1, sizeof(type),\
+                                                alignment, n);\
+    for(i = 0; i < peel; i++)
+
+#define UNARY_LOOP_BLOCKED(type, vsize)\
+    for(; i < npy_blocked_end(peel, sizeof(type), vsize, n);\
+            i += (vsize / sizeof(type)))
+
+#define UNARY_LOOP_BLOCKED_END\
+    for (; i < n; i++)
 
 #define BINARY_LOOP\
     char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];\
@@ -1265,6 +1302,50 @@ TIMEDELTA_mm_d_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *
  **                             FLOAT LOOPS                                 **
  *****************************************************************************
  */
+
+
+/**begin repeat
+ *  #type = npy_float, npy_double#
+ *  #TYPE = FLOAT, DOUBLE#
+ *  #scalarf = npy_sqrtf, npy_sqrt#
+ *  #vtype = __m128, __m128d#
+ *  #vsuf = ps, pd#
+ */
+NPY_NO_EXPORT void
+@TYPE@_sqrt(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+#ifdef HAVE_EMMINTRIN_H
+    if (IS_BLOCKABLE_UNARY(sizeof(@type@), 16)) {
+        UNARY_LOOP_BLOCK_ALIGN_OUT(@type@, 16) {
+            op1[i] = @scalarf@(ip1[i]);
+        }
+        assert(npy_is_aligned(&op1[i], 16));
+        if (npy_is_aligned(&ip1[i], 16)) {
+            UNARY_LOOP_BLOCKED(@type@, 16) {
+                @vtype@ d = _mm_load_@vsuf@(&ip1[i]);
+                _mm_store_@vsuf@(&op1[i], _mm_sqrt_@vsuf@(d));
+            }
+        }
+        else {
+            UNARY_LOOP_BLOCKED(@type@, 16) {
+                @vtype@ d = _mm_loadu_@vsuf@(&ip1[i]);
+                _mm_store_@vsuf@(&op1[i], _mm_sqrt_@vsuf@(d));
+            }
+        }
+        UNARY_LOOP_BLOCKED_END {
+            op1[i] = @scalarf@(ip1[i]);
+        }
+    }
+    else
+#endif
+    {
+        UNARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            *(@type@ *)op1 = @scalarf@(in1);
+        }
+    }
+}
+/**end repeat**/
 
 
 /**begin repeat

--- a/numpy/core/src/umath/loops.h
+++ b/numpy/core/src/umath/loops.h
@@ -1541,56 +1541,64 @@ ULONGLONG_remainder(char **args, npy_intp *dimensions, npy_intp *steps, void *NP
  *****************************************************************************
  */
 
+#line 187
+NPY_NO_EXPORT void
+FLOAT_sqrt(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 191
+#line 187
+NPY_NO_EXPORT void
+DOUBLE_sqrt(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 198
+#line 197
+
+
+#line 204
 NPY_NO_EXPORT void
 HALF_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 HALF_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 HALF_multiply(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 HALF_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 HALF_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -1601,49 +1609,49 @@ HALF_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_U
 NPY_NO_EXPORT void
 HALF_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_signbit(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_copysign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_nextafter(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 HALF_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 HALF_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 HALF_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 HALF_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 HALF_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -1696,55 +1704,55 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
 #define HALF_true_divide HALF_divide
 
 
-#line 191
+#line 197
 
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 FLOAT_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 FLOAT_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 FLOAT_multiply(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 FLOAT_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 FLOAT_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -1755,49 +1763,49 @@ FLOAT_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_
 NPY_NO_EXPORT void
 FLOAT_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_signbit(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_copysign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_nextafter(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 FLOAT_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 FLOAT_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 FLOAT_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 FLOAT_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 FLOAT_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -1850,55 +1858,55 @@ FLOAT_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_U
 #define FLOAT_true_divide FLOAT_divide
 
 
-#line 191
+#line 197
 
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 DOUBLE_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 DOUBLE_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 DOUBLE_multiply(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 DOUBLE_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 DOUBLE_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -1909,49 +1917,49 @@ DOUBLE_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY
 NPY_NO_EXPORT void
 DOUBLE_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_signbit(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_copysign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_nextafter(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 DOUBLE_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 DOUBLE_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 DOUBLE_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 DOUBLE_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 DOUBLE_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2004,55 +2012,55 @@ DOUBLE_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_
 #define DOUBLE_true_divide DOUBLE_divide
 
 
-#line 191
+#line 197
 
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 LONGDOUBLE_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 LONGDOUBLE_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 LONGDOUBLE_multiply(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 198
+#line 204
 NPY_NO_EXPORT void
 LONGDOUBLE_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 207
+#line 213
 NPY_NO_EXPORT void
 LONGDOUBLE_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2063,49 +2071,49 @@ LONGDOUBLE_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void 
 NPY_NO_EXPORT void
 LONGDOUBLE_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_signbit(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_copysign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_nextafter(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 221
+#line 227
 NPY_NO_EXPORT void
 LONGDOUBLE_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 LONGDOUBLE_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 229
+#line 235
 NPY_NO_EXPORT void
 LONGDOUBLE_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 LONGDOUBLE_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 237
+#line 243
 NPY_NO_EXPORT void
 LONGDOUBLE_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2173,14 +2181,14 @@ LONGDOUBLE_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *
 #define CEQ(xr,xi,yr,yi) (xr == yr && xi == yi);
 #define CNE(xr,xi,yr,yi) (xr != yr || xi != yi);
 
-#line 310
-
 #line 316
+
+#line 322
 NPY_NO_EXPORT void
 CFLOAT_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 316
+#line 322
 NPY_NO_EXPORT void
 CFLOAT_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2195,36 +2203,36 @@ CFLOAT_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
 NPY_NO_EXPORT void
 CFLOAT_floor_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CFLOAT_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CFLOAT_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CFLOAT_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CFLOAT_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CFLOAT_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CFLOAT_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 343
+#line 349
 NPY_NO_EXPORT void
 CFLOAT_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 343
+#line 349
 NPY_NO_EXPORT void
 CFLOAT_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2234,15 +2242,15 @@ CFLOAT_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY
 
 NPY_NO_EXPORT void
 CFLOAT_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CFLOAT_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CFLOAT_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CFLOAT_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2268,20 +2276,20 @@ CFLOAT__arg(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 NPY_NO_EXPORT void
 CFLOAT_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 386
+#line 392
 NPY_NO_EXPORT void
 CFLOAT_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 386
+#line 392
 NPY_NO_EXPORT void
 CFLOAT_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 394
+#line 400
 NPY_NO_EXPORT void
 CFLOAT_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 394
+#line 400
 NPY_NO_EXPORT void
 CFLOAT_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2289,14 +2297,14 @@ CFLOAT_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 #define CFLOAT_true_divide CFLOAT_divide
 
 
-#line 310
-
 #line 316
+
+#line 322
 NPY_NO_EXPORT void
 CDOUBLE_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 316
+#line 322
 NPY_NO_EXPORT void
 CDOUBLE_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2311,36 +2319,36 @@ CDOUBLE_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNU
 NPY_NO_EXPORT void
 CDOUBLE_floor_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CDOUBLE_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CDOUBLE_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CDOUBLE_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CDOUBLE_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CDOUBLE_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CDOUBLE_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 343
+#line 349
 NPY_NO_EXPORT void
 CDOUBLE_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 343
+#line 349
 NPY_NO_EXPORT void
 CDOUBLE_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2350,15 +2358,15 @@ CDOUBLE_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NP
 
 NPY_NO_EXPORT void
 CDOUBLE_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CDOUBLE_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CDOUBLE_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CDOUBLE_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2384,20 +2392,20 @@ CDOUBLE__arg(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSE
 NPY_NO_EXPORT void
 CDOUBLE_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 386
+#line 392
 NPY_NO_EXPORT void
 CDOUBLE_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 386
+#line 392
 NPY_NO_EXPORT void
 CDOUBLE_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 394
+#line 400
 NPY_NO_EXPORT void
 CDOUBLE_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 394
+#line 400
 NPY_NO_EXPORT void
 CDOUBLE_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2405,14 +2413,14 @@ CDOUBLE_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSE
 #define CDOUBLE_true_divide CDOUBLE_divide
 
 
-#line 310
-
 #line 316
+
+#line 322
 NPY_NO_EXPORT void
 CLONGDOUBLE_add(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 316
+#line 322
 NPY_NO_EXPORT void
 CLONGDOUBLE_subtract(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2427,36 +2435,36 @@ CLONGDOUBLE_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY
 NPY_NO_EXPORT void
 CLONGDOUBLE_floor_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CLONGDOUBLE_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CLONGDOUBLE_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CLONGDOUBLE_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CLONGDOUBLE_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CLONGDOUBLE_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 334
+#line 340
 NPY_NO_EXPORT void
 CLONGDOUBLE_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 343
+#line 349
 NPY_NO_EXPORT void
 CLONGDOUBLE_logical_and(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 343
+#line 349
 NPY_NO_EXPORT void
 CLONGDOUBLE_logical_or(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2466,15 +2474,15 @@ CLONGDOUBLE_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void
 
 NPY_NO_EXPORT void
 CLONGDOUBLE_logical_not(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CLONGDOUBLE_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CLONGDOUBLE_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 357
+#line 363
 NPY_NO_EXPORT void
 CLONGDOUBLE_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2500,20 +2508,20 @@ CLONGDOUBLE__arg(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_U
 NPY_NO_EXPORT void
 CLONGDOUBLE_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 386
+#line 392
 NPY_NO_EXPORT void
 CLONGDOUBLE_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 386
+#line 392
 NPY_NO_EXPORT void
 CLONGDOUBLE_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 394
+#line 400
 NPY_NO_EXPORT void
 CLONGDOUBLE_fmax(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 394
+#line 400
 NPY_NO_EXPORT void
 CLONGDOUBLE_fmin(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2544,81 +2552,81 @@ TIMEDELTA_absolute(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY
 NPY_NO_EXPORT void
 TIMEDELTA_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 427
+#line 433
 
 NPY_NO_EXPORT void
 DATETIME__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 DATETIME_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 DATETIME_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 DATETIME_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 DATETIME_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 DATETIME_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 DATETIME_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 443
+#line 449
 NPY_NO_EXPORT void
 DATETIME_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 443
+#line 449
 NPY_NO_EXPORT void
 DATETIME_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
 
-#line 427
+#line 433
 
 NPY_NO_EXPORT void
 TIMEDELTA__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 TIMEDELTA_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 TIMEDELTA_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 TIMEDELTA_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 TIMEDELTA_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 TIMEDELTA_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 435
+#line 441
 NPY_NO_EXPORT void
 TIMEDELTA_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 
-#line 443
+#line 449
 NPY_NO_EXPORT void
 TIMEDELTA_maximum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 443
+#line 449
 NPY_NO_EXPORT void
 TIMEDELTA_minimum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
@@ -2683,27 +2691,27 @@ TIMEDELTA_mm_d_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *
  *****************************************************************************
  */
 
-#line 511
+#line 517
 NPY_NO_EXPORT void
 OBJECT_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 511
+#line 517
 NPY_NO_EXPORT void
 OBJECT_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 511
+#line 517
 NPY_NO_EXPORT void
 OBJECT_greater(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 511
+#line 517
 NPY_NO_EXPORT void
 OBJECT_greater_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 511
+#line 517
 NPY_NO_EXPORT void
 OBJECT_less(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-#line 511
+#line 517
 NPY_NO_EXPORT void
 OBJECT_less_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -181,6 +181,12 @@ U@TYPE@_remainder(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_
  *****************************************************************************
  */
 
+/**begin repeat
+ *  #TYPE = FLOAT, DOUBLE#
+ */
+NPY_NO_EXPORT void
+@TYPE@_sqrt(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+/**end repeat**/
 
 /**begin repeat
  * Float types

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -4,6 +4,7 @@ import sys
 import platform
 
 from numpy.testing import *
+from numpy.testing.utils import gen_alignment_data
 import numpy.core.umath as ncu
 import numpy as np
 
@@ -99,6 +100,21 @@ class TestPower(TestCase):
         assert_equal(y, [1., 4., 9.])
         assert_almost_equal(x**(-1), [1., 0.5, 1./3])
         assert_almost_equal(x**(0.5), [1., ncu.sqrt(2), ncu.sqrt(3)])
+
+        for out, inp, msg in gen_alignment_data(dtype=np.float32,
+                                                type='unary'):
+            exp = [ncu.sqrt(i) for i in inp]
+            assert_almost_equal(inp**(0.5), exp, err_msg=msg)
+            np.sqrt(inp, out=out)
+            assert_equal(out, exp, err_msg=msg)
+
+        for out, inp, msg in gen_alignment_data(dtype=np.float64,
+                                                type='unary'):
+            exp = [ncu.sqrt(i) for i in inp]
+            assert_almost_equal(inp**(0.5), exp, err_msg=msg)
+            np.sqrt(inp, out=out)
+            assert_equal(out, exp, err_msg=msg)
+
 
     def test_power_complex(self):
         x = np.array([1+2j, 2+3j, 3+4j])


### PR DESCRIPTION
this is the most significant of my set of vectorized base operations I announced on the list, it improves performance by 2/4 for float/double if the data is located in the largest cpu cache which is quite often the case.
performance is always better on all tested machines (amd phenom X2, intel xeon, corei7, core2duo)
