### PR TITLE
Minor fix on c-info.python-as-glue.rst

### DIFF
--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -250,7 +250,7 @@ that it won't try to create the variable n until the variable a is
 created).
 
 After modifying ``add.pyf``, the python interface file can be generated
-by compiling both add.f95 and add.pyf::
+by compiling both ``add.f95`` and ``add.pyf``::
 
     f2py -c add.pyf add.f95 
 

--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -249,13 +249,14 @@ necessary to tell f2py that the value of n depends on the input a (so
 that it won't try to create the variable n until the variable a is
 created).
 
-After modifying ``add.pyf``, the python interface file can be generated
+After modifying ``add.pyf``, the new python module file can be generated
 by compiling both ``add.f95`` and ``add.pyf``::
 
     f2py -c add.pyf add.f95 
 
 The new interface has docstring:
 
+    >>> import add
     >>> print add.zadd.__doc__
     zadd - Function signature:
       c = zadd(a,b)

--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -249,6 +249,11 @@ necessary to tell f2py that the value of n depends on the input a (so
 that it won't try to create the variable n until the variable a is
 created).
 
+After modifying ``add.pyf``, the python interface file can be generated
+by compiling both add.f95 and add.pyf::
+
+    f2py -c add.pyf add.f95 
+
 The new interface has docstring:
 
     >>> print add.zadd.__doc__


### PR DESCRIPTION
Add a few lines to remind the readers to recompile `add.pyf` and `add.f95` files before checking the add module in python.
