### PR TITLE
DOC: some versionadded notes

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -668,6 +668,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         The returned array will have at least `ndmin` dimensions.
         Otherwise mono-dimensional axes will be squeezed.
         Legal values: 0 (default), 1 or 2.
+
         .. versionadded:: 1.6.0
 
     Returns
@@ -911,14 +912,17 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         .. versionadded:: 1.5.0
     header : str, optional
         String that will be written at the beginning of the file.
+
         .. versionadded:: 1.7.0
     footer : str, optional
         String that will be written at the end of the file.
+
         .. versionadded:: 1.7.0
     comments : str, optional
         String that will be prepended to the ``header`` and ``footer`` strings,
         to mark them as comments. Default: '# ',  as expected by e.g.
         ``numpy.loadtxt``.
+
         .. versionadded:: 1.7.0
 
         Character separating lines.

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1156,6 +1156,8 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0,
     It compares the difference between `actual` and `desired` to
     ``atol + rtol * abs(desired)``.
 
+    .. versionadded:: 1.5.0
+
     Parameters
     ----------
     actual : array_like
@@ -1465,6 +1467,7 @@ class WarningManager(object):
         self._module.filters = self._filters
         self._module.showwarning = self._showwarning
 
+
 def assert_warns(warning_class, func, *args, **kw):
     """
     Fail unless the given callable throws the specified warning.
@@ -1473,6 +1476,8 @@ def assert_warns(warning_class, func, *args, **kw):
     invoked with arguments args and keyword arguments kwargs.
     If a different type of warning is thrown, it will not be caught, and the
     test case will be deemed to have suffered an error.
+
+    .. versionadded:: 1.4.0
 
     Parameters
     ----------
@@ -1504,6 +1509,8 @@ def assert_warns(warning_class, func, *args, **kw):
 def assert_no_warnings(func, *args, **kw):
     """
     Fail if the given callable produces any warnings.
+
+    .. versionadded:: 1.8.0
 
     Parameters
     ----------

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1510,7 +1510,7 @@ def assert_no_warnings(func, *args, **kw):
     """
     Fail if the given callable produces any warnings.
 
-    .. versionadded:: 1.8.0
+    .. versionadded:: 1.7.0
 
     Parameters
     ----------


### PR DESCRIPTION
Add some `versionadded` and fix some existing notation that uses formatting that sphinx doesn't understand.  `assert_allclose` seems to have been added in 1.6 and subsequently backported to 1.5 so I am listing it as 1.5.  In practice I look at these annotations in the numpy docs so that I can decide whether or not I can use functions in projects that support e.g. numpy 1.5.1+
