### PR TITLE
BUG: fix wrong error checks of PyBytes_AsStringAndSize

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -492,7 +492,7 @@ STRING_setitem(PyObject *op, char *ov, PyArrayObject *ap)
         return -1;
     }
 #endif
-    if (PyBytes_AsStringAndSize(temp, &ptr, &len) == -1) {
+    if (PyBytes_AsStringAndSize(temp, &ptr, &len) < 0) {
         Py_DECREF(temp);
         return -1;
     }

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -270,6 +270,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             tmp = name;
 #endif
             if (tmp == NULL || PyBytes_AsStringAndSize(tmp, &p, &len) < 0) {
+                PyErr_Clear();
                 PyErr_SetString(PyExc_ValueError, "invalid field name");
                 return -1;
             }

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -689,7 +689,7 @@ PyArray_CastingConverter(PyObject *obj, NPY_CASTING *casting)
         return ret;
     }
 
-    if (PyBytes_AsStringAndSize(obj, &str, &length) == -1) {
+    if (PyBytes_AsStringAndSize(obj, &str, &length) < 0) {
         return 0;
     }
 

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -2369,7 +2369,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
             bytes = obj;
             Py_INCREF(bytes);
         }
-        if (PyBytes_AsStringAndSize(bytes, &str, &len) == -1) {
+        if (PyBytes_AsStringAndSize(bytes, &str, &len) < 0) {
             Py_DECREF(bytes);
             return -1;
         }
@@ -2558,7 +2558,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             bytes = obj;
             Py_INCREF(bytes);
         }
-        if (PyBytes_AsStringAndSize(bytes, &str, &len) == -1) {
+        if (PyBytes_AsStringAndSize(bytes, &str, &len) < 0) {
             Py_DECREF(bytes);
             return -1;
         }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2476,7 +2476,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
             endian_obj = tmp;
         }
 
-        if (PyBytes_AsStringAndSize(endian_obj, &str, &len) == -1) {
+        if (PyBytes_AsStringAndSize(endian_obj, &str, &len) < 0) {
             Py_XDECREF(tmp);
             return NULL;
         }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1687,7 +1687,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
             return NULL;
         }
 
-        if (PyBytes_AsStringAndSize(rawdata, &datastr, &len)) {
+        if (PyBytes_AsStringAndSize(rawdata, &datastr, &len) < 0) {
             Py_DECREF(rawdata);
             return NULL;
         }

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -129,7 +129,7 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
             f = f_str;
         }
 
-        if (PyBytes_AsStringAndSize(f, &str, &length) == -1) {
+        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
             Py_DECREF(f);
             return 0;
         }
@@ -238,7 +238,7 @@ npyiter_order_converter(PyObject *order_in, NPY_ORDER *order)
         return ret;
     }
 
-    if (PyBytes_AsStringAndSize(order_in, &str, &length) == -1) {
+    if (PyBytes_AsStringAndSize(order_in, &str, &length) < 0) {
         return 0;
     }
 
@@ -300,7 +300,8 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
             f = f_str;
         }
 
-        if (PyBytes_AsStringAndSize(f, &str, &length) == -1) {
+        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+            PyErr_Clear();
             Py_DECREF(f);
             PyErr_SetString(PyExc_ValueError,
                    "op_flags must be a tuple or array of per-op flag-tuples");

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -927,7 +927,8 @@ static int get_ufunc_arguments(PyUFuncObject *ufunc,
             }
 #endif
 
-            if (PyBytes_AsStringAndSize(key, &str, &length) == -1) {
+            if (PyBytes_AsStringAndSize(key, &str, &length) < 0) {
+                PyErr_Clear();
                 PyErr_SetString(PyExc_TypeError, "invalid keyword argument");
                 goto fail;
             }

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -2044,7 +2044,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
             type_tup = str_obj;
         }
 
-        if (!PyBytes_AsStringAndSize(type_tup, &str, &length) < 0) {
+        if (PyBytes_AsStringAndSize(type_tup, &str, &length) < 0) {
             Py_XDECREF(str_obj);
             return -1;
         }


### PR DESCRIPTION
The check in ufunc_type_resolution.c is broken due to a spurious not and
a few cases of TypeError being overwritten without clearing.
Also change all of these error checks to a negative check for
consistency.
