### PR TITLE
BUG: enable windows large file support for mingw

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -57,8 +57,16 @@
 #endif
 
 /* 64 bit file position support, also on win-amd64. Ticket #1660 */
-#if defined(_MSC_VER) && defined(_WIN64) && (_MSC_VER > 1400)
+#if defined(_MSC_VER) && defined(_WIN64) && (_MSC_VER > 1400) || \
+    defined(__MINGW32__) || defined(__MINGW64__)
     #include <io.h>
+
+/* mingw based on 3.4.5 has lseek but not ftell/fseek */
+#if defined(__MINGW32__) || defined(__MINGW64__)
+extern int __cdecl _fseeki64(FILE *, long long, int);
+extern long long __cdecl _ftelli64(FILE *);
+#endif
+
     #define npy_fseek _fseeki64
     #define npy_ftell _ftelli64
     #define npy_lseek _lseeki64


### PR DESCRIPTION
The (non-lfs) posix api mingw otherwise uses does not seem to work on win32.
The windows lseek prototypes are available in the ancient mingw32 version
we use for our windows binaries but not the fseek/ftell, so they are
defined manually.
