### PR TITLE
MAINT: Define NPY_NO_DEPRECATED_API in struct_ufunc_test.c.src

### DIFF
--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -1,3 +1,5 @@
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
 #include "Python.h"
 #include "math.h"
 #include "numpy/ndarraytypes.h"
@@ -106,7 +108,7 @@ PyMODINIT_FUNC initstruct_ufunc_test(void)
     dtypes[1] = dtype;
     dtypes[2] = dtype;
 
-    PyUFunc_RegisterLoopForDescr(add_triplet,
+    PyUFunc_RegisterLoopForDescr((PyUFuncObject *)add_triplet,
                                 dtype,
                                 &add_uint64_triplet,
                                 dtypes,


### PR DESCRIPTION
Removes a compile warning and makes the function use proper macro
replacements. Also fix a pointer type mismatch warning.
