### PR TITLE
TST: rename 2nd test_hypergeometric_range function

### DIFF
--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -46,7 +46,7 @@ class TestRegression(TestCase):
         b = np.random.permutation(long(12))
         assert_array_equal(a, b)
 
-    def test_hypergeometric_range(self) :
+    def test_randint_range(self) :
         """Test for ticket #1690"""
         lmax = np.iinfo('l').max
         lmin = np.iinfo('l').min

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -47,7 +47,7 @@ class TestRegression(TestCase):
         assert_array_equal(a, b)
 
     def test_randint_range(self) :
-        """Test for ticket #1690"""
+        # Test for ticket #1690
         lmax = np.iinfo('l').max
         lmin = np.iinfo('l').min
         try:


### PR DESCRIPTION
There are two test functions named `test_hypergeometric_range`
