### PR TITLE
BUG: Masked array filled method ignores fill value

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -416,7 +416,7 @@ def _check_fill_value(fill_value, ndtype):
             fill_value = np.array(_recursive_set_fill_value(fill_value, descr),
                                   dtype=ndtype)
     else:
-        if isinstance(fill_value, basestring) and (ndtype.char not in 'SVU'):
+        if isinstance(fill_value, basestring) and (ndtype.char not in 'OSVU'):
             fill_value = default_fill_value(ndtype)
         else:
             # In case we want to convert 1e+20 to int...

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -474,6 +474,10 @@ class TestMaskedArray(TestCase):
         atest[idx] = btest[idx]
         assert_equal(atest, [20])
 
+    def test_filled_w_object_dtype(self):
+        a = np.ma.masked_all(1, dtype='O')
+        assert_equal(a.filled('x')[0], 'x')
+
     def test_filled_w_flexible_dtype(self):
         # Test filled w/ flexible dtype
         flexi = array([(1, 1, 1)],


### PR DESCRIPTION
When string fill value is passed to the filled method of
a masked array with object ('O') dtype, it is ignored and
masked elements are filled with '?' instead.

Fixes #4436
