### PR TITLE
BUG: fix header using symbols not available in py3

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -14,6 +14,7 @@ extern "C" CONFUSE_EMACS
        everything when you're typing */
 #endif
 
+#include <Python.h>
 #include "ndarraytypes.h"
 
 /* Includes the "function" C-API -- these are all stored in a
@@ -50,24 +51,32 @@ extern "C" CONFUSE_EMACS
 
 #define PyArray_CheckScalar(m) (PyArray_IsScalar(m, Generic) ||               \
                                 PyArray_IsZeroDim(m))
-
+#if PY_MAJOR_VERSION >= 3
+#define PyArray_IsPythonNumber(obj)                                           \
+        (PyFloat_Check(obj) || PyComplex_Check(obj) ||                        \
+         PyLong_Check(obj) || PyBool_Check(obj))
+#define PyArray_IsIntegerScalar(obj) (PyLong_Check(obj)                       \
+              || PyArray_IsScalar((obj), Integer))
+#define PyArray_IsPythonScalar(obj)                                           \
+        (PyArray_IsPythonNumber(obj) || PyBytes_Check(obj) ||                 \
+         PyUnicode_Check(obj))
+#else
 #define PyArray_IsPythonNumber(obj)                                           \
         (PyInt_Check(obj) || PyFloat_Check(obj) || PyComplex_Check(obj) ||    \
          PyLong_Check(obj) || PyBool_Check(obj))
-
+#define PyArray_IsIntegerScalar(obj) (PyInt_Check(obj)                        \
+              || PyLong_Check(obj)                                            \
+              || PyArray_IsScalar((obj), Integer))
 #define PyArray_IsPythonScalar(obj)                                           \
         (PyArray_IsPythonNumber(obj) || PyString_Check(obj) ||                \
          PyUnicode_Check(obj))
+#endif
 
 #define PyArray_IsAnyScalar(obj)                                              \
         (PyArray_IsScalar(obj, Generic) || PyArray_IsPythonScalar(obj))
 
 #define PyArray_CheckAnyScalar(obj) (PyArray_IsPythonScalar(obj) ||           \
                                      PyArray_CheckScalar(obj))
-
-#define PyArray_IsIntegerScalar(obj) (PyInt_Check(obj)                        \
-              || PyLong_Check(obj)                                            \
-              || PyArray_IsScalar((obj), Integer))
 
 
 #define PyArray_GETCONTIGUOUS(m) (PyArray_ISCONTIGUOUS(m) ?                   \

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -2,6 +2,22 @@
 #include <Python.h>
 #include "numpy/arrayobject.h"
 
+/* test PyArray_IsPythonScalar, before including private py3 compat header */
+static PyObject *
+IsPythonScalar(PyObject * dummy, PyObject *args)
+{
+    PyObject *arg = NULL;
+    if (!PyArg_ParseTuple(args, "O", &arg)) {
+        return NULL;
+    }
+    if (PyArray_IsPythonScalar(arg)) {
+        Py_RETURN_TRUE;
+    }
+    else {
+        Py_RETURN_FALSE;
+    }
+}
+
 #include "npy_pycompat.h"
 
 /*
@@ -824,6 +840,9 @@ test_nditer_too_large(PyObject *NPY_UNUSED(self), PyObject *args) {
 
 
 static PyMethodDef Multiarray_TestsMethods[] = {
+    {"IsPythonScalar",
+        IsPythonScalar,
+        METH_VARARGS, NULL},
     {"test_neighborhood_iterator",
         test_neighborhood_iterator,
         METH_VARARGS, NULL},

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1892,6 +1892,16 @@ class TestBinop(object):
         assert_(isinstance(obj2, SomeClass2))
 
 
+class TestCAPI(TestCase):
+    def test_IsPythonScalar(self):
+        from numpy.core.multiarray_tests import IsPythonScalar
+        assert_(IsPythonScalar(b'foobar'))
+        assert_(IsPythonScalar(1))
+        assert_(IsPythonScalar(2**80))
+        assert_(IsPythonScalar(2.))
+        assert_(IsPythonScalar("a"))
+
+
 class TestSubscripting(TestCase):
     def test_test_zero_rank(self):
         x = array([1, 2, 3])


### PR DESCRIPTION
Inside numpy we handle this via the py3kcompat header which is not
really public api. So for our public headers we need some explicit checks.
