### PR TITLE
TST: switch i386 build to python3.4 defaulting ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 matrix:
   include:
     - python: 3.3
-      env: USE_CHROOT=1 ARCH=i386 DIST=saucy
+      env: USE_CHROOT=1 ARCH=i386 DIST=trusty PYTHON=3.4
     - python: 3.2
       env: USE_DEBUG=1
     - python: 2.7

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -43,9 +43,9 @@ setup_chroot()
   sudo debootstrap --variant=buildd --include=fakeroot,build-essential --arch=$ARCH --foreign $DIST $DIR
   sudo chroot $DIR ./debootstrap/debootstrap --second-stage
   sudo rsync -a $TRAVIS_BUILD_DIR $DIR/
-  echo deb http://archive.ubuntu.com/ubuntu/ saucy main restricted universe multiverse | sudo tee -a $DIR/etc/apt/sources.list
-  echo deb http://archive.ubuntu.com/ubuntu/ saucy-updates main restricted universe multiverse | sudo tee -a $DIR/etc/apt/sources.list
-  echo deb http://security.ubuntu.com/ubuntu saucy-security  main restricted universe multiverse | sudo tee -a $DIR/etc/apt/sources.list
+  echo deb http://archive.ubuntu.com/ubuntu/ $DIST main restricted universe multiverse | sudo tee -a $DIR/etc/apt/sources.list
+  echo deb http://archive.ubuntu.com/ubuntu/ $DIST-updates main restricted universe multiverse | sudo tee -a $DIR/etc/apt/sources.list
+  echo deb http://security.ubuntu.com/ubuntu $DIST-security  main restricted universe multiverse | sudo tee -a $DIR/etc/apt/sources.list
   sudo chroot $DIR bash -c "apt-get update"
   sudo chroot $DIR bash -c "apt-get install -qq -y --force-yes eatmydata"
   echo /usr/lib/libeatmydata/libeatmydata.so | sudo tee -a $DIR/etc/ld.so.preload


### PR DESCRIPTION
python 3.4rc1 is available and we should improve our coverage by switching one of our tests to it.
switching the i386 test to ubuntu 14.04 gives us newer compilers, libc and atlas in addition to python3.4. As 14.04 its still in development mode we might get some false positives due to issues in the distribution, but I think its worth trying.
