### PR TITLE
TST: bootstrap chroot in tmpfs

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -35,6 +35,9 @@ setup_chroot()
   # CC="gcc -m32" LDSHARED="gcc -m32 -shared" LDFLAGS="-m32 -shared" linux32 python setup.py build
   # when travis updates to ubuntu 14.04
   DIR=$1
+  # speeds up setup as we don't have eatmydata during bootstrap
+  sudo mkdir -p $DIR
+  sudo mount -t tmpfs -o size=4G tmpfs $DIR
   set -u
   sudo apt-get -qq -y --force-yes install debootstrap eatmydata
   sudo debootstrap --variant=buildd --include=fakeroot,build-essential --arch=$ARCH --foreign $DIST $DIR


### PR DESCRIPTION
during bootstrap eatmydata is not available in the chroot so it takes a
significant time. Avoid this by placing the whole chroot in a tmpfs
ramdisk.
