### PR TITLE
Updating docs with boolean array indexing and nonzero order. 

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -357,11 +357,10 @@ faster when ``obj.shape == x.shape``.
 
 If ``obj.ndim == x.ndim``, ``x[obj]`` returns a 1-dimensional array
 filled with the elements of *x* corresponding to the :const:`True`
-values of *obj*.  The search order will be :term:`row-major` (C-style,
-last index varies the fastest). If *obj* has :const:`True` values at
-entries that are outside of the bounds of *x*, then an index error
-will be raised. If *obj* is smaller than *x* it is identical to
-filling it with :const:`False`.
+values of *obj*.  The search order will be :term:`row-major`,
+C-style. If *obj* has :const:`True` values at entries that are outside
+of the bounds of *x*, then an index error will be raised. If *obj* is
+smaller than *x* it is identical to filling it with :const:`False`.
 
 .. admonition:: Example
 

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -357,11 +357,11 @@ faster when ``obj.shape == x.shape``.
 
 If ``obj.ndim == x.ndim``, ``x[obj]`` returns a 1-dimensional array
 filled with the elements of *x* corresponding to the :const:`True`
-values of *obj*.
-The search order will be C-style (last index varies the fastest). If
-*obj* has :const:`True` values at entries that are outside of the
-bounds of *x*, then an index error will be raised. If *obj* is smaller
-than *x* it is identical to filling it with :const:`False`.
+values of *obj*.  The search order will be :term:`row-major` (C-style,
+last index varies the fastest). If *obj* has :const:`True` values at
+entries that are outside of the bounds of *x*, then an index error
+will be raised. If *obj* is smaller than *x* it is identical to
+filling it with :const:`False`.
 
 .. admonition:: Example
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -28,7 +28,7 @@ add_newdoc('numpy.core', 'flatiter',
     It allows iterating over the array as if it were a 1-D array,
     either in a for-loop or by calling its `next` method.
 
-    Iteration is done in :term:`row-major`, C-style order (the last
+    Iteration is done in row-major, C-style order (the last
     index varying the fastest). The iterator can also be indexed using
     basic slicing or advanced indexing.
 
@@ -745,8 +745,8 @@ add_newdoc('numpy.core.multiarray', 'empty',
     dtype : data-type, optional
         Desired output data-type.
     order : {'C', 'F'}, optional
-        Whether to store multi-dimensional data in :term:`row-major`,
-        C-style or :term:`column-major`, Fortran-style order in
+        Whether to store multi-dimensional data in row-major
+        (C-style) or column-major (Fortran-style) order in
         memory.
 
     Returns
@@ -2315,7 +2315,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray',
     strides : tuple of ints, optional
         Strides of data in memory.
     order : {'C', 'F'}, optional
-        :term:`Row-major <row-major>`, C-style or :term:`column-major`, Fortran-style order.
+        Row-major (C-style) or column-major (Fortran-style) order.
 
     Attributes
     ----------
@@ -3459,8 +3459,8 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('flatten',
     Parameters
     ----------
     order : {'C', 'F', 'A'}, optional
-        Whether to flatten in :term:`row-major`, C-style or
-        :term:`column-major`, Fortran-style order or preserve the
+        Whether to flatten in row-major (C-style) or
+        column-major (Fortran-style) order or preserve the
         C/Fortran ordering from `a`.  The default is 'C'.
 
     Returns
@@ -5036,8 +5036,8 @@ add_newdoc('numpy.lib._compiled_base', 'ravel_multi_index',
         wrap will clip to 0 instead.
     order : {'C', 'F'}, optional
         Determines whether the multi-index should be viewed as
-        indexing in :term:`row-major`, C-style or
-        :term:`column-major`, Fortran-style order.
+        indexing in row-major (C-style) or column-major
+        (Fortran-style) order.
 
     Returns
     -------
@@ -5086,10 +5086,8 @@ add_newdoc('numpy.lib._compiled_base', 'unravel_index',
         The shape of the array to use for unraveling ``indices``.
     order : {'C', 'F'}, optional
         .. versionadded:: 1.6.0
-
         Determines whether the indices should be viewed as indexing in
-        :term:`row-major`, C-style or :term:`column-major`,
-        Fortran-style order.
+        row-major (C-style) or column-major (Fortran-style) order.
 
     Returns
     -------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -28,9 +28,9 @@ add_newdoc('numpy.core', 'flatiter',
     It allows iterating over the array as if it were a 1-D array,
     either in a for-loop or by calling its `next` method.
 
-    Iteration is done in :term:`row-major` order (C-contiguous style,
-    with the last index varying the fastest). The iterator can also be
-    indexed using basic slicing or advanced indexing.
+    Iteration is done in :term:`row-major`, C-style order (the last
+    index varying the fastest). The iterator can also be indexed using
+    basic slicing or advanced indexing.
 
     See Also
     --------
@@ -745,8 +745,9 @@ add_newdoc('numpy.core.multiarray', 'empty',
     dtype : data-type, optional
         Desired output data-type.
     order : {'C', 'F'}, optional
-        Whether to store multi-dimensional data in C (row-major) or
-        Fortran (column-major) order in memory.
+        Whether to store multi-dimensional data in :term:`row-major`,
+        C-style or :term:`column-major`, Fortran-style order in
+        memory.
 
     Returns
     -------
@@ -2314,7 +2315,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray',
     strides : tuple of ints, optional
         Strides of data in memory.
     order : {'C', 'F'}, optional
-        Row-major or column-major order.
+        :term:`Row-major <row-major>`, C-style or :term:`column-major`, Fortran-style order.
 
     Attributes
     ----------
@@ -3458,9 +3459,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('flatten',
     Parameters
     ----------
     order : {'C', 'F', 'A'}, optional
-        Whether to flatten in C (row-major), Fortran (column-major) order,
-        or preserve the C/Fortran ordering from `a`.
-        The default is 'C'.
+        Whether to flatten in :term:`row-major`, C-style or
+        :term:`column-major`, Fortran-style order or preserve the
+        C/Fortran ordering from `a`.  The default is 'C'.
 
     Returns
     -------
@@ -5034,8 +5035,9 @@ add_newdoc('numpy.lib._compiled_base', 'ravel_multi_index',
         In 'clip' mode, a negative index which would normally
         wrap will clip to 0 instead.
     order : {'C', 'F'}, optional
-        Determines whether the multi-index should be viewed as indexing in
-        C (row-major) order or FORTRAN (column-major) order.
+        Determines whether the multi-index should be viewed as
+        indexing in :term:`row-major`, C-style or
+        :term:`column-major`, Fortran-style order.
 
     Returns
     -------
@@ -5086,7 +5088,8 @@ add_newdoc('numpy.lib._compiled_base', 'unravel_index',
         .. versionadded:: 1.6.0
 
         Determines whether the indices should be viewed as indexing in
-        C (row-major) order or FORTRAN (column-major) order.
+        :term:`row-major`, C-style or :term:`column-major`,
+        Fortran-style order.
 
     Returns
     -------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -28,9 +28,9 @@ add_newdoc('numpy.core', 'flatiter',
     It allows iterating over the array as if it were a 1-D array,
     either in a for-loop or by calling its `next` method.
 
-    Iteration is done in C-contiguous style, with the last index varying the
-    fastest. The iterator can also be indexed using basic slicing or
-    advanced indexing.
+    Iteration is done in :term:`row-major` order (C-contiguous style,
+    with the last index varying the fastest). The iterator can also be
+    indexed using basic slicing or advanced indexing.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1281,8 +1281,7 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     return asarray(a).trace(offset, axis1, axis2, dtype, out)
 
 def ravel(a, order='C'):
-    """
-    Return a flattened array.
+    """Return a flattened array.
 
     A 1-D array, containing the elements of the input, is returned.  A copy is
     made only if needed.
@@ -1294,10 +1293,10 @@ def ravel(a, order='C'):
         `order`, and packed as a 1-D array.
     order : {'C','F', 'A', 'K'}, optional
         The elements of `a` are read using this index order. 'C' means
-        to index the elements in :term:`row-major` (C-like) order,
+        to index the elements in :term:`row-major`, C-style order,
         with the last axis index changing fastest, back to the first
         axis index changing slowest.  'F' means to index the elements
-        in :term:`column-major` (Fortran-like) index order, with the
+        in :term:`column-major`, Fortran-style order, with the
         first index changing fastest, and the last index changing
         slowest. Note that the 'C' and 'F' options take no account of
         the memory layout of the underlying array, and only refer to
@@ -1321,12 +1320,12 @@ def ravel(a, order='C'):
 
     Notes
     -----
-    In :term:`row-major` (C-like) order, in two dimensions, the row
+    In :term:`row-major`, C-style order, in two dimensions, the row
     index varies the slowest, and the column index the quickest.  This
     can be generalized to multiple dimensions, where row-major order
     implies that the index along the first axis varies slowest, and
     the index along the last quickest.  The opposite holds for
-    Fortran-like, or column-major, index ordering.
+    :term:`column-major`, Fortran-style index ordering.
 
     Examples
     --------
@@ -1380,7 +1379,7 @@ def nonzero(a):
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in
-    :term:`row-major` (C-style) order. The corresponding non-zero
+    :term:`row-major`, C-style order. The corresponding non-zero
     values can be obtained with::
 
         a[nonzero(a)]

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1293,10 +1293,10 @@ def ravel(a, order='C'):
         `order`, and packed as a 1-D array.
     order : {'C','F', 'A', 'K'}, optional
         The elements of `a` are read using this index order. 'C' means
-        to index the elements in :term:`row-major`, C-style order,
+        to index the elements in row-major, C-style order,
         with the last axis index changing fastest, back to the first
         axis index changing slowest.  'F' means to index the elements
-        in :term:`column-major`, Fortran-style order, with the
+        in column-major, Fortran-style order, with the
         first index changing fastest, and the last index changing
         slowest. Note that the 'C' and 'F' options take no account of
         the memory layout of the underlying array, and only refer to
@@ -1320,12 +1320,12 @@ def ravel(a, order='C'):
 
     Notes
     -----
-    In :term:`row-major`, C-style order, in two dimensions, the row
-    index varies the slowest, and the column index the quickest.  This
-    can be generalized to multiple dimensions, where row-major order
+    In row-major, C-style order, in two dimensions, the row index
+    varies the slowest, and the column index the quickest.  This can
+    be generalized to multiple dimensions, where row-major order
     implies that the index along the first axis varies slowest, and
     the index along the last quickest.  The opposite holds for
-    :term:`column-major`, Fortran-style index ordering.
+    column-major, Fortran-style index ordering.
 
     Examples
     --------
@@ -1379,7 +1379,7 @@ def nonzero(a):
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in
-    :term:`row-major`, C-style order. The corresponding non-zero
+    row-major, C-style order. The corresponding non-zero
     values can be obtained with::
 
         a[nonzero(a)]

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1293,17 +1293,20 @@ def ravel(a, order='C'):
         Input array.  The elements in `a` are read in the order specified by
         `order`, and packed as a 1-D array.
     order : {'C','F', 'A', 'K'}, optional
-        The elements of `a` are read using this index order. 'C' means to
-        index the elements in C-like order, with the last axis index changing
-        fastest, back to the first axis index changing slowest.   'F' means to
-        index the elements in Fortran-like index order, with the first index
-        changing fastest, and the last index changing slowest. Note that the 'C'
-        and 'F' options take no account of the memory layout of the underlying
-        array, and only refer to the order of axis indexing.  'A' means to read
-        the elements in Fortran-like index order if `a` is Fortran *contiguous*
-        in memory, C-like order otherwise.  'K' means to read the elements in
-        the order they occur in memory, except for reversing the data when
-        strides are negative.  By default, 'C' index order is used.
+        The elements of `a` are read using this index order. 'C' means
+        to index the elements in :term:`row-major` (C-like) order,
+        with the last axis index changing fastest, back to the first
+        axis index changing slowest.  'F' means to index the elements
+        in :term:`column-major` (Fortran-like) index order, with the
+        first index changing fastest, and the last index changing
+        slowest. Note that the 'C' and 'F' options take no account of
+        the memory layout of the underlying array, and only refer to
+        the order of axis indexing.  'A' means to read the elements in
+        Fortran-like index order if `a` is Fortran *contiguous* in
+        memory, C-like order otherwise.  'K' means to read the
+        elements in the order they occur in memory, except for
+        reversing the data when strides are negative.  By default, 'C'
+        index order is used.
 
     Returns
     -------
@@ -1318,11 +1321,12 @@ def ravel(a, order='C'):
 
     Notes
     -----
-    In C-like (row-major) order, in two dimensions, the row index varies the
-    slowest, and the column index the quickest.  This can be generalized to
-    multiple dimensions, where row-major order implies that the index along the
-    first axis varies slowest, and the index along the last quickest.  The
-    opposite holds for Fortran-like, or column-major, index ordering.
+    In :term:`row-major` (C-like) order, in two dimensions, the row
+    index varies the slowest, and the column index the quickest.  This
+    can be generalized to multiple dimensions, where row-major order
+    implies that the index along the first axis varies slowest, and
+    the index along the last quickest.  The opposite holds for
+    Fortran-like, or column-major, index ordering.
 
     Examples
     --------
@@ -1373,9 +1377,11 @@ def nonzero(a):
     """
     Return the indices of the elements that are non-zero.
 
-    Returns a tuple of arrays, one for each dimension of `a`, containing
-    the indices of the non-zero elements in that dimension. The
-    corresponding non-zero values can be obtained with::
+    Returns a tuple of arrays, one for each dimension of `a`,
+    containing the indices of the non-zero elements in that
+    dimension. The values in `a` are always tested and returned in
+    :term:`row-major` (C-style) order. The corresponding non-zero
+    values can be obtained with::
 
         a[nonzero(a)]
 

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -21,8 +21,7 @@ mode_equivalents = {
     }
 
 class memmap(ndarray):
-    """
-    Create a memory-map to an array stored in a *binary* file on disk.
+    """Create a memory-map to an array stored in a *binary* file on disk.
 
     Memory-mapped files are used for accessing small segments of large files
     on disk, without reading the entire file into memory.  Numpy's
@@ -80,9 +79,9 @@ class memmap(ndarray):
         and data-type.
     order : {'C', 'F'}, optional
         Specify the order of the ndarray memory layout:
-        :term:`row-major` ('C') or :term:`column-major` ('F').  This
-        only has an effect if the shape is greater than 1-D.  The
-        default order is 'C'.
+        :term:`row-major`, C-style or :term:`column-major`,
+        Fortran-style.  This only has an effect if the shape is
+        greater than 1-D.  The default order is 'C'.
 
     Attributes
     ----------

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -79,9 +79,10 @@ class memmap(ndarray):
         will be 1-D with the number of elements determined by file size
         and data-type.
     order : {'C', 'F'}, optional
-        Specify the order of the ndarray memory layout: C (row-major) or
-        Fortran (column-major).  This only has an effect if the shape is
-        greater than 1-D.  The default order is 'C'.
+        Specify the order of the ndarray memory layout:
+        :term:`row-major` ('C') or :term:`column-major` ('F').  This
+        only has an effect if the shape is greater than 1-D.  The
+        default order is 'C'.
 
     Attributes
     ----------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -404,8 +404,8 @@ def asarray(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use row-major ('C') or column-major ('F' for FORTRAN)
-        memory representation.  Defaults to 'C'.
+        Whether to use :term:`row-major` ('C') or :term:`column-major`
+        ('F' for FORTRAN) memory representation.  Defaults to 'C'.
 
     Returns
     -------
@@ -474,8 +474,8 @@ def asanyarray(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use row-major ('C') or column-major ('F') memory
-        representation.  Defaults to 'C'.
+        Whether to use :term:`row-major` ('C') or :term:`column-major`
+        ('F') memory representation.  Defaults to 'C'.
 
     Returns
     -------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -403,8 +403,8 @@ def asarray(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use :term:`row-major`, C-style or
-        :term:`column-major`, Fortran-style memory representation.
+        Whether to use row-major (C-style) or
+        column-major (Fortran-style) memory representation.
         Defaults to 'C'.
 
     Returns
@@ -473,9 +473,8 @@ def asanyarray(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use :term:`row-major`, C-style or
-        :term:`column-major`, Fortran-style memory representation.
-        Defaults to 'C'.
+        Whether to use row-major (C-style) or column-major
+        (Fortran-style) memory representation.  Defaults to 'C'.
 
     Returns
     -------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -392,8 +392,7 @@ putmask = multiarray.putmask
 einsum = multiarray.einsum
 
 def asarray(a, dtype=None, order=None):
-    """
-    Convert the input to an array.
+    """Convert the input to an array.
 
     Parameters
     ----------
@@ -404,8 +403,9 @@ def asarray(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use :term:`row-major` ('C') or :term:`column-major`
-        ('F' for FORTRAN) memory representation.  Defaults to 'C'.
+        Whether to use :term:`row-major`, C-style or
+        :term:`column-major`, Fortran-style memory representation.
+        Defaults to 'C'.
 
     Returns
     -------
@@ -462,8 +462,7 @@ def asarray(a, dtype=None, order=None):
     return array(a, dtype, copy=False, order=order)
 
 def asanyarray(a, dtype=None, order=None):
-    """
-    Convert the input to an ndarray, but pass ndarray subclasses through.
+    """Convert the input to an ndarray, but pass ndarray subclasses through.
 
     Parameters
     ----------
@@ -474,8 +473,9 @@ def asanyarray(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use :term:`row-major` ('C') or :term:`column-major`
-        ('F') memory representation.  Defaults to 'C'.
+        Whether to use :term:`row-major`, C-style or
+        :term:`column-major`, Fortran-style memory representation.
+        Defaults to 'C'.
 
     Returns
     -------

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -284,8 +284,7 @@ class record(nt.void):
 #  the fields (and any subfields)
 
 class recarray(ndarray):
-    """
-    Construct an ndarray that allows field access using attributes.
+    """Construct an ndarray that allows field access using attributes.
 
     Arrays may have a data-types containing fields, analogous
     to columns in a spread sheet.  An example is ``[(x, int), (y, float)]``,
@@ -334,7 +333,8 @@ class recarray(ndarray):
     offset : int, optional
         Start reading buffer (`buf`) from this offset onwards.
     order : {'C', 'F'}, optional
-        :term:`Row-major <row-major>` or :term:`column-major` order.
+        :term:`Row-major <row-major>`, C-style or
+        :term:`column-major`, Fortran-style order.
 
     Returns
     -------

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -334,7 +334,7 @@ class recarray(ndarray):
     offset : int, optional
         Start reading buffer (`buf`) from this offset onwards.
     order : {'C', 'F'}, optional
-        Row-major or column-major order.
+        :term:`Row-major <row-major>` or :term:`column-major` order.
 
     Returns
     -------

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -333,8 +333,7 @@ class recarray(ndarray):
     offset : int, optional
         Start reading buffer (`buf`) from this offset onwards.
     order : {'C', 'F'}, optional
-        :term:`Row-major <row-major>`, C-style or
-        :term:`column-major`, Fortran-style order.
+        Row-major (C-style) or column-major (Fortran-style) order.
 
     Returns
     -------

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -232,7 +232,7 @@ Unlike in the case of integer index arrays, in the boolean case, the
 result is a 1-D array containing all the elements in the indexed array
 corresponding to all the true elements in the boolean array. The
 elements in the indexed array is always iterated and returned in
-:term:`row-major`, C-style order. The result is also identical to
+:term:`row-major` (C-style) order. The result is also identical to
 ``y[np.nonzero(b)]``. As with index arrays, what is returned is a copy
 of the data, not a view as one gets with slices.
 

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -229,10 +229,13 @@ most straightforward case, the boolean array has the same shape: ::
  >>> y[b]
  array([21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34])
 
-The result is a 1-D array containing all the elements in the indexed
-array corresponding to all the true elements in the boolean array. As
-with index arrays, what is returned is a copy of the data, not a view
-as one gets with slices.
+Unlike in the case of integer index arrays, in the boolean case, the
+result is a 1-D array containing all the elements in the indexed array
+corresponding to all the true elements in the boolean array. The
+elements in the indexed array is always iterated and returned in
+:term:`row-major` order. The result is also identical to
+``y[np.nonzero(b)]``. As with index arrays, what is returned is a copy
+of the data, not a view as one gets with slices.
 
 The result will be multidimensional if y has more dimensions than b.
 For example: ::

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -1,5 +1,4 @@
-"""
-==============
+"""==============
 Array indexing
 ==============
 
@@ -233,7 +232,7 @@ Unlike in the case of integer index arrays, in the boolean case, the
 result is a 1-D array containing all the elements in the indexed array
 corresponding to all the true elements in the boolean array. The
 elements in the indexed array is always iterated and returned in
-:term:`row-major` order. The result is also identical to
+:term:`row-major`, C-style order. The result is also identical to
 ``y[np.nonzero(b)]``. As with index arrays, what is returned is a copy
 of the data, not a view as one gets with slices.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -559,8 +559,8 @@ def asarray_chkfinite(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-         Whether to use :term:`row-major`, C-style or
-         :term:`column-major`, Fortran-style memory representation.
+         Whether to use row-major (C-style) or
+         column-major (Fortran-style) memory representation.
          Defaults to 'C'.
 
     Returns

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -548,8 +548,7 @@ def average(a, axis=None, weights=None, returned=False):
 
 
 def asarray_chkfinite(a, dtype=None, order=None):
-    """
-    Convert the input to an array, checking for NaNs or Infs.
+    """Convert the input to an array, checking for NaNs or Infs.
 
     Parameters
     ----------
@@ -560,8 +559,9 @@ def asarray_chkfinite(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use :term:`row-major` ('C') or :term:`column-major`
-        ('F') memory representation.  Defaults to 'C'.
+         Whether to use :term:`row-major`, C-style or
+         :term:`column-major`, Fortran-style memory representation.
+         Defaults to 'C'.
 
     Returns
     -------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -560,8 +560,8 @@ def asarray_chkfinite(a, dtype=None, order=None):
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
     order : {'C', 'F'}, optional
-        Whether to use row-major ('C') or column-major ('FORTRAN') memory
-        representation.  Defaults to 'C'.
+        Whether to use :term:`row-major` ('C') or :term:`column-major`
+        ('F') memory representation.  Defaults to 'C'.
 
     Returns
     -------

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -21,8 +21,9 @@ def empty(shape, dtype=None, order='C'):
     dtype : data-type, optional
         Desired output data-type.
     order : {'C', 'F'}, optional
-        Whether to store multi-dimensional data in C (row-major) or
-        Fortran (column-major) order in memory.
+        Whether to store multi-dimensional data in :term:`row-major`
+        (C-style) or :term:`column-major` (Fortran-style) order in
+        memory.
 
     See Also
     --------

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -20,8 +20,8 @@ def empty(shape, dtype=None, order='C'):
     dtype : data-type, optional
         Desired output data-type.
     order : {'C', 'F'}, optional
-        Whether to store multi-dimensional data in :term:`row-major`,
-        C-style or :term:`column-major`, Fortran-style order in
+        Whether to store multi-dimensional data in row-major
+        (C-style) or column-major (Fortran-style) order in
         memory.
 
     See Also

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -11,8 +11,7 @@ __all__ = np.__all__[:] # copy numpy namespace
 __all__ += ['rand', 'randn', 'repmat']
 
 def empty(shape, dtype=None, order='C'):
-    """
-    Return a new matrix of given shape and type, without initializing entries.
+    """Return a new matrix of given shape and type, without initializing entries.
 
     Parameters
     ----------
@@ -21,8 +20,8 @@ def empty(shape, dtype=None, order='C'):
     dtype : data-type, optional
         Desired output data-type.
     order : {'C', 'F'}, optional
-        Whether to store multi-dimensional data in :term:`row-major`
-        (C-style) or :term:`column-major` (Fortran-style) order in
+        Whether to store multi-dimensional data in :term:`row-major`,
+        C-style or :term:`column-major`, Fortran-style order in
         memory.
 
     See Also


### PR DESCRIPTION
Small docs update of boolean indexing in the user and reference manuals and at _np.nonzero_ to close #3177. Also adding links to _row-major_ and _column-major_ terms where found. 
