### PR TITLE
DEP: non-integer scalar python sequence repeat

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -81,6 +81,11 @@ None
 Deprecations
 ============
 
+Non-integer scalars for sequence repetition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using non-integer numpy scalars to repeat python sequences is deprecated.
+For example `np.float_(2) * [1]` will be an error in the future.
+
 C-API
 ~~~~~
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -246,27 +246,28 @@ static PyObject *
 gentype_multiply(PyObject *m1, PyObject *m2)
 {
     PyObject *ret = NULL;
-    long repeat;
+    npy_intp repeat;
 
     if (!PyArray_IsScalar(m1, Generic) &&
             ((Py_TYPE(m1)->tp_as_number == NULL) ||
              (Py_TYPE(m1)->tp_as_number->nb_multiply == NULL))) {
         /* Try to convert m2 to an int and try sequence repeat */
-        repeat = PyInt_AsLong(m2);
+        repeat = PyArray_PyIntAsIntp(m2);
         if (repeat == -1 && PyErr_Occurred()) {
             return NULL;
         }
-        ret = PySequence_Repeat(m1, (int) repeat);
+        /* Note that npy_intp is compatible to Py_Ssize_t */
+        ret = PySequence_Repeat(m1, repeat);
     }
     else if (!PyArray_IsScalar(m2, Generic) &&
             ((Py_TYPE(m2)->tp_as_number == NULL) ||
              (Py_TYPE(m2)->tp_as_number->nb_multiply == NULL))) {
         /* Try to convert m1 to an int and try sequence repeat */
-        repeat = PyInt_AsLong(m1);
+        repeat = PyArray_PyIntAsIntp(m1);
         if (repeat == -1 && PyErr_Occurred()) {
             return NULL;
         }
-        ret = PySequence_Repeat(m2, (int) repeat);
+        ret = PySequence_Repeat(m2, repeat);
     }
     if (ret == NULL) {
         PyErr_Clear(); /* no effect if not set */

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -241,6 +241,14 @@ class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
         self.assert_deprecated(np.take, args=(a, [0], np.float64(1.)))
 
 
+    def test_non_integer_sequence_multiplication(self):
+        # Numpy scalar sequence multiply should not work with non-integers
+        def mult(a, b):
+            return a * b
+        self.assert_deprecated(mult, args=([1], np.float_(3)))
+        self.assert_not_deprecated(mult, args=([1], np.int_(3)))
+
+
 class TestBooleanArgumentDeprecation(_DeprecationTestCase):
     """This tests that using a boolean as integer argument/indexing is
     deprecated.


### PR DESCRIPTION
This starts deprecation for code such as
np.float_(3.4) \* [1, 2]
which should only work for integer objects. It may be possible
to just return NotImplemented since at least python sequences
implement their multiply themself through **index**.

Further action is only needed for PyArray_PyIntAsIntp, so this
is part of a larger deprecation now.

Closes gh-4036
