### PR TITLE
BUG: core: allow scalar type richcompare to call ndarray-subclass methods

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1082,7 +1082,11 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
     if (arr == NULL) {
         return NULL;
     }
-    ret = Py_TYPE(arr)->tp_richcompare(arr, other, cmp_op);
+    /*
+     * Call via PyObject_RichCompare to ensure that other.__eq__
+     * has a chance to run when necessary
+     */
+    ret = PyObject_RichCompare(arr, other, cmp_op);
     Py_DECREF(arr);
     return ret;
 }

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1993,6 +1993,16 @@ class TestRegression(TestCase):
         assert_(not op.eq(lhs, rhs))
         assert_(op.ne(lhs, rhs))
 
+    def test_richcompare_scalar_and_subclass(self):
+        # gh-4709
+        class Foo(np.ndarray):
+            def __eq__(self, other):
+                return "OK"
+        x = np.array([1,2,3]).view(Foo)
+        assert_equal(10 == x, "OK")
+        assert_equal(np.int32(10) == x, "OK")
+        assert_equal(np.array([10]) == x, "OK")
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This makes the scalar richcmp behave exactly as
"array(self) &lt;op&gt; other". The difference comes in when "other" is an ndarray
subclass, in which case this change allows the subclass to override the
comparison operations via usual Python binop dispatch rules.

Fixes gh-4709
