### PR TITLE
TST: increase test time to avoid negative times on UTC conversion

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -595,7 +595,7 @@ class TestDateTime(TestCase):
     def test_cast_overflow(self):
         # gh-4486
         def cast():
-            numpy.datetime64("1970-01-01 00:00:00.000000000000000").astype("<M8[D]")
+            numpy.datetime64("1971-01-01 00:00:00.000000000000000").astype("<M8[D]")
         assert_raises(OverflowError, cast)
         def cast2():
             numpy.datetime64("2014").astype("<M8[fs]")


### PR DESCRIPTION
fixes the test on windows where mingw _mktemp64 will return an error
instead of a negative time.
