### PR TITLE
BUG: fix string type inconsistency between zeros and zeros_like

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -240,6 +240,11 @@ a problem cannot occur.
 
 This change was already applied to the 1.8.1 release.
 
+``zeros_like`` for string dtypes now returns empty strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To match the `zeros` function `zeros_like` now returns an array initialized
+with empty strings instead of an array filled with `'0'`.
+
 
 New Features
 ============

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -131,7 +131,9 @@ def zeros_like(a, dtype=None, order='K', subok=True):
 
     """
     res = empty_like(a, dtype=dtype, order=order, subok=subok)
-    multiarray.copyto(res, 0, casting='unsafe')
+    # needed instead of a 0 to get same result as zeros for for string dtypes
+    z = zeros(1, dtype=res.dtype)
+    multiarray.copyto(res, z, casting='unsafe')
     return res
 
 def ones(shape, dtype=None, order='C'):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -515,6 +515,40 @@ class TestCreation(TestCase):
         d = zeros(10, dtype=[('k', object, 2)])
         assert_array_equal(d['k'], 0)
 
+    def test_zeros_like_like_zeros(self):
+        # test zeros_like returns the same as zeros
+        for c in np.typecodes['All']:
+            if c == 'V':
+                continue
+            d = zeros((3,3), dtype=c)
+            assert_array_equal(zeros_like(d), d)
+            assert_equal(zeros_like(d).dtype, d.dtype)
+        # explicitly check some special cases
+        d = zeros((3,3), dtype='S5')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+        d = zeros((3,3), dtype='U5')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+
+        d = zeros((3,3), dtype='<i4')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+        d = zeros((3,3), dtype='>i4')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+
+        d = zeros((3,3), dtype='<M8[s]')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+        d = zeros((3,3), dtype='>M8[s]')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+
+        d = zeros((3,3), dtype='f4,f4')
+        assert_array_equal(zeros_like(d), d)
+        assert_equal(zeros_like(d).dtype, d.dtype)
+
     def test_sequence_non_homogenous(self):
         assert_equal(np.array([4, 2**80]).dtype, np.object)
         assert_equal(np.array([4, 2**80, 4]).dtype, np.object)


### PR DESCRIPTION
np.zeros for strings returns empty strings while np.zeros_like of a
string array creates strings containing an string 0.
