### PR TITLE
Fix warnings

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -114,12 +114,17 @@ gentype_alloc(PyTypeObject *type, Py_ssize_t nitems)
     const size_t size = _PyObject_VAR_SIZE(type, nitems + 1);
 
     obj = (PyObject *)PyObject_Malloc(size);
+    /*
+     * Fixme. Need to check for no memory.
+     * If we don't need to zero memory, we could use
+     * PyObject_{New, NewVar} for this whole function.
+     */
     memset(obj, 0, size);
     if (type->tp_itemsize == 0) {
-        PyObject_INIT(obj, type);
+        PyObject_Init(obj, type);
     }
     else {
-        (void) PyObject_INIT_VAR((PyVarObject *)obj, type, nitems);
+        (void) PyObject_InitVar((PyVarObject *)obj, type, nitems);
     }
     return obj;
 }

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -948,7 +948,7 @@ PyArray_Ravel(PyArrayObject *arr, NPY_ORDER order)
     /* For KEEPORDER, check if we can make a flattened view */
     else {
         npy_stride_sort_item strideperm[NPY_MAXDIMS];
-        npy_intp stride, base_stride = NPY_MIN_INTP;
+        npy_intp stride = 0, base_stride = NPY_MIN_INTP;
         int i, ndim = PyArray_NDIM(arr);
 
         PyArray_CreateSortedStridePerm(PyArray_NDIM(arr),

--- a/numpy/core/src/umath/umath_tests.c.src
+++ b/numpy/core/src/umath/umath_tests.c.src
@@ -202,12 +202,11 @@ static void
     INIT_OUTER_LOOP_2
     npy_intp len_n = *dimensions++;
     npy_intp len_d = *dimensions++;
-    npy_intp len_p = *dimensions;
     npy_intp stride_n = *steps++;
     npy_intp stride_d = *steps++;
     npy_intp stride_p = *steps;
 
-    assert(len_n * (len_n - 1) / 2 == len_p);
+    assert(len_n * (len_n - 1) / 2 == *dimensions);
 
     BEGIN_OUTER_LOOP_2
         const char *data_this = (const char *)args[0];

--- a/numpy/fft/fftpack.c
+++ b/numpy/fft/fftpack.c
@@ -1,10 +1,8 @@
 /*
-fftpack.c : A set of FFT routines in C.
-Algorithmically based on Fortran-77 FFTPACK by Paul N. Swarztrauber (Version 4, 1985).
-
+ * fftpack.c : A set of FFT routines in C.
+ * Algorithmically based on Fortran-77 FFTPACK by Paul N. Swarztrauber (Version 4, 1985).
 */
-
-/* isign is +1 for backward and -1 for forward transforms */
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include <Python.h>
 #include <math.h>
@@ -12,7 +10,6 @@ Algorithmically based on Fortran-77 FFTPACK by Paul N. Swarztrauber (Version 4, 
 #include <numpy/ndarraytypes.h>
 
 #define DOUBLE
-
 #ifdef DOUBLE
 #define Treal double
 #else


### PR DESCRIPTION
Fix various compiler warnings that have slipped into the development branch. Some remain, but may not be worth the effort to clean up.
