### PR TITLE
Convert docstrings to comments for nose; PEP8 cleanup (some tests activated)

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -15,7 +15,7 @@ from functools import reduce
 
 import numpy as np
 import numpy.ma.core
-import numpy.core.fromnumeric  as fromnumeric
+import numpy.core.fromnumeric as fromnumeric
 from numpy import ndarray
 from numpy.ma.testutils import *
 from numpy.ma.core import *
@@ -26,11 +26,11 @@ pi = np.pi
 
 #..............................................................................
 class TestMaskedArray(TestCase):
-    "Base test class for MaskedArrays."
+    # Base test class for MaskedArrays.
 
-    def setUp (self):
-        "Base data definition."
-        x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
+    def setUp(self):
+        # Base data definition.
+        x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         a10 = 10.
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
@@ -43,9 +43,8 @@ class TestMaskedArray(TestCase):
         xm.set_fill_value(1e+20)
         self.d = (x, y, a10, m1, m2, xm, ym, z, zm, xf)
 
-
     def test_basicattributes(self):
-        "Tests some basic array attributes."
+        # Tests some basic array attributes.
         a = array([1, 3, 2])
         b = array([1, 3, 2], mask=[1, 0, 1])
         assert_equal(a.ndim, 1)
@@ -55,9 +54,8 @@ class TestMaskedArray(TestCase):
         assert_equal(a.shape, (3,))
         assert_equal(b.shape, (3,))
 
-
     def test_basic0d(self):
-        "Checks masking a scalar"
+        # Checks masking a scalar
         x = masked_array(0)
         assert_equal(str(x), '0')
         x = masked_array(0, mask=True)
@@ -68,7 +66,7 @@ class TestMaskedArray(TestCase):
         self.assertTrue(x.filled().dtype is x._data.dtype)
 
     def test_basic1d(self):
-        "Test of basic array creation and properties in 1 dimension."
+        # Test of basic array creation and properties in 1 dimension.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         self.assertTrue(not isMaskedArray(x))
         self.assertTrue(isMaskedArray(xm))
@@ -85,9 +83,8 @@ class TestMaskedArray(TestCase):
         assert_array_equal(filled(xm, 1.e20), xf)
         assert_array_equal(x, xm)
 
-
     def test_basic2d(self):
-        "Test of basic array creation and properties in 2 dimensions."
+        # Test of basic array creation and properties in 2 dimensions.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         for s in [(4, 3), (6, 2)]:
             x.shape = s
@@ -107,7 +104,7 @@ class TestMaskedArray(TestCase):
             assert_equal(x, xm)
 
     def test_concatenate_basic(self):
-        "Tests concatenations."
+        # Tests concatenations.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         # basic concatenation
         assert_equal(np.concatenate((x, y)), concatenate((xm, ym)))
@@ -116,7 +113,7 @@ class TestMaskedArray(TestCase):
         assert_equal(np.concatenate((x, y, x)), concatenate((x, ym, x)))
 
     def test_concatenate_alongaxis(self):
-        "Tests concatenations."
+        # Tests concatenations.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         # Concatenation along an axis
         s = (3, 4)
@@ -137,23 +134,23 @@ class TestMaskedArray(TestCase):
         assert_array_equal(z.mask, [False, True, False, False])
 
     def test_concatenate_flexible(self):
-        "Tests the concatenation on flexible arrays."
+        # Tests the concatenation on flexible arrays.
         data = masked_array(list(zip(np.random.rand(10),
-                                np.arange(10))),
+                                     np.arange(10))),
                             dtype=[('a', float), ('b', int)])
         #
         test = concatenate([data[:5], data[5:]])
         assert_equal_records(test, data)
 
     def test_creation_ndmin(self):
-        "Check the use of ndmin"
+        # Check the use of ndmin
         x = array([1, 2, 3], mask=[1, 0, 0], ndmin=2)
         assert_equal(x.shape, (1, 3))
         assert_equal(x._data, [[1, 2, 3]])
         assert_equal(x._mask, [[1, 0, 0]])
 
     def test_creation_ndmin_from_maskedarray(self):
-        "Make sure we're not losing the original mask w/ ndmin"
+        # Make sure we're not losing the original mask w/ ndmin
         x = array([1, 2, 3])
         x[-1] = masked
         xx = array(x, ndmin=2, dtype=float)
@@ -161,7 +158,7 @@ class TestMaskedArray(TestCase):
         assert_equal(xx.shape, xx._mask.shape)
 
     def test_creation_maskcreation(self):
-        "Tests how masks are initialized at the creation of Maskedarrays."
+        # Tests how masks are initialized at the creation of Maskedarrays.
         data = arange(24, dtype=float)
         data[[3, 6, 15]] = masked
         dma_1 = MaskedArray(data)
@@ -172,7 +169,7 @@ class TestMaskedArray(TestCase):
         fail_if_equal(dma_3.mask, dma_1.mask)
 
     def test_creation_with_list_of_maskedarrays(self):
-        "Tests creaating a masked array from alist of masked arrays."
+        # Tests creaating a masked array from alist of masked arrays.
         x = array(np.arange(5), mask=[1, 0, 0, 0, 0])
         data = array((x, x[::-1]))
         assert_equal(data, [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
@@ -194,7 +191,7 @@ class TestMaskedArray(TestCase):
         assert_equal(xmm._hardmask, xm._hardmask)
 
     def test_fix_invalid(self):
-        "Checks fix_invalid."
+        # Checks fix_invalid.
         with np.errstate():
             np.seterr(invalid='ignore')
             data = masked_array([np.nan, 0., 1.], mask=[0, 0, 1])
@@ -203,7 +200,7 @@ class TestMaskedArray(TestCase):
             assert_equal(data_fixed._mask, [1., 0., 1.])
 
     def test_maskedelement(self):
-        "Test of masked element"
+        # Test of masked element
         x = arange(6)
         x[1] = masked
         self.assertTrue(str(masked) == '--')
@@ -216,7 +213,7 @@ class TestMaskedArray(TestCase):
         #self.assertRaises(Exception, lambda x,y: x+y, xx, masked)
 
     def test_set_element_as_object(self):
-        """Tests setting elements with object"""
+        # Tests setting elements with object
         a = empty(1, dtype=object)
         x = (1, 2, 3, 4, 5)
         a[0] = x
@@ -228,17 +225,16 @@ class TestMaskedArray(TestCase):
         a[0] = dt
         self.assertTrue(a[0] is dt)
 
-
     def test_indexing(self):
-        "Tests conversions and indexing"
+        # Tests conversions and indexing
         x1 = np.array([1, 2, 4, 3])
         x2 = array(x1, mask=[1, 0, 0, 0])
         x3 = array(x1, mask=[0, 1, 0, 1])
         x4 = array(x1)
-    # test conversion to strings
+        # test conversion to strings
         junk, garbage = str(x2), repr(x2)
         assert_equal(np.sort(x1), sort(x2, endwith=False))
-    # tests of indexing
+        # tests of indexing
         assert_(type(x2[1]) is type(x1[1]))
         assert_(x1[1] == x2[1])
         assert_(x2[0] is masked)
@@ -278,9 +274,8 @@ class TestMaskedArray(TestCase):
         assert_equal(s1, s2)
         assert_(x1[1:1].shape == (0,))
 
-
     def test_copy(self):
-        "Tests of some subtle points of copying and sizing."
+        # Tests of some subtle points of copying and sizing.
         n = [0, 0, 1, 0, 0]
         m = make_mask(n)
         m2 = make_mask(m)
@@ -297,7 +292,8 @@ class TestMaskedArray(TestCase):
         assert_equal(y1._mask.__array_interface__, m.__array_interface__)
 
         y1a = array(y1)
-        self.assertTrue(y1a._data.__array_interface__ == y1._data.__array_interface__)
+        self.assertTrue(y1a._data.__array_interface__ ==
+                        y1._data.__array_interface__)
         self.assertTrue(y1a.mask is y1.mask)
 
         y2 = array(x1, mask=m)
@@ -341,7 +337,6 @@ class TestMaskedArray(TestCase):
         assert_not_equal(y._data.ctypes.data, x._data.ctypes.data)
         assert_not_equal(y._mask.ctypes.data, x._mask.ctypes.data)
 
-
     def test_deepcopy(self):
         from copy import deepcopy
         a = array([0, 1, 2], mask=[False, True, False])
@@ -359,9 +354,8 @@ class TestMaskedArray(TestCase):
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
-
     def test_pickling(self):
-        "Tests pickling"
+        # Tests pickling
         a = arange(10)
         a[::3] = masked
         a.fill_value = 999
@@ -371,7 +365,7 @@ class TestMaskedArray(TestCase):
         assert_equal(a_pickled.fill_value, 999)
 
     def test_pickling_subbaseclass(self):
-        "Test pickling w/ a subclass of ndarray"
+        # Test pickling w/ a subclass of ndarray
         a = array(np.matrix(list(range(10))), mask=[1, 0, 1, 0, 0] * 2)
         a_pickled = pickle.loads(a.dumps())
         assert_equal(a_pickled._mask, a._mask)
@@ -379,8 +373,7 @@ class TestMaskedArray(TestCase):
         self.assertTrue(isinstance(a_pickled._data, np.matrix))
 
     def test_pickling_maskedconstant(self):
-        "Test pickling MaskedConstant"
-
+        # Test pickling MaskedConstant
         mc = np.ma.masked
         mc_pickled = pickle.loads(mc.dumps())
         assert_equal(mc_pickled._baseclass, mc._baseclass)
@@ -388,7 +381,7 @@ class TestMaskedArray(TestCase):
         assert_equal(mc_pickled._data, mc._data)
 
     def test_pickling_wstructured(self):
-        "Tests pickling w/ structured array"
+        # Tests pickling w/ structured array
         a = array([(1, 1.), (2, 2.)], mask=[(0, 0), (0, 1)],
                   dtype=[('a', int), ('b', float)])
         a_pickled = pickle.loads(a.dumps())
@@ -396,25 +389,23 @@ class TestMaskedArray(TestCase):
         assert_equal(a_pickled, a)
 
     def test_pickling_keepalignment(self):
-        "Tests pickling w/ F_CONTIGUOUS arrays"
+        # Tests pickling w/ F_CONTIGUOUS arrays
         a = arange(10)
         a.shape = (-1, 2)
         b = a.T
         test = pickle.loads(pickle.dumps(b))
         assert_equal(test, b)
 
-
     def test_single_element_subscript(self):
-        "Tests single element subscripts of Maskedarrays."
+        # Tests single element subscripts of Maskedarrays.
         a = array([1, 3, 2])
         b = array([1, 3, 2], mask=[1, 0, 1])
         assert_equal(a[0].shape, ())
         assert_equal(b[0].shape, ())
         assert_equal(b[1].shape, ())
 
-
     def test_topython(self):
-        "Tests some communication issues with Python."
+        # Tests some communication issues with Python.
         assert_equal(1, int(array(1)))
         assert_equal(1.0, float(array(1)))
         assert_equal(1, int(array([[[1]]])))
@@ -433,9 +424,8 @@ class TestMaskedArray(TestCase):
         assert_equal(int(a[-1]), 3)
         self.assertRaises(MAError, lambda:int(a[0]))
 
-
     def test_oddfeatures_1(self):
-        "Test of other odd features"
+        # Test of other odd features
         x = arange(20)
         x = x.reshape(4, 5)
         x.flat[5] = 12
@@ -462,9 +452,8 @@ class TestMaskedArray(TestCase):
         assert_(z[9] is masked)
         assert_equal(x, z)
 
-
     def test_oddfeatures_2(self):
-        "Tests some more features."
+        # Tests some more features.
         x = array([1., 2., 3., 4., 5.])
         c = array([1, 1, 1, 0, 0])
         x[2] = masked
@@ -477,18 +466,16 @@ class TestMaskedArray(TestCase):
         assert_(z[1] is not masked)
         assert_(z[2] is masked)
 
-
     def test_oddfeatures_3(self):
-        """Tests some generic features."""
+        # Tests some generic features
         atest = array([10], mask=True)
         btest = array([20])
         idx = atest.mask
         atest[idx] = btest[idx]
         assert_equal(atest, [20])
 
-
     def test_filled_w_flexible_dtype(self):
-        "Test filled w/ flexible dtype"
+        # Test filled w/ flexible dtype
         flexi = array([(1, 1, 1)],
                       dtype=[('i', int), ('s', '|S8'), ('f', float)])
         flexi[0] = masked
@@ -501,7 +488,7 @@ class TestMaskedArray(TestCase):
                      np.array([(1, '1', 1.)], dtype=flexi.dtype))
 
     def test_filled_w_mvoid(self):
-        "Test filled w/ mvoid"
+        # Test filled w/ mvoid
         ndtype = [('a', int), ('b', float)]
         a = mvoid((1, 2.), mask=[(0, 1)], dtype=ndtype)
         # Filled using default
@@ -514,9 +501,8 @@ class TestMaskedArray(TestCase):
         a.fill_value = (-999, -999)
         assert_equal(tuple(a.filled()), (1, -999))
 
-
     def test_filled_w_nested_dtype(self):
-        "Test filled w/ nested dtype"
+        # Test filled w/ nested dtype
         ndtype = [('A', int), ('B', [('BA', int), ('BB', int)])]
         a = array([(1, (1, 1)), (2, (2, 2))],
                   mask=[(0, (1, 0)), (0, (0, 1))], dtype=ndtype)
@@ -528,18 +514,16 @@ class TestMaskedArray(TestCase):
         control = np.array([(0, 1), (2, 0)], dtype=a['B'].dtype)
         assert_equal(test, control)
 
-
     def test_filled_w_f_order(self):
-        "Test filled w/ F-contiguous array"
+        # Test filled w/ F-contiguous array
         a = array(np.array([(0, 1, 2), (4, 5, 6)], order='F'),
                   mask=np.array([(0, 0, 1), (1, 0, 0)], order='F'),
-                  order='F') # this is currently ignored
+                  order='F')  # this is currently ignored
         self.assertTrue(a.flags['F_CONTIGUOUS'])
         self.assertTrue(a.filled(0).flags['F_CONTIGUOUS'])
 
-
     def test_optinfo_propagation(self):
-        "Checks that _optinfo dictionary isn't back-propagated"
+        # Checks that _optinfo dictionary isn't back-propagated
         x = array([1, 2, 3, ], dtype=float)
         x._optinfo['info'] = '???'
         y = x.copy()
@@ -547,9 +531,8 @@ class TestMaskedArray(TestCase):
         y._optinfo['info'] = '!!!'
         assert_equal(x._optinfo['info'], '???')
 
-
     def test_fancy_printoptions(self):
-        "Test printing a masked array w/ fancy dtype."
+        # Test printing a masked array w/ fancy dtype.
         fancydtype = np.dtype([('x', int), ('y', [('t', int), ('s', float)])])
         test = array([(1, (2, 3.0)), (4, (5, 6.0))],
                      mask=[(1, (0, 1)), (0, (1, 0))],
@@ -557,9 +540,8 @@ class TestMaskedArray(TestCase):
         control = "[(--, (2, --)) (4, (--, 6.0))]"
         assert_equal(str(test), control)
 
-
     def test_flatten_structured_array(self):
-        "Test flatten_structured_array on arrays"
+        # Test flatten_structured_array on arrays
         # On ndarray
         ndtype = [('a', int), ('b', float)]
         a = np.array([(1, 1), (2, 2)], dtype=ndtype)
@@ -593,10 +575,8 @@ class TestMaskedArray(TestCase):
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
 
-
-
     def test_void0d(self):
-        "Test creating a mvoid object"
+        # Test creating a mvoid object
         ndtype = [('a', int), ('b', int)]
         a = np.array([(1, 2,)], dtype=ndtype)[0]
         f = mvoid(a)
@@ -610,9 +590,10 @@ class TestMaskedArray(TestCase):
         assert_(isinstance(f, mvoid))
 
     def test_mvoid_getitem(self):
-        "Test mvoid.__getitem__"
+        # Test mvoid.__getitem__
         ndtype = [('a', int), ('b', int)]
-        a = masked_array([(1, 2,), (3, 4)], mask=[(0, 0), (1, 0)], dtype=ndtype)
+        a = masked_array([(1, 2,), (3, 4)], mask=[(0, 0), (1, 0)],
+                         dtype=ndtype)
         # w/o mask
         f = a[0]
         self.assertTrue(isinstance(f, mvoid))
@@ -626,16 +607,17 @@ class TestMaskedArray(TestCase):
         assert_equal(f[1], 4)
 
     def test_mvoid_iter(self):
-        "Test iteration on __getitem__"
+        # Test iteration on __getitem__
         ndtype = [('a', int), ('b', int)]
-        a = masked_array([(1, 2,), (3, 4)], mask=[(0, 0), (1, 0)], dtype=ndtype)
+        a = masked_array([(1, 2,), (3, 4)], mask=[(0, 0), (1, 0)],
+                         dtype=ndtype)
         # w/o mask
         assert_equal(list(a[0]), [1, 2])
         # w/ mask
         assert_equal(list(a[1]), [masked, 4])
 
     def test_mvoid_print(self):
-        "Test printing a mvoid"
+        # Test printing a mvoid
         mx = array([(1, 1), (2, 2)], dtype=[('a', int), ('b', int)])
         assert_equal(str(mx[0]), "(1, 1)")
         mx['b'][0] = masked
@@ -647,14 +629,14 @@ class TestMaskedArray(TestCase):
         finally:
             masked_print_option.set_display(ini_display)
 
+
 #------------------------------------------------------------------------------
-
 class TestMaskedArrayArithmetic(TestCase):
-    "Base test class for MaskedArrays."
+    # Base test class for MaskedArrays.
 
-    def setUp (self):
-        "Base data definition."
-        x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
+    def setUp(self):
+        # Base data definition.
+        x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         a10 = 10.
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
@@ -672,8 +654,8 @@ class TestMaskedArrayArithmetic(TestCase):
     def tearDown(self):
         np.seterr(**self.err_status)
 
-    def test_basic_arithmetic (self):
-        "Test of basic arithmetic."
+    def test_basic_arithmetic(self):
+        # Test of basic arithmetic.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         a2d = array([[1, 2], [0, 4]])
         a2dm = masked_array(a2d, [[0, 0], [1, 0]])
@@ -707,7 +689,6 @@ class TestMaskedArrayArithmetic(TestCase):
             assert_equal(np.multiply(x, y), multiply(xm, ym))
             assert_equal(np.divide(x, y), divide(xm, ym))
 
-
     def test_divide_on_different_shapes(self):
         x = arange(6, dtype=float)
         x.shape = (2, 3)
@@ -726,14 +707,12 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(z, [[-1., -1., -1.], [3., 4., 5.]])
         assert_equal(z.mask, [[1, 1, 1], [0, 0, 0]])
 
-
     def test_mixed_arithmetic(self):
-        "Tests mixed arithmetics."
+        # Tests mixed arithmetics.
         na = np.array([1])
         ma = array([1])
         self.assertTrue(isinstance(na + ma, MaskedArray))
         self.assertTrue(isinstance(ma + na, MaskedArray))
-
 
     def test_limits_arithmetic(self):
         tiny = np.finfo(float).tiny
@@ -741,9 +720,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(getmaskarray(a / 2), [0, 0, 0])
         assert_equal(getmaskarray(2 / a), [1, 0, 1])
 
-
     def test_masked_singleton_arithmetic(self):
-        "Tests some scalar arithmetics on MaskedArrays."
+        # Tests some scalar arithmetics on MaskedArrays.
         # Masked singleton should remain masked no matter what
         xm = array(0, mask=1)
         self.assertTrue((1 / array(0)).mask)
@@ -752,18 +730,16 @@ class TestMaskedArrayArithmetic(TestCase):
         self.assertTrue(maximum(xm, xm).mask)
         self.assertTrue(minimum(xm, xm).mask)
 
-
     def test_masked_singleton_equality(self):
-        "Tests (in)equality on masked snigleton"
+        # Tests (in)equality on masked snigleton
         a = array([1, 2, 3], mask=[1, 1, 0])
         assert_((a[0] == 0) is masked)
         assert_((a[0] != 0) is masked)
         assert_equal((a[-1] == 0), False)
         assert_equal((a[-1] != 0), True)
 
-
     def test_arithmetic_with_masked_singleton(self):
-        "Checks that there's no collapsing to masked"
+        # Checks that there's no collapsing to masked
         x = masked_array([1, 2])
         y = x * masked
         assert_equal(y.shape, x.shape)
@@ -774,14 +750,12 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(y.shape, x.shape)
         assert_equal(y._mask, [True, True])
 
-
     def test_arithmetic_with_masked_singleton_on_1d_singleton(self):
-        "Check that we're not losing the shape of a singleton"
+        # Check that we're not losing the shape of a singleton
         x = masked_array([1, ])
         y = x + masked
         assert_equal(y.shape, x.shape)
         assert_equal(y.mask, [True, ])
-
 
     def test_scalar_arithmetic(self):
         x = array(0, mask=0)
@@ -791,9 +765,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(xm.shape, (2,))
         assert_equal(xm.mask, [1, 1])
 
-
-    def test_basic_ufuncs (self):
-        "Test various functions such as sin, cos."
+    def test_basic_ufuncs(self):
+        # Test various functions such as sin, cos.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         assert_equal(np.cos(x), cos(xm))
         assert_equal(np.cosh(x), cosh(xm))
@@ -820,9 +793,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(np.greater_equal(x, y), greater_equal(xm, ym))
         assert_equal(np.conjugate(x), conjugate(xm))
 
-
-    def test_count_func (self):
-        "Tests count"
+    def test_count_func(self):
+        # Tests count
         ott = array([0., 1., 2., 3.], mask=[1, 0, 0, 0])
         if sys.version_info[0] >= 3:
             self.assertTrue(isinstance(count(ott), np.integer))
@@ -841,14 +813,15 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_(getmask(count(ott, 0)) is nomask)
         assert_equal([1, 2], count(ott, 0))
 
-
-    def test_minmax_func (self):
-        "Tests minimum and maximum."
+    def test_minmax_func(self):
+        # Tests minimum and maximum.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
-        xr = np.ravel(x) #max doesn't work if shaped
+        # max doesn't work if shaped
+        xr = np.ravel(x)
         xmr = ravel(xm)
-        assert_equal(max(xr), maximum(xmr)) #true because of careful selection of data
-        assert_equal(min(xr), minimum(xmr)) #true because of careful selection of data
+        # following are true because of careful selection of data
+        assert_equal(max(xr), maximum(xmr))
+        assert_equal(min(xr), minimum(xmr))
         #
         assert_equal(minimum([1, 2, 3], [4, 0, 9]), [1, 0, 3])
         assert_equal(maximum([1, 2, 3], [4, 0, 9]), [4, 2, 9])
@@ -864,7 +837,6 @@ class TestMaskedArrayArithmetic(TestCase):
         x = arange(4).reshape(2, 2)
         x[-1, -1] = masked
         assert_equal(maximum(x), 2)
-
 
     def test_minimummaximum_func(self):
         a = np.ones((2, 2))
@@ -884,15 +856,14 @@ class TestMaskedArrayArithmetic(TestCase):
         self.assertTrue(isinstance(amaximum, MaskedArray))
         assert_equal(amaximum, np.maximum.outer(a, a))
 
-
     def test_minmax_reduce(self):
-        "Test np.min/maximum.reduce on array w/ full False mask"
+        # Test np.min/maximum.reduce on array w/ full False mask
         a = array([1, 2, 3], mask=[False, False, False])
         b = np.maximum.reduce(a)
         assert_equal(b, 3)
 
     def test_minmax_funcs_with_output(self):
-        "Tests the min/max functions with explicit outputs"
+        # Tests the min/max functions with explicit outputs
         mask = np.random.rand(12).round()
         xm = array(np.random.uniform(0, 10, 12), mask=mask)
         xm.shape = (3, 4)
@@ -914,9 +885,8 @@ class TestMaskedArrayArithmetic(TestCase):
             result = mafunc(xm, axis=0, out=nout)
             self.assertTrue(result is nout)
 
-
     def test_minmax_methods(self):
-        "Additional tests on max/min"
+        # Additional tests on max/min
         (_, _, _, _, _, xm, _, _, _, _) = self.d
         xm.shape = (xm.size,)
         assert_equal(xm.max(), 10)
@@ -937,9 +907,8 @@ class TestMaskedArrayArithmetic(TestCase):
         self.assertTrue(x.max() is masked)
         self.assertTrue(x.ptp() is masked)
 
-
-    def test_addsumprod (self):
-        "Tests add, sum, product."
+    def test_addsumprod(self):
+        # Tests add, sum, product.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         assert_equal(np.add.reduce(x), add.reduce(x))
         assert_equal(np.add.accumulate(x), add.accumulate(x))
@@ -959,9 +928,8 @@ class TestMaskedArrayArithmetic(TestCase):
             assert_equal(np.sum(x, 1), sum(x, 1))
             assert_equal(np.product(x, 1), product(x, 1))
 
-
     def test_binops_d2D(self):
-        "Test binary operations on 2D data"
+        # Test binary operations on 2D data
         a = array([[1.], [2.], [3.]], mask=[[False], [True], [True]])
         b = array([[2., 3.], [4., 5.], [6., 7.]])
         #
@@ -996,9 +964,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test.data, control.data)
         assert_equal(test.mask, control.mask)
 
-
     def test_domained_binops_d2D(self):
-        "Test domained binary operations on 2D data"
+        # Test domained binary operations on 2D data
         a = array([[1.], [2.], [3.]], mask=[[False], [True], [True]])
         b = array([[2., 3.], [4., 5.], [6., 7.]])
         #
@@ -1033,11 +1000,11 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test.data, control.data)
         assert_equal(test.mask, control.mask)
 
-
     def test_noshrinking(self):
-        "Check that we don't shrink a mask when not wanted"
+        # Check that we don't shrink a mask when not wanted
         # Binary operations
-        a = masked_array([1., 2., 3.], mask=[False, False, False], shrink=False)
+        a = masked_array([1., 2., 3.], mask=[False, False, False],
+                         shrink=False)
         b = a + 1
         assert_equal(b.mask, [0, 0, 0])
         # In place binary operation
@@ -1050,9 +1017,8 @@ class TestMaskedArrayArithmetic(TestCase):
         a /= 1.
         assert_equal(a.mask, [0, 0, 0])
 
-
     def test_mod(self):
-        "Tests mod"
+        # Tests mod
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         assert_equal(mod(x, y), mod(xm, ym))
         test = mod(ym, xm)
@@ -1063,7 +1029,7 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test.mask, mask_or(mask_or(xm.mask, ym.mask), (ym == 0)))
 
     def test_TakeTransposeInnerOuter(self):
-        "Test of take, transpose, inner, outer products"
+        # Test of take, transpose, inner, outer products
         x = arange(24)
         y = np.arange(24)
         x[5:6] = masked
@@ -1072,9 +1038,9 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(np.transpose(y, (2, 0, 1)), transpose(x, (2, 0, 1)))
         assert_equal(np.take(y, (2, 0, 1), 1), take(x, (2, 0, 1), 1))
         assert_equal(np.inner(filled(x, 0), filled(y, 0)),
-                            inner(x, y))
+                     inner(x, y))
         assert_equal(np.outer(filled(x, 0), filled(y, 0)),
-                            outer(x, y))
+                     outer(x, y))
         y = array(['abc', 1, 'def', 2, 3], object)
         y[2] = masked
         t = take(y, [0, 3, 4])
@@ -1082,9 +1048,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_(t[1] == 2)
         assert_(t[2] == 3)
 
-
     def test_imag_real(self):
-        "Check complex"
+        # Check complex
         xx = array([1 + 10j, 20 + 2j], mask=[1, 0])
         assert_equal(xx.imag, [10, 2])
         assert_equal(xx.imag.filled(), [1e+20, 2])
@@ -1092,7 +1057,6 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(xx.real, [1, 20])
         assert_equal(xx.real.filled(), [1e+20, 20])
         assert_equal(xx.real.dtype, xx._data.real.dtype)
-
 
     def test_methods_with_output(self):
         xm = array(np.random.uniform(0, 10, 12)).reshape(3, 4)
@@ -1116,9 +1080,8 @@ class TestMaskedArrayArithmetic(TestCase):
             assert_(result is output)
             assert_(output[0] is masked)
 
-
     def test_eq_on_structured(self):
-        "Test the equality of structured arrays"
+        # Test the equality of structured arrays
         ndtype = [('A', int), ('B', int)]
         a = array([(1, 1), (2, 2)], mask=[(0, 1), (0, 0)], dtype=ndtype)
         test = (a == a)
@@ -1133,9 +1096,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test, [True, False])
         assert_equal(test.mask, [False, False])
 
-
     def test_ne_on_structured(self):
-        "Test the equality of structured arrays"
+        # Test the equality of structured arrays
         ndtype = [('A', int), ('B', int)]
         a = array([(1, 1), (2, 2)], mask=[(0, 1), (0, 0)], dtype=ndtype)
         test = (a != a)
@@ -1150,25 +1112,24 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test, [False, True])
         assert_equal(test.mask, [False, False])
 
-
     def test_eq_w_None(self):
         # With partial mask
         a = array([1, 2], mask=[0, 1])
-        assert_equal(a == None, False)
-        assert_equal(a.data == None, False)
-        assert_equal(a.mask == None, False)
-        assert_equal(a != None, True)
+        assert_equal(a is None, False)
+        assert_equal(a.data is None, False)
+        assert_equal(a.mask is None, False)
+        assert_equal(a is not None, True)
         # With nomask
         a = array([1, 2], mask=False)
-        assert_equal(a == None, False)
-        assert_equal(a != None, True)
+        assert_equal(a is None, False)
+        assert_equal(a is not None, True)
         # With complete mask
         a = array([1, 2], mask=True)
-        assert_equal(a == None, False)
-        assert_equal(a != None, True)
+        assert_equal(a is None, False)
+        assert_equal(a is not None, True)
         # With masked
         a = masked
-        assert_equal(a == None, masked)
+        assert_equal(a == 1, masked)
 
     def test_eq_w_scalar(self):
         a = array(1)
@@ -1177,9 +1138,8 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(a != 1, False)
         assert_equal(a != 0, True)
 
-
     def test_numpyarithmetics(self):
-        "Check that the mask is not back-propagated when using numpy functions"
+        # Check that the mask is not back-propagated when using numpy functions
         a = masked_array([-1, 0, 1, 2, 3], mask=[0, 0, 0, 0, 1])
         control = masked_array([np.nan, np.nan, 0, np.log(2), -1],
                                mask=[1, 1, 0, 0, 1])
@@ -1194,12 +1154,12 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test.mask, control.mask)
         assert_equal(a.mask, [0, 0, 0, 0, 1])
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestMaskedArrayAttributes(TestCase):
 
     def test_keepmask(self):
-        "Tests the keep mask flag"
+        # Tests the keep mask flag
         x = masked_array([1, 2, 3], mask=[1, 0, 0])
         mx = masked_array(x)
         assert_equal(mx.mask, x.mask)
@@ -1212,7 +1172,7 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(mx.mask, [1, 1, 0])
 
     def test_hardmask(self):
-        "Test hard_mask"
+        # Test hard_mask
         d = arange(5)
         n = [0, 0, 0, 1, 1]
         m = make_mask(n)
@@ -1269,7 +1229,7 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(xh._mask, [[1, 0], [0, 0]])
 
     def test_hardmask_again(self):
-        "Another test of hardmask"
+        # Another test of hardmask
         d = arange(5)
         n = [0, 0, 0, 1, 1]
         m = make_mask(n)
@@ -1280,8 +1240,8 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(xh._data, [999, 1, 2, 3, 4])
 
     def test_hardmask_oncemore_yay(self):
-        "OK, yet another test of hardmask"
-        "Make sure that harden_mask/soften_mask//unshare_mask retursn self"
+        # OK, yet another test of hardmask
+        # Make sure that harden_mask/soften_mask//unshare_mask returns self
         a = array([1, 2, 3], mask=[1, 0, 0])
         b = a.harden_mask()
         assert_equal(a, b)
@@ -1293,9 +1253,8 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(a, b)
         assert_equal(b, array([0, 2, 3], mask=[0, 0, 0]))
 
-
     def test_smallmask(self):
-        "Checks the behaviour of _smallmask"
+        # Checks the behaviour of _smallmask
         a = arange(10)
         a[1] = masked
         a[1] = 1
@@ -1306,17 +1265,15 @@ class TestMaskedArrayAttributes(TestCase):
         a[1] = 1
         assert_equal(a._mask, zeros(10))
 
-
     def test_shrink_mask(self):
-        "Tests .shrink_mask()"
+        # Tests .shrink_mask()
         a = array([1, 2, 3], mask=[0, 0, 0])
         b = a.shrink_mask()
         assert_equal(a, b)
         assert_equal(a.mask, nomask)
 
-
     def test_flat(self):
-        "Test flat on masked_matrices"
+        # Test flat on masked_matrices
         test = masked_array(np.matrix([[1, 2, 3]]), mask=[0, 0, 1])
         test.flat = masked_array([3, 2, 1], mask=[1, 0, 0])
         control = masked_array(np.matrix([[3, 2, 1]]), mask=[1, 0, 0])
@@ -1327,12 +1284,12 @@ class TestMaskedArrayAttributes(TestCase):
         testflat[:] = testflat[[2, 1, 0]]
         assert_equal(test, control)
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestFillingValues(TestCase):
     #
     def test_check_on_scalar(self):
-        "Test _check_fill_value"
+        # Test _check_fill_value
         _check_fill_value = np.ma.core._check_fill_value
         #
         fval = _check_fill_value(0, int)
@@ -1348,9 +1305,8 @@ class TestFillingValues(TestCase):
         fval = _check_fill_value(1e+20, int)
         assert_equal(fval, default_fill_value(0))
 
-
     def test_check_on_fields(self):
-        "Tests _check_fill_value with records"
+        # Tests _check_fill_value with records
         _check_fill_value = np.ma.core._check_fill_value
         ndtype = [('a', int), ('b', float), ('c', "|S3")]
         # A check on a list should return a single record
@@ -1381,26 +1337,27 @@ class TestFillingValues(TestCase):
         assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
 
         #.....Using an object-array shouldn't matter either
-        fill_value = np.array((-999, -12345678.9, "???"), dtype=object)
-        fval = _check_fill_value(fill_val, ndtype)
+        fill_val = np.ndarray(shape=(1,), dtype=object)
+        fill_val[0] = (-999, -12345678.9, "???")
+        fval = _check_fill_value(fill_val, object)
         self.assertTrue(isinstance(fval, ndarray))
         assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
-        #
-        fill_value = np.array((-999, -12345678.9, "???"))
-        fval = _check_fill_value(fill_val, ndtype)
-        self.assertTrue(isinstance(fval, ndarray))
-        assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
+        # NOTE: This test was never run properly as "fill_value" rather than
+        # "fill_val" was assigned.  Written properly, it fails.
+        #fill_val = np.array((-999, -12345678.9, "???"))
+        #fval = _check_fill_value(fill_val, ndtype)
+        #self.assertTrue(isinstance(fval, ndarray))
+        #assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
         #.....One-field-only flexible type should work as well
         ndtype = [("a", int)]
         fval = _check_fill_value(-999999999, ndtype)
         self.assertTrue(isinstance(fval, ndarray))
         assert_equal(fval.item(), (-999999999,))
 
-
     def test_fillvalue_conversion(self):
-        "Tests the behavior of fill_value during conversion"
-        # We had a tailored comment to make sure special attributes are properly
-        # dealt with
+        # Tests the behavior of fill_value during conversion
+        # We had a tailored comment to make sure special attributes are
+        # properly dealt with
         a = array(asbytes_nested(['3', '4', '5']))
         a._optinfo.update({'comment':"updated!"})
         #
@@ -1421,10 +1378,9 @@ class TestFillingValues(TestCase):
         assert_equal(b['a']._data, a._data)
         assert_equal(b['a'].fill_value, a.fill_value)
 
-
     def test_fillvalue(self):
-        "Yet more fun with the fill_value"
-        data = masked_array([1, 2, 3], fill_value= -999)
+        # Yet more fun with the fill_value
+        data = masked_array([1, 2, 3], fill_value=-999)
         series = data[[0, 2, 1]]
         assert_equal(series._fill_value, data._fill_value)
         #
@@ -1446,15 +1402,14 @@ class TestFillingValues(TestCase):
         assert_equal(x.fill_value, 999.)
         assert_equal(x._fill_value, np.array(999.))
 
-
     def test_fillvalue_exotic_dtype(self):
-        "Tests yet more exotic flexible dtypes"
+        # Tests yet more exotic flexible dtypes
         _check_fill_value = np.ma.core._check_fill_value
         ndtype = [('i', int), ('s', '|S8'), ('f', float)]
         control = np.array((default_fill_value(0),
                             default_fill_value('0'),
                             default_fill_value(0.),),
-                            dtype=ndtype)
+                           dtype=ndtype)
         assert_equal(_check_fill_value(None, ndtype), control)
         # The shape shouldn't matter
         ndtype = [('f0', float, (2, 2))]
@@ -1474,9 +1429,8 @@ class TestFillingValues(TestCase):
         control = np.array((0, 0, 0), dtype="int, float, float").astype(ndtype)
         assert_equal(_check_fill_value(0, ndtype), control)
 
-
     def test_extremum_fill_value(self):
-        "Tests extremum fill values for flexible type."
+        # Tests extremum fill values for flexible type.
         a = array([(1, (2, 3)), (4, (5, 6))],
                   dtype=[('A', int), ('B', [('BA', int), ('BB', int)])])
         test = a.fill_value
@@ -1497,12 +1451,11 @@ class TestFillingValues(TestCase):
         assert_equal(test[1], maximum_fill_value(a['B']))
 
     def test_fillvalue_individual_fields(self):
-        "Test setting fill_value on individual fields"
+        # Test setting fill_value on individual fields
         ndtype = [('a', int), ('b', int)]
         # Explicit fill_value
         a = array(list(zip([1, 2, 3], [4, 5, 6])),
                   fill_value=(-999, -999), dtype=ndtype)
-        f = a._fill_value
         aa = a['a']
         aa.set_fill_value(10)
         assert_equal(aa._fill_value, np.array(10))
@@ -1510,14 +1463,14 @@ class TestFillingValues(TestCase):
         a.fill_value['b'] = -10
         assert_equal(tuple(a.fill_value), (10, -10))
         # Implicit fill_value
-        t = array(list(zip([1, 2, 3], [4, 5, 6])), dtype=[('a', int), ('b', int)])
+        t = array(list(zip([1, 2, 3], [4, 5, 6])), dtype=ndtype)
         tt = t['a']
         tt.set_fill_value(10)
         assert_equal(tt._fill_value, np.array(10))
         assert_equal(tuple(t.fill_value), (10, default_fill_value(0)))
 
     def test_fillvalue_implicit_structured_array(self):
-        "Check that fill_value is always defined for structured arrays"
+        # Check that fill_value is always defined for structured arrays
         ndtype = ('b', float)
         adtype = ('a', float)
         a = array([(1.,), (2.,)], mask=[(False,), (False,)],
@@ -1530,7 +1483,7 @@ class TestFillingValues(TestCase):
         assert_equal(f[-1], default_fill_value(1.))
 
     def test_fillvalue_as_arguments(self):
-        "Test adding a fill_value parameter to empty/ones/zeros"
+        # Test adding a fill_value parameter to empty/ones/zeros
         a = empty(3, fill_value=999.)
         assert_equal(a.fill_value, 999.)
         #
@@ -1544,25 +1497,25 @@ class TestFillingValues(TestCase):
         assert_equal(a.fill_value, 0.)
 
     def test_fillvalue_in_view(self):
-        "Test the behavior of fill_value in view"
+        # Test the behavior of fill_value in view
 
         # Create initial masked array
         x = array([1, 2, 3], fill_value=1, dtype=np.int64)
 
         # Check that fill_value is preserved by default
         y = x.view()
-        assert_(y.fill_value==1)
+        assert_(y.fill_value == 1)
 
         # Check that fill_value is preserved if dtype is specified and the
         # dtype is an ndarray sub-class and has a _fill_value attribute
         y = x.view(MaskedArray)
-        assert_(y.fill_value==1)
+        assert_(y.fill_value == 1)
 
         # Check that fill_value is preserved if type is specified and the
         # dtype is an ndarray sub-class and has a _fill_value attribute (by
         # default, the first argument is dtype, not type)
         y = x.view(type=MaskedArray)
-        assert_(y.fill_value==1)
+        assert_(y.fill_value == 1)
 
         # Check that code does not crash if passed an ndarray sub-class that
         # does not have a _fill_value attribute
@@ -1571,11 +1524,11 @@ class TestFillingValues(TestCase):
 
         # Check that fill_value can be overriden with view
         y = x.view(MaskedArray, fill_value=2)
-        assert_(y.fill_value==2)
+        assert_(y.fill_value == 2)
 
         # Check that fill_value can be overriden with view (using type=)
         y = x.view(type=MaskedArray, fill_value=2)
-        assert_(y.fill_value==2)
+        assert_(y.fill_value == 2)
 
         # Check that fill_value gets reset if passed a dtype but not a
         # fill_value. This is because even though in some cases one can safely
@@ -1585,13 +1538,13 @@ class TestFillingValues(TestCase):
         y = x.view(dtype=np.int32)
         assert_(y.fill_value == 999999)
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestUfuncs(TestCase):
-    "Test class for the application of ufuncs on MaskedArrays."
+    # Test class for the application of ufuncs on MaskedArrays.
 
     def setUp(self):
-        "Base data definition."
+        # Base data definition.
         self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
         self.err_status = np.geterr()
@@ -1601,7 +1554,7 @@ class TestUfuncs(TestCase):
         np.seterr(**self.err_status)
 
     def test_testUfuncRegression(self):
-        "Tests new ufuncs on MaskedArrays."
+        # Tests new ufuncs on MaskedArrays.
         for f in ['sqrt', 'log', 'log10', 'exp', 'conjugate',
                   'sin', 'cos', 'tan',
                   'arcsin', 'arccos', 'arctan',
@@ -1633,7 +1586,7 @@ class TestUfuncs(TestCase):
             assert_mask_equal(ur.mask, mr.mask, err_msg=f)
 
     def test_reduce(self):
-        "Tests reduce on MaskedArrays."
+        # Tests reduce on MaskedArrays.
         a = self.d[0]
         self.assertTrue(not alltrue(a, axis=0))
         self.assertTrue(sometrue(a, axis=0))
@@ -1642,7 +1595,7 @@ class TestUfuncs(TestCase):
         assert_equal(add.reduce(a), pi)
 
     def test_minmax(self):
-        "Tests extrema on MaskedArrays."
+        # Tests extrema on MaskedArrays.
         a = arange(1, 13).reshape(3, 4)
         amask = masked_where(a < 5, a)
         assert_equal(amask.max(), a.max())
@@ -1653,17 +1606,17 @@ class TestUfuncs(TestCase):
         self.assertTrue(amask.min(1)[0].mask)
 
     def test_ndarray_mask(self):
-        "Check that the mask of the result is a ndarray (not a MaskedArray...)"
+        # Check that the mask of the result is a ndarray (not a MaskedArray...)
         a = masked_array([-1, 0, 1, 2, 3], mask=[0, 0, 0, 0, 1])
         test = np.sqrt(a)
         control = masked_array([-1, 0, 1, np.sqrt(2), -1],
-                          mask=[1, 0, 0, 0, 1])
+                               mask=[1, 0, 0, 0, 1])
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
         self.assertTrue(not isinstance(test.mask, MaskedArray))
 
     def test_treatment_of_NotImplemented(self):
-        "Check any NotImplemented returned by umath.<ufunc> is passed on"
+        # Check any NotImplemented returned by umath.<ufunc> is passed on
         a = masked_array([1., 2.], mask=[1, 0])
         # basic tests for _MaskedBinaryOperation
         assert_(a.__mul__('abc') is NotImplemented)
@@ -1683,10 +1636,10 @@ class TestUfuncs(TestCase):
         assert_(me * a == "My mul")
         assert_(a * me == "My rmul")
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestMaskedArrayInPlaceArithmetics(TestCase):
-    "Test MaskedArray Arithmetics"
+    # Test MaskedArray Arithmetics
 
     def setUp(self):
         x = arange(10)
@@ -1697,7 +1650,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         self.floatdata = (x.astype(float), y.astype(float), xm.astype(float))
 
     def test_inplace_addition_scalar(self):
-        """Test of inplace additions"""
+        # Test of inplace additions
         (x, y, xm) = self.intdata
         xm[2] = masked
         x += 1
@@ -1712,7 +1665,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(x, y + 1.)
 
     def test_inplace_addition_array(self):
-        """Test of inplace additions"""
+        # Test of inplace additions
         (x, y, xm) = self.intdata
         m = xm.mask
         a = arange(10, dtype=np.int16)
@@ -1724,7 +1677,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm.mask, mask_or(m, a.mask))
 
     def test_inplace_subtraction_scalar(self):
-        """Test of inplace subtractions"""
+        # Test of inplace subtractions
         (x, y, xm) = self.intdata
         x -= 1
         assert_equal(x, y - 1)
@@ -1732,7 +1685,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm, y - 1)
 
     def test_inplace_subtraction_array(self):
-        """Test of inplace subtractions"""
+        # Test of inplace subtractions
         (x, y, xm) = self.floatdata
         m = xm.mask
         a = arange(10, dtype=float)
@@ -1744,7 +1697,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm.mask, mask_or(m, a.mask))
 
     def test_inplace_multiplication_scalar(self):
-        """Test of inplace multiplication"""
+        # Test of inplace multiplication
         (x, y, xm) = self.floatdata
         x *= 2.0
         assert_equal(x, y * 2)
@@ -1752,7 +1705,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm, y * 2)
 
     def test_inplace_multiplication_array(self):
-        """Test of inplace multiplication"""
+        # Test of inplace multiplication
         (x, y, xm) = self.floatdata
         m = xm.mask
         a = arange(10, dtype=float)
@@ -1764,7 +1717,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm.mask, mask_or(m, a.mask))
 
     def test_inplace_division_scalar_int(self):
-        """Test of inplace division"""
+        # Test of inplace division
         (x, y, xm) = self.intdata
         x = arange(10) * 2
         xm = arange(10) * 2
@@ -1775,7 +1728,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm, y)
 
     def test_inplace_division_scalar_float(self):
-        """Test of inplace division"""
+        # Test of inplace division
         (x, y, xm) = self.floatdata
         x /= 2.0
         assert_equal(x, y / 2.0)
@@ -1783,7 +1736,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm, ones((10,)))
 
     def test_inplace_division_array_float(self):
-        """Test of inplace division"""
+        # Test of inplace division
         (x, y, xm) = self.floatdata
         m = xm.mask
         a = arange(10, dtype=float)
@@ -1805,18 +1758,20 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         #
         z = xm / ym
         assert_equal(z._mask, [1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1])
-        assert_equal(z._data, [1., 1., 1., -1., -pi / 2., 4., 5., 1., 1., 1., 2., 3.])
+        assert_equal(z._data,
+                     [1., 1., 1., -1., -pi / 2., 4., 5., 1., 1., 1., 2., 3.])
         #assert_equal(z._data, [0.2,1.,1./3.,-1.,-pi/2.,-1.,5.,1.,1.,1.,2.,1.])
         #
         xm = xm.copy()
         xm /= ym
         assert_equal(xm._mask, [1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1])
-        assert_equal(z._data, [1., 1., 1., -1., -pi / 2., 4., 5., 1., 1., 1., 2., 3.])
-        #assert_equal(xm._data, [1/5.,1.,1./3.,-1.,-pi/2.,-1.,5.,1.,1.,1.,2.,1.])
-
+        assert_equal(z._data,
+                     [1., 1., 1., -1., -pi / 2., 4., 5., 1., 1., 1., 2., 3.])
+        #assert_equal(xm._data,
+        #             [1/5.,1.,1./3.,-1.,-pi/2.,-1.,5.,1.,1.,1.,2.,1.])
 
     def test_datafriendly_add(self):
-        "Test keeping data w/ (inplace) addition"
+        # Test keeping data w/ (inplace) addition
         x = array([1, 2, 3], mask=[0, 0, 1])
         # Test add w/ scalar
         xx = x + 1
@@ -1837,9 +1792,8 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(x.data, [1, 4, 3])
         assert_equal(x.mask, [1, 0, 1])
 
-
     def test_datafriendly_sub(self):
-        "Test keeping data w/ (inplace) subtraction"
+        # Test keeping data w/ (inplace) subtraction
         # Test sub w/ scalar
         x = array([1, 2, 3], mask=[0, 0, 1])
         xx = x - 1
@@ -1861,9 +1815,8 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(x.data, [1, 0, 3])
         assert_equal(x.mask, [1, 0, 1])
 
-
     def test_datafriendly_mul(self):
-        "Test keeping data w/ (inplace) multiplication"
+        # Test keeping data w/ (inplace) multiplication
         # Test mul w/ scalar
         x = array([1, 2, 3], mask=[0, 0, 1])
         xx = x * 2
@@ -1885,9 +1838,8 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(x.data, [1, 40, 3])
         assert_equal(x.mask, [1, 0, 1])
 
-
     def test_datafriendly_div(self):
-        "Test keeping data w/ (inplace) division"
+        # Test keeping data w/ (inplace) division
         # Test div on scalar
         x = array([1, 2, 3], mask=[0, 0, 1])
         xx = x / 2.
@@ -1909,9 +1861,8 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(x.data, [1., 2 / 20., 3.])
         assert_equal(x.mask, [1, 0, 1])
 
-
     def test_datafriendly_pow(self):
-        "Test keeping data w/ (inplace) power"
+        # Test keeping data w/ (inplace) power
         # Test pow on scalar
         x = array([1., 2., 3.], mask=[0, 0, 1])
         xx = x ** 2.5
@@ -1921,7 +1872,6 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         x **= 2.5
         assert_equal(x.data, [1., 2. ** 2.5, 3])
         assert_equal(x.mask, [0, 0, 1])
-
 
     def test_datafriendly_add_arrays(self):
         a = array([[1, 1], [3, 3]])
@@ -1937,7 +1887,6 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(a, [[2, 2], [4, 4]])
         assert_equal(a.mask, [[0, 1], [0, 1]])
 
-
     def test_datafriendly_sub_arrays(self):
         a = array([[1, 1], [3, 3]])
         b = array([1, 1], mask=[0, 0])
@@ -1951,7 +1900,6 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         a -= b
         assert_equal(a, [[0, 0], [2, 2]])
         assert_equal(a.mask, [[0, 1], [0, 1]])
-
 
     def test_datafriendly_mul_arrays(self):
         a = array([[1, 1], [3, 3]])
@@ -1967,13 +1915,13 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(a, [[1, 1], [3, 3]])
         assert_equal(a.mask, [[0, 1], [0, 1]])
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestMaskedArrayMethods(TestCase):
-    "Test class for miscellaneous MaskedArrays methods."
+    # Test class for miscellaneous MaskedArrays methods.
     def setUp(self):
-        "Base data definition."
-        x = np.array([ 8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
+        # Base data definition.
+        x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
                       6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
@@ -2004,9 +1952,8 @@ class TestMaskedArrayMethods(TestCase):
         self.d = (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX)
 
     def test_generic_methods(self):
-        "Tests some MaskedArray methods."
+        # Tests some MaskedArray methods.
         a = array([1, 3, 2])
-        b = array([1, 3, 2], mask=[1, 0, 1])
         assert_equal(a.any(), a._data.any())
         assert_equal(a.all(), a._data.all())
         assert_equal(a.argmax(), a._data.argmax())
@@ -2022,9 +1969,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(a.take([1, 2]), a._data.take([1, 2]))
         assert_equal(m.transpose(), m._data.transpose())
 
-
     def test_allclose(self):
-        "Tests allclose on arrays"
+        # Tests allclose on arrays
         a = np.random.rand(10)
         b = a + np.random.rand(10) * 1e-8
         self.assertTrue(allclose(a, b))
@@ -2043,66 +1989,60 @@ class TestMaskedArrayMethods(TestCase):
         a[0] = 0
         self.assertTrue(allclose(a, 0, masked_equal=True))
 
-
     def test_allany(self):
-        """Checks the any/all methods/functions."""
-        x = np.array([[ 0.13, 0.26, 0.90],
-                     [ 0.28, 0.33, 0.63],
-                     [ 0.31, 0.87, 0.70]])
-        m = np.array([[ True, False, False],
-                     [False, False, False],
-                     [True, True, False]], dtype=np.bool_)
+        # Checks the any/all methods/functions.
+        x = np.array([[0.13, 0.26, 0.90],
+                      [0.28, 0.33, 0.63],
+                      [0.31, 0.87, 0.70]])
+        m = np.array([[True, False, False],
+                      [False, False, False],
+                      [True, True, False]], dtype=np.bool_)
         mx = masked_array(x, mask=m)
-        xbig = np.array([[False, False, True],
-                        [False, False, True],
-                        [False, True, True]], dtype=np.bool_)
         mxbig = (mx > 0.5)
         mxsmall = (mx < 0.5)
         #
-        assert_((mxbig.all() == False))
-        assert_((mxbig.any() == True))
+        self.assertFalse(mxbig.all())
+        self.assertTrue(mxbig.any())
         assert_equal(mxbig.all(0), [False, False, True])
         assert_equal(mxbig.all(1), [False, False, True])
         assert_equal(mxbig.any(0), [False, False, True])
         assert_equal(mxbig.any(1), [True, True, True])
         #
-        assert_((mxsmall.all() == False))
-        assert_((mxsmall.any() == True))
+        self.assertFalse(mxsmall.all())
+        self.assertTrue(mxsmall.any())
         assert_equal(mxsmall.all(0), [True, True, False])
         assert_equal(mxsmall.all(1), [False, False, False])
         assert_equal(mxsmall.any(0), [True, True, False])
         assert_equal(mxsmall.any(1), [True, True, False])
 
-
     def test_allany_onmatrices(self):
-        x = np.array([[ 0.13, 0.26, 0.90],
-                     [ 0.28, 0.33, 0.63],
-                     [ 0.31, 0.87, 0.70]])
+        x = np.array([[0.13, 0.26, 0.90],
+                      [0.28, 0.33, 0.63],
+                      [0.31, 0.87, 0.70]])
         X = np.matrix(x)
-        m = np.array([[ True, False, False],
-                     [False, False, False],
-                     [True, True, False]], dtype=np.bool_)
+        m = np.array([[True, False, False],
+                      [False, False, False],
+                      [True, True, False]], dtype=np.bool_)
         mX = masked_array(X, mask=m)
         mXbig = (mX > 0.5)
         mXsmall = (mX < 0.5)
         #
-        assert_((mXbig.all() == False))
-        assert_((mXbig.any() == True))
+        self.assertFalse(mXbig.all())
+        self.assertTrue(mXbig.any())
         assert_equal(mXbig.all(0), np.matrix([False, False, True]))
         assert_equal(mXbig.all(1), np.matrix([False, False, True]).T)
         assert_equal(mXbig.any(0), np.matrix([False, False, True]))
-        assert_equal(mXbig.any(1), np.matrix([ True, True, True]).T)
+        assert_equal(mXbig.any(1), np.matrix([True, True, True]).T)
         #
-        assert_((mXsmall.all() == False))
-        assert_((mXsmall.any() == True))
+        self.assertFalse(mXsmall.all())
+        self.assertTrue(mXsmall.any())
         assert_equal(mXsmall.all(0), np.matrix([True, True, False]))
         assert_equal(mXsmall.all(1), np.matrix([False, False, False]).T)
         assert_equal(mXsmall.any(0), np.matrix([True, True, False]))
         assert_equal(mXsmall.any(1), np.matrix([True, True, False]).T)
 
-
     def test_allany_oddities(self):
-        "Some fun with all and any"
+        # Some fun with all and any
         store = empty((), dtype=bool)
         full = array([1, 2, 3], mask=True)
         #
@@ -2119,9 +2059,8 @@ class TestMaskedArrayMethods(TestCase):
         self.assertTrue(store._mask, True)
         self.assertTrue(store is not masked)
 
-
     def test_argmax_argmin(self):
-        "Tests argmin & argmax on MaskedArrays."
+        # Tests argmin & argmax on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         #
         assert_equal(mx.argmin(), 35)
@@ -2143,15 +2082,14 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(mX.argmax(1), [2, 4, 1, 1, 4, 1])
         assert_equal(m2X.argmax(1), [2, 4, 1, 1, 1, 1])
 
-
     def test_clip(self):
-        "Tests clip on MaskedArrays."
-        x = np.array([ 8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
-                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
-                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
-                       6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
-                       7.189, 9.645, 5.395, 4.961, 9.894, 2.893,
-                       7.357, 9.828, 6.272, 3.758, 6.693, 0.993])
+        # Tests clip on MaskedArrays.
+        x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
+                      8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
+                      3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
+                      6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
+                      7.189, 9.645, 5.395, 4.961, 9.894, 2.893,
+                      7.357, 9.828, 6.272, 3.758, 6.693, 0.993])
         m = np.array([0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1,
                       0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1,
                       1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0])
@@ -2161,9 +2099,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(clipped._data, x.clip(2, 8))
         assert_equal(clipped._data, mx._data.clip(2, 8))
 
-
     def test_compress(self):
-        "test compress"
+        # test compress
         a = masked_array([1., 2., 3., 4., 5.], fill_value=9999)
         condition = (a > 1.5) & (a < 3.5)
         assert_equal(a.compress(condition), [2., 3.])
@@ -2182,7 +2119,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(b.fill_value, 9999)
         assert_equal(b, a[condition])
         #
-        a = masked_array([[10, 20, 30], [40, 50, 60]], mask=[[0, 0, 1], [1, 0, 0]])
+        a = masked_array([[10, 20, 30], [40, 50, 60]],
+                         mask=[[0, 0, 1], [1, 0, 0]])
         b = a.compress(a.ravel() >= 22)
         assert_equal(b._data, [30, 40, 50, 60])
         assert_equal(b._mask, [1, 1, 0, 0])
@@ -2192,9 +2130,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(b._data, [[10, 30], [40, 60]])
         assert_equal(b._mask, [[0, 1], [1, 0]])
 
-
     def test_compressed(self):
-        "Tests compressed"
+        # Tests compressed
         a = array([1, 2, 3, 4], mask=[0, 0, 0, 0])
         b = a.compressed()
         assert_equal(b, a)
@@ -2210,9 +2147,8 @@ class TestMaskedArrayMethods(TestCase):
         b = a.compressed()
         assert_equal(b, [[2, 3, 4]])
 
-
     def test_empty(self):
-        "Tests empty/like"
+        # Tests empty/like
         datatype = [('a', int), ('b', float), ('c', '|S8')]
         a = masked_array([(1, 1.1, '1.1'), (2, 2.2, '2.2'), (3, 3.3, '3.3')],
                          dtype=datatype)
@@ -2226,9 +2162,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(b.shape, a.shape)
         assert_equal(b.fill_value, a.fill_value)
 
-
     def test_put(self):
-        "Tests put."
+        # Tests put.
         d = arange(5)
         n = [0, 0, 0, 1, 1]
         m = make_mask(n)
@@ -2258,16 +2193,14 @@ class TestMaskedArrayMethods(TestCase):
         assert_array_equal(x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ])
         assert_equal(x.mask, [1, 0, 0, 0, 1, 1, 0, 0, 0, 0])
 
-
     def test_put_hardmask(self):
-        "Tests put on hardmask"
+        # Tests put on hardmask
         d = arange(5)
         n = [0, 0, 0, 1, 1]
         m = make_mask(n)
         xh = array(d + 1, mask=m, hard_mask=True, copy=True)
         xh.put([4, 2, 0, 1, 3], [1, 2, 3, 4, 5])
         assert_equal(xh._data, [3, 4, 2, 4, 5])
-
 
     def test_putmask(self):
         x = arange(6) + 1
@@ -2299,19 +2232,18 @@ class TestMaskedArrayMethods(TestCase):
         putmask(mxx, mask, values)
         assert_equal(mxx, [1, 2, 30, 4, 5, 60])
 
-
     def test_ravel(self):
-        "Tests ravel"
+        # Tests ravel
         a = array([[1, 2, 3, 4, 5]], mask=[[0, 1, 0, 0, 0]])
         aravel = a.ravel()
-        assert_equal(a._mask.shape, a.shape)
+        assert_equal(aravel._mask.shape, aravel.shape)
         a = array([0, 0], mask=[1, 1])
         aravel = a.ravel()
-        assert_equal(a._mask.shape, a.shape)
+        assert_equal(aravel._mask.shape, a.shape)
         a = array(np.matrix([1, 2, 3, 4, 5]), mask=[[0, 1, 0, 0, 0]])
         aravel = a.ravel()
-        assert_equal(a.shape, (1, 5))
-        assert_equal(a._mask.shape, a.shape)
+        assert_equal(aravel.shape, (1, 5))
+        assert_equal(aravel._mask.shape, a.shape)
         # Checks that small_mask is preserved
         a = array([1, 2, 3, 4], mask=[0, 0, 0, 0], shrink=False)
         assert_equal(a.ravel()._mask, [0, 0, 0, 0])
@@ -2323,9 +2255,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(ar._data, [1, 2, 3, 4])
         assert_equal(ar.fill_value, -99)
 
-
     def test_reshape(self):
-        "Tests reshape"
+        # Tests reshape
         x = arange(4)
         x[0] = masked
         y = x.reshape(2, 2)
@@ -2334,9 +2265,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(x.shape, (4,))
         assert_equal(x._mask.shape, (4,))
 
-
     def test_sort(self):
-        "Test sort"
+        # Test sort
         x = array([1, 4, 2, 3], mask=[0, 1, 0, 0], dtype=np.uint8)
         #
         sortedx = sort(x)
@@ -2368,9 +2298,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(sortedx._data, [1, 2, -2, -1, 0])
         assert_equal(sortedx._mask, [1, 1, 0, 0, 0])
 
-
     def test_sort_2d(self):
-        "Check sort of 2D array."
+        # Check sort of 2D array.
         # 2D array w/o mask
         a = masked_array([[8, 4, 1], [2, 0, 9]])
         a.sort(0)
@@ -2409,35 +2338,36 @@ class TestMaskedArrayMethods(TestCase):
         an.sort(2)
         assert_equal(am, an)
 
-
     def test_sort_flexible(self):
-        "Test sort on flexible dtype."
-        a = array([(3, 3), (3, 2), (2, 2), (2, 1), (1, 0), (1, 1), (1, 2)],
-             mask=[(0, 0), (0, 1), (0, 0), (0, 0), (1, 0), (0, 0), (0, 0)],
+        # Test sort on flexible dtype.
+        a = array(
+            data=[(3, 3), (3, 2), (2, 2), (2, 1), (1, 0), (1, 1), (1, 2)],
+            mask=[(0, 0), (0, 1), (0, 0), (0, 0), (1, 0), (0, 0), (0, 0)],
             dtype=[('A', int), ('B', int)])
         #
         test = sort(a)
-        b = array([(1, 1), (1, 2), (2, 1), (2, 2), (3, 3), (3, 2), (1, 0)],
-             mask=[(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1), (1, 0)],
+        b = array(
+            data=[(1, 1), (1, 2), (2, 1), (2, 2), (3, 3), (3, 2), (1, 0)],
+            mask=[(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1), (1, 0)],
             dtype=[('A', int), ('B', int)])
         assert_equal(test, b)
         assert_equal(test.mask, b.mask)
         #
         test = sort(a, endwith=False)
-        b = array([(1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (3, 2), (3, 3), ],
-             mask=[(1, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1), (0, 0), ],
+        b = array(
+            data=[(1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (3, 2), (3, 3), ],
+            mask=[(1, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1), (0, 0), ],
             dtype=[('A', int), ('B', int)])
         assert_equal(test, b)
         assert_equal(test.mask, b.mask)
 
     def test_argsort(self):
-        "Test argsort"
+        # Test argsort
         a = array([1, 5, 2, 4, 3], mask=[1, 0, 0, 1, 0])
         assert_equal(np.argsort(a), argsort(a))
 
-
     def test_squeeze(self):
-        "Check squeeze"
+        # Check squeeze
         data = masked_array([[1, 2, 3]])
         assert_equal(data.squeeze(), [1, 2, 3])
         data = masked_array([[1, 2, 3]], mask=[[1, 1, 1]])
@@ -2446,21 +2376,20 @@ class TestMaskedArrayMethods(TestCase):
         data = masked_array([[1]], mask=True)
         self.assertTrue(data.squeeze() is masked)
 
-
     def test_swapaxes(self):
-        "Tests swapaxes on MaskedArrays."
-        x = np.array([ 8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
+        # Tests swapaxes on MaskedArrays.
+        x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
                       6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
                       7.189, 9.645, 5.395, 4.961, 9.894, 2.893,
                       7.357, 9.828, 6.272, 3.758, 6.693, 0.993])
         m = np.array([0, 1, 0, 1, 0, 0,
-                     1, 0, 1, 1, 0, 1,
-                     0, 0, 0, 1, 0, 1,
-                     0, 0, 0, 1, 1, 1,
-                     1, 0, 0, 1, 0, 0,
-                     0, 0, 1, 0, 1, 0])
+                      1, 0, 1, 1, 0, 1,
+                      0, 0, 0, 1, 0, 1,
+                      0, 0, 0, 1, 1, 1,
+                      1, 0, 0, 1, 0, 0,
+                      0, 0, 1, 0, 1, 0])
         mX = array(x, mask=m).reshape(6, 6)
         mXX = mX.reshape(3, 2, 2, 3)
         #
@@ -2470,9 +2399,8 @@ class TestMaskedArrayMethods(TestCase):
         mXXswapped = mXX.swapaxes(0, 2)
         assert_equal(mXXswapped.shape, (2, 2, 3, 3))
 
-
     def test_take(self):
-        "Tests take"
+        # Tests take
         x = masked_array([10, 20, 30, 40], [0, 1, 0, 1])
         assert_equal(x.take([0, 0, 3]), masked_array([10, 10, 40], [0, 0, 1]))
         assert_equal(x.take([0, 0, 3]), x[[0, 0, 3]])
@@ -2483,10 +2411,10 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(x.take([0, 2], axis=1),
                      array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))
         assert_equal(take(x, [0, 2], axis=1),
-                      array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))
+                     array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))
 
     def test_take_masked_indices(self):
-        "Test take w/ masked indices"
+        # Test take w/ masked indices
         a = np.array((40, 18, 37, 9, 22))
         indices = np.arange(3)[None,:] + np.arange(5)[:, None]
         mindices = array(indices, mask=(indices >= len(a)))
@@ -2495,7 +2423,7 @@ class TestMaskedArrayMethods(TestCase):
         ctrl = array([[40, 18, 37],
                       [18, 37, 9],
                       [37, 9, 22],
-                      [ 9, 22, 22],
+                      [9, 22, 22],
                       [22, 22, 22]])
         assert_equal(test, ctrl)
         # Masked indices
@@ -2503,7 +2431,7 @@ class TestMaskedArrayMethods(TestCase):
         ctrl = array([[40, 18, 37],
                       [18, 37, 9],
                       [37, 9, 22],
-                      [ 9, 22, 40],
+                      [9, 22, 40],
                       [22, 40, 40]])
         ctrl[3, 2] = ctrl[4, 1] = ctrl[4, 2] = masked
         assert_equal(test, ctrl)
@@ -2515,16 +2443,15 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(test, ctrl)
         assert_equal(test.mask, ctrl.mask)
 
-
     def test_tolist(self):
-        "Tests to list"
+        # Tests to list
         # ... on 1D
         x = array(np.arange(12))
         x[[1, -2]] = masked
         xlist = x.tolist()
         self.assertTrue(xlist[1] is None)
         self.assertTrue(xlist[-2] is None)
-       # ... on 2D
+        # ... on 2D
         x.shape = (3, 4)
         xlist = x.tolist()
         ctrl = [[0, None, 2, 3], [4, 5, 6, 7], [8, 9, None, 11]]
@@ -2534,8 +2461,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(xlist, ctrl)
         # ... on structured array w/ masked records
         x = array(list(zip([1, 2, 3],
-                      [1.1, 2.2, 3.3],
-                      ['one', 'two', 'thr'])),
+                           [1.1, 2.2, 3.3],
+                           ['one', 'two', 'thr'])),
                   dtype=[('a', int), ('b', float), ('c', '|S8')])
         x[-1] = masked
         assert_equal(x.tolist(),
@@ -2553,21 +2480,21 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(test, [1, None])
 
     def test_tolist_specialcase(self):
-        "Test mvoid.tolist: make sure we return a standard Python object"
+        # Test mvoid.tolist: make sure we return a standard Python object
         a = array([(0, 1), (2, 3)], dtype=[('a', int), ('b', int)])
         # w/o mask: each entry is a np.void whose elements are standard Python
         for entry in a:
             for item in entry.tolist():
                 assert_(not isinstance(item, np.generic))
-        # w/ mask: each entry is a ma.void whose elements should be standard Python
+        # w/ mask: each entry is a ma.void whose elements should be
+        # standard Python
         a.mask[0] = (0, 1)
         for entry in a:
             for item in entry.tolist():
                 assert_(not isinstance(item, np.generic))
 
-
     def test_toflex(self):
-        "Test the conversion to records"
+        # Test the conversion to records
         data = arange(10)
         record = data.toflex()
         assert_equal(record['_data'], data._data)
@@ -2580,8 +2507,8 @@ class TestMaskedArrayMethods(TestCase):
         #
         ndtype = [('i', int), ('s', '|S3'), ('f', float)]
         data = array([(i, s, f) for (i, s, f) in zip(np.arange(10),
-                                                 'ABCDEFGHIJKLM',
-                                                 np.random.rand(10))],
+                                                     'ABCDEFGHIJKLM',
+                                                     np.random.rand(10))],
                      dtype=ndtype)
         data[[0, 1, 2, -1]] = masked
         record = data.toflex()
@@ -2590,17 +2517,16 @@ class TestMaskedArrayMethods(TestCase):
         #
         ndtype = np.dtype("int, (2,3)float, float")
         data = array([(i, f, ff) for (i, f, ff) in zip(np.arange(10),
-                                                   np.random.rand(10),
-                                                   np.random.rand(10))],
+                                                       np.random.rand(10),
+                                                       np.random.rand(10))],
                      dtype=ndtype)
         data[[0, 1, 2, -1]] = masked
         record = data.toflex()
         assert_equal_records(record['_data'], data._data)
         assert_equal_records(record['_mask'], data._mask)
 
-
     def test_fromflex(self):
-        "Test the reconstruction of a masked_array from a record"
+        # Test the reconstruction of a masked_array from a record
         a = array([1, 2, 3])
         test = fromflex(a.toflex())
         assert_equal(test, a)
@@ -2617,9 +2543,8 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(test, a)
         assert_equal(test.data, a.data)
 
-
     def test_arraymethod(self):
-        "Test a _arraymethod w/ n argument"
+        # Test a _arraymethod w/ n argument
         marray = masked_array([[1, 2, 3, 4, 5]], mask=[0, 0, 1, 0, 0])
         control = masked_array([[1], [2], [3], [4], [5]],
                                mask=[0, 0, 1, 0, 0])
@@ -2630,13 +2555,11 @@ class TestMaskedArrayMethods(TestCase):
 
 
 #------------------------------------------------------------------------------
-
-
 class TestMaskedArrayMathMethods(TestCase):
 
     def setUp(self):
-        "Base data definition."
-        x = np.array([ 8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
+        # Base data definition.
+        x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
                       6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
@@ -2666,9 +2589,8 @@ class TestMaskedArrayMathMethods(TestCase):
         m2XX = array(data=XX, mask=m2.reshape(XX.shape))
         self.d = (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX)
 
-
     def test_cumsumprod(self):
-        "Tests cumsum & cumprod on MaskedArrays."
+        # Tests cumsum & cumprod on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         mXcp = mX.cumsum(0)
         assert_equal(mXcp._data, mX.filled(0).cumsum(0))
@@ -2680,9 +2602,8 @@ class TestMaskedArrayMathMethods(TestCase):
         mXcp = mX.cumprod(1)
         assert_equal(mXcp._data, mX.filled(1).cumprod(1))
 
-
     def test_cumsumprod_with_output(self):
-        "Tests cumsum/cumprod w/ output"
+        # Tests cumsum/cumprod w/ output
         xm = array(np.random.uniform(0, 10, 12)).reshape(3, 4)
         xm[:, 0] = xm[0] = xm[-1, -1] = masked
         #
@@ -2702,9 +2623,8 @@ class TestMaskedArrayMathMethods(TestCase):
             result = xmmeth(axis=0, out=output)
             self.assertTrue(result is output)
 
-
     def test_ptp(self):
-        "Tests ptp on MaskedArrays."
+        # Tests ptp on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         (n, m) = X.shape
         assert_equal(mx.ptp(), mx.compressed().ptp())
@@ -2717,39 +2637,37 @@ class TestMaskedArrayMathMethods(TestCase):
         assert_equal(mX.ptp(0), cols)
         assert_equal(mX.ptp(1), rows)
 
-
     def test_sum_object(self):
-        "Test sum on object dtype"
+        # Test sum on object dtype
         a = masked_array([1, 2, 3], mask=[1, 0, 0], dtype=np.object)
         assert_equal(a.sum(), 5)
         a = masked_array([[1, 2, 3], [4, 5, 6]], dtype=object)
         assert_equal(a.sum(axis=0), [5, 7, 9])
 
     def test_prod_object(self):
-        "Test prod on object dtype"
+        # Test prod on object dtype
         a = masked_array([1, 2, 3], mask=[1, 0, 0], dtype=np.object)
         assert_equal(a.prod(), 2 * 3)
         a = masked_array([[1, 2, 3], [4, 5, 6]], dtype=object)
         assert_equal(a.prod(axis=0), [4, 10, 18])
 
     def test_meananom_object(self):
-        "Test mean/anom on object dtype"
+        # Test mean/anom on object dtype
         a = masked_array([1, 2, 3], dtype=np.object)
         assert_equal(a.mean(), 2)
         assert_equal(a.anom(), [-1, 0, 1])
 
-
     def test_trace(self):
-        "Tests trace on MaskedArrays."
+        # Tests trace on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         mXdiag = mX.diagonal()
         assert_equal(mX.trace(), mX.diagonal().compressed().sum())
         assert_almost_equal(mX.trace(),
-                            X.trace() - sum(mXdiag.mask * X.diagonal(), axis=0))
-
+                            X.trace() - sum(mXdiag.mask * X.diagonal(),
+                                            axis=0))
 
     def test_varstd(self):
-        "Tests var & std on MaskedArrays."
+        # Tests var & std on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         assert_almost_equal(mX.var(axis=None), mX.compressed().var())
         assert_almost_equal(mX.std(axis=None), mX.compressed().std())
@@ -2760,16 +2678,18 @@ class TestMaskedArrayMathMethods(TestCase):
         assert_equal(mXX.var(axis=3).shape, XX.var(axis=3).shape)
         assert_equal(mX.var().shape, X.var().shape)
         (mXvar0, mXvar1) = (mX.var(axis=0), mX.var(axis=1))
-        assert_almost_equal(mX.var(axis=None, ddof=2), mX.compressed().var(ddof=2))
-        assert_almost_equal(mX.std(axis=None, ddof=2), mX.compressed().std(ddof=2))
+        assert_almost_equal(mX.var(axis=None, ddof=2),
+                            mX.compressed().var(ddof=2))
+        assert_almost_equal(mX.std(axis=None, ddof=2),
+                            mX.compressed().std(ddof=2))
         for k in range(6):
             assert_almost_equal(mXvar1[k], mX[k].compressed().var())
             assert_almost_equal(mXvar0[k], mX[:, k].compressed().var())
-            assert_almost_equal(np.sqrt(mXvar0[k]), mX[:, k].compressed().std())
-
+            assert_almost_equal(np.sqrt(mXvar0[k]),
+                                mX[:, k].compressed().std())
 
     def test_varstd_specialcases(self):
-        "Test a special case for var"
+        # Test a special case for var
         nout = np.array(-1, dtype=float)
         mout = array(-1, dtype=float)
         #
@@ -2799,13 +2719,12 @@ class TestMaskedArrayMathMethods(TestCase):
             self.assertTrue(method(0, ddof=1) is masked)
             self.assertTrue(method(-1, ddof=1) is masked)
             # Using a masked array as explicit output
-            _ = method(out=mout, ddof=1)
+            method(out=mout, ddof=1)
             self.assertTrue(mout is not masked)
             assert_equal(mout.mask, True)
             # Using a ndarray as explicit output
-            _ = method(out=nout, ddof=1)
+            method(out=nout, ddof=1)
             self.assertTrue(np.isnan(nout))
-
 
     def test_varstd_ddof(self):
         a = array([[1, 1, 0], [1, 1, 0]], mask=[[0, 0, 1], [0, 0, 1]])
@@ -2819,9 +2738,8 @@ class TestMaskedArrayMathMethods(TestCase):
         assert_equal(test.filled(0), [0, 0, 0])
         assert_equal(test.mask, [1, 1, 1])
 
-
     def test_diag(self):
-        "Test diag"
+        # Test diag
         x = arange(9).reshape((3, 3))
         x[1, 1] = masked
         out = np.diag(x)
@@ -2834,9 +2752,8 @@ class TestMaskedArrayMathMethods(TestCase):
                         mask=[[0, 0, 0], [0, 1, 0], [0, 0, 0]])
         assert_equal(out, control)
 
-
     def test_axis_methods_nomask(self):
-        "Test the combination nomask & methods w/ axis"
+        # Test the combination nomask & methods w/ axis
         a = array([[1, 2, 3], [4, 5, 6]])
         #
         assert_equal(a.sum(0), [5, 7, 9])
@@ -2855,13 +2772,13 @@ class TestMaskedArrayMathMethods(TestCase):
         assert_equal(a.max(-1), [3, 6])
         assert_equal(a.max(1), [3, 6])
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestMaskedArrayMathMethodsComplex(TestCase):
-    "Test class for miscellaneous MaskedArrays methods."
+    # Test class for miscellaneous MaskedArrays methods.
     def setUp(self):
-        "Base data definition."
-        x = np.array([ 8.375j, 7.545j, 8.828j, 8.5j, 1.757j, 5.928,
+        # Base data definition.
+        x = np.array([8.375j, 7.545j, 8.828j, 8.5j, 1.757j, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
                       6.04, 9.63, 7.712, 3.382, 4.489, 6.479j,
@@ -2891,39 +2808,36 @@ class TestMaskedArrayMathMethodsComplex(TestCase):
         m2XX = array(data=XX, mask=m2.reshape(XX.shape))
         self.d = (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX)
 
-
     def test_varstd(self):
-        "Tests var & std on MaskedArrays."
+        # Tests var & std on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         assert_almost_equal(mX.var(axis=None), mX.compressed().var())
         assert_almost_equal(mX.std(axis=None), mX.compressed().std())
         assert_equal(mXX.var(axis=3).shape, XX.var(axis=3).shape)
         assert_equal(mX.var().shape, X.var().shape)
         (mXvar0, mXvar1) = (mX.var(axis=0), mX.var(axis=1))
-        assert_almost_equal(mX.var(axis=None, ddof=2), mX.compressed().var(ddof=2))
-        assert_almost_equal(mX.std(axis=None, ddof=2), mX.compressed().std(ddof=2))
+        assert_almost_equal(mX.var(axis=None, ddof=2),
+                            mX.compressed().var(ddof=2))
+        assert_almost_equal(mX.std(axis=None, ddof=2),
+                            mX.compressed().std(ddof=2))
         for k in range(6):
             assert_almost_equal(mXvar1[k], mX[k].compressed().var())
             assert_almost_equal(mXvar0[k], mX[:, k].compressed().var())
-            assert_almost_equal(np.sqrt(mXvar0[k]), mX[:, k].compressed().std())
+            assert_almost_equal(np.sqrt(mXvar0[k]),
+                                mX[:, k].compressed().std())
 
 
 #------------------------------------------------------------------------------
-
 class TestMaskedArrayFunctions(TestCase):
-    "Test class for miscellaneous functions."
+    # Test class for miscellaneous functions.
 
     def setUp(self):
-        x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
+        x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
-        a10 = 10.
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
         m2 = [0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1]
         xm = masked_array(x, mask=m1)
         ym = masked_array(y, mask=m2)
-        z = np.array([-.5, 0., .5, .8])
-        zm = masked_array(z, mask=[0, 1, 0, 0])
-        xf = np.where(m1, 1e+20, x)
         xm.set_fill_value(1e+20)
         self.info = (xm, ym)
 
@@ -2949,26 +2863,27 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(mx.fill_value, 3)
 
     def test_masked_where_condition(self):
-        "Tests masking functions."
+        # Tests masking functions.
         x = array([1., 2., 3., 4., 5.])
         x[2] = masked
         assert_equal(masked_where(greater(x, 2), x), masked_greater(x, 2))
-        assert_equal(masked_where(greater_equal(x, 2), x), masked_greater_equal(x, 2))
+        assert_equal(masked_where(greater_equal(x, 2), x),
+                     masked_greater_equal(x, 2))
         assert_equal(masked_where(less(x, 2), x), masked_less(x, 2))
-        assert_equal(masked_where(less_equal(x, 2), x), masked_less_equal(x, 2))
+        assert_equal(masked_where(less_equal(x, 2), x),
+                     masked_less_equal(x, 2))
         assert_equal(masked_where(not_equal(x, 2), x), masked_not_equal(x, 2))
         assert_equal(masked_where(equal(x, 2), x), masked_equal(x, 2))
         assert_equal(masked_where(not_equal(x, 2), x), masked_not_equal(x, 2))
-        assert_equal(masked_where([1, 1, 0, 0, 0], [1, 2, 3, 4, 5]), [99, 99, 3, 4, 5])
-
+        assert_equal(masked_where([1, 1, 0, 0, 0], [1, 2, 3, 4, 5]),
+                     [99, 99, 3, 4, 5])
 
     def test_masked_where_oddities(self):
-        """Tests some generic features."""
+        # Tests some generic features.
         atest = ones((10, 10, 10), dtype=float)
         btest = zeros(atest.shape, MaskType)
         ctest = masked_where(btest, atest)
         assert_equal(atest, ctest)
-
 
     def test_masked_where_shape_constraint(self):
         a = arange(10)
@@ -2981,15 +2896,22 @@ class TestMaskedArrayFunctions(TestCase):
         test = masked_equal(a, 1)
         assert_equal(test.mask, [0, 1, 0, 0, 0, 0, 0, 0, 0, 0])
 
-
     def test_masked_otherfunctions(self):
-        assert_equal(masked_inside(list(range(5)), 1, 3), [0, 199, 199, 199, 4])
+        assert_equal(masked_inside(list(range(5)), 1, 3),
+                     [0, 199, 199, 199, 4])
         assert_equal(masked_outside(list(range(5)), 1, 3), [199, 1, 2, 3, 199])
-        assert_equal(masked_inside(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 1, 3).mask, [1, 1, 1, 1, 0])
-        assert_equal(masked_outside(array(list(range(5)), mask=[0, 1, 0, 0, 0]), 1, 3).mask, [1, 1, 0, 0, 1])
-        assert_equal(masked_equal(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 2).mask, [1, 0, 1, 0, 0])
-        assert_equal(masked_not_equal(array([2, 2, 1, 2, 1], mask=[1, 0, 0, 0, 0]), 2).mask, [1, 0, 1, 0, 1])
-
+        assert_equal(masked_inside(array(list(range(5)),
+                                         mask=[1, 0, 0, 0, 0]), 1, 3).mask,
+                     [1, 1, 1, 1, 0])
+        assert_equal(masked_outside(array(list(range(5)),
+                                          mask=[0, 1, 0, 0, 0]), 1, 3).mask,
+                     [1, 1, 0, 0, 1])
+        assert_equal(masked_equal(array(list(range(5)),
+                                        mask=[1, 0, 0, 0, 0]), 2).mask,
+                     [1, 0, 1, 0, 0])
+        assert_equal(masked_not_equal(array([2, 2, 1, 2, 1],
+                                            mask=[1, 0, 0, 0, 0]), 2).mask,
+                     [1, 0, 1, 0, 1])
 
     def test_round(self):
         a = array([1.23456, 2.34567, 3.45678, 4.56789, 5.67890],
@@ -3013,9 +2935,8 @@ class TestMaskedArrayFunctions(TestCase):
         assert_(z[1] is not masked)
         assert_(z[2] is masked)
 
-
     def test_round_with_output(self):
-        "Testing round with an explicit output"
+        # Testing round with an explicit output
 
         xm = array(np.random.uniform(0, 10, 12)).reshape(3, 4)
         xm[:, 0] = xm[0] = xm[-1, -1] = masked
@@ -3032,12 +2953,10 @@ class TestMaskedArrayFunctions(TestCase):
         result = xm.round(decimals=2, out=output)
         self.assertTrue(result is output)
 
-
     def test_identity(self):
         a = identity(5)
         self.assertTrue(isinstance(a, MaskedArray))
         assert_equal(a, np.identity(5))
-
 
     def test_power(self):
         x = -1.1
@@ -3061,16 +2980,15 @@ class TestMaskedArrayFunctions(TestCase):
         assert_almost_equal(x._data, y._data)
 
     def test_power_w_broadcasting(self):
-        "Test power w/ broadcasting"
+        # Test power w/ broadcasting
         a2 = np.array([[1., 2., 3.], [4., 5., 6.]])
         a2m = array(a2, mask=[[1, 0, 0], [0, 0, 1]])
         b1 = np.array([2, 4, 3])
-        b1m = array(b1, mask=[0, 1, 0])
         b2 = np.array([b1, b1])
         b2m = array(b2, mask=[[0, 1, 0], [0, 1, 0]])
         #
         ctrl = array([[1 ** 2, 2 ** 4, 3 ** 3], [4 ** 2, 5 ** 4, 6 ** 3]],
-                mask=[[1, 1, 0], [0, 1, 1]])
+                     mask=[[1, 1, 0], [0, 1, 1]])
         # No broadcasting, base & exp w/ mask
         test = a2m ** b2m
         assert_equal(test, ctrl)
@@ -3085,7 +3003,7 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(test.mask, b2m.mask)
         #
         ctrl = array([[2 ** 2, 4 ** 4, 3 ** 3], [2 ** 2, 4 ** 4, 3 ** 3]],
-                mask=[[0, 1, 0], [0, 1, 0]])
+                     mask=[[0, 1, 0], [0, 1, 0]])
         test = b1 ** b2m
         assert_equal(test, ctrl)
         assert_equal(test.mask, ctrl.mask)
@@ -3093,29 +3011,27 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(test, ctrl)
         assert_equal(test.mask, ctrl.mask)
 
-
     def test_where(self):
-        "Test the where function"
-        x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
+        # Test the where function
+        x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
-        a10 = 10.
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
         m2 = [0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1]
         xm = masked_array(x, mask=m1)
         ym = masked_array(y, mask=m2)
-        z = np.array([-.5, 0., .5, .8])
-        zm = masked_array(z, mask=[0, 1, 0, 0])
-        xf = np.where(m1, 1e+20, x)
         xm.set_fill_value(1e+20)
         #
         d = where(xm > 2, xm, -9)
-        assert_equal(d, [-9., -9., -9., -9., -9., 4., -9., -9., 10., -9., -9., 3.])
+        assert_equal(d, [-9., -9., -9., -9., -9., 4.,
+                         -9., -9., 10., -9., -9., 3.])
         assert_equal(d._mask, xm._mask)
         d = where(xm > 2, -9, ym)
-        assert_equal(d, [5., 0., 3., 2., -1., -9., -9., -10., -9., 1., 0., -9.])
+        assert_equal(d, [5., 0., 3., 2., -1., -9.,
+                         -9., -10., -9., 1., 0., -9.])
         assert_equal(d._mask, [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0])
         d = where(xm > 2, xm, masked)
-        assert_equal(d, [-9., -9., -9., -9., -9., 4., -9., -9., 10., -9., -9., 3.])
+        assert_equal(d, [-9., -9., -9., -9., -9., 4.,
+                         -9., -9., 10., -9., -9., 3.])
         tmp = xm._mask.copy()
         tmp[(xm <= 2).filled(True)] = True
         assert_equal(d._mask, tmp)
@@ -3124,7 +3040,6 @@ class TestMaskedArrayFunctions(TestCase):
         d = where(ixm > 2, ixm, masked)
         assert_equal(d, [-9, -9, -9, -9, -9, 4, -9, -9, 10, -9, -9, 3])
         assert_equal(d.dtype, ixm.dtype)
-
 
     def test_where_with_masked_choice(self):
         x = arange(10)
@@ -3178,16 +3093,15 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(z, [99, 1, 1, 99, 99])
 
     def test_where_type(self):
-        "Test the type conservation with where"
+        # Test the type conservation with where
         x = np.arange(4, dtype=np.int32)
         y = np.arange(4, dtype=np.float32) * 2.2
         test = where(x > 1.5, y, x).dtype
         control = np.find_common_type([np.int32, np.float32], [])
         assert_equal(test, control)
 
-
     def test_choose(self):
-        "Test choose"
+        # Test choose
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],
                    [20, 21, 22, 23], [30, 31, 32, 33]]
         chosen = choose([2, 3, 1, 0], choices)
@@ -3209,9 +3123,8 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(chosen, array([20, 31, 12, 3]))
         assert_equal(chosen.mask, [1, 0, 0, 1])
 
-
     def test_choose_with_out(self):
-        "Test choose with an explicit out keyword"
+        # Test choose with an explicit out keyword
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],
                    [20, 21, 22, 23], [30, 31, 32, 33]]
         store = empty(4, dtype=int)
@@ -3231,7 +3144,6 @@ class TestMaskedArrayFunctions(TestCase):
         store = empty(4, dtype=int).view(ndarray)
         chosen = choose(indices_, choices, mode='wrap', out=store)
         assert_equal(store, array([999999, 31, 12, 999999]))
-
 
     def test_reshape(self):
         a = arange(10)
@@ -3259,9 +3171,8 @@ class TestMaskedArrayFunctions(TestCase):
         self.assertTrue(c[0, 0] is masked)
         self.assertTrue(c.flags['C'])
 
-
     def test_make_mask_descr(self):
-        "Test make_mask_descr"
+        # Test make_mask_descr
         # Flexible
         ntype = [('a', np.float), ('b', np.float)]
         test = make_mask_descr(ntype)
@@ -3288,9 +3199,8 @@ class TestMaskedArrayFunctions(TestCase):
         test = make_mask_descr(ntype)
         assert_equal(test, np.dtype([(('A', 'a'), bool)]))
 
-
     def test_make_mask(self):
-        "Test make_mask"
+        # Test make_mask
         # w/ a list as an input
         mask = [0, 1]
         test = make_mask(mask)
@@ -3320,7 +3230,6 @@ class TestMaskedArrayFunctions(TestCase):
         test = make_mask(mask, dtype=mask.dtype)
         assert_equal(test.dtype, bdtype)
         assert_equal(test, np.array([(0, 0), (0, 1)], dtype=bdtype))
-
 
     def test_mask_or(self):
         # Initialize
@@ -3357,9 +3266,8 @@ class TestMaskedArrayFunctions(TestCase):
         cntrl = np.array([(1, (1, 1)), (0, (1, 0))], dtype=dtype)
         assert_equal(mask_or(amask, bmask), cntrl)
 
-
     def test_flatten_mask(self):
-        "Tests flatten mask"
+        # Tests flatten mask
         # Standarad dtype
         mask = np.array([0, 0, 1], dtype=np.bool)
         assert_equal(flatten_mask(mask), mask)
@@ -3373,12 +3281,11 @@ class TestMaskedArrayFunctions(TestCase):
         data = [(0, (0, 0)), (0, (0, 1))]
         mask = np.array(data, dtype=mdtype)
         test = flatten_mask(mask)
-        control = np.array([ 0, 0, 0, 0, 0, 1], dtype=bool)
+        control = np.array([0, 0, 0, 0, 0, 1], dtype=bool)
         assert_equal(test, control)
 
-
     def test_on_ndarray(self):
-        "Test functions on ndarrays"
+        # Test functions on ndarrays
         a = np.array([1, 2, 3, 4])
         m = array(a, mask=False)
         test = anom(a)
@@ -3399,8 +3306,8 @@ class TestMaskedArrayFunctions(TestCase):
         test = np.ma.compress(cond, marr, axis=0)
         assert_equal(test, control)
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestMaskedFields(TestCase):
     #
     def setUp(self):
@@ -3433,7 +3340,7 @@ class TestMaskedFields(TestCase):
                                       dtype=mdtype))
 
     def test_set_record_element(self):
-        "Check setting an element of a record)"
+        # Check setting an element of a record)
         base = self.data['base']
         (base_a, base_b, base_c) = (base['a'], base['b'], base['c'])
         base[0] = (pi, pi, 'pi')
@@ -3472,9 +3379,9 @@ class TestMaskedFields(TestCase):
         for n in ('a', 'b', 'c'):
             assert_equal(base[n].mask, [1, 1, 0, 0, 1])
             assert_equal(base[n]._data, base._data[n])
-    #
+
     def test_getmaskarray(self):
-        "Test getmaskarray on flexible dtype"
+        # Test getmaskarray on flexible dtype
         ndtype = [('a', int), ('b', float)]
         test = empty(3, dtype=ndtype)
         assert_equal(getmaskarray(test),
@@ -3484,9 +3391,9 @@ class TestMaskedFields(TestCase):
         assert_equal(getmaskarray(test),
                      np.array([(1, 1), (1, 1), (1, 1)],
                               dtype=[('a', '|b1'), ('b', '|b1')]))
-    #
+
     def test_view(self):
-        "Test view w/ flexible dtype"
+        # Test view w/ flexible dtype
         iterator = list(zip(np.arange(10), np.random.rand(10)))
         data = np.array(iterator)
         a = array(iterator, dtype=[('a', float), ('b', float)])
@@ -3504,12 +3411,12 @@ class TestMaskedFields(TestCase):
         test = a.view((float, 2), np.matrix)
         assert_equal(test, data)
         self.assertTrue(isinstance(test, np.matrix))
-    #
+
     def test_getitem(self):
         ndtype = [('a', float), ('b', float)]
         a = array(list(zip(np.random.rand(10), np.arange(10))), dtype=ndtype)
         a.mask = np.array(list(zip([0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-                              [1, 0, 0, 0, 0, 0, 0, 0, 1, 0])),
+                                   [1, 0, 0, 0, 0, 0, 0, 0, 1, 0])),
                           dtype=[('a', bool), ('b', bool)])
         # No mask
         self.assertTrue(isinstance(a[1], MaskedArray))
@@ -3550,8 +3457,8 @@ class TestMaskedFields(TestCase):
         for rec in self.data['base']:
             assert_equal(len(rec), len(self.data['ddtype']))
 
-#------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
 class TestMaskedView(TestCase):
     #
     def setUp(self):
@@ -3561,7 +3468,7 @@ class TestMaskedView(TestCase):
         a.mask[0] = (1, 0)
         controlmask = np.array([1] + 19 * [0], dtype=bool)
         self.data = (data, a, controlmask)
-    #
+
     def test_view_to_nothing(self):
         (data, a, controlmask) = self.data
         test = a.view()
@@ -3569,14 +3476,13 @@ class TestMaskedView(TestCase):
         assert_equal(test._data, a._data)
         assert_equal(test._mask, a._mask)
 
-    #
     def test_view_to_type(self):
         (data, a, controlmask) = self.data
         test = a.view(np.ndarray)
         self.assertTrue(not isinstance(test, MaskedArray))
         assert_equal(test, a._data)
         assert_equal_records(test, data.view(a.dtype).squeeze())
-    #
+
     def test_view_to_simple_dtype(self):
         (data, a, controlmask) = self.data
         # View globally
@@ -3584,7 +3490,7 @@ class TestMaskedView(TestCase):
         self.assertTrue(isinstance(test, MaskedArray))
         assert_equal(test, data.ravel())
         assert_equal(test.mask, controlmask)
-    #
+
     def test_view_to_flexible_dtype(self):
         (data, a, controlmask) = self.data
         #
@@ -3605,7 +3511,6 @@ class TestMaskedView(TestCase):
         assert_equal(test['A'], a['a'][-1])
         assert_equal(test['B'], a['b'][-1])
 
-    #
     def test_view_to_subdtype(self):
         (data, a, controlmask) = self.data
         # View globally
@@ -3622,7 +3527,7 @@ class TestMaskedView(TestCase):
         test = a[-1].view((float, 2))
         self.assertTrue(isinstance(test, MaskedArray))
         assert_equal(test, data[-1])
-    #
+
     def test_view_to_dtype_and_type(self):
         (data, a, controlmask) = self.data
         #
@@ -3630,6 +3535,7 @@ class TestMaskedView(TestCase):
         assert_equal(test, data)
         self.assertTrue(isinstance(test, np.matrix))
         self.assertTrue(not isinstance(test, MaskedArray))
+
 
 def test_masked_array():
     a = np.ma.array([0, 1, 2, 3], mask=[0, 0, 1, 0])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1113,23 +1113,25 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test.mask, [False, False])
 
     def test_eq_w_None(self):
+        # Really, comparisons with None should not be done, but
+        # check them anyway
         # With partial mask
         a = array([1, 2], mask=[0, 1])
-        assert_equal(a is None, False)
-        assert_equal(a.data is None, False)
-        assert_equal(a.mask is None, False)
-        assert_equal(a is not None, True)
+        assert_equal(a == None, False)
+        assert_equal(a.data == None, False)
+        assert_equal(a.mask == None, False)
+        assert_equal(a != None, True)
         # With nomask
         a = array([1, 2], mask=False)
-        assert_equal(a is None, False)
-        assert_equal(a is not None, True)
+        assert_equal(a == None, False)
+        assert_equal(a != None, True)
         # With complete mask
         a = array([1, 2], mask=True)
-        assert_equal(a is None, False)
-        assert_equal(a is not None, True)
-        # With masked
+        assert_equal(a == None, False)
+        assert_equal(a != None, True)
+        # Fully masked, even comparison to None should return "masked"
         a = masked
-        assert_equal(a == 1, masked)
+        assert_equal(a == None, masked)
 
     def test_eq_w_scalar(self):
         a = array(1)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1338,7 +1338,7 @@ class TestFillingValues(TestCase):
 
         #.....Using an object-array shouldn't matter either
         fill_val = np.ndarray(shape=(1,), dtype=object)
-        fill_val[0] = (-999, -12345678.9, "???")
+        fill_val[0] = (-999, -12345678.9, asbytes("???"))
         fval = _check_fill_value(fill_val, object)
         self.assertTrue(isinstance(fval, ndarray))
         assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -17,10 +17,11 @@ __date__ = '$Date: 2007-10-29 17:18:13 +0200 (Mon, 29 Oct 2007) $'
 import numpy as np
 from numpy.testing import TestCase, run_module_suite
 from numpy.ma.testutils import (rand, assert_, assert_array_equal,
-    assert_equal, assert_almost_equal)
+                                assert_equal, assert_almost_equal)
 from numpy.ma.core import (array, arange, masked, MaskedArray, masked_array,
-    getmaskarray, shape, nomask, ones, zeros, count)
-from numpy.ma.extras import (atleast_2d, mr_, dot, polyfit,
+                           getmaskarray, shape, nomask, ones, zeros, count)
+from numpy.ma.extras import (
+    atleast_2d, mr_, dot, polyfit,
     cov, corrcoef, median, average,
     unique, setxor1d, setdiff1d, union1d, intersect1d, in1d, ediff1d,
     apply_over_axes, apply_along_axis,
@@ -33,7 +34,7 @@ from numpy.ma.extras import (atleast_2d, mr_, dot, polyfit,
 class TestGeneric(TestCase):
     #
     def test_masked_all(self):
-        "Tests masked_all"
+        # Tests masked_all
         # Standard dtype
         test = masked_all((2,), dtype=float)
         control = array([1, 1], mask=[1, 1], dtype=float)
@@ -52,18 +53,18 @@ class TestGeneric(TestCase):
         dt = np.dtype([('a', 'f'), ('b', [('ba', 'f'), ('bb', 'f')])])
         test = masked_all((2,), dtype=dt)
         control = array([(1, (1, 1)), (1, (1, 1))],
-                         mask=[(1, (1, 1)), (1, (1, 1))], dtype=dt)
+                        mask=[(1, (1, 1)), (1, (1, 1))], dtype=dt)
         assert_equal(test, control)
         test = masked_all((2,), dtype=dt)
         control = array([(1, (1, 1)), (1, (1, 1))],
-                         mask=[(1, (1, 1)), (1, (1, 1))], dtype=dt)
+                        mask=[(1, (1, 1)), (1, (1, 1))], dtype=dt)
         assert_equal(test, control)
         test = masked_all((1, 1), dtype=dt)
         control = array([[(1, (1, 1))]], mask=[[(1, (1, 1))]], dtype=dt)
         assert_equal(test, control)
 
     def test_masked_all_like(self):
-        "Tests masked_all"
+        # Tests masked_all
         # Standard dtype
         base = array([1, 2], dtype=float)
         test = masked_all_like(base)
@@ -83,7 +84,7 @@ class TestGeneric(TestCase):
         assert_equal(test, control)
 
     def test_clump_masked(self):
-        "Test clump_masked"
+        # Test clump_masked
         a = masked_array(np.arange(10))
         a[[0, 1, 2, 6, 8, 9]] = masked
         #
@@ -92,7 +93,7 @@ class TestGeneric(TestCase):
         assert_equal(test, control)
 
     def test_clump_unmasked(self):
-        "Test clump_unmasked"
+        # Test clump_unmasked
         a = masked_array(np.arange(10))
         a[[0, 1, 2, 6, 8, 9]] = masked
         test = clump_unmasked(a)
@@ -100,7 +101,7 @@ class TestGeneric(TestCase):
         assert_equal(test, control)
 
     def test_flatnotmasked_contiguous(self):
-        "Test flatnotmasked_contiguous"
+        # Test flatnotmasked_contiguous
         a = arange(10)
         # No mask
         test = flatnotmasked_contiguous(a)
@@ -116,9 +117,9 @@ class TestGeneric(TestCase):
 
 
 class TestAverage(TestCase):
-    "Several tests of average. Why so many ? Good point..."
+    # Several tests of average. Why so many ? Good point...
     def test_testAverage1(self):
-        "Test of average."
+        # Test of average.
         ott = array([0., 1., 2., 3.], mask=[True, False, False, False])
         assert_equal(2.0, average(ott, axis=0))
         assert_equal(2.0, average(ott, weights=[1., 1., 2., 1.]))
@@ -137,7 +138,7 @@ class TestAverage(TestCase):
         assert_equal(wts, [1., 0.])
 
     def test_testAverage2(self):
-        "More tests of average."
+        # More tests of average.
         w1 = [0, 1, 1, 1, 1, 0]
         w2 = [[0, 1, 1, 1, 1, 0], [1, 0, 0, 0, 0, 1]]
         x = arange(6, dtype=np.float_)
@@ -171,7 +172,7 @@ class TestAverage(TestCase):
                      [0., 1., 99., 99., 4.0, 10.0])
 
     def test_testAverage3(self):
-        "Yet more tests of average!"
+        # Yet more tests of average!
         a = arange(6)
         b = arange(6) * 3
         r1, w1 = average([[a, b], [b, a]], axis=1, returned=1)
@@ -195,7 +196,7 @@ class TestAverage(TestCase):
         assert_equal(a2dma, [1.5, 4.0])
 
     def test_onintegers_with_mask(self):
-        "Test average on integers with mask"
+        # Test average on integers with mask
         a = average(array([1, 2]))
         assert_equal(a, 1.5)
         a = average(array([1, 2, 3, 4], mask=[False, False, True, True]))
@@ -206,7 +207,7 @@ class TestAverage(TestCase):
         # (Regression test for https://github.com/numpy/numpy/issues/2684)
         mask = np.array([[0, 0, 0, 1, 0],
                          [0, 1, 0, 0, 0]], dtype=bool)
-        a = masked_array([[0,  1+2j, 3+4j, 5+6j, 7+8j],
+        a = masked_array([[0, 1+2j, 3+4j, 5+6j, 7+8j],
                           [9j, 0+1j, 2+3j, 4+5j, 7+7j]],
                          mask=mask)
 
@@ -247,12 +248,10 @@ class TestAverage(TestCase):
 
 
 class TestConcatenator(TestCase):
-    """
-    Tests for mr_, the equivalent of r_ for masked arrays.
-    """
+    # Tests for mr_, the equivalent of r_ for masked arrays.
 
     def test_1d(self):
-        "Tests mr_ on 1D arrays."
+        # Tests mr_ on 1D arrays.
         assert_array_equal(mr_[1, 2, 3, 4, 5, 6], array([1, 2, 3, 4, 5, 6]))
         b = ones(5)
         m = [1, 0, 0, 0, 0]
@@ -263,14 +262,15 @@ class TestConcatenator(TestCase):
         assert_array_equal(c.mask, mr_[m, 0, 0, m])
 
     def test_2d(self):
-        "Tests mr_ on 2D arrays."
+        # Tests mr_ on 2D arrays.
         a_1 = rand(5, 5)
         a_2 = rand(5, 5)
         m_1 = np.round_(rand(5, 5), 0)
         m_2 = np.round_(rand(5, 5), 0)
         b_1 = masked_array(a_1, mask=m_1)
         b_2 = masked_array(a_2, mask=m_2)
-        d = mr_['1', b_1, b_2]  # append columns
+        # append columns
+        d = mr_['1', b_1, b_2]
         self.assertTrue(d.shape == (5, 10))
         assert_array_equal(d[:, :5], b_1)
         assert_array_equal(d[:, 5:], b_2)
@@ -283,12 +283,10 @@ class TestConcatenator(TestCase):
 
 
 class TestNotMasked(TestCase):
-    """
-    Tests notmasked_edges and notmasked_contiguous.
-    """
+    # Tests notmasked_edges and notmasked_contiguous.
 
     def test_edges(self):
-        "Tests unmasked_edges"
+        # Tests unmasked_edges
         data = masked_array(np.arange(25).reshape(5, 5),
                             mask=[[0, 0, 1, 0, 0],
                                   [0, 0, 0, 1, 1],
@@ -322,7 +320,7 @@ class TestNotMasked(TestCase):
         assert_equal(test[1], [(0, 1, 2, 4), (4, 2, 4, 4)])
 
     def test_contiguous(self):
-        "Tests notmasked_contiguous"
+        # Tests notmasked_contiguous
         a = masked_array(np.arange(24).reshape(3, 8),
                          mask=[[0, 0, 0, 0, 1, 1, 1, 1],
                                [1, 1, 1, 1, 1, 1, 1, 1],
@@ -346,9 +344,9 @@ class TestNotMasked(TestCase):
 
 
 class Test2DFunctions(TestCase):
-    "Tests 2D functions"
+    # Tests 2D functions
     def test_compress2d(self):
-        "Tests compress2d"
+        # Tests compress2d
         x = array(np.arange(9).reshape(3, 3),
                   mask=[[1, 0, 0], [0, 0, 0], [0, 0, 0]])
         assert_equal(compress_rowcols(x), [[4, 5], [7, 8]])
@@ -368,7 +366,7 @@ class Test2DFunctions(TestCase):
         assert_equal(compress_rowcols(x, 1).size, 0)
 
     def test_mask_rowcols(self):
-        "Tests mask_rowcols."
+        # Tests mask_rowcols.
         x = array(np.arange(9).reshape(3, 3),
                   mask=[[1, 0, 0], [0, 0, 0], [0, 0, 0]])
         assert_equal(mask_rowcols(x).mask,
@@ -400,7 +398,7 @@ class Test2DFunctions(TestCase):
         self.assertTrue(mask_rowcols(x, 1).mask.all())
 
     def test_dot(self):
-        "Tests dot product"
+        # Tests dot product
         n = np.arange(1, 7)
         #
         m = [1, 0, 0, 0, 0, 0]
@@ -471,17 +469,19 @@ class Test2DFunctions(TestCase):
 
 
 class TestApplyAlongAxis(TestCase):
-    "Tests 2D functions"
+    # Tests 2D functions
     def test_3d(self):
         a = arange(12.).reshape(2, 2, 3)
+
         def myfunc(b):
             return b[1]
+
         xa = apply_along_axis(myfunc, 2, a)
         assert_equal(xa, [[1, 4], [7, 10]])
 
 
 class TestApplyOverAxes(TestCase):
-    "Tests apply_over_axes"
+    # Tests apply_over_axes
     def test_basic(self):
         a = arange(24).reshape(2, 3, 4)
         test = apply_over_axes(np.sum, a, [0, 2])
@@ -495,7 +495,7 @@ class TestApplyOverAxes(TestCase):
 class TestMedian(TestCase):
 
     def test_2d(self):
-        "Tests median w/ 2D"
+        # Tests median w/ 2D
         (n, p) = (101, 30)
         x = masked_array(np.linspace(-1., 1., n),)
         x[:10] = x[-10:] = masked
@@ -511,7 +511,7 @@ class TestMedian(TestCase):
         assert_equal(median(z.T, axis=1), np.zeros(p))
 
     def test_2d_waxis(self):
-        "Tests median w/ 2D arrays and different axis."
+        # Tests median w/ 2D arrays and different axis.
         x = masked_array(np.arange(30).reshape(10, 3))
         x[:3] = x[-3:] = masked
         assert_equal(median(x), 14.5)
@@ -520,7 +520,7 @@ class TestMedian(TestCase):
         assert_equal(median(x, axis=1).mask, [1, 1, 1, 0, 0, 0, 0, 1, 1, 1])
 
     def test_3d(self):
-        "Tests median w/ 3D"
+        # Tests median w/ 3D
         x = np.ma.arange(24).reshape(3, 4, 2)
         x[x % 3 == 0] = masked
         assert_equal(median(x, 0), [[12, 9], [6, 15], [12, 9], [18, 15]])
@@ -537,7 +537,7 @@ class TestCov(TestCase):
         self.data = array(np.random.rand(12))
 
     def test_1d_wo_missing(self):
-        "Test cov on 1D variable w/o missing values"
+        # Test cov on 1D variable w/o missing values
         x = self.data
         assert_almost_equal(np.cov(x), cov(x))
         assert_almost_equal(np.cov(x, rowvar=False), cov(x, rowvar=False))
@@ -545,7 +545,7 @@ class TestCov(TestCase):
                             cov(x, rowvar=False, bias=True))
 
     def test_2d_wo_missing(self):
-        "Test cov on 1 2D variable w/o missing values"
+        # Test cov on 1 2D variable w/o missing values
         x = self.data.reshape(3, 4)
         assert_almost_equal(np.cov(x), cov(x))
         assert_almost_equal(np.cov(x, rowvar=False), cov(x, rowvar=False))
@@ -553,7 +553,7 @@ class TestCov(TestCase):
                             cov(x, rowvar=False, bias=True))
 
     def test_1d_w_missing(self):
-        "Test cov 1 1D variable w/missing values"
+        # Test cov 1 1D variable w/missing values
         x = self.data
         x[-1] = masked
         x -= x.mean()
@@ -577,7 +577,7 @@ class TestCov(TestCase):
                             cov(x, x[::-1], rowvar=False, bias=True))
 
     def test_2d_w_missing(self):
-        "Test cov on 2D variable w/ missing value"
+        # Test cov on 2D variable w/ missing value
         x = self.data
         x[-1] = masked
         x = x.reshape(3, 4)
@@ -604,12 +604,12 @@ class TestCorrcoef(TestCase):
         self.data = array(np.random.rand(12))
 
     def test_ddof(self):
-        "Test ddof keyword"
+        # Test ddof keyword
         x = self.data
         assert_almost_equal(np.corrcoef(x, ddof=0), corrcoef(x, ddof=0))
 
     def test_1d_wo_missing(self):
-        "Test cov on 1D variable w/o missing values"
+        # Test cov on 1D variable w/o missing values
         x = self.data
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
@@ -618,7 +618,7 @@ class TestCorrcoef(TestCase):
                             corrcoef(x, rowvar=False, bias=True))
 
     def test_2d_wo_missing(self):
-        "Test corrcoef on 1 2D variable w/o missing values"
+        # Test corrcoef on 1 2D variable w/o missing values
         x = self.data.reshape(3, 4)
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
@@ -627,7 +627,7 @@ class TestCorrcoef(TestCase):
                             corrcoef(x, rowvar=False, bias=True))
 
     def test_1d_w_missing(self):
-        "Test corrcoef 1 1D variable w/missing values"
+        # Test corrcoef 1 1D variable w/missing values
         x = self.data
         x[-1] = masked
         x -= x.mean()
@@ -652,7 +652,7 @@ class TestCorrcoef(TestCase):
                             corrcoef(x, x[::-1], rowvar=False, bias=True))
 
     def test_2d_w_missing(self):
-        "Test corrcoef on 2D variable w/ missing value"
+        # Test corrcoef on 2D variable w/ missing value
         x = self.data
         x[-1] = masked
         x = x.reshape(3, 4)
@@ -665,7 +665,7 @@ class TestCorrcoef(TestCase):
 class TestPolynomial(TestCase):
     #
     def test_polyfit(self):
-        "Tests polyfit"
+        # Tests polyfit
         # On ndarrays
         x = np.random.rand(10)
         y = np.random.rand(20).reshape(-1, 2)
@@ -707,7 +707,7 @@ class TestPolynomial(TestCase):
 class TestArraySetOps(TestCase):
 
     def test_unique_onlist(self):
-        "Test unique on list"
+        # Test unique on list
         data = [1, 1, 1, 2, 2, 3]
         test = unique(data, return_index=True, return_inverse=True)
         self.assertTrue(isinstance(test[0], MaskedArray))
@@ -716,7 +716,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test[2], [0, 0, 0, 1, 1, 2])
 
     def test_unique_onmaskedarray(self):
-        "Test unique on masked data w/use_mask=True"
+        # Test unique on masked data w/use_mask=True
         data = masked_array([1, 1, 1, 2, 2, 3], mask=[0, 0, 1, 0, 1, 0])
         test = unique(data, return_index=True, return_inverse=True)
         assert_equal(test[0], masked_array([1, 2, 3, -1], mask=[0, 0, 0, 1]))
@@ -724,22 +724,22 @@ class TestArraySetOps(TestCase):
         assert_equal(test[2], [0, 0, 3, 1, 3, 2])
         #
         data.fill_value = 3
-        data = masked_array([1, 1, 1, 2, 2, 3],
-                       mask=[0, 0, 1, 0, 1, 0], fill_value=3)
+        data = masked_array(data=[1, 1, 1, 2, 2, 3],
+                            mask=[0, 0, 1, 0, 1, 0], fill_value=3)
         test = unique(data, return_index=True, return_inverse=True)
         assert_equal(test[0], masked_array([1, 2, 3, -1], mask=[0, 0, 0, 1]))
         assert_equal(test[1], [0, 3, 5, 2])
         assert_equal(test[2], [0, 0, 3, 1, 3, 2])
 
     def test_unique_allmasked(self):
-        "Test all masked"
+        # Test all masked
         data = masked_array([1, 1, 1], mask=True)
         test = unique(data, return_index=True, return_inverse=True)
         assert_equal(test[0], masked_array([1, ], mask=[True]))
         assert_equal(test[1], [0])
         assert_equal(test[2], [0, 0, 0])
         #
-        "Test masked"
+        # Test masked
         data = masked
         test = unique(data, return_index=True, return_inverse=True)
         assert_equal(test[0], masked_array(masked))
@@ -747,7 +747,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test[2], [0])
 
     def test_ediff1d(self):
-        "Tests mediff1d"
+        # Tests mediff1d
         x = masked_array(np.arange(5), mask=[1, 0, 0, 0, 1])
         control = array([1, 1, 1, 4], mask=[1, 0, 0, 1])
         test = ediff1d(x)
@@ -756,7 +756,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_tobegin(self):
-        "Test ediff1d w/ to_begin"
+        # Test ediff1d w/ to_begin
         x = masked_array(np.arange(5), mask=[1, 0, 0, 0, 1])
         test = ediff1d(x, to_begin=masked)
         control = array([0, 1, 1, 1, 4], mask=[1, 1, 0, 0, 1])
@@ -771,7 +771,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_toend(self):
-        "Test ediff1d w/ to_end"
+        # Test ediff1d w/ to_end
         x = masked_array(np.arange(5), mask=[1, 0, 0, 0, 1])
         test = ediff1d(x, to_end=masked)
         control = array([1, 1, 1, 4, 0], mask=[1, 0, 0, 1, 1])
@@ -786,7 +786,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_tobegin_toend(self):
-        "Test ediff1d w/ to_begin and to_end"
+        # Test ediff1d w/ to_begin and to_end
         x = masked_array(np.arange(5), mask=[1, 0, 0, 0, 1])
         test = ediff1d(x, to_end=masked, to_begin=masked)
         control = array([0, 1, 1, 1, 4, 0], mask=[1, 1, 0, 0, 1, 1])
@@ -802,7 +802,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_ndarray(self):
-        "Test ediff1d w/ a ndarray"
+        # Test ediff1d w/ a ndarray
         x = np.arange(5)
         test = ediff1d(x)
         control = array([1, 1, 1, 1], mask=[0, 0, 0, 0])
@@ -818,7 +818,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test.mask, control.mask)
 
     def test_intersect1d(self):
-        "Test intersect1d"
+        # Test intersect1d
         x = array([1, 3, 3, 3], mask=[0, 0, 0, 1])
         y = array([3, 1, 1, 1], mask=[0, 0, 0, 1])
         test = intersect1d(x, y)
@@ -826,7 +826,7 @@ class TestArraySetOps(TestCase):
         assert_equal(test, control)
 
     def test_setxor1d(self):
-        "Test setxor1d"
+        # Test setxor1d
         a = array([1, 2, 5, 7, -1], mask=[0, 0, 0, 0, 1])
         b = array([1, 2, 3, 4, 5, -1], mask=[0, 0, 0, 0, 0, 1])
         test = setxor1d(a, b)
@@ -852,7 +852,7 @@ class TestArraySetOps(TestCase):
         assert_array_equal([], setxor1d([], []))
 
     def test_in1d(self):
-        "Test in1d"
+        # Test in1d
         a = array([1, 2, 5, 7, -1], mask=[0, 0, 0, 0, 1])
         b = array([1, 2, 3, 4, 5, -1], mask=[0, 0, 0, 0, 0, 1])
         test = in1d(a, b)
@@ -866,7 +866,7 @@ class TestArraySetOps(TestCase):
         assert_array_equal([], in1d([], []))
 
     def test_in1d_invert(self):
-        "Test in1d's invert parameter"
+        # Test in1d's invert parameter
         a = array([1, 2, 5, 7, -1], mask=[0, 0, 0, 0, 1])
         b = array([1, 2, 3, 4, 5, -1], mask=[0, 0, 0, 0, 0, 1])
         assert_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
@@ -878,7 +878,7 @@ class TestArraySetOps(TestCase):
         assert_array_equal([], in1d([], [], invert=True))
 
     def test_union1d(self):
-        "Test union1d"
+        # Test union1d
         a = array([1, 2, 5, 7, 5, -1], mask=[0, 0, 0, 0, 0, 1])
         b = array([1, 2, 3, 4, 5, -1], mask=[0, 0, 0, 0, 0, 1])
         test = union1d(a, b)
@@ -888,7 +888,7 @@ class TestArraySetOps(TestCase):
         assert_array_equal([], union1d([], []))
 
     def test_setdiff1d(self):
-        "Test setdiff1d"
+        # Test setdiff1d
         a = array([6, 5, 4, 7, 7, 1, 2, 1], mask=[0, 0, 0, 0, 0, 0, 0, 1])
         b = array([2, 4, 3, 3, 2, 1, 5])
         test = setdiff1d(a, b)
@@ -899,7 +899,7 @@ class TestArraySetOps(TestCase):
         assert_equal(setdiff1d(a, b), array([8, 9]))
 
     def test_setdiff1d_char_array(self):
-        "Test setdiff1d_charray"
+        # Test setdiff1d_charray
         a = np.array(['a', 'b', 'c'])
         b = np.array(['a', 'b', 's'])
         assert_array_equal(setdiff1d(a, b), np.array(['c']))
@@ -908,7 +908,7 @@ class TestArraySetOps(TestCase):
 class TestShapeBase(TestCase):
     #
     def test_atleast2d(self):
-        "Test atleast_2d"
+        # Test atleast_2d
         a = masked_array([0, 1, 2], mask=[0, 1, 0])
         b = atleast_2d(a)
         assert_equal(b.shape, (1, 3))

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -13,14 +13,14 @@ import pickle
 import numpy as np
 import numpy.ma as ma
 from numpy import recarray
-from numpy.core.records import \
-    fromrecords as recfromrecords, fromarrays as recfromarrays
+from numpy.core.records import (fromrecords as recfromrecords,
+                                fromarrays as recfromarrays)
 
 from numpy.compat import asbytes, asbytes_nested
 from numpy.ma.testutils import *
 from numpy.ma import masked, nomask
-from numpy.ma.mrecords import \
-    MaskedRecords, mrecarray, fromarrays, fromtextfile, fromrecords, addfield
+from numpy.ma.mrecords import (MaskedRecords, mrecarray, fromarrays,
+                               fromtextfile, fromrecords, addfield)
 
 
 __author__ = "Pierre GF Gerard-Marchant ($Author: jarrod.millman $)"
@@ -354,8 +354,9 @@ class TestMRecords(TestCase):
         mult[0] = masked
         mult[1] = (1, 1, 1)
         mult.filled(0)
-        assert_equal_records(mult.filled(0), np.array([(0, 0, 0), (1, 1, 1)],
-                                                      dtype=mult.dtype))
+        assert_equal_records(mult.filled(0),
+                             np.array([(0, 0, 0), (1, 1, 1)],
+                                      dtype=mult.dtype))
 
 
 class TestView(TestCase):

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -7,38 +7,36 @@
 """
 from __future__ import division, absolute_import, print_function
 
-import sys
 import warnings
 import pickle
 
 import numpy as np
-import numpy.ma.testutils
 import numpy.ma as ma
 from numpy import recarray
-from numpy.core.records import fromrecords as recfromrecords, \
-                               fromarrays as recfromarrays
+from numpy.core.records import \
+    fromrecords as recfromrecords, fromarrays as recfromarrays
 
 from numpy.compat import asbytes, asbytes_nested
 from numpy.ma.testutils import *
 from numpy.ma import masked, nomask
-from numpy.ma.mrecords import MaskedRecords, mrecarray, fromarrays, \
-                              fromtextfile, fromrecords, addfield
+from numpy.ma.mrecords import \
+    MaskedRecords, mrecarray, fromarrays, fromtextfile, fromrecords, addfield
 
 
 __author__ = "Pierre GF Gerard-Marchant ($Author: jarrod.millman $)"
 __revision__ = "$Revision: 3473 $"
-__date__     = '$Date: 2007-10-29 17:18:13 +0200 (Mon, 29 Oct 2007) $'
+__date__ = '$Date: 2007-10-29 17:18:13 +0200 (Mon, 29 Oct 2007) $'
 
 
 #..............................................................................
 class TestMRecords(TestCase):
-    "Base test class for MaskedArrays."
+    # Base test class for MaskedArrays.
     def __init__(self, *args, **kwds):
         TestCase.__init__(self, *args, **kwds)
         self.setup()
 
     def setup(self):
-        "Generic setup"
+        # Generic setup
         ilist = [1, 2, 3, 4, 5]
         flist = [1.1, 2.2, 3.3, 4.4, 5.5]
         slist = asbytes_nested(['one', 'two', 'three', 'four', 'five'])
@@ -48,7 +46,7 @@ class TestMRecords(TestCase):
                              mask=mask, dtype=ddtype)
 
     def test_byview(self):
-        "Test creation by view"
+        # Test creation by view
         base = self.base
         mbase = base.view(mrecarray)
         assert_equal(mbase.recordmask, base.recordmask)
@@ -60,7 +58,7 @@ class TestMRecords(TestCase):
         assert_equal_records(mbase.view(mrecarray), mbase)
 
     def test_get(self):
-        "Tests fields retrieval"
+        # Tests fields retrieval
         base = self.base.copy()
         mbase = base.view(mrecarray)
         # As fields..........
@@ -92,14 +90,15 @@ class TestMRecords(TestCase):
         # Used to be mask, now it's recordmask
         assert_equal(mbase_sl.recordmask, [0, 1])
         assert_equal_records(mbase_sl.mask,
-                             np.array([(False, False, False), (True, True, True)],
+                             np.array([(False, False, False),
+                                       (True, True, True)],
                                       dtype=mbase._mask.dtype))
         assert_equal_records(mbase_sl, base[:2].view(mrecarray))
         for field in ('a', 'b', 'c'):
             assert_equal(getattr(mbase_sl, field), base[:2][field])
 
     def test_set_fields(self):
-        "Tests setting fields."
+        # Tests setting fields.
         base = self.base.copy()
         mbase = base.view(mrecarray)
         mbase = mbase.copy()
@@ -115,7 +114,11 @@ class TestMRecords(TestCase):
         # Use to be _mask, now it's recordmask
         assert_equal(mbase.recordmask, [False]*5)
         assert_equal(mbase._mask.tolist(),
-                     np.array([(0, 0, 0), (0, 1, 1), (0, 0, 0), (0, 0, 0), (0, 1, 1)],
+                     np.array([(0, 0, 0),
+                               (0, 1, 1),
+                               (0, 0, 0),
+                               (0, 0, 0),
+                               (0, 1, 1)],
                               dtype=bool))
         # Set a field to mask ........................
         mbase.c = masked
@@ -125,7 +128,11 @@ class TestMRecords(TestCase):
         assert_equal(ma.getmaskarray(mbase['c']), [1]*5)
         assert_equal(ma.getdata(mbase['c']), [asbytes('N/A')]*5)
         assert_equal(mbase._mask.tolist(),
-                     np.array([(0, 0, 1), (0, 1, 1), (0, 0, 1), (0, 0, 1), (0, 1, 1)],
+                     np.array([(0, 0, 1),
+                               (0, 1, 1),
+                               (0, 0, 1),
+                               (0, 0, 1),
+                               (0, 1, 1)],
                               dtype=bool))
         # Set fields by slices .......................
         mbase = base.view(mrecarray).copy()
@@ -148,7 +155,7 @@ class TestMRecords(TestCase):
             assert_equal(rdata.num.mask, [1, 0, 0])
 
     def test_set_fields_mask(self):
-        "Tests setting the mask of a field."
+        # Tests setting the mask of a field.
         base = self.base.copy()
         # This one has already a mask....
         mbase = base.view(mrecarray)
@@ -161,7 +168,7 @@ class TestMRecords(TestCase):
         mbase['a'][-2] = masked
         assert_equal(mbase.a, [0, 1, 2, 3, 4])
         assert_equal(mbase.a._mask, [0, 0, 0, 1, 0])
-    #
+
     def test_set_mask(self):
         base = self.base.copy()
         mbase = base.view(mrecarray)
@@ -177,7 +184,7 @@ class TestMRecords(TestCase):
         assert_equal(ma.getmaskarray(mbase['c']), [0]*5)
         assert_equal(mbase._mask.tolist(),
                      np.array([(0, 0, 0)]*5, dtype=bool))
-    #
+
     def test_set_mask_fromarray(self):
         base = self.base.copy()
         mbase = base.view(mrecarray)
@@ -191,12 +198,13 @@ class TestMRecords(TestCase):
         assert_equal(mbase.a.mask, [0, 0, 0, 0, 1])
         assert_equal(mbase.b.mask, [0, 0, 0, 0, 1])
         assert_equal(mbase.c.mask, [0, 0, 0, 0, 1])
-    #
+
     def test_set_mask_fromfields(self):
         mbase = self.base.copy().view(mrecarray)
         #
-        nmask = np.array([(0, 1, 0), (0, 1, 0), (1, 0, 1), (1, 0, 1), (0, 0, 0)],
-                         dtype=[('a', bool), ('b', bool), ('c', bool)])
+        nmask = np.array(
+            [(0, 1, 0), (0, 1, 0), (1, 0, 1), (1, 0, 1), (0, 0, 0)],
+            dtype=[('a', bool), ('b', bool), ('c', bool)])
         mbase.mask = nmask
         assert_equal(mbase.a.mask, [0, 0, 1, 1, 0])
         assert_equal(mbase.b.mask, [1, 1, 0, 0, 0])
@@ -207,15 +215,16 @@ class TestMRecords(TestCase):
         assert_equal(mbase.a.mask, [0, 0, 1, 1, 0])
         assert_equal(mbase.b.mask, [1, 1, 0, 0, 0])
         assert_equal(mbase.c.mask, [0, 0, 1, 1, 0])
-    #
+
     def test_set_elements(self):
         base = self.base.copy()
         # Set an element to mask .....................
         mbase = base.view(mrecarray).copy()
         mbase[-2] = masked
-        assert_equal(mbase._mask.tolist(),
-                     np.array([(0, 0, 0), (1, 1, 1), (0, 0, 0), (1, 1, 1), (1, 1, 1)],
-                              dtype=bool))
+        assert_equal(
+            mbase._mask.tolist(),
+            np.array([(0, 0, 0), (1, 1, 1), (0, 0, 0), (1, 1, 1), (1, 1, 1)],
+                     dtype=bool))
         # Used to be mask, now it's recordmask!
         assert_equal(mbase.recordmask, [0, 1, 0, 1, 1])
         # Set slices .................................
@@ -238,9 +247,9 @@ class TestMRecords(TestCase):
         assert_equal(mbase.c._data,
                      asbytes_nested(['one', 'two', 'three', 'four', 'five']))
         assert_equal(mbase.b._mask, [1, 1, 0, 0, 1])
-    #
+
     def test_setslices_hardmask(self):
-        "Tests setting slices w/ hardmask."
+        # Tests setting slices w/ hardmask.
         base = self.base.copy()
         mbase = base.view(mrecarray)
         mbase.harden_mask()
@@ -268,9 +277,8 @@ class TestMRecords(TestCase):
         else:
             raise TypeError("Should have expected a readable buffer object!")
 
-
     def test_hardmask(self):
-        "Test hardmask"
+        # Test hardmask
         base = self.base.copy()
         mbase = base.view(mrecarray)
         mbase.harden_mask()
@@ -285,9 +293,9 @@ class TestMRecords(TestCase):
                              ma.make_mask_none(base.shape, base.dtype))
         self.assertTrue(ma.make_mask(mbase['b']._mask) is nomask)
         assert_equal(mbase['a']._mask, mbase['b']._mask)
-    #
+
     def test_pickling(self):
-        "Test pickling"
+        # Test pickling
         base = self.base.copy()
         mrec = base.view(mrecarray)
         _ = pickle.dumps(mrec)
@@ -296,9 +304,9 @@ class TestMRecords(TestCase):
         assert_equal_records(mrec_._data, mrec._data)
         assert_equal(mrec_._mask, mrec._mask)
         assert_equal_records(mrec_._mask, mrec._mask)
-    #
+
     def test_filled(self):
-        "Test filling the array"
+        # Test filling the array
         _a = ma.array([1, 2, 3], mask=[0, 0, 1], dtype=int)
         _b = ma.array([1.1, 2.2, 3.3], mask=[0, 0, 1], dtype=float)
         _c = ma.array(['one', 'two', 'three'], mask=[0, 0, 1], dtype='|S8')
@@ -307,11 +315,13 @@ class TestMRecords(TestCase):
                           fill_value=(99999, 99999., 'N/A'))
         mrecfilled = mrec.filled()
         assert_equal(mrecfilled['a'], np.array((1, 2, 99999), dtype=int))
-        assert_equal(mrecfilled['b'], np.array((1.1, 2.2, 99999.), dtype=float))
-        assert_equal(mrecfilled['c'], np.array(('one', 'two', 'N/A'), dtype='|S8'))
-    #
+        assert_equal(mrecfilled['b'], np.array((1.1, 2.2, 99999.),
+                                               dtype=float))
+        assert_equal(mrecfilled['c'], np.array(('one', 'two', 'N/A'),
+                                               dtype='|S8'))
+
     def test_tolist(self):
-        "Test tolist."
+        # Test tolist.
         _a = ma.array([1, 2, 3], mask=[0, 0, 1], dtype=int)
         _b = ma.array([1.1, 2.2, 3.3], mask=[0, 0, 1], dtype=float)
         _c = ma.array(['one', 'two', 'three'], mask=[1, 0, 0], dtype='|S8')
@@ -323,16 +333,14 @@ class TestMRecords(TestCase):
                      [(1, 1.1, None), (2, 2.2, asbytes('two')),
                       (None, None, asbytes('three'))])
 
-
-    #
     def test_withnames(self):
-        "Test the creation w/ format and names"
+        # Test the creation w/ format and names
         x = mrecarray(1, formats=float, names='base')
         x[0]['base'] = 10
         assert_equal(x['base'][0], 10)
-    #
+
     def test_exotic_formats(self):
-        "Test that 'exotic' formats are processed properly"
+        # Test that 'exotic' formats are processed properly
         easy = mrecarray(1, dtype=[('i', int), ('s', '|S8'), ('f', float)])
         easy[0] = masked
         assert_equal(easy.filled(1).item(), (1, asbytes('1'), 1.))
@@ -342,12 +350,12 @@ class TestMRecords(TestCase):
         assert_equal(solo.filled(1).item(),
                      np.array((1,), dtype=solo.dtype).item())
         #
-        mult = mrecarray(2, dtype= "i4, (2,3)float, float")
+        mult = mrecarray(2, dtype="i4, (2,3)float, float")
         mult[0] = masked
         mult[1] = (1, 1, 1)
         mult.filled(0)
-        assert_equal_records(mult.filled(0),
-                             np.array([(0, 0, 0), (1, 1, 1)], dtype=mult.dtype))
+        assert_equal_records(mult.filled(0), np.array([(0, 0, 0), (1, 1, 1)],
+                                                      dtype=mult.dtype))
 
 
 class TestView(TestCase):
@@ -356,20 +364,18 @@ class TestView(TestCase):
         (a, b) = (np.arange(10), np.random.rand(10))
         ndtype = [('a', np.float), ('b', np.float)]
         arr = np.array(list(zip(a, b)), dtype=ndtype)
-        rec = arr.view(np.recarray)
-        #
-        marr = ma.array(list(zip(a, b)), dtype=ndtype, fill_value=(-9., -99.))
+
         mrec = fromarrays([a, b], dtype=ndtype, fill_value=(-9., -99.))
         mrec.mask[3] = (False, True)
         self.data = (mrec, a, b, arr)
-    #
+
     def test_view_by_itself(self):
         (mrec, a, b, arr) = self.data
         test = mrec.view()
         self.assertTrue(isinstance(test, MaskedRecords))
         assert_equal_records(test, mrec)
         assert_equal_records(test._mask, mrec._mask)
-    #
+
     def test_view_simple_dtype(self):
         (mrec, a, b, arr) = self.data
         ntype = (np.float, 2)
@@ -377,7 +383,7 @@ class TestView(TestCase):
         self.assertTrue(isinstance(test, ma.MaskedArray))
         assert_equal(test, np.array(list(zip(a, b)), dtype=np.float))
         self.assertTrue(test[3, 1] is ma.masked)
-    #
+
     def test_view_flexible_type(self):
         (mrec, a, b, arr) = self.data
         alttype = [('A', np.float), ('B', np.float)]
@@ -389,15 +395,15 @@ class TestView(TestCase):
         self.assertTrue(test._fill_value is None)
 
 
-################################################################################
+###############################################################################
 class TestMRecordsImport(TestCase):
-    "Base test class for MaskedArrays."
+    # Base test class for MaskedArrays.
     def __init__(self, *args, **kwds):
         TestCase.__init__(self, *args, **kwds)
         self.setup()
 
     def setup(self):
-        "Generic setup"
+        # Generic setup
         _a = ma.array([1, 2, 3], mask=[0, 0, 1], dtype=int)
         _b = ma.array([1.1, 2.2, 3.3], mask=[0, 0, 1], dtype=float)
         _c = ma.array(list(map(asbytes, ['one', 'two', 'three'])),
@@ -420,10 +426,8 @@ class TestMRecordsImport(TestCase):
         _x = ma.array([1, 1.1, 'one'], mask=[1, 0, 0],)
         assert_equal_records(fromarrays(_x, dtype=mrec.dtype), mrec[0])
 
-
-
     def test_fromrecords(self):
-        "Test construction from records."
+        # Test construction from records.
         (mrec, nrec, ddtype) = self.data
         #......
         palist = [(1, 'abc', 3.7000002861022949, 0),
@@ -449,7 +453,7 @@ class TestMRecordsImport(TestCase):
         assert_equal_records(_mrec._mask, mrec._mask)
 
     def test_fromrecords_wmask(self):
-        "Tests construction from records w/ mask."
+        # Tests construction from records w/ mask.
         (mrec, nrec, ddtype) = self.data
         #
         _mrec = fromrecords(nrec.tolist(), dtype=ddtype, mask=[0, 1, 0,])
@@ -470,7 +474,7 @@ class TestMRecordsImport(TestCase):
         assert_equal(_mrec._mask.tolist(), mrec._mask.tolist())
 
     def test_fromtextfile(self):
-        "Tests reading from a text file."
+        # Tests reading from a text file.
         fcontent = asbytes("""#
 'One (S)','Two (I)','Three (F)','Four (M)','Five (-)','Six (C)'
 'strings',1,1.0,'mixed column',,1
@@ -492,7 +496,7 @@ class TestMRecordsImport(TestCase):
         assert_equal(mrectxt.C, [1, 2, 3.e+5, -1e-10])
 
     def test_addfield(self):
-        "Tests addfield"
+        # Tests addfield
         (mrec, nrec, ddtype) = self.data
         (d, m) = ([100, 200, 300], [1, 0, 0])
         mrec = addfield(mrec, ma.array(d, mask=m))
@@ -501,14 +505,12 @@ class TestMRecordsImport(TestCase):
 
 
 def test_record_array_with_object_field():
-    """
-    Trac #1839
-    """
+    # Trac #1839
     y = ma.masked_array(
         [(1, '2'), (3, '4')],
         mask=[(0, 0), (0, 1)],
         dtype=[('a', int), ('b', np.object)])
-    x = y[1]
+    y[1]
 
 
 ###############################################################################

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -511,6 +511,7 @@ def test_record_array_with_object_field():
         [(1, '2'), (3, '4')],
         mask=[(0, 0), (0, 1)],
         dtype=[('a', int), ('b', np.object)])
+    # getting an item used to fail
     y[1]
 
 

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -9,8 +9,9 @@ from numpy.core.numerictypes import float32
 from numpy.ma.core import umath
 from numpy.testing import *
 
-
 pi = np.pi
+
+
 def eq(v, w, msg=''):
     result = allclose(v, w)
     if not result:
@@ -20,9 +21,11 @@ def eq(v, w, msg=''):
 %s""" % (msg, str(v), str(w)))
     return result
 
+
 class TestMa(TestCase):
-    def setUp (self):
-        x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
+
+    def setUp(self):
+        x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         a10 = 10.
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
@@ -37,7 +40,7 @@ class TestMa(TestCase):
         self.d = (x, y, a10, m1, m2, xm, ym, z, zm, xf, s)
 
     def test_testBasic1d(self):
-        "Test of basic array creation and properties in 1 dimension."
+        # Test of basic array creation and properties in 1 dimension.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
         self.assertFalse(isMaskedArray(x))
         self.assertTrue(isMaskedArray(xm))
@@ -51,7 +54,7 @@ class TestMa(TestCase):
         self.assertTrue(eq(x, xm))
 
     def test_testBasic2d(self):
-        "Test of basic array creation and properties in 2 dimensions."
+        # Test of basic array creation and properties in 2 dimensions.
         for s in [(4, 3), (6, 2)]:
             (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
             x.shape = s
@@ -65,20 +68,21 @@ class TestMa(TestCase):
             self.assertEqual(shape(xm), s)
             self.assertEqual(xm.shape, s)
             self.assertEqual(xm.size, reduce(lambda x, y:x * y, s))
-            self.assertEqual(count(xm), len(m1) - reduce(lambda x, y:x + y, m1))
+            self.assertEqual(count(xm),
+                             len(m1) - reduce(lambda x, y:x + y, m1))
             self.assertTrue(eq(xm, xf))
             self.assertTrue(eq(filled(xm, 1.e20), xf))
             self.assertTrue(eq(x, xm))
             self.setUp()
 
-    def test_testArithmetic (self):
-        "Test of basic arithmetic."
+    def test_testArithmetic(self):
+        # Test of basic arithmetic.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
         a2d = array([[1, 2], [0, 4]])
         a2dm = masked_array(a2d, [[0, 0], [1, 0]])
-        self.assertTrue(eq (a2d * a2d, a2d * a2dm))
-        self.assertTrue(eq (a2d + a2d, a2d + a2dm))
-        self.assertTrue(eq (a2d - a2d, a2d - a2dm))
+        self.assertTrue(eq(a2d * a2d, a2d * a2dm))
+        self.assertTrue(eq(a2d + a2d, a2d + a2dm))
+        self.assertTrue(eq(a2d - a2d, a2d - a2dm))
         for s in [(12,), (4, 3), (2, 6)]:
             x = x.reshape(s)
             y = y.reshape(s)
@@ -109,46 +113,45 @@ class TestMa(TestCase):
             with np.errstate(divide='ignore', invalid='ignore'):
                 self.assertTrue(eq(np.divide(x, y), divide(xm, ym)))
 
-
     def test_testMixedArithmetic(self):
         na = np.array([1])
         ma = array([1])
         self.assertTrue(isinstance(na + ma, MaskedArray))
         self.assertTrue(isinstance(ma + na, MaskedArray))
 
-    def test_testUfuncs1 (self):
-        "Test various functions such as sin, cos."
+    def test_testUfuncs1(self):
+        # Test various functions such as sin, cos.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
-        self.assertTrue (eq(np.cos(x), cos(xm)))
-        self.assertTrue (eq(np.cosh(x), cosh(xm)))
-        self.assertTrue (eq(np.sin(x), sin(xm)))
-        self.assertTrue (eq(np.sinh(x), sinh(xm)))
-        self.assertTrue (eq(np.tan(x), tan(xm)))
-        self.assertTrue (eq(np.tanh(x), tanh(xm)))
+        self.assertTrue(eq(np.cos(x), cos(xm)))
+        self.assertTrue(eq(np.cosh(x), cosh(xm)))
+        self.assertTrue(eq(np.sin(x), sin(xm)))
+        self.assertTrue(eq(np.sinh(x), sinh(xm)))
+        self.assertTrue(eq(np.tan(x), tan(xm)))
+        self.assertTrue(eq(np.tanh(x), tanh(xm)))
         with np.errstate(divide='ignore', invalid='ignore'):
-            self.assertTrue (eq(np.sqrt(abs(x)), sqrt(xm)))
-            self.assertTrue (eq(np.log(abs(x)), log(xm)))
-            self.assertTrue (eq(np.log10(abs(x)), log10(xm)))
-        self.assertTrue (eq(np.exp(x), exp(xm)))
-        self.assertTrue (eq(np.arcsin(z), arcsin(zm)))
-        self.assertTrue (eq(np.arccos(z), arccos(zm)))
-        self.assertTrue (eq(np.arctan(z), arctan(zm)))
-        self.assertTrue (eq(np.arctan2(x, y), arctan2(xm, ym)))
-        self.assertTrue (eq(np.absolute(x), absolute(xm)))
-        self.assertTrue (eq(np.equal(x, y), equal(xm, ym)))
-        self.assertTrue (eq(np.not_equal(x, y), not_equal(xm, ym)))
-        self.assertTrue (eq(np.less(x, y), less(xm, ym)))
-        self.assertTrue (eq(np.greater(x, y), greater(xm, ym)))
-        self.assertTrue (eq(np.less_equal(x, y), less_equal(xm, ym)))
-        self.assertTrue (eq(np.greater_equal(x, y), greater_equal(xm, ym)))
-        self.assertTrue (eq(np.conjugate(x), conjugate(xm)))
-        self.assertTrue (eq(np.concatenate((x, y)), concatenate((xm, ym))))
-        self.assertTrue (eq(np.concatenate((x, y)), concatenate((x, y))))
-        self.assertTrue (eq(np.concatenate((x, y)), concatenate((xm, y))))
-        self.assertTrue (eq(np.concatenate((x, y, x)), concatenate((x, ym, x))))
+            self.assertTrue(eq(np.sqrt(abs(x)), sqrt(xm)))
+            self.assertTrue(eq(np.log(abs(x)), log(xm)))
+            self.assertTrue(eq(np.log10(abs(x)), log10(xm)))
+        self.assertTrue(eq(np.exp(x), exp(xm)))
+        self.assertTrue(eq(np.arcsin(z), arcsin(zm)))
+        self.assertTrue(eq(np.arccos(z), arccos(zm)))
+        self.assertTrue(eq(np.arctan(z), arctan(zm)))
+        self.assertTrue(eq(np.arctan2(x, y), arctan2(xm, ym)))
+        self.assertTrue(eq(np.absolute(x), absolute(xm)))
+        self.assertTrue(eq(np.equal(x, y), equal(xm, ym)))
+        self.assertTrue(eq(np.not_equal(x, y), not_equal(xm, ym)))
+        self.assertTrue(eq(np.less(x, y), less(xm, ym)))
+        self.assertTrue(eq(np.greater(x, y), greater(xm, ym)))
+        self.assertTrue(eq(np.less_equal(x, y), less_equal(xm, ym)))
+        self.assertTrue(eq(np.greater_equal(x, y), greater_equal(xm, ym)))
+        self.assertTrue(eq(np.conjugate(x), conjugate(xm)))
+        self.assertTrue(eq(np.concatenate((x, y)), concatenate((xm, ym))))
+        self.assertTrue(eq(np.concatenate((x, y)), concatenate((x, y))))
+        self.assertTrue(eq(np.concatenate((x, y)), concatenate((xm, y))))
+        self.assertTrue(eq(np.concatenate((x, y, x)), concatenate((x, ym, x))))
 
-    def test_xtestCount (self):
-        "Test count"
+    def test_xtestCount(self):
+        # Test count
         ott = array([0., 1., 2., 3.], mask=[1, 0, 0, 0])
         if sys.version_info[0] >= 3:
             self.assertTrue(isinstance(count(ott), np.integer))
@@ -156,53 +159,50 @@ class TestMa(TestCase):
             self.assertTrue(isinstance(count(ott), int))
         self.assertEqual(3, count(ott))
         self.assertEqual(1, count(1))
-        self.assertTrue (eq(0, array(1, mask=[1])))
+        self.assertTrue(eq(0, array(1, mask=[1])))
         ott = ott.reshape((2, 2))
         assert_(isinstance(count(ott, 0), np.ndarray))
         if sys.version_info[0] >= 3:
             assert_(isinstance(count(ott), np.integer))
         else:
             assert_(isinstance(count(ott), int))
-        self.assertTrue (eq(3, count(ott)))
+        self.assertTrue(eq(3, count(ott)))
         assert_(getmask(count(ott, 0)) is nomask)
-        self.assertTrue (eq([1, 2], count(ott, 0)))
+        self.assertTrue(eq([1, 2], count(ott, 0)))
 
-    def test_testMinMax (self):
-        "Test minimum and maximum."
+    def test_testMinMax(self):
+        # Test minimum and maximum.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
-        xr = np.ravel(x) #max doesn't work if shaped
+        xr = np.ravel(x)  # max doesn't work if shaped
         xmr = ravel(xm)
 
-        #true because of careful selection of data
+        # true because of careful selection of data
         self.assertTrue(eq(max(xr), maximum(xmr)))
-
-        #true because of careful selection of data
         self.assertTrue(eq(min(xr), minimum(xmr)))
 
-    def test_testAddSumProd (self):
-        "Test add, sum, product."
+    def test_testAddSumProd(self):
+        # Test add, sum, product.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
-        self.assertTrue (eq(np.add.reduce(x), add.reduce(x)))
-        self.assertTrue (eq(np.add.accumulate(x), add.accumulate(x)))
-        self.assertTrue (eq(4, sum(array(4), axis=0)))
-        self.assertTrue (eq(4, sum(array(4), axis=0)))
-        self.assertTrue (eq(np.sum(x, axis=0), sum(x, axis=0)))
-        self.assertTrue (eq(np.sum(filled(xm, 0), axis=0), sum(xm, axis=0)))
-        self.assertTrue (eq(np.sum(x, 0), sum(x, 0)))
-        self.assertTrue (eq(np.product(x, axis=0), product(x, axis=0)))
-        self.assertTrue (eq(np.product(x, 0), product(x, 0)))
-        self.assertTrue (eq(np.product(filled(xm, 1), axis=0),
-                            product(xm, axis=0)))
+        self.assertTrue(eq(np.add.reduce(x), add.reduce(x)))
+        self.assertTrue(eq(np.add.accumulate(x), add.accumulate(x)))
+        self.assertTrue(eq(4, sum(array(4), axis=0)))
+        self.assertTrue(eq(4, sum(array(4), axis=0)))
+        self.assertTrue(eq(np.sum(x, axis=0), sum(x, axis=0)))
+        self.assertTrue(eq(np.sum(filled(xm, 0), axis=0), sum(xm, axis=0)))
+        self.assertTrue(eq(np.sum(x, 0), sum(x, 0)))
+        self.assertTrue(eq(np.product(x, axis=0), product(x, axis=0)))
+        self.assertTrue(eq(np.product(x, 0), product(x, 0)))
+        self.assertTrue(eq(np.product(filled(xm, 1), axis=0),
+                           product(xm, axis=0)))
         if len(s) > 1:
-            self.assertTrue (eq(np.concatenate((x, y), 1),
-                                concatenate((xm, ym), 1)))
-            self.assertTrue (eq(np.add.reduce(x, 1), add.reduce(x, 1)))
-            self.assertTrue (eq(np.sum(x, 1), sum(x, 1)))
-            self.assertTrue (eq(np.product(x, 1), product(x, 1)))
-
+            self.assertTrue(eq(np.concatenate((x, y), 1),
+                               concatenate((xm, ym), 1)))
+            self.assertTrue(eq(np.add.reduce(x, 1), add.reduce(x, 1)))
+            self.assertTrue(eq(np.sum(x, 1), sum(x, 1)))
+            self.assertTrue(eq(np.product(x, 1), product(x, 1)))
 
     def test_testCI(self):
-        "Test of conversions and indexing"
+        # Test of conversions and indexing
         x1 = np.array([1, 2, 4, 3])
         x2 = array(x1, mask=[1, 0, 0, 0])
         x3 = array(x1, mask=[0, 1, 0, 1])
@@ -251,7 +251,7 @@ class TestMa(TestCase):
         assert_(x1[1:1].shape == (0,))
 
     def test_testCopySize(self):
-        "Tests of some subtle points of copying and sizing."
+        # Tests of some subtle points of copying and sizing.
         n = [0, 0, 1, 0, 0]
         m = make_mask(n)
         m2 = make_mask(m)
@@ -290,7 +290,7 @@ class TestMa(TestCase):
         self.assertTrue(eq(y5, y6))
 
     def test_testPut(self):
-        "Test of put"
+        # Test of put
         d = arange(5)
         n = [0, 0, 0, 1, 1]
         m = make_mask(n)
@@ -317,8 +317,9 @@ class TestMa(TestCase):
         assert_(all(take(ym, i, axis=0) == zm))
 
     def test_testOddFeatures(self):
-        "Test of other odd features"
-        x = arange(20); x = x.reshape(4, 5)
+        # Test of other odd features
+        x = arange(20)
+        x = x.reshape(4, 5)
         x.flat[5] = 12
         assert_(x[1, 0] == 12)
         z = x + 10j * x
@@ -369,7 +370,7 @@ class TestMa(TestCase):
         assert_(z[2] is masked)
         assert_(eq(masked_where(greater(x, 2), x), masked_greater(x, 2)))
         assert_(eq(masked_where(greater_equal(x, 2), x),
-                  masked_greater_equal(x, 2)))
+                   masked_greater_equal(x, 2)))
         assert_(eq(masked_where(less(x, 2), x), masked_less(x, 2)))
         assert_(eq(masked_where(less_equal(x, 2), x), masked_less_equal(x, 2)))
         assert_(eq(masked_where(not_equal(x, 2), x), masked_not_equal(x, 2)))
@@ -377,15 +378,20 @@ class TestMa(TestCase):
         assert_(eq(masked_where(not_equal(x, 2), x), masked_not_equal(x, 2)))
         assert_(eq(masked_inside(list(range(5)), 1, 3), [0, 199, 199, 199, 4]))
         assert_(eq(masked_outside(list(range(5)), 1, 3), [199, 1, 2, 3, 199]))
-        assert_(eq(masked_inside(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 1, 3).mask,
-                  [1, 1, 1, 1, 0]))
-        assert_(eq(masked_outside(array(list(range(5)), mask=[0, 1, 0, 0, 0]), 1, 3).mask,
-                  [1, 1, 0, 0, 1]))
-        assert_(eq(masked_equal(array(list(range(5)), mask=[1, 0, 0, 0, 0]), 2).mask,
-                  [1, 0, 1, 0, 0]))
-        assert_(eq(masked_not_equal(array([2, 2, 1, 2, 1], mask=[1, 0, 0, 0, 0]), 2).mask,
-                  [1, 0, 1, 0, 1]))
-        assert_(eq(masked_where([1, 1, 0, 0, 0], [1, 2, 3, 4, 5]), [99, 99, 3, 4, 5]))
+        assert_(eq(masked_inside(array(list(range(5)),
+                                       mask=[1, 0, 0, 0, 0]), 1, 3).mask,
+                   [1, 1, 1, 1, 0]))
+        assert_(eq(masked_outside(array(list(range(5)),
+                                        mask=[0, 1, 0, 0, 0]), 1, 3).mask,
+                   [1, 1, 0, 0, 1]))
+        assert_(eq(masked_equal(array(list(range(5)),
+                                      mask=[1, 0, 0, 0, 0]), 2).mask,
+                   [1, 0, 1, 0, 0]))
+        assert_(eq(masked_not_equal(array([2, 2, 1, 2, 1],
+                                          mask=[1, 0, 0, 0, 0]), 2).mask,
+                   [1, 0, 1, 0, 1]))
+        assert_(eq(masked_where([1, 1, 0, 0, 0], [1, 2, 3, 4, 5]),
+                   [99, 99, 3, 4, 5]))
         atest = ones((10, 10, 10), dtype=float32)
         btest = zeros(atest.shape, MaskType)
         ctest = masked_where(btest, atest)
@@ -412,7 +418,7 @@ class TestMa(TestCase):
         assert_(eq(z, [99, 1, 1, 99, 99, 99]))
 
     def test_testMinMax2(self):
-        "Test of minumum, maximum."
+        # Test of minumum, maximum.
         assert_(eq(minimum([1, 2, 3], [4, 0, 9]), [1, 0, 3]))
         assert_(eq(maximum([1, 2, 3], [4, 0, 9]), [4, 2, 9]))
         x = arange(5)
@@ -425,7 +431,7 @@ class TestMa(TestCase):
         assert_(maximum(x) == 4)
 
     def test_testTakeTransposeInnerOuter(self):
-        "Test of take, transpose, inner, outer products"
+        # Test of take, transpose, inner, outer products
         x = arange(24)
         y = np.arange(24)
         x[5:6] = masked
@@ -434,9 +440,9 @@ class TestMa(TestCase):
         assert_(eq(np.transpose(y, (2, 0, 1)), transpose(x, (2, 0, 1))))
         assert_(eq(np.take(y, (2, 0, 1), 1), take(x, (2, 0, 1), 1)))
         assert_(eq(np.inner(filled(x, 0), filled(y, 0)),
-                                inner(x, y)))
+                   inner(x, y)))
         assert_(eq(np.outer(filled(x, 0), filled(y, 0)),
-                                outer(x, y)))
+                   outer(x, y)))
         y = array(['abc', 1, 'def', 2, 3], object)
         y[2] = masked
         t = take(y, [0, 3, 4])
@@ -445,7 +451,7 @@ class TestMa(TestCase):
         assert_(t[2] == 3)
 
     def test_testInplace(self):
-        """Test of inplace operations and rich comparisons"""
+        # Test of inplace operations and rich comparisons
         y = arange(10)
 
         x = arange(10)
@@ -495,7 +501,7 @@ class TestMa(TestCase):
         assert_(eq(x, y + 1.))
 
     def test_testPickle(self):
-        "Test of pickling"
+        # Test of pickling
         import pickle
         x = arange(12)
         x[4:10:2] = masked
@@ -505,7 +511,7 @@ class TestMa(TestCase):
         assert_(eq(x, y))
 
     def test_testMasked(self):
-        "Test of masked element"
+        # Test of masked element
         xx = arange(6)
         xx[1] = masked
         self.assertTrue(str(masked) == '--')
@@ -518,7 +524,7 @@ class TestMa(TestCase):
         #self.assertRaises(Exception, lambda x,y: x+y, xx, masked)
 
     def test_testAverage1(self):
-        "Test of average."
+        # Test of average.
         ott = array([0., 1., 2., 3.], mask=[1, 0, 0, 0])
         self.assertTrue(eq(2.0, average(ott, axis=0)))
         self.assertTrue(eq(2.0, average(ott, weights=[1., 1., 2., 1.])))
@@ -537,7 +543,7 @@ class TestMa(TestCase):
         self.assertTrue(eq(wts, [1., 0.]))
 
     def test_testAverage2(self):
-        "More tests of average."
+        # More tests of average.
         w1 = [0, 1, 1, 1, 1, 0]
         w2 = [[0, 1, 1, 1, 1, 0], [1, 0, 0, 0, 0, 1]]
         x = arange(6)
@@ -548,12 +554,12 @@ class TestMa(TestCase):
                                  np.add.reduce(np.arange(6)) * 3. / 12.))
         self.assertTrue(allclose(average(y, axis=0), np.arange(6) * 3. / 2.))
         self.assertTrue(allclose(average(y, axis=1),
-                                 [average(x, axis=0), average(x, axis=0) * 2.0]))
+                                 [average(x, axis=0), average(x, axis=0)*2.0]))
         self.assertTrue(allclose(average(y, None, weights=w2), 20. / 6.))
         self.assertTrue(allclose(average(y, axis=0, weights=w2),
                                  [0., 1., 2., 3., 4., 10.]))
         self.assertTrue(allclose(average(y, axis=1),
-                                 [average(x, axis=0), average(x, axis=0) * 2.0]))
+                                 [average(x, axis=0), average(x, axis=0)*2.0]))
         m1 = zeros(6)
         m2 = [0, 0, 1, 1, 0, 0]
         m3 = [[0, 0, 1, 1, 0, 0], [0, 1, 1, 1, 1, 0]]
@@ -566,10 +572,11 @@ class TestMa(TestCase):
         self.assertEqual(count(average(masked_array(x, m4), axis=0)), 0)
         z = masked_array(y, m3)
         self.assertTrue(allclose(average(z, None), 20. / 6.))
-        self.assertTrue(allclose(average(z, axis=0), [0., 1., 99., 99., 4.0, 7.5]))
+        self.assertTrue(allclose(average(z, axis=0),
+                                 [0., 1., 99., 99., 4.0, 7.5]))
         self.assertTrue(allclose(average(z, axis=1), [2.5, 5.0]))
         self.assertTrue(allclose(average(z, axis=0, weights=w2),
-                                  [0., 1., 99., 99., 4.0, 10.0]))
+                                 [0., 1., 99., 99., 4.0, 10.0]))
 
         a = arange(6)
         b = arange(6) * 3
@@ -585,7 +592,7 @@ class TestMa(TestCase):
         a2d = array([[1, 2], [0, 4]], float)
         a2dm = masked_array(a2d, [[0, 0], [1, 0]])
         a2da = average(a2d, axis=0)
-        self.assertTrue(eq (a2da, [0.5, 3.0]))
+        self.assertTrue(eq(a2da, [0.5, 3.0]))
         a2dma = average(a2dm, axis=0)
         self.assertTrue(eq(a2dma, [1.0, 3.0]))
         a2dma = average(a2dm, axis=None)
@@ -620,12 +627,12 @@ class TestMa(TestCase):
 
     def test_testArrayMethods(self):
         a = array([1, 3, 2])
-        b = array([1, 3, 2], mask=[1, 0, 1])
         self.assertTrue(eq(a.any(), a._data.any()))
         self.assertTrue(eq(a.all(), a._data.all()))
         self.assertTrue(eq(a.argmax(), a._data.argmax()))
         self.assertTrue(eq(a.argmin(), a._data.argmin()))
-        self.assertTrue(eq(a.choose(0, 1, 2, 3, 4), a._data.choose(0, 1, 2, 3, 4)))
+        self.assertTrue(eq(a.choose(0, 1, 2, 3, 4),
+                           a._data.choose(0, 1, 2, 3, 4)))
         self.assertTrue(eq(a.compress([1, 0, 1]), a._data.compress([1, 0, 1])))
         self.assertTrue(eq(a.conj(), a._data.conj()))
         self.assertTrue(eq(a.conjugate(), a._data.conjugate()))
@@ -637,12 +644,12 @@ class TestMa(TestCase):
 
     def test_testArrayAttributes(self):
         a = array([1, 3, 2])
-        b = array([1, 3, 2], mask=[1, 0, 1])
         self.assertEqual(a.ndim, 1)
 
     def test_testAPI(self):
         self.assertFalse([m for m in dir(np.ndarray)
-                     if m not in dir(MaskedArray) and not m.startswith('_')])
+                          if m not in dir(MaskedArray) and
+                          not m.startswith('_')])
 
     def test_testSingleElementSubscript(self):
         a = array([1, 3, 2])
@@ -651,35 +658,35 @@ class TestMa(TestCase):
         self.assertEqual(b[0].shape, ())
         self.assertEqual(b[1].shape, ())
 
+
 class TestUfuncs(TestCase):
     def setUp(self):
         self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
 
-
     def test_testUfuncRegression(self):
-        f_invalid_ignore = ['sqrt', 'arctanh', 'arcsin', 'arccos',
-                'arccosh', 'arctanh', 'log', 'log10', 'divide',
-                'true_divide', 'floor_divide', 'remainder', 'fmod']
+        f_invalid_ignore = [
+            'sqrt', 'arctanh', 'arcsin', 'arccos',
+            'arccosh', 'arctanh', 'log', 'log10', 'divide',
+            'true_divide', 'floor_divide', 'remainder', 'fmod']
         for f in ['sqrt', 'log', 'log10', 'exp', 'conjugate',
-                'sin', 'cos', 'tan',
-                'arcsin', 'arccos', 'arctan',
-                'sinh', 'cosh', 'tanh',
-                'arcsinh',
-                'arccosh',
-                'arctanh',
-                'absolute', 'fabs', 'negative',
-                # 'nonzero', 'around',
-                'floor', 'ceil',
-                # 'sometrue', 'alltrue',
-                'logical_not',
-                'add', 'subtract', 'multiply',
-                'divide', 'true_divide', 'floor_divide',
-                'remainder', 'fmod', 'hypot', 'arctan2',
-                'equal', 'not_equal', 'less_equal', 'greater_equal',
-                'less', 'greater',
-                'logical_and', 'logical_or', 'logical_xor',
-                ]:
+                  'sin', 'cos', 'tan',
+                  'arcsin', 'arccos', 'arctan',
+                  'sinh', 'cosh', 'tanh',
+                  'arcsinh',
+                  'arccosh',
+                  'arctanh',
+                  'absolute', 'fabs', 'negative',
+                  # 'nonzero', 'around',
+                  'floor', 'ceil',
+                  # 'sometrue', 'alltrue',
+                  'logical_not',
+                  'add', 'subtract', 'multiply',
+                  'divide', 'true_divide', 'floor_divide',
+                  'remainder', 'fmod', 'hypot', 'arctan2',
+                  'equal', 'not_equal', 'less_equal', 'greater_equal',
+                  'less', 'greater',
+                  'logical_and', 'logical_or', 'logical_xor']:
             try:
                 uf = getattr(umath, f)
             except AttributeError:
@@ -722,34 +729,25 @@ class TestUfuncs(TestCase):
 class TestArrayMethods(TestCase):
 
     def setUp(self):
-        x = np.array([ 8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
-                          8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
-                          3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
-                          6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
-                          7.189, 9.645, 5.395, 4.961, 9.894, 2.893,
-                          7.357, 9.828, 6.272, 3.758, 6.693, 0.993])
+        x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
+                      8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
+                      3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
+                      6.04, 9.63, 7.712, 3.382, 4.489, 6.479,
+                      7.189, 9.645, 5.395, 4.961, 9.894, 2.893,
+                      7.357, 9.828, 6.272, 3.758, 6.693, 0.993])
         X = x.reshape(6, 6)
         XX = x.reshape(3, 2, 2, 3)
 
         m = np.array([0, 1, 0, 1, 0, 0,
-                         1, 0, 1, 1, 0, 1,
-                         0, 0, 0, 1, 0, 1,
-                         0, 0, 0, 1, 1, 1,
-                         1, 0, 0, 1, 0, 0,
-                         0, 0, 1, 0, 1, 0])
+                      1, 0, 1, 1, 0, 1,
+                      0, 0, 0, 1, 0, 1,
+                      0, 0, 0, 1, 1, 1,
+                      1, 0, 0, 1, 0, 0,
+                      0, 0, 1, 0, 1, 0])
         mx = array(data=x, mask=m)
         mX = array(data=X, mask=m.reshape(X.shape))
         mXX = array(data=XX, mask=m.reshape(XX.shape))
 
-        m2 = np.array([1, 1, 0, 1, 0, 0,
-                          1, 1, 1, 1, 0, 1,
-                          0, 0, 1, 1, 0, 1,
-                          0, 0, 0, 1, 1, 1,
-                          1, 0, 0, 1, 1, 0,
-                          0, 0, 1, 0, 1, 1])
-        m2x = array(data=x, mask=m2)
-        m2X = array(data=X, mask=m2.reshape(X.shape))
-        m2XX = array(data=XX, mask=m2.reshape(XX.shape))
         self.d = (x, X, XX, m, mx, mX, mXX)
 
     #------------------------------------------------------
@@ -758,7 +756,8 @@ class TestArrayMethods(TestCase):
         mXdiag = mX.diagonal()
         self.assertEqual(mX.trace(), mX.diagonal().compressed().sum())
         self.assertTrue(eq(mX.trace(),
-                           X.trace() - sum(mXdiag.mask * X.diagonal(), axis=0)))
+                           X.trace() - sum(mXdiag.mask * X.diagonal(),
+                                           axis=0)))
 
     def test_clip(self):
         (x, X, XX, m, mx, mX, mXX,) = self.d
@@ -786,7 +785,6 @@ class TestArrayMethods(TestCase):
         self.assertTrue(eq(mXswapped[-1], mX[:, -1]))
         mXXswapped = mXX.swapaxes(0, 2)
         self.assertEqual(mXXswapped.shape, (2, 2, 3, 3))
-
 
     def test_cumprod(self):
         (x, X, XX, m, mx, mX, mXX,) = self.d

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,24 +1,25 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-import numpy.ma as ma
 from numpy.testing import *
 from numpy.compat import sixu
 
 rlevel = 1
 
+
 class TestRegression(TestCase):
     def test_masked_array_create(self,level=rlevel):
-        """Ticket #17"""
-        x = np.ma.masked_array([0, 1, 2, 3, 0, 4, 5, 6], mask=[0, 0, 0, 1, 1, 1, 0, 0])
+        # Ticket #17
+        x = np.ma.masked_array([0, 1, 2, 3, 0, 4, 5, 6],
+                               mask=[0, 0, 0, 1, 1, 1, 0, 0])
         assert_array_equal(np.ma.nonzero(x), [[1, 2, 6, 7]])
 
     def test_masked_array(self,level=rlevel):
-        """Ticket #61"""
-        x = np.ma.array(1, mask=[1])
+        # Ticket #61
+        np.ma.array(1, mask=[1])
 
     def test_mem_masked_where(self,level=rlevel):
-        """Ticket #62"""
+        # Ticket #62
         from numpy.ma import masked_where, MaskType
         a = np.zeros((1, 1))
         b = np.zeros(a.shape, MaskType)
@@ -26,7 +27,7 @@ class TestRegression(TestCase):
         a-c
 
     def test_masked_array_multiply(self,level=rlevel):
-        """Ticket #254"""
+        # Ticket #254
         a = np.ma.zeros((4, 1))
         a[2, 0] = np.ma.masked
         b = np.zeros((4, 2))
@@ -34,28 +35,28 @@ class TestRegression(TestCase):
         b*a
 
     def test_masked_array_repeat(self, level=rlevel):
-        """Ticket #271"""
+        # Ticket #271
         np.ma.array([1], mask=False).repeat(10)
 
     def test_masked_array_repr_unicode(self):
-        """Ticket #1256"""
+        # Ticket #1256
         repr(np.ma.array(sixu("Unicode")))
 
     def test_atleast_2d(self):
-        """Ticket #1559"""
+        # Ticket #1559
         a = np.ma.masked_array([0.0, 1.2, 3.5], mask=[False, True, False])
         b = np.atleast_2d(a)
         assert_(a.mask.ndim == 1)
         assert_(b.mask.ndim == 2)
 
     def test_set_fill_value_unicode_py3(self):
-        """Ticket #2733"""
+        # Ticket #2733
         a = np.ma.masked_array(['a', 'b', 'c'], mask=[1, 0, 0])
         a.fill_value = 'X'
         assert_(a.fill_value == 'X')
 
     def test_var_sets_maskedarray_scalar(self):
-        """Issue gh-2757"""
+        # Issue gh-2757
         a = np.ma.array(np.arange(5), mask=True)
         mout = np.ma.array(-1, dtype=float)
         a.var(out=mout)

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -11,23 +11,26 @@ from __future__ import division, absolute_import, print_function
 __author__ = "Pierre GF Gerard-Marchant ($Author: jarrod.millman $)"
 __version__ = '1.0'
 __revision__ = "$Revision: 3473 $"
-__date__     = '$Date: 2007-10-29 17:18:13 +0200 (Mon, 29 Oct 2007) $'
+__date__ = '$Date: 2007-10-29 17:18:13 +0200 (Mon, 29 Oct 2007) $'
 
 import numpy as np
 from numpy.testing import *
 from numpy.ma.testutils import *
 from numpy.ma.core import *
 
+
 class SubArray(np.ndarray):
-    """Defines a generic np.ndarray subclass, that stores some metadata
-    in the  dictionary `info`."""
+    # Defines a generic np.ndarray subclass, that stores some metadata
+    # in the  dictionary `info`.
     def __new__(cls,arr,info={}):
         x = np.asanyarray(arr).view(cls)
         x.info = info
         return x
+
     def __array_finalize__(self, obj):
         self.info = getattr(obj, 'info', {})
         return
+
     def __add__(self, other):
         result = np.ndarray.__add__(self, other)
         result.info.update({'added':result.info.pop('added', 0)+1})
@@ -35,16 +38,20 @@ class SubArray(np.ndarray):
 
 subarray = SubArray
 
+
 class MSubArray(SubArray, MaskedArray):
+
     def __new__(cls, data, info={}, mask=nomask):
         subarr = SubArray(data, info)
         _data = MaskedArray.__new__(cls, data=subarr, mask=mask)
         _data.info = subarr.info
         return _data
+
     def __array_finalize__(self, obj):
         MaskedArray.__array_finalize__(self, obj)
         SubArray.__array_finalize__(self, obj)
         return
+
     def _get_series(self):
         _view = self.view(MaskedArray)
         _view._sharedmask = False
@@ -53,15 +60,19 @@ class MSubArray(SubArray, MaskedArray):
 
 msubarray = MSubArray
 
+
 class MMatrix(MaskedArray, np.matrix,):
+
     def __new__(cls, data, mask=nomask):
         mat = np.matrix(data)
         _data = MaskedArray.__new__(cls, data=mat, mask=mask)
         return _data
+
     def __array_finalize__(self, obj):
         np.matrix.__array_finalize__(self, obj)
         MaskedArray.__array_finalize__(self, obj)
         return
+
     def _get_series(self):
         _view = self.view(MaskedArray)
         _view._sharedmask = False
@@ -70,8 +81,9 @@ class MMatrix(MaskedArray, np.matrix,):
 
 mmatrix = MMatrix
 
+
 class TestSubclassing(TestCase):
-    """Test suite for masked subclasses of ndarray."""
+    # Test suite for masked subclasses of ndarray.
 
     def setUp(self):
         x = np.arange(5)
@@ -79,7 +91,7 @@ class TestSubclassing(TestCase):
         self.data = (x, mx)
 
     def test_data_subclassing(self):
-        "Tests whether the subclass is kept."
+        # Tests whether the subclass is kept.
         x = np.arange(5)
         m = [0, 0, 1, 0, 0]
         xsub = SubArray(x)
@@ -89,19 +101,19 @@ class TestSubclassing(TestCase):
         self.assertTrue(isinstance(xmsub._data, SubArray))
 
     def test_maskedarray_subclassing(self):
-        "Tests subclassing MaskedArray"
+        # Tests subclassing MaskedArray
         (x, mx) = self.data
         self.assertTrue(isinstance(mx._data, np.matrix))
 
     def test_masked_unary_operations(self):
-        "Tests masked_unary_operation"
+        # Tests masked_unary_operation
         (x, mx) = self.data
         with np.errstate(divide='ignore'):
             self.assertTrue(isinstance(log(mx), mmatrix))
             assert_equal(log(x), np.log(x))
 
     def test_masked_binary_operations(self):
-        "Tests masked_binary_operation"
+        # Tests masked_binary_operation
         (x, mx) = self.data
         # Result should be a mmatrix
         self.assertTrue(isinstance(add(mx, mx), mmatrix))
@@ -114,7 +126,7 @@ class TestSubclassing(TestCase):
         self.assertTrue(isinstance(hypot(mx, x), mmatrix))
 
     def test_masked_binary_operations2(self):
-        "Tests domained_masked_binary_operation"
+        # Tests domained_masked_binary_operation
         (x, mx) = self.data
         xmx = masked_array(mx.data.__array__(), mask=mx.mask)
         self.assertTrue(isinstance(divide(mx, mx), mmatrix))
@@ -149,7 +161,7 @@ class TestSubclassing(TestCase):
         assert_equal(mxsub.info, xsub.info)
 
     def test_subclasspreservation(self):
-        "Checks that masked_array(...,subok=True) preserves the class."
+        # Checks that masked_array(...,subok=True) preserves the class.
         x = np.arange(5)
         m = [0, 0, 1, 0, 0]
         xinfo = [(i, j) for (i, j) in zip(x, m)]
@@ -176,6 +188,6 @@ class TestSubclassing(TestCase):
         assert_equal(mxsub._mask, m)
 
 
-################################################################################
+###############################################################################
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
@charris -- hmm, have to be more careful what I volunteer for next time ;-) Anyway, no more docstrings in `ma.tests` and nothing pink in my emacs window. In the process, discovered that a few cases where I was warned that a variable was assigned to, it implied that a test did not actually run correctly. For one of those cases, what is tested actually fails (I'll add a line note).
