### PR TITLE
MAINT: allow '?' in structured dtype commastring specification

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -138,7 +138,7 @@ format_re = re.compile(asbytes(
                            r'(?P<order1>[<>|=]?)'
                            r'(?P<repeats> *[(]?[ ,0-9L]*[)]? *)'
                            r'(?P<order2>[<>|=]?)'
-                           r'(?P<dtype>[A-Za-z0-9.]*(?:\[[a-zA-Z0-9,.]+\])?)'))
+                           r'(?P<dtype>[A-Za-z0-9.?]*(?:\[[a-zA-Z0-9,.]+\])?)'))
 sep_re = re.compile(asbytes(r'\s*,\s*'))
 space_re = re.compile(asbytes(r'\s+$'))
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -252,6 +252,12 @@ class TestRecord(TestCase):
         dt2 = np.dtype((np.void, dt.fields))
         assert_equal(dt2.fields, dt.fields)
 
+    def test_bool_commastring(self):
+        d = np.dtype('?,?,?') # raises?
+        assert_equal(len(d.names), 3)
+        for n in d.names:
+            assert_equal(d.fields[n][0], np.dtype('?'))
+
 
 class TestSubarray(TestCase):
     def test_single_subarray(self):


### PR DESCRIPTION
Code like `dtype('?,?,?')` now works.
