### PR TITLE
TST: core: fix tofile file positioning test

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2415,6 +2415,7 @@ class TestIO(object):
 
             f = open(self.filename, 'r+b')
             f.read(2)
+            f.seek(0, 1) # seek between read&write required by ANSI C
             np.array([0], dtype=np.float64).tofile(f)
             pos = f.tell()
             f.close()


### PR DESCRIPTION
Python 2 I/O is a thin wrapper on FILE\* C-API. All Python code must
follow the ANSI C requirement (see man fopen) that there is a seek or a
flush between reads and writes, otherwise the behavior is undefined.
Whether this is required depends on the CRT implementation; glibc
doesn't seem to require it, but OSX apparently does.

Fixes gh-4189
