### PR TITLE
TST: re-enable TravisCI testing with Bento.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ matrix:
       env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.4
       env: NPY_RELAXED_STRIDES_CHECKING=0
-# disable bento test until waf issue is resolved.
-#    - python: 2.7
-#      env: USE_BENTO=1
+    - python: 2.7
+      env: USE_BENTO=1
     - python: 2.7
       env: USE_WHEEL=1
 before_install:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -62,7 +62,7 @@ setup_bento()
   cd ..
 
   # Waf
-  wget http://ftp.waf.io/pub/release/waf-1.7.16.tar.bz2
+  wget https://raw.githubusercontent.com/rgommers/numpy-vendor/master/waf-1.7.16.tar.bz2
   tar xjvf waf-1.7.16.tar.bz2
   cd waf-1.7.16
   python waf-light


### PR DESCRIPTION
Disabling was done in gh-5708, due to the Waf download site being down for a
while. It's up again, but having the tarball on Github is probably more robust anyway.

Note: this now points at my local fork of numpy-vendor. If this works and looks okay, then I'll push that to `numpy/numpy-vendor` and update this PR before it's merged.
