### PR TITLE
ENH: add np.stack

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -11,6 +11,9 @@ Highlights
 * Addition of *np.linalg.multi_dot*: compute the dot product of two or more
   arrays in a single function call, while automatically selecting the fastest
   evaluation order.
+* The new function `np.stack` provides a general interface for joining a
+  sequence of arrays along a new axis, complementing `np.concatenate` for
+  joining along an existing axis.
 * Addition of `nanprod` to the set of nanfunctions.
 
 

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -64,8 +64,9 @@ Joining arrays
 .. autosummary::
    :toctree: generated/
 
-   column_stack
    concatenate
+   stack
+   column_stack
    dstack
    hstack
    vstack
@@ -75,10 +76,10 @@ Splitting arrays
 .. autosummary::
    :toctree: generated/
 
+   split
    array_split
    dsplit
    hsplit
-   split
    vsplit
 
 Tiling arrays

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -1142,7 +1142,7 @@ add_newdoc('numpy.core.multiarray', 'concatenate',
     """
     concatenate((a1, a2, ...), axis=0)
 
-    Join a sequence of arrays together.
+    Join a sequence of arrays along an existing axis.
 
     Parameters
     ----------
@@ -1166,6 +1166,7 @@ add_newdoc('numpy.core.multiarray', 'concatenate',
     hsplit : Split array into multiple sub-arrays horizontally (column wise)
     vsplit : Split array into multiple sub-arrays vertically (row wise)
     dsplit : Split array into multiple sub-arrays along the 3rd axis (depth).
+    stack : Stack a sequence of arrays along a new axis.
     hstack : Stack arrays in sequence horizontally (column wise)
     vstack : Stack arrays in sequence vertically (row wise)
     dstack : Stack arrays in sequence depth wise (along third dimension)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3706,7 +3706,7 @@ def insert(arr, obj, values, axis=None):
     See Also
     --------
     append : Append elements at the end of an array.
-    concatenate : Join a sequence of arrays together.
+    concatenate : Join a sequence of arrays along an existing axis.
     delete : Delete elements from an array.
 
     Notes

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -404,7 +404,7 @@ class RClass(AxisConcatenator):
 
     See Also
     --------
-    concatenate : Join a sequence of arrays together.
+    concatenate : Join a sequence of arrays along an existing axis.
     c_ : Translates slice objects to concatenation along the second axis.
 
     Examples

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -338,9 +338,10 @@ def dstack(tup):
 
     See Also
     --------
+    stack : Join a sequence of arrays along a new axis.
     vstack : Stack along first axis.
     hstack : Stack along second axis.
-    concatenate : Join arrays.
+    concatenate : Join a sequence of arrays along an existing axis.
     dsplit : Split array along third axis.
 
     Notes
@@ -477,7 +478,8 @@ def split(ary,indices_or_sections,axis=0):
     hsplit : Split array into multiple sub-arrays horizontally (column-wise).
     vsplit : Split array into multiple sub-arrays vertically (row wise).
     dsplit : Split array into multiple sub-arrays along the 3rd axis (depth).
-    concatenate : Join arrays together.
+    concatenate : Join a sequence of arrays along an existing axis.
+    stack : Join a sequence of arrays along a new axis.
     hstack : Stack arrays in sequence horizontally (column wise).
     vstack : Stack arrays in sequence vertically (row wise).
     dstack : Stack arrays in sequence depth wise (along third dimension).


### PR DESCRIPTION
The motivation here is to present a uniform and N-dimensional interface for joining arrays along a new axis, similarly to how `concatenate` provides a uniform and N-dimensional interface for joining arrays along an existing axis.
## Background

Currently, users can choose between `hstack`, `vstack`, `column_stack` and `dstack`, but none of these functions handle N-dimensional input. In my opinion, it's also difficult to keep track of the differences between these methods and to predict how they will handle input with different dimensions.

In the past, my preferred approach has been to either construct the result array explicitly and use indexing for assignment, to or use `np.array` to stack along the first dimension and then use `transpose` (or a similar method) to reorder dimensions if necessary. This is pretty awkward.

I brought this proposal up a few weeks on the numpy-discussion list:
http://mail.scipy.org/pipermail/numpy-discussion/2015-February/072199.html

I also received positive feedback on Twitter:
https://twitter.com/shoyer/status/565937244599377920
## Implementation notes

The one line summaries for `concatenate` and `stack` have been (re)written to mirror each other, and to make clear that the distinction between these functions is whether they join over an existing or new axis.

In general, I've tweaked the documentation and docstrings with an eye toward pointing users to `concatenate`/`stack`/`split` as a fundamental set of basic array manipulation routines, and away from `array_split`/`{h,v,d}split`/`{h,v,d,column_}stack`

I put this implementation in `numpy.core.shape_base` alongside `hstack`/`vstack`, but it appears that there is also a `numpy.lib.shape_base` module that contains another larger set of functions, including `dstack`. I'm not really sure where this belongs (or if it even matters).

Finally, it might be a good idea to write a masked array version of `stack`. But I don't use masked arrays, so I'm not well motivated to do that.
