### PR TITLE
BUG: Fix segfault with custom dtypes 

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -1362,6 +1362,13 @@ get_nbo_cast_transfer_function(int aligned,
             break;
     }
 
+    if (PyDataType_FLAGCHK(src_dtype, NPY_NEEDS_PYAPI) ||
+            PyDataType_FLAGCHK(dst_dtype, NPY_NEEDS_PYAPI)) {
+        if (out_needs_api) {
+            *out_needs_api = 1;
+        }
+    }
+
     /* Get the cast function */
     castfunc = PyArray_GetCastFunc(src_dtype, dst_dtype->type_num);
     if (!castfunc) {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import numpy as np
 from numpy.testing import *
+from numpy.core.test_rational import rational
 
 def assert_dtype_equal(a, b):
     assert_equal(a, b)
@@ -531,6 +532,12 @@ class TestDtypeAttributes(TestCase):
         # Ticket #4357
         class user_def_subcls(np.void): pass
         assert_equal(np.dtype(user_def_subcls).name, 'user_def_subcls')
+
+
+def test_rational_dtype():
+    # test for bug gh-5719
+    a = np.array([1111], dtype=rational).astype
+    assert_raises(OverflowError, a, 'int8')
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -7,7 +7,7 @@ from numpy.testing import *
 import numpy.core.umath_tests as umt
 import numpy.core.operand_flag_tests as opflag_tests
 from numpy.compat import asbytes
-from numpy.core.test_rational import *
+from numpy.core.test_rational import rational, test_add, test_add_rationals
 
 
 class TestUfuncKwargs(TestCase):


### PR DESCRIPTION
This closes github bug #5719 

``` python
In [1]: import numpy as np

In [2]: from numpy.core.test_rational import rational

In [3]: np.array([1111], dtype=rational).astype('int8')
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-3-7ddceeb98104> in <module>()
----> 1 np.array([1111], dtype=rational).astype('int8')

OverflowError: overflow in rational arithmetic
```

as expected
