### PR TITLE
BUG Ensure masked object arrays can always return single items.

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -99,6 +99,11 @@ byte-array indices now raises an IndexError
 Indexing an ndarray using a byte-string in Python 3 now raises an IndexError
 instead of a ValueError.
 
+Masked arrays containing objects with arrays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For such (rare) masked arrays, getting a single masked item no longer returns a
+corrupted masked array, but a fully masked version of the item.
+
 New Features
 ============
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3046,6 +3046,7 @@ class MaskedArray(ndarray):
         # mask of being reshaped if it hasn't been set up properly yet...
         # So it's easier to stick to the current version
         _mask = self._mask
+        # Did we extract a single item?
         if not getattr(dout, 'ndim', False):
             # A record ................
             if isinstance(dout, np.void):
@@ -3057,6 +3058,11 @@ class MaskedArray(ndarray):
             # Just a scalar............
             elif _mask is not nomask and _mask[indx]:
                 return masked
+        elif self.dtype.type is np.object_ and self.dtype is not dout.dtype:
+            # self contains an object array of arrays (yes, that happens).
+            # If masked, turn into a MaskedArray, with everything masked.
+            if _mask is not nomask and _mask[indx]:
+                return MaskedArray(dout, mask=True)
         else:
             # Force dout to MA ........
             dout = dout.view(type(self))

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -685,6 +685,18 @@ class TestMaskedArray(TestCase):
         finally:
             masked_print_option.set_display(ini_display)
 
+    def test_object_with_array(self):
+        mx1 = masked_array([1.], mask=[True])
+        mx2 = masked_array([1., 2.])
+        mx = masked_array([mx1, mx2], mask=[False, True])
+        assert mx[0] is mx1
+        assert mx[1] is not mx2
+        assert np.all(mx[1].data == mx2.data)
+        assert np.all(mx[1].mask)
+        # check that we return a view.
+        mx[1].data[0] = 0.
+        assert mx2[0] == 0.
+
 
 #------------------------------------------------------------------------------
 class TestMaskedArrayArithmetic(TestCase):


### PR DESCRIPTION
For a masked array holding objects that themselves are arrays, when selecting a single item, it is treated as if it were a slice of the array and an attempt is made to set its mask.  This was always a bug, but it become visible with a recent change to `MaskedArray.__getitem__` (#4586) where it is attempted to change the shape of the mask (to help matrices, sigh, was not even part of PR initially!).  With this PR, the treatment is the same as for other single items: one either gets the array stored in the object, or masked.

Test case that now works but used to fail:

```
mx1 = MaskedArray([1.], mask=[True])
mx2 = MaskedArray_array([1., 2.])
mx = MaskedArray([mx1, mx2], mask=[False, True])
mx[0]
```
