### PR TITLE
BUG: ma: Inconsistent return type from the 'count' method.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3976,21 +3976,12 @@ class MaskedArray(ndarray):
         """
         m = self._mask
         s = self.shape
-        ls = len(s)
         if m is nomask:
-            if ls == 0:
-                return 1
-            if ls == 1:
-                return s[0]
-            if axis is None:
-                return self.size
-            else:
-                n = s[axis]
-                t = list(s)
-                del t[axis]
-                return np.ones(t) * n
-        n1 = np.size(m, axis)
-        n2 = m.astype(int).sum(axis)
+            ma = np.resize(m, s)
+        else:
+            ma = m
+        n1 = np.size(ma, axis)
+        n2 = ma.astype(int).sum(axis)
         if axis is None:
             return (n1 - n2)
         else:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -796,6 +796,7 @@ class TestMaskedArrayArithmetic(TestCase):
     def test_count_func(self):
         # Tests count
         ott = array([0., 1., 2., 3.], mask=[1, 0, 0, 0])
+        ott1 = array([0., 1., 2., 3.])
         if sys.version_info[0] >= 3:
             self.assertTrue(isinstance(count(ott), np.integer))
         else:
@@ -812,6 +813,7 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(3, count(ott))
         assert_(getmask(count(ott, 0)) is nomask)
         assert_equal([1, 2], count(ott, 0))
+        assert_equal(type(count(ott, 0)), type(count(ott1, 0)))
 
     def test_minmax_func(self):
         # Tests minimum and maximum.


### PR DESCRIPTION
This is an attempt to resolve the issue #3368 by WarrenWeckesser regarding the different datatypes returned bt count method when the masked_array is 1D and the axis is 0.
