### PR TITLE
ENH: Faster algorithm for computing histograms with equal-size bins

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1149,6 +1149,37 @@ class TestHistogram(TestCase):
             weights=[2, 1, 1, 1, 1, 1, 1, 1, 1], density=True)
         assert_almost_equal(a, [.2, .1, .1, .075])
 
+    def test_exotic_weights(self):
+
+        # Test the use of weights that are not integer or floats, but e.g.
+        # complex numbers or object types.
+
+        # Complex weights
+        values = np.array([1.3, 2.5, 2.3])
+        weights = np.array([1, -1, 2]) + 1j * np.array([2, 1, 2])
+
+        # Check with custom bins
+        wa, wb = histogram(values, bins=[0, 2, 3], weights=weights)
+        assert_array_almost_equal(wa, np.array([1, 1]) + 1j * np.array([2,3]))
+
+        # Check with even bins
+        wa, wb = histogram(values, bins=2, range=[1,3], weights=weights)
+        assert_array_almost_equal(wa, np.array([1, 1]) + 1j * np.array([2,3]))
+
+        # Decimal weights
+        from decimal import Decimal
+        values = np.array([1.3, 2.5, 2.3])
+        weights = np.array([Decimal(1), Decimal(2), Decimal(3)])
+
+        # Check with custom bins
+        wa, wb = histogram(values, bins=[0, 2, 3], weights=weights)
+        assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
+
+        # Check with even bins
+        wa, wb = histogram(values, bins=2, range=[1,3], weights=weights)
+        assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
+
+
     def test_empty(self):
         a, b = histogram([], bins=([0, 1]))
         assert_array_equal(a, np.array([0]))


### PR DESCRIPTION
### About

When bins are equal-sized, we don't have use `searchsorted` to find which bins values fall in, we can instead just scale and convert the values to the bin indices and use `bincount`.
### Results

I carried out speed tests with arrays going from 1 to 10^8 elements. The values were randomly sampled with:

``` python
x = np.random.uniform(-10., 100., N)
```

and the histogram was computed with:

``` python
hist, edges = np.histogram(x, bins=45, range=[-5, 99.])
```

The speed difference is as follows:

![comparison](https://cloud.githubusercontent.com/assets/314716/8807304/caf3d498-2fdb-11e5-9484-2ece925e29dc.png)

The new method is always faster, and for more than 10^5 elements, the speedup is a factor of ~10x.

I then checked that the memory usage is not increased, when binning an array with 10^9 values:

![memory](https://cloud.githubusercontent.com/assets/314716/8807318/f307d420-2fdb-11e5-8942-a36c8104c3c6.png)

There is no memory penalty!

Note that I originally implemented this without the iteration over blocks, and not only did it use more memory, it was 2x as slow as the version with looping over chunks (to my surprise).
### Future work

If this PR is merged, we can also consider switching to using C or Cython for the part where the bin indices are computed. This could provide a further ~3x improvement in performance.
### Notes

This partially addresses #6099 (np.histogram could be made even faster by switching to C in places)

A similar speedup could be made for `histogramdd`

Of course, given how extensively this function is used, it would be great if people could subject to more rigorous testing (I will also do some more testing to see if I can find cases where there is a performance regression)
