### PR TITLE
TST: remove not important tests to reduce travis load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,7 @@ matrix:
       env: USE_DEBUG=1
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=0
-    - python: 3.3
-      env: NPY_SEPARATE_COMPILATION=0
-    - python: 2.7
-      env: NPY_RELAXED_STRIDES_CHECKING=0
-    - python: 3.3
+    - python: 3.4
       env: NPY_RELAXED_STRIDES_CHECKING=0
     - python: 2.7
       env: USE_BENTO=1


### PR DESCRIPTION
Remove one of the separate compilation and relaxed strides tests, it is
not worth the cpu time to test these on two python versions.
Use one of them to add a non debug python3.4 test.
