### PR TITLE
ENH: Introduce np.arr array creation in `numpy.mat` style. Fixes #4817.

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -1,6 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-__all__ = ['logspace', 'linspace']
+__all__ = ['logspace', 'linspace', 'arr']
 
 from . import numeric as _nx
 from .numeric import array, result_type
@@ -184,3 +184,51 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     if dtype is None:
         return _nx.power(base, y)
     return _nx.power(base, y).astype(dtype)
+
+
+def arr(string, dtype=None):
+    """
+    Interpret an input string as a 2-D array.
+    
+    Parameters
+    ----------
+    string : str
+        Input string with rows sepearted by semicolons, and columns 
+        optionally seperated by commas.
+
+    dtype : dtype, optional
+        The type of the output array.  If `dtype` is not given, infer the data
+        type from the string.
+
+    Returns
+    -------
+    arr : ndarray
+        The input string interpretted as a 2-D array.
+
+    See Also
+    --------
+    mat : Similar to arr, but returns a matrix.
+
+    Examples
+    --------
+    >>> np.arr('3; 4; 5')
+        array([[3],
+               [4],
+               [5]])
+    
+    >>> np.arr('3; 4; 5', dtype=float)
+        array([[ 3.],
+               [ 4.],
+               [ 5.]])
+    
+    >>> np.arr('1 0 0; 0 1 0; 0 0 1')
+        array([[1, 0, 0],
+               [0, 1, 0],
+               [0, 0, 1]])
+
+    >>> np.arr('4, 5; 6, 7')
+        array([[4, 5],
+               [6, 7]])
+    """
+    from numpy.matrixlib.defmatrix import _convert_from_string
+    return array(_convert_from_string(string), dtype=dtype)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 from numpy.testing import *
-from numpy import logspace, linspace, dtype, array
+from numpy import logspace, linspace, arr, dtype, array
 
 class TestLogspace(TestCase):
 
@@ -109,3 +109,34 @@ class TestLinspace(TestCase):
         a = PhysicalQuantity(0.0)
         b = PhysicalQuantity(1.0)
         assert_equal(linspace(a, b), linspace(0.0, 1.0))
+
+
+class TestArr(TestCase):
+
+    def test_vector(self):
+        a = array([[3], [4], [5]])
+        b = arr('3; 4; 5')
+        assert_equal(a, b)
+
+    def test_respects_dtype(self):
+        a = array([[3.], [4.], [5.]])
+        b = arr('3; 4; 5', dtype=float)
+        assert_almost_equal(a, b)
+
+    def test_square_array(self):
+        a = array([[1, 0, 0],
+                   [0, 1, 0],
+                   [0, 0, 1]])
+        b = arr('1 0 0; 0 1 0; 0 0 1')
+        assert_equal(a, b)
+
+    def test_comma_sep_cols(self):
+        a = array([[4, 5],
+                   [6, 7]])
+        b = arr('4, 5; 6, 7')
+        assert_equal(a, b)
+
+    def test_empty_string(self):
+        self.assertEqual(arr('').shape, (1, 0))
+        self.assertEqual(arr(' ').shape, (1, 0))
+        


### PR DESCRIPTION
Introduces `np.arr(s)` which uses a utility function from `numpy.mat` to implement array creation in `numpy.mat` style. In #4817 @frozen-flame suggested this in light that it would be beneficial to beginners and presenters during demonstrations.

Examples:

```
>>> np.arr('3; 4; 5')
    array([[3],
           [4],
           [5]])

>>> np.arr('3; 4; 5', dtype=float)
    array([[ 3.],
           [ 4.],
           [ 5.]])

>>> np.arr('1 0 0; 0 1 0; 0 0 1')
    array([[1, 0, 0],
           [0, 1, 0],
           [0, 0, 1]])

>>> np.arr('4, 5; 6, 7')
    array([[4, 5],
           [6, 7]])
```
