### PR TITLE
BUG: don't propagate subtypes from np.where

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2763,7 +2763,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
             NULL, arr, ax, ay
         };
         npy_uint32 op_flags[4] = {
-            NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE,
+            NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE | NPY_ITER_NO_SUBTYPE,
             NPY_ITER_READONLY, NPY_ITER_READONLY, NPY_ITER_READONLY
         };
         PyArray_Descr * common_dt = PyArray_ResultType(2, &op_in[0] + 2,


### PR DESCRIPTION
the C implementation cannot preserve subclass attributes, this needs a
python wrapper using indexing for subclasses.
closes gh-5095
