### PR TITLE
link to correct msvcr using compiler specs

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -459,7 +459,7 @@ def make_specs():
 
     import sys, os
     fname = os.path.join(sys.prefix,'libs',msvcr+".specs")
-    fh = (fname, "w")
+    fh = open(fname, "w")
     fh.write(newspecs)
     fh.close()
     return fname

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -438,7 +438,7 @@ def make_specs():
     moldname = "moldname" if msvcr == "msvcrt" else "moldname" + msvcr.lstrip('msvcr')
 
     import subprocess
-    specs = subprocess.check_output(["gcc", "-dumpspecs"])
+    specs = subprocess.Popen(["gcc", "-dumpspecs"], stdout=subprocess.PIPE).communicate()[0].decode('ascii')
 
     #newspecs = specs.replace("msvcrt",msvcr).replace("moldname",moldname)
     #be more subtle:
@@ -459,8 +459,9 @@ def make_specs():
 
     import sys, os
     fname = os.path.join(sys.prefix,'libs',msvcr+".specs")
-    with open(fname,"w") as f:
-        f.write(newspecs)
+    fh = (fname, "w")
+    fh.write(newspecs)
+    fh.close()
     return fname
 
 


### PR DESCRIPTION
msvcrt.dll is used as default runtime library by mingw32, currently numpy.distutils tries to replace it by setting -D__MSVCRT_VERSION__=0x0900 and -lmsvcr90. In my case this creates additional (correct) dependency on msvcr90.dll but does not remove msvcrt.dll.

To achieve correct linking (only) to msvcr90.dll, compiler specs need to be modified, since linking to msvcrt.dll happens implicitly in the internals. (look at the first comment here: http://www.mingw.org/wiki/HOWTO_Use_the_GCC_specs_file#comment-106)

This was also reported as issue #4368
