### PR TITLE
Fix how strides is set on Py_buffer object when the array is C-contiguous

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -713,7 +713,8 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
          * (since one of the elements may be -1).  In that case, just
          * regenerate strides from shape.
          */
-        if (PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS)) {
+        if (PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS) &&
+            !((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS)) {
             sd = view->itemsize;
             for (i = view->ndim-1; i >= 0; --i) {
                 view->strides[i] = sd;
@@ -947,7 +948,7 @@ _descriptor_from_pep3118_format_fast(char *s, PyObject **result)
         *result = (PyObject*)PyArray_DescrNewByteorder(descr, byte_order);
         Py_DECREF(descr);
     }
-    
+
     return 1;
 }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4258,6 +4258,22 @@ class TestNewBufferProtocol(object):
         x3 = np.arange(dt3.itemsize, dtype=np.int8).view(dt3)
         self._check_roundtrip(x3)
 
+    def test_relaxed_strides(self):
+        # Test that relaxed strides are converted to non-relaxed
+        x = np.zeros((5, 10), dtype=">f4")
+
+        # Add an extra dimension in such a way that the strides will
+        # contain -1 markers
+        c = np.array([x])
+        assert memoryview(c).strides == (200, 40, 4)
+
+        # Writing C-contiguous data to a BytesIO buffer should work
+        fd = io.BytesIO()
+        fd.write(c.data)
+
+        fortran = c.T
+        assert memoryview(fortran).strides == (4, 40, 200)
+
 
 class TestArrayAttributeDeletion(object):
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4260,19 +4260,20 @@ class TestNewBufferProtocol(object):
 
     def test_relaxed_strides(self):
         # Test that relaxed strides are converted to non-relaxed
-        x = np.zeros((5, 10), dtype=">f4")
+        c = np.ones((1, 10, 10), dtype='i8')
 
-        # Add an extra dimension in such a way that the strides will
-        # contain -1 markers
-        c = np.array([x])
-        assert memoryview(c).strides == (200, 40, 4)
+        # Check for NPY_RELAXED_STRIDES_CHECKING:
+        if np.ones((10, 1), order="C").flags.f_contiguous:
+            c.strides = (-1, 80, 8)
+
+        assert memoryview(c).strides == (800, 80, 8)
 
         # Writing C-contiguous data to a BytesIO buffer should work
         fd = io.BytesIO()
         fd.write(c.data)
 
         fortran = c.T
-        assert memoryview(fortran).strides == (4, 40, 200)
+        assert memoryview(fortran).strides == (8, 80, 800)
 
 
 class TestArrayAttributeDeletion(object):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1873,7 +1873,7 @@ class TestMethods(TestCase):
 
         a = np.array([1-1j, 1, 2.0, 'f'], object)
         assert_raises(AttributeError, lambda: a.conj())
-        assert_raises(AttributeError, lambda: a.conjugate()) 
+        assert_raises(AttributeError, lambda: a.conjugate())
 
 
 class TestBinop(object):
@@ -4274,6 +4274,14 @@ class TestNewBufferProtocol(object):
 
         fortran = c.T
         assert memoryview(fortran).strides == (8, 80, 800)
+
+        arr = np.ones((1, 10))
+        if arr.flags.f_contiguous:
+            shape, strides = get_buffer_info(arr, ['F_CONTIGUOUS'])
+            assert_(strides[0] == 8)
+            arr = np.ones((10, 1), order='F')
+            shape, strides = get_buffer_info(arr, ['C_CONTIGUOUS'])
+            assert_(strides[-1] == 8)
 
 
 class TestArrayAttributeDeletion(object):


### PR DESCRIPTION
This is a possible fix for #5085.

A complete solution would probably convert the strides array from something containing -1's into the equivalent without them, but I don't know all the corner cases involved with that.
