### PR TITLE
Make allclose use isclose.

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -144,6 +144,18 @@ returned values, especially for corner cases.
 The strings produced by ``float.hex`` look like ``0x1.921fb54442d18p+1``,
 so this is not the hex used to represent unsigned integer types.
 
+*np.isclose* properly handles minimal values of integer dtypes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In order to properly handle minimal values of integer types, *np.isclose* will
+now cast to the float dtype during comparisons. This aligns its behavior with
+what was provided by *np.allclose*.
+
+*np.allclose* uses *np.isclose* internally.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*np.allcose* now uses *np.isclose* internally and inherits the ability to
+compare NaNs as equal by setting ``equal_nan=True``. Subclasses, such as
+*np.ma.MaskedArray*, are also preserved now.
+
 
 Changes
 =======

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2337,10 +2337,11 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     x = array(a, copy=False, subok=True, ndmin=1)
     y = array(b, copy=False, subok=True, ndmin=1)
 
-    # make sure y is an inexact type to avoid abs(MIN_INT); will cause
-    # casting of x later. Make sure to allow subclasses (e.g., for numpy.ma).
-    dtype = multiarray.result_type(y, 1.)
-    y = array(y, dtype=dtype, copy=False, subok=True)
+    # Make sure y is an inexact type to avoid bad behavior on abs(MIN_INT).
+    # This will cause casting of x later. Also, make sure to allow subclasses
+    # (e.g., for numpy.ma).
+    dt = multiarray.result_type(y, 1.)
+    y = array(y, dtype=dt, copy=False, subok=True)
 
     xfin = isfinite(x)
     yfin = isfinite(y)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2206,7 +2206,7 @@ def identity(n, dtype=None):
     from numpy import eye
     return eye(n, dtype=dtype)
 
-def allclose(a, b, rtol=1.e-5, atol=1.e-8):
+def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """
     Returns True if two arrays are element-wise equal within a tolerance.
 
@@ -2227,6 +2227,9 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
         The relative tolerance parameter (see Notes).
     atol : float
         The absolute tolerance parameter (see Notes).
+    equal_nan : bool
+        Whether to compare NaN's as equal.  If True, NaN's in `a` will be
+        considered equal to NaN's in `b` in the output array.
 
     Returns
     -------
@@ -2259,9 +2262,11 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8):
     False
     >>> np.allclose([1.0, np.nan], [1.0, np.nan])
     False
+    >>> np.allclose([1.0, np.nan], [1.0, np.nan], equal_nan=True)
+    True
 
     """
-    return all(isclose(a, b, rtol=rtol, atol=atol))
+    return all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
 
 def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1024,9 +1024,8 @@ def outer(a, b, out=None):
         Second input vector.  Input is flattened if
         not already 1-dimensional.
     out : (M, N) ndarray, optional
-          A location where the result is stored
-
         .. versionadded:: 1.9.0
+        A location where the result is stored
 
     Returns
     -------
@@ -2228,6 +2227,7 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     atol : float
         The absolute tolerance parameter (see Notes).
     equal_nan : bool
+        .. versionadded:: 1.10.0
         Whether to compare NaN's as equal.  If True, NaN's in `a` will be
         considered equal to NaN's in `b` in the output array.
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1574,6 +1574,11 @@ class TestAllclose(object):
         assert_(allclose(a, a))
 
 
+    def test_equalnan(self):
+        x = np.array([1.0, np.nan])
+        assert_(allclose(x, x, equal_nan=True))
+
+
 class TestIsclose(object):
     rtol = 1e-5
     atol = 1e-8
@@ -1664,14 +1669,22 @@ class TestIsclose(object):
         assert_array_equal(isclose(arr, arr, equal_nan=True), [True, True])
 
     def test_masked_arrays(self):
+        # Make sure to test the output type when arguments are interchanged.
+
         x = np.ma.masked_where([True, True, False], np.arange(3))
         assert_(type(x) is type(isclose(2, x)))
+        assert_(type(x) is type(isclose(x, 2)))
 
         x = np.ma.masked_where([True, True, False], [nan, inf, nan])
         assert_(type(x) is type(isclose(inf, x)))
+        assert_(type(x) is type(isclose(x, inf)))
 
         x = np.ma.masked_where([True, True, False], [nan, nan, nan])
         y = isclose(nan, x, equal_nan=True)
+        assert_(type(x) is type(y))
+        # Ensure that the mask isn't modified...
+        assert_array_equal([True, True, False], y.mask)
+        y = isclose(x, nan, equal_nan=True)
         assert_(type(x) is type(y))
         # Ensure that the mask isn't modified...
         assert_array_equal([True, True, False], y.mask)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1244,7 +1244,7 @@ def _assert_valid_refcount(op):
 
     assert_(sys.getrefcount(i) >= rc)
 
-def assert_allclose(actual, desired, rtol=1e-7, atol=0,
+def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=False,
                     err_msg='', verbose=True):
     """
     Raises an AssertionError if two objects are not equal up to desired
@@ -1266,6 +1266,8 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0,
         Relative tolerance.
     atol : float, optional
         Absolute tolerance.
+    equal_nan : bool, optional.
+        If True, NaNs will compare equal.
     err_msg : str, optional
         The error message to be printed in case of failure.
     verbose : bool, optional
@@ -1289,7 +1291,8 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0,
     """
     import numpy as np
     def compare(x, y):
-        return np.core.numeric._allclose_points(x, y, rtol=rtol, atol=atol)
+        return np.core.numeric.isclose(x, y, rtol=rtol, atol=atol,
+                                             equal_nan=equal_nan)
 
     actual, desired = np.asanyarray(actual), np.asanyarray(desired)
     header = 'Not equal to tolerance rtol=%g, atol=%g' % (rtol, atol)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1292,7 +1292,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=False,
     import numpy as np
     def compare(x, y):
         return np.core.numeric.isclose(x, y, rtol=rtol, atol=atol,
-                                             equal_nan=equal_nan)
+                                       equal_nan=equal_nan)
 
     actual, desired = np.asanyarray(actual), np.asanyarray(desired)
     header = 'Not equal to tolerance rtol=%g, atol=%g' % (rtol, atol)


### PR DESCRIPTION
Presently, `allclose` does not use `isclose`, preferring instead to use to `_allclose_points`, which barely differs from `isclose`. One of the subtle differences is that `isclose` has a bug that was previously fixed in #2280 for `allclose`. Similarly, `allclose` doesn't work nicely with `MaskedArray`, while `isclose` does. This PR fixes both issues. Finally, `allclose` doesn't have the option to compare NaNs as equal. This is now possible.
