### PR TITLE
BUG: cythonize sources for wheel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: NPY_RELAXED_STRIDES_CHECKING=1
     - python: 2.7
       env: USE_BENTO=1
+    - python: 2.7
+      env: USE_WHEEL=1
 before_install:
   - uname -a
   - free -m

--- a/setup.py
+++ b/setup.py
@@ -228,12 +228,10 @@ def setup_package():
 
         FULLVERSION, GIT_REVISION = get_version_info()
         metadata['version'] = FULLVERSION
-    elif len(sys.argv) >= 2 and sys.argv[1] == 'bdist_wheel':
-        # bdist_wheel needs setuptools
-        import setuptools
-        from numpy.distutils.core import setup
-        metadata['configuration'] = configuration
     else:
+        if len(sys.argv) >= 2 and sys.argv[1] == 'bdist_wheel':
+            # bdist_wheel needs setuptools
+            import setuptools
         from numpy.distutils.core import setup
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -110,7 +110,13 @@ fi
 
 export PYTHON
 export PIP
-if [ "$USE_CHROOT" != "1" ] && [ "$USE_BENTO" != "1" ]; then
+if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
+  $PIP install --upgrade pip
+  $PIP install wheel
+  $PYTHON setup.py bdist_wheel
+  $PIP install --pre --upgrade --find-links dist numpy
+  run_test
+elif [ "$USE_CHROOT" != "1" ] && [ "$USE_BENTO" != "1" ]; then
   setup_base
   run_test
 elif [ -n "$USE_CHROOT" ] && [ $# -eq 0 ]; then


### PR DESCRIPTION
Wheel build was not cythonizing sources, giving a compile error because needed
`numpy/random/mtrand/mtrand.c` was missing.
