### PR TITLE
ENH: optimize array creation from homogenous python sequences

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -511,6 +511,22 @@ class TestCreation(TestCase):
         assert_array_equal(d, [0] * 13)
         assert_equal(np.count_nonzero(d), 0)
 
+    def test_sequence_non_homogenous(self):
+        assert_equal(np.array([4, 2**80]).dtype, np.object)
+        assert_equal(np.array([4, 2**80, 4]).dtype, np.object)
+        assert_equal(np.array([2**80, 4]).dtype, np.object)
+        assert_equal(np.array([2**80] * 3).dtype, np.object)
+        assert_equal(np.array([[1, 1],[1j, 1j]]).dtype, np.complex)
+        assert_equal(np.array([[1j, 1j],[1, 1]]).dtype, np.complex)
+        assert_equal(np.array([[1, 1, 1],[1, 1j, 1.], [1, 1, 1]]).dtype, np.complex)
+
+    @dec.skipif(sys.version_info[0] >= 3)
+    def test_sequence_long(self):
+        assert_equal(np.array([long(4), long(4)]).dtype, np.long)
+        assert_equal(np.array([long(4), 2**80]).dtype, np.object)
+        assert_equal(np.array([long(4), 2**80, long(4)]).dtype, np.object)
+        assert_equal(np.array([2**80, long(4)]).dtype, np.object)
+
     def test_non_sequence_sequence(self):
         """Should not segfault.
 


### PR DESCRIPTION
Instead calling PyArray_DTypeFromObjectHelper for each item in a
sequence, check if all items in the sequence are of the same scalar
type, if this is the case we only need to recurse on one item.
Also use the PySequence_Fast API to avoid expensive function calls for
the common case of lists or tuples.

np.array(range(10)) improves about 25%
np.array(range(100)) improves about 40%
