### PR TITLE
Fix exceptions being swallowed by fromiter.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3522,7 +3522,14 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     }
 
     if (i < count) {
-        PyErr_SetString(PyExc_ValueError, "iterator too short");
+        /* If value is NULL, there was an exception already set by the iterator
+           protocol, so we shouldn't override it with a new exception.  By
+           simply allowing the original exception to propagate, user code will
+           be easier to debug.
+         */
+        if (value != NULL) {
+            PyErr_SetString(PyExc_ValueError, "iterator too short");
+        }
         goto done;
     }
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -588,6 +588,11 @@ class TestTypes(TestCase):
         assert_raises(TypeError, np.can_cast, 'i4', None)
         assert_raises(TypeError, np.can_cast, None, 'i4')
 
+
+# Custom exception class to test exception propagation in fromiter
+class NIterError(Exception): pass
+
+
 class TestFromiter(TestCase):
     def makegen(self):
         for x in range(24):
@@ -620,6 +625,29 @@ class TestFromiter(TestCase):
         a20 = fromiter(self.makegen(), int, 20)
         self.assertTrue(alltrue(a == expected,axis=0))
         self.assertTrue(alltrue(a20 == expected[:20],axis=0))
+
+    def load_data(self, n, eindex):
+        """Utility method for the issue 2592 tests.
+
+        Raise an exception at the desired index in the iterator."""
+        for e in xrange(n):
+            if e == eindex:
+                raise NIterError('error at index %s' % eindex)
+            yield e
+
+    def test_2592(self):
+        """Test iteration exceptions are correctly raised."""
+        count, eindex = 10, 5
+        self.assertRaises(NIterError, np.fromiter,
+                          self.load_data(count, eindex), dtype=int, count=count)
+
+    def test_2592_edge(self):
+        """Test iter. exceptions, edge case (exception at end of iterator)."""
+        count = 10
+        eindex = count-1
+        self.assertRaises(NIterError, np.fromiter,
+                          self.load_data(count, eindex), dtype=int, count=count)
+
 
 class TestNonzero(TestCase):
     def test_nonzero_trivial(self):


### PR DESCRIPTION
All exceptions from underlying iterator were being collapsed into a
generic one. This allows the original exception to propagate.

All work done with @certik during scipy 2013 [diving into numpy](http://cournape.github.io/davidc-scipy-2013/#43) tutorial.

Closes gh-2592.
