### PR TITLE
BUG: Fix missing NULL check in lexsort

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1681,6 +1681,9 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
     for (i = 0; i < n; i++) {
         PyObject *obj;
         obj = PySequence_GetItem(sort_keys, i);
+        if (obj == NULL) {
+            goto fail;
+        }
         mps[i] = (PyArrayObject *)PyArray_FROM_O(obj);
         Py_DECREF(obj);
         if (mps[i] == NULL) {

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -386,6 +386,17 @@ class TestRegression(TestCase):
         v = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         assert_equal(np.lexsort(v), 0)
 
+    def test_lexsort_invalid_sequence(self):
+        # Issue gh-4123
+        class BuggySequence(object):
+            def __len__(self):
+                return 4
+            def __getitem__(self, key):
+                raise KeyError
+
+        assert_raises(KeyError, np.lexsort, BuggySequence())
+
+
     def test_pickle_dtype(self,level=rlevel):
         """Ticket #251"""
         pickle.dumps(np.float)


### PR DESCRIPTION
When Getitem of the lexsort sequence argument failed
this was not checked.

Closes gh-4123
## 

Very simple fix.
