### PR TITLE
Remove NotImplemented handling from the ufunc machinery (almost)

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -16,19 +16,23 @@ Highlights
   evaluation order.
 * Addition of `nanprod` to the set of nanfunctions.
 
+Dropped Support:
 
-Dropped Support
-===============
 * The polytemplate.py file has been removed.
 * The _dotblas module is no longer available.
 * The testcalcs.py file has been removed.
 
+Future Changes:
 
-Future Changes
-==============
+* In array comparisons like ``arr1 == arr2``, many corner cases
+  involving strings or structured dtypes that used to return scalars
+  now issue ``FutureWarning`` or ``DeprecationWarning``, and in the
+  future will be change to either perform elementwise comparisons or
+  raise an error.
 * The SafeEval class will be removed.
 * The alterdot and restoredot functions will be removed.
 
+See below for more details on these changes.
 
 Compatibility notes
 ===================
@@ -249,6 +253,41 @@ array is writeable.
 
 Deprecations
 ============
+
+Array comparisons involving strings or structured dtypes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Normally, comparison operations on arrays perform elementwise
+comparisons and return arrays of booleans. But in some corner cases,
+especially involving strings are structured dtypes, NumPy has
+historically returned a scalar instead. For example::
+
+  ### Current behaviour
+
+  np.arange(2) == "foo"
+  # -> False
+
+  np.arange(2) < "foo"
+  # -> True on Python 2, error on Python 3
+
+  np.ones(2, dtype="i4,i4") == np.ones(2, dtype="i4,i4,i4")
+  # -> False
+
+Continuing work started in 1.9, in 1.10 these comparisons will now
+raise ``FutureWarning`` or ``DeprecationWarning``, and in the future
+they will be modified to behave more consistently with other
+comparison operations, e.g.::
+
+  ### Future behaviour
+
+  np.arange(2) == "foo"
+  # -> array([False, False])
+
+  np.arange(2) < "foo"
+  # -> error, strings and numbers are not orderable
+
+  np.ones(2, dtype="i4,i4") == np.ones(2, dtype="i4,i4,i4")
+  # -> [False, False]
 
 SafeEval
 ~~~~~~~~

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1343,16 +1343,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_False);
             return Py_False;
         }
-        if (needs_right_binop_forward(obj_self, other, "__eq__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        result = PyArray_GenericBinaryFunction(self,
-                (PyObject *)other,
-                n_ops.equal);
-        if (result && result != Py_NotImplemented)
-          break;
 
         /*
          * The ufunc does not support void/structured types, so these
@@ -1370,6 +1360,12 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             if (array_other == NULL) {
                 PyErr_Clear();
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_NotImplemented);
                 return Py_NotImplemented;
             }
@@ -1378,18 +1374,31 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
             if (_res == 0) {
-                Py_DECREF(result);
                 Py_DECREF(array_other);
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_False);
                 return Py_False;
             }
             else {
-                Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
             }
             Py_DECREF(array_other);
             return result;
         }
+
+        if (needs_right_binop_forward(obj_self, other, "__eq__", 0) &&
+                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
+        result = PyArray_GenericBinaryFunction(self,
+                (PyObject *)other,
+                n_ops.equal);
         /*
          * If the comparison results in NULL, then the
          * two array objects can not be compared together;
@@ -1402,7 +1411,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             PyErr_Clear();
             if (DEPRECATE("elementwise comparison failed; "
-                          "this will raise the error in the future.") < 0) {
+                          "this will raise an error in the future.") < 0) {
                 return NULL;
             }
 
@@ -1419,15 +1428,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_True);
             return Py_True;
         }
-        if (needs_right_binop_forward(obj_self, other, "__ne__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
-                n_ops.not_equal);
-        if (result && result != Py_NotImplemented)
-          break;
 
         /*
          * The ufunc does not support void/structured types, so these
@@ -1445,6 +1445,12 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             */
             if (array_other == NULL) {
                 PyErr_Clear();
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_NotImplemented);
                 return Py_NotImplemented;
             }
@@ -1453,19 +1459,30 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
             if (_res == 0) {
-                Py_DECREF(result);
                 Py_DECREF(array_other);
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_True);
                 return Py_True;
             }
             else {
-                Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
                 Py_DECREF(array_other);
             }
             return result;
         }
 
+        if (needs_right_binop_forward(obj_self, other, "__ne__", 0) &&
+                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
+        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
+                n_ops.not_equal);
         if (result == NULL) {
             /*
              * Comparisons should raise errors when element-wise comparison
@@ -1473,7 +1490,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             PyErr_Clear();
             if (DEPRECATE("elementwise comparison failed; "
-                          "this will raise the error in the future.") < 0) {
+                          "this will raise an error in the future.") < 0) {
                 return NULL;
             }
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1370,7 +1370,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (array_other == NULL) {
                 PyErr_Clear();
                 if (DEPRECATE(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise == comparison failed and returning scalar "
                         "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
@@ -1384,7 +1384,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (_res == 0) {
                 Py_DECREF(array_other);
                 if (DEPRECATE_FUTUREWARNING(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise == comparison failed and returning scalar "
                         "instead; this will raise an error or perform "
                         "elementwise comparison in the future.") < 0) {
                     return NULL;
@@ -1418,7 +1418,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * is not possible.
              */
             PyErr_Clear();
-            if (DEPRECATE("elementwise comparison failed; "
+            if (DEPRECATE("elementwise == comparison failed; "
                           "this will raise an error in the future.") < 0) {
                 return NULL;
             }
@@ -1454,7 +1454,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (array_other == NULL) {
                 PyErr_Clear();
                 if (DEPRECATE(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise != comparison failed and returning scalar "
                         "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
@@ -1468,7 +1468,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (_res == 0) {
                 Py_DECREF(array_other);
                 if (DEPRECATE_FUTUREWARNING(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise != comparison failed and returning scalar "
                         "instead; this will raise an error or perform "
                         "elementwise comparison in the future.") < 0) {
                     return NULL;
@@ -1496,7 +1496,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * is not possible.
              */
             PyErr_Clear();
-            if (DEPRECATE("elementwise comparison failed; "
+            if (DEPRECATE("elementwise != comparison failed; "
                           "this will raise an error in the future.") < 0) {
                 return NULL;
             }

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1312,6 +1312,15 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         else {
             return _strings_richcompare(self, array_other, cmp_op, 0);
         }
+        /* If we reach this point, it means that we are not comparing
+         * string-to-string. It's possible that this will still work out,
+         * e.g. if the other array is an object array, then both will be cast
+         * to object or something? I don't know how that works actually, but
+         * it does, b/c this works:
+         *   l = ["a", "b"]
+         *   assert np.array(l, dtype="S1") == np.array(l, dtype="O")
+         * So we fall through and see what happens.
+         */
     }
 
     switch (cmp_op) {
@@ -1360,10 +1369,9 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             if (array_other == NULL) {
                 PyErr_Clear();
-                if (DEPRECATE_FUTUREWARNING(
+                if (DEPRECATE(
                         "elementwise comparison failed and returning scalar "
-                        "instead; this will raise an error or perform "
-                        "elementwise comparison in the future.") < 0) {
+                        "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
                 Py_INCREF(Py_NotImplemented);
@@ -1445,10 +1453,9 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             */
             if (array_other == NULL) {
                 PyErr_Clear();
-                if (DEPRECATE_FUTUREWARNING(
+                if (DEPRECATE(
                         "elementwise comparison failed and returning scalar "
-                        "instead; this will raise an error or perform "
-                        "elementwise comparison in the future.") < 0) {
+                        "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
                 Py_INCREF(Py_NotImplemented);

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -304,6 +304,10 @@ PyArray_GenericBinaryFunction(PyArrayObject *m1, PyObject *m2, PyObject *op)
            * See also:
            * - https://github.com/numpy/numpy/issues/3502
            * - https://github.com/numpy/numpy/issues/3503
+           *
+           * NB: there's another copy of this code in
+           *    numpy.ma.core.MaskedArray._delegate_binop
+           * which should possibly be updated when this is.
            */
           double m1_prio = PyArray_GetPriority((PyObject *)m1,
                                                NPY_SCALAR_PRIORITY);

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -383,7 +383,7 @@ class TestComparisonDeprecations(_DeprecationTestCase):
     """
 
     message = "elementwise comparison failed; " \
-              "this will raise the error in the future."
+              "this will raise an error in the future."
 
     def test_normal_types(self):
         for op in (operator.eq, operator.ne):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -77,15 +77,25 @@ class _DeprecationTestCase(object):
             pass
         # just in case, clear the registry
         num_found = 0
+        # the warning log has weird WarningMessage objects in it, with no
+        # useful repr
+        def repr_warning_message(obj):
+            return warnings.formatwarning(message=obj.message,
+                                          category=obj.category,
+                                          filename=obj.filename,
+                                          lineno=obj.lineno,
+                                          line=obj.line)
         for warning in self.log:
             if warning.category is DeprecationWarning:
                 num_found += 1
             elif not ignore_others:
-                raise AssertionError("expected DeprecationWarning but %s given"
-                                                            % warning.category)
+                raise AssertionError("expected DeprecationWarning but got: %s"
+                                     % repr_warning_message(warning))
         if num is not None and num_found != num:
-            raise AssertionError("%i warnings found but %i expected"
-                                                        % (len(self.log), num))
+            raise AssertionError("%i warnings found but %i expected:\n"
+                                 % (len(self.log), num)
+                                 + "\n".join([repr_warning_message(w)
+                                              for w in self.log]))
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message=self.message,

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -959,12 +959,14 @@ class TestMultiIndexingAutomated(TestCase):
             # This is so that np.array(True) is not accepted in a full integer
             # index, when running the file separately.
             warnings.filterwarnings('error', '', DeprecationWarning)
+            def isskip(idx):
+                return isinstance(idx, str) and idx == "skip"
             for simple_pos in [0, 2, 3]:
                 tocheck = [self.fill_indices, self.complex_indices,
                            self.fill_indices, self.fill_indices]
                 tocheck[simple_pos] = self.simple_indices
                 for index in product(*tocheck):
-                    index = tuple(i for i in index if i != 'skip')
+                    index = tuple(i for i in index if not isskip(i))
                     self._check_multi_index(self.a, index)
                     self._check_multi_index(self.b, index)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -737,11 +737,21 @@ class TestStructured(TestCase):
         # Check that incompatible sub-array shapes don't result to broadcasting
         x = np.zeros((1,), dtype=[('a', ('f4', (1, 2))), ('b', 'i1')])
         y = np.zeros((1,), dtype=[('a', ('f4', (2,))), ('b', 'i1')])
-        assert_equal(x == y, False)
+        # This comparison invokes deprecated behaviour, and will probably
+        # start raising an error eventually. What we really care about in this
+        # test is just that it doesn't return True.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            assert_equal(x == y, False)
 
         x = np.zeros((1,), dtype=[('a', ('f4', (2, 1))), ('b', 'i1')])
         y = np.zeros((1,), dtype=[('a', ('f4', (2,))), ('b', 'i1')])
-        assert_equal(x == y, False)
+        # This comparison invokes deprecated behaviour, and will probably
+        # start raising an error eventually. What we really care about in this
+        # test is just that it doesn't return True.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            assert_equal(x == y, False)
 
         # Check that structured arrays that are different only in
         # byte-order work

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -128,13 +128,17 @@ class TestRegression(TestCase):
         assert_almost_equal(x**(-1), [1/(1+2j)])
 
     def test_scalar_compare(self,level=rlevel):
-        """Ticket #72"""
+        # Trac Ticket #72
+        # https://github.com/numpy/numpy/issues/565
         a = np.array(['test', 'auto'])
         assert_array_equal(a == 'auto', np.array([False, True]))
         self.assertTrue(a[1] == 'auto')
         self.assertTrue(a[0] != 'auto')
         b = np.linspace(0, 10, 11)
-        self.assertTrue(b != 'auto')
+        # This should return true for now, but will eventually raise an error:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self.assertTrue(b != 'auto')
         self.assertTrue(b[0] != 'auto')
 
     def test_unicode_swapping(self,level=rlevel):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3678,6 +3678,16 @@ class MaskedArray(ndarray):
             return _print_templates['short_std'] % parameters
         return _print_templates['long_std'] % parameters
 
+    def _delegate_binop(self, other):
+        # This emulates the logic in
+        #     multiarray/number.c:PyArray_GenericBinaryFunction
+        if (not isinstance(other, np.ndarray)
+            and not hasattr(other, "__numpy_ufunc__")):
+            other_priority = getattr(other, "__array_priority__", -1000000)
+            if self.__array_priority__ < other_priority:
+                return True
+        return False
+
     def __eq__(self, other):
         "Check whether other equals self elementwise"
         if self is masked:
@@ -3746,6 +3756,8 @@ class MaskedArray(ndarray):
     #
     def __add__(self, other):
         "Add other to self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return add(self, other)
     #
     def __radd__(self, other):
@@ -3754,6 +3766,8 @@ class MaskedArray(ndarray):
     #
     def __sub__(self, other):
         "Subtract other to self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return subtract(self, other)
     #
     def __rsub__(self, other):
@@ -3762,6 +3776,8 @@ class MaskedArray(ndarray):
     #
     def __mul__(self, other):
         "Multiply other by self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return multiply(self, other)
     #
     def __rmul__(self, other):
@@ -3770,10 +3786,14 @@ class MaskedArray(ndarray):
     #
     def __div__(self, other):
         "Divide other into self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return divide(self, other)
     #
     def __truediv__(self, other):
         "Divide other into self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return true_divide(self, other)
     #
     def __rtruediv__(self, other):
@@ -3782,6 +3802,8 @@ class MaskedArray(ndarray):
     #
     def __floordiv__(self, other):
         "Divide other into self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return floor_divide(self, other)
     #
     def __rfloordiv__(self, other):
@@ -3790,6 +3812,8 @@ class MaskedArray(ndarray):
     #
     def __pow__(self, other):
         "Raise self to the power other, masking the potential NaNs/Infs"
+        if self._delegate_binop(other):
+            return NotImplemented
         return power(self, other)
     #
     def __rpow__(self, other):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -12,6 +12,7 @@ import warnings
 import sys
 import pickle
 from functools import reduce
+import operator
 
 from nose.tools import assert_raises
 
@@ -1691,16 +1692,15 @@ class TestUfuncs(TestCase):
         self.assertTrue(not isinstance(test.mask, MaskedArray))
 
     def test_treatment_of_NotImplemented(self):
-        # Check any NotImplemented returned by umath.<ufunc> is passed on
-        a = masked_array([1., 2.], mask=[1, 0])
-        # basic tests for _MaskedBinaryOperation
-        assert_(a.__mul__('abc') is NotImplemented)
-        assert_(multiply.outer(a, 'abc') is NotImplemented)
-        # and for _DomainedBinaryOperation
-        assert_(a.__div__('abc') is NotImplemented)
+        # Check that NotImplemented is returned at appropriate places
 
-        # also check explicitly that rmul of another class can be accessed
-        class MyClass(str):
+        a = masked_array([1., 2.], mask=[1, 0])
+        self.assertRaises(TypeError, operator.mul, a, "abc")
+        self.assertRaises(TypeError, operator.truediv, a, "abc")
+
+        class MyClass(object):
+            __array_priority__ = a.__array_priority__ + 1
+
             def __mul__(self, other):
                 return "My mul"
 


### PR DESCRIPTION
We've long had consensus that returning `NotImplemented` from ufuncs was a bad and ugly hack, since it violates layering -- `NotImplemented` is the responsibility of `__op__` methods, not ufuncs. And one of the things that came out of the discussion in gh-5844 is that the `NotImplemented` handling inside the ufunc machinery was actually mostly useless and broken (see the first post on that report for analysis).

Of course, it turns out it's not _quite_ that simple -- there were some places, esp. in the trainwreck that is `array_richcompare`, which were depending on the current behavior.

This patch series fixes the main pieces of code that used to rely on this behavior, and then removes as much of the `NotImplemented` handling as it can. And for what isn't removed, it adds deprecation or future warnings.

In particular, there are a bunch of cases where `array_richcompare` returns bad and wrong results, like where you can compare two arrays (which should produce a boolean array), some failure occurs, and then the error gets thrown away and we end up returning a boolean scalar. Some of these were deprecated in 9b8f6c72, but this deprecates the rest. Probably the most controversial part of this is that this patch deprecates scalar ordering comparisons between unlike types, like `np.float64(1) < "foo"`, which are already an error on py3 but have traditionally returned some semi-arbitrary value on py2. To convince you that this is broken and we should stop supporting it, check this out:

```
# Note: the name of this class affects the results below
In [1]: class quux(object):
   ...:     pass
   ...: 

In [2]: q = quux()

In [3]: np.string_("foo") < q
Out[3]: True

In [4]: np.asarray(np.string_("foo")) < q
Out[4]: False
```

For a full analysis of how we handle all the legacy comparison cases, see the long comment that starts here: https://github.com/numpy/numpy/blob/19b829a660a6adc8118dc427e1a7e4ba6946ccf7/numpy/core/src/umath/ufunc_object.c#L867

NB this PR is probably easier to review if you read the commits one at a time in order, instead of jumping straight to the big diff.
