### PR TITLE
Datetime test fix 1.8

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -595,7 +595,7 @@ class TestDateTime(TestCase):
     def test_cast_overflow(self):
         # gh-4486
         def cast():
-            numpy.datetime64("1970-01-01 00:00:00.000000000000000").astype("<M8[D]")
+            numpy.datetime64("1971-01-01 00:00:00.000000000000000").astype("<M8[D]")
         assert_raises(OverflowError, cast)
         def cast2():
             numpy.datetime64("2014").astype("<M8[fs]")

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -424,21 +424,28 @@ class TestCreation(TestCase):
             assert_equal(np.count_nonzero(d), 0)
             # true for ieee floats
             assert_equal(d.sum(), 0)
-
-            d = np.zeros((30 * 1024**2,), dtype=dt)
-            assert_equal(np.count_nonzero(d), 0)
-            assert_equal(d.sum(), 0)
+            assert_(not d.any())
 
             d = np.zeros(2, dtype='(2,4)i4')
             assert_equal(np.count_nonzero(d), 0)
             assert_equal(d.sum(), 0)
+            assert_(not d.any())
 
             d = np.zeros(2, dtype='4i4')
             assert_equal(np.count_nonzero(d), 0)
             assert_equal(d.sum(), 0)
+            assert_(not d.any())
 
             d = np.zeros(2, dtype='(2,4)i4, (2,4)i4')
             assert_equal(np.count_nonzero(d), 0)
+
+    @dec.slow
+    def test_zeros_big(self):
+        # test big array as they might be allocated different by the sytem
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        for dt in types:
+            d = np.zeros((30 * 1024**2,), dtype=dt)
+            assert_(not d.any())
 
     def test_zeros_obj(self):
         # test initialization from PyLong(0)


### PR DESCRIPTION
the windows datetime test fix for 1.8 + sync test_zeros test with master as its faster and friendlier to little RAM test VMs
