### PR TITLE
Chunked reading fails when dtype.itemsize is larger than buffer size.

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -464,7 +464,7 @@ def read_array(fp):
             # non-chunked case count < max_read_count, so only one read is
             # performed.
 
-            max_read_count = BUFFER_SIZE // dtype.itemsize
+            max_read_count = BUFFER_SIZE // min(BUFFER_SIZE, dtype.itemsize)
 
             array = numpy.empty(count, dtype=dtype)
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -428,6 +428,9 @@ def test_roundtrip():
         arr2 = roundtrip(arr)
         yield assert_array_equal, arr, arr2
 
+def test_long_str():
+    long_str_arr = np.empty(10, dtype='S279291')
+    long_str_arr2 = roundtrip(long_str_arr)
 
 @dec.slow
 def test_memmap_roundtrip():

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -429,7 +429,7 @@ def test_roundtrip():
         yield assert_array_equal, arr, arr2
 
 def test_long_str():
-    long_str_arr = np.empty(10, dtype='S279291')
+    long_str_arr = np.ones(1, dtype=np.dtype((str, format.BUFFER_SIZE+1)))
     long_str_arr2 = roundtrip(long_str_arr)
 
 @dec.slow


### PR DESCRIPTION
When reading file in chunks, buffer_size < dtype.itemsize, ensure at least one read.

The tests pass.
