### PR TITLE
Small fixes, including a memset(NULL, c, n)

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -76,7 +76,9 @@ npy_alloc_cache_zero(npy_uintp sz)
     NPY_BEGIN_THREADS_DEF;
     if (sz < NBUCKETS) {
         p = _npy_alloc_cache(sz, 1, NBUCKETS, datacache, &PyDataMem_NEW);
-        memset(p, 0, sz);
+        if (p) {
+            memset(p, 0, sz);
+        }
         return p;
     }
     NPY_BEGIN_THREADS;

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -20,10 +20,9 @@
 
 int xerbla_(char *srname, integer *info)
 {
-        const char* format = "On entry to %.*s" \
+        static const char format[] = "On entry to %.*s" \
                 " parameter number %d had an illegal value";
-        char buf[57 + 6 + 4]; /* 57 for strlen(format),
-                                 6 for name, 4 for param. num. */
+        char buf[sizeof(format) + 6 + 4];   /* 6 for name, 4 for param. num. */
 
         int len = 0; /* length of subroutine name*/
 #ifdef WITH_THREAD


### PR DESCRIPTION
Here are some tiny fixes to C files. One of them prevents a call to `memset` with a `NULL` first argument when an allocation fails, and it makes the allocator cache more readable. (It also enlarges the cache a little bit, which is out of laziness rather than optimization concerns.)
