### PR TITLE
ENH: ma.asarray() and ma.asanyarray() will pass through input of the cor...

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6987,6 +6987,8 @@ def asarray(a, dtype=None, order=None):
     <class 'numpy.ma.core.MaskedArray'>
 
     """
+    if dtype is None and type(a) is MaskedArray:
+        return a
     return masked_array(a, dtype=dtype, copy=False, keep_mask=True, subok=False)
 
 def asanyarray(a, dtype=None):
@@ -7032,6 +7034,8 @@ def asanyarray(a, dtype=None):
     <class 'numpy.ma.core.MaskedArray'>
 
     """
+    if dtype is None and isinstance(a, MaskedArray):
+        return a
     return masked_array(a, dtype=dtype, copy=False, keep_mask=True, subok=True)
 
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -842,9 +842,9 @@ def mask_rowcols(a, axis=None):
           fill_value=999999)
 
     """
-    a = asarray(a)
+    a = array(a, subok=False)
     if a.ndim != 2:
-        raise NotImplementedError("compress2d works for 2D arrays only.")
+        raise NotImplementedError("mask_rowcols works for 2D arrays only.")
     m = getmask(a)
     # Nothing is masked: return a
     if m is nomask or not m.any():

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -184,11 +184,24 @@ class TestMaskedArray(TestCase):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         xm.fill_value = -9999
         xm._hardmask = True
-        xmm = asarray(xm)
+        xmm = asarray(xm, xm.dtype)
         assert_equal(xmm._data, xm._data)
         assert_equal(xmm._mask, xm._mask)
         assert_equal(xmm.fill_value, xm.fill_value)
         assert_equal(xmm._hardmask, xm._hardmask)
+        # address gh-4043
+        self.assertTrue(xm is asarray(xm))
+
+    def test_asanyarray(self):
+        class M(MaskedArray):
+            pass
+        xm = M([])
+        self.assertTrue(xm is not asarray(xm))
+        # address gh-4043
+        self.assertTrue(xm is asanyarray(xm))
+        test = asanyarray(xm, np.int64)
+        self.assertTrue(isinstance(test, M))
+        assert_equal(test.dtype, np.int64)
 
     def test_fix_invalid(self):
         # Checks fix_invalid.


### PR DESCRIPTION
...rect type.

If x is of type MaskedArray for ma.asarray(x) or any subtype of
MaskedArray for ma.asanyarray(x), these functions will simply return x.
This makes them consistent with their numpy counterparts.

Closes gh-4043.
