### PR TITLE
DOC: Make savez_compressed show up in the documentation.

### DIFF
--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -11,6 +11,7 @@ NPZ files
    load
    save
    savez
+   savez_compressed
 
 Text files
 ----------


### PR DESCRIPTION
Closes #3708.

Should be backported to 1.8.x.
