### PR TITLE
BUG: np.unique with chararray + inverse_index

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -204,7 +204,7 @@ def unique(ar, return_index=False, return_inverse=False, return_counts=False):
             ret += (perm[flag],)
         if return_inverse:
             iflag = np.cumsum(flag) - 1
-            inv_idx = np.empty_like(ar, dtype=np.intp)
+            inv_idx = np.empty(ar.shape, dtype=np.intp)
             inv_idx[perm] = iflag
             ret += (inv_idx,)
         if return_counts:

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -109,6 +109,12 @@ class TestSetOps(TestCase):
         assert_array_equal(a2, unq)
         assert_array_equal(a2_inv, inv)
 
+        # test for chararrays with return_inverse (gh-5099)
+        a = np.chararray(5)
+        a[...] = ''
+        a2, a2_inv = np.unique(a, return_inverse=True)
+        assert_array_equal(a2_inv, np.zeros(5))
+
     def test_intersect1d(self):
         # unique inputs
         a = np.array([5, 7, 1, 2])


### PR DESCRIPTION
The call to `empty_like` was trying to use the `chararray` subclass, which doesn't support the `np.intp` dtype.

```
In [16]: foo = np.chararray(5)

In [17]: np.unique(foo)
Out[17]: 
chararray([''], 
      dtype='|S1')

In [18]: np.unique(foo, return_inverse=True)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-18-bfdd2379988e> in <module>()
----> 1 np.unique(foo, return_inverse=True)

/usr/local/lib/python2.7/dist-packages/numpy/lib/arraysetops.pyc in unique(ar, return_index, return_inverse, return_counts)
    205         if return_inverse:
    206             iflag = np.cumsum(flag) - 1
--> 207             inv_idx = np.empty_like(ar, dtype=np.intp)
    208             inv_idx[perm] = iflag
    209             ret += (inv_idx,)

/usr/local/lib/python2.7/dist-packages/numpy/core/defchararray.pyc in __array_finalize__(self, obj)
   1846         # The b is a special case because it is used for reconstructing.
   1847         if not _globalvar and self.dtype.char not in 'SUbc':
-> 1848             raise ValueError("Can only create a chararray from string data.")
   1849 
   1850     def __getitem__(self, obj):

ValueError: Can only create a chararray from string data.
```
