### PR TITLE
BUG: Fix potential overflows in rk_hypergeometric_hrua()

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -788,9 +788,9 @@ long rk_hypergeometric_hrua(rk_state *state, long good, long bad, long sample)
     d4 = ((double)mingoodbad) / popsize;
     d5 = 1.0 - d4;
     d6 = m*d4 + 0.5;
-    d7 = sqrt((popsize - m) * sample * d4 *d5 / (popsize-1) + 0.5);
+    d7 = sqrt((double)(popsize - m) * sample * d4 * d5 / (popsize - 1) + 0.5);
     d8 = D1*d7 + D2;
-    d9 = (long)floor((double)((m+1)*(mingoodbad+1))/(popsize+2));
+    d9 = (long)floor((double)(m + 1) * (mingoodbad + 1) / (popsize + 2));
     d10 = (loggam(d9+1) + loggam(mingoodbad-d9+1) + loggam(m-d9+1) +
            loggam(maxgoodbad-m+d9+1));
     d11 = min(min(m, mingoodbad)+1.0, floor(d6+16*d7));

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import sys
 from numpy.testing import (TestCase, run_module_suite, assert_,
                            assert_array_equal)
 from numpy import random
@@ -20,6 +21,16 @@ class TestRegression(TestCase):
         # Test for ticket #921
         assert_(np.all(np.random.hypergeometric(3, 18, 11, size=10) < 4))
         assert_(np.all(np.random.hypergeometric(18, 3, 11, size=10) > 0))
+
+        # Test for ticket #5623
+        args = [
+            (2**20 - 2, 2**20 - 2, 2**20 - 2),  # Check for 32-bit systems
+        ]
+        is_64bits = sys.maxsize > 2**32
+        if is_64bits:
+            args.append((2**40 - 2, 2**40 - 2, 2**40 - 2)) # Check for 64-bit systems
+        for arg in args:
+            assert_(np.random.hypergeometric(*arg) > 0)
 
     def test_logseries_convergence(self):
         # Test for ticket #923


### PR DESCRIPTION
This fixes potential integer overflows when the function is called with large arguments.
Cast to 'double' must be performed before multiplication, otherwise the integer multiplication (`(popsize -m) * sample`) is carried out first, which may cause overflow.
For example, if `good == bad == sample == 2**50`, then `m == popsize - m == 2**50`, and the product yields undefined behaviour according to the standard.
