### PR TITLE
BUG: Xerbla doesn't get linked in 1.10-devel.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -178,12 +178,14 @@ else:
     test = Tester().test
     bench = Tester().bench
 
+    # linalg needs to be imported first so our xerbla get linked.
+    # We should maybe make it a standlone module.
+    from . import linalg
     from . import core
     from .core import *
     from . import compat
     from . import lib
     from .lib import *
-    from . import linalg
     from . import fft
     from . import polynomial
     from . import random

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1108,6 +1108,8 @@ def test_xerbla_override():
     # and may, or may not, abort the process depending on the LAPACK package.
     from nose import SkipTest
 
+    XERBLA_OK = 255
+
     try:
         pid = os.fork()
     except (OSError, AttributeError):
@@ -1137,15 +1139,16 @@ def test_xerbla_override():
                 a, a, 0, 0)
         except ValueError as e:
             if "DORGQR parameter number 5" in str(e):
-                # success
-                os._exit(os.EX_OK)
+                # success, reuse error code to mark success as
+                # FORTRAN STOP returns as success.
+                os._exit(XERBLA_OK)
 
         # Did not abort, but our xerbla was not linked in.
         os._exit(os.EX_CONFIG)
     else:
         # parent
         pid, status = os.wait()
-        if os.WEXITSTATUS(status) != os.EX_OK or os.WIFSIGNALED(status):
+        if os.WEXITSTATUS(status) != XERBLA_OK:
             raise SkipTest('Numpy xerbla not linked in.')
 
 


### PR DESCRIPTION
The linalg module needs to be imported first so that our xerbla gets
linked before any other module links to ATLAS or one of the other
optimized linear algebra packages.

Also make the test for xerbla linkage work correctly. If xerbla is not
linked the test will be skipped with a message.

Closes #5362.
