### PR TITLE
allow compiler vectorization of integer compares

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -52,6 +52,19 @@
         && (steps[0] == steps[2])\
         && (steps[0] == 0))
 
+/* binary loop input and output continous */
+#define IS_BINARY_CONT(tin, tout) (steps[0] == sizeof(tin) && \
+                                   steps[1] == sizeof(tin) && \
+                                   steps[2] == sizeof(tout))
+/* binary loop input and output continous with first scalar */
+#define IS_BINARY_CONT_S1(tin, tout) (steps[0] == 0 && \
+                                   steps[1] == sizeof(tin) && \
+                                   steps[2] == sizeof(tout))
+/* binary loop input and output continous with second scalar */
+#define IS_BINARY_CONT_S2(tin, tout) (steps[0] == sizeof(tin) && \
+                                   steps[1] == 0 && \
+                                   steps[2] == sizeof(tout))
+
 #define OUTPUT_LOOP\
     char *op1 = args[1];\
     npy_intp os1 = steps[1];\
@@ -803,13 +816,45 @@ NPY_NO_EXPORT void
  * #OP =  ==, !=, >, >=, <, <=, &&, ||#
  */
 
-NPY_NO_EXPORT void
+NPY_NO_EXPORT NPY_GCC_OPT_3 void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ in2 = *(@type@ *)ip2;
-        *((npy_bool *)op1) = in1 @OP@ in2;
+    /*
+     * gcc vectorization of this is not good (PR60575) but manual integer
+     * vectorization is too tedious to be worthwhile
+     */
+    if (IS_BINARY_CONT(@type@, npy_bool)) {
+        npy_intp i, n = dimensions[0];
+        @type@ * a = (@type@ *)args[0], * b = (@type@ *)args[1];
+        npy_bool * o = (npy_bool *)args[2];
+        for (i = 0; i < n; i++) {
+            o[i] = a[i] @OP@ b[i];
+        }
+    }
+    else if (IS_BINARY_CONT_S1(@type@, npy_bool)) {
+        npy_intp i, n = dimensions[0];
+        @type@ a = *(@type@ *)args[0];
+        @type@ * b = (@type@ *)args[1];
+        npy_bool * o = (npy_bool *)args[2];
+        for (i = 0; i < n; i++) {
+            o[i] = a @OP@ b[i];
+        }
+    }
+    else if (IS_BINARY_CONT_S2(@type@, npy_bool)) {
+        npy_intp i, n = dimensions[0];
+        @type@ * a = (@type@ *)args[0];
+        @type@ b = *(@type@*)args[1];
+        npy_bool * o = (npy_bool *)args[2];
+        for (i = 0; i < n; i++) {
+            o[i] = a[i] @OP@ b;
+        }
+    }
+    else {
+        BINARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            const @type@ in2 = *(@type@ *)ip2;
+            *((npy_bool *)op1) = in1 @OP@ in2;
+        }
     }
 }
 

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -11,9 +11,23 @@ __all__ = ['diag', 'diagflat', 'eye', 'fliplr', 'flipud', 'rot90', 'tri',
 
 from numpy.core.numeric import (
     asanyarray, subtract, arange, zeros, greater_equal, multiply, ones,
-    asarray, where, dtype as np_dtype, less
+    asarray, where, dtype as np_dtype, less, int8, int16, int32, int64
     )
+from numpy.core import iinfo
 
+
+i1 = iinfo(int8)
+i2 = iinfo(int16)
+i4 = iinfo(int32)
+def _min_int(low, high):
+    """ get small int that fits the range """
+    if high <= i1.max and low >= i1.min:
+        return int8
+    if high <= i2.max and low >= i2.min:
+        return int16
+    if high <= i4.max and low >= i4.min:
+        return int32
+    return int64
 
 
 def fliplr(m):
@@ -396,7 +410,8 @@ def tri(N, M=None, k=0, dtype=float):
     if M is None:
         M = N
 
-    m = greater_equal.outer(arange(N), arange(-k, M-k))
+    m = greater_equal.outer(arange(N, dtype=_min_int(0, N)),
+                            arange(-k, M-k, dtype=_min_int(-k, M - k)))
 
     # Avoid making a copy if the requested type is already bool
     if np_dtype(dtype) != np_dtype(bool):


### PR DESCRIPTION
write integer bool loops in a compiler vectorizable way and make use of it for tri boolean outer product on integer ranges which are usually in the int16 range

```
In [2]: %timeit np.tri(100)
10000 loops, best of 3: 32.1 µs per loop
In [3]: %timeit np.tri(1000)
100 loops, best of 3: 2.86 ms per loop
```

vs before

```
In [2]: %timeit np.tri(100)
10000 loops, best of 3: 46.4 µs per loop
In [3]: %timeit np.tri(1000)
100 loops, best of 3: 4.47 ms per loop
```

I'm not sure if this is really worth the extra code
default integers on 64 bit are 8 byte and not vectorizable with sse2, so the applications are relatively limited
