### PR TITLE
LIBPATH with spaces is now supported Python 2.7+ and Win32

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -583,8 +583,8 @@ ccompiler.gen_lib_options = gen_lib_options
 # Also fix up the various compiler modules, which do
 # from distutils.ccompiler import gen_lib_options
 # Don't bother with mwerks, as we don't support Classic Mac.
-for _cc in ['msvc', 'bcpp', 'cygwinc', 'emxc', 'unixc']:
-    _m = sys.modules.get('distutils.'+_cc+'compiler')
+for _cc in ['msvc9', 'msvc', 'bcpp', 'cygwinc', 'emxc', 'unixc']:
+    _m = sys.modules.get('distutils.' + _cc + 'compiler')
     if _m is not None:
         setattr(_m, 'gen_lib_options', gen_lib_options)
 


### PR DESCRIPTION
This looks like a very old bug - ever since msvc9 was introduced.

Known (to me) cases which triggered the issue on win32:
- The Python install path contained spaces.
- site.cfg library_dirs contained paths with spaces.

Build would fail in the link stage with an error similar to "Files.obj cannot be found".

Any suggestions on how to implement a test for this?
