### PR TITLE
BUG: multiarray/mapping -- address for former renaming of array_ass_big_item (closes #3922)

### DIFF
--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -26,16 +26,7 @@ NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op);
 
 NPY_NO_EXPORT int
-array_ass_big_item(PyArrayObject *self, npy_intp i, PyObject *v);
-
-/* SIZEOF_SIZE_T is nowhere defined, Py_ssize_t perhaps?*/
-#if SIZEOF_SIZE_T == NPY_SIZEOF_INTP
-#define array_ass_item array_ass_big_item
-#else
-NPY_NO_EXPORT int
-_array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
-#define array_ass_item _array_ass_item
-#endif
+array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
 
 NPY_NO_EXPORT PyObject *
 add_new_axes_0d(PyArrayObject *,  int);


### PR DESCRIPTION
Lead to build failures on s390 (32bit user space).
Tested to build fine and have the same test failures on both s390 and s390x (64 bit userspace).  I will let travis to test on commodity setups

Patch by Charles Harris
