### PR TITLE
BUG: check if object provides len() before trying to iterate it

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -518,12 +518,20 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         return 0;
     }
 
+    /*
+     * fails if convertable to list but no len is defined which some libraries
+     * require to get object arrays
+     */
+    size = PySequence_Size(obj);
+    if (size < 0) {
+        goto fail;
+    }
+
     /* Recursive case, first check the sequence contains only one type */
     seq = PySequence_Fast(obj, "Could not convert object to sequence");
     if (seq == NULL) {
         goto fail;
     }
-    size = PySequence_Fast_GET_SIZE(seq);
     objects = PySequence_Fast_ITEMS(seq);
     common_type = size > 0 ? Py_TYPE(objects[0]) : NULL;
     for (i = 1; i < size; ++i) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -593,6 +593,20 @@ class TestCreation(TestCase):
         assert_(a.dtype == np.dtype(object))
         assert_raises(ValueError, np.array, [Fail()])
 
+    def test_no_len_object_type(self):
+        # gh-5100, want object array from iterable object without len()
+        class Point2:
+            def __init__(self):
+                pass
+
+            def __getitem__(self, ind):
+                if ind in [0, 1]:
+                    return ind
+                else:
+                    raise IndexError()
+        d = np.array([Point2(), Point2(), Point2()])
+        assert_equal(d.dtype, np.dtype(object))
+
 
 class TestStructured(TestCase):
     def test_subarray_field_access(self):


### PR DESCRIPTION
some libraries want object arrays from objects that are iterable but
rely on not providing len() to get the right dtype from numpy.
closes gh-5100
