### PR TITLE
DOC: add nanmedian/nanpercentile to reference docs

### DIFF
--- a/doc/source/reference/routines.statistics.rst
+++ b/doc/source/reference/routines.statistics.rst
@@ -16,6 +16,7 @@ Order statistics
    nanmax
    ptp
    percentile
+   nanpercentile
 
 Averages and variances
 ----------------------
@@ -28,6 +29,7 @@ Averages and variances
    mean
    std
    var
+   nanmedian
    nanmean
    nanstd
    nanvar


### PR DESCRIPTION
I noticed that the new `nanmedian` and `nanpercentile` functions (1.9.0) were not yet in the reference docs.
