### PR TITLE
Fixup of PR #4921

### DIFF
--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -55,8 +55,6 @@ npy_ObjectPower(PyObject *x, PyObject *y)
     return PyNumber_Power(x, y, Py_None);
 }
 
-
-#if defined(NPY_PY3K)
 /**begin repeat
  * #Kind = Max, Min#
  * #OP = Py_GE, Py_LE#
@@ -81,33 +79,6 @@ npy_Object@Kind@(PyObject *i1, PyObject *i2)
     return result;
 }
 /**end repeat**/
-
-#else
-/**begin repeat
- * #Kind = Max, Min#
- * #OP = >=, <=#
- */
-static PyObject *
-npy_Object@Kind@(PyObject *i1, PyObject *i2)
-{
-    PyObject *result;
-    int cmp;
-
-    if (PyObject_Cmp(i1, i2, &cmp) < 0) {
-        return NULL;
-    }
-    if (cmp @OP@ 0) {
-        result = i1;
-    }
-    else {
-        result = i2;
-    }
-    Py_INCREF(result);
-    return result;
-}
-/**end repeat**/
-#endif
-
 
 /* Emulates Python's 'a or b' behavior */
 static PyObject *

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -540,6 +540,17 @@ class TestMaximum(_FilterInvalids):
         out  = np.array([nan, nan, nan])
         assert_equal(np.maximum(arg1, arg2), out)
 
+    def test_object_nans(self):
+        # Multiple checks to give this a chance to
+        # fail if cmp is used instead of rich compare.
+        # Failure cannot be guaranteed.
+        for i in range(1):
+            x = np.array(float('nan'), np.object)
+            y = 1.0
+            z = np.array(float('nan'), np.object)
+            assert_(np.maximum(x, y) == 1.0)
+            assert_(np.maximum(z, y) == 1.0)
+
     def test_complex_nans(self):
         nan = np.nan
         for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)] :
@@ -586,6 +597,17 @@ class TestMinimum(_FilterInvalids):
         arg2 = np.array([nan, 0,   nan])
         out  = np.array([nan, nan, nan])
         assert_equal(np.minimum(arg1, arg2), out)
+
+    def test_object_nans(self):
+        # Multiple checks to give this a chance to
+        # fail if cmp is used instead of rich compare.
+        # Failure cannot be guaranteed.
+        for i in range(1):
+            x = np.array(float('nan'), np.object)
+            y = 1.0
+            z = np.array(float('nan'), np.object)
+            assert_(np.minimum(x, y) == 1.0)
+            assert_(np.minimum(z, y) == 1.0)
 
     def test_complex_nans(self):
         nan = np.nan


### PR DESCRIPTION
BUG: Fix NaN handling in npy_ObjectMax and npy_ObjectMin.

These functions currently fail randomly for Python < 3.x because they
use PyObject_Cmp, which looks at addresses for NaN objects. The fix is
to use PyObject_RichCompareBool, which is available in Python >= 2.6.
Note that for Python 2.6 and 2.7, PyObject_RichCompareBool falls back on
PyObject_Cmp when an object doesn't provide rich compare.

Closes #4903.
