### PR TITLE
MAINT: Remove references to missing files from install.

### DIFF
--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -32,12 +32,10 @@ from __version__ import version
 def configuration(parent_package='',top_path=None):
     config = Configuration('f2py', parent_package, top_path)
 
-    config.add_data_dir('docs')
     config.add_data_dir('tests')
 
     config.add_data_files('src/fortranobject.c',
                           'src/fortranobject.h',
-                          'f2py.1'
                           )
 
     config.make_svn_version_py()

--- a/numpy/lib/setup.py
+++ b/numpy/lib/setup.py
@@ -13,7 +13,6 @@ def configuration(parent_package='',top_path=None):
                          sources=[join('src', '_compiled_base.c')]
                          )
 
-    config.add_data_dir('benchmarks')
     config.add_data_dir('tests')
 
     return config


### PR DESCRIPTION
The following directories and files have been moved or deleted

```
numpy/lib/benchmarks
numpy/f2py/docs
numpy/f2py/f2py.1
```

This PR removes references to them from the relevant setup.py files.

Closes #5010.

Rebased for backport to 1.9.
