### PR TITLE
Numpy.zeros returns wrong/random numbers with some dtypes

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -438,6 +438,7 @@ class TestCreation(TestCase):
 
     def test_zeros(self):
         types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        types = list(types) + ['(8,8)i4']
         for dt in types:
             d = np.zeros((13,), dtype=dt)
             assert_equal(np.count_nonzero(d), 0)


### PR DESCRIPTION
Using numpy-1.8.0b2 on Windows (all tests pass), `np.zeros` returns wrong/random numbers with some dtypes:

```
>>>> np.zeros(2, dtype='(2,4)i4')
array([[[43307584,        0, 43307440,        0],
        [41716112,        0, 43246240,        0]],

       [[41716592,        0, 41716976,        0],
        [43335872,        0, 41716832,        0]]])
>>> np.zeros(2, dtype='4i4')
array([[43301576,        0, 43374352,        0],
       [30655712,        0, 43374712,        0]])
```

Simpler and some more complex dtypes seem to work:

```
>>> np.zeros(2, dtype='1i4')
array([0, 0])
>>> np.zeros(2, dtype='(2,4)i4, (2,4)i4')
array([([[0, 0, 0, 0], [0, 0, 0, 0]], [[0, 0, 0, 0], [0, 0, 0, 0]]),
       ([[0, 0, 0, 0], [0, 0, 0, 0]], [[0, 0, 0, 0], [0, 0, 0, 0]])],
      dtype=[('f0', '<i4', (2, 4)), ('f1', '<i4', (2, 4))]) 
```

Could be related to PR #3590 
