### PR TITLE
Fix for unclear resize() error message

### DIFF
--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -93,7 +93,8 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
                 || (PyArray_BASE(self) != NULL)
                 || (((PyArrayObject_fields *)self)->weakreflist != NULL)) {
             PyErr_SetString(PyExc_ValueError,
-                    "cannot resize an array references or is referenced\n"\
+                    "cannot resize an array that "\
+                    "references or is referenced\n"\
                     "by another array in this way.  Use the resize function");
             return NULL;
         }


### PR DESCRIPTION
When attempting to resize an array that is referenced elsewhere, the following error message appears:

```
In [4]: a.resize(3,2)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-265528f898a8> in <module>()
----> 1 a.resize(3,2)

ValueError: cannot resize an array references or is referenced
by another array in this way.  Use the resize function
```

This message confused me because it is not a proper sentence. It should say:
"cannot resize an array **that** references or is referenced by ..."

=> PR attached
