### PR TITLE
BUG: Fix broadcast_arrays for object dtype in numpy==1.8.x

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -29,6 +29,7 @@ def as_strided(x, shape=None, strides=None):
         interface['strides'] = tuple(strides)
     array = np.asarray(DummyArray(interface, base=x))
     # Make sure dtype is correct in case of custom dtype
+    # Note: dtype is read-only for object arrays
     if array.dtype is not np.dtype('O'):
         array.dtype = x.dtype
     return array

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -29,7 +29,8 @@ def as_strided(x, shape=None, strides=None):
         interface['strides'] = tuple(strides)
     array = np.asarray(DummyArray(interface, base=x))
     # Make sure dtype is correct in case of custom dtype
-    array.dtype = x.dtype
+    if array.dtype is not np.dtype('O'):
+        array.dtype = x.dtype
     return array
 
 def broadcast_arrays(*args):

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -45,8 +45,7 @@ def assert_same_as_ufunc(shape0, shape1, transposed=False, flipped=False):
 
 
 def test_as_strided_dtype():
-    """Verify that as_strided works for arrays of different data types
-    """
+    # Verify that as_strided works for arrays of different data types
     # note: regression test for bug in GitHub issue #3323
     for dtype in [float, 'i4,f4', object]:
         x = np.zeros((2,), dtype)
@@ -70,8 +69,7 @@ def test_one_off():
     assert_array_equal(by0, by)
 
 def test_same_input_shapes():
-    """ Check that the final shape is just the input shape.
-    """
+    # Check that the final shape is just the input shape.
     data = [
         (),
         (1,),
@@ -96,9 +94,8 @@ def test_same_input_shapes():
         assert_shapes_correct(input_shapes3, shape)
 
 def test_two_compatible_by_ones_input_shapes():
-    """ Check that two different input shapes (of the same length but some have
-    1s) broadcast to the correct shape.
-    """
+    # Check that two different input shapes (of the same length but some have
+    # 1s) broadcast to the correct shape.
     data = [
         [[(1,), (3,)], (3,)],
         [[(1, 3), (3, 3)], (3, 3)],
@@ -120,9 +117,8 @@ def test_two_compatible_by_ones_input_shapes():
         assert_shapes_correct(input_shapes[::-1], expected_shape)
 
 def test_two_compatible_by_prepending_ones_input_shapes():
-    """ Check that two different input shapes (of different lengths) broadcast
-    to the correct shape.
-    """
+    # Check that two different input shapes (of different lengths) broadcast
+    # to the correct shape.
     data = [
         [[(), (3,)], (3,)],
         [[(3,), (3, 3)], (3, 3)],
@@ -151,8 +147,7 @@ def test_two_compatible_by_prepending_ones_input_shapes():
         assert_shapes_correct(input_shapes[::-1], expected_shape)
 
 def test_incompatible_shapes_raise_valueerror():
-    """ Check that a ValueError is raised for incompatible shapes.
-    """
+    # Check that a ValueError is raised for incompatible shapes.
     data = [
         [(3,), (4,)],
         [(2, 3), (2,)],
@@ -165,8 +160,7 @@ def test_incompatible_shapes_raise_valueerror():
         assert_incompatible_shapes_raise(input_shapes[::-1])
 
 def test_same_as_ufunc():
-    """ Check that the data layout is the same as if a ufunc did the operation.
-    """
+    # Check that the data layout is the same as if a ufunc did the operation.
     data = [
         [[(1,), (3,)], (3,)],
         [[(1, 3), (3, 3)], (3, 3)],

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import *
-from numpy.lib.stride_tricks import broadcast_arrays
+from numpy.lib.stride_tricks import as_strided, broadcast_arrays
 
 
 def assert_shapes_correct(input_shapes, expected_shape):
@@ -42,6 +42,15 @@ def assert_same_as_ufunc(shape0, shape1, transposed=False, flipped=False):
     y = x0 + x1
     b0, b1 = broadcast_arrays(x0, x1)
     assert_array_equal(y, b1)
+
+
+def test_as_strided_dtype():
+    """Verify that as_strided works for arrays of different data types
+    """
+    # note: regression test for bug in GitHub issue #3323
+    for dtype in [float, 'i4,f4', object]:
+        x = np.zeros((2,), dtype)
+        assert_array_equal(x, as_strided(x))
 
 
 def test_same():


### PR DESCRIPTION
This PR has the commits from #4343 backported to numpy 1.8.x. I would love to get this fix in to numpy 1.8.1!
