### PR TITLE
Stop F2Py from using the deprecated numpy API 

### DIFF
--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -357,11 +357,11 @@ cb_arg_rules=[
     'pyobjfrom': [{debugcapi:'\tfprintf(stderr,"debug-capi:cb:#varname#\\n");'},
                  {isintent_c: """\
 \tif (#name#_nofargs>capi_i) {
-\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,0,NPY_CARRAY,NULL); /*XXX: Hmm, what will destroy this array??? */
+\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,0,NPY_ARRAY_CARRAY,NULL); /*XXX: Hmm, what will destroy this array??? */
 """,
                   l_not(isintent_c): """\
 \tif (#name#_nofargs>capi_i) {
-\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,0,NPY_FARRAY,NULL); /*XXX: Hmm, what will destroy this array??? */
+\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,0,NPY_ARRAY_FARRAY,NULL); /*XXX: Hmm, what will destroy this array??? */
 """,
                   },
                  """

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -384,7 +384,7 @@ cb_arg_rules=[
 \t\t\tfprintf(stderr,\"rv_cb_arr is NULL\\n\");
 \t\t\tgoto capi_fail;
 \t\t}
-\t\tMEMCOPY(#varname_i#,rv_cb_arr->data,PyArray_NBYTES(rv_cb_arr));
+\t\tMEMCOPY(#varname_i#,PyArray_DATA(rv_cb_arr),PyArray_NBYTES(rv_cb_arr));
 \t\tif (capi_tmp != (PyObject *)rv_cb_arr) {
 \t\t\tPy_DECREF(rv_cb_arr);
 \t\t}

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -326,7 +326,7 @@ cppmacros['TRYPYARRAYTEMPLATE']="""\
         if (!PyArray_Check(obj)) return -1;\\
         if (!(arr=(PyArrayObject *)obj)) {fprintf(stderr,\"TRYPYARRAYTEMPLATE:\");PRINTPYOBJERR(obj);return 0;}\\
         if (PyArray_DESCR(arr)->type==typecode)  {*(ctype *)(PyArray_DATA(arr))=*v; return 1;}\\
-        switch (PyArray_DESCR(arr)->type_num) {\\
+        switch (PyArray_TYPE(arr)) {\\
                 case NPY_DOUBLE: *(double *)(PyArray_DATA(arr))=*v; break;\\
                 case NPY_INT: *(int *)(PyArray_DATA(arr))=*v; break;\\
                 case NPY_LONG: *(long *)(PyArray_DATA(arr))=*v; break;\\
@@ -363,7 +363,7 @@ cppmacros['TRYCOMPLEXPYARRAYTEMPLATE']="""\
             *(ctype *)(PyArray_DATA(arr)+sizeof(ctype))=(*v).i;\\
             return 1;\\
         }\\
-        switch (PyArray_DESCR(arr)->type_num) {\\
+        switch (PyArray_TYPE(arr)) {\\
                 case NPY_CDOUBLE: *(double *)(PyArray_DATA(arr))=(*v).r;*(double *)(PyArray_DATA(arr)+sizeof(double))=(*v).i;break;\\
                 case NPY_CFLOAT: *(float *)(PyArray_DATA(arr))=(*v).r;*(float *)(PyArray_DATA(arr)+sizeof(float))=(*v).i;break;\\
                 case NPY_DOUBLE: *(double *)(PyArray_DATA(arr))=(*v).r; break;\\
@@ -391,7 +391,7 @@ cppmacros['TRYCOMPLEXPYARRAYTEMPLATE']="""\
 ## \tif (PyArray_Check(obj)) arr = (PyArrayObject *)obj;\\
 ## \telse arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
 ## \tif (arr) {\\
-## \t\tif (PyArray_DESCR(arr)->type_num==NPY_OBJECT) {\\
+## \t\tif (PyArray_TYPE(arr)==NPY_OBJECT) {\\
 ## \t\t\tif (!ctype ## _from_pyobj(v,(PyArray_DESCR(arr)->getitem)(PyArray_DATA(arr)),\"\"))\\
 ## \t\t\tgoto capi_fail;\\
 ## \t\t} else {\\
@@ -407,7 +407,7 @@ cppmacros['TRYCOMPLEXPYARRAYTEMPLATE']="""\
 ## \tif (PyArray_Check(obj)) arr = (PyArrayObject *)obj;\\
 ## \telse arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
 ## \tif (arr) {\\
-## \t\tif (PyArray_DESCR(arr)->type_num==NPY_OBJECT) {\\
+## \t\tif (PyArray_TYPE(arr)==NPY_OBJECT) {\\
 ## \t\t\tif (!ctype ## _from_pyobj(v,(PyArray_DESCR(arr)->getitem)(PyArray_DATA(arr)),\"\"))\\
 ## \t\t\tgoto capi_fail;\\
 ## \t\t} else {\\
@@ -623,7 +623,7 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",(cha
 \t\t\tgoto capi_fail;
 \t\t}
 \t\tif (*len == -1)
-\t\t\t*len = (PyArray_DESCR(arr)->elsize)*PyArray_SIZE(arr);
+\t\t\t*len = (PyArray_ITEMSIZE(arr))*PyArray_SIZE(arr);
 \t\tSTRINGMALLOC(*str,*len);
 \t\tSTRINGCOPYN(*str,PyArray_DATA(arr),*len+1);
 \t\treturn 1;

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -316,35 +316,35 @@ cppmacros['pyobj_from_string1size']='#define pyobj_from_string1size(v,len) (PyUS
 needs['TRYPYARRAYTEMPLATE']=['PRINTPYOBJERR']
 cppmacros['TRYPYARRAYTEMPLATE']="""\
 /* New SciPy */
-#define TRYPYARRAYTEMPLATECHAR case NPY_STRING: *(char *)(arr->data)=*v; break;
-#define TRYPYARRAYTEMPLATELONG case NPY_LONG: *(long *)(arr->data)=*v; break;
-#define TRYPYARRAYTEMPLATEOBJECT case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_ ## ctype ## 1(*v),arr->data); break;
+#define TRYPYARRAYTEMPLATECHAR case NPY_STRING: *(char *)(PyArray_DATA(arr))=*v; break;
+#define TRYPYARRAYTEMPLATELONG case NPY_LONG: *(long *)(PyArray_DATA(arr))=*v; break;
+#define TRYPYARRAYTEMPLATEOBJECT case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_ ## ctype ## 1(*v),PyArray_DATA(arr)); break;
 
 #define TRYPYARRAYTEMPLATE(ctype,typecode) \\
         PyArrayObject *arr = NULL;\\
         if (!obj) return -2;\\
         if (!PyArray_Check(obj)) return -1;\\
         if (!(arr=(PyArrayObject *)obj)) {fprintf(stderr,\"TRYPYARRAYTEMPLATE:\");PRINTPYOBJERR(obj);return 0;}\\
-        if (arr->descr->type==typecode)  {*(ctype *)(arr->data)=*v; return 1;}\\
+        if (arr->descr->type==typecode)  {*(ctype *)(PyArray_DATA(arr))=*v; return 1;}\\
         switch (arr->descr->type_num) {\\
-                case NPY_DOUBLE: *(double *)(arr->data)=*v; break;\\
-                case NPY_INT: *(int *)(arr->data)=*v; break;\\
-                case NPY_LONG: *(long *)(arr->data)=*v; break;\\
-                case NPY_FLOAT: *(float *)(arr->data)=*v; break;\\
-                case NPY_CDOUBLE: *(double *)(arr->data)=*v; break;\\
-                case NPY_CFLOAT: *(float *)(arr->data)=*v; break;\\
-                case NPY_BOOL: *(npy_bool *)(arr->data)=(*v!=0); break;\\
-                case NPY_UBYTE: *(unsigned char *)(arr->data)=*v; break;\\
-                case NPY_BYTE: *(signed char *)(arr->data)=*v; break;\\
-                case NPY_SHORT: *(short *)(arr->data)=*v; break;\\
-                case NPY_USHORT: *(npy_ushort *)(arr->data)=*v; break;\\
-                case NPY_UINT: *(npy_uint *)(arr->data)=*v; break;\\
-                case NPY_ULONG: *(npy_ulong *)(arr->data)=*v; break;\\
-                case NPY_LONGLONG: *(npy_longlong *)(arr->data)=*v; break;\\
-                case NPY_ULONGLONG: *(npy_ulonglong *)(arr->data)=*v; break;\\
-                case NPY_LONGDOUBLE: *(npy_longdouble *)(arr->data)=*v; break;\\
-                case NPY_CLONGDOUBLE: *(npy_longdouble *)(arr->data)=*v; break;\\
-                case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_ ## ctype ## 1(*v),arr->data, arr); break;\\
+                case NPY_DOUBLE: *(double *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_INT: *(int *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_LONG: *(long *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_FLOAT: *(float *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_CDOUBLE: *(double *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_CFLOAT: *(float *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_BOOL: *(npy_bool *)(PyArray_DATA(arr))=(*v!=0); break;\\
+                case NPY_UBYTE: *(unsigned char *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_BYTE: *(signed char *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_SHORT: *(short *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_USHORT: *(npy_ushort *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_UINT: *(npy_uint *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_ULONG: *(npy_ulong *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_LONGLONG: *(npy_longlong *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_ULONGLONG: *(npy_ulonglong *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_LONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_CLONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=*v; break;\\
+                case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_ ## ctype ## 1(*v),PyArray_DATA(arr), arr); break;\\
         default: return -2;\\
         };\\
         return 1
@@ -352,36 +352,36 @@ cppmacros['TRYPYARRAYTEMPLATE']="""\
 
 needs['TRYCOMPLEXPYARRAYTEMPLATE']=['PRINTPYOBJERR']
 cppmacros['TRYCOMPLEXPYARRAYTEMPLATE']="""\
-#define TRYCOMPLEXPYARRAYTEMPLATEOBJECT case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_complex_ ## ctype ## 1((*v)),arr->data, arr); break;
+#define TRYCOMPLEXPYARRAYTEMPLATEOBJECT case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_complex_ ## ctype ## 1((*v)),PyArray_DATA(arr), arr); break;
 #define TRYCOMPLEXPYARRAYTEMPLATE(ctype,typecode)\\
         PyArrayObject *arr = NULL;\\
         if (!obj) return -2;\\
         if (!PyArray_Check(obj)) return -1;\\
         if (!(arr=(PyArrayObject *)obj)) {fprintf(stderr,\"TRYCOMPLEXPYARRAYTEMPLATE:\");PRINTPYOBJERR(obj);return 0;}\\
         if (arr->descr->type==typecode) {\\
-            *(ctype *)(arr->data)=(*v).r;\\
-            *(ctype *)(arr->data+sizeof(ctype))=(*v).i;\\
+            *(ctype *)(PyArray_DATA(arr))=(*v).r;\\
+            *(ctype *)(PyArray_DATA(arr)+sizeof(ctype))=(*v).i;\\
             return 1;\\
         }\\
         switch (arr->descr->type_num) {\\
-                case NPY_CDOUBLE: *(double *)(arr->data)=(*v).r;*(double *)(arr->data+sizeof(double))=(*v).i;break;\\
-                case NPY_CFLOAT: *(float *)(arr->data)=(*v).r;*(float *)(arr->data+sizeof(float))=(*v).i;break;\\
-                case NPY_DOUBLE: *(double *)(arr->data)=(*v).r; break;\\
-                case NPY_LONG: *(long *)(arr->data)=(*v).r; break;\\
-                case NPY_FLOAT: *(float *)(arr->data)=(*v).r; break;\\
-                case NPY_INT: *(int *)(arr->data)=(*v).r; break;\\
-                case NPY_SHORT: *(short *)(arr->data)=(*v).r; break;\\
-                case NPY_UBYTE: *(unsigned char *)(arr->data)=(*v).r; break;\\
-                case NPY_BYTE: *(signed char *)(arr->data)=(*v).r; break;\\
-                case NPY_BOOL: *(npy_bool *)(arr->data)=((*v).r!=0 && (*v).i!=0); break;\\
-                case NPY_USHORT: *(npy_ushort *)(arr->data)=(*v).r; break;\\
-                case NPY_UINT: *(npy_uint *)(arr->data)=(*v).r; break;\\
-                case NPY_ULONG: *(npy_ulong *)(arr->data)=(*v).r; break;\\
-                case NPY_LONGLONG: *(npy_longlong *)(arr->data)=(*v).r; break;\\
-                case NPY_ULONGLONG: *(npy_ulonglong *)(arr->data)=(*v).r; break;\\
-                case NPY_LONGDOUBLE: *(npy_longdouble *)(arr->data)=(*v).r; break;\\
-                case NPY_CLONGDOUBLE: *(npy_longdouble *)(arr->data)=(*v).r;*(npy_longdouble *)(arr->data+sizeof(npy_longdouble))=(*v).i;break;\\
-                case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_complex_ ## ctype ## 1((*v)),arr->data, arr); break;\\
+                case NPY_CDOUBLE: *(double *)(PyArray_DATA(arr))=(*v).r;*(double *)(PyArray_DATA(arr)+sizeof(double))=(*v).i;break;\\
+                case NPY_CFLOAT: *(float *)(PyArray_DATA(arr))=(*v).r;*(float *)(PyArray_DATA(arr)+sizeof(float))=(*v).i;break;\\
+                case NPY_DOUBLE: *(double *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_LONG: *(long *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_FLOAT: *(float *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_INT: *(int *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_SHORT: *(short *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_UBYTE: *(unsigned char *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_BYTE: *(signed char *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_BOOL: *(npy_bool *)(PyArray_DATA(arr))=((*v).r!=0 && (*v).i!=0); break;\\
+                case NPY_USHORT: *(npy_ushort *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_UINT: *(npy_uint *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_ULONG: *(npy_ulong *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_LONGLONG: *(npy_longlong *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_ULONGLONG: *(npy_ulonglong *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_LONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=(*v).r; break;\\
+                case NPY_CLONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=(*v).r;*(npy_longdouble *)(PyArray_DATA(arr)+sizeof(npy_longdouble))=(*v).i;break;\\
+                case NPY_OBJECT: (arr->descr->f->setitem)(pyobj_from_complex_ ## ctype ## 1((*v)),PyArray_DATA(arr), arr); break;\\
                 default: return -2;\\
         };\\
         return -1;
@@ -392,10 +392,10 @@ cppmacros['TRYCOMPLEXPYARRAYTEMPLATE']="""\
 ## \telse arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
 ## \tif (arr) {\\
 ## \t\tif (arr->descr->type_num==NPY_OBJECT) {\\
-## \t\t\tif (!ctype ## _from_pyobj(v,(arr->descr->getitem)(arr->data),\"\"))\\
+## \t\t\tif (!ctype ## _from_pyobj(v,(arr->descr->getitem)(PyArray_DATA(arr)),\"\"))\\
 ## \t\t\tgoto capi_fail;\\
 ## \t\t} else {\\
-## \t\t\t(arr->descr->cast[typenum])(arr->data,1,(char*)v,1,1);\\
+## \t\t\t(arr->descr->cast[typenum])(PyArray_DATA(arr),1,(char*)v,1,1);\\
 ## \t\t}\\
 ## \t\tif ((PyObject *)arr != obj) { Py_DECREF(arr); }\\
 ## \t\treturn 1;\\
@@ -408,10 +408,10 @@ cppmacros['TRYCOMPLEXPYARRAYTEMPLATE']="""\
 ## \telse arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
 ## \tif (arr) {\\
 ## \t\tif (arr->descr->type_num==NPY_OBJECT) {\\
-## \t\t\tif (!ctype ## _from_pyobj(v,(arr->descr->getitem)(arr->data),\"\"))\\
+## \t\t\tif (!ctype ## _from_pyobj(v,(arr->descr->getitem)(PyArray_DATA(arr)),\"\"))\\
 ## \t\t\tgoto capi_fail;\\
 ## \t\t} else {\\
-## \t\t\t(arr->descr->cast[typenum])((void *)(arr->data),1,(void *)(v),1,1);\\
+## \t\t\t(arr->descr->cast[typenum])((void *)(PyArray_DATA(arr)),1,(void *)(v),1,1);\\
 ## \t\t}\\
 ## \t\tif ((PyObject *)arr != obj) { Py_DECREF(arr); }\\
 ## \t\treturn 1;\\
@@ -592,7 +592,7 @@ cfuncs['try_pyarr_from_string']="""\
 static int try_pyarr_from_string(PyObject *obj,const string str) {
 \tPyArrayObject *arr = NULL;
 \tif (PyArray_Check(obj) && (!((arr = (PyArrayObject *)obj) == NULL)))
-\t\t{ STRINGCOPYN(arr->data,str,PyArray_NBYTES(arr)); }
+\t\t{ STRINGCOPYN(PyArray_DATA(arr),str,PyArray_NBYTES(arr)); }
 \treturn 1;
 capi_fail:
 \tPRINTPYOBJERR(obj);
@@ -625,7 +625,7 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",(cha
 \t\tif (*len == -1)
 \t\t\t*len = (arr->descr->elsize)*PyArray_SIZE(arr);
 \t\tSTRINGMALLOC(*str,*len);
-\t\tSTRINGCOPYN(*str,arr->data,*len+1);
+\t\tSTRINGCOPYN(*str,PyArray_DATA(arr),*len+1);
 \t\treturn 1;
 \t}
 \tif (PyString_Check(obj)) {

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -223,7 +223,7 @@ cppmacros['SWAP']="""\
 \ta = b;\\
 \tb = c;}
 """
-#cppmacros['ISCONTIGUOUS']='#define ISCONTIGUOUS(m) (PyArray_FLAGS(m) & NPY_CONTIGUOUS)'
+#cppmacros['ISCONTIGUOUS']='#define ISCONTIGUOUS(m) (PyArray_FLAGS(m) & NPY_ARRAY_C_CONTIGUOUS)'
 cppmacros['PRINTPYOBJERR']="""\
 #define PRINTPYOBJERR(obj)\\
 \tfprintf(stderr,\"#modulename#.error is related to \");\\

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -249,7 +249,7 @@ cppmacros['len..']="""\
 #define rank(var) var ## _Rank
 #define shape(var,dim) var ## _Dims[dim]
 #define old_rank(var) (PyArray_NDIM((PyArrayObject *)(capi_ ## var ## _tmp)))
-#define old_shape(var,dim) (((PyArrayObject *)(capi_ ## var ## _tmp))->dimensions[dim])
+#define old_shape(var,dim) PyArray_DIM(((PyArrayObject *)(capi_ ## var ## _tmp)),dim)
 #define fshape(var,dim) shape(var,rank(var)-dim-1)
 #define len(var) shape(var,0)
 #define flen(var) fshape(var,0)
@@ -537,14 +537,14 @@ cfuncs['calcarrindex']="""\
 static int calcarrindex(int *i,PyArrayObject *arr) {
 \tint k,ii = i[0];
 \tfor (k=1; k < PyArray_NDIM(arr); k++)
-\t\tii += (ii*(arr->dimensions[k] - 1)+i[k]); /* assuming contiguous arr */
+\t\tii += (ii*(PyArray_DIM(arr,k) - 1)+i[k]); /* assuming contiguous arr */
 \treturn ii;
 }"""
 cfuncs['calcarrindextr']="""\
 static int calcarrindextr(int *i,PyArrayObject *arr) {
 \tint k,ii = i[PyArray_NDIM(arr)-1];
 \tfor (k=1; k < PyArray_NDIM(arr); k++)
-\t\tii += (ii*(arr->dimensions[PyArray_NDIM(arr)-k-1] - 1)+i[PyArray_NDIM(arr)-k-1]); /* assuming contiguous arr */
+\t\tii += (ii*(PyArray_DIM(arr,PyArray_NDIM(arr)-k-1) - 1)+i[PyArray_NDIM(arr)-k-1]); /* assuming contiguous arr */
 \treturn ii;
 }"""
 cfuncs['forcomb']="""\

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -248,7 +248,7 @@ needs['len..']=['f2py_size']
 cppmacros['len..']="""\
 #define rank(var) var ## _Rank
 #define shape(var,dim) var ## _Dims[dim]
-#define old_rank(var) (((PyArrayObject *)(capi_ ## var ## _tmp))->nd)
+#define old_rank(var) (PyArray_NDIM((PyArrayObject *)(capi_ ## var ## _tmp)))
 #define old_shape(var,dim) (((PyArrayObject *)(capi_ ## var ## _tmp))->dimensions[dim])
 #define fshape(var,dim) shape(var,rank(var)-dim-1)
 #define len(var) shape(var,0)
@@ -536,15 +536,15 @@ cppmacros['OLDPYNUM']="""\
 cfuncs['calcarrindex']="""\
 static int calcarrindex(int *i,PyArrayObject *arr) {
 \tint k,ii = i[0];
-\tfor (k=1; k < arr->nd; k++)
+\tfor (k=1; k < PyArray_NDIM(arr); k++)
 \t\tii += (ii*(arr->dimensions[k] - 1)+i[k]); /* assuming contiguous arr */
 \treturn ii;
 }"""
 cfuncs['calcarrindextr']="""\
 static int calcarrindextr(int *i,PyArrayObject *arr) {
-\tint k,ii = i[arr->nd-1];
-\tfor (k=1; k < arr->nd; k++)
-\t\tii += (ii*(arr->dimensions[arr->nd-k-1] - 1)+i[arr->nd-k-1]); /* assuming contiguous arr */
+\tint k,ii = i[PyArray_NDIM(arr)-1];
+\tfor (k=1; k < PyArray_NDIM(arr); k++)
+\t\tii += (ii*(arr->dimensions[PyArray_NDIM(arr)-k-1] - 1)+i[PyArray_NDIM(arr)-k-1]); /* assuming contiguous arr */
 \treturn ii;
 }"""
 cfuncs['forcomb']="""\

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1047,7 +1047,7 @@ if (#varname#_capi==Py_None) {
 \t\tif (!PyErr_Occurred())
 \t\t\tPyErr_SetString(#modulename#_error,\"failed in converting #nth# `#varname#\' of #pyname# to C/Fortran array\" );
 \t} else {
-\t\t#varname# = (#ctype# *)(capi_#varname#_tmp->data);
+\t\t#varname# = (#ctype# *)(PyArray_DATA(capi_#varname#_tmp));
 """,
 {hasinitvalue:[
     {isintent_nothide:'\tif (#varname#_capi == Py_None) {'},

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1028,8 +1028,8 @@ if (#varname#_capi==Py_None) {
 # \tif ((#varname#_capi != Py_None) && PyArray_Check(#varname#_capi) \\
 # \t\t&& (#varname#_capi != (PyObject *)capi_#varname#_tmp)) {
 # \t\tif (PyArray_NDIM((PyArrayObject *)#varname#_capi) != PyArray_NDIM(capi_#varname#_tmp)) {
-# \t\t\tif (#varname#_capi != capi_#varname#_tmp->base)
-# \t\t\t\tcopy_ND_array((PyArrayObject *)capi_#varname#_tmp->base,(PyArrayObject *)#varname#_capi);
+# \t\t\tif (#varname#_capi != PyArray_BASE(capi_#varname#_tmp))
+# \t\t\t\tcopy_ND_array(PyArray_BASE((PyArrayObject *)capi_#varname#_tmp),(PyArrayObject *)#varname#_capi);
 # \t\t} else
 # \t\t\tcopy_ND_array(capi_#varname#_tmp,(PyArrayObject *)#varname#_capi);
 # \t}

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1056,7 +1056,7 @@ if (#varname#_capi==Py_None) {
     """\
 \t\tint *_i,capi_i=0;
 \t\tCFUNCSMESS(\"#name#: Initializing #varname#=#init#\\n\");
-\t\tif (initforcomb(capi_#varname#_tmp->dimensions,PyArray_NDIM(capi_#varname#_tmp),1)) {
+\t\tif (initforcomb(PyArray_DIMS(capi_#varname#_tmp),PyArray_NDIM(capi_#varname#_tmp),1)) {
 \t\t\twhile ((_i = nextforcomb()))
 \t\t\t\t#varname#[capi_i++] = #init#; /* fortran way */
 \t\t} else {

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1027,7 +1027,7 @@ if (#varname#_capi==Py_None) {
 
 # \tif ((#varname#_capi != Py_None) && PyArray_Check(#varname#_capi) \\
 # \t\t&& (#varname#_capi != (PyObject *)capi_#varname#_tmp)) {
-# \t\tif (((PyArrayObject *)#varname#_capi)->nd != capi_#varname#_tmp->nd) {
+# \t\tif (PyArray_NDIM((PyArrayObject *)#varname#_capi) != PyArray_NDIM(capi_#varname#_tmp)) {
 # \t\t\tif (#varname#_capi != capi_#varname#_tmp->base)
 # \t\t\t\tcopy_ND_array((PyArrayObject *)capi_#varname#_tmp->base,(PyArrayObject *)#varname#_capi);
 # \t\t} else
@@ -1056,7 +1056,7 @@ if (#varname#_capi==Py_None) {
     """\
 \t\tint *_i,capi_i=0;
 \t\tCFUNCSMESS(\"#name#: Initializing #varname#=#init#\\n\");
-\t\tif (initforcomb(capi_#varname#_tmp->dimensions,capi_#varname#_tmp->nd,1)) {
+\t\tif (initforcomb(capi_#varname#_tmp->dimensions,PyArray_NDIM(capi_#varname#_tmp),1)) {
 \t\t\twhile ((_i = nextforcomb()))
 \t\t\t\t#varname#[capi_i++] = #init#; /* fortran way */
 \t\t} else {

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -616,7 +616,8 @@ void dump_dims(int rank, npy_intp* dims) {
     }
     printf("]\n");
 }
-void dump_attrs(const PyArrayObject* arr) {
+void dump_attrs(const PyArrayObject* obj) {
+    const PyArrayObject_fields *arr = (const PyArrayObject_fields*) obj;
     int rank = PyArray_NDIM(arr);
     npy_intp size = PyArray_Size((PyObject *)arr);
     printf("\trank = %d, flags = %d, size = %" NPY_INTP_FMT  "\n",
@@ -630,7 +631,9 @@ void dump_attrs(const PyArrayObject* arr) {
 
 #define SWAPTYPE(a,b,t) {t c; c = (a); (a) = (b); (b) = c; }
 
-static int swap_arrays(PyArrayObject* arr1, PyArrayObject* arr2) {
+static int swap_arrays(PyArrayObject* obj1, PyArrayObject* obj2) {
+    PyArrayObject_fields *arr1 = (PyArrayObject_fields*) obj1,
+                         *arr2 = (PyArrayObject_fields*) obj2;
     SWAPTYPE(arr1->data,arr2->data,char*);
     SWAPTYPE(arr1->nd,arr2->nd,int);
     SWAPTYPE(arr1->dimensions,arr2->dimensions,npy_intp*);

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -361,7 +361,7 @@ fortran_setattr(PyFortranObject *fp, char *name, PyObject *v) {
             if (s==-1)
                 s = PyArray_MultiplyList(arr->dimensions,PyArray_NDIM(arr));
             if (s<0 ||
-                (memcpy(fp->defs[i].data,arr->data,s*PyArray_ITEMSIZE(arr)))==NULL) {
+                (memcpy(fp->defs[i].data,PyArray_DATA(arr),s*PyArray_ITEMSIZE(arr)))==NULL) {
                 if ((PyObject*)arr!=v) {
                     Py_DECREF(arr);
                 }

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -710,17 +710,17 @@ PyArrayObject* array_from_pyobj(const int type_num,
 
         if (intent & F2PY_INTENT_CACHE) {
             /* intent(cache) */
-            if (PyArray_ISONESEGMENT(obj)
-                && PyArray_ITEMSIZE((PyArrayObject *)obj)>=elsize) {
-                if (check_and_fix_dimensions((PyArrayObject *)obj,rank,dims)) {
+            if (PyArray_ISONESEGMENT(arr)
+                && PyArray_ITEMSIZE(arr)>=elsize) {
+                if (check_and_fix_dimensions(arr,rank,dims)) {
                     return NULL; /*XXX: set exception */
                 }
                 if (intent & F2PY_INTENT_OUT)
-                    Py_INCREF(obj);
-                return (PyArrayObject *)obj;
+                    Py_INCREF(arr);
+                return arr;
             }
             strcpy(mess, "failed to initialize intent(cache) array");
-            if (!PyArray_ISONESEGMENT(obj))
+            if (!PyArray_ISONESEGMENT(arr))
                 strcat(mess, " -- input must be in one segment");
             if (PyArray_ITEMSIZE(arr)<elsize)
                 sprintf(mess+strlen(mess)," -- expected at least elsize=%d but got %d",
@@ -818,7 +818,7 @@ PyArrayObject* array_from_pyobj(const int type_num,
         arr = (PyArrayObject *) \
             PyArray_FromAny(obj,PyArray_DescrFromType(type_num), 0,0,
                             ((intent & F2PY_INTENT_C)?NPY_ARRAY_CARRAY:NPY_ARRAY_FARRAY) \
-                            | NPY_FORCECAST, NULL);
+                            | NPY_ARRAY_FORCECAST, NULL);
         if (arr==NULL)
             return NULL;
         if (check_and_fix_dimensions(arr,rank,dims))

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -766,7 +766,7 @@ PyArrayObject* array_from_pyobj(const int type_num,
                         );
             if (!(ARRAY_ISCOMPATIBLE(arr,type_num)))
                 sprintf(mess+strlen(mess)," -- input '%c' not compatible to '%c'",
-                        arr->descr->type,typechar);
+                        PyArray_DESCR(arr)->type,typechar);
 	    if (!(F2PY_CHECK_ALIGNMENT(arr, intent)))
 	      sprintf(mess+strlen(mess)," -- input not %d-aligned", F2PY_GET_ALIGNMENT(intent));
             PyErr_SetString(PyExc_ValueError,mess);

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -58,11 +58,11 @@ PyFortranObject_New(FortranDataDef* defs, f2py_void_func init) {
                     int n = fp->defs[i].rank-1;
                     v = PyArray_New(&PyArray_Type, n, fp->defs[i].dims.d,
                                     NPY_STRING, NULL, fp->defs[i].data, fp->defs[i].dims.d[n],
-                                    NPY_FARRAY, NULL);
+                                    NPY_ARRAY_FARRAY, NULL);
                 }
                 else {
                     v = PyArray_New(&PyArray_Type, fp->defs[i].rank, fp->defs[i].dims.d,
-                                    fp->defs[i].type, NULL, fp->defs[i].data, 0, NPY_FARRAY,
+                                    fp->defs[i].type, NULL, fp->defs[i].data, 0, NPY_ARRAY_FARRAY,
                                     NULL);
                 }
                 if (v==NULL) return NULL;
@@ -273,7 +273,7 @@ fortran_getattr(PyFortranObject *fp, char *name) {
                 k = fp->defs[i].rank;
             if (fp->defs[i].data !=NULL) {              /* array is allocated */
                 PyObject *v = PyArray_New(&PyArray_Type, k, fp->defs[i].dims.d,
-                                          fp->defs[i].type, NULL, fp->defs[i].data, 0, NPY_FARRAY,
+                                          fp->defs[i].type, NULL, fp->defs[i].data, 0, NPY_ARRAY_FARRAY,
                                           NULL);
                 if (v==NULL) return NULL;
                 /* Py_INCREF(v); */
@@ -817,7 +817,7 @@ PyArrayObject* array_from_pyobj(const int type_num,
         F2PY_REPORT_ON_ARRAY_COPY_FROMANY;
         arr = (PyArrayObject *) \
             PyArray_FromAny(obj,PyArray_DescrFromType(type_num), 0,0,
-                            ((intent & F2PY_INTENT_C)?NPY_CARRAY:NPY_FARRAY) \
+                            ((intent & F2PY_INTENT_C)?NPY_ARRAY_CARRAY:NPY_ARRAY_FARRAY) \
                             | NPY_FORCECAST, NULL);
         if (arr==NULL)
             return NULL;

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -119,7 +119,7 @@ int F2PyCapsule_Check(PyObject *ptr);
 
 #endif
 
-#define ISCONTIGUOUS(m) ((m)->flags & NPY_CONTIGUOUS)
+#define ISCONTIGUOUS(m) (PyArray_FLAGS(m) & NPY_CONTIGUOUS)
 #define F2PY_INTENT_IN 1
 #define F2PY_INTENT_INOUT 2
 #define F2PY_INTENT_OUT 4

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -119,7 +119,7 @@ int F2PyCapsule_Check(PyObject *ptr);
 
 #endif
 
-#define ISCONTIGUOUS(m) (PyArray_FLAGS(m) & NPY_CONTIGUOUS)
+#define ISCONTIGUOUS(m) (PyArray_FLAGS(m) & NPY_ARRAY_C_CONTIGUOUS)
 #define F2PY_INTENT_IN 1
 #define F2PY_INTENT_INOUT 2
 #define F2PY_INTENT_OUT 4

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -4,6 +4,8 @@
 extern "C" {
 #endif
 
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
 #include "Python.h"
 
 #ifdef FORTRANOBJECT_C

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -90,22 +90,22 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
 			&PyArray_Type,&arr_capi))
     return NULL;
   arr = (PyArrayObject *)arr_capi;
-  sprintf(s,"%p",arr->data);
-  dimensions = PyTuple_New(arr->nd);
-  strides = PyTuple_New(arr->nd);
-  for (i=0;i<arr->nd;++i) {
-    PyTuple_SetItem(dimensions,i,PyInt_FromLong(arr->dimensions[i]));
-    PyTuple_SetItem(strides,i,PyInt_FromLong(arr->strides[i]));
+  sprintf(s,"%p",PyArray_DATA(arr));
+  dimensions = PyTuple_New(PyArray_NDIM(arr));
+  strides = PyTuple_New(PyArray_NDIM(arr));
+  for (i=0;i<PyArray_NDIM(arr);++i) {
+    PyTuple_SetItem(dimensions,i,PyInt_FromLong(PyArray_DIM(arr,i)));
+    PyTuple_SetItem(strides,i,PyInt_FromLong(PyArray_STRIDE(arr,i)));
   }
-  return Py_BuildValue("siOOO(cciii)ii",s,arr->nd,
+  return Py_BuildValue("siOOO(cciii)ii",s,PyArray_NDIM(arr),
 		       dimensions,strides,
-		       (arr->base==NULL?Py_None:arr->base),
-		       arr->descr->kind,
-		       arr->descr->type,
-		       arr->descr->type_num,
-		       arr->descr->elsize,
-		       arr->descr->alignment,
-		       arr->flags,
+		       (PyArray_BASE(arr)==NULL?Py_None:PyArray_BASE(arr)),
+		       PyArray_DESCR(arr)->kind,
+		       PyArray_DESCR(arr)->type,
+		       PyArray_TYPE(arr),
+		       PyArray_ITEMSIZE(arr),
+		       PyArray_DESCR(arr)->alignment,
+		       PyArray_FLAGS(arr),
 		       PyArray_ITEMSIZE(arr));
 }
 
@@ -190,24 +190,24 @@ PyMODINIT_FUNC inittest_array_from_pyobj_ext(void) {
   PyDict_SetItemString(d, "NPY_NOTYPE", PyInt_FromLong(NPY_NOTYPE));
   PyDict_SetItemString(d, "NPY_USERDEF", PyInt_FromLong(NPY_USERDEF));
 
-  PyDict_SetItemString(d, "CONTIGUOUS", PyInt_FromLong(NPY_CONTIGUOUS));
-  PyDict_SetItemString(d, "FORTRAN", PyInt_FromLong(NPY_FORTRAN));
-  PyDict_SetItemString(d, "OWNDATA", PyInt_FromLong(NPY_OWNDATA));
-  PyDict_SetItemString(d, "FORCECAST", PyInt_FromLong(NPY_FORCECAST));
-  PyDict_SetItemString(d, "ENSURECOPY", PyInt_FromLong(NPY_ENSURECOPY));
-  PyDict_SetItemString(d, "ENSUREARRAY", PyInt_FromLong(NPY_ENSUREARRAY));
-  PyDict_SetItemString(d, "ALIGNED", PyInt_FromLong(NPY_ALIGNED));
-  PyDict_SetItemString(d, "WRITEABLE", PyInt_FromLong(NPY_WRITEABLE));
-  PyDict_SetItemString(d, "UPDATEIFCOPY", PyInt_FromLong(NPY_UPDATEIFCOPY));
+  PyDict_SetItemString(d, "CONTIGUOUS", PyInt_FromLong(NPY_ARRAY_C_CONTIGUOUS));
+  PyDict_SetItemString(d, "FORTRAN", PyInt_FromLong(NPY_ARRAY_F_CONTIGUOUS));
+  PyDict_SetItemString(d, "OWNDATA", PyInt_FromLong(NPY_ARRAY_OWNDATA));
+  PyDict_SetItemString(d, "FORCECAST", PyInt_FromLong(NPY_ARRAY_FORCECAST));
+  PyDict_SetItemString(d, "ENSURECOPY", PyInt_FromLong(NPY_ARRAY_ENSURECOPY));
+  PyDict_SetItemString(d, "ENSUREARRAY", PyInt_FromLong(NPY_ARRAY_ENSUREARRAY));
+  PyDict_SetItemString(d, "ALIGNED", PyInt_FromLong(NPY_ARRAY_ALIGNED));
+  PyDict_SetItemString(d, "WRITEABLE", PyInt_FromLong(NPY_ARRAY_WRITEABLE));
+  PyDict_SetItemString(d, "UPDATEIFCOPY", PyInt_FromLong(NPY_ARRAY_UPDATEIFCOPY));
 
-  PyDict_SetItemString(d, "BEHAVED", PyInt_FromLong(NPY_BEHAVED));
-  PyDict_SetItemString(d, "BEHAVED_NS", PyInt_FromLong(NPY_BEHAVED_NS));
-  PyDict_SetItemString(d, "CARRAY", PyInt_FromLong(NPY_CARRAY));
-  PyDict_SetItemString(d, "FARRAY", PyInt_FromLong(NPY_FARRAY));
-  PyDict_SetItemString(d, "CARRAY_RO", PyInt_FromLong(NPY_CARRAY_RO));
-  PyDict_SetItemString(d, "FARRAY_RO", PyInt_FromLong(NPY_FARRAY_RO));
-  PyDict_SetItemString(d, "DEFAULT", PyInt_FromLong(NPY_DEFAULT));
-  PyDict_SetItemString(d, "UPDATE_ALL", PyInt_FromLong(NPY_UPDATE_ALL));
+  PyDict_SetItemString(d, "BEHAVED", PyInt_FromLong(NPY_ARRAY_BEHAVED));
+  PyDict_SetItemString(d, "BEHAVED_NS", PyInt_FromLong(NPY_ARRAY_BEHAVED_NS));
+  PyDict_SetItemString(d, "CARRAY", PyInt_FromLong(NPY_ARRAY_CARRAY));
+  PyDict_SetItemString(d, "FARRAY", PyInt_FromLong(NPY_ARRAY_FARRAY));
+  PyDict_SetItemString(d, "CARRAY_RO", PyInt_FromLong(NPY_ARRAY_CARRAY_RO));
+  PyDict_SetItemString(d, "FARRAY_RO", PyInt_FromLong(NPY_ARRAY_FARRAY_RO));
+  PyDict_SetItemString(d, "DEFAULT", PyInt_FromLong(NPY_ARRAY_DEFAULT));
+  PyDict_SetItemString(d, "UPDATE_ALL", PyInt_FromLong(NPY_ARRAY_UPDATE_ALL));
 
   if (PyErr_Occurred())
     Py_FatalError("can't initialize module wrap");


### PR DESCRIPTION
The f2py C code currently uses the pre 1.7 deprecated API, which causes lots of spurious warning messages when compiling Fortran extension modules with f2py (see #2639).

This pull request removes almost all of this, except for the `swap_arrays` and `dump_attrs` functions in fortranobject.c, which now cast the `PyArrayObject*` to `PyArrayObject_fields*`
