### PR TITLE
BUG: automatically convert recarray dtype to np.record

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -85,6 +85,13 @@ Notably, this affect recarrays containing strings with whitespace, as trailing
 whitespace is trimmed from chararrays but kept in ndarrays of string type.
 Also, the dtype.type of nested structured fields is now inherited.
 
+recarray views
+~~~~~~~~~~~~~~
+Viewing an ndarray as a recarray now automatically converts the dtype to
+np.record. See new record array documentation. Additionally, viewing a recarray
+with a non-structured dtype no longer converts the result's type to ndarray -
+the result will remain a recarray.
+
 'out' keyword argument of ufuncs now accepts tuples of arrays
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When using the 'out' keyword argument of a ufunc, a tuple of arrays, one per

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -424,16 +424,18 @@ Type strings
 
 ``(base_dtype, new_dtype)``
 
-    This usage is discouraged. In NumPy 1.7 and later, it is possible
-    to specify struct dtypes with overlapping fields, functioning like
-    the 'union' type in C. The union mechanism is preferred.
-
-    Both arguments must be convertible to data-type objects in this
-    case. The *base_dtype* is the data-type object that the new
-    data-type builds on. This is how you could assign named fields to
-    any built-in data-type object, as done in
+    In NumPy 1.7 and later, this form allows `base_dtype` to be interpreted as
+    a structured dtype. Arrays created with this dtype will have underlying
+    dtype `base_dtype` but will have fields and flags taken from `new_dtype`.
+    This is useful for creating custom structured dtypes, as done in
     :ref:`record arrays <arrays.classes.rec>`.
 
+    This form also makes it possible to specify struct dtypes with overlapping
+    fields, functioning like the 'union' type in C. This usage is discouraged,
+    however, and the union mechanism is preferred.
+
+    Both arguments must be convertible to data-type objects with the same total
+    size.
     .. admonition:: Example
 
        32-bit integer, whose first two bytes are interpreted as an integer

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -258,6 +258,19 @@ appropriate :ref:`view`: ::
  >>> recordarr = arr.view(dtype=dtype((np.record, arr.dtype)), 
  ...                      type=np.recarray)
 
+For convenience, viewing an ndarray as type `np.recarray` will automatically
+convert to `np.record` datatype, so the dtype can be left out of the view: ::
+
+ >>> recordarr = arr.view(np.recarray)
+ >>> recordarr.dtype
+ dtype((numpy.record, [('foo', '<i4'), ('bar', '<f4'), ('baz', 'S10')]))
+
+To get back to a plain ndarray both the dtype and type must be reset. The
+following view does so, taking into account the unusual case that the
+recordarr was not a structured type: ::
+
+ >>> arr2 = recordarr.view(recordarr.dtype.fields or recordarr.dtype, np.ndarray)
+
 Record array fields accessed by index or by attribute are returned as a record
 array if the field has a structured type but as a plain ndarray otherwise. ::
 
@@ -272,33 +285,6 @@ Note that if a field has the same name as an ndarray attribute, the ndarray
 attribute takes precedence. Such fields will be inaccessible by attribute but
 may still be accessed by index.
 
-Partial Attribute Access
-------------------------
-
-The differences between record arrays and plain structured arrays induce a
-small performance penalty. It is possible to apply one or the other view
-independently if desired. To allow field access by attribute only on the array
-object it is sufficient to view an array as a recarray: ::
-
- >>> recarr = arr.view(np.recarray)
-
-This type of view is commonly used, for example in np.npyio and
-np.recfunctions. Note that unlike full record arrays the individual elements of
-such a view do not have field attributes::
-
- >>> recarr[0].foo
- AttributeError: 'numpy.void' object has no attribute 'foo'
-
-To use the np.record dtype only, convert the dtype using the (base_class,
-dtype) form described in numpy.dtype.  This type of view is rarely used. ::
-
- >>> arr_records = arr.view(dtype((np.record, arr.dtype)))
-
-In documentation, the term 'structured array' will refer to objects of type
-np.ndarray with structured dtype, 'record array' will refer to structured
-arrays subclassed as np.recarray and whose dtype is of type np.record, and
-'recarray' will refer to arrays subclassed as np.recarray but whose dtype is
-not of type np.record.
 
 """
 from __future__ import division, absolute_import, print_function

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1401,6 +1401,32 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(b01.data, array([[1., 0.]]))
         assert_equal(b01.mask, array([[False, False]]))
 
+    def test_assign_dtype(self):
+        # check that the mask's dtype is updated when dtype is changed
+        a = np.zeros(4, dtype='f4,i4')
+
+        m = np.ma.array(a)
+        m.dtype = np.dtype('f4')
+        repr(m) # raises?
+        assert_equal(m.dtype, np.dtype('f4'))
+
+        # check that dtype changes that change shape of mask too much
+        # are not allowed
+        def assign():
+            m = np.ma.array(a)
+            m.dtype = np.dtype('f8')
+        assert_raises(ValueError, assign)
+
+        b = a.view(dtype='f4', type=np.ma.MaskedArray) # raises?
+        assert_equal(b.dtype, np.dtype('f4'))
+
+        # check that nomask is preserved
+        a = np.zeros(4, dtype='f4')
+        m = np.ma.array(a)
+        m.dtype = np.dtype('f4,i4')
+        assert_equal(m.dtype, np.dtype('f4,i4'))
+        assert_equal(m._mask, np.ma.nomask)
+
 
 #------------------------------------------------------------------------------
 class TestFillingValues(TestCase):


### PR DESCRIPTION
As discussed in #3581, this PR automatically converts the dtype of `np.recarray`s to `np.record`. 

To get unit tests to pass I also had to add a setattr to the `MaskedArray` class: MaskedArrays did not support assignment to dtype attribute, as demonstrated in the following examples:

```
>>> a = np.zeros(4, dtype='f4,i4')
>>> m = np.ma.array(a)
>>> m.dtype = np.dtype('f8')
>>> m   # Exception
>>> a.view(dtype='f8', type=np.ma.MaskedArray) #Exception
```

MaskedArray.setattr now catches assignments to dtype and updates the mask accordingly.

Possible issues with this PR, if anyone has any ideas: 

1) Viewing as `a.view(np.recarray)` now changes the dtype. It's not totally clear to me this won't break anything. (Example: It broke maskedarrays above, but due to a maskedaray bug).

2) Another example of the last point: Views are not reversible.

```
>>> a = np.zeros(4, 'f4,i4')
>>> b = a.view(np.recarray).view(np.ndarray)
>>> b.dtype
dtype((numpy.record, [('f0', '<f4'), ('f1', '<i4')]))
```

3) Note (not really a problem): Attempt to create record arrays of non-structured type does not set the dtype to `np.record` (since it is not possible to do so). This is not new to this PR.

```
>>> a = np.zeros(5, 'f8')
>>> np.rec.array(a)
array([ 0.,  0.,  0.,  0.], 
      dtype=float64).view(numpy.recarray)
```

Benefits:
- Goal is to improve results in #3581

I still need to finish writing unit tests
