### PR TITLE
Revert "Merge pull request #3567 from arinkverma/avoid_conversion"

### DIFF
--- a/numpy/core/src/scalarmathmodule.c.src
+++ b/numpy/core/src/scalarmathmodule.c.src
@@ -661,13 +661,21 @@ static void
  */
 
 /**begin repeat
- * #name = half, float, longdouble,
+ * #name = byte, ubyte, short, ushort, int, uint,
+ *         long, ulong, longlong, ulonglong,
+ *         half, float, longdouble,
  *         cfloat, cdouble, clongdouble#
- * #type = npy_half, npy_float, npy_longdouble,
+ * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
+ *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
+ *         npy_half, npy_float, npy_longdouble,
  *         npy_cfloat, npy_cdouble, npy_clongdouble#
- * #Name = Half, Float, LongDouble,
+ * #Name = Byte, UByte, Short, UShort, Int, UInt,
+ *         Long, ULong, LongLong, ULongLong,
+ *         Half, Float, LongDouble,
  *         CFloat, CDouble, CLongDouble#
- * #TYPE = NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
+ * #TYPE = NPY_BYTE, NPY_UBYTE, NPY_SHORT, NPY_USHORT, NPY_INT, NPY_UINT,
+ *         NPY_LONG, NPY_ULONG, NPY_LONGLONG, NPY_ULONGLONG,
+ *         NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
  *         NPY_CFLOAT, NPY_CDOUBLE, NPY_CLONGDOUBLE#
  */
 
@@ -731,216 +739,6 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
     if (@PYCHECKEXACT@(a)){
         *arg1 = @PYEXTRACTCTYPE@(a);
         return 0;
-    }
-
-    if (PyArray_IsScalar(a, @Name@)) {
-        *arg1 = PyArrayScalar_VAL(a, @Name@);
-        return 0;
-    }
-    else if (PyArray_IsScalar(a, Generic)) {
-        PyArray_Descr *descr1;
-
-        if (!PyArray_IsScalar(a, Number)) {
-            return -1;
-        }
-        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
-        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
-            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
-            Py_DECREF(descr1);
-            return 0;
-        }
-        else {
-            Py_DECREF(descr1);
-            return -1;
-        }
-    }
-    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
-        return -2;
-    }
-    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
-        int retval = _@name@_convert_to_ctype(temp, arg1);
-
-        Py_DECREF(temp);
-        return retval;
-    }
-    return -2;
-}
-
-/**end repeat**/
-
-
-/**begin repeat
- * #name = ubyte, ushort, uint, ulong#
- * #type = npy_ubyte, npy_ushort, npy_uint, npy_ulong#
- * #Name = UByte, UShort, UInt, ULong#
- * #TYPE = NPY_UBYTE, NPY_USHORT, NPY_UINT, NPY_ULONG#
- */
-
-static int
-_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
-{
-    PyObject *temp;
-
-#if PY_VERSION_HEX < 0x03000000
-    if (PyInt_CheckExact(a)) {
-        *arg1 = PyInt_AsLong(a);
-        if (*arg1 == -1 && PyErr_Occurred()) {
-            return -1;
-        }
-        else {
-            return 0;
-        }
-    }
-#endif
-
-    if(PyLong_CheckExact(a)) {
-        *arg1 = PyLong_AsUnsignedLong(a);
-        if (*arg1 == (unsigned long)-1 && PyErr_Occurred()) {
-            return -1;
-        }
-        else {
-            return 0;
-        }
-    }
-
-    if (PyArray_IsScalar(a, @Name@)) {
-        *arg1 = PyArrayScalar_VAL(a, @Name@);
-        return 0;
-    }
-    else if (PyArray_IsScalar(a, Generic)) {
-        PyArray_Descr *descr1;
-
-        if (!PyArray_IsScalar(a, Number)) {
-            return -1;
-        }
-        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
-        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
-            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
-            Py_DECREF(descr1);
-            return 0;
-        }
-        else {
-            Py_DECREF(descr1);
-            return -1;
-        }
-    }
-    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
-        return -2;
-    }
-    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
-        int retval = _@name@_convert_to_ctype(temp, arg1);
-
-        Py_DECREF(temp);
-        return retval;
-    }
-    return -2;
-}
-
-/**end repeat**/
-
-
-/**begin repeat
- * #name = byte, short, int, long#
- * #type = npy_byte, npy_short, npy_int, npy_long#
- * #Name = Byte, Short, Int, Long#
- * #TYPE = NPY_BYTE, NPY_SHORT, NPY_INT, NPY_LONG#
- */
-
-static int
-_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
-{
-    PyObject *temp;
-
-#if PY_VERSION_HEX < 0x03000000
-    if (PyInt_CheckExact(a)) {
-        *arg1 = PyInt_AsLong(a);
-        if (*arg1 == -1 && PyErr_Occurred()) {
-            return -1;
-        }
-        else {
-            return 0;
-        }
-    }
-#endif
-
-    if(PyLong_CheckExact(a)) {
-        *arg1 = PyLong_AsLong(a);
-        if (*arg1 == -1 && PyErr_Occurred()) {
-            return -1;
-        }
-        else {
-            return 0;
-        }
-    }
-
-    if (PyArray_IsScalar(a, @Name@)) {
-        *arg1 = PyArrayScalar_VAL(a, @Name@);
-        return 0;
-    }
-    else if (PyArray_IsScalar(a, Generic)) {
-        PyArray_Descr *descr1;
-
-        if (!PyArray_IsScalar(a, Number)) {
-            return -1;
-        }
-        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
-        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
-            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
-            Py_DECREF(descr1);
-            return 0;
-        }
-        else {
-            Py_DECREF(descr1);
-            return -1;
-        }
-    }
-    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
-        return -2;
-    }
-    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
-        int retval = _@name@_convert_to_ctype(temp, arg1);
-
-        Py_DECREF(temp);
-        return retval;
-    }
-    return -2;
-}
-
-/**end repeat**/
-
-
-/**begin repeat
- * #name = longlong, ulonglong#
- * #type = npy_longlong, npy_ulonglong#
- * #Name = LongLong, ULongLong#
- * #TYPE = NPY_LONGLONG, NPY_ULONGLONG#
- */#PYEXTRACTCTYPE = PyLong_AsLongLong, PyLong_AsUnsignedLongLong#
-
-static int
-_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
-{
-    PyObject *temp;
-
-#if PY_VERSION_HEX < 0x03000000
-    if (PyInt_CheckExact(a)) {
-        *arg1 = PyInt_AsLong(a);
-        if (*arg1 == -1 && PyErr_Occurred()) {
-            return -1;
-        }
-        else {
-            return 0;
-        }
-    }
-#endif
-
-    if (PyLong_CheckExact(a)) {
-        *arg1 = @PYEXTRACTCTYPE@(a);
-        if (*arg1 == (@type@)-1 && PyErr_Occurred()) {
-            return -1;
-        }
-        else {
-            return 0;
-        }
     }
 
     if (PyArray_IsScalar(a, @Name@)) {


### PR DESCRIPTION
This reverts commit de9f1c92d3ca0920bce915438f0406f587aa98db, reversing
changes made to d958dec676beeac218a118fac084fa8b14bc9171.

There is a change of behavior in conversion of signed to unsigned
PyLong that shows up on my machine. For some reason this did not show
up in the travisbot tests. This reverts the merge that led to this
problem until it can be sorted out. Error shows up as

numpy/core/arrayprint.py",
line 653, in **call**
    if _MININT < x < _MAXINT:
OverflowError: can't convert negative int to unsigned
