### PR TITLE
ma.empty/ones/zeros_like to copy mask properly

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7179,10 +7179,11 @@ class _convert2ma:
     """
     __doc__ = None
     #
-    def __init__(self, funcname, params=None):
+    def __init__(self, funcname, params=None, copy=False):
         self._func = getattr(np, funcname)
         self.__doc__ = self.getdoc()
         self._extras = params or {}
+        self._copy = copy
     #
     def getdoc(self):
         "Return the doc of the function (from the doc of the method)."
@@ -7208,21 +7209,23 @@ class _convert2ma:
             result.fill_value = _extras.get("fill_value", None)
         if "hardmask" in common_params:
             result._hardmask = bool(_extras.get("hard_mask", False))
+        if self._copy:
+            result._mask = result._mask.copy()
         return result
 
 arange = _convert2ma('arange', params=dict(fill_value=None, hardmask=False))
 clip = np.clip
 diff = np.diff
 empty = _convert2ma('empty', params=dict(fill_value=None, hardmask=False))
-empty_like = _convert2ma('empty_like')
+empty_like = _convert2ma('empty_like', copy=True)
 frombuffer = _convert2ma('frombuffer')
 fromfunction = _convert2ma('fromfunction')
 identity = _convert2ma('identity', params=dict(fill_value=None, hardmask=False))
 indices = np.indices
 ones = _convert2ma('ones', params=dict(fill_value=None, hardmask=False))
-ones_like = np.ones_like
+ones_like = _convert2ma('ones_like', copy=True)
 squeeze = np.squeeze
 zeros = _convert2ma('zeros', params=dict(fill_value=None, hardmask=False))
-zeros_like = np.zeros_like
+zeros_like = _convert2ma('zeros_like', copy=True)
 
 ###############################################################################

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -75,7 +75,7 @@ __all__ = ['MAError', 'MaskError', 'MaskType', 'MaskedArray',
            'maximum_fill_value', 'mean', 'min', 'minimum', 'minimum_fill_value',
            'mod', 'multiply', 'mvoid',
            'negative', 'nomask', 'nonzero', 'not_equal',
-           'ones', 'outer', 'outerproduct',
+           'ones', 'ones_like', 'outer', 'outerproduct',
            'power', 'prod', 'product', 'ptp', 'put', 'putmask',
            'rank', 'ravel', 'remainder', 'repeat', 'reshape', 'resize',
            'right_shift', 'round_', 'round',
@@ -84,7 +84,7 @@ __all__ = ['MAError', 'MaskError', 'MaskType', 'MaskedArray',
            'swapaxes',
            'take', 'tan', 'tanh', 'trace', 'transpose', 'true_divide',
            'var', 'where',
-           'zeros']
+           'zeros', 'zeros_like']
 
 MaskType = np.bool_
 nomask = MaskType(0)

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -70,5 +70,17 @@ class TestRegression(TestCase):
         # ddof should not have an effect (it gets cancelled out)
         assert_allclose(r0.data, r1.data)
 
+    def test_like_mask_copy(self):
+        """Issue gh-3145"""
+        m = [False, False, False, True]
+        a = np.ma.array([1, 2, 3, 4], mask=m)
+        a_empty = np.ma.empty_like(a)
+        a_ones = np.ma.ones_like(a)
+        a_zeros = np.ma.zeros_like(a)
+        a.mask = False
+        assert_array_equal(a_empty.mask, m)
+        assert_array_equal(a_ones.mask, m)
+        assert_array_equal(a_zeros.mask, m)
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
As reported in #3145 and #2572, `ma.empty_like` does not copy, but merely assigns a reference to the original mask, leading to undesirable results.

This patch makes `numpy.ma.empty_like()` to work properly, in addition to newly introduced `numpy.ma.ones_like()` and `numpy.ma.zeros_like()`.

However, `numpy.empty_like()` and siblings still do not handle masks correctly. This could be a work demanding more lower-level changes.
