### PR TITLE
ENH: distutils: add compiler classes for Intel compilers + MSVC-built Python

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -509,7 +509,9 @@ def CCompiler_cxx_compiler(self):
         The C++ compiler, as a `CCompiler` instance.
 
     """
-    if self.compiler_type=='msvc': return self
+    if self.compiler_type in ('msvc', 'intelw', 'intelemw'):
+        return self
+
     cxx = copy(self)
     cxx.compiler_so = [cxx.compiler_cxx[0]] + cxx.compiler_so[1:]
     if sys.platform.startswith('aix') and 'ld_so_aix' in cxx.linker_so[0]:
@@ -525,15 +527,21 @@ replace_method(CCompiler, 'cxx_compiler', CCompiler_cxx_compiler)
 compiler_class['intel'] = ('intelccompiler', 'IntelCCompiler',
                            "Intel C Compiler for 32-bit applications")
 compiler_class['intele'] = ('intelccompiler', 'IntelItaniumCCompiler',
-                           "Intel C Itanium Compiler for Itanium-based applications")
+                            "Intel C Itanium Compiler for Itanium-based applications")
 compiler_class['intelem'] = ('intelccompiler', 'IntelEM64TCCompiler',
                              "Intel C Compiler for 64-bit applications")
+compiler_class['intelw'] = ('intelccompiler', 'IntelCCompilerW',
+                            "Intel C Compiler for 32-bit applications on Windows")
+compiler_class['intelemw'] = ('intelem64tccompiler', 'IntelEM64TCCompilerW',
+                              "Intel C Compiler for 64-bit applications on Windows")
 compiler_class['pathcc'] = ('pathccompiler', 'PathScaleCCompiler',
                             "PathScale Compiler for SiCortex-based applications")
 ccompiler._default_compilers += (('linux.*', 'intel'),
                                  ('linux.*', 'intele'),
                                  ('linux.*', 'intelem'),
-                                 ('linux.*', 'pathcc'))
+                                 ('linux.*', 'pathcc'),
+                                 ('nt', 'intelw'),
+                                 ('nt', 'intelemw'))
 
 if sys.platform == 'win32':
     compiler_class['mingw32'] = ('mingw32ccompiler', 'Mingw32CCompiler',

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -2,15 +2,18 @@ from __future__ import division, absolute_import, print_function
 
 from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.exec_command import find_executable
+from numpy.distutils.msvc9compiler import MSVCCompiler
+from numpy.distutils.ccompiler import simple_version_match
+
 
 class IntelCCompiler(UnixCCompiler):
-    """ A modified Intel compiler compatible with an gcc built Python."""
+    """A modified Intel compiler compatible with a GCC-built Python."""
     compiler_type = 'intel'
     cc_exe = 'icc'
     cc_args = 'fPIC'
 
-    def __init__ (self, verbose=0, dry_run=0, force=0):
-        UnixCCompiler.__init__ (self, verbose, dry_run, force)
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        UnixCCompiler.__init__(self, verbose, dry_run, force)
         self.cc_exe = 'icc -fPIC'
         compiler = self.cc_exe
         self.set_executables(compiler=compiler,
@@ -18,6 +21,7 @@ class IntelCCompiler(UnixCCompiler):
                              compiler_cxx=compiler,
                              linker_exe=compiler,
                              linker_so=compiler + ' -shared')
+
 
 class IntelItaniumCCompiler(IntelCCompiler):
     compiler_type = 'intele'
@@ -28,14 +32,16 @@ class IntelItaniumCCompiler(IntelCCompiler):
         if cc_exe:
             break
 
+
 class IntelEM64TCCompiler(UnixCCompiler):
-    """ A modified Intel x86_64 compiler compatible with a 64bit gcc built Python.
+    """
+    A modified Intel x86_64 compiler compatible with a 64bit GCC-built Python.
     """
     compiler_type = 'intelem'
     cc_exe = 'icc -m64 -fPIC'
     cc_args = "-fPIC"
-    def __init__ (self, verbose=0, dry_run=0, force=0):
-        UnixCCompiler.__init__ (self, verbose, dry_run, force)
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        UnixCCompiler.__init__(self, verbose, dry_run, force)
         self.cc_exe = 'icc -m64 -fPIC'
         compiler = self.cc_exe
         self.set_executables(compiler=compiler,
@@ -43,3 +49,35 @@ class IntelEM64TCCompiler(UnixCCompiler):
                              compiler_cxx=compiler,
                              linker_exe=compiler,
                              linker_so=compiler + ' -shared')
+
+
+class IntelCCompilerW(MSVCCompiler):
+    """
+    A modified Intel compiler on Windows compatible with an MSVC-built Python.
+    """
+    compiler_type = 'intelw'
+
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        MSVCCompiler.__init__(self, verbose, dry_run, force)
+        version_match = simple_version_match(start='Intel\(R\).*?32,')
+        self.__version = version_match
+
+    def initialize(self, plat_name=None):
+        MSVCCompiler.initialize(self, plat_name)
+        self.cc = self.find_exe("icl.exe")
+        self.linker = self.find_exe("xilink")
+        self.compile_options = ['/nologo', '/O3', '/MD', '/W3']
+        self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/Z7',
+                                      '/D_DEBUG']
+
+
+class IntelEM64TCCompilerW(IntelCCompilerW):
+    """
+    A modified Intel x86_64 compiler compatible with a 64bit MSVC-built Python.
+    """
+    compiler_type = 'intelemw'
+
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        MSVCCompiler.__init__(self, verbose, dry_run, force)
+        version_match = simple_version_match(start='Intel\(R\).*?64,')
+        self.__version = version_match


### PR DESCRIPTION
Thanks to Intel for contributing this patch. 
