### PR TITLE
BUG: fix handling of negative strides in npy_memchr

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -116,7 +116,6 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        ("__builtin_bswap32", '5u'),
                        ("__builtin_bswap64", '5u'),
                        ("__builtin_expect", '5, 0'),
-                       ("__builtin_ctz", '5'),
                        ("_mm_load_ps", '(float*)0', "xmmintrin.h"), # SSE
                        ("_mm_load_pd", '(double*)0', "emmintrin.h"), # SSE2
                        ]

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -137,19 +137,18 @@ npy_memchr(char * haystack, char needle,
     }
     else {
         /* usually find elements to skip path */
-#if (defined HAVE___BUILTIN_CTZ && defined NPY_CPU_HAVE_UNALIGNED_ACCESS)
+#if defined NPY_CPU_HAVE_UNALIGNED_ACCESS
         if (needle == 0 && stride == 1) {
-            char * const end = haystack + size;
-            while (p < end - (size % sizeof(unsigned int))) {
+            /* iterate until last multiple of 4 */
+            char * block_end = haystack + size - (size % sizeof(unsigned int));
+            while (p < block_end) {
                 unsigned int  v = *(unsigned int*)p;
-                if (v == 0) {
-                    p += sizeof(unsigned int);
-                    continue;
+                if (v != 0) {
+                    break;
                 }
-                p += __builtin_ctz(v) / 8;
-                *psubloopsize = (p - haystack);
-                return p;
+                p += sizeof(unsigned int);
             }
+            /* handle rest */
             subloopsize = (p - haystack);
         }
 #endif

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -332,6 +332,14 @@ def test_copyto():
     assert_raises(TypeError, np.copyto, [1, 2, 3], [2, 3, 4])
 
 def test_copyto_permut():
+    # test explicit overflow case
+    pad = 500
+    l = [True] * pad + [True, True, True, True]
+    r = np.zeros(len(l)-pad)
+    d = np.ones(len(l)-pad)
+    mask = np.array(l)[pad:]
+    np.copyto(r, d, where=mask[::-1])
+
     # test all permutation of possible masks, 9 should be sufficient for
     # current 4 byte unrolled code
     power = 9


### PR DESCRIPTION
the new code did not account for them at all, add the old loops back but
keep the stride 1 optimization for sparse masks.
