### PR TITLE
DOC: update installation docs

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -113,7 +113,7 @@ Wine
 For building Windows binaries on OS X Wine can be used. In Wine the following
 needs to be installed:
 
-* Python 2.5-2.7 and 3.1-3.2
+* Python 2.6-2.7 and 3.2
 * MakeNsis
 * CpuId plugin for MakeNsis : this can be found in the NumPy source tree under
   tools/win32build/cpucaps and has to be built with MinGW (see SConstruct file in

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -267,13 +267,6 @@ they inherit from the ndarray): :meth:`.flush() <memmap.flush>` which
 must be called manually by the user to ensure that any changes to the
 array actually get written to disk.
 
-.. note::
-
-    Memory-mapped arrays use the the Python memory-map object which
-    (prior to Python 2.5) does not allow files to be larger than a
-    certain size depending on the platform. This size is always
-    < 2GB even on 64-bit systems.
-
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -1031,9 +1031,9 @@ PyArray_Chunk
 
    This is equivalent to the buffer object structure in Python up to
    the ptr member. On 32-bit platforms (*i.e.* if :cdata:`NPY_SIZEOF_INT`
-   == :cdata:`NPY_SIZEOF_INTP` ) or in Python 2.5, the len member also
-   matches an equivalent member of the buffer object. It is useful to
-   represent a generic single- segment chunk of memory.
+   == :cdata:`NPY_SIZEOF_INTP`), the len member also matches an equivalent
+   member of the buffer object. It is useful to represent a generic
+   single-segment chunk of memory.
 
    .. code-block:: c
 

--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -65,7 +65,7 @@ high-level language for scientific and engineering programming.
 Their are two basic approaches to calling compiled code: writing an
 extension module that is then imported to Python using the import
 command, or calling a shared-library subroutine directly from Python
-using the ctypes module (included in the standard distribution with
+using the ctypes module (included in the standard distribution since
 Python 2.5). The first method is the most common (but with the
 inclusion of ctypes into Python 2.5 this status may change).
 
@@ -902,14 +902,13 @@ libraries), or weave (for inline C-code).
 ctypes
 ======
 
-Ctypes is a python extension module (downloaded separately for Python
-<2.5 and included with Python 2.5) that allows you to call an
-arbitrary function in a shared library directly from Python. This
-approach allows you to interface with C-code directly from Python.
-This opens up an enormous number of libraries for use from Python. The
-drawback, however, is that coding mistakes can lead to ugly program
-crashes very easily (just as can happen in C) because there is little
-type or bounds checking done on the parameters. This is especially
+Ctypes is a Python extension module, included in the stdlib, that
+allows you to call an arbitrary function in a shared library directly
+from Python. This approach allows you to interface with C-code directly
+from Python. This opens up an enormous number of libraries for use from
+Python. The drawback, however, is that coding mistakes can lead to ugly
+program crashes very easily (just as can happen in C) because there is
+little type or bounds checking done on the parameters. This is especially
 true when array data is passed in as a pointer to a raw memory
 location. The responsibility is then on you that the subroutine will
 not access memory outside the actual array area. But, if you don't

--- a/doc/source/user/install.rst
+++ b/doc/source/user/install.rst
@@ -59,18 +59,19 @@ Prerequisites
 
 Building NumPy requires the following software installed:
 
-1) Python 2.4.x, 2.5.x or 2.6.x
+1) Python 2.6.x, 2.7.x, 3.2.x or newer
 
-   On Debian and derivative (Ubuntu): python, python-dev
+   On Debian and derivatives (Ubuntu): python, python-dev (or python3-dev)
 
    On Windows: the official python installer at
    `www.python.org <http://www.python.org>`_ is enough
 
    Make sure that the Python package distutils is installed before
-   continuing. For example, in Debian GNU/Linux, distutils is included
-   in the python-dev package.
+   continuing. For example, in Debian GNU/Linux, installing python-dev
+   also installs distutils.
 
-   Python must also be compiled with the zlib module enabled.
+   Python must also be compiled with the zlib module enabled. This is
+   practically always the case with pre-packaged Pythons.
 
 2) Compilers
 

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -507,7 +507,7 @@ NumPyOS_ascii_strtod(const char *s, char** endptr)
     /*
      * ## 2
      *
-     * At least Python versions <= 2.5.2 and <= 2.6.1
+     * At least Python versions <= 2.6.1
      *
      * Fails to do best-efforts parsing of strings of the form "1<DP>234"
      * where <DP> is the decimal point under the foreign locale.


### PR DESCRIPTION
These still stated Python 2.4 is supported, while not mentioning 3.x at all. Also corrected the statement that distutils is in `python-dev` on Debian, while it's actually in the main package as of wheezy.
