### PR TITLE
Correct typo in interp() docstring.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1085,7 +1085,7 @@ def interp(x, xp, fp, left=None, right=None):
         Value to return for `x < xp[0]`, default is `fp[0]`.
 
     right : float, optional
-        Value to return for `x > xp[-1]`, defaults is `fp[-1]`.
+        Value to return for `x > xp[-1]`, default is `fp[-1]`.
 
     Returns
     -------


### PR DESCRIPTION
The docstring for interp() contained the grammatically-incorrect text "defaults is". I corrected this to "default is".
