### PR TITLE
MAINT: merge scalarmathmodule into umath module

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -30,7 +30,6 @@ from . import records as rec
 from .records import *
 from .memmap import *
 from .defchararray import chararray
-from . import scalarmath
 from . import function_base
 from .function_base import *
 from . import machar

--- a/numpy/core/bento.info
+++ b/numpy/core/bento.info
@@ -29,10 +29,6 @@ Library:
     Extension: umath_tests
         Sources:
             src/umath/umath_tests.c.src
-    Extension: scalarmath
-        Sources:
-            src/private/scalarmathmodule.h.src,
-            src/scalarmathmodule.c.src
     Extension: test_rational
         Sources:
             src/umath/test_rational.c.src

--- a/numpy/core/bscript
+++ b/numpy/core/bscript
@@ -440,7 +440,7 @@ def pre_build(context):
                 "src/multiarray/arraytypes.c.src",
                 "src/multiarray/nditer_templ.c.src",
                 "src/multiarray/lowlevel_strided_loops.c.src",
-                "src/multiarray/templ_common.h.src",
+                "src/private/templ_common.h.src",
                 "src/multiarray/einsum.c.src"]
         bld(target="multiarray_templates", source=multiarray_templates)
         if ENABLE_SEPARATE_COMPILATION:
@@ -454,7 +454,6 @@ def pre_build(context):
                 pjoin('src', 'multiarray', 'buffer.c'),
                 pjoin('src', 'multiarray', 'calculation.c'),
                 pjoin('src', 'multiarray', 'common.c'),
-                pjoin('src', 'multiarray', 'templ_common.h.src'),
                 pjoin('src', 'multiarray', 'conversion_utils.c'),
                 pjoin('src', 'multiarray', 'convert.c'),
                 pjoin('src', 'multiarray', 'convert_datatype.c'),
@@ -490,6 +489,7 @@ def pre_build(context):
                 pjoin('src', 'multiarray', 'ucsnarrow.c'),
                 pjoin('src', 'multiarray', 'usertypes.c'),
                 pjoin('src', 'multiarray', 'vdot.c'),
+                pjoin('src', 'private', 'templ_common.h.src'),
                 ]
 
             if bld.env.HAS_CBLAS:
@@ -522,6 +522,7 @@ def pre_build(context):
             name="ufunc_api")
 
         ufunc_templates = [
+            "src/umath/scalarmath.c.src",
             "src/umath/loops.h.src",
             "src/umath/loops.c.src",
             "src/umath/funcs.inc.src",
@@ -535,6 +536,7 @@ def pre_build(context):
         includes = ["src/umath", "src/multiarray", "src/private"]
         if ENABLE_SEPARATE_COMPILATION:
             sources = [
+                    pjoin("src", "umath", "scalarmath.c.src"),
                     pjoin("src", "umath", "loops.h.src"),
                     pjoin("src", "umath", "loops.c.src"),
                     pjoin('src', 'umath', 'reduction.c'),
@@ -550,6 +552,5 @@ def pre_build(context):
                                        use="npymath")
     context.register_builder("umath", build_ufunc)
 
-    context.tweak_extension("scalarmath", use="npymath", includes=["src/private"])
     context.tweak_extension("multiarray_tests", use="npymath", includes=["src/private"])
     context.tweak_extension("umath_tests", use="npymath", includes=["src/private"])

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -738,7 +738,8 @@ def configuration(parent_package='',top_path=None):
                    join(local_dir, subpath, 'arraytypes.c.src'),
                    join(local_dir, subpath, 'nditer_templ.c.src'),
                    join(local_dir, subpath, 'lowlevel_strided_loops.c.src'),
-                   join(local_dir, subpath, 'einsum.c.src')]
+                   join(local_dir, subpath, 'einsum.c.src'),
+                   join(local_dir, 'src', 'private', 'templ_common.h.src')]
 
         # numpy.distutils generate .c from .c.src in weird directories, we have
         # to add them there as they depend on the build_dir
@@ -754,7 +755,6 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'buffer.h'),
             join('src', 'multiarray', 'calculation.h'),
             join('src', 'multiarray', 'common.h'),
-            join('src', 'multiarray', 'templ_common.h.src'),
             join('src', 'multiarray', 'convert_datatype.h'),
             join('src', 'multiarray', 'convert.h'),
             join('src', 'multiarray', 'conversion_utils.h'),
@@ -777,6 +777,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'ucsnarrow.h'),
             join('src', 'multiarray', 'usertypes.h'),
             join('src', 'multiarray', 'vdot.h'),
+            join('src', 'private', 'templ_common.h.src'),
             join('src', 'private', 'lowlevel_strided_loops.h'),
             join('include', 'numpy', 'arrayobject.h'),
             join('include', 'numpy', '_neighborhood_iterator_imp.h'),
@@ -830,7 +831,6 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'mapping.c'),
             join('src', 'multiarray', 'methods.c'),
             join('src', 'multiarray', 'multiarraymodule.c'),
-            join('src', 'multiarray', 'templ_common.h.src'),
             join('src', 'multiarray', 'nditer_templ.c.src'),
             join('src', 'multiarray', 'nditer_api.c'),
             join('src', 'multiarray', 'nditer_constr.c'),
@@ -846,6 +846,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'usertypes.c'),
             join('src', 'multiarray', 'ucsnarrow.c'),
             join('src', 'multiarray', 'vdot.c'),
+            join('src', 'private', 'templ_common.h.src'),
             ]
 
     blas_info = get_info('blas_opt', 0)
@@ -859,7 +860,6 @@ def configuration(parent_package='',top_path=None):
         multiarray_deps.extend(multiarray_src)
         multiarray_src = [join('src', 'multiarray', 'multiarraymodule_onefile.c')]
         multiarray_src.append(generate_multiarray_templated_sources)
-        multiarray_src.append(join('src', 'multiarray', 'templ_common.h.src'))
 
 
     config.add_extension('multiarray',
@@ -887,6 +887,7 @@ def configuration(parent_package='',top_path=None):
         sources = [
             join(local_dir, subpath, 'loops.h.src'),
             join(local_dir, subpath, 'loops.c.src'),
+            join(local_dir, subpath, 'scalarmath.c.src'),
             join(local_dir, subpath, 'simd.inc.src')]
 
         # numpy.distutils generate .c from .c.src in weird directories, we have
@@ -918,11 +919,13 @@ def configuration(parent_package='',top_path=None):
             join('src', 'umath', 'loops.h.src'),
             join('src', 'umath', 'loops.c.src'),
             join('src', 'umath', 'ufunc_object.c'),
+            join('src', 'umath', 'scalarmath.c.src'),
             join('src', 'umath', 'ufunc_type_resolution.c')]
 
     umath_deps = [
             generate_umath_py,
             join('src', 'multiarray', 'common.h'),
+            join('src', 'private', 'templ_common.h.src'),
             join('src', 'umath', 'simd.inc.src'),
             join(codegen_dir, 'generate_ufunc_api.py'),
             join('src', 'private', 'ufunc_override.h')] + npymath_sources
@@ -941,21 +944,6 @@ def configuration(parent_package='',top_path=None):
                                  generate_umath_c,
                                  generate_ufunc_api],
                          depends = deps + umath_deps,
-                         libraries = ['npymath'],
-                         )
-
-    #######################################################################
-    #                         scalarmath module                           #
-    #######################################################################
-
-    config.add_extension('scalarmath',
-                         sources = [join('src', 'scalarmathmodule.c.src'),
-                                    join('src', 'private', 'scalarmathmodule.h.src'),
-                                  generate_config_h,
-                                  generate_numpyconfig_h,
-                                  generate_numpy_api,
-                                  generate_ufunc_api],
-                         depends = deps + npymath_sources,
                          libraries = ['npymath'],
                          )
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -26,7 +26,7 @@
 #include "datetime_strings.h"
 #include "array_assign.h"
 #include "mapping.h" /* for array_item_asarray */
-#include "scalarmathmodule.h" /* for npy_mul_with_overflow_intp */
+#include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "alloc.h"
 #include <assert.h>
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -55,11 +55,10 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "array_assign.h"
 #include "common.h"
 #include "ufunc_override.h"
-#include "scalarmathmodule.h" /* for npy_mul_with_overflow_intp */
 #include "multiarraymodule.h"
 #include "cblasfuncs.h"
 #include "vdot.h"
-#include "templ_common.h"
+#include "templ_common.h" /* for npy_mul_with_overflow_intp */
 
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
@@ -4448,7 +4447,6 @@ PyMODINIT_FUNC initmultiarray(void) {
     Py_INCREF(&NpyBusDayCalendar_Type);
     PyDict_SetItemString(d, "busdaycalendar",
                             (PyObject *)&NpyBusDayCalendar_Type);
-
     set_flaginfo(d);
 
     if (!intern_strings()) {

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -14,7 +14,7 @@
 /* Indicate that this .c file is allowed to include the header */
 #define NPY_ITERATOR_IMPLEMENTATION_CODE
 #include "nditer_impl.h"
-#include "scalarmathmodule.h"
+#include "templ_common.h"
 
 /* Internal helper functions private to this file */
 static npy_intp

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -16,7 +16,7 @@
 #include "nditer_impl.h"
 
 #include "arrayobject.h"
-#include "scalarmathmodule.h"
+#include "templ_common.h"
 
 /* Internal helper functions private to this file */
 static int

--- a/numpy/core/src/multiarray/templ_common.h.src
+++ b/numpy/core/src/multiarray/templ_common.h.src
@@ -1,9 +1,0 @@
-#ifndef __NPY_TYPED_COMMON_INC
-#define __NPY_TYPED_COMMON_INC
-
-/* utility functions that profit from templates */
-
-#include "numpy/npy_common.h"
-
-
-#endif

--- a/numpy/core/src/private/templ_common.h.src
+++ b/numpy/core/src/private/templ_common.h.src
@@ -1,10 +1,9 @@
-/*
- * some overflow checking integer arithmetic
- */
-#include <numpy/npy_common.h>
+#ifndef __NPY_TYPED_COMMON_INC
+#define __NPY_TYPED_COMMON_INC
 
-#ifndef __NPY_SCALARMATHMODULE_H__
-#define __NPY_SCALARMATHMODULE_H__
+/* utility functions that profit from templates */
+
+#include "numpy/npy_common.h"
 
 /**begin repeat
  *  #name = int, uint, long, ulong,

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -6,9 +6,15 @@
    but still supports error-modes.
 */
 
+#define _UMATHMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include "Python.h"
+#include "npy_config.h"
+#ifdef ENABLE_SEPARATE_COMPILATION
+#define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
+#define NO_IMPORT_ARRAY
+#endif
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
@@ -16,7 +22,7 @@
 #include "npy_pycompat.h"
 
 #include "numpy/halffloat.h"
-#include "scalarmathmodule.h"
+#include "templ_common.h"
 
 /* Basic operations:
  *
@@ -1590,9 +1596,7 @@ static PyNumberMethods @name@_as_number = {
 };
 /**end repeat**/
 
-static void *saved_tables_arrtype[9];
-
-static void
+NPY_NO_EXPORT void
 add_scalarmath(void)
 {
     /**begin repeat
@@ -1609,28 +1613,12 @@ add_scalarmath(void)
     Py@NAME@ArrType_Type.tp_as_number = &(@name@_as_number);
     Py@NAME@ArrType_Type.tp_richcompare = @name@_richcompare;
     /**end repeat**/
-
-    saved_tables_arrtype[0] = PyLongArrType_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-    saved_tables_arrtype[1] = PyLongArrType_Type.tp_compare;
-#endif
-    saved_tables_arrtype[2] = PyLongArrType_Type.tp_richcompare;
-    saved_tables_arrtype[3] = PyDoubleArrType_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-    saved_tables_arrtype[4] = PyDoubleArrType_Type.tp_compare;
-#endif
-    saved_tables_arrtype[5] = PyDoubleArrType_Type.tp_richcompare;
-    saved_tables_arrtype[6] = PyCDoubleArrType_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-    saved_tables_arrtype[7] = PyCDoubleArrType_Type.tp_compare;
-#endif
-    saved_tables_arrtype[8] = PyCDoubleArrType_Type.tp_richcompare;
 }
 
 static int
-get_functions(void)
+get_functions(PyObject * mm)
 {
-    PyObject *mm, *obj;
+    PyObject *obj;
     void **funcdata;
     char *signatures;
     int i, j;
@@ -1638,11 +1626,6 @@ get_functions(void)
 
     /* Get the nc_pow functions */
     /* Get the pow functions */
-    mm = PyImport_ImportModule("numpy.core.umath");
-    if (mm == NULL) {
-        return -1;
-    }
-
     obj = PyObject_GetAttrString(mm, "power");
     if (obj == NULL) {
         goto fail;
@@ -1732,249 +1715,14 @@ get_functions(void)
     return ret;
 }
 
-static void *saved_tables[9];
 
-char doc_alterpyscalars[] = "";
-
-static PyObject *
-alter_pyscalars(PyObject *NPY_UNUSED(dummy), PyObject *args)
+NPY_NO_EXPORT int initscalarmath(PyObject * m)
 {
-    int n;
-    PyObject *obj;
-    n = PyTuple_GET_SIZE(args);
-    while (n--) {
-        obj = PyTuple_GET_ITEM(args, n);
-#if !defined(NPY_PY3K)
-        if (obj == (PyObject *)(&PyInt_Type)) {
-            PyInt_Type.tp_as_number = PyLongArrType_Type.tp_as_number;
-            PyInt_Type.tp_compare = PyLongArrType_Type.tp_compare;
-            PyInt_Type.tp_richcompare = PyLongArrType_Type.tp_richcompare;
-        }
-        else
-#endif
-        if (obj == (PyObject *)(&PyFloat_Type)) {
-            PyFloat_Type.tp_as_number = PyDoubleArrType_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-            PyFloat_Type.tp_compare = PyDoubleArrType_Type.tp_compare;
-#endif
-            PyFloat_Type.tp_richcompare = PyDoubleArrType_Type.tp_richcompare;
-        }
-        else if (obj == (PyObject *)(&PyComplex_Type)) {
-            PyComplex_Type.tp_as_number = PyCDoubleArrType_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-            PyComplex_Type.tp_compare = PyCDoubleArrType_Type.tp_compare;
-#endif
-            PyComplex_Type.tp_richcompare =             \
-                PyCDoubleArrType_Type.tp_richcompare;
-        }
-        else {
-            PyErr_SetString(PyExc_ValueError,
-                    "arguments must be int, float, or complex");
-            return NULL;
-        }
-    }
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-char doc_restorepyscalars[] = "";
-static PyObject *
-restore_pyscalars(PyObject *NPY_UNUSED(dummy), PyObject *args)
-{
-    int n;
-    PyObject *obj;
-
-    n = PyTuple_GET_SIZE(args);
-    while (n--) {
-        obj = PyTuple_GET_ITEM(args, n);
-#if !defined(NPY_PY3K)
-        if (obj == (PyObject *)(&PyInt_Type)) {
-            PyInt_Type.tp_as_number = saved_tables[0];
-            PyInt_Type.tp_compare = saved_tables[1];
-            PyInt_Type.tp_richcompare = saved_tables[2];
-        }
-        else
-#endif
-        if (obj == (PyObject *)(&PyFloat_Type)) {
-            PyFloat_Type.tp_as_number = saved_tables[3];
-#if !defined(NPY_PY3K)
-            PyFloat_Type.tp_compare = saved_tables[4];
-#endif
-            PyFloat_Type.tp_richcompare = saved_tables[5];
-        }
-        else if (obj == (PyObject *)(&PyComplex_Type)) {
-            PyComplex_Type.tp_as_number = saved_tables[6];
-#if !defined(NPY_PY3K)
-            PyComplex_Type.tp_compare = saved_tables[7];
-#endif
-            PyComplex_Type.tp_richcompare = saved_tables[8];
-        }
-        else {
-            PyErr_SetString(PyExc_ValueError,
-                    "arguments must be int, float, or complex");
-            return NULL;
-        }
-    }
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-char doc_usepythonmath[] = "";
-static PyObject *
-use_pythonmath(PyObject *NPY_UNUSED(dummy), PyObject *args)
-{
-    int n;
-    PyObject *obj;
-
-    n = PyTuple_GET_SIZE(args);
-    while (n--) {
-        obj = PyTuple_GET_ITEM(args, n);
-#if !defined(NPY_PY3K)
-        if (obj == (PyObject *)(&PyInt_Type)) {
-            PyLongArrType_Type.tp_as_number = saved_tables[0];
-            PyLongArrType_Type.tp_compare = saved_tables[1];
-            PyLongArrType_Type.tp_richcompare = saved_tables[2];
-        }
-        else
-#endif
-        if (obj == (PyObject *)(&PyFloat_Type)) {
-            PyDoubleArrType_Type.tp_as_number = saved_tables[3];
-#if !defined(NPY_PY3K)
-            PyDoubleArrType_Type.tp_compare = saved_tables[4];
-#endif
-            PyDoubleArrType_Type.tp_richcompare = saved_tables[5];
-        }
-        else if (obj == (PyObject *)(&PyComplex_Type)) {
-            PyCDoubleArrType_Type.tp_as_number = saved_tables[6];
-#if !defined(NPY_PY3K)
-            PyCDoubleArrType_Type.tp_compare = saved_tables[7];
-#endif
-            PyCDoubleArrType_Type.tp_richcompare = saved_tables[8];
-        }
-        else {
-            PyErr_SetString(PyExc_ValueError,
-                    "arguments must be int, float, or complex");
-            return NULL;
-        }
-    }
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-char doc_usescalarmath[] = "";
-static PyObject *
-use_scalarmath(PyObject *NPY_UNUSED(dummy), PyObject *args)
-{
-    int n;
-    PyObject *obj;
-
-    n = PyTuple_GET_SIZE(args);
-    while (n--) {
-        obj = PyTuple_GET_ITEM(args, n);
-#if !defined(NPY_PY3K)
-        if (obj == (PyObject *)(&PyInt_Type)) {
-            PyLongArrType_Type.tp_as_number = saved_tables_arrtype[0];
-            PyLongArrType_Type.tp_compare = saved_tables_arrtype[1];
-            PyLongArrType_Type.tp_richcompare = saved_tables_arrtype[2];
-        }
-        else
-#endif
-        if (obj == (PyObject *)(&PyFloat_Type)) {
-            PyDoubleArrType_Type.tp_as_number = saved_tables_arrtype[3];
-#if !defined(NPY_PY3K)
-            PyDoubleArrType_Type.tp_compare = saved_tables_arrtype[4];
-#endif
-            PyDoubleArrType_Type.tp_richcompare = saved_tables_arrtype[5];
-        }
-        else if (obj == (PyObject *)(&PyComplex_Type)) {
-            PyCDoubleArrType_Type.tp_as_number = saved_tables_arrtype[6];
-#if !defined(NPY_PY3K)
-            PyCDoubleArrType_Type.tp_compare = saved_tables_arrtype[7];
-#endif
-            PyCDoubleArrType_Type.tp_richcompare = saved_tables_arrtype[8];
-        }
-        else {
-            PyErr_SetString(PyExc_ValueError,
-                    "arguments must be int, float, or complex");
-            return NULL;
-        }
-    }
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-static struct PyMethodDef methods[] = {
-    {"alter_pythonmath",
-        (PyCFunction) alter_pyscalars,
-         METH_VARARGS, doc_alterpyscalars},
-    {"restore_pythonmath",
-        (PyCFunction) restore_pyscalars,
-         METH_VARARGS, doc_restorepyscalars},
-    {"use_pythonmath",
-        (PyCFunction) use_pythonmath,
-        METH_VARARGS, doc_usepythonmath},
-    {"use_scalarmath",
-        (PyCFunction) use_scalarmath,
-        METH_VARARGS, doc_usescalarmath},
-    {NULL, NULL, 0, NULL}
-};
-
-#if defined(NPY_PY3K)
-static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        "scalarmath",
-        NULL,
-        -1,
-        methods,
-        NULL,
-        NULL,
-        NULL,
-        NULL
-};
-#endif
-
-#if defined(NPY_PY3K)
-#define RETVAL m
-PyMODINIT_FUNC PyInit_scalarmath(void)
-#else
-#define RETVAL
-PyMODINIT_FUNC
-initscalarmath(void)
-#endif
-{
-#if defined(NPY_PY3K)
-    PyObject *m = PyModule_Create(&moduledef);
-    if (!m) {
-        return NULL;
-    }
-#else
-    Py_InitModule("scalarmath", methods);
-#endif
-
-    import_array();
-    import_umath();
-
-    if (get_functions() < 0) {
-        return RETVAL;
+    if (get_functions(m) < 0) {
+        return -1;
     }
 
     add_scalarmath();
 
-#if !defined(NPY_PY3K)
-    saved_tables[0] = PyInt_Type.tp_as_number;
-    saved_tables[1] = PyInt_Type.tp_compare;
-    saved_tables[2] = PyInt_Type.tp_richcompare;
-#endif
-    saved_tables[3] = PyFloat_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-    saved_tables[4] = PyFloat_Type.tp_compare;
-#endif
-    saved_tables[5] = PyFloat_Type.tp_richcompare;
-    saved_tables[6] = PyComplex_Type.tp_as_number;
-#if !defined(NPY_PY3K)
-    saved_tables[7] = PyComplex_Type.tp_compare;
-#endif
-    saved_tables[8] = PyComplex_Type.tp_richcompare;
-
-    return RETVAL;
+    return 0;
 }

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -44,6 +44,8 @@
 #include "__umath_generated.c"
 #include "__ufunc_api.c"
 
+NPY_NO_EXPORT int initscalarmath(PyObject *);
+
 static PyUFuncGenericFunction pyfunc_functions[] = {PyUFunc_On_Om};
 
 static int
@@ -371,6 +373,8 @@ PyMODINIT_FUNC initumath(void)
 
     PyDict_SetItemString(d, "conj", s);
     PyDict_SetItemString(d, "mod", s2);
+
+    initscalarmath(m);
 
     if (!intern_strings()) {
         goto err;

--- a/numpy/core/src/umath/umathmodule_onefile.c
+++ b/numpy/core/src/umath/umathmodule_onefile.c
@@ -1,4 +1,5 @@
 #include "loops.c"
+#include "scalarmath.c"
 
 #include "ufunc_object.c"
 #include "ufunc_type_resolution.c"


### PR DESCRIPTION
There is no good reason it needs to be its own module.
Also removes the undocumented pymath alter/restore functions.
