### PR TITLE
BUG: Fix test_operand_flags test.

### DIFF
--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -16,7 +16,8 @@ class TestUfunc(TestCase):
 
     def test_pickle_withstring(self):
         import pickle
-        astring = asbytes("cnumpy.core\n_ufunc_reconstruct\np0\n(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
+        astring = asbytes("cnumpy.core\n_ufunc_reconstruct\np0\n"
+                "(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
         assert pickle.loads(astring) is np.cos
 
     def test_reduceat_shifting_sum(self) :
@@ -802,11 +803,11 @@ class TestUfunc(TestCase):
         assert_raises(TypeError, test_add, a, b)
     
     def test_operand_flags(self):
-        a = np.arange(16, dtype='i8').reshape(4,4)
-        b = np.arange(9, dtype='i8').reshape(3,3)
+        a = np.arange(16, dtype='l').reshape(4,4)
+        b = np.arange(9, dtype='l').reshape(3,3)
         opflag_tests.inplace_add(a[:-1,:-1], b)
         assert_equal(a, np.array([[0,2,4,3],[7,9,11,7],
-            [14,16,18,11],[12,13,14,15]], dtype='i8'))
+            [14,16,18,11],[12,13,14,15]], dtype='l'))
 
         a = np.array(0)
         opflag_tests.inplace_add(a, 3)


### PR DESCRIPTION
The test tests an inner loop in operand_flag_tests.c.src that expects
a long type, but it is tested using 'i8'. This fails when long is not
'i8'.

Closes #3363.
