### PR TITLE
ENH: Explicitly use __eq__ in assert_equal(a,b)

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -318,7 +318,9 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
     # as before
     except (TypeError, ValueError, NotImplementedError):
         pass
-    if desired != actual :
+
+    # Explicitly use __eq__ for comparison, ticket #2552
+    if not (desired == actual):
         raise AssertionError(msg)
 
 def print_assert_equal(test_string, actual, desired):


### PR DESCRIPTION
Fixes #2552. Changes primary test expression in function.
