### PR TITLE
BUG Ensure NotImplemented is passed on in MaskedArray ufunc's

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -930,6 +930,9 @@ class _MaskedBinaryOperation:
         with np.errstate():
             np.seterr(divide='ignore', invalid='ignore')
             result = self.f(da, db, *args, **kwargs)
+        # check it worked
+        if result is NotImplemented:
+            return NotImplemented
         # Case 1. : scalar
         if not result.ndim:
             if m:
@@ -999,6 +1002,9 @@ class _MaskedBinaryOperation:
             return masked
         (da, db) = (getdata(a), getdata(b))
         d = self.f.outer(da, db)
+        # check it worked
+        if d is NotImplemented:
+            return NotImplemented
         if m is not nomask:
             np.copyto(d, da, where=m)
         if d.shape:
@@ -1065,6 +1071,9 @@ class _DomainedBinaryOperation:
         with np.errstate():
             np.seterr(divide='ignore', invalid='ignore')
             result = self.f(da, db, *args, **kwargs)
+        # check it worked
+        if result is NotImplemented:
+            return NotImplemented
         # Get the mask as a combination of ma, mb and invalid
         m = ~umath.isfinite(result)
         m |= ma

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1663,14 +1663,15 @@ class TestUfuncs(TestCase):
         self.assertTrue(not isinstance(test.mask, MaskedArray))
 
     def test_treatment_of_NotImplemented(self):
-        "Check we return NotImplemented if ufunc cannot deal with other"
+        "Check any NotImplemented returned by umath.<ufunc> is passed on"
         a = masked_array([1., 2.], mask=[1, 0])
-        # basic test
-        assert a.__mul__('abc') == NotImplemented  # _MaskedBinaryOperation
-        assert multiply.outer(a, 'abc') == NotImplemented
-        assert a.__div__('abc') == NotImplemented  # _DomainedBinaryOperation
+        # basic tests for _MaskedBinaryOperation
+        assert_(a.__mul__('abc') is NotImplemented)
+        assert_(multiply.outer(a, 'abc') is NotImplemented)
+        # and for _DomainedBinaryOperation
+        assert_(a.__div__('abc') is NotImplemented)
 
-        # also check that rmul of another class can be accessed
+        # also check explicitly that rmul of another class can be accessed
         class MyClass(str):
             def __mul__(self, other):
                 return "My mul"
@@ -1679,8 +1680,8 @@ class TestUfuncs(TestCase):
                 return "My rmul"
 
         me = MyClass()
-        assert me * a == "My mul"
-        assert a * me == "My rmul"
+        assert_(me * a == "My mul")
+        assert_(a * me == "My rmul")
 
 #------------------------------------------------------------------------------
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1662,6 +1662,26 @@ class TestUfuncs(TestCase):
         assert_equal(test.mask, control.mask)
         self.assertTrue(not isinstance(test.mask, MaskedArray))
 
+    def test_treatment_of_NotImplemented(self):
+        "Check we return NotImplemented if ufunc cannot deal with other"
+        a = masked_array([1., 2.], mask=[1, 0])
+        # basic test
+        assert a.__mul__('abc') == NotImplemented  # _MaskedBinaryOperation
+        assert multiply.outer(a, 'abc') == NotImplemented
+        assert a.__div__('abc') == NotImplemented  # _DomainedBinaryOperation
+
+        # also check that rmul of another class can be accessed
+        class MyClass(str):
+            def __mul__(self, other):
+                return "My mul"
+
+            def __rmul__(self, other):
+                return "My rmul"
+
+        me = MyClass()
+        assert me * a == "My mul"
+        assert a * me == "My rmul"
+
 #------------------------------------------------------------------------------
 
 class TestMaskedArrayInPlaceArithmetics(TestCase):


### PR DESCRIPTION
Currently, masked array `ufunc` replacements do not check whether the `ufunc` call on the data proper actually works (see below). This PR ensures that they pass on `NotImplemented` if needed, so that classes more interesting than the `string` below will have a chance to try to do the reverse operation.

Note that this is a long-standing bug; I'm not sure how far it can be backported, but hope it can make 1.8.0.

p.s. The reason I stumbled upon this is that I am trying to implement a `MaskedQuantity` class for `astropy` [1]. For this package, we already have `Unit` and `Quantity` classes, and set it up such that `array * unit` returns a `Quantity`; I'd hope to do have `masked_array * unit` similarly to return a `MaskedQuantity`.

[1] http://docs.astropy.org/en/latest/units/quantity.html

```

In [6]: np.array([1.,2.]).__mul__('abc')
Out[6]: NotImplemented

In [7]: np.ma.MaskedArray([1.,2.]).__mul__('abc')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-bc634e0e858e> in <module>()
----> 1 np.ma.MaskedArray([1.,2.]).__mul__('abc')

/usr/lib/pymodules/python2.7/numpy/ma/core.pyc in __mul__(self, other)
   3646     def __mul__(self, other):
   3647         "Multiply other by self, and return a new masked array."
-> 3648         return multiply(self, other)
   3649     #
   3650     def __rmul__(self, other):

/usr/lib/pymodules/python2.7/numpy/ma/core.pyc in __call__(self, a, b, *args, **kwargs)
    938             np.seterr(**err_status_ini)
    939         # Case 1. : scalar
--> 940         if not result.ndim:
    941             if m:
    942                 return masked

AttributeError: 'NotImplementedType' object has no attribute 'ndim'
```
