### PR TITLE
MAINT: eigenvalues returned by eigh are ascending

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -953,7 +953,7 @@ def eigvalsh(a, UPLO='L'):
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
-    The eigenvalues are computed using LAPACK routines _ssyevd, _heevd
+    The eigenvalues are computed using LAPACK routines _syevd, _heevd
 
     Examples
     --------
@@ -1176,7 +1176,7 @@ def eigh(a, UPLO='L'):
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
-    The eigenvalues/eigenvectors are computed using LAPACK routines _ssyevd,
+    The eigenvalues/eigenvectors are computed using LAPACK routines _syevd,
     _heevd
 
     The eigenvalues of real symmetric or complex Hermitian matrices are

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1151,7 +1151,8 @@ def eigh(a, UPLO='L'):
     Returns
     -------
     w : (..., M) ndarray
-        The eigenvalues, not necessarily ordered.
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
     v : {(..., M, M) ndarray, (..., M, M) matrix}
         The column ``v[:, i]`` is the normalized eigenvector corresponding
         to the eigenvalue ``w[i]``.  Will return a matrix object if `a` is

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -718,28 +718,27 @@ class TestEigvalsh(HermitianTestCase, HermitianGeneralizedTestCase):
 
         # Check default is 'L'
         w = np.linalg.eigvalsh(Klo)
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'L'
         w = np.linalg.eigvalsh(Klo, UPLO='L')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'l'
         w = np.linalg.eigvalsh(Klo, UPLO='l')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'U'
         w = np.linalg.eigvalsh(Kup, UPLO='U')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'u'
         w = np.linalg.eigvalsh(Kup, UPLO='u')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
 
 
 class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
     def do(self, a, b):
-        # note that eigenvalue arrays must be sorted since
+        # note that eigenvalue arrays returned by eig must be sorted since
         # their order isn't guaranteed.
         ev, evc = linalg.eigh(a)
         evalues, evectors = linalg.eig(a)
-        ev.sort(axis=-1)
         evalues.sort(axis=-1)
         assert_almost_equal(ev, evalues)
 
@@ -748,7 +747,6 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
                         rtol=get_rtol(ev.dtype))
 
         ev2, evc2 = linalg.eigh(a, 'U')
-        ev2.sort(axis=-1)
         assert_almost_equal(ev2, evalues)
 
         assert_allclose(dot_generalized(a, evc2),
@@ -778,19 +776,19 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
 
         # Check default is 'L'
         w, v = np.linalg.eigh(Klo)
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'L'
         w, v = np.linalg.eigh(Klo, UPLO='L')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'l'
         w, v = np.linalg.eigh(Klo, UPLO='l')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'U'
         w, v = np.linalg.eigh(Kup, UPLO='U')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
         # Check 'u'
         w, v = np.linalg.eigh(Kup, UPLO='u')
-        assert_allclose(np.sort(w), tgt, rtol=rtol)
+        assert_allclose(w, tgt, rtol=rtol)
 
 
 class _TestNorm(object):


### PR DESCRIPTION
The scipy docstrings say that eigvalsh and eigh use LAPACK syevd and heevd, and according to the netlib reference these LAPACK functions return eigenvalues in ascending order.
Related: https://github.com/numpy/numpy/pull/5988.
