### PR TITLE
DOC: Document bogus stride fix for release.

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -261,13 +261,14 @@ There are three steps to the process.
 2. If the C_API_VERSION in the first step has changed, or if the hash of
    the API has changed, the cversions.txt file needs to be updated. To check
    the hash, run the script numpy/core/cversions.py and note the api hash that
-   is printed. If that hash does not match the last hash in cversions.txt the
-   hash has changed. Using both the appropriate C_API_VERSION and hash, add a
-   new entry to numpy/core/code_generators/cversions.txt. If the API version
-   was not changed, but the hash differs, you will need to comment out the
-   previous entry for that API version. For instance, in NumPy 1.9 annotations
-   were added, which changed the hash, but the API was the same as in 1.8. The
-   hash serves as a check for API changes, but it is not definitive.
+   is printed. If that hash does not match the last hash in
+   numpy/core/code_generators/cversions.txt the hash has changed. Using both
+   the appropriate C_API_VERSION and hash, add a new entry to cversions.txt.
+   If the API version was not changed, but the hash differs, you will need to
+   comment out the previous entry for that API version. For instance, in NumPy
+   1.9 annotations were added, which changed the hash, but the API was the
+   same as in 1.8. The hash serves as a check for API changes, but it is not
+   definitive.
 
    If steps 1 and 2 are done correctly, compiling the release should not give
    a warning "API mismatch detect at the beginning of the build.

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -310,6 +310,13 @@ Now, set ``release=True`` in setup.py, then
     git tag <version>
     git push origin <version>
 
+Apply patch to fix bogus strides
+--------------------------------
+NPY_RELAXED_STRIDE_CHECKING was made the default in Numpy 1.10 and bogus
+strides are used in the development branch to smoke out problems. The
+`patch <https://github.com/numpy/numpy/pull/5996>`_ should be updated if
+necessary and applied to the release branch to rationalize the strides.
+
 Update the version of the master branch
 ---------------------------------------
 Increment the release number in setup.py. Release candidates should have "rc1"


### PR DESCRIPTION
Add an explanation and a patch link in doc/HOWTO_RELEASE.rst.txt.

[ci skip]
