### PR TITLE
Backport 1.8 3821

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -217,6 +217,7 @@ else:
                                              '/usr/include/X11'])
 
     import subprocess as sp
+    tmp = None
     try:
         # Explicitly open/close file to avoid ResourceWarning when
         # tests are run in debug mode Python 3.
@@ -234,7 +235,8 @@ else:
             default_x11_lib_dirs += [os.path.join("/usr/lib/", triplet)]
             default_lib_dirs += [os.path.join("/usr/lib/", triplet)]
     finally:
-        tmp.close()
+        if tmp is not None:
+            tmp.close()
 
 if os.path.join(sys.prefix, 'lib') not in default_lib_dirs:
     default_lib_dirs.insert(0, os.path.join(sys.prefix, 'lib'))


### PR DESCRIPTION
Backport #3821:`Installation fails with NameError if SandboxViolation is raised`.
