### PR TITLE
DOC: Fix examples in npyio.py to properly import StringIO.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -798,7 +798,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
     Examples
     --------
-    >>> from StringIO import StringIO   # StringIO behaves like a file object
+    >>> from io import StringIO   # StringIO behaves like a file object
     >>> c = StringIO("0 1\\n2 3")
     >>> np.loadtxt(c)
     array([[ 0.,  1.],
@@ -1420,7 +1420,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     Examples
     ---------
-    >>> from StringIO import StringIO
+    >>> from io import StringIO
     >>> import numpy as np
 
     Comma delimited file with mixed dtype


### PR DESCRIPTION
In two places they were doing

```
>>> from StringIO import StringIO
```

Since Python 2.6 that should be

```
>>> from io import StringIO
```

Closes #5995.
