### PR TITLE
DEP: Deprecate numpy.rank

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -347,6 +347,11 @@ The integer and empty input to ``select`` is deprecated. In the future only
 boolean arrays will be valid conditions and an empty ``condlist`` will be
 considered an input error instead of returning the default.
 
+``rank`` function
+~~~~~~~~~~~~~~~~~
+The ``rank`` function has been deprecated to avoid confusion with
+``numpy.linalg.matrix_rank``.
+
 C-API
 ~~~~~
 

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -121,6 +121,15 @@ class ModuleDeprecationWarning(DeprecationWarning):
     pass
 
 
+class VisibleDeprecationWarning(UserWarning):
+    """Deprecation warning for cases where it is desirable to warn
+    users more visible. By default, python will not show deprecation
+    warnings so this class can be used when a very visible warning is
+    helpful, for example because the usage is most likely a user bug.
+    """
+    pass
+
+
 # oldnumeric and numarray were removed in 1.9. In case some packages import
 # but do not use them, we define them here for backward compatibility.
 oldnumeric = 'removed'
@@ -157,7 +166,9 @@ else:
         return loader(*packages, **options)
 
     from . import add_newdocs
-    __all__ = ['add_newdocs', 'ModuleDeprecationWarning']
+    __all__ = ['add_newdocs',
+               'ModuleDeprecationWarning',
+               'VisibleDeprecationWarning']
 
     pkgload.__doc__ = PackageLoader.__call__.__doc__
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -4,7 +4,9 @@
 from __future__ import division, absolute_import, print_function
 
 import types
+import warnings
 
+from .. import VisibleDeprecationWarning
 from . import multiarray as mu
 from . import umath as um
 from . import numerictypes as nt
@@ -2453,6 +2455,11 @@ def rank(a):
     If `a` is not already an array, a conversion is attempted.
     Scalars are zero dimensional.
 
+    .. note::
+        This function is deprecated in NumPy 1.9 to avoid confusion with
+        `numpy.linalg.matrix_rank`. The ``ndim`` attribute or function
+        should be used instead.
+
     Parameters
     ----------
     a : array_like
@@ -2486,6 +2493,10 @@ def rank(a):
     0
 
     """
+    warnings.warn(
+        "`rank` is deprecated; use the `ndim` attribute or function instead. "
+        "To find the rank of a matrix see `numpy.linalg.matrix_rank`.",
+        VisibleDeprecationWarning)
     try:
         return a.ndim
     except AttributeError:

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -366,5 +366,14 @@ class TestBooleanSubtractDeprecations(_DeprecationTestCase):
         self.assert_deprecated(operator.neg, args=(generic,))
 
 
+class TestRankDeprecation(_DeprecationTestCase):
+    """Test that np.rank is deprecated. The function should simply be
+    removed. The VisibleDeprecationWarning may become unnecessary.
+    """
+    def test(self):
+        a = np.arange(10)
+        assert_warns(np.VisibleDeprecationWarning, np.rank, a)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This function is commonly confused with numpy.linalg.matrix_rank
and exists itself only for history reasons.

Closes gh-4616
