### PR TITLE
ENH: Make the ndarray diagonal method return a view.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3316,7 +3316,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('diagonal',
     """
     a.diagonal(offset=0, axis1=0, axis2=1)
 
-    Return specified diagonals.
+    Return specified diagonals. In NumPy 1.9 the returned array is a
+    read-only view instead of a copy as in previous NumPy versions.  In
+    NumPy 1.10 the read-only restriction will be removed.
 
     Refer to :func:`numpy.diagonal` for full documentation.
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1125,16 +1125,15 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     In versions of NumPy prior to 1.7, this function always returned a new,
     independent array containing a copy of the values in the diagonal.
 
-    In NumPy 1.7, it continues to return a copy of the diagonal, but depending
-    on this fact is deprecated. Writing to the resulting array continues to
-    work as it used to, but a FutureWarning will be issued.
+    In NumPy 1.7 and 1.8, it continues to return a copy of the diagonal,
+    but depending on this fact is deprecated. Writing to the resulting
+    array continues to work as it used to, but a FutureWarning is issued.
 
-    In NumPy 1.9, it will switch to returning a read-only view on the original
-    array. Attempting to write to the resulting array will produce an error.
+    In NumPy 1.9 it returns a read-only view on the original array.
+    Attempting to write to the resulting array will produce an error.
 
-    In NumPy 1.10, it will still return a view, but this view will no longer be
-    marked read-only. Writing to the returned array will alter your original
-    array as well.
+    In NumPy 1.10, it will return a read/write view, Writing to the returned
+    array will alter your original array.
 
     If you don't write to the array returned by this function, then you can
     just ignore all of the above.

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2341,14 +2341,13 @@ PyArray_Diagonal(PyArrayObject *self, int offset, int axis1, int axis2)
         return NULL;
     }
 
-    /* For backwards compatibility, during the deprecation period: */
-    copy = PyArray_NewCopy(ret, NPY_KEEPORDER);
-    Py_DECREF(ret);
-    if (!copy) {
-        return NULL;
-    }
-    PyArray_ENABLEFLAGS((PyArrayObject *)copy, NPY_ARRAY_WARN_ON_WRITE);
-    return copy;
+    /*
+     * For numpy 1.9 the diagonal view is not writeable.
+     * This line needs to be removed in 1.10.
+     */
+    PyArray_CLEARFLAGS(ret, NPY_ARRAY_WRITEABLE);
+
+    return ret;
 }
 
 /*NUMPY_API


### PR DESCRIPTION
Also remove the test_diagonal_deprecation test and add test that
checks that a view is returned and that it is not writeable.

Closes #596.
