### PR TITLE
BLD: add support for OpenRISC architecture.  Closes gh-4743.

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -69,6 +69,8 @@
     #define NPY_CPU_MIPSEL
 #elif defined(__MIPSEB__)
     #define NPY_CPU_MIPSEB
+#elif defined(__or1k__)
+    #define NPY_CPU_OR1K
 #elif defined(__aarch64__)
     #define NPY_CPU_AARCH64
 #elif defined(__mc68000__)

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -38,6 +38,7 @@
             || defined(NPY_CPU_ARMEB)   \
             || defined(NPY_CPU_SH_BE)   \
             || defined(NPY_CPU_MIPSEB)  \
+            || defined(NPY_CPU_OR1K)    \
             || defined(NPY_CPU_M68K)
         #define NPY_BYTE_ORDER NPY_BIG_ENDIAN
     #else


### PR DESCRIPTION
Thanks to @manuelafm for the patch.
