### PR TITLE
Add contribution guidelines that github will automatically display

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to numpy
+
+## Reporting issues
+
+When reporting issues please include as much detail as possible about your
+operating system, numpy version and python version. Whenever possible, please
+also include a brief code example that demonstrates the problem.
+
+## Contributing code
+
+Thanks for your interest in contributing code to numpy!
+
++ If this is your first time contributing to a project on GitHub, please read
+through our
+[guide to contributing to numpy](http://docs.scipy.org/doc/numpy-dev/dev/index.html)
++ If you have contributed to other projects on GitHub you can go straight to our
+[development workflow](http://docs.scipy.org/doc/numpy-dev/dev/gitwash/development_workflow.html)
+
+Either way, please be sure to follow our
+[convention for commit messages](http://docs.scipy.org/doc/numpy-dev/dev/gitwash/development_workflow.html).
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,11 @@
 
 When reporting issues please include as much detail as possible about your
 operating system, numpy version and python version. Whenever possible, please
-also include a brief code example that demonstrates the problem.
+also include a brief, self-contained code example that demonstrates the problem.
+
+If you are reporting a segfault please include a GDB traceback, which you can
+generate by following
+[these instructions.](https://github.com/numpy/numpy/blob/master/doc/source/dev/development_environment.rst#debugging)
 
 ## Contributing code
 


### PR DESCRIPTION
I thought this might be helpful in ensuring that contributions follow the workflow you recommend and your commit message convention. Github will automatically display a link to a file called `CONTRIBUTING` or `CONTRIBUTING.md` if it exists in the base of the repo. 

More information about this github feature is at: https://help.github.com/articles/setting-guidelines-for-repository-contributors/

Let me know if you want any revisions to this!
