### PR TITLE
Fix 1.7.x test failure

### DIFF
--- a/numpy/core/tests/test_blasdot.py
+++ b/numpy/core/tests/test_blasdot.py
@@ -109,15 +109,15 @@ def test_dot_array_order():
                 dtype=arr_type, order=a_order)
             assert_array_equal(np.dot(a, a), a.dot(a))
             # (a.a)' = a'.a', note that mse~=1e-31 needs almost_equal
-            assert_almost_equal(a.dot(a), a.T.dot(a.T).T, decimal=30)
+            assert_almost_equal(a.dot(a), a.T.dot(a.T).T, decimal=prec)
 
             #
             # Check with making explicit copy
             #
             a_T = a.T.copy(order=a_order)
-            assert_array_equal(a_T.dot(a_T), a.T.dot(a.T))
-            assert_array_equal(a.dot(a_T), a.dot(a.T))
-            assert_array_equal(a_T.dot(a), a.T.dot(a))
+            assert_almost_equal(a_T.dot(a_T), a.T.dot(a.T), decimal=prec)
+            assert_almost_equal(a.dot(a_T), a.dot(a.T), decimal=prec)
+            assert_almost_equal(a_T.dot(a), a.T.dot(a), decimal=prec)
 
             #
             # Compare with multiarray dot
@@ -133,10 +133,10 @@ def test_dot_array_order():
                 b = np.asarray(np.random.randn(a_dim, b_dim),
                     dtype=arr_type, order=b_order)
                 b_T = b.T.copy(order=b_order)
-                assert_array_equal(a_T.dot(b), a.T.dot(b))
-                assert_array_equal(b_T.dot(a), b.T.dot(a))
+                assert_almost_equal(a_T.dot(b), a.T.dot(b), decimal=prec)
+                assert_almost_equal(b_T.dot(a), b.T.dot(a), decimal=prec)
                 # (b'.a)' = a'.b
-                assert_almost_equal(b.T.dot(a), a.T.dot(b).T, decimal=30)
+                assert_almost_equal(b.T.dot(a), a.T.dot(b).T, decimal=prec)
                 assert_almost_equal(a.dot(b), _dot(a, b), decimal=prec)
                 assert_almost_equal(b.T.dot(a), _dot(b.T, a), decimal=prec)
 
@@ -145,7 +145,7 @@ def test_dot_array_order():
                     c = np.asarray(np.random.randn(b_dim, c_dim),
                         dtype=arr_type, order=c_order)
                     c_T = c.T.copy(order=c_order)
-                    assert_array_equal(c.T.dot(b.T), c_T.dot(b_T))
-                    assert_almost_equal(c.T.dot(b.T).T, b.dot(c), decimal=30)
+                    assert_almost_equal(c.T.dot(b.T), c_T.dot(b_T), decimal=prec)
+                    assert_almost_equal(c.T.dot(b.T).T, b.dot(c), decimal=prec)
                     assert_almost_equal(b.dot(c), _dot(b, c), decimal=prec)
                     assert_almost_equal(c.T.dot(b.T), _dot(c.T, b.T), decimal=prec)


### PR DESCRIPTION
Backport of partial fix for #3656.

Loosen some test requirements for np.dot. Because the 'F' order arrays are no longer copied, they no longer are likely to produce the same as the copied 'C' order arrays did due to different order of carrying out the arithmetic.
