### PR TITLE
ENH: Add 'HAS_CBLAS' macro for build purposes.

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -951,10 +951,10 @@ def configuration(parent_package='',top_path=None):
     #blas_info = {}
     def get_dotblas_sources(ext, build_dir):
         if blas_info:
-            if ('NO_ATLAS_INFO', 1) in blas_info.get('define_macros', []):
-                return None # dotblas needs ATLAS, Fortran compiled blas will not be sufficient.
-            return ext.depends[:1]
-        return None # no extension module will be built
+            if ('HAS_CBLAS', 1) in blas_info.get('define_macros', []):
+                return ext.depends[:1]
+        # dotblas needs CBLAS, Fortran compiled BLAS will not work.
+        return None
 
     config.add_extension('_dotblas',
                          sources = [get_dotblas_sources],

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -434,7 +434,7 @@ class UmfpackNotFoundError(NotFoundError):
     the UMFPACK environment variable."""
 
 
-class system_info:
+class system_info(object):
 
     """ get_info() is the only public method. Don't use others.
     """
@@ -962,7 +962,8 @@ class mkl_info(system_info):
         if info is None:
             return
         dict_append(info,
-                    define_macros=[('SCIPY_MKL_H', None)],
+                    define_macros=[('SCIPY_MKL_H', None),
+                                   ('HAS_CBLAS', 1)],
                     include_dirs=incl_dirs)
         if sys.platform == 'win32':
             pass  # win32 has no pthread library
@@ -1120,6 +1121,7 @@ class atlas_blas_info(atlas_info):
             h = os.path.dirname(h)
             dict_append(info, include_dirs=[h])
         info['language'] = 'c'
+        info['define_macros'] = [('HAS_CBLAS', 1)]
 
         atlas_version, atlas_extra_info = get_atlas_version(**atlas)
         dict_append(atlas, **atlas_extra_info)
@@ -1414,7 +1416,8 @@ class lapack_opt_info(system_info):
             if args:
                 self.set_info(extra_compile_args=args,
                               extra_link_args=link_args,
-                              define_macros=[('NO_ATLAS_INFO', 3)])
+                              define_macros=[('NO_ATLAS_INFO', 3),
+                                             ('HAS_CBLAS', 1)])
                 return
 
         #atlas_info = {} ## uncomment for testing
@@ -1515,7 +1518,8 @@ class blas_opt_info(system_info):
             if args:
                 self.set_info(extra_compile_args=args,
                               extra_link_args=link_args,
-                              define_macros=[('NO_ATLAS_INFO', 3)])
+                              define_macros=[('NO_ATLAS_INFO', 3),
+                                             ('HAS_CBLAS', 1)])
                 return
 
         need_blas = 0
@@ -1580,9 +1584,10 @@ class openblas_info(blas_info):
             return
 
         if not self.check_embedded_lapack(info):
-            return None
+            return
 
-        info['language'] = 'f77'  # XXX: is it generally true?
+        info['language'] = 'c'
+        info['define_macros'] = [('HAS_CBLAS', 1)]
         self.set_info(**info)
 
 


### PR DESCRIPTION
The current system works for MKL and OpenBLAS by default because the
mkl_info and openblas_info classes in numpy/distutils/system_info do not
define the macro 'NO_ATLAS_INFO=1' that currently signals the absence of
CBLAS. This PR declares the presence of CBLAS directly by defining the
'HAS_CBLAS=1' macro.
