### PR TITLE
DEP: deprecate float as axis argument to reductions

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3750,7 +3750,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
         }
         for (i = 0; i < naxes; ++i) {
             PyObject *tmp = PyTuple_GET_ITEM(axes_in, i);
-            long axis = PyInt_AsLong(tmp);
+            int axis = PyArray_PyIntAsInt(tmp);
             if (axis == -1 && PyErr_Occurred()) {
                 Py_XDECREF(otype);
                 Py_DECREF(mp);
@@ -3771,7 +3771,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     }
     /* Try to interpret axis as an integer */
     else {
-        long axis = PyInt_AsLong(axes_in);
+        int axis = PyArray_PyIntAsInt(axes_in);
         /* TODO: PyNumber_Index would be good to use here */
         if (axis == -1 && PyErr_Occurred()) {
             Py_XDECREF(otype);

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -249,6 +249,14 @@ class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
         self.assert_not_deprecated(mult, args=([1], np.int_(3)))
 
 
+    def test_reduce_axis_float_index(self):
+        d = np.zeros((3,3,3))
+        self.assert_deprecated(np.min, args=(d, 0.5))
+        self.assert_deprecated(np.min, num=1, args=(d, (0.5, 1)))
+        self.assert_deprecated(np.min, num=1, args=(d, (1, 2.2)))
+        self.assert_deprecated(np.min, num=2, args=(d, (.2, 1.2)))
+
+
 class TestBooleanArgumentDeprecation(_DeprecationTestCase):
     """This tests that using a boolean as integer argument/indexing is
     deprecated.


### PR DESCRIPTION
consistent with deprecation of float as slice indices.
Closes gh-4876
