### PR TITLE
BUG: fix collections.Hashable behaviour for numpy arrays.

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1769,7 +1769,7 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     &array_as_number,                           /* tp_as_number */
     &array_as_sequence,                         /* tp_as_sequence */
     &array_as_mapping,                          /* tp_as_mapping */
-    (hashfunc)0,                                /* tp_hash */
+    PyObject_HashNotImplemented,                /* tp_hash */
     (ternaryfunc)0,                             /* tp_call */
     (reprfunc)array_str,                        /* tp_str */
     (getattrofunc)0,                            /* tp_getattro */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import collections
 import tempfile
 import sys
 import os
@@ -4846,6 +4847,13 @@ class TestSizeOf(TestCase):
     def test_error(self):
         d = np.ones(100)
         assert_raises(TypeError, d.__sizeof__, "a")
+
+
+class TestHashing(TestCase):
+
+    def test_collections_hashable(self):
+        x = np.array([])
+        self.assertFalse(isinstance(x, collections.Hashable))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While `hash(a)` raises an exception as expected for an array `a`, `a.__hash__()` does not, and `isinstance(a, collections.IsHashable)` returns True.

This fixes the issuew/ one trivial test.
