### PR TITLE
BUG: Initialize NpyIter object to zero after malloc

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -195,6 +195,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
     /* Allocate memory for the iterator */
     iter = (NpyIter*)
                 PyObject_Malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
+    memset(iter, 0, NIT_SIZEOF_ITERATOR(itflags, ndim, nop));    
 
     NPY_IT_TIME_POINT(c_malloc);
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -580,6 +580,7 @@ class TestUfunc(TestCase):
         assert_equal(np.all(a), False)
         assert_equal(np.max(a), True)
         assert_equal(np.min(a), False)
+        assert_equal(np.array([[1]], dtype=object).sum(), 1)
 
     def test_zerosize_reduction(self):
         # Test with default dtype and object dtype


### PR DESCRIPTION
Unitialized NpyIter object is causing random weird behavior, including object's add method being invoked when sum() is called on an array of a single object. This results in the single object in the array being added to itself which is incorrect.
