### PR TITLE
ENH: perform inplace operations if one operand is a temporary

### DIFF
--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -346,6 +346,12 @@ array_inplace_divide(PyArrayObject *m1, PyObject *m2);
 #endif
 static PyObject *
 array_inplace_true_divide(PyArrayObject *m1, PyObject *m2);
+static PyObject *
+array_inplace_bitwise_and(PyArrayObject *m1, PyObject *m2);
+static PyObject *
+array_inplace_bitwise_or(PyArrayObject *m1, PyObject *m2);
+static PyObject *
+array_inplace_bitwise_xor(PyArrayObject *m1, PyObject *m2);
 
 /* check if m1 is a temporary (refcnt == 1) so we can do inplace operations
  * instead of creating a new temporary */
@@ -626,6 +632,9 @@ static PyObject *
 array_bitwise_and(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__and__", "__rand__", 0);
+    if (can_alide_temp(m1, m2)) {
+        return array_inplace_bitwise_and(m1, m2);
+    }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_and);
 }
 
@@ -633,6 +642,9 @@ static PyObject *
 array_bitwise_or(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__or__", "__ror__", 0);
+    if (can_alide_temp(m1, m2)) {
+        return array_inplace_bitwise_or(m1, m2);
+    }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_or);
 }
 
@@ -640,6 +652,9 @@ static PyObject *
 array_bitwise_xor(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__xor__", "__rxor__", 0);
+    if (can_alide_temp(m1, m2)) {
+        return array_inplace_bitwise_xor(m1, m2);
+    }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_xor);
 }
 

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -384,6 +384,9 @@ array_add(PyArrayObject *m1, PyObject *m2)
     if (can_elide_temp(m1, m2)) {
         return array_inplace_add(m1, m2);
     }
+    else if (can_elide_temp(m2, m1)) {
+        return array_inplace_add(m2, m1);
+    }
     else {
         return PyArray_GenericBinaryFunction(m1, m2, n_ops.add);
     }
@@ -407,6 +410,9 @@ array_multiply(PyArrayObject *m1, PyObject *m2)
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__mul__", "__rmul__", 0);
     if (can_elide_temp(m1, m2)) {
         return array_inplace_multiply(m1, m2);
+    }
+    else if (can_elide_temp(m2, m1)) {
+        return array_inplace_multiply(m2, m1);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.multiply);
 }
@@ -639,6 +645,9 @@ array_bitwise_and(PyArrayObject *m1, PyObject *m2)
     if (can_elide_temp(m1, m2)) {
         return array_inplace_bitwise_and(m1, m2);
     }
+    else if (can_elide_temp(m2, m1)) {
+        return array_inplace_bitwise_and(m2, m1);
+    }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_and);
 }
 
@@ -649,6 +658,9 @@ array_bitwise_or(PyArrayObject *m1, PyObject *m2)
     if (can_elide_temp(m1, m2)) {
         return array_inplace_bitwise_or(m1, m2);
     }
+    else if (can_elide_temp(m2, m1)) {
+        return array_inplace_bitwise_or(m2, m1);
+    }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_or);
 }
 
@@ -658,6 +670,9 @@ array_bitwise_xor(PyArrayObject *m1, PyObject *m2)
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__xor__", "__rxor__", 0);
     if (can_elide_temp(m1, m2)) {
         return array_inplace_bitwise_xor(m1, m2);
+    }
+    else if (can_elide_temp(m2, m1)) {
+        return array_inplace_bitwise_xor(m2, m1);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_xor);
 }

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -353,12 +353,15 @@ array_inplace_bitwise_or(PyArrayObject *m1, PyObject *m2);
 static PyObject *
 array_inplace_bitwise_xor(PyArrayObject *m1, PyObject *m2);
 
-/* check if m1 is a temporary (refcnt == 1) so we can do inplace operations
- * instead of creating a new temporary */
-static int can_alide_temp(PyArrayObject * m1, PyObject * m2)
+/*
+ * check if m1 is a temporary (refcnt == 1) so we can do inplace operations
+ * instead of creating a new temporary
+ */
+static int can_elide_temp(PyArrayObject * m1, PyObject * m2)
 {
-    if (Py_REFCNT(m1) == 1 &&
+    if (Py_REFCNT(m1) == 1 && /* TODO: use m2 == 1 too */
         PyArray_CheckExact(m1) && PyArray_CheckExact(m2) &&
+        PyArray_DESCR(m1)->type_num != NPY_VOID &&
         PyArray_DESCR(m1)->type_num == PyArray_DESCR(m2)->type_num &&
         PyArray_NDIM(m1) == PyArray_NDIM(m2) &&
         (PyArray_FLAGS(m1) & NPY_ARRAY_OWNDATA)) {
@@ -378,7 +381,7 @@ static PyObject *
 array_add(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__add__", "__radd__", 0);
-    if (can_alide_temp(m1, m2)) {
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_add(m1, m2);
     }
     else {
@@ -390,7 +393,7 @@ static PyObject *
 array_subtract(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__sub__", "__rsub__", 0);
-    if (can_alide_temp(m1, m2)) {
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_subtract(m1, m2);
     }
     else {
@@ -402,7 +405,7 @@ static PyObject *
 array_multiply(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__mul__", "__rmul__", 0);
-    if (can_alide_temp(m1, m2)) {
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_multiply(m1, m2);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.multiply);
@@ -413,7 +416,8 @@ static PyObject *
 array_divide(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__div__", "__rdiv__", 0);
-    if (can_alide_temp(m1, m2)) {
+    /* TODO mm->d type change */
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_divide(m1, m2);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.divide);
@@ -632,7 +636,7 @@ static PyObject *
 array_bitwise_and(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__and__", "__rand__", 0);
-    if (can_alide_temp(m1, m2)) {
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_bitwise_and(m1, m2);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_and);
@@ -642,7 +646,7 @@ static PyObject *
 array_bitwise_or(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__or__", "__ror__", 0);
-    if (can_alide_temp(m1, m2)) {
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_bitwise_or(m1, m2);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_or);
@@ -652,7 +656,7 @@ static PyObject *
 array_bitwise_xor(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__xor__", "__rxor__", 0);
-    if (can_alide_temp(m1, m2)) {
+    if (can_elide_temp(m1, m2)) {
         return array_inplace_bitwise_xor(m1, m2);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_xor);
@@ -754,7 +758,8 @@ static PyObject *
 array_true_divide(PyArrayObject *m1, PyObject *m2)
 {
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__truediv__", "__rtruediv__", 0);
-    if (can_alide_temp(m1, m2)) {
+    /* TODO how to check for inexact type? */
+    if (0 && can_elide_temp(m1, m2)) {
         return array_inplace_true_divide(m1, m2);
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.true_divide);


### PR DESCRIPTION
temporaries are identified by having a reference count of 1, if this is
the case we can perform inplace operations to avoid creating another
temporary.
E.g.

```
a = b + c + d 
```

contains one temporary (c + d) with reference count 1 while the other
operands have count 2, so b + temp can be performed inplace.
This saves memory allocation overheads and improves cache utilization.
