### PR TITLE
BLD: remove "-Wl,-framework,Python" from linker flags for Intel compiler...

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -68,7 +68,7 @@ class IntelFCompiler(BaseIntelFCompiler):
                 opt.remove('-shared')
             except ValueError:
                 idx = 0
-            opt[idx:idx] = ['-dynamiclib', '-Wl,-undefined,dynamic_lookup', '-Wl,-framework,Python']
+            opt[idx:idx] = ['-dynamiclib', '-Wl,-undefined,dynamic_lookup']
         return opt
 
 class IntelItaniumFCompiler(IntelFCompiler):


### PR DESCRIPTION
....

The "-Wl,-undefined,dynamic_lookup" flag is enough to make things work
with OS X bundles.  On the mailing list an issue was reported with
Anaconda (non-framework build) where f2py was picking up the system framework
Python instead of the Anaconda one.

Thanks to @rkern for explaining how to fix this.
