### PR TITLE
DOC: Document that fliplr only works on 2-D arrays.

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -25,7 +25,7 @@ def fliplr(m):
     Parameters
     ----------
     m : array_like
-        Input array.
+        Input array, must be at least 2-D.
 
     Returns
     -------
@@ -40,8 +40,7 @@ def fliplr(m):
 
     Notes
     -----
-    Equivalent to A[:,::-1]. Does not require the array to be
-    two-dimensional.
+    Equivalent to A[:,::-1]. Requires the array to be at least 2-D.
 
     Examples
     --------


### PR DESCRIPTION
Docstring claimed 2-D was not required, but it is. Fix that.

Closes #3332.
