### PR TITLE
ENH: Allow keyword arguments in auto-converted ma functions.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -33,6 +33,7 @@ from numpy import ndarray, amax, amin, iscomplexobj, bool_
 from numpy import array as narray
 from numpy.lib.function_base import angle
 from numpy.compat import getargspec, formatargspec, long, basestring
+from inspect import getcallargs
 from numpy import expand_dims as n_expand_dims
 
 if sys.version_info[0] >= 3:
@@ -7238,7 +7239,7 @@ class _convert2ma:
             doc = sig + doc
         return doc
     #
-    def __call__(self, a, *args, **params):
+    def __call__(self, *args, **params):
         # Find the common parameters to the call and the definition
         _extras = self._extras
         common_params = set(params).intersection(_extras)
@@ -7246,7 +7247,13 @@ class _convert2ma:
         for p in common_params:
             _extras[p] = params.pop(p)
         # Get the result
-        result = self._func.__call__(a, *args, **params).view(MaskedArray)
+        try:
+            params = getcallargs(self._func, *args, **params)
+        except TypeError:
+            result = self._func.__call__(*args, **params)
+        else:
+            result = self._func(**params)
+        result = result.view(MaskedArray)
         if "fill_value" in common_params:
             result.fill_value = _extras.get("fill_value", None)
         if "hardmask" in common_params:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3643,6 +3643,12 @@ def test_append_masked_array_along_axis():
     assert_array_equal(result.mask, expected.mask)
 
 
+def test_ctors_with_keyword_args():
+    x = np.ma.zeros(shape=2, dtype="f8")
+    y = np.zeros(2)
+    assert_array_equal(x.data, y)
+    assert_equal(x.dtype, y.dtype)
+
 ###############################################################################
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes #4582.
