### PR TITLE
Correct exit code if number of errors % 256 == 0

### DIFF
--- a/tools/swig/test/testArray.py
+++ b/tools/swig/test/testArray.py
@@ -382,4 +382,4 @@ if __name__ == "__main__":
     print("NumPy version", np.__version__)
     print()
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))

--- a/tools/swig/test/testFarray.py
+++ b/tools/swig/test/testFarray.py
@@ -156,4 +156,4 @@ if __name__ == "__main__":
     print("NumPy version", np.__version__)
     print()
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))

--- a/tools/swig/test/testFortran.py
+++ b/tools/swig/test/testFortran.py
@@ -170,4 +170,4 @@ if __name__ == "__main__":
     print("NumPy version", np.__version__)
     print()
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))

--- a/tools/swig/test/testMatrix.py
+++ b/tools/swig/test/testMatrix.py
@@ -359,4 +359,4 @@ if __name__ == "__main__":
     print("NumPy version", np.__version__)
     print()
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))

--- a/tools/swig/test/testSuperTensor.py
+++ b/tools/swig/test/testSuperTensor.py
@@ -385,4 +385,4 @@ if __name__ == "__main__":
     print "NumPy version", np.__version__
     print
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))

--- a/tools/swig/test/testTensor.py
+++ b/tools/swig/test/testTensor.py
@@ -399,4 +399,4 @@ if __name__ == "__main__":
     print("NumPy version", np.__version__)
     print()
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))

--- a/tools/swig/test/testVector.py
+++ b/tools/swig/test/testVector.py
@@ -378,4 +378,4 @@ if __name__ == "__main__":
     print("NumPy version", np.__version__)
     print()
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(len(result.errors) + len(result.failures))
+    sys.exit(bool(result.errors + result.failures))


### PR DESCRIPTION
For example, we had 256 errors (etc.) our process will exit with a
successful error code which is incorrect and/or misleading.

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
