### PR TITLE
ENH: speed up putmask avoiding % in inner loop

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3680,11 +3680,10 @@ static void
 @name@_fastputmask(@type@ *in, npy_bool *mask, npy_intp ni, @type@ *vals,
         npy_intp nv)
 {
-    npy_intp i;
-    @type@ s_val;
+    npy_intp i, j;
 
     if (nv == 1) {
-        s_val = *vals;
+        @type@ s_val = *vals;
         for (i = 0; i < ni; i++) {
             if (mask[i]) {
                 in[i] = s_val;
@@ -3692,9 +3691,12 @@ static void
         }
     }
     else {
-        for (i = 0; i < ni; i++) {
+        for (i = 0, j = 0; i < ni; i++, j++) {
+            if (j >= nv) {
+                j = 0;
+            }
             if (mask[i]) {
-                in[i] = vals[i%nv];
+                in[i] = vals[j];
             }
         }
     }


### PR DESCRIPTION
`putmask(a, mask, b)` is roughly equivalent to `a[mask] = b`, but `b` is tiled as needed if it is shorter than `a` and `m`. That was being done with a `%` operation, which is generally not cheap. On my system, checking the index in every iteration and resetting it to 0 when it exceeds the array's length is over 2x faster in the following test case:

```
import numpy as np
a = np.arange(1000)
m = (a & 1).astype(bool)  # 50% full mask
b = np.arange(100)

%timeit np.putmask(a,m,b)
100000 loops, best of 3: 2.67 us per loop  # current master
1000000 loops, best of 3: 1.15 us per loop  # this PR
```

There is a tradeoff on the sparsity of the mask: this PR's method has to do cheap work to keep the index updated in every iteration, while current master does expensive work only in iterations where the mask is `True`. But even with an all `False` mask, performance is virtually the same:

```
m = np.zeros(1000, bool)
%timeit np.putmask(a, m, b)
1000000 loops, best of 3: 1.04 us per loop  # current master
1000000 loops, best of 3: 1.1 us per loop  # this PR

```

For types that do not have a `fastputmask` function defined, moving chunks of memory around dominates the total time. But applying the same idea as above and removing some duplicated work from the inner loop, the improvements are more modest, but still noticeable:

```
a = np.arange(1000, dtype=object)
b = np.arange(100, dtype=object)
%timeit np.putmask(a, m, b)  # same m as before
100000 loops, best of 3: 10.5 us per loop  # current master
100000 loops, best of 3: 10.1 us per loop  # this PR

a = np.arange(1000).astype('S')
b = np.arange(100).astype('S')
%timeit np.putmask(a, m, b)
100000 loops, best of 3: 13.3 us per loop  # current master
100000 loops, best of 3: 10 us per loop  # this PR
```
