### PR TITLE
MAINT: use PyOS_snprintf instead of snprintf

### DIFF
--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -33,7 +33,7 @@ int xerbla_(char *srname, integer *info)
         while( len && srname[len-1]==' ' )
                 len--;
 
-        snprintf(buf, sizeof(buf), format, len, srname, *info);
+        PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
         save = PyGILState_Ensure();
         PyErr_SetString(PyExc_ValueError, buf);
         PyGILState_Release(save);


### PR DESCRIPTION
PyOS_snprintf is portable and more secure than snprintf.
