### PR TITLE
DEP: Make nansum return 0 for all-NaN or empty axis.

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -478,18 +478,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=0):
 
     """
     a, mask = _replace_nan(a, 0)
-    # In version 1.9 uncomment the following line and delete the rest.
-    #return a.sum(axis, dtype, out, keepdims)
-    warnings.warn("In Numpy 1.9 the sum along empty slices will be zero.",
-            FutureWarning)
-
-    if mask is None:
-        return a.sum(axis, dtype, out, keepdims)
-    mask = mask.all(axis, keepdims=keepdims)
-    tot = np.add.reduce(a, axis, dtype, out, keepdims)
-    if mask.any():
-        tot = _copyto(tot, np.nan, mask)
-    return tot
+    return a.sum(axis, dtype, out, keepdims)
 
 
 def nanmean(a, axis=None, dtype=None, out=None, keepdims=False):

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -244,36 +244,20 @@ class TestNanFunctions_Sum(TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             res = nansum([np.nan]*3, axis=None)
-            if np.__version__[:3] < '1.9':
-                assert_(np.isnan(res), 'result is not NaN')
-                assert_(len(w) == 1, 'no warning raised')
-                assert_(issubclass(w[0].category, FutureWarning))
-            else:
-                assert_(res == 0, 'result is not 0')
-                assert_(len(w) == 0, 'warning raised')
+            assert_(res == 0, 'result is not 0')
+            assert_(len(w) == 0, 'warning raised')
 
     def test_empty(self):
         mat = np.zeros((0, 3))
-        if np.__version__[:3] < '1.9':
-            tgt = [np.nan]*3
-            res = nansum(mat, axis=0)
-            assert_equal(res, tgt)
-            tgt = []
-            res = nansum(mat, axis=1)
-            assert_equal(res, tgt)
-            tgt = np.nan
-            res = nansum(mat, axis=None)
-            assert_equal(res, tgt)
-        else:
-            tgt = [0]*3
-            res = nansum(mat, axis=0)
-            assert_equal(res, tgt)
-            tgt = []
-            res = nansum(mat, axis=1)
-            assert_equal(res, tgt)
-            tgt = 0
-            res = nansum(mat, axis=None)
-            assert_equal(res, tgt)
+        tgt = [0]*3
+        res = nansum(mat, axis=0)
+        assert_equal(res, tgt)
+        tgt = []
+        res = nansum(mat, axis=1)
+        assert_equal(res, tgt)
+        tgt = 0
+        res = nansum(mat, axis=None)
+        assert_equal(res, tgt)
 
 
 class TestNanFunctions_MeanVarStd(TestCase):


### PR DESCRIPTION
Make this happen and remove test parts dependent on numpy version
< 1.9. Fixes test failures in numpy after 1.8 branch.
