### PR TITLE
BUG: linalg/test_build.py incorrectly reports conflicting fortran versio...

### DIFF
--- a/numpy/linalg/tests/test_build.py
+++ b/numpy/linalg/tests/test_build.py
@@ -45,9 +45,11 @@ class TestF77Mismatch(TestCase):
                 "Skipping fortran compiler mismatch on non Linux platform")
     def test_lapack(self):
         f = FindDependenciesLdd()
-        deps = f.grep_dependencies(lapack_lite.__file__,
-                                   asbytes_nested(['libg2c', 'libgfortran']))
-        self.assertFalse(len(deps) > 1,
+        depsLibg2c = f.grep_dependencies(lapack_lite.__file__,
+                                   asbytes_nested(['libg2c']))
+        depsLibgfortran = f.grep_dependencies(lapack_lite.__file__,
+                                   asbytes_nested(['libgfortran']))
+        self.assertFalse(len(depsLibg2c)*len(depsLibgfortran) > 0,
 """Both g77 and gfortran runtimes linked in lapack_lite ! This is likely to
 cause random crashes and wrong results. See numpy INSTALL.txt for more
 information.""")


### PR DESCRIPTION
...ns if lapack_lite.so links against multiple fortran libraries

See: linalg/tests/test_build.py incorrectly reports both g77 and gfortran (Trac #1519) (#2116)
The example we see of this is on CENTOS/RHEL 5 where numpy is built using gcc44/gfortran44 using OpenBLAS (from EPEL).
In that case lapack_lite.so links against /usr/lib64/libgfortran.so.1 and /usr/lib64/libgfortran.so.3
The test has been changed so that it only reports a failure if lapack_lite.so links against BOTH libg2c and libgfortran.
