### PR TITLE
REL: Reset strides for RELAXED_STRIDE_CHECKING for 1.10 release.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3773,10 +3773,6 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             else {
                 not_cf_contig = 0;
             }
-            if (dims[i] == 1) {
-                /* For testing purpose only */
-                strides[i] = NPY_MAX_INTP;
-            }
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }
 #if NPY_RELAXED_STRIDES_CHECKING
@@ -3800,10 +3796,6 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
 #if NPY_RELAXED_STRIDES_CHECKING
             else {
                 not_cf_contig = 0;
-            }
-            if (dims[i] == 1) {
-                /* For testing purpose only */
-                strides[i] = NPY_MAX_INTP;
             }
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }


### PR DESCRIPTION
Do not apply. This will be resubmitted against the 1.10 branch when it is made and is intended for release only. This is for review and testing only.

Strides in some cases are set to NPY_MAX_INTP to smoke out illegal usage
in packages that use Numpy. We don't want that for the release, so fix
it.
