### PR TITLE
MAINT: add 'nightly' (= 3.5ish) to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 2.7
   - 3.2
   - 3.3
+  - nightly
 matrix:
   include:
     - python: 3.3


### PR DESCRIPTION
Not sure if this works, but it's [documented](http://docs.travis-ci.com/user/languages/python/#Nightly-build-support) as being [recently added](https://twitter.com/travisci/status/573899818336129024) so let's see what Travis makes of this PR.
