### PR TITLE
BUG: Savetxt may ignore newline character on Windows:

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -878,8 +878,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         return X
 
 
-def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
-            footer='', comments='# '):
+def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=os.linesep,
+            header='', footer='', comments='# '):
     """
     Save an array to a text file.
 
@@ -1000,10 +1000,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             import gzip
             fh = gzip.open(fname, 'wb')
         else:
-            if sys.version_info[0] >= 3:
-                fh = open(fname, 'wb')
-            else:
-                fh = open(fname, 'w')
+            fh = open(fname, 'wb')
     elif hasattr(fname, 'write'):
         fh = fname
     else:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -427,6 +427,20 @@ class TestSaveTxt(TestCase):
         b = np.loadtxt(w)
         assert_array_equal(a, b)
 
+    def test_newline(self):
+        a = np.array([(1, 2, 3)], dtype=np.int)
+        a = a.reshape((3, 1))
+        for newline in ['\n', '\r\n', '\r']:
+            filename = mktemp()
+            np.savetxt(filename, a, fmt='%i', newline=newline)
+            b = np.loadtxt(filename)
+            assert_array_equal(a.flat, b)
+            f = open(filename, 'rb')
+            d = f.read()
+            f.close()
+            os.unlink(filename)
+            assert_equal(d, newline.join(['1', '2', '3', '']))
+
 
 class TestLoadTxt(TestCase):
     def test_record(self):


### PR DESCRIPTION
Under some circumstances savetxt ignores the newline character on Python 2.7 running on Windows:
If newline is set to '\n', actually '\n\r' is written, because of the linesep conversion of file.write.

Closes #3975.
