### PR TITLE
Backport 1.8 3827

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1912,6 +1912,13 @@ class TestRegression(TestCase):
         assert_(c.flags.fortran)
         assert_(c.flags.f_contiguous)
 
+    def test_fortran_order_buffer(self):
+        import numpy as np
+        a = np.array([['Hello', 'Foob']], dtype='<U5', order='F')
+        arr = np.ndarray(shape=[1, 2, 5], dtype='<U1', buffer=a)
+        arr2 = np.array([[[sixu('H'), sixu('e'), sixu('l'), sixu('l'), sixu('o')],
+                          [sixu('F'), sixu('o'), sixu('o'), sixu('b'), sixu('')]]])
+        assert_array_equal(arr, arr2)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport #3827: `BUG: core: consider both C and F order buffers as contiguous`
