### PR TITLE
MAINT: replace bytewise copy with memcpy

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -20,6 +20,7 @@
 #define _NPY_CPUARCH_H_
 
 #include "numpyconfig.h"
+#include <string.h> /* for memcpy */
 
 #if defined( __i386__ ) || defined(i386) || defined(_M_IX86)
     /*
@@ -80,38 +81,7 @@
     information about your platform (OS, CPU and compiler)
 #endif
 
-/*
-   This "white-lists" the architectures that we know don't require
-   pointer alignment.  We white-list, since the memcpy version will
-   work everywhere, whereas assignment will only work where pointer
-   dereferencing doesn't require alignment.
-
-   TODO: There may be more architectures we can white list.
-*/
-#if defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64)
-    #define NPY_COPY_PYOBJECT_PTR(dst, src) (*((PyObject **)(dst)) = *((PyObject **)(src)))
-#else
-    #if NPY_SIZEOF_PY_INTPTR_T == 4
-        #define NPY_COPY_PYOBJECT_PTR(dst, src) \
-            ((char*)(dst))[0] = ((char*)(src))[0]; \
-            ((char*)(dst))[1] = ((char*)(src))[1]; \
-            ((char*)(dst))[2] = ((char*)(src))[2]; \
-            ((char*)(dst))[3] = ((char*)(src))[3];
-    #elif NPY_SIZEOF_PY_INTPTR_T == 8
-        #define NPY_COPY_PYOBJECT_PTR(dst, src) \
-            ((char*)(dst))[0] = ((char*)(src))[0]; \
-            ((char*)(dst))[1] = ((char*)(src))[1]; \
-            ((char*)(dst))[2] = ((char*)(src))[2]; \
-            ((char*)(dst))[3] = ((char*)(src))[3]; \
-            ((char*)(dst))[4] = ((char*)(src))[4]; \
-            ((char*)(dst))[5] = ((char*)(src))[5]; \
-            ((char*)(dst))[6] = ((char*)(src))[6]; \
-            ((char*)(dst))[7] = ((char*)(src))[7];
-    #else
-        #error Unknown architecture, please report this to numpy maintainers with \
-        information about your platform (OS, CPU and compiler)
-    #endif
-#endif
+#define NPY_COPY_PYOBJECT_PTR(dst, src) memcpy(dst, src, sizeof(PyObject *))
 
 #if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
 #define NPY_CPU_HAVE_UNALIGNED_ACCESS 1


### PR DESCRIPTION
memcpy takes care of unaligned memory and is inlined by the compiler,
there is no need for own code.
