### PR TITLE
BUG: Fix writing of intrinsic long integers in python2 npy files.

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -298,7 +298,8 @@ def _write_array_header(fp, d, version=None):
     # can take advantage of our premature optimization.
     current_header_len = MAGIC_LEN + 2 + len(header) + 1  # 1 for the newline
     topad = 16 - (current_header_len % 16)
-    header = asbytes(header + ' '*topad + '\n')
+    header = header + ' '*topad + '\n'
+    header = asbytes(_filter_header(header))
 
     if len(header) >= (256*256) and version == (1, 0):
         raise ValueError("header does not fit inside %s bytes required by the"
@@ -433,7 +434,7 @@ def _filter_header(s):
         from io import StringIO
     else:
         from StringIO import StringIO
- 
+
     tokens = []
     last_token_was_number = False
     for token in tokenize.generate_tokens(StringIO(asstr(s)).read):
@@ -448,7 +449,7 @@ def _filter_header(s):
         last_token_was_number = (token_type == tokenize.NUMBER)
     return tokenize.untokenize(tokens)
 
- 
+
 def _read_array_header(fp, version):
     """
     see read_array_header_1_0


### PR DESCRIPTION
This only happens when C long is smaller than npy_intp, in particular,
on 64 bit windows. The 'L' suffix is not needed as long as safe_eval
is used to recover the values, and the long intrinsic causes problems
for python3.

The python3 read side has been fixed, but we might as well fix the
problem at the root as well.

Rebased for backport to 1.9.x.
