### PR TITLE
ENH: intern some commonly used strings in umath module

### DIFF
--- a/numpy/core/src/umath/ufunc_object.h
+++ b/numpy/core/src/umath/ufunc_object.h
@@ -7,4 +7,13 @@ ufunc_geterr(PyObject *NPY_UNUSED(dummy), PyObject *args);
 NPY_NO_EXPORT PyObject *
 ufunc_seterr(PyObject *NPY_UNUSED(dummy), PyObject *args);
 
+/* interned strings (on umath import) */
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_out;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_subok;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_array_prepare;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_array_wrap;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_array_finalize;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_ufunc;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_pyvals_name;
+
 #endif

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -27,6 +27,7 @@
 
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
+#include "numpy/npy_3kcompat.h"
 #include "abstract.h"
 
 #include "numpy/npy_math.h"
@@ -293,6 +294,30 @@ InitOtherOperators(PyObject *dictionary) {
     return;
 }
 
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_out = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_subok = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_array_prepare = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_array_wrap = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_array_finalize = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_ufunc = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_pyvals_name = NULL;
+
+/* intern some strings used in ufuncs */
+static int
+intern_strings(void)
+{
+    npy_um_str_out = PyUString_FromString("out");
+    npy_um_str_subok = PyUString_FromString("subok");
+    npy_um_str_array_prepare = PyUString_FromString("__array_prepare__");
+    npy_um_str_array_wrap = PyUString_FromString("__array_wrap__");
+    npy_um_str_array_finalize = PyUString_FromString("__array_finalize__");
+    npy_um_str_ufunc = PyUString_FromString("__numpy_ufunc__");
+    npy_um_str_pyvals_name = PyUString_FromString(UFUNC_PYVALS_NAME);
+
+    return npy_um_str_out && npy_um_str_subok && npy_um_str_array_prepare &&
+        npy_um_str_array_wrap && npy_um_str_array_finalize && npy_um_str_ufunc;
+}
+
 /* Setup the umath module */
 /* Remove for time being, it is declared in __ufunc_api.h */
 /*static PyTypeObject PyUFunc_Type;*/
@@ -436,6 +461,10 @@ PyMODINIT_FUNC initumath(void)
 
     PyDict_SetItemString(d, "conj", s);
     PyDict_SetItemString(d, "mod", s2);
+
+    if (!intern_strings()) {
+        goto err;
+    }
 
     return RETVAL;
 


### PR DESCRIPTION
Allows using the PyObject dictionary functions instead of the costly
C-string variants.

Make use of this in some of the ufunc subtype wrapper functions.

Improvement:

```
a, b = np.arange(200.), np.arange(200.)
%timeit np.add(a, b, out=a)
1000000 loops, best of 3: 768 ns per loop
```

vs before:

```
%timeit np.add(a, b, out=a)
1000000 loops, best of 3: 1.03 µs per loop
```
