### PR TITLE
BUG: compile random in lfs mode

### DIFF
--- a/numpy/random/bscript
+++ b/numpy/random/bscript
@@ -27,6 +27,11 @@ def build(context):
         includes = ["../core/include", "../core/include/numpy", "../core",
                     "../core/src/private"]
         kw = {}
+        # enable unix large file support on 32 bit systems
+        # (64 bit off_t, lseek -> lseek64 etc.)
+        kw['defines'] = ['_FILE_OFFSET_BITS=64',
+                         '_LARGEFILE_SOURCE=1',
+                         '_LARGEFILE64_SOURCE=1']
         if bld.env.USE_WINCRYPT:
             kw["lib"] = "ADVAPI32"
         return context.default_builder(extension, includes=includes, **kw)

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -30,7 +30,11 @@ def configuration(parent_package='',top_path=None):
         ext.libraries.extend(libs)
         return None
 
-    defs = []
+    # enable unix large file support on 32 bit systems
+    # (64 bit off_t, lseek -> lseek64 etc.)
+    defs = [('_FILE_OFFSET_BITS', '64'),
+            ('_LARGEFILE_SOURCE', '1'),
+            ('_LARGEFILE64_SOURCE', '1')]
     if needs_mingw_ftime_workaround():
         defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))
 


### PR DESCRIPTION
randomkit.c uses fopen which requires LFS mode to support larger than 64
bit files on 32 bit systems.
