### PR TITLE
Return output from nm command as string (and not bytes)

### DIFF
--- a/numpy/distutils/lib2def.py
+++ b/numpy/distutils/lib2def.py
@@ -69,7 +69,7 @@ nm_output = getnam(nm_cmd = 'nm -Cs py_lib')"""
     f = subprocess.Popen(nm_cmd, shell=True, stdout=subprocess.PIPE)
     nm_output = f.stdout.read()
     f.stdout.close()
-    return nm_output
+    return nm_output.decode('ascii')
 
 def parse_nm(nm_output):
     """Returns a tuple of lists: dlist for the list of data

--- a/numpy/distutils/lib2def.py
+++ b/numpy/distutils/lib2def.py
@@ -66,10 +66,10 @@ def getnm(nm_cmd = ['nm', '-Cs', 'python%s.lib' % py_ver]):
     """Returns the output of nm_cmd via a pipe.
 
 nm_output = getnam(nm_cmd = 'nm -Cs py_lib')"""
-    f = subprocess.Popen(nm_cmd, shell=True, stdout=subprocess.PIPE)
+    f = subprocess.Popen(nm_cmd, shell=True, stdout=subprocess.PIPE, universal_newlines=True)
     nm_output = f.stdout.read()
     f.stdout.close()
-    return nm_output.decode('ascii')
+    return nm_output
 
 def parse_nm(nm_output):
     """Returns a tuple of lists: dlist for the list of data


### PR DESCRIPTION
The output from nm (from `lib2def.getnm()`) is bytes. Afterwards, when `parse_nm` parses this data using a string regex, this fails with 

```
  File "C:\appl\ana3_32\envs\modelica\lib\site-packages\numpy\distutils\lib2def.py", line 80, in parse_nm
    data = DATA_RE.findall(nm_output)
TypeError: can't use a string pattern on a bytes-like object
```

A fix that works for me is to decode the nm output as an ascii string.
