### PR TITLE
DOC: Use tp_basicsize, not NPY_SIZEOF_PYARRAYOBJECT, for allocation

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -373,6 +373,14 @@ an inner loop for user types using the descr.
 
 * PyUFunc_RegisterLoopForDescr
 
+C-API Developer Improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``PyArray_Type`` instance creation function ``tp_new`` now
+uses ``tp_basicsize`` to determine how much memory to allocate.
+In previous releases only ``sizeof(PyArrayObject)`` bytes of
+memory were allocated, often requiring C-API subtypes to
+reimplement ``tp_new``.
+
 Deprecations
 ============
 


### PR DESCRIPTION
As mentioned in #2975, add agreed upon text from #2980 to the release notes.

Closes #2980.
