### PR TITLE
ENH: reduce the alignment requirement for complex arrays on x86

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -10,6 +10,7 @@
 #include "npy_pycompat.h"
 #include "numpy/npy_math.h"
 #include "numpy/halffloat.h"
+#include "numpy/npy_cpu.h"
 
 #include "npy_config.h"
 #include "npy_sort.h"
@@ -21,6 +22,9 @@
 
 #include "numpyos.h"
 
+#if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
+#define NPY_USE_UNALIGNED_ACCESS
+#endif
 
 /*
  *****************************************************************************
@@ -3821,8 +3825,15 @@ NPY_NO_EXPORT PyArray_Descr @from@_Descr = {
     NPY_@from@,
     /* elsize */
     @num@ * sizeof(@fromtype@),
-    /* alignment */
+    /*
+     * alignment, platforms without unaligned access need double alignment
+     * for dtype dtransfers
+     */
+#ifdef NPY_USE_UNALIGNED_ACCESS
+    _ALIGN(@fromtype@),
+#else
     @num@ * _ALIGN(@fromtype@),
+#endif
     /* subarray */
     NULL,
     /* fields */
@@ -4164,7 +4175,15 @@ set_typeinfo(PyObject *dict)
 #endif
                 NPY_@name@,
                 NPY_BITSOF_@name@,
+                /*
+                 * alignment, platforms without unaligned access need double
+                 * alignment for dtype dtransfers
+                 */
+#ifdef NPY_USE_UNALIGNED_ACCESS
+                _ALIGN(@type@),
+#else
                 @num@ * _ALIGN(@type@),
+#endif
                 (PyObject *) &Py@Name@ArrType_Type));
     Py_DECREF(s);
 


### PR DESCRIPTION
x86 can deal with unaligned memory access so it does not need to align
complex types to 2 \* sizeof(T) for the dtype transfers which work on the
full complex number.
closes #3768

Does not fix that new complex arrays are reported as aligned when
the allocator does not provide the required alignment.
