### PR TITLE
Remove travis 2.4 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ env:
   - TEST_PY24=""
 matrix:
   include:
-    - python: 2.5
-      env: TEST_PY24="true"
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=1
     - python: 3.2


### PR DESCRIPTION
The Travis pip version no longer supports 2.4 and the test always fails on that account. 
