### PR TITLE
BUG: Set __hash__ = None for non-hashable classes.

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1030,6 +1030,8 @@ class poly1d(object):
     coeffs = None
     order = None
     variable = None
+    __hash__ = None
+
     def __init__(self, c_or_r, r=0, variable=None):
         if isinstance(c_or_r, poly1d):
             for key in c_or_r.__dict__.keys():

--- a/numpy/polynomial/polytemplate.py
+++ b/numpy/polynomial/polytemplate.py
@@ -79,6 +79,8 @@ class $name(pu.PolyBase) :
     window = np.array($domain)
     # Don't let participate in array operations. Value doesn't matter.
     __array_priority__ = 1000
+    # Not hashable
+    __hash__ = None
 
     def has_samecoef(self, other):
         """Check if coefficients match.


### PR DESCRIPTION
Because neither poly1d nor the Polynomial package polynomial classes are
immutable, hence not reliably hashable, they should signal that by
setting **hash** = None. This also fixes the warning

Overriding **eq** blocks inheritance of **hash** in 3.x

that is given when the command `python2.7 -3 -c"import numpy"` is run.
