### PR TITLE
DOC: Remove confusing comment about warnings from top-level README.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -16,9 +16,6 @@ After installation, tests can be run with:
 
 python -c 'import numpy; numpy.test()'
 
-Starting in NumPy 1.7, deprecation warnings have been set to 'raise' by
-default, so the -Wd command-line option is no longer necessary.
-
 The most current development version is always available from our
 git repository:
 


### PR DESCRIPTION
This line only makes sense if you know that it replaced an old line that said you should run the tests with -Wd. Now it's saying that you _don't_ need to do that, which is not something we actually need to explain to people. And without that context it makes it sound like numpy itself will mess with the warnings settings by default, which is outright misleading. So whatever, let's get rid of it.
