### PR TITLE
BUG: Make ma.where consistent with unmasked where.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -29,7 +29,7 @@ from functools import reduce
 import numpy as np
 import numpy.core.umath as umath
 import numpy.core.numerictypes as ntypes
-from numpy import ndarray, amax, amin, iscomplexobj, bool_
+from numpy import ndarray, amax, amin, iscomplexobj, bool_, _NoValue
 from numpy import array as narray
 from numpy.lib.function_base import angle
 from numpy.compat import getargspec, formatargspec, long, basestring
@@ -6708,7 +6708,7 @@ size.__doc__ = np.size.__doc__
 #####--------------------------------------------------------------------------
 #---- --- Extra functions ---
 #####--------------------------------------------------------------------------
-def where(condition, *args, **kwargs):
+def where(condition, x=_NoValue, y=_NoValue):
     """
     Return a masked array with elements from x or y, depending on condition.
 
@@ -6755,40 +6755,20 @@ def where(condition, *args, **kwargs):
      [6.0 -- 8.0]]
 
     """
+    missing = (x is _NoValue, y is _NoValue).count(True)
 
-    if ((len(args) == 0) or (len(args) == 2)) and (len(kwargs) == 0):
-        pass
-    elif (len(args) == 1) and (len(kwargs) == 1):
-        if ("x" not in kwargs):
-            raise ValueError(
-                "Cannot provide `x` as an argument and a keyword argument."
-            )
-        if ("y" not in kwargs):
-            raise ValueError(
-                "Must provide `y` as a keyword argument if not as an argument."
-            )
-        args += (kwargs["y"],)
-    elif (len(args) == 0) and ((len(kwargs) == 0) or (len(kwargs) == 2)):
-        if (("x" not in kwargs) and ("y" not in kwargs) or
-            ("x" in kwargs) and ("y" in kwargs)):
-            raise ValueError(
-                "Must provide both `x` and `y` as keyword arguments or neither."
-            )
-        args += (kwargs["x"], kwargs["y"],)
-    else:
-        raise ValueError(
-            "Only takes 3 arguments was provided %i arguments." %
-            len(args) + len(kwargs)
-        )
-
-
-    if len(args) == 0:
+    if missing == 1:
+        raise ValueError("Must provide both 'x' and 'y' or neither.")
+    if missing == 2:
         return filled(condition, 0).nonzero()
-    x, y = args
-    # Get the condition ...............
+
+    # Both x and y are provided
+
+    # Get the condition
     fc = filled(condition, 0).astype(MaskType)
     notfc = np.logical_not(fc)
-    # Get the data ......................................
+
+    # Get the data
     xv = getdata(x)
     yv = getdata(y)
     if x is masked:
@@ -6797,19 +6777,23 @@ def where(condition, *args, **kwargs):
         ndtype = xv.dtype
     else:
         ndtype = np.find_common_type([xv.dtype, yv.dtype], [])
+
     # Construct an empty array and fill it
     d = np.empty(fc.shape, dtype=ndtype).view(MaskedArray)
-    _data = d._data
-    np.copyto(_data, xv.astype(ndtype), where=fc)
-    np.copyto(_data, yv.astype(ndtype), where=notfc)
+    np.copyto(d._data, xv.astype(ndtype), where=fc)
+    np.copyto(d._data, yv.astype(ndtype), where=notfc)
+
     # Create an empty mask and fill it
-    _mask = d._mask = np.zeros(fc.shape, dtype=MaskType)
-    np.copyto(_mask, getmask(x), where=fc)
-    np.copyto(_mask, getmask(y), where=notfc)
-    _mask |= getmaskarray(condition)
-    if not _mask.any():
-        d._mask = nomask
+    mask = np.zeros(fc.shape, dtype=MaskType)
+    np.copyto(mask, getmask(x), where=fc)
+    np.copyto(mask, getmask(y), where=notfc)
+    mask |= getmaskarray(condition)
+
+    # Use d._mask instead of d.mask to avoid copies
+    d._mask = mask if mask.any() else nomask
+
     return d
+
 
 def choose (indices, choices, out=None, mode='raise'):
     """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6708,7 +6708,7 @@ size.__doc__ = np.size.__doc__
 #####--------------------------------------------------------------------------
 #---- --- Extra functions ---
 #####--------------------------------------------------------------------------
-def where (condition, x=None, y=None):
+def where(condition, *args, **kwargs):
     """
     Return a masked array with elements from x or y, depending on condition.
 
@@ -6755,10 +6755,36 @@ def where (condition, x=None, y=None):
      [6.0 -- 8.0]]
 
     """
-    if x is None and y is None:
+
+    if ((len(args) == 0) or (len(args) == 2)) and (len(kwargs) == 0):
+        pass
+    elif (len(args) == 1) and (len(kwargs) == 1):
+        if ("x" not in kwargs):
+            raise ValueError(
+                "Cannot provide `x` as an argument and a keyword argument."
+            )
+        if ("y" not in kwargs):
+            raise ValueError(
+                "Must provide `y` as a keyword argument if not as an argument."
+            )
+        args += (kwargs["y"],)
+    elif (len(args) == 0) and ((len(kwargs) == 0) or (len(kwargs) == 2)):
+        if (("x" not in kwargs) and ("y" not in kwargs) or
+            ("x" in kwargs) and ("y" in kwargs)):
+            raise ValueError(
+                "Must provide both `x` and `y` as keyword arguments or neither."
+            )
+        args += (kwargs["x"], kwargs["y"],)
+    else:
+        raise ValueError(
+            "Only takes 3 arguments was provided %i arguments." %
+            len(args) + len(kwargs)
+        )
+
+
+    if len(args) == 0:
         return filled(condition, 0).nonzero()
-    elif x is None or y is None:
-        raise ValueError("Either both or neither x and y should be given.")
+    x, y = args
     # Get the condition ...............
     fc = filled(condition, 0).astype(MaskType)
     notfc = np.logical_not(fc)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3396,6 +3396,13 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(d, [-9, -9, -9, -9, -9, 4, -9, -9, 10, -9, -9, 3])
         assert_equal(d.dtype, ixm.dtype)
 
+    def test_where_object(self):
+        a = np.array(None)
+        b = masked_array(None)
+        r = b.copy()
+        assert_equal(np.ma.where(True, a, a), r)
+        assert_equal(np.ma.where(True, b, b), r)
+
     def test_where_with_masked_choice(self):
         x = arange(10)
         x[3] = masked


### PR DESCRIPTION
Cleanup of #5583.

The scalar case ma.where(True, None, None) is now conistent with unmasked version.

Cleanup #5583 for style and use np._NoValue as default value of `x` and `y` to simplify the logic.
