### PR TITLE
DOC: core: contents of newly allocated space in memmap

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -111,6 +111,11 @@ class memmap(ndarray):
     certain size depending on the platform. This size is always < 2GB
     even on 64-bit systems.
 
+    When a memmap causes a file to be created or extended beyond its
+    current size in the filesystem, the contents of the new part are
+    unspecified. On systems with POSIX filesystem semantics, the extended
+    part will be filled with zero bytes.
+
     Examples
     --------
     >>> data = np.arange(12, dtype='float32')


### PR DESCRIPTION
Fixes #5157.
