### PR TITLE
Fix platform detection for intel platforms

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1386,6 +1386,7 @@ class lapack_opt_info(system_info):
             args = []
             link_args = []
             if get_platform()[-4:] == 'i386' or 'intel' in get_platform() or \
+               'x86_64' in get_platform() or \
                'i386' in platform.platform():
                 intel = 1
             else:
@@ -1482,6 +1483,7 @@ class blas_opt_info(system_info):
             args = []
             link_args = []
             if get_platform()[-4:] == 'i386' or 'intel' in get_platform() or \
+               'x86_64' in get_platform() or \
                'i386' in platform.platform():
                 intel = 1
             else:


### PR DESCRIPTION
Installation of numpy fails on my Mac OSX machine as `distutils/system_info.py` wrongly assumes a non-intel platform:

```
>>> from distutils.util import get_platform
>>> get_platform()
'macosx-10.8-x86_64'
```

This PR fixes the issue by testing for:

```
'x86_64' in get_platform()
```

Related: #2631
