### PR TITLE
ENH: increase NPY_MAXARGS to 256

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -381,6 +381,12 @@ MaskedArray support for more complicated base classes
 Built-in assumptions that the baseclass behaved like a plain array are being
 removed. In particalur, ``repr`` and ``str`` should now work more reliably.
 
+Maximum nditer operands increased to 256
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The maximum number of operands that nditer can handle has been increased from
+32 to 256. This allows applications like `numexpr` to work with larger
+expressions.
+
 
 C-API
 ~~~~~

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -32,7 +32,7 @@
  */
 
 #define NPY_MAXDIMS 32
-#define NPY_MAXARGS 32
+#define NPY_MAXARGS 256
 
 /* Used for Converter Functions "O&" code in ParseTuple */
 #define NPY_FAIL 0

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -686,7 +686,7 @@ def test_iter_flags_errors():
     # Not enough operands
     assert_raises(ValueError, nditer, [], [], [])
     # Too many operands
-    assert_raises(ValueError, nditer, [a]*100, [], [['readonly']]*100)
+    assert_raises(ValueError, nditer, [a]*500, [], [['readonly']]*500)
     # Bad global flag
     assert_raises(ValueError, nditer, [a], ['bad flag'], [['readonly']])
     # Bad op flag

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -215,9 +215,9 @@ class TestSelect(TestCase):
             assert_raises(DeprecationWarning, select, conditions, choices)
 
     def test_many_arguments(self):
-        # This used to be limited by NPY_MAXARGS == 32
-        conditions = [np.array([False])] * 100
-        choices = [np.array([1])] * 100
+        # This used to be limited by NPY_MAXARGS
+        conditions = [np.array([False])] * 500
+        choices = [np.array([1])] * 500
         select(conditions, choices)
 
 


### PR DESCRIPTION
Allows larger numbers of arguments for nditer using functions. This can
be helpful for complex boolean expressions used in pytables.
Closes gh-4398
