### PR TITLE
    use PyDataMem_NEW_ZERO (calloc) for PyArray_Zeros

### DIFF
--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -15,5 +15,5 @@
 0x00000007 = e396ba3912dcf052eaee1b0b203a7724
 # Version 8 Added interface to MapIterObject
 0x00000008 = 17321775fc884de0b1eda478cd61c74b
-# Version 9 Added interface for partition functions.
-0x00000009 = f99a02b75bd60205d1afe1eed080fd53
+# Version 9 Added interface for partition functions, PyArray_NEW_ZEROED
+0x00000009 = 327bd114df09c2eb7a0bcc6901e2a3ed

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -339,6 +339,7 @@ multiarray_funcs_api = {
     'PyArray_Partition':                    296,
     'PyArray_ArgPartition':                 297,
     'PyArray_SelectkindConverter':          298,
+    'PyDataMem_NEW_ZEROED':                 299,
     # End 1.8 API
 }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3500,6 +3500,26 @@ PyDataMem_NEW(size_t size)
 }
 
 /*NUMPY_API
+ * Allocates zeroed memory for array data.
+ */
+NPY_NO_EXPORT void *
+PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
+{
+    void *result;
+
+    result = calloc(size, elsize);
+    if (_PyDataMem_eventhook != NULL) {
+        PyGILState_STATE gilstate = PyGILState_Ensure();
+        if (_PyDataMem_eventhook != NULL) {
+            (*_PyDataMem_eventhook)(NULL, result, size * elsize,
+                                    _PyDataMem_eventhook_user_data);
+        }
+        PyGILState_Release(gilstate);
+    }
+    return (char *)result;
+}
+
+/*NUMPY_API
  * Free memory for array data.
  */
 NPY_NO_EXPORT void

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -394,6 +394,24 @@ class TestCreation(TestCase):
         arr = np.array([], dtype='V')
         assert_equal(arr.dtype.kind, 'V')
 
+    def test_zeros(self):
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        for dt in types:
+            d = np.zeros((13,), dtype=dt)
+            assert_equal(np.count_nonzero(d), 0)
+            # true for ieee floats
+            assert_equal(d.sum(), 0)
+
+            d = np.zeros((30 * 1024**2,), dtype=dt)
+            assert_equal(np.count_nonzero(d), 0)
+            assert_equal(d.sum(), 0)
+
+    def test_zeros_obj(self):
+        # test initialization from PyLong(0)
+        d = np.zeros((13,), dtype=object)
+        assert_array_equal(d, [0] * 13)
+        assert_equal(np.count_nonzero(d), 0)
+
     def test_non_sequence_sequence(self):
         """Should not segfault.
 


### PR DESCRIPTION
PyDataMem_NEW_ZERO uses calloc which will take advantage of the fact
that most operating systems provide already zero initialized memory
blocks on larger allocations.
Additionally this memory can be sparse (= mapped to a single zero page)
on some systems (e.g. linux) reducing memory usage of applications
using sparse arrays.
