### PR TITLE
1.10 deprecated removal risky

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -32,7 +32,8 @@ Dropped Support:
 * try_run and get_output have been removed from
   numpy/distutils/command/config.py
 * The a._format attribute is no longer supported for array printing.
-* Keywords ``skiprows`` and ``missing`` removed from genfromtxt.
+* Keywords ``skiprows`` and ``missing`` removed from np.genfromtxt.
+* Keyword ``old_behavior`` removed from np.correlate.
 
 Future Changes:
 

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -32,6 +32,7 @@ Dropped Support:
 * try_run and get_output have been removed from
   numpy/distutils/command/config.py
 * The a._format attribute is no longer supported for array printing.
+* Keywords ``skiprows`` and ``missing`` removed from genfromtxt.
 
 Future Changes:
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -831,7 +831,7 @@ def _mode_from_name(mode):
         return _mode_from_name_dict[mode.lower()[0]]
     return mode
 
-def correlate(a, v, mode='valid', old_behavior=False):
+def correlate(a, v, mode='valid'):
     """
     Cross-correlation of two 1-dimensional sequences.
 
@@ -851,10 +851,8 @@ def correlate(a, v, mode='valid', old_behavior=False):
         Refer to the `convolve` docstring.  Note that the default
         is `valid`, unlike `convolve`, which uses `full`.
     old_behavior : bool
-        If True, uses the old behavior from Numeric,
-        (correlate(a,v) == correlate(v,a), and the conjugate is not taken
-        for complex arrays). If False, uses the conventional signal
-        processing definition.
+        `old_behavior` was removed in NumPy 1.10. If you need the old
+        behavior, use `multiarray.correlate`.
 
     Returns
     -------
@@ -864,6 +862,7 @@ def correlate(a, v, mode='valid', old_behavior=False):
     See Also
     --------
     convolve : Discrete, linear convolution of two one-dimensional sequences.
+    multiarray.correlate : Old, no conjugate, version of correlate.
 
     Notes
     -----
@@ -897,20 +896,7 @@ def correlate(a, v, mode='valid', old_behavior=False):
 
     """
     mode = _mode_from_name(mode)
-# the old behavior should be made available under a different name, see thread
-# http://thread.gmane.org/gmane.comp.python.numeric.general/12609/focus=12630
-    if old_behavior:
-        # 2009-07-18 Cannot remove without replacement function.
-        warnings.warn("""
-The old behavior of correlate was deprecated for 1.4.0, and will be completely removed
-for NumPy 2.0.
-
-The new behavior fits the conventional definition of correlation: inputs are
-never swapped, and the second argument is conjugated for complex arrays.""",
-            DeprecationWarning)
-        return multiarray.correlate(a, v, mode)
-    else:
-        return multiarray.correlate2(a, v, mode)
+    return multiarray.correlate2(a, v, mode)
 
 def convolve(a,v,mode='full'):
     """

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -980,6 +980,7 @@ class TestBinaryRepr(TestCase):
         assert_equal(binary_repr(-1), '-1')
         assert_equal(binary_repr(-1, width=8), '11111111')
 
+
 class TestBaseRepr(TestCase):
     def test_base3(self):
         assert_equal(base_repr(3**5, 3), '100000')
@@ -1946,7 +1947,7 @@ class TestLikeFuncs(TestCase):
         self.check_like_function(np.full_like, 123.456, True)
         self.check_like_function(np.full_like, np.inf, True)
 
-class _TestCorrelate(TestCase):
+class TestCorrelate(TestCase):
     def _setup(self, dt):
         self.x = np.array([1, 2, 3, 4, 5], dtype=dt)
         self.xs = np.arange(1, 20)[::3]
@@ -1961,24 +1962,24 @@ class _TestCorrelate(TestCase):
 
     def test_float(self):
         self._setup(np.float)
-        z = np.correlate(self.x, self.y, 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.x, self.y, 'full')
         assert_array_almost_equal(z, self.z1)
-        z = np.correlate(self.x, self.y[:-1], 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.x, self.y[:-1], 'full')
         assert_array_almost_equal(z, self.z1_4)
-        z = np.correlate(self.y, self.x, 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.y, self.x, 'full')
         assert_array_almost_equal(z, self.z2)
-        z = np.correlate(self.x[::-1], self.y, 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.x[::-1], self.y, 'full')
         assert_array_almost_equal(z, self.z1r)
-        z = np.correlate(self.y, self.x[::-1], 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.y, self.x[::-1], 'full')
         assert_array_almost_equal(z, self.z2r)
-        z = np.correlate(self.xs, self.y, 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.xs, self.y, 'full')
         assert_array_almost_equal(z, self.zs)
 
     def test_object(self):
         self._setup(Decimal)
-        z = np.correlate(self.x, self.y, 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.x, self.y, 'full')
         assert_array_almost_equal(z, self.z1)
-        z = np.correlate(self.y, self.x, 'full', old_behavior=self.old_behavior)
+        z = np.correlate(self.y, self.x, 'full')
         assert_array_almost_equal(z, self.z2)
 
     def test_no_overwrite(self):
@@ -1988,44 +1989,14 @@ class _TestCorrelate(TestCase):
         assert_array_equal(d, np.ones(100))
         assert_array_equal(k, np.ones(3))
 
-class TestCorrelate(_TestCorrelate):
-    old_behavior = True
-    def _setup(self, dt):
-        # correlate uses an unconventional definition so that correlate(a, b)
-        # == correlate(b, a), so force the corresponding outputs to be the same
-        # as well
-        _TestCorrelate._setup(self, dt)
-        self.z2 = self.z1
-        self.z2r = self.z1r
-
-    @dec.deprecated()
-    def test_complex(self):
-        x = np.array([1, 2, 3, 4+1j], dtype=np.complex)
-        y = np.array([-1, -2j, 3+1j], dtype=np.complex)
-        r_z = np.array([3+1j, 6, 8-1j, 9+1j, -1-8j, -4-1j], dtype=np.complex)
-        z = np.correlate(x, y, 'full', old_behavior=self.old_behavior)
-        assert_array_almost_equal(z, r_z)
-
-    @dec.deprecated()
-    def test_float(self):
-        _TestCorrelate.test_float(self)
-
-    @dec.deprecated()
-    def test_object(self):
-        _TestCorrelate.test_object(self)
-
-class TestCorrelateNew(_TestCorrelate):
-    old_behavior = False
     def test_complex(self):
         x = np.array([1, 2, 3, 4+1j], dtype=np.complex)
         y = np.array([-1, -2j, 3+1j], dtype=np.complex)
         r_z = np.array([3-1j, 6, 8+1j, 11+5j, -5+8j, -4-1j], dtype=np.complex)
-        #z = np.acorrelate(x, y, 'full')
-        #assert_array_almost_equal(z, r_z)
-
         r_z = r_z[::-1].conjugate()
-        z = np.correlate(y, x, 'full', old_behavior=self.old_behavior)
+        z = correlate(y, x, mode='full')
         assert_array_almost_equal(z, r_z)
+
 
 class TestConvolve(TestCase):
     def test_object(self):

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1301,13 +1301,12 @@ def fromregex(file, regexp, dtype):
 
 
 def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
-               skiprows=0, skip_header=0, skip_footer=0, converters=None,
-               missing='', missing_values=None, filling_values=None,
-               usecols=None, names=None,
-               excludelist=None, deletechars=None, replace_space='_',
-               autostrip=False, case_sensitive=True, defaultfmt="f%i",
-               unpack=None, usemask=False, loose=True, invalid_raise=True,
-               max_rows=None):
+               skip_header=0, skip_footer=0, converters=None,
+               missing_values=None, filling_values=None, usecols=None,
+               names=None, excludelist=None, deletechars=None,
+               replace_space='_', autostrip=False, case_sensitive=True,
+               defaultfmt="f%i", unpack=None, usemask=False, loose=True,
+               invalid_raise=True, max_rows=None):
     """
     Load data from a text file, with missing values handled as specified.
 
@@ -1332,8 +1331,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         whitespaces act as delimiter.  An integer or sequence of integers
         can also be provided as width(s) of each field.
     skiprows : int, optional
-        `skiprows` was deprecated in numpy 1.5, and will be removed in
-        numpy 2.0. Please use `skip_header` instead.
+        `skiprows` was removed in numpy 1.10. Please use `skip_header` instead.
     skip_header : int, optional
         The number of lines to skip at the beginning of the file.
     skip_footer : int, optional
@@ -1343,8 +1341,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         The converters can also be used to provide a default value
         for missing data: ``converters = {3: lambda s: float(s or 0)}``.
     missing : variable, optional
-        `missing` was deprecated in numpy 1.5, and will be removed in
-        numpy 2.0. Please use `missing_values` instead.
+        `missing` was removed in numpy 1.10. Please use `missing_values`
+        instead.
     missing_values : variable, optional
         The set of strings corresponding to missing data.
     filling_values : variable, optional
@@ -1475,8 +1473,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         comments = asbytes(comments)
     if isinstance(delimiter, unicode):
         delimiter = asbytes(delimiter)
-    if isinstance(missing, unicode):
-        missing = asbytes(missing)
     if isinstance(missing_values, (unicode, list, tuple)):
         missing_values = asbytes_nested(missing_values)
 
@@ -1513,14 +1509,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                                    case_sensitive=case_sensitive,
                                    replace_space=replace_space)
 
-    # Get the first valid lines after the first skiprows ones ..
-    if skiprows:
-        # 2011-03-06 Cannot remove is keyword.
-        warnings.warn(
-            "The use of `skiprows` is deprecated, it will be removed in "
-            "numpy 2.0.\nPlease use `skip_header` instead.",
-            DeprecationWarning)
-        skip_header = skiprows
     # Skip the first `skip_header` rows
     for i in range(skip_header):
         next(fhd)
@@ -1648,17 +1636,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     else:
         for entry in missing_values:
             entry.extend([str(user_missing_values)])
-
-    # Process the deprecated `missing`
-    if missing != asbytes(''):
-        # 2011-03-06 Cannot remove, is keyword.
-        warnings.warn(
-            "The use of `missing` is deprecated, it will be removed in "
-            "Numpy 2.0.\nPlease use `missing_values` instead.",
-            DeprecationWarning)
-        values = [str(_) for _ in missing.split(asbytes(","))]
-        for entry in missing_values:
-            entry.extend(values)
 
     # Process the filling_values ...............................
     # Rename the input for convenience


### PR DESCRIPTION
This PR removes some deprecated keywords.
- Keywords `skiprows` and `missing` removed from np.genfromtxt.
- Keyword `old_behavior` removed from np.correlate.

These were originally scheduled for removal in Numpy 2.0. Because removing keywords may risk breaking code, their removal is isolated here so that they can be easily reverted if there are problems.
