### PR TITLE
Fix for cov() with complex input

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1810,10 +1810,13 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         raise ValueError(
             "ddof must be integer")
 
-    if iscomplexobj(m):
-        X = array(m, ndmin=2, dtype=complex)
+    # Handles complex arrays too
+    if y is None:
+        dtype = np.result_type(m, np.float64)
     else:
-        X = array(m, ndmin=2, dtype=float)
+        dtype = np.result_type(m, y, np.float64)
+    X = array(m, ndmin=2, dtype=dtype)
+
     if X.size == 0:
         # handle empty arrays
         return np.array(m)
@@ -1827,7 +1830,7 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         tup = (newaxis, slice(None))
 
     if y is not None:
-        y = array(y, copy=False, ndmin=2, dtype=float)
+        y = array(y, copy=False, ndmin=2, dtype=dtype)
         X = concatenate((X, y), axis)
 
     X -= X.mean(axis=1-axis)[tup]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -30,6 +30,7 @@ from numpy.core.fromnumeric import (
     ravel, nonzero, choose, sort, partition, mean
     )
 from numpy.core.numerictypes import typecodes, number
+from numpy.lib import iscomplexobj
 from numpy.lib.twodim_base import diag
 from ._compiled_base import _insert, add_docstring
 from ._compiled_base import digitize, bincount, interp as compiled_interp
@@ -1809,7 +1810,10 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         raise ValueError(
             "ddof must be integer")
 
-    X = array(m, ndmin=2, dtype=float)
+    if iscomplexobj(m):
+        X = array(m, ndmin=2, dtype=complex)
+    else:
+        X = array(m, ndmin=2, dtype=float)
     if X.size == 0:
         # handle empty arrays
         return np.array(m)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1822,6 +1822,22 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
     if X.shape[0] == 1:
         rowvar = 1
     if rowvar:
+        N = X.shape[1]
+    else:
+        N = X.shape[0]
+
+    # check ddof
+    if ddof is None:
+        if bias == 0:
+            ddof = 1
+        else:
+            ddof = 0
+    fact = float(N - ddof)
+    if fact <= 0:
+        warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning)
+        fact = 0.0
+
+    if rowvar:
         axis = 0
         tup = (slice(None), newaxis)
     else:
@@ -1833,18 +1849,6 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         X = concatenate((X, y), axis)
 
     X -= X.mean(axis=1-axis)[tup]
-    if rowvar:
-        N = X.shape[1]
-    else:
-        N = X.shape[0]
-
-    if ddof is None:
-        if bias == 0:
-            ddof = 1
-        else:
-            ddof = 0
-    fact = float(N - ddof)
-
     if not rowvar:
         return (dot(X.T, X.conj()) / fact).squeeze()
     else:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1900,10 +1900,8 @@ def corrcoef(x, y=None, rowvar=1, bias=0, ddof=None):
     try:
         d = diag(c)
     except ValueError:  # scalar covariance
-        if np.isnan(c):  # cov returns nan for empty arrays
-            return np.nan
-        else:
-            return 1
+        # nan if incorrect value (nan, inf, 0), 1 otherwise
+        return c / c
     return c / sqrt(multiply.outer(d, d))
 
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -23,14 +23,13 @@ from numpy.core.numeric import (
     newaxis, intp, integer, isscalar
     )
 from numpy.core.umath import (
-    pi, multiply, add, arctan2, frompyfunc, isnan, cos, less_equal, sqrt, sin,
+    pi, multiply, add, arctan2, frompyfunc, cos, less_equal, sqrt, sin,
     mod, exp, log10
     )
 from numpy.core.fromnumeric import (
     ravel, nonzero, choose, sort, partition, mean
     )
 from numpy.core.numerictypes import typecodes, number
-from numpy.lib import iscomplexobj
 from numpy.lib.twodim_base import diag
 from ._compiled_base import _insert, add_docstring
 from ._compiled_base import digitize, bincount, interp as compiled_interp

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -350,8 +350,8 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
         dedges[i] = diff(edges[i])
         if np.any(np.asarray(dedges[i]) <= 0):
             raise ValueError(
-            "Found bin edge of size <= 0. Did you specify `bins` with"
-            "non-monotonic sequence?")
+                "Found bin edge of size <= 0. Did you specify `bins` with"
+                "non-monotonic sequence?")
 
     nbin = asarray(nbin)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1816,15 +1816,16 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
         dtype = np.result_type(m, y, np.float64)
     X = array(m, ndmin=2, dtype=dtype)
 
-    if X.size == 0:
-        # handle empty arrays
-        return np.array(m)
     if X.shape[0] == 1:
         rowvar = 1
     if rowvar:
         N = X.shape[1]
+        axis = 0
+        tup = (slice(None), newaxis)
     else:
         N = X.shape[0]
+        axis = 1
+        tup = (newaxis, slice(None))
 
     # check ddof
     if ddof is None:
@@ -1836,13 +1837,6 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
     if fact <= 0:
         warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning)
         fact = 0.0
-
-    if rowvar:
-        axis = 0
-        tup = (slice(None), newaxis)
-    else:
-        axis = 1
-        tup = (newaxis, slice(None))
 
     if y is not None:
         y = array(y, copy=False, ndmin=2, dtype=dtype)
@@ -1903,14 +1897,14 @@ def corrcoef(x, y=None, rowvar=1, bias=0, ddof=None):
 
     """
     c = cov(x, y, rowvar, bias, ddof)
-    if c.size == 0:
-        # handle empty arrays
-        return c
     try:
         d = diag(c)
     except ValueError:  # scalar covariance
-        return 1
-    return c/sqrt(multiply.outer(d, d))
+        if np.isnan(c):  # cov returns nan for empty arrays
+            return np.nan
+        else:
+            return 1
+    return c / sqrt(multiply.outer(d, d))
 
 
 def blackman(M):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1189,32 +1189,61 @@ class TestCorrCoef(TestCase):
         assert_almost_equal(corrcoef(self.A, ddof=-1), self.res1)
         assert_almost_equal(corrcoef(self.A, self.B, ddof=-1), self.res2)
 
+    def test_complex(self):
+        x = np.array([[1, 2, 3], [1j, 2j, 3j]])
+        assert_allclose(corrcoef(x), np.array([[1., -1.j], [1.j, 1.]]))
+
+    def test_xy(self):
+        x = np.array([[1, 2, 3]])
+        y = np.array([[1j, 2j, 3j]])
+        assert_allclose(np.corrcoef(x, y), np.array([[1., -1.j], [1.j, 1.]]))
+
     def test_empty(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            assert_equal(corrcoef(np.array([])), np.nan)
-            assert_equal(corrcoef(np.array([]).reshape(0, 2)), np.nan)
+            assert_array_equal(corrcoef(np.array([])), np.nan)
+            assert_array_equal(corrcoef(np.array([]).reshape(0, 2)),
+                               np.array([]).reshape(0, 0))
+            assert_array_equal(corrcoef(np.array([]).reshape(2, 0)),
+                               np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+
+    def test_wrong_ddof(self):
+        x = np.array([[0, 2], [1, 1], [2, 0]]).T
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            assert_array_equal(corrcoef(x, ddof=5),
+                               np.array([[np.nan, np.nan], [np.nan, np.nan]]))
 
 
 class TestCov(TestCase):
     def test_basic(self):
         x = np.array([[0, 2], [1, 1], [2, 0]]).T
-        assert_allclose(np.cov(x), np.array([[1., -1.], [-1., 1.]]))
+        assert_allclose(cov(x), np.array([[1., -1.], [-1., 1.]]))
 
     def test_complex(self):
         x = np.array([[1, 2, 3], [1j, 2j, 3j]])
-        assert_allclose(np.cov(x), np.array([[1., -1.j], [1.j, 1.]]))
+        assert_allclose(cov(x), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_xy(self):
         x = np.array([[1, 2, 3]])
         y = np.array([[1j, 2j, 3j]])
-        assert_allclose(np.cov(x, y), np.array([[1., -1.j], [1.j, 1.]]))
+        assert_allclose(cov(x, y), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_empty(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            assert_equal(cov(np.array([])), np.nan)
-            assert_equal(cov(np.array([]).reshape(0, 2)), np.nan)
+            assert_array_equal(cov(np.array([])), np.nan)
+            assert_array_equal(cov(np.array([]).reshape(0, 2)),
+                               np.array([]).reshape(0, 0))
+            assert_array_equal(cov(np.array([]).reshape(2, 0)),
+                               np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+
+    def test_wrong_ddof(self):
+        x = np.array([[0, 2], [1, 1], [2, 0]]).T
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            assert_array_equal(cov(x, ddof=5),
+                               np.array([[np.inf, -np.inf], [-np.inf, np.inf]]))
 
 
 class Test_I0(TestCase):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1203,6 +1203,11 @@ class TestCov(TestCase):
         x = np.array([[1, 2, 3], [1j, 2j, 3j]])
         assert_allclose(np.cov(x), np.array([[1., -1.j], [ 1.j, 1.]]))
 
+    def test_xy(self):
+        x = np.array([[1, 2, 3]])
+        y = np.array([[1j, 2j, 3j]])
+        assert_allclose(np.cov(x, y), np.array([[1., -1.j], [ 1.j, 1.]]))
+
     def test_empty(self):
         assert_equal(cov(np.array([])).size, 0)
         assert_equal(cov(np.array([]).reshape(0, 2)).shape, (0, 2))

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1201,12 +1201,12 @@ class TestCov(TestCase):
 
     def test_complex(self):
         x = np.array([[1, 2, 3], [1j, 2j, 3j]])
-        assert_allclose(np.cov(x), np.array([[1., -1.j], [ 1.j, 1.]]))
+        assert_allclose(np.cov(x), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_xy(self):
         x = np.array([[1, 2, 3]])
         y = np.array([[1j, 2j, 3j]])
-        assert_allclose(np.cov(x, y), np.array([[1., -1.j], [ 1.j, 1.]]))
+        assert_allclose(np.cov(x, y), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_empty(self):
         assert_equal(cov(np.array([])).size, 0)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1199,6 +1199,10 @@ class TestCov(TestCase):
         x = np.array([[0, 2], [1, 1], [2, 0]]).T
         assert_allclose(np.cov(x), np.array([[1., -1.], [-1., 1.]]))
 
+    def test_complex(self):
+        x = np.array([[1, 2, 3], [1j, 2j, 3j]])
+        assert_allclose(np.cov(x), np.array([[1., -1.j], [ 1.j, 1.]]))
+
     def test_empty(self):
         assert_equal(cov(np.array([])).size, 0)
         assert_equal(cov(np.array([]).reshape(0, 2)).shape, (0, 2))

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1190,8 +1190,10 @@ class TestCorrCoef(TestCase):
         assert_almost_equal(corrcoef(self.A, self.B, ddof=-1), self.res2)
 
     def test_empty(self):
-        assert_equal(corrcoef(np.array([])).size, 0)
-        assert_equal(corrcoef(np.array([]).reshape(0, 2)).shape, (0, 2))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            assert_equal(corrcoef(np.array([])), np.nan)
+            assert_equal(corrcoef(np.array([]).reshape(0, 2)), np.nan)
 
 
 class TestCov(TestCase):
@@ -1209,8 +1211,10 @@ class TestCov(TestCase):
         assert_allclose(np.cov(x, y), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_empty(self):
-        assert_equal(cov(np.array([])).size, 0)
-        assert_equal(cov(np.array([]).reshape(0, 2)).shape, (0, 2))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            assert_equal(cov(np.array([])), np.nan)
+            assert_equal(cov(np.array([]).reshape(0, 2)), np.nan)
 
 
 class Test_I0(TestCase):


### PR DESCRIPTION
Closes issues #597 and #2680, which are duplicates.

It follows #2716 which was abandoned.

The example for the test was taken from #597.
