### PR TITLE
ENH: improve string representation of NaTs in timedelta64 arrays

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -530,6 +530,17 @@ class TestDateTime(TestCase):
         a = np.array(['2010', 'NaT', '2030']).astype('M')
         assert_equal(str(a), "['2010' 'NaT' '2030']")
 
+    def test_timedelta_array_str(self):
+        a = np.array([-1, 0, 100], dtype='m')
+        assert_equal(str(a), "[ -1   0 100]")
+        a = np.array(['NaT', 'NaT'], dtype='m')
+        assert_equal(str(a), "['NaT' 'NaT']")
+        # Check right-alignment with NaTs
+        a = np.array([-1, 'NaT', 0], dtype='m')
+        assert_equal(str(a), "[   -1 'NaT'     0]")
+        a = np.array([-1, 'NaT', 1234567], dtype='m')
+        assert_equal(str(a), "[     -1   'NaT' 1234567]")
+
     def test_pickle(self):
         # Check that pickle roundtripping works
         dt = np.dtype('M8[7D]')


### PR DESCRIPTION
Rather than representing them as "-9223372036854775808",
we now represent them as "'NaT'", as in datetime64 arrays.
Note this changes the numpy.core.arrayprint printer, not the builtin
printer.
