### PR TITLE
BUG: Fixes #2799

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -163,8 +163,7 @@ def unique(ar, return_index=False, return_inverse=False):
         ar = ar.flatten()
     except AttributeError:
         if not return_inverse and not return_index:
-            items = sorted(set(ar))
-            return np.asarray(items)
+            return np.sort(list(set(ar)))
         else:
             ar = np.asanyarray(ar).flatten()
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -65,6 +65,10 @@ class TestSetOps(TestCase):
         bb = np.array(list(zip(b, b)), dt)
         check_all(aa, bb, i1, i2, dt)
 
+        # test for ticket #2799
+        aa = [1.+0.j, 1- 1.j, 1]
+        assert_array_equal(np.unique(aa), [ 1.-1.j,  1.+0.j])
+
     def test_intersect1d(self):
         # unique inputs
         a = np.array([5, 7, 1, 2])


### PR DESCRIPTION
Use `np.sort` instead of `sorted` when the input is a list and no indices
are requested. Fixes #2799.
