### PR TITLE
BUG: Fix large file support on 32 bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
   - 3.3
 matrix:
   include:
+    - python: 3.3
+      env: USE_CHROOT=1 ARCH=i386 DIST=saucy
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=0
     - python: 3.3
@@ -18,8 +20,6 @@ matrix:
       env: NPY_RELAXED_STRIDES_CHECKING=1
     - python: 2.7
       env: USE_BENTO=1
-    - python: 2.7
-      env: USE_CHROOT=1 ARCH=i386 DIST=saucy
 before_install:
   - uname -a
   - free -m

--- a/numpy/core/bscript
+++ b/numpy/core/bscript
@@ -491,7 +491,11 @@ def pre_build(context):
         return context.default_builder(extension,
                                        includes=includes,
                                        source=sources,
-                                       use="npysort npymath")
+                                       use="npysort npymath",
+                                       defines=['_FILE_OFFSET_BITS=64',
+                                                '_LARGEFILE_SOURCE=1',
+                                                '_LARGEFILE64_SOURCE=1']
+                                       )
     context.register_builder("multiarray", builder_multiarray)
 
     def build_ufunc(extension):

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -202,7 +202,7 @@ npy_PyFile_Dup(PyObject *file, char *mode, npy_off_t *orig_pos)
         fclose(handle);
         return NULL;
     }
-    pos = PyNumber_AsSsize_t(ret, PyExc_OverflowError);
+    pos = PyLong_AsLongLong(ret);
     Py_DECREF(ret);
     if (PyErr_Occurred()) {
         fclose(handle);

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -193,7 +193,8 @@ npy_PyFile_Dup(PyObject *file, char *mode, npy_off_t *orig_pos)
     *orig_pos = npy_ftell(handle);
     if (*orig_pos == -1) {
         PyErr_SetString(PyExc_IOError, "obtaining file position failed");
-        return -1;
+        fclose(handle);
+        return NULL;
     }
 
     /* Seek raw handle to the Python-side position */
@@ -210,7 +211,8 @@ npy_PyFile_Dup(PyObject *file, char *mode, npy_off_t *orig_pos)
     }
     if (npy_fseek(handle, pos, SEEK_SET) == -1) {
         PyErr_SetString(PyExc_IOError, "seeking file failed");
-        return -1;
+        fclose(handle);
+        return NULL;
     }
     return handle;
 }

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -74,8 +74,8 @@
         #error Unsupported size for type off_t
     #endif
 #else
-    #define npy_fseek fseek
-    #define npy_ftell ftell
+    #define npy_fseek fseeko
+    #define npy_ftell ftello
     #define npy_lseek lseek
     #define npy_off_t off_t
 

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -74,8 +74,16 @@
         #error Unsupported size for type off_t
     #endif
 #else
+#ifdef HAVE_FSEEKO
     #define npy_fseek fseeko
+#else
+    #define npy_fseek fseek
+#endif
+#ifdef HAVE_FTELLO
     #define npy_ftell ftello
+#else
+    #define npy_ftell ftell
+#endif
     #define npy_lseek lseek
     #define npy_off_t off_t
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -629,6 +629,9 @@ def configuration(parent_package='',top_path=None):
     config.add_include_dirs(join('src', 'npysort'))
 
     config.add_define_macros([("HAVE_NPY_CONFIG_H", "1")])
+    config.add_define_macros([("_FILE_OFFSET_BITS", "64")])
+    config.add_define_macros([('_LARGEFILE_SOURCE', '1')])
+    config.add_define_macros([('_LARGEFILE64_SOURCE', '1')])
 
     config.numpy_include_dirs.extend(config.paths('include'))
 

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -98,7 +98,7 @@ MANDATORY_FUNCS = ["sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs",
 # replacement implementation. Note that some of these are C99 functions.
 OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
-        "copysign", "nextafter"]
+        "copysign", "nextafter", "ftello", "fseeko"]
 
 
 OPTIONAL_HEADERS = [
@@ -129,7 +129,7 @@ OPTIONAL_GCC_ATTRIBUTES = [('__attribute__((optimize("unroll-loops")))',
 
 # Subset of OPTIONAL_STDFUNCS which may alreay have HAVE_* defined by Python.h
 OPTIONAL_STDFUNCS_MAYBE = ["expm1", "log1p", "acosh", "atanh", "asinh", "hypot",
-        "copysign"]
+        "copysign", "ftello", "fseeko"]
 
 # C99 functions: float and long double versions
 C99_FUNCS = ["sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs", "floor",

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3132,18 +3132,18 @@ static PyArrayObject *
 array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nread)
 {
     PyArrayObject *r;
-    npy_intp start, numbytes;
+    npy_off_t start, numbytes;
 
     if (num < 0) {
         int fail = 0;
-        start = (npy_intp) npy_ftell(fp);
+        start = npy_ftell(fp);
         if (start < 0) {
             fail = 1;
         }
         if (npy_fseek(fp, 0, SEEK_END) < 0) {
             fail = 1;
         }
-        numbytes = (npy_intp) npy_ftell(fp);
+        numbytes = npy_ftell(fp);
         if (numbytes < 0) {
             fail = 1;
         }

--- a/numpy/lib/bscript
+++ b/numpy/lib/bscript
@@ -4,4 +4,8 @@ from bento.commands import hooks
 def build(context):
     context.tweak_extension("_compiled_base",
                   includes=["../core/include", "../core/include/numpy", "../core",
-                            "../core/src/private"])
+                            "../core/src/private"],
+                  defines=['_FILE_OFFSET_BITS=64',
+                           '_LARGEFILE_SOURCE=1',
+                           '_LARGEFILE64_SOURCE=1']
+                            )

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -626,6 +626,9 @@ def test_large_file_support():
     # try creating a large sparse file
     with tempfile.NamedTemporaryFile() as tf:
         try:
+            # seek past end would work too, but linux truncate somewhat
+            # increases the chances that we have a sparse filesystem and can
+            # avoid actually writing 5GB
             import subprocess as sp
             sp.check_call(["truncate", "-s", "5368709120", tf.name])
         except:

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -620,5 +620,29 @@ def test_bad_header():
     format.write_array_header_1_0(s, d)
     assert_raises(ValueError, format.read_array_header_1_0, s)
 
+
+def test_large_file_support():
+    from nose import SkipTest
+    # try creating a large sparse file
+    with tempfile.NamedTemporaryFile() as tf:
+        try:
+            import subprocess as sp
+            sp.check_call(["truncate", "-s", "5368709120", tf.name])
+        except:
+            raise SkipTest("Could not create 5GB large file")
+        # write a small array to the end
+        f = open(tf.name, "wb")
+        f.seek(5368709120)
+        d = np.arange(5)
+        np.save(f, d)
+        f.close()
+        # read it back
+        f = open(tf.name, "rb")
+        f.seek(5368709120)
+        r = np.load(f)
+        f.close()
+        assert_array_equal(r, d)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
In order to use files larger than 32 bit on 32 bit systems one must use 64 bit variables for all seeks. On linux this means enabling the lfs macros and using ftello/fseeko. Windows was also broken due to a conversion to Py_Ssize_t.

The added test does not need to write 5GB of data on sparse filesystems so it is enabled by default.

Also update the travis tests 32 bit to run under python3 as the bug is only triggered with that version.
