### PR TITLE
TST: do not use "ignore" to filter warnings

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1222,8 +1222,8 @@ class TestCorrCoef(TestCase):
         assert_allclose(np.corrcoef(x, y), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_empty(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always', RuntimeWarning)
             assert_array_equal(corrcoef(np.array([])), np.nan)
             assert_array_equal(corrcoef(np.array([]).reshape(0, 2)),
                                np.array([]).reshape(0, 0))
@@ -1232,8 +1232,8 @@ class TestCorrCoef(TestCase):
 
     def test_wrong_ddof(self):
         x = np.array([[0, 2], [1, 1], [2, 0]]).T
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always', RuntimeWarning)
             assert_array_equal(corrcoef(x, ddof=5),
                                np.array([[np.nan, np.nan], [np.nan, np.nan]]))
 
@@ -1253,8 +1253,8 @@ class TestCov(TestCase):
         assert_allclose(cov(x, y), np.array([[1., -1.j], [1.j, 1.]]))
 
     def test_empty(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always', RuntimeWarning)
             assert_array_equal(cov(np.array([])), np.nan)
             assert_array_equal(cov(np.array([]).reshape(0, 2)),
                                np.array([]).reshape(0, 0))
@@ -1263,8 +1263,8 @@ class TestCov(TestCase):
 
     def test_wrong_ddof(self):
         x = np.array([[0, 2], [1, 1], [2, 0]]).T
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always', RuntimeWarning)
             assert_array_equal(cov(x, ddof=5),
                                np.array([[np.inf, -np.inf], [-np.inf, np.inf]]))
 

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -130,8 +130,8 @@ class TestNanFunctions_ArgminArgmax(TestCase):
     def test_result_values(self):
         for f, fcmp in zip(self.nanfuncs, [np.greater, np.less]):
             for row in _ndat:
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
+                with warnings.catch_warnings(record=True):
+                    warnings.simplefilter('always')
                     ind = f(row)
                     val = row[ind]
                     # comparing with NaN is tricky as the result


### PR DESCRIPTION
When a warning is ignored (or raised once) in python, the warnings
module will tag on a `__warningregistry__` dictionary to be able
to filter these warnings in the future. This is tagged on to the
current context, causing leakage to later calls (this is a bit
more complex, since where the registry ends up depends on the
layers between the original caller and warner).

In short, tests should typically not use ignore but catch the
warnings to avoid changing the user experience (or errors
on duplicate test runs).

Fixes an error on duplicate test runs (does not remove all
"ignores" which may change behaviour outside tests).
Closes gh-4340
## 

tl;dr: fixes test reruns by not using "ignore". Didn't replace all ignores though, just the ones I thought may be offending here. Could replace more if you like.
