### PR TITLE
Backport 1.8 3851

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2670,7 +2670,7 @@ def median(a, axis=None, out=None, overwrite_input=False):
     >>> assert not np.all(a==b)
 
     """
-    a = np.asarray(a)
+    a = np.asanyarray(a)
     if axis is not None and axis >= a.ndim:
         raise IndexError("axis %d out of bounds (%d)" % (axis, a.ndim))
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1483,6 +1483,19 @@ class TestMedian(TestCase):
         assert_almost_equal(np.median(x2), 2)
         assert_allclose(np.median(x2, axis=0), x)
 
+    def test_subclass(self):
+        # gh-3846
+        class MySubClass(np.ndarray):
+            def __new__(cls, input_array, info=None):
+                obj = np.asarray(input_array).view(cls)
+                obj.info = info
+                return obj
+
+            def mean(self, axis=None, dtype=None, out=None):
+                return -7
+
+        a = MySubClass([1,2,3])
+        assert_equal(np.median(a), -7)
 
 class TestAdd_newdoc_ufunc(TestCase):
 


### PR DESCRIPTION
Backport #3851: `BUG: preserve ndarray subclasses in median`.

Closes #3846.
