### PR TITLE
BUG: Use 'll' as the default length specifier for long long.

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -264,18 +264,9 @@ typedef unsigned PY_LONG_LONG npy_ulonglong;
 #  ifdef _MSC_VER
 #    define NPY_LONGLONG_FMT         "I64d"
 #    define NPY_ULONGLONG_FMT        "I64u"
-#  elif defined(__APPLE__) || defined(__FreeBSD__)
-/*   "%Ld" only parses 4 bytes -- "L" is floating modifier on MacOS X/BSD */
+#  else
 #    define NPY_LONGLONG_FMT         "lld"
 #    define NPY_ULONGLONG_FMT        "llu"
-/*
-     another possible variant -- *quad_t works on *BSD, but is deprecated:
-     #define LONGLONG_FMT   "qd"
-     #define ULONGLONG_FMT   "qu"
-*/
-#  else
-#    define NPY_LONGLONG_FMT         "Ld"
-#    define NPY_ULONGLONG_FMT        "Lu"
 #  endif
 #  ifdef _MSC_VER
 #    define NPY_LONGLONG_SUFFIX(x)   (x##i64)


### PR DESCRIPTION
The previous default was 'L', which seems gcc specific, whereas
'll' is the now recognized standard and is also accepted by gcc.

Closes #5027.

Rebased for backport to 1.9.x.
