### PR TITLE
MAINT: Fix an error in fmax docstring

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2310,7 +2310,7 @@ add_newdoc('numpy.core.umath', 'fmax',
     Returns
     -------
     y : ndarray or scalar
-        The minimum of `x1` and `x2`, element-wise.  Returns scalar if
+        The maximum of `x1` and `x2`, element-wise.  Returns scalar if
         both  `x1` and `x2` are scalars.
 
     See Also


### PR DESCRIPTION
This fixes a simple mistake in docstring of `np.fmax` which currently says that the returned array is an element-wise minimum, rather than maximum, of the input arrays.
