### PR TITLE
DOC: matrix_rank

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -46,6 +46,7 @@ Norms and other numbers
    linalg.norm
    linalg.cond
    linalg.det
+   linalg.matrix_rank
    linalg.slogdet
    trace
 

--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -14,6 +14,7 @@ lstsq           Solve linear least-squares problem
 pinv            Pseudo-inverse (Moore-Penrose) calculated using a singular
                 value decomposition
 matrix_power    Integer power of a square matrix
+matrix_rank     Calculate matrix rank using an SVD-based method
 =============== ==========================================================
 
 =============== ==========================================================


### PR DESCRIPTION
By the way, does `routines.linalg.rst` replace the `linalg/__init__.py` docstring?  The latter looks like it is rst formatted for sphinx but I don't see that it finds its way into the generated docs.

This PR should close https://github.com/numpy/numpy/issues/4121.
