### PR TITLE
digitize: fix checking for zero length of `x` and `bins`.

### DIFF
--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -296,7 +296,7 @@ arr_digitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     }
     iret = (npy_intp *)PyArray_DATA(aret);
 
-    if (lx <= 0 || lbins < 0) {
+    if (lx == 0 || lbins == 0) {
         PyErr_SetString(PyExc_ValueError,
                 "Both x and bins must have non-zero length");
             goto fail;

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -723,6 +723,11 @@ class TestVectorize(TestCase):
 
 
 class TestDigitize(TestCase):
+    def test_zerolength_input(self):
+        assert_raises(ValueError, digitize, x=[], bins=[])
+        assert_raises(ValueError, digitize, x=[1], bins=[])
+        assert_raises(ValueError, digitize, x=[], bins=[1])
+
     def test_forward(self):
         x = np.arange(-6, 5)
         bins = np.arange(-5, 5)


### PR DESCRIPTION
In the current version of `digitize`, array length check and error message don't go together:

``` python

>>> import numpy
>>> print "numpy version: ", numpy.__version__
numpy version:  1.8.0
>>> from numpy import digitize
>>> digitize(x=[], bins=[])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Both x and bins must have non-zero length
>>> digitize(x=[1], bins=[])
array([0])
```

In contrast to the error message `bins` of length 0 currently does not lead to an exception. I don't see why this should make sense. The current code (`if (lx <= 0 || lbins < 0)`) seems weird. I replaced it with `if (lx == 0 || lbins == 0)` (according to http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PyArray_SIZE), leading to expected behavior:

``` python

>>> digitize(x=[], bins=[])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Both x and bins must have non-zero length
>>> digitize(x=[1], bins=[])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Both x and bins must have non-zero length
>>> digitize(x=[], bins=[1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Both x and bins must have non-zero length
>>> digitize(x=[1], bins=[1])
array([1])
```
