### PR TITLE
BUG: Issue 5354 - Fixed segmentation fault when clipping complex arrays

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3598,8 +3598,6 @@ static void
     npy_intp i;
     @type@ max_val, min_val;
 
-    min_val = *min;
-    max_val = *max;
     if (max != NULL) {
         max_val = *max;
     }

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1176,6 +1176,18 @@ class TestClip(TestCase):
         act = self.clip(a, m, M)
         assert_array_strict_equal(ac, act)
 
+    def test_clip_complex(self):
+        # Address Issue gh-5354 for clipping complex arrays
+        # Test native complex input without explicit min/max
+        # ie, either min=None or max=None
+        a = np.ones(10, dtype=np.complex)
+        m = a.min()
+        M = a.max()
+        am = self.fastclip(a, m, None)
+        aM = self.fastclip(a, None, M)
+        assert_array_strict_equal(am, a)
+        assert_array_strict_equal(aM, a)
+
     def test_clip_non_contig(self):
         #Test clip for non contiguous native input and native scalar min/max.
         a   = self._generate_data(self.nr * 2, self.nc * 3)


### PR DESCRIPTION
BUG:An attempt to fix Issue #5354 .
The NULL dereference before checking whether the pointer is a NULL pointer is causing a segmentation fault. I am not sure whether the output coming now is the right one. Please do clarify anything else is wrong except the segmentation fault.

F_min
(-256+0j)
F.clip(F_min)
array([[ 8.29056000e+06 +0.j , 2.56000000e+02+358.28772462j,
-2.56000000e+02 +0.j , ...,
2.56000000e+02+861.73946261j, -2.56000000e+02 +0.j ,
2.56000000e+02-358.28772462j],
[ 0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j , ...,
0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j ],
[ 0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j , ...,
0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j ],
..., 
[ 0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j , ...,
0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j ],
[ 0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j , ...,
0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j ],
[ 0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j , ...,
0.00000000e+00 +0.j , 0.00000000e+00 +0.j ,
0.00000000e+00 +0.j ]])
