### PR TITLE
Minor C fixes

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1269,11 +1269,12 @@ NPY_NO_EXPORT PyObject *
 array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
 {
     PyArrayObject *array_other;
+    PyObject *obj_self = (PyObject *)self;
     PyObject *result = NULL;
 
     switch (cmp_op) {
     case Py_LT:
-        if (needs_right_binop_forward(self, other, "__gt__", 0)) {
+        if (needs_right_binop_forward(obj_self, other, "__gt__", 0)) {
             /* See discussion in number.c */
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
@@ -1282,7 +1283,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 n_ops.less);
         break;
     case Py_LE:
-        if (needs_right_binop_forward(self, other, "__ge__", 0)) {
+        if (needs_right_binop_forward(obj_self, other, "__ge__", 0)) {
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }
@@ -1294,7 +1295,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_False);
             return Py_False;
         }
-        if (needs_right_binop_forward(self, other, "__eq__", 0)) {
+        if (needs_right_binop_forward(obj_self, other, "__eq__", 0)) {
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }
@@ -1356,7 +1357,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_True);
             return Py_True;
         }
-        if (needs_right_binop_forward(self, other, "__ne__", 0)) {
+        if (needs_right_binop_forward(obj_self, other, "__ne__", 0)) {
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }
@@ -1409,7 +1410,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         }
         break;
     case Py_GT:
-        if (needs_right_binop_forward(self, other, "__lt__", 0)) {
+        if (needs_right_binop_forward(obj_self, other, "__lt__", 0)) {
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }
@@ -1417,7 +1418,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 n_ops.greater);
         break;
     case Py_GE:
-        if (needs_right_binop_forward(self, other, "__le__", 0)) {
+        if (needs_right_binop_forward(obj_self, other, "__le__", 0)) {
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
         }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -140,7 +140,6 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
     PyArray_Descr *dtype = NULL;
     int ndim = 0;
     npy_intp dims[NPY_MAXDIMS];
-    PyObject *list = NULL;
     int result;
 
     if (*flex_dtype == NULL) {
@@ -224,12 +223,14 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                     if ((flex_type_num == NPY_STRING ||
                             flex_type_num == NPY_UNICODE) &&
                             data_obj != NULL) {
+                        PyObject *list;
+
                         if (PyArray_CheckScalar(data_obj)) {
-                            PyObject *scalar = PyArray_ToList(data_obj);
-                            if (scalar != NULL) {
-                                PyObject *s = PyObject_Str(scalar);
+                            list = PyArray_ToList((PyArrayObject *)data_obj);
+                            if (list != NULL) {
+                                PyObject *s = PyObject_Str(list);
                                 if (s == NULL) {
-                                    Py_DECREF(scalar);
+                                    Py_DECREF(list);
                                     Py_DECREF(*flex_dtype);
                                     *flex_dtype = NULL;
                                     return;
@@ -238,7 +239,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                                     size = PyObject_Length(s);
                                     Py_DECREF(s);
                                 }
-                                Py_DECREF(scalar);
+                                Py_DECREF(list);
                             }
                         }
                         else if (PyArray_Check(data_obj)) {
@@ -247,7 +248,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                              * GetArrayParamsFromObject won't iterate over
                              * array.
                              */
-                            list = PyArray_ToList(data_obj);
+                            list = PyArray_ToList((PyArrayObject *)data_obj);
                             result = PyArray_GetArrayParamsFromObject(
                                     list,
                                     *flex_dtype,

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -115,7 +115,7 @@ has_ufunc_attr(PyObject * obj) {
 
 NPY_NO_EXPORT int
 needs_right_binop_forward(PyObject *self, PyObject *other,
-                          char *right_name, int inplace_op)
+                          const char *right_name, int inplace_op)
 {
     if (other == NULL ||
         self == NULL ||
@@ -127,7 +127,7 @@ needs_right_binop_forward(PyObject *self, PyObject *other,
          */
         return 0;
     }
-    if (!inplace_op && PyType_IsSubtype(Py_TYPE(other), Py_TYPE(self)) ||
+    if ((!inplace_op && PyType_IsSubtype(Py_TYPE(other), Py_TYPE(self))) ||
         !PyArray_Check(self)) {
         /*
          * Bail out if Python would already have called the right-hand
@@ -146,7 +146,8 @@ needs_right_binop_forward(PyObject *self, PyObject *other,
 
 #define GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, left_name, right_name, inplace)  \
     do {                                                                \
-        if (needs_right_binop_forward(m1, m2, right_name, inplace)) {   \
+        if (needs_right_binop_forward((PyObject *)m1, m2, right_name,   \
+                                      inplace)) {                       \
             Py_INCREF(Py_NotImplemented);                               \
             return Py_NotImplemented;                                   \
         }                                                               \

--- a/numpy/core/src/multiarray/number.h
+++ b/numpy/core/src/multiarray/number.h
@@ -70,7 +70,7 @@ PyArray_GenericAccumulateFunction(PyArrayObject *m1, PyObject *op, int axis,
                                   int rtype, PyArrayObject *out);
 
 NPY_NO_EXPORT int
-needs_right_binop_forward(PyObject *self, PyObject *other, char *right_name,
-                          int is_inplace);
+needs_right_binop_forward(PyObject *self, PyObject *other,
+                          const char *right_name, int is_inplace);
 
 #endif

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -846,7 +846,6 @@ npyrational_compare(const void* d0, const void* d1, void* arr) {
         data = (rational*)data_; \
         best_i = 0; \
         best_r = data[0]; \
-        i; \
         for (i = 1; i < n; i++) { \
             if (rational_##op(data[i],best_r)) { \
                 best_i = i; \


### PR DESCRIPTION
These two commits get rid of a _lot_ of compiler warnings, especially from `numbers.c`.
