### PR TITLE
TST: accept small error in threaded random test

### DIFF
--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -6,6 +6,7 @@ from numpy.testing import (
         assert_warns)
 from numpy import random
 from numpy.compat import asbytes
+import sys
 
 class TestSeed(TestCase):
     def test_scalar(self):
@@ -681,7 +682,13 @@ class TestThread:
         for s, o in zip(self.seeds, out2):
             function(np.random.RandomState(s), o)
 
-        np.testing.assert_array_equal(out1, out2)
+        # these platforms change x87 fpu precision mode in threads
+        if (np.intp().dtype.itemsize == 4 and
+                (sys.platform == "win32" or
+                 sys.platform.startswith("gnukfreebsd"))):
+            np.testing.assert_array_almost_equal(out1, out2)
+        else:
+            np.testing.assert_array_equal(out1, out2)
 
     def test_normal(self):
         def gen_random(state, out):


### PR DESCRIPTION
freebsd and windows change x87 precision mode (fctrl bit 8 and 9) from
extended to double in child threads so the random numbers cannot be
exactly the same from master and child threads.
see gh-4909
