### PR TITLE
Mention `compress` in `take`'s See Also docstring

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -90,6 +90,7 @@ def take(a, indices, axis=None, out=None, mode='raise'):
 
     See Also
     --------
+    compress : Take elements using a boolean mask
     ndarray.take : equivalent method
 
     Examples


### PR DESCRIPTION
Both are related -- one is for indexing using indices the other for boolean masks.

closes #3620
