### PR TITLE
BUG: Bug fix for Issue #5315

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -33,21 +33,25 @@ class GnuFCompiler(FCompiler):
     compiler_aliases = ('g77',)
     description = 'GNU Fortran 77 compiler'
 
-    def _vstring_paren_strip(self, vstring):
-        '''A private function for removing potentially nested parentheses from
-        a string.'''
+    def _vstring_paren_strip(self, s):
+        '''Remove potentially nested parentheses from the start of a string.
+        
+        This function accepts a string that starts with '(' and removes the
+        (potentially nested) opening parenthetical statement. The truncated
+        string is returned.'''
         # Number of left parenthesis
-        lparen = 1
+        cnt = 1
         # Run through the string until the closing bracket is found.
-        for index in range(1, len(vstring)):
-            if vstring[index] == '(':
-                lparen += 1
-            elif vstring[index] == ')':
-                lparen -= 1
-                if lparen == 0:
-                    string_no_paren = vstring[index+1:]
-                    break
-        return string_no_paren
+        for index in range(1, len(s)):
+            if s[index] == '(':
+                cnt += 1
+            elif s[index] == ')':
+                cnt -= 1
+                if cnt == 0:
+                    return s[index+1:]
+
+        raise ValueError('The following string contains unclosed ' +
+                'parentheses: \n' + s)
 
     def gnu_version_match(self, version_string):
         """Handle the different versions of GNU fortran compilers"""
@@ -96,8 +100,8 @@ class GnuFCompiler(FCompiler):
             else:
                 return ('gfortran', v)
         
-        # If it gets this far without a return, then there is something wrong with
-        # the version string. Throw an error to make it clear.
+        # If it gets this far without a return, then there is something wrong
+        # with the version string. Throw an error to make it clear.
         raise ValueError("Fortran version not found in the following string:\n" +
             version_string)
 

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -33,24 +33,74 @@ class GnuFCompiler(FCompiler):
     compiler_aliases = ('g77',)
     description = 'GNU Fortran 77 compiler'
 
+    def _vstring_paren_strip(self, vstring):
+        '''A private function for removing potentially nested parentheses from
+        a string.'''
+        # Number of left parenthesis
+        lparen = 1
+        # Run through the string until the closing bracket is found.
+        for index in range(1, len(vstring)):
+            if vstring[index] == '(':
+                lparen += 1
+            elif vstring[index] == ')':
+                lparen -= 1
+                if lparen == 0:
+                    string_no_paren = vstring[index+1:]
+                    break
+        return string_no_paren
+
     def gnu_version_match(self, version_string):
         """Handle the different versions of GNU fortran compilers"""
-        m = re.search(r'GNU Fortran', version_string)
-        if not m:
+        if "GNU Fortran" not in version_string:
             return None
-        m = re.search(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
-        if m:
-            return ('gfortran', m.group(1))
-        m = re.search(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)
+        
+        # Drop the preamble.
+        string_no_gnu = re.sub(r'GNU Fortran\s+', '', version_string) 
+        # This is the compiled version search regex
+        match_comp = re.compile(r'([0-9-.]+)')
+        
+        # When '95' comes directly after the preample that implies 'gfortran'
+        if string_no_gnu.startswith('95'):
+            # Get rid of 95 and spaces
+            string_no_95 = re.sub(r'95\s+', '', string_no_gnu)
+            # If the first character is '(', then we need to do some extra checks.
+            if string_no_95.startswith('('):
+                # Check if 'GCC #.#.#' is in this string.
+                m = re.search(r'GCC\s+([0-9-.]+)', string_no_95)
+                # If not, drop the section in parenteses
+                if not m:
+                    short_no_95 = self._vstring_paren_strip(string_no_95)
+                    m = match_comp.search(short_no_95)
+            # Just do a regular search if no parentheses
+            else:
+                m = match_comp.search(string_no_95)
+            v = m.group(1)
+            return ('gfortran', v)
+        
+        # If the first character after the preamble is '(', that suggests a gcc 
+        # built with --with-pkgversion=*some_string*. Remove characters in
+        # potentially nested parentheses.
+        elif string_no_gnu.startswith('('):
+            # Remove the stuff in (nested) parentheses and run match
+            string_no_paren = self._vstring_paren_strip(string_no_gnu)
+            m = match_comp.search(string_no_paren)
+        else:
+            # If isn't a starting parenthesis, check the string as usual
+            m = match_comp.search(string_no_gnu)
+            
         if m:
             v = m.group(1)
-            if v.startswith('0') or v.startswith('2') or v.startswith('3'):
-                # the '0' is for early g77's
+            # startswith can take a tuple only with >= Py2.5. Ok?
+            if v.startswith(('0', '2', '3',)):
                 return ('g77', v)
             else:
-                # at some point in the 4.x series, the ' 95' was dropped
-                # from the version string
                 return ('gfortran', v)
+        
+        # If it gets this far without a return, then there is something wrong with
+        # the version string. Throw an error to make it clear.
+        raise ValueError("Fortran version not found in the following string:\n" +
+            version_string)
+
 
     def version_match(self, version_string):
         v = self.gnu_version_match(version_string)

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -102,8 +102,19 @@ class GnuFCompiler(FCompiler):
         
         # If it gets this far without a return, then there is something wrong
         # with the version string. Throw an error to make it clear.
-        raise ValueError("Fortran version not found in the following string:\n" +
-            version_string)
+        with tempfile.NamedTemporaryFile(suffix='.for', mode='w') as tmp:        
+            tmp.write("[__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__]\n")
+            tmp.flush()
+            try:
+                p = Popen(['gfortran', '-cpp', '-E', tmp.name], 
+                        stdout=PIPE, universal_newlines=True)
+                stdout, _ = p.communicate()
+                version_list = eval(stdout)
+                version_join = '.'.join(version_list)
+                return ('gfortran', v)
+            except:
+                print("Fortran version not found in the following string:")
+                print(version_string)
 
 
     def version_match(self, version_string):

--- a/numpy/distutils/tests/test_fcompiler_gnu.py
+++ b/numpy/distutils/tests/test_fcompiler_gnu.py
@@ -20,6 +20,8 @@ gfortran_version_strings = [
     ('GNU Fortran 95 (GCC) 4.2.0 20060218 (experimental)', '4.2.0'),
     ('GNU Fortran (GCC) 4.3.0 20070316 (experimental)', '4.3.0'),
     ('GNU Fortran (rubenvb-4.8.0) 4.8.0', '4.8.0'),
+    ('GNU Fortran (AB2) 4.8.3', '4.8.3'),
+    ('GNU Fortran 95 (Just in case 4.1.7) 4.3.2', '4.3.2'),
 ]
 
 class TestG77Versions(TestCase):


### PR DESCRIPTION
Added new logic to the fortran compiler version check to handle cases where
gcc is built with "--with-pkgversion=_some_string_, where _some_string_
contains numbers that might be incorrectly interpreted as a gcc version.

This includes some additional tests. All tests run successfully on Linux
Python version 2.7.8 and 3.4.2.
