### PR TITLE
ENH: added short path scalar array in get_ufunc_arguments from ufunc_object.c

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -719,7 +719,11 @@ can_cast_scalar_to(PyArray_Descr *scal_type, char *scal_data,
     /* An aligned memory buffer large enough to hold any type */
     npy_longlong value[4];
 
-    if (casting == NPY_UNSAFE_CASTING) {
+    /* 
+     * If the two dtypes are actually references to the same object 
+     * or if casting type is forced unsafe then always OK. 
+     */
+    if (scal_type == to || casting == NPY_UNSAFE_CASTING ) {
         return 1;
     }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1798,11 +1798,10 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
 
     oldtype = PyArray_DESCR(arr);
     if (newtype == NULL) {
-        /* 
-         * Check if object is of array dimension zero with Null newtype. 
-         * If so return it directly instead of calling  PyArray_FromAny.
+        /* Check if object is of array with Null newtype. 
+         * If so return it directly instead of checking for casting.
          */
-        if (PyArray_NDIM(arr) == 0 && flags == 0) {
+        if (flags == 0) {
             Py_INCREF(arr);
             return (PyObject *)arr;
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1798,7 +1798,8 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
 
     oldtype = PyArray_DESCR(arr);
     if (newtype == NULL) {
-        /* Check if object is of array with Null newtype. 
+        /* 
+         * Check if object is of array with Null newtype. 
          * If so return it directly instead of checking for casting.
          */
         if (flags == 0) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1798,6 +1798,14 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
 
     oldtype = PyArray_DESCR(arr);
     if (newtype == NULL) {
+        /* 
+         * Check if object is of array dimension zero with Null newtype. 
+         * If so return it directly instead of calling  PyArray_FromAny.
+         */
+        if (PyArray_NDIM(arr) == 0 && flags == 0) {
+            Py_INCREF(arr);
+            return (PyObject *)arr;
+        }
         newtype = oldtype;
         Py_INCREF(oldtype);
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -754,15 +754,11 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
     for (i = 0; i < nin; ++i) {
         obj = PyTuple_GET_ITEM(args, i);
  
-        /*
-         * If obj is array of dimension zero. PyArray_FromAny(obj,NULL,0,0,0,NULL) calls
-         * PyArray_FromArray(obj,NULL,0) which return original obj
-         */
-        if(PyArray_IsZeroDim(obj) && PyArray_Check(obj)){
-            Py_INCREF(obj);
-            out_op[i] = (PyArrayObject *)obj;
-        }else{
-            if (!PyArray_Check(obj) && !PyArray_IsScalar(obj, Generic)) {
+        if (PyArray_Check(obj)) {
+            out_op[i] = (PyArrayObject *)PyArray_FromArray(obj,NULL,0);
+        }
+        else {
+            if (!PyArray_IsScalar(obj, Generic)) {
                 /*
                  * TODO: There should be a comment here explaining what
                  *       context does.

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -422,6 +422,7 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
      */
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
+
     if (type_num1 >= NPY_NTYPES || type_num2 >= NPY_NTYPES ||
             type_num1 == NPY_OBJECT || type_num2 == NPY_OBJECT) {
         return PyUFunc_DefaultTypeResolver(ufunc, casting, operands,
@@ -431,6 +432,7 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
     if (type_tup == NULL) {
         /* Input types are the result type */
         out_dtypes[0] = PyArray_ResultType(2, operands, 0, NULL);
+
         if (out_dtypes[0] == NULL) {
             return -1;
         }

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -422,7 +422,6 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
      */
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
-
     if (type_num1 >= NPY_NTYPES || type_num2 >= NPY_NTYPES ||
             type_num1 == NPY_OBJECT || type_num2 == NPY_OBJECT) {
         return PyUFunc_DefaultTypeResolver(ufunc, casting, operands,
@@ -432,7 +431,6 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
     if (type_tup == NULL) {
         /* Input types are the result type */
         out_dtypes[0] = PyArray_ResultType(2, operands, 0, NULL);
-
         if (out_dtypes[0] == NULL) {
             return -1;
         }


### PR DESCRIPTION
In function get_ufunc_arguments, check if object is of array dimension zero, then avoid heavy calls like PyArray_FromAny. Hence passing obj to out_op PyArrayObject unchanged.

Also PyArray_FromAny(obj,NULL,0,0,0,NULL) calls PyArray_FromArray(obj,NULL,0) which return original obj
# Call-graph comparing cumulative time

Following is the callgraph of

<pre>import timeit
timeit.timeit('x+x',number=20000000,setup='import numpy as np;x = np.asarray(1.0);')
</pre>

![scalar_array](https://f.cloud.github.com/assets/1556486/754439/a8321630-e588-11e2-9eaa-0fa98efcc5b9.jpg)
# timeit

<dl>
  <dt>Before</dt>
  <dd><pre>In [1]: import numpy as np;x = np.asarray(5.5)
In [2]: timeit x*x
100000 loops, best of 3: 2.59 us per loop</pre></dd>
  <dt>After</dt>
  <dd><pre>In [1]: import numpy as np;x = np.asarray(5.5)
In [2]: timeit x*x
100000 loops, best of 3: 2.01 us per loop</pre></dd>
</dl>
