### PR TITLE
ENH: add np.nanprod

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -11,6 +11,7 @@ Highlights
 * Addition of *np.linalg.multi_dot*: compute the dot product of two or more
   arrays in a single function call, while automatically selecting the fastest
   evaluation order.
+* Addition of `nanprod` to the set of nanfunctions.
 
 
 Dropped Support

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -9,9 +9,12 @@ Functions
 - `nanargmin` -- index of minimum non-NaN value
 - `nanargmax` -- index of maximum non-NaN value
 - `nansum` -- sum of non-NaN values
+- `nanprod` -- product of non-NaN values
 - `nanmean` -- mean of non-NaN values
 - `nanvar` -- variance of non-NaN values
 - `nanstd` -- standard deviation of non-NaN values
+- `nanmedian` -- median of non-NaN values
+- `nanpercentile` -- qth percentile of non-NaN values
 
 """
 from __future__ import division, absolute_import, print_function
@@ -22,7 +25,7 @@ from numpy.lib.function_base import _ureduce as _ureduce
 
 __all__ = [
     'nansum', 'nanmax', 'nanmin', 'nanargmax', 'nanargmin', 'nanmean',
-    'nanmedian', 'nanpercentile', 'nanvar', 'nanstd'
+    'nanmedian', 'nanpercentile', 'nanvar', 'nanstd', 'nanprod',
     ]
 
 
@@ -510,6 +513,76 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=0):
     return np.sum(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
 
+def nanprod(a, axis=None, dtype=None, out=None, keepdims=0):
+    """
+    Return the product of array elements over a given axis treating Not a
+    Numbers (NaNs) as zero.
+
+    One is returned for slices that are all-NaN or empty.
+
+    .. versionadded:: 1.10.0
+
+    Parameters
+    ----------
+    a : array_like
+        Array containing numbers whose sum is desired. If `a` is not an
+        array, a conversion is attempted.
+    axis : int, optional
+        Axis along which the product is computed. The default is to compute
+        the product of the flattened array.
+    dtype : data-type, optional
+        The type of the returned array and of the accumulator in which the
+        elements are summed.  By default, the dtype of `a` is used.  An
+        exception is when `a` has an integer type with less precision than
+        the platform (u)intp. In that case, the default will be either
+        (u)int32 or (u)int64 depending on whether the platform is 32 or 64
+        bits. For inexact inputs, dtype must be inexact.
+    out : ndarray, optional
+        Alternate output array in which to place the result.  The default
+        is ``None``. If provided, it must have the same shape as the
+        expected output, but the type will be cast if necessary.  See
+        `doc.ufuncs` for details. The casting of NaN to integer can yield
+        unexpected results.
+    keepdims : bool, optional
+        If True, the axes which are reduced are left in the result as
+        dimensions with size one. With this option, the result will
+        broadcast correctly against the original `arr`.
+
+    Returns
+    -------
+    y : ndarray or numpy scalar
+
+    See Also
+    --------
+    numpy.prod : Product across array propagating NaNs.
+    isnan : Show which elements are NaN.
+
+    Notes
+    -----
+    Numpy integer arithmetic is modular. If the size of a product exceeds
+    the size of an integer accumulator, its value will wrap around and the
+    result will be incorrect. Specifying ``dtype=double`` can alleviate
+    that problem.
+
+    Examples
+    --------
+    >>> np.nanprod(1)
+    1
+    >>> np.nanprod([1])
+    1
+    >>> np.nanprod([1, np.nan])
+    1.0
+    >>> a = np.array([[1, 2], [3, np.nan]])
+    >>> np.nanprod(a)
+    6.0
+    >>> np.nanprod(a, axis=0)
+    array([ 3.,  2.])
+
+    """
+    a, mask = _replace_nan(a, 1)
+    return np.prod(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+
+
 def nanmean(a, axis=None, dtype=None, out=None, keepdims=False):
     """
     Compute the arithmetic mean along the specified axis, ignoring NaNs.
@@ -769,6 +842,8 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     ignoring nan values.
 
     Returns the qth percentile of the array elements.
+
+    .. versionadded:: 1.9.0
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adds an implementation of `nanprod`.

The actual function is a two-liner adapted from `nansum`. Most of this PR
consists of documentation and tests (for which I took the opportunity to do
some consolidation).

A method with the same functionality exists in pandas, and I was surprised to
discover that it's not in numpy.
