### PR TITLE
TST: fix test error due to 2to3 conversion on py3.3.3

### DIFF
--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -315,8 +315,8 @@ class TestMethods(TestCase):
 
     def test_decode(self):
         if sys.version_info[0] >= 3:
-            A = np.char.array([asbytes('\\u03a3')])
-            assert_(A.decode('unicode-escape')[0] == '\u03a3')
+            A = np.char.array([asbytes(r'\u03a3')])
+            assert_(A.decode('unicode-escape')[0] == u'\u03a3')
         else:
             A = np.char.array(['736563726574206d657373616765'])
             assert_(A.decode('hex_codec')[0] == 'secret message')


### PR DESCRIPTION
This fixes one test error when building and testing numpy 1.7.x on Python 3.3.3:

```
======================================================================
FAIL: test_decode (test_defchararray.TestMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python33-x32\lib\site-packages\numpy\core\tests\test_defchararray.py", line 319, in test_decode
    assert_(A.decode('unicode-escape')[0] == '\\u03a3')
  File "X:\Python33-x32\lib\site-packages\numpy\testing\utils.py", line 35, in assert_
    raise AssertionError(msg)
AssertionError
```

Apparently Python 3.3.3 converts `assert_(A.decode('unicode-escape')[0] == '\u03a3')` to `assert_(A.decode('unicode-escape')[0] == '\\u03a3')`
