### PR TITLE
ENH: Increase numpy.average performance mentioned in #5507.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -514,7 +514,9 @@ def average(a, axis=None, weights=None, returned=False):
         avg = a.mean(axis)
         scl = avg.dtype.type(a.size/avg.size)
     else:
-        a = a + 0.0
+        if np.issubclass_(a.dtype.type, np.inexact) is False:
+            a = a.astype('float64')
+
         wgt = np.asarray(weights)
         # Sanity checks
         if a.shape != wgt.shape:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -514,7 +514,8 @@ def average(a, axis=None, weights=None, returned=False):
         avg = a.mean(axis)
         scl = avg.dtype.type(a.size/avg.size)
     else:
-        if not np.issubclass_(a.dtype.type, np.inexact):
+        # Cast bool, unsigned int, and int to float64 by default
+        if issubclass(a.dtype.type, (integer, bool)):
             a = a.astype('float64')
 
         wgt = np.asarray(weights)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -514,7 +514,9 @@ def average(a, axis=None, weights=None, returned=False):
         avg = a.mean(axis)
         scl = avg.dtype.type(a.size/avg.size)
     else:
-        a = a + 0.0
+        if np.issubclass(a.dtype.type, np.inexact) is False:
+            a = a.astype('float64')
+
         wgt = np.asarray(weights)
         # Sanity checks
         if a.shape != wgt.shape:


### PR DESCRIPTION
This numpy.inexact to determine if it is numpy.float64. If the data type not numpy.float64 then it uses astype() to convert to numpy.float64.
