### PR TITLE
BLD: ensure OPT build environment variable is read

### DIFF
--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -30,6 +30,15 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
         # add flags for (almost) sane C++ handling
         ccomp += ['-AA']
         self.compiler_so = ccomp
+    # ensure OPT environment variable is read
+    if 'OPT' in os.environ:
+        opt = " ".join(os.environ['OPT'].split())
+        ccomp_s = " ".join(ccomp)
+        if opt not in ccomp_s:
+            from distutils.sysconfig import get_config_vars
+            gcv_opt = " ".join(get_config_vars('OPT')[0].split())
+            ccomp_s = ccomp_s.replace(gcv_opt, opt)
+            self.compiler_so = ccomp_s.split()
 
     display = '%s: %s' % (os.path.basename(self.compiler_so[0]), src)
     try:

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -32,13 +32,16 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
         self.compiler_so = ccomp
     # ensure OPT environment variable is read
     if 'OPT' in os.environ:
+        from distutils.sysconfig import get_config_vars
         opt = " ".join(os.environ['OPT'].split())
-        ccomp_s = " ".join(ccomp)
+        gcv_opt = " ".join(get_config_vars('OPT')[0].split())
+        ccomp_s = " ".join(self.compiler_so)
         if opt not in ccomp_s:
-            from distutils.sysconfig import get_config_vars
-            gcv_opt = " ".join(get_config_vars('OPT')[0].split())
             ccomp_s = ccomp_s.replace(gcv_opt, opt)
             self.compiler_so = ccomp_s.split()
+        llink_s = " ".join(self.linker_so)
+        if opt not in llink_s:
+            self.linker_so = llink_s.split() + opt.split()
 
     display = '%s: %s' % (os.path.basename(self.compiler_so[0]), src)
     try:


### PR DESCRIPTION
http://docs.scipy.org/doc/numpy/user/install.html#supplying-additional-compiler-flags reads:
"Additional compiler flags can be supplied by setting the OPT, FOPT (for Fortran), and CC environment variables" (also `runtest.py` tries to set OPT and FOPT for debug mode). However, this is currently not the case for python3 on Debian jessie (and on Ubuntu 14.04 as reported on the mailing list http://lists.ipython.scipy.org/pipermail/numpy-discussion/2014-September/071136.html).

While `FOPT` is handled by `numpy/distutils/fcompiler/__init__.py`, `ÒPT` is handled on Debian jessie by python standard lib distutils `/usr/lib/python2.7/distutils/sysconfig.py`:

```
211         if 'OPT' in os.environ:
212             opt = os.environ['OPT']
213         cflags = ' '.join(str(x) for x in (basecflags, opt, extra_cflags) if x)
```

Interestingly though, these lines are missing in the v2.7.8 tag of python hg, https://hg.python.org/cpython/file/ee879c0ffa11/Lib/distutils/sysconfig.py#l198

They are actually patched by debian for python 2.7:
http://bazaar.launchpad.net/~doko/python/pkg2.7-debian/view/head:/patches/distutils-sysconfig.diff

Why ever this patch is missing for python 3.4:
http://bazaar.launchpad.net/~doko/python/pkg3.4-debian/view/head:/patches/distutils-sysconfig.diff

This pull request assures by patching `numpy/distutils/unixccompiler.py`, that the e.g. `"export OPT="-O0 -ggdb3"` environment variable is actually read on all python distributions, which do not ship this"debian python2.7 OPT patch".
