### PR TITLE
ENH: add user control to check embedded lapack in openblas

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1743,7 +1743,18 @@ class openblas_lapack_info(openblas_info):
     notfounderror = BlasNotFoundError
 
     def check_embedded_lapack(self, info):
-        res = False
+
+        # Enable the user to force embedded lapack.
+        # This can be used to bypass the following test
+        # which will often fail for gnu compiler env's
+        # Specifically the gfortran library might be necessary
+        # if OpenBLAS has been compiled without lapack support.
+        res = self.cp.has_option(self.section,'embedded_lapack')
+        if res:
+            res = self.cp.getboolean(self.section,'embedded_lapack')
+            if res:
+                return res
+
         c = distutils.ccompiler.new_compiler()
         tmpdir = tempfile.mkdtemp()
         s = """void zungqr();

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -121,6 +121,23 @@
 # multiprocessing.
 # (This problem does not exist with multithreaded ATLAS.)
 #
+# **Notice**: If you have build OpenBLAS without LAPACK support you are encouraged
+# to have this:
+#   [openblas]
+#   libraries = lapack,openblas
+# to force OpenBLAS usage and external lapack, be sure to have the lapack 
+# directory in the library_dirs path.
+# However, this might experience linking problems if you require threaded and/or
+# gfortran support as the default C-compiler will not necessarily add correct 
+# link paths.
+# To force numpy to disregard direct checking you can add this option to the
+# openblas section:
+#   [openblas]
+#   embedded_lapack = True
+# which will disable the check. If you experience later linker problems you have
+# errors elsewhere.
+# If it is False it will check for embedded lapack manually.
+#
 # http://docs.python.org/3.4/library/multiprocessing.html#contexts-and-start-methods
 # https://github.com/xianyi/OpenBLAS/issues/294
 #


### PR DESCRIPTION
Linking openblas without lapack support can in certain cases
fail due to erronous test. Instead of trying to fix tests
for linking correctly a library we allow the user to control
the build in check.
This can be acheived by adding:
  [openblas]
  embedded_lapack = True
which then forces lapack to be embedded.

I have added comments in site.cfg.example to explain when and
how it can be used.
