### PR TITLE
MAINT: Update link to numpydoc README

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -24,7 +24,7 @@ A Guide to NumPy/SciPy Documentation
    * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_
 
    Details of how to use it can be found `here
-   <https://github.com/numpy/numpydoc/blob/master/README.txt>`__ and
+   <https://github.com/numpy/numpydoc/blob/master/README.rst>`__ and
    `here
    <https://github.com/numpy/numpy/blob/master/doc/HOWTO_BUILD_DOCS.rst.txt>`__
 


### PR DESCRIPTION
This is the counterpart of my PR numpy/numpydoc#7 renaming the README.
