### PR TITLE
DEV: Replace deprecated options for ifort.

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -152,7 +152,7 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     module_include_switch = '/I'
 
     def get_flags(self):
-        opt = ['/nologo', '/MD', '/nbs', '/Qlowercase', '/us']
+        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore']
         return opt
 
     def get_flags_free(self):


### PR DESCRIPTION
The `/Qlowercase` and `/us` options have been deprecated in the Intel Visual Fortran Compiler 
since at least version 2013.
Replace with `/names:lowercase` and `/assume:underscore.`

Fixes https://github.com/numpy/numpy/issues/5554
