### PR TITLE
BUG: #2408, Fix f2py Python 3 error message string bug.

### DIFF
--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -741,14 +741,12 @@ PyArrayObject* array_from_pyobj(const int type_num,
         return arr;
     }
 
-    if ((intent & F2PY_INTENT_INOUT)
-        || (intent & F2PY_INTENT_INPLACE)
-        || (intent & F2PY_INTENT_CACHE)) {
-        sprintf(mess,"failed to initialize intent(inout|inplace|cache) array"
-                " -- input must be array but got %s",
-                PyString_AsString(PyObject_Str(PyObject_Type(obj)))
-                );
-        PyErr_SetString(PyExc_TypeError,mess);
+    if ((intent & F2PY_INTENT_INOUT) ||
+            (intent & F2PY_INTENT_INPLACE) ||
+            (intent & F2PY_INTENT_CACHE)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "failed to initialize intent(inout|inplace|cache) "
+                        "array, input not an array");
         return NULL;
     }
 


### PR DESCRIPTION
The original was generating an exception message and, after aliasing,
calling PyBytes_AsString on a unicode string -> error. It was also
leaking references, although that probably didn't matter in context.

The fix here is on the cheap side, just use a C string for the message
without including the extra information about the erroneous type that
led to the exception.

No test, I don't know how to evoke this error.

Closes #2408.
