### PR TITLE
MAINT: add check_finite kwarg to numpy.linalg functions that use lapack

### DIFF
--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -57,7 +57,7 @@ class TestRegression(TestCase):
     def test_poly1d_nan_roots(self, level=rlevel):
         """Ticket #396"""
         p = np.poly1d([np.nan, np.nan, 1], r=0)
-        self.assertRaises(np.linalg.LinAlgError, getattr, p, "r")
+        self.assertRaises(ValueError, getattr, p, "r")
 
     def test_mem_polymul(self, level=rlevel):
         """Ticket #448"""

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1513,7 +1513,9 @@ def cond(x, p=None, check_finite=True):
         s = svd(x, compute_uv=False, check_finite=False)
         return s[0]/s[-1]
     else:
-        return norm(x, p)*norm(inv(x), p)
+        xnorm = norm(x, p, svd_check_finite=False)
+        xinvnorm = norm(inv(x, check_finite=False), p, svd_check_finite=False)
+        return xnorm * xinvnorm
 
 
 def matrix_rank(M, tol=None, check_finite=True):


### PR DESCRIPTION
This PR is a possibly controversial proposal to add more checks to numpy.linalg calls that thinly wrap lapack.

Ideally the underlying LAPACK libraries, most of which numpy does not control (with the exception of lapack-lite), would do something reasonable with matrices containing nan or inf.  Maybe they would return some error code, or they would return a matrix of nans, or indicate an error or warning in some other way.  Some lapack libraries indeed seem to do this.  Others libraries go into an infinite loop.

One reasonable argument could be that if the lapack libraries are buggy then that's the fault of the lapack libraries, and we do not need to change or slow down numpy code on account of their brokenness, except for lapack-lite which we can fix.

An alternative argument is that if enough of the functions in lapack libraries are broken in weird ways then it would be worth checking `isfinite` for some or all of the matrix inputs to lapack.  This possibility is raised [here](http://mail.scipy.org/pipermail/numpy-discussion/2014-February/069028.html) on the mailing list.  The argument is that the `numpy.linalg` ndarray lapack interface should be as thin as possible, but not thinner, and that an interface that lets common LAPACK library bugs cause infinite loops or other trouble is too thin.
# 

I'll highlight a couple of odd cases.  The functions `eigvals` and `eig` were already checking finiteness unconditionally, so now it is optional.  The `norm` function doesn't use lapack for most norms, so finiteness is now only checked for norms that use svd, and only conditionally.  One of the tests expected a LinAlgError but now it gets a ValueError.
