### PR TITLE
MAINT: Get rid of some harmless gcc warnings about macro redefines.

### DIFF
--- a/numpy/core/src/npysort/heapsort.c.src
+++ b/numpy/core/src/npysort/heapsort.c.src
@@ -28,9 +28,9 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include <stdlib.h>
 #include "npy_sort.h"
 #include "npysort_common.h"
+#include <stdlib.h>
 
 #define NOT_USED NPY_UNUSED(unused)
 #define PYA_QS_STACK 100

--- a/numpy/core/src/npysort/mergesort.c.src
+++ b/numpy/core/src/npysort/mergesort.c.src
@@ -28,9 +28,9 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include <stdlib.h>
 #include "npy_sort.h"
 #include "npysort_common.h"
+#include <stdlib.h>
 
 #define NOT_USED NPY_UNUSED(unused)
 #define PYA_QS_STACK 100

--- a/numpy/core/src/npysort/quicksort.c.src
+++ b/numpy/core/src/npysort/quicksort.c.src
@@ -28,9 +28,9 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include <stdlib.h>
 #include "npy_sort.h"
 #include "npysort_common.h"
+#include <stdlib.h>
 
 #define NOT_USED NPY_UNUSED(unused)
 #define PYA_QS_STACK 100


### PR DESCRIPTION
The Python.h header likes to be included first, otherwise warnings about
redefining "_POSIX_C_SOURCE" and "_XOPEN_SOURCE" are generated. This is
really a problem with the Python.h header, but can be worked around by
changing the order of inclusion.
