### PR TITLE
backport-1.7-3872

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -2,6 +2,9 @@
 #define __NPY_MATH_C99_H_
 
 #include <math.h>
+#ifdef __SUNPRO_CC
+#include <sunmath.h>
+#endif
 #include <numpy/npy_common.h>
 
 /*


### PR DESCRIPTION
Backport #3872: `BUG: Include sunmath.h in npy_math.h when __SUNPRO_CC defined.`
