### PR TITLE
MAINT: Reconcile docstrings and function signatures where they disagree

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -206,7 +206,7 @@ class iinfo(object):
 
     Parameters
     ----------
-    type : integer type, dtype, or instance
+    int_type : integer type, dtype, or instance
         The kind of integer data type to get information about.
 
     See Also

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -160,7 +160,7 @@ class LineSplitter(object):
     delimiter : str, int, or sequence of ints, optional
         If a string, character used to delimit consecutive fields.
         If an integer or a sequence of integers, width(s) of each field.
-    comment : str, optional
+    comments : str, optional
         Character used to mark the beginning of a comment. Default is '#'.
     autostrip : bool, optional
         Whether to strip each individual field. Default is True.
@@ -271,7 +271,7 @@ class NameValidator(object):
     deletechars : str, optional
         A string combining invalid characters that must be deleted from the
         names.
-    casesensitive : {True, False, 'upper', 'lower'}, optional
+    case_sensitive : {True, False, 'upper', 'lower'}, optional
         * If True, field names are case-sensitive.
         * If False or 'upper', field names are converted to upper case.
         * If 'lower', field names are converted to lower case.
@@ -341,7 +341,7 @@ class NameValidator(object):
         defaultfmt : str, optional
             Default format string, used if validating a given string
             reduces its length to zero.
-        nboutput : integer, optional
+        nbfields : integer, optional
             Final number of validated names, used to expand or shrink the
             initial list of names.
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -480,7 +480,7 @@ class ndenumerate(object):
 
     Parameters
     ----------
-    a : ndarray
+    arr : ndarray
       Input array.
 
     See Also

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1240,8 +1240,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         The string used to separate values.  By default, any consecutive
         whitespaces act as delimiter.  An integer or sequence of integers
         can also be provided as width(s) of each field.
-    skip_rows : int, optional
-        `skip_rows` was deprecated in numpy 1.5, and will be removed in
+    skiprows : int, optional
+        `skiprows` was deprecated in numpy 1.5, and will be removed in
         numpy 2.0. Please use `skip_header` instead.
     skip_header : int, optional
         The number of lines to skip at the beginning of the file.

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -268,7 +268,7 @@ def izip_records(seqarrays, fill_value=None, flatten=True):
 
     Parameters
     ----------
-    seqarray : sequence of arrays
+    seqarrays : sequence of arrays
         Sequence of arrays.
     fill_value : {None, integer}
         Value used to pad shorter iterables.
@@ -683,7 +683,7 @@ def stack_arrays(arrays, defaults=None, usemask=True, asrecarray=False,
 
     Parameters
     ----------
-    seqarrays : array or sequence
+    arrays : array or sequence
         Sequence of input arrays.
     defaults : dictionary, optional
         Dictionary mapping field names to the corresponding default values.

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1123,7 +1123,7 @@ def eigh(a, UPLO='L'):
 
     Parameters
     ----------
-    A : (..., M, M) array
+    a : (..., M, M) array
         Hermitian/Symmetric matrices whose eigenvalues and
         eigenvectors are to be computed.
     UPLO : {'L', 'U'}, optional

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -681,6 +681,9 @@ def fix_invalid(a, mask=nomask, copy=True, fill_value=None):
     ----------
     a : array_like
         Input array, a (subclass of) ndarray.
+    mask : sequence, optional
+        Mask. Must be convertible to an array of booleans with the same
+        shape as `data`. True indicates a masked (i.e. invalid) data.
     copy : bool, optional
         Whether to use a copy of `a` (True) or to fix `a` in place (False).
         Default is True.
@@ -7378,21 +7381,21 @@ def append(a, b, axis=None):
 
     Parameters
     ----------
-    arr : array_like
+    a : array_like
         Values are appended to a copy of this array.
-    values : array_like
-        These values are appended to a copy of `arr`.  It must be of the
-        correct shape (the same shape as `arr`, excluding `axis`).  If `axis`
-        is not specified, `values` can be any shape and will be flattened
+    b : array_like
+        These values are appended to a copy of `a`.  It must be of the
+        correct shape (the same shape as `a`, excluding `axis`).  If `axis`
+        is not specified, `b` can be any shape and will be flattened
         before use.
     axis : int, optional
-        The axis along which `values` are appended.  If `axis` is not given,
-        both `arr` and `values` are flattened before use.
+        The axis along which `v` are appended.  If `axis` is not given,
+        both `a` and `b` are flattened before use.
 
     Returns
     -------
     append : MaskedArray
-        A copy of `arr` with `values` appended to `axis`.  Note that `append`
+        A copy of `a` with `b` appended to `axis`.  Note that `append`
         does not occur in-place: a new array is allocated and filled.  If
         `axis` is None, the result is a flattened array.
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -730,6 +730,10 @@ def compress_rowcols(x, axis=None):
 
     Parameters
     ----------
+    x : array_like, MaskedArray
+        The array to operate on.  If not a MaskedArray instance (or if no array
+        elements are masked), `x` is interpreted as a MaskedArray with
+        `mask` set to `nomask`. Must be a 2D array.
     axis : int, optional
         Axis along which to perform the operation. Default is None.
 
@@ -1561,7 +1565,7 @@ def flatnotmasked_edges(a):
 
     Parameters
     ----------
-    arr : array_like
+    a : array_like
         Input 1-D `MaskedArray`
 
     Returns

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -639,7 +639,7 @@ def fromtextfile(fname, delimitor=None, commentchar='#', missingchar='',
 
     Parameters
     ----------
-    filename : {file name/handle}
+    fname : {file name/handle}
         Handle of an opened file.
     delimitor : {None, string}, optional
         Alphanumeric character used to separate columns in the file.

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -74,6 +74,8 @@ def asmatrix(data, dtype=None):
     ----------
     data : array_like
         Input data.
+    dtype : data-type
+       Data-type of the output matrix.
 
     Returns
     -------

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -134,7 +134,7 @@ def as_series(alist, trim=True):
 
     Parameters
     ----------
-    a : array_like
+    alist : array_like
         A 1- or 2-d array_like
     trim : boolean, optional
         When True, trailing zeros are removed from the inputs.

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -84,10 +84,10 @@ def run_module_suite(file_to_run=None, argv=None):
 
     Parameters
     ----------
-    file_to_run: str, optional
+    file_to_run : str, optional
         Path to test module, or None.
         By default, run the module from which this function is called.
-    argv: list of strings
+    argv : list of strings
         Arguments to be passed to the nose test runner. ``argv[0]`` is
         ignored. All command line arguments accepted by ``nosetests``
         will work. If it is the default value None, sys.argv is used.

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1413,6 +1413,8 @@ def nulp_diff(x, y, dtype=None):
         first input array
     y : array_like
         second input array
+    dtype : dtype, optional
+        Data-type to convert `x` and `y` to if given. Default is None.
 
     Returns
     -------


### PR DESCRIPTION
I made a pass through the code base looking for places where function signatures disagree with the `Parameters` section of the docstrings using [this tool](https://github.com/rmcgibbo/doccheck).

In the appropriate cases (there were some false positives), this PR changes the docstring to be consistent with the signature. In some cases it might be preferable, all things being equal, to actually change the argument names in the signature to match the docstring, but that has a backward-compat problem with little gain.
