### PR TITLE
genfromtxt does not work in some cases on 32-bit systems with dtype=None

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -162,6 +162,12 @@ what was provided by *np.allclose*.
 compare NaNs as equal by setting ``equal_nan=True``. Subclasses, such as
 *np.ma.MaskedArray*, are also preserved now.
 
+*np.genfromtxt* now handles large integers correctly
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*np.genfromtxt* now correctly handles integers larger than ``2**31-1`` on
+32-bit systems and larger than ``2**63-1`` on 64-bit systems (it previously
+crashed with an ``OverflowError`` in these cases). Integers larger than
+``2**63-1`` are converted to floating-point values.
 
 Changes
 =======


### PR DESCRIPTION
If a text file contains an integer that is larger than 2**31 or so, `genfromtxt` crashes on 32-bit systems if `dtype` is set to `None` to allow auto-detection:

```
In [1]: import numpy as np

In [2]: np.genfromtxt('test.txt', dtype=None)
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-2-4e10a89c9647> in <module>()
----> 1 np.genfromtxt('test.txt', dtype=None)

/home/user/miniconda/envs/astroquery/lib/python2.7/site-packages/numpy/lib/npyio.pyc in genfromtxt(fname, dtype, comments, delimiter, skiprows, skip_header, skip_footer, converters, missing, missing_values, filling_values, usecols, names, excludelist, deletechars, replace_space, autostrip, case_sensitive, defaultfmt, unpack, usemask, loose, invalid_raise)
   1739             mdtype = list(zip(names, [np.bool] * len(column_types)))
-> 1740         output = np.array(data, dtype=ddtype)
   1741         if usemask:
   1742             outputmask = np.array(masks, dtype=mdtype)

OverflowError: Python int too large to convert to C long
```

The `test.txt` file above contains:

```
11222111331 22
```
