### PR TITLE
BUG: do a boolean check on casting bool to other types

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -759,7 +759,7 @@ NPY_NO_EXPORT PyArray_StridedUnaryOp *
 
 #else
 
-#  if @is_bool2@
+#  if @is_bool2@ || @is_bool1@
 #    define _CONVERT_FN(x) ((npy_bool)(x != 0))
 #  else
 #    define _CONVERT_FN(x) ((_TYPE2)x)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -573,6 +573,17 @@ class TestBool(TestCase):
         self.assertTrue(array([True])[0] is a1)
         self.assertTrue(array(True)[()] is a1)
 
+    def test_sum(self):
+        d = np.ones(101, dtype=np.bool);
+        assert_equal(d.sum(), d.size)
+        assert_equal(d[::2].sum(), d[::2].size)
+        assert_equal(d[::-2].sum(), d[::-2].size)
+
+        d = np.frombuffer(b'\xff\xff' * 100, dtype=bool)
+        assert_equal(d.sum(), d.size)
+        assert_equal(d[::2].sum(), d[::2].size)
+        assert_equal(d[::-2].sum(), d[::-2].size)
+
 
 class TestMethods(TestCase):
     def test_test_round(self):


### PR DESCRIPTION
avoids some issues of booleans coming from external buffers that may not
only contain 0 or 1.
closes #3801.
