### PR TITLE
BUG: Savetxt may ignore newline character on Windows

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -140,6 +140,15 @@ views returned from *np.einsum* are writeable
 Views returned by *np.einsum* will now be writeable whenever the input
 array is writeable.
 
+*savetxt* always opens output files in mode='wb'
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This was already the case in Python3, but in Python2 the files were opened
+as text files. This change may affect line separators on Windows and Mac if
+linesep='\n' was explicitly used in the call in the expectation that it
+would be automatically converted to the os appropriate value. The default
+value is now os.linesep instead of '\n', which will affect the results
+for Python3 on Windows and Mac, as those files were already opened as 'wb'.
+
 
 Deprecations
 ============

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -908,8 +908,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         return X
 
 
-def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
-            footer='', comments='# '):
+def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=os.linesep,
+            header='', footer='', comments='# '):
     """
     Save an array to a text file.
 
@@ -1034,10 +1034,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             import gzip
             fh = gzip.open(fname, 'wb')
         else:
-            if sys.version_info[0] >= 3:
-                fh = open(fname, 'wb')
-            else:
-                fh = open(fname, 'w')
+            fh = open(fname, 'wb')
     elif hasattr(fname, 'write'):
         fh = fname
     else:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -935,8 +935,11 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=os.linesep,
                 e.g. `['%.3e + %.3ej', '(%.15e%+.15ej)']` for 2 columns
     delimiter : str, optional
         String or character separating columns.
-    newline : str, optional
-        String or character separating lines.
+    newline : {os.linesep, str}, optional
+        String or character separating lines. Because output files are
+        opened in mode='wb', this must be the complete line ending; ``\n``
+        will not be converted to ``\r\n`` on Windows. The default is
+        ``os.linesep``.
 
         .. versionadded:: 1.5.0
     header : str, optional

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -216,7 +216,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
         l = np.load(c)
         assert_equal(a, l['file_a'])
         assert_equal(b, l['file_b'])
-    
+
     def test_BagObj(self):
         a = np.array([[1, 2], [3, 4]], float)
         b = np.array([[1 + 2j, 2 + 7j], [3 - 6j, 4 + 12j]], complex)
@@ -489,15 +489,20 @@ class TestSaveTxt(TestCase):
         a = np.array([(1, 2, 3)], dtype=np.int)
         a = a.reshape((3, 1))
         for newline in ['\n', '\r\n', '\r']:
-            filename = mktemp()
+            # we need a real file to test the correct path. The temporary
+            # file created needs to be closed before it can be reopened on
+            # windows.
+            output = NamedTemporaryFile(delete=False)
+            output.close()
+            filename = output.name
             np.savetxt(filename, a, fmt='%i', newline=newline)
             b = np.loadtxt(filename)
             assert_array_equal(a.flat, b)
             f = open(filename, 'rb')
             d = f.read()
             f.close()
-            os.unlink(filename)
-            assert_equal(d, newline.join(['1', '2', '3', '']))
+            os.remove(filename)
+            assert_equal(d, asbytes(newline.join(['1', '2', '3', ''])))
 
 
 class TestLoadTxt(TestCase):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -485,6 +485,20 @@ class TestSaveTxt(TestCase):
         b = np.loadtxt(w)
         assert_array_equal(a, b)
 
+    def test_newline(self):
+        a = np.array([(1, 2, 3)], dtype=np.int)
+        a = a.reshape((3, 1))
+        for newline in ['\n', '\r\n', '\r']:
+            filename = mktemp()
+            np.savetxt(filename, a, fmt='%i', newline=newline)
+            b = np.loadtxt(filename)
+            assert_array_equal(a.flat, b)
+            f = open(filename, 'rb')
+            d = f.read()
+            f.close()
+            os.unlink(filename)
+            assert_equal(d, newline.join(['1', '2', '3', '']))
+
 
 class TestLoadTxt(TestCase):
     def test_record(self):


### PR DESCRIPTION
Under some circumstances savetxt ignores the newline character on Python
2.7 running on Windows: If newline is set to '\n', actually '\n\r' is
written, because of the linesep conversion of file.write.

Closes #3975.

Cleanup of #3976.
