### PR TITLE
Backport 1.8 gh 4483

### DIFF
--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -47,6 +47,7 @@ Issues fixed
 * gh-4225: fix log1p and exmp1 return for np.inf on windows compiler builds
 * gh-4359: Fix infinite recursion in str.format of flex arrays
 * gh-4145: Incorrect shape of broadcast result with the exponent operator
+* gh-4483: Fix commutativity of {dot,multiply,inner}(scalar, matrix_of_objs)
 
 Deprecations
 ============

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2379,7 +2379,7 @@ PyUFunc_GenericFunction(PyUFuncObject *ufunc,
     */
     if (nin == 2 && nout == 1 && dtypes[1]->type_num == NPY_OBJECT) {
         PyObject *_obj = PyTuple_GET_ITEM(args, 1);
-        if (!PyArray_CheckExact(_obj)) {
+        if (!PyArray_Check(_obj)) {
             double self_prio, other_prio;
             self_prio = PyArray_GetPriority(PyTuple_GET_ITEM(args, 0),
                                                         NPY_SCALAR_PRIORITY);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2822,6 +2822,23 @@ class TestDot(TestCase):
         r = np.empty((1024, 32), dtype=int)
         assert_raises(ValueError, dot, f, v, r)
 
+    def test_dot_scalar_and_matrix_of_objects(self):
+        # Ticket #2469
+        arr = np.matrix([1, 2], dtype=object)
+        desired = np.matrix([[3, 6]], dtype=object)
+        assert_equal(np.dot(arr, 3), desired)
+        assert_equal(np.dot(3, arr), desired)
+
+
+class TestInner(TestCase):
+
+    def test_inner_scalar_and_matrix_of_objects(self):
+        # Ticket #4482
+        arr = np.matrix([1, 2], dtype=object)
+        desired = np.matrix([[3, 6]], dtype=object)
+        assert_equal(np.inner(arr, 3), desired)
+        assert_equal(np.inner(3, arr), desired)
+
 
 class TestSummarization(TestCase):
     def test_1d(self):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -535,6 +535,13 @@ class TestUfunc(TestCase):
         assert_equal(np.max(a), True)
         assert_equal(np.min(a), False)
 
+    def test_object_scalar_multiply(self):
+        # Tickets #2469 and #4482
+        arr = np.matrix([1, 2], dtype=object)
+        desired = np.matrix([[3, 6]], dtype=object)
+        assert_equal(np.multiply(arr, 3), desired)
+        assert_equal(np.multiply(3, arr), desired)
+
     def test_zerosize_reduction(self):
         # Test with default dtype and object dtype
         for a in [[], np.array([], dtype=object)]:


### PR DESCRIPTION
Backport gh-4483, `BUG: Fix commutativity of {dot,multiply,inner}(scalar, matrix_of_objs)`
