### PR TITLE
BUG: fix f2py shebang line for bdist wheel, egg

### DIFF
--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -33,11 +33,12 @@ from __version__ import version
 def _get_f2py_shebang():
     """ Return shebang line for f2py script
 
-    If we are building an egg or a wheel binary package, then the shebang line
+    If we are building a binary distribution format, then the shebang line
     should be ``#!python`` rather than ``#!`` followed by the contents of
     ``sys.executable``.
     """
-    if set(('bdist_wheel', 'bdist_egg')).intersection(sys.argv):
+    if set(('bdist_wheel', 'bdist_egg', 'bdist_mpkg', 'bdist_wininst',
+            'bdist_rpm')).intersection(sys.argv):
         return '#!python'
     return '#!' + sys.executable
 

--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -29,6 +29,19 @@ from numpy.distutils.misc_util import Configuration
 
 from __version__ import version
 
+
+def _get_f2py_shebang():
+    """ Return shebang line for f2py script
+
+    If we are building an egg or a wheel binary package, then the shebang line
+    should be ``#!python`` rather than ``#!`` followed by the contents of
+    ``sys.executable``.
+    """
+    if set(('bdist_wheel', 'bdist_egg')).intersection(sys.argv):
+        return '#!python'
+    return '#!' + sys.executable
+
+
 def configuration(parent_package='',top_path=None):
     config = Configuration('f2py', parent_package, top_path)
 
@@ -50,7 +63,7 @@ def configuration(parent_package='',top_path=None):
         if newer(__file__, target):
             log.info('Creating %s', target)
             f = open(target, 'w')
-            f.write('#!%s\n' % (sys.executable))
+            f.write(_get_f2py_shebang() + '\n')
             mainloc = os.path.join(os.path.dirname(__file__), "__main__.py")
             with open(mainloc) as mf:
                 f.write(mf.read())


### PR DESCRIPTION
This is a painful hack, but I don't know a better way.  So, I put it forward
for improvement by y'all.

Command `bdist_wheel` was generating a shebang line for f2py that uses the
Python path for the building Python.  If we are building a wheel or an egg,
use the generic `#!python` shebang line for the f2py script instead, which
setuptools will modify at install time.

Closes gh-5812.
