### PR TITLE
Allow checking two or more fortran compilers instead of one.

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -817,7 +817,7 @@ def get_default_fcompiler(osname=None, platform=None, requiref90=False,
     return compiler_type
 
 # Flag to avoid rechecking for Fortran compiler every time
-failed_fcompiler = False
+failed_fcompilers = set()
 
 def new_fcompiler(plat=None,
                   compiler=None,
@@ -829,8 +829,9 @@ def new_fcompiler(plat=None,
     """Generate an instance of some FCompiler subclass for the supplied
     platform/compiler combination.
     """
-    global failed_fcompiler
-    if failed_fcompiler:
+    global failed_fcompilers
+    fcompiler_key = (plat, compiler)
+    if fcompiler_key in failed_fcompilers:
         return None
 
     load_all_fcompiler_classes()
@@ -850,7 +851,7 @@ def new_fcompiler(plat=None,
             msg = msg + " Supported compilers are: %s)" \
                   % (','.join(fcompiler_class.keys()))
         log.warn(msg)
-        failed_fcompiler = True
+        failed_fcompilers.add(fcompiler_key)
         return None
 
     compiler = klass(verbose=verbose, dry_run=dry_run, force=force)


### PR DESCRIPTION
See https://trac.macports.org/ticket/40824
