### PR TITLE
Expanded warning conditions for array_split

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -423,7 +423,8 @@ def array_split(ary, indices_or_sections, axis=0):
     # This "kludge" was introduced here to replace arrays shaped (0, 10)
     # or similar with an array shaped (0,).
     # There seems no need for this, so give a FutureWarning to remove later.
-    if sub_arys[-1].size == 0 and sub_arys[-1].ndim != 1:
+    if (any([sub_arys[i].size == 0 and 
+             sub_arys[i].ndim != 1 for i in range(len(sub_arys))])):
         warnings.warn("in the future np.array_split will retain the shape of "
                       "arrays with a zero size, instead of replacing them by "
                       "`array([])`, which always has a shape of (0,).",


### PR DESCRIPTION
Zero-sized arrays can also occur with any of the partitions sub_arys[i]
induced by array_split, not just the final partition sub_arys[-1].
