### PR TITLE
BUG: Ensure MaskedArray.flat can access single items

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2534,8 +2534,11 @@ class MaskedIterator(object):
         result = self.dataiter.__getitem__(indx).view(type(self.ma))
         if self.maskiter is not None:
             _mask = self.maskiter.__getitem__(indx)
-            _mask.shape = result.shape
-            result._mask = _mask
+            if isinstance(_mask, ndarray):
+                _mask.shape = result.shape
+                result._mask = _mask
+            elif _mask:
+                return masked
         return result
 
     ### This won't work is ravel makes a copy

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1305,6 +1305,11 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(a.mask, nomask)
 
     def test_flat(self):
+        # test simple access
+        test = masked_array(np.matrix([[1, 2, 3]]), mask=[0, 0, 1])
+        assert_equal(test.flat[1], 2)
+        assert_equal(test.flat[2], masked)
+        self.assertTrue(np.all(test.flat[0:2] == test[0, 0:2]))
         # Test flat on masked_matrices
         test = masked_array(np.matrix([[1, 2, 3]]), mask=[0, 0, 1])
         test.flat = masked_array([3, 2, 1], mask=[1, 0, 0])
@@ -1315,6 +1320,8 @@ class TestMaskedArrayAttributes(TestCase):
         testflat = test.flat
         testflat[:] = testflat[[2, 1, 0]]
         assert_equal(test, control)
+        testflat[0] = 9
+        assert_equal(test[0, 0], 9)
 
 
 #------------------------------------------------------------------------------

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1315,14 +1315,40 @@ class TestMaskedArrayAttributes(TestCase):
         test.flat = masked_array([3, 2, 1], mask=[1, 0, 0])
         control = masked_array(np.matrix([[3, 2, 1]]), mask=[1, 0, 0])
         assert_equal(test, control)
-        #
+        # Test setting
         test = masked_array(np.matrix([[1, 2, 3]]), mask=[0, 0, 1])
         testflat = test.flat
         testflat[:] = testflat[[2, 1, 0]]
         assert_equal(test, control)
         testflat[0] = 9
         assert_equal(test[0, 0], 9)
-
+        # test 2-D record array
+        # ... on structured array w/ masked records
+        x = array([[(1, 1.1, 'one'), (2, 2.2, 'two'), (3, 3.3, 'thr')],
+                   [(4, 4.4, 'fou'), (5, 5.5, 'fiv'), (6, 6.6, 'six')]],
+                  dtype=[('a', int), ('b', float), ('c', '|S8')])
+        x['a'][0, 1] = masked
+        x['b'][1, 0] = masked
+        x['c'][0, 2] = masked
+        x[-1, -1] = masked
+        xflat = x.flat
+        assert_equal(xflat[0], x[0, 0])
+        assert_equal(xflat[1], x[0, 1])
+        assert_equal(xflat[2], x[0, 2])
+        assert_equal(xflat[:3], x[0])
+        assert_equal(xflat[3], x[1, 0])
+        assert_equal(xflat[4], x[1, 1])
+        assert_equal(xflat[5], x[1, 2])
+        assert_equal(xflat[3:], x[1])
+        assert_equal(xflat[-1], x[-1, -1])
+        i = 0
+        j = 0
+        for xf in xflat:
+            assert_equal(xf, x[j, i])
+            i += 1
+            if i >= x.shape[-1]:
+                i = 0
+                j += 1
 
 #------------------------------------------------------------------------------
 class TestFillingValues(TestCase):


### PR DESCRIPTION
Currently, the `MaskedArray.flat` iterator barfs when trying to access single items, because it is tried to overwrite `shape` of a non-ndarray mask (see below). This PR corrects this, and adds test cases.

```
import numpy as np
ma = np.ma.MaskedArray([1,2,3], mask=[0,1,0])
ma.flat[1]
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-d9496ad7cbf6> in <module>()
----> 1 ma.flat[1]

/usr/lib/python3/dist-packages/numpy/ma/core.py in __getitem__(self, indx)
   2530         if self.maskiter is not None:
   2531             _mask = self.maskiter.__getitem__(indx)
-> 2532             _mask.shape = result.shape
   2533             result._mask = _mask
   2534         return result

AttributeError: attribute 'shape' of 'numpy.generic' objects is not writable
```
