### PR TITLE
BUG: nditer: Initialize buffer reduce pos

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -758,14 +758,6 @@ NpyIter_IsFirstVisit(NpyIter *iter, int iop)
     NpyIter_AxisData *axisdata;
     npy_intp sizeof_axisdata;
 
-    /*
-     * size 1 reduction iterators are not full initialized but each visit is
-     * always the first, gh-4134
-     */
-    if (NPY_UNLIKELY(NIT_ITERSIZE(iter) == 1)) {
-        return 1;
-    }
-
     sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
     axisdata = NIT_AXISDATA(iter);
 
@@ -793,8 +785,8 @@ NpyIter_IsFirstVisit(NpyIter *iter, int iop)
     if (itflags&NPY_ITFLAG_BUFFER) {
         NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
         /* The outer reduce loop */
-        if (NBF_REDUCE_OUTERSTRIDES(bufferdata)[iop] == 0 &&
-                NBF_REDUCE_POS(bufferdata) != 0) {
+        if (NBF_REDUCE_POS(bufferdata) != 0 &&
+                NBF_REDUCE_OUTERSTRIDES(bufferdata)[iop] == 0) {
             return 0;
         }
     }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -261,6 +261,12 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
             buffersize = NIT_ITERSIZE(iter);
         }
         NBF_BUFFERSIZE(bufferdata) = buffersize;
+
+        /*
+         * Initialize for use in FirstVisit, which may be called before
+         * the buffers are filled and the reduce pos is updated.
+         */
+        NBF_REDUCE_POS(bufferdata) = 0;
     }
 
     /*

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -589,6 +589,7 @@ class TestUfunc(TestCase):
         assert_equal(np.max(a), True)
         assert_equal(np.min(a), False)
         assert_equal(np.array([[1]], dtype=object).sum(), 1)
+        assert_equal(np.array([[[1, 2]]], dtype=object).sum((0, 1)), [1, 2])
 
     def test_object_scalar_multiply(self):
         # Tickets #2469 and #4482


### PR DESCRIPTION
The FirstVisit function uses this, but when the reduction is
over a single element it isn't considered a reduction. This is
fine, however the reduce pos must still be initialized to 0 in
that case. Also changes the check order so that it is not
necessary to initialize the outerstrides as well.
## 

Sorry... been a bit lazy about numpy lately. This initializes the reduce_pos to 0 and removes the if from gh-4535. The reason is in the tests (they do warn you that something may be fishy when run in valgrind). The size==1 check does not work with an axis argument given.a
