### PR TITLE
BUG: Fix typo in f2py/cfuncs.py.

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -75,7 +75,7 @@ typedef long long long_long;
 typedef unsigned long long unsigned_long_long;
 #endif
 """
-typedefs['insinged_long_long']="""\
+typedefs['unsigned_long_long']="""\
 #ifdef _WIN32
 typedef __uint64 long_long;
 #else


### PR DESCRIPTION
Replace "insinged_long_long" by "unsigned_long_long". Patch due to trac
user pepijndevos.

Closes #636.
