### PR TITLE
DOC: Fix misleading description of random_sample in numpy.random docstring.

### DIFF
--- a/numpy/random/info.py
+++ b/numpy/random/info.py
@@ -6,10 +6,10 @@ Random Number Generation
 ==================== =========================================================
 Utility functions
 ==============================================================================
-random               Uniformly distributed values of a given shape.
+random_sample        Uniformly distributed floats over ``[0, 1)``.
+random               Alias for `random_sample`.
 bytes                Uniformly distributed random bytes.
 random_integers      Uniformly distributed integers in a given range.
-random_sample        Uniformly distributed floats in a given range.
 permutation          Randomly permute a sequence / generate a random sequence.
 shuffle              Randomly permute a sequence in place.
 seed                 Seed the random number generator.


### PR DESCRIPTION
The `random_sample` description seen at the top of the `help(numpy.random)` output is misleading:  it suggests that it's possible for the user to define the range of the uniform distribution.  This PR fixes that, and makes it clearer that `random` and `random_sample` are aliases for the same function.

Fixes #3920.
