### PR TITLE
BUG: Large concatenates with axis=None causing segfault.

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -479,7 +479,7 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
     PyTypeObject *subtype = &PyArray_Type;
     double priority = NPY_PRIORITY;
     int iarrays;
-    npy_intp stride, sizes[NPY_MAXDIMS];
+    npy_intp stride;
     npy_intp shape = 0;
     PyArray_Descr *dtype = NULL;
     PyArrayObject *ret = NULL;
@@ -496,7 +496,7 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
      * array's shape.
      */
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
-        shape += sizes[iarrays] = PyArray_SIZE(arrays[iarrays]);
+        shape += PyArray_SIZE(arrays[iarrays]);
         /* Check for overflow */
         if (shape < 0) {
             PyErr_SetString(PyExc_ValueError,
@@ -551,7 +551,7 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
 
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         /* Adjust the window dimensions for this array */
-        sliding_view->dimensions[0] = sizes[iarrays];
+        sliding_view->dimensions[0] = PyArray_SIZE(arrays[iarrays]);
 
         /* Copy the data for this array */
         if (PyArray_CopyAsFlat((PyArrayObject *)sliding_view, arrays[iarrays],
@@ -562,7 +562,8 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         }
 
         /* Slide to the start of the next window */
-        sliding_view->data += sliding_view->strides[0] * sizes[iarrays];
+        sliding_view->data +=
+            sliding_view->strides[0] * PyArray_SIZE(arrays[iarrays]);
     }
 
     Py_DECREF(sliding_view);

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -172,6 +172,7 @@ class TestVstack(TestCase):
         desired = array([[1, 2], [1, 2]])
         assert_array_equal(res, desired)
 
+
 def test_concatenate_axis_None():
     a = np.arange(4, dtype=np.float64).reshape((2, 2))
     b = list(range(3))
@@ -186,6 +187,18 @@ def test_concatenate_axis_None():
     d = array(['0.0', '1.0', '2.0', '3.0',
                '0', '1', '2', 'x'])
     assert_array_equal(r, d)
+
+
+def test_large_concatenate_axis_None():
+    # When no axis is given, concatenate uses flattened versions.
+    # This also had a bug with many arrays (see gh-5979).
+    x = np.arange(1, 100)
+    r = np.concatenate(x, None)
+    assert_array_equal(x, r)
+
+    # This should probably be deprecated:
+    r = np.concatenate(x, 100)  # axis is >= MAXDIMS
+    assert_array_equal(x, r)
 
 
 def test_concatenate():


### PR DESCRIPTION
This was due to sizes assuming a MAX_ARGS, just remove usage and
call PyArray_SIZE each time.

Closes gh-5979
