### PR TITLE
BUG: Fixed slicing of chararrays on Python 3.

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1849,12 +1849,14 @@ class chararray(ndarray):
 
     def __getitem__(self, obj):
         val = ndarray.__getitem__(self, obj)
-        if issubclass(val.dtype.type, character) and not _len(val) == 0:
+
+        if isinstance(val, character):
             temp = val.rstrip()
             if _len(temp) == 0:
                 val = ''
             else:
                 val = temp
+
         return val
 
     # IMPLEMENTATION NOTE: Most of the methods of this class are

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -329,7 +329,7 @@ class TestMethods(TestCase):
 
     def test_expandtabs(self):
         T = self.A.expandtabs()
-        assert_(T[2][0] == asbytes('123      345'))
+        assert_(T[2, 0] == asbytes('123      345 \0'))
 
     def test_join(self):
         if sys.version_info[0] >= 3:
@@ -628,6 +628,23 @@ class TestOperations(TestCase):
             else:
                 self.fail("chararray __rmod__ should fail with " \
                           "non-string objects")
+
+    def test_slice(self):
+        """Regression test for https://github.com/numpy/numpy/issues/5982"""
+
+        arr = np.array([['abc ', 'def '], ['geh ', 'ijk ']],
+                       dtype='S4').view(np.chararray)
+        sl1 = arr[:]
+        assert_array_equal(sl1, arr)
+        assert sl1.base is arr
+        assert sl1.base.base is arr.base
+
+        sl2 = arr[:, :]
+        assert_array_equal(sl2, arr)
+        assert sl2.base is arr
+        assert sl2.base.base is arr.base
+
+        assert arr[0, 0] == asbytes('abc')
 
 
 def test_empty_indexing():


### PR DESCRIPTION
When taking a slice of a chararray it was calling the rstrip() method
on the resulting slice, resulting in a new array rather than a view
of the original.  This was an unintended consequence of the `sq_slice`
member of the `tp_as_sequence` mapping being ignored in Python 3, so
that slice lookups go directly through `__getitem__`.

I realize the chararray type is deprecated now which is fine, but this bug
introduced a regression for the `astropy.io.fits` module on Python 3 (I'm not
sure why this only seems to have broken recently, but it did).  So it can't hurt
to fix this, and in the meantime I'm going to work on eliminating the dependency
on chararray in Astropy.
