### PR TITLE
BUG: get_info('openblas') does not read libraries key

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -703,7 +703,7 @@ class system_info:
         else:
             found_libs = self._lib_list(lib_dirs, libs, exts)
             found_dirs = [lib_dirs]
-        if len(found_libs) == len(libs):
+        if len(found_libs) > 0 and len(found_libs) == len(libs):
             info = {'libraries': found_libs, 'library_dirs': found_dirs}
             # Now, check for optional libraries
             if is_sequence(lib_dirs):
@@ -1565,7 +1565,9 @@ class openblas_info(blas_info):
     def calc_info(self):
         lib_dirs = self.get_lib_dirs()
 
-        openblas_libs = self.get_libs('openblas_libs', self._lib_names)
+        openblas_libs = self.get_libs('libraries', self._lib_names)
+        if openblas_libs == self._lib_names: # backward compat with 1.8.0
+            openblas_libs = self.get_libs('openblas_libs', self._lib_names)
         info = self.check_libs(lib_dirs, openblas_libs, [])
         if info is None:
             return

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -86,13 +86,17 @@
 # **Warning**: OpenBLAS, by default, is built in multithreaded mode. Due to the
 # way Python's multiprocessing is implemented, a multithreaded OpenBLAS can
 # cause programs using both to hang as soon as a worker process is forked on
-# POSIX systems (Linux, Mac). Python 3.4 will introduce a new feature in
-# multiprocessing, called the "forkserver", which solves this problem. For
-# older versions, either compile OpenBLAS with multithreading turned off or
-# use Python threads instead of multiprocessing.
+# POSIX systems (Linux, Mac).
+# This is fixed in Openblas 0.2.9 for the pthread build, the OpenMP build using
+# GNU openmp is as of gcc-4.9 not fixed yet.
+# Python 3.4 will introduce a new feature in multiprocessing, called the
+# "forkserver", which solves this problem. For older versions, make sure
+# OpenBLAS is built using pthreads or use Python threads instead of
+# multiprocessing.
 # (This problem does not exist with multithreaded ATLAS.)
 #
 # http://docs.python.org/3.4/library/multiprocessing.html#contexts-and-start-methods
+# https://github.com/xianyi/OpenBLAS/issues/294
 #
 # [openblas]
 # libraries = openblas


### PR DESCRIPTION
The documented libraries tag in the site.cfg is not read by the configuration,
instead openblas_libs is used, this is inconsistent with atlas configuration.
So libraries first and then try openblas_libs for backward compatibility.
