### PR TITLE
BUG: Correctly surface reshape invalid axis errors.

### DIFF
--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -294,7 +294,7 @@ PyArray_Reshape(PyArrayObject *self, PyObject *shape)
     PyObject *ret;
     PyArray_Dims newdims;
 
-    if (!PyArray_IntpConverter(shape, &newdims)) {
+    if (PyArray_IntpConverter(shape, &newdims) < 0) {
         return NULL;
     }
     ret = PyArray_Newshape(self, &newdims, NPY_CORDER);

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -548,6 +548,10 @@ class TestRegression(TestCase):
         a = np.ones((0, 2))
         a.shape = (-1, 2)
 
+    def test_reshape_invalid_axis(self):
+        # Make sure that reshape surfaces axis conversion errors
+        assert_raises(TypeError, np.reshape([1,2], (2, None)))
+
     # Cannot test if NPY_RELAXED_STRIDES_CHECKING changes the strides.
     # With NPY_RELAXED_STRIDES_CHECKING the test becomes superfluous.
     @dec.skipif(np.ones(1).strides[0] == np.iinfo(np.intp).max)


### PR DESCRIPTION
This was reported on the mailing list.
