### PR TITLE
ENH: Type specific binary search functions for `searchsorted`

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -89,6 +89,12 @@ The performance of converting lists containing arrays to arrays using
 `np.array` has been improved. It is now equivalent in speed to
 `np.vstack(list)`.
 
+Performance improvement for `np.searchsorted`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For the built-in numeric types, `np.searchsorted` no longer relies on the
+data type's `compare` function to perform the search, but is now implemented
+by type specific functions. Depending on the size of the inputs, this can
+result in performance improvements over 2x.
 
 Changes
 =======

--- a/numpy/core/bento.info
+++ b/numpy/core/bento.info
@@ -11,10 +11,12 @@ Library:
     CompiledLibrary: npysort
         Sources:
             src/private/npy_partition.h.src,
+            src/private/npy_binsearch.h.src,
             src/npysort/quicksort.c.src,
             src/npysort/mergesort.c.src,
             src/npysort/heapsort.c.src,
-            src/npysort/selection.c.src
+            src/npysort/selection.c.src,
+            src/npysort/binsearch.c.src
     Extension: multiarray
         Sources:
             src/multiarray/multiarraymodule_onefile.c

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -707,7 +707,7 @@ def configuration(parent_package='',top_path=None):
     npysort_sources=[join('src', 'npysort', 'quicksort.c.src'),
                      join('src', 'npysort', 'mergesort.c.src'),
                      join('src', 'npysort', 'heapsort.c.src'),
-                     join('src','private', 'npy_partition.h.src'),
+                     join('src', 'private', 'npy_partition.h.src'),
                      join('src', 'npysort', 'selection.c.src'),
                      join('src', 'private', 'npy_binsearch.h.src'),
                      join('src', 'npysort', 'binsearch.c.src'),

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -708,7 +708,10 @@ def configuration(parent_package='',top_path=None):
                      join('src', 'npysort', 'mergesort.c.src'),
                      join('src', 'npysort', 'heapsort.c.src'),
                      join('src','private', 'npy_partition.h.src'),
-                     join('src', 'npysort', 'selection.c.src')]
+                     join('src', 'npysort', 'selection.c.src'),
+                     join('src', 'private', 'npy_binsearch.h.src'),
+                     join('src', 'npysort', 'binsearch.c.src'),
+                    ]
     config.add_library('npysort',
                        sources=npysort_sources,
                        include_dirs=[])

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1839,7 +1839,7 @@ PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
         else if (descr && !PyArray_ISNBO(descr->byteorder)) {
             PyArray_DESCR_REPLACE(descr);
         }
-        if (descr) {
+        if (descr && descr->byteorder != NPY_IGNORE) {
             descr->byteorder = NPY_NATIVE;
         }
     }

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1904,8 +1904,7 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
                   *ap2 = NULL,
                   *ap3 = NULL,
                   *sorter = NULL,
-                  *ret = NULL,
-                  *store_arr = NULL;
+                  *ret = NULL;
     PyArray_Descr *dtype;
     int ap1_flags = NPY_ARRAY_NOTSWAPPED | NPY_ARRAY_ALIGNED;
     PyArray_BinSearchFunc *binsearch = NULL;

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -1,0 +1,184 @@
+/* -*- c -*- */
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include "npy_sort.h"
+#include "npysort_common.h"
+#include "numpy/npy_math.h"
+#include "npy_binsearch.h"
+#include <stdlib.h>
+
+/*
+ *****************************************************************************
+ **                            NUMERIC SEARCHES                             **
+ *****************************************************************************
+ */
+
+/**begin repeat
+ *
+ * #TYPE = BOOL, BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
+ *         LONGLONG, ULONGLONG, HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA#
+ * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+ *         longlong, ulonglong, half, float, double, longdouble, 
+ *         cfloat, cdouble, clongdouble, datetime, timedelta#
+ * #type = npy_bool, npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int,
+ *         npy_uint, npy_long, npy_ulong, npy_longlong, npy_ulonglong,
+ *         npy_ushort, npy_float, npy_double, npy_longdouble, npy_cfloat,
+ *         npy_cdouble, npy_clongdouble, npy_datetime, npy_timedelta#
+ */
+ 
+#define @TYPE@_LTE(a, b) (!@TYPE@_LT((b), (a)))
+
+/**begin repeat1
+ *
+ * #side = left, right#
+ * #CMP  = LT, LTE#
+ */
+
+void
+binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
+                        npy_intp arr_len, npy_intp key_len,
+                        npy_intp arr_str, npy_intp key_str,
+                        npy_intp ret_str)
+{
+    for (; key_len > 0; key_len--,
+                        key += key_str,
+                        ret += ret_str) {
+        npy_intp min_idx = 0,
+                 max_idx = arr_len;
+        const @type@ key_val = *(const @type@ *)key;
+        
+        while (min_idx < max_idx) {
+            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const @type@ mid_val = *(const @type@ *)(arr + mid_idx * arr_str);
+            if (@TYPE@_@CMP@(mid_val, key_val)) {
+                min_idx = mid_idx + 1;
+            }
+            else {
+                max_idx = mid_idx;
+            }
+        }
+        *(npy_intp *)ret = min_idx;
+    }
+}
+
+int
+argbinsearch_@side@_@suff@(const char *arr, const char *key,
+                           const char *sort, char *ret,
+                           npy_intp arr_len, npy_intp key_len,
+                           npy_intp arr_str, npy_intp key_str,
+                           npy_intp sort_str, npy_intp ret_str)
+{
+    for (; key_len > 0; key_len--,
+                        key += key_str,
+                        ret += ret_str) {
+        npy_intp min_idx = 0,
+                 max_idx = arr_len;
+        const @type@ key_val = *(const @type@ *)key;
+
+        while (min_idx < max_idx) {
+            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
+                           sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
+            @type@ mid_val;
+            
+            if (sort_idx < 0 || sort_idx >= arr_len) {
+                return -1;
+            }
+
+            mid_val = *(const @type@ *)(arr + sort_idx * arr_str);
+            
+            if (@TYPE@_@CMP@(mid_val, key_val)) {
+                min_idx = mid_idx + 1;
+            }
+            else {
+                max_idx = mid_idx;
+            }
+        }
+        *(npy_intp *)ret = min_idx;
+    }
+    return 0;
+}
+
+/**end repeat1**/
+/**end repeat**/ 
+
+/*
+ *****************************************************************************
+ **                             GENERIC SEARCH                              **
+ *****************************************************************************
+ */
+
+#define GENERIC_LTE(a, b, cmp) (!GENERIC_LT(b, a, cmp))
+ 
+ /**begin repeat
+ *
+ * #side = left, right#
+ * #CMP  = LT, LTE#
+ */
+ 
+void
+npy_binsearch_@side@(const char *arr, const char *key, char *ret,
+                     npy_intp arr_len, npy_intp key_len,
+                     npy_intp arr_str, npy_intp key_str,
+                     npy_intp ret_str, npy_comparator cmp)
+{
+    for (; key_len > 0; key_len--,
+                        key += key_str,
+                        ret += ret_str) {
+        npy_intp min_idx = 0,
+                 max_idx = arr_len;
+        
+        while (min_idx < max_idx) {
+            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const char *arr_ptr = arr + mid_idx*arr_str;
+            
+            if (GENERIC_@CMP@(arr_ptr, key, cmp)) {
+                min_idx = mid_idx + 1;
+            }
+            else {
+                max_idx = mid_idx;
+            }
+        }
+        *(npy_intp *)ret = min_idx;
+    }
+}
+
+int
+npy_argbinsearch_@side@(const char *arr, const char *key,
+                        const char *sort, char *ret,
+                        npy_intp arr_len, npy_intp key_len,
+                        npy_intp arr_str, npy_intp key_str,
+                        npy_intp sort_str, npy_intp ret_str,
+                        npy_comparator cmp)
+{
+    for (; key_len > 0; key_len--,
+                        key += key_str,
+                        ret += ret_str) {
+        npy_intp min_idx = 0,
+                 max_idx = arr_len;
+        
+        while (min_idx < max_idx) {
+            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
+                           sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
+            const char *arr_ptr;
+            
+            if (sort_idx < 0 || sort_idx >= arr_len) {
+                return -1;
+            }
+            
+            arr_ptr = arr + sort_idx*arr_str;
+            
+            if (GENERIC_@CMP@(arr_ptr, key, cmp)) {
+                min_idx = mid_idx + 1;
+            }
+            else {
+                max_idx = mid_idx;
+            }
+        }
+        *(npy_intp *)ret = min_idx;
+    }
+    return 0;
+}
+
+/**end repeat**/

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -20,14 +20,14 @@
  *         LONGLONG, ULONGLONG, HALF, FLOAT, DOUBLE, LONGDOUBLE,
  *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA#
  * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
- *         longlong, ulonglong, half, float, double, longdouble, 
+ *         longlong, ulonglong, half, float, double, longdouble,
  *         cfloat, cdouble, clongdouble, datetime, timedelta#
  * #type = npy_bool, npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int,
  *         npy_uint, npy_long, npy_ulong, npy_longlong, npy_ulonglong,
  *         npy_ushort, npy_float, npy_double, npy_longdouble, npy_cfloat,
  *         npy_cdouble, npy_clongdouble, npy_datetime, npy_timedelta#
  */
- 
+
 #define @TYPE@_LTE(a, b) (!@TYPE@_LT((b), (a)))
 
 /**begin repeat1
@@ -45,7 +45,7 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */
     @type@ last_key_val;
-             
+
     for (; key_len > 0; key_len--,
                         key += key_str,
                         ret += ret_str) {
@@ -61,9 +61,9 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
-        
+
         last_key_val = key_val;
-        
+
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
             const @type@ mid_val = *(const @type@ *)(arr + mid_idx * arr_str);
@@ -104,20 +104,20 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
-        
+
         last_key_val = key_val;
 
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
                            sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
             @type@ mid_val;
-            
+
             if (sort_idx < 0 || sort_idx >= arr_len) {
                 return -1;
             }
 
             mid_val = *(const @type@ *)(arr + sort_idx * arr_str);
-            
+
             if (@TYPE@_@CMP@(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
             }
@@ -131,7 +131,7 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
 }
 
 /**end repeat1**/
-/**end repeat**/ 
+/**end repeat**/
 
 /*
  *****************************************************************************
@@ -140,19 +140,20 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
  */
 
 #define GENERIC_LTE(a, b, cmp) (!GENERIC_LT(b, a, cmp))
- 
+
  /**begin repeat
  *
  * #side = left, right#
- * #CMP  = LT, LTE#
+ * #CMP  = <, <=#
  */
- 
+
 void
 npy_binsearch_@side@(const char *arr, const char *key, char *ret,
                      npy_intp arr_len, npy_intp key_len,
-                     npy_intp arr_str, npy_intp key_str,
-                     npy_intp ret_str, npy_comparator cmp)
+                     npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
+                     PyArrayObject *cmp)
 {
+    PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */
     const char *last_key = key;
@@ -165,20 +166,19 @@ npy_binsearch_@side@(const char *arr, const char *key, char *ret,
          * gives the search a big boost when keys are sorted, but slightly
          * slows down things for purely random ones.
          */
-        if (GENERIC_LT(last_key, key, cmp)) {
+        if (compare(last_key, key, cmp) @CMP@ 0) {
             max_idx = arr_len;
         } else {
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
-        
+
         last_key = key;
-        
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
             const char *arr_ptr = arr + mid_idx*arr_str;
-            
-            if (GENERIC_@CMP@(arr_ptr, key, cmp)) {
+
+            if (compare(arr_ptr, key, cmp) @CMP@ 0) {
                 min_idx = mid_idx + 1;
             }
             else {
@@ -195,12 +195,13 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
                         npy_intp arr_len, npy_intp key_len,
                         npy_intp arr_str, npy_intp key_str,
                         npy_intp sort_str, npy_intp ret_str,
-                        npy_comparator cmp)
+                        PyArrayObject *cmp)
 {
+    PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */
     const char *last_key = key;
-    
+
     for (; key_len > 0; key_len--,
                         key += key_str,
                         ret += ret_str) {
@@ -209,27 +210,27 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
          * gives the search a big boost when keys are sorted, but slightly
          * slows down things for purely random ones.
          */
-        if (GENERIC_LT(last_key, key, cmp)) {
+        if (compare(last_key, key, cmp) @CMP@ 0) {
             max_idx = arr_len;
         } else {
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
-        
+
         last_key = key;
-        
+
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
                            sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
             const char *arr_ptr;
-            
+
             if (sort_idx < 0 || sort_idx >= arr_len) {
                 return -1;
             }
-            
+
             arr_ptr = arr + sort_idx*arr_str;
-            
-            if (GENERIC_@CMP@(arr_ptr, key, cmp)) {
+
+            if (compare(arr_ptr, key, cmp) @CMP@ 0) {
                 min_idx = mid_idx + 1;
             }
             else {

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -35,7 +35,7 @@
  * #CMP  = LT, LTE#
  */
 
-void
+NPY_VISIBILITY_HIDDEN void
 binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
                         npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
@@ -76,7 +76,7 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
     }
 }
 
-int
+NPY_VISIBILITY_HIDDEN int
 argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            const char *sort, char *ret,
                            npy_intp arr_len, npy_intp key_len,
@@ -143,7 +143,7 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
  * #CMP  = <, <=#
  */
 
-void
+NPY_VISIBILITY_HIDDEN void
 npy_binsearch_@side@(const char *arr, const char *key, char *ret,
                      npy_intp arr_len, npy_intp key_len,
                      npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
@@ -185,7 +185,7 @@ npy_binsearch_@side@(const char *arr, const char *key, char *ret,
     }
 }
 
-int
+NPY_VISIBILITY_HIDDEN int
 npy_argbinsearch_@side@(const char *arr, const char *key,
                         const char *sort, char *ret,
                         npy_intp arr_len, npy_intp key_len,

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -42,12 +42,27 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_str, npy_intp key_str,
                         npy_intp ret_str)
 {
+    npy_intp min_idx = 0,
+             max_idx = arr_len-1; /* set to arr_len later on */
+    @type@ last_key_val;
+             
     for (; key_len > 0; key_len--,
                         key += key_str,
                         ret += ret_str) {
-        npy_intp min_idx = 0,
-                 max_idx = arr_len;
         const @type@ key_val = *(const @type@ *)key;
+        /*
+         * Updating only one of the indices based on the previous key
+         * gives the search a big boost when keys are sorted, but slightly
+         * slows down things for purely random ones.
+         */
+        if (@TYPE@_LT(last_key_val, key_val)) {
+            max_idx = arr_len;
+        } else {
+            min_idx = 0;
+            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
+        }
+        
+        last_key_val = key_val;
         
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
@@ -70,12 +85,27 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            npy_intp arr_str, npy_intp key_str,
                            npy_intp sort_str, npy_intp ret_str)
 {
+    npy_intp min_idx = 0,
+             max_idx = arr_len-1; /* set to arr_len later on */
+    @type@ last_key_val;
+
     for (; key_len > 0; key_len--,
                         key += key_str,
                         ret += ret_str) {
-        npy_intp min_idx = 0,
-                 max_idx = arr_len;
         const @type@ key_val = *(const @type@ *)key;
+        /*
+         * Updating only one of the indices based on the previous key
+         * gives the search a big boost when keys are sorted, but slightly
+         * slows down things for purely random ones.
+         */
+        if (@TYPE@_LT(last_key_val, key_val)) {
+            max_idx = arr_len;
+        } else {
+            min_idx = 0;
+            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
+        }
+        
+        last_key_val = key_val;
 
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
@@ -123,11 +153,26 @@ npy_binsearch_@side@(const char *arr, const char *key, char *ret,
                      npy_intp arr_str, npy_intp key_str,
                      npy_intp ret_str, npy_comparator cmp)
 {
+    npy_intp min_idx = 0,
+             max_idx = arr_len-1; /* set to arr_len later on */
+    const char *last_key = key;
+
     for (; key_len > 0; key_len--,
                         key += key_str,
                         ret += ret_str) {
-        npy_intp min_idx = 0,
-                 max_idx = arr_len;
+        /*
+         * Updating only one of the indices based on the previous key
+         * gives the search a big boost when keys are sorted, but slightly
+         * slows down things for purely random ones.
+         */
+        if (GENERIC_LT(last_key, key, cmp)) {
+            max_idx = arr_len;
+        } else {
+            min_idx = 0;
+            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
+        }
+        
+        last_key = key;
         
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
@@ -152,11 +197,26 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
                         npy_intp sort_str, npy_intp ret_str,
                         npy_comparator cmp)
 {
+    npy_intp min_idx = 0,
+             max_idx = arr_len-1; /* set to arr_len later on */
+    const char *last_key = key;
+    
     for (; key_len > 0; key_len--,
                         key += key_str,
                         ret += ret_str) {
-        npy_intp min_idx = 0,
-                 max_idx = arr_len;
+        /*
+         * Updating only one of the indices based on the previous key
+         * gives the search a big boost when keys are sorted, but slightly
+         * slows down things for purely random ones.
+         */
+        if (GENERIC_LT(last_key, key, cmp)) {
+            max_idx = arr_len;
+        } else {
+            min_idx = 0;
+            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
+        }
+        
+        last_key = key;
         
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -1,12 +1,11 @@
 /* -*- c -*- */
-
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include "npy_sort.h"
 #include "npysort_common.h"
-#include "numpy/npy_math.h"
 #include "npy_binsearch.h"
-#include <stdlib.h>
+
+#define NOT_USED NPY_UNUSED(unused)
 
 /*
  *****************************************************************************
@@ -39,8 +38,8 @@
 void
 binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
-                        npy_intp arr_str, npy_intp key_str,
-                        npy_intp ret_str)
+                        npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
+                        PyArrayObject *NOT_USED)
 {
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */
@@ -83,7 +82,8 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            const char *sort, char *ret,
                            npy_intp arr_len, npy_intp key_len,
                            npy_intp arr_str, npy_intp key_str,
-                           npy_intp sort_str, npy_intp ret_str)
+                           npy_intp sort_str, npy_intp ret_str,
+                           PyArrayObject *NOT_USED)
 {
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -43,7 +43,7 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
 {
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */
-    @type@ last_key_val;
+    @type@ last_key_val = *(const @type@ *)key;
 
     for (; key_len > 0; key_len--,
                         key += key_str,
@@ -87,7 +87,7 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
 {
     npy_intp min_idx = 0,
              max_idx = arr_len-1; /* set to arr_len later on */
-    @type@ last_key_val;
+    @type@ last_key_val = *(const @type@ *)key;
 
     for (; key_len > 0; key_len--,
                         key += key_str,

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -41,13 +41,11 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
                         PyArrayObject *NOT_USED)
 {
-    npy_intp min_idx = 0,
-             max_idx = arr_len-1; /* set to arr_len later on */
+    npy_intp min_idx = 0;
+    npy_intp max_idx = arr_len;
     @type@ last_key_val = *(const @type@ *)key;
 
-    for (; key_len > 0; key_len--,
-                        key += key_str,
-                        ret += ret_str) {
+    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
         const @type@ key_val = *(const @type@ *)key;
         /*
          * Updating only one of the indices based on the previous key
@@ -56,7 +54,8 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
          */
         if (@TYPE@_LT(last_key_val, key_val)) {
             max_idx = arr_len;
-        } else {
+        }
+        else {
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
@@ -65,7 +64,7 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
 
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
-            const @type@ mid_val = *(const @type@ *)(arr + mid_idx * arr_str);
+            const @type@ mid_val = *(const @type@ *)(arr + mid_idx*arr_str);
             if (@TYPE@_@CMP@(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
             }
@@ -85,13 +84,11 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            npy_intp sort_str, npy_intp ret_str,
                            PyArrayObject *NOT_USED)
 {
-    npy_intp min_idx = 0,
-             max_idx = arr_len-1; /* set to arr_len later on */
+    npy_intp min_idx = 0;
+    npy_intp max_idx = arr_len;
     @type@ last_key_val = *(const @type@ *)key;
 
-    for (; key_len > 0; key_len--,
-                        key += key_str,
-                        ret += ret_str) {
+    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
         const @type@ key_val = *(const @type@ *)key;
         /*
          * Updating only one of the indices based on the previous key
@@ -100,7 +97,8 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
          */
         if (@TYPE@_LT(last_key_val, key_val)) {
             max_idx = arr_len;
-        } else {
+        }
+        else {
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
@@ -108,15 +106,15 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
         last_key_val = key_val;
 
         while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
-                           sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
+            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const npy_intp sort_idx = *(npy_intp *)(sort + mid_idx*sort_str);
             @type@ mid_val;
 
             if (sort_idx < 0 || sort_idx >= arr_len) {
                 return -1;
             }
 
-            mid_val = *(const @type@ *)(arr + sort_idx * arr_str);
+            mid_val = *(const @type@ *)(arr + sort_idx*arr_str);
 
             if (@TYPE@_@CMP@(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
@@ -139,8 +137,6 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
  *****************************************************************************
  */
 
-#define GENERIC_LTE(a, b, cmp) (!GENERIC_LT(b, a, cmp))
-
  /**begin repeat
  *
  * #side = left, right#
@@ -154,13 +150,11 @@ npy_binsearch_@side@(const char *arr, const char *key, char *ret,
                      PyArrayObject *cmp)
 {
     PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
-    npy_intp min_idx = 0,
-             max_idx = arr_len-1; /* set to arr_len later on */
+    npy_intp min_idx = 0;
+    npy_intp max_idx = arr_len;
     const char *last_key = key;
 
-    for (; key_len > 0; key_len--,
-                        key += key_str,
-                        ret += ret_str) {
+    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
         /*
          * Updating only one of the indices based on the previous key
          * gives the search a big boost when keys are sorted, but slightly
@@ -168,12 +162,14 @@ npy_binsearch_@side@(const char *arr, const char *key, char *ret,
          */
         if (compare(last_key, key, cmp) @CMP@ 0) {
             max_idx = arr_len;
-        } else {
+        }
+        else {
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
 
         last_key = key;
+
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
             const char *arr_ptr = arr + mid_idx*arr_str;
@@ -198,13 +194,11 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
                         PyArrayObject *cmp)
 {
     PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
-    npy_intp min_idx = 0,
-             max_idx = arr_len-1; /* set to arr_len later on */
+    npy_intp min_idx = 0;
+    npy_intp max_idx = arr_len;
     const char *last_key = key;
 
-    for (; key_len > 0; key_len--,
-                        key += key_str,
-                        ret += ret_str) {
+    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
         /*
          * Updating only one of the indices based on the previous key
          * gives the search a big boost when keys are sorted, but slightly
@@ -212,7 +206,8 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
          */
         if (compare(last_key, key, cmp) @CMP@ 0) {
             max_idx = arr_len;
-        } else {
+        }
+        else {
             min_idx = 0;
             max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
         }
@@ -220,8 +215,8 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
         last_key = key;
 
         while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1),
-                           sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
+            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const npy_intp sort_idx = *(npy_intp *)(sort + mid_idx*sort_str);
             const char *arr_ptr;
 
             if (sort_idx < 0 || sort_idx >= arr_len) {

--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -1,0 +1,137 @@
+#ifndef __NPY_BINSEARCH_H__
+#define __NPY_BINSEARCH_H__
+
+#include "npy_sort.h"
+
+/* Python include is for future object sorts */
+#include <Python.h>
+#include <numpy/npy_common.h>
+#include <numpy/ndarraytypes.h>
+
+
+typedef void (PyArray_BinSearchFunc)(const char *, const char *, char *,
+                                     npy_intp, npy_intp,
+                                     npy_intp, npy_intp, npy_intp);
+
+typedef int (PyArray_ArgBinSearchFunc)(const char *, const char *,
+                                       const char *, char *,
+                                       npy_intp, npy_intp, npy_intp,
+                                       npy_intp, npy_intp, npy_intp);
+
+typedef struct{
+    enum NPY_TYPES typenum;
+    PyArray_BinSearchFunc *binsearch[NPY_NSEARCHSIDES];
+} binsearch_map;
+
+typedef struct{
+    enum NPY_TYPES typenum;
+    PyArray_ArgBinSearchFunc *argbinsearch[NPY_NSEARCHSIDES];
+} argbinsearch_map;
+
+
+/**begin repeat
+ *
+ * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+ *         longlong, ulonglong, half, float, double, longdouble,
+ *         cfloat, cdouble, clongdouble, datetime, timedelta#
+ */
+/**begin repeat1
+ *
+ * #side = left, right#
+ */
+void
+binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
+                        npy_intp arr_len, npy_intp key_len,
+                        npy_intp arr_str, npy_intp key_str,
+                        npy_intp ret_str);
+int
+argbinsearch_@side@_@suff@(const char *arr, const char *key,
+                           const char *sort, char *ret,
+                           npy_intp arr_len, npy_intp key_len,
+                           npy_intp arr_str, npy_intp key_str,
+                           npy_intp sort_str, npy_intp ret_str);
+/**end repeat1**/
+/**end repeat**/
+
+/**begin repeat
+ *
+ * #side = left, right#
+ */
+void
+npy_binsearch_@side@(const char *arr, const char *key, char *ret,
+                     npy_intp arr_len, npy_intp key_len,
+                     npy_intp arr_str, npy_intp key_str,
+                     npy_intp ret_str, npy_comparator cmp);
+int
+npy_argbinsearch_@side@(const char *arr, const char *key,
+                        const char *sort, char *ret,
+                        npy_intp arr_len, npy_intp key_len,
+                        npy_intp arr_str, npy_intp key_str,
+                        npy_intp sort_str, npy_intp ret_str,
+                        npy_comparator cmp);
+/**end repeat**/
+
+/**begin repeat
+ *
+ * #arg = , arg#
+ * #Arg = , Arg#
+ */
+static NPY_INLINE PyArray_@Arg@BinSearchFunc*
+get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
+{
+    static @arg@binsearch_map _@arg@binsearch_map[] = {
+        /**begin repeat1
+         *
+         * #TYPE = BOOL, BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
+         *         LONGLONG, ULONGLONG, HALF, FLOAT, DOUBLE, LONGDOUBLE,
+         *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA#
+         * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+         *         longlong, ulonglong, half, float, double, longdouble,
+         *         cfloat, cdouble, clongdouble, datetime, timedelta#
+         */
+        {NPY_@TYPE@,
+            {
+                /**begin repeat2
+                 *
+                 * #side = left, right#
+                 */
+                &@arg@binsearch_@side@_@suff@,
+                /**end repeat2**/
+            },
+        },
+        /**end repeat1**/
+    };
+    
+    static npy_intp num_funcs = sizeof(_@arg@binsearch_map) /
+                                sizeof(_@arg@binsearch_map[0]);
+    
+    npy_intp min_idx = 0,
+             max_idx = num_funcs;
+             
+    if (side >= NPY_NSEARCHSIDES) {
+        return NULL;
+    }
+    
+    /* It seems only fair that a binary search function be searched for
+     * using a binary search...
+     */
+    while (min_idx < max_idx) {
+        npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+        if (_@arg@binsearch_map[mid_idx].typenum < type) {
+            min_idx = mid_idx + 1;
+        }
+        else {
+            max_idx = mid_idx;
+        }
+    }
+    
+    if (_@arg@binsearch_map[min_idx].typenum == type) {
+        return _@arg@binsearch_map[min_idx].@arg@binsearch[side];
+    }
+    else {
+        return NULL;
+    }
+}
+/**end repeat**/
+
+#endif

--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -2,32 +2,21 @@
 #define __NPY_BINSEARCH_H__
 
 #include "npy_sort.h"
-
-/* Python include is for future object sorts */
-#include <Python.h>
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
 
 
-typedef void (PyArray_BinSearchFunc)(const char *, const char *, char *,
+
+typedef void (PyArray_BinSearchFunc)(const char*, const char*, char*,
                                      npy_intp, npy_intp,
-                                     npy_intp, npy_intp, npy_intp);
+                                     npy_intp, npy_intp, npy_intp,
+                                     PyArrayObject*);
 
-typedef int (PyArray_ArgBinSearchFunc)(const char *, const char *,
-                                       const char *, char *,
+typedef int (PyArray_ArgBinSearchFunc)(const char*, const char*,
+                                       const char*, char*,
                                        npy_intp, npy_intp, npy_intp,
-                                       npy_intp, npy_intp, npy_intp);
-
-typedef void (PyArray_GenericBinSearchFunc)(const char*, const char*, char*,
-                                            npy_intp, npy_intp,
-                                            npy_intp, npy_intp, npy_intp,
-                                            PyArrayObject*);
-
-typedef int (PyArray_GenericArgBinSearchFunc)(const char*, const char*,
-                                              const char*, char*,
-                                              npy_intp, npy_intp, npy_intp,
-                                              npy_intp, npy_intp, npy_intp,
-                                              PyArrayObject*);
+                                       npy_intp, npy_intp, npy_intp,
+                                       PyArrayObject*);
 
 typedef struct{
     enum NPY_TYPES typenum;
@@ -54,14 +43,15 @@ typedef struct{
 void
 binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
-                        npy_intp arr_str, npy_intp key_str,
-                        npy_intp ret_str);
+                        npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
+                        PyArrayObject *unused);
 int
 argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            const char *sort, char *ret,
                            npy_intp arr_len, npy_intp key_len,
                            npy_intp arr_str, npy_intp key_str,
-                           npy_intp sort_str, npy_intp ret_str);
+                           npy_intp sort_str, npy_intp ret_str,
+                           PyArrayObject *unused);
 /**end repeat1**/
 
 void
@@ -84,33 +74,19 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
  * #Arg = , Arg#
  */
 
-static NPY_INLINE PyArray_Generic@Arg@BinSearchFunc*
-get_generic@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
-{
-    static PyArray_Generic@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
-        &npy_@arg@binsearch_left,
-        &npy_@arg@binsearch_right,
-    };
-
-    if (side >= NPY_NSEARCHSIDES || dtype->f->compare == NULL) {
-        return NULL;
-    }
-
-    return gen@arg@binsearch_map[side];
-}
-
 static NPY_INLINE PyArray_@Arg@BinSearchFunc*
-get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
+get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
     static @arg@binsearch_map _@arg@binsearch_map[] = {
+        /* If adding new types, make sure to keep them ordered by type num */
         /**begin repeat1
          *
          * #TYPE = BOOL, BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
-         *         LONGLONG, ULONGLONG, HALF, FLOAT, DOUBLE, LONGDOUBLE,
-         *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA#
+         *         LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE,
+         *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA, HALF#
          * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
-         *         longlong, ulonglong, half, float, double, longdouble,
-         *         cfloat, cdouble, clongdouble, datetime, timedelta#
+         *         longlong, ulonglong, float, double, longdouble,
+         *         cfloat, cdouble, clongdouble, datetime, timedelta, half#
          */
         {NPY_@TYPE@,
             {
@@ -121,11 +97,19 @@ get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
         /**end repeat1**/
     };
 
+    static PyArray_@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
+        &npy_@arg@binsearch_left,
+        &npy_@arg@binsearch_right,
+    };
+
+
     static npy_intp num_funcs = sizeof(_@arg@binsearch_map) /
                                 sizeof(_@arg@binsearch_map[0]);
 
     npy_intp min_idx = 0,
              max_idx = num_funcs;
+
+    int type = dtype->type_num;
 
     if (side >= NPY_NSEARCHSIDES) {
         return NULL;
@@ -144,12 +128,13 @@ get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
         }
     }
 
-    if (_@arg@binsearch_map[min_idx].typenum == type) {
+    if (min_idx < num_funcs && _@arg@binsearch_map[min_idx].typenum == type) {
         return _@arg@binsearch_map[min_idx].@arg@binsearch[side];
     }
-    else {
-        return NULL;
+    if (dtype->f->compare) {
+        return gen@arg@binsearch_map[side];
     }
+    return NULL;
 }
 /**end repeat**/
 

--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -16,12 +16,12 @@ typedef int (PyArray_ArgBinSearchFunc)(const char*, const char*,
                                        npy_intp, npy_intp, npy_intp,
                                        PyArrayObject*);
 
-struct binsearch_map{
+struct binsearch_map {
     enum NPY_TYPES typenum;
     PyArray_BinSearchFunc *binsearch[NPY_NSEARCHSIDES];
 };
 
-struct argbinsearch_map{
+struct argbinsearch_map {
     enum NPY_TYPES typenum;
     PyArray_ArgBinSearchFunc *argbinsearch[NPY_NSEARCHSIDES];
 };
@@ -97,7 +97,7 @@ static PyArray_@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
     &npy_@arg@binsearch_right,
 };
 
-static NPY_INLINE PyArray_@Arg@BinSearchFunc*
+static PyArray_@Arg@BinSearchFunc*
 get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
     static npy_intp num_funcs = sizeof(_@arg@binsearch_map) /

--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -5,8 +5,6 @@
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
 
-
-
 typedef void (PyArray_BinSearchFunc)(const char*, const char*, char*,
                                      npy_intp, npy_intp,
                                      npy_intp, npy_intp, npy_intp,
@@ -18,15 +16,15 @@ typedef int (PyArray_ArgBinSearchFunc)(const char*, const char*,
                                        npy_intp, npy_intp, npy_intp,
                                        PyArrayObject*);
 
-typedef struct{
+struct binsearch_map{
     enum NPY_TYPES typenum;
     PyArray_BinSearchFunc *binsearch[NPY_NSEARCHSIDES];
-} binsearch_map;
+};
 
-typedef struct{
+struct argbinsearch_map{
     enum NPY_TYPES typenum;
     PyArray_ArgBinSearchFunc *argbinsearch[NPY_NSEARCHSIDES];
-} argbinsearch_map;
+};
 
 /**begin repeat
  *
@@ -74,52 +72,51 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
  * #Arg = , Arg#
  */
 
+static struct @arg@binsearch_map _@arg@binsearch_map[] = {
+    /* If adding new types, make sure to keep them ordered by type num */
+    /**begin repeat1
+     *
+     * #TYPE = BOOL, BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
+     *         LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE,
+     *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA, HALF#
+     * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+     *         longlong, ulonglong, float, double, longdouble,
+     *         cfloat, cdouble, clongdouble, datetime, timedelta, half#
+     */
+    {NPY_@TYPE@,
+        {
+            &@arg@binsearch_left_@suff@,
+            &@arg@binsearch_right_@suff@,
+        },
+    },
+    /**end repeat1**/
+};
+
+static PyArray_@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
+    &npy_@arg@binsearch_left,
+    &npy_@arg@binsearch_right,
+};
+
 static NPY_INLINE PyArray_@Arg@BinSearchFunc*
 get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
-    static @arg@binsearch_map _@arg@binsearch_map[] = {
-        /* If adding new types, make sure to keep them ordered by type num */
-        /**begin repeat1
-         *
-         * #TYPE = BOOL, BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
-         *         LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE,
-         *         CFLOAT, CDOUBLE, CLONGDOUBLE, DATETIME, TIMEDELTA, HALF#
-         * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
-         *         longlong, ulonglong, float, double, longdouble,
-         *         cfloat, cdouble, clongdouble, datetime, timedelta, half#
-         */
-        {NPY_@TYPE@,
-            {
-                &@arg@binsearch_left_@suff@,
-                &@arg@binsearch_right_@suff@,
-            },
-        },
-        /**end repeat1**/
-    };
-
-    static PyArray_@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
-        &npy_@arg@binsearch_left,
-        &npy_@arg@binsearch_right,
-    };
-
-
     static npy_intp num_funcs = sizeof(_@arg@binsearch_map) /
                                 sizeof(_@arg@binsearch_map[0]);
-
-    npy_intp min_idx = 0,
-             max_idx = num_funcs;
-
+    npy_intp min_idx = 0;
+    npy_intp max_idx = num_funcs;
     int type = dtype->type_num;
 
     if (side >= NPY_NSEARCHSIDES) {
         return NULL;
     }
 
-    /* It seems only fair that a binary search function be searched for
+    /*
+     * It seems only fair that a binary search function be searched for
      * using a binary search...
      */
     while (min_idx < max_idx) {
         npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+
         if (_@arg@binsearch_map[mid_idx].typenum < type) {
             min_idx = mid_idx + 1;
         }
@@ -131,9 +128,11 @@ get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
     if (min_idx < num_funcs && _@arg@binsearch_map[min_idx].typenum == type) {
         return _@arg@binsearch_map[min_idx].@arg@binsearch[side];
     }
+
     if (dtype->f->compare) {
         return gen@arg@binsearch_map[side];
     }
+
     return NULL;
 }
 /**end repeat**/

--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -38,12 +38,12 @@ struct argbinsearch_map{
  *         cfloat, cdouble, clongdouble, datetime, timedelta#
  */
 
-void
+NPY_VISIBILITY_HIDDEN void
 binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
                         npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
                         PyArrayObject *unused);
-int
+NPY_VISIBILITY_HIDDEN int
 argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            const char *sort, char *ret,
                            npy_intp arr_len, npy_intp key_len,
@@ -52,12 +52,12 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            PyArrayObject *unused);
 /**end repeat1**/
 
-void
+NPY_VISIBILITY_HIDDEN void
 npy_binsearch_@side@(const char *arr, const char *key, char *ret,
                      npy_intp arr_len, npy_intp key_len,
                      npy_intp arr_str, npy_intp key_str,
                      npy_intp ret_str, PyArrayObject *cmp);
-int
+NPY_VISIBILITY_HIDDEN int
 npy_argbinsearch_@side@(const char *arr, const char *key,
                         const char *sort, char *ret,
                         npy_intp arr_len, npy_intp key_len,

--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -18,6 +18,17 @@ typedef int (PyArray_ArgBinSearchFunc)(const char *, const char *,
                                        npy_intp, npy_intp, npy_intp,
                                        npy_intp, npy_intp, npy_intp);
 
+typedef void (PyArray_GenericBinSearchFunc)(const char*, const char*, char*,
+                                            npy_intp, npy_intp,
+                                            npy_intp, npy_intp, npy_intp,
+                                            PyArrayObject*);
+
+typedef int (PyArray_GenericArgBinSearchFunc)(const char*, const char*,
+                                              const char*, char*,
+                                              npy_intp, npy_intp, npy_intp,
+                                              npy_intp, npy_intp, npy_intp,
+                                              PyArrayObject*);
+
 typedef struct{
     enum NPY_TYPES typenum;
     PyArray_BinSearchFunc *binsearch[NPY_NSEARCHSIDES];
@@ -28,17 +39,18 @@ typedef struct{
     PyArray_ArgBinSearchFunc *argbinsearch[NPY_NSEARCHSIDES];
 } argbinsearch_map;
 
-
 /**begin repeat
+ *
+ * #side = left, right#
+ */
+
+/**begin repeat1
  *
  * #suff = bool, byte, ubyte, short, ushort, int, uint, long, ulong,
  *         longlong, ulonglong, half, float, double, longdouble,
  *         cfloat, cdouble, clongdouble, datetime, timedelta#
  */
-/**begin repeat1
- *
- * #side = left, right#
- */
+
 void
 binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
@@ -51,24 +63,19 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            npy_intp arr_str, npy_intp key_str,
                            npy_intp sort_str, npy_intp ret_str);
 /**end repeat1**/
-/**end repeat**/
 
-/**begin repeat
- *
- * #side = left, right#
- */
 void
 npy_binsearch_@side@(const char *arr, const char *key, char *ret,
                      npy_intp arr_len, npy_intp key_len,
                      npy_intp arr_str, npy_intp key_str,
-                     npy_intp ret_str, npy_comparator cmp);
+                     npy_intp ret_str, PyArrayObject *cmp);
 int
 npy_argbinsearch_@side@(const char *arr, const char *key,
                         const char *sort, char *ret,
                         npy_intp arr_len, npy_intp key_len,
                         npy_intp arr_str, npy_intp key_str,
                         npy_intp sort_str, npy_intp ret_str,
-                        npy_comparator cmp);
+                        PyArrayObject *cmp);
 /**end repeat**/
 
 /**begin repeat
@@ -76,6 +83,22 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
  * #arg = , arg#
  * #Arg = , Arg#
  */
+
+static NPY_INLINE PyArray_Generic@Arg@BinSearchFunc*
+get_generic@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
+{
+    static PyArray_Generic@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
+        &npy_@arg@binsearch_left,
+        &npy_@arg@binsearch_right,
+    };
+
+    if (side >= NPY_NSEARCHSIDES || dtype->f->compare == NULL) {
+        return NULL;
+    }
+
+    return gen@arg@binsearch_map[side];
+}
+
 static NPY_INLINE PyArray_@Arg@BinSearchFunc*
 get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
 {
@@ -91,27 +114,23 @@ get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
          */
         {NPY_@TYPE@,
             {
-                /**begin repeat2
-                 *
-                 * #side = left, right#
-                 */
-                &@arg@binsearch_@side@_@suff@,
-                /**end repeat2**/
+                &@arg@binsearch_left_@suff@,
+                &@arg@binsearch_right_@suff@,
             },
         },
         /**end repeat1**/
     };
-    
+
     static npy_intp num_funcs = sizeof(_@arg@binsearch_map) /
                                 sizeof(_@arg@binsearch_map[0]);
-    
+
     npy_intp min_idx = 0,
              max_idx = num_funcs;
-             
+
     if (side >= NPY_NSEARCHSIDES) {
         return NULL;
     }
-    
+
     /* It seems only fair that a binary search function be searched for
      * using a binary search...
      */
@@ -124,7 +143,7 @@ get_@arg@binsearch_func(int type, NPY_SEARCHSIDE side)
             max_idx = mid_idx;
         }
     }
-    
+
     if (_@arg@binsearch_map[min_idx].typenum == type) {
         return _@arg@binsearch_map[min_idx].@arg@binsearch[side];
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1072,6 +1072,31 @@ class TestMethods(TestCase):
         assert_equal(b, a)
         b = a.searchsorted(unaligned, 'r')
         assert_equal(b, a + 1)
+        
+        # Test smart resetting of binsearch indices
+        a = np.arange(5)
+        b = a.searchsorted([6, 5, 4], 'l')
+        assert_equal(b, [5, 5, 4])
+        b = a.searchsorted([6, 5, 4], 'r')
+        assert_equal(b, [5, 5, 5])
+        
+        # Test all type specific binary search functions
+        types = ''.join((np.typecodes['AllInteger'], np.typecodes['AllFloat'],
+                         np.typecodes['Datetime'], '?O'))
+        for dt in types:
+            if dt == 'M':
+                dt = 'M8[D]'
+            if dt == '?':
+                a = np.arange(2, dtype=dt)
+                out = np.arange(2)
+            else:
+                a = np.arange(0, 5, dtype=dt)
+                out = np.arange(5)
+            b = a.searchsorted(a, 'l')
+            assert_equal(b, out)
+            b = a.searchsorted(a, 'r')
+            assert_equal(b, out + 1)
+
 
     def test_searchsorted_unicode(self):
         # Test searchsorted on unicode strings.
@@ -1146,6 +1171,25 @@ class TestMethods(TestCase):
         assert_equal(b, keys)
         b = a.searchsorted(unaligned, 'r', s)
         assert_equal(b, keys + 1)
+        
+        # Test all type specific indirect binary search functions
+        types = ''.join((np.typecodes['AllInteger'], np.typecodes['AllFloat'],
+                         np.typecodes['Datetime'], '?O'))
+        for dt in types:
+            if dt == 'M':
+                dt = 'M8[D]'
+            if dt == '?':
+                a = np.array([1, 0], dtype=dt)
+                s = [1, 0]
+                out = np.array([1, 0])
+            else:
+                a = np.array([3, 4, 1, 2, 0], dtype=dt)
+                s = [4, 2, 3, 0, 1]
+                out = np.array([3, 4, 1, 2, 0], dtype=np.intp)
+            b = a.searchsorted(a, 'l', s)
+            assert_equal(b, out)
+            b = a.searchsorted(a, 'r', s)
+            assert_equal(b, out + 1)
 
 
     def test_partition(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1072,14 +1072,14 @@ class TestMethods(TestCase):
         assert_equal(b, a)
         b = a.searchsorted(unaligned, 'r')
         assert_equal(b, a + 1)
-        
+
         # Test smart resetting of binsearch indices
         a = np.arange(5)
         b = a.searchsorted([6, 5, 4], 'l')
         assert_equal(b, [5, 5, 4])
         b = a.searchsorted([6, 5, 4], 'r')
         assert_equal(b, [5, 5, 5])
-        
+
         # Test all type specific binary search functions
         types = ''.join((np.typecodes['AllInteger'], np.typecodes['AllFloat'],
                          np.typecodes['Datetime'], '?O'))
@@ -1171,7 +1171,7 @@ class TestMethods(TestCase):
         assert_equal(b, keys)
         b = a.searchsorted(unaligned, 'r', s)
         assert_equal(b, keys + 1)
-        
+
         # Test all type specific indirect binary search functions
         types = ''.join((np.typecodes['AllInteger'], np.typecodes['AllFloat'],
                          np.typecodes['Datetime'], '?O'))
@@ -1191,6 +1191,17 @@ class TestMethods(TestCase):
             b = a.searchsorted(a, 'r', s)
             assert_equal(b, out + 1)
 
+        # Test non-contiguous sorter array
+        a = np.array([3, 4, 1, 2, 0])
+        srt = np.empty((10,), dtype=np.intp)
+        srt[1::2] = -1
+        srt[::2] = [4, 2, 3, 0, 1]
+        s = srt[::2]
+        out = np.array([3, 4, 1, 2, 0], dtype=np.intp)
+        b = a.searchsorted(a, 'l', s)
+        assert_equal(b, out)
+        b = a.searchsorted(a, 'r', s)
+        assert_equal(b, out + 1)
 
     def test_partition(self):
         d = np.arange(10)


### PR DESCRIPTION
This PR replaces the generic binary search functions used by `searchsorted`
with type specific ones for numeric types. This results in a speed-up of
calls to `searchsorted` which is highly dependent on the size of the
'haystack' and the 'needle', with typical values for large enough needles
in the 1.5x - 3.0x for direct searches (i.e. without a `sorter` argument)
and 1.2x - 2.0x for indirect searches. A summary benchmark on float and
int arrays can be found [here](https://gist.github.com/jaimefrio/8704101).

Furthermore, the type specific binary search functions can take strided
inputs for all their arguments, which is a step in the right direction to
eventually add an `axis` argument to `searchsorted`.
