### PR TITLE
Fix version parse error from a personal build of GCC

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -41,7 +41,7 @@ class GnuFCompiler(FCompiler):
         m = re.match(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
         if m:
             return ('gfortran', m.group(1))
-        m = re.match(r'GNU Fortran.*?([0-9-.]+)', version_string)
+        m = re.match(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)
         if m:
             v = m.group(1)
             if v.startswith('0') or v.startswith('2') or v.startswith('3'):

--- a/numpy/distutils/tests/test_fcompiler_gnu.py
+++ b/numpy/distutils/tests/test_fcompiler_gnu.py
@@ -19,6 +19,7 @@ gfortran_version_strings = [
     ('GNU Fortran 95 (GCC) 4.1.0', '4.1.0'),
     ('GNU Fortran 95 (GCC) 4.2.0 20060218 (experimental)', '4.2.0'),
     ('GNU Fortran (GCC) 4.3.0 20070316 (experimental)', '4.3.0'),
+    ('GNU Fortran (rubenvb-4.8.0) 4.8.0', '4.8.0'),
 ]
 
 class TestG77Versions(TestCase):


### PR DESCRIPTION
I tried using GCC from this source http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/rubenvb/

which has a version string:

```
GNU Fortran (rubenvb-4.8.0) 4.8.0
```

This was incorrectly determined a version `-4.8.0`, and added `-mno-cygwin` to the compile flags, which are no longer accepted.

See related: http://cens.ioc.ee/pipermail/f2py-users/2010-October/002092.html
