### PR TITLE
MAINT: move npy_is_aligned to common.h

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -18,6 +18,24 @@
 #define NPY_GCC_UNROLL_LOOPS
 #endif
 
+/*
+ * give a hint to the compiler which branch is more likely or unlikely
+ * to occur, e.g. rare error cases:
+ *
+ * if (NPY_UNLIKELY(failure == 0))
+ *    return NULL;
+ *
+ * the double !! is to cast the expression (e.g. NULL) to a boolean required by
+ * the intrinsic
+ */
+#ifdef HAVE___BUILTIN_EXPECT
+#define NPY_LIKELY(x) __builtin_expect(!!(x), 1)
+#define NPY_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define NPY_LIKELY(x) (x)
+#define NPY_UNLIKELY(x) (x)
+#endif
+
 #if defined(_MSC_VER)
         #define NPY_INLINE __inline
 #elif defined(__GNUC__)

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -111,6 +111,7 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        ("__builtin_isfinite", '5.'),
                        ("__builtin_bswap32", '5u'),
                        ("__builtin_bswap64", '5u'),
+                       ("__builtin_expect", '5, 0'),
                        ]
 
 # gcc function attributes

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -7,6 +7,7 @@
 
 #include "npy_config.h"
 #include "npy_pycompat.h"
+#include "common.h"
 
 #include "usertypes.h"
 
@@ -674,8 +675,8 @@ _zerofill(PyArrayObject *ret)
 NPY_NO_EXPORT int
 _IsAligned(PyArrayObject *ap)
 {
-    int i, alignment, aligned = 1;
-    npy_intp ptr;
+    unsigned int i, aligned = 1;
+    const unsigned int alignment = PyArray_DESCR(ap)->alignment;
 
     /* The special casing for STRING and VOID types was removed
      * in accordance with http://projects.scipy.org/numpy/ticket/1227
@@ -684,25 +685,24 @@ _IsAligned(PyArrayObject *ap)
      * PyArray_DescrConverter(), but not necessarily when using
      * PyArray_DescrAlignConverter(). */
 
-    alignment = PyArray_DESCR(ap)->alignment;
     if (alignment == 1) {
         return 1;
     }
-    ptr = (npy_intp) PyArray_DATA(ap);
-    aligned = (ptr % alignment) == 0;
+    aligned = npy_is_aligned(PyArray_DATA(ap), alignment);
 
     for (i = 0; i < PyArray_NDIM(ap); i++) {
 #if NPY_RELAXED_STRIDES_CHECKING
         if (PyArray_DIM(ap, i) > 1) {
             /* if shape[i] == 1, the stride is never used */
-            aligned &= ((PyArray_STRIDES(ap)[i] % alignment) == 0);
+            aligned &= npy_is_aligned((void*)PyArray_STRIDES(ap)[i],
+                                      alignment);
         }
         else if (PyArray_DIM(ap, i) == 0) {
             /* an array with zero elements is always aligned */
             return 1;
         }
 #else /* not NPY_RELAXED_STRIDES_CHECKING */
-        aligned &= ((PyArray_STRIDES(ap)[i] % alignment) == 0);
+        aligned &= npy_is_aligned((void*)PyArray_STRIDES(ap)[i], alignment);
 #endif /* not NPY_RELAXED_STRIDES_CHECKING */
     }
     return aligned != 0;

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -1,5 +1,6 @@
 #ifndef _NPY_PRIVATE_COMMON_H_
 #define _NPY_PRIVATE_COMMON_H_
+#include <numpy/npy_common.h>
 
 #define error_converting(x)  (((x) == -1) && PyErr_Occurred())
 
@@ -71,11 +72,16 @@ offset_bounds_from_strides(const int itemsize, const int nd,
 static NPY_INLINE int
 npy_is_aligned(const void * p, const npy_uintp alignment)
 {
-    /* test for the and is still faster than a direct modulo */
-    if ((alignment & (alignment - 1)) == 0)
+    /*
+     * alignment is usually a power of two
+     * the test is faster than a direct modulo
+     */
+    if (NPY_LIKELY((alignment & (alignment - 1)) == 0)) {
         return ((npy_uintp)(p) & ((alignment) - 1)) == 0;
-    else
+    }
+    else {
         return ((npy_uintp)(p) % alignment) == 0;
+    }
 }
 
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -65,6 +65,20 @@ offset_bounds_from_strides(const int itemsize, const int nd,
                            const npy_intp *dims, const npy_intp *strides,
                            npy_intp *lower_offset, npy_intp *upper_offset);
 
+/*
+ * return true if pointer is aligned to 'alignment'
+ */
+static NPY_INLINE int
+npy_is_aligned(const void * p, const npy_uintp alignment)
+{
+    /* test for the and is still faster than a direct modulo */
+    if ((alignment & (alignment - 1)) == 0)
+        return ((npy_uintp)(p) & ((alignment) - 1)) == 0;
+    else
+        return ((npy_uintp)(p) % alignment) == 0;
+}
+
+
 #include "ucsnarrow.h"
 
 #endif

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -1,5 +1,6 @@
 #ifndef __LOWLEVEL_STRIDED_LOOPS_H
 #define __LOWLEVEL_STRIDED_LOOPS_H
+#include "common.h"
 #include <npy_config.h>
 
 /*
@@ -398,26 +399,18 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                             char **out_dataC, npy_intp *out_stridesC);
 
 /*
- * return true if pointer is aligned to 'alignment'
- */
-static NPY_INLINE int
-npy_is_aligned(const void * p, const npy_uintp alignment)
-{
-    return ((npy_uintp)(p) & ((alignment) - 1)) == 0;
-}
-
-/*
  * Return number of elements that must be peeled from
  * the start of 'addr' with 'nvals' elements of size 'esize'
  * in order to reach 'alignment'.
+ * alignment must be a power of two.
  * see npy_blocked_end for an example
  */
-static NPY_INLINE npy_intp
-npy_aligned_block_offset(const void * addr, const npy_intp esize,
-                         const npy_intp alignment, const npy_intp nvals)
+static NPY_INLINE npy_uintp
+npy_aligned_block_offset(const void * addr, const npy_uintp esize,
+                         const npy_uintp alignment, const npy_uintp nvals)
 {
-    const npy_intp offset = (npy_intp)addr & (alignment - 1);
-    npy_intp peel = offset ? (alignment - offset) / esize : 0;
+    const npy_uintp offset = (npy_uintp)addr & (alignment - 1);
+    npy_uintp peel = offset ? (alignment - offset) / esize : 0;
     peel = nvals < peel ? nvals : peel;
     return peel;
 }
@@ -442,9 +435,9 @@ npy_aligned_block_offset(const void * addr, const npy_intp esize,
  * for(; i < n; i++)
  *   <scalar-op>
  */
-static NPY_INLINE npy_intp
-npy_blocked_end(const npy_intp offset, const npy_intp esize,
-                const npy_intp vsz, const npy_intp nvals)
+static NPY_INLINE npy_uintp
+npy_blocked_end(const npy_uintp offset, const npy_uintp esize,
+                const npy_uintp vsz, const npy_uintp nvals)
 {
     return nvals - offset - (nvals - offset) % (vsz / esize);
 }


### PR DESCRIPTION
also make it and some other alignment operators a bit faster by using
unsigned integers and bitwise and if possible.
Make use of npy_is_aligned in _IsAligned too.

Also add NPY_LIKELY and NPY_UNLIKELY macros for branch prediction hints.
