### PR TITLE
ENH: Strict checking of ufunc keyword argument names

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -359,7 +359,7 @@ advanced usage and will not typically be used.
     Defaults to true. If set to false, the output will always be a strict
     array, not a subtype.
 
-*sig*
+*sig* or *signature*
 
     Either a data-type, a tuple of data-types, or a special signature
     string indicating the input and output types of a ufunc. This argument

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -9,6 +9,29 @@ import numpy.core.operand_flag_tests as opflag_tests
 from numpy.compat import asbytes
 from numpy.core.test_rational import *
 
+
+class TestUfuncKwargs(TestCase):
+    def test_kwarg_exact(self):
+        assert_raises(TypeError, np.add, 1, 2, castingx='safe')
+        assert_raises(TypeError, np.add, 1, 2, dtypex=np.int)
+        assert_raises(TypeError, np.add, 1, 2, extobjx=[4096])
+        assert_raises(TypeError, np.add, 1, 2, outx=None)
+        assert_raises(TypeError, np.add, 1, 2, sigx='ii->i')
+        assert_raises(TypeError, np.add, 1, 2, signaturex='ii->i')
+        assert_raises(TypeError, np.add, 1, 2, subokx=False)
+        assert_raises(TypeError, np.add, 1, 2, wherex=[True])
+
+    def test_sig_signature(self):
+        assert_raises(ValueError, np.add, 1, 2, sig='ii->i',
+                      signature='ii->i')
+
+    def test_sig_dtype(self):
+        assert_raises(RuntimeError, np.add, 1, 2, sig='ii->i',
+                      dtype=np.int)
+        assert_raises(RuntimeError, np.add, 1, 2, signature='ii->i',
+                      dtype=np.int)
+
+
 class TestUfunc(TestCase):
     def test_pickle(self):
         import pickle


### PR DESCRIPTION
Raises a TypeError if any of the keyword arguments supplied to a
ufunc does not exactly match the name in the signature. Prior to
this, trailing characters were discarded, e.g. 'out2' would be
treated as if it where 'out'.
