### PR TITLE
Fixing the `poly2herm` example import line

### DIFF
--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -110,7 +110,7 @@ def poly2herm(pol) :
 
     Examples
     --------
-    >>> from numpy.polynomial.hermite_e import poly2herme
+    >>> from numpy.polynomial.hermite import poly2herm
     >>> poly2herm(np.arange(4))
     array([ 1.   ,  2.75 ,  0.5  ,  0.375])
 


### PR DESCRIPTION
Just a quick commit fixing the `import` line on the `poly2herm` [example](http://docs.scipy.org/doc/numpy/reference/generated/numpy.polynomial.hermite.poly2herm.html#numpy.polynomial.hermite.poly2herm)

It was originally using the same `import` line from the `poly2herme` [example](http://docs.scipy.org/doc/numpy/reference/generated/numpy.polynomial.hermite_e.poly2herme.html#numpy.polynomial.hermite_e.poly2herme)
