### PR TITLE
BUG: argwhere is not equivalent to transpose(nonzero(...)))

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -767,7 +767,7 @@ def argwhere(a):
            [1, 2]])
 
     """
-    return transpose(asanyarray(a).nonzero())
+    return transpose(nonzero(a))
 
 def flatnonzero(a):
     """


### PR DESCRIPTION
This is the cause of https://github.com/scipy/scipy/issues/3621.

`np.nonzero` already takes care of non-ndarray inputs, and it tends to do a better job of it. This change simply gets rid of unnecessary code.
