### PR TITLE
BUG: include mtrand cython files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,8 @@ include *.txt
 include setupegg.py
 include site.cfg.example
 include tools/py3tool.py
+include numpy/random/mtrand/generate_mtrand_c.py
+recursive-include numpy/random/mtrand *.pyx *.pxd
 # Adding scons build related files not found by distutils
 recursive-include numpy/core/code_generators *.py *.txt
 recursive-include numpy/core *.in *.h


### PR DESCRIPTION
the files are required to do a full source rebuild.
