### PR TITLE
Fix for PR #3491

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -521,7 +521,7 @@ PyArray_AssignFromSequence(PyArrayObject *self, PyObject *v)
  */
 
 static int
-discover_itemsize(PyObject *s, int nd, int *itemsize, int size_as_string)
+discover_itemsize(PyObject *s, int nd, int *itemsize, int string_type)
 {
     int n, r, i;
 
@@ -539,8 +539,19 @@ discover_itemsize(PyObject *s, int nd, int *itemsize, int size_as_string)
             PyUnicode_Check(s)) {
 
         /* If an object has no length, leave it be */
-        if (size_as_string && s != NULL && !PyString_Check(s)) {
-            PyObject *s_string = PyObject_Str(s);
+        if (string_type && s != NULL &&
+                !PyString_Check(s) && !PyUnicode_Check(s)) {
+            PyObject *s_string = NULL;
+            if (string_type == NPY_STRING) {
+                s_string = PyObject_Str(s);
+            }
+            else {
+#if defined(NPY_PY3K)
+                s_string = PyObject_Str(s);
+#else
+                s_string = PyObject_Unicode(s);
+#endif
+            }
             if (s_string) {
                 n = PyObject_Length(s_string);
                 Py_DECREF(s_string);
@@ -569,7 +580,7 @@ discover_itemsize(PyObject *s, int nd, int *itemsize, int size_as_string)
             return -1;
         }
 
-        r = discover_itemsize(e, nd - 1, itemsize, size_as_string);
+        r = discover_itemsize(e, nd - 1, itemsize, string_type);
         Py_DECREF(e);
         if (r == -1) {
             return -1;
@@ -1547,12 +1558,12 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
         if ((*out_dtype)->elsize == 0 &&
                             PyTypeNum_ISEXTENDED((*out_dtype)->type_num)) {
             int itemsize = 0;
-            int size_as_string = 0;
+            int string_type = 0;
             if ((*out_dtype)->type_num == NPY_STRING ||
                     (*out_dtype)->type_num == NPY_UNICODE) {
-                size_as_string = 1;
+                string_type = (*out_dtype)->type_num;
             }
-            if (discover_itemsize(op, *out_ndim, &itemsize, size_as_string) < 0) {
+            if (discover_itemsize(op, *out_ndim, &itemsize, string_type) < 0) {
                 Py_DECREF(*out_dtype);
                 if (PyErr_Occurred() &&
                         PyErr_GivenExceptionMatches(PyErr_Occurred(),

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -274,6 +274,9 @@ def test_array_astype():
     a = np.array(123456789012345678901234567890, dtype='U')
     assert_array_equal(a, np.array(sixu('1234567890' * 3), dtype='U30'))
 
+    a = np.array(sixu('a\u0140'), dtype='U')
+    b = np.ndarray(buffer=a, dtype='uint32', shape=2)
+    assert_(b.size == 2)
 
 def test_copyto_fromscalar():
     a = np.arange(6, dtype='f4').reshape(2, 3)


### PR DESCRIPTION
Fix for PR #3491, reported on https://github.com/scipy/scipy/issues/2890

Don't convert unicode string to ascii string before getting byte length. Also, get length of non string type as ascii or unicode depending on output string type.
