### PR TITLE
BUG: Fix genfromtext NameValidator arguments passed to easy_dtype.

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -320,12 +320,13 @@ class NameValidator(object):
         # Process the case option .....
         if (case_sensitive is None) or (case_sensitive is True):
             self.case_converter = lambda x: x
-        elif (case_sensitive is False) or ('u' in case_sensitive):
+        elif (case_sensitive is False) or case_sensitive.startswith('u'):
             self.case_converter = lambda x: x.upper()
-        elif 'l' in case_sensitive:
+        elif case_sensitive.startswith('l'):
             self.case_converter = lambda x: x.lower()
         else:
-            self.case_converter = lambda x: x
+            msg = 'unrecognized case_sensitive value %s.' % case_sensitive
+            raise ValueError(msg)
         #
         self.replace_space = replace_space
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1451,7 +1451,11 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         names = validate_names(names)
     # Get the dtype
     if dtype is not None:
-        dtype = easy_dtype(dtype, defaultfmt=defaultfmt, names=names)
+        dtype = easy_dtype(dtype, defaultfmt=defaultfmt, names=names,
+                           excludelist=excludelist,
+                           deletechars=deletechars,
+                           case_sensitive=case_sensitive,
+                           replace_space=replace_space)
     # Make sure the names is a list (for 2.5)
     if names is not None:
         names = list(names)

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -7,7 +7,8 @@ from datetime import date
 import numpy as np
 from numpy.compat import asbytes, asbytes_nested
 from numpy.testing import (
-    run_module_suite, TestCase, assert_, assert_equal, assert_allclose
+    run_module_suite, TestCase, assert_, assert_equal, assert_allclose,
+    assert_raises
     )
 from numpy.lib._iotools import (
     LineSplitter, NameValidator, StringConverter,
@@ -92,6 +93,9 @@ class TestNameValidator(TestCase):
         assert_equal(test, ['A', 'A_1', 'B', 'C'])
         test = NameValidator(case_sensitive='lower').validate(names)
         assert_equal(test, ['a', 'a_1', 'b', 'c'])
+
+        # check exceptions
+        assert_raises(ValueError, NameValidator, case_sensitive='foobar')
 
     def test_excludelist(self):
         "Test excludelist"

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1107,13 +1107,13 @@ M   33  21.99
     def test_dtype_with_converters_and_usecols(self):
         dstr = "1,5,-1,1:1\n2,8,-1,1:n\n3,3,-2,m:n\n"
         dmap = {'1:1':0, '1:n':1, 'm:1':2, 'm:n':3}
-        dtyp = [('E1','i4'),('E2','i4'),('E3','i2'),('N', 'i1')]
+        dtyp = [('e1','i4'),('e2','i4'),('e3','i2'),('n', 'i1')]
         conv = {0: int, 1: int, 2: int, 3: lambda r: dmap[r.decode()]}
         test = np.recfromcsv(TextIO(dstr,), dtype=dtyp, delimiter=',',
                              names=None, converters=conv)
         control = np.rec.array([[1,5,-1,0], [2,8,-1,1], [3,3,-2,3]], dtype=dtyp)
         assert_equal(test, control)
-        dtyp = [('E1','i4'),('E2','i4'),('N', 'i1')]
+        dtyp = [('e1','i4'),('e2','i4'),('n', 'i1')]
         test = np.recfromcsv(TextIO(dstr,), dtype=dtyp, delimiter=',',
                              usecols=(0,1,3), names=None, converters=conv)
         control = np.rec.array([[1,5,0], [2,8,1], [3,3,3]], dtype=dtyp)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1514,6 +1514,30 @@ M   33  21.99
         ctrl = np.array((1, 2, 3.14), dtype=ctrl_dtype)
         assert_equal(test, ctrl)
 
+    def test_replace_space_known_dtype(self):
+        "Test the 'replace_space' (and related) options when dtype != None"
+        txt = "A.A, B (B), C:C\n1, 2, 3"
+        # Test default: replace ' ' by '_' and delete non-alphanum chars
+        test = np.genfromtxt(TextIO(txt),
+                             delimiter=",", names=True, dtype=int)
+        ctrl_dtype = [("AA", int), ("B_B", int), ("CC", int)]
+        ctrl = np.array((1, 2, 3), dtype=ctrl_dtype)
+        assert_equal(test, ctrl)
+        # Test: no replace, no delete
+        test = np.genfromtxt(TextIO(txt),
+                             delimiter=",", names=True, dtype=int,
+                             replace_space='', deletechars='')
+        ctrl_dtype = [("A.A", int), ("B (B)", int), ("C:C", int)]
+        ctrl = np.array((1, 2, 3), dtype=ctrl_dtype)
+        assert_equal(test, ctrl)
+        # Test: no delete (spaces are replaced by _)
+        test = np.genfromtxt(TextIO(txt),
+                             delimiter=",", names=True, dtype=int,
+                             deletechars='')
+        ctrl_dtype = [("A.A", int), ("B_(B)", int), ("C:C", int)]
+        ctrl = np.array((1, 2, 3), dtype=ctrl_dtype)
+        assert_equal(test, ctrl)
+
     def test_incomplete_names(self):
         "Test w/ incomplete names"
         data = "A,,C\n0,1,2\n3,4,5"


### PR DESCRIPTION
Squashed commits and rewrote commit message of #4649.

np.genfromtxt validates field names twice: once in genfromtxt and once
in easy_dtype. Whilst the arguments to genfromtxt are used in the first
validation, they aren't passed to easy_dtype (which is used only when
dtype != None) and therefore in this case the default validation (strip
non-alphanum, replace spaces) gets confusingly applied, ignoring
genfromtxt's arguments.

This patch adds fixes genfromtxt by passing the appropriate arguments
onwards to easy_dtype.  That is probably the least invasive way to fix
the issue.
