### PR TITLE
MAINT: runtests: make it work on Fedora

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -189,7 +189,7 @@ def build_project(args):
         sys.exit(1)
 
     from distutils.sysconfig import get_python_lib
-    site_dir = get_python_lib(prefix=dst_dir)
+    site_dir = get_python_lib(prefix=dst_dir, plat_specific=True)
 
     return site_dir
 


### PR DESCRIPTION
`runtests.py` looks into a wrong directory on Fedora linux (and derivatives), which patch Python to install modules into a `lib64` rather than `lib` directory. The flag has no effect on vanilla Python.

Fixes an issue reported on the mailing list: 
http://permalink.gmane.org/gmane.comp.python.numeric.general/54947
