### PR TITLE
ENH skip NPY_ALLOW_C_API for UFUNC_ERR_PRINT

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -105,7 +105,17 @@ _error_handler(int method, PyObject *errobj, char *errtype, int retstatus, int *
     PyObject *pyfunc, *ret, *args;
     char *name = PyBytes_AS_STRING(PyTuple_GET_ITEM(errobj,0));
     char msg[100];
-    NPY_ALLOW_C_API_DEF;
+
+    NPY_ALLOW_C_API_DEF
+
+    /* don't need C API for a simple print */
+    if (method == UFUNC_ERR_PRINT) {
+        if (*first) {
+            fprintf(stderr, "Warning: %s encountered in %s\n", errtype, name);
+            *first = 0;
+        }
+        return 0;
+    }
 
     NPY_ALLOW_C_API;
     switch(method) {
@@ -139,12 +149,6 @@ _error_handler(int method, PyObject *errobj, char *errtype, int retstatus, int *
             goto fail;
         }
         Py_DECREF(ret);
-        break;
-    case UFUNC_ERR_PRINT:
-        if (*first) {
-            fprintf(stderr, "Warning: %s encountered in %s\n", errtype, name);
-            *first = 0;
-        }
         break;
     case UFUNC_ERR_LOG:
         if (first) {


### PR DESCRIPTION
GIL unnecessary when numpy floating point error handling is set to print
potential micro-optimization when error handling is set to print
alleviates (but does not fix) #5856 deadlock with sub-interpreters

Change-Id: I0414df8c5dca131e1f8c8d867791ba63cf992b63
