### PR TITLE
ENH: Allow views using smaller coprime itemsizes

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -431,7 +431,7 @@ static int
 array_descr_set(PyArrayObject *self, PyObject *arg)
 {
     PyArray_Descr *newtype = NULL;
-    npy_intp newdim;
+    npy_intp nbytes;
     int i;
     char *msg = "new type not compatible with array.";
     PyObject *safe;
@@ -493,28 +493,17 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     else {
         i = 0;
     }
-    if (newtype->elsize < PyArray_DESCR(self)->elsize) {
-        /*
-         * if it is compatible increase the size of the
-         * dimension at end (or at the front for NPY_ARRAY_F_CONTIGUOUS)
-         */
-        if (PyArray_DESCR(self)->elsize % newtype->elsize != 0) {
-            goto fail;
-        }
-        newdim = PyArray_DESCR(self)->elsize / newtype->elsize;
-        PyArray_DIMS(self)[i] *= newdim;
-        PyArray_STRIDES(self)[i] = newtype->elsize;
-    }
-    else if (newtype->elsize > PyArray_DESCR(self)->elsize) {
+
+    if (newtype->elsize != PyArray_DESCR(self)->elsize) {
         /*
          * Determine if last (or first if NPY_ARRAY_F_CONTIGUOUS) dimension
          * is compatible
          */
-        newdim = PyArray_DIMS(self)[i] * PyArray_DESCR(self)->elsize;
-        if ((newdim % newtype->elsize) != 0) {
+        nbytes = PyArray_DIMS(self)[i] * PyArray_DESCR(self)->elsize;
+        if ((nbytes % newtype->elsize) != 0) {
             goto fail;
         }
-        PyArray_DIMS(self)[i] = newdim / newtype->elsize;
+        PyArray_DIMS(self)[i] = nbytes / newtype->elsize;
         PyArray_STRIDES(self)[i] = newtype->elsize;
     }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5707,6 +5707,16 @@ class TestObjViewSafetyFuncs(TestCase):
                             'itemsize': 4*psize})
         assert_equal(scanView(overlapped, 'p'), [0, 1, 3*psize-1, 3*psize])
 
+    def test_coprime_itemsizes(self):
+        # test we can view using coprime itemsizes, as long as the array length
+        # is suitable
+
+        np.zeros(2, 'p,p,p').view('p,p')
+        assert_raises(ValueError, np.zeros(3, 'p,p,p').view, 'p,p')
+
+        np.zeros(3, 'p,p').view('p,p,p')
+        assert_raises(ValueError, np.zeros(2, 'p,p').view, 'p,p,p')
+
 
 class TestArrayPriority(TestCase):
     # This will go away when __array_priority__ is settled, meanwhile


### PR DESCRIPTION
Previously, this was allowed:    

```
np.zeros(3, dtype='p,p').view('p,p,p')
```

But this was not:                

```
np.zeros(2, dtype='p,p,p').view('p,p')
```

This commit makes the second case work like the first.

I have to admit it's not clear to me why the code treated the two cases differently before.
