### PR TITLE
BUG: fix ma.median used on ndarrays

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -41,7 +41,7 @@ import warnings
 from . import core as ma
 from .core import MaskedArray, MAError, add, array, asarray, concatenate, count, \
     filled, getmask, getmaskarray, make_mask_descr, masked, masked_array, \
-    mask_or, nomask, ones, sort, zeros
+    mask_or, nomask, ones, sort, zeros, getdata
 #from core import *
 
 import numpy as np
@@ -671,7 +671,7 @@ def median(a, axis=None, out=None, overwrite_input=False):
 
     """
     if not hasattr(a, 'mask') or np.count_nonzero(a.mask) == 0:
-        return masked_array(np.median(getattr(a, 'data', a), axis=axis,
+        return masked_array(np.median(getdata(a, subok=True), axis=axis,
                       out=out, overwrite_input=overwrite_input), copy=False)
     if overwrite_input:
         if axis is None:

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -508,6 +508,10 @@ class TestMedian(TestCase):
         r = np.ma.median([[np.inf, np.inf], [np.inf, np.inf]], axis=-1)
         assert_equal(r, np.inf)
 
+    def test_non_masked(self):
+        assert_equal(np.ma.median(np.arange(9)), 4.)
+        assert_equal(np.ma.median(range(9)), 4)
+
     def test_2d(self):
         # Tests median w/ 2D
         (n, p) = (101, 30)


### PR DESCRIPTION
ndarrays have a data attribute pointing to the data buffer which leads
to the median working on a byte view instead of the actual type.
closes gh-5424

rebased for backport
