### PR TITLE
BLD: PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def get_version_info():
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        FULLVERSION += '.dev-' + GIT_REVISION[:7]
+        FULLVERSION += '.dev+' + GIT_REVISION[:7]
 
     return FULLVERSION, GIT_REVISION
 


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0440/
See https://github.com/pypa/pip/issues/2256.

This is just a proof of concept, I'm not seriously expecting this to be merged.  SciPy version names have the same issue.
