### PR TITLE
BUG: fix test_rational PyNumberMethods for python3

### DIFF
--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -604,7 +604,9 @@ static PyNumberMethods pyrational_as_number = {
     pyrational_add,          /* nb_add */
     pyrational_subtract,     /* nb_subtract */
     pyrational_multiply,     /* nb_multiply */
+#if PY_MAJOR_VERSION < 3
     pyrational_divide,       /* nb_divide */
+#endif
     pyrational_remainder,    /* nb_remainder */
     0,                       /* nb_divmod */
     0,                       /* nb_power */
@@ -618,17 +620,27 @@ static PyNumberMethods pyrational_as_number = {
     0,                       /* nb_and */
     0,                       /* nb_xor */
     0,                       /* nb_or */
+#if PY_MAJOR_VERSION < 3
     0,                       /* nb_coerce */
+#endif
     pyrational_int,          /* nb_int */
+#if PY_MAJOR_VERSION < 3
     pyrational_int,          /* nb_long */
+#else
+    0,                       /* reserved */
+#endif
     pyrational_float,        /* nb_float */
+#if PY_MAJOR_VERSION < 3
     0,                       /* nb_oct */
     0,                       /* nb_hex */
+#endif
 
     0,                       /* nb_inplace_add */
     0,                       /* nb_inplace_subtract */
     0,                       /* nb_inplace_multiply */
+#if PY_MAJOR_VERSION < 3
     0,                       /* nb_inplace_divide */
+#endif
     0,                       /* nb_inplace_remainder */
     0,                       /* nb_inplace_power */
     0,                       /* nb_inplace_lshift */


### PR DESCRIPTION
wrong structure makes VC9 fail to compile under python3
