### PR TITLE
MAINT: accept NULL in NpyIter_Deallocate and remove redundant NULL checks

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1627,19 +1627,13 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     }
 
     PyDimMem_FREE(dims.ptr);
-    if (strides.ptr) {
-        PyDimMem_FREE(strides.ptr);
-    }
+    PyDimMem_FREE(strides.ptr);
     return (PyObject *)ret;
 
  fail:
     Py_XDECREF(descr);
-    if (dims.ptr) {
-        PyDimMem_FREE(dims.ptr);
-    }
-    if (strides.ptr) {
-        PyDimMem_FREE(strides.ptr);
-    }
+    PyDimMem_FREE(dims.ptr);
+    PyDimMem_FREE(strides.ptr);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -3522,12 +3522,8 @@ find_string_array_datetime64_type(PyArrayObject *arr,
     return 0;
 
 fail:
-    if (tmp_buffer != NULL) {
-        PyArray_free(tmp_buffer);
-    }
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
+    PyArray_free(tmp_buffer);
+    NpyIter_Deallocate(iter);
 
     return -1;
 }

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -719,9 +719,7 @@ typedef struct {
 void _strided_datetime_cast_data_free(NpyAuxData *data)
 {
     _strided_datetime_cast_data *d = (_strided_datetime_cast_data *)data;
-    if (d->tmp_buffer != NULL) {
-        PyArray_free(d->tmp_buffer);
-    }
+    PyArray_free(d->tmp_buffer);
     PyArray_free(data);
 }
 
@@ -2296,9 +2294,7 @@ get_subarray_transfer_function(int aligned,
     if (PyDataType_HASSUBARRAY(dst_dtype)) {
        if (!(PyArray_IntpConverter(dst_dtype->subarray->shape,
                                             &dst_shape))) {
-            if (src_shape.ptr != NULL) {
-                PyDimMem_FREE(src_shape.ptr);
-            }
+            PyDimMem_FREE(src_shape.ptr);
             PyErr_SetString(PyExc_ValueError,
                     "invalid subarray shape");
             return NPY_FAIL;

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -2085,9 +2085,7 @@ static void neighiter_dealloc(PyArrayNeighborhoodIterObject* iter)
             Py_DECREF(*(PyObject**)iter->constant);
         }
     }
-    if (iter->constant != NULL) {
-        PyDataMem_FREE(iter->constant);
-    }
+    PyDataMem_FREE(iter->constant);
     Py_DECREF(iter->_internal_iter);
 
     array_iter_base_dealloc((PyArrayIterObject*)iter);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1692,9 +1692,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
     }
 
     if ((PyArray_FLAGS(self) & NPY_ARRAY_OWNDATA)) {
-        if (PyArray_DATA(self) != NULL) {
-            PyDataMem_FREE(PyArray_DATA(self));
-        }
+        PyDataMem_FREE(PyArray_DATA(self));
         PyArray_CLEARFLAGS(self, NPY_ARRAY_OWNDATA);
     }
     Py_XDECREF(PyArray_BASE(self));
@@ -1781,9 +1779,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         if (PyArray_DATA(self) == NULL) {
             fa->nd = 0;
             fa->data = PyDataMem_NEW(PyArray_DESCR(self)->elsize);
-            if (PyArray_DIMS(self)) {
-                PyDimMem_FREE(PyArray_DIMS(self));
-            }
+            PyDimMem_FREE(PyArray_DIMS(self));
             return PyErr_NoMemory();
         }
         if (PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_NEEDS_INIT)) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2605,9 +2605,7 @@ array__reconstruct(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
     ret = PyArray_NewFromDescr(subtype, dtype,
             (int)shape.len, shape.ptr, NULL, NULL, 0, NULL);
-    if (shape.ptr) {
-        PyDimMem_FREE(shape.ptr);
-    }
+    PyDimMem_FREE(shape.ptr);
 
     evil_global_disable_warn_O4O8_flag = 0;
 
@@ -2617,9 +2615,7 @@ array__reconstruct(PyObject *NPY_UNUSED(dummy), PyObject *args)
     evil_global_disable_warn_O4O8_flag = 0;
 
     Py_XDECREF(dtype);
-    if (shape.ptr) {
-        PyDimMem_FREE(shape.ptr);
-    }
+    PyDimMem_FREE(shape.ptr);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -639,12 +639,20 @@ NpyIter_Copy(NpyIter *iter)
 NPY_NO_EXPORT int
 NpyIter_Deallocate(NpyIter *iter)
 {
-    npy_uint32 itflags = NIT_ITFLAGS(iter);
+    npy_uint32 itflags;
     /*int ndim = NIT_NDIM(iter);*/
-    int iop, nop = NIT_NOP(iter);
+    int iop, nop;
+    PyArray_Descr **dtype;
+    PyArrayObject **object;
 
-    PyArray_Descr **dtype = NIT_DTYPES(iter);
-    PyArrayObject **object = NIT_OPERANDS(iter);
+    if (iter == NULL) {
+        return NPY_SUCCEED;
+    }
+
+    itflags = NIT_ITFLAGS(iter);
+    nop = NIT_NOP(iter);
+    dtype = NIT_DTYPES(iter);
+    object = NIT_OPERANDS(iter);
 
     /* Deallocate any buffers and buffering data */
     if (itflags & NPY_ITFLAG_BUFFER) {

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -742,9 +742,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
                     &op_axes_in,
                     PyArray_IntpConverter, &itershape,
                     &buffersize)) {
-        if (itershape.ptr != NULL) {
-            PyDimMem_FREE(itershape.ptr);
-        }
+        PyDimMem_FREE(itershape.ptr);
         return -1;
     }
 
@@ -816,9 +814,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
         self->finished = 0;
     }
 
-    if (itershape.ptr != NULL) {
-        PyDimMem_FREE(itershape.ptr);
-    }
+    PyDimMem_FREE(itershape.ptr);
 
     /* Release the references we got to the ops and dtypes */
     for (iop = 0; iop < nop; ++iop) {
@@ -829,9 +825,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     return 0;
 
 fail:
-    if (itershape.ptr != NULL) {
-        PyDimMem_FREE(itershape.ptr);
-    }
+    PyDimMem_FREE(itershape.ptr);
     for (iop = 0; iop < nop; ++iop) {
         Py_XDECREF(op[iop]);
         Py_XDECREF(op_request_dtypes[iop]);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2226,12 +2226,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
 fail:
     NPY_UF_DBG_PRINT1("Returning failure code %d\n", retval);
-    if (inner_strides) {
-        PyArray_free(inner_strides);
-    }
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
+    PyArray_free(inner_strides);
+    NpyIter_Deallocate(iter);
     for (i = 0; i < nop; ++i) {
         Py_XDECREF(op[i]);
         op[i] = NULL;
@@ -3170,12 +3166,8 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
 finish:
     Py_XDECREF(op_dtypes[0]);
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
-    if (iter_inner != NULL) {
-        NpyIter_Deallocate(iter_inner);
-    }
+    NpyIter_Deallocate(iter);
+    NpyIter_Deallocate(iter_inner);
 
     Py_XDECREF(errobj);
 
@@ -3185,12 +3177,8 @@ fail:
     Py_XDECREF(out);
     Py_XDECREF(op_dtypes[0]);
 
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
-    if (iter_inner != NULL) {
-        NpyIter_Deallocate(iter_inner);
-    }
+    NpyIter_Deallocate(iter);
+    NpyIter_Deallocate(iter_inner);
 
     Py_XDECREF(errobj);
 
@@ -3580,9 +3568,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
 finish:
     Py_XDECREF(op_dtypes[0]);
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
+    NpyIter_Deallocate(iter);
 
     Py_XDECREF(errobj);
 
@@ -3592,9 +3578,7 @@ fail:
     Py_XDECREF(out);
     Py_XDECREF(op_dtypes[0]);
 
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
+    NpyIter_Deallocate(iter);
 
     Py_XDECREF(errobj);
 
@@ -4709,24 +4693,12 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
 static void
 ufunc_dealloc(PyUFuncObject *ufunc)
 {
-    if (ufunc->core_num_dims) {
-        PyArray_free(ufunc->core_num_dims);
-    }
-    if (ufunc->core_dim_ixs) {
-        PyArray_free(ufunc->core_dim_ixs);
-    }
-    if (ufunc->core_offsets) {
-        PyArray_free(ufunc->core_offsets);
-    }
-    if (ufunc->core_signature) {
-        PyArray_free(ufunc->core_signature);
-    }
-    if (ufunc->ptr) {
-        PyArray_free(ufunc->ptr);
-    }
-    if (ufunc->op_flags) {
-        PyArray_free(ufunc->op_flags);
-    }
+    PyArray_free(ufunc->core_num_dims);
+    PyArray_free(ufunc->core_dim_ixs);
+    PyArray_free(ufunc->core_offsets);
+    PyArray_free(ufunc->core_signature);
+    PyArray_free(ufunc->ptr);
+    PyArray_free(ufunc->op_flags);
     Py_XDECREF(ufunc->userloops);
     Py_XDECREF(ufunc->obj);
     PyArray_free(ufunc);

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -980,12 +980,8 @@ fail:
     for (i = 0; i < dimensions.len; ++i) {
         Py_XDECREF(op[i]);
     }
-    if (dimensions.ptr) {
-        PyDimMem_FREE(dimensions.ptr);
-    }
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
+    PyDimMem_FREE(dimensions.ptr);
+    NpyIter_Deallocate(iter);
     return NULL;
 }
 
@@ -1247,12 +1243,8 @@ fail:
     Py_XDECREF(ret_arr);
     Py_XDECREF(dtype);
     Py_XDECREF(indices);
-    if (dimensions.ptr) {
-        PyDimMem_FREE(dimensions.ptr);
-    }
-    if (iter != NULL) {
-        NpyIter_Deallocate(iter);
-    }
+    PyDimMem_FREE(dimensions.ptr);
+    NpyIter_Deallocate(iter);
     return NULL;
 }
 


### PR DESCRIPTION
Deallocation should just do nothing if provided a NULL pointer nditer
deletion broke this convention.
Removed many redundant NULL checks for various deallocation functions
used in numpy, they all end up in standard C free or PyMem_Free which
are both NULL safe.
