### PR TITLE
DOC: added version information for slogdet

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -72,6 +72,8 @@ Exceptions
 Linear algebra on several matrices at once
 ------------------------------------------
 
+.. versionadded:: 1.8.0
+
 Several of the linear algebra routines listed above are able to
 compute results for several matrices at once, if they are stacked into
 the same array.

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -319,6 +319,8 @@ def solve(a, b):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -476,6 +478,8 @@ def inv(a):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -553,6 +557,8 @@ def cholesky(a):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -849,6 +855,8 @@ def eigvals(a):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -937,6 +945,8 @@ def eigvalsh(a, UPLO='L'):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1017,6 +1027,8 @@ def eig(a):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1152,6 +1164,8 @@ def eigh(a, UPLO='L'):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1259,6 +1273,8 @@ def svd(a, full_matrices=1, compute_uv=1):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1628,6 +1644,8 @@ def slogdet(a):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1697,6 +1715,8 @@ def det(a):
 
     Notes
     -----
+
+    .. versionadded:: 1.8.0
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 


### PR DESCRIPTION
Presently, the docs for `slogdet` state only that this functionality was added in 1.6.0. However, usage of `slogdet` for a stack of matrices requires at least 1.8.0. This requirement should be stated somewhere. I am not sure whether the example is the best place to do so but I did not want to mess up the list of function arguments.
