### PR TITLE
Fix reference leak

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -99,6 +99,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
             /*
              * After the deprecation the PyNumber_Check could be replaced
              * by PyIndex_Check.
+             * FIXME 1.9 ?
              */
             len = 1;
         }
@@ -922,8 +923,8 @@ PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals)
                 return -1;
             }
 
-
             vals[i] = PyArray_PyIntAsIntp(op);
+            Py_DECREF(op);
             if(vals[i] == -1) {
                 err = PyErr_Occurred();
                 if (err &&

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1546,6 +1546,20 @@ class TestCreationFuncs(TestCase):
         self.check_function(np.full, 0)
         self.check_function(np.full, 1)
 
+    def test_for_reference_leak(self):
+        # Make sure we have an object for reference
+        dim = 1
+        beg = sys.getrefcount(dim)
+        np.zeros([dim]*10)
+        assert_(sys.getrefcount(dim) == beg)
+        np.ones([dim]*10)
+        assert_(sys.getrefcount(dim) == beg)
+        np.empty([dim]*10)
+        assert_(sys.getrefcount(dim) == beg)
+        np.full([dim]*10, 0)
+        assert_(sys.getrefcount(dim) == beg)
+
+
 
 class TestLikeFuncs(TestCase):
     '''Test ones_like, zeros_like, empty_like and full_like'''


### PR DESCRIPTION
Fix reference leak. All of zeros, ones, full, and empty were incrementing the reference count of the items in the dimensions list.

Does not need backport.
