### PR TITLE
TST: speed up some very slow tests

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -443,21 +443,28 @@ class TestCreation(TestCase):
             assert_equal(np.count_nonzero(d), 0)
             # true for ieee floats
             assert_equal(d.sum(), 0)
-
-            d = np.zeros((30 * 1024**2,), dtype=dt)
-            assert_equal(np.count_nonzero(d), 0)
-            assert_equal(d.sum(), 0)
+            assert_(not d.any())
 
             d = np.zeros(2, dtype='(2,4)i4')
             assert_equal(np.count_nonzero(d), 0)
             assert_equal(d.sum(), 0)
+            assert_(not d.any())
 
             d = np.zeros(2, dtype='4i4')
             assert_equal(np.count_nonzero(d), 0)
             assert_equal(d.sum(), 0)
+            assert_(not d.any())
 
             d = np.zeros(2, dtype='(2,4)i4, (2,4)i4')
             assert_equal(np.count_nonzero(d), 0)
+
+    @dec.slow
+    def test_zeros_big(self):
+        # test big array as they might be allocated different by the sytem
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        for dt in types:
+            d = np.zeros((30 * 1024**2,), dtype=dt)
+            assert_(not d.any())
 
     def test_zeros_obj(self):
         # test initialization from PyLong(0)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import platform
 from numpy.testing import *
-from numpy.testing.utils import gen_alignment_data
+from numpy.testing.utils import _gen_alignment_data
 import numpy as np
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -48,11 +48,12 @@ class TestTypes(TestCase):
 
 class TestBaseMath(TestCase):
     def test_blocked(self):
-        #test alignments offsets for simd instructions
-        for dt in [np.float32, np.float64]:
-            for out, inp1, inp2, msg in gen_alignment_data(dtype=dt,
-                                                           type='binary',
-                                                           max_size=12):
+        # test alignments offsets for simd instructions
+        # alignments for vz + 2 * (vs - 1) + 1
+        for dt, sz in [(np.float32, 11), (np.float64, 7)]:
+            for out, inp1, inp2, msg in _gen_alignment_data(dtype=dt,
+                                                            type='binary',
+                                                            max_size=sz):
                 exp1 = np.ones_like(inp1)
                 inp1[...] = np.ones_like(inp1)
                 inp2[...] = np.zeros_like(inp2)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -4,7 +4,7 @@ import sys
 import platform
 
 from numpy.testing import *
-from numpy.testing.utils import gen_alignment_data
+from numpy.testing.utils import _gen_alignment_data
 import numpy.core.umath as ncu
 import numpy as np
 
@@ -98,15 +98,17 @@ class TestPower(TestCase):
         assert_almost_equal(x**(-1), [1., 0.5, 1./3])
         assert_almost_equal(x**(0.5), [1., ncu.sqrt(2), ncu.sqrt(3)])
 
-        for out, inp, msg in gen_alignment_data(dtype=np.float32,
-                                                type='unary'):
+        for out, inp, msg in _gen_alignment_data(dtype=np.float32,
+                                                 type='unary',
+                                                 max_size=11):
             exp = [ncu.sqrt(i) for i in inp]
             assert_almost_equal(inp**(0.5), exp, err_msg=msg)
             np.sqrt(inp, out=out)
             assert_equal(out, exp, err_msg=msg)
 
-        for out, inp, msg in gen_alignment_data(dtype=np.float64,
-                                                type='unary'):
+        for out, inp, msg in _gen_alignment_data(dtype=np.float64,
+                                                 type='unary',
+                                                 max_size=7):
             exp = [ncu.sqrt(i) for i in inp]
             assert_almost_equal(inp**(0.5), exp, err_msg=msg)
             np.sqrt(inp, out=out)
@@ -668,10 +670,11 @@ class TestSign(TestCase):
 
 class TestMinMax(TestCase):
     def test_minmax_blocked(self):
-        "simd tests on max/min"
-        for dt in [np.float32, np.float64]:
-            for out, inp, msg in gen_alignment_data(dtype=dt, type='unary',
-                                                    max_size=17):
+        # simd tests on max/min, test all alignments, slow but important
+        # for 2 * vz + 2 * (vs - 1) + 1 (unrolled once)
+        for dt, sz in [(np.float32, 15), (np.float64, 7)]:
+            for out, inp, msg in _gen_alignment_data(dtype=dt, type='unary',
+                                                     max_size=sz):
                 for i in range(inp.size):
                     inp[:] = np.arange(inp.size, dtype=dt)
                     inp[i] = np.nan
@@ -686,13 +689,12 @@ class TestMinMax(TestCase):
                     assert_equal(inp.min(), -1e10, err_msg=msg)
 
 
-
 class TestAbsolute(TestCase):
     def test_abs_blocked(self):
-        "simd tests on abs"
-        for dt in [np.float32, np.float64]:
-            for out, inp, msg in gen_alignment_data(dtype=dt, type='unary',
-                                                    max_size=17):
+        # simd tests on abs, test all alignments for vz + 2 * (vs - 1) + 1
+        for dt, sz in [(np.float32, 11), (np.float64, 5)]:
+            for out, inp, msg in _gen_alignment_data(dtype=dt, type='unary',
+                                                     max_size=sz):
                 tgt = [ncu.absolute(i) for i in inp]
                 np.absolute(inp, out=out)
                 assert_equal(out, tgt, err_msg=msg)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1512,7 +1512,7 @@ def assert_no_warnings(func, *args, **kw):
     return result
 
 
-def gen_alignment_data(dtype=float32, type='binary', max_size=24):
+def _gen_alignment_data(dtype=float32, type='binary', max_size=24):
     """
     generator producing data with different alignment and offsets
     to test simd vectorization

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -427,8 +427,10 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
     except ValueError:
         usecomplex = False
 
-    msg = build_err_msg([actual, desired], err_msg, verbose=verbose,
-             header=('Arrays are not almost equal to %d decimals' % decimal))
+    def _build_err_msg():
+        header = ('Arrays are not almost equal to %d decimals' % decimal)
+        return build_err_msg([actual, desired], err_msg, verbose=verbose,
+                             header=header)
 
     if usecomplex:
         if iscomplexobj(actual):
@@ -447,7 +449,7 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
             assert_almost_equal(actualr, desiredr, decimal=decimal)
             assert_almost_equal(actuali, desiredi, decimal=decimal)
         except AssertionError:
-            raise AssertionError(msg)
+            raise AssertionError(_build_err_msg())
 
     if isinstance(actual, (ndarray, tuple, list)) \
             or isinstance(desired, (ndarray, tuple, list)):
@@ -459,15 +461,15 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
         if not (gisfinite(desired) and gisfinite(actual)):
             if gisnan(desired) or gisnan(actual):
                 if not (gisnan(desired) and gisnan(actual)):
-                    raise AssertionError(msg)
+                    raise AssertionError(_build_err_msg())
             else:
                 if not desired == actual:
-                    raise AssertionError(msg)
+                    raise AssertionError(_build_err_msg())
             return
     except (NotImplementedError, TypeError):
         pass
     if round(abs(desired - actual), decimal) != 0 :
-        raise AssertionError(msg)
+        raise AssertionError(_build_err_msg())
 
 
 def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):


### PR DESCRIPTION
Minimize alignment combinations to useful set with SSE, might need to
be revisited if we add AVX support.
Move large data test_zeros test to slow and drop the extremely slow
count_nonzero() call.
Rename gen_alignment_data to _gen_alignment_data (private) to reserve
right to change it, e.g. add min_size.
