### PR TITLE
ENH: Make fromiter() accept iterators of sequences

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3579,7 +3579,9 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     elcount[0] = (count < 0) ? 0 : count;
     if (PySequence_Check(value) && (dtype->fields == Py_None)) {
         elcount[1] = PySequence_Length(value);
-        if (elcount[1] < 1) elcount[1] = 1;
+        if (elcount[1] < 1) {
+            elcount[1] = 1;
+        }
     }
     else {
         elcount[1] = 1;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3573,6 +3573,9 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         goto done;
     }
     value = PyIter_Next(iter);
+    if (PyErr_Occurred()) {
+        goto done;
+    }
     elcount[0] = (count < 0) ? 0 : count;
     if (PySequence_Check(value) && (dtype->fields == Py_None)) {
         elcount[1] = PySequence_Length(value);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3648,28 +3648,29 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                     if (!PyErr_Occurred()) {
                         PyErr_SetString(PyExc_ValueError, "sequence too short");
                     }
+                    Py_DECREF(iter2);
                     Py_DECREF(value);
                     goto done;
                 }
                 if (PyArray_DESCR(ret)->f->setitem(value2, item, ret) == -1) {
                     Py_DECREF(value2);
-                    Py_DECREF(value);
                     Py_DECREF(iter2);
+                    Py_DECREF(value);
                     goto done;
                 }
             }
             value2 = PyIter_Next(iter2);
             if (value2 == NULL) {
                 if (PyErr_Occurred()) {
-                    Py_DECREF(value);
                     Py_DECREF(iter2);
+                    Py_DECREF(value);
                     goto done;
                 }
             } else {
                 PyErr_SetString(PyExc_ValueError, "sequence too long");
                 Py_DECREF(value2);
-                Py_DECREF(value);
                 Py_DECREF(iter2);
+                Py_DECREF(value);
                 goto done;
             }
             Py_DECREF(iter2);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3641,10 +3641,12 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                 item = PyArray_GETPTR2(ret, i, j);
                 value2 = PyIter_Next(iter2);
                 if (PyArray_DESCR(ret)->f->setitem(value2, item, ret) == -1) {
+                    Py_DECREF(value2);
                     Py_DECREF(value);
                     goto done;
                 }
             }
+            Py_DECREF(iter2);
         }
         Py_DECREF(value);
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3645,7 +3645,9 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                 item = PyArray_GETPTR2(ret, i, j);
                 value2 = PyIter_Next(iter2);
                 if (value2 == NULL) {
-                    PyErr_SetString(PyExc_ValueError, "sequence too short");
+                    if (!PyErr_Occurred()) {
+                        PyErr_SetString(PyExc_ValueError, "sequence too short");
+                    }
                     Py_DECREF(value);
                     goto done;
                 }
@@ -3657,7 +3659,13 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                 }
             }
             value2 = PyIter_Next(iter2);
-            if (value2 != NULL) {
+            if (value2 == NULL) {
+                if (PyErr_Occurred()) {
+                    Py_DECREF(value);
+                    Py_DECREF(iter2);
+                    goto done;
+                }
+            } else {
                 PyErr_SetString(PyExc_ValueError, "sequence too long");
                 Py_DECREF(value2);
                 Py_DECREF(value);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3597,6 +3597,10 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         goto done;
     }
 
+    /*
+     * We would need to alter the memory RENEW code to decrement any
+     * reference counts before throwing away any memory.
+     */
     if (PyDataType_REFCHK(dtype)) {
         PyErr_SetString(PyExc_ValueError,
                 "cannot create object arrays from iterator");

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3580,12 +3580,14 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     if (PySequence_Check(value) && (dtype->fields == Py_None)) {
         elcount[1] = PySequence_Length(value);
         if (elcount[1] < 1) elcount[1] = 1;
-    } else {
+    }
+    else {
         elcount[1] = 1;
     }
     if (elcount[1] == 1) {
         ndim = 1;
-    } else {
+    }
+    else {
         ndim = 2;
     }
 
@@ -3638,7 +3640,8 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                 Py_DECREF(value);
                 goto done;
             }
-        } else {
+        }
+        else {
             iter2 = PyObject_GetIter(value);
             if (iter2 == NULL) {
                 Py_DECREF(value);
@@ -3669,7 +3672,8 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                     Py_DECREF(value);
                     goto done;
                 }
-            } else {
+            }
+            else {
                 PyErr_SetString(PyExc_ValueError, "sequence too long");
                 Py_DECREF(value2);
                 Py_DECREF(iter2);

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -903,8 +903,7 @@ class TestFromiter(TestCase):
     def test_sequences_of_sequences_improper(self):
         s = [[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
                           [4, 2, 9], [5, 2, 10]]
-        expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
-                          [4, 2, 9], [5, 2, 10]], dtype=int)
+        expected = array(s, dtype=int)
         self.assertTrue(alltrue(fromiter(s, dtype=int) == expected))
 
         s = [[0, 0, 5], [1, 0], [2, 1, 7], [3, 1, 8],

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -922,6 +922,13 @@ class TestFromiter(TestCase):
                     [4, 2, 9], [5, 2, 10]]
         self.assertRaises(TypeError, fromiter, s, dtype=int)
 
+        s = [[], [], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]]
+        self.assertRaises(ValueError, fromiter, s, dtype=int)
+
+        s = [[], [], []]
+        self.assertRaises(ValueError, fromiter, s, dtype=int)
+
     def load_data_2d(self, n, eindex):
         # Raise an exception at the desired index in the iterator of sequences.
         for e in range(n):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -888,6 +888,18 @@ class TestFromiter(TestCase):
         self.assertRaises(NIterError, np.fromiter,
                           self.load_data(count, eindex), dtype=int, count=count)
 
+    def test_sequences(self):
+        a = fromiter(([x, x // 2, x+5] for x in range(6)), dtype=int)
+        expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]], dtype=int)
+        self.assertTrue(alltrue(a == expected))
+
+        a = fromiter(([x, x // 2, x+5, x+1] for x in range(6)), dtype=int)
+        expected = array([[0, 0, 5, 1], [1, 0, 6, 2], [2, 1, 7, 3],
+                    [3, 1, 8, 4], [4, 2, 9, 5], [5, 2, 10,  6]], dtype=int)
+        self.assertTrue(alltrue(a == expected))
+
+
 
 class TestNonzero(TestCase):
     def test_nonzero_trivial(self):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -888,7 +888,7 @@ class TestFromiter(TestCase):
         self.assertRaises(NIterError, np.fromiter,
                           self.load_data(count, eindex), dtype=int, count=count)
 
-    def test_sequences(self):
+    def test_sequences_of_sequences(self):
         a = fromiter(([x, x // 2, x+5] for x in range(6)), dtype=int)
         expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
                           [4, 2, 9], [5, 2, 10]], dtype=int)
@@ -900,7 +900,7 @@ class TestFromiter(TestCase):
                           dtype=int)
         self.assertTrue(alltrue(a == expected))
 
-    def test_sequences_improper(self):
+    def test_sequences_of_sequences_improper(self):
         s = [[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
                           [4, 2, 9], [5, 2, 10]]
         expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -891,39 +891,40 @@ class TestFromiter(TestCase):
     def test_sequences(self):
         a = fromiter(([x, x // 2, x+5] for x in range(6)), dtype=int)
         expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]], dtype=int)
+                          [4, 2, 9], [5, 2, 10]], dtype=int)
         self.assertTrue(alltrue(a == expected))
 
         a = fromiter(([x, x // 2, x+5, x+1] for x in range(6)), dtype=int)
         expected = array([[0, 0, 5, 1], [1, 0, 6, 2], [2, 1, 7, 3],
-                    [3, 1, 8, 4], [4, 2, 9, 5], [5, 2, 10,  6]], dtype=int)
+                          [3, 1, 8, 4], [4, 2, 9, 5], [5, 2, 10,  6]],
+                          dtype=int)
         self.assertTrue(alltrue(a == expected))
 
     def test_sequences_improper(self):
         s = [[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]]
+                          [4, 2, 9], [5, 2, 10]]
         expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]], dtype=int)
+                          [4, 2, 9], [5, 2, 10]], dtype=int)
         self.assertTrue(alltrue(fromiter(s, dtype=int) == expected))
 
         s = [[0, 0, 5], [1, 0], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]]
+                          [4, 2, 9], [5, 2, 10]]
         self.assertRaises(ValueError, fromiter, s, dtype=int)
 
         s = [[0, 0, 5], [1, 0, 6, 7], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]]
+                          [4, 2, 9], [5, 2, 10]]
         self.assertRaises(ValueError, fromiter, s, dtype=int)
 
         s = [[0, 0, 5], [], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]]
+                          [4, 2, 9], [5, 2, 10]]
         self.assertRaises(ValueError, fromiter, s, dtype=int)
 
         s = [[0, 0, 5], 5, [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]]
+                          [4, 2, 9], [5, 2, 10]]
         self.assertRaises(TypeError, fromiter, s, dtype=int)
 
         s = [[], [], [2, 1, 7], [3, 1, 8],
-                    [4, 2, 9], [5, 2, 10]]
+                          [4, 2, 9], [5, 2, 10]]
         self.assertRaises(ValueError, fromiter, s, dtype=int)
 
         s = [[], [], []]

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -899,6 +899,29 @@ class TestFromiter(TestCase):
                     [3, 1, 8, 4], [4, 2, 9, 5], [5, 2, 10,  6]], dtype=int)
         self.assertTrue(alltrue(a == expected))
 
+    def test_sequences_improper(self):
+        s = [[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]]
+        expected = array([[0, 0, 5], [1, 0, 6], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]], dtype=int)
+        self.assertTrue(alltrue(fromiter(s, dtype=int) == expected))
+
+        s = [[0, 0, 5], [1, 0], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]]
+        self.assertRaises(ValueError, fromiter, s, dtype=int)
+
+        s = [[0, 0, 5], [1, 0, 6, 7], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]]
+        self.assertRaises(ValueError, fromiter, s, dtype=int)
+
+        s = [[0, 0, 5], [], [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]]
+        self.assertRaises(ValueError, fromiter, s, dtype=int)
+
+        s = [[0, 0, 5], 5, [2, 1, 7], [3, 1, 8],
+                    [4, 2, 9], [5, 2, 10]]
+        self.assertRaises(TypeError, fromiter, s, dtype=int)
+
 
 
 class TestNonzero(TestCase):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -922,6 +922,50 @@ class TestFromiter(TestCase):
                     [4, 2, 9], [5, 2, 10]]
         self.assertRaises(TypeError, fromiter, s, dtype=int)
 
+    def load_data_2d(self, n, eindex):
+        # Raise an exception at the desired index in the iterator of sequences.
+        for e in range(n):
+            if e == eindex:
+                raise NIterError('error at index %s' % eindex)
+            yield [1, 2, 3]
+
+    def test_iterator_sequences_exception1(self):
+        count, eindex = 10, 0
+        self.assertRaises(NIterError, np.fromiter,
+                          self.load_data_2d(count, eindex), dtype=int)
+
+        count, eindex = 10, 5
+        self.assertRaises(NIterError, np.fromiter,
+                          self.load_data_2d(count, eindex), dtype=int)
+
+    def test_iterator_sequences_exception2(self):
+        # User exception in the iterator
+        s = [[1, 4, 5], self.load_data(3, 0)]
+        self.assertRaises(NIterError, np.fromiter, s, dtype=int)
+
+        # User exception in the iterator
+        s = [[1, 4, 5], self.load_data(3, 1)]
+        self.assertRaises(NIterError, np.fromiter, s, dtype=int)
+
+        # User exception in the iterator
+        s = [[1, 4, 5], self.load_data(3, 2)]
+        self.assertRaises(NIterError, np.fromiter, s, dtype=int)
+
+        s = [[1, 4, 5], self.load_data(3, 3)]
+        expected = array([[1, 4, 5], [0, 1, 2]], dtype=int)
+        self.assertTrue(alltrue(fromiter(s, dtype=int) == expected))
+
+        # User exception in the iterator
+        s = [[1, 4, 5], self.load_data(4, 3)]
+        self.assertRaises(NIterError, np.fromiter, s, dtype=int)
+
+        s = [[1, 4, 5], self.load_data(4, 3), [1, 2, 3]]
+        self.assertRaises(NIterError, np.fromiter, s, dtype=int)
+
+        # Sequence is too long
+        s = [[1, 4, 5], self.load_data(4, 4)]
+        self.assertRaises(ValueError, np.fromiter, s, dtype=int)
+
 
 
 class TestNonzero(TestCase):


### PR DESCRIPTION
Tests were added.

Fixes #4791.

The example from http://mail.scipy.org/pipermail/numpy-discussion/2006-November/024747.html now works:

```
>>> from numpy import fromiter
>>> fromiter(([x, x // 2, x+5] for x in range(1000)), dtype=int)
array([[   0,    0,    5],
       [   1,    0,    6],
       [   2,    1,    7],
       ..., 
       [ 997,  498, 1002],
       [ 998,  499, 1003],
       [ 999,  499, 1004]])
>>> _.shape
(1000, 3)
```

TODO:
- [x] Go very carefully over the whole patch and make sure there are no memory leaks
- [x] Add tests for corner cases, when the sequence lengths are not all the same in the iterator (it should raise an exception)
