### PR TITLE
ENH: Add encoding option to numpy text IO

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -9,6 +9,8 @@ Highlights
 ==========
 
 * The `np.einsum` function will use BLAS when possible
+* ``genfromtxt``, ``loadtxt``, ``fromregex`` and ``savetxt`` can now handle files
+with arbitrary encoding supported by Python.
 
 
 New functions
@@ -191,6 +193,18 @@ C API changes
 New Features
 ============
 
+Encoding argument for text IO functions
+---------------------------------------
+``genfromtxt``, ``loadtxt``, ``fromregex`` and ``savetxt`` can now handle files
+with arbitrary encoding supported by Python via the encoding argument.
+For backward compatiblity the argument defaults to the special ``bytes`` value
+which continues to treat text as raw byte values and continues to pass latin1
+encoded bytes to custom converters.
+Using any other value (including ``None`` for system default) will switch the
+functions to real text IO so one receives unicode strings instead of bytes in
+the resulting arrays.
+
+
 External ``nose`` plugins are usable by ``numpy.testing.Tester``
 ----------------------------------------------------------------
 ``numpy.testing.Tester`` is now aware of ``nose`` plugins that are outside the
@@ -219,6 +233,10 @@ The new ``chebinterpolate`` function interpolates a given function at the
 Chebyshev points of the first kind. A new ``Chebyshev.interpolate`` class
 method adds support for interpolation over arbitrary intervals using the scaled
 and shifted Chebyshev points of the first kind.
+Support for reading lzma compressed text files in Python 3
+----------------------------------------------------------
+With Python versions containing the ``lzma`` module the text IO functions can
+now transparently read from files with ``xz`` or ``lzma`` extension.
 
 
 Improvements
@@ -334,6 +352,10 @@ default is ``floatmode='maxprec'`` with ``precision=8``, which will print at mos
 8 fractional digits, or fewer if an element can be uniquely represented with
 fewer.
 
+Reduced memory usage of ``np.loadtxt``
+--------------------------------------
+``np.loadtxt`` now reads files in chunks instead of all at once which decreases
+its memory usage significantly for large files.
 
 Changes
 =======

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -122,6 +122,12 @@ class _FileOpeners(object):
             self._file_openers[".gz"] = _gzipopen
         except ImportError:
             pass
+        try:
+            import lzma
+            self._file_openers[".xz"] = lzma.open
+            self._file_openers[".lzma"] = lzma.open
+        except ImportError:
+            pass
         self._loaded = True
 
     def keys(self):

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -216,8 +216,6 @@ class LineSplitter(object):
 
     def _delimited_splitter(self, line):
         """Chop off comments, strip, and split at delimiter. """
-        line = _decode_line(line, self.encoding)
-
         if self.comments is not None:
             line = line.split(self.comments)[0]
         line = line.strip(" \r\n")
@@ -227,8 +225,6 @@ class LineSplitter(object):
     #
 
     def _fixedwidth_splitter(self, line):
-        line = _decode_line(line, self.encoding)
-
         if self.comments is not None:
             line = line.split(self.comments)[0]
         line = line.strip("\r\n")
@@ -240,8 +236,6 @@ class LineSplitter(object):
     #
 
     def _variablewidth_splitter(self, line):
-        line = _decode_line(line, self.encoding)
-
         if self.comments is not None:
             line = line.split(self.comments)[0]
         if not line:
@@ -251,7 +245,7 @@ class LineSplitter(object):
     #
 
     def __call__(self, line):
-        return self._handyman(line)
+        return self._handyman(_decode_line(line, self.encoding))
 
 
 class NameValidator(object):

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -17,15 +17,8 @@ else:
     from __builtin__ import bool, int, float, complex, object, unicode, str
 
 
-if sys.version_info[0] >= 3:
-    def _bytes_to_complex(s):
-        return complex(s.decode('ascii'))
-
-    def _bytes_to_name(s):
-        return s.decode('ascii')
-else:
-    _bytes_to_complex = complex
-    _bytes_to_name = str
+_bytes_to_complex = complex
+_bytes_to_name = str
 
 
 def _is_string_like(obj):
@@ -189,12 +182,10 @@ class LineSplitter(object):
         return lambda input: [_.strip() for _ in method(input)]
     #
 
-    def __init__(self, delimiter=None, comments=b'#', autostrip=True):
+    def __init__(self, delimiter=None, comments='#', autostrip=True, encoding=None):
         self.comments = comments
         # Delimiter is a character
-        if isinstance(delimiter, unicode):
-            delimiter = delimiter.encode('ascii')
-        if (delimiter is None) or _is_bytes_like(delimiter):
+        if (delimiter is None) or isinstance(delimiter, basestring):
             delimiter = delimiter or None
             _handyman = self._delimited_splitter
         # Delimiter is a list of field widths
@@ -213,21 +204,36 @@ class LineSplitter(object):
             self._handyman = self.autostrip(_handyman)
         else:
             self._handyman = _handyman
+        self.encoding = encoding
     #
 
     def _delimited_splitter(self, line):
+        """Chop off comments, strip, and split at delimiter. """
+        # decode bytes, default to latin1
+        if type(line) == bytes:
+            if self.encoding is None:
+                line = line.decode('latin1')
+            else:
+                line = line.decode(self.encoding)
+
         if self.comments is not None:
             line = line.split(self.comments)[0]
-        line = line.strip(b" \r\n")
+        line = line.strip(" \r\n")
         if not line:
             return []
         return line.split(self.delimiter)
     #
 
     def _fixedwidth_splitter(self, line):
+        # decode bytes, default to latin1
+        if type(line) == bytes:
+            if self.encoding is None:
+                line = line.decode('latin1')
+            else:
+                line = line.decode(self.encoding)
         if self.comments is not None:
             line = line.split(self.comments)[0]
-        line = line.strip(b"\r\n")
+        line = line.strip("\r\n")
         if not line:
             return []
         fixed = self.delimiter
@@ -236,6 +242,12 @@ class LineSplitter(object):
     #
 
     def _variablewidth_splitter(self, line):
+        # decode bytes, default to latin1
+        if type(line) == bytes:
+            if self.encoding is None:
+                line = line.decode('latin1')
+            else:
+                line = line.decode(self.encoding)
         if self.comments is not None:
             line = line.split(self.comments)[0]
         if not line:
@@ -434,9 +446,9 @@ def str2bool(value):
 
     """
     value = value.upper()
-    if value == b'TRUE':
+    if value == 'TRUE':
         return True
-    elif value == b'FALSE':
+    elif value == 'FALSE':
         return False
     else:
         raise ValueError("Invalid boolean")
@@ -529,7 +541,7 @@ class StringConverter(object):
     _mapper.extend([(nx.floating, float, nx.nan),
                     (nx.complexfloating, _bytes_to_complex, nx.nan + 0j),
                     (nx.longdouble, nx.longdouble, nx.nan),
-                    (nx.string_, bytes, b'???')])
+                    (nx.string_, asbytes, '???')])
 
     (_defaulttype, _defaultfunc, _defaultfill) = zip(*_mapper)
 
@@ -601,11 +613,6 @@ class StringConverter(object):
 
     def __init__(self, dtype_or_func=None, default=None, missing_values=None,
                  locked=False):
-        # Convert unicode (for Py3)
-        if isinstance(missing_values, unicode):
-            missing_values = asbytes(missing_values)
-        elif isinstance(missing_values, (list, tuple)):
-            missing_values = asbytes_nested(missing_values)
         # Defines a lock for upgrade
         self._locked = bool(locked)
         # No input dtype: minimal initialization
@@ -631,7 +638,7 @@ class StringConverter(object):
                 # None
                 if default is None:
                     try:
-                        default = self.func(b'0')
+                        default = self.func('0')
                     except ValueError:
                         default = None
                 dtype = self._getdtype(default)
@@ -676,11 +683,11 @@ class StringConverter(object):
                     self.func = lambda x: int(float(x))
         # Store the list of strings corresponding to missing values.
         if missing_values is None:
-            self.missing_values = set([b''])
+            self.missing_values = set([''])
         else:
-            if isinstance(missing_values, bytes):
-                missing_values = missing_values.split(b",")
-            self.missing_values = set(list(missing_values) + [b''])
+            if isinstance(missing_values, basestring):
+                missing_values = missing_values.split(",")
+            self.missing_values = set(list(missing_values) + [''])
         #
         self._callingfunction = self._strict_call
         self.type = self._dtypeortype(dtype)
@@ -801,7 +808,7 @@ class StringConverter(object):
             self.iterupgrade(value)
 
     def update(self, func, default=None, testing_value=None,
-               missing_values=b'', locked=False):
+               missing_values='', locked=False):
         """
         Set StringConverter attributes directly.
 
@@ -838,13 +845,13 @@ class StringConverter(object):
             self.type = self._dtypeortype(self._getdtype(default))
         else:
             try:
-                tester = func(testing_value or b'1')
+                tester = func(testing_value or '1')
             except (TypeError, ValueError):
                 tester = None
             self.type = self._dtypeortype(self._getdtype(tester))
         # Add the missing values to the existing set
         if missing_values is not None:
-            if _is_bytes_like(missing_values):
+            if isinstance(missing_values, basestring):
                 self.missing_values.add(missing_values)
             elif hasattr(missing_values, '__iter__'):
                 for val in missing_values:

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -17,10 +17,6 @@ else:
     from __builtin__ import bool, int, float, complex, object, unicode, str
 
 
-_bytes_to_complex = complex
-_bytes_to_name = str
-
-
 def _decode_line(line, encoding=None):
     """ decode bytes from binary input streams, default to latin1 """
     if type(line) == bytes:
@@ -537,7 +533,7 @@ class StringConverter(object):
         _mapper.append((nx.int64, int, -1))
 
     _mapper.extend([(nx.floating, float, nx.nan),
-                    (nx.complexfloating, _bytes_to_complex, nx.nan + 0j),
+                    (nx.complexfloating, complex, nx.nan + 0j),
                     (nx.longdouble, nx.longdouble, nx.nan),
                     (nx.unicode_, asunicode, '???'),
                     (nx.string_, asbytes, '???')])

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -21,6 +21,17 @@ _bytes_to_complex = complex
 _bytes_to_name = str
 
 
+def _decode_line(line, encoding=None):
+    """ decode bytes from binary input streams, default to latin1 """
+    if type(line) == bytes:
+        if encoding is None:
+            line = line.decode('latin1')
+        else:
+            line = line.decode(encoding)
+
+    return line
+
+
 def _is_string_like(obj):
     """
     Check whether obj behaves like a string.
@@ -209,12 +220,7 @@ class LineSplitter(object):
 
     def _delimited_splitter(self, line):
         """Chop off comments, strip, and split at delimiter. """
-        # decode bytes, default to latin1
-        if type(line) == bytes:
-            if self.encoding is None:
-                line = line.decode('latin1')
-            else:
-                line = line.decode(self.encoding)
+        line = _decode_line(line, self.encoding)
 
         if self.comments is not None:
             line = line.split(self.comments)[0]
@@ -225,12 +231,8 @@ class LineSplitter(object):
     #
 
     def _fixedwidth_splitter(self, line):
-        # decode bytes, default to latin1
-        if type(line) == bytes:
-            if self.encoding is None:
-                line = line.decode('latin1')
-            else:
-                line = line.decode(self.encoding)
+        line = _decode_line(line, self.encoding)
+
         if self.comments is not None:
             line = line.split(self.comments)[0]
         line = line.strip("\r\n")
@@ -242,12 +244,8 @@ class LineSplitter(object):
     #
 
     def _variablewidth_splitter(self, line):
-        # decode bytes, default to latin1
-        if type(line) == bytes:
-            if self.encoding is None:
-                line = line.decode('latin1')
-            else:
-                line = line.decode(self.encoding)
+        line = _decode_line(line, self.encoding)
+
         if self.comments is not None:
             line = line.split(self.comments)[0]
         if not line:

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -19,7 +19,7 @@ else:
 
 def _decode_line(line, encoding=None):
     """ decode bytes from binary input streams, default to latin1 """
-    if type(line) == bytes:
+    if type(line) is bytes:
         if encoding is None:
             line = line.decode('latin1')
         else:

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -8,7 +8,7 @@ __docformat__ = "restructuredtext en"
 import sys
 import numpy as np
 import numpy.core.numeric as nx
-from numpy.compat import asbytes, bytes, asbytes_nested, basestring
+from numpy.compat import asbytes, asunicode, bytes, asbytes_nested, basestring
 
 if sys.version_info[0] >= 3:
     from builtins import bool, int, float, complex, object, str
@@ -541,6 +541,7 @@ class StringConverter(object):
     _mapper.extend([(nx.floating, float, nx.nan),
                     (nx.complexfloating, _bytes_to_complex, nx.nan + 0j),
                     (nx.longdouble, nx.longdouble, nx.nan),
+                    (nx.unicode_, asunicode, '???'),
                     (nx.string_, asbytes, '???')])
 
     (_defaulttype, _defaultfunc, _defaultfill) = zip(*_mapper)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -2032,6 +2032,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         typestr = 'U'
         if byte_converters and strcolidx:
             # convert strings back to bytes for backward compatibility
+            warnings.warn(
+                "Reading strings without specifying the encoding argument is "
+                "deprecated. Set encoding, use None for the system default.",
+                np.VisibleDeprecationWarning, stacklevel=2)
             try:
                 for j in range(len(data)):
                     row = list(data[j])

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -2053,6 +2053,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                         ishomogeneous &= (ttype == dtype.type)
                         if ttype == np.string_:
                             ttype = "|S%i" % max(len(row[i]) for row in data)
+                        elif ttype == np.unicode_:
+                            ttype = "|U%i" % max(len(row[i]) for row in data)
                         descr.append(('', ttype))
                     else:
                         descr.append(('', dtype))

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1651,7 +1651,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             "or generator. Got %s instead." % type(fname))
 
     split_line = LineSplitter(delimiter=delimiter, comments=comments,
-                              autostrip=autostrip, encoding=encoding)._handyman
+                              autostrip=autostrip, encoding=encoding)
     validate_names = NameValidator(excludelist=excludelist,
                                    deletechars=deletechars,
                                    case_sensitive=case_sensitive,

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -922,9 +922,13 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     except TypeError:
         raise ValueError('fname must be a string, file handle, or generator')
     X = []
-    # input may be a python2 io stream, we must assume local encoding
+
+    # input may be a python2 io stream
+    if encoding is not None and encoding != 'bytes':
+        fencoding = encoding
+    # we must assume local encoding
     # TOOD emit portability warning?
-    if fencoding is None:
+    elif fencoding is None:
         import locale
         fencoding = locale.getpreferredencoding()
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1981,13 +1981,13 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     # Convert each value according to the converter:
     # We want to modify the list in place to avoid creating a new one...
     if loose:
-        rows = [list(x) for x in
+        rows = list(
             zip(*[[conv._loose_call(_r) for _r in map(itemgetter(i), rows)]
-                  for (i, conv) in enumerate(converters)])]
+                  for (i, conv) in enumerate(converters)]))
     else:
-        rows = [list(x) for x in
+        rows = list(
             zip(*[[conv._strict_call(_r) for _r in map(itemgetter(i), rows)]
-                  for (i, conv) in enumerate(converters)])]
+                  for (i, conv) in enumerate(converters)]))
 
     # Reset the dtype
     data = rows
@@ -1999,20 +1999,23 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                      if v == np.unicode_]
 
         typestr = 'U'
-        if byte_converters:
+        if byte_converters and strcolidx:
             # convert strings back to bytes for backward compatibility
             try:
-                for j, row in enumerate(data):
+                for j in range(len(data)):
+                    row = list(data[j])
                     for i in strcolidx:
                         row[i] = row[i].encode('latin1')
+                    data[j] = tuple(row)
                 typestr = 'S'
             except UnicodeEncodeError:
                 # we must use unicode, revert encoding
                 for k in range(0, j + 1):
+                    row = list(data[k])
                     for i in strcolidx:
-                        if isinstance(data[k][i], bytes):
-                            data[k][i] = data[k][i].decode('latin1')
-        data = [tuple(x) for x in data]
+                        if isinstance(row[i], bytes):
+                            row[i] = row[i].decode('latin1')
+                    data[k] = tuple(row)
 
         # ... and take the largest number of chars.
         for i in strcolidx:
@@ -2039,7 +2042,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         if usemask:
             outputmask = np.array(masks, dtype=mdtype)
     else:
-        data = [tuple(x) for x in data]
         # Overwrite the initial dtype names if needed
         if names and dtype.names:
             dtype.names = names

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1651,7 +1651,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             "or generator. Got %s instead." % type(fname))
 
     split_line = LineSplitter(delimiter=delimiter, comments=comments,
-                              autostrip=autostrip)._handyman
+                              autostrip=autostrip, encoding=encoding)._handyman
     validate_names = NameValidator(excludelist=excludelist,
                                    deletechars=deletechars,
                                    case_sensitive=case_sensitive,

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -817,6 +817,15 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         Legal values: 0 (default), 1 or 2.
 
         .. versionadded:: 1.6.0
+    encoding: string, optional
+        Encoding used to decode the inputfile. Does not apply to input streams.
+        The special value 'bytes' enables backward compatibility workarounds
+        that ensures you receive byte arrays as results if possible and passes
+        latin1 encoded strings to converters. Override this value to receive
+        unicode arrays and pass strings as input to converters.
+        If set to None the system default is used.
+
+        .. versionadded:: 1.14.0
 
     Returns
     -------
@@ -1137,6 +1146,11 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         ``numpy.loadtxt``.
 
         .. versionadded:: 1.7.0
+    encoding: string, optional
+        Encoding used to encode the outputfile. Does not apply to output
+        streams.
+
+        .. versionadded:: 1.14.0
 
 
     See Also
@@ -1346,6 +1360,10 @@ def fromregex(file, regexp, dtype, encoding=None):
         Groups in the regular expression correspond to fields in the dtype.
     dtype : dtype or list of dtypes
         Dtype for the structured array.
+    encoding: string, optional
+        Encoding used to decode the inputfile. Does not apply to input streams.
+
+        .. versionadded:: 1.14.0
 
     Returns
     -------
@@ -1517,6 +1535,15 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         to read the entire file.
 
         .. versionadded:: 1.10.0
+    encoding: string, optional
+        Encoding used to decode the inputfile. Does not apply to input streams.
+        The special value 'bytes' enables backward compatibility workarounds
+        that ensures you receive byte arrays as results if possible and passes
+        latin1 encoded strings to converters. Override this value to receive
+        unicode arrays and pass strings as input to converters.
+        If set to None the system default is used.
+
+        .. versionadded:: 1.14.0
 
     Returns
     -------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -16,7 +16,7 @@ from numpy.core.multiarray import packbits, unpackbits
 from ._iotools import (
     LineSplitter, NameValidator, StringConverter, ConverterError,
     ConverterLockError, ConversionWarning, _is_string_like,
-    has_nested_fields, flatten_dtype, easy_dtype, _bytes_to_name, _decode_line
+    has_nested_fields, flatten_dtype, easy_dtype, _decode_line
     )
 
 from numpy.compat import (
@@ -1696,8 +1696,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     # Check the names and overwrite the dtype.names if needed
     if names is True:
-        names = validate_names([_bytes_to_name(_.strip())
-                                for _ in first_values])
+        names = validate_names([str(_.strip()) for _ in first_values])
         first_line = ''
     elif _is_string_like(names):
         names = validate_names([_.strip() for _ in names.split(',')])

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -895,17 +895,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         if is_pathlib_path(fname):
             fname = str(fname)
         if _is_string_like(fname):
+            fh = iter(np.lib._datasource.open(fname, 'rt', encoding=encoding))
             fown = True
-            if fname.endswith('.gz'):
-                import gzip
-                fh = iter(gzip.GzipFile(fname))
-            elif fname.endswith('.bz2'):
-                import bz2
-                fh = iter(bz2.BZ2File(fname))
-            elif sys.version_info[0] == 2:
-                fh = iter(io.open(fname, 'U', encoding=encoding))
-            else:
-                fh = iter(open(fname, encoding=encoding))
         else:
             fh = iter(fname)
     except TypeError:
@@ -1564,10 +1555,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         if is_pathlib_path(fname):
             fname = str(fname)
         if isinstance(fname, basestring):
-            if sys.version_info[0] == 2:
-                fhd = iter(np.lib._datasource.open(fname, 'rU'))
-            else:
-                fhd = iter(np.lib._datasource.open(fname, 'r'))
+            fhd = iter(np.lib._datasource.open(fname, 'rt', encoding=encoding))
             own_fhd = True
         else:
             fhd = iter(fname)

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -19,61 +19,61 @@ class TestLineSplitter(object):
 
     def test_no_delimiter(self):
         "Test LineSplitter w/o delimiter"
-        strg = b" 1 2 3 4  5 # test"
+        strg = " 1 2 3 4  5 # test"
         test = LineSplitter()(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'5'])
+        assert_equal(test, ['1', '2', '3', '4', '5'])
         test = LineSplitter('')(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'5'])
+        assert_equal(test, ['1', '2', '3', '4', '5'])
 
     def test_space_delimiter(self):
         "Test space delimiter"
-        strg = b" 1 2 3 4  5 # test"
-        test = LineSplitter(b' ')(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5'])
-        test = LineSplitter(b'  ')(strg)
-        assert_equal(test, [b'1 2 3 4', b'5'])
+        strg = " 1 2 3 4  5 # test"
+        test = LineSplitter(' ')(strg)
+        assert_equal(test, ['1', '2', '3', '4', '', '5'])
+        test = LineSplitter('  ')(strg)
+        assert_equal(test, ['1 2 3 4', '5'])
 
     def test_tab_delimiter(self):
         "Test tab delimiter"
-        strg = b" 1\t 2\t 3\t 4\t 5  6"
-        test = LineSplitter(b'\t')(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'5  6'])
-        strg = b" 1  2\t 3  4\t 5  6"
-        test = LineSplitter(b'\t')(strg)
-        assert_equal(test, [b'1  2', b'3  4', b'5  6'])
+        strg = " 1\t 2\t 3\t 4\t 5  6"
+        test = LineSplitter('\t')(strg)
+        assert_equal(test, ['1', '2', '3', '4', '5  6'])
+        strg = " 1  2\t 3  4\t 5  6"
+        test = LineSplitter('\t')(strg)
+        assert_equal(test, ['1  2', '3  4', '5  6'])
 
     def test_other_delimiter(self):
         "Test LineSplitter on delimiter"
-        strg = b"1,2,3,4,,5"
-        test = LineSplitter(b',')(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5'])
+        strg = "1,2,3,4,,5"
+        test = LineSplitter(',')(strg)
+        assert_equal(test, ['1', '2', '3', '4', '', '5'])
         #
-        strg = b" 1,2,3,4,,5 # test"
-        test = LineSplitter(b',')(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5'])
+        strg = " 1,2,3,4,,5 # test"
+        test = LineSplitter(',')(strg)
+        assert_equal(test, ['1', '2', '3', '4', '', '5'])
 
     def test_constant_fixed_width(self):
         "Test LineSplitter w/ fixed-width fields"
-        strg = b"  1  2  3  4     5   # test"
+        strg = "  1  2  3  4     5   # test"
         test = LineSplitter(3)(strg)
-        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5', b''])
+        assert_equal(test, ['1', '2', '3', '4', '', '5', ''])
         #
-        strg = b"  1     3  4  5  6# test"
+        strg = "  1     3  4  5  6# test"
         test = LineSplitter(20)(strg)
-        assert_equal(test, [b'1     3  4  5  6'])
+        assert_equal(test, ['1     3  4  5  6'])
         #
-        strg = b"  1     3  4  5  6# test"
+        strg = "  1     3  4  5  6# test"
         test = LineSplitter(30)(strg)
-        assert_equal(test, [b'1     3  4  5  6'])
+        assert_equal(test, ['1     3  4  5  6'])
 
     def test_variable_fixed_width(self):
-        strg = b"  1     3  4  5  6# test"
+        strg = "  1     3  4  5  6# test"
         test = LineSplitter((3, 6, 6, 3))(strg)
-        assert_equal(test, [b'1', b'3', b'4  5', b'6'])
+        assert_equal(test, ['1', '3', '4  5', '6'])
         #
-        strg = b"  1     3  4  5  6# test"
+        strg = "  1     3  4  5  6# test"
         test = LineSplitter((6, 6, 9))(strg)
-        assert_equal(test, [b'1', b'3  4', b'5  6'])
+        assert_equal(test, ['1', '3  4', '5  6'])
 
 # -----------------------------------------------------------------------------
 
@@ -133,10 +133,9 @@ class TestNameValidator(object):
 
 
 def _bytes_to_date(s):
-    if sys.version_info[0] >= 3:
-        return date(*time.strptime(s.decode('latin1'), "%Y-%m-%d")[:3])
-    else:
-        return date(*time.strptime(s, "%Y-%m-%d")[:3])
+    if type(s) == bytes:
+        s = s.decode("latin1")
+    return date(*time.strptime(s, "%Y-%m-%d")[:3])
 
 
 class TestStringConverter(object):
@@ -155,7 +154,7 @@ class TestStringConverter(object):
         assert_equal(converter._status, 0)
 
         # test int
-        assert_equal(converter.upgrade(b'0'), 0)
+        assert_equal(converter.upgrade('0'), 0)
         assert_equal(converter._status, 1)
 
         # On systems where integer defaults to 32-bit, the statuses will be
@@ -164,30 +163,30 @@ class TestStringConverter(object):
         status_offset = int(nx.dtype(nx.integer).itemsize < nx.dtype(nx.int64).itemsize)
 
         # test int > 2**32
-        assert_equal(converter.upgrade(b'17179869184'), 17179869184)
+        assert_equal(converter.upgrade('17179869184'), 17179869184)
         assert_equal(converter._status, 1 + status_offset)
 
         # test float
-        assert_allclose(converter.upgrade(b'0.'), 0.0)
+        assert_allclose(converter.upgrade('0.'), 0.0)
         assert_equal(converter._status, 2 + status_offset)
 
         # test complex
-        assert_equal(converter.upgrade(b'0j'), complex('0j'))
+        assert_equal(converter.upgrade('0j'), complex('0j'))
         assert_equal(converter._status, 3 + status_offset)
 
-        # test str
-        assert_equal(converter.upgrade(b'a'), b'a')
-        assert_equal(converter._status, len(converter._mapper) - 1)
+        # test str TODO
+        #assert_equal(converter.upgrade(b'a'), b'a')
+        #assert_equal(converter._status, len(converter._mapper) - 1)
 
     def test_missing(self):
         "Tests the use of missing values."
-        converter = StringConverter(missing_values=(b'missing',
-                                                    b'missed'))
-        converter.upgrade(b'0')
-        assert_equal(converter(b'0'), 0)
-        assert_equal(converter(b''), converter.default)
-        assert_equal(converter(b'missing'), converter.default)
-        assert_equal(converter(b'missed'), converter.default)
+        converter = StringConverter(missing_values=('missing',
+                                                    'missed'))
+        converter.upgrade('0')
+        assert_equal(converter('0'), 0)
+        assert_equal(converter(''), converter.default)
+        assert_equal(converter('missing'), converter.default)
+        assert_equal(converter('missed'), converter.default)
         try:
             converter('miss')
         except ValueError:
@@ -198,11 +197,11 @@ class TestStringConverter(object):
         dateparser = _bytes_to_date
         StringConverter.upgrade_mapper(dateparser, date(2000, 1, 1))
         convert = StringConverter(dateparser, date(2000, 1, 1))
-        test = convert(b'2001-01-01')
+        test = convert('2001-01-01')
         assert_equal(test, date(2001, 1, 1))
-        test = convert(b'2009-01-01')
+        test = convert('2009-01-01')
         assert_equal(test, date(2009, 1, 1))
-        test = convert(b'')
+        test = convert('')
         assert_equal(test, date(2000, 1, 1))
 
     def test_string_to_object(self):
@@ -213,43 +212,43 @@ class TestStringConverter(object):
 
     def test_keep_default(self):
         "Make sure we don't lose an explicit default"
-        converter = StringConverter(None, missing_values=b'',
+        converter = StringConverter(None, missing_values='',
                                     default=-999)
-        converter.upgrade(b'3.14159265')
+        converter.upgrade('3.14159265')
         assert_equal(converter.default, -999)
         assert_equal(converter.type, np.dtype(float))
         #
         converter = StringConverter(
-            None, missing_values=b'', default=0)
-        converter.upgrade(b'3.14159265')
+            None, missing_values='', default=0)
+        converter.upgrade('3.14159265')
         assert_equal(converter.default, 0)
         assert_equal(converter.type, np.dtype(float))
 
     def test_keep_default_zero(self):
         "Check that we don't lose a default of 0"
         converter = StringConverter(int, default=0,
-                                    missing_values=b"N/A")
+                                    missing_values="N/A")
         assert_equal(converter.default, 0)
 
     def test_keep_missing_values(self):
         "Check that we're not losing missing values"
         converter = StringConverter(int, default=0,
-                                    missing_values=b"N/A")
+                                    missing_values="N/A")
         assert_equal(
-            converter.missing_values, set([b'', b'N/A']))
+            converter.missing_values, set(['', 'N/A']))
 
     def test_int64_dtype(self):
         "Check that int64 integer types can be specified"
         converter = StringConverter(np.int64, default=0)
-        val = b"-9223372036854775807"
+        val = "-9223372036854775807"
         assert_(converter(val) == -9223372036854775807)
-        val = b"9223372036854775807"
+        val = "9223372036854775807"
         assert_(converter(val) == 9223372036854775807)
 
     def test_uint64_dtype(self):
         "Check that uint64 integer types can be specified"
         converter = StringConverter(np.uint64, default=0)
-        val = b"9223372043271415339"
+        val = "9223372043271415339"
         assert_(converter(val) == 9223372043271415339)
 
 

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -207,7 +207,7 @@ class TestStringConverter(object):
     def test_string_to_object(self):
         "Make sure that string-to-object functions are properly recognized"
         conv = StringConverter(_bytes_to_date)
-        assert_equal(conv._mapper[-2][0](0), 0j)
+        assert_equal(conv._mapper[-3][0](0), 0j)
         assert_(hasattr(conv, 'default'))
 
     def test_keep_default(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1182,7 +1182,10 @@ class TestFromTxt(LoadTxtBase):
     def test_header(self):
         # Test retrieving a header
         data = TextIO('gender age weight\nM 64.0 75.0\nF 25.0 60.0')
-        test = np.ndfromtxt(data, dtype=None, names=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.ndfromtxt(data, dtype=None, names=True)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         control = {'gender': np.array([b'M', b'F']),
                    'age': np.array([64.0, 25.0]),
                    'weight': np.array([75.0, 60.0])}
@@ -1193,7 +1196,10 @@ class TestFromTxt(LoadTxtBase):
     def test_auto_dtype(self):
         # Test the automatic definition of the output dtype
         data = TextIO('A 64 75.0 3+4j True\nBCD 25 60.0 5+6j False')
-        test = np.ndfromtxt(data, dtype=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.ndfromtxt(data, dtype=None)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         control = [np.array([b'A', b'BCD']),
                    np.array([64, 25]),
                    np.array([75.0, 60.0]),
@@ -1239,7 +1245,10 @@ F   35  58.330000
 M   33  21.99
         """)
         # The # is part of the first name and should be deleted automatically.
-        test = np.genfromtxt(data, names=True, dtype=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(data, names=True, dtype=None)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         ctrl = np.array([('M', 21, 72.1), ('F', 35, 58.33), ('M', 33, 21.99)],
                         dtype=[('gender', '|S1'), ('age', int), ('weight', float)])
         assert_equal(test, ctrl)
@@ -1250,14 +1259,20 @@ M   21  72.100000
 F   35  58.330000
 M   33  21.99
         """)
-        test = np.genfromtxt(data, names=True, dtype=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(data, names=True, dtype=None)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         assert_equal(test, ctrl)
 
     def test_autonames_and_usecols(self):
         # Tests names and usecols
         data = TextIO('A B C D\n aaaa 121 45 9.1')
-        test = np.ndfromtxt(data, usecols=('A', 'C', 'D'),
-                            names=True, dtype=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.ndfromtxt(data, usecols=('A', 'C', 'D'),
+                                names=True, dtype=None)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         control = np.array(('aaaa', 45, 9.1),
                            dtype=[('A', '|S4'), ('C', int), ('D', float)])
         assert_equal(test, control)
@@ -1274,8 +1289,12 @@ M   33  21.99
     def test_converters_with_usecols_and_names(self):
         # Tests names and usecols
         data = TextIO('A B C D\n aaaa 121 45 9.1')
-        test = np.ndfromtxt(data, usecols=('A', 'C', 'D'), names=True,
-                            dtype=None, converters={'C': lambda s: 2 * int(s)})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.ndfromtxt(data, usecols=('A', 'C', 'D'), names=True,
+                                dtype=None,
+                                converters={'C': lambda s: 2 * int(s)})
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         control = np.array(('aaaa', 90, 9.1),
                            dtype=[('A', '|S4'), ('C', int), ('D', float)])
         assert_equal(test, control)
@@ -1733,11 +1752,17 @@ M   33  21.99
         # Test autostrip
         data = "01/01/2003  , 1.3,   abcde"
         kwargs = dict(delimiter=",", dtype=None)
-        mtest = np.ndfromtxt(TextIO(data), **kwargs)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            mtest = np.ndfromtxt(TextIO(data), **kwargs)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         ctrl = np.array([('01/01/2003  ', 1.3, '   abcde')],
                         dtype=[('f0', '|S12'), ('f1', float), ('f2', '|S8')])
         assert_equal(mtest, ctrl)
-        mtest = np.ndfromtxt(TextIO(data), autostrip=True, **kwargs)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            mtest = np.ndfromtxt(TextIO(data), autostrip=True, **kwargs)
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         ctrl = np.array([('01/01/2003', 1.3, 'abcde')],
                         dtype=[('f0', '|S10'), ('f1', float), ('f2', '|S5')])
         assert_equal(mtest, ctrl)
@@ -1857,11 +1882,17 @@ M   33  21.99
 
     def test_comments_is_none(self):
         # Github issue 329 (None was previously being converted to 'None').
-        test = np.genfromtxt(TextIO("test1,testNonetherestofthedata"),
-                             dtype=None, comments=None, delimiter=',')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(TextIO("test1,testNonetherestofthedata"),
+                                 dtype=None, comments=None, delimiter=',')
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         assert_equal(test[1], b'testNonetherestofthedata')
-        test = np.genfromtxt(TextIO("test1, testNonetherestofthedata"),
-                             dtype=None, comments=None, delimiter=',')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(TextIO("test1, testNonetherestofthedata"),
+                                 dtype=None, comments=None, delimiter=',')
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         assert_equal(test[1], b' testNonetherestofthedata')
 
     def test_latin1(self):
@@ -1869,8 +1900,11 @@ M   33  21.99
         norm = b"norm1,norm2,norm3\n"
         enc = b"test1,testNonethe" + latin1 + b",test3\n"
         s = norm + enc + norm
-        test = np.genfromtxt(TextIO(s),
-                             dtype=None, comments=None, delimiter=',')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(TextIO(s),
+                                 dtype=None, comments=None, delimiter=',')
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         assert_equal(test[1, 0], b"test1")
         assert_equal(test[1, 1], b"testNonethe" + latin1)
         assert_equal(test[1, 2], b"test3")
@@ -1881,8 +1915,11 @@ M   33  21.99
         assert_equal(test[1, 1], u"testNonethe" + latin1.decode('latin1'))
         assert_equal(test[1, 2], u"test3")
 
-        test = np.genfromtxt(TextIO(b"0,testNonethe" + latin1),
-                             dtype=None, comments=None, delimiter=',')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(TextIO(b"0,testNonethe" + latin1),
+                                 dtype=None, comments=None, delimiter=',')
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         assert_equal(test['f0'], 0)
         assert_equal(test['f1'], b"testNonethe" + latin1)
 
@@ -1897,8 +1934,11 @@ M   33  21.99
         norm = b"norm1,norm2,norm3\n"
         enc = b"test1,testNonethe" + utf8 + b",test3\n"
         s = norm + enc + norm
-        test = np.genfromtxt(TextIO(s),
-                             dtype=None, comments=None, delimiter=',')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
+            test = np.genfromtxt(TextIO(s),
+                                 dtype=None, comments=None, delimiter=',')
+            assert_(w[0].category is np.VisibleDeprecationWarning)
         ctl = np.array([
                  [b'norm1', b'norm2', b'norm3'],
                  [b'test1', b'testNonethe' + utf8, b'test3'],
@@ -1939,8 +1979,12 @@ M   33  21.99
                 f.write(u"norm1," + latin1.decode("latin1") + u",norm3\n")
                 f.write(u"test1,testNonethe" + utf8.decode("UTF-8") +
                         u",test3\n")
-            test = np.genfromtxt(path, dtype=None, comments=None,
-                                 delimiter=',')
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings('always', '',
+                                        np.VisibleDeprecationWarning)
+                test = np.genfromtxt(path, dtype=None, comments=None,
+                                     delimiter=',')
+                assert_(w[0].category is np.VisibleDeprecationWarning)
             ctl = np.array([
                      ["norm1", "norm2", "norm3"],
                      ["norm1", latin1.decode("latin1"), "norm3"],

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -512,6 +512,12 @@ class LoadTxtBase:
             x = getattr(np, self.loadfunc)(path, encoding="UTF-16", dtype=np.unicode)
             assert_array_equal(x, nonascii)
 
+    def test_binary_decode(self):
+        utf16 = b'\xff\xfeh\x04 \x00i\x04 \x00j\x04'
+        v = getattr(np, self.loadfunc)(BytesIO(utf16), dtype=np.unicode,
+                                       encoding='UTF-16')
+        assert_array_equal(v, np.array(utf16.decode('UTF-16').split()))
+
     def test_converters_decode(self):
         # test converters that decode strings
         c = TextIO()
@@ -1809,6 +1815,12 @@ M   33  21.99
                              dtype=None, comments=None, delimiter=',')
         assert_equal(test['f0'], 0)
         assert_equal(test['f1'], b"testNonethe" + latin1)
+
+    def test_binary_decode_autodtype(self):
+        utf16 = b'\xff\xfeh\x04 \x00i\x04 \x00j\x04'
+        v = getattr(np, self.loadfunc)(BytesIO(utf16), dtype=None,
+                                       encoding='UTF-16')
+        assert_array_equal(v, np.array(utf16.decode('UTF-16').split()))
 
     def test_utf8_byte_encoding(self):
         utf8 = b"\xcf\x96"

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -494,6 +494,14 @@ class TestSaveTxt(object):
                            dtype=np.unicode)
             assert_array_equal(a, b)
 
+    def test_unicode_bytestream(self):
+        utf8 = b'\xcf\x96'.decode('UTF-8')
+        a = np.array([utf8], dtype=np.unicode)
+        s = BytesIO()
+        np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
+        s.seek(0)
+        assert_equal(s.read().decode('UTF-8'), utf8 + '\n')
+
 
 class LoadTxtBase:
     def test_encoding(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1867,6 +1867,12 @@ M   33  21.99
         assert_equal(test[1, 0], b"test1")
         assert_equal(test[1, 1], b"testNonethe" + latin1)
         assert_equal(test[1, 2], b"test3")
+        test = np.genfromtxt(TextIO(s),
+                             dtype=None, comments=None, delimiter=',',
+                             encoding='latin1')
+        assert_equal(test[1, 0], u"test1")
+        assert_equal(test[1, 1], u"testNonethe" + latin1.decode('latin1'))
+        assert_equal(test[1, 2], u"test3")
 
         test = np.genfromtxt(TextIO(b"0,testNonethe" + latin1),
                              dtype=None, comments=None, delimiter=',')

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -869,33 +869,33 @@ class TestLoadTxt(object):
         np.loadtxt(c, delimiter=',', dtype=dt, comments=None)  # Should succeed
 
     def test_encoding(self):
-        with NamedTemporaryFile() as e:
-            e.write('0.\n1.\n2.'.encode("UTF-16"))
-            e.seek(0)
-            x = np.loadtxt(e.name, encoding="UTF-16")
+        with temppath() as path:
+            with open(path, "wb") as f:
+                f.write('0.\n1.\n2.'.encode("UTF-16"))
+            x = np.loadtxt(path, encoding="UTF-16")
             assert_array_equal(x, [0., 1., 2.])
 
     def test_stringload(self):
         # umlaute
         nonascii = b'\xc3\xb6\xc3\xbc\xc3\xb6'.decode("UTF-8")
-        with NamedTemporaryFile() as e:
-            e.write(nonascii.encode("UTF-16"))
-            e.seek(0)
-            x = np.loadtxt(e.name, encoding="UTF-16", dtype=np.unicode)
+        with temppath() as path:
+            with open(path, "wb") as f:
+                f.write(nonascii.encode("UTF-16"))
+            x = np.loadtxt(path, encoding="UTF-16", dtype=np.unicode)
             assert_array_equal(x, nonascii)
 
     def test_binary_load(self):
         butf8 = b"5,6,7,\xc3\x95scarscar\n\r15,2,3,hello\n\r"\
                 b"20,2,3,\xc3\x95scar\n\r"
         sutf8 = butf8.decode("UTF-8").replace("\r", "").splitlines()
-        with NamedTemporaryFile() as e:
-            e.write(butf8)
-            e.seek(0)
-            with open(e.name, "rb") as f:
+        with temppath() as path:
+            with open(path, "wb") as f:
+                f.write(butf8)
+            with open(path, "rb") as f:
                 x = np.loadtxt(f, encoding="UTF-8", dtype=np.unicode)
             assert_array_equal(x, sutf8)
             # test broken latin1 conversion people now rely on
-            with open(e.name, "rb") as f:
+            with open(path, "rb") as f:
                 x = np.loadtxt(f, encoding="UTF-8", dtype="S")
             #lutf8 = butf8.decode("latin1").replace("\r", "").splitlines()
             x = [b'5,6,7,\xc3\x95scarscar', b'15,2,3,hello', b'20,2,3,\xc3\x95scar']

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1309,6 +1309,18 @@ M   33  21.99
                            dtype=[('', '|S10'), ('', float)])
         assert_equal(test, control)
 
+    def test_utf8_userconverters_with_explicit_dtype(self):
+        utf8 = b'\xcf\x96'
+        with temppath() as path:
+            with open(path, 'wb') as f:
+                f.write(b'skip,skip,2001-01-01' + utf8 + b',1.0,skip')
+            test = np.genfromtxt(path, delimiter=",", names=None, dtype=float,
+                                 usecols=(2, 3), converters={2: np.unicode},
+                                 encoding='UTF-8')
+        control = np.array([('2001-01-01' + utf8.decode('UTF-8'), 1.)],
+                           dtype=[('', '|U11'), ('', float)])
+        assert_equal(test, control)
+
     def test_spacedelimiter(self):
         # Test space delimiter
         data = TextIO("1  2  3  4   5\n6  7  8  9  10")

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -600,6 +600,13 @@ class LoadTxtBase:
 
 class TestLoadTxt(LoadTxtBase):
     loadfunc = 'loadtxt'
+    def setUp(self):
+        # lower chunksize for testing
+        self.orig_chunk = np.lib.npyio._loadtxt_chunksize
+        np.lib.npyio._loadtxt_chunksize = 1
+    def tearDown(self):
+        np.lib.npyio._loadtxt_chunksize = self.orig_chunk
+
     def test_record(self):
         c = TextIO()
         c.write('1 2\n3 4')

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -9,7 +9,7 @@ import time
 import warnings
 import gc
 import io
-from io import BytesIO
+from io import BytesIO, StringIO
 from datetime import datetime
 import locale
 import re
@@ -520,6 +520,14 @@ class TestSaveTxt(object):
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
         assert_equal(s.read().decode('UTF-8'), utf8 + '\n')
+
+    def test_unicode_stringstream(self):
+        utf8 = b'\xcf\x96'.decode('UTF-8')
+        a = np.array([utf8], dtype=np.unicode)
+        s = StringIO()
+        np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
+        s.seek(0)
+        assert_equal(s.read(), utf8 + '\n')
 
 
 class LoadTxtBase:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1824,11 +1824,7 @@ M   33  21.99
         # Test that we can load data from a filename as well as a file
         # object
         tgt = np.arange(6).reshape((2, 3))
-        if sys.version_info[0] >= 3:
-            # python 3k is known to fail for '\r'
-            linesep = ('\n', '\r\n')
-        else:
-            linesep = ('\n', '\r\n', '\r')
+        linesep = ('\n', '\r\n', '\r')
 
         for sep in linesep:
             data = '0 1 2' + sep + '3 4 5'
@@ -1837,6 +1833,22 @@ M   33  21.99
                     f.write(data)
                 res = np.genfromtxt(name)
             assert_array_equal(res, tgt)
+
+    def test_gft_from_gzip(self):
+        # Test that we can load data from a gzipped file
+        wanted = np.arange(6).reshape((2, 3))
+        linesep = ('\n', '\r\n', '\r')
+
+        for sep in linesep:
+            data = '0 1 2' + sep + '3 4 5'
+            s = BytesIO()
+            with gzip.GzipFile(fileobj=s, mode='w') as g:
+                g.write(asbytes(data))
+
+            with temppath(suffix='.gz2') as name:
+                with open(name, 'w') as f:
+                    f.write(data)
+                assert_array_equal(np.genfromtxt(name), wanted)
 
     def test_gft_using_generator(self):
         # gft doesn't work with unicode.


### PR DESCRIPTION
add encoding flag to np.loadtxt to be able to load non default encoded
text files.
