### PR TITLE
BUG: fix out of bound access in unicode argmin/argmax

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2991,7 +2991,7 @@ static int
     memcpy(mp, ip, elsize);
     *max_ind = 0;
     for (i = 1; i < n; i++) {
-        ip += elsize;
+        ip += elsize / sizeof(@type@);
         if (@fname@_compare(ip, mp, aip) > 0) {
             memcpy(mp, ip, elsize);
             *max_ind = i;
@@ -3048,7 +3048,7 @@ static int
     memcpy(mp, ip, elsize);
     *min_ind = 0;
     for(i=1; i<n; i++) {
-        ip += elsize;
+        ip += elsize / sizeof(@type@);
         if (@fname@_compare(mp,ip,aip) > 0) {
             memcpy(mp, ip, elsize);
             *min_ind=i;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2144,6 +2144,11 @@ class TestArgmax(TestCase):
         a.argmax(-1, out=out)
         assert_equal(out, a.argmax(-1))
 
+    def test_argmax_unicode(self):
+        d = np.zeros(6031, dtype='<U9')
+        d[5942] = "as"
+        assert_equal(d.argmax(), 5942)
+
 
 class TestArgmin(TestCase):
 
@@ -2248,6 +2253,11 @@ class TestArgmin(TestCase):
         out = np.ones(10, dtype=np.int_)
         a.argmin(-1, out=out)
         assert_equal(out, a.argmin(-1))
+
+    def test_argmin_unicode(self):
+        d = np.ones(6031, dtype='<U9')
+        d[6001] = "0"
+        assert_equal(d.argmin(), 6001)
 
 
 class TestMinMax(TestCase):


### PR DESCRIPTION
elsize is in bytes and the pointer of unicode type, so it must divided
by the size.
Closes gh-5082
