### PR TITLE
Hide testing helper tracebacks when using them with pytest

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -255,7 +255,7 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
      DESIRED: 6
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     if isinstance(desired, dict):
         if not isinstance(actual, dict) :
             raise AssertionError(repr(type(actual)))
@@ -362,7 +362,7 @@ def print_assert_equal(test_string, actual, desired):
     [0, 2]
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     import pprint
 
     if not (actual == desired):
@@ -436,7 +436,7 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
      y: array([ 1.        ,  2.33333334])
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     from numpy.core import ndarray
     from numpy.lib import iscomplexobj, real, imag
 
@@ -550,7 +550,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
     True
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     import numpy as np
 
     (actual, desired) = map(float, (actual, desired))
@@ -592,7 +592,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          header='', precision=6):
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     from numpy.core import array, isnan, isinf, any, all, inf
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -813,7 +813,7 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
      y: array([ 1.     ,  2.33333,  5.     ])
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     from numpy.core import around, number, float_, result_type, array
     from numpy.core.numerictypes import issubdtype
     from numpy.core.fromnumeric import any as npany
@@ -914,7 +914,7 @@ def assert_array_less(x, y, err_msg='', verbose=True):
      y: array([4])
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     assert_array_compare(operator.__lt__, x, y, err_msg=err_msg,
                          verbose=verbose,
                          header='Arrays are not less-ordered')
@@ -949,7 +949,7 @@ def assert_string_equal(actual, desired):
 
     """
     # delay import of difflib to reduce startup time
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     import difflib
 
     if not isinstance(actual, str) :
@@ -1058,7 +1058,7 @@ def assert_raises(*args,**kwargs):
     unexpected exception.
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     nose = import_nose()
     return nose.tools.assert_raises(*args,**kwargs)
 
@@ -1077,7 +1077,7 @@ def assert_raises_regex(exception_class, expected_regexp,
     all versions down to 2.6.
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     nose = import_nose()
 
     global assert_raises_regex_impl
@@ -1299,7 +1299,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=False,
     >>> assert_allclose(x, y, rtol=1e-5, atol=0)
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     import numpy as np
     def compare(x, y):
         return np.core.numeric.isclose(x, y, rtol=rtol, atol=atol,
@@ -1359,7 +1359,7 @@ def assert_array_almost_equal_nulp(x, y, nulp=1):
     AssertionError: X and Y are not equal to 1 ULP (max is 2)
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     import numpy as np
     ax = np.abs(x)
     ay = np.abs(y)
@@ -1408,7 +1408,7 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
     >>> res = np.testing.assert_array_max_ulp(a, np.arcsin(np.sin(a)))
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     import numpy as np
     ret = nulp_diff(a, b, dtype)
     if not np.all(ret <= maxulp):
@@ -1610,7 +1610,7 @@ def assert_warns(warning_class, func, *args, **kw):
     The value returned by `func`.
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
         result = func(*args, **kw)
@@ -1642,7 +1642,7 @@ def assert_no_warnings(func, *args, **kw):
     The value returned by `func`.
 
     """
-    __tracebackhide__ = True
+    __tracebackhide__ = True # Hide traceback for py.test
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
         result = func(*args, **kw)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -255,7 +255,7 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
      DESIRED: 6
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     if isinstance(desired, dict):
         if not isinstance(actual, dict) :
             raise AssertionError(repr(type(actual)))
@@ -362,7 +362,7 @@ def print_assert_equal(test_string, actual, desired):
     [0, 2]
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     import pprint
 
     if not (actual == desired):
@@ -436,7 +436,7 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
      y: array([ 1.        ,  2.33333334])
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import ndarray
     from numpy.lib import iscomplexobj, real, imag
 
@@ -550,7 +550,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
     True
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     import numpy as np
 
     (actual, desired) = map(float, (actual, desired))
@@ -592,7 +592,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          header='', precision=6):
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, isnan, isinf, any, all, inf
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -813,7 +813,7 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
      y: array([ 1.     ,  2.33333,  5.     ])
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import around, number, float_, result_type, array
     from numpy.core.numerictypes import issubdtype
     from numpy.core.fromnumeric import any as npany
@@ -914,7 +914,7 @@ def assert_array_less(x, y, err_msg='', verbose=True):
      y: array([4])
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     assert_array_compare(operator.__lt__, x, y, err_msg=err_msg,
                          verbose=verbose,
                          header='Arrays are not less-ordered')
@@ -949,7 +949,7 @@ def assert_string_equal(actual, desired):
 
     """
     # delay import of difflib to reduce startup time
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     import difflib
 
     if not isinstance(actual, str) :
@@ -1058,7 +1058,7 @@ def assert_raises(*args,**kwargs):
     unexpected exception.
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     nose = import_nose()
     return nose.tools.assert_raises(*args,**kwargs)
 
@@ -1077,7 +1077,7 @@ def assert_raises_regex(exception_class, expected_regexp,
     all versions down to 2.6.
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     nose = import_nose()
 
     global assert_raises_regex_impl
@@ -1299,7 +1299,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=False,
     >>> assert_allclose(x, y, rtol=1e-5, atol=0)
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     import numpy as np
     def compare(x, y):
         return np.core.numeric.isclose(x, y, rtol=rtol, atol=atol,
@@ -1359,7 +1359,7 @@ def assert_array_almost_equal_nulp(x, y, nulp=1):
     AssertionError: X and Y are not equal to 1 ULP (max is 2)
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     import numpy as np
     ax = np.abs(x)
     ay = np.abs(y)
@@ -1408,7 +1408,7 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
     >>> res = np.testing.assert_array_max_ulp(a, np.arcsin(np.sin(a)))
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     import numpy as np
     ret = nulp_diff(a, b, dtype)
     if not np.all(ret <= maxulp):
@@ -1610,7 +1610,7 @@ def assert_warns(warning_class, func, *args, **kw):
     The value returned by `func`.
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
         result = func(*args, **kw)
@@ -1642,7 +1642,7 @@ def assert_no_warnings(func, *args, **kw):
     The value returned by `func`.
 
     """
-    __tracebackhide__ = True # Hide traceback for py.test
+    __tracebackhide__ = True  # Hide traceback for py.test
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
         result = func(*args, **kw)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -255,6 +255,7 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
      DESIRED: 6
 
     """
+    __tracebackhide__ = True
     if isinstance(desired, dict):
         if not isinstance(actual, dict) :
             raise AssertionError(repr(type(actual)))
@@ -361,6 +362,7 @@ def print_assert_equal(test_string, actual, desired):
     [0, 2]
 
     """
+    __tracebackhide__ = True
     import pprint
 
     if not (actual == desired):
@@ -434,6 +436,7 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
      y: array([ 1.        ,  2.33333334])
 
     """
+    __tracebackhide__ = True
     from numpy.core import ndarray
     from numpy.lib import iscomplexobj, real, imag
 
@@ -547,6 +550,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
     True
 
     """
+    __tracebackhide__ = True
     import numpy as np
 
     (actual, desired) = map(float, (actual, desired))
@@ -588,6 +592,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          header='', precision=6):
+    __tracebackhide__ = True
     from numpy.core import array, isnan, isinf, any, all, inf
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -808,6 +813,7 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
      y: array([ 1.     ,  2.33333,  5.     ])
 
     """
+    __tracebackhide__ = True
     from numpy.core import around, number, float_, result_type, array
     from numpy.core.numerictypes import issubdtype
     from numpy.core.fromnumeric import any as npany
@@ -908,6 +914,7 @@ def assert_array_less(x, y, err_msg='', verbose=True):
      y: array([4])
 
     """
+    __tracebackhide__ = True
     assert_array_compare(operator.__lt__, x, y, err_msg=err_msg,
                          verbose=verbose,
                          header='Arrays are not less-ordered')
@@ -942,6 +949,7 @@ def assert_string_equal(actual, desired):
 
     """
     # delay import of difflib to reduce startup time
+    __tracebackhide__ = True
     import difflib
 
     if not isinstance(actual, str) :
@@ -1050,6 +1058,7 @@ def assert_raises(*args,**kwargs):
     unexpected exception.
 
     """
+    __tracebackhide__ = True
     nose = import_nose()
     return nose.tools.assert_raises(*args,**kwargs)
 
@@ -1068,6 +1077,7 @@ def assert_raises_regex(exception_class, expected_regexp,
     all versions down to 2.6.
 
     """
+    __tracebackhide__ = True
     nose = import_nose()
 
     global assert_raises_regex_impl
@@ -1289,6 +1299,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=False,
     >>> assert_allclose(x, y, rtol=1e-5, atol=0)
 
     """
+    __tracebackhide__ = True
     import numpy as np
     def compare(x, y):
         return np.core.numeric.isclose(x, y, rtol=rtol, atol=atol,
@@ -1348,6 +1359,7 @@ def assert_array_almost_equal_nulp(x, y, nulp=1):
     AssertionError: X and Y are not equal to 1 ULP (max is 2)
 
     """
+    __tracebackhide__ = True
     import numpy as np
     ax = np.abs(x)
     ay = np.abs(y)
@@ -1396,6 +1408,7 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
     >>> res = np.testing.assert_array_max_ulp(a, np.arcsin(np.sin(a)))
 
     """
+    __tracebackhide__ = True
     import numpy as np
     ret = nulp_diff(a, b, dtype)
     if not np.all(ret <= maxulp):
@@ -1597,6 +1610,7 @@ def assert_warns(warning_class, func, *args, **kw):
     The value returned by `func`.
 
     """
+    __tracebackhide__ = True
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
         result = func(*args, **kw)
@@ -1628,6 +1642,7 @@ def assert_no_warnings(func, *args, **kw):
     The value returned by `func`.
 
     """
+    __tracebackhide__ = True
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
         result = func(*args, **kw)


### PR DESCRIPTION
I'm using the nice helper functions from `numpy.testing` for a bunch of own testing modules. Tests there run with pytest. Unfortunately so far errors are totally cluttered up with backtraces from within the testing module itself. pytest supports a simple function marker, to hide the tracebacks of these assert helpers. This patch adds these markers to the testing utils.

It shouldn't have any downsides and be hopefully side effects free, and would greatly improve the life of combined numpy and pytest users ;-)
