### PR TITLE
Explicitly set encoding to UTF-8 in postprocess.py

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -23,7 +23,7 @@ def main():
         p.error('unknown mode %s' % mode)
 
     for fn in args:
-        f = open(fn, 'r')
+        f = open(fn, 'r', encoding="utf-8")
         try:
             if mode == 'html':
                 lines = process_html(fn, f.readlines())
@@ -32,7 +32,7 @@ def main():
         finally:
             f.close()
 
-        f = open(fn, 'w')
+        f = open(fn, 'w', encoding="utf-8")
         f.write("".join(lines))
         f.close()
 


### PR DESCRIPTION
The default (ascii) encoding breaks:

python3.3 postprocess.py html build/html/*.html
Traceback (most recent call last):
  File "postprocess.py", line 59, in <module>
    main()
  File "postprocess.py", line 27, in main
    lines = process_html(fn, f.readlines())
  File "/usr/lib64/python3.3/encodings/ascii.py", line 26, in

```
return codecs.ascii_decode(input, self.errors)[0]
```

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in
2309: ordinal not in range(128)
