### PR TITLE
BUG: Fix failure to return monic polynomials from roots.

### DIFF
--- a/numpy/polynomial/polytemplate.py
+++ b/numpy/polynomial/polytemplate.py
@@ -806,6 +806,13 @@ class $name(pu.PolyBase) :
         ----------
         roots : array_like
             List of roots.
+        domain : {array_like, None}, optional
+            Domain for the resulting instance of $name. If none the domain
+            is the interval from the smallest root to the largest. The
+            default is $domain.
+        window : array_like, optional
+            Window for the resulting instance of $name. The default value
+            is $domain.
 
         Returns
         -------
@@ -817,10 +824,13 @@ class $name(pu.PolyBase) :
         ${nick}fromroots : equivalent function
 
         """
+        [roots] = pu.as_series([roots], trim=False)
         if domain is None :
             domain = pu.getdomain(roots)
-        rnew = pu.mapdomain(roots, domain, window)
-        coef = ${nick}fromroots(rnew)
+        deg = len(roots)
+        off, scl = pu.mapparms(domain, window)
+        rnew = off + scl*roots
+        coef = ${nick}fromroots(rnew) / scl**deg
         return $name(coef, domain=domain, window=window)
 
     @staticmethod

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -145,7 +145,9 @@ def check_fromroots(Poly):
     assert_almost_equal(p1(r), 0)
 
     # check that polynomial is monic
-    p2 = Polynomial.cast(p1, domain=d, window=w)
+    pdom = Polynomial.domain
+    pwin = Polynomial.window
+    p2 = Polynomial.cast(p1, domain=pdom, window=pwin)
     assert_almost_equal(p2.coef[-1], 1)
 
 


### PR DESCRIPTION
This bug affected the various polynomial class methods fromroots due to
the ability to specify both window and domain. In that circumstance the
roots are mapped from the domain to the window by the substitution
`x = off + scl*x`. The polynomial that was being generated was monic in
the window before substitution, but if scl was not one it was not monic
considered as a function of the variable x in the domain. The fix is to
divide the generated coefficients by `scl ** deg` so that the scaling of
the highest degree term after substitution is canceled.

It might be better to make the scaling optional in the future, but this
fix makes the result match the documentation.

Closes #3467.
