### PR TITLE
BUG: fix complex norm of higher order

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2088,7 +2088,7 @@ def norm(x, ord=None, axis=None):
                 # because it will downcast to float64.
                 absx = abs(x)
             else:
-                absx = asfarray(x)
+                absx = x if isComplexType(x.dtype.type) else asfarray(x)
                 if absx.dtype is x.dtype:
                     absx = abs(absx)
                 else:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -921,6 +921,18 @@ class _TestNorm(object):
         x = np.array([-2 ** 31], dtype=np.int32)
         old_assert_almost_equal(norm(x, ord=3), 2 ** 31, decimal=5)
 
+    def test_complex_high_ord(self):
+        # gh-4156
+        d = np.empty((2,), dtype=np.clongdouble)
+        d[0] = 6+7j
+        d[1] = -6+7j
+        res = 11.615898132184
+        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=10)
+        d = d.astype(np.complex128)
+        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=9)
+        d = d.astype(np.complex64)
+        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=5)
+
 
 class TestNormDouble(_TestNorm):
     dt = np.double


### PR DESCRIPTION
asfarray truncates the complex part, so it must be avoided for complex
types.
Closes gh-4156.
