### PR TITLE
MAINT: const correctness and minor fixes to C code

### DIFF
--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -646,9 +646,9 @@ PyUFunc_Type
           void **data;
           int ntypes;
           int check_return;
-          char *name;
+          const char *name;
           char *types;
-          char *doc;
+          const char *doc;
           void *ptr;
           PyObject *obj;
           PyObject *userloops;

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -152,13 +152,13 @@ typedef struct _tagPyUFuncObject {
         int check_return;
 
         /* The name of the ufunc */
-        char *name;
+        const char *name;
 
         /* Array of type numbers, of size ('nargs' * 'ntypes') */
         char *types;
 
         /* Documentation string */
-        char *doc;
+        const char *doc;
 
         void *ptr;
         PyObject *obj;

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1490,7 +1490,9 @@ mapiter_@name@(PyArrayMapIterObject *mit)
     /* Constant information */
     npy_intp fancy_dims[NPY_MAXDIMS];
     npy_intp fancy_strides[NPY_MAXDIMS];
+#if @isget@
     int iteraxis;
+#endif
 
     char *baseoffset = mit->baseoffset;
     char **outer_ptrs = mit->outer_ptrs;
@@ -1498,7 +1500,9 @@ mapiter_@name@(PyArrayMapIterObject *mit)
     PyArrayObject *array= mit->array;
 
     /* Fill constant information */
+#if @isget@
     iteraxis = mit->iteraxes[0];
+#endif
     for (i = 0; i < numiter; i++) {
         fancy_dims[i] = mit->fancy_dims[i];
         fancy_strides[i] = mit->fancy_strides[i];

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -58,7 +58,7 @@ PyUFunc_ValidateCasting(PyUFuncObject *ufunc,
                             PyArray_Descr **dtypes)
 {
     int i, nin = ufunc->nin, nop = nin + ufunc->nout;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -186,7 +186,7 @@ PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, type_num1, type_num2;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -292,7 +292,7 @@ PyUFunc_SimpleUnaryOperationTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, type_num1;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -433,7 +433,7 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, type_num1, type_num2;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -591,7 +591,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -781,7 +781,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -963,7 +963,7 @@ PyUFunc_MultiplicationTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -1106,7 +1106,7 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    char *ufunc_name;
+    const char *ufunc_name;
 
     ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
 
@@ -1875,7 +1875,7 @@ linear_search_type_resolver(PyUFuncObject *self,
 {
     npy_intp i, j, nin = self->nin, nop = nin + self->nout;
     int types[NPY_MAXARGS];
-    char *ufunc_name;
+    const char *ufunc_name;
     int no_castable_output, use_min_scalar;
 
     /* For making a better error message on coercion error */
@@ -1984,7 +1984,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
     npy_intp i, j, n, nin = self->nin, nop = nin + self->nout;
     int n_specified = 0;
     int specified_types[NPY_MAXARGS], types[NPY_MAXARGS];
-    char *ufunc_name;
+    const char *ufunc_name;
     int no_castable_output, use_min_scalar;
 
     /* For making a better error message on coercion error */


### PR DESCRIPTION
Fixed some more compiler warnings, many of them related to incorrect handling of `const` with C strings.
