### PR TITLE
TST: silence deprecation warnings for bad index calls

### DIFF
--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -34,8 +34,8 @@ class TestIndexing(TestCase):
 
         # Regression, it needs to fall through integer and fancy indexing
         # cases, so need the with statement to ignore the non-integer error.
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', '', DeprecationWarning)
+        with warnings.catch_warnings(record=True):
+            warnings.filterwarnings('always', '', DeprecationWarning)
             a = np.array([1.])
             assert_(isinstance(a[0.], np.float_))
 
@@ -111,7 +111,9 @@ class TestIndexing(TestCase):
         # Index out of bounds produces IndexError
         assert_raises(IndexError, a.__getitem__, 1<<30)
         # Index overflow produces IndexError
-        assert_raises(IndexError, a.__getitem__, 1<<64)
+        with warnings.catch_warnings(record=True):
+            warnings.filterwarnings('always', '', DeprecationWarning)
+            assert_raises(IndexError, a.__getitem__, 1<<64)
 
     def test_single_bool_index(self):
         # Single boolean index

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import warnings
 from numpy.testing import *
 from numpy.compat import asbytes, asunicode
 import numpy as np
@@ -363,7 +364,9 @@ class TestMultipleFields(TestCase):
     def setUp(self):
         self.ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
     def _bad_call(self):
-        return self.ary['f0', 'f1']
+        with warnings.catch_warnings(record=True):
+            warnings.filterwarnings('always', '', DeprecationWarning)
+            return self.ary['f0', 'f1']
     def test_no_tuple(self):
         self.assertRaises(IndexError, self._bad_call)
     def test_return(self):


### PR DESCRIPTION
Some bad indexing calls throw exceptions and deprecations, silence the
warnings in the test.
