### PR TITLE
size and version check maintenance

### DIFF
--- a/numpy/core/bscript
+++ b/numpy/core/bscript
@@ -60,27 +60,13 @@ def define_no_smp():
     #--------------------------------
     # Checking SMP and thread options
     #--------------------------------
-    # Python 2.3 causes a segfault when
-    #  trying to re-acquire the thread-state
-    #  which is done in error-handling
-    #  ufunc code.  NPY_ALLOW_C_API and friends
-    #  cause the segfault. So, we disable threading
-    #  for now.
-    if sys.version[:5] < '2.4.2':
-        nosmp = 1
-    else:
-        # Perhaps a fancier check is in order here.
-        #  so that threads are only enabled if there
-        #  are actually multiple CPUS? -- but
-        #  threaded code can be nice even on a single
-        #  CPU so that long-calculating code doesn't
-        #  block.
-        try:
-            nosmp = os.environ['NPY_NOSMP']
-            nosmp = 1
-        except KeyError:
-            nosmp = 0
-    return nosmp == 1
+    # Perhaps a fancier check is in order here.
+    #  so that threads are only enabled if there
+    #  are actually multiple CPUS? -- but
+    #  threaded code can be nice even on a single
+    #  CPU so that long-calculating code doesn't
+    #  block.
+    return 'NPY_NOSMP' in os.environ
 
 def write_numpy_config(conf):
     subst_dict = {}

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -78,27 +78,13 @@ def is_npy_no_signal():
 def is_npy_no_smp():
     """Return True if the NPY_NO_SMP symbol must be defined in public
     header (when SMP support cannot be reliably enabled)."""
-    # Python 2.3 causes a segfault when
-    #  trying to re-acquire the thread-state
-    #  which is done in error-handling
-    #  ufunc code.  NPY_ALLOW_C_API and friends
-    #  cause the segfault. So, we disable threading
-    #  for now.
-    if sys.version[:5] < '2.4.2':
-        nosmp = 1
-    else:
-        # Perhaps a fancier check is in order here.
-        #  so that threads are only enabled if there
-        #  are actually multiple CPUS? -- but
-        #  threaded code can be nice even on a single
-        #  CPU so that long-calculating code doesn't
-        #  block.
-        try:
-            nosmp = os.environ['NPY_NOSMP']
-            nosmp = 1
-        except KeyError:
-            nosmp = 0
-    return nosmp == 1
+    # Perhaps a fancier check is in order here.
+    #  so that threads are only enabled if there
+    #  are actually multiple CPUS? -- but
+    #  threaded code can be nice even on a single
+    #  CPU so that long-calculating code doesn't
+    #  block.
+    return 'NPY_NOSMP' in os.environ
 
 def win32_checks(deflist):
     from numpy.distutils.misc_util import get_build_architecture

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -279,11 +279,11 @@ def check_types(config_cmd, ext, build_dir):
     expected['long'] = [8, 4]
     expected['float'] = [4]
     expected['double'] = [8]
-    expected['long double'] = [8, 12, 16]
-    expected['Py_intptr_t'] = [4, 8]
+    expected['long double'] = [16, 12, 8]
+    expected['Py_intptr_t'] = [8, 4]
     expected['PY_LONG_LONG'] = [8]
     expected['long long'] = [8]
-    expected['off_t'] = [4, 8]
+    expected['off_t'] = [8, 4]
 
     # Check we have the python header (-dev* packages on Linux)
     result = config_cmd.check_header('Python.h')

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -323,7 +323,8 @@ def check_types(config_cmd, ext, build_dir):
         # definition is binary compatible with C99 complex type (check done at
         # build time in npy_common.h)
         complex_def = "struct {%s __x; %s __y;}" % (type, type)
-        res = config_cmd.check_type_size(complex_def, expected=2*expected[type])
+        res = config_cmd.check_type_size(complex_def,
+                                         expected=[2 * x for x in expected[type]])
         if res >= 0:
             public_defines.append(('NPY_SIZEOF_COMPLEX_%s' % sym2def(type), '%d' % res))
         else:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -508,13 +508,8 @@ class TestDtypeAttributeDeletion(object):
                 "isbuiltin", "isnative", "isalignedstruct", "fields",
                 "metadata", "hasobject"]
 
-        if sys.version[:3] == '2.4':
-            error = TypeError
-        else:
-            error = AttributeError
-
         for s in attr:
-            assert_raises(error, delattr, dt, s)
+            assert_raises(AttributeError, delattr, dt, s)
 
 
     def test_dtype_writable_attributes_deletion(self):

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2481,13 +2481,8 @@ def test_iter_non_writable_attribute_deletion():
             "iterationneedsapi", "has_multi_index", "has_index", "dtypes",
             "ndim", "nop", "itersize", "finished"]
 
-    if sys.version[:3] == '2.4':
-        error = TypeError
-    else:
-        error = AttributeError
-
     for s in attr:
-        assert_raises(error, delattr, it, s)
+        assert_raises(AttributeError, delattr, it, s)
 
 
 def test_iter_writable_attribute_deletion():

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -407,11 +407,6 @@ class build_ext (old_build_ext):
         if ext.language=='c++' and cxx_compiler is not None:
             linker = cxx_compiler.link_shared_object
 
-        if sys.version[:3]>='2.3':
-            kws = {'target_lang':ext.language}
-        else:
-            kws = {}
-
         linker(objects, ext_filename,
                libraries=libraries,
                library_dirs=library_dirs,
@@ -419,7 +414,8 @@ class build_ext (old_build_ext):
                extra_postargs=extra_args,
                export_symbols=self.get_export_symbols(ext),
                debug=self.debug,
-               build_temp=self.build_temp,**kws)
+               build_temp=self.build_temp,
+               target_lang=ext.language)
 
     def _add_dummy_mingwex_sym(self, c_sources):
         build_src = self.get_finalized_command("build_src").build_src

--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -88,26 +88,24 @@ main()
 if __name__ == "__main__":
 
     config = configuration(top_path='')
-    version = config.get_version()
     print('F2PY Version', version)
     config = config.todict()
 
-    if sys.version[:3]>='2.3':
-        config['download_url'] = "http://cens.ioc.ee/projects/f2py2e/2.x"\
-                                 "/F2PY-2-latest.tar.gz"
-        config['classifiers'] = [
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'Intended Audience :: Science/Research',
-            'License :: OSI Approved :: NumPy License',
-            'Natural Language :: English',
-            'Operating System :: OS Independent',
-            'Programming Language :: C',
-            'Programming Language :: Fortran',
-            'Programming Language :: Python',
-            'Topic :: Scientific/Engineering',
-            'Topic :: Software Development :: Code Generators',
-            ]
+    config['download_url'] = "http://cens.ioc.ee/projects/f2py2e/2.x"\
+                             "/F2PY-2-latest.tar.gz"
+    config['classifiers'] = [
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: NumPy License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: C',
+        'Programming Language :: Fortran',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Software Development :: Code Generators',
+        ]
     setup(version=version,
           description       = "F2PY - Fortran to Python Interface Generaton",
           author            = "Pearu Peterson",

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -159,7 +159,7 @@ else:
         """ Return memory usage of running python. [Not implemented]"""
         raise NotImplementedError
 
-if os.name=='nt' and sys.version[:3] > '2.3':
+if os.name=='nt':
     # Code "stolen" from enthought/debug/memusage.py
     def GetPerformanceAttributes(object, counter, instance = None,
                                  inum=-1, format = None, machine=None):


### PR DESCRIPTION
improve the C type size checks by tuning them to the more common 64 bit platforms and fix the expected values of complex types. This removes 29 try_compiles on amd64.

remove some obsolete python 2.3 and 2.4 version checks
