### PR TITLE
MAINT: Refactor _new_sortlike and _new_argsortlike

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -835,7 +835,7 @@ class TestMethods(TestCase):
             assert_equal(c, a, msg)
 
         # test complex sorts. These use the same code as the scalars
-        # but the compare fuction differs.
+        # but the compare function differs.
         ai = a*1j + 1
         bi = b*1j + 1
         for kind in ['q', 'm', 'h'] :
@@ -856,6 +856,16 @@ class TestMethods(TestCase):
             c = bi.copy();
             c.sort(kind=kind)
             assert_equal(c, ai, msg)
+
+        # test sorting of complex arrays requiring byte-swapping, gh-5441
+        for endianess in '<>':
+            for dt in np.typecodes['Complex']:
+                dtype = '{0}{1}'.format(endianess, dt)
+                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=dt)
+                c = arr.copy()
+                c.sort()
+                msg = 'byte-swapped complex sort, dtype={0}'.format(dt)
+                assert_equal(c, arr, msg)
 
         # test string sorts.
         s = 'aaaaaaaa'
@@ -1034,6 +1044,15 @@ class TestMethods(TestCase):
             msg = "complex argsort, kind=%s" % kind
             assert_equal(ai.copy().argsort(kind=kind), a, msg)
             assert_equal(bi.copy().argsort(kind=kind), b, msg)
+
+        # test argsort of complex arrays requiring byte-swapping, gh-5441
+        for endianess in '<>':
+            for dt in np.typecodes['Complex']:
+                dtype = '{0}{1}'.format(endianess, dt)
+                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=dt)
+                msg = 'byte-swapped complex argsort, dtype={0}'.format(dt)
+                assert_equal(arr.argsort(),
+                             np.arange(len(arr), dtype=np.intp), msg)
 
         # test string argsorts.
         s = 'aaaaaaaa'


### PR DESCRIPTION
Simplify the signature of both functions, remove code duplication
inside, add proper handling of byte-swapping for compound dtypes
(like complex, fixes #5441), and add functionality to deal with
dtypes containing Python object references. This last enhancement is
not needed for this PR, but supports subsequent ones.
