### PR TITLE
explain character codes of dtype.kind

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -220,16 +220,20 @@ One-character strings
 Array-protocol type strings (see :ref:`arrays.interface`)
 
    The first character specifies the kind of data and the remaining
-   characters specify how many bytes of data. The supported kinds are
+   characters specify the number of bytes per item.  The item size may
+   be ignored for some kinds (i.e., boolean, object), rounded to the
+   next supported size (float, complex), or interpreted as the number
+   of characters (Unicode).  The supported kinds are
 
    ================   ========================
-   ``'b'``            Boolean
+   ``'b'``            boolean
    ``'i'``            (signed) integer
    ``'u'``            unsigned integer
    ``'f'``            floating-point
    ``'c'``            complex-floating point
-   ``'S'``, ``'a'``   string
-   ``'U'``            unicode
+   ``'O'``            (Python) objects
+   ``'S'``, ``'a'``   (byte-)string
+   ``'U'``            Unicode
    ``'V'``            raw data (:class:`void`)
    ================   ========================
 

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -1119,8 +1119,8 @@ PyArrayInterface
        A character indicating what kind of array is present according to the
        typestring convention with 't' -> bitfield, 'b' -> Boolean, 'i' ->
        signed integer, 'u' -> unsigned integer, 'f' -> floating point, 'c' ->
-       complex floating point, 'O' -> object, 'S' -> string, 'U' -> unicode,
-       'V' -> void.
+       complex floating point, 'O' -> object, 'S' -> (byte-)string, 'U' ->
+       unicode, 'V' -> void.
 
    .. cmember:: int PyArrayInterface.itemsize
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -6118,7 +6118,19 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('itemsize',
 
 add_newdoc('numpy.core.multiarray', 'dtype', ('kind',
     """
-    A character code (one of 'biufcSUV') identifying the general kind of data.
+    A character code (one of 'biufcOSUV') identifying the general kind of data.
+
+    =  ======================
+    b  boolean
+    i  signed integer
+    u  unsigned integer
+    f  floating-point
+    c  complex floating-point
+    O  object
+    S  (byte-)string
+    U  Unicode
+    V  void
+    =  ======================
 
     """))
 


### PR DESCRIPTION
"one of 'biufcSUV'" is not very helpful if it stands alone,
also the 'O' typecode was missing.
