### PR TITLE
Poor performance complex strided copies since 1.7

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3817,9 +3817,9 @@ NPY_NO_EXPORT PyArray_Descr @from@_Descr = {
     /* type_num */
     NPY_@from@,
     /* elsize */
-    @num@*sizeof(@fromtype@),
+    @num@ * sizeof(@fromtype@),
     /* alignment */
-    _ALIGN(@fromtype@),
+    @num@ * _ALIGN(@fromtype@),
     /* subarray */
     NULL,
     /* fields */
@@ -4150,6 +4150,7 @@ set_typeinfo(PyObject *dict)
      *         CFLOAT, CDOUBLE, CLONGDOUBLE#
      * #Name = Half, Float, Double, LongDouble,
      *         CFloat, CDouble, CLongDouble#
+     * #num  = 1, 1, 1, 1, 2, 2, 2#
      */
 
     PyDict_SetItemString(infodict, "@name@",
@@ -4160,7 +4161,7 @@ set_typeinfo(PyObject *dict)
 #endif
                 NPY_@name@,
                 NPY_BITSOF_@name@,
-                _ALIGN(@type@),
+                @num@ * _ALIGN(@type@),
                 (PyObject *) &Py@Name@ArrType_Type));
     Py_DECREF(s);
 

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -3574,13 +3574,6 @@ PyArray_GetDTypeTransferFunction(int aligned,
                     PyArray_ISNBO(dst_dtype->byteorder)) {
 
         if (PyArray_EquivTypenums(src_type_num, dst_type_num)) {
-            /*
-             * For complex numbers, the alignment is smaller than the
-             * type size, so we turn off the aligned flag then.
-             */
-            if (src_dtype->kind == 'c' || dst_dtype->kind == 'c') {
-                aligned = 0;
-            }
             *out_stransfer = PyArray_GetStridedCopyFn(aligned,
                                         src_stride, dst_stride,
                                         src_itemsize);
@@ -3677,13 +3670,6 @@ PyArray_GetDTypeTransferFunction(int aligned,
         /* This is a straight copy */
         if (src_itemsize == 1 || PyArray_ISNBO(src_dtype->byteorder) ==
                                  PyArray_ISNBO(dst_dtype->byteorder)) {
-            /*
-             * For complex numbers, the alignment is smaller than the
-             * type size, so we turn off the aligned flag then.
-             */
-            if (src_dtype->kind == 'c' || dst_dtype->kind == 'c') {
-                aligned = 0;
-            }
             *out_stransfer = PyArray_GetStridedCopyFn(aligned,
                                         src_stride, dst_stride,
                                         src_itemsize);

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -21,12 +21,10 @@
 #include "lowlevel_strided_loops.h"
 
 /*
- * x86 platform may work with unaligned access, except when the
- * compiler uses aligned SSE instructions, which gcc does in some
- * cases.  This is disabled for the time being.
+ * x86 platform works with unaligned access
  */
 #if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
-#  define NPY_USE_UNALIGNED_ACCESS 0
+#  define NPY_USE_UNALIGNED_ACCESS 1
 #else
 #  define NPY_USE_UNALIGNED_ACCESS 0
 #endif

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -532,7 +532,7 @@ NPY_NO_EXPORT PyArray_StridedUnaryOp *
 /**end repeat1**/
                 }
 
-                return &_strided_to_strided;
+                return  &_swap@tag@_strided_to_strided;
             }
             else {
                 switch (itemsize) {
@@ -580,7 +580,7 @@ NPY_NO_EXPORT PyArray_StridedUnaryOp *
                 }
             }
 
-            return &_strided_to_strided;
+            return  &_swap@tag@_strided_to_strided;
         }
         /* general dst */
         else {
@@ -597,7 +597,7 @@ NPY_NO_EXPORT PyArray_StridedUnaryOp *
 /**end repeat1**/
                 }
 
-                return &_strided_to_strided;
+                return  &_swap@tag@_strided_to_strided;
             }
             /* general src */
             else {


### PR DESCRIPTION
complex strided copies are very slow compared to non complex types since numpy 1.7:
on an amd x4:

```
In [2]: d = np.arange(200*1000, dtype=np.float64).reshape((1000,200))
In [3]: e = np.arange(200*1000, dtype=np.float64).reshape((200,1000))
In [4]: %timeit d[...] = e.T
1000 loops, best of 3: 510 µs per loop


In [5]: d = np.arange(100*1000, dtype=np.complex128).reshape((1000,100))
In [6]: e = np.arange(100*1000, dtype=np.complex128).reshape((100,1000))
In [7]: %timeit d[...] = e.T
1000 loops, best of 3: 1.47 ms per loop
```

on an intel I even saw a tenfold slowdown.

The reason for this is twofold, for one the fix for gh-2668 set all complex types to unaligned.
This causes lowlevel_strided_loops to use elementwise memmoves which is extremely slow.
This would be somewhat fine if it were limited to architectures which can't load unaligned data, but even on x86 it uses the unaligned loads for a pretty bogus reason.

So to fix this I for one enabled unaligned loads for x86 and more invasive removed the unaligned setting from complex arrays.
Instead I fixed the alignment requirement to actually be correct, hopefully that fixes the sparc segfault but I can't verify that yet.

with the fix:

```
In [5]: d = np.arange(100*1000, dtype=np.complex128).reshape((1000,100))
In [6]: e = np.arange(100*1000, dtype=np.complex128).reshape((100,1000))

In [7]: %timeit d[...] = e.T
1000 loops, best of 3: 397 µs per loop
```

(which is faster than float64 due to the unrolling in this case, I'll post a PR which improves non float type to the same speed later.)

testing this is actually a little tricky, as i386 aligns doubles to 4 byte by default so complex is 8 byte. This is fine as it can do unaligned loads.
One could align to 16 byte also on i386 and make sure the flags are properly set in ctors.c (that introduces  whole a bunch of test failures as almost all array flags change on i386)
