### PR TITLE
BUG: fix fancy indexing with negated strides

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2673,7 +2673,8 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
         tmp_iter = NpyIter_MultiNew(mit->numiter, index_arrays,
                                     NPY_ITER_ZEROSIZE_OK |
                                     NPY_ITER_REFS_OK |
-                                    NPY_ITER_MULTI_INDEX,
+                                    NPY_ITER_MULTI_INDEX |
+                                    NPY_ITER_DONT_NEGATE_STRIDES,
                                     NPY_KEEPORDER,
                                     NPY_UNSAFE_CASTING,
                                     tmp_op_flags, NULL);
@@ -2687,9 +2688,13 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
              * here, but it would *not* work directly, since elsize
              * is limited to int.
              */
-            NpyIter_CreateCompatibleStrides(tmp_iter,
+            if (!NpyIter_CreateCompatibleStrides(tmp_iter,
                         extra_op_dtype->elsize * PyArray_SIZE(subspace),
-                        strides);
+                        strides)) {
+                PyErr_SetString(PyExc_ValueError,
+                        "internal error: failed to find output array strides");
+                goto fail;
+            }
         }
         else {
             /* Just use C-order strides (TODO: allow also F-order) */

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -193,6 +193,15 @@ class TestIndexing(TestCase):
         c = np.arange(10).reshape(5, 2)[::-1]
         a[b, :] = c
         assert_equal(a[0], [0, 1])
+    
+    def test_reversed_strides_result_allocation(self):
+        # Test a bug when calculating the output strides for a result array
+        # when the subspace size was 1 (and test other cases as well)
+        a = np.arange(10)[:, None]
+        i = np.arange(10)[::-1]
+        assert_array_equal(a[i], a[i.copy('C')])
+
+        a = np.arange(20).reshape(-1, 2)
 
 
     def test_uncontiguous_subspace_assignment(self):


### PR DESCRIPTION
When strides where negated and the subspace had a size of 1, then
finding the output array strides did not work because
DONT_NEGATE_STRIDES was not set on the iterator used to find
the output arrays strides.
## 

Small fix...
