### PR TITLE
Nocopy array save on arbitrary file objects

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -7,9 +7,16 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
            'asstr', 'open_latin1', 'long', 'basestring', 'sixu',
-           'integer_types']
+           'integer_types', 'memoryview_or_buffer']
 
 import sys
+
+# Use memoryview on 2.7+ and fallback to the old buffer callable on Python 2.6
+try:
+    memoryview_or_buffer = memoryview
+except NameError:
+    memoryview_or_buffer = buffer
+
 
 if sys.version_info[0] >= 3:
     import io
@@ -46,7 +53,6 @@ if sys.version_info[0] >= 3:
 
     strchar = 'U'
 
-
 else:
     bytes = str
     long = long
@@ -56,7 +62,6 @@ else:
     asbytes = str
     asstr = str
     strchar = 'S'
-
 
     def isfileobj(f):
         return isinstance(f, file)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -104,18 +104,34 @@ class RoundtripTest(object):
         self.arr = arr
         self.arr_reloaded = arr_reloaded
 
-    def test_array(self):
-        a = np.array([[1, 2], [3, 4]], float)
+    def check_roundtrips(self, a):
         self.roundtrip(a)
+        self.roundtrip(a, file_on_disk=True)
+        self.roundtrip(np.asfortranarray(a))
+        self.roundtrip(np.asfortranarray(a), file_on_disk=True)
+        if a.shape[0] > 1:
+            # neither C nor Fortran contiguous for 2D arrays or more
+            self.roundtrip(np.asfortranarray(a)[1:])
+            self.roundtrip(np.asfortranarray(a)[1:], file_on_disk=True)
+
+    def test_array(self):
+        a = np.array([], float)
+        self.check_roundtrips(a)
+
+        a = np.array([[1, 2], [3, 4]], float)
+        self.check_roundtrips(a)
 
         a = np.array([[1, 2], [3, 4]], int)
-        self.roundtrip(a)
+        self.check_roundtrips(a)
+
+        a = np.array([[1, 2], [3, 4]], object)
+        self.check_roundtrips(a)
 
         a = np.array([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]], dtype=np.csingle)
-        self.roundtrip(a)
+        self.check_roundtrips(a)
 
         a = np.array([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]], dtype=np.cdouble)
-        self.roundtrip(a)
+        self.check_roundtrips(a)
 
     def test_1D(self):
         a = np.array([1, 2, 3, 4], int)
@@ -126,22 +142,31 @@ class RoundtripTest(object):
         a = np.array([[1, 2.5], [4, 7.3]])
         self.roundtrip(a, file_on_disk=True, load_kwds={'mmap_mode': 'r'})
 
+        a = np.asfortranarray([[1, 2.5], [4, 7.3]])
+        self.roundtrip(a, file_on_disk=True, load_kwds={'mmap_mode': 'r'})
+
     def test_record(self):
         a = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
-        self.roundtrip(a)
+        self.check_roundtrips(a)
 
 
 class TestSaveLoad(RoundtripTest, TestCase):
     def roundtrip(self, *args, **kwargs):
         RoundtripTest.roundtrip(self, np.save, *args, **kwargs)
         assert_equal(self.arr[0], self.arr_reloaded)
-
+        assert_equal(self.arr[0].flags['F_CONTIGUOUS'],
+                     self.arr_reloaded.flags['F_CONTIGUOUS'])
+        assert_equal(self.arr[0].dtype, self.arr_reloaded.dtype)
 
 class TestSavezLoad(RoundtripTest, TestCase):
     def roundtrip(self, *args, **kwargs):
         RoundtripTest.roundtrip(self, np.savez, *args, **kwargs)
         for n, arr in enumerate(self.arr):
-            assert_equal(arr, self.arr_reloaded['arr_%d' % n])
+            reloaded = self.arr_reloaded['arr_%d' % n]
+            assert_equal(arr, reloaded)
+            assert_equal(arr.dtype, reloaded.dtype)
+            assert_equal(arr.flags['F_CONTIGUOUS'],
+                         reloaded.flags['F_CONTIGUOUS'])
 
     @np.testing.dec.skipif(not IS_64BIT, "Works only with 64bit systems")
     @np.testing.dec.slow

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -157,9 +157,10 @@ class TestSaveLoad(RoundtripTest, TestCase):
     def roundtrip(self, *args, **kwargs):
         RoundtripTest.roundtrip(self, np.save, *args, **kwargs)
         assert_equal(self.arr[0], self.arr_reloaded)
-        assert_equal(self.arr[0].flags['F_CONTIGUOUS'],
-                     self.arr_reloaded.flags['F_CONTIGUOUS'])
         assert_equal(self.arr[0].dtype, self.arr_reloaded.dtype)
+        # Check that fortran alignment is preserved even with relaxed strides
+        assert_equal(self.arr[0].flags.fnc, self.arr_reloaded.flags.fnc)
+
 
 class TestSavezLoad(RoundtripTest, TestCase):
     def roundtrip(self, *args, **kwargs):
@@ -168,8 +169,9 @@ class TestSavezLoad(RoundtripTest, TestCase):
             reloaded = self.arr_reloaded['arr_%d' % n]
             assert_equal(arr, reloaded)
             assert_equal(arr.dtype, reloaded.dtype)
-            assert_equal(arr.flags['F_CONTIGUOUS'],
-                         reloaded.flags['F_CONTIGUOUS'])
+            # Check that fortran alignment is preserved even with relaxed
+            # strides
+            assert_equal(arr.flags.fnc, reloaded.flags.fnc)
 
     @np.testing.dec.skipif(not IS_64BIT, "Works only with 64bit systems")
     @np.testing.dec.slow

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -124,14 +124,17 @@ class RoundtripTest(object):
         a = np.array([[1, 2], [3, 4]], int)
         self.check_roundtrips(a)
 
-        a = np.array([[1, 2], [3, 4]], object)
-        self.check_roundtrips(a)
-
         a = np.array([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]], dtype=np.csingle)
         self.check_roundtrips(a)
 
         a = np.array([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]], dtype=np.cdouble)
         self.check_roundtrips(a)
+
+    def test_array_object(self):
+        if sys.version_info[:2] >= (2, 7):
+            a = np.array([[1, 2], [3, 4]], object)
+            self.check_roundtrips(a)
+        # Fails with UnpicklingError: could not find MARK on Python 2.6
 
     def test_1D(self):
         a = np.array([1, 2, 3, 4], int)


### PR DESCRIPTION
This PRs add more tests for the `numpy.save(z) / load` roundtrips and leverage the `memoryview` / `buffer` protocol to avoid a memory copy when saving the content of a contiguous numpy array to an arbitrary file object (using the `write` method).

This is especially useful for saving the bytes of a numpy array into a compressing file object such as a `GzipFile` instance for example.
