### PR TITLE
DOC: Commit message lines should not excede 72 characters.

### DIFF
--- a/doc/source/dev/gitwash/development_workflow.rst
+++ b/doc/source/dev/gitwash/development_workflow.rst
@@ -181,7 +181,7 @@ Commit messages should be clear and follow a few basic rules.  Example::
 
    The first line of the commit message starts with a capitalized acronym
    (options listed below) indicating what type of commit this is.  Then a blank
-   line, then more text if needed.  Lines shouldn't be longer than 80
+   line, then more text if needed.  Lines shouldn't be longer than 72
    characters.  If the commit is related to a ticket, indicate that with
    "See #3456", "See ticket 3456", "Closes #3456" or similar.
 


### PR DESCRIPTION
The reason is that git log indents parts of the message and longer
lines will wrap. Linus has a post on this somewhere.
