### PR TITLE
BUG: close file-like objects returned by urlopen

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -297,6 +297,7 @@ class DataSource (object):
                     copyfileobj(openedurl, f)
                 finally:
                     f.close()
+                    openedurl.close()
             except URLError:
                 raise URLError("URL not found: %s" % path)
         else:
@@ -445,6 +446,7 @@ class DataSource (object):
         if self._isurl(path):
             try:
                 netfile = urlopen(path)
+                netfile.close()
                 del(netfile)
                 return True
             except URLError:


### PR DESCRIPTION
Fix `ResourceWarning: unclosed file` on Python 3

Please backport to 1.8
