### PR TITLE
Fix for obscure einsum bug (#4485)

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -181,7 +181,7 @@ NpyIter_RemoveMultiIndex(NpyIter *iter)
             PyErr_SetString(PyExc_ValueError, "iterator is too large");
             return NPY_FAIL;
         }
-    
+
         NIT_ITFLAGS(iter) = itflags & ~NPY_ITFLAG_HASMULTIINDEX;
         npyiter_coalesce_axes(iter);
     }
@@ -1331,21 +1331,20 @@ NpyIter_GetInnerFixedStrideArray(NpyIter *iter, npy_intp *out_strides)
                     out_strides[iop] = stride;
                 }
                 /*
-                 * Otherwise it's a fixed stride if the stride is 0
-                 * for all inner dimensions of the reduction double loop
+                 * Otherwise it's guaranteed to be a fixed stride if the
+                 * stride is 0 for all the dimensions.
                  */
                 else {
                     NpyIter_AxisData *axisdata = axisdata0;
-                    int idim,
-                            reduce_outerdim = NBF_REDUCE_OUTERDIM(data);
-                    for (idim = 0; idim < reduce_outerdim; ++idim) {
+                    int idim;
+                    for (idim = 0; idim < ndim; ++idim) {
                         if (NAD_STRIDES(axisdata)[iop] != 0) {
                             break;
                         }
                         NIT_ADVANCE_AXISDATA(axisdata, 1);
                     }
                     /* If all the strides were 0, the stride won't change */
-                    if (idim == reduce_outerdim) {
+                    if (idim == ndim) {
                         out_strides[iop] = stride;
                     }
                     else {

--- a/numpy/core/src/npymath/ieee754.c.src
+++ b/numpy/core/src/npymath/ieee754.c.src
@@ -28,12 +28,12 @@ double npy_copysign(double x, double y)
 #if !defined(HAVE_DECL_SIGNBIT)
 #include "_signbit.c"
 
-static int _npy_signbit_f(float x)
+int _npy_signbit_f(float x)
 {
     return _npy_signbit_d((double) x);
 }
 
-static int _npy_signbit_ld(long double x)
+int _npy_signbit_ld(long double x)
 {
     return _npy_signbit_d((double) x);
 }


### PR DESCRIPTION
I wrote an explanation of what was going on in the testcase, copied here:

```
        # This case revealed a bug in nditer where it reported a stride
        # as 'fixed' (0) when it was in fact not fixed during processing
        # (0 or 4). The reason for the bug was that the check for a fixed
        # stride was using the information from the 2D inner loop reuse
        # to restrict the iteration dimensions it had to validate to be
        # the same, but that 2D inner loop reuse logic is only triggered
        # during the buffer copying step, and hence it was invalid to
        # rely on those values. The fix is to check all the dimensions
        # of the stride in question, which in the test case reveals that
        # the stride is not fixed.
```
