### PR TITLE
DOC: Remove references to diagonal changes in 1.8.

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -23,11 +23,6 @@ Support for SCons has been removed.
 Compatibility notes
 ===================
 
-numpy.diag, np.diagonal, and the diagonal method of ndarrays return a view
-onto the original array, instead of producing a copy.
-
-selecting multiple fields out of an array also produces a view.
-
 The hash function of numpy.void scalars has been changed.  Previously the
 pointer to the data was hashed as an integer.  Now, the hash function uses
 the tuple-hash algorithm to combine the hash functions of the elements of

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1130,10 +1130,10 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     on this fact is deprecated. Writing to the resulting array continues to
     work as it used to, but a FutureWarning will be issued.
 
-    In NumPy 1.8, it will switch to returning a read-only view on the original
+    In NumPy 1.9, it will switch to returning a read-only view on the original
     array. Attempting to write to the resulting array will produce an error.
 
-    In NumPy 1.9, it will still return a view, but this view will no longer be
+    In NumPy 1.10, it will still return a view, but this view will no longer be
     marked read-only. Writing to the returned array will alter your original
     array as well.
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -705,7 +705,7 @@ array_might_be_written(PyArrayObject *obj)
     const char *msg =
         "Numpy has detected that you (may be) writing to an array returned\n"
         "by numpy.diagonal or by selecting multiple fields in a record\n"
-        "array. This code will likely break in the next numpy release --\n"
+        "array. This code will likely break in a future numpy release --\n"
         "see numpy.diagonal or arrays.indexing reference docs for details.\n"
         "The quick fix is to make an explicit copy (e.g., do\n"
         "arr.diagonal().copy() or arr[['f0','f1']].copy()).";


### PR DESCRIPTION
Not happening. Also remove reference to selecting multiple fields out of
an array returning a view from 1.8.0 release notes.

Closes #3228.

This is an alternate to #3604 that removes references to diagonal returning a view in 1.8, whereas #3604 enables the view. One or the other should be applied, but not both.
