### PR TITLE
BUG: Fix negative axis insert (issue 3494)

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3607,7 +3607,7 @@ def insert(arr, obj, values, axis=None):
             # broadcasting is very different here, since a[:,0,:] = ... behaves
             # very different from a[:,[0],:] = ...! This changes values so that
             # it works likes the second case. (here a[:,0:1,:])
-            values = np.rollaxis(values, 0, axis + 1)
+            values = np.rollaxis(values, 0, (axis % values.ndim) + 1)
         numnew = values.shape[axis]
         newshape[axis] += numnew
         new = empty(newshape, arr.dtype, arr.flags.fnc)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -226,6 +226,13 @@ class TestInsert(TestCase):
         assert_raises(IndexError, insert, a, 1, a[:, 2, :], axis=3)
         assert_raises(IndexError, insert, a, 1, a[:, 2, :], axis=-4)
 
+        # negative axis value
+        a = np.arange(24).reshape((2,3,4))
+        assert_equal(insert(a, 1, a[:,:,3], axis=-1),
+                     insert(a, 1, a[:,:,3], axis=2))
+        assert_equal(insert(a, 1, a[:,2,:], axis=-2),
+                     insert(a, 1, a[:,2,:], axis=1))
+
     def test_0d(self):
         # This is an error in the future
         a = np.array(1)


### PR DESCRIPTION
This fix was still missing in master (it is in 1.8.x, it maybe should still be backported to 1.7.x which seems not be in there yet, the correct commit for backporting are 79b094e and c57c417 -- the first here won't apply, since it is slightly different)
