### PR TITLE
ENH: adds support for array construction from iterators

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -13,6 +13,7 @@ if sys.version_info[0] >= 3:
     import builtins
 else:
     import __builtin__ as builtins
+    range = xrange
 from decimal import Decimal
 
 
@@ -304,6 +305,17 @@ class TestArrayConstruction(TestCase):
         assert_(np.ascontiguousarray(d).flags.c_contiguous)
         assert_(np.asfortranarray(d).flags.f_contiguous)
 
+    def test_array_iter(self):
+        assert_array_equal(np.array(x for x in range(3)), [0, 1, 2])
+
+        arr = np.array(map(np.sqrt, [0, 1, 4]), dtype='float')
+        assert_array_equal(arr, [0, 1, 2])
+
+        arr = np.array((x for x in [0, 'abc', 2.7]), dtype='object')
+        assert_array_equal(arr, np.array([0, 'abc', 2.7], dtype='object'))
+
+        arr = np.array(x for x in [range(2), range(2, 4)])
+        assert_array_equal(arr, [[0, 1], [2, 3]])
 
 class TestAssignment(TestCase):
     def test_assignment_broadcasting(self):


### PR DESCRIPTION
on numpy master, iterators are not iterated in array construction:

``` python
>>> np.__version__
'1.10.0.dev0+30e3d41'
>>> np.array(range(5))
array([0, 1, 2, 3, 4])
>>> np.array(x for x in range(5))
array(<generator object <genexpr> at 0x7fed88898f30>, dtype=object)
>>> np.array(map(np.sqrt, [0, 1, 4]))
array(<map object at 0x7fed8616cb38>, dtype=object)
>>> np.array(map(np.sqrt, [0, 1, 4]), dtype='float')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: float() argument must be a string or a number, not 'map'
```

this is almost never what one would expect and can cause issues as in https://github.com/numpy/numpy/issues/5756, https://github.com/numpy/numpy/issues/5951, and gh-6555

with this patch:

``` python
>>> np.array(map(np.sqrt, [0, 1, 4]), dtype='float')
array([ 0.,  1.,  2.])
>>> np.array(x for x in [range(2), range(2, 4)])
array([[0, 1],
       [2, 3]])
```
