### PR TITLE
TST: skip clongdouble alignment checks on 32 bit arches for 1.9

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1049,9 +1049,9 @@ class TestArrayComparisons(TestCase):
 
 def assert_array_strict_equal(x, y):
     assert_array_equal(x, y)
-    # Check flags, debian sparc and win32 don't provide 16 byte alignment
-    if (x.dtype.alignment > 8 and
-            'sparc' not in platform.platform().lower() and
+    # Check flags, 32 bit arches typically don't provide 16 byte alignment
+    if ((x.dtype.alignment <= 8 or
+            np.intp().dtype.itemsize != 4) and
             sys.platform != 'win32'):
         assert_(x.flags == y.flags)
     else:

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -9,7 +9,8 @@ import platform
 import nose
 
 from numpy.testing import *
-from numpy import array, alltrue, ndarray, asarray, can_cast, zeros, dtype
+from numpy import (array, alltrue, ndarray, asarray, can_cast, zeros, dtype,
+                   intp, clongdouble)
 from numpy.core.multiarray import typeinfo
 
 import util
@@ -107,11 +108,12 @@ _cast_dict['DOUBLE'] = _cast_dict['INT'] + ['UINT', 'FLOAT', 'DOUBLE']
 
 _cast_dict['CFLOAT'] = _cast_dict['FLOAT'] + ['CFLOAT']
 
-# (debian) sparc system malloc does not provide the alignment required by
+# 32 bit system malloc typically does not provide the alignment required by
 # 16 byte long double types this means the inout intent cannot be satisfied and
 # several tests fail as the alignment flag can be randomly true or fals
 # when numpy gains an aligned allocator the tests could be enabled again
-if 'sparc' not in platform.platform().lower() and sys.platform != 'win32':
+if ((intp().dtype.itemsize != 4 or clongdouble().dtype.alignment <= 8) and
+        sys.platform != 'win32'):
     _type_names.extend(['LONGDOUBLE', 'CDOUBLE', 'CLONGDOUBLE'])
     _cast_dict['LONGDOUBLE'] = _cast_dict['LONG'] + \
                                ['ULONG', 'FLOAT', 'DOUBLE', 'LONGDOUBLE']


### PR DESCRIPTION
turns out not only sparc is borked, skip the checks on all 32 bit arches
with too large clongdouble alignments until we have an aligned
allocator.
