### PR TITLE
BUG: loadtxt fails with complex data in Python 3.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -690,7 +690,7 @@ def _getconv(dtype):
     elif issubclass(typ, np.floating):
         return floatconv
     elif issubclass(typ, np.complex):
-        return complex
+        return lambda x: complex(asstr(x))
     elif issubclass(typ, np.bytes_):
         return bytes
     else:
@@ -863,7 +863,12 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             return tuple(ret)
 
     def split_line(line):
-        """Chop off comments, strip, and split at delimiter."""
+        """Chop off comments, strip, and split at delimiter.
+
+        Note that although the file is opened as text, this function
+        returns bytes.
+
+        """
         if comments is None:
             line = asbytes(line).strip(asbytes('\r\n'))
         else:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -707,6 +707,14 @@ class TestLoadTxt(TestCase):
             res = np.loadtxt(c, dtype=dt)
             assert_equal(res, tgt, err_msg="%s" % dt)
 
+    def test_from_complex(self):
+        tgt = (complex(1, 1), complex(1, -1))
+        c = TextIO()
+        c.write("%s %s" % tgt)
+        c.seek(0)
+        res = np.loadtxt(c, dtype=np.complex)
+        assert_equal(res, tgt)
+
     def test_universal_newline(self):
         f, name = mkstemp()
         os.write(f, b'1 21\r3 42\r')


### PR DESCRIPTION
The problem is that the Python complex type constructor only accepts a
pair of numbers or a string, unlike other numeric types it does not work
with byte strings. The numpy error is subtle, as loadtxt opens the file
in the default text mode, but then converts the input lines to byte
strings when they are split into separate values. The fix here is to
convert the values back to strings in the complex converter.

Closes #5655.
