### PR TITLE
f2py executable script shebang

### DIFF
--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -53,7 +53,7 @@ def configuration(parent_package='',top_path=None):
             log.info('Creating %s', target)
             f = open(target,'w')
             f.write('''\
-#!/usr/bin/env %s
+#!%s
 # See http://cens.ioc.ee/projects/f2py2e/
 import os, sys
 for mode in ["g3-numpy", "2e-numeric", "2e-numarray", "2e-numpy"]:
@@ -77,7 +77,7 @@ else:
     sys.stderr.write("Unknown mode: " + repr(mode) + "\\n")
     sys.exit(1)
 main()
-'''%(os.path.basename(sys.executable)))
+'''%(sys.executable))
             f.close()
         return target
 


### PR DESCRIPTION
The f2py executable has a shebang which uses the default python, rather than the python it was compiled for.  This causes issues for deployment of numpy (+f2py) across systems which have different environments.

We are currently patching the f2py setup.py as part of our build process which eliminates this problem.
