### PR TITLE
Gil release for nonzero

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -928,10 +928,11 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define PyArray_IS_C_CONTIGUOUS(m) PyArray_CHKFLAGS(m, NPY_ARRAY_C_CONTIGUOUS)
 #define PyArray_IS_F_CONTIGUOUS(m) PyArray_CHKFLAGS(m, NPY_ARRAY_F_CONTIGUOUS)
 
+/* the variable is used in some places, so always define it */
+#define NPY_BEGIN_THREADS_DEF PyThreadState *_save=NULL;
 #if NPY_ALLOW_THREADS
 #define NPY_BEGIN_ALLOW_THREADS Py_BEGIN_ALLOW_THREADS
 #define NPY_END_ALLOW_THREADS Py_END_ALLOW_THREADS
-#define NPY_BEGIN_THREADS_DEF PyThreadState *_save=NULL;
 #define NPY_BEGIN_THREADS do {_save = PyEval_SaveThread();} while (0);
 #define NPY_END_THREADS   do {if (_save) PyEval_RestoreThread(_save);} while (0);
 #define NPY_BEGIN_THREADS_THRESHOLDED(loop_size) do { if (loop_size > 500) \
@@ -951,7 +952,6 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #else
 #define NPY_BEGIN_ALLOW_THREADS
 #define NPY_END_ALLOW_THREADS
-#define NPY_BEGIN_THREADS_DEF
 #define NPY_BEGIN_THREADS
 #define NPY_END_THREADS
 #define NPY_BEGIN_THREADS_THRESHOLDED(loop_size)

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -99,9 +99,7 @@ raw_array_assign_array(int ndim, npy_intp *shape,
                             dst_data, dst_strides_it,
                             src_data, src_strides_it);
 
-    if (!needs_api) {
-        NPY_END_THREADS;
-    }
+    NPY_END_THREADS;
 
     NPY_AUXDATA_FREE(transferdata);
 
@@ -194,9 +192,7 @@ raw_array_wheremasked_assign_array(int ndim, npy_intp *shape,
                             src_data, src_strides_it,
                             wheremask_data, wheremask_strides_it);
 
-    if (!needs_api) {
-        NPY_END_THREADS;
-    }
+    NPY_END_THREADS;
 
     NPY_AUXDATA_FREE(transferdata);
 

--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -86,9 +86,7 @@ raw_array_assign_scalar(int ndim, npy_intp *shape,
     } NPY_RAW_ITER_ONE_NEXT(idim, ndim, coord,
                             shape_it, dst_data, dst_strides_it);
 
-    if (!needs_api) {
-        NPY_END_THREADS;
-    }
+    NPY_END_THREADS;
 
     NPY_AUXDATA_FREE(transferdata);
 
@@ -165,9 +163,7 @@ raw_array_wheremasked_assign_scalar(int ndim, npy_intp *shape,
                             dst_data, dst_strides_it,
                             wheremask_data, wheremask_strides_it);
 
-    if (!needs_api) {
-        NPY_END_THREADS;
-    }
+    NPY_END_THREADS;
 
     NPY_AUXDATA_FREE(transferdata);
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3501,15 +3501,22 @@ static int
                     NPY_CLIPMODE clipmode)
 {
     npy_intp i, j, k, tmp;
+    NPY_BEGIN_THREADS_DEF;
+
+    NPY_BEGIN_THREADS;
 
     switch(clipmode) {
     case NPY_RAISE:
         for (i = 0; i < n_outer; i++) {
             for (j = 0; j < m_middle; j++) {
                 tmp = indarray[j];
-                /* We don't know what axis we're operating on, so don't report it in case of an error. */
-                if (check_and_adjust_index(&tmp, nindarray, -1) < 0)
+                /*
+                 * We don't know what axis we're operating on,
+                 * so don't report it in case of an error.
+                 */
+                if (check_and_adjust_index(&tmp, nindarray, -1, _save) < 0) {
                     return 1;
+                }
                 if (NPY_LIKELY(nelem == 1)) {
                     *dest++ = *(src + tmp);
                 }
@@ -3571,6 +3578,8 @@ static int
         }
         break;
     }
+
+    NPY_END_THREADS;
     return 0;
 }
 /**end repeat**/

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -618,7 +618,7 @@ index2ptr(PyArrayObject *mp, npy_intp i)
         return NULL;
     }
     dim0 = PyArray_DIMS(mp)[0];
-    if (check_and_adjust_index(&i, dim0, 0) < 0)
+    if (check_and_adjust_index(&i, dim0, 0, NULL) < 0)
         return NULL;
     if (i == 0) {
         return PyArray_DATA(mp);

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -2,8 +2,20 @@
 #define _NPY_PRIVATE_COMMON_H_
 #include <numpy/npy_common.h>
 #include <numpy/npy_cpu.h>
+#include <numpy/ndarraytypes.h>
 
 #define error_converting(x)  (((x) == -1) && PyErr_Occurred())
+
+#ifdef NPY_ALLOW_THREADS
+#define NPY_BEGIN_THREADS_NDITER(iter) \
+        do { \
+            if (!NpyIter_IterationNeedsAPI(iter)) { \
+                NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter)); \
+            } \
+        } while(0)
+#else
+#define NPY_BEGIN_THREADS_NDITER(iter)
+#endif
 
 /*
  * Recursively examines the object to determine an appropriate dtype

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -82,12 +82,17 @@ convert_shape_to_string(npy_intp n, npy_intp *vals, char *ending);
  * 0 <= *index < max_item, and returns 0.
  * 'axis' should be the array axis that is being indexed over, if known. If
  * unknown, use -1.
+ * If _save is NULL it is assumed the GIL is taken
+ * If _save is not NULL it is assumed the GIL is not taken and it
+ * is acquired in the case of an error
  */
 static NPY_INLINE int
-check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis)
+check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis,
+                       PyThreadState * _save)
 {
     /* Check that index is valid, taking into account negative indices */
     if (NPY_UNLIKELY((*index < -max_item) || (*index >= max_item))) {
+        NPY_END_THREADS;
         /* Try to be as clear as possible about what went wrong. */
         if (axis >= 0) {
             PyErr_Format(PyExc_IndexError,
@@ -97,8 +102,7 @@ check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis)
         } else {
             PyErr_Format(PyExc_IndexError,
                          "index %"NPY_INTP_FMT" is out of bounds "
-                         "for size %"NPY_INTP_FMT,
-                         *index, max_item);
+                         "for size %"NPY_INTP_FMT, *index, max_item);
         }
         return -1;
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2635,9 +2635,7 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
         }
     }
 
-    if (!needs_api) {
-        NPY_END_THREADS;
-    }
+    NPY_END_THREADS;
 
     NPY_AUXDATA_FREE(transferdata);
     NpyIter_Deallocate(dst_iter);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2843,6 +2843,7 @@ PyArray_Arange(double start, double stop, double step, int type_num)
     PyArray_ArrFuncs *funcs;
     PyObject *obj;
     int ret;
+    NPY_BEGIN_THREADS_DEF;
 
     if (_safe_ceil_to_intp((stop - start)/step, &length)) {
         PyErr_SetString(PyExc_OverflowError,
@@ -2890,7 +2891,9 @@ PyArray_Arange(double start, double stop, double step, int type_num)
         Py_DECREF(range);
         return NULL;
     }
+    NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(range));
     funcs->fill(PyArray_DATA(range), length, range);
+    NPY_END_THREADS;
     if (PyErr_Occurred()) {
         goto fail;
     }
@@ -2987,6 +2990,7 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
     npy_intp length;
     PyArray_Descr *native = NULL;
     int swap;
+    NPY_BEGIN_THREADS_DEF;
 
     /* Datetime arange is handled specially */
     if ((dtype != NULL && (dtype->type_num == NPY_DATETIME ||
@@ -3103,7 +3107,9 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
         Py_DECREF(range);
         goto fail;
     }
+    NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(range));
     funcs->fill(PyArray_DATA(range), length, range);
+    NPY_END_THREADS;
     if (PyErr_Occurred()) {
         goto fail;
     }

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -22,6 +22,7 @@
 #include <ctype.h>
 
 #include "convert.h"
+#include "common.h"
 
 #ifdef NPY_HAVE_SSE_INTRINSICS
 #define EINSUM_USE_SSE1 1
@@ -2969,7 +2970,6 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
         char **dataptr;
         npy_intp *stride;
         npy_intp *countptr;
-        int needs_api = NpyIter_IterationNeedsAPI(iter);
         NPY_BEGIN_THREADS_DEF;
 
         iternext = NpyIter_GetIterNext(iter, NULL);
@@ -2982,19 +2982,15 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
         stride = NpyIter_GetInnerStrideArray(iter);
         countptr = NpyIter_GetInnerLoopSizePtr(iter);
 
-        if (!needs_api) {
-            NPY_BEGIN_THREADS;
-        }
+        NPY_BEGIN_THREADS_NDITER(iter);
         NPY_EINSUM_DBG_PRINT("Einsum loop\n");
         do {
             sop(nop, dataptr, stride, *countptr);
         } while(iternext(iter));
-        if (!needs_api) {
-            NPY_END_THREADS;
-        }
+        NPY_END_THREADS;
 
         /* If the API was needed, it may have thrown an error */
-        if (needs_api && PyErr_Occurred()) {
+        if (NpyIter_IterationNeedsAPI(iter) && PyErr_Occurred()) {
             Py_DECREF(ret);
             ret = NULL;
         }

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -71,7 +71,7 @@ parse_index_entry(PyObject *op, npy_intp *step_size,
         *n_steps = SINGLE_INDEX;
         *step_size = 0;
         if (check_index) {
-            if (check_and_adjust_index(&i, max, axis) < 0) {
+            if (check_and_adjust_index(&i, max, axis, NULL) < 0) {
             goto fail;
             }
         }
@@ -668,7 +668,7 @@ iter_subscript_int(PyArrayIterObject *self, PyArrayObject *ind)
     itemsize = PyArray_DESCR(self->ao)->elsize;
     if (PyArray_NDIM(ind) == 0) {
         num = *((npy_intp *)PyArray_DATA(ind));
-        if (check_and_adjust_index(&num, self->size, -1) < 0) {
+        if (check_and_adjust_index(&num, self->size, -1, NULL) < 0) {
             PyArray_ITER_RESET(self);
             return NULL;
         }
@@ -702,7 +702,7 @@ iter_subscript_int(PyArrayIterObject *self, PyArrayObject *ind)
     swap = (PyArray_ISNOTSWAPPED(ret) != PyArray_ISNOTSWAPPED(self->ao));
     while (counter--) {
         num = *((npy_intp *)(ind_it->dataptr));
-        if (check_and_adjust_index(&num, self->size, -1) < 0) {
+        if (check_and_adjust_index(&num, self->size, -1, NULL) < 0) {
             Py_DECREF(ind_it);
             Py_DECREF(ret);
             PyArray_ITER_RESET(self);
@@ -926,7 +926,7 @@ iter_ass_sub_int(PyArrayIterObject *self, PyArrayObject *ind,
     copyswap = PyArray_DESCR(self->ao)->f->copyswap;
     if (PyArray_NDIM(ind) == 0) {
         num = *((npy_intp *)PyArray_DATA(ind));
-        if (check_and_adjust_index(&num, self->size, -1) < 0) {
+        if (check_and_adjust_index(&num, self->size, -1, NULL) < 0) {
             return -1;
         }
         PyArray_ITER_GOTO1D(self, num);
@@ -940,7 +940,7 @@ iter_ass_sub_int(PyArrayIterObject *self, PyArrayObject *ind,
     counter = ind_it->size;
     while (counter--) {
         num = *((npy_intp *)(ind_it->dataptr));
-        if (check_and_adjust_index(&num, self->size, -1) < 0) {
+        if (check_and_adjust_index(&num, self->size, -1, NULL) < 0) {
             Py_DECREF(ind_it);
             return -1;
         }
@@ -1017,7 +1017,7 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
         PyErr_Clear();
     }
     else {
-        if (check_and_adjust_index(&start, self->size, -1) < 0) {
+        if (check_and_adjust_index(&start, self->size, -1, NULL) < 0) {
             goto finish;
         }
         retval = 0;

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1396,7 +1396,7 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
     /* Check the indices beforehand */
     while (itersize--) {
         indval = *((npy_intp*)ind_ptr);
-        if (check_and_adjust_index(&indval, fancy_dim, 1) < 0 ) {
+        if (check_and_adjust_index(&indval, fancy_dim, 1, NULL) < 0 ) {
             return -1;
         }
         ind_ptr += ind_stride;
@@ -1426,7 +1426,7 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
         while (itersize--) {
             indval = *((npy_intp*)ind_ptr);
 #if @isget@
-            if (check_and_adjust_index(&indval, fancy_dim, 1) < 0 ) {
+            if (check_and_adjust_index(&indval, fancy_dim, 1, NULL) < 0 ) {
                 return -1;
             }
 #else
@@ -1560,7 +1560,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 
 #if @isget@ && @one_iter@
                             if (check_and_adjust_index(&indval, fancy_dims[i],
-                                                       iteraxis) < 0 ) {
+                                                       iteraxis, NULL) < 0 ) {
                                 return -1;
                             }
 #else
@@ -1662,7 +1662,7 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 
 #if @isget@ && @one_iter@
                     if (check_and_adjust_index(&indval, fancy_dims[i],
-                                               iteraxis) < 0 ) {
+                                               iteraxis, NULL) < 0 ) {
                         NPY_AUXDATA_FREE(transferdata);
                         return -1;
                     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -799,7 +799,7 @@ get_item_pointer(PyArrayObject *self, char **ptr,
     *ptr = PyArray_BYTES(self);
     for (i=0; i < index_num; i++) {
         if ((check_and_adjust_index(&(indices[i].value),
-                               PyArray_DIMS(self)[i], i)) < 0) {
+                               PyArray_DIMS(self)[i], i, NULL)) < 0) {
             return -1;
         }
         *ptr += PyArray_STRIDE(self, i) * indices[i].value;
@@ -842,7 +842,8 @@ get_view_from_index(PyArrayObject *self, PyArrayObject **view,
         switch (indices[i].type) {
             case HAS_INTEGER:
                 if ((check_and_adjust_index(&indices[i].value,
-                                PyArray_DIMS(self)[orig_dim], orig_dim)) < 0) {
+                                PyArray_DIMS(self)[orig_dim], orig_dim,
+                                NULL)) < 0) {
                     return -1;
                 }
                 data_ptr += PyArray_STRIDE(self, orig_dim) * indices[i].value;
@@ -2366,7 +2367,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
             while (itersize--) {
                 indval = *((npy_intp*)data);
                 if (check_and_adjust_index(&indval,
-                                           outer_dim, outer_axis) < 0) {
+                                           outer_dim, outer_axis, NULL) < 0) {
                     return -1;
                 }
                 data += stride;
@@ -2400,7 +2401,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
             while (itersize--) {
                 indval = *((npy_intp*)*iterptr);
                 if (check_and_adjust_index(&indval,
-                                           outer_dim, outer_axis) < 0) {
+                                           outer_dim, outer_axis, NULL) < 0) {
 
                     Py_DECREF(intp_type);
                     NpyIter_Deallocate(op_iter);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -647,7 +647,7 @@ array_toscalar(PyArrayObject *self, PyObject *args)
             return NULL;
         }
 
-        if (check_and_adjust_index(&value, size, -1) < 0) {
+        if (check_and_adjust_index(&value, size, -1, NULL) < 0) {
             return NULL;
         }
 
@@ -724,7 +724,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
             return NULL;
         }
 
-        if (check_and_adjust_index(&value, size, -1) < 0) {
+        if (check_and_adjust_index(&value, size, -1, NULL) < 0) {
             return NULL;
         }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2774,9 +2774,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 
         needs_api = NpyIter_IterationNeedsAPI(iter);
 
-        if (!needs_api) {
-            NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
-        }
+        NPY_BEGIN_THREADS_NDITER(iter);
 
         if (NpyIter_GetIterSize(iter) != 0) {
             NpyIter_IterNextFunc *iternext = NpyIter_GetIterNext(iter, NULL);
@@ -2836,9 +2834,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
             } while (iternext(iter));
         }
 
-        if (!needs_api) {
-            NPY_END_THREADS;
-        }
+        NPY_END_THREADS;
 
         /* Get the result from the iterator object array */
         ret = (PyObject*)NpyIter_GetOperandArray(iter)[0];

--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -1417,6 +1417,9 @@ _packbits( void *In,
     npy_intp out_Nm1;
     int maxi, remain, nonzero, j;
     char *outptr,*inptr;
+    NPY_BEGIN_THREADS_DEF;
+
+    NPY_BEGIN_THREADS_THRESHOLDED(out_N);
 
     outptr = Out;    /* pointer to output buffer */
     inptr  = In;     /* pointer to input buffer */
@@ -1451,6 +1454,8 @@ _packbits( void *In,
         *outptr = build;
         outptr += out_stride;
     }
+
+    NPY_END_THREADS;
     return;
 }
 
@@ -1468,6 +1473,9 @@ _unpackbits(void *In,
     unsigned char mask;
     int i, index;
     char *inptr, *outptr;
+    NPY_BEGIN_THREADS_DEF;
+
+    NPY_BEGIN_THREADS_THRESHOLDED(in_N);
 
     outptr = Out;
     inptr  = In;
@@ -1480,6 +1488,8 @@ _unpackbits(void *In,
         }
         inptr += in_stride;
     }
+
+    NPY_END_THREADS;
     return;
 }
 


### PR DESCRIPTION
release gil for nonzero and add an internal NPY_BEGIN_THREAD_NDITER to simplify gil release of nditer loops.
also remove some unnecessary needs_api checks, the thread variable is initialized to NULL and checked by the end macro so it is redundant.
