### PR TITLE
BUG/ENH: Switch to simplified __numpy_ufunc__/binop interaction

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -52,6 +52,8 @@ maintainer email:  oliphant.travis@ieee.org
 #include "array_assign.h"
 #include "alloc.h"
 
+#include "binop_override.h"
+
 /*NUMPY_API
   Compute the size of an array (in number of items)
 */
@@ -1326,23 +1328,12 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
 
     switch (cmp_op) {
     case Py_LT:
-        if (needs_right_binop_forward(obj_self, other, "__gt__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            /* See discussion in number.c */
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        result = PyArray_GenericBinaryFunction(self, other,
-                n_ops.less);
+        RICHCMP_GIVE_UP_IF_NEEDED(obj_self, other);
+        result = PyArray_GenericBinaryFunction(self, other, n_ops.less);
         break;
     case Py_LE:
-        if (needs_right_binop_forward(obj_self, other, "__ge__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
-        result = PyArray_GenericBinaryFunction(self, other,
-                n_ops.less_equal);
+        RICHCMP_GIVE_UP_IF_NEEDED(obj_self, other);
+        result = PyArray_GenericBinaryFunction(self, other, n_ops.less_equal);
         break;
     case Py_EQ:
         if (other == Py_None) {
@@ -1403,11 +1394,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return result;
         }
 
-        if (needs_right_binop_forward(obj_self, other, "__eq__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
+        RICHCMP_GIVE_UP_IF_NEEDED(obj_self, other);
         result = PyArray_GenericBinaryFunction(self,
                 (PyObject *)other,
                 n_ops.equal);
@@ -1491,11 +1478,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
             return result;
         }
 
-        if (needs_right_binop_forward(obj_self, other, "__ne__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
+        RICHCMP_GIVE_UP_IF_NEEDED(obj_self, other);
         result = PyArray_GenericBinaryFunction(self, (PyObject *)other,
                 n_ops.not_equal);
         if (result == NULL) {
@@ -1515,20 +1498,12 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         }
         break;
     case Py_GT:
-        if (needs_right_binop_forward(obj_self, other, "__lt__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
+        RICHCMP_GIVE_UP_IF_NEEDED(obj_self, other);
         result = PyArray_GenericBinaryFunction(self, other,
                 n_ops.greater);
         break;
     case Py_GE:
-        if (needs_right_binop_forward(obj_self, other, "__le__", 0) &&
-                Py_TYPE(obj_self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
-            Py_INCREF(Py_NotImplemented);
-            return Py_NotImplemented;
-        }
+        RICHCMP_GIVE_UP_IF_NEEDED(obj_self, other);
         result = PyArray_GenericBinaryFunction(self, other,
                 n_ops.greater_equal);
         break;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -14,6 +14,8 @@
 #include "common.h"
 #include "buffer.h"
 
+#include "get_attr_string.h"
+
 /*
  * The casting to use for implicit assignment operations resulting from
  * in-place operations (like +=) and out= arguments. (Notice that this
@@ -28,61 +30,6 @@
  * be allowed under the NPY_SAME_KIND_CASTING rules, and if not we issue a
  * warning (that people's code will be broken in a future release.)
  */
-
-/*
- * PyArray_GetAttrString_SuppressException:
- *
- * Stripped down version of PyObject_GetAttrString,
- * avoids lookups for None, tuple, and List objects,
- * and doesn't create a PyErr since this code ignores it.
- *
- * This can be much faster then PyObject_GetAttrString where
- * exceptions are not used by caller.
- *
- * 'obj' is the object to search for attribute.
- *
- * 'name' is the attribute to search for.
- *
- * Returns attribute value on success, 0 on failure.
- */
-PyObject *
-PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
-{
-    PyTypeObject *tp = Py_TYPE(obj);
-    PyObject *res = (PyObject *)NULL;
-
-    /* We do not need to check for special attributes on trivial types */
-    if (_is_basic_python_type(obj)) {
-        return NULL;
-    }
-
-    /* Attribute referenced by (char *)name */
-    if (tp->tp_getattr != NULL) {
-        res = (*tp->tp_getattr)(obj, name);
-        if (res == NULL) {
-            PyErr_Clear();
-        }
-    }
-    /* Attribute referenced by (PyObject *)name */
-    else if (tp->tp_getattro != NULL) {
-#if defined(NPY_PY3K)
-        PyObject *w = PyUnicode_InternFromString(name);
-#else
-        PyObject *w = PyString_InternFromString(name);
-#endif
-        if (w == NULL) {
-            return (PyObject *)NULL;
-        }
-        res = (*tp->tp_getattro)(obj, w);
-        Py_DECREF(w);
-        if (res == NULL) {
-            PyErr_Clear();
-        }
-    }
-    return res;
-}
-
-
 
 NPY_NO_EXPORT NPY_CASTING NPY_DEFAULT_ASSIGN_CASTING = NPY_SAME_KIND_CASTING;
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -40,9 +40,6 @@ NPY_NO_EXPORT int
 PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
                               PyArray_Descr **out_dtype, int string_status);
 
-NPY_NO_EXPORT PyObject *
-PyArray_GetAttrString_SuppressException(PyObject *v, char *name);
-
 /*
  * Returns NULL without setting an exception if no scalar is matched, a
  * new dtype reference otherwise.
@@ -186,34 +183,6 @@ npy_memchr(char * haystack, char needle,
     *psubloopsize = subloopsize;
 
     return p;
-}
-
-static NPY_INLINE int
-_is_basic_python_type(PyObject * obj)
-{
-    if (obj == Py_None ||
-            PyBool_Check(obj) ||
-            /* Basic number types */
-#if !defined(NPY_PY3K)
-            PyInt_CheckExact(obj) ||
-            PyString_CheckExact(obj) ||
-#endif
-            PyLong_CheckExact(obj) ||
-            PyFloat_CheckExact(obj) ||
-            PyComplex_CheckExact(obj) ||
-            /* Basic sequence types */
-            PyList_CheckExact(obj) ||
-            PyTuple_CheckExact(obj) ||
-            PyDict_CheckExact(obj) ||
-            PyAnySet_CheckExact(obj) ||
-            PyUnicode_CheckExact(obj) ||
-            PyBytes_CheckExact(obj) ||
-            PySlice_Check(obj)) {
-
-        return 1;
-    }
-
-    return 0;
 }
 
 /*

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -30,6 +30,8 @@
 #include "alloc.h"
 #include <assert.h>
 
+#include "get_attr_string.h"
+
 /*
  * Reading from a file or a string.
  *

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -61,6 +61,8 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "compiled_base.h"
 
+#include "get_attr_string.h"
+
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
 

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -13,6 +13,8 @@
 #include "common.h"
 #include "number.h"
 
+#include "binop_override.h"
+
 /*************************************************************************
  ****************   Implement Number Protocol ****************************
  *************************************************************************/
@@ -85,88 +87,6 @@ PyArray_SetNumericOps(PyObject *dict)
 #define GET(op) if (n_ops.op &&                                         \
                     (PyDict_SetItemString(dict, #op, n_ops.op)==-1))    \
         goto fail;
-
-static int
-has_ufunc_attr(PyObject * obj) {
-    /* attribute check is expensive for scalar operations, avoid if possible */
-    if (PyArray_CheckExact(obj) || PyArray_CheckAnyScalarExact(obj) ||
-        _is_basic_python_type(obj)) {
-        return 0;
-    }
-    else {
-        return PyObject_HasAttrString(obj, "__numpy_ufunc__");
-    }
-}
-
-/*
- * Check whether the operation needs to be forwarded to the right-hand binary
- * operation.
- *
- * This is the case when all of the following conditions apply:
- *
- * (i) the other object defines __numpy_ufunc__
- * (ii) the other object defines the right-hand operation __r*__
- * (iii) Python hasn't already called the right-hand operation
- *       [occurs if the other object is a strict subclass provided
- *       the operation is not in-place]
- *
- * An additional check is made in GIVE_UP_IF_HAS_RIGHT_BINOP macro below:
- *
- * (iv) other.__class__.__r*__ is not self.__class__.__r*__
- *
- *      This is needed, because CPython does not call __rmul__ if
- *      the tp_number slots of the two objects are the same.
- *
- * This always prioritizes the __r*__ routines over __numpy_ufunc__, independent
- * of whether the other object is an ndarray subclass or not.
- */
-
-NPY_NO_EXPORT int
-needs_right_binop_forward(PyObject *self, PyObject *other,
-                          const char *right_name, int inplace_op)
-{
-    if (other == NULL ||
-        self == NULL ||
-        Py_TYPE(self) == Py_TYPE(other) ||
-        PyArray_CheckExact(other) ||
-        PyArray_CheckAnyScalar(other)) {
-        /*
-         * Quick cases
-         */
-        return 0;
-    }
-    if ((!inplace_op && PyType_IsSubtype(Py_TYPE(other), Py_TYPE(self))) ||
-        !PyArray_Check(self)) {
-        /*
-         * Bail out if Python would already have called the right-hand
-         * operation.
-         */
-        return 0;
-    }
-    if (has_ufunc_attr(other) &&
-        PyObject_HasAttrString(other, right_name)) {
-        return 1;
-    }
-    else {
-        return 0;
-    }
-}
-
-/* In pure-Python, SAME_SLOTS can be replaced by
-   getattr(m1, op_name) is getattr(m2, op_name) */
-#define SAME_SLOTS(m1, m2, slot_name)                                   \
-    (Py_TYPE(m1)->tp_as_number != NULL && Py_TYPE(m2)->tp_as_number != NULL && \
-     Py_TYPE(m1)->tp_as_number->slot_name == Py_TYPE(m2)->tp_as_number->slot_name)
-
-#define GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, left_name, right_name, inplace, slot_name) \
-    do {                                                                          \
-        if (needs_right_binop_forward((PyObject *)m1, m2, right_name, inplace) && \
-                (inplace || !SAME_SLOTS(m1, m2, slot_name))) {                    \
-            Py_INCREF(Py_NotImplemented);                                         \
-            return Py_NotImplemented;                                             \
-        }                                                                         \
-    } while (0)
-
 
 /*NUMPY_API
   Get dictionary showing number functions that all arrays will use
@@ -288,34 +208,16 @@ PyArray_GenericAccumulateFunction(PyArrayObject *m1, PyObject *op, int axis,
 NPY_NO_EXPORT PyObject *
 PyArray_GenericBinaryFunction(PyArrayObject *m1, PyObject *m2, PyObject *op)
 {
+    /*
+     * I suspect that the next few lines are buggy and cause NotImplemented to
+     * be returned at weird times... but if we raise an error here, then
+     * *everything* breaks. (Like, 'arange(10) + 1' and just
+     * 'repr(arange(10))' both blow up with an error here.) Not sure what's
+     * going on with that, but I'll leave it alone for now. - njs, 2015-06-21
+     */
     if (op == NULL) {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;
-    }
-
-    if (!PyArray_Check(m2) && !has_ufunc_attr(m2)) {
-          /*
-           * Catch priority inversion and punt, but only if it's guaranteed
-           * that we were called through m1 and the other guy is not an array
-           * at all. Note that some arrays need to pass through here even
-           * with priorities inverted, for example: float(17) * np.matrix(...)
-           *
-           * See also:
-           * - https://github.com/numpy/numpy/issues/3502
-           * - https://github.com/numpy/numpy/issues/3503
-           *
-           * NB: there's another copy of this code in
-           *    numpy.ma.core.MaskedArray._delegate_binop
-           * which should possibly be updated when this is.
-           */
-          double m1_prio = PyArray_GetPriority((PyObject *)m1,
-                                               NPY_SCALAR_PRIORITY);
-          double m2_prio = PyArray_GetPriority((PyObject *)m2,
-                                               NPY_SCALAR_PRIORITY);
-          if (m1_prio < m2_prio) {
-              Py_INCREF(Py_NotImplemented);
-              return Py_NotImplemented;
-          }
     }
 
     return PyObject_CallFunctionObjArgs(op, m1, m2, NULL);
@@ -355,21 +257,21 @@ PyArray_GenericInplaceUnaryFunction(PyArrayObject *m1, PyObject *op)
 static PyObject *
 array_add(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__add__", "__radd__", 0, nb_add);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_add, array_add);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.add);
 }
 
 static PyObject *
 array_subtract(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__sub__", "__rsub__", 0, nb_subtract);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_subtract, array_subtract);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.subtract);
 }
 
 static PyObject *
 array_multiply(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__mul__", "__rmul__", 0, nb_multiply);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_multiply, array_multiply);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.multiply);
 }
 
@@ -377,7 +279,7 @@ array_multiply(PyArrayObject *m1, PyObject *m2)
 static PyObject *
 array_divide(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__div__", "__rdiv__", 0, nb_divide);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_divide, array_divide);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.divide);
 }
 #endif
@@ -385,7 +287,7 @@ array_divide(PyArrayObject *m1, PyObject *m2)
 static PyObject *
 array_remainder(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__mod__", "__rmod__", 0, nb_remainder);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_remainder, array_remainder);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.remainder);
 }
 
@@ -401,8 +303,7 @@ array_matrix_multiply(PyArrayObject *m1, PyObject *m2)
     if (matmul == NULL) {
         return NULL;
     }
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__matmul__", "__rmatmul__",
-                               0, nb_matrix_multiply);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_matrix_multiply, array_matrix_multiply);
     return PyArray_GenericBinaryFunction(m1, m2, matmul);
 }
 #endif
@@ -567,7 +468,7 @@ array_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo))
 {
     /* modulo is ignored! */
     PyObject *value;
-    GIVE_UP_IF_HAS_RIGHT_BINOP(a1, o2, "__pow__", "__rpow__", 0, nb_power);
+    BINOP_GIVE_UP_IF_NEEDED(a1, o2, nb_power, array_power);
     value = fast_scalar_power(a1, o2, 0);
     if (!value) {
         value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
@@ -597,56 +498,53 @@ array_invert(PyArrayObject *m1)
 static PyObject *
 array_left_shift(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__lshift__", "__rlshift__", 0, nb_lshift);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_lshift, array_left_shift);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.left_shift);
 }
 
 static PyObject *
 array_right_shift(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__rshift__", "__rrshift__", 0, nb_rshift);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_rshift, array_right_shift);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.right_shift);
 }
 
 static PyObject *
 array_bitwise_and(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__and__", "__rand__", 0, nb_and);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_and, array_bitwise_and);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_and);
 }
 
 static PyObject *
 array_bitwise_or(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__or__", "__ror__", 0, nb_or);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_or, array_bitwise_or);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_or);
 }
 
 static PyObject *
 array_bitwise_xor(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__xor__", "__rxor__", 0, nb_xor);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_xor, array_bitwise_xor);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.bitwise_xor);
 }
 
 static PyObject *
 array_inplace_add(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__iadd__", "__radd__", 1, nb_inplace_add);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.add);
 }
 
 static PyObject *
 array_inplace_subtract(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__isub__", "__rsub__", 1, nb_inplace_subtract);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.subtract);
 }
 
 static PyObject *
 array_inplace_multiply(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__imul__", "__rmul__", 1, nb_inplace_multiply);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.multiply);
 }
 
@@ -654,7 +552,6 @@ array_inplace_multiply(PyArrayObject *m1, PyObject *m2)
 static PyObject *
 array_inplace_divide(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__idiv__", "__rdiv__", 1, nb_inplace_divide);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.divide);
 }
 #endif
@@ -662,7 +559,6 @@ array_inplace_divide(PyArrayObject *m1, PyObject *m2)
 static PyObject *
 array_inplace_remainder(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__imod__", "__rmod__", 1, nb_inplace_remainder);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.remainder);
 }
 
@@ -671,7 +567,6 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
 {
     /* modulo is ignored! */
     PyObject *value;
-    GIVE_UP_IF_HAS_RIGHT_BINOP(a1, o2, "__ipow__", "__rpow__", 1, nb_inplace_power);
     value = fast_scalar_power(a1, o2, 1);
     if (!value) {
         value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
@@ -682,56 +577,50 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
 static PyObject *
 array_inplace_left_shift(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__ilshift__", "__rlshift__", 1, nb_inplace_lshift);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.left_shift);
 }
 
 static PyObject *
 array_inplace_right_shift(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__irshift__", "__rrshift__", 1, nb_inplace_rshift);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.right_shift);
 }
 
 static PyObject *
 array_inplace_bitwise_and(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__iand__", "__rand__", 1, nb_inplace_and);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.bitwise_and);
 }
 
 static PyObject *
 array_inplace_bitwise_or(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__ior__", "__ror__", 1, nb_inplace_or);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.bitwise_or);
 }
 
 static PyObject *
 array_inplace_bitwise_xor(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__ixor__", "__rxor__", 1, nb_inplace_xor);
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.bitwise_xor);
 }
 
 static PyObject *
 array_floor_divide(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__floordiv__", "__rfloordiv__", 0, nb_floor_divide);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_floor_divide, array_floor_divide);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.floor_divide);
 }
 
 static PyObject *
 array_true_divide(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__truediv__", "__rtruediv__", 0, nb_true_divide);
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_true_divide, array_true_divide);
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.true_divide);
 }
 
 static PyObject *
 array_inplace_floor_divide(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__ifloordiv__", "__rfloordiv__", 1, nb_inplace_floor_divide);
     return PyArray_GenericInplaceBinaryFunction(m1, m2,
                                                 n_ops.floor_divide);
 }
@@ -739,7 +628,6 @@ array_inplace_floor_divide(PyArrayObject *m1, PyObject *m2)
 static PyObject *
 array_inplace_true_divide(PyArrayObject *m1, PyObject *m2)
 {
-    GIVE_UP_IF_HAS_RIGHT_BINOP(m1, m2, "__itruediv__", "__rtruediv__", 1, nb_inplace_true_divide);
     return PyArray_GenericInplaceBinaryFunction(m1, m2,
                                                 n_ops.true_divide);
 }
@@ -772,7 +660,7 @@ static PyObject *
 array_divmod(PyArrayObject *op1, PyObject *op2)
 {
     PyObject *divp, *modp, *result;
-    GIVE_UP_IF_HAS_RIGHT_BINOP(op1, op2, "__divmod__", "__rdivmod__", 0, nb_divmod);
+    BINOP_GIVE_UP_IF_NEEDED(op1, op2, nb_divmod, array_divmod);
 
     divp = array_floor_divide(op1, op2);
     if (divp == NULL) {

--- a/numpy/core/src/multiarray/number.h
+++ b/numpy/core/src/multiarray/number.h
@@ -70,8 +70,4 @@ NPY_NO_EXPORT PyObject *
 PyArray_GenericAccumulateFunction(PyArrayObject *m1, PyObject *op, int axis,
                                   int rtype, PyArrayObject *out);
 
-NPY_NO_EXPORT int
-needs_right_binop_forward(PyObject *self, PyObject *other,
-                          const char *right_name, int is_inplace);
-
 #endif

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -151,57 +151,8 @@ gentype_free(PyObject *v)
 static PyObject *
 gentype_power(PyObject *m1, PyObject *m2, PyObject *NPY_UNUSED(m3))
 {
-    PyObject *arr, *ret, *arg2;
-    char *msg="unsupported operand type(s) for ** or pow()";
-
-    if (!PyArray_IsScalar(m1, Generic)) {
-        if (PyArray_Check(m1)) {
-            ret = Py_TYPE(m1)->tp_as_number->nb_power(m1,m2, Py_None);
-        }
-        else {
-            if (!PyArray_IsScalar(m2, Generic)) {
-                PyErr_SetString(PyExc_TypeError, msg);
-                return NULL;
-            }
-            arr = PyArray_FromScalar(m2, NULL);
-            if (arr == NULL) {
-                return NULL;
-            }
-            ret = Py_TYPE(arr)->tp_as_number->nb_power(m1, arr, Py_None);
-            Py_DECREF(arr);
-        }
-        return ret;
-    }
-    if (!PyArray_IsScalar(m2, Generic)) {
-        if (PyArray_Check(m2)) {
-            ret = Py_TYPE(m2)->tp_as_number->nb_power(m1,m2, Py_None);
-        }
-        else {
-            if (!PyArray_IsScalar(m1, Generic)) {
-                PyErr_SetString(PyExc_TypeError, msg);
-                return NULL;
-            }
-            arr = PyArray_FromScalar(m1, NULL);
-            if (arr == NULL) {
-                return NULL;
-            }
-            ret = Py_TYPE(arr)->tp_as_number->nb_power(arr, m2, Py_None);
-            Py_DECREF(arr);
-        }
-        return ret;
-    }
-    arr = arg2 = NULL;
-    arr = PyArray_FromScalar(m1, NULL);
-    arg2 = PyArray_FromScalar(m2, NULL);
-    if (arr == NULL || arg2 == NULL) {
-        Py_XDECREF(arr);
-        Py_XDECREF(arg2);
-        return NULL;
-    }
-    ret = Py_TYPE(arr)->tp_as_number->nb_power(arr, arg2, Py_None);
-    Py_DECREF(arr);
-    Py_DECREF(arg2);
-    return ret;
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_power, gentype_power);
+    return PyArray_Type.tp_as_number->nb_power(m1, m2, NULL);
 }
 
 static PyObject *

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -27,6 +27,8 @@
 
 #include <stdlib.h>
 
+#include "binop_override.h"
+
 NPY_NO_EXPORT PyBoolScalarObject _PyArrayScalar_BoolValues[] = {
     {PyObject_HEAD_INIT(&PyBoolArrType_Type) 0},
     {PyObject_HEAD_INIT(&PyBoolArrType_Type) 1},
@@ -194,6 +196,7 @@ gentype_generic_method(PyObject *self, PyObject *args, PyObject *kwds,
 static PyObject *
 gentype_@name@(PyObject *m1, PyObject *m2)
 {
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_@name@, gentype_@name@);
     return PyArray_Type.tp_as_number->nb_@name@(m1, m2);
 }
 
@@ -207,6 +210,7 @@ gentype_@name@(PyObject *m1, PyObject *m2)
 static PyObject *
 gentype_@name@(PyObject *m1, PyObject *m2)
 {
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_@name@, gentype_@name@);
     return PyArray_Type.tp_as_number->nb_@name@(m1, m2);
 }
 /**end repeat**/
@@ -241,6 +245,7 @@ gentype_multiply(PyObject *m1, PyObject *m2)
     }
     if (ret == NULL) {
         PyErr_Clear(); /* no effect if not set */
+        BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_multiply, gentype_multiply);
         ret = PyArray_Type.tp_as_number->nb_multiply(m1, m2);
     }
     return ret;

--- a/numpy/core/src/private/binop_override.h
+++ b/numpy/core/src/private/binop_override.h
@@ -1,0 +1,292 @@
+#ifndef __BINOP_OVERRIDE_H
+#define __BINOP_OVERRIDE_H
+
+#include <string.h>
+#include <Python.h>
+#include "numpy/arrayobject.h"
+
+#include "get_attr_string.h"
+
+/*
+ * Logic for deciding when binops should return NotImplemented versus when
+ * they should go ahead and call a ufunc (or similar).
+ *
+ * The interaction between binop methods (ndarray.__add__ and friends) and
+ * ufuncs (which dispatch to __numpy_ufunc__) is both complicated in its own
+ * right, and also has complicated historical constraints.
+ *
+ * In the very old days, the rules were:
+ * - If the other argument has a higher __array_priority__, then return
+ *   NotImplemented
+ * - Otherwise, call the corresponding ufunc.
+ *   - And the ufunc might return NotImplemented based on some complex
+ *     criteria that I won't reproduce here.
+ *
+ * Ufuncs no longer return NotImplemented (except in a few marginal situations
+ * which are being phased out -- see https://github.com/numpy/numpy/pull/5864)
+ *
+ * So as of 1.9, the effective rules were:
+ * - If the other argument has a higher __array_priority__, and is *not* a
+ *   subclass of ndarray, then return NotImplemented. (If it is a subclass,
+ *   the regular Python rules have already given it a chance to run; so if we
+ *   are running, then it means the other argument has already returned
+ *   NotImplemented and is basically asking us to take care of things.)
+ * - Otherwise call the corresponding ufunc.
+ *
+ * We would like to get rid of __array_priority__, and __numpy_ufunc__
+ * provides a large part of a replacement for it. Once __numpy_ufunc__ is
+ * widely available, the simplest dispatch rules that might possibly work
+ * would be:
+ * - Always call the corresponding ufunc.
+ *
+ * But:
+ * - Doing this immediately would break backwards compatibility -- there's a
+ *   lot of code using __array_priority__ out there.
+ * - It's not at all clear whether __numpy_ufunc__ actually is sufficient for
+ *   all use cases. (See https://github.com/numpy/numpy/issues/5844 for lots
+ *   of discussion of this, and in particular
+ *     https://github.com/numpy/numpy/issues/5844#issuecomment-112014014
+ *   for a summary of some conclusions.)
+ *
+ * So for 1.10, we are going to try the following rules. a.__add__(b) will
+ * be implemented as follows:
+ * - If b does not define __numpy_ufunc__, apply the legacy rule:
+ *   - If not isinstance(b, a.__class__), and b.__array_priority__ is higher
+ *     than a.__array_priority__, return NotImplemented
+ *   - Otherwise, fall through.
+ * - If b->ob_type["__module__"].startswith("scipy.sparse."), then return
+ *   NotImplemented. (Rationale: scipy.sparse defines __mul__ and np.multiply
+ *   to do two totally different things. We want to grandfather this behavior
+ *   in, but we don't want to support it in the long run, as per PEP
+ *   465. Additionally, several versions of scipy.sparse were released with
+ *   __numpy_ufunc__ implementations that don't match the final interface, and
+ *   we don't want dense + sparse to suddenly start erroring out because
+ *   dense.__add__ dispatched to a broken sparse.__numpy_ufunc__.)
+ * - Otherwise, call the corresponding ufunc.
+ *
+ * For reversed operations like b.__radd__(a), and for in-place operations
+ * like a.__iadd__(b), we:
+ * - Call the corresponding ufunc
+ *
+ * Rationale for __radd__: This is because by the time the reversed operation
+ * is called, there are only two possibilities: The first possibility is that
+ * the current class is a strict subclass of the other class. In practice, the
+ * only way this will happen is if b is a strict subclass of a, and a is
+ * ndarray or a subclass of ndarray, and neither a nor b has actually
+ * overridden this method. In this case, Python will never call a.__add__
+ * (because it's identical to b.__radd__), so we have no-one to defer to;
+ * there's no reason to return NotImplemented. The second possibility is that
+ * a.__add__ has already been called and returned NotImplemented. Again, in
+ * this case there is no point in returning NotImplemented.
+ *
+ * Rationale for __iadd__: In-place operations do not take all the trouble
+ * above, because if __iadd__ returns NotImplemented then Python will silently
+ * convert the operation into an out-of-place operation, i.e. 'a += b' will
+ * silently become 'a = a + b'. We don't want to allow this for arrays,
+ * because it will create unexpected memory allocations, break views,
+ * etc.
+ *
+ * In the future we might change these rules further. For example, we plan to
+ * eventually deprecate __array_priority__ in cases where __numpy_ufunc__ is
+ * not present, and we might decide that we need somewhat more flexible
+ * dispatch rules where the ndarray binops sometimes return NotImplemented
+ * rather than always dispatching to ufuncs.
+ *
+ * Note that these rules are also implemented by ABCArray, so any changes here
+ * should also be reflected there.
+ */
+
+static int
+binop_override_has_ufunc_attr(PyObject *obj) {
+    PyObject *attr;
+    int result;
+
+    /* attribute check is expensive for scalar operations, avoid if possible */
+    if (PyArray_CheckExact(obj) || PyArray_CheckAnyScalarExact(obj) ||
+        _is_basic_python_type(obj)) {
+        return 0;
+    }
+
+    attr = PyArray_GetAttrString_SuppressException(obj, "__numpy_ufunc__");
+    if (attr == NULL) {
+        return 0;
+    }
+    else {
+        /*
+         * Pretend that non-callable __numpy_ufunc__ isn't there. This is an
+         * escape hatch in case we want to assign some special meaning to
+         * something like __numpy_ufunc__ = None, later on. (And can be
+         * deleted if we decide we don't want to do that.) See these two
+         * comments:
+         *   https://github.com/numpy/numpy/issues/5844#issuecomment-105081603
+         *   https://github.com/numpy/numpy/issues/5844#issuecomment-105170926
+         */
+        result = PyCallable_Check(attr);
+        Py_DECREF(attr);
+        return result;
+    }
+}
+
+static int
+binop_override_is_scipy_sparse(PyObject *obj) {
+    PyObject *module_name = NULL;
+    PyObject *bytes = NULL;
+    int result = 0;
+    char *contents;
+
+    module_name = PyArray_GetAttrString_SuppressException(
+        (PyObject*) Py_TYPE(obj),
+        "__module__");
+    if (module_name == NULL) {
+        goto done;
+    }
+    if (PyBytes_CheckExact(module_name)) {
+        contents = PyBytes_AS_STRING(module_name);
+    }
+#if PY_VERSION_HEX >= 0x03020000
+    else if (PyUnicode_CheckExact(module_name)) {
+#if (PY_VERSION_HEX >= 0x03020000) && (PY_VERSION_HEX < 0x03030000)
+        /* Python 3.2: unicode, but old API */
+        bytes = PyUnicode_AsLatin1String(module_name);
+        if (bytes == NULL) {
+            PyErr_Clear();
+            goto done;
+        }
+        contents = PyString_AS_STRING(bytes);
+#endif /* cpython == 3.2.x */
+#if PY_VERSION_HEX >= 0x03030000
+        /* Python 3.3+: new unicode API */
+        if (PyUnicode_READY(module_name) < 0) {
+            PyErr_Clear();
+            goto done;
+        }
+        /*
+         * We assume that scipy.sparse modules will always have ascii names
+         */
+        if (PyUnicode_KIND(module_name) != PyUnicode_1BYTE_KIND) {
+            goto done;
+        }
+        contents = (char*) PyUnicode_1BYTE_DATA(module_name);
+#endif /* cpython >= 3.3 */
+    }
+#endif /* cpython >= 3.2 */
+    else {
+        goto done;
+    }
+    if (strncmp("scipy.sparse", contents, 12) == 0) {
+        result = 1;
+    }
+
+  done:
+    Py_XDECREF(module_name);
+    Py_XDECREF(bytes);
+    return result;
+}
+
+static int
+binop_override_forward_binop_should_defer(PyObject *self, PyObject *other)
+{
+    /*
+     * This function assumes that self.__binop__(other) is underway and
+     * implements the rules described above. Python's C API is funny, and
+     * makes it tricky to tell whether a given slot is called for __binop__
+     * ("forward") or __rbinop__ ("reversed"). You are responsible for
+     * determining this before calling this function; it only provides the
+     * logic for forward binop implementations.
+     */
+
+    /*
+     * NB: there's another copy of this code in
+     *    numpy.ma.core.MaskedArray._delegate_binop
+     * which should possibly be updated when this is.
+     */
+
+    if (other == NULL ||
+        self == NULL ||
+        Py_TYPE(self) == Py_TYPE(other) ||
+        PyArray_CheckExact(other) ||
+        PyArray_CheckAnyScalar(other)) {
+        /*
+         * Quick cases
+         */
+        return 0;
+    }
+
+    /*
+     * Classes with __numpy_ufunc__ are living in the future, and don't need
+     * a check for the legacy __array_priority__. And if other.__class__ is a
+     * subtype of self.__class__, then it's already had a chance to run, so no
+     * need to defer to it.
+     */
+    if (!binop_override_has_ufunc_attr(other) &&
+        !PyType_IsSubtype(Py_TYPE(other), Py_TYPE(self))) {
+        double self_prio = PyArray_GetPriority((PyObject *)self,
+                                               NPY_SCALAR_PRIORITY);
+        double other_prio = PyArray_GetPriority((PyObject *)other,
+                                                NPY_SCALAR_PRIORITY);
+        if (self_prio < other_prio) {
+            return 1;
+        }
+    }
+    if (binop_override_is_scipy_sparse(other)) {
+        /* Special case grandfathering in scipy.sparse */
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
+ * A CPython slot like ->tp_as_number->nb_add gets called for *both* forward
+ * and reversed operations. E.g.
+ *   a + b
+ * may call
+ *   a->tp_as_number->nb_add(a, b)
+ * and
+ *   b + a
+ * may call
+ *   a->tp_as_number->nb_add(b, a)
+ * and the only way to tell which is which is for a slot implementation 'f' to
+ * check
+ *   arg1->tp_as_number->nb_add == f
+ *   arg2->tp_as_number->nb_add == f
+ * If both are true, then CPython will as a special case only call the
+ * operation once (i.e., it performs both the forward and reversed binops
+ * simultaneously). This function is mostly intended for figuring out
+ * whether we are a forward binop that might want to return NotImplemented,
+ * and in the both-at-once case we never want to return NotImplemented, so in
+ * that case BINOP_IS_FORWARD returns false.
+ *
+ * This is modeled on the checks in CPython's typeobject.c SLOT1BINFULL
+ * macro.
+ */
+#define BINOP_IS_FORWARD(m1, m2, SLOT_NAME, test_func)  \
+    (Py_TYPE(m2)->tp_as_number != NULL &&                               \
+     (void*)(Py_TYPE(m2)->tp_as_number->SLOT_NAME) != (void*)(test_func))
+
+#define BINOP_GIVE_UP_IF_NEEDED(m1, m2, slot_expr, test_func)           \
+    do {                                                                \
+        if (BINOP_IS_FORWARD(m1, m2, slot_expr, test_func) &&           \
+            binop_override_forward_binop_should_defer((PyObject*)m1, (PyObject*)m2)) { \
+            Py_INCREF(Py_NotImplemented);                               \
+            return Py_NotImplemented;                                   \
+        }                                                               \
+    } while (0)
+
+/*
+ * For rich comparison operations, it's impossible to distinguish
+ * between a forward comparison and a reversed/reflected
+ * comparison. So we assume they are all forward. This only works because the
+ * logic in binop_override_forward_binop_should_defer is essentially
+ * asymmetric -- you can never have two duck-array types that each decide to
+ * defer to the other.
+ */
+#define RICHCMP_GIVE_UP_IF_NEEDED(m1, m2)                               \
+    do {                                                                \
+        if (binop_override_forward_binop_should_defer((PyObject*)m1, (PyObject*)m2)) { \
+            Py_INCREF(Py_NotImplemented);                               \
+            return Py_NotImplemented;                                   \
+        }                                                               \
+    } while (0)
+
+#endif

--- a/numpy/core/src/private/get_attr_string.h
+++ b/numpy/core/src/private/get_attr_string.h
@@ -1,0 +1,85 @@
+#ifndef __GET_ATTR_STRING_H
+#define __GET_ATTR_STRING_H
+
+static NPY_INLINE int
+_is_basic_python_type(PyObject * obj)
+{
+    if (obj == Py_None ||
+            PyBool_Check(obj) ||
+            /* Basic number types */
+#if !defined(NPY_PY3K)
+            PyInt_CheckExact(obj) ||
+            PyString_CheckExact(obj) ||
+#endif
+            PyLong_CheckExact(obj) ||
+            PyFloat_CheckExact(obj) ||
+            PyComplex_CheckExact(obj) ||
+            /* Basic sequence types */
+            PyList_CheckExact(obj) ||
+            PyTuple_CheckExact(obj) ||
+            PyDict_CheckExact(obj) ||
+            PyAnySet_CheckExact(obj) ||
+            PyUnicode_CheckExact(obj) ||
+            PyBytes_CheckExact(obj) ||
+            PySlice_Check(obj)) {
+
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
+ * PyArray_GetAttrString_SuppressException:
+ *
+ * Stripped down version of PyObject_GetAttrString,
+ * avoids lookups for None, tuple, and List objects,
+ * and doesn't create a PyErr since this code ignores it.
+ *
+ * This can be much faster then PyObject_GetAttrString where
+ * exceptions are not used by caller.
+ *
+ * 'obj' is the object to search for attribute.
+ *
+ * 'name' is the attribute to search for.
+ *
+ * Returns attribute value on success, 0 on failure.
+ */
+static PyObject *
+PyArray_GetAttrString_SuppressException(PyObject *obj, char *name)
+{
+    PyTypeObject *tp = Py_TYPE(obj);
+    PyObject *res = (PyObject *)NULL;
+
+    /* We do not need to check for special attributes on trivial types */
+    if (_is_basic_python_type(obj)) {
+        return NULL;
+    }
+
+    /* Attribute referenced by (char *)name */
+    if (tp->tp_getattr != NULL) {
+        res = (*tp->tp_getattr)(obj, name);
+        if (res == NULL) {
+            PyErr_Clear();
+        }
+    }
+    /* Attribute referenced by (PyObject *)name */
+    else if (tp->tp_getattro != NULL) {
+#if defined(NPY_PY3K)
+        PyObject *w = PyUnicode_InternFromString(name);
+#else
+        PyObject *w = PyString_InternFromString(name);
+#endif
+        if (w == NULL) {
+            return (PyObject *)NULL;
+        }
+        res = (*tp->tp_getattro)(obj, w);
+        Py_DECREF(w);
+        if (res == NULL) {
+            PyErr_Clear();
+        }
+    }
+    return res;
+}
+
+#endif

--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -6,6 +6,8 @@
 #include <string.h>
 #include "numpy/ufuncobject.h"
 
+#include "get_attr_string.h"
+
 static void
 normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
                     PyObject **normal_args, PyObject **normal_kwds,
@@ -213,16 +215,11 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     }
 
     for (i = 0; i < nargs; ++i) {
+        PyObject *tmp;
         obj = PyTuple_GET_ITEM(args, i);
-        /*
-         * TODO: could use PyArray_GetAttrString_SuppressException if it
-         * weren't private to multiarray.so
-         */
-        if (PyArray_CheckExact(obj) || PyArray_IsScalar(obj, Generic) ||
-            _is_basic_python_type(obj)) {
-            continue;
-        }
-        if (PyObject_HasAttrString(obj, "__numpy_ufunc__")) {
+        tmp = PyArray_GetAttrString_SuppressException(obj, "__numpy_ufunc__");
+        if (tmp) {
+            Py_DECREF(tmp);
             with_override[noa] = obj;
             with_override_pos[noa] = i;
             ++noa;

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -24,6 +24,8 @@
 #include "numpy/halffloat.h"
 #include "templ_common.h"
 
+#include "binop_override.h"
+
 /* Basic operations:
  *
  *  BINARY:
@@ -795,6 +797,8 @@ static PyObject *
     int first;
 #endif
 
+    BINOP_GIVE_UP_IF_NEEDED(a, b, nb_@oper@, @name@_@oper@);
+
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
             break;
@@ -929,6 +933,8 @@ static PyObject *
     int first;
     @type@ out = {@zero@, @zero@};
 
+    BINOP_GIVE_UP_IF_NEEDED(a, b, nb_power, @name@_power);
+
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
             break;
@@ -1002,6 +1008,8 @@ static PyObject *
     int first;
     @type@ out = @zero@;
     @otype@ out1 = @zero@;
+
+    BINOP_GIVE_UP_IF_NEEDED(a, b, nb_power, @name@_power);
 
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
@@ -1088,6 +1096,9 @@ static PyObject *
     int first;
 
     @type@ out = @zero@;
+
+    BINOP_GIVE_UP_IF_NEEDED(a, b, nb_power, @name@_power);
+
     switch(_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
         case 0:
             break;
@@ -1484,6 +1495,8 @@ static PyObject*
 {
     npy_@name@ arg1, arg2;
     int out=0;
+
+    RICHCMP_GIVE_UP_IF_NEEDED(self, other);
 
     switch(_@name@_convert2_to_ctypes(self, &arg1, other, &arg2)) {
     case 0:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2242,222 +2242,179 @@ class TestBinop(object):
         assert_array_equal(l[4], np.ones(5))
         assert_array_equal(res, l[4] + l[4])
 
-    def test_ufunc_override_rop_precedence(self):
-        # Check that __rmul__ and other right-hand operations have
-        # precedence over __numpy_ufunc__
+    # ndarray.__rop__ always calls ufunc
+    # ndarray.__iop__ always calls ufunc
+    # ndarray.__op__:
+    #   - if other has __numpy_ufunc__, call ufunc
+    #   - else, if other is not a subclass and has higher array priority, defer
+    #   - else, if other is in scipy.sparse, defer
+    #   - else, call ufunc
 
+    def test_ufunc_binop_interaction(self):
+        # Python method name (without underscores)
+        #   -> (numpy ufunc, has_in_place_version, preferred_dtype)
         ops = {
-            '__add__':      ('__radd__', np.add, True),
-            '__sub__':      ('__rsub__', np.subtract, True),
-            '__mul__':      ('__rmul__', np.multiply, True),
-            '__truediv__':  ('__rtruediv__', np.true_divide, True),
-            '__floordiv__': ('__rfloordiv__', np.floor_divide, True),
-            '__mod__':      ('__rmod__', np.remainder, True),
-            '__divmod__':   ('__rdivmod__', None, False),
-            '__pow__':      ('__rpow__', np.power, True),
-            '__lshift__':   ('__rlshift__', np.left_shift, True),
-            '__rshift__':   ('__rrshift__', np.right_shift, True),
-            '__and__':      ('__rand__', np.bitwise_and, True),
-            '__xor__':      ('__rxor__', np.bitwise_xor, True),
-            '__or__':       ('__ror__', np.bitwise_or, True),
-            '__ge__':       ('__le__', np.less_equal, False),
-            '__gt__':       ('__lt__', np.less, False),
-            '__le__':       ('__ge__', np.greater_equal, False),
-            '__lt__':       ('__gt__', np.greater, False),
-            '__eq__':       ('__eq__', np.equal, False),
-            '__ne__':       ('__ne__', np.not_equal, False),
+            'add':      (np.add, True, float),
+            'sub':      (np.subtract, True, float),
+            'mul':      (np.multiply, True, float),
+            'truediv':  (np.true_divide, True, float),
+            'floordiv': (np.floor_divide, True, float),
+            'mod':      (np.remainder, True, float),
+            'divmod':   (None, False, float),
+            'pow':      (np.power, True, int),
+            'lshift':   (np.left_shift, True, int),
+            'rshift':   (np.right_shift, True, int),
+            'and':      (np.bitwise_and, True, int),
+            'xor':      (np.bitwise_xor, True, int),
+            'or':       (np.bitwise_or, True, int),
+            # 'ge':       (np.less_equal, False),
+            # 'gt':       (np.less, False),
+            # 'le':       (np.greater_equal, False),
+            # 'lt':       (np.greater, False),
+            # 'eq':       (np.equal, False),
+            # 'ne':       (np.not_equal, False),
         }
 
-        class OtherNdarraySubclass(ndarray):
+        class Coerced(Exception):
             pass
+        def array_impl(self):
+            raise Coerced
+        def op_impl(self, other):
+            return "forward"
+        def rop_impl(self, other):
+            return "reverse"
+        def iop_impl(self, other):
+            return "in-place"
 
-        class OtherNdarraySubclassWithOverride(ndarray):
-            def __numpy_ufunc__(self, *a, **kw):
-                raise AssertionError(("__numpy_ufunc__ %r %r shouldn't have "
-                                      "been called!") % (a, kw))
+        def numpy_ufunc_impl(self, ufunc, *args, **kwargs):
+            return ("__numpy_ufunc__", ufunc, args, kwargs)
 
-        def check(op_name, ndsubclass):
-            rop_name, np_op, has_iop = ops[op_name]
-
-            if has_iop:
-                iop_name = '__i' + op_name[2:]
-                iop = getattr(operator, iop_name)
-
-            if op_name == "__divmod__":
-                op = divmod
+        # Create an object with the given base, in the given module, with a
+        # bunch of placeholder __op__ methods, and optionally a
+        # __numpy_ufunc__ and __array_priority__.
+        def make_obj(base, array_priority, numpy_ufunc,
+                     alleged_module="__main__"):
+            class_namespace = {"__array__": array_impl}
+            if array_priority is not None:
+                class_namespace["__array_priority__"] = array_priority
+            for op in ops:
+                class_namespace["__{0}__".format(op)] = op_impl
+                class_namespace["__r{0}__".format(op)] = rop_impl
+                class_namespace["__i{0}__".format(op)] = iop_impl
+            if numpy_ufunc is not None:
+                class_namespace["__numpy_ufunc__"] = numpy_ufunc
+            eval_namespace = {"base": base,
+                              "class_namespace": class_namespace,
+                              "__name__": alleged_module,
+                              }
+            MyType = eval("type('MyType', (base,), class_namespace)",
+                          eval_namespace)
+            if issubclass(MyType, np.ndarray):
+                # Use this range to avoid special case weirdnesses around
+                # divide-by-0, pow(x, 2), overflow due to pow(big, big), etc.
+                return np.arange(3, 5).view(MyType)
             else:
-                op = getattr(operator, op_name)
+                return MyType()
 
-            # Dummy class
-            def __init__(self, *a, **kw):
-                pass
-
-            def __numpy_ufunc__(self, *a, **kw):
-                raise AssertionError(("__numpy_ufunc__ %r %r shouldn't have "
-                                      "been called!") % (a, kw))
-
-            def __op__(self, *other):
-                return "op"
-
-            def __rop__(self, *other):
-                return "rop"
-
-            if ndsubclass:
-                bases = (ndarray,)
-            else:
-                bases = (object,)
-
-            dct = {'__init__': __init__,
-                   '__numpy_ufunc__': __numpy_ufunc__,
-                   op_name: __op__}
-            if op_name != rop_name:
-                dct[rop_name] = __rop__
-
-            cls = type("Rop" + rop_name, bases, dct)
-
-            # Check behavior against both bare ndarray objects and a
-            # ndarray subclasses with and without their own override
-            obj = cls((1,), buffer=np.ones(1,))
-
-            arr_objs = [np.array([1]),
-                        np.array([2]).view(OtherNdarraySubclass),
-                        np.array([3]).view(OtherNdarraySubclassWithOverride),
-                        ]
-
-            for arr in arr_objs:
-                err_msg = "%r %r" % (op_name, arr,)
-
-                # Check that ndarray op gives up if it sees a non-subclass
-                if not isinstance(obj, arr.__class__):
-                    assert_equal(getattr(arr, op_name)(obj),
-                                 NotImplemented, err_msg=err_msg)
-
-                # Check that the Python binops have priority
-                assert_equal(op(obj, arr), "op", err_msg=err_msg)
-                if op_name == rop_name:
-                    assert_equal(op(arr, obj), "op", err_msg=err_msg)
-                else:
-                    assert_equal(op(arr, obj), "rop", err_msg=err_msg)
-
-                # Check that Python binops have priority also for in-place ops
-                if has_iop:
-                    assert_equal(getattr(arr, iop_name)(obj),
-                                 NotImplemented, err_msg=err_msg)
-                    if op_name != "__pow__":
-                        # inplace pow requires the other object to be
-                        # integer-like?
-                        assert_equal(iop(arr, obj), "rop", err_msg=err_msg)
-
-                # Check that ufunc call __numpy_ufunc__ normally
-                if np_op is not None:
-                    assert_raises(AssertionError, np_op, arr, obj,
-                                  err_msg=err_msg)
-                    assert_raises(AssertionError, np_op, obj, arr,
-                                  err_msg=err_msg)
-
-        # Check all binary operations
-        for op_name in sorted(ops.keys()):
-            yield check, op_name, True
-            yield check, op_name, False
-
-    def test_ufunc_override_rop_simple(self):
-        # Check parts of the binary op overriding behavior in an
-        # explicit test case that is easier to understand.
-        class SomeClass(object):
-            def __numpy_ufunc__(self, *a, **kw):
-                return "ufunc"
-            def __mul__(self, other):
-                return 123
-            def __rmul__(self, other):
-                return 321
-            def __rsub__(self, other):
-                return "no subs for me"
-            def __gt__(self, other):
-                return "yep"
-            def __lt__(self, other):
-                return "nope"
-
-        class SomeClass2(SomeClass, ndarray):
-            def __numpy_ufunc__(self, ufunc, method, i, inputs, **kw):
-                if ufunc is np.multiply or ufunc is np.bitwise_and:
-                    return "ufunc"
-                else:
-                    inputs = list(inputs)
-                    inputs[i] = np.asarray(self)
-                    func = getattr(ufunc, method)
-                    r = func(*inputs, **kw)
-                    if 'out' in kw:
-                        return r
+        def check(obj, binop_override_expected, ufunc_override_expected,
+                  check_scalar=True):
+            for op, (ufunc, has_inplace, dtype) in ops.items():
+                check_objs = [np.arange(3, 5, dtype=dtype)]
+                if check_scalar:
+                    check_objs.append(check_objs[0][0])
+                for arr in check_objs:
+                    arr_method = getattr(arr, "__{0}__".format(op))
+                    def norm(result):
+                        if op == "divmod":
+                            assert_(isinstance(result, tuple))
+                            return result[0]
+                        else:
+                            return result
+                    if binop_override_expected:
+                        assert_equal(arr_method(obj), NotImplemented)
+                    elif ufunc_override_expected:
+                        assert_equal(norm(arr_method(obj))[0],
+                                     "__numpy_ufunc__")
                     else:
-                        x = self.__class__(r.shape, dtype=r.dtype)
-                        x[...] = r
-                        return x
+                        if (isinstance(obj, np.ndarray)
+                            and not hasattr(obj, "__numpy_ufunc__")):
+                            # __array__ gets ignored
+                            res = norm(arr_method(obj))
+                            assert_(res.__class__ is obj.__class__)
+                        else:
+                            assert_raises((TypeError, Coerced),
+                                          arr_method, obj)
+                    arr_rmethod = getattr(arr, "__r{0}__".format(op))
+                    if ufunc_override_expected:
+                        res = norm(arr_rmethod(obj))
+                        assert_equal(res[0], "__numpy_ufunc__")
+                        if ufunc is not None:
+                            assert_equal(res[1], ufunc)
+                    else:
+                        if (isinstance(obj, np.ndarray) and
+                            not hasattr(obj, "__numpy_ufunc__")):
+                            # __array__ gets ignored
+                            res = norm(arr_rmethod(obj))
+                            assert_(res.__class__ is obj.__class__)
+                        else:
+                            # __numpy_ufunc__ = "asdf" creates a TypeError
+                            assert_raises((TypeError, Coerced),
+                                          arr_rmethod, obj)
+                    # array scalars don't have in-place operators
+                    if has_inplace and isinstance(arr, np.ndarray):
+                        arr_imethod = getattr(arr, "__i{0}__".format(op))
+                        if ufunc_override_expected:
+                            res = arr_imethod(obj)
+                            assert_equal(res[0], "__numpy_ufunc__")
+                            if ufunc is not None:
+                                assert_equal(res[1], ufunc)
+                                assert_(res[-1]["out"] is arr)
+                        else:
+                            if (isinstance(obj, np.ndarray) and
+                                not hasattr(obj, "__numpy_ufunc__")):
+                                # __array__ gets ignored
+                                assert_(arr_imethod(obj) is arr)
+                            else:
+                                assert_raises((TypeError, Coerced),
+                                              arr_imethod, obj)
 
-        class SomeClass3(SomeClass2):
-            def __rsub__(self, other):
-                return "sub for me"
+                    import operator
+                    op_fn = getattr(operator, op, None)
+                    if op_fn is None:
+                        op_fn = getattr(operator, op + "_", None)
+                    if op_fn is None:
+                        op_fn = getattr(builtins, op)
+                    assert_equal(op_fn(obj, arr), "forward")
+                    if not isinstance(obj, np.ndarray):
+                        if binop_override_expected:
+                            assert_equal(op_fn(arr, obj), "reverse")
+                        elif ufunc_override_expected:
+                            assert_equal(norm(op_fn(arr, obj))[0],
+                                         "__numpy_ufunc__")
+                    if ufunc_override_expected and ufunc is not None:
+                        assert_equal(norm(ufunc(obj, arr))[0],
+                                     "__numpy_ufunc__")
 
-        arr = np.array([0])
-        obj = SomeClass()
-        obj2 = SomeClass2((1,), dtype=np.int_)
-        obj2[0] = 9
-        obj3 = SomeClass3((1,), dtype=np.int_)
-        obj3[0] = 4
-
-        # obj is first, so should get to define outcome.
-        assert_equal(obj * arr, 123)
-        # obj is second, but has __numpy_ufunc__ and defines __rmul__.
-        assert_equal(arr * obj, 321)
-        # obj is second, but has __numpy_ufunc__ and defines __rsub__.
-        assert_equal(arr - obj, "no subs for me")
-        # obj is second, but has __numpy_ufunc__ and defines __lt__.
-        assert_equal(arr > obj, "nope")
-        # obj is second, but has __numpy_ufunc__ and defines __gt__.
-        assert_equal(arr < obj, "yep")
-        # Called as a ufunc, obj.__numpy_ufunc__ is used.
-        assert_equal(np.multiply(arr, obj), "ufunc")
-        # obj is second, but has __numpy_ufunc__ and defines __rmul__.
-        arr *= obj
-        assert_equal(arr, 321)
-
-        # obj2 is an ndarray subclass, so CPython takes care of the same rules.
-        assert_equal(obj2 * arr, 123)
-        assert_equal(arr * obj2, 321)
-        assert_equal(arr - obj2, "no subs for me")
-        assert_equal(arr > obj2, "nope")
-        assert_equal(arr < obj2, "yep")
-        # Called as a ufunc, obj2.__numpy_ufunc__ is called.
-        assert_equal(np.multiply(arr, obj2), "ufunc")
-        # Also when the method is not overridden.
-        assert_equal(arr & obj2, "ufunc")
-        arr *= obj2
-        assert_equal(arr, 321)
-
-        obj2 += 33
-        assert_equal(obj2[0], 42)
-        assert_equal(obj2.sum(), 42)
-        assert_(isinstance(obj2, SomeClass2))
-
-        # Obj3 is subclass that defines __rsub__.  CPython calls it.
-        assert_equal(arr - obj3, "sub for me")
-        assert_equal(obj2 - obj3, "sub for me")
-        # obj3 is a subclass that defines __rmul__.  CPython calls it.
-        assert_equal(arr * obj3, 321)
-        # But not here, since obj3.__rmul__ is obj2.__rmul__.
-        assert_equal(obj2 * obj3, 123)
-        # And of course, here obj3.__mul__ should be called.
-        assert_equal(obj3 * obj2, 123)
-        # obj3 defines __numpy_ufunc__ but obj3.__radd__ is obj2.__radd__.
-        # (and both are just ndarray.__radd__); see #4815.
-        res = obj2 + obj3
-        assert_equal(res, 46)
-        assert_(isinstance(res, SomeClass2))
-        # Since obj3 is a subclass, it should have precedence, like CPython
-        # would give, even though obj2 has __numpy_ufunc__ and __radd__.
-        # See gh-4815 and gh-5747.
-        res = obj3 + obj2
-        assert_equal(res, 46)
-        assert_(isinstance(res, SomeClass3))
+        # No array priority, no numpy ufunc -> nothing called
+        check(make_obj(object, None, None), False, False)
+        # Negative array priority, no numpy ufunc -> nothing called
+        # (has to be very negative, because scalar priority is -1000000.0)
+        check(make_obj(object, -2**30, None), False, False)
+        # Positive array priority, no numpy ufunc -> binops only
+        check(make_obj(object,  1, None), True, False)
+        # ndarray ignores array priority for ndarray subclasses
+        check(make_obj(np.ndarray, 1, None), False, False, check_scalar=False)
+        # Positive array priority and numpy ufunc -> numpy ufunc only
+        check(make_obj(object,  1, numpy_ufunc_impl), False, True)
+        check(make_obj(np.ndarray, 1, numpy_ufunc_impl), False, True)
+        # But a non-callable numpy_ufunc -> like no numpy_ufunc at all
+        check(make_obj(object,  1, "asdf"), True, False)
+        check(make_obj(np.ndarray, 1, "asdf"), False, False, check_scalar=False)
+        # Objects in scipy.sparse are special: for them we can do both binops
+        # and ufunc:
+        check(make_obj(object,  1, numpy_ufunc_impl,
+                       alleged_module="scipy.sparse"),
+              True, True)
 
     def test_ufunc_override_normalize_signature(self):
         # gh-5674

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3690,12 +3690,15 @@ class MaskedArray(ndarray):
 
     def _delegate_binop(self, other):
         # This emulates the logic in
-        #     multiarray/number.c:PyArray_GenericBinaryFunction
-        if (not isinstance(other, np.ndarray)
-            and not hasattr(other, "__numpy_ufunc__")):
+        #     private/binop_override.h:forward_binop_should_defer
+        if isinstance(other, type(self)):
+            return False
+        if not hasattr(other, "__numpy_ufunc__"):
             other_priority = getattr(other, "__array_priority__", -1000000)
             if self.__array_priority__ < other_priority:
                 return True
+        if other.__class__.__module__.startswith("scipy.sparse"):
+            return True
         return False
 
     def __eq__(self, other):


### PR DESCRIPTION
[Posting this now for any feedback, though it still needs some work to sort out scalar handling -- CC @pv @mhvk @shoyer @charris]

As per the discussion at gh-5844, and in particular
   https://github.com/numpy/numpy/issues/5844#issuecomment-112014014
this commit switches binop dispatch to mostly defer to ufuncs, except
in some specific cases elaborated in a long comment in number.c.

This currently _fails_ on the following code from test_ufunc.py, which
creates an infinite loop and eats memory until killed:

```
class MyThing(object):
    __array_priority__ = 1000

    rmul_count = 0
    getitem_count = 0

    def __init__(self, shape):
        self.shape = shape

    def __len__(self):
        return self.shape[0]

    def __getitem__(self, i):
        MyThing.getitem_count += 1
        if not isinstance(i, tuple):
            i = (i,)
        if len(i) > len(self.shape):
            raise IndexError("boo")

        return MyThing(self.shape[len(i):])

    def __rmul__(self, other):
        MyThing.rmul_count += 1
        return self

np.float64(5) * MyThing((3, 3))

# Alternative, with same result:

np.float64(5) + MyThing((3, 3))
```

I don't yet really understand what is going on here. As far as I've
tracked it down:

np.float64.**add** is scalarmath.c.src:@oper@_@name@

  @oper@_@name@ calls _@name@_convert2_to_ctypes

```
_@name@_convert2_to_ctypes just calls _@name@_convert_to_ctype twice

_@name@_convert_to_ctype returns -1 or -2 on various error
  conditions that I don't fully understanding, including in
  particular a -2 if other.__array_priority__ > self.__array_priority__
```

  On -1 or -2 returns, @oper@_@name@ calls one of
    PyArray_Type.tp_as_number->nb_@oper@(a, b)
    PyGenericArrType_Type.tp_as_number->nb_@oper@(a, b)

  The latter is gentype_@name@, which for "add" just calls back to
    PyArray_Type.tp_as_number->nb_@name@
  so it should be equivalent. For some other cases, things are more
  complicated -- in particular gentype_multiply implements sequence
  multiplication, which looks suspicious given the definition of
  MyThing. Except we crash on float64 + MyThing as well, so that can't
  be it.

Actually, I guess the problem must be exactly that we _are_ deferring
to the ufunc; np.add(5, MyThing((3, 3))) also blows up. We shouldn't
be, though, because of the **array_priority**.

More after I wake up again...
