### PR TITLE
ENH: add a warning to np.save that saved object arrays are not necessarily portable

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -161,6 +161,11 @@ if sys.version_info[0] >= 3:
 else:
     import cPickle as pickle
 
+
+class PickleWarning(UserWarning):
+    pass
+
+
 MAGIC_PREFIX = asbytes('\x93NUMPY')
 MAGIC_LEN = len(MAGIC_PREFIX) + 2
 BUFFER_SIZE = 2**18  # size of buffer for reading npz files in bytes
@@ -571,6 +576,11 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
         if not allow_pickle:
             raise ValueError("Object arrays cannot be saved when "
                              "allow_pickle=False")
+        else:
+            warnings.warn("Serializing an object array as a Python pickle. "
+                          "Note that the resulting file may not be portable "
+                          "between Python 2 and 3 environments.",
+                          PickleWarning, stacklevel=2)
         if pickle_kwargs is None:
             pickle_kwargs = {}
         pickle.dump(array, fp, protocol=2, **pickle_kwargs)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -10,6 +10,7 @@ from operator import itemgetter, index as opindex
 
 import numpy as np
 from . import format
+from .format import PickleWarning
 from ._datasource import DataSource
 from numpy.core.multiarray import packbits, unpackbits
 from ._iotools import (
@@ -33,7 +34,8 @@ loads = pickle.loads
 __all__ = [
     'savetxt', 'loadtxt', 'genfromtxt', 'ndfromtxt', 'mafromtxt',
     'recfromtxt', 'recfromcsv', 'load', 'loads', 'save', 'savez',
-    'savez_compressed', 'packbits', 'unpackbits', 'fromregex', 'DataSource'
+    'savez_compressed', 'packbits', 'unpackbits', 'fromregex', 'DataSource',
+    'PickleWarning'
     ]
 
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -287,7 +287,7 @@ import numpy as np
 from numpy.compat import asbytes, asbytes_nested, sixu
 from numpy.testing import (
     run_module_suite, assert_, assert_array_equal, assert_raises, raises,
-    dec, SkipTest
+    dec, SkipTest, assert_warns, suppress_warnings
     )
 from numpy.lib import format
 
@@ -453,9 +453,12 @@ def assert_equal_(o1, o2):
 
 
 def test_roundtrip():
-    for arr in basic_arrays + record_arrays:
-        arr2 = roundtrip(arr)
-        yield assert_array_equal, arr, arr2
+    with suppress_warnings() as sup:
+        sup.filter(np.PickleWarning)
+
+        for arr in basic_arrays + record_arrays:
+            arr2 = roundtrip(arr)
+            yield assert_array_equal, arr, arr2
 
 
 def test_roundtrip_randsize():
@@ -602,6 +605,16 @@ def test_pickle_disallow():
     path = os.path.join(tempdir, 'pickle-disabled.npy')
     assert_raises(ValueError, np.save, path, np.array([None], dtype=object),
                   allow_pickle=False)
+
+
+def test_pickle_warning():
+    fd, tmpfile = tempfile.mkstemp(dir=tempdir)
+    os.close(fd)
+
+    data = np.array([1, 'a'], dtype=object)
+
+    assert_warns(np.PickleWarning, np.save, tmpfile, data,
+                 allow_pickle=True)
 
 
 def test_version_2_0():

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -133,11 +133,14 @@ class RoundtripTest(object):
         self.check_roundtrips(a)
 
     def test_array_object(self):
-        a = np.array([], object)
-        self.check_roundtrips(a)
+        with suppress_warnings() as sup:
+            sup.filter(np.PickleWarning)
 
-        a = np.array([[1, 2], [3, 4]], object)
-        self.check_roundtrips(a)
+            a = np.array([], object)
+            self.check_roundtrips(a)
+
+            a = np.array([[1, 2], [3, 4]], object)
+            self.check_roundtrips(a)
 
     def test_1D(self):
         a = np.array([1, 2, 3, 4], int)


### PR DESCRIPTION
As [suggested on the mailing list](http://article.gmane.org/gmane.comp.python.numeric.general/60065), add a warning to `np.save/savez*` to dissuade people from saving object arrays to them.

(Not sure if I'm +0 or -0 on this, but here goes.)
