### PR TITLE
BUG: Fix commutativity of {dot,multiply,inner}(scalar, matrix_of_objects)

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2438,7 +2438,7 @@ PyUFunc_GenericFunction(PyUFuncObject *ufunc,
     */
     if (nin == 2 && nout == 1 && dtypes[1]->type_num == NPY_OBJECT) {
         PyObject *_obj = PyTuple_GET_ITEM(args, 1);
-        if (!PyArray_CheckExact(_obj)) {
+        if (!PyArray_Check(_obj)) {
             double self_prio, other_prio;
             self_prio = PyArray_GetPriority(PyTuple_GET_ITEM(args, 0),
                                                         NPY_SCALAR_PRIORITY);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3152,6 +3152,23 @@ class TestDot(TestCase):
         r = np.empty((1024, 32), dtype=int)
         assert_raises(ValueError, dot, f, v, r)
 
+    def test_dot_scalar_and_matrix_of_objects(self):
+        # Ticket #2469
+        arr = np.matrix([1, 2], dtype=object)
+        desired = np.matrix([[3, 6]], dtype=object)
+        assert_equal(np.dot(arr, 3), desired)
+        assert_equal(np.dot(3, arr), desired)
+
+
+class TestInner(TestCase):
+
+    def test_inner_scalar_and_matrix_of_objects(self):
+        # Ticket #4482
+        arr = np.matrix([1, 2], dtype=object)
+        desired = np.matrix([[3, 6]], dtype=object)
+        assert_equal(np.inner(arr, 3), desired)
+        assert_equal(np.inner(3, arr), desired)
+
 
 class TestSummarization(TestCase):
     def test_1d(self):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -589,6 +589,13 @@ class TestUfunc(TestCase):
         assert_equal(np.max(a), True)
         assert_equal(np.min(a), False)
 
+    def test_object_scalar_multiply(self):
+        # Tickets #2469 and #4482
+        arr = np.matrix([1, 2], dtype=object)
+        desired = np.matrix([[3, 6]], dtype=object)
+        assert_equal(np.multiply(arr, 3), desired)
+        assert_equal(np.multiply(3, arr), desired)
+
     def test_zerosize_reduction(self):
         # Test with default dtype and object dtype
         for a in [[], np.array([], dtype=object)]:


### PR DESCRIPTION
Fixes #2469 and #4482. Relaxes fail condition to allow subtype as documented.

The comment above the changed code stated "or a subtype of the same type", but the code was calling `PyArray_CheckExact` to do the check. Changed this to `PyArray_Check` to allow matching of subtypes.
