### PR TITLE
BUG: Uninitialized variable ret XDECREF'ed on fail

### DIFF
--- a/numpy/core/src/multiarray/cblasfuncs.c
+++ b/numpy/core/src/multiarray/cblasfuncs.c
@@ -685,7 +685,7 @@ cblas_innerproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2)
     int j, l, lda, ldb;
     int nd;
     double prior1, prior2;
-    PyArrayObject *ret;
+    PyArrayObject *ret = NULL;
     npy_intp dimensions[NPY_MAXDIMS];
     PyTypeObject *subtype;
 


### PR DESCRIPTION
Found through a compiler warning: if the check in line 713 did not succeed and we did the `goto fail`, the variable `ret` was being `Py_XDECREF`'ed in line 810 without being initialized.
