### PR TITLE
TST: fix random failing histogram test

### DIFF
--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -254,7 +254,7 @@ class TestHistogram2d(TestCase):
         assert_array_almost_equal(H, answer, 3)
 
     def test_all_outliers(self):
-        r = rand(100)+1.
+        r = rand(100) + 1. + 1e6 # histogramdd rounds by decimal=6
         H, xed, yed = histogram2d(r, r, (4, 5), range=([0, 1], [0, 1]))
         assert_array_equal(H, 0)
 


### PR DESCRIPTION
histogramdd rounds by decimal=6 so the random numbers may not be
outliers if they are below 1. + 1e6
