### PR TITLE
umath static analysis fixes

### DIFF
--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -28,4 +28,4 @@
 # Version 9 (NumPy 1.9) Added function annotations.
 # The interface has not changed, but the hash is different due to
 # the annotations, so keep the previous version number.
-0x00000009 = 49b27dc2dc7206a775a7376fdbc3b80c
+0x00000009 = 982c4ebb6e7e4c194bf46b1535b4ef1b

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -473,9 +473,9 @@ def fullapi_hash(api_dicts):
     of the list of items in the API (as a string)."""
     a = []
     for d in api_dicts:
-        for name, index in order_dict(d):
+        for name, data in order_dict(d):
             a.extend(name)
-            a.extend(str(index))
+            a.extend(','.join(map(str, data)))
 
     return md5new(''.join(a).encode('ascii')).hexdigest()
 

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -8,8 +8,9 @@ from genapi import \
 
 import numpy_api
 
+# use annotated api when running under cpychecker
 h_template = r"""
-#ifdef _MULTIARRAYMODULE
+#if defined(_MULTIARRAYMODULE) || defined(WITH_CPYCHECKER_STEALS_REFERENCE_TO_ARG_ATTRIBUTE)
 
 typedef struct {
         PyObject_HEAD

--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -26,6 +26,7 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
         else {
             obj = PyTuple_GetSlice(args, nin, nargs);
             PyDict_SetItemString(*normal_kwds, "out", obj);
+            Py_DECREF(obj);
         }
     }
 }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2572,6 +2572,7 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
             return;
         }
         ret = PyObject_IsTrue(ret_obj);
+        Py_DECREF(ret_obj);
         if (ret == -1) {
 #if @identity@ != -1
             if (in1 == in2) {
@@ -2621,6 +2622,7 @@ OBJECT_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
         }
         ret = PyLong_FromLong(v);
         if (PyErr_Occurred()) {
+            Py_DECREF(zero);
             return;
         }
         Py_XDECREF(*out);
@@ -2635,6 +2637,7 @@ OBJECT_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
         PyObject *ret = PyInt_FromLong(
                             PyObject_Compare(in1 ? in1 : Py_None, zero));
         if (PyErr_Occurred()) {
+            Py_DECREF(zero);
             return;
         }
         Py_XDECREF(*out);

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -54,16 +54,15 @@ object_ufunc_type_resolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, nop = ufunc->nin + ufunc->nout;
-    PyArray_Descr *obj_dtype;
 
-    obj_dtype = PyArray_DescrFromType(NPY_OBJECT);
-    if (obj_dtype == NULL) {
+    out_dtypes[0] = PyArray_DescrFromType(NPY_OBJECT);
+    if (out_dtypes[0] == NULL) {
         return -1;
     }
 
-    for (i = 0; i < nop; ++i) {
-        Py_INCREF(obj_dtype);
-        out_dtypes[i] = obj_dtype;
+    for (i = 1; i < nop; ++i) {
+        Py_INCREF(out_dtypes[0]);
+        out_dtypes[i] = out_dtypes[0];
     }
 
     return 0;


### PR DESCRIPTION
one significant memory leak (added in 1.9) and a few insignificant ones fixed, found by cpycheck

also fixed the api checksum warnings that occur due to the annotations not printed as repr (with pointer values) instead of str
