### PR TITLE
Possible regression in `multivariate_normal()`

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2919,7 +2919,7 @@ cdef class RandomState:
 
         Plot Gaussian for comparison:
 
-        >>> g = (1/(scale * np.sqrt(2 * np.pi)) * 
+        >>> g = (1/(scale * np.sqrt(2 * np.pi)) *
         ...      np.exp(-(x - loc)**2 / (2 * scale**2)))
         >>> plt.plot(x,g)
 
@@ -4220,8 +4220,8 @@ cdef class RandomState:
         mean : 1-D array_like, of length N
             Mean of the N-dimensional distribution.
         cov : 2-D array_like, of shape (N, N)
-            Covariance matrix of the distribution.  Must be symmetric and
-            positive-semidefinite for "physically meaningful" results.
+            Covariance matrix of the distribution. It must be symmetric and
+            positive-semidefinite for proper sampling.
         size : int or tuple of ints, optional
             Given a shape of, for example, ``(m,n,k)``, ``m*n*k`` samples are
             generated, and packed in an `m`-by-`n`-by-`k` arrangement.  Because
@@ -4268,7 +4268,9 @@ cdef class RandomState:
         >>> x,y = np.random.multivariate_normal(mean,cov,5000).T
         >>> plt.plot(x,y,'x'); plt.axis('equal'); plt.show()
 
-        Note that the covariance matrix must be non-negative definite.
+        Note that the covariance matrix must be positive semidefinite (a.k.a.
+        nonnegative-definite). Otherwise, the behavior of this method is
+        undefined and backwards compatibility is not guaranteed.
 
         References
         ----------


### PR DESCRIPTION
When generating numbers from `np.random.multivariate_normal`, I'm not getting the same numbers when moving from NumPy 1.8.2 to 1.9.1.  This seems to happen only when the covariance matrix is not positive semi-definite, but note, the docs never stated this was a requirement to guarantee backwards compatibility.

Here is current behavior:

```
In [1]: np.random.seed(0)

In [2]: np.random.multivariate_normal([.5, .5], [[.3, .2],[.2, .4]])
Out[2]: array([-0.42923317, -0.44352946])

In [3]: np.random.multivariate_normal([.5, .5], [[.3, .5],[.5, .4]])
/Users/me/.virtualenvs/py27/bin/ipython:1: RuntimeWarning: covariance is not positive-semidefinite.
Out[3]: array([-0.10637043, -0.17003179])

In [4]: np.__version__
Out[4]: '1.9.1'
```

Here is behavior in 1.8.1 and also 1.8.2:

```
In [1]: np.random.seed(0)

In [2]: np.random.multivariate_normal([.5, .5], [[.3, .2],[.2, .4]])
Out[2]: array([-0.42923317, -0.44352946])

In [3]: np.random.multivariate_normal([.5, .5], [[.3, .5],[.5, .4]])
Out[3]: array([ 0.54245905, -0.7572144 ])

In [4]: np.__version__
Out[4]: '1.8.1'
```

Resetting the seed before `In [3]` doesn't affect the difference between versions.
