### PR TITLE
BLD: add a simple python file to build cpucaps.dll

### DIFF
--- a/tools/win32build/README.txt
+++ b/tools/win32build/README.txt
@@ -48,6 +48,8 @@ cpuid. To build it, you have two options:
         - with scons: if you have scons, just do scons install. It will build
           and put the CpuCaps.dll  in the plugins directory of nsis (if you
           install nsis in the default path).
+        - run build-cpucaps.py with a windows python, e.g.
+          wine "C:\Python27\python" build-cpucaps.py
 
 build.py:
 ---------

--- a/tools/win32build/build-cpucaps.py
+++ b/tools/win32build/build-cpucaps.py
@@ -1,0 +1,15 @@
+import os
+import subprocess
+# build cpucaps.dll
+# needs to be run in tools/win32build folder under wine
+# e.g. wine "C:\Python27\python" build-cpucaps.py
+cc = os.environ.get('CC', 'gcc')
+fmt = (cc, os.getcwd())
+cmd = '"{0}" -o cpucaps_main.o -c -W -Wall "-I{1}/cpuid" "-I{1}/cpucaps" cpucaps/cpucaps_main.c'.format(*fmt)
+subprocess.check_call(cmd, shell=True)
+cmd = '"{0}" -o cpuid.o -c -W -Wall "-I{1}/cpuid" cpuid/cpuid.c'.format(*fmt)
+subprocess.check_call(cmd, shell=True)
+cmd = '"{0}" -shared -Wl,--out-implib,libcpucaps.a -o cpucaps.dll cpuid.o cpucaps_main.o'.format(*fmt)
+subprocess.check_call(cmd, shell=True)
+os.remove('cpuid.o')
+os.remove('cpucaps_main.o')


### PR DESCRIPTION
using scons seems to fail with wine 1.6, but one only needs to run three
commands so its simpler to just put these into a script instead of
trying to debug scons.
