### PR TITLE
ENH: Added argv argument and docstring to run_module_suite.

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -75,7 +75,7 @@ def import_nose():
 
     return nose
 
-def run_module_suite(file_to_run=None,argv=None):
+def run_module_suite(file_to_run=None, argv=None):
     """
     Run a test module.
 
@@ -91,6 +91,8 @@ def run_module_suite(file_to_run=None,argv=None):
         Arguments to be passed to the nose test runner. ``argv[0]`` is 
         ignored. All command line arguments accepted by ``nosetests`` 
         will work.
+
+        .. versionadded:: 1.9.0
 
     Examples
     --------

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -76,6 +76,38 @@ def import_nose():
     return nose
 
 def run_module_suite(file_to_run=None,argv=None):
+    """
+    Run a test module.
+
+    Equivalent to calling ``$ nosetests <argv> <file_to_run>`` from 
+    the command line
+
+    Parameters
+    ----------
+    file_to_run: str, optional
+        Path to test module, or None. 
+        By default, run the module from which this function is called.
+    argv: list of strings
+        Arguments to be passed to the nose test runner. ``argv[0]`` is 
+        ignored. All command line arguments accepted by ``nosetests`` 
+        will work.
+
+    Examples
+    --------
+    Adding the following::
+
+        if __name__ == "__main__" :
+            run_module_suite(argv=sys.argv)
+
+    at the end of a test module will run the tests when that module is 
+    called in the python interpreter.
+
+    Alternatively, calling::
+
+    >>> run_module_suite(file_to_run="numpy/tests/test_matlib.py")
+
+    from an interpreter will run all the test routine in 'test_matlib.py'.
+    """
     if file_to_run is None:
         f = sys._getframe(1)
         file_to_run = f.f_locals.get('__file__', None)

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -75,14 +75,18 @@ def import_nose():
 
     return nose
 
-def run_module_suite(file_to_run = None):
+def run_module_suite(file_to_run=None,argv=None):
     if file_to_run is None:
         f = sys._getframe(1)
         file_to_run = f.f_locals.get('__file__', None)
         if file_to_run is None:
             raise AssertionError
 
-    import_nose().run(argv=['', file_to_run])
+    if argv is None:
+        argv = ['', file_to_run]
+    else:
+        argv = argv + [file_to_run]
+    import_nose().run(argv=argv)
 
 
 class NoseTester(object):


### PR DESCRIPTION
Adding an 'argv' optional argument to the "numpy.testing.run_module_suite" function lets the client pass arguments to the nose testrunner.

For example, this lets the user add things like:

run_module_suite(sys.argv)

at the end of a test module, so that arguments specified on the command
line will get passed to the nose runner. The user could then run:

$ python test_module.py --nocapture

This PR also adds a docstring to the "run_module_suite".
