### PR TITLE
fix for imp module deprecation

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -56,8 +56,9 @@ sys.path.pop(0)
 import shutil
 import subprocess
 import time
-import imp
+import types
 from argparse import ArgumentParser, REMAINDER
+
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 
@@ -132,7 +133,7 @@ def main(argv):
             sys.argv = extra_argv
             with open(extra_argv[0], 'r') as f:
                 script = f.read()
-            sys.modules['__main__'] = imp.new_module('__main__')
+            sys.modules['__main__'] = types.ModuleType('__main__')
             ns = dict(__name__='__main__',
                       __file__=extra_argv[0])
             exec_(script, ns)

--- a/setupegg.py
+++ b/setupegg.py
@@ -17,9 +17,11 @@ from __future__ import division, absolute_import, print_function
 import sys
 from setuptools import setup
 
-if sys.version_info[0] >= 3:
+if sys.version_info[:2] >= (3, 4):
+    from importlib.machinery import SourceFileLoader
+    setupfile = SourceFileLoader('setupfile', 'setup.py').load_module()
+    setupfile.setup_package()
+else:
     import imp
     setupfile = imp.load_source('setupfile', 'setup.py')
     setupfile.setup_package()
-else:
-    exec(compile(open('setup.py').read(), 'setup.py', 'exec'))


### PR DESCRIPTION
Testing work in progess,. The imp module will be deprecated in favor of importlib and when this is finished it will close #5849.
