### PR TITLE
Expand np.resize docstring

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1088,6 +1088,9 @@ def resize(a, new_shape):
     Examples
     --------
     >>> a=np.array([[0,1],[2,3]])
+    >>> np.resize(a,(2,3))
+    array([[0, 1, 2],
+           [3, 0, 1]])
     >>> np.resize(a,(1,4))
     array([[0, 1, 2, 3]])
     >>> np.resize(a,(2,4))


### PR DESCRIPTION
Show an example that explains the potentially confusing behaviour of resize (repetitition of data not along the dimensions but along the internal memory representation)
