### PR TITLE
Untranspose method

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -513,6 +513,12 @@ def transpose(a, axes=None):
     See Also
     --------
     rollaxis
+    argsort
+
+    Notes
+    -----
+    Use `transpose(a, argsort(axes))` to invert the transposition of tensors
+    when using the `axes` keyword argument.
 
     Examples
     --------


### PR DESCRIPTION
In some cases, for higher dimensional tensor arrays it is not obvious how a transposition can be undone. This function adds a simple helper function for that.
