### PR TITLE
BUG: Non-bool result when comparing ma scalars.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2840,12 +2840,8 @@ class MaskedArray(ndarray):
                 else:
                     # Don't modify inplace, we risk back-propagation
                     m = (m | d)
-            # Make sure the mask has the proper size
-            if result.shape == () and m:
-                return masked
-            else:
-                result._mask = m
-                result._sharedmask = False
+            result._mask = m
+            result._sharedmask = False
         #....
         return result
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -729,6 +729,9 @@ class TestMaskedArrayArithmetic(TestCase):
         self.assertTrue((-xm).mask)
         self.assertTrue(maximum(xm, xm).mask)
         self.assertTrue(minimum(xm, xm).mask)
+        # Issue #4332
+        self.assertEqual((xm > 0).dtype, np.dtype(bool))
+
 
     def test_masked_singleton_equality(self):
         # Tests (in)equality on masked snigleton


### PR DESCRIPTION
Removed logic replacing masked scalar results from ufuncs
with ma.masked singleton which has dtype float64.

Fixes #4332.
