### PR TITLE
BUG: cannot convert invalid sequence index to tuple

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -206,14 +206,17 @@ prepare_index(PyArrayObject *self, PyObject *index,
             n = 0;
             make_tuple = 1;
         }
-        n = PySequence_Size(index);
+        else {
+            n = PySequence_Size(index);
+        }
         if (n < 0 || n >= NPY_MAXDIMS) {
             n = 0;
         }
         for (i = 0; i < n; i++) {
             PyObject *tmp_obj = PySequence_GetItem(index, i);
             if (tmp_obj == NULL) {
-                make_tuple = 1;
+                PyErr_Clear();
+                make_tuple = 0;
                 break;
             }
             if (PyArray_Check(tmp_obj) || PySequence_Check(tmp_obj)

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -193,7 +193,7 @@ class TestIndexing(TestCase):
         c = np.arange(10).reshape(5, 2)[::-1]
         a[b, :] = c
         assert_equal(a[0], [0, 1])
-    
+
     def test_reversed_strides_result_allocation(self):
         # Test a bug when calculating the output strides for a result array
         # when the subspace size was 1 (and test other cases as well)
@@ -366,6 +366,37 @@ class TestIndexing(TestCase):
         # boolean
         d[b % 2 == 0]
         d[b % 2 == 0] = x[::2]
+
+    def test_tuple_subclass(self):
+        arr = np.ones((5, 5))
+
+        # A tuple subclass should also be an nd-index
+        class TupleSubclass(tuple):
+            pass
+        index = ([1], [1])
+        index = TupleSubclass(index)
+        assert_(arr[index].shape == (1,))
+        # Unlike the non nd-index:
+        assert_(arr[index,].shape != (1,))
+
+    def test_broken_sequence_not_nd_index(self):
+        # See gh-5063:
+        # If we have an object which claims to be a sequence, but fails
+        # on item getting, this should not be converted to an nd-index (tuple)
+        # If this object happens to be a valid index otherwise, it should work
+        # This object here is very dubious and probably bad though:
+        class SequenceLike(object):
+            def __index__(self):
+                return 0
+
+            def __len__(self):
+                return 1
+
+            def __getitem__(self, item):
+                raise IndexError('Not possible')
+
+        arr = np.arange(10)
+        assert_array_equal(arr[SequenceLike()], arr[SequenceLike(),])
 
 
 class TestFieldIndexing(TestCase):


### PR DESCRIPTION
A sequence which raises an error on item getting, should be just
handled as a single index and not a tuple nd-index.

Also fix some error handling.

closes gh-5063
## 

Tests still missing...
