### PR TITLE
ENH: Implement sys.getsizeof(x) for arrays and scalars.

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1891,6 +1891,16 @@ array_dumps(PyArrayObject *self, PyObject *args)
 
 
 static PyObject *
+array_sizeof(PyArrayObject *self, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+    return PyObject_GetAttrString(self, "nbytes");
+}
+
+
+static PyObject *
 array_transpose(PyArrayObject *self, PyObject *args)
 {
     PyObject *shape = Py_None;
@@ -2296,6 +2306,11 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_VARARGS, NULL},
     {"__array_wrap__",
         (PyCFunction)array_wraparray,
+        METH_VARARGS, NULL},
+
+    /* for the sys module */
+    {"__sizeof__",
+        (PyCFunction) array_sizeof,
         METH_VARARGS, NULL},
 
     /* for the copy module */

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1885,6 +1885,11 @@ static PyMethodDef gentype_methods[] = {
         (PyCFunction)gentype_wraparray,
         METH_VARARGS, doc_sc_wraparray},
 
+    /* for the sys module */
+    {"__sizeof__",
+        (PyCFunction)gentype_itemsize_get,
+        METH_VARARGS, NULL},
+
     /* for the copy module */
     {"__copy__",
         (PyCFunction)gentype_copy,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4276,5 +4276,31 @@ class TestWhere(TestCase):
         assert_raises(ValueError, np.where, c[0], a, b)
 
 
+class TestSizeOf(TestCase):
+
+    def test_empty_array(self):
+        x = np.array([])
+        assert_equal(0, sys.getsizeof(x))
+
+    def check_array(self, dtype):
+        elem_size = sys.getsizeof(dtype(0))
+
+        for length in [10, 50, 100, 500]:
+            x = np.arange(length, dtype=dtype)
+            assert_equal(length * elem_size, sys.getsizeof(x))
+
+    def test_array_int32(self):
+        self.check_array(np.int32)
+
+    def test_array_int64(self):
+        self.check_array(np.int64)
+
+    def test_array_float32(self):
+        self.check_array(np.float32)
+
+    def test_array_float64(self):
+        self.check_array(np.float64)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -259,5 +259,14 @@ class TestRepr(object):
         for t in [np.float32, np.float64]:
             yield self._test_type_repr, t
 
+
+class TestSizeOf(TestCase):
+
+    def test_equal_nbytes(self):
+        for type in types:
+            x = type(0)
+            assert_equal(sys.getsizeof(x), x.nbytes)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes #2279.  The `__sizeof__` method uses the nbytes attribute on the same object.
