### PR TITLE
BUG: fix bug in genfromtxt

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1391,10 +1391,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     try:
         while not first_values:
             first_line = next(fhd)
-            if names is True:
-                if comments in first_line:
-                    first_line = (
-                        asbytes('').join(first_line.split(comments)[1:]))
             first_values = split_line(first_line)
     except StopIteration:
         # return an empty array if the datafile is empty


### PR DESCRIPTION
genfromtxt was not correctly discarding comments when names=True,
resulting in an exception.
It is not useful in thic context to process the line wrt comments,
because it is done already in split_line(). There was an error because
only the comments were retained.
Closes #3386.
