### PR TITLE
ENH: vectorize negative with sse

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1692,9 +1692,11 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_negative(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        *((@type@ *)op1) = -in1;
+    if (!run_unary_simd_negative_@TYPE@(args, dimensions, steps)) {
+        UNARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            *((@type@ *)op1) = -in1;
+        }
     }
 }
 

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -133,10 +133,10 @@ static const npy_int32 fanout_4[] = {
  */
 
 /**begin repeat1
- * #func = sqrt, absolute, minimum, maximum#
- * #check = IS_BLOCKABLE_UNARY, IS_BLOCKABLE_UNARY, IS_BLOCKABLE_REDUCE, IS_BLOCKABLE_REDUCE#
- * #name = unary, unary, unary_reduce, unary_reduce#
- * #minmax = 0, 0, 1, 1#
+ * #func = sqrt, absolute, negative, minimum, maximum#
+ * #check = IS_BLOCKABLE_UNARY*3, IS_BLOCKABLE_REDUCE*2 #
+ * #name = unary*3, unary_reduce*2#
+ * #minmax = 0*3, 1*2#
  */
 
 #if @vector@ && defined NPY_HAVE_SSE2_INTRINSICS
@@ -621,41 +621,56 @@ sse2_sqrt_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 }
 
 
+static NPY_INLINE
+@type@ scalar_abs_@type@(@type@ v)
+{
+    /* add 0 to clear -0.0 */
+    return (v > 0 ? v: -v) + 0;
+}
+
+static NPY_INLINE
+@type@ scalar_neg_@type@(@type@ v)
+{
+    return -v;
+}
+
+/**begin repeat1
+ * #kind = absolute, negative#
+ * #VOP = andnot, xor#
+ * #scalar = scalar_abs, scalar_neg#
+ **/
 static void
-sse2_absolute_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
+sse2_@kind@_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 {
     /*
      * get 0x7FFFFFFF mask (everything but signbit set)
-     * float & ~mask will remove the sign
+     * float & ~mask will remove the sign, float ^ mask flips the sign
      * this is equivalent to how the compiler implements fabs on amd64
      */
     const @vtype@ mask = @vpre@_set1_@vsuf@(-0.@c@);
 
     /* align output to 16 bytes */
     LOOP_BLOCK_ALIGN_VAR(op, @type@, 16) {
-        const @type@ tmp = ip[i] > 0 ? ip[i]: -ip[i];
-        /* add 0 to clear -0.0 */
-        op[i] = tmp + 0;
+        op[i] = @scalar@_@type@(ip[i]);
     }
     assert(n < (16 / sizeof(@type@)) || npy_is_aligned(&op[i], 16));
     if (npy_is_aligned(&ip[i], 16)) {
         LOOP_BLOCKED(@type@, 16) {
             @vtype@ a = @vpre@_load_@vsuf@(&ip[i]);
-            @vpre@_store_@vsuf@(&op[i], @vpre@_andnot_@vsuf@(mask, a));
+            @vpre@_store_@vsuf@(&op[i], @vpre@_@VOP@_@vsuf@(mask, a));
         }
     }
     else {
         LOOP_BLOCKED(@type@, 16) {
             @vtype@ a = @vpre@_loadu_@vsuf@(&ip[i]);
-            @vpre@_store_@vsuf@(&op[i], @vpre@_andnot_@vsuf@(mask, a));
+            @vpre@_store_@vsuf@(&op[i], @vpre@_@VOP@_@vsuf@(mask, a));
         }
     }
     LOOP_BLOCKED_END {
-        const @type@ tmp = ip[i] > 0 ? ip[i]: -ip[i];
-        /* add 0 to clear -0.0 */
-        op[i] = tmp + 0;
+        op[i] = @scalar@_@type@(ip[i]);
     }
 }
+/**end repeat1**/
 
 
 /**begin repeat1

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -693,8 +693,8 @@ class TestMinMax(TestCase):
                     assert_equal(inp.min(), -1e10, err_msg=msg)
 
 
-class TestAbsolute(TestCase):
-    def test_abs_blocked(self):
+class TestAbsoluteNegative(TestCase):
+    def test_abs_neg_blocked(self):
         # simd tests on abs, test all alignments for vz + 2 * (vs - 1) + 1
         for dt, sz in [(np.float32, 11), (np.float64, 5)]:
             for out, inp, msg in _gen_alignment_data(dtype=dt, type='unary',
@@ -703,6 +703,10 @@ class TestAbsolute(TestCase):
                 np.absolute(inp, out=out)
                 assert_equal(out, tgt, err_msg=msg)
                 self.assertTrue((out >= 0).all())
+
+                tgt = [-1*(i) for i in inp]
+                np.negative(inp, out=out)
+                assert_equal(out, tgt, err_msg=msg)
 
                 # will throw invalid flag depending on compiler optimizations
                 with np.errstate(invalid='ignore'):
@@ -715,6 +719,10 @@ class TestAbsolute(TestCase):
                             assert_array_equal(np.abs(inp), d, err_msg=msg)
                             np.abs(inp, out=out)
                             assert_array_equal(out, d, err_msg=msg)
+
+                            assert_array_equal(-inp, -1*inp, err_msg=msg)
+                            np.negative(inp, out=out)
+                            assert_array_equal(out, -1*inp, err_msg=msg)
 
 
 class TestSpecialMethods(TestCase):


### PR DESCRIPTION
negative on amd64 is the same as absolute except using xor instead of andnot
