### PR TITLE
Use correct #ifdef __cplusplus guard to include std_complex.i

### DIFF
--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -3071,13 +3071,13 @@
  *    %numpy_typemaps(long double, NPY_LONGDOUBLE, int)
  */
 
-%#ifdef __cplusplus
+#ifdef __cplusplus
 
 %include <std_complex.i>
 
 %numpy_typemaps(std::complex<float>,  NPY_CFLOAT , int)
 %numpy_typemaps(std::complex<double>, NPY_CDOUBLE, int)
 
-%#endif
+#endif
 
 #endif /* SWIGPYTHON */


### PR DESCRIPTION
The final section at 3074+ in numpy.i was added to allow wrapping of std::complex when building C++ extensions, but it leads to syntax errors in C.

This is because it was included optionally using @#ifdef/@#endif rather than #ifdef/#endif; the additional @s cause the preprocessor directives to be passed on to the C compiler instead of being used by swig. Then swig (in C mode) chokes inside std_complex_i.

The fix is to use #ifdef/#endif.
