### PR TITLE
ENH: Improve arg handling & enhance test suite for `np.pad`

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -73,6 +73,12 @@ given period and one end point is added to each extremity of *xp* in order to
 close the previous and the next period cycles, resulting in the correct
 interpolation behavior.
 
+*np.pad* supports more input types for ``pad_width`` and ``constant_values``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``constant_values`` parameters now accepts NumPy arrays and float values.
+NumPy arrays are supported as input for ``pad_width``, and an exception is
+raised if its values are not of integral type.
+
 
 Changes
 =======


### PR DESCRIPTION
This PR supersedes #4113, including changes from @ahojnnes and further improvements. Briefly, this consists of major increases to test coverage and enhancements allowing ndarrays as arguments to `pad_width`, `constant_values`, or `end_values`. Also, floating point inputs are now handled properly for `constant_values` and `end_values`.
- Argument handling improved
- Complicated logic in the hidden function `_normalize_shape` replaced
  - New version operates internally on NumPy arrays instead of attempting to do type and shape checking on nested iterables.
  - Overall structure easier to follow
  - Comments added for maintainability
  - Import of `numbers` and `long` from `np.compat` no longer required
- Test suite greatly improved, now 100% coverage
- Removed nonfunctional lines from final `'reflect'` loop - artifacts _someone_ forgot to take out after developing this thing...
- PEP8 fixes
- Docstring clarifications in hidden functions.

The concern raised by @charris in #4113 has been addressed, and tests added to ensure this behavior is maintained. The output array dtype always preserves the dtype of the array _to be padded_, including at all intermediate steps. Accomplishing this in an elegant manner required the re-write of `_normalize_shape`.
