### PR TITLE
PyErr_NoMemory when PyArray_Zeros fails to initialize

### DIFF
--- a/numpy/fft/fftpack_litemodule.c
+++ b/numpy/fft/fftpack_litemodule.c
@@ -149,7 +149,7 @@ fftpack_rfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     PyObject *op1, *op2;
     PyArrayObject *data, *ret;
     PyArray_Descr *descr;
-    double *wsave, *dptr, *rptr;
+    double *wsave = NULL, *dptr, *rptr;
     npy_intp nsave;
     int npts, nrepeats, i, rstep;
 
@@ -166,6 +166,10 @@ fftpack_rfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     PyArray_DIMS(data)[PyArray_NDIM(data) - 1] = npts/2 + 1;
     ret = (PyArrayObject *)PyArray_Zeros(PyArray_NDIM(data),
             PyArray_DIMS(data), PyArray_DescrFromType(NPY_CDOUBLE), 0);
+    if (ret == NULL) {
+        PyErr_NoMemory();
+        goto fail;
+    }
     PyArray_DIMS(data)[PyArray_NDIM(data) - 1] = npts;
     rstep = PyArray_DIM(ret, PyArray_NDIM(ret) - 1)*2;
 


### PR DESCRIPTION
I also initialize `wsave` to NULL for safety during the Free. Here is a relevant stack trace:

```
#0  0x00007fc630f19f6b in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  <signal handler called>
#2  fftpack_rfftf (__NPY_UNUSED_TAGGEDself=<optimized out>, args=<optimized out>) at numpy/fft/fftpack_litemodule.c:172
#3  0x00007fc63125c64a in call_function (oparg=<optimized out>, pp_stack=0x7fff1dc12180) at Python/ceval.c:4234
#4  PyEval_EvalFrameEx (f=f@entry=0x2f10dc8, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#5  0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=6, kws=0x7fc61c565210, kwcount=0, defs=0x7fc62b4c6d70, defcount=5,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#6  0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=6, n=<optimized out>, pp_stack=0x7fff1dc12410, func=0x7fc62b23ff28) at Python/ceval.c:4341
#7  call_function (oparg=<optimized out>, pp_stack=0x7fff1dc12410) at Python/ceval.c:4259
#8  PyEval_EvalFrameEx (f=f@entry=0x7fc61c565048, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#9  0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=2, kws=0x7fc620bafad8, kwcount=0, defs=0x7fc62b246da0, defcount=2,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#10 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=2, n=<optimized out>, pp_stack=0x7fff1dc126a0, func=0x7fc62c54e488) at Python/ceval.c:4341
#11 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc126a0) at Python/ceval.c:4259
#12 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#13 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=2, n=2, pp_stack=0x7fff1dc12880, func=0x7fc62355c048) at Python/ceval.c:4331
#14 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc12880) at Python/ceval.c:4259
#15 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#16 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=2, n=2, pp_stack=0x7fff1dc12a60, func=0x7fc62355c0d0) at Python/ceval.c:4331
#17 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc12a60) at Python/ceval.c:4259
#18 PyEval_EvalFrameEx (f=f@entry=0x2f0d578, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#19 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=9, kws=0x2f0d548, kwcount=0, defs=0x7fc623568300, defcount=8,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#20 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=9, n=<optimized out>, pp_stack=0x7fff1dc12cf0, func=0x7fc62355c268) at Python/ceval.c:4341
#21 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc12cf0) at Python/ceval.c:4259
#22 PyEval_EvalFrameEx (f=f@entry=0x2f0d328, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#23 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=2, kws=0x7fc61c556b38, kwcount=0, defs=0x7fc623568370, defcount=8,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#24 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=2, n=<optimized out>, pp_stack=0x7fff1dc12f80, func=0x7fc623565d08) at Python/ceval.c:4341
#25 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc12f80) at Python/ceval.c:4259
#26 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#27 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc13160, func=0x7fc623559a60) at Python/ceval.c:4331
#28 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc13160) at Python/ceval.c:4259
#29 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#30 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc13340, func=0x7fc622e189d8) at Python/ceval.c:4331
#31 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc13340) at Python/ceval.c:4259
#32 PyEval_EvalFrameEx (f=f@entry=0x2b01e28, throwflag=throwflag@entry=583684488) at Python/ceval.c:2836
#33 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622d0cc30, argcount=1, kws=kws@entry=0x7fc622cf66e0, kwcount=kwcount@entry=5,
    defs=defs@entry=0x0, defcount=defcount@entry=0, kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#34 0x00007fc6311bade0 in function_call (func=0x7fc622e18a60, arg=0x7fc622d0cc18, kw=0x7fc622d19a08) at Objects/funcobject.c:632
#35 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc622e18a60, arg=arg@entry=0x7fc622d0cc18, kw=kw@entry=0x7fc622d19a08) at Objects/abstract.c:2067
#36 0x00007fc631258a18 in ext_do_call (nk=584109080, na=1, flags=<optimized out>, pp_stack=0x7fff1dc136d0, func=0x7fc622e18a60) at Python/ceval.c:4558
#37 PyEval_EvalFrameEx (f=f@entry=0x2ab3f88, throwflag=throwflag@entry=584161800) at Python/ceval.c:2876
#38 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622d02258, argcount=1, kws=kws@entry=0x7fc622d9abe0, kwcount=kwcount@entry=5,
    defs=defs@entry=0x0, defcount=defcount@entry=0, kwdefs=0x0, closure=0x7fc62b7c42b0) at Python/ceval.c:3585
#39 0x00007fc6311bade0 in function_call (func=0x7fc622e18ae8, arg=0x7fc622d02240, kw=0x7fc622d19a48) at Objects/funcobject.c:632
#40 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc622e18ae8, arg=arg@entry=0x7fc622d02240, kw=kw@entry=0x7fc622d19a48) at Objects/abstract.c:2067
#41 0x00007fc631258a18 in ext_do_call (nk=584065600, na=1, flags=<optimized out>, pp_stack=0x7fff1dc13a50, func=0x7fc622e18ae8) at Python/ceval.c:4558
#42 PyEval_EvalFrameEx (f=f@entry=0x7fc622d70da0, throwflag=throwflag@entry=584161864) at Python/ceval.c:2876
#43 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622d02300, argcount=1, kws=kws@entry=0x7fc622d9ab60, kwcount=kwcount@entry=5,
    defs=defs@entry=0x0, defcount=defcount@entry=0, kwdefs=0x0, closure=0x7fc6304064a8) at Python/ceval.c:3585
#44 0x00007fc6311bade0 in function_call (func=0x7fc630408400, arg=0x7fc622d022e8, kw=0x7fc622d69cc8) at Objects/funcobject.c:632
#45 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc630408400, arg=arg@entry=0x7fc622d022e8, kw=kw@entry=0x7fc622d69cc8) at Objects/abstract.c:2067
#46 0x00007fc6311a614d in method_call (func=0x7fc630408400, arg=0x7fc622d022e8, kw=0x7fc622d69cc8) at Objects/classobject.c:347
#47 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc622d73c08, arg=arg@entry=0x7fc631609048, kw=kw@entry=0x7fc622d69cc8) at Objects/abstract.c:2067
#48 0x00007fc6311f1f6f in slot_tp_call (self=0x7fc62b722da0, args=0x7fc631609048, kwds=0x7fc622d69cc8) at Objects/typeobject.c:5808
#49 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62b722da0, arg=arg@entry=0x7fc631609048, kw=kw@entry=0x7fc622d69cc8) at Objects/abstract.c:2067
#50 0x00007fc631258a18 in ext_do_call (nk=828411976, na=0, flags=<optimized out>, pp_stack=0x7fff1dc13ee0, func=0x7fc62b722da0) at Python/ceval.c:4558
#51 PyEval_EvalFrameEx (f=f@entry=0x2ab3698, throwflag=throwflag@entry=0) at Python/ceval.c:2876
#52 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=4, kws=0x7fc622d70b98, kwcount=0, defs=0x7fc622d6a8b0, defcount=1,
    kwdefs=0x0, closure=0x7fc622d18248) at Python/ceval.c:3585
#53 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=4, n=<optimized out>, pp_stack=0x7fff1dc14160, func=0x7fc622d16730) at Python/ceval.c:4341
#54 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc14160) at Python/ceval.c:4259
#55 PyEval_EvalFrameEx (f=f@entry=0x7fc622d709d0, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#56 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622d0d950, argcount=5, kws=kws@entry=0x7fc631609060, kwcount=kwcount@entry=0,
    defs=defs@entry=0x7fc62ba8c178, defcount=defcount@entry=1, kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#57 0x00007fc6311bade0 in function_call (func=0x7fc62b7be1e0, arg=0x7fc622d0d938, kw=0x7fc622d198c8) at Objects/funcobject.c:632
#58 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62b7be1e0, arg=arg@entry=0x7fc622d0d938, kw=kw@entry=0x7fc622d198c8) at Objects/abstract.c:2067
#59 0x00007fc631258a18 in ext_do_call (nk=584112440, na=0, flags=<optimized out>, pp_stack=0x7fff1dc144f0, func=0x7fc62b7be1e0) at Python/ceval.c:4558
#60 PyEval_EvalFrameEx (f=f@entry=0x2a8bc08, throwflag=throwflag@entry=0) at Python/ceval.c:2876
#61 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=1, kws=0x2aae390, kwcount=1, defs=0x7fc62ba77720, defcount=3,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#62 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=1, n=<optimized out>, pp_stack=0x7fff1dc14770, func=0x7fc62ba81840) at Python/ceval.c:4341
#63 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc14770) at Python/ceval.c:4259
#64 PyEval_EvalFrameEx (f=f@entry=0x2aae1d8, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#65 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=1, kws=0x2aac9c8, kwcount=0, defs=0x0, defcount=0, kwdefs=0x0,
    closure=0x0) at Python/ceval.c:3585
#66 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=1, n=<optimized out>, pp_stack=0x7fff1dc14a00, func=0x7fc62ba81598) at Python/ceval.c:4341
#67 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc14a00) at Python/ceval.c:4259
#68 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#69 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc14be0, func=0x7fc62c0316a8) at Python/ceval.c:4331
#70 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc14be0) at Python/ceval.c:4259
#71 PyEval_EvalFrameEx (f=f@entry=0x2aab7a8, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#72 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622e871e0, argcount=2, kws=kws@entry=0x0, kwcount=kwcount@entry=0, defs=defs@entry=0x0,
    defcount=defcount@entry=0, kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#73 0x00007fc6311bacbf in function_call (func=0x7fc62b77f2f0, arg=0x7fc622e871c8, kw=0x0) at Objects/funcobject.c:632
#74 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62b77f2f0, arg=arg@entry=0x7fc622e871c8, kw=kw@entry=0x0) at Objects/abstract.c:2067
#75 0x00007fc6311a614d in method_call (func=0x7fc62b77f2f0, arg=0x7fc622e871c8, kw=0x0) at Objects/classobject.c:347
#76 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc622d76048, arg=arg@entry=0x7fc622df51d0, kw=kw@entry=0x0) at Objects/abstract.c:2067
#77 0x00007fc6311f1a37 in slot_tp_init (self=0x7fc622d6a978, args=0x7fc622df51d0, kwds=0x0) at Objects/typeobject.c:6023
#78 0x00007fc6311ed1d3 in type_call (type=<optimized out>, args=0x7fc622df51d0, kwds=0x0) at Objects/typeobject.c:869
#79 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x2493e38, arg=arg@entry=0x7fc622df51d0, kw=kw@entry=0x0) at Objects/abstract.c:2067
#80 0x00007fc631256dd9 in do_call (nk=<optimized out>, na=<optimized out>, pp_stack=0x7fff1dc150a0, func=0x2493e38) at Python/ceval.c:4463
#81 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc150a0) at Python/ceval.c:4261
#82 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#83 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc15280, func=0x7fc62c028e18) at Python/ceval.c:4331
#84 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc15280) at Python/ceval.c:4259
#85 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#86 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=2, n=2, pp_stack=0x7fff1dc15460, func=0x7fc62b80ff28) at Python/ceval.c:4331
#87 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc15460) at Python/ceval.c:4259
#88 PyEval_EvalFrameEx (f=f@entry=0x2aa90f8, throwflag=throwflag@entry=584542088) at Python/ceval.c:2836
#89 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622d8b2e0, argcount=2, kws=kws@entry=0x7fc622d7b140, kwcount=kwcount@entry=11,
    defs=defs@entry=0x7fc62ba7f1f0, defcount=defcount@entry=19, kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#90 0x00007fc6311bade0 in function_call (func=0x7fc62b80fa60, arg=0x7fc622d8b2c8, kw=0x7fc622d73208) at Objects/funcobject.c:632
#91 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62b80fa60, arg=arg@entry=0x7fc622d8b2c8, kw=kw@entry=0x7fc622d73208) at Objects/abstract.c:2067
#92 0x00007fc631258a18 in ext_do_call (nk=584626888, na=2, flags=<optimized out>, pp_stack=0x7fff1dc157f0, func=0x7fc62b80fa60) at Python/ceval.c:4558
#93 PyEval_EvalFrameEx (f=f@entry=0x7fc622df1048, throwflag=throwflag@entry=584528392) at Python/ceval.c:2876
#94 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc622df51b0, argcount=1, kws=kws@entry=0x7fc622e0a280, kwcount=kwcount@entry=14,
    defs=defs@entry=0x7fc62b718f00, defcount=defcount@entry=3, kwdefs=0x0, closure=0x7fc62b7222e8) at Python/ceval.c:3585
#95 0x00007fc6311bade0 in function_call (func=0x7fc62ba8b730, arg=0x7fc622df5198, kw=0x7fc622d73148) at Objects/funcobject.c:632
#96 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62ba8b730, arg=arg@entry=0x7fc622df5198, kw=kw@entry=0x7fc622d73148) at Objects/abstract.c:2067
#97 0x00007fc6311a614d in method_call (func=0x7fc62ba8b730, arg=0x7fc622df5198, kw=0x7fc622d73148) at Objects/classobject.c:347
#98 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62c00fe08, arg=arg@entry=0x7fc631609048, kw=kw@entry=0x7fc622d73148) at Objects/abstract.c:2067
#99 0x00007fc6311f1a37 in slot_tp_init (self=0x7fc622d6af98, args=0x7fc631609048, kwds=0x7fc622d73148) at Objects/typeobject.c:6023
#100 0x00007fc6311ed1d3 in type_call (type=<optimized out>, args=0x7fc631609048, kwds=0x7fc622d73148) at Objects/typeobject.c:869
#101 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x24aa3c8, arg=arg@entry=0x7fc631609048, kw=kw@entry=0x7fc622d73148) at Objects/abstract.c:2067
#102 0x00007fc631258a18 in ext_do_call (nk=828411976, na=0, flags=<optimized out>, pp_stack=0x7fff1dc15cb0, func=0x24aa3c8) at Python/ceval.c:4558
#103 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2876
#104 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc15e80, func=0x7fc62b7339d8) at Python/ceval.c:4331
#105 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc15e80) at Python/ceval.c:4259
#106 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#107 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc16060, func=0x7fc62b76d158) at Python/ceval.c:4331
#108 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc16060) at Python/ceval.c:4259
#109 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#110 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=2, n=2, pp_stack=0x7fff1dc16240, func=0x7fc62b716158) at Python/ceval.c:4331
#111 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc16240) at Python/ceval.c:4259
#112 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#113 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=2, n=2, pp_stack=0x7fff1dc16420, func=0x7fc62b70d510) at Python/ceval.c:4331
#114 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc16420) at Python/ceval.c:4259
#115 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#116 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=1, n=1, pp_stack=0x7fff1dc16600, func=0x7fc62b7271e0) at Python/ceval.c:4331
#117 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc16600) at Python/ceval.c:4259
#118 PyEval_EvalFrameEx (f=f@entry=0x2419878, throwflag=throwflag@entry=732674120) at Python/ceval.c:2836
#119 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc63042b4c0, argcount=1, kws=kws@entry=0x2419600, kwcount=kwcount@entry=37,
    defs=defs@entry=0x7fc62bd3e420, defcount=defcount@entry=9, kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#120 0x00007fc6311bade0 in function_call (func=0x7fc62bd48a60, arg=0x7fc63042b4a8, kw=0x7fc62bab8b48) at Objects/funcobject.c:632
#121 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62bd48a60, arg=arg@entry=0x7fc63042b4a8, kw=kw@entry=0x7fc62bab8b48) at Objects/abstract.c:2067
#122 0x00007fc631258a18 in ext_do_call (nk=809677992, na=1, flags=<optimized out>, pp_stack=0x7fff1dc16990, func=0x7fc62bd48a60) at Python/ceval.c:4558
#123 PyEval_EvalFrameEx (f=f@entry=0x2417b58, throwflag=throwflag@entry=732662600) at Python/ceval.c:2876
#124 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7fc6303accd8, argcount=1, kws=kws@entry=0x2416b30, kwcount=kwcount@entry=37,
    defs=defs@entry=0x0, defcount=defcount@entry=0, kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#125 0x00007fc6311bade0 in function_call (func=0x7fc62bdce048, arg=0x7fc6303accc0, kw=0x7fc62babb608) at Objects/funcobject.c:632
#126 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc62bdce048, arg=arg@entry=0x7fc6303accc0, kw=kw@entry=0x7fc62babb608) at Objects/abstract.c:2067
#127 0x00007fc6311a614d in method_call (func=0x7fc62bdce048, arg=0x7fc6303accc0, kw=0x7fc62babb608) at Objects/classobject.c:347
#128 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc63047fcc8, arg=arg@entry=0x7fc631609048, kw=kw@entry=0x7fc62babb608) at Objects/abstract.c:2067
#129 0x00007fc6311f1f6f in slot_tp_call (self=0x7fc6303b6710, args=0x7fc631609048, kwds=0x7fc62babb608) at Objects/typeobject.c:5808
#130 0x00007fc63118e8ea in PyObject_Call (func=func@entry=0x7fc6303b6710, arg=arg@entry=0x7fc631609048, kw=kw@entry=0x7fc62babb608) at Objects/abstract.c:2067
#131 0x00007fc631258a18 in ext_do_call (nk=828411976, na=0, flags=<optimized out>, pp_stack=0x7fff1dc16e20, func=0x7fc6303b6710) at Python/ceval.c:4558
#132 PyEval_EvalFrameEx (f=f@entry=0x7fc62bb04238, throwflag=throwflag@entry=0) at Python/ceval.c:2876
#133 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=3, kws=0x2410a60, kwcount=1, defs=0x7fc62bd2ae60, defcount=2,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#134 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=3, n=<optimized out>, pp_stack=0x7fff1dc170a0, func=0x7fc62bd48950) at Python/ceval.c:4341
#135 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc170a0) at Python/ceval.c:4259
#136 PyEval_EvalFrameEx (f=f@entry=0x24108a8, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#137 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=3, kws=0x2214d80, kwcount=0, defs=0x7fc62bd4ccd8, defcount=1,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#138 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=3, n=<optimized out>, pp_stack=0x7fff1dc17330, func=0x7fc62bacd2f0) at Python/ceval.c:4341
#139 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc17330) at Python/ceval.c:4259
#140 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#141 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=3, n=3, pp_stack=0x7fff1dc17510, func=0x7fc62bacd510) at Python/ceval.c:4331
#142 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc17510) at Python/ceval.c:4259
#143 PyEval_EvalFrameEx (f=f@entry=0x7fc6303f6cf8, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#144 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=2, kws=0x2392038, kwcount=0, defs=0x7fc62d5cc878, defcount=1,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#145 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=2, n=<optimized out>, pp_stack=0x7fff1dc177a0, func=0x7fc62bdce158) at Python/ceval.c:4341
#146 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc177a0) at Python/ceval.c:4259
#147 PyEval_EvalFrameEx (f=f@entry=0x2391e88, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#148 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=2, kws=0x2103e58, kwcount=0, defs=0x7fc62bd4cdf0, defcount=1,
    kwdefs=0x0, closure=0x7fc62bd4cda0) at Python/ceval.c:3585
#149 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=2, n=<optimized out>, pp_stack=0x7fff1dc17a30, func=0x7fc62bacd598) at Python/ceval.c:4341
#150 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc17a30) at Python/ceval.c:4259
#151 PyEval_EvalFrameEx (f=f@entry=0x2103cb8, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#152 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=argcount@entry=0, kws=0x20dc930, kwcount=0, defs=0x7fc62bd420d0, defcount=1,
    kwdefs=0x0, closure=0x0) at Python/ceval.c:3585
#153 0x00007fc63125b0ea in fast_function (nk=<optimized out>, na=0, n=<optimized out>, pp_stack=0x7fff1dc17cc0, func=0x7fc62bd48bf8) at Python/ceval.c:4341
#154 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc17cc0) at Python/ceval.c:4259
#155 PyEval_EvalFrameEx (f=<optimized out>, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#156 0x00007fc63125b44a in fast_function (nk=<optimized out>, na=0, n=0, pp_stack=0x7fff1dc17ea0, func=0x7fc62dc85510) at Python/ceval.c:4331
#157 call_function (oparg=<optimized out>, pp_stack=0x7fff1dc17ea0) at Python/ceval.c:4259
#158 PyEval_EvalFrameEx (f=f@entry=0x7fc630499438, throwflag=throwflag@entry=0) at Python/ceval.c:2836
#159 0x00007fc63125cfb5 in PyEval_EvalCodeEx (_co=_co@entry=0x7fc63042d150, globals=globals@entry=0x7fc630496348, locals=locals@entry=0x7fc630496348, args=args@entry=0x0, argcount=argcount@entry=0, kws=kws@entry=0x0,
    kwcount=kwcount@entry=0, defs=defs@entry=0x0, defcount=defcount@entry=0, kwdefs=kwdefs@entry=0x0, closure=closure@entry=0x0) at Python/ceval.c:3585
#160 0x00007fc63125d08b in PyEval_EvalCode (co=co@entry=0x7fc63042d150, globals=globals@entry=0x7fc630496348, locals=locals@entry=0x7fc630496348) at Python/ceval.c:773
#161 0x00007fc631282efe in run_mod (arena=0x2098680, flags=0x7fff1dc18140, locals=0x7fc630496348, globals=0x7fc630496348, filename=0x7fc63039a228, mod=0x20ccf48) at Python/pythonrun.c:2180
#162 PyRun_FileExFlags (fp=fp@entry=0x204fc60, filename_str=filename_str@entry=0x7fc6303877c0 "/usr/local/bin/celery", start=start@entry=257, globals=globals@entry=0x7fc630496348, locals=locals@entry=0x7fc630496348,
    closeit=closeit@entry=1, flags=flags@entry=0x7fff1dc18140) at Python/pythonrun.c:2133
#163 0x00007fc631283d35 in PyRun_SimpleFileExFlags (fp=fp@entry=0x204fc60, filename=<optimized out>, closeit=closeit@entry=1, flags=flags@entry=0x7fff1dc18140) at Python/pythonrun.c:1606
#164 0x00007fc631284d69 in PyRun_AnyFileExFlags (fp=fp@entry=0x204fc60, filename=<optimized out>, closeit=closeit@entry=1, flags=flags@entry=0x7fff1dc18140) at Python/pythonrun.c:1292
#165 0x00007fc63129d7c5 in run_file (p_cf=0x7fff1dc18140, filename=0x2003a50 L"/usr/local/bin/celery", fp=0x204fc60) at Modules/main.c:319
#166 Py_Main (argc=argc@entry=11, argv=argv@entry=0x2001010) at Modules/main.c:751
#167 0x0000000000400b06 in main (argc=11, argv=<optimized out>) at ./Modules/python.c:69
```
