### PR TITLE
BUG: fix ineffective as ascontiguousarray

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1653,8 +1653,9 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
             }
             copy = NPY_FALSE;
 
-            /* order does not matter for 1d arrays */
-            if (PyArray_NDIM(op) > 1) {
+            /* order does not matter for contiguous 1d arrays */
+            if (PyArray_NDIM((PyArrayObject*)op) > 1 ||
+                !PyArray_IS_C_CONTIGUOUS((PyArrayObject*)op)) {
                 order_obj = PyDict_GetItem(kws, npy_ma_str_order);
                 if (order_obj != Py_None && order_obj != NULL) {
                     goto full_path;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -273,6 +273,16 @@ class TestArrayConstruction(TestCase):
         assert_array_equal(e, [[1, 3, 7], [1, 2, 3]])
         assert_array_equal(d, [[1, 5, 3], [1,2,3]])
 
+    def test_array_cont(self):
+        d = np.ones(10)[::2]
+        assert_(np.ascontiguousarray(d).flags.c_contiguous)
+        assert_(np.ascontiguousarray(d).flags.f_contiguous)
+        assert_(np.asfortranarray(d).flags.c_contiguous)
+        assert_(np.asfortranarray(d).flags.f_contiguous)
+        d = np.ones((10, 10))[::2,::2]
+        assert_(np.ascontiguousarray(d).flags.c_contiguous)
+        assert_(np.asfortranarray(d).flags.f_contiguous)
+
 
 class TestAssignment(TestCase):
     def test_assignment_broadcasting(self):


### PR DESCRIPTION
My last microoptimization break copying of non-contigous 1d arrays in
the continous array constructors.
What was that saying about premature optimization again?
