### PR TITLE
DOC: Fix indentation and add missing blank lines for meshgrid doc.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3288,10 +3288,12 @@ def meshgrid(*xi, **kwargs):
     indexing : {'xy', 'ij'}, optional
         Cartesian ('xy', default) or matrix ('ij') indexing of output.
         See Notes for more details.
-       .. versionadded:: 1.7.0
+
+        .. versionadded:: 1.7.0
     sparse : bool, optional
-         If True a sparse grid is returned in order to conserve memory.
-         Default is False.
+        If True a sparse grid is returned in order to conserve memory.
+        Default is False.
+
         .. versionadded:: 1.7.0
     copy : bool, optional
         If False, a view into the original arrays are returned in order to
@@ -3300,7 +3302,8 @@ def meshgrid(*xi, **kwargs):
         arrays.  Furthermore, more than one element of a broadcast array
         may refer to a single memory location.  If you need to write to the
         arrays, make copies first.
-       .. versionadded:: 1.7.0
+
+        .. versionadded:: 1.7.0
 
     Returns
     -------


### PR DESCRIPTION
.. versionadded:: had wrong indentation and needed preceding blank line to render correctly. Might be good to have a version of this that was cleaner for use in arguments.
