### PR TITLE
BUG: fix #3017 Inconsistency in indexing 0-d arrays with Ellipsis.

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1391,7 +1391,9 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
     }
 
     /* Ellipsis index */
-    if (ind == Py_Ellipsis) {
+    if (ind == Py_Ellipsis || (PyTuple_Check(ind) && 
+                               1 == PyTuple_GET_SIZE(ind) && 
+                               Py_Ellipsis == PyTuple_GET_ITEM(ind, 0))) {
         /*
          * Doing "a[...] += 1" triggers assigning an array to itself,
          * so this check is needed.
@@ -1408,7 +1410,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         /*
          * Several different exceptions to the 0-d no-indexing rule
          *
-         *  1) ellipses (handled above generally)
+         *  1) ellipses or tuple with ellipses (handled above generally)
          *  2) empty tuple
          *  3) Using newaxis (None)
          *  4) Boolean mask indexing

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1391,9 +1391,9 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
     }
 
     /* Ellipsis index */
-    if (ind == Py_Ellipsis || (PyTuple_Check(ind) && 
-                               1 == PyTuple_GET_SIZE(ind) && 
-                               Py_Ellipsis == PyTuple_GET_ITEM(ind, 0))) {
+    if (ind == Py_Ellipsis ||
+        (PyTuple_Check(ind) && 1 == PyTuple_GET_SIZE(ind) &&
+         Py_Ellipsis == PyTuple_GET_ITEM(ind, 0))) {
         /*
          * Doing "a[...] += 1" triggers assigning an array to itself,
          * so this check is needed.

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -54,6 +54,11 @@ class TestIndexing(TestCase):
         # in an array, not a scalar
         assert_equal(a[0, ..., 1], np.array(2))
 
+        # Assignment with `(Ellipsis,)` on 0-d arrays
+        b = np.array(1)
+        b[(Ellipsis,)] = 2
+        assert_equal(b, 2)
+
     def test_single_int_index(self):
         # Single integer index selects one row
         a = np.array([[1, 2, 3],


### PR DESCRIPTION
As mentioned in Issue #3017, there were inconsistencies in the indexing and assignment of 0-d arrays:

```
>>> import numpy as np
>>> a = np.array(1)
>>> a[...] = 2
>>> a[...,]
array(2)
>>> a[...,] = 3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: 0-d arrays can't be indexed.
```

The code which checked for special cases omitted this case (of `a[...,]`) so I included it as equivalent to `a[...]`.

Tested in python 2.7.3 and 3.2.3.
