### PR TITLE
BUG: searchsorted fails if sorter is not of type np.intp fixes #4698

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2030,12 +2030,12 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
         NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(ap2));
         error = argbinsearch((const char *)PyArray_DATA(ap1),
                              (const char *)PyArray_DATA(ap2),
-                             (const char *)PyArray_DATA(ap3),
+                             (const char *)PyArray_DATA(sorter),
                              (char *)PyArray_DATA(ret),
                              PyArray_SIZE(ap1), PyArray_SIZE(ap2),
                              PyArray_STRIDES(ap1)[0],
                              PyArray_DESCR(ap2)->elsize,
-                             PyArray_STRIDES(ap3)[0], NPY_SIZEOF_INTP, ap2);
+                             PyArray_STRIDES(sorter)[0], NPY_SIZEOF_INTP, ap2);
         NPY_END_THREADS_DESCR(PyArray_DESCR(ap2));
         if (error < 0) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1212,11 +1212,15 @@ class TestMethods(TestCase):
                 dt = 'M8[D]'
             if dt == '?':
                 a = np.array([1, 0], dtype=dt)
-                s = [1, 0]
+                # We want the sorter array to be of a type that is different
+                # from np.intp in all platforms, to check for #4698
+                s = np.array([1, 0], dtype=np.int16)
                 out = np.array([1, 0])
             else:
                 a = np.array([3, 4, 1, 2, 0], dtype=dt)
-                s = [4, 2, 3, 0, 1]
+                # We want the sorter array to be of a type that is different
+                # from np.intp in all platforms, to check for #4698
+                s = np.array([4, 2, 3, 0, 1], dtype=np.int16)
                 out = np.array([3, 4, 1, 2, 0], dtype=np.intp)
             b = a.searchsorted(a, 'l', s)
             assert_equal(b, out)


### PR DESCRIPTION
The array being passed to the search function was not the one converted
to NPY_INTP, so it only worked if it was of that type to begin with.
