### PR TITLE
Bugfix (and test) for issue 2972

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2294,7 +2294,8 @@ def _recursive_printoption(result, mask, printopt):
     """
     names = result.dtype.names
     for name in names:
-        (curdata, curmask) = (result[name], mask[name])
+        curdata = result[name]
+        curmask = mask if mask.dtype.fields is None else mask[name]
         if curdata.dtype.names:
             _recursive_printoption(curdata, curmask, printopt)
         else:
@@ -3070,7 +3071,12 @@ class MaskedArray(ndarray):
                 dout._isfield = True
             # Update the mask if needed
             if _mask is not nomask:
-                dout._mask = _mask[indx]
+                if (_mask.dtype.fields is None
+                        and self.dtype.fields is not None
+                        and isinstance(indx, str)):
+                    dout._mask = _mask
+                else:
+                    dout._mask = _mask[indx]
                 dout._sharedmask = True
 #               Note: Don't try to check for m.any(), that'll take too long...
         return dout

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3581,6 +3581,18 @@ class TestMaskedFields(TestCase):
         for rec in self.data['base']:
             assert_equal(len(rec), len(self.data['ddtype']))
 
+    def test_fieldless_mask(self):
+        # check that item-getting and representation do not fail when the
+        # mask is not structured.  See issue #2072.
+        ndtype = [('a', float), ('b', float)]
+        a = array(list(zip(np.arange(3), np.arange(3))), dtype=ndtype)
+        a._mask = numpy.zeros(shape=a.shape, dtype="?")
+        assert_equal(a["a"].data, a.data["a"])
+        assert_equal(a.__repr__(), "masked_array(data = [(0.0, 0.0) (1.0, 1.0) (2.0, 2.0)],\n"
+                    "             mask = [False False False],\n"
+                    "       fill_value = (1e+20, 1e+20),\n"
+                    "            dtype = [('a', '<f8'), ('b', '<f8')])\n")
+
 
 #------------------------------------------------------------------------------
 class TestMaskedView(TestCase):


### PR DESCRIPTION
This pull request fixed issue #2972: when a masked array has structured data, but an unstructured mask, both **getitem** and **repr** will prance and fail.
