### PR TITLE
BUG: revert use of !python for bdist_mpkg scripts

### DIFF
--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -37,7 +37,7 @@ def _get_f2py_shebang():
     should be ``#!python`` rather than ``#!`` followed by the contents of
     ``sys.executable``.
     """
-    if set(('bdist_wheel', 'bdist_egg', 'bdist_mpkg', 'bdist_wininst',
+    if set(('bdist_wheel', 'bdist_egg', 'bdist_wininst',
             'bdist_rpm')).intersection(sys.argv):
         return '#!python'
     return '#!' + sys.executable


### PR DESCRIPTION
bdist_mpkg is a very crude install method that will assume the path to Python,
so we should not use the `#!python` form when installing scripts in
bdist_mpkg.
