### PR TITLE
support rpath for GNU Fortran compiler.

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -220,6 +220,9 @@ class GnuFCompiler(FCompiler):
     def get_flags_arch(self):
         return []
 
+    def runtime_library_dir_option(self, dir):
+        return '-Wl,-rpath="%s"' % dir
+
 class Gnu95FCompiler(GnuFCompiler):
     compiler_type = 'gnu95'
     compiler_aliases = ('gfortran',)


### PR DESCRIPTION
Hello !

`python setup.py build_ext --rpath=...` raises a NotImplementedError exception, because runtime_library_dir_option() is not defined in numpy/distutils/fcompiler/*.py.

```
...
x86_64-linux-gnu-gcc: numpy/linalg/lapack_litemodule.c
x86_64-linux-gnu-gcc: numpy/linalg/lapack_lite/python_xerbla.c
Traceback (most recent call last):
  File "setup.py", line 239, in <module>
    setup_package()
  File "setup.py", line 231, in setup_package
    setup(**metadata)
  File "/tmp/numpy/numpy/distutils/core.py", line 169, in setup
    return old_setup(**new_attr)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/tmp/numpy/numpy/distutils/command/build_ext.py", line 234, in run
    self.build_extensions()
  File "/usr/lib/python2.7/distutils/command/build_ext.py", line 446, in build_extensions
    self.build_extension(ext)
  File "/tmp/numpy/numpy/distutils/command/build_ext.py", line 422, in build_extension
    build_temp=self.build_temp,**kws)
  File "/usr/lib/python2.7/distutils/ccompiler.py", line 691, in link_shared_object
    extra_preargs, extra_postargs, build_temp, target_lang)
  File "/tmp/numpy/numpy/distutils/fcompiler/__init__.py", line 645, in link
    libraries)
  File "/tmp/numpy/numpy/distutils/ccompiler.py", line 573, in gen_lib_options
    runtime_library_dirs, libraries)
  File "/usr/lib/python2.7/distutils/ccompiler.py", line 1071, in gen_lib_options
    opt = compiler.runtime_library_dir_option(dir)
  File "/usr/lib/python2.7/distutils/ccompiler.py", line 718, in runtime_library_dir_option
    raise NotImplementedError
NotImplementedError
```

Here is the comment in /usr/lib/python2.7/distutils/ccompiler.py ::

```
    # -- Miscellaneous methods -----------------------------------------
    # These are all used by the 'gen_lib_options() function; there is
    # no appropriate default implementation so subclasses should
    # implement all of these.
    (snip)
    def runtime_library_dir_option(self, dir):
        """Return the compiler option to add 'dir' to the list of
        directories searched for runtime libraries.
        """
        raise NotImplementedError
```

I implemented the method for GNU Fortran compiler, that I am using. Ideally we need the implementation for other compilers as well.
