### PR TITLE
DOC: document `ldict` and `gdict` in `bmat`, closes #5058

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1161,6 +1161,12 @@ def bmat(obj, ldict=None, gdict=None):
     obj : str or array_like
         Input data.  Names of variables in the current scope may be
         referenced, even if `obj` is a string.
+    ldict : dict, optional
+        A dictionary that replaces local operands in current frame.
+        Ignored if `obj` is not a string or `gdict` is `None`.
+    gdict : dict, optional
+        A dictionary that replaces global operands in current frame.
+        Ignored if `obj` is not a string.
 
     Returns
     -------


### PR DESCRIPTION
Have used the exact same wording of `numexpr`'s `evaluate`, see [here](https://github.com/pydata/numexpr/blob/7ccec503ca3a0601eec791c156c5723f7548168a/numexpr/necompiler.py#L688).
