### PR TITLE
DEP: Deprecate the oldnumeric and numarray modules.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -108,6 +108,19 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 
+
+class ModuleDeprecationWarning(DeprecationWarning):
+    """Module deprecation warning.
+
+    The nose tester turns ordinary Deprecation warnings into test failures.
+    That makes it hard to deprecate whole modules, because they get
+    imported by default. So this is a special Deprecation warning that the
+    nose tester will let pass without making tests fail.
+
+    """
+    pass
+
+
 # We first need to detect if we're being called as part of the numpy setup
 # procedure itself in a reliable manner.
 try:
@@ -138,7 +151,7 @@ else:
         return loader(*packages, **options)
 
     from . import add_newdocs
-    __all__ = ['add_newdocs']
+    __all__ = ['add_newdocs', 'ModuleDeprecationWarning']
 
     pkgload.__doc__ = PackageLoader.__call__.__doc__
 

--- a/numpy/numarray/__init__.py
+++ b/numpy/numarray/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import division, absolute_import, print_function
 
+import warnings
+from numpy import ModuleDeprecationWarning
+
 from .util import *
 from .numerictypes import *
 from .functions import *
@@ -13,6 +16,9 @@ from . import functions
 from . import ufuncs
 from . import compat
 from . import session
+
+_msg = "The numarray module will be dropped in Numpy 1.9"
+warnings.warn(_msg, ModuleDeprecationWarning)
 
 __all__ = ['session', 'numerictypes']
 __all__ += util.__all__

--- a/numpy/oldnumeric/__init__.py
+++ b/numpy/oldnumeric/__init__.py
@@ -3,7 +3,13 @@
 """
 from __future__ import division, absolute_import, print_function
 
+import warnings
+
 from numpy import *
+
+_msg = "The oldnumeric module will be dropped in Numpy 1.9"
+warnings.warn(_msg, ModuleDeprecationWarning)
+
 
 def _move_axis_to_0(a, axis):
     if axis == 0:

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -11,6 +11,7 @@ import sys
 import warnings
 import numpy.testing.utils
 from numpy.compat import basestring
+from numpy import ModuleDeprecationWarning
 
 def get_package_name(filepath):
     """
@@ -378,6 +379,7 @@ class NoseTester(object):
         warnings.filterwarnings('ignore', message='Not importing directory')
         warnings.filterwarnings("ignore", message="numpy.dtype size changed")
         warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+        warnings.filterwarnings("ignore", category=ModuleDeprecationWarning)
 
         try:
             from .noseclasses import NumpyTestProgram

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -26,7 +26,9 @@ __all__ = ['assert_equal', 'assert_almost_equal','assert_approx_equal',
            'assert_array_max_ulp', 'assert_warns', 'assert_no_warnings',
            'assert_allclose']
 
+
 verbose = 0
+
 
 def assert_(val, msg='') :
     """


### PR DESCRIPTION
The numarray and oldnumeric modules are deprecated. This is a bit tricky
as raising a DeprecationWarning on import causes an error when tests are
run. To deal with that, a ModuleDeprecationWarning class is added to
numpy and NoseTester is modified to ignore that warning during testing.

Closes #2905
