### PR TITLE
ENH: replace a few small allocations with PyObject_Malloc

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1678,7 +1678,7 @@ static PyObject *
 array_alloc(PyTypeObject *type, Py_ssize_t NPY_UNUSED(nitems))
 {
     /* nitems will always be 0 */
-    PyObject *obj = PyArray_malloc(type->tp_basicsize);
+    PyObject *obj = PyObject_Malloc(type->tp_basicsize);
     PyObject_Init(obj, type);
     return obj;
 }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4016,7 +4016,7 @@ PyMODINIT_FUNC initmultiarray(void) {
     if (!d) {
         goto err;
     }
-    PyArray_Type.tp_free = PyArray_free;
+    PyArray_Type.tp_free = PyObject_Free;
     if (PyType_Ready(&PyArray_Type) < 0) {
         return RETVAL;
     }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -194,7 +194,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
 
     /* Allocate memory for the iterator */
     iter = (NpyIter*)
-                PyArray_malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
+                PyObject_Malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
 
     NPY_IT_TIME_POINT(c_malloc);
 
@@ -217,7 +217,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
                         flags,
                         op_flags, op_itflags,
                         &NIT_MASKOP(iter))) {
-        PyArray_free(iter);
+        PyObject_Free(iter);
         return NULL;
     }
     /* Set resetindex to zero as well (it's just after the resetdataptr) */
@@ -549,7 +549,7 @@ NpyIter_Copy(NpyIter *iter)
 
     /* Allocate memory for the new iterator */
     size = NIT_SIZEOF_ITERATOR(itflags, ndim, nop);
-    newiter = (NpyIter*)PyArray_malloc(size);
+    newiter = (NpyIter*)PyObject_Malloc(size);
 
     /* Copy the raw values to the new iterator */
     memcpy(newiter, iter, size);
@@ -664,9 +664,7 @@ NpyIter_Deallocate(NpyIter *iter)
         /* buffers */
         buffers = NBF_BUFFERS(bufferdata);
         for(iop = 0; iop < nop; ++iop, ++buffers) {
-            if (*buffers) {
-                PyArray_free(*buffers);
-            }
+            PyArray_free(*buffers);
         }
         /* read bufferdata */
         transferdata = NBF_READTRANSFERDATA(bufferdata);
@@ -691,7 +689,7 @@ NpyIter_Deallocate(NpyIter *iter)
     }
 
     /* Deallocate the iterator memory */
-    PyArray_free(iter);
+    PyObject_Free(iter);
 
     return NPY_SUCCEED;
 }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -111,7 +111,7 @@ gentype_alloc(PyTypeObject *type, Py_ssize_t nitems)
     PyObject *obj;
     const size_t size = _PyObject_VAR_SIZE(type, nitems + 1);
 
-    obj = (PyObject *)PyArray_malloc(size);
+    obj = (PyObject *)PyObject_Malloc(size);
     memset(obj, 0, size);
     if (type->tp_itemsize == 0) {
         PyObject_INIT(obj, type);
@@ -1540,7 +1540,7 @@ gentype_byteswap(PyObject *self, PyObject *args)
 
         gentype_getreadbuf(self, 0, (void **)&data);
         descr = PyArray_DescrFromScalar(self);
-        newmem = PyArray_malloc(descr->elsize);
+        newmem = PyObject_Malloc(descr->elsize);
         if (newmem == NULL) {
             Py_DECREF(descr);
             return PyErr_NoMemory();
@@ -1549,7 +1549,7 @@ gentype_byteswap(PyObject *self, PyObject *args)
             descr->f->copyswap(newmem, data, 1, NULL);
         }
         new = PyArray_Scalar(newmem, descr, NULL);
-        PyArray_free(newmem);
+        PyObject_Free(newmem);
         Py_DECREF(descr);
         return new;
     }
@@ -3985,7 +3985,7 @@ initialize_numeric_types(void)
     PyGenericArrType_Type.tp_getset = gentype_getsets;
     PyGenericArrType_Type.tp_new = NULL;
     PyGenericArrType_Type.tp_alloc = gentype_alloc;
-    PyGenericArrType_Type.tp_free = PyArray_free;
+    PyGenericArrType_Type.tp_free = PyObject_Free;
     PyGenericArrType_Type.tp_repr = gentype_repr;
     PyGenericArrType_Type.tp_str = gentype_str;
     PyGenericArrType_Type.tp_richcompare = gentype_richcompare;
@@ -4009,7 +4009,7 @@ initialize_numeric_types(void)
     PyBoolArrType_Type.tp_as_number->nb_index = (unaryfunc)bool_index;
 
     PyStringArrType_Type.tp_alloc = NULL;
-    PyStringArrType_Type.tp_free = NULL;
+    PyStringArrType_Type.tp_free = PyObject_Free;
 
     PyStringArrType_Type.tp_repr = stringtype_repr;
     PyStringArrType_Type.tp_str = stringtype_str;


### PR DESCRIPTION
It uses a faster small object allocator for sizes smaller than 512 bytes
(256 in python2). This improves nditer construction and scalar
operations by about 10%.

For now only replace high profile encapsulated nditer allocation and 
python object (PyArray and gentype) allocations that go over tp_free to
ensure no non-buggy third party application is broken.
