### PR TITLE
ENH: speed-up of triangular matrix functions

### DIFF
--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -286,6 +286,7 @@ def test_tril_triu_ndim2():
         yield assert_equal, b.dtype, a.dtype
         yield assert_equal, c.dtype, a.dtype
 
+
 def test_tril_triu_ndim3():
     for dtype in np.typecodes['AllFloat'] + np.typecodes['AllInteger']:
         a = np.array([
@@ -324,16 +325,21 @@ def test_mask_indices():
 def test_tril_indices():
     # indices without and with offset
     il1 = tril_indices(4)
-    il2 = tril_indices(4, 2)
+    il2 = tril_indices(4, k=2)
+    il3 = tril_indices(4, m=5)
+    il4 = tril_indices(4, k=2, m=5)
 
     a = np.array([[1,  2,  3,  4],
                   [5,  6,  7,  8],
                   [9,  10, 11, 12],
                   [13, 14, 15, 16]])
+    b = np.arange(1, 21).reshape(4, 5)
 
     # indexing:
     yield (assert_array_equal, a[il1],
            array([1,  5,  6,  9, 10, 11, 13, 14, 15, 16]))
+    yield (assert_array_equal, b[il3],
+           array([1, 6, 7, 11, 12, 13, 16, 17, 18, 19]))
 
     # And for assigning values:
     a[il1] = -1
@@ -342,7 +348,12 @@ def test_tril_indices():
                   [-1, -1,  7, 8],
                   [-1, -1, -1, 12],
                   [-1, -1, -1, -1]]))
-
+    b[il3] = -1
+    yield (assert_array_equal, b,
+           array([[-1,  2,  3,  4,  5],
+                  [-1, -1,  8,  9, 10],
+                  [-1, -1, -1, 14, 15],
+                  [-1, -1, -1, -1, 20]]))
     # These cover almost the whole array (two diagonals right of the main one):
     a[il2] = -10
     yield (assert_array_equal, a,
@@ -350,21 +361,32 @@ def test_tril_indices():
                   [-10, -10, -10, -10],
                   [-10, -10, -10, -10],
                   [-10, -10, -10, -10]]))
+    b[il4] = -10
+    yield (assert_array_equal, b,
+           array([[-10, -10, -10,   4,   5],
+                  [-10, -10, -10, -10,  10],
+                  [-10, -10, -10, -10, -10],
+                  [-10, -10, -10, -10, -10]]))
 
 
 class TestTriuIndices(object):
     def test_triu_indices(self):
         iu1 = triu_indices(4)
-        iu2 = triu_indices(4, 2)
+        iu2 = triu_indices(4, k=2)
+        iu3 = triu_indices(4, m=5)
+        iu4 = triu_indices(4, k=2, m=5)
 
         a = np.array([[1,  2,  3,  4],
                       [5,  6,  7,  8],
                       [9,  10, 11, 12],
                       [13, 14, 15, 16]])
+        b = np.arange(1, 21).reshape(4, 5)
 
         # Both for indexing:
         yield (assert_array_equal, a[iu1],
                array([1, 2,  3,  4,  6, 7, 8, 11, 12, 16]))
+        yield (assert_array_equal, b[iu3],
+               array([1, 2, 3, 4, 5, 7, 8, 9, 10, 13, 14, 15, 19, 20]))
 
         # And for assigning values:
         a[iu1] = -1
@@ -373,6 +395,12 @@ class TestTriuIndices(object):
                       [5,  -1, -1, -1],
                       [9,  10, -1, -1],
                       [13, 14, 15, -1]]))
+        b[iu3] = -1
+        yield (assert_array_equal, b,
+               array([[-1, -1, -1, -1, -1],
+                      [ 6, -1, -1, -1, -1],
+                      [11, 12, -1, -1, -1],
+                      [16, 17, 18, -1, -1]]))
 
         # These cover almost the whole array (two diagonals right of the
         # main one):
@@ -382,20 +410,26 @@ class TestTriuIndices(object):
                       [5,   -1, -1,  -10],
                       [9,   10, -1,  -1],
                       [13,  14, 15,  -1]]))
+        b[iu4] = -10
+        yield (assert_array_equal, b,
+               array([[-1, -1, -10, -10, -10],
+                      [6, -1, -1, -10, -10],
+                      [11, 12, -1, -1, -10],
+                      [16, 17, 18, -1, -1]]))
 
 
 class TestTrilIndicesFrom(object):
     def test_exceptions(self):
         assert_raises(ValueError, tril_indices_from, np.ones((2,)))
         assert_raises(ValueError, tril_indices_from, np.ones((2, 2, 2)))
-        assert_raises(ValueError, tril_indices_from, np.ones((2, 3)))
+        # assert_raises(ValueError, tril_indices_from, np.ones((2, 3)))
 
 
 class TestTriuIndicesFrom(object):
     def test_exceptions(self):
         assert_raises(ValueError, triu_indices_from, np.ones((2,)))
         assert_raises(ValueError, triu_indices_from, np.ones((2, 2, 2)))
-        assert_raises(ValueError, triu_indices_from, np.ones((2, 3)))
+        # assert_raises(ValueError, triu_indices_from, np.ones((2, 3)))
 
 
 class TestVander(object):


### PR DESCRIPTION
- `np.tri` now produces less intermediate arrays. Runs about 40% faster for
  general dtypes, up to 3x faster for boolean arrays.
- `np.tril` now does smarter type conversions (thanks Julian!), and together
  with the improvements in `np.tri` now runs about 30% faster. `np.triu`
  runs almost 2x faster than before, but still runs 20% slower than
  `np.tril`, which is an improvement over the 50% difference before.
- `np.triu_indices` and `np.tril_indices` do not call `np.mask_indices`,
  instead they call `np.where` directly on a boolean array created with
  `np.tri`. They now run roughly 2x faster.
- Removed the constraint for the array to be square in calls to
  `np.triu_indices`, `np.tril_indices`, `np.triu_indices_from` and
  `np.tril_indices_from`.
