### PR TITLE
BUG|API: Raise wrong arg{min|max} out shape and stricter check

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -72,6 +72,13 @@ The performance of converting lists containing arrays to arrays using
 Changes
 =======
 
+Argmin and argmax out argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `out` argument to `np.argmin` and `np.argmax` and their equivalent
+C-API functions is now checked to match the desired output shape exactly.
+If the check fails a `ValueError` instead of `TypeError` is raised.
+
  
 C-API
 ~~~~~

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -109,10 +109,12 @@ PyArray_ArgMax(PyArrayObject *op, int axis, PyArrayObject *out)
         }
     }
     else {
-        if (PyArray_SIZE(out) !=
-                PyArray_MultiplyList(PyArray_DIMS(ap), PyArray_NDIM(ap) - 1)) {
-            PyErr_SetString(PyExc_TypeError,
-                    "invalid shape for output array.");
+        if ((PyArray_NDIM(out) != PyArray_NDIM(ap) - 1) ||
+                !PyArray_CompareLists(PyArray_DIMS(out), PyArray_DIMS(ap),
+                                      PyArray_NDIM(out))) {
+            PyErr_SetString(PyExc_ValueError,
+                    "output array does not match result of np.argmax.");
+            goto fail;
         }
         rp = (PyArrayObject *)PyArray_FromArray(out,
                               PyArray_DescrFromType(NPY_INTP),
@@ -222,10 +224,12 @@ PyArray_ArgMin(PyArrayObject *op, int axis, PyArrayObject *out)
         }
     }
     else {
-        if (PyArray_SIZE(out) !=
-                PyArray_MultiplyList(PyArray_DIMS(ap), PyArray_NDIM(ap) - 1)) {
-            PyErr_SetString(PyExc_TypeError,
-                    "invalid shape for output array.");
+        if ((PyArray_NDIM(out) != PyArray_NDIM(ap) - 1) ||
+                !PyArray_CompareLists(PyArray_DIMS(out), PyArray_DIMS(ap),
+                                      PyArray_NDIM(out))) {
+            PyErr_SetString(PyExc_ValueError,
+                    "output array does not match result of np.argmin.");
+            goto fail;
         }
         rp = (PyArrayObject *)PyArray_FromArray(out,
                               PyArray_DescrFromType(NPY_INTP),

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1955,6 +1955,24 @@ class TestArgmax(TestCase):
             assert_equal(np.argmax(arr), pos, err_msg="%r"%arr)
             assert_equal(arr[np.argmax(arr)], np.max(arr), err_msg="%r"%arr)
 
+    def test_output_shape(self):
+        # see also gh-616
+        a = np.ones((10, 5))
+        # Check some simple shape mismatches
+        out = np.ones(11, dtype=np.int_)
+        assert_raises(ValueError, a.argmax, -1, out)
+
+        out = np.ones((2, 5), dtype=np.int_)
+        assert_raises(ValueError, a.argmax, -1, out)
+
+        # these could be relaxed possibly (used to allow even the previous)
+        out = np.ones((1, 10), dtype=np.int_)
+        assert_raises(ValueError, a.argmax, -1, np.ones((1, 10)))
+
+        out = np.ones(10, dtype=np.int_)
+        a.argmax(-1, out=out)
+        assert_equal(out, a.argmax(-1))
+
 
 class TestArgmin(TestCase):
 
@@ -2036,6 +2054,24 @@ class TestArgmin(TestCase):
 
         a = np.array([1, -2**63, -2**63 + 1], dtype=np.int64)
         assert_equal(np.argmin(a), 1)
+
+    def test_output_shape(self):
+        # see also gh-616
+        a = np.ones((10, 5))
+        # Check some simple shape mismatches
+        out = np.ones(11, dtype=np.int_)
+        assert_raises(ValueError, a.argmin, -1, out)
+
+        out = np.ones((2, 5), dtype=np.int_)
+        assert_raises(ValueError, a.argmin, -1, out)
+
+        # these could be relaxed possibly (used to allow even the previous)
+        out = np.ones((1, 10), dtype=np.int_)
+        assert_raises(ValueError, a.argmin, -1, np.ones((1, 10)))
+
+        out = np.ones(10, dtype=np.int_)
+        a.argmin(-1, out=out)
+        assert_equal(out, a.argmin(-1))
 
 
 class TestMinMax(TestCase):


### PR DESCRIPTION
The error was not raised when the output array size did not match
the given out array causing segfaults if the out array was smaller.

This also makes the shape check strict and changes the error
to a ValueError. The shape check could be relaxed for leading
ones. ufuncs and assignments do this.
## 

The new check is more strict (and the error type changed), if someone thinks that a stricter issue is a problem I can relax it again (this makes it behave like e.g. take's out, some out's allow leading 1s)
