### PR TITLE
ENH: add PrintOptions context manager to numpy.core.

### DIFF
--- a/doc/numpybook/runcode.py
+++ b/doc/numpybook/runcode.py
@@ -98,7 +98,7 @@ def runpycode(lyxstr, name='MyCode'):
     indx.append(len(lyxstr))
     edic = {}
     exec('from numpy import *', edic)
-    exec('set_printoptions(linewidth=65)', edic)
+    exec('PrintOptions(linewidth=65).apply()', edic)
     # indx now contains [st0,en0, ..., stN,enN]
     #  where stX is the start of code segment X
     #  and enX is the start of \layout MyCode for
@@ -113,7 +113,7 @@ def runpycode(lyxstr, name='MyCode'):
             if mat:
                 edic = {}
                 exec('from numpy import *', edic)
-                exec('set_printoptions(linewidth=65)', edic)
+                exec('PrintOptions(linewidth=65).apply()', edic)
         # now find the code in the code segment
         # endoutput will contain the index just past any output
         #  already present in the lyx string.

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -158,16 +158,13 @@ class PrintOptions(Mapping):
     ... suppress=False, threshold=1000, formatter=None).apply()
     """
     def __init__(self, **kwargs):
-        for key in kwargs:
+        overridden_options = {'formatter': None}
+        for key, value in kwargs.items():
             if key not in _printoptions:
                 raise ValueError(key + ' is an invalid printing option.')
-        # Remove having keys having None as a value...
-        kwargs = {k: v
-                  for k, v in kwargs.items()
-                  if v is not None}
-        # ...except 'formatter', which is always overridden.
-        kwargs.setdefault('formatter', None)
-        self.overridden_options = kwargs
+            if value is not None:
+                overridden_options[key] = value
+        self.overridden_options = overridden_options
         self.old_options = dict(_printoptions)
 
     def __enter__(self):

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -28,9 +28,9 @@ __all__ = ['newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
            'isfortran', 'empty_like', 'zeros_like', 'ones_like',
            'correlate', 'convolve', 'inner', 'dot', 'einsum', 'outer', 'vdot',
            'alterdot', 'restoredot', 'roll', 'rollaxis', 'cross', 'tensordot',
-           'array2string', 'get_printoptions', 'set_printoptions',
-           'array_repr', 'array_str', 'set_string_function',
-           'little_endian', 'require',
+           'array2string', 'PrintOptions', 'get_printoptions',
+           'set_printoptions', 'array_repr', 'array_str',
+           'set_string_function', 'little_endian', 'require',
            'fromiter', 'array_equal', 'array_equiv',
            'indices', 'fromfunction', 'isclose',
            'load', 'loads', 'isscalar', 'binary_repr', 'base_repr',
@@ -1523,7 +1523,8 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 
 #Use numarray's printing function
-from .arrayprint import array2string, get_printoptions, set_printoptions
+from .arrayprint import (PrintOptions, array2string, get_printoptions,
+                         set_printoptions)
 
 _typelessdata = [int_, float_, complex_]
 if issubclass(intc, int):
@@ -1545,7 +1546,7 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
         characters split the string appropriately after array elements.
     precision : int, optional
         Floating point precision. Default is the current printing precision
-        (usually 8), which can be altered using `set_printoptions`.
+        (usually 8), which can be altered using `PrintOptions`.
     suppress_small : bool, optional
         Represent very small numbers as zero, default is False. Very small
         is defined by `precision`, if the precision is 8 then
@@ -1558,7 +1559,7 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
 
     See Also
     --------
-    array_str, array2string, set_printoptions
+    array_str, array2string, PrintOptions
 
     Examples
     --------
@@ -1621,7 +1622,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
         default is, indirectly, 75.
     precision : int, optional
         Floating point precision.  Default is the current printing precision
-        (usually 8), which can be altered using `set_printoptions`.
+        (usually 8), which can be altered using `PrintOptions`.
     suppress_small : bool, optional
         Represent numbers "very close" to zero as zero; default is False.
         Very close is defined by precision: if the precision is 8, e.g.,
@@ -1630,7 +1631,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
 
     See Also
     --------
-    array2string, array_repr, set_printoptions
+    array2string, array_repr, PrintOptions
 
     Examples
     --------
@@ -1658,7 +1659,7 @@ def set_string_function(f, repr=True):
 
     See Also
     --------
-    set_printoptions, get_printoptions
+    PrintOptions
 
     Examples
     --------

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -112,45 +112,39 @@ class TestArray2String(TestCase):
 
 class TestPrintOptions:
     """Test getting and setting global print options."""
-    def setUp(self):
-        self.oldopts = np.get_printoptions()
-
-    def tearDown(self):
-        np.set_printoptions(**self.oldopts)
-
     def test_basic(self):
         x = np.array([1.5, 0, 1.234567890])
         assert_equal(repr(x), "array([ 1.5       ,  0.        ,  1.23456789])")
-        np.set_printoptions(precision=4)
-        assert_equal(repr(x), "array([ 1.5   ,  0.    ,  1.2346])")
+        with np.PrintOptions(precision=4):
+            assert_equal(repr(x), "array([ 1.5   ,  0.    ,  1.2346])")
 
     def test_formatter(self):
         x = np.arange(3)
-        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
-        assert_equal(repr(x), "array([-1, 0, 1])")
+        with np.PrintOptions(formatter={'all':lambda x: str(x-1)}):
+            assert_equal(repr(x), "array([-1, 0, 1])")
 
     def test_formatter_reset(self):
         x = np.arange(3)
-        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
-        assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={'int':None})
-        assert_equal(repr(x), "array([0, 1, 2])")
+        with np.PrintOptions(formatter={'all':lambda x: str(x-1)}):
+            assert_equal(repr(x), "array([-1, 0, 1])")
+        with np.PrintOptions(formatter={'int':None}):
+            assert_equal(repr(x), "array([0, 1, 2])")
 
-        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
-        assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={'all':None})
-        assert_equal(repr(x), "array([0, 1, 2])")
+        with np.PrintOptions(formatter={'all':lambda x: str(x-1)}):
+            assert_equal(repr(x), "array([-1, 0, 1])")
+        with np.PrintOptions(formatter={'all':None}):
+            assert_equal(repr(x), "array([0, 1, 2])")
 
-        np.set_printoptions(formatter={'int':lambda x: str(x-1)})
-        assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={'int_kind':None})
-        assert_equal(repr(x), "array([0, 1, 2])")
+        with np.PrintOptions(formatter={'int':lambda x: str(x-1)}):
+            assert_equal(repr(x), "array([-1, 0, 1])")
+        with np.PrintOptions(formatter={'int_kind':None}):
+            assert_equal(repr(x), "array([0, 1, 2])")
 
         x = np.arange(3.)
-        np.set_printoptions(formatter={'float':lambda x: str(x-1)})
-        assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
-        np.set_printoptions(formatter={'float_kind':None})
-        assert_equal(repr(x), "array([ 0.,  1.,  2.])")
+        with np.PrintOptions(formatter={'float':lambda x: str(x-1)}):
+            assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
+        with np.PrintOptions(formatter={'float_kind':None}):
+            assert_equal(repr(x), "array([ 0.,  1.,  2.])")
 
 def test_unicode_object_array():
     import sys

--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -291,7 +291,7 @@ def log10(x):
 
     (We set the printing precision so the example can be auto-tested)
 
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.emath.log10(10**1)
     1.0
@@ -325,7 +325,7 @@ def logn(n, x):
 
     Examples
     --------
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.lib.scimath.logn(2, [4, 8])
     array([ 2.,  3.])
@@ -372,7 +372,7 @@ def log2(x):
     --------
     We set the printing precision so the example can be auto-tested:
 
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.emath.log2(8)
     3.0
@@ -412,7 +412,7 @@ def power(x, p):
 
     Examples
     --------
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.lib.scimath.power([2, 4], 2)
     array([ 4, 16])
@@ -457,7 +457,7 @@ def arccos(x):
 
     Examples
     --------
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.emath.arccos(1) # a scalar is returned
     0.0
@@ -501,7 +501,7 @@ def arcsin(x):
 
     Examples
     --------
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.emath.arcsin(0)
     0.0
@@ -547,7 +547,7 @@ def arctanh(x):
 
     Examples
     --------
-    >>> np.set_printoptions(precision=4)
+    >>> np.PrintOptions(precision=4).apply()
 
     >>> np.emath.arctanh(np.matrix(np.eye(2)))
     array([[ Inf,   0.],

--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -155,7 +155,7 @@ class NumpyDocTestCase(npd.DocTestCase):
                                      checker=checker)
 
 
-print_state = numpy.get_printoptions()
+_print_state = numpy.PrintOptions()
 
 class NumpyDoctest(npd.Doctest):
     name = 'numpydoctest'   # call nosetests with --with-numpydoctest
@@ -264,10 +264,10 @@ class NumpyDoctest(npd.Doctest):
                                           checker=self.out_check_class(),
                                           result_var=self.doctest_result_var)
 
-    # Add an afterContext method to nose.plugins.doctests.Doctest in order
-    # to restore print options to the original state after each doctest
+    # Override afterContext from nose.plugins.doctests.Doctest in order to
+    # restore printing options to their original state after each doctest
     def afterContext(self):
-        numpy.set_printoptions(**print_state)
+        numpy.PrintOptions(**_print_state).apply()
 
     # Ignore NumPy-specific build files that shouldn't be searched for tests
     def wantFile(self, file):


### PR DESCRIPTION
Instantiating `PrintOptions` returns an object that is both:
- a context manager for setting printing options, and
- a Mapping exposing the current printing options.

Instead of using a `PrintOptions` object as a context manager, the
`apply` method can be called, which will apply the options
specified in the constructor.  If the formatter printing option is not
specified, it is reset.

Printing options determine the way floating point numbers, arrays
and other NumPy objects are displayed.
