### PR TITLE
Fix linspace for use with physical quantities

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -80,8 +80,8 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
     num = int(num)
 
     # Convert float/complex array scalars to float, gh-3504 
-    start = start + 0.
-    stop = stop + 0.
+    start = start * 1.
+    stop = stop * 1.
 
     if dtype is None:
         dtype = result_type(start, stop, float(num))

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -76,3 +76,36 @@ class TestLinspace(TestCase):
         t2 = array([  0.0+1.j  ,   2.5+0.75j,   5.0+0.5j ,   7.5+0.25j,  10.0+0.j])
         assert_equal(lim1, t1)
         assert_equal(lim2, t2)
+        
+    def test_physical_quantities(self):
+        class PhysicalQuantity(float):
+            def __new__(cls, value):
+                return float.__new__(cls, value)
+                
+            def __add__(self, x):
+                assert_(isinstance(x, PhysicalQuantity))
+                return PhysicalQuantity(float(x) + float(self))
+            __radd__ = __add__
+                
+            def __sub__(self, x):
+                assert_(isinstance(x, PhysicalQuantity))
+                return PhysicalQuantity(float(self) - float(x))
+                
+            def __rsub__(self, x):
+                assert_(isinstance(x, PhysicalQuantity))
+                return PhysicalQuantity(float(x) - float(self))
+                
+            def __mul__(self, x):
+                return PhysicalQuantity(float(x) * float(self))
+            __rmul__ = __mul__
+                
+            def __div__(self, x):
+                return PhysicalQuantity(float(self) / float(x))
+                
+            def __rdiv__(self, x):
+                return PhysicalQuantity(float(x) / float(self))
+
+        
+        a = PhysicalQuantity(0.0)
+        b = PhysicalQuantity(1.0)
+        assert_equal(linspace(a, b), linspace(0.0, 1.0))


### PR DESCRIPTION
#4336 breaks linspace for use with the quantities package (https://pypi.python.org/pypi/quantities) and perhaps other packages that work in a similar way.

The specific issue occurs when trying to create a range of numbers with physical quantities, e.g. to get 50 values from one second to ten seconds:

```
import quantities as pq
linspace(1 * pq.s, 10 * pq.s)
```

will raise an exception because a physical quantity (seconds) and a dimensionless quantity (the 0.0 used in the code) are being added. Since this only occurs when using numpy with additional packages, I haven't opened a new issue for it. But I propose to multiply with one instead of adding zero to avoid issues when using physical quantities.
