### PR TITLE
DOC: Correcting docstring for asscalar

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -451,7 +451,8 @@ def asscalar(a):
     Returns
     -------
     out : scalar
-        Scalar representation of `a`. The input data type is preserved.
+        Scalar representation of `a`. The output data type is the same type
+        returned by the input's `item` method.
 
     Examples
     --------


### PR DESCRIPTION
The current doc string for `numpy.asscalar` is incorrect. It says the input data type is preserved, but it's in fact always converted to a native Python type via the input's `item` method.
