### PR TITLE
A couple micro optimizations

### DIFF
--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -84,6 +84,29 @@ npy_is_aligned(const void * p, const npy_uintp alignment)
     }
 }
 
+/*
+ * writes result of a * b into r
+ * returns 1 if a * b overflowed else returns 0
+ */
+static NPY_INLINE int
+npy_mul_with_overflow_intp(npy_intp * r, npy_intp a, npy_intp b)
+{
+    const npy_intp half_sz = (((npy_intp)1 << (sizeof(a) * 8 / 2)) - 1);
+
+    *r = a * b;
+
+    /*
+     * avoid expensive division on common no overflow case
+     * could be improved via compiler intrinsics e.g. via clang
+     * __builtin_mul_with_overflow, gcc __int128 or cpu overflow flags
+     */
+    if (NPY_UNLIKELY((a | b) >= half_sz) &&
+        a != 0 && b > NPY_MAX_INTP / a) {
+        return 1;
+    }
+
+    return 0;
+}
 
 #include "ucsnarrow.h"
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -115,7 +115,6 @@ NPY_NO_EXPORT npy_intp
 PyArray_OverflowMultiplyList(npy_intp *l1, int n)
 {
     npy_intp prod = 1;
-    npy_intp imax = NPY_MAX_INTP;
     int i;
 
     for (i = 0; i < n; i++) {
@@ -124,11 +123,9 @@ PyArray_OverflowMultiplyList(npy_intp *l1, int n)
         if (dim == 0) {
             return 0;
         }
-        if (dim > imax) {
+        if (npy_mul_with_overflow_intp(&prod, prod, dim)) {
             return -1;
         }
-        imax /= dim;
-        prod *= dim;
     }
     return prod;
 }

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -429,6 +429,7 @@ def test_roundtrip():
         yield assert_array_equal, arr, arr2
 
 
+@dec.slow
 def test_memmap_roundtrip():
     # XXX: test crashes nose on windows. Fix this
     if not (sys.platform == 'win32' or sys.platform == 'cygwin'):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1430,7 +1430,7 @@ class TestInterp(TestCase):
         assert_almost_equal(np.interp(x0, x, y), .3)
 
     def test_if_len_x_is_small(self):
-        xp = np.arange(0, 1000, 0.0001)
+        xp = np.arange(0, 10, 0.0001)
         fp = np.sin(xp)
         assert_almost_equal(np.interp(np.pi, xp, fp), 0.0)
 


### PR DESCRIPTION
add faster npy_mul_with_overflow_intp and use it in PyArray_NewFromDescr and PyArray_OverflowMultiplyList
makes the former about two times faster according to perf.

improve _IsAligned, probably no measuable impact, but unifies it with raw_array_is_aligned.

improve test speed by making one faster and moving test_memmap_roundtrip to slow tests.
