### PR TITLE
Fix numpy compat  _inspect

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -57,7 +57,6 @@ else:
     asstr = str
     strchar = 'S'
 
-
     def isfileobj(f):
         return isinstance(f, file)
 

--- a/numpy/compat/setup.py
+++ b/numpy/compat/setup.py
@@ -8,5 +8,5 @@ def configuration(parent_package='',top_path=None):
     return config
 
 if __name__ == '__main__':
-    from numpy.distutils.core      import setup
+    from numpy.distutils.core import setup
     setup(configuration=configuration)

--- a/numpy/compat/tests/test_compat.py
+++ b/numpy/compat/tests/test_compat.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 from numpy.compat import isfileobj
-from numpy.testing import TestCase, assert_
+from numpy.testing import assert_
 from numpy.testing.utils import tempdir
 
 


### PR DESCRIPTION
Fix `_inpect.py` code the depends on the `dis` and `string` modules. The first fix is accomplished by deleting the offending code path and raising an error if there is an attempt to use it. Minor style fixes are made to the other files in `numpy/compat`.
