### PR TITLE
ENH: Make allclose(x, y) equivalent to all(x == y) when both x and y are...

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2139,8 +2139,13 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     x = array(a, copy=False, ndmin=1)
     y = array(b, copy=False, ndmin=1)
 
-    xinf = isinf(x)
-    yinf = isinf(y)
+    xexact = x.dtype.kind not in 'fc'
+    yexact = y.dtype.kind not in 'fc'
+    if xexact and yexact:
+        return (x == y).all()
+
+    xinf = not xexact and isinf(x)
+    yinf = not yexact and isinf(y)
     if any(xinf) or any(yinf):
         # Check that x and y have inf's only in the same positions
         if not all(xinf == yinf):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1355,7 +1355,7 @@ class TestClip(TestCase):
         self.assertTrue(a2 is a)
 
 
-class TestAllclose(object):
+class TestAllclose(TestCase):
     rtol = 1e-5
     atol = 1e-8
 
@@ -1418,6 +1418,14 @@ class TestAllclose(object):
         allclose(x, y)
         assert_array_equal(x, array([inf, 1]))
         assert_array_equal(y, array([0, inf]))
+
+    def test_exact(self):
+        self.assertTrue(allclose([True], [True]))
+        self.assertTrue(allclose(['a'], ['a']))
+        self.assertFalse(allclose([True], [False]))
+        self.assertFalse(allclose(['a'], ['b']))
+        self.assertTrue(allclose([1], [1.0]))
+        self.assertTrue(allclose([1.0], [1]))
 
 
 class TestIsclose(object):


### PR DESCRIPTION
... exact.

This improves performance and makes allclose() work on non-numeric dtypes.

Closes gh-4107.
