### PR TITLE
MAINT: adapt parallel build option names to python3.5

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -6,8 +6,8 @@ This release supports Python 2.6 - 2.7 and 3.2 - 3.4.
 
 Highlights
 ==========
-* numpy.distutils now supports parallel compilation via the --jobs/-j argument
-  passed to setup.py build
+* numpy.distutils now supports parallel compilation via the --parallel/-j
+  argument passed to setup.py build
 * numpy.distutils now supports additional customization via site.cfg to
   control compilation parameters, i.e. runtime libraries, extra
   linking/compilation flags.
@@ -172,7 +172,7 @@ and a bit faster.
 
 numpy.distutils now allows parallel compilation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-By passing *--jobs=n* or *-j n* to *setup.py build* the compilation of
+By passing *--parallel=n* or *-j n* to *setup.py build* the compilation of
 extensions is now performed in *n* parallel processes.
 The parallelization is limited to files within one extension so projects using
 Cython will not profit because it builds extensions from single files.

--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -16,7 +16,7 @@ class build(old_build):
     user_options = old_build.user_options + [
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
-        ('jobs=', 'j',
+        ('parallel=', 'j',
          "number of parallel jobs"),
         ]
 
@@ -28,14 +28,14 @@ class build(old_build):
     def initialize_options(self):
         old_build.initialize_options(self)
         self.fcompiler = None
-        self.jobs = None
+        self.parallel = None
 
     def finalize_options(self):
-        if self.jobs:
+        if self.parallel:
             try:
-                self.jobs = int(self.jobs)
+                self.parallel = int(self.parallel)
             except ValueError:
-                raise ValueError("--jobs/-j argument must be an integer")
+                raise ValueError("--parallel/-j argument must be an integer")
         build_scripts = self.build_scripts
         old_build.finalize_options(self)
         plat_specifier = ".%s-%s" % (get_platform(), sys.version[0:3])

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -30,7 +30,7 @@ class build_clib(old_build_clib):
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
         ('inplace', 'i', 'Build in-place'),
-        ('jobs=', 'j',
+        ('parallel=', 'j',
          "number of parallel jobs"),
         ]
 
@@ -40,16 +40,16 @@ class build_clib(old_build_clib):
         old_build_clib.initialize_options(self)
         self.fcompiler = None
         self.inplace = 0
-        self.jobs = None
+        self.parallel = None
 
     def finalize_options(self):
-        if self.jobs:
+        if self.parallel:
             try:
-                self.jobs = int(self.jobs)
+                self.parallel = int(self.parallel)
             except ValueError:
-                raise ValueError("--jobs/-j argument must be an integer")
+                raise ValueError("--parallel/-j argument must be an integer")
         old_build_clib.finalize_options(self)
-        self.set_undefined_options('build', ('jobs', 'jobs'))
+        self.set_undefined_options('build', ('parallel', 'parallel'))
 
     def have_f_sources(self):
         for (lib_name, build_info) in self.libraries:

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -34,7 +34,7 @@ class build_ext (old_build_ext):
     user_options = old_build_ext.user_options + [
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
-        ('jobs=', 'j',
+        ('parallel=', 'j',
          "number of parallel jobs"),
         ]
 
@@ -46,14 +46,14 @@ class build_ext (old_build_ext):
     def initialize_options(self):
         old_build_ext.initialize_options(self)
         self.fcompiler = None
-        self.jobs = None
+        self.parallel = None
 
     def finalize_options(self):
-        if self.jobs:
+        if self.parallel:
             try:
-                self.jobs = int(self.jobs)
+                self.parallel = int(self.parallel)
             except ValueError:
-                raise ValueError("--jobs/-j argument must be an integer")
+                raise ValueError("--parallel/-j argument must be an integer")
 
         # Ensure that self.include_dirs and self.distribution.include_dirs
         # refer to the same list object. finalize_options will modify
@@ -72,7 +72,7 @@ class build_ext (old_build_ext):
         self.include_dirs.extend(incl_dirs)
 
         old_build_ext.finalize_options(self)
-        self.set_undefined_options('build', ('jobs', 'jobs'))
+        self.set_undefined_options('build', ('parallel', 'parallel'))
 
     def run(self):
         if not self.extensions:

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -68,8 +68,8 @@ class InstallableLib(object):
 
 def get_num_build_jobs():
     """
-    Get number of parallel build jobs set by the --jobs command line argument
-    of setup.py
+    Get number of parallel build jobs set by the --parallel command line
+    argument of setup.py
     If the command did not receive a setting the environment variable
     NPY_NUM_BUILD_JOBS checked and if that is unset it returns 1.
 
@@ -87,9 +87,9 @@ def get_num_build_jobs():
         return envjobs
 
     # any of these three may have the job set, take the largest
-    cmdattr = (getattr(dist.get_command_obj('build'), 'jobs', None),
-               getattr(dist.get_command_obj('build_ext'), 'jobs', None),
-               getattr(dist.get_command_obj('build_clib'), 'jobs', None))
+    cmdattr = (getattr(dist.get_command_obj('build'), 'parallel', None),
+               getattr(dist.get_command_obj('build_ext'), 'parallel', None),
+               getattr(dist.get_command_obj('build_clib'), 'parallel', None))
     if all(x is None for x in cmdattr):
         return envjobs
     else:


### PR DESCRIPTION
python3.5 uses --parallel instead of --jobs
