### PR TITLE
DOC/FIX: Fix error in documentation

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -287,10 +287,6 @@ def column_stack(tup):
     --------
     hstack, vstack, concatenate
 
-    Notes
-    -----
-    This function is equivalent to ``np.vstack(tup).T``.
-
     Examples
     --------
     >>> a = np.array((1,2,3))


### PR DESCRIPTION
Remove misleading note about equivalency column_stack and np.vstack(tup).T.

Fixes #3488
