### PR TITLE
BUG: fix typo on npy_config.h include guard

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 #include <math.h>
-#ifdef NPY_HAVE_CONFIG_H
+#ifdef HAVE_NPY_CONFIG_H
 #include <npy_config.h>
 #endif
 #include <numpy/npy_common.h>

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -5,7 +5,6 @@
 
 #include "Python.h"
 
-#include "npy_config.h"
 #ifdef  ENABLE_SEPARATE_COMPILATION
 #define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
 #define NO_IMPORT_ARRAY


### PR DESCRIPTION
Was overlooked as loops.c.src where np.isnan lives includes it directly.
Now all isnan calls in numpy profit from the improvement.
