### PR TITLE
DOC: Polynomial.deriv refers to integrations, not differentiations

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -661,7 +661,7 @@ class ABCPolyBase(object):
         Parameters
         ----------
         m : non-negative int
-            The number of integrations to perform.
+            Find the derivative of order `m`.
 
         Returns
         -------


### PR DESCRIPTION
Docstring for `numpy.polynomial.Polynomial.deriv` refers to the number of integrations to perform, but it should be the number of differentiations.
