### PR TITLE
more small-array performance improvements

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1080,7 +1080,8 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
      * platforms (debian sparc) malloc does not provide enough alignment for
      * long double types
      */
-    PyArray_UpdateFlags((PyArrayObject *)fa, NPY_ARRAY_UPDATE_ALL);
+    PyArray_UpdateFlags((PyArrayObject *)fa,
+                        strides ? NPY_ARRAY_UPDATE_ALL : NPY_ARRAY_ALIGNED);
 
     /*
      * call the __array_finalize__

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3954,8 +3954,9 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
          * is used for add and multiply reduction to avoid overflow
          */
         int typenum = PyArray_TYPE(mp);
-        if ((PyTypeNum_ISBOOL(typenum) || PyTypeNum_ISINTEGER(typenum))
-            && ((strcmp(ufunc->name,"add") == 0)
+        if ((PyTypeNum_ISBOOL(typenum) || PyTypeNum_ISINTEGER(typenum)) &&
+            (ufunc->name[0] == 'a' || ufunc->name[0] == 'm') &&
+            ((strcmp(ufunc->name,"add") == 0)
                 || (strcmp(ufunc->name,"multiply") == 0))) {
             if (PyTypeNum_ISBOOL(typenum)) {
                 typenum = NPY_LONG;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2774,9 +2774,16 @@ reduce_type_resolver(PyUFuncObject *ufunc, PyArrayObject *arr,
      * resolution.
      */
     if (odtype != NULL) {
-        type_tup = PyTuple_Pack(3, odtype, odtype, Py_None);
-        if (type_tup == NULL) {
-            return -1;
+        if (!(PyTypeNum_ISBOOL(odtype->type_num) &&
+              PyArray_TYPE(arr) == odtype->type_num) &&
+            !(PyTypeNum_ISFLOAT(odtype->type_num) &&
+              PyArray_TYPE(arr) == odtype->type_num &&
+              PyArray_DESCR(arr)->byteorder == odtype->byteorder &&
+              odtype->byteorder == NPY_NATIVE)) {
+            type_tup = PyTuple_Pack(3, odtype, odtype, Py_None);
+            if (type_tup == NULL) {
+                return -1;
+            }
         }
     }
 
@@ -2784,7 +2791,7 @@ reduce_type_resolver(PyUFuncObject *ufunc, PyArrayObject *arr,
     retcode = ufunc->type_resolver(
                         ufunc, NPY_UNSAFE_CASTING,
                         op, type_tup, dtypes);
-    Py_DECREF(type_tup);
+    Py_XDECREF(type_tup);
     if (retcode == -1) {
         return -1;
     }


### PR DESCRIPTION
some more small array performance improvements, please see the commits for details.
The changes are somewhat hackish and could probably also be resolved by a more extensive overhaul of the ufunc object, though these changes are also very simple and should we decide to do an overhaul its good to have a better performance in our benchmarks for comparison.

small reductions (O(100) elements) improve on my machine by ~20% and binary ufuncs by about ~10%.
- `add.reduce(ones(100))` from 1.80us to 1.5us
- `add(ones(100), ones(100))` from 0.77us to 0.7us
