### PR TITLE
MAINT: use the fast elementwise 2-norm implementation more often in linalg.norm

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2082,18 +2082,22 @@ def norm(x, ord=None, axis=None, keepdims=False):
     """
     x = asarray(x)
 
-    # Check the default case first and handle it immediately.
-    if ord is None and axis is None:
+    # Immediately handle some default, simple, fast, and common cases.
+    if axis is None:
         ndim = x.ndim
-        x = x.ravel(order='K')
-        if isComplexType(x.dtype.type):
-            sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
-        else:
-            sqnorm = dot(x, x)
-        ret = sqrt(sqnorm)
-        if keepdims:
-            ret = ret.reshape(ndim*[1])
-        return ret
+        if ((ord is None) or
+            (ord in ('f', 'fro') and ndim == 2) or
+            (ord == 2 and ndim == 1)):
+
+            x = x.ravel(order='K')
+            if isComplexType(x.dtype.type):
+                sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
+            else:
+                sqnorm = dot(x, x)
+            ret = sqrt(sqnorm)
+            if keepdims:
+                ret = ret.reshape(ndim*[1])
+            return ret
 
     # Normalize the `axis` argument to a tuple.
     nd = x.ndim


### PR DESCRIPTION
This applies the speedup in https://github.com/numpy/numpy/pull/3895 across more combinations of inputs, addressing the 'lovely example' in https://github.com/scipy/scipy/pull/4642#issuecomment-83237655.

Some timings:

```
before:
In [1]: import numpy as np
In [2]: a = np.random.randn(1000, 1000)
In [3]: %timeit np.linalg.norm(a.ravel())
1000 loops, best of 3: 441 µs per loop
In [4]: %timeit np.linalg.norm(a, 'fro')
1000 loops, best of 3: 1.84 ms per loop

after:
In [1]: import numpy as np
In [2]: a = np.random.randn(1000, 1000)
In [3]: %timeit np.linalg.norm(a.ravel())
1000 loops, best of 3: 441 µs per loop
In [4]: %timeit np.linalg.norm(a, 'fro')
1000 loops, best of 3: 441 µs per loop
```
