### PR TITLE
BUG: Fixes `numpy.ma.where` to behave more consistently.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6684,7 +6684,7 @@ size.__doc__ = np.size.__doc__
 #####--------------------------------------------------------------------------
 #---- --- Extra functions ---
 #####--------------------------------------------------------------------------
-def where (condition, x=None, y=None):
+def where(condition, *args, **kwargs):
     """
     Return a masked array with elements from x or y, depending on condition.
 
@@ -6731,10 +6731,36 @@ def where (condition, x=None, y=None):
      [6.0 -- 8.0]]
 
     """
-    if x is None and y is None:
+
+    if ((len(args) == 0) or (len(args) == 2)) and (len(kwargs) == 0):
+        pass
+    elif (len(args) == 1) and (len(kwargs) == 1):
+        if ("x" not in kwargs):
+            raise ValueError(
+                "Cannot provide `x` as an argument and a keyword argument."
+            )
+        if ("y" not in kwargs):
+            raise ValueError(
+                "Must provide `y` as a keyword argument if not as an argument."
+            )
+        args += (kwargs["y"],)
+    elif (len(args) == 0) and ((len(kwargs) == 0) or (len(kwargs) == 2)):
+        if (("x" not in kwargs) and ("y" not in kwargs) or
+            ("x" in kwargs) and ("y" in kwargs)):
+            raise ValueError(
+                "Must provide both `x` and `y` as keyword arguments or neither."
+            )
+        args += (kwargs["x"], kwargs["y"],)
+    else:
+        raise ValueError(
+            "Only takes 3 arguments was provided %i arguments." %
+            len(args) + len(kwargs)
+        )
+
+
+    if len(args) == 0:
         return filled(condition, 0).nonzero()
-    elif x is None or y is None:
-        raise ValueError("Either both or neither x and y should be given.")
+    x, y = args
     # Get the condition ...............
     fc = filled(condition, 0).astype(MaskType)
     notfc = np.logical_not(fc)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3357,6 +3357,13 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(d, [-9, -9, -9, -9, -9, 4, -9, -9, 10, -9, -9, 3])
         assert_equal(d.dtype, ixm.dtype)
 
+    def test_where_object(self):
+        a = np.array(None)
+        b = masked_array(None)
+        r = b.copy()
+        assert_equal(np.ma.where(True, a, a), r)
+        assert_equal(np.ma.where(True, b, b), r)
+
     def test_where_with_masked_choice(self):
         x = arange(10)
         x[3] = masked


### PR DESCRIPTION
In other words, if `numpy.ma.where` is provided explicitly with two arrays as `None`, then the result will be the same as if those arrays were `0D` arrays. This is the same sort of behavior that one would see when using `numpy.where`.

To demonstrate, four cases are shown below. An example of the problem can be seen when looking at the result of `numpy.ma.where(True, None, None)`. The goal of this pull request is to make sure the fourth case has the same result as the second case.

```
>>> import numpy
>>> numpy.where(True)
... (array([0]),)
>>> numpy.where(True, None, None)
... array(None, dtype=object)
>>> numpy.ma.where(True)
... (array([0]),)
>>> numpy.ma.where(True, None, None)
... (array([0]),)
```

Going forward, one will need to do `numpy.ma.where(True)`, to get the old result for `numpy.ma.where(True, None, None)`.

This is a counter proposal to https://github.com/numpy/numpy/pull/5582. Only one of them should be accepted if either.
