### PR TITLE
ENH: simplify field indexing of structured arrays

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -726,7 +726,7 @@ VOID_setitem(PyObject *op, char *ip, PyArrayObject *ap)
         PyObject *tup;
         int savedflags;
 
-        res = -1;
+        res = 0;
         /* get the names from the fields dictionary*/
         names = descr->names;
         n = PyTuple_GET_SIZE(names);

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -409,6 +409,10 @@ class TestIndexing(TestCase):
         arr = np.arange(10)
         assert_array_equal(arr[SequenceLike()], arr[SequenceLike(),])
 
+        # also test that field indexing does not segfault
+        # for a similar reason, by indexing a structured array
+        arr = np.zeros((1,), dtype=[('f1', 'i8'), ('f2', 'i8')])
+        assert_array_equal(arr[SequenceLike()], arr[SequenceLike(),])
 
 class TestFieldIndexing(TestCase):
     def test_scalar_return_type(self):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -235,6 +235,11 @@ class TestRecord(TestCase):
         rec[0].x = 1
         assert_equal(rec[0].x, np.ones(5))
 
+    def test_missing_field(self):
+        # https://github.com/numpy/numpy/issues/4806
+        arr = np.zeros((3,), dtype=[('x', int), ('y', int)])
+        assert_raises(ValueError, lambda: arr[['nofield']])
+
 def test_find_duplicate():
     l1 = [1, 2, 3, 4, 5, 6]
     assert_(np.rec.find_duplicate(l1) == [])


### PR DESCRIPTION
This commit simplifies the code in `array_subscript` and `array_assign_subscript` related to field access. This fixes https://github.com/numpy/numpy/issues/4806, and also removes a potential segfaults, eg if the array is indexed using an sequence-like object that raises an exception in getitem.
#### KeyError vs ValueError

One minor comment on field subscripts: Currently the following code raises a `ValueError`:

```
>>> a = np.zeros((1,), dtype=[('f1', 'i4')]
>>> a['nofield']
```

However `KeyError` seems slightly better to me, and it's what my code "naturally" produced (but I corrected it since some tests expected `ValueError`). Is it worth changing? (Probably not, for back-compatability).

(Also note that multi-field indexing still returns a copy, though it had been planned to return a view in 1.10. I originally considered changing that here, but I left that for another time).
