### PR TITLE
BUG: Index arrays need to be cast with SAME_KIND or FORCE casting

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2379,7 +2379,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
                         NPY_ITER_BUFFERED | NPY_ITER_NBO | NPY_ITER_ALIGNED |
                         NPY_ITER_EXTERNAL_LOOP | NPY_ITER_GROWINNER |
                         NPY_ITER_READONLY,
-                        NPY_KEEPORDER, NPY_SAFE_CASTING, intp_type);
+                        NPY_KEEPORDER, NPY_SAME_KIND_CASTING, intp_type);
 
         if (op_iter == NULL) {
             Py_DECREF(intp_type);

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -42,6 +42,25 @@ class TestIndexing(TestCase):
             a = np.array([np.array(1)], dtype=object)
             assert_(isinstance(a[0.], np.ndarray))
 
+    def test_same_kind_index_casting(self):
+        # Indexes should be cast with same-kind and not safe, even if
+        # that is somewhat unsafe. So test various different code paths.
+        index = np.arange(5)
+        u_index = index.astype(np.uintp)
+        arr = np.arange(10)
+
+        assert_array_equal(arr[index], arr[u_index])
+        arr[u_index] = np.arange(5)
+        assert_array_equal(arr, np.arange(10))
+
+        arr = np.arange(10).reshape(5, 2)
+        assert_array_equal(arr[index], arr[u_index])
+
+        arr[u_index] = np.arange(5)[:,None]
+        assert_array_equal(arr, np.arange(5)[:,None].repeat(2, axis=1))
+
+        arr = np.arange(25).reshape(5, 5)
+        assert_array_equal(arr[u_index, u_index], arr[index, index])
 
     def test_empty_fancy_index(self):
         # Empty list index creates an empty array


### PR DESCRIPTION
When checking index arrays for out of bound values, safe casting
was used. In principle this is unsafe, but we need to support indexing
with a 64bit integer array on 32bit systems.

Closes gh-4328
