### PR TITLE
BUG: fix nanmedian on arrays containing inf

### DIFF
--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -645,6 +645,22 @@ class TestNanFunctions_Median(TestCase):
         assert_raises(IndexError, np.nanmedian, d, axis=(0, 4))
         assert_raises(ValueError, np.nanmedian, d, axis=(1, 1))
 
+    def test_float_special(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore', RuntimeWarning)
+            a = np.array([[np.inf,  np.nan], [np.nan, np.nan]])
+            assert_equal(np.nanmedian(a, axis=0), [np.inf,  np.nan])
+            assert_equal(np.nanmedian(a, axis=1), [np.inf,  np.nan])
+            assert_equal(np.nanmedian(a), np.inf)
+
+            # minimum fill value check
+            a = np.array([[np.nan, np.nan, np.inf], [np.nan, np.nan, np.inf]])
+            assert_equal(np.nanmedian(a, axis=1), np.inf)
+
+            # no mask path
+            a = np.array([[np.inf, np.inf], [np.inf, np.inf]])
+            assert_equal(np.nanmedian(a, axis=1), np.inf)
+
 
 class TestNanFunctions_Percentile(TestCase):
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5077,7 +5077,11 @@ class MaskedArray(ndarray):
                 return self
             if fill_value is None:
                 if endwith:
-                    filler = minimum_fill_value(self)
+                    # nan > inf
+                    if np.issubdtype(self.dtype, np.floating):
+                        filler = np.nan
+                    else:
+                        filler = minimum_fill_value(self)
                 else:
                     filler = maximum_fill_value(self)
             else:
@@ -6188,7 +6192,11 @@ def sort(a, axis= -1, kind='quicksort', order=None, endwith=True, fill_value=Non
         axis = 0
     if fill_value is None:
         if endwith:
-            filler = minimum_fill_value(a)
+            # nan > inf
+            if np.issubdtype(a.dtype, np.floating):
+                filler = np.nan
+            else:
+                filler = minimum_fill_value(a)
         else:
             filler = maximum_fill_value(a)
     else:

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -504,6 +504,9 @@ class TestApplyOverAxes(TestCase):
 
 
 class TestMedian(TestCase):
+    def test_pytype(self):
+        r = np.ma.median([[np.inf, np.inf], [np.inf, np.inf]], axis=-1)
+        assert_equal(r, np.inf)
 
     def test_2d(self):
         # Tests median w/ 2D


### PR DESCRIPTION
There are two issues:
A masked divide of an infinite value is a masked value which means one
can't use np.ma.mean to compute the median as infinity division is well
defined.
This behaviour seems wrong to me but it also looks intentional so
changing it is not appropriate for a bugfix release.

The second issue is that the ordering of the sorted masked array is
undefined for equal values, the sorting considers infinity the largest
floating point value which is not correct in respect to sorting where
nan is considered larger. This is fixed by changing the
minimum_fill_value to nan for float data in the masked sorts.

Closes gh-5138
