### PR TITLE
ENH: rewrite ma.median to improve poor performance for multiple dimensions

### DIFF
--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from numpy.testing import (
     run_module_suite, TestCase, assert_, assert_equal, assert_almost_equal,
-    assert_raises
+    assert_raises, assert_array_equal
     )
 
 
@@ -579,6 +579,22 @@ class TestNanFunctions_Median(TestCase):
         res = np.nanmedian(nan_mat, axis=(0, 1), out=resout)
         assert_almost_equal(res, resout)
         assert_almost_equal(res, tgt)
+
+    def test_small_large(self):
+        # test the small and large code paths, current cutoff 400 elements
+        for s in [5, 20, 51, 200, 1000]:
+            d = np.random.randn(4, s)
+            # Randomly set some elements to NaN:
+            w = np.random.randint(0, d.size, size=d.size // 5)
+            d.ravel()[w] = np.nan
+            d[:,0] = 1. # ensure at least one good value
+            # use normal median without nans to compare
+            tgt = []
+            for x in d:
+                nonan = np.compress(~np.isnan(x), x)
+                tgt.append(np.median(nonan, overwrite_input=True))
+
+            assert_array_equal(np.nanmedian(d, axis=-1), tgt)
 
     def test_result_values(self):
             tgt = [np.median(d) for d in _rdat]

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5082,12 +5082,12 @@ class MaskedArray(ndarray):
                     filler = maximum_fill_value(self)
             else:
                 filler = fill_value
-            idx = np.indices(self.shape)
+            idx = np.meshgrid(*[np.arange(x) for x in self.shape], sparse=True,
+                              indexing='ij')
             idx[axis] = self.filled(filler).argsort(axis=axis, kind=kind,
                                                     order=order)
-            idx_l = idx.tolist()
-            tmp_mask = self._mask[idx_l].flat
-            tmp_data = self._data[idx_l].flat
+            tmp_mask = self._mask[idx].flat
+            tmp_data = self._data[idx].flat
             self._data.flat = tmp_data
             self._mask.flat = tmp_mask
         return
@@ -6188,7 +6188,8 @@ def sort(a, axis= -1, kind='quicksort', order=None, endwith=True, fill_value=Non
     else:
         filler = fill_value
 #    return
-    indx = np.indices(a.shape).tolist()
+    indx = np.meshgrid(*[np.arange(x) for x in a.shape], sparse=True,
+                       indexing='ij')
     indx[axis] = filled(a, filler).argsort(axis=axis, kind=kind, order=order)
     return a[indx]
 sort.__doc__ = MaskedArray.sort.__doc__

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -531,6 +531,19 @@ class TestMedian(TestCase):
         x[x % 5 == 0] = masked
         assert_equal(median(x, 0), [[12, 10], [8, 9], [16, 17]])
 
+    def test_neg_axis(self):
+        x = masked_array(np.arange(30).reshape(10, 3))
+        x[:3] = x[-3:] = masked
+        assert_equal(median(x, axis=-1), median(x, axis=1))
+
+    def test_out(self):
+        x = masked_array(np.arange(30).reshape(10, 3))
+        x[:3] = x[-3:] = masked
+        out = masked_array(np.ones(10))
+        r = median(x, axis=1, out=out)
+        assert_equal(r, out)
+        assert_(type(r) == MaskedArray)
+
 
 class TestCov(TestCase):
 


### PR DESCRIPTION
many masked median along a small dimension is extremely slow due to the
usage of apply_along_axis which iterates fully in python. The unmasked
median is about 1000x faster.

Work around this issue by using indexing to select the median element
instead of apply_along_axis.

Further improvements are possible, e.g. using the current np.nanmedian
approach for masked medians along large dimensions so partition is used
instead of sort or to extend partition to allow broadcasting over
multiple elements.

Closes gh-4683.
