### PR TITLE
BUG: fix incorrect type in binomial ditsributions.c

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -310,7 +310,7 @@ long rk_binomial_btpe(rk_state *state, long n, double p)
     goto Step50;
 
   Step40:
-    y = (int)floor(xr - log(v)/lamr);
+    y = (long)floor(xr - log(v)/lamr);
     if (y > n) goto Step10;
     v = v*(u-p3)*lamr;
 


### PR DESCRIPTION
This caused slowness and wrong/potentially wrong results
when the binomial result is larger then a native C int.

Closes gh-3352
## 

Small and simple bufix...
