### PR TITLE
MAINT: make NPY_CPU_HAVE_UNALIGNED_ACCESS a numeric macro

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -109,7 +109,9 @@
 #endif
 
 #if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
-#define NPY_CPU_HAVE_UNALIGNED_ACCESS
+#define NPY_CPU_HAVE_UNALIGNED_ACCESS 1
+#else
+#define NPY_CPU_HAVE_UNALIGNED_ACCESS 0
 #endif
 
 #endif

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -140,8 +140,7 @@ npy_memchr(char * haystack, char needle,
     }
     else {
         /* usually find elements to skip path */
-#if defined NPY_CPU_HAVE_UNALIGNED_ACCESS
-        if (needle == 0 && stride == 1) {
+        if (NPY_CPU_HAVE_UNALIGNED_ACCESS && needle == 0 && stride == 1) {
             /* iterate until last multiple of 4 */
             char * block_end = haystack + size - (size % sizeof(unsigned int));
             while (p < block_end) {
@@ -154,7 +153,6 @@ npy_memchr(char * haystack, char needle,
             /* handle rest */
             subloopsize = (p - haystack);
         }
-#endif
         while (subloopsize < size && *p == needle) {
             subloopsize++;
             p += stride;

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -39,7 +39,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#ifdef NPY_CPU_HAVE_UNALIGNED_ACCESS
+#if NPY_CPU_HAVE_UNALIGNED_ACCESS
 #  define NPY_USE_UNALIGNED_ACCESS 0
 #else
 #  define NPY_USE_UNALIGNED_ACCESS 0


### PR DESCRIPTION
allows using it in if statements like for count_nonzero
also fix a compiler warning by casting
