### PR TITLE
BUG: fix restrict check

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -447,9 +447,7 @@ def configuration(parent_package='',top_path=None):
                 win32_checks(moredefs)
 
             # C99 restrict keyword
-            restrict = config_cmd.check_restrict()
-            if restrict:
-                moredefs.append(('NPY_RESTRICT', restrict))
+            moredefs.append(('NPY_RESTRICT', config_cmd.check_restrict()))
 
             # Inline check
             inline = config_cmd.check_inline()


### PR DESCRIPTION
If the compiler does not support the keyword the macro must still exist.
