### PR TITLE
BUG: Make f2py work with intent(in out).

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1274,7 +1274,7 @@ def markinnerspaces(line):
     cb=''
     for c in line:
         if cb=='\\' and c in ['\\', '\'', '"']:
-            l=l+c;
+            l=l+c
             cb=c
             continue
         if f==0 and c in ['\'', '"']: cc=c; cc1={'\'':'"','"':'\''}[c]
@@ -2198,8 +2198,10 @@ def analyzevars(block):
                     if 'intent' not in vars[n]:
                         vars[n]['intent']=[]
                     for c in [x.strip() for x in markoutercomma(intent).split('@,@')]:
-                        if not c in vars[n]['intent']:
-                            vars[n]['intent'].append(c)
+                        # Remove spaces so that 'in out' becomes 'inout'
+                        tmp = c.replace(' ', '')
+                        if tmp not in vars[n]['intent']:
+                            vars[n]['intent'].append(tmp)
                     intent=None
                 if note:
                     note=note.replace('\\n\\n', '\n\n')
@@ -2220,7 +2222,7 @@ def analyzevars(block):
                     if 'check' not in vars[n]:
                         vars[n]['check']=[]
                     for c in [x.strip() for x in markoutercomma(check).split('@,@')]:
-                        if not c in vars[n]['check']:
+                        if c not in vars[n]['check']:
                             vars[n]['check'].append(c)
                     check=None
             if dim and 'dimension' not in vars[n]:

--- a/numpy/f2py/tests/src/regression/inout.f90
+++ b/numpy/f2py/tests/src/regression/inout.f90
@@ -1,0 +1,9 @@
+! Check that intent(in out) translates as intent(inout).
+! The separation seems to be a common usage.
+      subroutine foo(x)
+          implicit none
+          real(4), intent(in out) :: x
+          dimension x(3)
+          x(1) = x(1) + x(2) + x(3)
+          return
+      end

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -1,0 +1,32 @@
+from __future__ import division, absolute_import, print_function
+
+import os
+import math
+
+import numpy as np
+from numpy.testing import dec, assert_raises, assert_equal
+
+import util
+
+def _path(*a):
+    return os.path.join(*((os.path.dirname(__file__),) + a))
+
+class TestIntentInOut(util.F2PyTest):
+    # Check that intent(in out) translates as intent(inout)
+    sources = [_path('src', 'regression', 'inout.f90')]
+
+    @dec.slow
+    def test_inout(self):
+        # non-contiguous should raise error
+        x = np.arange(6, dtype=np.float32)[::2]
+        assert_raises(ValueError, self.module.foo, x)
+
+        # check values with contiguous array
+        x = np.arange(3, dtype=np.float32)
+        self.module.foo(x)
+        assert_equal(x, [3, 1, 2])
+
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
Note that Fortran ignores spaces in this case, so that 'in out' is
treated as 'inout'.

Closes #479.

Rebased for backport to 1.9.0.
