### PR TITLE
1.9.x fix typo in _iotools.py docstring.

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -687,7 +687,7 @@ class StringConverter(object):
 
     def upgrade(self, value):
         """
-        Rind the best converter for a given string, and return the result.
+        Find the best converter for a given string, and return the result.
 
         The supplied string `value` is converted by testing different
         converters in order. First the `func` method of the


### PR DESCRIPTION
The error is in the StringConverter.upgrade docstring.
