### PR TITLE
ENH: add options for disabling use of pickle in load/save

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -515,7 +515,7 @@ def _read_array_header(fp, version):
 
     return d['shape'], d['fortran_order'], dtype
 
-def write_array(fp, array, version=None, pickle_kwargs=None):
+def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
     """
     Write an array to an NPY file, including a header.
 
@@ -533,6 +533,8 @@ def write_array(fp, array, version=None, pickle_kwargs=None):
     version : (int, int) or None, optional
         The version number of the format. None means use the oldest
         supported version that is able to store the data.  Default: None
+    allow_pickle : bool, optional
+        Whether to allow writing pickled data. Default: True
     pickle_kwargs : dict, optional
         Additional keyword arguments to pass to pickle.dump, excluding
         'protocol'. These are only useful when pickling objects in object
@@ -541,7 +543,8 @@ def write_array(fp, array, version=None, pickle_kwargs=None):
     Raises
     ------
     ValueError
-        If the array cannot be persisted.
+        If the array cannot be persisted. This includes the case of
+        allow_pickle=False and array being an object array.
     Various other errors
         If the array contains Python objects as part of its dtype, the
         process of pickling them may raise various errors if the objects
@@ -563,6 +566,9 @@ def write_array(fp, array, version=None, pickle_kwargs=None):
         # We contain Python objects so we cannot write out the data
         # directly.  Instead, we will pickle it out with version 2 of the
         # pickle protocol.
+        if not allow_pickle:
+            raise ValueError("Object arrays cannot be saved when "
+                             "allow_pickle=False")
         if pickle_kwargs is None:
             pickle_kwargs = {}
         pickle.dump(array, fp, protocol=2, **pickle_kwargs)
@@ -584,7 +590,7 @@ def write_array(fp, array, version=None, pickle_kwargs=None):
                 fp.write(chunk.tobytes('C'))
 
 
-def read_array(fp, pickle_kwargs=None):
+def read_array(fp, allow_pickle=True, pickle_kwargs=None):
     """
     Read an array from an NPY file.
 
@@ -593,6 +599,8 @@ def read_array(fp, pickle_kwargs=None):
     fp : file_like object
         If this is not a real file object, then this may take extra memory
         and time.
+    allow_pickle : bool, optional
+        Whether to allow reading pickled data. Default: True
     pickle_kwargs : dict
         Additional keyword arguments to pass to pickle.load. These are only
         useful when loading object arrays saved on Python 2 when using
@@ -606,7 +614,8 @@ def read_array(fp, pickle_kwargs=None):
     Raises
     ------
     ValueError
-        If the data is invalid.
+        If the data is invalid, or allow_pickle=False and the file contains
+        an object array.
 
     """
     version = read_magic(fp)
@@ -620,6 +629,9 @@ def read_array(fp, pickle_kwargs=None):
     # Now read the actual data.
     if dtype.hasobject:
         # The array contained Python objects. We need to unpickle the data.
+        if not allow_pickle:
+            raise ValueError("Object arrays cannot be loaded when "
+                             "allow_pickle=False")
         if pickle_kwargs is None:
             pickle_kwargs = {}
         try:

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -599,6 +599,22 @@ def test_pickle_python2_python3():
                                   encoding='latin1', fix_imports=False)
 
 
+def test_pickle_disallow():
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+    path = os.path.join(data_dir, 'py2-objarr.npy')
+    assert_raises(ValueError, np.load, path,
+                  allow_pickle=False, encoding='latin1')
+
+    path = os.path.join(data_dir, 'py2-objarr.npz')
+    f = np.load(path, allow_pickle=False, encoding='latin1')
+    assert_raises(ValueError, f.__getitem__, 'x')
+
+    path = os.path.join(tempdir, 'pickle-disabled.npy')
+    assert_raises(ValueError, np.save, path, np.array([None], dtype=object),
+                  allow_pickle=False)
+
+
 def test_version_2_0():
     f = BytesIO()
     # requires more than 2 byte for header


### PR DESCRIPTION
Following the [discussion on the mailing list](http://article.gmane.org/gmane.comp.python.numeric.general/60071), add options to `np.load` and `np.save` for disallowing use of pickle.

Very good reason for not using pickle on loading is security (arbitrary code execution), and a good reason for not using it on saving is enforcing portability (pickles are not portable; e.g. they are generally incompatible between Py2 and Py3).

This doesn't add the options to `savez*`, since the API for those is such that adding kwargs cannot be cleanly done.

I didn't add `allow_pickle` to the end of kwarg lists, as the `encoding`, `fix_imports` kwargs have not been included in a released version yet.

Changing the default value to `allow_pickle=False` could make sense, but that probably has not insignificant backward compat issues, so I won't consider it here.
