### PR TITLE
MANT: Add castings to PyObject in PyArray_Round

### DIFF
--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -618,7 +618,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
         }
 
         /* arr.real = a.real.round(decimals) */
-        part = PyObject_GetAttrString(a, "real");
+        part = PyObject_GetAttrString((PyObject *)a, "real");
         if (part == NULL) {
             Py_DECREF(arr);
             return NULL;
@@ -639,7 +639,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
         }
 
         /* arr.imag = a.imag.round(decimals) */
-        part = PyObject_GetAttrString(a, "imag");
+        part = PyObject_GetAttrString((PyObject *)a, "imag");
         if (part == NULL) {
             Py_DECREF(arr);
             return NULL;


### PR DESCRIPTION
Removes a couple of compiler warnings introduced in #5788 
