### PR TITLE
Fix exceptions being swallowed by fromiter.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3466,9 +3466,9 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         goto done;
     }
     elcount = (count < 0) ? 0 : count;
-    if ((elsize=dtype->elsize) == 0) {
-        PyErr_SetString(PyExc_ValueError, "Must specify length "\
-                        "when using variable-size data-type.");
+    if ((elsize = dtype->elsize) == 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "Must specify length when using variable-size data-type.");
         goto done;
     }
 
@@ -3477,8 +3477,8 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
      * reference counts before throwing away any memory.
      */
     if (PyDataType_REFCHK(dtype)) {
-        PyErr_SetString(PyExc_ValueError, "cannot create "\
-                        "object arrays from iterator");
+        PyErr_SetString(PyExc_ValueError,
+                "cannot create object arrays from iterator");
         goto done;
     }
 
@@ -3505,7 +3505,7 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
             }
             if (new_data == NULL) {
                 PyErr_SetString(PyExc_MemoryError,
-                                "cannot allocate array memory");
+                        "cannot allocate array memory");
                 Py_DECREF(value);
                 goto done;
             }
@@ -3513,16 +3513,21 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         }
         PyArray_DIMS(ret)[0] = i + 1;
 
-        if (((item = index2ptr(ret, i)) == NULL)
-            || (PyArray_DESCR(ret)->f->setitem(value, item, ret) == -1)) {
+        if (((item = index2ptr(ret, i)) == NULL) ||
+                (PyArray_DESCR(ret)->f->setitem(value, item, ret) == -1)) {
             Py_DECREF(value);
             goto done;
         }
         Py_DECREF(value);
     }
 
+
+    if (PyErr_Occurred()) {
+        goto done;
+    }
     if (i < count) {
-        PyErr_SetString(PyExc_ValueError, "iterator too short");
+        PyErr_SetString(PyExc_ValueError,
+                "iterator too short");
         goto done;
     }
 
@@ -3531,11 +3536,13 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
      * (assuming realloc is reasonably good about reusing space...)
      */
     if (i == 0) {
+        /* The size cannot be zero for PyDataMem_RENEW. */
         i = 1;
     }
     new_data = PyDataMem_RENEW(PyArray_DATA(ret), i * elsize);
     if (new_data == NULL) {
-        PyErr_SetString(PyExc_MemoryError, "cannot allocate array memory");
+        PyErr_SetString(PyExc_MemoryError,
+                "cannot allocate array memory");
         goto done;
     }
     ((PyArrayObject_fields *)ret)->data = new_data;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -346,13 +346,12 @@ class TestFloatExceptions(TestCase):
                     "Type %s raised wrong fpe error '%s'." % (ftype, exc))
 
     def assert_op_raises_fpe(self, fpeerr, flop, sc1, sc2):
-        """Check that fpe exception is raised.
+        # Check that fpe exception is raised.
+        #
+        # Given a floating operation `flop` and two scalar values, check that
+        # the operation raises the floating point exception specified by
+        #`fpeerr`. Tests all variants with 0-d array scalars as well.
 
-       Given a floating operation `flop` and two scalar values, check that
-       the operation raises the floating point exception specified by
-       `fpeerr`. Tests all variants with 0-d array scalars as well.
-
-        """
         self.assert_raises_fpe(fpeerr, flop, sc1, sc2);
         self.assert_raises_fpe(fpeerr, flop, sc1[()], sc2);
         self.assert_raises_fpe(fpeerr, flop, sc1, sc2[()]);
@@ -360,7 +359,7 @@ class TestFloatExceptions(TestCase):
 
     @dec.knownfailureif(True, "See ticket 1755")
     def test_floating_exceptions(self):
-        """Test basic arithmetic function errors"""
+        # Test basic arithmetic function errors
         oldsettings = np.seterr(all='raise')
         try:
             # Test for all real and complex float types
@@ -476,9 +475,11 @@ class TestTypes(TestCase):
         assert_equal(promote_func(array([b]),u64), np.dtype(uint64))
         assert_equal(promote_func(array([i8]),f64), np.dtype(float64))
         assert_equal(promote_func(array([u16]),f64), np.dtype(float64))
+
         # uint and int are treated as the same "kind" for
         # the purposes of array-scalar promotion.
         assert_equal(promote_func(array([u16]), i32), np.dtype(uint16))
+
         # float and complex are treated as the same "kind" for
         # the purposes of array-scalar promotion, so that you can do
         # (0j + float32array) to get a complex64 array instead of
@@ -612,7 +613,7 @@ class TestFromiter(TestCase):
         a20 = fromiter(self.makegen(), int, 20)
         self.assertTrue(len(a) == len(expected))
         self.assertTrue(len(a20) == 20)
-        self.assertRaises(ValueError, fromiter, 
+        self.assertRaises(ValueError, fromiter,
                           self.makegen(), int, len(expected) + 10)
 
     def test_values(self):
@@ -623,22 +624,21 @@ class TestFromiter(TestCase):
         self.assertTrue(alltrue(a20 == expected[:20],axis=0))
 
     def load_data(self, n, eindex):
-        """Utility method for the issue 2592 tests.
-
-        Raise an exception at the desired index in the iterator."""
+        # Utility method for the issue 2592 tests.
+        # Raise an exception at the desired index in the iterator.
         for e in range(n):
             if e == eindex:
                 raise NIterError('error at index %s' % eindex)
             yield e
 
     def test_2592(self):
-        """Test iteration exceptions are correctly raised."""
+        # Test iteration exceptions are correctly raised.
         count, eindex = 10, 5
         self.assertRaises(NIterError, np.fromiter,
                           self.load_data(count, eindex), dtype=int, count=count)
 
     def test_2592_edge(self):
-        """Test iter. exceptions, edge case (exception at end of iterator)."""
+        # Test iter. exceptions, edge case (exception at end of iterator).
         count = 10
         eindex = count-1
         self.assertRaises(NIterError, np.fromiter,

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -626,7 +626,7 @@ class TestFromiter(TestCase):
         """Utility method for the issue 2592 tests.
 
         Raise an exception at the desired index in the iterator."""
-        for e in xrange(n):
+        for e in range(n):
             if e == eindex:
                 raise NIterError('error at index %s' % eindex)
             yield e


### PR DESCRIPTION
All exceptions from underlying iterator were being collapsed into a
generic one. This allows the original exception to propagate.

All work done with @certik during scipy 2013 diving into numpy tutorial.

Closes gh-2592.
