### PR TITLE
ENH: structured datatype safety checks

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -305,6 +305,174 @@ def _index_fields(ary, fields):
     copy_dtype = {'names':view_dtype['names'], 'formats':view_dtype['formats']}
     return array(view, dtype=copy_dtype, copy=True)
 
+def _get_all_field_offsets(dtype, base_offset=0):
+    """ Returns the types and offsets of all fields in a (possibly structured)
+    data type, including nested fields and subarrays.
+
+    Parameters
+    ----------
+    dtype : data-type
+        Data type to extract fields from.
+    base_offset : int, optional
+        Additional offset to add to all field offsets.
+
+    Returns
+    -------
+    fields : list of (data-type, int) pairs
+        A flat list of (dtype, byte offset) pairs.
+
+    """
+    fields = []
+    if dtype.fields is not None:
+        for name in dtype.names:
+           sub_dtype = dtype.fields[name][0]
+           sub_offset = dtype.fields[name][1] + base_offset
+           fields.extend(_get_all_field_offsets(sub_dtype, sub_offset))
+    else:
+        if dtype.shape:
+            sub_offsets = _get_all_field_offsets(dtype.base, base_offset)
+            count = 1
+            for dim in dtype.shape:
+                count *= dim
+            fields.extend((typ, off + dtype.base.itemsize*j)
+                           for j in range(count) for (typ, off) in sub_offsets)
+        else:
+            fields.append((dtype, base_offset))
+    return fields
+
+def _check_field_overlap(new_fields, old_fields):
+    """ Perform object memory overlap tests for two data-types (see
+    _view_is_safe).
+
+    This function checks that new fields only access memory contained in old
+    fields, and that non-object fields are not interpreted as objects and vice
+    versa.
+
+    Parameters
+    ----------
+    new_fields : list of (data-type, int) pairs
+        Flat list of (dtype, byte offset) pairs for the new data type, as
+        returned by _get_all_field_offsets.
+    old_fields: list of (data-type, int) pairs
+        Flat list of (dtype, byte offset) pairs for the old data type, as
+        returned by _get_all_field_offsets.
+
+    Raises
+    ------
+    TypeError
+        If the new fields are incompatible with the old fields
+
+    """
+    from .numerictypes import object_
+    from .multiarray import dtype
+
+    #first go byte by byte and check we do not access bytes not in old_fields
+    new_bytes = set()
+    for tp, off in new_fields:
+        new_bytes.update(set(range(off, off+tp.itemsize)))
+    old_bytes = set()
+    for tp, off in old_fields:
+        old_bytes.update(set(range(off, off+tp.itemsize)))
+    if new_bytes.difference(old_bytes):
+        raise TypeError("view would access data parent array doesn't own")
+
+    #next check that we do not interpret non-Objects as Objects, and vv
+    obj_offsets = [off for (tp, off) in old_fields if tp.type is object_]
+    obj_size = dtype(object_).itemsize
+
+    for fld_dtype, fld_offset in new_fields:
+        if fld_dtype.type is object_:
+            # check we do not create object views where
+            # there are no objects.
+            if fld_offset not in obj_offsets:
+                raise TypeError("cannot view non-Object data as Object type")
+        else:
+            # next check we do not create non-object views
+            # where there are already objects.
+            # see validate_object_field_overlap for a similar computation.
+            for obj_offset in obj_offsets:
+                if (fld_offset < obj_offset + obj_size and
+                        obj_offset < fld_offset + fld_dtype.itemsize):
+                    raise TypeError("cannot view Object as non-Object type")
+
+def _getfield_is_safe(oldtype, newtype, offset):
+    """ Checks safety of getfield for object arrays.
+
+    As in _view_is_safe, we need to check that memory containing objects is not
+    reinterpreted as a non-object datatype and vice versa.
+
+    Parameters
+    ----------
+    oldtype : data-type
+        Data type of the original ndarray.
+    newtype : data-type
+        Data type of the field being accessed by ndarray.getfield
+    offset : int
+        Offset of the field being accessed by ndarray.getfield
+
+    Raises
+    ------
+    TypeError
+        If the field access is invalid
+
+    """
+    new_fields = _get_all_field_offsets(newtype, offset)
+    old_fields = _get_all_field_offsets(oldtype)
+    # raises if there is a problem
+    _check_field_overlap(new_fields, old_fields)
+
+def _view_is_safe(oldtype, newtype):
+    """ Checks safety of a view involving object arrays, for example when
+    doing::
+
+        np.zeros(10, dtype=oldtype).view(newtype)
+
+    We need to check that
+    1) No memory that is not an object will be interpreted as a object,
+    2) No memory containing an object will be interpreted as an arbitrary type.
+    Both cases can cause segfaults, eg in the case the view is written to.
+    Strategy here is to also disallow views where newtype has any field in a
+    place oldtype doesn't.
+
+    Parameters
+    ----------
+    oldtype : data-type
+        Data type of original ndarray
+    newtype : data-type
+        Data type of the view
+
+    Raises
+    ------
+    TypeError
+        If the new type is incompatible with the old type.
+
+    """
+    new_fields = _get_all_field_offsets(newtype)
+    new_size = newtype.itemsize
+
+    old_fields = _get_all_field_offsets(oldtype)
+    old_size = oldtype.itemsize
+
+    # if the itemsizes are not equal, we need to check that all the
+    # 'tiled positions' of the object match up. Here, we allow
+    # for arbirary itemsizes (even those possibly disallowed
+    # due to stride/data length issues).
+    if old_size ==  new_size:
+        new_num = old_num = 1
+    else:
+        gcd_new_old = _gcd(new_size, old_size)
+        new_num = old_size // gcd_new_old
+        old_num = new_size // gcd_new_old
+
+    # get position of fields within the tiling
+    new_fieldtile = [(tp, off + new_size*j)
+                     for j in range(new_num) for (tp, off) in new_fields]
+    old_fieldtile = [(tp, off + old_size*j)
+                     for j in range(old_num) for (tp, off) in old_fields]
+
+    # raises if there is a problem
+    _check_field_overlap(new_fieldtile, old_fieldtile)
+
 # Given a string containing a PEP 3118 format specifier,
 # construct a Numpy dtype
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -219,6 +219,15 @@ class TestRecord(TestCase):
         assert_equal(a, pickle.loads(pickle.dumps(a)))
         assert_equal(a[0], pickle.loads(pickle.dumps(a[0])))
 
+    def test_objview_record(self):
+        # https://github.com/numpy/numpy/issues/2599
+        dt = np.dtype([('foo', 'i8'), ('bar', 'O')])
+        r = np.zeros((1,3), dtype=dt).view(np.recarray)
+        r.foo = np.array([1, 2, 3]) # TypeError?
+
+        # https://github.com/numpy/numpy/issues/3256
+        ra = np.recarray((2,), dtype=[('x', object), ('y', float), ('z', int)])
+        ra[['x','y']] #TypeError?
 
 def test_find_duplicate():
     l1 = [1, 2, 3, 4, 5, 6]

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1739,10 +1739,9 @@ class TestRegression(TestCase):
         assert_equal(np.add.accumulate(x[:-1, 0]), [])
 
     def test_objectarray_setfield(self):
-        # Setfield directly manipulates the raw array data,
-        # so is invalid for object arrays.
+        # Setfield should not overwrite Object fields with non-Object data
         x = np.array([1, 2, 3], dtype=object)
-        assert_raises(RuntimeError, x.setfield, 4, np.int32, 0)
+        assert_raises(TypeError, x.setfield, 4, np.int32, 0)
 
     def test_setting_rank0_string(self):
         "Ticket #1736"

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -700,6 +700,36 @@ class TestJoinBy2(TestCase):
         assert_equal(test.dtype, control.dtype)
         assert_equal(test, control)
 
+class TestAppendFieldsObj(TestCase):
+    """
+    Test append_fields with arrays containing objects
+    """
+    # https://github.com/numpy/numpy/issues/2346
+
+    def setUp(self):
+        from datetime import date
+        self.data = dict(obj=date(2000, 1, 1))
+
+    def test_append_to_objects(self):
+        "Test append_fields when the base array contains objects"
+        obj = self.data['obj']
+        x = np.array([(obj, 1.), (obj, 2.)],
+                      dtype=[('A', object), ('B', float)])
+        y = np.array([10, 20], dtype=int)
+        test = append_fields(x, 'C', data=y, usemask=False)
+        control = np.array([(obj, 1.0, 10), (obj, 2.0, 20)],
+                           dtype=[('A', object), ('B', float), ('C', int)])
+        assert_equal(test, control)
+
+    def test_append_with_objects(self):
+        "Test append_fields when the appended data contains objects"
+        obj = self.data['obj']
+        x = np.array([(10, 1.), (20, 2.)], dtype=[('A', int), ('B', float)])
+        y = np.array([obj, obj], dtype=object)
+        test = append_fields(x, 'C', data=y, dtypes=object, usemask=False)
+        control = np.array([(10, 1.0, obj), (20, 2.0, obj)],
+                           dtype=[('A', int), ('B', float), ('C', object)])
+        assert_equal(test, control)
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
This PR tries to solve some issues related structured datatypes, especially view/getfield/setfield. Previously views of structured arrays containing objects were completely disabled.  This commit adds more lenient check for whether an object-array view is allowed, and adds similar checks to getfield/setfield

(This PR has been edited around 3/4/15. I originally planned other changes which I will submit as separate PRs)

I believe this PR solves issues https://github.com/numpy/numpy/issues/2599, https://github.com/numpy/numpy/issues/3256, https://github.com/numpy/numpy/issues/3286, https://github.com/numpy/numpy/issues/2346, https://github.com/numpy/numpy/issues/3253. Issue https://github.com/numpy/numpy/issues/5081 is also now partially fixed, but requires further thought (please take a look at the example there). It also fixes the new scipy issue https://github.com/scipy/scipy/issues/4589.

Only one test needed modification to pass: `test_objectarray_setfield` checks that `setfield` with objects is disallowed, and expects a `RuntimeError` but I give it `TypeError`.
### Summary

Previously views of structured arrays containing objects were completely disabled, which was a problem since views are needed in a few important cases such as when indexing multiple fields of a structured array, or in `__getitem__` in record arrays.

With help from @jaimefrio I now have functions that carefully check whether a view into array would interpret non-Object memory as an object, or vice versa, and allow the view if there is no problem. Big thanks to Jaime for help, code, and explanations on this. I think the checks are compatible with his PR https://github.com/numpy/numpy/pull/5508. I check that 1) No memory that is not an object will be interpreted as a object, 2) No memory containing an object will be interpreted as an arbitrary type. Both cases can cause segfaults.

I also added similar checks to `PyArray_GetField` and `PyArray_SetField`. Previsouly, the user could view arbitrary data as a python Object, and it was fairly easy to make cases where a segfault would happen.

Note, however, that there are still "unsafe" operations (wrt Objects) in numpy which I hope to examine in future PRs, when I have time.
### How to keep track of objects

There is a design choice here worth discussing. As part of the check for objects when taking a view, we need to go though the new dtypes's fields and make sure none of them overlap with memory containing an object in the old dtype (unless the field is also an object). Consider this potential view:

```
>>> basearr = np.array([(1,2,3),(4,5,6)], 
...                    dtype=[('f0', 'i8'), ('f1', 'O'), ('f2', 'i8')])
>>> varr = basearr.view({'names': ['f0','f2'], 
...                      'formats': ['i8','i8'], 
...                      'offsets': [0,16]})
>>> v2arr = varr.view({'names': ['f0'], 
...                    'formats': ['i8'], 
...                    'offsets': [8]})  
```

The problem would be that writing to v2arr will overwrite the Object in basearr. We need to prevent this, but the challenge is that `varr` doesn't "know" that there is an object at position 8. This raises the question: How do we figure out where the objects are in memory to prevent them from being viewed?

The strategy I have taken in this PR is to only allow views into fields "known" to the parent array. In the example above, the `v2arr` view would be disallowed, and only views of `varr` into offsets 0 and 16 would be allowed. (specifically, views into bytes 0-8 and 16-24). The downside is that many views are no longer "reversible", since once you take a view that "forgets" what was at an offset, you can never view the memory at that offset again in further views. While this constraint only really has to apply to object arrays (as tested with `NPY_ITEM_HASOBJECT`, which I think is inherited in all views) I think for consistency it should apply to all structured arrays.. That is, all 'partial' views (views that have less fields than the original array) would be irreversible.

An alternate strategy is to too look up all the object positions in the "base" object of the array, `varr.base` in this case. I assume that the "base" array (if it is an array) contains the list of all object offsets, which I use to check for view overlaps. I implemented this in a separate branch (partial version [here](https://github.com/ahaldane/numpy/tree/view_objects_base)), but it was difficult because `arr.base` does not always lead to an array object. For example it may be a buffer, in which case I disallow views containing object types, but that's not a big problem because users aren't allowed to create object arrays from buffers anyway. Another problem is (void) scalar structured types, as they do not list their "base" object even after being converted to a 0-d array. To fix this I made void scalar types' base attribute point to the original array. However, there are still some cases where I cannot get to the original array - for example `nditer` buffers the source array, which causes about 5 unit tests to fail, which I have not solved yet (but I could try). The advantage would be that views are reversible.

The irreversible view strategy seems better because it touches less parts, has fewer edge cases, and seems to me less likely to go wrong. It also works right now. I also have not imagined any scenarios where inability to reverse a view would be a big problem, and no related unit tests fail.

Note that even if the 'base array' strategy is not good, perhaps it's still a good idea to make void scalars "base" attribute point to the original array, as another PR? I admit I am not totally clear on the true purposes of "base" objects.

In this PR I also made some small tweaks to recarrays: I don't think they need to implement their own `view` function as a result of my last PRs.
