### PR TITLE
BUG: Avoid type promotion in tril and triu.

### DIFF
--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -324,6 +324,28 @@ def test_tril_triu_with_inf():
     assert_array_equal(np.tril(arr), out_tril)
 
 
+def test_tril_triu_dtype():
+    # Issue 4916
+    # tril and triu should return the same dtype as input
+    for c in np.typecodes['All']:
+        if c == 'V':
+            continue
+        arr = np.zeros((3, 3), dtype=c)
+        assert_equal(np.triu(arr).dtype, arr.dtype)
+        assert_equal(np.tril(arr).dtype, arr.dtype)
+
+    # check special cases
+    arr = np.array([['2001-01-01T12:00', '2002-02-03T13:56'],
+                    ['2004-01-01T12:00', '2003-01-03T13:45']],
+                   dtype='datetime64')
+    assert_equal(np.triu(arr).dtype, arr.dtype)
+    assert_equal(np.tril(arr).dtype, arr.dtype)
+
+    arr = np.zeros((3,3), dtype='f4,f4')
+    assert_equal(np.triu(arr).dtype, arr.dtype)
+    assert_equal(np.tril(arr).dtype, arr.dtype)
+
+
 def test_mask_indices():
     # simple test without offset
     iu = mask_indices(3, np.triu)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -453,7 +453,7 @@ def tril(m, k=0):
     m = asanyarray(m)
     mask = tri(*m.shape[-2:], k=k, dtype=bool)
 
-    return where(mask, m, 0)
+    return where(mask, m, zeros(1, m.dtype))
 
 
 def triu(m, k=0):
@@ -481,7 +481,7 @@ def triu(m, k=0):
     m = asanyarray(m)
     mask = tri(*m.shape[-2:], k=k-1, dtype=bool)
 
-    return where(mask, 0, m)
+    return where(mask, zeros(1, m.dtype), m)
 
 
 # Originally borrowed from John Hunter and matplotlib


### PR DESCRIPTION
This looks like it was originally fixed in [an old commit](https://github.com/numpy/numpy/commit/1af2f37eae78986b370e2d44df6c5156945d69d8), however the issue was reintroduced by the refactoring in [a recent commit](https://github.com/numpy/numpy/commit/1392888ec4ddb37d4fa7bbb9231712af0dda4ea6). This commit maintains the datatype of the array in `np.triu` and `np.tril`.

Before

```
>>> import numpy as np
>>> a = np.array([[0, 1], [1, 0]], dtype=np.bool)
>>> a
array([[False,  True],
       [ True, False]], dtype=bool)
>>> np.triu(a)
array([[0, 1],
       [0, 0]])
```

After

```
>>> import numpy as np
>>> a = np.array([[0, 1], [1, 0]], dtype=np.bool)
>>> a
array([[False,  True],
       [ True, False]], dtype=bool)
>>> np.triu(a)
array([[False,  True],
       [False, False]], dtype=bool)
>>> 
```
