### PR TITLE
Fixed incorrect documentation

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1331,7 +1331,7 @@ def assert_array_almost_equal_nulp(x, y, nulp=1):
     -----
     An assertion is raised if the following condition is not met::
 
-        abs(x - y) <= nulps * spacing(max(abs(x), abs(y)))
+        abs(x - y) <= nulps * spacing(maximum(abs(x), abs(y)))
 
     Examples
     --------


### PR DESCRIPTION
The `max()` function previously mentioned in the code does not work with two array-like. `maximum()` does, and is what is essentially used in the code (`ref = nulp * np.spacing(np.where(ax > ay, ax, ay))`).
