### PR TITLE
ENH: speed-up in1d replacing sorting with fancy indexing

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -392,12 +392,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     else:
         bool_ar = (sar[1:] == sar[:-1])
     flag = np.concatenate((bool_ar, [invert]))
-    indx = order.argsort(kind='mergesort')[:len(ar1)]
+    ret = np.empty(ar.shape, dtype=bool)
+    ret[order] = flag
 
     if assume_unique:
-        return flag[indx]
+        return ret[:len(ar1)]
     else:
-        return flag[indx][rev_idx]
+        return ret[rev_idx]
 
 def union1d(ar1, ar2):
     """


### PR DESCRIPTION
This uses a similar trick as in #5012, this time in `np.in1d`: to rescramble a sorted array, use fancy indexing instead of `argsort`-ing the result of the original `argsort`. Performance improvement is noticeable, about 25% faster for the following example:

```
import numpy as np
np.random.seed(0)
a = np.random.randint(2000, size=1000)
b = np.random.randint(2000, size=1000)
%timeit np.in1d(a, b)
1000 loops, best of 3: 227 us per loop  # current master
10000 loops, best of 3: 183 us per loop  # this PR
```
