### PR TITLE
Docstring fix for `savetxt` (minor change)

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -913,6 +913,8 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
     delimiter : str, optional
         Character separating columns.
     newline : str, optional
+        Character separating lines.
+
         .. versionadded:: 1.5.0
     header : str, optional
         String that will be written at the beginning of the file.
@@ -929,7 +931,6 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
 
         .. versionadded:: 1.7.0
 
-        Character separating lines.
 
     See Also
     --------


### PR DESCRIPTION
I think this was the intended result. 

See also: http://docs.scipy.org/doc/numpy/reference/generated/numpy.savetxt.html
