### PR TITLE
ENH: add a ndarray super-fast path to _array_from_object

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -12,6 +12,7 @@
 #include "npy_config.h"
 
 #include "npy_pycompat.h"
+#include "multiarraymodule.h"
 
 #include "common.h"
 #include "ctors.h"
@@ -1069,7 +1070,7 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     if ((subtype != &PyArray_Type)) {
         PyObject *res, *func, *args;
 
-        func = PyObject_GetAttrString((PyObject *)fa, "__array_finalize__");
+        func = PyObject_GetAttr((PyObject *)fa, npy_ma_str_array_finalize);
         if (func && func != Py_None) {
             if (NpyCapsule_Check(func)) {
                 /* A C-function is stored here */
@@ -3368,7 +3369,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
 #endif
         ) {
         PyObject *newbuf;
-        newbuf = PyObject_GetAttrString(buf, "__buffer__");
+        newbuf = PyObject_GetAttr(buf, npy_ma_str_buffer);
         if (newbuf == NULL) {
             Py_DECREF(type);
             return NULL;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -56,6 +56,7 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "common.h"
 #include "ufunc_override.h"
 #include "scalarmathmodule.h" /* for npy_mul_with_overflow_intp */
+#include "multiarraymodule.h"
 
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
@@ -4022,6 +4023,38 @@ set_flaginfo(PyObject *d)
     return;
 }
 
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_prepare = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_wrap = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_finalize = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_buffer = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_ufunc = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_order = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_copy = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_dtype = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_ndmin = NULL;
+
+static int
+intern_strings(void)
+{
+    npy_ma_str_array = PyUString_InternFromString("__array__");
+    npy_ma_str_array_prepare = PyUString_InternFromString("__array_prepare__");
+    npy_ma_str_array_wrap = PyUString_InternFromString("__array_wrap__");
+    npy_ma_str_array_finalize = PyUString_InternFromString("__array_finalize__");
+    npy_ma_str_buffer = PyUString_InternFromString("__buffer__");
+    npy_ma_str_ufunc = PyUString_InternFromString("__numpy_ufunc__");
+    npy_ma_str_order = PyUString_InternFromString("order");
+    npy_ma_str_copy = PyUString_InternFromString("copy");
+    npy_ma_str_dtype = PyUString_InternFromString("dtype");
+    npy_ma_str_ndmin = PyUString_InternFromString("ndmin");
+
+    return npy_ma_str_array && npy_ma_str_array_prepare &&
+           npy_ma_str_array_wrap && npy_ma_str_array_finalize &&
+           npy_ma_str_array_finalize && npy_ma_str_ufunc &&
+           npy_ma_str_order && npy_ma_str_copy && npy_ma_str_dtype &&
+           npy_ma_str_ndmin;
+}
+
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
@@ -4193,6 +4226,10 @@ PyMODINIT_FUNC initmultiarray(void) {
                             (PyObject *)&NpyBusDayCalendar_Type);
 
     set_flaginfo(d);
+
+    if (!intern_strings()) {
+        goto err;
+    }
 
     if (set_typeinfo(d) != 0) {
         goto err;

--- a/numpy/core/src/multiarray/multiarraymodule.h
+++ b/numpy/core/src/multiarray/multiarraymodule.h
@@ -1,4 +1,15 @@
 #ifndef _NPY_MULTIARRAY_H_
 #define _NPY_MULTIARRAY_H_
 
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_prepare;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_wrap;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_finalize;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_buffer;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_ufunc;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_order;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_copy;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_dtype;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_ndmin;
+
 #endif

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -246,6 +246,33 @@ class TestArrayConstruction(TestCase):
         r = np.array([[True, False], [True, False], [False, True]])
         assert_equal(r, tgt.T)
 
+    def test_array_empty(self):
+        assert_raises(TypeError, np.array)
+
+    def test_array_copy_false(self):
+        d = np.array([1, 2, 3])
+        e = np.array(d, copy=False)
+        d[1] = 3
+        assert_array_equal(e, [1, 3, 3])
+        e = np.array(d, copy=False, order='F')
+        d[1] = 4
+        assert_array_equal(e, [1, 4, 3])
+        e[2] = 7
+        assert_array_equal(d, [1, 4, 7])
+
+    def test_array_copy_true(self):
+        d = np.array([[1,2,3], [1, 2, 3]])
+        e = np.array(d, copy=True)
+        d[0, 1] = 3
+        e[0, 2] = -7
+        assert_array_equal(e, [[1, 2, -7], [1, 2, 3]])
+        assert_array_equal(d, [[1, 3, 3], [1, 2, 3]])
+        e = np.array(d, copy=True, order='F')
+        d[0, 1] = 5
+        e[0, 2] = 7
+        assert_array_equal(e, [[1, 3, 7], [1, 2, 3]])
+        assert_array_equal(d, [[1, 5, 3], [1,2,3]])
+
 
 class TestAssignment(TestCase):
     def test_assignment_broadcasting(self):


### PR DESCRIPTION
When the argument is exactly an ndarray and the rest of the arguments
are their defaults we can skip the very slow
PyArg_ParseTupleAndKeywords.
This improves np.array(ndarray, copy=False) performance by about a
factor three and np.asarray(ndarray) by about a factor of two.

also add some interned strings to multiarraymodule
