### PR TITLE
BUG: field assignment in masked array did not reset mask; closes #2403

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3453,6 +3453,30 @@ class TestMaskedFields(TestCase):
         assert_equal_records(a[-2]._data, a._data[-2])
         assert_equal_records(a[-2]._mask, a._mask[-2])
 
+    def test_setitem(self):
+        # Issue 2403
+        ndtype = np.dtype([('a', float), ('b', int)])
+        mdtype = np.dtype([('a', bool), ('b', bool)])
+        # soft mask
+        control = np.array([(False, True), (True, True)], dtype=mdtype)
+        a = np.ma.masked_all((2,), dtype=ndtype)
+        a['a'][0] = 2
+        assert_equal(a.mask, control)
+        a = np.ma.masked_all((2,), dtype=ndtype)
+        a[0]['a'] = 2
+        assert_equal(a.mask, control)
+        # hard mask
+        control = np.array([(True, True), (True, True)], dtype=mdtype)
+        a = np.ma.masked_all((2,), dtype=ndtype)
+        a.harden_mask()
+        a['a'][0] = 2
+        assert_equal(a.mask, control)
+        a = np.ma.masked_all((2,), dtype=ndtype)
+        a.harden_mask()
+        a[0]['a'] = 2
+        assert_equal(a.mask, control)
+
+
 #------------------------------------------------------------------------------
 
 class TestMaskedView(TestCase):


### PR DESCRIPTION
The previous behavior when setting a field after indexing to
select an element was suitable for the hard mask case, but
not for the default soft mask.  In addition, the _hardmask
value was not being set at all in the mvoid instance.  With
this changeset, the _hardmask is passed in and __setitem__
takes it into account.

Backport of fb4edf7 from master to 1.7.x.

Conflicts:

```
numpy/ma/core.py
```
