### PR TITLE
Special case matrix

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -41,11 +41,13 @@ NPY_RELAXED_STRIDE_CHECKING is now true by default.
 
 *np.ravel*, *np.diagonal* and *np.diag* now preserve subtypes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-There was inconsistent behavior between *x.ravel()* and *np.ravel(x)*, as well
-as between *x.diagonal()* and *np.diagonal(x)*.  For example, if *x* was a
-matrix, then *x.ravel()* returned a matrix, while *np.ravel(x)* returned an
-ndarray.  In the case of matrices, the returned value will have different
-dimensions and that may lead to problems in using the result.
+There was inconsistent behavior between *x.ravel()* and *np.ravel(x)*, as
+well as between *x.diagonal()* and *np.diagonal(x)*, with the methods
+preserving subtypes while the functions did not. This has been fixed and
+the functions now behave like the methods, preserving subtypes except in
+the case of matrices.  Matrices are special cased for backward
+compatibility and still return 1-D arrays as before. If you need to
+preserve the matrix subtype, use the methods instead of the functions.
 
 
 New Features

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -6,12 +6,14 @@ from __future__ import division, absolute_import, print_function
 import types
 import warnings
 
+import numpy as np
 from .. import VisibleDeprecationWarning
 from . import multiarray as mu
 from . import umath as um
 from . import numerictypes as nt
 from .numeric import asarray, array, asanyarray, concatenate
 from . import _methods
+
 
 _dt_ = nt.sctype2char
 
@@ -1199,9 +1201,9 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     just ignore all of the above.
 
     If you depend on the current behavior, then we suggest copying the
-    returned array explicitly, i.e., use ``np.diagonal(a).copy()`` instead of
-    just ``np.diagonal(a)``. This will work with both past and future versions
-    of NumPy.
+    returned array explicitly, i.e., use ``np.diagonal(a).copy()`` instead
+    of just ``np.diagonal(a)``. This will work with both past and future
+    versions of NumPy.
 
     Parameters
     ----------
@@ -1220,11 +1222,13 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     Returns
     -------
     array_of_diagonals : ndarray
-        If `a` is 2-D, a 1-D array of the same type as `a` containing the
-        diagonal is returned (or 2-D matrix for matrix input).
-        If the dimension of `a` is larger, then an array of diagonals is
-        returned, "packed" from left-most dimension to right-most (e.g.,
-        if `a` is 3-D, then the diagonals are "packed" along rows).
+        If `a` is 2-D and not a matrix, a 1-D array of the same type as `a`
+        containing the diagonal is returned. If `a` is a matrix, a 1-D
+        array containing the diagonal is returned in order to maintain
+        backward compatibility.  If the dimension of `a` is greater than
+        two, then an array of diagonals is returned, "packed" from
+        left-most dimension to right-most (e.g., if `a` is 3-D, then the
+        diagonals are "packed" along rows).
 
     Raises
     ------
@@ -1273,7 +1277,11 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
            [5, 7]])
 
     """
-    return asanyarray(a).diagonal(offset, axis1, axis2)
+    if isinstance(a, np.matrix):
+        # Make diagonal of matrix 1-D to preserve backward compatibility.
+        return asarray(a).diagonal(offset, axis1, axis2)
+    else:
+        return asanyarray(a).diagonal(offset, axis1, axis2)
 
 
 def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1376,8 +1376,10 @@ def ravel(a, order='C'):
     Returns
     -------
     y : array_like
-        Array of the same type as `a`, and of shape ``(a.size,)``
-        or ``(1, a.size)`` for matrices.
+        If `a` is a matrix, y is a 1-D ndarray, otherwise y is an array of
+        the same subtype as `a`. The shape of the returned array is
+        ``(a.size,)``. Matrices are special cased for backward
+        compatibility.
 
     See Also
     --------
@@ -1435,7 +1437,10 @@ def ravel(a, order='C'):
     array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11])
 
     """
-    return asanyarray(a).ravel(order)
+    if isinstance(a, np.matrix):
+        return asarray(a).ravel(order)
+    else:
+        return asanyarray(a).ravel(order)
 
 
 def nonzero(a):

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -5,7 +5,7 @@ from __future__ import division, absolute_import, print_function
 
 from numpy.core.numeric import (
     asanyarray, arange, zeros, greater_equal, multiply, ones, asarray,
-    where, int8, int16, int32, int64, empty, promote_types
+    where, int8, int16, int32, int64, empty, promote_types, diagonal,
     )
 from numpy.core import iinfo
 
@@ -307,7 +307,7 @@ def diag(v, k=0):
         res[:n-k].flat[i::n+1] = v
         return res
     elif len(s) == 2:
-        return v.diagonal(k)
+        return diagonal(v, k)
     else:
         raise ValueError("Input must be 1- or 2-d.")
 

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -409,7 +409,7 @@ class TestShape(TestCase):
 
     def test_numpy_ravel(self):
         assert_equal(np.ravel(self.a).shape, (2,))
-        assert_equal(np.ravel(self.m).shape, (1, 2))
+        assert_equal(np.ravel(self.m).shape, (2,))
 
     def test_member_ravel(self):
         assert_equal(self.a.ravel().shape, (2,))
@@ -426,10 +426,10 @@ class TestShape(TestCase):
         assert_equal(np.ravel(x.T), [1, 4, 2, 5, 3, 6])
         assert_equal(np.ravel(x.T, order='A'), [1, 2, 3, 4, 5, 6])
         x = matrix([[1, 2, 3], [4, 5, 6]])
-        assert_equal(np.ravel(x), [[1, 2, 3, 4, 5, 6]])
-        assert_equal(np.ravel(x, order='F'), [[1, 4, 2, 5, 3, 6]])
-        assert_equal(np.ravel(x.T), [[1, 4, 2, 5, 3, 6]])
-        assert_equal(np.ravel(x.T, order='A'), [[1, 2, 3, 4, 5, 6]])
+        assert_equal(np.ravel(x), [1, 2, 3, 4, 5, 6])
+        assert_equal(np.ravel(x, order='F'), [1, 4, 2, 5, 3, 6])
+        assert_equal(np.ravel(x.T), [1, 4, 2, 5, 3, 6])
+        assert_equal(np.ravel(x.T, order='A'), [1, 2, 3, 4, 5, 6])
 
     def test_matrix_ravel_order(self):
         x = matrix([[1, 2, 3], [4, 5, 6]])

--- a/numpy/matrixlib/tests/test_numeric.py
+++ b/numpy/matrixlib/tests/test_numeric.py
@@ -1,22 +1,22 @@
 from __future__ import division, absolute_import, print_function
 
+import numpy as np
 from numpy.testing import assert_equal, TestCase, run_module_suite
-from numpy.core import ones
-from numpy import matrix, diagonal, diag
 
 class TestDot(TestCase):
     def test_matscalar(self):
-        b1 = matrix(ones((3, 3), dtype=complex))
+        b1 = np.matrix(np.ones((3, 3), dtype=complex))
         assert_equal(b1*1.0, b1)
 
 
 def test_diagonal():
-    b1 = matrix([[1,2],[3,4]])
-    diag_b1 = matrix([[1, 4]])
+    b1 = np.matrix([[1,2],[3,4]])
+    diag_b1 = np.matrix([[1, 4]])
+    array_b1 = np.array([1, 4])
 
     assert_equal(b1.diagonal(), diag_b1)
-    assert_equal(diagonal(b1), diag_b1)
-    assert_equal(diag(b1), diag_b1)
+    assert_equal(np.diagonal(b1), array_b1)
+    assert_equal(np.diag(b1), array_b1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Special case matrix for ravel, diag, diagonal. Instead of returning a matrix subtype, return a 1-D array. This is for backward compatibility, see #5398. The optional last commit adds a FutureWarning that at some future date these functions will preserve the matrix type also. This PR should be discussed before merging.
