### PR TITLE
BUG: Fixes `numpy.where` to behave more consistently.

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3109,6 +3109,12 @@ array_where(PyObject *NPY_UNUSED(ignored), PyObject *args)
     if (!PyArg_ParseTuple(args, "O|OO", &obj, &x, &y)) {
         return NULL;
     }
+    if (x == Py_None) {
+        x = NULL;
+    }
+    if (y == Py_None) {
+        y = NULL;
+    }
     return PyArray_Where(obj, x, y);
 }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4818,7 +4818,12 @@ class TestWhere(TestCase):
 
     def test_exotic(self):
         # object
-        assert_array_equal(np.where(True, None, None), np.array(None))
+        assert_array_equal(np.where(True), (np.array([0]),))
+        assert_array_equal(np.where(True, None, None), (np.array([0]),))
+        assert_array_equal(
+            np.where(True, np.array(None), np.array(None)),
+            np.array(None)
+        )
         # zero sized
         m = np.array([], dtype=bool).reshape(0, 3)
         b = np.array([], dtype=np.float64).reshape(0, 3)


### PR DESCRIPTION
In other words, if `numpy.where` is provided explicitly with two arrays as `None`, then the result will be the same as if those arrays were not provided (i.e. only the condition variable was provided). This is the same sort of behavior that one would see when using `numpy.ma.where`.

To demonstrate, four cases are shown below. An example of the problem can be seen when looking at the result of `numpy.where(True, None, None)`. The goal of this pull request is to make sure all four cases have the same result.

```
>>> import numpy
>>> numpy.where(True)
... (array([0]),)
>>> numpy.where(True, None, None)
... array(None, dtype=object)
>>> numpy.ma.where(True)
... (array([0]),)
>>> numpy.ma.where(True, None, None)
... (array([0]),)
```

Going forward, one will need to do `numpy.where(True, numpy.array(None), numpy.array(None))`, to get the old result for `numpy.where(True, None, None)`.

This is a counter proposal to https://github.com/numpy/numpy/pull/5583. Only one of them should be accepted if either.
