### PR TITLE
[fix] Check for errors in PyArray_CanCastTypeto DEPRECATE

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -583,9 +583,13 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
         same_kind_ok = PyArray_CanCastTypeTo_impl(from, to,
                                                   NPY_SAME_KIND_CASTING);
         if (unsafe_ok && !same_kind_ok) {
-            DEPRECATE("Implicitly casting between incompatible kinds. In "
-                      "a future numpy release, this will raise an error. "
-                      "Use casting=\"unsafe\" if this is intentional.");
+            if (DEPRECATE("Implicitly casting between incompatible kinds. In "
+                          "a future numpy release, this will raise an error. "
+                          "Use casting=\"unsafe\" if this is intentional.")
+                < 0) {
+                /* We have no way to propagate an exception :-( */
+                PyErr_Clear();
+            }
         }
         return unsafe_ok;
     }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -583,12 +583,18 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
         same_kind_ok = PyArray_CanCastTypeTo_impl(from, to,
                                                   NPY_SAME_KIND_CASTING);
         if (unsafe_ok && !same_kind_ok) {
-            if (DEPRECATE("Implicitly casting between incompatible kinds. In "
-                          "a future numpy release, this will raise an error. "
-                          "Use casting=\"unsafe\" if this is intentional.")
-                < 0) {
+            char * msg = "Implicitly casting between incompatible kinds. In "
+                "a future numpy release, this will raise an error. "
+                "Use casting=\"unsafe\" if this is intentional.";
+            if (DEPRECATE(msg) < 0) {
                 /* We have no way to propagate an exception :-( */
                 PyErr_Clear();
+                PySys_WriteStderr("Sorry, you requested this warning "
+                                  "be raised as an error, but we couldn't "
+                                  "do it. (See issue #3806 in the numpy "
+                                  "bug tracker.) So FYI, it was: "
+                                  "DeprecationWarning: %s\n",
+                                  msg);
             }
         }
         return unsafe_ok;

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -787,6 +787,19 @@ class TestUfunc(TestCase):
         assert_no_warnings(np.add, a, 1.1, out=a, casting="unsafe")
         assert_array_equal(a, [4, 5, 6])
 
+        # There's no way to propagate exceptions from the place where we issue
+        # this deprecation warning, so we must throw the exception away
+        # entirely rather than cause it to be raised at some other point, or
+        # trigger some other unsuspecting if (PyErr_Occurred()) { ...} at some
+        # other location entirely.
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # No error
+            a += 1.1
+            # No error on the next bit of code executed either
+            1 + 1
+
     def test_ufunc_custom_out(self):
         # Test ufunc with built in input types and custom output type
 


### PR DESCRIPTION
If a user had set warnings to raise errors, then this DEPRECATE would
leave us with an unpropagated exception and cause havoc downstream.

Unfortunately there is no way to propagate an exception from here, so
we just have to throw it away :-(. But this is still better than the
alternative...

Needs backport.
