### PR TITLE
ENH: Ignore submodule content in git status.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "doc/scipy-sphinx-theme"]
-	path = doc/scipy-sphinx-theme
-	url = https://github.com/scipy/scipy-sphinx-theme.git
+    path = doc/scipy-sphinx-theme
+    url = https://github.com/scipy/scipy-sphinx-theme.git
+    ignore = dirty
 [submodule "doc/sphinxext"]
-	path = doc/sphinxext
-	url = https://github.com/numpy/numpydoc.git
+    path = doc/sphinxext
+    url = https://github.com/numpy/numpydoc.git
+    ignore = dirty


### PR DESCRIPTION
Currently git status will show the submodules as containing untracked
content. This cannot be fixed in .gitignore, but rather needs to be
marked in .gitmodules.
