### PR TITLE
Backport 1.7 3418

### DIFF
--- a/numpy/linalg/python_xerbla.c
+++ b/numpy/linalg/python_xerbla.c
@@ -33,7 +33,7 @@ int xerbla_(char *srname, integer *info)
         while( len && srname[len-1]==' ' )
                 len--;
 
-        snprintf(buf, sizeof(buf), format, len, srname, *info);
+        PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
         save = PyGILState_Ensure();
         PyErr_SetString(PyExc_ValueError, buf);
         PyGILState_Release(save);


### PR DESCRIPTION
Backport #3418 `MAINT: use PyOS_snprintf instead of snprintf`
