### PR TITLE
ENH: faster (branchless) logical_xor

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -838,9 +838,9 @@ NPY_NO_EXPORT void
 @TYPE@_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ in2 = *(@type@ *)ip2;
-        *((npy_bool *)op1)= (in1 && !in2) || (!in1 && in2);
+        const int t1 = !!*(@type@ *)ip1;
+        const int t2 = !!*(@type@ *)ip2;
+        *((npy_bool *)op1) = (t1 != t2);
     }
 }
 
@@ -1515,9 +1515,9 @@ NPY_NO_EXPORT void
 @TYPE@_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ in2 = *(@type@ *)ip2;
-        *((npy_bool *)op1)= (in1 && !in2) || (!in1 && in2);
+        const int t1 = !!*(@type@ *)ip1;
+        const int t2 = !!*(@type@ *)ip2;
+        *((npy_bool *)op1) = (t1 != t2);
     }
 }
 
@@ -1864,7 +1864,7 @@ HALF_logical_xor(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_U
     BINARY_LOOP {
         const int in1 = !npy_half_iszero(*(npy_half *)ip1);
         const int in2 = !npy_half_iszero(*(npy_half *)ip2);
-        *((npy_bool *)op1)= (in1 && !in2) || (!in1 && in2);
+        *((npy_bool *)op1) = (in1 != in2);
     }
 }
 
@@ -2346,7 +2346,7 @@ NPY_NO_EXPORT void
         const @ftype@ in2i = ((@ftype@ *)ip2)[1];
         const npy_bool tmp1 = (in1r || in1i);
         const npy_bool tmp2 = (in2r || in2i);
-        *((npy_bool *)op1) = (tmp1 && !tmp2) || (!tmp1 && tmp2);
+        *((npy_bool *)op1) = tmp1 != tmp2;
     }
 }
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -720,21 +720,43 @@ class TestFmin(_FilterInvalids):
 
 
 class TestBool(TestCase):
-    def test_truth_table(self):
+    def test_truth_table_logical(self):
+        # 2, 3 and 4 serves as true values
+        input1 = [0, 0, 3, 2]
+        input2 = [0, 4, 0, 2]
+
+        typecodes = (np.typecodes['AllFloat']
+                     + np.typecodes['AllInteger']
+                     + '?')     # boolean
+        for dtype in map(np.dtype, typecodes):
+            arg1 = np.asarray(input1, dtype=dtype)
+            arg2 = np.asarray(input2, dtype=dtype)
+
+            # OR
+            out = [False, True, True, True]
+            for func in (np.logical_or, np.maximum):
+                assert_equal(func(arg1, arg2).astype(bool), out)
+            # AND
+            out = [False, False, False, True]
+            for func in (np.logical_and, np.minimum):
+                assert_equal(func(arg1, arg2).astype(bool), out)
+            # XOR
+            out = [False, True, True, False]
+            for func in (np.logical_xor, np.not_equal):
+                assert_equal(func(arg1, arg2).astype(bool), out)
+
+    def test_truth_table_bitwise(self):
         arg1 = [False, False, True, True]
         arg2 = [False, True, False, True]
-        # OR
+
         out = [False, True, True, True]
-        for func in (np.logical_or, np.bitwise_or, np.maximum):
-            assert_equal(func(arg1, arg2), out)
-        # AND
+        assert_equal(np.bitwise_or(arg1, arg2), out)
+
         out = [False, False, False, True]
-        for func in (np.logical_and, np.bitwise_and, np.minimum):
-            assert_equal(func(arg1, arg2), out)
-        # XOR
+        assert_equal(np.bitwise_and(arg1, arg2), out)
+
         out = [False, True, True, False]
-        for func in (np.logical_xor, np.bitwise_xor, np.not_equal):
-            assert_equal(func(arg1, arg2), out)
+        assert_equal(np.bitwise_xor(arg1, arg2), out)
 
 
 class TestFloatingPoint(TestCase):


### PR DESCRIPTION
Here's an optimization to `logical_xor` for non-`bool` types (because @jaimefrio already tackled those in 494abcf189e9b53e42b624752eb3eaaf46a0dfd3). Current master:

``` python
In [1]: x = (np.random.RandomState(30).randn(1e7) > 0).astype(np.intc)

In [2]: y = (np.random.RandomState(30).randn(1e7) > 0).astype(np.intc)

In [3]: %timeit np.logical_xor(x, y)
10 loops, best of 3: 41.6 ms per loop

In [5]: x = x.astype(np.uint8)

In [6]: x = x.astype(np.uint8)

In [7]: y = y.astype(np.uint8)

In [8]: %timeit np.logical_xor(x, y)
10 loops, best of 3: 40.8 ms per loop
```

This PR, same data:

``` python
In [3]: %timeit np.logical_xor(x, y)
100 loops, best of 3: 11.5 ms per loop

In [4]: np.all(np.logical_xor(x, y) == (x != y))  # sanity check
Out[4]: True

In [7]: %timeit np.logical_xor(x, y)              # np.uint8
100 loops, best of 3: 9.95 ms per loop
```

For floats the speedup isn't quite as dramatic:

``` python
In [9]: x = np.random.RandomState(30).randn(1e7)

In [10]: y = np.random.RandomState(30).randn(1e7)

In [11]: %timeit np.logical_xor(x, y)
10 loops, best of 3: 23.2 ms per loop
```

Now:

``` python
In [8]: x = np.random.RandomState(30).randn(1e7)

In [9]: y = np.random.RandomState(30).randn(1e7)

In [10]: %timeit np.logical_xor(x, y)
100 loops, best of 3: 17.4 ms per loop
```

(Then again, who would do a XOR on two float arrays?)
