### PR TITLE
DOC: site.cfg: warn against OpenBLAS and multiprocessing

### DIFF
--- a/site.cfg.example
+++ b/site.cfg.example
@@ -83,6 +83,17 @@
 # for your configuration (in the following example we installed OpenBLAS with
 # ``make install PREFIX=/opt/OpenBLAS``.
 #
+# **Warning**: OpenBLAS, by default, is built in multithreaded mode. Due to the
+# way Python's multiprocessing is implemented, a multithreaded OpenBLAS can
+# cause programs using both to hang as soon as a worker process is forked on
+# POSIX systems (Linux, Mac). Python 3.4 will introduce a new feature in
+# multiprocessing, called the "forkserver", which solves this problem. For
+# older versions, either compile OpenBLAS with multithreading turned off or
+# use Python threads instead of multiprocessing.
+# (This problem does not exist with multithreaded ATLAS.)
+#
+# http://docs.python.org/3.4/library/multiprocessing.html#contexts-and-start-methods
+#
 # [openblas]
 # libraries = openblas
 # library_dirs = /opt/OpenBLAS/lib


### PR DESCRIPTION
Fixes #654 by not fixing it; I don't think NumPy _can_ actually fix the problem as it's a design flaw in Python's multiprocessing. Listed various alternatives (Python 3.4 forkserver, single-threaded OpenBLAS, Python threading).

Maybe @ogrisel wants to chip in on this one as well?
