### PR TITLE
move memchr like code to a function

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -108,4 +108,8 @@
     #endif
 #endif
 
+#if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
+#define NPY_CPU_HAVE_UNALIGNED_ACCESS
+#endif
+
 #endif

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -894,6 +894,7 @@ def configuration(parent_package='',top_path=None):
 
     umath_deps = [
             generate_umath_py,
+            join('src', 'multiarray', 'common.h'),
             join('src', 'umath', 'simd.inc.src'),
             join(codegen_dir, 'generate_ufunc_api.py'),
             join('src', 'private', 'ufunc_override.h')] + npymath_sources

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -116,6 +116,7 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        ("__builtin_bswap32", '5u'),
                        ("__builtin_bswap64", '5u'),
                        ("__builtin_expect", '5, 0'),
+                       ("__builtin_ctz", '5'),
                        ("_mm_load_ps", '(float*)0', "xmmintrin.h"), # SSE
                        ("_mm_load_pd", '(double*)0', "emmintrin.h"), # SSE2
                        ]

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -706,7 +706,7 @@ _IsAligned(PyArrayObject *ap)
         aligned |= (npy_uintp)PyArray_STRIDES(ap)[i];
 #endif /* not NPY_RELAXED_STRIDES_CHECKING */
     }
-    return npy_is_aligned(aligned, alignment);
+    return npy_is_aligned((void *)aligned, alignment);
 }
 
 NPY_NO_EXPORT npy_bool

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -3059,22 +3059,14 @@ void _strided_masked_wrapper_decsrcref_transfer_function(
 
     while (N > 0) {
         /* Skip masked values, still calling decsrcref for move_references */
-        subloopsize = 0;
-        while (subloopsize < N && !*mask) {
-            ++subloopsize;
-            mask += mask_stride;
-        }
+        mask = npy_memchr((char *)mask, 0, mask_stride, N, &subloopsize, 1);
         decsrcref_stransfer(NULL, 0, src, src_stride,
                             subloopsize, src_itemsize, decsrcref_transferdata);
         dst += subloopsize * dst_stride;
         src += subloopsize * src_stride;
         N -= subloopsize;
         /* Process unmasked values */
-        subloopsize = 0;
-        while (subloopsize < N && *mask) {
-            ++subloopsize;
-            mask += mask_stride;
-        }
+        mask = npy_memchr((char *)mask, 0, mask_stride, N, &subloopsize, 0);
         unmasked_stransfer(dst, dst_stride, src, src_stride,
                             subloopsize, src_itemsize, unmasked_transferdata);
         dst += subloopsize * dst_stride;
@@ -3102,20 +3094,12 @@ void _strided_masked_wrapper_transfer_function(
 
     while (N > 0) {
         /* Skip masked values */
-        subloopsize = 0;
-        while (subloopsize < N && !*mask) {
-            ++subloopsize;
-            mask += mask_stride;
-        }
+        mask = npy_memchr((char *)mask, 0, mask_stride, N, &subloopsize, 1);
         dst += subloopsize * dst_stride;
         src += subloopsize * src_stride;
         N -= subloopsize;
         /* Process unmasked values */
-        subloopsize = 0;
-        while (subloopsize < N && *mask) {
-            ++subloopsize;
-            mask += mask_stride;
-        }
+        mask = npy_memchr((char *)mask, 0, mask_stride, N, &subloopsize, 0);
         unmasked_stransfer(dst, dst_stride, src, src_stride,
                             subloopsize, src_itemsize, unmasked_transferdata);
         dst += subloopsize * dst_stride;

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2414,7 +2414,7 @@ count_nonzero_bytes_128(npy_uint64 * w)
      */
     if (NPY_UNLIKELY(((w1 | w2)  & 0xFEFEFEFEFEFEFEFEULL) != 0)) {
         /* reload from pointer to avoid a unnecessary stack spill with gcc */
-        char * c = w;
+        char * c = (char *)w;
         npy_uintp i, count = 0;
         for (i = 0; i < 16; i++) {
             count += (c[i] != 0);
@@ -2469,7 +2469,7 @@ count_boolean_trues(int ndim, char *data, npy_intp *ashape, npy_intp *astrides)
             if (npy_is_aligned(data, sizeof(npy_uint64))) {
                 npy_uintp stride = 2 * sizeof(npy_uint64);
                 for (; d < e - (shape[0]  % stride); d += stride) {
-                    count += count_nonzero_bytes_128(d);
+                    count += count_nonzero_bytes_128((npy_uint64 *)d);
                 }
             }
             for (; d < e; ++d) {

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -39,7 +39,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
+#ifdef NPY_CPU_HAVE_UNALIGNED_ACCESS
 #  define NPY_USE_UNALIGNED_ACCESS 0
 #else
 #  define NPY_USE_UNALIGNED_ACCESS 0

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -725,19 +725,13 @@ array_boolean_subscript(PyArrayObject *self,
 
             while (innersize > 0) {
                 /* Skip masked values */
-                subloopsize = 0;
-                while (subloopsize < innersize && *bmask_data == 0) {
-                    ++subloopsize;
-                    bmask_data += bmask_stride;
-                }
+                bmask_data = npy_memchr(bmask_data, 0, bmask_stride,
+                                        innersize, &subloopsize, 1);
                 innersize -= subloopsize;
                 self_data += subloopsize * self_stride;
                 /* Process unmasked values */
-                subloopsize = 0;
-                while (subloopsize < innersize && *bmask_data != 0) {
-                    ++subloopsize;
-                    bmask_data += bmask_stride;
-                }
+                bmask_data = npy_memchr(bmask_data, 0, bmask_stride, innersize,
+                                        &subloopsize, 0);
                 stransfer(ret_data, itemsize, self_data, self_stride,
                             subloopsize, itemsize, transferdata);
                 innersize -= subloopsize;
@@ -884,19 +878,13 @@ array_ass_boolean_subscript(PyArrayObject *self,
 
             while (innersize > 0) {
                 /* Skip masked values */
-                subloopsize = 0;
-                while (subloopsize < innersize && *bmask_data == 0) {
-                    ++subloopsize;
-                    bmask_data += bmask_stride;
-                }
+                bmask_data = npy_memchr(bmask_data, 0, bmask_stride,
+                                        innersize, &subloopsize, 1);
                 innersize -= subloopsize;
                 self_data += subloopsize * self_stride;
                 /* Process unmasked values */
-                subloopsize = 0;
-                while (subloopsize < innersize && *bmask_data != 0) {
-                    ++subloopsize;
-                    bmask_data += bmask_stride;
-                }
+                bmask_data = npy_memchr(bmask_data, 0, bmask_stride, innersize,
+                                        &subloopsize, 0);
                 stransfer(self_data, self_stride, v_data, v_stride,
                             subloopsize, src_itemsize, transferdata);
                 innersize -= subloopsize;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -23,6 +23,7 @@
 
 #include "numpy/ufuncobject.h"
 #include "ufunc_type_resolution.h"
+#include "common.h"
 
 static const char *
 npy_casting_to_string(NPY_CASTING casting)
@@ -1343,11 +1344,7 @@ unmasked_ufunc_loop_as_masked(
     /* Process the data as runs of unmasked values */
     do {
         /* Skip masked values */
-        subloopsize = 0;
-        while (subloopsize < loopsize && !*mask) {
-            ++subloopsize;
-            mask += mask_stride;
-        }
+        mask = npy_memchr(mask, 0, mask_stride, loopsize, &subloopsize, 1);
         for (iargs = 0; iargs < nargs; ++iargs) {
             dataptrs[iargs] += subloopsize * strides[iargs];
         }
@@ -1356,11 +1353,7 @@ unmasked_ufunc_loop_as_masked(
          * Process unmasked values (assumes unmasked loop doesn't
          * mess with the 'args' pointer values)
          */
-        subloopsize = 0;
-        while (subloopsize < loopsize && *mask) {
-            ++subloopsize;
-            mask += mask_stride;
-        }
+        mask = npy_memchr(mask, 0, mask_stride, loopsize, &subloopsize, 0);
         unmasked_innerloop(dataptrs, &subloopsize, strides,
                                         unmasked_innerloopdata);
         for (iargs = 0; iargs < nargs; ++iargs) {


### PR DESCRIPTION
and improve the speed a bit by using by using __builtin_ctz (tzcnt on x86)

Improves sparse mask performance by about a factor of three, the worst
case of no consecutive mask elements slows down by about 10%-20%.

```
In [1]: import numpy as np
In [2]: d = np.ones(60000)
In [3]: m = np.ones(60000, dtype=np.bool)
In [4]: r = np.zeros(60000)
In [5]: %timeit np.copyto(r, d, where=m)
10000 loops, best of 3: 137 µs per loop
# vs before 156 µs
In [7]: %timeit np.copyto(r, d, where=m)
100000 loops, best of 3: 15.5 µs per loop
# vs before 58.2 µs
In [8]: m[::2] = ~m[::2]
In [9]: %timeit np.copyto(r, d, where=m)
1000 loops, best of 3: 634 µs per loop
# vs before 548 µs
```
