### PR TITLE
Fix stride_stricks.as_strided function for object arrays

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -29,7 +29,8 @@ def as_strided(x, shape=None, strides=None):
         interface['strides'] = tuple(strides)
     array = np.asarray(DummyArray(interface, base=x))
     # Make sure dtype is correct in case of custom dtype
-    array.dtype = x.dtype
+    if array.dtype.kind == 'V':
+        array.dtype = x.dtype
     return array
 
 def broadcast_arrays(*args):

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.testing import *
 from numpy.lib.stride_tricks import broadcast_arrays
+from numpy.lib.stride_tricks import as_strided
 
 
 def assert_shapes_correct(input_shapes, expected_shape):
@@ -213,6 +214,22 @@ def test_same_as_ufunc():
         if () not in input_shapes:
             assert_same_as_ufunc(input_shapes[0], input_shapes[1], False, True)
             assert_same_as_ufunc(input_shapes[0], input_shapes[1], True, True)
+
+def test_as_strided():
+    a = np.array([None])
+    a_view = as_strided(a)
+    expected = np.array([None])
+    assert_array_equal(a_view, np.array([None]))
+
+    a = np.array([1, 2, 3, 4])
+    a_view = as_strided(a, shape=(2,), strides=(2 * a.itemsize,))
+    expected = np.array([1, 3])
+    assert_array_equal(a_view, expected)
+
+    a = np.array([1, 2, 3, 4])
+    a_view = as_strided(a, shape=(3, 4), strides=(0, 1 * a.itemsize))
+    expected = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+    assert_array_equal(a_view, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, calling as_strided for object array results in 'TypeError: Cannot change data-type for object array.'. Fix so that dtype of new array is only set for void dtype, as originally intended.

Also add a few tests for as_strided function.
