### PR TITLE
BUG: recarray __repr__ gives inaccurate representation

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -485,9 +485,28 @@ class recarray(ndarray):
             # return a single element
             return obj
 
-    def __repr__(self) :
-        ret = ndarray.__repr__(self)
-        return ret.replace("recarray", "rec.array", 1)
+    def __repr__(self):
+        # get data/shape string. logic taken from numeric.array_repr
+        if self.size > 0 or self.shape==(0,):
+            lst = sb.array2string(self, separator=', ')
+        else:
+            # show zero-length shape unless it is (0,)
+            lst = "[], shape=%s" % (repr(self.shape),)
+
+        if self.dtype.type is record:
+            # If this is a full record array (has numpy.record dtype),
+            # represent it using the rec.array function. Since rec.array
+            # converts dtype to a numpy.record for us, use only dtype.descr,
+            # not repr(dtype).
+            lf = '\n'+' '*len("rec.array(")
+            return ('rec.array(%s, %sdtype=%s)' %
+                          (lst, lf, repr(self.dtype.descr)))
+        else:
+            # otherwise represent it using np.array plus a view
+            # (There is currently (v1.10) no other easy way to create it)
+            lf = '\n'+' '*len("array(")
+            return ('array(%s, %sdtype=%s).view(numpy.recarray)' %
+                          (lst, lf, str(self.dtype)))
 
     def field(self, attr, val=None):
         if isinstance(attr, int):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -73,10 +73,27 @@ class TestFromrecords(TestCase):
             assert_((mine.data2[i] == 0.0))
 
     def test_recarray_from_repr(self):
-        x = np.rec.array([ (1, 2)], dtype=[('a', np.int8), ('b', np.int8)])
-        y = eval("numpy." + repr(x), {'numpy': np})
-        assert_(isinstance(y, np.recarray))
-        assert_equal(y, x)
+        a = np.array([(1,'ABC'), (2, "DEF")],
+                     dtype=[('foo', int), ('bar', 'S4')])
+        recordarr = np.rec.array(a)
+        recarr = a.view(np.recarray)
+        recordview = a.view(np.dtype((np.record, a.dtype)))
+
+        recordarr_r = eval("numpy." + repr(recordarr), {'numpy': np})
+        recarr_r = eval("numpy." + repr(recarr), {'numpy': np})
+        recordview_r = eval("numpy." + repr(recordview), {'numpy': np})
+
+        assert_equal(type(recordarr_r), np.recarray)
+        assert_equal(recordarr_r.dtype.type, np.record)
+        assert_equal(recordarr, recordarr_r)
+
+        assert_equal(type(recarr_r), np.recarray)
+        assert_equal(recarr_r.dtype.type, np.void)
+        assert_equal(recarr, recarr_r)
+
+        assert_equal(type(recordview_r), np.ndarray)
+        assert_equal(recordview.dtype.type, np.record)
+        assert_equal(recordview, recordview_r)
 
     def test_recarray_from_names(self):
         ra = np.rec.array([

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -292,7 +292,7 @@ such a view do not have field attributes::
 To use the np.record dtype only, convert the dtype using the (base_class,
 dtype) form described in numpy.dtype.  This type of view is rarely used. ::
 
- >>> arr_records = arr.view(dtype(np.record, arr.dtype))
+ >>> arr_records = arr.view(dtype((np.record, arr.dtype)))
 
 In documentation, the term 'structured array' will refer to objects of type
 np.ndarray with structured dtype, 'record array' will refer to structured


### PR DESCRIPTION
This is a followup to https://github.com/numpy/numpy/pull/5483, with the goal of solving https://github.com/numpy/numpy/issues/3581, 

In https://github.com/numpy/numpy/pull/5483, I solved the problem that a "recarray" and a "record array" (nomenclature defined in https://github.com/numpy/numpy/pull/5482) looked identical by making sure that a type's subclass was listed in the repr. However, there is still the problem that recarrays are represented using the function 'rec.array' even though this function technically creates record arrays, not recarrays.

So I have updated `recarray.__repr__` to give accurate representations. Demonstration:

Setup: 

```
>>> a = np.array([(1,'ABC'), (2, "DEF")], dtype=[('foo', int), ('bar', 'S4')])
>>> recordarr = np.rec.array(a)
>>> recarr = a.view(np.recarray)
>>> recordview = a.view(dtype((np.record, a.dtype)))
```

(Very) Old Behavior:

```
>>> recordarr
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
>>> recarr
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
>>> recordview
array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
```

Behavior after https://github.com/numpy/numpy/pull/5483:

```
>>> recordarr
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=(numpy.record, [('foo', '<i8'), ('bar', 'S4')]))
>>> recarr
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')])
>>> recordview
array([(1, 'ABC'), (2, 'DEF')], 
      dtype=(numpy.record, [('foo', '<i8'), ('bar', 'S4')]))
```

New Behavior:

```
>>> recordarr
rec.array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', '|S4')])
>>> recarr
array([(1, 'ABC'), (2, 'DEF')], 
      dtype=[('foo', '<i8'), ('bar', 'S4')]).view(numpy.recarray)
>>> recordview
array([(1, 'ABC'), (2, 'DEF')], 
      dtype=(numpy.record, [('foo', '<i8'), ('bar', 'S4')]))
```

Representing the recarr using `array` plus a view seems a little clunky, but there aren't many other options. The only other option I can think of is to use the recarray constructor, but that seems even clunkier since it has a totally different signature.

However, perhaps the clunkier description will be motivation for people to always use np.rec.array, and help emphasize that taking `view(np.recarray)` gives you a weird hybrid.

Also, I now get some extra `|` in the dtype since I use dtype.descr, hopefully that's acceptable.

I also fixed some missing parentheses in the record array docs.
