### PR TITLE
fix two uninitialized uses reported with valgrind

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -884,7 +884,7 @@ _strided_to_strided_string_to_datetime(char *dst, npy_intp dst_stride,
                         NpyAuxData *data)
 {
     _strided_datetime_cast_data *d = (_strided_datetime_cast_data *)data;
-    npy_int64 dt;
+    npy_int64 dt = ~NPY_DATETIME_NAT;
     npy_datetimestruct dts;
     char *tmp_buffer = d->tmp_buffer;
     char *tmp;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4952,7 +4952,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     PyUFuncGenericFunction innerloop;
     void *innerloopdata;
-    npy_intp count[1], stride[1];
     int i;
     int nop;
 
@@ -5056,9 +5055,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         goto fail;
     }
 
-    count[0] = 1;
-    stride[0] = 1;
-
     Py_INCREF(PyArray_DESCR(op1_array));
     array_operands[0] = new_array_op(op1_array, iter->dataptr);
     if (iter2 != NULL) {
@@ -5144,6 +5140,9 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     {
         char *dataptr[3];
         char **buffer_dataptr;
+        /* one element at a time, no stride required but read by innerloop */
+        npy_intp count[3] = {1, 0xDEADBEEF, 0xDEADBEEF};
+        npy_intp stride[3] = {0xDEADBEEF, 0xDEADBEEF, 0xDEADBEEF};
 
         /*
          * Set up data pointers for either one or two input operands.


### PR DESCRIPTION
the one in ufunc.at is a false positive as the content of the uninitialized memory doesn't matter
the datetime one is a real bug, but triggering it is very unlikely
