### PR TITLE
Raise TypeError when setting inappropriate ma fill_value 

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -66,6 +66,17 @@ ndarray.tofile exception type
 All ``tofile`` exceptions are now ``IOError``, some were previously
 ``ValueError``.
 
+Invalid fill value exceptions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Two changes to numpy.ma.core._check_fill_value:
+
+* When the fill value is a string and the array type is not one of
+  'OSUV', TypeError is raised instead of the default fill value being used.
+
+* When the fill value overflows the array type, TypeError is raised instead
+  of OverflowError.
+
+
 The ``doc/swig`` directory moved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``doc/swig`` directory has been moved to ``tools/swig``.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -417,13 +417,18 @@ def _check_fill_value(fill_value, ndtype):
                                   dtype=ndtype)
     else:
         if isinstance(fill_value, basestring) and (ndtype.char not in 'OSVU'):
-            fill_value = default_fill_value(ndtype)
+            err_msg = "Cannot set fill value of string with array of dtype %s"
+            raise TypeError(err_msg % ndtype)
         else:
-            # In case we want to convert 1e+20 to int...
+            # In case we want to convert 1e20 to int...
             try:
-                fill_value = np.array(fill_value, copy=False, dtype=ndtype)#.item()
+                fill_value = np.array(fill_value, copy=False, dtype=ndtype)
             except OverflowError:
-                fill_value = default_fill_value(ndtype)
+                # Raise TypeError instead of OverflowError. OverflowError
+                # is seldom used, and the real problem here is that the
+                # passed fill_value is not compatible with the ndtype.
+                err_msg = "Fill value %s overflows dtype %s"
+                raise TypeError(err_msg % (fill_value, ndtype))
     return np.array(fill_value)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1312,9 +1312,9 @@ class TestMaskedArrayAttributes(TestCase):
 
 #------------------------------------------------------------------------------
 class TestFillingValues(TestCase):
-    #
+
     def test_check_on_scalar(self):
-        # Test _check_fill_value
+        # Test _check_fill_value set to valid and invalid values
         _check_fill_value = np.ma.core._check_fill_value
         #
         fval = _check_fill_value(0, int)
@@ -1326,9 +1326,8 @@ class TestFillingValues(TestCase):
         assert_equal(fval, asbytes("0"))
         fval = _check_fill_value(None, "|S3")
         assert_equal(fval, default_fill_value("|S3"))
-        #
-        fval = _check_fill_value(1e+20, int)
-        assert_equal(fval, default_fill_value(0))
+        self.assertRaises(TypeError, _check_fill_value, 1e+20, int)
+        self.assertRaises(TypeError, _check_fill_value, 'stuff', int)
 
     def test_check_on_fields(self):
         # Tests _check_fill_value with records


### PR DESCRIPTION
Rebased and cleaned up version of #3379.
