### PR TITLE
BUG: einsums bool_sum_of_products_contig incorrect for small arrays

### DIFF
--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -1399,28 +1399,19 @@ finish_after_unrolled_loop:
  */
         case @i@+1:
 #  if @nop@ == 1
-            *((npy_bool *)data_out + @i@) = (*((npy_bool *)data0 + @i@)) ||
-                                            (*((npy_bool *)data_out + @i@));
-            data0 += 8*sizeof(npy_bool);
-            data_out += 8*sizeof(npy_bool);
+            ((npy_bool *)data_out)[@i@] = ((npy_bool *)data0)[@i@] ||
+                                            ((npy_bool *)data_out)[@i@];
 #  elif @nop@ == 2
-            *((npy_bool *)data_out + @i@) =
-                            ((*((npy_bool *)data0 + @i@)) &&
-                             (*((npy_bool *)data1 + @i@))) ||
-                                (*((npy_bool *)data_out + @i@));
-            data0 += 8*sizeof(npy_bool);
-            data1 += 8*sizeof(npy_bool);
-            data_out += 8*sizeof(npy_bool);
+            ((npy_bool *)data_out)[@i@] =
+                            (((npy_bool *)data0)[@i@] &&
+                             ((npy_bool *)data1)[@i@]) ||
+                                ((npy_bool *)data_out)[@i@];
 #  elif @nop@ == 3
-            *((npy_bool *)data_out + @i@) =
-                           ((*((npy_bool *)data0 + @i@)) &&
-                            (*((npy_bool *)data1 + @i@)) &&
-                            (*((npy_bool *)data2 + @i@))) ||
-                                (*((npy_bool *)data_out + @i@));
-            data0 += 8*sizeof(npy_bool);
-            data1 += 8*sizeof(npy_bool);
-            data2 += 8*sizeof(npy_bool);
-            data_out += 8*sizeof(npy_bool);
+            ((npy_bool *)data_out)[@i@] =
+                           (((npy_bool *)data0)[@i@] &&
+                            ((npy_bool *)data1)[@i@] &&
+                            ((npy_bool *)data2)[@i@]) ||
+                                ((npy_bool *)data_out)[@i@];
 #  endif
 /**end repeat1**/
         case 0:


### PR DESCRIPTION
The small array (and end of loop) special case incorrectly stepped
through array and left pointers bogus.
## 

Tests still needed, anyone want to jump on this....

Honestly, I am a bit dumbstruck that this was never found. The tests probably just do not test this special case (until now matmul shapes tests), and nobody probably ever really used boolean einsum....
I found this running the tests with valgrind.
