### PR TITLE
ENH: use copyswap instead of memmove for flat assignment

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -869,10 +869,7 @@ array_flat_set(PyArrayObject *self, PyObject *val)
     }
 
     while(selfit->index < selfit->size) {
-        memmove(selfit->dataptr, arrit->dataptr, PyArray_DESCR(self)->elsize);
-        if (swap) {
-            copyswap(selfit->dataptr, NULL, swap, self);
-        }
+        copyswap(selfit->dataptr, arrit->dataptr, swap, self);
         PyArray_ITER_NEXT(selfit);
         PyArray_ITER_NEXT(arrit);
         if (arrit->index == arrit->size) {


### PR DESCRIPTION
improves d.flat = x performance by about 35% for basic types as the
copyswap functions have known elementsizes and these are implemented
optimally by the compiler while for the generic call the compiler needs
to call out to libc.
