### PR TITLE
BUG: Fixed issue #4679 - make numpy.tile always return a copy

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -850,10 +850,10 @@ def tile(A, reps):
     except TypeError:
         tup = (reps,)
     d = len(tup)
-    if all((x == 1 for x in tup)) and isinstance(A, _nx.ndarray):
+    if all(x == 1 for x in tup) and isinstance(A, _nx.ndarray):
         # Fixes the problem that the function does not make a copy if A is a
         # numpy array and the repetitions are 1 in all dimensions
-        c = _nx.array(A, copy=True, subok=True, ndmin=d)
+        return _nx.array(A, copy=True, subok=True, ndmin=d)
     else:
         c = _nx.array(A, copy=False, subok=True, ndmin=d)
     shape = list(c.shape)

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -850,7 +850,12 @@ def tile(A, reps):
     except TypeError:
         tup = (reps,)
     d = len(tup)
-    c = _nx.array(A, copy=False, subok=True, ndmin=d)
+    if all((x == 1 for x in tup)) and isinstance(A, _nx.ndarray):
+        # Fixes the problem that the function does not make a copy if A is a
+        # numpy array and the repetitions are 1 in all dimensions
+        c = _nx.array(A, copy=True, subok=True, ndmin=d)
+    else:
+        c = _nx.array(A, copy=False, subok=True, ndmin=d)
     shape = list(c.shape)
     n = max(c.size, 1)
     if (d < c.ndim):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -324,6 +324,12 @@ class TestTile(TestCase):
         assert_equal(tile(b, (2, 2)), [[1, 2, 1, 2], [3, 4, 3, 4],
                                        [1, 2, 1, 2], [3, 4, 3, 4]])
 
+    def test_tile_one_repetition_on_array_gh4679(self):
+        a = np.arange(5)
+        b = tile(a, 1)
+        b += 2
+        assert_equal(a, np.arange(5))
+
     def test_empty(self):
         a = np.array([[[]]])
         d = tile(a, (3, 2, 5)).shape


### PR DESCRIPTION
Tile now copies the input when it is a numpy array and all dimensions are
repeated only once.

This is the result of a students project: @husejnc @emebeiran @awakenting @LNaumann @SmokinCaterpillar 
