### PR TITLE
BUG: Fix handling of dependencies between libraries

### DIFF
--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -290,6 +290,6 @@ class build_clib(old_build_clib):
         clib_libraries = build_info.get('libraries', [])
         for lname, binfo in libraries:
             if lname in clib_libraries:
-                clib_libraries.extend(binfo[1].get('libraries', []))
+                clib_libraries.extend(binfo.get('libraries', []))
         if clib_libraries:
             build_info['libraries'] = clib_libraries


### PR DESCRIPTION
This bug shows up when one library is listed as depending on another library that is added as a part of the same configuration step. For example, without this, something like the following would fail:

```
def configuration():
    config = Configuration()
    config.add_library('lib1',
                       sources=['lib1.f'])
    config.add_library('lib2',
                       sources=['lib2.f'],
                       libraries = ['lib1'])
    config.add_extension('pymod',
                         sources=['pymod.c'],
                         libraries=['lib2'])
    return config
```

I'm not sure if NumPy can handle traversing arbitrary dependencies between libraries, but this patch is still an improvement.
