### PR TITLE
fixes bug #5561

### DIFF
--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -3071,13 +3071,13 @@
  *    %numpy_typemaps(long double, NPY_LONGDOUBLE, int)
  */
 
-%#ifdef __cplusplus
+#ifdef __cplusplus
 
 %include <std_complex.i>
 
 %numpy_typemaps(std::complex<float>,  NPY_CFLOAT , int)
 %numpy_typemaps(std::complex<double>, NPY_CDOUBLE, int)
 
-%#endif
+#endif
 
 #endif /* SWIGPYTHON */


### PR DESCRIPTION
BUG: tools/swig/numpy.i gives syntax error when swigged in C mode #5561

Now respects the __cplusplus conditional.
