### PR TITLE
DOC, MAINT: fix typo in np.insert docstring

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3739,6 +3739,7 @@ def insert(arr, obj, values, axis=None):
            [3, 5, 3]])
 
     Difference between sequence and scalars:
+
     >>> np.insert(a, [1], [[1],[2],[3]], axis=1)
     array([[1, 1, 1],
            [2, 2, 2],


### PR DESCRIPTION
Add a line between text description and code example for the `np.insert` function.
