### PR TITLE
BUG: check full signature if dtype of ufunc is set

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -2089,8 +2089,11 @@ type_tuple_type_resolver(PyUFuncObject *self,
                 }
             }
         } else {
-            if (types[nin] != specified_types[0]) {
-                matched = 0;
+            for (j = 0; j < nop; ++j) {
+                if (types[j] != specified_types[0]) {
+                    matched = 0;
+                    break;
+                }
             }
         }
         if (!matched) {

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -164,6 +164,17 @@ class TestUfunc(TestCase):
         # check PyUFunc_On_Om
         # fixme -- I don't know how to do this yet
 
+    def test_true_divide(self):
+        # true_divide has a non uniform signature, see 3484
+        a = np.zeros(10, dtype=np.int) + 550.
+        b = np.zeros(10, dtype=np.int) + 73.
+        r = np.array([550. / 73.] * 10)
+        assert_almost_equal(np.true_divide(a, b, dtype=np.float64), r)
+        assert_almost_equal(np.true_divide(a, b, dtype=np.float32), r)
+        assert_almost_equal(np.divide(a, b, dtype=np.float64), r)
+        assert_almost_equal(np.divide(a, b, dtype=np.float32), r)
+        assert_raises(TypeError, np.true_divide, a, b, dtype=np.int)
+
     def test_all_ufunc(self) :
         """Try to check presence and results of all ufuncs.
 


### PR DESCRIPTION
type_tuple_type_resolver only checks the last type to determine a
mismatch. For true_divide with the signature (x, x, double) this causes
it to use BYTE_divide for everything.
To fix it check the full signature before accepting a match.
Closes gh-3484.
