### PR TITLE
ENH: Ensure that repr and str work for MaskedArray non-ndarray bases

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -194,6 +194,11 @@ Several more functions now release the Global Interpreter Lock allowing more
 efficient parallization using the ``threading`` module. Most notably the GIL is
 now released for fancy indexing and ``np.where``.
 
+MaskedArray support for more complicated base classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Built-in assumptions that the baseclass behaved like a plain array are being
+removed. In particalur, ``repr`` and ``str`` should now work more reliably.
+
 Changes
 =======
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -369,6 +369,13 @@ class TestMaskedArray(TestCase):
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
+    def test_str_repr(self):
+        a = array([0, 1, 2], mask=[False, True, False])
+        assert_equal(str(a), '[0 -- 2]')
+        assert_equal(repr(a), 'masked_array(data = [0 -- 2],\n'
+                              '             mask = [False  True False],\n'
+                              '       fill_value = 999999)\n')
+
     def test_pickling(self):
         # Tests pickling
         a = arange(10)
@@ -3624,7 +3631,7 @@ def test_append_masked_array():
 def test_append_masked_array_along_axis():
     a = np.ma.masked_equal([1,2,3], value=2)
     b = np.ma.masked_values([[4, 5, 6], [7, 8, 9]], 7)
-    
+
     # When `axis` is specified, `values` must have the correct shape.
     assert_raises(ValueError, np.ma.append, a, b, axis=0)
 
@@ -3634,7 +3641,7 @@ def test_append_masked_array_along_axis():
     expected = expected.reshape((3,3))
     assert_array_equal(result.data, expected.data)
     assert_array_equal(result.mask, expected.mask)
-    
+
 
 ###############################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
(@charris: this is one of the corrections I mentioned in #3907 that we need to make to MaskedArray to get astropy's more complicated ndarray subclasses to be used as base classes.)

Currently, `repr(ma)` and `str(ma)` do not deal well with base classes that redefine `__repr__` to use a different way to print the class name, or that override `__setitem__` to do checks on values, respectively. This PR corrects this, by simply letting `__repr__` use `__class__.__name__` instead of trying to be smart in how to get it, and by ensuring that `__str__` inserts `masked_print_option` in an `ndarray` view of the object array that is created for string output (the current way `__str__` is handled is perhaps too clever a trick, but I'm not quite sure yet how to make it safer; my PR should at least help a little.). 

Specifically, currently, after defining:

```
import numpy as np

class ComplicatedSubArray(np.ndarray):
    def __new__(cls, arr):
        return np.asanyarray(arr).view(cls)

    def __str__(self):
        return 'myprefix {0} mypostfix'.format(
            super(ComplicatedSubArray, self).__str__())

    def __repr__(self):
        # Return a repr that does not start with 'name('
        return '<{0} {1}>'.format(self.__class__.__name__, self)

    def __setitem__(self, item, value):
        # this ensures direct assignment to masked_print_option will fail
        if not isinstance(value, ComplicatedSubArray):
            raise ValueError("Can only set to MySubArray values")
        super(ComplicatedSubArray, self).__setitem__(item, value)

xcsub = ComplicatedSubArray(np.arange(5))
mxcsub1 = np.ma.masked_array(xcsub)
mxcsub2 = np.ma.masked_array(xcsub, mask=[True, False, True, False, False])
```

one gets

```
In [15]: mxcsub1
Out[15]: 
masked_<ComplicatedSubArray myprefix [0 1 2 3 4] mypostfix>(data = myprefix [0 1 2 3 4] mypostfix,
                                                            mask = False,
                                                      fill_value = 999999)
In [16]: mxcsub2
Out[16]: 
.
.
.
ValueError: Can only set to MySubArray values
```

With the PR,

```
In [2]: mxcsub1
Out[2]: 
masked_ComplicatedSubArray(data = myprefix [0 1 2 3 4] mypostfix,
                           mask = False,
                     fill_value = 999999)
In [3]: mxcsub2
Out[3]: 
masked_ComplicatedSubArray(data = myprefix [-- 1 -- 3 4] mypostfix,
                           mask = [ True False  True False False],
                     fill_value = 999999)
```
