### PR TITLE
remove /GL for vs2015 in check_long_double_representation

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -181,6 +181,15 @@ def check_long_double_representation(cmd):
     cmd._check_compiler()
     body = LONG_DOUBLE_REPRESENTATION_SRC % {'type': 'long double'}
 
+    # Disable whole program optimization (the default on vs2015, with python 3.5+)
+    # which generates intermediary object files and prevents checking the
+    # float representation.
+    if sys.platform == "win32":
+        try:
+            cmd.compiler.compile_options.remove("/GL")
+        except ValueError:
+            pass
+
     # We need to use _compile because we need the object filename
     src, obj = cmd._compile(body, None, None, 'c')
     try:


### PR DESCRIPTION
In Python 3.5, visual studio 2015 is the default compiler on windows and /GL (whole program optimisation) is enabled by default.

This breaks check_long_double_representation because .obj files contain an intermediary format that isn't converted into a real object until link time. 

This patch edits the compile options on cmd.compiler - bit of a hack but unfortunately there doesn't really seem to be a better way to do this from this point in the code.
