### PR TITLE
DOC: remove preservena reference from docstrings

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3834,7 +3834,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('put',
 
 add_newdoc('numpy.core.multiarray', 'copyto',
     """
-    copyto(dst, src, casting='same_kind', where=None, preservena=False)
+    copyto(dst, src, casting='same_kind', where=None)
 
     Copies values from one array to another, broadcasting as necessary.
 
@@ -3862,9 +3862,6 @@ add_newdoc('numpy.core.multiarray', 'copyto',
         A boolean array which is broadcasted to match the dimensions
         of `dst`, and selects elements to copy from `src` to `dst`
         wherever it contains the value True.
-    preservena : bool, optional
-        If set to True, leaves any NA values in `dst` untouched. This
-        is similar to the "hard mask" feature in numpy.ma.
 
     """)
 
@@ -3878,11 +3875,6 @@ add_newdoc('numpy.core.multiarray', 'putmask',
 
     If `values` is not the same size as `a` and `mask` then it will repeat.
     This gives behavior different from ``a[mask] = values``.
-
-    .. note:: The `putmask` functionality is also provided by `copyto`, which
-              can be significantly faster and in addition is NA-aware
-              (`preservena` keyword).  Replacing `putmask` with
-              ``np.copyto(a, values, where=mask)`` is recommended.
 
     Parameters
     ----------


### PR DESCRIPTION
preservena is not not implemented.
the putmask is be misleading, currently copyto is faster for dense or
sparse masks while putmask is faster for random masks.
[ci skip]
