### PR TITLE
issue #4952 ufuncs __qualname__ should return the same thing as __name__

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5447,6 +5447,9 @@ static PyGetSetDef ufunc_getset[] = {
     {"signature",
         (getter)ufunc_get_signature,
         NULL, NULL, NULL},
+    {"__qualname__",
+        (getter)ufunc_get_name,
+        NULL, NULL, NULL},
     {NULL, NULL, NULL, NULL, NULL},  /* Sentinel */
 };
 


### PR DESCRIPTION
This commit fixes issue #4952. 
numpy ufuncs **qualname** returns the same thing as **name**
