### PR TITLE
Bugfix: Regression when filling struct from tuple

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -413,7 +413,14 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
     else {
         PyArrayObject *src_arr;
 
-        src_arr = (PyArrayObject *)PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
+        /**
+         * The dtype of the destination is used when converting
+         * from the pyobject, so that for example a tuple gets
+         * recognized as a struct scalar of the required type.
+         */
+        Py_INCREF(PyArray_DTYPE(arr));
+        src_arr = (PyArrayObject *)PyArray_FromAny(obj,
+                        PyArray_DTYPE(arr), 0, 0, 0, NULL);
         if (src_arr == NULL) {
             return -1;
         }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -164,9 +164,17 @@ class TestAttributes(TestCase):
             y[...] = 1
             assert_equal(x,y)
 
+    def test_fill_struct_array(self):
+        # Filling from a scalar
         x = array([(0,0.0), (1,1.0)], dtype='i4,f8')
         x.fill(x[0])
         assert_equal(x['f1'][1], x['f1'][0])
+        # Filling from a tuple that can be converted
+        # to a scalar
+        x = np.zeros(2, dtype=[('a', 'f8'), ('b', 'i4')])
+        x.fill((3.5, -2))
+        assert_array_equal(x['a'], [3.5, 3.5])
+        assert_array_equal(x['b'], [-2, -2])
 
 class TestAssignment(TestCase):
     def test_assignment_broadcasting(self):


### PR DESCRIPTION
Here's a bugfix for functionality which regressed from 1.6 -> 1.7, calling x.fill() with a tuple. Should have filed this PR sooner, sorry!

```
>>> import numpy as np
>>> np.__version__
'1.6.2'
>>> x = np.zeros(2, dtype=[('a', 'f8'), ('b', 'i4')])
>>> x.fill((3.5, -2))
>>> x
array([(3.5, -2), (3.5, -2)],
      dtype=[('a', '<f8'), ('b', '<i4')])

>>> import numpy as np
>>> np.__version__
'1.7.1'
>>> x = np.zeros(2, dtype=[('a', 'f8'), ('b', 'i4')])
>>> x.fill((3.5, -2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Input object to FillWithScalar is not a scalar
```
