### PR TITLE
BUG: fix initialized half sum

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1791,20 +1791,19 @@ NPY_NO_EXPORT void
 HALF_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     if (IS_BINARY_REDUCE) {
-#if @PW@
-        npy_half * iop1 = (npy_half *)args[0];
-        npy_intp n = dimensions[0];
-
-        *iop1 @OP@= npy_float_to_half(pairwise_sum_HALF((npy_half *)args[1], n,
-                                       steps[1] / (npy_intp)sizeof(npy_half)));
-#else
         char *iop1 = args[0];
         float io1 = npy_half_to_float(*(npy_half *)iop1);
+#if @PW@
+        npy_intp n = dimensions[0];
+
+        io1 @OP@= pairwise_sum_HALF((npy_half *)args[1], n,
+                                    steps[1] / (npy_intp)sizeof(npy_half));
+#else
         BINARY_REDUCE_LOOP_INNER {
             io1 @OP@= npy_half_to_float(*(npy_half *)ip2);
         }
-        *((npy_half *)iop1) = npy_float_to_half(io1);
 #endif
+        *((npy_half *)iop1) = npy_float_to_half(io1);
     }
     else {
         BINARY_LOOP {

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -340,6 +340,10 @@ class TestUfunc(TestCase):
             assert_almost_equal(np.sum(d[-1::-2]), 250.)
             assert_almost_equal(np.sum(d[::-3]), 167.)
             assert_almost_equal(np.sum(d[-1::-3]), 167.)
+            # sum with first reduction entry != 0
+            d = np.ones((1,), dtype=dt)
+            d += d
+            assert_almost_equal(d, 2.)
 
     def test_sum_complex(self):
         for dt in (np.complex64, np.complex128, np.clongdouble):
@@ -361,6 +365,10 @@ class TestUfunc(TestCase):
             assert_almost_equal(np.sum(d[-1::-2]), 250. + 250j)
             assert_almost_equal(np.sum(d[::-3]), 167. + 167j)
             assert_almost_equal(np.sum(d[-1::-3]), 167. + 167j)
+            # sum with first reduction entry != 0
+            d = np.ones((1,), dtype=dt) + 1j
+            d += d
+            assert_almost_equal(d, 2. + 2j)
 
     def test_inner1d(self):
         a = np.arange(6).reshape((2, 3))


### PR DESCRIPTION
pairwise summation added in 1.9 broke half sums if the first element is
initialized non-zero. E.g. d += x
