### PR TITLE
Improve MinGW-w64 compatibility on 64-bit Windows.

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -24,7 +24,7 @@ def is_win64():
 
 if is_win64():
     #_EXTRAFLAGS = ["-fno-leading-underscore"]
-    _EXTRAFLAGS = []
+    _EXTRAFLAGS = ['-fno-stack-check', '-fno-stack-protector', '-mno-stack-arg-probe']
 else:
     _EXTRAFLAGS = []
 
@@ -328,7 +328,7 @@ class Gnu95FCompiler(GnuFCompiler):
             if is_win64():
                 c_compiler = self.c_compiler
                 if c_compiler and c_compiler.compiler_type == "msvc":
-                    return []
+                    return ['gfortran.dll']
                 else:
                     raise NotImplementedError("Only MS compiler supported with gfortran on win64")
         return opt

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -24,7 +24,9 @@ def is_win64():
 
 if is_win64():
     #_EXTRAFLAGS = ["-fno-leading-underscore"]
-    _EXTRAFLAGS = ['-fno-stack-check', '-fno-stack-protector', '-mno-stack-arg-probe']
+    _EXTRAFLAGS = ['-fno-stack-check',
+                   '-fno-stack-protector',
+                   '-mno-stack-arg-probe']
 else:
     _EXTRAFLAGS = []
 


### PR DESCRIPTION
- encountered missing symbol (from gfortran.dll) problems when installing scipy; this seems to fix them
- the "gfortran.dll" in get_libraries will trigger linking to libgfortran.dll.a in mingw-builds\x64-4.8.1-posix-seh-rev5\mingw64\lib\gcc\x86_64-w64-mingw32\4.8.1\ which I think is the static IMPORT library for libgfortran-3.dll from mingw-builds\x64-4.8.1-posix-seh-rev5\mingw64\bin\
- if we instead link to the static version (i.e. by replacing 'gfortran.dll' by 'gfortran' in gnu,py, thus linking with libgfortran.a instead of libgfortran.dll.a) we'll also have to import for some packages (like scipy.integrate.quadpack) other runtime libraries like mingwex, gcc, gcc_s and, most importantly to mingw32, which contains symbols that conflict with msvcrt
