### PR TITLE
Fixed meshgrid to return arrays with same dtype as arguments.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3463,7 +3463,7 @@ def meshgrid(*xi, **kwargs):
 
     if not sparse and len(output) > 0:
         # Return the full N-D matrix (not only the 1-D vector)
-        output = np.broadcast_arrays(*output)
+        output = np.broadcast_arrays(*output, subok=True)
 
     return output
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3458,18 +3458,14 @@ def meshgrid(*xi, **kwargs):
         output[1].shape = (-1, 1) + (1,)*(ndim - 2)
         shape[0], shape[1] = shape[1], shape[0]
 
-    if sparse:
-        if copy_:
-            return [x.copy() for x in output]
-        else:
-            return output
-    else:
+    if copy_:
+        output = [x.copy() for x in output]
+
+    if not sparse and len(output) > 0:
         # Return the full N-D matrix (not only the 1-D vector)
-        if copy_:
-            mult_fact = np.ones(shape, dtype=int)
-            return [x * mult_fact for x in output]
-        else:
-            return np.broadcast_arrays(*output)
+        output = np.broadcast_arrays(*output)
+
+    return output
 
 
 def delete(arr, obj, axis=None):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1462,6 +1462,7 @@ class TestMeshgrid(TestCase):
     def test_no_input(self):
         args = []
         assert_array_equal([], meshgrid(*args))
+        assert_array_equal([], meshgrid(*args, copy=False))
 
     def test_indexing(self):
         x = [1, 2, 3]
@@ -1494,6 +1495,30 @@ class TestMeshgrid(TestCase):
         # https://github.com/numpy/numpy/issues/4755
         assert_raises(TypeError, meshgrid,
                       [1, 2, 3], [4, 5, 6, 7], indices='ij')
+
+    def test_return_type(self):
+        # Test for appropriate dtype in returned arrays.
+        # Regression test for issue #5297
+        # https://github.com/numpy/numpy/issues/5297
+        x = np.arange(0, 10, dtype=np.float32)
+        y = np.arange(10, 20, dtype=np.float64)
+
+        X, Y = np.meshgrid(x,y)
+
+        assert_(X.dtype == x.dtype)
+        assert_(Y.dtype == y.dtype)
+
+        # copy
+        X, Y = np.meshgrid(x,y, copy=True)
+
+        assert_(X.dtype == x.dtype)
+        assert_(Y.dtype == y.dtype)
+
+        # sparse
+        X, Y = np.meshgrid(x,y, sparse=True)
+
+        assert_(X.dtype == x.dtype)
+        assert_(Y.dtype == y.dtype)
 
 
 class TestPiecewise(TestCase):


### PR DESCRIPTION
Fixes issue with meshgrid discussed in issue #5297.

A few things to note:
- meshgrid takes multiple arrays as arguments and returns multiple arrays.  With this proposed change the dtype of each returned array will have the same dtype as its corresponding argument.  An alternative would have been to use the common dtype returned by np.return_type but this didn't seem to make as much sense to me.
- I added a test case to verify that the dtypes of the returned arrays match the arguments.
- I added a test case to test_no_input because this test case would have failed before my patch if `copy=False` had been set.
