### PR TITLE
BUG: None comparison deprecation does not affect scalars

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1078,6 +1078,24 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
 {
     PyObject *arr, *ret;
 
+    /*
+     * If the other object is None, False is always right. This avoids
+     * the array None comparison, at least until deprecation it is fixed.
+     * After that, this may be removed and numpy false would be returned.
+     *
+     * NOTE: np.equal(NaT, None) evaluates to TRUE! This is an
+     *       an inconsistency, which may has to be considered
+     *       when the deprecation is finished.
+     */
+    if (other == Py_None) {
+        if (cmp_op == Py_EQ) {
+            Py_RETURN_FALSE;
+        }
+        if (cmp_op == Py_NE) {
+            Py_RETURN_TRUE;
+        }
+    }
+
     arr = PyArray_FromScalar(self, NULL);
     if (arr == NULL) {
         return NULL;

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -12,7 +12,7 @@ from nose.plugins.skip import SkipTest
 
 import numpy as np
 from numpy.testing import (dec, run_module_suite, assert_raises,
-                           assert_warns, assert_array_equal)
+                           assert_warns, assert_array_equal, assert_)
 
 
 class _DeprecationTestCase(object):
@@ -425,6 +425,26 @@ class TestComparisonDepreactions(_DeprecationTestCase):
             warnings.filterwarnings('error', '', FutureWarning)
             assert_raises(FutureWarning, operator.eq, np.arange(3), None)
             assert_raises(FutureWarning, operator.ne, np.arange(3), None)
+
+    def test_scalar_none_comparison(self):
+        # Scalars should still just return false and not give a warnings.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', FutureWarning)
+            assert_(not np.float32(1) == None)
+            assert_(not np.str_('test') == None)
+            # This is dubious (see below):
+            assert_(not np.datetime64('NaT') == None)
+
+            assert_(np.float32(1) != None)
+            assert_(np.str_('test') != None)
+            # This is dubious (see below):
+            assert_(np.datetime64('NaT') != None)
+        assert_(len(w) == 0)
+
+        # For documentaiton purpose, this is why the datetime is dubious.
+        # At the time of deprecation this was no behaviour change, but
+        # it has to be considered when the deprecations is done.
+        assert_(np.equal(np.datetime64('NaT'), None))
 
 
 class TestIdentityComparisonDepreactions(_DeprecationTestCase):


### PR DESCRIPTION
This circumvents the None warnings for scalar comparisons.
Unfortunatly datetime NaT _can_ in some cases evaluate equal
to None because NaT.item() is None.

Closes gh-4894
