### PR TITLE
BUG: Fix PyType_FastSubclass() check for numpy.int_ and Py3k inheritance

### DIFF
--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -61,14 +61,14 @@ are also provided. The C-like names are associated with character codes,
 which are shown in the table. Use of the character codes, however,
 is discouraged.
 
-Five of the scalar types are essentially equivalent to fundamental
+Some of the scalar types are essentially equivalent to fundamental
 Python types and therefore inherit from them as well as from the
 generic array scalar type:
 
 ====================  ====================
 Array scalar type     Related Python type
 ====================  ====================
-:class:`int_`         :class:`IntType`
+:class:`int_`         :class:`IntType` (Python 2 only)
 :class:`float_`       :class:`FloatType`
 :class:`complex_`     :class:`ComplexType`
 :class:`str_`         :class:`StringType`
@@ -88,6 +88,11 @@ Python Boolean scalar.
    than Python's default implementation of :class:`bool` as a
    sub-class of int.
 
+.. warning::
+
+   The :class:`int_` type does **not** inherit from the
+   :class:`int` built-in under Python 3, because type :class:`int` is no
+   longer a fixed-width integer type.
 
 .. tip:: The default data type in Numpy is :class:`float_`.
 

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -557,6 +557,30 @@ fail:
 
     return NULL;
 }
+
+#if !defined(NPY_PY3K)
+static PyObject *
+int_subclass(PyObject *dummy, PyObject *args)
+{
+
+  PyObject *result = NULL;
+  PyObject *scalar_object = NULL;
+
+  if (!PyArg_UnpackTuple(args, "test_int_subclass", 1, 1, &scalar_object))
+    return NULL;
+
+  if (PyInt_Check(scalar_object))
+    result = Py_True;
+  else
+    result = Py_False;
+
+  Py_INCREF(result);
+
+  return result;
+
+}
+#endif
+
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"test_neighborhood_iterator",
         test_neighborhood_iterator,
@@ -573,6 +597,11 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"test_inplace_increment",
         inplace_increment,
         METH_VARARGS, NULL},
+#if !defined(NPY_PY3K)
+    {"test_int_subclass",
+        int_subclass,
+        METH_VARARGS, NULL},
+#endif
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -95,6 +95,22 @@ class TestAttributes(TestCase):
         assert_equal(self.one.dtype.str[1], 'i')
         assert_equal(self.three.dtype.str[1], 'f')
 
+    def test_int_subclassing(self):
+        # Regression test for https://github.com/numpy/numpy/pull/3526
+
+        numpy_int = np.int_(0)
+
+        if sys.version_info[0] >= 3:
+            # On Py3k int_ should not inherit from int, because it's not fixed-width anymore
+            assert_equal(isinstance(numpy_int, int), False)
+        else:
+            # Otherwise, it should inherit from int...
+            assert_equal(isinstance(numpy_int, int), True)
+
+            # ... and fast-path checks on C-API level should also work
+            from numpy.core.multiarray_tests import test_int_subclass
+            assert_equal(test_int_subclass(numpy_int), True)
+
     def test_stridesattr(self):
         x = self.one
         def make_array(size, offset, strides):


### PR DESCRIPTION
Quote from the documentation at http://docs.scipy.org/doc/numpy/reference/arrays.scalars.html :

> Five of the scalar types are essentially equivalent to fundamental Python types and therefore inherit from them as well as from the generic array scalar type <...>

However, presently, the code deviates from this document in two ways:

1) For `numpy.int_` type, the correct `tp_flags` are not set, which means that if one uses specialized fast-path Python C-API macro `PyInt_Check` on its instances to check whether the object is a subclass of a Python builtin, the result will be different (`False`) as compared to `PyObject_TypeCheck` (`True`).

This results in a different behavior of seemingly the same logic run through the Python interpreter using its MRO facilities and hand-written or generated modules, using optimized C-API calls directly.

2) If one is using Py3k, then the code is expanded only to contain `SINGLE_INHERIT` macros, which means that `numpy.int_` is not a subclass of `int` under Py3k at all.

My patch fixes these two issues by (a) introducing new macro `DUAL_INHERIT_INT`, which expands to `DUAL_INHERIT(XXX, Long, XXX)` under Py3k and `DUAL_INHERIT(XXX, Int, XXX)` otherwise and (b) setting `tp_flags` correctly from within this macro.

In order to test my changes, you will need the following minimal Cython program that generates code using optimized C-API calls:

``` python
def inspect(x):
    print("My MRO: {0}".format(type.mro(type(x))))
    if isinstance(x, int):
        print("I'm an normal integer number")
    elif isinstance(x, long):
        print("I'm an < Py3k long integer number")
    elif isinstance(x, float):
        print("I'm a floating point number")
    else:
        print("I don't know who I am")
```

Test output on the x86_64 machine:
##### Python 2.7, without patch

```
In [1]: import bt

In [2]: import numpy as np

In [3]: type.mro(type(np.int_(0)))
Out[3]: [numpy.int64, numpy.signedinteger, numpy.integer, numpy.number, numpy.generic, int, object]

In [4]: type.mro(type(np.int32(0)))
Out[4]: [numpy.int32, numpy.signedinteger, numpy.integer, numpy.number, numpy.generic, object]

In [5]: type.mro(type(np.int64(0)))
Out[5]: [numpy.int64, numpy.signedinteger, numpy.integer, numpy.number, numpy.generic, int, object]

In [6]: bt.inspect(np.int_(0))
My MRO: [<type 'numpy.int64'>, <type 'numpy.signedinteger'>, <type 'numpy.integer'>, <type 'numpy.number'>, <type 'numpy.generic'>, <type 'int'>, <type 'object'>]
I don't know who I am <--- WRONG!

In [7]: bt.inspect(np.int32(0))
My MRO: [<type 'numpy.int32'>, <type 'numpy.signedinteger'>, <type 'numpy.integer'>, <type 'numpy.number'>, <type 'numpy.generic'>, <type 'object'>]
I don't know who I am

In [8]: bt.inspect(np.int64(0))
My MRO: [<type 'numpy.int64'>, <type 'numpy.signedinteger'>, <type 'numpy.integer'>, <type 'numpy.number'>, <type 'numpy.generic'>, <type 'int'>, <type 'object'>]
I don't know who I am <--- WRONG!
```
##### Python 2.7, with patch

```
In [1]: import bt

In [2]: import numpy as np

In [3]: type.mro(type(np.int_(0)))
Out[3]: [numpy.int64, numpy.signedinteger, numpy.integer, numpy.number, numpy.generic, int, object]

In [4]: type.mro(type(np.int32(0)))
Out[4]: [numpy.int32, numpy.signedinteger, numpy.integer, numpy.number, numpy.generic, object]

In [5]: type.mro(type(np.int64(0)))
Out[5]: [numpy.int64, numpy.signedinteger, numpy.integer, numpy.number, numpy.generic, int, object]

In [6]: bt.inspect(np.int_(0))
My MRO: [<type 'numpy.int64'>, <type 'numpy.signedinteger'>, <type 'numpy.integer'>, <type 'numpy.number'>, <type 'numpy.generic'>, <type 'int'>, <type 'object'>]
I'm an normal integer number
^^^^ FIXED!
In [7]: bt.inspect(np.int32(0))
My MRO: [<type 'numpy.int32'>, <type 'numpy.signedinteger'>, <type 'numpy.integer'>, <type 'numpy.number'>, <type 'numpy.generic'>, <type 'object'>]
I don't know who I am

In [8]: bt.inspect(np.int64(0))
My MRO: [<type 'numpy.int64'>, <type 'numpy.signedinteger'>, <type 'numpy.integer'>, <type 'numpy.number'>, <type 'numpy.generic'>, <type 'int'>, <type 'object'>]
I'm an normal integer number
^^^^ FIXED!
```

Thank you for considering my bugfix for inclusion in NumPy,

--Yury.
