### PR TITLE
BUG: PyArray_PyIntAsIntp had variable size check wrong way around.

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -726,9 +726,9 @@ NPY_NO_EXPORT npy_intp
 PyArray_PyIntAsIntp(PyObject *o)
 {
 #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
-    npy_long long_value = -1;
+    long long long_value = -1;
 #else
-    npy_longlong long_value = -1;
+    long long_value = -1;
 #endif
     PyObject *obj, *err;
     static char *msg = "an integer is required";


### PR DESCRIPTION
This bug resulted in using a long type when a long long was required,
resulting in numerous errors when numpy was compiled as 64 bits on
64 bit windows.

Needs a backport to 1.8.x.
