### PR TITLE
BLD: add check for C99 restrict keyword

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -446,6 +446,11 @@ def configuration(parent_package='',top_path=None):
             if sys.platform=='win32' or os.name=='nt':
                 win32_checks(moredefs)
 
+            # C99 restrict keyword
+            restrict = config_cmd.check_restrict()
+            if restrict:
+                moredefs.append(('NPY_RESTRICT', restrict))
+
             # Inline check
             inline = config_cmd.check_inline()
 

--- a/numpy/distutils/command/autodist.py
+++ b/numpy/distutils/command/autodist.py
@@ -28,6 +28,23 @@ static %(inline)s int static_func (void)
 
     return ''
 
+def check_restrict(cmd):
+    """Return the restrict identifier (may be empty)."""
+    cmd._check_compiler()
+    body = """
+static int static_func (char * %(restrict)s a)
+{
+    return 0;
+}
+"""
+
+    for kw in ['restrict', '__restrict__', '__restrict']:
+        st = cmd.try_compile(body % {'restrict': kw}, None, None)
+        if st:
+            return kw
+
+    return ''
+
 def check_compiler_gcc4(cmd):
     """Return True if the C compiler is GCC 4.x."""
     cmd._check_compiler()

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -19,6 +19,7 @@ from numpy.distutils.mingw32ccompiler import generate_manifest
 from numpy.distutils.command.autodist import (check_gcc_function_attribute,
                                               check_gcc_variable_attribute,
                                               check_inline,
+                                              check_restrict,
                                               check_compiler_gcc4)
 from numpy.distutils.compat import get_exception
 
@@ -411,6 +412,11 @@ int main (void)
         """Return the inline keyword recognized by the compiler, empty string
         otherwise."""
         return check_inline(self)
+
+    def check_restrict(self):
+        """Return the restrict keyword recognized by the compiler, empty string
+        otherwise."""
+        return check_restrict(self)
 
     def check_compiler_gcc4(self):
         """Return True if the C compiler is gcc >= 4."""


### PR DESCRIPTION
Define it as NPY_RESTRICT
Restrict indicates a memory block does not alias, gcc supports it in c89
with the `__restrict__` keyword.
