### PR TITLE
GBB: New version of select which is several times faster, bugfixes, more input validation, better internal documentation.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -790,6 +790,8 @@ def select(condlist, choicelist, default=0):
     for i in range(0,len(condlist)):
         if type(condlist[i]) is np.ndarray:
             cond_sizes[condlist[i].shape]=True 
+        else:
+            cond_sizes['scalar bool']=True
 
     for i in range(0,len(choicelist)):
         if type(choicelist[i]) is np.ndarray:
@@ -805,7 +807,7 @@ def select(condlist, choicelist, default=0):
     # If there is more than one size of array in condlist, we should broadcast them now.
     # (I am not sure if this is useful/meaningful, I will leave it to the user to find a use case). 
     if len(cond_sizes.keys())>1:
-        condlist=broadcast_arrays(*condlist)
+        condlist=np.broadcast_arrays(*condlist)
 
     # Reverse the lists to put lowest priority (end of condlist) conditions at the beginning.
     # This is so the low priority values are overwritten during successive stages of burning

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -733,7 +733,7 @@ def select(condlist, choicelist, default=0):
         The list of conditions which determine from which array in `choicelist`
         the output elements are taken. When multiple conditions are satisfied,
         the first one encountered in `condlist` is used.
-    choicelist : list of ndarrays
+    choicelist : list of ndarrays and/or scalars.
         The list of arrays from which the output elements are taken. It has
         to be of the same length as `condlist`.
     default : scalar, optional
@@ -760,29 +760,88 @@ def select(condlist, choicelist, default=0):
     array([ 0,  1,  2,  0,  0,  0, 36, 49, 64, 81])
 
     """
-    n = len(condlist)
-    n2 = len(choicelist)
-    if n2 != n:
-        raise ValueError(
-                "list of cases must be same length as list of conditions")
-    choicelist = [default] + choicelist
-    S = 0
-    pfac = 1
-    for k in range(1, n+1):
-        S += k * pfac * asarray(condlist[k-1])
-        if k < n:
-            pfac *= (1-asarray(condlist[k-1]))
-    # handle special case of a 1-element condition but
-    #  a multi-element choice
-    if type(S) in ScalarType or max(asarray(S).shape)==1:
-        pfac = asarray(1)
-        for k in range(n2+1):
-            pfac = pfac + asarray(choicelist[k])
-        if type(S) in ScalarType:
-            S = S*ones(asarray(pfac).shape, type(S))
+
+    # Clone the input lists to prevent side effects to the parameter lists:
+    condlist = list(condlist)
+    choicelist = list(choicelist)
+
+    # Check that the inputs are acceptable.
+
+    # Check the size of condlist and choicelist are the same, or abort.
+    if len(condlist) != len(choicelist):
+        raise ValueError('list of cases must be same length as list of conditions')
+
+    # If condlist/choicelist are empty, return the default value immediately.
+    if len(condlist)==0:
+        return np.array([]) 
+
+    # If cond array is not an ndarray in boolean format or scalar bool, abort.
+    for index,item in enumerate(condlist):
+        if type(item) is not np.ndarray:
+            if type(item) is not bool:
+                raise ValueError('invalid entry in choice array: should be boolean ndarray')
         else:
-            S = S*ones(asarray(pfac).shape, S.dtype)
-    return choose(S, tuple(choicelist))
+            if item.dtype != 'bool':
+                raise ValueError('invalid entry in choice array: should be boolean ndarray')
+
+    # Create dictionaries noting the sizes of the items in the lists. 
+    cond_sizes = {} ; choice_sizes = {}    
+
+    for i in range(0,len(condlist)):
+        if type(condlist[i]) is np.ndarray:
+            cond_sizes[condlist[i].shape]=True 
+
+    for i in range(0,len(choicelist)):
+        if type(choicelist[i]) is np.ndarray:
+            choice_sizes[choicelist[i].shape]=True 
+     
+    sizes=cond_sizes.copy() 
+    sizes.update(choice_sizes)
+
+    # Test for ndarrays with no data.
+    if (0,) in sizes.keys():
+        raise ValueError('ndarray containing no items is present')
+
+    # If there is more than one size of array in condlist, we should broadcast them now.
+    # (I am not sure if this is useful/meaningful, I will leave it to the user to find a use case). 
+    if len(cond_sizes.keys())>1:
+        condlist=broadcast_arrays(*condlist)
+
+    # Reverse the lists to put lowest priority (end of condlist) conditions at the beginning.
+    # This is so the low priority values are overwritten during successive stages of burning
+    # values through masks.
+    condlist.reverse()
+    choicelist.reverse()
+
+    # Super-fast execution path if there are only scalar values in the choice list (common use case)
+    # Generate array; iteratively burn values onto result using simple boolean indexing; return. 
+
+    if len(choice_sizes.keys())==0:
+        result=np.ones_like(condlist[0])*default      
+        for i in range(0,len(condlist)):    
+            result[condlist[i]]=choicelist[i]
+        return result
+
+    # otherwise, we have to broadcast    
+    # for numpy 1.7, you have to broadcast the indexes by hand. 
+    # numpy 1.6 did it automatically, I think?
+
+    to_broadcast = condlist + choicelist      # make into a single big list
+    bc=np.broadcast_arrays(*to_broadcast)     # unpack values from big list and broadcast them
+    condlist=bc[:len(bc)/2]                   # split the bc'd big list back into 2 parts again
+    choicelist=bc[len(bc)/2:]                 # down the middle
+   
+    # Setup an array filled with default values
+    result=np.ones_like(condlist[0])*default      
+
+    # Use numpy boolean addressing to burn each choicelist array onto result, 
+    # using the corresponding condlist as a boolean mask 
+    # Doing it this way is several times faster than e.g. numpy.where.
+    for i in range(0,len(condlist)):
+         result[condlist[i]]=(choicelist[i])[condlist[i]]
+
+    return result
+
 
 def copy(a, order='K'):
     """

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -776,21 +776,17 @@ def select(condlist, choicelist, default=0):
         return np.array([]) 
 
     # If cond array is not an ndarray in boolean format or scalar bool, abort.
-    deprecated_ints=False
+    deprecated_ints=False    
     for i in range(0,len(condlist)):
-        item=condlist[i]
-        if type(item) is not np.ndarray:
-            if type(item) is not bool:
+        item=np.asarray(condlist[i])
+        if item.dtype != np.bool_:
+            if np.issubdtype(item.dtype, np.int_):
+                # A previous implementation accepted int ndarrays accidentally.
+                # Supported here deliberately, but deprecated and to be removed.
+                condlist[i]=condlist[i].astype(bool)
+                deprecated_ints=True
+            else:
                 raise ValueError('invalid entry in choice array: should be boolean ndarray')
-        else:
-            if item.dtype != 'bool':
-                if np.issubdtype(item.dtype, int):
-                    # A previous implementation accepted int ndarrays accidentally.
-                    # Supported here deliberately, but deprecated and to be removed.
-                    condlist[i]=condlist[i].astype(bool)                    
-                    deprecated_ints=True
-                else:
-                    raise ValueError('invalid entry in choice array: should be boolean ndarray')
 
     if deprecated_ints:
         msg="select() condlists containing integer ndarrays are deprecated and will be removed " \

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -53,12 +53,15 @@ def broadcast_arrays(*args):
     --------
     >>> x = np.array([[1,2,3]])
     >>> y = np.array([[1],[2],[3]])
-    >>> np.broadcast_arrays(x, y)
-    [array([[1, 2, 3],
+    >>> (broadcasted_x, broadcasted_y) = np.broadcast_arrays(x, y)
+    >>> broadcasted_x
+    array([[1, 2, 3],
            [1, 2, 3],
-           [1, 2, 3]]), array([[1, 1, 1],
+           [1, 2, 3]])
+    >>> broadcasted_y
+    array([[1, 1, 1],
            [2, 2, 2],
-           [3, 3, 3]])]
+           [3, 3, 3]])
 
     Here is a useful idiom for getting contiguous copies instead of
     non-contiguous views.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -155,17 +155,42 @@ class TestSelect(TestCase):
         return output
 
     def test_basic(self):
+
         choices = [np.array([1, 2, 3]),
                    np.array([4, 5, 6]),
                    np.array([7, 8, 9])]
-        conditions = [np.array([0, 0, 0]),
-                      np.array([0, 1, 0]),
-                      np.array([0, 0, 1])]
-        assert_array_equal(select(conditions, choices, default=15),
-                           self._select(conditions, choices, default=15))
+
+        int_conditions = [np.array([0, 0, 0]),
+                          np.array([0, 1, 0]),
+                          np.array([0, 0, 1])]
+ 
+        bool_conditions = [item.astype(bool) for item in int_conditions] 
+
+        # Test normal use case
 
         assert_equal(len(choices), 3)
-        assert_equal(len(conditions), 3)
+        assert_equal(len(int_conditions), 3)
+   
+        assert_array_equal(select(bool_conditions, choices, default=15),
+                           self._select(bool_conditions, choices, default=15))
+
+        # Confirm DeprecationWarning raised when int ndarray is used. 
+
+        warnings.simplefilter('always', DeprecationWarning)
+        try:
+            assert_warns(DeprecationWarning, select, int_conditions, choices, default=15)
+        finally:
+             warnings.filters.pop(0)
+
+        # Check deprecated int ndarray workaround works.
+
+        warnings.simplefilter('ignore', DeprecationWarning)
+        try:
+            assert_array_equal(select(int_conditions, choices, default=15),
+                               self._select(int_conditions, choices, default=15))
+        finally:
+            warnings.filters.pop(0)
+
 
 
 class TestInsert(TestCase):


### PR DESCRIPTION
GBB: New version of select which is several times faster, bugfixes, more input validation, better internal documentation.

Supports broadcasting, and has a special fast execution path for scalar condlists.
Testing + benchmarks: see https://github.com/gbb/numpy-simple-select/blob/master/README.md

I've run runtests.py as well as my own test harness before submitting. I'm pretty confident this is a drop-in improvement. Please can you merge and test?

(Hi everyone! My first commit to numpy, as proposed by njs. Please let me know if there is anything else I should be doing at this stage). 
1. I've also made a change to the broadcast_arrays() documentation. I think it is easier for a beginner to understand what the function is doing, this way. Personally, I was very confused by the format of the output in the original example.
