### PR TITLE
BUG: Don't use longlong for PyLong if it isn't larger than long

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -106,21 +106,39 @@ _array_find_python_scalar_type(PyObject *op)
         }
     }
     else if (PyLong_Check(op)) {
-        /* check to see if integer can fit into a longlong or ulonglong
-           and return that --- otherwise return object */
+        /*
+         * check to see if integer can fit into the largest C int or
+         * uint (use long long only if it is larger than long) and
+         * return that --- otherwise return object
+         */
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
         if ((PyLong_AsLongLong(op) == -1) && PyErr_Occurred()) {
+#else
+        if ((PyLong_AsLong(op) == -1) && PyErr_Occurred()) {
+#endif
             PyErr_Clear();
         }
         else {
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
             return PyArray_DescrFromType(NPY_LONGLONG);
+#else
+            return PyArray_DescrFromType(NPY_LONG);
+#endif
         }
-
-        if ((PyLong_AsUnsignedLongLong(op) == (unsigned long long) -1)
-            && PyErr_Occurred()){
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
+        if ((PyLong_AsUnsignedLongLong(op) == (unsigned long long)-1) &&
+#else
+        if ((PyLong_AsUnsignedLong(op) == (unsigned long)-1) &&
+#endif
+                    PyErr_Occurred()) {
             PyErr_Clear();
         }
         else {
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
             return PyArray_DescrFromType(NPY_ULONGLONG);
+#else
+            return PyArray_DescrFromType(NPY_ULONG);
+#endif
         }
 
         return PyArray_DescrFromType(NPY_OBJECT);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1264,7 +1264,12 @@ PyArray_DescrConverter(PyObject *obj, PyArray_Descr **at)
             check_num = NPY_LONG;
         }
         else if (obj == (PyObject *)(&PyLong_Type)) {
+/* Use long long only if it is larger than long */
+#   if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
             check_num = NPY_LONGLONG;
+#   else
+            check_num = NPY_LONG;
+#   endif
         }
 #else
         if (obj == (PyObject *)(&PyLong_Type)) {

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -413,17 +413,29 @@ PyArray_ScalarFromObject(PyObject *object)
         PyArrayScalar_VAL(ret, CDouble).imag = PyComplex_ImagAsDouble(object);
     }
     else if (PyLong_Check(object)) {
-        npy_longlong val;
-        val = PyLong_AsLongLong(object);
-        if (val==-1 && PyErr_Occurred()) {
+/* Use long long only if it is larger than long */
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
+        npy_longlong val = PyLong_AsLongLong(object);
+#else
+        npy_long val = PyLong_AsLong(object);
+#endif
+        if (val == -1 && PyErr_Occurred()) {
             PyErr_Clear();
             return NULL;
         }
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
         ret = PyArrayScalar_New(LongLong);
+#else
+        ret = PyArrayScalar_New(Long);
+#endif
         if (ret == NULL) {
             return NULL;
         }
+#if NPY_SIZEOF_LONGLONG > NPY_SIZEOF_LONG
         PyArrayScalar_VAL(ret, LongLong) = val;
+#else
+        PyArrayScalar_VAL(ret, Long) = val;
+#endif
     }
     return ret;
 }


### PR DESCRIPTION
Closes #5801.

PyLong types are only converted to npy_longlong if it is larger
than npy_long.
