### PR TITLE
MAINT: fix another wrong NULL check

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2960,7 +2960,7 @@ _calc_length(PyObject *start, PyObject *stop, PyObject *step, PyObject **next, i
     }
     if (len > 0) {
         *next = PyNumber_Add(start, step);
-        if (!next) {
+        if (!*next) {
             return -1;
         }
     }


### PR DESCRIPTION
silences cppcheck error, not a bug as the only caller checks the python
error.
