### PR TITLE
BUG: fix uninitialized use of size 1 reductions

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -758,6 +758,14 @@ NpyIter_IsFirstVisit(NpyIter *iter, int iop)
     NpyIter_AxisData *axisdata;
     npy_intp sizeof_axisdata;
 
+    /*
+     * size 1 reduction iterators are not full initialized but each visit is
+     * always the first, gh-4134
+     */
+    if (NPY_UNLIKELY(NIT_ITERSIZE(iter) == 1)) {
+        return 1;
+    }
+
     sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
     axisdata = NIT_AXISDATA(iter);
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -588,6 +588,7 @@ class TestUfunc(TestCase):
         assert_equal(np.all(a), False)
         assert_equal(np.max(a), True)
         assert_equal(np.min(a), False)
+        assert_equal(np.array([[1]], dtype=object).sum(), 1)
 
     def test_object_scalar_multiply(self):
         # Tickets #2469 and #4482


### PR DESCRIPTION
Size 1 reductions do not intiialize the iterator fully as normal
reductions which triggers uninitialized use in NpyIter_IsFirstVisit.
To fix this check the size of the iterator and return true if it only
has size 1.
