### PR TITLE
BUG: Fixes ndarray.fill to accept maximum uint64 value

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -193,6 +193,14 @@ class TestAttributes(TestCase):
             y[...] = 1
             assert_equal(x, y)
 
+    def test_fill_max_uint64(self):
+        x = empty((3, 2, 1), dtype=uint64)
+        y = empty((3, 2, 1), dtype=uint64)
+        value = 2**64 - 1
+        y[...] = value
+        x.fill(value)
+        assert_array_equal(x, y)
+
     def test_fill_struct_array(self):
         # Filling from a scalar
         x = array([(0, 0.0), (1, 1.0)], dtype='i4,f8')


### PR DESCRIPTION
This PR changes `np.ndarray.fill` to attempt to convert to `uint64` if its argument is a Python integer and conversion to`int64` fails.  

`np.ndarray.fill` now accepts the Python long `2**64 - 1` as a value. Previously it failed because the value overflows an `int64` and `uint64` was not attempted. Constructing the value as a `uint64` manually and then passing it to fill succeeded.

Fixes #5612 
