### PR TITLE
BUG: Fix mean, var, std methods for object arrays.

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -63,8 +63,10 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False):
     if isinstance(ret, mu.ndarray):
         ret = um.true_divide(
                 ret, rcount, out=ret, casting='unsafe', subok=False)
-    else:
+    elif hasattr(ret, 'dtype'):
         ret = ret.dtype.type(ret / rcount)
+    else:
+        ret = ret / rcount
 
     return ret
 
@@ -107,8 +109,10 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     if isinstance(ret, mu.ndarray):
         ret = um.true_divide(
                 ret, rcount, out=ret, casting='unsafe', subok=False)
-    else:
+    elif hasattr(ret, 'dtype'):
         ret = ret.dtype.type(ret / rcount)
+    else:
+        ret = ret / rcount
 
     return ret
 
@@ -118,7 +122,9 @@ def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
     if isinstance(ret, mu.ndarray):
         ret = um.sqrt(ret, out=ret)
-    else:
+    elif hasattr(ret, 'dtype'):
         ret = ret.dtype.type(um.sqrt(ret))
+    else:
+        ret = um.sqrt(ret)
 
     return ret

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3134,12 +3134,6 @@ class TestChoose(TestCase):
         A = np.choose(self.ind, (self.x, self.y2))
         assert_equal(A, [[2, 2, 3], [2, 2, 3]])
 
-def can_use_decimal():
-    try:
-        from decimal import Decimal
-        return True
-    except ImportError:
-        return False
 
 # TODO: test for multidimensional
 NEIGH_MODE = {'zero': 0, 'one': 1, 'constant': 2, 'circular': 3, 'mirror': 4}
@@ -3175,11 +3169,7 @@ class TestNeighborhoodIter(TestCase):
     def test_simple2d(self):
         self._test_simple2d(np.float)
 
-    @dec.skipif(not can_use_decimal(),
-            "Skip neighborhood iterator tests for decimal objects " \
-            "(decimal module not available")
     def test_simple2d_object(self):
-        from decimal import Decimal
         self._test_simple2d(Decimal)
 
     def _test_mirror2d(self, dt):
@@ -3195,11 +3185,7 @@ class TestNeighborhoodIter(TestCase):
     def test_mirror2d(self):
         self._test_mirror2d(np.float)
 
-    @dec.skipif(not can_use_decimal(),
-            "Skip neighborhood iterator tests for decimal objects " \
-            "(decimal module not available")
     def test_mirror2d_object(self):
-        from decimal import Decimal
         self._test_mirror2d(Decimal)
 
     # Simple, 1d tests
@@ -3221,11 +3207,7 @@ class TestNeighborhoodIter(TestCase):
     def test_simple_float(self):
         self._test_simple(np.float)
 
-    @dec.skipif(not can_use_decimal(),
-            "Skip neighborhood iterator tests for decimal objects " \
-            "(decimal module not available")
     def test_simple_object(self):
-        from decimal import Decimal
         self._test_simple(Decimal)
 
     # Test mirror modes
@@ -3240,11 +3222,7 @@ class TestNeighborhoodIter(TestCase):
     def test_mirror(self):
         self._test_mirror(np.float)
 
-    @dec.skipif(not can_use_decimal(),
-            "Skip neighborhood iterator tests for decimal objects " \
-            "(decimal module not available")
     def test_mirror_object(self):
-        from decimal import Decimal
         self._test_mirror(Decimal)
 
     # Circular mode
@@ -3258,11 +3236,7 @@ class TestNeighborhoodIter(TestCase):
     def test_circular(self):
         self._test_circular(np.float)
 
-    @dec.skipif(not can_use_decimal(),
-            "Skip neighborhood iterator tests for decimal objects " \
-            "(decimal module not available")
     def test_circular_object(self):
-        from decimal import Decimal
         self._test_circular(Decimal)
 
 # Test stacking neighborhood iterators


### PR DESCRIPTION
This takes care to preserve the object type for scalar returns and
fixes the error that resulted when the scalar did not have a dtype
attribute.

Closes #4063.
