### PR TITLE
FIX isfileobj accepts write-mode files under PY3

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -36,7 +36,7 @@ if sys.version_info[0] >= 3:
         return str(s)
 
     def isfileobj(f):
-        return isinstance(f, (io.FileIO, io.BufferedReader))
+        return isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter))
 
     def open_latin1(filename, mode='r'):
         return open(filename, mode=mode, encoding='iso-8859-1')

--- a/numpy/compat/tests/test_compat.py
+++ b/numpy/compat/tests/test_compat.py
@@ -1,0 +1,19 @@
+from os.path import join
+
+from numpy.compat import isfileobj
+from numpy.testing import TestCase, assert_
+from numpy.testing.utils import tempdir
+
+
+def test_isfileobj():
+    with tempdir(prefix="numpy_test_compat_") as folder:
+        filename = join(folder, 'a.bin')
+
+        with open(filename, 'wb') as f:
+            assert_(isfileobj(f))
+
+        with open(filename, 'ab') as f:
+            assert_(isfileobj(f))
+
+        with open(filename, 'rb') as f:
+            assert_(isfileobj(f))

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -4,9 +4,7 @@ import sys
 import gzip
 import os
 import threading
-import shutil
-import contextlib
-from tempfile import mkstemp, mkdtemp, NamedTemporaryFile
+from tempfile import mkstemp, NamedTemporaryFile
 import time
 import warnings
 import gc
@@ -24,13 +22,7 @@ from numpy.ma.testutils import (
     assert_raises, assert_raises_regex, run_module_suite
 )
 from numpy.testing import assert_warns, assert_, build_err_msg
-
-
-@contextlib.contextmanager
-def tempdir(change_dir=False):
-    tmpdir = mkdtemp()
-    yield tmpdir
-    shutil.rmtree(tmpdir)
+from numpy.testing.utils import tempdir
 
 
 class TextIO(BytesIO):
@@ -202,7 +194,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
     def test_big_arrays(self):
         L = (1 << 31) + 100000
         a = np.empty(L, dtype=np.uint8)
-        with tempdir() as tmpdir:
+        with tempdir(prefix="numpy_test_big_arrays_") as tmpdir:
             tmp = os.path.join(tmpdir, "file.npz")
             np.savez(tmp, a=a)
             del a
@@ -311,7 +303,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
         # Check that zipfile owns file and can close it.
         # This needs to pass a file name to load for the
         # test.
-        with tempdir() as tmpdir:
+        with tempdir(prefix="numpy_test_closing_zipfile_after_load_") as tmpdir:
             fd, tmp = mkstemp(suffix='.npz', dir=tmpdir)
             os.close(fd)
             np.savez(tmp, lab='place holder')

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -10,6 +10,9 @@ import re
 import operator
 import warnings
 from functools import partial
+import shutil
+import contextlib
+from tempfile import mkdtemp
 from .nosetester import import_nose
 from numpy.core import float32, empty, arange, array_repr, ndarray
 
@@ -1692,3 +1695,16 @@ def _gen_alignment_data(dtype=float32, type='binary', max_size=24):
 
 class IgnoreException(Exception):
     "Ignoring this exception due to disabled feature"
+
+
+@contextlib.contextmanager
+def tempdir(*args, **kwargs):
+    """Context manager to provide a temporary test folder.
+
+    All arguments are passed as this to the underlying tempfile.mkdtemp
+    function.
+
+    """
+    tmpdir = mkdtemp(*args, **kwargs)
+    yield tmpdir
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
Under Python 3, files open in write mode were not recognized as file objects, triggering large memory copies with `np.save`.
