### PR TITLE
Backport gh-3575

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -805,8 +805,7 @@ array_ass_boolean_subscript(PyArrayObject *self,
     }
 
     /* Tweak the strides for 0-dim and broadcasting cases */
-    if (PyArray_NDIM(v) > 0 && PyArray_DIMS(v)[0] > 1) {
-        v_stride = PyArray_STRIDES(v)[0];
+    if (PyArray_NDIM(v) > 0 && PyArray_DIMS(v)[0] != 1) {
         if (size != PyArray_DIMS(v)[0]) {
             PyErr_Format(PyExc_ValueError,
                     "NumPy boolean array indexing assignment "
@@ -815,6 +814,7 @@ array_ass_boolean_subscript(PyArrayObject *self,
                     (int)PyArray_DIMS(v)[0], (int)size);
             return -1;
         }
+        v_stride = PyArray_STRIDES(v)[0];
     }
     else {
         v_stride = 0;

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -21,5 +21,18 @@ def test_boolean_indexing():
     a[b] = 1.
     assert_equal(a, [[1., 1., 1.]])
 
+
+def test_boolean_assignment_value_mismatch():
+    # A boolean assignment should fail when the shape of the values
+    # cannot be broadcasted to the subscription. (see also gh-3458)
+    a = np.arange(4)
+    def f(a, v):
+        a[a > -1] = v
+
+    assert_raises(ValueError, f, a, [])
+    assert_raises(ValueError, f, a, [1, 2, 3])
+    assert_raises(ValueError, f, a[:1], [1, 2, 3])
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This was because of the assumption that broadcasting works
if the dimension is not > 1, but correct is != 1.

Adepted from a patch provided by prossahl, backports gh-3575
