### PR TITLE
ENH: Cast non-object arrays to float in np.poly

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -37,6 +37,13 @@ and a bit faster.
 Improvements
 ============
 
+`np.poly` now casts integer inputs to float
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`np.poly` will now cast 1-dimensional input arrays of integer type to double
+precision floating point, to prevent integer overflow when computing the monic
+polynomial. It is still possible to obtain higher precision results by
+passing in an array of object type, filled e.g. with Python ints.
+
 
 Changes
 =======

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -153,6 +153,9 @@ class TestDocs(TestCase):
         assert_(p2[3] == Decimal("1.333333333333333333333333333"))
         assert_(p2[2] == Decimal('1.5'))
         assert_(np.issubdtype(p2.coeffs.dtype, np.object_))
+        p = np.poly([Decimal(1), Decimal(2)])
+        assert_equal(np.poly([Decimal(1), Decimal(2)]),
+                     [1, Decimal(-3), Decimal(2)])
 
     def test_complex(self):
         p = np.poly1d([3j, 2j, 1j])
@@ -172,6 +175,14 @@ class TestDocs(TestCase):
             np.poly(np.zeros((0, 0)))
         except ValueError:
             pass
+
+    def test_poly_int_overflow(self):
+        """
+        Regression test for gh-5096.
+        """
+        v = np.arange(1, 21)
+        assert_almost_equal(np.poly(v), np.poly(np.diag(v)))
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Closes #5096. Casts integer arrays to np.double, to prevent
integer overflow. Object arrays are left unchanged, to allow
use of arbitrary precision objects.
