### PR TITLE
Backport 1.8 3872

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -6,10 +6,14 @@ extern "C" {
 #endif
 
 #include <math.h>
+#ifdef __SUNPRO_CC
+#include <sunmath.h>
+#endif
 #ifdef HAVE_NPY_CONFIG_H
 #include <npy_config.h>
 #endif
 #include <numpy/npy_common.h>
+
 
 /*
  * NAN and INFINITY like macros (same behavior as glibc for NAN, same as C99


### PR DESCRIPTION
Backport #3872:`BUG: Include sunmath.h in npy_math.h when __SUNPRO_CC defined.`
