### PR TITLE
Match absolute tolerance of `assert_allclose` with `allclose` and `isclo...

### DIFF
--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -439,7 +439,7 @@ class TestAssertAllclose(unittest.TestCase):
         b[-1] = y * (1 + 1e-8)
         assert_allclose(a, b)
         self.assertRaises(AssertionError, assert_allclose, a, b,
-                          rtol=1e-9)
+                          rtol=1e-9, atol=0)
 
         assert_allclose(6, 10, rtol=0.5)
         self.assertRaises(AssertionError, assert_allclose, 10, 6, rtol=0.5)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1240,7 +1240,7 @@ def _assert_valid_refcount(op):
 
     assert_(sys.getrefcount(i) >= rc)
 
-def assert_allclose(actual, desired, rtol=1e-7, atol=0,
+def assert_allclose(actual, desired, rtol=1e-7, atol=1e-8,
                     err_msg='', verbose=True):
     """
     Raise an assertion if two objects are not equal up to desired tolerance.


### PR DESCRIPTION
Note that `rtol` wasn't altered to reduce backward incompatibility. Using an absolute tolerance of 0 prevents many common cases from passing. Also, matching the absolute tolerance of `allclose` and `isclose` makes debugging much easier.

See discussion:

http://mail.scipy.org/pipermail/numpy-discussion/2014-July/070602.html
