### PR TITLE
BUG: remove static from function

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4042,8 +4042,12 @@ datetime_dtype_metadata_clone(NpyAuxData *data)
 /*
  * Initializes the c_metadata field for the _builtin_descrs DATETIME
  * and TIMEDELTA.
+ *
+ * must not be static, gcc 4.1.2 on redhat 5 then miscompiles this function
+ * see gh-5163
+ *
  */
-static int
+NPY_NO_EXPORT int
 initialize_builtin_datetime_metadata(void)
 {
     PyArray_DatetimeDTypeMetaData *data1, *data2;


### PR DESCRIPTION
gcc 4.1.2 (e.g. in red hat 5) will miscompile the function when
inlining. Without static it will not inline solving the issue.
Closes gh-5163
