### PR TITLE
TST: wrong indent in multiarray tests

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3475,11 +3475,11 @@ class TestMapIter(TestCase):
                          [ 104.,    5.,    6.,    7.,],
                          [   8.,    9.,   40.,   11.,]])
 
-    b = arange(6).astype(float)
-    index = (array([1, 2, 0]),)
-    vals = [50, 4, 100.1]
-    test_inplace_increment(b, index, vals)
-    assert_equal(b, [ 100.1,  51.,   6.,   3.,   4.,   5. ])
+        b = arange(6).astype(float)
+        index = (array([1, 2, 0]),)
+        vals = [50, 4, 100.1]
+        test_inplace_increment(b, index, vals)
+        assert_equal(b, [ 100.1,  51.,   6.,   3.,   4.,   5. ])
 
 
 class PriorityNdarray():


### PR DESCRIPTION
Tiny thing, indentation level off by one in the tests.
