### PR TITLE
BUG: set needs-init flag for unicode dtype

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3696,6 +3696,7 @@ static int
  * #align = char, char, npy_ucs4#
  * #NAME = Void, String, Unicode#
  * #endian = |, |, =#
+ * #flags = 0, 0, NPY_NEEDS_INIT#
  */
 static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     {
@@ -3775,8 +3776,8 @@ static PyArray_Descr @from@_Descr = {
     NPY_@from@LTR,
     /* byteorder */
     '@endian@',
-    /* flags */
-    0,
+    /* flags, unicode needs init as py3.3 does not like printing garbage  */
+    @flags@,
     /* type_num */
     NPY_@from@,
     /* elsize */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -549,6 +549,12 @@ class TestCreation(TestCase):
         assert_array_equal(zeros_like(d), d)
         assert_equal(zeros_like(d).dtype, d.dtype)
 
+    def test_empty_unicode(self):
+        # don't throw decode errors on garbage memory
+        for i in range(5, 100, 5):
+            d = np.empty(i, dtype='U')
+            str(d)
+
     def test_sequence_non_homogenous(self):
         assert_equal(np.array([4, 2**80]).dtype, np.object)
         assert_equal(np.array([4, 2**80, 4]).dtype, np.object)


### PR DESCRIPTION
Python >= 3.3 does not like printing garbage unicode so printing
np.empty(x, 'U') can throw UnicodeDecode errors.
It is probably easier to just require initializing the dtype as a whole
instead of trying to catching the decode error on all places where it
might occur. Hopefully 0 is a valid code in all codecs.
Closes gh-4994.
