### PR TITLE
BUG: fix inconsistency with np.array(['']) being truthy

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2298,6 +2298,10 @@ STRING_nonzero (char *ip, PyArrayObject *ap)
     int i;
     npy_bool nonz = NPY_FALSE;
 
+    if ((len == 1) && (*ip == '\0')) {
+        return NPY_FALSE;
+    }
+
     for (i = 0; i < len; i++) {
         if (!Py_STRING_ISSPACE(*ip)) {
             nonz = NPY_TRUE;
@@ -2332,6 +2336,10 @@ UNICODE_nonzero (npy_ucs4 *ip, PyArrayObject *ap)
             byte_swap_vector(buffer, len, 4);
         }
         ip = (npy_ucs4 *)buffer;
+    }
+
+    if ((len == 1) && (*ip == '\0')) {
+        return NPY_FALSE;
     }
 
     for (i = 0; i < len; i++) {

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2339,10 +2339,6 @@ UNICODE_nonzero (npy_ucs4 *ip, PyArrayObject *ap)
         ip = (npy_ucs4 *)buffer;
     }
 
-    if ((len == 1) && (*ip == '\0')) {
-        return NPY_FALSE;
-    }
-
     for (i = 0; i < len; i++) {
         if (*ip == '\0') {
             seen_null = NPY_TRUE;

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2297,13 +2297,13 @@ STRING_nonzero (char *ip, PyArrayObject *ap)
     int len = PyArray_DESCR(ap)->elsize;
     int i;
     npy_bool nonz = NPY_FALSE;
-
-    if ((len == 1) && (*ip == '\0')) {
-        return NPY_FALSE;
-    }
+    npy_bool seen_null = NPY_FALSE;
 
     for (i = 0; i < len; i++) {
-        if (!Py_STRING_ISSPACE(*ip)) {
+        if (*ip == '\0') {
+            seen_null = NPY_TRUE;
+        }
+        else if (seen_null || !Py_STRING_ISSPACE(*ip)) {
             nonz = NPY_TRUE;
             break;
         }
@@ -2324,6 +2324,7 @@ UNICODE_nonzero (npy_ucs4 *ip, PyArrayObject *ap)
     int len = PyArray_DESCR(ap)->elsize >> 2;
     int i;
     npy_bool nonz = NPY_FALSE;
+    npy_bool seen_null = NPY_FALSE;
     char *buffer = NULL;
 
     if ((!PyArray_ISNOTSWAPPED(ap)) || (!PyArray_ISALIGNED(ap))) {
@@ -2343,7 +2344,10 @@ UNICODE_nonzero (npy_ucs4 *ip, PyArrayObject *ap)
     }
 
     for (i = 0; i < len; i++) {
-        if (!PyArray_UCS4_ISSPACE(*ip)) {
+        if (*ip == '\0') {
+            seen_null = NPY_TRUE;
+        }
+        else if (seen_null || !PyArray_UCS4_ISSPACE(*ip)) {
             nonz = NPY_TRUE;
             break;
         }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5734,10 +5734,10 @@ class TestArrayPriority(TestCase):
 class TestEmptyStringArray(TestCase):
 
     def test_empty_bstring_array_is_falsey(self):
-        self.assertFalse(np.array([b'']))
+        self.assertFalse(np.array([''], dtype=np.str))
 
     def test_empty_ustring_array_is_falsey(self):
-        self.assertFalse(np.array([u'']))
+        self.assertFalse(np.array([''], dtype=np.unicode))
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5731,13 +5731,46 @@ class TestArrayPriority(TestCase):
             assert_(isinstance(f(b, a), self.Other), msg)
 
 
-class TestEmptyStringArray(TestCase):
+class TestBytestringArrayNonzero(TestCase):
 
     def test_empty_bstring_array_is_falsey(self):
         self.assertFalse(np.array([''], dtype=np.str))
 
+    def test_whitespace_bstring_array_is_falsey(self):
+        a = np.array(['spam'], dtype=np.str)
+        a[0] = '  \0\0'
+        self.assertFalse(a)
+
+    def test_all_null_bstring_array_is_falsey(self):
+        a = np.array(['spam'], dtype=np.str)
+        a[0] = '\0\0\0\0'
+        self.assertFalse(a)
+
+    def test_null_inside_bstring_array_is_truthy(self):
+        a = np.array(['spam'], dtype=np.str)
+        a[0] = ' \0 \0'
+        self.assertTrue(a)
+
+
+class TestUnicodeArrayNonzero(TestCase):
+
     def test_empty_ustring_array_is_falsey(self):
         self.assertFalse(np.array([''], dtype=np.unicode))
+
+    def test_whitespace_ustring_array_is_falsey(self):
+        a = np.array(['eggs'], dtype=np.unicode)
+        a[0] = '  \0\0'
+        self.assertFalse(a)
+
+    def test_all_null_ustring_array_is_falsey(self):
+        a = np.array(['eggs'], dtype=np.unicode)
+        a[0] = '\0\0\0\0'
+        self.assertFalse(a)
+
+    def test_null_inside_ustring_array_is_truthy(self):
+        a = np.array(['eggs'], dtype=np.unicode)
+        a[0] = ' \0 \0'
+        self.assertTrue(a)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5731,5 +5731,14 @@ class TestArrayPriority(TestCase):
             assert_(isinstance(f(b, a), self.Other), msg)
 
 
+class TestEmptyStringArray(TestCase):
+
+    def test_empty_bstring_array_is_falsey(self):
+        self.assertFalse(np.array([b'']))
+
+    def test_empty_ustring_array_is_falsey(self):
+        self.assertFalse(np.array([u'']))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
```
a = np.array([0])
b = np.array([None])
c = np.array([''])
d = np.array(['   '])
```

Why should we have this inconsistency:

```
>>> bool(a)
False
>>> bool(b)
False
>>> bool(c)
True
>>> bool(d)
False
```
