### PR TITLE
Remove the msvc_on_amd64 function

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 from numpy.distutils import log
 from numpy.distutils.exec_command import exec_command
 from numpy.distutils.misc_util import cyg2win32, is_sequence, mingw32, \
-                                      quote_args, msvc_on_amd64
+                                      quote_args
 from numpy.distutils.compat import get_exception
 
 
@@ -654,6 +654,3 @@ def split_quoted(s):
     return words
 ccompiler.split_quoted = split_quoted
 ##Fix distutils.util.split_quoted:
-
-# define DISTUTILS_USE_SDK when necessary to workaround distutils/msvccompiler.py bug
-msvc_on_amd64()

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -367,17 +367,6 @@ def msvc_runtime_library():
         lib = None
     return lib
 
-def msvc_on_amd64():
-    if not (sys.platform=='win32' or os.name=='nt'):
-        return
-    if get_build_architecture() != 'AMD64':
-        return
-    if 'DISTUTILS_USE_SDK' in os.environ:
-        return
-    # try to avoid _MSVCCompiler__root attribute error
-    print('Forcing DISTUTILS_USE_SDK=1')
-    os.environ['DISTUTILS_USE_SDK']='1'
-    return
 
 #########################
 


### PR DESCRIPTION
Which `distutils/msvccompiler.py` bug is fixed by the `msvc_on_amd64` function? Numpy and other extensions build OK for me without this function on latest Python 2.6, 2.7, 3.2, to 3.3 using Visual Studio 2008 and 2010. The `Forcing DISTUTILS_USE_SDK=1` printed when importing numpy.distutils is annoying. The use of `DISTUTILS_USE_SDK` to build with the Platform SDK is documented at http://docs.python.org/2/distutils/apiref.html#module-distutils.msvccompiler. Why change the documented behavior?
