### PR TITLE
ENH: unroll correlate loops

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3801,6 +3801,90 @@ static int
 
 #define OBJECT_fasttake NULL
 
+/*
+ *****************************************************************************
+ **                       small correlate                                   **
+ *****************************************************************************
+ */
+
+/*
+ * Compute correlation of data with with small kernels
+ * Calling a BLAS dot product for the inner loop of the correlation is overkill
+ * for small kernels. It is faster to compute it directly.
+ * Intended to be used by _pyarray_correlate so no input verifications is done
+ * especially it does not handle the boundaries, they should be handled by the
+ * caller.
+ * Returns 0 if kernel is considered too large or types are not supported, then
+ * the regular array dot should be used to process the data.
+ *
+ * d_, dstride, nd, dtype: data pointer, its stride in bytes, number of
+ *                         elements and type of data
+ * k_, kstride, nk, ktype: kernel pointer, its stride in bytes, number of
+ *                         elements and type of data
+ * out_, ostride: output data pointer and its stride in bytes
+ */
+NPY_NO_EXPORT int
+small_correlate(const char * d_, npy_intp dstride,
+                npy_intp nd, enum NPY_TYPES dtype,
+                const char * k_, npy_intp kstride,
+                npy_intp nk, enum NPY_TYPES ktype,
+                char * out_, npy_intp ostride)
+{
+    /* only handle small kernels and uniform types */
+    if (nk > 11 || dtype != ktype) {
+        return 0;
+    }
+
+    switch (dtype) {
+/**begin repeat
+ * Float types
+ *  #type = npy_float, npy_double#
+ *  #TYPE = NPY_FLOAT, NPY_DOUBLE#
+ */
+        case @TYPE@:
+            {
+                npy_intp i;
+                const @type@ * d = (@type@*)d_;
+                const @type@ * k = (@type@*)k_;
+                @type@ * out = (@type@*)out_;
+                dstride /= sizeof(@type@);
+                kstride /= sizeof(@type@);
+                ostride /= sizeof(@type@);
+                /* unroll inner loop to optimize register usage of the kernel*/
+                switch (nk) {
+/**begin repeat1
+ *  #ksz_outer = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11# */
+                    case @ksz_outer@:
+                    {
+/**begin repeat2
+ *  #ksz = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11# */
+#if @ksz@ <= @ksz_outer@
+                        /* load kernel */
+                        const @type@ k@ksz@ = k[(@ksz@ - 1) * kstride];
+#endif
+/**end repeat2**/
+                        for (i = 0; i < nd; i++) {
+                            @type@ s = 0;
+/**begin repeat2
+ *  #ksz = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11# */
+#if @ksz@ <= @ksz_outer@
+                            s += d[(i + @ksz@ - 1) * dstride] * k@ksz@;
+#endif
+/**end repeat2**/
+                            out[i * ostride] = s;
+                        }
+                        return 1;
+                    }
+/**end repeat1**/
+                    default:
+                        return 0;
+                }
+            }
+/**end repeat**/
+        default:
+            return 0;
+    }
+}
 
 /*
  *****************************************************************************

--- a/numpy/core/src/multiarray/arraytypes.h
+++ b/numpy/core/src/multiarray/arraytypes.h
@@ -25,4 +25,13 @@ DOUBLE_dot(char *, npy_intp, char *, npy_intp, char *, npy_intp, void *);
 NPY_NO_EXPORT void
 CDOUBLE_dot(char *, npy_intp, char *, npy_intp, char *, npy_intp, void *);
 
+
+/* for _pyarray_correlate */
+NPY_NO_EXPORT int
+small_correlate(const char * d_, npy_intp dstride,
+                npy_intp nd, enum NPY_TYPES dtype,
+                const char * k_, npy_intp kstride,
+                npy_intp nk, enum NPY_TYPES ktype,
+                char * out_, npy_intp ostride);
+
 #endif

--- a/numpy/core/src/multiarray/templ_common.h.src
+++ b/numpy/core/src/multiarray/templ_common.h.src
@@ -3,69 +3,7 @@
 
 /* utility functions that profit from templates */
 
-#include "lowlevel_strided_loops.h"
 #include "numpy/npy_common.h"
-#include "numpy/ndarraytypes.h"
-
-
-/*
- * Compute correlation of data with with small kernels
- * Calling a BLAS dot product for the inner loop of the correlation is overkill
- * for small kernels. It is faster to compute it directly.
- * Intended to be used by _pyarray_correlate so no input verifications is done
- * especially it does not handle the boundaries, they should be handled by the
- * caller.
- * Returns 0 if kernel is considered too large or types are not supported, then
- * the regular array dot should be used to process the data.
- *
- * d_, dstride, nd, dtype: data pointer, its stride in bytes, number of
- *                         elements and type of data
- * k_, kstride, nk, ktype: kernel pointer, its stride in bytes, number of
- *                         elements and type of data
- * out_, ostride: output data pointer and its stride in bytes
- */
-static int
-small_correlate(const char * d_, npy_intp dstride,
-                npy_intp nd, enum NPY_TYPES dtype,
-                const char * k_, npy_intp kstride,
-                npy_intp nk, enum NPY_TYPES ktype,
-                char * out_, npy_intp ostride)
-{
-    /* only handle small kernels and uniform types */
-    if (nk > 11 || dtype != ktype) {
-        return 0;
-    }
-
-    switch (dtype) {
-/**begin repeat
- * Float types
- *  #type = npy_float, npy_double#
- *  #TYPE = NPY_FLOAT, NPY_DOUBLE#
- */
-        case @TYPE@:
-            {
-                npy_intp i;
-                const @type@ * d = (@type@*)d_;
-                const @type@ * k = (@type@*)k_;
-                @type@ * out = (@type@*)out_;
-                dstride /= sizeof(@type@);
-                kstride /= sizeof(@type@);
-                ostride /= sizeof(@type@);
-                for (i = 0; i < nd; i++) {
-                    npy_intp j;
-                    @type@ s = d[i * dstride] * k[0 * kstride];
-                    for (j = 1; j < nk; j++) {
-                        s += d[(i + j) * dstride] * k[j * kstride];
-                    }
-                    out[i * ostride] = s;
-                }
-                return 1;
-            }
-/**end repeat**/
-        default:
-            return 0;
-    }
-}
 
 
 #endif


### PR DESCRIPTION
Unrolling the inner loop ensures the kernel is placed into registers and
reused, this almost doubles performance.
Also move the function to arraytypes.c.src where also our dot product is
placed.
The templ_common.h might still be useful in future so its kept.
