### PR TITLE
ENH: support parallel compilation of extensions

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -35,6 +35,21 @@ Building NumPy requires the following software installed:
 Python__ http://www.python.org
 nose__ http://somethingaboutorange.com/mrl/projects/nose/
 
+Basic Installation
+==================
+
+To install numpy run:
+
+    python setup.py build -j 4 install --prefix $HOME/.local
+
+This will compile numpy on 4 CPUs and install it into the specified prefix.
+To perform an inplace build that can be run from the source folder run:
+
+   python setup.py build_ext --inplace -j 4
+
+The number of build jobs can also be specified via the environment variable
+NPY_NUM_BUILD_JOBS.
+
 Fortran ABI mismatch
 ====================
 
@@ -65,40 +80,34 @@ this means that g77 has been used. If libgfortran.so is a dependency,
 gfortran has been used. If both are dependencies, this means both have been
 used, which is almost always a very bad idea.
 
-Building with ATLAS support
-===========================
+Building with optimized BLAS support
+====================================
 
-Ubuntu 8.10 (Intrepid)
-----------------------
+Ubuntu/Debian
+-------------
 
-You can install the necessary packages for optimized ATLAS with this
-command:
+In order to build with optimized a BLAS providing development package must be installed.
+Options are for example:
 
-    sudo apt-get install libatlas-base-dev
+ - libblas-dev
+   reference BLAS not very optimized
+ - libatlas-base-dev
+   generic tuned ATLAS, it is recommended to tune it to the available hardware,
+   see /usr/share/doc/libatlas3-base/README.Debian for instructions
+ - libopenblas-base
+   fast and runtime detected so no tuning required but as of version 2.11 still
+   suffers from correctness issues on some CPUs, test your applications
+   thoughly.
 
-If you have a recent CPU with SIMD support (SSE, SSE2, etc...), you should
-also install the corresponding package for optimal performance. For
-example, for SSE2:
+The actual implementation can be exchanged also after installation via the
+alternatives mechanism:
 
-    sudo apt-get install libatlas3gf-sse2
+   update-alternatives --config libblas.so.3
+   update-alternatives --config liblapack.so.3
 
-*NOTE*: if you build your own atlas, Intrepid changed its default fortran
-compiler to gfortran. So you should rebuild everything from scratch,
-including lapack, to use it on Intrepid.
+Or by preloading a specific BLAS library with
+    LD_PRELOAD=/usr/lib/atlas-base/atlas/libblas.so.3 python ...
 
-Ubuntu 8.04 and lower
----------------------
-
-You can install the necessary packages for optimized ATLAS with this
-command:
-
-    sudo apt-get install atlas3-base-dev
-
-If you have a recent CPU with SIMD support (SSE, SSE2, etc...), you should
-also install the corresponding package for optimal performance. For
-example, for SSE2:
-
-    sudo apt-get install atlas3-sse2
 
 Windows 64 bits notes
 =====================

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -6,6 +6,8 @@ This release supports Python 2.6 - 2.7 and 3.2 - 3.4.
 
 Highlights
 ==========
+* numpy.distutils now supports parallel compilation via the --jobs/-j argument
+  passed to setup.py build
 
 
 Dropped Support
@@ -34,6 +36,13 @@ New Features
 `np.cbrt` wraps the C99 cube root function `cbrt`.
 Compared to `np.power(x, 1./3.)` it is well defined for negative real floats
 and a bit faster.
+
+numpy.distutils now allows parallel compilation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By passing `--jobs=n` or `-j n` to `setup.py build` the compilation of
+extensions is now performed in `n` parallel processes.
+The parallelization is limited to files within one extension so projects using
+Cython will not profit because it builds extensions from single files.
 
 
 Improvements

--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -16,6 +16,8 @@ class build(old_build):
     user_options = old_build.user_options + [
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
+        ('jobs=', 'j',
+         "number of parallel jobs"),
         ]
 
     help_options = old_build.help_options + [
@@ -26,8 +28,14 @@ class build(old_build):
     def initialize_options(self):
         old_build.initialize_options(self)
         self.fcompiler = None
+        self.jobs = None
 
     def finalize_options(self):
+        if self.jobs:
+            try:
+                self.jobs = int(self.jobs)
+            except ValueError:
+                raise ValueError("--jobs/-j argument must be an integer")
         build_scripts = self.build_scripts
         old_build.finalize_options(self)
         plat_specifier = ".%s-%s" % (get_platform(), sys.version[0:3])

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -30,6 +30,8 @@ class build_clib(old_build_clib):
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
         ('inplace', 'i', 'Build in-place'),
+        ('jobs=', 'j',
+         "number of parallel jobs"),
         ]
 
     boolean_options = old_build_clib.boolean_options + ['inplace']
@@ -38,7 +40,16 @@ class build_clib(old_build_clib):
         old_build_clib.initialize_options(self)
         self.fcompiler = None
         self.inplace = 0
-        return
+        self.jobs = None
+
+    def finalize_options(self):
+        if self.jobs:
+            try:
+                self.jobs = int(self.jobs)
+            except ValueError:
+                raise ValueError("--jobs/-j argument must be an integer")
+        old_build_clib.finalize_options(self)
+        self.set_undefined_options('build', ('jobs', 'jobs'))
 
     def have_f_sources(self):
         for (lib_name, build_info) in self.libraries:

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -34,6 +34,8 @@ class build_ext (old_build_ext):
     user_options = old_build_ext.user_options + [
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
+        ('jobs=', 'j',
+         "number of parallel jobs"),
         ]
 
     help_options = old_build_ext.help_options + [
@@ -44,12 +46,19 @@ class build_ext (old_build_ext):
     def initialize_options(self):
         old_build_ext.initialize_options(self)
         self.fcompiler = None
+        self.jobs = None
 
     def finalize_options(self):
+        if self.jobs:
+            try:
+                self.jobs = int(self.jobs)
+            except ValueError:
+                raise ValueError("--jobs/-j argument must be an integer")
         incl_dirs = self.include_dirs
         old_build_ext.finalize_options(self)
         if incl_dirs is not None:
             self.include_dirs.extend(self.distribution.include_dirs or [])
+        self.set_undefined_options('build', ('jobs', 'jobs'))
 
     def run(self):
         if not self.extensions:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -ex
 
+# travis boxes give you 1.5 cpus
+export NPY_NUM_BUILD_JOBS=2
+
 # setup env
 if [ -r /usr/lib/libeatmydata/libeatmydata.so ]; then
   # much faster package installation


### PR DESCRIPTION
Allow extensions using numpy.distutils to compile in parallel.
By passing `--jobs=n` or `-j n` to `setup.py build` the compilation of
extensions is now performed in `n` parallel processes.
Additionally the environment variable NUMPY_NUM_BUILD_JOBS is used as
the default value, if its unset the default is serial compilation.

The parallelization is limited to within the files of an extension, so
only numpy multiarraymodule really profits but its still a nice
improvement when you have 2-4 cores.
Unfortunately Cython will not profit at all as it tends to build one
module per file.

Currently only CCompiler adapted, but adding Fortran and C++ should be
straightforward.
