### PR TITLE
MANT: Remove size from string representation of object dtype

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -91,7 +91,7 @@ New Features
 
 Reading extra flags from site.cfg
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Previously customization of compilation of dependency libraries and numpy 
+Previously customization of compilation of dependency libraries and numpy
 itself was only accomblishable via code changes in the distutils package.
 Now numpy.distutils reads in the following extra flags from each group of the
 *site.cfg*:
@@ -278,3 +278,19 @@ Because we are deprecating the ``bias`` argument to ``ma.corrcoef``, we also
 deprecate the use of the ``allow_masked`` argument as a positional argument,
 as its position will change with the removal of ``bias``.  ``allow_masked``
 will in due course become a keyword-only argument.
+
+dtype string representation changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Since 1.6, creating a dtype object from its string representation, e.g.
+``'f4'``, would issue a deprecation warning if the size did not correspond
+to an existing type, and default to creating a dtype of the default size
+for the type. Starting with this release, this will now raise a ``TypeError``.
+
+The only exception is object dtypes, where both ``'O4'`` and ``'O8'`` will
+still issue a deprecation warning. This platform-dependent representation
+will raise an error in the next release.
+
+In preparation for this upcoming change, the string representation of an
+object dtype, i.e. ``np.dtype(object).str``, no longer includes the item
+size, i.e. will return ``'|O'`` instead of ``'|O4'`` or ``'|O8'`` as
+before.

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -46,7 +46,7 @@ Structured data types are formed by creating a data type whose
 which it can be :ref:`accessed <arrays.indexing.fields>`. The parent data
 type should be of sufficient size to contain all its fields; the
 parent is nearly always based on the :class:`void` type which allows
-an arbitrary item size. Structured data types may also contain nested 
+an arbitrary item size. Structured data types may also contain nested
 structured sub-array data types in their fields.
 
 .. index::
@@ -219,10 +219,10 @@ One-character strings
 Array-protocol type strings (see :ref:`arrays.interface`)
 
    The first character specifies the kind of data and the remaining
-   characters specify the number of bytes per item.  The item size may
-   be ignored for some kinds (i.e., boolean, object), rounded to the
-   next supported size (float, complex), or interpreted as the number
-   of characters (Unicode).  The supported kinds are
+   characters specify the number of bytes per item, except for Unicode,
+   where it is interpreted as the number of characters.  The item size
+   must correspond to an existing type, or an error will be raised.  The
+   supported kinds are
 
    ================   ========================
    ``'b'``            boolean
@@ -431,7 +431,7 @@ Type strings
     Both arguments must be convertible to data-type objects in this
     case. The *base_dtype* is the data-type object that the new
     data-type builds on. This is how you could assign named fields to
-    any built-in data-type object, as done in 
+    any built-in data-type object, as done in
     :ref:`record arrays <arrays.classes.rec>`.
 
     .. admonition:: Example

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1677,8 +1677,12 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self)
     if (self->type_num == NPY_UNICODE) {
         size >>= 2;
     }
-
-    ret = PyUString_FromFormat("%c%c%d", endian, basic_, size);
+    if (self->type_num == NPY_OBJECT) {
+        ret = PyUString_FromFormat("%c%c", endian, basic_);
+    }
+    else {
+        ret = PyUString_FromFormat("%c%c%d", endian, basic_, size);
+    }
     if (PyDataType_ISDATETIME(self)) {
         PyArray_DatetimeMetaData *meta;
 


### PR DESCRIPTION
Follow-up to #5840, removing the size from object dtype string representation.
