### PR TITLE
BUG: core: ensure __r*__ has precedence over __numpy_ufunc__

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -80,6 +80,35 @@ Numpy provides several hooks that classes can customize:
       overrides the behavior of :func:`numpy.dot` even though it is
       not an Ufunc.
 
+   .. note:: If you also define right-hand binary operator override
+      methods (such as ``__rmul__``) or comparison operations (such as
+      ``__gt__``) in your class, they take precedence over the
+      :func:`__numpy_ufunc__` mechanism when resolving results of
+      binary operations (such as ``ndarray_obj * your_obj``).
+
+      The technical special case is: ``ndarray.__mul__`` returns
+      ``NotImplemented`` if the other object is *not* a subclass of
+      :class:`ndarray`, and defines both ``__numpy_ufunc__`` and
+      ``__rmul__``. Similar exception applies for the other operations
+      than multiplication.
+
+      In such a case, when computing a binary operation such as
+      ``ndarray_obj * your_obj``, your ``__numpy_ufunc__`` method
+      *will not* be called.  Instead, the execution passes on to your
+      right-hand ``__rmul__`` operation, as per standard Python
+      operator override rules.
+
+      Similar special case applies to *in-place operations*: If you
+      define ``__rmul__``, then ``ndarray_obj *= your_obj`` *will not*
+      call your ``__numpy_ufunc__`` implementation. Instead, the
+      default Python behavior ``ndarray_obj = ndarray_obj * your_obj``
+      occurs.
+
+      Note that the above discussion applies only to Python's builtin
+      binary operation mechanism. ``np.multiply(ndarray_obj,
+      your_obj)`` always calls only your ``__numpy_ufunc__``, as
+      expected.
+
 .. function:: class.__array_finalize__(self)
 
    This method is called whenever the system internally allocates a

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1273,10 +1273,19 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
 
     switch (cmp_op) {
     case Py_LT:
+        if (needs_right_binop_forward(self, other, "__gt__", 0)) {
+            /* See discussion in number.c */
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
         result = PyArray_GenericBinaryFunction(self, other,
                 n_ops.less);
         break;
     case Py_LE:
+        if (needs_right_binop_forward(self, other, "__ge__", 0)) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
         result = PyArray_GenericBinaryFunction(self, other,
                 n_ops.less_equal);
         break;
@@ -1284,6 +1293,10 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         if (other == Py_None) {
             Py_INCREF(Py_False);
             return Py_False;
+        }
+        if (needs_right_binop_forward(self, other, "__eq__", 0)) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
         }
         result = PyArray_GenericBinaryFunction(self,
                 (PyObject *)other,
@@ -1343,6 +1356,10 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_True);
             return Py_True;
         }
+        if (needs_right_binop_forward(self, other, "__ne__", 0)) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
         result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
                 n_ops.not_equal);
         if (result && result != Py_NotImplemented)
@@ -1392,10 +1409,18 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         }
         break;
     case Py_GT:
+        if (needs_right_binop_forward(self, other, "__lt__", 0)) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
         result = PyArray_GenericBinaryFunction(self, other,
                 n_ops.greater);
         break;
     case Py_GE:
+        if (needs_right_binop_forward(self, other, "__le__", 0)) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
         result = PyArray_GenericBinaryFunction(self, other,
                 n_ops.greater_equal);
         break;

--- a/numpy/core/src/multiarray/number.h
+++ b/numpy/core/src/multiarray/number.h
@@ -69,4 +69,8 @@ NPY_NO_EXPORT PyObject *
 PyArray_GenericAccumulateFunction(PyArrayObject *m1, PyObject *op, int axis,
                                   int rtype, PyArrayObject *out);
 
+NPY_NO_EXPORT int
+needs_right_binop_forward(PyObject *self, PyObject *other, char *right_name,
+                          int is_inplace);
+
 #endif


### PR DESCRIPTION
Add a special case to the implementation of `ndarray.__mul__` et al. that refuses to work on other objects that are not ndarray subclasses and implement both `__numpy_ufunc__` and `__r*__`.

This way, execution passes first to the custom `__r*__` method, which makes it possible to have e.g. `__mul__` and np.multiply do different things.

Additionally, disable one `__array_priority__` special case handling when also `__numpy_ufunc__` is defined (which may have been the reason why `__rmul__` continued to work in scipy.sparse matrices).

Addresses gh-3812

Feedback welcome --- I think this solves the issue without being too magical, but YMMV
