### PR TITLE
MAINT: remove use of 'raise StopIteration' from generators

### DIFF
--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -182,7 +182,7 @@ class Arrayterator(object):
     def __iter__(self):
         # Skip arrays with degenerate dimensions
         if [dim for dim in self.shape if dim <= 0]:
-            raise StopIteration
+            return
 
         start = self.start[:]
         stop = self.stop[:]
@@ -223,4 +223,4 @@ class Arrayterator(object):
                     start[i] = self.start[i]
                     start[i-1] += self.step[i-1]
             if start[0] >= self.stop[0]:
-                raise StopIteration
+                return


### PR DESCRIPTION
This triggers a PendingDeprecationWarning in py3.5 -- you're supposed
to just write "return" instead (which on earlier versions is
equivalent). See PEP 479: https://www.python.org/dev/peps/pep-0479/
