### PR TITLE
BUG: ma: in-place operations fail dtype checks

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2332,6 +2332,15 @@ masked_%(name)s(data = %(data)s,
 #---- --- MaskedArray class ---
 #####--------------------------------------------------------------------------
 
+
+def _where_scalar(mask, scalar_constant, array):
+    """
+    Replacement for np.where(mask, scalar_constant, array) that preseves dtype.
+    Private function
+    """
+    return np.where(mask, array.dtype.type(scalar_constant), array)
+
+
 def _recursive_filled(a, mask, fill_value):
     """
     Recursively fill `a` with `fill_value`.
@@ -3802,7 +3811,7 @@ class MaskedArray(ndarray):
         else:
             if m is not nomask:
                 self._mask += m
-        ndarray.__iadd__(self._data, np.where(self._mask, 0, getdata(other)))
+        ndarray.__iadd__(self._data, _where_scalar(self._mask, 0, getdata(other)))
         return self
     #....
     def __isub__(self, other):
@@ -3814,7 +3823,7 @@ class MaskedArray(ndarray):
                 self._mask += m
         elif m is not nomask:
             self._mask += m
-        ndarray.__isub__(self._data, np.where(self._mask, 0, getdata(other)))
+        ndarray.__isub__(self._data, _where_scalar(self._mask, 0, getdata(other)))
         return self
     #....
     def __imul__(self, other):
@@ -3826,7 +3835,7 @@ class MaskedArray(ndarray):
                 self._mask += m
         elif m is not nomask:
             self._mask += m
-        ndarray.__imul__(self._data, np.where(self._mask, 1, getdata(other)))
+        ndarray.__imul__(self._data, _where_scalar(self._mask, 1, getdata(other)))
         return self
     #....
     def __idiv__(self, other):
@@ -3841,7 +3850,7 @@ class MaskedArray(ndarray):
             other_data = np.where(dom_mask, fval, other_data)
 #        self._mask = mask_or(self._mask, new_mask)
         self._mask |= new_mask
-        ndarray.__idiv__(self._data, np.where(self._mask, 1, other_data))
+        ndarray.__idiv__(self._data, _where_scalar(self._mask, 1, other_data))
         return self
     #....
     def __ifloordiv__(self, other):
@@ -3856,7 +3865,7 @@ class MaskedArray(ndarray):
             other_data = np.where(dom_mask, fval, other_data)
 #        self._mask = mask_or(self._mask, new_mask)
         self._mask |= new_mask
-        ndarray.__ifloordiv__(self._data, np.where(self._mask, 1, other_data))
+        ndarray.__ifloordiv__(self._data, _where_scalar(self._mask, 1, other_data))
         return self
     #....
     def __itruediv__(self, other):
@@ -3871,7 +3880,7 @@ class MaskedArray(ndarray):
             other_data = np.where(dom_mask, fval, other_data)
 #        self._mask = mask_or(self._mask, new_mask)
         self._mask |= new_mask
-        ndarray.__itruediv__(self._data, np.where(self._mask, 1, other_data))
+        ndarray.__itruediv__(self._data, _where_scalar(self._mask, 1, other_data))
         return self
     #...
     def __ipow__(self, other):
@@ -3879,7 +3888,7 @@ class MaskedArray(ndarray):
         other_data = getdata(other)
         other_mask = getmask(other)
         with np.errstate(divide='ignore', invalid='ignore'):
-            ndarray.__ipow__(self._data, np.where(self._mask, 1, other_data))
+            ndarray.__ipow__(self._data, _where_scalar(self._mask, 1, other_data))
         invalid = np.logical_not(np.isfinite(self._data))
         if invalid.any():
             if self._mask is not nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1751,6 +1751,13 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         assert_equal(xm, y + a)
         assert_equal(xm.mask, mask_or(m, a.mask))
 
+    def test_inplace_addition_dtype(self):
+        # Ensure inplace addition respects dtype
+        x = arange(5, dtype=np.uint16)
+        x[0] = masked
+        x += np.uint16(1)
+        assert_equal(x.dtype, np.uint16)
+
     def test_inplace_subtraction_scalar(self):
         # Test of inplace subtractions
         (x, y, xm) = self.intdata


### PR DESCRIPTION
An error is thrown if you run this code on current numpy master:

```
import numpy as np
foo = np.ma.array([5], mask=[True], dtype=np.uint16)
foo += np.uint16(1)
```

The use of np.where with a constant scalar causes a TypeError when the dtype of the masked array is incompatible with `np.int64` (the default dtype for constant integers, on my machine).

The test case only checks iadd, but the bug touches seven operations in total: iadd, isub, imul, idiv, ifloordiv, itruediv, and ipow. If desired, I can add tests for the rest of the operations as well.
