### PR TITLE
Update docstring of ma.extras.average to reflect actual behavior

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -497,8 +497,9 @@ def average(a, axis=None, weights=None, returned=False):
         The average along the specified axis. When returned is `True`,
         return a tuple with the average as the first element and the sum
         of the weights as the second element. The return type is `np.float64`
-        if `a` is of integer type, otherwise it is of the same type as `a`.
-        If returned, `sum_of_weights` is of the same type as `average`.
+        if `a` is of integer type and floats smaller than `float64`, or the
+        input data-type, otherwise. If returned, `sum_of_weights` is always
+        `float64`.
 
     Examples
     --------


### PR DESCRIPTION
The docstring of `numpy.ma.average` currently says that

```
The return type is `np.float64` if `a` is of integer type, otherwise it is of the 
same type as `a`. If returned, `sum_of_weights` is of the same type as `average`.
```

In fact, `average`, like the other functions in `numpy/ma/extras.py`, returns `float64` for `float` input that is smaller than `float64`. In addition, the returned `sum_of_weights` is always `float64`.

This PR updates the docstring to clarify what `average` will return.
