### PR TITLE
MAINT: fix typo in site.cfg.example

### DIFF
--- a/site.cfg.example
+++ b/site.cfg.example
@@ -35,7 +35,7 @@
 #           library_dirs = /usr/lib,/usr/local/lib
 #
 #   include_dirs
-#       List of directories to add to the header file earch path.
+#       List of directories to add to the header file search path.
 #           include_dirs = /usr/include:/usr/local/include
 #
 #   src_dirs 


### PR DESCRIPTION
Changed "earch path" to "search path" in description of include_dirs.
