### PR TITLE
BUG: Rename fft C functions to avoid name conflict

### DIFF
--- a/numpy/fft/fftpack.c
+++ b/numpy/fft/fftpack.c
@@ -8,6 +8,9 @@ Algorithmically based on Fortran-77 FFTPACK by Paul N. Swarztrauber (Version 4, 
 
 #include <math.h>
 #include <stdio.h>
+#include <Python.h>
+#include <numpy/ndarraytypes.h>
+
 #define DOUBLE
 
 #ifdef DOUBLE
@@ -29,7 +32,7 @@ extern "C" {
 
 /* ----------------------------------------------------------------------
    passf2, passf3, passf4, passf5, passf. Complex FFT passes fwd and bwd.
----------------------------------------------------------------------- */
+----------------------------------------------------------------------- */
 
 static void passf2(int ido, int l1, const Treal cc[], Treal ch[], const Treal wa1[], int isign)
   /* isign==+1 for backward transform */
@@ -1142,9 +1145,9 @@ static void radbg(int ido, int ip, int l1, int idl1,
     }
   } /* radbg */
 
-  /* ----------------------------------------------------------------------
-cfftf1, cfftf, cfftb, cffti1, cffti. Complex FFTs.
----------------------------------------------------------------------- */
+  /* ------------------------------------------------------------
+cfftf1, npy_cfftf, npy_cfftb, cffti1, npy_cffti. Complex FFTs.
+--------------------------------------------------------------- */
 
 static void cfftf1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifac[MAXFAC+2], int isign)
   {
@@ -1204,24 +1207,24 @@ static void cfftf1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifa
   } /* cfftf1 */
 
 
-void cfftf(int n, Treal c[], Treal wsave[])
+NPY_VISIBILITY_HIDDEN void npy_cfftf(int n, Treal c[], Treal wsave[])
   {
     int iw1, iw2;
     if (n == 1) return;
     iw1 = 2*n;
     iw2 = iw1 + 2*n;
     cfftf1(n, c, wsave, wsave+iw1, (int*)(wsave+iw2), -1);
-  } /* cfftf */
+  } /* npy_cfftf */
 
 
-void cfftb(int n, Treal c[], Treal wsave[])
+NPY_VISIBILITY_HIDDEN void npy_cfftb(int n, Treal c[], Treal wsave[])
   {
     int iw1, iw2;
     if (n == 1) return;
     iw1 = 2*n;
     iw2 = iw1 + 2*n;
     cfftf1(n, c, wsave, wsave+iw1, (int*)(wsave+iw2), +1);
-  } /* cfftb */
+  } /* npy_cfftb */
 
 
 static void factorize(int n, int ifac[MAXFAC+2], const int ntryh[NSPECIAL])
@@ -1304,17 +1307,17 @@ static void cffti1(int n, Treal wa[], int ifac[MAXFAC+2])
   } /* cffti1 */
 
 
-void cffti(int n, Treal wsave[])
+NPY_VISIBILITY_HIDDEN void npy_cffti(int n, Treal wsave[])
  {
     int iw1, iw2;
     if (n == 1) return;
     iw1 = 2*n;
     iw2 = iw1 + 2*n;
     cffti1(n, wsave+iw1, (int*)(wsave+iw2));
-  } /* cffti */
+  } /* npy_cffti */
 
-  /* ----------------------------------------------------------------------
-rfftf1, rfftb1, rfftf, rfftb, rffti1, rffti. Treal FFTs.
+  /* -------------------------------------------------------------------
+rfftf1, rfftb1, npy_rfftf, npy_rfftb, rffti1, npy_rffti. Treal FFTs.
 ---------------------------------------------------------------------- */
 
 static void rfftf1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifac[MAXFAC+2])
@@ -1378,7 +1381,7 @@ static void rfftf1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifa
   } /* rfftf1 */
 
 
-void rfftb1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifac[MAXFAC+2])
+static void rfftb1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifac[MAXFAC+2])
   {
     int i;
     int k1, l1, l2, na, nf, ip, iw, ix2, ix3, ix4, ido, idl1;
@@ -1434,18 +1437,18 @@ void rfftb1(int n, Treal c[], Treal ch[], const Treal wa[], const int ifac[MAXFA
   } /* rfftb1 */
 
 
-void rfftf(int n, Treal r[], Treal wsave[])
+NPY_VISIBILITY_HIDDEN void npy_rfftf(int n, Treal r[], Treal wsave[])
   {
     if (n == 1) return;
     rfftf1(n, r, wsave, wsave+n, (int*)(wsave+2*n));
-  } /* rfftf */
+  } /* npy_rfftf */
 
 
-void rfftb(int n, Treal r[], Treal wsave[])
+NPY_VISIBILITY_HIDDEN void npy_rfftb(int n, Treal r[], Treal wsave[])
   {
     if (n == 1) return;
     rfftb1(n, r, wsave, wsave+n, (int*)(wsave+2*n));
-  } /* rfftb */
+  } /* npy_rfftb */
 
 
 static void rffti1(int n, Treal wa[], int ifac[MAXFAC+2])
@@ -1490,11 +1493,11 @@ static void rffti1(int n, Treal wa[], int ifac[MAXFAC+2])
   } /* rffti1 */
 
 
-void rffti(int n, Treal wsave[])
+NPY_VISIBILITY_HIDDEN void npy_rffti(int n, Treal wsave[])
   {
     if (n == 1) return;
     rffti1(n, wsave+n, (int*)(wsave+2*n));
-  } /* rffti */
+  } /* npy_rffti */
 
 #ifdef __cplusplus
 }

--- a/numpy/fft/fftpack.h
+++ b/numpy/fft/fftpack.h
@@ -15,13 +15,13 @@ extern "C" {
 #define Treal float
 #endif
 
-extern void cfftf(int N, Treal data[], const Treal wrk[]);
-extern void cfftb(int N, Treal data[], const Treal wrk[]);
-extern void cffti(int N, Treal wrk[]);
+extern NPY_VISIBILITY_HIDDEN void npy_cfftf(int N, Treal data[], const Treal wrk[]);
+extern NPY_VISIBILITY_HIDDEN void npy_cfftb(int N, Treal data[], const Treal wrk[]);
+extern NPY_VISIBILITY_HIDDEN void npy_cffti(int N, Treal wrk[]);
 
-extern void rfftf(int N, Treal data[], const Treal wrk[]);
-extern void rfftb(int N, Treal data[], const Treal wrk[]);
-extern void rffti(int N, Treal wrk[]);
+extern NPY_VISIBILITY_HIDDEN void npy_rfftf(int N, Treal data[], const Treal wrk[]);
+extern NPY_VISIBILITY_HIDDEN void npy_rfftb(int N, Treal data[], const Treal wrk[]);
+extern NPY_VISIBILITY_HIDDEN void npy_rffti(int N, Treal wrk[]);
 
 #ifdef __cplusplus
 }

--- a/numpy/fft/fftpack_litemodule.c
+++ b/numpy/fft/fftpack_litemodule.c
@@ -1,8 +1,8 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include "fftpack.h"
 #include "Python.h"
 #include "numpy/arrayobject.h"
+#include "fftpack.h"
 
 static PyObject *ErrorObject;
 
@@ -45,7 +45,7 @@ fftpack_cfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     Py_BEGIN_ALLOW_THREADS;
     NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
-        cfftf(npts, dptr, wsave);
+        npy_cfftf(npts, dptr, wsave);
         dptr += npts*2;
     }
     NPY_SIGINT_OFF;
@@ -98,7 +98,7 @@ fftpack_cfftb(PyObject *NPY_UNUSED(self), PyObject *args)
     Py_BEGIN_ALLOW_THREADS;
     NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
-        cfftb(npts, dptr, wsave);
+        npy_cfftb(npts, dptr, wsave);
         dptr += npts*2;
     }
     NPY_SIGINT_OFF;
@@ -124,7 +124,7 @@ fftpack_cffti(PyObject *NPY_UNUSED(self), PyObject *args)
     if (!PyArg_ParseTuple(args, "l", &n)) {
         return NULL;
     }
-    /*Magic size needed by cffti*/
+    /*Magic size needed by npy_cffti*/
     dim = 4*n + 15;
     /*Create a 1 dimensional array of dimensions of type double*/
     op = (PyArrayObject *)PyArray_SimpleNew(1, &dim, NPY_DOUBLE);
@@ -134,7 +134,7 @@ fftpack_cffti(PyObject *NPY_UNUSED(self), PyObject *args)
 
     Py_BEGIN_ALLOW_THREADS;
     NPY_SIGINT_ON;
-    cffti(n, (double *)PyArray_DATA((PyArrayObject*)op));
+    npy_cffti(n, (double *)PyArray_DATA((PyArrayObject*)op));
     NPY_SIGINT_OFF;
     Py_END_ALLOW_THREADS;
 
@@ -189,7 +189,7 @@ fftpack_rfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     NPY_SIGINT_ON;
     for (i = 0; i < nrepeats; i++) {
         memcpy((char *)(rptr+1), dptr, npts*sizeof(double));
-        rfftf(npts, rptr+1, wsave);
+        npy_rfftf(npts, rptr+1, wsave);
         rptr[0] = rptr[1];
         rptr[1] = 0.0;
         rptr += rstep;
@@ -253,7 +253,7 @@ fftpack_rfftb(PyObject *NPY_UNUSED(self), PyObject *args)
     for (i = 0; i < nrepeats; i++) {
         memcpy((char *)(rptr + 1), (dptr + 2), (npts - 1)*sizeof(double));
         rptr[0] = dptr[0];
-        rfftb(npts, rptr, wsave);
+        npy_rfftb(npts, rptr, wsave);
         rptr += npts;
         dptr += npts*2;
     }
@@ -282,7 +282,7 @@ fftpack_rffti(PyObject *NPY_UNUSED(self), PyObject *args)
   if (!PyArg_ParseTuple(args, "l", &n)) {
       return NULL;
   }
-  /*Magic size needed by rffti*/
+  /*Magic size needed by npy_rffti*/
   dim = 2*n + 15;
   /*Create a 1 dimensional array of dimensions of type double*/
   op = (PyArrayObject *)PyArray_SimpleNew(1, &dim, NPY_DOUBLE);
@@ -291,7 +291,7 @@ fftpack_rffti(PyObject *NPY_UNUSED(self), PyObject *args)
   }
   Py_BEGIN_ALLOW_THREADS;
   NPY_SIGINT_ON;
-  rffti(n, (double *)PyArray_DATA((PyArrayObject*)op));
+  npy_rffti(n, (double *)PyArray_DATA((PyArrayObject*)op));
   NPY_SIGINT_OFF;
   Py_END_ALLOW_THREADS;
 


### PR DESCRIPTION
Resolves issue #565. The fft functions defined in fftpack.c have name
conflicts on certain systems. Because these functions are not exposed, the
prefix "npy_" was added to these functions.

Build and tests pass using both Python 2.7.8 and Python 3.4.2.
