### PR TITLE
BUG: IRR does not return valid solutions in range (-1,0)

### DIFF
--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -628,22 +628,28 @@ def irr(values):
 
     Examples
     --------
-    >>> print round(np.irr([-100, 39, 59, 55, 20]), 5)
+    >>> round(np.irr([-100, 39, 59, 55, 20]), 5)
     0.28095
+    >>> round(irr([-100, 0, 0, 74]), 5)
+    -0.0955
+    >>> round(np.irr([-100, 100, 0, -7]), 5)
+    -0.0833
+    >>> round(np.irr([-100, 100, 0, 7]), 5)
+    0.06206
 
     (Compare with the Example given for numpy.lib.financial.npv)
 
     """
     res = np.roots(values[::-1])
-    # Find the root(s) between 0 and 1
     mask = (res.imag == 0) & (res.real > 0) 
-    res = res[mask].real
+    # NPV(rate) = 0 can have more than one solution so we return
+    # only the largest solution (the extraneous solutions will
+    # have values near -100%). The largest solution for rate is
+    # the min of res.
     if res.size == 0:
         return np.nan
-    #TODO: change this to find the minimum value of the array (smallest res = largest rate, which will be th correct answer)
+    res = np.amin(res[mask].real).item()
     rate = 1.0/res - 1
-    if rate.size == 1:
-        rate = rate.item()
     return rate
 
 def npv(rate, values):

--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -636,10 +636,11 @@ def irr(values):
     """
     res = np.roots(values[::-1])
     # Find the root(s) between 0 and 1
-    mask = (res.imag == 0) & (res.real > 0) & (res.real <= 1)
+    mask = (res.imag == 0) & (res.real > 0) 
     res = res[mask].real
     if res.size == 0:
         return np.nan
+    #TODO: change this to find the minimum value of the array (smallest res = largest rate, which will be th correct answer)
     rate = 1.0/res - 1
     if rate.size == 1:
         rate = rate.item()

--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -628,28 +628,29 @@ def irr(values):
 
     Examples
     --------
-    >>> round(np.irr([-100, 39, 59, 55, 20]), 5)
+    >>> round(irr([-100, 39, 59, 55, 20]), 5)
     0.28095
     >>> round(irr([-100, 0, 0, 74]), 5)
     -0.0955
-    >>> round(np.irr([-100, 100, 0, -7]), 5)
+    >>> round(irr([-100, 100, 0, -7]), 5)
     -0.0833
-    >>> round(np.irr([-100, 100, 0, 7]), 5)
+    >>> round(irr([-100, 100, 0, 7]), 5)
     0.06206
+    >>> round(irr([-5, 10.5, 1, -8, 1]), 5)
+    0.0886
 
     (Compare with the Example given for numpy.lib.financial.npv)
 
     """
     res = np.roots(values[::-1])
     mask = (res.imag == 0) & (res.real > 0) 
-    # NPV(rate) = 0 can have more than one solution so we return
-    # only the largest solution (the extraneous solutions will
-    # have values near -100%). The largest solution for rate is
-    # the min of res.
     if res.size == 0:
         return np.nan
-    res = np.amin(res[mask].real).item()
+    res = res[mask].real
+    # NPV(rate) = 0 can have more than one solution so we return
+    # only the solution closest to zero.
     rate = 1.0/res - 1
+    rate = rate.item(np.argmin(np.abs(rate)))
     return rate
 
 def npv(rate, values):

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -13,6 +13,9 @@ class TestFinancial(TestCase):
         v = [-150000, 15000, 25000, 35000, 45000, 60000]
         assert_almost_equal(np.irr(v),
                             0.0524, 2)
+        v = [-100, 0, 0, 74]
+        assert_almost_equal(np.irr(v),
+                            -0.0955, 2)
 
     def test_pv(self):
         assert_almost_equal(np.pv(0.07, 20, 12000, 0),

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -16,6 +16,18 @@ class TestFinancial(TestCase):
         v = [-100, 0, 0, 74]
         assert_almost_equal(np.irr(v),
                             -0.0955, 2)
+        v = [-100, 39, 59, 55, 20]
+        assert_almost_equal(np.irr(v),
+                            0.28095, 2)
+        v = [-100, 100, 0, -7]
+        assert_almost_equal(np.irr(v),
+                            -0.0833, 2)
+        v = [-100, 100, 0, 7]
+        assert_almost_equal(np.irr(v),
+                            0.06206, 2)
+        v = [-5, 10.5, 1, -8, 1]
+        assert_almost_equal(np.irr(v),
+                            0.0886, 2)
 
     def test_pv(self):
         assert_almost_equal(np.pv(0.07, 20, 12000, 0),


### PR DESCRIPTION
The existing imlementation of numpy.irr finds the real roots of NPV(rate) and returns a root if there is a positive real root, and returns nan otherwise. The weakness in this implementation is that it does not find valid solutions when the solution is negative (as is the case when an investment loses money). 
The corrected implementation makes two changes. First, it allows all real roots, not just the positive roots. Second, it returns only the minimum of those real roots. In cases where the IRR is negative, there can be multiple roots. By convention, the largest of the rates (which is the smallest of the roots, since the root is 1/(1+rate)) is treated as the correct answer. For example, IRR([-100,0,0,-7]) has roots at both -69% and -8%, and the function returns -8%. The original implementation avoided this by eliminating all negative roots, but in doing so eliminated valid solutions as well.
This new implementation returns the same value as the original when the solution is positive, but returns valid answers in the range (-1,0) for which the original implementation returned nan.
Illustrative doctests were added in the docstring as well.
