### PR TITLE
BUG: astype is broken for structured arrays with different byte orders

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -624,7 +624,17 @@ type_num_unsigned_to_signed(int type_num)
     }
 }
 
-/* Compare two field dictionaries for castability. */
+/*
+ * Compare two field dictionaries for castability.
+ *
+ * Return 1 if 'field1' can be cast to 'field2' according to the rule
+ * 'casting', 0 if not.
+ *
+ * Castabiliy of field dictionaries is defined recursively: 'field1' and
+ * 'field2' must have the same field names (possibly in different
+ * orders), and the corresponding field types must be castable according
+ * to the given casting rule.
+ */
 static int
 can_cast_fields(PyObject *field1, PyObject *field2, NPY_CASTING casting)
 {

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -624,6 +624,43 @@ type_num_unsigned_to_signed(int type_num)
     }
 }
 
+/* Compare two field dictionaries for castability. */
+static int
+can_cast_fields(PyObject *field1, PyObject *field2, NPY_CASTING casting)
+{
+    Py_ssize_t ppos;
+    PyObject *key;
+    PyObject *tuple1, *tuple2;
+
+    if (field1 == field2) {
+        return 1;
+    }
+    if (field1 == NULL || field2 == NULL) {
+        return 0;
+    }
+
+    if (PyDict_Size(field1) != PyDict_Size(field2)) {
+        return 0;
+    }
+
+    /* Iterate over all the fields and compare for castability */
+    ppos = 0;
+    while (PyDict_Next(field1, &ppos, &key, &tuple1)) {
+        if ((tuple2 = PyDict_GetItem(field2, key)) == NULL) {
+            return 0;
+        }
+        /* Compare the dtype of the field for castability */
+        if (!PyArray_CanCastTypeTo(
+                        (PyArray_Descr *)PyTuple_GET_ITEM(tuple1, 0),
+                        (PyArray_Descr *)PyTuple_GET_ITEM(tuple2, 0),
+                        casting)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 /*NUMPY_API
  * Returns true if data of type 'from' may be cast to data of type
  * 'to' according to the rule 'casting'.
@@ -643,7 +680,6 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
     else if (PyArray_EquivTypenums(from->type_num, to->type_num)) {
         /* For complicated case, use EquivTypes (for now) */
         if (PyTypeNum_ISUSERDEF(from->type_num) ||
-                        PyDataType_HASFIELDS(from) ||
                         from->subarray != NULL) {
             int ret;
 
@@ -669,6 +705,22 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
                 ret = PyArray_EquivTypes(from, to);
             }
             return ret;
+        }
+
+        if (PyDataType_HASFIELDS(from)) {
+            switch (casting) {
+                case NPY_EQUIV_CASTING:
+                case NPY_SAFE_CASTING:
+                case NPY_SAME_KIND_CASTING:
+                    /* `from' and `to' must have the same fields, and
+                     * corresponding fields must be (recursively) castable.
+                     */
+                    return can_cast_fields(from->fields, to->fields, casting);
+
+                case NPY_NO_CASTING:
+                default:
+                    return PyArray_EquivTypes(from, to);
+            }
         }
 
         switch (from->type_num) {

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -638,7 +638,6 @@ can_cast_fields(PyObject *field1, PyObject *field2, NPY_CASTING casting)
     if (field1 == NULL || field2 == NULL) {
         return 0;
     }
-
     if (PyDict_Size(field1) != PyDict_Size(field2)) {
         return 0;
     }
@@ -712,7 +711,8 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
                 case NPY_EQUIV_CASTING:
                 case NPY_SAFE_CASTING:
                 case NPY_SAME_KIND_CASTING:
-                    /* `from' and `to' must have the same fields, and
+                    /* 
+                     * `from' and `to' must have the same fields, and
                      * corresponding fields must be (recursively) castable.
                      */
                     return can_cast_fields(from->fields, to->fields, casting);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1445,9 +1445,7 @@ array_putmask(PyObject *NPY_UNUSED(module), PyObject *args, PyObject *kwds)
 static int
 _equivalent_fields(PyObject *field1, PyObject *field2) {
 
-    Py_ssize_t ppos;
-    PyObject *key;
-    PyObject *tuple1, *tuple2;
+    int same, val;
 
     if (field1 == field2) {
         return 1;
@@ -1455,33 +1453,20 @@ _equivalent_fields(PyObject *field1, PyObject *field2) {
     if (field1 == NULL || field2 == NULL) {
         return 0;
     }
-
-    if (PyDict_Size(field1) != PyDict_Size(field2)) {
-        return 0;
+#if defined(NPY_PY3K)
+    val = PyObject_RichCompareBool(field1, field2, Py_EQ);
+    if (val != 1 || PyErr_Occurred()) {
+#else
+    val = PyObject_Compare(field1, field2);
+    if (val != 0 || PyErr_Occurred()) {
+#endif
+        same = 0;
     }
-
-    /* Iterate over all the fields and compare for equivalency */
-    ppos = 0;
-    while (PyDict_Next(field1, &ppos, &key, &tuple1)) {
-        if ((tuple2 = PyDict_GetItem(field2, key)) == NULL) {
-            return 0;
-        }
-        /* Compare the dtype of the field for equivalency */
-        if (!PyArray_CanCastTypeTo((PyArray_Descr *)PyTuple_GET_ITEM(tuple1, 0),
-                                   (PyArray_Descr *)PyTuple_GET_ITEM(tuple2, 0),
-                                   NPY_EQUIV_CASTING)) {
-            return 0;
-        }
-        /* Compare the byte position of the field */
-        if (PyObject_RichCompareBool(PyTuple_GET_ITEM(tuple1, 1),
-                                     PyTuple_GET_ITEM(tuple2, 1),
-                                     Py_EQ) != 1) {
-            PyErr_Clear();
-            return 0;
-        }
+    else {
+        same = 1;
     }
-
-    return 1;
+    PyErr_Clear();
+    return same;
 }
 
 /*

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -781,6 +781,13 @@ class TestStructured(TestCase):
         assert_(not np.can_cast(a.dtype, b.dtype, casting='no'))
         assert_raises(TypeError, a.astype, b.dtype, casting='no')
 
+        # Check that non-'unsafe' casting can't change the set of field names
+        for casting in ['no', 'safe', 'equiv', 'same_kind']:
+            t = [('a', '>i4')]
+            assert_(not np.can_cast(a.dtype, t, casting=casting))
+            t = [('a', '>i4'), ('b', '<f8'), ('c', 'i4')]
+            assert_(not np.can_cast(a.dtype, t, casting=casting))
+
 
 class TestBool(TestCase):
     def test_test_interning(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -753,17 +753,16 @@ class TestStructured(TestCase):
         assert_equal((c == np.array([(5, 42), (10, 1)], dtype=t)),
                      [True, True])
 
-        with self.assertRaises(TypeError):
-            a.astype([('a', '>i8'), ('b', '<f4')], casting='safe')
+        assert_raises(TypeError, a.astype, [('a', '>i8'), ('b', '<f4')],
+                      casting='safe')
 
-        with self.assertRaises(TypeError):
-            a.astype([('a', '>i2'), ('b', '<f8')], casting='equiv')
+        assert_raises(TypeError, a.astype, [('a', '>i2'), ('b', '<f8')],
+                      casting='equiv')
 
-        with self.assertRaises(TypeError):
-            a.astype([('a', '>i8'), ('b', '<i2')], casting='same_kind')
+        assert_raises(TypeError, a.astype, [('a', '>i8'), ('b', '<i2')],
+                      casting='same_kind')
 
-        with self.assertRaises(TypeError):
-            a.astype(b.dtype, casting='no')
+        assert_raises(TypeError, a.astype, b.dtype, casting='no')
 
 
 class TestBool(TestCase):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -730,28 +730,40 @@ class TestStructured(TestCase):
         assert_equal(a == b, [False, True])
 
     def test_casting(self):
+        # Check that casting a structured array to change its byte order
+        # works
         a = np.array([(1,)], dtype=[('a', '<i4')])
         b = a.astype([('a', '>i4')])
         assert_equal(b, a.byteswap().newbyteorder())
         assert_equal(a['a'][0], b['a'][0])
 
+        # Check that equality comparison works on structured arrays if
+        # they should be 'equiv'-castable
         a = np.array([(5, 42), (10, 1)], dtype=[('a', '>i4'), ('b', '<f8')])
         b = np.array([(42, 5), (1, 10)], dtype=[('b', '>f8'), ('a', '<i4')])
         assert_equal(a == b, [True, True])
 
+        # Check that 'equiv' casting can reorder fields and change byte
+        # order
         c = a.astype(b.dtype, casting='equiv')
         assert_equal(a == c, [True, True])
 
+        # Check that 'safe' casting can change byte order and up-cast
+        # fields
         t = [('a', '<i8'), ('b', '>f8')]
         c = a.astype(t, casting='safe')
         assert_equal((c == np.array([(5, 42), (10, 1)], dtype=t)),
                      [True, True])
 
+        # Check that 'same_kind' casting can change byte order and
+        # change field widths within a "kind"
         t = [('a', '<i4'), ('b', '>f4')]
         c = a.astype(t, casting='same_kind')
         assert_equal((c == np.array([(5, 42), (10, 1)], dtype=t)),
                      [True, True])
 
+        # Check that casting fails if the casting rule should fail on
+        # any of the fields
         assert_raises(TypeError, a.astype, [('a', '>i8'), ('b', '<f4')],
                       casting='safe')
         assert_raises(TypeError, a.astype, [('a', '>i2'), ('b', '<f8')],

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -729,11 +729,41 @@ class TestStructured(TestCase):
         b = np.array([(5, 43), (10, 1)], dtype=[('a', '<i8'), ('b', '>f8')])
         assert_equal(a == b, [False, True])
 
-    def test_cast_with_swap(self):
+    def test_casting(self):
         a = np.array([(1,)], dtype=[('a', '<i4')])
         b = a.astype([('a', '>i4')])
         assert_equal(b, a.byteswap().newbyteorder())
         assert_equal(a['a'][0], b['a'][0])
+
+        a = np.array([(5, 42), (10, 1)], dtype=[('a', '>i4'), ('b', '<f8')])
+        b = np.array([(42, 5), (1, 10)], dtype=[('b', '>f8'), ('a', '<i4')])
+
+        assert_equal(a == b, [True, True])
+
+        c = a.astype(b.dtype, casting='equiv')
+        assert_equal(a == c, [True, True])
+
+        t = [('a', '<i8'), ('b', '>f8')]
+        c = a.astype(t, casting='safe')
+        assert_equal((c == np.array([(5, 42), (10, 1)], dtype=t)),
+                     [True, True])
+
+        t = [('a', '<i4'), ('b', '>f4')]
+        c = a.astype(t, casting='same_kind')
+        assert_equal((c == np.array([(5, 42), (10, 1)], dtype=t)),
+                     [True, True])
+
+        with self.assertRaises(TypeError):
+            a.astype([('a', '>i8'), ('b', '<f4')], casting='safe')
+
+        with self.assertRaises(TypeError):
+            a.astype([('a', '>i2'), ('b', '<f8')], casting='equiv')
+
+        with self.assertRaises(TypeError):
+            a.astype([('a', '>i8'), ('b', '<i2')], casting='same_kind')
+
+        with self.assertRaises(TypeError):
+            a.astype(b.dtype, casting='no')
 
 
 class TestBool(TestCase):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -737,7 +737,6 @@ class TestStructured(TestCase):
 
         a = np.array([(5, 42), (10, 1)], dtype=[('a', '>i4'), ('b', '<f8')])
         b = np.array([(42, 5), (1, 10)], dtype=[('b', '>f8'), ('a', '<i4')])
-
         assert_equal(a == b, [True, True])
 
         c = a.astype(b.dtype, casting='equiv')
@@ -755,13 +754,10 @@ class TestStructured(TestCase):
 
         assert_raises(TypeError, a.astype, [('a', '>i8'), ('b', '<f4')],
                       casting='safe')
-
         assert_raises(TypeError, a.astype, [('a', '>i2'), ('b', '<f8')],
                       casting='equiv')
-
         assert_raises(TypeError, a.astype, [('a', '>i8'), ('b', '<i2')],
                       casting='same_kind')
-
         assert_raises(TypeError, a.astype, b.dtype, casting='no')
 
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -326,6 +326,10 @@ class TestDtypedescr(TestCase):
         d2 = dtype('f8')
         assert_equal(d2, dtype(float64))
 
+    def test_byteorders(self):
+        self.assertNotEqual(dtype('<i4'), dtype('>i4'))
+        self.assertNotEqual(dtype([('a', '<i4')]), dtype([('a', '>i4')]))
+
 class TestZeroRank(TestCase):
     def setUp(self):
         self.d = array(0), array('x', object)
@@ -724,6 +728,12 @@ class TestStructured(TestCase):
         a = np.array([(5, 42), (10, 1)], dtype=[('a', '>i8'), ('b', '<f8')])
         b = np.array([(5, 43), (10, 1)], dtype=[('a', '<i8'), ('b', '>f8')])
         assert_equal(a == b, [False, True])
+
+    def test_cast_with_swap(self):
+        a = np.array([(1,)], dtype=[('a', '<i4')])
+        b = a.astype([('a', '>i4')])
+        assert_equal(b, a.byteswap().newbyteorder())
+        assert_equal(a['a'][0], b['a'][0])
 
 
 class TestBool(TestCase):


### PR DESCRIPTION
The offending commit is c53b0e4, which introduced two regressions:
- using `astype` to cast a structured array to one with a different byte order no longer works;
- comparing structured-array dtypes can give incorrect results if the two dtypes have different byte orders.

This pull request should fix both.

One thing I wasn't sure about is reordering struct fields.  In my implementation, the `equiv`, `same_kind`, and `safe` rules are now allowed to reorder fields.  If that isn't desired, though, it's a pretty easy change.
