### PR TITLE
BF: do not crash lookfor if inspection fails - catch any Exception

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -976,7 +976,7 @@ def _getmembers(item):
     import inspect
     try:
         members = inspect.getmembers(item)
-    except AttributeError:
+    except Exception:
         members = [(x, getattr(item, x)) for x in dir(item)
                    if hasattr(item, x)]
     return members


### PR DESCRIPTION
My use case:

```
$> PYTHONPATH=$PWD python -c "import numpy as np, nipy; np.lookfor('whatever', nipy)" 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "numpy/lib/utils.py", line 750, in lookfor
    cache = _lookfor_generate_cache(module, import_modules, regenerate)
  File "numpy/lib/utils.py", line 960, in _lookfor_generate_cache
    for n, v in _getmembers(item):
  File "numpy/lib/utils.py", line 978, in _getmembers
    members = inspect.getmembers(item)
  File "/usr/lib/python2.7/inspect.py", line 253, in getmembers
    value = getattr(object, key)
  File "/usr/lib/python2.7/dist-packages/nipy/externals/six.py", line 86, in __get__
    result = self._resolve()
  File "/usr/lib/python2.7/dist-packages/nipy/externals/six.py", line 105, in _resolve
    return _import_module(self.mod)
  File "/usr/lib/python2.7/dist-packages/nipy/externals/six.py", line 76, in _import_module
    __import__(name)
ImportError: No module named _winreg
```

So imho reverting back to rudimentary getattr should be the way to go for any exception to happen.
