### PR TITLE
ENH: PyArray_FromInterface checks descr if typestr is np.void

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -46,9 +46,11 @@ def as_strided(x, shape=None, strides=None, subok=False):
     if strides is not None:
         interface['strides'] = tuple(strides)
     array = np.asarray(DummyArray(interface, base=x))
-    # Make sure dtype is correct in case of custom dtype
-    if array.dtype.kind == 'V':
+
+    if array.dtype.fields is None and x.dtype.fields is not None:
+        # This should only happen if x.dtype is [('', 'Vx')]
         array.dtype = x.dtype
+
     return _maybe_view_as_subclass(x, array)
 
 


### PR DESCRIPTION
When the 'typestr' member of the **array_interface** dictionary defines
a np.void dtype, check the 'descr' member, and if it is a valid dtype
description and it is not the default one, use it to construct the
dtype for the array to return.

This fixes #5081, as as_strided no longer has to worry about changing
the dtype of the return.
