### PR TITLE
[MRG]: Fweight and aweight support for np.var

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -79,10 +79,6 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False,
     from numpy.lib.function_base import _product_fweights_aweights
     arr = asanyarray(a)
 
-    if arr.ndim > 2:
-        raise ValueError(
-            "No. of dimensions of the array should be greater than 2.")
-
     rcount = _count_reduce_items(arr, axis)
     w, aweights = _product_fweights_aweights(fweights, aweights, rcount)
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3075,8 +3075,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
     if type(a) is not mu.ndarray:
         try:
             var = a.var
-            return var(axis=axis, dtype=dtype, out=out, ddof=ddof,
-                       fweights=fweights, aweights=aweights)
+            return var(axis=axis, dtype=dtype, out=out, ddof=ddof)
         except AttributeError:
             pass
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2963,7 +2963,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
 
 def var(a, axis=None, dtype=None, out=None, ddof=0,
-        keepdims=False):
+        keepdims=False, fweights=None, aweights=None):
     """
     Compute the variance along the specified axis.
 
@@ -3000,6 +3000,16 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
         the result will broadcast correctly against the original `arr`.
+    fweights : array_like, int, optional
+        .. versionadded:: 1.10
+        1-D array of integer freguency weights; the number of times each
+        observation vector should be repeated.
+    aweights : array_like, optional
+        .. versionadded:: 1.10
+        1-D array of observation vector weights. These relative weights are
+        typically large for observations considered "important" and smaller for
+        observations considered less "important". If ``ddof=0`` the array of
+        weights can be used to assign probabilities to observation vectors.
 
     Returns
     -------
@@ -3033,6 +3043,9 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
     below).  Specifying a higher-accuracy accumulator using the ``dtype``
     keyword can alleviate this issue.
 
+    The formula for calculating the weighted variance when fweight and aweight
+    is provided is similar to that of covariance.
+
     Examples
     --------
     >>> a = np.array([[1, 2], [3, 4]])
@@ -3062,9 +3075,11 @@ def var(a, axis=None, dtype=None, out=None, ddof=0,
     if type(a) is not mu.ndarray:
         try:
             var = a.var
-            return var(axis=axis, dtype=dtype, out=out, ddof=ddof)
+            return var(axis=axis, dtype=dtype, out=out, ddof=ddof,
+                       fweights=fweights, aweights=aweights)
         except AttributeError:
             pass
 
     return _methods._var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                         fweights=fweights, aweights=aweights,
                          keepdims=keepdims)


### PR DESCRIPTION
Support for frequency weights and aweights in np.var. I've kept it coherent with `np.cov` and used the same consistency when ddof is not equal to zero or one.
Fixes https://github.com/numpy/numpy/issues/5164
