### PR TITLE
Issue with fromarrays not using correct format for unicode arrays

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -71,7 +71,6 @@ _byteorderconv = {'b':'>',
 # are equally allowed
 
 numfmt = nt.typeDict
-_typestr = nt._typestr
 
 def find_duplicate(list):
     """Find duplication in a list, return a list of duplicated elements"""
@@ -527,15 +526,12 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
     if formats is None and dtype is None:
         # go through each object in the list to see if it is an ndarray
         # and determine the formats.
-        formats = ''
+        formats = []
         for obj in arrayList:
             if not isinstance(obj, ndarray):
                 raise ValueError("item in the array list must be an ndarray.")
-            formats += _typestr[obj.dtype.type]
-            if issubclass(obj.dtype.type, nt.flexible):
-                formats += repr(obj.itemsize)
-            formats += ','
-        formats = formats[:-1]
+            formats.append(obj.dtype.str)
+        formats = ','.join(formats)
 
     if dtype is not None:
         descr = sb.dtype(dtype)

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import sys
 from os import path
 import numpy as np
 from numpy.testing import *
@@ -15,6 +16,14 @@ class TestFromrecords(TestCase):
         r = np.rec.fromrecords([[456, 'dbe', 1.2], [2, 'de', 1.3]],
                             names='col1,col2,col3')
         assert_equal(r[0].item(), (456, 'dbe', 1.2))
+        assert_equal(r['col1'].dtype.kind, 'i')
+        if sys.version_info[0] >= 3:
+            assert_equal(r['col2'].dtype.kind, 'U')
+            assert_equal(r['col2'].dtype.itemsize, 12)
+        else:
+            assert_equal(r['col2'].dtype.kind, 'S')
+            assert_equal(r['col2'].dtype.itemsize, 3)
+        assert_equal(r['col3'].dtype.kind, 'f')
 
     def test_method_array(self):
         r = np.rec.array(asbytes('abcdefg') * 100, formats='i2,a3,i4', shape=3, byteorder='big')


### PR DESCRIPTION
If I understand correctly the records module is all but deprecated, so this is probably a bit obscure.  But it came up in Astropy (see astropy/astropy#3052).  This ensures that `np.rec.fromarrays`, and by extension `np.rec.fromrecords` uses the correct format for unicode arrays.
