### PR TITLE
ENH: Break out early of loop in argmin/max for bool, fixes #4659

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2714,6 +2714,7 @@ finish:
  *         npy_half, npy_float, npy_double, npy_longdouble,
  *         npy_float, npy_double, npy_longdouble,
  *         npy_datetime, npy_timedelta#
+ * #isbool = 1, 0*19#
  * #isfloat = 0*11, 1*7, 0*2#
  * #isnan = nop*11, npy_half_isnan, npy_isnan*6, nop*2#
  * #le = _LESS_THAN_OR_EQUAL*11, npy_half_le, _LESS_THAN_OR_EQUAL*8#
@@ -2741,6 +2742,12 @@ static int
 #if @iscomplex@
     if (@isnan@(mp_im)) {
         /* nan encountered; it's maximal */
+        return 0;
+    }
+#endif
+#if @isbool@
+    if (mp) {
+        /* True encountered; it's maximal */
         return 0;
     }
 #endif
@@ -2772,6 +2779,12 @@ static int
                 break;
             }
 #endif
+#if @isbool@
+            if (mp) {
+                /* True encountered; it's maximal */
+                break;
+            }
+#endif
         }
 #endif
     }
@@ -2794,6 +2807,7 @@ static int
  *         npy_half, npy_float, npy_double, npy_longdouble,
  *         npy_float, npy_double, npy_longdouble,
  *         npy_datetime, npy_timedelta#
+ * #isbool = 1, 0*19#
  * #isfloat = 0*11, 1*7, 0*2#
  * #isnan = nop*11, npy_half_isnan, npy_isnan*6, nop*2#
  * #le = _LESS_THAN_OR_EQUAL*11, npy_half_le, _LESS_THAN_OR_EQUAL*8#
@@ -2824,6 +2838,12 @@ static int
         return 0;
     }
 #endif
+#if @isbool@
+    if (!mp) {
+        /* False encountered; it's minimal */
+        return 0;
+    }
+#endif
 
     for (i = 1; i < n; i++) {
         @incr@;
@@ -2849,6 +2869,12 @@ static int
 #if @isfloat@
             if (@isnan@(mp)) {
                 /* nan encountered, it's minimal */
+                break;
+            }
+#endif
+#if @isbool@
+            if (!mp) {
+                /* False encountered; it's minimal */
                 break;
             }
 #endif

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2058,6 +2058,11 @@ class TestArgmax(TestCase):
         ([timedelta(days=10, seconds=24), timedelta(days=10, seconds=5),
           timedelta(days=10, seconds=43)], 2),
 
+        ([False, False, False, False, True], 4),
+        ([False, False, False, True, False], 3),
+        ([True, False, False, False, False], 0),
+        ([True, False, True, False, False], 0),
+
         # Can't reduce a "flexible type"
         #(['a', 'z', 'aa', 'zz'], 3),
         #(['zz', 'a', 'aa', 'a'], 0),
@@ -2143,6 +2148,11 @@ class TestArgmin(TestCase):
           timedelta(days=5, seconds=14)], 0),
         ([timedelta(days=10, seconds=24), timedelta(days=10, seconds=5),
           timedelta(days=10, seconds=43)], 1),
+
+        ([True, True, True, True, False], 4),
+        ([True, True, True, False, True], 3),
+        ([False, True, True, True, True], 0),
+        ([False, True, False, True, True], 0),
 
         # Can't reduce a "flexible type"
         #(['a', 'z', 'aa', 'zz'], 0),


### PR DESCRIPTION
Break out early of loop if the min (max) found is `False` (`True`) when
`argmin` (`argmax`) is called on an array of type `bool`.
