### PR TITLE
BUG: fix non-c99 fallback for np.inf input to log1p/expm1

### DIFF
--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -44,3 +44,4 @@ Issues fixed
 * gh-3175: segmentation fault with numpy.array() from bytearray
 * gh-4266: histogramdd - wrong result for entries very close to last boundary
 * gh-4408: Fix stride_stricks.as_strided function for object arrays
+* gh-4225: fix log1p and exmp1 return for np.inf on windows compiler builds

--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -65,14 +65,19 @@
 #ifndef HAVE_EXPM1
 double npy_expm1(double x)
 {
-    const double u = npy_exp(x);
-
-    if (u == 1.0) {
+    if (npy_isinf(x) && x > 0) {
         return x;
-    } else if (u - 1.0 == -1.0) {
-        return -1;
-    } else {
-        return (u - 1.0) * x/npy_log(u);
+    }
+    else {
+        const double u = npy_exp(x);
+
+        if (u == 1.0) {
+            return x;
+        } else if (u - 1.0 == -1.0) {
+            return -1;
+        } else {
+            return (u - 1.0) * x/npy_log(u);
+        }
     }
 }
 #endif
@@ -80,13 +85,18 @@ double npy_expm1(double x)
 #ifndef HAVE_LOG1P
 double npy_log1p(double x)
 {
-    const double u = 1. + x;
-    const double d = u - 1.;
-
-    if (d == 0) {
+    if (npy_isinf(x) && x > 0) {
         return x;
-    } else {
-        return npy_log(u) * x / d;
+    }
+    else {
+        const double u = 1. + x;
+        const double d = u - 1.;
+
+        if (d == 0) {
+            return x;
+        } else {
+            return npy_log(u) * x / d;
+        }
     }
 }
 #endif

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -303,11 +303,27 @@ class TestLog1p(TestCase):
         assert_almost_equal(ncu.log1p(0.2), ncu.log(1.2))
         assert_almost_equal(ncu.log1p(1e-6), ncu.log(1+1e-6))
 
+    def test_special(self):
+        assert_equal(ncu.log1p(np.nan), np.nan)
+        assert_equal(ncu.log1p(np.inf), np.inf)
+        with np.errstate(divide="ignore"):
+            assert_equal(ncu.log1p(-1.), -np.inf)
+        with np.errstate(invalid="ignore"):
+            assert_equal(ncu.log1p(-2.), np.nan)
+            assert_equal(ncu.log1p(-np.inf), np.nan)
+
 
 class TestExpm1(TestCase):
     def test_expm1(self):
         assert_almost_equal(ncu.expm1(0.2), ncu.exp(0.2)-1)
         assert_almost_equal(ncu.expm1(1e-6), ncu.exp(1e-6)-1)
+
+    def test_special(self):
+        assert_equal(ncu.expm1(np.inf), np.inf)
+        assert_equal(ncu.expm1(0.), 0.)
+        assert_equal(ncu.expm1(-0.), -0.)
+        assert_equal(ncu.expm1(np.inf), np.inf)
+        assert_equal(ncu.expm1(-np.inf), -1.)
 
 
 class TestHypot(TestCase, object):


### PR DESCRIPTION
closes gh-4225

backport for 1.8
