### PR TITLE
fixed #4896 (fails to build with MSVC 2013)

### DIFF
--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -247,7 +247,8 @@
 #ifdef HAVE_@KIND@@C@
 @type@ npy_@kind@@c@(@ctype@ z)
 {
-    __@ctype@_to_c99_cast z1 = {z};
+    __@ctype@_to_c99_cast z1;
+    z1.npy_z = z;
     return @kind@@c@(z1.c99_z);
 }
 #endif
@@ -260,8 +261,9 @@
 #ifdef HAVE_@KIND@@C@
 @ctype@ npy_@kind@@c@(@ctype@ z)
 {
-    __@ctype@_to_c99_cast z1 = {z};
+    __@ctype@_to_c99_cast z1;
     __@ctype@_to_c99_cast ret;
+    z1.npy_z = z;
     ret.c99_z = @kind@@c@(z1.c99_z);
     return ret.npy_z;
 }
@@ -275,9 +277,11 @@
 #ifdef HAVE_@KIND@@C@
 @ctype@ npy_@kind@@c@(@ctype@ x, @ctype@ y)
 {
-    __@ctype@_to_c99_cast xcast = {x};
-    __@ctype@_to_c99_cast ycast = {y};
+    __@ctype@_to_c99_cast xcast;
+    __@ctype@_to_c99_cast ycast;
     __@ctype@_to_c99_cast ret;
+    xcast.npy_z = x;
+    ycast.npy_z = y;
     ret.c99_z = @kind@@c@(xcast.c99_z, ycast.c99_z);
     return ret.npy_z;
 }

--- a/numpy/core/src/npymath/npy_math_private.h
+++ b/numpy/core/src/npymath/npy_math_private.h
@@ -485,6 +485,24 @@ do {                                                            \
  * support is available
  */
 #ifdef NPY_USE_C99_COMPLEX
+
+/* Microsoft C defines _MSC_VER */
+#ifdef _MSC_VER
+typedef union {
+        npy_cdouble npy_z;
+        _Dcomplex c99_z;
+} __npy_cdouble_to_c99_cast;
+
+typedef union {
+        npy_cfloat npy_z;
+        _Fcomplex c99_z;
+} __npy_cfloat_to_c99_cast;
+
+typedef union {
+        npy_clongdouble npy_z;
+        _Lcomplex c99_z;
+} __npy_clongdouble_to_c99_cast;
+#else /* !_MSC_VER */
 typedef union {
         npy_cdouble npy_z;
         complex double c99_z;
@@ -499,7 +517,9 @@ typedef union {
         npy_clongdouble npy_z;
         complex long double c99_z;
 } __npy_clongdouble_to_c99_cast;
-#else
+#endif /* !_MSC_VER */
+
+#else /* !NPY_USE_C99_COMPLEX */
 typedef union {
         npy_cdouble npy_z;
         npy_cdouble c99_z;
@@ -514,6 +534,6 @@ typedef union {
         npy_clongdouble npy_z;
         npy_clongdouble c99_z;
 } __npy_clongdouble_to_c99_cast;
-#endif
+#endif /* !NPY_USE_C99_COMPLEX */
 
 #endif /* !_NPY_MATH_PRIVATE_H_ */


### PR DESCRIPTION
fix build error with MSVC 2013 caused by C99 complex support

I already tested in Win8.1 with VS2013 Express 64bit.
Because I am not sure this patch is correct, **please let me know if something is wrong in this patch**.

_How to build(Win8.1+VS2013)_
- Install VS2013 Express(it support 64bit, don't need Windows SDK)
- In cmd, execute those commad:

``` cmd
cd \path\to\numpy
set VS100COMNTOOLS=%VS120COMNTOOLS%
"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64
python setup.py install
```
