### PR TITLE
Update ufunc override to work properly with ufunc methods.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4066,7 +4066,7 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         mps[i] = NULL;
     }
 
-    errval = PyUFunc_CheckOverride(ufunc, "__call__", args, kwds, &override, 
+    errval = PyUFunc_CheckOverride(ufunc, "__call__", args, kwds, &override,
                                    ufunc->nin);
     if (errval) {
         return NULL;
@@ -4751,6 +4751,8 @@ static PyObject *
 ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
 {
     int i;
+    int errval;
+    PyObject *override = NULL;
     PyObject *ret;
     PyArrayObject *ap1 = NULL, *ap2 = NULL, *ap_new = NULL;
     PyObject *new_args, *tmp;
@@ -4773,6 +4775,15 @@ ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     if (PySequence_Length(args) != 2) {
         PyErr_SetString(PyExc_TypeError, "exactly two arguments expected");
         return NULL;
+    }
+
+    /* `nin`, the last arg, is unused. So we put 0. */
+    errval = PyUFunc_CheckOverride(ufunc, "outer", args, kwds, &override, 0);
+    if (errval) {
+        return NULL;
+    }
+    else if (override) {
+        return override;
     }
 
     tmp = PySequence_GetItem(args, 0);
@@ -4844,8 +4855,8 @@ ufunc_reduce(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     int errval;
     PyObject *override = NULL;
 
-    errval = PyUFunc_CheckOverride(ufunc, "reduce", args, kwds, &override, 
-                                   ufunc->nin);
+    /* `nin`, the last arg, is unused. So we put 0. */
+    errval = PyUFunc_CheckOverride(ufunc, "reduce", args, kwds, &override, 0);
     if (errval) {
         return NULL;
     }
@@ -4861,8 +4872,8 @@ ufunc_accumulate(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     int errval;
     PyObject *override = NULL;
 
-    errval = PyUFunc_CheckOverride(ufunc, "accumulate", args, kwds, &override, 
-                                   ufunc->nin);
+    /* `nin`, the last arg, is unused. So we put 0. */
+    errval = PyUFunc_CheckOverride(ufunc, "accumulate", args, kwds, &override, 0);
     if (errval) {
         return NULL;
     }
@@ -4878,8 +4889,8 @@ ufunc_reduceat(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
     int errval;
     PyObject *override = NULL;
 
-    errval = PyUFunc_CheckOverride(ufunc, "reduceat", args, kwds, &override, 
-                                   ufunc->nin);
+    /* `nin`, the last arg, is unused. So we put 0. */
+    errval = PyUFunc_CheckOverride(ufunc, "reduceat", args, kwds, &override, 0);
     if (errval) {
         return NULL;
     }
@@ -4931,6 +4942,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     int i;
     int nop;
 
+    /* override vars */
+    int errval;
+    PyObject *override = NULL;
+
     NpyIter *iter_buffer;
     NpyIter_IterNextFunc *iternext;
     npy_uint32 op_flags[NPY_MAXARGS];
@@ -4938,6 +4953,15 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
     int errormask = 0;
     char * err_msg = NULL;
     NPY_BEGIN_THREADS_DEF;
+
+    /* `nin`, the last arg, is unused. So we put 0. */
+    errval = PyUFunc_CheckOverride(ufunc, "at", args, NULL, &override, 0);
+    if (errval) {
+        return NULL;
+    }
+    else if (override) {
+        return override;
+    }
 
     if (ufunc->nin > 2) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1026,39 +1026,105 @@ class TestSpecialMethods(TestCase):
     def test_ufunc_override_methods(self):
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
-                if method == "__call__":
-                    return method
-                if method == "reduce":
-                    return method
-                if method == "accumulate":
-                    return method
-                if method == "reduceat":
-                    return method
+                return self, ufunc, method, pos, inputs, kwargs
 
+        # __call__
         a = A()
-        res = np.multiply(1, a)
-        assert_equal(res, "__call__")
+        res = np.multiply.__call__(1, a, foo='bar', answer=42)
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], '__call__')
+        assert_equal(res[3], 1)
+        assert_equal(res[4], (1, a))
+        assert_equal(res[5], {'foo': 'bar', 'answer': 42})
 
-        res = np.multiply.reduce(1, a)
-        assert_equal(res, "reduce")
+        # reduce, positional args
+        res = np.multiply.reduce(a, 'axis0', 'dtype0', 'out0', 'keep0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'reduce')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a,))
+        assert_equal(res[5], {'dtype':'dtype0',
+                               'out': 'out0',
+                               'keepdims': 'keep0',
+                               'axis': 'axis0'})
 
-        res = np.multiply.accumulate(1, a)
-        assert_equal(res, "accumulate")
+        # reduce, kwargs
+        res = np.multiply.reduce(a, axis='axis0', dtype='dtype0', out='out0',
+                                 keepdims='keep0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'reduce')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a,))
+        assert_equal(res[5], {'dtype':'dtype0',
+                               'out': 'out0',
+                               'keepdims': 'keep0',
+                               'axis': 'axis0'})
 
-        res = np.multiply.reduceat(1, a)
-        assert_equal(res, "reduceat")
+        # accumulate, pos args
+        res = np.multiply.accumulate(a, 'axis0', 'dtype0', 'out0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'accumulate')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a,))
+        assert_equal(res[5], {'dtype':'dtype0',
+                               'out': 'out0',
+                               'axis': 'axis0'})
 
-        res = np.multiply(a, 1)
-        assert_equal(res, "__call__")
+        # accumulate, kwargs
+        res = np.multiply.accumulate(a, axis='axis0', dtype='dtype0',
+                                     out='out0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'accumulate')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a,))
+        assert_equal(res[5], {'dtype':'dtype0',
+                               'out': 'out0',
+                               'axis': 'axis0'})
 
-        res = np.multiply.reduce(a, 1)
-        assert_equal(res, "reduce")
+        # reduceat, pos args
+        res = np.multiply.reduceat(a, [4, 2], 'axis0', 'dtype0', 'out0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'reduceat')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a, [4, 2]))
+        assert_equal(res[5], {'dtype':'dtype0',
+                               'out': 'out0',
+                               'axis': 'axis0'})
 
-        res = np.multiply.accumulate(a, 1)
-        assert_equal(res, "accumulate")
+        # reduceat, kwargs
+        res = np.multiply.reduceat(a, [4, 2], axis='axis0', dtype='dtype0',
+                                   out='out0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'reduceat')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a, [4, 2]))
+        assert_equal(res[5], {'dtype':'dtype0',
+                               'out': 'out0',
+                               'axis': 'axis0'})
 
-        res = np.multiply.reduceat(a, 1)
-        assert_equal(res, "reduceat")
+        # outer
+        res = np.multiply.outer(a, 42)
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'outer')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a, 42))
+        assert_equal(res[5], {})
+
+        # at
+        res = np.multiply.at(a, [4, 2], 'b0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'at')
+        assert_equal(res[3], 0)
+        assert_equal(res[4], (a, [4, 2], 'b0'))
 
     def test_ufunc_override_out(self):
         class A(object):
@@ -1093,7 +1159,6 @@ class TestSpecialMethods(TestCase):
         assert_equal(res6['out'][1], 'out1')
         assert_equal(res7['out'][0], 'out0')
         assert_equal(res7['out'][1], 'out1')
-
 
     def test_ufunc_override_exception(self):
         class A(object):


### PR DESCRIPTION
This allows the ufunc override machinery to work properly with all the ufunc methods.

There is one failing test [here](https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_umath.py#L929) which I am looking into. It passes for some python versions and not others.

The ufunc methods required some API design decisions and I'd like to hear what people think. The original ufunc override spec [called for the arguments to be parsed into `inputs` and `kwargs`](https://github.com/numpy/numpy/blob/master/doc/neps/ufunc-overrides.rst#proposed-interface). But what is an input and what is a kwarg?

The methods I'm wondering about are `ufunc.outer(A, B)` and `ufunc.at(a, indices[, b])`.
For `outer` I guess both `A` and `B` should be in `inputs`? For `at` should `b` also be in `inputs`.

Also please check my reference counting, I'm not confident about it.
