### PR TITLE
BUG: Correct behavior for lists of tuples in unique, closes #4785

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -167,13 +167,7 @@ def unique(ar, return_index=False, return_inverse=False, return_counts=False):
     array([1, 2, 6, 4, 2, 3, 2])
 
     """
-    try:
-        ar = ar.flatten()
-    except AttributeError:
-        if not return_inverse and not return_index and not return_counts:
-            return np.sort(list((set(ar))))
-        else:
-            ar = np.asanyarray(ar).flatten()
+    ar = np.asanyarray(ar).flatten()
 
     optional_indices = return_index or return_inverse
     optional_returns = optional_indices or return_counts

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -97,6 +97,16 @@ class TestSetOps(TestCase):
         aa = [1.+0.j, 1- 1.j, 1]
         assert_array_equal(np.unique(aa), [ 1.-1.j,  1.+0.j])
 
+        # test for ticket #4785
+        a = [(1, 2), (1, 2), (2, 3)]
+        unq = [1, 2, 3]
+        inv = [0, 1, 0, 1, 1, 2]
+        a1 = unique(a)
+        assert_array_equal(a1, unq)
+        a2, a2_inv = unique(a, return_inverse=True)
+        assert_array_equal(a2, unq)
+        assert_array_equal(a2_inv, inv)
+
     def test_intersect1d(self):
         # unique inputs
         a = np.array([5, 7, 1, 2])


### PR DESCRIPTION
`np.unique` produces wrong results when passed a list of tuples and
no keyword arguments, as it fails to recognize it as a multidim
array, but handles it as a 1D array of objects. The only way around
this seems to be to completely eliminate the fast path for non-array
inputs using `set`.
