### PR TITLE
MAINT (API?): organize npyio.recfromcsv defaults

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -207,6 +207,12 @@ is being casted. Previously the casting was allowed even if the result was
 truncated.
 
 
+`npyio.recfromcsv` keyword arguments change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`npyio.recfromcsv` no longer accepts the undocumented `update` keyword,
+which used to override the `dtype` keyword.
+
+ 
 C-API
 ~~~~~
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1871,6 +1871,11 @@ def recfromcsv(fname, **kwargs):
     --------
     numpy.genfromtxt : generic function to load ASCII data.
 
+    Notes
+    -----
+    By default, `dtype` is None, which means that the data-type of the output
+    array will be determined from the data.
+
     """
     # Set default kwargs as relevant to csv import.
     # These seem to be undocumented. (case_sensitive is mentioned in basics.io)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1877,15 +1877,11 @@ def recfromcsv(fname, **kwargs):
     array will be determined from the data.
 
     """
-    # Set default kwargs as relevant to csv import.
-    # These seem to be undocumented. (case_sensitive is mentioned in basics.io)
+    # Set default kwargs for genfromtxt as relevant to csv import.
     kwargs.setdefault("case_sensitive", "lower")
-    # previously, names were set to True if they were not set or if they
-    # were set to None, overriding the user's choice.
     kwargs.setdefault("names", True)
     kwargs.setdefault("delimiter", ",")
     kwargs.setdefault("dtype", None)
-
     output = genfromtxt(fname, **kwargs)
 
     usemask = kwargs.get("usemask", False)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1844,7 +1844,7 @@ def recfromtxt(fname, **kwargs):
     array will be determined from the data.
 
     """
-    kwargs.update(dtype=kwargs.get('dtype', None))
+    kwargs.setdefault("dtype", None)
     usemask = kwargs.get('usemask', False)
     output = genfromtxt(fname, **kwargs)
     if usemask:
@@ -1872,16 +1872,18 @@ def recfromcsv(fname, **kwargs):
     numpy.genfromtxt : generic function to load ASCII data.
 
     """
-    case_sensitive = kwargs.get('case_sensitive', "lower") or "lower"
-    names = kwargs.get('names', True)
-    if names is None:
-        names = True
-    kwargs.update(dtype=kwargs.get('update', None),
-                  delimiter=kwargs.get('delimiter', ",") or ",",
-                  names=names,
-                  case_sensitive=case_sensitive)
-    usemask = kwargs.get("usemask", False)
+    # Set default kwargs as relevant to csv import.
+    # These seem to be undocumented. (case_sensitive is mentioned in basics.io)
+    kwargs.setdefault("case_sensitive", "lower")
+    # previously, names were set to True if they were not set or if they
+    # were set to None, overriding the user's choice.
+    kwargs.setdefault("names", True)
+    kwargs.setdefault("delimiter", ",")
+    kwargs.setdefault("dtype", None)
+
     output = genfromtxt(fname, **kwargs)
+
+    usemask = kwargs.get("usemask", False)
     if usemask:
         from numpy.ma.mrecords import MaskedRecords
         output = output.view(MaskedRecords)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1572,6 +1572,14 @@ M   33  21.99
                            dtype=[('a', np.int), ('b', np.int)])
         self.assertTrue(isinstance(test, np.recarray))
         assert_equal(test, control)
+        #
+        data = TextIO('A,B\n0,1\n2,3')
+        dtype = [('a', np.int), ('b', np.float)]
+        test = np.recfromcsv(data, missing_values='N/A', dtype=dtype)
+        control = np.array([(0, 1), (2, 3)],
+                           dtype=dtype)
+        self.assertTrue(isinstance(test, np.recarray))
+        assert_equal(test, control)
 
     def test_gft_using_filename(self):
         # Test that we can load data from a filename as well as a file object


### PR DESCRIPTION
Organizes the default kwargs in recfromcsv. Changes two undocumented
kwargs behaviors:
-  previously, if a user set `names=None`, it was ignored and replaced
  with `names=True`
-  the `dtype` kwarg was ignored. If `update` was given, it was used as
  `dtype`, and if not, None was used. We can retain the `update` behavior
  by using `kwargs.setdefault("dtype",kwargs.get('update', None))`.
  This Closes #311 .
