### PR TITLE
ENH: add BagObj.__dir__ to numpy.lib.npyio

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -122,6 +122,14 @@ class BagObj(object):
             return object.__getattribute__(self, '_obj')[key]
         except KeyError:
             raise AttributeError(key)
+    
+    def __dir__(self):
+        """
+        Enables dir(bagobj) to list the files in an NpzFile.
+        
+        This also enables tab-completion in an interpreter or IPython.
+        """
+        return object.__getattribute__(self, '_obj').keys()
 
 
 def zipfile_factory(*args, **kwargs):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -216,6 +216,17 @@ class TestSavezLoad(RoundtripTest, TestCase):
         l = np.load(c)
         assert_equal(a, l['file_a'])
         assert_equal(b, l['file_b'])
+    
+    def test_BagObj(self):
+        a = np.array([[1, 2], [3, 4]], float)
+        b = np.array([[1 + 2j, 2 + 7j], [3 - 6j, 4 + 12j]], complex)
+        c = BytesIO()
+        np.savez(c, file_a=a, file_b=b)
+        c.seek(0)
+        l = np.load(c)
+        assert_equal(sorted(dir(l.f)), ['file_a','file_b'])
+        assert_equal(a, l.f.file_a)
+        assert_equal(b, l.f.file_b)
 
     def test_savez_filename_clashes(self):
         # Test that issue #852 is fixed


### PR DESCRIPTION
This allows dir(bagobj), and also enables tab-completion on a BagObj, which can be useful in an interpreter or IPython:

``` python
>>> dat = np.load('mydata.npz')
>>> dir(dat.f)
[]                 # Before this PR
['a', 'b']         # After this PR
>>> dat.f. ⇥ ⇥     # TAB TAB to see completions
                   # blank before this PR
dat.f.a  dat.f.b   # after this PR 
```

This PR has two commits: one makes the change above, the other adds a test of `BagObj`. This test tests both the main functionality of BagObj (`BagObj.__getattribute__` was not previously tested according to `runtests.py --coverage`), as well as testing this enhancement.

Also, this is my first PR to numpy, so please feel free to give me any helpful advice you'd like!
