### PR TITLE
BUG: fix hashing of long integers under python3

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2872,8 +2872,8 @@ static npy_hash_t
 /**end repeat**/
 
 /**begin repeat
- * #lname = byte, short, uint, ulong#
- * #name = Byte, Short, UInt, ULong#
+ * #lname = byte, short, uint#
+ * #name = Byte, Short, UInt#
  */
 static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
@@ -2885,6 +2885,15 @@ static npy_hash_t
     return x;
 }
 /**end repeat**/
+
+static npy_hash_t
+ulong_arrtype_hash(PyObject *obj)
+{
+    PyObject * l = PyLong_FromUnsignedLong(((PyULongScalarObject*)obj)->obval);
+    npy_hash_t x = PyObject_Hash(l);
+    Py_DECREF(l);
+    return x;
+}
 
 #if (NPY_SIZEOF_INT != NPY_SIZEOF_LONG) || defined(NPY_PY3K)
 static npy_hash_t
@@ -2898,49 +2907,31 @@ int_arrtype_hash(PyObject *obj)
 }
 #endif
 
+#if defined(NPY_PY3K)
+static npy_hash_t
+long_arrtype_hash(PyObject *obj)
+{
+    PyObject * l = PyLong_FromLong(((PyLongScalarObject*)obj)->obval);
+    npy_hash_t x = PyObject_Hash(l);
+    Py_DECREF(l);
+    return x;
+}
+#endif
+
 /**begin repeat
  * #char = ,u#
  * #Char = ,U#
- * #ext = && (x >= LONG_MIN),#
+ * #Word = ,Unsigned#
  */
-#if NPY_SIZEOF_HASH_T != NPY_SIZEOF_LONGLONG
-/* we assume NPY_SIZEOF_LONGLONG=2*NPY_SIZEOF_LONG */
 static npy_hash_t
 @char@longlong_arrtype_hash(PyObject *obj)
 {
-    npy_hash_t y;
-    npy_@char@longlong x = (((Py@Char@LongLongScalarObject *)obj)->obval);
-
-    if ((x <= LONG_MAX)@ext@) {
-        y = (npy_hash_t) x;
-    }
-    else {
-        union Mask {
-            long hashvals[2];
-            npy_@char@longlong v;
-        } both;
-
-        both.v = x;
-        y = both.hashvals[0] + (1000003)*both.hashvals[1];
-    }
-    if (y == -1) {
-        y = -2;
-    }
-    return y;
-}
-#else
-
-static npy_hash_t
-@char@longlong_arrtype_hash(PyObject *obj)
-{
-    npy_hash_t x = (npy_hash_t)(((Py@Char@LongLongScalarObject *)obj)->obval);
-    if (x == -1) {
-        x = -2;
-    }
+    PyObject * l = PyLong_From@Word@LongLong(
+                                 ((Py@Char@LongLongScalarObject*)obj)->obval);
+    npy_hash_t x = PyObject_Hash(l);
+    Py_DECREF(l);
     return x;
 }
-
-#endif
 /**end repeat**/
 
 
@@ -4079,7 +4070,7 @@ initialize_numeric_types(void)
 
 #if defined(NPY_PY3K)
     /* We won't be inheriting from Python Int type. */
-    PyLongArrType_Type.tp_hash = int_arrtype_hash;
+    PyLongArrType_Type.tp_hash = long_arrtype_hash;
 #endif
 
 #if (NPY_SIZEOF_LONG != NPY_SIZEOF_LONGLONG) || defined(NPY_PY3K)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -59,6 +59,26 @@ class TestFlags(TestCase):
         assert_equal(self.a.flags.aligned, True)
         assert_equal(self.a.flags.updateifcopy, False)
 
+class TestHash(TestCase):
+    # see #3793
+    def test_int(self):
+        for st, ut, s in [(np.int8, np.uint8, 8),
+                          (np.int16, np.uint16, 16),
+                          (np.int32, np.uint32, 32),
+                          (np.int64, np.uint64, 64)]:
+            for i in range(1, s):
+                assert_equal(hash(st(-2**i)), hash(-2**i),
+                             err_msg="%r: -2**%d" % (st, i))
+                assert_equal(hash(st(2**(i - 1))), hash(2**(i - 1)),
+                             err_msg="%r: 2**%d" % (st, i - 1))
+                assert_equal(hash(st(2**i - 1)), hash(2**i - 1),
+                             err_msg="%r: 2**%d - 1" % (st, i))
+
+                i = max(i - 1, 1)
+                assert_equal(hash(ut(2**(i - 1))), hash(2**(i - 1)),
+                             err_msg="%r: 2**%d" % (ut, i - 1))
+                assert_equal(hash(ut(2**i - 1)), hash(2**i - 1),
+                             err_msg="%r: 2**%d - 1" % (ut, i))
 
 class TestAttributes(TestCase):
     def setUp(self):


### PR DESCRIPTION
python3 long_hash is more complex than int_hash so instead of copying
into numpy call it via the Python capi.
Same for long long for wich the numpy hash function is not correct with
python 2.7 on i386.
Will be slower but doesn't need adapting each timy python changes.
closes #3793
