### PR TITLE
MAINT: Simplify some uses of errstate context manager.

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -194,8 +194,7 @@ class TestMaskedArray(TestCase):
 
     def test_fix_invalid(self):
         # Checks fix_invalid.
-        with np.errstate():
-            np.seterr(invalid='ignore')
+        with np.errstate(invalid='ignore'):
             data = masked_array([np.nan, 0., 1.], mask=[0, 0, 1])
             data_fixed = fix_invalid(data)
             assert_equal(data_fixed._data, [data.fill_value, 0., 1.])

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -607,8 +607,7 @@ class TestMa(TestCase):
     def test_testScalarArithmetic(self):
         xm = array(0, mask=1)
         #TODO FIXME: Find out what the following raises a warning in r8247
-        with np.errstate():
-            np.seterr(divide='ignore')
+        with np.errstate(divide='ignore'):
             self.assertTrue((1 / array(0)).mask)
         self.assertTrue((1 + xm).mask)
         self.assertTrue((-xm).mask)


### PR DESCRIPTION
This changes, e.g.,

```
with np.errstate():
    np.seterr(divide='ignore')
    ...
```

to

```
with np.errstate(divide='ignore'):
    ...
```
