### PR TITLE
BUG: ifort has issues with optimization flag /O2

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -162,7 +162,7 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
         return ['/4Yb', '/d2']
 
     def get_flags_opt(self):
-        return ['/O2']
+        return ['/O1']  # Scipy test failures with /O2
 
     def get_flags_arch(self):
         return ["/arch:IA-32", "/QaxSSE3"]


### PR DESCRIPTION
Fixes several hard to track scipy test failures. 
See scipy/scipy#3306, scipy/scipy#3340, scipy/scipy#1205, and discussion at http://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl.
Needs backporting to numpy 1.8.x.
