### PR TITLE
BUG: .gitignore ignores all release directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ MANIFEST
 
 # Paver generated files #
 #########################
-release/
+/release
 
 # Logs and databases #
 ######################


### PR DESCRIPTION
It should only ignore the one in the root directory. The fix is to
prepend a '/' to the directory name.
