### PR TITLE
BUG: Fix deepcopy() of rank-zero arrays.

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1457,7 +1457,7 @@ array_deepcopy(PyArrayObject *self, PyObject *args)
         Py_DECREF(deepcopy);
         Py_DECREF(it);
     }
-    return PyArray_Return(ret);
+    return ret;
 }
 
 /* Convert Array to flat list (using getitem) */

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import copy
 import pickle
 import sys
 import platform
@@ -1951,6 +1952,17 @@ class TestRegression(TestCase):
         arr = np.array([('2000-01-01', 1)], dt)
         formatted = '{0}'.format(arr[0])
         assert_equal(formatted, str(arr[0]))
+
+    def test_deepcopy_on_0d_array(self):
+        # Ticket #3311.
+        arr = np.array(3)
+        arr_cp = copy.deepcopy(arr)
+
+        assert_equal(arr, arr_cp)
+        assert_equal(arr.shape, arr_cp.shape)
+        assert_equal(int(arr), int(arr_cp))
+        self.assertTrue(arr is not arr_cp)
+        self.assertTrue(isinstance(arr_cp, type(arr)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3311. Removed call to PyArray_Return() on return value. 

`PyArray_Return(PyArrayObject*)` is described as _"Return either an array or the appropriate Python object if the array is 0d and matches a Python type."_ The single path out of the `__deepcopy__` implementation was: `return PyArray_Return(ret);`.

The type of the return value of `__deepcopy__` on an array should **always** be an array, so there should be no case where `PyArray_Return` acts. 

Looking at the history of this line, the call was originally added when a developer was adding it to six other method in the file (`git show 2d0b625d`). So it was very likely a mistake. It likely went unnoticed because it has no effect when ndim > 0.
