### PR TITLE
TST: win32 also does not provide 16 byte alignment, for 1.9

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1049,11 +1049,12 @@ class TestArrayComparisons(TestCase):
 
 def assert_array_strict_equal(x, y):
     assert_array_equal(x, y)
-    # Check flags
-    if 'sparc' not in platform.platform().lower():
+    # Check flags, debian sparc and win32 don't provide 16 byte alignment
+    if (x.dtype.alignment > 8 and
+            'sparc' not in platform.platform().lower() and
+            sys.platform != 'win32'):
         assert_(x.flags == y.flags)
     else:
-        # sparc arrays may not be aligned for long double types
         assert_(x.flags.owndata == y.flags.owndata)
         assert_(x.flags.writeable == y.flags.writeable)
         assert_(x.flags.c_contiguous == y.flags.c_contiguous)

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -111,7 +111,7 @@ _cast_dict['CFLOAT'] = _cast_dict['FLOAT'] + ['CFLOAT']
 # 16 byte long double types this means the inout intent cannot be satisfied and
 # several tests fail as the alignment flag can be randomly true or fals
 # when numpy gains an aligned allocator the tests could be enabled again
-if 'sparc' not in platform.platform().lower():
+if 'sparc' not in platform.platform().lower() and sys.platform != 'win32':
     _type_names.extend(['LONGDOUBLE', 'CDOUBLE', 'CLONGDOUBLE'])
     _cast_dict['LONGDOUBLE'] = _cast_dict['LONG'] + \
                                ['ULONG', 'FLOAT', 'DOUBLE', 'LONGDOUBLE']


### PR DESCRIPTION
mingw builds set the alignment requirement for complex doubles types to
16 byte so the tests checking the alignment flag must be disabled as win32 only provides 8 bytes.
