### PR TITLE
MAINT: Rename npy_cache_pyfunc to npy_cache_import.

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -437,7 +437,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     PyObject *safe;
     static PyObject *checkfunc = NULL;
 
-    npy_cache_pyfunc("numpy.core._internal", "_view_is_safe", &checkfunc);
+    npy_cache_import("numpy.core._internal", "_view_is_safe", &checkfunc);
     if (checkfunc == NULL) {
         return -1;
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -781,7 +781,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
                         used_ndim, PyArray_DIM(self, used_ndim),
                         indices[i].value);
 
-                    npy_cache_pyfunc(
+                    npy_cache_import(
                         "numpy", "VisibleDeprecationWarning", &warning);
                     if (warning == NULL) {
                         goto failed_building_indices;
@@ -1434,7 +1434,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
             obj_is_string_or_stringlist(op)) {
         PyObject *obj;
         static PyObject *indexfunc = NULL;
-        npy_cache_pyfunc("numpy.core._internal", "_index_fields", &indexfunc);
+        npy_cache_import("numpy.core._internal", "_index_fields", &indexfunc);
         if (indexfunc == NULL) {
             return NULL;
         }
@@ -1795,7 +1795,7 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
                             "multi-field assignment is not supported");
         }
 
-        npy_cache_pyfunc("numpy.core._internal", "_index_fields", &indexfunc);
+        npy_cache_import("numpy.core._internal", "_index_fields", &indexfunc);
         if (indexfunc == NULL) {
             return -1;
         }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -362,7 +362,7 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
     PyObject *safe;
     static PyObject *checkfunc = NULL;
 
-    npy_cache_pyfunc("numpy.core._internal", "_getfield_is_safe", &checkfunc);
+    npy_cache_import("numpy.core._internal", "_getfield_is_safe", &checkfunc);
     if (checkfunc == NULL) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2403,7 +2403,7 @@ array_matmul(PyObject *NPY_UNUSED(m), PyObject *args, PyObject* kwds)
     char *subscripts;
     PyArrayObject *ops[2];
 
-    npy_cache_pyfunc("numpy.core.multiarray", "matmul", &matmul);
+    npy_cache_import("numpy.core.multiarray", "matmul", &matmul);
     if (matmul == NULL) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -397,7 +397,7 @@ array_matrix_multiply(PyArrayObject *m1, PyObject *m2)
 {
     static PyObject *matmul = NULL;
 
-    npy_cache_pyfunc("numpy.core.multiarray", "matmul", &matmul);
+    npy_cache_import("numpy.core.multiarray", "matmul", &matmul);
     if (matmul == NULL) {
         return NULL;
     }

--- a/numpy/core/src/private/npy_import.h
+++ b/numpy/core/src/private/npy_import.h
@@ -13,17 +13,17 @@
  * exit,
  *
  * @param module Absolute module name.
- * @param function Function name.
+ * @param attr module attribute to cache.
  * @param cache Storage location for imported function.
  */
 NPY_INLINE static void
-npy_cache_pyfunc(const char *module, const char *function, PyObject **cache)
+npy_cache_import(const char *module, const char *attr, PyObject **cache)
 {
     if (*cache == NULL) {
         PyObject *mod = PyImport_ImportModule(module);
 
         if (mod != NULL) {
-            *cache = PyObject_GetAttrString(mod, function);
+            *cache = PyObject_GetAttrString(mod, attr);
             Py_DECREF(mod);
         }
     }


### PR DESCRIPTION
The function will be new in NumPy 1.10, so get this done before
branching that version. The old name was a bit too specific for a
function that could also be used to cache other attributes than just
functions.
