### PR TITLE
Allow pad_width of zero in np.pad

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1079,7 +1079,7 @@ def _validate_lengths(narray, number_elements):
     normshp = _normalize_shape(narray, number_elements)
     for i in normshp:
         chk = [1 if x is None else x for x in i]
-        chk = [1 if x > 0 else -1 for x in chk]
+        chk = [1 if x >= 0 else -1 for x in chk]
         if (chk[0] < 0) or (chk[1] < 0):
             fmt = "%s cannot contain negative values."
             raise ValueError(fmt % (number_elements,))

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -486,6 +486,14 @@ class TestEdge(TestCase):
         assert_array_equal(a, b)
 
 
+class TestZeroPadWidth(TestCase):
+    def test_zero_pad_width(self):
+        arr = np.arange(30)
+        arr = np.reshape(arr, (6, 5))
+        for pad_width in (0, (0, 0), ((0, 0), (0, 0))):
+            assert_array_equal(arr, pad(arr, pad_width, mode='constant'))
+
+
 class ValueError1(TestCase):
     def test_check_simple(self):
         arr = np.arange(30)


### PR DESCRIPTION
Input validation of `np.pad` was a bit too strict, disallowing padding an array by zero entries. This PR aims to correct that.

The same changes have been discussed in scikit-image: https://github.com/scikit-image/scikit-image/pull/634
