### PR TITLE
ENH: single pass over array in `bincount` to determine output size

### DIFF
--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -109,8 +109,8 @@ check_array_monotonic(const double *a, npy_int lena)
 static void
 minmax(const npy_intp *data, npy_intp data_len, npy_intp *mn, npy_intp *mx)
 {
-    npy_intp min;
-    npy_intp max = min = *data;
+    npy_intp min = *data;
+    npy_intp max = *data;
 
     while (--data_len) {
         const npy_intp val = *(++data);


### PR DESCRIPTION
`bincount` checks its input array to make sure there are no negative entries,
and to determine the size of the output array. This is done by calling two
different functions, each having to loop over the whole array. This PR
adds a new function, `minmax`, that computes the minimum and maximum of the
array in a single pass over it. This leads to speed-ups peaking at 1.5x,
with typical values for large arrays around 1.15x - 1.25x.

A full benchmark summary of the new implementation, including a supposedly
more efficient algorithm that turned out to run slower, can be found [here](https://gist.github.com/jaimefrio/8743836).
