### PR TITLE
BUG: fix genfromtxt check of converters when using usecols

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1575,22 +1575,25 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                           for (miss, fill) in zipit]
     # Update the converters to use the user-defined ones
     uc_update = []
-    for (i, conv) in user_converters.items():
+    for (j, conv) in user_converters.items():
         # If the converter is specified by column names, use the index instead
-        if _is_string_like(i):
+        if _is_string_like(j):
             try:
-                i = names.index(i)
+                j = names.index(j)
+                i = j
             except ValueError:
                 continue
         elif usecols:
             try:
-                i = usecols.index(i)
+                i = usecols.index(j)
             except ValueError:
                 # Unused converter specified
                 continue
-        # Find the value to test:
+        else:
+            i = j
+        # Find the value to test - first_line is not filtered by usecols:
         if len(first_line):
-            testing_value = first_values[i]
+            testing_value = first_values[j]
         else:
             testing_value = None
         converters[i].update(conv, locked=True,

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1085,6 +1085,21 @@ M   33  21.99
         control = np.array([2009., 23., 46],)
         assert_equal(test, control)
 
+    def test_dtype_with_converters_and_usecols(self):
+        dstr = "1,5,-1,1:1\n2,8,-1,1:n\n3,3,-2,m:n\n"
+        dmap = {'1:1':0, '1:n':1, 'm:1':2, 'm:n':3}
+        dtyp = [('E1','i4'),('E2','i4'),('E3','i2'),('N', 'i1')]
+        conv = {0: int, 1: int, 2: int, 3: lambda r: dmap[r.decode()]}
+        test = np.recfromcsv(TextIO(dstr,), dtype=dtyp, delimiter=',',
+                             names=None, converters=conv)
+        control = np.rec.array([[1,5,-1,0], [2,8,-1,1], [3,3,-2,3]], dtype=dtyp)
+        assert_equal(test, control)
+        dtyp = [('E1','i4'),('E2','i4'),('N', 'i1')]
+        test = np.recfromcsv(TextIO(dstr,), dtype=dtyp, delimiter=',',
+                             usecols=(0,1,3), names=None, converters=conv)
+        control = np.rec.array([[1,5,0], [2,8,1], [3,3,3]], dtype=dtyp)
+        assert_equal(test, control)
+
     def test_dtype_with_object(self):
         "Test using an explicit dtype with an object"
         from datetime import date


### PR DESCRIPTION
fixes an issue reported by Adrian Altenhoff where user-supplied
converters in genfromtxt were not tested with the right first_values
when also specifying usecols -
http://mail.scipy.org/pipermail/numpy-discussion/2014-August/071005.html
