### PR TITLE
MAINT: filter out some warnings triggered by nose 1.3.7 + python 3.5b2

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -425,6 +425,12 @@ class NoseTester(object):
             # older versions of scipy to test without a flood of messages.
             warnings.filterwarnings("ignore", message=".*boolean negative.*")
             warnings.filterwarnings("ignore", message=".*boolean subtract.*")
+            # Filter out some deprecation warnings inside nose 1.3.7 when run
+            # on python 3.5b2. See
+            #     https://github.com/nose-devs/nose/issues/929
+            warnings.filterwarnings("ignore", message=".*getargspec.*",
+                                    category=DeprecationWarning,
+                                    module="nose\.")
 
             from .noseclasses import NumpyTestProgram
 


### PR DESCRIPTION
Filed upstream as:
    https://github.com/nose-devs/nose/issues/929
Not our problem.

[Not 100% sure if we want this, but for now it's necessary if we want to run any kind of automated tests on 3.5. Which seems like a useful thing to be able to do between now and release.]
