### PR TITLE
BUG: incorrect argument order to _copyto in in np.nanmax, np.nanmin

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -228,7 +228,7 @@ def nanmin(a, axis=None, out=None, keepdims=False):
         # Check for all-NaN axis
         mask = np.all(mask, axis=axis, keepdims=keepdims)
         if np.any(mask):
-            res = _copyto(res, mask, np.nan)
+            res = _copyto(res, np.nan, mask)
             warnings.warn("All-NaN axis encountered", RuntimeWarning)
     return res
 
@@ -327,7 +327,7 @@ def nanmax(a, axis=None, out=None, keepdims=False):
         # Check for all-NaN axis
         mask = np.all(mask, axis=axis, keepdims=keepdims)
         if np.any(mask):
-            res = _copyto(res, mask, np.nan)
+            res = _copyto(res, np.nan, mask)
             warnings.warn("All-NaN axis encountered", RuntimeWarning)
     return res
 

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -114,6 +114,31 @@ class TestNanFunctions_MinMax(TestCase):
             assert_(res.shape == (3, 1))
             res = f(mat)
             assert_(np.isscalar(res))
+        # check that rows of nan are dealt with for subclasses (#4628)
+        mat[1] = np.nan
+        for f in self.nanfuncs:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                res = f(mat, axis=0)
+                assert_(isinstance(res, np.matrix))
+                assert_(not np.any(np.isnan(res)))
+                assert_(len(w) == 0)
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                res = f(mat, axis=1)
+                assert_(isinstance(res, np.matrix))
+                assert_(np.isnan(res[1, 0]) and not np.isnan(res[0, 0])
+                        and not np.isnan(res[2, 0]))
+                assert_(len(w) == 1, 'no warning raised')
+                assert_(issubclass(w[0].category, RuntimeWarning))
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                res = f(mat)
+                assert_(np.isscalar(res))
+                assert_(res != np.nan)
+                assert_(len(w) == 0)
 
 
 class TestNanFunctions_ArgminArgmax(TestCase):


### PR DESCRIPTION
In https://github.com/astropy/astropy/issues/2340, it was noticed that `np.nanmax` on the `ndarray` subclass `Quantity` did not work properly. This can be traced to the arguments to the `_copyto` call in `numpy.lib/nanfunctions` not being in the correct order:

```
res = _copyto(res, mask, np.nan)
```

while the call sequence to `_copyto` is

```
def _copyto(a, val, mask):
```

This PR corrects the two occurrences of this mistake. 

Obviously, it should also add test cases, and the simplest would seem to be to run all the ones in `test_nanfunctions.py` with an `ndarray` subclass. Is there an easy way to implement this?
