### PR TITLE
Rubustify tuple loop search

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -2106,7 +2106,6 @@ type_tuple_type_resolver(PyUFuncObject *self,
 
     for (i = 0; i < self->ntypes; ++i) {
         char *orig_types = self->types + i*self->nargs;
-        int matched = 1;
 
         /* Copy the types into an int array for matching */
         for (j = 0; j < nop; ++j) {
@@ -2116,17 +2115,17 @@ type_tuple_type_resolver(PyUFuncObject *self,
         if (n_specified == nop) {
             for (j = 0; j < nop; ++j) {
                 if (types[j] != specified_types[j] &&
-                                specified_types[j] != NPY_NOTYPE) {
-                    matched = 0;
+                        specified_types[j] != NPY_NOTYPE) {
                     break;
                 }
             }
-        } else {
-            if (types[nin] != specified_types[0]) {
-                matched = 0;
+            if (j < nop) {
+                /* no match */
+                continue;
             }
         }
-        if (!matched) {
+        else if (types[nin] != specified_types[0]) {
+            /* no match */
             continue;
         }
 
@@ -2136,29 +2135,23 @@ type_tuple_type_resolver(PyUFuncObject *self,
                     types, NULL,
                     &no_castable_output, &err_src_typecode,
                     &err_dst_typecode)) {
-            /* Error */
             case -1:
+                /* Error */
                 return -1;
-            /* It worked */
+            case 0:
+                /* Cannot cast inputs */
+                continue;
             case 1:
+                /* Success */
                 set_ufunc_loop_data_types(self, op, out_dtype, types, NULL);
                 return 0;
-            /* Didn't work */
-            case 0:
-                PyErr_Format(PyExc_TypeError,
-                     "found a loop for ufunc '%s' "
-                     "matching the type-tuple, "
-                     "but the inputs and/or outputs could not be "
-                     "cast according to the casting rule",
-                     ufunc_name);
-                return -1;
         }
     }
 
     /* If no function was found, throw an error */
     PyErr_Format(PyExc_TypeError,
-            "No loop matching the specified signature was found "
-            "for ufunc %s", ufunc_name);
+            "No loop matching the specified signature and casting\n"
+            "was found for ufunc %s", ufunc_name);
 
     return -1;
 }

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -342,6 +342,16 @@ class TestUfunc(TestCase):
         np.add(a, 0.5, sig=('i4', 'i4', 'i4'), out=b, casting='unsafe')
         assert_equal(b, [0, 0, 1])
 
+    def test_true_divide(self):
+        # True_divide has a non uniform signature, see #3484.
+        # This also tests type_tuple_type_resolver.
+        a = np.full(5, 12.5)
+        b = np.full(5, 10.0)
+        tgt = np.full(5, 1.25)
+        assert_almost_equal(np.true_divide(a, b, dtype=np.float64), tgt)
+        assert_almost_equal(np.true_divide(a, b, dtype=np.float32), tgt)
+        assert_raises(TypeError, np.true_divide, a, b, dtype=np.int)
+
     def test_sum_stability(self):
         a = np.ones(500, dtype=np.float32)
         assert_almost_equal((a / 10.).sum() - a.size / 10., 0, 4)


### PR DESCRIPTION
Fix for #3484, the failure to find a loop for true_divide for `float64` inputs when `dtype=float64` is also specified.

This is a minimal fix. A first cut at more extensive casting revisions fell short and needs more study.
