### PR TITLE
ENH: Avoiding conversion of integer to NumPy Scalar.

### DIFF
--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -783,13 +783,19 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 
 #if PY_VERSION_HEX < 0x03000000
     if (PyInt_CheckExact(a)) {
-        *arg1 = PyInt_AS_LONG(a);
-        return 0;
+        *arg1 = PyInt_AsLong(a);
+        if (*arg1 == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
     }
 #endif
 
     if(PyLong_CheckExact(a)) {
-        if ((*arg1 = PyLong_AsUnsignedLong(a)) == -1 && PyErr_Occurred()) {
+        *arg1 = PyLong_AsUnsignedLong(a);
+        if (*arg1 == -1 && PyErr_Occurred()) {
             return -1;
         }
         else {
@@ -847,13 +853,19 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 
 #if PY_VERSION_HEX < 0x03000000
     if (PyInt_CheckExact(a)) {
-        *arg1 = PyInt_AS_LONG(a);
-        return 0;
+        *arg1 = PyInt_AsLong(a);
+        if (*arg1 == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
     }
 #endif
 
     if(PyLong_CheckExact(a)) {
-        if ((*arg1 = PyLong_AsLong(a)) == -1 && PyErr_Occurred()) {
+        *arg1 = PyLong_AsLong(a);
+        if (*arg1 == -1 && PyErr_Occurred()) {
             return -1;
         }
         else {
@@ -909,16 +921,21 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 {
     PyObject *temp;
 
-
 #if PY_VERSION_HEX < 0x03000000
     if (PyInt_CheckExact(a)) {
-        *arg1 = PyInt_AS_LONG(a);
-        return 0;
+        *arg1 = PyInt_AsLong(a);
+        if (*arg1 == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
     }
 #endif
 
     if (PyLong_CheckExact(a)) {
-        if ((*arg1 = @PYEXTRACTCTYPE@(a)) == -1 && PyErr_Occurred()) {
+        *arg1 = @PYEXTRACTCTYPE@(a);
+        if (*arg1 == (@type@)-1 && PyErr_Occurred()) {
             return -1;
         }
         else {

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -795,7 +795,7 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 
     if(PyLong_CheckExact(a)) {
         *arg1 = PyLong_AsUnsignedLong(a);
-        if (*arg1 == -1 && PyErr_Occurred()) {
+        if (*arg1 == (unsigned long)-1 && PyErr_Occurred()) {
             return -1;
         }
         else {

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -661,21 +661,13 @@ static void
  */
 
 /**begin repeat
- * #name = byte, ubyte, short, ushort, int, uint,
- *         long, ulong, longlong, ulonglong,
- *         half, float, longdouble,
+ * #name = longlong, ulonglong, half, float, longdouble,
  *         cfloat, cdouble, clongdouble#
- * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_half, npy_float, npy_longdouble,
+ * #type = npy_longlong, npy_ulonglong, npy_half, npy_float, npy_longdouble,
  *         npy_cfloat, npy_cdouble, npy_clongdouble#
- * #Name = Byte, UByte, Short, UShort, Int, UInt,
- *         Long, ULong, LongLong, ULongLong,
- *         Half, Float, LongDouble,
+ * #Name = LongLong, ULongLong, Half, Float, LongDouble,
  *         CFloat, CDouble, CLongDouble#
- * #TYPE = NPY_BYTE, NPY_UBYTE, NPY_SHORT, NPY_USHORT, NPY_INT, NPY_UINT,
- *         NPY_LONG, NPY_ULONG, NPY_LONGLONG, NPY_ULONGLONG,
- *         NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
+ * #TYPE = NPY_LONGLONG, NPY_ULONGLONG, NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
  *         NPY_CFLOAT, NPY_CDOUBLE, NPY_CLONGDOUBLE#
  */
 
@@ -718,7 +710,6 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 }
 
 /**end repeat**/
-
 
 /* Same as above but added exact checks against known python types for speed */
 
@@ -776,6 +767,125 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 
 /**end repeat**/
 
+
+/**begin repeat
+ * #name = ubyte, ushort, uint, ulong#
+ * #type = npy_ubyte, npy_ushort, npy_uint, npy_ulong#
+ * #Name = UByte, UShort, UInt, ULong#
+ * #TYPE = NPY_UBYTE, NPY_USHORT, NPY_UINT, NPY_ULONG#
+ */
+
+static int
+_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
+{
+    PyObject *temp;
+
+#if PY_VERSION_HEX >= 0x03000000
+    if(PyLong_CheckExact(a)){
+        *arg1 = PyLong_AsUnsignedLong(a);
+        return 0;        
+    }
+#else
+    if (PyInt_CheckExact(a)){
+        *arg1 = PyInt_AS_LONG(a);
+        return 0;
+    }
+#endif
+
+    if (PyArray_IsScalar(a, @Name@)) {
+        *arg1 = PyArrayScalar_VAL(a, @Name@);
+        return 0;
+    }
+    else if (PyArray_IsScalar(a, Generic)) {
+        PyArray_Descr *descr1;
+
+        if (!PyArray_IsScalar(a, Number)) {
+            return -1;
+        }
+        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
+        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
+            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
+            Py_DECREF(descr1);
+            return 0;
+        }
+        else {
+            Py_DECREF(descr1);
+            return -1;
+        }
+    }
+    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
+        return -2;
+    }
+    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
+        int retval = _@name@_convert_to_ctype(temp, arg1);
+
+        Py_DECREF(temp);
+        return retval;
+    }
+    return -2;
+}
+
+/**end repeat**/
+
+
+/**begin repeat
+ * #name = byte, short, int, long#
+ * #type = npy_byte, npy_short, npy_int, npy_long#
+ * #Name = Byte, Short, Int, Long#
+ * #TYPE = NPY_BYTE, NPY_SHORT, NPY_INT, NPY_LONG#
+ */
+
+static int
+_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
+{
+    PyObject *temp;
+
+#if PY_VERSION_HEX >= 0x03000000
+    if(PyLong_CheckExact(a)){
+        *arg1 = PyLong_AsLong(a);
+        return 0;        
+    }
+#else
+    if (PyInt_CheckExact(a)){
+        *arg1 = PyInt_AS_LONG(a);
+        return 0;
+    }
+#endif
+
+    if (PyArray_IsScalar(a, @Name@)) {
+        *arg1 = PyArrayScalar_VAL(a, @Name@);
+        return 0;
+    }
+    else if (PyArray_IsScalar(a, Generic)) {
+        PyArray_Descr *descr1;
+
+        if (!PyArray_IsScalar(a, Number)) {
+            return -1;
+        }
+        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
+        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
+            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
+            Py_DECREF(descr1);
+            return 0;
+        }
+        else {
+            Py_DECREF(descr1);
+            return -1;
+        }
+    }
+    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
+        return -2;
+    }
+    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
+        int retval = _@name@_convert_to_ctype(temp, arg1);
+
+        Py_DECREF(temp);
+        return retval;
+    }
+    return -2;
+}
+
+/**end repeat**/
 
 /**begin repeat
  * #name = byte, ubyte, short, ushort, int, uint,

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -781,17 +781,21 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 {
     PyObject *temp;
 
-#if PY_VERSION_HEX >= 0x03000000
-    if(PyLong_CheckExact(a)){
-        *arg1 = PyLong_AsUnsignedLong(a);
-        return 0;        
-    }
-#else
-    if (PyInt_CheckExact(a)){
+#if PY_VERSION_HEX < 0x03000000
+    if (PyInt_CheckExact(a)) {
         *arg1 = PyInt_AS_LONG(a);
         return 0;
     }
 #endif
+
+    if(PyLong_CheckExact(a)) {
+        if ((*arg1 = PyLong_AsUnsignedLong(a)) == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
+    }
 
     if (PyArray_IsScalar(a, @Name@)) {
         *arg1 = PyArrayScalar_VAL(a, @Name@);
@@ -841,17 +845,21 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 {
     PyObject *temp;
 
-#if PY_VERSION_HEX >= 0x03000000
-    if(PyLong_CheckExact(a)){
-        *arg1 = PyLong_AsLong(a);
-        return 0;        
-    }
-#else
-    if (PyInt_CheckExact(a)){
+#if PY_VERSION_HEX < 0x03000000
+    if (PyInt_CheckExact(a)) {
         *arg1 = PyInt_AS_LONG(a);
         return 0;
     }
 #endif
+
+    if(PyLong_CheckExact(a)) {
+        if ((*arg1 = PyLong_AsLong(a)) == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
+    }
 
     if (PyArray_IsScalar(a, @Name@)) {
         *arg1 = PyArrayScalar_VAL(a, @Name@);
@@ -901,17 +909,22 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 {
     PyObject *temp;
 
-#if PY_VERSION_HEX >= 0x03000000
-    if(PyLong_CheckExact(a)){
-        *arg1 = @PYEXTRACTCTYPE@(a);
-        return 0;        
-    }
-#else
-    if (PyInt_CheckExact(a)){
+
+#if PY_VERSION_HEX < 0x03000000
+    if (PyInt_CheckExact(a)) {
         *arg1 = PyInt_AS_LONG(a);
         return 0;
     }
 #endif
+
+    if (PyLong_CheckExact(a)) {
+        if ((*arg1 = @PYEXTRACTCTYPE@(a)) == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
+    }
 
     if (PyArray_IsScalar(a, @Name@)) {
         *arg1 = PyArrayScalar_VAL(a, @Name@);

--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -661,13 +661,13 @@ static void
  */
 
 /**begin repeat
- * #name = longlong, ulonglong, half, float, longdouble,
+ * #name = half, float, longdouble,
  *         cfloat, cdouble, clongdouble#
- * #type = npy_longlong, npy_ulonglong, npy_half, npy_float, npy_longdouble,
+ * #type = npy_half, npy_float, npy_longdouble,
  *         npy_cfloat, npy_cdouble, npy_clongdouble#
- * #Name = LongLong, ULongLong, Half, Float, LongDouble,
+ * #Name = Half, Float, LongDouble,
  *         CFloat, CDouble, CLongDouble#
- * #TYPE = NPY_LONGLONG, NPY_ULONGLONG, NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
+ * #TYPE = NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
  *         NPY_CFLOAT, NPY_CDOUBLE, NPY_CLONGDOUBLE#
  */
 
@@ -710,6 +710,7 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 }
 
 /**end repeat**/
+
 
 /* Same as above but added exact checks against known python types for speed */
 
@@ -886,6 +887,67 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
 }
 
 /**end repeat**/
+
+
+/**begin repeat
+ * #name = longlong, ulonglong#
+ * #type = npy_longlong, npy_ulonglong#
+ * #Name = LongLong, ULongLong#
+ * #TYPE = NPY_LONGLONG, NPY_ULONGLONG#
+ */#PYEXTRACTCTYPE = PyLong_AsLongLong, PyLong_AsUnsignedLongLong#
+
+static int
+_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
+{
+    PyObject *temp;
+
+#if PY_VERSION_HEX >= 0x03000000
+    if(PyLong_CheckExact(a)){
+        *arg1 = @PYEXTRACTCTYPE@(a);
+        return 0;        
+    }
+#else
+    if (PyInt_CheckExact(a)){
+        *arg1 = PyInt_AS_LONG(a);
+        return 0;
+    }
+#endif
+
+    if (PyArray_IsScalar(a, @Name@)) {
+        *arg1 = PyArrayScalar_VAL(a, @Name@);
+        return 0;
+    }
+    else if (PyArray_IsScalar(a, Generic)) {
+        PyArray_Descr *descr1;
+
+        if (!PyArray_IsScalar(a, Number)) {
+            return -1;
+        }
+        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
+        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
+            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
+            Py_DECREF(descr1);
+            return 0;
+        }
+        else {
+            Py_DECREF(descr1);
+            return -1;
+        }
+    }
+    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
+        return -2;
+    }
+    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
+        int retval = _@name@_convert_to_ctype(temp, arg1);
+
+        Py_DECREF(temp);
+        return retval;
+    }
+    return -2;
+}
+
+/**end repeat**/
+
 
 /**begin repeat
  * #name = byte, ubyte, short, ushort, int, uint,

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -139,6 +139,34 @@ class TestConversion(TestCase):
         a = np.array(l[:3], dtype=np.uint64)
         assert_equal([int(_m) for _m in a], li[:3])
 
+    def test_int_value_behaviour(self):
+        l = [0, 2**7-1, 2**15-1, 2**31-1, 2**63-1]
+        li = [-1, -2**7, -2**15, -2**31, -2**63]
+        x = 1
+        for T in [np.int8, np.int16, np.int32, np.int64]:
+            a1 = np.array([l[:x]],dtype=T)
+            b1= np.array([li[:x]], dtype=T)
+            assert_equal(-a1-1,b1)
+
+            a2 = np.array([l[x]],dtype=T)
+            b2= np.array([li[x]], dtype=T)            
+            assert_equal(a2,b2-1)
+            x = x+1
+
+
+        l = [0, 2**8-1, 2**16-1, 2**32-1, 2**64-1]
+        li = [1, 2**8,  2**16, 2**32, 2**64]
+        x = 1
+        for T in [np.uint8, np.uint16, np.uint32, np.uint64]:
+            a1 = np.array([l[:x]],dtype=T)
+            b1= np.array([li[:x]], dtype=T)
+            assert_equal(a1+1,b1)
+
+            a2 = np.array([l[x]],dtype=T)
+            b2= np.array([0], dtype=T)            
+            assert_equal(a2+1,b2)
+            x = x+1
+
 
     def test_iinfo_long_values(self):
         for code in 'bBhH':

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -139,34 +139,6 @@ class TestConversion(TestCase):
         a = np.array(l[:3], dtype=np.uint64)
         assert_equal([int(_m) for _m in a], li[:3])
 
-    def test_int_value_behaviour(self):
-        l = [0, 2**7-1, 2**15-1, 2**31-1, 2**63-1]
-        li = [-1, -2**7, -2**15, -2**31, -2**63]
-        x = 1
-        for T in [np.int8, np.int16, np.int32, np.int64]:
-            a1 = np.array([l[:x]],dtype=T)
-            b1= np.array([li[:x]], dtype=T)
-            assert_equal(-a1-1,b1)
-
-            a2 = np.array([l[x]],dtype=T)
-            b2= np.array([li[x]], dtype=T)            
-            assert_equal(a2,b2-1)
-            x = x+1
-
-
-        l = [0, 2**8-1, 2**16-1, 2**32-1, 2**64-1]
-        li = [1, 2**8,  2**16, 2**32, 2**64]
-        x = 1
-        for T in [np.uint8, np.uint16, np.uint32, np.uint64]:
-            a1 = np.array([l[:x]],dtype=T)
-            b1= np.array([li[:x]], dtype=T)
-            assert_equal(a1+1,b1)
-
-            a2 = np.array([l[x]],dtype=T)
-            b2= np.array([0], dtype=T)            
-            assert_equal(a2+1,b2)
-            x = x+1
-
 
     def test_iinfo_long_values(self):
         for code in 'bBhH':


### PR DESCRIPTION
There is a bottleneck in scalar operations, when trying to extract the underlying C value from a Python integer. 
Numpy converts the Python scalar into its matching scalar (e.g. PyLong -> int32) and then it extracts the C value from the NumPy scalar. 

I have avoid conversion for know integer type but extracting its value.

For <i>byte, short, int, long</i>

<pre>
#if PY_VERSION_HEX >= 0x03000000
    if(PyLong_CheckExact(a)){
        *arg1 = PyLong_AsLong(a);
        return 0;        
    }
#else
    if (PyInt_CheckExact(a)){
        *arg1 = PyInt_AS_LONG(a);
        return 0;
    }
#endif
</pre>

## Performance

1.09 Array \* Array
1.09 Array + Array
1.18 np.int \* np.int
1.14 np.int + np.int
1.08 PyInt \* Array
1.07 np.int \* Array
1.10 PyInt + Array
1.09 np.int + Array
1.08 PyInt \* PyInt
1.09 PyInt + PyInt
2.53 PyInt \* np.int
2.69 PyInt + np.int
1.06 np.int  \* np.int
1.13 np.int + np.int
7.29 PyInt < np.int
2.38 np.int *\* 2
1.07 PyInt *\* 2

where

<pre>
Array = np.array([2234,32342])
PyType = 3
NyType = Array[0]
</pre>

Speedup Datasheet is https://docs.google.com/spreadsheet/ccc?key=0AnPqyp8kuQw0dHpITGFYWlVZelhHSl83bzA5U0dlMmc&usp=sharing
## Test case

I have written test cases to ensure the behavior of integer in separate pr #3592  
