### PR TITLE
ENH: Add support for float hex format to loadtxt.

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -139,6 +139,11 @@ fallback implementations of the following functions.
 As a result of these improvements, there will be some small changes in
 returned values, especially for corner cases.
 
+*np.loadtxt* support for the strings produced by the ``float.hex`` method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The strings produced by ``float.hex`` look like ``0x1.921fb54442d18p+1``,
+so this is not the hex used to represent unsigned integer types.
+
 
 Changes
 =======

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -621,6 +621,13 @@ def _savez(file, args, kwds, compress):
 
 def _getconv(dtype):
     """ Find the correct dtype converter. Adapted from matplotlib """
+
+    def floatconv(x):
+        x.lower()
+        if b'0x' in x:
+            return float.fromhex(asstr(x))
+        return float(x)
+
     typ = dtype.type
     if issubclass(typ, np.bool_):
         return lambda x: bool(int(x))
@@ -631,7 +638,7 @@ def _getconv(dtype):
     if issubclass(typ, np.integer):
         return lambda x: int(float(x))
     elif issubclass(typ, np.floating):
-        return float
+        return floatconv
     elif issubclass(typ, np.complex):
         return complex
     elif issubclass(typ, np.bytes_):
@@ -705,6 +712,10 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     This function aims to be a fast reader for simply formatted files.  The
     `genfromtxt` function provides more sophisticated handling of, e.g.,
     lines with missing values.
+
+    .. versionadded:: 1.10.0
+    The strings produced by the Python float.hex method can be used as
+    input for floats.
 
     Examples
     --------

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -694,6 +694,19 @@ class TestLoadTxt(TestCase):
         res = np.loadtxt(c, dtype=np.int64)
         assert_equal(res, tgt)
 
+    def test_from_float_hex(self):
+        # IEEE doubles and floats only, otherwise the float32
+        # conversion may fail.
+        tgt = np.logspace(-10, 10, 5).astype(np.float32)
+        tgt = np.hstack((tgt, -tgt)).astype(np.float)
+        inp = '\n'.join(map(float.hex, tgt))
+        c = TextIO()
+        c.write(inp)
+        for dt in [np.float, np.float32]:
+            c.seek(0)
+            res = np.loadtxt(c, dtype=dt)
+            assert_equal(res, tgt, err_msg="%s" % dt)
+
     def test_universal_newline(self):
         f, name = mkstemp()
         os.write(f, b'1 21\r3 42\r')


### PR DESCRIPTION
Add _floatconv to npyio.py as a default floating point converter. This
uses float() as a type conversion with a fallback on (ValueError) to
float.fromhex().

Closes #2517.

Cleanup of #133.
