### PR TITLE
ENH: Allow dictproxy objects to be used in place of dicts when creating a dtype

### DIFF
--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -245,6 +245,14 @@ class TestRecord(TestCase):
                                    ('f1', 'datetime64[Y]'),
                                    ('f2', 'i8')]))
 
+    def test_from_dictproxy(self):
+        # Tests for PR #5920
+        dt = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'f4']})
+        assert_dtype_equal(dt, np.dtype(dt.fields))
+        dt2 = np.dtype((np.void, dt.fields))
+        assert_equal(dt2.fields, dt.fields)
+
+
 class TestSubarray(TestCase):
     def test_single_subarray(self):
         a = np.dtype((np.int, (2)))


### PR DESCRIPTION
`arraydescr_new` allows passing in a dict to represent a multi-field
dtype.  However, the .fields attribute on such dtypes is returned
as a dictproxy object.  Therefore it is convenient, for copying
existing multi-field dtypes, to be able to pass in a dictproxy object
as well.

I have another PR I will post shortly that motivated this, and that
demonstrates an example of the (admittedly uncommon) case
where this is useful.
