### PR TITLE
ENH: dtype objects with non-empty metadata display the metadata in their repr

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3289,6 +3289,12 @@ arraydescr_struct_repr(PyArray_Descr *dtype)
         PyUString_ConcatAndDel(&s, PyUString_FromString(", align=True"));
     }
 
+    /* If the dtype has non-empty metadata, add the dtype repr */
+    if (dtype->metadata && PyDict_Size(dtype->metadata)) {
+        PyUString_ConcatAndDel(&s, PyUString_FromString(", metadata="));
+        PyUString_ConcatAndDel(&s, PyObject_Repr(dtype->metadata));
+    }
+
     PyUString_ConcatAndDel(&s, PyUString_FromString(")"));
     return s;
 }
@@ -3453,6 +3459,11 @@ arraydescr_repr(PyArray_Descr *dtype)
         ret = PyUString_FromString("dtype(");
         PyUString_ConcatAndDel(&ret,
                             arraydescr_construction_repr(dtype, 1, 0));
+        /* If the dtype has non-empty metadata, add the dtype repr */
+        if (dtype->metadata && PyDict_Size(dtype->metadata)) {
+            PyUString_ConcatAndDel(&ret, PyUString_FromString(", metadata="));
+            PyUString_ConcatAndDel(&ret, PyObject_Repr(dtype->metadata));
+        }
         PyUString_ConcatAndDel(&ret, PyUString_FromString(")"));
         return ret;
     }


### PR DESCRIPTION
Before:

```
>>> dt = np.dtype('int32', metadata={'a': 1})
>>> dt
dtype('int32')
>>> dt == np.dtype('int32')
True
>>> dt is np.dtype('int32')
False
```

The last two examples demonstrate that although the new dtype object
reprs identically to dtype('int32') it is suprisingly not the same.
Displaying its metadata makes this clear, and is supported by the
general recommendation of reprs that can recreate the object they
repr.

After:

```
>>> dt = np.dtype('int32', metadata={'a': 1})
>>> dt
dtype('int32', metadata={'a': 1})
```

I couldn't find any prior discussion about this, so I guess it just hasn't come up.  It doesn't break any existing tests, and makes the repr of dtypes with metadata more accurate, so I don't see the harm.  I can add a new test if desired.
