### PR TITLE
ENH: Inline check_and_adjust_index

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -609,31 +609,6 @@ _array_typedescr_fromstr(char *c_str)
     return descr;
 }
 
-NPY_NO_EXPORT int
-check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis)
-{
-    /* Check that index is valid, taking into account negative indices */
-    if ((*index < -max_item) || (*index >= max_item)) {
-        /* Try to be as clear as possible about what went wrong. */
-        if (axis >= 0) {
-            PyErr_Format(PyExc_IndexError,
-                         "index %"NPY_INTP_FMT" is out of bounds "
-                         "for axis %d with size %"NPY_INTP_FMT,
-                         *index, axis, max_item);
-        } else {
-            PyErr_Format(PyExc_IndexError,
-                         "index %"NPY_INTP_FMT" is out of bounds "
-                         "for size %"NPY_INTP_FMT,
-                         *index, max_item);
-        }
-        return -1;
-    }
-    /* adjust negative indices */
-    if (*index < 0) {
-        *index += max_item;
-    }
-    return 0;
-}
 
 NPY_NO_EXPORT char *
 index2ptr(PyArrayObject *mp, npy_intp i)


### PR DESCRIPTION
The function takes a considerable amount of time of np.take and
to also fancy indexing. Simple np.takes can speed up by more then
40%, fancy indexes around 10%.
