### PR TITLE
Detect vendor versions of GNU Compilers

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -35,13 +35,13 @@ class GnuFCompiler(FCompiler):
 
     def gnu_version_match(self, version_string):
         """Handle the different versions of GNU fortran compilers"""
-        m = re.match(r'GNU Fortran', version_string)
+        m = re.search(r'GNU Fortran', version_string)
         if not m:
             return None
-        m = re.match(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
+        m = re.search(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
         if m:
             return ('gfortran', m.group(1))
-        m = re.match(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)
+        m = re.search(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)
         if m:
             v = m.group(1)
             if v.startswith('0') or v.startswith('2') or v.startswith('3'):


### PR DESCRIPTION
Cray and other HPC vendors provide patched versions of the GNU compilers
with modified version strings.  Use `re.search` instead of `re.match` in the
version detection scripts to account for modified version strings.

Ref: https://github.com/numpy/numpy/issues/4259
