### PR TITLE
BUG: Fix test error in scipy introduced by commit d8fd283.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7018,8 +7018,6 @@ def asarray(a, dtype=None, order=None):
     <class 'numpy.ma.core.MaskedArray'>
 
     """
-    if dtype is None and type(a) is MaskedArray:
-        return a
     return masked_array(a, dtype=dtype, copy=False, keep_mask=True, subok=False)
 
 def asanyarray(a, dtype=None):
@@ -7065,8 +7063,6 @@ def asanyarray(a, dtype=None):
     <class 'numpy.ma.core.MaskedArray'>
 
     """
-    if dtype is None and isinstance(a, MaskedArray):
-        return a
     return masked_array(a, dtype=dtype, copy=False, keep_mask=True, subok=True)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -186,24 +186,11 @@ class TestMaskedArray(TestCase):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         xm.fill_value = -9999
         xm._hardmask = True
-        xmm = asarray(xm, xm.dtype)
+        xmm = asarray(xm)
         assert_equal(xmm._data, xm._data)
         assert_equal(xmm._mask, xm._mask)
         assert_equal(xmm.fill_value, xm.fill_value)
         assert_equal(xmm._hardmask, xm._hardmask)
-        # address gh-4043
-        self.assertTrue(xm is asarray(xm))
-
-    def test_asanyarray(self):
-        class M(MaskedArray):
-            pass
-        xm = M([])
-        self.assertTrue(xm is not asarray(xm))
-        # address gh-4043
-        self.assertTrue(xm is asanyarray(xm))
-        test = asanyarray(xm, np.int64)
-        self.assertTrue(isinstance(test, M))
-        assert_equal(test.dtype, np.int64)
 
     def test_fix_invalid(self):
         # Checks fix_invalid.


### PR DESCRIPTION
Revert "ENH: ma.asarray() and ma.asanyarray() will pass through input
        of the correct type."

This reverts commit d8fd28389adb491e24b7cdc25cd1b20f539310c3.

That commit caused test errors in scipy, which was apparently
expecting a copy rather than a passed through array. The idea
may be good, but at a minimum it should probably be preceded
by a deprecation period.

Closes #4675.
