### PR TITLE
MAINT: Use Python 3.5-dev instead of nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
   - 3.2
   - 3.3
-  - nightly
+  - 3.5-dev
 matrix:
   include:
     - python: 3.3


### PR DESCRIPTION
Python 3.6-dev has broken the nose tester. Use an earlier version
until that gets fixed upstream.
