### PR TITLE
Backport-1.8-gh-4456.

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -103,6 +103,7 @@ PYTHON=${PYTHON:-python}
 PIP=${PIP:-pip}
 
 if [ -n "$USE_DEBUG" ]; then
+  sudo apt-get update # 06.03.2014, temporary until travis boxes are resynced
   sudo apt-get install -qq -y --force-yes python3-dbg python3-dev python3-nose
   PYTHON=python3-dbg
 fi


### PR DESCRIPTION
Backport gh-4456: `TST: work around outdated travis boxes`

Run manual apt-get update to pick up the latest py3 security update
