### PR TITLE
ENH: Support for file-like objects in np.fromfile

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -388,8 +388,6 @@ typedef void (PyArray_VectorUnaryFunc)(void *, void *, npy_intp, void *,
  * XXX the ignore argument should be removed next time the API version
  * is bumped. It used to be the separator.
  */
-typedef int (PyArray_ScanFunc)(FILE *fp, void *dptr,
-                               char *ignore, struct _PyArray_Descr *);
 typedef int (PyArray_FromStrFunc)(char *s, void *dptr, char **endptr,
                                   struct _PyArray_Descr *);
 
@@ -464,13 +462,6 @@ typedef struct {
          * Can be NULL
          */
         PyArray_DotFunc *dotfunc;
-
-        /*
-         * Function to scan an ASCII file and
-         * place a single value plus possible separator
-         * Can be NULL
-         */
-        PyArray_ScanFunc *scanfunc;
 
         /*
          * Function to read a single value from a string

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1395,105 +1395,6 @@ static void
 
 /*
  *****************************************************************************
- **                               SCAN                                      **
- *****************************************************************************
- */
-
-
-/*
- * The first ignore argument is for backwards compatibility.
- * Should be removed when the API version is bumped up.
- */
-
-/**begin repeat
- * #fname = SHORT, USHORT, INT, UINT,
- *          LONG, ULONG, LONGLONG, ULONGLONG#
- * #type = npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong#
- * #format = "hd", "hu", "d", "u",
- *           "ld", "lu", NPY_LONGLONG_FMT, NPY_ULONGLONG_FMT#
- */
-static int
-@fname@_scan(FILE *fp, @type@ *ip, void *NPY_UNUSED(ignore),
-        PyArray_Descr *NPY_UNUSED(ignored))
-{
-    return fscanf(fp, "%"@format@, ip);
-}
-/**end repeat**/
-
-/**begin repeat
- * #fname = FLOAT, DOUBLE, LONGDOUBLE#
- * #type = npy_float, npy_double, npy_longdouble#
- */
-static int
-@fname@_scan(FILE *fp, @type@ *ip, void *NPY_UNUSED(ignore),
-        PyArray_Descr *NPY_UNUSED(ignored))
-{
-    double result;
-    int ret;
-
-    ret = NumPyOS_ascii_ftolf(fp, &result);
-    *ip = (@type@) result;
-    return ret;
-}
-/**end repeat**/
-
-static int
-HALF_scan(FILE *fp, npy_half *ip, void *NPY_UNUSED(ignore),
-        PyArray_Descr *NPY_UNUSED(ignored))
-{
-    double result;
-    int ret;
-
-    ret = NumPyOS_ascii_ftolf(fp, &result);
-    *ip = npy_double_to_half(result);
-    return ret;
-}
-
-/**begin repeat
- * #fname = BYTE, UBYTE#
- * #type = npy_byte, npy_ubyte#
- * #btype = npy_int, npy_uint#
- * #format = "d", "u"#
- */
-static int
-@fname@_scan(FILE *fp, @type@ *ip, void *NPY_UNUSED(ignore),
-        PyArray_Descr *NPY_UNUSED(ignore2))
-{
-    @btype@ temp;
-    int num;
-
-    num = fscanf(fp, "%"@format@, &temp);
-    *ip = (@type@) temp;
-    return num;
-}
-/**end repeat**/
-
-static int
-BOOL_scan(FILE *fp, npy_bool *ip, void *NPY_UNUSED(ignore),
-        PyArray_Descr *NPY_UNUSED(ignore2))
-{
-    double result;
-    int ret;
-
-    ret = NumPyOS_ascii_ftolf(fp, &result);
-    *ip = (npy_bool) (result != 0.0);
-    return ret;
-}
-
-/**begin repeat
- * #fname = CFLOAT, CDOUBLE, CLONGDOUBLE,
- *          OBJECT, STRING, UNICODE, VOID,
- *          DATETIME, TIMEDELTA#
- */
-
-#define @fname@_scan NULL
-
-/**end repeat**/
-
-
-/*
- *****************************************************************************
  **                             FROMSTR                                     **
  *****************************************************************************
  */
@@ -3644,7 +3545,6 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_CompareFunc*)@from@_compare,
     (PyArray_ArgFunc*)@from@_argmax,
     (PyArray_DotFunc*)NULL,
-    (PyArray_ScanFunc*)@from@_scan,
     (PyArray_FromStrFunc*)@from@_fromstr,
     (PyArray_NonzeroFunc*)@from@_nonzero,
     (PyArray_FillFunc*)NULL,
@@ -3784,7 +3684,6 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_CompareFunc*)@from@_compare,
     (PyArray_ArgFunc*)@from@_argmax,
     (PyArray_DotFunc*)@from@_dot,
-    (PyArray_ScanFunc*)@from@_scan,
     (PyArray_FromStrFunc*)@from@_fromstr,
     (PyArray_NonzeroFunc*)@from@_nonzero,
     (PyArray_FillFunc*)@from@_fill,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1965,6 +1965,24 @@ array_count_nonzero(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
 #endif
 }
 
+
+static int
+PyArray_IsFileLike(PyObject *obj)
+{
+    static char *needed_attrs[] = {"read", "close", NULL};
+    int i = 0;
+
+    while (needed_attrs[i] != NULL) {
+        if (! PyObject_HasAttrString(obj, needed_attrs[i])) {
+            return 0;
+        }
+        i++;
+    }
+
+    return 1;
+}
+
+
 static PyObject *
 array_fromstring(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
 {
@@ -1985,62 +2003,104 @@ array_fromstring(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds
 }
 
 
-
 static PyObject *
 array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
 {
-    PyObject *file = NULL, *ret;
+    PyObject *file = NULL, *ret, *tmp;
     char *sep = "";
     Py_ssize_t nin = -1;
     static char *kwlist[] = {"file", "dtype", "count", "sep", NULL};
     PyArray_Descr *type = NULL;
     int own;
-    npy_off_t orig_pos;
-    FILE *fp;
+    npy_off_t orig_pos = -1, seek_pos;
 
+    /* parse arguments and keywords */
     if (!PyArg_ParseTupleAndKeywords(args, keywds,
                 "O|O&" NPY_SSIZE_T_PYFMT "s", kwlist,
                 &file, PyArray_DescrConverter, &type, &nin, &sep)) {
         Py_XDECREF(type);
         return NULL;
     }
+
+    /* if passed string, create file. otherwise, require it be file-like */
     if (PyString_Check(file) || PyUnicode_Check(file)) {
         file = npy_PyFile_OpenFile(file, "rb");
         if (file == NULL) {
             return NULL;
         }
         own = 1;
-    }
-    else {
+    } else if (PyArray_IsFileLike(file)) {
         Py_INCREF(file);
         own = 0;
+
+        /* capture original position if supported */
+        if (PyObject_HasAttrString(file, "tell")) {
+            tmp = PyObject_CallMethod(file, "tell", NULL);
+
+            if (tmp == NULL) {
+                PyErr_Clear();
+            }
+            else {
+                orig_pos = (npy_off_t)PyInt_AsLong(tmp);
+                Py_DECREF(tmp);
+            }
+        }
     }
-    fp = npy_PyFile_Dup2(file, "rb", &orig_pos);
-    if (fp == NULL) {
+    else {
         PyErr_SetString(PyExc_IOError,
-                "first argument must be an open file");
+                        "first argument must be an open file");
         Py_DECREF(file);
         return NULL;
     }
+
     if (type == NULL) {
         type = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    ret = PyArray_FromFile(fp, type, (npy_intp) nin, sep);
 
-    if (npy_PyFile_DupClose2(file, fp, orig_pos) < 0) {
+    /* Call PyArray_FromFileLike */
+    ret = PyArray_FromFileLike(file, type, (npy_intp) nin, sep);
+
+    if (ret == NULL) {
         goto fail;
     }
-    if (own && npy_PyFile_CloseFile(file) < 0) {
-        goto fail;
+
+    /* Close the file if we made it */
+    if (own) {
+        tmp = PyObject_CallMethod(file, "close", NULL);
+        if (tmp == NULL) {
+            goto fail;
+        }
+        Py_DECREF(tmp);
     }
+
+    /* If we did not make the file, seek to proper position */
+    if (nin < 0) {
+        /* seek to end of file */
+        tmp = PyObject_CallMethod(file, "seek", "ii", 0, SEEK_END);
+        if (tmp == NULL) {
+            PyErr_Clear();
+        }
+    }
+    else if (orig_pos >= 0) {
+        /* seek to original position + read */
+        seek_pos = orig_pos + nin * type->elsize;
+        tmp = PyObject_CallMethod(file, "seek", "i", seek_pos);
+        if (tmp == NULL) {
+            PyErr_Clear();
+        }
+    }
+
     Py_DECREF(file);
     return ret;
 
 fail:
     Py_DECREF(file);
-    Py_DECREF(ret);
+    if (ret != NULL) {
+        Py_DECREF(ret);
+    }
     return NULL;
 }
+
 
 static PyObject *
 array_fromiter(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -105,7 +105,6 @@ PyArray_InitArrFuncs(PyArray_ArrFuncs *f)
     f->argmax = NULL;
     f->argmin = NULL;
     f->dotfunc = NULL;
-    f->scanfunc = NULL;
     f->fromstr = NULL;
     f->nonzero = NULL;
     f->fill = NULL;

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -1187,7 +1187,7 @@ PyMODINIT_FUNC inittest_rational(void) {
     npyrational_arrfuncs.nonzero = npyrational_nonzero;
     npyrational_arrfuncs.fill = npyrational_fill;
     npyrational_arrfuncs.fillwithscalar = npyrational_fillwithscalar;
-    /* Left undefined: scanfunc, fromstr, sort, argsort */
+    /* Left undefined: fromstr, sort, argsort */
     Py_TYPE(&npyrational_descr) = &PyArrayDescr_Type;
     npy_rational = PyArray_RegisterDataType(&npyrational_descr);
     if (npy_rational<0) {


### PR DESCRIPTION
Fixes #3207. Reads file-like object into tempfile, then proceeds normally.

An object is determined to be "file-like" if it has `read` and `close` attributes. If any exceptions occur while calling these two methods, they are propagated upwards. Tests include use-case with `StringIO` and `zipfile`.
