### PR TITLE
Backport 1.8 gh 4502

### DIFF
--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -49,6 +49,7 @@ Issues fixed
 * gh-4145: Incorrect shape of broadcast result with the exponent operator
 * gh-4483: Fix commutativity of {dot,multiply,inner}(scalar, matrix_of_objs)
 * gh-4466: Delay npyiter size check when size may change
+* gh-4502: Buffered stride was erroneously marked fixed (fixes #4485)
 
 Deprecations
 ============

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -181,7 +181,7 @@ NpyIter_RemoveMultiIndex(NpyIter *iter)
             PyErr_SetString(PyExc_ValueError, "iterator is too large");
             return NPY_FAIL;
         }
-    
+
         NIT_ITFLAGS(iter) = itflags & ~NPY_ITFLAG_HASMULTIINDEX;
         npyiter_coalesce_axes(iter);
     }
@@ -1331,21 +1331,20 @@ NpyIter_GetInnerFixedStrideArray(NpyIter *iter, npy_intp *out_strides)
                     out_strides[iop] = stride;
                 }
                 /*
-                 * Otherwise it's a fixed stride if the stride is 0
-                 * for all inner dimensions of the reduction double loop
+                 * Otherwise it's guaranteed to be a fixed stride if the
+                 * stride is 0 for all the dimensions.
                  */
                 else {
                     NpyIter_AxisData *axisdata = axisdata0;
-                    int idim,
-                            reduce_outerdim = NBF_REDUCE_OUTERDIM(data);
-                    for (idim = 0; idim < reduce_outerdim; ++idim) {
+                    int idim;
+                    for (idim = 0; idim < ndim; ++idim) {
                         if (NAD_STRIDES(axisdata)[iop] != 0) {
                             break;
                         }
                         NIT_ADVANCE_AXISDATA(axisdata, 1);
                     }
                     /* If all the strides were 0, the stride won't change */
-                    if (idim == reduce_outerdim) {
+                    if (idim == ndim) {
                         out_strides[iop] = stride;
                     }
                     else {

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -498,5 +498,36 @@ class TestEinSum(TestCase):
                     [[[1,  3], [3,  9], [5, 15], [7, 21]],
                     [[8, 16], [16, 32], [24, 48], [32, 64]]])
 
+    def test_einsum_fixedstridebug(self):
+        # Issue #4485 obscure einsum bug
+        # This case revealed a bug in nditer where it reported a stride
+        # as 'fixed' (0) when it was in fact not fixed during processing
+        # (0 or 4). The reason for the bug was that the check for a fixed
+        # stride was using the information from the 2D inner loop reuse
+        # to restrict the iteration dimensions it had to validate to be
+        # the same, but that 2D inner loop reuse logic is only triggered
+        # during the buffer copying step, and hence it was invalid to
+        # rely on those values. The fix is to check all the dimensions
+        # of the stride in question, which in the test case reveals that
+        # the stride is not fixed.
+        #
+        # NOTE: This test is triggered by the fact that the default buffersize,
+        #       used by einsum, is 8192, and 3*2731 = 8193, is larger than that
+        #       and results in a mismatch between the buffering and the
+        #       striding for operand A.
+        A = np.arange(2*3).reshape(2,3).astype(np.float32)
+        B = np.arange(2*3*2731).reshape(2,3,2731).astype(np.int16)
+        es = np.einsum('cl,cpx->lpx', A, B)
+        tp = np.tensordot(A, B, axes=(0, 0))
+        assert_equal(es, tp)
+        # The following is the original test case from the bug report,
+        # made repeatable by changing random arrays to aranges.
+        A = np.arange(3*3).reshape(3,3).astype(np.float64)
+        B = np.arange(3*3*64*64).reshape(3,3,64,64).astype(np.float32)
+        es = np.einsum ('cl,cpxy->lpxy', A,B)
+        tp = np.tensordot(A,B, axes=(0,0))
+        assert_equal(es, tp)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport to 1.8: `BUG: Buffered stride was erroneously marked fixed (fixes #4485)`
