### PR TITLE
MAINT: Make useless imports of oldnumeric and numarray safe.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -121,6 +121,12 @@ class ModuleDeprecationWarning(DeprecationWarning):
     pass
 
 
+# oldnumeric and numarray were removed in 1.9. In case some packages import
+# but do not use them, we define them here for backward compatibility.
+oldnumeric = 'removed'
+numarray = 'removed'
+
+
 # We first need to detect if we're being called as part of the numpy setup
 # procedure itself in a reliable manner.
 try:


### PR DESCRIPTION
The oldnumeric and numarray packages were removed in numpy 1.9, but
some packages, e.g. scipy, import them even though they are not used.
This defines both to the string 'removed' in numpy/**init**.py, which
avoids an import error.
