### PR TITLE
BLD: Change Fortran version flag and string check

### DIFF
--- a/numpy/distutils/tests/test_fcompiler_gnu.py
+++ b/numpy/distutils/tests/test_fcompiler_gnu.py
@@ -14,12 +14,8 @@ g77_version_strings = [
 ]
 
 gfortran_version_strings = [
-    ('GNU Fortran 95 (GCC 4.0.3 20051023 (prerelease) (Debian 4.0.2-3))',
-     '4.0.3'),
-    ('GNU Fortran 95 (GCC) 4.1.0', '4.1.0'),
-    ('GNU Fortran 95 (GCC) 4.2.0 20060218 (experimental)', '4.2.0'),
-    ('GNU Fortran (GCC) 4.3.0 20070316 (experimental)', '4.3.0'),
-    ('GNU Fortran (rubenvb-4.8.0) 4.8.0', '4.8.0'),
+    ('4.8.0', '4.8.0'),
+    ('4.0.3-7', '4.0.3'),
 ]
 
 class TestG77Versions(TestCase):


### PR DESCRIPTION
The version check flag for GnuFCompiler and Gnu95FCompiler were changed from
`--version` to `-dumpversion`. This simplifies the gnu_version_match code for
gfortran, and makes it possible to drop much of the check code for g77 as
well. This fix addresses issue #5315 and #5321.
