### PR TITLE
Extend github source links to line ranges

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -312,12 +312,12 @@ def linkcode_resolve(domain, info):
         return None
 
     try:
-        source, lineno = inspect.findsource(obj)
+        source, lineno = inspect.getsourcelines(obj)
     except:
         lineno = None
 
     if lineno:
-        linespec = "#L%d" % (lineno + 1)
+        linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
     else:
         linespec = ""
 


### PR DESCRIPTION
Currently, documentation generated with Sphinx includes links to the correct source file and definition line number on github for each documented entity. This PR extends the links to not only link to the starting line, but highlight the full range of an entity. (Feel free to disregard, I did this for a different project and thought you might be interested as well.)

PS: Noticed the guidelines too late, will change the commit message to include the `DOC:` prefix.
