### PR TITLE
Fixing help documentation error in numpy.zeros. Fixes #5497

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -885,7 +885,7 @@ add_newdoc('numpy.core.multiarray', 'zeros',
     >>> np.zeros(5)
     array([ 0.,  0.,  0.,  0.,  0.])
 
-    >>> np.zeros((5,), dtype=numpy.int)
+    >>> np.zeros((5,), dtype=np.int)
     array([0, 0, 0, 0, 0])
 
     >>> np.zeros((2, 1))


### PR DESCRIPTION
This corrects an example provided in the docstring by changing `numpy` to `np` in one place to be consistent with the rest of the code.
