### PR TITLE
ENH: Added code generator logic for innerloop lookup in  generate_umath.py

### DIFF
--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -189,7 +189,6 @@ typedef struct _tagPyUFuncObject {
         int *core_offsets;
         /* signature string for printing purpose */
         char *core_signature;
-
         /*
          * A function which resolves the types and fills an array
          * with the dtypes for the inputs and outputs.
@@ -208,6 +207,12 @@ typedef struct _tagPyUFuncObject {
          * if NULL the legacy_inner_loop_selector is used instead.
          */
         PyUFunc_InnerLoopSelectionFunc *inner_loop_selector;
+        /*
+         * A function which returns index for innerloop and innerloopdata.
+         * It takes argument type_num, based on pre-generated condition find
+         * index
+         */
+        int (*sig_index)(int , int);
         /*
          * A function which returns a masked inner loop for the ufunc.
          */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4292,6 +4292,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     ufunc->ptr = NULL;
     ufunc->obj = NULL;
     ufunc->userloops=NULL;
+    ufunc->sig_index=NULL;
 
     /* Type resolution and inner loop selection functions */
     ufunc->type_resolver = &PyUFunc_DefaultTypeResolver;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1260,6 +1260,16 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
         }
     }
 
+    /* sig_index, return index based on precoded condition and case */
+    if(ufunc->sig_index != NULL){
+        i = ufunc->sig_index(dtypes[0]->type_num, dtypes[1]->type_num);
+        if ( i >=0 ) {
+            *out_innerloop = ufunc->functions[i];
+            *out_innerloopdata = ufunc->data[i];
+            return 0;
+        }
+    }
+
     types = ufunc->types;
     for (i = 0; i < ufunc->ntypes; ++i) {
         /* Copy the types into an int array for matching */


### PR DESCRIPTION
## Implementation
- Reduced signature array into distinct types, now <b>32</b> <br/>
  E.g These sets (add, subtracts) , (arccos, arcsin, arctan, arcsinh, arccosh) share same signature array
-  For each distinct signature array, auto-gen lookup function having if-else condition which check and return index <br/>
  E.g
  <pre>
  static int input1_id7_index(int x, int y){
  if ( x == NPY_HALF ) { return x+(-23); }
  if ( x >= NPY_FLOAT && x <= NPY_LONGDOUBLE ) { return x+(-10); }
  if ( x == NPY_OBJECT ) { return x+(-13); }
  return -1;
  }
  </pre>
- Most of binary operations have input of same type, so check for homogeneous inputs first then rests like date, time etc 
- Encapsulates logic, with <code>((PyUFuncObject *)f)->sig_index(arg1, args2)</code>
## Improvement

<code>PyUFunc_DefaultLegacyInnerLoopSelector</code> now stay below 1%. This save <b>3-4%</b> of time used to be consumed to find proper index by searching to nargs*types array
