### PR TITLE
BUG: mtrand binomial algorithm is different from original paper algorithm

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -104,6 +104,14 @@ base class ABCPolyBase. Strictly speaking, there should be a deprecation
 involved, but no external code making use of the old baseclass could be
 found.
 
+Using numpy.random.binomial may change the RNG state vs. numpy < 1.9
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A bug in one of the algorithms to generate a binomial random variate has
+been fixed. This change will likely alter the number of random draws
+performed, and hence the sequence location will be different after a
+call to distribution.c::rk_binomial_btpe. Any tests which rely on the RNG
+being in a known state should be checked and/or updated as a result.
+
 New Features
 ============
 

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -323,23 +323,20 @@ long rk_binomial_btpe(rk_state *state, long n, double p)
     F = 1.0;
     if (m < y)
     {
-        for (i=m; i<=y; i++)
+        for (i=m+1; i<=y; i++)
         {
             F *= (a/i - s);
         }
     }
     else if (m > y)
     {
-        for (i=y; i<=m; i++)
+        for (i=y+1; i<=m; i++)
         {
             F /= (a/i - s);
         }
     }
-    else
-    {
-        if (v > F) goto Step10;
-        goto Step60;
-    }
+    if (v > F) goto Step10;
+    goto Step60;
 
     Step52:
     rho = (k/(nrq))*((k*(k/3.0 + 0.625) + 0.16666666666666666)/nrq + 0.5);


### PR DESCRIPTION
Proposed fix for issue 2012:
https://github.com/numpy/numpy/issues/2012

Also relevant is the discussion on scipy-user:
http://mail.scipy.org/pipermail/scipy-user/2012-October/033299.html

The else block should not be conditional (i.e., remove the else, {, }, and properly indent).
Also the counting variables need a +1.
