### PR TITLE
MAINT: give up on rackspace wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
   # pip install coverage
   - python -V
   - pip install --upgrade pip setuptools
-  - pip install --find-links http://travis-wheels.scikit-image.org --install-option="--no-cython-compile" Cython
+  # Speed up install by not compiling Cython
+  - pip install --install-option="--no-cython-compile" Cython
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   - popd
 


### PR DESCRIPTION
Rackspace wheels (from http://wheels.scikit-image.org) are giving timeouts,
again - e.g.:

https://travis-ci.org/numpy/numpy/jobs/40578751

Use Nathaniel's trick of not compiling Cython, for speed, and to work round
previous Cython build breakage.
