### PR TITLE
Documentation fixes.

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -147,14 +147,14 @@ Numpy provides several hooks that classes can customize:
    The value of this attribute is used to determine what type of
    object to return in situations where there is more than one
    possibility for the Python type of the returned object. Subclasses
-   inherit a default value of 1.0 for this attribute.
+   inherit a default value of 0.0 for this attribute.
 
 .. function:: class.__array__([dtype])
 
    If a class (ndarray subclass or not) having the :func:`__array__`
    method is used as the output object of an :ref:`ufunc
    <ufuncs.output-type>`, results will be written to the object
-   returned by :func:`__array__`. Similar conversion is done on 
+   returned by :func:`__array__`. Similar conversion is done on
    input arrays.
 
 

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -12,7 +12,7 @@ The Array Interface
 
    This page describes the numpy-specific API for accessing the contents of
    a numpy array from other C extensions. :pep:`3118` --
-   :cfunc:`The Revised Buffer Protocol <PyObject_GetBuffer>` introduces
+   :c:func:`The Revised Buffer Protocol <PyObject_GetBuffer>` introduces
    similar, standardized API to Python 2.6 and 3.0 for any extension
    module to use. Cython__'s buffer array support
    uses the :pep:`3118` API; see the `Cython numpy
@@ -67,7 +67,7 @@ This approach to the interface consists of the object having an
        could hold (a Python int is a C long). It is up to the code
        using this attribute to handle this appropriately; either by
        raising an error when overflow is possible, or by using
-       :cdata:`Py_LONG_LONG` as the C type for the shapes.
+       :c:data:`Py_LONG_LONG` as the C type for the shapes.
 
    **typestr** (required)
 
@@ -88,9 +88,9 @@ This approach to the interface consists of the object having an
        ``u``  Unsigned integer
        ``f``  Floating point
        ``c``  Complex floating point
-       ``O``  Object (i.e. the memory contains a pointer to :ctype:`PyObject`)
+       ``O``  Object (i.e. the memory contains a pointer to :c:type:`PyObject`)
        ``S``  String (fixed-length sequence of char)
-       ``U``  Unicode (fixed-length sequence of :ctype:`Py_UNICODE`)
+       ``U``  Unicode (fixed-length sequence of :c:type:`Py_UNICODE`)
        ``V``  Other (void \* -- each item is a fixed-size chunk of memory)
        =====  ================================================================
 
@@ -134,7 +134,7 @@ This approach to the interface consists of the object having an
        means the data area is read-only).
 
        This attribute can also be an object exposing the
-       :cfunc:`buffer interface <PyObject_AsCharBuffer>` which
+       :c:func:`buffer interface <PyObject_AsCharBuffer>` which
        will be used to share the data. If this key is not present (or
        returns :class:`None`), then memory sharing will be done
        through the buffer interface of the object itself.  In this
@@ -154,7 +154,7 @@ This approach to the interface consists of the object having an
        :const:`int` or :const:`long`). As with shape, the values may
        be larger than can be represented by a C "int" or "long"; the
        calling code should handle this appropiately, either by
-       raising an error, or by using :ctype:`Py_LONG_LONG` in C. The
+       raising an error, or by using :c:type:`Py_LONG_LONG` in C. The
        default is :const:`None` which implies a C-style contiguous
        memory buffer.  In this model, the last dimension of the array
        varies the fastest.  For example, the default strides tuple
@@ -195,13 +195,13 @@ C-struct access
 This approach to the array interface allows for faster access to an
 array using only one attribute lookup and a well-defined C-structure.
 
-.. cvar:: __array_struct__
+.. c:var:: __array_struct__
 
-   A :ctype:`PyCObject` whose :cdata:`voidptr` member contains a
-   pointer to a filled :ctype:`PyArrayInterface` structure.  Memory
-   for the structure is dynamically created and the :ctype:`PyCObject`
+   A :c:type: `PyCObject` whose :c:data:`voidptr` member contains a
+   pointer to a filled :c:type:`PyArrayInterface` structure.  Memory
+   for the structure is dynamically created and the :c:type:`PyCObject`
    is also created with an appropriate destructor so the retriever of
-   this attribute simply has to apply :cfunc:`Py_DECREF()` to the
+   this attribute simply has to apply :c:func:`Py_DECREF()` to the
    object returned by this attribute when it is finished.  Also,
    either the data needs to be copied out, or a reference to the
    object exposing this attribute must be held to ensure the data is
@@ -239,12 +239,12 @@ flag is present.
 .. admonition:: New since June 16, 2006:
 
    In the past most implementations used the "desc" member of the
-   :ctype:`PyCObject` itself (do not confuse this with the "descr" member of
-   the :ctype:`PyArrayInterface` structure above --- they are two separate
+   :c:type:`PyCObject` itself (do not confuse this with the "descr" member of
+   the :c:type:`PyArrayInterface` structure above --- they are two separate
    things) to hold the pointer to the object exposing the interface.
    This is now an explicit part of the interface.  Be sure to own a
-   reference to the object when the :ctype:`PyCObject` is created using
-   :ctype:`PyCObject_FromVoidPtrAndDesc`.
+   reference to the object when the :c:type:`PyCObject` is created using
+   :c:type:`PyCObject_FromVoidPtrAndDesc`.
 
 
 Type description examples

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -292,7 +292,6 @@ Array conversion
    ndarray.item
    ndarray.tolist
    ndarray.itemset
-   ndarray.setasflat
    ndarray.tostring
    ndarray.tobytes
    ndarray.tofile

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -133,13 +133,14 @@ memory block can be accessed by some combination of the indices.
 While a C-style and Fortran-style contiguous array, which has the corresponding
 flags set, can be addressed with the above strides, the actual strides may be
 different. This can happen in two cases:
-  1. If ``self.shape[k] == 1`` then for any legal index ``index[k] == 0``.
-     This means that in the formula for the offset
-     :math:`n_k = 0` and thus :math:`s_k n_k = 0` and the value of
-     :math:`s_k` `= self.strides[k]` is arbitrary.
-  2. If an array has no elements (``self.size == 0``) there is no legal index
-     and the strides are never used. Any array with no elements may be
-     considered C-style and Fortran-style contiguous.
+
+    1. If ``self.shape[k] == 1`` then for any legal index ``index[k] == 0``.
+       This means that in the formula for the offset :math:`n_k = 0` and thus
+       :math:`s_k n_k = 0` and the value of :math:`s_k` `= self.strides[k]` is
+       arbitrary.
+    2. If an array has no elements (``self.size == 0``) there is no legal
+       index and the strides are never used. Any array with no elements may be
+       considered C-style and Fortran-style contiguous.
 
 Point 1. means that ``self``and ``self.squeeze()`` always have the same
 contiguity and :term:`aligned` flags value. This also means that even a high

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -239,7 +239,6 @@ Other attributes
    ndarray.imag
    ndarray.flat
    ndarray.ctypes
-   __array_priority__
 
 
 .. _arrays.ndarray.array-interface:

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -65,15 +65,15 @@ Some of the scalar types are essentially equivalent to fundamental
 Python types and therefore inherit from them as well as from the
 generic array scalar type:
 
-====================  ====================
+====================  ================================
 Array scalar type     Related Python type
-====================  ====================
+====================  ================================
 :class:`int_`         :class:`IntType` (Python 2 only)
 :class:`float_`       :class:`FloatType`
 :class:`complex_`     :class:`ComplexType`
 :class:`str_`         :class:`StringType`
 :class:`unicode_`     :class:`UnicodeType`
-====================  ====================
+====================  ================================
 
 The :class:`bool_` data type is very similar to the Python
 :class:`BooleanType` but does not inherit from it because Python's
@@ -215,7 +215,7 @@ Attributes
 ==========
 
 The array scalar objects have an :obj:`array priority
-<__array_priority__>` of :cdata:`NPY_SCALAR_PRIORITY`
+<__array_priority__>` of :c:data:`NPY_SCALAR_PRIORITY`
 (-1,000,000.0). They also do not (yet) have a :attr:`ctypes <ndarray.ctypes>`
 attribute. Otherwise, they share the same attributes as arrays:
 

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -20,31 +20,31 @@ Array API
 Array structure and data access
 -------------------------------
 
-These macros all access the :ctype:`PyArrayObject` structure members. The input
-argument, arr, can be any :ctype:`PyObject *` that is directly interpretable
-as a :ctype:`PyArrayObject *` (any instance of the :cdata:`PyArray_Type` and its
+These macros all access the :c:type:`PyArrayObject` structure members. The input
+argument, arr, can be any :c:type:`PyObject *` that is directly interpretable
+as a :c:type:`PyArrayObject *` (any instance of the :c:data:`PyArray_Type` and its
 sub-types).
 
-.. cfunction:: int PyArray_NDIM(PyArrayObject *arr)
+.. c:function:: int PyArray_NDIM(PyArrayObject *arr)
 
     The number of dimensions in the array.
 
-.. cfunction:: npy_intp *PyArray_DIMS(PyArrayObject *arr)
+.. c:function:: npy_intp *PyArray_DIMS(PyArrayObject *arr)
 
     Returns a pointer to the dimensions/shape of the array. The
     number of elements matches the number of dimensions
     of the array.
 
-.. cfunction:: npy_intp *PyArray_SHAPE(PyArrayObject *arr)
+.. c:function:: npy_intp *PyArray_SHAPE(PyArrayObject *arr)
 
     .. versionadded:: 1.7
 
     A synonym for PyArray_DIMS, named to be consistent with the
     'shape' usage within Python.
 
-.. cfunction:: void *PyArray_DATA(PyArrayObject *arr)
+.. c:function:: void *PyArray_DATA(PyArrayObject *arr)
 
-.. cfunction:: char *PyArray_BYTES(PyArrayObject *arr)
+.. c:function:: char *PyArray_BYTES(PyArrayObject *arr)
 
     These two macros are similar and obtain the pointer to the
     data-buffer for the array. The first macro can (and should be)
@@ -53,94 +53,94 @@ sub-types).
     array then be sure you understand how to access the data in the
     array to avoid memory and/or alignment problems.
 
-.. cfunction:: npy_intp *PyArray_STRIDES(PyArrayObject* arr)
+.. c:function:: npy_intp *PyArray_STRIDES(PyArrayObject* arr)
 
     Returns a pointer to the strides of the array. The
     number of elements matches the number of dimensions
     of the array.
 
-.. cfunction:: npy_intp PyArray_DIM(PyArrayObject* arr, int n)
+.. c:function:: npy_intp PyArray_DIM(PyArrayObject* arr, int n)
 
     Return the shape in the *n* :math:`^{\textrm{th}}` dimension.
 
-.. cfunction:: npy_intp PyArray_STRIDE(PyArrayObject* arr, int n)
+.. c:function:: npy_intp PyArray_STRIDE(PyArrayObject* arr, int n)
 
     Return the stride in the *n* :math:`^{\textrm{th}}` dimension.
 
-.. cfunction:: PyObject *PyArray_BASE(PyArrayObject* arr)
+.. c:function:: PyObject *PyArray_BASE(PyArrayObject* arr)
 
     This returns the base object of the array. In most cases, this
     means the object which owns the memory the array is pointing at.
 
     If you are constructing an array using the C API, and specifying
-    your own memory, you should use the function :cfunc:`PyArray_SetBaseObject`
+    your own memory, you should use the function :c:func:`PyArray_SetBaseObject`
     to set the base to an object which owns the memory.
 
-    If the :cdata:`NPY_ARRAY_UPDATEIFCOPY` flag is set, it has a different
+    If the :c:data:`NPY_ARRAY_UPDATEIFCOPY` flag is set, it has a different
     meaning, namely base is the array into which the current array will
     be copied upon destruction. This overloading of the base property
     for two functions is likely to change in a future version of NumPy.
 
-.. cfunction:: PyArray_Descr *PyArray_DESCR(PyArrayObject* arr)
+.. c:function:: PyArray_Descr *PyArray_DESCR(PyArrayObject* arr)
 
     Returns a borrowed reference to the dtype property of the array.
 
-.. cfunction:: PyArray_Descr *PyArray_DTYPE(PyArrayObject* arr)
+.. c:function:: PyArray_Descr *PyArray_DTYPE(PyArrayObject* arr)
 
     .. versionadded:: 1.7
 
     A synonym for PyArray_DESCR, named to be consistent with the
     'dtype' usage within Python.
 
-.. cfunction:: void PyArray_ENABLEFLAGS(PyArrayObject* arr, int flags)
+.. c:function:: void PyArray_ENABLEFLAGS(PyArrayObject* arr, int flags)
 
     .. versionadded:: 1.7
 
     Enables the specified array flags. This function does no validation,
     and assumes that you know what you're doing.
 
-.. cfunction:: void PyArray_CLEARFLAGS(PyArrayObject* arr, int flags)
+.. c:function:: void PyArray_CLEARFLAGS(PyArrayObject* arr, int flags)
 
     .. versionadded:: 1.7
 
     Clears the specified array flags. This function does no validation,
     and assumes that you know what you're doing.
 
-.. cfunction:: int PyArray_FLAGS(PyArrayObject* arr)
+.. c:function:: int PyArray_FLAGS(PyArrayObject* arr)
 
-.. cfunction:: npy_intp PyArray_ITEMSIZE(PyArrayObject* arr)
+.. c:function:: npy_intp PyArray_ITEMSIZE(PyArrayObject* arr)
 
     Return the itemsize for the elements of this array.
 
     Note that, in the old API that was deprecated in version 1.7, this function
     had the return type ``int``.
 
-.. cfunction:: int PyArray_TYPE(PyArrayObject* arr)
+.. c:function:: int PyArray_TYPE(PyArrayObject* arr)
 
     Return the (builtin) typenumber for the elements of this array.
 
-.. cfunction:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
+.. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 
     Get a Python object from the ndarray, *arr*, at the location
     pointed to by itemptr. Return ``NULL`` on failure.
 
-.. cfunction:: int PyArray_SETITEM(PyArrayObject* arr, void* itemptr, PyObject* obj)
+.. c:function:: int PyArray_SETITEM(PyArrayObject* arr, void* itemptr, PyObject* obj)
 
     Convert obj and place it in the ndarray, *arr*, at the place
     pointed to by itemptr. Return -1 if an error occurs or 0 on
     success.
 
-.. cfunction:: npy_intp PyArray_SIZE(PyArrayObject* arr)
+.. c:function:: npy_intp PyArray_SIZE(PyArrayObject* arr)
 
     Returns the total size (in number of elements) of the array.
 
-.. cfunction:: npy_intp PyArray_Size(PyArrayObject* obj)
+.. c:function:: npy_intp PyArray_Size(PyArrayObject* obj)
 
     Returns 0 if *obj* is not a sub-class of bigndarray. Otherwise,
     returns the total number of elements in the array. Safer version
-    of :cfunc:`PyArray_SIZE` (*obj*).
+    of :c:func:`PyArray_SIZE` (*obj*).
 
-.. cfunction:: npy_intp PyArray_NBYTES(PyArrayObject* arr)
+.. c:function:: npy_intp PyArray_NBYTES(PyArrayObject* arr)
 
     Returns the total number of bytes consumed by the array.
 
@@ -154,27 +154,27 @@ when accessing the data in the array, however, if it is not in machine
 byte-order, misaligned, or not writeable. In other words, be sure to
 respect the state of the flags unless you know what you are doing, or
 have previously guaranteed an array that is writeable, aligned, and in
-machine byte-order using :cfunc:`PyArray_FromAny`. If you wish to handle all
+machine byte-order using :c:func:`PyArray_FromAny`. If you wish to handle all
 types of arrays, the copyswap function for each type is useful for
 handling misbehaved arrays. Some platforms (e.g. Solaris) do not like
 misaligned data and will crash if you de-reference a misaligned
 pointer. Other platforms (e.g. x86 Linux) will just work more slowly
 with misaligned data.
 
-.. cfunction:: void* PyArray_GetPtr(PyArrayObject* aobj, npy_intp* ind)
+.. c:function:: void* PyArray_GetPtr(PyArrayObject* aobj, npy_intp* ind)
 
     Return a pointer to the data of the ndarray, *aobj*, at the
     N-dimensional index given by the c-array, *ind*, (which must be
     at least *aobj* ->nd in size). You may want to typecast the
     returned pointer to the data type of the ndarray.
 
-.. cfunction:: void* PyArray_GETPTR1(PyArrayObject* obj, npy_intp i)
+.. c:function:: void* PyArray_GETPTR1(PyArrayObject* obj, npy_intp i)
 
-.. cfunction:: void* PyArray_GETPTR2(PyArrayObject* obj, npy_intp i, npy_intp j)
+.. c:function:: void* PyArray_GETPTR2(PyArrayObject* obj, npy_intp i, npy_intp j)
 
-.. cfunction:: void* PyArray_GETPTR3(PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k)
+.. c:function:: void* PyArray_GETPTR3(PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k)
 
-.. cfunction:: void* PyArray_GETPTR4(PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k, npy_intp l)
+.. c:function:: void* PyArray_GETPTR4(PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k, npy_intp l)
 
     Quick, inline access to the element at the given coordinates in
     the ndarray, *obj*, which must have respectively 1, 2, 3, or 4
@@ -191,7 +191,7 @@ Creating arrays
 From scratch
 ^^^^^^^^^^^^
 
-.. cfunction:: PyObject* PyArray_NewFromDescr(PyTypeObject* subtype, PyArray_Descr* descr, int nd, npy_intp* dims, npy_intp* strides, void* data, int flags, PyObject* obj)
+.. c:function:: PyObject* PyArray_NewFromDescr(PyTypeObject* subtype, PyArray_Descr* descr, int nd, npy_intp* dims, npy_intp* strides, void* data, int flags, PyObject* obj)
 
     This function steals a reference to *descr*.
 
@@ -199,31 +199,31 @@ From scratch
     created with this flexible function.
 
     The returned object is an object of Python-type *subtype*, which
-    must be a subtype of :cdata:`PyArray_Type`.  The array has *nd*
+    must be a subtype of :c:data:`PyArray_Type`.  The array has *nd*
     dimensions, described by *dims*. The data-type descriptor of the
     new array is *descr*.
 
     If *subtype* is of an array subclass instead of the base
-    :cdata:`&PyArray_Type`, then *obj* is the object to pass to
+    :c:data:`&PyArray_Type`, then *obj* is the object to pass to
     the :obj:`__array_finalize__` method of the subclass.
 
     If *data* is ``NULL``, then new memory will be allocated and *flags*
     can be non-zero to indicate a Fortran-style contiguous array. If
     *data* is not ``NULL``, then it is assumed to point to the memory
     to be used for the array and the *flags* argument is used as the
-    new flags for the array (except the state of :cdata:`NPY_OWNDATA`
-    and :cdata:`NPY_ARRAY_UPDATEIFCOPY` flags of the new array will
+    new flags for the array (except the state of :c:data:`NPY_OWNDATA`
+    and :c:data:`NPY_ARRAY_UPDATEIFCOPY` flags of the new array will
     be reset).
 
     In addition, if *data* is non-NULL, then *strides* can
     also be provided. If *strides* is ``NULL``, then the array strides
     are computed as C-style contiguous (default) or Fortran-style
     contiguous (*flags* is nonzero for *data* = ``NULL`` or *flags* &
-    :cdata:`NPY_ARRAY_F_CONTIGUOUS` is nonzero non-NULL *data*). Any
+    :c:data:`NPY_ARRAY_F_CONTIGUOUS` is nonzero non-NULL *data*). Any
     provided *dims* and *strides* are copied into newly allocated
     dimension and strides arrays for the new array object.
 
-.. cfunction:: PyObject* PyArray_NewLikeArray(PyArrayObject* prototype, NPY_ORDER order, PyArray_Descr* descr, int subok)
+.. c:function:: PyObject* PyArray_NewLikeArray(PyArrayObject* prototype, NPY_ORDER order, PyArray_Descr* descr, int subok)
 
     .. versionadded:: 1.6
 
@@ -233,10 +233,10 @@ From scratch
     a new array matching an existing array's shapes and memory layout,
     possibly changing the layout and/or data type.
 
-    When *order* is :cdata:`NPY_ANYORDER`, the result order is
-    :cdata:`NPY_FORTRANORDER` if *prototype* is a fortran array,
-    :cdata:`NPY_CORDER` otherwise.  When *order* is
-    :cdata:`NPY_KEEPORDER`, the result order matches that of *prototype*, even
+    When *order* is :c:data:`NPY_ANYORDER`, the result order is
+    :c:data:`NPY_FORTRANORDER` if *prototype* is a fortran array,
+    :c:data:`NPY_CORDER` otherwise.  When *order* is
+    :c:data:`NPY_KEEPORDER`, the result order matches that of *prototype*, even
     when the axes of *prototype* aren't in C or Fortran order.
 
     If *descr* is NULL, the data type of *prototype* is used.
@@ -245,9 +245,9 @@ From scratch
     *prototype* to create the new array, otherwise it will create a
     base-class array.
 
-.. cfunction:: PyObject* PyArray_New(PyTypeObject* subtype, int nd, npy_intp* dims, int type_num, npy_intp* strides, void* data, int itemsize, int flags, PyObject* obj)
+.. c:function:: PyObject* PyArray_New(PyTypeObject* subtype, int nd, npy_intp* dims, int type_num, npy_intp* strides, void* data, int itemsize, int flags, PyObject* obj)
 
-    This is similar to :cfunc:`PyArray_DescrNew` (...) except you
+    This is similar to :c:func:`PyArray_DescrNew` (...) except you
     specify the data-type descriptor with *type_num* and *itemsize*,
     where *type_num* corresponds to a builtin (or user-defined)
     type. If the type always has the same number of bytes, then
@@ -258,22 +258,22 @@ From scratch
 
 .. warning::
 
-    If data is passed to :cfunc:`PyArray_NewFromDescr` or :cfunc:`PyArray_New`,
+    If data is passed to :c:func:`PyArray_NewFromDescr` or :c:func:`PyArray_New`,
     this memory must not be deallocated until the new array is
     deleted.  If this data came from another Python object, this can
-    be accomplished using :cfunc:`Py_INCREF` on that object and setting the
+    be accomplished using :c:func:`Py_INCREF` on that object and setting the
     base member of the new array to point to that object. If strides
     are passed in they must be consistent with the dimensions, the
     itemsize, and the data of the array.
 
-.. cfunction:: PyObject* PyArray_SimpleNew(int nd, npy_intp* dims, int typenum)
+.. c:function:: PyObject* PyArray_SimpleNew(int nd, npy_intp* dims, int typenum)
 
     Create a new unitialized array of type, *typenum*, whose size in
     each of *nd* dimensions is given by the integer array, *dims*.
     This function cannot be used to create a flexible-type array (no
     itemsize given).
 
-.. cfunction:: PyObject* PyArray_SimpleNewFromData(int nd, npy_intp* dims, int typenum, void* data)
+.. c:function:: PyObject* PyArray_SimpleNewFromData(int nd, npy_intp* dims, int typenum, void* data)
 
     Create an array wrapper around *data* pointed to by the given
     pointer. The array flags will have a default that the data area is
@@ -281,60 +281,60 @@ From scratch
     given by the *dims* c-array of length *nd*. The data-type of the
     array is indicated by *typenum*.
 
-.. cfunction:: PyObject* PyArray_SimpleNewFromDescr(int nd, npy_intp* dims, PyArray_Descr* descr)
+.. c:function:: PyObject* PyArray_SimpleNewFromDescr(int nd, npy_intp* dims, PyArray_Descr* descr)
 
     This function steals a reference to *descr* if it is not NULL.
 
     Create a new array with the provided data-type descriptor, *descr*
     , of the shape deteremined by *nd* and *dims*.
 
-.. cfunction:: PyArray_FILLWBYTE(PyObject* obj, int val)
+.. c:function:: PyArray_FILLWBYTE(PyObject* obj, int val)
 
     Fill the array pointed to by *obj* ---which must be a (subclass
     of) bigndarray---with the contents of *val* (evaluated as a byte).
     This macro calls memset, so obj must be contiguous.
 
-.. cfunction:: PyObject* PyArray_Zeros(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
+.. c:function:: PyObject* PyArray_Zeros(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
 
     Construct a new *nd* -dimensional array with shape given by *dims*
     and data type given by *dtype*. If *fortran* is non-zero, then a
     Fortran-order array is created, otherwise a C-order array is
     created. Fill the memory with zeros (or the 0 object if *dtype*
-    corresponds to :ctype:`NPY_OBJECT` ).
+    corresponds to :c:type:`NPY_OBJECT` ).
 
-.. cfunction:: PyObject* PyArray_ZEROS(int nd, npy_intp* dims, int type_num, int fortran)
+.. c:function:: PyObject* PyArray_ZEROS(int nd, npy_intp* dims, int type_num, int fortran)
 
-    Macro form of :cfunc:`PyArray_Zeros` which takes a type-number instead
+    Macro form of :c:func:`PyArray_Zeros` which takes a type-number instead
     of a data-type object.
 
-.. cfunction:: PyObject* PyArray_Empty(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
+.. c:function:: PyObject* PyArray_Empty(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
 
     Construct a new *nd* -dimensional array with shape given by *dims*
     and data type given by *dtype*. If *fortran* is non-zero, then a
     Fortran-order array is created, otherwise a C-order array is
     created. The array is uninitialized unless the data type
-    corresponds to :ctype:`NPY_OBJECT` in which case the array is
-    filled with :cdata:`Py_None`.
+    corresponds to :c:type:`NPY_OBJECT` in which case the array is
+    filled with :c:data:`Py_None`.
 
-.. cfunction:: PyObject* PyArray_EMPTY(int nd, npy_intp* dims, int typenum, int fortran)
+.. c:function:: PyObject* PyArray_EMPTY(int nd, npy_intp* dims, int typenum, int fortran)
 
-    Macro form of :cfunc:`PyArray_Empty` which takes a type-number,
+    Macro form of :c:func:`PyArray_Empty` which takes a type-number,
     *typenum*, instead of a data-type object.
 
-.. cfunction:: PyObject* PyArray_Arange(double start, double stop, double step, int typenum)
+.. c:function:: PyObject* PyArray_Arange(double start, double stop, double step, int typenum)
 
     Construct a new 1-dimensional array of data-type, *typenum*, that
     ranges from *start* to *stop* (exclusive) in increments of *step*
     . Equivalent to **arange** (*start*, *stop*, *step*, dtype).
 
-.. cfunction:: PyObject* PyArray_ArangeObj(PyObject* start, PyObject* stop, PyObject* step, PyArray_Descr* descr)
+.. c:function:: PyObject* PyArray_ArangeObj(PyObject* start, PyObject* stop, PyObject* step, PyArray_Descr* descr)
 
     Construct a new 1-dimensional array of data-type determined by
     ``descr``, that ranges from ``start`` to ``stop`` (exclusive) in
     increments of ``step``. Equivalent to arange( ``start``,
     ``stop``, ``step``, ``typenum`` ).
 
-.. cfunction:: int PyArray_SetBaseObject(PyArrayObject* arr, PyObject* obj)
+.. c:function:: int PyArray_SetBaseObject(PyArrayObject* arr, PyObject* obj)
 
     .. versionadded:: 1.7
 
@@ -355,21 +355,21 @@ From scratch
 From other objects
 ^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: PyObject* PyArray_FromAny(PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, int requirements, PyObject* context)
+.. c:function:: PyObject* PyArray_FromAny(PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, int requirements, PyObject* context)
 
     This is the main function used to obtain an array from any nested
     sequence, or object that exposes the array interface, *op*. The
     parameters allow specification of the required *dtype*, the
     minimum (*min_depth*) and maximum (*max_depth*) number of
     dimensions acceptable, and other *requirements* for the array. The
-    *dtype* argument needs to be a :ctype:`PyArray_Descr` structure
+    *dtype* argument needs to be a :c:type:`PyArray_Descr` structure
     indicating the desired data-type (including required
     byteorder). The *dtype* argument may be NULL, indicating that any
     data-type (and byteorder) is acceptable. Unless ``FORCECAST`` is
     present in ``flags``, this call will generate an error if the data
     type cannot be safely obtained from the object. If you want to use
     ``NULL`` for the *dtype* and ensure the array is notswapped then
-    use :cfunc:`PyArray_CheckFromAny`. A value of 0 for either of the
+    use :c:func:`PyArray_CheckFromAny`. A value of 0 for either of the
     depth parameters causes the parameter to be ignored. Any of the
     following array flags can be added (*e.g.* using \|) to get the
     *requirements* argument. If your code can handle general (*e.g.*
@@ -377,7 +377,7 @@ From other objects
     may be 0. Also, if *op* is not already an array (or does not
     expose the array interface), then a new array will be created (and
     filled from *op* using the sequence protocol). The new array will
-    have :cdata:`NPY_DEFAULT` as its flags member. The *context* argument
+    have :c:data:`NPY_DEFAULT` as its flags member. The *context* argument
     is passed to the :obj:`__array__` method of *op* and is only used if
     the array is constructed that way. Almost always this
     parameter is ``NULL``.
@@ -386,50 +386,50 @@ From other objects
     did not have the _ARRAY_ macro namespace in them. That form
     of the constant names is deprecated in 1.7.
 
-    .. cvar:: NPY_ARRAY_C_CONTIGUOUS
+    .. c:var:: NPY_ARRAY_C_CONTIGUOUS
 
         Make sure the returned array is C-style contiguous
 
-    .. cvar:: NPY_ARRAY_F_CONTIGUOUS
+    .. c:var:: NPY_ARRAY_F_CONTIGUOUS
 
         Make sure the returned array is Fortran-style contiguous.
 
-    .. cvar:: NPY_ARRAY_ALIGNED
+    .. c:var:: NPY_ARRAY_ALIGNED
 
         Make sure the returned array is aligned on proper boundaries for its
         data type. An aligned array has the data pointer and every strides
         factor as a multiple of the alignment factor for the data-type-
         descriptor.
 
-    .. cvar:: NPY_ARRAY_WRITEABLE
+    .. c:var:: NPY_ARRAY_WRITEABLE
 
         Make sure the returned array can be written to.
 
-    .. cvar:: NPY_ARRAY_ENSURECOPY
+    .. c:var:: NPY_ARRAY_ENSURECOPY
 
         Make sure a copy is made of *op*. If this flag is not
         present, data is not copied if it can be avoided.
 
-    .. cvar:: NPY_ARRAY_ENSUREARRAY
+    .. c:var:: NPY_ARRAY_ENSUREARRAY
 
         Make sure the result is a base-class ndarray or bigndarray. By
         default, if *op* is an instance of a subclass of the
         bigndarray, an instance of that same subclass is returned. If
         this flag is set, an ndarray object will be returned instead.
 
-    .. cvar:: NPY_ARRAY_FORCECAST
+    .. c:var:: NPY_ARRAY_FORCECAST
 
         Force a cast to the output type even if it cannot be done
         safely.  Without this flag, a data cast will occur only if it
         can be done safely, otherwise an error is reaised.
 
-    .. cvar:: NPY_ARRAY_UPDATEIFCOPY
+    .. c:var:: NPY_ARRAY_UPDATEIFCOPY
 
         If *op* is already an array, but does not satisfy the
         requirements, then a copy is made (which will satisfy the
         requirements). If this flag is present and a copy (of an object
         that is already an array) must be made, then the corresponding
-        :cdata:`NPY_ARRAY_UPDATEIFCOPY` flag is set in the returned
+        :c:data:`NPY_ARRAY_UPDATEIFCOPY` flag is set in the returned
         copy and *op* is made to be read-only. When the returned copy
         is deleted (presumably after your calculations are complete),
         its contents will be copied back into *op* and the *op* array
@@ -437,59 +437,59 @@ From other objects
         with, then an error is raised. If *op* is not already an array,
         then this flag has no effect.
 
-    .. cvar:: NPY_ARRAY_BEHAVED
+    .. c:var:: NPY_ARRAY_BEHAVED
 
-        :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_WRITEABLE`
+        :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE`
 
-    .. cvar:: NPY_ARRAY_CARRAY
+    .. c:var:: NPY_ARRAY_CARRAY
 
-        :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_BEHAVED`
+        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-    .. cvar:: NPY_ARRAY_CARRAY_RO
+    .. c:var:: NPY_ARRAY_CARRAY_RO
 
-        :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. cvar:: NPY_ARRAY_FARRAY
+    .. c:var:: NPY_ARRAY_FARRAY
 
-        :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_BEHAVED`
+        :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-    .. cvar:: NPY_ARRAY_FARRAY_RO
+    .. c:var:: NPY_ARRAY_FARRAY_RO
 
-        :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+        :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. cvar:: NPY_ARRAY_DEFAULT
+    .. c:var:: NPY_ARRAY_DEFAULT
 
-        :cdata:`NPY_ARRAY_CARRAY`
+        :c:data:`NPY_ARRAY_CARRAY`
 
-    .. cvar:: NPY_ARRAY_IN_ARRAY
+    .. c:var:: NPY_ARRAY_IN_ARRAY
 
-        :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. cvar:: NPY_ARRAY_IN_FARRAY
+    .. c:var:: NPY_ARRAY_IN_FARRAY
 
-        :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+        :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. cvar:: NPY_OUT_ARRAY
+    .. c:var:: NPY_OUT_ARRAY
 
-        :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_WRITEABLE` \|
-        :cdata:`NPY_ARRAY_ALIGNED`
+        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+        :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. cvar:: NPY_ARRAY_OUT_FARRAY
+    .. c:var:: NPY_ARRAY_OUT_FARRAY
 
-        :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_WRITEABLE` \|
-        :cdata:`NPY_ARRAY_ALIGNED`
+        :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+        :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. cvar:: NPY_ARRAY_INOUT_ARRAY
+    .. c:var:: NPY_ARRAY_INOUT_ARRAY
 
-        :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_WRITEABLE` \|
-        :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_UPDATEIFCOPY`
+        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+        :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_UPDATEIFCOPY`
 
-    .. cvar:: NPY_ARRAY_INOUT_FARRAY
+    .. c:var:: NPY_ARRAY_INOUT_FARRAY
 
-        :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_WRITEABLE` \|
-        :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_UPDATEIFCOPY`
+        :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+        :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_UPDATEIFCOPY`
 
-.. cfunction:: int PyArray_GetArrayParamsFromObject(PyObject* op, PyArray_Descr* requested_dtype, npy_bool writeable, PyArray_Descr** out_dtype, int* out_ndim, npy_intp* out_dims, PyArrayObject** out_arr, PyObject* context)
+.. c:function:: int PyArray_GetArrayParamsFromObject(PyObject* op, PyArray_Descr* requested_dtype, npy_bool writeable, PyArray_Descr** out_dtype, int* out_ndim, npy_intp* out_dims, PyArrayObject** out_arr, PyObject* context)
 
     .. versionadded:: 1.6
 
@@ -552,11 +552,11 @@ From other objects
         }
         ... use arr ...
 
-.. cfunction:: PyObject* PyArray_CheckFromAny(PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, int requirements, PyObject* context)
+.. c:function:: PyObject* PyArray_CheckFromAny(PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, int requirements, PyObject* context)
 
-    Nearly identical to :cfunc:`PyArray_FromAny` (...) except
-    *requirements* can contain :cdata:`NPY_ARRAY_NOTSWAPPED` (over-riding the
-    specification in *dtype*) and :cdata:`NPY_ARRAY_ELEMENTSTRIDES` which
+    Nearly identical to :c:func:`PyArray_FromAny` (...) except
+    *requirements* can contain :c:data:`NPY_ARRAY_NOTSWAPPED` (over-riding the
+    specification in *dtype*) and :c:data:`NPY_ARRAY_ELEMENTSTRIDES` which
     indicates that the array should be aligned in the sense that the
     strides are multiples of the element size.
 
@@ -564,7 +564,7 @@ From other objects
     did not have the _ARRAY_ macro namespace in them. That form
     of the constant names is deprecated in 1.7.
 
-.. cvar:: NPY_ARRAY_NOTSWAPPED
+.. c:var:: NPY_ARRAY_NOTSWAPPED
 
     Make sure the returned array has a data-type descriptor that is in
     machine byte-order, over-riding any specification in the *dtype*
@@ -575,36 +575,36 @@ From other objects
     not in machine byte- order), then a new data-type descriptor is
     created and used with its byte-order field set to native.
 
-.. cvar:: NPY_ARRAY_BEHAVED_NS
+.. c:var:: NPY_ARRAY_BEHAVED_NS
 
-    :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_WRITEABLE` \| :cdata:`NPY_ARRAY_NOTSWAPPED`
+    :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \| :c:data:`NPY_ARRAY_NOTSWAPPED`
 
-.. cvar:: NPY_ARRAY_ELEMENTSTRIDES
+.. c:var:: NPY_ARRAY_ELEMENTSTRIDES
 
     Make sure the returned array has strides that are multiples of the
     element size.
 
-.. cfunction:: PyObject* PyArray_FromArray(PyArrayObject* op, PyArray_Descr* newtype, int requirements)
+.. c:function:: PyObject* PyArray_FromArray(PyArrayObject* op, PyArray_Descr* newtype, int requirements)
 
-    Special case of :cfunc:`PyArray_FromAny` for when *op* is already an
+    Special case of :c:func:`PyArray_FromAny` for when *op* is already an
     array but it needs to be of a specific *newtype* (including
     byte-order) or has certain *requirements*.
 
-.. cfunction:: PyObject* PyArray_FromStructInterface(PyObject* op)
+.. c:function:: PyObject* PyArray_FromStructInterface(PyObject* op)
 
     Returns an ndarray object from a Python object that exposes the
     :obj:`__array_struct__` attribute and follows the array interface
     protocol. If the object does not contain this attribute then a
-    borrowed reference to :cdata:`Py_NotImplemented` is returned.
+    borrowed reference to :c:data:`Py_NotImplemented` is returned.
 
-.. cfunction:: PyObject* PyArray_FromInterface(PyObject* op)
+.. c:function:: PyObject* PyArray_FromInterface(PyObject* op)
 
     Returns an ndarray object from a Python object that exposes the
     :obj:`__array_interface__` attribute following the array interface
     protocol. If the object does not contain this attribute then a
-    borrowed reference to :cdata:`Py_NotImplemented` is returned.
+    borrowed reference to :c:data:`Py_NotImplemented` is returned.
 
-.. cfunction:: PyObject* PyArray_FromArrayAttr(PyObject* op, PyArray_Descr* dtype, PyObject* context)
+.. c:function:: PyObject* PyArray_FromArrayAttr(PyObject* op, PyArray_Descr* dtype, PyObject* context)
 
     Return an ndarray object from a Python object that exposes the
     :obj:`__array__` method. The :obj:`__array__` method can take 0, 1, or 2
@@ -612,33 +612,33 @@ From other objects
     information about where the :obj:`__array__` method is being called
     from (currently only used in ufuncs).
 
-.. cfunction:: PyObject* PyArray_ContiguousFromAny(PyObject* op, int typenum, int min_depth, int max_depth)
+.. c:function:: PyObject* PyArray_ContiguousFromAny(PyObject* op, int typenum, int min_depth, int max_depth)
 
     This function returns a (C-style) contiguous and behaved function
     array from any nested sequence or array interface exporting
     object, *op*, of (non-flexible) type given by the enumerated
     *typenum*, of minimum depth *min_depth*, and of maximum depth
-    *max_depth*. Equivalent to a call to :cfunc:`PyArray_FromAny` with
-    requirements set to :cdata:`NPY_DEFAULT` and the type_num member of the
+    *max_depth*. Equivalent to a call to :c:func:`PyArray_FromAny` with
+    requirements set to :c:data:`NPY_DEFAULT` and the type_num member of the
     type argument set to *typenum*.
 
-.. cfunction:: PyObject *PyArray_FromObject(PyObject *op, int typenum, int min_depth, int max_depth)
+.. c:function:: PyObject *PyArray_FromObject(PyObject *op, int typenum, int min_depth, int max_depth)
 
     Return an aligned and in native-byteorder array from any nested
     sequence or array-interface exporting object, op, of a type given by
     the enumerated typenum. The minimum number of dimensions the array can
     have is given by min_depth while the maximum is max_depth. This is
-    equivalent to a call to :cfunc:`PyArray_FromAny` with requirements set to
+    equivalent to a call to :c:func:`PyArray_FromAny` with requirements set to
     BEHAVED.
 
-.. cfunction:: PyObject* PyArray_EnsureArray(PyObject* op)
+.. c:function:: PyObject* PyArray_EnsureArray(PyObject* op)
 
     This function **steals a reference** to ``op`` and makes sure that
     ``op`` is a base-class ndarray. It special cases array scalars,
-    but otherwise calls :cfunc:`PyArray_FromAny` ( ``op``, NULL, 0, 0,
-    :cdata:`NPY_ARRAY_ENSUREARRAY`).
+    but otherwise calls :c:func:`PyArray_FromAny` ( ``op``, NULL, 0, 0,
+    :c:data:`NPY_ARRAY_ENSUREARRAY`).
 
-.. cfunction:: PyObject* PyArray_FromString(char* string, npy_intp slen, PyArray_Descr* dtype, npy_intp num, char* sep)
+.. c:function:: PyObject* PyArray_FromString(char* string, npy_intp slen, PyArray_Descr* dtype, npy_intp num, char* sep)
 
     Construct a one-dimensional ndarray of a single type from a binary
     or (ASCII) text ``string`` of length ``slen``. The data-type of
@@ -651,7 +651,7 @@ From other objects
     data-types may not be readable in text mode and an error will be
     raised if that occurs. All errors return NULL.
 
-.. cfunction:: PyObject* PyArray_FromFile(FILE* fp, PyArray_Descr* dtype, npy_intp num, char* sep)
+.. c:function:: PyObject* PyArray_FromFile(FILE* fp, PyArray_Descr* dtype, npy_intp num, char* sep)
 
     Construct a one-dimensional ndarray of a single type from a binary
     or text file. The open file pointer is ``fp``, the data-type of
@@ -664,13 +664,13 @@ From other objects
     separator. Some array types cannot be read in text mode in which
     case an error is raised.
 
-.. cfunction:: PyObject* PyArray_FromBuffer(PyObject* buf, PyArray_Descr* dtype, npy_intp count, npy_intp offset)
+.. c:function:: PyObject* PyArray_FromBuffer(PyObject* buf, PyArray_Descr* dtype, npy_intp count, npy_intp offset)
 
     Construct a one-dimensional ndarray of a single type from an
     object, ``buf``, that exports the (single-segment) buffer protocol
     (or has an attribute __buffer\__ that returns an object that
     exports the buffer protocol). A writeable buffer will be tried
-    first followed by a read- only buffer. The :cdata:`NPY_ARRAY_WRITEABLE`
+    first followed by a read- only buffer. The :c:data:`NPY_ARRAY_WRITEABLE`
     flag of the returned array will reflect which one was
     successful. The data is assumed to start at ``offset`` bytes from
     the start of the memory location for the object. The type of the
@@ -680,7 +680,7 @@ From other objects
     otherwise, ``count`` represents how many elements should be
     converted from the buffer.
 
-.. cfunction:: int PyArray_CopyInto(PyArrayObject* dest, PyArrayObject* src)
+.. c:function:: int PyArray_CopyInto(PyArrayObject* dest, PyArrayObject* src)
 
     Copy from the source array, ``src``, into the destination array,
     ``dest``, performing a data-type conversion if necessary. If an
@@ -688,7 +688,7 @@ From other objects
     broadcastable to the shape of ``dest``. The data areas of dest
     and src must not overlap.
 
-.. cfunction:: int PyArray_MoveInto(PyArrayObject* dest, PyArrayObject* src)
+.. c:function:: int PyArray_MoveInto(PyArrayObject* dest, PyArrayObject* src)
 
     Move data from the source array, ``src``, into the destination
     array, ``dest``, performing a data-type conversion if
@@ -696,52 +696,52 @@ From other objects
     of ``src`` must be broadcastable to the shape of ``dest``. The
     data areas of dest and src may overlap.
 
-.. cfunction:: PyArrayObject* PyArray_GETCONTIGUOUS(PyObject* op)
+.. c:function:: PyArrayObject* PyArray_GETCONTIGUOUS(PyObject* op)
 
     If ``op`` is already (C-style) contiguous and well-behaved then
     just return a reference, otherwise return a (contiguous and
     well-behaved) copy of the array. The parameter op must be a
     (sub-class of an) ndarray and no checking for that is done.
 
-.. cfunction:: PyObject* PyArray_FROM_O(PyObject* obj)
+.. c:function:: PyObject* PyArray_FROM_O(PyObject* obj)
 
     Convert ``obj`` to an ndarray. The argument can be any nested
     sequence or object that exports the array interface. This is a
-    macro form of :cfunc:`PyArray_FromAny` using ``NULL``, 0, 0, 0 for the
+    macro form of :c:func:`PyArray_FromAny` using ``NULL``, 0, 0, 0 for the
     other arguments. Your code must be able to handle any data-type
     descriptor and any combination of data-flags to use this macro.
 
-.. cfunction:: PyObject* PyArray_FROM_OF(PyObject* obj, int requirements)
+.. c:function:: PyObject* PyArray_FROM_OF(PyObject* obj, int requirements)
 
-    Similar to :cfunc:`PyArray_FROM_O` except it can take an argument
+    Similar to :c:func:`PyArray_FROM_O` except it can take an argument
     of *requirements* indicating properties the resulting array must
     have. Available requirements that can be enforced are
-    :cdata:`NPY_ARRAY_C_CONTIGUOUS`, :cdata:`NPY_ARRAY_F_CONTIGUOUS`,
-    :cdata:`NPY_ARRAY_ALIGNED`, :cdata:`NPY_ARRAY_WRITEABLE`,
-    :cdata:`NPY_ARRAY_NOTSWAPPED`, :cdata:`NPY_ARRAY_ENSURECOPY`,
-    :cdata:`NPY_ARRAY_UPDATEIFCOPY`, :cdata:`NPY_ARRAY_FORCECAST`, and
-    :cdata:`NPY_ARRAY_ENSUREARRAY`. Standard combinations of flags can also
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS`, :c:data:`NPY_ARRAY_F_CONTIGUOUS`,
+    :c:data:`NPY_ARRAY_ALIGNED`, :c:data:`NPY_ARRAY_WRITEABLE`,
+    :c:data:`NPY_ARRAY_NOTSWAPPED`, :c:data:`NPY_ARRAY_ENSURECOPY`,
+    :c:data:`NPY_ARRAY_UPDATEIFCOPY`, :c:data:`NPY_ARRAY_FORCECAST`, and
+    :c:data:`NPY_ARRAY_ENSUREARRAY`. Standard combinations of flags can also
     be used:
 
-.. cfunction:: PyObject* PyArray_FROM_OT(PyObject* obj, int typenum)
+.. c:function:: PyObject* PyArray_FROM_OT(PyObject* obj, int typenum)
 
-    Similar to :cfunc:`PyArray_FROM_O` except it can take an argument of
+    Similar to :c:func:`PyArray_FROM_O` except it can take an argument of
     *typenum* specifying the type-number the returned array.
 
-.. cfunction:: PyObject* PyArray_FROM_OTF(PyObject* obj, int typenum, int requirements)
+.. c:function:: PyObject* PyArray_FROM_OTF(PyObject* obj, int typenum, int requirements)
 
-    Combination of :cfunc:`PyArray_FROM_OF` and :cfunc:`PyArray_FROM_OT`
+    Combination of :c:func:`PyArray_FROM_OF` and :c:func:`PyArray_FROM_OT`
     allowing both a *typenum* and a *flags* argument to be provided..
 
-.. cfunction:: PyObject* PyArray_FROMANY(PyObject* obj, int typenum, int min, int max, int requirements)
+.. c:function:: PyObject* PyArray_FROMANY(PyObject* obj, int typenum, int min, int max, int requirements)
 
-    Similar to :cfunc:`PyArray_FromAny` except the data-type is
-    specified using a typenumber. :cfunc:`PyArray_DescrFromType`
-    (*typenum*) is passed directly to :cfunc:`PyArray_FromAny`. This
-    macro also adds :cdata:`NPY_DEFAULT` to requirements if
-    :cdata:`NPY_ARRAY_ENSURECOPY` is passed in as requirements.
+    Similar to :c:func:`PyArray_FromAny` except the data-type is
+    specified using a typenumber. :c:func:`PyArray_DescrFromType`
+    (*typenum*) is passed directly to :c:func:`PyArray_FromAny`. This
+    macro also adds :c:data:`NPY_DEFAULT` to requirements if
+    :c:data:`NPY_ARRAY_ENSURECOPY` is passed in as requirements.
 
-.. cfunction:: PyObject *PyArray_CheckAxis(PyObject* obj, int* axis, int requirements)
+.. c:function:: PyObject *PyArray_CheckAxis(PyObject* obj, int* axis, int requirements)
 
     Encapsulate the functionality of functions and methods that take
     the axis= keyword and work properly with None as the axis
@@ -761,25 +761,25 @@ Dealing with types
 General check of Python Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: PyArray_Check(op)
+.. c:function:: PyArray_Check(op)
 
     Evaluates true if *op* is a Python object whose type is a sub-type
-    of :cdata:`PyArray_Type`.
+    of :c:data:`PyArray_Type`.
 
-.. cfunction:: PyArray_CheckExact(op)
+.. c:function:: PyArray_CheckExact(op)
 
     Evaluates true if *op* is a Python object with type
-    :cdata:`PyArray_Type`.
+    :c:data:`PyArray_Type`.
 
-.. cfunction:: PyArray_HasArrayInterface(op, out)
+.. c:function:: PyArray_HasArrayInterface(op, out)
 
     If ``op`` implements any part of the array interface, then ``out``
     will contain a new reference to the newly created ndarray using
     the interface or ``out`` will contain ``NULL`` if an error during
     conversion occurs. Otherwise, out will contain a borrowed
-    reference to :cdata:`Py_NotImplemented` and no error condition is set.
+    reference to :c:data:`Py_NotImplemented` and no error condition is set.
 
-.. cfunction:: PyArray_HasArrayInterfaceType(op, type, context, out)
+.. c:function:: PyArray_HasArrayInterfaceType(op, type, context, out)
 
     If ``op`` implements any part of the array interface, then ``out``
     will contain a new reference to the newly created ndarray using
@@ -789,43 +789,43 @@ General check of Python Type
     This version allows setting of the type and context in the part of
     the array interface that looks for the :obj:`__array__` attribute.
 
-.. cfunction:: PyArray_IsZeroDim(op)
+.. c:function:: PyArray_IsZeroDim(op)
 
     Evaluates true if *op* is an instance of (a subclass of)
-    :cdata:`PyArray_Type` and has 0 dimensions.
+    :c:data:`PyArray_Type` and has 0 dimensions.
 
-.. cfunction:: PyArray_IsScalar(op, cls)
+.. c:function:: PyArray_IsScalar(op, cls)
 
-    Evaluates true if *op* is an instance of :cdata:`Py{cls}ArrType_Type`.
+    Evaluates true if *op* is an instance of :c:data:`Py{cls}ArrType_Type`.
 
-.. cfunction:: PyArray_CheckScalar(op)
+.. c:function:: PyArray_CheckScalar(op)
 
     Evaluates true if *op* is either an array scalar (an instance of a
-    sub-type of :cdata:`PyGenericArr_Type` ), or an instance of (a
-    sub-class of) :cdata:`PyArray_Type` whose dimensionality is 0.
+    sub-type of :c:data:`PyGenericArr_Type` ), or an instance of (a
+    sub-class of) :c:data:`PyArray_Type` whose dimensionality is 0.
 
-.. cfunction:: PyArray_IsPythonNumber(op)
+.. c:function:: PyArray_IsPythonNumber(op)
 
     Evaluates true if *op* is an instance of a builtin numeric type (int,
     float, complex, long, bool)
 
-.. cfunction:: PyArray_IsPythonScalar(op)
+.. c:function:: PyArray_IsPythonScalar(op)
 
     Evaluates true if *op* is a builtin Python scalar object (int,
     float, complex, str, unicode, long, bool).
 
-.. cfunction:: PyArray_IsAnyScalar(op)
+.. c:function:: PyArray_IsAnyScalar(op)
 
     Evaluates true if *op* is either a Python scalar object (see
-    :cfunc:`PyArray_IsPythonScalar`) or an array scalar (an instance of a sub-
-    type of :cdata:`PyGenericArr_Type` ).
+    :c:func:`PyArray_IsPythonScalar`) or an array scalar (an instance of a sub-
+    type of :c:data:`PyGenericArr_Type` ).
 
-.. cfunction:: PyArray_CheckAnyScalar(op)
+.. c:function:: PyArray_CheckAnyScalar(op)
 
     Evaluates true if *op* is a Python scalar object (see
-    :cfunc:`PyArray_IsPythonScalar`), an array scalar (an instance of a
-    sub-type of :cdata:`PyGenericArr_Type`) or an instance of a sub-type of
-    :cdata:`PyArray_Type` whose dimensionality is 0.
+    :c:func:`PyArray_IsPythonScalar`), an array scalar (an instance of a
+    sub-type of :c:data:`PyGenericArr_Type`) or an instance of a sub-type of
+    :c:data:`PyArray_Type` whose dimensionality is 0.
 
 
 Data-type checking
@@ -833,179 +833,179 @@ Data-type checking
 
 For the typenum macros, the argument is an integer representing an
 enumerated array data type. For the array type checking macros the
-argument must be a :ctype:`PyObject *` that can be directly interpreted as a
-:ctype:`PyArrayObject *`.
+argument must be a :c:type:`PyObject *` that can be directly interpreted as a
+:c:type:`PyArrayObject *`.
 
-.. cfunction:: PyTypeNum_ISUNSIGNED(num)
+.. c:function:: PyTypeNum_ISUNSIGNED(num)
 
-.. cfunction:: PyDataType_ISUNSIGNED(descr)
+.. c:function:: PyDataType_ISUNSIGNED(descr)
 
-.. cfunction:: PyArray_ISUNSIGNED(obj)
+.. c:function:: PyArray_ISUNSIGNED(obj)
 
     Type represents an unsigned integer.
 
-.. cfunction:: PyTypeNum_ISSIGNED(num)
+.. c:function:: PyTypeNum_ISSIGNED(num)
 
-.. cfunction:: PyDataType_ISSIGNED(descr)
+.. c:function:: PyDataType_ISSIGNED(descr)
 
-.. cfunction:: PyArray_ISSIGNED(obj)
+.. c:function:: PyArray_ISSIGNED(obj)
 
     Type represents a signed integer.
 
-.. cfunction:: PyTypeNum_ISINTEGER(num)
+.. c:function:: PyTypeNum_ISINTEGER(num)
 
-.. cfunction:: PyDataType_ISINTEGER(descr)
+.. c:function:: PyDataType_ISINTEGER(descr)
 
-.. cfunction:: PyArray_ISINTEGER(obj)
+.. c:function:: PyArray_ISINTEGER(obj)
 
     Type represents any integer.
 
-.. cfunction:: PyTypeNum_ISFLOAT(num)
+.. c:function:: PyTypeNum_ISFLOAT(num)
 
-.. cfunction:: PyDataType_ISFLOAT(descr)
+.. c:function:: PyDataType_ISFLOAT(descr)
 
-.. cfunction:: PyArray_ISFLOAT(obj)
+.. c:function:: PyArray_ISFLOAT(obj)
 
     Type represents any floating point number.
 
-.. cfunction:: PyTypeNum_ISCOMPLEX(num)
+.. c:function:: PyTypeNum_ISCOMPLEX(num)
 
-.. cfunction:: PyDataType_ISCOMPLEX(descr)
+.. c:function:: PyDataType_ISCOMPLEX(descr)
 
-.. cfunction:: PyArray_ISCOMPLEX(obj)
+.. c:function:: PyArray_ISCOMPLEX(obj)
 
     Type represents any complex floating point number.
 
-.. cfunction:: PyTypeNum_ISNUMBER(num)
+.. c:function:: PyTypeNum_ISNUMBER(num)
 
-.. cfunction:: PyDataType_ISNUMBER(descr)
+.. c:function:: PyDataType_ISNUMBER(descr)
 
-.. cfunction:: PyArray_ISNUMBER(obj)
+.. c:function:: PyArray_ISNUMBER(obj)
 
     Type represents any integer, floating point, or complex floating point
     number.
 
-.. cfunction:: PyTypeNum_ISSTRING(num)
+.. c:function:: PyTypeNum_ISSTRING(num)
 
-.. cfunction:: PyDataType_ISSTRING(descr)
+.. c:function:: PyDataType_ISSTRING(descr)
 
-.. cfunction:: PyArray_ISSTRING(obj)
+.. c:function:: PyArray_ISSTRING(obj)
 
     Type represents a string data type.
 
-.. cfunction:: PyTypeNum_ISPYTHON(num)
+.. c:function:: PyTypeNum_ISPYTHON(num)
 
-.. cfunction:: PyDataType_ISPYTHON(descr)
+.. c:function:: PyDataType_ISPYTHON(descr)
 
-.. cfunction:: PyArray_ISPYTHON(obj)
+.. c:function:: PyArray_ISPYTHON(obj)
 
     Type represents an enumerated type corresponding to one of the
     standard Python scalar (bool, int, float, or complex).
 
-.. cfunction:: PyTypeNum_ISFLEXIBLE(num)
+.. c:function:: PyTypeNum_ISFLEXIBLE(num)
 
-.. cfunction:: PyDataType_ISFLEXIBLE(descr)
+.. c:function:: PyDataType_ISFLEXIBLE(descr)
 
-.. cfunction:: PyArray_ISFLEXIBLE(obj)
+.. c:function:: PyArray_ISFLEXIBLE(obj)
 
-    Type represents one of the flexible array types ( :cdata:`NPY_STRING`,
-    :cdata:`NPY_UNICODE`, or :cdata:`NPY_VOID` ).
+    Type represents one of the flexible array types ( :c:data:`NPY_STRING`,
+    :c:data:`NPY_UNICODE`, or :c:data:`NPY_VOID` ).
 
-.. cfunction:: PyTypeNum_ISUSERDEF(num)
+.. c:function:: PyTypeNum_ISUSERDEF(num)
 
-.. cfunction:: PyDataType_ISUSERDEF(descr)
+.. c:function:: PyDataType_ISUSERDEF(descr)
 
-.. cfunction:: PyArray_ISUSERDEF(obj)
+.. c:function:: PyArray_ISUSERDEF(obj)
 
     Type represents a user-defined type.
 
-.. cfunction:: PyTypeNum_ISEXTENDED(num)
+.. c:function:: PyTypeNum_ISEXTENDED(num)
 
-.. cfunction:: PyDataType_ISEXTENDED(descr)
+.. c:function:: PyDataType_ISEXTENDED(descr)
 
-.. cfunction:: PyArray_ISEXTENDED(obj)
+.. c:function:: PyArray_ISEXTENDED(obj)
 
     Type is either flexible or user-defined.
 
-.. cfunction:: PyTypeNum_ISOBJECT(num)
+.. c:function:: PyTypeNum_ISOBJECT(num)
 
-.. cfunction:: PyDataType_ISOBJECT(descr)
+.. c:function:: PyDataType_ISOBJECT(descr)
 
-.. cfunction:: PyArray_ISOBJECT(obj)
+.. c:function:: PyArray_ISOBJECT(obj)
 
     Type represents object data type.
 
-.. cfunction:: PyTypeNum_ISBOOL(num)
+.. c:function:: PyTypeNum_ISBOOL(num)
 
-.. cfunction:: PyDataType_ISBOOL(descr)
+.. c:function:: PyDataType_ISBOOL(descr)
 
-.. cfunction:: PyArray_ISBOOL(obj)
+.. c:function:: PyArray_ISBOOL(obj)
 
     Type represents Boolean data type.
 
-.. cfunction:: PyDataType_HASFIELDS(descr)
+.. c:function:: PyDataType_HASFIELDS(descr)
 
-.. cfunction:: PyArray_HASFIELDS(obj)
+.. c:function:: PyArray_HASFIELDS(obj)
 
     Type has fields associated with it.
 
-.. cfunction:: PyArray_ISNOTSWAPPED(m)
+.. c:function:: PyArray_ISNOTSWAPPED(m)
 
     Evaluates true if the data area of the ndarray *m* is in machine
     byte-order according to the array's data-type descriptor.
 
-.. cfunction:: PyArray_ISBYTESWAPPED(m)
+.. c:function:: PyArray_ISBYTESWAPPED(m)
 
     Evaluates true if the data area of the ndarray *m* is **not** in
     machine byte-order according to the array's data-type descriptor.
 
-.. cfunction:: Bool PyArray_EquivTypes(PyArray_Descr* type1, PyArray_Descr* type2)
+.. c:function:: Bool PyArray_EquivTypes(PyArray_Descr* type1, PyArray_Descr* type2)
 
-    Return :cdata:`NPY_TRUE` if *type1* and *type2* actually represent
+    Return :c:data:`NPY_TRUE` if *type1* and *type2* actually represent
     equivalent types for this platform (the fortran member of each
     type is ignored). For example, on 32-bit platforms,
-    :cdata:`NPY_LONG` and :cdata:`NPY_INT` are equivalent. Otherwise
-    return :cdata:`NPY_FALSE`.
+    :c:data:`NPY_LONG` and :c:data:`NPY_INT` are equivalent. Otherwise
+    return :c:data:`NPY_FALSE`.
 
-.. cfunction:: Bool PyArray_EquivArrTypes(PyArrayObject* a1, PyArrayObject * a2)
+.. c:function:: Bool PyArray_EquivArrTypes(PyArrayObject* a1, PyArrayObject * a2)
 
-    Return :cdata:`NPY_TRUE` if *a1* and *a2* are arrays with equivalent
+    Return :c:data:`NPY_TRUE` if *a1* and *a2* are arrays with equivalent
     types for this platform.
 
-.. cfunction:: Bool PyArray_EquivTypenums(int typenum1, int typenum2)
+.. c:function:: Bool PyArray_EquivTypenums(int typenum1, int typenum2)
 
-    Special case of :cfunc:`PyArray_EquivTypes` (...) that does not accept
+    Special case of :c:func:`PyArray_EquivTypes` (...) that does not accept
     flexible data types but may be easier to call.
 
-.. cfunction:: int PyArray_EquivByteorders({byteorder} b1, {byteorder} b2)
+.. c:function:: int PyArray_EquivByteorders({byteorder} b1, {byteorder} b2)
 
-    True if byteorder characters ( :cdata:`NPY_LITTLE`,
-    :cdata:`NPY_BIG`, :cdata:`NPY_NATIVE`, :cdata:`NPY_IGNORE` ) are
+    True if byteorder characters ( :c:data:`NPY_LITTLE`,
+    :c:data:`NPY_BIG`, :c:data:`NPY_NATIVE`, :c:data:`NPY_IGNORE` ) are
     either equal or equivalent as to their specification of a native
-    byte order. Thus, on a little-endian machine :cdata:`NPY_LITTLE`
-    and :cdata:`NPY_NATIVE` are equivalent where they are not
+    byte order. Thus, on a little-endian machine :c:data:`NPY_LITTLE`
+    and :c:data:`NPY_NATIVE` are equivalent where they are not
     equivalent on a big-endian machine.
 
 
 Converting data types
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: PyObject* PyArray_Cast(PyArrayObject* arr, int typenum)
+.. c:function:: PyObject* PyArray_Cast(PyArrayObject* arr, int typenum)
 
     Mainly for backwards compatibility to the Numeric C-API and for
     simple casts to non-flexible types. Return a new array object with
     the elements of *arr* cast to the data-type *typenum* which must
     be one of the enumerated types and not a flexible type.
 
-.. cfunction:: PyObject* PyArray_CastToType(PyArrayObject* arr, PyArray_Descr* type, int fortran)
+.. c:function:: PyObject* PyArray_CastToType(PyArrayObject* arr, PyArray_Descr* type, int fortran)
 
     Return a new array of the *type* specified, casting the elements
     of *arr* as appropriate. The fortran argument specifies the
     ordering of the output array.
 
-.. cfunction:: int PyArray_CastTo(PyArrayObject* out, PyArrayObject* in)
+.. c:function:: int PyArray_CastTo(PyArrayObject* out, PyArrayObject* in)
 
-    As of 1.6, this function simply calls :cfunc:`PyArray_CopyInto`,
+    As of 1.6, this function simply calls :c:func:`PyArray_CopyInto`,
     which handles the casting.
 
     Cast the elements of the array *in* into the array *out*. The
@@ -1014,7 +1014,7 @@ Converting data types
     placed in out), and have a data type that is one of the builtin
     types.  Returns 0 on success and -1 if an error occurs.
 
-.. cfunction:: PyArray_VectorUnaryFunc* PyArray_GetCastFunc(PyArray_Descr* from, int totype)
+.. c:function:: PyArray_VectorUnaryFunc* PyArray_GetCastFunc(PyArray_Descr* from, int totype)
 
     Return the low-level casting function to cast from the given
     descriptor to the builtin type number. If no casting function
@@ -1023,7 +1023,7 @@ Converting data types
     any user-defined casting functions added to a descriptors casting
     dictionary.
 
-.. cfunction:: int PyArray_CanCastSafely(int fromtype, int totype)
+.. c:function:: int PyArray_CanCastSafely(int fromtype, int totype)
 
     Returns non-zero if an array of data type *fromtype* can be cast
     to an array of data type *totype* without losing information. An
@@ -1033,29 +1033,29 @@ Converting data types
     explict requests. Flexible array types are not checked according
     to their lengths with this function.
 
-.. cfunction:: int PyArray_CanCastTo(PyArray_Descr* fromtype, PyArray_Descr* totype)
+.. c:function:: int PyArray_CanCastTo(PyArray_Descr* fromtype, PyArray_Descr* totype)
 
-    :cfunc:`PyArray_CanCastTypeTo` supercedes this function in
+    :c:func:`PyArray_CanCastTypeTo` supercedes this function in
     NumPy 1.6 and later.
 
     Equivalent to PyArray_CanCastTypeTo(fromtype, totype, NPY_SAFE_CASTING).
 
-.. cfunction:: int PyArray_CanCastTypeTo(PyArray_Descr* fromtype, PyArray_Descr* totype, NPY_CASTING casting)
+.. c:function:: int PyArray_CanCastTypeTo(PyArray_Descr* fromtype, PyArray_Descr* totype, NPY_CASTING casting)
 
     .. versionadded:: 1.6
 
     Returns non-zero if an array of data type *fromtype* (which can
     include flexible types) can be cast safely to an array of data
     type *totype* (which can include flexible types) according to
-    the casting rule *casting*. For simple types with :cdata:`NPY_SAFE_CASTING`,
-    this is basically a wrapper around :cfunc:`PyArray_CanCastSafely`, but
+    the casting rule *casting*. For simple types with :c:data:`NPY_SAFE_CASTING`,
+    this is basically a wrapper around :c:func:`PyArray_CanCastSafely`, but
     for flexible types such as strings or unicode, it produces results
     taking into account their sizes. Integer and float types can only be cast
-    to a string or unicode type using :cdata:`NPY_SAFE_CASTING` if the string
+    to a string or unicode type using :c:data:`NPY_SAFE_CASTING` if the string
     or unicode type is big enough to hold the max value of the integer/float
     type being cast from.
 
-.. cfunction:: int PyArray_CanCastArrayTo(PyArrayObject* arr, PyArray_Descr* totype, NPY_CASTING casting)
+.. c:function:: int PyArray_CanCastArrayTo(PyArrayObject* arr, PyArray_Descr* totype, NPY_CASTING casting)
 
     .. versionadded:: 1.6
 
@@ -1071,7 +1071,7 @@ Converting data types
     of uint values is not a subset of the int values for types with the
     same number of bits.
 
-.. cfunction:: PyArray_Descr* PyArray_MinScalarType(PyArrayObject* arr)
+.. c:function:: PyArray_Descr* PyArray_MinScalarType(PyArrayObject* arr)
 
     .. versionadded:: 1.6
 
@@ -1084,7 +1084,7 @@ Converting data types
     boolean, but will demote a signed integer to an unsigned integer
     when the scalar value is positive.
 
-.. cfunction:: PyArray_Descr* PyArray_PromoteTypes(PyArray_Descr* type1, PyArray_Descr* type2)
+.. c:function:: PyArray_Descr* PyArray_PromoteTypes(PyArray_Descr* type1, PyArray_Descr* type2)
 
     .. versionadded:: 1.6
 
@@ -1093,7 +1093,7 @@ Converting data types
     associative. A string or unicode result will be the proper size for
     storing the max value of the input types converted to a string or unicode.
 
-.. cfunction:: PyArray_Descr* PyArray_ResultType(npy_intp narrs, PyArrayObject**arrs, npy_intp ndtypes, PyArray_Descr**dtypes)
+.. c:function:: PyArray_Descr* PyArray_ResultType(npy_intp narrs, PyArrayObject**arrs, npy_intp ndtypes, PyArray_Descr**dtypes)
 
     .. versionadded:: 1.6
 
@@ -1109,22 +1109,22 @@ Converting data types
 
     If there are only scalars or the maximum category of the scalars
     is higher than the maximum category of the arrays,
-    the data types are combined with :cfunc:`PyArray_PromoteTypes`
+    the data types are combined with :c:func:`PyArray_PromoteTypes`
     to produce the return value.
 
     Otherwise, PyArray_MinScalarType is called on each array, and
     the resulting data types are all combined with
-    :cfunc:`PyArray_PromoteTypes` to produce the return value.
+    :c:func:`PyArray_PromoteTypes` to produce the return value.
 
     The set of int values is not a subset of the uint values for types
     with the same number of bits, something not reflected in
-    :cfunc:`PyArray_MinScalarType`, but handled as a special case in
+    :c:func:`PyArray_MinScalarType`, but handled as a special case in
     PyArray_ResultType.
 
-.. cfunction:: int PyArray_ObjectType(PyObject* op, int mintype)
+.. c:function:: int PyArray_ObjectType(PyObject* op, int mintype)
 
-    This function is superceded by :cfunc:`PyArray_MinScalarType` and/or
-    :cfunc:`PyArray_ResultType`.
+    This function is superceded by :c:func:`PyArray_MinScalarType` and/or
+    :c:func:`PyArray_ResultType`.
 
     This function is useful for determining a common type that two or
     more arrays can be converted to. It only works for non-flexible
@@ -1134,21 +1134,21 @@ Converting data types
     return value is the enumerated typenumber that represents the
     data-type that *op* should have.
 
-.. cfunction:: void PyArray_ArrayType(PyObject* op, PyArray_Descr* mintype, PyArray_Descr* outtype)
+.. c:function:: void PyArray_ArrayType(PyObject* op, PyArray_Descr* mintype, PyArray_Descr* outtype)
 
-    This function is superceded by :cfunc:`PyArray_ResultType`.
+    This function is superceded by :c:func:`PyArray_ResultType`.
 
-    This function works similarly to :cfunc:`PyArray_ObjectType` (...)
+    This function works similarly to :c:func:`PyArray_ObjectType` (...)
     except it handles flexible arrays. The *mintype* argument can have
     an itemsize member and the *outtype* argument will have an
     itemsize member at least as big but perhaps bigger depending on
     the object *op*.
 
-.. cfunction:: PyArrayObject** PyArray_ConvertToCommonType(PyObject* op, int* n)
+.. c:function:: PyArrayObject** PyArray_ConvertToCommonType(PyObject* op, int* n)
 
     The functionality this provides is largely superceded by iterator
-    :ctype:`NpyIter` introduced in 1.6, with flag
-    :cdata:`NPY_ITER_COMMON_DTYPE` or with the same dtype parameter for
+    :c:type:`NpyIter` introduced in 1.6, with flag
+    :c:data:`NPY_ITER_COMMON_DTYPE` or with the same dtype parameter for
     all operands.
 
     Convert a sequence of Python objects contained in *op* to an array
@@ -1156,9 +1156,9 @@ Converting data types
     based on the typenumber (larger type number is chosen over a
     smaller one) ignoring objects that are only scalars. The length of
     the sequence is returned in *n*, and an *n* -length array of
-    :ctype:`PyArrayObject` pointers is the return value (or ``NULL`` if an
+    :c:type:`PyArrayObject` pointers is the return value (or ``NULL`` if an
     error occurs). The returned array must be freed by the caller of
-    this routine (using :cfunc:`PyDataMem_FREE` ) and all the array objects
+    this routine (using :c:func:`PyDataMem_FREE` ) and all the array objects
     in it ``DECREF`` 'd or a memory-leak will occur. The example
     template-code below shows a typically usage:
 
@@ -1172,35 +1172,35 @@ Converting data types
         PyDataMem_FREE(mps);
         {return}
 
-.. cfunction:: char* PyArray_Zero(PyArrayObject* arr)
+.. c:function:: char* PyArray_Zero(PyArrayObject* arr)
 
     A pointer to newly created memory of size *arr* ->itemsize that
     holds the representation of 0 for that type. The returned pointer,
-    *ret*, **must be freed** using :cfunc:`PyDataMem_FREE` (ret) when it is
+    *ret*, **must be freed** using :c:func:`PyDataMem_FREE` (ret) when it is
     not needed anymore.
 
-.. cfunction:: char* PyArray_One(PyArrayObject* arr)
+.. c:function:: char* PyArray_One(PyArrayObject* arr)
 
     A pointer to newly created memory of size *arr* ->itemsize that
     holds the representation of 1 for that type. The returned pointer,
-    *ret*, **must be freed** using :cfunc:`PyDataMem_FREE` (ret) when it
+    *ret*, **must be freed** using :c:func:`PyDataMem_FREE` (ret) when it
     is not needed anymore.
 
-.. cfunction:: int PyArray_ValidType(int typenum)
+.. c:function:: int PyArray_ValidType(int typenum)
 
-    Returns :cdata:`NPY_TRUE` if *typenum* represents a valid type-number
+    Returns :c:data:`NPY_TRUE` if *typenum* represents a valid type-number
     (builtin or user-defined or character code). Otherwise, this
-    function returns :cdata:`NPY_FALSE`.
+    function returns :c:data:`NPY_FALSE`.
 
 
 New data types
 ^^^^^^^^^^^^^^
 
-.. cfunction:: void PyArray_InitArrFuncs(PyArray_ArrFuncs* f)
+.. c:function:: void PyArray_InitArrFuncs(PyArray_ArrFuncs* f)
 
     Initialize all function pointers and members to ``NULL``.
 
-.. cfunction:: int PyArray_RegisterDataType(PyArray_Descr* dtype)
+.. c:function:: int PyArray_RegisterDataType(PyArray_Descr* dtype)
 
     Register a data-type as a new user-defined data type for
     arrays. The type must have most of its entries filled in. This is
@@ -1216,23 +1216,23 @@ New data types
 
     A user-defined type number is returned that uniquely identifies
     the type. A pointer to the new structure can then be obtained from
-    :cfunc:`PyArray_DescrFromType` using the returned type number. A -1 is
+    :c:func:`PyArray_DescrFromType` using the returned type number. A -1 is
     returned if an error occurs.  If this *dtype* has already been
     registered (checked only by the address of the pointer), then
     return the previously-assigned type-number.
 
-.. cfunction:: int PyArray_RegisterCastFunc(PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
+.. c:function:: int PyArray_RegisterCastFunc(PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
 
     Register a low-level casting function, *castfunc*, to convert
     from the data-type, *descr*, to the given data-type number,
     *totype*. Any old casting function is over-written. A ``0`` is
     returned on success or a ``-1`` on failure.
 
-.. cfunction:: int PyArray_RegisterCanCast(PyArray_Descr* descr, int totype, NPY_SCALARKIND scalar)
+.. c:function:: int PyArray_RegisterCanCast(PyArray_Descr* descr, int totype, NPY_SCALARKIND scalar)
 
     Register the data-type number, *totype*, as castable from
     data-type object, *descr*, of the given *scalar* kind. Use
-    *scalar* = :cdata:`NPY_NOSCALAR` to register that an array of data-type
+    *scalar* = :c:data:`NPY_NOSCALAR` to register that an array of data-type
     *descr* can be cast safely to a data-type whose type_number is
     *totype*.
 
@@ -1240,14 +1240,14 @@ New data types
 Special functions for NPY_OBJECT
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: int PyArray_INCREF(PyArrayObject* op)
+.. c:function:: int PyArray_INCREF(PyArrayObject* op)
 
     Used for an array, *op*, that contains any Python objects. It
     increments the reference count of every object in the array
     according to the data-type of *op*. A -1 is returned if an error
     occurs, otherwise 0 is returned.
 
-.. cfunction:: void PyArray_Item_INCREF(char* ptr, PyArray_Descr* dtype)
+.. c:function:: void PyArray_Item_INCREF(char* ptr, PyArray_Descr* dtype)
 
     A function to INCREF all the objects at the location *ptr*
     according to the data-type *dtype*. If *ptr* is the start of a
@@ -1255,14 +1255,14 @@ Special functions for NPY_OBJECT
     increment the reference count of all object-like items in the
     structured type.
 
-.. cfunction:: int PyArray_XDECREF(PyArrayObject* op)
+.. c:function:: int PyArray_XDECREF(PyArrayObject* op)
 
     Used for an array, *op*, that contains any Python objects. It
     decrements the reference count of every object in the array
     according to the data-type of *op*. Normal return value is 0. A
     -1 is returned if an error occurs.
 
-.. cfunction:: void PyArray_Item_XDECREF(char* ptr, PyArray_Descr* dtype)
+.. c:function:: void PyArray_Item_XDECREF(char* ptr, PyArray_Descr* dtype)
 
     A function to XDECREF all the object-like items at the location
     *ptr* as recorded in the data-type, *dtype*. This works
@@ -1270,13 +1270,13 @@ Special functions for NPY_OBJECT
     that contain object-like items, all the object-like fields will be
     XDECREF ``'d``.
 
-.. cfunction:: void PyArray_FillObjectArray(PyArrayObject* arr, PyObject* obj)
+.. c:function:: void PyArray_FillObjectArray(PyArrayObject* arr, PyObject* obj)
 
     Fill a newly created array with a single value obj at all
     locations in the structure with object data-types. No checking is
-    performed but *arr* must be of data-type :ctype:`NPY_OBJECT` and be
+    performed but *arr* must be of data-type :c:type:`NPY_OBJECT` and be
     single-segment and uninitialized (no previous objects in
-    position). Use :cfunc:`PyArray_DECREF` (*arr*) if you need to
+    position). Use :c:func:`PyArray_DECREF` (*arr*) if you need to
     decrement all the items in the object array prior to calling this
     function.
 
@@ -1298,8 +1298,8 @@ getting (and, if appropriate, setting) these flags.
 Memory areas of all kinds can be pointed to by an ndarray, necessitating
 these flags.  If you get an arbitrary ``PyArrayObject`` in C-code, you
 need to be aware of the flags that are set.  If you need to guarantee
-a certain kind of array (like :cdata:`NPY_ARRAY_C_CONTIGUOUS` and
-:cdata:`NPY_ARRAY_BEHAVED`), then pass these requirements into the
+a certain kind of array (like :c:data:`NPY_ARRAY_C_CONTIGUOUS` and
+:c:data:`NPY_ARRAY_BEHAVED`), then pass these requirements into the
 PyArray_FromAny function.
 
 
@@ -1318,12 +1318,12 @@ In versions 1.6 and earlier of NumPy, the following flags
 did not have the _ARRAY_ macro namespace in them. That form
 of the constant names is deprecated in 1.7.
 
-.. cvar:: NPY_ARRAY_C_CONTIGUOUS
+.. c:var:: NPY_ARRAY_C_CONTIGUOUS
 
     The data area is in C-style contiguous order (last index varies the
     fastest).
 
-.. cvar:: NPY_ARRAY_F_CONTIGUOUS
+.. c:var:: NPY_ARRAY_F_CONTIGUOUS
 
     The data area is in Fortran-style contiguous order (first index varies
     the fastest).
@@ -1344,184 +1344,184 @@ of the constant names is deprecated in 1.7.
 
     .. seealso:: :ref:`Internal memory layout of an ndarray <arrays.ndarray>`
 
-.. cvar:: NPY_ARRAY_OWNDATA
+.. c:var:: NPY_ARRAY_OWNDATA
 
     The data area is owned by this array.
 
-.. cvar:: NPY_ARRAY_ALIGNED
+.. c:var:: NPY_ARRAY_ALIGNED
 
     The data area and all array elements are aligned appropriately.
 
-.. cvar:: NPY_ARRAY_WRITEABLE
+.. c:var:: NPY_ARRAY_WRITEABLE
 
     The data area can be written to.
 
     Notice that the above 3 flags are are defined so that a new, well-
     behaved array has these flags defined as true.
 
-.. cvar:: NPY_ARRAY_UPDATEIFCOPY
+.. c:var:: NPY_ARRAY_UPDATEIFCOPY
 
     The data area represents a (well-behaved) copy whose information
     should be transferred back to the original when this array is deleted.
 
     This is a special flag that is set if this array represents a copy
     made because a user required certain flags in
-    :cfunc:`PyArray_FromAny` and a copy had to be made of some other
+    :c:func:`PyArray_FromAny` and a copy had to be made of some other
     array (and the user asked for this flag to be set in such a
     situation). The base attribute then points to the "misbehaved"
     array (which is set read_only). When the array with this flag set
     is deallocated, it will copy its contents back to the "misbehaved"
     array (casting if necessary) and will reset the "misbehaved" array
-    to :cdata:`NPY_ARRAY_WRITEABLE`. If the "misbehaved" array was not
-    :cdata:`NPY_ARRAY_WRITEABLE` to begin with then :cfunc:`PyArray_FromAny`
-    would have returned an error because :cdata:`NPY_ARRAY_UPDATEIFCOPY`
+    to :c:data:`NPY_ARRAY_WRITEABLE`. If the "misbehaved" array was not
+    :c:data:`NPY_ARRAY_WRITEABLE` to begin with then :c:func:`PyArray_FromAny`
+    would have returned an error because :c:data:`NPY_ARRAY_UPDATEIFCOPY`
     would not have been possible.
 
-:cfunc:`PyArray_UpdateFlags` (obj, flags) will update the ``obj->flags``
-for ``flags`` which can be any of :cdata:`NPY_ARRAY_C_CONTIGUOUS`,
-:cdata:`NPY_ARRAY_F_CONTIGUOUS`, :cdata:`NPY_ARRAY_ALIGNED`, or
-:cdata:`NPY_ARRAY_WRITEABLE`.
+:c:func:`PyArray_UpdateFlags` (obj, flags) will update the ``obj->flags``
+for ``flags`` which can be any of :c:data:`NPY_ARRAY_C_CONTIGUOUS`,
+:c:data:`NPY_ARRAY_F_CONTIGUOUS`, :c:data:`NPY_ARRAY_ALIGNED`, or
+:c:data:`NPY_ARRAY_WRITEABLE`.
 
 
 Combinations of array flags
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cvar:: NPY_ARRAY_BEHAVED
+.. c:var:: NPY_ARRAY_BEHAVED
 
-    :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_WRITEABLE`
+    :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE`
 
-.. cvar:: NPY_ARRAY_CARRAY
+.. c:var:: NPY_ARRAY_CARRAY
 
-    :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_BEHAVED`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-.. cvar:: NPY_ARRAY_CARRAY_RO
+.. c:var:: NPY_ARRAY_CARRAY_RO
 
-    :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-.. cvar:: NPY_ARRAY_FARRAY
+.. c:var:: NPY_ARRAY_FARRAY
 
-    :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_BEHAVED`
+    :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-.. cvar:: NPY_ARRAY_FARRAY_RO
+.. c:var:: NPY_ARRAY_FARRAY_RO
 
-    :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+    :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-.. cvar:: NPY_ARRAY_DEFAULT
+.. c:var:: NPY_ARRAY_DEFAULT
 
-    :cdata:`NPY_ARRAY_CARRAY`
+    :c:data:`NPY_ARRAY_CARRAY`
 
-.. cvar:: NPY_ARRAY_UPDATE_ALL
+.. c:var:: NPY_ARRAY_UPDATE_ALL
 
-    :cdata:`NPY_ARRAY_C_CONTIGUOUS` \| :cdata:`NPY_ARRAY_F_CONTIGUOUS` \| :cdata:`NPY_ARRAY_ALIGNED`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
 
 Flag-like constants
 ^^^^^^^^^^^^^^^^^^^
 
-These constants are used in :cfunc:`PyArray_FromAny` (and its macro forms) to
+These constants are used in :c:func:`PyArray_FromAny` (and its macro forms) to
 specify desired properties of the new array.
 
-.. cvar:: NPY_ARRAY_FORCECAST
+.. c:var:: NPY_ARRAY_FORCECAST
 
     Cast to the desired type, even if it can't be done without losing
     information.
 
-.. cvar:: NPY_ARRAY_ENSURECOPY
+.. c:var:: NPY_ARRAY_ENSURECOPY
 
     Make sure the resulting array is a copy of the original.
 
-.. cvar:: NPY_ARRAY_ENSUREARRAY
+.. c:var:: NPY_ARRAY_ENSUREARRAY
 
     Make sure the resulting object is an actual ndarray (or bigndarray),
     and not a sub-class.
 
-.. cvar:: NPY_ARRAY_NOTSWAPPED
+.. c:var:: NPY_ARRAY_NOTSWAPPED
 
-    Only used in :cfunc:`PyArray_CheckFromAny` to over-ride the byteorder
+    Only used in :c:func:`PyArray_CheckFromAny` to over-ride the byteorder
     of the data-type object passed in.
 
-.. cvar:: NPY_ARRAY_BEHAVED_NS
+.. c:var:: NPY_ARRAY_BEHAVED_NS
 
-    :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_WRITEABLE` \| :cdata:`NPY_ARRAY_NOTSWAPPED`
+    :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \| :c:data:`NPY_ARRAY_NOTSWAPPED`
 
 
 Flag checking
 ^^^^^^^^^^^^^
 
 For all of these macros *arr* must be an instance of a (subclass of)
-:cdata:`PyArray_Type`, but no checking is done.
+:c:data:`PyArray_Type`, but no checking is done.
 
-.. cfunction:: PyArray_CHKFLAGS(arr, flags)
+.. c:function:: PyArray_CHKFLAGS(arr, flags)
 
     The first parameter, arr, must be an ndarray or subclass. The
     parameter, *flags*, should be an integer consisting of bitwise
     combinations of the possible flags an array can have:
-    :cdata:`NPY_ARRAY_C_CONTIGUOUS`, :cdata:`NPY_ARRAY_F_CONTIGUOUS`,
-    :cdata:`NPY_ARRAY_OWNDATA`, :cdata:`NPY_ARRAY_ALIGNED`,
-    :cdata:`NPY_ARRAY_WRITEABLE`, :cdata:`NPY_ARRAY_UPDATEIFCOPY`.
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS`, :c:data:`NPY_ARRAY_F_CONTIGUOUS`,
+    :c:data:`NPY_ARRAY_OWNDATA`, :c:data:`NPY_ARRAY_ALIGNED`,
+    :c:data:`NPY_ARRAY_WRITEABLE`, :c:data:`NPY_ARRAY_UPDATEIFCOPY`.
 
-.. cfunction:: PyArray_IS_C_CONTIGUOUS(arr)
+.. c:function:: PyArray_IS_C_CONTIGUOUS(arr)
 
     Evaluates true if *arr* is C-style contiguous.
 
-.. cfunction:: PyArray_IS_F_CONTIGUOUS(arr)
+.. c:function:: PyArray_IS_F_CONTIGUOUS(arr)
 
     Evaluates true if *arr* is Fortran-style contiguous.
 
-.. cfunction:: PyArray_ISFORTRAN(arr)
+.. c:function:: PyArray_ISFORTRAN(arr)
 
     Evaluates true if *arr* is Fortran-style contiguous and *not*
-    C-style contiguous. :cfunc:`PyArray_IS_F_CONTIGUOUS`
+    C-style contiguous. :c:func:`PyArray_IS_F_CONTIGUOUS`
     is the correct way to test for Fortran-style contiguity.
 
-.. cfunction:: PyArray_ISWRITEABLE(arr)
+.. c:function:: PyArray_ISWRITEABLE(arr)
 
     Evaluates true if the data area of *arr* can be written to
 
-.. cfunction:: PyArray_ISALIGNED(arr)
+.. c:function:: PyArray_ISALIGNED(arr)
 
     Evaluates true if the data area of *arr* is properly aligned on
     the machine.
 
-.. cfunction:: PyArray_ISBEHAVED(arr)
+.. c:function:: PyArray_ISBEHAVED(arr)
 
     Evalutes true if the data area of *arr* is aligned and writeable
     and in machine byte-order according to its descriptor.
 
-.. cfunction:: PyArray_ISBEHAVED_RO(arr)
+.. c:function:: PyArray_ISBEHAVED_RO(arr)
 
     Evaluates true if the data area of *arr* is aligned and in machine
     byte-order.
 
-.. cfunction:: PyArray_ISCARRAY(arr)
+.. c:function:: PyArray_ISCARRAY(arr)
 
     Evaluates true if the data area of *arr* is C-style contiguous,
-    and :cfunc:`PyArray_ISBEHAVED` (*arr*) is true.
+    and :c:func:`PyArray_ISBEHAVED` (*arr*) is true.
 
-.. cfunction:: PyArray_ISFARRAY(arr)
+.. c:function:: PyArray_ISFARRAY(arr)
 
     Evaluates true if the data area of *arr* is Fortran-style
-    contiguous and :cfunc:`PyArray_ISBEHAVED` (*arr*) is true.
+    contiguous and :c:func:`PyArray_ISBEHAVED` (*arr*) is true.
 
-.. cfunction:: PyArray_ISCARRAY_RO(arr)
+.. c:function:: PyArray_ISCARRAY_RO(arr)
 
     Evaluates true if the data area of *arr* is C-style contiguous,
     aligned, and in machine byte-order.
 
-.. cfunction:: PyArray_ISFARRAY_RO(arr)
+.. c:function:: PyArray_ISFARRAY_RO(arr)
 
     Evaluates true if the data area of *arr* is Fortran-style
     contiguous, aligned, and in machine byte-order **.**
 
-.. cfunction:: PyArray_ISONESEGMENT(arr)
+.. c:function:: PyArray_ISONESEGMENT(arr)
 
     Evaluates true if the data area of *arr* consists of a single
     (C-style or Fortran-style) contiguous segment.
 
-.. cfunction:: void PyArray_UpdateFlags(PyArrayObject* arr, int flagmask)
+.. c:function:: void PyArray_UpdateFlags(PyArrayObject* arr, int flagmask)
 
-    The :cdata:`NPY_ARRAY_C_CONTIGUOUS`, :cdata:`NPY_ARRAY_ALIGNED`, and
-    :cdata:`NPY_ARRAY_F_CONTIGUOUS` array flags can be "calculated" from the
+    The :c:data:`NPY_ARRAY_C_CONTIGUOUS`, :c:data:`NPY_ARRAY_ALIGNED`, and
+    :c:data:`NPY_ARRAY_F_CONTIGUOUS` array flags can be "calculated" from the
     array object itself. This routine updates one or more of these
     flags of *arr* as specified in *flagmask* by performing the
     required calculation.
@@ -1530,7 +1530,7 @@ For all of these macros *arr* must be an instance of a (subclass of)
 .. warning::
 
     It is important to keep the flags updated (using
-    :cfunc:`PyArray_UpdateFlags` can help) whenever a manipulation with an
+    :c:func:`PyArray_UpdateFlags` can help) whenever a manipulation with an
     array is performed that might cause them to change. Later
     calculations in NumPy that rely on the state of these flags do not
     repeat the calculation to update them.
@@ -1543,7 +1543,7 @@ Array method alternative API
 Conversion
 ^^^^^^^^^^
 
-.. cfunction:: PyObject* PyArray_GetField(PyArrayObject* self, PyArray_Descr* dtype, int offset)
+.. c:function:: PyObject* PyArray_GetField(PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
     Equivalent to :meth:`ndarray.getfield` (*self*, *dtype*, *offset*). Return
     a new array of the given *dtype* using the data in the current
@@ -1555,7 +1555,7 @@ Conversion
     be used to select specific bytes or groups of bytes from any array
     type.
 
-.. cfunction:: int PyArray_SetField(PyArrayObject* self, PyArray_Descr* dtype, int offset, PyObject* val)
+.. c:function:: int PyArray_SetField(PyArrayObject* self, PyArray_Descr* dtype, int offset, PyObject* val)
 
     Equivalent to :meth:`ndarray.setfield` (*self*, *val*, *dtype*, *offset*
     ). Set the field starting at *offset* in bytes and of the given
@@ -1567,35 +1567,35 @@ Conversion
     destination must be an integer multiple of the number of elements
     in *val*.
 
-.. cfunction:: PyObject* PyArray_Byteswap(PyArrayObject* self, Bool inplace)
+.. c:function:: PyObject* PyArray_Byteswap(PyArrayObject* self, Bool inplace)
 
     Equivalent to :meth:`ndarray.byteswap` (*self*, *inplace*). Return an array
     whose data area is byteswapped. If *inplace* is non-zero, then do
     the byteswap inplace and return a reference to self. Otherwise,
     create a byteswapped copy and leave self unchanged.
 
-.. cfunction:: PyObject* PyArray_NewCopy(PyArrayObject* old, NPY_ORDER order)
+.. c:function:: PyObject* PyArray_NewCopy(PyArrayObject* old, NPY_ORDER order)
 
     Equivalent to :meth:`ndarray.copy` (*self*, *fortran*). Make a copy of the
     *old* array. The returned array is always aligned and writeable
     with data interpreted the same as the old array. If *order* is
-    :cdata:`NPY_CORDER`, then a C-style contiguous array is returned. If
-    *order* is :cdata:`NPY_FORTRANORDER`, then a Fortran-style contiguous
-    array is returned. If *order is* :cdata:`NPY_ANYORDER`, then the array
+    :c:data:`NPY_CORDER`, then a C-style contiguous array is returned. If
+    *order* is :c:data:`NPY_FORTRANORDER`, then a Fortran-style contiguous
+    array is returned. If *order is* :c:data:`NPY_ANYORDER`, then the array
     returned is Fortran-style contiguous only if the old one is;
     otherwise, it is C-style contiguous.
 
-.. cfunction:: PyObject* PyArray_ToList(PyArrayObject* self)
+.. c:function:: PyObject* PyArray_ToList(PyArrayObject* self)
 
     Equivalent to :meth:`ndarray.tolist` (*self*). Return a nested Python list
     from *self*.
 
-.. cfunction:: PyObject* PyArray_ToString(PyArrayObject* self, NPY_ORDER order)
+.. c:function:: PyObject* PyArray_ToString(PyArrayObject* self, NPY_ORDER order)
 
     Equivalent to :meth:`ndarray.tobytes` (*self*, *order*). Return the bytes
     of this array in a Python string.
 
-.. cfunction:: PyObject* PyArray_ToFile(PyArrayObject* self, FILE* fp, char* sep, char* format)
+.. c:function:: PyObject* PyArray_ToFile(PyArrayObject* self, FILE* fp, char* sep, char* format)
 
     Write the contents of *self* to the file pointer *fp* in C-style
     contiguous fashion. Write the data as binary bytes if *sep* is the
@@ -1605,7 +1605,7 @@ Conversion
     "", then it is a Python print statement format string showing how
     the items are to be written.
 
-.. cfunction:: int PyArray_Dump(PyObject* self, PyObject* file, int protocol)
+.. c:function:: int PyArray_Dump(PyObject* self, PyObject* file, int protocol)
 
     Pickle the object in *self* to the given *file* (either a string
     or a Python file object). If *file* is a Python string it is
@@ -1614,20 +1614,20 @@ Conversion
     the highest available is used). This is a simple wrapper around
     cPickle.dump(*self*, *file*, *protocol*).
 
-.. cfunction:: PyObject* PyArray_Dumps(PyObject* self, int protocol)
+.. c:function:: PyObject* PyArray_Dumps(PyObject* self, int protocol)
 
     Pickle the object in *self* to a Python string and return it. Use
     the Pickle *protocol* provided (or the highest available if
     *protocol* is negative).
 
-.. cfunction:: int PyArray_FillWithScalar(PyArrayObject* arr, PyObject* obj)
+.. c:function:: int PyArray_FillWithScalar(PyArrayObject* arr, PyObject* obj)
 
     Fill the array, *arr*, with the given scalar object, *obj*. The
     object is first converted to the data type of *arr*, and then
     copied into every location. A -1 is returned if an error occurs,
     otherwise 0 is returned.
 
-.. cfunction:: PyObject* PyArray_View(PyArrayObject* self, PyArray_Descr* dtype, PyTypeObject *ptype)
+.. c:function:: PyObject* PyArray_View(PyArrayObject* self, PyArray_Descr* dtype, PyTypeObject *ptype)
 
     Equivalent to :meth:`ndarray.view` (*self*, *dtype*). Return a new
     view of the array *self* as possibly a different data-type, *dtype*,
@@ -1646,7 +1646,7 @@ Conversion
 Shape Manipulation
 ^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: PyObject* PyArray_Newshape(PyArrayObject* self, PyArray_Dims* newshape, NPY_ORDER order)
+.. c:function:: PyObject* PyArray_Newshape(PyArrayObject* self, PyArray_Dims* newshape, NPY_ORDER order)
 
     Result will be a new array (pointing to the same memory location
     as *self* if possible), but having a shape given by *newshape*.
@@ -1654,14 +1654,14 @@ Shape Manipulation
     then a copy of the array with the new specified shape will be
     returned.
 
-.. cfunction:: PyObject* PyArray_Reshape(PyArrayObject* self, PyObject* shape)
+.. c:function:: PyObject* PyArray_Reshape(PyArrayObject* self, PyObject* shape)
 
     Equivalent to :meth:`ndarray.reshape` (*self*, *shape*) where *shape* is a
-    sequence. Converts *shape* to a :ctype:`PyArray_Dims` structure and
-    calls :cfunc:`PyArray_Newshape` internally.
+    sequence. Converts *shape* to a :c:type:`PyArray_Dims` structure and
+    calls :c:func:`PyArray_Newshape` internally.
     For back-ward compatability -- Not recommended
 
-.. cfunction:: PyObject* PyArray_Squeeze(PyArrayObject* self)
+.. c:function:: PyObject* PyArray_Squeeze(PyArrayObject* self)
 
     Equivalent to :meth:`ndarray.squeeze` (*self*). Return a new view of *self*
     with all of the dimensions of length 1 removed from the shape.
@@ -1669,15 +1669,15 @@ Shape Manipulation
 .. warning::
 
     matrix objects are always 2-dimensional. Therefore,
-    :cfunc:`PyArray_Squeeze` has no effect on arrays of matrix sub-class.
+    :c:func:`PyArray_Squeeze` has no effect on arrays of matrix sub-class.
 
-.. cfunction:: PyObject* PyArray_SwapAxes(PyArrayObject* self, int a1, int a2)
+.. c:function:: PyObject* PyArray_SwapAxes(PyArrayObject* self, int a1, int a2)
 
     Equivalent to :meth:`ndarray.swapaxes` (*self*, *a1*, *a2*). The returned
     array is a new view of the data in *self* with the given axes,
     *a1* and *a2*, swapped.
 
-.. cfunction:: PyObject* PyArray_Resize(PyArrayObject* self, PyArray_Dims* newshape, int refcheck, NPY_ORDER fortran)
+.. c:function:: PyObject* PyArray_Resize(PyArrayObject* self, PyArray_Dims* newshape, int refcheck, NPY_ORDER fortran)
 
     Equivalent to :meth:`ndarray.resize` (*self*, *newshape*, refcheck
     ``=`` *refcheck*, order= fortran ). This function only works on
@@ -1688,12 +1688,12 @@ Shape Manipulation
     *self* - ``>base==NULL``, have *self* - ``>weakrefs==NULL``, and
     (unless refcheck is 0) not be referenced by any other array. A
     reference to the new array is returned. The fortran argument can
-    be :cdata:`NPY_ANYORDER`, :cdata:`NPY_CORDER`, or
-    :cdata:`NPY_FORTRANORDER`. It currently has no effect. Eventually
+    be :c:data:`NPY_ANYORDER`, :c:data:`NPY_CORDER`, or
+    :c:data:`NPY_FORTRANORDER`. It currently has no effect. Eventually
     it could be used to determine how the resize operation should view
     the data when constructing a differently-dimensioned array.
 
-.. cfunction:: PyObject* PyArray_Transpose(PyArrayObject* self, PyArray_Dims* permute)
+.. c:function:: PyObject* PyArray_Transpose(PyArrayObject* self, PyArray_Dims* permute)
 
     Equivalent to :meth:`ndarray.transpose` (*self*, *permute*). Permute the
     axes of the ndarray object *self* according to the data structure
@@ -1704,21 +1704,21 @@ Shape Manipulation
     *permute* is ``NULL``, the shape of the result is
     :math:`30\times20\times10.`
 
-.. cfunction:: PyObject* PyArray_Flatten(PyArrayObject* self, NPY_ORDER order)
+.. c:function:: PyObject* PyArray_Flatten(PyArrayObject* self, NPY_ORDER order)
 
     Equivalent to :meth:`ndarray.flatten` (*self*, *order*). Return a 1-d copy
-    of the array. If *order* is :cdata:`NPY_FORTRANORDER` the elements are
+    of the array. If *order* is :c:data:`NPY_FORTRANORDER` the elements are
     scanned out in Fortran order (first-dimension varies the
-    fastest). If *order* is :cdata:`NPY_CORDER`, the elements of ``self``
+    fastest). If *order* is :c:data:`NPY_CORDER`, the elements of ``self``
     are scanned in C-order (last dimension varies the fastest). If
-    *order* :cdata:`NPY_ANYORDER`, then the result of
-    :cfunc:`PyArray_ISFORTRAN` (*self*) is used to determine which order
+    *order* :c:data:`NPY_ANYORDER`, then the result of
+    :c:func:`PyArray_ISFORTRAN` (*self*) is used to determine which order
     to flatten.
 
-.. cfunction:: PyObject* PyArray_Ravel(PyArrayObject* self, NPY_ORDER order)
+.. c:function:: PyObject* PyArray_Ravel(PyArrayObject* self, NPY_ORDER order)
 
     Equivalent to *self*.ravel(*order*). Same basic functionality
-    as :cfunc:`PyArray_Flatten` (*self*, *order*) except if *order* is 0
+    as :c:func:`PyArray_Flatten` (*self*, *order*) except if *order* is 0
     and *self* is C-style contiguous, the shape is altered but no copy
     is performed.
 
@@ -1726,32 +1726,32 @@ Shape Manipulation
 Item selection and manipulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: PyObject* PyArray_TakeFrom(PyArrayObject* self, PyObject* indices, int axis, PyArrayObject* ret, NPY_CLIPMODE clipmode)
+.. c:function:: PyObject* PyArray_TakeFrom(PyArrayObject* self, PyObject* indices, int axis, PyArrayObject* ret, NPY_CLIPMODE clipmode)
 
     Equivalent to :meth:`ndarray.take` (*self*, *indices*, *axis*, *ret*,
     *clipmode*) except *axis* =None in Python is obtained by setting
-    *axis* = :cdata:`NPY_MAXDIMS` in C. Extract the items from self
+    *axis* = :c:data:`NPY_MAXDIMS` in C. Extract the items from self
     indicated by the integer-valued *indices* along the given *axis.*
-    The clipmode argument can be :cdata:`NPY_RAISE`, :cdata:`NPY_WRAP`, or
-    :cdata:`NPY_CLIP` to indicate what to do with out-of-bound indices. The
+    The clipmode argument can be :c:data:`NPY_RAISE`, :c:data:`NPY_WRAP`, or
+    :c:data:`NPY_CLIP` to indicate what to do with out-of-bound indices. The
     *ret* argument can specify an output array rather than having one
     created internally.
 
-.. cfunction:: PyObject* PyArray_PutTo(PyArrayObject* self, PyObject* values, PyObject* indices, NPY_CLIPMODE clipmode)
+.. c:function:: PyObject* PyArray_PutTo(PyArrayObject* self, PyObject* values, PyObject* indices, NPY_CLIPMODE clipmode)
 
     Equivalent to *self*.put(*values*, *indices*, *clipmode*
     ). Put *values* into *self* at the corresponding (flattened)
     *indices*. If *values* is too small it will be repeated as
     necessary.
 
-.. cfunction:: PyObject* PyArray_PutMask(PyArrayObject* self, PyObject* values, PyObject* mask)
+.. c:function:: PyObject* PyArray_PutMask(PyArrayObject* self, PyObject* values, PyObject* mask)
 
     Place the *values* in *self* wherever corresponding positions
     (using a flattened context) in *mask* are true. The *mask* and
     *self* arrays must have the same total number of elements. If
     *values* is too small, it will be repeated as necessary.
 
-.. cfunction:: PyObject* PyArray_Repeat(PyArrayObject* self, PyObject* op, int axis)
+.. c:function:: PyObject* PyArray_Repeat(PyArrayObject* self, PyObject* op, int axis)
 
     Equivalent to :meth:`ndarray.repeat` (*self*, *op*, *axis*). Copy the
     elements of *self*, *op* times along the given *axis*. Either
@@ -1759,7 +1759,7 @@ Item selection and manipulation
     ->dimensions[ *axis* ] indicating how many times to repeat each
     item along the axis.
 
-.. cfunction:: PyObject* PyArray_Choose(PyArrayObject* self, PyObject* op, PyArrayObject* ret, NPY_CLIPMODE clipmode)
+.. c:function:: PyObject* PyArray_Choose(PyArrayObject* self, PyObject* op, PyArrayObject* ret, NPY_CLIPMODE clipmode)
 
     Equivalent to :meth:`ndarray.choose` (*self*, *op*, *ret*, *clipmode*).
     Create a new array by selecting elements from the sequence of
@@ -1770,26 +1770,26 @@ Item selection and manipulation
     created. The *clipmode* argument determines behavior for when
     entries in *self* are not between 0 and len(*op*).
 
-    .. cvar:: NPY_RAISE
+    .. c:var:: NPY_RAISE
 
         raise a ValueError;
 
-    .. cvar:: NPY_WRAP
+    .. c:var:: NPY_WRAP
 
         wrap values < 0 by adding len(*op*) and values >=len(*op*)
         by subtracting len(*op*) until they are in range;
 
-    .. cvar:: NPY_CLIP
+    .. c:var:: NPY_CLIP
 
         all values are clipped to the region [0, len(*op*) ).
 
 
-.. cfunction:: PyObject* PyArray_Sort(PyArrayObject* self, int axis)
+.. c:function:: PyObject* PyArray_Sort(PyArrayObject* self, int axis)
 
     Equivalent to :meth:`ndarray.sort` (*self*, *axis*). Return an array with
     the items of *self* sorted along *axis*.
 
-.. cfunction:: PyObject* PyArray_ArgSort(PyArrayObject* self, int axis)
+.. c:function:: PyObject* PyArray_ArgSort(PyArrayObject* self, int axis)
 
     Equivalent to :meth:`ndarray.argsort` (*self*, *axis*). Return an array of
     indices such that selection of these indices along the given
@@ -1801,10 +1801,10 @@ Item selection and manipulation
     a new data-type with a different order of names and construct a
     view of the array with that new data-type.
 
-.. cfunction:: PyObject* PyArray_LexSort(PyObject* sort_keys, int axis)
+.. c:function:: PyObject* PyArray_LexSort(PyObject* sort_keys, int axis)
 
     Given a sequence of arrays (*sort_keys*) of the same shape,
-    return an array of indices (similar to :cfunc:`PyArray_ArgSort` (...))
+    return an array of indices (similar to :c:func:`PyArray_ArgSort` (...))
     that would sort the arrays lexicographically. A lexicographic sort
     specifies that when two keys are found to be equal, the order is
     based on comparison of subsequent keys. A merge sort (which leaves
@@ -1817,10 +1817,10 @@ Item selection and manipulation
     the order you would use when comparing two elements).
 
     If these arrays are all collected in a structured array, then
-    :cfunc:`PyArray_Sort` (...) can also be used to sort the array
+    :c:func:`PyArray_Sort` (...) can also be used to sort the array
     directly.
 
-.. cfunction:: PyObject* PyArray_SearchSorted(PyArrayObject* self, PyObject* values, NPY_SEARCHSIDE side, PyObject* perm)
+.. c:function:: PyObject* PyArray_SearchSorted(PyArrayObject* self, PyObject* values, NPY_SEARCHSIDE side, PyObject* perm)
 
     Equivalent to :meth:`ndarray.searchsorted` (*self*, *values*, *side*,
     *perm*). Assuming *self* is a 1-d array in ascending order, then the
@@ -1830,15 +1830,15 @@ Item selection and manipulation
     in ascending order.
 
     The *side* argument indicates whther the index returned should be that of
-    the first suitable location (if :cdata:`NPY_SEARCHLEFT`) or of the last
-    (if :cdata:`NPY_SEARCHRIGHT`).
+    the first suitable location (if :c:data:`NPY_SEARCHLEFT`) or of the last
+    (if :c:data:`NPY_SEARCHRIGHT`).
 
     The *sorter* argument, if not ``NULL``, must be a 1D array of integer
     indices the same length as *self*, that sorts it into ascending order.
-    This is typically the result of a call to :cfunc:`PyArray_ArgSort` (...)
+    This is typically the result of a call to :c:func:`PyArray_ArgSort` (...)
     Binary search is used to find the required insertion points.
 
-.. cfunction:: int PyArray_Partition(PyArrayObject *self, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
+.. c:function:: int PyArray_Partition(PyArrayObject *self, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
 
     Equivalent to :meth:`ndarray.partition` (*self*, *ktharray*, *axis*,
     *kind*). Partitions the array so that the values of the element indexed by
@@ -1853,33 +1853,33 @@ Item selection and manipulation
     order of names and construct a view of the array with that new data-type.
     Returns zero on success and -1 on failure.
 
-.. cfunction:: PyObject* PyArray_ArgPartition(PyArrayObject *op, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
+.. c:function:: PyObject* PyArray_ArgPartition(PyArrayObject *op, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
 
     Equivalent to :meth:`ndarray.argpartition` (*self*, *ktharray*, *axis*,
     *kind*). Return an array of indices such that selection of these indices
     along the given ``axis`` would return a partitioned version of *self*.
 
-.. cfunction:: PyObject* PyArray_Diagonal(PyArrayObject* self, int offset, int axis1, int axis2)
+.. c:function:: PyObject* PyArray_Diagonal(PyArrayObject* self, int offset, int axis1, int axis2)
 
     Equivalent to :meth:`ndarray.diagonal` (*self*, *offset*, *axis1*, *axis2*
     ). Return the *offset* diagonals of the 2-d arrays defined by
     *axis1* and *axis2*.
 
-.. cfunction:: npy_intp PyArray_CountNonzero(PyArrayObject* self)
+.. c:function:: npy_intp PyArray_CountNonzero(PyArrayObject* self)
 
     .. versionadded:: 1.6
 
     Counts the number of non-zero elements in the array object *self*.
 
-.. cfunction:: PyObject* PyArray_Nonzero(PyArrayObject* self)
+.. c:function:: PyObject* PyArray_Nonzero(PyArrayObject* self)
 
     Equivalent to :meth:`ndarray.nonzero` (*self*). Returns a tuple of index
     arrays that select elements of *self* that are nonzero. If (nd=
-    :cfunc:`PyArray_NDIM` ( ``self`` ))==1, then a single index array is
-    returned. The index arrays have data type :cdata:`NPY_INTP`. If a
+    :c:func:`PyArray_NDIM` ( ``self`` ))==1, then a single index array is
+    returned. The index arrays have data type :c:data:`NPY_INTP`. If a
     tuple is returned (nd :math:`\neq` 1), then its length is nd.
 
-.. cfunction:: PyObject* PyArray_Compress(PyArrayObject* self, PyObject* condition, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Compress(PyArrayObject* self, PyObject* condition, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.compress` (*self*, *condition*, *axis*
     ). Return the elements along *axis* corresponding to elements of
@@ -1891,16 +1891,16 @@ Calculation
 
 .. tip::
 
-    Pass in :cdata:`NPY_MAXDIMS` for axis in order to achieve the same
+    Pass in :c:data:`NPY_MAXDIMS` for axis in order to achieve the same
     effect that is obtained by passing in *axis* = :const:`None` in Python
     (treating the array as a 1-d array).
 
-.. cfunction:: PyObject* PyArray_ArgMax(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_ArgMax(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.argmax` (*self*, *axis*). Return the index of
     the largest element of *self* along *axis*.
 
-.. cfunction:: PyObject* PyArray_ArgMin(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_ArgMin(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.argmin` (*self*, *axis*). Return the index of
     the smallest element of *self* along *axis*.
@@ -1917,17 +1917,17 @@ Calculation
     is not NULL. The caller of the routine has the responsability
     to ``DECREF`` out if not NULL or a memory-leak will occur.
 
-.. cfunction:: PyObject* PyArray_Max(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Max(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.max` (*self*, *axis*). Return the largest
     element of *self* along the given *axis*.
 
-.. cfunction:: PyObject* PyArray_Min(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Min(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.min` (*self*, *axis*). Return the smallest
     element of *self* along the given *axis*.
 
-.. cfunction:: PyObject* PyArray_Ptp(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Ptp(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.ptp` (*self*, *axis*). Return the difference
     between the largest element of *self* along *axis* and the
@@ -1940,18 +1940,18 @@ Calculation
     The rtype argument specifies the data-type the reduction should
     take place over. This is important if the data-type of the array
     is not "large" enough to handle the output. By default, all
-    integer data-types are made at least as large as :cdata:`NPY_LONG`
+    integer data-types are made at least as large as :c:data:`NPY_LONG`
     for the "add" and "multiply" ufuncs (which form the basis for
     mean, sum, cumsum, prod, and cumprod functions).
 
-.. cfunction:: PyObject* PyArray_Mean(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Mean(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.mean` (*self*, *axis*, *rtype*). Returns the
     mean of the elements along the given *axis*, using the enumerated
     type *rtype* as the data type to sum in. Default sum behavior is
-    obtained using :cdata:`NPY_NOTYPE` for *rtype*.
+    obtained using :c:data:`NPY_NOTYPE` for *rtype*.
 
-.. cfunction:: PyObject* PyArray_Trace(PyArrayObject* self, int offset, int axis1, int axis2, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Trace(PyArrayObject* self, int offset, int axis1, int axis2, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.trace` (*self*, *offset*, *axis1*, *axis2*,
     *rtype*). Return the sum (using *rtype* as the data type of
@@ -1960,62 +1960,62 @@ Calculation
     chooses diagonals above the main diagonal. A negative offset
     selects diagonals below the main diagonal.
 
-.. cfunction:: PyObject* PyArray_Clip(PyArrayObject* self, PyObject* min, PyObject* max)
+.. c:function:: PyObject* PyArray_Clip(PyArrayObject* self, PyObject* min, PyObject* max)
 
     Equivalent to :meth:`ndarray.clip` (*self*, *min*, *max*). Clip an array,
     *self*, so that values larger than *max* are fixed to *max* and
     values less than *min* are fixed to *min*.
 
-.. cfunction:: PyObject* PyArray_Conjugate(PyArrayObject* self)
+.. c:function:: PyObject* PyArray_Conjugate(PyArrayObject* self)
 
     Equivalent to :meth:`ndarray.conjugate` (*self*).
     Return the complex conjugate of *self*. If *self* is not of
     complex data type, then return *self* with an reference.
 
-.. cfunction:: PyObject* PyArray_Round(PyArrayObject* self, int decimals, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Round(PyArrayObject* self, int decimals, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.round` (*self*, *decimals*, *out*). Returns
     the array with elements rounded to the nearest decimal place. The
     decimal place is defined as the :math:`10^{-\textrm{decimals}}`
     digit so that negative *decimals* cause rounding to the nearest 10's, 100's, etc. If out is ``NULL``, then the output array is created, otherwise the output is placed in *out* which must be the correct size and type.
 
-.. cfunction:: PyObject* PyArray_Std(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Std(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.std` (*self*, *axis*, *rtype*). Return the
     standard deviation using data along *axis* converted to data type
     *rtype*.
 
-.. cfunction:: PyObject* PyArray_Sum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Sum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.sum` (*self*, *axis*, *rtype*). Return 1-d
     vector sums of elements in *self* along *axis*. Perform the sum
     after converting data to data type *rtype*.
 
-.. cfunction:: PyObject* PyArray_CumSum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_CumSum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.cumsum` (*self*, *axis*, *rtype*). Return
     cumulative 1-d sums of elements in *self* along *axis*. Perform
     the sum after converting data to data type *rtype*.
 
-.. cfunction:: PyObject* PyArray_Prod(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Prod(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.prod` (*self*, *axis*, *rtype*). Return 1-d
     products of elements in *self* along *axis*. Perform the product
     after converting data to data type *rtype*.
 
-.. cfunction:: PyObject* PyArray_CumProd(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_CumProd(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.cumprod` (*self*, *axis*, *rtype*). Return
     1-d cumulative products of elements in ``self`` along ``axis``.
     Perform the product after converting data to data type ``rtype``.
 
-.. cfunction:: PyObject* PyArray_All(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_All(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.all` (*self*, *axis*). Return an array with
     True elements for every 1-d sub-array of ``self`` defined by
     ``axis`` in which all the elements are True.
 
-.. cfunction:: PyObject* PyArray_Any(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Any(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.any` (*self*, *axis*). Return an array with
     True elements for every 1-d sub-array of *self* defined by *axis*
@@ -2028,7 +2028,7 @@ Functions
 Array Functions
 ^^^^^^^^^^^^^^^
 
-.. cfunction:: int PyArray_AsCArray(PyObject** op, void* ptr, npy_intp* dims, int nd, int typenum, int itemsize)
+.. c:function:: int PyArray_AsCArray(PyObject** op, void* ptr, npy_intp* dims, int nd, int typenum, int itemsize)
 
     Sometimes it is useful to access a multidimensional array as a
     C-style multi-dimensional array so that algorithms can be
@@ -2075,30 +2075,30 @@ Array Functions
     arrays. To pass to functions requiring those kind of inputs, you must
     statically define the required array and copy data.
 
-.. cfunction:: int PyArray_Free(PyObject* op, void* ptr)
+.. c:function:: int PyArray_Free(PyObject* op, void* ptr)
 
     Must be called with the same objects and memory locations returned
-    from :cfunc:`PyArray_AsCArray` (...). This function cleans up memory
+    from :c:func:`PyArray_AsCArray` (...). This function cleans up memory
     that otherwise would get leaked.
 
-.. cfunction:: PyObject* PyArray_Concatenate(PyObject* obj, int axis)
+.. c:function:: PyObject* PyArray_Concatenate(PyObject* obj, int axis)
 
     Join the sequence of objects in *obj* together along *axis* into a
     single array. If the dimensions or types are not compatible an
     error is raised.
 
-.. cfunction:: PyObject* PyArray_InnerProduct(PyObject* obj1, PyObject* obj2)
+.. c:function:: PyObject* PyArray_InnerProduct(PyObject* obj1, PyObject* obj2)
 
     Compute a product-sum over the last dimensions of *obj1* and
     *obj2*. Neither array is conjugated.
 
-.. cfunction:: PyObject* PyArray_MatrixProduct(PyObject* obj1, PyObject* obj)
+.. c:function:: PyObject* PyArray_MatrixProduct(PyObject* obj1, PyObject* obj)
 
     Compute a product-sum over the last dimension of *obj1* and the
     second-to-last dimension of *obj2*. For 2-d arrays this is a
     matrix-product. Neither array is conjugated.
 
-.. cfunction:: PyObject* PyArray_MatrixProduct2(PyObject* obj1, PyObject* obj, PyObject* out)
+.. c:function:: PyObject* PyArray_MatrixProduct2(PyObject* obj1, PyObject* obj, PyObject* out)
 
     .. versionadded:: 1.6
 
@@ -2106,7 +2106,7 @@ Array Functions
     output array must have the correct shape, type, and be
     C-contiguous, or an exception is raised.
 
-.. cfunction:: PyObject* PyArray_EinsteinSum(char* subscripts, npy_intp nop, PyArrayObject** op_in, PyArray_Descr* dtype, NPY_ORDER order, NPY_CASTING casting, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_EinsteinSum(char* subscripts, npy_intp nop, PyArrayObject** op_in, PyArray_Descr* dtype, NPY_ORDER order, NPY_CASTING casting, PyArrayObject* out)
 
     .. versionadded:: 1.6
 
@@ -2116,17 +2116,17 @@ Array Functions
     letters. The number of operands is in *nop*, and *op_in* is an
     array containing those operands. The data type of the output can
     be forced with *dtype*, the output order can be forced with *order*
-    (:cdata:`NPY_KEEPORDER` is recommended), and when *dtype* is specified,
+    (:c:data:`NPY_KEEPORDER` is recommended), and when *dtype* is specified,
     *casting* indicates how permissive the data conversion should be.
 
     See the :func:`einsum` function for more details.
 
-.. cfunction:: PyObject* PyArray_CopyAndTranspose(PyObject \* op)
+.. c:function:: PyObject* PyArray_CopyAndTranspose(PyObject \* op)
 
     A specialized copy and transpose function that works only for 2-d
     arrays. The returned array is a transposed copy of *op*.
 
-.. cfunction:: PyObject* PyArray_Correlate(PyObject* op1, PyObject* op2, int mode)
+.. c:function:: PyObject* PyArray_Correlate(PyObject* op1, PyObject* op2, int mode)
 
     Compute the 1-d correlation of the 1-d arrays *op1* and *op2*
     . The correlation is computed at each output point by multiplying
@@ -2144,7 +2144,7 @@ Array Functions
     arguments are swapped, and the conjugate is never taken for complex arrays.
     See PyArray_Correlate2 for the usual signal processing correlation.
 
-.. cfunction:: PyObject* PyArray_Correlate2(PyObject* op1, PyObject* op2, int mode)
+.. c:function:: PyObject* PyArray_Correlate2(PyObject* op1, PyObject* op2, int mode)
 
     Updated version of PyArray_Correlate, which uses the usual definition of
     correlation for 1d arrays. The correlation is computed at each output point
@@ -2161,10 +2161,10 @@ Array Functions
 
       z[k] = sum_n op1[n] * conj(op2[n+k])
 
-.. cfunction:: PyObject* PyArray_Where(PyObject* condition, PyObject* x, PyObject* y)
+.. c:function:: PyObject* PyArray_Where(PyObject* condition, PyObject* x, PyObject* y)
 
     If both ``x`` and ``y`` are ``NULL``, then return
-    :cfunc:`PyArray_Nonzero` (*condition*). Otherwise, both *x* and *y*
+    :c:func:`PyArray_Nonzero` (*condition*). Otherwise, both *x* and *y*
     must be given and the object returned is shaped like *condition*
     and has elements of *x* and *y* where *condition* is respectively
     True or False.
@@ -2173,7 +2173,7 @@ Array Functions
 Other functions
 ^^^^^^^^^^^^^^^
 
-.. cfunction:: Bool PyArray_CheckStrides(int elsize, int nd, npy_intp numbytes, npy_intp* dims, npy_intp* newstrides)
+.. c:function:: Bool PyArray_CheckStrides(int elsize, int nd, npy_intp numbytes, npy_intp* dims, npy_intp* newstrides)
 
     Determine if *newstrides* is a strides array consistent with the
     memory of an *nd* -dimensional array with shape ``dims`` and
@@ -2182,17 +2182,17 @@ Other functions
     ever mean jumping more than *numbytes* which is the assumed size
     of the available memory segment. If *numbytes* is 0, then an
     equivalent *numbytes* is computed assuming *nd*, *dims*, and
-    *elsize* refer to a single-segment array. Return :cdata:`NPY_TRUE` if
-    *newstrides* is acceptable, otherwise return :cdata:`NPY_FALSE`.
+    *elsize* refer to a single-segment array. Return :c:data:`NPY_TRUE` if
+    *newstrides* is acceptable, otherwise return :c:data:`NPY_FALSE`.
 
-.. cfunction:: npy_intp PyArray_MultiplyList(npy_intp* seq, int n)
+.. c:function:: npy_intp PyArray_MultiplyList(npy_intp* seq, int n)
 
-.. cfunction:: int PyArray_MultiplyIntList(int* seq, int n)
+.. c:function:: int PyArray_MultiplyIntList(int* seq, int n)
 
     Both of these routines multiply an *n* -length array, *seq*, of
     integers and return the result. No overflow checking is performed.
 
-.. cfunction:: int PyArray_CompareLists(npy_intp* l1, npy_intp* l2, int n)
+.. c:function:: int PyArray_CompareLists(npy_intp* l1, npy_intp* l2, int n)
 
     Given two *n* -length arrays of integers, *l1*, and *l2*, return
     1 if the lists are identical; otherwise, return 0.
@@ -2203,15 +2203,15 @@ Auxiliary Data With Object Semantics
 
 .. versionadded:: 1.7.0
 
-.. ctype:: NpyAuxData
+.. c:type:: NpyAuxData
 
 When working with more complex dtypes which are composed of other dtypes,
 such as the struct dtype, creating inner loops that manipulate the dtypes
 requires carrying along additional data. NumPy supports this idea
-through a struct :ctype:`NpyAuxData`, mandating a few conventions so that
+through a struct :c:type:`NpyAuxData`, mandating a few conventions so that
 it is possible to do this.
 
-Defining an :ctype:`NpyAuxData` is similar to defining a class in C++,
+Defining an :c:type:`NpyAuxData` is similar to defining a class in C++,
 but the object semantics have to be tracked manually since the API is in C.
 Here's an example for a function which doubles up an element using
 an element copier function as a primitive.::
@@ -2268,22 +2268,22 @@ an element copier function as a primitive.::
         return (NpyAuxData *)ret;
     }
 
-.. ctype:: NpyAuxData_FreeFunc
+.. c:type:: NpyAuxData_FreeFunc
 
     The function pointer type for NpyAuxData free functions.
 
-.. ctype:: NpyAuxData_CloneFunc
+.. c:type:: NpyAuxData_CloneFunc
 
     The function pointer type for NpyAuxData clone functions. These
     functions should never set the Python exception on error, because
     they may be called from a multi-threaded context.
 
-.. cfunction:: NPY_AUXDATA_FREE(auxdata)
+.. c:function:: NPY_AUXDATA_FREE(auxdata)
 
     A macro which calls the auxdata's free function appropriately,
     does nothing if auxdata is NULL.
 
-.. cfunction:: NPY_AUXDATA_CLONE(auxdata)
+.. c:function:: NPY_AUXDATA_CLONE(auxdata)
 
     A macro which calls the auxdata's clone function appropriately,
     returning a deep copy of the auxiliary data.
@@ -2292,69 +2292,69 @@ Array Iterators
 ---------------
 
 As of Numpy 1.6, these array iterators are superceded by
-the new array iterator, :ctype:`NpyIter`.
+the new array iterator, :c:type:`NpyIter`.
 
 An array iterator is a simple way to access the elements of an
 N-dimensional array quickly and efficiently. Section `2
 <#sec-array-iterator>`__ provides more description and examples of
 this useful approach to looping over an array.
 
-.. cfunction:: PyObject* PyArray_IterNew(PyObject* arr)
+.. c:function:: PyObject* PyArray_IterNew(PyObject* arr)
 
     Return an array iterator object from the array, *arr*. This is
     equivalent to *arr*. **flat**. The array iterator object makes
     it easy to loop over an N-dimensional non-contiguous array in
     C-style contiguous fashion.
 
-.. cfunction:: PyObject* PyArray_IterAllButAxis(PyObject* arr, int \*axis)
+.. c:function:: PyObject* PyArray_IterAllButAxis(PyObject* arr, int \*axis)
 
     Return an array iterator that will iterate over all axes but the
     one provided in *\*axis*. The returned iterator cannot be used
-    with :cfunc:`PyArray_ITER_GOTO1D`. This iterator could be used to
+    with :c:func:`PyArray_ITER_GOTO1D`. This iterator could be used to
     write something similar to what ufuncs do wherein the loop over
     the largest axis is done by a separate sub-routine. If *\*axis* is
     negative then *\*axis* will be set to the axis having the smallest
     stride and that axis will be used.
 
-.. cfunction:: PyObject *PyArray_BroadcastToShape(PyObject* arr, npy_intp *dimensions, int nd)
+.. c:function:: PyObject *PyArray_BroadcastToShape(PyObject* arr, npy_intp *dimensions, int nd)
 
     Return an array iterator that is broadcast to iterate as an array
     of the shape provided by *dimensions* and *nd*.
 
-.. cfunction:: int PyArrayIter_Check(PyObject* op)
+.. c:function:: int PyArrayIter_Check(PyObject* op)
 
     Evaluates true if *op* is an array iterator (or instance of a
     subclass of the array iterator type).
 
-.. cfunction:: void PyArray_ITER_RESET(PyObject* iterator)
+.. c:function:: void PyArray_ITER_RESET(PyObject* iterator)
 
     Reset an *iterator* to the beginning of the array.
 
-.. cfunction:: void PyArray_ITER_NEXT(PyObject* iterator)
+.. c:function:: void PyArray_ITER_NEXT(PyObject* iterator)
 
     Incremement the index and the dataptr members of the *iterator* to
     point to the next element of the array. If the array is not
     (C-style) contiguous, also increment the N-dimensional coordinates
     array.
 
-.. cfunction:: void *PyArray_ITER_DATA(PyObject* iterator)
+.. c:function:: void *PyArray_ITER_DATA(PyObject* iterator)
 
     A pointer to the current element of the array.
 
-.. cfunction:: void PyArray_ITER_GOTO(PyObject* iterator, npy_intp* destination)
+.. c:function:: void PyArray_ITER_GOTO(PyObject* iterator, npy_intp* destination)
 
     Set the *iterator* index, dataptr, and coordinates members to the
     location in the array indicated by the N-dimensional c-array,
     *destination*, which must have size at least *iterator*
     ->nd_m1+1.
 
-.. cfunction:: PyArray_ITER_GOTO1D(PyObject* iterator, npy_intp index)
+.. c:function:: PyArray_ITER_GOTO1D(PyObject* iterator, npy_intp index)
 
     Set the *iterator* index and dataptr to the location in the array
     indicated by the integer *index* which points to an element in the
     C-styled flattened array.
 
-.. cfunction:: int PyArray_ITER_NOTDONE(PyObject* iterator)
+.. c:function:: int PyArray_ITER_NOTDONE(PyObject* iterator)
 
     Evaluates TRUE as long as the iterator has not looped through all of
     the elements, otherwise it evaluates FALSE.
@@ -2363,55 +2363,55 @@ this useful approach to looping over an array.
 Broadcasting (multi-iterators)
 ------------------------------
 
-.. cfunction:: PyObject* PyArray_MultiIterNew(int num, ...)
+.. c:function:: PyObject* PyArray_MultiIterNew(int num, ...)
 
     A simplified interface to broadcasting. This function takes the
-    number of arrays to broadcast and then *num* extra ( :ctype:`PyObject *`
+    number of arrays to broadcast and then *num* extra ( :c:type:`PyObject *`
     ) arguments. These arguments are converted to arrays and iterators
-    are created. :cfunc:`PyArray_Broadcast` is then called on the resulting
+    are created. :c:func:`PyArray_Broadcast` is then called on the resulting
     multi-iterator object. The resulting, broadcasted mult-iterator
     object is then returned. A broadcasted operation can then be
-    performed using a single loop and using :cfunc:`PyArray_MultiIter_NEXT`
+    performed using a single loop and using :c:func:`PyArray_MultiIter_NEXT`
     (..)
 
-.. cfunction:: void PyArray_MultiIter_RESET(PyObject* multi)
+.. c:function:: void PyArray_MultiIter_RESET(PyObject* multi)
 
     Reset all the iterators to the beginning in a multi-iterator
     object, *multi*.
 
-.. cfunction:: void PyArray_MultiIter_NEXT(PyObject* multi)
+.. c:function:: void PyArray_MultiIter_NEXT(PyObject* multi)
 
     Advance each iterator in a multi-iterator object, *multi*, to its
     next (broadcasted) element.
 
-.. cfunction:: void *PyArray_MultiIter_DATA(PyObject* multi, int i)
+.. c:function:: void *PyArray_MultiIter_DATA(PyObject* multi, int i)
 
     Return the data-pointer of the *i* :math:`^{\textrm{th}}` iterator
     in a multi-iterator object.
 
-.. cfunction:: void PyArray_MultiIter_NEXTi(PyObject* multi, int i)
+.. c:function:: void PyArray_MultiIter_NEXTi(PyObject* multi, int i)
 
     Advance the pointer of only the *i* :math:`^{\textrm{th}}` iterator.
 
-.. cfunction:: void PyArray_MultiIter_GOTO(PyObject* multi, npy_intp* destination)
+.. c:function:: void PyArray_MultiIter_GOTO(PyObject* multi, npy_intp* destination)
 
     Advance each iterator in a multi-iterator object, *multi*, to the
     given :math:`N` -dimensional *destination* where :math:`N` is the
     number of dimensions in the broadcasted array.
 
-.. cfunction:: void PyArray_MultiIter_GOTO1D(PyObject* multi, npy_intp index)
+.. c:function:: void PyArray_MultiIter_GOTO1D(PyObject* multi, npy_intp index)
 
     Advance each iterator in a multi-iterator object, *multi*, to the
     corresponding location of the *index* into the flattened
     broadcasted array.
 
-.. cfunction:: int PyArray_MultiIter_NOTDONE(PyObject* multi)
+.. c:function:: int PyArray_MultiIter_NOTDONE(PyObject* multi)
 
     Evaluates TRUE as long as the multi-iterator has not looped
     through all of the elements (of the broadcasted result), otherwise
     it evaluates FALSE.
 
-.. cfunction:: int PyArray_Broadcast(PyArrayMultiIterObject* mit)
+.. c:function:: int PyArray_Broadcast(PyArrayMultiIterObject* mit)
 
     This function encapsulates the broadcasting rules. The *mit*
     container should already contain iterators for all the arrays that
@@ -2419,7 +2419,7 @@ Broadcasting (multi-iterators)
     so that iteration over each simultaneously will accomplish the
     broadcasting. A negative number is returned if an error occurs.
 
-.. cfunction:: int PyArray_RemoveSmallest(PyArrayMultiIterObject* mit)
+.. c:function:: int PyArray_RemoveSmallest(PyArrayMultiIterObject* mit)
 
     This function takes a multi-iterator object that has been
     previously "broadcasted," finds the dimension with the smallest
@@ -2446,7 +2446,7 @@ hypercube. Neighborhood iterator automatically handle boundaries, thus making
 this kind of code much easier to write than manual boundaries handling, at the
 cost of a slight overhead.
 
-.. cfunction:: PyObject* PyArray_NeighborhoodIterNew(PyArrayIterObject* iter, npy_intp bounds, int mode, PyArrayObject* fill_value)
+.. c:function:: PyObject* PyArray_NeighborhoodIterNew(PyArrayIterObject* iter, npy_intp bounds, int mode, PyArrayObject* fill_value)
 
     This function creates a new neighborhood iterator from an existing
     iterator.  The neighborhood will be computed relatively to the position
@@ -2513,13 +2513,13 @@ cost of a slight overhead.
             PyArrayNeighborhoodIter_Reset(neigh_iter);
        }
 
-.. cfunction:: int PyArrayNeighborhoodIter_Reset(PyArrayNeighborhoodIterObject* iter)
+.. c:function:: int PyArrayNeighborhoodIter_Reset(PyArrayNeighborhoodIterObject* iter)
 
     Reset the iterator position to the first point of the neighborhood. This
     should be called whenever the iter argument given at
     PyArray_NeighborhoodIterObject is changed (see example)
 
-.. cfunction:: int PyArrayNeighborhoodIter_Next(PyArrayNeighborhoodIterObject* iter)
+.. c:function:: int PyArrayNeighborhoodIter_Next(PyArrayNeighborhoodIterObject* iter)
 
     After this call, iter->dataptr points to the next point of the
     neighborhood. Calling this function after every point of the
@@ -2528,7 +2528,7 @@ cost of a slight overhead.
 Array Scalars
 -------------
 
-.. cfunction:: PyObject* PyArray_Return(PyArrayObject* arr)
+.. c:function:: PyObject* PyArray_Return(PyArrayObject* arr)
 
     This function steals a reference to *arr*.
 
@@ -2536,7 +2536,7 @@ Array Scalars
     if so, returns the appropriate array scalar. It should be used
     whenever 0-dimensional arrays could be returned to Python.
 
-.. cfunction:: PyObject* PyArray_Scalar(void* data, PyArray_Descr* dtype, PyObject* itemsize)
+.. c:function:: PyObject* PyArray_Scalar(void* data, PyArray_Descr* dtype, PyObject* itemsize)
 
     Return an array scalar object of the given enumerated *typenum*
     and *itemsize* by **copying** from memory pointed to by *data*
@@ -2544,20 +2544,20 @@ Array Scalars
     if appropriate to the data-type because array scalars are always
     in correct machine-byte order.
 
-.. cfunction:: PyObject* PyArray_ToScalar(void* data, PyArrayObject* arr)
+.. c:function:: PyObject* PyArray_ToScalar(void* data, PyArrayObject* arr)
 
     Return an array scalar object of the type and itemsize indicated
     by the array object *arr* copied from the memory pointed to by
     *data* and swapping if the data in *arr* is not in machine
     byte-order.
 
-.. cfunction:: PyObject* PyArray_FromScalar(PyObject* scalar, PyArray_Descr* outcode)
+.. c:function:: PyObject* PyArray_FromScalar(PyObject* scalar, PyArray_Descr* outcode)
 
     Return a 0-dimensional array of type determined by *outcode* from
     *scalar* which should be an array-scalar object. If *outcode* is
     NULL, then the type is determined from *scalar*.
 
-.. cfunction:: void PyArray_ScalarAsCtype(PyObject* scalar, void* ctypeptr)
+.. c:function:: void PyArray_ScalarAsCtype(PyObject* scalar, void* ctypeptr)
 
     Return in *ctypeptr* a pointer to the actual value in an array
     scalar. There is no error checking so *scalar* must be an
@@ -2566,45 +2566,45 @@ Array Scalars
     is copied into the memory of *ctypeptr*, for all other types, the
     actual data is copied into the address pointed to by *ctypeptr*.
 
-.. cfunction:: void PyArray_CastScalarToCtype(PyObject* scalar, void* ctypeptr, PyArray_Descr* outcode)
+.. c:function:: void PyArray_CastScalarToCtype(PyObject* scalar, void* ctypeptr, PyArray_Descr* outcode)
 
     Return the data (cast to the data type indicated by *outcode*)
     from the array-scalar, *scalar*, into the memory pointed to by
     *ctypeptr* (which must be large enough to handle the incoming
     memory).
 
-.. cfunction:: PyObject* PyArray_TypeObjectFromType(int type)
+.. c:function:: PyObject* PyArray_TypeObjectFromType(int type)
 
     Returns a scalar type-object from a type-number, *type*
-    . Equivalent to :cfunc:`PyArray_DescrFromType` (*type*)->typeobj
+    . Equivalent to :c:func:`PyArray_DescrFromType` (*type*)->typeobj
     except for reference counting and error-checking. Returns a new
     reference to the typeobject on success or ``NULL`` on failure.
 
-.. cfunction:: NPY_SCALARKIND PyArray_ScalarKind(int typenum, PyArrayObject** arr)
+.. c:function:: NPY_SCALARKIND PyArray_ScalarKind(int typenum, PyArrayObject** arr)
 
-    See the function :cfunc:`PyArray_MinScalarType` for an alternative
+    See the function :c:func:`PyArray_MinScalarType` for an alternative
     mechanism introduced in NumPy 1.6.0.
 
     Return the kind of scalar represented by *typenum* and the array
     in *\*arr* (if *arr* is not ``NULL`` ). The array is assumed to be
     rank-0 and only used if *typenum* represents a signed integer. If
     *arr* is not ``NULL`` and the first element is negative then
-    :cdata:`NPY_INTNEG_SCALAR` is returned, otherwise
-    :cdata:`NPY_INTPOS_SCALAR` is returned. The possible return values
-    are :cdata:`NPY_{kind}_SCALAR` where ``{kind}`` can be **INTPOS**,
+    :c:data:`NPY_INTNEG_SCALAR` is returned, otherwise
+    :c:data:`NPY_INTPOS_SCALAR` is returned. The possible return values
+    are :c:data:`NPY_{kind}_SCALAR` where ``{kind}`` can be **INTPOS**,
     **INTNEG**, **FLOAT**, **COMPLEX**, **BOOL**, or **OBJECT**.
-    :cdata:`NPY_NOSCALAR` is also an enumerated value
-    :ctype:`NPY_SCALARKIND` variables can take on.
+    :c:data:`NPY_NOSCALAR` is also an enumerated value
+    :c:type:`NPY_SCALARKIND` variables can take on.
 
-.. cfunction:: int PyArray_CanCoerceScalar(char thistype, char neededtype, NPY_SCALARKIND scalar)
+.. c:function:: int PyArray_CanCoerceScalar(char thistype, char neededtype, NPY_SCALARKIND scalar)
 
-    See the function :cfunc:`PyArray_ResultType` for details of
+    See the function :c:func:`PyArray_ResultType` for details of
     NumPy type promotion, updated in NumPy 1.6.0.
 
     Implements the rules for scalar coercion. Scalars are only
     silently coerced from thistype to neededtype if this function
-    returns nonzero.  If scalar is :cdata:`NPY_NOSCALAR`, then this
-    function is equivalent to :cfunc:`PyArray_CanCastSafely`. The rule is
+    returns nonzero.  If scalar is :c:data:`NPY_NOSCALAR`, then this
+    function is equivalent to :c:func:`PyArray_CanCastSafely`. The rule is
     that scalars of the same KIND can be coerced into arrays of the
     same KIND. This rule means that high-precision scalars will never
     cause low-precision arrays of the same KIND to be upcast.
@@ -2620,78 +2620,78 @@ Data-type descriptors
     Data-type objects must be reference counted so be aware of the
     action on the data-type reference of different C-API calls. The
     standard rule is that when a data-type object is returned it is a
-    new reference.  Functions that take :ctype:`PyArray_Descr *` objects and
+    new reference.  Functions that take :c:type:`PyArray_Descr *` objects and
     return arrays steal references to the data-type their inputs
     unless otherwise noted. Therefore, you must own a reference to any
     data-type object used as input to such a function.
 
-.. cfunction:: int PyArray_DescrCheck(PyObject* obj)
+.. c:function:: int PyArray_DescrCheck(PyObject* obj)
 
-    Evaluates as true if *obj* is a data-type object ( :ctype:`PyArray_Descr *` ).
+    Evaluates as true if *obj* is a data-type object ( :c:type:`PyArray_Descr *` ).
 
-.. cfunction:: PyArray_Descr* PyArray_DescrNew(PyArray_Descr* obj)
+.. c:function:: PyArray_Descr* PyArray_DescrNew(PyArray_Descr* obj)
 
     Return a new data-type object copied from *obj* (the fields
     reference is just updated so that the new object points to the
     same fields dictionary if any).
 
-.. cfunction:: PyArray_Descr* PyArray_DescrNewFromType(int typenum)
+.. c:function:: PyArray_Descr* PyArray_DescrNewFromType(int typenum)
 
     Create a new data-type object from the built-in (or
     user-registered) data-type indicated by *typenum*. All builtin
     types should not have any of their fields changed. This creates a
-    new copy of the :ctype:`PyArray_Descr` structure so that you can fill
+    new copy of the :c:type:`PyArray_Descr` structure so that you can fill
     it in as appropriate. This function is especially needed for
     flexible data-types which need to have a new elsize member in
     order to be meaningful in array construction.
 
-.. cfunction:: PyArray_Descr* PyArray_DescrNewByteorder(PyArray_Descr* obj, char newendian)
+.. c:function:: PyArray_Descr* PyArray_DescrNewByteorder(PyArray_Descr* obj, char newendian)
 
     Create a new data-type object with the byteorder set according to
     *newendian*. All referenced data-type objects (in subdescr and
     fields members of the data-type object) are also changed
-    (recursively). If a byteorder of :cdata:`NPY_IGNORE` is encountered it
-    is left alone. If newendian is :cdata:`NPY_SWAP`, then all byte-orders
-    are swapped. Other valid newendian values are :cdata:`NPY_NATIVE`,
-    :cdata:`NPY_LITTLE`, and :cdata:`NPY_BIG` which all cause the returned
+    (recursively). If a byteorder of :c:data:`NPY_IGNORE` is encountered it
+    is left alone. If newendian is :c:data:`NPY_SWAP`, then all byte-orders
+    are swapped. Other valid newendian values are :c:data:`NPY_NATIVE`,
+    :c:data:`NPY_LITTLE`, and :c:data:`NPY_BIG` which all cause the returned
     data-typed descriptor (and all it's
     referenced data-type descriptors) to have the corresponding byte-
     order.
 
-.. cfunction:: PyArray_Descr* PyArray_DescrFromObject(PyObject* op, PyArray_Descr* mintype)
+.. c:function:: PyArray_Descr* PyArray_DescrFromObject(PyObject* op, PyArray_Descr* mintype)
 
     Determine an appropriate data-type object from the object *op*
     (which should be a "nested" sequence object) and the minimum
     data-type descriptor mintype (which can be ``NULL`` ). Similar in
     behavior to array(*op*).dtype. Don't confuse this function with
-    :cfunc:`PyArray_DescrConverter`. This function essentially looks at
+    :c:func:`PyArray_DescrConverter`. This function essentially looks at
     all the objects in the (nested) sequence and determines the
     data-type from the elements it finds.
 
-.. cfunction:: PyArray_Descr* PyArray_DescrFromScalar(PyObject* scalar)
+.. c:function:: PyArray_Descr* PyArray_DescrFromScalar(PyObject* scalar)
 
     Return a data-type object from an array-scalar object. No checking
     is done to be sure that *scalar* is an array scalar. If no
     suitable data-type can be determined, then a data-type of
-    :cdata:`NPY_OBJECT` is returned by default.
+    :c:data:`NPY_OBJECT` is returned by default.
 
-.. cfunction:: PyArray_Descr* PyArray_DescrFromType(int typenum)
+.. c:function:: PyArray_Descr* PyArray_DescrFromType(int typenum)
 
     Returns a data-type object corresponding to *typenum*. The
     *typenum* can be one of the enumerated types, a character code for
     one of the enumerated types, or a user-defined type.
 
-.. cfunction:: int PyArray_DescrConverter(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int PyArray_DescrConverter(PyObject* obj, PyArray_Descr** dtype)
 
     Convert any compatible Python object, *obj*, to a data-type object
     in *dtype*. A large number of Python objects can be converted to
     data-type objects. See :ref:`arrays.dtypes` for a complete
     description. This version of the converter converts None objects
-    to a :cdata:`NPY_DEFAULT_TYPE` data-type object. This function can
-    be used with the "O&" character code in :cfunc:`PyArg_ParseTuple`
+    to a :c:data:`NPY_DEFAULT_TYPE` data-type object. This function can
+    be used with the "O&" character code in :c:func:`PyArg_ParseTuple`
     processing.
 
-.. cfunction:: int PyArray_DescrConverter2(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int PyArray_DescrConverter2(PyObject* obj, PyArray_Descr** dtype)
 
     Convert any compatible Python object, *obj*, to a data-type
     object in *dtype*. This version of the converter converts None
@@ -2699,34 +2699,34 @@ Data-type descriptors
     can also be used with the "O&" character in PyArg_ParseTuple
     processing.
 
-.. cfunction:: int Pyarray_DescrAlignConverter(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int Pyarray_DescrAlignConverter(PyObject* obj, PyArray_Descr** dtype)
 
-    Like :cfunc:`PyArray_DescrConverter` except it aligns C-struct-like
+    Like :c:func:`PyArray_DescrConverter` except it aligns C-struct-like
     objects on word-boundaries as the compiler would.
 
-.. cfunction:: int Pyarray_DescrAlignConverter2(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int Pyarray_DescrAlignConverter2(PyObject* obj, PyArray_Descr** dtype)
 
-    Like :cfunc:`PyArray_DescrConverter2` except it aligns C-struct-like
+    Like :c:func:`PyArray_DescrConverter2` except it aligns C-struct-like
     objects on word-boundaries as the compiler would.
 
-.. cfunction:: PyObject *PyArray_FieldNames(PyObject* dict)
+.. c:function:: PyObject *PyArray_FieldNames(PyObject* dict)
 
     Take the fields dictionary, *dict*, such as the one attached to a
     data-type object and construct an ordered-list of field names such
-    as is stored in the names field of the :ctype:`PyArray_Descr` object.
+    as is stored in the names field of the :c:type:`PyArray_Descr` object.
 
 
 Conversion Utilities
 --------------------
 
 
-For use with :cfunc:`PyArg_ParseTuple`
+For use with :c:func:`PyArg_ParseTuple`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All of these functions can be used in :cfunc:`PyArg_ParseTuple` (...) with
+All of these functions can be used in :c:func:`PyArg_ParseTuple` (...) with
 the "O&" format specifier to automatically convert any Python object
 to the required C-object. All of these functions return
-:cdata:`NPY_SUCCEED` if successful and :cdata:`NPY_FAIL` if not. The first
+:c:data:`NPY_SUCCEED` if successful and :c:data:`NPY_FAIL` if not. The first
 argument to all of these function is a Python object. The second
 argument is the **address** of the C-type to convert the Python object
 to.
@@ -2739,27 +2739,27 @@ to.
     require freeing memory, and/or altering the reference counts of
     specific objects based on your use.
 
-.. cfunction:: int PyArray_Converter(PyObject* obj, PyObject** address)
+.. c:function:: int PyArray_Converter(PyObject* obj, PyObject** address)
 
-    Convert any Python object to a :ctype:`PyArrayObject`. If
-    :cfunc:`PyArray_Check` (*obj*) is TRUE then its reference count is
+    Convert any Python object to a :c:type:`PyArrayObject`. If
+    :c:func:`PyArray_Check` (*obj*) is TRUE then its reference count is
     incremented and a reference placed in *address*. If *obj* is not
-    an array, then convert it to an array using :cfunc:`PyArray_FromAny`
+    an array, then convert it to an array using :c:func:`PyArray_FromAny`
     . No matter what is returned, you must DECREF the object returned
     by this routine in *address* when you are done with it.
 
-.. cfunction:: int PyArray_OutputConverter(PyObject* obj, PyArrayObject** address)
+.. c:function:: int PyArray_OutputConverter(PyObject* obj, PyArrayObject** address)
 
     This is a default converter for output arrays given to
-    functions. If *obj* is :cdata:`Py_None` or ``NULL``, then *\*address*
-    will be ``NULL`` but the call will succeed. If :cfunc:`PyArray_Check` (
+    functions. If *obj* is :c:data:`Py_None` or ``NULL``, then *\*address*
+    will be ``NULL`` but the call will succeed. If :c:func:`PyArray_Check` (
     *obj*) is TRUE then it is returned in *\*address* without
     incrementing its reference count.
 
-.. cfunction:: int PyArray_IntpConverter(PyObject* obj, PyArray_Dims* seq)
+.. c:function:: int PyArray_IntpConverter(PyObject* obj, PyArray_Dims* seq)
 
-    Convert any Python sequence, *obj*, smaller than :cdata:`NPY_MAXDIMS`
-    to a C-array of :ctype:`npy_intp`. The Python object could also be a
+    Convert any Python sequence, *obj*, smaller than :c:data:`NPY_MAXDIMS`
+    to a C-array of :c:type:`npy_intp`. The Python object could also be a
     single number. The *seq* variable is a pointer to a structure with
     members ptr and len. On successful return, *seq* ->ptr contains a
     pointer to memory that must be freed to avoid a memory leak. The
@@ -2767,83 +2767,83 @@ to.
     conveniently used for sequences intended to be interpreted as
     array shapes.
 
-.. cfunction:: int PyArray_BufferConverter(PyObject* obj, PyArray_Chunk* buf)
+.. c:function:: int PyArray_BufferConverter(PyObject* obj, PyArray_Chunk* buf)
 
     Convert any Python object, *obj*, with a (single-segment) buffer
     interface to a variable with members that detail the object's use
     of its chunk of memory. The *buf* variable is a pointer to a
     structure with base, ptr, len, and flags members. The
-    :ctype:`PyArray_Chunk` structure is binary compatibile with the
+    :c:type:`PyArray_Chunk` structure is binary compatibile with the
     Python's buffer object (through its len member on 32-bit platforms
     and its ptr member on 64-bit platforms or in Python 2.5). On
     return, the base member is set to *obj* (or its base if *obj* is
     already a buffer object pointing to another object). If you need
     to hold on to the memory be sure to INCREF the base member. The
     chunk of memory is pointed to by *buf* ->ptr member and has length
-    *buf* ->len. The flags member of *buf* is :cdata:`NPY_BEHAVED_RO` with
-    the :cdata:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writeable buffer
+    *buf* ->len. The flags member of *buf* is :c:data:`NPY_BEHAVED_RO` with
+    the :c:data:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writeable buffer
     interface.
 
-.. cfunction:: int PyArray_AxisConverter(PyObject \* obj, int* axis)
+.. c:function:: int PyArray_AxisConverter(PyObject \* obj, int* axis)
 
     Convert a Python object, *obj*, representing an axis argument to
     the proper value for passing to the functions that take an integer
     axis. Specifically, if *obj* is None, *axis* is set to
-    :cdata:`NPY_MAXDIMS` which is interpreted correctly by the C-API
+    :c:data:`NPY_MAXDIMS` which is interpreted correctly by the C-API
     functions that take axis arguments.
 
-.. cfunction:: int PyArray_BoolConverter(PyObject* obj, Bool* value)
+.. c:function:: int PyArray_BoolConverter(PyObject* obj, Bool* value)
 
-    Convert any Python object, *obj*, to :cdata:`NPY_TRUE` or
-    :cdata:`NPY_FALSE`, and place the result in *value*.
+    Convert any Python object, *obj*, to :c:data:`NPY_TRUE` or
+    :c:data:`NPY_FALSE`, and place the result in *value*.
 
-.. cfunction:: int PyArray_ByteorderConverter(PyObject* obj, char* endian)
+.. c:function:: int PyArray_ByteorderConverter(PyObject* obj, char* endian)
 
     Convert Python strings into the corresponding byte-order
     character:
     '>', '<', 's', '=', or '\|'.
 
-.. cfunction:: int PyArray_SortkindConverter(PyObject* obj, NPY_SORTKIND* sort)
+.. c:function:: int PyArray_SortkindConverter(PyObject* obj, NPY_SORTKIND* sort)
 
-    Convert Python strings into one of :cdata:`NPY_QUICKSORT` (starts
-    with 'q' or 'Q') , :cdata:`NPY_HEAPSORT` (starts with 'h' or 'H'),
-    or :cdata:`NPY_MERGESORT` (starts with 'm' or 'M').
+    Convert Python strings into one of :c:data:`NPY_QUICKSORT` (starts
+    with 'q' or 'Q') , :c:data:`NPY_HEAPSORT` (starts with 'h' or 'H'),
+    or :c:data:`NPY_MERGESORT` (starts with 'm' or 'M').
 
-.. cfunction:: int PyArray_SearchsideConverter(PyObject* obj, NPY_SEARCHSIDE* side)
+.. c:function:: int PyArray_SearchsideConverter(PyObject* obj, NPY_SEARCHSIDE* side)
 
-    Convert Python strings into one of :cdata:`NPY_SEARCHLEFT` (starts with 'l'
-    or 'L'), or :cdata:`NPY_SEARCHRIGHT` (starts with 'r' or 'R').
+    Convert Python strings into one of :c:data:`NPY_SEARCHLEFT` (starts with 'l'
+    or 'L'), or :c:data:`NPY_SEARCHRIGHT` (starts with 'r' or 'R').
 
-.. cfunction:: int PyArray_OrderConverter(PyObject* obj, NPY_ORDER* order)
+.. c:function:: int PyArray_OrderConverter(PyObject* obj, NPY_ORDER* order)
 
-   Convert the Python strings 'C', 'F', 'A', and 'K' into the :ctype:`NPY_ORDER`
-   enumeration :cdata:`NPY_CORDER`, :cdata:`NPY_FORTRANORDER`,
-   :cdata:`NPY_ANYORDER`, and :cdata:`NPY_KEEPORDER`.
+   Convert the Python strings 'C', 'F', 'A', and 'K' into the :c:type:`NPY_ORDER`
+   enumeration :c:data:`NPY_CORDER`, :c:data:`NPY_FORTRANORDER`,
+   :c:data:`NPY_ANYORDER`, and :c:data:`NPY_KEEPORDER`.
 
-.. cfunction:: int PyArray_CastingConverter(PyObject* obj, NPY_CASTING* casting)
+.. c:function:: int PyArray_CastingConverter(PyObject* obj, NPY_CASTING* casting)
 
    Convert the Python strings 'no', 'equiv', 'safe', 'same_kind', and
-   'unsafe' into the :ctype:`NPY_CASTING` enumeration :cdata:`NPY_NO_CASTING`,
-   :cdata:`NPY_EQUIV_CASTING`, :cdata:`NPY_SAFE_CASTING`,
-   :cdata:`NPY_SAME_KIND_CASTING`, and :cdata:`NPY_UNSAFE_CASTING`.
+   'unsafe' into the :c:type:`NPY_CASTING` enumeration :c:data:`NPY_NO_CASTING`,
+   :c:data:`NPY_EQUIV_CASTING`, :c:data:`NPY_SAFE_CASTING`,
+   :c:data:`NPY_SAME_KIND_CASTING`, and :c:data:`NPY_UNSAFE_CASTING`.
 
-.. cfunction:: int PyArray_ClipmodeConverter(PyObject* object, NPY_CLIPMODE* val)
+.. c:function:: int PyArray_ClipmodeConverter(PyObject* object, NPY_CLIPMODE* val)
 
     Convert the Python strings 'clip', 'wrap', and 'raise' into the
-    :ctype:`NPY_CLIPMODE` enumeration :cdata:`NPY_CLIP`, :cdata:`NPY_WRAP`,
-    and :cdata:`NPY_RAISE`.
+    :c:type:`NPY_CLIPMODE` enumeration :c:data:`NPY_CLIP`, :c:data:`NPY_WRAP`,
+    and :c:data:`NPY_RAISE`.
 
-.. cfunction:: int PyArray_ConvertClipmodeSequence(PyObject* object, NPY_CLIPMODE* modes, int n)
+.. c:function:: int PyArray_ConvertClipmodeSequence(PyObject* object, NPY_CLIPMODE* modes, int n)
 
    Converts either a sequence of clipmodes or a single clipmode into
-   a C array of :ctype:`NPY_CLIPMODE` values. The number of clipmodes *n*
+   a C array of :c:type:`NPY_CLIPMODE` values. The number of clipmodes *n*
    must be known before calling this function. This function is provided
    to help functions allow a different clipmode for each dimension.
 
 Other conversions
 ^^^^^^^^^^^^^^^^^
 
-.. cfunction:: int PyArray_PyIntAsInt(PyObject* op)
+.. c:function:: int PyArray_PyIntAsInt(PyObject* op)
 
     Convert all kinds of Python objects (including arrays and array
     scalars) to a standard integer. On error, -1 is returned and an
@@ -2853,27 +2853,27 @@ Other conversions
 
         #define error_converting(x) (((x) == -1) && PyErr_Occurred()
 
-.. cfunction:: npy_intp PyArray_PyIntAsIntp(PyObject* op)
+.. c:function:: npy_intp PyArray_PyIntAsIntp(PyObject* op)
 
     Convert all kinds of Python objects (including arrays and array
     scalars) to a (platform-pointer-sized) integer. On error, -1 is
     returned and an exception set.
 
-.. cfunction:: int PyArray_IntpFromSequence(PyObject* seq, npy_intp* vals, int maxvals)
+.. c:function:: int PyArray_IntpFromSequence(PyObject* seq, npy_intp* vals, int maxvals)
 
     Convert any Python sequence (or single Python number) passed in as
     *seq* to (up to) *maxvals* pointer-sized integers and place them
     in the *vals* array. The sequence can be smaller then *maxvals* as
     the number of converted objects is returned.
 
-.. cfunction:: int PyArray_TypestrConvert(int itemsize, int gentype)
+.. c:function:: int PyArray_TypestrConvert(int itemsize, int gentype)
 
     Convert typestring characters (with *itemsize*) to basic
     enumerated data types. The typestring character corresponding to
     signed and unsigned integers, floating point numbers, and
     complex-floating point numbers are recognized and converted. Other
     values of gentype are returned. This function can be used to
-    convert, for example, the string 'f4' to :cdata:`NPY_FLOAT32`.
+    convert, for example, the string 'f4' to :c:data:`NPY_FLOAT32`.
 
 
 Miscellaneous
@@ -2889,25 +2889,25 @@ self-contained in a single .c file, then that is all that needs to be
 done. If, however, the extension module involves multiple files where
 the C-API is needed then some additional steps must be taken.
 
-.. cfunction:: void import_array(void)
+.. c:function:: void import_array(void)
 
     This function must be called in the initialization section of a
     module that will make use of the C-API. It imports the module
     where the function-pointer table is stored and points the correct
     variable to it.
 
-.. cmacro:: PY_ARRAY_UNIQUE_SYMBOL
+.. c:macro:: PY_ARRAY_UNIQUE_SYMBOL
 
-.. cmacro:: NO_IMPORT_ARRAY
+.. c:macro:: NO_IMPORT_ARRAY
 
     Using these #defines you can use the C-API in multiple files for a
     single extension module. In each file you must define
-    :cmacro:`PY_ARRAY_UNIQUE_SYMBOL` to some name that will hold the
+    :c:macro:`PY_ARRAY_UNIQUE_SYMBOL` to some name that will hold the
     C-API (*e.g.* myextension_ARRAY_API). This must be done **before**
     including the numpy/arrayobject.h file. In the module
     intialization routine you call ``import_array`` (). In addition,
     in the files that do not have the module initialization
-    sub_routine define :cmacro:`NO_IMPORT_ARRAY` prior to including
+    sub_routine define :c:macro:`NO_IMPORT_ARRAY` prior to including
     numpy/arrayobject.h.
 
     Suppose I have two files coolmodule.c and coolhelper.c which need
@@ -2942,18 +2942,18 @@ even runtime. For example, if you build an extension using a function available
 only for numpy >= 1.3.0, and you import the extension later with numpy 1.2, you
 will not get an import error (but almost certainly a segmentation fault when
 calling the function). That's why several functions are provided to check for
-numpy versions. The macros :cdata:`NPY_VERSION`  and
-:cdata:`NPY_FEATURE_VERSION` corresponds to the numpy version used to build the
+numpy versions. The macros :c:data:`NPY_VERSION`  and
+:c:data:`NPY_FEATURE_VERSION` corresponds to the numpy version used to build the
 extension, whereas the versions returned by the functions
 PyArray_GetNDArrayCVersion and PyArray_GetNDArrayCFeatureVersion corresponds to
 the runtime numpy's version.
 
 The rules for ABI and API compatibilities can be summarized as follows:
 
-    * Whenever :cdata:`NPY_VERSION` != PyArray_GetNDArrayCVersion, the
+    * Whenever :c:data:`NPY_VERSION` != PyArray_GetNDArrayCVersion, the
       extension has to be recompiled (ABI incompatibility).
-    * :cdata:`NPY_VERSION` == PyArray_GetNDArrayCVersion and
-      :cdata:`NPY_FEATURE_VERSION` <= PyArray_GetNDArrayCFeatureVersion means
+    * :c:data:`NPY_VERSION` == PyArray_GetNDArrayCVersion and
+      :c:data:`NPY_FEATURE_VERSION` <= PyArray_GetNDArrayCFeatureVersion means
       backward compatible changes.
 
 ABI incompatibility is automatically detected in every numpy's version. API
@@ -2961,27 +2961,27 @@ incompatibility detection was added in numpy 1.4.0. If you want to supported
 many different numpy versions with one extension binary, you have to build your
 extension with the lowest NPY_FEATURE_VERSION as possible.
 
-.. cfunction:: unsigned int PyArray_GetNDArrayCVersion(void)
+.. c:function:: unsigned int PyArray_GetNDArrayCVersion(void)
 
-    This just returns the value :cdata:`NPY_VERSION`. :cdata:`NPY_VERSION`
+    This just returns the value :c:data:`NPY_VERSION`. :c:data:`NPY_VERSION`
     changes whenever a backward incompatible change at the ABI level. Because
     it is in the C-API, however, comparing the output of this function from the
     value defined in the current header gives a way to test if the C-API has
     changed thus requiring a re-compilation of extension modules that use the
     C-API. This is automatically checked in the function import_array.
 
-.. cfunction:: unsigned int PyArray_GetNDArrayCFeatureVersion(void)
+.. c:function:: unsigned int PyArray_GetNDArrayCFeatureVersion(void)
 
     .. versionadded:: 1.4.0
 
-    This just returns the value :cdata:`NPY_FEATURE_VERSION`.
-    :cdata:`NPY_FEATURE_VERSION` changes whenever the API changes (e.g. a
+    This just returns the value :c:data:`NPY_FEATURE_VERSION`.
+    :c:data:`NPY_FEATURE_VERSION` changes whenever the API changes (e.g. a
     function is added). A changed value does not always require a recompile.
 
 Internal Flexibility
 ^^^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: int PyArray_SetNumericOps(PyObject* dict)
+.. c:function:: int PyArray_SetNumericOps(PyObject* dict)
 
     NumPy stores an internal table of Python callable objects that are
     used to implement arithmetic operations for arrays as well as
@@ -3012,13 +3012,13 @@ Internal Flexibility
     setting a Python Error) if one of the objects being assigned is not
     callable.
 
-.. cfunction:: PyObject* PyArray_GetNumericOps(void)
+.. c:function:: PyObject* PyArray_GetNumericOps(void)
 
     Return a Python dictionary containing the callable Python objects
     stored in the the internal arithmetic operation table. The keys of
-    this dictionary are given in the explanation for :cfunc:`PyArray_SetNumericOps`.
+    this dictionary are given in the explanation for :c:func:`PyArray_SetNumericOps`.
 
-.. cfunction:: void PyArray_SetStringFunction(PyObject* op, int repr)
+.. c:function:: void PyArray_SetStringFunction(PyObject* op, int repr)
 
     This function allows you to alter the tp_str and tp_repr methods
     of the array object to any Python function. Thus you can alter
@@ -3034,39 +3034,39 @@ Internal Flexibility
 Memory management
 ^^^^^^^^^^^^^^^^^
 
-.. cfunction:: char* PyDataMem_NEW(size_t nbytes)
+.. c:function:: char* PyDataMem_NEW(size_t nbytes)
 
-.. cfunction:: PyDataMem_FREE(char* ptr)
+.. c:function:: PyDataMem_FREE(char* ptr)
 
-.. cfunction:: char* PyDataMem_RENEW(void * ptr, size_t newbytes)
+.. c:function:: char* PyDataMem_RENEW(void * ptr, size_t newbytes)
 
     Macros to allocate, free, and reallocate memory. These macros are used
     internally to create arrays.
 
-.. cfunction:: npy_intp*  PyDimMem_NEW(nd)
+.. c:function:: npy_intp*  PyDimMem_NEW(nd)
 
-.. cfunction:: PyDimMem_FREE(npy_intp* ptr)
+.. c:function:: PyDimMem_FREE(npy_intp* ptr)
 
-.. cfunction:: npy_intp* PyDimMem_RENEW(npy_intp* ptr, npy_intp newnd)
+.. c:function:: npy_intp* PyDimMem_RENEW(npy_intp* ptr, npy_intp newnd)
 
     Macros to allocate, free, and reallocate dimension and strides memory.
 
-.. cfunction:: PyArray_malloc(nbytes)
+.. c:function:: PyArray_malloc(nbytes)
 
-.. cfunction:: PyArray_free(ptr)
+.. c:function:: PyArray_free(ptr)
 
-.. cfunction:: PyArray_realloc(ptr, nbytes)
+.. c:function:: PyArray_realloc(ptr, nbytes)
 
     These macros use different memory allocators, depending on the
-    constant :cdata:`NPY_USE_PYMEM`. The system malloc is used when
-    :cdata:`NPY_USE_PYMEM` is 0, if :cdata:`NPY_USE_PYMEM` is 1, then
+    constant :c:data:`NPY_USE_PYMEM`. The system malloc is used when
+    :c:data:`NPY_USE_PYMEM` is 0, if :c:data:`NPY_USE_PYMEM` is 1, then
     the Python memory allocator is used.
 
 
 Threading support
 ^^^^^^^^^^^^^^^^^
 
-These macros are only meaningful if :cdata:`NPY_ALLOW_THREADS`
+These macros are only meaningful if :c:data:`NPY_ALLOW_THREADS`
 evaluates True during compilation of the extension module. Otherwise,
 these macros are equivalent to whitespace. Python uses a single Global
 Interpreter Lock (GIL) for each Python process so that only a single
@@ -3077,10 +3077,10 @@ variables), the GIL should be released so that other Python threads
 can run while the time-consuming calculations are performed. This can
 be accomplished using two groups of macros. Typically, if one macro in
 a group is used in a code block, all of them must be used in the same
-code block. Currently, :cdata:`NPY_ALLOW_THREADS` is defined to the
-python-defined :cdata:`WITH_THREADS` constant unless the environment
-variable :cdata:`NPY_NOSMP` is set in which case
-:cdata:`NPY_ALLOW_THREADS` is defined to be 0.
+code block. Currently, :c:data:`NPY_ALLOW_THREADS` is defined to the
+python-defined :c:data:`WITH_THREADS` constant unless the environment
+variable :c:data:`NPY_NOSMP` is set in which case
+:c:data:`NPY_ALLOW_THREADS` is defined to be 0.
 
 Group 1
 """""""
@@ -3089,51 +3089,51 @@ Group 1
     use any Python C-API calls. Thus, the GIL should be released during
     its calculation.
 
-    .. cmacro:: NPY_BEGIN_ALLOW_THREADS
+    .. c:macro:: NPY_BEGIN_ALLOW_THREADS
 
-        Equivalent to :cmacro:`Py_BEGIN_ALLOW_THREADS` except it uses
-        :cdata:`NPY_ALLOW_THREADS` to determine if the macro if
+        Equivalent to :c:macro:`Py_BEGIN_ALLOW_THREADS` except it uses
+        :c:data:`NPY_ALLOW_THREADS` to determine if the macro if
         replaced with white-space or not.
 
-    .. cmacro:: NPY_END_ALLOW_THREADS
+    .. c:macro:: NPY_END_ALLOW_THREADS
 
-        Equivalent to :cmacro:`Py_END_ALLOW_THREADS` except it uses
-        :cdata:`NPY_ALLOW_THREADS` to determine if the macro if
+        Equivalent to :c:macro:`Py_END_ALLOW_THREADS` except it uses
+        :c:data:`NPY_ALLOW_THREADS` to determine if the macro if
         replaced with white-space or not.
 
-    .. cmacro:: NPY_BEGIN_THREADS_DEF
+    .. c:macro:: NPY_BEGIN_THREADS_DEF
 
         Place in the variable declaration area. This macro sets up the
         variable needed for storing the Python state.
 
-    .. cmacro:: NPY_BEGIN_THREADS
+    .. c:macro:: NPY_BEGIN_THREADS
 
         Place right before code that does not need the Python
         interpreter (no Python C-API calls). This macro saves the
         Python state and releases the GIL.
 
-    .. cmacro:: NPY_END_THREADS
+    .. c:macro:: NPY_END_THREADS
 
         Place right after code that does not need the Python
         interpreter. This macro acquires the GIL and restores the
         Python state from the saved variable.
 
-    .. cfunction:: NPY_BEGIN_THREADS_DESCR(PyArray_Descr *dtype)
+    .. c:function:: NPY_BEGIN_THREADS_DESCR(PyArray_Descr *dtype)
 
         Useful to release the GIL only if *dtype* does not contain
         arbitrary Python objects which may need the Python interpreter
         during execution of the loop. Equivalent to
 
-    .. cfunction:: NPY_END_THREADS_DESCR(PyArray_Descr *dtype)
+    .. c:function:: NPY_END_THREADS_DESCR(PyArray_Descr *dtype)
 
         Useful to regain the GIL in situations where it was released
         using the BEGIN form of this macro.
 
-    .. cfunction:: NPY_BEGIN_THREADS_THRESHOLDED(int loop_size)
+    .. c:function:: NPY_BEGIN_THREADS_THRESHOLDED(int loop_size)
 
         Useful to release the GIL only if *loop_size* exceeds a
         minimum threshold, currently set to 500. Should be matched
-        with a .. cmacro::`NPY_END_THREADS` to regain the GIL.
+        with a .. c:macro::`NPY_END_THREADS` to regain the GIL.
 
 Group 2
 """""""
@@ -3146,17 +3146,17 @@ Group 2
     essentially a reverse of the previous three (acquire the LOCK saving
     what state it had) and then re-release it with the saved state.
 
-    .. cmacro:: NPY_ALLOW_C_API_DEF
+    .. c:macro:: NPY_ALLOW_C_API_DEF
 
         Place in the variable declaration area to set up the necessary
         variable.
 
-    .. cmacro:: NPY_ALLOW_C_API
+    .. c:macro:: NPY_ALLOW_C_API
 
         Place before code that needs to call the Python C-API (when it is
         known that the GIL has already been released).
 
-    .. cmacro:: NPY_DISABLE_C_API
+    .. c:macro:: NPY_DISABLE_C_API
 
         Place after code that needs to call the Python C-API (to re-release
         the GIL).
@@ -3169,38 +3169,38 @@ Group 2
 Priority
 ^^^^^^^^
 
-.. cvar:: NPY_PRIORITY
+.. c:var:: NPY_PRIORITY
 
     Default priority for arrays.
 
-.. cvar:: NPY_SUBTYPE_PRIORITY
+.. c:var:: NPY_SUBTYPE_PRIORITY
 
     Default subtype priority.
 
-.. cvar:: NPY_SCALAR_PRIORITY
+.. c:var:: NPY_SCALAR_PRIORITY
 
     Default scalar priority (very small)
 
-.. cfunction:: double PyArray_GetPriority(PyObject* obj, double def)
+.. c:function:: double PyArray_GetPriority(PyObject* obj, double def)
 
     Return the :obj:`__array_priority__` attribute (converted to a
     double) of *obj* or *def* if no attribute of that name
     exists. Fast returns that avoid the attribute lookup are provided
-    for objects of type :cdata:`PyArray_Type`.
+    for objects of type :c:data:`PyArray_Type`.
 
 
 Default buffers
 ^^^^^^^^^^^^^^^
 
-.. cvar:: NPY_BUFSIZE
+.. c:var:: NPY_BUFSIZE
 
     Default size of the user-settable internal buffers.
 
-.. cvar:: NPY_MIN_BUFSIZE
+.. c:var:: NPY_MIN_BUFSIZE
 
     Smallest size of user-settable internal buffers.
 
-.. cvar:: NPY_MAX_BUFSIZE
+.. c:var:: NPY_MAX_BUFSIZE
 
     Largest size allowed for the user-settable buffers.
 
@@ -3208,158 +3208,158 @@ Default buffers
 Other constants
 ^^^^^^^^^^^^^^^
 
-.. cvar:: NPY_NUM_FLOATTYPE
+.. c:var:: NPY_NUM_FLOATTYPE
 
     The number of floating-point types
 
-.. cvar:: NPY_MAXDIMS
+.. c:var:: NPY_MAXDIMS
 
     The maximum number of dimensions allowed in arrays.
 
-.. cvar:: NPY_VERSION
+.. c:var:: NPY_VERSION
 
     The current version of the ndarray object (check to see if this
     variable is defined to guarantee the numpy/arrayobject.h header is
     being used).
 
-.. cvar:: NPY_FALSE
+.. c:var:: NPY_FALSE
 
     Defined as 0 for use with Bool.
 
-.. cvar:: NPY_TRUE
+.. c:var:: NPY_TRUE
 
     Defined as 1 for use with Bool.
 
-.. cvar:: NPY_FAIL
+.. c:var:: NPY_FAIL
 
     The return value of failed converter functions which are called using
-    the "O&" syntax in :cfunc:`PyArg_ParseTuple`-like functions.
+    the "O&" syntax in :c:func:`PyArg_ParseTuple`-like functions.
 
-.. cvar:: NPY_SUCCEED
+.. c:var:: NPY_SUCCEED
 
     The return value of successful converter functions which are called
-    using the "O&" syntax in :cfunc:`PyArg_ParseTuple`-like functions.
+    using the "O&" syntax in :c:func:`PyArg_ParseTuple`-like functions.
 
 
 Miscellaneous Macros
 ^^^^^^^^^^^^^^^^^^^^
 
-.. cfunction:: PyArray_SAMESHAPE(a1, a2)
+.. c:function:: PyArray_SAMESHAPE(a1, a2)
 
     Evaluates as True if arrays *a1* and *a2* have the same shape.
 
-.. cfunction:: PyArray_MAX(a,b)
+.. c:function:: PyArray_MAX(a,b)
 
     Returns the maximum of *a* and *b*. If (*a*) or (*b*) are
     expressions they are evaluated twice.
 
-.. cfunction:: PyArray_MIN(a,b)
+.. c:function:: PyArray_MIN(a,b)
 
     Returns the minimum of *a* and *b*. If (*a*) or (*b*) are
     expressions they are evaluated twice.
 
-.. cfunction:: PyArray_CLT(a,b)
+.. c:function:: PyArray_CLT(a,b)
 
-.. cfunction:: PyArray_CGT(a,b)
+.. c:function:: PyArray_CGT(a,b)
 
-.. cfunction:: PyArray_CLE(a,b)
+.. c:function:: PyArray_CLE(a,b)
 
-.. cfunction:: PyArray_CGE(a,b)
+.. c:function:: PyArray_CGE(a,b)
 
-.. cfunction:: PyArray_CEQ(a,b)
+.. c:function:: PyArray_CEQ(a,b)
 
-.. cfunction:: PyArray_CNE(a,b)
+.. c:function:: PyArray_CNE(a,b)
 
     Implements the complex comparisons between two complex numbers
     (structures with a real and imag member) using NumPy's definition
     of the ordering which is lexicographic: comparing the real parts
     first and then the complex parts if the real parts are equal.
 
-.. cfunction:: PyArray_REFCOUNT(PyObject* op)
+.. c:function:: PyArray_REFCOUNT(PyObject* op)
 
     Returns the reference count of any Python object.
 
-.. cfunction:: PyArray_XDECREF_ERR(PyObject \*obj)
+.. c:function:: PyArray_XDECREF_ERR(PyObject \*obj)
 
-    DECREF's an array object which may have the :cdata:`NPY_ARRAY_UPDATEIFCOPY`
+    DECREF's an array object which may have the :c:data:`NPY_ARRAY_UPDATEIFCOPY`
     flag set without causing the contents to be copied back into the
-    original array. Resets the :cdata:`NPY_ARRAY_WRITEABLE` flag on the base
+    original array. Resets the :c:data:`NPY_ARRAY_WRITEABLE` flag on the base
     object. This is useful for recovering from an error condition when
-    :cdata:`NPY_ARRAY_UPDATEIFCOPY` is used.
+    :c:data:`NPY_ARRAY_UPDATEIFCOPY` is used.
 
 
 Enumerated Types
 ^^^^^^^^^^^^^^^^
 
-.. ctype:: NPY_SORTKIND
+.. c:type:: NPY_SORTKIND
 
-    A special variable-type which can take on the values :cdata:`NPY_{KIND}`
+    A special variable-type which can take on the values :c:data:`NPY_{KIND}`
     where ``{KIND}`` is
 
         **QUICKSORT**, **HEAPSORT**, **MERGESORT**
 
-    .. cvar:: NPY_NSORTS
+    .. c:var:: NPY_NSORTS
 
        Defined to be the number of sorts.
 
-.. ctype:: NPY_SCALARKIND
+.. c:type:: NPY_SCALARKIND
 
     A special variable type indicating the number of "kinds" of
     scalars distinguished in determining scalar-coercion rules. This
-    variable can take on the values :cdata:`NPY_{KIND}` where ``{KIND}`` can be
+    variable can take on the values :c:data:`NPY_{KIND}` where ``{KIND}`` can be
 
         **NOSCALAR**, **BOOL_SCALAR**, **INTPOS_SCALAR**,
         **INTNEG_SCALAR**, **FLOAT_SCALAR**, **COMPLEX_SCALAR**,
         **OBJECT_SCALAR**
 
-    .. cvar:: NPY_NSCALARKINDS
+    .. c:var:: NPY_NSCALARKINDS
 
        Defined to be the number of scalar kinds
-       (not including :cdata:`NPY_NOSCALAR`).
+       (not including :c:data:`NPY_NOSCALAR`).
 
-.. ctype:: NPY_ORDER
+.. c:type:: NPY_ORDER
 
     An enumeration type indicating the element order that an array should be
     interpreted in. When a brand new array is created, generally
     only **NPY_CORDER** and **NPY_FORTRANORDER** are used, whereas
     when one or more inputs are provided, the order can be based on them.
 
-    .. cvar:: NPY_ANYORDER
+    .. c:var:: NPY_ANYORDER
 
         Fortran order if all the inputs are Fortran, C otherwise.
 
-    .. cvar:: NPY_CORDER
+    .. c:var:: NPY_CORDER
 
         C order.
 
-    .. cvar:: NPY_FORTRANORDER
+    .. c:var:: NPY_FORTRANORDER
 
         Fortran order.
 
-    .. cvar:: NPY_KEEPORDER
+    .. c:var:: NPY_KEEPORDER
 
         An order as close to the order of the inputs as possible, even
         if the input is in neither C nor Fortran order.
 
-.. ctype:: NPY_CLIPMODE
+.. c:type:: NPY_CLIPMODE
 
     A variable type indicating the kind of clipping that should be
     applied in certain functions.
 
-    .. cvar:: NPY_RAISE
+    .. c:var:: NPY_RAISE
 
         The default for most operations, raises an exception if an index
         is out of bounds.
 
-    .. cvar:: NPY_CLIP
+    .. c:var:: NPY_CLIP
 
         Clips an index to the valid range if it is out of bounds.
 
-    .. cvar:: NPY_WRAP
+    .. c:var:: NPY_WRAP
 
         Wraps an index to the valid range if it is out of bounds.
 
-.. ctype:: NPY_CASTING
+.. c:type:: NPY_CASTING
 
     .. versionadded:: 1.6
 
@@ -3367,25 +3367,25 @@ Enumerated Types
     be. This is used by the iterator added in NumPy 1.6, and is intended
     to be used more broadly in a future version.
 
-    .. cvar:: NPY_NO_CASTING
+    .. c:var:: NPY_NO_CASTING
 
         Only allow identical types.
 
-    .. cvar:: NPY_EQUIV_CASTING
+    .. c:var:: NPY_EQUIV_CASTING
 
        Allow identical and casts involving byte swapping.
 
-    .. cvar:: NPY_SAFE_CASTING
+    .. c:var:: NPY_SAFE_CASTING
 
        Only allow casts which will not cause values to be rounded,
        truncated, or otherwise changed.
 
-    .. cvar:: NPY_SAME_KIND_CASTING
+    .. c:var:: NPY_SAME_KIND_CASTING
 
        Allow any safe casts, and casts between types of the same kind.
        For example, float64 -> float32 is permitted with this rule.
 
-    .. cvar:: NPY_UNSAFE_CASTING
+    .. c:var:: NPY_UNSAFE_CASTING
 
        Allow any cast, no matter what kind of data loss may occur.
 

--- a/doc/source/reference/c-api.config.rst
+++ b/doc/source/reference/c-api.config.rst
@@ -19,42 +19,42 @@ avoid namespace pollution.
 Data type sizes
 ---------------
 
-The :cdata:`NPY_SIZEOF_{CTYPE}` constants are defined so that sizeof
+The :c:data:`NPY_SIZEOF_{CTYPE}` constants are defined so that sizeof
 information is available to the pre-processor.
 
-.. cvar:: NPY_SIZEOF_SHORT
+.. c:var:: NPY_SIZEOF_SHORT
 
     sizeof(short)
 
-.. cvar:: NPY_SIZEOF_INT
+.. c:var:: NPY_SIZEOF_INT
 
     sizeof(int)
 
-.. cvar:: NPY_SIZEOF_LONG
+.. c:var:: NPY_SIZEOF_LONG
 
     sizeof(long)
 
-.. cvar:: NPY_SIZEOF_LONGLONG
+.. c:var:: NPY_SIZEOF_LONGLONG
 
     sizeof(longlong) where longlong is defined appropriately on the
     platform.
 
-.. cvar:: NPY_SIZEOF_PY_LONG_LONG
+.. c:var:: NPY_SIZEOF_PY_LONG_LONG
 
 
-.. cvar:: NPY_SIZEOF_FLOAT
+.. c:var:: NPY_SIZEOF_FLOAT
 
     sizeof(float)
 
-.. cvar:: NPY_SIZEOF_DOUBLE
+.. c:var:: NPY_SIZEOF_DOUBLE
 
     sizeof(double)
 
-.. cvar:: NPY_SIZEOF_LONG_DOUBLE
+.. c:var:: NPY_SIZEOF_LONG_DOUBLE
 
     sizeof(longdouble) (A macro defines **NPY_SIZEOF_LONGDOUBLE** as well.)
 
-.. cvar:: NPY_SIZEOF_PY_INTPTR_T
+.. c:var:: NPY_SIZEOF_PY_INTPTR_T
 
     Size of a pointer on this platform (sizeof(void \*)) (A macro defines
     NPY_SIZEOF_INTP as well.)
@@ -63,15 +63,15 @@ information is available to the pre-processor.
 Platform information
 --------------------
 
-.. cvar:: NPY_CPU_X86
-.. cvar:: NPY_CPU_AMD64
-.. cvar:: NPY_CPU_IA64
-.. cvar:: NPY_CPU_PPC
-.. cvar:: NPY_CPU_PPC64
-.. cvar:: NPY_CPU_SPARC
-.. cvar:: NPY_CPU_SPARC64
-.. cvar:: NPY_CPU_S390
-.. cvar:: NPY_CPU_PARISC
+.. c:var:: NPY_CPU_X86
+.. c:var:: NPY_CPU_AMD64
+.. c:var:: NPY_CPU_IA64
+.. c:var:: NPY_CPU_PPC
+.. c:var:: NPY_CPU_PPC64
+.. c:var:: NPY_CPU_SPARC
+.. c:var:: NPY_CPU_SPARC64
+.. c:var:: NPY_CPU_S390
+.. c:var:: NPY_CPU_PARISC
 
     .. versionadded:: 1.3.0
 
@@ -80,24 +80,24 @@ Platform information
 
     Defined in ``numpy/npy_cpu.h``
 
-.. cvar:: NPY_LITTLE_ENDIAN
+.. c:var:: NPY_LITTLE_ENDIAN
 
-.. cvar:: NPY_BIG_ENDIAN
+.. c:var:: NPY_BIG_ENDIAN
 
-.. cvar:: NPY_BYTE_ORDER
+.. c:var:: NPY_BYTE_ORDER
 
     .. versionadded:: 1.3.0
 
     Portable alternatives to the ``endian.h`` macros of GNU Libc.
-    If big endian, :cdata:`NPY_BYTE_ORDER` == :cdata:`NPY_BIG_ENDIAN`, and
+    If big endian, :c:data:`NPY_BYTE_ORDER` == :c:data:`NPY_BIG_ENDIAN`, and
     similarly for little endian architectures.
 
     Defined in ``numpy/npy_endian.h``.
 
-.. cfunction:: PyArray_GetEndianness()
+.. c:function:: PyArray_GetEndianness()
 
     .. versionadded:: 1.3.0
 
     Returns the endianness of the current platform.
-    One of :cdata:`NPY_CPU_BIG`, :cdata:`NPY_CPU_LITTLE`,
-    or :cdata:`NPY_CPU_UNKNOWN_ENDIAN`.
+    One of :c:data:`NPY_CPU_BIG`, :c:data:`NPY_CPU_LITTLE`,
+    or :c:data:`NPY_CPU_UNKNOWN_ENDIAN`.

--- a/doc/source/reference/c-api.coremath.rst
+++ b/doc/source/reference/c-api.coremath.rst
@@ -24,52 +24,52 @@ in doubt.
 Floating point classification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. cvar:: NPY_NAN
+.. c:var:: NPY_NAN
 
     This macro is defined to a NaN (Not a Number), and is guaranteed to have
     the signbit unset ('positive' NaN). The corresponding single and extension
     precision macro are available with the suffix F and L.
 
-.. cvar:: NPY_INFINITY
+.. c:var:: NPY_INFINITY
 
     This macro is defined to a positive inf. The corresponding single and
     extension precision macro are available with the suffix F and L.
 
-.. cvar:: NPY_PZERO
+.. c:var:: NPY_PZERO
 
     This macro is defined to positive zero. The corresponding single and
     extension precision macro are available with the suffix F and L.
 
-.. cvar:: NPY_NZERO
+.. c:var:: NPY_NZERO
 
     This macro is defined to negative zero (that is with the sign bit set). The
     corresponding single and extension precision macro are available with the
     suffix F and L.
 
-.. cfunction:: int npy_isnan(x)
+.. c:function:: int npy_isnan(x)
 
     This is a macro, and is equivalent to C99 isnan: works for single, double
     and extended precision, and return a non 0 value is x is a NaN.
 
-.. cfunction:: int npy_isfinite(x)
+.. c:function:: int npy_isfinite(x)
 
     This is a macro, and is equivalent to C99 isfinite: works for single,
     double and extended precision, and return a non 0 value is x is neither a
     NaN nor an infinity.
 
-.. cfunction:: int npy_isinf(x)
+.. c:function:: int npy_isinf(x)
 
     This is a macro, and is equivalent to C99 isinf: works for single, double
     and extended precision, and return a non 0 value is x is infinite (positive
     and negative).
 
-.. cfunction:: int npy_signbit(x)
+.. c:function:: int npy_signbit(x)
 
     This is a macro, and is equivalent to C99 signbit: works for single, double
     and extended precision, and return a non 0 value is x has the signbit set
     (that is the number is negative).
 
-.. cfunction:: double npy_copysign(double x, double y)
+.. c:function:: double npy_copysign(double x, double y)
 
     This is a function equivalent to C99 copysign: return x with the same sign
     as y. Works for any value, including inf and nan. Single and extended
@@ -83,47 +83,47 @@ Useful math constants
 The following math constants are available in npy_math.h. Single and extended
 precision are also available by adding the F and L suffixes respectively.
 
-.. cvar:: NPY_E
+.. c:var:: NPY_E
 
     Base of natural logarithm (:math:`e`)
 
-.. cvar:: NPY_LOG2E
+.. c:var:: NPY_LOG2E
 
     Logarithm to base 2 of the Euler constant (:math:`\frac{\ln(e)}{\ln(2)}`)
 
-.. cvar:: NPY_LOG10E
+.. c:var:: NPY_LOG10E
 
     Logarithm to base 10 of the Euler constant (:math:`\frac{\ln(e)}{\ln(10)}`)
 
-.. cvar:: NPY_LOGE2
+.. c:var:: NPY_LOGE2
 
     Natural logarithm of 2 (:math:`\ln(2)`)
 
-.. cvar:: NPY_LOGE10
+.. c:var:: NPY_LOGE10
 
     Natural logarithm of 10 (:math:`\ln(10)`)
 
-.. cvar:: NPY_PI
+.. c:var:: NPY_PI
 
     Pi (:math:`\pi`)
 
-.. cvar:: NPY_PI_2
+.. c:var:: NPY_PI_2
 
     Pi divided by 2 (:math:`\frac{\pi}{2}`)
 
-.. cvar:: NPY_PI_4
+.. c:var:: NPY_PI_4
 
     Pi divided by 4 (:math:`\frac{\pi}{4}`)
 
-.. cvar:: NPY_1_PI
+.. c:var:: NPY_1_PI
 
     Reciprocal of pi (:math:`\frac{1}{\pi}`)
 
-.. cvar:: NPY_2_PI
+.. c:var:: NPY_2_PI
 
     Two times the reciprocal of pi (:math:`\frac{2}{\pi}`)
 
-.. cvar:: NPY_EULER
+.. c:var:: NPY_EULER
 
     The Euler constant
         :math:`\lim_{n\rightarrow\infty}({\sum_{k=1}^n{\frac{1}{k}}-\ln n})`
@@ -133,7 +133,7 @@ Low-level floating point manipulation
 
 Those can be useful for precise floating point comparison.
 
-.. cfunction:: double npy_nextafter(double x, double y)
+.. c:function:: double npy_nextafter(double x, double y)
 
     This is a function equivalent to C99 nextafter: return next representable
     floating point value from x in the direction of y. Single and extended
@@ -141,7 +141,7 @@ Those can be useful for precise floating point comparison.
 
     .. versionadded:: 1.4.0
 
-.. cfunction:: double npy_spacing(double x)
+.. c:function:: double npy_spacing(double x)
 
     This is a function equivalent to Fortran intrinsic. Return distance between
     x and next representable floating point value from x, e.g. spacing(1) ==
@@ -150,31 +150,31 @@ Those can be useful for precise floating point comparison.
 
     .. versionadded:: 1.4.0
 
-.. cfunction:: void npy_set_floatstatus_divbyzero()
+.. c:function:: void npy_set_floatstatus_divbyzero()
 
     Set the divide by zero floating point exception
 
     .. versionadded:: 1.6.0
 
-.. cfunction:: void npy_set_floatstatus_overflow()
+.. c:function:: void npy_set_floatstatus_overflow()
 
     Set the overflow floating point exception
 
     .. versionadded:: 1.6.0
 
-.. cfunction:: void npy_set_floatstatus_underflow()
+.. c:function:: void npy_set_floatstatus_underflow()
 
     Set the underflow floating point exception
 
     .. versionadded:: 1.6.0
 
-.. cfunction:: void npy_set_floatstatus_invalid()
+.. c:function:: void npy_set_floatstatus_invalid()
 
     Set the invalid floating point exception
 
     .. versionadded:: 1.6.0
 
-.. cfunction:: int npy_get_floatstatus()
+.. c:function:: int npy_get_floatstatus()
 
     Get floating point status. Returns a bitmask with following possible flags:
 
@@ -185,7 +185,7 @@ Those can be useful for precise floating point comparison.
 
     .. versionadded:: 1.9.0
 
-.. cfunction:: int npy_clear_floatstatus()
+.. c:function:: int npy_clear_floatstatus()
 
     Clears the floating point status. Returns the previous status mask.
 
@@ -270,151 +270,151 @@ __ http://en.wikipedia.org/wiki/Half_precision_floating-point_format
 __ http://www.opengl.org/registry/specs/ARB/half_float_pixel.txt
 __ http://www.openexr.com/about.html
 
-.. cvar:: NPY_HALF_ZERO
+.. c:var:: NPY_HALF_ZERO
 
     This macro is defined to positive zero.
 
-.. cvar:: NPY_HALF_PZERO
+.. c:var:: NPY_HALF_PZERO
 
     This macro is defined to positive zero.
 
-.. cvar:: NPY_HALF_NZERO
+.. c:var:: NPY_HALF_NZERO
 
     This macro is defined to negative zero.
 
-.. cvar:: NPY_HALF_ONE
+.. c:var:: NPY_HALF_ONE
 
     This macro is defined to 1.0.
 
-.. cvar:: NPY_HALF_NEGONE
+.. c:var:: NPY_HALF_NEGONE
 
     This macro is defined to -1.0.
 
-.. cvar:: NPY_HALF_PINF
+.. c:var:: NPY_HALF_PINF
 
     This macro is defined to +inf.
 
-.. cvar:: NPY_HALF_NINF
+.. c:var:: NPY_HALF_NINF
 
     This macro is defined to -inf.
 
-.. cvar:: NPY_HALF_NAN
+.. c:var:: NPY_HALF_NAN
 
     This macro is defined to a NaN value, guaranteed to have its sign bit unset.
 
-.. cfunction:: float npy_half_to_float(npy_half h)
+.. c:function:: float npy_half_to_float(npy_half h)
 
    Converts a half-precision float to a single-precision float.
 
-.. cfunction:: double npy_half_to_double(npy_half h)
+.. c:function:: double npy_half_to_double(npy_half h)
 
    Converts a half-precision float to a double-precision float.
 
-.. cfunction:: npy_half npy_float_to_half(float f)
+.. c:function:: npy_half npy_float_to_half(float f)
 
    Converts a single-precision float to a half-precision float.  The
    value is rounded to the nearest representable half, with ties going
    to the nearest even.  If the value is too small or too big, the
    system's floating point underflow or overflow bit will be set.
 
-.. cfunction:: npy_half npy_double_to_half(double d)
+.. c:function:: npy_half npy_double_to_half(double d)
 
    Converts a double-precision float to a half-precision float.  The
    value is rounded to the nearest representable half, with ties going
    to the nearest even.  If the value is too small or too big, the
    system's floating point underflow or overflow bit will be set.
 
-.. cfunction:: int npy_half_eq(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_eq(npy_half h1, npy_half h2)
 
    Compares two half-precision floats (h1 == h2).
 
-.. cfunction:: int npy_half_ne(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_ne(npy_half h1, npy_half h2)
 
    Compares two half-precision floats (h1 != h2).
 
-.. cfunction:: int npy_half_le(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_le(npy_half h1, npy_half h2)
 
    Compares two half-precision floats (h1 <= h2).
 
-.. cfunction:: int npy_half_lt(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_lt(npy_half h1, npy_half h2)
 
    Compares two half-precision floats (h1 < h2).
 
-.. cfunction:: int npy_half_ge(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_ge(npy_half h1, npy_half h2)
 
    Compares two half-precision floats (h1 >= h2).
 
-.. cfunction:: int npy_half_gt(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_gt(npy_half h1, npy_half h2)
 
    Compares two half-precision floats (h1 > h2).
 
-.. cfunction:: int npy_half_eq_nonan(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_eq_nonan(npy_half h1, npy_half h2)
 
    Compares two half-precision floats that are known to not be NaN (h1 == h2).  If
    a value is NaN, the result is undefined.
 
-.. cfunction:: int npy_half_lt_nonan(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_lt_nonan(npy_half h1, npy_half h2)
 
    Compares two half-precision floats that are known to not be NaN (h1 < h2).  If
    a value is NaN, the result is undefined.
 
-.. cfunction:: int npy_half_le_nonan(npy_half h1, npy_half h2)
+.. c:function:: int npy_half_le_nonan(npy_half h1, npy_half h2)
 
    Compares two half-precision floats that are known to not be NaN (h1 <= h2).  If
    a value is NaN, the result is undefined.
 
-.. cfunction:: int npy_half_iszero(npy_half h)
+.. c:function:: int npy_half_iszero(npy_half h)
 
    Tests whether the half-precision float has a value equal to zero.  This may be slightly
    faster than calling npy_half_eq(h, NPY_ZERO).
 
-.. cfunction:: int npy_half_isnan(npy_half h)
+.. c:function:: int npy_half_isnan(npy_half h)
 
    Tests whether the half-precision float is a NaN.
 
-.. cfunction:: int npy_half_isinf(npy_half h)
+.. c:function:: int npy_half_isinf(npy_half h)
 
    Tests whether the half-precision float is plus or minus Inf.
 
-.. cfunction:: int npy_half_isfinite(npy_half h)
+.. c:function:: int npy_half_isfinite(npy_half h)
 
    Tests whether the half-precision float is finite (not NaN or Inf).
 
-.. cfunction:: int npy_half_signbit(npy_half h)
+.. c:function:: int npy_half_signbit(npy_half h)
 
    Returns 1 is h is negative, 0 otherwise.
 
-.. cfunction:: npy_half npy_half_copysign(npy_half x, npy_half y)
+.. c:function:: npy_half npy_half_copysign(npy_half x, npy_half y)
 
     Returns the value of x with the sign bit copied from y.  Works for any value,
     including Inf and NaN.
 
-.. cfunction:: npy_half npy_half_spacing(npy_half h)
+.. c:function:: npy_half npy_half_spacing(npy_half h)
 
     This is the same for half-precision float as npy_spacing and npy_spacingf
     described in the low-level floating point section.
 
-.. cfunction:: npy_half npy_half_nextafter(npy_half x, npy_half y)
+.. c:function:: npy_half npy_half_nextafter(npy_half x, npy_half y)
 
     This is the same for half-precision float as npy_nextafter and npy_nextafterf
     described in the low-level floating point section.
 
-.. cfunction:: npy_uint16 npy_floatbits_to_halfbits(npy_uint32 f)
+.. c:function:: npy_uint16 npy_floatbits_to_halfbits(npy_uint32 f)
 
    Low-level function which converts a 32-bit single-precision float, stored
    as a uint32, into a 16-bit half-precision float.
 
-.. cfunction:: npy_uint16 npy_doublebits_to_halfbits(npy_uint64 d)
+.. c:function:: npy_uint16 npy_doublebits_to_halfbits(npy_uint64 d)
 
    Low-level function which converts a 64-bit double-precision float, stored
    as a uint64, into a 16-bit half-precision float.
 
-.. cfunction:: npy_uint32 npy_halfbits_to_floatbits(npy_uint16 h)
+.. c:function:: npy_uint32 npy_halfbits_to_floatbits(npy_uint16 h)
 
    Low-level function which converts a 16-bit half-precision float
    into a 32-bit single-precision float, stored as a uint32.
 
-.. cfunction:: npy_uint64 npy_halfbits_to_doublebits(npy_uint16 h)
+.. c:function:: npy_uint64 npy_halfbits_to_doublebits(npy_uint16 h)
 
    Low-level function which converts a 16-bit half-precision float
    into a 64-bit double-precision float, stored as a uint64.

--- a/doc/source/reference/c-api.dtype.rst
+++ b/doc/source/reference/c-api.dtype.rst
@@ -16,7 +16,7 @@ select the precision desired.
 
     The names for the types in c code follows c naming conventions
     more closely. The Python names for these types follow Python
-    conventions.  Thus, :cdata:`NPY_FLOAT` picks up a 32-bit float in
+    conventions.  Thus, :c:data:`NPY_FLOAT` picks up a 32-bit float in
     C, but :class:`numpy.float_` in Python corresponds to a 64-bit
     double. The bit-width names can be used in both Python and C for
     clarity.
@@ -28,176 +28,176 @@ Enumerated Types
 There is a list of enumerated types defined providing the basic 24
 data types plus some useful generic names. Whenever the code requires
 a type number, one of these enumerated types is requested. The types
-are all called :cdata:`NPY_{NAME}`:
+are all called :c:data:`NPY_{NAME}`:
 
-.. cvar:: NPY_BOOL
+.. c:var:: NPY_BOOL
 
     The enumeration value for the boolean type, stored as one byte.
     It may only be set to the values 0 and 1.
 
-.. cvar:: NPY_BYTE
-.. cvar:: NPY_INT8
+.. c:var:: NPY_BYTE
+.. c:var:: NPY_INT8
 
     The enumeration value for an 8-bit/1-byte signed integer.
 
-.. cvar:: NPY_SHORT
-.. cvar:: NPY_INT16
+.. c:var:: NPY_SHORT
+.. c:var:: NPY_INT16
 
     The enumeration value for a 16-bit/2-byte signed integer.
 
-.. cvar:: NPY_INT
-.. cvar:: NPY_INT32
+.. c:var:: NPY_INT
+.. c:var:: NPY_INT32
 
     The enumeration value for a 32-bit/4-byte signed integer.
 
-.. cvar:: NPY_LONG
+.. c:var:: NPY_LONG
 
     Equivalent to either NPY_INT or NPY_LONGLONG, depending on the
     platform.
 
-.. cvar:: NPY_LONGLONG
-.. cvar:: NPY_INT64
+.. c:var:: NPY_LONGLONG
+.. c:var:: NPY_INT64
 
     The enumeration value for a 64-bit/8-byte signed integer.
 
-.. cvar:: NPY_UBYTE
-.. cvar:: NPY_UINT8
+.. c:var:: NPY_UBYTE
+.. c:var:: NPY_UINT8
 
     The enumeration value for an 8-bit/1-byte unsigned integer.
 
-.. cvar:: NPY_USHORT
-.. cvar:: NPY_UINT16
+.. c:var:: NPY_USHORT
+.. c:var:: NPY_UINT16
 
     The enumeration value for a 16-bit/2-byte unsigned integer.
 
-.. cvar:: NPY_UINT
-.. cvar:: NPY_UINT32
+.. c:var:: NPY_UINT
+.. c:var:: NPY_UINT32
 
     The enumeration value for a 32-bit/4-byte unsigned integer.
 
-.. cvar:: NPY_ULONG
+.. c:var:: NPY_ULONG
 
     Equivalent to either NPY_UINT or NPY_ULONGLONG, depending on the
     platform.
 
-.. cvar:: NPY_ULONGLONG
-.. cvar:: NPY_UINT64
+.. c:var:: NPY_ULONGLONG
+.. c:var:: NPY_UINT64
 
     The enumeration value for a 64-bit/8-byte unsigned integer.
 
-.. cvar:: NPY_HALF
-.. cvar:: NPY_FLOAT16
+.. c:var:: NPY_HALF
+.. c:var:: NPY_FLOAT16
 
     The enumeration value for a 16-bit/2-byte IEEE 754-2008 compatible floating
     point type.
 
-.. cvar:: NPY_FLOAT
-.. cvar:: NPY_FLOAT32
+.. c:var:: NPY_FLOAT
+.. c:var:: NPY_FLOAT32
 
     The enumeration value for a 32-bit/4-byte IEEE 754 compatible floating
     point type.
 
-.. cvar:: NPY_DOUBLE
-.. cvar:: NPY_FLOAT64
+.. c:var:: NPY_DOUBLE
+.. c:var:: NPY_FLOAT64
 
     The enumeration value for a 64-bit/8-byte IEEE 754 compatible floating
     point type.
 
-.. cvar:: NPY_LONGDOUBLE
+.. c:var:: NPY_LONGDOUBLE
 
     The enumeration value for a platform-specific floating point type which is
     at least as large as NPY_DOUBLE, but larger on many platforms.
 
-.. cvar:: NPY_CFLOAT
-.. cvar:: NPY_COMPLEX64
+.. c:var:: NPY_CFLOAT
+.. c:var:: NPY_COMPLEX64
 
     The enumeration value for a 64-bit/8-byte complex type made up of
     two NPY_FLOAT values.
 
-.. cvar:: NPY_CDOUBLE
-.. cvar:: NPY_COMPLEX128
+.. c:var:: NPY_CDOUBLE
+.. c:var:: NPY_COMPLEX128
 
     The enumeration value for a 128-bit/16-byte complex type made up of
     two NPY_DOUBLE values.
 
-.. cvar:: NPY_CLONGDOUBLE
+.. c:var:: NPY_CLONGDOUBLE
 
     The enumeration value for a platform-specific complex floating point
     type which is made up of two NPY_LONGDOUBLE values.
 
-.. cvar:: NPY_DATETIME
+.. c:var:: NPY_DATETIME
 
     The enumeration value for a data type which holds dates or datetimes with
     a precision based on selectable date or time units.
 
-.. cvar:: NPY_TIMEDELTA
+.. c:var:: NPY_TIMEDELTA
 
     The enumeration value for a data type which holds lengths of times in
     integers of selectable date or time units.
 
-.. cvar:: NPY_STRING
+.. c:var:: NPY_STRING
 
     The enumeration value for ASCII strings of a selectable size. The
     strings have a fixed maximum size within a given array.
 
-.. cvar:: NPY_UNICODE
+.. c:var:: NPY_UNICODE
 
     The enumeration value for UCS4 strings of a selectable size. The
     strings have a fixed maximum size within a given array.
 
-.. cvar:: NPY_OBJECT
+.. c:var:: NPY_OBJECT
 
     The enumeration value for references to arbitrary Python objects.
 
-.. cvar:: NPY_VOID
+.. c:var:: NPY_VOID
 
     Primarily used to hold struct dtypes, but can contain arbitrary
     binary data.
 
 Some useful aliases of the above types are
 
-.. cvar:: NPY_INTP
+.. c:var:: NPY_INTP
 
     The enumeration value for a signed integer type which is the same
     size as a (void \*) pointer. This is the type used by all
     arrays of indices.
 
-.. cvar:: NPY_UINTP
+.. c:var:: NPY_UINTP
 
     The enumeration value for an unsigned integer type which is the
     same size as a (void \*) pointer.
 
-.. cvar:: NPY_MASK
+.. c:var:: NPY_MASK
 
     The enumeration value of the type used for masks, such as with
-    the :cdata:`NPY_ITER_ARRAYMASK` iterator flag. This is equivalent
-    to :cdata:`NPY_UINT8`.
+    the :c:data:`NPY_ITER_ARRAYMASK` iterator flag. This is equivalent
+    to :c:data:`NPY_UINT8`.
 
-.. cvar:: NPY_DEFAULT_TYPE
+.. c:var:: NPY_DEFAULT_TYPE
 
     The default type to use when no dtype is explicitly specified, for
     example when calling np.zero(shape). This is equivalent to
-    :cdata:`NPY_DOUBLE`.
+    :c:data:`NPY_DOUBLE`.
 
 Other useful related constants are
 
-.. cvar:: NPY_NTYPES
+.. c:var:: NPY_NTYPES
 
     The total number of built-in NumPy types. The enumeration covers
     the range from 0 to NPY_NTYPES-1.
 
-.. cvar:: NPY_NOTYPE
+.. c:var:: NPY_NOTYPE
 
     A signal value guaranteed not to be a valid type enumeration number.
 
-.. cvar:: NPY_USERDEF
+.. c:var:: NPY_USERDEF
 
     The start of type numbers used for Custom Data types.
 
 The various character codes indicating certain types are also part of
 an enumerated list. References to type characters (should they be
 needed at all) should always use these enumerations. The form of them
-is :cdata:`NPY_{NAME}LTR` where ``{NAME}`` can be
+is :c:data:`NPY_{NAME}LTR` where ``{NAME}`` can be
 
     **BOOL**, **BYTE**, **UBYTE**, **SHORT**, **USHORT**, **INT**,
     **UINT**, **LONG**, **ULONG**, **LONGLONG**, **ULONGLONG**,
@@ -219,23 +219,23 @@ Defines
 Max and min values for integers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cvar:: NPY_MAX_INT{bits}
+.. c:var:: NPY_MAX_INT{bits}
 
-.. cvar:: NPY_MAX_UINT{bits}
+.. c:var:: NPY_MAX_UINT{bits}
 
-.. cvar:: NPY_MIN_INT{bits}
+.. c:var:: NPY_MIN_INT{bits}
 
     These are defined for ``{bits}`` = 8, 16, 32, 64, 128, and 256 and provide
     the maximum (minimum) value of the corresponding (unsigned) integer
     type. Note: the actual integer type may not be available on all
     platforms (i.e. 128-bit and 256-bit integers are rare).
 
-.. cvar:: NPY_MIN_{type}
+.. c:var:: NPY_MIN_{type}
 
     This is defined for ``{type}`` = **BYTE**, **SHORT**, **INT**,
     **LONG**, **LONGLONG**, **INTP**
 
-.. cvar:: NPY_MAX_{type}
+.. c:var:: NPY_MAX_{type}
 
     This is defined for all defined for ``{type}`` = **BYTE**, **UBYTE**,
     **SHORT**, **USHORT**, **INT**, **UINT**, **LONG**, **ULONG**,
@@ -245,8 +245,8 @@ Max and min values for integers
 Number of bits in data types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All :cdata:`NPY_SIZEOF_{CTYPE}` constants have corresponding
-:cdata:`NPY_BITSOF_{CTYPE}` constants defined. The :cdata:`NPY_BITSOF_{CTYPE}`
+All :c:data:`NPY_SIZEOF_{CTYPE}` constants have corresponding
+:c:data:`NPY_BITSOF_{CTYPE}` constants defined. The :c:data:`NPY_BITSOF_{CTYPE}`
 constants provide the number of bits in the data type.  Specifically,
 the available ``{CTYPE}s`` are
 
@@ -261,7 +261,7 @@ All of the numeric data types (integer, floating point, and complex)
 have constants that are defined to be a specific enumerated type
 number. Exactly which enumerated type a bit-width type refers to is
 platform dependent. In particular, the constants available are
-:cdata:`PyArray_{NAME}{BITS}` where ``{NAME}`` is **INT**, **UINT**,
+:c:data:`PyArray_{NAME}{BITS}` where ``{NAME}`` is **INT**, **UINT**,
 **FLOAT**, **COMPLEX** and ``{BITS}`` can be 8, 16, 32, 64, 80, 96, 128,
 160, 192, 256, and 512.  Obviously not all bit-widths are available on
 all platforms for all the kinds of numeric types. Commonly 8-, 16-,
@@ -290,10 +290,10 @@ types.
 Boolean
 ^^^^^^^
 
-.. ctype:: npy_bool
+.. c:type:: npy_bool
 
-    unsigned char; The constants :cdata:`NPY_FALSE` and
-    :cdata:`NPY_TRUE` are also defined.
+    unsigned char; The constants :c:data:`NPY_FALSE` and
+    :c:data:`NPY_TRUE` are also defined.
 
 
 (Un)Signed Integer
@@ -302,27 +302,27 @@ Boolean
 Unsigned versions of the integers can be defined by pre-pending a 'u'
 to the front of the integer name.
 
-.. ctype:: npy_(u)byte
+.. c:type:: npy_(u)byte
 
     (unsigned) char
 
-.. ctype:: npy_(u)short
+.. c:type:: npy_(u)short
 
     (unsigned) short
 
-.. ctype:: npy_(u)int
+.. c:type:: npy_(u)int
 
     (unsigned) int
 
-.. ctype:: npy_(u)long
+.. c:type:: npy_(u)long
 
     (unsigned) long int
 
-.. ctype:: npy_(u)longlong
+.. c:type:: npy_(u)longlong
 
     (unsigned long long int)
 
-.. ctype:: npy_(u)intp
+.. c:type:: npy_(u)intp
 
     (unsigned) Py_intptr_t (an integer that is the size of a pointer on
     the platform).
@@ -331,15 +331,15 @@ to the front of the integer name.
 (Complex) Floating point
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. ctype:: npy_(c)float
+.. c:type:: npy_(c)float
 
     float
 
-.. ctype:: npy_(c)double
+.. c:type:: npy_(c)double
 
     double
 
-.. ctype:: npy_(c)longdouble
+.. c:type:: npy_(c)longdouble
 
     long double
 
@@ -354,8 +354,8 @@ There are also typedefs for signed integers, unsigned integers,
 floating point, and complex floating point types of specific bit-
 widths. The available type names are
 
-    :ctype:`npy_int{bits}`, :ctype:`npy_uint{bits}`, :ctype:`npy_float{bits}`,
-    and :ctype:`npy_complex{bits}`
+    :c:type:`npy_int{bits}`, :c:type:`npy_uint{bits}`, :c:type:`npy_float{bits}`,
+    and :c:type:`npy_complex{bits}`
 
 where ``{bits}`` is the number of bits in the type and can be **8**,
 **16**, **32**, **64**, 128, and 256 for integer types; 16, **32**
@@ -371,6 +371,6 @@ Printf Formatting
 For help in printing, the following strings are defined as the correct
 format specifier in printf and related commands.
 
-    :cdata:`NPY_LONGLONG_FMT`, :cdata:`NPY_ULONGLONG_FMT`,
-    :cdata:`NPY_INTP_FMT`, :cdata:`NPY_UINTP_FMT`,
-    :cdata:`NPY_LONGDOUBLE_FMT`
+    :c:data:`NPY_LONGLONG_FMT`, :c:data:`NPY_ULONGLONG_FMT`,
+    :c:data:`NPY_INTP_FMT`, :c:data:`NPY_UINTP_FMT`,
+    :c:data:`NPY_LONGDOUBLE_FMT`

--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -31,7 +31,7 @@ Simple Iteration Example
 
 The best way to become familiar with the iterator is to look at its
 usage within the NumPy codebase itself. For example, here is a slightly
-tweaked version of the code for :cfunc:`PyArray_CountNonzero`, which counts the
+tweaked version of the code for :c:func:`PyArray_CountNonzero`, which counts the
 number of non-zero elements in an array.
 
 .. code-block:: c
@@ -120,7 +120,7 @@ Simple Multi-Iteration Example
 
 Here is a simple copy function using the iterator.  The ``order`` parameter
 is used to control the memory layout of the allocated result, typically
-:cdata:`NPY_KEEPORDER` is desired.
+:c:data:`NPY_KEEPORDER` is desired.
 
 .. code-block:: c
 
@@ -209,52 +209,52 @@ Iterator Data Types
 The iterator layout is an internal detail, and user code only sees
 an incomplete struct.
 
-.. ctype:: NpyIter
+.. c:type:: NpyIter
 
     This is an opaque pointer type for the iterator. Access to its contents
     can only be done through the iterator API.
 
-.. ctype:: NpyIter_Type
+.. c:type:: NpyIter_Type
 
    This is the type which exposes the iterator to Python. Currently, no
    API is exposed which provides access to the values of a Python-created
    iterator. If an iterator is created in Python, it must be used in Python
    and vice versa. Such an API will likely be created in a future version.
 
-.. ctype:: NpyIter_IterNextFunc
+.. c:type:: NpyIter_IterNextFunc
 
    This is a function pointer for the iteration loop, returned by
-   :cfunc:`NpyIter_GetIterNext`.
+   :c:func:`NpyIter_GetIterNext`.
 
-.. ctype:: NpyIter_GetMultiIndexFunc
+.. c:type:: NpyIter_GetMultiIndexFunc
 
    This is a function pointer for getting the current iterator multi-index,
-   returned by :cfunc:`NpyIter_GetGetMultiIndex`.
+   returned by :c:func:`NpyIter_GetGetMultiIndex`.
 
 Construction and Destruction
 ----------------------------
 
-.. cfunction:: NpyIter* NpyIter_New(PyArrayObject* op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, PyArray_Descr* dtype)
+.. c:function:: NpyIter* NpyIter_New(PyArrayObject* op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, PyArray_Descr* dtype)
 
     Creates an iterator for the given numpy array object ``op``.
 
     Flags that may be passed in ``flags`` are any combination
     of the global and per-operand flags documented in
-    :cfunc:`NpyIter_MultiNew`, except for :cdata:`NPY_ITER_ALLOCATE`.
+    :c:func:`NpyIter_MultiNew`, except for :c:data:`NPY_ITER_ALLOCATE`.
 
-    Any of the :ctype:`NPY_ORDER` enum values may be passed to ``order``.  For
-    efficient iteration, :ctype:`NPY_KEEPORDER` is the best option, and
+    Any of the :c:type:`NPY_ORDER` enum values may be passed to ``order``.  For
+    efficient iteration, :c:type:`NPY_KEEPORDER` is the best option, and
     the other orders enforce the particular iteration pattern.
 
-    Any of the :ctype:`NPY_CASTING` enum values may be passed to ``casting``.
-    The values include :cdata:`NPY_NO_CASTING`, :cdata:`NPY_EQUIV_CASTING`,
-    :cdata:`NPY_SAFE_CASTING`, :cdata:`NPY_SAME_KIND_CASTING`, and
-    :cdata:`NPY_UNSAFE_CASTING`.  To allow the casts to occur, copying or
+    Any of the :c:type:`NPY_CASTING` enum values may be passed to ``casting``.
+    The values include :c:data:`NPY_NO_CASTING`, :c:data:`NPY_EQUIV_CASTING`,
+    :c:data:`NPY_SAFE_CASTING`, :c:data:`NPY_SAME_KIND_CASTING`, and
+    :c:data:`NPY_UNSAFE_CASTING`.  To allow the casts to occur, copying or
     buffering must also be enabled.
 
     If ``dtype`` isn't ``NULL``, then it requires that data type.
     If copying is allowed, it will make a temporary copy if the data
-    is castable.  If :cdata:`NPY_ITER_UPDATEIFCOPY` is enabled, it will
+    is castable.  If :c:data:`NPY_ITER_UPDATEIFCOPY` is enabled, it will
     also copy the data back with another cast upon iterator destruction.
 
     Returns NULL if there is an error, otherwise returns the allocated
@@ -282,22 +282,22 @@ Construction and Destruction
                             dtype);
         Py_DECREF(dtype);
 
-.. cfunction:: NpyIter* NpyIter_MultiNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes)
+.. c:function:: NpyIter* NpyIter_MultiNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes)
 
     Creates an iterator for broadcasting the ``nop`` array objects provided
     in ``op``, using regular NumPy broadcasting rules.
 
-    Any of the :ctype:`NPY_ORDER` enum values may be passed to ``order``.  For
-    efficient iteration, :cdata:`NPY_KEEPORDER` is the best option, and the
+    Any of the :c:type:`NPY_ORDER` enum values may be passed to ``order``.  For
+    efficient iteration, :c:data:`NPY_KEEPORDER` is the best option, and the
     other orders enforce the particular iteration pattern.  When using
-    :cdata:`NPY_KEEPORDER`, if you also want to ensure that the iteration is
+    :c:data:`NPY_KEEPORDER`, if you also want to ensure that the iteration is
     not reversed along an axis, you should pass the flag
-    :cdata:`NPY_ITER_DONT_NEGATE_STRIDES`.
+    :c:data:`NPY_ITER_DONT_NEGATE_STRIDES`.
 
-    Any of the :ctype:`NPY_CASTING` enum values may be passed to ``casting``.
-    The values include :cdata:`NPY_NO_CASTING`, :cdata:`NPY_EQUIV_CASTING`,
-    :cdata:`NPY_SAFE_CASTING`, :cdata:`NPY_SAME_KIND_CASTING`, and
-    :cdata:`NPY_UNSAFE_CASTING`.  To allow the casts to occur, copying or
+    Any of the :c:type:`NPY_CASTING` enum values may be passed to ``casting``.
+    The values include :c:data:`NPY_NO_CASTING`, :c:data:`NPY_EQUIV_CASTING`,
+    :c:data:`NPY_SAFE_CASTING`, :c:data:`NPY_SAME_KIND_CASTING`, and
+    :c:data:`NPY_UNSAFE_CASTING`.  To allow the casts to occur, copying or
     buffering must also be enabled.
 
     If ``op_dtypes`` isn't ``NULL``, it specifies a data type or ``NULL``
@@ -309,17 +309,17 @@ Construction and Destruction
     Flags that may be passed in ``flags``, applying to the whole
     iterator, are:
 
-        .. cvar:: NPY_ITER_C_INDEX
+        .. c:var:: NPY_ITER_C_INDEX
 
             Causes the iterator to track a raveled flat index matching C
-            order. This option cannot be used with :cdata:`NPY_ITER_F_INDEX`.
+            order. This option cannot be used with :c:data:`NPY_ITER_F_INDEX`.
 
-        .. cvar:: NPY_ITER_F_INDEX
+        .. c:var:: NPY_ITER_F_INDEX
 
             Causes the iterator to track a raveled flat index matching Fortran
-            order. This option cannot be used with :cdata:`NPY_ITER_C_INDEX`.
+            order. This option cannot be used with :c:data:`NPY_ITER_C_INDEX`.
 
-        .. cvar:: NPY_ITER_MULTI_INDEX
+        .. c:var:: NPY_ITER_MULTI_INDEX
 
             Causes the iterator to track a multi-index.
             This prevents the iterator from coalescing axes to
@@ -332,26 +332,26 @@ Construction and Destruction
             However, it is possible to remove axes again and use the iterator
             normally if the size is small enough after removal.
 
-        .. cvar:: NPY_ITER_EXTERNAL_LOOP
+        .. c:var:: NPY_ITER_EXTERNAL_LOOP
 
             Causes the iterator to skip iteration of the innermost
             loop, requiring the user of the iterator to handle it.
 
-            This flag is incompatible with :cdata:`NPY_ITER_C_INDEX`,
-            :cdata:`NPY_ITER_F_INDEX`, and :cdata:`NPY_ITER_MULTI_INDEX`.
+            This flag is incompatible with :c:data:`NPY_ITER_C_INDEX`,
+            :c:data:`NPY_ITER_F_INDEX`, and :c:data:`NPY_ITER_MULTI_INDEX`.
 
-        .. cvar:: NPY_ITER_DONT_NEGATE_STRIDES
+        .. c:var:: NPY_ITER_DONT_NEGATE_STRIDES
 
-            This only affects the iterator when :ctype:`NPY_KEEPORDER` is
+            This only affects the iterator when :c:type:`NPY_KEEPORDER` is
             specified for the order parameter.  By default with
-            :ctype:`NPY_KEEPORDER`, the iterator reverses axes which have
+            :c:type:`NPY_KEEPORDER`, the iterator reverses axes which have
             negative strides, so that memory is traversed in a forward
             direction.  This disables this step.  Use this flag if you
             want to use the underlying memory-ordering of the axes,
             but don't want an axis reversed. This is the behavior of
             ``numpy.ravel(a, order='K')``, for instance.
 
-        .. cvar:: NPY_ITER_COMMON_DTYPE
+        .. c:var:: NPY_ITER_COMMON_DTYPE
 
             Causes the iterator to convert all the operands to a common
             data type, calculated based on the ufunc type promotion rules.
@@ -360,16 +360,16 @@ Construction and Destruction
             If the common data type is known ahead of time, don't use this
             flag.  Instead, set the requested dtype for all the operands.
 
-        .. cvar:: NPY_ITER_REFS_OK
+        .. c:var:: NPY_ITER_REFS_OK
 
             Indicates that arrays with reference types (object
             arrays or structured arrays containing an object type)
             may be accepted and used in the iterator.  If this flag
             is enabled, the caller must be sure to check whether
-            :cfunc:`NpyIter_IterationNeedsAPI`(iter) is true, in which case
+            :c:func:`NpyIter_IterationNeedsAPI(iter)` is true, in which case
             it may not release the GIL during iteration.
 
-        .. cvar:: NPY_ITER_ZEROSIZE_OK
+        .. c:var:: NPY_ITER_ZEROSIZE_OK
 
             Indicates that arrays with a size of zero should be permitted.
             Since the typical iteration loop does not naturally work with
@@ -377,7 +377,7 @@ Construction and Destruction
             than zero before entering the iteration loop.
             Currently only the operands are checked, not a forced shape.
 
-        .. cvar:: NPY_ITER_REDUCE_OK
+        .. c:var:: NPY_ITER_REDUCE_OK
 
             Permits writeable operands with a dimension with zero
             stride and size greater than one.  Note that such operands
@@ -388,56 +388,56 @@ Construction and Destruction
             not trample on values being reduced.
 
             Note that if you want to do a reduction on an automatically
-            allocated output, you must use :cfunc:`NpyIter_GetOperandArray`
+            allocated output, you must use :c:func:`NpyIter_GetOperandArray`
             to get its reference, then set every value to the reduction
             unit before doing the iteration loop.  In the case of a
             buffered reduction, this means you must also specify the
-            flag :cdata:`NPY_ITER_DELAY_BUFALLOC`, then reset the iterator
+            flag :c:data:`NPY_ITER_DELAY_BUFALLOC`, then reset the iterator
             after initializing the allocated operand to prepare the
             buffers.
 
-        .. cvar:: NPY_ITER_RANGED
+        .. c:var:: NPY_ITER_RANGED
 
             Enables support for iteration of sub-ranges of the full
             ``iterindex`` range ``[0, NpyIter_IterSize(iter))``.  Use
-            the function :cfunc:`NpyIter_ResetToIterIndexRange` to specify
+            the function :c:func:`NpyIter_ResetToIterIndexRange` to specify
             a range for iteration.
 
-            This flag can only be used with :cdata:`NPY_ITER_EXTERNAL_LOOP`
-            when :cdata:`NPY_ITER_BUFFERED` is enabled.  This is because
+            This flag can only be used with :c:data:`NPY_ITER_EXTERNAL_LOOP`
+            when :c:data:`NPY_ITER_BUFFERED` is enabled.  This is because
             without buffering, the inner loop is always the size of the
             innermost iteration dimension, and allowing it to get cut up
             would require special handling, effectively making it more
             like the buffered version.
 
-        .. cvar:: NPY_ITER_BUFFERED
+        .. c:var:: NPY_ITER_BUFFERED
 
             Causes the iterator to store buffering data, and use buffering
             to satisfy data type, alignment, and byte-order requirements.
-            To buffer an operand, do not specify the :cdata:`NPY_ITER_COPY`
-            or :cdata:`NPY_ITER_UPDATEIFCOPY` flags, because they will
+            To buffer an operand, do not specify the :c:data:`NPY_ITER_COPY`
+            or :c:data:`NPY_ITER_UPDATEIFCOPY` flags, because they will
             override buffering.  Buffering is especially useful for Python
             code using the iterator, allowing for larger chunks
             of data at once to amortize the Python interpreter overhead.
 
-            If used with :cdata:`NPY_ITER_EXTERNAL_LOOP`, the inner loop
+            If used with :c:data:`NPY_ITER_EXTERNAL_LOOP`, the inner loop
             for the caller may get larger chunks than would be possible
             without buffering, because of how the strides are laid out.
 
-            Note that if an operand is given the flag :cdata:`NPY_ITER_COPY`
-            or :cdata:`NPY_ITER_UPDATEIFCOPY`, a copy will be made in preference
+            Note that if an operand is given the flag :c:data:`NPY_ITER_COPY`
+            or :c:data:`NPY_ITER_UPDATEIFCOPY`, a copy will be made in preference
             to buffering.  Buffering will still occur when the array was
             broadcast so elements need to be duplicated to get a constant
             stride.
 
             In normal buffering, the size of each inner loop is equal
             to the buffer size, or possibly larger if
-            :cdata:`NPY_ITER_GROWINNER` is specified.  If
-            :cdata:`NPY_ITER_REDUCE_OK` is enabled and a reduction occurs,
+            :c:data:`NPY_ITER_GROWINNER` is specified.  If
+            :c:data:`NPY_ITER_REDUCE_OK` is enabled and a reduction occurs,
             the inner loops may become smaller depending
             on the structure of the reduction.
 
-        .. cvar:: NPY_ITER_GROWINNER
+        .. c:var:: NPY_ITER_GROWINNER
 
             When buffering is enabled, this allows the size of the inner
             loop to grow when buffering isn't necessary.  This option
@@ -445,10 +445,10 @@ Construction and Destruction
             data, rather than anything with small cache-friendly arrays
             of temporary values for each inner loop.
 
-        .. cvar:: NPY_ITER_DELAY_BUFALLOC
+        .. c:var:: NPY_ITER_DELAY_BUFALLOC
 
             When buffering is enabled, this delays allocation of the
-            buffers until :cfunc:`NpyIter_Reset` or another reset function is
+            buffers until :c:func:`NpyIter_Reset` or another reset function is
             called.  This flag exists to avoid wasteful copying of
             buffer data when making multiple copies of a buffered
             iterator for multi-threaded iteration.
@@ -457,29 +457,29 @@ Construction and Destruction
             After the iterator is created, and a reduction output
             is allocated automatically by the iterator (be sure to use
             READWRITE access), its value may be initialized to the reduction
-            unit.  Use :cfunc:`NpyIter_GetOperandArray` to get the object.
-            Then, call :cfunc:`NpyIter_Reset` to allocate and fill the buffers
+            unit.  Use :c:func:`NpyIter_GetOperandArray` to get the object.
+            Then, call :c:func:`NpyIter_Reset` to allocate and fill the buffers
             with their initial values.
 
     Flags that may be passed in ``op_flags[i]``, where ``0 <= i < nop``:
 
-        .. cvar:: NPY_ITER_READWRITE
-        .. cvar:: NPY_ITER_READONLY
-        .. cvar:: NPY_ITER_WRITEONLY
+        .. c:var:: NPY_ITER_READWRITE
+        .. c:var:: NPY_ITER_READONLY
+        .. c:var:: NPY_ITER_WRITEONLY
 
             Indicate how the user of the iterator will read or write
             to ``op[i]``.  Exactly one of these flags must be specified
             per operand.
 
-        .. cvar:: NPY_ITER_COPY
+        .. c:var:: NPY_ITER_COPY
 
             Allow a copy of ``op[i]`` to be made if it does not
             meet the data type or alignment requirements as specified
             by the constructor flags and parameters.
 
-        .. cvar:: NPY_ITER_UPDATEIFCOPY
+        .. c:var:: NPY_ITER_UPDATEIFCOPY
 
-            Triggers :cdata:`NPY_ITER_COPY`, and when an array operand
+            Triggers :c:data:`NPY_ITER_COPY`, and when an array operand
             is flagged for writing and is copied, causes the data
             in a copy to be copied back to ``op[i]`` when the iterator
             is destroyed.
@@ -489,9 +489,9 @@ Construction and Destruction
             to back to ``op[i]`` on destruction, instead of doing
             the unecessary copy operation.
 
-        .. cvar:: NPY_ITER_NBO
-        .. cvar:: NPY_ITER_ALIGNED
-        .. cvar:: NPY_ITER_CONTIG
+        .. c:var:: NPY_ITER_NBO
+        .. c:var:: NPY_ITER_ALIGNED
+        .. c:var:: NPY_ITER_CONTIG
 
             Causes the iterator to provide data for ``op[i]``
             that is in native byte order, aligned according to
@@ -510,10 +510,10 @@ Construction and Destruction
             the NBO flag overrides it and the requested data type is
             converted to be in native byte order.
 
-        .. cvar:: NPY_ITER_ALLOCATE
+        .. c:var:: NPY_ITER_ALLOCATE
 
             This is for output arrays, and requires that the flag
-            :cdata:`NPY_ITER_WRITEONLY` or :cdata:`NPY_ITER_READWRITE`
+            :c:data:`NPY_ITER_WRITEONLY` or :c:data:`NPY_ITER_READWRITE`
             be set.  If ``op[i]`` is NULL, creates a new array with
             the final broadcast dimensions, and a layout matching
             the iteration order of the iterator.
@@ -529,50 +529,50 @@ Construction and Destruction
             output will be in native byte order.
 
             After being allocated with this flag, the caller may retrieve
-            the new array by calling :cfunc:`NpyIter_GetOperandArray` and
+            the new array by calling :c:func:`NpyIter_GetOperandArray` and
             getting the i-th object in the returned C array.  The caller
             must call Py_INCREF on it to claim a reference to the array.
 
-        .. cvar:: NPY_ITER_NO_SUBTYPE
+        .. c:var:: NPY_ITER_NO_SUBTYPE
 
-            For use with :cdata:`NPY_ITER_ALLOCATE`, this flag disables
+            For use with :c:data:`NPY_ITER_ALLOCATE`, this flag disables
             allocating an array subtype for the output, forcing
             it to be a straight ndarray.
 
             TODO: Maybe it would be better to introduce a function
             ``NpyIter_GetWrappedOutput`` and remove this flag?
 
-        .. cvar:: NPY_ITER_NO_BROADCAST
+        .. c:var:: NPY_ITER_NO_BROADCAST
 
             Ensures that the input or output matches the iteration
             dimensions exactly.
 
-        .. cvar:: NPY_ITER_ARRAYMASK
+        .. c:var:: NPY_ITER_ARRAYMASK
 
             .. versionadded:: 1.7
 
             Indicates that this operand is the mask to use for
             selecting elements when writing to operands which have
-            the :cdata:`NPY_ITER_WRITEMASKED` flag applied to them.
-            Only one operand may have :cdata:`NPY_ITER_ARRAYMASK` flag
+            the :c:data:`NPY_ITER_WRITEMASKED` flag applied to them.
+            Only one operand may have :c:data:`NPY_ITER_ARRAYMASK` flag
             applied to it.
 
             The data type of an operand with this flag should be either
-            :cdata:`NPY_BOOL`, :cdata:`NPY_MASK`, or a struct dtype
+            :c:data:`NPY_BOOL`, :c:data:`NPY_MASK`, or a struct dtype
             whose fields are all valid mask dtypes. In the latter case,
             it must match up with a struct operand being WRITEMASKED,
             as it is specifying a mask for each field of that array.
 
             This flag only affects writing from the buffer back to
             the array. This means that if the operand is also
-            :cdata:`NPY_ITER_READWRITE` or :cdata:`NPY_ITER_WRITEONLY`,
+            :c:data:`NPY_ITER_READWRITE` or :c:data:`NPY_ITER_WRITEONLY`,
             code doing iteration can write to this operand to
             control which elements will be untouched and which ones will be
             modified. This is useful when the mask should be a combination
             of input masks, for example. Mask values can be created
-            with the :cfunc:`NpyMask_Create` function.
+            with the :c:func:`NpyMask_Create` function.
 
-        .. cvar:: NPY_ITER_WRITEMASKED
+        .. c:var:: NPY_ITER_WRITEMASKED
 
             .. versionadded:: 1.7
 
@@ -580,24 +580,24 @@ Construction and Destruction
             the ARRAYMASK flag indicates are intended to be modified
             by the iteration. In general, the iterator does not enforce
             this, it is up to the code doing the iteration to follow
-            that promise. Code can use the :cfunc:`NpyMask_IsExposed`
+            that promise. Code can use the :c:func:`NpyMask_IsExposed`
             inline function to test whether the mask at a particular
             element allows writing.
 
             When this flag is used, and this operand is buffered, this
             changes how data is copied from the buffer into the array.
             A masked copying routine is used, which only copies the
-            elements in the buffer for which :cfunc:`NpyMask_IsExposed`
+            elements in the buffer for which :c:func:`NpyMask_IsExposed`
             returns true from the corresponding element in the ARRAYMASK
             operand.
 
-.. cfunction:: NpyIter* NpyIter_AdvancedNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
+.. c:function:: NpyIter* NpyIter_AdvancedNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
 
-    Extends :cfunc:`NpyIter_MultiNew` with several advanced options providing
+    Extends :c:func:`NpyIter_MultiNew` with several advanced options providing
     more control over broadcasting and buffering.
 
     If -1/NULL values are passed to ``oa_ndim``, ``op_axes``, ``itershape``,
-    and ``buffersize``, it is equivalent to :cfunc:`NpyIter_MultiNew`.
+    and ``buffersize``, it is equivalent to :c:func:`NpyIter_MultiNew`.
 
     The parameter ``oa_ndim``, when not zero or -1, specifies the number of
     dimensions that will be iterated with customized broadcasting.
@@ -615,7 +615,7 @@ Construction and Destruction
     **Note**: Before NumPy 1.8 ``oa_ndim == 0` was used for signalling that
     that ``op_axes`` and ``itershape`` are unused. This is deprecated and
     should be replaced with -1. Better backward compatibility may be
-    achieved by using :cfunc:`NpyIter_MultiNew` for this case.
+    achieved by using :c:func:`NpyIter_MultiNew` for this case.
 
     .. code-block:: c
 
@@ -640,7 +640,7 @@ Construction and Destruction
     Returns NULL if there is an error, otherwise returns the allocated
     iterator.
 
-.. cfunction:: NpyIter* NpyIter_Copy(NpyIter* iter)
+.. c:function:: NpyIter* NpyIter_Copy(NpyIter* iter)
 
     Makes a copy of the given iterator.  This function is provided
     primarily to enable multi-threaded iteration of the data.
@@ -649,29 +649,29 @@ Construction and Destruction
 
     The recommended approach to multithreaded iteration is to
     first create an iterator with the flags
-    :cdata:`NPY_ITER_EXTERNAL_LOOP`, :cdata:`NPY_ITER_RANGED`,
-    :cdata:`NPY_ITER_BUFFERED`, :cdata:`NPY_ITER_DELAY_BUFALLOC`, and
-    possibly :cdata:`NPY_ITER_GROWINNER`.  Create a copy of this iterator
+    :c:data:`NPY_ITER_EXTERNAL_LOOP`, :c:data:`NPY_ITER_RANGED`,
+    :c:data:`NPY_ITER_BUFFERED`, :c:data:`NPY_ITER_DELAY_BUFALLOC`, and
+    possibly :c:data:`NPY_ITER_GROWINNER`.  Create a copy of this iterator
     for each thread (minus one for the first iterator).  Then, take
     the iteration index range ``[0, NpyIter_GetIterSize(iter))`` and
     split it up into tasks, for example using a TBB parallel_for loop.
     When a thread gets a task to execute, it then uses its copy of
-    the iterator by calling :cfunc:`NpyIter_ResetToIterIndexRange` and
+    the iterator by calling :c:func:`NpyIter_ResetToIterIndexRange` and
     iterating over the full range.
 
     When using the iterator in multi-threaded code or in code not
     holding the Python GIL, care must be taken to only call functions
-    which are safe in that context.  :cfunc:`NpyIter_Copy` cannot be safely
+    which are safe in that context.  :c:func:`NpyIter_Copy` cannot be safely
     called without the Python GIL, because it increments Python
     references.  The ``Reset*`` and some other functions may be safely
     called by passing in the ``errmsg`` parameter as non-NULL, so that
     the functions will pass back errors through it instead of setting
     a Python exception.
 
-.. cfunction:: int NpyIter_RemoveAxis(NpyIter* iter, int axis)``
+.. c:function:: int NpyIter_RemoveAxis(NpyIter* iter, int axis)``
 
     Removes an axis from iteration.  This requires that
-    :cdata:`NPY_ITER_MULTI_INDEX` was set for iterator creation, and does
+    :c:data:`NPY_ITER_MULTI_INDEX` was set for iterator creation, and does
     not work if buffering is enabled or an index is being tracked. This
     function also resets the iterator to its initial state.
 
@@ -688,7 +688,7 @@ Construction and Destruction
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
 
-.. cfunction:: int NpyIter_RemoveMultiIndex(NpyIter* iter)
+.. c:function:: int NpyIter_RemoveMultiIndex(NpyIter* iter)
 
     If the iterator is tracking a multi-index, this strips support for them,
     and does further iterator optimizations that are possible if multi-indices
@@ -699,17 +699,17 @@ Construction and Destruction
     the iterator.  Any cached functions or pointers from the iterator
     must be retrieved again!
 
-    After calling this function, :cfunc:`NpyIter_HasMultiIndex`(iter) will
+    After calling this function, :c:func:`NpyIter_HasMultiIndex(iter)` will
     return false.
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: int NpyIter_EnableExternalLoop(NpyIter* iter)
+.. c:function:: int NpyIter_EnableExternalLoop(NpyIter* iter)
 
-    If :cfunc:`NpyIter_RemoveMultiIndex` was called, you may want to enable the
-    flag :cdata:`NPY_ITER_EXTERNAL_LOOP`.  This flag is not permitted
-    together with :cdata:`NPY_ITER_MULTI_INDEX`, so this function is provided
-    to enable the feature after :cfunc:`NpyIter_RemoveMultiIndex` is called.
+    If :c:func:`NpyIter_RemoveMultiIndex` was called, you may want to enable the
+    flag :c:data:`NPY_ITER_EXTERNAL_LOOP`.  This flag is not permitted
+    together with :c:data:`NPY_ITER_MULTI_INDEX`, so this function is provided
+    to enable the feature after :c:func:`NpyIter_RemoveMultiIndex` is called.
     This function also resets the iterator to its initial state.
 
     **WARNING**: This function changes the internal logic of the iterator.
@@ -718,14 +718,14 @@ Construction and Destruction
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: int NpyIter_Deallocate(NpyIter* iter)
+.. c:function:: int NpyIter_Deallocate(NpyIter* iter)
 
     Deallocates the iterator object.  This additionally frees any
     copies made, triggering UPDATEIFCOPY behavior where necessary.
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: int NpyIter_Reset(NpyIter* iter, char** errmsg)
+.. c:function:: int NpyIter_Reset(NpyIter* iter, char** errmsg)
 
     Resets the iterator back to its initial state, at the beginning
     of the iteration range.
@@ -736,12 +736,12 @@ Construction and Destruction
     non-NULL, the function may be safely called without holding
     the Python GIL.
 
-.. cfunction:: int NpyIter_ResetToIterIndexRange(NpyIter* iter, npy_intp istart, npy_intp iend, char** errmsg)
+.. c:function:: int NpyIter_ResetToIterIndexRange(NpyIter* iter, npy_intp istart, npy_intp iend, char** errmsg)
 
     Resets the iterator and restricts it to the ``iterindex`` range
-    ``[istart, iend)``.  See :cfunc:`NpyIter_Copy` for an explanation of
+    ``[istart, iend)``.  See :c:func:`NpyIter_Copy` for an explanation of
     how to use this for multi-threaded iteration.  This requires that
-    the flag :cdata:`NPY_ITER_RANGED` was passed to the iterator constructor.
+    the flag :c:data:`NPY_ITER_RANGED` was passed to the iterator constructor.
 
     If you want to reset both the ``iterindex`` range and the base
     pointers at the same time, you can do the following to avoid
@@ -763,7 +763,7 @@ Construction and Destruction
     non-NULL, the function may be safely called without holding
     the Python GIL.
 
-.. cfunction:: int NpyIter_ResetBasePointers(NpyIter *iter, char** baseptrs, char** errmsg)
+.. c:function:: int NpyIter_ResetBasePointers(NpyIter *iter, char** baseptrs, char** errmsg)
 
     Resets the iterator back to its initial state, but using the values
     in ``baseptrs`` for the data instead of the pointers from the arrays
@@ -781,12 +781,12 @@ Construction and Destruction
 
     Creating iterators for nested iteration requires some care.  All
     the iterator operands must match exactly, or the calls to
-    :cfunc:`NpyIter_ResetBasePointers` will be invalid.  This means that
+    :c:func:`NpyIter_ResetBasePointers` will be invalid.  This means that
     automatic copies and output allocation should not be used haphazardly.
     It is possible to still use the automatic data conversion and casting
     features of the iterator by creating one of the iterators with
     all the conversion parameters enabled, then grabbing the allocated
-    operands with the :cfunc:`NpyIter_GetOperandArray` function and passing
+    operands with the :c:func:`NpyIter_GetOperandArray` function and passing
     them into the constructors for the rest of the iterators.
 
     **WARNING**: When creating iterators for nested iteration,
@@ -825,7 +825,7 @@ Construction and Destruction
             } while (iternext2(iter2));
         } while (iternext1(iter1));
 
-.. cfunction:: int NpyIter_GotoMultiIndex(NpyIter* iter, npy_intp* multi_index)
+.. c:function:: int NpyIter_GotoMultiIndex(NpyIter* iter, npy_intp* multi_index)
 
     Adjusts the iterator to point to the ``ndim`` indices
     pointed to by ``multi_index``.  Returns an error if a multi-index
@@ -834,19 +834,19 @@ Construction and Destruction
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: int NpyIter_GotoIndex(NpyIter* iter, npy_intp index)
+.. c:function:: int NpyIter_GotoIndex(NpyIter* iter, npy_intp index)
 
     Adjusts the iterator to point to the ``index`` specified.
     If the iterator was constructed with the flag
-    :cdata:`NPY_ITER_C_INDEX`, ``index`` is the C-order index,
+    :c:data:`NPY_ITER_C_INDEX`, ``index`` is the C-order index,
     and if the iterator was constructed with the flag
-    :cdata:`NPY_ITER_F_INDEX`, ``index`` is the Fortran-order
+    :c:data:`NPY_ITER_F_INDEX`, ``index`` is the Fortran-order
     index.  Returns an error if there is no index being tracked,
     the index is out of bounds, or inner loop iteration is disabled.
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: npy_intp NpyIter_GetIterSize(NpyIter* iter)
+.. c:function:: npy_intp NpyIter_GetIterSize(NpyIter* iter)
 
     Returns the number of elements being iterated.  This is the product
     of all the dimensions in the shape.  When a multi index is being tracked
@@ -855,18 +855,18 @@ Construction and Destruction
     may become valid after `NpyIter_RemoveAxis` is called. It is not
     necessary to check for this case.
 
-.. cfunction:: npy_intp NpyIter_GetIterIndex(NpyIter* iter)
+.. c:function:: npy_intp NpyIter_GetIterIndex(NpyIter* iter)
 
     Gets the ``iterindex`` of the iterator, which is an index matching
     the iteration order of the iterator.
 
-.. cfunction:: void NpyIter_GetIterIndexRange(NpyIter* iter, npy_intp* istart, npy_intp* iend)
+.. c:function:: void NpyIter_GetIterIndexRange(NpyIter* iter, npy_intp* istart, npy_intp* iend)
 
     Gets the ``iterindex`` sub-range that is being iterated.  If
-    :cdata:`NPY_ITER_RANGED` was not specified, this always returns the
+    :c:data:`NPY_ITER_RANGED` was not specified, this always returns the
     range ``[0, NpyIter_IterSize(iter))``.
 
-.. cfunction:: int NpyIter_GotoIterIndex(NpyIter* iter, npy_intp iterindex)
+.. c:function:: int NpyIter_GotoIterIndex(NpyIter* iter, npy_intp iterindex)
 
     Adjusts the iterator to point to the ``iterindex`` specified.
     The IterIndex is an index matching the iteration order of the iterator.
@@ -875,97 +875,97 @@ Construction and Destruction
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: npy_bool NpyIter_HasDelayedBufAlloc(NpyIter* iter)
+.. c:function:: npy_bool NpyIter_HasDelayedBufAlloc(NpyIter* iter)
 
-    Returns 1 if the flag :cdata:`NPY_ITER_DELAY_BUFALLOC` was passed
+    Returns 1 if the flag :c:data:`NPY_ITER_DELAY_BUFALLOC` was passed
     to the iterator constructor, and no call to one of the Reset
     functions has been done yet, 0 otherwise.
 
-.. cfunction:: npy_bool NpyIter_HasExternalLoop(NpyIter* iter)
+.. c:function:: npy_bool NpyIter_HasExternalLoop(NpyIter* iter)
 
     Returns 1 if the caller needs to handle the inner-most 1-dimensional
     loop, or 0 if the iterator handles all looping. This is controlled
-    by the constructor flag :cdata:`NPY_ITER_EXTERNAL_LOOP` or
-    :cfunc:`NpyIter_EnableExternalLoop`.
+    by the constructor flag :c:data:`NPY_ITER_EXTERNAL_LOOP` or
+    :c:func:`NpyIter_EnableExternalLoop`.
 
-.. cfunction:: npy_bool NpyIter_HasMultiIndex(NpyIter* iter)
-
-    Returns 1 if the iterator was created with the
-    :cdata:`NPY_ITER_MULTI_INDEX` flag, 0 otherwise.
-
-.. cfunction:: npy_bool NpyIter_HasIndex(NpyIter* iter)
+.. c:function:: npy_bool NpyIter_HasMultiIndex(NpyIter* iter)
 
     Returns 1 if the iterator was created with the
-    :cdata:`NPY_ITER_C_INDEX` or :cdata:`NPY_ITER_F_INDEX`
+    :c:data:`NPY_ITER_MULTI_INDEX` flag, 0 otherwise.
+
+.. c:function:: npy_bool NpyIter_HasIndex(NpyIter* iter)
+
+    Returns 1 if the iterator was created with the
+    :c:data:`NPY_ITER_C_INDEX` or :c:data:`NPY_ITER_F_INDEX`
     flag, 0 otherwise.
 
-.. cfunction:: npy_bool NpyIter_RequiresBuffering(NpyIter* iter)
+.. c:function:: npy_bool NpyIter_RequiresBuffering(NpyIter* iter)
 
     Returns 1 if the iterator requires buffering, which occurs
     when an operand needs conversion or alignment and so cannot
     be used directly.
 
-.. cfunction:: npy_bool NpyIter_IsBuffered(NpyIter* iter)
+.. c:function:: npy_bool NpyIter_IsBuffered(NpyIter* iter)
 
     Returns 1 if the iterator was created with the
-    :cdata:`NPY_ITER_BUFFERED` flag, 0 otherwise.
+    :c:data:`NPY_ITER_BUFFERED` flag, 0 otherwise.
 
-.. cfunction:: npy_bool NpyIter_IsGrowInner(NpyIter* iter)
+.. c:function:: npy_bool NpyIter_IsGrowInner(NpyIter* iter)
 
     Returns 1 if the iterator was created with the
-    :cdata:`NPY_ITER_GROWINNER` flag, 0 otherwise.
+    :c:data:`NPY_ITER_GROWINNER` flag, 0 otherwise.
 
-.. cfunction:: npy_intp NpyIter_GetBufferSize(NpyIter* iter)
+.. c:function:: npy_intp NpyIter_GetBufferSize(NpyIter* iter)
 
     If the iterator is buffered, returns the size of the buffer
     being used, otherwise returns 0.
 
-.. cfunction:: int NpyIter_GetNDim(NpyIter* iter)
+.. c:function:: int NpyIter_GetNDim(NpyIter* iter)
 
     Returns the number of dimensions being iterated.  If a multi-index
     was not requested in the iterator constructor, this value
     may be smaller than the number of dimensions in the original
     objects.
 
-.. cfunction:: int NpyIter_GetNOp(NpyIter* iter)
+.. c:function:: int NpyIter_GetNOp(NpyIter* iter)
 
     Returns the number of operands in the iterator.
 
-    When :cdata:`NPY_ITER_USE_MASKNA` is used on an operand, a new
+    When :c:data:`NPY_ITER_USE_MASKNA` is used on an operand, a new
     operand is added to the end of the operand list in the iterator
     to track that operand's NA mask. Thus, this equals the number
     of construction operands plus the number of operands for
-    which the flag :cdata:`NPY_ITER_USE_MASKNA` was specified.
+    which the flag :c:data:`NPY_ITER_USE_MASKNA` was specified.
 
-.. cfunction:: int NpyIter_GetFirstMaskNAOp(NpyIter* iter)
+.. c:function:: int NpyIter_GetFirstMaskNAOp(NpyIter* iter)
 
     .. versionadded:: 1.7
 
     Returns the index of the first NA mask operand in the array. This
     value is equal to the number of operands passed into the constructor.
 
-.. cfunction:: npy_intp* NpyIter_GetAxisStrideArray(NpyIter* iter, int axis)
+.. c:function:: npy_intp* NpyIter_GetAxisStrideArray(NpyIter* iter, int axis)
 
     Gets the array of strides for the specified axis. Requires that
     the iterator be tracking a multi-index, and that buffering not
     be enabled.
 
     This may be used when you want to match up operand axes in
-    some fashion, then remove them with :cfunc:`NpyIter_RemoveAxis` to
+    some fashion, then remove them with :c:func:`NpyIter_RemoveAxis` to
     handle their processing manually.  By calling this function
     before removing the axes, you can get the strides for the
     manual processing.
 
     Returns ``NULL`` on error.
 
-.. cfunction:: int NpyIter_GetShape(NpyIter* iter, npy_intp* outshape)
+.. c:function:: int NpyIter_GetShape(NpyIter* iter, npy_intp* outshape)
 
     Returns the broadcast shape of the iterator in ``outshape``.
     This can only be called on an iterator which is tracking a multi-index.
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: PyArray_Descr** NpyIter_GetDescrArray(NpyIter* iter)
+.. c:function:: PyArray_Descr** NpyIter_GetDescrArray(NpyIter* iter)
 
     This gives back a pointer to the ``nop`` data type Descrs for
     the objects being iterated.  The result points into ``iter``,
@@ -974,26 +974,26 @@ Construction and Destruction
     This pointer may be cached before the iteration loop, calling
     ``iternext`` will not change it.
 
-.. cfunction:: PyObject** NpyIter_GetOperandArray(NpyIter* iter)
+.. c:function:: PyObject** NpyIter_GetOperandArray(NpyIter* iter)
 
     This gives back a pointer to the ``nop`` operand PyObjects
     that are being iterated.  The result points into ``iter``,
     so the caller does not gain any references to the PyObjects.
 
-.. cfunction:: npy_int8* NpyIter_GetMaskNAIndexArray(NpyIter* iter)
+.. c:function:: npy_int8* NpyIter_GetMaskNAIndexArray(NpyIter* iter)
 
     .. versionadded:: 1.7
 
     This gives back a pointer to the ``nop`` indices which map
-    construction operands with :cdata:`NPY_ITER_USE_MASKNA` flagged
+    construction operands with :c:data:`NPY_ITER_USE_MASKNA` flagged
     to their corresponding NA mask operands and vice versa. For
-    operands which were not flagged with :cdata:`NPY_ITER_USE_MASKNA`,
+    operands which were not flagged with :c:data:`NPY_ITER_USE_MASKNA`,
     this array contains negative values.
 
-.. cfunction:: PyObject* NpyIter_GetIterView(NpyIter* iter, npy_intp i)
+.. c:function:: PyObject* NpyIter_GetIterView(NpyIter* iter, npy_intp i)
 
     This gives back a reference to a new ndarray view, which is a view
-    into the i-th object in the array :cfunc:`NpyIter_GetOperandArray`(),
+    into the i-th object in the array :c:func:`NpyIter_GetOperandArray()`,
     whose dimensions and strides match the internal optimized
     iteration pattern.  A C-order iteration of this view is equivalent
     to the iterator's iteration order.
@@ -1003,24 +1003,24 @@ Construction and Destruction
     collapse it into a single strided iteration, this would return
     a view that is a one-dimensional array.
 
-.. cfunction:: void NpyIter_GetReadFlags(NpyIter* iter, char* outreadflags)
+.. c:function:: void NpyIter_GetReadFlags(NpyIter* iter, char* outreadflags)
 
     Fills ``nop`` flags. Sets ``outreadflags[i]`` to 1 if
     ``op[i]`` can be read from, and to 0 if not.
 
-.. cfunction:: void NpyIter_GetWriteFlags(NpyIter* iter, char* outwriteflags)
+.. c:function:: void NpyIter_GetWriteFlags(NpyIter* iter, char* outwriteflags)
 
     Fills ``nop`` flags. Sets ``outwriteflags[i]`` to 1 if
     ``op[i]`` can be written to, and to 0 if not.
 
-.. cfunction:: int NpyIter_CreateCompatibleStrides(NpyIter* iter, npy_intp itemsize, npy_intp* outstrides)
+.. c:function:: int NpyIter_CreateCompatibleStrides(NpyIter* iter, npy_intp itemsize, npy_intp* outstrides)
 
     Builds a set of strides which are the same as the strides of an
-    output array created using the :cdata:`NPY_ITER_ALLOCATE` flag, where NULL
+    output array created using the :c:data:`NPY_ITER_ALLOCATE` flag, where NULL
     was passed for op_axes.  This is for data packed contiguously,
     but not necessarily in C or Fortran order. This should be used
-    together with :cfunc:`NpyIter_GetShape` and :cfunc:`NpyIter_GetNDim`
-    with the flag :cdata:`NPY_ITER_MULTI_INDEX` passed into the constructor.
+    together with :c:func:`NpyIter_GetShape` and :c:func:`NpyIter_GetNDim`
+    with the flag :c:data:`NPY_ITER_MULTI_INDEX` passed into the constructor.
 
     A use case for this function is to match the shape and layout of
     the iterator and tack on one or more dimensions.  For example,
@@ -1031,7 +1031,7 @@ Construction and Destruction
     the symmetry and pack it into 1 dimension with a particular encoding.
 
     This function may only be called if the iterator is tracking a multi-index
-    and if :cdata:`NPY_ITER_DONT_NEGATE_STRIDES` was used to prevent an axis
+    and if :c:data:`NPY_ITER_DONT_NEGATE_STRIDES` was used to prevent an axis
     from being iterated in reverse order.
 
     If an array is created with this method, simply adding 'itemsize'
@@ -1040,7 +1040,7 @@ Construction and Destruction
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-.. cfunction:: npy_bool NpyIter_IsFirstVisit(NpyIter* iter, int iop)
+.. c:function:: npy_bool NpyIter_IsFirstVisit(NpyIter* iter, int iop)
 
     .. versionadded:: 1.7
 
@@ -1067,7 +1067,7 @@ Construction and Destruction
 Functions For Iteration
 -----------------------
 
-.. cfunction:: NpyIter_IterNextFunc* NpyIter_GetIterNext(NpyIter* iter, char** errmsg)
+.. c:function:: NpyIter_IterNextFunc* NpyIter_GetIterNext(NpyIter* iter, char** errmsg)
 
     Returns a function pointer for iteration.  A specialized version
     of the function pointer may be calculated by this function
@@ -1092,7 +1092,7 @@ Functions For Iteration
             /* use the addresses dataptr[0], ... dataptr[nop-1] */
         } while(iternext(iter));
 
-    When :cdata:`NPY_ITER_EXTERNAL_LOOP` is specified, the typical
+    When :c:data:`NPY_ITER_EXTERNAL_LOOP` is specified, the typical
     inner loop construct is as follows.
 
     .. code-block:: c
@@ -1119,11 +1119,11 @@ Functions For Iteration
     with fresh values, not incrementally updated.
 
     If a compile-time fixed buffer is being used (both flags
-    :cdata:`NPY_ITER_BUFFERED` and :cdata:`NPY_ITER_EXTERNAL_LOOP`), the
+    :c:data:`NPY_ITER_BUFFERED` and :c:data:`NPY_ITER_EXTERNAL_LOOP`), the
     inner size may be used as a signal as well.  The size is guaranteed
     to become zero when ``iternext()`` returns false, enabling the
     following loop construct.  Note that if you use this construct,
-    you should not pass :cdata:`NPY_ITER_GROWINNER` as a flag, because it
+    you should not pass :c:data:`NPY_ITER_GROWINNER` as a flag, because it
     will cause larger sizes under some circumstances.
 
     .. code-block:: c
@@ -1165,7 +1165,7 @@ Functions For Iteration
             }
         } while (iternext());
 
-.. cfunction:: NpyIter_GetMultiIndexFunc *NpyIter_GetGetMultiIndex(NpyIter* iter, char** errmsg)
+.. c:function:: NpyIter_GetMultiIndexFunc *NpyIter_GetGetMultiIndex(NpyIter* iter, char** errmsg)
 
     Returns a function pointer for getting the current multi-index
     of the iterator.  Returns NULL if the iterator is not tracking
@@ -1179,10 +1179,10 @@ Functions For Iteration
     non-NULL, the function may be safely called without holding
     the Python GIL.
 
-.. cfunction:: char** NpyIter_GetDataPtrArray(NpyIter* iter)
+.. c:function:: char** NpyIter_GetDataPtrArray(NpyIter* iter)
 
     This gives back a pointer to the ``nop`` data pointers.  If
-    :cdata:`NPY_ITER_EXTERNAL_LOOP` was not specified, each data
+    :c:data:`NPY_ITER_EXTERNAL_LOOP` was not specified, each data
     pointer points to the current data item of the iterator.  If
     no inner iteration was specified, it points to the first data
     item of the inner loop.
@@ -1191,7 +1191,7 @@ Functions For Iteration
     ``iternext`` will not change it.  This function may be safely
     called without holding the Python GIL.
 
-.. cfunction:: char** NpyIter_GetInitialDataPtrArray(NpyIter* iter)
+.. c:function:: char** NpyIter_GetInitialDataPtrArray(NpyIter* iter)
 
    Gets the array of data pointers directly into the arrays (never
    into the buffers), corresponding to iteration index 0.
@@ -1202,18 +1202,18 @@ Functions For Iteration
 
    This function may be safely called without holding the Python GIL.
 
-.. cfunction:: npy_intp* NpyIter_GetIndexPtr(NpyIter* iter)
+.. c:function:: npy_intp* NpyIter_GetIndexPtr(NpyIter* iter)
 
     This gives back a pointer to the index being tracked, or NULL
     if no index is being tracked.  It is only useable if one of
-    the flags :cdata:`NPY_ITER_C_INDEX` or :cdata:`NPY_ITER_F_INDEX`
+    the flags :c:data:`NPY_ITER_C_INDEX` or :c:data:`NPY_ITER_F_INDEX`
     were specified during construction.
 
-When the flag :cdata:`NPY_ITER_EXTERNAL_LOOP` is used, the code
+When the flag :c:data:`NPY_ITER_EXTERNAL_LOOP` is used, the code
 needs to know the parameters for doing the inner loop.  These
 functions provide that information.
 
-.. cfunction:: npy_intp* NpyIter_GetInnerStrideArray(NpyIter* iter)
+.. c:function:: npy_intp* NpyIter_GetInnerStrideArray(NpyIter* iter)
 
     Returns a pointer to an array of the ``nop`` strides,
     one for each iterated object, to be used by the inner loop.
@@ -1222,7 +1222,7 @@ functions provide that information.
     ``iternext`` will not change it. This function may be safely
     called without holding the Python GIL.
 
-.. cfunction:: npy_intp* NpyIter_GetInnerLoopSizePtr(NpyIter* iter)
+.. c:function:: npy_intp* NpyIter_GetInnerLoopSizePtr(NpyIter* iter)
 
     Returns a pointer to the number of iterations the
     inner loop should execute.
@@ -1232,14 +1232,14 @@ functions provide that information.
     iteration, in particular if buffering is enabled.  This function
     may be safely called without holding the Python GIL.
 
-.. cfunction:: void NpyIter_GetInnerFixedStrideArray(NpyIter* iter, npy_intp* out_strides)
+.. c:function:: void NpyIter_GetInnerFixedStrideArray(NpyIter* iter, npy_intp* out_strides)
 
     Gets an array of strides which are fixed, or will not change during
     the entire iteration.  For strides that may change, the value
     NPY_MAX_INTP is placed in the stride.
 
     Once the iterator is prepared for iteration (after a reset if
-    :cdata:`NPY_DELAY_BUFALLOC` was used), call this to get the strides
+    :c:data:`NPY_DELAY_BUFALLOC` was used), call this to get the strides
     which may be used to select a fast inner loop function.  For example,
     if the stride is 0, that means the inner loop can always load its
     value into a variable once, then use the variable throughout the loop,
@@ -1265,33 +1265,33 @@ iterator, which does not have corresponding features in this iterator.
 
 Here is a conversion table for which functions to use with the new iterator:
 
-=====================================  =============================================
+=====================================  ===================================================
 *Iterator Functions*
-:cfunc:`PyArray_IterNew`               :cfunc:`NpyIter_New`
-:cfunc:`PyArray_IterAllButAxis`        :cfunc:`NpyIter_New` + ``axes`` parameter **or**
-                                       Iterator flag :cdata:`NPY_ITER_EXTERNAL_LOOP`
-:cfunc:`PyArray_BroadcastToShape`      **NOT SUPPORTED** (Use the support for
+:c:func:`PyArray_IterNew`              :c:func:`NpyIter_New`
+:c:func:`PyArray_IterAllButAxis`       :c:func:`NpyIter_New` + ``axes`` parameter **or**
+                                       Iterator flag :c:data:`NPY_ITER_EXTERNAL_LOOP`
+:c:func:`PyArray_BroadcastToShape`     **NOT SUPPORTED** (Use the support for
                                        multiple operands instead.)
-:cfunc:`PyArrayIter_Check`             Will need to add this in Python exposure
-:cfunc:`PyArray_ITER_RESET`            :cfunc:`NpyIter_Reset`
-:cfunc:`PyArray_ITER_NEXT`             Function pointer from :cfunc:`NpyIter_GetIterNext`
-:cfunc:`PyArray_ITER_DATA`             :cfunc:`NpyIter_GetDataPtrArray`
-:cfunc:`PyArray_ITER_GOTO`             :cfunc:`NpyIter_GotoMultiIndex`
-:cfunc:`PyArray_ITER_GOTO1D`           :cfunc:`NpyIter_GotoIndex` or
-                                       :cfunc:`NpyIter_GotoIterIndex`
-:cfunc:`PyArray_ITER_NOTDONE`          Return value of ``iternext`` function pointer
+:c:func:`PyArrayIter_Check`            Will need to add this in Python exposure
+:c:func:`PyArray_ITER_RESET`           :c:func:`NpyIter_Reset`
+:c:func:`PyArray_ITER_NEXT`            Function pointer from :c:func:`NpyIter_GetIterNext`
+:c:func:`PyArray_ITER_DATA`            c:func:`NpyIter_GetDataPtrArray`
+:c:func:`PyArray_ITER_GOTO`            :c:func:`NpyIter_GotoMultiIndex`
+:c:func:`PyArray_ITER_GOTO1D`          :c:func:`NpyIter_GotoIndex` or
+                                       :c:func:`NpyIter_GotoIterIndex`
+:c:func:`PyArray_ITER_NOTDONE`         Return value of ``iternext`` function pointer
 *Multi-iterator Functions*
-:cfunc:`PyArray_MultiIterNew`          :cfunc:`NpyIter_MultiNew`
-:cfunc:`PyArray_MultiIter_RESET`       :cfunc:`NpyIter_Reset`
-:cfunc:`PyArray_MultiIter_NEXT`        Function pointer from :cfunc:`NpyIter_GetIterNext`
-:cfunc:`PyArray_MultiIter_DATA`        :cfunc:`NpyIter_GetDataPtrArray`
-:cfunc:`PyArray_MultiIter_NEXTi`       **NOT SUPPORTED** (always lock-step iteration)
-:cfunc:`PyArray_MultiIter_GOTO`        :cfunc:`NpyIter_GotoMultiIndex`
-:cfunc:`PyArray_MultiIter_GOTO1D`      :cfunc:`NpyIter_GotoIndex` or
-                                       :cfunc:`NpyIter_GotoIterIndex`
-:cfunc:`PyArray_MultiIter_NOTDONE`     Return value of ``iternext`` function pointer
-:cfunc:`PyArray_Broadcast`             Handled by :cfunc:`NpyIter_MultiNew`
-:cfunc:`PyArray_RemoveSmallest`        Iterator flag :cdata:`NPY_ITER_EXTERNAL_LOOP`
+:c:func:`PyArray_MultiIterNew`         :c:func:`NpyIter_MultiNew`
+:c:func:`PyArray_MultiIter_RESET`      :c:func:`NpyIter_Reset`
+:c:func:`PyArray_MultiIter_NEXT`       Function pointer from :c:func:`NpyIter_GetIterNext`
+:c:func:`PyArray_MultiIter_DATA`       :c:func:`NpyIter_GetDataPtrArray`
+:c:func:`PyArray_MultiIter_NEXTi`      **NOT SUPPORTED** (always lock-step iteration)
+:c:func:`PyArray_MultiIter_GOTO`       :c:func:`NpyIter_GotoMultiIndex`
+:c:func:`PyArray_MultiIter_GOTO1D`     :c:func:`NpyIter_GotoIndex` or
+                                       :c:func:`NpyIter_GotoIterIndex`
+:c:func:`PyArray_MultiIter_NOTDONE`    Return value of ``iternext`` function pointer
+:c:func:`PyArray_Broadcast`            Handled by :c:func:`NpyIter_MultiNew`
+:c:func:`PyArray_RemoveSmallest`       Iterator flag :c:data:`NPY_ITER_EXTERNAL_LOOP`
 *Other Functions*
-:cfunc:`PyArray_ConvertToCommonType`   Iterator flag :cdata:`NPY_ITER_COMMON_DTYPE`
-=====================================  =============================================
+:c:func:`PyArray_ConvertToCommonType`  Iterator flag :c:data:`NPY_ITER_COMMON_DTYPE`
+=====================================  ===================================================

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -6,14 +6,14 @@ Python Types and C-Structures
 
 Several new types are defined in the C-code. Most of these are
 accessible from Python, but a few are not exposed due to their limited
-use. Every new Python type has an associated :ctype:`PyObject *` with an
+use. Every new Python type has an associated :c:type:`PyObject *` with an
 internal structure that includes a pointer to a "method table" that
 defines how the new object behaves in Python. When you receive a
 Python object into C code, you always get a pointer to a
-:ctype:`PyObject` structure. Because a :ctype:`PyObject` structure is
-very generic and defines only :cmacro:`PyObject_HEAD`, by itself it
+:c:type:`PyObject` structure. Because a :c:type:`PyObject` structure is
+very generic and defines only :c:macro:`PyObject_HEAD`, by itself it
 is not very interesting. However, different objects contain more
-details after the :cmacro:`PyObject_HEAD` (but you have to cast to the
+details after the :c:macro:`PyObject_HEAD` (but you have to cast to the
 correct type to access them --- or use accessor functions or macros).
 
 
@@ -25,12 +25,12 @@ By constructing a new Python type you make available a new object for
 Python. The ndarray object is an example of a new type defined in C.
 New types are defined in C by two basic steps:
 
-1. creating a C-structure (usually named :ctype:`Py{Name}Object`) that is
-   binary- compatible with the :ctype:`PyObject` structure itself but holds
+1. creating a C-structure (usually named :c:type:`Py{Name}Object`) that is
+   binary- compatible with the :c:type:`PyObject` structure itself but holds
    the additional information needed for that particular object;
 
-2. populating the :ctype:`PyTypeObject` table (pointed to by the ob_type
-   member of the :ctype:`PyObject` structure) with pointers to functions
+2. populating the :c:type:`PyTypeObject` table (pointed to by the ob_type
+   member of the :c:type:`PyObject` structure) with pointers to functions
    that implement the desired behavior for the type.
 
 Instead of special method names which define behavior for Python
@@ -40,16 +40,16 @@ itself has become dynamic which allows C types that can be "sub-typed
 "from other C-types in C, and sub-classed in Python. The children
 types inherit the attributes and methods from their parent(s).
 
-There are two major new types: the ndarray ( :cdata:`PyArray_Type` )
-and the ufunc ( :cdata:`PyUFunc_Type` ). Additional types play a
-supportive role: the :cdata:`PyArrayIter_Type`, the
-:cdata:`PyArrayMultiIter_Type`, and the :cdata:`PyArrayDescr_Type`
-. The :cdata:`PyArrayIter_Type` is the type for a flat iterator for an
+There are two major new types: the ndarray ( :c:data:`PyArray_Type` )
+and the ufunc ( :c:data:`PyUFunc_Type` ). Additional types play a
+supportive role: the :c:data:`PyArrayIter_Type`, the
+:c:data:`PyArrayMultiIter_Type`, and the :c:data:`PyArrayDescr_Type`
+. The :c:data:`PyArrayIter_Type` is the type for a flat iterator for an
 ndarray (the object that is returned when getting the flat
-attribute). The :cdata:`PyArrayMultiIter_Type` is the type of the
+attribute). The :c:data:`PyArrayMultiIter_Type` is the type of the
 object returned when calling ``broadcast`` (). It handles iteration
 and broadcasting over a collection of nested sequences. Also, the
-:cdata:`PyArrayDescr_Type` is the data-type-descriptor type whose
+:c:data:`PyArrayDescr_Type` is the data-type-descriptor type whose
 instances describe the data.  Finally, there are 21 new scalar-array
 types which are new Python scalars corresponding to each of the
 fundamental data types available for arrays. An additional 10 other
@@ -60,22 +60,22 @@ hierarchy of actual Python types.
 PyArray_Type
 ------------
 
-.. cvar:: PyArray_Type
+.. c:var: PyArray_Type
 
-   The Python type of the ndarray is :cdata:`PyArray_Type`. In C, every
-   ndarray is a pointer to a :ctype:`PyArrayObject` structure. The ob_type
-   member of this structure contains a pointer to the :cdata:`PyArray_Type`
+   The Python type of the ndarray is :c:data:`PyArray_Type`. In C, every
+   ndarray is a pointer to a :c:type:`PyArrayObject` structure. The ob_type
+   member of this structure contains a pointer to the :c:data:`PyArray_Type`
    typeobject.
 
-.. ctype:: PyArrayObject
+.. c:type:: PyArrayObject
 
-   The :ctype:`PyArrayObject` C-structure contains all of the required
+   The :c:type:`PyArrayObject` C-structure contains all of the required
    information for an array. All instances of an ndarray (and its
    subclasses) will have this structure.  For future compatibility,
    these structure members should normally be accessed using the
    provided macros. If you need a shorter name, then you can make use
-   of :ctype:`NPY_AO` which is defined to be equivalent to
-   :ctype:`PyArrayObject`.
+   of :c:type:`NPY_AO` which is defined to be equivalent to
+   :c:type:`PyArrayObject`.
 
    .. code-block:: c
 
@@ -91,7 +91,7 @@ PyArray_Type
           PyObject *weakreflist;
       } PyArrayObject;
 
-.. cmacro:: PyArrayObject.PyObject_HEAD
+.. c:macro: PyArrayObject.PyObject_HEAD
 
     This is needed by all Python objects. It consists of (at least)
     a reference count member ( ``ob_refcnt`` ) and a pointer to the
@@ -101,44 +101,44 @@ PyArray_Type
     information). The ob_type member points to a Python type
     object.
 
-.. cmember:: char *PyArrayObject.data
+.. c:member:: char *PyArrayObject.data
 
     A pointer to the first element of the array. This pointer can
     (and normally should) be recast to the data type of the array.
 
-.. cmember:: int PyArrayObject.nd
+.. c:member:: int PyArrayObject.nd
 
     An integer providing the number of dimensions for this
     array. When nd is 0, the array is sometimes called a rank-0
     array. Such arrays have undefined dimensions and strides and
-    cannot be accessed. :cdata:`NPY_MAXDIMS` is the largest number of
+    cannot be accessed. :c:data:`NPY_MAXDIMS` is the largest number of
     dimensions for any array.
 
-.. cmember:: npy_intp PyArrayObject.dimensions
+.. c:member:: npy_intp PyArrayObject.dimensions
 
     An array of integers providing the shape in each dimension as
     long as nd :math:`\geq` 1. The integer is always large enough
     to hold a pointer on the platform, so the dimension size is
     only limited by memory.
 
-.. cmember:: npy_intp *PyArrayObject.strides
+.. c:member:: npy_intp *PyArrayObject.strides
 
     An array of integers providing for each dimension the number of
     bytes that must be skipped to get to the next element in that
     dimension.
 
-.. cmember:: PyObject *PyArrayObject.base
+.. c:member:: PyObject *PyArrayObject.base
 
     This member is used to hold a pointer to another Python object that
     is related to this array. There are two use cases: 1) If this array
     does not own its own memory, then base points to the Python object
     that owns it (perhaps another array object), 2) If this array has
-    the :cdata:`NPY_ARRAY_UPDATEIFCOPY` flag set, then this array is
+    the :c:data:`NPY_ARRAY_UPDATEIFCOPY` flag set, then this array is
     a working copy of a "misbehaved" array. As soon as this array is
     deleted, the array pointed to by base will be updated with the
     contents of this array.
 
-.. cmember:: PyArray_Descr *PyArrayObject.descr
+.. c:member:: PyArray_Descr *PyArrayObject.descr
 
     A pointer to a data-type descriptor object (see below). The
     data-type descriptor object is an instance of a new built-in
@@ -148,15 +148,15 @@ PyArray_Type
     as well as a pointer to a table of function pointers to
     implement specific functionality.
 
-.. cmember:: int PyArrayObject.flags
+.. c:member:: int PyArrayObject.flags
 
     Flags indicating how the memory pointed to by data is to be
-    interpreted. Possible flags are :cdata:`NPY_ARRAY_C_CONTIGUOUS`,
-    :cdata:`NPY_ARRAY_F_CONTIGUOUS`, :cdata:`NPY_ARRAY_OWNDATA`,
-    :cdata:`NPY_ARRAY_ALIGNED`, :cdata:`NPY_ARRAY_WRITEABLE`, and
-    :cdata:`NPY_ARRAY_UPDATEIFCOPY`.
+    interpreted. Possible flags are :c:data:`NPY_ARRAY_C_CONTIGUOUS`,
+    :c:data:`NPY_ARRAY_F_CONTIGUOUS`, :c:data:`NPY_ARRAY_OWNDATA`,
+    :c:data:`NPY_ARRAY_ALIGNED`, :c:data:`NPY_ARRAY_WRITEABLE`, and
+    :c:data:`NPY_ARRAY_UPDATEIFCOPY`.
 
-.. cmember:: PyObject *PyArrayObject.weakreflist
+.. c:member:: PyObject *PyArrayObject.weakreflist
 
     This member allows array objects to have weak references (using the
     weakref module).
@@ -165,24 +165,24 @@ PyArray_Type
 PyArrayDescr_Type
 -----------------
 
-.. cvar:: PyArrayDescr_Type
+.. c:var: PyArrayDescr_Type
 
-   The :cdata:`PyArrayDescr_Type` is the built-in type of the
+   The :c:data:`PyArrayDescr_Type` is the built-in type of the
    data-type-descriptor objects used to describe how the bytes comprising
    the array are to be interpreted.  There are 21 statically-defined
-   :ctype:`PyArray_Descr` objects for the built-in data-types. While these
+   :c:type:`PyArray_Descr` objects for the built-in data-types. While these
    participate in reference counting, their reference count should never
    reach zero.  There is also a dynamic table of user-defined
-   :ctype:`PyArray_Descr` objects that is also maintained. Once a
+   :c:type:`PyArray_Descr` objects that is also maintained. Once a
    data-type-descriptor object is "registered" it should never be
-   deallocated either. The function :cfunc:`PyArray_DescrFromType` (...) can
-   be used to retrieve a :ctype:`PyArray_Descr` object from an enumerated
+   deallocated either. The function :c:func:`PyArray_DescrFromType` (...) can
+   be used to retrieve a :c:type:`PyArray_Descr` object from an enumerated
    type-number (either built-in or user- defined).
 
-.. ctype:: PyArray_Descr
+.. c:type:: PyArray_Descr
 
-   The format of the :ctype:`PyArray_Descr` structure that lies at the
-   heart of the :cdata:`PyArrayDescr_Type` is
+   The format of the :c:type:`PyArray_Descr` structure that lies at the
+   heart of the :c:data:`PyArrayDescr_Type` is
 
    .. code-block:: c
 
@@ -202,17 +202,17 @@ PyArrayDescr_Type
           PyArray_ArrFuncs *f;
       } PyArray_Descr;
 
-.. cmember:: PyTypeObject *PyArray_Descr.typeobj
+.. c:member:: PyTypeObject *PyArray_Descr.typeobj
 
     Pointer to a typeobject that is the corresponding Python type for
     the elements of this array. For the builtin types, this points to
     the corresponding array scalar. For user-defined types, this
     should point to a user-defined typeobject. This typeobject can
     either inherit from array scalars or not. If it does not inherit
-    from array scalars, then the :cdata:`NPY_USE_GETITEM` and
-    :cdata:`NPY_USE_SETITEM` flags should be set in the ``flags`` member.
+    from array scalars, then the :c:data:`NPY_USE_GETITEM` and
+    :c:data:`NPY_USE_SETITEM` flags should be set in the ``flags`` member.
 
-.. cmember:: char PyArray_Descr.kind
+.. c:member:: char PyArray_Descr.kind
 
     A character code indicating the kind of array (using the array
     interface typestring notation). A 'b' represents Boolean, a 'i'
@@ -221,100 +221,100 @@ PyArrayDescr_Type
     represents 8-bit character string, 'U' represents 32-bit/character
     unicode string, and 'V' repesents arbitrary.
 
-.. cmember:: char PyArray_Descr.type
+.. c:member:: char PyArray_Descr.type
 
     A traditional character code indicating the data type.
 
-.. cmember:: char PyArray_Descr.byteorder
+.. c:member:: char PyArray_Descr.byteorder
 
     A character indicating the byte-order: '>' (big-endian), '<' (little-
     endian), '=' (native), '\|' (irrelevant, ignore). All builtin data-
     types have byteorder '='.
 
-.. cmember:: int PyArray_Descr.flags
+.. c:member:: int PyArray_Descr.flags
 
     A data-type bit-flag that determines if the data-type exhibits object-
     array like behavior. Each bit in this member is a flag which are named
     as:
 
-    .. cvar:: NPY_ITEM_REFCOUNT
+    .. c:var: NPY_ITEM_REFCOUNT
 
-    .. cvar:: NPY_ITEM_HASOBJECT
+    .. c:var: NPY_ITEM_HASOBJECT
 
         Indicates that items of this data-type must be reference
-        counted (using :cfunc:`Py_INCREF` and :cfunc:`Py_DECREF` ).
+        counted (using :c:func:`Py_INCREF` and :c:func:`Py_DECREF` ).
 
-    .. cvar:: NPY_LIST_PICKLE
+    .. c:var: NPY_LIST_PICKLE
 
         Indicates arrays of this data-type must be converted to a list
         before pickling.
 
-    .. cvar:: NPY_ITEM_IS_POINTER
+    .. c:var: NPY_ITEM_IS_POINTER
 
         Indicates the item is a pointer to some other data-type
 
-    .. cvar:: NPY_NEEDS_INIT
+    .. c:var: NPY_NEEDS_INIT
 
         Indicates memory for this data-type must be initialized (set
         to 0) on creation.
 
-    .. cvar:: NPY_NEEDS_PYAPI
+    .. c:var: NPY_NEEDS_PYAPI
 
         Indicates this data-type requires the Python C-API during
         access (so don't give up the GIL if array access is going to
         be needed).
 
-    .. cvar:: NPY_USE_GETITEM
+    .. c:var: NPY_USE_GETITEM
 
         On array access use the ``f->getitem`` function pointer
         instead of the standard conversion to an array scalar. Must
         use if you don't define an array scalar to go along with
         the data-type.
 
-    .. cvar:: NPY_USE_SETITEM
+    .. c:var: NPY_USE_SETITEM
 
         When creating a 0-d array from an array scalar use
         ``f->setitem`` instead of the standard copy from an array
         scalar. Must use if you don't define an array scalar to go
         along with the data-type.
 
-    .. cvar:: NPY_FROM_FIELDS
+    .. c:var: NPY_FROM_FIELDS
 
         The bits that are inherited for the parent data-type if these
         bits are set in any field of the data-type. Currently (
-        :cdata:`NPY_NEEDS_INIT` \| :cdata:`NPY_LIST_PICKLE` \|
-        :cdata:`NPY_ITEM_REFCOUNT` \| :cdata:`NPY_NEEDS_PYAPI` ).
+        :c:data:`NPY_NEEDS_INIT` \| :c:data:`NPY_LIST_PICKLE` \|
+        :c:data:`NPY_ITEM_REFCOUNT` \| :c:data:`NPY_NEEDS_PYAPI` ).
 
-    .. cvar:: NPY_OBJECT_DTYPE_FLAGS
+    .. c:var: NPY_OBJECT_DTYPE_FLAGS
 
-        Bits set for the object data-type: ( :cdata:`NPY_LIST_PICKLE`
-        \| :cdata:`NPY_USE_GETITEM` \| :cdata:`NPY_ITEM_IS_POINTER` \|
-        :cdata:`NPY_REFCOUNT` \| :cdata:`NPY_NEEDS_INIT` \|
-        :cdata:`NPY_NEEDS_PYAPI`).
+        Bits set for the object data-type: ( :c:data:`NPY_LIST_PICKLE`
+        \| :c:data:`NPY_USE_GETITEM` \| :c:data:`NPY_ITEM_IS_POINTER` \|
+        :c:data:`NPY_REFCOUNT` \| :c:data:`NPY_NEEDS_INIT` \|
+        :c:data:`NPY_NEEDS_PYAPI`).
 
-    .. cfunction:: PyDataType_FLAGCHK(PyArray_Descr *dtype, int flags)
+    .. c:function:: PyDataType_FLAGCHK(PyArray_Descr *dtype, int flags)
 
         Return true if all the given flags are set for the data-type
         object.
 
-    .. cfunction:: PyDataType_REFCHK(PyArray_Descr *dtype)
+    .. c:function:: PyDataType_REFCHK(PyArray_Descr *dtype)
 
-        Equivalent to :cfunc:`PyDataType_FLAGCHK` (*dtype*,
- 	:cdata:`NPY_ITEM_REFCOUNT`).
+        Equivalent to :c:func:`PyDataType_FLAGCHK` (*dtype*,
+ 	:c:data:`NPY_ITEM_REFCOUNT`).
 
-.. cmember:: int PyArray_Descr.type_num
+.. c:member:: int PyArray_Descr.type_num
 
     A number that uniquely identifies the data type. For new data-types,
     this number is assigned when the data-type is registered.
 
-.. cmember:: int PyArray_Descr.elsize
+.. c:member:: int PyArray_Descr.elsize
 
     For data types that are always the same size (such as long), this
     holds the size of the data type. For flexible data types where
     different arrays can have a different elementsize, this should be
     0.
 
-.. cmember:: int PyArray_Descr.alignment
+.. c:member:: int PyArray_Descr.alignment
 
     A number providing alignment information for this data type.
     Specifically, it shows how far from the start of a 2-element
@@ -322,7 +322,7 @@ PyArrayDescr_Type
     places an item of this type: ``offsetof(struct {char c; type v;},
     v)``
 
-.. cmember:: PyArray_ArrayDescr *PyArray_Descr.subarray
+.. c:member:: PyArray_ArrayDescr *PyArray_Descr.subarray
 
     If this is non- ``NULL``, then this data-type descriptor is a
     C-style contiguous array of another data-type descriptor. In
@@ -331,7 +331,7 @@ PyArrayDescr_Type
     useful as the data-type descriptor for a field in another
     data-type descriptor. The fields member should be ``NULL`` if this
     is non- ``NULL`` (the fields member of the base descriptor can be
-    non- ``NULL`` however). The :ctype:`PyArray_ArrayDescr` structure is
+    non- ``NULL`` however). The :c:type:`PyArray_ArrayDescr` structure is
     defined using
 
     .. code-block:: c
@@ -343,17 +343,17 @@ PyArrayDescr_Type
 
     The elements of this structure are:
 
-    .. cmember:: PyArray_Descr *PyArray_ArrayDescr.base
+    .. c:member:: PyArray_Descr *PyArray_ArrayDescr.base
 
         The data-type-descriptor object of the base-type.
 
-    .. cmember:: PyObject *PyArray_ArrayDescr.shape
+    .. c:member:: PyObject *PyArray_ArrayDescr.shape
 
         The shape (always C-style contiguous) of the sub-array as a Python
         tuple.
 
 
-.. cmember:: PyObject *PyArray_Descr.fields
+.. c:member:: PyObject *PyArray_Descr.fields
 
     If this is non-NULL, then this data-type-descriptor has fields
     described by a Python dictionary whose keys are names (and also
@@ -366,14 +366,14 @@ PyArrayDescr_Type
     normally a Python string. These tuples are placed in this
     dictionary keyed by name (and also title if given).
 
-.. cmember:: PyArray_ArrFuncs *PyArray_Descr.f
+.. c:member:: PyArray_ArrFuncs *PyArray_Descr.f
 
     A pointer to a structure containing functions that the type needs
     to implement internal features. These functions are not the same
     thing as the universal functions (ufuncs) described later. Their
     signatures can vary arbitrarily.
 
-.. ctype:: PyArray_ArrFuncs
+.. c:type:: PyArray_ArrFuncs
 
     Functions implementing internal features. Not all of these
     function pointers must be defined for a given type. The required
@@ -420,7 +420,7 @@ PyArrayDescr_Type
     functions can (and must) deal with mis-behaved arrays. The other
     functions require behaved memory segments.
 
-    .. cmember:: void cast(void *from, void *to, npy_intp n, void *fromarr, void *toarr)
+    .. c:member:: void cast(void *from, void *to, npy_intp n, void *fromarr, void *toarr)
 
         An array of function pointers to cast from the current type to
         all of the other builtin types. Each function casts a
@@ -431,14 +431,14 @@ PyArrayDescr_Type
         PyArrayObjects for flexible arrays to get itemsize
         information.
 
-    .. cmember:: PyObject *getitem(void *data, void *arr)
+    .. c:member:: PyObject *getitem(void *data, void *arr)
 
         A pointer to a function that returns a standard Python object
         from a single element of the array object *arr* pointed to by
         *data*. This function must be able to deal with "misbehaved
         "(misaligned and/or swapped) arrays correctly.
 
-    .. cmember:: int setitem(PyObject *item, void *data, void *arr)
+    .. c:member:: int setitem(PyObject *item, void *data, void *arr)
 
         A pointer to a function that sets the Python object *item*
         into the array, *arr*, at the position pointed to by *data*
@@ -446,14 +446,14 @@ PyArrayDescr_Type
         a zero is returned, otherwise, a negative one is returned (and
         a Python error set).
 
-    .. cmember:: void copyswapn(void *dest, npy_intp dstride, void *src, npy_intp sstride, npy_intp n, int swap, void *arr)
+    .. c:member:: void copyswapn(void *dest, npy_intp dstride, void *src, npy_intp sstride, npy_intp n, int swap, void *arr)
 
-    .. cmember:: void copyswap(void *dest, void *src, int swap, void *arr)
+    .. c:member:: void copyswap(void *dest, void *src, int swap, void *arr)
 
         These members are both pointers to functions to copy data from
         *src* to *dest* and *swap* if indicated. The value of arr is
-        only used for flexible ( :cdata:`NPY_STRING`, :cdata:`NPY_UNICODE`,
-        and :cdata:`NPY_VOID` ) arrays (and is obtained from
+        only used for flexible ( :c:data:`NPY_STRING`, :c:data:`NPY_UNICODE`,
+        and :c:data:`NPY_VOID` ) arrays (and is obtained from
         ``arr->descr->elsize`` ). The second function copies a single
         value, while the first loops over n values with the provided
         strides. These functions can deal with misbehaved *src*
@@ -463,7 +463,7 @@ PyArrayDescr_Type
         (...) first followed by ``copyswap(n)`` with NULL valued
         ``src``.
 
-    .. cmember:: int compare(const void* d1, const void* d2, void* arr)
+    .. c:member:: int compare(const void* d1, const void* d2, void* arr)
 
         A pointer to a function that compares two elements of the
         array, ``arr``, pointed to by ``d1`` and ``d2``. This
@@ -472,7 +472,7 @@ PyArrayDescr_Type
         ``d2``, and -1 if * ``d1`` < * ``d2``. The array object ``arr`` is
         used to retrieve itemsize and field information for flexible arrays.
 
-    .. cmember:: int argmax(void* data, npy_intp n, npy_intp* max_ind, void* arr)
+    .. c:member:: int argmax(void* data, npy_intp n, npy_intp* max_ind, void* arr)
 
         A pointer to a function that retrieves the index of the
         largest of ``n`` elements in ``arr`` beginning at the element
@@ -481,7 +481,7 @@ PyArrayDescr_Type
         always 0. The index of the largest element is returned in
         ``max_ind``.
 
-    .. cmember:: void dotfunc(void* ip1, npy_intp is1, void* ip2, npy_intp is2, void* op, npy_intp n, void* arr)
+    .. c:member:: void dotfunc(void* ip1, npy_intp is1, void* ip2, npy_intp is2, void* op, npy_intp n, void* arr)
 
         A pointer to a function that multiplies two ``n`` -length
         sequences together, adds them, and places the result in
@@ -491,7 +491,7 @@ PyArrayDescr_Type
         and ``is2`` *bytes*, respectively. This function requires
         behaved (though not necessarily contiguous) memory.
 
-    .. cmember:: int scanfunc(FILE* fd, void* ip , void* sep , void* arr)
+    .. c:member:: int scanfunc(FILE* fd, void* ip , void* sep , void* arr)
 
         A pointer to a function that scans (scanf style) one element
         of the corresponding type from the file descriptor ``fd`` into
@@ -506,7 +506,7 @@ PyArrayDescr_Type
         scanned, and -3 means that the element could not be
         interpreted from the format string. Requires a behaved array.
 
-    .. cmember:: int fromstr(char* str, void* ip, char** endptr, void* arr)
+    .. c:member:: int fromstr(char* str, void* ip, char** endptr, void* arr)
 
         A pointer to a function that converts the string pointed to by
         ``str`` to one element of the corresponding type and places it
@@ -516,13 +516,13 @@ PyArrayDescr_Type
         points (needed for variable-size data- types). Returns 0 on
         success or -1 on failure. Requires a behaved array.
 
-    .. cmember:: Bool nonzero(void* data, void* arr)
+    .. c:member:: Bool nonzero(void* data, void* arr)
 
         A pointer to a function that returns TRUE if the item of
         ``arr`` pointed to by ``data`` is nonzero. This function can
         deal with misbehaved arrays.
 
-    .. cmember:: void fill(void* data, npy_intp length, void* arr)
+    .. c:member:: void fill(void* data, npy_intp length, void* arr)
 
         A pointer to a function that fills a contiguous array of given
         length with data. The first two elements of the array must
@@ -531,22 +531,22 @@ PyArrayDescr_Type
         computed by repeatedly adding this computed delta. The data
         buffer must be well-behaved.
 
-    .. cmember:: void fillwithscalar(void* buffer, npy_intp length, void* value, void* arr)
+    .. c:member:: void fillwithscalar(void* buffer, npy_intp length, void* value, void* arr)
 
         A pointer to a function that fills a contiguous ``buffer`` of
         the given ``length`` with a single scalar ``value`` whose
         address is given. The final argument is the array which is
         needed to get the itemsize for variable-length arrays.
 
-    .. cmember:: int sort(void* start, npy_intp length, void* arr)
+    .. c:member:: int sort(void* start, npy_intp length, void* arr)
 
         An array of function pointers to a particular sorting
         algorithms. A particular sorting algorithm is obtained using a
-        key (so far :cdata:`NPY_QUICKSORT`, :data`NPY_HEAPSORT`, and
-        :cdata:`NPY_MERGESORT` are defined). These sorts are done
+        key (so far :c:data:`NPY_QUICKSORT`, :data`NPY_HEAPSORT`, and
+        :c:data:`NPY_MERGESORT` are defined). These sorts are done
         in-place assuming contiguous and aligned data.
 
-    .. cmember:: int argsort(void* start, npy_intp* result, npy_intp length, void *arr)
+    .. c:member:: int argsort(void* start, npy_intp* result, npy_intp length, void *arr)
 
         An array of function pointers to sorting algorithms for this
         data type. The same sorting algorithms as for sort are
@@ -554,37 +554,37 @@ PyArrayDescr_Type
         ``result`` (which must be initialized with indices 0 to
         ``length-1`` inclusive).
 
-    .. cmember:: PyObject *castdict
+    .. c:member:: PyObject *castdict
 
         Either ``NULL`` or a dictionary containing low-level casting
         functions for user- defined data-types. Each function is
-        wrapped in a :ctype:`PyCObject *` and keyed by the data-type number.
+        wrapped in a :c:type:`PyCObject *` and keyed by the data-type number.
 
-    .. cmember:: NPY_SCALARKIND scalarkind(PyArrayObject* arr)
+    .. c:member:: NPY_SCALARKIND scalarkind(PyArrayObject* arr)
 
         A function to determine how scalars of this type should be
         interpreted. The argument is ``NULL`` or a 0-dimensional array
         containing the data (if that is needed to determine the kind
         of scalar). The return value must be of type
-        :ctype:`NPY_SCALARKIND`.
+        :c:type:`NPY_SCALARKIND`.
 
-    .. cmember:: int **cancastscalarkindto
+    .. c:member:: int **cancastscalarkindto
 
-        Either ``NULL`` or an array of :ctype:`NPY_NSCALARKINDS`
+        Either ``NULL`` or an array of :c:type:`NPY_NSCALARKINDS`
         pointers. These pointers should each be either ``NULL`` or a
         pointer to an array of integers (terminated by
-        :cdata:`NPY_NOTYPE`) indicating data-types that a scalar of
+        :c:data:`NPY_NOTYPE`) indicating data-types that a scalar of
         this data-type of the specified kind can be cast to safely
         (this usually means without losing precision).
 
-    .. cmember:: int *cancastto
+    .. c:member:: int *cancastto
 
         Either ``NULL`` or an array of integers (terminated by
-        :cdata:`NPY_NOTYPE` ) indicated data-types that this data-type
+        :c:data:`NPY_NOTYPE` ) indicated data-types that this data-type
         can be cast to safely (this usually means without losing
         precision).
 
-    .. cmember:: void fastclip(void *in, npy_intp n_in, void *min, void *max, void *out)
+    .. c:member:: void fastclip(void *in, npy_intp n_in, void *min, void *max, void *out)
 
         A function that reads ``n_in`` items from ``in``, and writes to
         ``out`` the read value if it is within the limits pointed to by
@@ -592,7 +592,7 @@ PyArrayDescr_Type
         memory segments must be contiguous and behaved, and either
         ``min`` or ``max`` may be ``NULL``, but not both.
 
-    .. cmember:: void fastputmask(void *in, void *mask, npy_intp n_in, void *values, npy_intp nv)
+    .. c:member:: void fastputmask(void *in, void *mask, npy_intp n_in, void *values, npy_intp nv)
 
         A function that takes a pointer ``in`` to an array of ``n_in``
         items, a pointer ``mask`` to an array of ``n_in`` boolean
@@ -601,7 +601,7 @@ PyArrayDescr_Type
         in ``mask`` is non-zero, tiling ``vals`` as needed if
         ``nv < n_in``. All arrays must be contiguous and behaved.
 
-    .. cmember:: void fasttake(void *dest, void *src, npy_intp *indarray, npy_intp nindarray, npy_intp n_outer, npy_intp m_middle, npy_intp nelem, NPY_CLIPMODE clipmode)
+    .. c:member:: void fasttake(void *dest, void *src, npy_intp *indarray, npy_intp nindarray, npy_intp n_outer, npy_intp m_middle, npy_intp nelem, NPY_CLIPMODE clipmode)
 
         A function that takes a pointer ``src`` to a C contiguous,
         behaved segment, interpreted as a 3-dimensional array of shape
@@ -612,12 +612,12 @@ PyArrayDescr_Type
         ``(n_outer, m_middle, nelem)``. The indices in ``indarray`` are
         used to index ``src`` along the second dimension, and copy the
         corresponding chunks of ``nelem`` items into ``dest``.
-        ``clipmode`` (which can take on the values :cdata:`NPY_RAISE`,
-        :cdata:`NPY_WRAP` or :cdata:`NPY_CLIP`) determines how will
+        ``clipmode`` (which can take on the values :c:data:`NPY_RAISE`,
+        :c:data:`NPY_WRAP` or :c:data:`NPY_CLIP`) determines how will
         indices smaller than 0 or larger than ``nindarray`` will be
         handled.
 
-    .. cmember:: int argmin(void* data, npy_intp n, npy_intp* min_ind, void* arr)
+    .. c:member:: int argmin(void* data, npy_intp n, npy_intp* min_ind, void* arr)
 
         A pointer to a function that retrieves the index of the
         smallest of ``n`` elements in ``arr`` beginning at the element
@@ -627,12 +627,12 @@ PyArrayDescr_Type
         ``min_ind``.
 
 
-The :cdata:`PyArray_Type` typeobject implements many of the features of
+The :c:data:`PyArray_Type` typeobject implements many of the features of
 Python objects including the tp_as_number, tp_as_sequence,
 tp_as_mapping, and tp_as_buffer interfaces. The rich comparison
 (tp_richcompare) is also used along with new-style attribute lookup
 for methods (tp_methods) and properties (tp_getset). The
-:cdata:`PyArray_Type` can also be sub-typed.
+:c:data:`PyArray_Type` can also be sub-typed.
 
 .. tip::
 
@@ -648,10 +648,10 @@ for methods (tp_methods) and properties (tp_getset). The
 PyUFunc_Type
 ------------
 
-.. cvar:: PyUFunc_Type
+.. c:var: PyUFunc_Type
 
    The ufunc object is implemented by creation of the
-   :cdata:`PyUFunc_Type`. It is a very simple type that implements only
+   :c:data:`PyUFunc_Type`. It is a very simple type that implements only
    basic getattribute behavior, printing behavior, and has call
    behavior which allows these objects to act like functions. The
    basic idea behind the ufunc is to hold a reference to fast
@@ -664,9 +664,9 @@ PyUFunc_Type
    ufunc using a single scalar function (*e.g.* atanh).
 
 
-.. ctype:: PyUFuncObject
+.. c:type:: PyUFuncObject
 
-   The core of the ufunc is the :ctype:`PyUFuncObject` which contains all
+   The core of the ufunc is the :c:type:`PyUFuncObject` which contains all
    the information needed to call the underlying C-code loops that
    perform the actual work. It has the following structure:
 
@@ -692,30 +692,30 @@ PyUFunc_Type
           npy_uint32 *iter_flags;
       } PyUFuncObject;
 
-   .. cmacro:: PyUFuncObject.PyObject_HEAD
+   .. c:macro: PyUFuncObject.PyObject_HEAD
 
        required for all Python objects.
 
-   .. cmember:: int PyUFuncObject.nin
+   .. c:member:: int PyUFuncObject.nin
 
        The number of input arguments.
 
-   .. cmember:: int PyUFuncObject.nout
+   .. c:member:: int PyUFuncObject.nout
 
        The number of output arguments.
 
-   .. cmember:: int PyUFuncObject.nargs
+   .. c:member:: int PyUFuncObject.nargs
 
        The total number of arguments (*nin* + *nout*). This must be
-       less than :cdata:`NPY_MAXARGS`.
+       less than :c:data:`NPY_MAXARGS`.
 
-   .. cmember:: int PyUFuncObject.identity
+   .. c:member:: int PyUFuncObject.identity
 
-       Either :cdata:`PyUFunc_One`, :cdata:`PyUFunc_Zero`, or
-       :cdata:`PyUFunc_None` to indicate the identity for this operation.
+       Either :c:data:`PyUFunc_One`, :c:data:`PyUFunc_Zero`, or
+       :c:data:`PyUFunc_None` to indicate the identity for this operation.
        It is only used for a reduce-like call on an empty array.
 
-   .. cmember:: void PyUFuncObject.functions(char** args, npy_intp* dims,
+   .. c:member:: void PyUFuncObject.functions(char** args, npy_intp* dims,
       npy_intp* steps, void* extradata)
 
        An array of function pointers --- one for each data type
@@ -733,7 +733,7 @@ PyUFunc_Type
        passed in as *extradata*. The size of this function pointer
        array is ntypes.
 
-   .. cmember:: void **PyUFuncObject.data
+   .. c:member:: void **PyUFuncObject.data
 
        Extra data to be passed to the 1-d vector loops or ``NULL`` if
        no extra-data is needed. This C-array must be the same size (
@@ -742,23 +742,23 @@ PyUFunc_Type
        just 1-d vector loops that make use of this extra data to
        receive a pointer to the actual function to call.
 
-   .. cmember:: int PyUFuncObject.ntypes
+   .. c:member:: int PyUFuncObject.ntypes
 
        The number of supported data types for the ufunc. This number
        specifies how many different 1-d loops (of the builtin data types) are
        available.
 
-   .. cmember:: int PyUFuncObject.check_return
+   .. c:member:: int PyUFuncObject.check_return
 
        Obsolete and unused. However, it is set by the corresponding entry in
-       the main ufunc creation routine: :cfunc:`PyUFunc_FromFuncAndData` (...).
+       the main ufunc creation routine: :c:func:`PyUFunc_FromFuncAndData` (...).
 
-   .. cmember:: char *PyUFuncObject.name
+   .. c:member:: char *PyUFuncObject.name
 
        A string name for the ufunc. This is used dynamically to build
        the __doc\__ attribute of ufuncs.
 
-   .. cmember:: char *PyUFuncObject.types
+   .. c:member:: char *PyUFuncObject.types
 
        An array of *nargs* :math:`\times` *ntypes* 8-bit type_numbers
        which contains the type signature for the function for each of
@@ -768,43 +768,43 @@ PyUFunc_Type
        vector loop. These type numbers do not have to be the same type
        and mixed-type ufuncs are supported.
 
-   .. cmember:: char *PyUFuncObject.doc
+   .. c:member:: char *PyUFuncObject.doc
 
        Documentation for the ufunc. Should not contain the function
        signature as this is generated dynamically when __doc\__ is
        retrieved.
 
-   .. cmember:: void *PyUFuncObject.ptr
+   .. c:member:: void *PyUFuncObject.ptr
 
        Any dynamically allocated memory. Currently, this is used for dynamic
        ufuncs created from a python function to store room for the types,
        data, and name members.
 
-   .. cmember:: PyObject *PyUFuncObject.obj
+   .. c:member:: PyObject *PyUFuncObject.obj
 
        For ufuncs dynamically created from python functions, this member
        holds a reference to the underlying Python function.
 
-   .. cmember:: PyObject *PyUFuncObject.userloops
+   .. c:member:: PyObject *PyUFuncObject.userloops
 
        A dictionary of user-defined 1-d vector loops (stored as CObject ptrs)
        for user-defined types. A loop may be registered by the user for any
        user-defined type. It is retrieved by type number. User defined type
-       numbers are always larger than :cdata:`NPY_USERDEF`.
+       numbers are always larger than :c:data:`NPY_USERDEF`.
 
 
-   .. cmember:: npy_uint32 PyUFuncObject.op_flags
+   .. c:member:: npy_uint32 PyUFuncObject.op_flags
 
        Override the default operand flags for each ufunc operand.
 
-   .. cmember:: npy_uint32 PyUFuncObject.iter_flags
+   .. c:member:: npy_uint32 PyUFuncObject.iter_flags
 
        Override the default nditer flags for the ufunc.
 
 PyArrayIter_Type
 ----------------
 
-.. cvar:: PyArrayIter_Type
+.. c:var: PyArrayIter_Type
 
    This is an iterator object that makes it easy to loop over an N-dimensional
    array. It is the object returned from the flat attribute of an
@@ -815,17 +815,17 @@ PyArrayIter_Type
    tp_methods table. This object implements the next method and can be
    used anywhere an iterator can be used in Python.
 
-.. ctype:: PyArrayIterObject
+.. c:type:: PyArrayIterObject
 
-   The C-structure corresponding to an object of :cdata:`PyArrayIter_Type` is
-   the :ctype:`PyArrayIterObject`. The :ctype:`PyArrayIterObject` is used to
+   The C-structure corresponding to an object of :c:data:`PyArrayIter_Type` is
+   the :c:type:`PyArrayIterObject`. The :c:type:`PyArrayIterObject` is used to
    keep track of a pointer into an N-dimensional array. It contains associated
    information used to quickly march through the array. The pointer can
    be adjusted in three basic ways: 1) advance to the "next" position in
    the array in a C-style contiguous fashion, 2) advance to an arbitrary
    N-dimensional coordinate in the array, and 3) advance to an arbitrary
    one-dimensional index into the array. The members of the
-   :ctype:`PyArrayIterObject` structure are used in these
+   :c:type:`PyArrayIterObject` structure are used in these
    calculations. Iterator objects keep their own dimension and strides
    information about an array. This can be adjusted as needed for
    "broadcasting," or to loop over only specific dimensions.
@@ -847,87 +847,87 @@ PyArrayIter_Type
           Bool  contiguous;
       } PyArrayIterObject;
 
-   .. cmember:: int PyArrayIterObject.nd_m1
+   .. c:member:: int PyArrayIterObject.nd_m1
 
        :math:`N-1` where :math:`N` is the number of dimensions in the
        underlying array.
 
-   .. cmember:: npy_intp PyArrayIterObject.index
+   .. c:member:: npy_intp PyArrayIterObject.index
 
        The current 1-d index into the array.
 
-   .. cmember:: npy_intp PyArrayIterObject.size
+   .. c:member:: npy_intp PyArrayIterObject.size
 
        The total size of the underlying array.
 
-   .. cmember:: npy_intp *PyArrayIterObject.coordinates
+   .. c:member:: npy_intp *PyArrayIterObject.coordinates
 
        An :math:`N` -dimensional index into the array.
 
-   .. cmember:: npy_intp *PyArrayIterObject.dims_m1
+   .. c:member:: npy_intp *PyArrayIterObject.dims_m1
 
        The size of the array minus 1 in each dimension.
 
-   .. cmember:: npy_intp *PyArrayIterObject.strides
+   .. c:member:: npy_intp *PyArrayIterObject.strides
 
        The strides of the array. How many bytes needed to jump to the next
        element in each dimension.
 
-   .. cmember:: npy_intp *PyArrayIterObject.backstrides
+   .. c:member:: npy_intp *PyArrayIterObject.backstrides
 
        How many bytes needed to jump from the end of a dimension back
        to its beginning. Note that *backstrides* [k]= *strides* [k]*d
        *ims_m1* [k], but it is stored here as an optimization.
 
-   .. cmember:: npy_intp *PyArrayIterObject.factors
+   .. c:member:: npy_intp *PyArrayIterObject.factors
 
        This array is used in computing an N-d index from a 1-d index. It
        contains needed products of the dimensions.
 
-   .. cmember:: PyArrayObject *PyArrayIterObject.ao
+   .. c:member:: PyArrayObject *PyArrayIterObject.ao
 
        A pointer to the underlying ndarray this iterator was created to
        represent.
 
-   .. cmember:: char *PyArrayIterObject.dataptr
+   .. c:member:: char *PyArrayIterObject.dataptr
 
        This member points to an element in the ndarray indicated by the
        index.
 
-   .. cmember:: Bool PyArrayIterObject.contiguous
+   .. c:member:: Bool PyArrayIterObject.contiguous
 
        This flag is true if the underlying array is
-       :cdata:`NPY_ARRAY_C_CONTIGUOUS`. It is used to simplify
+       :c:data:`NPY_ARRAY_C_CONTIGUOUS`. It is used to simplify
        calculations when possible.
 
 
 How to use an array iterator on a C-level is explained more fully in
 later sections. Typically, you do not need to concern yourself with
 the internal structure of the iterator object, and merely interact
-with it through the use of the macros :cfunc:`PyArray_ITER_NEXT` (it),
-:cfunc:`PyArray_ITER_GOTO` (it, dest), or :cfunc:`PyArray_ITER_GOTO1D` (it,
+with it through the use of the macros :c:func:`PyArray_ITER_NEXT` (it),
+:c:func:`PyArray_ITER_GOTO` (it, dest), or :c:func:`PyArray_ITER_GOTO1D` (it,
 index). All of these macros require the argument *it* to be a
-:ctype:`PyArrayIterObject *`.
+:c:type:`PyArrayIterObject *`.
 
 
 PyArrayMultiIter_Type
 ---------------------
 
-.. cvar:: PyArrayMultiIter_Type
+.. c:var: PyArrayMultiIter_Type
 
    This type provides an iterator that encapsulates the concept of
    broadcasting. It allows :math:`N` arrays to be broadcast together
    so that the loop progresses in C-style contiguous fashion over the
    broadcasted array. The corresponding C-structure is the
-   :ctype:`PyArrayMultiIterObject` whose memory layout must begin any
-   object, *obj*, passed in to the :cfunc:`PyArray_Broadcast` (obj)
+   :c:type:`PyArrayMultiIterObject` whose memory layout must begin any
+   object, *obj*, passed in to the :c:func:`PyArray_Broadcast` (obj)
    function. Broadcasting is performed by adjusting array iterators so
    that each iterator represents the broadcasted shape and size, but
    has its strides adjusted so that the correct element from the array
    is used at each iteration.
 
 
-.. ctype:: PyArrayMultiIterObject
+.. c:type:: PyArrayMultiIterObject
 
    .. code-block:: c
 
@@ -941,32 +941,32 @@ PyArrayMultiIter_Type
           PyArrayIterObject *iters[NPY_MAXDIMS];
       } PyArrayMultiIterObject;
 
-   .. cmacro:: PyArrayMultiIterObject.PyObject_HEAD
+   .. c:macro: PyArrayMultiIterObject.PyObject_HEAD
 
        Needed at the start of every Python object (holds reference count and
        type identification).
 
-   .. cmember:: int PyArrayMultiIterObject.numiter
+   .. c:member:: int PyArrayMultiIterObject.numiter
 
        The number of arrays that need to be broadcast to the same shape.
 
-   .. cmember:: npy_intp PyArrayMultiIterObject.size
+   .. c:member:: npy_intp PyArrayMultiIterObject.size
 
        The total broadcasted size.
 
-   .. cmember:: npy_intp PyArrayMultiIterObject.index
+   .. c:member:: npy_intp PyArrayMultiIterObject.index
 
        The current (1-d) index into the broadcasted result.
 
-   .. cmember:: int PyArrayMultiIterObject.nd
+   .. c:member:: int PyArrayMultiIterObject.nd
 
        The number of dimensions in the broadcasted result.
 
-   .. cmember:: npy_intp *PyArrayMultiIterObject.dimensions
+   .. c:member:: npy_intp *PyArrayMultiIterObject.dimensions
 
        The shape of the broadcasted result (only ``nd`` slots are used).
 
-   .. cmember:: PyArrayIterObject **PyArrayMultiIterObject.iters
+   .. c:member:: PyArrayIterObject **PyArrayMultiIterObject.iters
 
        An array of iterator objects that holds the iterators for the arrays
        to be broadcast together. On return, the iterators are adjusted for
@@ -975,21 +975,21 @@ PyArrayMultiIter_Type
 PyArrayNeighborhoodIter_Type
 ----------------------------
 
-.. cvar:: PyArrayNeighborhoodIter_Type
+.. c:var: PyArrayNeighborhoodIter_Type
 
    This is an iterator object that makes it easy to loop over an N-dimensional
    neighborhood.
 
-.. ctype:: PyArrayNeighborhoodIterObject
+.. c:type:: PyArrayNeighborhoodIterObject
 
    The C-structure corresponding to an object of
-   :cdata:`PyArrayNeighborhoodIter_Type` is the
-   :ctype:`PyArrayNeighborhoodIterObject`.
+   :c:data:`PyArrayNeighborhoodIter_Type` is the
+   :c:type:`PyArrayNeighborhoodIterObject`.
 
 PyArrayFlags_Type
 -----------------
 
-.. cvar:: PyArrayFlags_Type
+.. c:var: PyArrayFlags_Type
 
    When the flags attribute is retrieved from Python, a special
    builtin object of this type is constructed. This special type makes
@@ -1004,7 +1004,7 @@ ScalarArrayTypes
 There is a Python type for each of the different built-in data types
 that can be present in the array Most of these are simple wrappers
 around the corresponding data type in C. The C-names for these types
-are :cdata:`Py{TYPE}ArrType_Type` where ``{TYPE}`` can be
+are :c:data:`Py{TYPE}ArrType_Type` where ``{TYPE}`` can be
 
     **Bool**, **Byte**, **Short**, **Int**, **Long**, **LongLong**,
     **UByte**, **UShort**, **UInt**, **ULong**, **ULongLong**,
@@ -1013,12 +1013,12 @@ are :cdata:`Py{TYPE}ArrType_Type` where ``{TYPE}`` can be
     **Object**.
 
 These type names are part of the C-API and can therefore be created in
-extension C-code. There is also a :cdata:`PyIntpArrType_Type` and a
-:cdata:`PyUIntpArrType_Type` that are simple substitutes for one of the
+extension C-code. There is also a :c:data:`PyIntpArrType_Type` and a
+:c:data:`PyUIntpArrType_Type` that are simple substitutes for one of the
 integer types that can hold a pointer on the platform. The structure
 of these scalar objects is not exposed to C-code. The function
-:cfunc:`PyArray_ScalarAsCtype` (..) can be used to extract the C-type value
-from the array scalar and the function :cfunc:`PyArray_Scalar` (...) can be
+:c:func:`PyArray_ScalarAsCtype` (..) can be used to extract the C-type value
+from the array scalar and the function :c:func:`PyArray_Scalar` (...) can be
 used to construct an array scalar from a C-value.
 
 
@@ -1035,7 +1035,7 @@ convert from Python objects to a useful C-Object.
 PyArray_Dims
 ------------
 
-.. ctype:: PyArray_Dims
+.. c:type:: PyArray_Dims
 
    This structure is very useful when shape and/or strides information is
    supposed to be interpreted. The structure is:
@@ -1049,12 +1049,12 @@ PyArray_Dims
 
    The members of this structure are
 
-   .. cmember:: npy_intp *PyArray_Dims.ptr
+   .. c:member:: npy_intp *PyArray_Dims.ptr
 
-       A pointer to a list of (:ctype:`npy_intp`) integers which usually
+       A pointer to a list of (:c:type:`npy_intp`) integers which usually
        represent array shape or array strides.
 
-   .. cmember:: int PyArray_Dims.len
+   .. c:member:: int PyArray_Dims.len
 
        The length of the list of integers. It is assumed safe to
        access *ptr* [0] to *ptr* [len-1].
@@ -1063,11 +1063,11 @@ PyArray_Dims
 PyArray_Chunk
 -------------
 
-.. ctype:: PyArray_Chunk
+.. c:type:: PyArray_Chunk
 
    This is equivalent to the buffer object structure in Python up to
-   the ptr member. On 32-bit platforms (*i.e.* if :cdata:`NPY_SIZEOF_INT`
-   == :cdata:`NPY_SIZEOF_INTP`), the len member also matches an equivalent
+   the ptr member. On 32-bit platforms (*i.e.* if :c:data:`NPY_SIZEOF_INT`
+   == :c:data:`NPY_SIZEOF_INTP`), the len member also matches an equivalent
    member of the buffer object. It is useful to represent a generic
    single-segment chunk of memory.
 
@@ -1083,28 +1083,28 @@ PyArray_Chunk
 
    The members are
 
-   .. cmacro:: PyArray_Chunk.PyObject_HEAD
+   .. c:macro: PyArray_Chunk.PyObject_HEAD
 
        Necessary for all Python objects. Included here so that the
-       :ctype:`PyArray_Chunk` structure matches that of the buffer object
+       :c:type:`PyArray_Chunk` structure matches that of the buffer object
        (at least to the len member).
 
-   .. cmember:: PyObject *PyArray_Chunk.base
+   .. c:member:: PyObject *PyArray_Chunk.base
 
        The Python object this chunk of memory comes from. Needed so that
        memory can be accounted for properly.
 
-   .. cmember:: void *PyArray_Chunk.ptr
+   .. c:member:: void *PyArray_Chunk.ptr
 
        A pointer to the start of the single-segment chunk of memory.
 
-   .. cmember:: npy_intp PyArray_Chunk.len
+   .. c:member:: npy_intp PyArray_Chunk.len
 
        The length of the segment in bytes.
 
-   .. cmember:: int PyArray_Chunk.flags
+   .. c:member:: int PyArray_Chunk.flags
 
-       Any data flags (*e.g.* :cdata:`NPY_ARRAY_WRITEABLE` ) that should
+       Any data flags (*e.g.* :c:data:`NPY_ARRAY_WRITEABLE` ) that should
        be used to interpret the memory.
 
 
@@ -1113,18 +1113,18 @@ PyArrayInterface
 
 .. seealso:: :ref:`arrays.interface`
 
-.. ctype:: PyArrayInterface
+.. c:type:: PyArrayInterface
 
-   The :ctype:`PyArrayInterface` structure is defined so that NumPy and
+   The :c:type:`PyArrayInterface` structure is defined so that NumPy and
    other extension modules can use the rapid array interface
    protocol. The :obj:`__array_struct__` method of an object that
    supports the rapid array interface protocol should return a
-   :ctype:`PyCObject` that contains a pointer to a :ctype:`PyArrayInterface`
+   :c:type:`PyCObject` that contains a pointer to a :c:type:`PyArrayInterface`
    structure with the relevant details of the array. After the new
    array is created, the attribute should be ``DECREF``'d which will
-   free the :ctype:`PyArrayInterface` structure. Remember to ``INCREF`` the
+   free the :c:type:`PyArrayInterface` structure. Remember to ``INCREF`` the
    object (whose :obj:`__array_struct__` attribute was retrieved) and
-   point the base member of the new :ctype:`PyArrayObject` to this same
+   point the base member of the new :c:type:`PyArrayObject` to this same
    object. In this way the memory for the array will be managed
    correctly.
 
@@ -1142,15 +1142,15 @@ PyArrayInterface
           PyObject *descr;
       } PyArrayInterface;
 
-   .. cmember:: int PyArrayInterface.two
+   .. c:member:: int PyArrayInterface.two
 
        the integer 2 as a sanity check.
 
-   .. cmember:: int PyArrayInterface.nd
+   .. c:member:: int PyArrayInterface.nd
 
        the number of dimensions in the array.
 
-   .. cmember:: char PyArrayInterface.typekind
+   .. c:member:: char PyArrayInterface.typekind
 
        A character indicating what kind of array is present according to the
        typestring convention with 't' -> bitfield, 'b' -> Boolean, 'i' ->
@@ -1158,44 +1158,44 @@ PyArrayInterface
        complex floating point, 'O' -> object, 'S' -> (byte-)string, 'U' ->
        unicode, 'V' -> void.
 
-   .. cmember:: int PyArrayInterface.itemsize
+   .. c:member:: int PyArrayInterface.itemsize
 
        The number of bytes each item in the array requires.
 
-   .. cmember:: int PyArrayInterface.flags
+   .. c:member:: int PyArrayInterface.flags
 
-       Any of the bits :cdata:`NPY_ARRAY_C_CONTIGUOUS` (1),
-       :cdata:`NPY_ARRAY_F_CONTIGUOUS` (2), :cdata:`NPY_ARRAY_ALIGNED` (0x100),
-       :cdata:`NPY_ARRAY_NOTSWAPPED` (0x200), or :cdata:`NPY_ARRAY_WRITEABLE`
+       Any of the bits :c:data:`NPY_ARRAY_C_CONTIGUOUS` (1),
+       :c:data:`NPY_ARRAY_F_CONTIGUOUS` (2), :c:data:`NPY_ARRAY_ALIGNED` (0x100),
+       :c:data:`NPY_ARRAY_NOTSWAPPED` (0x200), or :c:data:`NPY_ARRAY_WRITEABLE`
        (0x400) to indicate something about the data. The
-       :cdata:`NPY_ARRAY_ALIGNED`, :cdata:`NPY_ARRAY_C_CONTIGUOUS`, and
-       :cdata:`NPY_ARRAY_F_CONTIGUOUS` flags can actually be determined from
-       the other parameters. The flag :cdata:`NPY_ARR_HAS_DESCR`
+       :c:data:`NPY_ARRAY_ALIGNED`, :c:data:`NPY_ARRAY_C_CONTIGUOUS`, and
+       :c:data:`NPY_ARRAY_F_CONTIGUOUS` flags can actually be determined from
+       the other parameters. The flag :c:data:`NPY_ARR_HAS_DESCR`
        (0x800) can also be set to indicate to objects consuming the
        version 3 array interface that the descr member of the
        structure is present (it will be ignored by objects consuming
        version 2 of the array interface).
 
-   .. cmember:: npy_intp *PyArrayInterface.shape
+   .. c:member:: npy_intp *PyArrayInterface.shape
 
        An array containing the size of the array in each dimension.
 
-   .. cmember:: npy_intp *PyArrayInterface.strides
+   .. c:member:: npy_intp *PyArrayInterface.strides
 
        An array containing the number of bytes to jump to get to the next
        element in each dimension.
 
-   .. cmember:: void *PyArrayInterface.data
+   .. c:member:: void *PyArrayInterface.data
 
        A pointer *to* the first element of the array.
 
-   .. cmember:: PyObject *PyArrayInterface.descr
+   .. c:member:: PyObject *PyArrayInterface.descr
 
        A Python object describing the data-type in more detail (same
        as the *descr* key in :obj:`__array_interface__`). This can be
        ``NULL`` if *typekind* and *itemsize* provide enough
        information. This field is also ignored unless
-       :cdata:`ARR_HAS_DESCR` flag is on in *flags*.
+       :c:data:`ARR_HAS_DESCR` flag is on in *flags*.
 
 
 Internally used structures
@@ -1207,33 +1207,33 @@ Python, and are not exposed to the C-API. They are included here only
 for completeness and assistance in understanding the code.
 
 
-.. ctype:: PyUFuncLoopObject
+.. c:type:: PyUFuncLoopObject
 
    A loose wrapper for a C-structure that contains the information
    needed for looping. This is useful if you are trying to understand
-   the ufunc looping code. The :ctype:`PyUFuncLoopObject` is the associated
+   the ufunc looping code. The :c:type:`PyUFuncLoopObject` is the associated
    C-structure. It is defined in the ``ufuncobject.h`` header.
 
-.. ctype:: PyUFuncReduceObject
+.. c:type:: PyUFuncReduceObject
 
    A loose wrapper for the C-structure that contains the information
    needed for reduce-like methods of ufuncs. This is useful if you are
    trying to understand the reduce, accumulate, and reduce-at
-   code. The :ctype:`PyUFuncReduceObject` is the associated C-structure. It
+   code. The :c:type:`PyUFuncReduceObject` is the associated C-structure. It
    is defined in the ``ufuncobject.h`` header.
 
-.. ctype:: PyUFunc_Loop1d
+.. c:type:: PyUFunc_Loop1d
 
    A simple linked-list of C-structures containing the information needed
    to define a 1-d loop for a ufunc for every defined signature of a
    user-defined data-type.
 
-.. cvar:: PyArrayMapIter_Type
+.. c:var: PyArrayMapIter_Type
 
    Advanced indexing is handled with this Python type. It is simply a
    loose wrapper around the C-structure containing the variables
    needed for advanced array indexing. The associated C-structure,
-   :ctype:`PyArrayMapIterObject`, is useful if you are trying to
+   :c:type:`PyArrayMapIterObject`, is useful if you are trying to
    understand the advanced-index mapping code. It is defined in the
    ``arrayobject.h`` header. This type is not exposed to Python and
    could be replaced with a C-structure. As a Python type it takes

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -10,16 +10,16 @@ UFunc API
 Constants
 ---------
 
-.. cvar:: UFUNC_ERR_{HANDLER}
+.. c:var:: UFUNC_ERR_{HANDLER}
 
     ``{HANDLER}`` can be **IGNORE**, **WARN**, **RAISE**, or **CALL**
 
-.. cvar:: UFUNC_{THING}_{ERR}
+.. c:var:: UFUNC_{THING}_{ERR}
 
     ``{THING}`` can be **MASK**, **SHIFT**, or **FPE**, and ``{ERR}`` can
     be **DIVIDEBYZERO**, **OVERFLOW**, **UNDERFLOW**, and **INVALID**.
 
-.. cvar:: PyUFunc_{VALUE}
+.. c:var:: PyUFunc_{VALUE}
 
     ``{VALUE}`` can be **One** (1), **Zero** (0), or **None** (-1)
 
@@ -27,37 +27,37 @@ Constants
 Macros
 ------
 
-.. cmacro:: NPY_LOOP_BEGIN_THREADS
+.. c:macro:: NPY_LOOP_BEGIN_THREADS
 
     Used in universal function code to only release the Python GIL if
     loop->obj is not true (*i.e.* this is not an OBJECT array
-    loop). Requires use of :cmacro:`NPY_BEGIN_THREADS_DEF` in variable
+    loop). Requires use of :c:macro:`NPY_BEGIN_THREADS_DEF` in variable
     declaration area.
 
-.. cmacro:: NPY_LOOP_END_THREADS
+.. c:macro:: NPY_LOOP_END_THREADS
 
     Used in universal function code to re-acquire the Python GIL if it
     was released (because loop->obj was not true).
 
-.. cfunction:: UFUNC_CHECK_ERROR(loop)
+.. c:function:: UFUNC_CHECK_ERROR(loop)
 
     A macro used internally to check for errors and goto fail if
     found.  This macro requires a fail label in the current code
     block. The *loop* variable must have at least members (obj,
     errormask, and errorobj). If *loop* ->obj is nonzero, then
-    :cfunc:`PyErr_Occurred` () is called (meaning the GIL must be held). If
+    :c:func:`PyErr_Occurred` () is called (meaning the GIL must be held). If
     *loop* ->obj is zero, then if *loop* ->errormask is nonzero,
-    :cfunc:`PyUFunc_checkfperr` is called with arguments *loop* ->errormask
+    :c:func:`PyUFunc_checkfperr` is called with arguments *loop* ->errormask
     and *loop* ->errobj. If the result of this check of the IEEE
     floating point registers is true then the code redirects to the
     fail label which must be defined.
 
-.. cfunction:: UFUNC_CHECK_STATUS(ret)
+.. c:function:: UFUNC_CHECK_STATUS(ret)
 
     Deprecated: use npy_clear_floatstatus from npy_math.h instead.
 
     A macro that expands to platform-dependent code. The *ret*
-    variable can can be any integer. The :cdata:`UFUNC_FPE_{ERR}` bits are
+    variable can can be any integer. The :c:data:`UFUNC_FPE_{ERR}` bits are
     set in *ret* according to the status of the corresponding error
     flags of the floating point processor.
 
@@ -65,7 +65,7 @@ Macros
 Functions
 ---------
 
-.. cfunction:: PyObject* PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func,
+.. c:function:: PyObject* PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func,
    void** data, char* types, int ntypes, int nin, int nout, int identity,
    char* name, char* doc, int check_return)
 
@@ -77,13 +77,13 @@ Functions
     .. note::
 
        The *func*, *data*, *types*, *name*, and *doc* arguments are not
-       copied by :cfunc:`PyUFunc_FromFuncAndData`. The caller must ensure
+       copied by :c:func:`PyUFunc_FromFuncAndData`. The caller must ensure
        that the memory used by these arrays is not freed as long as the
        ufunc object is alive.
 
     :param func:
         Must to an array of length *ntypes* containing
-        :ctype:`PyUFuncGenericFunction` items. These items are pointers to
+        :c:type:`PyUFuncGenericFunction` items. These items are pointers to
         functions that actually implement the underlying
         (element-by-element) function :math:`N` times.
 
@@ -127,7 +127,7 @@ Functions
         structure and it does get set with this value when the ufunc
         object is created.
 
-.. cfunction:: PyObject* PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction* func,
+.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction* func,
    void** data, char* types, int ntypes, int nin, int nout, int identity,
    char* name, char* doc, int check_return, char *signature)
 
@@ -142,7 +142,7 @@ Functions
         to calling PyUFunc_FromFuncAndData. A copy of the string is made,
         so the passed in buffer can be freed.
 
-.. cfunction:: int PyUFunc_RegisterLoopForType(PyUFuncObject* ufunc,
+.. c:function:: int PyUFunc_RegisterLoopForType(PyUFuncObject* ufunc,
    int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
 
     This function allows the user to register a 1-d loop with an
@@ -156,7 +156,7 @@ Functions
     in as *arg_types* which must be a pointer to memory at least as
     large as ufunc->nargs.
 
-.. cfunction:: int PyUFunc_RegisterLoopForDescr(PyUFuncObject* ufunc,
+.. c:function:: int PyUFunc_RegisterLoopForDescr(PyUFuncObject* ufunc,
    PyArray_Descr* userdtype, PyUFuncGenericFunction function,
    PyArray_Descr** arg_dtypes, void* data)
 
@@ -166,7 +166,7 @@ Functions
    registered for structured array data-dtypes and custom data-types
    instead of scalar data-types.
 
-.. cfunction:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc,
+.. c:function:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc,
    PyUFuncGenericFunction newfunc, int* signature,
    PyUFuncGenericFunction* oldfunc)
 
@@ -174,16 +174,16 @@ Functions
     already-created *ufunc* with the new 1-d loop newfunc. Return the
     old 1-d loop function in *oldfunc*. Return 0 on success and -1 on
     failure. This function works only with built-in types (use
-    :cfunc:`PyUFunc_RegisterLoopForType` for user-defined types). A
+    :c:func:`PyUFunc_RegisterLoopForType` for user-defined types). A
     signature is an array of data-type numbers indicating the inputs
     followed by the outputs assumed by the 1-d loop.
 
-.. cfunction:: int PyUFunc_GenericFunction(PyUFuncObject* self,
+.. c:function:: int PyUFunc_GenericFunction(PyUFuncObject* self,
    PyObject* args, PyObject* kwds, PyArrayObject** mps)
 
     A generic ufunc call. The ufunc is passed in as *self*, the arguments
     to the ufunc as *args* and *kwds*. The *mps* argument is an array of
-    :ctype:`PyArrayObject` pointers whose values are discarded and which
+    :c:type:`PyArrayObject` pointers whose values are discarded and which
     receive the converted input arguments as well as the ufunc outputs
     when success is returned. The user is responsible for managing this
     array and receives a new reference for each array in *mps*. The total
@@ -191,26 +191,26 @@ Functions
 
     Returns 0 on success, -1 on error.
 
-.. cfunction:: int PyUFunc_checkfperr(int errmask, PyObject* errobj)
+.. c:function:: int PyUFunc_checkfperr(int errmask, PyObject* errobj)
 
     A simple interface to the IEEE error-flag checking support. The
-    *errmask* argument is a mask of :cdata:`UFUNC_MASK_{ERR}` bitmasks
+    *errmask* argument is a mask of :c:data:`UFUNC_MASK_{ERR}` bitmasks
     indicating which errors to check for (and how to check for
     them). The *errobj* must be a Python tuple with two elements: a
     string containing the name which will be used in any communication
     of error and either a callable Python object (call-back function)
-    or :cdata:`Py_None`. The callable object will only be used if
-    :cdata:`UFUNC_ERR_CALL` is set as the desired error checking
+    or :c:data:`Py_None`. The callable object will only be used if
+    :c:data:`UFUNC_ERR_CALL` is set as the desired error checking
     method. This routine manages the GIL and is safe to call even
     after releasing the GIL. If an error in the IEEE-compatibile
     hardware is determined a -1 is returned, otherwise a 0 is
     returned.
 
-.. cfunction::  void  PyUFunc_clearfperr()
+.. c:function::  void  PyUFunc_clearfperr()
 
     Clear the IEEE error flags.
 
-.. cfunction:: void PyUFunc_GetPyValues(char* name, int* bufsize,
+.. c:function:: void PyUFunc_GetPyValues(char* name, int* bufsize,
    int* errmask, PyObject** errobj)
 
     Get the Python values used for ufunc processing from the
@@ -238,37 +238,37 @@ of these functions are suitable for placing directly in the array of
 functions stored in the functions member of the PyUFuncObject
 structure.
 
-.. cfunction:: void PyUFunc_f_f_As_d_d(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_f_f_As_d_d(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_d_d(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_d_d(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_f_f(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_f_f(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_g_g(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_g_g(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_F_F_As_D_D(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_F_F_As_D_D(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_F_F(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_F_F(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_D_D(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_D_D(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_G_G(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_G_G(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_e_e(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_e_e(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_e_e_As_f_f(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_e_e_As_f_f(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_e_e_As_d_d(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_e_e_As_d_d(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
     Type specific, core 1-d functions for ufuncs where each
@@ -280,41 +280,41 @@ structure.
     ``G`` - clongdouble). The argument *func* must support the same
     signature. The _As_X_X variants assume ndarray's of one data type
     but cast the values to use an underlying function that takes a
-    different data type. Thus, :cfunc:`PyUFunc_f_f_As_d_d` uses
-    ndarrays of data type :cdata:`NPY_FLOAT` but calls out to a
+    different data type. Thus, :c:func:`PyUFunc_f_f_As_d_d` uses
+    ndarrays of data type :c:data:`NPY_FLOAT` but calls out to a
     C-function that takes double and returns double.
 
-.. cfunction:: void PyUFunc_ff_f_As_dd_d(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_ff_f_As_dd_d(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_ff_f(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_ff_f(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_dd_d(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_dd_d(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_gg_g(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_gg_g(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_FF_F_As_DD_D(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_FF_F_As_DD_D(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_DD_D(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_DD_D(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_FF_F(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_FF_F(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_GG_G(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_GG_G(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_ee_e(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_ee_e(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_ee_e_As_ff_f(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_ee_e_As_ff_f(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_ee_e_As_dd_d(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_ee_e_As_dd_d(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
     Type specific, core 1-d functions for ufuncs where each
@@ -327,20 +327,20 @@ structure.
     of one data type but cast the values at each iteration of the loop
     to use the underlying function that takes a different data type.
 
-.. cfunction:: void PyUFunc_O_O(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_O_O(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
-.. cfunction:: void PyUFunc_OO_O(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_OO_O(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
     One-input, one-output, and two-input, one-output core 1-d functions
-    for the :cdata:`NPY_OBJECT` data type. These functions handle reference
+    for the :c:data:`NPY_OBJECT` data type. These functions handle reference
     count issues and return early on error. The actual function to call is
     *func* and it must accept calls with the signature ``(PyObject*)
-    (PyObject*)`` for :cfunc:`PyUFunc_O_O` or ``(PyObject*)(PyObject *,
-    PyObject *)`` for :cfunc:`PyUFunc_OO_O`.
+    (PyObject*)`` for :c:func:`PyUFunc_O_O` or ``(PyObject*)(PyObject *,
+    PyObject *)`` for :c:func:`PyUFunc_OO_O`.
 
-.. cfunction:: void PyUFunc_O_O_method(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_O_O_method(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
     This general purpose 1-d core function assumes that *func* is a string
@@ -348,7 +348,7 @@ structure.
     iteration of the loop, the Python obejct is extracted from the array
     and its *func* method is called returning the result to the output array.
 
-.. cfunction:: void PyUFunc_OO_O_method(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_OO_O_method(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
     This general purpose 1-d core function assumes that *func* is a
@@ -358,14 +358,14 @@ structure.
     function. The output of the function is stored in the third entry
     of *args*.
 
-.. cfunction:: void PyUFunc_On_Om(char** args, npy_intp* dimensions,
+.. c:function:: void PyUFunc_On_Om(char** args, npy_intp* dimensions,
    npy_intp* steps, void* func)
 
     This is the 1-d core function used by the dynamic ufuncs created
     by umath.frompyfunc(function, nin, nout). In this case *func* is a
-    pointer to a :ctype:`PyUFunc_PyFuncData` structure which has definition
+    pointer to a :c:type:`PyUFunc_PyFuncData` structure which has definition
 
-    .. ctype:: PyUFunc_PyFuncData
+    .. c:type:: PyUFunc_PyFuncData
 
        .. code-block:: c
 
@@ -384,11 +384,11 @@ structure.
 Importing the API
 -----------------
 
-.. cvar:: PY_UFUNC_UNIQUE_SYMBOL
+.. c:var:: PY_UFUNC_UNIQUE_SYMBOL
 
-.. cvar:: NO_IMPORT_UFUNC
+.. c:var:: NO_IMPORT_UFUNC
 
-.. cfunction:: void import_ufunc(void)
+.. c:function:: void import_ufunc(void)
 
     These are the constants and functions for accessing the ufunc
     C-API from extension modules in precisely the same way as the
@@ -397,17 +397,17 @@ Importing the API
     extension module). If your extension module is in one file then
     that is all that is required. The other two constants are useful
     if your extension module makes use of multiple files. In that
-    case, define :cdata:`PY_UFUNC_UNIQUE_SYMBOL` to something unique to
+    case, define :c:data:`PY_UFUNC_UNIQUE_SYMBOL` to something unique to
     your code and then in source files that do not contain the module
     initialization function but still need access to the UFUNC API,
-    define :cdata:`PY_UFUNC_UNIQUE_SYMBOL` to the same name used previously
-    and also define :cdata:`NO_IMPORT_UFUNC`.
+    define :c:data:`PY_UFUNC_UNIQUE_SYMBOL` to the same name used previously
+    and also define :c:data:`NO_IMPORT_UFUNC`.
 
     The C-API is actually an array of function pointers. This array is
     created (and pointed to by a global variable) by import_ufunc. The
     global variable is either statically defined or allowed to be seen
     by other files depending on the state of
-    :cdata:`Py_UFUNC_UNIQUE_SYMBOL` and :cdata:`NO_IMPORT_UFUNC`.
+    :c:data:`Py_UFUNC_UNIQUE_SYMBOL` and :c:data:`NO_IMPORT_UFUNC`.
 
 .. index::
    pair: ufunc; C-API

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -21,7 +21,6 @@ For learning how to use NumPy, see also :ref:`user`.
    arrays
    ufuncs
    routines
-   ctypeslib
    distutils
    c-api
    internals

--- a/doc/source/reference/internals.code-explanations.rst
+++ b/doc/source/reference/internals.code-explanations.rst
@@ -41,18 +41,18 @@ called a rank-0 array), then the strides and dimensions variables are
 NULL.
 
 Besides the structural information contained in the strides and
-dimensions members of the :ctype:`PyArrayObject`, the flags contain
+dimensions members of the :c:type:`PyArrayObject`, the flags contain
 important information about how the data may be accessed. In particular,
-the :cdata:`NPY_ARRAY_ALIGNED` flag is set when the memory is on a
+the :c:data:`NPY_ARRAY_ALIGNED` flag is set when the memory is on a
 suitable boundary according to the data-type array. Even if you have
 a contiguous chunk of memory, you cannot just assume it is safe to
 dereference a data- type-specific pointer to an element. Only if the
-:cdata:`NPY_ARRAY_ALIGNED` flag is set is this a safe operation (on
+:c:data:`NPY_ARRAY_ALIGNED` flag is set is this a safe operation (on
 some platforms it will work but on others, like Solaris, it will cause
-a bus error). The :cdata:`NPY_ARRAY_WRITEABLE` should also be ensured
+a bus error). The :c:data:`NPY_ARRAY_WRITEABLE` should also be ensured
 if you plan on writing to the memory area of the array. It is also
 possible to obtain a pointer to an unwritable memory area. Sometimes,
-writing to the memory area when the :cdata:`NPY_ARRAY_WRITEABLE` flag is not
+writing to the memory area when the :c:data:`NPY_ARRAY_WRITEABLE` flag is not
 set will just be rude. Other times it can cause program crashes ( *e.g.*
 a data-area that is a read-only memory-mapped file).
 
@@ -67,8 +67,8 @@ The data-type is an important abstraction of the ndarray. Operations
 will look to the data-type to provide the key functionality that is
 needed to operate on the array. This functionality is provided in the
 list of function pointers pointed to by the 'f' member of the
-:ctype:`PyArray_Descr` structure. In this way, the number of data-types can be
-extended simply by providing a :ctype:`PyArray_Descr` structure with suitable
+:c:type:`PyArray_Descr` structure. In this way, the number of data-types can be
+extended simply by providing a :c:type:`PyArray_Descr` structure with suitable
 function pointers in the 'f' member. For built-in types there are some
 optimizations that by-pass this mechanism, but the point of the data-
 type abstraction is to allow new data-types to be added.
@@ -97,7 +97,7 @@ operation of a general-purpose N-dimensional loop is abstracted in the
 notion of an iterator object. To write an N-dimensional loop, you only
 have to create an iterator object from an ndarray, work with the
 dataptr member of the iterator object structure and call the macro
-:cfunc:`PyArray_ITER_NEXT` (it) on the iterator object to move to the next
+:c:func:`PyArray_ITER_NEXT` (it) on the iterator object to move to the next
 element. The "next" element is always in C-contiguous order. The macro
 works by first special casing the C-contiguous, 1-D, and 2-D cases
 which work very simply.
@@ -120,11 +120,11 @@ previously-described tests are executed again on the next-to-last
 dimension. In this way, the dataptr is adjusted appropriately for
 arbitrary striding.
 
-The coordinates member of the :ctype:`PyArrayIterObject` structure maintains
+The coordinates member of the :c:type:`PyArrayIterObject` structure maintains
 the current N-d counter unless the underlying array is C-contiguous in
 which case the coordinate counting is by-passed. The index member of
-the :ctype:`PyArrayIterObject` keeps track of the current flat index of the
-iterator. It is updated by the :cfunc:`PyArray_ITER_NEXT` macro.
+the :c:type:`PyArrayIterObject` keeps track of the current flat index of the
+iterator. It is updated by the :c:func:`PyArray_ITER_NEXT` macro.
 
 
 Broadcasting
@@ -136,18 +136,18 @@ Broadcasting
 In Numeric, broadcasting was implemented in several lines of code
 buried deep in ufuncobject.c. In NumPy, the notion of broadcasting has
 been abstracted so that it can be performed in multiple places.
-Broadcasting is handled by the function :cfunc:`PyArray_Broadcast`. This
-function requires a :ctype:`PyArrayMultiIterObject` (or something that is a
-binary equivalent) to be passed in. The :ctype:`PyArrayMultiIterObject` keeps
+Broadcasting is handled by the function :c:func:`PyArray_Broadcast`. This
+function requires a :c:type:`PyArrayMultiIterObject` (or something that is a
+binary equivalent) to be passed in. The :c:type:`PyArrayMultiIterObject` keeps
 track of the broadcast number of dimensions and size in each
 dimension along with the total size of the broadcast result. It also
 keeps track of the number of arrays being broadcast and a pointer to
 an iterator for each of the arrays being broadcast.
 
-The :cfunc:`PyArray_Broadcast` function takes the iterators that have already
+The :c:func:`PyArray_Broadcast` function takes the iterators that have already
 been defined and uses them to determine the broadcast shape in each
 dimension (to create the iterators at the same time that broadcasting
-occurs then use the :cfunc:`PyMultiIter_New` function). Then, the iterators are
+occurs then use the :c:func:`PyMultiIter_New` function). Then, the iterators are
 adjusted so that each iterator thinks it is iterating over an array
 with the broadcast size. This is done by adjusting the iterators
 number of dimensions, and the shape in each dimension. This works
@@ -160,9 +160,9 @@ operates over the extended dimension.
 Broadcasting was always implemented in Numeric using 0-valued strides
 for the extended dimensions. It is done in exactly the same way in
 NumPy. The big difference is that now the array of strides is kept
-track of in a :ctype:`PyArrayIterObject`, the iterators involved in a
-broadcast result are kept track of in a :ctype:`PyArrayMultiIterObject`,
-and the :cfunc:`PyArray_BroadCast` call implements the broad-casting rules.
+track of in a :c:type:`PyArrayIterObject`, the iterators involved in a
+broadcast result are kept track of in a :c:type:`PyArrayMultiIterObject`,
+and the :c:func:`PyArray_BroadCast` call implements the broad-casting rules.
 
 
 Array Scalars
@@ -222,7 +222,7 @@ single boolean indexing array will call specialized boolean functions.
 Indices containing an ellipsis or slice but no advanced indexing will
 always create a view into the old array by calculating the new strides and
 memory offset.  This view can then either be returned or, for assignments,
-filled using :cfunc:`PyArray_CopyObject`. Note that `PyArray_CopyObject`
+filled using :c:func:`PyArray_CopyObject`. Note that `PyArray_CopyObject`
 may also be called on temporary arrays in other branches to support
 complicated assignments when the array is of object dtype.
 
@@ -260,7 +260,7 @@ the start of the subarray, which then allows to restart the subarray
 iteration.
 
 When advanced indices are next to each other transposing may be necessary.
-All necessary transposing is handled by :cfunc:`PyArray_MapIterSwapAxes` and
+All necessary transposing is handled by :c:func:`PyArray_MapIterSwapAxes` and
 has to be handled by the caller unless `PyArray_MapIterNew` is asked to
 allocate the result.
 
@@ -385,7 +385,7 @@ Function call
 
 This section describes how the basic universal function computation loop is
 setup and executed for each of the three different kinds of execution. If
-:cdata:`NPY_ALLOW_THREADS` is defined during compilation, then as long as
+:c:data:`NPY_ALLOW_THREADS` is defined during compilation, then as long as
 no object arrays are involved, the Python Global Interpreter Lock (GIL) is
 released prior to calling the loops.  It is re-acquired if necessary to
 handle error conditions. The hardware error flags are checked only after

--- a/doc/source/reference/internals.code-explanations.rst
+++ b/doc/source/reference/internals.code-explanations.rst
@@ -196,6 +196,7 @@ Indexing
 
 All python indexing operations ``arr[index]`` are organized by first preparing
 the index and finding the index type. The supported index types are:
+
 * integer
 * newaxis
 * slice
@@ -234,6 +235,7 @@ combined with typical view based indexing. Here integer indices are
 interpreted as view based. Before trying to understand this, you may want
 to make yourself familiar with its subtleties. The advanced indexing code
 has three different branches and one special case:
+
 * There is one indexing array and it, as well as the assignment array, can
   be iterated trivially. For example they may be contiguous. Also the
   indexing array must be of `intp` type and the value array in assignments

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -32,7 +32,7 @@ of an array.
 .. index::
    single: array iterator
 
-Basic usage is to call :cfunc:`PyArray_IterNew` ( ``array`` ) where array
+Basic usage is to call :c:func:`PyArray_IterNew` ( ``array`` ) where array
 is an ndarray object (or one of its sub-classes). The returned object
 is an array-iterator object (the same object returned by the .flat
 attribute of the ndarray). This object is usually cast to
@@ -46,13 +46,13 @@ ndarray object.
 
 After processing data at the current element of the array, the next
 element of the array can be obtained using the macro
-:cfunc:`PyArray_ITER_NEXT` ( ``iter`` ). The iteration always proceeds in a
+:c:func:`PyArray_ITER_NEXT` ( ``iter`` ). The iteration always proceeds in a
 C-style contiguous fashion (last index varying the fastest). The
-:cfunc:`PyArray_ITER_GOTO` ( ``iter``, ``destination`` ) can be used to
+:c:func:`PyArray_ITER_GOTO` ( ``iter``, ``destination`` ) can be used to
 jump to a particular point in the array, where ``destination`` is an
 array of npy_intp data-type with space to handle at least the number
 of dimensions in the underlying array. Occasionally it is useful to
-use :cfunc:`PyArray_ITER_GOTO1D` ( ``iter``, ``index`` ) which will jump
+use :c:func:`PyArray_ITER_GOTO1D` ( ``iter``, ``index`` ) which will jump
 to the 1-d index given by the value of ``index``. The most common
 usage, however, is given in the following example.
 
@@ -69,8 +69,8 @@ usage, however, is given in the following example.
     }
     ...
 
-You can also use :cfunc:`PyArrayIter_Check` ( ``obj`` ) to ensure you have
-an iterator object and :cfunc:`PyArray_ITER_RESET` ( ``iter`` ) to reset an
+You can also use :c:func:`PyArrayIter_Check` ( ``obj`` ) to ensure you have
+an iterator object and :c:func:`PyArray_ITER_RESET` ( ``iter`` ) to reset an
 iterator object back to the beginning of the array.
 
 It should be emphasized at this point that you may not need the array
@@ -112,10 +112,10 @@ perform the inner loop over the dimension with the highest number of
 elements to take advantage of speed enhancements available on micro-
 processors that use pipelining to enhance fundmental operations.
 
-The :cfunc:`PyArray_IterAllButAxis` ( ``array``, ``&dim`` ) constructs an
+The :c:func:`PyArray_IterAllButAxis` ( ``array``, ``&dim`` ) constructs an
 iterator object that is modified so that it will not iterate over the
 dimension indicated by dim. The only restriction on this iterator
-object, is that the :cfunc:`PyArray_Iter_GOTO1D` ( ``it``, ``ind`` ) macro
+object, is that the :c:func:`PyArray_Iter_GOTO1D` ( ``it``, ``ind`` ) macro
 cannot be used (thus flat indexing won't work either if you pass this
 object back to Python --- so you shouldn't do this). Note that the
 returned object from this routine is still usually cast to
@@ -161,21 +161,21 @@ Broadcasting over multiple arrays
 
 When multiple arrays are involved in an operation, you may want to use the
 same broadcasting rules that the math operations (*i.e.* the ufuncs) use.
-This can be done easily using the :ctype:`PyArrayMultiIterObject`.  This is
+This can be done easily using the :c:type:`PyArrayMultiIterObject`.  This is
 the object returned from the Python command numpy.broadcast and it is almost
 as easy to use from C. The function
-:cfunc:`PyArray_MultiIterNew` ( ``n``, ``...`` ) is used (with ``n`` input
+:c:func:`PyArray_MultiIterNew` ( ``n``, ``...`` ) is used (with ``n`` input
 objects in place of ``...`` ). The input objects can be arrays or anything
 that can be converted into an array. A pointer to a PyArrayMultiIterObject is
 returned.  Broadcasting has already been accomplished which adjusts the
 iterators so that all that needs to be done to advance to the next element in
 each array is for PyArray_ITER_NEXT to be called for each of the inputs. This
 incrementing is automatically performed by
-:cfunc:`PyArray_MultiIter_NEXT` ( ``obj`` ) macro (which can handle a
-multiterator ``obj`` as either a :ctype:`PyArrayMultiObject *` or a
-:ctype:`PyObject *`). The data from input number ``i`` is available using
-:cfunc:`PyArray_MultiIter_DATA` ( ``obj``, ``i`` ) and the total (broadcasted)
-size as :cfunc:`PyArray_MultiIter_SIZE` ( ``obj``). An example of using this
+:c:func:`PyArray_MultiIter_NEXT` ( ``obj`` ) macro (which can handle a
+multiterator ``obj`` as either a :c:type:`PyArrayMultiObject *` or a
+:c:type:`PyObject *`). The data from input number ``i`` is available using
+:c:func:`PyArray_MultiIter_DATA` ( ``obj``, ``i`` ) and the total (broadcasted)
+size as :c:func:`PyArray_MultiIter_SIZE` ( ``obj``). An example of using this
 feature follows.
 
 .. code-block:: c
@@ -189,7 +189,7 @@ feature follows.
         PyArray_MultiIter_NEXT(mobj);
     }
 
-The function :cfunc:`PyArray_RemoveSmallest` ( ``multi`` ) can be used to
+The function :c:func:`PyArray_RemoveSmallest` ( ``multi`` ) can be used to
 take a multi-iterator object and adjust all the iterators so that
 iteration does not take place over the largest dimension (it makes
 that dimension of size 1). The code being looped over that makes use
@@ -254,23 +254,23 @@ type. For example, a suitable structure for the new Python type is:
     } PySomeDataTypeObject;
 
 After you have defined a new Python type object, you must then define
-a new :ctype:`PyArray_Descr` structure whose typeobject member will contain a
+a new :c:type:`PyArray_Descr` structure whose typeobject member will contain a
 pointer to the data-type you've just defined. In addition, the
 required functions in the ".f" member must be defined: nonzero,
 copyswap, copyswapn, setitem, getitem, and cast. The more functions in
 the ".f" member you define, however, the more useful the new data-type
 will be.  It is very important to intialize unused functions to NULL.
-This can be achieved using :cfunc:`PyArray_InitArrFuncs` (f).
+This can be achieved using :c:func:`PyArray_InitArrFuncs` (f).
 
-Once a new :ctype:`PyArray_Descr` structure is created and filled with the
+Once a new :c:type:`PyArray_Descr` structure is created and filled with the
 needed information and useful functions you call
-:cfunc:`PyArray_RegisterDataType` (new_descr). The return value from this
+:c:func:`PyArray_RegisterDataType` (new_descr). The return value from this
 call is an integer providing you with a unique type_number that
 specifies your data-type. This type number should be stored and made
 available by your module so that other modules can use it to recognize
 your data-type (the other mechanism for finding a user-defined
 data-type number is to search based on the name of the type-object
-associated with the data-type using :cfunc:`PyArray_TypeNumFromName` ).
+associated with the data-type using :c:func:`PyArray_TypeNumFromName` ).
 
 
 Registering a casting function
@@ -284,7 +284,7 @@ functions for each conversion you want to support and then registering
 these functions with the data-type descriptor. A low-level casting
 function has the signature.
 
-.. cfunction:: void castfunc( void* from, void* to, npy_intp n, void* fromarr,
+.. c:function:: void castfunc( void* from, void* to, npy_intp n, void* fromarr,
    void* toarr)
 
     Cast ``n`` elements ``from`` one type ``to`` another. The data to
@@ -326,11 +326,11 @@ situation limits the ability of user-defined data-types to participate
 in the coercion system used by ufuncs and other times when automatic
 coercion takes place in NumPy. This can be changed by registering
 data-types as safely castable from a particlar data-type object. The
-function :cfunc:`PyArray_RegisterCanCast` (from_descr, totype_number,
+function :c:func:`PyArray_RegisterCanCast` (from_descr, totype_number,
 scalarkind) should be used to specify that the data-type object
 from_descr can be cast to the data-type with type number
 totype_number. If you are not trying to alter scalar coercion rules,
-then use :cdata:`NPY_NOSCALAR` for the scalarkind argument.
+then use :c:data:`NPY_NOSCALAR` for the scalarkind argument.
 
 If you want to allow your new data-type to also be able to share in
 the scalar coercion rules, then you need to specify the scalarkind
@@ -340,7 +340,7 @@ available to that function). Then, you can register data-types that
 can be cast to separately for each scalar kind that may be returned
 from your user-defined data-type. If you don't register scalar
 coercion handling, then all of your user-defined data-types will be
-seen as :cdata:`NPY_NOSCALAR`.
+seen as :c:data:`NPY_NOSCALAR`.
 
 
 Registering a ufunc loop
@@ -353,12 +353,12 @@ signature, silently replaces any previously registered loops for that
 data-type.
 
 Before you can register a 1-d loop for a ufunc, the ufunc must be
-previously created. Then you call :cfunc:`PyUFunc_RegisterLoopForType`
+previously created. Then you call :c:func:`PyUFunc_RegisterLoopForType`
 (...) with the information needed for the loop. The return value of
 this function is ``0`` if the process was successful and ``-1`` with
 an error condition set if it was not successful.
 
-.. cfunction:: int PyUFunc_RegisterLoopForType( PyUFuncObject* ufunc,
+.. c:function:: int PyUFunc_RegisterLoopForType( PyUFuncObject* ufunc,
    int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
 
     *ufunc*
@@ -413,7 +413,7 @@ easier to sub-type from a single parent type.
    pair: ndarray; subtyping
 
 All C-structures corresponding to Python objects must begin with
-:cmacro:`PyObject_HEAD` (or :cmacro:`PyObject_VAR_HEAD`). In the same
+:c:macro:`PyObject_HEAD` (or :c:macro:`PyObject_VAR_HEAD`). In the same
 way, any sub-type must have a C-structure that begins with exactly the
 same memory layout as the parent type (or all of the parent types in
 the case of multiple-inheritance). The reason for this is that Python
@@ -424,17 +424,17 @@ members). If the memory layouts are not compatible, then this attempt
 will cause unpredictable behavior (eventually leading to a memory
 violation and program crash).
 
-One of the elements in :cmacro:`PyObject_HEAD` is a pointer to a
+One of the elements in :c:macro:`PyObject_HEAD` is a pointer to a
 type-object structure. A new Python type is created by creating a new
 type-object structure and populating it with functions and pointers to
 describe the desired behavior of the type. Typically, a new
 C-structure is also created to contain the instance-specific
 information needed for each object of the type as well. For example,
-:cdata:`&PyArray_Type` is a pointer to the type-object table for the ndarray
-while a :ctype:`PyArrayObject *` variable is a pointer to a particular instance
+:c:data:`&PyArray_Type` is a pointer to the type-object table for the ndarray
+while a :c:type:`PyArrayObject *` variable is a pointer to a particular instance
 of an ndarray (one of the members of the ndarray structure is, in
-turn, a pointer to the type- object table :cdata:`&PyArray_Type`). Finally
-:cfunc:`PyType_Ready` (<pointer_to_type_object>) must be called for
+turn, a pointer to the type- object table :c:data:`&PyArray_Type`). Finally
+:c:func:`PyType_Ready` (<pointer_to_type_object>) must be called for
 every new Python type.
 
 
@@ -444,7 +444,7 @@ Creating sub-types
 To create a sub-type, a similar proceedure must be followed except
 only behaviors that are different require new entries in the type-
 object structure. All other entires can be NULL and will be filled in
-by :cfunc:`PyType_Ready` with appropriate functions from the parent
+by :c:func:`PyType_Ready` with appropriate functions from the parent
 type(s). In particular, to create a sub-type in C follow these steps:
 
 1. If needed create a new C-structure to handle each instance of your
@@ -473,7 +473,7 @@ type(s). In particular, to create a sub-type in C follow these steps:
    Remember, all parent-types must have the same C-structure for multiple
    inheritance to work properly.
 
-4. Call :cfunc:`PyType_Ready` (<pointer_to_new_type>). If this function
+4. Call :c:func:`PyType_Ready` (<pointer_to_new_type>). If this function
    returns a negative number, a failure occurred and the type is not
    initialized. Otherwise, the type is ready to be used. It is
    generally important to place a reference to the new type into the
@@ -503,7 +503,7 @@ The __array_finalize\__ method
    members are filled in. Finally, the :obj:`__array_finalize__`
    attribute is looked-up in the object dictionary. If it is present
    and not None, then it can be either a CObject containing a pointer
-   to a :cfunc:`PyArray_FinalizeFunc` or it can be a method taking a
+   to a :c:func:`PyArray_FinalizeFunc` or it can be a method taking a
    single argument (which could be None).
 
    If the :obj:`__array_finalize__` attribute is a CObject, then the pointer

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -90,17 +90,17 @@ that do not require a separate extraction of the module dictionary.
 These are documented in the Python documentation, but repeated here
 for convenience:
 
-.. cfunction:: int PyModule_AddObject(PyObject* module, char* name, PyObject* value)
+.. c:function:: int PyModule_AddObject(PyObject* module, char* name, PyObject* value)
 
-.. cfunction:: int PyModule_AddIntConstant(PyObject* module, char* name, long value)
+.. c:function:: int PyModule_AddIntConstant(PyObject* module, char* name, long value)
 
-.. cfunction:: int PyModule_AddStringConstant(PyObject* module, char* name, char* value)
+.. c:function:: int PyModule_AddStringConstant(PyObject* module, char* name, char* value)
 
     All three of these functions require the *module* object (the
     return value of Py_InitModule). The *name* is a string that
     labels the value in the module. Depending on which function is
     called, the *value* argument is either a general object
-    (:cfunc:`PyModule_AddObject` steals a reference to it), an integer
+    (:c:func:`PyModule_AddObject` steals a reference to it), an integer
     constant, or a string constant.
 
 
@@ -125,7 +125,7 @@ subroutine) to:
         {NULL, NULL, 0, NULL} /* Sentinel */
     }
 
-Each entry in the mymethods array is a :ctype:`PyMethodDef` structure
+Each entry in the mymethods array is a :c:type:`PyMethodDef` structure
 containing 1) the Python name, 2) the C-function that implements the
 function, 3) flags indicating whether or not keywords are accepted for
 this function, and 4) The docstring for the function. Any number of
@@ -159,8 +159,8 @@ The dummy argument is not used in this context and can be safely
 ignored. The *args* argument contains all of the arguments passed in
 to the function as a tuple. You can do anything you want at this
 point, but usually the easiest way to manage the input arguments is to
-call :cfunc:`PyArg_ParseTuple` (args, format_string,
-addresses_to_C_variables...) or :cfunc:`PyArg_UnpackTuple` (tuple, "name" ,
+call :c:func:`PyArg_ParseTuple` (args, format_string,
+addresses_to_C_variables...) or :c:func:`PyArg_UnpackTuple` (tuple, "name" ,
 min, max, ...). A good description of how to use the first function is
 contained in the Python C-API reference manual under section 5.5
 (Parsing arguments and building values). You should pay particular
@@ -168,13 +168,13 @@ attention to the "O&" format which uses converter functions to go
 between the Python object and the C object. All of the other format
 functions can be (mostly) thought of as special cases of this general
 rule. There are several converter functions defined in the NumPy C-API
-that may be of use. In particular, the :cfunc:`PyArray_DescrConverter`
+that may be of use. In particular, the :c:func:`PyArray_DescrConverter`
 function is very useful to support arbitrary data-type specification.
 This function transforms any valid data-type Python object into a
-:ctype:`PyArray_Descr *` object. Remember to pass in the address of the
+:c:type:`PyArray_Descr *` object. Remember to pass in the address of the
 C-variables that should be filled in.
 
-There are lots of examples of how to use :cfunc:`PyArg_ParseTuple`
+There are lots of examples of how to use :c:func:`PyArg_ParseTuple`
 throughout the NumPy source code. The standard usage is like this:
 
 .. code-block:: c
@@ -189,13 +189,13 @@ It is important to keep in mind that you get a *borrowed* reference to
 the object when using the "O" format string. However, the converter
 functions usually require some form of memory handling. In this
 example, if the conversion is successful, *dtype* will hold a new
-reference to a :ctype:`PyArray_Descr *` object, while *input* will hold a
+reference to a :c:type:`PyArray_Descr *` object, while *input* will hold a
 borrowed reference. Therefore, if this conversion were mixed with
 another conversion (say to an integer) and the data-type conversion
 was successful but the integer conversion failed, then you would need
 to release the reference count to the data-type object before
 returning. A typical way to do this is to set *dtype* to ``NULL``
-before calling :cfunc:`PyArg_ParseTuple` and then use :cfunc:`Py_XDECREF`
+before calling :c:func:`PyArg_ParseTuple` and then use :c:func:`Py_XDECREF`
 on *dtype* before returning.
 
 After the input arguments are processed, the code that actually does
@@ -203,16 +203,16 @@ the work is written (likely calling other functions as needed). The
 final step of the C-function is to return something. If an error is
 encountered then ``NULL`` should be returned (making sure an error has
 actually been set). If nothing should be returned then increment
-:cdata:`Py_None` and return it. If a single object should be returned then
+:c:data:`Py_None` and return it. If a single object should be returned then
 it is returned (ensuring that you own a reference to it first). If
 multiple objects should be returned then you need to return a tuple.
-The :cfunc:`Py_BuildValue` (format_string, c_variables...) function makes
+The :c:func:`Py_BuildValue` (format_string, c_variables...) function makes
 it easy to build tuples of Python objects from C variables. Pay
 special attention to the difference between 'N' and 'O' in the format
 string or you can easily create memory leaks. The 'O' format string
-increments the reference count of the :ctype:`PyObject *` C-variable it
+increments the reference count of the :c:type:`PyObject *` C-variable it
 corresponds to, while the 'N' format string steals a reference to the
-corresponding :ctype:`PyObject *` C-variable. You should use 'N' if you have
+corresponding :c:type:`PyObject *` C-variable. You should use 'N' if you have
 already created a reference for the object and just want to give that
 reference to the tuple. You should use 'O' if you only have a borrowed
 reference to an object and need to create one to provide for the
@@ -237,8 +237,8 @@ The kwds argument holds a Python dictionary whose keys are the names
 of the keyword arguments and whose values are the corresponding
 keyword-argument values. This dictionary can be processed however you
 see fit. The easiest way to handle it, however, is to replace the
-:cfunc:`PyArg_ParseTuple` (args, format_string, addresses...) function with
-a call to :cfunc:`PyArg_ParseTupleAndKeywords` (args, kwds, format_string,
+:c:func:`PyArg_ParseTuple` (args, format_string, addresses...) function with
+a call to :c:func:`PyArg_ParseTupleAndKeywords` (args, kwds, format_string,
 char \*kwlist[], addresses...). The kwlist parameter to this function
 is a ``NULL`` -terminated array of strings providing the expected
 keyword arguments.  There should be one string for each entry in the
@@ -268,8 +268,8 @@ counting are quite straightforward with the most common difficulty
 being not using DECREF on objects before exiting early from a routine
 due to some error. In second place, is the common error of not owning
 the reference on an object that is passed to a function or macro that
-is going to steal the reference ( *e.g.* :cfunc:`PyTuple_SET_ITEM`, and
-most functions that take :ctype:`PyArray_Descr` objects).
+is going to steal the reference ( *e.g.* :c:func:`PyTuple_SET_ITEM`, and
+most functions that take :c:type:`PyArray_Descr` objects).
 
 .. index::
    single: reference counting
@@ -278,26 +278,26 @@ Typically you get a new reference to a variable when it is created or
 is the return value of some function (there are some prominent
 exceptions, however --- such as getting an item out of a tuple or a
 dictionary). When you own the reference, you are responsible to make
-sure that :cfunc:`Py_DECREF` (var) is called when the variable is no
+sure that :c:func:`Py_DECREF` (var) is called when the variable is no
 longer necessary (and no other function has "stolen" its
 reference). Also, if you are passing a Python object to a function
 that will "steal" the reference, then you need to make sure you own it
-(or use :cfunc:`Py_INCREF` to get your own reference). You will also
+(or use :c:func:`Py_INCREF` to get your own reference). You will also
 encounter the notion of borrowing a reference. A function that borrows
 a reference does not alter the reference count of the object and does
 not expect to "hold on "to the reference. It's just going to use the
-object temporarily.  When you use :cfunc:`PyArg_ParseTuple` or
-:cfunc:`PyArg_UnpackTuple` you receive a borrowed reference to the
+object temporarily.  When you use :c:func:`PyArg_ParseTuple` or
+:c:func:`PyArg_UnpackTuple` you receive a borrowed reference to the
 objects in the tuple and should not alter their reference count inside
 your function. With practice, you can learn to get reference counting
 right, but it can be frustrating at first.
 
-One common source of reference-count errors is the :cfunc:`Py_BuildValue`
+One common source of reference-count errors is the :c:func:`Py_BuildValue`
 function. Pay careful attention to the difference between the 'N'
 format character and the 'O' format character. If you create a new
 object in your subroutine (such as an output array), and you are
 passing it back in a tuple of return values, then you should most-
-likely use the 'N' format character in :cfunc:`Py_BuildValue`. The 'O'
+likely use the 'N' format character in :c:func:`Py_BuildValue`. The 'O'
 character will increase the reference count by one. This will leave
 the caller with two reference counts for a brand-new array.  When the
 variable is deleted and the reference count decremented by one, there
@@ -325,10 +325,10 @@ The method is to
    dimensions.
 
     1. By converting it from some Python object using
-       :cfunc:`PyArray_FromAny` or a macro built on it.
+       :c:func:`PyArray_FromAny` or a macro built on it.
 
     2. By constructing a new ndarray of your desired shape and type
-       using :cfunc:`PyArray_NewFromDescr` or a simpler macro or function
+       using :c:func:`PyArray_NewFromDescr` or a simpler macro or function
        based on it.
 
 
@@ -339,7 +339,7 @@ The method is to
 
 4. If you are writing the algorithm, then I recommend that you use the
    stride information contained in the array to access the elements of
-   the array (the :cfunc:`PyArray_GETPTR` macros make this painless). Then,
+   the array (the :c:func:`PyArray_GETPTR` macros make this painless). Then,
    you can relax your requirements so as not to force a single-segment
    array and the data-copying that might result.
 
@@ -350,16 +350,16 @@ Converting an arbitrary sequence object
 ---------------------------------------
 
 The main routine for obtaining an array from any Python object that
-can be converted to an array is :cfunc:`PyArray_FromAny`. This
+can be converted to an array is :c:func:`PyArray_FromAny`. This
 function is very flexible with many input arguments. Several macros
-make it easier to use the basic function. :cfunc:`PyArray_FROM_OTF` is
+make it easier to use the basic function. :c:func:`PyArray_FROM_OTF` is
 arguably the most useful of these macros for the most common uses.  It
 allows you to convert an arbitrary Python object to an array of a
 specific builtin data-type ( *e.g.* float), while specifying a
 particular set of requirements ( *e.g.* contiguous, aligned, and
 writeable). The syntax is
 
-.. cfunction:: PyObject *PyArray_FROM_OTF(PyObject* obj, int typenum, int requirements)
+.. c:function:: PyObject *PyArray_FROM_OTF(PyObject* obj, int typenum, int requirements)
 
     Return an ndarray from any Python object, *obj*, that can be
     converted to an array. The number of dimensions in the returned
@@ -385,37 +385,37 @@ writeable). The syntax is
         and 4) any scalar object (becomes a zero-dimensional
         array). Sub-classes of the ndarray that otherwise fit the
         requirements will be passed through. If you want to ensure
-        a base-class ndarray, then use :cdata:`NPY_ENSUREARRAY` in the
+        a base-class ndarray, then use :c:data:`NPY_ENSUREARRAY` in the
         requirements flag. A copy is made only if necessary. If you
-        want to guarantee a copy, then pass in :cdata:`NPY_ENSURECOPY`
+        want to guarantee a copy, then pass in :c:data:`NPY_ENSURECOPY`
         to the requirements flag.
 
     *typenum*
 
-        One of the enumerated types or :cdata:`NPY_NOTYPE` if the data-type
+        One of the enumerated types or :c:data:`NPY_NOTYPE` if the data-type
         should be determined from the object itself. The C-based names
         can be used:
 
-            :cdata:`NPY_BOOL`, :cdata:`NPY_BYTE`, :cdata:`NPY_UBYTE`,
-            :cdata:`NPY_SHORT`, :cdata:`NPY_USHORT`, :cdata:`NPY_INT`,
-            :cdata:`NPY_UINT`, :cdata:`NPY_LONG`, :cdata:`NPY_ULONG`,
-            :cdata:`NPY_LONGLONG`, :cdata:`NPY_ULONGLONG`, :cdata:`NPY_DOUBLE`,
-            :cdata:`NPY_LONGDOUBLE`, :cdata:`NPY_CFLOAT`, :cdata:`NPY_CDOUBLE`,
-            :cdata:`NPY_CLONGDOUBLE`, :cdata:`NPY_OBJECT`.
+            :c:data:`NPY_BOOL`, :c:data:`NPY_BYTE`, :c:data:`NPY_UBYTE`,
+            :c:data:`NPY_SHORT`, :c:data:`NPY_USHORT`, :c:data:`NPY_INT`,
+            :c:data:`NPY_UINT`, :c:data:`NPY_LONG`, :c:data:`NPY_ULONG`,
+            :c:data:`NPY_LONGLONG`, :c:data:`NPY_ULONGLONG`, :c:data:`NPY_DOUBLE`,
+            :c:data:`NPY_LONGDOUBLE`, :c:data:`NPY_CFLOAT`, :c:data:`NPY_CDOUBLE`,
+            :c:data:`NPY_CLONGDOUBLE`, :c:data:`NPY_OBJECT`.
 
         Alternatively, the bit-width names can be used as supported on the
         platform. For example:
 
-            :cdata:`NPY_INT8`, :cdata:`NPY_INT16`, :cdata:`NPY_INT32`,
-            :cdata:`NPY_INT64`, :cdata:`NPY_UINT8`,
-            :cdata:`NPY_UINT16`, :cdata:`NPY_UINT32`,
-            :cdata:`NPY_UINT64`, :cdata:`NPY_FLOAT32`,
-            :cdata:`NPY_FLOAT64`, :cdata:`NPY_COMPLEX64`,
-            :cdata:`NPY_COMPLEX128`.
+            :c:data:`NPY_INT8`, :c:data:`NPY_INT16`, :c:data:`NPY_INT32`,
+            :c:data:`NPY_INT64`, :c:data:`NPY_UINT8`,
+            :c:data:`NPY_UINT16`, :c:data:`NPY_UINT32`,
+            :c:data:`NPY_UINT64`, :c:data:`NPY_FLOAT32`,
+            :c:data:`NPY_FLOAT64`, :c:data:`NPY_COMPLEX64`,
+            :c:data:`NPY_COMPLEX128`.
 
         The object will be converted to the desired type only if it
         can be done without losing precision. Otherwise ``NULL`` will
-        be returned and an error raised. Use :cdata:`NPY_FORCECAST` in the
+        be returned and an error raised. Use :c:data:`NPY_FORCECAST` in the
         requirements flag to override this behavior.
 
     *requirements*
@@ -439,58 +439,58 @@ writeable). The syntax is
         very generic pointer to memory.  This flag allows specification
         of the desired properties of the returned array object. All
         of the flags are explained in the detailed API chapter. The
-        flags most commonly needed are :cdata:`NPY_ARRAY_IN_ARRAY`,
-        :cdata:`NPY_OUT_ARRAY`, and :cdata:`NPY_ARRAY_INOUT_ARRAY`:
+        flags most commonly needed are :c:data:`NPY_ARRAY_IN_ARRAY`,
+        :c:data:`NPY_OUT_ARRAY`, and :c:data:`NPY_ARRAY_INOUT_ARRAY`:
 
-        .. cvar:: NPY_ARRAY_IN_ARRAY
+        .. c:var:: NPY_ARRAY_IN_ARRAY
 
-            Equivalent to :cdata:`NPY_ARRAY_C_CONTIGUOUS` \|
-            :cdata:`NPY_ARRAY_ALIGNED`. This combination of flags is useful
+            Equivalent to :c:data:`NPY_ARRAY_C_CONTIGUOUS` \|
+            :c:data:`NPY_ARRAY_ALIGNED`. This combination of flags is useful
             for arrays that must be in C-contiguous order and aligned.
             These kinds of arrays are usually input arrays for some
             algorithm.
 
-        .. cvar:: NPY_ARRAY_OUT_ARRAY
+        .. c:var:: NPY_ARRAY_OUT_ARRAY
 
-            Equivalent to :cdata:`NPY_ARRAY_C_CONTIGUOUS` \|
-            :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_WRITEABLE`. This
+            Equivalent to :c:data:`NPY_ARRAY_C_CONTIGUOUS` \|
+            :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE`. This
             combination of flags is useful to specify an array that is
             in C-contiguous order, is aligned, and can be written to
             as well. Such an array is usually returned as output
             (although normally such output arrays are created from
             scratch).
 
-        .. cvar:: NPY_ARRAY_INOUT_ARRAY
+        .. c:var:: NPY_ARRAY_INOUT_ARRAY
 
-            Equivalent to :cdata:`NPY_ARRAY_C_CONTIGUOUS` \|
-            :cdata:`NPY_ARRAY_ALIGNED` \| :cdata:`NPY_ARRAY_WRITEABLE` \|
-            :cdata:`NPY_ARRAY_UPDATEIFCOPY`. This combination of flags is
+            Equivalent to :c:data:`NPY_ARRAY_C_CONTIGUOUS` \|
+            :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+            :c:data:`NPY_ARRAY_UPDATEIFCOPY`. This combination of flags is
             useful to specify an array that will be used for both
             input and output. If a copy is needed, then when the
-            temporary is deleted (by your use of :cfunc:`Py_DECREF` at
+            temporary is deleted (by your use of :c:func:`Py_DECREF` at
             the end of the interface routine), the temporary array
             will be copied back into the original array passed in. Use
-            of the :cdata:`NPY_ARRAY_UPDATEIFCOPY` flag requires that the input
+            of the :c:data:`NPY_ARRAY_UPDATEIFCOPY` flag requires that the input
             object is already an array (because other objects cannot
             be automatically updated in this fashion). If an error
-            occurs use :cfunc:`PyArray_DECREF_ERR` (obj) on an array
-            with the :cdata:`NPY_ARRAY_UPDATEIFCOPY` flag set. This will
+            occurs use :c:func:`PyArray_DECREF_ERR` (obj) on an array
+            with the :c:data:`NPY_ARRAY_UPDATEIFCOPY` flag set. This will
             delete the array without causing the contents to be copied
             back into the original array.
 
 
         Other useful flags that can be OR'd as additional requirements are:
 
-        .. cvar:: NPY_ARRAY_FORCECAST
+        .. c:var:: NPY_ARRAY_FORCECAST
 
             Cast to the desired type, even if it can't be done without losing
             information.
 
-        .. cvar:: NPY_ARRAY_ENSURECOPY
+        .. c:var:: NPY_ARRAY_ENSURECOPY
 
             Make sure the resulting array is a copy of the original.
 
-        .. cvar:: NPY_ARRAY_ENSUREARRAY
+        .. c:var:: NPY_ARRAY_ENSUREARRAY
 
             Make sure the resulting object is an actual ndarray and not a sub-
             class.
@@ -499,8 +499,8 @@ writeable). The syntax is
 
     Whether or not an array is byte-swapped is determined by the
     data-type of the array. Native byte-order arrays are always
-    requested by :cfunc:`PyArray_FROM_OTF` and so there is no need for
-    a :cdata:`NPY_ARRAY_NOTSWAPPED` flag in the requirements argument. There
+    requested by :c:func:`PyArray_FROM_OTF` and so there is no need for
+    a :c:data:`NPY_ARRAY_NOTSWAPPED` flag in the requirements argument. There
     is also no way to get a byte-swapped array from this routine.
 
 
@@ -512,29 +512,29 @@ code. Perhaps an output array is needed and you don't want the caller
 to have to supply it. Perhaps only a temporary array is needed to hold
 an intermediate calculation. Whatever the need there are simple ways
 to get an ndarray object of whatever data-type is needed. The most
-general function for doing this is :cfunc:`PyArray_NewFromDescr`. All array
+general function for doing this is :c:func:`PyArray_NewFromDescr`. All array
 creation functions go through this heavily re-used code. Because of
 its flexibility, it can be somewhat confusing to use. As a result,
 simpler forms exist that are easier to use.
 
-.. cfunction:: PyObject *PyArray_SimpleNew(int nd, npy_intp* dims, int typenum)
+.. c:function:: PyObject *PyArray_SimpleNew(int nd, npy_intp* dims, int typenum)
 
     This function allocates new memory and places it in an ndarray
     with *nd* dimensions whose shape is determined by the array of
     at least *nd* items pointed to by *dims*. The memory for the
-    array is uninitialized (unless typenum is :cdata:`NPY_OBJECT` in
+    array is uninitialized (unless typenum is :c:data:`NPY_OBJECT` in
     which case each element in the array is set to NULL). The
     *typenum* argument allows specification of any of the builtin
-    data-types such as :cdata:`NPY_FLOAT` or :cdata:`NPY_LONG`. The
+    data-types such as :c:data:`NPY_FLOAT` or :c:data:`NPY_LONG`. The
     memory for the array can be set to zero if desired using
-    :cfunc:`PyArray_FILLWBYTE` (return_object, 0).
+    :c:func:`PyArray_FILLWBYTE` (return_object, 0).
 
-.. cfunction:: PyObject *PyArray_SimpleNewFromData( int nd, npy_intp* dims, int typenum, void* data)
+.. c:function:: PyObject *PyArray_SimpleNewFromData( int nd, npy_intp* dims, int typenum, void* data)
 
     Sometimes, you want to wrap memory allocated elsewhere into an
     ndarray object for downstream use. This routine makes it
     straightforward to do that. The first three arguments are the same
-    as in :cfunc:`PyArray_SimpleNew`, the final argument is a pointer to a
+    as in :c:func:`PyArray_SimpleNew`, the final argument is a pointer to a
     block of contiguous memory that the ndarray should use as it's
     data-buffer which will be interpreted in C-style contiguous
     fashion. A new reference to an ndarray is returned, but the
@@ -556,31 +556,31 @@ simpler forms exist that are easier to use.
 Getting at ndarray memory and accessing elements of the ndarray
 ---------------------------------------------------------------
 
-If obj is an ndarray (:ctype:`PyArrayObject *`), then the data-area of the
-ndarray is pointed to by the void* pointer :cfunc:`PyArray_DATA` (obj) or
-the char* pointer :cfunc:`PyArray_BYTES` (obj). Remember that (in general)
+If obj is an ndarray (:c:type:`PyArrayObject *`), then the data-area of the
+ndarray is pointed to by the void* pointer :c:func:`PyArray_DATA` (obj) or
+the char* pointer :c:func:`PyArray_BYTES` (obj). Remember that (in general)
 this data-area may not be aligned according to the data-type, it may
 represent byte-swapped data, and/or it may not be writeable. If the
 data area is aligned and in native byte-order, then how to get at a
 specific element of the array is determined only by the array of
-npy_intp variables, :cfunc:`PyArray_STRIDES` (obj). In particular, this
+npy_intp variables, :c:func:`PyArray_STRIDES` (obj). In particular, this
 c-array of integers shows how many **bytes** must be added to the
 current element pointer to get to the next element in each dimension.
-For arrays less than 4-dimensions there are :cfunc:`PyArray_GETPTR{k}`
+For arrays less than 4-dimensions there are :c:func:`PyArray_GETPTR{k}`
 (obj, ...) macros where {k} is the integer 1, 2, 3, or 4 that make
 using the array strides easier. The arguments .... represent {k} non-
 negative integer indices into the array. For example, suppose ``E`` is
 a 3-dimensional ndarray. A (void*) pointer to the element ``E[i,j,k]``
-is obtained as :cfunc:`PyArray_GETPTR3` (E, i, j, k).
+is obtained as :c:func:`PyArray_GETPTR3` (E, i, j, k).
 
 As explained previously, C-style contiguous arrays and Fortran-style
 contiguous arrays have particular striding patterns. Two array flags
-(:cdata:`NPY_C_CONTIGUOUS` and :cdata`NPY_F_CONTIGUOUS`) indicate
+(:c:data:`NPY_C_CONTIGUOUS` and :cdata`NPY_F_CONTIGUOUS`) indicate
 whether or not the striding pattern of a particular array matches the
 C-style contiguous or Fortran-style contiguous or neither. Whether or
 not the striding pattern matches a standard C or Fortran one can be
-tested Using :cfunc:`PyArray_ISCONTIGUOUS` (obj) and
-:cfunc:`PyArray_ISFORTRAN` (obj) respectively. Most third-party
+tested Using :c:func:`PyArray_ISCONTIGUOUS` (obj) and
+:c:func:`PyArray_ISFORTRAN` (obj) respectively. Most third-party
 libraries expect contiguous arrays.  But, often it is not difficult to
 support general-purpose striding. I encourage you to use the striding
 information in your own code whenever possible, and reserve

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -1058,7 +1058,7 @@ What follows is the full specification of PyUFunc_FromFuncAndData, which
 automatically generates a ufunc from a C function with the correct signature.
 
 
-.. cfunction:: PyObject *PyUFunc_FromFuncAndData( PyUFuncGenericFunction* func,
+.. c:function:: PyObject *PyUFunc_FromFuncAndData( PyUFuncGenericFunction* func,
    void** data, char* types, int ntypes, int nin, int nout, int identity,
    char* name, char* doc, int check_return)
 
@@ -1069,7 +1069,7 @@ automatically generates a ufunc from a C function with the correct signature.
         ``PyUFuncGenericFunction`` function. This function has the following
         signature. An example of a valid 1d loop function is also given.
 
-        .. cfunction:: void loop1d(char** args, npy_intp* dimensions,
+        .. c:function:: void loop1d(char** args, npy_intp* dimensions,
            npy_intp* steps, void* data)
 
         *args*
@@ -1120,7 +1120,7 @@ automatically generates a ufunc from a C function with the correct signature.
         every loop function defined for this ufunc. This data will be passed
         in to the 1-d loop. One common use of this data variable is to pass in
         an actual function to call to compute the result when a generic 1-d
-        loop (e.g. :cfunc:`PyUFunc_d_d`) is being used.
+        loop (e.g. :c:func:`PyUFunc_d_d`) is being used.
 
     *types*
 
@@ -1137,8 +1137,8 @@ automatically generates a ufunc from a C function with the correct signature.
 
             static char types[3] = {NPY_INT, NPY_DOUBLE, NPY_CDOUBLE}
 
-        The bit-width names can also be used (e.g. :cdata:`NPY_INT32`,
-        :cdata:`NPY_COMPLEX128` ) if desired.
+        The bit-width names can also be used (e.g. :c:data:`NPY_INT32`,
+        :c:data:`NPY_COMPLEX128` ) if desired.
 
     *ntypes*
 
@@ -1155,8 +1155,8 @@ automatically generates a ufunc from a C function with the correct signature.
 
     *identity*
 
-        Either :cdata:`PyUFunc_One`, :cdata:`PyUFunc_Zero`,
-        :cdata:`PyUFunc_None`. This specifies what should be returned when
+        Either :c:data:`PyUFunc_One`, :c:data:`PyUFunc_Zero`,
+        :c:data:`PyUFunc_None`. This specifies what should be returned when
         an empty array is passed to the reduce method of the ufunc.
 
     *name*

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3736,37 +3736,6 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('itemset',
     """))
 
 
-add_newdoc('numpy.core.multiarray', 'ndarray', ('setasflat',
-    """
-    a.setasflat(arr)
-
-    Equivalent to a.flat = arr.flat, but is generally more efficient.
-    This function does not check for overlap, so if ``arr`` and ``a``
-    are viewing the same data with different strides, the results will
-    be unpredictable.
-
-    Parameters
-    ----------
-    arr : array_like
-        The array to copy into a.
-
-    Examples
-    --------
-    >>> a = np.arange(2*4).reshape(2,4)[:,:-1]; a
-    array([[0, 1, 2],
-           [4, 5, 6]])
-    >>> b = np.arange(3*3, dtype='f4').reshape(3,3).T[::-1,:-1]; b
-    array([[ 2.,  5.],
-           [ 1.,  4.],
-           [ 0.,  3.]], dtype=float32)
-    >>> a.setasflat(b)
-    >>> a
-    array([[2, 5, 1],
-           [4, 0, 3]])
-
-    """))
-
-
 add_newdoc('numpy.core.multiarray', 'ndarray', ('max',
     """
     a.max(axis=None, out=None)

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -790,14 +790,16 @@ add_newdoc('numpy.core.multiarray', 'empty_like',
         The shape and data-type of `a` define these same attributes of the
         returned array.
     dtype : data-type, optional
-        .. versionadded:: 1.6.0
         Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
+
         .. versionadded:: 1.6.0
+    order : {'C', 'F', 'A', or 'K'}, optional
         Overrides the memory layout of the result. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if ``a`` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of ``a`` as closely
         as possible.
+
+        .. versionadded:: 1.6.0
     subok : bool, optional.
         If True, then the newly created array will use the sub-class
         type of 'a', otherwise it will be a base-class array. Defaults
@@ -1703,6 +1705,7 @@ add_newdoc('numpy.core.multiarray', 'promote_types',
     Notes
     -----
     .. versionadded:: 1.6.0
+
     Starting in NumPy 1.9, promote_types function now returns a valid string
     length when given an integer or float dtype as one argument and a string
     dtype as another argument. Previously it always returned the input string
@@ -5039,9 +5042,9 @@ add_newdoc('numpy.core.multiarray', 'bincount',
     weights : array_like, optional
         Weights, array of the same shape as `x`.
     minlength : int, optional
-        .. versionadded:: 1.6.0
-
         A minimum number of bins for the output array.
+
+        .. versionadded:: 1.6.0
 
     Returns
     -------
@@ -5164,9 +5167,10 @@ add_newdoc('numpy.core.multiarray', 'unravel_index',
     dims : tuple of ints
         The shape of the array to use for unraveling ``indices``.
     order : {'C', 'F'}, optional
-        .. versionadded:: 1.6.0
         Determines whether the indices should be viewed as indexing in
         row-major (C-style) or column-major (Fortran-style) order.
+
+        .. versionadded:: 1.6.0
 
     Returns
     -------

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -2652,7 +2652,7 @@ def asarray(obj, itemsize=None, unicode=None, order=None):
          end when comparing values
 
       3) vectorized string operations are provided as methods
-         (e.g. `str.endswith`) and infix operators (e.g. +, *, %)
+         (e.g. `str.endswith`) and infix operators (e.g. ``+``, ``*``,``%``)
 
     Parameters
     ----------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1049,9 +1049,10 @@ def searchsorted(a, v, side='left', sorter=None):
         If 'right', return the last such index.  If there is no suitable
         index, return either 0 or N (where N is the length of `a`).
     sorter : 1-D array_like, optional
-        .. versionadded:: 1.7.0
         Optional array of integer indices that sort array a into ascending
         order. They are typically the result of argsort.
+
+        .. versionadded:: 1.7.0
 
     Returns
     -------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -89,14 +89,16 @@ def zeros_like(a, dtype=None, order='K', subok=True):
         The shape and data-type of `a` define these same attributes of
         the returned array.
     dtype : data-type, optional
-        .. versionadded:: 1.6.0
         Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
+
         .. versionadded:: 1.6.0
+    order : {'C', 'F', 'A', or 'K'}, optional
         Overrides the memory layout of the result. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
         as possible.
+
+        .. versionadded:: 1.6.0
     subok : bool, optional.
         If True, then the newly created array will use the sub-class
         type of 'a', otherwise it will be a base-class array. Defaults
@@ -195,14 +197,16 @@ def ones_like(a, dtype=None, order='K', subok=True):
         The shape and data-type of `a` define these same attributes of
         the returned array.
     dtype : data-type, optional
-        .. versionadded:: 1.6.0
         Overrides the data type of the result.
-    order : {'C', 'F', 'A', or 'K'}, optional
+
         .. versionadded:: 1.6.0
+    order : {'C', 'F', 'A', or 'K'}, optional
         Overrides the memory layout of the result. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
         as possible.
+
+        .. versionadded:: 1.6.0
     subok : bool, optional.
         If True, then the newly created array will use the sub-class
         type of 'a', otherwise it will be a base-class array. Defaults
@@ -1016,8 +1020,9 @@ def outer(a, b, out=None):
         Second input vector.  Input is flattened if
         not already 1-dimensional.
     out : (M, N) ndarray, optional
-        .. versionadded:: 1.9.0
         A location where the result is stored
+
+        .. versionadded:: 1.9.0
 
     Returns
     -------
@@ -1494,6 +1499,7 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     Notes
     -----
     .. versionadded:: 1.9.0
+
     Supports full broadcasting of the inputs.
 
     Examples
@@ -2222,9 +2228,10 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     atol : float
         The absolute tolerance parameter (see Notes).
     equal_nan : bool
-        .. versionadded:: 1.10.0
         Whether to compare NaN's as equal.  If True, NaN's in `a` will be
         considered equal to NaN's in `b` in the output array.
+
+        .. versionadded:: 1.10.0
 
     Returns
     -------

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -9,6 +9,7 @@ values may be different by a factor). In addition, exec_command
 takes keyword arguments for (re-)defining environment variables.
 
 Provides functions:
+
   exec_command  --- execute command in a specified directory and
                     in the modified environment.
   find_executable --- locate a command using info from environment
@@ -21,28 +22,33 @@ Created: 11 January 2003
 Requires: Python 2.x
 
 Succesfully tested on:
-  os.name | sys.platform | comments
-  --------+--------------+----------
-  posix   | linux2       | Debian (sid) Linux, Python 2.1.3+, 2.2.3+, 2.3.3
-                           PyCrust 0.9.3, Idle 1.0.2
-  posix   | linux2       | Red Hat 9 Linux, Python 2.1.3, 2.2.2, 2.3.2
-  posix   | sunos5       | SunOS 5.9, Python 2.2, 2.3.2
-  posix   | darwin       | Darwin 7.2.0, Python 2.3
-  nt      | win32        | Windows Me
-                           Python 2.3(EE), Idle 1.0, PyCrust 0.7.2
-                           Python 2.1.1 Idle 0.8
-  nt      | win32        | Windows 98, Python 2.1.1. Idle 0.8
-  nt      | win32        | Cygwin 98-4.10, Python 2.1.1(MSC) - echo tests
-                           fail i.e. redefining environment variables may
-                           not work. FIXED: don't use cygwin echo!
-                           Comment: also `cmd /c echo` will not work
-                           but redefining environment variables do work.
-  posix   | cygwin       | Cygwin 98-4.10, Python 2.3.3(cygming special)
-  nt      | win32        | Windows XP, Python 2.3.3
+
+========  ============  =================================================
+os.name   sys.platform  comments
+========  ============  =================================================
+posix     linux2        Debian (sid) Linux, Python 2.1.3+, 2.2.3+, 2.3.3
+                        PyCrust 0.9.3, Idle 1.0.2
+posix     linux2        Red Hat 9 Linux, Python 2.1.3, 2.2.2, 2.3.2
+posix     sunos5        SunOS 5.9, Python 2.2, 2.3.2
+posix     darwin        Darwin 7.2.0, Python 2.3
+nt        win32         Windows Me
+                        Python 2.3(EE), Idle 1.0, PyCrust 0.7.2
+                        Python 2.1.1 Idle 0.8
+nt        win32         Windows 98, Python 2.1.1. Idle 0.8
+nt        win32         Cygwin 98-4.10, Python 2.1.1(MSC) - echo tests
+                        fail i.e. redefining environment variables may
+                        not work. FIXED: don't use cygwin echo!
+                        Comment: also `cmd /c echo` will not work
+                        but redefining environment variables do work.
+posix     cygwin        Cygwin 98-4.10, Python 2.3.3(cygming special)
+nt        win32         Windows XP, Python 2.3.3
+========  ============  =================================================
 
 Known bugs:
-- Tests, that send messages to stderr, fail when executed from MSYS prompt
+
+* Tests, that send messages to stderr, fail when executed from MSYS prompt
   because the messages are lost at some point.
+
 """
 from __future__ import division, absolute_import, print_function
 
@@ -148,21 +154,33 @@ def _supports_fileno(stream):
     else:
         return False
 
-def exec_command( command,
-                  execute_in='', use_shell=None, use_tee = None,
-                  _with_python = 1,
-                  **env ):
-    """ Return (status,output) of executed command.
+def exec_command(command, execute_in='', use_shell=None, use_tee=None,
+                 _with_python = 1, **env ):
+    """
+    Return (status,output) of executed command.
 
-    command is a concatenated string of executable and arguments.
-    The output contains both stdout and stderr messages.
-    The following special keyword arguments can be used:
-      use_shell - execute `sh -c command`
-      use_tee   - pipe the output of command through tee
-      execute_in - before run command `cd execute_in` and after `cd -`.
+    Parameters
+    ----------
+    command : str
+        A concatenated string of executable and arguments.
+    execute_in : str
+        Before running command ``cd execute_in`` and after ``cd -``.
+    use_shell : {bool, None}, optional
+        If True, execute ``sh -c command``. Default None (True)
+    use_tee : {bool, None}, optional
+        If True use tee. Default None (True)
 
+
+    Returns
+    -------
+    res : str
+        Both stdout and stderr messages.
+
+    Notes
+    -----
     On NT, DOS systems the returned status is correct for external commands.
     Wild cards will not work for non-posix systems or when use_shell=0.
+
     """
     log.debug('exec_command(%r,%s)' % (command,\
          ','.join(['%s=%r'%kv for kv in env.items()])))

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -264,7 +264,6 @@ Glossary
        (matrix multiplication) and ``**`` (matrix power), defined::
 
          >>> x = np.mat([[1, 2], [3, 4]])
-
          >>> x
          matrix([[1, 2],
                  [3, 4]])
@@ -278,18 +277,17 @@ Glossary
        method called ``repeat``::
 
          >>> x = np.array([1, 2, 3])
-
          >>> x.repeat(2)
          array([1, 1, 2, 2, 3, 3])
 
    ndarray
        See *array*.
-    
+
    record array
        An `ndarray`_ with `structured data type`_ which has been subclassed as
        np.recarray and whose dtype is of type np.record, making the
        fields of its data type to be accessible by attribute.
-       
+
    reference
        If ``a`` is a reference to ``b``, then ``(a is b) == True``.  Therefore,
        ``a`` and ``b`` are different names for the same Python object.
@@ -360,7 +358,6 @@ Glossary
        changed.  Similar to a list, it can be indexed and sliced::
 
          >>> x = (1, 'one', [1, 2])
-
          >>> x
          (1, 'one', [1, 2])
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -114,9 +114,10 @@ def unique(ar, return_index=False, return_inverse=False, return_counts=False):
         If True, also return the indices of the unique array that can be used
         to reconstruct `ar`.
     return_counts : bool, optional
-        .. versionadded:: 1.9.0
         If True, also return the number of times each unique value comes up
         in `ar`.
+
+        .. versionadded:: 1.9.0
 
     Returns
     -------
@@ -129,9 +130,10 @@ def unique(ar, return_index=False, return_inverse=False, return_counts=False):
         The indices to reconstruct the (flattened) original array from the
         unique array. Only provided if `return_inverse` is True.
     unique_counts : ndarray, optional
-        .. versionadded:: 1.9.0
         The number of times each of the unique values comes up in the
         original array. Only provided if `return_counts` is True.
+
+        .. versionadded:: 1.9.0
 
     See Also
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1146,10 +1146,11 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         Value to return for `x > xp[-1]`, default is `fp[-1]`.
 
     period : None or float, optional
-        .. versionadded:: 1.10.0
         A period for the x-coordinates. This parameter allows the proper
         interpolation of angular x-coordinates. Parameters `left` and `right`
         are ignored if `period` is specified.
+
+        .. versionadded:: 1.10.0
 
     Returns
     -------
@@ -1863,22 +1864,25 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None, fweights=None, aweights=None):
         normalization is by ``N``. These values can be overridden by using the
         keyword ``ddof`` in numpy versions >= 1.5.
     ddof : int, optional
-        .. versionadded:: 1.5
         If not ``None`` the default value implied by `bias` is overridden.
         Note that ``ddof=1`` will return the unbiased estimate, even if both
         `fweights` and `aweights` are specified, and ``ddof=0`` will return
         the simple average. See the notes for the details. The default value
         is ``None``.
+
+        .. versionadded:: 1.5
     fweights : array_like, int, optional
-        .. versionadded:: 1.10
         1-D array of integer freguency weights; the number of times each
         observation vector should be repeated.
-    aweights : array_like, optional
+
         .. versionadded:: 1.10
+    aweights : array_like, optional
         1-D array of observation vector weights. These relative weights are
         typically large for observations considered "important" and smaller for
         observations considered less "important". If ``ddof=0`` the array of
         weights can be used to assign probabilities to observation vectors.
+
+        .. versionadded:: 1.10
 
     Returns
     -------
@@ -2054,11 +2058,13 @@ def corrcoef(x, y=None, rowvar=1, bias=np._NoValue, ddof=np._NoValue):
         is transposed: each column represents a variable, while the rows
         contain observations.
     bias : _NoValue, optional
-        .. deprecated:: 1.10.0
         Has no affect, do not use.
+
+        .. deprecated:: 1.10.0
     ddof : _NoValue, optional
-        .. deprecated:: 1.10.0
         Has no affect, do not use.
+
+        .. deprecated:: 1.10.0
 
     Returns
     -------

--- a/numpy/lib/info.py
+++ b/numpy/lib/info.py
@@ -74,6 +74,7 @@ vstack           Stack arrays vertically (row on row)
 hstack           Stack arrays horizontally (column on column)
 column_stack     Stack 1D arrays as columns into 2D array
 dstack           Stack arrays depthwise (along third dimension)
+stack            Stack arrays along a new axis
 split            Divide array into a list of sub-arrays
 hsplit           Split into columns
 vsplit           Split into rows

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -745,6 +745,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     lines with missing values.
 
     .. versionadded:: 1.10.0
+
     The strings produced by the Python float.hex method can be used as
     input for floats.
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -238,8 +238,8 @@ def tensorsolve(a, b, axes=None):
         Coefficient tensor, of shape ``b.shape + Q``. `Q`, a tuple, equals
         the shape of that sub-tensor of `a` consisting of the appropriate
         number of its rightmost indices, and must be such that
-       ``prod(Q) == prod(b.shape)`` (in which sense `a` is said to be
-       'square').
+        ``prod(Q) == prod(b.shape)`` (in which sense `a` is said to be
+        'square').
     b : array_like
         Right-hand tensor, which can be of any shape.
     axes : tuple of ints, optional
@@ -321,6 +321,7 @@ def solve(a, b):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -480,6 +481,7 @@ def inv(a):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -559,6 +561,7 @@ def cholesky(a):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -860,6 +863,7 @@ def eigvals(a):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -950,6 +954,7 @@ def eigvalsh(a, UPLO='L'):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1035,6 +1040,7 @@ def eig(a):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1173,6 +1179,7 @@ def eigh(a, UPLO='L'):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1282,6 +1289,7 @@ def svd(a, full_matrices=1, compute_uv=1):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1653,10 +1661,12 @@ def slogdet(a):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
     .. versionadded:: 1.6.0.
+
     The determinant is computed via LU factorization using the LAPACK
     routine z/dgetrf.
 
@@ -1732,6 +1742,7 @@ def det(a):
     -----
 
     .. versionadded:: 1.8.0
+
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1983,10 +1994,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
         are computed.  If `axis` is None then either a vector norm (when `x`
         is 1-D) or a matrix norm (when `x` is 2-D) is returned.
     keepdims : bool, optional
-        .. versionadded:: 1.10.0
         If this is set to True, the axes which are normed over are left in the
         result as dimensions with size one.  With this option the result will
         broadcast correctly against the original `x`.
+
+        .. versionadded:: 1.10.0
 
     Returns
     -------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1371,11 +1371,11 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
         in `x`, the corresponding value is masked in `y`.
         If False, raises a `ValueError` exception when some values are missing.
     ddof : {None, int}, optional
-        .. versionadded:: 1.5
         If not ``None`` normalization is by ``(N - ddof)``, where ``N`` is
         the number of observations; this overrides the value implied by
         ``bias``. The default value is ``None``.
 
+        .. versionadded:: 1.5
 
     Raises
     ------
@@ -1430,16 +1430,18 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
         is transposed: each column represents a variable, while the rows
         contain observations.
     bias : _NoValue, optional
-        .. deprecated:: 1.10.0
         Has no affect, do not use.
+
+        .. deprecated:: 1.10.0
     allow_masked : bool, optional
         If True, masked values are propagated pair-wise: if a value is masked
         in `x`, the corresponding value is masked in `y`.
         If False, raises an exception.  Because `bias` is deprecated, this
         argument needs to be treated as keyword only to avoid a warning.
     ddof : _NoValue, optional
-        .. deprecated:: 1.10.0
         Has no affect, do not use.
+
+        .. deprecated:: 1.10.0
 
     See Also
     --------

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -287,7 +287,7 @@ class TestMatrixReturn(TestCase):
             'partition', 'argpartition',
             'take', 'tofile', 'tolist', 'tostring', 'tobytes', 'all', 'any',
             'sum', 'argmax', 'argmin', 'min', 'max', 'mean', 'var', 'ptp',
-            'prod', 'std', 'ctypes', 'itemset', 'setasflat'
+            'prod', 'std', 'ctypes', 'itemset',
             ]
         for attrib in dir(a):
             if attrib.startswith('_') or attrib in excluded_methods:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2430,7 +2430,7 @@ cdef class RandomState:
         For a one-sided t-test, how far out in the distribution does the t
         statistic appear?
 
-        >>> >>> np.sum(s<t) / float(len(s))
+        >>> np.sum(s<t) / float(len(s))
         0.0090699999999999999  #random
 
         So the p-value is about 0.009, which says the null hypothesis has a
@@ -3285,7 +3285,7 @@ cdef class RandomState:
         ...    b.append(np.product(a))
 
         >>> b = np.array(b) / np.min(b) # scale values to be positive
-        >>> count, bins, ignored = plt.hist(b, 100, normed=True, align='center')
+        >>> count, bins, ignored = plt.hist(b, 100, normed=True, align='mid')
         >>> sigma = np.std(np.log(b))
         >>> mu = np.mean(np.log(b))
 


### PR DESCRIPTION
Sphinx directive updates, docstring fixes, and example fixes.

There are a few remaining warnings that I have't managed to track down, plus some involving the `Raises` section that I think originate in `numpydoc`,
