### PR TITLE
fix 1.9 alignment issues

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -764,6 +764,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'ucsnarrow.h'),
             join('src', 'multiarray', 'usertypes.h'),
             join('src', 'multiarray', 'vdot.h'),
+            join('src', 'private', 'npy_config.h'),
             join('src', 'private', 'templ_common.h.src'),
             join('src', 'private', 'lowlevel_strided_loops.h'),
             join('include', 'numpy', 'arrayobject.h'),

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -684,7 +684,16 @@ _IsAligned(PyArrayObject *ap)
 
     /* alignment 1 types should have a efficient alignment for copy loops */
     if (PyArray_ISFLEXIBLE(ap) || PyArray_ISSTRING(ap)) {
-        alignment = NPY_MAX_COPY_ALIGNMENT;
+        npy_intp itemsize = PyArray_ITEMSIZE(ap);
+        /* power of two sizes may be loaded in larger moves */
+        if (((itemsize & (itemsize - 1)) == 0)) {
+            alignment = itemsize > NPY_MAX_COPY_ALIGNMENT ?
+                NPY_MAX_COPY_ALIGNMENT : itemsize;
+        }
+        else {
+            /* if not power of two it will be accessed bytewise */
+            alignment = 1;
+        }
     }
 
     if (alignment == 1) {

--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "numpy/numpyconfig.h"
+#include "numpy/npy_cpu.h"
 
 /* Disable broken MS math functions */
 #if defined(_MSC_VER) || defined(__MINGW32_VERSION)
@@ -19,7 +20,11 @@
  * amd64 is not harmed much by the bloat as the system provides 16 byte
  * alignment by default.
  */
+#if (defined NPY_CPU_X86 || defined _WIN32)
+#define NPY_MAX_COPY_ALIGNMENT 8
+#else
 #define NPY_MAX_COPY_ALIGNMENT 16
+#endif
 
 /* Disable broken Sun Workshop Pro math functions */
 #ifdef __SUNPRO_C

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -68,6 +68,17 @@ class TestFlags(TestCase):
         assert_equal(self.a.flags.aligned, True)
         assert_equal(self.a.flags.updateifcopy, False)
 
+    def test_string_align(self):
+        a = np.zeros(4, dtype=np.dtype('|S4'))
+        assert_(a.flags.aligned)
+        # not power of two are accessed bytewise and thus considered aligned
+        a = np.zeros(5, dtype=np.dtype('|S4'))
+        assert_(a.flags.aligned)
+
+    def test_void_align(self):
+        a = np.zeros(4, dtype=np.dtype([("a", "i4"), ("b", "i4")]))
+        assert_(a.flags.aligned)
+
 class TestHash(TestCase):
     # see #3793
     def test_int(self):


### PR DESCRIPTION
reduce maximum required alignment to 8 bytes on 32 bit but no sparc and fix alignment flag of string arrays, see commit messages for details
