### PR TITLE
BUG: Fix failing python long behaviour and possible heisen bug

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -70,14 +70,12 @@ PyArray_GetPriority(PyObject *obj, double default_)
         return priority;
 
     ret = PyArray_GetAttrString_SuppressException(obj, "__array_priority__");
-    if (ret != NULL) {
-        priority = PyFloat_AsDouble(ret);
+    if (ret == NULL) {
+        return default_;
     }
-    if (PyErr_Occurred()) {
-        PyErr_Clear();
-        priority = default_;
-    }
-    Py_XDECREF(ret);
+
+    priority = PyFloat_AsDouble(ret);
+    Py_DECREF(ret);
     return priority;
 }
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -263,6 +263,11 @@ class TestRegression(TestCase):
         """Ticket #143"""
         assert_equal(0,np.add.identity)
 
+    def test_numpy_float_python_long_addition(self):
+        # Check that numpy float and python longs can be added correctly.
+        a = np.float_(23.) + 2**135
+        assert_equal(a, 23. + 2**135)
+
     def test_binary_repr_0(self,level=rlevel):
         """Ticket #151"""
         assert_equal('0',np.binary_repr(0))


### PR DESCRIPTION
The priority error fixes np.float_(64) + python_long not working
anymore. The second change reformats the
PyArray_GetAttrString_SuppressException to avoid a possible
heisenbug decrefing an object before use.

---

This bugged me quite a lot... it does _not_ fix the buffer error in the tests. @m-d-w did you look at that?
