### PR TITLE
BUG: Fix variable declaration after statement.

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1292,6 +1292,8 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
+            int _res;
+
             array_other = (PyArrayObject *)PyArray_FromAny(other, NULL, 0, 0, 0,
                                                            NULL);
             /*
@@ -1303,8 +1305,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 Py_INCREF(Py_NotImplemented);
                 return Py_NotImplemented;
             }
-
-            int _res;
 
             _res = PyObject_RichCompareBool
                 ((PyObject *)PyArray_DESCR(self),
@@ -1349,6 +1349,8 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
+            int _res;
+
             array_other = (PyArrayObject *)PyArray_FromAny(other, NULL, 0, 0, 0,
                                                            NULL);
             /*
@@ -1360,8 +1362,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 Py_INCREF(Py_NotImplemented);
                 return Py_NotImplemented;
             }
-
-            int _res;
 
             _res = PyObject_RichCompareBool(
                     (PyObject *)PyArray_DESCR(self),

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -589,32 +589,38 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
              */
             static const npy_bool zero[4096]; /* zero by C standard */
             npy_uintp i, n = dimensions[0];
+
             for (i = 0; !*op && i < n - (n % sizeof(zero)); i += sizeof(zero)) {
                 *op = memcmp(&args[1][i], zero, sizeof(zero)) != 0;
             }
-            if (!*op && n - i > 0)
+            if (!*op && n - i > 0) {
                 *op = memcmp(&args[1][i], zero, n - i) != 0;
+            }
 #endif
             return;
         }
 #endif
-        BINARY_REDUCE_LOOP(npy_bool) {
-            const npy_bool in2 = *(npy_bool *)ip2;
-            io1 = io1 @OP@ in2;
-            if (io1 @SC@ 0) {
-                break;
+        else {
+            BINARY_REDUCE_LOOP(npy_bool) {
+                const npy_bool in2 = *(npy_bool *)ip2;
+                io1 = io1 @OP@ in2;
+                if (io1 @SC@ 0) {
+                    break;
+                }
             }
+            *((npy_bool *)iop1) = io1;
         }
-        *((npy_bool *)iop1) = io1;
     }
     else {
         if (run_binary_simd_@kind@_BOOL(args, dimensions, steps)) {
             return;
         }
-        BINARY_LOOP {
-            const npy_bool in1 = *(npy_bool *)ip1;
-            const npy_bool in2 = *(npy_bool *)ip2;
-            *((npy_bool *)op1) = in1 @OP@ in2;
+        else {
+            BINARY_LOOP {
+                const npy_bool in1 = *(npy_bool *)ip1;
+                const npy_bool in2 = *(npy_bool *)ip2;
+                *((npy_bool *)op1) = in1 @OP@ in2;
+            }
         }
     }
 }
@@ -656,9 +662,11 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
     if (run_unary_simd_@kind@_BOOL(args, dimensions, steps)) {
         return;
     }
-    UNARY_LOOP {
-        npy_bool in1 = *(npy_bool *)ip1;
-        *((npy_bool *)op1) = in1 @OP@ 0;
+    else {
+        UNARY_LOOP {
+            npy_bool in1 = *(npy_bool *)ip1;
+            *((npy_bool *)op1) = in1 @OP@ 0;
+        }
     }
 }
 /**end repeat**/
@@ -1329,12 +1337,11 @@ TIMEDELTA_mm_d_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *
 NPY_NO_EXPORT void
 @TYPE@_sqrt(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    if (run_unary_simd_sqrt_@TYPE@(args, dimensions, steps)) {
-        return;
-    }
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        *(@type@ *)op1 = @scalarf@(in1);
+    if (!run_unary_simd_sqrt_@TYPE@(args, dimensions, steps)) {
+        UNARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            *(@type@ *)op1 = @scalarf@(in1);
+        }
     }
 }
 
@@ -1358,16 +1365,13 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    if(IS_BINARY_REDUCE) {
+    if (IS_BINARY_REDUCE) {
         BINARY_REDUCE_LOOP(@type@) {
             io1 @OP@= *(@type@ *)ip2;
         }
         *((@type@ *)iop1) = io1;
     }
-    else {
-        if (run_binary_simd_@kind@_@TYPE@(args, dimensions, steps)) {
-            return;
-        }
+    else if (!run_binary_simd_@kind@_@TYPE@(args, dimensions, steps)) {
         BINARY_LOOP {
             const @type@ in1 = *(@type@ *)ip1;
             const @type@ in2 = *(@type@ *)ip2;
@@ -1385,13 +1389,12 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    if (run_binary_simd_@kind@_@TYPE@(args, dimensions, steps)) {
-        return;
-    }
-    BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ in2 = *(@type@ *)ip2;
-        *((npy_bool *)op1) = in1 @OP@ in2;
+    if (!run_binary_simd_@kind@_@TYPE@(args, dimensions, steps)) {
+        BINARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            const @type@ in2 = *(@type@ *)ip2;
+            *((npy_bool *)op1) = in1 @OP@ in2;
+        }
     }
 }
 /**end repeat1**/
@@ -1467,14 +1470,13 @@ NPY_NO_EXPORT void
 {
     /*  */
     if (IS_BINARY_REDUCE) {
-        if (run_unary_reduce_simd_@kind@_@TYPE@(args, dimensions, steps)) {
-            return;
+        if (!run_unary_reduce_simd_@kind@_@TYPE@(args, dimensions, steps)) {
+            BINARY_REDUCE_LOOP(@type@) {
+                const @type@ in2 = *(@type@ *)ip2;
+                io1 = (io1 @OP@ in2 || npy_isnan(io1)) ? io1 : in2;
+            }
+            *((@type@ *)iop1) = io1;
         }
-        BINARY_REDUCE_LOOP(@type@) {
-            const @type@ in2 = *(@type@ *)ip2;
-            io1 = (io1 @OP@ in2 || npy_isnan(io1)) ? io1 : in2;
-        }
-        *((@type@ *)iop1) = io1;
     }
     else {
         BINARY_LOOP {
@@ -1542,12 +1544,11 @@ NPY_NO_EXPORT void
 {
     char * margs[] = {args[0], args[0], args[1]};
     npy_intp msteps[] = {steps[0], steps[0], steps[1]};
-    if (run_binary_simd_multiply_@TYPE@(margs, dimensions, msteps)) {
-        return;
-    }
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        *((@type@ *)op1) = in1*in1;
+    if (!run_binary_simd_multiply_@TYPE@(margs, dimensions, msteps)) {
+        UNARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            *((@type@ *)op1) = in1*in1;
+        }
     }
 }
 
@@ -1557,12 +1558,11 @@ NPY_NO_EXPORT void
     @type@ one = 1.@c@;
     char * margs[] = {(char*)&one, args[0], args[1]};
     npy_intp msteps[] = {0, steps[0], steps[1]};
-    if (run_binary_simd_divide_@TYPE@(margs, dimensions, msteps)) {
-        return;
-    }
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        *((@type@ *)op1) = 1/in1;
+    if (!run_binary_simd_divide_@TYPE@(margs, dimensions, msteps)) {
+        UNARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            *((@type@ *)op1) = 1/in1;
+        }
     }
 }
 
@@ -1586,14 +1586,13 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_absolute(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    if (run_unary_simd_absolute_@TYPE@(args, dimensions, steps)) {
-        return;
-    }
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ tmp = in1 > 0 ? in1 : -in1;
-        /* add 0 to clear -0.0 */
-        *((@type@ *)op1) = tmp + 0;
+    if (!run_unary_simd_absolute_@TYPE@(args, dimensions, steps)) {
+        UNARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            const @type@ tmp = in1 > 0 ? in1 : -in1;
+            /* add 0 to clear -0.0 */
+            *((@type@ *)op1) = tmp + 0;
+        }
     }
 }
 
@@ -1697,7 +1696,7 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 HALF_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    if(IS_BINARY_REDUCE) {
+    if (IS_BINARY_REDUCE) {
         char *iop1 = args[0];
         float io1 = npy_half_to_float(*(npy_half *)iop1);
         BINARY_REDUCE_LOOP_INNER {

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1306,9 +1306,10 @@ PyMODINIT_FUNC inittest_rational(void) {
     /* Create test ufunc with built in input types and rational output type */
     {
         int types3[3] = {NPY_INT64,NPY_INT64,npy_rational};
+
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
-            PyUFunc_None,(char*)"test_add",
-            (char*)"add two matrices of int64 and return rational matrix",0);
+                PyUFunc_None,(char*)"test_add",
+                (char*)"add two matrices of int64 and return rational matrix",0);
         if (!ufunc) {
             goto fail;
         }
@@ -1322,14 +1323,15 @@ PyMODINIT_FUNC inittest_rational(void) {
     /* Create test ufunc with rational types using RegisterLoopForDescr */
     {
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
-            PyUFunc_None,(char*)"test_add_rationals",
-            (char*)"add two matrices of rationals and return rational matrix",0);
-        if (!ufunc) {
-            goto fail;
-        }
+                PyUFunc_None,(char*)"test_add_rationals",
+                (char*)"add two matrices of rationals and return rational matrix",0);
         PyArray_Descr* types[3] = {&npyrational_descr,
                                     &npyrational_descr,
                                     &npyrational_descr};
+
+        if (!ufunc) {
+            goto fail;
+        }
         if (PyUFunc_RegisterLoopForDescr((PyUFuncObject*)ufunc, &npyrational_descr,
                 rational_ufunc_test_add_rationals, types, 0) < 0) {
             goto fail;


### PR DESCRIPTION
Some declarations that are not at the beginning of a block have slipped
into the code. This breaks compilation on Python3.4a1. The Numpy coding
standard also disallows that construct.

Closes #3598.
