### PR TITLE
backport-1.8-3952

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2185,6 +2185,12 @@ voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val)
         return -1;
     }
 
+    if (!val) {
+        PyErr_SetString(PyExc_ValueError,
+                "cannot delete scalar field");
+        return -1;
+    }
+
 #if defined(NPY_PY3K)
     if (PyUString_Check(ind)) {
 #else

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3513,6 +3513,10 @@ def test_flat_element_deletion():
     except:
         raise AssertionError
 
+def test_scalar_element_deletion():
+    a = np.zeros(2, dtype=[('x', 'int'), ('y', 'int')])
+    assert_raises(ValueError, a[0].__delitem__, 'x')
+
 class TestMemEventHook(TestCase):
     def test_mem_seteventhook(self):
         # The actual tests are within the C code in


### PR DESCRIPTION
Backport #3952: `BUG: #2052 del scalar subscript causes segfault`
