### PR TITLE
FIX pickling ufuncs defined in nested modules

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -52,7 +52,11 @@ bench = Tester().bench
 # The name numpy.core._ufunc_reconstruct must be
 #   available for unpickling to work.
 def _ufunc_reconstruct(module, name):
-    mod = __import__(module)
+    # The `fromlist` kwarg is required to ensure that `mod` points to the
+    # inner-most module rather than the parent package when module name is
+    # nested. This makes it possible to pickle non-toplevel ufuncs such as
+    # scipy.special.expit for instance.
+    mod = __import__(module, fromlist=[name])
     return getattr(mod, name)
 
 def _ufunc_reduce(func):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -14,6 +14,10 @@ class TestUfunc(TestCase):
         import pickle
         assert pickle.loads(pickle.dumps(np.sin)) is np.sin
 
+        # Check that ufunc not defined in the top level numpy namespace such as
+        # numpy.core.test_rational.test_add can also be pickled
+        assert pickle.loads(pickle.dumps(test_add)) is test_add
+
     def test_pickle_withstring(self):
         import pickle
         astring = asbytes("cnumpy.core\n_ufunc_reconstruct\np0\n"


### PR DESCRIPTION
This is a fix for the following problem with ufuncs that are not defined in a top level module:

```
>>> from scipy.special import expit
>>> import pickle
>>> pickle.loads(pickle.dumps(expit))
Traceback (most recent call last):
  File "<ipython-input-4-c8a97e87e418>", line 1, in <module>
    pickle.loads(pickle.dumps(expit))
  File "/usr/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/usr/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/usr/lib/python2.7/pickle.py", line 1133, in load_reduce
    value = func(*args)
  File "/volatile/ogrisel/envs/py27/local/lib/python2.7/site-packages/numpy/core/__init__.py", line 56, in _ufunc_reconstruct
    return getattr(mod, name)
AttributeError: 'module' object has no attribute 'expit'
```

Unfortunately I don't know how to write a test in numpy as all its ufuncs are importable from the namespace of the top level `numpy` package as far as I know.
