### PR TITLE
BUG: test_fortran_order_buffer fails on big endian architectures.

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1908,8 +1908,8 @@ class TestRegression(TestCase):
 
     def test_fortran_order_buffer(self):
         import numpy as np
-        a = np.array([['Hello', 'Foob']], dtype='<U5', order='F')
-        arr = np.ndarray(shape=[1, 2, 5], dtype='<U1', buffer=a)
+        a = np.array([['Hello', 'Foob']], dtype='U5', order='F')
+        arr = np.ndarray(shape=[1, 2, 5], dtype='U1', buffer=a)
         arr2 = np.array([[[sixu('H'), sixu('e'), sixu('l'), sixu('l'), sixu('o')],
                           [sixu('F'), sixu('o'), sixu('o'), sixu('b'), sixu('')]]])
         assert_array_equal(arr, arr2)


### PR DESCRIPTION
The numpy unicode string comparison function does not work correctly
for non-native byte orders. That is a problem needing fixing, but
test_fortran_order_buffer is only needed to check that the buffer
works correctly for fortran order buffers, so let the endianess of
test data be the platform default.
