### PR TITLE
Fix #5221 unexpected behaviour of datetime_arange

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -3323,10 +3323,7 @@ datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
         type_nums[2] = NPY_TIMEDELTA;
     }
     else {
-        if (PyInt_Check(objs[1]) ||
-                        PyLong_Check(objs[1]) ||
-                        PyArray_IsScalar(objs[1], Integer) ||
-                        is_any_numpy_timedelta(objs[1])) {
+        if (is_any_numpy_timedelta(objs[1])) {
             type_nums[1] = NPY_TIMEDELTA;
         }
         else {

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1393,11 +1393,12 @@ class TestDateTime(TestCase):
 
         # datetime, integer|timedelta works as well
         # produces arange (start, start + stop) in this case
-        a = np.arange('1969', 18, 3, dtype='M8')
+        a = np.arange('1969', np.timedelta64(18), 3, dtype='M8')
         assert_equal(a.dtype, np.dtype('M8[Y]'))
         assert_equal(a,
             np.datetime64('1969') + np.arange(18, step=3))
-        a = np.arange('1969-12-19', 22, np.timedelta64(2), dtype='M8')
+        a = np.arange('1969-12-19', np.timedelta64(22), 
+                      np.timedelta64(2), dtype='M8')
         assert_equal(a.dtype, np.dtype('M8[D]'))
         assert_equal(a,
             np.datetime64('1969-12-19') + np.arange(22, step=2))

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1417,6 +1417,12 @@ class TestDateTime(TestCase):
         assert_equal(np.arange(d, d + 1), d)
         assert_raises(ValueError, np.arange, d)
 
+    def test_datetime_arange_int(self):
+        a = np.arange(-2, 4, dtype='M8[Y]')
+        assert_equal(a,
+                     np.array(['1968', '1969', '1970', '1971', '1972', '1973'],
+                              dtype='datetime64[Y]'))
+
     def test_timedelta_arange(self):
         a = np.arange(3, 10, dtype='m8')
         assert_equal(a.dtype, np.dtype('m8'))


### PR DESCRIPTION
An integer passed to the `stop` argument of `datetime_arange` was automatically converted to a timedelta; this confused some people. This PR changes the behaviour to what the OP of #5221 expects. Whether that is the right thing or not is a separate question.
