### PR TITLE
Fix some build warnings

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -30,6 +30,12 @@ to an array via `np.array`.
 If the `overwrite_input` option is used the input is only partially instead of
 fully sorted.
 
+npy_3kcompat.h header change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The unused ``simple_capsule_dtor`` function has been removed from
+``npy_3kcompat.h``.  Note that this header is not meant to be used outside of
+numpy; other projects should be using their own copy of this file when needed.
+
 
 New Features
 ============

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -391,12 +391,6 @@ NpyCapsule_Check(PyObject *ptr)
     return PyCapsule_CheckExact(ptr);
 }
 
-static NPY_INLINE void
-simple_capsule_dtor(PyObject *cap)
-{
-    PyArray_free(PyCapsule_GetPointer(cap, NULL));
-}
-
 #else
 
 static NPY_INLINE PyObject *
@@ -428,12 +422,6 @@ static NPY_INLINE int
 NpyCapsule_Check(PyObject *ptr)
 {
     return PyCObject_Check(ptr);
-}
-
-static NPY_INLINE void
-simple_capsule_dtor(void *ptr)
-{
-    PyArray_free(ptr);
 }
 
 #endif

--- a/numpy/core/src/dummymodule.c
+++ b/numpy/core/src/dummymodule.c
@@ -6,6 +6,7 @@
  */
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define NO_IMPORT_ARRAY
 
 #include <Python.h>
 #include <npy_pycompat.h>

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -1798,7 +1798,7 @@ parse_operand_subscripts(char *subscripts, int length,
                         int *out_num_labels)
 {
     int i, idim, ndim_left, label;
-    int left_labels = 0, right_labels = 0, ellipsis = 0;
+    int ellipsis = 0;
 
     /* Process the labels from the end until the ellipsis */
     idim = ndim-1;
@@ -1820,7 +1820,6 @@ parse_operand_subscripts(char *subscripts, int length,
                     (*out_num_labels)++;
                 }
                 out_label_counts[label]++;
-                right_labels = 1;
             }
             else {
                 PyErr_Format(PyExc_ValueError,
@@ -1889,7 +1888,6 @@ parse_operand_subscripts(char *subscripts, int length,
                         (*out_num_labels)++;
                     }
                     out_label_counts[label]++;
-                    left_labels = 1;
                 }
                 else {
                     PyErr_Format(PyExc_ValueError,
@@ -1954,7 +1952,7 @@ parse_output_subscripts(char *subscripts, int length,
                         char *out_labels)
 {
     int i, nlabels, label, idim, ndim, ndim_left;
-    int left_labels = 0, right_labels = 0, ellipsis = 0;
+    int ellipsis = 0;
 
     /* Count the labels, making sure they're all unique and valid */
     nlabels = 0;
@@ -2009,7 +2007,6 @@ parse_output_subscripts(char *subscripts, int length,
                             "too many output subscripts");
                 return -1;
             }
-            right_labels = 1;
         }
         /* The end of the ellipsis */
         else if (label == '.') {
@@ -2059,7 +2056,6 @@ parse_output_subscripts(char *subscripts, int length,
                                 "too many subscripts for the output");
                     return -1;
                 }
-                left_labels = 1;
             }
             else {
                 PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2132,7 +2132,7 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, @ftype@ * a, npy_uintp n,
     }
     else if (n <= PW_BLOCKSIZE) {
         npy_intp i;
-        @ftype@ r[8], res;
+        @ftype@ r[8];
 
         /*
          * sum a block with 8 accumulators

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -5,7 +5,8 @@
 
 #include "Python.h"
 
-#ifdef  ENABLE_SEPARATE_COMPILATION
+#include "npy_config.h"
+#ifdef ENABLE_SEPARATE_COMPILATION
 #define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
 #define NO_IMPORT_ARRAY
 #endif

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1239,8 +1239,9 @@ PyMODINIT_FUNC inittest_rational(void) {
         } \
         if (sizeof(_types)/sizeof(int)!=ufunc->nargs) { \
             PyErr_Format(PyExc_AssertionError, \
-                         "ufunc %s takes %d arguments, our loop takes %ld", \
-                         #name, ufunc->nargs, sizeof(_types)/sizeof(int)); \
+                         "ufunc %s takes %d arguments, our loop takes %lu", \
+                         #name, ufunc->nargs, (unsigned long) \
+                         (sizeof(_types)/sizeof(int))); \
             Py_DECREF(ufunc); \
             goto fail; \
         } \

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -2208,10 +2208,10 @@ process_@lapack_func@_results(GEEV_PARAMS_t *NPY_UNUSED(params))
 
 
 /**begin repeat
-   #TYPE=FLOAT,DOUBLE,CFLOAT,CDOUBLE#
-   #COMPLEXTYPE=CFLOAT,CDOUBLE,CFLOAT,CDOUBLE#
-   #ftype=fortran_real,fortran_doublereal,fortran_complex,fortran_doublecomplex#
-   #lapack_func=sgeev,dgeev,cgeev,zgeev#
+   #TYPE=FLOAT,DOUBLE,CDOUBLE#
+   #COMPLEXTYPE=CFLOAT,CDOUBLE,CDOUBLE#
+   #ftype=fortran_real,fortran_doublereal,fortran_doublecomplex#
+   #lapack_func=sgeev,dgeev,zgeev#
  */
 
 static inline void
@@ -2873,27 +2873,6 @@ static char equal_3_types[] = {
     NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT,
     NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE
-};
-
-static char equal_4_types[] = {
-    NPY_FLOAT, NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,
-    NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
-    NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT,
-    NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE
-};
-
-static char equal_5_types[] = {
-    NPY_FLOAT, NPY_FLOAT, NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,
-    NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
-    NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT,
-    NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE
-};
-
-static char equal_6_types[] = {
-    NPY_FLOAT, NPY_FLOAT, NPY_FLOAT, NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,
-    NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
-    NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT,
-    NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE
 };
 
 /* second result is logdet, that will always be a REAL */

--- a/numpy/random/mtrand/initarray.h
+++ b/numpy/random/mtrand/initarray.h
@@ -1,4 +1,5 @@
 #include "Python.h"
+#define NO_IMPORT_ARRAY
 #include "numpy/arrayobject.h"
 #include "randomkit.h"
 


### PR DESCRIPTION
Still one warning for `_import_array` coming from loops.c.src, no clue why.

The removal of `simple_capsule_dtor` also fixes scipy build warnings.
