### PR TITLE
BUG: Fix seg fault converting empty string to object

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -426,7 +426,7 @@ STRING_getitem(char *ip, PyArrayObject *ap)
     int size = PyArray_DESCR(ap)->elsize;
 
     ptr = ip + size - 1;
-    while (*ptr-- == '\0' && size > 0) {
+    while (size > 0 && *ptr-- == '\0') {
         size--;
     }
     return PyBytes_FromStringAndSize(ip,size);

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -496,6 +496,10 @@ class TestString(TestCase):
         # Issue gh-2798
         a = np.array(['a'], dtype="O").astype(("O", [("name", "O")]))
 
+    def test_empty_string_to_object(self):
+        # Pull request #4722
+        np.array(["", ""]).astype(object)
+
 class TestDtypeAttributeDeletion(object):
 
     def test_dtype_non_writable_attributes_deletion(self):


### PR DESCRIPTION
I get frequent segmentation faults when converting arrays of empty strings to objects, because the STRING_getitem function reads one byte too far before the front of the allocated memory on empty strings.

This happens in the context of reading database tables containing null values for char columns (using IOpro) and converting the results to a pandas DataFrame.

I'm using numpy 1.8.1 on Mac 10.9.3.

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   multiarray.so                   0x000000010482be80 STRING_to_OBJECT + 112
1   multiarray.so                   0x000000010482d0e6 raw_array_assign_array + 518
2   multiarray.so                   0x000000010482da16 PyArray_AssignArray + 838
3   multiarray.so                   0x000000010483bd20 PyArray_FromArray + 368
4   multiarray.so                   0x000000010483ea7b PyArray_FromAny + 203
5   multiarray.so                   0x000000010483f3f4 PyArray_CheckFromAny + 116
6   multiarray.so                   0x00000001048b86cd _array_fromobject + 653
7   libpython2.7.dylib              0x00000001000c927f PyEval_EvalFrameEx + 25135
```
