### PR TITLE
MAINT: bring back np.lib tests

### DIFF
--- a/numpy/lib/setup.py
+++ b/numpy/lib/setup.py
@@ -1,0 +1,12 @@
+from __future__ import division, print_function
+
+def configuration(parent_package='',top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('lib', parent_package, top_path)
+    config.add_data_dir('tests')
+    return config
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(configuration=configuration)


### PR DESCRIPTION
Merging #5476 removed automatic test discovery for np.lib, this PR adds back numpy/lib/setup.py to fix that.
