### PR TITLE
ENH: Add gfortran to travis.yml configuration to enable f2py tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ before_install:
   - pip install nose
   # pip install coverage
   - python -V
-  - sudo apt-get install -qq libatlas-dev libatlas-base-dev
+  - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   - popd
-    
+
 install:
   # We used to use 'setup.py install' here, but that has the terrible
   # behaviour that if a copy of the package is already installed in


### PR DESCRIPTION
Currently 4937 tests are run for Python 2.7. If this PR increases the number is should be committed. 
