### PR TITLE
Add NULL check after malloc() in fortranobject.c

### DIFF
--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -125,7 +125,10 @@ fortran_doc (FortranDataDef def) {
     if (def.doc!=NULL)
         size += strlen(def.doc);
     p = (char*)malloc (size);
-    if (p==NULL) goto fail;
+    if (p==NULL) {
+        /* No need to call free() because p is NULL */
+        return PyErr_NoMemory();
+    }
     p[0] = '\0'; /* make sure that the buffer has zero length */
     if (def.rank==-1) {
         if (def.doc==NULL) {

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -125,6 +125,7 @@ fortran_doc (FortranDataDef def) {
     if (def.doc!=NULL)
         size += strlen(def.doc);
     p = (char*)malloc (size);
+    if (p==NULL) goto fail;
     p[0] = '\0'; /* make sure that the buffer has zero length */
     if (def.rank==-1) {
         if (def.doc==NULL) {


### PR DESCRIPTION
In fortranobject.c there was a `malloc()` without a `NULL` check on the returned pointer.
