### PR TITLE
DOC: Make arg names in random.normal match the variable names in the formula

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1472,9 +1472,9 @@ cdef class RandomState:
         """
         return cont0_array(self.internal_state, rk_gauss, size, self.lock)
 
-    def normal(self, loc=0.0, scale=1.0, size=None):
+    def normal(self, mean=0.0, sigma=1.0, size=None):
         """
-        normal(loc=0.0, scale=1.0, size=None)
+        normal(mean=0.0, sigma=1.0, size=None)
 
         Draw random samples from a normal (Gaussian) distribution.
 
@@ -1490,9 +1490,9 @@ cdef class RandomState:
 
         Parameters
         ----------
-        loc : float
+        mean : float
             Mean ("centre") of the distribution.
-        scale : float
+        sigma : float
             Standard deviation (spread or "width") of the distribution.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then


### PR DESCRIPTION
Previously, the args were "loc" and "scale". The docstring defined these as

``` python
"""
loc : float
    Mean ("centre") of the distribution.
scale : float
    Standard deviation (spread or "width") of the distribution.
"""
```

Going from "loc" to "mean" and from "scale" to "standard deviation" seems
unnecessarily confusing, particularly since the mean and standard deviation
were then redefined again with new symbols in the formula:

``` python
"""
The probability density for the Gaussian distribution is

.. math:: p(x) = \frac{1}{\sqrt{ 2 \pi \sigma^2 }}
                 e^{ - \frac{ (x - \mu)^2 } {2 \sigma^2} },

where :math:`\mu` is the mean and :math:`\sigma` the standard deviation.
The square of the standard deviation, :math:`\sigma^2`, is called the
variance.
"""

This change makes the arg names correspond to the names used in the formula.
```
