### PR TITLE
BUG: Avoid casting warning with masked arrays when using in-place operations

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3802,7 +3802,10 @@ class MaskedArray(ndarray):
         else:
             if m is not nomask:
                 self._mask += m
-        ndarray.__iadd__(self._data, np.where(self._mask, 0, getdata(other)))
+        ndarray.__iadd__(
+            self._data,
+            np.where(self._mask, self.dtype.type(0), getdata(other))
+        )
         return self
     #....
     def __isub__(self, other):
@@ -3814,7 +3817,10 @@ class MaskedArray(ndarray):
                 self._mask += m
         elif m is not nomask:
             self._mask += m
-        ndarray.__isub__(self._data, np.where(self._mask, 0, getdata(other)))
+        ndarray.__isub__(
+            self._data,
+            np.where(self._mask, self.dtype.type(0), getdata(other))
+        )
         return self
     #....
     def __imul__(self, other):
@@ -3826,7 +3832,10 @@ class MaskedArray(ndarray):
                 self._mask += m
         elif m is not nomask:
             self._mask += m
-        ndarray.__imul__(self._data, np.where(self._mask, 1, getdata(other)))
+        ndarray.__imul__(
+            self._data,
+            np.where(self._mask, self.dtype.type(1), getdata(other))
+        )
         return self
     #....
     def __idiv__(self, other):
@@ -3841,7 +3850,10 @@ class MaskedArray(ndarray):
             other_data = np.where(dom_mask, fval, other_data)
 #        self._mask = mask_or(self._mask, new_mask)
         self._mask |= new_mask
-        ndarray.__idiv__(self._data, np.where(self._mask, 1, other_data))
+        ndarray.__idiv__(
+            self._data,
+            np.where(self._mask, self.dtype.type(1), other_data)
+        )
         return self
     #....
     def __ifloordiv__(self, other):
@@ -3856,7 +3868,10 @@ class MaskedArray(ndarray):
             other_data = np.where(dom_mask, fval, other_data)
 #        self._mask = mask_or(self._mask, new_mask)
         self._mask |= new_mask
-        ndarray.__ifloordiv__(self._data, np.where(self._mask, 1, other_data))
+        ndarray.__ifloordiv__(
+            self._data,
+            np.where(self._mask, self.dtype.type(1), other_data)
+        )
         return self
     #....
     def __itruediv__(self, other):
@@ -3871,7 +3886,10 @@ class MaskedArray(ndarray):
             other_data = np.where(dom_mask, fval, other_data)
 #        self._mask = mask_or(self._mask, new_mask)
         self._mask |= new_mask
-        ndarray.__itruediv__(self._data, np.where(self._mask, 1, other_data))
+        ndarray.__itruediv__(
+            self._data,
+            np.where(self._mask, self.dtype.type(1), other_data)
+        )
         return self
     #...
     def __ipow__(self, other):
@@ -3879,7 +3897,10 @@ class MaskedArray(ndarray):
         other_data = getdata(other)
         other_mask = getmask(other)
         with np.errstate(divide='ignore', invalid='ignore'):
-            ndarray.__ipow__(self._data, np.where(self._mask, 1, other_data))
+            ndarray.__ipow__(
+                self._data,
+                np.where(self._mask, self.dtype.type(1), other_data)
+            )
         invalid = np.logical_not(np.isfinite(self._data))
         if invalid.any():
             if self._mask is not nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1723,6 +1723,13 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         xm[2] = masked
         self.intdata = (x, y, xm)
         self.floatdata = (x.astype(float), y.astype(float), xm.astype(float))
+        self.othertypes = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        self.othertypes = [np.dtype(_).type for _ in self.othertypes]
+        self.uint8data = (
+            x.astype(np.uint8),
+            y.astype(np.uint8),
+            xm.astype(np.uint8)
+        )
 
     def test_inplace_addition_scalar(self):
         # Test of inplace additions
@@ -1989,6 +1996,226 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         a *= b
         assert_equal(a, [[1, 1], [3, 3]])
         assert_equal(a.mask, [[0, 1], [0, 1]])
+
+    def test_inplace_addition_scalar_type(self):
+        # Test of inplace additions
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                xm[2] = masked
+                x += t(1)
+                assert_equal(x, y + t(1))
+                xm += t(1)
+                assert_equal(xm, y + t(1))
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_addition_array_type(self):
+        # Test of inplace additions
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                m = xm.mask
+                a = arange(10, dtype=t)
+                a[-1] = masked
+                x += a
+                xm += a
+                assert_equal(x, y + a)
+                assert_equal(xm, y + a)
+                assert_equal(xm.mask, mask_or(m, a.mask))
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_subtraction_scalar_type(self):
+        # Test of inplace subtractions
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x -= t(1)
+                assert_equal(x, y - t(1))
+                xm -= t(1)
+                assert_equal(xm, y - t(1))
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+
+    def test_inplace_subtraction_array_type(self):
+        # Test of inplace subtractions
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                m = xm.mask
+                a = arange(10, dtype=t)
+                a[-1] = masked
+                x -= a
+                xm -= a
+                assert_equal(x, y - a)
+                assert_equal(xm, y - a)
+                assert_equal(xm.mask, mask_or(m, a.mask))
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_multiplication_scalar_type(self):
+        # Test of inplace multiplication
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x *= t(2)
+                assert_equal(x, y * t(2))
+                xm *= t(2)
+                assert_equal(xm, y * t(2))
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_multiplication_array_type(self):
+        # Test of inplace multiplication
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                m = xm.mask
+                a = arange(10, dtype=t)
+                a[-1] = masked
+                x *= a
+                xm *= a
+                assert_equal(x, y * a)
+                assert_equal(xm, y * a)
+                assert_equal(xm.mask, mask_or(m, a.mask))
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_floor_division_scalar_type(self):
+        # Test of inplace division
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x = arange(10, dtype=t) * t(2)
+                xm = arange(10, dtype=t) * t(2)
+                xm[2] = masked
+                x //= t(2)
+                xm //= t(2)
+                assert_equal(x, y)
+                assert_equal(xm, y)
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_floor_division_array_type(self):
+        # Test of inplace division
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                m = xm.mask
+                a = arange(10, dtype=t)
+                a[-1] = masked
+                x //= a
+                xm //= a
+                assert_equal(x, y // a)
+                assert_equal(xm, y // a)
+                assert_equal(
+                    xm.mask,
+                    mask_or(mask_or(m, a.mask), (a == t(0)))
+                )
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_division_scalar_type(self):
+        # Test of inplace division
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x = arange(10, dtype=t) * t(2)
+                xm = arange(10, dtype=t) * t(2)
+                xm[2] = masked
+
+                # May get a DeprecationWarning or a TypeError.
+                #
+                # This is a consequence of the fact that this is true divide
+                # and will require casting to float for calculation and
+                # casting back to the original type. This will only be raised
+                # with integers. Whether it is an error or warning is only
+                # dependent on how stringent the casting rules are.
+                #
+                # Will handle the same way.
+                try:
+                    x /= t(2)
+                    assert_equal(x, y)
+                except (DeprecationWarning, TypeError) as e:
+                    warnings.warn(str(e))
+                try:
+                    xm /= t(2)
+                    assert_equal(xm, y)
+                except (DeprecationWarning, TypeError) as e:
+                    warnings.warn(str(e))
+
+                if issubclass(t, np.integer):
+                    assert_equal(len(w), 2, "Failed on type=%s." % t)
+                else:
+                    assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_division_array_type(self):
+        # Test of inplace division
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                m = xm.mask
+                a = arange(10, dtype=t)
+                a[-1] = masked
+
+                # May get a DeprecationWarning or a TypeError.
+                #
+                # This is a consequence of the fact that this is true divide
+                # and will require casting to float for calculation and
+                # casting back to the original type. This will only be raised
+                # with integers. Whether it is an error or warning is only
+                # dependent on how stringent the casting rules are.
+                #
+                # Will handle the same way.
+                try:
+                    x /= a
+                    assert_equal(x, y / a)
+                except (DeprecationWarning, TypeError) as e:
+                    warnings.warn(str(e))
+                try:
+                    xm /= a
+                    assert_equal(xm, y / a)
+                    assert_equal(
+                        xm.mask,
+                        mask_or(mask_or(m, a.mask), (a == t(0)))
+                    )
+                except (DeprecationWarning, TypeError) as e:
+                    warnings.warn(str(e))
+
+                if issubclass(t, np.integer):
+                    assert_equal(len(w), 2, "Failed on type=%s." % t)
+                else:
+                    assert_equal(len(w), 0, "Failed on type=%s." % t)
+
+    def test_inplace_pow_type(self):
+        # Test keeping data w/ (inplace) power
+        for t in self.othertypes:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
+                # Test pow on scalar
+                x = array([1, 2, 3], mask=[0, 0, 1], dtype=t)
+                xx = x ** t(2)
+                xx_r = array([1, 2 ** 2, 3], mask=[0, 0, 1], dtype=t)
+                assert_equal(xx.data, xx_r.data)
+                assert_equal(xx.mask, xx_r.mask)
+                # Test ipow on scalar
+                x **= t(2)
+                assert_equal(x.data, xx_r.data)
+                assert_equal(x.mask, xx_r.mask)
+
+                assert_equal(len(w), 0, "Failed on type=%s." % t)
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
With `numpy.ma.MaskedArray`s, `DeprecationWarning`s are raised when using an in-place operation between two type compatible `numpy.ma.MaskedArray`s.

An example of the problem can be seen with one of the operators (i.e. `__iadd__`). This is currently an issue with several in-place arithmetic operators. This PR attempts to simply correct this issue and provide some tests to ensure that the warnings are not unnecessarily being generated.

```
>>> import warnings
>>> warnings.filterwarnings("always")
>>> import numpy
>>> a = numpy.ma.arange(10, dtype=np.uint8)
>>> a[2] = numpy.ma.masked
>>> a
masked_array(data = [0 1 -- 3 4 5 6 7 8 9],
             mask = [False False  True False False False False False False False],
       fill_value = 999999)
>>> a += numpy.uint8(1)
.../numpy/ma/core.py:3692: DeprecationWarning: Implicitly casting between incompatible kinds. In a future numpy release, this will raise an error. Use casting="unsafe" if this is intentional.
  ndarray.__iadd__(self._data, np.where(self._mask, 0, getdata(other)))
```
