### PR TITLE
BUG: digitize segfaults on TypeError

### DIFF
--- a/numpy/lib/src/_compiled_base.c
+++ b/numpy/lib/src/_compiled_base.c
@@ -295,8 +295,8 @@ arr_digitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     }
 
     fail:
-        Py_DECREF(arr_x);
-        Py_DECREF(arr_bins);
+        Py_XDECREF(arr_x);
+        Py_XDECREF(arr_bins);
         return ret;
 }
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -861,6 +861,13 @@ class TestDigitize(TestCase):
         bins = [1, 1, 0, 1]
         assert_raises(ValueError, digitize, x, bins)
 
+    def test_casting_error(self):
+        x = [1, 2, 3+1.j]
+        bins = [1, 2, 3]
+        assert_raises(TypeError, digitize, x, bins)
+        x, bins = bins, x
+        assert_raises(TypeError, digitize, x, bins)
+
 
 class TestUnwrap(TestCase):
     def test_simple(self):


### PR DESCRIPTION
The new searchsorted-based digitize introduced in #5101 segfaults
when it should raise a TypeError.

Should be backported to 1.9.x.
