### PR TITLE
BUG: fix unaligned access of new indexing

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -650,14 +650,12 @@ _IsAligned(PyArrayObject *ap)
 {
     unsigned int i;
     npy_uintp aligned;
-    const unsigned int alignment = PyArray_DESCR(ap)->alignment;
+    npy_uintp alignment = PyArray_DESCR(ap)->alignment;
 
-    /* The special casing for STRING and VOID types was removed
-     * in accordance with http://projects.scipy.org/numpy/ticket/1227
-     * It used to be that IsAligned always returned True for these
-     * types, which is indeed the case when they are created using
-     * PyArray_DescrConverter(), but not necessarily when using
-     * PyArray_DescrAlignConverter(). */
+    /* alignment 1 types should have a efficient alignment for copy loops */
+    if (PyArray_ISFLEXIBLE(ap) || PyArray_ISSTRING(ap)) {
+        alignment = 16;
+    }
 
     if (alignment == 1) {
         return 1;

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1429,6 +1429,7 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
     default:
 #endif
         while (itersize--) {
+            assert(npy_is_aligned(ind_ptr, _ALIGN(npy_intp)));
             indval = *((npy_intp*)ind_ptr);
 #if @isget@
             if (check_and_adjust_index(&indval, fancy_dim, 1, _save) < 0 ) {
@@ -1443,6 +1444,8 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
 
 #if @isget@
 #if @elsize@
+            assert(npy_is_aligned(result_ptr, _ALIGN(@copytype@)));
+            assert(npy_is_aligned(self_ptr, _ALIGN(@copytype@)));
             *(@copytype@ *)result_ptr = *(@copytype@ *)self_ptr;
 #else
             copyswap(result_ptr, self_ptr, 0, self);
@@ -1450,6 +1453,8 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
 
 #else /* !@isget@ */
 #if @elsize@
+            assert(npy_is_aligned(result_ptr, _ALIGN(@copytype@)));
+            assert(npy_is_aligned(self_ptr, _ALIGN(@copytype@)));
             *(@copytype@ *)self_ptr = *(@copytype@ *)result_ptr;
 #else
             copyswap(self_ptr, result_ptr, 0, self);
@@ -1567,6 +1572,8 @@ mapiter_@name@(PyArrayMapIterObject *mit)
                     while (count--) {
                         self_ptr = baseoffset;
                         for (i=0; i < @numiter@; i++) {
+                            assert(npy_is_aligned(outer_ptrs[i],
+                                                  _ALIGN(npy_intp)));
                             indval = *((npy_intp*)outer_ptrs[i]);
 
 #if @isget@ && @one_iter@
@@ -1587,12 +1594,16 @@ mapiter_@name@(PyArrayMapIterObject *mit)
 
 #if @isget@
 #if @elsize@
+                        assert(npy_is_aligned(outer_ptrs[i], _ALIGN(@copytype@)));
+                        assert(npy_is_aligned(self_ptr, _ALIGN(@copytype@)));
                         *(@copytype@ *)(outer_ptrs[i]) = *(@copytype@ *)self_ptr;
 #else
                         copyswap(outer_ptrs[i], self_ptr, 0, array);
 #endif
 #else /* !@isget@ */
 #if @elsize@
+                        assert(npy_is_aligned(outer_ptrs[i], _ALIGN(@copytype@)));
+                        assert(npy_is_aligned(self_ptr, _ALIGN(@copytype@)));
                         *(@copytype@ *)self_ptr = *(@copytype@ *)(outer_ptrs[i]);
 #else
                         copyswap(self_ptr, outer_ptrs[i], 0, array);


### PR DESCRIPTION
Requires 16 bytes alignment from string and flexible dtypes, as
processing functions might access them on the itemsize which can be
larger than 1 byte (e.g. 8 bytes strings)
16 byte the largest alignment required for all numpy copy loops.
Closes gh-4314
