### PR TITLE
ENH: Add scalar special cases to Priority getter

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -53,6 +53,13 @@ PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
 
     /* We do not need to check for special attributes on trivial types */
     if (obj == Py_None ||
+            /* Basic number types */
+#if !defined(NPY_PY3K)
+            PyInt_CheckExact(obj) ||
+#endif
+            PyLong_CheckExact(obj) ||
+            PyFloat_CheckExact(obj) ||
+            /* Basic sequence types */
             PyList_CheckExact(obj) ||
             PyTuple_CheckExact(obj)) {
         return NULL;


### PR DESCRIPTION
Exact Python scalars can never have a priority, but checking
it is expensive. This adds checks for these to the Priority
getter function.
## 

Not sure if adding the special case at that point is ideal. For most/all other branches the scalars were probably already ruled out by the time calling this, so might also the special case down the iteration loop.

This should fix the slowdown of `a = np.array(1); a + 1.` when comparing master to 1.7.
