### PR TITLE
__numpy_ufunc__ check improvement

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -781,29 +781,6 @@ offset_bounds_from_strides(const int itemsize, const int nd,
 }
 
 
-NPY_NO_EXPORT int
-_is_basic_python_type(PyObject * obj)
-{
-    if (obj == Py_None ||
-            /* Basic number types */
-#if !defined(NPY_PY3K)
-            PyInt_CheckExact(obj) ||
-#endif
-            PyLong_CheckExact(obj) ||
-            PyFloat_CheckExact(obj) ||
-            PyComplex_CheckExact(obj) ||
-            /* Basic sequence types */
-            PyList_CheckExact(obj) ||
-            PyTuple_CheckExact(obj) ||
-            PyDict_CheckExact(obj) ||
-            PyAnySet_CheckExact(obj)) {
-        return 1;
-    }
-
-    return 0;
-}
-
-
 /**
  * Convert an array shape to a string such as "(1, 2)".
  *

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -64,9 +64,6 @@ _IsAligned(PyArrayObject *ap);
 NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 
-NPY_NO_EXPORT int
-_is_basic_python_type(PyObject * obj);
-
 NPY_NO_EXPORT void
 offset_bounds_from_strides(const int itemsize, const int nd,
                            const npy_intp *dims, const npy_intp *strides,
@@ -181,6 +178,34 @@ npy_memchr(char * haystack, char needle,
     *psubloopsize = subloopsize;
 
     return p;
+}
+
+static NPY_INLINE int
+_is_basic_python_type(PyObject * obj)
+{
+    if (obj == Py_None ||
+            PyBool_Check(obj) ||
+            /* Basic number types */
+#if !defined(NPY_PY3K)
+            PyInt_CheckExact(obj) ||
+            PyString_CheckExact(obj) ||
+#endif
+            PyLong_CheckExact(obj) ||
+            PyFloat_CheckExact(obj) ||
+            PyComplex_CheckExact(obj) ||
+            /* Basic sequence types */
+            PyList_CheckExact(obj) ||
+            PyTuple_CheckExact(obj) ||
+            PyDict_CheckExact(obj) ||
+            PyAnySet_CheckExact(obj) ||
+            PyUnicode_CheckExact(obj) ||
+            PyBytes_CheckExact(obj) ||
+            PySlice_Check(obj)) {
+
+        return 1;
+    }
+
+    return 0;
 }
 
 #include "ucsnarrow.h"

--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -60,7 +60,12 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
 
     for (i = 0; i < nargs; ++i) {
         obj = PyTuple_GET_ITEM(args, i);
-        if (PyArray_CheckExact(obj) || PyArray_IsAnyScalar(obj)) {
+        /*
+         * TODO: could use PyArray_GetAttrString_SuppressException if it
+         * weren't private to multiarray.so
+         */
+        if (PyArray_CheckExact(obj) || PyArray_IsScalar(obj, Generic) ||
+            _is_basic_python_type(obj)) {
             continue;
         }
         if (PyObject_HasAttrString(obj, "__numpy_ufunc__")) {

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -390,13 +390,13 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_um_str_pyvals_name = NULL;
 static int
 intern_strings(void)
 {
-    npy_um_str_out = PyUString_FromString("out");
-    npy_um_str_subok = PyUString_FromString("subok");
-    npy_um_str_array_prepare = PyUString_FromString("__array_prepare__");
-    npy_um_str_array_wrap = PyUString_FromString("__array_wrap__");
-    npy_um_str_array_finalize = PyUString_FromString("__array_finalize__");
-    npy_um_str_ufunc = PyUString_FromString("__numpy_ufunc__");
-    npy_um_str_pyvals_name = PyUString_FromString(UFUNC_PYVALS_NAME);
+    npy_um_str_out = PyUString_InternFromString("out");
+    npy_um_str_subok = PyUString_InternFromString("subok");
+    npy_um_str_array_prepare = PyUString_InternFromString("__array_prepare__");
+    npy_um_str_array_wrap = PyUString_InternFromString("__array_wrap__");
+    npy_um_str_array_finalize = PyUString_InternFromString("__array_finalize__");
+    npy_um_str_ufunc = PyUString_InternFromString("__numpy_ufunc__");
+    npy_um_str_pyvals_name = PyUString_InternFromString(UFUNC_PYVALS_NAME);
 
     return npy_um_str_out && npy_um_str_subok && npy_um_str_array_prepare &&
         npy_um_str_array_wrap && npy_um_str_array_finalize && npy_um_str_ufunc;


### PR DESCRIPTION
the first two commits of gh-4186 which are useful on their own right and need not waiting until `__numpy_ufunc__` is fixed

see commit messages for details.
