### PR TITLE
Backport 1.8 3773

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - pip install nose
   # pip install coverage
   - python -V
+  - sudo apt-get install -qq gfortran
   - popd
 install:
   # We used to use 'setup.py install' here, but that has the terrible


### PR DESCRIPTION
Backport #3773: `ENH: Add gfortran to travis.yml configuration to enable f2py.`
