### PR TITLE
ENH: Quoting support in np.genfromtxt(...)

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1174,7 +1174,7 @@ def fromregex(file, regexp, dtype):
 #####--------------------------------------------------------------------------
 
 
-def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
+def genfromtxt(fname, dtype=float, comments='#', delimiter=None, quoter=None,
                skiprows=0, skip_header=0, skip_footer=0, converters=None,
                missing='', missing_values=None, filling_values=None,
                usecols=None, names=None,
@@ -1207,6 +1207,9 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     skip_rows : int, optional
         `skip_rows` was deprecated in numpy 1.5, and will be removed in
         numpy 2.0. Please use `skip_header` instead.
+    quoter  str, optional
+        The string used as a quoting character. By default it's assumed that
+        the values are not quoted.
     skip_header : int, optional
         The number of lines to skip at the beginning of the file.
     skip_footer : int, optional
@@ -1334,6 +1337,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         comments = asbytes(comments)
     if isinstance(delimiter, unicode):
         delimiter = asbytes(delimiter)
+    if isinstance(quoter, unicode):
+        quoter = asbytes(quoter)
     if isinstance(missing, unicode):
         missing = asbytes(missing)
     if isinstance(missing_values, (unicode, list, tuple)):
@@ -1365,7 +1370,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             "fname must be a string, filehandle, or generator. "
             "(got %s instead)" % type(fname))
 
-    split_line = LineSplitter(delimiter=delimiter, comments=comments,
+    split_line = LineSplitter(delimiter=delimiter, quoter=quoter,
+                              comments=comments,
                               autostrip=autostrip)._handyman
     validate_names = NameValidator(excludelist=excludelist,
                                    deletechars=deletechars,

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -986,6 +986,34 @@ M   33  21.99
         test = np.genfromtxt(data, names=True, dtype=None)
         assert_equal(test, ctrl)
 
+    def check_quoter(self, quoter):
+        data = [["a, b c d", "e f", "g" + quoter + ' x'],
+                ["h, i jk", "lm no, p q", "r"]]
+
+        ctrl = np.array([[asbytes(el) for el in row]
+                         for row in data],
+                        dtype='|S10')
+
+        tio = TextIO()
+        for row in data:
+            quoted = []
+            for el in row:
+                text = el.replace(quoter, '\\' + quoter)
+                quoted.append(quoter + text + quoter)
+            line = ','.join(quoted)
+            tio.write(line)
+            tio.write('\n')
+        tio.seek(0)
+
+        test = np.genfromtxt(tio, quoter=quoter, delimiter=",",
+                             dtype='|S10')
+
+        assert_equal(test, ctrl)
+
+    def test_quote(self):
+        self.check_quoter('"')
+        self.check_quoter("'")
+
     def test_autonames_and_usecols(self):
         "Tests names and usecols"
         data = TextIO('A B C D\n aaaa 121 45 9.1')


### PR DESCRIPTION
Based off patch in #2211. Implements custom split method and adds new keyword argument `quoter=` to `np.genfromtxt`. The quoting feature also supports escaping.
#### Example usage:

data.txt:

```
"King","Henry, VI"
"Queen","Victoria"
Sir,Isaac Newton
```

Python:

```
>>> np.genfromtxt("data.txt", quoter='"', delimiter=",", dtype="|S20")
array([[b'King', b'Henry, VI'],
       [b'Queen', b'Victoria'],
       [b'Sir', b'Isaac Newton']], 
      dtype='|S20')
```
#### Changes from original patch:
- **Python 3 compatibility**:
  old code was iterating through bytes and not expecting int
- **Bugfix**:
  old code was dropping final word in split implemention
- **Test**:
  added a unit test
