### PR TITLE
Fixup gh 5864

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -20,19 +20,23 @@ Highlights
 * Addition of `nanprod` to the set of nanfunctions.
 * Support for the '@' operator in Python 3.5.
 
+Dropped Support:
 
-Dropped Support
-===============
 * The polytemplate.py file has been removed.
 * The _dotblas module is no longer available.
 * The testcalcs.py file has been removed.
 
+Future Changes:
 
-Future Changes
-==============
+* In array comparisons like ``arr1 == arr2``, many corner cases
+  involving strings or structured dtypes that used to return scalars
+  now issue ``FutureWarning`` or ``DeprecationWarning``, and in the
+  future will be change to either perform elementwise comparisons or
+  raise an error.
 * The SafeEval class will be removed.
 * The alterdot and restoredot functions will be removed.
 
+See below for more details on these changes.
 
 Compatibility notes
 ===================
@@ -276,6 +280,41 @@ array is writeable.
 
 Deprecations
 ============
+
+Array comparisons involving strings or structured dtypes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Normally, comparison operations on arrays perform elementwise
+comparisons and return arrays of booleans. But in some corner cases,
+especially involving strings are structured dtypes, NumPy has
+historically returned a scalar instead. For example::
+
+  ### Current behaviour
+
+  np.arange(2) == "foo"
+  # -> False
+
+  np.arange(2) < "foo"
+  # -> True on Python 2, error on Python 3
+
+  np.ones(2, dtype="i4,i4") == np.ones(2, dtype="i4,i4,i4")
+  # -> False
+
+Continuing work started in 1.9, in 1.10 these comparisons will now
+raise ``FutureWarning`` or ``DeprecationWarning``, and in the future
+they will be modified to behave more consistently with other
+comparison operations, e.g.::
+
+  ### Future behaviour
+
+  np.arange(2) == "foo"
+  # -> array([False, False])
+
+  np.arange(2) < "foo"
+  # -> error, strings and numbers are not orderable
+
+  np.ones(2, dtype="i4,i4") == np.ones(2, dtype="i4,i4,i4")
+  # -> [False, False]
 
 SafeEval
 ~~~~~~~~

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1343,16 +1343,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_False);
             return Py_False;
         }
-        if (needs_right_binop_forward(obj_self, other, "__eq__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        result = PyArray_GenericBinaryFunction(self,
-                (PyObject *)other,
-                n_ops.equal);
-        if (result && result != Py_NotImplemented)
-          break;
 
         /*
          * The ufunc does not support void/structured types, so these
@@ -1370,6 +1360,12 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             if (array_other == NULL) {
                 PyErr_Clear();
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_NotImplemented);
                 return Py_NotImplemented;
             }
@@ -1378,18 +1374,31 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
             if (_res == 0) {
-                Py_DECREF(result);
                 Py_DECREF(array_other);
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_False);
                 return Py_False;
             }
             else {
-                Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
             }
             Py_DECREF(array_other);
             return result;
         }
+
+        if (needs_right_binop_forward(obj_self, other, "__eq__", 0) &&
+                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
+        result = PyArray_GenericBinaryFunction(self,
+                (PyObject *)other,
+                n_ops.equal);
         /*
          * If the comparison results in NULL, then the
          * two array objects can not be compared together;
@@ -1402,7 +1411,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             PyErr_Clear();
             if (DEPRECATE("elementwise comparison failed; "
-                          "this will raise the error in the future.") < 0) {
+                          "this will raise an error in the future.") < 0) {
                 return NULL;
             }
 
@@ -1419,15 +1428,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             Py_INCREF(Py_True);
             return Py_True;
         }
-        if (needs_right_binop_forward(obj_self, other, "__ne__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
-                n_ops.not_equal);
-        if (result && result != Py_NotImplemented)
-          break;
 
         /*
          * The ufunc does not support void/structured types, so these
@@ -1445,6 +1445,12 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             */
             if (array_other == NULL) {
                 PyErr_Clear();
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_NotImplemented);
                 return Py_NotImplemented;
             }
@@ -1453,19 +1459,30 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
             if (_res == 0) {
-                Py_DECREF(result);
                 Py_DECREF(array_other);
+                if (DEPRECATE_FUTUREWARNING(
+                        "elementwise comparison failed and returning scalar "
+                        "instead; this will raise an error or perform "
+                        "elementwise comparison in the future.") < 0) {
+                    return NULL;
+                }
                 Py_INCREF(Py_True);
                 return Py_True;
             }
             else {
-                Py_DECREF(result);
                 result = _void_compare(self, array_other, cmp_op);
                 Py_DECREF(array_other);
             }
             return result;
         }
 
+        if (needs_right_binop_forward(obj_self, other, "__ne__", 0) &&
+                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+        }
+        result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
+                n_ops.not_equal);
         if (result == NULL) {
             /*
              * Comparisons should raise errors when element-wise comparison
@@ -1473,7 +1490,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             PyErr_Clear();
             if (DEPRECATE("elementwise comparison failed; "
-                          "this will raise the error in the future.") < 0) {
+                          "this will raise an error in the future.") < 0) {
                 return NULL;
             }
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1370,7 +1370,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (array_other == NULL) {
                 PyErr_Clear();
                 if (DEPRECATE(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise == comparison failed and returning scalar "
                         "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
@@ -1384,7 +1384,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (_res == 0) {
                 Py_DECREF(array_other);
                 if (DEPRECATE_FUTUREWARNING(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise == comparison failed and returning scalar "
                         "instead; this will raise an error or perform "
                         "elementwise comparison in the future.") < 0) {
                     return NULL;
@@ -1418,7 +1418,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * is not possible.
              */
             PyErr_Clear();
-            if (DEPRECATE("elementwise comparison failed; "
+            if (DEPRECATE("elementwise == comparison failed; "
                           "this will raise an error in the future.") < 0) {
                 return NULL;
             }
@@ -1454,7 +1454,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (array_other == NULL) {
                 PyErr_Clear();
                 if (DEPRECATE(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise != comparison failed and returning scalar "
                         "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
@@ -1468,7 +1468,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             if (_res == 0) {
                 Py_DECREF(array_other);
                 if (DEPRECATE_FUTUREWARNING(
-                        "elementwise comparison failed and returning scalar "
+                        "elementwise != comparison failed and returning scalar "
                         "instead; this will raise an error or perform "
                         "elementwise comparison in the future.") < 0) {
                     return NULL;
@@ -1496,7 +1496,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * is not possible.
              */
             PyErr_Clear();
-            if (DEPRECATE("elementwise comparison failed; "
+            if (DEPRECATE("elementwise != comparison failed; "
                           "this will raise an error in the future.") < 0) {
                 return NULL;
             }

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1312,6 +1312,15 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         else {
             return _strings_richcompare(self, array_other, cmp_op, 0);
         }
+        /* If we reach this point, it means that we are not comparing
+         * string-to-string. It's possible that this will still work out,
+         * e.g. if the other array is an object array, then both will be cast
+         * to object or something? I don't know how that works actually, but
+         * it does, b/c this works:
+         *   l = ["a", "b"]
+         *   assert np.array(l, dtype="S1") == np.array(l, dtype="O")
+         * So we fall through and see what happens.
+         */
     }
 
     switch (cmp_op) {
@@ -1360,10 +1369,9 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              */
             if (array_other == NULL) {
                 PyErr_Clear();
-                if (DEPRECATE_FUTUREWARNING(
+                if (DEPRECATE(
                         "elementwise comparison failed and returning scalar "
-                        "instead; this will raise an error or perform "
-                        "elementwise comparison in the future.") < 0) {
+                        "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
                 Py_INCREF(Py_NotImplemented);
@@ -1445,10 +1453,9 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             */
             if (array_other == NULL) {
                 PyErr_Clear();
-                if (DEPRECATE_FUTUREWARNING(
+                if (DEPRECATE(
                         "elementwise comparison failed and returning scalar "
-                        "instead; this will raise an error or perform "
-                        "elementwise comparison in the future.") < 0) {
+                        "instead; this will raise an error in the future.") < 0) {
                     return NULL;
                 }
                 Py_INCREF(Py_NotImplemented);

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -303,6 +303,10 @@ PyArray_GenericBinaryFunction(PyArrayObject *m1, PyObject *m2, PyObject *op)
            * See also:
            * - https://github.com/numpy/numpy/issues/3502
            * - https://github.com/numpy/numpy/issues/3503
+           *
+           * NB: there's another copy of this code in
+           *    numpy.ma.core.MaskedArray._delegate_binop
+           * which should possibly be updated when this is.
            */
           double m1_prio = PyArray_GetPriority((PyObject *)m1,
                                                NPY_SCALAR_PRIORITY);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -953,25 +953,25 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
         /* strcmp() is a hack but I think we can get away with it for this
          * temporary measure.
          */
-        if (!strcmp(ufunc_name, "equal")
-            || !strcmp(ufunc_name, "not_equal")) {
+        if (!strcmp(ufunc_name, "equal") ||
+                !strcmp(ufunc_name, "not_equal")) {
             /* Warn on non-scalar, return NotImplemented regardless */
             assert(nin == 2);
-            if (PyArray_NDIM(out_op[0]) != 0
-                || PyArray_NDIM(out_op[1]) != 0) {
+            if (PyArray_NDIM(out_op[0]) != 0 ||
+                    PyArray_NDIM(out_op[1]) != 0) {
                 if (DEPRECATE_FUTUREWARNING(
                         "elementwise comparison failed; returning scalar "
-                        "but in the future will perform elementwise "
+                        "instead, but in the future will perform elementwise "
                         "comparison") < 0) {
                     return -1;
                 }
             }
             return -2;
         }
-        else if (!strcmp(ufunc_name, "less")
-                 || !strcmp(ufunc_name, "less_equal")
-                 || !strcmp(ufunc_name, "greater")
-                 || !strcmp(ufunc_name, "greater_equal")) {
+        else if (!strcmp(ufunc_name, "less") ||
+                 !strcmp(ufunc_name, "less_equal") ||
+                 !strcmp(ufunc_name, "greater") ||
+                 !strcmp(ufunc_name, "greater_equal")) {
 #if !defined(NPY_PY3K)
             if (DEPRECATE("unorderable dtypes; returning scalar but in "
                           "the future this will be an error") < 0) {
@@ -4255,7 +4255,8 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
             return NULL;
         }
         else if (ufunc->nin == 2 && ufunc->nout == 1) {
-            /* For array_richcompare's benefit -- see the long comment in
+            /*
+             * For array_richcompare's benefit -- see the long comment in
              * get_ufunc_arguments.
              */
             Py_INCREF(Py_NotImplemented);

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -82,23 +82,26 @@ class _DeprecationTestCase(object):
             if warning.category is DeprecationWarning:
                 num_found += 1
             elif not ignore_others:
-                raise AssertionError("expected DeprecationWarning but %s given"
-                                                            % warning.category)
+                raise AssertionError(
+                        "expected DeprecationWarning but got: %s" %
+                        (repr_warning_message(warning),))
         if num is not None and num_found != num:
-            raise AssertionError("%i warnings found but %i expected"
-                                                        % (len(self.log), num))
+            msg = "%i warnings found but %i expected." % (len(self.log), num)
+            lst = [repr_warning_message(w) for w in self.log]
+            raise AssertionError("\n".join([msg] + [lst]))
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message=self.message,
-                                        category=DeprecationWarning)
-
+                                    category=DeprecationWarning)
             try:
                 function(*args, **kwargs)
                 if exceptions != tuple():
-                    raise AssertionError("No error raised during function call")
+                    raise AssertionError(
+                            "No error raised during function call")
             except exceptions:
                 if exceptions == tuple():
-                    raise AssertionError("Error raised during function call")
+                    raise AssertionError(
+                            "Error raised during function call")
 
     def assert_not_deprecated(self, function, args=(), kwargs={}):
         """Test if DeprecationWarnings are given and raised.
@@ -493,6 +496,7 @@ class TestComparisonDeprecations(_DeprecationTestCase):
                     else:
                         # py2
                         assert_warns(DeprecationWarning, f, arg1, arg2)
+
 
 class TestIdentityComparisonDeprecations(_DeprecationTestCase):
     """This tests the equal and not_equal object ufuncs identity check

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -75,6 +75,7 @@ class _DeprecationTestCase(object):
             function(*args, **kwargs)
         except (Exception if function_fails else tuple()):
             pass
+
         # just in case, clear the registry
         num_found = 0
         for warning in self.log:
@@ -446,6 +447,10 @@ class TestComparisonDeprecations(_DeprecationTestCase):
         class NotArray(object):
             def __array__(self):
                 raise TypeError
+
+            # Needed so Python 3 does not raise DeprecationWarning twice.
+            def __ne__(self, other):
+                return NotImplemented
 
         self.assert_deprecated(lambda: np.arange(2) == NotArray())
         self.assert_deprecated(lambda: np.arange(2) != NotArray())

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -383,7 +383,7 @@ class TestComparisonDeprecations(_DeprecationTestCase):
     """
 
     message = "elementwise comparison failed; " \
-              "this will raise the error in the future."
+              "this will raise an error in the future."
 
     def test_normal_types(self):
         for op in (operator.eq, operator.ne):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -955,12 +955,16 @@ class TestMultiIndexingAutomated(TestCase):
             # index, when running the file separately.
             warnings.filterwarnings('error', '', DeprecationWarning)
             warnings.filterwarnings('error', '', np.VisibleDeprecationWarning)
+
+            def isskip(idx):
+                return isinstance(idx, str) and idx == "skip"
+
             for simple_pos in [0, 2, 3]:
                 tocheck = [self.fill_indices, self.complex_indices,
                            self.fill_indices, self.fill_indices]
                 tocheck[simple_pos] = self.simple_indices
                 for index in product(*tocheck):
-                    index = tuple(i for i in index if i != 'skip')
+                    index = tuple(i for i in index if not isskip(i))
                     self._check_multi_index(self.a, index)
                     self._check_multi_index(self.b, index)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -738,11 +738,21 @@ class TestStructured(TestCase):
         # Check that incompatible sub-array shapes don't result to broadcasting
         x = np.zeros((1,), dtype=[('a', ('f4', (1, 2))), ('b', 'i1')])
         y = np.zeros((1,), dtype=[('a', ('f4', (2,))), ('b', 'i1')])
-        assert_equal(x == y, False)
+        # This comparison invokes deprecated behaviour, and will probably
+        # start raising an error eventually. What we really care about in this
+        # test is just that it doesn't return True.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            assert_equal(x == y, False)
 
         x = np.zeros((1,), dtype=[('a', ('f4', (2, 1))), ('b', 'i1')])
         y = np.zeros((1,), dtype=[('a', ('f4', (2,))), ('b', 'i1')])
-        assert_equal(x == y, False)
+        # This comparison invokes deprecated behaviour, and will probably
+        # start raising an error eventually. What we really care about in this
+        # test is just that it doesn't return True.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            assert_equal(x == y, False)
 
         # Check that structured arrays that are different only in
         # byte-order work

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -128,13 +128,17 @@ class TestRegression(TestCase):
         assert_almost_equal(x**(-1), [1/(1+2j)])
 
     def test_scalar_compare(self,level=rlevel):
-        """Ticket #72"""
+        # Trac Ticket #72
+        # https://github.com/numpy/numpy/issues/565
         a = np.array(['test', 'auto'])
         assert_array_equal(a == 'auto', np.array([False, True]))
         self.assertTrue(a[1] == 'auto')
         self.assertTrue(a[0] != 'auto')
         b = np.linspace(0, 10, 11)
-        self.assertTrue(b != 'auto')
+        # This should return true for now, but will eventually raise an error:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self.assertTrue(b != 'auto')
         self.assertTrue(b[0] != 'auto')
 
     def test_unicode_swapping(self,level=rlevel):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1157,14 +1157,35 @@ class TestUfunc(TestCase):
                      out=None)
 
         # invalid keyord
+        assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
+        assert_raises(TypeError, f, d, invalid=0)
         assert_raises(TypeError, f, d, 0, keepdims=True, invalid="invalid",
                       out=None)
-        assert_raises(TypeError, f, d, invalid=0)
         assert_raises(TypeError, f, d, axis=0, dtype=None, keepdims=True,
                       out=None, invalid=0)
         assert_raises(TypeError, f, d, axis=0, dtype=None,
                       out=None, invalid=0)
-        assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
+
+    def test_NotImplemented_not_returned(self):
+        # See gh-5964 and gh-2091. Some of these functions are not operator
+        # related and were fixed for other reasons in the past.
+        binary_funcs = [
+            np.power, np.add, np.subtract, np.multiply, np.divide,
+            np.true_divide, np.floor_divide, np.bitwise_and, np.bitwise_or,
+            np.bitwise_xor, np.left_shift, np.right_shift, np.fmax,
+            np.fmin, np.fmod, np.hypot, np.logaddexp, np.logaddexp2,
+            np.logical_and, np.logical_or, np.logical_xor, np.maximum,
+            np.minimum, np.mod
+            ]
+
+        # These functions still return NotImplemented. Will be fixed in
+        # future.
+        # bad = [np.greater, np.greater_equal, np.less, np.less_equal, np.not_equal]
+
+        a = np.array('1')
+        b = 1
+        for f in binary_funcs:
+            assert_raises(TypeError, f, a, b)
 
 
 if __name__ == "__main__":

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3679,6 +3679,16 @@ class MaskedArray(ndarray):
             return _print_templates['short_std'] % parameters
         return _print_templates['long_std'] % parameters
 
+    def _delegate_binop(self, other):
+        # This emulates the logic in
+        #     multiarray/number.c:PyArray_GenericBinaryFunction
+        if (not isinstance(other, np.ndarray)
+            and not hasattr(other, "__numpy_ufunc__")):
+            other_priority = getattr(other, "__array_priority__", -1000000)
+            if self.__array_priority__ < other_priority:
+                return True
+        return False
+
     def __eq__(self, other):
         "Check whether other equals self elementwise"
         if self is masked:
@@ -3747,6 +3757,8 @@ class MaskedArray(ndarray):
     #
     def __add__(self, other):
         "Add other to self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return add(self, other)
     #
     def __radd__(self, other):
@@ -3755,6 +3767,8 @@ class MaskedArray(ndarray):
     #
     def __sub__(self, other):
         "Subtract other to self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return subtract(self, other)
     #
     def __rsub__(self, other):
@@ -3763,6 +3777,8 @@ class MaskedArray(ndarray):
     #
     def __mul__(self, other):
         "Multiply other by self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return multiply(self, other)
     #
     def __rmul__(self, other):
@@ -3771,10 +3787,14 @@ class MaskedArray(ndarray):
     #
     def __div__(self, other):
         "Divide other into self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return divide(self, other)
     #
     def __truediv__(self, other):
         "Divide other into self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return true_divide(self, other)
     #
     def __rtruediv__(self, other):
@@ -3783,6 +3803,8 @@ class MaskedArray(ndarray):
     #
     def __floordiv__(self, other):
         "Divide other into self, and return a new masked array."
+        if self._delegate_binop(other):
+            return NotImplemented
         return floor_divide(self, other)
     #
     def __rfloordiv__(self, other):
@@ -3791,6 +3813,8 @@ class MaskedArray(ndarray):
     #
     def __pow__(self, other):
         "Raise self to the power other, masking the potential NaNs/Infs"
+        if self._delegate_binop(other):
+            return NotImplemented
         return power(self, other)
     #
     def __rpow__(self, other):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -12,6 +12,7 @@ import warnings
 import sys
 import pickle
 from functools import reduce
+import operator
 
 from nose.tools import assert_raises
 
@@ -1734,16 +1735,15 @@ class TestUfuncs(TestCase):
         self.assertTrue(not isinstance(test.mask, MaskedArray))
 
     def test_treatment_of_NotImplemented(self):
-        # Check any NotImplemented returned by umath.<ufunc> is passed on
-        a = masked_array([1., 2.], mask=[1, 0])
-        # basic tests for _MaskedBinaryOperation
-        assert_(a.__mul__('abc') is NotImplemented)
-        assert_(multiply.outer(a, 'abc') is NotImplemented)
-        # and for _DomainedBinaryOperation
-        assert_(a.__div__('abc') is NotImplemented)
+        # Check that NotImplemented is returned at appropriate places
 
-        # also check explicitly that rmul of another class can be accessed
-        class MyClass(str):
+        a = masked_array([1., 2.], mask=[1, 0])
+        self.assertRaises(TypeError, operator.mul, a, "abc")
+        self.assertRaises(TypeError, operator.truediv, a, "abc")
+
+        class MyClass(object):
+            __array_priority__ = a.__array_priority__ + 1
+
             def __mul__(self, other):
                 return "My mul"
 


### PR DESCRIPTION
Fix failing test in #5864 and make some style cleanups. Original message from Nathaniel follows.

We've long had consensus that returning NotImplemented from ufuncs was a bad and ugly hack, since it violates layering -- NotImplemented is the responsibility of **op** methods, not ufuncs. And one of the things that came out of the discussion in gh-5844 is that the NotImplemented handling inside the ufunc machinery was actually mostly useless and broken (see the first post on that report for analysis).

Of course, it turns out it's not quite that simple -- there were some places, esp. in the trainwreck that is array_richcompare, which were depending on the current behavior.

This patch series fixes the main pieces of code that used to rely on this behavior, and then removes as much of the NotImplemented handling as it can. And for what isn't removed, it adds deprecation or future warnings.

In particular, there are a bunch of cases where array_richcompare returns bad and wrong results, like where you can compare two arrays (which should produce a boolean array), some failure occurs, and then the error gets thrown away and we end up returning a boolean scalar. Some of these were deprecated in 9b8f6c7, but this deprecates the rest. Probably the most controversial part of this is that this patch deprecates scalar ordering comparisons between unlike types, like np.float64(1) < "foo", which are already an error on py3 but have traditionally returned some semi-arbitrary value on py2. To convince you that this is broken and we should stop supporting it, check this out:
# Note: the name of this class affects the results below

In [1]: class quux(object):
   ...:     pass
   ...: 

In [2]: q = quux()

In [3]: np.string_("foo") < q
Out[3]: True

In [4]: np.asarray(np.string_("foo")) < q
Out[4]: False

For a full analysis of how we handle all the legacy comparison cases, see the long comment that starts here: https://github.com/numpy/numpy/blob/19b829a660a6adc8118dc427e1a7e4ba6946ccf7/numpy/core/src/umath/ufunc_object.c#L867

NB this PR is probably easier to review if you read the commits one at a time in order, instead of jumping straight to the big diff.
