### PR TITLE
MAINT: io: handle a bad fmt argument in savetxt by raising a ValueError.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1047,6 +1047,8 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
                 raise error
             else:
                 format = fmt
+        else:
+            raise ValueError('invalid fmt: %r' % (fmt,))
 
         if len(header) > 0:
             header = header.replace('\n', '\n' + comments)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -327,6 +327,10 @@ class TestSaveTxt(TestCase):
         lines = c.readlines()
         assert_equal(lines, [b'01 : 2.0\n', b'03 : 4.0\n'])
 
+        # Bad fmt, should raise a ValueError
+        c = BytesIO()
+        assert_raises(ValueError, np.savetxt, c, a, fmt=99)
+
     def test_header_footer(self):
         """
         Test the functionality of the header and footer keyword argument.


### PR DESCRIPTION
Raise a ValueError when the `fmt` argument to `savetxt` is not a list, tuple or string.

Currenty, a bad `fmt` results in an `UnboundLocalError`:

```
In [1]: x = linspace(0,1,5)

In [2]: savetxt('x.txt', x, fmt=99)
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-2-32dc79a49f0c> in <module>()
----> 1 savetxt('x.txt', x, fmt=99)

/home/warren/anaconda/lib/python2.7/site-packages/numpy/lib/npyio.pyc in savetxt(fname, X, fmt, delimiter, newline, header, footer, comments)
   1045         else:
   1046             for row in X:
-> 1047                 fh.write(asbytes(format % tuple(row) + newline))
   1048         if len(footer) > 0:
   1049             footer = footer.replace('\n', '\n' + comments)

UnboundLocalError: local variable 'format' referenced before assignment
```

With this PR, a ValueError that states the problem is raised instead:

```
In [1]: x = linspace(0,1,5)

In [2]: savetxt('x.txt', x, fmt=99)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-32dc79a49f0c> in <module>()
----> 1 savetxt('x.txt', x, fmt=99)

/home/warren/local_scipy/lib/python2.7/site-packages/numpy/lib/npyio.pyc in savetxt(fname, X, fmt, delimiter, newline, header, footer, comments)
   1049                 format = fmt
   1050         else:
-> 1051             raise ValueError('invalid fmt: %r' % (fmt,))
   1052 
   1053         if len(header) > 0:

ValueError: invalid fmt: 99
```
