### PR TITLE
BLD, ENH: Reading of extra flags from site.cfg to extend flexibility

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -8,6 +8,9 @@ Highlights
 ==========
 * numpy.distutils now supports parallel compilation via the --jobs/-j argument
   passed to setup.py build
+* numpy.distutils now supports additional customization via site.cfg to
+  control compilation parameters, i.e. runtime libraries, extra
+  linking/compilation flags.
 * Addition of *np.linalg.multi_dot*: compute the dot product of two or more
   arrays in a single function call, while automatically selecting the fastest
   evaluation order.
@@ -73,6 +76,18 @@ Also, the dtype.type of nested structured fields is now inherited.
 
 New Features
 ============
+
+Reading extra flags from site.cfg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously customization of compilation of dependency libraries and numpy 
+itself was only accomblishable via code changes in the distutils package.
+Now numpy.distutils reads in the following extra flags from each group of the
+site.cfg:
+  runtime_library_dirs (sets the runtime library directories to override
+    LD_LIBRARY_PATH)
+  extra_compile_args (add extra flags to the compilation of sources)
+  extra_link_args (add extra flags when linking libraries)
+This should, at least partially, complete user customization.
 
 *np.cbrt* to compute cube root for real floats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -82,11 +82,13 @@ Reading extra flags from site.cfg
 Previously customization of compilation of dependency libraries and numpy 
 itself was only accomblishable via code changes in the distutils package.
 Now numpy.distutils reads in the following extra flags from each group of the
-site.cfg:
-  runtime_library_dirs (sets the runtime library directories to override
-    LD_LIBRARY_PATH)
-  extra_compile_args (add extra flags to the compilation of sources)
-  extra_link_args (add extra flags when linking libraries)
+*site.cfg*:
+
+* ``runtime_library_dirs``, sets runtime library directories to override
+    ``LD_LIBRARY_PATH``
+* ``extra_compile_args``, add extra flags to the compilation of sources
+* ``extra_link_args``, add extra flags when linking libraries
+
 This should, at least partially, complete user customization.
 
 *np.cbrt* to compute cube root for real floats

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -84,7 +84,7 @@ itself was only accomblishable via code changes in the distutils package.
 Now numpy.distutils reads in the following extra flags from each group of the
 *site.cfg*:
 
-* ``runtime_library_dirs``, sets runtime library directories to override
+* ``runtime_library_dirs/rpath``, sets runtime library directories to override
     ``LD_LIBRARY_PATH``
 * ``extra_compile_args``, add extra flags to the compilation of sources
 * ``extra_link_args``, add extra flags when linking libraries

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -14,11 +14,16 @@ def intel_version_match(type):
     # Match against the important stuff in the version string
     return simple_version_match(start=r'Intel.*?Fortran.*?(?:%s).*?Version' % (type,))
 
+
 class BaseIntelFCompiler(FCompiler):
     def update_executables(self):
         f = dummy_fortran_file()
         self.executables['version_cmd'] = ['<F77>', '-FI', '-V', '-c',
                                            f + '.f', '-o', f + '.o']
+
+    def runtime_library_dir_option(self, dir):
+        return '-Wl,-rpath="%s"' % dir
+
 
 class IntelFCompiler(BaseIntelFCompiler):
 
@@ -71,6 +76,7 @@ class IntelFCompiler(BaseIntelFCompiler):
             opt[idx:idx] = ['-dynamiclib', '-Wl,-undefined,dynamic_lookup']
         return opt
 
+
 class IntelItaniumFCompiler(IntelFCompiler):
     compiler_type = 'intele'
     compiler_aliases = ()
@@ -89,6 +95,7 @@ class IntelItaniumFCompiler(IntelFCompiler):
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"]
         }
+
 
 class IntelEM64TFCompiler(IntelFCompiler):
     compiler_type = 'intelem'
@@ -121,6 +128,7 @@ class IntelEM64TFCompiler(IntelFCompiler):
 
 # Is there no difference in the version string between the above compilers
 # and the Visual compilers?
+
 
 class IntelVisualFCompiler(BaseIntelFCompiler):
     compiler_type = 'intelv'
@@ -167,6 +175,10 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     def get_flags_arch(self):
         return ["/arch:IA-32", "/QaxSSE3"]
 
+    def runtime_library_dir_option(self, dir):
+        raise NotImplementedError
+
+
 class IntelItaniumVisualFCompiler(IntelVisualFCompiler):
     compiler_type = 'intelev'
     description = 'Intel Visual Fortran Compiler for Itanium apps'
@@ -185,6 +197,7 @@ class IntelItaniumVisualFCompiler(IntelVisualFCompiler):
         'archiver'     : [ar_exe, "/verbose", "/OUT:"],
         'ranlib'       : None
         }
+
 
 class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     compiler_type = 'intelvem'

--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -51,6 +51,9 @@ class PGroupFCompiler(FCompiler):
         def get_flags_linker_so(self):
             return ["-dynamic", '-undefined', 'dynamic_lookup']
 
+    def runtime_library_dir_option(self, dir):
+        return '-R"%s"' % dir
+
 if __name__ == '__main__':
     from distutils import log
     log.set_verbosity(2)

--- a/numpy/distutils/fcompiler/sun.py
+++ b/numpy/distutils/fcompiler/sun.py
@@ -43,6 +43,9 @@ class SunFCompiler(FCompiler):
         opt.extend(['fsu', 'sunmath', 'mvec'])
         return opt
 
+    def runtime_library_dir_option(self, dir):
+        return '-R"%s"' % dir
+
 if __name__ == '__main__':
     from distutils import log
     log.set_verbosity(2)

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -474,11 +474,11 @@ class system_info(object):
         defaults['library_dirs'] = os.pathsep.join(default_lib_dirs)
         defaults['include_dirs'] = os.pathsep.join(default_include_dirs)
         defaults['runtime_library_dirs'] = os.pathsep.join(default_runtime_dirs)
-        defaults['rpath'] = []
+        defaults['rpath'] = ''
         defaults['src_dirs'] = os.pathsep.join(default_src_dirs)
         defaults['search_static_first'] = str(self.search_static_first)
-        defaults['extra_compile_args'] = []
-        defaults['extra_link_args'] = []
+        defaults['extra_compile_args'] = ''
+        defaults['extra_link_args'] = ''
         self.cp = ConfigParser(defaults)
         self.files = []
         self.files.extend(get_standard_file('.numpy-site.cfg'))

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -198,6 +198,7 @@ if sys.platform == 'win32':
     default_lib_dirs = ['C:\\',
                         os.path.join(distutils.sysconfig.EXEC_PREFIX,
                                      'libs')]
+    default_runtime_dirs = []
     default_include_dirs = []
     default_src_dirs = ['.']
     default_x11_lib_dirs = []
@@ -205,6 +206,7 @@ if sys.platform == 'win32':
 else:
     default_lib_dirs = libpaths(['/usr/local/lib', '/opt/lib', '/usr/lib',
                                  '/opt/local/lib', '/sw/lib'], platform_bits)
+    default_runtime_dirs = []
     default_include_dirs = ['/usr/local/include',
                             '/opt/include', '/usr/include',
                             # path of umfpack under macports
@@ -254,6 +256,7 @@ if os.path.join(sys.prefix, 'lib') not in default_lib_dirs:
     default_src_dirs.append(os.path.join(sys.prefix, 'src'))
 
 default_lib_dirs = [_m for _m in default_lib_dirs if os.path.isdir(_m)]
+default_runtime_dirs = [_m for _m in default_runtime_dirs if os.path.isdir(_m)]
 default_include_dirs = [_m for _m in default_include_dirs if os.path.isdir(_m)]
 default_src_dirs = [_m for _m in default_src_dirs if os.path.isdir(_m)]
 
@@ -470,8 +473,11 @@ class system_info(object):
         defaults = {}
         defaults['library_dirs'] = os.pathsep.join(default_lib_dirs)
         defaults['include_dirs'] = os.pathsep.join(default_include_dirs)
+        defaults['runtime_library_dirs'] = os.pathsep.join(default_runtime_dirs)
         defaults['src_dirs'] = os.pathsep.join(default_src_dirs)
         defaults['search_static_first'] = str(self.search_static_first)
+        defaults['extra_compile_args'] = []
+        defaults['extra_link_args'] = []
         self.cp = ConfigParser(defaults)
         self.files = []
         self.files.extend(get_standard_file('.numpy-site.cfg'))
@@ -489,8 +495,9 @@ class system_info(object):
                 self.cp.add_section(self.section)
 
     def calc_libraries_info(self):
-        libs = self.get_libraries()
-        dirs = self.get_lib_dirs()
+        libs   = self.get_libraries()
+        dirs   = self.get_lib_dirs()
+        r_dirs = self.get_runtime_lib_dirs()
         info = {}
         for lib in libs:
             i = self.check_libs(dirs, [lib])
@@ -498,16 +505,45 @@ class system_info(object):
                 dict_append(info, **i)
             else:
                 log.info('Library %s was not found. Ignoring' % (lib))
+            i = self.check_libs(r_dirs, [lib])
+            if i is not None:
+                # Swap library keywords found to runtime_library_dirs
+                # the libraries are insisting on the user having defined
+                # them using the library_dirs, and not necessarily by
+                # runtime_library_dirs
+                del i['libraries']
+                i['runtime_library_dirs'] = i.pop('library_dirs')
+                dict_append(info, **i)
+            else:
+                log.info('Runtime library %s was not found. Ignoring' % (lib))
         return info
 
     def set_info(self, **info):
         if info:
             lib_info = self.calc_libraries_info()
             dict_append(info, **lib_info)
+            # Update extra information
+            extra_info = self.calc_extra_info()
+            dict_append(info, **extra_info)
         self.saved_results[self.__class__.__name__] = info
 
     def has_info(self):
         return self.__class__.__name__ in self.saved_results
+
+    def calc_extra_info(self):
+        """ Updates the information in the current information with
+        respect to these flags:
+          extra_compile_args
+          extra_link_args
+        """
+        info = {}
+        for key in ['extra_compile_args','extra_link_args']:
+            # Get values
+            opt = self.cp.get(self.section, key)
+            if opt:
+                tmp = { key : [opt] }
+                dict_append(info,**tmp)
+        return info
 
     def get_info(self, notfound_action=0):
         """ Return a dictonary with items that are compatible
@@ -601,6 +637,9 @@ class system_info(object):
         return ret
 
     def get_lib_dirs(self, key='library_dirs'):
+        return self.get_paths(self.section, key)
+
+    def get_runtime_lib_dirs(self, key='runtime_library_dirs'):
         return self.get_paths(self.section, key)
 
     def get_include_dirs(self, key='include_dirs'):
@@ -2290,7 +2329,9 @@ def dict_append(d, **kws):
             languages.append(v)
             continue
         if k in d:
-            if k in ['library_dirs', 'include_dirs', 'define_macros']:
+            if k in ['library_dirs', 'include_dirs', 
+                     'extra_compile_args', 'extra_link_args',
+                     'runtime_library_dirs', 'define_macros']:
                 [d[k].append(vv) for vv in v if vv not in d[k]]
             else:
                 d[k].extend(v)

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -537,12 +537,12 @@ class system_info(object):
           extra_link_args
         """
         info = {}
-        for key in ['extra_compile_args','extra_link_args']:
+        for key in ['extra_compile_args', 'extra_link_args']:
             # Get values
             opt = self.cp.get(self.section, key)
             if opt:
-                tmp = { key : [opt] }
-                dict_append(info,**tmp)
+                tmp = {key : [opt]}
+                dict_append(info, **tmp)
         return info
 
     def get_info(self, notfound_action=0):

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -495,8 +495,8 @@ class system_info(object):
                 self.cp.add_section(self.section)
 
     def calc_libraries_info(self):
-        libs   = self.get_libraries()
-        dirs   = self.get_lib_dirs()
+        libs = self.get_libraries()
+        dirs = self.get_lib_dirs()
         r_dirs = self.get_runtime_lib_dirs()
         info = {}
         for lib in libs:

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -474,6 +474,7 @@ class system_info(object):
         defaults['library_dirs'] = os.pathsep.join(default_lib_dirs)
         defaults['include_dirs'] = os.pathsep.join(default_include_dirs)
         defaults['runtime_library_dirs'] = os.pathsep.join(default_runtime_dirs)
+        defaults['rpath'] = []
         defaults['src_dirs'] = os.pathsep.join(default_src_dirs)
         defaults['search_static_first'] = str(self.search_static_first)
         defaults['extra_compile_args'] = []
@@ -497,7 +498,11 @@ class system_info(object):
     def calc_libraries_info(self):
         libs = self.get_libraries()
         dirs = self.get_lib_dirs()
-        r_dirs = self.get_runtime_lib_dirs()
+        # The extensions use runtime_library_dirs
+        r_dirs = self.get_runtime_lib_dirs() 
+        # Intrinsic distutils use rpath, we simply append both entries
+        # as though they were one entry
+        r_dirs.extend(self.get_runtime_lib_dirs(key='rpath'))
         info = {}
         for lib in libs:
             i = self.check_libs(dirs, [lib])

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -107,15 +107,16 @@ class TestSystemInfoReading(TestCase):
                 })
         # Write site.cfg
         fd, self._sitecfg = mkstemp()
-        os.write(fd,site_cfg)
         os.close(fd)
+        with open(self._sitecfg, 'w') as fd:
+            fd.write(site_cfg)
         # Write the sources
-        with open(self._src1,'w') as fd:
+        with open(self._src1, 'w') as fd:
             fd.write(fakelib_c_text)
-        with open(self._src2,'w') as fd:
+        with open(self._src2, 'w') as fd:
             fd.write(fakelib_c_text)
         # We create all class-instances 
-        def site_and_parse(c,site_cfg):
+        def site_and_parse(c, site_cfg):
             c.files = [site_cfg]
             c.parse_config_files()
             return c

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -1,0 +1,203 @@
+from __future__ import division, absolute_import, print_function
+
+import os
+from tempfile import mkstemp, mkdtemp
+
+import distutils
+from numpy.testing import *
+from numpy.distutils.system_info import *
+
+simple_site = """\
+[ALL]
+library_dirs = {dir1:s}:{dir2:s}
+libraries = {lib1:s},{lib2:s}
+extra_compile_args = -I/fake/directory
+runtime_library_dirs = {dir1:s}
+
+[temp1]
+library_dirs = {dir1:s}
+libraries = {lib1:s}
+runtime_library_dirs = {dir1:s}
+
+[temp2]
+library_dirs = {dir2:s}
+libraries = {lib2:s}
+extra_link_args = -Wl,-rpath={lib2:s}
+"""
+site_cfg = simple_site
+
+fakelib_c_text = r'''
+/* This file is generated from numpy/distutils/testing/test_system_info.py */
+#include<stdio.h>
+void foo(void) {
+   printf("Hello foo");
+}
+void bar(void) {
+   printf("Hello bar");
+}
+'''
+
+class test_system_info(system_info):
+    def __init__(self,
+                 default_lib_dirs=default_lib_dirs,
+                 default_include_dirs=default_include_dirs,
+                 verbosity=1,
+                 ):
+        self.__class__.info = {}
+        self.local_prefixes = []
+        defaults = {}
+        defaults['library_dirs'] = []
+        defaults['include_dirs'] = []
+        defaults['runtime_library_dirs'] = []
+        defaults['src_dirs'] = []
+        defaults['search_static_first'] = []
+        defaults['extra_compile_args'] = []
+        defaults['extra_link_args'] = []
+        self.cp = ConfigParser(defaults)
+        self.files = []
+        self.files.extend(get_standard_file('site.cfg'))
+        self.parse_config_files()
+        if self.section is not None:
+            try:
+                self.search_static_first = self.cp.getboolean(self.section, 'search_static_first')
+            except: pass
+        assert isinstance(self.search_static_first, int)
+
+    def _check_libs(self, lib_dirs, libs, opt_libs, exts):
+        """Override _check_libs to return with all dirs """
+        info = {'libraries' : libs , 'library_dirs' : lib_dirs }
+        return info
+
+class test_temp1(test_system_info):
+    section = 'temp1'
+class test_temp2(test_system_info):
+    section = 'temp2'
+
+def get_class(name, notfound_action=1):
+    """
+    notfound_action:
+      0 - do nothing
+      1 - display warning message
+      2 - raise error
+    """
+    cl = {'temp1': test_temp1,
+          'temp2': test_temp2
+          }.get(name.lower(), test_system_info)
+    return cl()
+
+def get_standard_file(fname):
+    """
+    Overrides the get_standard_file from system_info
+    """
+    tmpdir = mkdtemp()
+    filename = tmpdir + '/' + fname 
+    with open(filename,'w') as fd:
+        fd.write(site_cfg.encode('ascii'))
+    filenames = [filename]
+    return filenames
+
+class TestSystemInfoReading(TestCase):
+
+    def setUp(self):
+        """ Create the libraries """
+        # Create 2 sources and 2 libraries
+        self._dir1 = mkdtemp()
+        self._src1 = os.path.join(self._dir1,'foo.c')
+        self._lib1 = os.path.join(self._dir1,'libfoo.so')
+        self._dir2 = mkdtemp()
+        self._src2 = os.path.join(self._dir2,'bar.c')
+        self._lib2 = os.path.join(self._dir2,'libbar.so')
+        # Update local site.cfg
+        global simple_site, site_cfg
+        site_cfg = simple_site.format(**{
+                'dir1' : self._dir1 ,
+                'lib1' : self._lib1 ,
+                'dir2' : self._dir2 ,
+                'lib2' : self._lib2 
+                })
+        # Write the sources
+        with open(self._src1,'w') as fd:
+            fd.write(fakelib_c_text.encode('ascii'))
+        with open(self._src2,'w') as fd:
+            fd.write(fakelib_c_text.encode('ascii'))
+
+    def tearDown(self):
+        try: 
+            shutil.rmtree(self._dir1)
+            shutil.rmtree(self._dir2)
+        except: 
+            pass
+
+    def test_all(self):
+        """ Read in all information in the ALL block """
+        tsi = get_class('default')
+        a = [self._dir1,self._dir2]
+        self.assertTrue(tsi.get_lib_dirs() == a,
+                        (tsi.get_lib_dirs(),a))
+        a = [self._lib1,self._lib2]
+        self.assertTrue(tsi.get_libraries() == a,
+                        (tsi.get_libraries(),a))
+        a = [self._dir1]
+        self.assertTrue(tsi.get_runtime_lib_dirs() == a,
+                        (tsi.get_runtime_lib_dirs(),a))
+        extra = tsi.calc_extra_info()
+        a = ['-I/fake/directory']
+        self.assertTrue(extra['extra_compile_args'] == a,
+                        (extra['extra_compile_args'],a))
+
+    def test_temp1(self):
+        """ Read in all information in the temp1 block """
+        tsi = get_class('temp1')
+        a = [self._dir1]
+        self.assertTrue(tsi.get_lib_dirs() == a,
+                        (tsi.get_lib_dirs(),a))
+        a = [self._lib1]
+        self.assertTrue(tsi.get_libraries() == a,
+                        (tsi.get_libraries(),a))
+        a = [self._dir1]
+        self.assertTrue(tsi.get_runtime_lib_dirs() == a,
+                        (tsi.get_runtime_lib_dirs(),a))
+
+    def test_temp2(self):
+        """ Read in all information in the temp2 block """
+        tsi = get_class('temp2')
+        a = [self._dir2]
+        self.assertTrue(tsi.get_lib_dirs() == a,
+                        (tsi.get_lib_dirs(),a))
+        a = [self._lib2]
+        self.assertTrue(tsi.get_libraries() == a,
+                        (tsi.get_libraries(),a))
+        extra = tsi.calc_extra_info()
+        a = ['-Wl,-rpath='+self._lib2]
+        self.assertTrue(extra['extra_link_args'] == a,
+                        (extra['extra_link_args'],a))
+
+    def test_compile1(self):
+        """ Compile source and link the first source """
+        tsi = get_class('temp1')
+        c = distutils.ccompiler.new_compiler()
+        # Change directory to not screw up directories
+        previousDir = os.getcwd()
+        os.chdir(self._dir1)
+        c.compile([os.path.basename(self._src1)], output_dir=self._dir1,
+                  include_dirs=tsi.get_include_dirs())
+        # Ensure that the object exists
+        self.assertTrue(os.path.isfile(self._src1.replace('.c','.o')))
+        os.chdir(previousDir)
+
+    def test_compile2(self):
+        """ Compile source and link the second source """
+        tsi = get_class('temp2')
+        c = distutils.ccompiler.new_compiler()
+        # Change directory to not screw up directories
+        previousDir = os.getcwd()
+        os.chdir(self._dir2)
+        c.compile([os.path.basename(self._src2)], output_dir=self._dir2,
+                  include_dirs=tsi.get_include_dirs(),
+                  extra_postargs=tsi.calc_extra_info()['extra_link_args'])
+        # Ensure that the object exists
+        self.assertTrue(os.path.isfile(self._src2.replace('.c','.o')))
+        os.chdir(previousDir)
+
+if __name__ == '__main__':
+    run_module_suite()

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function
 
 import os
-from tempfile import mkdtemp
+import shutil
+from tempfile import mkstemp, mkdtemp
 
 from numpy.distutils import ccompiler
 from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
@@ -15,21 +16,10 @@ def get_class(name, notfound_action=1):
       1 - display warning message
       2 - raise error
     """
-    cl = {'temp1': test_temp1,
-          'temp2': test_temp2
+    cl = {'temp1': TestTemp1,
+          'temp2': TestTemp2
           }.get(name.lower(), test_system_info)
     return cl()
-
-def get_standard_file(fname):
-    """
-    Overrides the get_standard_file from system_info
-    """
-    tmpdir = mkdtemp()
-    filename = os.path.join(tmpdir,fname)
-    with open(filename,'w') as fd:
-        fd.write(site_cfg)
-    filenames = [filename]
-    return filenames
 
 simple_site = """
 [ALL]
@@ -61,6 +51,7 @@ void bar(void) {
 }
 """
 
+
 class test_system_info(system_info):
     def __init__(self,
                  default_lib_dirs=default_lib_dirs,
@@ -78,25 +69,22 @@ class test_system_info(system_info):
         defaults['extra_compile_args'] = []
         defaults['extra_link_args'] = []
         self.cp = ConfigParser(defaults)
-        self.files = []
-        self.files.extend(get_standard_file('site.cfg'))
-        self.parse_config_files()
-        if self.section is not None:
-            # Have to by-pass a boolean conversion for non-existing variable
-            try:
-                self.search_static_first = self.cp.getboolean(self.section, 'search_static_first')
-            except: pass
-        assert_(isinstance(self.search_static_first, int))
-
+        # We have to parse the config files afterwards
+        # to have a consistent temporary filepath
+        
     def _check_libs(self, lib_dirs, libs, opt_libs, exts):
         """Override _check_libs to return with all dirs """
-        info = {'libraries' : libs , 'library_dirs' : lib_dirs }
+        info = {'libraries' : libs , 'library_dirs' : lib_dirs}
         return info
 
-class test_temp1(test_system_info):
+
+class TestTemp1(test_system_info):
     section = 'temp1'
-class test_temp2(test_system_info):
+
+
+class TestTemp2(test_system_info):
     section = 'temp2'
+
 
 class TestSystemInfoReading(TestCase):
 
@@ -104,87 +92,107 @@ class TestSystemInfoReading(TestCase):
         """ Create the libraries """
         # Create 2 sources and 2 libraries
         self._dir1 = mkdtemp()
-        self._src1 = os.path.join(self._dir1,'foo.c')
-        self._lib1 = os.path.join(self._dir1,'libfoo.so')
+        self._src1 = os.path.join(self._dir1, 'foo.c')
+        self._lib1 = os.path.join(self._dir1, 'libfoo.so')
         self._dir2 = mkdtemp()
-        self._src2 = os.path.join(self._dir2,'bar.c')
-        self._lib2 = os.path.join(self._dir2,'libbar.so')
+        self._src2 = os.path.join(self._dir2, 'bar.c')
+        self._lib2 = os.path.join(self._dir2, 'libbar.so')
         # Update local site.cfg
         global simple_site, site_cfg
         site_cfg = simple_site.format(**{
-                'dir1' : self._dir1 ,
-                'lib1' : self._lib1 ,
-                'dir2' : self._dir2 ,
+                'dir1' : self._dir1,
+                'lib1' : self._lib1,
+                'dir2' : self._dir2,
                 'lib2' : self._lib2 
                 })
+        # Write site.cfg
+        fd, self._sitecfg = mkstemp()
+        os.write(fd,site_cfg)
+        os.close(fd)
         # Write the sources
         with open(self._src1,'w') as fd:
             fd.write(fakelib_c_text)
         with open(self._src2,'w') as fd:
             fd.write(fakelib_c_text)
+        # We create all class-instances 
+        def site_and_parse(c,site_cfg):
+            c.files = [site_cfg]
+            c.parse_config_files()
+            return c
+        self.c_default = site_and_parse(get_class('default'), self._sitecfg)
+        self.c_temp1 = site_and_parse(get_class('temp1'), self._sitecfg)
+        self.c_temp2 = site_and_parse(get_class('temp2'), self._sitecfg)
 
     def tearDown(self):
+        # Do each removal separately
         try: 
             shutil.rmtree(self._dir1)
+        except:
+            pass
+        try: 
             shutil.rmtree(self._dir2)
-        except: 
+        except:
+            pass
+        try: 
+            os.remove(self._sitecfg)
+        except:
             pass
 
     def test_all(self):
-        """ Read in all information in the ALL block """
-        tsi = get_class('default')
-        assert_equal(tsi.get_lib_dirs(),[self._dir1,self._dir2])
-        assert_equal(tsi.get_libraries(),[self._lib1,self._lib2])
-        assert_equal(tsi.get_runtime_lib_dirs(),[self._dir1])
+        # Read in all information in the ALL block
+        tsi = self.c_default
+        assert_equal(tsi.get_lib_dirs(), [self._dir1, self._dir2])
+        assert_equal(tsi.get_libraries(), [self._lib1, self._lib2])
+        assert_equal(tsi.get_runtime_lib_dirs(), [self._dir1])
         extra = tsi.calc_extra_info()
-        assert_equal(extra['extra_compile_args'],['-I/fake/directory'])
+        assert_equal(extra['extra_compile_args'], ['-I/fake/directory'])
 
     def test_temp1(self):
-        """ Read in all information in the temp1 block """
-        tsi = get_class('temp1')
-        assert_equal(tsi.get_lib_dirs(),[self._dir1])
-        assert_equal(tsi.get_libraries(),[self._lib1])
-        assert_equal(tsi.get_runtime_lib_dirs(),[self._dir1])
+        # Read in all information in the temp1 block
+        tsi = self.c_temp1
+        assert_equal(tsi.get_lib_dirs(), [self._dir1])
+        assert_equal(tsi.get_libraries(), [self._lib1])
+        assert_equal(tsi.get_runtime_lib_dirs(), [self._dir1])
 
     def test_temp2(self):
-        """ Read in all information in the temp2 block """
-        tsi = get_class('temp2')
-        assert_equal(tsi.get_lib_dirs(),[self._dir2])
-        assert_equal(tsi.get_libraries(),[self._lib2])
+        # Read in all information in the temp2 block
+        tsi = self.c_temp2
+        assert_equal(tsi.get_lib_dirs(), [self._dir2])
+        assert_equal(tsi.get_libraries(), [self._lib2])
         extra = tsi.calc_extra_info()
-        assert_equal(extra['extra_link_args'],['-Wl,-rpath='+self._lib2])
+        assert_equal(extra['extra_link_args'], ['-Wl,-rpath='+self._lib2])
 
     def test_compile1(self):
-        """ Compile source and link the first source """
-        tsi = get_class('temp1')
+        # Compile source and link the first source
+        tsi = self.c_temp1
         c = ccompiler.new_compiler()
-        # Change directory to not screw up directories
         try:
+            # Change directory to not screw up directories
             previousDir = os.getcwd()
+            os.chdir(self._dir1)
+            c.compile([os.path.basename(self._src1)], output_dir=self._dir1)
+            # Ensure that the object exists
+            assert_(os.path.isfile(self._src1.replace('.c', '.o')))
+            os.chdir(previousDir)
         except OSError:
-            return
-        os.chdir(self._dir1)
-        c.compile([os.path.basename(self._src1)], output_dir=self._dir1)
-        # Ensure that the object exists
-        assert_(os.path.isfile(self._src1.replace('.c','.o')))
-        os.chdir(previousDir)
+            pass
 
     def test_compile2(self):
-        """ Compile source and link the second source """
-        tsi = get_class('temp2')
+        # Compile source and link the second source
+        tsi = self.c_temp2
         c = ccompiler.new_compiler()
         extra_link_args = tsi.calc_extra_info()['extra_link_args']
-        # Change directory to not screw up directories
         try:
+            # Change directory to not screw up directories
             previousDir = os.getcwd()
+            os.chdir(self._dir2)
+            c.compile([os.path.basename(self._src2)], output_dir=self._dir2,
+                      extra_postargs=extra_link_args)
+            # Ensure that the object exists
+            assert_(os.path.isfile(self._src2.replace('.c', '.o')))
+            os.chdir(previousDir)
         except OSError:
-            return
-        os.chdir(self._dir2)
-        c.compile([os.path.basename(self._src2)], output_dir=self._dir2,
-                  extra_postargs=extra_link_args)
-        # Ensure that the object exists
-        assert_(os.path.isfile(self._src2.replace('.c','.o')))
-        os.chdir(previousDir)
-
+            pass
+        
 if __name__ == '__main__':
     run_module_suite()

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -62,14 +62,14 @@ class test_system_info(system_info):
         self.__class__.info = {}
         self.local_prefixes = []
         defaults = {}
-        defaults['library_dirs'] = []
-        defaults['include_dirs'] = []
-        defaults['runtime_library_dirs'] = []
-        defaults['rpath'] = []
-        defaults['src_dirs'] = []
+        defaults['library_dirs'] = ''
+        defaults['include_dirs'] = ''
+        defaults['runtime_library_dirs'] = ''
+        defaults['rpath'] = ''
+        defaults['src_dirs'] = ''
         defaults['search_static_first'] = "0"
-        defaults['extra_compile_args'] = []
-        defaults['extra_link_args'] = []
+        defaults['extra_compile_args'] = ''
+        defaults['extra_link_args'] = ''
         self.cp = ConfigParser(defaults)
         # We have to parse the config files afterwards
         # to have a consistent temporary filepath

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -37,6 +37,7 @@ runtime_library_dirs = {dir1:s}
 library_dirs = {dir2:s}
 libraries = {lib2:s}
 extra_link_args = -Wl,-rpath={lib2:s}
+rpath = {dir2:s}
 """
 site_cfg = simple_site
 
@@ -64,8 +65,9 @@ class test_system_info(system_info):
         defaults['library_dirs'] = []
         defaults['include_dirs'] = []
         defaults['runtime_library_dirs'] = []
+        defaults['rpath'] = []
         defaults['src_dirs'] = []
-        defaults['search_static_first'] = []
+        defaults['search_static_first'] = "0"
         defaults['extra_compile_args'] = []
         defaults['extra_link_args'] = []
         self.cp = ConfigParser(defaults)
@@ -160,6 +162,8 @@ class TestSystemInfoReading(TestCase):
         tsi = self.c_temp2
         assert_equal(tsi.get_lib_dirs(), [self._dir2])
         assert_equal(tsi.get_libraries(), [self._lib2])
+        # Now from rpath and not runtime_library_dirs
+        assert_equal(tsi.get_runtime_lib_dirs(key='rpath'), [self._dir2])
         extra = tsi.calc_extra_info()
         assert_equal(extra['extra_link_args'], ['-Wl,-rpath='+self._lib2])
 

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -26,7 +26,7 @@ def get_standard_file(fname):
     tmpdir = mkdtemp()
     filename = tmpdir + '/' + fname 
     with open(filename,'w') as fd:
-        fd.write(site_cfg.encode('ascii'))
+        fd.write(site_cfg)
     filenames = [filename]
     return filenames
 
@@ -182,8 +182,7 @@ class TestSystemInfoReading(TestCase):
         except OSError:
             return
         os.chdir(self._dir1)
-        c.compile([os.path.basename(self._src1)], output_dir=self._dir1,
-                  include_dirs=tsi.get_include_dirs())
+        c.compile([os.path.basename(self._src1)], output_dir=self._dir1)
         # Ensure that the object exists
         self.assertTrue(os.path.isfile(self._src1.replace('.c','.o')))
         os.chdir(previousDir)
@@ -192,6 +191,7 @@ class TestSystemInfoReading(TestCase):
         """ Compile source and link the second source """
         tsi = get_class('temp2')
         c = distutils.ccompiler.new_compiler()
+        extra_link_args = tsi.calc_extra_info()['extra_link_args']
         # Change directory to not screw up directories
         try:
             previousDir = os.getcwd()
@@ -199,8 +199,7 @@ class TestSystemInfoReading(TestCase):
             return
         os.chdir(self._dir2)
         c.compile([os.path.basename(self._src2)], output_dir=self._dir2,
-                  include_dirs=tsi.get_include_dirs(),
-                  extra_postargs=tsi.calc_extra_info()['extra_link_args'])
+                  extra_postargs=extra_link_args)
         # Ensure that the object exists
         self.assertTrue(os.path.isfile(self._src2.replace('.c','.o')))
         os.chdir(previousDir)

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -53,11 +53,13 @@
 #       shared libraries (.so). It is turned off by default.
 #           search_static_first = false
 #
-#   runtime_library_dirs
+#   runtime_library_dirs/rpath
 #       List of directories that contains the libraries that should be 
 #       used at runtime, thereby disregarding the LD_LIBRARY_PATH variable.
 #       See 'library_dirs' for formatting on different platforms.
 #           runtime_library_dirs = /opt/blas/lib:/opt/lapack/lib
+#       or equivalently
+#           rpath = /opt/blas/lib:/opt/lapack/lib
 #
 #   extra_compile_args
 #       Add additional arguments to the compilation of sources.

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -52,6 +52,26 @@
 #       True) to tell numpy.distutils to prefer static libraries (.a) over
 #       shared libraries (.so). It is turned off by default.
 #           search_static_first = false
+#
+#   runtime_library_dirs
+#       List of directories that contains the libraries that should be 
+#       used at runtime, thereby disregarding the LD_LIBRARY_PATH variable.
+#       See 'library_dirs' for formatting on different platforms.
+#           runtime_library_dirs = /opt/blas/lib:/opt/lapack/lib
+#
+#   extra_compile_args
+#       Add additional arguments to the compilation of sources.
+#       Simple variable with no parsing done. 
+#       Provide a single line with all complete flags.
+#           extra_compile_args = -g -ftree-vectorize
+#
+#   extra_link_args
+#       Add additional arguments to when libraries/executables
+#       are linked.
+#       Simple variable with no parsing done. 
+#       Provide a single line with all complete flags.
+#           extra_link_args = -lgfortran
+#
 
 # Defaults
 # ========
@@ -59,9 +79,10 @@
 # This is a good place to add general library and include directories like
 # /usr/local/{lib,include}
 #
-#[DEFAULT]
+#[ALL]
 #library_dirs = /usr/local/lib
 #include_dirs = /usr/local/include
+#
 
 # Atlas
 # -----
@@ -82,6 +103,9 @@
 # instead of Atlas, use this section instead of the above, adjusting as needed
 # for your configuration (in the following example we installed OpenBLAS with
 # ``make install PREFIX=/opt/OpenBLAS``.
+# OpenBLAS is generically installed as a shared library, to force the OpenBLAS
+# library linked to also be used at runtime you can utilize the 
+# runtime_library_dirs variable.
 #
 # **Warning**: OpenBLAS, by default, is built in multithreaded mode. Due to the
 # way Python's multiprocessing is implemented, a multithreaded OpenBLAS can
@@ -102,6 +126,7 @@
 # libraries = openblas
 # library_dirs = /opt/OpenBLAS/lib
 # include_dirs = /opt/OpenBLAS/include
+# runtime_library_dirs = /opt/OpenBLAS/lib
 
 # MKL
 #----


### PR DESCRIPTION
BLD: Because it allows greater flexibility of the build phase for numpy, but no changes to _how_ numpy is build has been made

Addition to the distutils module to be able
to read in more optional arguments and flags
from the site.cfg file.

Up till this commit it has really been a _pain in the neck_ to optimize the build for certain flags, etc.
With this any user should be capable of providing their own flags/linker options to control the build
more easily.  
This commit can also be merged in the 1.9 maintenance branch.

Especially the runtime_library_dirs can come handy if users rely on LD_LIBRARY_PATH to super seed such env's.

There is still the caveat that hard-coded flags are not overwritten in any way so that providing additional flags has to be compatible with the hard-coded flags for the specific compiler.

Currently these additional options read:
- runtime_library_dirs:
  It allows users to set the runtime
  library directories so that LD_LIBRARY_PATH can be ignored.
  This has the same format as the library_dirs option.
- extra_compile_args:
  This allows the user to add specific compiler
  flags when compiling sources.
  There will be no formatting/checking of these additional compile
  flags, the compiler should complain if something is wrong.
- extra_link_args:
  This allows the user to add specific linker flags
  when linking the .so objects.
  There will be no formatting/checking of these additional compile
  flags, the linker should complain if something is wrong.

When the config is runned it automatically prints out the
read in information, thereby allowing the user to see
what has been set and what has not.

Tested with and without the added options to check that it builds correctly.
