### PR TITLE
Add "out" keyword argument to numpy.argmax and argmin.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -878,7 +878,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     return argsort(axis, kind, order)
 
 
-def argmax(a, axis=None):
+def argmax(a, axis=None, out=None):
     """
     Indices of the maximum values along an axis.
 
@@ -889,6 +889,11 @@ def argmax(a, axis=None):
     axis : int, optional
         By default, the index is into the flattened array, otherwise
         along the specified axis.
+    out : ndarray, optional
+        Alternative output array in which to place the result. It must
+        have the same shape and buffer length as the expected output
+        but the type will be cast if necessary. See `doc.ufuncs`
+        (Section "Output arguments") for more details.
 
     Returns
     -------
@@ -931,11 +936,15 @@ def argmax(a, axis=None):
     try:
         argmax = a.argmax
     except AttributeError:
-        return _wrapit(a, 'argmax', axis)
-    return argmax(axis)
+        return _wrapit(a, 'argmax', axis, out)
+    try:
+        return argmax(axis, out)
+    except TypeError:
+        # for backwards compatibility
+        return argmax(axis)
 
 
-def argmin(a, axis=None):
+def argmin(a, axis=None, out=None):
     """
     Return the indices of the minimum values along an axis.
 
@@ -948,8 +957,12 @@ def argmin(a, axis=None):
     try:
         argmin = a.argmin
     except AttributeError:
-        return _wrapit(a, 'argmin', axis)
-    return argmin(axis)
+        return _wrapit(a, 'argmin', axis, out)
+    try:
+        return argmin(axis, out)
+    except TypeError:
+        # for backwards compatibility
+        return argmin(axis)
 
 
 def searchsorted(a, v, side='left', sorter=None):


### PR DESCRIPTION
For backwards compatibility, ignores the "out" keyword if the object being operated on doesn't support it.

(ndarray already does, as does using _wrapit for other array-like objects, so this will only affect custom subclasses, and seems to be the same solution as for numpy.squeeze() and others.)
