### PR TITLE
DOC: escape the italics bold and monospace examples

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -597,7 +597,8 @@ Common reST concepts
 For paragraphs, indentation is significant and indicates indentation in the
 output. New paragraphs are marked with a blank line.
 
-Use *italics*, **bold**, and ``monospace`` if needed in any explanations
+Use ``*italics*``, ``**bold**`` and ````monospace```` if needed in any
+explanations
 (but not for variable names and doctest code or multi-line code).
 Variable, module, function, and class names should be written between
 single back-ticks (```numpy```).


### PR DESCRIPTION
since this is meant to be read in rendered form, and there are examples of these scattered through the text otherwise
