### PR TITLE
DOC: matrix.squeeze docstring

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -454,6 +454,60 @@ class matrix(N.ndarray):
         """
         return N.ndarray.sum(self, axis, dtype, out, keepdims=True)._collapse(axis)
 
+
+    # To update docstring from array to matrix...
+    def squeeze(self, axis=None):
+        """
+        Return a possibly reshaped matrix.
+
+        Refer to `numpy.squeeze` for more documentation.
+
+        Parameters
+        ----------
+        axis : None or int or tuple of ints, optional
+            Selects a subset of the single-dimensional entries in the shape.
+            If an axis is selected with shape entry greater than one,
+            an error is raised.
+
+        Returns
+        -------
+        squeezed : matrix
+            The matrix, but as a (1, N) matrix if it had shape (N, 1).
+
+        See Also
+        --------
+        numpy.squeeze : related function
+
+        Notes
+        -----
+        If `m` has a single column then that column is returned
+        as the single row of a matrix.  Otherwise `m` is returned.
+        The returned matrix is always either `m` itself or a view into `m`.
+        Supplying an axis keyword argument will not affect the returned matrix
+        but it may cause an error to be raised.
+
+        Examples
+        --------
+        >>> c = np.matrix([[1], [2]])
+        >>> c
+        matrix([[1],
+                [2]])
+        >>> c.squeeze()
+        matrix([[1, 2]])
+        >>> r = c.T
+        >>> r
+        matrix([[1, 2]])
+        >>> r.squeeze()
+        matrix([[1, 2]])
+        >>> m = np.matrix([[1, 2], [3, 4]])
+        >>> m.squeeze()
+        matrix([[1, 2],
+                [3, 4]])
+
+        """
+        return N.ndarray.squeeze(self, axis=axis)
+
+
     # To update docstring from array to matrix...
     def flatten(self, order='C'):
         """


### PR DESCRIPTION
Add a docstring that should be less wrong than http://docs.scipy.org/doc/numpy/reference/generated/numpy.matrix.squeeze.html and more informative.  The behavior should not be affected.
