### PR TITLE
MAINT: fix some compiler warnings

### DIFF
--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -10,7 +10,7 @@ NPY_NO_EXPORT int _days_per_month_table[2][12];
 #endif
 
 NPY_NO_EXPORT void
-numpy_pydatetime_import();
+numpy_pydatetime_import(void);
 
 /*
  * Returns 1 if the given year is a leap year, 0 otherwise.

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -49,6 +49,7 @@ maintainer email:  oliphant.travis@ieee.org
 #include "getset.h"
 #include "sequence.h"
 #include "buffer.h"
+#include "array_assign.h"
 
 /*NUMPY_API
   Compute the size of an array (in number of items)
@@ -1464,8 +1465,6 @@ NPY_NO_EXPORT npy_bool
 PyArray_CheckStrides(int elsize, int nd, npy_intp numbytes, npy_intp offset,
                      npy_intp *dims, npy_intp *newstrides)
 {
-    int i;
-    npy_intp max_axis_offset;
     npy_intp begin, end;
     npy_intp lower_offset;
     npy_intp upper_offset;

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -14,6 +14,7 @@
 #include "number.h"
 
 #include "calculation.h"
+#include "array_assign.h"
 
 static double
 power_of_ten(int n)

--- a/numpy/core/src/multiarray/convert.h
+++ b/numpy/core/src/multiarray/convert.h
@@ -1,4 +1,8 @@
 #ifndef _NPY_ARRAYOBJECT_CONVERT_H_
 #define _NPY_ARRAYOBJECT_CONVERT_H_
 
+NPY_NO_EXPORT int
+PyArray_AssignZero(PyArrayObject *dst,
+                   PyArrayObject *wheremask);
+
 #endif

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -141,7 +141,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
 {
     PyArray_DatetimeMetaData *meta;
     int flex_type_num;
-    PyArrayObject *arr = NULL, *ret;
+    PyArrayObject *arr = NULL;
     PyArray_Descr *dtype = NULL;
     int ndim = 0;
     npy_intp dims[NPY_MAXDIMS];

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1319,7 +1319,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
         }
         if (!PyArray_DESCR(mps[i])->f->argsort[NPY_MERGESORT]) {
             PyErr_Format(PyExc_TypeError,
-                         "merge sort not available for item %d", i);
+                         "merge sort not available for item %zd", i);
             goto fail;
         }
         if (!object

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -51,6 +51,7 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "item_selection.h"
 #include "shape.h"
 #include "ctors.h"
+#include "array_assign.h"
 
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
@@ -338,7 +339,7 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis)
         axis += ndim;
     }
 
-    if (ndim == 1 & axis != 0) {
+    if (ndim == 1 && axis != 0) {
         char msg[] = "axis != 0 for ndim == 1; this will raise an error in "
                      "future versions of numpy";
         if (DEPRECATE(msg) < 0) {

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1027,7 +1027,6 @@ npyiter_prepare_one_operand(PyArrayObject **op,
 
 
     if (PyArray_Check(*op)) {
-        npy_uint32 tmp;
 
         if ((*op_itflags) & NPY_OP_ITFLAG_WRITE
             && PyArray_FailUnlessWriteable(*op, "operand array with iterator "

--- a/numpy/core/src/multiarray/ucsnarrow.c
+++ b/numpy/core/src/multiarray/ucsnarrow.c
@@ -13,6 +13,7 @@
 #include "npy_config.h"
 
 #include "npy_pycompat.h"
+#include "ctors.h"
 
 /*
  * Functions only needed on narrow builds of Python for converting back and

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -1381,7 +1381,7 @@ NONZERO_NAME(@name@_)(PyObject *a)
 
 
 static int
-emit_complexwarning()
+emit_complexwarning(void)
 {
     static PyObject *cls = NULL;
     if (cls == NULL) {

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1138,7 +1138,6 @@ PyMODINIT_FUNC inittest_rational(void) {
     PyObject* numpy_str;
     PyObject* numpy;
     int npy_rational;
-    PyObject* gufunc;
 
     import_array();
     if (PyErr_Occurred()) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -727,7 +727,7 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
                 int *out_subok,
                 PyArrayObject **out_wheremask)
 {
-    int i, nargs, nin = ufunc->nin, nout = ufunc->nout;
+    int i, nargs, nin = ufunc->nin;
     PyObject *obj, *context;
     PyObject *str_key_obj = NULL;
     char *ufunc_name;
@@ -1743,7 +1743,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     /* The strides which get passed to the inner loop */
     npy_intp *inner_strides = NULL;
 
-    npy_intp *inner_strides_tmp, *ax_strides_tmp[NPY_MAXDIMS];
     /* The sizes of the core dimensions (# entries is ufunc->core_num_dim_ix) */
     npy_intp *core_dim_sizes = inner_dimensions + 1;
     int core_dim_ixs_size;
@@ -1875,7 +1874,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                     PyErr_Format(PyExc_ValueError,
                             "%s: Operand %d has a mismatch in its core "
                             "dimension %d, with gufunc signature %s "
-                            "(size %d is different from %d)",
+                            "(size %zd is different from %zd)",
                             ufunc_name, i, idim, ufunc->core_signature,
                             op_dim_size, core_dim_sizes[core_dim_index]);
                     retval = -1;
@@ -2081,7 +2080,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     /* Copy the strides after the first nop */
     idim = nop;
     for (i = 0; i < nop; ++i) {
-        int dim_offset = ufunc->core_offsets[i];
         int num_dims = ufunc->core_num_dims[i];
         int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
         /*

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -375,7 +375,7 @@ offset_ptr(void* ptr, ptrdiff_t offset)
 }
 
 static inline int
-get_fp_invalid_and_clear()
+get_fp_invalid_and_clear(void)
 {
     int status;
     status = PyUFunc_getfperr();
@@ -434,7 +434,7 @@ static DOUBLECOMPLEX_t z_minus_one;
 static DOUBLECOMPLEX_t z_ninf;
 static DOUBLECOMPLEX_t z_nan;
 
-static void init_constants()
+static void init_constants(void)
 {
     /*
        this is needed as NPY_INFINITY and NPY_NAN macros
@@ -1177,8 +1177,8 @@ matrix_desc_init(matrix_desc *mtxd,
     mtxd->buff = NULL;
 }
 
-static inline npy_int8 *
-matrix_desc_assign_buff(matrix_desc* mtxd, npy_int8 *p)
+static inline npy_uint8 *
+matrix_desc_assign_buff(matrix_desc* mtxd, npy_uint8 *p)
 {
     if (mtxd->need_buff) {
         mtxd->buff = p;


### PR DESCRIPTION
implicit declarations, wrong declarations, unused variables and fixes a
comparison typo bug in multiarraymodule.c
