### PR TITLE
BUG: Propagate error when assigning an instance to an array item.

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -157,11 +157,18 @@ static int
         temp = (@type@)@func2@(op);
     }
     if (PyErr_Occurred()) {
+        PyObject *type, *value, *traceback;
+        PyErr_Fetch(&type, &value, &traceback);
         if (PySequence_Check(op) && !PyString_Check(op) &&
-                                            !PyUnicode_Check(op)) {
-            PyErr_Clear();
+                                    !PyUnicode_Check(op)) {
             PyErr_SetString(PyExc_ValueError,
                     "setting an array element with a sequence.");
+            Py_DECREF(type);
+            Py_XDECREF(value);
+            Py_XDECREF(traceback);
+        }
+        else {
+            PyErr_Restore(type, value, traceback);
         }
         return -1;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -268,6 +268,16 @@ class TestAssignment(TestCase):
             a[...] = b
         assert_raises(ValueError, assign, a, np.arange(12).reshape(2, 2, 3))
 
+    def test_assignment_errors(self):
+        # Address issue #2276
+        class C:
+            pass
+        a = np.zeros(1)
+        def assign(v):
+            a[0] = v
+        assert_raises((AttributeError, TypeError), assign, C())
+        assert_raises(ValueError, assign, [1])
+
 class TestDtypedescr(TestCase):
     def test_construction(self):
         d1 = dtype('i4')


### PR DESCRIPTION
Prior to this fix, numpy would swallow an error that may occur when
an instance of an old-style class would be used to set an item in an
incompatible array.  This would result in a SystemError.

Fixes #2276.
