### PR TITLE
ENH: Add new array joining function: np.interleave

### DIFF
--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -67,6 +67,7 @@ Joining arrays
    dstack
    hstack
    vstack
+   interleave
 
 Splitting arrays
 ================

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -893,7 +893,7 @@ def interleave(arrays, axis=0):
     narrays = len(arrays)
     if narrays == 0:
         raise ValueError("interleave takes at least one (reasonably two) arrays")
-    arrays = map(asarray, arrays)
+    arrays = [asarray(a) for a in arrays]
     if any(x.dtype != arrays[0].dtype for x in arrays[1:]):
         raise ValueError("dtype of arrays must be consistent")
     if any(x.shape != arrays[0].shape for x in arrays[1:]):

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -915,6 +915,6 @@ def interleave(arrays, axis=0):
                   dtype=_nx.find_common_type([a.dtype for a in arrays], []))
     for i, arr in enumerate(arrays):
         slicing = [slice(i, arrays[0].shape[j]*narrays, narrays) if
-                   j == axis else Ellipsis for j in range(arrays[0].ndim)]
+                   j == axis else slice(None) for j in range(arrays[0].ndim)]
         c[slicing] = arr
     return c

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -853,25 +853,26 @@ def tile(A, reps):
     return c.reshape(shape)
 
 
-def interleave(arrays, axis=0, dtype=None):
+def interleave(arrays, axis=0):
     """
     Interleaves multiple arrays along a user specified axis.
 
-    Parrameters
-    -----------
-    arrays : sequence of array_like with consistent shape
-        Input arrays, if a sequence of length 1 is given, the first
+    Parameters
+    ----------
+    arrays : sequence of array_like
+        Input arrays (of same shape)
     axis : int, optional
         Along what axis interleaving should be performed
-    dtype : dtype
-        What dtype resulting array should be (default: same as
-        first array).
 
     Returns
     -------
     interleave: ndarray
-        Interleaved array of rank queal to arrays in `arrays` with shape
+        Interleaved array of rank equal to arrays in `arrays` with shape
         in `axis` dimension multiplied with number of arrays in `arrays`.
+
+    Notes
+    -----
+    .. versionadded:: 1.9.0
 
     Raises
     ------
@@ -892,25 +893,28 @@ def interleave(arrays, axis=0, dtype=None):
     >>> interleave(a, a+4, axis=1)
     array([[0, 4, 1, 5],
            [2, 6, 3, 7]])
+
     """
     narrays = len(arrays)
     if narrays == 0:
-        raise ValueError("interleave takes at least one (reasonably two) arrays")
+        raise ValueError("interleave takes at least one array")
     arrays = [asarray(a) for a in arrays]
-    if any(x.shape != arrays[0].shape for x in arrays[1:]):
+    shp = arrays[0].shape
+    if any(x.shape != shp for x in arrays[1:]):
         raise ValueError("Shapes of arrays must be consistent")
     nd = arrays[0].ndim
-    if nd == 0: raise ValueError("interleave only works on arrays of 1 or more dimensions")
+    if nd == 0:
+        raise ValueError("interleave only works on arrays of 1 "
+                         "or more dimensions")
     if axis < 0:
         axis += nd
     if (axis >= nd):
         raise ValueError("axis must be less than arr.ndim; axis=%d, rank=%d."
-            % (axis, nd))
-
-    c = _nx.empty([narrays*n if i==axis else n for i, n \
-                  in enumerate(arrays[0].shape)], dtype=dtype or arrays[0].dtype)
+                         % (axis, nd))
+    c = _nx.empty([narrays * n if i == axis else n for i, n in enumerate(shp)],
+                  dtype=_nx.find_common_type([a.dtype for a in arrays], []))
     for i, arr in enumerate(arrays):
-        slicing = [slice(i, arrays[0].shape[j]*narrays, narrays) if\
-                   j==axis else Ellipsis for j in range(arrays[0].ndim)]
+        slicing = [slice(i, arrays[0].shape[j]*narrays, narrays) if
+                   j == axis else Ellipsis for j in range(arrays[0].ndim)]
         c[slicing] = arr
     return c

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -853,16 +853,19 @@ def tile(A, reps):
     return c.reshape(shape)
 
 
-def interleave(arrays, axis=0):
+def interleave(arrays, axis=0, dtype=None):
     """
     Interleaves multiple arrays along a user specified axis.
 
     Parrameters
     -----------
-    arrays : sequence of array_like with same shape and dtype
-         Input arrays, if a sequence of length 1 is given, the fist
-    axis : int
-         Along what axis interleaving should be performed
+    arrays : sequence of array_like with consistent shape
+        Input arrays, if a sequence of length 1 is given, the first
+    axis : int, optional
+        Along what axis interleaving should be performed
+    dtype : dtype
+        What dtype resulting array should be (default: same as
+        first array).
 
     Returns
     -------
@@ -894,8 +897,6 @@ def interleave(arrays, axis=0):
     if narrays == 0:
         raise ValueError("interleave takes at least one (reasonably two) arrays")
     arrays = [asarray(a) for a in arrays]
-    if any(x.dtype != arrays[0].dtype for x in arrays[1:]):
-        raise ValueError("dtype of arrays must be consistent")
     if any(x.shape != arrays[0].shape for x in arrays[1:]):
         raise ValueError("Shapes of arrays must be consistent")
     nd = arrays[0].ndim
@@ -907,7 +908,7 @@ def interleave(arrays, axis=0):
             % (axis, nd))
 
     c = _nx.empty([narrays*n if i==axis else n for i, n \
-                  in enumerate(arrays[0].shape)], dtype=arrays[0].dtype)
+                  in enumerate(arrays[0].shape)], dtype=dtype or arrays[0].dtype)
     for i, arr in enumerate(arrays):
         slicing = [slice(i, arrays[0].shape[j]*narrays, narrays) if\
                    j==axis else Ellipsis for j in range(arrays[0].ndim)]

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -351,6 +351,30 @@ class TestMayShareMemory(TestCase):
         self.assertTrue(may_share_memory(d2[1:, ::-1], d2))
 
 
+class TestInterleave(TestCase):
+    def test_basic(self):
+        arrs = map(array, [(0,1,2), (6,7,8), (0,6,1,7,2,8)])
+        c = interleave(arrs[:-1])
+        assert_equal(c, arrs[-1])
+
+        arrs = map(array, [(0,1,2), (6,7,8), (12,13,14), (0,6,12,1,7,13,2,8,14)])
+        c = interleave(arrs[:-1])
+        assert_equal(c, arrs[-1])
+
+        arrs = map(array, [arange(9).reshape((3,3)),
+                              arange(18,27).reshape((3,3)),
+                              arange(36,45).reshape((3,3)),
+                              [[18*(i%3)+3*(i//3)+j for j in range(3)] for i in range(9)]])
+        c = interleave(arrs[:-1], axis=0)
+        assert_equal(c, arrs[-1])
+
+        arrs = map(array, [arange(4).reshape((2,2)),
+                              arange(8,12).reshape((2,2)),
+                              [[8*(j%2)+(j//2)+2*i for j in range(4)] for i in range(2)]])
+        c = interleave(arrs[:-1], axis=1)
+        assert_equal(c, arrs[-1])
+
+
 # Utility
 def compare_results(res, desired):
     for i in range(len(desired)):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -353,27 +353,29 @@ class TestMayShareMemory(TestCase):
 
 class TestInterleave(TestCase):
     def test_basic(self):
-        arrs = [array(a) for a in [(0,1,2), (6,7,8), (0,6,1,7,2,8)]]
+        arrs = [array(a) for a in [(0, 1, 2),  (6, 7, 8),  (0, 6, 1, 7, 2, 8)]]
         c = interleave(arrs[:-1])
         assert_equal(c, arrs[-1])
 
-        arrs = [array(a) for a in [(0,1,2), (6,7,8), (12,13,14),
-                                   (0,6,12,1,7,13,2,8,14)]]
+    def test_triplet(self):
+        arrs = [array(a) for a in [(0, 1, 2),  (6, 7, 8),  (12, 13, 14),
+                                   (0, 6, 12, 1, 7, 13, 2, 8, 14)]]
         c = interleave(arrs[:-1])
         assert_equal(c, arrs[-1])
 
-        arrs = [array(a) for a in [arange(9).reshape((3,3)),
-                              arange(18,27).reshape((3,3)),
-                              arange(36,45).reshape((3,3)),
-                              [[18*(i%3)+3*(i//3)+j for j in range(3)] for\
-                               i in range(9)]]]
+    def test_axis_kw(self):
+        arrs = [array(a) for a in [arange(9).reshape((3, 3)),
+                                   arange(18, 27).reshape((3, 3)),
+                                   arange(36, 45).reshape((3, 3)),
+                                   [[18*(i % 3) + 3*(i // 3) + j for j
+                                     in range(3)] for i in range(9)]]]
         c = interleave(arrs[:-1], axis=0)
         assert_equal(c, arrs[-1])
 
-        arrs = [array(a) for a in [arange(4).reshape((2,2)),
-                                   arange(8,12).reshape((2,2)),
-                                   [[8*(j%2)+(j//2)+2*i for j in range(4)] for\
-                                    i in range(2)]]]
+        arrs = [array(a) for a in [arange(4).reshape((2, 2)),
+                                   arange(8, 12).reshape((2, 2)),
+                                   [[8*(j % 2) + (j // 2) + 2*i for j
+                                     in range(4)] for i in range(2)]]]
         c = interleave(arrs[:-1], axis=1)
         assert_equal(c, arrs[-1])
 

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -379,6 +379,20 @@ class TestInterleave(TestCase):
         c = interleave(arrs[:-1], axis=1)
         assert_equal(c, arrs[-1])
 
+    def test_broadcast(self):
+        arrs = [array(a) for a in [arange(4).reshape((2, 2)),
+                                   ones(2)*9,
+                                   [[0, 1], [9, 9], [2, 3], [9, 9]]]]
+        c = interleave(arrs[:-1])
+        assert_equal(c, arrs[-1])
+
+    def test_broadcast_multidim(self):
+        arrs = [array(a) for a in [arange(4).reshape((2, 2)),
+                                   1,
+                                   [[0, 1], [1, 1], [2, 3], [1, 1]]]]
+        c = interleave(arrs[:-1])
+        assert_equal(c, arrs[-1])
+
 
 # Utility
 def compare_results(res, desired):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -353,24 +353,27 @@ class TestMayShareMemory(TestCase):
 
 class TestInterleave(TestCase):
     def test_basic(self):
-        arrs = map(array, [(0,1,2), (6,7,8), (0,6,1,7,2,8)])
+        arrs = [array(a) for a in [(0,1,2), (6,7,8), (0,6,1,7,2,8)]]
         c = interleave(arrs[:-1])
         assert_equal(c, arrs[-1])
 
-        arrs = map(array, [(0,1,2), (6,7,8), (12,13,14), (0,6,12,1,7,13,2,8,14)])
+        arrs = [array(a) for a in [(0,1,2), (6,7,8), (12,13,14),
+                                   (0,6,12,1,7,13,2,8,14)]]
         c = interleave(arrs[:-1])
         assert_equal(c, arrs[-1])
 
-        arrs = map(array, [arange(9).reshape((3,3)),
+        arrs = [array(a) for a in [arange(9).reshape((3,3)),
                               arange(18,27).reshape((3,3)),
                               arange(36,45).reshape((3,3)),
-                              [[18*(i%3)+3*(i//3)+j for j in range(3)] for i in range(9)]])
+                              [[18*(i%3)+3*(i//3)+j for j in range(3)] for\
+                               i in range(9)]]]
         c = interleave(arrs[:-1], axis=0)
         assert_equal(c, arrs[-1])
 
-        arrs = map(array, [arange(4).reshape((2,2)),
-                              arange(8,12).reshape((2,2)),
-                              [[8*(j%2)+(j//2)+2*i for j in range(4)] for i in range(2)]])
+        arrs = [array(a) for a in [arange(4).reshape((2,2)),
+                                   arange(8,12).reshape((2,2)),
+                                   [[8*(j%2)+(j//2)+2*i for j in range(4)] for\
+                                    i in range(2)]]]
         c = interleave(arrs[:-1], axis=1)
         assert_equal(c, arrs[-1])
 


### PR DESCRIPTION
Interleaving arrays is something I need to do every now and then, and by the looks of stackoverflow so do others:

http://stackoverflow.com/questions/12861314/interleave-rows-of-two-numpy-arrays-in-python
http://stackoverflow.com/questions/5347065/interweaving-two-numpy-arrays

I think the code needed for the general `n` dimensional case with `m` number of arrays
is non-trivial enough for it to be useful to provide such a function in numpy, so I took the liberty to
make this PR with my implementation. This would be my first contribution to NumPy so I apologize if something is not adhering to your practices.
