### PR TITLE
ENH: More efficient algorithm for unweighted random choice without replacement

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1057,7 +1057,11 @@ cdef class RandomState:
 
         """
 
+        cdef npy_intp i, j, pop_size, output_size
+        cdef ndarray[npy_intp, ndim=1] tmp_idx_array
+
         # Format and Verify input
+
         a = np.array(a, copy=False)
         if a.ndim == 0:
             try:
@@ -1093,6 +1097,7 @@ cdef class RandomState:
             size = np.prod(shape, dtype=np.intp)
         else:
             size = 1
+        output_size=size
 
         # Actual sampling
         if replace:
@@ -1130,7 +1135,14 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                idx = self.permutation(pop_size)[:size]
+                # perform a partial Knuth shuffle.
+                tmp_idx_array = np.arange(pop_size)
+                i = 0
+                while i < output_size:
+                    j = rk_interval(pop_size - 1 - i, self.internal_state)+i #rand int from [i, pop_size-1]
+                    tmp_idx_array[i], tmp_idx_array[j] = tmp_idx_array[j], tmp_idx_array[i]
+                    i = i + 1
+                idx = tmp_idx_array[:output_size]
                 if shape is not None:
                     idx.shape = shape
 

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -190,7 +190,7 @@ class TestRandomDist(TestCase):
     def test_choice_uniform_noreplace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 3, replace=False)
-        desired = np.array([0, 1, 3])
+        desired = np.array([2, 3, 1])
         np.testing.assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -190,7 +190,7 @@ class TestRandomDist(TestCase):
     def test_choice_uniform_noreplace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 3, replace=False)
-        desired = np.array([2, 3, 1])
+        desired = np.array([[0, 1, 3]])
         np.testing.assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -190,7 +190,7 @@ class TestRandomDist(TestCase):
     def test_choice_uniform_noreplace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 3, replace=False)
-        desired = np.array([[0, 1, 3]])
+        desired = np.array([0, 1, 3])
         np.testing.assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):


### PR DESCRIPTION
1) The present algorithm applies a Knuth shuffle to the entire population and then truncates it to the requested size. This can be more efficiently achieved by not shuffling those elements that are not seen by the end user. Especially relevant when choosing small samples from a large population.

2) The present shuffling code is very general purpose. As what is being shuffled is an array of indices, specifying the type in the cython code gives significant speed benefits.

| input size | output size | original | new |
| --- | --- | --- | --- |
| 10 | 1 | 25.3 µs | 24.6 µs |
| 10 | 3 | 25.5 µs | 24.7 µs |
| 10 | 10 | 25.5 µs | 25 µs |
| 100 | 10 | 40.6 µs | 25.2 µs |
| 100 | 30 | 40.7 µs | 26 µs |
| 100 | 100 | 40.8 µs | 28.2 µs |
| 1000 | 100 | 190 µs | 29.7 µs |
| 1000 | 300 | 192 µs | 35.7 µs |
| 1000 | 1000 | 192 µs | 58.9 µs |
| 10000 | 1000 | 1.68 ms | 76.4 µs |
| 10000 | 3000 | 1.69 ms | 140 µs |
| 10000 | 10000 | 1.71 ms | 363 µs |
