### PR TITLE
BUG: linspace handling of denormals, fixes #5437

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -11,7 +11,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
     Return evenly spaced numbers over a specified interval.
 
     Returns `num` evenly spaced samples, calculated over the
-    interval [`start`, `stop` ].
+    interval [`start`, `stop`].
 
     The endpoint of the interval can optionally be excluded.
 
@@ -83,28 +83,45 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
     """
     num = int(num)
 
-    # Convert float/complex array scalars to float, gh-3504 
+    # Convert float/complex array scalars to float, gh-3504
     start = start * 1.
     stop = stop * 1.
 
+    dt = result_type(start, stop, float(num))
     if dtype is None:
-        dtype = result_type(start, stop, float(num))
+        dtype = dt
 
     if num <= 0:
         return array([], dtype)
+    if num == 1:
+        return array([start], dtype=dtype)
+    y = _nx.arange(0, num, dtype=dt)
     if endpoint:
-        if num == 1:
-            return array([start], dtype=dtype)
-        step = (stop-start)/float((num-1))
-        y = _nx.arange(0, num, dtype=dtype) * step + start
+        num -= 1
+    y /= num
+    y *= stop - start
+    y += start
+    if endpoint:
         y[-1] = stop
-    else:
-        step = (stop-start)/float(num)
-        y = _nx.arange(0, num, dtype=dtype) * step + start
+
     if retstep:
-        return y.astype(dtype), step
+        return y.astype(dtype, copy=False), (stop - start) / num
     else:
-        return y.astype(dtype)
+        return y.astype(dtype, copy=False)
+
+    # if endpoint:
+        # if num == 1:
+            # return array([start], dtype=dtype)
+        # step = (stop-start)/float((num-1))
+        # y = _nx.arange(0, num, dtype=dtype) * step + start
+        # y[-1] = stop
+    # else:
+        # step = (stop-start)/float(num)
+        # y = _nx.arange(0, num, dtype=dtype) * step + start
+    # if retstep:
+        # return y.astype(dtype), step
+    # else:
+        # return y.astype(dtype)
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 from numpy.testing import *
-from numpy import logspace, linspace, dtype, array
+from numpy import logspace, linspace, dtype, array, finfo, typecodes
 
 class TestLogspace(TestCase):
 
@@ -76,39 +76,46 @@ class TestLinspace(TestCase):
         t2 = array([  0.0+1.j  ,   2.5+0.75j,   5.0+0.5j ,   7.5+0.25j,  10.0+0.j])
         assert_equal(lim1, t1)
         assert_equal(lim2, t2)
-        
+
     def test_physical_quantities(self):
         class PhysicalQuantity(float):
             def __new__(cls, value):
                 return float.__new__(cls, value)
-                
+
             def __add__(self, x):
                 assert_(isinstance(x, PhysicalQuantity))
                 return PhysicalQuantity(float(x) + float(self))
             __radd__ = __add__
-                
+
             def __sub__(self, x):
                 assert_(isinstance(x, PhysicalQuantity))
                 return PhysicalQuantity(float(self) - float(x))
-                
+
             def __rsub__(self, x):
                 assert_(isinstance(x, PhysicalQuantity))
                 return PhysicalQuantity(float(x) - float(self))
-                
+
             def __mul__(self, x):
                 return PhysicalQuantity(float(x) * float(self))
             __rmul__ = __mul__
-                
+
             def __div__(self, x):
                 return PhysicalQuantity(float(self) / float(x))
-                
+
             def __rdiv__(self, x):
                 return PhysicalQuantity(float(x) / float(self))
 
-        
+
         a = PhysicalQuantity(0.0)
         b = PhysicalQuantity(1.0)
         assert_equal(linspace(a, b), linspace(0.0, 1.0))
+
+    def test_denormal_numbers(self):
+        # Regression test for gh-5437. Will probably fail when compiled
+        # with ICC, which flushes denormals to zero
+        for dt in (dtype(f) for f in typecodes['Float']):
+            stop = finfo(dt).tiny * finfo(dt).resolution
+            assert_(any(linspace(0, stop, 10, endpoint=False, dtype=dt)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The following code now runs about 50% slower:

```
# current master
In [2]: %timeit np.linspace(0, 1, 1000000)
100 loops, best of 3: 15.8 ms per loop

# this PR
In [2]: %timeit np.linspace(0, 1, 1000000)
10 loops, best of 3: 21.7 ms per loop
```

But denormals are correctly handled:

```
# Current master
In [2]: np.linspace(0, np.finfo(np.double).tiny*np.finfo(np.double).resolution,
   ...:             10, endpoint=False)
Out[2]: array([ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.])

# This PR
In [2]: np.linspace(0, np.finfo(np.double).tiny*np.finfo(np.double).resolution,
   ...:             10, endpoint=False)
Out[2]:
array([  0.00000000e+000,   0.00000000e+000,   4.94065646e-324,
         9.88131292e-324,   9.88131292e-324,   9.88131292e-324,
         1.48219694e-323,   1.97626258e-323,   1.97626258e-323,
         1.97626258e-323])
```

We could get that speed back by branching on the size of `step = (stop - start) / num`, not sure it is worth the extra complication.
