### PR TITLE
ENH: Add inline C function to import and cache Python functions.

### DIFF
--- a/numpy/core/src/private/npy_import.h
+++ b/numpy/core/src/private/npy_import.h
@@ -1,0 +1,33 @@
+#ifndef NPY_IMPORT_H
+#define NPY_IMPORT_H
+
+#include <Python.h>
+#include <assert.h>
+
+/*! \brief Fetch and cache Python function.
+ *
+ * Import a Python function and cache it for use. The function checks if
+ * cache is NULL, and if not NULL imports the Python function specified by
+ * \a module and \a function, increments its reference count, and stores
+ * the result in \a cache. Usually \a cache will be a static variable and
+ * should be initialized to NULL. On error \a cache will contain NULL on
+ * exit,
+ *
+ * @param module Absolute module name.
+ * @param function Function name.
+ * @param cache Storage location for imported function.
+ */
+NPY_INLINE void
+npy_cache_pyfunc(const char *module, const char *function, PyObject **cache)
+{
+    if (*cache == NULL) {
+        PyObject *mod = PyImport_ImportModule(module);
+
+        if (mod != NULL) {
+            *cache = PyObject_GetAttrString(mod, function);
+            Py_DECREF(mod);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
A new inline function 'npy_cache_pyfunc' is provided for the common
operation of inporting and caching a Python function in static
variables. The intended usage is as follows.

int myfunc()
{
    static PyObject *cache = NULL:

```
npy_cache_pyfunc("the.module.name", "function", &cache);
...
```

}

Errors are not recoverable, so checked with assert for debugging.
