### PR TITLE
BUG: #4256: f2py, PyString_FromStringAndSize is undefined in Python3.

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -312,7 +312,7 @@ cppmacros['pyobj_from_complex_float1']='#define pyobj_from_complex_float1(v) (Py
 needs['pyobj_from_string1']=['string']
 cppmacros['pyobj_from_string1']='#define pyobj_from_string1(v) (PyString_FromString((char *)v))'
 needs['pyobj_from_string1size']=['string']
-cppmacros['pyobj_from_string1size']='#define pyobj_from_string1size(v,len) (PyString_FromStringAndSize((char *)v, len))'
+cppmacros['pyobj_from_string1size']='#define pyobj_from_string1size(v,len) (PyUString_FromStringAndSize((char *)v, len))'
 needs['TRYPYARRAYTEMPLATE']=['PRINTPYOBJERR']
 cppmacros['TRYPYARRAYTEMPLATE']="""\
 /* New SciPy */

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -20,6 +20,7 @@ extern "C" {
 #define PyString_GET_SIZE PyBytes_GET_SIZE
 #define PyString_AS_STRING PyBytes_AS_STRING
 #define PyString_FromString PyBytes_FromString
+#define PyUString_FromStringAndSize PyUnicode_FromStringAndSize
 #define PyString_ConcatAndDel PyBytes_ConcatAndDel
 #define PyString_AsString PyBytes_AsString
 
@@ -29,6 +30,10 @@ extern "C" {
 #define PyInt_AsLong PyLong_AsLong
 
 #define PyNumber_Int PyNumber_Long
+
+#else
+
+#define PyUString_FromStringAndSize PyString_FromStringAndSize
 #endif
 
 

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -34,6 +34,17 @@ cf2py  intent(out) a
        external fun
        call fun(a)
        end
+
+       subroutine string_callback(callback, a)
+       external callback
+       double precision callback
+       double precision a
+       character*1 r
+cf2py  intent(out) a
+       r = 'r'
+       a = callback(r)
+       end
+
     """
 
     @dec.slow
@@ -102,6 +113,19 @@ cf2py  intent(out) a
         assert_( r==7, repr(r))
         r = t(a.mth)
         assert_( r==9, repr(r))
+
+    def test_string_callback(self):
+
+        def callback(code):
+            if code == 'r':
+                return 0
+            else:
+                return 1
+
+        f = getattr(self.module, 'string_callback')
+        r = f(callback)
+        assert_(r == 0, repr(r))
+
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
Use PyUString_FromStringAndSize defined in npy_3kcompat instead. Not
using bytes may cause some problems, but strings seem like a better
choice. As modules generated with current f2py error out, this
particular use is not common and we are free to choose.

Closes #4256.
