### PR TITLE
BUG: fix PyArray_IsPythonScalar to detect bytes objects on Python 3

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -56,7 +56,7 @@ extern "C" CONFUSE_EMACS
          PyLong_Check(obj) || PyBool_Check(obj))
 
 #define PyArray_IsPythonScalar(obj)                                           \
-        (PyArray_IsPythonNumber(obj) || PyString_Check(obj) ||                \
+        (PyArray_IsPythonNumber(obj) || PyBytes_Check(obj) ||                 \
          PyUnicode_Check(obj))
 
 #define PyArray_IsAnyScalar(obj)                                              \


### PR DESCRIPTION
This PR should fix `PyArray_IsPythonScalar` to return True for unibyte strings on Python 3.

As you can see [here](http://nbviewer.ipython.org/gist/immerrr/ab4a50a665844c2293aa), unibyte strings don't pass `PyString_Check` on Python 3 and only `PyBytes_Check` will work there. On 2.6/2.7 `PyBytes_Check` is an alias for `PyString_Check` (or vice versa, I don't remember), so it should work too.
