### PR TITLE
ENH: better error message for invalid axis and concatenate inputs

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -576,6 +576,12 @@ PyArray_Concatenate(PyObject *op, int axis)
     PyArrayObject **arrays;
     PyArrayObject *ret;
 
+    if (!PySequence_Check(op)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "The first input argument needs to be a sequence");
+        return NULL;
+    }
+
     /* Convert the input list into arrays */
     narrays = PySequence_Size(op);
     if (narrays < 0) {


### PR DESCRIPTION
the old errors
np.concatenate(1,2)
TypeError: object of type 'int' has no len()

concatenate([1], [2])
TypeError: an integer is required

are not very helpful, add a new internal function that allows adding
some context to axis argument conversion failures and check for sequence
inputs in concatenate.
Closes gh-4923.
