### PR TITLE
ENH: add cartesian()

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -31,7 +31,7 @@ import numpy as np
 
 __all__ = [
     'ediff1d', 'intersect1d', 'setxor1d', 'union1d', 'setdiff1d', 'unique',
-    'in1d'
+    'in1d', 'cartesian'
     ]
 
 
@@ -476,3 +476,55 @@ def setdiff1d(ar1, ar2, assume_unique=False):
         ar1 = unique(ar1)
         ar2 = unique(ar2)
     return ar1[in1d(ar1, ar2, assume_unique=True, invert=True)]
+
+
+def cartesian(arrays, out=None):
+    """
+    Generate a cartesian product of the input arrays.
+
+    Parameters
+    ----------
+    arrays : list of array-like
+        1-D arrays to form the cartesian product of.
+    out : ndarray
+        Array to place the cartesian product in.
+
+    Returns
+    -------
+    out : ndarray
+        2-D array of shape (M, len(arrays)) containing the cartesian products
+        formed of the input arrays.
+
+    Examples
+    --------
+    >>> cartesian(([1, 2, 3], [4, 5], [6, 7]))
+    array([[1, 4, 6],
+           [1, 4, 7],
+           [1, 5, 6],
+           [1, 5, 7],
+           [2, 4, 6],
+           [2, 4, 7],
+           [2, 5, 6],
+           [2, 5, 7],
+           [3, 4, 6],
+           [3, 4, 7],
+           [3, 5, 6],
+           [3, 5, 7]])
+
+    """
+    arrays = [np.asarray(x).ravel() for x in arrays]
+    dtype = np.result_type(*arrays)
+
+    n = np.prod([arr.size for arr in arrays])
+    if out is None:
+        out = np.empty((len(arrays), n), dtype=dtype)
+    else:
+        out = out.T
+
+    for j, arr in enumerate(arrays):
+        n /= arr.size
+        out.shape = (len(arrays), -1, arr.size, n)
+        out[j] = arr[np.newaxis, :, np.newaxis]
+    out.shape = (len(arrays), -1)
+
+    return out.T

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -478,25 +478,52 @@ def setdiff1d(ar1, ar2, assume_unique=False):
     return ar1[in1d(ar1, ar2, assume_unique=True, invert=True)]
 
 
-def cartesian(arrays, out=None):
+def cartesian(arrays, out=None, unique=False):
     """
-    Generate a cartesian product of the input arrays.
+    Generate the cartesian product [1]_ of the input arrays.
+
+    `cartesian` is the numpy version of Python's `itertools.product` [2]_.
+
+    .. versionadded:: 1.10.0
 
     Parameters
     ----------
     arrays : list of array-like
         1-D arrays to form the cartesian product of.
-    out : ndarray
+    out : ndarray, optional
         Array to place the cartesian product in.
+    unique : bool, optional
+        If True only the unique elements of each input array are used. This
+        corresponds to the definition of the cartesian product on sets. If
+        False (default) the arrays are used as supplied.
 
     Returns
     -------
     out : ndarray
-        2-D array of shape (M, len(arrays)) containing the cartesian products
-        formed of the input arrays.
+        2-D array of shape (n, len(arrays)) containing the cartesian products
+        formed of the input arrays where
+        `n = prod(a.shape[0] for a in arrays)`.
+
+    Raises
+    ------
+    ValueError
+        If input is the wrong shape (the input must be a list of 1-D arrays.
+    ValueError
+        If input contains less than two arrays.
+
+    References
+    ----------
+    .. [1] http://en.wikipedia.org/wiki/Cartesian_product
+    .. [2] https://docs.python.org/3.4/library/itertools.html#itertools.product
 
     Examples
     --------
+    >>> cartesian([[1, 2], [3, 4]])
+    array([[1, 3],
+           [1, 4],
+           [2, 3],
+           [2, 4]])
+
     >>> cartesian(([1, 2, 3], [4, 5], [6, 7]))
     array([[1, 4, 6],
            [1, 4, 7],
@@ -511,15 +538,27 @@ def cartesian(arrays, out=None):
            [3, 5, 6],
            [3, 5, 7]])
 
-    """
-    arrays = [np.asarray(x).ravel() for x in arrays]
-    dtype = np.result_type(*arrays)
+    >>> cartesian([[1, 1], [2]], unique=True)
+    array([[1, 2]])
 
+    """
+    if len(arrays) < 2:
+        msg = "need at least two array to calculate the cartesian product"
+        raise ValueError(msg)
+
+    arrays = [np.asarray(a) for a in arrays]
+
+    for a in arrays:
+        if a.ndim != 1:
+            raise ValueError("accepting only 1-D arrays")
+
+    if unique:
+        arrays = [np.unique(a) for a in arrays]
+
+    dtype = np.result_type(*arrays)
     n = np.prod([arr.size for arr in arrays])
-    if out is None:
-        out = np.empty((len(arrays), n), dtype=dtype)
-    else:
-        out = out.T
+
+    out = np.empty((len(arrays), n), dtype=dtype) if out is None else out.T
 
     for j, arr in enumerate(arrays):
         n //= arr.size

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -522,7 +522,7 @@ def cartesian(arrays, out=None):
         out = out.T
 
     for j, arr in enumerate(arrays):
-        n /= arr.size
+        n //= arr.size
         out.shape = (len(arrays), -1, arr.size, n)
         out[j] = arr[np.newaxis, :, np.newaxis]
     out.shape = (len(arrays), -1)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -5,7 +5,7 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import (
-    run_module_suite, TestCase, assert_array_equal, assert_equal
+    run_module_suite, TestCase, assert_array_equal, assert_equal, assert_raises
 )
 from numpy.lib.arraysetops import (
     ediff1d, intersect1d, setxor1d, union1d, setdiff1d, unique, in1d,
@@ -307,29 +307,50 @@ class TestSetOps(TestCase):
 
 
 class TestCartesian(TestCase):
-    def test_one_array(self):
+    def test_too_few_arrays(self):
         x = np.array([0, 1])
-        assert_array_equal(cartesian([x]), x)
+        assert_raises(ValueError, cartesian, [])
+        assert_raises(ValueError, cartesian, [x])
 
     def test_two_arrays(self):
         x = np.array([0, 1])
-        assert_array_equal(cartesian([x, x]),
-                           np.array([[0,  0],
-                                     [0,  1],
-                                     [1,  0],
-                                     [1,  1]]))
+        out = cartesian([x, x])
+        expected = np.array([[0,  0], [0,  1], [1,  0], [1, 1]])
+        assert_array_equal(out, expected)
 
     def test_three_arrays(self):
         x = np.array([0, 1])
-        assert_array_equal(cartesian([x, x, x]),
-                           np.array([[0,  0,  0],
-                                     [0,  0,  1],
-                                     [0,  1,  0],
-                                     [0,  1,  1],
-                                     [1,  0,  0],
-                                     [1,  0,  1],
-                                     [1,  1,  0],
-                                     [1,  1,  1]]))
+        out = cartesian([x, x, x])
+        expected = np.array([[0,  0,  0],
+                             [0,  0,  1],
+                             [0,  1,  0],
+                             [0,  1,  1],
+                             [1,  0,  0],
+                             [1,  0,  1],
+                             [1,  1,  0],
+                             [1,  1,  1]])
+        assert_array_equal(out, expected)
+
+    def test_arrays_as_lists(self):
+        x = [0, 1]
+        out = cartesian([x, x])
+        expected = np.array([[0,  0], [0,  1], [1,  0], [1, 1]])
+        assert_array_equal(out, expected)
+
+    def test_unique_parameter(self):
+        x = np.array([1, 1])
+
+        out = cartesian([x, x], unique=False)
+        expected = np.array([[1, 1], [1, 1], [1, 1], [1, 1]])
+        assert_array_equal(out, expected)
+
+        out = cartesian([x, x], unique=True)
+        expected = np.array([[1, 1]])
+        assert_array_equal(out, expected)
+
+    def test_refuse_2D_arrays(self):
+        x = np.array([[0, 1], [2, 3]])
+        assert_raises(ValueError,  cartesian, [x, x])
 
     def test_valid_out_parameter(self):
         x = np.array([0, 1])
@@ -337,6 +358,11 @@ class TestCartesian(TestCase):
         cartesian([x, x], out=out)
         expected = np.array([[0,  0], [0,  1], [1,  0], [1,  1]])
         assert_array_equal(out, expected)
+
+    def test_invalid_out_parameter(self):
+        x = np.array([0, 1])
+        out = np.empty((1, 1))  # not the correct shape
+        assert_raises(ValueError,  cartesian, [x, x], out)
 
 
 if __name__ == "__main__":

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -6,10 +6,11 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.testing import (
     run_module_suite, TestCase, assert_array_equal, assert_equal
-    )
+)
 from numpy.lib.arraysetops import (
-    ediff1d, intersect1d, setxor1d, union1d, setdiff1d, unique, in1d
-    )
+    ediff1d, intersect1d, setxor1d, union1d, setdiff1d, unique, in1d,
+    cartesian,
+)
 
 
 class TestSetOps(TestCase):
@@ -303,6 +304,39 @@ class TestSetOps(TestCase):
         aux2 = union1d(a, b)
         c2 = setdiff1d(aux2, aux1)
         assert_array_equal(c1, c2)
+
+
+class TestCartesian(TestCase):
+    def test_one_array(self):
+        x = np.array([0, 1])
+        assert_array_equal(cartesian([x]), x)
+
+    def test_two_arrays(self):
+        x = np.array([0, 1])
+        assert_array_equal(cartesian([x, x]),
+                           np.array([[0,  0],
+                                     [0,  1],
+                                     [1,  0],
+                                     [1,  1]]))
+
+    def test_three_arrays(self):
+        x = np.array([0, 1])
+        assert_array_equal(cartesian([x, x, x]),
+                           np.array([[0,  0,  0],
+                                     [0,  0,  1],
+                                     [0,  1,  0],
+                                     [0,  1,  1],
+                                     [1,  0,  0],
+                                     [1,  0,  1],
+                                     [1,  1,  0],
+                                     [1,  1,  1]]))
+
+    def test_valid_out_parameter(self):
+        x = np.array([0, 1])
+        out = np.empty((4, 2))
+        cartesian([x, x], out=out)
+        expected = np.array([[0,  0], [0,  1], [1,  0], [1,  1]])
+        assert_array_equal(out, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Generate the cartesian product of input arrays.

This is the pull request that resulted from the [discussion](http://mail.scipy.org/pipermail/numpy-discussion/2015-May/072872.html). First, thanks to everybody who participated in the discussion!

[Here](https://github.com/sotte/ipynb_snippets/blob/master/2015-05%20gridspace%20-%20cartesian.ipynb) is a performance comparison of different implementations.

The PR contains the implementation, docs and unittests, but...

I'm not quite sure if `arraysetopt.py` it the right place for this function.
["Set operations for 1D numeric arrays based on sorting."](https://github.com/numpy/numpy/blob/master/numpy/lib/arraysetops.py#L2) does not sound like `cartesian`.
`cartesian` is similar to `prod`, but `fromnumeric.py` is also not the right place.
Maybe `core/function_base.py` next to `linspace`? Or `linalg.py`?

Open questions
- [ ] where should we put it?
- [ ] Jaime raised the following question: "should it work on flattened arrays?
  or should we give it an axis argument, and then "broadcast on the rest", a la
  generalized ufunc?" :
