### PR TITLE
BUG: Fix issue with PR #3491

### DIFF
--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -274,6 +274,9 @@ def test_array_astype():
     a = np.array(123456789012345678901234567890, dtype='U')
     assert_array_equal(a, np.array(sixu('1234567890' * 3), dtype='U30'))
 
+    a = np.array(sixu('a\u0140'), dtype='U')
+    b = np.ndarray(buffer=a, dtype='uint32', shape=2)
+    assert_(b.size == 2)
 
 def test_copyto_fromscalar():
     a = np.arange(6, dtype='f4').reshape(2, 3)


### PR DESCRIPTION
Don't convert unicode string to ascii string before getting byte length.
Also, get length of non string type as ascii or unicode depending on
output string type.
