### PR TITLE
BUG: add __len__ method to ma.mvoid; closes #576

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5643,6 +5643,9 @@ class mvoid(MaskedArray):
                 else:
                     yield d
 
+    def __len__(self):
+        return self._data.__len__()
+
     def filled(self, fill_value=None):
         """
         Return a copy with masked fields filled with a given value.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3527,6 +3527,10 @@ class TestMaskedFields(TestCase):
         a[0]['a'] = 2
         assert_equal(a.mask, control)
 
+    def test_element_len(self):
+        # check that len() works for mvoid (Github issue #576)
+        for rec in self.data['base']:
+            assert_equal(len(rec), len(self.data['ddtype']))
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
A record selected from a structured ndarray by indexing is of type numpy.void.  Indexing a record from a structured masked array yields numpy.void if the mask is False, but numpy.ma.mvoid if the mask is True.  This PR adds the mvoid.**len**() method that was missing.  It merely calls the **len**() method on the _data attribute, which is of type numpy.void.

A test is included. 
