### PR TITLE
structured arrays with different byteorders do not compare

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1325,16 +1325,16 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 return Py_NotImplemented;
             }
 
-            _res = PyObject_RichCompareBool
-                ((PyObject *)PyArray_DESCR(self),
-                 (PyObject *)PyArray_DESCR(array_other),
-                 Py_EQ);
-            if (_res < 0) {
+            _res = PyArray_CanCastTypeTo(PyArray_DESCR(self),
+                                         PyArray_DESCR(array_other),
+                                         NPY_EQUIV_CASTING);
+            if (_res == 0) {
                 Py_DECREF(result);
                 Py_DECREF(array_other);
-                return NULL;
+                Py_INCREF(Py_False);
+                return Py_False;
             }
-            if (_res) {
+            else {
                 Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
             }
@@ -1386,16 +1386,16 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 return Py_NotImplemented;
             }
 
-            _res = PyObject_RichCompareBool(
-                    (PyObject *)PyArray_DESCR(self),
-                    (PyObject *)PyArray_DESCR(array_other),
-                    Py_EQ);
-            if (_res < 0) {
+            _res = PyArray_CanCastTypeTo(PyArray_DESCR(self),
+                                         PyArray_DESCR(array_other),
+                                         NPY_EQUIV_CASTING);
+            if (_res == 0) {
                 Py_DECREF(result);
                 Py_DECREF(array_other);
-                return NULL;
+                Py_INCREF(Py_True);
+                return Py_True;
             }
-            if (_res) {
+            else {
                 Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
                 Py_DECREF(array_other);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -623,6 +623,12 @@ class TestStructured(TestCase):
         y = np.zeros((1,), dtype=[('a', ('f4', (2,))), ('b', 'i1')])
         assert_equal(x == y, False)
 
+        # Check that structured arrays that are different only in
+        # byte-order work
+        a = np.array([(5, 42), (10, 1)], dtype=[('a', '>i8'), ('b', '<f8')])
+        b = np.array([(5, 43), (10, 1)], dtype=[('a', '<i8'), ('b', '>f8')])
+        assert_equal(a == b, [False, True])
+
 
 class TestBool(TestCase):
     def test_test_interning(self):


### PR DESCRIPTION
Equality comparisons don't work on structured arrays if they have different byteorders.  This seems to be inconsistent with what happens with non-structured arrays.  Should this be considered a bug?  If so, I'd be happy to take a crack at fixing it.

```
In [1]: import numpy as np

In [2]: x = np.array([5], dtype=">i8")

In [3]: y = np.array([5], dtype="<i8")

In [4]: x == y
Out[4]: array([ True], dtype=bool)

In [6]: x = np.array([(5,)], dtype=[('a', '>i8')])

In [7]: y = np.array([(5,)], dtype=[('a', '<i8')])

In [8]: x == y
Out[8]: False
```
