### PR TITLE
MAINT: Remove outdated version checks.

### DIFF
--- a/doc/sphinxext/setup.py
+++ b/doc/sphinxext/setup.py
@@ -1,11 +1,10 @@
 from __future__ import division, print_function
 
+import sys
 import setuptools
 from distutils.core import setup
 
-import sys
-if sys.version_info[0] >= 3 and sys.version_info[1] < 3 or \
-        sys.version_info[0] <= 2 and sys.version_info[1] < 6:
+if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 3):
     raise RuntimeError("Python version 2.6, 2.7 or >= 3.3 required.")
 
 version = "0.4.dev"

--- a/numpy/core/blasdot/_dotblas.c
+++ b/numpy/core/blasdot/_dotblas.c
@@ -14,12 +14,6 @@
 
 #include <stdio.h>
 
-#if (PY_VERSION_HEX < 0x02060000)
-#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
-#define Py_REFCNT(o)  (((PyObject*)(o))->ob_refcnt)
-#define Py_SIZE(o)    (((PyVarObject*)(o))->ob_size)
-#endif
-
 static char module_doc[] =
 "This module provides a BLAS optimized\nmatrix multiply, inner product and dot for numpy arrays";
 

--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -225,15 +225,8 @@ PyArray_XDECREF_ERR(PyArrayObject *arr)
                                    (PyTuple_GET_ITEM((value), 2) == (key)))
 
 
-/* Define python version independent deprecation macro */
-
-#if PY_VERSION_HEX >= 0x02050000
 #define DEPRECATE(msg) PyErr_WarnEx(PyExc_DeprecationWarning,msg,1)
 #define DEPRECATE_FUTUREWARNING(msg) PyErr_WarnEx(PyExc_FutureWarning,msg,1)
-#else
-#define DEPRECATE(msg) PyErr_Warn(PyExc_DeprecationWarning,msg)
-#define DEPRECATE_FUTUREWARNING(msg) PyErr_Warn(PyExc_FutureWarning,msg)
-#endif
 
 
 #ifdef __cplusplus

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -71,18 +71,8 @@ typedef Py_uintptr_t npy_uintp;
 #undef constchar
 #endif
 
-#if (PY_VERSION_HEX < 0x02050000)
-  #ifndef PY_SSIZE_T_MIN
-    typedef int Py_ssize_t;
-    #define PY_SSIZE_T_MAX INT_MAX
-    #define PY_SSIZE_T_MIN INT_MIN
-  #endif
-#define NPY_SSIZE_T_PYFMT "i"
-#define constchar const char
-#else
 #define NPY_SSIZE_T_PYFMT "n"
 #define constchar char
-#endif
 
 /* NPY_INTP_FMT Note:
  *      Unlike the other NPY_*_FMT macros which are used with

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1694,8 +1694,6 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     (Py_TPFLAGS_DEFAULT
 #if !defined(NPY_PY3K)
      | Py_TPFLAGS_CHECKTYPES
-#endif
-#if (PY_VERSION_HEX >= 0x02060000) && (PY_VERSION_HEX < 0x03000000)
      | Py_TPFLAGS_HAVE_NEWBUFFER
 #endif
      | Py_TPFLAGS_BASETYPE),                  /* tp_flags */
@@ -1726,7 +1724,5 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -93,8 +93,6 @@ array_getcharbuf(PyArrayObject *self, Py_ssize_t segment, constchar **ptrptr)
  * Py_buffers.
  *************************************************************************/
 
-#if PY_VERSION_HEX >= 0x02060000
-
 /*
  * Format string translator
  *
@@ -333,8 +331,10 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             }
 
             if (is_native_only_type) {
-                /* It's not possible to express native-only data types
-                   in non-native npy_byte orders */
+                /*
+                 * It's not possible to express native-only data types
+                 * in non-native npy_byte orders
+                 */
                 PyErr_Format(PyExc_ValueError,
                              "cannot expose native-only dtype '%c' in "
                              "non-native byte order '%c' via buffer interface",
@@ -722,42 +722,24 @@ _array_dealloc_buffer_info(PyArrayObject *self)
     }
 }
 
-#else
-
-NPY_NO_EXPORT void
-_array_dealloc_buffer_info(PyArrayObject *self)
-{
-}
-
-#endif
 
 /*************************************************************************/
 
 NPY_NO_EXPORT PyBufferProcs array_as_buffer = {
 #if !defined(NPY_PY3K)
-#if PY_VERSION_HEX >= 0x02050000
     (readbufferproc)array_getreadbuf,       /*bf_getreadbuffer*/
     (writebufferproc)array_getwritebuf,     /*bf_getwritebuffer*/
     (segcountproc)array_getsegcount,        /*bf_getsegcount*/
     (charbufferproc)array_getcharbuf,       /*bf_getcharbuffer*/
-#else
-    (getreadbufferproc)array_getreadbuf,    /*bf_getreadbuffer*/
-    (getwritebufferproc)array_getwritebuf,  /*bf_getwritebuffer*/
-    (getsegcountproc)array_getsegcount,     /*bf_getsegcount*/
-    (getcharbufferproc)array_getcharbuf,    /*bf_getcharbuffer*/
 #endif
-#endif
-#if PY_VERSION_HEX >= 0x02060000
     (getbufferproc)array_getbuffer,
     (releasebufferproc)0,
-#endif
 };
 
 
 /*************************************************************************
  * Convert PEP 3118 format string to PyArray_Descr
  */
-#if PY_VERSION_HEX >= 0x02060000
 
 NPY_NO_EXPORT PyArray_Descr*
 _descriptor_from_pep3118_format(char *s)
@@ -817,15 +799,3 @@ _descriptor_from_pep3118_format(char *s)
     }
     return (PyArray_Descr*)descr;
 }
-
-#else
-
-NPY_NO_EXPORT PyArray_Descr*
-_descriptor_from_pep3118_format(char *s)
-{
-    PyErr_SetString(PyExc_RuntimeError,
-                    "PEP 3118 is not supported on Python versions < 2.6");
-    return NULL;
-}
-
-#endif

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -97,15 +97,9 @@ PyArray_GetCastFunc(PyArray_Descr *descr, int type_num)
             cls = PyObject_GetAttrString(obj, "ComplexWarning");
             Py_DECREF(obj);
         }
-#if PY_VERSION_HEX >= 0x02050000
         ret = PyErr_WarnEx(cls,
-                           "Casting complex values to real discards "
-                           "the imaginary part", 1);
-#else
-        ret = PyErr_Warn(cls,
-                         "Casting complex values to real discards "
-                         "the imaginary part");
-#endif
+                "Casting complex values to real discards "
+                "the imaginary part", 1);
         Py_XDECREF(cls);
         if (ret < 0) {
             return NULL;
@@ -115,7 +109,8 @@ PyArray_GetCastFunc(PyArray_Descr *descr, int type_num)
         return castfunc;
     }
 
-    PyErr_SetString(PyExc_ValueError, "No cast function available.");
+    PyErr_SetString(PyExc_ValueError,
+            "No cast function available.");
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -590,9 +590,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
 {
     PyObject *e;
     int r, n, i;
-#if PY_VERSION_HEX >= 0x02060000
     Py_buffer buffer_view;
-#endif
 
     if (*maxndim == 0) {
         return 0;
@@ -655,7 +653,6 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     }
 
     /* obj is a PEP 3118 buffer */
-#if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 buffer interface */
     if (PyObject_CheckBuffer(obj) == 1) {
         memset(&buffer_view, 0, sizeof(Py_buffer));
@@ -681,7 +678,6 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
             PyErr_Clear();
         }
     }
-#endif
 
     /* obj has the __array_struct__ interface */
     e = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
@@ -721,11 +717,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
                     *maxndim = nd;
                 }
                 for (i=0; i<*maxndim; i++) {
-#if (PY_VERSION_HEX >= 0x02050000)
                     d[i] = PyInt_AsSsize_t(PyTuple_GET_ITEM(new, i));
-#else
-                    d[i] = PyInt_AsLong(PyTuple_GET_ITEM(new, i));
-#endif
                     if (d[i] < 0) {
                         PyErr_SetString(PyExc_RuntimeError,
                                 "Invalid shape in __array_interface__");
@@ -1197,7 +1189,6 @@ PyArray_New(PyTypeObject *subtype, int nd, npy_intp *dims, int type_num,
 NPY_NO_EXPORT int
 _array_from_buffer_3118(PyObject *obj, PyObject **out)
 {
-#if PY_VERSION_HEX >= 0x02060000
     /* PEP 3118 */
     PyObject *memoryview;
     Py_buffer *view;
@@ -1286,9 +1277,6 @@ fail:
     Py_DECREF(memoryview);
     return -1;
 
-#else
-    return -1;
-#endif
 }
 
 /*NUMPY_API

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -547,7 +547,5 @@ NPY_NO_EXPORT PyTypeObject NpyBusDayCalendar_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3497,7 +3497,5 @@ NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -669,15 +669,9 @@ get_nbo_cast_numeric_transfer_function(int aligned,
             cls = PyObject_GetAttrString(obj, "ComplexWarning");
             Py_DECREF(obj);
         }
-#if PY_VERSION_HEX >= 0x02050000
         ret = PyErr_WarnEx(cls,
-                           "Casting complex values to real discards "
-                           "the imaginary part", 1);
-#else
-        ret = PyErr_Warn(cls,
-                         "Casting complex values to real discards "
-                         "the imaginary part");
-#endif
+                "Casting complex values to real discards "
+                "the imaginary part", 1);
         Py_XDECREF(cls);
         if (ret < 0) {
             return NPY_FAIL;

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -643,11 +643,7 @@ arrayflags_richcompare(PyObject *self, PyObject *other, int cmp_op)
 }
 
 static PyMappingMethods arrayflags_as_mapping = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)NULL,                       /*mp_length*/
-#else
-    (inquiry)NULL,                       /*mp_length*/
-#endif
     (binaryfunc)arrayflags_getitem,      /*mp_subscript*/
     (objobjargproc)arrayflags_setitem,   /*mp_ass_subscript*/
 };
@@ -725,7 +721,5 @@ NPY_NO_EXPORT PyTypeObject PyArrayFlags_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1136,11 +1136,7 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
 
 
 static PyMappingMethods iter_as_mapping = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)iter_length,                   /*mp_length*/
-#else
-    (inquiry)iter_length,                   /*mp_length*/
-#endif
     (binaryfunc)iter_subscript,             /*mp_subscript*/
     (objobjargproc)iter_ass_subscript,      /*mp_ass_subscript*/
 };
@@ -1349,9 +1345,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayIter_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 /** END of Array Iterator **/
@@ -1826,9 +1820,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayMultiIter_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 /*========================= Neighborhood iterator ======================*/
@@ -2158,7 +2150,5 @@ NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1502,11 +1502,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
 }
 
 NPY_NO_EXPORT PyMappingMethods array_as_mapping = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)array_length,              /*mp_length*/
-#else
-    (inquiry)array_length,              /*mp_length*/
-#endif
     (binaryfunc)array_subscript,        /*mp_subscript*/
     (objobjargproc)array_ass_sub,       /*mp_ass_subscript*/
 };
@@ -2235,9 +2231,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 /** END of Subscript Iterator **/

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -28,17 +28,10 @@ array_subscript(PyArrayObject *self, PyObject *op);
 NPY_NO_EXPORT int
 array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v);
 
-#if PY_VERSION_HEX < 0x02050000
-        #if NPY_SIZEOF_INT == NPY_SIZEOF_INTP
-                #define array_ass_item array_ass_big_item
-        #endif
+/* SIZEOF_SIZE_T is nowhere defined, Py_ssize_t perhaps?*/
+#if SIZEOF_SIZE_T == NPY_SIZEOF_INTP
+#define array_ass_item array_ass_big_item
 #else
-        /* SIZEOF_SIZE_T is nowhere defined, Py_ssize_t perhaps?*/
-        #if SIZEOF_SIZE_T == NPY_SIZEOF_INTP
-                #define array_ass_item array_ass_big_item
-        #endif
-#endif
-#ifndef array_ass_item
 NPY_NO_EXPORT int
 _array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
 #define array_ass_item _array_ass_item

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1933,15 +1933,8 @@ array_count_nonzero(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     }
 #if defined(NPY_PY3K)
     return PyLong_FromSsize_t(count);
-#elif PY_VERSION_HEX >= 0x02050000
-    return PyInt_FromSsize_t(count);
 #else
-    if ((npy_intp)((long)count) == count) {
-        return PyInt_FromLong(count);
-    }
-    else {
-        return PyLong_FromVoidPtr((void*)count);
-    }
+    return PyInt_FromSsize_t(count);
 #endif
 }
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1747,11 +1747,7 @@ static PyObject *npyiter_iterrange_get(NewNpyArrayIterObject *self)
 
 static int npyiter_iterrange_set(NewNpyArrayIterObject *self, PyObject *value)
 {
-#if PY_VERSION_HEX >= 0x02050000
     npy_intp istart = 0, iend = 0;
-#else
-    long istart = 0, iend = 0;
-#endif
 
     if (value == NULL) {
         PyErr_SetString(PyExc_AttributeError,
@@ -1764,11 +1760,7 @@ static int npyiter_iterrange_set(NewNpyArrayIterObject *self, PyObject *value)
         return -1;
     }
 
-#if PY_VERSION_HEX >= 0x02050000
     if (!PyArg_ParseTuple(value, "nn", &istart, &iend)) {
-#else
-    if (!PyArg_ParseTuple(value, "ll", &istart, &iend)) {
-#endif
         return -1;
     }
 
@@ -2405,7 +2397,6 @@ static PyGetSetDef npyiter_getsets[] = {
 };
 
 NPY_NO_EXPORT PySequenceMethods npyiter_as_sequence = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)npyiter_seq_length,            /*sq_length*/
     (binaryfunc)NULL,                       /*sq_concat*/
     (ssizeargfunc)NULL,                     /*sq_repeat*/
@@ -2416,26 +2407,10 @@ NPY_NO_EXPORT PySequenceMethods npyiter_as_sequence = {
     (objobjproc)NULL,                       /*sq_contains */
     (binaryfunc)NULL,                       /*sq_inplace_concat */
     (ssizeargfunc)NULL,                     /*sq_inplace_repeat */
-#else
-    (inquiry)npyiter_seq_length,            /*sq_length*/
-    (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
-    (intargfunc)NULL,                       /*sq_repeat is handled nb_multiply*/
-    (intargfunc)npyiter_seq_item,           /*sq_item*/
-    (intintargfunc)npyiter_seq_slice,       /*sq_slice*/
-    (intobjargproc)npyiter_seq_ass_item,    /*sq_ass_item*/
-    (intintobjargproc)npyiter_seq_ass_slice,/*sq_ass_slice*/
-    (objobjproc)NULL,                       /*sq_contains */
-    (binaryfunc)NULL,                       /*sg_inplace_concat */
-    (intargfunc)NULL                        /*sg_inplace_repeat */
-#endif
 };
 
 NPY_NO_EXPORT PyMappingMethods npyiter_as_mapping = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)npyiter_seq_length,          /*mp_length*/
-#else
-    (inquiry)npyiter_seq_length,          /*mp_length*/
-#endif
     (binaryfunc)npyiter_subscript,        /*mp_subscript*/
     (objobjargproc)npyiter_ass_subscript, /*mp_ass_subscript*/
 };
@@ -2497,7 +2472,5 @@ NPY_NO_EXPORT PyTypeObject NpyIter_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -340,7 +340,6 @@ is_scalar_with_conversion(PyObject *o2, double* out_exponent)
             }
         }
     }
-#if (PY_VERSION_HEX >= 0x02050000)
     if (PyIndex_Check(o2)) {
         PyObject* value = PyNumber_Index(o2);
         Py_ssize_t val;
@@ -358,7 +357,6 @@ is_scalar_with_conversion(PyObject *o2, double* out_exponent)
         *out_exponent = (double) val;
         return NPY_INTPOS_SCALAR;
     }
-#endif
     return NPY_NOSCALAR;
 }
 
@@ -851,7 +849,6 @@ _array_copy_nice(PyArrayObject *self)
     return PyArray_Return((PyArrayObject *) PyArray_Copy(self));
 }
 
-#if PY_VERSION_HEX >= 0x02050000
 static PyObject *
 array_index(PyArrayObject *v)
 {
@@ -868,7 +865,6 @@ array_index(PyArrayObject *v)
     }
     return PyArray_DESCR(v)->f->getitem(PyArray_DATA(v), v);
 }
-#endif
 
 
 NPY_NO_EXPORT PyNumberMethods array_as_number = {
@@ -928,9 +924,5 @@ NPY_NO_EXPORT PyNumberMethods array_as_number = {
     (binaryfunc)array_true_divide,              /*nb_true_divide*/
     (binaryfunc)array_inplace_floor_divide,     /*nb_inplace_floor_divide*/
     (binaryfunc)array_inplace_true_divide,      /*nb_inplace_true_divide*/
-
-#if PY_VERSION_HEX >= 0x02050000
     (unaryfunc)array_index,                     /* nb_index */
-#endif
-
 };

--- a/numpy/core/src/multiarray/numpymemoryview.c
+++ b/numpy/core/src/multiarray/numpymemoryview.c
@@ -21,7 +21,7 @@
 #include "numpymemoryview.h"
 
 
-#if (PY_VERSION_HEX >= 0x02060000) && (PY_VERSION_HEX < 0x02070000)
+#if PY_VERSION_HEX < 0x02070000
 
 /*
  * Memory allocation
@@ -241,9 +241,7 @@ NPY_NO_EXPORT PyTypeObject PyMemorySimpleView_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 

--- a/numpy/core/src/multiarray/numpymemoryview.h
+++ b/numpy/core/src/multiarray/numpymemoryview.h
@@ -5,7 +5,7 @@
  * Memoryview is introduced to 2.x series only in 2.7, so for supporting 2.6,
  * we need to have a minimal implementation here.
  */
-#if (PY_VERSION_HEX >= 0x02060000) && (PY_VERSION_HEX < 0x02070000)
+#if PY_VERSION_HEX < 0x02070000
 
 typedef struct {
     PyObject_HEAD

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -19,12 +19,7 @@
  * exponent.
  */
 
-/* We force 3 digits on windows for python < 2.6 for compatibility reason */
-#if defined(MS_WIN32) && (PY_VERSION_HEX < 0x02060000)
-#define MIN_EXPONENT_DIGITS 3
-#else
 #define MIN_EXPONENT_DIGITS 2
-#endif
 
 /*
  * Ensure that any exponent, if present, is at least MIN_EXPONENT_DIGITS

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -101,9 +101,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 /**end repeat**/
 
@@ -364,7 +362,6 @@ gentype_repr(PyObject *self)
     return ret;
 }
 
-#if PY_VERSION_HEX >= 0x02060000
 /*
  * The __format__ method for PEP 3101.
  */
@@ -435,7 +432,6 @@ gentype_format(PyObject *self, PyObject *args)
     Py_DECREF(obj);
     return ret;
 }
-#endif
 
 #ifdef FORCE_NO_LONG_DOUBLE_FORMATTING
 #undef NPY_LONGDOUBLE_FMT
@@ -517,11 +513,9 @@ format_@name@(char *buf, size_t buflen, @type@ val, unsigned int prec)
             fprintf(stderr, "Error while formatting\n");
             return;
         }
-#if PY_VERSION_HEX >= 0x02060000
         if (!npy_isfinite(val.imag)) {
             strncat(buf, "*", 1);
         }
-#endif
         strncat(buf, "j", 1);
     }
     else {
@@ -570,11 +564,9 @@ format_@name@(char *buf, size_t buflen, @type@ val, unsigned int prec)
                 else {
                         strcpy(im, "-inf");
                 }
-                #if PY_VERSION_HEX >= 0x02060000
                 if (!npy_isfinite(val.imag)) {
                         strncat(im, "*", 1);
                 }
-                #endif
         }
         PyOS_snprintf(buf, buflen, "(%s%sj)", re, im);
     }
@@ -1059,9 +1051,7 @@ static PyNumberMethods gentype_as_number = {
     (binaryfunc)gentype_true_divide,             /*nb_true_divide*/
     0,                                           /*nb_inplace_floor_divide*/
     0,                                           /*nb_inplace_true_divide*/
-#if PY_VERSION_HEX >= 0x02050000
     (unaryfunc)NULL,                             /*nb_index*/
-#endif
 };
 
 
@@ -2014,13 +2004,11 @@ static PyMethodDef gentype_methods[] = {
         (PyCFunction)gentype_round,
         METH_VARARGS | METH_KEYWORDS, NULL},
 #endif
-#if PY_VERSION_HEX >= 0x02060000
     /* For the format function */
     {"__format__",
         gentype_format,
         METH_VARARGS,
         "NumPy array scalar formatter"},
-#endif
     {"setflags",
         (PyCFunction)gentype_setflags,
         METH_VARARGS | METH_KEYWORDS, NULL},
@@ -2232,32 +2220,19 @@ fail:
 }
 
 static PyMappingMethods voidtype_as_mapping = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)voidtype_length,                    /*mp_length*/
-#else
-    (inquiry)voidtype_length,                    /*mp_length*/
-#endif
     (binaryfunc)voidtype_subscript,              /*mp_subscript*/
     (objobjargproc)voidtype_ass_subscript,       /*mp_ass_subscript*/
 };
 
 
 static PySequenceMethods voidtype_as_sequence = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)voidtype_length,                    /*sq_length*/
     0,                                           /*sq_concat*/
     0,                                           /*sq_repeat*/
     (ssizeargfunc)voidtype_item,                 /*sq_item*/
     0,                                           /*sq_slice*/
     (ssizeobjargproc)voidtype_ass_item,          /*sq_ass_item*/
-#else
-        (inquiry)voidtype_length,                /*sq_length*/
-    0,                                           /*sq_concat*/
-    0,                                           /*sq_repeat*/
-    (intargfunc)voidtype_item,                   /*sq_item*/
-    0,                                           /*sq_slice*/
-    (intobjargproc)voidtype_ass_item,            /*sq_ass_item*/
-#endif
     0,                                           /* ssq_ass_slice */
     0,                                           /* sq_contains */
     0,                                           /* sq_inplace_concat */
@@ -2325,7 +2300,6 @@ gentype_getcharbuf(PyObject *self, Py_ssize_t segment, constchar **ptrptr)
 }
 #endif /* !defined(NPY_PY3K) */
 
-#if PY_VERSION_HEX >= 0x02060000
 
 static int
 gentype_getbuffer(PyObject *self, Py_buffer *view, int flags)
@@ -2341,7 +2315,6 @@ gentype_getbuffer(PyObject *self, Py_buffer *view, int flags)
 
 /* releasebuffer is not needed */
 
-#endif
 
 static PyBufferProcs gentype_as_buffer = {
 #if !defined(NPY_PY3K)
@@ -2350,10 +2323,8 @@ static PyBufferProcs gentype_as_buffer = {
     gentype_getsegcount,                         /* bf_getsegcount*/
     gentype_getcharbuf,                          /* bf_getcharbuffer*/
 #endif
-#if PY_VERSION_HEX >= 0x02060000
     gentype_getbuffer,                           /* bf_getbuffer */
     NULL,                                        /* bf_releasebuffer */
-#endif
 };
 
 
@@ -2422,9 +2393,7 @@ NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 static void
@@ -2741,7 +2710,6 @@ bool_arrtype_nonzero(PyObject *a)
     return a == PyArrayScalar_True;
 }
 
-#if PY_VERSION_HEX >= 0x02050000
 /**begin repeat
  * #name = byte, short, int, long, ubyte, ushort, longlong, uint,
  *         ulong, ulonglong#
@@ -2763,7 +2731,6 @@ bool_index(PyObject *a)
 {
     return PyInt_FromLong(PyArrayScalar_VAL(a, Bool));
 }
-#endif
 
 /* Arithmetic methods -- only so we can override &, |, ^. */
 NPY_NO_EXPORT PyNumberMethods bool_arrtype_as_number = {
@@ -2825,9 +2792,7 @@ NPY_NO_EXPORT PyNumberMethods bool_arrtype_as_number = {
     0,                                           /* nb_inplace_floor_divide */
     0,                                           /* nb_inplace_true_divide */
     /* Added in release 2.5 */
-#if PY_VERSION_HEX >= 0x02050000
     0,                                           /* nb_index */
-#endif
 };
 
 static PyObject *
@@ -3182,7 +3147,6 @@ object_arrtype_inplace_repeat(PyObjectScalarObject *self, Py_ssize_t count)
 }
 
 static PySequenceMethods object_arrtype_as_sequence = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)object_arrtype_length,              /*sq_length*/
     (binaryfunc)object_arrtype_concat,           /*sq_concat*/
     (ssizeargfunc)object_arrtype_repeat,         /*sq_repeat*/
@@ -3193,30 +3157,12 @@ static PySequenceMethods object_arrtype_as_sequence = {
     (objobjproc)object_arrtype_contains,         /* sq_contains */
     (binaryfunc)object_arrtype_inplace_concat,   /* sq_inplace_concat */
     (ssizeargfunc)object_arrtype_inplace_repeat, /* sq_inplace_repeat */
-#else
-    (inquiry)object_arrtype_length,              /*sq_length*/
-    (binaryfunc)object_arrtype_concat,           /*sq_concat*/
-    (intargfunc)object_arrtype_repeat,           /*sq_repeat*/
-    0,                                           /*sq_item*/
-    0,                                           /*sq_slice*/
-    0,                                           /* sq_ass_item */
-    0,                                           /* sq_ass_slice */
-    (objobjproc)object_arrtype_contains,         /* sq_contains */
-    (binaryfunc)object_arrtype_inplace_concat,   /* sq_inplace_concat */
-    (intargfunc)object_arrtype_inplace_repeat,   /* sq_inplace_repeat */
-#endif
 };
 
 static PyMappingMethods object_arrtype_as_mapping = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)object_arrtype_length,
     (binaryfunc)object_arrtype_subscript,
     (objobjargproc)object_arrtype_ass_subscript,
-#else
-    (inquiry)object_arrtype_length,
-    (binaryfunc)object_arrtype_subscript,
-    (objobjargproc)object_arrtype_ass_subscript,
-#endif
 };
 
 #if !defined(NPY_PY3K)
@@ -3285,7 +3231,6 @@ object_arrtype_getcharbuf(PyObjectScalarObject *self, Py_ssize_t segment,
 }
 #endif
 
-#if PY_VERSION_HEX >= 0x02060000
 static int
 object_arrtype_getbuffer(PyObjectScalarObject *self, Py_buffer *view, int flags)
 {
@@ -3311,26 +3256,16 @@ object_arrtype_releasebuffer(PyObjectScalarObject *self, Py_buffer *view)
         (*pb->bf_releasebuffer)(self->obval, view);
     }
 }
-#endif
 
 static PyBufferProcs object_arrtype_as_buffer = {
 #if !defined(NPY_PY3K)
-#if PY_VERSION_HEX >= 0x02050000
     (readbufferproc)object_arrtype_getreadbuf,
     (writebufferproc)object_arrtype_getwritebuf,
     (segcountproc)object_arrtype_getsegcount,
     (charbufferproc)object_arrtype_getcharbuf,
-#else
-    (getreadbufferproc)object_arrtype_getreadbuf,
-    (getwritebufferproc)object_arrtype_getwritebuf,
-    (getsegcountproc)object_arrtype_getsegcount,
-    (getcharbufferproc)object_arrtype_getcharbuf,
 #endif
-#endif
-#if PY_VERSION_HEX >= 0x02060000
     (getbufferproc)object_arrtype_getbuffer,
     (releasebufferproc)object_arrtype_releasebuffer,
-#endif
 };
 
 static PyObject *
@@ -3395,9 +3330,7 @@ NPY_NO_EXPORT PyTypeObject PyObjectArrType_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 static PyObject *
@@ -3513,9 +3446,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 /**end repeat**/
 
@@ -3604,9 +3535,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 #undef _THIS_SIZE
@@ -3706,9 +3635,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 #undef _THIS_SIZE1
 #undef _THIS_SIZE2
@@ -4066,7 +3993,6 @@ initialize_numeric_types(void)
     PyGenericArrType_Type.tp_richcompare = gentype_richcompare;
 
     PyBoolArrType_Type.tp_as_number = &bool_arrtype_as_number;
-#if PY_VERSION_HEX >= 0x02050000
     /*
      * need to add dummy versions with filled-in nb_index
      * in-order for PyType_Ready to fill in .__index__() method
@@ -4083,7 +4009,6 @@ initialize_numeric_types(void)
 
     /**end repeat**/
     PyBoolArrType_Type.tp_as_number->nb_index = (unaryfunc)bool_index;
-#endif
 
     PyStringArrType_Type.tp_alloc = NULL;
     PyStringArrType_Type.tp_free = NULL;

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -130,7 +130,6 @@ array_contains(PyArrayObject *self, PyObject *el)
 }
 
 NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
-#if PY_VERSION_HEX >= 0x02050000
     (lenfunc)array_length,                  /*sq_length*/
     (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
     (ssizeargfunc)NULL,
@@ -141,18 +140,6 @@ NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
     (objobjproc) array_contains,            /*sq_contains */
     (binaryfunc) NULL,                      /*sg_inplace_concat */
     (ssizeargfunc)NULL,
-#else
-    (inquiry)array_length,                  /*sq_length*/
-    (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
-    (intargfunc)NULL,                       /*sq_repeat is handled nb_multiply*/
-    (intargfunc)array_item,                 /*sq_item*/
-    (intintargfunc)array_slice,             /*sq_slice*/
-    (intobjargproc)array_ass_item,          /*sq_ass_item*/
-    (intintobjargproc)array_ass_slice,      /*sq_ass_slice*/
-    (objobjproc) array_contains,            /*sq_contains */
-    (binaryfunc) NULL,                      /*sg_inplace_concat */
-    (intargfunc) NULL                       /*sg_inplace_repeat */
-#endif
 };
 
 

--- a/numpy/core/src/private/npy_pycompat.h
+++ b/numpy/core/src/private/npy_pycompat.h
@@ -3,14 +3,4 @@
 
 #include "numpy/npy_3kcompat.h"
 
-/*
- * Accessing items of ob_base
- */
-
-#if (PY_VERSION_HEX < 0x02060000)
-#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
-#define Py_REFCNT(o)  (((PyObject*)(o))->ob_refcnt)
-#define Py_SIZE(o)    (((PyVarObject*)(o))->ob_size)
-#endif
-
 #endif /* _NPY_COMPAT_H_ */

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -1392,13 +1392,8 @@ emit_complexwarning(void)
         assert(cls != NULL);
         Py_DECREF(mod);
     }
-#if PY_VERSION_HEX >= 0x02050000
     return PyErr_WarnEx(cls,
             "Casting complex values to real discards the imaginary part", 1);
-#else
-    return PyErr_Warn(cls,
-            "Casting complex values to real discards the imaginary part");
-#endif
 }
 
 /**begin repeat
@@ -1658,9 +1653,7 @@ static PyNumberMethods @name@_as_number = {
     (binaryfunc)@name@_true_divide,             /*nb_true_divide*/
     0,                                          /*nb_inplace_floor_divide*/
     0,                                          /*nb_inplace_true_divide*/
-#if PY_VERSION_HEX >= 0x02050000
     (unaryfunc)NULL,                            /*nb_index*/
-#endif
 };
 /**end repeat**/
 
@@ -1679,9 +1672,7 @@ add_scalarmath(void)
      *          Half, Float, Double, LongDouble,
      *          CFloat, CDouble, CLongDouble#
      **/
-#if PY_VERSION_HEX >= 0x02050000
     @name@_as_number.nb_index = Py@NAME@ArrType_Type.tp_as_number->nb_index;
-#endif
     Py@NAME@ArrType_Type.tp_as_number = &(@name@_as_number);
     Py@NAME@ArrType_Type.tp_richcompare = @name@_richcompare;
     /**end repeat**/

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -716,9 +716,7 @@ static PyTypeObject PyRational_Type = {
     0,                                        /* tp_subclasses */
     0,                                        /* tp_weaklist */
     0,                                        /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                        /* tp_version_tag */
-#endif
 };
 
 /* Numpy support */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5101,9 +5101,7 @@ NPY_NO_EXPORT PyTypeObject PyUFunc_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
 };
 
 /* End of code for ufunc objects */

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -31,27 +31,6 @@ extern "C" {
 #define PyNumber_Int PyNumber_Long
 #endif
 
-#if (PY_VERSION_HEX < 0x02060000)
-#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
-#define Py_REFCNT(o)  (((PyObject*)(o))->ob_refcnt)
-#define Py_SIZE(o)    (((PyVarObject*)(o))->ob_size)
-#endif
-
-  /*
-#ifdef F2PY_REPORT_ATEXIT_DISABLE
-#undef F2PY_REPORT_ATEXIT
-#else
-
-#ifndef __FreeBSD__
-#ifndef __WIN32__
-#ifndef __APPLE__
-#define F2PY_REPORT_ATEXIT
-#endif
-#endif
-#endif
-
-#endif
-  */
 
 #ifdef F2PY_REPORT_ATEXIT
 #include <sys/timeb.h>

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -7,9 +7,6 @@
 #include "numpy/ufuncobject.h"
 #include "string.h"
 
-#if (PY_VERSION_HEX < 0x02060000)
-#define Py_TYPE(o)    (((PyObject*)(o))->ob_type)
-#endif
 
 static npy_intp
 incr_slot_(double x, double *bins, npy_intp lbins)

--- a/numpy/numarray/_capi.c
+++ b/numpy/numarray/_capi.c
@@ -996,9 +996,7 @@ static PyTypeObject CfuncType = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
-#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
-#endif
     };
 
 /* CfuncObjects are created at the c-level only.  They ensure that each
@@ -2250,11 +2248,9 @@ _NA_maxType(PyObject *seq, int limit)
         }
         return maxtype;
     } else {
-#if PY_VERSION_HEX >= 0x02030000
         if (PyBool_Check(seq))
             return BOOL_SCALAR;
         else
-#endif
 #if defined(NPY_PY3K)
             if (PyInt_Check(seq))
                 return INT_SCALAR;

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ import sys
 import re
 import subprocess
 
+if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
+    raise RuntimeError("Python version 2.6, 2.7 or >= 3.2 required.")
+
 if sys.version_info[0] >= 3:
     import builtins
 else:


### PR DESCRIPTION
Because Numpy 1.8.0 will no longer supports Python versions < 2.6 we
no longer need to check for that and can also remove the code that is
specific to those earlier versions.

To make this a bit safer, the toplevel setup.py file now contains a
check of the Python version number and raises an error when run by an
unsupported version.
