### PR TITLE
BUG: numpy.split() should respect the dtype of its input

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -347,9 +347,9 @@ def dstack(tup):
 def _replace_zero_by_x_arrays(sub_arys):
     for i in range(len(sub_arys)):
         if len(_nx.shape(sub_arys[i])) == 0:
-            sub_arys[i] = _nx.array([])
+            sub_arys[i] = _nx.array([], dtype=sub_arys[i].dtype)
         elif _nx.sometrue(_nx.equal(_nx.shape(sub_arys[i]), 0)):
-            sub_arys[i] = _nx.array([])
+            sub_arys[i] = _nx.array([], dtype=sub_arys[i].dtype)
     return sub_arys
 
 def array_split(ary,indices_or_sections,axis = 0):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -143,6 +143,14 @@ class TestArraySplit(TestCase):
                    array([]), array([])]
         compare_results(res, desired)
 
+    def test_structured_array_split(self):
+        a = array([('a', 1), ('b', 2), ('c', 3)],
+                  dtype=[('k', '|S1'), ('v', '<i8')])
+        indices = [1, 1]
+        res = array_split(a, indices, axis=-1)
+        desired = [a[:1], a[1:1], a[1:]]
+        compare_results(res, desired)
+
 
 class TestSplit(TestCase):
     """* This function is essentially the same as array_split,


### PR DESCRIPTION
When given an empty range, numpy.split() returns empty arrays of
dtype float instead of the dtype of the input. Particularly annoying
when used with structured arrays.
