### PR TITLE
BUG: Use io.open instead of open for compatibility.

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -8,7 +8,9 @@ MODE is either 'html' or 'tex'.
 """
 from __future__ import division, absolute_import, print_function
 
-import re, optparse
+import re
+import optparse
+import io
 
 def main():
     p = optparse.OptionParser(__doc__)
@@ -23,7 +25,7 @@ def main():
         p.error('unknown mode %s' % mode)
 
     for fn in args:
-        f = open(fn, 'r', encoding="utf-8")
+        f = io.open(fn, 'r', encoding="utf-8")
         try:
             if mode == 'html':
                 lines = process_html(fn, f.readlines())
@@ -32,7 +34,7 @@ def main():
         finally:
             f.close()
 
-        f = open(fn, 'w', encoding="utf-8")
+        f = io.open(fn, 'w', encoding="utf-8")
         f.write("".join(lines))
         f.close()
 


### PR DESCRIPTION
The recent Python 3 fix adding encoding="utf-8" to the open function
fails on Python 2 because the encoding keyword is not defined. The
solution is to use io.open, which is available for Python 2.6 and 2.7
and is an alias for open when Python >= 3.0. It is reputed to be slow
when running in 2.6, but that should not be a problem.
