### PR TITLE
MSVC fixes

### DIFF
--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -491,7 +491,11 @@ double npy_log2(double x)
 #ifndef HAVE_CBRT@C@
 @type@ npy_cbrt@c@(@type@ x)
 {
-    if (x < 0) {
+    /* don't set invalid flag */
+    if (npy_isnan(x)) {
+        return NPY_NAN;
+    }
+    else if (x < 0) {
         return -npy_pow@c@(-x, 1. / 3.);
     }
     else {

--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -21,16 +21,6 @@
  */
 #define NPY_MAX_COPY_ALIGNMENT 16
 
-/* Safe to use ldexp and frexp for long double for MSVC builds */
-#if (NPY_SIZEOF_LONGDOUBLE == NPY_SIZEOF_DOUBLE) || defined(_MSC_VER)
-    #ifdef HAVE_LDEXP
-        #define HAVE_LDEXPL 1
-    #endif
-    #ifdef HAVE_FREXP
-        #define HAVE_FREXPL 1
-    #endif
-#endif
-
 /* Disable broken Sun Workshop Pro math functions */
 #ifdef __SUNPRO_C
 #undef HAVE_ATAN2


### PR DESCRIPTION
fix undefined reference of ldexpl/frexpl and the cbrt fallback raising an invalid flag on nan input.
