### PR TITLE
ENH: Show subclass type in dtype repr and str of structured arrays

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -215,6 +215,12 @@ class format_parser:
 class record(nt.void):
     """A data-type scalar that allows field access as attribute lookup.
     """
+
+    # manually set name and module so that this class's type shows up
+    # as numpy.record when printed
+    __name__ = 'record'
+    __module__ = 'numpy'
+
     def __repr__(self):
         return self.__str__()
 
@@ -388,6 +394,12 @@ class recarray(ndarray):
           dtype=[('x', '<i4'), ('y', '<f8'), ('z', '<i4')])
 
     """
+
+    # manually set name and module so that this class's type shows
+    # up as "numpy.recarray" when printed
+    __name__ = 'recarray'
+    __module__ = 'numpy'
+
     def __new__(subtype, shape, dtype=None, buf=None, offset=0, strides=None,
                 formats=None, names=None, titles=None,
                 byteorder=None, aligned=False, order='C'):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -74,7 +74,7 @@ class TestFromrecords(TestCase):
 
     def test_recarray_from_repr(self):
         x = np.rec.array([ (1, 2)], dtype=[('a', np.int8), ('b', np.int8)])
-        y = eval("np." + repr(x))
+        y = eval("numpy." + repr(x), {'numpy': np})
         assert_(isinstance(y, np.recarray))
         assert_equal(y, x)
 


### PR DESCRIPTION
Hello, this is an enhancement that clarifies (or solves?) https://github.com/numpy/numpy/issues/3581.

I discussed it on the mailing list in a message "Re: structured arrays, recarrays, and record arrays" on Jan 19 2015. I didn't get any replies, but hopefully that merely means "no opinion" rather than "bad idea". I though maybe implementing it would draw more interest.

What it does: For structured arrays, if the dtype is not np.void then print the dtype as `(base_dtype, dtype)`. This is the standard form for subclassed dtypes as documented  in reference/arrays.dtypes, although that page says this form is discouraged. (Perhaps that discouragement should also be removed?).

This solves the problem that array objects may "look" identical even though their dtypes differ, as happened in issue 3581.

Old Behavior:

```
>>> a = np.array([(1,'ABC'), (2, "DEF")], dtype=[('foo', int), ('bar', 'S4')])
>>> np.rec.array(a)
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
>>> a.view(np.recarray)
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
```

New Behavior:

```
>>> a = np.array([(1,'ABC'), (2, "DEF")], dtype=[('foo', int), ('bar', 'S4')])
>>> np.rec.array(a)
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=(record, [('foo', '<i8'), ('bar', 'S4')]))
>>> a.view(np.recarray)
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
```

Now, probably instead of saying simply "record" in these examples, it should say something like "numpy.record" or "np.record". Any preference?
