### PR TITLE
BUG: fix leak and possible use after free

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3971,7 +3971,7 @@ initialize_builtin_datetime_metadata(void)
     data2->meta.num = 1;
 
     _builtin_descrs[NPY_DATETIME]->c_metadata = (NpyAuxData *)data1;
-    _builtin_descrs[NPY_TIMEDELTA]->c_metadata = (NpyAuxData *)data1;
+    _builtin_descrs[NPY_TIMEDELTA]->c_metadata = (NpyAuxData *)data2;
 
     return 0;
 }


### PR DESCRIPTION
not sure if this is the right thing, but it looks like assigning data1 to both entries was a typo.
Its probably harmless but would cause issues if one metadata is freed while the other is still needed.
