### PR TITLE
ENH: add np.broadcast_to and reimplement np.broadcast_arrays

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -94,6 +94,12 @@ number of rows read in a single call. Using this functionality, it is
 possible to read in multiple arrays stored in a single file by making
 repeated calls to the function.
 
+New function *np.broadcast_to* for invoking array broadcasting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*np.broadcast_to* manually broadcasts an array to a given shape according to
+numpy's broadcasting rules. The functionality is similar to broadcast_arrays,
+which in fact has been rewritten to use broadcast_to internally, but only a
+single array is necessary.
 
 Improvements
 ============

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -40,6 +40,7 @@ Changing number of dimensions
    atleast_2d
    atleast_3d
    broadcast
+   broadcast_to
    broadcast_arrays
    expand_dims
    squeeze

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -9,7 +9,8 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 
-__all__ = ['broadcast_arrays']
+__all__ = ['broadcast_to', 'broadcast_arrays']
+
 
 class DummyArray(object):
     """Dummy object that just exists to hang __array_interface__ dictionaries
@@ -19,6 +20,20 @@ class DummyArray(object):
     def __init__(self, interface, base=None):
         self.__array_interface__ = interface
         self.base = base
+
+
+def _maybe_view_as_subclass(original_array, new_array):
+    if type(original_array) is not type(new_array):
+        # if input was an ndarray subclass and subclasses were OK,
+        # then view the result as that subclass.
+        new_array = new_array.view(type=type(original_array))
+        # Since we have done something akin to a view from original_array, we
+        # should let the subclass finalize (if it has it implemented, i.e., is
+        # not None).
+        if new_array.__array_finalize__:
+            new_array.__array_finalize__(original_array)
+    return new_array
+
 
 def as_strided(x, shape=None, strides=None, subok=False):
     """ Make an ndarray from the given array with the given shape and strides.
@@ -34,15 +49,80 @@ def as_strided(x, shape=None, strides=None, subok=False):
     # Make sure dtype is correct in case of custom dtype
     if array.dtype.kind == 'V':
         array.dtype = x.dtype
-    if type(x) is not type(array):
-        # if input was an ndarray subclass and subclasses were OK,
-        # then view the result as that subclass.
-        array = array.view(type=type(x))
-        # Since we have done something akin to a view from x, we should let
-        # the subclass finalize (if it has it implemented, i.e., is not None).
-        if array.__array_finalize__:
-            array.__array_finalize__(x)
-    return array
+    return _maybe_view_as_subclass(x, array)
+
+
+def _broadcast_to(array, shape, subok, readonly):
+    shape = tuple(shape) if np.iterable(shape) else (shape,)
+    array = np.array(array, copy=False, subok=subok)
+    if not shape and array.shape:
+        raise ValueError('cannot broadcast a non-scalar to a scalar array')
+    if any(size < 0 for size in shape):
+        raise ValueError('all elements of broadcast shape must be non-'
+                         'negative')
+    broadcast = np.nditer((array,), flags=['multi_index', 'zerosize_ok'],
+                          op_flags=['readonly'], itershape=shape, order='C'
+                          ).itviews[0]
+    result = _maybe_view_as_subclass(array, broadcast)
+    if not readonly and array.flags.writeable:
+        result.flags.writeable = True
+    return result
+
+
+def broadcast_to(array, shape, subok=False):
+    """Broadcast an array to a new shape.
+
+    Parameters
+    ----------
+    array : array_like
+        The array to broadcast.
+    shape : tuple
+        The shape of the desired array.
+    subok : bool, optional
+        If True, then sub-classes will be passed-through, otherwise
+        the returned array will be forced to be a base-class array (default).
+
+    Returns
+    -------
+    broadcast : array
+        A readonly view on the original array with the given shape. It is
+        typically not contiguous. Furthermore, more than one element of a
+        broadcasted array may refer to a single memory location.
+
+    Raises
+    ------
+    ValueError
+        If the array is not compatible with the new shape according to NumPy's
+        broadcasting rules.
+
+    Examples
+    --------
+    >>> x = np.array([1, 2, 3])
+    >>> np.broadcast_to(x, (3, 3))
+    array([[1, 2, 3],
+           [1, 2, 3],
+           [1, 2, 3]])
+    """
+    return _broadcast_to(array, shape, subok=subok, readonly=True)
+
+
+def _broadcast_shape(*args):
+    """Returns the shape of the ararys that would result from broadcasting the
+    supplied arrays against each other.
+    """
+    if not args:
+        raise ValueError('must provide at least one argument')
+    if len(args) == 1:
+        # a single argument does not work with np.broadcast
+        return np.asarray(args[0]).shape
+    # use the old-iterator because np.nditer does not handle size 0 arrays
+    # consistently
+    b = np.broadcast(*args[:32])
+    # unfortunately, it cannot handle 32 or more arguments directly
+    for pos in range(32, len(args), 31):
+        b = np.broadcast(b, *args[pos:(pos + 31)])
+    return b.shape
+
 
 def broadcast_arrays(*args, **kwargs):
     """
@@ -87,55 +167,24 @@ def broadcast_arrays(*args, **kwargs):
            [3, 3, 3]])]
 
     """
+    # nditer is not used here to avoid the limit of 32 arrays.
+    # Otherwise, something like the following one-liner would suffice:
+    # return np.nditer(args, flags=['multi_index', 'zerosize_ok'],
+    #                  order='C').itviews
+
     subok = kwargs.pop('subok', False)
     if kwargs:
         raise TypeError('broadcast_arrays() got an unexpected keyword '
                         'argument {}'.format(kwargs.pop()))
     args = [np.array(_m, copy=False, subok=subok) for _m in args]
-    shapes = [x.shape for x in args]
-    if len(set(shapes)) == 1:
+
+    shape = _broadcast_shape(*args)
+
+    if all(array.shape == shape for array in args):
         # Common case where nothing needs to be broadcasted.
         return args
-    shapes = [list(s) for s in shapes]
-    strides = [list(x.strides) for x in args]
-    nds = [len(s) for s in shapes]
-    biggest = max(nds)
-    # Go through each array and prepend dimensions of length 1 to each of
-    # the shapes in order to make the number of dimensions equal.
-    for i in range(len(args)):
-        diff = biggest - nds[i]
-        if diff > 0:
-            shapes[i] = [1] * diff + shapes[i]
-            strides[i] = [0] * diff + strides[i]
-    # Chech each dimension for compatibility. A dimension length of 1 is
-    # accepted as compatible with any other length.
-    common_shape = []
-    for axis in range(biggest):
-        lengths = [s[axis] for s in shapes]
-        unique = set(lengths + [1])
-        if len(unique) > 2:
-            # There must be at least two non-1 lengths for this axis.
-            raise ValueError("shape mismatch: two or more arrays have "
-                "incompatible dimensions on axis %r." % (axis,))
-        elif len(unique) == 2:
-            # There is exactly one non-1 length. The common shape will take
-            # this value.
-            unique.remove(1)
-            new_length = unique.pop()
-            common_shape.append(new_length)
-            # For each array, if this axis is being broadcasted from a
-            # length of 1, then set its stride to 0 so that it repeats its
-            # data.
-            for i in range(len(args)):
-                if shapes[i][axis] == 1:
-                    shapes[i][axis] = new_length
-                    strides[i][axis] = 0
-        else:
-            # Every array has a length of 1 on this axis. Strides can be
-            # left alone as nothing is broadcasted.
-            common_shape.append(1)
 
-    # Construct the new arrays.
-    broadcasted = [as_strided(x, shape=sh, strides=st, subok=subok)
-                   for (x, sh, st) in zip(args, shapes, strides)]
-    return broadcasted
+    # TODO: consider making the results of broadcast_arrays readonly to match
+    # broadcast_to. This will require a deprecation cycle.
+    return [_broadcast_to(array, shape, subok=subok, readonly=False)
+            for array in args]


### PR DESCRIPTION
Per the [mailing list discussion](http://mail.scipy.org/pipermail/numpy-discussion/2014-December/071796.html), I have implemented a new function `broadcast_to` that broadcasts an array to a given shape according to numpy's broadcasting rules.

The new array iterator has functionality that could make several of these functions into _almost_ one liners (thank you @jaimefrio, @seberg and @mwiebe for showing how), although we do have to do some extra work to preserve subclasses.

The first commit (eventually to be squashed away) shows how I would implement these _without_ relying heavily on `nditer`. It also includes the `broadcast_shape` function (no longer necessary for the implementation of `broadcast_arrays`), which almost but didn't quite work as a one-liner (it failed for size 0 arrays). We could revive it if others think it would serve a useful purpose.

Question: should we allow for broadcasting with negative numbers in the shape? This seems strange but it does work (sort of like reshape) with the current implementation and I suppose someone could find it useful. On the other hand, numbers less than -1 are also supported, which may just be a bug with nditer?

```
In [1]: import numpy as np

In [2]: x = np.array([1, 2, 3])

# possibly useful
In [3]: np.broadcast_to(x, (-1, -1))
Out[3]: array([[1, 2, 3]])

# probably not useful
In [4]: np.broadcast_to(x, (-10,))
Out[4]: array([1, 2, 3])
```

(I did not yet add tests for the behavior with negative sizes.)
