### PR TITLE
TST: Fix ImportError in runtests.py (fixes #5273)

### DIFF
--- a/numpy/testing/__init__.py
+++ b/numpy/testing/__init__.py
@@ -10,7 +10,6 @@ from __future__ import division, absolute_import, print_function
 from unittest import TestCase
 
 from . import decorators as dec
+from .nosetester import run_module_suite, NoseTester as Tester
 from .utils import *
-from .nosetester import NoseTester as Tester
-from .nosetester import run_module_suite
 test = Tester().test


### PR DESCRIPTION
I think the problem is because numpy.testing has only been partially imported when it tries to import numpy.utils, so when numpy.core tries `from numpy.testing import Tester` it can't find it. I've fixed this by moving the import of Tester to before `from .utils import *`. However I'm not sure why this problem hasn't appeared for others -- perhaps I am doing something else wrong.
