### PR TITLE
BUG Masked recarray assignment with [row][record] does not work

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5594,9 +5594,8 @@ class mvoid(MaskedArray):
     """
     #
     def __new__(self, data, mask=nomask, dtype=None, fill_value=None,
-                hardmask=False):
-        dtype = dtype or data.dtype
-        _data = np.array(data, dtype=dtype)
+                hardmask=False, copy=False, subok=True):
+        _data = np.array(data, copy=copy, subok=subok, dtype=dtype)
         _data = _data.view(self)
         _data._hardmask = hardmask
         if mask is not nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -815,7 +815,7 @@ class TestMaskedArrayArithmetic(TestCase):
         res = count(ott)
         self.assertTrue(res.dtype.type is np.intp)
         assert_equal(3, res)
-        
+
         ott = ott.reshape((2, 2))
         res = count(ott)
         assert_(res.dtype.type is np.intp)
@@ -3523,8 +3523,15 @@ class TestMaskedFields(TestCase):
         assert_equal_records(a[-2]._mask, a._mask[-2])
 
     def test_setitem(self):
-        # Issue 2403
+        # Issue 4866: check that one can set individual items in [record][col]
+        # and [col][record] order
         ndtype = np.dtype([('a', float), ('b', int)])
+        ma = np.ma.MaskedArray([(1.0, 1), (2.0, 2)], dtype=ndtype)
+        ma['a'][1] = 3.0
+        assert_equal(ma['a'], np.array([1.0, 3.0]))
+        ma[1]['a'] = 4.0
+        assert_equal(ma['a'], np.array([1.0, 4.0]))
+        # Issue 2403
         mdtype = np.dtype([('a', bool), ('b', bool)])
         # soft mask
         control = np.array([(False, True), (True, True)], dtype=mdtype)


### PR DESCRIPTION
As reported by @tobias-andrew-marriage in https://github.com/astropy/astropy/issues/2734, assignment to a masked array containing a recarray object doesn't work properly when being assigned in `[row][record]` order (the other way around works fine; as a normal recarray it works fine too):

```
In [13]: ma = np.ma.MaskedArray([(1, 1.0), (2, 2.0)], dtype=[('a', '<i8'), ('b', '<f8')])

In [14]: ma
Out[14]: 
masked_array(data = [(1, 1.0) (2, 2.0)],
             mask = [(False, False) (False, False)],
       fill_value = (999999, 1e+20),
            dtype = [('a', '<i8'), ('b', '<f8')])

In [15]: ma[1]['a']
Out[15]: 2

In [16]: ma[1]['a'] = 3

In [17]: ma[1]['a']
Out[17]: 2
```
