### PR TITLE
BUG: Fetching a non-integer item caused array return

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -560,7 +560,7 @@ array_subscript_simple(PyArrayObject *self, PyObject *op, int check_index)
     PyArrayObject *ret;
     npy_intp value;
 
-    if (!(PyArray_Check(op) && (PyArray_SIZE((PyArrayObject*)op) > 1))) {
+    if (!PyArray_Check(op)) {
         value = PyArray_PyIntAsIntp(op);
 
         if (value == -1 && PyErr_Occurred()) {
@@ -575,7 +575,7 @@ array_subscript_simple(PyArrayObject *self, PyObject *op, int check_index)
             }
         }
         else {
-            return array_item_asarray(self, value);
+            return array_item(self, value);
         }
     }
 

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -48,6 +48,17 @@ class TestIndexing(TestCase):
         a = np.array([[b, None]])
         assert_(isinstance(a[z, np.array(0)], np.ndarray))
 
+        # Regression, it needs to fall through integer and fancy indexing
+        # cases, so need the with statement to ignore the non-integer error.
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', '', DeprecationWarning)
+            a = np.array([1.])
+            assert_(isinstance(a[0.], np.float_))
+
+            a = np.array([np.array(1)], dtype=object)
+            assert_(isinstance(a[0.], np.ndarray))
+
+
     def test_empty_fancy_index(self):
         # Empty list index creates an empty array
         # with the same dtype (but with weird shape)


### PR DESCRIPTION
After a bug fix, a non-integer integer fetch (i.e. float), caused
array returns, because it passed through both integer and fancy
special cases which have logic in place to return scalars.
The last fallback incorrectly returned an array in this case.
