### PR TITLE
Let apply_along_axis work with more function return types: Issue/2582

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -94,7 +94,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     if not asscalar:
         try:
             len(res)
-        except TypeError:
+        except (TypeError, AttributeError):
             asscalar = True
     if asscalar:
         outarr = zeros(outshape, asarray(res).dtype)

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -90,7 +90,13 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     i.put(indlist, ind)
     res = func1d(arr[tuple(i.tolist())], *args, **kwargs)
     #  if res is a number, then we have a smaller output array
-    if isscalar(res):
+    asscalar = isscalar(res)
+    if not asscalar:
+        try:
+            len(res)
+        except TypeError:
+            asscalar = True
+    if asscalar:
         outarr = zeros(outshape, asarray(res).dtype)
         outarr[tuple(ind)] = res
         Ntot = product(outshape)

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -27,6 +27,16 @@ class TestApplyAlongAxis(TestCase):
         assert_array_equal(apply_along_axis(np.sum, 0, a),
                            [[27, 30, 33], [36, 39, 42], [45, 48, 51]])
 
+    def test_function_returning_array(self):
+        a = np.ones(4)
+        assert_array_equal(apply_along_axis(np.sqrt, 0, a), [1, 1, 1, 1])
+
+    def test_function_returning_non_scalar(self):
+        def return_none(x):
+            pass
+        a = np.ones(4)
+        assert_array_equal(apply_along_axis(return_none, 0, a), [None, None, None, None])
+
 
 class TestApplyOverAxes(TestCase):
     def test_simple(self):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -37,6 +37,14 @@ class TestApplyAlongAxis(TestCase):
         a = np.ones(4)
         assert_array_equal(apply_along_axis(return_none, 0, a), [None, None, None, None])
 
+    def test_return_object(self):
+        class NotAScalar():
+            def __eq__(this, other):
+                return isinstance(other, NotAScalar)
+        a = np.arange(27).reshape((3, 3, 3))
+        assert_array_equal(apply_along_axis(lambda x: NotAScalar(), 0, a),
+                           np.full((3, 3), NotAScalar(), np.object))
+
 
 class TestApplyOverAxes(TestCase):
     def test_simple(self):

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -349,7 +349,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     if not asscalar:
         try:
             len(res)
-        except TypeError:
+        except (TypeError, AttributeError):
             asscalar = True
     # Note: we shouldn't set the dtype of the output from the first result...
     #...so we force the type to object, and build a list of dtypes


### PR DESCRIPTION
Fixed issue #2582. If the function passed into the apply_along_axis function returned anything other than a "scalar" or "array-like object" then it would throw an exception that len method did not exist.
