### PR TITLE
Closes issue #4266, fixes histogramdd treatment of events at rightmost binedge

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -373,10 +373,10 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
         if not np.isinf(mindiff):
             decimal = int(-log10(mindiff)) + 6
             # Find which points are on the rightmost edge.
-            on_edge = where(around(sample[:, i], decimal) ==
-                            around(edges[i][-1], decimal))[0]
+            not_smaller_than_edge = (sample[:, i] >= edges[i][-1])
+            on_edge = (around(sample[:, i], decimal) == around(edges[i][-1], decimal))
             # Shift these points one bin to the left.
-            Ncount[i][on_edge] -= 1
+            Ncount[i][where(on_edge & not_smaller_than_edge)[0]] -= 1
 
     # Flattened histogram matrix (1D)
     # Reshape is used so that overlarge arrays

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1155,6 +1155,30 @@ class TestHistogramdd(TestCase):
             h, e = np.histogramdd(x, bins=[3, [-np.inf, 3, np.inf]])
             assert_allclose(h, expected)
 
+    def test_rightmost_binedge(self):
+        """Test event very close to rightmost binedge.
+        See Github issue #4266"""
+        x = [0.9999999995]
+        bins = [[0.,0.5,1.0]]
+        hist, _ = histogramdd(x, bins=bins)
+        assert_(hist[0] == 0.0)
+        assert_(hist[1] == 1.)
+        x = [1.0]
+        bins = [[0.,0.5,1.0]]
+        hist, _ = histogramdd(x, bins=bins)
+        assert_(hist[0] == 0.0)
+        assert_(hist[1] == 1.)
+        x = [1.0000000001]
+        bins = [[0.,0.5,1.0]]
+        hist, _ = histogramdd(x, bins=bins)
+        assert_(hist[0] == 0.0)
+        assert_(hist[1] == 1.)
+        x = [1.0001]
+        bins = [[0.,0.5,1.0]]
+        hist, _ = histogramdd(x, bins=bins)
+        assert_(hist[0] == 0.0)
+        assert_(hist[1] == 0.0)
+
 
 class TestUnique(TestCase):
     def test_simple(self):


### PR DESCRIPTION
This fixes the treatment of values very close to the rightmost binedge in historgramdd. It makes sure values are greater or equal to the bin edge (if they are smaller they will already be in the correct bin), before moving them one bin left.
Fixes Github issue #4266
