### PR TITLE
BUG: f2py, fix decref on wrong object

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1072,14 +1072,15 @@ goto capi_fail;
 \t}
 \t/* Get the number of optional arguments */
 #if PY_VERSION_HEX >= 0x03000000
-\tif (PyObject_HasAttrString(tmp_fun,\"__defaults__\"))
+\tif (PyObject_HasAttrString(tmp_fun,\"__defaults__\")) {
 \t\tif (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"__defaults__\")))
 #else
-\tif (PyObject_HasAttrString(tmp_fun,\"func_defaults\"))
+\tif (PyObject_HasAttrString(tmp_fun,\"func_defaults\")) {
 \t\tif (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"func_defaults\")))
 #endif
 \t\t\topt = PyTuple_Size(tmp);
 \t\tPy_XDECREF(tmp);
+\t}
 \t/* Get the number of extra arguments */
 \tif (xa != NULL)
 \t\text = PyTuple_Size((PyObject *)xa);


### PR DESCRIPTION
missing brackets causes decref on an wrong object.
shows itself as abort with negative refcount in test_callback using
python-dbg.
