### PR TITLE
BUG: fix reference count, thread safety and dtypes of np.where

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -20,6 +20,21 @@ Future Changes
 Compatibility notes
 ===================
 
+Special scalar float values don't cause upcast to double anymore
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In previous numpy versions operations involving floating point scalars
+containing special values `NaN`, `Inf` and `-Inf` caused the result type to be
+at least `float64`.
+As the special values can be represented in the smallest available floating
+point type the upcast not performed anymore.
+
+For example the dtype of:
+
+    np.array([1.], dtype=np.float32) * float('nan')
+
+now remains `float32` instead of being cast to `float64`.
+Operations involving non-special values have not been changed.
+
 Percentile output changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 If given more than one percentile to compute numpy.percentile returns an array

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -10,6 +10,7 @@
 #include "npy_config.h"
 
 #include "npy_pycompat.h"
+#include "numpy/npy_math.h"
 
 #include "common.h"
 #include "scalartypes.h"
@@ -1340,14 +1341,14 @@ static int min_scalar_type_num(char *valueptr, int type_num,
         }
         case NPY_FLOAT: {
             float value = *(float *)valueptr;
-            if (value > -65000 && value < 65000) {
+            if ((value > -65000 && value < 65000) || !npy_isfinite(value)) {
                 return NPY_HALF;
             }
             break;
         }
         case NPY_DOUBLE: {
             double value = *(double *)valueptr;
-            if (value > -65000 && value < 65000) {
+            if ((value > -65000 && value < 65000) || !npy_isfinite(value)) {
                 return NPY_HALF;
             }
             else if (value > -3.4e38 && value < 3.4e38) {
@@ -1357,7 +1358,7 @@ static int min_scalar_type_num(char *valueptr, int type_num,
         }
         case NPY_LONGDOUBLE: {
             npy_longdouble value = *(npy_longdouble *)valueptr;
-            if (value > -65000 && value < 65000) {
+            if ((value > -65000 && value < 65000) || !npy_isfinite(value)) {
                 return NPY_HALF;
             }
             else if (value > -3.4e38 && value < 3.4e38) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2782,7 +2782,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
                 int ayswap = PyDataType_ISBYTESWAPPED(dty);
                 PyArray_CopySwapFunc *copyswapx = dtx->f->copyswap;
                 PyArray_CopySwapFunc *copyswapy = dty->f->copyswap;
-                int native = (axswap == ayswap) && (axswap == 0);
+                int native = (axswap == ayswap) && (axswap == 0) && !needs_api;
                 npy_intp n = (*innersizeptr);
                 npy_intp itemsize = NpyIter_GetDescrArray(iter)[0]->elsize;
                 npy_intp cstride = NpyIter_GetInnerStrideArray(iter)[1];
@@ -2828,6 +2828,10 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
             } while (iternext(iter));
         }
 
+        if (!needs_api) {
+            NPY_END_THREADS;
+        }
+
         /* Get the result from the iterator object array */
         ret = (PyObject*)NpyIter_GetOperandArray(iter)[0];
         Py_INCREF(ret);
@@ -2835,9 +2839,6 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         Py_DECREF(ax);
         Py_DECREF(ay);
 
-        if (!needs_api) {
-            NPY_END_THREADS;
-        }
         if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
             Py_DECREF(ret);
             return NULL;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4118,6 +4118,26 @@ class TestWhere(TestCase):
         b = np.array([], dtype=np.float64).reshape(0, 3)
         assert_array_equal(np.where(m, 0, b), np.array([]).reshape(0, 3))
 
+        # object cast
+        d = np.array([-1.34, -0.16, -0.54, -0.31, -0.08, -0.95, 0.000, 0.313,
+                      0.547, -0.18, 0.876, 0.236, 1.969, 0.310, 0.699, 1.013,
+                      1.267, 0.229, -1.39, 0.487])
+        nan = float('NaN')
+        e = np.array(['5z', '0l', nan, 'Wz', nan, nan, 'Xq', 'cs', nan, nan,
+                     'QN', nan, nan, 'Fd', nan, nan, 'kp', nan, '36', 'i1'],
+                     dtype=object);
+        m = np.array([0,0,1,0,1,1,0,0,1,1,0,1,1,0,1,1,0,1,0,0], dtype=bool)
+
+        r = e[:]
+        r[np.where(m)] = d[np.where(m)]
+        assert_array_equal(np.where(m, d, e), r)
+
+        r = e[:]
+        r[np.where(~m)] = d[np.where(~m)]
+        assert_array_equal(np.where(m, e, d), r)
+
+        assert_array_equal(np.where(m, e, e), e)
+
     def test_ndim(self):
         c = [True, False]
         a = np.zeros((2, 25))

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4138,6 +4138,18 @@ class TestWhere(TestCase):
 
         assert_array_equal(np.where(m, e, e), e)
 
+        # minimal dtype result with NaN scalar (e.g required by pandas)
+        d =  np.array([1., 2.], dtype=np.float32)
+        e =  float('NaN')
+        assert_equal(np.where(True, d, e).dtype, np.float32)
+        e =  float('Infinity')
+        assert_equal(np.where(True, d, e).dtype, np.float32)
+        e =  float('-Infinity')
+        assert_equal(np.where(True, d, e).dtype, np.float32)
+        # also check upcast
+        e =  float(1e150)
+        assert_equal(np.where(True, d, e).dtype, np.float64)
+
     def test_ndim(self):
         c = [True, False]
         a = np.zeros((2, 25))


### PR DESCRIPTION
Objects must go over the objects copyswap function for correct reference
counting.
The GIL must be taken before arrays are DECREF'd

min_scalar_type_num must also handle `NaN` to avoid unecessary upcasts in np.where
