### PR TITLE
BUG: Make numpy import when run with Python flag '-OO'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - python: 3.2
       env: USE_DEBUG=1
     - python: 2.7
-      env: NPY_SEPARATE_COMPILATION=0
+      env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.3
       env: NPY_SEPARATE_COMPILATION=0
     - python: 2.7

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1,12 +1,14 @@
 from __future__ import division, absolute_import, print_function
 
 import warnings
+import sys
 
 import numpy as np
 from numpy.testing import (
     run_module_suite, TestCase, assert_, assert_equal, assert_array_equal,
     assert_almost_equal, assert_array_almost_equal, assert_raises,
-    assert_allclose, assert_array_max_ulp, assert_warns, assert_raises_regex
+    assert_allclose, assert_array_max_ulp, assert_warns,
+    assert_raises_regex, dec
     )
 from numpy.random import rand
 from numpy.lib import *
@@ -2094,6 +2096,8 @@ class TestAdd_newdoc_ufunc(TestCase):
 
 
 class TestAdd_newdoc(TestCase):
+
+    @dec.skipif(sys.flags.optimize == 2)
     def test_add_doc(self):
         # test np.add_newdoc
         tgt = "Current flat index into the array."

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 from numpy.core import arange
 from numpy.testing import (
-    run_module_suite, assert_, assert_equal
+    run_module_suite, assert_, assert_equal, dec
     )
 from numpy.lib import deprecate
 import numpy.lib.utils as utils
@@ -14,6 +14,7 @@ else:
     from StringIO import StringIO
 
 
+@dec.skipif(sys.flags.optimize == 2)
 def test_lookfor():
     out = StringIO()
     utils.lookfor('eigenvalue', module='numpy', output=out,

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -434,8 +434,10 @@ def apply_over_axes(func, a, axes):
                 raise ValueError("function is not returning "
                         "an array of the correct shape")
     return val
-apply_over_axes.__doc__ = np.apply_over_axes.__doc__[
-    :np.apply_over_axes.__doc__.find('Notes')].rstrip() + \
+
+if apply_over_axes.__doc__ is not None:
+    apply_over_axes.__doc__ = np.apply_over_axes.__doc__[
+        :np.apply_over_axes.__doc__.find('Notes')].rstrip() + \
     """
 
     Examples
@@ -462,7 +464,7 @@ apply_over_axes.__doc__ = np.apply_over_axes.__doc__[
     [[[46]
       [--]
       [124]]]
-"""
+    """
 
 
 def average(a, axis=None, weights=None, returned=False):

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -88,6 +88,7 @@ run_test()
   if [ -n "$USE_DEBUG" ]; then
     export PYTHONPATH=$PWD
   fi
+
   # We change directories to make sure that python won't find the copy
   # of numpy in the source directory.
   mkdir -p empty
@@ -107,6 +108,10 @@ if [ -n "$USE_DEBUG" ]; then
   sudo apt-get update
   sudo apt-get install -qq -y --force-yes python3-dbg python3-dev python3-nose
   PYTHON=python3-dbg
+fi
+
+if [ -n "$PYTHON_OO" ]; then
+  PYTHON="$PYTHON -OO"
 fi
 
 export PYTHON


### PR DESCRIPTION
This consists of checking for a docstring equal to None and skipping two
tests that require docstrings.

Closes #5148.

Rebased for backport to 1.9.
