### PR TITLE
Mingw w64 building

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4316,15 +4316,6 @@ PyMODINIT_FUNC initmultiarray(void) {
         goto err;
     }
 
-#if defined(MS_WIN64) && defined(__GNUC__)
-  PyErr_WarnEx(PyExc_Warning,
-        "Numpy built with MINGW-W64 on Windows 64 bits is experimental, " \
-        "and only available for \n" \
-        "testing. You are advised not to use it for production. \n\n" \
-        "CRASHES ARE TO BE EXPECTED - PLEASE REPORT THEM TO NUMPY DEVELOPERS",
-        1);
-#endif
-
     /* Initialize access to the PyDateTime API */
     numpy_pydatetime_import();
 

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -21,6 +21,8 @@ TARGET_R = re.compile("Target: ([a-zA-Z0-9_\-]*)")
 # XXX: handle cross compilation
 def is_win64():
     return sys.platform == "win32" and platform.architecture()[0] == "64bit"
+def is_win32():
+    return sys.platform == "win32" and platform.architecture()[0] == "32bit"
 
 if is_win64():
     #_EXTRAFLAGS = ["-fno-leading-underscore"]
@@ -130,7 +132,7 @@ class GnuFCompiler(FCompiler):
 
             opt.extend(['-undefined', 'dynamic_lookup', '-bundle'])
         else:
-            opt.append("-shared")
+            opt.append("-shared -Wl,-gc-sections -Wl,-s")
         if sys.platform.startswith('sunos'):
             # SunOS often has dynamically loaded symbols defined in the
             # static library libg2c.a  The linker doesn't like this.  To
@@ -200,9 +202,17 @@ class GnuFCompiler(FCompiler):
             # With this compiler version building Fortran BLAS/LAPACK
             # with -O3 caused failures in lib.lapack heevr,syevr tests.
             opt = ['-O2']
+        elif v and v>='4.6.0':
+            if is_win32():
+                # use -mincoming-stack-boundary=2 
+                # due to the change to 16 byte stack alignment since GCC 4.6
+                # but 32 bit Windows ABI defines 4 bytes stack alignment
+                opt = ['-O2 -march=core2 -mtune=generic -mfpmath=sse -msse2 -mincoming-stack-boundary=2'] 
+            else:
+                opt = ['-O2 -march=x86-64 -DMS_WIN64 -mtune=generic -msse2'] 
         else:
-            opt = ['-O3']
-        opt.append('-funroll-loops')
+            opt = ['-O2'] 
+        # opt.append()
         return opt
 
     def _c_arch_flags(self):
@@ -349,10 +359,7 @@ class Gnu95FCompiler(GnuFCompiler):
         return ""
 
     def get_flags_opt(self):
-        if is_win64():
-            return ['-O0']
-        else:
-            return GnuFCompiler.get_flags_opt(self)
+        return GnuFCompiler.get_flags_opt(self)
 
 def _can_target(cmd, arch):
     """Return true is the command supports the -arch flag for the given
@@ -378,9 +385,13 @@ if __name__ == '__main__':
     from distutils import log
     log.set_verbosity(2)
 
-    compiler = GnuFCompiler()
-    compiler.customize()
-    print(compiler.get_version())
+    try:
+        compiler = GnuFCompiler()
+        compiler.customize()
+        print(compiler.get_version())
+    except Exception:
+        msg = get_exception()
+        print(msg)
 
     try:
         compiler = Gnu95FCompiler()

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -85,17 +85,28 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         elif self.linker_dll == 'gcc':
             self.linker = 'g++'
 
-        # **changes: eric jones 4/11/01
-        # 1. Check for import library on Windows.  Build if it doesn't exist.
-
-        build_import_library()
-
-        # Check for custom msvc runtime library on Windows. Build if it doesn't exist.
-        msvcr_success = build_msvcr_library()
-        msvcr_dbg_success = build_msvcr_library(debug=True)
-        if msvcr_success or msvcr_dbg_success:
-            # add preprocessor statement for using customized msvcr lib
-            self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
+        p = subprocess.Popen(['gcc', '--version'], shell=True,
+                             stdout=subprocess.PIPE)
+        out_string = p.stdout.read()
+        p.stdout.close()
+        
+        # Before build with MinGW-W64 generate the python import library
+        # with gendef and dlltool according to the MingW-W64 FAQ. 
+        # Use the MinGW-W64 provided msvc runtime import libraries.
+        # Don't call build_import_library() and build_msvcr_library.
+        
+        if 'MinGW-W64' not in str(out_string):
+            
+            # **changes: eric jones 4/11/01
+            # 1. Check for import library on Windows.  Build if it doesn't exist.            
+            build_import_library()
+            
+            # Check for custom msvc runtime library on Windows. Build if it doesn't exist.
+            msvcr_success = build_msvcr_library()
+            msvcr_dbg_success = build_msvcr_library(debug=True)
+            if msvcr_success or msvcr_dbg_success:
+                # add preprocessor statement for using customized msvcr lib
+                self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
 
         # Define the MSVC version as hint for MinGW
         msvcr_version = '0x%03i0' % int(msvc_runtime_library().lstrip('msvcr'))
@@ -124,10 +135,10 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             else:
                 # gcc-4 series releases do not support -mno-cygwin option
                 self.set_executables(
-                    compiler='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall',
-                    compiler_so='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall -Wstrict-prototypes',
-                    linker_exe='gcc -g',
-                    linker_so='gcc -g -shared')
+                    compiler='gcc -march=x86-64 -mtune=generic -DMS_WIN64 -O2 -msse2 -Wall',
+                    compiler_so='gcc -march=x86-64 -mtune=generic -DMS_WIN64 -O2 -msse2 -Wall -Wstrict-prototypes',
+                    linker_exe='gcc',
+                    linker_so='gcc -shared -Wl,-gc-sections -Wl,-s')
         else:
             if self.gcc_version <= "3.0.0":
                 self.set_executables(compiler='gcc -mno-cygwin -O2 -w',
@@ -142,10 +153,11 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
                                      linker_so='g++ -mno-cygwin -shared')
             else:
                 # gcc-4 series releases do not support -mno-cygwin option
-                self.set_executables(compiler='gcc -O2 -Wall',
-                                     compiler_so='gcc -O2 -Wall -Wstrict-prototypes',
+                # i686 build needs '-mincoming-stack-boundary=2' due to ABI incompatibility to Win32 ABI
+                self.set_executables(compiler='gcc -O2 -march=core2 -mtune=generic -mfpmath=sse -msse2 -mincoming-stack-boundary=2 -Wall',
+                                     compiler_so='gcc -O2 -march=core2 -mtune=generic  -mfpmath=sse -msse2 -mincoming-stack-boundary=2 -Wall -Wstrict-prototypes',
                                      linker_exe='g++ ',
-                                     linker_so='g++ -shared')
+                                     linker_so='g++ -shared -Wl,-gc-sections -Wl,-s')
         # added for python2.3 support
         # we can't pass it through set_executables because pre 2.2 would fail
         self.compiler_cxx = ['g++']

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1722,6 +1722,23 @@ class openblas_lapack_info(openblas_info):
                 res = False
         finally:
             shutil.rmtree(tmpdir)
+        if sys.platform == 'win32' and not res:
+            c = distutils.ccompiler.new_compiler(compiler='mingw32')
+            tmpdir = tempfile.mkdtemp()
+            src = os.path.join(tmpdir, 'source.c')
+            out = os.path.join(tmpdir, 'a.out')
+            try:
+                with open(src, 'wt') as f:
+                    f.write(s)
+                obj = c.compile([src], output_dir=tmpdir)
+                try:
+                    c.link_executable(obj, out, libraries=info['libraries'],
+                                    library_dirs=info['library_dirs'])
+                    res = True
+                except distutils.ccompiler.LinkError:
+                    res = False
+            finally:
+                shutil.rmtree(tmpdir)
         return res
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -668,7 +668,7 @@ class TestVectorize(TestCase):
         args = np.array([0, 0.5*np.pi, np.pi, 1.5*np.pi, 2*np.pi])
         r1 = f(args)
         r2 = np.cos(args)
-        assert_array_equal(r1, r2)
+        assert_array_almost_equal(r1, r2)
 
     def test_keywords(self):
         import math

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,7 @@ def setup_package():
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked},
+        package_data={'numpy.core': ['libopenblaspy.dll']},
     )
 
     # Run build


### PR DESCRIPTION
mingw-w64 / OpenBLAS support for the mingw-w64 toolchains available on https://bitbucket.org/carlkl/mingw-w64-for-python/downloads. site.cfg should be configured like this:

``` shell
[openblas]
libraries = openblaspy
library_dirs = <openblaspath>/lib
include_dirs = <openblaspath>/include
```

libopenblaspy.dll from `<openblaspath>/bin` has to be copied to numpy/core first before build.
For this mingw-w64 toolchains a manual creation of the python import libs is necessary, i.e.:

```
gendef python2.7.dll
dlltool -D python27.dll -d python27.def -l libpython27.dll.a
move libpython27.dll.a libs\libpython27.dll.a
```

For python-2.6 up to python 3.2 use https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_win32_vc90.tar.xz or https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_amd64_vc90.tar.xz
For python-3.3 and python-3.4 use https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_win32_vc100.tar.xz or https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_amd64_vc100.tar.xz
