### PR TITLE
Move nansum warning in 1.8

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -478,10 +478,6 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=0):
 
     """
     a, mask = _replace_nan(a, 0)
-    # In version 1.9 uncomment the following line and delete the rest.
-    #return a.sum(axis, dtype, out, keepdims)
-    warnings.warn("In Numpy 1.9 the sum along empty slices will be zero.",
-            FutureWarning)
 
     if mask is None:
         return a.sum(axis, dtype, out, keepdims)
@@ -489,6 +485,8 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=0):
     tot = np.add.reduce(a, axis, dtype, out, keepdims)
     if mask.any():
         tot = _copyto(tot, np.nan, mask)
+        warnings.warn("In Numpy 1.9 the sum along empty slices will be zero.",
+                      FutureWarning)
     return tot
 
 

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -248,6 +248,9 @@ class TestNanFunctions_Sum(TestCase):
                 assert_(np.isnan(res), 'result is not NaN')
                 assert_(len(w) == 1, 'no warning raised')
                 assert_(issubclass(w[0].category, FutureWarning))
+                # Check there is no warning for not all-nan
+                nansum([0]*3, axis=None)
+                assert_(len(w) == 1, 'unwanted warning raised')
             else:
                 assert_(res == 0, 'result is not 0')
                 assert_(len(w) == 0, 'warning raised')


### PR DESCRIPTION
Warning should only be issued for actual empty slice.
