### PR TITLE
Backport 3324

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1298,7 +1298,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         }
 
         result = PyArray_GenericBinaryFunction(self,
-                (PyObject *)array_other,
+                (PyObject *)other,
                 n_ops.equal);
         if ((result == Py_NotImplemented) &&
                 (PyArray_TYPE(self) == NPY_VOID)) {
@@ -1354,7 +1354,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return Py_NotImplemented;
         }
 
-        result = PyArray_GenericBinaryFunction(self, (PyObject *)array_other,
+        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
                 n_ops.not_equal);
         if ((result == Py_NotImplemented) &&
                 (PyArray_TYPE(self) == NPY_VOID)) {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1286,9 +1286,11 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         if (result && result != Py_NotImplemented)
           break;
 
-        // I have been told that the rest of this case is probably an
-        // hack to support a few cases of structured arrays since
-        // ufuncs cannot handle general structured arrays.
+        /*
+         * I have been told that the rest of this case is probably an
+         * hack to support a few cases of structured arrays since
+         * ufuncs cannot handle general structured arrays.
+         */
 
         /* Make sure 'other' is an array */
         if (PyArray_TYPE(self) == NPY_OBJECT) {
@@ -1349,9 +1351,11 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         if (result && result != Py_NotImplemented)
           break;
 
-        // I have been told that the rest of this case is probably an
-        // hack to support a few cases of structured arrays since
-        // ufuncs cannot handle general structured arrays.
+        /*
+         * I have been told that the rest of this case is probably an
+         * hack to support a few cases of structured arrays since
+         * ufuncs cannot handle general structured arrays.
+         */
 
         /* Make sure 'other' is an array */
         if (PyArray_TYPE(self) == NPY_OBJECT) {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1292,24 +1292,25 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          * ufuncs cannot handle general structured arrays.
          */
 
-        /* Make sure 'other' is an array */
-        if (PyArray_TYPE(self) == NPY_OBJECT) {
-            dtype = PyArray_DTYPE(self);
-            Py_INCREF(dtype);
-        }
-        array_other = (PyArrayObject *)PyArray_FromAny(other, dtype, 0, 0, 0,
-                                                    NULL);
-        /*
-         * If not successful, indicate that the items cannot be compared
-         * this way.
-         */
-        if (array_other == NULL) {
-            PyErr_Clear();
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-
         if (PyArray_TYPE(self) == NPY_VOID) {
+            /* Make sure 'other' is an array */
+            if (PyArray_TYPE(self) == NPY_OBJECT) {
+                dtype = PyArray_DTYPE(self);
+                Py_INCREF(dtype);
+            }
+
+            array_other = (PyArrayObject *)PyArray_FromAny(other, dtype, 0, 0, 0,
+                                                           NULL);
+            /*
+             * If not successful, indicate that the items cannot be compared
+             * this way.
+             */
+            if (array_other == NULL) {
+                PyErr_Clear();
+                Py_INCREF(Py_NotImplemented);
+                return Py_NotImplemented;
+            }
+
             int _res;
 
             _res = PyObject_RichCompareBool
@@ -1333,7 +1334,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          * two array objects can not be compared together;
          * indicate that
          */
-        Py_DECREF(array_other);
         if (result == NULL) {
             PyErr_Clear();
             Py_INCREF(Py_NotImplemented);
@@ -1356,24 +1356,24 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          * ufuncs cannot handle general structured arrays.
          */
 
-        /* Make sure 'other' is an array */
-        if (PyArray_TYPE(self) == NPY_OBJECT) {
-            dtype = PyArray_DTYPE(self);
-            Py_INCREF(dtype);
-        }
-        array_other = (PyArrayObject *)PyArray_FromAny(other, dtype, 0, 0, 0,
-                                                    NULL);
-        /*
-         * If not successful, indicate that the items cannot be compared
-         * this way.
-         */
-        if (array_other == NULL) {
-            PyErr_Clear();
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-
         if (PyArray_TYPE(self) == NPY_VOID) {
+            /* Make sure 'other' is an array */
+            if (PyArray_TYPE(self) == NPY_OBJECT) {
+                dtype = PyArray_DTYPE(self);
+                Py_INCREF(dtype);
+            }
+            array_other = (PyArrayObject *)PyArray_FromAny(other, dtype, 0, 0, 0,
+                                                           NULL);
+            /*
+             * If not successful, indicate that the items cannot be compared
+             * this way.
+            */
+            if (array_other == NULL) {
+                PyErr_Clear();
+                Py_INCREF(Py_NotImplemented);
+                return Py_NotImplemented;
+            }
+
             int _res;
 
             _res = PyObject_RichCompareBool(
@@ -1393,7 +1393,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return result;
         }
 
-        Py_DECREF(array_other);
         if (result == NULL) {
             PyErr_Clear();
             Py_INCREF(Py_NotImplemented);

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1287,9 +1287,8 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
           break;
 
         /*
-         * I have been told that the rest of this case is probably an
-         * hack to support a few cases of structured arrays since
-         * ufuncs cannot handle general structured arrays.
+         * The ufunc does not support void/structured types, so these
+         * need to be handled specifically. Only a few cases are supported.
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
@@ -1351,9 +1350,8 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
           break;
 
         /*
-         * I have been told that the rest of this case is probably an
-         * hack to support a few cases of structured arrays since
-         * ufuncs cannot handle general structured arrays.
+         * The ufunc does not support void/structured types, so these
+         * need to be handled specifically. Only a few cases are supported.
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1266,50 +1266,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
     PyObject *result = NULL;
     PyArray_Descr *dtype = NULL;
 
-    // If other is of different type and the type priority is higher
-    // use its comparison function.
-    if (Py_TYPE(other) != Py_TYPE(self)) {
-        double prior1, prior2;
-        prior2 = PyArray_GetPriority((PyObject *)other, 0.0);
-        prior1 = PyArray_GetPriority((PyObject *)self, 0.0);
-        if (prior2 > prior1) {
-            PyObject *attr;
-            char * str = NULL;
-            switch (cmp_op) {
-            case Py_LT:
-                str = "__gt__";
-                break;
-            case Py_LE:
-                str = "__ge__";
-                break;
-            case Py_EQ:
-                str = "__eq__";
-                break;
-            case Py_NE:
-                str = "__ne__";
-                break;
-            case Py_GT:
-                str = "__lt__";
-                break;
-            case Py_GE:
-                str = "__le__";
-                break;
-            }
-
-            if (str != NULL) {
-                attr = PyObject_GetAttrString(other, str);
-
-                if (attr != NULL && PyCallable_Check(attr)) {
-                    PyObject * ret;
-                    ret = PyObject_CallFunctionObjArgs(attr, (PyObject *)self, NULL);
-                    Py_DECREF(attr);
-                    return ret;
-                }
-                Py_XDECREF(attr);
-            }
-        }
-    }
-
     switch (cmp_op) {
     case Py_LT:
         result = PyArray_GenericBinaryFunction(self, other,

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1309,8 +1309,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return Py_NotImplemented;
         }
 
-        if ((result == Py_NotImplemented) &&
-                (PyArray_TYPE(self) == NPY_VOID)) {
+        if (PyArray_TYPE(self) == NPY_VOID) {
             int _res;
 
             _res = PyObject_RichCompareBool
@@ -1374,8 +1373,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return Py_NotImplemented;
         }
 
-        if ((result == Py_NotImplemented) &&
-                (PyArray_TYPE(self) == NPY_VOID)) {
+        if (PyArray_TYPE(self) == NPY_VOID) {
             int _res;
 
             _res = PyObject_RichCompareBool(

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1264,7 +1264,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
 {
     PyArrayObject *array_other;
     PyObject *result = NULL;
-    PyArray_Descr *dtype = NULL;
 
     switch (cmp_op) {
     case Py_LT:
@@ -1292,13 +1291,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
-            /* Make sure 'other' is an array */
-            if (PyArray_TYPE(self) == NPY_OBJECT) {
-                dtype = PyArray_DTYPE(self);
-                Py_INCREF(dtype);
-            }
-
-            array_other = (PyArrayObject *)PyArray_FromAny(other, dtype, 0, 0, 0,
+            array_other = (PyArrayObject *)PyArray_FromAny(other, NULL, 0, 0, 0,
                                                            NULL);
             /*
              * If not successful, indicate that the items cannot be compared
@@ -1355,12 +1348,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
-            /* Make sure 'other' is an array */
-            if (PyArray_TYPE(self) == NPY_OBJECT) {
-                dtype = PyArray_DTYPE(self);
-                Py_INCREF(dtype);
-            }
-            array_other = (PyArrayObject *)PyArray_FromAny(other, dtype, 0, 0, 0,
+            array_other = (PyArrayObject *)PyArray_FromAny(other, NULL, 0, 0, 0,
                                                            NULL);
             /*
              * If not successful, indicate that the items cannot be compared

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1280,6 +1280,16 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_False);
             return Py_False;
         }
+        result = PyArray_GenericBinaryFunction(self,
+                (PyObject *)other,
+                n_ops.equal);
+        if (result && result != Py_NotImplemented)
+          break;
+
+        // I have been told that the rest of this case is probably an
+        // hack to support a few cases of structured arrays since
+        // ufuncs cannot handle general structured arrays.
+
         /* Make sure 'other' is an array */
         if (PyArray_TYPE(self) == NPY_OBJECT) {
             dtype = PyArray_DTYPE(self);
@@ -1297,9 +1307,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return Py_NotImplemented;
         }
 
-        result = PyArray_GenericBinaryFunction(self,
-                (PyObject *)other,
-                n_ops.equal);
         if ((result == Py_NotImplemented) &&
                 (PyArray_TYPE(self) == NPY_VOID)) {
             int _res;
@@ -1337,6 +1344,15 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_True);
             return Py_True;
         }
+        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
+                n_ops.not_equal);
+        if (result && result != Py_NotImplemented)
+          break;
+
+        // I have been told that the rest of this case is probably an
+        // hack to support a few cases of structured arrays since
+        // ufuncs cannot handle general structured arrays.
+
         /* Make sure 'other' is an array */
         if (PyArray_TYPE(self) == NPY_OBJECT) {
             dtype = PyArray_DTYPE(self);
@@ -1354,8 +1370,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return Py_NotImplemented;
         }
 
-        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
-                n_ops.not_equal);
         if ((result == Py_NotImplemented) &&
                 (PyArray_TYPE(self) == NPY_VOID)) {
             int _res;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -486,6 +486,13 @@ _has_reflected_op(PyObject *op, char *name)
     _GETATTR_(bitwise_and, rand);
     _GETATTR_(bitwise_xor, rxor);
     _GETATTR_(bitwise_or, ror);
+    /* Comparisons */
+    _GETATTR_(equal, eq);
+    _GETATTR_(not_equal, ne);
+    _GETATTR_(greater, lt);
+    _GETATTR_(less, gt);
+    _GETATTR_(greater_equal, le);
+    _GETATTR_(less_equal, ge);
     return 0;
 }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2918,13 +2918,13 @@ class TestArrayPriority(TestCase):
         res3 = lp < r
         res4 = lp < rp
 
-        assert np.allclose(res1, res2.array)
-        assert np.allclose(res1, res3.array)
-        assert np.allclose(res1, res4.array)
-        assert isinstance(res1, np.ndarray)
-        assert isinstance(res2, PriorityNdarray)
-        assert isinstance(res3, PriorityNdarray)
-        assert isinstance(res4, PriorityNdarray)
+        assert_array_equal(res1, res2.array)
+        assert_array_equal(res1, res3.array)
+        assert_array_equal(res1, res4.array)
+        assert_(isinstance(res1, np.ndarray))
+        assert_(isinstance(res2, PriorityNdarray))
+        assert_(isinstance(res3, PriorityNdarray))
+        assert_(isinstance(res4, PriorityNdarray))
 
     def test_gt(self):
         l = np.asarray([0., -1., 1.], dtype=dtype)
@@ -2936,13 +2936,13 @@ class TestArrayPriority(TestCase):
         res3 = lp > r
         res4 = lp > rp
 
-        assert np.allclose(res1, res2.array)
-        assert np.allclose(res1, res3.array)
-        assert np.allclose(res1, res4.array)
-        assert isinstance(res1, np.ndarray)
-        assert isinstance(res2, PriorityNdarray)
-        assert isinstance(res3, PriorityNdarray)
-        assert isinstance(res4, PriorityNdarray)
+        assert_array_equal(res1, res2.array)
+        assert_array_equal(res1, res3.array)
+        assert_array_equal(res1, res4.array)
+        assert_(isinstance(res1, np.ndarray))
+        assert_(isinstance(res2, PriorityNdarray))
+        assert_(isinstance(res3, PriorityNdarray))
+        assert_(isinstance(res4, PriorityNdarray))
 
     def test_le(self):
         l = np.asarray([0., -1., 1.], dtype=dtype)
@@ -2954,13 +2954,13 @@ class TestArrayPriority(TestCase):
         res3 = lp <= r
         res4 = lp <= rp
 
-        assert np.allclose(res1, res2.array)
-        assert np.allclose(res1, res3.array)
-        assert np.allclose(res1, res4.array)
-        assert isinstance(res1, np.ndarray)
-        assert isinstance(res2, PriorityNdarray)
-        assert isinstance(res3, PriorityNdarray)
-        assert isinstance(res4, PriorityNdarray)
+        assert_array_equal(res1, res2.array)
+        assert_array_equal(res1, res3.array)
+        assert_array_equal(res1, res4.array)
+        assert_(isinstance(res1, np.ndarray))
+        assert_(isinstance(res2, PriorityNdarray))
+        assert_(isinstance(res3, PriorityNdarray))
+        assert_(isinstance(res4, PriorityNdarray))
 
     def test_ge(self):
         l = np.asarray([0., -1., 1.], dtype=dtype)
@@ -2972,13 +2972,13 @@ class TestArrayPriority(TestCase):
         res3 = lp >= r
         res4 = lp >= rp
 
-        assert np.allclose(res1, res2.array)
-        assert np.allclose(res1, res3.array)
-        assert np.allclose(res1, res4.array)
-        assert isinstance(res1, np.ndarray)
-        assert isinstance(res2, PriorityNdarray)
-        assert isinstance(res3, PriorityNdarray)
-        assert isinstance(res4, PriorityNdarray)
+        assert_array_equal(res1, res2.array)
+        assert_array_equal(res1, res3.array)
+        assert_array_equal(res1, res4.array)
+        assert_(isinstance(res1, np.ndarray))
+        assert_(isinstance(res2, PriorityNdarray))
+        assert_(isinstance(res3, PriorityNdarray))
+        assert_(isinstance(res4, PriorityNdarray))
 
     def test_eq(self):
         l = np.asarray([0., -1., 1.], dtype=dtype)
@@ -2990,13 +2990,13 @@ class TestArrayPriority(TestCase):
         res3 = lp == r
         res4 = lp == rp
 
-        assert np.allclose(res1, res2.array)
-        assert np.allclose(res1, res3.array)
-        assert np.allclose(res1, res4.array)
-        assert isinstance(res1, np.ndarray)
-        assert isinstance(res2, PriorityNdarray)
-        assert isinstance(res3, PriorityNdarray)
-        assert isinstance(res4, PriorityNdarray)
+        assert_array_equal(res1, res2.array)
+        assert_array_equal(res1, res3.array)
+        assert_array_equal(res1, res4.array)
+        assert_(isinstance(res1, np.ndarray))
+        assert_(isinstance(res2, PriorityNdarray))
+        assert_(isinstance(res3, PriorityNdarray))
+        assert_(isinstance(res4, PriorityNdarray))
 
     def test_ne(self):
         l = np.asarray([0., -1., 1.], dtype=dtype)
@@ -3008,13 +3008,13 @@ class TestArrayPriority(TestCase):
         res3 = lp != r
         res4 = lp != rp
 
-        assert np.allclose(res1, res2.array)
-        assert np.allclose(res1, res3.array)
-        assert np.allclose(res1, res4.array)
-        assert isinstance(res1, np.ndarray)
-        assert isinstance(res2, PriorityNdarray)
-        assert isinstance(res3, PriorityNdarray)
-        assert isinstance(res4, PriorityNdarray)
+        assert_array_equal(res1, res2.array)
+        assert_array_equal(res1, res3.array)
+        assert_array_equal(res1, res4.array)
+        assert_(isinstance(res1, np.ndarray))
+        assert_(isinstance(res2, PriorityNdarray))
+        assert_(isinstance(res3, PriorityNdarray))
+        assert_(isinstance(res4, PriorityNdarray))
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2870,5 +2870,152 @@ class TestMemEventHook(TestCase):
         test_pydatamem_seteventhook_end()
 
 
+class PriorityNdarray():
+    __array_priority__ = 1000
+
+    def __init__(self, array):
+        self.array = array
+
+    def __lt__(self, array):
+        if isinstance(array, PriorityNdarray):
+            array = array.array
+        return PriorityNdarray(self.array < array)
+
+    def __gt__(self, array):
+        if isinstance(array, PriorityNdarray):
+            array = array.array
+        return PriorityNdarray(self.array > array)
+
+    def __le__(self, array):
+        if isinstance(array, PriorityNdarray):
+            array = array.array
+        return PriorityNdarray(self.array <= array)
+
+    def __ge__(self, array):
+        if isinstance(array, PriorityNdarray):
+            array = array.array
+        return PriorityNdarray(self.array >= array)
+
+    def __eq__(self, array):
+        if isinstance(array, PriorityNdarray):
+            array = array.array
+        return PriorityNdarray(self.array == array)
+
+    def __ne__(self, array):
+        if isinstance(array, PriorityNdarray):
+            array = array.array
+        return PriorityNdarray(self.array != array)
+
+
+class TestArrayPriority(TestCase):
+    def test_lt(self):
+        l = np.asarray([0., -1., 1.], dtype=dtype)
+        r = np.asarray([0., 1., -1.], dtype=dtype)
+        lp = PriorityNdarray(l)
+        rp = PriorityNdarray(r)
+        res1 = l < r
+        res2 = l < rp
+        res3 = lp < r
+        res4 = lp < rp
+
+        assert np.allclose(res1, res2.array)
+        assert np.allclose(res1, res3.array)
+        assert np.allclose(res1, res4.array)
+        assert isinstance(res1, np.ndarray)
+        assert isinstance(res2, PriorityNdarray)
+        assert isinstance(res3, PriorityNdarray)
+        assert isinstance(res4, PriorityNdarray)
+
+    def test_gt(self):
+        l = np.asarray([0., -1., 1.], dtype=dtype)
+        r = np.asarray([0., 1., -1.], dtype=dtype)
+        lp = PriorityNdarray(l)
+        rp = PriorityNdarray(r)
+        res1 = l > r
+        res2 = l > rp
+        res3 = lp > r
+        res4 = lp > rp
+
+        assert np.allclose(res1, res2.array)
+        assert np.allclose(res1, res3.array)
+        assert np.allclose(res1, res4.array)
+        assert isinstance(res1, np.ndarray)
+        assert isinstance(res2, PriorityNdarray)
+        assert isinstance(res3, PriorityNdarray)
+        assert isinstance(res4, PriorityNdarray)
+
+    def test_le(self):
+        l = np.asarray([0., -1., 1.], dtype=dtype)
+        r = np.asarray([0., 1., -1.], dtype=dtype)
+        lp = PriorityNdarray(l)
+        rp = PriorityNdarray(r)
+        res1 = l <= r
+        res2 = l <= rp
+        res3 = lp <= r
+        res4 = lp <= rp
+
+        assert np.allclose(res1, res2.array)
+        assert np.allclose(res1, res3.array)
+        assert np.allclose(res1, res4.array)
+        assert isinstance(res1, np.ndarray)
+        assert isinstance(res2, PriorityNdarray)
+        assert isinstance(res3, PriorityNdarray)
+        assert isinstance(res4, PriorityNdarray)
+
+    def test_ge(self):
+        l = np.asarray([0., -1., 1.], dtype=dtype)
+        r = np.asarray([0., 1., -1.], dtype=dtype)
+        lp = PriorityNdarray(l)
+        rp = PriorityNdarray(r)
+        res1 = l >= r
+        res2 = l >= rp
+        res3 = lp >= r
+        res4 = lp >= rp
+
+        assert np.allclose(res1, res2.array)
+        assert np.allclose(res1, res3.array)
+        assert np.allclose(res1, res4.array)
+        assert isinstance(res1, np.ndarray)
+        assert isinstance(res2, PriorityNdarray)
+        assert isinstance(res3, PriorityNdarray)
+        assert isinstance(res4, PriorityNdarray)
+
+    def test_eq(self):
+        l = np.asarray([0., -1., 1.], dtype=dtype)
+        r = np.asarray([0., 1., -1.], dtype=dtype)
+        lp = PriorityNdarray(l)
+        rp = PriorityNdarray(r)
+        res1 = l == r
+        res2 = l == rp
+        res3 = lp == r
+        res4 = lp == rp
+
+        assert np.allclose(res1, res2.array)
+        assert np.allclose(res1, res3.array)
+        assert np.allclose(res1, res4.array)
+        assert isinstance(res1, np.ndarray)
+        assert isinstance(res2, PriorityNdarray)
+        assert isinstance(res3, PriorityNdarray)
+        assert isinstance(res4, PriorityNdarray)
+
+    def test_ne(self):
+        l = np.asarray([0., -1., 1.], dtype=dtype)
+        r = np.asarray([0., 1., -1.], dtype=dtype)
+        lp = PriorityNdarray(l)
+        rp = PriorityNdarray(r)
+        res1 = l != r
+        res2 = l != rp
+        res3 = lp != r
+        res4 = lp != rp
+
+        assert np.allclose(res1, res2.array)
+        assert np.allclose(res1, res3.array)
+        assert np.allclose(res1, res4.array)
+        assert isinstance(res1, np.ndarray)
+        assert isinstance(res2, PriorityNdarray)
+        assert isinstance(res3, PriorityNdarray)
+        assert isinstance(res4, PriorityNdarray)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2870,7 +2870,7 @@ class TestMemEventHook(TestCase):
         test_pydatamem_seteventhook_end()
 
 
-class PriorityNdarray():
+class PriorityNdarray(object):
     __array_priority__ = 1000
 
     def __init__(self, array):


### PR DESCRIPTION
This backports the fix for having boolean comparisons respect array priority. ([original PR](https://github.com/numpy/numpy/pull/3324)). 

I need this in 1.7.x for adding boolean comparisons to sparse matrices in SciPy. [PR 1](https://github.com/scipy/scipy/pull/2586) [PR 2](https://github.com/scipy/scipy/pull/2561). Otherwise, comparing a sparse matrix with a dense matrix fails when the dense matrix is on the LHS.
