### PR TITLE
BUG: core: consider both C and F order buffers as contiguous

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1906,6 +1906,13 @@ class TestRegression(TestCase):
         assert_(c.flags.fortran)
         assert_(c.flags.f_contiguous)
 
+    def test_fortran_order_buffer(self):
+        import numpy as np
+        a = np.array([['Hello', 'Foob']], dtype='<U5', order='F')
+        arr = np.ndarray(shape=[1, 2, 5], dtype='<U1', buffer=a)
+        arr2 = np.array([[[sixu('H'), sixu('e'), sixu('l'), sixu('l'), sixu('o')],
+                          [sixu('F'), sixu('o'), sixu('o'), sixu('b'), sixu('')]]])
+        assert_array_equal(arr, arr2)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Accept also Fortran-order buffers as continuous in ndarray constructor. (The Bufferconverter is apparently not used elsewhere in the codebase.)

This commit plays fast and loose with the buffer life cycle management. However, this is also what PyObject_AsWriteBuffer does, as can be easily checked in [CPython sources](http://hg.python.org/cpython/file/f6792f734fcc/Objects/abstract.c#l321), so the situation does not get worse by this change.

The life cycle management of PEP-3118 buffers unfortunately is somewhat a PITA, since Py_buffer is not a refcounted Python object. In the long term, we want a managed buffer object --- this can be copied directly from [Python3 sources](http://hg.python.org/cpython/file/f6792f734fcc/Objects/memoryobject.c#l7), since they implemented one in order to implement memoryviews in a correct fashion.

Fixes gh-3796
