### PR TITLE
FIX: missing asarray import in numpy.libs.utils

### DIFF
--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+from numpy.core import arange
 from numpy.testing import *
 import numpy.lib.utils as utils
 from numpy.lib import deprecate
@@ -46,9 +47,17 @@ def test_deprecate_fn():
     assert_('old_func3' in new_func3.__doc__)
     assert_('new_func3' in new_func3.__doc__)
 
+
 def test_safe_eval_nameconstant():
     # Test if safe_eval supports Python 3.4 _ast.NameConstant
     utils.safe_eval('None')
+
+
+def test_byte_bounds():
+    a = arange(12).reshape(3, 4)
+    low, high = utils.byte_bounds(a)
+    assert_equal(high - low, a.size * a.itemsize)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -6,7 +6,7 @@ import types
 import re
 
 from numpy.core.numerictypes import issubclass_, issubsctype, issubdtype
-from numpy.core import product, ndarray, ufunc
+from numpy.core import product, ndarray, ufunc, asarray
 
 __all__ = [
     'issubclass_', 'issubsctype', 'issubdtype', 'deprecate',


### PR DESCRIPTION
There was a missing import for the `asarray` function. The doctests should have caught this but:
- they do not seem to be run by travis
- there were missing imports for the np symbols in the doctests (fixed)
- there are blanklines / ellipsis issues to have them pass. I don't know what is the preferred way to address this.
