### PR TITLE
ENH: Make the `mode` parameter of np.pad default to 'constant'

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -962,7 +962,7 @@ def _pad_dispatcher(array, pad_width, mode, **kwargs):
 
 
 @array_function_dispatch(_pad_dispatcher, module='numpy')
-def pad(array, pad_width, mode, **kwargs):
+def pad(array, pad_width, mode='constant', **kwargs):
     """
     Pads an array.
 
@@ -977,10 +977,10 @@ def pad(array, pad_width, mode, **kwargs):
         ((before, after),) yields same before and after pad for each axis.
         (pad,) or int is a shortcut for before = after = pad width for all
         axes.
-    mode : str or function
+    mode : str or function, optional
         One of the following string values or a user supplied function.
 
-        'constant'
+        'constant' (default)
             Pads with a constant value.
         'edge'
             Pads with the edge values of array.

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -957,7 +957,7 @@ def _as_pairs(x, ndim, as_index=False):
 # Public functions
 
 
-def _pad_dispatcher(array, pad_width, mode, **kwargs):
+def _pad_dispatcher(array, pad_width, mode=None, **kwargs):
     return (array,)
 
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1251,7 +1251,7 @@ def test_kwargs(mode):
 
 def test_constant_zero_default():
     arr = np.array([1, 1])
-    assert_array_equal(pad(arr, 2), [0, 0, 1, 1, 0, 0])
+    assert_array_equal(np.pad(arr, 2), [0, 0, 1, 1, 0, 0])
 
 
 @pytest.mark.parametrize("mode", _all_modes.keys())

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1249,10 +1249,9 @@ def test_kwargs(mode):
             np.pad([1, 2, 3], 1, mode, **{key: value})
 
 
-def test_missing_mode():
-    match = "missing 1 required positional argument: 'mode'"
-    with pytest.raises(TypeError, match=match):
-        np.pad(np.ones((5, 6)), 4)
+def test_constant_zero_default():
+    arr = np.array([1, 1])
+    assert_array_equal(pad(arr, 2), [0, 0, 1, 1, 0, 0])
 
 
 @pytest.mark.parametrize("mode", _all_modes.keys())


### PR DESCRIPTION
See [the mailing list discussion initiated by Nadav Horesh](http://numpy-discussion.10968.n7.nabble.com/numpy-1-9b1-bug-in-pad-function-td37768.html)
