### PR TITLE
ENH: Reimplementing the indexing machinery

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -100,11 +100,54 @@ The `out` argument to `np.argmin` and `np.argmax` and their equivalent
 C-API functions is now checked to match the desired output shape exactly.
 If the check fails a `ValueError` instead of `TypeError` is raised.
 
+
 Einsum
 ~~~~~~
 Remove unnecessary broadcasting notation restrictions.
 np.einsum('ijk,j->ijk', A, B) can also be written as
 np.einsum('ij...,j->ij...', A, B) (ellipsis is no longer required on 'j')
+
+
+Indexing
+~~~~~~~~
+
+The NumPy indexing has seen a complete rewrite in this version. This makes
+most advanced indexing operations much faster and should have no effect
+to normal usage.
+However some subtle changes and deprecations were introduced in advanced
+indexing operations:
+
+  * Boolean indexing into scalar arrays will always return a new 1-d array.
+    This means that ``array(1)[array(True)]`` gives ``array([1])`` and
+    not the original array.
+  * Advanced indexing into one dimensional arrays used to have (undocumented)
+    special handling regarding repeating the value array in assignments
+    when the shapes did not match.
+    Code using this will raise an error now. For compatibility you can use
+    ``arr.flat[index] = values``, which uses the old code branch.
+  * The iteration order over advanced indexes used to be always C-order.
+    In NumPy 1.9. the iteration order adapts to the input and is not
+    guaranteed (with the exception of a *single* advanced index which is
+    never reversed for compatibility reasons). This means that the result is
+    undefined if multiple values are assigned to the same element.
+    An example for this is ``arr[[0, 0], [1, 1]] = [1, 2]``, which may
+    set ``arr[0, 1]`` to either 1 or 2 depending the memory order of the
+    indexing and values arrays.
+  * Equivalent to the iteration order, the memory layout of the advanced
+    indexing result is adapted for faster indexing and cannot be predicted.
+  * All indexing operations return a view or a copy. No indexing operation
+    will return the original array object.
+  * In the future Boolean array-likes (such as lists of python bools)
+    will always be treated as boolean indexes and boolean scalars (including
+    python `True`) will be a legal *boolean* index. At this time, this is
+    already the case for scalar arrays to allow the general
+    ``positive = a[a > 0]`` to work when ``a`` is zero dimensional.
+  * All non-integer array-likes are deprecated, object arrays of custom
+    integer like objects may have to be cast explicitly.
+  * The error reporting for advanced indexing is more informative, however
+    the error type has changed in some cases.
+  * Indexing with more then one ellipsis (`...`) is deprecated.
+
 
 C-API
 ~~~~~

--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -131,8 +131,7 @@ indexing operations:
     never reversed for compatibility reasons). This means that the result is
     undefined if multiple values are assigned to the same element.
     An example for this is ``arr[[0, 0], [1, 1]] = [1, 2]``, which may
-    set ``arr[0, 1]`` to either 1 or 2 depending on the memory order of the
-    indexing and value arrays.
+    set ``arr[0, 1]`` to either 1 or 2.
   * Equivalent to the iteration order, the memory layout of the advanced
     indexing result is adapted for faster indexing and cannot be predicted.
   * All indexing operations return a view or a copy. No indexing operation
@@ -145,7 +144,7 @@ indexing operations:
   * All non-integer array-likes are deprecated, object arrays of custom
     integer like objects may have to be cast explicitly.
   * The error reporting for advanced indexing is more informative, however
-    the error type has changed in some cases. (e.g. Broadcasting errors of
+    the error type has changed in some cases. (Broadcasting errors of
     indexing arrays are reported as `IndexError`)
   * Indexing with more then one ellipsis (`...`) is deprecated.
 

--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -112,8 +112,8 @@ Indexing
 ~~~~~~~~
 
 The NumPy indexing has seen a complete rewrite in this version. This makes
-most advanced indexing operations much faster and should have no effect
-to normal usage.
+most advanced integer indexing operations much faster and should have no
+other implications.
 However some subtle changes and deprecations were introduced in advanced
 indexing operations:
 
@@ -122,30 +122,31 @@ indexing operations:
     not the original array.
   * Advanced indexing into one dimensional arrays used to have (undocumented)
     special handling regarding repeating the value array in assignments
-    when the shapes did not match.
-    Code using this will raise an error now. For compatibility you can use
+    when the shape of the value array was too small or did not match.
+    Code using this will raise an error. For compatibility you can use
     ``arr.flat[index] = values``, which uses the old code branch.
   * The iteration order over advanced indexes used to be always C-order.
-    In NumPy 1.9. the iteration order adapts to the input and is not
+    In NumPy 1.9. the iteration order adapts to the inputs and is not
     guaranteed (with the exception of a *single* advanced index which is
     never reversed for compatibility reasons). This means that the result is
     undefined if multiple values are assigned to the same element.
     An example for this is ``arr[[0, 0], [1, 1]] = [1, 2]``, which may
-    set ``arr[0, 1]`` to either 1 or 2 depending the memory order of the
-    indexing and values arrays.
+    set ``arr[0, 1]`` to either 1 or 2 depending on the memory order of the
+    indexing and value arrays.
   * Equivalent to the iteration order, the memory layout of the advanced
     indexing result is adapted for faster indexing and cannot be predicted.
   * All indexing operations return a view or a copy. No indexing operation
     will return the original array object.
   * In the future Boolean array-likes (such as lists of python bools)
-    will always be treated as boolean indexes and boolean scalars (including
+    will always be treated as Boolean indexes and Boolean scalars (including
     python `True`) will be a legal *boolean* index. At this time, this is
     already the case for scalar arrays to allow the general
     ``positive = a[a > 0]`` to work when ``a`` is zero dimensional.
   * All non-integer array-likes are deprecated, object arrays of custom
     integer like objects may have to be cast explicitly.
   * The error reporting for advanced indexing is more informative, however
-    the error type has changed in some cases.
+    the error type has changed in some cases. (e.g. Broadcasting errors of
+    indexing arrays are reported as `IndexError`)
   * Indexing with more then one ellipsis (`...`) is deprecated.
 
 

--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -125,6 +125,7 @@ indexing operations:
     when the shape of the value array was too small or did not match.
     Code using this will raise an error. For compatibility you can use
     ``arr.flat[index] = values``, which uses the old code branch.
+    (for example `a = np.ones(10); a[np.arange(10)] = [1, 2, 3]`)
   * The iteration order over advanced indexes used to be always C-order.
     In NumPy 1.9. the iteration order adapts to the inputs and is not
     guaranteed (with the exception of a *single* advanced index which is
@@ -135,7 +136,7 @@ indexing operations:
   * Equivalent to the iteration order, the memory layout of the advanced
     indexing result is adapted for faster indexing and cannot be predicted.
   * All indexing operations return a view or a copy. No indexing operation
-    will return the original array object.
+    will return the original array object. (For example `arr[...]`)
   * In the future Boolean array-likes (such as lists of python bools)
     will always be treated as Boolean indexes and Boolean scalars (including
     python `True`) will be a legal *boolean* index. At this time, this is

--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -141,6 +141,10 @@ indexing operations:
     python `True`) will be a legal *boolean* index. At this time, this is
     already the case for scalar arrays to allow the general
     ``positive = a[a > 0]`` to work when ``a`` is zero dimensional.
+  * In NumPy 1.8 it was possible to use `array(True)` and `array(False)`
+    equivalent to 1 and 0 if the result of the operation was a scalar.
+    This will raise an error in NumPy 1.9 and, as noted above, treated as a
+    boolean index in the future.
   * All non-integer array-likes are deprecated, object arrays of custom
     integer like objects may have to be cast explicitly.
   * The error reporting for advanced indexing is more informative, however

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1273,7 +1273,11 @@ typedef struct {
 } npy_index_info;
 
 
-/* Store the information needed for fancy-indexing over an array */
+/*
+ * Store the information needed for fancy-indexing over an array. The
+ * fields are slightly unordered to keep consec, dataptr and subspace
+ * where they were originally.
+ */
 typedef struct {
         PyObject_HEAD
         /*
@@ -1290,18 +1294,13 @@ typedef struct {
         npy_intp              dimensions[NPY_MAXDIMS]; /* dimensions */
         NpyIter               *outer;                  /* index objects
                                                           iterator */
+        void                  *unused[NPY_MAXDIMS - 1];
         PyArrayIterObject     *ait;                    /* flat Iterator for
-                                                          underlying array */
+                                                          underlying array;
+                                                          should not be used */
 
-        /* flat iterator for subspace (when numiter < nd) */
+        /* flat iterator for subspace */
         PyArrayIterObject     *subspace;
-        char                  *baseoffset;
-
-        NpyIter_IterNextFunc  *iternext;
-        char                  **iterptrs;
-        npy_intp              *iterstrides;
-        npy_intp              itersize; /* store innersize for MapIterNext */
-        int                   nd_fancy;
 
         /*
          * if subspace iteration, then this is the array of axes in
@@ -1309,7 +1308,9 @@ typedef struct {
          */
         int                   iteraxes[NPY_MAXDIMS];
         npy_intp              outer_strides[NPY_MAXDIMS];
-        npy_intp              outer_dims[NPY_MAXDIMS];
+
+        /* pointer when all fancy indices are 0 */
+        char                  *baseoffset;
 
         /*
          * after binding consec denotes at which axis the fancy axes
@@ -1317,6 +1318,17 @@ typedef struct {
          */
         int                   consec;
         char                  *dataptr;
+
+        int                   nd_fancy;
+        npy_intp              outer_dims[NPY_MAXDIMS];
+
+        /*
+         * Information about the iteration state.
+         */
+        NpyIter_IterNextFunc  *iternext;
+        char                  **iterptrs;
+        npy_intp              *iterstrides;
+        npy_intp              itersize;    /* store innersize for MapIterNext */
 
 } PyArrayMapIterObject;
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1295,12 +1295,14 @@ typedef struct {
         NpyIter               *outer;                  /* index objects
                                                           iterator */
         void                  *unused[NPY_MAXDIMS - 1];
-        PyArrayIterObject     *ait;                    /* flat Iterator for
-                                                          underlying array;
-                                                          should not be used */
+        /* Flat iterator for the indexed array. For compatibility solely. */
+        PyArrayIterObject     *ait;
 
-        /* flat iterator for subspace */
-        NpyIter              *subspace;
+        /*
+         * Subspace array. For binary compatibility (was an iterator,
+         * but only the check for NULL should be used).
+         */
+        PyArrayObject         *subspace;
 
         /*
          * if subspace iteration, then this is the array of axes in
@@ -1339,14 +1341,17 @@ typedef struct {
         NpyIter_IterNextFunc  *outer_next;
         char                  **outer_ptrs;
         npy_intp              *outer_strides;
-        npy_intp              itersize;    /* store innersize for MapIterNext */
 
         /*
          * Information about the subspace iterator.
          */
+        NpyIter               *subspace_iter;
         NpyIter_IterNextFunc  *subspace_next;
         char                  **subspace_ptrs;
         npy_intp              *subspace_strides;
+
+        /* Count for the external loop (which ever it is) for API iteration */
+        npy_intp              iter_count;
 
 } PyArrayMapIterObject;
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1294,22 +1294,20 @@ typedef struct {
         npy_intp              dimensions[NPY_MAXDIMS]; /* dimensions */
         NpyIter               *outer;                  /* index objects
                                                           iterator */
-        PyArrayObject         *extra_op;
-        PyArray_Descr         *extra_op_dtype;         /* desired dtype */
-        void                  *unused[NPY_MAXDIMS - 3];
+        void                  *unused[NPY_MAXDIMS - 1];
         PyArrayIterObject     *ait;                    /* flat Iterator for
                                                           underlying array;
                                                           should not be used */
 
         /* flat iterator for subspace */
-        PyArrayIterObject     *subspace;
+        NpyIter              *subspace;
 
         /*
          * if subspace iteration, then this is the array of axes in
          * the underlying array represented by the index objects
          */
         int                   iteraxes[NPY_MAXDIMS];
-        npy_intp              outer_strides[NPY_MAXDIMS];
+        npy_intp              fancy_strides[NPY_MAXDIMS];
 
         /* pointer when all fancy indices are 0 */
         char                  *baseoffset;
@@ -1322,15 +1320,33 @@ typedef struct {
         char                  *dataptr;
 
         int                   nd_fancy;
-        npy_intp              outer_dims[NPY_MAXDIMS];
+        npy_intp              fancy_dims[NPY_MAXDIMS];
+
+        /*
+         * Extra op information.
+         */
+        PyArrayObject         *extra_op;
+        PyArray_Descr         *extra_op_dtype;         /* desired dtype */
+        npy_uint32            *extra_op_flags;         /* Iterator flags */
+
+        NpyIter               *extra_op_iter;
+        NpyIter_IterNextFunc  *extra_op_next;
+        char                  **extra_op_ptrs;
 
         /*
          * Information about the iteration state.
          */
-        NpyIter_IterNextFunc  *iternext;
-        char                  **iterptrs;
-        npy_intp              *iterstrides;
+        NpyIter_IterNextFunc  *outer_next;
+        char                  **outer_ptrs;
+        npy_intp              *outer_strides;
         npy_intp              itersize;    /* store innersize for MapIterNext */
+
+        /*
+         * Information about the subspace iterator.
+         */
+        NpyIter_IterNextFunc  *subspace_next;
+        char                  **subspace_ptrs;
+        npy_intp              *subspace_strides;
 
 } PyArrayMapIterObject;
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1255,8 +1255,25 @@ typedef struct {
 #define PyArray_MultiIter_NOTDONE(multi)                \
         (_PyMIT(multi)->index < _PyMIT(multi)->size)
 
-/* Store the information needed for fancy-indexing over an array */
 
+/*
+ * Struct into which indices are parsed.
+ * I.e. integer ones should only be parsed once, slices and arrays
+ * need to be validated later and for the ellipsis we need to find how
+ * many slices it represents.
+ */
+typedef struct {
+    /*
+     * Object of index: slice, array, or NULL. Owns a reference.
+     */
+    PyObject *object;
+    /* Value of an integer index or number of slices an Ellipsis is worth */
+    npy_intp value;
+    int type;       /* kind of index, see magic values in mapping.c */
+} npy_index_info;
+
+
+/* Store the information needed for fancy-indexing over an array */
 typedef struct {
         PyObject_HEAD
         /*
@@ -1271,29 +1288,30 @@ typedef struct {
         npy_intp              index;                   /* current index */
         int                   nd;                      /* number of dims */
         npy_intp              dimensions[NPY_MAXDIMS]; /* dimensions */
-        PyArrayIterObject     *iters[NPY_MAXDIMS];     /* index object
-                                                          iterators */
+        NpyIter               *outer;                  /* index objects
+                                                          iterator */
         PyArrayIterObject     *ait;                    /* flat Iterator for
                                                           underlying array */
 
         /* flat iterator for subspace (when numiter < nd) */
         PyArrayIterObject     *subspace;
+        char                  *baseoffset;
+
+        NpyIter_IterNextFunc  *iternext;
+        npy_intp              **outerptr;
+        int                   nd_fancy;
 
         /*
          * if subspace iteration, then this is the array of axes in
          * the underlying array represented by the index objects
          */
         int                   iteraxes[NPY_MAXDIMS];
-        /*
-         * if subspace iteration, the these are the coordinates to the
-         * start of the subspace.
-         */
-        npy_intp              bscoord[NPY_MAXDIMS];
+        npy_intp              outer_strides[NPY_MAXDIMS];
+        npy_intp              outer_dims[NPY_MAXDIMS];
 
-        PyObject              *indexobj;               /* creating obj */
         /*
-         * consec is first used to indicate wether fancy indices are
-         * consecutive and then denotes at which axis they are inserted
+         * after binding consec denotes at which axis the fancy axes
+         * are inserted.
          */
         int                   consec;
         char                  *dataptr;

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1294,7 +1294,8 @@ typedef struct {
         npy_intp              dimensions[NPY_MAXDIMS]; /* dimensions */
         NpyIter               *outer;                  /* index objects
                                                           iterator */
-        void                  *unused[NPY_MAXDIMS - 1];
+        void                  *unused[NPY_MAXDIMS - 2];
+        PyArrayObject         *array;
         /* Flat iterator for the indexed array. For compatibility solely. */
         PyArrayIterObject     *ait;
 
@@ -1323,6 +1324,9 @@ typedef struct {
 
         int                   nd_fancy;
         npy_intp              fancy_dims[NPY_MAXDIMS];
+
+        /* Whether the iterator (any of the iterators) requires API */
+        int                   needs_api;
 
         /*
          * Extra op information.

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1257,23 +1257,6 @@ typedef struct {
 
 
 /*
- * Struct into which indices are parsed.
- * I.e. integer ones should only be parsed once, slices and arrays
- * need to be validated later and for the ellipsis we need to find how
- * many slices it represents.
- */
-typedef struct {
-    /*
-     * Object of index: slice, array, or NULL. Owns a reference.
-     */
-    PyObject *object;
-    /* Value of an integer index or number of slices an Ellipsis is worth */
-    npy_intp value;
-    int type;       /* kind of index, see magic values in mapping.c */
-} npy_index_info;
-
-
-/*
  * Store the information needed for fancy-indexing over an array. The
  * fields are slightly unordered to keep consec, dataptr and subspace
  * where they were originally.

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1294,7 +1294,9 @@ typedef struct {
         npy_intp              dimensions[NPY_MAXDIMS]; /* dimensions */
         NpyIter               *outer;                  /* index objects
                                                           iterator */
-        void                  *unused[NPY_MAXDIMS - 1];
+        PyArrayObject         *extra_op;
+        PyArray_Descr         *extra_op_dtype;         /* desired dtype */
+        void                  *unused[NPY_MAXDIMS - 3];
         PyArrayIterObject     *ait;                    /* flat Iterator for
                                                           underlying array;
                                                           should not be used */

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1298,7 +1298,9 @@ typedef struct {
         char                  *baseoffset;
 
         NpyIter_IterNextFunc  *iternext;
-        npy_intp              **outerptr;
+        char                  **iterptrs;
+        npy_intp              *iterstrides;
+        npy_intp              itersize; /* store innersize for MapIterNext */
         int                   nd_fancy;
 
         /*

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -784,8 +784,17 @@ _is_basic_python_type(PyObject * obj)
 }
 
 
+/**
+ * Convert an array shape to a string such as "(1, 2)".
+ *
+ * @param Dimensionality of the shape
+ * @param npy_intp pointer to shape array
+ * @param String to append after the shape `(1, 2)%s`.
+ * 
+ * @return Python unicode string
+ */
 NPY_NO_EXPORT PyObject *
-get_shape_string(npy_intp n, npy_intp *vals, char *ending)
+convert_shape_to_string(npy_intp n, npy_intp *vals, char *ending)
 {
     npy_intp i;
     PyObject *ret, *tmp;
@@ -795,10 +804,7 @@ get_shape_string(npy_intp n, npy_intp *vals, char *ending)
      * be discarded for printing if it's a leading dimension.
      * Find the first non-"newaxis" dimension.
      */
-    i = 0;
-    while (i < n && vals[i] < 0) {
-        ++i;
-    }
+    for (i = 0; i < n && vals[i] < 0; i++);
 
     if (i == n) {
         return PyUString_FromFormat("()%s", ending);

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -61,7 +61,7 @@ offset_bounds_from_strides(const int itemsize, const int nd,
                            npy_intp *lower_offset, npy_intp *upper_offset);
 
 NPY_NO_EXPORT PyObject *
-get_shape_string(npy_intp n, npy_intp *vals, char *ending);
+convert_shape_to_string(npy_intp n, npy_intp *vals, char *ending);
 
 
 /*

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -60,6 +60,9 @@ offset_bounds_from_strides(const int itemsize, const int nd,
                            const npy_intp *dims, const npy_intp *strides,
                            npy_intp *lower_offset, npy_intp *upper_offset);
 
+NPY_NO_EXPORT PyObject *
+get_shape_string(npy_intp n, npy_intp *vals, char *ending);
+
 
 /*
  * Returns -1 and sets an exception if *index is an invalid index for

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1353,3 +1353,255 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
         }
     }
 }
+
+
+/***************************************************************************/
+/****************** Mapiter (Advanced indexing) Get/Set ********************/
+/***************************************************************************/
+
+/**begin repeat
+ * #name = set, get#
+ * #isget = 0, 1#
+ */
+
+NPY_NO_EXPORT int
+mapiter_@name@(PyArrayMapIterObject *mit)
+{
+    npy_intp *counter, count;
+    npy_intp indval;
+    int i, is_aligned;
+    char *self_ptr;
+
+    /* Cached mit info */
+    int numiter = mit->numiter;
+    int needs_api = mit->needs_api;
+    /* Constant information */
+    npy_intp fancy_dims[NPY_MAXDIMS];
+    npy_intp fancy_strides[NPY_MAXDIMS];
+    int iteraxes[NPY_MAXDIMS];
+
+    char *baseoffset = mit->baseoffset;
+    char **outer_ptrs = mit->outer_ptrs;
+    npy_intp *outer_strides = mit->outer_strides;
+    PyArrayObject *array= mit->array;
+
+    /* Fill constant information */
+    for (i = 0; i < numiter; i++) {
+        fancy_dims[i] = mit->fancy_dims[i];
+        fancy_strides[i] = mit->fancy_strides[i];
+        iteraxes[i] = mit->iteraxes[i];
+    }
+
+    /*
+     * Alignment information (swapping is never needed, since we buffer),
+     * could also check extra_op is buffered, but it should rarely matter.
+     */
+
+    is_aligned = PyArray_ISALIGNED(array) && PyArray_ISALIGNED(mit->extra_op);
+
+    if (mit->size == 0) {
+       return 0;
+    }
+
+    if (mit->subspace_iter == NULL) {
+        /*
+         * Item by item copy situation, the operand is buffered
+         * so use copyswap.
+         */
+         PyArray_CopySwapFunc *copyswap = PyArray_DESCR(array)->f->copyswap;
+
+        /* We have only one iterator handling everything */
+        counter = NpyIter_GetInnerLoopSizePtr(mit->outer);
+
+        /************ Optimized inner loops without subspace *************/
+
+/**begin repeat1
+ * #numiter = 1, numiter#
+ */
+        if (numiter == @numiter@) {
+
+        /* Optimization for aligned types that do not need the api */
+        switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(array) : 0) {
+
+/**begin repeat2
+ * #elsize = 1, 2, 4, 8, 0#
+ * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, 0#
+ */
+
+#if @elsize@
+            case @elsize@:
+#else
+            default:
+#endif
+                do {
+#if !@isget@
+                    /*
+                     * When the API is needed the casting might fail
+                     * TODO: (only if buffering is enabled).
+                     */
+                    if (needs_api && PyErr_Occurred()) {
+                        return -1;
+                    }
+#endif
+                    count = *counter;
+                    while (count--) {
+                        self_ptr = baseoffset;
+                        for (i=0; i < @numiter@; i++) {
+                            indval = *((npy_intp*)outer_ptrs[i]);
+#if @isget@
+                            if (check_and_adjust_index(&indval, fancy_dims[i],
+                                                       iteraxes[i]) < 0 ) {
+                                return -1;
+                            }
+#else
+                            if (indval < 0) {
+                                indval += fancy_dims[i];
+                            }
+#endif
+                            self_ptr += indval * fancy_strides[i];
+
+                            /* advance indexing arrays */
+                            outer_ptrs[i] += outer_strides[i];
+                        }
+
+#if @isget@
+#if @elsize@
+                        *(@copytype@ *)(outer_ptrs[i]) = *(@copytype@ *)self_ptr;
+#else
+                        copyswap(outer_ptrs[i], self_ptr, 0, array);
+#endif
+
+#else /* !@isget@ */
+#if @elsize@
+                        *(@copytype@ *)self_ptr = *(@copytype@ *)(outer_ptrs[i]);
+#else
+                        copyswap(self_ptr, outer_ptrs[i], 0, array);
+#endif
+#endif
+                        /* advance extra operand */
+                        outer_ptrs[i] += outer_strides[i];
+                    }
+                } while (mit->outer_next(mit->outer));
+
+                break;
+
+/**end repeat2**/
+            }
+        }
+/**end repeat1**/
+    }
+
+    /******************* Nested Iteration Situation *******************/
+    else {
+        char *subspace_baseptrs[2];
+        char **subspace_ptrs = mit->subspace_ptrs;
+        npy_intp *subspace_strides = mit->subspace_strides;
+        int skip = 0;
+
+        /* Use strided transfer functions for the inner loop */
+        PyArray_StridedUnaryOp *stransfer = NULL;
+        NpyAuxData *transferdata = NULL;
+        npy_intp fixed_strides[2];
+
+#if @isget@
+        npy_intp src_itemsize = PyArray_ITEMSIZE(array);
+#else
+        npy_intp src_itemsize = PyArray_ITEMSIZE(array);
+#endif
+
+        /*
+         * Get a dtype transfer function, since there are no
+         * buffers, this is safe.
+         */
+        NpyIter_GetInnerFixedStrideArray(mit->subspace_iter, fixed_strides);
+        if (PyArray_GetDTypeTransferFunction(is_aligned,
+#if @isget@
+                        fixed_strides[0], fixed_strides[1],
+#else
+                        fixed_strides[1], fixed_strides[0],
+#endif
+                        PyArray_DESCR(array), PyArray_DESCR(mit->extra_op),
+                        0,
+                        &stransfer, &transferdata,
+                        &needs_api) != NPY_SUCCEED) {
+            return -1;
+        }
+
+        counter = NpyIter_GetInnerLoopSizePtr(mit->subspace_iter);
+        if (*counter == PyArray_NDIM(mit->subspace)) {
+            skip = 1;
+        }
+
+        do {
+            self_ptr = baseoffset;
+            for (i=0; i < numiter; i++) {
+                indval = *((npy_intp*)outer_ptrs[i]);
+#if @isget@
+                if (check_and_adjust_index(&indval, fancy_dims[i],
+                                           iteraxes[i]) < 0 ) {
+                    return -1;
+                }
+#else
+                if (indval < 0) {
+                    indval += fancy_dims[i];
+                }
+#endif
+
+                self_ptr += indval * fancy_strides[i];
+            }
+
+            /*
+             * Resetting is slow, so skip if the subspace iteration has
+             * only a single inner loop.
+             */
+            if (!skip) {
+                subspace_baseptrs[0] = self_ptr;
+                subspace_baseptrs[1] = mit->extra_op_ptrs[0];
+
+                /* (can't really fail, since no buffering necessary) */
+                if (!NpyIter_ResetBasePointers(mit->subspace_iter,
+                                               subspace_baseptrs, NULL)) {
+                    NPY_AUXDATA_FREE(transferdata);
+                    return -1;
+                }
+            }
+            else {
+                subspace_ptrs[0] = self_ptr;
+                subspace_ptrs[1] = mit->extra_op_ptrs[0];
+            }
+
+#if !@isget@
+            /*
+             * When the API is needed the casting might fail
+             * TODO: Could only check if casting is unsafe, or even just
+             *       not at all...
+             */
+            if (needs_api && PyErr_Occurred()) {
+                NPY_AUXDATA_FREE(transferdata);
+                return -1;
+            }
+#endif
+
+            do {
+
+#if @isget@
+                stransfer(subspace_ptrs[1], subspace_strides[1],
+                          subspace_ptrs[0], subspace_strides[0],
+                          *counter, src_itemsize, transferdata);
+#else
+                stransfer(subspace_ptrs[0], subspace_strides[0],
+                          subspace_ptrs[1], subspace_strides[1],
+                          *counter, src_itemsize, transferdata);
+#endif
+            } while (mit->subspace_next(mit->subspace_iter));
+
+            mit->extra_op_next(mit->extra_op_iter);
+        } while (mit->outer_next(mit->outer));
+
+        NPY_AUXDATA_FREE(transferdata);
+    }
+
+    return 0;
+}
+
+/**end repeat**/

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1356,7 +1356,7 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
 
 
 /***************************************************************************/
-/****************** Mapiter (Advanced indexing) Get/Set ********************/
+/****************** MapIter (Advanced indexing) Get/Set ********************/
 /***************************************************************************/
 
 /**begin repeat
@@ -1472,7 +1472,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
     /* Constant information */
     npy_intp fancy_dims[NPY_MAXDIMS];
     npy_intp fancy_strides[NPY_MAXDIMS];
-    int iteraxes[NPY_MAXDIMS];
+    int iteraxis;
 
     char *baseoffset = mit->baseoffset;
     char **outer_ptrs = mit->outer_ptrs;
@@ -1480,10 +1480,10 @@ mapiter_@name@(PyArrayMapIterObject *mit)
     PyArrayObject *array= mit->array;
 
     /* Fill constant information */
+    iteraxis = mit->iteraxes[0];
     for (i = 0; i < numiter; i++) {
         fancy_dims[i] = mit->fancy_dims[i];
         fancy_strides[i] = mit->fancy_strides[i];
-        iteraxes[i] = mit->iteraxes[i];
     }
 
     /*
@@ -1510,11 +1510,15 @@ mapiter_@name@(PyArrayMapIterObject *mit)
         /************ Optimized inner loops without subspace *************/
 
 /**begin repeat1
- * #is_one_dim = 1, 0#
+ * #one_iter = 1, 0#
  * #numiter = 1, numiter#
- * #numiter_op = ==, >#
  */
-        if (numiter @numiter_op@ 1) {
+
+#if @one_iter@
+        if (numiter == 1) {
+#else
+        else {
+#endif
 
             /* Optimization for aligned types that do not need the api */
             switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(array) : 0) {
@@ -1545,9 +1549,9 @@ mapiter_@name@(PyArrayMapIterObject *mit)
                         for (i=0; i < @numiter@; i++) {
                             indval = *((npy_intp*)outer_ptrs[i]);
 
-#if @isget@ && @is_one_dim@
+#if @isget@ && @one_iter@
                             if (check_and_adjust_index(&indval, fancy_dims[i],
-                                                       iteraxes[i]) < 0 ) {
+                                                       iteraxis) < 0 ) {
                                 return -1;
                             }
 #else
@@ -1567,7 +1571,6 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 #else
                         copyswap(outer_ptrs[i], self_ptr, 0, array);
 #endif
-
 #else /* !@isget@ */
 #if @elsize@
                         *(@copytype@ *)self_ptr = *(@copytype@ *)(outer_ptrs[i]);
@@ -1584,7 +1587,6 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 
 /**end repeat2**/
             }
-        return 0;
         }
 /**end repeat1**/
     }
@@ -1631,20 +1633,24 @@ mapiter_@name@(PyArrayMapIterObject *mit)
         }
 
 /**begin repeat1
- * #is_one_dim = 1, 0#
+ * #one_iter = 1, 0#
  * #numiter = 1, numiter#
- * #numiter_op = ==, >#
  */
-        if (numiter @numiter_op@ 1) {
+
+#if @one_iter@
+        if (numiter == 1) {
+#else
+        else {
+#endif
 
             do {
                 self_ptr = baseoffset;
                 for (i=0; i < @numiter@; i++) {
                     indval = *((npy_intp*)outer_ptrs[i]);
 
-#if @isget@ && @is_one_dim@
+#if @isget@ && @one_iter@
                     if (check_and_adjust_index(&indval, fancy_dims[i],
-                                               iteraxes[i]) < 0 ) {
+                                               iteraxis) < 0 ) {
                         NPY_AUXDATA_FREE(transferdata);
                         return -1;
                     }
@@ -1706,10 +1712,10 @@ mapiter_@name@(PyArrayMapIterObject *mit)
             } while (mit->outer_next(mit->outer));
 
             NPY_AUXDATA_FREE(transferdata);
-            return 0;
         }
 /**end repeat1**/
     }
+    return 0;
 }
 
 /**end repeat**/

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1510,12 +1510,14 @@ mapiter_@name@(PyArrayMapIterObject *mit)
         /************ Optimized inner loops without subspace *************/
 
 /**begin repeat1
+ * #is_one_dim = 1, 0#
  * #numiter = 1, numiter#
+ * #numiter_op = ==, >#
  */
-        if (numiter == @numiter@) {
+        if (numiter @numiter_op@ 1) {
 
-        /* Optimization for aligned types that do not need the api */
-        switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(array) : 0) {
+            /* Optimization for aligned types that do not need the api */
+            switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(array) : 0) {
 
 /**begin repeat2
  * #elsize = 1, 2, 4, 8, 0#
@@ -1542,7 +1544,8 @@ mapiter_@name@(PyArrayMapIterObject *mit)
                         self_ptr = baseoffset;
                         for (i=0; i < @numiter@; i++) {
                             indval = *((npy_intp*)outer_ptrs[i]);
-#if @isget@
+
+#if @isget@ && @is_one_dim@
                             if (check_and_adjust_index(&indval, fancy_dims[i],
                                                        iteraxes[i]) < 0 ) {
                                 return -1;
@@ -1601,7 +1604,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 #if @isget@
         npy_intp src_itemsize = PyArray_ITEMSIZE(array);
 #else
-        npy_intp src_itemsize = PyArray_ITEMSIZE(array);
+        npy_intp src_itemsize = PyArray_ITEMSIZE(mit->extra_op);
 #endif
 
         /*
@@ -1627,76 +1630,86 @@ mapiter_@name@(PyArrayMapIterObject *mit)
             skip = 1;
         }
 
-        do {
-            self_ptr = baseoffset;
-            for (i=0; i < numiter; i++) {
-                indval = *((npy_intp*)outer_ptrs[i]);
-#if @isget@
-                if (check_and_adjust_index(&indval, fancy_dims[i],
-                                           iteraxes[i]) < 0 ) {
-                    return -1;
-                }
+/**begin repeat1
+ * #is_one_dim = 1, 0#
+ * #numiter = 1, numiter#
+ * #numiter_op = ==, >#
+ */
+        if (numiter @numiter_op@ 1) {
+
+            do {
+                self_ptr = baseoffset;
+                for (i=0; i < @numiter@; i++) {
+                    indval = *((npy_intp*)outer_ptrs[i]);
+
+#if @isget@ && @is_one_dim@
+                    if (check_and_adjust_index(&indval, fancy_dims[i],
+                                               iteraxes[i]) < 0 ) {
+                        NPY_AUXDATA_FREE(transferdata);
+                        return -1;
+                    }
 #else
-                if (indval < 0) {
-                    indval += fancy_dims[i];
-                }
+                    if (indval < 0) {
+                        indval += fancy_dims[i];
+                    }
 #endif
 
-                self_ptr += indval * fancy_strides[i];
-            }
+                    self_ptr += indval * fancy_strides[i];
+                }
 
-            /*
-             * Resetting is slow, so skip if the subspace iteration has
-             * only a single inner loop.
-             */
-            if (!skip) {
-                subspace_baseptrs[0] = self_ptr;
-                subspace_baseptrs[1] = mit->extra_op_ptrs[0];
+                /*
+                 * Resetting is slow, so skip if the subspace iteration has
+                 * only a single inner loop.
+                 */
+                if (!skip) {
+                    subspace_baseptrs[0] = self_ptr;
+                    subspace_baseptrs[1] = mit->extra_op_ptrs[0];
 
-                /* (can't really fail, since no buffering necessary) */
-                if (!NpyIter_ResetBasePointers(mit->subspace_iter,
-                                               subspace_baseptrs, NULL)) {
+                    /* (can't really fail, since no buffering necessary) */
+                    if (!NpyIter_ResetBasePointers(mit->subspace_iter,
+                                                   subspace_baseptrs, NULL)) {
+                        NPY_AUXDATA_FREE(transferdata);
+                        return -1;
+                    }
+                }
+                else {
+                    subspace_ptrs[0] = self_ptr;
+                    subspace_ptrs[1] = mit->extra_op_ptrs[0];
+                }
+
+#if !@isget@
+                /*
+                 * When the API is needed the casting might fail
+                 * TODO: Could only check if casting is unsafe, or even just
+                 *       not at all...
+                 */
+                if (needs_api && PyErr_Occurred()) {
                     NPY_AUXDATA_FREE(transferdata);
                     return -1;
                 }
-            }
-            else {
-                subspace_ptrs[0] = self_ptr;
-                subspace_ptrs[1] = mit->extra_op_ptrs[0];
-            }
-
-#if !@isget@
-            /*
-             * When the API is needed the casting might fail
-             * TODO: Could only check if casting is unsafe, or even just
-             *       not at all...
-             */
-            if (needs_api && PyErr_Occurred()) {
-                NPY_AUXDATA_FREE(transferdata);
-                return -1;
-            }
 #endif
 
-            do {
+                do {
 
 #if @isget@
-                stransfer(subspace_ptrs[1], subspace_strides[1],
-                          subspace_ptrs[0], subspace_strides[0],
-                          *counter, src_itemsize, transferdata);
+                    stransfer(subspace_ptrs[1], subspace_strides[1],
+                              subspace_ptrs[0], subspace_strides[0],
+                              *counter, src_itemsize, transferdata);
 #else
-                stransfer(subspace_ptrs[0], subspace_strides[0],
-                          subspace_ptrs[1], subspace_strides[1],
-                          *counter, src_itemsize, transferdata);
+                    stransfer(subspace_ptrs[0], subspace_strides[0],
+                              subspace_ptrs[1], subspace_strides[1],
+                              *counter, src_itemsize, transferdata);
 #endif
-            } while (mit->subspace_next(mit->subspace_iter));
+                } while (mit->subspace_next(mit->subspace_iter));
 
-            mit->extra_op_next(mit->extra_op_iter);
-        } while (mit->outer_next(mit->outer));
+                mit->extra_op_next(mit->extra_op_iter);
+            } while (mit->outer_next(mit->outer));
 
-        NPY_AUXDATA_FREE(transferdata);
+            NPY_AUXDATA_FREE(transferdata);
+            return 0;
+        }
+/**end repeat1**/
     }
-
-    return 0;
 }
 
 /**end repeat**/

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1364,6 +1364,11 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
  * #isget = 0, 1#
  */
 
+/*
+ * Advanded indexing iteration of arrays when there is a single indexing
+ * array which has the same memory order as the value array and both
+ * can be trivally iterated (single stride, aligned, no casting necessary).
+ */
 NPY_NO_EXPORT int
 mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
                        PyArrayObject *result)
@@ -1418,37 +1423,37 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
 #else
     default:
 #endif
-            while (itersize--) {
-                indval = *((npy_intp*)ind_ptr);
+        while (itersize--) {
+            indval = *((npy_intp*)ind_ptr);
 #if @isget@
-                if (check_and_adjust_index(&indval, fancy_dim, 1) < 0 ) {
-                    return -1;
-                }
+            if (check_and_adjust_index(&indval, fancy_dim, 1) < 0 ) {
+                return -1;
+            }
 #else
-                if (indval < 0) {
-                    indval += fancy_dim;
-                }
+            if (indval < 0) {
+                indval += fancy_dim;
+            }
 #endif
-                self_ptr = base_ptr + indval * self_stride;
+            self_ptr = base_ptr + indval * self_stride;
 
 #if @isget@
 #if @elsize@
-                *(@copytype@ *)result_ptr = *(@copytype@ *)self_ptr;
+            *(@copytype@ *)result_ptr = *(@copytype@ *)self_ptr;
 #else
-                copyswap(result_ptr, self_ptr, 0, self);
+            copyswap(result_ptr, self_ptr, 0, self);
 #endif
 
 #else /* !@isget@ */
 #if @elsize@
-                *(@copytype@ *)self_ptr = *(@copytype@ *)result_ptr;
+            *(@copytype@ *)self_ptr = *(@copytype@ *)result_ptr;
 #else
-                copyswap(self_ptr, result_ptr, 0, self);
+            copyswap(self_ptr, result_ptr, 0, self);
 #endif
 #endif
 
-                ind_ptr += ind_stride;
-                result_ptr += result_stride;
-            }
+            ind_ptr += ind_stride;
+            result_ptr += result_stride;
+        }
         break;
 
 /**end repeat1**/
@@ -1458,6 +1463,9 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
 }
 
 
+/*
+ * General advanced indexing iteration.
+ */
 NPY_NO_EXPORT int
 mapiter_@name@(PyArrayMapIterObject *mit)
 {
@@ -1533,6 +1541,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 #else
             default:
 #endif
+                /* Outer iteration (safe because mit->size != 0) */
                 do {
 #if !@isget@
                     /*
@@ -1645,6 +1654,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
         else {
 #endif
 
+            /* Outer iteration (safe because mit->size != 0) */
             do {
                 self_ptr = baseoffset;
                 for (i=0; i < @numiter@; i++) {

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1614,13 +1614,15 @@ mapiter_@name@(PyArrayMapIterObject *mit)
          * buffers, this is safe.
          */
         NpyIter_GetInnerFixedStrideArray(mit->subspace_iter, fixed_strides);
+
         if (PyArray_GetDTypeTransferFunction(is_aligned,
 #if @isget@
                         fixed_strides[0], fixed_strides[1],
+                        PyArray_DESCR(array), PyArray_DESCR(mit->extra_op),
 #else
                         fixed_strides[1], fixed_strides[0],
+                         PyArray_DESCR(mit->extra_op), PyArray_DESCR(array),
 #endif
-                        PyArray_DESCR(array), PyArray_DESCR(mit->extra_op),
                         0,
                         &stransfer, &transferdata,
                         &needs_api) != NPY_SUCCEED) {
@@ -1710,10 +1712,10 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 
                 mit->extra_op_next(mit->extra_op_iter);
             } while (mit->outer_next(mit->outer));
-
-            NPY_AUXDATA_FREE(transferdata);
         }
 /**end repeat1**/
+
+        NPY_AUXDATA_FREE(transferdata);
     }
     return 0;
 }

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1365,6 +1365,100 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
  */
 
 NPY_NO_EXPORT int
+mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
+                       PyArrayObject *result)
+{
+    char *base_ptr, *self_ptr, *ind_ptr, *result_ptr;
+    npy_intp self_stride, ind_stride, result_stride;
+    npy_intp fancy_dim = PyArray_DIM(self, 0);
+
+    npy_intp itersize;
+    npy_intp indval;
+
+    int is_aligned = PyArray_ISALIGNED(self) && PyArray_ISALIGNED(result);
+    int needs_api = PyDataType_REFCHK(PyArray_DESCR(self));
+
+    PyArray_CopySwapFunc *copyswap = PyArray_DESCR(self)->f->copyswap;
+
+    base_ptr = PyArray_BYTES(self);
+    self_stride = PyArray_STRIDE(self, 0);
+
+    PyArray_PREPARE_TRIVIAL_PAIR_ITERATION(ind, result, itersize,
+                                           ind_ptr, result_ptr,
+                                           ind_stride, result_stride)
+
+#if !@isget@
+    /* Check the indices beforehand */
+    while (itersize--) {
+        indval = *((npy_intp*)ind_ptr);
+        if (check_and_adjust_index(&indval, fancy_dim, 1) < 0 ) {
+            return -1;
+        }
+        ind_ptr += ind_stride;
+    }
+
+    /*
+     * Reset the ind_ptr and itersize, due to broadcasting it is always
+     * the size of ind.
+     */
+    ind_ptr = PyArray_BYTES(ind);
+    itersize = PyArray_SIZE(ind);
+#endif
+
+    /* Optimization for aligned types that do not need the api */
+    switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(self) : 0) {
+
+/**begin repeat1
+ * #elsize = 1, 2, 4, 8, 0#
+ * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, 0#
+ */
+
+#if @elsize@
+    case @elsize@:
+#else
+    default:
+#endif
+            while (itersize--) {
+                indval = *((npy_intp*)ind_ptr);
+#if @isget@
+                if (check_and_adjust_index(&indval, fancy_dim, 1) < 0 ) {
+                    return -1;
+                }
+#else
+                if (indval < 0) {
+                    indval += fancy_dim;
+                }
+#endif
+                self_ptr = base_ptr + indval * self_stride;
+
+#if @isget@
+#if @elsize@
+                *(@copytype@ *)result_ptr = *(@copytype@ *)self_ptr;
+#else
+                copyswap(result_ptr, self_ptr, 0, self);
+#endif
+
+#else /* !@isget@ */
+#if @elsize@
+                *(@copytype@ *)self_ptr = *(@copytype@ *)result_ptr;
+#else
+                copyswap(self_ptr, result_ptr, 0, self);
+#endif
+#endif
+
+                ind_ptr += ind_stride;
+                result_ptr += result_stride;
+            }
+        break;
+
+/**end repeat1**/
+    }
+
+    return 0;
+}
+
+
+NPY_NO_EXPORT int
 mapiter_@name@(PyArrayMapIterObject *mit)
 {
     npy_intp *counter, count;
@@ -1487,6 +1581,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 
 /**end repeat2**/
             }
+        return 0;
         }
 /**end repeat1**/
     }

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1630,7 +1630,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
         }
 
         counter = NpyIter_GetInnerLoopSizePtr(mit->subspace_iter);
-        if (*counter == PyArray_NDIM(mit->subspace)) {
+        if (*counter == PyArray_SIZE(mit->subspace)) {
             skip = 1;
         }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2094,6 +2094,7 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
  *
  * @param MapIterObject
  * @param The parsed indices object
+ * @param Number of indices
  * @param The array that is being iterated
  *
  * Sets the following information:

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -564,9 +564,9 @@ prepare_index(PyArrayObject *self, PyObject *index,
                     }
                 }
 
-                PyArray_Descr *indtype = PyArray_DescrFromType(NPY_INTP);
-                arr = (PyArrayObject *)PyArray_FromArray(tmp_arr, indtype,
-                                                         NPY_ARRAY_FORCECAST);
+                arr = (PyArrayObject *)PyArray_FromArray(tmp_arr,
+                                            PyArray_DescrFromType(NPY_INTP),
+                                            NPY_ARRAY_FORCECAST);
 
                 if (arr == NULL) {
                     /* Since this will be removed, handle this later */
@@ -2571,17 +2571,18 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
      */
     else if (extra_op_flags && (subspace != NULL)) {
         npy_uint32 tmp_op_flags[NPY_MAXDIMS];
+
+        NpyIter *tmp_iter;
+        npy_intp stride;
+        npy_intp strides[NPY_MAXDIMS];
+        npy_stride_sort_item strideperm[NPY_MAXDIMS];
+
         for (i=0; i < mit->numiter; i++) {
             tmp_op_flags[i] = NPY_ITER_READONLY;
         }
 
         Py_INCREF(extra_op_dtype);
         mit->extra_op_dtype = extra_op_dtype;
-
-        NpyIter *tmp_iter;
-        npy_intp stride;
-        npy_intp strides[NPY_MAXDIMS];
-        npy_stride_sort_item strideperm[NPY_MAXDIMS];
 
         /* Create an iterator, just to broadcast the arrays?! */
         tmp_iter = NpyIter_MultiNew(mit->numiter, index_arrays,

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3021,9 +3021,6 @@ PyArray_MapIterArray(PyArrayObject * a, PyObject * index)
 #undef HAS_SCALAR_ARRAY
 #undef HAS_0D_BOOL
 
-#undef SET_MIT_DATAPTR_CHECK_INDEX
-#undef SET_MIT_DATAPTR_0_NUMITER_CHECK_INDEX
-
 
 static void
 arraymapiter_dealloc(PyArrayMapIterObject *mit)

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -566,9 +566,9 @@ prepare_index(PyArrayObject *self, PyObject *index,
                     }
                 }
 
-                PyArray_Descr *indtype = PyArray_DescrFromType(NPY_INTP);
-                arr = (PyArrayObject *)PyArray_FromArray(tmp_arr, indtype,
-                                                         NPY_ARRAY_FORCECAST);
+                arr = (PyArrayObject *)PyArray_FromArray(tmp_arr,
+                                            PyArray_DescrFromType(NPY_INTP),
+                                            NPY_ARRAY_FORCECAST);
 
                 if (arr == NULL) {
                     /* Since this will be removed, handle this later */
@@ -2596,17 +2596,18 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
      */
     else if (extra_op_flags && (subspace != NULL)) {
         npy_uint32 tmp_op_flags[NPY_MAXDIMS];
+
+        NpyIter *tmp_iter;
+        npy_intp stride;
+        npy_intp strides[NPY_MAXDIMS];
+        npy_stride_sort_item strideperm[NPY_MAXDIMS];
+
         for (i=0; i < mit->numiter; i++) {
             tmp_op_flags[i] = NPY_ITER_READONLY;
         }
 
         Py_INCREF(extra_op_dtype);
         mit->extra_op_dtype = extra_op_dtype;
-
-        NpyIter *tmp_iter;
-        npy_intp stride;
-        npy_intp strides[NPY_MAXDIMS];
-        npy_stride_sort_item strideperm[NPY_MAXDIMS];
 
         /* Create an iterator, just to broadcast the arrays?! */
         tmp_iter = NpyIter_MultiNew(mit->numiter, index_arrays,

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2348,12 +2348,12 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
 
     /* create new MapIter object */
     mit = (PyArrayMapIterObject *)PyArray_malloc(sizeof(PyArrayMapIterObject));
-    /* set all attributes of mapiter to zero */
-    memset(mit, 0, sizeof(PyArrayMapIterObject));
-    PyObject_Init((PyObject *)mit, &PyArrayMapIter_Type);
     if (mit == NULL) {
         return NULL;
     }
+    /* set all attributes of mapiter to zero */
+    memset(mit, 0, sizeof(PyArrayMapIterObject));
+    PyObject_Init((PyObject *)mit, &PyArrayMapIter_Type);
 
     Py_XINCREF(subspace);
     mit->subspace = subspace;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2691,7 +2691,7 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
         }
         else {
             mit->outer = NpyIter_MultiNew(nops, index_arrays, outer_flags,
-                             NPY_CORDER, NPY_UNSAFE_CASTING, op_flags, dtypes);
+                             NPY_KEEPORDER, NPY_UNSAFE_CASTING, op_flags, dtypes);
         }
 
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1859,8 +1859,15 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
      *          very own index machinery.
      *          I find this weird, but not sure if there is a way to
      *          deprecate. (why does the class not implement getitem too?)
+     *
+     * TODO|FIXME: The HAS_SCALAR_ARRAY special case here will break matrix
+     *          for `matrix[:,np.array(1)] = vals`  (found by scipy test),
+     *          this should not be that bad. This could be fixed by not
+     *          returning a copy for __getitem__ here, always, or for
+     *          subclasses.
      */
-    else if (!(index_type & HAS_FANCY) && !PyArray_CheckExact(self)) {
+    else if (!(index_type & (HAS_FANCY | HAS_SCALAR_ARRAY))
+                && !PyArray_CheckExact(self)) {
         view = (PyArrayObject *)PyObject_GetItem((PyObject *)self, ind);
         if (view == NULL) {
             goto fail;
@@ -2636,6 +2643,7 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
                                      NPY_ITER_BUFFERED |
                                      NPY_ITER_DELAY_BUFALLOC |
                                      NPY_ITER_GROWINNER |
+                                     /* TODO: Just for scipy... */
                                      NPY_ITER_DONT_NEGATE_STRIDES,
                                      /* C-order if extra op is not used */
                                      extra_op_flags ? NPY_KEEPORDER : NPY_CORDER,

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2474,7 +2474,8 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
      */
     if (extra_op != NULL) {
         if (!PyArray_CheckExact(extra_op)) {
-            extra_op = (PyArrayObject *)PyArray_View(extra_op, NULL, NULL);
+            extra_op = (PyArrayObject *)PyArray_View(extra_op, NULL,
+                                                     &PyArray_Type);
             if (extra_op == NULL) {
                 goto fail;
             }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -18,14 +18,26 @@
 #include "lowlevel_strided_loops.h"
 #include "item_selection.h"
 
-#define SOBJ_NOTFANCY 0
-#define SOBJ_ISFANCY 1
-#define SOBJ_BADARRAY 2
-#define SOBJ_TOOMANY 3
-#define SOBJ_LISTTUP 4
 
-static PyObject *
-array_subscript_simple(PyArrayObject *self, PyObject *op, int check_index);
+#define HAS_INTEGER 1
+#define HAS_NEWAXIS 2
+#define HAS_SLICE 4
+#define HAS_ELLIPSIS 8
+/* HAS_FANCY can be mixed with HAS_0D_BOOL, be careful when to use & or == */
+#define HAS_FANCY 16
+#define HAS_BOOL 32
+/* NOTE: Only set if it is neither fancy nor purely integer index! */
+#define HAS_SCALAR_ARRAY 64
+/*
+ * Indicate that this is a fancy index that comes from a 0d boolean.
+ * This means that the index does not operate along a real axis. The
+ * corresponding index type is just HAS_FANCY.
+ */
+#define HAS_0D_BOOL (HAS_FANCY | 128)
+
+
+static int
+_nonzero_indices(PyObject *myBool, PyArrayObject **arrays);
 
 /******************************************************************************
  ***                    IMPLEMENT MAPPING PROTOCOL                          ***
@@ -122,52 +134,6 @@ array_item(PyArrayObject *self, Py_ssize_t _i)
     }
 }
 
-NPY_NO_EXPORT int
-array_ass_item_object(PyArrayObject *self, npy_intp i, PyObject *v)
-{
-    PyArrayObject *tmp;
-    char *item;
-    npy_intp dim0;
-    int ret;
-
-    if (v == NULL) {
-        PyErr_SetString(PyExc_ValueError,
-                        "can't delete array elements");
-        return -1;
-    }
-
-    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
-        return -1;
-    }
-
-    if (PyArray_NDIM(self) == 0) {
-        PyErr_SetString(PyExc_IndexError,
-                        "0-d arrays can't be indexed");
-        return -1;
-    }
-
-
-    /* For multi-dimensional arrays, use CopyObject */
-    if (PyArray_NDIM(self) > 1) {
-        tmp = (PyArrayObject *)array_item_asarray(self, i);
-        if(tmp == NULL) {
-            return -1;
-        }
-        ret = PyArray_CopyObject(tmp, v);
-        Py_DECREF(tmp);
-        return ret;
-    }
-
-    /* Bounds check and get the data pointer */
-    dim0 = PyArray_DIM(self, 0);
-    if (check_and_adjust_index(&i, dim0, 0) < 0) {
-        return -1;
-    }
-    item = PyArray_BYTES(self) + i * PyArray_STRIDE(self, 0);
-
-    return PyArray_SETITEM(self, item, v);
-}
-
 /* -------------------------------------------------------------- */
 
 /*NUMPY_API
@@ -225,7 +191,7 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
      * For setting the array the tuple for transpose is
      * (n2,...,n1+n2-1,0,...,n2-1,n1+n2,...n3-1)
      */
-    n1 = mit->iters[0]->nd_m1 + 1;
+    n1 = mit->nd_fancy;
     n2 = mit->consec; /* axes to insert at */
     n3 = mit->nd;
 
@@ -280,6 +246,13 @@ PyArray_GetMap(PyArrayMapIterObject *mit)
         return NULL;
     }
 
+    if (mit->size == 0) {
+        if (mit->consec) {
+            PyArray_MapIterSwapAxes(mit, &ret, 1);
+        }
+        return ret;
+    }
+
     /*
      * Now just iterate through the new array filling it in
      * with the next object from the original array as
@@ -290,29 +263,36 @@ PyArray_GetMap(PyArrayMapIterObject *mit)
         Py_DECREF(ret);
         return NULL;
     }
-    counter = it->size;
     swap = (PyArray_ISNOTSWAPPED(temp) != PyArray_ISNOTSWAPPED(ret));
     copyswap = PyArray_DESCR(ret)->f->copyswap;
     PyArray_MapIterReset(mit);
-    while (counter--) {
-        copyswap(it->dataptr, mit->dataptr, swap, ret);
-        PyArray_MapIterNext(mit);
-        PyArray_ITER_NEXT(it);
+    if (mit->subspace == NULL) {
+        do {
+            copyswap(it->dataptr, mit->dataptr, swap, ret);
+            PyArray_ITER_NEXT(it);
+        } while (PyArray_MapIterOuterNext(mit));
+    }
+    else {
+        do {
+            counter = mit->subspace->size;
+            PyArray_ITER_RESET(mit->subspace);
+            mit->subspace->dataptr = mit->dataptr;
+            while (counter--) {
+                copyswap(it->dataptr, mit->subspace->dataptr, swap, ret);
+                PyArray_ITER_NEXT(it);
+                PyArray_ITER_NEXT(mit->subspace);
+            }
+        } while (PyArray_MapIterOuterNext(mit));
     }
     Py_DECREF(it);
 
     /* check for consecutive axes */
-    if ((mit->subspace != NULL) && (mit->consec)) {
+    if (mit->consec) {
         PyArray_MapIterSwapAxes(mit, &ret, 1);
     }
     return (PyObject *)ret;
 }
 
-NPY_NO_EXPORT int
-array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
-{
-    return array_ass_item_object(self, (npy_intp) i, v);
-}
 
 static int
 PyArray_SetMap(PyArrayMapIterObject *mit, PyObject *op)
@@ -389,223 +369,665 @@ PyArray_SetMap(PyArrayMapIterObject *mit, PyObject *op)
     }
 }
 
+
+/*
+ * This function handles all index preparations with the exception
+ * of field access. It fills the array of index_info structs correctly.
+ * It already handles the boolean array special case for fancy indexing,
+ * i.e. if the index type is boolean, it is exactly one matching boolean
+ * array. If the index type is fancy, the boolean array is already
+ * converted to single arrays. There is (as before) no checking of the
+ * boolean dimension. For this to be implemented, the index_info struct
+ * would require a new field to save the original corresponding shape.
+ *
+ * Checks everything but the bounds.
+ *
+ * Returns the index_type or -1 on failure and fills the number of indices.
+ */
 NPY_NO_EXPORT int
-count_new_axes_0d(PyObject *tuple)
-{
-    int i, argument_count;
-    int ellipsis_count = 0;
-    int newaxis_count = 0;
+prepare_index(PyArrayObject *self, PyObject *index,
+              npy_index_info *indices,
+              int *num, int *ndim, int allow_boolean) {
+    int new_ndim, used_ndim, fancy_ndim, index_ndim;
+    int curr_idx, get_idx;
 
-    argument_count = PyTuple_GET_SIZE(tuple);
-    for (i = 0; i < argument_count; ++i) {
-        PyObject *arg = PyTuple_GET_ITEM(tuple, i);
-        if (arg == Py_Ellipsis && !ellipsis_count) {
-            ellipsis_count++;
-        }
-        else if (arg == Py_None) {
-            newaxis_count++;
-        }
-        else {
-            break;
-        }
-    }
-    if (i < argument_count) {
-        PyErr_SetString(PyExc_IndexError,
-                        "0-d arrays can only use a single ()"
-                        " or a list of newaxes (and a single ...)"
-                        " as an index");
-        return -1;
-    }
-    if (newaxis_count > NPY_MAXDIMS) {
-        PyErr_SetString(PyExc_IndexError, "too many dimensions");
-        return -1;
-    }
-    return newaxis_count;
-}
+    npy_intp i, n;
 
-NPY_NO_EXPORT PyObject *
-add_new_axes_0d(PyArrayObject *arr,  int newaxis_count)
-{
-    PyArrayObject *ret;
-    npy_intp dimensions[NPY_MAXDIMS];
-    int i;
+    npy_bool make_tuple = 0;
+    PyObject *obj = NULL;
+    PyArrayObject *arr;
+    PyArrayObject *nonzero_result[NPY_MAXDIMS];
 
-    for (i = 0; i < newaxis_count; ++i) {
-        dimensions[i]  = 1;
-    }
-    Py_INCREF(PyArray_DESCR(arr));
-    ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(arr),
-                                PyArray_DESCR(arr),
-                                newaxis_count, dimensions,
-                                NULL, PyArray_DATA(arr),
-                                PyArray_FLAGS(arr),
-                                (PyObject *)arr);
-    if (ret == NULL) {
-        return NULL;
-    }
+    int index_type = 0;
+    int ellipsis_pos = -1;
 
-    Py_INCREF(arr);
-    if (PyArray_SetBaseObject(ret, (PyObject *)arr) < 0) {
-        Py_DECREF(ret);
-        return NULL;
-    }
-
-    return (PyObject *)ret;
-}
-
-
-/* This checks the args for any fancy indexing objects */
-
-static int
-fancy_indexing_check(PyObject *args)
-{
-    int i, n;
-    int retval = SOBJ_NOTFANCY;
-
-    if (PyTuple_Check(args)) {
-        n = PyTuple_GET_SIZE(args);
-        if (n >= NPY_MAXDIMS) {
-            return SOBJ_TOOMANY;
-        }
-        for (i = 0; i < n; i++) {
-            PyObject *obj = PyTuple_GET_ITEM(args,i);
-            if (PyArray_Check(obj)) {
-                int type_num = PyArray_DESCR((PyArrayObject *)obj)->type_num;
-                if (PyTypeNum_ISINTEGER(type_num) ||
-                                        PyTypeNum_ISBOOL(type_num)) {
-                    retval = SOBJ_ISFANCY;
-                }
-                else {
-                    retval = SOBJ_BADARRAY;
-                    break;
-                }
-            }
-            else if (PySequence_Check(obj)) {
-                retval = SOBJ_ISFANCY;
-            }
-        }
-    }
-    else if (PyArray_Check(args)) {
-        int type_num = PyArray_DESCR((PyArrayObject *)args)->type_num;
-        if (PyTypeNum_ISINTEGER(type_num) || PyTypeNum_ISBOOL(type_num)) {
-            return SOBJ_ISFANCY;
-        }
-        else {
-            return SOBJ_BADARRAY;
-        }
-    }
-    else if (PySequence_Check(args)) {
+    /*
+     * The index might be a multi-dimensional index, but not yet a tuple
+     * this makes it a tuple in that case.
+     *
+     * TODO: Refactor into its own function.
+     */
+    if ((!PyTuple_Check(index))
+            && (!PyArray_Check(index))
+            && (PySequence_Check(index))) {
         /*
          * Sequences < NPY_MAXDIMS with any slice objects
          * or newaxis, or Ellipsis is considered standard
          * as long as there are also no Arrays and or additional
          * sequences embedded.
+         *
+         * This check is historically as is.
          */
-        retval = SOBJ_ISFANCY;
-        n = PySequence_Size(args);
+
+        n = PySequence_Size(index);
         if (n < 0 || n >= NPY_MAXDIMS) {
-            return SOBJ_ISFANCY;
+            n = 0;
         }
         for (i = 0; i < n; i++) {
-            PyObject *obj = PySequence_GetItem(args, i);
+            PyObject *obj = PySequence_GetItem(index, i);
             if (obj == NULL) {
-                return SOBJ_ISFANCY;
+                make_tuple = 1;
+                break;
             }
-            if (PyArray_Check(obj)) {
-                int type_num = PyArray_DESCR((PyArrayObject *)obj)->type_num;
-                if (PyTypeNum_ISINTEGER(type_num) ||
-                                            PyTypeNum_ISBOOL(type_num)) {
-                    retval = SOBJ_LISTTUP;
-                }
-                else {
-                    retval = SOBJ_BADARRAY;
-                }
-            }
-            else if (PySequence_Check(obj)) {
-                retval = SOBJ_LISTTUP;
-            }
-            else if (PySlice_Check(obj) || obj == Py_Ellipsis ||
-                                                    obj == Py_None) {
-                retval = SOBJ_NOTFANCY;
+            if (PyArray_Check(obj) || PySequence_Check(obj)
+                    || PySlice_Check(obj) || obj == Py_Ellipsis
+                    || obj == Py_None) {
+                make_tuple = 1;
+                Py_DECREF(obj);
+                break;
             }
             Py_DECREF(obj);
-            if (retval > SOBJ_ISFANCY) {
-                return retval;
+        }
+
+        if (make_tuple) {
+            /* We want to interpret it as a tuple, so make it one */
+            index = PySequence_Tuple(index);
+            if (index == NULL) {
+                return -1;
             }
         }
     }
-    return retval;
-}
 
-/*
- * Called when treating array object like a mapping -- called first from
- * Python when using a[object] unless object is a standard slice object
- * (not an extended one).
- *
- * There are two situations:
- *
- *   1 - the subscript is a standard view and a reference to the
- *   array can be returned
- *
- *   2 - the subscript uses Boolean masks or integer indexing and
- *   therefore a new array is created and returned.
- */
+    /* If the index is not a tuple, handle it the same as (index,) */
+    if (!PyTuple_Check(index)) {
+        obj = index;
+        index_ndim = 1;
+    }
+    else {
+        n = PyTuple_GET_SIZE(index);
+        if (n > NPY_MAXDIMS * 2) {
+            PyErr_SetString(PyExc_IndexError,
+                            "too many indices for array");
+            goto fail;
+        }
+        index_ndim = (int)n;
+        obj = NULL;
+    }
 
-NPY_NO_EXPORT PyObject *
-array_subscript_simple(PyArrayObject *self, PyObject *op, int check_index)
-{
-    npy_intp dimensions[NPY_MAXDIMS], strides[NPY_MAXDIMS];
-    npy_intp offset;
-    int nd;
-    PyArrayObject *ret;
-    npy_intp value;
+    /*
+     * Parse all indices into the `indices` array of index_info structs
+     */
+    used_ndim = 0;
+    new_ndim = 0;
+    fancy_ndim = 0;
+    get_idx = 0;
+    curr_idx = 0;
 
-    if (!(PyArray_Check(op) && (PyArray_SIZE((PyArrayObject*)op) > 1))) {
-        value = PyArray_PyIntAsIntp(op);
+    while (get_idx < index_ndim) {
+        if (curr_idx > NPY_MAXDIMS * 2) {
+            PyErr_SetString(PyExc_IndexError,
+                            "too many indices for array");
+            goto failed_building_indices;
+        }
 
-        if (value == -1 && PyErr_Occurred()) {
-            if (PyErr_ExceptionMatches(PyExc_TypeError)) {
-                /* Operand is not an integer type */
+        /* Check for single index. obj is already set then. */
+        if ((curr_idx != 0) || (obj == NULL)) {
+            obj = PyTuple_GET_ITEM(index, get_idx++);
+        }
+        else {
+            get_idx += 1; /* only one loop */
+        }
+
+        /**** Try the cascade of possible indices ****/
+
+        /* Index is an ellipsis (`...`) */
+        if (obj == Py_Ellipsis) {
+            /*
+             * If there is more then one Ellipsis, it is replaced. Deprecated,
+             * since it is hard to imagine anyone using two Ellipsis and
+             * actually planning on all but the first being automatically
+             * replaced with a slice.
+             */
+            if (index_type & HAS_ELLIPSIS) {
+                if (DEPRECATE(
+                        "an index can only have a single Ellipsis (`...`); "
+                        "replace all but one with slices (`:`).") < 0) {
+                    goto failed_building_indices;
+                }
+                index_type |= HAS_SLICE;
+
+                indices[curr_idx].type = HAS_SLICE;
+                indices[curr_idx].object = PySlice_New(NULL, NULL, NULL);
+
+                if (indices[curr_idx].object == NULL) {
+                    goto failed_building_indices;
+                }
+
+                used_ndim += 1;
+                new_ndim += 1;
+                curr_idx += 1;
+                continue;
+            }
+            index_type |= HAS_ELLIPSIS;
+
+            indices[curr_idx].type = HAS_ELLIPSIS;
+            indices[curr_idx].object = NULL;
+            /* number of slices it is worth, won't update if it is 0: */
+            indices[curr_idx].value = 0;
+
+            ellipsis_pos = curr_idx;
+            used_ndim += 0; /* We don't know yet */
+            used_ndim += 0;
+            curr_idx += 1;
+            continue;
+        }
+
+        /* Index is np.newaxis/None */
+        else if (obj == Py_None) {
+            index_type |= HAS_NEWAXIS;
+
+            indices[curr_idx].type = HAS_NEWAXIS;
+            indices[curr_idx].object = NULL;
+
+            used_ndim += 0;
+            new_ndim += 1;
+            curr_idx += 1;
+            continue;
+        }
+
+        /*
+         * Single integer index, there are two cases here.
+         * It could be an array, a 0-d array is handled
+         * a bit weird however, so need to special case it.
+         */
+        else if (PyInt_CheckExact(obj) || !PyArray_Check(obj)) {
+            i = PyArray_PyIntAsIntp(obj);
+            if ((i == -1) && PyErr_Occurred()) {
                 PyErr_Clear();
             }
             else {
-                PyErr_SetString(PyExc_IndexError,
-                                "cannot convert index to integer");
-                return NULL;
+                index_type |= HAS_INTEGER;
+                indices[curr_idx].object = NULL;
+                indices[curr_idx].value = i;
+                indices[curr_idx].type = HAS_INTEGER;
+                used_ndim += 1;
+                new_ndim += 0;
+                curr_idx += 1;
+                continue;
+            }
+        }
+        else if (PyArray_NDIM((PyArrayObject *)obj) == 0) {
+             i = PyArray_PyIntAsIntp(obj);
+             if ((i == -1) && PyErr_Occurred()) {
+                 PyErr_Clear();
+             }
+             else {
+                 index_type |= (HAS_INTEGER | HAS_SCALAR_ARRAY);
+                 indices[curr_idx].object = NULL;
+                 indices[curr_idx].value = i;
+                 indices[curr_idx].type = HAS_INTEGER;
+                 used_ndim += 1;
+                 new_ndim += 0;
+                 curr_idx += 1;
+                 continue;
+             }
+        }
+
+        /* Index is a slice object. (Not else, int check is a try/except) */
+        if (PySlice_Check(obj)) {
+            index_type |= HAS_SLICE;
+
+            Py_INCREF(obj);
+            indices[curr_idx].object = obj;
+            indices[curr_idx].type = HAS_SLICE;
+            used_ndim += 1;
+            new_ndim += 1;
+            curr_idx += 1;
+            continue;
+        }
+
+        /*
+         * At this point, we must have an index array (or array-like).
+         * It might still be a (purely) bool special case though.
+         * (Or complete nonsense...)
+         */
+        index_type |= HAS_FANCY;
+        indices[curr_idx].type = HAS_FANCY;
+        indices[curr_idx].object = NULL;
+
+        if (!PyArray_Check(obj)) {
+            PyObject *tmp_arr;
+            tmp_arr = PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
+            if (tmp_arr == NULL) {
+                /* TODO: Should maybe replace the error here? */
+                goto failed_building_indices;
+            }
+
+            /*
+             * For example an empty list can be cast to an integer array,
+             * however it will default to a float one.
+             */
+            if (PyArray_SIZE((PyArrayObject *)tmp_arr) == 0) {
+                PyArray_Descr *indtype = PyArray_DescrFromType(NPY_INTP);
+                /* TODO: Is the force-cast the right way? */
+                arr = (PyArrayObject *)PyArray_FromAny(tmp_arr, indtype, 0, 0,
+                                        NPY_ARRAY_FORCECAST, NULL);
+                if (arr == NULL) {
+                    Py_DECREF(tmp_arr);
+                    goto failed_building_indices;
+                }
+            }
+            else {
+                /*
+                 * These Checks can be removed after deprecation, since
+                 * they should then be either correct already or error out
+                 * later just like a normal array.
+                 */
+                if (PyArray_ISBOOL((PyArrayObject *)tmp_arr)) {
+                    if (DEPRECATE_FUTUREWARNING(
+                            "in the future, boolean array-likes will be "
+                            "handled as a boolean array index") < 0) {
+                        Py_DECREF(tmp_arr);
+                        goto failed_building_indices;  
+                    }
+                }
+                else if (!PyArray_ISINTEGER((PyArrayObject *)tmp_arr)) {
+                    if (DEPRECATE(
+                            "non integer (and non boolean) array-likes will "
+                            "not be accepted as indices in the future") < 0) {
+
+                        /*
+                         * raise ValueError, similar to conversion failure
+                         * (do not actually attempt it, because it might
+                         * actually work for example for strings)
+                         */
+                        if (PyArray_NDIM(tmp_arr) == 0) {
+                            PyErr_SetString(PyExc_IndexError,
+                                "only integers, slices (`:`), ellipsis (`...`), "
+                                "numpy.newaxis (`None`) and integer or boolean "
+                                "arrays are valid indices.");
+                        }
+                        else {
+                            PyErr_SetString(PyExc_IndexError,
+                                "non integer (and non boolean) array-likes will "
+                                "not be accepted as indices in the future");
+                        }
+                        Py_DECREF(tmp_arr);
+                        goto failed_building_indices;  
+                    }
+                }
+
+                PyArray_Descr *indtype = PyArray_DescrFromType(NPY_INTP);
+                arr = (PyArrayObject *)PyArray_FromAny(tmp_arr, indtype, 0, 0,
+                                        NPY_ARRAY_FORCECAST, NULL);
+
+                if (arr == NULL) {
+                    /* Since this will be removed, handle this later */
+                    PyErr_Clear();
+                    arr = tmp_arr;
+                }
             }
         }
         else {
-            return array_item_asarray(self, value);
+            Py_INCREF(obj);
+            arr = (PyArrayObject *)obj;
+        }
+
+        /* Check if the array is valid and fill the information */
+        if PyArray_ISBOOL(arr) {
+            /*
+             * There are two types of boolean indices (which are equivalent,
+             * for the most part though). A single boolean index of matching
+             * dimensionality and size is a boolean index.
+             * If this is not the case, it is instead expanded into (multiple)
+             * integer array indices.
+             */
+            if ((index_ndim == 1) && allow_boolean) {
+                /*
+                 * If ndim and size match, this can be optimized as a single
+                 * boolean index. The size check is necessary only to support
+                 * old non-matching sizes by using fancy indexing instead.
+                 * The reason for that is that fancy indexing uses nonzero,
+                 * and only the result of nonzero is checked for legality.
+                 */
+                if ((PyArray_NDIM(arr) == PyArray_NDIM(self))
+                        && PyArray_SIZE(arr) == PyArray_SIZE(self)) {
+
+                    index_type = HAS_BOOL;
+                    indices[curr_idx].type = HAS_BOOL;
+                    indices[curr_idx].object = (PyObject *)arr;
+
+                    /* keep track anyway, even if it is trivial */
+                    used_ndim = PyArray_NDIM(self);
+                    fancy_ndim = PyArray_NDIM(self);
+                    curr_idx += 1;
+                    break;
+                }
+            }
+
+            if (PyArray_NDIM(arr) == 0) {
+                /*
+                 * TODO, WARNING: This code block cannot be used due to
+                 *                FutureWarnings at this time. So instead
+                 *                just raise an IndexError.
+                 */
+                PyErr_SetString(PyExc_IndexError,
+                        "in the future, 0-d boolean arrays will be "
+                        "interpreted as a valid boolean index");
+                goto failed_building_indices;
+                /*
+                 * This can actually be well defined. A new axis is added,
+                 * but at the same time no axis is "used". So if we have True,
+                 * we add a new axis (a bit like with np.newaxis). If it is
+                 * False, we add a new axis, but this axis has 0 entries.
+                 */
+
+                indices[curr_idx].type = HAS_0D_BOOL;
+
+                /* TODO: This can't fail, right? Is there a faster way? */
+                if (PyObject_IsTrue(arr)) {
+                    n = 1;
+                }
+                else {
+                    n = 0;
+                }
+                indices[curr_idx].object = PyArray_Zeros(1, &n,
+                                            PyArray_DescrFromType(NPY_INTP), 0);
+                if (indices[curr_idx].object == NULL) {
+                    goto failed_building_indices;
+                }
+
+                used_ndim += 0;
+                if (fancy_ndim < 1) {
+                    fancy_ndim = 1;
+                }
+                curr_idx += 1;
+                continue;
+            }
+
+            /* Convert the boolean array into multiple integer ones */
+            n = _nonzero_indices(arr, nonzero_result);
+            if (n < 0) {
+                goto failed_building_indices;
+            }
+
+            /* Check that we will not run out of indices to store new ones */
+            if (curr_idx + n >= NPY_MAXDIMS * 2) {
+                PyErr_SetString(PyExc_IndexError,
+                                "too many indices for array");
+                goto failed_building_indices;
+            }
+
+            /* Add the arrays from the nonzero result to the index */
+            for (i=0; i < n; i++) {
+                indices[curr_idx].type = HAS_FANCY;
+                indices[curr_idx].object = (PyObject *)nonzero_result[i];
+
+                used_ndim += 1;
+                curr_idx += 1;
+            }
+
+            /* All added indices have 1 dimension */
+            if (fancy_ndim < 1) {
+                fancy_ndim = 1;
+            }
+            continue;
+        }
+
+        /* Normal case of an integer array */
+        else if PyArray_ISINTEGER(arr) {
+            indices[curr_idx].object = (PyObject *)arr;
+
+            used_ndim += 1;
+            if (fancy_ndim < PyArray_NDIM(arr)) {
+                fancy_ndim = PyArray_NDIM(arr);
+            }
+            curr_idx += 1;
+            continue;
+        }
+
+        /*
+         * The array does not have a valid type.
+         */
+        if (arr == obj) {
+            /* The input was an array already */
+            PyErr_SetString(PyExc_IndexError,
+                "arrays used as indices must be of integer (or boolean) type");
+        }
+        else {
+            /* The input was not an array, so give a general error message */
+            PyErr_SetString(PyExc_IndexError,
+                    "only integers, slices (`:`), ellipsis (`...`), "
+                    "numpy.newaxis (`None`) and integer or boolean "
+                    "arrays are valid indices.");
+        }
+        goto failed_building_indices;
+    }
+
+    /*
+     * Compare dimension of the index to the real dimension, this is
+     * to find the ellipsis value or append an ellipsis if necessary.
+     */
+    if (used_ndim < PyArray_NDIM(self)) {
+       if (index_type & HAS_ELLIPSIS) {
+           indices[ellipsis_pos].value = PyArray_NDIM(self) - used_ndim;
+           used_ndim = PyArray_NDIM(self);
+           new_ndim += indices[ellipsis_pos].value;
+       }
+       else {
+           /*
+            * There is no ellipsis yet, but it is not a full index
+            * so we append an ellipsis to the end.
+            */
+           index_type |= HAS_ELLIPSIS;
+           indices[curr_idx].object = NULL;
+           indices[curr_idx].type = HAS_ELLIPSIS;
+           indices[curr_idx].value = PyArray_NDIM(self) - used_ndim;
+           ellipsis_pos = curr_idx;
+
+           used_ndim = PyArray_NDIM(self);
+           new_ndim += indices[curr_idx].value;
+           curr_idx += 1;
+       }
+    }
+    else if (used_ndim > PyArray_NDIM(self)) {
+        PyErr_SetString(PyExc_IndexError,
+                        "too many indices for array");
+        goto failed_building_indices;
+    }
+    else if (index_ndim == 0) {
+        /*
+         * 0-d index into 0-d array, i.e. array[()]
+         * We consider this an integer index. Which means it will return
+         * the scalar.
+         * This makes sense, because then array[...] gives
+         * an array and array[()] gives the scalar.
+         */
+        used_ndim = 0;
+        index_type = HAS_INTEGER;
+    }
+
+    /* HAS_SCALAR_ARRAY requires cleaning up the index_type */
+    if (index_type & HAS_SCALAR_ARRAY) {
+        /* clear as info is unnecessary and makes life harder later */
+        if (index_type & HAS_FANCY) {
+            index_type -= HAS_SCALAR_ARRAY;
+        }
+        /* A full integer index sees array scalars as part of itself */
+        else if (index_type == (HAS_INTEGER | HAS_SCALAR_ARRAY)) {
+            index_type -= HAS_SCALAR_ARRAY;
         }
     }
 
-    /* Standard (view-based) Indexing */
-    nd = parse_index(self, op, dimensions,
-                     strides, &offset, check_index);
-    if (nd == -1) {
-        return NULL;
+    /*
+     * At this point indices are all set correctly, no bounds checking
+     * has been made and the new array may still have more dimensions
+     * then is possible.
+     *
+     * Check this now so we do not have to worry about it later.
+     * It can happen for fancy indexing or with newaxis.
+     * This means broadcasting errors in the case of too many dimensions
+     * take less priority.
+     */
+    if (index_type & (HAS_NEWAXIS | HAS_FANCY)) {
+        if (new_ndim + fancy_ndim > NPY_MAXDIMS) {
+            PyErr_Format(PyExc_IndexError,
+                         "number of dimensions must be within [0, %d], "
+                         "indexed array has %d",
+                         NPY_MAXDIMS, (new_ndim + fancy_ndim));
+            goto failed_building_indices;
+        }
     }
 
-    /* Create a view using the indexing result */
-    Py_INCREF(PyArray_DESCR(self));
-    ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self),
-                                PyArray_DESCR(self),
-                                nd, dimensions,
-                                strides, PyArray_BYTES(self) + offset,
-                                PyArray_FLAGS(self),
-                                (PyObject *)self);
-    if (ret == NULL) {
-        return NULL;
-    }
-    Py_INCREF(self);
-    if (PyArray_SetBaseObject(ret, (PyObject *)self) < 0) {
-        Py_DECREF(ret);
-        return NULL;
-    }
-    PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
+    *num = curr_idx;
+    *ndim = new_ndim + fancy_ndim;
 
-    return (PyObject *)ret;
+    if (make_tuple) {
+        Py_DECREF(index);
+    }
+
+    return index_type;
+
+  failed_building_indices:
+    for (i=0; i < curr_idx; i++) {
+        Py_XDECREF(indices[i].object);
+    }
+  fail:
+    if (make_tuple) {
+        Py_DECREF(index);
+    }
+    return -1;
 }
+
+
+/*
+ * For a purely integer index, set ptr to the memory address.
+ * Returns 0 on success, -1 on failure.
+ * The caller must ensure that the index is a full integer
+ * one.
+ */
+static int
+get_item_pointer(PyArrayObject *self, char **ptr,
+                    npy_index_info *indices, int index_num) {
+    int i;
+    *ptr = PyArray_BYTES(self);
+    for (i=0; i < index_num; i++) {
+        if ((check_and_adjust_index(&(indices[i].value),
+                               PyArray_DIMS(self)[i], i)) < 0) {
+            return -1;
+        }
+        *ptr += PyArray_STRIDE(self, i) * indices[i].value;
+    }
+    return 0;
+}
+
+/*
+ * For any index, get a view of the subspace into the original
+ * array. If there are no fancy indices, this is the result of
+ * the indexing operation.
+ */
+static int
+get_view_from_index(PyArrayObject *self, PyArrayObject **view,
+                    npy_index_info *indices, int index_num, int ensure_array) {
+    npy_intp new_strides[NPY_MAXDIMS];
+    npy_intp new_shape[NPY_MAXDIMS];
+    int i, j;
+    int new_dim = 0;
+    int orig_dim = 0;
+    char *data_ptr = PyArray_BYTES(self);
+
+    npy_intp start, stop, step, n_steps; /* for slice parsing */
+
+    for (i=0; i < index_num; i++) {
+        switch (indices[i].type) {
+            case HAS_INTEGER:
+                if ((check_and_adjust_index(&indices[i].value,
+                                    PyArray_DIMS(self)[orig_dim], i)) < 0) {
+                    return -1;
+                }
+                data_ptr += PyArray_STRIDE(self, orig_dim) * indices[i].value;
+
+                new_dim += 0;
+                orig_dim += 1;
+                break;
+            case HAS_ELLIPSIS:
+                for (j=0; j < indices[i].value; j++) {
+                    new_strides[new_dim] = PyArray_STRIDE(self, orig_dim);
+                    new_shape[new_dim] = PyArray_DIMS(self)[orig_dim];
+                    new_dim += 1;
+                    orig_dim += 1;
+                }
+                break;
+            case HAS_SLICE:
+                if (slice_GetIndices((PySliceObject *)indices[i].object,
+                                     PyArray_DIMS(self)[orig_dim],
+                                     &start, &stop, &step, &n_steps) < 0) {
+                    if (!PyErr_Occurred()) {
+                        PyErr_SetString(PyExc_IndexError,
+                                        "invalid slice");
+                    }
+                    return -1;
+                }
+                if (n_steps <= 0) {
+                    n_steps = 0;
+                    step = 1;
+                    start = 0;
+                }
+
+                data_ptr += PyArray_STRIDE(self, orig_dim) * start;
+                new_strides[new_dim] = PyArray_STRIDE(self, orig_dim) * step;
+                new_shape[new_dim] = n_steps;
+                new_dim += 1;
+                orig_dim += 1;
+                break;
+            case HAS_NEWAXIS:
+                new_strides[new_dim] = 0;
+                new_shape[new_dim] = 1;
+                new_dim += 1;
+                break;
+            /* Fancy and 0-d boolean indices are ignored here */
+            case HAS_0D_BOOL:
+                break;
+            default:
+                new_dim += 0;
+                orig_dim += 1;
+                break;
+        }
+    }
+
+    /* Create the new view and set the base array */
+    Py_INCREF(PyArray_DESCR(self));
+    *view = (PyArrayObject *)PyArray_NewFromDescr(
+                                ensure_array ? &PyArray_Type : Py_TYPE(self),
+                                PyArray_DESCR(self),
+                                new_dim, new_shape,
+                                new_strides, data_ptr,
+                                PyArray_FLAGS(self),
+                                ensure_array ? NULL : (PyObject *)self);
+    if (*view == NULL) {
+        return -1;
+    }
+
+    Py_INCREF(self);
+    if (PyArray_SetBaseObject(*view, (PyObject *)self) < 0) {
+        Py_DECREF(*view);
+        return -1;
+    }
+    /* TODO: Don't have to update all? */
+    PyArray_UpdateFlags(*view, NPY_ARRAY_UPDATE_ALL);
+    return 0;
+}
+
 
 /*
  * Implements boolean indexing. This produces a one-dimensional
@@ -626,30 +1048,9 @@ array_boolean_subscript(PyArrayObject *self,
     PyArray_Descr *dtype;
     PyArrayObject *ret;
     int needs_api = 0;
-    npy_intp bmask_size;
-
-    if (PyArray_DESCR(bmask)->type_num != NPY_BOOL) {
-        PyErr_SetString(PyExc_TypeError,
-                "NumPy boolean array indexing requires a boolean index");
-        return NULL;
-    }
-
-    if (PyArray_NDIM(bmask) != PyArray_NDIM(self)) {
-        PyErr_SetString(PyExc_ValueError,
-                "The boolean mask assignment indexing array "
-                "must have the same number of dimensions as "
-                "the array being indexed");
-        return NULL;
-    }
-
 
     size = count_boolean_trues(PyArray_NDIM(bmask), PyArray_DATA(bmask),
                                 PyArray_DIMS(bmask), PyArray_STRIDES(bmask));
-    /* Correction factor for broadcasting 'bmask' to 'self' */
-    bmask_size = PyArray_SIZE(bmask);
-    if (bmask_size > 0) {
-        size *= PyArray_SIZE(self) / bmask_size;
-    }
 
     /* Allocate the output of the boolean indexing */
     dtype = PyArray_DESCR(self);
@@ -901,111 +1302,6 @@ array_ass_boolean_subscript(PyArrayObject *self,
 }
 
 
-/* Check if ind is a tuple and if it has as many elements as arr has axes. */
-static NPY_INLINE int
-_is_full_index(PyObject *ind, PyArrayObject *arr)
-{
-    return PyTuple_Check(ind) && (PyTuple_GET_SIZE(ind) == PyArray_NDIM(arr));
-}
-
-/*
- * Returns 0 if tuple-object seq is not a tuple of integers.
- * If the return value is positive, vals will be filled with the elements
- * from the tuple.
- */
-static int
-_tuple_of_integers(PyObject *seq, npy_intp *vals, int maxvals)
-{
-    int i;
-    PyObject *obj;
-    npy_intp temp;
-
-    for(i=0; i<maxvals; i++) {
-        obj = PyTuple_GET_ITEM(seq, i);
-        if ((PyArray_Check(obj) && PyArray_NDIM((PyArrayObject *)obj) > 0)
-                || PyList_Check(obj)) {
-            return 0;
-        }
-        temp = PyArray_PyIntAsIntp(obj);
-        if (error_converting(temp)) {
-            PyErr_Clear();
-            return 0;
-        }
-        vals[i] = temp;
-    }
-    return 1;
-}
-
-
-/* return TRUE if ellipses are found else return FALSE */
-static npy_bool
-_check_ellipses(PyObject *op)
-{
-    if ((op == Py_Ellipsis) || PyString_Check(op) || PyUnicode_Check(op)) {
-        return NPY_TRUE;
-    }
-    else if (PyBool_Check(op) || PyArray_IsScalar(op, Bool) ||
-             (PyArray_Check(op) &&
-                (PyArray_DIMS((PyArrayObject *)op)==0) &&
-                 PyArray_ISBOOL((PyArrayObject *)op))) {
-        return NPY_TRUE;
-    }
-    else if (PySequence_Check(op)) {
-        Py_ssize_t n, i;
-        PyObject *temp;
-
-        n = PySequence_Size(op);
-        i = 0;
-        while (i < n) {
-            temp = PySequence_GetItem(op, i);
-            if (temp == Py_Ellipsis) {
-                Py_DECREF(temp);
-                return NPY_TRUE;
-            }
-            Py_DECREF(temp);
-            i++;
-        }
-    }
-    return NPY_FALSE;
-}
-
-NPY_NO_EXPORT PyObject *
-array_subscript_fancy(PyArrayObject *self, PyObject *op, int fancy)
- {
-    int oned;
-    PyObject *other;
-    PyArrayMapIterObject *mit;
-
-    oned = ((PyArray_NDIM(self) == 1) &&
-            !(PyTuple_Check(op) && PyTuple_GET_SIZE(op) > 1));
-
-    /* wrap arguments into a mapiter object */
-    mit = (PyArrayMapIterObject *) PyArray_MapIterNew(op, oned, fancy);
-    if (mit == NULL) {
-        return NULL;
-    }
-    if (oned) {
-        PyArrayIterObject *it;
-        PyObject *rval;
-        it = (PyArrayIterObject *) PyArray_IterNew((PyObject *)self);
-        if (it == NULL) {
-            Py_DECREF(mit);
-            return NULL;
-        }
-        rval = iter_subscript(it, mit->indexobj);
-        Py_DECREF(it);
-        Py_DECREF(mit);
-        return rval;
-    }
-    if (PyArray_MapIterBind(mit, self) != 0) {
-        Py_DECREF(mit);
-        return NULL;
-    }
-    other = (PyObject *)PyArray_GetMap(mit);
-    Py_DECREF(mit);
-    return other;
-}
-
 /* make sure subscript always returns an array object */
 NPY_NO_EXPORT PyObject *
 array_subscript_asarray(PyArrayObject *self, PyObject *op)
@@ -1014,45 +1310,20 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
 }
 
 NPY_NO_EXPORT PyObject *
-array_subscript_fromobject(PyArrayObject *self, PyObject *op)
+array_subscript(PyArrayObject *self, PyObject *op)
 {
-    int fancy;
-    npy_intp vals[NPY_MAXDIMS];
+    int index_type;
+    int index_num;
+    int i, ndim, fancy;
+    /*
+     * Index info array. We can have twice as many indices as dimensions
+     * (because of None). The + 1 is to not need to check as much.
+     */
+    npy_index_info indices[NPY_MAXDIMS * 2 + 1];
 
-    /* Integer index */
-    if (PyArray_IsIntegerScalar(op) || (PyIndex_Check(op) &&
-                                    !PySequence_Check(op))) {
-        npy_intp value = PyArray_PyIntAsIntp(op);
-        if (value == -1 && PyErr_Occurred()) {
-            /* fail on error */
-            PyErr_SetString(PyExc_IndexError,
-                            "cannot convert index to integer");
-            return NULL;
-        }
-        else {
-            return array_item(self, (Py_ssize_t) value);
-        }
-    }
-    /* optimization for a tuple of integers */
-    if (PyArray_NDIM(self) > 1 && _is_full_index(op, self)) {
-        int ret = _tuple_of_integers(op, vals, PyArray_NDIM(self));
-
-        if (ret > 0) {
-            int idim, ndim = PyArray_NDIM(self);
-            npy_intp *shape = PyArray_DIMS(self);
-            npy_intp *strides = PyArray_STRIDES(self);
-            char *item = PyArray_BYTES(self);
-            for (idim = 0; idim < ndim; idim++) {
-                npy_intp v = vals[idim];
-                if (check_and_adjust_index(&v, shape[idim], idim) < 0) {
-                  return NULL;
-                }
-                item += v * strides[idim];
-            }
-            return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
-        }
-    }
-
+    PyArrayObject *view = NULL;
+    PyObject *result = NULL;
+    
     /* Check for single field access */
     if (PyString_Check(op) || PyUnicode_Check(op)) {
         PyObject *temp, *obj;
@@ -1121,209 +1392,117 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
         }
     }
 
-    /* Check for Ellipsis index */
-    if (op == Py_Ellipsis) {
-        Py_INCREF(self);
-        return (PyObject *)self;
-    }
+    /* Prepare the indices */
+    //printf("preparing indices for getting\n");
+    index_type = prepare_index(self, op, indices, &index_num, &ndim, 1);
+    //PyObject_Print(op, stdout, 0);
+    //printf("getting index_type %d, index_num %d, ndim %d\n", index_type, index_num, ndim);
 
-    if (PyArray_NDIM(self) == 0) {
-        int nd;
-        /* Check for None index */
-        if (op == Py_None) {
-            return add_new_axes_0d(self, 1);
-        }
-        /* Check for (empty) tuple index */
-        if (PyTuple_Check(op)) {
-            if (0 == PyTuple_GET_SIZE(op))  {
-                Py_INCREF(self);
-                return (PyObject *)self;
-            }
-            nd = count_new_axes_0d(op);
-            if (nd == -1) {
-                return NULL;
-            }
-            return add_new_axes_0d(self, nd);
-        }
-        /* Allow Boolean mask selection also */
-        if ((PyArray_Check(op) && (PyArray_DIMS((PyArrayObject *)op)==0)
-                                && PyArray_ISBOOL((PyArrayObject *)op))) {
-            if (PyObject_IsTrue(op)) {
-                Py_INCREF(self);
-                return (PyObject *)self;
-            }
-            else {
-                npy_intp oned = 0;
-                Py_INCREF(PyArray_DESCR(self));
-                return PyArray_NewFromDescr(Py_TYPE(self),
-                                            PyArray_DESCR(self),
-                                            1, &oned,
-                                            NULL, NULL,
-                                            NPY_ARRAY_DEFAULT,
-                                            NULL);
-            }
-        }
-        PyErr_SetString(PyExc_IndexError,
-                        "0-dimensional arrays can't be indexed");
+    if (index_type < 0) {
         return NULL;
     }
 
-    fancy = fancy_indexing_check(op);
-    if (fancy != SOBJ_NOTFANCY) {
-        return array_subscript_fancy(self, op, fancy);
-    }
-    else {
-        return array_subscript_simple(self, op, 1);
-    }
-}
-
-NPY_NO_EXPORT PyObject *
-array_subscript(PyArrayObject *self, PyObject *op)
-{
-    int fancy;
-    PyObject *ret = NULL;
-    if (!PyArray_Check(op)) {
-        ret = array_subscript_fromobject(self, op);
-    }
-
-    /* Boolean indexing special case */
-    /* The SIZE check is to ensure old behaviour for non-matching arrays. */
-    else if (PyArray_ISBOOL((PyArrayObject *)op)
-                && (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)op))
-                && (PyArray_SIZE((PyArrayObject *)op) == PyArray_SIZE(self))) {
-        return (PyObject *)array_boolean_subscript(self,
-                                        (PyArrayObject *)op, NPY_CORDER);
-    }
-    /* Error case when indexing 0-dim array with non-boolean. */
-    else if (PyArray_NDIM(self) == 0) {
-        PyErr_SetString(PyExc_IndexError,
-                        "0-dimensional arrays can't be indexed");
-        return NULL;
-    }
-
-    else {
-        fancy = fancy_indexing_check(op);
-        if (fancy != SOBJ_NOTFANCY) {
-            ret = array_subscript_fancy(self, op, fancy);
+    /* Full integer index */
+    if (index_type == HAS_INTEGER) {
+        char *item;
+        if (get_item_pointer(self, &item, indices, index_num) < 0) {
+            goto finish;
         }
-        else {
-            ret = array_subscript_simple(self, op, 1);
+        result = (PyObject *) PyArray_Scalar(item, PyArray_DESCR(self),
+                                             (PyObject *)self);
+        /* Because the index is full integer, we do not need to decref */
+        return result;
+    }
+
+    /* Single boolean array */
+    else if (index_type == HAS_BOOL) {
+        result = (PyObject *)array_boolean_subscript(self,
+                                    (PyArrayObject *)indices[0].object,
+                                    NPY_CORDER);
+        goto finish;
+    }
+
+    /* If it is only a single ellipsis, just return self */
+    else if (index_type == HAS_ELLIPSIS) {
+        /*
+         * TODO: Should this be a view or not? The only reason not would be
+         *       optimization (i.e. of array[...] += 1) I think.
+         *       Before, it was just self for a single Ellipis.
+         */
+        result = PyArray_View(self, NULL, NULL);
+        /* A single ellipsis, so no need to decref */
+        return result;
+    }
+
+    /*
+     * View based indexing.
+     * There are two cases here. First we need to create a simple view,
+     * second we need to create a (possibly invalid) view for the
+     * subspace to the fancy index. This procedure is identical.
+     */
+    else if (index_type & (HAS_SLICE | HAS_NEWAXIS |
+                           HAS_ELLIPSIS | HAS_INTEGER)) {
+        if (get_view_from_index(self, &view, indices, index_num,
+                                (index_type & HAS_FANCY)) < 0) {
+            goto finish;
         }
-    }
-
-    if (ret == NULL) {
-        return NULL;
-    }
-
-    if (PyArray_Check(ret) && PyArray_NDIM((PyArrayObject *)ret) == 0
-                                                && !_check_ellipses(op)) {
-        return PyArray_Return((PyArrayObject *)ret);
-    }
-    return ret;
-}
-
-/*
- * Another assignment hacked by using CopyObject.
- * This only works if subscript returns a standard view.
- * Again there are two cases.  In the first case, PyArray_CopyObject
- * can be used.  In the second case, a new indexing function has to be
- * used.
- */
-
-static int
-array_ass_sub_simple(PyArrayObject *self, PyObject *ind, PyObject *op)
-{
-    int ret;
-    PyArrayObject *tmp;
-    npy_intp value;
-
-    value = PyArray_PyIntAsIntp(ind);
-    if (value == -1 && PyErr_Occurred()) {
-        if (PyErr_ExceptionMatches(PyExc_TypeError)) {
-            /* Operand is not an integer type */
-            PyErr_Clear();
-        }
-        else {
-            return -1;
-        }
-    }
-    else {
-        return array_ass_item_object(self, value, op);
-    }
-
-    /* Rest of standard (view-based) indexing */
-    if (PyArray_CheckExact(self)) {
-        tmp = (PyArrayObject *)array_subscript_simple(self, ind, 1);
-        if (tmp == NULL) {
-            return -1;
-        }
-    }
-    else {
-        PyObject *tmp0;
 
         /*
-         * Note: this code path should never be reached with an index that
-         *       produces scalars -- those are handled earlier in array_ass_sub
+         * There is a scalar array, so we need to force a copy to simulate
+         * fancy indexing.
          */
-
-        tmp0 = PyObject_GetItem((PyObject *)self, ind);
-        if (tmp0 == NULL) {
-            return -1;
+        if (index_type & HAS_SCALAR_ARRAY) {
+            result = PyArray_NewCopy(view, NPY_ANYORDER);
+            goto finish_view;
         }
-        if (!PyArray_Check(tmp0)) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "Getitem not returning array");
-            Py_DECREF(tmp0);
-            return -1;
-        }
-        tmp = (PyArrayObject *)tmp0;
     }
 
-    ret = PyArray_CopyObject(tmp, op);
-    Py_DECREF(tmp);
-    return ret;
-}
+    /* If there is no fancy indexing, we have the result */
+    if (!(index_type & HAS_FANCY)) {
+        result = (PyObject *)view;
+        goto finish;
+    }
 
-static int
-array_ass_sub_fancy(PyArrayObject *self, PyObject *ind, PyObject *op, int fancy)
-{
-    int oned, ret;
-    PyArrayMapIterObject *mit;
-    oned = ((PyArray_NDIM(self) == 1) &&
-            !(PyTuple_Check(ind) && PyTuple_GET_SIZE(ind) > 1));
-    mit = (PyArrayMapIterObject *) PyArray_MapIterNew(ind, oned, fancy);
+    /* fancy indexing has to be used. And view is the subspace. */
+    /* TODO: Add 1-dim and 1 index special case */
+    PyArrayMapIterObject * mit;
+    mit = (PyArrayMapIterObject *)PyArray_MapIterNew(indices,
+                                                     index_num, index_type);
     if (mit == NULL) {
-        return -1;
+        goto finish_view;
     }
-    if (oned) {
-        PyArrayIterObject *it;
-        int rval;
 
-        it = (PyArrayIterObject *)PyArray_IterNew((PyObject *)self);
-        if (it == NULL) {
-            Py_DECREF(mit);
-            return -1;
-        }
-        rval = iter_ass_subscript(it, mit->indexobj, op);
-        Py_DECREF(it);
-        Py_DECREF(mit);
-        return rval;
+    if (PyArray_MapIterBind(mit, view, self, indices, index_num) < 0) {
+        Py_DECREF((PyObject *)mit);
+        goto finish_view;
     }
-    if (PyArray_MapIterBind(mit, self) != 0) {
-        Py_DECREF(mit);
-        return -1;
-    }
-    ret = PyArray_SetMap(mit, op);
+
+    result = (PyObject *)PyArray_GetMap(mit);
     Py_DECREF(mit);
-    return ret;
+    if (result == NULL) {
+        goto finish_view;
+    }
+
+  finish_view:
+    Py_XDECREF(view);
+    /* Clean up indices */
+  finish:
+    for (i=0; i < index_num; i++) {
+        Py_XDECREF(indices[i].object);
+    }
+    return result;
 }
 
 
 static int
 array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
 {
-    int fancy;
-    npy_intp vals[NPY_MAXDIMS];
+    int index_type;
+    int index_num;
+    int i, ndim;
+    PyArrayObject *view = NULL;
+    PyArrayObject *tmp_arr = NULL;
+    npy_index_info indices[NPY_MAXDIMS * 2 + 1];
 
     if (op == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1332,21 +1511,6 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
     }
     if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         return -1;
-    }
-
-    /* Integer index */
-    if (PyArray_IsIntegerScalar(ind) || (PyIndex_Check(ind) &&
-                                     !PySequence_Check(ind))) {
-        npy_intp value = PyArray_PyIntAsIntp(ind);
-        if (value == -1 && PyErr_Occurred()) {
-            /* fail on error */
-            PyErr_SetString(PyExc_IndexError,
-                            "cannot convert index to integer");
-            return -1;
-        }
-        else {
-            return array_ass_item_object(self, value, op);
-        }
     }
 
     /* Single field access */
@@ -1378,120 +1542,166 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         return -1;
     }
 
-    /* Ellipsis index */
-    if (ind == Py_Ellipsis ||
-        (PyTuple_Check(ind) && 1 == PyTuple_GET_SIZE(ind) &&
-         Py_Ellipsis == PyTuple_GET_ITEM(ind, 0))) {
-        /*
-         * Doing "a[...] += 1" triggers assigning an array to itself,
-         * so this check is needed.
-         */
-        if ((PyObject *)self == op) {
-            return 0;
-        }
-        else {
-            return PyArray_CopyObject(self, op);
-        }
-    }
 
-    if (PyArray_NDIM(self) == 0) {
-        /*
-         * Several different exceptions to the 0-d no-indexing rule
-         *
-         *  1) ellipses or tuple with ellipses (handled above generally)
-         *  2) empty tuple
-         *  3) Using newaxis (None)
-         *  4) Boolean mask indexing
-         */
+    /* Prepare the indices */
+    //printf("preparing indices\n");
+    index_type = prepare_index(self, ind, indices, &index_num, &ndim, 1);
+    //printf("setting index_type %d, index_num %d, ndim %d\n", index_type, index_num, ndim);
 
-        /* Check for None or empty tuple */
-        if (ind == Py_None || (PyTuple_Check(ind) &&
-                                        (0 == PyTuple_GET_SIZE(ind) ||
-                                         count_new_axes_0d(ind) > 0))) {
-            return PyArray_SETITEM(self, PyArray_DATA(self), op);
-        }
-        /* Check for boolean index */
-        if (PyBool_Check(ind) || PyArray_IsScalar(ind, Bool) ||
-                        (PyArray_Check(ind) &&
-                         (PyArray_NDIM((PyArrayObject *)ind)==0) &&
-                         PyArray_ISBOOL((PyArrayObject *)ind))) {
-            if (PyObject_IsTrue(ind)) {
-                return PyArray_CopyObject(self, op);
-            }
-            else { /* False: don't do anything */
-                return 0;
-            }
-        }
-        PyErr_SetString(PyExc_IndexError,
-                        "0-dimensional arrays can't be indexed");
+    if (index_type < 0) {
         return -1;
     }
 
-    /* Integer-tuple index */
-    if (_is_full_index(ind, self)) {
-        int ret = _tuple_of_integers(ind, vals, PyArray_NDIM(self));
-
-        if (ret > 0) {
-            int idim, ndim = PyArray_NDIM(self);
-            npy_intp *shape = PyArray_DIMS(self);
-            npy_intp *strides = PyArray_STRIDES(self);
-            char *item = PyArray_BYTES(self);
-            for (idim = 0; idim < ndim; idim++) {
-                npy_intp v = vals[idim];
-                if (check_and_adjust_index(&v, shape[idim], idim) < 0) {
-                  return -1;
-                }
-                item += v * strides[idim];
-            }
-            return PyArray_SETITEM(self, item, op);
+    /* Full integer index */
+    if (index_type == HAS_INTEGER) {
+        char *item;
+        if (get_item_pointer(self, &item, indices, index_num) < 0) {
+            return -1;
         }
+        if (PyArray_SETITEM(self, item, op) < 0) {
+            return -1;
+        }
+        /* integers do not store objects in indices */
+        return 0;
     }
 
-    /* Boolean indexing special case */
-    if (PyArray_Check(ind) &&
-                (PyArray_TYPE((PyArrayObject *)ind) == NPY_BOOL) &&
-                (PyArray_NDIM(self) == PyArray_NDIM((PyArrayObject *)ind)) &&
-                (PyArray_SIZE(self) == PyArray_SIZE((PyArrayObject *)ind))) {
-        int retcode;
-        PyArrayObject *op_arr;
-        PyArray_Descr *dtype = NULL;
-
+    /* Single boolean array */
+    if (index_type == HAS_BOOL) {
         if (!PyArray_Check(op)) {
-            dtype = PyArray_DTYPE(self);
-            Py_INCREF(dtype);
-            op_arr = (PyArrayObject *)PyArray_FromAny(op, dtype, 0, 0, 0, NULL);
-            if (op_arr == NULL) {
-                return -1;
+            Py_INCREF(PyArray_DESCR(self));
+            tmp_arr = (PyArrayObject *)PyArray_FromAny(op,
+                                                   PyArray_DESCR(self), 0, 0,
+                                                   NPY_ARRAY_FORCECAST, NULL);
+            if (tmp_arr == NULL) {
+                goto fail;
             }
         }
         else {
-            op_arr = op;
-            Py_INCREF(op_arr);
+            Py_INCREF(op);
+            tmp_arr = (PyArrayObject *)op;
         }
-
-        if (PyArray_NDIM(op_arr) < 2) {
-            retcode = array_ass_boolean_subscript(self,
-                            (PyArrayObject *)ind,
-                            op_arr, NPY_CORDER);
-            Py_DECREF(op_arr);
-            return retcode;
+        if (array_ass_boolean_subscript(self,
+                                        (PyArrayObject *)indices[0].object,
+                                        tmp_arr, NPY_CORDER) < 0) {
+            goto fail;
         }
-        /*
-         * Assigning from multi-dimensional 'op' in this case seems
-         * inconsistent, so falling through to old code for backwards
-         * compatibility.
-         */
-        Py_DECREF(op_arr);
+        goto success;
     }
 
-    fancy = fancy_indexing_check(ind);
-    if (fancy != SOBJ_NOTFANCY) {
-        return array_ass_sub_fancy(self, ind, op, fancy);
+    /*
+     * WARNING: There is a huge special case here. If this is not a
+     *          base class array, we have to get the view through its
+     *          very own index machinery.
+     *          I find this weird, but not sure if there is a way to
+     *          deprecate. (why does the class not implement getitem too?)
+     */
+    else if (!(index_type & HAS_FANCY) && !PyArray_CheckExact(self)) {
+        view = PyObject_GetItem((PyObject *)self, ind);
+        if (view == NULL) {
+            goto fail;
+        }
+        if (!PyArray_Check(view)) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "Getitem not returning array");
+            goto fail;
+        }
+    }
+
+    /* Single ellipsis index, no need to create a new view */
+    else if (index_type == HAS_ELLIPSIS) {
+        if (self == op) {
+            /*
+             * CopyObject does not handle this case gracefully and
+             * there is nothing to do. Removing the special case
+             * will cause segfaults, though it is unclear what exactly
+             * happens.
+             */
+            return 0;
+        }
+        /* we can just use self, but incref for error handling */
+        Py_INCREF((PyObject *)self);
+        view = self;
+    }
+
+    /*
+     * View based indexing.
+     * There are two cases here. First we need to create a simple view,
+     * second we need to create a (possibly invalid) view for the
+     * subspace to the fancy index. This procedure is identical.
+     */
+    else if (index_type & (HAS_SLICE | HAS_NEWAXIS |
+                           HAS_ELLIPSIS | HAS_INTEGER)) {
+        if (get_view_from_index(self, &view, indices, index_num,
+                                (index_type & HAS_FANCY)) < 0) {
+            goto fail;
+        }
     }
     else {
-        return array_ass_sub_simple(self, ind, op);
+        view = NULL;
     }
+
+    /* If there is no fancy indexing, we have the array to assign to */
+    if (!(index_type & HAS_FANCY)) {
+        /*
+         * CopyObject handles all weirdness for us, this however also
+         * means that other array assignments which convert more strictly
+         * do *not* handle all weirdnesses correctly.
+         * TODO: To have other assignments handle them correctly, we
+         *       should copy into a temporary array of the correct shape
+         *       if it is not an array yet!
+         * TODO: We could use PyArray_SETITEM if it is 0-d?
+         */
+        if (PyArray_CopyObject(view, op) < 0) {
+            goto fail;
+        }
+        goto success;
+    }
+
+    /* fancy indexing has to be used. And view is the subspace. */
+    /* TODO: Add 1-dim and 1 index special case */
+    PyArrayMapIterObject * mit;
+    mit = (PyArrayMapIterObject *)PyArray_MapIterNew(indices,
+                                                     index_num, index_type);
+    if (mit == NULL) {
+        goto fail;
+    }
+    if (PyArray_MapIterBind(mit, view, self, indices, index_num) < 0) {
+        Py_DECREF((PyObject *)mit);
+        goto fail;
+    }
+    if (PyArray_SetMap(mit, op) < 0) {
+        Py_DECREF((PyObject *)mit);
+        goto fail;
+    }
+    Py_DECREF(mit);
+    goto success;
+
+    /* Clean up temporary variables and indices */
+    fail:
+        Py_XDECREF((PyObject *)view);
+        Py_XDECREF((PyObject *)tmp_arr);
+        for (i=0; i < index_num; i++) {
+            Py_XDECREF(indices[i].object);
+        }
+        return -1;
+    success:
+        Py_XDECREF((PyObject *)view);
+        Py_XDECREF((PyObject *)tmp_arr);
+        for (i=0; i < index_num; i++) {
+            Py_XDECREF(indices[i].object);
+        }
+        return 0;
 }
+
+
+NPY_NO_EXPORT int
+array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
+{
+    PyObject * ind = PyLong_FromLong(i); /* Fix this */
+    Py_INCREF(ind); /* TODO: Should not be needed! */
+    return array_ass_sub(self, ind, v);
+}
+
 
 NPY_NO_EXPORT PyMappingMethods array_as_mapping = {
     (lenfunc)array_length,              /*mp_length*/
@@ -1513,9 +1723,11 @@ NPY_NO_EXPORT PyMappingMethods array_as_mapping = {
 /*
  * This function takes a Boolean array and constructs index objects and
  * iterators as if nonzero(Bool) had been called
+ *
+ * Must not be called on a 0-d array.
  */
 static int
-_nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
+_nonzero_indices(PyObject *myBool, PyArrayObject **arrays)
 {
     PyArray_Descr *typecode;
     PyArrayObject *ba = NULL, *new = NULL;
@@ -1533,15 +1745,8 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
     }
     nd = PyArray_NDIM(ba);
 
-    if (nd == 0) {
-        PyErr_SetString(PyExc_IndexError,
-                        "only scalars can be indexed by 0-dimensional "
-                        "boolean arrays");
-        goto fail;
-    }
-
     for (j = 0; j < nd; j++) {
-        iters[j] = NULL;
+        arrays[j] = NULL;
     }
     size = PyArray_SIZE(ba);
     ptr = (npy_bool *)PyArray_DATA(ba);
@@ -1562,13 +1767,9 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
         if (new == NULL) {
             goto fail;
         }
-        iters[j] = (PyArrayIterObject *)
-            PyArray_IterNew((PyObject *)new);
-        Py_DECREF(new);
-        if (iters[j] == NULL) {
-            goto fail;
-        }
-        dptr[j] = (npy_intp *)PyArray_DATA(iters[j]->ao);
+        arrays[j] = new;
+
+        dptr[j] = (npy_intp *)PyArray_DATA(new);
         coords[j] = 0;
         dims_m1[j] = PyArray_DIMS(ba)[j]-1;
     }
@@ -1578,7 +1779,6 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
     }
 
     /*
-
      * Loop through the Boolean array  and copy coordinates
      * for non-zero entries
      */
@@ -1606,89 +1806,61 @@ _nonzero_indices(PyObject *myBool, PyArrayIterObject **iters)
 
  fail:
     for (j = 0; j < nd; j++) {
-        Py_XDECREF(iters[j]);
+        Py_XDECREF(arrays[j]);
     }
     Py_XDECREF(ba);
     return -1;
 }
 
-/* convert an indexing object to an INTP indexing array iterator
-   if possible -- otherwise, it is a Slice, Ellipsis or None object
-   and has to be interpreted on bind to a particular
-   array so leave it NULL for now.
-*/
-static int
-_convert_obj(PyObject *obj, PyArrayIterObject **iter)
-{
-    PyArray_Descr *indtype;
-    PyObject *arr;
-
-    if (PySlice_Check(obj) || (obj == Py_Ellipsis) || (obj == Py_None)) {
-        return 0;
-    }
-    else if (PyArray_Check(obj) && PyArray_ISBOOL((PyArrayObject *)obj)) {
-        return _nonzero_indices(obj, iter);
-    }
-    else {
-        indtype = PyArray_DescrFromType(NPY_INTP);
-        arr = PyArray_FromAny(obj, indtype, 0, 0, NPY_ARRAY_FORCECAST, NULL);
-        if (arr == NULL) {
-            return -1;
-        }
-        *iter = (PyArrayIterObject *)PyArray_IterNew(arr);
-        Py_DECREF(arr);
-        if (*iter == NULL) {
-            return -1;
-        }
-    }
-    return 1;
-}
 
 /* Reset the map iterator to the beginning */
 NPY_NO_EXPORT void
 PyArray_MapIterReset(PyArrayMapIterObject *mit)
 {
-    int i,j; npy_intp coord[NPY_MAXDIMS];
-    PyArrayIterObject *it;
-    PyArray_CopySwapFunc *copyswap;
-
+    int i,j;
+    npy_intp offset_add;
     mit->index = 0;
 
-    if (mit->numiter > 0) {
-        copyswap = PyArray_DESCR(mit->iters[0]->ao)->f->copyswap;
+    NpyIter_Reset(mit->outer, NULL);
+    mit->dataptr = mit->baseoffset;
+
+    for (j = 0; j < mit->numiter; j++) {
+        offset_add = mit->outerptr[j][0];
+        if (offset_add < 0) {
+            offset_add += mit->outer_dims[j];
+        }
+        mit->dataptr += offset_add * mit->outer_strides[j];
+    }
+    if (mit->subspace != NULL) {
+        PyArray_ITER_RESET(mit->subspace);
+        mit->subspace->dataptr = mit->dataptr;
     }
 
-    if (mit->subspace != NULL) {
-        memcpy(coord, mit->bscoord, sizeof(npy_intp)*PyArray_NDIM(mit->ait->ao));
-        PyArray_ITER_RESET(mit->subspace);
-        for (i = 0; i < mit->numiter; i++) {
-            it = mit->iters[i];
-            PyArray_ITER_RESET(it);
-            j = mit->iteraxes[i];
-            copyswap(coord+j,it->dataptr, !PyArray_ISNOTSWAPPED(it->ao),
-                     it->ao);
-        }
-        PyArray_ITER_GOTO(mit->ait, coord);
-        mit->subspace->dataptr = mit->ait->dataptr;
-        mit->dataptr = mit->subspace->dataptr;
-    }
-    else {
-        for (i = 0; i < mit->numiter; i++) {
-            it = mit->iters[i];
-            if (it->size != 0) {
-                PyArray_ITER_RESET(it);
-                copyswap(coord+i,it->dataptr, !PyArray_ISNOTSWAPPED(it->ao),
-                         it->ao);
-            }
-            else {
-                coord[i] = 0;
-            }
-        }
-        PyArray_ITER_GOTO(mit->ait, coord);
-        mit->dataptr = mit->ait->dataptr;
-    }
     return;
 }
+
+
+NPY_NO_EXPORT int
+PyArray_MapIterOuterNext(PyArrayMapIterObject *mit)
+{
+    int j;
+    npy_intp offset_add;
+    if (mit->iternext(mit->outer)) {
+        mit->dataptr = mit->baseoffset;
+        for (j = 0; j < mit->numiter; j++) {
+            offset_add = mit->outerptr[j][0];
+            if (offset_add < 0) {
+                offset_add += mit->outer_dims[j];
+            }
+            mit->dataptr += offset_add * mit->outer_strides[j];
+        }
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
+
 
 /*NUMPY_API
  * This function needs to update the state of the map iterator
@@ -1697,63 +1869,27 @@ PyArray_MapIterReset(PyArrayMapIterObject *mit)
 NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit)
 {
-    int i, j;
-    npy_intp coord[NPY_MAXDIMS];
-    PyArrayIterObject *it;
-    PyArray_CopySwapFunc *copyswap;
-
-    mit->index += 1;
-    if (mit->index >= mit->size) {
-        return;
-    }
-
-    if (mit->numiter > 0) {
-        copyswap = PyArray_DESCR(mit->iters[0]->ao)->f->copyswap;
-    }
-
     /* Sub-space iteration */
     if (mit->subspace != NULL) {
         PyArray_ITER_NEXT(mit->subspace);
+
         if (mit->subspace->index >= mit->subspace->size) {
-            /* reset coord to coordinates of beginning of the subspace */
-            memcpy(coord, mit->bscoord,
-                        sizeof(npy_intp)*PyArray_NDIM(mit->ait->ao));
             PyArray_ITER_RESET(mit->subspace);
-            for (i = 0; i < mit->numiter; i++) {
-                it = mit->iters[i];
-                PyArray_ITER_NEXT(it);
-                j = mit->iteraxes[i];
-                copyswap(coord+j,it->dataptr, !PyArray_ISNOTSWAPPED(it->ao),
-                         it->ao);
-            }
-            PyArray_ITER_GOTO(mit->ait, coord);
-            mit->subspace->dataptr = mit->ait->dataptr;
+            PyArray_MapIterOuterNext(mit);
+            mit->subspace->dataptr = mit->dataptr;
         }
         mit->dataptr = mit->subspace->dataptr;
     }
     else {
-        for (i = 0; i < mit->numiter; i++) {
-            it = mit->iters[i];
-            PyArray_ITER_NEXT(it);
-            copyswap(coord+i,it->dataptr,
-                     !PyArray_ISNOTSWAPPED(it->ao),
-                     it->ao);
-        }
-        PyArray_ITER_GOTO(mit->ait, coord);
-        mit->dataptr = mit->ait->dataptr;
+        PyArray_MapIterOuterNext(mit);
     }
     return;
 }
 
 /*
- * Bind a mapiteration to a particular array
- *
- *  Determine if subspace iteration is necessary.  If so,
- *  1) Fill in mit->iteraxes
- *  2) Create subspace iterator
- *  3) Update nd, dimensions, and size.
- *
- *  Subspace iteration is necessary if:  PyArray_NDIM(arr) > mit->numiter
+ * Bind a mapiteration to a particular array and subspace.
+ * Note that the subspace must be a base class array. Otherwise
+ * there might be reshaping applied before the indexing is finished.
  *
  * Need to check for index-errors somewhere.
  *
@@ -1761,148 +1897,101 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
  * as well.
  */
 NPY_NO_EXPORT int
-PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
+PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *subspace,
+                    PyArrayObject *arr, npy_index_info *indices, int index_num)
 {
     int subnd;
-    PyObject *sub, *obj = NULL;
-    int i, j, n, curraxis, ellipexp, noellip, newaxes;
+    int i, j, n, curr_dim, result_dim, consec_status;
     PyArrayIterObject *it;
-    npy_intp dimsize;
     npy_intp *indptr;
 
-    subnd = PyArray_NDIM(arr) - mit->numiter;
-    if (subnd < 0) {
-        PyErr_SetString(PyExc_IndexError,
-                        "too many indices for array");
-        return -1;
-    }
-
+    /* Note: ait is probably never really used. */
     mit->ait = (PyArrayIterObject *)PyArray_IterNew((PyObject *)arr);
     if (mit->ait == NULL) {
         return -1;
     }
 
-    /*
-     * all indexing arrays have been converted to 0
-     * therefore we can extract the subspace with a simple
-     * getitem call which will use view semantics, but
-     * without index checking since all original normal
-     * indexes are checked later as fancy ones.
-     *
-     * But, be sure to do it with a true array.
-     */
-    if (PyArray_CheckExact(arr)) {
-        sub = array_subscript_simple(arr, mit->indexobj, 0);
-    }
-    else {
-        Py_INCREF(arr);
-        obj = PyArray_EnsureArray((PyObject *)arr);
-        if (obj == NULL) {
+    if (subspace != NULL) {
+        /* Get subspace iterator */
+        subnd = PyArray_NDIM(subspace);
+        mit->baseoffset = PyArray_BYTES(subspace);
+        mit->subspace = (PyArrayIterObject *)PyArray_IterNew((PyObject *)subspace);
+        if (mit->subspace == NULL) {
             return -1;
         }
-        sub = array_subscript_simple((PyArrayObject *)obj, mit->indexobj, 0);
-        Py_DECREF(obj);
-    }
 
-    if (sub == NULL) {
-        return -1;
-    }
-
-    subnd = PyArray_NDIM(sub);
-    /* no subspace iteration needed.  Finish up and Return */
-    if (subnd == 0) {
-        n = PyArray_NDIM(arr);
+        /* Expand dimensions of result */
+        n = PyArray_NDIM(mit->subspace->ao);
         for (i = 0; i < n; i++) {
-            mit->iteraxes[i] = i;
+            mit->dimensions[mit->nd+i] = PyArray_DIMS(mit->subspace->ao)[i];
         }
-        Py_DECREF(sub);
-        goto finish;
+        mit->nd += n;
     }
-
-    mit->subspace = (PyArrayIterObject *)PyArray_IterNew(sub);
-    Py_DECREF(sub);
-    if (mit->subspace == NULL) {
-        return -1;
-    }
-
-    if (mit->nd + subnd > NPY_MAXDIMS) {
-        PyErr_Format(PyExc_ValueError,
-                     "number of dimensions must be within [0, %d], "
-                     "indexed array has %d",
-                     NPY_MAXDIMS, mit->nd + subnd);
-        return -1;
-    }
-
-    /* Expand dimensions of result */
-    for (i = 0; i < subnd; i++) {
-        mit->dimensions[mit->nd+i] = PyArray_DIMS(mit->subspace->ao)[i];
-    }
-    mit->nd += subnd;
-
-    /*
-     * Now, we still need to interpret the ellipsis, slice and None
-     * objects to determine which axes the indexing arrays are
-     * referring to
-     */
-    n = PyTuple_GET_SIZE(mit->indexobj);
-    /* The number of dimensions an ellipsis takes up */
-    newaxes = subnd - (PyArray_NDIM(arr) - mit->numiter);
-    ellipexp = PyArray_NDIM(arr) + newaxes - n + 1;
-    /*
-     * Now fill in iteraxes -- remember indexing arrays have been
-     * converted to 0's in mit->indexobj
-     */
-    curraxis = 0;
-    j = 0;
-    /* Only expand the first ellipsis */
-    noellip = 1;
-    /* count newaxes before iter axes */
-    newaxes = 0;
-    memset(mit->bscoord, 0, sizeof(npy_intp)*PyArray_NDIM(arr));
-    for (i = 0; i < n; i++) {
+    else {
         /*
-         * We need to fill in the starting coordinates for
-         * the subspace
+         * FIXME: This means if subspace is a scalar, we still need to use it.
+         *        It is however probably no worse then before when all scalars
+         *        were promoted to iterator arrays of the outer iteration.
          */
-        obj = PyTuple_GET_ITEM(mit->indexobj, i);
-        if (PyInt_Check(obj) || PyLong_Check(obj)) {
-            mit->iteraxes[j++] = curraxis++;
-        }
-        else if (noellip && obj == Py_Ellipsis) {
-            curraxis += ellipexp;
-            noellip = 0;
-        }
-        else if (obj == Py_None) {
-            if (j == 0) {
-                newaxes += 1;
+        subnd = 0;
+        mit->subspace == NULL;
+        mit->baseoffset = PyArray_BYTES(arr);
+    }
+
+    /*
+     * Now need to set mit->iteraxes and ..., also need
+     * to find the correct mit->consec value.
+     */
+    j = 0;
+    curr_dim = 0;
+    result_dim = 0; /* dimension of index result (up to first fancy index) */
+    mit->consec = 0;
+    consec_status = -1; /* no fancy index yet */
+    for (i = 0; i < index_num; i++) {
+        /* integer and fancy indexes are transposed together */
+        if (indices[i].type & (HAS_FANCY | HAS_INTEGER)) {
+            /* there was no previous fancy index, so set consec */
+            if (consec_status == -1) {
+                mit->consec = result_dim;
+                consec_status = 0;
+            }
+            /* there was already a non-fancy index after a fancy one */
+            else if (consec_status == 1) {
+                consec_status = 2;
+                mit->consec = 0;
             }
         }
         else {
-            npy_intp start = 0;
-            npy_intp stop, step;
-            /* Should be slice object or another Ellipsis */
-            if (obj == Py_Ellipsis) {
-                mit->bscoord[curraxis] = 0;
+            /* consec_status == 0 means there was a fancy index before */
+            if (consec_status == 0) {
+                consec_status = 1;
             }
-            else if (!PySlice_Check(obj) ||
-                     (slice_GetIndices((PySliceObject *)obj,
-                                       PyArray_DIMS(arr)[curraxis],
-                                       &start, &stop, &step,
-                                       &dimsize) < 0)) {
-                PyErr_Format(PyExc_ValueError,
-                             "unexpected object "       \
-                             "(%s) in selection position %d",
-                             Py_TYPE(obj)->tp_name, i);
-                return -1;
-            }
-            else {
-                mit->bscoord[curraxis] = start;
-            }
-            curraxis += 1;
         }
-    }
-    if (mit->consec) {
-        mit->consec = mit->iteraxes[0] + newaxes;
+
+        /* (iterating) fancy index, store the iterator */
+        if (indices[i].type == HAS_FANCY) {
+            mit->outer_strides[j] = PyArray_STRIDE(arr, curr_dim);
+            mit->outer_dims[j] = PyArray_DIM(arr, curr_dim);
+            mit->iteraxes[j++] = curr_dim++;
+        }
+        else if (indices[i].type == HAS_0D_BOOL) {
+            mit->outer_strides[j] = 0;
+            mit->outer_dims[j] = 1;
+            mit->iteraxes[j++] = -1; /* Does not exist */
+        }
+
+        /* advance curr_dim for non-fancy indices */
+        else if (indices[i].type == HAS_ELLIPSIS) {
+            curr_dim += indices[i].value;
+            result_dim += indices[i].value;
+        }
+        else if (indices[i].type != HAS_NEWAXIS){
+            curr_dim += 1;
+            result_dim += 1;
+        }
+        else {
+            result_dim += 1;
+        }
     }
 
  finish:
@@ -1919,185 +2008,92 @@ PyArray_MapIterBind(PyArrayMapIterObject *mit, PyArrayObject *arr)
         return -1;
     }
 
-    for (i = 0; i < mit->numiter; i++) {
-        npy_intp indval;
-        it = mit->iters[i];
-        PyArray_ITER_RESET(it);
-        dimsize = PyArray_DIMS(arr)[mit->iteraxes[i]];
-        while (it->index < it->size) {
-            indptr = ((npy_intp *)it->dataptr);
-            indval = *indptr;
-            if (check_and_adjust_index(&indval, dimsize, mit->iteraxes[i]) < 0) {
-                return -1;
+    npy_intp indval;
+    npy_intp *outer_dim = mit->outer_dims;
+    int *outer_axis = mit->iteraxes;
+    if (NpyIter_GetIterSize(mit->outer) > 0) {
+        do {
+            for (j=0; j<mit->numiter; j++) {
+                indval = *mit->outerptr[j];
+                if (check_and_adjust_index(&indval, *(outer_dim++), *(outer_axis++)) < 0) {
+                    return -1;
+                }
             }
-            PyArray_ITER_NEXT(it);
-        }
-        PyArray_ITER_RESET(it);
+            outer_dim -= mit->numiter;
+            outer_axis -= mit->numiter;
+        } while (mit->iternext(mit->outer));
     }
+
+    NpyIter_Reset(mit->outer, NULL);
     return 0;
 }
 
 
 NPY_NO_EXPORT PyObject *
-PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
+PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type)
 {
+    PyArrayObject *index_arrays[NPY_MAXDIMS];
+    PyArray_Descr *dtypes[NPY_MAXDIMS];
+    npy_uint32 op_flags[NPY_MAXDIMS];
     PyArrayMapIterObject *mit;
-    PyArray_Descr *indtype;
-    PyArrayObject *arr = NULL;
-    int i, n, started, nonindex;
+    int i, requires_buffer = 0;
 
-    if (fancy == SOBJ_BADARRAY) {
-        PyErr_SetString(PyExc_IndexError,
-                        "arrays used as indices must be of "
-                        "integer (or boolean) type");
-        return NULL;
-    }
-    if (fancy == SOBJ_TOOMANY) {
-        PyErr_SetString(PyExc_IndexError, "too many indices");
-        return NULL;
-    }
+    /* Note: Does MapIter support no fancy index?! */
 
+    /* create new MapIter object */
     mit = (PyArrayMapIterObject *)PyArray_malloc(sizeof(PyArrayMapIterObject));
-    if (mit == NULL) {
-        return NULL;
-    }
     /* set all attributes of mapiter to zero */
     memset(mit, 0, sizeof(PyArrayMapIterObject));
     PyObject_Init((PyObject *)mit, &PyArrayMapIter_Type);
-    /* initialize mapiter attributes */
-    mit->consec = 1;
-
-    if (fancy == SOBJ_LISTTUP) {
-        PyObject *newobj;
-        newobj = PySequence_Tuple(indexobj);
-        if (newobj == NULL) {
-            goto fail;
-        }
-        indexobj = newobj;
-        mit->indexobj = indexobj;
-    }
-    else {
-        Py_INCREF(indexobj);
-        mit->indexobj = indexobj;
+    if (mit == NULL) {
+        return NULL;
     }
 
+    for (i=0; i < index_num; i++) {
+        if (indices[i].type & HAS_FANCY) {
+            index_arrays[mit->numiter] = (PyArrayObject *)indices[i].object;
+            dtypes[mit->numiter] = PyArray_DescrFromType(NPY_INTP); /* may have to refcount? */
 
-    if (oned) {
-        return (PyObject *)mit;
-    }
-    /*
-     * Must have some kind of fancy indexing if we are here
-     * indexobj is either a list, an arrayobject, or a tuple
-     * (with at least 1 list or arrayobject or Bool object)
-     */
-
-    /* convert all inputs to iterators */
-    if (PyArray_Check(indexobj) && PyArray_ISBOOL(indexobj)
-                                && !PyArray_IsZeroDim(indexobj)) {
-        mit->numiter = _nonzero_indices(indexobj, mit->iters);
-        if (mit->numiter < 0) {
-            goto fail;
-        }
-        mit->nd = 1;
-        mit->dimensions[0] = mit->iters[0]->dims_m1[0]+1;
-        Py_DECREF(mit->indexobj);
-        mit->indexobj = PyTuple_New(mit->numiter);
-        if (mit->indexobj == NULL) {
-            goto fail;
-        }
-        for (i = 0; i < mit->numiter; i++) {
-            PyTuple_SET_ITEM(mit->indexobj, i, PyInt_FromLong(0));
-        }
-    }
-    else if (PyArray_Check(indexobj) || !PyTuple_Check(indexobj)) {
-        mit->numiter = 1;
-        indtype = PyArray_DescrFromType(NPY_INTP);
-        arr = (PyArrayObject *)PyArray_FromAny(indexobj, indtype, 0, 0,
-                                NPY_ARRAY_FORCECAST, NULL);
-        if (arr == NULL) {
-            goto fail;
-        }
-        mit->iters[0] = (PyArrayIterObject *)PyArray_IterNew((PyObject *)arr);
-        if (mit->iters[0] == NULL) {
-            Py_DECREF(arr);
-            goto fail;
-        }
-        mit->nd = PyArray_NDIM(arr);
-        memcpy(mit->dimensions, PyArray_DIMS(arr), mit->nd*sizeof(npy_intp));
-        mit->size = PyArray_SIZE(arr);
-        Py_DECREF(arr);
-        Py_DECREF(mit->indexobj);
-        mit->indexobj = Py_BuildValue("(N)", PyInt_FromLong(0));
-    }
-    else {
-        /* must be a tuple */
-        PyObject *obj;
-        PyArrayIterObject **iterp;
-        PyObject *new;
-        int numiters, j, n2;
-        /*
-         * Make a copy of the tuple -- we will be replacing
-         * index objects with 0's
-         */
-        n = PyTuple_GET_SIZE(indexobj);
-        n2 = n;
-        new = PyTuple_New(n2);
-        if (new == NULL) {
-            goto fail;
-        }
-        started = 0;
-        nonindex = 0;
-        j = 0;
-        for (i = 0; i < n; i++) {
-            obj = PyTuple_GET_ITEM(indexobj,i);
-            iterp = mit->iters + mit->numiter;
-            if ((numiters=_convert_obj(obj, iterp)) < 0) {
-                Py_DECREF(new);
-                goto fail;
+            if (!PyArray_ISBEHAVED_RO(index_arrays[mit->numiter])) {
+                requires_buffer |= NPY_ITER_BUFFERED;
             }
-            if (numiters > 0) {
-                started = 1;
-                if (nonindex) {
-                    mit->consec = 0;
-                }
-                mit->numiter += numiters;
-                if (numiters == 1) {
-                    PyTuple_SET_ITEM(new,j++, PyInt_FromLong(0));
-                }
-                else {
-                    /*
-                     * we need to grow the new indexing object and fill
-                     * it with 0s for each of the iterators produced
-                     */
-                    int k;
-                    n2 += numiters - 1;
-                    if (_PyTuple_Resize(&new, n2) < 0) {
-                        goto fail;
-                    }
-                    for (k = 0; k < numiters; k++) {
-                        PyTuple_SET_ITEM(new, j++, PyInt_FromLong(0));
-                    }
-                }
+            else if (PyArray_DESCR(index_arrays[mit->numiter])->type_num != NPY_INTP) {
+                requires_buffer |= NPY_ITER_BUFFERED;
             }
-            else {
-                if (started) {
-                    nonindex = 1;
-                }
-                Py_INCREF(obj);
-                PyTuple_SET_ITEM(new,j++,obj);
-            }
+
+            // | NPY_ITER_COPY; Copying seems quite a bit faster then buffering...
+            op_flags[mit->numiter] = NPY_ITER_NBO | NPY_ITER_ALIGNED | NPY_ITER_READONLY;
+            mit->numiter += 1;
         }
-        Py_DECREF(mit->indexobj);
-        mit->indexobj = new;
-        /*
-         * Store the number of iterators actually converted
-         * These will be mapped to actual axes at bind time
-         */
-        if (PyArray_Broadcast((PyArrayMultiIterObject *)mit) < 0) {
-            goto fail;
-        }
+    }    
+
+    //printf("Creating MultiNew\n");
+    mit->outer = NpyIter_MultiNew(mit->numiter,
+                                  index_arrays,
+                                  NPY_ITER_ZEROSIZE_OK |
+                                  requires_buffer |
+                                  NPY_ITER_MULTI_INDEX, /* strip later */
+                                  NPY_CORDER,
+                                  NPY_SAME_KIND_CASTING,
+                                  op_flags,
+                                  dtypes);
+
+    if (mit->outer == NULL) {
+        //printf("Allocating multiNew failed!\n");
+        goto fail;
     }
 
+    /* I doubt this can really fail, but should add error checking... */
+    NpyIter_GetShape(mit->outer, mit->dimensions);
+    mit->nd = NpyIter_GetNDim(mit->outer);
+    mit->nd_fancy = mit->nd;
+    NpyIter_RemoveMultiIndex(mit->outer);
+    NpyIter_Reset(mit->outer, NULL);
+
+    mit->iternext = NpyIter_GetIterNext(mit->outer, NULL);
+    mit->outerptr = NpyIter_GetDataPtrArray(mit->outer);
+
+    //printf("Done mapiternew\n");
     return (PyObject *)mit;
 
  fail:
@@ -2110,47 +2106,72 @@ PyArray_MapIterNew(PyObject *indexobj, int oned, int fancy)
 NPY_NO_EXPORT PyObject *
 PyArray_MapIterArray(PyArrayObject * a, PyObject * index)
 {
-    PyArrayMapIterObject * mit;
-    int fancy = fancy_indexing_check(index);
+    PyArrayMapIterObject * mit = NULL;
+    PyArrayObject *subspace = NULL;
+    npy_index_info indices[NPY_MAXDIMS * 2 + 1];
+    int i, index_num, ndim, index_type;
 
-    /*
-     * MapIterNew supports a special mode that allows more efficient 1-d iteration,
-     * but clients that want to make use of this need to use a different API just
-     * for the one-d cases. For the public interface this is confusing, so we
-     * unconditionally disable the 1-d optimized mode, and use the generic
-     * implementation in all cases.
-     */
-    int oned = 0;
+    index_type = prepare_index(a, index, indices, &index_num, &ndim, 0);
 
-    mit = (PyArrayMapIterObject *) PyArray_MapIterNew(index, oned, fancy);
+    if (index_type < 0) {
+        return NULL;
+    }
+
+    mit = (PyArrayMapIterObject *) PyArray_MapIterNew(indices, index_num, index_type);
     if (mit == NULL) {
-        return NULL;
+        goto fail;
     }
 
-    if (PyArray_MapIterBind(mit, a) != 0) {
-        Py_DECREF(mit);
-        return NULL;
+    /* If it is not a pure fancy index, need to get the subspace */
+    if (index_type != HAS_FANCY) {
+        if (get_view_from_index(a, &subspace, indices, index_num, 1) < 0) {
+            Py_DECREF((PyObject *)mit);
+            goto fail;
+        }
     }
+
+    if (PyArray_MapIterBind(mit, subspace, a, indices, index_num) < 0) {
+        Py_XDECREF(subspace);
+        Py_DECREF((PyObject *)mit);
+        goto fail;
+    }
+    Py_XDECREF(subspace);
     PyArray_MapIterReset(mit);
-    return mit;
+
+    for (i=0; i < index_num; i++) {
+        Py_XDECREF(indices[i].object);
+    }
+
+    return (PyObject *)mit;
+
+ fail:
+    Py_XDECREF((PyObject *)mit);
+    for (i=0; i < index_num; i++) {
+        Py_XDECREF(indices[i].object);
+    }
+    return NULL;
 }
 
 
-#undef SOBJ_NOTFANCY
-#undef SOBJ_ISFANCY
-#undef SOBJ_BADARRAY
-#undef SOBJ_TOOMANY
-#undef SOBJ_LISTTUP
+
+#undef HAS_INTEGER
+#undef HAS_NEWAXIS
+#undef HAS_SLICE
+#undef HAS_ELLIPSIS
+#undef HAS_FANCY
+#undef HAS_BOOL
+#undef HAS_SCALAR_ARRAY
+#undef HAS_0D_BOOL
+
 
 static void
 arraymapiter_dealloc(PyArrayMapIterObject *mit)
 {
     int i;
-    Py_XDECREF(mit->indexobj);
     Py_XDECREF(mit->ait);
     Py_XDECREF(mit->subspace);
-    for (i = 0; i < mit->numiter; i++) {
-        Py_XDECREF(mit->iters[i]);
+    if (mit->outer != NULL) {
+        NpyIter_Deallocate(mit->outer);
     }
     PyArray_free(mit);
 }
@@ -2164,7 +2185,7 @@ arraymapiter_dealloc(PyArrayMapIterObject *mit)
  *
  * It's not very useful anyway, since mapiter(indexobj); mapiter.bind(a);
  * mapiter is equivalent to a[indexobj].flat but the latter gets to use
- * slice syntax.
+ * slice syntax. (indexobj has been removed from it)
  */
 NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
 #if defined(NPY_PY3K)
@@ -2223,7 +2244,9 @@ NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
+#if PY_VERSION_HEX >= 0x02060000
     0,                                          /* tp_version_tag */
+#endif
 };
 
 /** END of Subscript Iterator **/

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2210,7 +2210,7 @@ mapiter_fill_info(PyArrayMapIterObject *mit, npy_index_info *indices,
     return 0;
 
   broadcast_error:
-     /*
+    /*
      * Attempt to set a meaningful exception. Could also find out
      * if a boolean index was converted.
      */
@@ -2365,7 +2365,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
  * @param Dtype for the extra operand, borrows the reference and must not
  *        be NULL (if extra_op_flags is not 0).
  *
- * @return A new MapIter (PyObject *) which still requires binding or NULL.
+ * @return A new MapIter (PyObject *) or NULL.
  *
  * NOTE: The outer iteration (and subspace if requested buffered) is
  *       created with DELAY_BUFALLOC. It must be reset before usage!

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -551,7 +551,11 @@ prepare_index(PyArrayObject *self, PyObject *index,
      */
     if (!PyTuple_CheckExact(index)
             /* Next three are just to avoid slow checks */
+#if !defined(NPY_PY3K)
             && (!PyInt_CheckExact(index))
+#else
+            && (!PyLong_CheckExact(index))
+#endif
             && (index != Py_None)
             && (!PySlice_Check(index))
             && (!PyArray_Check(index))
@@ -714,7 +718,11 @@ prepare_index(PyArrayObject *self, PyObject *index,
          * It could be an array, a 0-d array is handled
          * a bit weird however, so need to special case it.
          */
+#if !defined(NPY_PY3K)
         else if (PyInt_CheckExact(obj) || !PyArray_Check(obj)) {
+#else
+        else if (PyLong_CheckExact(obj) || !PyArray_Check(obj)) {
+#endif
             i = PyArray_PyIntAsIntp(obj);
             if ((i == -1) && PyErr_Occurred()) {
                 PyErr_Clear();
@@ -1695,8 +1703,8 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
     }
 
     /* Single field access */
-    if (PyString_Check(ind) || PyUnicode_Check(ind)) {
-        if (PyDataType_HASFIELDS(PyArray_DESCR(self))) {
+    if (PyDataType_HASFIELDS(PyArray_DESCR(self))) {
+        if (PyString_Check(ind) || PyUnicode_Check(ind)) {
             PyObject *obj;
 
             obj = PyDict_GetItem(PyArray_DESCR(self)->fields, ind);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -883,13 +883,14 @@ get_view_from_index(PyArrayObject *self, PyArrayObject **view,
     int orig_dim = 0;
     char *data_ptr = PyArray_BYTES(self);
 
-    npy_intp start, stop, step, n_steps; /* for slice parsing */
+    /* for slice parsing */
+    npy_intp start, stop, step, n_steps;
 
     for (i=0; i < index_num; i++) {
         switch (indices[i].type) {
             case HAS_INTEGER:
                 if ((check_and_adjust_index(&indices[i].value,
-                                    PyArray_DIMS(self)[orig_dim], i)) < 0) {
+                                PyArray_DIMS(self)[orig_dim], orig_dim)) < 0) {
                     return -1;
                 }
                 data_ptr += PyArray_STRIDE(self, orig_dim) * indices[i].value;
@@ -910,8 +911,7 @@ get_view_from_index(PyArrayObject *self, PyArrayObject **view,
                                      PyArray_DIMS(self)[orig_dim],
                                      &start, &stop, &step, &n_steps) < 0) {
                     if (!PyErr_Occurred()) {
-                        PyErr_SetString(PyExc_IndexError,
-                                        "invalid slice");
+                        PyErr_SetString(PyExc_IndexError, "invalid slice");
                     }
                     return -1;
                 }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2635,7 +2635,8 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
                                      NPY_ITER_MULTI_INDEX |
                                      NPY_ITER_BUFFERED |
                                      NPY_ITER_DELAY_BUFALLOC |
-                                     NPY_ITER_GROWINNER,
+                                     NPY_ITER_GROWINNER |
+                                     NPY_ITER_DONT_NEGATE_STRIDES,
                                      /* C-order if extra op is not used */
                                      extra_op_flags ? NPY_KEEPORDER : NPY_CORDER,
                                      NPY_UNSAFE_CASTING,

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -227,7 +227,15 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
  *
  * Checks everything but the bounds.
  *
- * Returns the index_type or -1 on failure and fills the number of indices.
+ * @param the array being indexed
+ * @param the index object
+ * @param index info struct being filled (size of NPY_MAXDIMS * 2 + 1)
+ * @param number of indices found
+ * @param dimension of the indexing result
+ * @param dimension of the fancy/advanced indices part
+ * @param whether to allow the boolean special case
+ *
+ * @returns the index_type or -1 on failure and fills the number of indices.
  */
 NPY_NO_EXPORT int
 prepare_index(PyArrayObject *self, PyObject *index,
@@ -908,7 +916,7 @@ get_view_from_index(PyArrayObject *self, PyArrayObject **view,
                     return -1;
                 }
                 if (n_steps <= 0) {
-                    /* TODO: Always points start then, could change that */
+                    /* TODO: Always points to start then, could change that */
                     n_steps = 0;
                     step = 1;
                     start = 0;
@@ -1289,8 +1297,8 @@ array_subscript(PyArrayObject *self, PyObject *op)
     if (PyDataType_HASFIELDS(PyArray_DESCR(self))) {
         /* Check for single field access */
         /*
-         * TODO: Moving this code block into the HASFIELDS, might have
-         *       consequences for strings that can be interpreted as ints?
+         * TODO: Moving this code block into the HASFIELDS, means that
+         *       string integers temporarily work as indices.
          */
         if (PyString_Check(op) || PyUnicode_Check(op)) {
             PyObject *temp, *obj;
@@ -2522,7 +2530,6 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
              * All dimensions of the extra_op corresponding to the
              * subspace must be equal to 1.
              */
-            /* TODO: Add a test for this special case! */
             if (PyArray_NDIM(subspace) <= PyArray_NDIM(extra_op)) {
                 j = PyArray_NDIM(subspace);
             }
@@ -2646,7 +2653,6 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
      * For a single 1-d operand, guarantee itertion order
      * (scipy used this), note subspace may be True (otherwise as of
      * writing this, NpyIter does not negate the external loop)
-     * TODO: Add test.
      */
     if ((mit->numiter == 1) && (PyArray_NDIM(index_arrays[0]) == 1)) {
         outer_flags |= NPY_ITER_DONT_NEGATE_STRIDES;

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -45,7 +45,7 @@ NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit);
 
 NPY_NO_EXPORT int
-PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *subspace, PyArrayObject *, npy_index_info *indices, int index_num);
+PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *subspace, PyArrayObject *, npy_index_info *indices, int index_num, int delayed_index_check);
 
 NPY_NO_EXPORT PyObject*
 PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type);

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -45,8 +45,13 @@ NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit);
 
 NPY_NO_EXPORT int
-PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *subspace, PyArrayObject *, npy_index_info *indices, int index_num, int delayed_index_check);
+PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *subspace,
+                    PyArrayObject *, npy_index_info *indices, int index_num,
+                    int delayed_index_check);
 
 NPY_NO_EXPORT PyObject*
-PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type);
+PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
+                   PyArrayObject *subspace,
+                   npy_uint32 extra_op_flags,
+                   PyArrayObject *extra_op, PyArray_Descr *extra_op_dtype);
 #endif

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -28,12 +28,6 @@ array_subscript(PyArrayObject *self, PyObject *op);
 NPY_NO_EXPORT int
 array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
 
-NPY_NO_EXPORT PyObject *
-add_new_axes_0d(PyArrayObject *,  int);
-
-NPY_NO_EXPORT int
-count_new_axes_0d(PyObject *tuple);
-
 /*
  * Prototypes for Mapping calls --- not part of the C-API
  * because only useful as part of a getitem call.
@@ -45,13 +39,16 @@ NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit);
 
 NPY_NO_EXPORT int
-PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *subspace,
-                    PyArrayObject *, npy_index_info *indices, int index_num,
-                    int delayed_index_check);
+PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit);
+
+NPY_NO_EXPORT void
+PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getmap);
 
 NPY_NO_EXPORT PyObject*
 PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
-                   PyArrayObject *subspace,
-                   npy_uint32 extra_op_flags,
-                   PyArrayObject *extra_op, PyArray_Descr *extra_op_dtype);
+                   int ndim, int fancy_ndim,
+                   PyArrayObject *arr, PyArrayObject *subspace,
+                   npy_uint32 subspace_flags,
+                   npy_uint32 extra_op_flags, PyArrayObject *extra_op,
+                   PyArray_Descr *extra_op_dtype);
 #endif

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -45,9 +45,8 @@ NPY_NO_EXPORT void
 PyArray_MapIterNext(PyArrayMapIterObject *mit);
 
 NPY_NO_EXPORT int
-PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *);
+PyArray_MapIterBind(PyArrayMapIterObject *, PyArrayObject *subspace, PyArrayObject *, npy_index_info *indices, int index_num);
 
 NPY_NO_EXPORT PyObject*
-PyArray_MapIterNew(PyObject *, int, int);
-
+PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type);
 #endif

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -48,7 +48,7 @@ NPY_NO_EXPORT PyObject*
 PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
                    int ndim, int fancy_ndim,
                    PyArrayObject *arr, PyArrayObject *subspace,
-                   npy_uint32 subspace_flags,
+                   npy_uint32 subspace_iter_flags,npy_uint32 subspace_flags,
                    npy_uint32 extra_op_flags, PyArrayObject *extra_op,
                    PyArray_Descr *extra_op_dtype);
 #endif

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -7,6 +7,25 @@ extern NPY_NO_EXPORT PyMappingMethods array_as_mapping;
 NPY_NO_EXPORT PyMappingMethods array_as_mapping;
 #endif
 
+
+/*
+ * Struct into which indices are parsed.
+ * I.e. integer ones should only be parsed once, slices and arrays
+ * need to be validated later and for the ellipsis we need to find how
+ * many slices it represents.
+ */
+typedef struct {
+    /*
+     * Object of index: slice, array, or NULL. Owns a reference.
+     */
+    PyObject *object;
+    /* Value of an integer index or number of slices an Ellipsis is worth */
+    npy_intp value;
+    /* kind of index, see constants in mapping.c */
+    int type;
+} npy_index_info;
+
+
 NPY_NO_EXPORT Py_ssize_t
 array_length(PyArrayObject *self);
 
@@ -48,7 +67,7 @@ NPY_NO_EXPORT PyObject*
 PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
                    int ndim, int fancy_ndim,
                    PyArrayObject *arr, PyArrayObject *subspace,
-                   npy_uint32 subspace_iter_flags,npy_uint32 subspace_flags,
+                   npy_uint32 subspace_iter_flags, npy_uint32 subspace_flags,
                    npy_uint32 extra_op_flags, PyArrayObject *extra_op,
                    PyArray_Descr *extra_op_dtype);
 #endif

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1255,54 +1255,6 @@ npyiter_casting_to_string(NPY_CASTING casting)
     }
 }
 
-static PyObject *
-npyiter_shape_string(npy_intp n, npy_intp *vals, char *ending)
-{
-    npy_intp i;
-    PyObject *ret, *tmp;
-
-    /*
-     * Negative dimension indicates "newaxis", which can
-     * be discarded for printing if it's a leading dimension.
-     * Find the first non-"newaxis" dimension.
-     */
-    i = 0;
-    while (i < n && vals[i] < 0) {
-        ++i;
-    }
-
-    if (i == n) {
-        return PyUString_FromFormat("()%s", ending);
-    }
-    else {
-        ret = PyUString_FromFormat("(%" NPY_INTP_FMT, vals[i++]);
-        if (ret == NULL) {
-            return NULL;
-        }
-    }
-
-    for (; i < n; ++i) {
-        if (vals[i] < 0) {
-            tmp = PyUString_FromString(",newaxis");
-        }
-        else {
-            tmp = PyUString_FromFormat(",%" NPY_INTP_FMT, vals[i]);
-        }
-        if (tmp == NULL) {
-            Py_DECREF(ret);
-            return NULL;
-        }
-
-        PyUString_ConcatAndDel(&ret, tmp);
-        if (ret == NULL) {
-            return NULL;
-        }
-    }
-
-    tmp = PyUString_FromFormat(")%s", ending);
-    PyUString_ConcatAndDel(&ret, tmp);
-    return ret;
-}
 
 static int
 npyiter_check_casting(int nop, PyArrayObject **op,
@@ -1727,7 +1679,7 @@ broadcast_error: {
             }
             for (iop = 0; iop < nop; ++iop) {
                 if (op[iop] != NULL) {
-                    tmp = npyiter_shape_string(PyArray_NDIM(op[iop]),
+                    tmp = get_shape_string(PyArray_NDIM(op[iop]),
                                                     PyArray_DIMS(op[iop]),
                                                     " ");
                     if (tmp == NULL) {
@@ -1751,7 +1703,7 @@ broadcast_error: {
                     return 0;
                 }
 
-                tmp = npyiter_shape_string(ndim, itershape, "");
+                tmp = get_shape_string(ndim, itershape, "");
                 if (tmp == NULL) {
                     Py_DECREF(errmsg);
                     return 0;
@@ -1774,7 +1726,7 @@ broadcast_error: {
                     int *axes = op_axes[iop];
 
                     tmpstr = (axes == NULL) ? " " : "->";
-                    tmp = npyiter_shape_string(PyArray_NDIM(op[iop]),
+                    tmp = get_shape_string(PyArray_NDIM(op[iop]),
                                                     PyArray_DIMS(op[iop]),
                                                     tmpstr);
                     if (tmp == NULL) {
@@ -1796,7 +1748,7 @@ broadcast_error: {
                                 remdims[idim] = -1;
                             }
                         }
-                        tmp = npyiter_shape_string(ndim, remdims, " ");
+                        tmp = get_shape_string(ndim, remdims, " ");
                         if (tmp == NULL) {
                             return 0;
                         }
@@ -1818,7 +1770,7 @@ broadcast_error: {
                     return 0;
                 }
 
-                tmp = npyiter_shape_string(ndim, itershape, "");
+                tmp = get_shape_string(ndim, itershape, "");
                 if (tmp == NULL) {
                     Py_DECREF(errmsg);
                     return 0;
@@ -1854,7 +1806,7 @@ operand_different_than_broadcast: {
         }
 
         /* Operand shape */
-        tmp = npyiter_shape_string(PyArray_NDIM(op[iop]),
+        tmp = get_shape_string(PyArray_NDIM(op[iop]),
                                         PyArray_DIMS(op[iop]), "");
         if (tmp == NULL) {
             return 0;
@@ -1887,7 +1839,7 @@ operand_different_than_broadcast: {
                 return 0;
             }
 
-            tmp = npyiter_shape_string(ndim, remdims, "]");
+            tmp = get_shape_string(ndim, remdims, "]");
             if (tmp == NULL) {
                 return 0;
             }
@@ -1907,7 +1859,7 @@ operand_different_than_broadcast: {
         }
 
         /* Broadcast shape */
-        tmp = npyiter_shape_string(ndim, broadcast_shape, "");
+        tmp = get_shape_string(ndim, broadcast_shape, "");
         if (tmp == NULL) {
             return 0;
         }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1679,7 +1679,7 @@ broadcast_error: {
             }
             for (iop = 0; iop < nop; ++iop) {
                 if (op[iop] != NULL) {
-                    tmp = get_shape_string(PyArray_NDIM(op[iop]),
+                    tmp = convert_shape_to_string(PyArray_NDIM(op[iop]),
                                                     PyArray_DIMS(op[iop]),
                                                     " ");
                     if (tmp == NULL) {
@@ -1703,7 +1703,7 @@ broadcast_error: {
                     return 0;
                 }
 
-                tmp = get_shape_string(ndim, itershape, "");
+                tmp = convert_shape_to_string(ndim, itershape, "");
                 if (tmp == NULL) {
                     Py_DECREF(errmsg);
                     return 0;
@@ -1726,7 +1726,7 @@ broadcast_error: {
                     int *axes = op_axes[iop];
 
                     tmpstr = (axes == NULL) ? " " : "->";
-                    tmp = get_shape_string(PyArray_NDIM(op[iop]),
+                    tmp = convert_shape_to_string(PyArray_NDIM(op[iop]),
                                                     PyArray_DIMS(op[iop]),
                                                     tmpstr);
                     if (tmp == NULL) {
@@ -1748,7 +1748,7 @@ broadcast_error: {
                                 remdims[idim] = -1;
                             }
                         }
-                        tmp = get_shape_string(ndim, remdims, " ");
+                        tmp = convert_shape_to_string(ndim, remdims, " ");
                         if (tmp == NULL) {
                             return 0;
                         }
@@ -1770,7 +1770,7 @@ broadcast_error: {
                     return 0;
                 }
 
-                tmp = get_shape_string(ndim, itershape, "");
+                tmp = convert_shape_to_string(ndim, itershape, "");
                 if (tmp == NULL) {
                     Py_DECREF(errmsg);
                     return 0;
@@ -1806,7 +1806,7 @@ operand_different_than_broadcast: {
         }
 
         /* Operand shape */
-        tmp = get_shape_string(PyArray_NDIM(op[iop]),
+        tmp = convert_shape_to_string(PyArray_NDIM(op[iop]),
                                         PyArray_DIMS(op[iop]), "");
         if (tmp == NULL) {
             return 0;
@@ -1839,7 +1839,7 @@ operand_different_than_broadcast: {
                 return 0;
             }
 
-            tmp = get_shape_string(ndim, remdims, "]");
+            tmp = convert_shape_to_string(ndim, remdims, "]");
             if (tmp == NULL) {
                 return 0;
             }
@@ -1859,7 +1859,7 @@ operand_different_than_broadcast: {
         }
 
         /* Broadcast shape */
-        tmp = get_shape_string(ndim, broadcast_shape, "");
+        tmp = convert_shape_to_string(ndim, broadcast_shape, "");
         if (tmp == NULL) {
             return 0;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3356,31 +3356,14 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
     PyObject *res, *ret;
     int N;
 
-    if (key == Py_Ellipsis || key == Py_None ||
-            PyTuple_Check(key)) {
-        res = PyArray_FromScalar(self, NULL);
-    }
-    else {
-        PyErr_SetString(PyExc_IndexError,
-                "invalid index to scalar variable.");
-        return NULL;
-    }
-    if (key == Py_Ellipsis) {
-        return res;
-    }
-    if (key == Py_None) {
-        ret = add_new_axes_0d((PyArrayObject *)res, 1);
-        Py_DECREF(res);
-        return ret;
-    }
-    /* Must be a Tuple */
-    N = count_new_axes_0d(key);
-    if (N < 0) {
-        Py_DECREF(res);
-        return NULL;
-    }
-    ret = add_new_axes_0d((PyArrayObject *)res, N);
+    res = PyArray_FromScalar(self, NULL);
+
+    ret = array_subscript((PyArrayObject *)res, key);
     Py_DECREF(res);
+    if (ret == NULL) {
+        PyErr_SetString(PyExc_IndexError,
+                        "invalid index to scalar variable.");
+    }
     return ret;
 }
 

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -326,6 +326,12 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
                 PyArray_MaskedStridedUnaryOp *stransfer,
                 NpyAuxData *data);
 
+NPY_NO_EXPORT int
+mapiter_get(PyArrayMapIterObject *mit);
+
+NPY_NO_EXPORT int
+mapiter_set(PyArrayMapIterObject *mit);
+
 /*
  * Prepares shape and strides for a simple raw array iteration.
  * This sorts the strides into FORTRAN order, reverses any negative

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -327,6 +327,14 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
                 NpyAuxData *data);
 
 NPY_NO_EXPORT int
+mapiter_trivial_get(PyArrayObject *self, PyArrayObject *ind,
+                       PyArrayObject *result);
+
+NPY_NO_EXPORT int
+mapiter_trivial_set(PyArrayObject *self, PyArrayObject *ind,
+                       PyArrayObject *result);
+
+NPY_NO_EXPORT int
 mapiter_get(PyArrayMapIterObject *mit);
 
 NPY_NO_EXPORT int

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -668,7 +668,7 @@ npy_bswap8_unaligned(char * x)
                                              PyArray_DIMS(arr2), \
                                              PyArray_NDIM(arr1)) && \
                         (PyArray_FLAGS(arr1)&(NPY_ARRAY_C_CONTIGUOUS| \
-                                      NPY_ARRAY_F_CONTIGUOUS)) == \
+                                      NPY_ARRAY_F_CONTIGUOUS)) & \
                                 (PyArray_FLAGS(arr2)&(NPY_ARRAY_C_CONTIGUOUS| \
                                               NPY_ARRAY_F_CONTIGUOUS)) \
                         )
@@ -679,12 +679,12 @@ npy_bswap8_unaligned(char * x)
                     PyArray_CHKFLAGS(arr, NPY_ARRAY_F_CONTIGUOUS) \
                     )
 #define PyArray_PREPARE_TRIVIAL_ITERATION(arr, count, data, stride) \
-                    count = PyArray_SIZE(arr), \
-                    data = PyArray_BYTES(arr), \
+                    count = PyArray_SIZE(arr); \
+                    data = PyArray_BYTES(arr); \
                     stride = ((PyArray_NDIM(arr) == 0) ? 0 : \
                                     ((PyArray_NDIM(arr) == 1) ? \
                                             PyArray_STRIDE(arr, 0) : \
-                                            PyArray_ITEMSIZE(arr))) \
+                                            PyArray_ITEMSIZE(arr)));
 
 
 #define PyArray_TRIVIALLY_ITERABLE_PAIR(arr1, arr2) (\

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -151,7 +151,7 @@ class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
         assert_deprecated(lambda: a[0.0,:])
         assert_deprecated(lambda: a[:, 0.0])
         assert_deprecated(lambda: a[:, 0.0,:])
-        assert_deprecated(lambda: a[0.0,:,:], num=2) # [1]
+        assert_deprecated(lambda: a[0.0,:,:])
         assert_deprecated(lambda: a[0, 0, 0.0])
         assert_deprecated(lambda: a[0.0, 0, 0])
         assert_deprecated(lambda: a[0, 0.0, 0])
@@ -161,11 +161,10 @@ class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
         assert_deprecated(lambda: a[-1.4,:])
         assert_deprecated(lambda: a[:, -1.4])
         assert_deprecated(lambda: a[:, -1.4,:])
-        assert_deprecated(lambda: a[-1.4,:,:], num=2) # [1]
+        assert_deprecated(lambda: a[-1.4,:,:])
         assert_deprecated(lambda: a[0, 0, -1.4])
         assert_deprecated(lambda: a[-1.4, 0, 0])
         assert_deprecated(lambda: a[0, -1.4, 0])
-        # [1] These are duplicate because of the _tuple_of_integers quick check
 
         # Test that the slice parameter deprecation warning doesn't mask
         # the scalar index warning.

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -315,6 +315,19 @@ class TestMultiIndexingAutomated(TestCase):
                     # Note that originally this is could be interpreted as
                     # integer in the full integer special case.
                     raise IndexError
+            else:
+                # If the index is a singleton, the bounds check is done
+                # before the broadcasting. This used to be different in <1.8
+                if indx.ndim == 0:
+                    if indx >= arr.shape[ax] or indx < -arr.shape[ax]:
+                        raise IndexError
+            if indx.ndim == 0:
+                # The index is a scalar. This used to be two fold, but if fancy
+                # indexing was active, the check was done later, possibly
+                # after broadcasting it away (1.7. or earlier). Now it is always
+                # done.
+                if indx >= arr.shape[ax] or indx < - arr.shape[ax]:
+                    raise IndexError
             if len(indices) > 0 and indices[-1][0] == 'f' and ax != ellipsis_pos:
                 # NOTE: There could still have been a 0-sized Ellipsis
                 # between them. Checked that with ellipsis_pos.

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -147,6 +147,49 @@ class TestIndexing(TestCase):
                          [0, 8, 0]])
 
 
+class TestBroadcastedAssignments(TestCase):
+    def assign(self, a, ind, val):
+        a[ind] = val
+
+
+    def test_non_fancy(self):
+        assign = self.assign
+        s_ = np.s_
+
+        a = np.zeros((1,2,0))
+
+        assert_raises(ValueError, assign, a, s_[...], np.ones((1,2,3)))
+        # Too large should raise
+        assert_raises(ValueError, assign, a, s_[...], np.ones((1,1,1,1)))
+        a[...] = np.ones((1,1,1))
+
+    def test_fancy_no_subspace(self):
+        assign = self.assign
+        s_ = np.s_
+
+        a = np.zeros(5)
+
+        a[[1,2,3]] = 0
+        assert_raises(ValueError, a, s_[[1,2,3]], [1,2,3,4])
+
+        # values can be extended, result cannot
+        a[[[1,2,3]]] = [1,2,3]
+        assert_raises(ValueError, a, s_[[1,2,3]], [[1,2,3]])
+
+    def test_fancy_with_ignored_subspace(self):
+        assign = self.assign
+        s_ = np.s_
+
+        a = np.zeros(1,5,1)
+
+        a[:,[1,2,3],:] = [1,2,3]
+        assert_array_equal(a, [[[1], [2], [3]]])
+        assert_raises(ValueError, assign, a, s_[:,[1],:], np.ones((1,) * 4))
+
+    def test_fancy_with_subspace(self):
+        pass
+
+
 class TestMultiIndexingAutomated(TestCase):
     """
      These test use code to mimic the C-Code indexing for selection.

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -253,10 +253,12 @@ class TestIndexing(TestCase):
         a = np.array([0])
         refcount = sys.getrefcount(np.dtype(np.intp))
         # item setting always checks indices in seperate function:
-        a[np.array([1], dtype=np.intp)] = 1
-        a[np.array([1], dtype=np.uint8)] = 1
         a[np.array([0], dtype=np.intp)] = 1
         a[np.array([0], dtype=np.uint8)] = 1
+        assert_raises(IndexError, a.__setitem__,
+                      np.array([1], dtype=np.intp), 1)
+        assert_raises(IndexError, a.__setitem__,
+                      np.array([1], dtype=np.uint8), 1)
 
         assert_equal(sys.getrefcount(np.dtype(np.intp)), refcount)
 

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -236,6 +236,18 @@ class TestIndexing(TestCase):
         assert_((a == 1).all())
 
 
+    def test_memory_order(self):
+        # These is not necessary to preserve. Memory layouts for
+        # more complex indices are not as simple.
+        a = np.arange(10)
+        b = np.arange(10).reshape(5,2).T
+        assert_(a[b].flags.f_contiguous)
+
+        # Takes a different implementation branch:
+        a = a.reshape(-1, 1)
+        assert_(a[b, 0].flags.f_contiguous)
+
+
 class TestBroadcastedAssignments(TestCase):
     def assign(self, a, ind, val):
         a[ind] = val

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -166,6 +166,18 @@ class TestIndexing(TestCase):
         assert_equal(a[0], [0, 1])
 
 
+    def test_uncontiguous_subspace_assignment(self):
+        # During development there was a bug activating a skip logic
+        # based on ndim instead of size.
+        a = np.full((3, 4, 2), -1)
+        b = np.full((3, 4, 2), -1)
+
+        a[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).T
+        b[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).T.copy()
+
+        assert_equal(a, b)
+
+
     def test_too_many_fancy_indices_special_case(self):
         # Just documents behaviour, this is a small limitation.
         a = np.ones((1,) * 32) # 32 is NPY_MAXDIMS

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -214,6 +214,28 @@ class TestIndexing(TestCase):
         assert_raises(IndexError, a.__setitem__, ind, 0)
 
 
+    def test_nonbaseclass_values(self):
+        class SubClass(np.ndarray):
+            def __array_finalize__(self, old):
+                # Have array finalize do funny things
+                self.fill(99)
+
+        a = np.zeros((5, 5))
+        s = a.copy().view(type=SubClass)
+        s.fill(1)
+
+        a[[0, 1, 2, 3, 4], :] = s
+        assert_((a == 1).all())
+
+        # Subspace is last, so transposing might want to finalize
+        a[:, [0, 1, 2, 3, 4]] = s
+        assert_((a == 1).all())
+
+        a.fill(0)
+        a[...] = s
+        assert_((a == 1).all())
+
+
 class TestBroadcastedAssignments(TestCase):
     def assign(self, a, ind, val):
         a[ind] = val

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -305,11 +305,19 @@ class TestBroadcastedAssignments(TestCase):
 
 
     def test_index_is_larger(self):
-        # Simple case of fancy index broadcastin of the index.
+        # Simple case of fancy index broadcasting of the index.
         a = np.zeros((5, 5))
         a[[[0], [1], [2]], [0, 1, 2]] = [2, 3, 4]
 
         assert_((a[:3, :3] == [2, 3, 4]).all())
+
+
+    def test_broadcast_subspace(self):
+        a = np.zeros((100, 100))
+        v = np.arange(100)[:,None]
+        b = np.arange(100)[::-1]
+        a[b] = v
+        assert_((a[::-1] == v).all())
 
 
 class TestSubclasses(TestCase):
@@ -362,7 +370,7 @@ class TestSubclasses(TestCase):
 
 class TestFancyIndexingEquivalence(TestCase):
     def test_object_assign(self):
-        # Check that the field and object special case using copyto is active
+        # Check that the field and object special case using copyto is active.
         # The right hand side cannot be converted to an array here.
         a = np.arange(5, dtype=object)
         b = a.copy()

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -182,8 +182,8 @@ class TestMultiIndexingAutomated(TestCase):
             np.empty((0, 1, 1), dtype=np.intp), # empty broadcastable
             np.array([0, 1, -2]),
             np.array([[2], [0], [1]]),
-            np.array([[0, -1], [0, 1]]),
-            np.array([2, -1]),
+            np.array([[0, -1], [0, 1]], dtype=np.dtype('intp').newbyteorder()),
+            np.array([2, -1], dtype=np.int8),
             np.zeros([1]*31, dtype=int), # trigger too large array.
             np.array([0., 1.])] # invalid datatype
         # Some simpler indices that still cover a bit more

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -53,7 +53,7 @@ class TestIndexing(TestCase):
                       [4, 5, 6],
                       [7, 8, 9]])
         assert_equal(a[...], a)
-        assert_(a[...] is a)
+        assert_(a[...].base is a) # `a[...]` was `a` in numpy <1.9.)
 
         # Slicing with ellipsis can skip an
         # arbitrary number of dimensions
@@ -96,8 +96,15 @@ class TestIndexing(TestCase):
         #assert_equal(a[False], a[0])
 
         # Same with NumPy boolean scalar
-        assert_equal(a[np.array(True)], a[1])
-        assert_equal(a[np.array(False)], a[0])
+        # Before DEPRECATE:
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_equal(a[np.array(True)], a[1])
+            assert_equal(a[np.array(False)], a[0])
+        # After DEPRECATE:
+        #assert_equal(a[np.array(True)], a[None])
+        #assert_equal(a[np.array(False), a[None][0:0]])
+
 
     def test_boolean_indexing_onedim(self):
         # Indexing a 2-dimensional array with
@@ -242,9 +249,7 @@ class TestMultiIndexingAutomated(TestCase):
                 if ellipsis_pos is None:
                     ellipsis_pos = i
                     continue # do not increment ndim counter
-                in_indices[i] = slice(None, None)
-                ndim += 1
-                continue
+                raise IndexError
             if isinstance(indx, slice):
                 ndim += 1
                 continue
@@ -546,7 +551,6 @@ class TestMultiIndexingAutomated(TestCase):
             warnings.filterwarnings('error', '', DeprecationWarning)
             for index in self.complex_indices:
                 self._check_single_index(a, index)
-
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -116,6 +116,7 @@ class TestIndexing(TestCase):
         a[b] = 1.
         assert_equal(a, [[1., 1., 1.]])
 
+
     def test_boolean_assignment_value_mismatch(self):
         # A boolean assignment should fail when the shape of the values
         # cannot be broadcasted to the subscription. (see also gh-3458)
@@ -126,6 +127,7 @@ class TestIndexing(TestCase):
         assert_raises(ValueError, f, a, [])
         assert_raises(ValueError, f, a, [1, 2, 3])
         assert_raises(ValueError, f, a[:1], [1, 2, 3])
+
 
     def test_boolean_indexing_twodim(self):
         # Indexing a 2-dimensional array with
@@ -192,6 +194,24 @@ class TestIndexing(TestCase):
         assert_(a is not a[()])
         assert_(a is not a[...])
         assert_(a is not a[:])
+
+
+    def test_broaderrors_indexing(self):
+        a = np.zeros((5, 5))
+        assert_raises(IndexError, a.__getitem__, ([0, 1], [0, 1, 2]))
+        assert_raises(IndexError, a.__setitem__, ([0, 1], [0, 1, 2]), 0)
+
+
+    def test_trivial_fancy_out_of_bounds(self):
+        a = np.zeros(5)
+        ind = np.ones(20, dtype=np.intp)
+        ind[-1] = 10
+        assert_raises(IndexError, a.__getitem__, ind)
+        assert_raises(IndexError, a.__setitem__, ind, 0)
+        ind = np.ones(20, dtype=np.intp)
+        ind[0] = 11
+        assert_raises(IndexError, a.__getitem__, ind)
+        assert_raises(IndexError, a.__setitem__, ind, 0)
 
 
 class TestBroadcastedAssignments(TestCase):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -237,7 +237,7 @@ class TestIndexing(TestCase):
 
 
     def test_memory_order(self):
-        # These is not necessary to preserve. Memory layouts for
+        # This is not necessary to preserve. Memory layouts for
         # more complex indices are not as simple.
         a = np.arange(10)
         b = np.arange(10).reshape(5,2).T
@@ -246,6 +246,19 @@ class TestIndexing(TestCase):
         # Takes a different implementation branch:
         a = a.reshape(-1, 1)
         assert_(a[b, 0].flags.f_contiguous)
+
+
+    def test_small_regressions(self):
+        # Reference count of intp for index checks
+        a = np.array([0])
+        refcount = sys.getrefcount(np.dtype(np.intp))
+        # item setting always checks indices in seperate function:
+        a[np.array([1], dtype=np.intp)] = 1
+        a[np.array([1], dtype=np.uint8)] = 1
+        a[np.array([0], dtype=np.intp)] = 1
+        a[np.array([0], dtype=np.uint8)] = 1
+
+        assert_equal(sys.getrefcount(np.dtype(np.intp)), refcount)
 
 
 class TestBroadcastedAssignments(TestCase):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -322,7 +322,7 @@ class TestMultiIndexingAutomated(TestCase):
                     raise IndexError
             else:
                 # If the index is a singleton, the bounds check is done
-                # before the broadcasting. This used to be different in <1.8
+                # before the broadcasting. This used to be different in <1.9
                 if indx.ndim == 0:
                     if indx >= arr.shape[ax] or indx < -arr.shape[ax]:
                         raise IndexError

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -294,8 +294,8 @@ class TestZeroRank(TestCase):
         a, b = self.d
         self.assertEqual(a[...], 0)
         self.assertEqual(b[...], 'x')
-        self.assertTrue(a[...] is a)
-        self.assertTrue(b[...] is b)
+        self.assertTrue(a[...].base is a) # `a[...] is a` in numpy <1.9.
+        self.assertTrue(b[...].base is b) # `b[...] is b` in numpy <1.9.
 
     def test_empty_subscript(self):
         a, b = self.d

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2708,8 +2708,8 @@ class TestRecord(TestCase):
             # byte string indexing fails gracefully
             assert_raises(ValueError, a.__setitem__, asbytes('f1'), 1)
             assert_raises(ValueError, a.__getitem__, asbytes('f1'))
-            assert_raises(ValueError, a['f1'].__setitem__, asbytes('sf1'), 1)
-            assert_raises(ValueError, a['f1'].__getitem__, asbytes('sf1'))
+            assert_raises(IndexError, a['f1'].__setitem__, asbytes('sf1'), 1)
+            assert_raises(IndexError, a['f1'].__getitem__, asbytes('sf1'))
         else:
             funcs = (str, unicode)
         for func in funcs:

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -657,9 +657,9 @@ def test_iter_broadcasting_errors():
         # The message should contain "shape->remappedshape" for each operand
         assert_(msg.find('(2,3)->(2,3)') >= 0,
             'Message "%s" doesn\'t contain operand shape (2,3)->(2,3)' % msg)
-        assert_(msg.find('(2)->(2,newaxis)') >= 0,
+        assert_(msg.find('(2,)->(2,newaxis)') >= 0,
                 ('Message "%s" doesn\'t contain remapped operand shape' +
-                '(2)->(2,newaxis)') % msg)
+                '(2,)->(2,newaxis)') % msg)
         # The message should contain the itershape parameter
         assert_(msg.find('(4,3)') >= 0,
                 'Message "%s" doesn\'t contain itershape parameter (4,3)' % msg)

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -365,7 +365,7 @@ class TestMultipleFields(TestCase):
     def _bad_call(self):
         return self.ary['f0', 'f1']
     def test_no_tuple(self):
-        self.assertRaises(ValueError, self._bad_call)
+        self.assertRaises(IndexError, self._bad_call)
     def test_return(self):
         res = self.ary[['f0', 'f2']].tolist()
         assert_(res == [(1, 3), (5, 7)])

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -751,8 +751,11 @@ class TestRegression(TestCase):
         s = np.ones(10, dtype=float)
         x = np.array((15,), dtype=float)
         def ia(x, s, v): x[(s>0)]=v
-        self.assertRaises(ValueError, ia, x, s, np.zeros(9, dtype=float))
-        self.assertRaises(ValueError, ia, x, s, np.zeros(11, dtype=float))
+        # Before 1.9. was ValueError (a special case not used anymore)
+        self.assertRaises(IndexError, ia, x, s, np.zeros(9, dtype=float))
+        self.assertRaises(IndexError, ia, x, s, np.zeros(11, dtype=float))
+        # However, this still uses that special case:
+        self.assertRaises(ValueError, ia, x.flat, s, np.zeros(9, dtype=float))
 
     def test_mem_scalar_indexing(self, level=rlevel):
         """Ticket #603"""

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -751,10 +751,9 @@ class TestRegression(TestCase):
         s = np.ones(10, dtype=float)
         x = np.array((15,), dtype=float)
         def ia(x, s, v): x[(s>0)]=v
-        # Before 1.9. was ValueError (a special case not used anymore)
-        self.assertRaises(IndexError, ia, x, s, np.zeros(9, dtype=float))
-        self.assertRaises(IndexError, ia, x, s, np.zeros(11, dtype=float))
-        # However, this still uses that special case:
+        self.assertRaises(ValueError, ia, x, s, np.zeros(9, dtype=float))
+        self.assertRaises(ValueError, ia, x, s, np.zeros(11, dtype=float))
+        # Old special case (different code path):
         self.assertRaises(ValueError, ia, x.flat, s, np.zeros(9, dtype=float))
 
     def test_mem_scalar_indexing(self, level=rlevel):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -249,7 +249,7 @@ class TestInsert(TestCase):
         assert_(isinstance(np.insert(a, [], []), SubClass))
         assert_(isinstance(np.insert(a, [0, 1], [1, 2]), SubClass))
         assert_(isinstance(np.insert(a, slice(1, 2), [1, 2]), SubClass))
-        assert_(isinstance(np.insert(a, slice(1, -2), []), SubClass))
+        assert_(isinstance(np.insert(a, slice(1, -2, -1), []), SubClass))
         # This is an error in the future:
         a = np.array(1).view(SubClass)
         assert_(isinstance(np.insert(a, 0, [0]), SubClass))


### PR DESCRIPTION
Current status: Everything works. Some reorganizing is likely necessary, but pending input on that.
- Check the release notes changes for a detailed list of compatibility changes.
- Tested against scipy and pandas
- The code has a few `TODO`s, but they should not require much action.
- New 0-d boolean index support can't be tested/used until deprecation is done...
- Check http://sebastian.sipsolutions.net/indexing_speedup/ for some speedup examples. Indices that require casting or are not trivial looping are unfortunatly slower for small and sometimes medium sized arrays.
- The memory layout changes give close to 20% speed increase for a simple loop test (disabling fast path). Of course these would normally take the fast path. So the real world speed loss is much more if that fast path cannot be taken anymore, but on the other hand it is probably less for most other cases.
