### PR TITLE
MAINT: more informative errors for 'axis' argument of ufuncs

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -258,7 +258,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
         for (i = 0; i < naxes; ++i) {
             PyObject *tmp = PyTuple_GET_ITEM(axis_in, i);
             int axis = PyArray_PyIntAsInt_ErrMsg(tmp,
-                          "integers are required for the axis tuple elements");
+                          "'axis' tuple entries must be integers");
             int axis_orig = axis;
             if (error_converting(axis)) {
                 return NPY_FAIL;
@@ -289,7 +289,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
         memset(out_axis_flags, 0, ndim);
 
         axis = PyArray_PyIntAsInt_ErrMsg(axis_in,
-                                   "an integer is required for the axis");
+                   "'axis' must be None, an integer or a tuple of integers");
         axis_orig = axis;
 
         if (error_converting(axis)) {

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1073,6 +1073,9 @@ class TestUfunc(TestCase):
         assert_equal(f(d), r)
         # a, axis=0, dtype=None, out=None, keepdims=False
         assert_equal(f(d, axis=0), r)
+        assert_equal(f(d, axis=None), 10)
+        assert_equal(f(d, axis=(0, 1)), 10)
+        assert_equal(f(d, axis=(-1, -2)), 10)
         assert_equal(f(d, 0), r)
         assert_equal(f(d, 0, dtype=None), r)
         assert_equal(f(d, 0, dtype='i'), r)
@@ -1098,6 +1101,12 @@ class TestUfunc(TestCase):
         assert_raises(TypeError, f, d, axis="invalid")
         assert_raises(TypeError, f, d, axis="invalid", dtype=None,
                       keepdims=True)
+        assert_raises(TypeError, f, d, axis=[-1, -2])
+        assert_raises(TypeError, f, d, axis=(-1, 'invalid'))
+        assert_raises(ValueError, f, d, axis=(0, -3))
+        assert_raises(ValueError, f, d, axis=(0, 2))
+
+
         # invalid dtype
         assert_raises(TypeError, f, d, 0, "invalid")
         assert_raises(TypeError, f, d, dtype="invalid")


### PR DESCRIPTION
This follows from the discussion in #5196, and unifies the errors returned by `PyArray_ConvertMultiAxis` in `conversion_utils.c`, with the similar code in `ufunc_object.c` to handle the `axis` parameter to ufunc reduction methods.
