### PR TITLE
Fix np.genfromtxt field name handling when dtype != None

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1426,7 +1426,11 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         names = validate_names(names)
     # Get the dtype
     if dtype is not None:
-        dtype = easy_dtype(dtype, defaultfmt=defaultfmt, names=names)
+        dtype = easy_dtype(dtype, defaultfmt=defaultfmt, names=names,
+                           excludelist=excludelist,
+                           deletechars=deletechars,
+                           case_sensitive=case_sensitive,
+                           replace_space=replace_space)
     # Make sure the names is a list (for 2.5)
     if names is not None:
         names = list(names)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1465,6 +1465,30 @@ M   33  21.99
         ctrl = np.array((1, 2, 3.14), dtype=ctrl_dtype)
         assert_equal(test, ctrl)
 
+    def test_replace_space_known_dtype(self):
+        "Test the 'replace_space' (and related) options when dtype != None"
+        txt = "A.A, B (B), C:C\n1, 2, 3"
+        # Test default: replace ' ' by '_' and delete non-alphanum chars
+        test = np.genfromtxt(TextIO(txt),
+                             delimiter=",", names=True, dtype=int)
+        ctrl_dtype = [("AA", int), ("B_B", int), ("CC", int)]
+        ctrl = np.array((1, 2, 3), dtype=ctrl_dtype)
+        assert_equal(test, ctrl)
+        # Test: no replace, no delete
+        test = np.genfromtxt(TextIO(txt),
+                             delimiter=",", names=True, dtype=int,
+                             replace_space='', deletechars='')
+        ctrl_dtype = [("A.A", int), ("B (B)", int), ("C:C", int)]
+        ctrl = np.array((1, 2, 3), dtype=ctrl_dtype)
+        assert_equal(test, ctrl)
+        # Test: no delete (spaces are replaced by _)
+        test = np.genfromtxt(TextIO(txt),
+                             delimiter=",", names=True, dtype=int,
+                             deletechars='')
+        ctrl_dtype = [("A.A", int), ("B_(B)", int), ("C:C", int)]
+        ctrl = np.array((1, 2, 3), dtype=ctrl_dtype)
+        assert_equal(test, ctrl)
+
     def test_incomplete_names(self):
         "Test w/ incomplete names"
         data = "A,,C\n0,1,2\n3,4,5"


### PR DESCRIPTION
`np.genfromtxt` validates field names twice: once in `genfromtxt` and once in `easy_dtype`.  Whilst the arguments to `genfromtxt` are used in the first validation, they aren't passed to `easy_dtype` (which is used only when `dtype != None`) and therefore in this case the default validation (strip non-alphanum, replace spaces) gets confusingly applied, ignoring `genfromtxt`'s arguments.

This patch adds failing tests for the issue and fixes `genfromtxt` by passing the appropriate arguments onwards to `easy_dtype`.

This is probably the least invasive way to fix the issue.  In my opinion, the whole thing is a nest of poorly-defined responsibilities between `genfromtxt`, `easy_dtype` and `NameValidator`, especially since the latter two are only used in the former.  I'm willing to take the time to try and clean that up if it's likely to be well-received.
