### PR TITLE
MAINT: Temporarily disable __numpy_ufunc__ for 1.10

### DIFF
--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -195,6 +195,16 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     /* Pos of each override in args */
     int with_override_pos[NPY_MAXARGS];
 
+    /****************************************************************
+     * Temporarily disable this functionality for the 1.10 release.
+     * See gh-5844.
+     ****************************************************************/
+    *result = NULL;
+    return 0;
+    /****************************************************************
+     * Actual implementation follows:
+     ****************************************************************/
+
     /*
      * Check inputs
      */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1923,6 +1923,9 @@ class TestMethods(TestCase):
         assert_equal(c, np.dot(a, b))
 
     def test_dot_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return "A"
@@ -2246,6 +2249,9 @@ class TestBinop(object):
         # Check that __rmul__ and other right-hand operations have
         # precedence over __numpy_ufunc__
 
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         ops = {
             '__add__':      ('__radd__', np.add, True),
             '__sub__':      ('__rsub__', np.subtract, True),
@@ -2361,6 +2367,9 @@ class TestBinop(object):
             yield check, op_name, False
 
     def test_ufunc_override_rop_simple(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
+
         # Check parts of the binary op overriding behavior in an
         # explicit test case that is easier to understand.
         class SomeClass(object):
@@ -2460,6 +2469,9 @@ class TestBinop(object):
         assert_(isinstance(res, SomeClass3))
 
     def test_ufunc_override_normalize_signature(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         # gh-5674
         class SomeClass(object):
             def __numpy_ufunc__(self, ufunc, method, i, inputs, **kw):
@@ -3998,6 +4010,9 @@ class TestDot(TestCase):
         assert_equal(np.dot(3, arr), desired)
 
     def test_dot_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return "A"
@@ -4279,6 +4294,8 @@ class MatmulCommon():
         assert_equal(res, tgt12_21)
 
     def test_numpy_ufunc_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
 
         class A(np.ndarray):
             def __new__(cls, *args, **kwargs):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1162,6 +1162,9 @@ class TestSpecialMethods(TestCase):
         assert_equal(ncu.maximum(a, C()), 0)
 
     def test_ufunc_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         class A(object):
             def __numpy_ufunc__(self, func, method, pos, inputs, **kwargs):
                 return self, func, method, pos, inputs, kwargs
@@ -1188,6 +1191,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res1[5], {})
 
     def test_ufunc_override_mro(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
 
         # Some multi arg functions for testing.
         def tres_mul(a, b, c):
@@ -1281,6 +1286,9 @@ class TestSpecialMethods(TestCase):
         assert_raises(TypeError, four_mul_ufunc, 1, c, c_sub, c)
 
     def test_ufunc_override_methods(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return self, ufunc, method, pos, inputs, kwargs
@@ -1384,6 +1392,9 @@ class TestSpecialMethods(TestCase):
         assert_equal(res[4], (a, [4, 2], 'b0'))
 
     def test_ufunc_override_out(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return kwargs
@@ -1418,6 +1429,9 @@ class TestSpecialMethods(TestCase):
         assert_equal(res7['out'][1], 'out1')
 
     def test_ufunc_override_exception(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
+
         class A(object):
             def __numpy_ufunc__(self, *a, **kwargs):
                 raise ValueError("oops")


### PR DESCRIPTION
Following discussion in gh-5844, we regretfully decided that we have to
disable `__numpy_ufunc__` again for 1.10. This patch should be reverted
on master after 1.10 is branched.
