### PR TITLE
ENH: Optimize array creation by avoiding errors

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -359,7 +359,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    if (SUPPORTS_BUFFER_PROTOCOL(obj) &&
+    if (Py_None != obj &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj) &&
         PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(obj, &buffer_view,

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -360,7 +360,7 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 
     /* PEP 3118 buffer interface */
     if (SUPPORTS_BUFFER_PROTOCOL(obj) &&
-	PyObject_CheckBuffer(obj) == 1) {
+        PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(obj, &buffer_view,
                                PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,48 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * 'v' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_Lite(PyObject *v, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(v);
+    if (tp == &PyList_Type || tp == &PyTuple_Type || v == Py_None) {
+        return (PyObject *)NULL;
+    }
+    else if (tp->tp_getattr != NULL) {
+        return (*tp->tp_getattr)(v, name);
+    }
+    else if (tp->tp_getattro != NULL) {
+        PyObject *w, *res;
+#if defined(NPY_PY3K)
+        w = PyUnicode_InternFromString(name);
+#else
+        w = PyString_InternFromString(name);
+#endif
+        if (w == NULL)
+            return (PyObject *)NULL;
+        res = (*tp->tp_getattro)(v, w);
+        Py_XDECREF(w);
+        return res;
+    }
+    else {
+        return (PyObject *)NULL;
+    }
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +198,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +359,38 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (Py_None != obj &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj) &&
+        PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_Lite(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -369,7 +426,7 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_Lite(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -407,7 +464,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_Lite(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);
@@ -419,6 +478,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         if (PyErr_Occurred()) {
             goto fail;
         }
+    }
+    else {
+        PyErr_Clear();
     }
 
     /* Not exactly sure what this is about... */

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,48 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * 'v' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_Lite(PyObject *v, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(v);
+    if (tp == &PyList_Type || tp == &PyTuple_Type || v == Py_None) {
+        return (PyObject *)NULL;
+    }
+    else if (tp->tp_getattr != NULL) {
+        return (*tp->tp_getattr)(v, name);
+    }
+    else if (tp->tp_getattro != NULL) {
+        PyObject *w, *res;
+#if defined(NPY_PY3K)
+        w = PyUnicode_InternFromString(name);
+#else
+        w = PyString_InternFromString(name);
+#endif
+        if (w == NULL)
+            return (PyObject *)NULL;
+        res = (*tp->tp_getattro)(v, w);
+        Py_XDECREF(w);
+        return res;
+    }
+    else {
+        return (PyObject *)NULL;
+    }
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +198,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +359,35 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_Lite(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -369,7 +423,7 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_Lite(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -407,7 +461,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_Lite(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);
@@ -419,6 +475,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         if (PyErr_Occurred()) {
             goto fail;
         }
+    }
+    else {
+        PyErr_Clear();
     }
 
     /* Not exactly sure what this is about... */

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,60 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * PyArray_GetAttrString_SuppressException:
+ *
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * This can be much faster then PyObject_GetAttrString where
+ * exceptions are not used by caller.
+ *
+ * 'obj' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(obj);
+    PyObject *res = (PyObject *)NULL;
+    if (/* Is not trivial type */
+        obj != Py_None &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj)) {
+        /* Attribute referenced by (char *)name */
+        if (tp->tp_getattr != NULL) {
+            res = (*tp->tp_getattr)(obj, name);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+        /* Attribute referenced by (PyObject *)name */
+        else if (tp->tp_getattro != NULL) {
+#if defined(NPY_PY3K)
+            PyObject *w = PyUnicode_InternFromString(name);
+#else
+            PyObject *w = PyString_InternFromString(name);
+#endif
+            if (w == NULL)
+                return (PyObject *)NULL;
+            Py_DECREF(w);
+            res = (*tp->tp_getattro)(obj, w);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+    }
+    return res;
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +210,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +371,35 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -364,12 +430,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -389,9 +452,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The old buffer interface */
 #if !defined(NPY_PY3K)
@@ -407,7 +467,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,55 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * PyArray_GetAttrString_SuppressException:
+ *
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * This can be much faster then PyObject_GetAttrString where
+ * exceptions are not used by caller.
+ *
+ * 'v' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_SuppressException(PyObject *v, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(v);
+    PyObject *res = (PyObject *)NULL;
+    if (tp != &PyList_Type && tp != &PyTuple_Type && v != Py_None) {
+        if (tp->tp_getattr != NULL) {
+            res = (*tp->tp_getattr)(v, name);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+        else if (tp->tp_getattro != NULL) {
+#if defined(NPY_PY3K)
+            PyObject *w = PyUnicode_InternFromString(name);
+#else
+            PyObject *w = PyString_InternFromString(name);
+#endif
+            if (w == NULL)
+                return (PyObject *)NULL;
+            Py_XDECREF(w);
+            res = (*tp->tp_getattro)(v, w);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+    }
+    return res;
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +205,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +366,35 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -364,12 +425,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -389,9 +447,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The old buffer interface */
 #if !defined(NPY_PY3K)
@@ -407,7 +462,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -38,7 +38,7 @@
  * This can be much faster then PyObject_GetAttrString where
  * exceptions are not used by caller.
  *
- * 'v' is the object to search for attribute.
+ * 'obj' is the object to search for attribute.
  *
  * 'name' is the attribute to search for.
  *

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -359,7 +359,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    if (PyObject_CheckBuffer(obj) == 1) {
+    if (SUPPORTS_BUFFER_PROTOCOL(obj) &&
+	PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(obj, &buffer_view,
                                PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,55 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * PyArray_GetAttrString_IgnoreException:
+ *
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * This can be much faster then PyObject_GetAttrString where
+ * exceptions are not to be expected.
+ *
+ * 'v' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_IgnoreException(PyObject *v, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(v);
+    PyObject *res = (PyObject *)NULL;
+    if (tp != &PyList_Type && tp != &PyTuple_Type && v != Py_None) {
+        if (tp->tp_getattr != NULL) {
+            res = (*tp->tp_getattr)(v, name);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+        else if (tp->tp_getattro != NULL) {
+#if defined(NPY_PY3K)
+            PyObject *w = PyUnicode_InternFromString(name);
+#else
+            PyObject *w = PyString_InternFromString(name);
+#endif
+            if (w == NULL)
+                return (PyObject *)NULL;
+            Py_XDECREF(w);
+            res = (*tp->tp_getattro)(v, w);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+    }
+    return res;
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +205,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +366,35 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_IgnoreException(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -364,12 +425,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_IgnoreException(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -389,9 +447,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The old buffer interface */
 #if !defined(NPY_PY3K)
@@ -407,7 +462,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_IgnoreException(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,60 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * PyArray_GetAttrString_SuppressException:
+ *
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * This can be much faster then PyObject_GetAttrString where
+ * exceptions are not used by caller.
+ *
+ * 'v' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(obj);
+    PyObject *res = (PyObject *)NULL;
+    if (/* Is not trivial type */
+        obj != Py_None &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj)) {
+        /* Attribute referenced by (char *)name */
+        if (tp->tp_getattr != NULL) {
+            res = (*tp->tp_getattr)(obj, name);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+        /* Attribute referenced by (PyObject *)name */
+        else if (tp->tp_getattro != NULL) {
+#if defined(NPY_PY3K)
+            PyObject *w = PyUnicode_InternFromString(name);
+#else
+            PyObject *w = PyString_InternFromString(name);
+#endif
+            if (w == NULL)
+                return (PyObject *)NULL;
+            Py_DECREF(w);
+            res = (*tp->tp_getattro)(obj, w);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+    }
+    return res;
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +210,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +371,35 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -364,12 +430,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -389,9 +452,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The old buffer interface */
 #if !defined(NPY_PY3K)
@@ -407,7 +467,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -477,9 +477,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
             goto fail;
         }
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* Not exactly sure what this is about... */
 #if !defined(NPY_PY3K)

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -27,6 +27,60 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
+
+/*
+ * PyArray_GetAttrString_SuppressException:
+ *
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * This can be much faster then PyObject_GetAttrString where
+ * exceptions are not used by caller.
+ *
+ * 'v' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+PyObject *
+PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(obj);
+    PyObject *res = (PyObject *)NULL;
+    if (// Is not trivial type
+        obj != Py_None &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj)) {
+        // Attribute referenced by (char *)name
+        if (tp->tp_getattr != NULL) {
+            res = (*tp->tp_getattr)(obj, name);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+        // Attribute referenced by (PyObject *)name
+        else if (tp->tp_getattro != NULL) {
+#if defined(NPY_PY3K)
+            PyObject *w = PyUnicode_InternFromString(name);
+#else
+            PyObject *w = PyString_InternFromString(name);
+#endif
+            if (w == NULL)
+                return (PyObject *)NULL;
+            Py_DECREF(w);
+            res = (*tp->tp_getattro)(obj, w);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+        }
+    }
+    return res;
+}
+
+
+
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_INTERNAL_UNSAFE_CASTING_BUT_WARN_UNLESS_SAME_KIND;
 
 
@@ -156,8 +210,17 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         goto promote_types;
     }
 
+    /* See if it's a python None */
+    if (obj == Py_None) {
+        dtype = PyArray_DescrFromType(NPY_OBJECT);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype);
+        goto promote_types;
+    }
     /* Check if it's a NumPy scalar */
-    if (PyArray_IsScalar(obj, Generic)) {
+    else if (PyArray_IsScalar(obj, Generic)) {
         if (!string_type) {
             dtype = PyArray_DescrFromScalar(obj);
             if (dtype == NULL) {
@@ -308,32 +371,35 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
-
-        PyErr_Clear();
-        dtype = _descriptor_from_pep3118_format(buffer_view.format);
-        PyBuffer_Release(&buffer_view);
-        if (dtype) {
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view,
+                               PyBUF_FORMAT|PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_FORMAT) == 0) {
+    
+            PyErr_Clear();
+            dtype = _descriptor_from_pep3118_format(buffer_view.format);
+            PyBuffer_Release(&buffer_view);
+            if (dtype) {
+                goto promote_types;
+            }
+        }
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+                 PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+    
+            PyErr_Clear();
+            dtype = PyArray_DescrNewFromType(NPY_VOID);
+            dtype->elsize = buffer_view.itemsize;
+            PyBuffer_Release(&buffer_view);
             goto promote_types;
         }
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-             PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-
-        PyErr_Clear();
-        dtype = PyArray_DescrNewFromType(NPY_VOID);
-        dtype->elsize = buffer_view.itemsize;
-        PyBuffer_Release(&buffer_view);
-        goto promote_types;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 
     /* The array interface */
-    ip = PyObject_GetAttrString(obj, "__array_interface__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -364,12 +430,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The array struct interface */
-    ip = PyObject_GetAttrString(obj, "__array_struct__");
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -389,9 +452,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* The old buffer interface */
 #if !defined(NPY_PY3K)
@@ -407,7 +467,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    if (PyObject_HasAttrString(obj, "__array__")) {
+    ip = PyArray_GetAttrString_SuppressException(obj, "__array__");
+    if (ip != NULL) {
+        Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);
         if(ip && PyArray_Check(ip)) {
             dtype = PyArray_DESCR((PyArrayObject *)ip);

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -49,18 +49,18 @@ PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
     PyObject *res = (PyObject *)NULL;
-    if (// Is not trivial type
+    if (/* Is not trivial type */
         obj != Py_None &&
         !PyList_CheckExact(obj) &&
         !PyTuple_CheckExact(obj)) {
-        // Attribute referenced by (char *)name
+        /* Attribute referenced by (char *)name */
         if (tp->tp_getattr != NULL) {
             res = (*tp->tp_getattr)(obj, name);
             if (res == NULL) {
                 PyErr_Clear();
             }
         }
-        // Attribute referenced by (PyObject *)name
+        /* Attribute referenced by (PyObject *)name */
         else if (tp->tp_getattro != NULL) {
 #if defined(NPY_PY3K)
             PyObject *w = PyUnicode_InternFromString(name);

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,6 +25,8 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
+#define SUPPORTS_BUFFER_PROTOCOL(op) ( (Py_TYPE(op) != &PyList_Type) && (Py_None != op) || (Py_TYPE(op) != &PyTuple_Type) )
+
 NPY_NO_EXPORT PyObject *
 PyArray_GetAttrString_Lite(PyObject *v, char *name);
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,6 +25,9 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
+NPY_NO_EXPORT PyObject *
+PyArray_GetAttrString_Lite(PyObject *v, char *name);
+
 /*
  * Returns NULL without setting an exception if no scalar is matched, a
  * new dtype reference otherwise.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,6 +25,11 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
+#define SUPPORTS_BUFFER_PROTOCOL(op) ((Py_TYPE(op) != &PyList_Type) && (Py_None != op) && (Py_TYPE(op) != &PyTuple_Type))
+
+NPY_NO_EXPORT PyObject *
+PyArray_GetAttrString_Lite(PyObject *v, char *name);
+
 /*
  * Returns NULL without setting an exception if no scalar is matched, a
  * new dtype reference otherwise.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,6 +25,9 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
+NPY_NO_EXPORT PyObject *
+PyArray_GetAttrString_IgnoreException(PyObject *v, char *name);
+
 /*
  * Returns NULL without setting an exception if no scalar is matched, a
  * new dtype reference otherwise.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,8 +25,6 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
-#define SUPPORTS_BUFFER_PROTOCOL(op) ((Py_TYPE(op) != &PyList_Type) && (Py_None != op) && (Py_TYPE(op) != &PyTuple_Type))
-
 NPY_NO_EXPORT PyObject *
 PyArray_GetAttrString_Lite(PyObject *v, char *name);
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,6 +25,9 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
+NPY_NO_EXPORT PyObject *
+PyArray_GetAttrString_SuppressException(PyObject *v, char *name);
+
 /*
  * Returns NULL without setting an exception if no scalar is matched, a
  * new dtype reference otherwise.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -25,7 +25,7 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
-#define SUPPORTS_BUFFER_PROTOCOL(op) ( (Py_TYPE(op) != &PyList_Type) && (Py_None != op) || (Py_TYPE(op) != &PyTuple_Type) )
+#define SUPPORTS_BUFFER_PROTOCOL(op) ((Py_TYPE(op) != &PyList_Type) && (Py_None != op) && (Py_TYPE(op) != &PyTuple_Type))
 
 NPY_NO_EXPORT PyObject *
 PyArray_GetAttrString_Lite(PyObject *v, char *name);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -646,32 +646,37 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     /* obj is a PEP 3118 buffer */
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
-        int nd = buffer_view.ndim;
-        if (nd < *maxndim) {
-            *maxndim = nd;
+    if (Py_None != obj &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj) &&
+        PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
+            int nd = buffer_view.ndim;
+            if (nd < *maxndim) {
+                *maxndim = nd;
+            }
+            for (i=0; i<*maxndim; i++) {
+                d[i] = buffer_view.shape[i];
+            }
+            PyBuffer_Release(&buffer_view);
+            return 0;
         }
-        for (i=0; i<*maxndim; i++) {
-            d[i] = buffer_view.shape[i];
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+            d[0] = buffer_view.len;
+            *maxndim = 1;
+            PyBuffer_Release(&buffer_view);
+            return 0;
         }
-        PyBuffer_Release(&buffer_view);
-        return 0;
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-        d[0] = buffer_view.len;
-        *maxndim = 1;
-        PyBuffer_Release(&buffer_view);
-        return 0;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 #endif
 
     /* obj has the __array_struct__ interface */
-    if ((e = PyObject_GetAttrString(obj, "__array_struct__")) != NULL) {
+    if ((e = PyArray_GetAttrString_Lite(obj, "__array_struct__")) != NULL) {
         int nd = -1;
         if (NpyCapsule_Check(e)) {
             PyArrayInterface *inter;
@@ -698,7 +703,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     }
 
     /* obj has the __array_interface__ interface */
-    if ((e = PyObject_GetAttrString(obj, "__array_interface__")) != NULL) {
+    if ((e = PyArray_GetAttrString_Lite(obj, "__array_interface__")) != NULL) {
         int nd = -1;
         if (PyDict_Check(e)) {
             PyObject *new;
@@ -1024,7 +1029,7 @@ PyArray_NewFromDescr(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     if ((subtype != &PyArray_Type)) {
         PyObject *res, *func, *args;
 
-        func = PyObject_GetAttrString((PyObject *)fa, "__array_finalize__");
+        func = PyArray_GetAttrString_Lite((PyObject *)fa, "__array_finalize__");
         if (func && func != Py_None) {
             if (NpyCapsule_Check(func)) {
                 /* A C-function is stored here */
@@ -1934,7 +1939,7 @@ PyArray_FromStructInterface(PyObject *input)
     PyArrayObject *ret;
     char endian = NPY_NATBYTE;
 
-    attr = PyObject_GetAttrString(input, "__array_struct__");
+    attr = PyArray_GetAttrString_Lite(input, "__array_struct__");
     if (attr == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
@@ -2009,7 +2014,7 @@ PyArray_FromInterface(PyObject *origin)
     /* Get the memory from __array_data__ and __array_offset__ */
     /* Get the strides */
 
-    iface = PyObject_GetAttrString(origin, "__array_interface__");
+    iface = PyArray_GetAttrString_Lite(origin, "__array_interface__");
     if (iface == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
@@ -2226,7 +2231,7 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
     PyObject *new;
     PyObject *array_meth;
 
-    array_meth = PyObject_GetAttrString(op, "__array__");
+    array_meth = PyArray_GetAttrString_Lite(op, "__array__");
     if (array_meth == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
@@ -3268,7 +3273,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
 #endif
         ) {
         PyObject *newbuf;
-        newbuf = PyObject_GetAttrString(buf, "__buffer__");
+        newbuf = PyArray_GetAttrString_Lite(buf, "__buffer__");
         if (newbuf == NULL) {
             Py_DECREF(type);
             return NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -647,7 +647,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
     if (SUPPORTS_BUFFER_PROTOCOL(obj) &&
-	PyObject_CheckBuffer(obj) == 1) {
+        PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
             PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -646,7 +646,9 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     /* obj is a PEP 3118 buffer */
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
-    if (SUPPORTS_BUFFER_PROTOCOL(obj) &&
+    if (Py_None != obj &&
+        !PyList_CheckExact(obj) &&
+        !PyTuple_CheckExact(obj) &&
         PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -646,32 +646,34 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     /* obj is a PEP 3118 buffer */
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
-        int nd = buffer_view.ndim;
-        if (nd < *maxndim) {
-            *maxndim = nd;
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
+            int nd = buffer_view.ndim;
+            if (nd < *maxndim) {
+                *maxndim = nd;
+            }
+            for (i=0; i<*maxndim; i++) {
+                d[i] = buffer_view.shape[i];
+            }
+            PyBuffer_Release(&buffer_view);
+            return 0;
         }
-        for (i=0; i<*maxndim; i++) {
-            d[i] = buffer_view.shape[i];
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+            d[0] = buffer_view.len;
+            *maxndim = 1;
+            PyBuffer_Release(&buffer_view);
+            return 0;
         }
-        PyBuffer_Release(&buffer_view);
-        return 0;
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-        d[0] = buffer_view.len;
-        *maxndim = 1;
-        PyBuffer_Release(&buffer_view);
-        return 0;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 #endif
 
     /* obj has the __array_struct__ interface */
-    if ((e = PyObject_GetAttrString(obj, "__array_struct__")) != NULL) {
+    if ((e = PyArray_GetAttrString_Lite(obj, "__array_struct__")) != NULL) {
         int nd = -1;
         if (NpyCapsule_Check(e)) {
             PyArrayInterface *inter;
@@ -698,7 +700,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     }
 
     /* obj has the __array_interface__ interface */
-    if ((e = PyObject_GetAttrString(obj, "__array_interface__")) != NULL) {
+    if ((e = PyArray_GetAttrString_Lite(obj, "__array_interface__")) != NULL) {
         int nd = -1;
         if (PyDict_Check(e)) {
             PyObject *new;
@@ -1024,7 +1026,7 @@ PyArray_NewFromDescr(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     if ((subtype != &PyArray_Type)) {
         PyObject *res, *func, *args;
 
-        func = PyObject_GetAttrString((PyObject *)fa, "__array_finalize__");
+        func = PyArray_GetAttrString_Lite((PyObject *)fa, "__array_finalize__");
         if (func && func != Py_None) {
             if (NpyCapsule_Check(func)) {
                 /* A C-function is stored here */
@@ -1934,7 +1936,7 @@ PyArray_FromStructInterface(PyObject *input)
     PyArrayObject *ret;
     char endian = NPY_NATBYTE;
 
-    attr = PyObject_GetAttrString(input, "__array_struct__");
+    attr = PyArray_GetAttrString_Lite(input, "__array_struct__");
     if (attr == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
@@ -2009,7 +2011,7 @@ PyArray_FromInterface(PyObject *origin)
     /* Get the memory from __array_data__ and __array_offset__ */
     /* Get the strides */
 
-    iface = PyObject_GetAttrString(origin, "__array_interface__");
+    iface = PyArray_GetAttrString_Lite(origin, "__array_interface__");
     if (iface == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
@@ -2226,7 +2228,7 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
     PyObject *new;
     PyObject *array_meth;
 
-    array_meth = PyObject_GetAttrString(op, "__array__");
+    array_meth = PyArray_GetAttrString_Lite(op, "__array__");
     if (array_meth == NULL) {
         PyErr_Clear();
         return Py_NotImplemented;
@@ -3268,7 +3270,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
 #endif
         ) {
         PyObject *newbuf;
-        newbuf = PyObject_GetAttrString(buf, "__buffer__");
+        newbuf = PyArray_GetAttrString_Lite(buf, "__buffer__");
         if (newbuf == NULL) {
             Py_DECREF(type);
             return NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -646,7 +646,8 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     /* obj is a PEP 3118 buffer */
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
-    if (PyObject_CheckBuffer(obj) == 1) {
+    if (SUPPORTS_BUFFER_PROTOCOL(obj) &&
+	PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
             PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1022,7 +1022,7 @@ PyArray_NewFromDescr(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     if ((subtype != &PyArray_Type)) {
         PyObject *res, *func, *args;
 
-        func = PyArray_GetAttrString_Lite((PyObject *)fa, "__array_finalize__");
+        func = PyObject_GetAttrString((PyObject *)fa, "__array_finalize__");
         if (func && func != Py_None) {
             if (NpyCapsule_Check(func)) {
                 /* A C-function is stored here */
@@ -3263,7 +3263,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
 #endif
         ) {
         PyObject *newbuf;
-        newbuf = PyArray_GetAttrString_Lite(buf, "__buffer__");
+        newbuf = PyObject_GetAttrString(buf, "__buffer__");
         if (newbuf == NULL) {
             Py_DECREF(type);
             return NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -646,32 +646,35 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     /* obj is a PEP 3118 buffer */
 #if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
-    memset(&buffer_view, 0, sizeof(Py_buffer));
-    if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
-        PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
-        int nd = buffer_view.ndim;
-        if (nd < *maxndim) {
-            *maxndim = nd;
+    if (PyObject_CheckBuffer(obj) == 1) {
+        memset(&buffer_view, 0, sizeof(Py_buffer));
+        if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_STRIDES) == 0 ||
+            PyObject_GetBuffer(obj, &buffer_view, PyBUF_ND) == 0) {
+            int nd = buffer_view.ndim;
+            if (nd < *maxndim) {
+                *maxndim = nd;
+            }
+            for (i=0; i<*maxndim; i++) {
+                d[i] = buffer_view.shape[i];
+            }
+            PyBuffer_Release(&buffer_view);
+            return 0;
         }
-        for (i=0; i<*maxndim; i++) {
-            d[i] = buffer_view.shape[i];
+        else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
+            d[0] = buffer_view.len;
+            *maxndim = 1;
+            PyBuffer_Release(&buffer_view);
+            return 0;
         }
-        PyBuffer_Release(&buffer_view);
-        return 0;
-    }
-    else if (PyObject_GetBuffer(obj, &buffer_view, PyBUF_SIMPLE) == 0) {
-        d[0] = buffer_view.len;
-        *maxndim = 1;
-        PyBuffer_Release(&buffer_view);
-        return 0;
-    }
-    else {
-        PyErr_Clear();
+        else {
+            PyErr_Clear();
+        }
     }
 #endif
 
     /* obj has the __array_struct__ interface */
-    if ((e = PyObject_GetAttrString(obj, "__array_struct__")) != NULL) {
+    e = PyArray_GetAttrString_IgnoreException(obj, "__array_struct__");
+    if (e != NULL) {
         int nd = -1;
         if (NpyCapsule_Check(e)) {
             PyArrayInterface *inter;
@@ -693,12 +696,10 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
             return 0;
         }
     }
-    else {
-        PyErr_Clear();
-    }
 
     /* obj has the __array_interface__ interface */
-    if ((e = PyObject_GetAttrString(obj, "__array_interface__")) != NULL) {
+    e = PyArray_GetAttrString_IgnoreException(obj, "__array_interface__");
+    if (e != NULL) {
         int nd = -1;
         if (PyDict_Check(e)) {
             PyObject *new;
@@ -727,9 +728,6 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         if (nd >= 0) {
             return 0;
         }
-    }
-    else {
-        PyErr_Clear();
     }
 
     n = PySequence_Size(obj);
@@ -1934,9 +1932,8 @@ PyArray_FromStructInterface(PyObject *input)
     PyArrayObject *ret;
     char endian = NPY_NATBYTE;
 
-    attr = PyObject_GetAttrString(input, "__array_struct__");
+    attr = PyArray_GetAttrString_IgnoreException(input, "__array_struct__");
     if (attr == NULL) {
-        PyErr_Clear();
         return Py_NotImplemented;
     }
     if (!NpyCapsule_Check(attr)) {
@@ -2009,9 +2006,8 @@ PyArray_FromInterface(PyObject *origin)
     /* Get the memory from __array_data__ and __array_offset__ */
     /* Get the strides */
 
-    iface = PyObject_GetAttrString(origin, "__array_interface__");
+    iface = PyArray_GetAttrString_IgnoreException(origin, "__array_interface__");
     if (iface == NULL) {
-        PyErr_Clear();
         return Py_NotImplemented;
     }
     if (!PyDict_Check(iface)) {
@@ -2226,9 +2222,8 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
     PyObject *new;
     PyObject *array_meth;
 
-    array_meth = PyObject_GetAttrString(op, "__array__");
+    array_meth = PyArray_GetAttrString_IgnoreException(op, "__array__");
     if (array_meth == NULL) {
-        PyErr_Clear();
         return Py_NotImplemented;
     }
     if (context == NULL) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -52,6 +52,7 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "shape.h"
 #include "ctors.h"
 #include "array_assign.h"
+#include "common.h"
 
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
@@ -68,7 +69,7 @@ PyArray_GetPriority(PyObject *obj, double default_)
     if (PyArray_CheckExact(obj))
         return priority;
 
-    ret = PyObject_GetAttrString(obj, "__array_priority__");
+    ret = PyArray_GetAttrString_SuppressException(obj, "__array_priority__");
     if (ret != NULL) {
         priority = PyFloat_AsDouble(ret);
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -68,7 +68,7 @@ PyArray_GetPriority(PyObject *obj, double default_)
     if (PyArray_CheckExact(obj))
         return priority;
 
-    ret = PyObject_GetAttrString(obj, "__array_priority__");
+    ret = PyArray_GetAttrString_IgnoreException(obj, "__array_priority__");
     if (ret != NULL) {
         priority = PyFloat_AsDouble(ret);
     }


### PR DESCRIPTION
This code optimizes numpy.array() when argument contains either list of lists or lists containing None.
These were problematic because exceptions are created and ignored causing significant (40x) overhead.

This optimization works by providing a 'lite' version of PyObject_GetAttrString which avoids creating exceptions
by special casing list, tuple and None types. Buffer operations are gated by PyObject_CheckBuffer.

Discused on stack overflow: http://stackoverflow.com/questions/16819261/why-is-numpy-array-is-sometimes-very-slow
#3396 - original version of this PR
#2938 - similar PR
