### PR TITLE
ENH: Fix SyntaxError when matrix() is called with invalid string

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -19,7 +19,12 @@ if sys.version_info[0] >= 3:
                 return None
     _table = _NumCharTable()
     def _eval(astr):
-        return eval(astr.translate(_table))
+        str_ = astr.translate(_table)
+        if not str_:
+            raise TypeError("Invalid data string supplied: " + astr)
+        else:
+            return eval(str_)
+
 else:
     _table = [None]*256
     for k in range(256):
@@ -34,7 +39,11 @@ else:
     del k
 
     def _eval(astr):
-        return eval(astr.translate(_table,_todelete))
+        str_ = astr.translate(_table,_todelete)
+        if not str_:
+            raise TypeError("Invalid data string supplied: " + astr)
+        else:
+            return eval(str_)
 
 def _convert_from_string(data):
     rows = data.split(';')

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -31,6 +31,10 @@ class TestCtor(TestCase):
         mvec = matrix(vec)
         assert_(mvec.shape == (1,5))
 
+    def test_exceptions(self):
+        # Check for TypeError when called with invalid string data.
+        assert_raises(TypeError, matrix, "invalid")
+
     def test_bmat_nondefault_str(self):
         A = array([[1,2],[3,4]])
         B = array([[5,6],[7,8]])


### PR DESCRIPTION
The numpy.matrix constructor uses eval(str.translate(table)) to convert
input strings to numeric matrix contents. str.translate(table) will
return empty string if str consists only of invalid characters, causing
SyntaxError in eval(). This is confusing, as one would expect an
exception like TypeError when trying to construct a matrix from invalid
input.

This fix makes sure eval() is only called if str is not empty.
Otherwise, TypeError is raised.
