### PR TITLE
Fix 'dimensions' typo in numpy.kron() help message

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -685,7 +685,7 @@ def kron(a,b):
     Notes
     -----
 
-    The function assumes that the number of dimenensions of `a` and `b`
+    The function assumes that the number of dimensions of `a` and `b`
     are the same, if necessary prepending the smallest with ones.
     If `a.shape = (r0,r1,..,rN)` and `b.shape = (s0,s1,...,sN)`,
     the Kronecker product has shape `(r0*s0, r1*s1, ..., rN*SN)`.


### PR DESCRIPTION
This bug was reported in Debian as: http://bugs.debian.org/777172 .
