### PR TITLE
Adds missing Py_INCREF in array_boolean_subscript

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1039,7 +1039,6 @@ array_boolean_subscript(PyArrayObject *self,
         PyArrayObject *tmp = ret;
 
         Py_INCREF(dtype);
-
         ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self), dtype, 1,
                             &size, PyArray_STRIDES(ret), PyArray_BYTES(ret),
                             0, (PyObject *)self);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1038,6 +1038,8 @@ array_boolean_subscript(PyArrayObject *self,
     if (!PyArray_CheckExact(self)) {
         PyArrayObject *tmp = ret;
 
+        Py_INCREF(dtype);
+
         ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self), dtype, 1,
                             &size, PyArray_STRIDES(ret), PyArray_BYTES(ret),
                             0, (PyObject *)self);


### PR DESCRIPTION
This bug was introduced, as far as I can tell, in 52b4a94.  It came up in the context of astropy/astropy#1987 where we were getting semi-irregular segfaults.  The problem is that after this line a new array is created with `PyArray_NewFromDescr` using an existing dtype object, but it does not incref that dtype object.

A reliable way that I found to demonstrate this bug was something like:

```
>>> import numpy as np
>>> c = np.rec.array([(1, 2, 3), (4, 5, 6)])
>>> masked = c[np.array([True, False])]
>>> base = masked.base
>>> del masked, c
>>> base.dtype
```

at this point various different things could happen, but most often it just results in a segfault.
