### PR TITLE
genfromtxt example in user docs missing delimiter

### DIFF
--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -94,12 +94,12 @@ This behavior can be overwritten by setting the optional argument
 
    >>> data = "1, abc , 2\n 3, xxx, 4"
    >>> # Without autostrip
-   >>> np.genfromtxt(StringIO(data), dtype="|S5")
+   >>> np.genfromtxt(StringIO(data), delimiter=",", dtype="|S5")
    array([['1', ' abc ', ' 2'],
           ['3', ' xxx', ' 4']],
          dtype='|S5')
    >>> # With autostrip
-   >>> np.genfromtxt(StringIO(data), dtype="|S5", autostrip=True)
+   >>> np.genfromtxt(StringIO(data), delimiter=",", dtype="|S5", autostrip=True)
    array([['1', 'abc', '2'],
           ['3', 'xxx', '4']],
          dtype='|S5')


### PR DESCRIPTION
The example given in the user docs does not run correctly without adding `delimiter=","`. This add the missing keyword to allow the examples to be run.
