### PR TITLE
Fix typo in slogdet doc

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1600,7 +1600,7 @@ def slogdet(a):
     """
     Compute the sign and (natural) logarithm of the determinant of an array.
 
-    If an array has a very small or very large determinant, than a call to
+    If an array has a very small or very large determinant, then a call to
     `det` may overflow or underflow. This routine is more robust against such
     issues, because it computes the logarithm of the determinant rather than
     the determinant itself.


### PR DESCRIPTION
fix typo in slogdet docstring

"than" -> "then"

I'm not that good at English grammar, please be aware.
