### PR TITLE
BUG: check for nargs <= NPY_MAXARGS in ufunc constructor

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4450,6 +4450,14 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
 {
     PyUFuncObject *ufunc;
 
+    if (nin + nout > NPY_MAXARGS) {
+        PyErr_Format(PyExc_ValueError,
+                     "Cannot construct a ufunc with more than %d operands "
+                     "(requested number were: inputs = %d and outputs = %d)",
+                     NPY_MAXARGS, nin, nout);
+        return NULL;
+    }
+
     ufunc = PyArray_malloc(sizeof(PyUFuncObject));
     if (ufunc == NULL) {
         return NULL;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -103,6 +103,13 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
         PyErr_SetString(PyExc_TypeError, "function must be callable");
         return NULL;
     }
+    if (nin + nout > NPY_MAXARGS) {
+        PyErr_Format(PyExc_ValueError,
+                     "Cannot construct a ufunc with more than %d operands "
+                     "(requested number were: inputs = %d and outputs = %d)",
+                     NPY_MAXARGS, nin, nout);
+        return NULL;
+    }
     self = PyArray_malloc(sizeof(PyUFuncObject));
     if (self == NULL) {
         return NULL;

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2110,6 +2110,14 @@ class TestRegression(TestCase):
         test_string = np.string_('')
         assert_equal(pickle.loads(pickle.dumps(test_string)), test_string)
 
+    def test_frompyfunc_many_args(self):
+        # gh-5672
+
+        def passer(*args):
+            pass
+
+        assert_raises(ValueError, np.frompyfunc, passer, 32, 1)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes #5672
