### PR TITLE
Backport 1.7 3806

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -564,12 +564,18 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
         same_kind_ok = PyArray_CanCastTypeTo_impl(from, to,
                                                   NPY_SAME_KIND_CASTING);
         if (unsafe_ok && !same_kind_ok) {
-            if (DEPRECATE("Implicitly casting between incompatible kinds. In "
-                          "a future numpy release, this will raise an error. "
-                          "Use casting=\"unsafe\" if this is intentional.")
-                < 0) {
+            char * msg = "Implicitly casting between incompatible kinds. In "
+                "a future numpy release, this will raise an error. "
+                "Use casting=\"unsafe\" if this is intentional.";
+            if (DEPRECATE(msg) < 0) {
                 /* We have no way to propagate an exception :-( */
                 PyErr_Clear();
+                PySys_WriteStderr("Sorry, you requested this warning "
+                                  "be raised as an error, but we couldn't "
+                                  "do it. (See issue #3806 in the numpy "
+                                  "bug tracker.) So FYI, it was: "
+                                  "DeprecationWarning: %s\n",
+                                  msg);
             }
         }
         return unsafe_ok;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -564,9 +564,13 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
         same_kind_ok = PyArray_CanCastTypeTo_impl(from, to,
                                                   NPY_SAME_KIND_CASTING);
         if (unsafe_ok && !same_kind_ok) {
-            DEPRECATE("Implicitly casting between incompatible kinds. In "
-                      "a future numpy release, this will raise an error. "
-                      "Use casting=\"unsafe\" if this is intentional.");
+            if (DEPRECATE("Implicitly casting between incompatible kinds. In "
+                          "a future numpy release, this will raise an error. "
+                          "Use casting=\"unsafe\" if this is intentional.")
+                < 0) {
+                /* We have no way to propagate an exception :-( */
+                PyErr_Clear();
+            }
         }
         return unsafe_ok;
     }

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -760,5 +760,30 @@ class TestUfunc(TestCase):
         assert_no_warnings(np.add, a, 1.1, out=a, casting="unsafe")
         assert_array_equal(a, [4, 5, 6])
 
+        # There's no way to propagate exceptions from the place where we issue
+        # this deprecation warning, so we must throw the exception away
+        # entirely rather than cause it to be raised at some other point, or
+        # trigger some other unsuspecting if (PyErr_Occurred()) { ...} at some
+        # other location entirely.
+        import warnings
+        import sys
+        if sys.version_info[0] >= 3:
+            from io import StringIO
+        else:
+            from StringIO import StringIO
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            old_stderr = sys.stderr
+            try:
+                sys.stderr = StringIO()
+                # No error, but dumps to stderr
+                a += 1.1
+                # No error on the next bit of code executed either
+                1 + 1
+                assert_("Implicitly casting" in sys.stderr.getvalue())
+            finally:
+                sys.stderr = old_stderr
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport #3806: `[fix] Check for errors in PyArray_CanCastTypeto DEPRECATE`. 
