### PR TITLE
BUG: tighten alignment for complex types.

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4138,8 +4138,8 @@ NPY_NO_EXPORT PyArray_Descr @from@_Descr = {
     /* elsize */
     @num@ * sizeof(@fromtype@),
     /* alignment */
-    @num@ * _ALIGN(@fromtype@) > NPY_MAX_COPY_ALIGNMENT ?
-        NPY_MAX_COPY_ALIGNMENT : @num@ * _ALIGN(@fromtype@),
+    _ALIGN(@fromtype@) > NPY_MAX_COPY_ALIGNMENT ?
+        NPY_MAX_COPY_ALIGNMENT : _ALIGN(@fromtype@),
     /* subarray */
     NULL,
     /* fields */


### PR DESCRIPTION
Complex types memory representations in C for a given `type` are guaranteed to be equivalent to `type[2]`. As such, the alignment of `complex<type>` should be the same as `type`.

I tested scipy 0.14.x (at scipy/scipy@d6c32069f1379b3517eee8511e323607c246c66c, containing the f2py workaround) in the following setups:
##### numpy 1.9.1, w/ this patch
- one genuine error (all platforms). Unlikely to be related to numpy.

```
[192.168.33.13] out: ======================================================================
[192.168.33.13] out: ERROR: test_antiderivative_of_constant (test_interpolate.TestPPoly)
[192.168.33.13] out: ----------------------------------------------------------------------
[192.168.33.13] out: Traceback (most recent call last):
[192.168.33.13] out:   File "/home/vagrant/src/master-env/lib/python2.7/site-packages/scipy/interpolate/tests/test_interpolate.py", line 659, in test_antiderivative_of_constant
[192.168.33.13] out:     assert_equal(p.antiderivative().c, PPoly([[1], [0]], [0, 1]).c)
[192.168.33.13] out:   File "/home/vagrant/src/master-env/lib/python2.7/site-packages/scipy/interpolate/interpolate.py", line 821, in antiderivative
[192.168.33.13] out:     self.x, nu)
[192.168.33.13] out:   File "_ppoly.pyx", line 142, in scipy.interpolate._ppoly.fix_continuity (scipy/interpolate/_ppoly.c:5462)
[192.168.33.13] out: ValueError: order too large
```
- a few minor precision issues that have been here for a while otherwise.
##### numpy 1.9.1, w/o this patch
- Same results as above for rh5 and osx and windows 64 bits, but a dozen new errors for windows 32 bits:

```
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_and_y_stride (test_fblas.TestZaxpy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 85, in test_x_and_y_stride
[172.17.5.102] err:     assert_array_almost_equal(real_y,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([  0.+0.j,  12.+0.j,  24.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_stride (test_fblas.TestZaxpy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 71, in test_x_stride
[172.17.5.102] err:     assert_array_almost_equal(real_y,y)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([  0.+0.j,   7.+0.j,  14.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_y_stride (test_fblas.TestZaxpy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 78, in test_y_stride
[172.17.5.102] err:     assert_array_almost_equal(real_y,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  3.+0.j,  6.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_and_y_stride (test_fblas.TestZcopy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 219, in test_x_and_y_stride
[172.17.5.102] err:     assert_array_almost_equal(x[::4],y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  4.+0.j,  8.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_y_stride (test_fblas.TestZcopy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 213, in test_y_stride
[172.17.5.102] err:     assert_array_almost_equal(x,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_simple (test_fblas.TestZscal)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 145, in test_simple
[172.17.5.102] err:     assert_array_almost_equal(real_x,x)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  3.+0.j,  6.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_simple (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 288, in test_simple
[172.17.5.102] err:     assert_array_almost_equal(desired_x,x)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_and_y_stride (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 315, in test_x_and_y_stride
[172.17.5.102] err:     assert_array_almost_equal(desired_x,x[::4])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  4.+0.j,  8.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_stride (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 297, in test_x_stride
[172.17.5.102] err:     assert_array_almost_equal(desired_x,x[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  2.+0.j,  4.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_y_stride (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\lib\blas\tests\test_fblas.py", line 307, in test_y_stride
[172.17.5.102] err:     assert_array_almost_equal(desired_y,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
[172.17.5.102] err:     precision=decimal)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not almost equal to 6 decimals
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_and_y_stride (test_fblas.TestZaxpy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 87, in test_x_and_y_stride
[172.17.5.102] err:     assert_array_equal(real_y,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([  0.+0.j,  12.+0.j,  24.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_y_stride (test_fblas.TestZaxpy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 80, in test_y_stride
[172.17.5.102] err:     assert_array_equal(real_y,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  3.+0.j,  6.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_and_y_stride (test_fblas.TestZcopy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 219, in test_x_and_y_stride
[172.17.5.102] err:     assert_array_equal(x[::4],y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  4.+0.j,  8.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_y_stride (test_fblas.TestZcopy)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 213, in test_y_stride
[172.17.5.102] err:     assert_array_equal(x,y[::2])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_simple (test_fblas.TestZscal)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 146, in test_simple
[172.17.5.102] err:     assert_array_equal(real_x,x)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  3.+0.j,  6.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_simple (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 287, in test_simple
[172.17.5.102] err:     assert_array_equal(desired_x,x)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_and_y_stride (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 314, in test_x_and_y_stride
[172.17.5.102] err:     assert_array_equal(desired_x,x[::4])
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  4.+0.j,  8.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_x_stride (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 297, in test_x_stride
[172.17.5.102] err:     assert_array_equal(desired_y,y)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  2.+0.j,  4.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err: 
[172.17.5.102] err: ======================================================================
[172.17.5.102] err: FAIL: test_y_stride (test_fblas.TestZswap)
[172.17.5.102] err: ----------------------------------------------------------------------
[172.17.5.102] err: Traceback (most recent call last):
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\scipy\linalg\tests\test_fblas.py", line 305, in test_y_stride
[172.17.5.102] err:     assert_array_equal(desired_x,x)
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 739, in assert_array_equal
[172.17.5.102] err:     verbose=verbose, header='Arrays are not equal')
[172.17.5.102] err:   File "C:\Users\vagrant\src\master-env\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
[172.17.5.102] err:     raise AssertionError(msg)
[172.17.5.102] err: AssertionError:
[172.17.5.102] err: Arrays are not equal
[172.17.5.102] err: 
[172.17.5.102] err: (mismatch 66.6666666667%)
[172.17.5.102] err:  x: array([ 0.+0.j,  0.+0.j,  0.+0.j])
[172.17.5.102] err:  y: array([ 0.+0.j,  1.+0.j,  2.+0.j])
[172.17.5.102] err: 

```
