### PR TITLE
BUG: _savez function broken by temporary file size limit.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -534,8 +534,8 @@ def savez_compressed(file, *args, **kwds):
 
     Parameters
     ----------
-    file : str
-        File name of .npz file.
+    file : str, file
+        File name of .npz file or filelike object.
     args : Arguments
         Function arguments.
     kwds : Keyword arguments
@@ -573,8 +573,17 @@ def _savez(file, args, kwds, compress):
 
     zip = zipfile_factory(file, mode="w", compression=compression)
 
-    # Stage arrays in a temporary file on disk, before writing to zip.
-    fd, tmpfile = tempfile.mkstemp(suffix='-numpy.npy')
+    # Stage arrays in a temporary file on disk, before writing to zip.  The
+    # default directory /tmp on linux may be size limited, so when possible
+    # use the same directory the output file will go in.
+    if isinstance(file, basestring):
+        tmpdir = os.path.dirname(file)
+    elif hasattr(file, 'name'):
+        tmpdir = os.path.dirname(file.name)
+    else:
+        tmpdir = None
+
+    fd, tmpfile = tempfile.mkstemp(suffix='-numpy.npy', dir=tmpdir)
     os.close(fd)
     try:
         for key, val in namedict.items():

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -144,9 +144,14 @@ class TestSavezLoad(RoundtripTest, TestCase):
     @np.testing.dec.skipif(not IS_64BIT, "Works only with 64bit systems")
     @np.testing.dec.slow
     def test_big_arrays(self):
-        L = (1 << 31) + 100000
-        tmp = mktemp(suffix='.npz')
-        a = np.empty(L, dtype=np.uint8)
+        try:
+            a = np.empty((1 << 31) + 100000, dtype=np.uint8)
+        except MemoryError:
+            return
+
+        tmpdir = os.getcwd()
+        fd, tmp = mkstemp(suffix='.npz', dir=tmpdir)
+        os.close(fd)
         np.savez(tmp, a=a)
         del a
         npfile = np.load(tmp)


### PR DESCRIPTION
On Linux systems the  _savez function creates temporary files in the
/tmp directory before adding them to the zip archive.  Recent Linux
distros have started mounting tmpfs on /tmp and, because tmpfs resides
in memory, file size is limited by memory size. The approach taken here
is to create the temporary files in the current working directory.  That
is the default on Windows and should cause no problems on Linux.

The test_big_arrays test in test_npyio.py tests this, allthough it was
not originally intended as a test for this specific problem.  It is also
fixed so that the big npz output file is put in the current working
directory.

Closes #3464
