### PR TITLE
BUG: Fix 0-sized ndindex

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -540,7 +540,8 @@ class ndindex(object):
         if len(shape) == 1 and isinstance(shape[0], tuple):
             shape = shape[0]
         x = as_strided(_nx.zeros(1), shape=shape, strides=_nx.zeros_like(shape))
-        self._it = _nx.nditer(x, flags=['multi_index'], order='C')
+        self._it = _nx.nditer(x, flags=['multi_index', 'zerosize_ok'],
+                              order='C')
 
     def __iter__(self):
         return self

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -274,6 +274,10 @@ def test_ndindex():
     x = list(np.ndindex(()))
     assert_equal(x, [()])
 
+    # Make sure 0-sized ndindex works correctly
+    x = list(np.ndindex(*[0]))
+    assert_equal(x, [])
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The zerosize_ok flag to nditer was missing, so that it did not
allow for 0-sized iteration.

Closes gh-3714
