### PR TITLE
DOC: Covariance matrix should be symmetric

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4295,7 +4295,7 @@ cdef class RandomState:
         Examples
         --------
         >>> mean = (1, 2)
-        >>> cov = [[1, 0], [1, 0]]
+        >>> cov = [[1, 0], [0, 1]]
         >>> x = np.random.multivariate_normal(mean, cov, (3, 3))
         >>> x.shape
         (3, 3, 2)


### PR DESCRIPTION
Fix a typo in `random.multivariate_normal.__doc__` where a non-symmetric matrix is used as the covariance matrix. The covariance matrix is specified to be symmetric [here](https://github.com/numpy/numpy/blob/c0c6690d0cdfe820d14d5d8520ddd999c32a156a/numpy/random/mtrand/mtrand.pyx#L4231).
