### PR TITLE
FIX: Make object comparison ufuncs not include identity check

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -352,6 +352,26 @@ considered an input error instead of returning the default.
 The ``rank`` function has been deprecated to avoid confusion with
 ``numpy.linalg.matrix_rank``.
 
+Object array equality comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In the future object array comparisons both `==` and `np.equal` will not
+make use of identity checks anymore. For example:
+
+>>> a = np.array([np.array([1, 2, 3]), 1])
+>>> b = np.array([np.array([1, 2, 3]), 1])
+>>> a == b
+
+will consistently return False (and in the future an error) even if the array
+in `a` and `b` was the same object.
+
+The equality operator `==` will in the future raise errors like `np.equal`
+if broadcasting or element comparisons, etc. fails.
+
+Comparison with `arr == None` will in the future do an elementwise comparison
+instead of just returning False. Code should be using `arr is None`.
+
+All of these changes will give Deprecation- or FutureWarnings at this time.
+
 C-API
 ~~~~~
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2388,9 +2388,11 @@ def array_equiv(a1, a2):
     except:
         return False
     try:
-        return bool(asarray(a1 == a2).all())
-    except ValueError:
+        multiarray.broadcast(a1, a2)
+    except:
         return False
+
+    return bool(asarray(a1 == a2).all())
 
 
 _errdict = {"ignore":ERR_IGNORE,

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1292,6 +1292,10 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         break;
     case Py_EQ:
         if (other == Py_None) {
+            if (DEPRECATE_FUTUREWARNING("comparison to `None` will result in "
+                    "an elementwise object comparison in the future.") < 0) {
+                return NULL;
+            }
             Py_INCREF(Py_False);
             return Py_False;
         }
@@ -1347,13 +1351,26 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          * indicate that
          */
         if (result == NULL) {
+            /*
+             * Comparisons should raise errors when element-wise comparison
+             * is not possible.
+             */
             PyErr_Clear();
+            if (DEPRECATE("elementwise comparison failed; "
+                          "this will raise the error in the future.") < 0) {
+                return NULL;
+            }
+
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }
         break;
     case Py_NE:
         if (other == Py_None) {
+            if (DEPRECATE_FUTUREWARNING("comparison to `None` will result in "
+                    "an elementwise object comparison in the future.") < 0) {
+                return NULL;
+            }
             Py_INCREF(Py_True);
             return Py_True;
         }
@@ -1404,7 +1421,16 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         }
 
         if (result == NULL) {
+            /*
+             * Comparisons should raise errors when element-wise comparison
+             * is not possible.
+             */
             PyErr_Clear();
+            if (DEPRECATE("elementwise comparison failed; "
+                          "this will raise the error in the future.") < 0) {
+                return NULL;
+            }
+
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2562,22 +2562,28 @@ NPY_NO_EXPORT void
 /**begin repeat
  * #kind = equal, not_equal, greater, greater_equal, less, less_equal#
  * #OP = EQ, NE, GT, GE, LT, LE#
- * #identity = NPY_TRUE, NPY_FALSE, NPY_FALSE, NPY_TRUE, NPY_FALSE, NPY_TRUE#
+ * #identity = NPY_TRUE, NPY_FALSE, -1*4#
  */
 NPY_NO_EXPORT void
 OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func)) {
     BINARY_LOOP {
+        int ret;
+        PyObject *ret_obj;
         PyObject *in1 = *(PyObject **)ip1;
         PyObject *in2 = *(PyObject **)ip2;
+
         in1 = in1 ? in1 : Py_None;
         in2 = in2 ? in2 : Py_None;
+
         /*
-         * Do not use RichCompareBool because it includes an identity check.
-         * But this is wrong for elementwise behaviour, since i.e. it says
-         * that NaN can be equal to NaN, and an array is equal to itself.
+         * Do not use RichCompareBool because it includes an identity check
+         * (for == and !=).
+         * This is wrong for elementwise behaviour, since it means
+         * that NaN can be equal to NaN and an array is equal to itself.
          */
-        PyObject *ret_obj = PyObject_RichCompare(in1, in2, Py_@OP@);
+        ret_obj = PyObject_RichCompare(in1, in2, Py_@OP@);
         if (ret_obj == NULL) {
+#if @identity@ != -1
             if (in1 == in2) {
                 PyErr_Clear();
                 if (DEPRECATE("numpy @kind@ will not check object identity "
@@ -2588,10 +2594,12 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
                 *((npy_bool *)op1) = @identity@;
                 continue;
             }
+#endif
             return;
         }
-        int ret = PyObject_IsTrue(ret_obj);
+        ret = PyObject_IsTrue(ret_obj);
         if (ret == -1) {
+#if @identity@ != -1
             if (in1 == in2) {
                 PyErr_Clear();
                 if (DEPRECATE("numpy @kind@ will not check object identity "
@@ -2603,19 +2611,22 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
                 *((npy_bool *)op1) = @identity@;
                 continue;
             }
+#endif
             return;
         }
+#if @identity@ != -1
         if ((in1 == in2) && ((npy_bool)ret != @identity@)) {
             if (DEPRECATE_FUTUREWARNING(
                         "numpy @kind@ will not check object identity "
                         "in the future. The comparison did not return the "
-                        "same result as suggested by the identity "
+                        "same result as suggested by the identity (`is`)) "
                         "and will change.") < 0) {
                 return;
             }
             *((npy_bool *)op1) = @identity@;
             continue;
         }
+#endif
         *((npy_bool *)op1) = (npy_bool)ret;
     }
 }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2568,9 +2568,18 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
     BINARY_LOOP {
         PyObject *in1 = *(PyObject **)ip1;
         PyObject *in2 = *(PyObject **)ip2;
-        int ret = PyObject_RichCompareBool(
+        /*
+         * Do not use RichCompareBool because it includes an identity check.
+         * But this is wrong for elementwise behaviour, since i.e. it says
+         * that NaN can be equal to NaN, and an array is equal to itself.
+         */
+        PyObject *ret_obj = PyObject_RichCompare(
                             in1 ? in1 : Py_None,
                             in2 ? in2 : Py_None, Py_@OP@);
+        if (ret_obj == NULL) {
+            return;
+        }
+        int ret = PyObject_IsTrue(ret_obj);
         if (ret == -1) {
             return;
         }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2562,26 +2562,59 @@ NPY_NO_EXPORT void
 /**begin repeat
  * #kind = equal, not_equal, greater, greater_equal, less, less_equal#
  * #OP = EQ, NE, GT, GE, LT, LE#
+ * #identity = NPY_TRUE, NPY_FALSE, NPY_FALSE, NPY_TRUE, NPY_FALSE, NPY_TRUE#
  */
 NPY_NO_EXPORT void
 OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func)) {
     BINARY_LOOP {
         PyObject *in1 = *(PyObject **)ip1;
         PyObject *in2 = *(PyObject **)ip2;
+        in1 = in1 ? in1 : Py_None;
+        in2 = in2 ? in2 : Py_None;
         /*
          * Do not use RichCompareBool because it includes an identity check.
          * But this is wrong for elementwise behaviour, since i.e. it says
          * that NaN can be equal to NaN, and an array is equal to itself.
          */
-        PyObject *ret_obj = PyObject_RichCompare(
-                            in1 ? in1 : Py_None,
-                            in2 ? in2 : Py_None, Py_@OP@);
+        PyObject *ret_obj = PyObject_RichCompare(in1, in2, Py_@OP@);
         if (ret_obj == NULL) {
+            if (in1 == in2) {
+                PyErr_Clear();
+                if (DEPRECATE("numpy @kind@ will not check object identity "
+                              "in the future. The comparison error will "
+                              "be raised.") < 0) {
+                    return;
+                }
+                *((npy_bool *)op1) = @identity@;
+                continue;
+            }
             return;
         }
         int ret = PyObject_IsTrue(ret_obj);
         if (ret == -1) {
+            if (in1 == in2) {
+                PyErr_Clear();
+                if (DEPRECATE("numpy @kind@ will not check object identity "
+                              "in the future. The error trying to get the "
+                              "boolean value of the comparison result will "
+                              "be raised.") < 0) {
+                    return;
+                }
+                *((npy_bool *)op1) = @identity@;
+                continue;
+            }
             return;
+        }
+        if ((in1 == in2) && ((npy_bool)ret != @identity@)) {
+            if (DEPRECATE_FUTUREWARNING(
+                        "numpy @kind@ will not check object identity "
+                        "in the future. The comparison did not return the "
+                        "same result as suggested by the identity "
+                        "and will change.") < 0) {
+                return;
+            }
+            *((npy_bool *)op1) = @identity@;
+            continue;
         }
         *((npy_bool *)op1) = (npy_bool)ret;
     }

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -397,7 +397,8 @@ class TestComparisonDepreactions(_DeprecationTestCase):
 
             # Element comparison error (numpy array can't be compared).
             a = np.array([1, np.array([1,2,3])], dtype=object)
-            self.assert_deprecated(op, args=(a, a), num=None)
+            b = np.array([1, np.array([1,2,3])], dtype=object)
+            self.assert_deprecated(op, args=(a, b), num=None)
 
 
     def test_string(self):
@@ -417,7 +418,6 @@ class TestComparisonDepreactions(_DeprecationTestCase):
         # comparison in the future. [1, 2] == None should be [False, False].
         with warnings.catch_warnings():
             warnings.filterwarnings('always', '', FutureWarning)
-            a = np.array([1, 2])
             assert_warns(FutureWarning, operator.eq, np.arange(3), None)
             assert_warns(FutureWarning, operator.ne, np.arange(3), None)
 
@@ -426,6 +426,58 @@ class TestComparisonDepreactions(_DeprecationTestCase):
             assert_raises(FutureWarning, operator.eq, np.arange(3), None)
             assert_raises(FutureWarning, operator.ne, np.arange(3), None)
 
+
+class TestIdentityComparisonDepreactions(_DeprecationTestCase):
+    """This tests the equal and not_equal object ufuncs identity check
+    deprecation. This was due to the usage of PyObject_RichCompareBool.
+
+    This tests that for example for `a = np.array([np.nan], dtype=object)`
+    `a == a` it is warned that False and not `np.nan is np.nan` is returned.
+
+    Should be kept in sync with TestComparisonDepreactions and new tests
+    added when the deprecation is over. Requires only removing of @identity@
+    (and blocks) from the ufunc loops.c.src of the OBJECT comparisons.
+    """
+
+    message = "numpy .* will not check object identity in the future."
+
+    def test_identity_equality_mismatch(self):
+        a = np.array([np.nan], dtype=object)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('always', '', FutureWarning)
+            assert_warns(FutureWarning, np.equal, a, a)
+            assert_warns(FutureWarning, np.not_equal, a, a)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', '', FutureWarning)
+            assert_raises(FutureWarning, np.equal, a, a)
+            assert_raises(FutureWarning, np.not_equal, a, a)
+            # And the other do not warn:
+            np.less(a, a)
+            np.greater(a, a)
+            np.less_equal(a, a)
+            np.greater_equal(a, a)
+
+
+    def test_comparison_error(self):
+        class FunkyType(object):
+            def __eq__(self, other):
+                raise TypeError("I won't compare")
+            def __ne__(self, other):
+                raise TypeError("I won't compare")
+
+        a = np.array([FunkyType()])
+        self.assert_deprecated(np.equal, args=(a, a))
+        self.assert_deprecated(np.not_equal, args=(a, a))
+
+
+    def test_bool_error(self):
+        # The comparison result cannot be interpreted as a bool
+        a = np.array([np.array([1, 2, 3]), None], dtype=object)
+        self.assert_deprecated(np.equal, args=(a, a))
+        self.assert_deprecated(np.not_equal, args=(a, a))
+        
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -86,7 +86,7 @@ class _DeprecationTestCase(object):
             elif not ignore_others:
                 raise AssertionError("expected DeprecationWarning but %s given"
                                                             % warning.category)
-        if num_found != num:
+        if num is not None and num_found != num:
             raise AssertionError("%i warnings found but %i expected"
                                                         % (len(self.log), num))
 
@@ -373,6 +373,58 @@ class TestRankDeprecation(_DeprecationTestCase):
     def test(self):
         a = np.arange(10)
         assert_warns(np.VisibleDeprecationWarning, np.rank, a)
+
+
+class TestComparisonDepreactions(_DeprecationTestCase):
+    """This tests the deprecation, for non-elementwise comparison logic.
+    This used to mean that when an error occured during element-wise comparison
+    (i.e. broadcasting) NotImplemented was returned, but also in the comparison
+    itself, False was given instead of the error.
+
+    Also test FutureWarning for the None comparison.
+    """
+
+    message = "elementwise comparison failed; " \
+              "this will raise the error in the future."
+
+    def test_normal_types(self):
+        for op in (operator.eq, operator.ne):
+            # Broadcasting errors:
+            self.assert_deprecated(op, args=(np.zeros(3), []))
+            a = np.zeros(3, dtype='i,i')
+            # (warning is issued a couple of times here)
+            self.assert_deprecated(op, args=(a, a[:-1]), num=None)
+
+            # Element comparison error (numpy array can't be compared).
+            a = np.array([1, np.array([1,2,3])], dtype=object)
+            self.assert_deprecated(op, args=(a, a), num=None)
+
+
+    def test_string(self):
+        # For two string arrays, strings always raised the broadcasting error:
+        a = np.array(['a', 'b'])
+        b = np.array(['a', 'b', 'c'])
+        assert_raises(ValueError, lambda x, y: x == y, a, b)
+
+        # The empty list is not cast to string, this is only to document
+        # that fact (it likely should be changed). This means that the
+        # following works (and returns False) due to dtype mismatch:
+        a == []
+
+
+    def test_none_comparison(self):
+        # Test comparison of None, which should result in elementwise
+        # comparison in the future. [1, 2] == None should be [False, False].
+        with warnings.catch_warnings():
+            warnings.filterwarnings('always', '', FutureWarning)
+            a = np.array([1, 2])
+            assert_warns(FutureWarning, operator.eq, np.arange(3), None)
+            assert_warns(FutureWarning, operator.ne, np.arange(3), None)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', '', FutureWarning)
+            assert_raises(FutureWarning, operator.eq, np.arange(3), None)
+            assert_raises(FutureWarning, operator.ne, np.arange(3), None)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -561,8 +561,9 @@ class TestStructured(TestCase):
         a = np.zeros((3, 5), dtype=[('a', ('i4', (2, 2)))])
         a['a'] = np.arange(60).reshape(3, 5, 2, 2)
 
-        # Since the subarray is always in C-order, these aren't equal
-        assert_(np.any(a['a'].T != a.T['a']))
+        # Since the subarray is always in C-order, a transpose
+        # does not swap the subarray:
+        assert_array_equal(a.T['a'], a['a'].transpose(1, 0, 2, 3))
 
         # In Fortran order, the subarray gets appended
         # like in all other cases, not prepended as a special case

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1534,16 +1534,5 @@ def test_complex_nan_comparisons():
                 assert_equal(x == y, False, err_msg="%r == %r" % (x, y))
 
 
-def test_object_array_comparison():
-    obj_array = np.arange(3)
-    a = np.array([obj_array, 1])
-    # Should raise an error because (obj_array == obj_array) is not a bool.
-    # At this time, a == a would return False because of the error.
-    assert_raises(ValueError, np.equal, a, a)
-
-    # Check the same for NaN, when it is the *same* NaN.
-    a = np.array([np.nan])
-    assert_equal(a == a, [False])
-
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1534,5 +1534,16 @@ def test_complex_nan_comparisons():
                 assert_equal(x == y, False, err_msg="%r == %r" % (x, y))
 
 
+def test_object_array_comparison():
+    obj_array = np.arange(3)
+    a = np.array([obj_array, 1])
+    # Should raise an error because (obj_array == obj_array) is not a bool.
+    # At this time, a == a would return False because of the error.
+    assert_raises(ValueError, np.equal, a, a)
+
+    # Check the same for NaN, when it is the *same* NaN.
+    a = np.array([np.nan])
+    assert_equal(a == a, [False])
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1193,10 +1193,24 @@ class poly1d(object):
     __rtruediv__ = __rdiv__
 
     def __eq__(self, other):
-        return NX.alltrue(self.coeffs == other.coeffs)
+        dim = min(self.coeffs.shape[0], other.coeffs.shape[0])
+        if (self.coeffs[-dim:] != other.coeffs[-dim:]).any():
+            return False
+        elif (self.coeffs[:-dim] != 0).any():
+            return False
+        elif (other.coeffs[:-dim] != 0).any():
+            return False
+        return True
 
     def __ne__(self, other):
-        return NX.any(self.coeffs != other.coeffs)
+        dim = min(self.coeffs.shape[0], other.coeffs.shape[0])
+        if (self.coeffs[-dim:] != other.coeffs[-dim:]).any():
+            return True
+        elif (self.coeffs[:-dim] != 0).any():
+            return True
+        elif (other.coeffs[:-dim] != 0).any():
+            return True
+        return False
 
     def __setattr__(self, key, val):
         raise ValueError("Attributes cannot be changed this way.")

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1193,24 +1193,12 @@ class poly1d(object):
     __rtruediv__ = __rdiv__
 
     def __eq__(self, other):
-        dim = min(self.coeffs.shape[0], other.coeffs.shape[0])
-        if (self.coeffs[-dim:] != other.coeffs[-dim:]).any():
+        if self.coeffs.shape != other.coeffs.shape:
             return False
-        elif (self.coeffs[:-dim] != 0).any():
-            return False
-        elif (other.coeffs[:-dim] != 0).any():
-            return False
-        return True
+        return (self.coeffs == other.coeffs).all()
 
     def __ne__(self, other):
-        dim = min(self.coeffs.shape[0], other.coeffs.shape[0])
-        if (self.coeffs[-dim:] != other.coeffs[-dim:]).any():
-            return True
-        elif (self.coeffs[:-dim] != 0).any():
-            return True
-        elif (other.coeffs[:-dim] != 0).any():
-            return True
-        return False
+        return not self.__eq__(other)
 
     def __setattr__(self, key, val):
         raise ValueError("Attributes cannot be changed this way.")

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -438,6 +438,7 @@ class ABCPolyBase(object):
         res = (isinstance(other, self.__class__) and
                np.all(self.domain == other.domain) and
                np.all(self.window == other.window) and
+               (self.coef.shape == other.coef.shape) and
                np.all(self.coef == other.coef))
         return res
 
@@ -792,7 +793,7 @@ class ABCPolyBase(object):
         """
         if domain is None:
             domain = pu.getdomain(x)
-        elif isinstance(domain, list) and len(domain) == 0:
+        elif type(domain) is list and len(domain) == 0:
             domain = cls.domain
 
         if window is None:
@@ -836,7 +837,7 @@ class ABCPolyBase(object):
         [roots] = pu.as_series([roots], trim=False)
         if domain is None:
             domain = pu.getdomain(roots)
-        elif isinstance(domain, list) and len(domain) == 0:
+        elif type(domain) is list and len(domain) == 0:
             domain = cls.domain
 
         if window is None:

--- a/numpy/polynomial/polytemplate.py
+++ b/numpy/polynomial/polytemplate.py
@@ -737,7 +737,7 @@ class $name(pu.PolyBase) :
             then a minimal domain that covers the points `x` is chosen.  If
             ``[]`` the default domain ``$domain`` is used. The default
             value is $domain in numpy 1.4.x and ``None`` in later versions.
-            The ``'[]`` value was added in numpy 1.5.0.
+            The ``[]`` value was added in numpy 1.5.0.
         rcond : float, optional
             Relative condition number of the fit. Singular values smaller
             than this relative to the largest singular value will be
@@ -780,10 +780,10 @@ class $name(pu.PolyBase) :
         """
         if domain is None:
             domain = pu.getdomain(x)
-        elif domain == []:
+        elif len(domain) == 0:
             domain = $domain
 
-        if window == []:
+        if len(window) == 0:
             window = $domain
 
         xnew = pu.mapdomain(x, domain, window)

--- a/numpy/polynomial/polytemplate.py
+++ b/numpy/polynomial/polytemplate.py
@@ -780,10 +780,10 @@ class $name(pu.PolyBase) :
         """
         if domain is None:
             domain = pu.getdomain(x)
-        elif len(domain) == 0:
+        elif type(domain) is list and len(domain) == 0:
             domain = $domain
 
-        if len(window) == 0:
+        if type(window) is list and len(window) == 0:
             window = $domain
 
         xnew = pu.mapdomain(x, domain, window)


### PR DESCRIPTION
The issue here is that PyObject_RichCompareBool does an identity
check before doing any other checks. This is good, and is the
way for example list comparisons are handled. However in numpy
comparisons are elementwise, so that the identitycheck should
not be expected. The example for this is as follows:
obj_array = np.arange(3)
a = np.array([obj_array, 0], dtype=object)
np.equal(a, a)
If an identity check is done, this returns [True, True]. But
obj_array == obj_array itself cannot be cast to a bool.

While this is slightly slower, not doing the identity check seems
more logical in the light of elementwise operations.

Closes gh-2117.

---

Just put it out there, might be that someone disagrees with this change. Remembered it because of that NaN inside object arrays discussion.
