### PR TITLE
Possible memory overwrite in copy_and_swap

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -373,15 +373,14 @@ NPY_NO_EXPORT void
 copy_and_swap(void *dst, void *src, int itemsize, npy_intp numitems,
               npy_intp srcstrides, int swap)
 {
-    npy_intp i;
-    char *s1 = (char *)src;
-    char *d1 = (char *)dst;
-
-
     if ((numitems == 1) || (itemsize == srcstrides)) {
-        memcpy(d1, s1, itemsize*numitems);
+        memcpy(dst, src, itemsize*numitems);
     }
     else {
+        npy_intp i;
+        char *s1 = (char *)src;
+        char *d1 = (char *)dst;
+
         for (i = 0; i < numitems; i++) {
             memcpy(d1, s1, itemsize);
             d1 += itemsize;
@@ -390,7 +389,7 @@ copy_and_swap(void *dst, void *src, int itemsize, npy_intp numitems,
     }
 
     if (swap) {
-        byte_swap_vector(d1, numitems, itemsize);
+        byte_swap_vector(dst, numitems, itemsize);
     }
 }
 


### PR DESCRIPTION
In ctors.c (copy_and_swap) it is possible for memory to be trashed by the call to byte_swap_vector if the strided memcpy is performed, because d1 points to the end of the buffer after the copy. We don't see this happening in the wild because this function is only currently called with numitems == 1 or itemsize == srcstrides, so the first IF-statement path is always taken. Still, I think it should be fixed in case this ever changes.

The fix is to make sure we always pass dst to the byte_swap_vector function and move the d1/s1 variables local to the stride copy. This way they cannot be inadvertently used later on. In fact this bit of the code could probably be replaced by a call to _unaligned_strided_byte_copy in future.

Since it's not possible to get the Python to cause this code path to run, testing was performed by temporarily commenting out the first memcpy path and always choosing the strided copy (which also works for the simple case). For the existing code, after running the 'core' tests, the python interpreter segv'd on exit. With the fix, the tests complete successfully without adverse effects on the interpreter.
