### PR TITLE
BUG: Fix object scalar return type of 0-d array indices

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1046,7 +1046,7 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
         }
     }
     /* optimization for a tuple of integers */
-    if (PyArray_NDIM(self) > 1 && _is_full_index(op, self)) {
+    if (_is_full_index(op, self)) {
         int ret = _tuple_of_integers(op, vals, PyArray_NDIM(self));
 
         if (ret > 0) {
@@ -1182,7 +1182,18 @@ array_subscript_fromobject(PyArrayObject *self, PyObject *op)
 
     fancy = fancy_indexing_check(op);
     if (fancy != SOBJ_NOTFANCY) {
-        return array_subscript_fancy(self, op, fancy);
+        PyObject *ret;
+
+        ret = array_subscript_fancy(self, op, fancy);
+        if (ret == NULL) {
+            return NULL;
+        }
+        if (PyArray_Check(ret) &&
+                PyArray_NDIM((PyArrayObject *)ret) == 0 &&
+                !_check_ellipses(op)) {
+            return PyArray_Return((PyArrayObject *)ret);
+        }
+        return ret;
     }
     else {
         return array_subscript_simple(self, op, 1);
@@ -1195,7 +1206,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
     int fancy;
     PyObject *ret = NULL;
     if (!PyArray_Check(op)) {
-        ret = array_subscript_fromobject(self, op);
+        return array_subscript_fromobject(self, op);
     }
 
     /* Boolean indexing special case */
@@ -1223,14 +1234,6 @@ array_subscript(PyArrayObject *self, PyObject *op)
         }
     }
 
-    if (ret == NULL) {
-        return NULL;
-    }
-
-    if (PyArray_Check(ret) && PyArray_NDIM((PyArrayObject *)ret) == 0
-                                                && !_check_ellipses(op)) {
-        return PyArray_Return((PyArrayObject *)ret);
-    }
     return ret;
 }
 


### PR DESCRIPTION
PyArray_Result was called when it should not have been. This caused
object arrays of 0-d arrays have the inner array converted to a
scalar:

`np.array([np.array(0), None])[0] -> np._float(0)`

The same case happened to recarray field access. This fixes it.
## 

(This was an SO question, maybe it will be an issue here, too... It is a regression in 1.8.x). There are some code blocks there I am sure are not used, but I don't want to touch the old mapping.c more then absolutely necessary... My current plan is, that when this is merged I create a blocker issue for 1.9.x. My indexing branch has it fixed anyway, I know that is not the right procedure, so if someone disagrees...
