### PR TITLE
ENH: Avoiding NPY_BEGIN_THREADS for small arrays can speed-up trivial_three_operand_loop by 5%

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -921,6 +921,8 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_BEGIN_THREADS_DEF PyThreadState *_save=NULL;
 #define NPY_BEGIN_THREADS do {_save = PyEval_SaveThread();} while (0);
 #define NPY_END_THREADS   do {if (_save) PyEval_RestoreThread(_save);} while (0);
+#define NPY_BEGIN_THREADS_THRESHOLDED(loop_size) do { if (loop_size > 500) \
+                { _save = PyEval_SaveThread();} } while (0);
 
 #define NPY_BEGIN_THREADS_DESCR(dtype) \
         do {if (!(PyDataType_FLAGCHK(dtype, NPY_NEEDS_PYAPI))) \

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1098,7 +1098,7 @@ trivial_two_operand_loop(PyArrayObject **op,
     NPY_UF_DBG_PRINT1("two operand loop count %d\n", (int)count[0]);
 
     if (!needs_api) {
-        NPY_BEGIN_THREADS;
+        NPY_BEGIN_THREADS_THRESHOLDED(count[0]);
     }
 
     innerloop(data, count, stride, innerloopdata);
@@ -1131,7 +1131,7 @@ trivial_three_operand_loop(PyArrayObject **op,
     NPY_UF_DBG_PRINT1("three operand loop count %d\n", (int)count[0]);
 
     if (!needs_api) {
-        NPY_BEGIN_THREADS;
+        NPY_BEGIN_THREADS_THRESHOLDED(count[0]);
     }
 
     innerloop(data, count, stride, innerloopdata);


### PR DESCRIPTION
In <code>trivial_three_operand_loop</code> from <b>ufunc_object.c</b>, avoiding NPY_BEGIN_THREADS for small arrays, can speed-up function by <b>5%</b>.

As releases of GIL, then quickly restoring just after small operation doesn't provide much benefit.
## Before

<pre>
In [2]: x = np.asarray(5.0)
In [3]: timeit x+x
1000000 loops, best of 3: 1.99 us per loop
</pre>

## After

<pre>
In [3]: timeit x+x
1000000 loops, best of 3: 1.71 us per loop
</pre>
