### PR TITLE
Remove NotImplementedError for MinGW-w64

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -335,7 +335,7 @@ class Gnu95FCompiler(GnuFCompiler):
                 if c_compiler and c_compiler.compiler_type == "msvc":
                     return []
                 else:
-                    raise NotImplementedError("Only MS compiler supported with gfortran on win64")
+                    pass
         return opt
 
     def get_target(self):


### PR DESCRIPTION
See #3405 for discussion about this issue.

Some (me, @mwtoews) have successfully built Fortran extensions using the MinGW-w64 compiler. The block affected by this PR was written by @cournape in dfefe95, and perhaps the line `# XXX: fix this mess, does not work for mingw` is worth removing at this point too. 
