### PR TITLE
BUG: adds check in dtype.name that string starts with "numpy." prefix before removing it (Fixes #4357)

### DIFF
--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -513,6 +513,20 @@ class TestDtypeAttributeDeletion(object):
         for s in attr:
             assert_raises(AttributeError, delattr, dt, s)
 
+class TestDtypeAttributes(TestCase):
+
+    def test_name_builtin(self):
+        for t in np.typeDict.values():
+            name = t.__name__
+            if name.endswith('_'):
+                name = name[:-1]
+            assert_equal(np.dtype(t).name, name)
+
+    def test_name_dtype_subclass(self):
+        # Ticket #4357
+        class user_def_subcls(np.void): pass
+        assert_equal(np.dtype(user_def_subcls).name, 'user_def_subcls')
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is my second contribution to NumPy; any and all feedback is welcome.

Fixes #4357. Adds check in `arraydescr_typename_get()` (implementation of dtype.name) that the name string inherited from  `typeobj->tp_name` does indeed start with "numpy." before offsetting the pointer to remove it.
