### PR TITLE
DOC: remove 'count_reduce_items' from the 'Counting' section.

### DIFF
--- a/doc/source/reference/routines.sort.rst
+++ b/doc/source/reference/routines.sort.rst
@@ -39,4 +39,3 @@ Counting
    :toctree: generated/
 
    count_nonzero
-   count_reduce_items


### PR DESCRIPTION
There is no such public function.
