### PR TITLE
BUG: add missing gufunc failure return values and missing malloc fail check

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2167,6 +2167,11 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     inner_strides = (npy_intp *)PyArray_malloc(
                         NPY_SIZEOF_INTP * (nop+core_dim_ixs_size));
+    if (inner_strides == NULL) {
+        PyErr_NoMemory();
+        retval = -1;
+        goto fail;
+    }
     /* Copy the strides after the first nop */
     idim = nop;
     for (i = 0; i < nop; ++i) {
@@ -2273,11 +2278,13 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                         PyErr_Format(PyExc_ValueError,
                                 "ufunc %s ",
                                 ufunc_name);
+                        retval = -1;
                         goto fail;
                     default:
                         PyErr_Format(PyExc_ValueError,
                                 "ufunc %s has an invalid identity for reduction",
                                 ufunc_name);
+                        retval = -1;
                         goto fail;
                 }
             }


### PR DESCRIPTION
this is the path the gufunc nditer size overflow goes over causing the segfault later on as no error is set.
I'm not sure why it takes this path, probably it clobbers the ufunc somewhere.
