### PR TITLE
BUG: inf turned to nan when calling np.triu/np.tril, fixes #4859

### DIFF
--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -311,6 +311,18 @@ def test_tril_triu_ndim3():
         yield assert_equal, a_triu_observed.dtype, a.dtype
         yield assert_equal, a_tril_observed.dtype, a.dtype
 
+def test_tril_triu_with_inf():
+    # Issue 4859
+    arr = np.array([[1, 1, np.inf],
+                    [1, 1, 1],
+                    [np.inf, 1, 1]])
+    out_tril = np.array([[1, 0, 0],
+                         [1, 1, 0],
+                         [np.inf, 1, 1]])
+    out_triu = out_tril.T
+    assert_array_equal(np.triu(arr), out_triu)
+    assert_array_equal(np.tril(arr), out_tril)
+
 
 def test_mask_indices():
     # simple test without offset

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -387,7 +387,6 @@ def tri(N, M=None, k=0, dtype=float):
     dtype : dtype, optional
         Data type of the returned array.  The default is float.
 
-
     Returns
     -------
     tri : ndarray of shape (N, M)
@@ -452,7 +451,9 @@ def tril(m, k=0):
 
     """
     m = asanyarray(m)
-    return multiply(tri(*m.shape[-2:], k=k, dtype=bool), m, dtype=m.dtype)
+    mask = tri(*m.shape[-2:], k=k, dtype=bool)
+
+    return where(mask, m, 0)
 
 
 def triu(m, k=0):
@@ -478,7 +479,9 @@ def triu(m, k=0):
 
     """
     m = asanyarray(m)
-    return multiply(~tri(*m.shape[-2:], k=k-1, dtype=bool), m, dtype=m.dtype)
+    mask = tri(*m.shape[-2:], k=k-1, dtype=bool)
+
+    return where(mask, 0, m)
 
 
 # Originally borrowed from John Hunter and matplotlib


### PR DESCRIPTION
Changes the current multiplication method to zero the items to remove
with boolean indexing.
