### PR TITLE
1.10 deprecated removal

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -25,9 +25,12 @@ Dropped Support:
 * The polytemplate.py file has been removed.
 * The _dotblas module is no longer available.
 * The testcalcs.py file has been removed.
-* npy_PyFile_Dup`` and npy_PyFile_DupClose have been removed from
+* npy_PyFile_Dup and npy_PyFile_DupClose have been removed from
   npy_3kcompat.h.
 * splitcmdline has been removed from numpy/distutils/exec_command.py.
+* try_run and get_output have been removed from
+  numpy/distutils/command/config.py
+*
 
 Future Changes:
 

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -30,7 +30,7 @@ Dropped Support:
 * splitcmdline has been removed from numpy/distutils/exec_command.py.
 * try_run and get_output have been removed from
   numpy/distutils/command/config.py
-*
+* The a._format attribute is no longer supported for array printing.
 
 Future Changes:
 

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -25,6 +25,7 @@ Dropped Support:
 * The polytemplate.py file has been removed.
 * The _dotblas module is no longer available.
 * The testcalcs.py file has been removed.
+* npy_PyFile_Dup and npy_PyFile_DupClose have been removed from npy_3kcompat.h.
 
 Future Changes:
 

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -25,7 +25,9 @@ Dropped Support:
 * The polytemplate.py file has been removed.
 * The _dotblas module is no longer available.
 * The testcalcs.py file has been removed.
-* npy_PyFile_Dup and npy_PyFile_DupClose have been removed from npy_3kcompat.h.
+* npy_PyFile_Dup`` and npy_PyFile_DupClose have been removed from
+  npy_3kcompat.h.
+* splitcmdline has been removed from numpy/distutils/exec_command.py.
 
 Future Changes:
 

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -22,9 +22,10 @@ Highlights
 
 Dropped Support:
 
-* The polytemplate.py file has been removed.
-* The _dotblas module is no longer available.
+* The _dotblas module has been removed. CBLAS Support is now in
+  Multiarray.
 * The testcalcs.py file has been removed.
+* The polytemplate.py file has been removed.
 * npy_PyFile_Dup and npy_PyFile_DupClose have been removed from
   npy_3kcompat.h.
 * splitcmdline has been removed from numpy/distutils/exec_command.py.

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -52,6 +52,11 @@ relaxed stride checking
 ~~~~~~~~~~~~~~~~~~~~~~~
 NPY_RELAXED_STRIDE_CHECKING is now true by default.
 
+Concatenation of 1d arrays along any but ``axis=0`` raises ``IndexError``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using axis != 0 has raised a DeprecationWarning since NumPy 1.7, it now
+raises an error.
+
 *np.ravel*, *np.diagonal* and *np.diag* now preserve subtypes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 There was inconsistent behavior between *x.ravel()* and *np.ravel(x)*, as
@@ -75,6 +80,9 @@ which now returns a view in all cases.
 
 The dtype structure (PyArray_Descr) has a new member at the end to cache
 its hash value.  This shouldn't affect any well-written applications.
+
+The change to the concatenation function DeprecationWarning also affects
+PyArray_ConcatenateArrays,
 
 recarray field return types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/_import_tools.py
+++ b/numpy/_import_tools.py
@@ -164,6 +164,7 @@ class PackageLoader(object):
              when True, don't load packages [default: False]
 
         """
+        # 2014-10-29, 1.10
         warnings.warn('pkgload and PackageLoader are obsolete '
                 'and will be removed in a future version of numpy',
                 DeprecationWarning)

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -291,6 +291,7 @@ def _array2string(a, max_line_width, precision, suppress_small, separator=' ',
         msg = "The `_format` attribute is deprecated in Numpy 2.0 and " \
               "will be removed in 2.1. Use the `formatter` kw instead."
         import warnings
+        # 2011-04-03, RemoveMe
         warnings.warn(msg, DeprecationWarning)
     except AttributeError:
         # find the right formatting function for the array
@@ -446,6 +447,7 @@ def array2string(a, max_line_width=None, precision=None,
                   "2.0 and will be removed in 2.1. Use the " \
                   "`formatter` kw instead."
             import warnings
+            # 2012-05-11, RemoveMe
             warnings.warn(msg, DeprecationWarning)
         except AttributeError:
             if isinstance(x, tuple):

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -286,39 +286,31 @@ def _array2string(a, max_line_width, precision, suppress_small, separator=' ',
             if key in fkeys:
                 formatdict[key] = formatter[key]
 
-    try:
-        format_function = a._format
-        msg = "The `_format` attribute is deprecated in Numpy 2.0 and " \
-              "will be removed in 2.1. Use the `formatter` kw instead."
-        import warnings
-        # 2011-04-03, RemoveMe
-        warnings.warn(msg, DeprecationWarning)
-    except AttributeError:
-        # find the right formatting function for the array
-        dtypeobj = a.dtype.type
-        if issubclass(dtypeobj, _nt.bool_):
-            format_function = formatdict['bool']
-        elif issubclass(dtypeobj, _nt.integer):
-            if issubclass(dtypeobj, _nt.timedelta64):
-                format_function = formatdict['timedelta']
-            else:
-                format_function = formatdict['int']
-        elif issubclass(dtypeobj, _nt.floating):
-            if issubclass(dtypeobj, _nt.longfloat):
-                format_function = formatdict['longfloat']
-            else:
-                format_function = formatdict['float']
-        elif issubclass(dtypeobj, _nt.complexfloating):
-            if issubclass(dtypeobj, _nt.clongfloat):
-                format_function = formatdict['longcomplexfloat']
-            else:
-                format_function = formatdict['complexfloat']
-        elif issubclass(dtypeobj, (_nt.unicode_, _nt.string_)):
-            format_function = formatdict['numpystr']
-        elif issubclass(dtypeobj, _nt.datetime64):
-            format_function = formatdict['datetime']
+    # find the right formatting function for the array
+    dtypeobj = a.dtype.type
+    if issubclass(dtypeobj, _nt.bool_):
+        format_function = formatdict['bool']
+    elif issubclass(dtypeobj, _nt.integer):
+        if issubclass(dtypeobj, _nt.timedelta64):
+            format_function = formatdict['timedelta']
         else:
-            format_function = formatdict['numpystr']
+            format_function = formatdict['int']
+    elif issubclass(dtypeobj, _nt.floating):
+        if issubclass(dtypeobj, _nt.longfloat):
+            format_function = formatdict['longfloat']
+        else:
+            format_function = formatdict['float']
+    elif issubclass(dtypeobj, _nt.complexfloating):
+        if issubclass(dtypeobj, _nt.clongfloat):
+            format_function = formatdict['longcomplexfloat']
+        else:
+            format_function = formatdict['complexfloat']
+    elif issubclass(dtypeobj, (_nt.unicode_, _nt.string_)):
+        format_function = formatdict['numpystr']
+    elif issubclass(dtypeobj, _nt.datetime64):
+        format_function = formatdict['datetime']
+    else:
+        format_function = formatdict['numpystr']
 
     # skip over "["
     next_line_prefix = " "
@@ -441,18 +433,9 @@ def array2string(a, max_line_width=None, precision=None,
 
     if a.shape == ():
         x = a.item()
-        try:
-            lst = a._format(x)
-            msg = "The `_format` attribute is deprecated in Numpy " \
-                  "2.0 and will be removed in 2.1. Use the " \
-                  "`formatter` kw instead."
-            import warnings
-            # 2012-05-11, RemoveMe
-            warnings.warn(msg, DeprecationWarning)
-        except AttributeError:
-            if isinstance(x, tuple):
-                x = _convert_arrays(x)
-            lst = style(x)
+        if isinstance(x, tuple):
+            x = _convert_arrays(x)
+        lst = style(x)
     elif reduce(product, a.shape) == 0:
         # treat as a null array if any of shape elements == 0
         lst = "[]"

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2624,6 +2624,7 @@ def rank(a):
     0
 
     """
+    # 2014-04-12, 1.9
     warnings.warn(
         "`rank` is deprecated; use the `ndim` attribute or function instead. "
         "To find the rank of a matrix see `numpy.linalg.matrix_rank`.",

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -272,35 +272,8 @@ npy_PyFile_Check(PyObject *file)
     return 1;
 }
 
-/*
- * DEPRECATED DO NOT USE
- * use npy_PyFile_DupClose2 instead
- * this function will mess ups python3 internal file object buffering
- * Close the dup-ed file handle, and seek the Python one to the current position
- */
-static NPY_INLINE int
-npy_PyFile_DupClose(PyObject *file, FILE* handle)
-{
-    PyObject *ret;
-    Py_ssize_t position;
-    position = npy_ftell(handle);
-    fclose(handle);
-
-    ret = PyObject_CallMethod(file, "seek", NPY_SSIZE_T_PYFMT "i", position, 0);
-    if (ret == NULL) {
-        return -1;
-    }
-    Py_DECREF(ret);
-    return 0;
-}
-
-
 #else
 
-/* DEPRECATED, DO NOT USE */
-#define npy_PyFile_DupClose(f, h) npy_PyFile_DupClose2((f), (h), 0)
-
-/* use these */
 static NPY_INLINE FILE *
 npy_PyFile_Dup2(PyObject *file,
                 const char *NPY_UNUSED(mode), npy_off_t *NPY_UNUSED(orig_pos))
@@ -318,24 +291,6 @@ npy_PyFile_DupClose2(PyObject *NPY_UNUSED(file), FILE* NPY_UNUSED(handle),
 #define npy_PyFile_Check PyFile_Check
 
 #endif
-
-/*
- * DEPRECATED, DO NOT USE
- * Use npy_PyFile_Dup2 instead.
- * This function will mess up python3 internal file object buffering.
- * Get a FILE* handle to the file represented by the Python object.
- */
-static NPY_INLINE FILE*
-npy_PyFile_Dup(PyObject *file, char *mode)
-{
-    npy_off_t orig;
-    if (DEPRECATE("npy_PyFile_Dup is deprecated, use "
-                  "npy_PyFile_Dup2") < 0) {
-        return NULL;
-    }
-
-    return npy_PyFile_Dup2(file, mode, &orig);
-}
 
 static NPY_INLINE PyObject*
 npy_PyFile_OpenFile(PyObject *filename, const char *mode)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -900,6 +900,7 @@ def correlate(a, v, mode='valid', old_behavior=False):
 # the old behavior should be made available under a different name, see thread
 # http://thread.gmane.org/gmane.comp.python.numeric.general/12609/focus=12630
     if old_behavior:
+        # 2009-07-18 RemoveMe
         warnings.warn("""
 The old behavior of correlate was deprecated for 1.4.0, and will be completely removed
 for NumPy 2.0.
@@ -1114,6 +1115,7 @@ def alterdot():
     restoredot : `restoredot` undoes the effects of `alterdot`.
 
     """
+    # 2014-08-13, 1.10
     warnings.warn("alterdot no longer does anything.", DeprecationWarning)
 
 
@@ -1137,6 +1139,7 @@ def restoredot():
     alterdot : `restoredot` undoes the effects of `alterdot`.
 
     """
+    # 2014-08-13, 1.10
     warnings.warn("restoredot no longer does anything.", DeprecationWarning)
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -900,7 +900,7 @@ def correlate(a, v, mode='valid', old_behavior=False):
 # the old behavior should be made available under a different name, see thread
 # http://thread.gmane.org/gmane.comp.python.numeric.general/12609/focus=12630
     if old_behavior:
-        # 2009-07-18 RemoveMe
+        # 2009-07-18 Cannot remove without replacement function.
         warnings.warn("""
 The old behavior of correlate was deprecated for 1.4.0, and will be completely removed
 for NumPy 2.0.

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -738,6 +738,7 @@ array_might_be_written(PyArrayObject *obj)
         "The quick fix is to make an explicit copy (e.g., do\n"
         "arr.diagonal().copy() or arr[['f0','f1']].copy()).";
     if (PyArray_FLAGS(obj) & NPY_ARRAY_WARN_ON_WRITE) {
+        /* 2012-07-17, 1.7 */
         if (DEPRECATE_FUTUREWARNING(msg) < 0) {
             return -1;
         }
@@ -1345,6 +1346,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         break;
     case Py_EQ:
         if (other == Py_None) {
+            /* 2013-07-25, 1.7 */
             if (DEPRECATE_FUTUREWARNING("comparison to `None` will result in "
                     "an elementwise object comparison in the future.") < 0) {
                 return NULL;
@@ -1368,6 +1370,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * this way.
              */
             if (array_other == NULL) {
+                /* 2015-05-07, 1.10 */
                 PyErr_Clear();
                 if (DEPRECATE(
                         "elementwise == comparison failed and returning scalar "
@@ -1382,6 +1385,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
             if (_res == 0) {
+                /* 2015-05-07, 1.10 */
                 Py_DECREF(array_other);
                 if (DEPRECATE_FUTUREWARNING(
                         "elementwise == comparison failed and returning scalar "
@@ -1417,6 +1421,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * Comparisons should raise errors when element-wise comparison
              * is not possible.
              */
+            /* 2015-05-14, 1.10 */
             PyErr_Clear();
             if (DEPRECATE("elementwise == comparison failed; "
                           "this will raise an error in the future.") < 0) {
@@ -1429,6 +1434,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         break;
     case Py_NE:
         if (other == Py_None) {
+            /* 2013-07-25, 1.8 */
             if (DEPRECATE_FUTUREWARNING("comparison to `None` will result in "
                     "an elementwise object comparison in the future.") < 0) {
                 return NULL;
@@ -1452,6 +1458,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * this way.
             */
             if (array_other == NULL) {
+                /* 2015-05-07, 1.10 */
                 PyErr_Clear();
                 if (DEPRECATE(
                         "elementwise != comparison failed and returning scalar "
@@ -1466,6 +1473,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                                          PyArray_DESCR(array_other),
                                          NPY_EQUIV_CASTING);
             if (_res == 0) {
+                /* 2015-05-07, 1.10 */
                 Py_DECREF(array_other);
                 if (DEPRECATE_FUTUREWARNING(
                         "elementwise != comparison failed and returning scalar "
@@ -1495,6 +1503,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
              * Comparisons should raise errors when element-wise comparison
              * is not possible.
              */
+            /* 2015-05-14, 1.10 */
             PyErr_Clear();
             if (DEPRECATE("elementwise != comparison failed; "
                           "this will raise an error in the future.") < 0) {

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -784,6 +784,7 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
 
     /* Be a bit stricter and not allow bools, np.bool_ is handled later */
     if (PyBool_Check(o)) {
+        /* 2013-04-13, 1.8 */
         if (DEPRECATE("using a boolean instead of an integer"
                       " will result in an error in the future") < 0) {
             return -1;
@@ -817,6 +818,7 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
 
     /* Disallow numpy.bool_. Boolean arrays do not currently support index. */
     if (PyArray_IsScalar(o, Bool)) {
+        /* 2013-06-09, 1.8 */
         if (DEPRECATE("using a boolean instead of an integer"
                       " will result in an error in the future") < 0) {
             return -1;
@@ -884,6 +886,7 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
     }
     /* Give a deprecation warning, unless there was already an error */
     if (!error_converting(long_value)) {
+        /* 2013-04-13, 1.8 */
         if (DEPRECATE("using a non-integer number instead of an integer"
                       " will result in an error in the future") < 0) {
             return -1;
@@ -1139,6 +1142,7 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             if (itemsize == 4 || itemsize == 8) {
                 int ret = 0;
                 if (evil_global_disable_warn_O4O8_flag) {
+                    /* 2012-02-04, 1.7, not sure when this can be removed */
                     ret = DEPRECATE("DType strings 'O4' and 'O8' are "
                             "deprecated because they are platform "
                             "specific. Use 'O' instead");

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2452,6 +2452,7 @@ PyArray_FromDimsAndDataAndDescr(int nd, int *d,
     char msg[] = "PyArray_FromDimsAndDataAndDescr: use PyArray_NewFromDescr.";
 
     if (DEPRECATE(msg) < 0) {
+        /* 2009-04-30, 1.5 */
         return NULL;
     }
     if (!PyArray_ISNBO(descr->byteorder))
@@ -2476,6 +2477,7 @@ PyArray_FromDims(int nd, int *d, int type)
     char msg[] = "PyArray_FromDims: use PyArray_SimpleNew.";
 
     if (DEPRECATE(msg) < 0) {
+        /* 2009-04-30, 1.5 */
         return NULL;
     }
     ret = (PyArrayObject *)PyArray_FromDimsAndDataAndDescr(nd, d,

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1975,6 +1975,8 @@ arraydescr_names_set(PyArray_Descr *self, PyObject *val)
     }
 
     /*
+     * FIXME
+     *
      * This deprecation has been temporarily removed for the NumPy 1.7
      * release. It should be re-added after the 1.7 branch is done,
      * and a convenience API to replace the typical use-cases for

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1157,6 +1157,7 @@ partition_prep_kth_array(PyArrayObject * ktharray,
     npy_intp nkth, i;
 
     if (!PyArray_CanCastSafely(PyArray_TYPE(ktharray), NPY_INTP)) {
+        /* 2013-05-18, 1.8 */
         if (DEPRECATE("Calling partition with a non integer index"
                       " will result in an error in the future") < 0) {
             return NULL;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -292,6 +292,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
              * replaced with a slice.
              */
             if (index_type & HAS_ELLIPSIS) {
+                /* 2013-04-14, 1.8 */
                 if (DEPRECATE(
                         "an index can only have a single Ellipsis (`...`); "
                         "replace all but one with slices (`:`).") < 0) {
@@ -433,6 +434,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
                  * later just like a normal array.
                  */
                 if (PyArray_ISBOOL(tmp_arr)) {
+                    /* 2013-04-14, 1.8 */
                     if (DEPRECATE_FUTUREWARNING(
                             "in the future, boolean array-likes will be "
                             "handled as a boolean array index") < 0) {
@@ -465,6 +467,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
                 else if (!PyArray_ISINTEGER(tmp_arr)) {
                     if (PyArray_NDIM(tmp_arr) == 0) {
                         /* match integer deprecation warning */
+                        /* 2013-09-25, 1.8 */
                         if (DEPRECATE(
                                     "using a non-integer number instead of an "
                                     "integer will result in an error in the "
@@ -480,6 +483,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
                         }
                     }
                     else {
+                        /* 2013-09-25, 1.8 */
                         if (DEPRECATE(
                                     "non integer (and non boolean) array-likes "
                                     "will not be accepted as indices in the "
@@ -1727,10 +1731,11 @@ attempt_1d_fallback(PyArrayObject *self, PyObject *ind, PyObject *op)
     if (iter_ass_subscript(self_iter, ind, op) < 0) {
         goto fail;
     }
-    
+
     Py_XDECREF((PyObject *)self_iter);
     Py_DECREF(err);
 
+    /* 2014-06-12, 1.9 */
     if (DEPRECATE(
             "assignment will raise an error in the future, most likely "
             "because your index result shape does not match the value array "
@@ -1744,6 +1749,7 @@ attempt_1d_fallback(PyArrayObject *self, PyObject *ind, PyObject *op)
     if (!PyErr_ExceptionMatches(err)) {
         PyObject *err, *val, *tb;
         PyErr_Fetch(&err, &val, &tb);
+        /* 2014-06-12, 1.9 */
         DEPRECATE_FUTUREWARNING(
             "assignment exception type will change in the future");
         PyErr_Restore(err, val, tb);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -347,16 +347,6 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis)
         axis += ndim;
     }
 
-    if (ndim == 1 && axis != 0) {
-        static const char msg[] = "axis != 0 for ndim == 1; "
-                                  "this will raise an error in "
-                                  "future versions of numpy";
-        if (DEPRECATE(msg) < 0) {
-            return NULL;
-        }
-        axis = 0;
-    }
-
     if (axis < 0 || axis >= ndim) {
         PyErr_Format(PyExc_IndexError,
                      "axis %d out of bounds [0, %d)", orig_axis, ndim);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -257,6 +257,7 @@ PyArray_As1D(PyObject **op, char **ptr, int *d1, int typecode)
     PyArray_Descr *descr;
     static const char msg[] = "PyArray_As1D: use PyArray_AsCArray.";
 
+    /* 2008-07-14, 1.5 */
     if (DEPRECATE(msg) < 0) {
         return -1;
     }
@@ -278,6 +279,7 @@ PyArray_As2D(PyObject **op, char ***ptr, int *d1, int *d2, int typecode)
     PyArray_Descr *descr;
     static const char msg[] = "PyArray_As1D: use PyArray_AsCArray.";
 
+    /* 2008-07-14, 1.5 */
     if (DEPRECATE(msg) < 0) {
         return -1;
     }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -168,6 +168,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
                      "deprecated. Use `oa_ndim == -1` or the MultiNew "
                      "iterator for NumPy <1.8 compatibility";
         if (DEPRECATE(mesg) < 0) {
+            /* 2013-02-23, 1.8 */
             return NULL;
         }
         oa_ndim = -1;

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -1022,6 +1022,7 @@ array_index(PyArrayObject *v)
         return NULL;
     }
     if (PyArray_NDIM(v) != 0) {
+        /* 2013-04-20, 1.8 */
         if (DEPRECATE("converting an array with ndim > 0 to an index"
                       " will result in an error in the future") < 0) {
             return NULL;

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2574,6 +2574,7 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
         if (ret_obj == NULL) {
 #if @identity@ != -1
             if (in1 == in2) {
+                /* 2014-01-26, 1.9 */
                 PyErr_Clear();
                 if (DEPRECATE("numpy @kind@ will not check object identity "
                               "in the future. The comparison error will "
@@ -2591,6 +2592,7 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
         if (ret == -1) {
 #if @identity@ != -1
             if (in1 == in2) {
+                /* 2014-01-26, 1.9 */
                 PyErr_Clear();
                 if (DEPRECATE("numpy @kind@ will not check object identity "
                               "in the future. The error trying to get the "
@@ -2606,6 +2608,7 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
         }
 #if @identity@ != -1
         if ((in1 == in2) && ((npy_bool)ret != @identity@)) {
+            /* 2014-01-26, 1.9 */
             if (DEPRECATE_FUTUREWARNING(
                         "numpy @kind@ will not check object identity "
                         "in the future. The comparison did not return the "

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -384,6 +384,7 @@ PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
 
     /* The type resolver would have upcast already */
     if (out_dtypes[0]->type_num == NPY_BOOL) {
+        /* 2013-12-05, 1.9 */
         if (DEPRECATE("numpy boolean negative (the unary `-` operator) is "
                       "deprecated, use the bitwise_xor (the `^` operator) "
                       "or the logical_xor function instead.") < 0) {
@@ -799,6 +800,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
 
         /* The type resolver would have upcast already */
         if (out_dtypes[0]->type_num == NPY_BOOL) {
+            /* 2013-12-05, 1.9 */
             if (DEPRECATE("numpy boolean subtract (the binary `-` operator) is "
                           "deprecated, use the bitwise_xor (the `^` operator) "
                           "or the logical_xor function instead.") < 0) {

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -385,9 +385,9 @@ PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
     /* The type resolver would have upcast already */
     if (out_dtypes[0]->type_num == NPY_BOOL) {
         /* 2013-12-05, 1.9 */
-        if (DEPRECATE("numpy boolean negative (the unary `-` operator) is "
-                      "deprecated, use the bitwise_xor (the `^` operator) "
-                      "or the logical_xor function instead.") < 0) {
+        if (DEPRECATE("numpy boolean negative, the `-` operator, is "
+                      "deprecated, use the `~` operator or the logical_not "
+                      "function instead.") < 0) {
             return -1;
         }
     }
@@ -801,8 +801,8 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* The type resolver would have upcast already */
         if (out_dtypes[0]->type_num == NPY_BOOL) {
             /* 2013-12-05, 1.9 */
-            if (DEPRECATE("numpy boolean subtract (the binary `-` operator) is "
-                          "deprecated, use the bitwise_xor (the `^` operator) "
+            if (DEPRECATE("numpy boolean subtract, the `-` operator, is "
+                          "deprecated, use the bitwise_xor, the `^` operator, "
                           "or the logical_xor function instead.") < 0) {
                 return -1;
             }

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -345,15 +345,32 @@ class TestMultipleEllipsisDeprecation(_DeprecationTestCase):
             assert_raises(IndexError, a.__getitem__, ((Ellipsis, ) * 3,))
 
 
-class TestBooleanSubtractDeprecations(_DeprecationTestCase):
-    """Test deprecation of boolean `-`. While + and * are well
-    defined, - is not and even a corrected form seems to have
+class TestBooleanUnaryMinusDeprecation(_DeprecationTestCase):
+    """Test deprecation of unary boolean `-`. While + and * are well
+    defined, unary - is not and even a corrected form seems to have
     no real uses.
 
     The deprecation process was started in NumPy 1.9.
     """
-    message = r"numpy boolean .* \(the .* `-` operator\) is deprecated, " \
-              "use the bitwise"
+    message = r"numpy boolean negative, the `-` operator, .*"
+
+    def test_unary_minus_operator_deprecation(self):
+        array = np.array([True])
+        generic = np.bool_(True)
+
+        # Unary minus/negative ufunc:
+        self.assert_deprecated(operator.neg, args=(array,))
+        self.assert_deprecated(operator.neg, args=(generic,))
+
+
+class TestBooleanBinaryMinusDeprecation(_DeprecationTestCase):
+    """Test deprecation of binary boolean `-`. While + and * are well
+    defined, binary  - is not and even a corrected form seems to have
+    no real uses.
+
+    The deprecation process was started in NumPy 1.9.
+    """
+    message = r"numpy boolean subtract, the `-` operator, .*"
 
     def test_operator_deprecation(self):
         array = np.array([True])
@@ -363,9 +380,6 @@ class TestBooleanSubtractDeprecations(_DeprecationTestCase):
         self.assert_deprecated(operator.sub, args=(array, array))
         self.assert_deprecated(operator.sub, args=(generic, generic))
 
-        # Unary minus/negative ufunc:
-        self.assert_deprecated(operator.neg, args=(array,))
-        self.assert_deprecated(operator.neg, args=(generic,))
 
 
 class TestRankDeprecation(_DeprecationTestCase):

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -37,6 +37,7 @@ class config(old_config):
 
     def try_run(self, body, headers=None, include_dirs=None,
                 libraries=None, library_dirs=None, lang="c"):
+        # 2008-11-16, RemoveMe
         warnings.warn("\n+++++++++++++++++++++++++++++++++++++++++++++++++\n" \
                       "Usage of try_run is deprecated: please do not \n" \
                       "use it anymore, and avoid configuration checks \n" \
@@ -435,6 +436,7 @@ int main (void)
         built from 'body' and 'headers'. Returns the exit status code
         of the program and its output.
         """
+        # 2008-11-16, RemoveMe
         warnings.warn("\n+++++++++++++++++++++++++++++++++++++++++++++++++\n" \
                       "Usage of get_output is deprecated: please do not \n" \
                       "use it anymore, and avoid configuration checks \n" \

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -35,18 +35,6 @@ class config(old_config):
         self.fcompiler = None
         old_config.initialize_options(self)
 
-    def try_run(self, body, headers=None, include_dirs=None,
-                libraries=None, library_dirs=None, lang="c"):
-        # 2008-11-16, RemoveMe
-        warnings.warn("\n+++++++++++++++++++++++++++++++++++++++++++++++++\n" \
-                      "Usage of try_run is deprecated: please do not \n" \
-                      "use it anymore, and avoid configuration checks \n" \
-                      "involving running executable on the target machine.\n" \
-                      "+++++++++++++++++++++++++++++++++++++++++++++++++\n",
-                      DeprecationWarning)
-        return old_config.try_run(self, body, headers, include_dirs, libraries,
-                                  library_dirs, lang)
-
     def _check_compiler (self):
         old_config._check_compiler(self)
         from numpy.distutils.fcompiler import FCompiler, new_fcompiler
@@ -429,51 +417,6 @@ int main (void)
     def check_gcc_variable_attribute(self, attribute):
         return check_gcc_variable_attribute(self, attribute)
 
-    def get_output(self, body, headers=None, include_dirs=None,
-                   libraries=None, library_dirs=None,
-                   lang="c", use_tee=None):
-        """Try to compile, link to an executable, and run a program
-        built from 'body' and 'headers'. Returns the exit status code
-        of the program and its output.
-        """
-        # 2008-11-16, RemoveMe
-        warnings.warn("\n+++++++++++++++++++++++++++++++++++++++++++++++++\n" \
-                      "Usage of get_output is deprecated: please do not \n" \
-                      "use it anymore, and avoid configuration checks \n" \
-                      "involving running executable on the target machine.\n" \
-                      "+++++++++++++++++++++++++++++++++++++++++++++++++\n",
-                      DeprecationWarning)
-        from distutils.ccompiler import CompileError, LinkError
-        self._check_compiler()
-        exitcode, output = 255, ''
-        try:
-            grabber = GrabStdout()
-            try:
-                src, obj, exe = self._link(body, headers, include_dirs,
-                                           libraries, library_dirs, lang)
-                grabber.restore()
-            except:
-                output = grabber.data
-                grabber.restore()
-                raise
-            exe = os.path.join('.', exe)
-            exitstatus, output = exec_command(exe, execute_in='.',
-                                              use_tee=use_tee)
-            if hasattr(os, 'WEXITSTATUS'):
-                exitcode = os.WEXITSTATUS(exitstatus)
-                if os.WIFSIGNALED(exitstatus):
-                    sig = os.WTERMSIG(exitstatus)
-                    log.error('subprocess exited with signal %d' % (sig,))
-                    if sig == signal.SIGINT:
-                        # control-C
-                        raise KeyboardInterrupt
-            else:
-                exitcode = exitstatus
-            log.info("success!")
-        except (CompileError, LinkError):
-            log.info("failure.")
-        self._clean()
-        return exitcode, output
 
 class GrabStdout(object):
 

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -74,6 +74,7 @@ def get_pythonexe():
 
 def splitcmdline(line):
     import warnings
+    # 2007-12-26 RemoveMe
     warnings.warn('splitcmdline is deprecated; use shlex.split',
                   DeprecationWarning)
     return shlex.split(line)

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -72,13 +72,6 @@ def get_pythonexe():
         assert os.path.isfile(pythonexe), '%r is not a file' % (pythonexe,)
     return pythonexe
 
-def splitcmdline(line):
-    import warnings
-    # 2007-12-26 RemoveMe
-    warnings.warn('splitcmdline is deprecated; use shlex.split',
-                  DeprecationWarning)
-    return shlex.split(line)
-
 def find_executable(exe, path=None, _cache={}):
     """Return full path of a executable or None.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -776,6 +776,7 @@ def select(condlist, choicelist, default=0):
 
     # Now that the dtype is known, handle the deprecated select([], []) case
     if len(condlist) == 0:
+        # 2014-02-24, 1.9
         warnings.warn("select with an empty condition list is not possible"
                       "and will be deprecated",
                       DeprecationWarning)
@@ -809,6 +810,7 @@ def select(condlist, choicelist, default=0):
                     'invalid entry in choicelist: should be boolean ndarray')
 
     if deprecated_ints:
+        # 2014-02-24, 1.9
         msg = "select condlists containing integer ndarrays is deprecated " \
             "and will be removed in the future. Use `.astype(bool)` to " \
             "convert to bools."
@@ -2075,6 +2077,7 @@ def corrcoef(x, y=None, rowvar=1, bias=np._NoValue, ddof=np._NoValue):
     safely ignored in this and previous versions of numpy.
     """
     if bias is not np._NoValue or ddof is not np._NoValue:
+        # 2015-03-15, 1.10
         warnings.warn('bias and ddof have no affect and are deprecated',
                       DeprecationWarning)
     c = cov(x, y, rowvar)
@@ -3626,6 +3629,7 @@ def delete(arr, obj, axis=None):
         ndim = arr.ndim
         axis = ndim - 1
     if ndim == 0:
+        # 2013-09-24, 1.9
         warnings.warn(
             "in the future the special handling of scalars will be removed "
             "from delete and raise an error", DeprecationWarning)
@@ -3720,6 +3724,7 @@ def delete(arr, obj, axis=None):
         if not np.can_cast(obj, intp, 'same_kind'):
             # obj.size = 1 special case always failed and would just
             # give superfluous warnings.
+            # 2013-09-24, 1.9
             warnings.warn(
                 "using a non-integer array as obj in delete will result in an "
                 "error in the future", DeprecationWarning)
@@ -3729,6 +3734,7 @@ def delete(arr, obj, axis=None):
         # Test if there are out of bound indices, this is deprecated
         inside_bounds = (obj < N) & (obj >= -N)
         if not inside_bounds.all():
+            # 2013-09-24, 1.9
             warnings.warn(
                 "in the future out of bounds indices will raise an error "
                 "instead of being ignored by `numpy.delete`.",
@@ -3861,6 +3867,7 @@ def insert(arr, obj, values, axis=None):
         if (axis < 0):
             axis += ndim
     if (ndim == 0):
+        # 2013-09-24, 1.9
         warnings.warn(
             "in the future the special handling of scalars will be removed "
             "from insert and raise an error", DeprecationWarning)
@@ -3932,6 +3939,7 @@ def insert(arr, obj, values, axis=None):
         indices = indices.astype(intp)
 
     if not np.can_cast(indices, intp, 'same_kind'):
+        # 2013-09-24, 1.9
         warnings.warn(
             "using a non-integer array as obj in insert will result in an "
             "error in the future", DeprecationWarning)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1515,7 +1515,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     # Get the first valid lines after the first skiprows ones ..
     if skiprows:
-        # 2011-03-06 RemoveMe
+        # 2011-03-06 Cannot remove is keyword.
         warnings.warn(
             "The use of `skiprows` is deprecated, it will be removed in "
             "numpy 2.0.\nPlease use `skip_header` instead.",
@@ -1651,7 +1651,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     # Process the deprecated `missing`
     if missing != asbytes(''):
-        # 2011-03-06 RemoveMe
+        # 2011-03-06 Cannot remove, is keyword.
         warnings.warn(
             "The use of `missing` is deprecated, it will be removed in "
             "Numpy 2.0.\nPlease use `missing_values` instead.",

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1515,6 +1515,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     # Get the first valid lines after the first skiprows ones ..
     if skiprows:
+        # 2011-03-06 RemoveMe
         warnings.warn(
             "The use of `skiprows` is deprecated, it will be removed in "
             "numpy 2.0.\nPlease use `skip_header` instead.",
@@ -1650,6 +1651,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     # Process the deprecated `missing`
     if missing != asbytes(''):
+        # 2011-03-06 RemoveMe
         warnings.warn(
             "The use of `missing` is deprecated, it will be removed in "
             "Numpy 2.0.\nPlease use `missing_values` instead.",

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1011,6 +1011,7 @@ class SafeEval(object):
 
     """
     def __init__(self):
+        # 2014-10-15, 1.10
         warnings.warn("SafeEval is deprecated in 1.10 and will be removed.",
                       DeprecationWarning)
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -730,12 +730,14 @@ def qr(a, mode='reduced'):
     """
     if mode not in ('reduced', 'complete', 'r', 'raw'):
         if mode in ('f', 'full'):
+            # 2013-04-01, 1.8
             msg = "".join((
                     "The 'full' option is deprecated in favor of 'reduced'.\n",
                     "For backward compatibility let mode default."))
             warnings.warn(msg, DeprecationWarning)
             mode = 'reduced'
         elif mode in ('e', 'economic'):
+            # 2013-04-01, 1.8
             msg = "The 'economic' option is deprecated.",
             warnings.warn(msg, DeprecationWarning)
             mode = 'economic'

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1455,6 +1455,7 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
     """
     msg = 'bias and ddof have no affect and are deprecated'
     if bias is not np._NoValue or ddof is not np._NoValue:
+        # 2015-03-15, 1.10
         warnings.warn(msg, DeprecationWarning)
     # Get the data
     (x, xnotmask, rowvar) = _covhelper(x, y, rowvar, allow_masked)


### PR DESCRIPTION
Remove some deprecated bits and mark all Deprecations with a date and Numpy version for further action.
This PR is not finished yet, but need review anyway ;)

One question is what to do with deprecated C-API functions, of which there are four. We can't remove them, but perhaps we should return an error. Thoughts?
