### PR TITLE
BUG Masked arrays treated incorrectly in isclose(..,..,equal_nan=True)

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2216,7 +2216,8 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         cond[~finite] = (x[~finite] == y[~finite])
         if equal_nan:
             # Make NaN == NaN
-            cond[isnan(x) & isnan(y)] = True
+            both_nan = isnan(x) & isnan(y)
+            cond[both_nan] = both_nan[both_nan]
         return cond
 
 def array_equal(a1, a2):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1454,6 +1454,12 @@ class TestIsclose(object):
         # Ensure that the mask isn't modified...
         assert_array_equal([True, True, False], y.mask)
 
+        x = np.ma.masked_where([True, True, False], [nan, nan, nan])
+        y = isclose(x, x, equal_nan=True)
+        assert_(type(x) is type(y))
+        # Ensure that the mask isn't modified...
+        assert_array_equal([True, True, False], y.mask)
+
     def test_scalar_return(self):
         assert_(isscalar(isclose(1, 1)))
 


### PR DESCRIPTION
Currently, the mask of a MaskedArray is incorrectly changed in the following:

```
import numpy as np; from numpy import isclose, nan
m = np.ma.MaskedArray([nan, nan], mask=[True, False])
isclose(m, m, equal_nan=True)
```

yields

```
masked_array(data = [True True],
             mask = [False False],
       fill_value = True)
```

The problem lies in the fact that in `isclose`, the following final assignment is done

```
cond[isnan(x) & isnan(y)] = True 
```

The problem here is that the mask of the index is ignored in `__setitem__` (and it would be very hard to do otherwise), but and hence all elements are being set. Since `True` has no mask, the mask of all ements is cleared. To avoid this, this PR ensured that the vallues used include a mask, by replacing the above line with

```
both_nan = isnan(x) & isnan(y)
cond[both_nan] = both_nan[both_nan]
```

A test case is included as well.

p.s. This bug was found while trying to allow `MaskedArray` to behave better with subclasses; see #3907
