### PR TITLE
DOC: Move versionadded 1.6.0 in slogdet to better place.

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1649,10 +1649,10 @@ def slogdet(a):
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
+    .. versionadded:: 1.6.0.
     The determinant is computed via LU factorization using the LAPACK
     routine z/dgetrf.
 
-    .. versionadded:: 1.6.0.
 
     Examples
     --------


### PR DESCRIPTION
Put it up top, it matches better with the versionadded 1.8.0 for
stacked matrices.

[skip ci]
