### PR TITLE
ENH: add support for Python 3.4 ast.NameConstant

### DIFF
--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -46,5 +46,9 @@ def test_deprecate_fn():
     assert_('old_func3' in new_func3.__doc__)
     assert_('new_func3' in new_func3.__doc__)
 
+def test_safe_eval_nameconstant():
+    # Test if safe_eval supports Python 3.4 _ast.NameConstant
+    utils.safe_eval('None')
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1062,6 +1062,9 @@ class SafeEval(object):
             else:
                 raise SyntaxError("Unknown name: %s" % node.id)
 
+        def visitNameConstant(self, node):
+            return node.value
+
 def safe_eval(source):
     """
     Protected string evaluation.


### PR DESCRIPTION
Python 3.4 created a "NameConstant AST class to represent None, True, and False literals" (http://docs.python.org/3.4/whatsnew/changelog.html). Numpy 1.8.0b2 fails 13 tests of the following kind. The suggested change fixes those test errors on win-amd64-py3.4a2. Consider backporting this to numpy 1.8.x.

```
======================================================================
ERROR: Failure: ValueError (Cannot parse header: b"{'descr': '|u1', 'fortran_order': False, 'shape': (0,), }
\n"
Exception: SyntaxError("Unsupported source construct: <class '_ast.NameConstant'>",))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\numpy\lib\format.py", line 341, in read_array_header_1_0
    d = safe_eval(header)
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1131, in safe_eval
    return walker.visit(ast)
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1018, in visit
    return meth(node)
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1025, in visitExpression
    return self.visit(node.body)
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1018, in visit
    return meth(node)
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1038, in visitDict
    for k, v in zip(node.keys, node.values)])
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1038, in <listcomp>
    for k, v in zip(node.keys, node.values)])
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1018, in visit
    return meth(node)
  File "X:\Python34\lib\site-packages\numpy\lib\utils.py", line 1022, in default
    % node.__class__)
  File "<string>", line None
SyntaxError: Unsupported source construct: <class '_ast.NameConstant'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\failure.py", line 38, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "X:\Python34\lib\site-packages\nose\loader.py", line 254, in generate
    for test in g():
  File "X:\Python34\lib\site-packages\numpy\lib\tests\test_format.py", line 421, in test_roundtrip
    arr2 = roundtrip(arr)
  File "X:\Python34\lib\site-packages\numpy\lib\tests\test_format.py", line 412, in roundtrip
    arr2 = format.read_array(f2)
  File "X:\Python34\lib\site-packages\numpy\lib\format.py", line 444, in read_array
    shape, fortran_order, dtype = read_array_header_1_0(fp)
  File "X:\Python34\lib\site-packages\numpy\lib\format.py", line 344, in read_array_header_1_0
    raise ValueError(msg % (header, e))
ValueError: Cannot parse header: b"{'descr': '|u1', 'fortran_order': False, 'shape': (0,), }            \n"
Exception: SyntaxError("Unsupported source construct: <class '_ast.NameConstant'>",)

```
