### PR TITLE
BUG: Fix performance regression for PyObject_Get/SetItem

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -51,6 +51,13 @@ The unused ``simple_capsule_dtor`` function has been removed from
 ``npy_3kcompat.h``.  Note that this header is not meant to be used outside of
 numpy; other projects should be using their own copy of this file when needed.
 
+Negative indices in C-Api sq_item and sq_ass_item sequence methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When directly accessing the ``sq_item`` or ``sq_ass_item`` PyObject slots
+for item getting, negative indices will not be supported anymore.
+``PySequence_GetItem`` and ``PySequence_SetItem`` however fix negative
+indices so that they can be used there.
+
 
 New Features
 ============

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -238,9 +238,9 @@ PyArray_AssignArray(PyArrayObject *dst, PyArrayObject *src,
      * case, first an in-place add is done, followed by an assignment,
      * equivalently expressed like this:
      *
-     *   tmp = a[1000:6000]   # Calls array_subscript_nice in mapping.c
+     *   tmp = a[1000:6000]   # Calls array_subscript in mapping.c
      *   np.add(tmp, x, tmp)
-     *   a[1000:6000] = tmp   # Calls array_ass_sub in mapping.c
+     *   a[1000:6000] = tmp   # Calls array_assign_subscript in mapping.c
      *
      * In the assignment the underlying data type, shape, strides, and
      * data pointers are identical, but src != dst because they are separately

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1068,7 +1068,7 @@ array_boolean_subscript(PyArrayObject *self,
  * Returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT int
-array_ass_boolean_subscript(PyArrayObject *self,
+array_assign_boolean_subscript(PyArrayObject *self,
                     PyArrayObject *bmask, PyArrayObject *v, NPY_ORDER order)
 {
     npy_intp size, src_itemsize, v_stride;
@@ -1222,15 +1222,18 @@ array_ass_boolean_subscript(PyArrayObject *self,
 
 
 /*
- * C-level item subscription always returning an array and never a scalar.
- * Note that in principle the result is a subclass if called on a subclass.
- * However for PyObject_GetItem calls this will never happen.
+ * C-level integer indexing always returning an array and never a scalar.
+ * Works also for subclasses, but it will not be called on one from the
+ * Python API.
+ *
+ * This function does not accept negative indices because it is called by
+ * PySequence_GetItem (through array_item) and that converts them to
+ * positive indices.
  */
 NPY_NO_EXPORT PyObject *
-array_item_asarray(PyArrayObject *self, Py_ssize_t i)
+array_item_asarray(PyArrayObject *self, npy_intp i)
 {
     npy_index_info indices[2];
-
     PyObject *result;
 
     if (PyArray_NDIM(self) == 0) {
@@ -1238,24 +1241,28 @@ array_item_asarray(PyArrayObject *self, Py_ssize_t i)
                         "too many indices for array"); 
         return NULL;
     }
+    if (i < 0) {
+        /* This is an error, but undo PySequence_GetItem fix for message */
+        i -= PyArray_DIM(self, 0);
+    }
 
     indices[0].value = i;
     indices[0].type = HAS_INTEGER;
-
     indices[1].value = PyArray_NDIM(self) - 1;
     indices[1].type = HAS_ELLIPSIS;
-
     if (get_view_from_index(self, (PyArrayObject **)&result,
                             indices, 2, 0) < 0) {
         return NULL;
     }
-
     return result;
 }
 
 
 /*
- * C-level item subscription (via PyObject_GetItem)
+ * Python C-Api level item subscription (implementation for PySequence_GetItem)
+ *
+ * Negative indices are not accepted because PySequence_GetItem converts
+ * them to positive indices before calling this.
  */
 NPY_NO_EXPORT PyObject *
 array_item(PyArrayObject *self, Py_ssize_t i)
@@ -1264,9 +1271,13 @@ array_item(PyArrayObject *self, Py_ssize_t i)
         char *item;
         npy_index_info index;
 
+        if (i < 0) {
+            /* This is an error, but undo PySequence_GetItem fix for message */
+            i -= PyArray_DIM(self, 0);
+        }
+
         index.value = i;
         index.type = HAS_INTEGER;
-
         if (get_item_pointer(self, &item, &index, 1) < 0) {
             return NULL;
         }
@@ -1287,7 +1298,7 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
 
 
 /*
- * General item subscription with a Python object.
+ * General function for indexing a NumPy array with a Python object.
  */
 NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op)
@@ -1572,15 +1583,15 @@ array_subscript(PyArrayObject *self, PyObject *op)
 
 
 /*
- * C-api level item assignment (via PyObject_SetItem).
+ * Python C-Api level item assignment (implementation for PySequence_SetItem)
+ *
+ * Negative indices are not accepted because PySequence_SetItem converts
+ * them to positive indices before calling this.
  */
 NPY_NO_EXPORT int
-array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *op)
+array_assign_item(PyArrayObject *self, Py_ssize_t i, PyObject *op)
 {
     npy_index_info indices[2];
-
-    indices[0].value = i;
-    indices[0].type = HAS_INTEGER;
 
     if (op == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1590,7 +1601,19 @@ array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *op)
     if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         return -1;
     }
+    if (PyArray_NDIM(self) == 0) {
+        PyErr_SetString(PyExc_IndexError,
+                        "too many indices for array"); 
+        return -1;
+    }
 
+    if (i < 0) {
+        /* This is an error, but undo PySequence_SetItem fix for message */
+        i -= PyArray_DIM(self, 0);
+    }
+
+    indices[0].value = i;
+    indices[0].type = HAS_INTEGER;
     if (PyArray_NDIM(self) == 1) {
         char *item;
         if (get_item_pointer(self, &item, indices, 1) < 0) {
@@ -1600,26 +1623,18 @@ array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *op)
             return -1;
         }
     }
-    else if (PyArray_NDIM(self) == 0) {
-        PyErr_SetString(PyExc_IndexError,
-                        "too many indices for array"); 
-        return -1;
-    }
     else {
         PyArrayObject *view;
 
         indices[1].value = PyArray_NDIM(self) - 1;
         indices[1].type = HAS_ELLIPSIS;
-
         if (get_view_from_index(self, &view, indices, 2, 0) < 0) {
             return -1;
         }
-
         if (PyArray_CopyObject(view, op) < 0) {
             return -1;
         }
     }
-    
     return 0;
 }
 
@@ -1628,7 +1643,7 @@ array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *op)
  * General assignment with python indexing objects.
  */
 static int
-array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
+array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
 {
     int index_type;
     int index_num;
@@ -1715,9 +1730,9 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
             Py_INCREF(op);
             tmp_arr = (PyArrayObject *)op;
         }
-        if (array_ass_boolean_subscript(self,
-                                        (PyArrayObject *)indices[0].object,
-                                        tmp_arr, NPY_CORDER) < 0) {
+        if (array_assign_boolean_subscript(self,
+                                           (PyArrayObject *)indices[0].object,
+                                           tmp_arr, NPY_CORDER) < 0) {
             goto fail;
         }
         goto success;
@@ -1923,7 +1938,7 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
 NPY_NO_EXPORT PyMappingMethods array_as_mapping = {
     (lenfunc)array_length,              /*mp_length*/
     (binaryfunc)array_subscript,        /*mp_subscript*/
-    (objobjargproc)array_ass_sub,       /*mp_ass_subscript*/
+    (objobjargproc)array_assign_subscript,       /*mp_ass_subscript*/
 };
 
 /****************** End of Mapping Protocol ******************************/

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -54,82 +54,6 @@ array_length(PyArrayObject *self)
     }
 }
 
-/* Get array item as scalar type */
-NPY_NO_EXPORT PyObject *
-array_item_asscalar(PyArrayObject *self, npy_intp i)
-{
-    char *item;
-    npy_intp dim0;
-
-    /* Bounds check and get the data pointer */
-    dim0 = PyArray_DIM(self, 0);
-    if (i < 0) {
-        i += dim0;
-    }
-    if (i < 0 || i >= dim0) {
-        PyErr_SetString(PyExc_IndexError, "index out of bounds");
-        return NULL;
-    }
-    item = PyArray_BYTES(self) + i * PyArray_STRIDE(self, 0);
-    return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
-}
-
-/* Get array item as ndarray type */
-NPY_NO_EXPORT PyObject *
-array_item_asarray(PyArrayObject *self, npy_intp i)
-{
-    char *item;
-    PyArrayObject *ret;
-    npy_intp dim0;
-
-    if(PyArray_NDIM(self) == 0) {
-        PyErr_SetString(PyExc_IndexError,
-                        "0-d arrays can't be indexed");
-        return NULL;
-    }
-
-    /* Bounds check and get the data pointer */
-    dim0 = PyArray_DIM(self, 0);
-    if (check_and_adjust_index(&i, dim0, 0) < 0) {
-        return NULL;
-    }
-    item = PyArray_BYTES(self) + i * PyArray_STRIDE(self, 0);
-
-    /* Create the view array */
-    Py_INCREF(PyArray_DESCR(self));
-    ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self),
-                                              PyArray_DESCR(self),
-                                              PyArray_NDIM(self)-1,
-                                              PyArray_DIMS(self)+1,
-                                              PyArray_STRIDES(self)+1, item,
-                                              PyArray_FLAGS(self),
-                                              (PyObject *)self);
-    if (ret == NULL) {
-        return NULL;
-    }
-
-    /* Set the base object */
-    Py_INCREF(self);
-    if (PyArray_SetBaseObject(ret, (PyObject *)self) < 0) {
-        Py_DECREF(ret);
-        return NULL;
-    }
-
-    PyArray_UpdateFlags(ret, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
-    return (PyObject *)ret;
-}
-
-/* Get array item at given index */
-NPY_NO_EXPORT PyObject *
-array_item(PyArrayObject *self, Py_ssize_t i)
-{
-    if (PyArray_NDIM(self) == 1) {
-        return array_item_asscalar(self, (npy_intp) i);
-    }
-    else {
-        return array_item_asarray(self, (npy_intp) i);
-    }
-}
 
 /* -------------------------------------------------------------- */
 
@@ -1297,6 +1221,63 @@ array_ass_boolean_subscript(PyArrayObject *self,
 }
 
 
+/*
+ * C-level item subscription always returning an array and never a scalar.
+ * Note that in principle the result is a subclass if called on a subclass.
+ * However for PyObject_GetItem calls this will never happen.
+ */
+NPY_NO_EXPORT PyObject *
+array_item_asarray(PyArrayObject *self, Py_ssize_t i)
+{
+    npy_index_info indices[2];
+
+    PyObject *result;
+
+    if (PyArray_NDIM(self) == 0) {
+        PyErr_SetString(PyExc_IndexError,
+                        "too many indices for array"); 
+        return NULL;
+    }
+
+    indices[0].value = i;
+    indices[0].type = HAS_INTEGER;
+
+    indices[1].value = PyArray_NDIM(self) - 1;
+    indices[1].type = HAS_ELLIPSIS;
+
+    if (get_view_from_index(self, (PyArrayObject **)&result,
+                            indices, 2, 0) < 0) {
+        return NULL;
+    }
+
+    return result;
+}
+
+
+/*
+ * C-level item subscription (via PyObject_GetItem)
+ */
+NPY_NO_EXPORT PyObject *
+array_item(PyArrayObject *self, Py_ssize_t i)
+{
+    if (PyArray_NDIM(self) == 1) {
+        char *item;
+        npy_index_info index;
+
+        index.value = i;
+        index.type = HAS_INTEGER;
+
+        if (get_item_pointer(self, &item, &index, 1) < 0) {
+            return NULL;
+        }
+        return PyArray_Scalar(item, PyArray_DESCR(self), (PyObject *)self);
+    }
+    else {
+        return array_item_asarray(self, i);
+    }
+}
+
+
 /* make sure subscript always returns an array object */
 NPY_NO_EXPORT PyObject *
 array_subscript_asarray(PyArrayObject *self, PyObject *op)
@@ -1304,6 +1285,10 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
     return PyArray_EnsureAnyArray(array_subscript(self, op));
 }
 
+
+/*
+ * General item subscription with a Python object.
+ */
 NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op)
 {
@@ -1586,6 +1571,62 @@ array_subscript(PyArrayObject *self, PyObject *op)
 }
 
 
+/*
+ * C-api level item assignment (via PyObject_SetItem).
+ */
+NPY_NO_EXPORT int
+array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *op)
+{
+    npy_index_info indices[2];
+
+    indices[0].value = i;
+    indices[0].type = HAS_INTEGER;
+
+    if (op == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                        "cannot delete array elements");
+        return -1;
+    }
+    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
+        return -1;
+    }
+
+    if (PyArray_NDIM(self) == 1) {
+        char *item;
+        if (get_item_pointer(self, &item, indices, 1) < 0) {
+            return -1;
+        }
+        if (PyArray_SETITEM(self, item, op) < 0) {
+            return -1;
+        }
+    }
+    else if (PyArray_NDIM(self) == 0) {
+        PyErr_SetString(PyExc_IndexError,
+                        "too many indices for array"); 
+        return -1;
+    }
+    else {
+        PyArrayObject *view;
+
+        indices[1].value = PyArray_NDIM(self) - 1;
+        indices[1].type = HAS_ELLIPSIS;
+
+        if (get_view_from_index(self, &view, indices, 2, 0) < 0) {
+            return -1;
+        }
+
+        if (PyArray_CopyObject(view, op) < 0) {
+            return -1;
+        }
+    }
+    
+    return 0;
+}
+
+
+/*
+ * General assignment with python indexing objects.
+ */
 static int
 array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
 {
@@ -1876,17 +1917,6 @@ array_ass_sub(PyArrayObject *self, PyObject *ind, PyObject *op)
         Py_XDECREF(indices[i].object);
     }
     return 0;
-}
-
-
-NPY_NO_EXPORT int
-array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v)
-{
-    PyObject * ind = PyLong_FromSsize_t(i);
-    if (ind == NULL) {
-        return -1;
-    }
-    return array_ass_sub(self, ind, v);
 }
 
 

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -45,7 +45,7 @@ NPY_NO_EXPORT PyObject *
 array_subscript(PyArrayObject *self, PyObject *op);
 
 NPY_NO_EXPORT int
-array_ass_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
+array_assign_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
 
 /*
  * Prototypes for Mapping calls --- not part of the C-API

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -690,6 +690,37 @@ get_buffer_info(PyObject *NPY_UNUSED(self), PyObject *args)
 #undef GET_PYBUF_FLAG
 
 
+/*
+ * Test C-api level item getting.
+ */
+static PyObject *
+array_indexing(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    int mode;
+    Py_ssize_t i;
+    PyObject *arr, *op = NULL;
+
+    if (!PyArg_ParseTuple(args, "iOn|O", &mode, &arr, &i, &op)) {
+        return NULL;
+    }
+
+    if (mode == 0) {
+        return PySequence_GetItem(arr, i);
+    }
+    if (mode == 1) {
+        if (PySequence_SetItem(arr, i, op) < 0) {
+            return NULL;
+        }
+        
+        Py_RETURN_NONE;
+    }
+
+    PyErr_SetString(PyExc_ValueError,
+                    "invalid mode. 0: item 1: assign");
+    return NULL;
+}
+
+
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"test_neighborhood_iterator",
         test_neighborhood_iterator,
@@ -713,6 +744,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
 #endif
     {"get_buffer_info",
         get_buffer_info,
+        METH_VARARGS, NULL},
+    {"array_indexing",
+        array_indexing,
         METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -710,8 +710,7 @@ array_indexing(PyObject *NPY_UNUSED(self), PyObject *args)
     if (mode == 1) {
         if (PySequence_SetItem(arr, i, op) < 0) {
             return NULL;
-        }
-        
+        }        
         Py_RETURN_NONE;
     }
 

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -88,7 +88,7 @@ array_slice(PyArrayObject *self, Py_ssize_t ilow, Py_ssize_t ihigh)
 
 
 static int
-array_ass_slice(PyArrayObject *self, Py_ssize_t ilow,
+array_assign_slice(PyArrayObject *self, Py_ssize_t ilow,
                 Py_ssize_t ihigh, PyObject *v) {
     int ret;
     PyArrayObject *tmp;
@@ -135,8 +135,8 @@ NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
     (ssizeargfunc)NULL,
     (ssizeargfunc)array_item,
     (ssizessizeargfunc)array_slice,
-    (ssizeobjargproc)array_ass_item,        /*sq_ass_item*/
-    (ssizessizeobjargproc)array_ass_slice,  /*sq_ass_slice*/
+    (ssizeobjargproc)array_assign_item,        /*sq_ass_item*/
+    (ssizessizeobjargproc)array_assign_slice,  /*sq_ass_slice*/
     (objobjproc) array_contains,            /*sq_contains */
     (binaryfunc) NULL,                      /*sg_inplace_concat */
     (ssizeargfunc)NULL,

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -875,16 +875,13 @@ class TestCApiAccess(TestCase):
     def test_getitem(self):
         subscript = functools.partial(array_indexing, 0)
 
-        # Out of bound values:
+        # 0-d arrays don't work:
         assert_raises(IndexError, subscript, np.ones(()), 0)
+        # Out of bound values:
         assert_raises(IndexError, subscript, np.ones(10), 11)
-
-        # Python PySequence_SetItem fixes negative indices, and we fix them
-        # as well, so the following works even though it should fail:
-        #assert_raises(IndexError, subscript, np.ones((10, 10)), 20)
-        assert_raises(IndexError, subscript, np.ones(10), -21)
-
-        assert_raises(IndexError, subscript, np.ones((10, 10)), -21)
+        assert_raises(IndexError, subscript, np.ones(10), -11)
+        assert_raises(IndexError, subscript, np.ones((10, 10)), 11)
+        assert_raises(IndexError, subscript, np.ones((10, 10)), -11)
 
         a = np.arange(10)
         assert_array_equal(a[4], subscript(a, 4))
@@ -896,17 +893,13 @@ class TestCApiAccess(TestCase):
 
         # Deletion is impossible:
         assert_raises(ValueError, assign, np.ones(10), 0)
-        # Out of bound values:
+        # 0-d arrays don't work:
         assert_raises(IndexError, assign, np.ones(()), 0, 0)
+        # Out of bound values:
         assert_raises(IndexError, assign, np.ones(10), 11, 0)
-
-        # Python PySequence_SetItem fixes negative indices, and we fix them
-        # as well, so the following works even though it should fail:
-        #assert_raises(IndexError, assign, np.ones(10), -20, 0)
-        assert_raises(IndexError, assign, np.ones(10), -21, 0)
-
+        assert_raises(IndexError, assign, np.ones(10), -11, 0)
         assert_raises(IndexError, assign, np.ones((10, 10)), 11, 0)
-        assert_raises(IndexError, assign, np.ones((10, 10)), -21, 0)
+        assert_raises(IndexError, assign, np.ones((10, 10)), -11, 0)
 
         a = np.arange(10)
         assign(a, 4, 10)


### PR DESCRIPTION
Also restructures the calling conventions a little to channel
all calls through the general functions, this will add a little
overhead and could be streamlined if necessary.
## 

The performance regression was because I must have removed the item assignment speciallization. This should at least mostly fix the regression shown by http://yarikoptic.github.io/numpy-vbench/vb_vb_random.html#vb-random-shuffle100000
