### PR TITLE
Fix #2972, ensure masked_where gives structured mask for structured masked array

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1815,7 +1815,7 @@ def masked_where(condition, a, copy=True):
     else:
         cls = MaskedArray
     result = a.view(cls)
-    result._mask = cond
+    result.mask = cond
     return result
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2985,6 +2985,13 @@ class TestMaskedArrayFunctions(TestCase):
         test = masked_equal(a, 1)
         assert_equal(test.mask, [0, 1, 0, 0, 0, 0, 0, 0, 0, 0])
 
+    def test_masked_where_structured(self):
+        # test that masked_where on a structured array sets a structured
+        # mask (see issue #2972)
+        a = np.zeros(10, dtype=[("A", "<f2"), ("B", "<f4")])
+        am = numpy.ma.masked_where(a["A"]<5, a)
+        assert_equal(am.mask.dtype.names, am.dtype.names)
+
     def test_masked_otherfunctions(self):
         assert_equal(masked_inside(list(range(5)), 1, 3),
                      [0, 199, 199, 199, 4])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2989,8 +2989,10 @@ class TestMaskedArrayFunctions(TestCase):
         # test that masked_where on a structured array sets a structured
         # mask (see issue #2972)
         a = np.zeros(10, dtype=[("A", "<f2"), ("B", "<f4")])
-        am = numpy.ma.masked_where(a["A"]<5, a)
+        am = np.ma.masked_where(a["A"]<5, a)
         assert_equal(am.mask.dtype.names, am.dtype.names)
+        assert_equal(am["A"],
+                    np.ma.masked_array(np.zeros(10), np.ones(10)))
 
     def test_masked_otherfunctions(self):
         assert_equal(masked_inside(list(range(5)), 1, 3),


### PR DESCRIPTION
This pull request fixes bug #2972, caused by a bug in `numpy.ma.masked_where` when it is passed a
structured array.  `masked_where` was inadvertently setting the _mask field
of a structured array to a non-structured array, so we would end up with
a masked structured array where `x.data` was structured, but `x.mask` was not.
This would lead to troubles for methods such as `__getitem__`,`**repr**`, and
`tolist`.  By writing to`.mask`instead of`._mask`, this problem is
mitigated.

This is an alternative solution to pull request #5513.
