### PR TITLE
changes to return item rather than scalar for user defined types

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1417,8 +1417,13 @@ array_subscript(PyArrayObject *self, PyObject *op)
         if (get_item_pointer(self, &item, indices, index_num) < 0) {
             goto finish;
         }
-        result = (PyObject *) PyArray_Scalar(item, PyArray_DESCR(self),
+        if (PyTypeNum_ISUSERDEF(PyArray_DESCR(self)->type_num)) {
+            result = (PyObject *) PyArray_GETITEM(self, item);
+        }
+        else {
+            result = (PyObject *) PyArray_Scalar(item, PyArray_DESCR(self),
                                              (PyObject *)self);
+        }
         /* Because the index is full integer, we do not need to decref */
         return result;
     }


### PR DESCRIPTION
This updates what is effectively the `__getitem__()` method. For arrays such that the dtype is a user defined type, you receive the return that dtype's `getitem()` rather than a numpy scalar of the dtype. This allow the custom type to present a single Python API as well as an associated dtype.  It also prevents users from having to subclass ndarray to get the appropriate behaviour.

For example, suppose that we have a dtype representing a C++ `std::vector<int>` and then we had a numpy array of this dtype.  From Python, it might look like

``` python
>>> arr
array([array([0, 0, 0, 0, 0], dtype=int32),
       array([0, 1, 2, 3, 4], dtype=int32),
       array([0, 2, 4, 6, 8], dtype=int32)], dtype='xd_vector_int')
```

Without this PR, you'd have to do the following to access the most deeply nested elements:

``` python
>>> arr.item(2)[4]
8
```

This is because you cannot index a scalar:

``` python
>>> arr[2][4]
IndexError: invalid index to scalar variable
```

With this PR, the idiomatic expression is now allowable because `arr[2]` is the associated Python type:

``` python
>>> arr[2][4]
8
```

This is a pretty big deal for [xdress](http://xdress.org/) which creates many custom dtypes and provided a Python interface into those.  See xdress/xdress#265 for what prompted this.

Thanks for considering!
