### PR TITLE
FIX sprintf bug + get rid of a lot of warnings

### DIFF
--- a/numpy/build_utils/src/apple_sgemv_fix.c
+++ b/numpy/build_utils/src/apple_sgemv_fix.c
@@ -97,29 +97,27 @@ static void loadlib()
     veclib = dlopen(VECLIB_FILE, RTLD_LOCAL | RTLD_FIRST);
     if (!veclib) {
         veclib = NULL;
-        sprintf(errormsg,"Failed to open vecLib from location '%s'.", VECLIB_FILE);
+        snprintf(errormsg, sizeof(errormsg),
+                 "Failed to open vecLib from location '%s'.", VECLIB_FILE);
         Py_FatalError(errormsg); /* calls abort() and dumps core */
     }
     /* resolve Fortran SGEMV from Accelerate */
     accelerate_sgemv = (fortran_sgemv_t*) dlsym(veclib, "sgemv_");
     if (!accelerate_sgemv) {
         unloadlib();
-        sprintf(errormsg,"Failed to resolve symbol 'sgemv_'.");
-        Py_FatalError(errormsg);
+        Py_FatalError("Failed to resolve symbol 'sgemv_'.");
     }
     /* resolve cblas_sgemv from Accelerate */
     accelerate_cblas_sgemv = (cblas_sgemv_t*) dlsym(veclib, "cblas_sgemv");
     if (!accelerate_cblas_sgemv) {
         unloadlib();
-        sprintf(errormsg,"Failed to resolve symbol 'cblas_sgemv'.");
-        Py_FatalError(errormsg);
+        Py_FatalError("Failed to resolve symbol 'cblas_sgemv'.");
     }
     /* resolve cblas_sgemm from Accelerate */
     accelerate_cblas_sgemm = (cblas_sgemm_t*) dlsym(veclib, "cblas_sgemm");
     if (!accelerate_cblas_sgemm) {
         unloadlib();
-        sprintf(errormsg,"Failed to resolve symbol 'cblas_sgemm'.");
-        Py_FatalError(errormsg);
+        Py_FatalError("Failed to resolve symbol 'cblas_sgemm'.");
     }
 }
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3964,14 +3964,14 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_FillWithScalarFunc*)NULL,
 #if @sort@
     {
-        (PyArray_SortFunc *)quicksort_@suff@,
-        (PyArray_SortFunc *)heapsort_@suff@,
-        (PyArray_SortFunc *)mergesort_@suff@
+        quicksort_@suff@,
+        heapsort_@suff@,
+        mergesort_@suff@
     },
     {
-        (PyArray_ArgSortFunc *)aquicksort_@suff@,
-        (PyArray_ArgSortFunc *)aheapsort_@suff@,
-        (PyArray_ArgSortFunc *)amergesort_@suff@
+        aquicksort_@suff@,
+        aheapsort_@suff@,
+        amergesort_@suff@
     },
 #else
     {
@@ -4106,14 +4106,14 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_FillWithScalarFunc*)@from@_fillwithscalar,
 #if @sort@
     {
-        (PyArray_SortFunc *)quicksort_@suff@,
-        (PyArray_SortFunc *)heapsort_@suff@,
-        (PyArray_SortFunc *)mergesort_@suff@
+        quicksort_@suff@,
+        heapsort_@suff@,
+        mergesort_@suff@
     },
     {
-        (PyArray_ArgSortFunc *)aquicksort_@suff@,
-        (PyArray_ArgSortFunc *)aheapsort_@suff@,
-        (PyArray_ArgSortFunc *)amergesort_@suff@
+        aquicksort_@suff@,
+        aheapsort_@suff@,
+        amergesort_@suff@
     },
 #else
     {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -772,8 +772,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
                 if (indices[i].value != PyArray_DIM(self, used_ndim)) {
                     static PyObject *warning;
 
-                    char *err_msg[174];
-                    sprintf(err_msg,
+                    char err_msg[174];
+                    PyOS_snprintf(err_msg, sizeof(err_msg),
                         "boolean index did not match indexed array along "
                         "dimension %d; dimension is %" NPY_INTP_FMT
                         " but corresponding boolean dimension is %" NPY_INTP_FMT,

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2227,6 +2227,14 @@ npyiter_seq_ass_slice(NewNpyArrayIterObject *self, Py_ssize_t ilow,
     return 0;
 }
 
+/* Py3 changes PySlice_GetIndices' first argument's type to PyObject* */
+#ifdef NPY_PY3K
+#  define slice_getindices PySlice_GetIndices
+#else
+#  define slice_getindices(op, nop, start, end, step) \
+        PySlice_GetIndices((PySliceObject *)op, nop, start, end, step)
+#endif
+
 static PyObject *
 npyiter_subscript(NewNpyArrayIterObject *self, PyObject *op)
 {
@@ -2253,8 +2261,7 @@ npyiter_subscript(NewNpyArrayIterObject *self, PyObject *op)
     }
     else if (PySlice_Check(op)) {
         Py_ssize_t istart = 0, iend = 0, istep = 0;
-        if (PySlice_GetIndices((PySliceObject *)op,
-                            NpyIter_GetNOp(self->iter),
+        if (slice_getindices(op, NpyIter_GetNOp(self->iter),
                             &istart, &iend, &istep) < 0) {
             return NULL;
         }
@@ -2303,8 +2310,7 @@ npyiter_ass_subscript(NewNpyArrayIterObject *self, PyObject *op,
     }
     else if (PySlice_Check(op)) {
         Py_ssize_t istart = 0, iend = 0, istep = 0;
-        if (PySlice_GetIndices((PySliceObject *)op,
-                            NpyIter_GetNOp(self->iter),
+        if (slice_getindices(op, NpyIter_GetNOp(self->iter),
                             &istart, &iend, &istep) < 0) {
             return -1;
         }

--- a/numpy/core/src/npysort/heapsort.c.src
+++ b/numpy/core/src/npysort/heapsort.c.src
@@ -61,13 +61,13 @@
  */
 
 int
-heapsort_@suff@(@type@ *start, npy_intp n, void *NOT_USED)
+heapsort_@suff@(void *start, npy_intp n, void *NOT_USED)
 {
     @type@ tmp, *a;
     npy_intp i,j,l;
 
     /* The array needs to be offset by one for heapsort indexing */
-    a = start - 1;
+    a = (@type@ *)start - 1;
 
     for (l = n>>1; l > 0; --l) {
         tmp = a[l];
@@ -112,8 +112,9 @@ heapsort_@suff@(@type@ *start, npy_intp n, void *NOT_USED)
 
 
 int
-aheapsort_@suff@(@type@ *v, npy_intp *tosort, npy_intp n, void *NOT_USED)
+aheapsort_@suff@(void *vv, npy_intp *tosort, npy_intp n, void *NOT_USED)
 {
+    @type@ *v = vv;
     npy_intp *a, i,j,l, tmp;
     /* The arrays need to be offset by one for heapsort indexing */
     a = tosort - 1;
@@ -177,11 +178,12 @@ aheapsort_@suff@(@type@ *v, npy_intp *tosort, npy_intp n, void *NOT_USED)
  */
 
 int
-heapsort_@suff@(@type@ *start, npy_intp n, PyArrayObject *arr)
+heapsort_@suff@(void *start, npy_intp n, void *varr)
 {
+    PyArrayObject *arr = varr;
     size_t len = PyArray_ITEMSIZE(arr)/sizeof(@type@);
     @type@ *tmp = malloc(PyArray_ITEMSIZE(arr));
-    @type@ *a = start - len;
+    @type@ *a = (@type@ *)start - len;
     npy_intp i, j, l;
 
     if (tmp == NULL) {
@@ -230,8 +232,10 @@ heapsort_@suff@(@type@ *start, npy_intp n, PyArrayObject *arr)
 
 
 int
-aheapsort_@suff@(@type@ *v, npy_intp *tosort, npy_intp n, PyArrayObject *arr)
+aheapsort_@suff@(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 {
+    @type@ *v = vv;
+    PyArrayObject *arr = varr;
     size_t len = PyArray_ITEMSIZE(arr)/sizeof(@type@);
     npy_intp *a, i,j,l, tmp;
 
@@ -288,12 +292,13 @@ aheapsort_@suff@(@type@ *v, npy_intp *tosort, npy_intp n, PyArrayObject *arr)
 
 
 int
-npy_heapsort(char *start, npy_intp num, PyArrayObject *arr)
+npy_heapsort(void *start, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
     char *tmp = malloc(elsize);
-    char *a = start - elsize;
+    char *a = (char *)start - elsize;
     npy_intp i, j, l;
 
     if (tmp == NULL) {
@@ -344,8 +349,10 @@ npy_heapsort(char *start, npy_intp num, PyArrayObject *arr)
 
 
 int
-npy_aheapsort(char *v, npy_intp *tosort, npy_intp n, PyArrayObject *arr)
+npy_aheapsort(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 {
+    char *v = vv;
+    PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
     npy_intp *a, i, j, l, tmp;

--- a/numpy/core/src/npysort/mergesort.c.src
+++ b/numpy/core/src/npysort/mergesort.c.src
@@ -104,7 +104,7 @@ mergesort0_@suff@(@type@ *pl, @type@ *pr, @type@ *pw)
 
 
 int
-mergesort_@suff@(@type@ *start, npy_intp num, void *NOT_USED)
+mergesort_@suff@(void *start, npy_intp num, void *NOT_USED)
 {
     @type@ *pl, *pr, *pw;
 
@@ -167,7 +167,7 @@ amergesort0_@suff@(npy_intp *pl, npy_intp *pr, @type@ *v, npy_intp *pw)
 
 
 int
-amergesort_@suff@(@type@ *v, npy_intp *tosort, npy_intp num, void *NOT_USED)
+amergesort_@suff@(void *v, npy_intp *tosort, npy_intp num, void *NOT_USED)
 {
     npy_intp *pl, *pr, *pw;
 
@@ -246,8 +246,9 @@ mergesort0_@suff@(@type@ *pl, @type@ *pr, @type@ *pw, @type@ *vp, size_t len)
 
 
 int
-mergesort_@suff@(@type@ *start, npy_intp num, PyArrayObject *arr)
+mergesort_@suff@(void *start, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     size_t elsize = PyArray_ITEMSIZE(arr);
     size_t len = elsize / sizeof(@type@);
     @type@ *pl, *pr, *pw, *vp;
@@ -321,8 +322,9 @@ amergesort0_@suff@(npy_intp *pl, npy_intp *pr, @type@ *v, npy_intp *pw, size_t l
 
 
 int
-amergesort_@suff@(@type@ *v, npy_intp *tosort, npy_intp num, PyArrayObject *arr)
+amergesort_@suff@(void *v, npy_intp *tosort, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     size_t elsize = PyArray_ITEMSIZE(arr);
     size_t len = elsize / sizeof(@type@);
     npy_intp *pl, *pr, *pw;
@@ -396,8 +398,9 @@ npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
 
 
 int
-npy_mergesort(char *start, npy_intp num, PyArrayObject *arr)
+npy_mergesort(void *start, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
     char *pl = start;
@@ -465,8 +468,9 @@ npy_amergesort0(npy_intp *pl, npy_intp *pr, char *v, npy_intp *pw,
 
 
 int
-npy_amergesort(char *v, npy_intp *tosort, npy_intp num, PyArrayObject *arr)
+npy_amergesort(void *v, npy_intp *tosort, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
     npy_intp *pl, *pr, *pw;

--- a/numpy/core/src/npysort/quicksort.c.src
+++ b/numpy/core/src/npysort/quicksort.c.src
@@ -61,11 +61,11 @@
  */
 
 int
-quicksort_@suff@(@type@ *start, npy_intp num, void *NOT_USED)
+quicksort_@suff@(void *start, npy_intp num, void *NOT_USED)
 {
     @type@ vp;
     @type@ *pl = start;
-    @type@ *pr = start + num - 1;
+    @type@ *pr = pl + num - 1;
     @type@ *stack[PYA_QS_STACK];
     @type@ **sptr = stack;
     @type@ *pm, *pi, *pj, *pk;
@@ -126,8 +126,9 @@ quicksort_@suff@(@type@ *start, npy_intp num, void *NOT_USED)
 
 
 int
-aquicksort_@suff@(@type@ *v, npy_intp* tosort, npy_intp num, void *NOT_USED)
+aquicksort_@suff@(void *vv, npy_intp* tosort, npy_intp num, void *NOT_USED)
 {
+    @type@ *v = vv;
     @type@ vp;
     npy_intp *pl = tosort;
     npy_intp *pr = tosort + num - 1;
@@ -208,12 +209,13 @@ aquicksort_@suff@(@type@ *v, npy_intp* tosort, npy_intp num, void *NOT_USED)
  */
 
 int
-quicksort_@suff@(@type@ *start, npy_intp num, PyArrayObject *arr)
+quicksort_@suff@(void *start, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     const size_t len = PyArray_ITEMSIZE(arr)/sizeof(@type@);
     @type@ *vp = malloc(PyArray_ITEMSIZE(arr));
     @type@ *pl = start;
-    @type@ *pr = start + (num - 1)*len;
+    @type@ *pr = pl + (num - 1)*len;
     @type@ *stack[PYA_QS_STACK], **sptr = stack, *pm, *pi, *pj, *pk;
 
     if (vp == NULL) {
@@ -279,8 +281,10 @@ quicksort_@suff@(@type@ *start, npy_intp num, PyArrayObject *arr)
 
 
 int
-aquicksort_@suff@(@type@ *v, npy_intp* tosort, npy_intp num, PyArrayObject *arr)
+aquicksort_@suff@(void *vv, npy_intp* tosort, npy_intp num, void *varr)
 {
+    @type@ *v = vv;
+    PyArrayObject *arr = varr;
     size_t len = PyArray_ITEMSIZE(arr)/sizeof(@type@);
     @type@ *vp;
     npy_intp *pl = tosort;
@@ -355,13 +359,14 @@ aquicksort_@suff@(@type@ *v, npy_intp* tosort, npy_intp num, PyArrayObject *arr)
 
 
 int
-npy_quicksort(char *start, npy_intp num, PyArrayObject *arr)
+npy_quicksort(void *start, npy_intp num, void *varr)
 {
+    PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
     char *vp = malloc(elsize);
     char *pl = start;
-    char *pr = start + (num - 1)*elsize;
+    char *pr = pl + (num - 1)*elsize;
     char *stack[PYA_QS_STACK];
     char **sptr = stack;
     char *pm, *pi, *pj, *pk;
@@ -439,8 +444,10 @@ npy_quicksort(char *start, npy_intp num, PyArrayObject *arr)
 
 
 int
-npy_aquicksort(char *v, npy_intp* tosort, npy_intp num, PyArrayObject *arr)
+npy_aquicksort(void *vv, npy_intp* tosort, npy_intp num, void *varr)
 {
+    char *v = vv;
+    PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
     char *vp;

--- a/numpy/core/src/private/npy_sort.h
+++ b/numpy/core/src/private/npy_sort.h
@@ -10,187 +10,187 @@
 #define NPY_ECOMP 2
 
 
-int quicksort_bool(npy_bool *vec, npy_intp cnt, void *null);
-int heapsort_bool(npy_bool *vec, npy_intp cnt, void *null);
-int mergesort_bool(npy_bool *vec, npy_intp cnt, void *null);
-int aquicksort_bool(npy_bool *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_bool(npy_bool *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_bool(npy_bool *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_bool(void *vec, npy_intp cnt, void *null);
+int heapsort_bool(void *vec, npy_intp cnt, void *null);
+int mergesort_bool(void *vec, npy_intp cnt, void *null);
+int aquicksort_bool(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_bool(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_bool(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_byte(npy_byte *vec, npy_intp cnt, void *null);
-int heapsort_byte(npy_byte *vec, npy_intp cnt, void *null);
-int mergesort_byte(npy_byte *vec, npy_intp cnt, void *null);
-int aquicksort_byte(npy_byte *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_byte(npy_byte *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_byte(npy_byte *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_byte(void *vec, npy_intp cnt, void *null);
+int heapsort_byte(void *vec, npy_intp cnt, void *null);
+int mergesort_byte(void *vec, npy_intp cnt, void *null);
+int aquicksort_byte(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_byte(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_byte(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_ubyte(npy_ubyte *vec, npy_intp cnt, void *null);
-int heapsort_ubyte(npy_ubyte *vec, npy_intp cnt, void *null);
-int mergesort_ubyte(npy_ubyte *vec, npy_intp cnt, void *null);
-int aquicksort_ubyte(npy_ubyte *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_ubyte(npy_ubyte *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_ubyte(npy_ubyte *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_ubyte(void *vec, npy_intp cnt, void *null);
+int heapsort_ubyte(void *vec, npy_intp cnt, void *null);
+int mergesort_ubyte(void *vec, npy_intp cnt, void *null);
+int aquicksort_ubyte(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_ubyte(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_ubyte(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_short(npy_short *vec, npy_intp cnt, void *null);
-int heapsort_short(npy_short *vec, npy_intp cnt, void *null);
-int mergesort_short(npy_short *vec, npy_intp cnt, void *null);
-int aquicksort_short(npy_short *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_short(npy_short *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_short(npy_short *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_short(void *vec, npy_intp cnt, void *null);
+int heapsort_short(void *vec, npy_intp cnt, void *null);
+int mergesort_short(void *vec, npy_intp cnt, void *null);
+int aquicksort_short(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_short(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_short(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_ushort(npy_ushort *vec, npy_intp cnt, void *null);
-int heapsort_ushort(npy_ushort *vec, npy_intp cnt, void *null);
-int mergesort_ushort(npy_ushort *vec, npy_intp cnt, void *null);
-int aquicksort_ushort(npy_ushort *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_ushort(npy_ushort *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_ushort(npy_ushort *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_ushort(void *vec, npy_intp cnt, void *null);
+int heapsort_ushort(void *vec, npy_intp cnt, void *null);
+int mergesort_ushort(void *vec, npy_intp cnt, void *null);
+int aquicksort_ushort(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_ushort(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_ushort(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_int(npy_int *vec, npy_intp cnt, void *null);
-int heapsort_int(npy_int *vec, npy_intp cnt, void *null);
-int mergesort_int(npy_int *vec, npy_intp cnt, void *null);
-int aquicksort_int(npy_int *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_int(npy_int *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_int(npy_int *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_int(void *vec, npy_intp cnt, void *null);
+int heapsort_int(void *vec, npy_intp cnt, void *null);
+int mergesort_int(void *vec, npy_intp cnt, void *null);
+int aquicksort_int(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_int(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_int(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_uint(npy_uint *vec, npy_intp cnt, void *null);
-int heapsort_uint(npy_uint *vec, npy_intp cnt, void *null);
-int mergesort_uint(npy_uint *vec, npy_intp cnt, void *null);
-int aquicksort_uint(npy_uint *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_uint(npy_uint *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_uint(npy_uint *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_uint(void *vec, npy_intp cnt, void *null);
+int heapsort_uint(void *vec, npy_intp cnt, void *null);
+int mergesort_uint(void *vec, npy_intp cnt, void *null);
+int aquicksort_uint(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_uint(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_uint(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_long(npy_long *vec, npy_intp cnt, void *null);
-int heapsort_long(npy_long *vec, npy_intp cnt, void *null);
-int mergesort_long(npy_long *vec, npy_intp cnt, void *null);
-int aquicksort_long(npy_long *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_long(npy_long *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_long(npy_long *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_long(void *vec, npy_intp cnt, void *null);
+int heapsort_long(void *vec, npy_intp cnt, void *null);
+int mergesort_long(void *vec, npy_intp cnt, void *null);
+int aquicksort_long(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_long(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_long(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_ulong(npy_ulong *vec, npy_intp cnt, void *null);
-int heapsort_ulong(npy_ulong *vec, npy_intp cnt, void *null);
-int mergesort_ulong(npy_ulong *vec, npy_intp cnt, void *null);
-int aquicksort_ulong(npy_ulong *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_ulong(npy_ulong *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_ulong(npy_ulong *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_ulong(void *vec, npy_intp cnt, void *null);
+int heapsort_ulong(void *vec, npy_intp cnt, void *null);
+int mergesort_ulong(void *vec, npy_intp cnt, void *null);
+int aquicksort_ulong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_ulong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_ulong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_longlong(npy_longlong *vec, npy_intp cnt, void *null);
-int heapsort_longlong(npy_longlong *vec, npy_intp cnt, void *null);
-int mergesort_longlong(npy_longlong *vec, npy_intp cnt, void *null);
-int aquicksort_longlong(npy_longlong *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_longlong(npy_longlong *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_longlong(npy_longlong *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_longlong(void *vec, npy_intp cnt, void *null);
+int heapsort_longlong(void *vec, npy_intp cnt, void *null);
+int mergesort_longlong(void *vec, npy_intp cnt, void *null);
+int aquicksort_longlong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_longlong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_longlong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_ulonglong(npy_ulonglong *vec, npy_intp cnt, void *null);
-int heapsort_ulonglong(npy_ulonglong *vec, npy_intp cnt, void *null);
-int mergesort_ulonglong(npy_ulonglong *vec, npy_intp cnt, void *null);
-int aquicksort_ulonglong(npy_ulonglong *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_ulonglong(npy_ulonglong *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_ulonglong(npy_ulonglong *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_ulonglong(void *vec, npy_intp cnt, void *null);
+int heapsort_ulonglong(void *vec, npy_intp cnt, void *null);
+int mergesort_ulonglong(void *vec, npy_intp cnt, void *null);
+int aquicksort_ulonglong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_ulonglong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_ulonglong(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_half(npy_ushort *vec, npy_intp cnt, void *null);
-int heapsort_half(npy_ushort *vec, npy_intp cnt, void *null);
-int mergesort_half(npy_ushort *vec, npy_intp cnt, void *null);
-int aquicksort_half(npy_ushort *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_half(npy_ushort *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_half(npy_ushort *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_half(void *vec, npy_intp cnt, void *null);
+int heapsort_half(void *vec, npy_intp cnt, void *null);
+int mergesort_half(void *vec, npy_intp cnt, void *null);
+int aquicksort_half(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_half(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_half(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_float(npy_float *vec, npy_intp cnt, void *null);
-int heapsort_float(npy_float *vec, npy_intp cnt, void *null);
-int mergesort_float(npy_float *vec, npy_intp cnt, void *null);
-int aquicksort_float(npy_float *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_float(npy_float *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_float(npy_float *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_float(void *vec, npy_intp cnt, void *null);
+int heapsort_float(void *vec, npy_intp cnt, void *null);
+int mergesort_float(void *vec, npy_intp cnt, void *null);
+int aquicksort_float(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_float(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_float(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_double(npy_double *vec, npy_intp cnt, void *null);
-int heapsort_double(npy_double *vec, npy_intp cnt, void *null);
-int mergesort_double(npy_double *vec, npy_intp cnt, void *null);
-int aquicksort_double(npy_double *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_double(npy_double *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_double(npy_double *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_double(void *vec, npy_intp cnt, void *null);
+int heapsort_double(void *vec, npy_intp cnt, void *null);
+int mergesort_double(void *vec, npy_intp cnt, void *null);
+int aquicksort_double(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_double(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_double(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_longdouble(npy_longdouble *vec, npy_intp cnt, void *null);
-int heapsort_longdouble(npy_longdouble *vec, npy_intp cnt, void *null);
-int mergesort_longdouble(npy_longdouble *vec, npy_intp cnt, void *null);
-int aquicksort_longdouble(npy_longdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_longdouble(npy_longdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_longdouble(npy_longdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_longdouble(void *vec, npy_intp cnt, void *null);
+int heapsort_longdouble(void *vec, npy_intp cnt, void *null);
+int mergesort_longdouble(void *vec, npy_intp cnt, void *null);
+int aquicksort_longdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_longdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_longdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_cfloat(npy_cfloat *vec, npy_intp cnt, void *null);
-int heapsort_cfloat(npy_cfloat *vec, npy_intp cnt, void *null);
-int mergesort_cfloat(npy_cfloat *vec, npy_intp cnt, void *null);
-int aquicksort_cfloat(npy_cfloat *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_cfloat(npy_cfloat *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_cfloat(npy_cfloat *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_cfloat(void *vec, npy_intp cnt, void *null);
+int heapsort_cfloat(void *vec, npy_intp cnt, void *null);
+int mergesort_cfloat(void *vec, npy_intp cnt, void *null);
+int aquicksort_cfloat(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_cfloat(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_cfloat(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_cdouble(npy_cdouble *vec, npy_intp cnt, void *null);
-int heapsort_cdouble(npy_cdouble *vec, npy_intp cnt, void *null);
-int mergesort_cdouble(npy_cdouble *vec, npy_intp cnt, void *null);
-int aquicksort_cdouble(npy_cdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_cdouble(npy_cdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_cdouble(npy_cdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_cdouble(void *vec, npy_intp cnt, void *null);
+int heapsort_cdouble(void *vec, npy_intp cnt, void *null);
+int mergesort_cdouble(void *vec, npy_intp cnt, void *null);
+int aquicksort_cdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_cdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_cdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_clongdouble(npy_clongdouble *vec, npy_intp cnt, void *null);
-int heapsort_clongdouble(npy_clongdouble *vec, npy_intp cnt, void *null);
-int mergesort_clongdouble(npy_clongdouble *vec, npy_intp cnt, void *null);
-int aquicksort_clongdouble(npy_clongdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_clongdouble(npy_clongdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_clongdouble(npy_clongdouble *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_clongdouble(void *vec, npy_intp cnt, void *null);
+int heapsort_clongdouble(void *vec, npy_intp cnt, void *null);
+int mergesort_clongdouble(void *vec, npy_intp cnt, void *null);
+int aquicksort_clongdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_clongdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_clongdouble(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_string(npy_char *vec, npy_intp cnt, PyArrayObject *arr);
-int heapsort_string(npy_char *vec, npy_intp cnt, PyArrayObject *arr);
-int mergesort_string(npy_char *vec, npy_intp cnt, PyArrayObject *arr);
-int aquicksort_string(npy_char *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
-int aheapsort_string(npy_char *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
-int amergesort_string(npy_char *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
+int quicksort_string(void *vec, npy_intp cnt, void *arr);
+int heapsort_string(void *vec, npy_intp cnt, void *arr);
+int mergesort_string(void *vec, npy_intp cnt, void *arr);
+int aquicksort_string(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+int aheapsort_string(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+int amergesort_string(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 
 
-int quicksort_unicode(npy_ucs4 *vec, npy_intp cnt, PyArrayObject *arr);
-int heapsort_unicode(npy_ucs4 *vec, npy_intp cnt, PyArrayObject *arr);
-int mergesort_unicode(npy_ucs4 *vec, npy_intp cnt, PyArrayObject *arr);
-int aquicksort_unicode(npy_ucs4 *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
-int aheapsort_unicode(npy_ucs4 *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
-int amergesort_unicode(npy_ucs4 *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
+int quicksort_unicode(void *vec, npy_intp cnt, void *arr);
+int heapsort_unicode(void *vec, npy_intp cnt, void *arr);
+int mergesort_unicode(void *vec, npy_intp cnt, void *arr);
+int aquicksort_unicode(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+int aheapsort_unicode(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+int amergesort_unicode(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 
 
-int quicksort_datetime(npy_datetime *vec, npy_intp cnt, void *null);
-int heapsort_datetime(npy_datetime *vec, npy_intp cnt, void *null);
-int mergesort_datetime(npy_datetime *vec, npy_intp cnt, void *null);
-int aquicksort_datetime(npy_datetime *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_datetime(npy_datetime *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_datetime(npy_datetime *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_datetime(void *vec, npy_intp cnt, void *null);
+int heapsort_datetime(void *vec, npy_intp cnt, void *null);
+int mergesort_datetime(void *vec, npy_intp cnt, void *null);
+int aquicksort_datetime(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_datetime(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_datetime(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int quicksort_timedelta(npy_timedelta *vec, npy_intp cnt, void *null);
-int heapsort_timedelta(npy_timedelta *vec, npy_intp cnt, void *null);
-int mergesort_timedelta(npy_timedelta *vec, npy_intp cnt, void *null);
-int aquicksort_timedelta(npy_timedelta *vec, npy_intp *ind, npy_intp cnt, void *null);
-int aheapsort_timedelta(npy_timedelta *vec, npy_intp *ind, npy_intp cnt, void *null);
-int amergesort_timedelta(npy_timedelta *vec, npy_intp *ind, npy_intp cnt, void *null);
+int quicksort_timedelta(void *vec, npy_intp cnt, void *null);
+int heapsort_timedelta(void *vec, npy_intp cnt, void *null);
+int mergesort_timedelta(void *vec, npy_intp cnt, void *null);
+int aquicksort_timedelta(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int aheapsort_timedelta(void *vec, npy_intp *ind, npy_intp cnt, void *null);
+int amergesort_timedelta(void *vec, npy_intp *ind, npy_intp cnt, void *null);
 
 
-int npy_quicksort(char *vec, npy_intp cnt, PyArrayObject *arr);
-int npy_heapsort(char *vec, npy_intp cnt, PyArrayObject *arr);
-int npy_mergesort(char *vec, npy_intp cnt, PyArrayObject *arr);
-int npy_aquicksort(char *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
-int npy_aheapsort(char *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
-int npy_amergesort(char *vec, npy_intp *ind, npy_intp cnt, PyArrayObject *arr);
+int npy_quicksort(void *vec, npy_intp cnt, void *arr);
+int npy_heapsort(void *vec, npy_intp cnt, void *arr);
+int npy_mergesort(void *vec, npy_intp cnt, void *arr);
+int npy_aquicksort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+int npy_aheapsort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+int npy_amergesort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 
 #endif


### PR DESCRIPTION
Does anyone ever look at compiler warnings? One of them was warning about a bug where code was passing a `char**` instead of a `char*` to `sprintf`.

Anyway, these patches fix the bug, as well as replacing `sprintf` by `PyOS_snprintf` and getting rid of dozens of warnings and casts.
