### PR TITLE
Backport 1.8 3736

### DIFF
--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -11,6 +11,7 @@ NPZ files
    load
    save
    savez
+   savez_compressed
 
 Text files
 ----------


### PR DESCRIPTION
Backport #3736 `DOC: Make savez_compressed show up in the documentation.`
