### PR TITLE
BUG: reference stolen from None when looking up a ufunc's identity attribute

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5547,7 +5547,7 @@ ufunc_get_identity(PyUFuncObject *ufunc)
     case PyUFunc_Zero:
         return PyInt_FromLong(0);
     }
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *


### PR DESCRIPTION
A new reference must be returned by the C getter function, not a borrowed one.
