### PR TITLE
Change to fully PEP440 compliant dev version numbers (always .dev0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def get_version_info():
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        FULLVERSION += '.dev+' + GIT_REVISION[:7]
+        FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 
     return FULLVERSION, GIT_REVISION
 


### PR DESCRIPTION
PEP440 requires .devN (where N is a non-negative integer). A similar change to scipy is proposed in PR https://github.com/scipy/scipy/pull/4512
