### PR TITLE
Generating error for  #3357

### DIFF
--- a/numpy/core/blasdot/_dotblas.c
+++ b/numpy/core/blasdot/_dotblas.c
@@ -247,8 +247,7 @@ dotblas_matrixproduct(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject* kwa
     }
 
 
-    if((PyObject *)out == op1 || (PyObject *)out == op2)
-    {
+    if ((PyObject *)out == op1 || (PyObject *)out == op2) {
         PyErr_SetString(PyExc_ValueError, "One of the input arrays cannot be assigned to OUT");
         goto fail;
     }

--- a/numpy/core/blasdot/_dotblas.c
+++ b/numpy/core/blasdot/_dotblas.c
@@ -250,7 +250,7 @@ dotblas_matrixproduct(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject* kwa
     if((PyObject *)out == op1 || (PyObject *)out == op2)
     {
         PyErr_SetString(PyExc_ValueError, "One of the input arrays cannot be assigned to OUT");
-        return NULL;
+        goto fail;
     }
     /*
      * "Matrix product" using the BLAS.

--- a/numpy/core/blasdot/_dotblas.c
+++ b/numpy/core/blasdot/_dotblas.c
@@ -246,6 +246,12 @@ dotblas_matrixproduct(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject* kwa
         out = NULL;
     }
 
+
+    if((PyObject *)out == op1 || (PyObject *)out == op2)
+    {
+        PyErr_SetString(PyExc_ValueError, "One of the input arrays cannot be assigned to OUT");
+        return NULL;
+    }
     /*
      * "Matrix product" using the BLAS.
      * Only works for float double and complex types.

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -925,11 +925,8 @@ class TestMethods(TestCase):
         b = np.array([[0, 1], [1, 0]])
         c = np.array([[9, 1], [1, -9]])
 
-        #new test
-        try:
-            np.dot(a,b,out=a)
-        except ValueError:
-            pass
+        #Test to verifiy that np.dot with "out" as one of the input arrays raises ValueError
+        assert_raises(ValueError,np.dot,a,b,out=a)
 
         assert_equal(np.dot(a, b), a.dot(b))
         assert_equal(np.dot(np.dot(a, b), c), a.dot(b).dot(c))

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -926,7 +926,10 @@ class TestMethods(TestCase):
         c = np.array([[9, 1], [1, -9]])
 
         #new test
-        assert_equal(np.dot(a, b), np.dot(a, b, out = a))
+        try:
+            np.dot(a,b,out=a)
+        except ValueError:
+            pass
 
         assert_equal(np.dot(a, b), a.dot(b))
         assert_equal(np.dot(np.dot(a, b), c), a.dot(b).dot(c))

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -925,6 +925,9 @@ class TestMethods(TestCase):
         b = np.array([[0, 1], [1, 0]])
         c = np.array([[9, 1], [1, -9]])
 
+        #new test
+        assert_equal(np.dot(a, b), np.dot(a, b, out = a))
+
         assert_equal(np.dot(a, b), a.dot(b))
         assert_equal(np.dot(np.dot(a, b), c), a.dot(b).dot(c))
 


### PR DESCRIPTION
Generates an error if "out" matches one of the inputs. This should be good to avoid returning wrong results till the bug itself is not fixed ( #3357 ).
