### PR TITLE
Fix for Issue #3255: ImportError Undefined symbol: PyGILState_Release

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -954,6 +954,7 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_BEGIN_THREADS_DEF
 #define NPY_BEGIN_THREADS
 #define NPY_END_THREADS
+#define NPY_BEGIN_THREADS_THRESHOLDED(loop_size)
 #define NPY_BEGIN_THREADS_DESCR(dtype)
 #define NPY_END_THREADS_DESCR(dtype)
 #define NPY_ALLOW_C_API_DEF

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3489,14 +3489,18 @@ NPY_NO_EXPORT PyDataMem_EventHookFunc *
 PyDataMem_SetEventHook(PyDataMem_EventHookFunc *newhook,
                        void *user_data, void **old_data)
 {
+#ifdef WITH_THREAD
     PyGILState_STATE gilstate = PyGILState_Ensure();
+#endif
     PyDataMem_EventHookFunc *temp = _PyDataMem_eventhook;
     _PyDataMem_eventhook = newhook;
     if (old_data != NULL) {
         *old_data = _PyDataMem_eventhook_user_data;
     }
     _PyDataMem_eventhook_user_data = user_data;
+#ifdef WITH_THREAD
     PyGILState_Release(gilstate);
+#endif
     return temp;
 }
 
@@ -3510,12 +3514,16 @@ PyDataMem_NEW(size_t size)
 
     result = malloc(size);
     if (_PyDataMem_eventhook != NULL) {
+#ifdef WITH_THREAD
         PyGILState_STATE gilstate = PyGILState_Ensure();
+#endif
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(NULL, result, size,
                                     _PyDataMem_eventhook_user_data);
         }
+#ifdef WITH_THREAD
         PyGILState_Release(gilstate);
+#endif
     }
     return result;
 }
@@ -3530,12 +3538,16 @@ PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
 
     result = calloc(size, elsize);
     if (_PyDataMem_eventhook != NULL) {
+#ifdef WITH_THREAD
         PyGILState_STATE gilstate = PyGILState_Ensure();
+#endif
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(NULL, result, size * elsize,
                                     _PyDataMem_eventhook_user_data);
         }
+#ifdef WITH_THREAD
         PyGILState_Release(gilstate);
+#endif
     }
     return result;
 }
@@ -3548,12 +3560,16 @@ PyDataMem_FREE(void *ptr)
 {
     free(ptr);
     if (_PyDataMem_eventhook != NULL) {
+#ifdef WITH_THREAD
         PyGILState_STATE gilstate = PyGILState_Ensure();
+#endif
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(ptr, NULL, 0,
                                     _PyDataMem_eventhook_user_data);
         }
+#ifdef WITH_THREAD
         PyGILState_Release(gilstate);
+#endif
     }
 }
 
@@ -3567,12 +3583,16 @@ PyDataMem_RENEW(void *ptr, size_t size)
 
     result = realloc(ptr, size);
     if (_PyDataMem_eventhook != NULL) {
+#ifdef WITH_THREAD
         PyGILState_STATE gilstate = PyGILState_Ensure();
+#endif
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(ptr, result, size,
                                     _PyDataMem_eventhook_user_data);
         }
+#ifdef WITH_THREAD
         PyGILState_Release(gilstate);
+#endif
     }
     return result;
 }

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1377,7 +1377,9 @@ NpyIter_DebugPrint(NpyIter *iter)
     NpyIter_AxisData *axisdata;
     npy_intp sizeof_axisdata;
 
+#ifdef WITH_THREAD
     PyGILState_STATE gilstate = PyGILState_Ensure();
+#endif
 
     printf("\n------ BEGIN ITERATOR DUMP ------\n");
     printf("| Iterator Address: %p\n", (void *)iter);
@@ -1598,7 +1600,9 @@ NpyIter_DebugPrint(NpyIter *iter)
     printf("------- END ITERATOR DUMP -------\n");
     fflush(stdout);
 
+#ifdef WITH_THREAD
     PyGILState_Release(gilstate);
+#endif
 }
 
 NPY_NO_EXPORT void

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -26,7 +26,9 @@ int xerbla_(char *srname, integer *info)
                                  6 for name, 4 for param. num. */
 
         int len = 0; /* length of subroutine name*/
+#ifdef WITH_THREAD
         PyGILState_STATE save;
+#endif
 
         while( len<6 && srname[len]!='\0' )
                 len++;
@@ -34,8 +36,10 @@ int xerbla_(char *srname, integer *info)
                 len--;
 
         PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
+#ifdef WITH_THREAD
         save = PyGILState_Ensure();
         PyErr_SetString(PyExc_ValueError, buf);
         PyGILState_Release(save);
+#endif
         return 0;
 }


### PR DESCRIPTION
We need to enclose all calls to python API functions which are available only for a multi-threaded python with #ifdef WITH_THREAD.
