### PR TITLE
BUG: fix array_almost_equal for array subclasses

### DIFF
--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -244,6 +244,14 @@ class TestArrayAlmostEqual(_GenericTest, unittest.TestCase):
         self.assertRaises(AssertionError,
                 lambda : self._assert_func(a, b))
 
+    def test_subclass(self):
+        a = np.array([[1., 2.], [3., 4.]])
+        b = np.ma.masked_array([[1., 2.], [0., 4.]],
+                               [[False, False], [True, False]])
+        assert_array_almost_equal(a, b)
+        assert_array_almost_equal(b, a)
+        assert_array_almost_equal(b, b)
+
 class TestAlmostEqual(_GenericTest, unittest.TestCase):
     def setUp(self):
         self._assert_func = assert_almost_equal

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -823,7 +823,7 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
         # make sure y is an inexact type to avoid abs(MIN_INT); will cause
         # casting of x later.
         dtype = result_type(y, 1.)
-        y = array(y, dtype=dtype, copy=False)
+        y = array(y, dtype=dtype, copy=False, subok=True)
         z = abs(x-y)
 
         if not issubdtype(z.dtype, number):


### PR DESCRIPTION
introduced in gh-4105, ab04e1ae0e8eca717bc7e42f3b0a60c9ff764289
