### PR TITLE
Backport fixes to 1.8

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -886,12 +886,13 @@ _strided_to_strided_string_to_datetime(char *dst, npy_intp dst_stride,
                         NpyAuxData *data)
 {
     _strided_datetime_cast_data *d = (_strided_datetime_cast_data *)data;
-    npy_int64 dt = ~NPY_DATETIME_NAT;
     npy_datetimestruct dts;
     char *tmp_buffer = d->tmp_buffer;
     char *tmp;
 
     while (N > 0) {
+        npy_int64 dt = ~NPY_DATETIME_NAT;
+
         /* Replicating strnlen with memchr, because Mac OS X lacks it */
         tmp = memchr(src, '\0', src_itemsize);
 

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -886,7 +886,7 @@ _strided_to_strided_string_to_datetime(char *dst, npy_intp dst_stride,
                         NpyAuxData *data)
 {
     _strided_datetime_cast_data *d = (_strided_datetime_cast_data *)data;
-    npy_int64 dt;
+    npy_int64 dt = ~NPY_DATETIME_NAT;
     npy_datetimestruct dts;
     char *tmp_buffer = d->tmp_buffer;
     char *tmp;

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1680,6 +1680,9 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
     for (i = 0; i < n; i++) {
         PyObject *obj;
         obj = PySequence_GetItem(sort_keys, i);
+        if (obj == NULL) {
+            goto fail;
+        }
         mps[i] = (PyArrayObject *)PyArray_FROM_O(obj);
         Py_DECREF(obj);
         if (mps[i] == NULL) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1389,6 +1389,9 @@ execute_legacy_ufunc_loop(PyUFuncObject *ufunc,
                              PyArray_ISFORTRAN(op[0]) ?
                                             NPY_ARRAY_F_CONTIGUOUS : 0,
                              NULL);
+                if (op[1] == NULL) {
+                    return -1;
+                }
 
                 /* Call the __prepare_array__ if necessary */
                 if (prepare_ufunc_output(ufunc, &op[1],
@@ -1441,6 +1444,9 @@ execute_legacy_ufunc_loop(PyUFuncObject *ufunc,
                                  PyArray_ISFORTRAN(tmp) ?
                                                 NPY_ARRAY_F_CONTIGUOUS : 0,
                                  NULL);
+                if (op[2] == NULL) {
+                    return -1;
+                }
 
                 /* Call the __prepare_array__ if necessary */
                 if (prepare_ufunc_output(ufunc, &op[2],

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -526,6 +526,9 @@ class TestDateTime(TestCase):
                             "'%s'" % np.datetime_as_string(x, timezone='UTC')}),
                      "['2011-03-16T13:55Z', '1920-01-01T03:12Z']")
 
+        # Check that one NaT doesn't corrupt subsequent entries
+        a = np.array(['2010', 'NaT', '2030']).astype('M')
+        assert_equal(str(a), "['2010' 'NaT' '2030']")
 
     def test_pickle(self):
         # Check that pickle roundtripping works

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -386,6 +386,17 @@ class TestRegression(TestCase):
         v = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         assert_equal(np.lexsort(v), 0)
 
+    def test_lexsort_invalid_sequence(self):
+        # Issue gh-4123
+        class BuggySequence(object):
+            def __len__(self):
+                return 4
+            def __getitem__(self, key):
+                raise KeyError
+
+        assert_raises(KeyError, np.lexsort, BuggySequence())
+
+
     def test_pickle_dtype(self,level=rlevel):
         """Ticket #251"""
         pickle.dumps(np.float)

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -138,6 +138,7 @@ from __future__ import division, absolute_import, print_function
 
 import numpy
 import sys
+import io
 from numpy.lib.utils import safe_eval
 from numpy.compat import asbytes, isfileobj, long, basestring
 
@@ -187,10 +188,7 @@ def read_magic(fp):
     major : int
     minor : int
     """
-    magic_str = fp.read(MAGIC_LEN)
-    if len(magic_str) != MAGIC_LEN:
-        msg = "could not read %d characters for the magic string; got %r"
-        raise ValueError(msg % (MAGIC_LEN, magic_str))
+    magic_str = _read_bytes(fp, MAGIC_LEN, "magic string")
     if magic_str[:-2] != MAGIC_PREFIX:
         msg = "the magic string is not correct; expected %r, got %r"
         raise ValueError(msg % (MAGIC_PREFIX, magic_str[:-2]))
@@ -322,14 +320,9 @@ def read_array_header_1_0(fp):
     # Read an unsigned, little-endian short int which has the length of the
     # header.
     import struct
-    hlength_str = fp.read(2)
-    if len(hlength_str) != 2:
-        msg = "EOF at %s before reading array header length"
-        raise ValueError(msg % fp.tell())
+    hlength_str = _read_bytes(fp, 2, "array header length")
     header_length = struct.unpack('<H', hlength_str)[0]
-    header = fp.read(header_length)
-    if len(header) != header_length:
-        raise ValueError("EOF at %s before reading array header" % fp.tell())
+    header = _read_bytes(fp, header_length, "array header")
 
     # The header is a pretty-printed string representation of a literal Python
     # dictionary with trailing newlines padded to a 16-byte boundary. The keys
@@ -467,11 +460,10 @@ def read_array(fp):
             max_read_count = BUFFER_SIZE // min(BUFFER_SIZE, dtype.itemsize)
 
             array = numpy.empty(count, dtype=dtype)
-
             for i in range(0, count, max_read_count):
                 read_count = min(max_read_count, count - i)
-
-                data = fp.read(int(read_count * dtype.itemsize))
+                read_size = int(read_count * dtype.itemsize)
+                data = _read_bytes(fp, read_size, "array data")
                 array[i:i+read_count] = numpy.frombuffer(data, dtype=dtype,
                                                          count=read_count)
 
@@ -592,3 +584,31 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
         mode=mode, offset=offset)
 
     return marray
+
+
+def _read_bytes(fp, size, error_template="ran out of data"):
+    """
+    Read from file-like object until size bytes are read.
+    Raises ValueError if not EOF is encountered before size bytes are read.
+    Non-blocking objects only supported if they derive from io objects.
+
+    Required as e.g. ZipExtFile in python 2.6 can return less data than
+    requested.
+    """
+    data = bytes()
+    while True:
+        # io files (default in python3) return None or raise on would-block,
+        # python2 file will truncate, probably nothing can be done about that.
+        # note that regular files can't be non-blocking
+        try:
+            r = fp.read(size - len(data))
+            data += r
+            if len(r) == 0 or len(data) == size:
+                break
+        except io.BlockingIOError:
+            pass
+    if len(data) != size:
+        msg = "EOF: reading %s, expected %d bytes got %d"
+        raise ValueError(msg %(error_template, size, len(data)))
+    else:
+        return data

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -725,8 +725,10 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             elif fname.endswith('.bz2'):
                 import bz2
                 fh = iter(bz2.BZ2File(fname))
-            else:
+            elif sys.version_info[0] == 2:
                 fh = iter(open(fname, 'U'))
+            else:
+                fh = iter(open(fname))
         else:
             fh = iter(fname)
     except TypeError:
@@ -1330,7 +1332,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     own_fhd = False
     try:
         if isinstance(fname, basestring):
-            fhd = iter(np.lib._datasource.open(fname, 'rbU'))
+            if sys.version_info[0] == 2:
+                fhd = iter(np.lib._datasource.open(fname, 'rbU'))
+            else:
+                fhd = iter(np.lib._datasource.open(fname, 'rb'))
             own_fhd = True
         else:
             fhd = iter(fname)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -926,7 +926,7 @@ class TestHistogram(TestCase):
 
         # Normalization
         h, b = histogram(a, range=[1, 9], normed=True)
-        assert_equal((h * diff(b)).sum(), 1)
+        assert_almost_equal((h * diff(b)).sum(), 1, decimal=15)
 
         # Weights
         w = np.arange(10) + .5

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -22,7 +22,7 @@ from numpy.core import (
     array, asarray, zeros, empty, empty_like, transpose, intc, single, double,
     csingle, cdouble, inexact, complexfloating, newaxis, ravel, all, Inf, dot,
     add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
-    finfo, errstate, geterrobj, longdouble, rollaxis, amin, amax, product,
+    finfo, errstate, geterrobj, longdouble, rollaxis, amin, amax, product, abs,
     broadcast
     )
 from numpy.lib import triu, asfarray
@@ -2082,12 +2082,20 @@ def norm(x, ord=None, axis=None):
                 ord + 1
             except TypeError:
                 raise ValueError("Invalid norm order for vectors.")
-            if x.dtype.type is not longdouble:
+            if x.dtype.type is longdouble:
                 # Convert to a float type, so integer arrays give
                 # float results.  Don't apply asfarray to longdouble arrays,
                 # because it will downcast to float64.
-                absx = asfarray(abs(x))
-            return add.reduce(absx**ord, axis=axis)**(1.0/ord)
+                absx = abs(x)
+            else:
+                absx = asfarray(x)
+                if absx.dtype is x.dtype:
+                    absx = abs(absx)
+                else:
+                    # if the type changed, we can safely overwrite absx
+                    abs(absx, out=absx)
+            absx **= ord
+            return add.reduce(absx, axis=axis) ** (1.0 / ord)
     elif len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2088,7 +2088,7 @@ def norm(x, ord=None, axis=None):
                 # because it will downcast to float64.
                 absx = abs(x)
             else:
-                absx = asfarray(x)
+                absx = x if isComplexType(x.dtype.type) else asfarray(x)
                 if absx.dtype is x.dtype:
                     absx = abs(absx)
                 else:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -921,6 +921,18 @@ class _TestNorm(object):
         x = np.array([-2 ** 31], dtype=np.int32)
         old_assert_almost_equal(norm(x, ord=3), 2 ** 31, decimal=5)
 
+    def test_complex_high_ord(self):
+        # gh-4156
+        d = np.empty((2,), dtype=np.clongdouble)
+        d[0] = 6+7j
+        d[1] = -6+7j
+        res = 11.615898132184
+        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=10)
+        d = d.astype(np.complex128)
+        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=9)
+        d = d.astype(np.complex64)
+        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=5)
+
 
 class TestNormDouble(_TestNorm):
     dt = np.double

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -909,6 +909,18 @@ class _TestNorm(object):
         assert_raises(ValueError, norm, B, None, (2, 3))
         assert_raises(ValueError, norm, B, None, (0, 1, 2))
 
+    def test_longdouble_norm(self):
+        # Non-regression test: p-norm of longdouble would previously raise
+        # UnboundLocalError.
+        x = np.arange(10, dtype=np.longdouble)
+        old_assert_almost_equal(norm(x, ord=3), 12.65, decimal=2)
+
+    def test_intmin(self):
+        # Non-regression test: p-norm of signed integer would previously do
+        # float cast and abs in the wrong order.
+        x = np.array([-2 ** 31], dtype=np.int32)
+        old_assert_almost_equal(norm(x, ord=3), 2 ** 31, decimal=5)
+
 
 class TestNormDouble(_TestNorm):
     dt = np.double


### PR DESCRIPTION
backport #4020, #4051, #4094, #4115, #4124, #4141, #4144, #4163 to 1.8.x
