### PR TITLE
ENH: optimize srcstride0 copy with O3

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -18,6 +18,13 @@
 #define NPY_GCC_UNROLL_LOOPS
 #endif
 
+/* highest gcc optimization level, enabled autovectorizer */
+#ifdef HAVE_ATTRIBUTE_OPTIMIZE_OPT_3
+#define NPY_GCC_OPT_3 __attribute__((optimize("O3")))
+#else
+#define NPY_GCC_OPT_3
+#endif
+
 #if defined HAVE_XMMINTRIN_H && defined HAVE__MM_LOAD_PS
 #define NPY_HAVE_SSE_INTRINSICS
 #endif

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -125,6 +125,8 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
 # function name will be converted to HAVE_<upper-case-name> preprocessor macro
 OPTIONAL_GCC_ATTRIBUTES = [('__attribute__((optimize("unroll-loops")))',
                             'attribute_optimize_unroll_loops'),
+                            ('__attribute__((optimize("O3")))',
+                             'attribute_optimize_opt_3'),
                           ]
 
 # Subset of OPTIONAL_STDFUNCS which may alreay have HAVE_* defined by Python.h

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -189,9 +189,10 @@ static void
  * specialized copy and swap for source stride 0,
  * interestingly unrolling here is like above is only marginally profitable for
  * small types and detrimental for >= 8byte moves on x86
+ * but it profits from vectorization enabled with -O3
  */
 #if (@src_contig@ == 0) && @is_aligned@
-static void
+static NPY_GCC_OPT_3 void
 @prefix@_@oper@_size@elsize@_srcstride0(char *dst,
                         npy_intp dst_stride,
                         char *src, npy_intp NPY_UNUSED(src_stride),


### PR DESCRIPTION
enables autovectorization with gcc and improves performance by about 25% for cached data.
