### PR TITLE
ENH: Added test cases for relational operation. To ensure behavior of int

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3406,6 +3406,48 @@ class TestArrayAttributeDeletion(object):
                 "num"]
         for s in attr:
             assert_raises(AttributeError, delattr, a, s)
+            
+
+    def test_multiarra_relational_operators(self):
+         #All integer
+        for dt1 in np.typecodes['AllInteger']:
+            assert_(1 > np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
+
+            for dt2 in np.typecodes['AllInteger']:
+                assert_(np.array(1, dtype=dt1)[()] > np.array(0, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(0, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
+
+        #Unsigned integers
+        for dt1 in 'BHILQP':
+            assert_(-1 < np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+
+            #unsigned vs signed
+            for dt2 in 'bhilqp':
+                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1)[()] != np.array(-1, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
+
+        #Signed integers and floats
+        for dt1 in 'bhlqp'+np.typecodes['Float']:
+            assert_(1 > np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 == np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+
+            for dt2 in 'bhlqp'+np.typecodes['Float']:
+                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))                
+                assert_(np.array(-1, dtype=dt1)[()] == np.array(-1, dtype=dt2)[()],
+                    "type %s and %s failed" % (dt1, dt2))
 
 def test_array_interface():
     # Test scalar coercion within the array interface

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3408,47 +3408,6 @@ class TestArrayAttributeDeletion(object):
             assert_raises(AttributeError, delattr, a, s)
             
 
-    def test_multiarra_relational_operators(self):
-         #All integer
-        for dt1 in np.typecodes['AllInteger']:
-            assert_(1 > np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(not 1 < np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
-
-            for dt2 in np.typecodes['AllInteger']:
-                assert_(np.array(1, dtype=dt1)[()] > np.array(0, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(not np.array(1, dtype=dt1)[()] < np.array(0, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-
-        #Unsigned integers
-        for dt1 in 'BHILQP':
-            assert_(-1 < np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(not -1 > np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(-1 != np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
-
-            #unsigned vs signed
-            for dt2 in 'bhilqp':
-                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(np.array(1, dtype=dt1)[()] != np.array(-1, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-
-        #Signed integers and floats
-        for dt1 in 'bhlqp'+np.typecodes['Float']:
-            assert_(1 > np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(not 1 < np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(-1 == np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
-
-            for dt2 in 'bhlqp'+np.typecodes['Float']:
-                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))                
-                assert_(np.array(-1, dtype=dt1)[()] == np.array(-1, dtype=dt2)[()],
-                    "type %s and %s failed" % (dt1, dt2))
-
 def test_array_interface():
     # Test scalar coercion within the array interface
     class Foo(object):
@@ -3669,6 +3628,49 @@ class TestArrayPriority(TestCase):
         assert_(isinstance(res2, PriorityNdarray))
         assert_(isinstance(res3, PriorityNdarray))
         assert_(isinstance(res4, PriorityNdarray))
+
+
+class TestConversion(TestCase):
+    def test_array_scalar_relational_operation(self):
+        #All integer
+        for dt1 in np.typecodes['AllInteger']:
+            assert_(1 > np.array(0, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(0, dtype=dt1), "type %s failed" % (dt1,))
+
+            for dt2 in np.typecodes['AllInteger']:
+                assert_(np.array(1, dtype=dt1) > np.array(0, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1) < np.array(0, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
+
+        #Unsigned integers
+        for dt1 in 'BHILQP':
+            assert_(-1 < np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+
+            #unsigned vs signed
+            for dt2 in 'bhilqp':
+                assert_(np.array(1, dtype=dt1) > np.array(-1, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1) < np.array(-1, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1) != np.array(-1, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
+
+        #Signed integers and floats
+        for dt1 in 'bhlqp'+np.typecodes['Float']:
+            assert_(1 > np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(-1 == np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
+
+            for dt2 in 'bhlqp'+np.typecodes['Float']:
+                assert_(np.array(1, dtype=dt1) > np.array(-1, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1) < np.array(-1, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))                
+                assert_(np.array(-1, dtype=dt1) == np.array(-1, dtype=dt2),
+                        "type %s and %s failed" % (dt1, dt2))
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -139,7 +139,6 @@ class TestConversion(TestCase):
         a = np.array(l[:3], dtype=np.uint64)
         assert_equal([int(_m) for _m in a], li[:3])
 
-
     def test_iinfo_long_values(self):
         for code in 'bBhH':
             res = np.array(np.iinfo(code).max + 1, dtype=code)
@@ -156,14 +155,19 @@ class TestConversion(TestCase):
             tgt = np.iinfo(code).max
             assert_(res == tgt)
 
-
     def test_int_raise_behaviour(self):
-
         def Overflow_error_func(dtype): 
             res = np.typeDict[dtype](np.iinfo(dtype).max + 1)
 
         for code in 'lLqQ':
             assert_raises(OverflowError, Overflow_error_func, code)
+
+    def test_int_relaion_operation(self):
+        for code in 'bhlq':
+            assert_(True == (-1 < np.array(1, dtype=code)))
+            assert_(False == (-1 > np.array(1, dtype=code)))
+            assert_(True == (np.array(-1, dtype=code) < np.array(1, dtype=code)))
+            assert_(False == (np.array(-1, dtype=code) > np.array(1, dtype=code)))
 
 
 #class TestRepr(TestCase):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -162,71 +162,47 @@ class TestConversion(TestCase):
         for code in 'lLqQ':
             assert_raises(OverflowError, Overflow_error_func, code)
 
+
     def test_int_relational_operation(self):
         #All integer
-        for code in np.typecodes['AllInteger']:
-            assert_(1 > np.array(0, dtype=code), "type %s failed" % (code,))
-            assert_(not 1 < np.array(0, dtype=code), "type %s failed" % (code,))
+        for dt1 in np.typecodes['AllInteger']:
+            assert_(1 > np.array(0, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(0, dtype=dt1), "type %s failed" % (dt1,))
 
-            for code2 in np.typecodes['AllInteger']:
-                assert_(np.array(1, dtype=code) > np.array(0, dtype=code2), "type %s and %s failed" % (code, code2))
-                assert_(not np.array(1, dtype=code) < np.array(0, dtype=code2), "type %s and %s failed" % (code, code2))
-
-        #Unsigned integers
-        for code in 'BHILQP':
-            assert_(1 < np.array(-1, dtype=code), "type %s failed" % (code,))
-            assert_(not 1 > np.array(-1, dtype=code), "type %s failed" % (code,))
-            assert_(-1 != np.array(-1, dtype=code), "type %s failed" % (code,))
-
-            for code2 in 'BHILQP':
-                assert_(np.array(1, dtype=code) < np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
-                assert_(not np.array(1, dtype=code) > np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
-                assert_(np.array(1, dtype=code) != np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
-
-        #Signed integers and floats
-        for code in 'bhlqp'+np.typecodes['Float']:
-            assert_(1 > np.array(-1, dtype=code), "type %s failed" % (code,))
-            assert_(not 1 < np.array(-1, dtype=code), "type %s failed" % (code,))
-            assert_(-1 == np.array(-1, dtype=code), "type %s failed" % (code,))
-
-            for code2 in 'bhlqp'+np.typecodes['Float']:
-                assert_(np.array(1, dtype=code) > np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
-                assert_(not np.array(1, dtype=code) < np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))                
-                assert_(np.array(-1, dtype=code) == np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
-
-
-    def test_scalar_relational_operators(self):
-         #All integer
-        for code in np.typecodes['AllInteger']:
-            assert_(1 > np.array(0, dtype=code)[()], "type %s failed" % (code,))
-            assert_(not 1 < np.array(0, dtype=code)[()], "type %s failed" % (code,))
-
-            for code2 in np.typecodes['AllInteger']:
-                assert_(np.array(1, dtype=code)[()] > np.array(0, dtype=code2)[()], "type %s and %s failed" % (code, code2))
-                assert_(not np.array(1, dtype=code)[()] < np.array(0, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+            for dt2 in np.typecodes['AllInteger']:
+                assert_(np.array(1, dtype=dt1) > np.array(0, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1) < np.array(0, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
 
         #Unsigned integers
-        for code in 'BHILQP':
-            assert_(1 < np.array(-1, dtype=code)[()], "type %s failed" % (code,))
-            assert_(not 1 > np.array(-1, dtype=code)[()], "type %s failed" % (code,))
-            assert_(-1 != np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+        for dt1 in 'BHILQP':
+            assert_(-1 < np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1), "type %s failed" % (dt1,))
 
-            for code2 in 'BHILQP':
-                assert_(np.array(1, dtype=code)[()] < np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
-                assert_(not np.array(1, dtype=code)[()] > np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
-                assert_(np.array(1, dtype=code)[()] != np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+            #unsigned vs signed
+            for dt2 in 'bhilqp':
+                assert_(np.array(1, dtype=dt1) > np.array(-1, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1) < np.array(-1, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1) != np.array(-1, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
 
         #Signed integers and floats
-        for code in 'bhlqp'+np.typecodes['Float']:
-            assert_(1 > np.array(-1, dtype=code)[()], "type %s failed" % (code,))
-            assert_(not 1 < np.array(-1, dtype=code)[()], "type %s failed" % (code,))
-            assert_(-1 == np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+        for dt1 in 'bhlqp'+np.typecodes['Float']:
+            assert_(1 > np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(-1 == np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
 
-            for code2 in 'bhlqp'+np.typecodes['Float']:
-                assert_(np.array(1, dtype=code)[()] > np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
-                assert_(not np.array(1, dtype=code)[()] < np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))                
-                assert_(np.array(-1, dtype=code)[()] == np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
-
+            for dt2 in 'bhlqp'+np.typecodes['Float']:
+                assert_(np.array(1, dtype=dt1) > np.array(-1, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1) < np.array(-1, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))                
+                assert_(np.array(-1, dtype=dt1) == np.array(-1, dtype=dt2),
+                    "type %s and %s failed" % (dt1, dt2))
 
 
 #class TestRepr(TestCase):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -162,12 +162,71 @@ class TestConversion(TestCase):
         for code in 'lLqQ':
             assert_raises(OverflowError, Overflow_error_func, code)
 
-    def test_int_relaion_operation(self):
-        for code in 'bhlq':
-            assert_(True == (-1 < np.array(1, dtype=code)))
-            assert_(False == (-1 > np.array(1, dtype=code)))
-            assert_(True == (np.array(-1, dtype=code) < np.array(1, dtype=code)))
-            assert_(False == (np.array(-1, dtype=code) > np.array(1, dtype=code)))
+    def test_int_relational_operation(self):
+        #All integer
+        for code in np.typecodes['AllInteger']:
+            assert_(1 > np.array(0, dtype=code), "type %s failed" % (code,))
+            assert_(not 1 < np.array(0, dtype=code), "type %s failed" % (code,))
+
+            for code2 in np.typecodes['AllInteger']:
+                assert_(np.array(1, dtype=code) > np.array(0, dtype=code2), "type %s and %s failed" % (code, code2))
+                assert_(not np.array(1, dtype=code) < np.array(0, dtype=code2), "type %s and %s failed" % (code, code2))
+
+        #Unsigned integers
+        for code in 'BHILQP':
+            assert_(1 < np.array(-1, dtype=code), "type %s failed" % (code,))
+            assert_(not 1 > np.array(-1, dtype=code), "type %s failed" % (code,))
+            assert_(-1 != np.array(-1, dtype=code), "type %s failed" % (code,))
+
+            for code2 in 'BHILQP':
+                assert_(np.array(1, dtype=code) < np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
+                assert_(not np.array(1, dtype=code) > np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
+                assert_(np.array(1, dtype=code) != np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
+
+        #Signed integers and floats
+        for code in 'bhlqp'+np.typecodes['Float']:
+            assert_(1 > np.array(-1, dtype=code), "type %s failed" % (code,))
+            assert_(not 1 < np.array(-1, dtype=code), "type %s failed" % (code,))
+            assert_(-1 == np.array(-1, dtype=code), "type %s failed" % (code,))
+
+            for code2 in 'bhlqp'+np.typecodes['Float']:
+                assert_(np.array(1, dtype=code) > np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
+                assert_(not np.array(1, dtype=code) < np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))                
+                assert_(np.array(-1, dtype=code) == np.array(-1, dtype=code2), "type %s and %s failed" % (code, code2))
+
+
+    def test_scalar_relational_operators(self):
+         #All integer
+        for code in np.typecodes['AllInteger']:
+            assert_(1 > np.array(0, dtype=code)[()], "type %s failed" % (code,))
+            assert_(not 1 < np.array(0, dtype=code)[()], "type %s failed" % (code,))
+
+            for code2 in np.typecodes['AllInteger']:
+                assert_(np.array(1, dtype=code)[()] > np.array(0, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+                assert_(not np.array(1, dtype=code)[()] < np.array(0, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+
+        #Unsigned integers
+        for code in 'BHILQP':
+            assert_(1 < np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+            assert_(not 1 > np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+            assert_(-1 != np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+
+            for code2 in 'BHILQP':
+                assert_(np.array(1, dtype=code)[()] < np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+                assert_(not np.array(1, dtype=code)[()] > np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+                assert_(np.array(1, dtype=code)[()] != np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+
+        #Signed integers and floats
+        for code in 'bhlqp'+np.typecodes['Float']:
+            assert_(1 > np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+            assert_(not 1 < np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+            assert_(-1 == np.array(-1, dtype=code)[()], "type %s failed" % (code,))
+
+            for code2 in 'bhlqp'+np.typecodes['Float']:
+                assert_(np.array(1, dtype=code)[()] > np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+                assert_(not np.array(1, dtype=code)[()] < np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))                
+                assert_(np.array(-1, dtype=code)[()] == np.array(-1, dtype=code2)[()], "type %s and %s failed" % (code, code2))
+
 
 
 #class TestRepr(TestCase):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -163,46 +163,46 @@ class TestConversion(TestCase):
             assert_raises(OverflowError, Overflow_error_func, code)
 
 
-    def test_int_relational_operation(self):
-        #All integer
+    def test_numpy_scalar_relational_operators(self):
+         #All integer
         for dt1 in np.typecodes['AllInteger']:
-            assert_(1 > np.array(0, dtype=dt1), "type %s failed" % (dt1,))
-            assert_(not 1 < np.array(0, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(1 > np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
 
             for dt2 in np.typecodes['AllInteger']:
-                assert_(np.array(1, dtype=dt1) > np.array(0, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(not np.array(1, dtype=dt1) < np.array(0, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1)[()] > np.array(0, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(0, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
 
         #Unsigned integers
         for dt1 in 'BHILQP':
-            assert_(-1 < np.array(1, dtype=dt1), "type %s failed" % (dt1,))
-            assert_(not -1 > np.array(1, dtype=dt1), "type %s failed" % (dt1,))
-            assert_(-1 != np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(-1 < np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
 
             #unsigned vs signed
             for dt2 in 'bhilqp':
-                assert_(np.array(1, dtype=dt1) > np.array(-1, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(not np.array(1, dtype=dt1) < np.array(-1, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(np.array(1, dtype=dt1) != np.array(-1, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1)[()] != np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
 
         #Signed integers and floats
         for dt1 in 'bhlqp'+np.typecodes['Float']:
-            assert_(1 > np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
-            assert_(not 1 < np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
-            assert_(-1 == np.array(-1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(1 > np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 == np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
 
             for dt2 in 'bhlqp'+np.typecodes['Float']:
-                assert_(np.array(1, dtype=dt1) > np.array(-1, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
-                assert_(not np.array(1, dtype=dt1) < np.array(-1, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))                
-                assert_(np.array(-1, dtype=dt1) == np.array(-1, dtype=dt2),
-                    "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))                
+                assert_(np.array(-1, dtype=dt1)[()] == np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
 
 
 #class TestRepr(TestCase):


### PR DESCRIPTION
This is extension of PR #3592. 

Adding test for int relational operations. To ensure int behavior after PR #3567. As per pr #3567, which speed up integer scalar's operations by avoiding the conversion of integer to NumPy Scalar.
