### PR TITLE
BUG: Fix #4476 by adding datetime64 and timedelta64 types

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -145,10 +145,15 @@ default_filler = {'b': True,
                   'S' : 'N/A',
                   'u' : 999999,
                   'V' : '???',
-                  'U' : 'N/A',
-                  'M8[D]' : np.datetime64('NaT', 'D'),
-                  'M8[us]' : np.datetime64('NaT', 'us')
+                  'U' : 'N/A'
                   }
+
+# Add datetime64 and timedelta64 types
+for v in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps",
+          "fs", "as"]:
+    default_filler["M8[" + v + "]"] = np.datetime64("NaT", v)
+    default_filler["m8[" + v + "]"] = np.timedelta64("NaT", v)
+
 max_filler = ntypes._minvals
 max_filler.update([(k, -np.inf) for k in [np.float32, np.float64]])
 min_filler = ntypes._maxvals
@@ -194,7 +199,7 @@ def default_fill_value(obj):
     999999
     >>> np.ma.default_fill_value(np.array([1.1, 2., np.pi]))
     1e+20
-    >>>  np.ma.default_fill_value(np.dtype(complex))
+    >>> np.ma.default_fill_value(np.dtype(complex))
     (1e+20+0j)
 
     """
@@ -203,7 +208,7 @@ def default_fill_value(obj):
     elif isinstance(obj, np.dtype):
         if obj.subdtype:
             defval = default_filler.get(obj.subdtype[0].kind, '?')
-        elif obj.kind == 'M':
+        elif obj.kind in 'Mm':
             defval = default_filler.get(obj.str[1:], '?')
         else:
             defval = default_filler.get(obj.kind, '?')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1489,6 +1489,21 @@ class TestFillingValues(TestCase):
         control = np.array((0, 0, 0), dtype="int, float, float").astype(ndtype)
         assert_equal(_check_fill_value(0, ndtype), control)
 
+    def test_fillvalue_datetime_timedelta(self):
+        # Test default fillvalue for datetime64 and timedelta64 types.
+        # See issue #4476, this would return '?' which would cause errors
+        # elsewhere
+
+        for timecode in ("as", "fs", "ps", "ns", "us", "ms", "s", "m",
+                         "h", "D", "W", "M", "Y"):
+            control = numpy.datetime64("NaT", timecode)
+            test = default_fill_value(numpy.dtype("<M8[" + timecode + "]"))
+            assert_equal(test, control)
+
+            control = numpy.timedelta64("NaT", timecode)
+            test = default_fill_value(numpy.dtype("<m8[" + timecode + "]"))
+            assert_equal(test, control)
+
     def test_extremum_fill_value(self):
         # Tests extremum fill values for flexible type.
         a = array([(1, (2, 3)), (4, (5, 6))],


### PR DESCRIPTION
This commit fixes bug #4476 by adding the codes for the datetime64 and
timedelta64 types to the `default_filler` dictionary in numpy.ma.core,
used by `default_fill_value`.  Also adapt checking in the
`default_fill_value` to include code for timedelta64, not only datetime64.
