### PR TITLE
ENH: Speed improvements and deprecations for np.select

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -239,6 +239,12 @@ Non-integer scalars for sequence repetition
 Using non-integer numpy scalars to repeat python sequences is deprecated.
 For example ``np.float_(2) * [1]`` will be an error in the future.
 
+``select`` input deprecations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The integer and empty input to ``select`` is deprecated. In the future only
+boolean arrays will be valid conditions and an empty ``condlist`` will be
+considered an input error instead of returning the default.
+
 C-API
 ~~~~~
 


### PR DESCRIPTION
The idea for this (and some of the code) originally comes from
Graeme B Bell (gh-3537).
Choose is not as fast and pretty limited, so an iterative
copyto is used instead.

Closes gh-3259, gh-3537, gh-3551, and gh-3254
