### PR TITLE
Minor docstring fix

### DIFF
--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1799,7 +1799,7 @@ class Hermite(ABCPolyBase):
     Parameters
     ----------
     coef : array_like
-        Laguerre coefficients in order of increasing degree, i.e,
+        Hermite coefficients in order of increasing degree, i.e,
         ``(1, 2, 3)`` gives ``1*H_0(x) + 2*H_1(X) + 3*H_2(x)``.
     domain : (2,) array_like, optional
         Domain to use. The interval ``[domain[0], domain[1]]`` is mapped

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1796,7 +1796,7 @@ class HermiteE(ABCPolyBase):
     Parameters
     ----------
     coef : array_like
-        Laguerre coefficients in order of increasing degree, i.e,
+        HermiteE coefficients in order of increasing degree, i.e,
         ``(1, 2, 3)`` gives ``1*He_0(x) + 2*He_1(X) + 3*He_2(x)``.
     domain : (2,) array_like, optional
         Domain to use. The interval ``[domain[0], domain[1]]`` is mapped


### PR DESCRIPTION
Fixes a couple of minor polynomial name mixups in the docstrings for the `Hermite` and `HermiteE` classes.
