### PR TITLE
MAINT: Initialize strides in NpyIter and silence valgrind

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1396,7 +1396,7 @@ static int min_scalar_type_num(char *valueptr, int type_num,
             break;
         }
         case NPY_CLONGDOUBLE: {
-            npy_cdouble value = *(npy_cdouble *)valueptr;
+            npy_clongdouble value = *(npy_clongdouble *)valueptr;
             /*
             if (value.imag == 0) {
                 return min_scalar_type_num((char *)&value.real,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1548,6 +1548,7 @@ _prepend_ones(PyArrayObject *arr, int nd, int ndmin, NPY_ORDER order)
                         PyArray_FLAGS(arr),
                         (PyObject *)arr);
     if (ret == NULL) {
+        Py_DECREF(arr);
         return NULL;
     }
     /* steals a reference to arr --- so don't increment here */

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1565,6 +1565,7 @@ npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itf
         NAD_SHAPE(axisdata) = 1;
         NAD_INDEX(axisdata) = 0;
         memcpy(NAD_PTRS(axisdata), op_dataptr, NPY_SIZEOF_INTP*nop);
+        memset(NAD_STRIDES(axisdata), 0, NPY_SIZEOF_INTP*nop);
     }
 
     /* Now process the operands, filling in the axisdata */

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -771,6 +771,7 @@ array_int(PyArrayObject *v)
                 PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)pv))) {
         PyErr_SetString(PyExc_TypeError,
                 "object array may be self-referencing");
+        Py_DECREF(pv);
         return NULL;
     }
 
@@ -812,6 +813,7 @@ array_float(PyArrayObject *v)
                     PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)pv))) {
         PyErr_SetString(PyExc_TypeError,
                 "object array may be self-referencing");
+        Py_DECREF(pv);
         return NULL;
     }
     pv2 = Py_TYPE(pv)->tp_as_number->nb_float(pv);
@@ -849,6 +851,7 @@ array_long(PyArrayObject *v)
                     PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)pv))) {
         PyErr_SetString(PyExc_TypeError,
                 "object array may be self-referencing");
+        Py_DECREF(pv);
         return NULL;
     }
     pv2 = Py_TYPE(pv)->tp_as_number->nb_long(pv);
@@ -884,6 +887,7 @@ array_oct(PyArrayObject *v)
                     PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)pv))) {
         PyErr_SetString(PyExc_TypeError,
                 "object array may be self-referencing");
+        Py_DECREF(pv);
         return NULL;
     }
     pv2 = Py_TYPE(pv)->tp_as_number->nb_oct(pv);
@@ -919,6 +923,7 @@ array_hex(PyArrayObject *v)
                     PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)pv))) {
         PyErr_SetString(PyExc_TypeError,
                 "object array may be self-referencing");
+        Py_DECREF(pv);
         return NULL;
     }
     pv2 = Py_TYPE(pv)->tp_as_number->nb_hex(pv);

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -833,14 +833,19 @@ array_long(PyArrayObject *v)
         return NULL;
     }
     pv = PyArray_DESCR(v)->f->getitem(PyArray_DATA(v), v);
+    if (pv == NULL) {
+        return NULL;
+    }
     if (Py_TYPE(pv)->tp_as_number == 0) {
         PyErr_SetString(PyExc_TypeError, "cannot convert to an int; "\
                         "scalar object is not a number");
+        Py_DECREF(pv);
         return NULL;
     }
     if (Py_TYPE(pv)->tp_as_number->nb_long == 0) {
         PyErr_SetString(PyExc_TypeError, "don't know how to convert "\
                         "scalar number to long");
+        Py_DECREF(pv);
         return NULL;
     }
     /*
@@ -869,14 +874,19 @@ array_oct(PyArrayObject *v)
         return NULL;
     }
     pv = PyArray_DESCR(v)->f->getitem(PyArray_DATA(v), v);
+    if (pv == NULL) {
+        return NULL;
+    }
     if (Py_TYPE(pv)->tp_as_number == 0) {
         PyErr_SetString(PyExc_TypeError, "cannot convert to an int; "\
                         "scalar object is not a number");
+        Py_DECREF(pv);
         return NULL;
     }
     if (Py_TYPE(pv)->tp_as_number->nb_oct == 0) {
         PyErr_SetString(PyExc_TypeError, "don't know how to convert "\
                         "scalar number to oct");
+        Py_DECREF(pv);
         return NULL;
     }
     /*
@@ -905,14 +915,19 @@ array_hex(PyArrayObject *v)
         return NULL;
     }
     pv = PyArray_DESCR(v)->f->getitem(PyArray_DATA(v), v);
+    if (pv == NULL) {
+        return NULL;
+    }
     if (Py_TYPE(pv)->tp_as_number == 0) {
         PyErr_SetString(PyExc_TypeError, "cannot convert to an int; "\
                         "scalar object is not a number");
+        Py_DECREF(pv);
         return NULL;
     }
     if (Py_TYPE(pv)->tp_as_number->nb_hex == 0) {
         PyErr_SetString(PyExc_TypeError, "don't know how to convert "\
                         "scalar number to hex");
+        Py_DECREF(pv);
         return NULL;
     }
     /*

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1242,12 +1242,15 @@ PyMODINIT_FUNC inittest_rational(void) {
             PyErr_Format(PyExc_AssertionError, \
                          "ufunc %s takes %d arguments, our loop takes %ld", \
                          #name, ufunc->nargs, sizeof(_types)/sizeof(int)); \
+            Py_DECREF(ufunc); \
             goto fail; \
         } \
         if (PyUFunc_RegisterLoopForType((PyUFuncObject*)ufunc, npy_rational, \
                 rational_ufunc_##name, _types, 0) < 0) { \
+            Py_DECREF(ufunc); \
             goto fail; \
         } \
+        Py_DECREF(ufunc); \
     }
     #define REGISTER_UFUNC_BINARY_RATIONAL(name) \
         REGISTER_UFUNC(name, {npy_rational, npy_rational, npy_rational})

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5076,7 +5076,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     }
     else {
         Py_INCREF(PyArray_DESCR(op1_array));
-        array_operands[2] = new_array_op(op1_array, iter->dataptr);
+        array_operands[1] = new_array_op(op1_array, iter->dataptr);
         array_operands[2] = NULL;
     }
 

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -122,13 +122,13 @@ def test_array_array():
 
     # Try with lists...
     assert_equal(np.array([None] * 10, dtype=np.float64),
-                 np.empty((10,), dtype=np.float64) + np.nan)
+                 np.full((10,), np.nan, dtype=np.float64))
     assert_equal(np.array([[None]] * 10, dtype=np.float64),
-                 np.empty((10, 1), dtype=np.float64) + np.nan)
+                 np.full((10, 1), np.nan, dtype=np.float64))
     assert_equal(np.array([[None] * 10], dtype=np.float64),
-                 np.empty((1, 10), dtype=np.float64) + np.nan)
+                 np.full((1, 10), np.nan, dtype=np.float64))
     assert_equal(np.array([[None] * 10] * 10, dtype=np.float64),
-                 np.empty((10, 10), dtype=np.float64) + np.nan)
+                 np.full((10, 10), np.nan, dtype=np.float64))
 
     assert_equal(np.array([1.0] * 10, dtype=np.float64),
                  np.ones((10,), dtype=np.float64))
@@ -141,13 +141,13 @@ def test_array_array():
 
     # Try with tuples
     assert_equal(np.array((None,) * 10, dtype=np.float64),
-                 np.empty((10,), dtype=np.float64) + np.nan)
+                 np.full((10,), np.nan, dtype=np.float64))
     assert_equal(np.array([(None,)] * 10, dtype=np.float64),
-                 np.empty((10, 1), dtype=np.float64) + np.nan)
+                 np.full((10, 1), np.nan, dtype=np.float64))
     assert_equal(np.array([(None,) * 10], dtype=np.float64),
-                 np.empty((1, 10), dtype=np.float64) + np.nan)
+                 np.full((1, 10), np.nan, dtype=np.float64))
     assert_equal(np.array([(None,) * 10] * 10, dtype=np.float64),
-                 np.empty((10, 10), dtype=np.float64) + np.nan)
+                 np.full((10, 10), np.nan, dtype=np.float64))
 
     assert_equal(np.array((1.0,) * 10, dtype=np.float64),
                  np.ones((10,), dtype=np.float64))

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1624,7 +1624,7 @@ class TestBinop(object):
 
             # Check behavior against both bare ndarray objects and a
             # ndarray subclasses with and without their own override
-            obj = cls((1,))
+            obj = cls((1,), buffer=np.ones(1,))
 
             arr_objs = [np.array([1]),
                         np.array([2]).view(OtherNdarraySubclass),

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1654,6 +1654,14 @@ class TestRegression(TestCase):
         assert_raises(TypeError, oct, a)
         assert_raises(TypeError, hex, a)
 
+        # Test the same for a circular reference.
+        b = np.array(a, dtype=object)
+        a[()] = b
+        assert_raises(TypeError, int, a)
+        # Numpy has no tp_traverse currently, so circular references
+        # cannot be detected. So resolve it:
+        a[()] = 0
+
         # This was causing a to become like the above
         a = np.array(0, dtype=object)
         a[...] += 1
@@ -1661,7 +1669,7 @@ class TestRegression(TestCase):
 
     def test_object_array_self_copy(self):
         # An object array being copied into itself DECREF'ed before INCREF'ing
-        # causing segmentation faults (gh-3787) 
+        # causing segmentation faults (gh-3787)
         a = np.array(object(), dtype=object)
         np.copyto(a, a)
         assert_equal(sys.getrefcount(a[()]), 2)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -616,7 +616,7 @@ class TestLstsq(LinalgTestCase, LinalgNonsquareTestCase):
                 expect_resids.shape = (1,)
                 assert_equal(residuals.shape, expect_resids.shape)
         else:
-            expect_resids = type(x)([])
+            expect_resids = np.array([]).view(type(x))
         assert_almost_equal(residuals, expect_resids)
         assert_(np.issubdtype(residuals.dtype, np.floating))
         assert_(imply(isinstance(b, matrix), isinstance(x, matrix)))


### PR DESCRIPTION
The strides are arbitrary, but 0 makes sense. The empty arrays
cause valgrind to spit many errors, so use filled instead.
## 

Nothing big, just sets the strides for 0-d iterations (they are never used anyway) and changes a test to not use uninitialized arrays. Makes running the numpy tests in valgrind bearable (with python suppressions, I edited the python supp to match the object malloc stuff very broadly: http://sebastian.sipsolutions.net/python.supp). There is some spam left, but I will wait for memchr fix to see if it stays...
