### PR TITLE
BUG: Fix infinite recursion in else case of __format__() implementation (fixes #4359)

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -433,8 +433,7 @@ gentype_format(PyObject *self, PyObject *args)
         Py_DECREF(dtype);
     }
     else {
-        obj = self;
-        Py_INCREF(obj);
+        obj = PyObject_Str(self);
     }
 
     if (obj == NULL) {

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1945,5 +1945,13 @@ class TestRegression(TestCase):
         arr.__setitem__(slice(None), [9])
         assert_equal(arr, [9, 9, 9])
 
+    def test_format_on_flex_array_element(self):
+        # Ticket #4369.
+        dt = np.dtype([('date', '<M8[D]'), ('val', '<f8')])
+        arr = np.array([('2000-01-01', 1)], dt)
+        formatted = '{0}'.format(arr[0])
+        assert_equal(formatted, str(arr[0]))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is my first contribution to NumPy, so any and all feedback is welcome.

Fixes #4359. When Python evaluates `>>> "{}".format(some_generic_obj)`, the numpy `gentype_format()` C function is called. The existing code implements a set of pre-known types, and has an else case. The else case as implemented was calling `PyObject_Format()`, which lead to infinite recursion. The new code handles the else case by calling `PyObject_Str()` on the object.
