### PR TITLE
modified distribution.c

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -450,7 +450,7 @@ long rk_negative_binomial(rk_state *state, double n, double p)
 {
     double Y;
 
-    Y = rk_gamma(state, n, (1-p)/p);
+    Y = rk_gamma(state, n, p/(1-p));
     return rk_poisson(state, Y);
 }
 


### PR DESCRIPTION
In documentation , p is the possibility of success.
so scale θ = p/(1 − p) rather than (1-p)/p
cite: http://en.wikipedia.org/wiki/Negative_binomial_distribution
