### PR TITLE
BUG: Fix recarray getattr and getindex return types

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -61,6 +61,15 @@ C API
 The changes to *swapaxes* also apply to the *PyArray_SwapAxes* C function,
 which now returns a view in all cases.
 
+recarray field return types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously the returned types for recarray fields accessed by attribute and by
+index were inconsistent, and fields of string type were returned as chararrays.
+Now, fields accessed by either attribute or indexing will return an ndarray for
+fields of non-structured type, and a recarray for fields of structured type.
+Notably, this affect recarrays containing strings with whitespace, as trailing
+whitespace is trimmed from chararrays but kept in ndarrays of string type.
+Also, the dtype.type of nested structured fields is now inherited.
 
 New Features
 ============

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -124,6 +124,28 @@ class TestFromrecords(TestCase):
         assert_equal(a.b, ['a', 'bbb'])
         assert_equal(a[-1].b, 'bbb')
 
+    def test_recarray_stringtypes(self):
+        # Issue #3993
+        a = np.array([('abc ', 1), ('abc', 2)],
+                     dtype=[('foo', 'S4'), ('bar', int)])
+        a = a.view(np.recarray)
+        assert_equal(a.foo[0] == a.foo[1], False)
+
+    def test_recarray_returntypes(self):
+        a = np.rec.array([('abc ', (1,1), 1), ('abc', (2,3), 1)],
+                         dtype=[('foo', 'S4'),
+                                ('bar', [('A', int), ('B', int)]),
+                                ('baz', int)])
+        assert_equal(type(a.foo), np.ndarray)
+        assert_equal(type(a['foo']), np.ndarray)
+        assert_equal(type(a.bar), np.recarray)
+        assert_equal(type(a['bar']), np.recarray)
+        assert_equal(a.bar.dtype.type, np.record)
+        assert_equal(type(a.baz), np.ndarray)
+        assert_equal(type(a['baz']), np.ndarray)
+        assert_equal(type(a[0].bar), np.record)
+        assert_equal(a[0].bar.A, 1)
+
 
 class TestRecord(TestCase):
     def setUp(self):

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -268,6 +268,10 @@ array if the field has a structured type but as a plain ndarray otherwise. ::
  >>> type(recordarr.bar)
  <class 'numpy.core.records.recarray'>
 
+Note that if a field has the same name as an ndarray attribute, the ndarray
+attribute takes precedence. Such fields will be inaccessible by attribute but
+may still be accessed by index.
+
 Partial Attribute Access
 ------------------------
 


### PR DESCRIPTION
This pull request was originally requested as https://github.com/numpy/numpy/pull/5454, but I moved it here because it was on the wrong branch, plus other reasons.

This pull request makes changes to `__getitem__` and `__getattr__` of recarrays. It makes three notable changes:

A. recarrays no longer convert string ndarrays to chararrays, and instead simply return ndarrays of string type.

This was confusing, and led to bugs for anyone unaware of this special conversion (ie, me) since chararrays trim trailing whitespace but ndarrays fo string type do not, and because it only occured when the field was accessed by attribute (not index).

Old behavior:

```
>>> rec = np.rec.array([('abc ', (1,1), 1), ('abc', (2,3), 1)],
...       dtype=[('foo', 'S4'), ('bar', [('A', int), ('B', int)]), ('baz', int)])
>>> rec.foo[0] == rec.foo[1]
True
>>> rec['foo'][0] == rec['foo'][1]
False
```

New behavior: Both lines return False.

I think this is the main compatability risk in this pull request, as some people might have _expected_ the whitespace removal. But I didn't see anything in a quick github search.

B: the return type of fields accessed by index and by attribute was inconsistent for flexible types.

Previous behavior:

```
>>> type(rec.foo), type(rec['foo'])
(numpy.core.defchararray.chararray, numpy.recarray)
>>> type(rec.bar), type(rec['bar'])
(numpy.recarray, numpy.recarray)
>>> type(rec.baz), type(rec['baz'])
(numpy.ndarray, numpy.ndarray)
```

New behavior:

```
>>> type(rec.foo), type(rec['foo'])
(numpy.ndarray, numpy.ndarray)
>>> type(rec.bar), type(rec['bar'])
(numpy.recarray, numpy.recarray)
>>> type(rec.baz), type(rec['baz'])
(numpy.ndarray, numpy.ndarray)
```

C. dtype.type is now inherited when fields of structured type are accessed

Old Behavior:

```
>>> rec.dtype.type, rec.bar.dtype.type
(numpy.record, numpy.void)
```

New behavior:

```
>>> rec.dtype.type, rec.bar.dtype.type
(numpy.record, numpy.record)
```

This guarantees that if an array is a "record" array, structured fields will also be returned as "record arrays" (rather than merely views of np.recarray).

I am planning two more recarray-related pull requests: One to fix `recarray.__repr__`, and another to reduce dependence on `numpy.rec.format_parser`, which duplicates logic in the descriptor.c parser.
