### PR TITLE
memoryview issues with python 3.4

### DIFF
--- a/doc/source/reference/c-api.config.rst
+++ b/doc/source/reference/c-api.config.rst
@@ -34,10 +34,10 @@ information is available to the pre-processor.
 
     sizeof(long)
 
-.. cvar:: NPY_SIZEOF_LONG_LONG
+.. cvar:: NPY_SIZEOF_LONGLONG
 
     sizeof(longlong) where longlong is defined appropriately on the
-    platform (A macro defines **NPY_SIZEOF_LONGLONG** as well.)
+    platform.
 
 .. cvar:: NPY_SIZEOF_PY_LONG_LONG
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -297,11 +297,11 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
         int is_standard_size = 1;
         int is_native_only_type = (descr->type_num == NPY_LONGDOUBLE ||
                                    descr->type_num == NPY_CLONGDOUBLE);
-#if NPY_SIZEOF_LONG_LONG != 8
-        is_native_only_type = is_native_only_type || (
-            descr->type_num == NPY_LONGLONG ||
-            descr->type_num == NPY_ULONGLONG);
-#endif
+        if (sizeof(npy_longlong) != 8) {
+            is_native_only_type = is_native_only_type || (
+                descr->type_num == NPY_LONGLONG ||
+                descr->type_num == NPY_ULONGLONG);
+        }
 
         *offset += descr->elsize;
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -339,6 +339,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
                              "cannot expose native-only dtype '%c' in "
                              "non-native byte order '%c' via buffer interface",
                              descr->type, descr->byteorder);
+                return -1;
             }
         }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3528,17 +3528,21 @@ class TestNewBufferProtocol(object):
         x = np.array([1, 2, 3], dtype='<i4')
         self._check_roundtrip(x)
 
+        # check long long can be represented as non-native
+        x = np.array([1, 2, 3], dtype='>q')
+        self._check_roundtrip(x)
+
         # Native-only data types can be passed through the buffer interface
         # only in native byte order
         if sys.byteorder == 'little':
-            x = np.array([1, 2, 3], dtype='>q')
+            x = np.array([1, 2, 3], dtype='>g')
             assert_raises(ValueError, self._check_roundtrip, x)
-            x = np.array([1, 2, 3], dtype='<q')
+            x = np.array([1, 2, 3], dtype='<g')
             self._check_roundtrip(x)
         else:
-            x = np.array([1, 2, 3], dtype='>q')
+            x = np.array([1, 2, 3], dtype='>g')
             self._check_roundtrip(x)
-            x = np.array([1, 2, 3], dtype='<q')
+            x = np.array([1, 2, 3], dtype='<g')
             assert_raises(ValueError, self._check_roundtrip, x)
 
     def test_roundtrip_half(self):
@@ -3651,9 +3655,9 @@ class TestNewBufferProtocol(object):
 
         sz = sum([dtype(b).itemsize for a, b in dt])
         if dtype('l').itemsize == 4:
-            assert_equal(y.format, 'T{b:a:=h:b:i:c:l:d:^q:dx:B:e:@H:f:=I:g:L:h:^Q:hx:=f:i:d:j:^g:k:=Zf:ix:Zd:jx:^Zg:kx:4s:l:=4w:m:3x:n:?:o:@e:p:}')
+            assert_equal(y.format, 'T{b:a:=h:b:i:c:l:d:q:dx:B:e:@H:f:=I:g:L:h:Q:hx:f:i:d:j:^g:k:=Zf:ix:Zd:jx:^Zg:kx:4s:l:=4w:m:3x:n:?:o:@e:p:}')
         else:
-            assert_equal(y.format, 'T{b:a:=h:b:i:c:q:d:^q:dx:B:e:@H:f:=I:g:Q:h:^Q:hx:=f:i:d:j:^g:k:=Zf:ix:Zd:jx:^Zg:kx:4s:l:=4w:m:3x:n:?:o:@e:p:}')
+            assert_equal(y.format, 'T{b:a:=h:b:i:c:q:d:q:dx:B:e:@H:f:=I:g:Q:h:Q:hx:f:i:d:j:^g:k:=Zf:ix:Zd:jx:^Zg:kx:4s:l:=4w:m:3x:n:?:o:@e:p:}')
         # Cannot test if NPY_RELAXED_STRIDES_CHECKING changes the strides
         if not (np.ones(1).strides[0] == np.iinfo(np.intp).max):
             assert_equal(y.strides, (sz,))


### PR DESCRIPTION
a late error return in the memoryview format string parsing triggers an assertion in python3.4 in debug mode during the tests.

an undefined macro was used in the format parsing causing all long long types to have native only requirement, fixed the type size check and testcases.
