### PR TITLE
MAINT: explicit fft copy

### DIFF
--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -249,7 +249,8 @@ def ifft(a, n=None, axis=-1):
     >>> plt.show()
 
     """
-    a = np.array(a, dtype=complex)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=complex)
     if n is None:
         n = shape(a)[axis]
     return _raw_fft(a, n, axis, fftpack.cffti, fftpack.cfftb, _fft_cache) / n
@@ -329,7 +330,8 @@ def rfft(a, n=None, axis=-1):
     exploited to compute only the non-negative frequency terms.
 
     """
-    a = np.array(a, dtype=float)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=float)
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftf, _real_fft_cache)
 
 
@@ -409,7 +411,8 @@ def irfft(a, n=None, axis=-1):
     specified, and the output array is purely real.
 
     """
-    a = np.array(a, dtype=complex)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftb,
@@ -482,7 +485,8 @@ def hfft(a, n=None, axis=-1):
            [ 2., -2.]])
 
     """
-    a = np.array(a, dtype=complex)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return irfft(conjugate(a), n, axis) * n
@@ -535,7 +539,8 @@ def ihfft(a, n=None, axis=-1):
     array([ 1.-0.j,  2.-0.j,  3.-0.j,  4.-0.j])
 
     """
-    a = np.array(a, dtype=float)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=float)
     if n is None:
         n = shape(a)[axis]
     return conjugate(rfft(a, n, axis))/n
@@ -1003,7 +1008,8 @@ def rfftn(a, s=None, axes=None):
             [ 0.+0.j,  0.+0.j]]])
 
     """
-    a = np.array(a, dtype=float)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=float)
     s, axes = _cook_nd_args(a, s, axes)
     a = rfft(a, s[-1], axes[-1])
     for ii in range(len(axes)-1):
@@ -1123,7 +1129,8 @@ def irfftn(a, s=None, axes=None):
             [ 1.,  1.]]])
 
     """
-    a = np.array(a, dtype=complex)
+    # The copy may be required for multithreading.
+    a = np.array(a, copy=True, dtype=complex)
     s, axes = _cook_nd_args(a, s, axes, invreal=1)
     for ii in range(len(axes)-1):
         a = ifft(a, s[ii], axes[ii])

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -35,16 +35,12 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['fft', 'ifft', 'rfft', 'irfft', 'hfft', 'ihfft', 'rfftn',
            'irfftn', 'rfft2', 'irfft2', 'fft2', 'ifft2', 'fftn', 'ifftn']
 
-from numpy.core import asarray, zeros, swapaxes, shape, conjugate, \
-     take
+import numpy as np
+from numpy.core import asarray, zeros, swapaxes, shape, conjugate, take
 from . import fftpack_lite as fftpack
 
 _fft_cache = {}
 _real_fft_cache = {}
-
-
-def _asarray_copy(*args, **kwargs):
-    return asarray(*args, **kwargs).copy()
 
 
 def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,
@@ -253,7 +249,7 @@ def ifft(a, n=None, axis=-1):
     >>> plt.show()
 
     """
-    a = _asarray_copy(a, dtype=complex)
+    a = np.array(a, dtype=complex)
     if n is None:
         n = shape(a)[axis]
     return _raw_fft(a, n, axis, fftpack.cffti, fftpack.cfftb, _fft_cache) / n
@@ -333,7 +329,7 @@ def rfft(a, n=None, axis=-1):
     exploited to compute only the non-negative frequency terms.
 
     """
-    a = _asarray_copy(a, dtype=float)
+    a = np.array(a, dtype=float)
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftf, _real_fft_cache)
 
 
@@ -413,7 +409,7 @@ def irfft(a, n=None, axis=-1):
     specified, and the output array is purely real.
 
     """
-    a = _asarray_copy(a, dtype=complex)
+    a = np.array(a, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftb,
@@ -486,7 +482,7 @@ def hfft(a, n=None, axis=-1):
            [ 2., -2.]])
 
     """
-    a = _asarray_copy(a, dtype=complex)
+    a = np.array(a, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return irfft(conjugate(a), n, axis) * n
@@ -539,7 +535,7 @@ def ihfft(a, n=None, axis=-1):
     array([ 1.-0.j,  2.-0.j,  3.-0.j,  4.-0.j])
 
     """
-    a = _asarray_copy(a, dtype=float)
+    a = np.array(a, dtype=float)
     if n is None:
         n = shape(a)[axis]
     return conjugate(rfft(a, n, axis))/n
@@ -1007,7 +1003,7 @@ def rfftn(a, s=None, axes=None):
             [ 0.+0.j,  0.+0.j]]])
 
     """
-    a = _asarray_copy(a, dtype=float)
+    a = np.array(a, dtype=float)
     s, axes = _cook_nd_args(a, s, axes)
     a = rfft(a, s[-1], axes[-1])
     for ii in range(len(axes)-1):
@@ -1127,7 +1123,7 @@ def irfftn(a, s=None, axes=None):
             [ 1.,  1.]]])
 
     """
-    a = _asarray_copy(a, dtype=complex)
+    a = np.array(a, dtype=complex)
     s, axes = _cook_nd_args(a, s, axes, invreal=1)
     for ii in range(len(axes)-1):
         a = ifft(a, s[ii], axes[ii])

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -35,8 +35,7 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['fft', 'ifft', 'rfft', 'irfft', 'hfft', 'ihfft', 'rfftn',
            'irfftn', 'rfft2', 'irfft2', 'fft2', 'ifft2', 'fftn', 'ifftn']
 
-import numpy as np
-from numpy.core import asarray, zeros, swapaxes, shape, conjugate, take
+from numpy.core import array, asarray, zeros, swapaxes, shape, conjugate, take
 from . import fftpack_lite as fftpack
 
 _fft_cache = {}
@@ -250,7 +249,7 @@ def ifft(a, n=None, axis=-1):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=complex)
+    a = array(a, copy=True, dtype=complex)
     if n is None:
         n = shape(a)[axis]
     return _raw_fft(a, n, axis, fftpack.cffti, fftpack.cfftb, _fft_cache) / n
@@ -331,7 +330,7 @@ def rfft(a, n=None, axis=-1):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=float)
+    a = array(a, copy=True, dtype=float)
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftf, _real_fft_cache)
 
 
@@ -412,7 +411,7 @@ def irfft(a, n=None, axis=-1):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=complex)
+    a = array(a, copy=True, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftb,
@@ -486,7 +485,7 @@ def hfft(a, n=None, axis=-1):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=complex)
+    a = array(a, copy=True, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return irfft(conjugate(a), n, axis) * n
@@ -540,7 +539,7 @@ def ihfft(a, n=None, axis=-1):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=float)
+    a = array(a, copy=True, dtype=float)
     if n is None:
         n = shape(a)[axis]
     return conjugate(rfft(a, n, axis))/n
@@ -1009,7 +1008,7 @@ def rfftn(a, s=None, axes=None):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=float)
+    a = array(a, copy=True, dtype=float)
     s, axes = _cook_nd_args(a, s, axes)
     a = rfft(a, s[-1], axes[-1])
     for ii in range(len(axes)-1):
@@ -1130,7 +1129,7 @@ def irfftn(a, s=None, axes=None):
 
     """
     # The copy may be required for multithreading.
-    a = np.array(a, copy=True, dtype=complex)
+    a = array(a, copy=True, dtype=complex)
     s, axes = _cook_nd_args(a, s, axes, invreal=1)
     for ii in range(len(axes)-1):
         a = ifft(a, s[ii], axes[ii])

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -42,6 +42,11 @@ from . import fftpack_lite as fftpack
 _fft_cache = {}
 _real_fft_cache = {}
 
+
+def _asarray_copy(*args, **kwargs):
+    return asarray(*args, **kwargs).copy()
+
+
 def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,
              work_function=fftpack.cfftf, fft_cache=_fft_cache):
     a = asarray(a)
@@ -248,8 +253,7 @@ def ifft(a, n=None, axis=-1):
     >>> plt.show()
 
     """
-
-    a = asarray(a).astype(complex)
+    a = _asarray_copy(a, dtype=complex)
     if n is None:
         n = shape(a)[axis]
     return _raw_fft(a, n, axis, fftpack.cffti, fftpack.cfftb, _fft_cache) / n
@@ -329,8 +333,7 @@ def rfft(a, n=None, axis=-1):
     exploited to compute only the non-negative frequency terms.
 
     """
-
-    a = asarray(a).astype(float)
+    a = _asarray_copy(a, dtype=float)
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftf, _real_fft_cache)
 
 
@@ -410,8 +413,7 @@ def irfft(a, n=None, axis=-1):
     specified, and the output array is purely real.
 
     """
-
-    a = asarray(a).astype(complex)
+    a = _asarray_copy(a, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return _raw_fft(a, n, axis, fftpack.rffti, fftpack.rfftb,
@@ -484,8 +486,7 @@ def hfft(a, n=None, axis=-1):
            [ 2., -2.]])
 
     """
-
-    a = asarray(a).astype(complex)
+    a = _asarray_copy(a, dtype=complex)
     if n is None:
         n = (shape(a)[axis] - 1) * 2
     return irfft(conjugate(a), n, axis) * n
@@ -538,8 +539,7 @@ def ihfft(a, n=None, axis=-1):
     array([ 1.-0.j,  2.-0.j,  3.-0.j,  4.-0.j])
 
     """
-
-    a = asarray(a).astype(float)
+    a = _asarray_copy(a, dtype=float)
     if n is None:
         n = shape(a)[axis]
     return conjugate(rfft(a, n, axis))/n
@@ -1007,8 +1007,7 @@ def rfftn(a, s=None, axes=None):
             [ 0.+0.j,  0.+0.j]]])
 
     """
-
-    a = asarray(a).astype(float)
+    a = _asarray_copy(a, dtype=float)
     s, axes = _cook_nd_args(a, s, axes)
     a = rfft(a, s[-1], axes[-1])
     for ii in range(len(axes)-1):
@@ -1128,8 +1127,7 @@ def irfftn(a, s=None, axes=None):
             [ 1.,  1.]]])
 
     """
-
-    a = asarray(a).astype(complex)
+    a = _asarray_copy(a, dtype=complex)
     s, axes = _cook_nd_args(a, s, axes, invreal=1)
     for ii in range(len(axes)-1):
         a = ifft(a, s[ii], axes[ii])


### PR DESCRIPTION
The array copy implicit in `astype` was apparently necessary to pass the multithreading tests. This PR makes the copy more explicit.
