### PR TITLE
ENH: core: add a fast path for PEP3118 buffer string parsing

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -767,17 +767,30 @@ NPY_NO_EXPORT PyBufferProcs array_as_buffer = {
  * Convert PEP 3118 format string to PyArray_Descr
  */
 
+static int
+_descriptor_from_pep3118_format_fast(char *s, PyObject **result);
+
+static int
+_pep3118_letter_to_type(char letter, int native, int complex);
+
 NPY_NO_EXPORT PyArray_Descr*
 _descriptor_from_pep3118_format(char *s)
 {
     char *buf, *p;
     int in_name = 0;
+    int obtained;
     PyObject *descr;
     PyObject *str;
     PyObject *_numpy_internal;
 
     if (s == NULL) {
         return PyArray_DescrNewFromType(NPY_BYTE);
+    }
+
+    /* Fast path */
+    obtained = _descriptor_from_pep3118_format_fast(s, &descr);
+    if (obtained) {
+        return (PyArray_Descr*)descr;
     }
 
     /* Strip whitespace, except from field names */
@@ -827,4 +840,106 @@ _descriptor_from_pep3118_format(char *s)
         return NULL;
     }
     return (PyArray_Descr*)descr;
+}
+
+/*
+ * Fast path for parsing buffer strings corresponding to simple types.
+ *
+ * Currently, this deals only with single-element data types.
+ */
+
+static int
+_descriptor_from_pep3118_format_fast(char *s, PyObject **result)
+{
+    PyArray_Descr *descr;
+
+    int is_standard_size = 0;
+    char byte_order = '=';
+    int is_complex = 0;
+
+    int type_num = NPY_BYTE;
+    int item_seen = 0;
+
+    for (; *s != '\0'; ++s) {
+        is_complex = 0;
+        switch (*s) {
+        case '@':
+        case '^':
+            /* ^ means no alignment; doesn't matter for a single element */
+            byte_order = '=';
+            is_standard_size = 0;
+            break;
+        case '<':
+            byte_order = '<';
+            is_standard_size = 1;
+            break;
+        case '>':
+        case '!':
+            byte_order = '>';
+            is_standard_size = 1;
+            break;
+        case '=':
+            byte_order = '=';
+            is_standard_size = 1;
+            break;
+        case 'Z':
+            is_complex = 1;
+            ++s;
+        default:
+            if (item_seen) {
+                /* Not a single-element data type */
+                return 0;
+            }
+            type_num = _pep3118_letter_to_type(*s, !is_standard_size,
+                                               is_complex);
+            if (type_num < 0) {
+                /* Something unknown */
+                return 0;
+            }
+            item_seen = 1;
+            break;
+        }
+    }
+
+    if (!item_seen) {
+        return 0;
+    }
+
+    descr = PyArray_DescrFromType(type_num);
+    if (byte_order == '=') {
+        *result = (PyObject*)descr;
+    }
+    else {
+        *result = (PyObject*)PyArray_DescrNewByteorder(descr, byte_order);
+        Py_DECREF(descr);
+    }
+    
+    return 1;
+}
+
+static int
+_pep3118_letter_to_type(char letter, int native, int complex)
+{
+    switch (letter)
+    {
+    case '?': return NPY_BOOL;
+    case 'b': return NPY_BYTE;
+    case 'B': return NPY_UBYTE;
+    case 'h': return native ? NPY_SHORT : NPY_INT16;
+    case 'H': return native ? NPY_USHORT : NPY_UINT16;
+    case 'i': return native ? NPY_INT : NPY_INT32;
+    case 'I': return native ? NPY_UINT : NPY_UINT32;
+    case 'l': return native ? NPY_LONG : NPY_INT32;
+    case 'L': return native ? NPY_ULONG : NPY_UINT32;
+    case 'q': return native ? NPY_LONGLONG : NPY_INT64;
+    case 'Q': return native ? NPY_ULONGLONG : NPY_UINT64;
+    case 'e': return NPY_HALF;
+    case 'f': return complex ? NPY_CFLOAT : NPY_FLOAT;
+    case 'd': return complex ? NPY_CDOUBLE : NPY_DOUBLE;
+    case 'g': return native ? (complex ? NPY_CLONGDOUBLE : NPY_LONGDOUBLE) : -1;
+    default:
+        /* Other unhandled cases */
+        return -1;
+    }
+    return -1;
 }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3239,6 +3239,29 @@ class TestNewBufferProtocol(object):
         x = np.array(half_list, dtype='<e')
         self._check_roundtrip(x)
 
+    def test_roundtrip_single_types(self):
+        for typ in np.typeDict.values():
+            dtype = np.dtype(typ)
+
+            if dtype.char in 'Mm':
+                # datetimes cannot be used in buffers
+                continue
+            if dtype.char == 'V':
+                # skip void
+                continue
+
+            x = np.zeros(4, dtype=dtype)
+            self._check_roundtrip(x)
+
+            if dtype.char not in 'qQgG':
+                dt = dtype.newbyteorder('<')
+                x = np.zeros(4, dtype=dt)
+                self._check_roundtrip(x)
+
+                dt = dtype.newbyteorder('>')
+                x = np.zeros(4, dtype=dt)
+                self._check_roundtrip(x)
+
     def test_export_simple_1d(self):
         x = np.array([1, 2, 3, 4, 5], dtype='i')
         y = memoryview(x)


### PR DESCRIPTION
The parsing of PEP 3118 format strings is currently written in Python, and this is somewhat slow. The call back to Python numpy.core._internal._dtype_from_pep3118 is an unnecessary large overhead for the most common case, when the buffer passed in has a simple non-composite type.

This is annoying especially for Cython, whose otherwise nice memoryview syntax takes a hit from this overhead when small arrays are used.

This PR adds a fast path for the simple case.

Before:

```
In [2]: %%cython
   ...: import numpy as np
   ...: def nop(double[::1] arr):
   ...:     return np.asarray(arr)
   ...: 

In [3]: x = randn(1000000)

In [4]: %timeit nop(x)
100000 loops, best of 3: 15.3 us per loop

In [5]: y = memoryview(x)

In [6]: %timeit np.asarray(y)
100000 loops, best of 3: 12.8 us per loop
```

After:

```
In [2]: %%cython
   ...: import numpy as np
   ...: def nop(double[::1] arr):
   ...:     return np.asarray(arr)
   ...: 

In [3]: x = randn(1000000)

In [4]: %timeit nop(x)
100000 loops, best of 3: 2.73 us per loop

In [5]: y = memoryview(x)

In [6]: %timeit np.asarray(y)
1000000 loops, best of 3: 1.24 us per loop
```
