### PR TITLE
MAINT: Refactor .flags attribute of ndarray

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2638,7 +2638,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('flags',
     CARRAY (CA)
         BEHAVED and C_CONTIGUOUS.
     FARRAY (FA)
-        BEHAVED and F_CONTIGUOUS and not C_CONTIGUOUS.
+        BEHAVED and F_CONTIGUOUS.
 
     Notes
     -----

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1123,9 +1123,9 @@ gentype_ndim_get(PyObject *NPY_UNUSED(self))
 }
 
 static PyObject *
-gentype_flags_get(PyObject *NPY_UNUSED(self))
+gentype_flags_get(PyObject *self)
 {
-    return PyArray_NewFlagsObject(NULL);
+    return PyArray_NewFlagsObject(self);
 }
 
 static PyObject *
@@ -2575,7 +2575,7 @@ static PyObject *
     PyArrayObject *arr;
     PyArray_Descr *typecode = NULL;
 #if (@work@ != 0) || (@default@ == 1)
-    void *thisfunc = (void *)@name@_arrtype_new; 
+    void *thisfunc = (void *)@name@_arrtype_new;
 #endif
 #if !(@default@ == 2)
     int itemsize;

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -514,9 +514,8 @@ class TestFortranFlagDeprecation(_DeprecationTestCase):
     ndarray.flags.f_contiguous.
 
     """
-    message = ("the 'fortran' attribute is deprecated and "
-               "will be removed in a future release, use "
-               "'f_contiguous' instead")
+    message = ("the 'fortran' attribute is deprecated and will be\n"
+               "removed in a future release, use 'f_contiguous' instead")
 
     def test_fortran_flag_deprecation(self):
         a = np.arange(10)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -508,5 +508,21 @@ class TestAlterdotRestoredotDeprecations(_DeprecationTestCase):
         self.assert_deprecated(np.restoredot)
 
 
+class TestFortranFlagDeprecation(_DeprecationTestCase):
+    """The definition of ndarray.flags.fortran was inconsistent with the
+    C macro PyArray_ISFORTRAN, so it has been deprecated in favor of
+    ndarray.flags.f_contiguous.
+
+    """
+    message = ("the 'fortran' attribute is deprecated and "
+               "will be removed in a future release, use "
+               "'f_contiguous' instead")
+
+    def test_fortran_flag_deprecation(self):
+        a = np.arange(10)
+        self.assert_deprecated(getattr, args=(a.flags, 'fortran'))
+        self.assert_deprecated(a.flags.__getitem__, args=('FORTRAN',))
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -60,7 +60,7 @@ class TestFlags(TestCase):
 
     def test_otherflags(self):
         assert_equal(self.a.flags.carray, True)
-        assert_equal(self.a.flags.farray, False)
+        assert_equal(self.a.flags.farray, True)
         assert_equal(self.a.flags.behaved, True)
         assert_equal(self.a.flags.fnc, False)
         assert_equal(self.a.flags.forc, True)
@@ -1040,12 +1040,10 @@ class TestMethods(TestCase):
 
     def test_copy(self):
         def assert_fortran(arr):
-            assert_(arr.flags.fortran)
             assert_(arr.flags.f_contiguous)
             assert_(not arr.flags.c_contiguous)
 
         def assert_c(arr):
-            assert_(not arr.flags.fortran)
             assert_(not arr.flags.f_contiguous)
             assert_(arr.flags.c_contiguous)
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2234,7 +2234,7 @@ def test_outer_out_param():
 
 class TestRequire(object):
     flag_names = ['C', 'C_CONTIGUOUS', 'CONTIGUOUS',
-                  'F', 'F_CONTIGUOUS', 'FORTRAN',
+                  'F', 'F_CONTIGUOUS',
                   'A', 'ALIGNED',
                   'W', 'WRITEABLE',
                   'O', 'OWNDATA']

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2027,9 +2027,7 @@ class TestRegression(TestCase):
         a = np.empty((2, 2), order='F')
         b = copy.copy(a)
         c = copy.deepcopy(a)
-        assert_(b.flags.fortran)
         assert_(b.flags.f_contiguous)
-        assert_(c.flags.fortran)
         assert_(c.flags.f_contiguous)
 
     def test_fortran_order_buffer(self):

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -46,7 +46,7 @@ def flags_info(arr):
 
 def flags2names(flags):
     info = []
-    for flagname in ['CONTIGUOUS', 'F_CONTIGUOUS', 'OWNDATA', 'ENSURECOPY',
+    for flagname in ['C_CONTIGUOUS', 'F_CONTIGUOUS', 'OWNDATA', 'ENSURECOPY',
                      'ENSUREARRAY', 'ALIGNED', 'NOTSWAPPED', 'WRITEABLE',
                      'UPDATEIFCOPY', 'BEHAVED', 'BEHAVED_RO',
                      'CARRAY', 'FARRAY'
@@ -199,12 +199,12 @@ class Array(object):
                 assert_(intent.flags & wrap.F2PY_INTENT_C)
                 assert_(not self.arr.flags['F_CONTIGUOUS'],
                         repr((self.arr.flags, getattr(obj, 'flags', None))))
-                assert_(self.arr.flags['CONTIGUOUS'])
+                assert_(self.arr.flags['C_CONTIGUOUS'])
                 assert_(not self.arr_attr[6] & wrap.FORTRAN)
             else:
                 assert_(not intent.flags & wrap.F2PY_INTENT_C)
                 assert_(self.arr.flags['F_CONTIGUOUS'])
-                assert_(not self.arr.flags['CONTIGUOUS'])
+                assert_(not self.arr.flags['C_CONTIGUOUS'])
                 assert_(self.arr_attr[6] & wrap.FORTRAN)
 
         if obj is None:
@@ -227,11 +227,11 @@ class Array(object):
         if len(dims)>1:
             if self.intent.is_intent('c'):
                 assert_(not self.pyarr.flags['F_CONTIGUOUS'])
-                assert_(self.pyarr.flags['CONTIGUOUS'])
+                assert_(self.pyarr.flags['C_CONTIGUOUS'])
                 assert_(not self.pyarr_attr[6] & wrap.FORTRAN)
             else:
                 assert_(self.pyarr.flags['F_CONTIGUOUS'])
-                assert_(not self.pyarr.flags['CONTIGUOUS'])
+                assert_(not self.pyarr.flags['C_CONTIGUOUS'])
                 assert_(self.pyarr_attr[6] & wrap.FORTRAN)
 
 
@@ -460,13 +460,15 @@ class _test_shared_memory:
         a = self.array(shape, intent.hide, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(a.arr.flags['F_CONTIGUOUS'] and not a.arr.flags['CONTIGUOUS'])
+        assert_(a.arr.flags['F_CONTIGUOUS'] and
+                not a.arr.flags['C_CONTIGUOUS'])
 
         shape = (2, 3)
         a = self.array(shape, intent.c.hide, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(not a.arr.flags['F_CONTIGUOUS'] and a.arr.flags['CONTIGUOUS'])
+        assert_(not a.arr.flags['F_CONTIGUOUS'] and
+                a.arr.flags['C_CONTIGUOUS'])
 
         shape = (-1, 3)
         try:
@@ -487,13 +489,15 @@ class _test_shared_memory:
         a = self.array(shape, intent.optional, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(a.arr.flags['F_CONTIGUOUS'] and not a.arr.flags['CONTIGUOUS'])
+        assert_(a.arr.flags['F_CONTIGUOUS'] and
+                not a.arr.flags['C_CONTIGUOUS'])
 
         shape = (2, 3)
         a = self.array(shape, intent.c.optional, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(not a.arr.flags['F_CONTIGUOUS'] and a.arr.flags['CONTIGUOUS'])
+        assert_(not a.arr.flags['F_CONTIGUOUS'] and
+                a.arr.flags['C_CONTIGUOUS'])
 
     def test_optional_from_2seq(self):
         obj = self.num2seq
@@ -515,7 +519,7 @@ class _test_shared_memory:
 
     def test_inplace(self):
         obj = array(self.num23seq, dtype=self.type.dtype)
-        assert_(not obj.flags['F_CONTIGUOUS'] and obj.flags['CONTIGUOUS'])
+        assert_(not obj.flags['F_CONTIGUOUS'] and obj.flags['C_CONTIGUOUS'])
         shape = obj.shape
         a = self.array(shape, intent.inplace, obj)
         assert_(obj[1][2]==a.arr[1][2], repr((obj, a.arr)))
@@ -523,7 +527,7 @@ class _test_shared_memory:
         assert_(obj[1][2]==a.arr[1][2]==array(54, dtype=self.type.dtype), repr((obj, a.arr)))
         assert_(a.arr is obj)
         assert_(obj.flags['F_CONTIGUOUS']) # obj attributes are changed inplace!
-        assert_(not obj.flags['CONTIGUOUS'])
+        assert_(not obj.flags['C_CONTIGUOUS'])
 
     def test_inplace_from_casttype(self):
         for t in self.type.cast_types():
@@ -532,7 +536,7 @@ class _test_shared_memory:
             obj = array(self.num23seq, dtype=t.dtype)
             assert_(obj.dtype.type==t.dtype)
             assert_(obj.dtype.type is not self.type.dtype)
-            assert_(not obj.flags['F_CONTIGUOUS'] and obj.flags['CONTIGUOUS'])
+            assert_(not obj.flags['F_CONTIGUOUS'] and obj.flags['C_CONTIGUOUS'])
             shape = obj.shape
             a = self.array(shape, intent.inplace, obj)
             assert_(obj[1][2]==a.arr[1][2], repr((obj, a.arr)))
@@ -540,7 +544,7 @@ class _test_shared_memory:
             assert_(obj[1][2]==a.arr[1][2]==array(54, dtype=self.type.dtype), repr((obj, a.arr)))
             assert_(a.arr is obj)
             assert_(obj.flags['F_CONTIGUOUS']) # obj attributes are changed inplace!
-            assert_(not obj.flags['CONTIGUOUS'])
+            assert_(not obj.flags['C_CONTIGUOUS'])
             assert_(obj.dtype.type is self.type.dtype) # obj type is changed inplace!
 
 

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -46,7 +46,7 @@ def flags_info(arr):
 
 def flags2names(flags):
     info = []
-    for flagname in ['CONTIGUOUS', 'FORTRAN', 'OWNDATA', 'ENSURECOPY',
+    for flagname in ['CONTIGUOUS', 'F_CONTIGUOUS', 'OWNDATA', 'ENSURECOPY',
                      'ENSUREARRAY', 'ALIGNED', 'NOTSWAPPED', 'WRITEABLE',
                      'UPDATEIFCOPY', 'BEHAVED', 'BEHAVED_RO',
                      'CARRAY', 'FARRAY'
@@ -197,12 +197,13 @@ class Array(object):
         if len(dims)>1:
             if self.intent.is_intent('c'):
                 assert_(intent.flags & wrap.F2PY_INTENT_C)
-                assert_(not self.arr.flags['FORTRAN'], repr((self.arr.flags, getattr(obj, 'flags', None))))
+                assert_(not self.arr.flags['F_CONTIGUOUS'],
+                        repr((self.arr.flags, getattr(obj, 'flags', None))))
                 assert_(self.arr.flags['CONTIGUOUS'])
                 assert_(not self.arr_attr[6] & wrap.FORTRAN)
             else:
                 assert_(not intent.flags & wrap.F2PY_INTENT_C)
-                assert_(self.arr.flags['FORTRAN'])
+                assert_(self.arr.flags['F_CONTIGUOUS'])
                 assert_(not self.arr.flags['CONTIGUOUS'])
                 assert_(self.arr_attr[6] & wrap.FORTRAN)
 
@@ -225,11 +226,11 @@ class Array(object):
 
         if len(dims)>1:
             if self.intent.is_intent('c'):
-                assert_(not self.pyarr.flags['FORTRAN'])
+                assert_(not self.pyarr.flags['F_CONTIGUOUS'])
                 assert_(self.pyarr.flags['CONTIGUOUS'])
                 assert_(not self.pyarr_attr[6] & wrap.FORTRAN)
             else:
-                assert_(self.pyarr.flags['FORTRAN'])
+                assert_(self.pyarr.flags['F_CONTIGUOUS'])
                 assert_(not self.pyarr.flags['CONTIGUOUS'])
                 assert_(self.pyarr_attr[6] & wrap.FORTRAN)
 
@@ -459,13 +460,13 @@ class _test_shared_memory:
         a = self.array(shape, intent.hide, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(a.arr.flags['FORTRAN'] and not a.arr.flags['CONTIGUOUS'])
+        assert_(a.arr.flags['F_CONTIGUOUS'] and not a.arr.flags['CONTIGUOUS'])
 
         shape = (2, 3)
         a = self.array(shape, intent.c.hide, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(not a.arr.flags['FORTRAN'] and a.arr.flags['CONTIGUOUS'])
+        assert_(not a.arr.flags['F_CONTIGUOUS'] and a.arr.flags['CONTIGUOUS'])
 
         shape = (-1, 3)
         try:
@@ -486,13 +487,13 @@ class _test_shared_memory:
         a = self.array(shape, intent.optional, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(a.arr.flags['FORTRAN'] and not a.arr.flags['CONTIGUOUS'])
+        assert_(a.arr.flags['F_CONTIGUOUS'] and not a.arr.flags['CONTIGUOUS'])
 
         shape = (2, 3)
         a = self.array(shape, intent.c.optional, None)
         assert_(a.arr.shape==shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
-        assert_(not a.arr.flags['FORTRAN'] and a.arr.flags['CONTIGUOUS'])
+        assert_(not a.arr.flags['F_CONTIGUOUS'] and a.arr.flags['CONTIGUOUS'])
 
     def test_optional_from_2seq(self):
         obj = self.num2seq
@@ -514,14 +515,14 @@ class _test_shared_memory:
 
     def test_inplace(self):
         obj = array(self.num23seq, dtype=self.type.dtype)
-        assert_(not obj.flags['FORTRAN'] and obj.flags['CONTIGUOUS'])
+        assert_(not obj.flags['F_CONTIGUOUS'] and obj.flags['CONTIGUOUS'])
         shape = obj.shape
         a = self.array(shape, intent.inplace, obj)
         assert_(obj[1][2]==a.arr[1][2], repr((obj, a.arr)))
         a.arr[1][2]=54
         assert_(obj[1][2]==a.arr[1][2]==array(54, dtype=self.type.dtype), repr((obj, a.arr)))
         assert_(a.arr is obj)
-        assert_(obj.flags['FORTRAN']) # obj attributes are changed inplace!
+        assert_(obj.flags['F_CONTIGUOUS']) # obj attributes are changed inplace!
         assert_(not obj.flags['CONTIGUOUS'])
 
     def test_inplace_from_casttype(self):
@@ -531,14 +532,14 @@ class _test_shared_memory:
             obj = array(self.num23seq, dtype=t.dtype)
             assert_(obj.dtype.type==t.dtype)
             assert_(obj.dtype.type is not self.type.dtype)
-            assert_(not obj.flags['FORTRAN'] and obj.flags['CONTIGUOUS'])
+            assert_(not obj.flags['F_CONTIGUOUS'] and obj.flags['CONTIGUOUS'])
             shape = obj.shape
             a = self.array(shape, intent.inplace, obj)
             assert_(obj[1][2]==a.arr[1][2], repr((obj, a.arr)))
             a.arr[1][2]=54
             assert_(obj[1][2]==a.arr[1][2]==array(54, dtype=self.type.dtype), repr((obj, a.arr)))
             assert_(a.arr is obj)
-            assert_(obj.flags['FORTRAN']) # obj attributes are changed inplace!
+            assert_(obj.flags['F_CONTIGUOUS']) # obj attributes are changed inplace!
             assert_(not obj.flags['CONTIGUOUS'])
             assert_(obj.dtype.type is self.type.dtype) # obj type is changed inplace!
 

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -278,7 +278,7 @@ class matrix(N.ndarray):
             shape = (1, shape[0])
 
         order = False
-        if (ndim == 2) and arr.flags.fortran:
+        if (ndim == 2) and arr.flags.f_contiguous:
             order = True
 
         if not (order or arr.flags.contiguous):


### PR DESCRIPTION
Fixes #5721. Changes include:

The object returned now fully behaves like a mutable attribute of
the array, by not using a cached, possibly outdated, value of the
flags whenever the original array can be queried.

Also, the class constructor now requires being linked to either
an array or a numpy scalar, can no longer be initialized without
any argument.

Also, fixed the check for the FARRAY flag, which was notoriously
broken. As part of the fix, it was made to match PyArray_ISFARRAY
and no longer requires that the array not be C_CONTIGUOUS.

When possible, flag checks use the corresponding C function/macro,
which may cause subtly different behavior, e.g. BEHAVED, CARRAY
and FARRAY now also require that the dtype not be swapped.

The FORTRAN flag, which behaved differently from the
PyArray_ISFORTRAN C macro, has been deprecated. It wasn't even
mentioned in the docs, so it seems like a low risk change.

The code has been refactored to avoid repetition and made a little
more compact.
