### PR TITLE
ENH: avoid more thread save/restores for small iteration counts

### DIFF
--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -72,7 +72,11 @@ raw_array_assign_scalar(int ndim, npy_intp *shape,
     }
 
     if (!needs_api) {
-        NPY_BEGIN_THREADS;
+        npy_intp nitems = 1, i;
+        for (i = 0; i < ndim; i++) {
+            nitems *= shape_it[i];
+        }
+        NPY_BEGIN_THREADS_THRESHOLDED(nitems);
     }
 
     NPY_RAW_ITER_START(idim, ndim, coord, shape_it) {
@@ -145,7 +149,11 @@ raw_array_wheremasked_assign_scalar(int ndim, npy_intp *shape,
     }
 
     if (!needs_api) {
-        NPY_BEGIN_THREADS;
+        npy_intp nitems = 1, i;
+        for (i = 0; i < ndim; i++) {
+            nitems *= shape_it[i];
+        }
+        NPY_BEGIN_THREADS_THRESHOLDED(nitems);
     }
 
     NPY_RAW_ITER_START(idim, ndim, coord, shape_it) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1371,7 +1371,7 @@ iterator_loop(PyUFuncObject *ufunc,
         count_ptr = NpyIter_GetInnerLoopSizePtr(iter);
 
         if (!needs_api) {
-            NPY_BEGIN_THREADS;
+            NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
         }
 
         /* Execute the loop */
@@ -2743,7 +2743,7 @@ reduce_loop(NpyIter *iter, char **dataptrs, npy_intp *strides,
     }
 
     if (!needs_api) {
-        NPY_BEGIN_THREADS;
+        NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
     }
 
     if (skip_first_count > 0) {
@@ -3127,7 +3127,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         needs_api = NpyIter_IterationNeedsAPI(iter);
 
         if (!needs_api) {
-            NPY_BEGIN_THREADS;
+            NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
         }
 
         do {
@@ -3215,7 +3215,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             needs_api = PyDataType_REFCHK(op_dtypes[0]);
 
             if (!needs_api) {
-                NPY_BEGIN_THREADS;
+                NPY_BEGIN_THREADS_THRESHOLDED(count);
             }
 
             innerloop(dataptr_copy, &count,


### PR DESCRIPTION
Releasing the GIL is not worthwhile for small loop iteration counts.
This was previously only done for non-reduction ufuncs.
Do this now also for reductions and assignments.
Improves performance of small reductions by about 10% as they avoid two
save and restores.
