### PR TITLE
Piecewise fix for 0d

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1487,6 +1487,7 @@ class TestPiecewise(TestCase):
         x = piecewise([0, 0], [[False, True]], [lambda x:-1])
         assert_array_equal(x, [0, -1])
 
+    def test_two_conditions(self):
         x = piecewise([1, 2], [[True, False], [False, True]], [3, 4])
         assert_array_equal(x, [3, 4])
 
@@ -1504,6 +1505,15 @@ class TestPiecewise(TestCase):
         y = piecewise(x, x > 3, [4, 0])
         assert_(y.ndim == 0)
         assert_(y == 0)
+
+        x = 5
+        y = piecewise(x, [[True], [False]], [1, 0])
+        assert_(y.ndim == 0)
+        assert_(y == 1)
+
+    def test_0d_comparison(self):
+        x = 3
+        y = piecewise(x, [x <= 3, x > 3], [4, 0])
 
 
 class TestBincount(TestCase):


### PR DESCRIPTION
I provide a fix for #331. Actually little changes were needed, but I had to carefully think about the assumptions being made by the function. Some additional tests were added and the behavior remains backwards compatible.

Besides, I corrected the documentation because there was an inconsistent bit, see 0d1f7d3.
