### PR TITLE
TST: pass sys.argv to run_module_suite by default

### DIFF
--- a/numpy/compat/tests/test_compat.py
+++ b/numpy/compat/tests/test_compat.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 from numpy.compat import isfileobj
-from numpy.testing import assert_
+from numpy.testing import assert_, run_module_suite
 from numpy.testing.utils import tempdir
 
 
@@ -17,3 +17,7 @@ def test_isfileobj():
 
         with open(filename, 'rb') as f:
             assert_(isfileobj(f))
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/core/tests/test_abc.py
+++ b/numpy/core/tests/test_abc.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import numpy as np
-from numpy.testing import TestCase, assert_
+from numpy.testing import TestCase, assert_, run_module_suite
 
 import numbers
 from numpy.core.numerictypes import sctypes
@@ -43,3 +42,6 @@ class ABC(TestCase):
             assert_(issubclass(t, numbers.Integral),
                     "{0} is not subclass of Integral".format(t.__name__))
 
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/core/tests/test_blasdot.py
+++ b/numpy/core/tests/test_blasdot.py
@@ -4,7 +4,8 @@ import numpy as np
 import sys
 from numpy.core import zeros, float64
 from numpy.testing import dec, TestCase, assert_almost_equal, assert_, \
-     assert_raises, assert_array_equal, assert_allclose, assert_equal
+     assert_raises, assert_array_equal, assert_allclose, assert_equal, \
+     run_module_suite
 from numpy.core.multiarray import inner as inner_
 
 DECPREC = 14
@@ -169,3 +170,7 @@ def test_dot_override():
     assert_equal(c.dot(a), "A")
     assert_raises(TypeError, np.dot, b, c)
     assert_raises(TypeError, c.dot, b)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -109,3 +109,7 @@ class TestLinspace(TestCase):
         a = PhysicalQuantity(0.0)
         b = PhysicalQuantity(1.0)
         assert_equal(linspace(a, b), linspace(0.0, 1.0))
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/core/tests/test_multiarray_assignment.py
+++ b/numpy/core/tests/test_multiarray_assignment.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.testing import TestCase
+from numpy.testing import run_module_suite
 
 ndims = 2
 size = 10
@@ -78,3 +78,7 @@ def test_overlapping_assignments():
         dstidx = tuple([a[1] for a in ind])
 
         yield _check_assignment, srcidx, dstidx
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/linalg/tests/test_build.py
+++ b/numpy/linalg/tests/test_build.py
@@ -1,12 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-from subprocess import call, PIPE, Popen
+from subprocess import PIPE, Popen
 import sys
 import re
 
-import numpy as np
 from numpy.linalg import lapack_lite
-from numpy.testing import TestCase, dec
+from numpy.testing import TestCase, dec, run_module_suite
 
 from numpy.compat import asbytes_nested
 
@@ -51,3 +50,6 @@ class TestF77Mismatch(TestCase):
 """Both g77 and gfortran runtimes linked in lapack_lite ! This is likely to
 cause random crashes and wrong results. See numpy INSTALL.txt for more
 information.""")
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/matrixlib/tests/test_multiarray.py
+++ b/numpy/matrixlib/tests/test_multiarray.py
@@ -16,3 +16,6 @@ class TestView(TestCase):
 
         assert_(isinstance(y, np.matrix))
         assert_equal(y.dtype, np.dtype('<i2'))
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/matrixlib/tests/test_numeric.py
+++ b/numpy/matrixlib/tests/test_numeric.py
@@ -1,6 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import assert_equal, TestCase
+from numpy.testing import assert_equal, TestCase, run_module_suite
 from numpy.core import ones
 from numpy import matrix
 
@@ -8,3 +8,6 @@ class TestDot(TestCase):
     def test_matscalar(self):
         b1 = matrix(ones((3, 3), dtype=complex))
         assert_equal(b1*1.0, b1)
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/matrixlib/tests/test_regression.py
+++ b/numpy/matrixlib/tests/test_regression.py
@@ -32,3 +32,6 @@ class TestRegression(TestCase):
         x = np.asmatrix(np.random.uniform(0, 1, (3, 3)))
         self.assertEqual(x.std().shape, ())
         self.assertEqual(x.argmax().shape, ())
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -90,7 +90,7 @@ def run_module_suite(file_to_run=None, argv=None):
     argv: list of strings
         Arguments to be passed to the nose test runner. ``argv[0]`` is
         ignored. All command line arguments accepted by ``nosetests``
-        will work.
+        will work. If it is the default value None, sys.argv is used.
 
         .. versionadded:: 1.9.0
 
@@ -117,7 +117,7 @@ def run_module_suite(file_to_run=None, argv=None):
             raise AssertionError
 
     if argv is None:
-        argv = ['', file_to_run]
+        argv = sys.argv + [file_to_run]
     else:
         argv = argv + [file_to_run]
 


### PR DESCRIPTION
allows passing flags like --pdb to test files
also add call to files where its missing
