### PR TITLE
WIP: Fix matplotlib, etc. errors

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1796,6 +1796,23 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
             Py_INCREF(op);
             tmp_arr = (PyArrayObject *)op;
         }
+
+        /*
+         * Deprecated case. The old boolean indexing seemed to have some
+         * check to allow wrong dimensional boolean arrays in all cases.
+         * Note that it did *not* allow a wrong number of elements here.
+         */
+        if (PyArray_NDIM(tmp_arr) > 1) {
+            PyArrayObject *unraveled_tmp = tmp_arr;
+            if (DEPRECATE("boolean assignment blah blah.") < 0) {
+                goto fail;
+            }
+            tmp_arr = (PyArrayObject *)PyArray_Ravel(unraveled_tmp, NPY_CORDER);
+            Py_DECREF(unraveled_tmp);
+            if (tmp_arr == NULL) {
+                goto fail;
+            }
+        }
         if (array_assign_boolean_subscript(self,
                                            (PyArrayObject *)indices[0].object,
                                            tmp_arr, NPY_CORDER) < 0) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1668,6 +1668,8 @@ attempt_1d_fallback(PyArrayObject *self, PyObject *ind, PyObject *op)
 {
     PyObject *err = PyErr_Occurred();
     PyArrayIterObject *self_iter = NULL;
+
+    Py_INCREF(err);
     PyErr_Clear();
 
     self_iter = (PyArrayIterObject *)PyArray_IterNew((PyObject *)self);
@@ -1803,7 +1805,6 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
             /*
              * Deprecated case. The old boolean indexing seemed to have some
              * check to allow wrong dimensional boolean arrays in all cases.
-             * Note that it did *not* allow a wrong number of elements here.
              */
             if (PyArray_NDIM(tmp_arr) > 1) {
                 if (attempt_1d_fallback(self, indices[0].object, tmp_arr) < 0) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1797,25 +1797,20 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
             tmp_arr = (PyArrayObject *)op;
         }
 
-        /*
-         * Deprecated case. The old boolean indexing seemed to have some
-         * check to allow wrong dimensional boolean arrays in all cases.
-         * Note that it did *not* allow a wrong number of elements here.
-         */
-        if (PyArray_NDIM(tmp_arr) > 1) {
-            PyArrayObject *unraveled_tmp = tmp_arr;
-            if (DEPRECATE("boolean assignment blah blah.") < 0) {
-                goto fail;
-            }
-            tmp_arr = (PyArrayObject *)PyArray_Ravel(unraveled_tmp, NPY_CORDER);
-            Py_DECREF(unraveled_tmp);
-            if (tmp_arr == NULL) {
-                goto fail;
-            }
-        }
         if (array_assign_boolean_subscript(self,
                                            (PyArrayObject *)indices[0].object,
                                            tmp_arr, NPY_CORDER) < 0) {
+            /*
+             * Deprecated case. The old boolean indexing seemed to have some
+             * check to allow wrong dimensional boolean arrays in all cases.
+             * Note that it did *not* allow a wrong number of elements here.
+             */
+            if (PyArray_NDIM(tmp_arr) > 1) {
+                if (attempt_1d_fallback(self, indices[0].object, tmp_arr) < 0) {
+                    goto fail;
+                }
+                goto success;
+            }
             goto fail;
         }
         goto success;

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -402,8 +402,14 @@ class TestBroadcastedAssignments(TestCase):
 
         # Too large and not only ones.
         assert_raises(ValueError, assign, a, s_[...],  np.ones((2, 1)))
-        assert_raises(ValueError, assign, a, s_[[1, 2, 3],],  np.ones((2, 1)))
-        assert_raises(ValueError, assign, a, s_[[[1], [2]],], np.ones((2,2,1)))
+        
+        with warnings.catch_warnings():
+            # Will be a ValueError as well.
+            warnings.simplefilter("error", DeprecationWarning)
+            assert_raises(DeprecationWarning, assign, a, s_[[1, 2, 3],],
+                          np.ones((2, 1)))
+            assert_raises(DeprecationWarning, assign, a, s_[[[1], [2]],],
+                          np.ones((2,2,1)))
 
 
     def test_simple_broadcasting_errors(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -756,8 +756,12 @@ class TestRegression(TestCase):
         s = np.ones(10, dtype=float)
         x = np.array((15,), dtype=float)
         def ia(x, s, v): x[(s>0)]=v
-        self.assertRaises(ValueError, ia, x, s, np.zeros(9, dtype=float))
-        self.assertRaises(ValueError, ia, x, s, np.zeros(11, dtype=float))
+        # After removing deprecation, the following is are ValueErrors.
+        # This might seem odd as compared to the value error below. This
+        # is due to the fact that the new code always use "nonzero" logic
+        # and the boolean special case is not taken.
+        self.assertRaises(IndexError, ia, x, s, np.zeros(9, dtype=float))
+        self.assertRaises(IndexError, ia, x, s, np.zeros(11, dtype=float))
         # Old special case (different code path):
         self.assertRaises(ValueError, ia, x.flat, s, np.zeros(9, dtype=float))
 


### PR DESCRIPTION
I would like the deprecation warning to show the actual error message. It might also make sense to replace the error again with the original one if the fallback failed as well.
