### PR TITLE
DOC: np.std and np.var docstring examples are outdated

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2939,16 +2939,16 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
     In single precision, std() can be inaccurate:
 
-    >>> a = np.zeros((2,512*512), dtype=np.float32)
-    >>> a[0,:] = 1.0
-    >>> a[1,:] = 0.1
+    >>> a = np.zeros((2, 512*512), dtype=np.float32)
+    >>> a[0, :] = 1.0
+    >>> a[1, :] = 0.1
     >>> np.std(a)
-    0.45172946707416706
+    0.45000005
 
     Computing the standard deviation in float64 is more accurate:
 
     >>> np.std(a, dtype=np.float64)
-    0.44999999925552653
+    0.44999999925494177
 
     """
     if type(a) is not mu.ndarray:
@@ -3035,7 +3035,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
 
     Examples
     --------
-    >>> a = np.array([[1,2],[3,4]])
+    >>> a = np.array([[1, 2], [3, 4]])
     >>> np.var(a)
     1.25
     >>> np.var(a, axis=0)
@@ -3045,18 +3045,18 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
 
     In single precision, var() can be inaccurate:
 
-    >>> a = np.zeros((2,512*512), dtype=np.float32)
-    >>> a[0,:] = 1.0
-    >>> a[1,:] = 0.1
+    >>> a = np.zeros((2, 512*512), dtype=np.float32)
+    >>> a[0, :] = 1.0
+    >>> a[1, :] = 0.1
     >>> np.var(a)
-    0.20405951142311096
+    0.20250003
 
     Computing the variance in float64 is more accurate:
 
     >>> np.var(a, dtype=np.float64)
-    0.20249999932997387
+    0.20249999932944759
     >>> ((1-0.55)**2 + (0.1-0.55)**2)/2
-    0.20250000000000001
+    0.2025
 
     """
     if type(a) is not mu.ndarray:


### PR DESCRIPTION
current examples are showing behaviors of older versions of `numpy`

new behaviors should be:

```
In [1]: import numpy as np

In [2]: a = np.zeros((2, 512*512), dtype=np.float32)

In [3]: a[0, :] = 1.0

In [4]: a[1, :] = 0.1

In [5]: np.std(a)
Out[5]: 0.45000005

In [6]: np.std(a, dtype=np.float64)
Out[6]: 0.44999999925494177

In [7]: np.var(a)
Out[7]: 0.20250003

In [8]: np.var(a, dtype=np.float64)
Out[8]: 0.20249999932944759

In [9]: ((1-0.55)**2 + (0.1-0.55)**2)/2
Out[9]: 0.2025
```
