### PR TITLE
DEP: deprecate np.bool, np.int, np.float, np.long, np.str, np.unicode, and np.complex, which are misleading aliases for builtin types

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -108,9 +108,9 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 
-import metamodule
-metamodule.install(__name__)
-del metamodule
+from ._metamodule import install
+install(__name__)
+del install
 
 class ModuleDeprecationWarning(DeprecationWarning):
     """Module deprecation warning.

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -414,7 +414,9 @@ class NoseTester(object):
             warnings.filterwarnings('always', category=DeprecationWarning)
             # Force the requested warnings to raise
             for warningtype in raise_warnings:
-                warnings.filterwarnings('error', category=warningtype)
+                warnings.filterwarnings('error',
+                                        category=warningtype,
+                                        module=r"numpy.*")
             # Filter out annoying import messages.
             warnings.filterwarnings('ignore', message='Not importing directory')
             warnings.filterwarnings("ignore", message="numpy.dtype size changed")

--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,6 @@ def setup_package():
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked},
         package_data={'numpy.core': ['libopenblaspy.dll']},
-        install_requires=["metamodule"],
     )
 
     # Run build

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,7 @@ def setup_package():
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked},
         package_data={'numpy.core': ['libopenblaspy.dll']},
+        install_requires=["metamodule"],
     )
 
     # Run build


### PR DESCRIPTION
This isn't ready yet -- it causes hundreds of test failures due to our own internal usage of `np.bool` etc., plus it is missing new tests of its own -- but posting now as an RFC.

---

For reasons which are lost in the mists of time, numpy has always
re-exported a bunch of built-in types like `int` as `np.int`, `bool` as
`np.bool`, etc. We can't possibly remove these exports anytime in the
near future, because they are widely used -- people write things like

```
  np.asarray(obj, dtype=np.int)
```

These people are confused, and would be better off writing either

```
  np.asarray(obj, dtype=int)
```

or

```
  np.asarray(obj, dtype=np.int_)
```

depending on what they actually want, but their code does work (and is
equivalent to the `dtype=int` version), so we can't break it. But,
thanks to a new feature added in 3.5, plus some glue and sealing back
for previous versions, it is finally at least possible to deprecate
these attributes!

This adds a dependency on the `metamodule` package, which is a tiny
pure-Python package that supports every version of Python that numpy
supports. This will Just Work for pip and other sensible installation
tools, but the alternative would be to just vendor our own copy of
`metamodule.py` into the numpy/ directory instead.

Personally I am kinda inclined to try going with the explicit dependency route and see how far we can get, because maintaining vendored libraries is a huge pain, and because c'mon it's 2015, and because sooner or later we are probably going to want to add an external dependency or two (e.g. [sempervirens](https://github.com/njsmith/sempervirens)) and so we might as well find out what the pain points are now. But I can see the arguments either way...
