### PR TITLE
DOC: iterator: don't bother users with NumPy development details

### DIFF
--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -18,8 +18,6 @@ preservation of memory layouts, and buffering of data with the wrong
 alignment or type, without requiring difficult coding.
 
 This page documents the API for the iterator.
-The C-API naming convention chosen is based on the one in the numpy-refactor
-branch, so will integrate naturally into the refactored code base.
 The iterator is named ``NpyIter`` and functions are
 named ``NpyIter_*``.
 


### PR DESCRIPTION
This removes all mentions of the "numpy-refactor branch" from the PyIter docs. I don't know what that is (it's apparently not a branch in the GitHub repo) and I don't want to know either. This NumPy development detail is distracting from the actual API docs.
