### PR TITLE
BUG: fix build in c99 mode

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -133,6 +133,7 @@ extern long long __cdecl _ftelli64(FILE *);
 #else
     #define npy_ftell ftell
 #endif
+    #include <sys/types.h>
     #define npy_lseek lseek
     #define npy_off_t off_t
 


### PR DESCRIPTION
The definition of off_t is located in sys/types.h and is not pulled
by other files when compiling in c99 mode instead of the default gnu89.
Closes gh-5231
