### PR TITLE
WIP: MAINT: Add deprecation warning to views of multi-field indexes

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -29,6 +29,33 @@ Future Changes
   other numpy functions such as np.mean. In particular, this means calls which
   returned a scalar may return a 0-d subclass object instead.
 
+Multiple-field manipulation of structured arrays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In 1.13 the behavior of structured arrays involving multiple fields will change
+in two ways:
+
+First, indexing a structured array with multiple fields (eg,
+``arr[['f1', 'f3']]``) will return a view into the original array in 1.13,
+instead of a copy. Note the returned view will have extra padding bytes
+corresponding to intervening fields in the original array, unlike the copy in
+1.12, which will affect code such as ``arr[['f1', 'f3']].view(newdtype)``.
+
+Second, for numpy versions 1.6 to 1.12 assignment between structured arrays
+occurs "by field name": Fields in the dst array are set to the
+identically-named field in the src or to 0 if the src does not have a field:
+
+    >>> a = np.array([(1,2),(3,4)], dtype=[('x', 'i4'), ('y', 'i4')])
+    >>> b = np.ones(2, dtype=[('z', 'i4'), ('y', 'i4'), ('x', 'i4')])
+    >>> b[:] = a
+    >>> b
+    array([(0, 2, 1), (0, 4, 3)],
+          dtype=[('z', '<i4'), ('y', '<i4'), ('x', '<i4')])
+
+In 1.13 assignment will instead occur "by position": The Nth field of the dst
+will be set to the Nth field of the src, regardless of field name. The old
+behavior can be obtained by using indexing to reorder the fields before
+assignment, eg ``b[['x', 'y']] = a[['y', 'x']]``.
+
 
 Compatibility notes
 ===================

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -601,6 +601,20 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
         subtype = Py_TYPE(self);
     }
 
+    if (type != NULL && (PyArray_FLAGS(self) & NPY_ARRAY_WARN_ON_WRITE)) {
+        const char *msg =
+            "Numpy has detected that you may be viewing or writing to an array "
+            "returned by selecting multiple fields in a structured array. \n\n"
+            "This code may break in numpy 1.13 because this will return a view "
+            "instead of a copy -- see release notes for details.";
+        /* 2016-09-19, 1.12 */
+        if (DEPRECATE_FUTUREWARNING(msg) < 0) {
+            return NULL;
+        }
+        /* Only warn once per array */
+        PyArray_CLEARFLAGS(self, NPY_ARRAY_WARN_ON_WRITE);
+    }
+
     flags = PyArray_FLAGS(self);
 
     dtype = PyArray_DESCR(self);

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2746,6 +2746,31 @@ get_fields_transfer_function(int aligned,
     else {
         /* Keeps track of the names we already used */
         PyObject *used_names_dict = NULL;
+        int cmpval;
+
+        const char *msg =
+            "Assignment between structured arrays with different field names "
+            "will change in numpy 1.13.\n\n"
+            "Previously fields in the dst would be set to the value of the "
+            "identically-named field in the src. In numpy 1.13 fields will "
+            "instead be assigned 'by position': The Nth field of the dst "
+            "will be set to the Nth field of the src array.\n\n"
+            "See the release notes for details";
+        /*
+         * 2016-09-19, 1.12
+         * Warn if the field names of the dst and src are not
+         * identical, since then behavior will change in 1.13.
+         */
+        cmpval = PyObject_RichCompareBool(src_dtype->names,
+                                          dst_dtype->names, Py_EQ);
+        if (PyErr_Occurred()) {
+            return NPY_FAIL;
+        }
+        if (cmpval != 1) {
+            if (DEPRECATE_FUTUREWARNING(msg) < 0) {
+                return NPY_FAIL;
+            }
+        }
 
         names = dst_dtype->names;
         names_size = PyTuple_GET_SIZE(dst_dtype->names);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1428,6 +1428,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
             return 0;
         }
 
+        PyArray_CLEARFLAGS(*view, NPY_ARRAY_WARN_ON_WRITE);
         viewcopy = PyObject_CallFunction(copyfunc, "O", *view);
         if (viewcopy == NULL) {
             Py_DECREF(*view);
@@ -1436,6 +1437,9 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
         }
         Py_DECREF(*view);
         *view = (PyArrayObject*)viewcopy;
+
+        /* warn when writing to the copy */
+        PyArray_ENABLEFLAGS(*view, NPY_ARRAY_WARN_ON_WRITE);
         return 0;
     }
     return -1;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1417,6 +1417,9 @@ array_deepcopy(PyArrayObject *self, PyObject *args)
         return NULL;
     }
     ret = (PyArrayObject *)PyArray_NewCopy(self, NPY_KEEPORDER);
+    if (ret == NULL) {
+        return NULL;
+    }
     if (PyDataType_REFCHK(PyArray_DESCR(self))) {
         copy = PyImport_ImportModule("copy");
         if (copy == NULL) {

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
@@ -8,7 +9,7 @@ from numpy.compat import asbytes, sixu
 from numpy.core.multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_raises, dec, HAS_REFCOUNT, suppress_warnings
+    assert_raises, assert_warns, dec, HAS_REFCOUNT, suppress_warnings
     )
 
 
@@ -1740,9 +1741,11 @@ def test_iter_buffered_cast_structured_type():
     sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', 'O')]
     sdt2 = [('d', 'u2'), ('a', 'O'), ('b', 'f8')]
     a = np.array([(1, 2, 3), (4, 5, 6)], dtype=sdt1)
-    i = nditer(a, ['buffered', 'refs_ok'], ['readonly'],
-                    casting='unsafe',
-                    op_dtypes=sdt2)
+    # New in 1.12: This behavior changes in 1.13, test for dep warning
+    with assert_warns(FutureWarning):
+        i = nditer(a, ['buffered', 'refs_ok'], ['readonly'],
+                        casting='unsafe',
+                        op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
     assert_equal([np.array(x_) for x_ in i],
                  [np.array((3, 1, 2), dtype=sdt2),
@@ -1752,9 +1755,11 @@ def test_iter_buffered_cast_structured_type():
     sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', 'O')]
     sdt2 = [('b', 'O'), ('a', 'f8')]
     a = np.array([(1, 2, 3), (4, 5, 6)], dtype=sdt1)
-    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
-                    casting='unsafe',
-                    op_dtypes=sdt2)
+    # New in 1.12: This behavior changes in 1.13, test for dep warning
+    with assert_warns(FutureWarning):
+        i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                        casting='unsafe',
+                        op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
     vals = []
     for x in i:
@@ -1768,9 +1773,11 @@ def test_iter_buffered_cast_structured_type():
     sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', [('a', 'i2'), ('b', 'i4')])]
     sdt2 = [('b', 'O'), ('a', 'f8')]
     a = np.array([(1, 2, (0, 9)), (4, 5, (20, 21))], dtype=sdt1)
-    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
-                    casting='unsafe',
-                    op_dtypes=sdt2)
+    # New in 1.12: This behavior changes in 1.13, test for dep warning
+    with assert_warns(FutureWarning):
+        i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                        casting='unsafe',
+                        op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
     vals = []
     for x in i:
@@ -1784,9 +1791,11 @@ def test_iter_buffered_cast_structured_type():
     sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', [('a', 'i2'), ('b', 'O')])]
     sdt2 = [('b', 'O'), ('a', 'f8')]
     a = np.array([(1, 2, (0, 9)), (4, 5, (20, 21))], dtype=sdt1)
-    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
-                    casting='unsafe',
-                    op_dtypes=sdt2)
+    # New in 1.12: This behavior changes in 1.13, test for dep warning
+    with assert_warns(FutureWarning):
+        i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                        casting='unsafe',
+                        op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
     vals = []
     for x in i:
@@ -1800,9 +1809,11 @@ def test_iter_buffered_cast_structured_type():
     sdt1 = [('b', 'O'), ('a', 'f8')]
     sdt2 = [('a', 'f4'), ('b', 'i8'), ('d', [('a', 'i2'), ('b', 'O')])]
     a = np.array([(1, 2), (4, 5)], dtype=sdt1)
-    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
-                    casting='unsafe',
-                    op_dtypes=sdt2)
+    # New in 1.12: This behavior changes in 1.13, test for dep warning
+    with assert_warns(FutureWarning):
+        i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                        casting='unsafe',
+                        op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
     vals = []
     for x in i:

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -3,13 +3,14 @@ from __future__ import division, absolute_import, print_function
 import sys
 import collections
 import pickle
+import warnings
 from os import path
 
 import numpy as np
 from numpy.compat import asbytes
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_array_almost_equal, assert_raises
+    assert_array_almost_equal, assert_raises, assert_warns
     )
 
 
@@ -126,8 +127,11 @@ class TestFromrecords(TestCase):
                                            ('c', 'i4,i4')]))
         assert_equal(r['c'].dtype.type, np.record)
         assert_equal(type(r['c']), np.recarray)
-        assert_equal(r[['a', 'b']].dtype.type, np.record)
-        assert_equal(type(r[['a', 'b']]), np.recarray)
+
+        # suppress deprecation warning in 1.12 (remove in 1.13)
+        with assert_warns(FutureWarning):
+            assert_equal(r[['a', 'b']].dtype.type, np.record)
+            assert_equal(type(r[['a', 'b']]), np.recarray)
 
         #and that it preserves subclasses (gh-6949)
         class C(np.recarray):
@@ -298,8 +302,11 @@ class TestRecord(TestCase):
 
     def test_out_of_order_fields(self):
         """Ticket #1431."""
-        x = self.data[['col1', 'col2']]
-        y = self.data[['col2', 'col1']]
+        # this test will be invalid in 1.13
+        # suppress deprecation warning in 1.12 (remove in 1.13)
+        with assert_warns(FutureWarning):
+            x = self.data[['col1', 'col2']]
+            y = self.data[['col2', 'col1']]
         assert_equal(x[0][0], y[0][1])
 
     def test_pickle_1(self):
@@ -330,7 +337,8 @@ class TestRecord(TestCase):
 
         # https://github.com/numpy/numpy/issues/3256
         ra = np.recarray((2,), dtype=[('x', object), ('y', float), ('z', int)])
-        ra[['x','y']]  # TypeError?
+        with assert_warns(FutureWarning):
+            ra[['x','y']]  # TypeError?
 
     def test_record_scalar_setitem(self):
         # https://github.com/numpy/numpy/issues/3561

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -20,7 +20,7 @@ import numpy.ma.core
 import numpy.core.fromnumeric as fromnumeric
 import numpy.core.umath as umath
 from numpy.testing import (
-    TestCase, run_module_suite, assert_raises, suppress_warnings)
+    TestCase, run_module_suite, assert_raises, assert_warns, suppress_warnings)
 from numpy import ndarray
 from numpy.compat import asbytes, asbytes_nested
 from numpy.ma.testutils import (
@@ -1629,7 +1629,9 @@ class TestFillingValues(TestCase):
         # BEHAVIOR in 1.6 and later: match structured types by name
         fill_val = np.array(("???", -999, -12345678.9),
                             dtype=[("c", "|S3"), ("a", int), ("b", float), ])
-        fval = _check_fill_value(fill_val, ndtype)
+        # suppress deprecation warning in 1.12 (remove in 1.13)
+        with assert_warns(FutureWarning):
+            fval = _check_fill_value(fill_val, ndtype)
         self.assertTrue(isinstance(fval, ndarray))
         assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
 


### PR DESCRIPTION
As discussed in #6053, in preparation for making multi-field indices return a view instead of a copy, this adds a deprecation warning when attempting to view the result of a multi-field index, as in:

```
>>> a = ones(10, dtype='i8,i8,i8')
>>> b = a[['f0','f2']
>>> b.view('i4') # Deprecation warning
```

Such code will break any time we convert copies to views, because the byte arrangement of copies and views is necessarily different. I'd like to get it in for 1.10, so we can more easily make the copy->view change in 1.11.

My computer access is limited right now so this PR might be a bit rough, I'll tidy it later. Just posting for feedback now.

One thing I haven't figured out is how to make the unit tests show the deprecation warning: There are unit tests which I know show the warning (`test_field_names`) but the warnings don't show up when I run `np.test('full')` or even `np.test('full', raise_warnings=[FutureWarning])`. I'd like to use this to catch all the numpy code that will break when convertingmulti-field  copies to view. Any ideas?
