### PR TITLE
MAINT: document change to bytestring index behavior

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -94,6 +94,11 @@ provided in the 'out' keyword argument, and it would be used as the first
 output for ufuncs with multiple outputs, is deprecated, and will result in a
 `DeprecationWarning` now and an error in the future.
 
+byte-array indices now raises an IndexError
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Indexing an ndarray using a byte-string in Python 3 now raises an IndexError
+instead of a ValueError.
+
 New Features
 ============
 


### PR DESCRIPTION
@charris I guess there was one change in #5636 which maybe needs documenting:

Indexing with a byte-string in python 3 now raises IndexError, not ValueError.

Indexing with a bytestring has never done anything useful so I can't imagine anyone caring, but here's a release note for it if desired. 
