### PR TITLE
Backport 3497

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1734,9 +1734,9 @@ class vectorize(object):
         Set of strings or integers representing the positional or keyword
         arguments for which the function will not be vectorized.  These will be
         passed directly to `pyfunc` unmodified.
-        
+
         .. versionadded:: 1.7.0
-    
+
     cache : bool, optional
        If `True`, then cache the first function call that determines the number
        of outputs if `otypes` is not provided.
@@ -1863,7 +1863,7 @@ class vectorize(object):
             the_args = list(args)
             def func(*vargs):
                 for _n, _i in enumerate(inds):
-                    the_args[_i] = vargs[_n] 
+                    the_args[_i] = vargs[_n]
                 kwargs.update(zip(names, vargs[len(inds):]))
                 return self.pyfunc(*the_args, **kwargs)
 
@@ -1924,7 +1924,7 @@ class vectorize(object):
             ufunc = frompyfunc(_func, len(args), nout)
 
         return ufunc, otypes
-        
+
     def _vectorize_call(self, func, args):
         """Vectorized call to `func` over positional `args`."""
         if not args:
@@ -1933,8 +1933,8 @@ class vectorize(object):
             ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
 
             # Convert args to object arrays first
-            inputs = [array(_a, copy=False, subok=True, dtype=object) 
-                      for _a in args]            
+            inputs = [array(_a, copy=False, subok=True, dtype=object)
+                      for _a in args]
 
             outputs = ufunc(*inputs)
 
@@ -3603,7 +3603,7 @@ def insert(arr, obj, values, axis=None):
                     "index (%d) out of range (0<=index<=%d) "\
                     "in dimension %d" % (obj, N, axis))
         values = array(values, copy=False, ndmin=arr.ndim)
-        values = np.rollaxis(values, 0, axis+1)
+        values = np.rollaxis(values, 0, (axis % values.ndim) + 1)
         obj = [obj] * values.shape[axis]
 
     elif isinstance(obj, slice):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -185,6 +185,18 @@ class TestInsert(TestCase):
         assert_equal(insert(a[:,:1], 1, a[:,1], axis=1), a)
         assert_equal(insert(a[:1,:], 1, a[1,:], axis=0), a)
 
+        # negative axis value
+        a = np.arange(24).reshape((2,3,4))
+        assert_equal(insert(a, 1, a[:,:,3], axis=-1),
+                     insert(a, 1, a[:,:,3], axis=2))
+        assert_equal(insert(a, 1, a[:,2,:], axis=-2),
+                     insert(a, 1, a[:,2,:], axis=1))
+
+        # invalid axis value
+        assert_raises(IndexError, insert, a, 1, a[:,2,:], axis=3)
+        assert_raises(IndexError, insert, a, 1, a[:,2,:], axis=-4)
+
+
 class TestAmax(TestCase):
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]


### PR DESCRIPTION
In some cases a negative axis argument to np.insert would result
in wrong behaviour due to np.rollaxis, add modulo operation to
avoid this (an error is still raised due to arr.shape[axis]).
