### PR TITLE
Revert "ENH: cache dtype.__hash__"

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -86,9 +86,6 @@ C API
 The changes to *swapaxes* also apply to the *PyArray_SwapAxes* C function,
 which now returns a view in all cases.
 
-The dtype structure (PyArray_Descr) has a new member at the end to cache
-its hash value.  This shouldn't affect any well-written applications.
-
 The change to the concatenation function DeprecationWarning also affects
 PyArray_ConcatenateArrays,
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -619,10 +619,6 @@ typedef struct _PyArray_Descr {
          * for NumPy 1.7.0.
          */
         NpyAuxData *c_metadata;
-        /* Cached hash value (-1 if not yet computed).
-         * This was added for NumPy 2.0.0.
-         */
-        npy_hash_t hash;
 } PyArray_Descr;
 
 typedef struct _arr_descr {

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -441,6 +441,19 @@ NpyCapsule_Check(PyObject *ptr)
 
 #endif
 
+/*
+ * Hash value compatibility.
+ * As of Python 3.2 hash values are of type Py_hash_t.
+ * Previous versions use C long.
+ */
+#if PY_VERSION_HEX < 0x03020000
+typedef long npy_hash_t;
+#define NPY_SIZEOF_HASH_T NPY_SIZEOF_LONG
+#else
+typedef Py_hash_t npy_hash_t;
+#define NPY_SIZEOF_HASH_T NPY_SIZEOF_INTP
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -317,19 +317,6 @@ typedef float npy_float;
 typedef double npy_double;
 
 /*
- * Hash value compatibility.
- * As of Python 3.2 hash values are of type Py_hash_t.
- * Previous versions use C long.
- */
-#if PY_VERSION_HEX < 0x03020000
-typedef long npy_hash_t;
-#define NPY_SIZEOF_HASH_T NPY_SIZEOF_LONG
-#else
-typedef Py_hash_t npy_hash_t;
-#define NPY_SIZEOF_HASH_T NPY_SIZEOF_INTP
-#endif
-
-/*
  * Disabling C99 complex usage: a lot of C code in numpy/scipy rely on being
  * able to do .real/.imag. Will have to convert code first.
  */

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4032,8 +4032,6 @@ static PyArray_Descr @from@_Descr = {
     NULL,
     /* c_metadata */
     NULL,
-    /* hash */
-    -1,
 };
 
 /**end repeat**/
@@ -4175,8 +4173,6 @@ NPY_NO_EXPORT PyArray_Descr @from@_Descr = {
     NULL,
     /* c_metadata */
     NULL,
-    /* hash */
-    -1,
 };
 
 /**end repeat**/

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1603,7 +1603,6 @@ PyArray_DescrNew(PyArray_Descr *base)
     }
     Py_XINCREF(newdescr->typeobj);
     Py_XINCREF(newdescr->metadata);
-    newdescr->hash = -1;
 
     return newdescr;
 }
@@ -2009,8 +2008,6 @@ arraydescr_names_set(PyArray_Descr *self, PyObject *val)
             return -1;
         }
     }
-    /* Invalidate cached hash value */
-    self->hash = -1;
     /* Update dictionary keys in fields */
     new_names = PySequence_Tuple(val);
     new_fields = PyDict_New();
@@ -2459,8 +2456,6 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
                      version);
         return NULL;
     }
-    /* Invalidate cached hash value */
-    self->hash = -1;
 
     if (version == 1 || version == 0) {
         if (fields != Py_None) {

--- a/numpy/core/src/multiarray/hashdescr.c
+++ b/numpy/core/src/multiarray/hashdescr.c
@@ -299,6 +299,7 @@ PyArray_DescrHash(PyObject* odescr)
 {
     PyArray_Descr *descr;
     int st;
+    npy_hash_t hash;
 
     if (!PyArray_DescrCheck(odescr)) {
         PyErr_SetString(PyExc_ValueError,
@@ -307,12 +308,10 @@ PyArray_DescrHash(PyObject* odescr)
     }
     descr = (PyArray_Descr*)odescr;
 
-    if (descr->hash == -1) {
-        st = _PyArray_DescrHashImp(descr, &descr->hash);
-        if (st) {
-            return -1;
-        }
+    st = _PyArray_DescrHashImp(descr, &hash);
+    if (st) {
+        return -1;
     }
 
-    return descr->hash;
+    return hash;
 }

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -122,21 +122,6 @@ class TestRecord(TestCase):
                       'titles': ['RRed pixel', 'Blue pixel']})
         assert_dtype_not_equal(a, b)
 
-    def test_mutate(self):
-        # Mutating a dtype should reset the cached hash value
-        a = np.dtype([('yo', np.int)])
-        b = np.dtype([('yo', np.int)])
-        c = np.dtype([('ye', np.int)])
-        assert_dtype_equal(a, b)
-        assert_dtype_not_equal(a, c)
-        a.names = ['ye']
-        assert_dtype_equal(a, c)
-        assert_dtype_not_equal(a, b)
-        state = b.__reduce__()[2]
-        a.__setstate__(state)
-        assert_dtype_equal(a, b)
-        assert_dtype_not_equal(a, c)
-
     def test_not_lists(self):
         """Test if an appropriate exception is raised when passing bad values to
         the dtype constructor.


### PR DESCRIPTION
The type hash is a marginal micro optimization only useful to tiny
subset of users. As currently implemented it is not worth the minor ABI
break. We should not let that slide anymore else we may turn the dtype
object into the same poor state as the ufunc object.

This reverts commit cca2c1a4fecfa5533b5579204c5f28a12c5b078a.
