### PR TITLE
ENH: Make views produced by np.einsum writeable

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -105,6 +105,11 @@ be present in input arrays; core dimensions with the same label must have
 the exact same size; and output core dimension's must be specified, either
 by a same label input core dimension or by a passed-in output array.
 
+views returned from *np.einsum* are writeable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Views returned by *np.einsum* will now be writeable whenever the input
+array is writeable.
+
 
 Deprecations
 ============

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2063,6 +2063,14 @@ add_newdoc('numpy.core', 'einsum',
     ``einsum(op0, sublist0, op1, sublist1, ..., [sublistout])``. The examples
     below have corresponding `einsum` calls with the two parameter methods.
 
+    .. versionadded:: 1.10.0
+
+    Views returned from einsum are now writeable whenever the input array
+    is writeable. For example, ``np.einsum('ijk...->kji...', a)`` will now
+    have the same effect as ``np.swapaxes(a, 0, 2)`` and
+    ``np.einsum('ii->i', a)`` will return a writeable view of the diagonal
+    of a 2D array.
+
     Examples
     --------
     >>> a = np.arange(25).reshape(5,5)
@@ -2171,6 +2179,14 @@ add_newdoc('numpy.core', 'einsum',
     >>> np.einsum('k...,jk', a, b)
     array([[10, 28, 46, 64],
            [13, 40, 67, 94]])
+
+    >>> # since version 1.10.0
+    >>> a = np.zeros((3, 3))
+    >>> np.einsum('ii->i', a)[:] = 1
+    >>> a
+    array([[ 1.,  0.,  0.],
+           [ 0.,  1.,  0.],
+           [ 0.,  0.,  1.]])
 
     """)
 

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2158,7 +2158,8 @@ get_single_op_view(PyArrayObject *op, int  iop, char *labels,
                                 PyArray_DESCR(op),
                                 ndim_output, new_dims, new_strides,
                                 PyArray_DATA(op),
-                                0, (PyObject *)op);
+                                PyArray_ISWRITEABLE(op) ? NPY_ARRAY_WRITEABLE : 0,
+                                (PyObject *)op);
 
         if (*ret == NULL) {
             return 0;

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -91,6 +91,13 @@ class TestEinSum(TestCase):
         b = np.einsum(a, [0, 1])
         assert_(b.base is a)
         assert_equal(b, a)
+        
+        # output is writeable whenever input is writeable
+        b = np.einsum("...", a)
+        assert_(b.flags['WRITEABLE'])
+        a.flags['WRITEABLE'] = False
+        b = np.einsum("...", a)
+        assert_(not b.flags['WRITEABLE'])
 
         # transpose
         a = np.arange(6)


### PR DESCRIPTION
`einsum` can be useful for extracting a view of different diagonals of an array, but, currently, the views it returns are not writeable. This changes that.
