### PR TITLE
backport #5475

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1843,11 +1843,6 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
                 &PyArrayDescr_Type, &typecode, &obj)) {
         return NULL;
     }
-    if (typecode->elsize == 0) {
-        PyErr_SetString(PyExc_ValueError,
-                "itemsize cannot be zero");
-        return NULL;
-    }
 
     if (PyDataType_FLAGCHK(typecode, NPY_ITEM_IS_POINTER)) {
         if (obj == NULL) {
@@ -1857,6 +1852,9 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     }
     else {
         if (obj == NULL) {
+            if (typecode->elsize == 0) {
+                typecode->elsize = 1;
+            }
             dptr = PyArray_malloc(typecode->elsize);
             if (dptr == NULL) {
                 return PyErr_NoMemory();

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2103,6 +2103,13 @@ class TestRegression(TestCase):
         assert_equal(np.int32(10) == x, "OK")
         assert_equal(np.array([10]) == x, "OK")
 
+    def test_pickle_empty_string(self):
+        # gh-3926
+
+        import pickle
+        test_string = np.string_('')
+        assert_equal(pickle.loads(pickle.dumps(test_string)), test_string)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport the [PR](https://github.com/numpy/numpy/pull/5475) that fixes [this issue](https://github.com/numpy/numpy/issues/3926). To allow pickling empty strings.
