### PR TITLE
BUG allow subclasses in MaskedArray ufuncs -- for non-ndarray _data

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1754,6 +1754,29 @@ class TestUfuncs(TestCase):
         assert_(me * a == "My mul")
         assert_(a * me == "My rmul")
 
+        # and that __array_priority__ is respected
+        class MyClass2(object):
+            __array_priority__ = 100
+
+            def __mul__(self, other):
+                return "Me2mul"
+
+            def __rmul__(self, other):
+                return "Me2rmul"
+
+            def __rdiv__(self, other):
+                return "Me2rdiv"
+
+            __rtruediv__ = __rdiv__
+
+        me_too = MyClass2()
+        assert_(a.__mul__(me_too) is NotImplemented)
+        assert_(all(multiply.outer(a, me_too) == "Me2rmul"))
+        assert_(a.__truediv__(me_too) is NotImplemented)
+        assert_(me_too * a == "Me2mul")
+        assert_(a * me_too == "Me2rmul")
+        assert_(a / me_too == "Me2rdiv")
+
 
 #------------------------------------------------------------------------------
 class TestMaskedArrayInPlaceArithmetics(TestCase):

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -24,17 +24,26 @@ class SubArray(np.ndarray):
     # in the  dictionary `info`.
     def __new__(cls,arr,info={}):
         x = np.asanyarray(arr).view(cls)
-        x.info = info
+        x.info = info.copy()
         return x
 
     def __array_finalize__(self, obj):
-        self.info = getattr(obj, 'info', {})
+        if callable(getattr(super(SubArray, self),
+                            '__array_finalize__', None)):
+            super(SubArray, self).__array_finalize__(obj)
+        self.info = getattr(obj, 'info', {}).copy()
         return
 
     def __add__(self, other):
-        result = np.ndarray.__add__(self, other)
-        result.info.update({'added':result.info.pop('added', 0)+1})
+        result = super(SubArray, self).__add__(other)
+        result.info['added'] = result.info.get('added', 0) + 1
         return result
+
+    def __iadd__(self, other):
+        result = super(SubArray, self).__iadd__(other)
+        result.info['iadded'] = result.info.get('iadded', 0) + 1
+        return result
+
 
 subarray = SubArray
 
@@ -46,11 +55,6 @@ class MSubArray(SubArray, MaskedArray):
         _data = MaskedArray.__new__(cls, data=subarr, mask=mask)
         _data.info = subarr.info
         return _data
-
-    def __array_finalize__(self, obj):
-        MaskedArray.__array_finalize__(self, obj)
-        SubArray.__array_finalize__(self, obj)
-        return
 
     def _get_series(self):
         _view = self.view(MaskedArray)
@@ -82,8 +86,11 @@ class MMatrix(MaskedArray, np.matrix,):
 mmatrix = MMatrix
 
 
-# also a subclass that overrides __str__, __repr__ and __setitem__, disallowing
+# Also a subclass that overrides __str__, __repr__ and __setitem__, disallowing
 # setting to non-class values (and thus np.ma.core.masked_print_option)
+# and overrides __array_wrap__, updating the info dict, to check that this
+# doesn't get destroyed by MaskedArray._update_from.  But this one also needs
+# its own iterator...
 class CSAIterator(object):
     """
     Flat iterator object that uses its own setter/getter
@@ -149,6 +156,13 @@ class ComplicatedSubArray(SubArray):
     def flat(self, value):
         y = self.ravel()
         y[:] = value
+
+    def __array_wrap__(self, obj, context=None):
+        obj = super(ComplicatedSubArray, self).__array_wrap__(obj, context)
+        if context is not None and context[0] is np.multiply:
+            obj.info['multiplied'] = obj.info.get('multiplied', 0) + 1
+
+        return obj
 
 
 class TestSubclassing(TestCase):
@@ -218,6 +232,12 @@ class TestSubclassing(TestCase):
         self.assertTrue(isinstance(z, MSubArray))
         self.assertTrue(isinstance(z._data, SubArray))
         self.assertTrue(z._data.info['added'] > 0)
+        # Test that inplace methods from data get used (gh-4617)
+        ym += 1
+        self.assertTrue(isinstance(ym, MaskedArray))
+        self.assertTrue(isinstance(ym, MSubArray))
+        self.assertTrue(isinstance(ym._data, SubArray))
+        self.assertTrue(ym._data.info['iadded'] > 0)
         #
         ym._set_mask([1, 0, 0, 0, 1])
         assert_equal(ym._mask, [1, 0, 0, 0, 1])


### PR DESCRIPTION
This is a follow-on to #3900, making two furthe changes to tryto reach the ultimate goal of `MaskedArray` behaving sensibly for subclasses. 
1. Ensure that for two-argument ufunc's, the data in the subclass are no longer converted to `ndarray`; rather, a possible subclass is kept. This is particularly relevant for my work on a `MaskedQuantity` class, where `_data` contains a `Quantity` which has not just a value (the ndarray) but also a unit.
2. Avoid the creation of `object` arrays, so that non-array Classes with an `__array_priority__` set and with a reverse method defined properly lead to `NotImplemented` (i.e., making the behaviour match that of regular arrays).

In order for this to work, I
- removed `subok=False` in the `getdata` calls in the two `BinaryOperation` classes
- slightly changed the method used to keep previous values when they are masked, including allowing this to fail (e.g., when I multiply two masked quantities in meters, the result is an area, and hence it is senseless to keep the original values, and quantities raise an appropriate UnitError). (Without this, the matrix subclass tests would not pass).
- slightly changed the order, with result masks only calculated if the primary calculation succeeded.
- slightly changed `getdata` to avoid the creation of `object` arrays, and `getmaskedarray` to deal with the consequences.

I also added a test case, which perhaps best makes clear why this is useful. 

CC @charris -- I consider the above a correction of a bug, but realise this is subjective; it could also be ENH, even though the API does not change. It would be wonderful if this could still make it to 1.8.
