### PR TITLE
BUG: fix issue#4354 byte_bounds() bug closes gh-4354

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -210,8 +210,9 @@ def byte_bounds(a):
     a_data = ai['data'][0]
     astrides = ai['strides']
     ashape = ai['shape']
-    bytes_a = int(ai['typestr'][2:])
-
+   
+    bytes_a = asarray(a).dtype.itemsize
+       
     a_low = a_high = a_data
     if astrides is None: # contiguous case
         a_high += a.size * bytes_a


### PR DESCRIPTION
I am not sure whether this solves the whole problem, but the I try the following changes in utils.py.
Then, I get 8 bytes for each datetime record.
