### PR TITLE
DOC: specify that 2d array must be non-empty in np.poly error message.

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -127,7 +127,7 @@ def poly(seq_of_zeros):
     elif len(sh) == 1:
         pass
     else:
-        raise ValueError("input must be 1d or square 2d array.")
+        raise ValueError("input must be 1d or non-empty square 2d array.")
 
     if len(seq_of_zeros) == 0:
         return 1.0


### PR DESCRIPTION
Fixes #2092. Changes message passed to ValueError.

Now more explicit for empty 2D arrays:

```
>>> np.poly(np.zeros((0,0)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/numpy/lib/polynomial.py", line 130, in poly
    raise ValueError("input must be 1d or non-empty square 2d array.")
ValueError: input must be 1d or non-empty square 2d array.
```
