### PR TITLE
FIX: call through wrong function pointer type + minor stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,10 +111,16 @@ numpy/core/src/npymath/npy_math_complex.c
 numpy/core/src/npysort/heapsort.c
 numpy/core/src/npysort/mergesort.c
 numpy/core/src/npysort/quicksort.c
+numpy/core/src/npysort/selection.c
 numpy/core/src/npysort/sort.c
 numpy/core/src/scalarmathmodule.c
 numpy/core/src/umath/funcs.inc
 numpy/core/src/umath/loops.c
+numpy/core/src/umath/operand_flag_tests.c
+numpy/core/src/umath/simd.inc
+numpy/core/src/umath/struct_ufunc_test.c
+numpy/core/src/umath/test_rational.c
 numpy/core/src/umath/umath_tests.c
 numpy/distutils/__config__.py
+numpy/linalg/umath_linalg.c
 doc/source/reference/generated

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -478,7 +478,8 @@ map_increment(PyArrayMapIterObject *mit, PyObject *op, inplace_map_binop add_inp
     }
 
     if ((it = (PyArrayIterObject *)\
-            PyArray_BroadcastToShape(arr, mit->dimensions, mit->nd)) == NULL) {
+            PyArray_BroadcastToShape((PyObject *)arr, mit->dimensions,
+                                     mit->nd)) == NULL) {
         Py_DECREF(arr);
 
         return -1;

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1837,7 +1837,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
     npy_intp *strides = NBF_STRIDES(bufferdata),
              *ad_strides = NAD_STRIDES(axisdata);
     npy_intp sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
-    char **ptrs = NBF_PTRS(bufferdata), **ad_ptrs = NAD_PTRS(axisdata);
+    char **ad_ptrs = NAD_PTRS(axisdata);
     char **buffers = NBF_BUFFERS(bufferdata);
     char *buffer;
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -72,10 +72,10 @@ static int
 _does_loop_use_arrays(void *data);
 
 static int
-assign_reduce_identity_zero(PyArrayObject *result);
+assign_reduce_identity_zero(PyArrayObject *result, void *data);
 
 static int
-assign_reduce_identity_one(PyArrayObject *result);
+assign_reduce_identity_one(PyArrayObject *result, void *data);
 
 /*
  * fpstatus is the ufunc_formatted hardware status
@@ -2180,10 +2180,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
             if (PyArray_SIZE(op[i]) != 0) {
                 switch (ufunc->identity) {
                     case PyUFunc_Zero:
-                        assign_reduce_identity_zero(op[i]);
+                        assign_reduce_identity_zero(op[i], NULL);
                         break;
                     case PyUFunc_One:
-                        assign_reduce_identity_one(op[i]);
+                        assign_reduce_identity_one(op[i], NULL);
                         break;
                     case PyUFunc_None:
                     case PyUFunc_ReorderableNone:
@@ -2641,13 +2641,13 @@ reduce_type_resolver(PyUFuncObject *ufunc, PyArrayObject *arr,
 }
 
 static int
-assign_reduce_identity_zero(PyArrayObject *result)
+assign_reduce_identity_zero(PyArrayObject *result, void *NPY_UNUSED(data))
 {
     return PyArray_FillWithScalar(result, PyArrayScalar_False);
 }
 
 static int
-assign_reduce_identity_one(PyArrayObject *result)
+assign_reduce_identity_one(PyArrayObject *result, void *NPY_UNUSED(data))
 {
     return PyArray_FillWithScalar(result, PyArrayScalar_True);
 }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -755,7 +755,8 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
         obj = PyTuple_GET_ITEM(args, i);
 
         if (PyArray_Check(obj)) {
-            out_op[i] = (PyArrayObject *)PyArray_FromArray(obj,NULL,0);
+            PyArrayObject *obj_a = (PyArrayObject *)obj;
+            out_op[i] = (PyArrayObject *)PyArray_FromArray(obj_a, NULL, 0);
         }
         else {
             if (!PyArray_IsScalar(obj, Generic)) {
@@ -4529,7 +4530,7 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
             result = -1;
         }
         else {
-            PyUFunc_Loop1d *current, *prev = NULL;
+            PyUFunc_Loop1d *current;
             int cmp = 1;
             current = (PyUFunc_Loop1d *)NpyCapsule_AsVoidPtr(cobj);
             while (current != NULL) {
@@ -4538,7 +4539,6 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
                 if (cmp >= 0 && current->arg_dtypes == NULL) {
                     break;
                 }
-                prev = current;
                 current = current->next;
             }
             if (cmp == 0 && current->arg_dtypes == NULL) {

--- a/numpy/numarray/_capi.c
+++ b/numpy/numarray/_capi.c
@@ -1099,7 +1099,7 @@ NA_OutputArray(PyObject *a, NumarrayType t, int requires)
                                         PyArray_DIMS((PyArrayObject *)a),
                                         dtype, 0);
     Py_INCREF(a);
-    if (PyArray_SetUpdateIfCopyBase(ret, a) < 0) {
+    if (PyArray_SetUpdateIfCopyBase(ret, (PyArrayObject *)a) < 0) {
         Py_DECREF(ret);
         return NULL;
     }


### PR DESCRIPTION
Two patches that improve the C code quality. The first is important, as it fixes a few calls through function pointers of the wrong type (which cause undefined behavior). The second just shuts up the build by introducing a few casts and removing some unused variables.
