### PR TITLE
BUG: fix loading from compressed .npz (Issue 4093)

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -486,10 +486,11 @@ def read_array(fp):
                     msg = "EOF: expected %d entries, got %d entries" % (count, i)
                     raise ValueError(msg)
                 actual_count = len(data) // dtype.itemsize
-                extra_data = data[actual_count*dtype.itemsize:] 
-                array[i:i+actual_count] = numpy.frombuffer(data, dtype=dtype,
-                                                         count=actual_count)
-                i += actual_count
+                if actual_count > 0:
+                    array[i:i + actual_count] = \
+                        numpy.frombuffer(data, dtype=dtype, count=actual_count)
+                    i += actual_count
+                extra_data = data[actual_count * dtype.itemsize:]
 
         if fortran_order:
             array.shape = shape[::-1]

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -476,13 +476,16 @@ def read_array(fp):
             max_read_count = BUFFER_SIZE // min(BUFFER_SIZE, dtype.itemsize)
 
             array = numpy.empty(count, dtype=dtype)
-
-            for i in range(0, count, max_read_count):
+            extra_data = ''
+            i = 0
+            while i < count: 
                 read_count = min(max_read_count, count - i)
-
-                data = fp.read(int(read_count * dtype.itemsize))
-                array[i:i+read_count] = numpy.frombuffer(data, dtype=dtype,
-                                                         count=read_count)
+                data = extra_data + fp.read(int(read_count * dtype.itemsize))
+                actual_count = len(data) // dtype.itemsize
+                extra_data = data[actual_count*dtype.itemsize:] 
+                array[i:i+actual_count] = numpy.frombuffer(data, dtype=dtype,
+                                                         count=actual_count)
+                i += actual_count
 
         if fortran_order:
             array.shape = shape[::-1]

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -476,7 +476,7 @@ def read_array(fp):
             max_read_count = BUFFER_SIZE // min(BUFFER_SIZE, dtype.itemsize)
 
             array = numpy.empty(count, dtype=dtype)
-            extra_data = ''
+            extra_data = bytes()
             i = 0
             while i < count: 
                 read_count = min(max_read_count, count - i)

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -481,6 +481,10 @@ def read_array(fp):
             while i < count: 
                 read_count = min(max_read_count, count - i)
                 data = extra_data + fp.read(int(read_count * dtype.itemsize))
+                if len(data) == len(extra_data):
+                    #Unable to read sufficient data from fp
+                    msg = "EOF: expected %d entries, got %d entries" % (count, i)
+                    raise ValueError(msg)
                 actual_count = len(data) // dtype.itemsize
                 extra_data = data[actual_count*dtype.itemsize:] 
                 array[i:i+actual_count] = numpy.frombuffer(data, dtype=dtype,

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -410,14 +410,14 @@ record_arrays = [
     np.array(NbufferT, dtype=np.dtype(Ndescr).newbyteorder('>')),
 ]
 
+
 #BytesIO that returns fewer bytes than requested
 class BytesIORandomSize(BytesIO):
     def read(self, size=None):
         from random import randint
-        size = randint(min(512,size), size)
-        data =  super(BytesIORandomSize, self).read(size)
-        assert len(data) <= size
-        return data
+        size = randint(min(512, size), size)
+        return super(BytesIORandomSize, self).read(size)
+
 
 def roundtrip(arr):
     f = BytesIO()
@@ -426,12 +426,14 @@ def roundtrip(arr):
     arr2 = format.read_array(f2)
     return arr2
 
+
 def roundtrip_randsize(arr):
     f = BytesIO()
     format.write_array(f, arr)
     f2 = BytesIORandomSize(f.getvalue())
     arr2 = format.read_array(f2)
     return arr2
+
 
 def roundtrip_truncated(arr):
     f = BytesIO()
@@ -451,21 +453,25 @@ def test_roundtrip():
         arr2 = roundtrip(arr)
         yield assert_array_equal, arr, arr2
 
+
 def test_roundtrip_randsize():
     for arr in basic_arrays[2:] + record_arrays:
         arr2 = roundtrip_randsize(arr)
         yield assert_array_equal, arr, arr2
 
+
 def test_roundtrip_truncated():
     for arr in basic_arrays:
         if arr.dtype != object:
-            assert_raises(ValueError, roundtrip_truncated, arr)
+            yield assert_raises, ValueError, roundtrip_truncated, arr
+
 
 def test_long_str():
     # check items larger than internal buffer size, gh-4027
     long_str_arr = np.ones(1, dtype=np.dtype((str, format.BUFFER_SIZE + 1)))
     long_str_arr2 = roundtrip(long_str_arr)
     assert_array_equal(long_str_arr, long_str_arr2)
+
 
 @dec.slow
 def test_memmap_roundtrip():

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -517,6 +517,14 @@ def test_memmap_roundtrip():
             del ma
 
 
+def test_compressed_roundtrip():
+    arr = np.random.rand(200, 200)
+    npz_file = os.path.join(tempdir, 'compressed.npz')
+    np.savez_compressed(npz_file, arr=arr)
+    arr1 = np.load(npz_file)['arr']
+    assert_array_equal(arr, arr1)
+
+
 def test_write_version_1_0():
     f = BytesIO()
     arr = np.arange(1)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -411,16 +411,12 @@ record_arrays = [
 ]
 
 
-#BytesIO that reads a single byte at a time
-class BytesIOSingleByte(BytesIO):
+#BytesIO that reads a random number of bytes at a time
+class BytesIOSRandomSize(BytesIO):
     def read(self, size=None):
-        #Return first 512 bytes normally, otherwise checking magic bytes
-        #and reading header fails
-        if self.tell() > 512:
-            size = 1
-        else:
-            size = min(size, 512)
-        return super(BytesIOSingleByte, self).read(size)
+        import random
+        size = random.randint(1, size)
+        return super(BytesIOSRandomSize, self).read(size)
 
 
 def roundtrip(arr):
@@ -431,10 +427,10 @@ def roundtrip(arr):
     return arr2
 
 
-def roundtrip_onebyte(arr):
+def roundtrip_randsize(arr):
     f = BytesIO()
     format.write_array(f, arr)
-    f2 = BytesIOSingleByte(f.getvalue())
+    f2 = BytesIOSRandomSize(f.getvalue())
     arr2 = format.read_array(f2)
     return arr2
 
@@ -458,10 +454,10 @@ def test_roundtrip():
         yield assert_array_equal, arr, arr2
 
 
-def test_roundtrip_onebyte():
+def test_roundtrip_randsize():
     for arr in basic_arrays + record_arrays:
         if arr.dtype != object:
-            arr2 = roundtrip_onebyte(arr)
+            arr2 = roundtrip_randsize(arr)
             yield assert_array_equal, arr, arr2
 
 


### PR DESCRIPTION
In Python 2.6.x the number of bytes read from a zip file is 2^16, which
is less than the 2^18 requested by lib.format.py. This change handles
the case where fp.read() returns fewer than the requested number of bytes.
