### PR TITLE
Fix minor error in "squeeze" docstring

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1090,7 +1090,7 @@ def squeeze(a, axis=None):
     Returns
     -------
     squeezed : ndarray
-        The input array, but with with all or a subset of the
+        The input array, but with all or a subset of the
         dimensions of length 1 removed. This is always `a` itself
         or a view into `a`.
 


### PR DESCRIPTION
Noticed a minor error in the "squeeze" docstring while reading about it. 
