### PR TITLE
can't find Python.h when build_ext --include-dirs is set

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -54,10 +54,24 @@ class build_ext (old_build_ext):
                 self.jobs = int(self.jobs)
             except ValueError:
                 raise ValueError("--jobs/-j argument must be an integer")
-        incl_dirs = self.include_dirs
+
+        # Ensure that self.include_dirs and self.distribution.include_dirs
+        # refer to the same list object. finalize_options will modify
+        # self.include_dirs, but self.distribution.include_dirs is used
+        # during the actual build.
+        # self.include_dirs is None unless paths are specified with
+        # --include-dirs.
+        # The include paths will be passed to the compiler in the order:
+        # numpy paths, --include-dirs paths, Python include path.
+        if isinstance(self.include_dirs, str):
+            self.include_dirs = self.include_dirs.split(os.pathsep)
+        incl_dirs = self.include_dirs or []
+        if self.distribution.include_dirs is None:
+            self.distribution.include_dirs = []
+        self.include_dirs = self.distribution.include_dirs
+        self.include_dirs.extend(incl_dirs)
+
         old_build_ext.finalize_options(self)
-        if incl_dirs is not None:
-            self.include_dirs.extend(self.distribution.include_dirs or [])
         self.set_undefined_options('build', ('jobs', 'jobs'))
 
     def run(self):


### PR DESCRIPTION
Not sure whether this is a distutils bug or a numpy.distutils bug, but here goes: When `build_ext --include-dirs` is set in distutils.cfg or provided on the numpy setup.py command line, `build_src` fails, because Python.h cannot be found by the compiler. This happens because `sysconfig.get_python_inc()` is not added to the correct include path.

Specifically, `build_ext.finalize_options` fails to add the Python include directory to the include_dirs attribute of the NumpyDistribution object, which is the include_dir list that seems to be used for the configuration operations.

Normally, `self.include_dirs` is `None` at the top of `numpy.distutils.command.build_ext.finalize_options()` (unless `--include-dirs` is specified, in which case `self.include_dirs` is a string). Inside `distutils.command.build_ext.finalize_options()`, this line:

``` python
if self.include_dirs is None:
    self.include_dirs = self.distribution.include_dirs or []
```

sets the `include_dirs` attributes of the self `build_ext` object and the `NumpyDistribution` object to the same physical list.

Later, `self.include_dirs.append(py_include)` adds the Python interpreter's include directory only to `self.include_dirs`.

No other action is taken to synchronize `self.include_dirs` and `self.distribution.include_dirs`. If and only if `self.include_dirs` was None at the top of the function, `self.include_dirs` and `self.distribution.include_dirs` reference the same list. Otherwise, they are independent, and `self.distribution.include_dirs` does not include the Python include path, and the build fails.

The failure looks like this:
https://gist.githubusercontent.com/anonymous/7889988776d3204fe240/raw/355c6ca936b54092193c92a9010c508b4d343f5d/04.python3

This patch ensures that the `include_dirs` attribute of the `build_ext` object is the same physical list as the `include_dirs` attribute of the `NumpyDistribution` object. I'm not sure it's "correct," but it builds correctly.

To reproduce, use `python setup.py build build_ext --include-dirs=/usr/local/include install --prefix=/some/prefix`.
