### PR TITLE
BUG: Fix use of setuptools.command.install._install.

### DIFF
--- a/numpy/distutils/command/install.py
+++ b/numpy/distutils/command/install.py
@@ -7,8 +7,9 @@ if 'setuptools' in sys.modules:
 else:
     import distutils.command.install as old_install_mod
     have_setuptools = False
-old_install = old_install_mod.install
 from distutils.file_util import write_file
+
+old_install = old_install_mod.install
 
 class install(old_install):
 
@@ -28,9 +29,11 @@ class install(old_install):
         We must pull in the entire code so we can override the level used in the
         _getframe() call since we wrap this call by one more level.
         """
+        from distutils.command.install import install as distutils_install
+
         # Explicit request for old-style install?  Just do it
         if self.old_and_unmanageable or self.single_version_externally_managed:
-            return old_install_mod._install.run(self)
+            return distutils_install.run(self)
 
         # Attempt to detect whether we were called from setup() or by another
         # command.  If we were called by setup(), our caller will be the
@@ -48,7 +51,7 @@ class install(old_install):
             # We weren't called from the command line or setup(), so we
             # should run in backward-compatibility mode to support bdist_*
             # commands.
-            old_install_mod._install.run(self)
+            distutils_install.run(self)
         else:
             self.do_egg_install()
 


### PR DESCRIPTION
This private variable has disappeared in later versions of setuptools.
In older versions of setuptools it is the same as
distutils.command.install.install, so use that instead.

Closes #4664.
