### PR TITLE
Backport 1.7 3342

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -221,8 +221,10 @@ else:
         tmp = open(os.devnull, 'w')
         p = sp.Popen(["gcc", "-print-multiarch"], stdout=sp.PIPE,
                 stderr=tmp)
-    except OSError:
-        pass # gcc is not installed
+    except (OSError, DistutilsError):
+        # OSError if gcc is not installed, or SandboxViolation (DistutilsError
+        # subclass) if an old setuptools bug is triggered (see gh-3160).
+        pass
     else:
         triplet = str(p.communicate()[0].decode().strip())
         if p.returncode == 0:


### PR DESCRIPTION
BAckport #3342: `BLD: fix setuptools-specific easy_install issue. Closes gh-3160.`
