### PR TITLE
ENH: faster fastclip functions

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3538,6 +3538,7 @@ static void
         /* NaNs result in no clipping, so optimize the case away */
         if (@isnan@(max_val)) {
             if (min == NULL) {
+                memmove(out, in, ni * sizeof(@type@));
                 return;
             }
             max = NULL;
@@ -3549,6 +3550,7 @@ static void
 #if @isfloat@
         if (@isnan@(min_val)) {
             if (max == NULL) {
+                memmove(out, in, ni * sizeof(@type@));
                 return;
             }
             min = NULL;
@@ -3560,12 +3562,18 @@ static void
             if (@lt@(in[i], min_val)) {
                 out[i] = min_val;
             }
+            else {
+                out[i] = in[i];
+            }
         }
     }
     else if (min == NULL) {
         for (i = 0; i < ni; i++) {
             if (@gt@(in[i], max_val)) {
                 out[i] = max_val;
+            }
+            else {
+                out[i] = in[i];
             }
         }
     }
@@ -3576,6 +3584,9 @@ static void
             }
             else if (@gt@(in[i], max_val)) {
                 out[i]   = max_val;
+            }
+            else {
+                out[i] = in[i];
             }
         }
     }
@@ -3609,12 +3620,18 @@ static void
             if (PyArray_CLT(in[i],min_val)) {
                 out[i] = min_val;
             }
+            else {
+                out[i] = in[i];
+            }
         }
     }
     else if (min == NULL) {
         for (i = 0; i < ni; i++) {
             if (PyArray_CGT(in[i], max_val)) {
                 out[i] = max_val;
+            }
+            else {
+                out[i] = in[i];
             }
         }
     }
@@ -3625,6 +3642,9 @@ static void
             }
             else if (PyArray_CGT(in[i], max_val)) {
                 out[i] = max_val;
+            }
+            else {
+                out[i] = in[i];
             }
         }
     }

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -921,7 +921,9 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
     func = PyArray_DESCR(self)->f->fastclip;
     if (func == NULL
         || (min != NULL && !PyArray_CheckAnyScalar(min))
-        || (max != NULL && !PyArray_CheckAnyScalar(max))) {
+        || (max != NULL && !PyArray_CheckAnyScalar(max))
+        || PyArray_ISBYTESWAPPED(self)
+        || (out && PyArray_ISBYTESWAPPED(out))) {
         return _slow_array_clip(self, min, max, out);
     }
     /* Use the fast scalar clip function */
@@ -1032,7 +1034,6 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
         }
     }
 
-
     /*
      * Check to see if input is single-segment, aligned,
      * and in native byteorder
@@ -1137,12 +1138,6 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
         PyErr_SetString(PyExc_ValueError, "clip: Output array must have the"
                         "same shape as the input.");
         goto fail;
-    }
-    if (PyArray_DATA(newout) != PyArray_DATA(newin)) {
-        if (PyArray_AssignArray(newout, newin,
-                    NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {
-            goto fail;
-        }
     }
 
     /* Now we can call the fast-clip function */

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1493,6 +1493,14 @@ class TestClip(TestCase):
         assert_array_strict_equal(a2, ac)
         self.assertTrue(a2 is a)
 
+    def test_clip_nan(self):
+        d = np.arange(7.)
+        assert_equal(d.clip(min=np.nan), d)
+        assert_equal(d.clip(max=np.nan), d)
+        assert_equal(d.clip(min=np.nan, max=np.nan), d)
+        assert_equal(d.clip(min=-2, max=np.nan), d)
+        assert_equal(d.clip(min=np.nan, max=10), d)
+
 
 class TestAllclose(object):
     rtol = 1e-5


### PR DESCRIPTION
copying the element in the loop via an else is significantly faster than
copying first and skipping the else clause as it allows the compiler to
use branchless instructions like minsd/maxsd.

For floats this is 3 times faster for min xor max and 40% faster for min
and max. Further improvements are possible via vectorization.
There is a penalty for inplace clips due to higher memory bandwidth
usage but it seems to be less than 10% and could be easily recovered
with another template specialization if required.
