### PR TITLE
FIX: core: remove sprintf calls

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -743,16 +743,9 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
 fail:
     PyArray_free((void*)var_names);
     if (parse_error) {
-        char *buf = PyArray_malloc(sizeof(char) * (len + 200));
-        if (buf) {
-            sprintf(buf, "%s at position %d in \"%s\"",
-                    parse_error, i, signature);
-            PyErr_SetString(PyExc_ValueError, signature);
-            PyArray_free(buf);
-        }
-        else {
-            PyErr_NoMemory();
-        }
+        PyErr_Format(PyExc_ValueError,
+                     "%s at position %d in \"%s\"",
+                     parse_error, i, signature);
     }
     return -1;
 }
@@ -4728,10 +4721,7 @@ ufunc_dealloc(PyUFuncObject *ufunc)
 static PyObject *
 ufunc_repr(PyUFuncObject *ufunc)
 {
-    char buf[100];
-
-    sprintf(buf, "<ufunc '%.50s'>", ufunc->name);
-    return PyUString_FromString(buf);
+    return PyUString_FromFormat("<ufunc '%s'>", ufunc->name);
 }
 
 


### PR DESCRIPTION
This changes the behavior of ufunc_repr to no longer truncate its argument's name. I'm guessing the truncation was only there to make the function work with sprintf, and if I read http://bugs.python.org/issue7330 correctly, then truncation wouldn't work in 3.2 <= Python <= 3.4.
