### PR TITLE
Fix for #4655: Make fftpack._raw_fft threadsafe

### DIFF
--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -53,10 +53,9 @@ def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,
         raise ValueError("Invalid number of FFT data points (%d) specified." % n)
 
     try:
-        wsave = fft_cache[n]
-    except(KeyError):
+        wsave = fft_cache.setdefault(n, []).pop()
+    except (IndexError):
         wsave = init_function(n)
-        fft_cache[n] = wsave
 
     if a.shape[axis] != n:
         s = list(a.shape)
@@ -77,6 +76,7 @@ def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,
     r = work_function(a, wsave)
     if axis != -1:
         r = swapaxes(r, axis, -1)
+    fft_cache[n].append(wsave)
     return r
 
 

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -53,6 +53,9 @@ def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,
         raise ValueError("Invalid number of FFT data points (%d) specified." % n)
 
     try:
+        # Thread-safety note: We rely on list.pop() here to atomically
+        # retrieve-and-remove a wsave from the cache.  This ensures that no
+        # other thread can get the same wsave while we're using it.
         wsave = fft_cache.setdefault(n, []).pop()
     except (IndexError):
         wsave = init_function(n)
@@ -76,7 +79,12 @@ def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,
     r = work_function(a, wsave)
     if axis != -1:
         r = swapaxes(r, axis, -1)
+
+    # As soon as we put wsave back into the cache, another thread could pick it
+    # up and start using it, so we must not do this until after we're
+    # completely done using it ourselves.
     fft_cache[n].append(wsave)
+
     return r
 
 

--- a/numpy/fft/tests/test_fftpack.py
+++ b/numpy/fft/tests/test_fftpack.py
@@ -1,7 +1,8 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal
+from numpy.testing import TestCase, run_module_suite, assert_array_equal, assert_array_almost_equal
+import threading, Queue
 
 def fft1(x):
     L = len(x)
@@ -21,6 +22,42 @@ class TestFFT1D(TestCase):
         rand = np.random.random
         x = rand(30) + 1j*rand(30)
         assert_array_almost_equal(fft1(x), np.fft.fft(x))
+
+
+class TestFFTThreadSafe(TestCase):
+    threads = 32
+    input_shape = (1000, 1000)
+
+    def _test_mtsame(self, func, *args):
+        def worker(args, q):
+            q.put(func(*args))
+
+        q = Queue.Queue()
+        expected = func(*args)
+
+        # Spin off a bunch of threads to call the same function simultaneously
+        for i in xrange(self.threads):
+            threading.Thread(target=worker, args=(args, q)).start()
+
+        # Make sure all threads returned the correct value
+        for i in xrange(self.threads):
+            assert_array_equal(q.get(), expected, 'Function returned wrong value in multithreaded context')
+
+    def test_fft(self):
+        a = np.ones(self.input_shape) * 1+0j
+        self._test_mtsame(np.fft.fft, a)
+
+    def test_ifft(self):
+        a = np.ones(self.input_shape) * 1+0j
+        self._test_mtsame(np.fft.ifft, a)
+
+    def test_rfft(self):
+        a = np.ones(self.input_shape)
+        self._test_mtsame(np.fft.rfft, a)
+
+    def test_irfft(self):
+        a = np.ones(self.input_shape) * 1+0j
+        self._test_mtsame(np.fft.irfft, a)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch replaces the naive dictionary-cache implementation in _raw_fft with an equivalent cache that will perform correctly in a multithreaded context.
