### PR TITLE
BUG: fix NULL dereference on longdouble conversion error

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -977,6 +977,9 @@ static PyObject *
 
     dval = (double)(((Py@CHAR@LongDoubleScalarObject *)self)->obval)@POST@;
     obj = Py@KIND@_FromDouble(dval);
+    if (obj == NULL) {
+        return NULL;
+    }
     ret = Py_TYPE(obj)->tp_as_number->nb_@name@(obj);
     Py_DECREF(obj);
     return ret;
@@ -1001,6 +1004,9 @@ static PyObject *
 
     dval = (double)(((Py@CHAR@LongDoubleScalarObject *)self)->obval)@POST@;
     obj = Py@KIND@_FromDouble(dval);
+    if (obj == NULL) {
+        return NULL;
+    }
     ret = Py_TYPE(obj)->tp_as_number->nb_@name@(obj);
     Py_DECREF(obj);
     return ret;

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -169,6 +169,12 @@ class TestConversion(TestCase):
         for code in 'lLqQ':
             assert_raises(OverflowError, Overflow_error_func, code)
 
+    def test_longdouble_int(self):
+        # gh-627
+        x = np.longdouble(np.inf)
+        assert_raises(OverflowError, x.__int__)
+        x = np.clongdouble(np.inf)
+        assert_raises(OverflowError, x.__int__)
 
     def test_numpy_scalar_relational_operators(self):
          #All integer


### PR DESCRIPTION
Closes gh-627
