### PR TITLE
Example to convert the type of an array using the astype method and minor typo fix

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -42,8 +42,11 @@ Additional PEPs of interest regarding documentation of code:
 
 Use a code checker:
  * `pylint <http://www.logilab.org/857>`_
- * `pyflakes` easy_install pyflakes
+ * `pyflakes <https://pypi.python.org/pypi/pyflakes>`_
  * `pep8.py <http://svn.browsershots.org/trunk/devtools/pep8/pep8.py>`_
+ * `flake8 <https://pypi.python.org/pypi/flake8>`_
+ * `vim-flake8 <https://github.com/nvie/vim-flake8>`_ plugin for
+   automatically checking syntax and style with flake8
 
 The following import conventions are used throughout the NumPy source
 and documentation::
@@ -260,7 +263,7 @@ The sections of the docstring are:
      LinAlgException
          If the matrix is not numerically invertible.
 
-   This section should be used judiciously, i.e only for errors
+   This section should be used judiciously, i.e., only for errors
    that are non-obvious or have a large chance of getting raised.
 
 8. **See Also**

--- a/numpy/doc/byteswapping.py
+++ b/numpy/doc/byteswapping.py
@@ -134,5 +134,14 @@ the previous operations:
 >>> swapped_end_arr.tostring() == big_end_str
 False
 
+An easier way of casting the data to a specific dtype and byte ordering
+can be achieved with the ndarray astype method:
+
+>>> swapped_end_arr = big_end_arr.astype('<i2')
+>>> swapped_end_arr[0]
+1
+>>> swapped_end_arr.tostring() == big_end_str
+False
+
 """
 from __future__ import division, absolute_import, print_function


### PR DESCRIPTION
A short example is added about changing the type of an array using the `astype` method in the byteswapping section of the manual as suggested in this thread: https://github.com/scipy/scipy/issues/2643#issuecomment-28159861
