### PR TITLE
BUG: fix broadcast_to for reference types

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -60,9 +60,9 @@ def _broadcast_to(array, shape, subok, readonly):
     if any(size < 0 for size in shape):
         raise ValueError('all elements of broadcast shape must be non-'
                          'negative')
-    broadcast = np.nditer((array,), flags=['multi_index', 'zerosize_ok'],
-                          op_flags=['readonly'], itershape=shape, order='C'
-                          ).itviews[0]
+    broadcast = np.nditer(
+        (array,), flags=['multi_index', 'refs_ok', 'zerosize_ok'],
+        op_flags=['readonly'], itershape=shape, order='C').itviews[0]
     result = _maybe_view_as_subclass(array, broadcast)
     if not readonly and array.flags.writeable:
         result.flags.writeable = True

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -364,5 +364,15 @@ def test_writeable():
     assert_equal(result.flags.writeable, False)
 
 
+def test_reference_types():
+    input_array = np.array('a', dtype=object)
+    expected = np.array(['a'] * 3, dtype=object)
+    actual = broadcast_to(input_array, (3,))
+    assert_array_equal(expected, actual)
+
+    actual, _ = broadcast_arrays(input_array, np.ones(3))
+    assert_array_equal(expected, actual)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Without this change, the new test fails with:

```
======================================================================
ERROR: test_stride_tricks.test_reference_types
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shoyer/miniconda/envs/numpy-dev/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/shoyer/dev/numpy/numpy/lib/tests/test_stride_tricks.py", line 370, in test_reference_types
    actual = broadcast_to(input_array, (3,))
  File "/Users/shoyer/dev/numpy/numpy/lib/stride_tricks.py", line 106, in broadcast_to
    return _broadcast_to(array, shape, subok=subok, readonly=True)
  File "/Users/shoyer/dev/numpy/numpy/lib/stride_tricks.py", line 65, in _broadcast_to
    op_flags=['readonly'], itershape=shape, order='C').itviews[0]
TypeError: Iterator operand or requested dtype holds references, but the REFS_OK flag was not enabled
```
