### PR TITLE
MAINT: Make numpy/lib/polynomial/polyval a bit faster.

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -671,7 +671,7 @@ def polyval(p, x):
         x = NX.asarray(x)
         y = NX.zeros_like(x)
     for i in range(len(p)):
-        y = x * y + p[i]
+        y = y * x + p[i]
     return y
 
 def polyadd(a1, a2):


### PR DESCRIPTION
Multiplying a numpy_scalar times a numpy_array is much faster than
the other way around. This PR switches the order of multiplication
in the polyval function resulting in a speedup of about 5x for scalar
values of x.

Closes #4610.
