### PR TITLE
fix endianness detection with clang on osx 10.9

### DIFF
--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -10,9 +10,21 @@
     /* Use endian.h if available */
     #include <endian.h>
 
-    #define NPY_BYTE_ORDER __BYTE_ORDER
-    #define NPY_LITTLE_ENDIAN __LITTLE_ENDIAN
-    #define NPY_BIG_ENDIAN __BIG_ENDIAN
+    #if defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && defined(__LITTLE_ENDIAN)
+        #define NPY_BYTE_ORDER    __BYTE_ORDER
+        #define NPY_LITTLE_ENDIAN __LITTLE_ENDIAN
+        #define NPY_BIG_ENDIAN    __BIG_ENDIAN
+    #elif defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
+        #define NPY_BYTE_ORDER    _BYTE_ORDER
+        #define NPY_LITTLE_ENDIAN _LITTLE_ENDIAN
+        #define NPY_BIG_ENDIAN    _BIG_ENDIAN
+    #elif defined(BYTE_ORDER) && defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN)
+        #define NPY_BYTE_ORDER    BYTE_ORDER
+        #define NPY_LITTLE_ENDIAN LITTLE_ENDIAN
+        #define NPY_BIG_ENDIAN    BIG_ENDIAN
+    #else
+        #error "Endian symbols BYTE_ORDER, LITTLE_ENDIAN, and BIG_ENDIAN were not found in <endian.h>"
+    #endif
 #else
     /* Set endianness info using target CPU */
     #include "npy_cpu.h"

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -10,18 +10,18 @@
     /* Use endian.h if available */
     #include <endian.h>
 
-    #if defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && defined(__LITTLE_ENDIAN)
-        #define NPY_BYTE_ORDER    __BYTE_ORDER
-        #define NPY_LITTLE_ENDIAN __LITTLE_ENDIAN
-        #define NPY_BIG_ENDIAN    __BIG_ENDIAN
+    #if defined(BYTE_ORDER) && defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN)
+        #define NPY_BYTE_ORDER    BYTE_ORDER
+        #define NPY_LITTLE_ENDIAN LITTLE_ENDIAN
+        #define NPY_BIG_ENDIAN    BIG_ENDIAN
     #elif defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
         #define NPY_BYTE_ORDER    _BYTE_ORDER
         #define NPY_LITTLE_ENDIAN _LITTLE_ENDIAN
         #define NPY_BIG_ENDIAN    _BIG_ENDIAN
-    #elif defined(BYTE_ORDER) && defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN)
-        #define NPY_BYTE_ORDER    BYTE_ORDER
-        #define NPY_LITTLE_ENDIAN LITTLE_ENDIAN
-        #define NPY_BIG_ENDIAN    BIG_ENDIAN
+    #elif defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && defined(__LITTLE_ENDIAN)
+        #define NPY_BYTE_ORDER    __BYTE_ORDER
+        #define NPY_LITTLE_ENDIAN __LITTLE_ENDIAN
+        #define NPY_BIG_ENDIAN    __BIG_ENDIAN
     #endif
 #endif
 

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -22,10 +22,10 @@
         #define NPY_BYTE_ORDER    BYTE_ORDER
         #define NPY_LITTLE_ENDIAN LITTLE_ENDIAN
         #define NPY_BIG_ENDIAN    BIG_ENDIAN
-    #else
-        #error "Endian symbols BYTE_ORDER, LITTLE_ENDIAN, and BIG_ENDIAN were not found in <endian.h>"
     #endif
-#else
+#endif
+
+#ifndef NPY_BYTE_ORDER
     /* Set endianness info using target CPU */
     #include "npy_cpu.h"
 


### PR DESCRIPTION
When compiling on OSX 10.9 using Apple's clang:

```
In file included from numpy/core/src/npymath/npy_math.c.src:56:
numpy/core/src/npymath/npy_math_private.h:78:3: error: typedef redefinition
with different types ('union ieee_double_shape_type' vs 'union
ieee_double_shape_type')

} ieee_double_shape_type;
  ^

numpy/core/src/npymath/npy_math_private.h:64:3: note: previous definition is
here

} ieee_double_shape_type;
  ^

1 error generated.

error: Command "clang -fno-strict-aliasing -fno-common -dynamic -arch i386
-arch x86_64 -I/usr/local/include -I/usr/local/opt/sqlite/include -DNDEBUG
-g -fwrapv -O3 -Wall -Wstrict-prototypes -Inumpy/core/include
-Inumpy/core/include/numpy -Inumpy/core/src/private -Inumpy/core/src
-Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray
-Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/include
-I/usr/local/Cellar/python/2.7.7_1/Frameworks/Python.framework/Versions/2.7/include/python2.7
-Inumpy/core/src/private -Inumpy/core/src/private -Inumpy/core/src/private
-Inumpy/core/src/private
-I/usr/local/Cellar/python/2.7.7_1/Frameworks/Python.framework/Versions/2.7/include/python2.7
-c numpy/core/src/npymath/npy_math.c -o
build/temp.macosx-10.9-intel-2.7/numpy/core/src/npymath/npy_math.o" failed
with exit status 1
```

This is because `/usr/include/i386/endian.h` (included by `<endian.h>`) defines BYTE_ORDER, LITTLE_ENDIAN and BIG_ENDIAN without leading underscores. I'm not sure why this wasn't fixed earlier.
The patch is coming from https://dev.lsstcorp.org/trac/ticket/1926.
