### PR TITLE
Fixed incorrect docstring

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1331,7 +1331,7 @@ def assert_array_almost_equal_nulp(x, y, nulp=1):
     -----
     An assertion is raised if the following condition is not met::
 
-        abs(x - y) <= nulps * spacing(max(abs(x), abs(y)))
+        abs(x - y) <= nulps * spacing(maximum(abs(x), abs(y)))
 
     Examples
     --------


### PR DESCRIPTION
`max()` does not work with two arrays. The documentation intended to write `maximum()`, which does work, and also represent what the code does (through `np.where()`).
