### PR TITLE
MAINT: fix raise_warnings in np.test in py3

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -401,7 +401,7 @@ class NoseTester(object):
 
         _warn_opts = dict(develop=(DeprecationWarning, RuntimeWarning),
                           release=())
-        if raise_warnings in _warn_opts.keys():
+        if isinstance(raise_warnings, basestring):
             raise_warnings = _warn_opts[raise_warnings]
 
         with warnings.catch_warnings():


### PR DESCRIPTION
In python3 `np.test` would raise an error if `raise_warnings` is a list
since `dict.keys()` now returns a `dict_keys` instance. Eg,

```
np.test('full', raise_warnings=[FutureWarning])
```
