### PR TITLE
support __sizeof__()

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1901,6 +1901,16 @@ array_dumps(PyArrayObject *self, PyObject *args)
 
 
 static PyObject *
+array_sizeof(PyArrayObject *self, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+    return PyObject_GetAttrString(self, "nbytes");
+}
+
+
+static PyObject *
 array_transpose(PyArrayObject *self, PyObject *args)
 {
     PyObject *shape = Py_None;
@@ -2306,6 +2316,11 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_VARARGS, NULL},
     {"__array_wrap__",
         (PyCFunction)array_wraparray,
+        METH_VARARGS, NULL},
+
+    /* for the sys module */
+    {"__sizeof__",
+        (PyCFunction) array_sizeof,
         METH_VARARGS, NULL},
 
     /* for the copy module */

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1901,12 +1901,15 @@ array_dumps(PyArrayObject *self, PyObject *args)
 
 
 static PyObject *
-array_sizeof(PyArrayObject *self, PyObject *args)
+array_sizeof(PyArrayObject *self)
 {
-    if (!PyArg_ParseTuple(args, "")) {
-        return NULL;
+    /* object + dimension and strides */
+    Py_ssize_t nbytes = NPY_SIZEOF_PYARRAYOBJECT +
+        PyArray_NDIM(self) * sizeof(npy_intp) * 2;
+    if (PyArray_CHKFLAGS(self, NPY_ARRAY_OWNDATA)) {
+        nbytes += PyArray_NBYTES(self);
     }
-    return PyObject_GetAttrString(self, "nbytes");
+    return PyLong_FromSsize_t(nbytes);
 }
 
 
@@ -2321,7 +2324,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
     /* for the sys module */
     {"__sizeof__",
         (PyCFunction) array_sizeof,
-        METH_VARARGS, NULL},
+        METH_NOARGS, NULL},
 
     /* for the copy module */
     {"__copy__",

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1193,6 +1193,20 @@ gentype_size_get(PyObject *NPY_UNUSED(self))
     return PyInt_FromLong(1);
 }
 
+static PyObject *
+gentype_sizeof(PyObject *self)
+{
+    Py_ssize_t nbytes;
+    PyObject * isz = gentype_itemsize_get(self);
+    if (isz == NULL) {
+        return NULL;
+    }
+    nbytes = PyLong_AsLong(isz) + Py_TYPE(self)->tp_basicsize +
+        Py_SIZE(self) * Py_TYPE(self)->tp_itemsize;
+    Py_DECREF(isz);
+    return PyLong_FromSsize_t(nbytes);
+}
+
 #if PY_VERSION_HEX >= 0x03000000
 NPY_NO_EXPORT void
 gentype_struct_free(PyObject *ptr)
@@ -1923,8 +1937,8 @@ static PyMethodDef gentype_methods[] = {
 
     /* for the sys module */
     {"__sizeof__",
-        (PyCFunction)gentype_itemsize_get,
-        METH_VARARGS, NULL},
+        (PyCFunction)gentype_sizeof,
+        METH_NOARGS, NULL},
 
     /* for the copy module */
     {"__copy__",

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1921,6 +1921,11 @@ static PyMethodDef gentype_methods[] = {
         (PyCFunction)gentype_wraparray,
         METH_VARARGS, doc_sc_wraparray},
 
+    /* for the sys module */
+    {"__sizeof__",
+        (PyCFunction)gentype_itemsize_get,
+        METH_VARARGS, NULL},
+
     /* for the copy module */
     {"__copy__",
         (PyCFunction)gentype_copy,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4570,14 +4570,14 @@ class TestSizeOf(TestCase):
 
     def test_empty_array(self):
         x = np.array([])
-        assert_equal(0, sys.getsizeof(x))
+        assert_(sys.getsizeof(x) > 0)
 
     def check_array(self, dtype):
-        elem_size = sys.getsizeof(dtype(0))
+        elem_size = dtype(0).itemsize
 
         for length in [10, 50, 100, 500]:
             x = np.arange(length, dtype=dtype)
-            assert_equal(length * elem_size, sys.getsizeof(x))
+            assert_(sys.getsizeof(x) > length * elem_size)
 
     def test_array_int32(self):
         self.check_array(np.int32)
@@ -4590,6 +4590,26 @@ class TestSizeOf(TestCase):
 
     def test_array_float64(self):
         self.check_array(np.float64)
+
+    def test_view(self):
+        d = np.ones(100)
+        assert_(sys.getsizeof(d[...]) < sys.getsizeof(d))
+
+    def test_reshape(self):
+        d = np.ones(100)
+        assert_(sys.getsizeof(d) < sys.getsizeof(d.reshape(100, 1, 1).copy()))
+
+    def test_resize(self):
+        d = np.ones(100)
+        old = sys.getsizeof(d)
+        d.resize(50)
+        assert_(old > sys.getsizeof(d))
+        d.resize(150)
+        assert_(old < sys.getsizeof(d))
+
+    def test_error(self):
+        d = np.ones(100)
+        assert_raises(TypeError, d.__sizeof__, "a")
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4566,5 +4566,31 @@ class TestWhere(TestCase):
         assert_equal(np.where(False, b, a), "abcd")
 
 
+class TestSizeOf(TestCase):
+
+    def test_empty_array(self):
+        x = np.array([])
+        assert_equal(0, sys.getsizeof(x))
+
+    def check_array(self, dtype):
+        elem_size = sys.getsizeof(dtype(0))
+
+        for length in [10, 50, 100, 500]:
+            x = np.arange(length, dtype=dtype)
+            assert_equal(length * elem_size, sys.getsizeof(x))
+
+    def test_array_int32(self):
+        self.check_array(np.int32)
+
+    def test_array_int64(self):
+        self.check_array(np.int64)
+
+    def test_array_float32(self):
+        self.check_array(np.float32)
+
+    def test_array_float64(self):
+        self.check_array(np.float64)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -277,7 +277,11 @@ class TestSizeOf(TestCase):
     def test_equal_nbytes(self):
         for type in types:
             x = type(0)
-            assert_equal(sys.getsizeof(x), x.nbytes)
+            assert_(sys.getsizeof(x) > x.nbytes)
+
+    def test_error(self):
+        d = np.float32()
+        assert_raises(TypeError, d.__sizeof__, "a")
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -271,5 +271,14 @@ class TestRepr(object):
         for t in [np.float32, np.float64]:
             yield self._test_type_repr, t
 
+
+class TestSizeOf(TestCase):
+
+    def test_equal_nbytes(self):
+        for type in types:
+            x = type(0)
+            assert_equal(sys.getsizeof(x), x.nbytes)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
reports object sizes, storage needed for strides and dimensions + the data if its owned.
I'm not sure if its really a useful feature but its been requested twice, so why not. Based on patch by @ddasilva
