### PR TITLE
BUG: segfault in array_richcompare

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1358,18 +1358,24 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             _res = PyArray_CanCastTypeTo(PyArray_DESCR(self),
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
-            if (_res == 0) {
+
+            if (result == NULL) {
+                PyErr_Clear();
+            }
+            else {
                 Py_DECREF(result);
+            }
+
+            if (_res == 0) {
                 Py_DECREF(array_other);
                 Py_INCREF(Py_False);
                 return Py_False;
             }
             else {
-                Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
+                Py_DECREF(array_other);
+                return result;
             }
-            Py_DECREF(array_other);
-            return result;
         }
         /*
          * If the comparison results in NULL, then the
@@ -1433,18 +1439,24 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             _res = PyArray_CanCastTypeTo(PyArray_DESCR(self),
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
-            if (_res == 0) {
+
+            if (result == NULL) {
+                PyErr_Clear();
+            }
+            else {
                 Py_DECREF(result);
+            }
+
+            if (_res == 0) {
                 Py_DECREF(array_other);
                 Py_INCREF(Py_True);
                 return Py_True;
             }
             else {
-                Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
                 Py_DECREF(array_other);
+                return result;
             }
-            return result;
         }
 
         if (result == NULL) {

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1156,6 +1156,19 @@ class TestUfunc(TestCase):
                       out=None, invalid=0)
         assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
 
+    def test_structured_equal(self):
+        # https://github.com/numpy/numpy/issues/4855
+        class MyA(np.ndarray):
+            def __numpy_ufunc__(self, ufunc, method, i, inputs, **kwargs):
+                return getattr(ufunc, method)(*(input.view(np.ndarray)
+                                              for input in inputs), **kwargs)
+        a = np.arange(12.).reshape(4,3)
+        ra = a.view(dtype=('f8,f8,f8')).squeeze()
+        mra = ra.view(MyA)
+
+        target = np.array([ True, False, False, False], dtype=bool)
+        assert_equal(np.all(target == (mra == ra[0])), True)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes #4855. Only real change was `Py_DECREF(result)` became `Py_XDECREF(result)`.

I assume the other logic there is fine, I don't know ufunc code very well.
