### PR TITLE
ENH: Make output of get_atlas_info conditional on system_info.verbosity

### DIFF
--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -401,7 +401,7 @@ int main ()
 
     def get_output(self, body, headers=None, include_dirs=None,
                    libraries=None, library_dirs=None,
-                   lang="c"):
+                   lang="c", use_tee=None):
         """Try to compile, link to an executable, and run a program
         built from 'body' and 'headers'. Returns the exit status code
         of the program and its output.
@@ -426,7 +426,8 @@ int main ()
                 grabber.restore()
                 raise
             exe = os.path.join('.', exe)
-            exitstatus, output = exec_command(exe, execute_in='.')
+            exitstatus, output = exec_command(exe, execute_in='.',
+                                              use_tee=use_tee)
             if hasattr(os, 'WEXITSTATUS'):
                 exitcode = os.WEXITSTATUS(exitstatus)
                 if os.WIFSIGNALED(exitstatus):

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -120,7 +120,7 @@ def find_executable(exe, path=None, _cache={}):
             if not os.path.islink(f_ext):
                 f_ext = realpath(f_ext)
             if os.path.isfile(f_ext) and os.access(f_ext, os.X_OK):
-                log.good('Found executable %s' % f_ext)
+                log.info('Found executable %s' % f_ext)
                 _cache[key] = f_ext
                 return f_ext
 

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -756,9 +756,6 @@ class fftw_info(system_info):
                     'includes':['fftw.h', 'rfftw.h'],
                     'macros':[('SCIPY_FFTW_H', None)]}]
 
-    def __init__(self):
-        system_info.__init__(self)
-
     def calc_ver_info(self, ver_param):
         """Returns True on successful version detection, else False"""
         lib_dirs = self.get_lib_dirs()
@@ -1302,11 +1299,13 @@ def get_atlas_version(**config):
     info = {}
     try:
         s, o = c.get_output(atlas_version_c_text,
-                            libraries=libraries, library_dirs=library_dirs)
+                            libraries=libraries, library_dirs=library_dirs,
+                            use_tee=(system_info.verbosity > 0))
         if s and re.search(r'undefined reference to `_gfortran', o, re.M):
             s, o = c.get_output(atlas_version_c_text,
                                 libraries=libraries + ['gfortran'],
-                                library_dirs=library_dirs)
+                                library_dirs=library_dirs,
+                                use_tee=(system_info.verbosity > 0))
             if not s:
                 warnings.warn("""
 *****************************************************
@@ -1480,7 +1479,7 @@ class blas_opt_info(system_info):
         if not atlas_info:
             atlas_info = get_info('atlas_blas')
 
-        if sys.platform == 'darwin'and not atlas_info:
+        if sys.platform == 'darwin' and not atlas_info:
             # Use the system BLAS from Accelerate or vecLib under OSX
             args = []
             link_args = []


### PR DESCRIPTION
This is an alternative solution to #4081 that requires less code modification.

This stills prints everything as the default behaviour but lets clients decide to hide the output if they want, without introducing any new parameters.
