### PR TITLE
backport-1.7-3952

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2197,6 +2197,12 @@ voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val)
         return -1;
     }
 
+    if (!val) {
+        PyErr_SetString(PyExc_ValueError,
+                "cannot delete scalar field");
+        return -1;
+    }
+
 #if defined(NPY_PY3K)
     if (PyUString_Check(ind)) {
 #else

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2887,6 +2887,10 @@ def test_flat_element_deletion():
     except:
         raise AssertionError
 
+def test_scalar_element_deletion():
+    a = np.zeros(2, dtype=[('x', 'int'), ('y', 'int')])
+    assert_raises(ValueError, a[0].__delitem__, 'x')
+
 class TestMemEventHook(TestCase):
     def test_mem_seteventhook(self):
         # The actual tests are within the C code in


### PR DESCRIPTION
Backport #3952: `BUG: #2052 del scalar subscript causes segfault`.
