### PR TITLE
minor fasttake performance improvement

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3510,7 +3510,7 @@ static int
                 /* We don't know what axis we're operating on, so don't report it in case of an error. */
                 if (check_and_adjust_index(&tmp, nindarray, -1) < 0)
                     return 1;
-                if (nelem == 1) {
+                if (NPY_LIKELY(nelem == 1)) {
                     *dest++ = *(src + tmp);
                 }
                 else {
@@ -3536,7 +3536,7 @@ static int
                         tmp -= nindarray;
                     }
                 }
-                if (nelem == 1) {
+                if (NPY_LIKELY(nelem == 1)) {
                     *dest++ = *(src+tmp);
                 }
                 else {
@@ -3558,7 +3558,7 @@ static int
                 else if (tmp >= nindarray) {
                     tmp = nindarray - 1;
                 }
-                if (nelem == 1) {
+                if (NPY_LIKELY(nelem == 1)) {
                     *dest++ = *(src + tmp);
                 }
                 else {

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -75,7 +75,7 @@ static NPY_INLINE int
 check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis)
 {
     /* Check that index is valid, taking into account negative indices */
-    if ((*index < -max_item) || (*index >= max_item)) {
+    if (NPY_UNLIKELY((*index < -max_item) || (*index >= max_item))) {
         /* Try to be as clear as possible about what went wrong. */
         if (axis >= 0) {
             PyErr_Format(PyExc_IndexError,


### PR DESCRIPTION
hint that nelem == 1 branch is more likely 
improves performance for simple takes by 10%, chunked takes spend more
time copying so the less dense code matters less.

also add a hint to the error case of check_and_adjust_index, not required with gcc but can't do any harm either.
