### PR TITLE
DOC: Docstring of gradient() function

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -906,9 +906,9 @@ def gradient(f, *varargs, **kwargs):
 
     Returns
     -------
-    gradient : ndarray
-        N arrays of the same shape as `f` giving the derivative of `f` with
-        respect to each dimension.
+    gradient : list of ndarray
+        Each element of `list` has the same shape as `f` giving the derivative 
+        of `f` with respect to each dimension.
 
     Examples
     --------


### PR DESCRIPTION
Updating of docstring of gradient() function specifying the return is a `list` of `ndarray`.
