### PR TITLE
BUG: make preprocessor tests consistent in halffloat.c

### DIFF
--- a/numpy/core/src/npymath/halffloat.c
+++ b/numpy/core/src/npymath/halffloat.c
@@ -137,7 +137,7 @@ npy_half npy_half_nextafter(npy_half x, npy_half y)
             ret = x+1;
         }
     }
-#ifdef NPY_HALF_GENERATE_OVERFLOW
+#if NPY_HALF_GENERATE_OVERFLOW
     if (npy_half_isinf(ret)) {
         npy_set_floatstatus_overflow();
     }


### PR DESCRIPTION
halfloat.c uses preprocessor tests to conditionally raise floating point exceptions. This fixes an inconsistent usage of #ifdef instead of #if in these tests.
