### PR TITLE
BUG: reject too large seeds to RandomState

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -112,6 +112,14 @@ performed, and hence the sequence location will be different after a
 call to distribution.c::rk_binomial_btpe. Any tests which rely on the RNG
 being in a known state should be checked and/or updated as a result.
 
+Random seed enforced to be a 32 bit unsigned integer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``np.random.seed`` and ``np.random.RandomState`` now throw a ``ValueError``
+if the seed cannot safely be converted to 32 bit unsigned integers.
+Applications that now fail can be fixed by masking the higher 32 bit values to
+zero: ``seed = seed & 0xFFFFFFFF``. This is what is done silently in older
+versions so the random stream remains the same.
+
 New Features
 ============
 

--- a/numpy/random/mtrand/numpy.pxd
+++ b/numpy/random/mtrand/numpy.pxd
@@ -121,6 +121,8 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_IterNew(object arr)
     void PyArray_ITER_NEXT(flatiter it) nogil
 
+    dtype PyArray_DescrFromType(int)
+
     void import_array()
 
 # include functions that were once macros in the new api

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -7,6 +7,35 @@ from numpy.testing import (
 from numpy import random
 from numpy.compat import asbytes
 
+class TestSeed(TestCase):
+    def test_scalar(self):
+        s = np.random.RandomState(0)
+        assert_equal(s.randint(1000), 684)
+        s = np.random.RandomState(4294967295)
+        assert_equal(s.randint(1000), 419)
+
+    def test_array(self):
+        s = np.random.RandomState(range(10))
+        assert_equal(s.randint(1000), 468)
+        s = np.random.RandomState(np.arange(10))
+        assert_equal(s.randint(1000), 468)
+        s = np.random.RandomState([0])
+        assert_equal(s.randint(1000), 973)
+        s = np.random.RandomState([4294967295])
+        assert_equal(s.randint(1000), 265)
+
+    def test_invalid_scalar(self):
+        # seed must be a unsigned 32 bit integers
+        assert_raises(TypeError, np.random.RandomState, -0.5)
+        assert_raises(ValueError, np.random.RandomState, -1)
+
+    def test_invalid_array(self):
+        # seed must be a unsigned 32 bit integers
+        assert_raises(TypeError, np.random.RandomState, [-0.5])
+        assert_raises(ValueError, np.random.RandomState, [-1])
+        assert_raises(ValueError, np.random.RandomState, [4294967296])
+        assert_raises(ValueError, np.random.RandomState, [1, 2, 4294967296])
+        assert_raises(ValueError, np.random.RandomState, [1, -2, 4294967296])
 
 class TestBinomial(TestCase):
     def test_n_zero(self):


### PR DESCRIPTION
mtrand accepts seeds larger than 32 bit but silently truncates them back
to 32 bit. This can lead to accidentally getting the same random stream
for two different seeds, e.g. 1 and 1 + 2**40.
