### PR TITLE
MAINT: more informative error message from linalg.norm

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2074,6 +2074,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
     if axis is None:
         axis = tuple(range(nd))
     elif not isinstance(axis, tuple):
+        try:
+            axis = int(axis)
+        except:
+            raise TypeError("'axis' must be None, an integer or a tuple of integers")
         axis = (axis,)
 
     if len(axis) == 1:


### PR DESCRIPTION
From the discussion in #5196, provides a better error message for a bad axis specification in `np.linalg.norm`.  The other cases should be handled eventually by which ever ufunc ends up being called.   This particular case needs handled because `norm` wraps anything that isn't a tuple in a tuple.  If that happened to be a list, you would receive an error asking for an int.  So.  `np.linalg.norm(a, axis=[0,1])` failed with an unhelpful error even accounting for #5201.
