### PR TITLE
TST: Disable travis bento build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ matrix:
       env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.4
       env: NPY_RELAXED_STRIDES_CHECKING=0
-    - python: 2.7
-      env: USE_BENTO=1
+# disable bento test until waf issue is resolved.
+#    - python: 2.7
+#      env: USE_BENTO=1
     - python: 2.7
       env: USE_WHEEL=1
 before_install:


### PR DESCRIPTION
The waf.io site needed looks to be offline at the moment. This
disables the travis bento build test that depends on it.
