### PR TITLE
ENH: change `np.digitize` to use binary search

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -144,26 +144,31 @@ def new_digitize(x, bins, right=False):
     >>> np.digitize(x,bins,right=False)
     array([1, 3, 3, 4, 5])
     """
-    x = np.asarray(x).ravel()
-    bins = np.asarray(bins).ravel()
-    
-    if not x.size or not bins.size:
-        raise ValueError('Both x and bins must have non-zero length.')
-    
-    stride = 1
-    if np.all(bins[:-1] > bins[1:]):
-        stride = -1
-    elif not np.all(bins[:-1] < bins[1:]):
-        msg = 'The bins must be monotonically increasing or decreasing.'
+    x = np.asarray(x)
+
+    # scalars get promoted to 1-D arrays
+    bins = np.array(bins, copy=False, ndmin=1)
+    if bins.ndim > 1:
+        msg = "bins must be 1-dimensional"
         raise ValueError(msg)
-    bins = bins[::stride]
-    
+    if bins.size == 0:
+        msg = "bins must have non-zero length"
+        raise ValueError(msg)
+
+    stride = 1
+    # if np.all(bins[:-1] >= bins[1:]):
+        # stride = -1
+    # elif not np.all(bins[:-1] <= bins[1:]):
+        # msg = 'the bins must be monotonically increasing or decreasing'
+        # raise ValueError(msg)
+    # bins = bins[::stride]
+
     side = 'left' if right else 'right'
     out = np.searchsorted(bins, x, side=side)
-    
+
     if stride == -1:
         out = bins.size - out
-    
+
     return out
 
 def histogram(a, bins=10, range=None, normed=False, weights=None,
@@ -3223,7 +3228,7 @@ def meshgrid(*xi, **kwargs):
     Make N-D coordinate arrays for vectorized evaluations of
     N-D scalar/vector fields over N-D grids, given
     one-dimensional coordinate arrays x1, x2,..., xn.
-    
+
     .. versionchanged:: 1.9
        1-D and 0-D cases are allowed.
 
@@ -3274,7 +3279,7 @@ def meshgrid(*xi, **kwargs):
         for i in range(nx):
             for j in range(ny):
                 # treat xv[j,i], yv[j,i]
-    
+
     In the 1-D and 0-D case, the indexing and sparse keywords have no effect.
 
     See Also

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -7,6 +7,93 @@
 #include "numpy/ufuncobject.h"
 #include "string.h"
 
+static void
+bin_incr_slot_(const double *x, const double *bins, npy_intp *out,
+               npy_intp len_x, npy_intp len_bins)
+{
+    for (; len_x > 0; len_x--,
+                     x++,
+                     out++) {
+        npy_intp imin = 0,
+                 imax = len_bins;
+        while (imin < imax) {
+            npy_intp imid = imin + ((imax - imin) >> 1);
+            if (bins[imid] <= *x) {
+                imin = imid + 1;
+            }
+            else {
+                imax = imid;
+            }
+        }
+        *out = imin;
+    }
+}
+
+static void
+bin_incr_slot_right_(const double *x, const double *bins, npy_intp *out,
+                     npy_intp len_x, npy_intp len_bins)
+{
+    for (; len_x > 0; len_x--,
+                     x++,
+                     out++) {
+        npy_intp imin = 0,
+                 imax = len_bins;
+        while (imin < imax) {
+            npy_intp imid = imin + ((imax - imin) >> 1);
+            if (bins[imid] < *x) {
+                imin = imid + 1;
+            }
+            else {
+                imax = imid;
+            }
+        }
+        *out = imin;
+    }
+}
+
+static void
+bin_decr_slot_(const double *x, const double *bins, npy_intp *out,
+               npy_intp len_x, npy_intp len_bins)
+{
+    for (; len_x > 0; len_x--,
+                     x++,
+                     out++) {
+        npy_intp imin = 0,
+                 imax = len_bins;
+        while (imin < imax) {
+            npy_intp imid = imin + ((imax - imin) >> 1);
+            if (bins[imid] > *x) {
+                imin = imid + 1;
+            }
+            else {
+                imax = imid;
+            }
+        }
+        *out = imin;
+    }
+}
+
+static void
+bin_decr_slot_right_(const double *x, const double *bins, npy_intp *out,
+                     npy_intp len_x, npy_intp len_bins)
+{
+    for (; len_x > 0; len_x--,
+                     x++,
+                     out++) {
+        npy_intp imin = 0,
+                 imax = len_bins;
+        while (imin < imax) {
+            npy_intp imid = imin + ((imax - imin) >> 1);
+            if (bins[imid] >= *x) {
+                imin = imid + 1;
+            }
+            else {
+                imax = imid;
+            }
+        }
+        *out = imin;
+    }
+}
 
 static npy_intp
 incr_slot_(double x, double *bins, npy_intp lbins)
@@ -381,7 +468,130 @@ fail:
     return NULL;
 }
 
+/*
+ * bindigitize (x, bins, right=False) returns an array of python integers the same
+ * length of x. The values i returned are such that bins [i - 1] <= x <
+ * bins [i] if bins is monotonically increasing, or bins [i - 1] > x >=
+ * bins [i] if bins is monotonically decreasing.  Beyond the bounds of
+ * bins, returns either i = 0 or i = len (bins) as appropriate.
+ * if right == True the comparison is bins [i - 1] < x <= bins[i]
+ * or bins [i - 1] >= x > bins[i]
+ */
+static PyObject *
+arr_bindigitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
+{
+    /* self is not used */
+    PyObject *ox, *obins;
+    PyArrayObject *ax = NULL, *abins = NULL, *aret = NULL;
+    double *dx, *dbins;
+    npy_intp lbins, lx;             /* lengths */
+    npy_intp right = 0; /* whether right or left is inclusive */
+    npy_intp *iret;
+    int m, i;
+    static char *kwlist[] = {"x", "bins", "right", NULL};
+    PyArray_Descr *type;
+    char bins_non_monotonic = 0;
 
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i", kwlist, &ox, &obins,
+                &right)) {
+        goto fail;
+    }
+    type = PyArray_DescrFromType(NPY_DOUBLE);
+    ax = (PyArrayObject *)PyArray_FromAny(ox, type,
+                                        1, 1, NPY_ARRAY_CARRAY, NULL);
+    if (ax == NULL) {
+        goto fail;
+    }
+    Py_INCREF(type);
+    abins = (PyArrayObject *)PyArray_FromAny(obins, type,
+                                        1, 1, NPY_ARRAY_CARRAY, NULL);
+    if (abins == NULL) {
+        goto fail;
+    }
+
+    lx = PyArray_SIZE(ax);
+    dx = (double *)PyArray_DATA(ax);
+    lbins = PyArray_SIZE(abins);
+    dbins = (double *)PyArray_DATA(abins);
+    aret = (PyArrayObject *)PyArray_SimpleNew(1, &lx, NPY_INTP);
+    if (aret == NULL) {
+        goto fail;
+    }
+    iret = (npy_intp *)PyArray_DATA(aret);
+
+    if (lx <= 0 || lbins < 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "Both x and bins must have non-zero length");
+            goto fail;
+    }
+    NPY_BEGIN_ALLOW_THREADS;
+    if (lbins == 1)  {
+        if (right == 0) {
+            for (i = 0; i < lx; i++) {
+                if (dx [i] >= dbins[0]) {
+                    iret[i] = 1;
+                }
+                else {
+                    iret[i] = 0;
+                }
+            }
+        }
+        else {
+            for (i = 0; i < lx; i++) {
+                if (dx [i] > dbins[0]) {
+                    iret[i] = 1;
+                }
+                else {
+                    iret[i] = 0;
+                }
+            }
+
+        }
+    }
+    else {
+        m = check_array_monotonic(dbins, lbins);
+        if (right == 0) {
+            if (m == -1) {
+                bin_decr_slot_(dx, dbins, iret, lx, lbins);
+            }
+            else if (m == 1) {
+                bin_incr_slot_(dx, dbins, iret, lx, lbins);
+            }
+            else {
+            /* defer PyErr_SetString until after NPY_END_ALLOW_THREADS */
+                bins_non_monotonic = 1;
+            }
+        }
+        else {
+            if ( m == -1 ) {
+                bin_decr_slot_right_(dx, dbins, iret, lx, lbins);
+            }
+            else if (m == 1) {
+                bin_incr_slot_right_(dx, dbins, iret, lx, lbins);
+            }
+            else {
+            /* defer PyErr_SetString until after NPY_END_ALLOW_THREADS */
+                bins_non_monotonic = 1;
+            }
+
+        }
+    }
+    NPY_END_ALLOW_THREADS;
+    if (bins_non_monotonic) {
+        PyErr_SetString(PyExc_ValueError,
+                "The bins must be monotonically increasing or decreasing");
+        goto fail;
+    }
+    Py_DECREF(ax);
+    Py_DECREF(abins);
+    return (PyObject *)aret;
+
+fail:
+    Py_XDECREF(ax);
+    Py_XDECREF(abins);
+    Py_XDECREF(aret);
+    return NULL;
+}
 
 static char arr_insert__doc__[] = "Insert vals sequentially into equivalent 1-d positions indicated by mask.";
 
@@ -1638,6 +1848,8 @@ static struct PyMethodDef methods[] = {
     {"bincount", (PyCFunction)arr_bincount,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"digitize", (PyCFunction)arr_digitize,
+        METH_VARARGS | METH_KEYWORDS, NULL},
+    {"bindigitize", (PyCFunction)arr_bindigitize,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"interp", (PyCFunction)arr_interp,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -727,39 +727,55 @@ class TestDigitize(TestCase):
         x = np.arange(-6, 5)
         bins = np.arange(-5, 5)
         assert_array_equal(digitize(x, bins), np.arange(11))
+        assert_array_equal(new_digitize(x, bins), np.arange(11))
+        assert_array_equal(bindigitize(x, bins), np.arange(11))
 
     def test_reverse(self):
         x = np.arange(5, -6, -1)
         bins = np.arange(5, -5, -1)
         assert_array_equal(digitize(x, bins), np.arange(11))
+        assert_array_equal(new_digitize(x, bins), np.arange(11))
+        assert_array_equal(bindigitize(x, bins), np.arange(11))
 
     def test_random(self):
         x = rand(10)
         bin = np.linspace(x.min(), x.max(), 10)
         assert_(np.all(digitize(x, bin) != 0))
+        assert_(np.all(new_digitize(x, bin) != 0))
+        assert_(np.all(bindigitize(x, bin) != 0))
 
     def test_right_basic(self):
         x = [1, 5, 4, 10, 8, 11, 0]
         bins = [1, 5, 10]
         default_answer = [1, 2, 1, 3, 2, 3, 0]
         assert_array_equal(digitize(x, bins), default_answer)
+        assert_array_equal(new_digitize(x, bins), default_answer)
+        assert_array_equal(bindigitize(x, bins), default_answer)
         right_answer = [0, 1, 1, 2, 2, 3, 0]
         assert_array_equal(digitize(x, bins, True), right_answer)
+        assert_array_equal(new_digitize(x, bins, True), right_answer)
+        assert_array_equal(bindigitize(x, bins, True), right_answer)
 
     def test_right_open(self):
         x = np.arange(-6, 5)
         bins = np.arange(-6, 4)
         assert_array_equal(digitize(x, bins, True), np.arange(11))
+        assert_array_equal(new_digitize(x, bins, True), np.arange(11))
+        assert_array_equal(bindigitize(x, bins, True), np.arange(11))
 
     def test_right_open_reverse(self):
         x = np.arange(5, -6, -1)
         bins = np.arange(4, -6, -1)
         assert_array_equal(digitize(x, bins, True), np.arange(11))
+        assert_array_equal(new_digitize(x, bins, True), np.arange(11))
+        assert_array_equal(bindigitize(x, bins, True), np.arange(11))
 
     def test_right_open_random(self):
         x = rand(10)
         bins = np.linspace(x.min(), x.max(), 10)
         assert_(np.all(digitize(x, bins, True) != 10))
+        assert_(np.all(new_digitize(x, bins, True) != 10))
+        assert_(np.all(bindigitize(x, bins, True) != 10))
 
     def test_monotonic(self):
         x = [-1, 0, 1, 2]


### PR DESCRIPTION
Currently `np.digitize` uses a linear search to bin the input values, this
PR provides two different implementations of the same functionality using
binary search:

`np.new_digitize` is a pure Python function that replicates the functionality
of `np.digitize`, but calls `np.searchsorted` to perform the binning. While
it outperforms the current `np.digitize` for inputs with many bins, it can be
(much) slower for inputs with less than ~200 bins.

`np.bindigitize` is a modification of the C code, which replaces the current
binning functions with binary search equivalents, which are heavily leveraged
from the corresponding C functions of `np.searchsorted`. It appears to always
outperform `np.digitize`.

If this PR is accepted, only one of the two new functions would remain (I
think `np.bindigitize` should be it) and be renamed to the current
`np.digitize`.
