### PR TITLE
BUG: Disable check for oldstyle classes in python3 (np.info)

### DIFF
--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import os
 import sys
 
 import numpy as np
@@ -239,6 +240,19 @@ class TestRegression(TestCase):
             np.nansum(a)
         except:
             raise AssertionError()
+
+    def test_py3_compat(self):
+        # gh-2561
+        # Test if the oldstyle class test is bypassed in python3
+        class C():
+            """Old-style class in python2, normal class in python3"""
+            pass
+
+        out = open(os.devnull, 'w')
+        try:
+            np.info(C(), output=out)
+        finally:
+            out.close()
 
 
 if __name__ == "__main__":

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -251,6 +251,8 @@ class TestRegression(TestCase):
         out = open(os.devnull, 'w')
         try:
             np.info(C(), output=out)
+        except AttributeError:
+            raise AssertionError()
         finally:
             out.close()
 

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -561,7 +561,10 @@ def info(object=None,maxwidth=76,output=sys.stdout,toplevel='numpy'):
                     methstr, other = pydoc.splitdoc(inspect.getdoc(thisobj) or "None")
                 print("  %s  --  %s" % (meth, methstr), file=output)
 
-    elif isinstance(object, types.InstanceType): ## check for __call__ method
+    elif (sys.version_info[0] < 3
+            and isinstance(object, types.InstanceType)):
+        # check for __call__ method
+        # types.InstanceType is the type of the instances of oldstyle classes
         print("Instance of class: ", object.__class__.__name__, file=output)
         print(file=output)
         if hasattr(object, '__call__'):


### PR DESCRIPTION
This fixes gh-2561.

During the test, nose raises a ResourceWarning. It has been fixed in newer versions of nose (see https://github.com/nose-devs/nose/issues/524). In the meantime I tried to disable it from within the test with 

```
with warnings.catch_warnings():
    warnings.simplefilter("ignore", ResourceWarning)
```

but it didn't work as the warning is raised from outside the test.
Maybe the test itself is not really necessary ?
