### PR TITLE
Proposed fix for Bug #3255

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -954,6 +954,7 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_BEGIN_THREADS_DEF
 #define NPY_BEGIN_THREADS
 #define NPY_END_THREADS
+#define NPY_BEGIN_THREADS_THRESHOLDED(loop_size)
 #define NPY_BEGIN_THREADS_DESCR(dtype)
 #define NPY_END_THREADS_DESCR(dtype)
 #define NPY_ALLOW_C_API_DEF

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3490,14 +3490,15 @@ NPY_NO_EXPORT PyDataMem_EventHookFunc *
 PyDataMem_SetEventHook(PyDataMem_EventHookFunc *newhook,
                        void *user_data, void **old_data)
 {
-    PyGILState_STATE gilstate = PyGILState_Ensure();
+    NPY_ALLOW_C_API_DEF
+    NPY_ALLOW_C_API
     PyDataMem_EventHookFunc *temp = _PyDataMem_eventhook;
     _PyDataMem_eventhook = newhook;
     if (old_data != NULL) {
         *old_data = _PyDataMem_eventhook_user_data;
     }
     _PyDataMem_eventhook_user_data = user_data;
-    PyGILState_Release(gilstate);
+    NPY_DISABLE_C_API
     return temp;
 }
 
@@ -3511,12 +3512,13 @@ PyDataMem_NEW(size_t size)
 
     result = malloc(size);
     if (_PyDataMem_eventhook != NULL) {
-        PyGILState_STATE gilstate = PyGILState_Ensure();
+        NPY_ALLOW_C_API_DEF
+        NPY_ALLOW_C_API
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(NULL, result, size,
                                     _PyDataMem_eventhook_user_data);
         }
-        PyGILState_Release(gilstate);
+        NPY_DISABLE_C_API
     }
     return result;
 }
@@ -3531,12 +3533,13 @@ PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
 
     result = calloc(size, elsize);
     if (_PyDataMem_eventhook != NULL) {
-        PyGILState_STATE gilstate = PyGILState_Ensure();
+        NPY_ALLOW_C_API_DEF
+        NPY_ALLOW_C_API
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(NULL, result, size * elsize,
                                     _PyDataMem_eventhook_user_data);
         }
-        PyGILState_Release(gilstate);
+        NPY_DISABLE_C_API
     }
     return result;
 }
@@ -3549,12 +3552,13 @@ PyDataMem_FREE(void *ptr)
 {
     free(ptr);
     if (_PyDataMem_eventhook != NULL) {
-        PyGILState_STATE gilstate = PyGILState_Ensure();
+        NPY_ALLOW_C_API_DEF
+        NPY_ALLOW_C_API
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(ptr, NULL, 0,
                                     _PyDataMem_eventhook_user_data);
         }
-        PyGILState_Release(gilstate);
+        NPY_DISABLE_C_API
     }
 }
 
@@ -3568,12 +3572,13 @@ PyDataMem_RENEW(void *ptr, size_t size)
 
     result = realloc(ptr, size);
     if (_PyDataMem_eventhook != NULL) {
-        PyGILState_STATE gilstate = PyGILState_Ensure();
+        NPY_ALLOW_C_API_DEF
+        NPY_ALLOW_C_API
         if (_PyDataMem_eventhook != NULL) {
             (*_PyDataMem_eventhook)(ptr, result, size,
                                     _PyDataMem_eventhook_user_data);
         }
-        PyGILState_Release(gilstate);
+        NPY_DISABLE_C_API
     }
     return result;
 }

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1377,7 +1377,8 @@ NpyIter_DebugPrint(NpyIter *iter)
     NpyIter_AxisData *axisdata;
     npy_intp sizeof_axisdata;
 
-    PyGILState_STATE gilstate = PyGILState_Ensure();
+    NPY_ALLOW_C_API_DEF
+    NPY_ALLOW_C_API
 
     printf("\n------ BEGIN ITERATOR DUMP ------\n");
     printf("| Iterator Address: %p\n", (void *)iter);
@@ -1598,7 +1599,7 @@ NpyIter_DebugPrint(NpyIter *iter)
     printf("------- END ITERATOR DUMP -------\n");
     fflush(stdout);
 
-    PyGILState_Release(gilstate);
+    NPY_DISABLE_C_API
 }
 
 NPY_NO_EXPORT void

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -26,16 +26,22 @@ int xerbla_(char *srname, integer *info)
                                  6 for name, 4 for param. num. */
 
         int len = 0; /* length of subroutine name*/
+#ifdef WITH_THREAD
         PyGILState_STATE save;
+#endif
 
         while( len<6 && srname[len]!='\0' )
                 len++;
         while( len && srname[len-1]==' ' )
                 len--;
-
-        PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
+#ifdef WITH_THREAD
         save = PyGILState_Ensure();
+#endif
+        PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
         PyErr_SetString(PyExc_ValueError, buf);
+#ifdef WITH_THREAD
         PyGILState_Release(save);
+#endif
+
         return 0;
 }

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -26,16 +26,19 @@ int xerbla_(char *srname, integer *info)
                                  6 for name, 4 for param. num. */
 
         int len = 0; /* length of subroutine name*/
-        PyGILState_STATE save;
 
         while( len<6 && srname[len]!='\0' )
                 len++;
         while( len && srname[len-1]==' ' )
                 len--;
-
-        PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
+#ifdef WITH_THREAD
         save = PyGILState_Ensure();
+#endif
+        PyOS_snprintf(buf, sizeof(buf), format, len, srname, *info);
         PyErr_SetString(PyExc_ValueError, buf);
+#ifdef WITH_THREAD
         PyGILState_Release(save);
+#endif
+
         return 0;
 }


### PR DESCRIPTION
Another try for fixing #3255. Replaced the #ifdefs with NPY_ALLOW_C_API and NPY_DISABLE_C_API except for numpy/linalg/lapack_lite/python_xerbla.c where ndarraytypes.h is currently not included.
