### PR TITLE
DEP: Deprecate boolean math operations

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -369,7 +369,7 @@ defdict = {
 'negative':
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.negative'),
-          'PyUFunc_SimpleUnaryOperationTypeResolver',
+          'PyUFunc_NegativeTypeResolver',
           TD(bints+flts+timedeltaonly),
           TD(cmplx, f='neg'),
           TD(O, f='PyNumber_Negative'),

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2139,6 +2139,11 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     x = array(a, copy=False, ndmin=1)
     y = array(b, copy=False, ndmin=1)
 
+    # make sure y is an inexact type to avoid abs(MIN_INT); will cause
+    # casting of x later.
+    dtype = multiarray.result_type(y, 1.)
+    y = array(y, dtype=dtype, copy=False)
+
     xinf = isinf(x)
     yinf = isinf(y)
     if any(xinf) or any(yinf):
@@ -2154,12 +2159,7 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
 
     # ignore invalid fpe's
     with errstate(invalid='ignore'):
-        if not x.dtype.kind == 'b' and not y.dtype.kind == 'b':
-            diff = abs(x - y)
-        else:
-            diff = x ^ y
-
-        r = all(less_equal(diff, atol + rtol * abs(y)))
+        r = all(less_equal(abs(x - y), atol + rtol * abs(y)))
 
     return r
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2154,7 +2154,12 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
 
     # ignore invalid fpe's
     with errstate(invalid='ignore'):
-        r = all(less_equal(abs(x-y), atol + rtol * abs(y)))
+        if not x.dtype.kind == 'b' and not y.dtype.kind == 'b':
+            diff = abs(x - y)
+        else:
+            diff = x ^ y
+
+        r = all(less_equal(diff, atol + rtol * abs(y)))
 
     return r
 

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -16,6 +16,13 @@ PyUFunc_SimpleUnaryOperationTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
+PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
+                                NPY_CASTING casting,
+                                PyArrayObject **operands,
+                                PyObject *type_tup,
+                                PyArray_Descr **out_dtypes);
+
+NPY_NO_EXPORT int
 PyUFunc_OnesLikeTypeResolver(PyUFuncObject *ufunc,
                                 NPY_CASTING casting,
                                 PyArrayObject **operands,

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -128,9 +128,9 @@ class TestWhitespace(TestCase):
         assert_(all(self.A == self.B))
         assert_(all(self.A >= self.B))
         assert_(all(self.A <= self.B))
-        assert_(all(negative(self.A > self.B)))
-        assert_(all(negative(self.A < self.B)))
-        assert_(all(negative(self.A != self.B)))
+        assert_(not any(self.A > self.B))
+        assert_(not any(self.A < self.B))
+        assert_(not any(self.A != self.B))
 
 class TestChar(TestCase):
     def setUp(self):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -343,5 +343,28 @@ class TestMultipleEllipsisDeprecation(_DeprecationTestCase):
             assert_raises(IndexError, a.__getitem__, ((Ellipsis, ) * 3,))
 
 
+class TestBooleanSubtractDeprecations(_DeprecationTestCase):
+    """Test deprecation of boolean `-`. While + and * are well
+    defined, - is not and even a corrected form seems to have
+    no real uses.
+
+    The deprecation process was started in NumPy 1.9.
+    """
+    message = r"numpy boolean .* \(the .* `-` operator\) is deprecated, " \
+              "use the bitwise"
+
+    def test_operator_deprecation(self):
+        array = np.array([True])
+        generic = np.bool_(True)
+
+        # Minus operator/subtract ufunc:
+        self.assert_deprecated(operator.sub, args=(array, array))
+        self.assert_deprecated(operator.sub, args=(generic, generic))
+
+        # Unary minus/negative ufunc:
+        self.assert_deprecated(operator.neg, args=(array,))
+        self.assert_deprecated(operator.neg, args=(generic,))
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1420,6 +1420,13 @@ class TestAllclose(object):
         assert_array_equal(y, array([0, inf]))
 
 
+    def test_min_int(self):
+        # Could make problems because of abs(min_int) == min_int
+        min_int = np.iinfo(np.int_).min
+        a = np.array([min_int], dtype=np.int_)
+        assert_(allclose(a, a))
+
+
 class TestIsclose(object):
     rtol = 1e-5
     atol = 1e-8

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -447,7 +447,10 @@ class TestRegression(TestCase):
             res1 = getattr(arr, func_meth)()
             res2 = getattr(np, func)(arr2)
             if res1 is None:
-                assert_(abs(arr-res2).max() < 1e-8, func)
+                res1 = arr
+
+            if res1.dtype.kind in 'uib':
+                assert_((res1 == res2).all(), func)
             else:
                 assert_(abs(res1-res2).max() < 1e-8, func)
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6923,16 +6923,25 @@ def allclose (a, b, masked_equal=True, rtol=1e-5, atol=1e-8):
         return False
     # No infs at all
     if not np.any(xinf):
-        d = filled(umath.less_equal(umath.absolute(x - y),
-                                    atol + rtol * umath.absolute(y)),
+        if not x.dtype.kind == 'b' and not y.dtype.kind == 'b':
+            diff = umath.absolute(x - y)
+        else:
+            diff = x ^ y
+
+        d = filled(umath.less_equal(diff, atol + rtol * umath.absolute(y)),
                    masked_equal)
         return np.all(d)
     if not np.all(filled(x[xinf] == y[xinf], masked_equal)):
         return False
     x = x[~xinf]
     y = y[~xinf]
-    d = filled(umath.less_equal(umath.absolute(x - y),
-                                atol + rtol * umath.absolute(y)),
+
+    if not x.dtype.kind == 'b' and not y.dtype.kind == 'b':
+        diff = umath.absolute(x - y)
+    else:
+        diff = x ^ y
+
+    d = filled(umath.less_equal(diff, atol + rtol * umath.absolute(y)),
                masked_equal)
     return np.all(d)
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -540,7 +540,7 @@ def average(a, axis=None, weights=None, returned=False):
         else:
             if weights is None:
                 n = add.reduce(a, axis)
-                d = umath.add.reduce((-mask), axis=axis, dtype=float)
+                d = umath.add.reduce((~mask), axis=axis, dtype=float)
             else:
                 w = filled(weights, 0.0)
                 wsh = w.shape
@@ -1735,7 +1735,7 @@ def _ezclump(mask):
     #def clump_masked(a):
     if mask.ndim > 1:
         mask = mask.ravel()
-    idx = (mask[1:] - mask[:-1]).nonzero()
+    idx = (mask[1:] ^ mask[:-1]).nonzero()
     idx = idx[0] + 1
     slices = [slice(left, right)
               for (left, right) in zip(itertools.chain([0], idx),

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1995,6 +1995,10 @@ class TestMaskedArrayMethods(TestCase):
         a[0] = 0
         self.assertTrue(allclose(a, 0, masked_equal=True))
 
+        # Test that the function works for MIN_INT integer typed arrays
+        a = masked_array([np.iinfo(np.int_).min], dtype=np.int_)
+        self.assertTrue(allclose(a, a))
+
     def test_allany(self):
         # Checks the any/all methods/functions.
         x = np.array([[0.13, 0.26, 0.90],

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -53,6 +53,9 @@ class _GenericTest(object):
         a = np.array([1, 1], dtype=np.object)
         self._test_equal(a, 1)
 
+    def test_array_likes(self):
+        self._test_equal([1, 2, 3], (1, 2, 3))
+
 class TestArrayEqual(_GenericTest, unittest.TestCase):
     def setUp(self):
         self._assert_func = assert_array_equal
@@ -372,6 +375,11 @@ class TestAssertAllclose(unittest.TestCase):
 
         assert_allclose(6, 10, rtol=0.5)
         self.assertRaises(AssertionError, assert_allclose, 10, 6, rtol=0.5)
+
+    def test_min_int(self):
+        a = np.array([np.iinfo(np.int_).min], dtype=np.int_)
+        # Should not raise:
+        assert_allclose(a, a)
 
 
 class TestArrayAlmostEqualNulp(unittest.TestCase):

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -810,7 +810,12 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
                 y = y[~yinfid]
         except (TypeError, NotImplementedError):
             pass
-        z = abs(x-y)
+
+        if x.dtype.kind == 'b' and y.dtype.kind == 'b':
+            z = x ^ y
+        else:
+            z = abs(x-y)
+
         if not issubdtype(z.dtype, number):
             z = z.astype(float_) # handle object arrays
         return around(z, decimal) <= 10.0**(-decimal)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -793,7 +793,7 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
      y: array([ 1.     ,  2.33333,  5.     ])
 
     """
-    from numpy.core import around, number, float_
+    from numpy.core import around, number, float_, result_type, array
     from numpy.core.numerictypes import issubdtype
     from numpy.core.fromnumeric import any as npany
     def compare(x, y):
@@ -811,16 +811,20 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
         except (TypeError, NotImplementedError):
             pass
 
-        if x.dtype.kind == 'b' and y.dtype.kind == 'b':
-            z = x ^ y
-        else:
-            z = abs(x-y)
+        # make sure y is an inexact type to avoid abs(MIN_INT); will cause
+        # casting of x later.
+        dtype = result_type(y, 1.)
+        y = array(y, dtype=dtype, copy=False)
+        z = abs(x-y)
 
         if not issubdtype(z.dtype, number):
             z = z.astype(float_) # handle object arrays
+
         return around(z, decimal) <= 10.0**(-decimal)
+
     assert_array_compare(compare, x, y, err_msg=err_msg, verbose=verbose,
              header=('Arrays are not almost equal to %d decimals' % decimal))
+
 
 def assert_array_less(x, y, err_msg='', verbose=True):
     """


### PR DESCRIPTION
The bitwise or logical operations should be used instead,
after a while.
## 

To be honest, I am a bit unsure here. While it is nice, the impact out there might be rather big (this currently does not include the fixes necessary in ma and some tests, so failing).
