### PR TITLE
MANT: Turn deprecated dtype string warnings into errors

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1023,9 +1023,6 @@ NPY_NO_EXPORT int
 PyArray_TypestrConvert(int itemsize, int gentype)
 {
     int newtype = NPY_NOTYPE;
-    PyArray_Descr *temp;
-    const char *msg = "Specified size is invalid for this data type.\n"
-        "Size will be ignored in NumPy 1.7 but may throw an exception in future versions.";
 
     switch (gentype) {
         case NPY_GENBOOLLTR:
@@ -1177,31 +1174,6 @@ PyArray_TypestrConvert(int itemsize, int gentype)
                 newtype = NPY_TIMEDELTA;
             }
             break;
-    }
-
-    /*
-     * Raise deprecate warning if new type hasn't been
-     * set yet and size char is invalid.
-     * This should eventually be changed to an error in
-     * future NumPy versions.
-     */
-    if (newtype == NPY_NOTYPE) {
-        temp = PyArray_DescrFromType(gentype);
-        if (temp != NULL) {
-            if (temp->elsize != itemsize) {
-                if (DEPRECATE(msg) < 0) {
-                    Py_DECREF(temp);
-                    return -1;
-                }
-
-                newtype = gentype;
-            }
-            else {
-                newtype = gentype;
-            }
-
-            Py_DECREF(temp);
-        }
     }
 
     return newtype;

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -50,11 +50,11 @@ class TestDateTime(TestCase):
         assert_raises(TypeError, np.dtype, 'm8[badunit]')
         assert_raises(TypeError, np.dtype, 'M8[YY]')
         assert_raises(TypeError, np.dtype, 'm8[YY]')
-        assert_warns(DeprecationWarning, np.dtype, 'm4')
-        assert_warns(DeprecationWarning, np.dtype, 'M7')
-        assert_warns(DeprecationWarning, np.dtype, 'm7')
-        assert_warns(DeprecationWarning, np.dtype, 'M16')
-        assert_warns(DeprecationWarning, np.dtype, 'm16')
+        assert_raises(TypeError, np.dtype, 'm4')
+        assert_raises(TypeError, np.dtype, 'M7')
+        assert_raises(TypeError, np.dtype, 'm7')
+        assert_raises(TypeError, np.dtype, 'M16')
+        assert_raises(TypeError, np.dtype, 'm16')
 
     def test_datetime_casting_rules(self):
         # Cannot cast safely/same_kind between timedelta and datetime

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -50,38 +50,35 @@ class TestBuiltin(TestCase):
         self.assertTrue(hash(left) == hash(right))
 
     def test_invalid_types(self):
-        # Make sure invalid type strings raise a warning.
-        # For now, display a deprecation warning for invalid
-        # type sizes. In the future this should be changed
-        # to an exception.
+        # Make sure invalid type strings raise an error
 
-        assert_warns(DeprecationWarning, np.dtype, 'O3')
-        assert_warns(DeprecationWarning, np.dtype, 'O5')
-        assert_warns(DeprecationWarning, np.dtype, 'O7')
-        assert_warns(DeprecationWarning, np.dtype, 'b3')
-        assert_warns(DeprecationWarning, np.dtype, 'h4')
-        assert_warns(DeprecationWarning, np.dtype, 'I5')
-        assert_warns(DeprecationWarning, np.dtype, 'e3')
-        assert_warns(DeprecationWarning, np.dtype, 'f5')
+        assert_raises(TypeError, np.dtype, 'O3')
+        assert_raises(TypeError, np.dtype, 'O5')
+        assert_raises(TypeError, np.dtype, 'O7')
+        assert_raises(TypeError, np.dtype, 'b3')
+        assert_raises(TypeError, np.dtype, 'h4')
+        assert_raises(TypeError, np.dtype, 'I5')
+        assert_raises(TypeError, np.dtype, 'e3')
+        assert_raises(TypeError, np.dtype, 'f5')
 
         if np.dtype('g').itemsize == 8 or np.dtype('g').itemsize == 16:
-            assert_warns(DeprecationWarning, np.dtype, 'g12')
+            assert_raises(TypeError, np.dtype, 'g12')
         elif np.dtype('g').itemsize == 12:
-            assert_warns(DeprecationWarning, np.dtype, 'g16')
+            assert_raises(TypeError, np.dtype, 'g16')
 
         if np.dtype('l').itemsize == 8:
-            assert_warns(DeprecationWarning, np.dtype, 'l4')
-            assert_warns(DeprecationWarning, np.dtype, 'L4')
+            assert_raises(TypeError, np.dtype, 'l4')
+            assert_raises(TypeError, np.dtype, 'L4')
         else:
-            assert_warns(DeprecationWarning, np.dtype, 'l8')
-            assert_warns(DeprecationWarning, np.dtype, 'L8')
+            assert_raises(TypeError, np.dtype, 'l8')
+            assert_raises(TypeError, np.dtype, 'L8')
 
         if np.dtype('q').itemsize == 8:
-            assert_warns(DeprecationWarning, np.dtype, 'q4')
-            assert_warns(DeprecationWarning, np.dtype, 'Q4')
+            assert_raises(TypeError, np.dtype, 'q4')
+            assert_raises(TypeError, np.dtype, 'Q4')
         else:
-            assert_warns(DeprecationWarning, np.dtype, 'q8')
-            assert_warns(DeprecationWarning, np.dtype, 'Q8')
+            assert_raises(TypeError, np.dtype, 'q8')
+            assert_raises(TypeError, np.dtype, 'Q8')
 
     def test_bad_param(self):
         # Can't give a size that's too small
@@ -319,7 +316,7 @@ class TestSubarray(TestCase):
         # List gets converted
         dt = np.dtype([('a', 'f4', l)])
         assert_(isinstance(dt['a'].shape, tuple))
-        # 
+        #
         class IntLike(object):
             def __index__(self):
                 return 3


### PR DESCRIPTION
Fixes #5790
