### PR TITLE
mention possible definition of unique symbol in .h

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -2899,9 +2899,13 @@ the C-API is needed then some additional steps must be taken.
 
     .. code-block:: c
 
-        #define PY_ARRAY_UNIQUE_SYMBOL cool_ARRAY_API
         #define NO_IMPORT_ARRAY
+        #define PY_ARRAY_UNIQUE_SYMBOL cool_ARRAY_API
         #include numpy/arrayobject.h
+
+    You can also put the common two last lines into an extension-local
+    header file as long as you make sure that NO_IMPORT_ARRAY is
+    #defined before #including that file.
 
 Checking the API Version
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I find it much more convenient to define the PY_ARRAY_UNIQUE_SYMBOL in a
header file #included by all files of the extension (than to repeat its definition in each and every file).

(In case you find the diff strange; I just reordered the #defines in order to make it more obvious that the #define NO_IMPORT_ARRAY can be separated from the other two lines, if they should be moved into a header file.)
