### PR TITLE
BUG: Make np.load transfer file ownership to the returned NpzFile.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -377,15 +377,20 @@ def load(file, mmap_mode=None):
         N = len(format.MAGIC_PREFIX)
         magic = fid.read(N)
         fid.seek(-N, 1) # back-up
-        if magic.startswith(_ZIP_PREFIX):  # zip-file (assume .npz)
+        if magic.startswith(_ZIP_PREFIX):
+            # zip-file (assume .npz)
+            # Transfer file ownership to NpzFile
+            tmp = own_fid
             own_fid = False
-            return NpzFile(fid, own_fid=own_fid)
-        elif magic == format.MAGIC_PREFIX: # .npy file
+            return NpzFile(fid, own_fid=tmp)
+        elif magic == format.MAGIC_PREFIX:
+            # .npy file
             if mmap_mode:
                 return format.open_memmap(file, mode=mmap_mode)
             else:
                 return format.read_array(fid)
-        else:  # Try a pickle
+        else:
+            # Try a pickle
             try:
                 return pickle.load(fid)
             except:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -221,7 +221,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
 
     def test_closing_fid(self):
         # Test that issue #1517 (too many opened files) remains closed
-        # It might be a "week" test since failed to get triggered on
+        # It might be a "weak" test since failed to get triggered on
         # e.g. Debian sid of 2012 Jul 05 but was reported to
         # trigger the failure on Ubuntu 10.04:
         # http://projects.scipy.org/numpy/ticket/1517#comment:2
@@ -249,6 +249,18 @@ class TestSavezLoad(RoundtripTest, TestCase):
                         raise AssertionError(msg)
         finally:
             os.remove(tmp)
+
+    def test_closing_zipfile_after_load(self):
+        # Check that zipfile owns file and can close it.
+        # This needs to pass a file name to load for the
+        # test.
+        fd, tmp = mkstemp(suffix='.npz')
+        os.close(fd)
+        np.savez(tmp, lab='place holder')
+        data = np.load(tmp)
+        fp = data.zip.fp
+        data.close()
+        assert_(fp.closed)
 
 
 class TestSaveTxt(TestCase):


### PR DESCRIPTION
This assures that when the loaded file is closed it also closes the
file descriptor, avoiding a resource warning in Python3.

Closes #3457.
