### PR TITLE
Backport 1.8 4022 3996

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -817,7 +817,7 @@ def get_default_fcompiler(osname=None, platform=None, requiref90=False,
     return compiler_type
 
 # Flag to avoid rechecking for Fortran compiler every time
-failed_fcompiler = False
+failed_fcompilers = set()
 
 def new_fcompiler(plat=None,
                   compiler=None,
@@ -829,8 +829,9 @@ def new_fcompiler(plat=None,
     """Generate an instance of some FCompiler subclass for the supplied
     platform/compiler combination.
     """
-    global failed_fcompiler
-    if failed_fcompiler:
+    global failed_fcompilers
+    fcompiler_key = (plat, compiler)
+    if fcompiler_key in failed_fcompilers:
         return None
 
     load_all_fcompiler_classes()
@@ -850,7 +851,7 @@ def new_fcompiler(plat=None,
             msg = msg + " Supported compilers are: %s)" \
                   % (','.join(fcompiler_class.keys()))
         log.warn(msg)
-        failed_fcompiler = True
+        failed_fcompilers.add(fcompiler_key)
         return None
 
     compiler = klass(verbose=verbose, dry_run=dry_run, force=force)

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -271,7 +271,7 @@ def get_standard_file(fname):
     # Home directory
     # And look for the user config file
     try:
-        f = os.environ['HOME']
+        f = os.path.expanduser('~')
     except KeyError:
         pass
     else:


### PR DESCRIPTION
Backport #3996: `Allow checking two or more fortran compilers instead of one.`
Backport #4022: `cross-platform code to find numpy config`
