### PR TITLE
BUG: fix crash when sending interrupt signal to fft functions

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -73,6 +73,16 @@
         #define NPY_INLINE
 #endif
 
+#ifdef HAVE___THREAD
+    #define NPY_TLS __thread
+#else
+    #ifdef HAVE___DECLSPEC_THREAD_
+        #define NPY_TLS __declspec(thread)
+    #else
+        #define NPY_TLS
+    #endif
+#endif
+
 #ifdef WITH_CPYCHECKER_RETURNS_BORROWED_REF_ATTRIBUTE
   #define NPY_RETURNS_BORROWED_REF \
     __attribute__((cpychecker_returns_borrowed_ref))

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -180,6 +180,11 @@ def check_math_capabilities(config, moredefs, mathlibs):
                              call=False):
             moredefs.append((fname2def(fn), 1))
 
+    for fn in ("__thread", "__declspec(thread)"):
+        if config.check_func(fn, decl='int %s a;' % (fn), call=False):
+            m = fn.replace("(", "_").replace(")", "_")
+            moredefs.append((fname2def(m), 1))
+
     # C99 functions: float and long double versions
     check_funcs(C99_FUNCS_SINGLE)
     check_funcs(C99_FUNCS_EXTENDED)

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -175,12 +175,12 @@ def check_math_capabilities(config, moredefs, mathlibs):
                              headers=headers):
             moredefs.append((fname2def(f), 1))
 
-    for dec, fn in OPTIONAL_GCC_ATTRIBUTES:
+    for dec, fn in OPTIONAL_FUNCTION_ATTRIBUTES:
         if config.check_func(fn, decl='int %s %s(void *);' % (dec, fn),
                              call=False):
             moredefs.append((fname2def(fn), 1))
 
-    for fn in ("__thread", "__declspec(thread)"):
+    for fn in OPTIONAL_VARIABLE_ATTRIBUTES:
         if config.check_func(fn, decl='int %s a;' % (fn), call=False):
             m = fn.replace("(", "_").replace(")", "_")
             moredefs.append((fname2def(m), 1))

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -121,16 +121,19 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        ("_mm_load_pd", '(double*)0', "emmintrin.h"), # SSE2
                        ]
 
-# gcc function attributes
-# (attribute as understood by gcc, function name),
+# function attributes
+# tested via "int %s %s(void *);" % (attribute, name)
 # function name will be converted to HAVE_<upper-case-name> preprocessor macro
-OPTIONAL_GCC_ATTRIBUTES = [('__attribute__((optimize("unroll-loops")))',
-                            'attribute_optimize_unroll_loops'),
-                            ('__attribute__((optimize("O3")))',
-                             'attribute_optimize_opt_3'),
-                            ('__attribute__((nonnull (1)))',
-                             'attribute_nonnull'),
-                          ]
+OPTIONAL_FUNCTION_ATTRIBUTES = [('__attribute__((optimize("unroll-loops")))',
+                                'attribute_optimize_unroll_loops'),
+                                ('__attribute__((optimize("O3")))',
+                                 'attribute_optimize_opt_3'),
+                                ('__attribute__((nonnull (1)))',
+                                 'attribute_nonnull'),
+                               ]
+
+# variable attributes tested via "int %s a" % attribute
+OPTIONAL_VARIABLE_ATTRIBUTES = ["__thread", "__declspec(thread)"]
 
 # Subset of OPTIONAL_STDFUNCS which may alreay have HAVE_* defined by Python.h
 OPTIONAL_STDFUNCS_MAYBE = ["expm1", "log1p", "acosh", "atanh", "asinh", "hypot",

--- a/numpy/fft/fftpack_litemodule.c
+++ b/numpy/fft/fftpack_litemodule.c
@@ -44,14 +44,14 @@ fftpack_cfftf(PyObject *NPY_UNUSED(self), PyObject *args)
 
     nrepeats = PyArray_SIZE(data)/npts;
     dptr = (double *)PyArray_DATA(data);
-    NPY_SIGINT_ON;
     Py_BEGIN_ALLOW_THREADS;
+    NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
         cfftf(npts, dptr, wsave);
         dptr += npts*2;
     }
-    Py_END_ALLOW_THREADS;
     NPY_SIGINT_OFF;
+    Py_END_ALLOW_THREADS;
     PyArray_Free(op2, (char *)wsave);
     return (PyObject *)data;
 
@@ -97,14 +97,14 @@ fftpack_cfftb(PyObject *NPY_UNUSED(self), PyObject *args)
 
     nrepeats = PyArray_SIZE(data)/npts;
     dptr = (double *)PyArray_DATA(data);
-    NPY_SIGINT_ON;
     Py_BEGIN_ALLOW_THREADS;
+    NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
         cfftb(npts, dptr, wsave);
         dptr += npts*2;
     }
-    Py_END_ALLOW_THREADS;
     NPY_SIGINT_OFF;
+    Py_END_ALLOW_THREADS;
     PyArray_Free(op2, (char *)wsave);
     return (PyObject *)data;
 
@@ -134,11 +134,11 @@ fftpack_cffti(PyObject *NPY_UNUSED(self), PyObject *args)
         return NULL;
     }
 
-    NPY_SIGINT_ON;
     Py_BEGIN_ALLOW_THREADS;
+    NPY_SIGINT_ON;
     cffti(n, (double *)PyArray_DATA((PyArrayObject*)op));
-    Py_END_ALLOW_THREADS;
     NPY_SIGINT_OFF;
+    Py_END_ALLOW_THREADS;
 
     return (PyObject *)op;
 }
@@ -188,8 +188,8 @@ fftpack_rfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     dptr = (double *)PyArray_DATA(data);
 
 
-    NPY_SIGINT_ON;
     Py_BEGIN_ALLOW_THREADS;
+    NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
         memcpy((char *)(rptr+1), dptr, npts*sizeof(double));
         rfftf(npts, rptr+1, wsave);
@@ -198,8 +198,8 @@ fftpack_rfftf(PyObject *NPY_UNUSED(self), PyObject *args)
         rptr += rstep;
         dptr += npts;
     }
-    Py_END_ALLOW_THREADS;
     NPY_SIGINT_OFF;
+    Py_END_ALLOW_THREADS;
     PyArray_Free(op2, (char *)wsave);
     Py_DECREF(data);
     return (PyObject *)ret;
@@ -252,8 +252,8 @@ fftpack_rfftb(PyObject *NPY_UNUSED(self), PyObject *args)
     rptr = (double *)PyArray_DATA(ret);
     dptr = (double *)PyArray_DATA(data);
 
-    NPY_SIGINT_ON;
     Py_BEGIN_ALLOW_THREADS;
+    NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
         memcpy((char *)(rptr + 1), (dptr + 2), (npts - 1)*sizeof(double));
         rptr[0] = dptr[0];
@@ -261,8 +261,8 @@ fftpack_rfftb(PyObject *NPY_UNUSED(self), PyObject *args)
         rptr += npts;
         dptr += npts*2;
     }
-    Py_END_ALLOW_THREADS;
     NPY_SIGINT_OFF;
+    Py_END_ALLOW_THREADS;
     PyArray_Free(op2, (char *)wsave);
     Py_DECREF(data);
     return (PyObject *)ret;
@@ -294,11 +294,11 @@ fftpack_rffti(PyObject *NPY_UNUSED(self), PyObject *args)
   if (op == NULL) {
       return NULL;
   }
-  NPY_SIGINT_ON;
   Py_BEGIN_ALLOW_THREADS;
+  NPY_SIGINT_ON;
   rffti(n, (double *)PyArray_DATA((PyArrayObject*)op));
-  Py_END_ALLOW_THREADS;
   NPY_SIGINT_OFF;
+  Py_END_ALLOW_THREADS;
 
   return (PyObject *)op;
 }


### PR DESCRIPTION
the SIGINT handling code must be in the GIL released section so the
longjmp does not skip the retaking.
This implies that the signal handlers must use thread local storage to
avoid a crash when sending interrupt to threaded fft functions.
Distribution of SIGINT to each threads must be handled by the
application as only the master thread receives it
Closes gh-4634
