### PR TITLE
Sequence assignment doesn't raise exception on shape mismatch

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -412,7 +412,7 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
                         int dim, PyArrayObject * dst)
 {
     Py_ssize_t i, slen;
-    int res = 0;
+    int res = -1;
 
     /* first recursion, view equal destination */
     if (dst == NULL)

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1922,5 +1922,12 @@ class TestRegression(TestCase):
                           [sixu('F'), sixu('o'), sixu('o'), sixu('b'), sixu('')]]])
         assert_array_equal(arr, arr2)
 
+    def test_assign_from_sequence_error(self):
+        # Ticket #4024.
+        arr = np.array([1, 2, 3])
+        assert_raises(ValueError, arr.__setitem__, slice(None), [9, 9])
+        arr.__setitem__(slice(None), [9])
+        assert_equal(arr, [9, 9, 9])
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
To reproduce:

``` python
>>> import numpy
>>> a = numpy.array([1,2,3])
>>> a[:] = [9,9]
>>> 'hello!'
ValueError: cannot copy sequence with size 2 to array axis with dimension 3
```

Note that the exception is not raised from the faulty assignment, but lingers and strikes completely unrelated statement.

This, of course, is the sign that the exception was set, but an error indicator was not returned. This is the result of this change 2b05fadefd18f2206b11a548fc44d783898ec366, which is frankly shocking. I suggest the change is reverted and some tests are added.
