### PR TITLE
DOC: Link convolve with polymul

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -941,6 +941,8 @@ def convolve(a,v,mode='full'):
     scipy.signal.fftconvolve : Convolve two arrays using the Fast Fourier
                                Transform.
     scipy.linalg.toeplitz : Used to construct the convolution operator.
+    polymul : Polynomial multiplication. Same output as convolve, but also
+              accepts poly1d objects as input.
 
     Notes
     -----

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -806,6 +806,8 @@ def polymul(a1, a2):
     poly1d : A one-dimensional polynomial class.
     poly, polyadd, polyder, polydiv, polyfit, polyint, polysub,
     polyval
+    convolve : Array convolution. Same output as polymul, but has parameter
+               for overlap mode.
 
     Examples
     --------


### PR DESCRIPTION
Matlab uses `conv` for both convolution and polynomial multiplication. Clarifying that numpy has functions for each.
