### PR TITLE
add support for python ABCs

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -105,6 +105,12 @@ for ``tostring`` which exports arrays as ``bytes``. This is more consistent
 in Python 3 where ``str`` and ``bytes`` are not the same.
 
 
+compatibility to python ``numbers`` module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All numerical numpy types are now registered with the type hierarchy in
+the python ``numbers`` module.
+
+
 Improvements
 ============
 

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -98,6 +98,7 @@ from numpy.core.multiarray import (
 import types as _types
 import sys
 from numpy.compat import bytes, long
+import numbers
 
 # we don't export these for import *, but we do want them accessible
 # as numerictypes.bool, etc.
@@ -959,6 +960,12 @@ def _can_coerce_all(dtypelist, start=0):
             return newdtype
         thisind += 1
     return None
+
+def _register_types():
+    numbers.Integral.register(integer)
+    numbers.Complex.register(inexact)
+    numbers.Real.register(floating)
+_register_types()
 
 def find_common_type(array_types, scalar_types):
     """

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1121,6 +1121,21 @@ voidtype_dtypedescr_get(PyVoidScalarObject *self)
 
 
 static PyObject *
+inttype_numerator_get(PyObject *self)
+{
+    Py_INCREF(self);
+    return self;
+}
+
+
+static PyObject *
+inttype_denominator_get(PyObject *self)
+{
+    return PyInt_FromLong(1);
+}
+
+
+static PyObject *
 gentype_data_get(PyObject *self)
 {
 #if defined(NPY_PY3K)
@@ -2062,6 +2077,20 @@ static PyMethodDef voidtype_methods[] = {
         (PyCFunction)voidtype_setfield,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {NULL, NULL, 0, NULL}
+};
+
+static PyGetSetDef inttype_getsets[] = {
+    {"numerator",
+        (getter)inttype_numerator_get,
+        (setter)0,
+        "numerator of value (the value itself)",
+        NULL},
+    {"denominator",
+        (getter)inttype_denominator_get,
+        (setter)0,
+        "denominator of value (1)",
+        NULL},
+    {NULL, NULL, NULL, NULL, NULL}
 };
 
 /**begin repeat
@@ -4029,6 +4058,8 @@ initialize_numeric_types(void)
     PyVoidArrType_Type.tp_getset = voidtype_getsets;
     PyVoidArrType_Type.tp_as_mapping = &voidtype_as_mapping;
     PyVoidArrType_Type.tp_as_sequence = &voidtype_as_sequence;
+
+    PyIntegerArrType_Type.tp_getset = inttype_getsets;
 
     /**begin repeat
      * #NAME= Number, Integer, SignedInteger, UnsignedInteger, Inexact,

--- a/numpy/core/tests/test_abc.py
+++ b/numpy/core/tests/test_abc.py
@@ -1,0 +1,45 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from numpy.testing import TestCase, assert_
+
+import numbers
+from numpy.core.numerictypes import sctypes
+
+class ABC(TestCase):
+    def test_floats(self):
+        for t in sctypes['float']:
+            assert_(isinstance(t(), numbers.Real), 
+                    "{0} is not instance of Real".format(t.__name__))
+            assert_(issubclass(t, numbers.Real),
+                    "{0} is not subclass of Real".format(t.__name__))
+            assert_(not isinstance(t(), numbers.Rational), 
+                    "{0} is instance of Rational".format(t.__name__))
+            assert_(not issubclass(t, numbers.Rational),
+                    "{0} is subclass of Rational".format(t.__name__))
+
+    def test_complex(self):
+        for t in sctypes['complex']:
+            assert_(isinstance(t(), numbers.Complex), 
+                    "{0} is not instance of Complex".format(t.__name__))
+            assert_(issubclass(t, numbers.Complex),
+                    "{0} is not subclass of Complex".format(t.__name__))
+            assert_(not isinstance(t(), numbers.Real), 
+                    "{0} is instance of Real".format(t.__name__))
+            assert_(not issubclass(t, numbers.Real),
+                    "{0} is subclass of Real".format(t.__name__))
+
+    def test_int(self):
+        for t in sctypes['int']:
+            assert_(isinstance(t(), numbers.Integral), 
+                    "{0} is not instance of Integral".format(t.__name__))
+            assert_(issubclass(t, numbers.Integral),
+                    "{0} is not subclass of Integral".format(t.__name__))
+
+    def test_uint(self):
+        for t in sctypes['uint']:
+            assert_(isinstance(t(), numbers.Integral), 
+                    "{0} is not instance of Integral".format(t.__name__))
+            assert_(issubclass(t, numbers.Integral),
+                    "{0} is not subclass of Integral".format(t.__name__))
+


### PR DESCRIPTION
Beginning with version 2.6, python supports abstract base classes,
which contain a class hierarchy for numbers. This class hierarchy is
very similar to the one of numpy, so it is very easy to register
the numpy type hierarchy with the python type hierarchy.

This pull request adds those registration and test cases for it.
