### PR TITLE
Backport 1.8 gh 4533

### DIFF
--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -52,6 +52,7 @@ Issues fixed
 * gh-4485: Buffered stride was erroneously marked fixed
 * gh-4354: byte_bounds fails with datetime dtypes
 * gh-4486: segfault/error converting from/to high-precision datetime64 objects
+* gh-4428: einsum(None, None, None, None) causes segfault
 
 Changes
 =======

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2273,7 +2273,7 @@ einsum_sub_op_from_lists(PyObject *args,
 
     /* Set the operands to NULL */
     for (i = 0; i < nop; ++i) {
-        op[nop] = NULL;
+        op[i] = NULL;
     }
 
     /* Get the operands and build the subscript string */

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -31,6 +31,9 @@ class TestEinSum(TestCase):
         # other keyword arguments are rejected
         assert_raises(TypeError, np.einsum, "", 0, bad_arg=0)
 
+        # issue 4528 revealed a segfault with this call
+        assert_raises(TypeError, np.einsum, *(None,)*63)
+
         # number of operands must match count in subscripts string
         assert_raises(ValueError, np.einsum, "", 0, 0)
         assert_raises(ValueError, np.einsum, ",", 0, [0], [0])


### PR DESCRIPTION
Backport #4533: `BUG: fix broken operand initialization for einsum.`
