### PR TITLE
MAINT: Get rid of some harmless gcc warnings about macro redefines.

### DIFF
--- a/numpy/core/src/umath/operand_flag_tests.c.src
+++ b/numpy/core/src/umath/operand_flag_tests.c.src
@@ -1,11 +1,11 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include <math.h>
 #include <Python.h>
-#include <structmember.h>
 #include <numpy/arrayobject.h>
 #include <numpy/ufuncobject.h>
 #include "numpy/npy_3kcompat.h"
+#include <math.h>
+#include <structmember.h>
 
 
 static PyMethodDef TestMethods[] = {

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -2,12 +2,12 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include <math.h>
 #include <Python.h>
 #include <structmember.h>
 #include <numpy/arrayobject.h>
 #include <numpy/ufuncobject.h>
 #include <numpy/npy_3kcompat.h>
+#include <math.h>
 
 /* Relevant arithmetic exceptions */
 


### PR DESCRIPTION
The Python.h header likes to be included first, otherwise warnings about
redefining "_POSIX_C_SOURCE" and "_XOPEN_SOURCE" are generated. This is
really a problem with the Python.h header, but can be worked around by
changing the order of inclusion.

Missed a couple of these last time through. This should be all of them.
