### PR TITLE
BUG __numpy_ufunc__ gives unexpected TypeError with subclasses

### DIFF
--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -2,7 +2,7 @@
 #include <Python.h>
 #include "structmember.h"
 
-/*#include <stdio.h>*/
+/* #include <stdio.h> */
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
@@ -135,7 +135,7 @@ needs_right_binop_forward(PyObject *self, PyObject *other,
          */
         return 0;
     }
-    if (has_ufunc_attr(other) &&
+    if (!has_ufunc_attr(self) && has_ufunc_attr(other) &&
         PyObject_HasAttrString(other, right_name)) {
         return 1;
     }
@@ -337,6 +337,8 @@ PyArray_GenericInplaceUnaryFunction(PyArrayObject *m1, PyObject *op)
 static PyObject *
 array_add(PyArrayObject *m1, PyObject *m2)
 {
+    float f;
+    f = 1./0.;
     GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__add__", "__radd__", 0);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.add);
 }


### PR DESCRIPTION
I'm trying to use `__numpy_ufunc__` for astropy `Quantity` and found surprising difficulties with subclasses, where `<Q-subclass>+<Q>` yields a `TypeError` while `<Q>+<Q-subclass>` works (see below for a simple example using just `ndarray` subclasses). This behaviour seems surprising. Am I missing something?

```
import numpy as np
np.version.version
# '1.9.0.dev-133d4f4'
class MyA(np.ndarray):                                
    def __numpy_ufunc__(self, ufunc, method, i, inputs, **kwargs):
        return getattr(ufunc, method)(*(input.view(np.ndarray) for input in inputs), **kwargs)

class MyA2(MyA):                                      
    pass

np.arange(2.).view(MyA) + np.arange(2.).view(MyA2)
# array([ 0.,  2.])
np.arange(2.).view(MyA2) + np.arange(2.).view(MyA)
# TypeError: unsupported operand type(s) for +: 'MyA2' and 'MyA'
```
