### PR TITLE
Fix URL in documentation guide.

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -601,7 +601,7 @@ Conclusion
 `An example <http://github.com/numpy/numpy/blob/master/doc/example.py>`_ of the
 format shown here is available.  Refer to `How to Build API/Reference
 Documentation
-<http://github.com/numpy/numpy/blob/master/doc/HOWTO_BUILD_DOCS.txt>`_
+<http://github.com/numpy/numpy/blob/master/doc/HOWTO_BUILD_DOCS.rst.txt>`_
 on how to use Sphinx_ to build the manual.
 
 This document itself was written in ReStructuredText, and may be converted to


### PR DESCRIPTION
One of the links in the docs guide results in a Github 404.
