### PR TITLE
Backport 1.8 3978

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -950,7 +950,9 @@ def eigvalsh(a, UPLO='L'):
     array([ 0.17157288+0.j,  5.82842712+0.j])
 
     """
-    UPLO = asbytes(UPLO)
+    UPLO = asbytes(UPLO.upper())
+    if UPLO not in (b'L', b'U'):
+        raise ValueError("UPLO argument must be 'L' or 'U'")
 
     extobj = get_linalg_error_extobj(
         _raise_linalgerror_eigenvalues_nonconvergence)
@@ -1195,7 +1197,9 @@ def eigh(a, UPLO='L'):
             [ 0.00000000+0.38268343j,  0.00000000-0.92387953j]])
 
     """
-    UPLO = asbytes(UPLO)
+    UPLO = asbytes(UPLO.upper())
+    if UPLO not in (b'L', b'U'):
+        raise ValueError("UPLO argument must be 'L' or 'U'")
 
     a, wrap = _makearray(a)
     _assertRankAtLeast2(a)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -914,7 +914,7 @@ def eigvalsh(a, UPLO='L'):
         A complex- or real-valued matrix whose eigenvalues are to be
         computed.
     UPLO : {'L', 'U'}, optional
-        Same as `lower`, wth 'L' for lower and 'U' for upper triangular.
+        Same as `lower`, with 'L' for lower and 'U' for upper triangular.
         Deprecated.
 
     Returns
@@ -950,10 +950,11 @@ def eigvalsh(a, UPLO='L'):
     array([ 0.17157288+0.j,  5.82842712+0.j])
 
     """
+    UPLO = asbytes(UPLO)
 
     extobj = get_linalg_error_extobj(
         _raise_linalgerror_eigenvalues_nonconvergence)
-    if UPLO == 'L':
+    if UPLO == _L:
         gufunc = _umath_linalg.eigvalsh_lo
     else:
         gufunc = _umath_linalg.eigvalsh_up
@@ -1203,7 +1204,7 @@ def eigh(a, UPLO='L'):
 
     extobj = get_linalg_error_extobj(
         _raise_linalgerror_eigenvalues_nonconvergence)
-    if 'L' == UPLO:
+    if _L == UPLO:
         gufunc = _umath_linalg.eigh_lo
     else:
         gufunc = _umath_linalg.eigh_up

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -739,26 +739,52 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
         for dtype in [single, double, csingle, cdouble]:
             yield check, dtype
 
+    def test_invalid(self):
+        x = np.array([[1, 0.5], [0.5, 1]], dtype=np.float32)
+        assert_raises(ValueError, np.linalg.eigh, x, UPLO="lrong")
+        assert_raises(ValueError, np.linalg.eigh, x, "lower")
+        assert_raises(ValueError, np.linalg.eigh, x, "upper")
+        assert_raises(ValueError, np.linalg.eigvalsh, x, UPLO="lrong")
+        assert_raises(ValueError, np.linalg.eigvalsh, x, "lower")
+        assert_raises(ValueError, np.linalg.eigvalsh, x, "upper")
+
     def test_half_filled(self):
         expect = np.array([-0.33333333, -0.33333333, -0.33333333, 0.99999999])
         K = np.array([[ 0.        ,  0.        ,  0.        ,  0.        ],
-              [-0.33333333,  0.        ,  0.        ,  0.        ],
-              [ 0.33333333, -0.33333333,  0.        ,  0.        ],
-              [ 0.33333333, -0.33333333,  0.33333333,  0.        ]])
+                      [-0.33333333,  0.        ,  0.        ,  0.        ],
+                      [ 0.33333333, -0.33333333,  0.        ,  0.        ],
+                      [ 0.33333333, -0.33333333,  0.33333333,  0.        ]])
         Kr = np.rot90(K, k=2)
+
         w, V = np.linalg.eigh(K)
         assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+
         w, V = np.linalg.eigh(UPLO='L', a=K)
         assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        w, V = np.linalg.eigh(K, 'l')
+        w2, V2 = np.linalg.eigh(K, 'L')
+        assert_allclose(w, w2, rtol=get_rtol(K.dtype))
+        assert_allclose(V, V2, rtol=get_rtol(K.dtype))
+
         w, V = np.linalg.eigh(Kr, 'U')
         assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        w, V = np.linalg.eigh(Kr, 'u')
+        w2, V2 = np.linalg.eigh(Kr, 'u')
+        assert_allclose(w, w2, rtol=get_rtol(K.dtype))
+        assert_allclose(V, V2, rtol=get_rtol(K.dtype))
 
         w = np.linalg.eigvalsh(K)
         assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+
         w = np.linalg.eigvalsh(UPLO='L', a=K)
         assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        assert_allclose(np.linalg.eigvalsh(K, 'L'),
+                        np.linalg.eigvalsh(K, 'l'), rtol=get_rtol(K.dtype))
+
         w = np.linalg.eigvalsh(Kr, 'U')
         assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        assert_allclose(np.linalg.eigvalsh(Kr, 'U'),
+                        np.linalg.eigvalsh(Kr, 'u'), rtol=get_rtol(K.dtype))
 
 
 class _TestNorm(object):

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -728,7 +728,7 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
 
         assert_allclose(dot_generalized(a, evc2),
                         np.asarray(ev2)[...,None,:] * np.asarray(evc2),
-                        rtol=get_rtol(ev.dtype))
+                        rtol=get_rtol(ev.dtype), err_msg=repr(a))
 
     def test_types(self):
         def check(dtype):
@@ -738,6 +738,27 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
             assert_equal(v.dtype, dtype)
         for dtype in [single, double, csingle, cdouble]:
             yield check, dtype
+
+    def test_half_filled(self):
+        expect = np.array([-0.33333333, -0.33333333, -0.33333333, 0.99999999])
+        K = np.array([[ 0.        ,  0.        ,  0.        ,  0.        ],
+              [-0.33333333,  0.        ,  0.        ,  0.        ],
+              [ 0.33333333, -0.33333333,  0.        ,  0.        ],
+              [ 0.33333333, -0.33333333,  0.33333333,  0.        ]])
+        Kr = np.rot90(K, k=2)
+        w, V = np.linalg.eigh(K)
+        assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        w, V = np.linalg.eigh(UPLO='L', a=K)
+        assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        w, V = np.linalg.eigh(Kr, 'U')
+        assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+
+        w = np.linalg.eigvalsh(K)
+        assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        w = np.linalg.eigvalsh(UPLO='L', a=K)
+        assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
+        w = np.linalg.eigvalsh(Kr, 'U')
+        assert_allclose(np.sort(w), expect, rtol=get_rtol(K.dtype))
 
 
 class _TestNorm(object):


### PR DESCRIPTION
Backport #3978: `BUG: fix broken UPLO of eigh in python3`.
