### PR TITLE
BUG: when initialize a vectorize object, always set self._ufunc to None first. fix #3285.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1616,8 +1616,7 @@ class vectorize(object):
             excluded = set()
         self.excluded = set(excluded)
 
-        if self.otypes and not self.excluded:
-            self._ufunc = None      # Caching to improve default performance
+        self._ufunc = None      # Caching to improve default performance
 
     def __call__(self, *args, **kwargs):
         """

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1593,6 +1593,7 @@ class vectorize(object):
                  cache=False):
         self.pyfunc = pyfunc
         self.cache = cache
+        self._ufunc = None    # Caching to improve default performance
 
         if doc is None:
             self.__doc__ = pyfunc.__doc__
@@ -1615,8 +1616,6 @@ class vectorize(object):
         if excluded is None:
             excluded = set()
         self.excluded = set(excluded)
-
-        self._ufunc = None      # Caching to improve default performance
 
     def __call__(self, *args, **kwargs):
         """
@@ -1651,7 +1650,8 @@ class vectorize(object):
     def _get_ufunc_and_otypes(self, func, args):
         """Return (ufunc, otypes)."""
         # frompyfunc will fail if args is empty
-        assert args
+        if not args:
+            raise ValueError('args can not be empty')
 
         if self.otypes:
             otypes = self.otypes

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -721,6 +721,12 @@ class TestVectorize(TestCase):
         assert_array_equal(f(x), x*x)
         assert_equal(_calls[0], len(x))
 
+    def test_otypes(self):
+        f = np.vectorize(lambda x: x)
+        f.otypes = 'i'
+        x = np.arange(5)
+        assert_array_equal(f(x), x)
+
 
 class TestDigitize(TestCase):
     def test_forward(self):


### PR DESCRIPTION
I think we can always let `self._ufunc = None` when initialize a vectorize object, and this fix #3285.
