### PR TITLE
BUG: hypot(inf, 0) shouldn't raise a warning

### DIFF
--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -183,13 +183,12 @@ double npy_hypot(double x, double y)
 {
     double yx;
 
-    /* Handle the case where x or y is a NaN */
-    if (npy_isnan(x * y)) {
-        if (npy_isinf(x) || npy_isinf(y)) {
-            return NPY_INFINITY;
-        } else {
-            return NPY_NAN;
-        }
+    if (npy_isinf(x) || npy_isinf(y)) {
+        return NPY_INFINITY;
+    }
+
+    if (npy_isnan(x) || npy_isnan(y)) {
+        return NPY_NAN;
     }
 
     x = npy_fabs(x);

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -340,6 +340,11 @@ class TestHypotSpecialValues(TestCase):
         assert_hypot_isinf(np.inf, np.nan)
         assert_hypot_isinf(np.inf, 0)
         assert_hypot_isinf(0, np.inf)
+        assert_hypot_isinf(np.inf, np.inf)
+        assert_hypot_isinf(np.inf, 23.0)
+
+    def test_no_fpe(self):
+        assert_no_warnings(ncu.hypot, np.inf, 0)
 
 
 def assert_arctan2_isnan(x, y):


### PR DESCRIPTION
inf \* 0 == nan, but raises invalid.  Don't do anything really, until we
have dealt with the infs and/or nans.  This only effected windows or
where ever else we use our own implmentation.

Fixes gh-2385

Tested on windows using MSVC.
