### PR TITLE
ENH: speed up ufunc reduce argument parsing

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -69,6 +69,8 @@
 
 /* ---------------------------------------------------------------- */
 
+typedef int(*npy_converter)(PyObject *, PyObject **);
+
 static int
 _does_loop_use_arrays(void *data);
 
@@ -3639,6 +3641,60 @@ fail:
     return NULL;
 }
 
+/**
+ * Simple parsing of arguments args and kwds into the array obj.
+ * Apply PyObject conversion function to found arguments.
+ * Returns -1 if conversion failed or less thant `n` arguments were found.
+ */
+static int
+_parseargs(PyObject * args, PyObject * kwds, PyObject ** kwlist,
+           npy_converter * conv, npy_intp n, PyObject ** obj)
+{
+    Py_ssize_t na, nk;
+    Py_ssize_t i;
+    int args_found = 0;
+
+    if (!args || !kwds) {
+        return -1;
+    }
+    na = PyObject_Length(args);
+    nk = PyDict_Size(kwds);
+    if (na + nk != n) {
+        return -1;
+    }
+    for (i = 0; i < na; i++) {
+        obj[i] = PyTuple_GET_ITEM(args, i);
+        if (obj[i]) {
+            args_found++;
+        }
+    }
+    i = na;
+    for (i = na; i < n; i++) {
+        obj[i] = PyDict_GetItem(kwds, kwlist[i]);
+        if (obj[i]) {
+            args_found++;
+        }
+    }
+
+    if (args_found != n) {
+        return -1;
+    }
+
+    for (i = 0; i < n; i++) {
+        PyObject * tmp;
+        if (conv[i]) {
+            if (conv[i](obj[i], &tmp) == NPY_SUCCEED) {
+                obj[i] = tmp;
+            }
+            else {
+                return -1;
+            }
+        }
+    }
+
+    return args_found;
+}
+
 
 /*
  * This code handles reduce, reduceat, and accumulate
@@ -3661,6 +3717,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     int keepdims = 0;
     static char *kwlist1[] = {"array", "axis", "dtype",
                                 "out", "keepdims", NULL};
+    PyObject *okwlist1[] = {npy_um_str_array, npy_um_str_axis, npy_um_str_dtype,
+                            npy_um_str_out, npy_um_str_keepdims};
     static char *kwlist2[] = {"array", "indices", "axis",
                                 "dtype", "out", NULL};
     static char *_reduce_type[] = {"reduce", "accumulate", "reduceat", NULL};
@@ -3707,26 +3765,34 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
             return NULL;
         }
     }
-    else if (operation == UFUNC_ACCUMULATE) {
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&i", kwlist1,
-                                        &op,
-                                        &axes_in,
-                                        PyArray_DescrConverter2, &otype,
-                                        PyArray_OutputConverter, &out,
-                                        &keepdims)) {
-            Py_XDECREF(otype);
-            return NULL;
-        }
-    }
     else {
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&i", kwlist1,
-                                        &op,
-                                        &axes_in,
-                                        PyArray_DescrConverter2, &otype,
-                                        PyArray_OutputConverter, &out,
-                                        &keepdims)) {
-            Py_XDECREF(otype);
-            return NULL;
+        PyObject * obj[5] = {0};
+        npy_converter conv[5] = {NULL, NULL, (npy_converter)PyArray_DescrConverter2,
+                                 (npy_converter)PyArray_OutputConverter, NULL};
+        int r = _parseargs(args, kwds, okwlist1, conv, 5, obj);
+        if (r == 5) {
+            op = obj[0];
+            axes_in = obj[1];
+            otype = (PyArray_Descr*)obj[2];
+            out = (PyArrayObject*)obj[3];
+            keepdims = PyObject_IsTrue(obj[4]);
+            if (keepdims < 0) {
+                r = -1;
+            }
+        }
+
+        if (r != 5 || PyErr_Occurred()) {
+            Py_XDECREF(obj[3]);
+            PyErr_Clear();
+            if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&i", kwlist1,
+                                             &op,
+                                             &axes_in,
+                                             PyArray_DescrConverter2, &otype,
+                                             PyArray_OutputConverter, &out,
+                                             &keepdims)) {
+                Py_XDECREF(otype);
+                return NULL;
+            }
         }
     }
     /* Ensure input is an array */

--- a/numpy/core/src/umath/ufunc_object.h
+++ b/numpy/core/src/umath/ufunc_object.h
@@ -15,5 +15,9 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_array_wrap;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_array_finalize;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_ufunc;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_pyvals_name;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_array;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_axis;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_dtype;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_keepdims;
 
 #endif

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -301,6 +301,10 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_array_wrap = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_array_finalize = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_ufunc = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_pyvals_name = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_array = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_axis = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_dtype = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_keepdims = NULL;
 
 /* intern some strings used in ufuncs */
 static int
@@ -313,6 +317,10 @@ intern_strings(void)
     npy_um_str_array_finalize = PyUString_FromString("__array_finalize__");
     npy_um_str_ufunc = PyUString_FromString("__numpy_ufunc__");
     npy_um_str_pyvals_name = PyUString_FromString(UFUNC_PYVALS_NAME);
+    npy_um_str_array = PyUString_FromString("array");
+    npy_um_str_axis = PyUString_FromString("axis");
+    npy_um_str_dtype = PyUString_FromString("dtype");
+    npy_um_str_keepdims = PyUString_FromString("keepdims");
 
     return npy_um_str_out && npy_um_str_subok && npy_um_str_array_prepare &&
         npy_um_str_array_wrap && npy_um_str_array_finalize && npy_um_str_ufunc;

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1070,5 +1070,64 @@ class TestUfunc(TestCase):
         self.assertRaises(TypeError, np.add.at, values, [0, 1], 1)
         assert_array_equal(values, np.array(['a', 1], dtype=np.object))
 
+    def test_reduce_arguments(self):
+        f = np.add.reduce
+        d = np.ones((5,2), dtype=int)
+        o = np.ones((2,), dtype=d.dtype)
+        r = o * 5
+        assert_equal(f(d), r)
+        # a, axis=0, dtype=None, out=None, keepdims=False
+        assert_equal(f(d, axis=0), r)
+        assert_equal(f(d, 0), r)
+        assert_equal(f(d, 0, dtype=None), r)
+        assert_equal(f(d, 0, dtype='i'), r)
+        assert_equal(f(d, 0, 'i'), r)
+        assert_equal(f(d, 0, None), r)
+        assert_equal(f(d, 0, None, out=None), r)
+        assert_equal(f(d, 0, None, out=o), r)
+        assert_equal(f(d, 0, None, o), r)
+        assert_equal(f(d, 0, None, None), r)
+        assert_equal(f(d, 0, None, None, keepdims=False), r)
+        assert_equal(f(d, 0, None, None, True), r.reshape((1,) + r.shape))
+        # multiple keywords
+        assert_equal(f(d, axis=0, dtype=None, out=None, keepdims=False), r)
+        assert_equal(f(d, 0, dtype=None, out=None, keepdims=False), r)
+        assert_equal(f(d, 0, None, out=None, keepdims=False), r)
+
+        # too little
+        assert_raises(TypeError, f)
+        # too much
+        assert_raises(TypeError, f, d, 0, None, None, False, 1)
+        # invalid axis
+        assert_raises(TypeError, f, d, "invalid")
+        assert_raises(TypeError, f, d, axis="invalid")
+        assert_raises(TypeError, f, d, axis="invalid", dtype=None,
+                      keepdims=True)
+        # invalid dtype
+        assert_raises(TypeError, f, d, 0, "invalid")
+        assert_raises(TypeError, f, d, dtype="invalid")
+        assert_raises(TypeError, f, d, dtype="invalid", out=None)
+        # invalid out
+        assert_raises(TypeError, f, d, 0, None, "invalid")
+        assert_raises(TypeError, f, d, out="invalid")
+        assert_raises(TypeError, f, d, out="invalid", dtype=None)
+        # keepdims boolean, no invalid value
+        # assert_raises(TypeError, f, d, 0, None, None, "invalid")
+        # assert_raises(TypeError, f, d, keepdims="invalid", axis=0, dtype=None)
+        # invalid mix
+        assert_raises(TypeError, f, d, 0, keepdims="invalid", dtype="invalid",
+                     out=None)
+
+        # invalid keyord
+        assert_raises(TypeError, f, d, 0, keepdims=True, invalid="invalid",
+                      out=None)
+        assert_raises(TypeError, f, d, invalid=0)
+        assert_raises(TypeError, f, d, axis=0, dtype=None, keepdims=True,
+                      out=None, invalid=0)
+        assert_raises(TypeError, f, d, axis=0, dtype=None,
+                      out=None, invalid=0)
+        assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
PyArg_ParseTupleAndKeywords makes out about 20% of the runtime of small
reductions. Replace it with faster parsing using pre-interned python
strings. This improves performance by about 15% for reductions in the
order of 100 elements.
Error handling is done by calling PyArg_ParseTupleAndKeywords after the
fast parsing fails.

before:

```
d = np.arange(100)
%timeit np.sum(d)
100000 loops, best of 3: 4.79 µs per loop
```

after:

```
d = np.arange(100)
%timeit np.sum(d)
100000 loops, best of 3: 4.03 µs per loop
```
