### PR TITLE
MAINT: remove redundant sorting of eigenvalues

### DIFF
--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1734,7 +1734,6 @@ def hermgauss(deg):
     c = np.array([0]*deg + [1], dtype=np.float64)
     m = hermcompanion(c)
     x = la.eigvalsh(m)
-    x.sort()
 
     # improve roots by one application of Newton
     dy = _normed_hermite_n(x, ideg)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1732,7 +1732,6 @@ def hermegauss(deg):
     c = np.array([0]*deg + [1])
     m = hermecompanion(c)
     x = la.eigvalsh(m)
-    x.sort()
 
     # improve roots by one application of Newton
     dy = _normed_hermite_e_n(x, ideg)


### PR DESCRIPTION
np.linalg.eigvalsh returns an array sorted in ascending order, so it does not need to be sorted again
