### PR TITLE
Pyflakes fix star imports and other style violations.

### DIFF
--- a/numpy/distutils/tests/f2py_ext/tests/test_fib2.py
+++ b/numpy/distutils/tests/f2py_ext/tests/test_fib2.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-from numpy.testing import *
+from numpy.testing import TestCase, run_module_suite, assert_array_equal
 from f2py_ext import fib2
 
 class TestFib2(TestCase):

--- a/numpy/distutils/tests/f2py_f90_ext/tests/test_foo.py
+++ b/numpy/distutils/tests/f2py_f90_ext/tests/test_foo.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-from numpy.testing import *
+from numpy.testing import TestCase, run_module_suite, assert_equal
 from f2py_f90_ext import foo
 
 class TestFoo(TestCase):

--- a/numpy/distutils/tests/gen_ext/tests/test_fib3.py
+++ b/numpy/distutils/tests/gen_ext/tests/test_fib3.py
@@ -1,8 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-from numpy.testing import *
 from gen_ext import fib3
+from numpy.testing import TestCase, run_module_suite, assert_array_equal
 
 class TestFib3(TestCase):
     def test_fib(self):

--- a/numpy/distutils/tests/pyrex_ext/tests/test_primes.py
+++ b/numpy/distutils/tests/pyrex_ext/tests/test_primes.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-from numpy.testing import *
+from numpy.testing import TestCase, run_module_suite, assert_equal
 from pyrex_ext.primes import primes
 
 class TestPrimes(TestCase):

--- a/numpy/distutils/tests/swig_ext/tests/test_example.py
+++ b/numpy/distutils/tests/swig_ext/tests/test_example.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-from numpy.testing import *
+from numpy.testing import TestCase, run_module_suite, assert_equal
 from swig_ext import example
 
 class TestExample(TestCase):

--- a/numpy/distutils/tests/swig_ext/tests/test_example2.py
+++ b/numpy/distutils/tests/swig_ext/tests/test_example2.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-from numpy.testing import *
+from numpy.testing import TestCase, run_module_suite
 from swig_ext import example2
 
 class TestExample2(TestCase):

--- a/numpy/distutils/tests/test_fcompiler_intel.py
+++ b/numpy/distutils/tests/test_fcompiler_intel.py
@@ -1,18 +1,18 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
-
 import numpy.distutils.fcompiler
+from numpy.testing import TestCase, run_module_suite, assert_
+
 
 intel_32bit_version_strings = [
-    ("Intel(R) Fortran Intel(R) 32-bit Compiler Professional for applications"\
+    ("Intel(R) Fortran Intel(R) 32-bit Compiler Professional for applications"
      "running on Intel(R) 32, Version 11.1", '11.1'),
 ]
 
 intel_64bit_version_strings = [
-    ("Intel(R) Fortran IA-64 Compiler Professional for applications"\
+    ("Intel(R) Fortran IA-64 Compiler Professional for applications"
      "running on IA-64, Version 11.0", '11.0'),
-    ("Intel(R) Fortran Intel(R) 64 Compiler Professional for applications"\
+    ("Intel(R) Fortran Intel(R) 64 Compiler Professional for applications"
      "running on Intel(R) 64, Version 11.1", '11.1')
 ]
 

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
-from numpy.distutils.misc_util import appendpath, minrelpath, \
-    gpaths, get_shared_lib_extension
 from os.path import join, sep, dirname
+
+from numpy.distutils.misc_util import (
+    appendpath, minrelpath, gpaths, get_shared_lib_extension
+)
+from numpy.testing import (
+    TestCase, run_module_suite, assert_, assert_equal
+)
 
 ajoin = lambda *paths: join(*((sep,)+paths))
 
@@ -53,7 +57,7 @@ class TestGpaths(TestCase):
         ls = gpaths('command/*.py', local_path)
         assert_(join(local_path, 'command', 'build_src.py') in ls, repr(ls))
         f = gpaths('system_info.py', local_path)
-        assert_(join(local_path, 'system_info.py')==f[0], repr(f))
+        assert_(join(local_path, 'system_info.py') == f[0], repr(f))
 
 class TestSharedExtension(TestCase):
 

--- a/numpy/distutils/tests/test_npy_pkg_config.py
+++ b/numpy/distutils/tests/test_npy_pkg_config.py
@@ -3,8 +3,8 @@ from __future__ import division, absolute_import, print_function
 import os
 from tempfile import mkstemp
 
-from numpy.testing import *
 from numpy.distutils.npy_pkg_config import read_config, parse_flags
+from numpy.testing import TestCase, run_module_suite
 
 simple = """\
 [meta]
@@ -96,3 +96,7 @@ class TestParseFlags(TestCase):
         d = parse_flags("-L /usr/lib -lfoo -L/usr/lib -lbar")
         self.assertTrue(d['library_dirs'] == ['/usr/lib', '/usr/lib'])
         self.assertTrue(d['libraries'] == ['foo', 'bar'])
+
+
+if __name__ == '__main__':
+    run_module_suite()

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -9,6 +9,7 @@ from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
 from numpy.distutils.system_info import system_info, ConfigParser
 from numpy.distutils.system_info import default_lib_dirs, default_include_dirs
 
+
 def get_class(name, notfound_action=1):
     """
     notfound_action:
@@ -54,6 +55,7 @@ void bar(void) {
 
 
 class test_system_info(system_info):
+
     def __init__(self,
                  default_lib_dirs=default_lib_dirs,
                  default_include_dirs=default_include_dirs,
@@ -73,10 +75,10 @@ class test_system_info(system_info):
         self.cp = ConfigParser(defaults)
         # We have to parse the config files afterwards
         # to have a consistent temporary filepath
-        
+
     def _check_libs(self, lib_dirs, libs, opt_libs, exts):
         """Override _check_libs to return with all dirs """
-        info = {'libraries' : libs , 'library_dirs' : lib_dirs}
+        info = {'libraries': libs, 'library_dirs': lib_dirs}
         return info
 
 
@@ -102,11 +104,11 @@ class TestSystemInfoReading(TestCase):
         # Update local site.cfg
         global simple_site, site_cfg
         site_cfg = simple_site.format(**{
-                'dir1' : self._dir1,
-                'lib1' : self._lib1,
-                'dir2' : self._dir2,
-                'lib2' : self._lib2 
-                })
+            'dir1': self._dir1,
+            'lib1': self._lib1,
+            'dir2': self._dir2,
+            'lib2': self._lib2
+        })
         # Write site.cfg
         fd, self._sitecfg = mkstemp()
         os.close(fd)
@@ -117,7 +119,8 @@ class TestSystemInfoReading(TestCase):
             fd.write(fakelib_c_text)
         with open(self._src2, 'w') as fd:
             fd.write(fakelib_c_text)
-        # We create all class-instances 
+        # We create all class-instances
+
         def site_and_parse(c, site_cfg):
             c.files = [site_cfg]
             c.parse_config_files()
@@ -128,15 +131,15 @@ class TestSystemInfoReading(TestCase):
 
     def tearDown(self):
         # Do each removal separately
-        try: 
+        try:
             shutil.rmtree(self._dir1)
         except:
             pass
-        try: 
+        try:
             shutil.rmtree(self._dir2)
         except:
             pass
-        try: 
+        try:
             os.remove(self._sitecfg)
         except:
             pass
@@ -165,11 +168,10 @@ class TestSystemInfoReading(TestCase):
         # Now from rpath and not runtime_library_dirs
         assert_equal(tsi.get_runtime_lib_dirs(key='rpath'), [self._dir2])
         extra = tsi.calc_extra_info()
-        assert_equal(extra['extra_link_args'], ['-Wl,-rpath='+self._lib2])
+        assert_equal(extra['extra_link_args'], ['-Wl,-rpath=' + self._lib2])
 
     def test_compile1(self):
         # Compile source and link the first source
-        tsi = self.c_temp1
         c = ccompiler.new_compiler()
         try:
             # Change directory to not screw up directories
@@ -198,6 +200,6 @@ class TestSystemInfoReading(TestCase):
             os.chdir(previousDir)
         except OSError:
             pass
-        
+
 if __name__ == '__main__':
     run_module_suite()

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -4,18 +4,21 @@ import unittest
 import os
 import sys
 import copy
-import platform
 
 import nose
 
-from numpy.testing import *
-from numpy import (array, alltrue, ndarray, asarray, can_cast, zeros, dtype,
-                   intp, clongdouble)
+from numpy import (
+    array, alltrue, ndarray, zeros, dtype, intp, clongdouble
+)
+from numpy.testing import (
+    run_module_suite, assert_, assert_equal
+)
 from numpy.core.multiarray import typeinfo
-
 import util
 
 wrap = None
+
+
 def setup():
     """
     Build the required testing extension module
@@ -40,9 +43,11 @@ def setup():
         wrap = util.build_module_distutils(src, config_code,
                                            'test_array_from_pyobj_ext')
 
+
 def flags_info(arr):
     flags = wrap.array_attrs(arr)[6]
     return flags2names(flags)
+
 
 def flags2names(flags):
     info = []
@@ -55,31 +60,39 @@ def flags2names(flags):
             info.append(flagname)
     return info
 
+
 class Intent(object):
-    def __init__(self,intent_list=[]):
+
+    def __init__(self, intent_list=[]):
         self.intent_list = intent_list[:]
         flags = 0
         for i in intent_list:
-            if i=='optional':
+            if i == 'optional':
                 flags |= wrap.F2PY_OPTIONAL
             else:
-                flags |= getattr(wrap, 'F2PY_INTENT_'+i.upper())
+                flags |= getattr(wrap, 'F2PY_INTENT_' + i.upper())
         self.flags = flags
+
     def __getattr__(self, name):
         name = name.lower()
-        if name=='in_': name='in'
-        return self.__class__(self.intent_list+[name])
+        if name == 'in_':
+            name = 'in'
+        return self.__class__(self.intent_list + [name])
+
     def __str__(self):
         return 'intent(%s)' % (','.join(self.intent_list))
+
     def __repr__(self):
         return 'Intent(%r)' % (self.intent_list)
-    def is_intent(self,*names):
+
+    def is_intent(self, *names):
         for name in names:
             if name not in self.intent_list:
                 return False
         return True
-    def is_intent_exact(self,*names):
-        return len(self.intent_list)==len(names) and self.is_intent(*names)
+
+    def is_intent_exact(self, *names):
+        return len(self.intent_list) == len(names) and self.is_intent(*names)
 
 intent = Intent()
 
@@ -87,7 +100,7 @@ _type_names = ['BOOL', 'BYTE', 'UBYTE', 'SHORT', 'USHORT', 'INT', 'UINT',
                'LONG', 'ULONG', 'LONGLONG', 'ULONGLONG',
                'FLOAT', 'DOUBLE', 'CFLOAT']
 
-_cast_dict = {'BOOL':['BOOL']}
+_cast_dict = {'BOOL': ['BOOL']}
 _cast_dict['BYTE'] = _cast_dict['BOOL'] + ['BYTE']
 _cast_dict['UBYTE'] = _cast_dict['BOOL'] + ['UBYTE']
 _cast_dict['BYTE'] = ['BYTE']
@@ -109,17 +122,18 @@ _cast_dict['DOUBLE'] = _cast_dict['INT'] + ['UINT', 'FLOAT', 'DOUBLE']
 _cast_dict['CFLOAT'] = _cast_dict['FLOAT'] + ['CFLOAT']
 
 # 32 bit system malloc typically does not provide the alignment required by
-# 16 byte long double types this means the inout intent cannot be satisfied and
-# several tests fail as the alignment flag can be randomly true or fals
+# 16 byte long double types this means the inout intent cannot be satisfied
+# and several tests fail as the alignment flag can be randomly true or fals
 # when numpy gains an aligned allocator the tests could be enabled again
 if ((intp().dtype.itemsize != 4 or clongdouble().dtype.alignment <= 8) and
         sys.platform != 'win32'):
     _type_names.extend(['LONGDOUBLE', 'CDOUBLE', 'CLONGDOUBLE'])
     _cast_dict['LONGDOUBLE'] = _cast_dict['LONG'] + \
-                               ['ULONG', 'FLOAT', 'DOUBLE', 'LONGDOUBLE']
+        ['ULONG', 'FLOAT', 'DOUBLE', 'LONGDOUBLE']
     _cast_dict['CLONGDOUBLE'] = _cast_dict['LONGDOUBLE'] + \
-                               ['CFLOAT', 'CDOUBLE', 'CLONGDOUBLE']
+        ['CFLOAT', 'CDOUBLE', 'CLONGDOUBLE']
     _cast_dict['CDOUBLE'] = _cast_dict['DOUBLE'] + ['CFLOAT', 'CDOUBLE']
+
 
 class Type(object):
     _type_cache = {}
@@ -142,7 +156,7 @@ class Type(object):
 
     def _init(self, name):
         self.NAME = name.upper()
-        self.type_num = getattr(wrap, 'NPY_'+self.NAME)
+        self.type_num = getattr(wrap, 'NPY_' + self.NAME)
         assert_equal(self.type_num, typeinfo[self.NAME][1])
         self.dtype = typeinfo[self.NAME][-1]
         self.elsize = typeinfo[self.NAME][2] / 8
@@ -158,7 +172,7 @@ class Type(object):
         bits = typeinfo[self.NAME][3]
         types = []
         for name in _type_names:
-            if typeinfo[name][3]<bits:
+            if typeinfo[name][3] < bits:
                 types.append(Type(name))
         return types
 
@@ -166,8 +180,9 @@ class Type(object):
         bits = typeinfo[self.NAME][3]
         types = []
         for name in _type_names:
-            if name==self.NAME: continue
-            if typeinfo[name][3]==bits:
+            if name == self.NAME:
+                continue
+            if typeinfo[name][3] == bits:
                 types.append(Type(name))
         return types
 
@@ -175,11 +190,13 @@ class Type(object):
         bits = typeinfo[self.NAME][3]
         types = []
         for name in _type_names:
-            if typeinfo[name][3]>bits:
+            if typeinfo[name][3] > bits:
                 types.append(Type(name))
         return types
 
+
 class Array(object):
+
     def __init__(self, typ, dims, intent, obj):
         self.type = typ
         self.dims = dims
@@ -194,10 +211,11 @@ class Array(object):
 
         self.arr_attr = wrap.array_attrs(self.arr)
 
-        if len(dims)>1:
+        if len(dims) > 1:
             if self.intent.is_intent('c'):
                 assert_(intent.flags & wrap.F2PY_INTENT_C)
-                assert_(not self.arr.flags['FORTRAN'], repr((self.arr.flags, getattr(obj, 'flags', None))))
+                assert_(not self.arr.flags['FORTRAN'],
+                        repr((self.arr.flags, getattr(obj, 'flags', None))))
                 assert_(self.arr.flags['CONTIGUOUS'])
                 assert_(not self.arr_attr[6] & wrap.FORTRAN)
             else:
@@ -215,15 +233,14 @@ class Array(object):
             assert_(isinstance(obj, ndarray), repr(type(obj)))
             self.pyarr = array(obj).reshape(*dims).copy()
         else:
-            self.pyarr = array(array(obj,
-                                     dtype = typ.dtypechar).reshape(*dims),
+            self.pyarr = array(array(obj, dtype=typ.dtypechar).reshape(*dims),
                                order=self.intent.is_intent('c') and 'C' or 'F')
-            assert_(self.pyarr.dtype == typ, \
-                   repr((self.pyarr.dtype, typ)))
+            assert_(self.pyarr.dtype == typ,
+                    repr((self.pyarr.dtype, typ)))
         assert_(self.pyarr.flags['OWNDATA'], (obj, intent))
         self.pyarr_attr = wrap.array_attrs(self.pyarr)
 
-        if len(dims)>1:
+        if len(dims) > 1:
             if self.intent.is_intent('c'):
                 assert_(not self.pyarr.flags['FORTRAN'])
                 assert_(self.pyarr.flags['CONTIGUOUS'])
@@ -233,35 +250,36 @@ class Array(object):
                 assert_(not self.pyarr.flags['CONTIGUOUS'])
                 assert_(self.pyarr_attr[6] & wrap.FORTRAN)
 
-
-        assert_(self.arr_attr[1]==self.pyarr_attr[1]) # nd
-        assert_(self.arr_attr[2]==self.pyarr_attr[2]) # dimensions
-        if self.arr_attr[1]<=1:
-            assert_(self.arr_attr[3]==self.pyarr_attr[3],\
-                   repr((self.arr_attr[3], self.pyarr_attr[3],
-                         self.arr.tobytes(), self.pyarr.tobytes()))) # strides
-        assert_(self.arr_attr[5][-2:]==self.pyarr_attr[5][-2:],\
-               repr((self.arr_attr[5], self.pyarr_attr[5]))) # descr
-        assert_(self.arr_attr[6]==self.pyarr_attr[6],\
-               repr((self.arr_attr[6], self.pyarr_attr[6], flags2names(0*self.arr_attr[6]-self.pyarr_attr[6]), flags2names(self.arr_attr[6]), intent))) # flags
+        assert_(self.arr_attr[1] == self.pyarr_attr[1])  # nd
+        assert_(self.arr_attr[2] == self.pyarr_attr[2])  # dimensions
+        if self.arr_attr[1] <= 1:
+            assert_(self.arr_attr[3] == self.pyarr_attr[3],
+                    repr((self.arr_attr[3], self.pyarr_attr[3],
+                          self.arr.tobytes(), self.pyarr.tobytes())))  # strides
+        assert_(self.arr_attr[5][-2:] == self.pyarr_attr[5][-2:],
+                repr((self.arr_attr[5], self.pyarr_attr[5])))  # descr
+        assert_(self.arr_attr[6] == self.pyarr_attr[6],
+                repr((self.arr_attr[6], self.pyarr_attr[6],
+                      flags2names(0 * self.arr_attr[6] - self.pyarr_attr[6]),
+                      flags2names(self.arr_attr[6]), intent)))  # flags
 
         if intent.is_intent('cache'):
-            assert_(self.arr_attr[5][3]>=self.type.elsize,\
-                   repr((self.arr_attr[5][3], self.type.elsize)))
+            assert_(self.arr_attr[5][3] >= self.type.elsize,
+                    repr((self.arr_attr[5][3], self.type.elsize)))
         else:
-            assert_(self.arr_attr[5][3]==self.type.elsize,\
-                   repr((self.arr_attr[5][3], self.type.elsize)))
+            assert_(self.arr_attr[5][3] == self.type.elsize,
+                    repr((self.arr_attr[5][3], self.type.elsize)))
         assert_(self.arr_equal(self.pyarr, self.arr))
 
         if isinstance(self.obj, ndarray):
-            if typ.elsize==Type(obj.dtype).elsize:
-                if not intent.is_intent('copy') and self.arr_attr[1]<=1:
+            if typ.elsize == Type(obj.dtype).elsize:
+                if not intent.is_intent('copy') and self.arr_attr[1] <= 1:
                     assert_(self.has_shared_memory())
 
     def arr_equal(self, arr1, arr2):
         if arr1.shape != arr2.shape:
             return False
-        s = arr1==arr2
+        s = arr1 == arr2
         return alltrue(s.flatten())
 
     def __str__(self):
@@ -275,11 +293,11 @@ class Array(object):
         if not isinstance(self.obj, ndarray):
             return False
         obj_attr = wrap.array_attrs(self.obj)
-        return obj_attr[0]==self.arr_attr[0]
+        return obj_attr[0] == self.arr_attr[0]
 
-##################################################
 
 class test_intent(unittest.TestCase):
+
     def test_in_out(self):
         assert_equal(str(intent.in_.out), 'intent(in,out)')
         assert_(intent.in_.c.is_intent('c'))
@@ -288,9 +306,11 @@ class test_intent(unittest.TestCase):
         assert_(intent.in_.c.is_intent_exact('in', 'c'))
         assert_(not intent.in_.is_intent('c'))
 
+
 class _test_shared_memory:
     num2seq = [1, 2]
     num23seq = [[1, 2, 3], [4, 5, 6]]
+
     def test_in_from_2seq(self):
         a = self.array([2], intent.in_, self.num2seq)
         assert_(not a.has_shared_memory())
@@ -299,8 +319,9 @@ class _test_shared_memory:
         for t in self.type.cast_types():
             obj = array(self.num2seq, dtype=t.dtype)
             a = self.array([len(self.num2seq)], intent.in_, obj)
-            if t.elsize==self.type.elsize:
-                assert_(a.has_shared_memory(), repr((self.type.dtype, t.dtype)))
+            if t.elsize == self.type.elsize:
+                assert_(
+                    a.has_shared_memory(), repr((self.type.dtype, t.dtype)))
             else:
                 assert_(not a.has_shared_memory(), repr(t.dtype))
 
@@ -312,7 +333,8 @@ class _test_shared_memory:
         try:
             a = self.array([2], intent.in_.inout, self.num2seq)
         except TypeError as msg:
-            if not str(msg).startswith('failed to initialize intent(inout|inplace|cache) array'):
+            if not str(msg).startswith('failed to initialize intent'
+                                       '(inout|inplace|cache) array'):
                 raise
         else:
             raise SystemError('intent(inout) should have failed on sequence')
@@ -328,10 +350,12 @@ class _test_shared_memory:
         try:
             a = self.array(shape, intent.in_.inout, obj)
         except ValueError as msg:
-            if not str(msg).startswith('failed to initialize intent(inout) array'):
+            if not str(msg).startswith('failed to initialize intent'
+                                       '(inout) array'):
                 raise
         else:
-            raise SystemError('intent(inout) should have failed on improper array')
+            raise SystemError(
+                'intent(inout) should have failed on improper array')
 
     def test_c_inout_23seq(self):
         obj = array(self.num23seq, dtype=self.type.dtype)
@@ -362,7 +386,7 @@ class _test_shared_memory:
             obj = array(self.num23seq, dtype=t.dtype, order='F')
             a = self.array([len(self.num23seq), len(self.num23seq[0])],
                            intent.in_, obj)
-            if t.elsize==self.type.elsize:
+            if t.elsize == self.type.elsize:
                 assert_(a.has_shared_memory(), repr(t.dtype))
             else:
                 assert_(not a.has_shared_memory(), repr(t.dtype))
@@ -372,7 +396,7 @@ class _test_shared_memory:
             obj = array(self.num23seq, dtype=t.dtype)
             a = self.array([len(self.num23seq), len(self.num23seq[0])],
                            intent.in_.c, obj)
-            if t.elsize==self.type.elsize:
+            if t.elsize == self.type.elsize:
                 assert_(a.has_shared_memory(), repr(t.dtype))
             else:
                 assert_(not a.has_shared_memory(), repr(t.dtype))
@@ -413,10 +437,13 @@ class _test_shared_memory:
             try:
                 a = self.array(shape, intent.in_.cache, obj[::-1])
             except ValueError as msg:
-                if not str(msg).startswith('failed to initialize intent(cache) array'):
+                if not str(msg).startswith('failed to initialize'
+                                           ' intent(cache) array'):
                     raise
             else:
-                raise SystemError('intent(cache) should have failed on multisegmented array')
+                raise SystemError(
+                    'intent(cache) should have failed on multisegmented array')
+
     def test_in_cache_from_2casttype_failure(self):
         for t in self.type.all_types():
             if t.elsize >= self.type.elsize:
@@ -424,46 +451,50 @@ class _test_shared_memory:
             obj = array(self.num2seq, dtype=t.dtype)
             shape = (len(self.num2seq),)
             try:
-                a = self.array(shape, intent.in_.cache, obj)
+                self.array(shape, intent.in_.cache, obj)  # Should succeed
             except ValueError as msg:
-                if not str(msg).startswith('failed to initialize intent(cache) array'):
+                if not str(msg).startswith('failed to initialize'
+                                           ' intent(cache) array'):
                     raise
             else:
-                raise SystemError('intent(cache) should have failed on smaller array')
+                raise SystemError(
+                    'intent(cache) should have failed on smaller array')
 
     def test_cache_hidden(self):
         shape = (2,)
         a = self.array(shape, intent.cache.hide, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
 
         shape = (2, 3)
         a = self.array(shape, intent.cache.hide, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
 
         shape = (-1, 3)
         try:
             a = self.array(shape, intent.cache.hide, None)
         except ValueError as msg:
-            if not str(msg).startswith('failed to create intent(cache|hide)|optional array'):
+            if not str(msg).startswith('failed to create intent'
+                                       '(cache|hide)|optional array'):
                 raise
         else:
-            raise SystemError('intent(cache) should have failed on undefined dimensions')
+            raise SystemError(
+                'intent(cache) should have failed on undefined dimensions')
 
     def test_hidden(self):
         shape = (2,)
         a = self.array(shape, intent.hide, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
 
         shape = (2, 3)
         a = self.array(shape, intent.hide, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
         assert_(a.arr.flags['FORTRAN'] and not a.arr.flags['CONTIGUOUS'])
 
         shape = (2, 3)
         a = self.array(shape, intent.c.hide, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
         assert_(not a.arr.flags['FORTRAN'] and a.arr.flags['CONTIGUOUS'])
 
@@ -471,26 +502,28 @@ class _test_shared_memory:
         try:
             a = self.array(shape, intent.hide, None)
         except ValueError as msg:
-            if not str(msg).startswith('failed to create intent(cache|hide)|optional array'):
+            if not str(msg).startswith('failed to create intent'
+                                       '(cache|hide)|optional array'):
                 raise
         else:
-            raise SystemError('intent(hide) should have failed on undefined dimensions')
+            raise SystemError('intent(hide) should have failed'
+                              ' on undefined dimensions')
 
     def test_optional_none(self):
         shape = (2,)
         a = self.array(shape, intent.optional, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
 
         shape = (2, 3)
         a = self.array(shape, intent.optional, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
         assert_(a.arr.flags['FORTRAN'] and not a.arr.flags['CONTIGUOUS'])
 
         shape = (2, 3)
         a = self.array(shape, intent.c.optional, None)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(a.arr_equal(a.arr, zeros(shape, dtype=self.type.dtype)))
         assert_(not a.arr.flags['FORTRAN'] and a.arr.flags['CONTIGUOUS'])
 
@@ -498,18 +531,18 @@ class _test_shared_memory:
         obj = self.num2seq
         shape = (len(obj),)
         a = self.array(shape, intent.optional, obj)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(not a.has_shared_memory())
 
     def test_optional_from_23seq(self):
         obj = self.num23seq
         shape = (len(obj), len(obj[0]))
         a = self.array(shape, intent.optional, obj)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(not a.has_shared_memory())
 
         a = self.array(shape, intent.optional.c, obj)
-        assert_(a.arr.shape==shape)
+        assert_(a.arr.shape == shape)
         assert_(not a.has_shared_memory())
 
     def test_inplace(self):
@@ -517,11 +550,12 @@ class _test_shared_memory:
         assert_(not obj.flags['FORTRAN'] and obj.flags['CONTIGUOUS'])
         shape = obj.shape
         a = self.array(shape, intent.inplace, obj)
-        assert_(obj[1][2]==a.arr[1][2], repr((obj, a.arr)))
-        a.arr[1][2]=54
-        assert_(obj[1][2]==a.arr[1][2]==array(54, dtype=self.type.dtype), repr((obj, a.arr)))
+        assert_(obj[1][2] == a.arr[1][2], repr((obj, a.arr)))
+        a.arr[1][2] = 54
+        assert_(obj[1][2] == a.arr[1][2] ==
+                array(54, dtype=self.type.dtype), repr((obj, a.arr)))
         assert_(a.arr is obj)
-        assert_(obj.flags['FORTRAN']) # obj attributes are changed inplace!
+        assert_(obj.flags['FORTRAN'])  # obj attributes are changed inplace!
         assert_(not obj.flags['CONTIGUOUS'])
 
     def test_inplace_from_casttype(self):
@@ -529,18 +563,19 @@ class _test_shared_memory:
             if t is self.type:
                 continue
             obj = array(self.num23seq, dtype=t.dtype)
-            assert_(obj.dtype.type==t.dtype)
+            assert_(obj.dtype.type == t.dtype)
             assert_(obj.dtype.type is not self.type.dtype)
             assert_(not obj.flags['FORTRAN'] and obj.flags['CONTIGUOUS'])
             shape = obj.shape
             a = self.array(shape, intent.inplace, obj)
-            assert_(obj[1][2]==a.arr[1][2], repr((obj, a.arr)))
-            a.arr[1][2]=54
-            assert_(obj[1][2]==a.arr[1][2]==array(54, dtype=self.type.dtype), repr((obj, a.arr)))
+            assert_(obj[1][2] == a.arr[1][2], repr((obj, a.arr)))
+            a.arr[1][2] = 54
+            assert_(obj[1][2] == a.arr[1][2] ==
+                    array( 54, dtype=self.type.dtype), repr((obj, a.arr)))
             assert_(a.arr is obj)
-            assert_(obj.flags['FORTRAN']) # obj attributes are changed inplace!
+            assert_(obj.flags['FORTRAN'])  # obj attributes changed inplace!
             assert_(not obj.flags['CONTIGUOUS'])
-            assert_(obj.dtype.type is self.type.dtype) # obj type is changed inplace!
+            assert_(obj.dtype.type is self.type.dtype)  # obj changed inplace!
 
 
 for t in _type_names:
@@ -555,5 +590,4 @@ class test_%s_gen(unittest.TestCase,
 
 if __name__ == "__main__":
     setup()
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -1,15 +1,14 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import math
 
-from numpy.testing import *
-from numpy import array
-
+from numpy.testing import run_module_suite, assert_, dec
 import util
+
 
 def _path(*a):
     return os.path.join(*((os.path.dirname(__file__),) + a))
+
 
 class TestAssumedShapeSumExample(util.F2PyTest):
     sources = [_path('src', 'assumed_shape', 'foo_free.f90'),
@@ -21,17 +20,16 @@ class TestAssumedShapeSumExample(util.F2PyTest):
     @dec.slow
     def test_all(self):
         r = self.module.fsum([1, 2])
-        assert_(r==3, repr(r))
+        assert_(r == 3, repr(r))
         r = self.module.sum([1, 2])
-        assert_(r==3, repr(r))
+        assert_(r == 3, repr(r))
         r = self.module.sum_with_use([1, 2])
-        assert_(r==3, repr(r))
+        assert_(r == 3, repr(r))
 
         r = self.module.mod.sum([1, 2])
-        assert_(r==3, repr(r))
+        assert_(r == 3, repr(r))
         r = self.module.mod.fsum([1, 2])
-        assert_(r==3, repr(r))
+        assert_(r == 3, repr(r))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -1,10 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
-from numpy import array
 import math
-import util
 import textwrap
+
+from numpy import array
+from numpy.testing import run_module_suite, assert_, assert_equal, dec
+import util
 
 class TestF77Callback(util.F2PyTest):
     code = """
@@ -128,5 +129,4 @@ cf2py  intent(out) a
 
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -1,22 +1,21 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import math
 
-from numpy.testing import *
-from numpy import array
-
+from numpy.testing import run_module_suite, assert_, dec
+from numpy.f2py.crackfortran import (
+    _selected_int_kind_func as selected_int_kind,
+    _selected_real_kind_func as selected_real_kind
+)
 import util
+
 
 def _path(*a):
     return os.path.join(*((os.path.dirname(__file__),) + a))
 
-from numpy.f2py.crackfortran import _selected_int_kind_func as selected_int_kind
-from numpy.f2py.crackfortran import _selected_real_kind_func as selected_real_kind
 
 class TestKind(util.F2PyTest):
-    sources = [_path('src', 'kind', 'foo.f90'),
-               ]
+    sources = [_path('src', 'kind', 'foo.f90')]
 
     @dec.slow
     def test_all(self):
@@ -24,13 +23,14 @@ class TestKind(util.F2PyTest):
         selectedintkind = self.module.selectedintkind
 
         for i in range(40):
-            assert_(selectedintkind(i) in [selected_int_kind(i), -1],\
-                    'selectedintkind(%s): expected %r but got %r' %  (i, selected_int_kind(i), selectedintkind(i)))
+            assert_(selectedintkind(i) in [selected_int_kind(i), -1],
+                    'selectedintkind(%s): expected %r but got %r' %
+                        (i, selected_int_kind(i), selectedintkind(i)))
 
         for i in range(20):
-            assert_(selectedrealkind(i) in [selected_real_kind(i), -1],\
-                    'selectedrealkind(%s): expected %r but got %r' %  (i, selected_real_kind(i), selectedrealkind(i)))
+            assert_(selectedrealkind(i) in [selected_real_kind(i), -1],
+                    'selectedrealkind(%s): expected %r but got %r' %
+                        (i, selected_real_kind(i), selectedrealkind(i)))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -1,13 +1,10 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import math
-
-from numpy.testing import *
-from numpy import array
-
-import util
 import textwrap
+
+from numpy.testing import run_module_suite, assert_, assert_equal, dec
+import util
 
 def _path(*a):
     return os.path.join(*((os.path.dirname(__file__),) + a))
@@ -34,8 +31,8 @@ class TestMixed(util.F2PyTest):
         -------
         a : int
         """
-        assert_equal(self.module.bar11.__doc__, textwrap.dedent(expected).lstrip())
+        assert_equal(self.module.bar11.__doc__,
+                     textwrap.dedent(expected).lstrip())
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -1,29 +1,35 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 from numpy import array
 from numpy.compat import asbytes
+from numpy.testing import run_module_suite, assert_, dec
 import util
 
+
 class TestReturnCharacter(util.F2PyTest):
+
     def check_function(self, t):
         tname = t.__doc__.split()[0]
         if tname in ['t0', 't1', 's0', 's1']:
-            assert_( t(23)==asbytes('2'))
-            r = t('ab');assert_( r==asbytes('a'), repr(r))
-            r = t(array('ab'));assert_( r==asbytes('a'), repr(r))
-            r = t(array(77, 'u1'));assert_( r==asbytes('M'), repr(r))
+            assert_(t(23) == asbytes('2'))
+            r = t('ab')
+            assert_(r == asbytes('a'), repr(r))
+            r = t(array('ab'))
+            assert_(r == asbytes('a'), repr(r))
+            r = t(array(77, 'u1'))
+            assert_(r == asbytes('M'), repr(r))
             #assert_(_raises(ValueError, t, array([77,87])))
             #assert_(_raises(ValueError, t, array(77)))
         elif tname in ['ts', 'ss']:
-            assert_( t(23)==asbytes('23        '), repr(t(23)))
-            assert_( t('123456789abcdef')==asbytes('123456789a'))
+            assert_(t(23) == asbytes('23        '), repr(t(23)))
+            assert_(t('123456789abcdef') == asbytes('123456789a'))
         elif tname in ['t5', 's5']:
-            assert_( t(23)==asbytes('23   '), repr(t(23)))
-            assert_( t('ab')==asbytes('ab   '), repr(t('ab')))
-            assert_( t('123456789abcdef')==asbytes('12345'))
+            assert_(t(23) == asbytes('23   '), repr(t(23)))
+            assert_(t('ab') == asbytes('ab   '), repr(t('ab')))
+            assert_(t('123456789abcdef') == asbytes('12345'))
         else:
             raise NotImplementedError
+
 
 class TestF77ReturnCharacter(TestReturnCharacter):
     code = """
@@ -78,6 +84,7 @@ cf2py    intent(out) ts
     def test_all(self):
         for name in "t0,t1,t5,s0,s1,s5,ss".split(","):
             self.check_function(getattr(self.module, name))
+
 
 class TestF90ReturnCharacter(TestReturnCharacter):
     suffix = ".f90"
@@ -138,5 +145,4 @@ end module f90_return_char
             self.check_function(getattr(self.module.f90_return_char, name))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -1,39 +1,41 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 from numpy import array
 from numpy.compat import long
+from numpy.testing import run_module_suite, assert_, assert_raises, dec
 import util
 
+
 class TestReturnComplex(util.F2PyTest):
+
     def check_function(self, t):
         tname = t.__doc__.split()[0]
         if tname in ['t0', 't8', 's0', 's8']:
             err = 1e-5
         else:
             err = 0.0
-        assert_( abs(t(234j)-234.0j)<=err)
-        assert_( abs(t(234.6)-234.6)<=err)
-        assert_( abs(t(long(234))-234.0)<=err)
-        assert_( abs(t(234.6+3j)-(234.6+3j))<=err)
+        assert_(abs(t(234j) - 234.0j) <= err)
+        assert_(abs(t(234.6) - 234.6) <= err)
+        assert_(abs(t(long(234)) - 234.0) <= err)
+        assert_(abs(t(234.6 + 3j) - (234.6 + 3j)) <= err)
         #assert_( abs(t('234')-234.)<=err)
         #assert_( abs(t('234.6')-234.6)<=err)
-        assert_( abs(t(-234)+234.)<=err)
-        assert_( abs(t([234])-234.)<=err)
-        assert_( abs(t((234,))-234.)<=err)
-        assert_( abs(t(array(234))-234.)<=err)
-        assert_( abs(t(array(23+4j, 'F'))-(23+4j))<=err)
-        assert_( abs(t(array([234]))-234.)<=err)
-        assert_( abs(t(array([[234]]))-234.)<=err)
-        assert_( abs(t(array([234], 'b'))+22.)<=err)
-        assert_( abs(t(array([234], 'h'))-234.)<=err)
-        assert_( abs(t(array([234], 'i'))-234.)<=err)
-        assert_( abs(t(array([234], 'l'))-234.)<=err)
-        assert_( abs(t(array([234], 'q'))-234.)<=err)
-        assert_( abs(t(array([234], 'f'))-234.)<=err)
-        assert_( abs(t(array([234], 'd'))-234.)<=err)
-        assert_( abs(t(array([234+3j], 'F'))-(234+3j))<=err)
-        assert_( abs(t(array([234], 'D'))-234.)<=err)
+        assert_(abs(t(-234) + 234.) <= err)
+        assert_(abs(t([234]) - 234.) <= err)
+        assert_(abs(t((234,)) - 234.) <= err)
+        assert_(abs(t(array(234)) - 234.) <= err)
+        assert_(abs(t(array(23 + 4j, 'F')) - (23 + 4j)) <= err)
+        assert_(abs(t(array([234])) - 234.) <= err)
+        assert_(abs(t(array([[234]])) - 234.) <= err)
+        assert_(abs(t(array([234], 'b')) + 22.) <= err)
+        assert_(abs(t(array([234], 'h')) - 234.) <= err)
+        assert_(abs(t(array([234], 'i')) - 234.) <= err)
+        assert_(abs(t(array([234], 'l')) - 234.) <= err)
+        assert_(abs(t(array([234], 'q')) - 234.) <= err)
+        assert_(abs(t(array([234], 'f')) - 234.) <= err)
+        assert_(abs(t(array([234], 'd')) - 234.) <= err)
+        assert_(abs(t(array([234 + 3j], 'F')) - (234 + 3j)) <= err)
+        assert_(abs(t(array([234], 'D')) - 234.) <= err)
 
         #assert_raises(TypeError, t, array([234], 'a1'))
         assert_raises(TypeError, t, 'abc')
@@ -45,8 +47,8 @@ class TestReturnComplex(util.F2PyTest):
         assert_raises(TypeError, t, {})
 
         try:
-            r = t(10**400)
-            assert_( repr(r) in ['(inf+0j)', '(Infinity+0j)'], repr(r))
+            r = t(10 ** 400)
+            assert_(repr(r) in ['(inf+0j)', '(Infinity+0j)'], repr(r))
         except OverflowError:
             pass
 
@@ -165,5 +167,4 @@ end module f90_return_complex
             self.check_function(getattr(self.module.f90_return_complex, name))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -1,29 +1,31 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 from numpy import array
 from numpy.compat import long
+from numpy.testing import run_module_suite, assert_, assert_raises, dec
 import util
 
+
 class TestReturnInteger(util.F2PyTest):
+
     def check_function(self, t):
-        assert_( t(123)==123, repr(t(123)))
-        assert_( t(123.6)==123)
-        assert_( t(long(123))==123)
-        assert_( t('123')==123)
-        assert_( t(-123)==-123)
-        assert_( t([123])==123)
-        assert_( t((123,))==123)
-        assert_( t(array(123))==123)
-        assert_( t(array([123]))==123)
-        assert_( t(array([[123]]))==123)
-        assert_( t(array([123], 'b'))==123)
-        assert_( t(array([123], 'h'))==123)
-        assert_( t(array([123], 'i'))==123)
-        assert_( t(array([123], 'l'))==123)
-        assert_( t(array([123], 'B'))==123)
-        assert_( t(array([123], 'f'))==123)
-        assert_( t(array([123], 'd'))==123)
+        assert_(t(123) == 123, repr(t(123)))
+        assert_(t(123.6) == 123)
+        assert_(t(long(123)) == 123)
+        assert_(t('123') == 123)
+        assert_(t(-123) == -123)
+        assert_(t([123]) == 123)
+        assert_(t((123,)) == 123)
+        assert_(t(array(123)) == 123)
+        assert_(t(array([123])) == 123)
+        assert_(t(array([[123]])) == 123)
+        assert_(t(array([123], 'b')) == 123)
+        assert_(t(array([123], 'h')) == 123)
+        assert_(t(array([123], 'i')) == 123)
+        assert_(t(array([123], 'l')) == 123)
+        assert_(t(array([123], 'B')) == 123)
+        assert_(t(array([123], 'f')) == 123)
+        assert_(t(array([123], 'd')) == 123)
 
         #assert_raises(ValueError, t, array([123],'S3'))
         assert_raises(ValueError, t, 'abc')
@@ -37,6 +39,7 @@ class TestReturnInteger(util.F2PyTest):
         if t.__doc__.split()[0] in ['t8', 's8']:
             assert_raises(OverflowError, t, 100000000000000000000000)
             assert_raises(OverflowError, t, 10000000011111111111111.23)
+
 
 class TestF77ReturnInteger(TestReturnInteger):
     code = """
@@ -174,5 +177,4 @@ end module f90_return_integer
             self.check_function(getattr(self.module.f90_return_integer, name))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -1,50 +1,52 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 from numpy import array
 from numpy.compat import long
+from numpy.testing import run_module_suite, assert_, assert_raises, dec
 import util
 
+
 class TestReturnLogical(util.F2PyTest):
+
     def check_function(self, t):
-        assert_( t(True)==1, repr(t(True)))
-        assert_( t(False)==0, repr(t(False)))
-        assert_( t(0)==0)
-        assert_( t(None)==0)
-        assert_( t(0.0)==0)
-        assert_( t(0j)==0)
-        assert_( t(1j)==1)
-        assert_( t(234)==1)
-        assert_( t(234.6)==1)
-        assert_( t(long(234))==1)
-        assert_( t(234.6+3j)==1)
-        assert_( t('234')==1)
-        assert_( t('aaa')==1)
-        assert_( t('')==0)
-        assert_( t([])==0)
-        assert_( t(())==0)
-        assert_( t({})==0)
-        assert_( t(t)==1)
-        assert_( t(-234)==1)
-        assert_( t(10**100)==1)
-        assert_( t([234])==1)
-        assert_( t((234,))==1)
-        assert_( t(array(234))==1)
-        assert_( t(array([234]))==1)
-        assert_( t(array([[234]]))==1)
-        assert_( t(array([234], 'b'))==1)
-        assert_( t(array([234], 'h'))==1)
-        assert_( t(array([234], 'i'))==1)
-        assert_( t(array([234], 'l'))==1)
-        assert_( t(array([234], 'f'))==1)
-        assert_( t(array([234], 'd'))==1)
-        assert_( t(array([234+3j], 'F'))==1)
-        assert_( t(array([234], 'D'))==1)
-        assert_( t(array(0))==0)
-        assert_( t(array([0]))==0)
-        assert_( t(array([[0]]))==0)
-        assert_( t(array([0j]))==0)
-        assert_( t(array([1]))==1)
+        assert_(t(True) == 1, repr(t(True)))
+        assert_(t(False) == 0, repr(t(False)))
+        assert_(t(0) == 0)
+        assert_(t(None) == 0)
+        assert_(t(0.0) == 0)
+        assert_(t(0j) == 0)
+        assert_(t(1j) == 1)
+        assert_(t(234) == 1)
+        assert_(t(234.6) == 1)
+        assert_(t(long(234)) == 1)
+        assert_(t(234.6 + 3j) == 1)
+        assert_(t('234') == 1)
+        assert_(t('aaa') == 1)
+        assert_(t('') == 0)
+        assert_(t([]) == 0)
+        assert_(t(()) == 0)
+        assert_(t({}) == 0)
+        assert_(t(t) == 1)
+        assert_(t(-234) == 1)
+        assert_(t(10 ** 100) == 1)
+        assert_(t([234]) == 1)
+        assert_(t((234,)) == 1)
+        assert_(t(array(234)) == 1)
+        assert_(t(array([234])) == 1)
+        assert_(t(array([[234]])) == 1)
+        assert_(t(array([234], 'b')) == 1)
+        assert_(t(array([234], 'h')) == 1)
+        assert_(t(array([234], 'i')) == 1)
+        assert_(t(array([234], 'l')) == 1)
+        assert_(t(array([234], 'f')) == 1)
+        assert_(t(array([234], 'd')) == 1)
+        assert_(t(array([234 + 3j], 'F')) == 1)
+        assert_(t(array([234], 'D')) == 1)
+        assert_(t(array(0)) == 0)
+        assert_(t(array([0])) == 0)
+        assert_(t(array([[0]])) == 0)
+        assert_(t(array([0j])) == 0)
+        assert_(t(array([1])) == 1)
         assert_raises(ValueError, t, array([0, 0]))
 
 
@@ -112,6 +114,7 @@ c       end
     def test_all(self):
         for name in "t0,t1,t2,t4,s0,s1,s2,s4".split(","):
             self.check_function(getattr(self.module, name))
+
 
 class TestF90ReturnLogical(TestReturnLogical):
     suffix = ".f90"
@@ -183,5 +186,4 @@ end module f90_return_logical
             self.check_function(getattr(self.module.f90_return_logical, name))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -1,37 +1,38 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 from numpy import array
 from numpy.compat import long
-import math
+from numpy.testing import run_module_suite, assert_, assert_raises, dec
 import util
 
+
 class TestReturnReal(util.F2PyTest):
+
     def check_function(self, t):
         if t.__doc__.split()[0] in ['t0', 't4', 's0', 's4']:
             err = 1e-5
         else:
             err = 0.0
-        assert_( abs(t(234)-234.0)<=err)
-        assert_( abs(t(234.6)-234.6)<=err)
-        assert_( abs(t(long(234))-234.0)<=err)
-        assert_( abs(t('234')-234)<=err)
-        assert_( abs(t('234.6')-234.6)<=err)
-        assert_( abs(t(-234)+234)<=err)
-        assert_( abs(t([234])-234)<=err)
-        assert_( abs(t((234,))-234.)<=err)
-        assert_( abs(t(array(234))-234.)<=err)
-        assert_( abs(t(array([234]))-234.)<=err)
-        assert_( abs(t(array([[234]]))-234.)<=err)
-        assert_( abs(t(array([234], 'b'))+22)<=err)
-        assert_( abs(t(array([234], 'h'))-234.)<=err)
-        assert_( abs(t(array([234], 'i'))-234.)<=err)
-        assert_( abs(t(array([234], 'l'))-234.)<=err)
-        assert_( abs(t(array([234], 'B'))-234.)<=err)
-        assert_( abs(t(array([234], 'f'))-234.)<=err)
-        assert_( abs(t(array([234], 'd'))-234.)<=err)
+        assert_(abs(t(234) - 234.0) <= err)
+        assert_(abs(t(234.6) - 234.6) <= err)
+        assert_(abs(t(long(234)) - 234.0) <= err)
+        assert_(abs(t('234') - 234) <= err)
+        assert_(abs(t('234.6') - 234.6) <= err)
+        assert_(abs(t(-234) + 234) <= err)
+        assert_(abs(t([234]) - 234) <= err)
+        assert_(abs(t((234,)) - 234.) <= err)
+        assert_(abs(t(array(234)) - 234.) <= err)
+        assert_(abs(t(array([234])) - 234.) <= err)
+        assert_(abs(t(array([[234]])) - 234.) <= err)
+        assert_(abs(t(array([234], 'b')) + 22) <= err)
+        assert_(abs(t(array([234], 'h')) - 234.) <= err)
+        assert_(abs(t(array([234], 'i')) - 234.) <= err)
+        assert_(abs(t(array([234], 'l')) - 234.) <= err)
+        assert_(abs(t(array([234], 'B')) - 234.) <= err)
+        assert_(abs(t(array([234], 'f')) - 234.) <= err)
+        assert_(abs(t(array([234], 'd')) - 234.) <= err)
         if t.__doc__.split()[0] in ['t0', 't4', 's0', 's4']:
-            assert_( t(1e200)==t(1e300)) # inf
+            assert_(t(1e200) == t(1e300))  # inf
 
         #assert_raises(ValueError, t, array([234], 'S1'))
         assert_raises(ValueError, t, 'abc')
@@ -43,10 +44,11 @@ class TestReturnReal(util.F2PyTest):
         assert_raises(Exception, t, {})
 
         try:
-            r = t(10**400)
-            assert_( repr(r) in ['inf', 'Infinity'], repr(r))
+            r = t(10 ** 400)
+            assert_(repr(r) in ['inf', 'Infinity'], repr(r))
         except OverflowError:
             pass
+
 
 class TestCReturnReal(TestReturnReal):
     suffix = ".pyf"
@@ -84,6 +86,7 @@ end python module c_ext_return_real
     def test_all(self):
         for name in "t4,t8,s4,s8".split(","):
             self.check_function(getattr(self.module, name))
+
 
 class TestF77ReturnReal(TestReturnReal):
     code = """
@@ -138,6 +141,7 @@ cf2py    intent(out) td
     def test_all(self):
         for name in "t0,t4,t8,td,s0,s4,s8,sd".split(","):
             self.check_function(getattr(self.module, name))
+
 
 class TestF90ReturnReal(TestReturnReal):
     suffix = ".f90"
@@ -199,5 +203,4 @@ end module f90_return_real
 
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -1,19 +1,17 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import math
 
-from numpy.testing import *
-from numpy import array
-
+from numpy.testing import run_module_suite, assert_equal, dec
 import util
+
 
 def _path(*a):
     return os.path.join(*((os.path.dirname(__file__),) + a))
 
+
 class TestSizeSumExample(util.F2PyTest):
-    sources = [_path('src', 'size', 'foo.f90'),
-               ]
+    sources = [_path('src', 'size', 'foo.f90')]
 
     @dec.slow
     def test_all(self):
@@ -43,5 +41,4 @@ class TestSizeSumExample(util.F2PyTest):
         assert_equal(r, [1, 2, 3, 4, 5, 6], repr(r))
 
 if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -9,14 +9,22 @@ from numpy.testing import (
     assert_almost_equal, assert_array_almost_equal, assert_raises,
     assert_allclose, assert_array_max_ulp, assert_warns,
     assert_raises_regex, dec, clear_and_catch_warnings
-    )
+)
 import numpy.lib.function_base as nfb
 from numpy.random import rand
-from numpy.lib import *
+from numpy.lib import (
+    add_newdoc_ufunc, angle, average, bartlett, blackman, corrcoef, cov,
+    delete, diff, digitize, extract, flipud, gradient, hamming, hanning,
+    histogram, histogramdd, i0, insert, interp, kaiser, meshgrid, msort,
+    piecewise, place, select, setxor1d, sinc, split, trapz, trim_zeros,
+    unwrap, unique, vectorize,
+)
+
 from numpy.compat import long
 
 
 class TestAny(TestCase):
+
     def test_basic(self):
         y1 = [0, 0, 1, 0]
         y2 = [0, 0, 0, 0]
@@ -33,6 +41,7 @@ class TestAny(TestCase):
 
 
 class TestAll(TestCase):
+
     def test_basic(self):
         y1 = [0, 1, 1, 0]
         y2 = [0, 0, 0, 0]
@@ -50,6 +59,7 @@ class TestAll(TestCase):
 
 
 class TestCopy(TestCase):
+
     def test_basic(self):
         a = np.array([[1, 2], [3, 4]])
         a_copy = np.copy(a)
@@ -77,6 +87,7 @@ class TestCopy(TestCase):
 
 
 class TestAverage(TestCase):
+
     def test_basic(self):
         y1 = np.array([1, 2, 3])
         assert_(average(y1, axis=0) == 2.)
@@ -102,7 +113,7 @@ class TestAverage(TestCase):
         y = np.arange(10)
         w = np.arange(10)
         actual = average(y, weights=w)
-        desired = (np.arange(10) ** 2).sum()*1. / np.arange(10).sum()
+        desired = (np.arange(10) ** 2).sum() * 1. / np.arange(10).sum()
         assert_almost_equal(actual, desired)
 
         y1 = np.array([[1, 2, 3], [4, 5, 6]])
@@ -230,6 +241,7 @@ class TestSelect(TestCase):
 
 
 class TestInsert(TestCase):
+
     def test_basic(self):
         a = [1, 2, 3]
         assert_equal(insert(a, 0, 1), [1, 1, 2, 3])
@@ -247,7 +259,7 @@ class TestInsert(TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', FutureWarning)
             assert_equal(
-                insert(a, np.array([True]*4), 9), [1, 9, 9, 9, 9, 2, 3])
+                insert(a, np.array([True] * 4), 9), [1, 9, 9, 9, 9, 2, 3])
             assert_(w[0].category is FutureWarning)
 
     def test_multidim(self):
@@ -272,25 +284,25 @@ class TestInsert(TestCase):
 
         a = np.arange(4).reshape(2, 2)
         assert_equal(insert(a[:, :1], 1, a[:, 1], axis=1), a)
-        assert_equal(insert(a[:1, :], 1, a[1, :], axis=0), a)
+        assert_equal(insert(a[:1,:], 1, a[1,:], axis=0), a)
 
         # negative axis value
         a = np.arange(24).reshape((2, 3, 4))
-        assert_equal(insert(a, 1, a[:, :, 3], axis=-1),
-                     insert(a, 1, a[:, :, 3], axis=2))
-        assert_equal(insert(a, 1, a[:, 2, :], axis=-2),
-                     insert(a, 1, a[:, 2, :], axis=1))
+        assert_equal(insert(a, 1, a[:,:, 3], axis=-1),
+                     insert(a, 1, a[:,:, 3], axis=2))
+        assert_equal(insert(a, 1, a[:, 2,:], axis=-2),
+                     insert(a, 1, a[:, 2,:], axis=1))
 
         # invalid axis value
-        assert_raises(IndexError, insert, a, 1, a[:, 2, :], axis=3)
-        assert_raises(IndexError, insert, a, 1, a[:, 2, :], axis=-4)
+        assert_raises(IndexError, insert, a, 1, a[:, 2,:], axis=3)
+        assert_raises(IndexError, insert, a, 1, a[:, 2,:], axis=-4)
 
         # negative axis value
-        a = np.arange(24).reshape((2,3,4))
-        assert_equal(insert(a, 1, a[:,:,3], axis=-1),
-                     insert(a, 1, a[:,:,3], axis=2))
-        assert_equal(insert(a, 1, a[:,2,:], axis=-2),
-                     insert(a, 1, a[:,2,:], axis=1))
+        a = np.arange(24).reshape((2, 3, 4))
+        assert_equal(insert(a, 1, a[:,:, 3], axis=-1),
+                     insert(a, 1, a[:,:, 3], axis=2))
+        assert_equal(insert(a, 1, a[:, 2,:], axis=-2),
+                     insert(a, 1, a[:, 2,:], axis=1))
 
     def test_0d(self):
         # This is an error in the future
@@ -330,6 +342,7 @@ class TestInsert(TestCase):
 
 
 class TestAmax(TestCase):
+
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.amax(a), 10.0)
@@ -341,6 +354,7 @@ class TestAmax(TestCase):
 
 
 class TestAmin(TestCase):
+
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.amin(a), -5.0)
@@ -352,6 +366,7 @@ class TestAmin(TestCase):
 
 
 class TestPtp(TestCase):
+
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.ptp(a, axis=0), 15.0)
@@ -363,6 +378,7 @@ class TestPtp(TestCase):
 
 
 class TestCumsum(TestCase):
+
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]
@@ -384,6 +400,7 @@ class TestCumsum(TestCase):
 
 
 class TestProd(TestCase):
+
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]
@@ -392,9 +409,9 @@ class TestProd(TestCase):
             a = np.array(ba, ctype)
             a2 = np.array(ba2, ctype)
             if ctype in ['1', 'b']:
-                self.assertRaises(ArithmeticError, prod, a)
-                self.assertRaises(ArithmeticError, prod, a2, 1)
-                self.assertRaises(ArithmeticError, prod, a)
+                self.assertRaises(ArithmeticError, np.prod, a)
+                self.assertRaises(ArithmeticError, np.prod, a2, 1)
+                self.assertRaises(ArithmeticError, np.prod, a)
             else:
                 assert_equal(np.prod(a, axis=0), 26400)
                 assert_array_equal(np.prod(a2, axis=0),
@@ -404,6 +421,7 @@ class TestProd(TestCase):
 
 
 class TestCumprod(TestCase):
+
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]
@@ -412,9 +430,9 @@ class TestCumprod(TestCase):
             a = np.array(ba, ctype)
             a2 = np.array(ba2, ctype)
             if ctype in ['1', 'b']:
-                self.assertRaises(ArithmeticError, cumprod, a)
-                self.assertRaises(ArithmeticError, cumprod, a2, 1)
-                self.assertRaises(ArithmeticError, cumprod, a)
+                self.assertRaises(ArithmeticError, np.cumprod, a)
+                self.assertRaises(ArithmeticError, np.cumprod, a2, 1)
+                self.assertRaises(ArithmeticError, np.cumprod, a)
             else:
                 assert_array_equal(np.cumprod(a, axis=-1),
                                    np.array([1, 2, 20, 220,
@@ -430,6 +448,7 @@ class TestCumprod(TestCase):
 
 
 class TestDiff(TestCase):
+
     def test_basic(self):
         x = [1, 4, 6, 7, 12]
         out = np.array([3, 2, 1, 5])
@@ -441,10 +460,10 @@ class TestDiff(TestCase):
 
     def test_nd(self):
         x = 20 * rand(10, 20, 30)
-        out1 = x[:, :, 1:] - x[:, :, :-1]
-        out2 = out1[:, :, 1:] - out1[:, :, :-1]
-        out3 = x[1:, :, :] - x[:-1, :, :]
-        out4 = out3[1:, :, :] - out3[:-1, :, :]
+        out1 = x[:,:, 1:] - x[:,:, :-1]
+        out2 = out1[:,:, 1:] - out1[:,:, :-1]
+        out3 = x[1:,:,:] - x[:-1,:,:]
+        out4 = out3[1:,:,:] - out3[:-1,:,:]
         assert_array_equal(diff(x), out1)
         assert_array_equal(diff(x, n=2), out2)
         assert_array_equal(diff(x, axis=0), out3)
@@ -452,6 +471,7 @@ class TestDiff(TestCase):
 
 
 class TestDelete(TestCase):
+
     def setUp(self):
         self.a = np.arange(5)
         self.nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
@@ -466,8 +486,8 @@ class TestDelete(TestCase):
             indices = indices[(indices >= 0) & (indices < 5)]
         assert_array_equal(setxor1d(a_del, self.a[indices, ]), self.a,
                            err_msg=msg)
-        xor = setxor1d(nd_a_del[0, :, 0], self.nd_a[0, indices, 0])
-        assert_array_equal(xor, self.nd_a[0, :, 0], err_msg=msg)
+        xor = setxor1d(nd_a_del[0,:, 0], self.nd_a[0, indices, 0])
+        assert_array_equal(xor, self.nd_a[0,:, 0], err_msg=msg)
 
     def test_slices(self):
         lims = [-6, -2, 0, 1, 2, 4, 5]
@@ -516,6 +536,7 @@ class TestDelete(TestCase):
 
 
 class TestGradient(TestCase):
+
     def test_basic(self):
         v = [[1, 1], [3, 4]]
         x = np.array(v)
@@ -582,6 +603,7 @@ class TestGradient(TestCase):
 
 
 class TestAngle(TestCase):
+
     def test_basic(self):
         x = [1 + 3j, np.sqrt(2) / 2.0 + 1j * np.sqrt(2) / 2,
              1, 1j, -1, -1j, 1 - 3j, -1 + 3j]
@@ -597,8 +619,12 @@ class TestAngle(TestCase):
 
 
 class TestTrimZeros(TestCase):
-    """ only testing for integer splits.
+
     """
+    Only testing for integer splits.
+
+    """
+
     def test_basic(self):
         a = np.array([0, 0, 1, 2, 3, 4, 0])
         res = trim_zeros(a)
@@ -616,6 +642,7 @@ class TestTrimZeros(TestCase):
 
 
 class TestExtins(TestCase):
+
     def test_basic(self):
         a = np.array([1, 3, 2, 1, 2, 3, 3])
         b = extract(a > 1, a)
@@ -632,7 +659,7 @@ class TestExtins(TestCase):
         place(a, [1, 0, 1, 0, 1, 0, 1], [8, 9])
         assert_array_equal(a, [8, 2, 9, 4, 8, 6, 9])
         assert_raises_regex(ValueError, "Cannot insert from an empty array",
-                lambda: place(a, [0, 0, 0, 0, 0, 1, 0], []))
+                            lambda: place(a, [0, 0, 0, 0, 0, 1, 0], []))
 
     def test_both(self):
         a = rand(10)
@@ -645,12 +672,14 @@ class TestExtins(TestCase):
 
 
 class TestVectorize(TestCase):
+
     def test_simple(self):
         def addsubtract(a, b):
             if a > b:
                 return a - b
             else:
                 return a + b
+
         f = vectorize(addsubtract)
         r = f([0, 3, 6, 9], [1, 3, 5, 7])
         assert_array_equal(r, [1, 6, 1, 2])
@@ -661,6 +690,7 @@ class TestVectorize(TestCase):
                 return a - b
             else:
                 return a + b
+
         f = vectorize(addsubtract)
         r = f([0, 3, 6, 9], 5)
         assert_array_equal(r, [5, 8, 1, 4])
@@ -674,16 +704,16 @@ class TestVectorize(TestCase):
     def test_ufunc(self):
         import math
         f = vectorize(math.cos)
-        args = np.array([0, 0.5*np.pi, np.pi, 1.5*np.pi, 2*np.pi])
+        args = np.array([0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2 * np.pi])
         r1 = f(args)
         r2 = np.cos(args)
         assert_array_almost_equal(r1, r2)
 
     def test_keywords(self):
-        import math
 
         def foo(a, b=1):
             return a + b
+
         f = vectorize(foo)
         args = np.array([1, 2, 3])
         r1 = f(args)
@@ -699,16 +729,16 @@ class TestVectorize(TestCase):
         # inspect the func_code.
         import random
         try:
-            f = vectorize(random.randrange)
+            vectorize(random.randrange)  # Should succeed
         except:
             raise AssertionError()
 
     def test_keywords2_ticket_2100(self):
-        r"""Test kwarg support: enhancement ticket 2100"""
-        import math
+        # Test kwarg support: enhancement ticket 2100
 
         def foo(a, b=1):
             return a + b
+
         f = vectorize(foo)
         args = np.array([1, 2, 3])
         r1 = f(a=args)
@@ -721,13 +751,14 @@ class TestVectorize(TestCase):
         assert_array_equal(r1, r2)
 
     def test_keywords3_ticket_2100(self):
-        """Test excluded with mixed positional and kwargs: ticket 2100"""
+        # Test excluded with mixed positional and kwargs: ticket 2100
         def mypolyval(x, p):
             _p = list(p)
             res = _p.pop(0)
             while _p:
-                res = res*x + _p.pop(0)
+                res = res * x + _p.pop(0)
             return res
+
         vpolyval = np.vectorize(mypolyval, excluded=['p', 1])
         ans = [3, 6]
         assert_array_equal(ans, vpolyval(x=[0, 1], p=[1, 2, 3]))
@@ -735,49 +766,54 @@ class TestVectorize(TestCase):
         assert_array_equal(ans, vpolyval([0, 1], [1, 2, 3]))
 
     def test_keywords4_ticket_2100(self):
-        """Test vectorizing function with no positional args."""
+        # Test vectorizing function with no positional args.
         @vectorize
         def f(**kw):
             res = 1.0
             for _k in kw:
                 res *= kw[_k]
             return res
+
         assert_array_equal(f(a=[1, 2], b=[3, 4]), [3, 8])
 
     def test_keywords5_ticket_2100(self):
-        """Test vectorizing function with no kwargs args."""
+        # Test vectorizing function with no kwargs args.
         @vectorize
         def f(*v):
             return np.prod(v)
+
         assert_array_equal(f([1, 2], [3, 4]), [3, 8])
 
     def test_coverage1_ticket_2100(self):
         def foo():
             return 1
+
         f = vectorize(foo)
         assert_array_equal(f(), 1)
 
     def test_assigning_docstring(self):
         def foo(x):
             return x
+
         doc = "Provided documentation"
         f = vectorize(foo, doc=doc)
         assert_equal(f.__doc__, doc)
 
     def test_UnboundMethod_ticket_1156(self):
-        """Regression test for issue 1156"""
+        # Regression test for issue 1156
         class Foo:
             b = 2
 
             def bar(self, a):
-                return a**self.b
+                return a ** self.b
+
         assert_array_equal(vectorize(Foo().bar)(np.arange(9)),
-                           np.arange(9)**2)
+                           np.arange(9) ** 2)
         assert_array_equal(vectorize(Foo.bar)(Foo(), np.arange(9)),
-                           np.arange(9)**2)
+                           np.arange(9) ** 2)
 
     def test_execution_order_ticket_1487(self):
-        """Regression test for dependence on execution order: issue 1487"""
+        # Regression test for dependence on execution order: issue 1487
         f1 = vectorize(lambda x: x)
         res1a = f1(np.arange(3))
         res1b = f1(np.arange(0.1, 3))
@@ -788,24 +824,23 @@ class TestVectorize(TestCase):
         assert_equal(res1b, res2b)
 
     def test_string_ticket_1892(self):
-        """Test vectorization over strings: issue 1892."""
+        # Test vectorization over strings: issue 1892.
         f = np.vectorize(lambda x: x)
-        s = '0123456789'*10
+        s = '0123456789' * 10
         assert_equal(s, f(s))
-        #z = f(np.array([s,s]))
-        #assert_array_equal([s,s], f(s))
 
     def test_cache(self):
-        """Ensure that vectorized func called exactly once per argument."""
+        # Ensure that vectorized func called exactly once per argument.
         _calls = [0]
 
         @vectorize
         def f(x):
             _calls[0] += 1
-            return x**2
+            return x ** 2
+
         f.cache = True
         x = np.arange(5)
-        assert_array_equal(f(x), x*x)
+        assert_array_equal(f(x), x * x)
         assert_equal(_calls[0], len(x))
 
     def test_otypes(self):
@@ -816,6 +851,7 @@ class TestVectorize(TestCase):
 
 
 class TestDigitize(TestCase):
+
     def test_forward(self):
         x = np.arange(-6, 5)
         bins = np.arange(-5, 5)
@@ -871,7 +907,7 @@ class TestDigitize(TestCase):
         assert_raises(ValueError, digitize, x, bins)
 
     def test_casting_error(self):
-        x = [1, 2, 3+1.j]
+        x = [1, 2, 3 + 1.j]
         bins = [1, 2, 3]
         assert_raises(TypeError, digitize, x, bins)
         x, bins = bins, x
@@ -879,48 +915,51 @@ class TestDigitize(TestCase):
 
 
 class TestUnwrap(TestCase):
+
     def test_simple(self):
-                #check that unwrap removes jumps greather that 2*pi
+        # check that unwrap removes jumps greather that 2*pi
         assert_array_equal(unwrap([1, 1 + 2 * np.pi]), [1, 1])
-        #check that unwrap maintans continuity
+        # check that unwrap maintans continuity
         assert_(np.all(diff(unwrap(rand(10) * 100)) < np.pi))
 
 
 class TestFilterwindows(TestCase):
+
     def test_hanning(self):
-        #check symmetry
+        # check symmetry
         w = hanning(10)
         assert_array_almost_equal(w, flipud(w), 7)
-        #check known value
+        # check known value
         assert_almost_equal(np.sum(w, axis=0), 4.500, 4)
 
     def test_hamming(self):
-        #check symmetry
+        # check symmetry
         w = hamming(10)
         assert_array_almost_equal(w, flipud(w), 7)
-        #check known value
+        # check known value
         assert_almost_equal(np.sum(w, axis=0), 4.9400, 4)
 
     def test_bartlett(self):
-        #check symmetry
+        # check symmetry
         w = bartlett(10)
         assert_array_almost_equal(w, flipud(w), 7)
-        #check known value
+        # check known value
         assert_almost_equal(np.sum(w, axis=0), 4.4444, 4)
 
     def test_blackman(self):
-        #check symmetry
+        # check symmetry
         w = blackman(10)
         assert_array_almost_equal(w, flipud(w), 7)
-        #check known value
+        # check known value
         assert_almost_equal(np.sum(w, axis=0), 3.7800, 4)
 
 
 class TestTrapz(TestCase):
+
     def test_simple(self):
         x = np.arange(-10, 10, .1)
-        r = trapz(np.exp(-.5*x**2) / np.sqrt(2*np.pi), dx=0.1)
-        #check integral of normal equals 1
+        r = trapz(np.exp(-.5 * x ** 2) / np.sqrt(2 * np.pi), dx=0.1)
+        # check integral of normal equals 1
         assert_almost_equal(r, 1, 7)
 
     def test_ndim(self):
@@ -938,18 +977,18 @@ class TestTrapz(TestCase):
         wz[0] /= 2
         wz[-1] /= 2
 
-        q = x[:, None, None] + y[None, :, None] + z[None, None, :]
+        q = x[:, None, None] + y[None,:, None] + z[None, None,:]
 
         qx = (q * wx[:, None, None]).sum(axis=0)
-        qy = (q * wy[None, :, None]).sum(axis=1)
-        qz = (q * wz[None, None, :]).sum(axis=2)
+        qy = (q * wy[None,:, None]).sum(axis=1)
+        qz = (q * wz[None, None,:]).sum(axis=2)
 
         # n-d `x`
         r = trapz(q, x=x[:, None, None], axis=0)
         assert_almost_equal(r, qx)
-        r = trapz(q, x=y[None, :, None], axis=1)
+        r = trapz(q, x=y[None,:, None], axis=1)
         assert_almost_equal(r, qy)
-        r = trapz(q, x=z[None, None, :], axis=2)
+        r = trapz(q, x=z[None, None,:], axis=2)
         assert_almost_equal(r, qz)
 
         # 1-d `x`
@@ -961,8 +1000,8 @@ class TestTrapz(TestCase):
         assert_almost_equal(r, qz)
 
     def test_masked(self):
-        #Testing that masked arrays behave as if the function is 0 where
-        #masked
+        # Testing that masked arrays behave as if the function is 0 where
+        # masked
         x = np.arange(5)
         y = x * x
         mask = x == 2
@@ -977,7 +1016,7 @@ class TestTrapz(TestCase):
         assert_almost_equal(trapz(y, xm), r)
 
     def test_matrix(self):
-        #Test to make sure matrices give the same answer as ndarrays
+        # Test to make sure matrices give the same answer as ndarrays
         x = np.linspace(0, 5)
         y = x * x
         r = trapz(y, x)
@@ -988,10 +1027,11 @@ class TestTrapz(TestCase):
 
 
 class TestSinc(TestCase):
+
     def test_simple(self):
         assert_(sinc(0) == 1)
         w = sinc(np.linspace(-1, 1, 100))
-        #check symmetry
+        # check symmetry
         assert_array_almost_equal(w, flipud(w), 7)
 
     def test_array_like(self):
@@ -1004,6 +1044,7 @@ class TestSinc(TestCase):
 
 
 class TestHistogram(TestCase):
+
     def setUp(self):
         pass
 
@@ -1014,10 +1055,10 @@ class TestHistogram(TestCase):
         n = 100
         v = rand(n)
         (a, b) = histogram(v)
-        #check if the sum of the bins equals the number of samples
+        # check if the sum of the bins equals the number of samples
         assert_equal(np.sum(a, axis=0), n)
-        #check that the bin counts are evenly spaced when the data is from a
-        # linear function
+        # check that the bin counts are evenly spaced when the data is from
+        # a linear function
         (a, b) = histogram(np.linspace(0, 10, 100))
         assert_array_equal(a, 10)
 
@@ -1039,7 +1080,8 @@ class TestHistogram(TestCase):
         area = np.sum(a * diff(b))
         assert_almost_equal(area, 1)
 
-        # Check with non-constant bin widths (buggy but backwards compatible)
+        # Check with non-constant bin widths (buggy but backwards
+        # compatible)
         v = np.arange(10)
         bins = [0, 1, 5, 9, 10]
         a, b = histogram(v, bins, normed=True)
@@ -1059,7 +1101,7 @@ class TestHistogram(TestCase):
         bins = [0, 1, 3, 6, 10]
         a, b = histogram(v, bins, density=True)
         assert_array_equal(a, .1)
-        assert_equal(np.sum(a*diff(b)), 1)
+        assert_equal(np.sum(a * diff(b)), 1)
 
         # Variale bin widths are especially useful to deal with
         # infinities.
@@ -1102,20 +1144,20 @@ class TestHistogram(TestCase):
         # Check the type of the returned histogram
         a = np.arange(10) + .5
         h, b = histogram(a)
-        assert_(issubdtype(h.dtype, int))
+        assert_(np.issubdtype(h.dtype, int))
 
         h, b = histogram(a, normed=True)
-        assert_(issubdtype(h.dtype, float))
+        assert_(np.issubdtype(h.dtype, float))
 
         h, b = histogram(a, weights=np.ones(10, int))
-        assert_(issubdtype(h.dtype, int))
+        assert_(np.issubdtype(h.dtype, int))
 
         h, b = histogram(a, weights=np.ones(10, float))
-        assert_(issubdtype(h.dtype, float))
+        assert_(np.issubdtype(h.dtype, float))
 
     def test_f32_rounding(self):
         # gh-4799, check that the rounding of the edges works with float32
-        x = np.array([276.318359  , -69.593948  , 21.329449], dtype=np.float32)
+        x = np.array([276.318359, -69.593948, 21.329449], dtype=np.float32)
         y = np.array([5005.689453, 4481.327637, 6010.369629], dtype=np.float32)
         counts_hist, xedges, yedges = np.histogram2d(x, y, bins=100)
         assert_equal(counts_hist.sum(), 3.)
@@ -1160,11 +1202,11 @@ class TestHistogram(TestCase):
 
         # Check with custom bins
         wa, wb = histogram(values, bins=[0, 2, 3], weights=weights)
-        assert_array_almost_equal(wa, np.array([1, 1]) + 1j * np.array([2,3]))
+        assert_array_almost_equal(wa, np.array([1, 1]) + 1j * np.array([2, 3]))
 
         # Check with even bins
-        wa, wb = histogram(values, bins=2, range=[1,3], weights=weights)
-        assert_array_almost_equal(wa, np.array([1, 1]) + 1j * np.array([2,3]))
+        wa, wb = histogram(values, bins=2, range=[1, 3], weights=weights)
+        assert_array_almost_equal(wa, np.array([1, 1]) + 1j * np.array([2, 3]))
 
         # Decimal weights
         from decimal import Decimal
@@ -1176,9 +1218,8 @@ class TestHistogram(TestCase):
         assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
 
         # Check with even bins
-        wa, wb = histogram(values, bins=2, range=[1,3], weights=weights)
+        wa, wb = histogram(values, bins=2, range=[1, 3], weights=weights)
         assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
-
 
     def test_empty(self):
         a, b = histogram([], bins=([0, 1]))
@@ -1187,6 +1228,7 @@ class TestHistogram(TestCase):
 
 
 class TestHistogramdd(TestCase):
+
     def test_simple(self):
         x = np.array([[-.5, .5, 1.5], [-.5, 1.5, 2.5], [-.5, 2.5, .5],
                       [.5,  .5, 1.5], [.5,  1.5, 2.5], [.5,  2.5, 2.5]])
@@ -1270,8 +1312,8 @@ class TestHistogramdd(TestCase):
         assert_array_max_ulp(a, np.zeros((2, 2, 2)))
 
     def test_bins_errors(self):
-        """There are two ways to specify bins. Check for the right errors when
-        mixing those."""
+        # There are two ways to specify bins. Check for the right errors
+        # when mixing those.
         x = np.arange(8).reshape(2, 4)
         assert_raises(ValueError, np.histogramdd, x, bins=[-1, 2, 4, 5])
         assert_raises(ValueError, np.histogramdd, x, bins=[1, 0.99, 1, 1])
@@ -1282,7 +1324,7 @@ class TestHistogramdd(TestCase):
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))
 
     def test_inf_edges(self):
-        """Test using +/-inf bin edges works. See #1788."""
+        # Test using +/-inf bin edges works. See #1788.
         with np.errstate(invalid='ignore'):
             x = np.arange(6).reshape(3, 2)
             expected = np.array([[1, 0], [0, 1], [0, 1]])
@@ -1294,31 +1336,31 @@ class TestHistogramdd(TestCase):
             assert_allclose(h, expected)
 
     def test_rightmost_binedge(self):
-        """Test event very close to rightmost binedge.
-        See Github issue #4266"""
+        # Test event very close to rightmost binedge. See Github issue #4266
         x = [0.9999999995]
-        bins = [[0.,0.5,1.0]]
+        bins = [[0., 0.5, 1.0]]
         hist, _ = histogramdd(x, bins=bins)
         assert_(hist[0] == 0.0)
         assert_(hist[1] == 1.)
         x = [1.0]
-        bins = [[0.,0.5,1.0]]
+        bins = [[0., 0.5, 1.0]]
         hist, _ = histogramdd(x, bins=bins)
         assert_(hist[0] == 0.0)
         assert_(hist[1] == 1.)
         x = [1.0000000001]
-        bins = [[0.,0.5,1.0]]
+        bins = [[0., 0.5, 1.0]]
         hist, _ = histogramdd(x, bins=bins)
         assert_(hist[0] == 0.0)
         assert_(hist[1] == 1.)
         x = [1.0001]
-        bins = [[0.,0.5,1.0]]
+        bins = [[0., 0.5, 1.0]]
         hist, _ = histogramdd(x, bins=bins)
         assert_(hist[0] == 0.0)
         assert_(hist[1] == 0.0)
 
 
 class TestUnique(TestCase):
+
     def test_simple(self):
         x = np.array([4, 3, 2, 1, 1, 2, 3, 4, 0])
         assert_(np.all(unique(x) == [0, 1, 2, 3, 4]))
@@ -1330,6 +1372,7 @@ class TestUnique(TestCase):
 
 
 class TestCheckFinite(TestCase):
+
     def test_simple(self):
         a = [1, 2, 3]
         b = [1, 2, np.inf]
@@ -1339,14 +1382,17 @@ class TestCheckFinite(TestCase):
         assert_raises(ValueError, np.lib.asarray_chkfinite, c)
 
     def test_dtype_order(self):
-        """Regression test for missing dtype and order arguments"""
+        # Regression test for missing dtype and order arguments
         a = [1, 2, 3]
         a = np.lib.asarray_chkfinite(a, order='F', dtype=np.float64)
         assert_(a.dtype == np.float64)
 
 
 class catch_warn_nfb(clear_and_catch_warnings):
-    """ Context manager to catch, reset warnings in function_base module
+
+    """
+    Context manager to catch, reset warnings in function_base module
+
     """
     class_modules = (nfb,)
 
@@ -1430,7 +1476,7 @@ class TestCov(TestCase):
     res2 = np.array([[0.4, -0.4], [-0.4, 0.4]])
     unit_frequencies = np.ones(3, dtype=np.integer)
     weights = np.array([1.0, 4.0, 1.0])
-    res3 = np.array([[2./3., -2./3.], [-2./3., 2./3.]])
+    res3 = np.array([[2. / 3., -2. / 3.], [-2. / 3., 2. / 3.]])
     unit_weights = np.ones(3)
     x3 = np.array([0.3942, 0.5969, 0.7730, 0.9918, 0.7964])
 
@@ -1483,19 +1529,19 @@ class TestCov(TestCase):
         assert_raises(RuntimeError, cov, self.x1, fweights=f)
         f = np.ones(2, dtype=np.integer)
         assert_raises(RuntimeError, cov, self.x1, fweights=f)
-        f = -1*np.ones(3, dtype=np.integer)
+        f = -1 * np.ones(3, dtype=np.integer)
         assert_raises(ValueError, cov, self.x1, fweights=f)
 
     def test_aweights(self):
         assert_allclose(cov(self.x1, aweights=self.weights), self.res3)
-        assert_allclose(cov(self.x1, aweights=3.0*self.weights),
+        assert_allclose(cov(self.x1, aweights=3.0 * self.weights),
                         cov(self.x1, aweights=self.weights))
         assert_allclose(cov(self.x1, aweights=self.unit_weights), self.res1)
         w = np.ones((2, 3))
         assert_raises(RuntimeError, cov, self.x1, aweights=w)
         w = np.ones(2)
         assert_raises(RuntimeError, cov, self.x1, aweights=w)
-        w = -1.0*np.ones(3)
+        w = -1.0 * np.ones(3)
         assert_raises(ValueError, cov, self.x1, aweights=w)
 
     def test_unit_fweights_and_aweights(self):
@@ -1512,7 +1558,7 @@ class TestCov(TestCase):
                             aweights=self.weights),
                         self.res3)
         assert_allclose(cov(self.x1, fweights=self.unit_frequencies,
-                            aweights=3.0*self.weights),
+                            aweights=3.0 * self.weights),
                         cov(self.x1, aweights=self.weights))
         assert_allclose(cov(self.x1, fweights=self.unit_frequencies,
                             aweights=self.unit_weights),
@@ -1520,6 +1566,7 @@ class TestCov(TestCase):
 
 
 class Test_I0(TestCase):
+
     def test_simple(self):
         assert_almost_equal(
             i0(0.5),
@@ -1545,6 +1592,7 @@ class Test_I0(TestCase):
 
 
 class TestKaiser(TestCase):
+
     def test_simple(self):
         assert_(np.isfinite(kaiser(1, 1.0)))
         assert_almost_equal(kaiser(0, 1.0),
@@ -1563,6 +1611,7 @@ class TestKaiser(TestCase):
 
 
 class TestMsort(TestCase):
+
     def test_simple(self):
         A = np.array([[0.44567325, 0.79115165, 0.54900530],
                       [0.36844147, 0.37325583, 0.96098397],
@@ -1575,6 +1624,7 @@ class TestMsort(TestCase):
 
 
 class TestMeshgrid(TestCase):
+
     def test_simple(self):
         [X, Y] = meshgrid([1, 2, 3], [4, 5, 6, 7])
         assert_array_equal(X, np.array([[1, 2, 3],
@@ -1628,6 +1678,7 @@ class TestMeshgrid(TestCase):
 
 
 class TestPiecewise(TestCase):
+
     def test_simple(self):
         # Condition is single bool list
         x = piecewise([0, 0], [True, False], [1])
@@ -1678,10 +1729,11 @@ class TestPiecewise(TestCase):
 
     def test_0d_comparison(self):
         x = 3
-        y = piecewise(x, [x <= 3, x > 3], [4, 0])
+        piecewise(x, [x <= 3, x > 3], [4, 0])  # Should succeed.
 
 
 class TestBincount(TestCase):
+
     def test_simple(self):
         y = np.bincount(np.arange(4))
         assert_array_equal(y, np.ones(4))
@@ -1747,6 +1799,7 @@ class TestBincount(TestCase):
 
 
 class TestInterp(TestCase):
+
     def test_exceptions(self):
         assert_raises(ValueError, interp, 0, [], [])
         assert_raises(ValueError, interp, 0, [0], [1, 2])
@@ -1832,10 +1885,10 @@ class TestScoreatpercentile(TestCase):
 
     def test_2D(self):
         x = np.array([[1, 1, 1],
-                     [1, 1, 1],
-                     [4, 4, 3],
-                     [1, 1, 1],
-                     [1, 1, 1]])
+                      [1, 1, 1],
+                      [4, 4, 3],
+                      [1, 1, 1],
+                      [1, 1, 1]])
         assert_array_equal(np.percentile(x, 50, axis=0), [1, 1, 1])
 
     def test_linear(self):
@@ -1888,7 +1941,8 @@ class TestScoreatpercentile(TestCase):
         assert_equal(np.percentile(x, (25, 50), axis=1).shape, (2, 3, 5, 6))
         assert_equal(np.percentile(x, (25, 50), axis=2).shape, (2, 3, 4, 6))
         assert_equal(np.percentile(x, (25, 50), axis=3).shape, (2, 3, 4, 5))
-        assert_equal(np.percentile(x, (25, 50, 75), axis=1).shape, (3, 3, 5, 6))
+        assert_equal(
+            np.percentile(x, (25, 50, 75), axis=1).shape, (3, 3, 5, 6))
         assert_equal(np.percentile(x, (25, 50),
                                    interpolation="higher").shape, (2,))
         assert_equal(np.percentile(x, (25, 50, 75),
@@ -1909,10 +1963,10 @@ class TestScoreatpercentile(TestCase):
         x = np.arange(12).reshape(3, 4)
         assert_equal(np.percentile(x, 50), 5.5)
         self.assertTrue(np.isscalar(np.percentile(x, 50)))
-        r0 = np.array([ 4.,  5.,  6.,  7.])
+        r0 = np.array([4.,  5.,  6.,  7.])
         assert_equal(np.percentile(x, 50, axis=0), r0)
         assert_equal(np.percentile(x, 50, axis=0).shape, r0.shape)
-        r1 = np.array([ 1.5,  5.5,  9.5])
+        r1 = np.array([1.5,  5.5,  9.5])
         assert_almost_equal(np.percentile(x, 50, axis=1), r1)
         assert_equal(np.percentile(x, 50, axis=1).shape, r1.shape)
 
@@ -1930,11 +1984,11 @@ class TestScoreatpercentile(TestCase):
         x = np.arange(12).reshape(3, 4)
         assert_equal(np.percentile(x, 50, interpolation='lower'), 5.)
         self.assertTrue(np.isscalar(np.percentile(x, 50)))
-        r0 = np.array([ 4.,  5.,  6.,  7.])
+        r0 = np.array([4.,  5.,  6.,  7.])
         c0 = np.percentile(x, 50, interpolation='lower', axis=0)
         assert_equal(c0, r0)
         assert_equal(c0.shape, r0.shape)
-        r1 = np.array([ 1.,  5.,  9.])
+        r1 = np.array([1.,  5.,  9.])
         c1 = np.percentile(x, 50, interpolation='lower', axis=1)
         assert_almost_equal(c1, r1)
         assert_equal(c1.shape, r1.shape)
@@ -2006,7 +2060,7 @@ class TestScoreatpercentile(TestCase):
 
     def test_percentile_empty_dim(self):
         # empty dims are preserved
-        d = np.arange(11*2).reshape(11, 1, 2, 1)
+        d = np.arange(11 * 2).reshape(11, 1, 2, 1)
         assert_array_equal(np.percentile(d, 50, axis=0).shape, (1, 2, 1))
         assert_array_equal(np.percentile(d, 50, axis=1).shape, (11, 2, 1))
         assert_array_equal(np.percentile(d, 50, axis=2).shape, (11, 1, 1))
@@ -2031,7 +2085,6 @@ class TestScoreatpercentile(TestCase):
                            (2, 11, 1, 1))
         assert_array_equal(np.array(np.percentile(d, [10, 50], axis=3)).shape,
                            (2, 11, 1, 2))
-
 
     def test_percentile_no_overwrite(self):
         a = np.array([2, 3, 4, 1])
@@ -2076,19 +2129,19 @@ class TestScoreatpercentile(TestCase):
         d = np.arange(3 * 5 * 7 * 11).reshape(3, 5, 7, 11)
         np.random.shuffle(d)
         assert_equal(np.percentile(d, 25,  axis=(0, 1, 2))[0],
-                     np.percentile(d[:, :, :, 0].flatten(), 25))
+                     np.percentile(d[:,:,:, 0].flatten(), 25))
         assert_equal(np.percentile(d, [10, 90], axis=(0, 1, 3))[:, 1],
-                     np.percentile(d[:, :, 1, :].flatten(), [10, 90]))
+                     np.percentile(d[:,:, 1,:].flatten(), [10, 90]))
         assert_equal(np.percentile(d, 25, axis=(3, 1, -4))[2],
-                     np.percentile(d[:, :, 2, :].flatten(), 25))
+                     np.percentile(d[:,:, 2,:].flatten(), 25))
         assert_equal(np.percentile(d, 25, axis=(3, 1, 2))[2],
-                     np.percentile(d[2, :, :, :].flatten(), 25))
+                     np.percentile(d[2,:,:,:].flatten(), 25))
         assert_equal(np.percentile(d, 25, axis=(3, 2))[2, 1],
-                     np.percentile(d[2, 1, :, :].flatten(), 25))
+                     np.percentile(d[2, 1,:,:].flatten(), 25))
         assert_equal(np.percentile(d, 25, axis=(1, -2))[2, 1],
-                     np.percentile(d[2, :, :, 1].flatten(), 25))
+                     np.percentile(d[2,:,:, 1].flatten(), 25))
         assert_equal(np.percentile(d, 25, axis=(1, 3))[2, 2],
-                     np.percentile(d[2, :, 2, :].flatten(), 25))
+                     np.percentile(d[2,:, 2,:].flatten(), 25))
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
@@ -2117,6 +2170,7 @@ class TestScoreatpercentile(TestCase):
                                    keepdims=True).shape, (2, 1, 1, 7, 1))
         assert_equal(np.percentile(d, [1, 7], axis=(0, 3),
                                    keepdims=True).shape, (2, 1, 5, 7, 1))
+
     def test_out(self):
         o = np.zeros((4,))
         d = np.ones((3, 4))
@@ -2130,7 +2184,6 @@ class TestScoreatpercentile(TestCase):
         assert_equal(np.percentile(d, 2, out=o), o)
         assert_equal(np.percentile(d, 2, interpolation='nearest', out=o), o)
 
-
     def test_out_nan(self):
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings('always', '', RuntimeWarning)
@@ -2138,13 +2191,16 @@ class TestScoreatpercentile(TestCase):
             d = np.ones((3, 4))
             d[2, 1] = np.nan
             assert_equal(np.percentile(d, 0, 0, out=o), o)
-            assert_equal(np.percentile(d, 0, 0, interpolation='nearest', out=o), o)
+            assert_equal(
+                np.percentile(d, 0, 0, interpolation='nearest', out=o), o)
             o = np.zeros((3,))
             assert_equal(np.percentile(d, 1, 1, out=o), o)
-            assert_equal(np.percentile(d, 1, 1, interpolation='nearest', out=o), o)
+            assert_equal(
+                np.percentile(d, 1, 1, interpolation='nearest', out=o), o)
             o = np.zeros(())
             assert_equal(np.percentile(d, 1, out=o), o)
-            assert_equal(np.percentile(d, 1, interpolation='nearest', out=o), o)
+            assert_equal(
+                np.percentile(d, 1, interpolation='nearest', out=o), o)
 
     def test_nan_behavior(self):
         a = np.arange(24, dtype=float)
@@ -2171,7 +2227,8 @@ class TestScoreatpercentile(TestCase):
 
         # axis0 zerod
         b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4), 0.3, 0)
-        b[2, 3] = np.nan; b[1, 2] = np.nan
+        b[2, 3] = np.nan
+        b[1, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(a, 0.3, 0), b)
@@ -2179,47 +2236,57 @@ class TestScoreatpercentile(TestCase):
         # axis0 not zerod
         b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4),
                           [0.3, 0.6], 0)
-        b[:, 2, 3] = np.nan; b[:, 1, 2] = np.nan
+        b[:, 2, 3] = np.nan
+        b[:, 1, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(a, [0.3, 0.6], 0), b)
 
         # axis1 zerod
         b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4), 0.3, 1)
-        b[1, 3] = np.nan; b[1, 2] = np.nan
+        b[1, 3] = np.nan
+        b[1, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(a, 0.3, 1), b)
         # axis1 not zerod
-        b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4), [0.3, 0.6], 1)
-        b[:, 1, 3] = np.nan; b[:, 1, 2] = np.nan
+        b = np.percentile(
+            np.arange(24, dtype=float).reshape(2, 3, 4), [0.3, 0.6], 1)
+        b[:, 1, 3] = np.nan
+        b[:, 1, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(a, [0.3, 0.6], 1), b)
 
         # axis02 zerod
-        b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4), 0.3, (0, 2))
-        b[1] = np.nan; b[2] = np.nan
+        b = np.percentile(
+            np.arange(24, dtype=float).reshape(2, 3, 4), 0.3, (0, 2))
+        b[1] = np.nan
+        b[2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(a, 0.3, (0, 2)), b)
         # axis02 not zerod
         b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4),
                           [0.3, 0.6], (0, 2))
-        b[:, 1] = np.nan; b[:, 2] = np.nan
+        b[:, 1] = np.nan
+        b[:, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(a, [0.3, 0.6], (0, 2)), b)
         # axis02 not zerod with nearest interpolation
         b = np.percentile(np.arange(24, dtype=float).reshape(2, 3, 4),
                           [0.3, 0.6], (0, 2), interpolation='nearest')
-        b[:, 1] = np.nan; b[:, 2] = np.nan
+        b[:, 1] = np.nan
+        b[:, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.percentile(
                 a, [0.3, 0.6], (0, 2), interpolation='nearest'), b)
 
+
 class TestMedian(TestCase):
+
     def test_basic(self):
         a0 = np.array(1)
         a1 = np.arange(2)
@@ -2244,7 +2311,6 @@ class TestMedian(TestCase):
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.median(a).ndim, 0)
             assert_(w[0].category is RuntimeWarning)
-
 
     def test_axis_keyword(self):
         a3 = np.array([[2, 3],
@@ -2307,6 +2373,7 @@ class TestMedian(TestCase):
     def test_subclass(self):
         # gh-3846
         class MySubClass(np.ndarray):
+
             def __new__(cls, input_array, info=None):
                 obj = np.asarray(input_array).view(cls)
                 obj.info = info
@@ -2315,7 +2382,7 @@ class TestMedian(TestCase):
             def mean(self, axis=None, dtype=None, out=None):
                 return -7
 
-        a = MySubClass([1,2,3])
+        a = MySubClass([1, 2, 3])
         assert_equal(np.median(a), -7)
 
     def test_out(self):
@@ -2353,39 +2420,42 @@ class TestMedian(TestCase):
         a[1, 2, 3] = np.nan
         a[1, 1, 2] = np.nan
 
-        #no axis
+        # no axis
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.median(a), np.nan)
             assert_equal(np.median(a).ndim, 0)
             assert_(w[0].category is RuntimeWarning)
 
-        #axis0
+        # axis0
         b = np.median(np.arange(24, dtype=float).reshape(2, 3, 4), 0)
-        b[2, 3] = np.nan; b[1, 2] = np.nan
+        b[2, 3] = np.nan
+        b[1, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.median(a, 0), b)
             assert_equal(len(w), 1)
 
-        #axis1
+        # axis1
         b = np.median(np.arange(24, dtype=float).reshape(2, 3, 4), 1)
-        b[1, 3] = np.nan; b[1, 2] = np.nan
+        b[1, 3] = np.nan
+        b[1, 2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.median(a, 1), b)
             assert_equal(len(w), 1)
 
-       #axis02
+        # axis02
         b = np.median(np.arange(24, dtype=float).reshape(2, 3, 4), (0, 2))
-        b[1] = np.nan; b[2] = np.nan
+        b[1] = np.nan
+        b[2] = np.nan
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_equal(np.median(a, (0, 2)), b)
             assert_equal(len(w), 1)
 
     def test_object(self):
-        o = np.arange(7.);
+        o = np.arange(7.)
         assert_(type(np.median(o.astype(object))), float)
         o[2] = np.nan
         assert_(type(np.median(o.astype(object))), float)
@@ -2406,19 +2476,19 @@ class TestMedian(TestCase):
         d = np.arange(3 * 5 * 7 * 11).reshape(3, 5, 7, 11)
         np.random.shuffle(d)
         assert_equal(np.median(d, axis=(0, 1, 2))[0],
-                     np.median(d[:, :, :, 0].flatten()))
+                     np.median(d[:,:,:, 0].flatten()))
         assert_equal(np.median(d, axis=(0, 1, 3))[1],
-                     np.median(d[:, :, 1, :].flatten()))
+                     np.median(d[:,:, 1,:].flatten()))
         assert_equal(np.median(d, axis=(3, 1, -4))[2],
-                     np.median(d[:, :, 2, :].flatten()))
+                     np.median(d[:,:, 2,:].flatten()))
         assert_equal(np.median(d, axis=(3, 1, 2))[2],
-                     np.median(d[2, :, :, :].flatten()))
+                     np.median(d[2,:,:,:].flatten()))
         assert_equal(np.median(d, axis=(3, 2))[2, 1],
-                     np.median(d[2, 1, :, :].flatten()))
+                     np.median(d[2, 1,:,:].flatten()))
         assert_equal(np.median(d, axis=(1, -2))[2, 1],
-                     np.median(d[2, :, :, 1].flatten()))
+                     np.median(d[2,:,:, 1].flatten()))
         assert_equal(np.median(d, axis=(1, 3))[2, 2],
-                     np.median(d[2, :, 2, :].flatten()))
+                     np.median(d[2,:, 2,:].flatten()))
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
@@ -2442,7 +2512,6 @@ class TestMedian(TestCase):
                      (1, 1, 1, 1))
         assert_equal(np.median(d, axis=(0, 1, 3), keepdims=True).shape,
                      (1, 1, 7, 1))
-
 
 
 class TestAdd_newdoc_ufunc(TestCase):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -13,17 +13,14 @@ from datetime import datetime
 
 import numpy as np
 import numpy.ma as ma
-from numpy.lib._iotools import (
-    ConverterError, ConverterLockError, ConversionWarning
-    )
+from numpy.lib._iotools import ConverterError, ConversionWarning
 from numpy.compat import asbytes, bytes, unicode
-from nose import SkipTest
-from numpy.ma.testutils import assert_equal, assert_almost_equal
+from numpy.ma.testutils import assert_equal
 from numpy.testing import (
-    TestCase, run_module_suite, assert_warns, assert_, build_err_msg,
+    TestCase, run_module_suite, assert_warns, assert_,
     assert_raises_regex, assert_raises, assert_allclose,
     assert_array_equal,
-    )
+)
 from numpy.testing.utils import tempdir
 
 
@@ -51,8 +48,9 @@ IS_64BIT = sys.maxsize > 2**32
 
 
 def strptime(s, fmt=None):
-    """This function is available in the datetime module only
-    from Python >= 2.5.
+    """
+    This function is available in the datetime module only from Python >=
+    2.5.
 
     """
     if sys.version_info[0] >= 3:
@@ -201,8 +199,9 @@ class TestSavezLoad(RoundtripTest, TestCase):
             np.savez(tmp, a=a)
             del a
             npfile = np.load(tmp)
-            a = npfile['a']
+            a = npfile['a']  # Should succeed
             npfile.close()
+            del a  # Avoid pyflakes unused variable warning.
 
     def test_multiple_arrays(self):
         a = np.array([[1, 2], [3, 4]], float)
@@ -271,9 +270,9 @@ class TestSavezLoad(RoundtripTest, TestCase):
             fp = open(tmp, 'rb', 10000)
             fp.seek(0)
             assert_(not fp.closed)
-            _ = np.load(fp)['data']
+            np.load(fp)['data']
+            # fp must not get closed by .load
             assert_(not fp.closed)
-                    # must not get closed by .load(opened fp)
             fp.seek(0)
             assert_(not fp.closed)
 
@@ -392,9 +391,8 @@ class TestSaveTxt(TestCase):
         assert_raises(ValueError, np.savetxt, c, a, fmt=99)
 
     def test_header_footer(self):
-        """
-        Test the functionality of the header and footer keyword argument.
-        """
+        # Test the functionality of the header and footer keyword argument.
+
         c = BytesIO()
         a = np.array([(1, 2), (3, 4)], dtype=np.int)
         test_header_footer = 'Test header / footer'
@@ -699,9 +697,7 @@ class TestLoadTxt(TestCase):
         assert_array_equal(data, [33, 66])
 
     def test_dtype_with_object(self):
-        "Test using an explicit dtype with an object"
-        from datetime import date
-        import time
+        # Test using an explicit dtype with an object
         data = """ 1; 2001-01-01
                    2; 2002-01-31 """
         ndtype = [('idx', int), ('code', np.object)]
@@ -849,7 +845,7 @@ class TestLoadTxt(TestCase):
         c.write('100,foo,200\n300,None,400')
         c.seek(0)
         dt = np.dtype([('x', int), ('a', 'S10'), ('y', int)])
-        data = np.loadtxt(c, delimiter=',', dtype=dt, comments=None)
+        np.loadtxt(c, delimiter=',', dtype=dt, comments=None)  # Should succeed
 
 
 class Testfromregex(TestCase):
@@ -893,15 +889,13 @@ class Testfromregex(TestCase):
 class TestFromTxt(TestCase):
     #
     def test_record(self):
-        "Test w/ explicit dtype"
+        # Test w/ explicit dtype
         data = TextIO('1 2\n3 4')
-#        data.seek(0)
         test = np.ndfromtxt(data, dtype=[('x', np.int32), ('y', np.int32)])
         control = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
         assert_equal(test, control)
         #
         data = TextIO('M 64.0 75.0\nF 25.0 60.0')
-#        data.seek(0)
         descriptor = {'names': ('gender', 'age', 'weight'),
                       'formats': ('S1', 'i4', 'f4')}
         control = np.array([('M', 64.0, 75.0), ('F', 25.0, 60.0)],
@@ -910,7 +904,7 @@ class TestFromTxt(TestCase):
         assert_equal(test, control)
 
     def test_array(self):
-        "Test outputing a standard ndarray"
+        # Test outputing a standard ndarray
         data = TextIO('1 2\n3 4')
         control = np.array([[1, 2], [3, 4]], dtype=int)
         test = np.ndfromtxt(data, dtype=int)
@@ -922,7 +916,7 @@ class TestFromTxt(TestCase):
         assert_array_equal(test, control)
 
     def test_1D(self):
-        "Test squeezing to 1D"
+        # Test squeezing to 1D
         control = np.array([1, 2, 3, 4], int)
         #
         data = TextIO('1\n2\n3\n4\n')
@@ -934,7 +928,7 @@ class TestFromTxt(TestCase):
         assert_array_equal(test, control)
 
     def test_comments(self):
-        "Test the stripping of comments"
+        # Test the stripping of comments
         control = np.array([1, 2, 3, 5], int)
         # Comment on its own line
         data = TextIO('# comment\n1,2,3,5\n')
@@ -946,7 +940,7 @@ class TestFromTxt(TestCase):
         assert_equal(test, control)
 
     def test_skiprows(self):
-        "Test row skipping"
+        # Test row skipping
         control = np.array([1, 2, 3, 5], int)
         kwargs = dict(dtype=int, delimiter=',')
         #
@@ -994,7 +988,7 @@ class TestFromTxt(TestCase):
             assert_equal(a, np.array([[1., 1.], [3., 3.], [4., 4.]]))
 
     def test_header(self):
-        "Test retrieving a header"
+        # Test retrieving a header
         data = TextIO('gender age weight\nM 64.0 75.0\nF 25.0 60.0')
         test = np.ndfromtxt(data, dtype=None, names=True)
         control = {'gender': np.array([b'M', b'F']),
@@ -1005,7 +999,7 @@ class TestFromTxt(TestCase):
         assert_equal(test['weight'], control['weight'])
 
     def test_auto_dtype(self):
-        "Test the automatic definition of the output dtype"
+        # Test the automatic definition of the output dtype
         data = TextIO('A 64 75.0 3+4j True\nBCD 25 60.0 5+6j False')
         test = np.ndfromtxt(data, dtype=None)
         control = [np.array([b'A', b'BCD']),
@@ -1018,14 +1012,14 @@ class TestFromTxt(TestCase):
             assert_equal(test['f%i' % i], ctrl)
 
     def test_auto_dtype_uniform(self):
-        "Tests whether the output dtype can be uniformized"
+        # Tests whether the output dtype can be uniformized
         data = TextIO('1 2 3 4\n5 6 7 8\n')
         test = np.ndfromtxt(data, dtype=None)
         control = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
         assert_equal(test, control)
 
     def test_fancy_dtype(self):
-        "Check that a nested dtype isn't MIA"
+        # Check that a nested dtype isn't MIA
         data = TextIO('1,2,3.0\n4,5,6.0\n')
         fancydtype = np.dtype([('x', int), ('y', [('t', int), ('s', float)])])
         test = np.ndfromtxt(data, dtype=fancydtype, delimiter=',')
@@ -1033,7 +1027,7 @@ class TestFromTxt(TestCase):
         assert_equal(test, control)
 
     def test_names_overwrite(self):
-        "Test overwriting the names of the dtype"
+        # Test overwriting the names of the dtype
         descriptor = {'names': ('g', 'a', 'w'),
                       'formats': ('S1', 'i4', 'f4')}
         data = TextIO(b'M 64.0 75.0\nF 25.0 60.0')
@@ -1045,7 +1039,7 @@ class TestFromTxt(TestCase):
         assert_equal(test, control)
 
     def test_commented_header(self):
-        "Check that names can be retrieved even if the line is commented out."
+        # Check that names can be retrieved even if the line is commented out.
         data = TextIO("""
 #gender age weight
 M   21  72.100000
@@ -1068,7 +1062,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_autonames_and_usecols(self):
-        "Tests names and usecols"
+        # Tests names and usecols
         data = TextIO('A B C D\n aaaa 121 45 9.1')
         test = np.ndfromtxt(data, usecols=('A', 'C', 'D'),
                             names=True, dtype=None)
@@ -1077,7 +1071,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_converters_with_usecols(self):
-        "Test the combination user-defined converters and usecol"
+        # Test the combination user-defined converters and usecol
         data = TextIO('1,2,3,,5\n6,7,8,9,10\n')
         test = np.ndfromtxt(data, dtype=int, delimiter=',',
                             converters={3: lambda s: int(s or - 999)},
@@ -1086,7 +1080,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_converters_with_usecols_and_names(self):
-        "Tests names and usecols"
+        # Tests names and usecols
         data = TextIO('A B C D\n aaaa 121 45 9.1')
         test = np.ndfromtxt(data, usecols=('A', 'C', 'D'), names=True,
                             dtype=None, converters={'C': lambda s: 2 * int(s)})
@@ -1095,7 +1089,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_converters_cornercases(self):
-        "Test the conversion to datetime."
+        # Test the conversion to datetime.
         converter = {
             'date': lambda s: strptime(s, '%Y-%m-%d %H:%M:%SZ')}
         data = TextIO('2009-02-03 12:00:00Z, 72214.0')
@@ -1106,7 +1100,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_converters_cornercases2(self):
-        "Test the conversion to datetime64."
+        # Test the conversion to datetime64.
         converter = {
             'date': lambda s: np.datetime64(strptime(s, '%Y-%m-%d %H:%M:%SZ'))}
         data = TextIO('2009-02-03 12:00:00Z, 72214.0')
@@ -1117,7 +1111,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_unused_converter(self):
-        "Test whether unused converters are forgotten"
+        # Test whether unused converters are forgotten
         data = TextIO("1 21\n  3 42\n")
         test = np.ndfromtxt(data, usecols=(1,),
                             converters={0: lambda s: int(s, 16)})
@@ -1142,7 +1136,7 @@ M   33  21.99
         assert_raises(ConverterError, np.genfromtxt, s, **kwargs)
 
     def test_tricky_converter_bug1666(self):
-        "Test some corner case"
+        # Test some corner cases
         s = TextIO('q1,2\nq3,4')
         cnv = lambda s: float(s[1:])
         test = np.genfromtxt(s, delimiter=',', converters={0: cnv})
@@ -1177,9 +1171,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_dtype_with_object(self):
-        "Test using an explicit dtype with an object"
-        from datetime import date
-        import time
+        # Test using an explicit dtype with an object
         data = """ 1; 2001-01-01
                    2; 2002-01-31 """
         ndtype = [('idx', int), ('code', np.object)]
@@ -1191,7 +1183,7 @@ M   33  21.99
             [(1, datetime(2001, 1, 1)), (2, datetime(2002, 1, 31))],
             dtype=ndtype)
         assert_equal(test, control)
-        #
+
         ndtype = [('nest', [('idx', int), ('code', np.object)])]
         try:
             test = np.genfromtxt(TextIO(data), delimiter=";",
@@ -1203,7 +1195,7 @@ M   33  21.99
             raise AssertionError(errmsg)
 
     def test_userconverters_with_explicit_dtype(self):
-        "Test user_converters w/ explicit (standard) dtype"
+        # Test user_converters w/ explicit (standard) dtype
         data = TextIO('skip,skip,2001-01-01,1.0,skip')
         test = np.genfromtxt(data, delimiter=",", names=None, dtype=float,
                              usecols=(2, 3), converters={2: bytes})
@@ -1212,7 +1204,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_spacedelimiter(self):
-        "Test space delimiter"
+        # Test space delimiter
         data = TextIO("1  2  3  4   5\n6  7  8  9  10")
         test = np.ndfromtxt(data)
         control = np.array([[1., 2., 3., 4., 5.],
@@ -1220,7 +1212,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_integer_delimiter(self):
-        "Test using an integer for delimiter"
+        # Test using an integer for delimiter
         data = "  1  2  3\n  4  5 67\n890123  4"
         test = np.genfromtxt(TextIO(data), delimiter=3)
         control = np.array([[1, 2, 3], [4, 5, 67], [890, 123, 4]])
@@ -1234,7 +1226,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_missing_with_tabs(self):
-        "Test w/ a delimiter tab"
+        # Test w/ a delimiter tab
         txt = "1\t2\t3\n\t2\t\n1\t\t3"
         test = np.genfromtxt(TextIO(txt), delimiter="\t",
                              usemask=True,)
@@ -1244,7 +1236,7 @@ M   33  21.99
         assert_equal(test.mask, ctrl_m)
 
     def test_usecols(self):
-        "Test the selection of columns"
+        # Test the selection of columns
         # Select 1 column
         control = np.array([[1, 2], [3, 4]], float)
         data = TextIO()
@@ -1265,7 +1257,7 @@ M   33  21.99
         assert_equal(test, control[:, 1:])
 
     def test_usecols_as_css(self):
-        "Test giving usecols with a comma-separated string"
+        # Test giving usecols with a comma-separated string
         data = "1 2 3\n4 5 6"
         test = np.genfromtxt(TextIO(data),
                              names="a, b, c", usecols="a, c")
@@ -1273,7 +1265,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_usecols_with_structured_dtype(self):
-        "Test usecols with an explicit structured dtype"
+        # Test usecols with an explicit structured dtype
         data = TextIO("JOE 70.1 25.3\nBOB 60.5 27.9")
         names = ['stid', 'temp']
         dtypes = ['S4', 'f8']
@@ -1283,12 +1275,12 @@ M   33  21.99
         assert_equal(test['temp'], [25.3, 27.9])
 
     def test_usecols_with_integer(self):
-        "Test usecols with an integer"
+        # Test usecols with an integer
         test = np.genfromtxt(TextIO(b"1 2 3\n4 5 6"), usecols=0)
         assert_equal(test, np.array([1., 4.]))
 
     def test_usecols_with_named_columns(self):
-        "Test usecols with named columns"
+        # Test usecols with named columns
         ctrl = np.array([(1, 3), (4, 6)], dtype=[('a', float), ('c', float)])
         data = "1 2 3\n4 5 6"
         kwargs = dict(names="a, b, c")
@@ -1299,7 +1291,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_empty_file(self):
-        "Test that an empty file raises the proper warning."
+        # Test that an empty file raises the proper warning.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
                                     message="genfromtxt: Empty input file:")
@@ -1308,7 +1300,7 @@ M   33  21.99
             assert_equal(test, np.array([]))
 
     def test_fancy_dtype_alt(self):
-        "Check that a nested dtype isn't MIA"
+        # Check that a nested dtype isn't MIA
         data = TextIO('1,2,3.0\n4,5,6.0\n')
         fancydtype = np.dtype([('x', int), ('y', [('t', int), ('s', float)])])
         test = np.mafromtxt(data, dtype=fancydtype, delimiter=',')
@@ -1374,7 +1366,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_user_filling_values(self):
-        "Test with missing and filling values"
+        # Test with missing and filling values
         ctrl = np.array([(0, 3), (4, -999)], dtype=[('a', int), ('b', int)])
         data = "N/A, 2, 3\n4, ,???"
         kwargs = dict(delimiter=",",
@@ -1412,7 +1404,7 @@ M   33  21.99
         assert_equal(test.mask, control.mask)
 
     def test_with_masked_column_uniform(self):
-        "Test masked column"
+        # Test masked column
         data = TextIO('1 2 3\n4 5 6\n')
         test = np.genfromtxt(data, dtype=None,
                              missing_values='2,5', usemask=True)
@@ -1420,7 +1412,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_with_masked_column_various(self):
-        "Test masked column"
+        # Test masked column
         data = TextIO('True 2 3\nFalse 5 6\n')
         test = np.genfromtxt(data, dtype=None,
                              missing_values='2,5', usemask=True)
@@ -1430,7 +1422,7 @@ M   33  21.99
         assert_equal(test, control)
 
     def test_invalid_raise(self):
-        "Test invalid raise"
+        # Test invalid raise
         data = ["1, 1, 1, 1, 1"] * 50
         for i in range(5):
             data[10 * i] = "2, 2, 2, 2 2"
@@ -1438,8 +1430,8 @@ M   33  21.99
         mdata = TextIO("\n".join(data))
         #
         kwargs = dict(delimiter=",", dtype=None, names=True)
-        # XXX: is there a better way to get the return value of the callable in
-        # assert_warns ?
+        # XXX: is there a better way to get the return value of the
+        # callable in assert_warns ?
         ret = {}
 
         def f(_ret={}):
@@ -1454,7 +1446,7 @@ M   33  21.99
                       delimiter=",", names=True)
 
     def test_invalid_raise_with_usecols(self):
-        "Test invalid_raise with usecols"
+        # Test invalid_raise with usecols
         data = ["1, 1, 1, 1, 1"] * 50
         for i in range(5):
             data[10 * i] = "2, 2, 2, 2 2"
@@ -1462,8 +1454,8 @@ M   33  21.99
         mdata = TextIO("\n".join(data))
         kwargs = dict(delimiter=",", dtype=None, names=True,
                       invalid_raise=False)
-        # XXX: is there a better way to get the return value of the callable in
-        # assert_warns ?
+        # XXX: is there a better way to get the return value of the
+        # callable in assert_warns ?
         ret = {}
 
         def f(_ret={}):
@@ -1481,7 +1473,7 @@ M   33  21.99
         assert_equal(mtest, control)
 
     def test_inconsistent_dtype(self):
-        "Test inconsistent dtype"
+        # Test inconsistent dtype
         data = ["1, 1, 1, 1, -1.1"] * 50
         mdata = TextIO("\n".join(data))
 
@@ -1491,7 +1483,7 @@ M   33  21.99
         assert_raises(ValueError, np.genfromtxt, mdata, **kwargs)
 
     def test_default_field_format(self):
-        "Test default format"
+        # Test default format
         data = "0, 1, 2.3\n4, 5, 6.7"
         mtest = np.ndfromtxt(TextIO(data),
                              delimiter=",", dtype=None, defaultfmt="f%02i")
@@ -1500,7 +1492,7 @@ M   33  21.99
         assert_equal(mtest, ctrl)
 
     def test_single_dtype_wo_names(self):
-        "Test single dtype w/o names"
+        # Test single dtype w/o names
         data = "0, 1, 2.3\n4, 5, 6.7"
         mtest = np.ndfromtxt(TextIO(data),
                              delimiter=",", dtype=float, defaultfmt="f%02i")
@@ -1508,7 +1500,7 @@ M   33  21.99
         assert_equal(mtest, ctrl)
 
     def test_single_dtype_w_explicit_names(self):
-        "Test single dtype w explicit names"
+        # Test single dtype w explicit names
         data = "0, 1, 2.3\n4, 5, 6.7"
         mtest = np.ndfromtxt(TextIO(data),
                              delimiter=",", dtype=float, names="a, b, c")
@@ -1517,7 +1509,7 @@ M   33  21.99
         assert_equal(mtest, ctrl)
 
     def test_single_dtype_w_implicit_names(self):
-        "Test single dtype w implicit names"
+        # Test single dtype w implicit names
         data = "a, b, c\n0, 1, 2.3\n4, 5, 6.7"
         mtest = np.ndfromtxt(TextIO(data),
                              delimiter=",", dtype=float, names=True)
@@ -1526,7 +1518,7 @@ M   33  21.99
         assert_equal(mtest, ctrl)
 
     def test_easy_structured_dtype(self):
-        "Test easy structured dtype"
+        # Test easy structured dtype
         data = "0, 1, 2.3\n4, 5, 6.7"
         mtest = np.ndfromtxt(TextIO(data), delimiter=",",
                              dtype=(int, float, float), defaultfmt="f_%02i")
@@ -1535,7 +1527,7 @@ M   33  21.99
         assert_equal(mtest, ctrl)
 
     def test_autostrip(self):
-        "Test autostrip"
+        # Test autostrip
         data = "01/01/2003  , 1.3,   abcde"
         kwargs = dict(delimiter=",", dtype=None)
         mtest = np.ndfromtxt(TextIO(data), **kwargs)
@@ -1548,7 +1540,7 @@ M   33  21.99
         assert_equal(mtest, ctrl)
 
     def test_replace_space(self):
-        "Test the 'replace_space' option"
+        # Test the 'replace_space' option
         txt = "A.A, B (B), C:C\n1, 2, 3.14"
         # Test default: replace ' ' by '_' and delete non-alphanum chars
         test = np.genfromtxt(TextIO(txt),
@@ -1572,7 +1564,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_replace_space_known_dtype(self):
-        "Test the 'replace_space' (and related) options when dtype != None"
+        # Test the 'replace_space' (and related) options when dtype != None
         txt = "A.A, B (B), C:C\n1, 2, 3"
         # Test default: replace ' ' by '_' and delete non-alphanum chars
         test = np.genfromtxt(TextIO(txt),
@@ -1596,7 +1588,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_incomplete_names(self):
-        "Test w/ incomplete names"
+        # Test w/ incomplete names
         data = "A,,C\n0,1,2\n3,4,5"
         kwargs = dict(delimiter=",", names=True)
         # w/ dtype=None
@@ -1610,7 +1602,7 @@ M   33  21.99
         test = np.ndfromtxt(TextIO(data), **kwargs)
 
     def test_names_auto_completion(self):
-        "Make sure that names are properly completed"
+        # Make sure that names are properly completed
         data = "1 2 3\n 4 5 6"
         test = np.genfromtxt(TextIO(data),
                              dtype=(int, float, int), names="a")
@@ -1619,7 +1611,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_names_with_usecols_bug1636(self):
-        "Make sure we pick up the right names w/ usecols"
+        # Make sure we pick up the right names w/ usecols
         data = "A,B,C,D,E\n0,1,2,3,4\n0,1,2,3,4\n0,1,2,3,4"
         ctrl_names = ("A", "C", "E")
         test = np.genfromtxt(TextIO(data),
@@ -1638,7 +1630,7 @@ M   33  21.99
         assert_equal(test.dtype.names, ctrl_names)
 
     def test_fixed_width_names(self):
-        "Test fix-width w/ names"
+        # Test fix-width w/ names
         data = "    A    B   C\n    0    1 2.3\n   45   67   9."
         kwargs = dict(delimiter=(5, 5, 4), names=True, dtype=None)
         ctrl = np.array([(0, 1, 2.3), (45, 67, 9.)],
@@ -1653,7 +1645,7 @@ M   33  21.99
         assert_equal(test, ctrl)
 
     def test_filling_values(self):
-        "Test missing values"
+        # Test missing values
         data = b"1, 2, 3\n1, , 5\n0, 6, \n"
         kwargs = dict(delimiter=",", dtype=None, filling_values=-999)
         ctrl = np.array([[1, 2, 3], [1, -999, 5], [0, 6, -999]], dtype=int)
@@ -1807,12 +1799,11 @@ M   33  21.99
         assert_array_equal(res, np.arange(10))
 
     def test_auto_dtype_largeint(self):
-        """
-        Regression test for numpy/numpy#5635 whereby large integers could
-        cause OverflowErrors.
-        """
-        "Test the automatic definition of the output dtype"
+        # Regression test for numpy/numpy#5635 whereby large integers could
+        # cause OverflowErrors.
 
+        # Test the automatic definition of the output dtype
+        #
         # 2**66 = 73786976294838206464 => should convert to float
         # 2**34 = 17179869184 => should convert to int64
         # 2**10 = 1024 => should convert to int (int32 on 32-bit systems,

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -318,7 +318,6 @@ def test_as_strided():
     assert_equal(a.dtype, a_view.dtype)
 
 
-
 class VerySimpleSubClass(np.ndarray):
     def __new__(cls, *args, **kwargs):
         kwargs['subok'] = True

--- a/numpy/linalg/tests/test_build.py
+++ b/numpy/linalg/tests/test_build.py
@@ -9,7 +9,9 @@ from numpy.testing import TestCase, dec, run_module_suite
 
 from numpy.compat import asbytes_nested
 
+
 class FindDependenciesLdd(object):
+
     def __init__(self):
         self.cmd = ['ldd']
 
@@ -39,7 +41,9 @@ class FindDependenciesLdd(object):
 
         return founds
 
+
 class TestF77Mismatch(TestCase):
+
     @dec.skipif(not(sys.platform[:5] == 'linux'),
                 "Skipping fortran compiler mismatch on non Linux platform")
     def test_lapack(self):
@@ -47,7 +51,7 @@ class TestF77Mismatch(TestCase):
         deps = f.grep_dependencies(lapack_lite.__file__,
                                    asbytes_nested(['libg2c', 'libgfortran']))
         self.assertFalse(len(deps) > 1,
-"""Both g77 and gfortran runtimes linked in lapack_lite ! This is likely to
+                         """Both g77 and gfortran runtimes linked in lapack_lite ! This is likely to
 cause random crashes and wrong results. See numpy INSTALL.txt for more
 information.""")
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -49,6 +49,7 @@ def get_complex_dtype(dtype):
     return {single: csingle, double: cdouble,
             csingle: csingle, cdouble: cdouble}[dtype]
 
+
 def get_rtol(dtype):
     # Choose a safe rtol
     if dtype in (single, csingle):
@@ -56,7 +57,9 @@ def get_rtol(dtype):
     else:
         return 1e-11
 
+
 class LinalgCase(object):
+
     def __init__(self, name, a, b, exception_cls=None):
         assert isinstance(name, str)
         self.name = name
@@ -91,17 +94,17 @@ SQUARE_CASES = [
                array([[1., 2.], [3., 4.]], dtype=double),
                array([[2., 1., 4.], [3., 4., 6.]], dtype=double)),
     LinalgCase("csingle",
-               array([[1.+2j, 2+3j], [3+4j, 4+5j]], dtype=csingle),
-               array([2.+1j, 1.+2j], dtype=csingle)),
+               array([[1. + 2j, 2 + 3j], [3 + 4j, 4 + 5j]], dtype=csingle),
+               array([2. + 1j, 1. + 2j], dtype=csingle)),
     LinalgCase("cdouble",
-               array([[1.+2j, 2+3j], [3+4j, 4+5j]], dtype=cdouble),
-               array([2.+1j, 1.+2j], dtype=cdouble)),
+               array([[1. + 2j, 2 + 3j], [3 + 4j, 4 + 5j]], dtype=cdouble),
+               array([2. + 1j, 1. + 2j], dtype=cdouble)),
     LinalgCase("cdouble_2",
-               array([[1.+2j, 2+3j], [3+4j, 4+5j]], dtype=cdouble),
-               array([[2.+1j, 1.+2j, 1+3j], [1-2j, 1-3j, 1-6j]], dtype=cdouble)),
+               array([[1. + 2j, 2 + 3j], [3 + 4j, 4 + 5j]], dtype=cdouble),
+               array([[2. + 1j, 1. + 2j, 1 + 3j], [1 - 2j, 1 - 3j, 1 - 6j]], dtype=cdouble)),
     LinalgCase("empty",
-               atleast_2d(array([], dtype = double)),
-               atleast_2d(array([], dtype = double)),
+               atleast_2d(array([], dtype=double)),
+               atleast_2d(array([], dtype=double)),
                linalg.LinAlgError),
     LinalgCase("8x8",
                np.random.rand(8, 8),
@@ -134,23 +137,29 @@ NONSQUARE_CASES = [
                array([[1., 2.], [3., 4.], [5., 6.]], dtype=double),
                array([2., 1., 3.], dtype=double)),
     LinalgCase("csingle_nsq_1",
-               array([[1.+1j, 2.+2j, 3.-3j], [3.-5j, 4.+9j, 6.+2j]], dtype=csingle),
-               array([2.+1j, 1.+2j], dtype=csingle)),
+               array(
+                   [[1. + 1j, 2. + 2j, 3. - 3j], [3. - 5j, 4. + 9j, 6. + 2j]], dtype=csingle),
+               array([2. + 1j, 1. + 2j], dtype=csingle)),
     LinalgCase("csingle_nsq_2",
-               array([[1.+1j, 2.+2j], [3.-3j, 4.-9j], [5.-4j, 6.+8j]], dtype=csingle),
-               array([2.+1j, 1.+2j, 3.-3j], dtype=csingle)),
+               array(
+                   [[1. + 1j, 2. + 2j], [3. - 3j, 4. - 9j], [5. - 4j, 6. + 8j]], dtype=csingle),
+               array([2. + 1j, 1. + 2j, 3. - 3j], dtype=csingle)),
     LinalgCase("cdouble_nsq_1",
-               array([[1.+1j, 2.+2j, 3.-3j], [3.-5j, 4.+9j, 6.+2j]], dtype=cdouble),
-               array([2.+1j, 1.+2j], dtype=cdouble)),
+               array(
+                   [[1. + 1j, 2. + 2j, 3. - 3j], [3. - 5j, 4. + 9j, 6. + 2j]], dtype=cdouble),
+               array([2. + 1j, 1. + 2j], dtype=cdouble)),
     LinalgCase("cdouble_nsq_2",
-               array([[1.+1j, 2.+2j], [3.-3j, 4.-9j], [5.-4j, 6.+8j]], dtype=cdouble),
-               array([2.+1j, 1.+2j, 3.-3j], dtype=cdouble)),
+               array(
+                   [[1. + 1j, 2. + 2j], [3. - 3j, 4. - 9j], [5. - 4j, 6. + 8j]], dtype=cdouble),
+               array([2. + 1j, 1. + 2j, 3. - 3j], dtype=cdouble)),
     LinalgCase("cdouble_nsq_1_2",
-               array([[1.+1j, 2.+2j, 3.-3j], [3.-5j, 4.+9j, 6.+2j]], dtype=cdouble),
-               array([[2.+1j, 1.+2j], [1-1j, 2-2j]], dtype=cdouble)),
+               array(
+                   [[1. + 1j, 2. + 2j, 3. - 3j], [3. - 5j, 4. + 9j, 6. + 2j]], dtype=cdouble),
+               array([[2. + 1j, 1. + 2j], [1 - 1j, 2 - 2j]], dtype=cdouble)),
     LinalgCase("cdouble_nsq_2_2",
-               array([[1.+1j, 2.+2j], [3.-3j, 4.-9j], [5.-4j, 6.+8j]], dtype=cdouble),
-               array([[2.+1j, 1.+2j], [1-1j, 2-2j], [1-1j, 2-2j]], dtype=cdouble)),
+               array(
+                   [[1. + 1j, 2. + 2j], [3. - 3j, 4. - 9j], [5. - 4j, 6. + 8j]], dtype=cdouble),
+               array([[2. + 1j, 1. + 2j], [1 - 1j, 2 - 2j], [1 - 1j, 2 - 2j]], dtype=cdouble)),
     LinalgCase("8x11",
                np.random.rand(8, 11),
                np.random.rand(11)),
@@ -170,13 +179,13 @@ HERMITIAN_CASES = [
                array([[1., 2.], [2., 1.]], dtype=double),
                None),
     LinalgCase("hcsingle",
-               array([[1., 2+3j], [2-3j, 1]], dtype=csingle),
+               array([[1., 2 + 3j], [2 - 3j, 1]], dtype=csingle),
                None),
     LinalgCase("hcdouble",
-               array([[1., 2+3j], [2-3j, 1]], dtype=cdouble),
+               array([[1., 2 + 3j], [2 - 3j, 1]], dtype=cdouble),
                None),
     LinalgCase("hempty",
-               atleast_2d(array([], dtype = double)),
+               atleast_2d(array([], dtype=double)),
                None,
                linalg.LinAlgError),
     LinalgCase("hnonarray",
@@ -209,20 +218,20 @@ for tgt, src in ((GENERALIZED_SQUARE_CASES, SQUARE_CASES),
         if not isinstance(case.a, np.ndarray):
             continue
 
-        a = np.array([case.a, 2*case.a, 3*case.a])
+        a = np.array([case.a, 2 * case.a, 3 * case.a])
         if case.b is None:
             b = None
         else:
-            b = np.array([case.b, 7*case.b, 6*case.b])
+            b = np.array([case.b, 7 * case.b, 6 * case.b])
         new_case = LinalgCase(case.name + "_tile3", a, b,
                               case.exception_cls)
         tgt.append(new_case)
 
-        a = np.array([case.a]*2*3).reshape((3, 2) + case.a.shape)
+        a = np.array([case.a] * 2 * 3).reshape((3, 2) + case.a.shape)
         if case.b is None:
             b = None
         else:
-            b = np.array([case.b]*2*3).reshape((3, 2) + case.b.shape)
+            b = np.array([case.b] * 2 * 3).reshape((3, 2) + case.b.shape)
         new_case = LinalgCase(case.name + "_tile213", a, b,
                               case.exception_cls)
         tgt.append(new_case)
@@ -230,6 +239,7 @@ for tgt, src in ((GENERALIZED_SQUARE_CASES, SQUARE_CASES),
 #
 # Generate stride combination variations of the above
 #
+
 
 def _stride_comb_iter(x):
     """
@@ -240,7 +250,7 @@ def _stride_comb_iter(x):
         yield x, "nop"
         return
 
-    stride_set = [(1,)]*x.ndim
+    stride_set = [(1,)] * x.ndim
     stride_set[-1] = (1, 3, -4)
     if x.ndim > 1:
         stride_set[-2] = (1, 3, -4)
@@ -248,7 +258,7 @@ def _stride_comb_iter(x):
         stride_set[-3] = (1, -4)
 
     for repeats in itertools.product(*tuple(stride_set)):
-        new_shape = [abs(a*b) for a, b in zip(x.shape, repeats)]
+        new_shape = [abs(a * b) for a, b in zip(x.shape, repeats)]
         slices = tuple([slice(None, None, repeat) for repeat in repeats])
 
         # new array with different strides, but same data
@@ -308,34 +318,41 @@ def _check_cases(func, cases):
             msg += traceback.format_exc()
             raise AssertionError(msg)
 
+
 class LinalgTestCase(object):
+
     def test_sq_cases(self):
         _check_cases(self.do, SQUARE_CASES)
 
 
 class LinalgNonsquareTestCase(object):
+
     def test_sq_cases(self):
         _check_cases(self.do, NONSQUARE_CASES)
 
 
 class LinalgGeneralizedTestCase(object):
+
     @dec.slow
     def test_generalized_sq_cases(self):
         _check_cases(self.do, GENERALIZED_SQUARE_CASES)
 
 
 class LinalgGeneralizedNonsquareTestCase(object):
+
     @dec.slow
     def test_generalized_nonsq_cases(self):
         _check_cases(self.do, GENERALIZED_NONSQUARE_CASES)
 
 
 class HermitianTestCase(object):
+
     def test_herm_cases(self):
         _check_cases(self.do, HERMITIAN_CASES)
 
 
 class HermitianGeneralizedTestCase(object):
+
     @dec.slow
     def test_generalized_herm_cases(self):
         _check_cases(self.do, GENERALIZED_HERMITIAN_CASES)
@@ -372,6 +389,7 @@ def identity_like_generalized(a):
 
 
 class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
         x = linalg.solve(a, b)
         assert_almost_equal(b, dot_generalized(a, x))
@@ -391,17 +409,17 @@ class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase):
         a = np.arange(8).reshape(2, 2, 2)
         b = np.arange(6).reshape(1, 2, 3).view(ArraySubclass)
 
-        expected = linalg.solve(a, b)[:, 0:0,:]
-        result = linalg.solve(a[:, 0:0, 0:0], b[:, 0:0,:])
+        expected = linalg.solve(a, b)[:, 0:0, :]
+        result = linalg.solve(a[:, 0:0, 0:0], b[:, 0:0, :])
         assert_array_equal(result, expected)
         assert_(isinstance(result, ArraySubclass))
 
         # Test errors for non-square and only b's dimension being 0
         assert_raises(linalg.LinAlgError, linalg.solve, a[:, 0:0, 0:1], b)
-        assert_raises(ValueError, linalg.solve, a, b[:, 0:0,:])
+        assert_raises(ValueError, linalg.solve, a, b[:, 0:0, :])
 
         # Test broadcasting error
-        b = np.arange(6).reshape(1, 3, 2) # broadcasting error
+        b = np.arange(6).reshape(1, 3, 2)  # broadcasting error
         assert_raises(ValueError, linalg.solve, a, b)
         assert_raises(ValueError, linalg.solve, a[0:0], b[0:0])
 
@@ -424,19 +442,20 @@ class TestSolve(LinalgTestCase, LinalgGeneralizedTestCase):
         a = np.arange(4).reshape(1, 2, 2)
         b = np.arange(6).reshape(3, 2, 1).view(ArraySubclass)
 
-        expected = linalg.solve(a, b)[:,:, 0:0]
-        result = linalg.solve(a, b[:,:, 0:0])
+        expected = linalg.solve(a, b)[:, :, 0:0]
+        result = linalg.solve(a, b[:, :, 0:0])
         assert_array_equal(result, expected)
         assert_(isinstance(result, ArraySubclass))
 
         # test both zero.
         expected = linalg.solve(a, b)[:, 0:0, 0:0]
-        result = linalg.solve(a[:, 0:0, 0:0], b[:,0:0, 0:0])
+        result = linalg.solve(a[:, 0:0, 0:0], b[:, 0:0, 0:0])
         assert_array_equal(result, expected)
         assert_(isinstance(result, ArraySubclass))
 
 
 class TestInv(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
         a_inv = linalg.inv(a)
         assert_almost_equal(dot_generalized(a, a_inv),
@@ -467,6 +486,7 @@ class TestInv(LinalgTestCase, LinalgGeneralizedTestCase):
 
 
 class TestEigvals(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
         ev = linalg.eigvals(a)
         evalues, evectors = linalg.eig(a)
@@ -483,10 +503,11 @@ class TestEigvals(LinalgTestCase, LinalgGeneralizedTestCase):
 
 
 class TestEig(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
         evalues, evectors = linalg.eig(a)
         assert_allclose(dot_generalized(a, evectors),
-                        np.asarray(evectors) * np.asarray(evalues)[...,None,:],
+                        np.asarray(evectors) * np.asarray(evalues)[..., None, :],
                         rtol=get_rtol(evalues.dtype))
         assert_(imply(isinstance(a, matrix), isinstance(evectors, matrix)))
 
@@ -507,9 +528,10 @@ class TestEig(LinalgTestCase, LinalgGeneralizedTestCase):
 
 
 class TestSVD(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
         u, s, vt = linalg.svd(a, 0)
-        assert_allclose(a, dot_generalized(np.asarray(u) * np.asarray(s)[...,None,:],
+        assert_allclose(a, dot_generalized(np.asarray(u) * np.asarray(s)[..., None, :],
                                            np.asarray(vt)),
                         rtol=get_rtol(u.dtype))
         assert_(imply(isinstance(a, matrix), isinstance(u, matrix)))
@@ -530,26 +552,30 @@ class TestSVD(LinalgTestCase, LinalgGeneralizedTestCase):
 
 
 class TestCondSVD(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
-        c = asarray(a) # a might be a matrix
+        c = asarray(a)  # a might be a matrix
         s = linalg.svd(c, compute_uv=False)
-        old_assert_almost_equal(s[0]/s[-1], linalg.cond(a), decimal=5)
+        old_assert_almost_equal(s[0] / s[-1], linalg.cond(a), decimal=5)
 
 
 class TestCond2(LinalgTestCase):
+
     def do(self, a, b):
-        c = asarray(a) # a might be a matrix
+        c = asarray(a)  # a might be a matrix
         s = linalg.svd(c, compute_uv=False)
-        old_assert_almost_equal(s[0]/s[-1], linalg.cond(a, 2), decimal=5)
+        old_assert_almost_equal(s[0] / s[-1], linalg.cond(a, 2), decimal=5)
 
 
 class TestCondInf(object):
+
     def test(self):
         A = array([[1., 0, 0], [0, -2., 0], [0, 0, 3.]])
         assert_almost_equal(linalg.cond(A, inf), 3.)
 
 
 class TestPinv(LinalgTestCase):
+
     def do(self, a, b):
         a_ginv = linalg.pinv(a)
         assert_almost_equal(dot(a, a_ginv), identity(asarray(a).shape[0]))
@@ -557,6 +583,7 @@ class TestPinv(LinalgTestCase):
 
 
 class TestDet(LinalgTestCase, LinalgGeneralizedTestCase):
+
     def do(self, a, b):
         d = linalg.det(a)
         (s, ld) = linalg.slogdet(a)
@@ -599,6 +626,7 @@ class TestDet(LinalgTestCase, LinalgGeneralizedTestCase):
 
 
 class TestLstsq(LinalgTestCase, LinalgNonsquareTestCase):
+
     def do(self, a, b):
         arr = np.asarray(a)
         m, n = arr.shape
@@ -611,7 +639,8 @@ class TestLstsq(LinalgTestCase, LinalgNonsquareTestCase):
             assert_equal(rank, n)
         assert_almost_equal(sv, sv.__array_wrap__(s))
         if rank == n and m > n:
-            expect_resids = (np.asarray(abs(np.dot(a, x) - b))**2).sum(axis=0)
+            expect_resids = (
+                np.asarray(abs(np.dot(a, x) - b)) ** 2).sum(axis=0)
             expect_resids = np.asarray(expect_resids)
             if len(np.asarray(b).shape) == 1:
                 expect_resids.shape = (1,)
@@ -631,15 +660,17 @@ class TestMatrixPower(object):
     arbfloat = array([[0.1, 3.2], [1.2, 0.7]])
 
     large = identity(10)
-    t = large[1,:].copy()
-    large[1,:] = large[0,:]
-    large[0,:] = t
+    t = large[1, :].copy()
+    large[1, :] = large[0,:]
+    large[0, :] = t
 
     def test_large_power(self):
-        assert_equal(matrix_power(self.R90, 2**100+2**10+2**5+1), self.R90)
+        assert_equal(
+            matrix_power(self.R90, 2 ** 100 + 2 ** 10 + 2 ** 5 + 1), self.R90)
 
     def test_large_power_trailing_zero(self):
-        assert_equal(matrix_power(self.R90, 2**100+2**10+2**5), identity(2))
+        assert_equal(
+            matrix_power(self.R90, 2 ** 100 + 2 ** 10 + 2 ** 5), identity(2))
 
     def testip_zero(self):
         def tz(M):
@@ -679,12 +710,14 @@ class TestMatrixPower(object):
 
 
 class TestBoolPower(object):
+
     def test_square(self):
         A = array([[True, False], [True, True]])
         assert_equal(matrix_power(A, 2), A)
 
 
 class TestEigvalsh(HermitianTestCase, HermitianGeneralizedTestCase):
+
     def do(self, a, b):
         # note that eigenvalue arrays returned by eig must be sorted since
         # their order isn't guaranteed.
@@ -711,8 +744,8 @@ class TestEigvalsh(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_raises(ValueError, np.linalg.eigvalsh, x, "upper")
 
     def test_UPLO(self):
-        Klo = np.array([[0, 0],[1, 0]], dtype=np.double)
-        Kup = np.array([[0, 1],[0, 0]], dtype=np.double)
+        Klo = np.array([[0, 0], [1, 0]], dtype=np.double)
+        Kup = np.array([[0, 1], [0, 0]], dtype=np.double)
         tgt = np.array([-1, 1], dtype=np.double)
         rtol = get_rtol(np.double)
 
@@ -734,6 +767,7 @@ class TestEigvalsh(HermitianTestCase, HermitianGeneralizedTestCase):
 
 
 class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
+
     def do(self, a, b):
         # note that eigenvalue arrays returned by eig must be sorted since
         # their order isn't guaranteed.
@@ -743,14 +777,14 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_almost_equal(ev, evalues)
 
         assert_allclose(dot_generalized(a, evc),
-                        np.asarray(ev)[...,None,:] * np.asarray(evc),
+                        np.asarray(ev)[..., None, :] * np.asarray(evc),
                         rtol=get_rtol(ev.dtype))
 
         ev2, evc2 = linalg.eigh(a, 'U')
         assert_almost_equal(ev2, evalues)
 
         assert_allclose(dot_generalized(a, evc2),
-                        np.asarray(ev2)[...,None,:] * np.asarray(evc2),
+                        np.asarray(ev2)[..., None, :] * np.asarray(evc2),
                         rtol=get_rtol(ev.dtype), err_msg=repr(a))
 
     def test_types(self):
@@ -769,8 +803,8 @@ class TestEigh(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_raises(ValueError, np.linalg.eigh, x, "upper")
 
     def test_UPLO(self):
-        Klo = np.array([[0, 0],[1, 0]], dtype=np.double)
-        Kup = np.array([[0, 1],[0, 0]], dtype=np.double)
+        Klo = np.array([[0, 0], [1, 0]], dtype=np.double)
+        Kup = np.array([[0, 1], [0, 0]], dtype=np.double)
         tgt = np.array([-1, 1], dtype=np.double)
         rtol = get_rtol(np.double)
 
@@ -807,7 +841,7 @@ class _TestNorm(object):
         c = [-1, 2, -3, 4]
 
         def _test(v):
-            np.testing.assert_almost_equal(norm(v), 30**0.5,
+            np.testing.assert_almost_equal(norm(v), 30 ** 0.5,
                                            decimal=self.dec)
             np.testing.assert_almost_equal(norm(v, inf), 4.0,
                                            decimal=self.dec)
@@ -815,11 +849,11 @@ class _TestNorm(object):
                                            decimal=self.dec)
             np.testing.assert_almost_equal(norm(v, 1), 10.0,
                                            decimal=self.dec)
-            np.testing.assert_almost_equal(norm(v, -1), 12.0/25,
+            np.testing.assert_almost_equal(norm(v, -1), 12.0 / 25,
                                            decimal=self.dec)
-            np.testing.assert_almost_equal(norm(v, 2), 30**0.5,
+            np.testing.assert_almost_equal(norm(v, 2), 30 ** 0.5,
                                            decimal=self.dec)
-            np.testing.assert_almost_equal(norm(v, -2), ((205./144)**-0.5),
+            np.testing.assert_almost_equal(norm(v, -2), ((205. / 144) ** -0.5),
                                            decimal=self.dec)
             np.testing.assert_almost_equal(norm(v, 0), 4,
                                            decimal=self.dec)
@@ -833,8 +867,8 @@ class _TestNorm(object):
 
     def test_matrix_2x2(self):
         A = matrix([[1, 3], [5, 7]], dtype=self.dt)
-        assert_almost_equal(norm(A), 84**0.5)
-        assert_almost_equal(norm(A, 'fro'), 84**0.5)
+        assert_almost_equal(norm(A), 84 ** 0.5)
+        assert_almost_equal(norm(A, 'fro'), 84 ** 0.5)
         assert_almost_equal(norm(A, 'nuc'), 10.0)
         assert_almost_equal(norm(A, inf), 12.0)
         assert_almost_equal(norm(A, -inf), 4.0)
@@ -852,9 +886,10 @@ class _TestNorm(object):
         # happened to have equal nuclear norm and induced 1-norm.
         # The 1/10 scaling factor accommodates the absolute tolerance
         # used in assert_almost_equal.
-        A = (1/10) * np.array([[1, 2, 3], [6, 0, 5], [3, 2, 1]], dtype=self.dt)
-        assert_almost_equal(norm(A), (1/10) * 89**0.5)
-        assert_almost_equal(norm(A, 'fro'), (1/10) * 89**0.5)
+        A = (1 / 10) * \
+            np.array([[1, 2, 3], [6, 0, 5], [3, 2, 1]], dtype=self.dt)
+        assert_almost_equal(norm(A), (1 / 10) * 89 ** 0.5)
+        assert_almost_equal(norm(A, 'fro'), (1 / 10) * 89 ** 0.5)
         assert_almost_equal(norm(A, 'nuc'), 1.3366836911774836)
         assert_almost_equal(norm(A, inf), 1.1)
         assert_almost_equal(norm(A, -inf), 0.6)
@@ -871,7 +906,7 @@ class _TestNorm(object):
         for order in [None, -1, 0, 1, 2, 3, np.Inf, -np.Inf]:
             expected0 = [norm(A[:, k], ord=order) for k in range(A.shape[1])]
             assert_almost_equal(norm(A, ord=order, axis=0), expected0)
-            expected1 = [norm(A[k,:], ord=order) for k in range(A.shape[0])]
+            expected1 = [norm(A[k, :], ord=order) for k in range(A.shape[0])]
             assert_almost_equal(norm(A, ord=order, axis=1), expected1)
 
         # Matrix norms.
@@ -901,7 +936,7 @@ class _TestNorm(object):
                     assert_almost_equal(n, expected)
 
     def test_keepdims(self):
-        A = np.arange(1,25, dtype=self.dt).reshape(2,3,4)
+        A = np.arange(1, 25, dtype=self.dt).reshape(2, 3, 4)
 
         allclose_err = 'order {0}, axis = {1}'
         shape_err = 'Shape mismatch found {0}, expected {1}, order={2}, axis={3}'
@@ -910,8 +945,8 @@ class _TestNorm(object):
         expected = norm(A, ord=None, axis=None)
         found = norm(A, ord=None, axis=None, keepdims=True)
         assert_allclose(np.squeeze(found), expected,
-                        err_msg=allclose_err.format(None,None))
-        expected_shape = (1,1,1)
+                        err_msg=allclose_err.format(None, None))
+        expected_shape = (1, 1, 1)
         assert_(found.shape == expected_shape,
                 shape_err.format(found.shape, expected_shape, None, None))
 
@@ -921,12 +956,12 @@ class _TestNorm(object):
                 expected = norm(A, ord=order, axis=k)
                 found = norm(A, ord=order, axis=k, keepdims=True)
                 assert_allclose(np.squeeze(found), expected,
-                        err_msg=allclose_err.format(order,k))
+                                err_msg=allclose_err.format(order, k))
                 expected_shape = list(A.shape)
                 expected_shape[k] = 1
                 expected_shape = tuple(expected_shape)
                 assert_(found.shape == expected_shape,
-                    shape_err.format(found.shape, expected_shape, order, k))
+                        shape_err.format(found.shape, expected_shape, order, k))
 
         # Matrix norms.
         for order in [None, -2, 2, -1, 1, np.Inf, -np.Inf, 'fro', 'nuc']:
@@ -934,13 +969,13 @@ class _TestNorm(object):
                 expected = norm(A, ord=order, axis=k)
                 found = norm(A, ord=order, axis=k, keepdims=True)
                 assert_allclose(np.squeeze(found), expected,
-                        err_msg=allclose_err.format(order,k))
+                                err_msg=allclose_err.format(order, k))
                 expected_shape = list(A.shape)
                 expected_shape[k[0]] = 1
                 expected_shape[k[1]] = 1
                 expected_shape = tuple(expected_shape)
                 assert_(found.shape == expected_shape,
-                    shape_err.format(found.shape, expected_shape, order, k))
+                        shape_err.format(found.shape, expected_shape, order, k))
 
     def test_bad_args(self):
         # Check that bad arguments raise the appropriate exceptions.
@@ -968,7 +1003,9 @@ class _TestNorm(object):
         assert_raises(ValueError, norm, B, None, (2, 3))
         assert_raises(ValueError, norm, B, None, (0, 1, 2))
 
+
 class TestNorm_NonSystematic(object):
+
     def test_longdouble_norm(self):
         # Non-regression test: p-norm of longdouble would previously raise
         # UnboundLocalError.
@@ -984,8 +1021,8 @@ class TestNorm_NonSystematic(object):
     def test_complex_high_ord(self):
         # gh-4156
         d = np.empty((2,), dtype=np.clongdouble)
-        d[0] = 6+7j
-        d[1] = -6+7j
+        d[0] = 6 + 7j
+        d[1] = -6 + 7j
         res = 11.615898132184
         old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=10)
         d = d.astype(np.complex128)
@@ -1010,11 +1047,13 @@ class TestNormInt64(_TestNorm):
 
 
 class TestMatrixRank(object):
+
     def test_matrix_rank(self):
         # Full rank matrix
         yield assert_equal, 4, matrix_rank(np.eye(4))
         # rank deficient matrix
-        I=np.eye(4); I[-1, -1] = 0.
+        I = np.eye(4)
+        I[-1, -1] = 0.
         yield assert_equal, matrix_rank(I), 3
         # All zeros - zero rank
         yield assert_equal, matrix_rank(np.zeros((4, 4))), 0
@@ -1094,7 +1133,6 @@ class TestQR(object):
         # very limited in scope. Note that the results are in FORTRAN
         # order, hence the h arrays are transposed.
         a = array([[1, 2], [3, 4], [5, 6]], dtype=np.double)
-        b = a.astype(np.single)
 
         # Test double
         h, tau = linalg.qr(a, mode='raw')
@@ -1162,6 +1200,7 @@ def test_generalized_raise_multiloop():
 
     assert_raises(np.linalg.LinAlgError, np.linalg.inv, x)
 
+
 def test_xerbla_override():
     # Check that our xerbla has been successfully linked in. If it is not,
     # the default xerbla routine is called, which prints a message to stdout
@@ -1195,7 +1234,7 @@ def test_xerbla_override():
             a = np.array([[1.]])
             np.linalg.lapack_lite.dorgqr(
                 1, 1, 1, a,
-                0, # <- invalid value
+                0,  # <- invalid value
                 a, a, 0, 0)
         except ValueError as e:
             if "DORGQR parameter number 5" in str(e):
@@ -1213,6 +1252,7 @@ def test_xerbla_override():
 
 
 class TestMultiDot(object):
+
     def test_basic_function_with_three_arguments(self):
         # multi_dot with three arguments uses a fast hand coded algorithm to
         # determine the optimal order. Therefore test it separately.

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -2,51 +2,56 @@
 """
 from __future__ import division, absolute_import, print_function
 
-
-from numpy.testing import *
 import numpy as np
 from numpy import linalg, arange, float64, array, dot, transpose
+from numpy.testing import (
+    TestCase, run_module_suite, assert_equal, assert_array_equal,
+    assert_array_almost_equal, assert_array_less
+)
+
 
 rlevel = 1
 
+
 class TestRegression(TestCase):
-    def test_eig_build(self, level = rlevel):
-        """Ticket #652"""
-        rva = array([1.03221168e+02 +0.j,
-               -1.91843603e+01 +0.j,
-               -6.04004526e-01+15.84422474j,
-               -6.04004526e-01-15.84422474j,
-               -1.13692929e+01 +0.j,
-               -6.57612485e-01+10.41755503j,
-               -6.57612485e-01-10.41755503j,
-               1.82126812e+01 +0.j,
-               1.06011014e+01 +0.j,
-               7.80732773e+00 +0.j,
-               -7.65390898e-01 +0.j,
-               1.51971555e-15 +0.j,
-               -1.51308713e-15 +0.j])
-        a = arange(13*13, dtype = float64)
+
+    def test_eig_build(self, level=rlevel):
+        # Ticket #652
+        rva = array([1.03221168e+02 + 0.j,
+                     -1.91843603e+01 + 0.j,
+                     -6.04004526e-01 + 15.84422474j,
+                     -6.04004526e-01 - 15.84422474j,
+                     -1.13692929e+01 + 0.j,
+                     -6.57612485e-01 + 10.41755503j,
+                     -6.57612485e-01 - 10.41755503j,
+                     1.82126812e+01 + 0.j,
+                     1.06011014e+01 + 0.j,
+                     7.80732773e+00 + 0.j,
+                     -7.65390898e-01 + 0.j,
+                     1.51971555e-15 + 0.j,
+                     -1.51308713e-15 + 0.j])
+        a = arange(13 * 13, dtype=float64)
         a.shape = (13, 13)
-        a = a%17
+        a = a % 17
         va, ve = linalg.eig(a)
         va.sort()
         rva.sort()
         assert_array_almost_equal(va, rva)
 
-    def test_eigh_build(self, level = rlevel):
-        """Ticket 662."""
+    def test_eigh_build(self, level=rlevel):
+        # Ticket 662.
         rvals = [68.60568999, 89.57756725, 106.67185574]
 
-        cov = array([[ 77.70273908,   3.51489954,  15.64602427],
+        cov = array([[77.70273908,   3.51489954,  15.64602427],
                      [3.51489954,  88.97013878,  -1.07431931],
                      [15.64602427,  -1.07431931,  98.18223512]])
 
         vals, vecs = linalg.eigh(cov)
         assert_array_almost_equal(vals, rvals)
 
-    def test_svd_build(self, level = rlevel):
-        """Ticket 627."""
-        a = array([[ 0., 1.], [ 1., 1.], [ 2., 1.], [ 3., 1.]])
+    def test_svd_build(self, level=rlevel):
+        # Ticket 627.
+        a = array([[0., 1.], [1., 1.], [2., 1.], [3., 1.]])
         m, n = a.shape
         u, s, vh = linalg.svd(a)
 
@@ -55,13 +60,13 @@ class TestRegression(TestCase):
         assert_array_almost_equal(b, np.zeros((2, 2)))
 
     def test_norm_vector_badarg(self):
-        """Regression for #786: Froebenius norm for vectors raises
-        TypeError."""
+        # Regression for #786: Froebenius norm for vectors raises
+        # TypeError.
         self.assertRaises(ValueError, linalg.norm, array([1., 2., 3.]), 'fro')
 
     def test_lapack_endian(self):
         # For bug #1482
-        a = array([[5.7998084,  -2.1825367 ],
+        a = array([[5.7998084,  -2.1825367],
                    [-2.1825367,   9.85910595]], dtype='>f8')
         b = array(a, dtype='<f8')
 

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -1,33 +1,36 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
-from numpy.core import *
+import collections
+
+import numpy as np
 from numpy import matrix, asmatrix, bmat
+from numpy.testing import (
+    TestCase, run_module_suite, assert_, assert_equal, assert_almost_equal,
+    assert_array_equal, assert_array_almost_equal, assert_raises
+)
 from numpy.matrixlib.defmatrix import matrix_power
 from numpy.matrixlib import mat
-import numpy as np
-import collections
 
 class TestCtor(TestCase):
     def test_basic(self):
-        A = array([[1, 2], [3, 4]])
+        A = np.array([[1, 2], [3, 4]])
         mA = matrix(A)
-        assert_(all(mA.A == A))
+        assert_(np.all(mA.A == A))
 
         B = bmat("A,A;A,A")
         C = bmat([[A, A], [A, A]])
-        D = array([[1, 2, 1, 2],
-                   [3, 4, 3, 4],
-                   [1, 2, 1, 2],
-                   [3, 4, 3, 4]])
-        assert_(all(B.A == D))
-        assert_(all(C.A == D))
+        D = np.array([[1, 2, 1, 2],
+                      [3, 4, 3, 4],
+                      [1, 2, 1, 2],
+                      [3, 4, 3, 4]])
+        assert_(np.all(B.A == D))
+        assert_(np.all(C.A == D))
 
-        E = array([[5, 6], [7, 8]])
+        E = np.array([[5, 6], [7, 8]])
         AEresult = matrix([[1, 2, 5, 6], [3, 4, 7, 8]])
-        assert_(all(bmat([A, E]) == AEresult))
+        assert_(np.all(bmat([A, E]) == AEresult))
 
-        vec = arange(5)
+        vec = np.arange(5)
         mvec = matrix(vec)
         assert_(mvec.shape == (1, 5))
 
@@ -36,26 +39,23 @@ class TestCtor(TestCase):
         assert_raises(TypeError, matrix, "invalid")
 
     def test_bmat_nondefault_str(self):
-        A = array([[1, 2], [3, 4]])
-        B = array([[5, 6], [7, 8]])
-        Aresult = array([[1, 2, 1, 2],
-                         [3, 4, 3, 4],
-                         [1, 2, 1, 2],
-                         [3, 4, 3, 4]])
-        Bresult = array([[5, 6, 5, 6],
-                         [7, 8, 7, 8],
-                         [5, 6, 5, 6],
-                         [7, 8, 7, 8]])
-        mixresult = array([[1, 2, 5, 6],
-                           [3, 4, 7, 8],
-                           [5, 6, 1, 2],
-                           [7, 8, 3, 4]])
-        assert_(all(bmat("A,A;A,A") == Aresult))
-        assert_(all(bmat("A,A;A,A", ldict={'A':B}) == Aresult))
+        A = np.array([[1, 2], [3, 4]])
+        B = np.array([[5, 6], [7, 8]])
+        Aresult = np.array([[1, 2, 1, 2],
+                            [3, 4, 3, 4],
+                            [1, 2, 1, 2],
+                            [3, 4, 3, 4]])
+        mixresult = np.array([[1, 2, 5, 6],
+                              [3, 4, 7, 8],
+                              [5, 6, 1, 2],
+                              [7, 8, 3, 4]])
+        assert_(np.all(bmat("A,A;A,A") == Aresult))
+        assert_(np.all(bmat("A,A;A,A", ldict={'A':B}) == Aresult))
         assert_raises(TypeError, bmat, "A,A;A,A", gdict={'A':B})
-        assert_(all(bmat("A,A;A,A", ldict={'A':A}, gdict={'A':B}) == Aresult))
+        assert_(
+            np.all(bmat("A,A;A,A", ldict={'A':A}, gdict={'A':B}) == Aresult))
         b2 = bmat("A,B;C,D", ldict={'A':A,'B':B}, gdict={'C':B,'D':A})
-        assert_(all(b2 == mixresult))
+        assert_(np.all(b2 == mixresult))
 
 
 class TestProperties(TestCase):
@@ -77,7 +77,6 @@ class TestProperties(TestCase):
         assert_array_equal(sum0, np.sum(M, axis=0))
         assert_array_equal(sum1, np.sum(M, axis=1))
         assert_equal(sumall, np.sum(M))
-
 
     def test_prod(self):
         x = matrix([[1, 2, 3], [4, 5, 6]])
@@ -115,8 +114,8 @@ class TestProperties(TestCase):
     def test_ptp(self):
         x = np.arange(4).reshape((2, 2))
         assert_(x.ptp() == 3)
-        assert_(all(x.ptp(0) == array([2, 2])))
-        assert_(all(x.ptp(1) == array([1, 1])))
+        assert_(np.all(x.ptp(0) == np.array([2, 2])))
+        assert_(np.all(x.ptp(1) == np.array([1, 1])))
 
     def test_var(self):
         x = np.arange(9).reshape((3, 3))
@@ -127,53 +126,53 @@ class TestProperties(TestCase):
     def test_basic(self):
         import numpy.linalg as linalg
 
-        A = array([[1., 2.],
-                   [3., 4.]])
+        A = np.array([[1., 2.],
+                      [3., 4.]])
         mA = matrix(A)
-        assert_(allclose(linalg.inv(A), mA.I))
-        assert_(all(array(transpose(A) == mA.T)))
-        assert_(all(array(transpose(A) == mA.H)))
-        assert_(all(A == mA.A))
+        assert_(np.allclose(linalg.inv(A), mA.I))
+        assert_(np.all(np.array(np.transpose(A) == mA.T)))
+        assert_(np.all(np.array(np.transpose(A) == mA.H)))
+        assert_(np.all(A == mA.A))
 
         B = A + 2j*A
         mB = matrix(B)
-        assert_(allclose(linalg.inv(B), mB.I))
-        assert_(all(array(transpose(B) == mB.T)))
-        assert_(all(array(conjugate(transpose(B)) == mB.H)))
+        assert_(np.allclose(linalg.inv(B), mB.I))
+        assert_(np.all(np.array(np.transpose(B) == mB.T)))
+        assert_(np.all(np.array(np.transpose(B).conj() == mB.H)))
 
     def test_pinv(self):
-        x = matrix(arange(6).reshape(2, 3))
+        x = matrix(np.arange(6).reshape(2, 3))
         xpinv = matrix([[-0.77777778,  0.27777778],
                         [-0.11111111,  0.11111111],
                         [ 0.55555556, -0.05555556]])
         assert_almost_equal(x.I, xpinv)
 
     def test_comparisons(self):
-        A = arange(100).reshape(10, 10)
+        A = np.arange(100).reshape(10, 10)
         mA = matrix(A)
         mB = matrix(A) + 0.1
-        assert_(all(mB == A+0.1))
-        assert_(all(mB == matrix(A+0.1)))
-        assert_(not any(mB == matrix(A-0.1)))
-        assert_(all(mA < mB))
-        assert_(all(mA <= mB))
-        assert_(all(mA <= mA))
-        assert_(not any(mA < mA))
+        assert_(np.all(mB == A+0.1))
+        assert_(np.all(mB == matrix(A+0.1)))
+        assert_(not np.any(mB == matrix(A-0.1)))
+        assert_(np.all(mA < mB))
+        assert_(np.all(mA <= mB))
+        assert_(np.all(mA <= mA))
+        assert_(not np.any(mA < mA))
 
-        assert_(not any(mB < mA))
-        assert_(all(mB >= mA))
-        assert_(all(mB >= mB))
-        assert_(not any(mB > mB))
+        assert_(not np.any(mB < mA))
+        assert_(np.all(mB >= mA))
+        assert_(np.all(mB >= mB))
+        assert_(not np.any(mB > mB))
 
-        assert_(all(mA == mA))
-        assert_(not any(mA == mB))
-        assert_(all(mB != mA))
+        assert_(np.all(mA == mA))
+        assert_(not np.any(mA == mB))
+        assert_(np.all(mB != mA))
 
-        assert_(not all(abs(mA) > 0))
-        assert_(all(abs(mB > 0)))
+        assert_(not np.all(abs(mA) > 0))
+        assert_(np.all(abs(mB > 0)))
 
     def test_asmatrix(self):
-        A = arange(100).reshape(10, 10)
+        A = np.arange(100).reshape(10, 10)
         mA = asmatrix(A)
         A[0, 0] = -10
         assert_(A[0, 0] == mA[0, 0])
@@ -189,49 +188,48 @@ class TestProperties(TestCase):
 
 class TestCasting(TestCase):
     def test_basic(self):
-        A = arange(100).reshape(10, 10)
+        A = np.arange(100).reshape(10, 10)
         mA = matrix(A)
 
         mB = mA.copy()
-        O = ones((10, 10), float64) * 0.1
+        O = np.ones((10, 10), np.float64) * 0.1
         mB = mB + O
-        assert_(mB.dtype.type == float64)
-        assert_(all(mA != mB))
-        assert_(all(mB == mA+0.1))
+        assert_(mB.dtype.type == np.float64)
+        assert_(np.all(mA != mB))
+        assert_(np.all(mB == mA+0.1))
 
         mC = mA.copy()
-        O = ones((10, 10), complex128)
+        O = np.ones((10, 10), np.complex128)
         mC = mC * O
-        assert_(mC.dtype.type == complex128)
-        assert_(all(mA != mB))
+        assert_(mC.dtype.type == np.complex128)
+        assert_(np.all(mA != mB))
 
 
 class TestAlgebra(TestCase):
     def test_basic(self):
         import numpy.linalg as linalg
 
-        A = array([[1., 2.],
-                   [3., 4.]])
+        A = np.array([[1., 2.], [3., 4.]])
         mA = matrix(A)
 
-        B = identity(2)
+        B = np.identity(2)
         for i in range(6):
-            assert_(allclose((mA ** i).A, B))
-            B = dot(B, A)
+            assert_(np.allclose((mA ** i).A, B))
+            B = np.dot(B, A)
 
         Ainv = linalg.inv(A)
-        B = identity(2)
+        B = np.identity(2)
         for i in range(6):
-            assert_(allclose((mA ** -i).A, B))
-            B = dot(B, Ainv)
+            assert_(np.allclose((mA ** -i).A, B))
+            B = np.dot(B, Ainv)
 
-        assert_(allclose((mA * mA).A, dot(A, A)))
-        assert_(allclose((mA + mA).A, (A + A)))
-        assert_(allclose((3*mA).A, (3*A)))
+        assert_(np.allclose((mA * mA).A, np.dot(A, A)))
+        assert_(np.allclose((mA + mA).A, (A + A)))
+        assert_(np.allclose((3*mA).A, (3*A)))
 
         mA2 = matrix(A)
         mA2 *= 3
-        assert_(allclose(mA2.A, 3*A))
+        assert_(np.allclose(mA2.A, 3*A))
 
     def test_pow(self):
         """Test raising a matrix to an integer power works as expected."""
@@ -312,10 +310,10 @@ class TestMatrixReturn(TestCase):
 
 class TestIndexing(TestCase):
     def test_basic(self):
-        x = asmatrix(zeros((3, 2), float))
-        y = zeros((3, 1), float)
+        x = asmatrix(np.zeros((3, 2), float))
+        y = np.zeros((3, 1), float)
         y[:, 0] = [0.8, 0.2, 0.3]
-        x[:, 1] = y>0.5
+        x[:, 1] = y > 0.5
         assert_equal(x, [[0, 1], [0, 0], [0, 0]])
 
 
@@ -330,7 +328,7 @@ class TestNewScalarIndexing(TestCase):
 
     def test_array_from_matrix_list(self):
         a = self.a
-        x = array([a, a])
+        x = np.array([a, a])
         assert_equal(x.shape, [2, 2, 2])
 
     def test_array_to_list(self):
@@ -362,7 +360,7 @@ class TestNewScalarIndexing(TestCase):
         assert_equal(x[:, 0].shape, x.shape)
 
     def test_scalar_indexing(self):
-        x = asmatrix(zeros((3, 2), float))
+        x = asmatrix(np.zeros((3, 2), float))
         assert_equal(x[0, 0], x[0][0])
 
     def test_row_column_indexing(self):
@@ -373,14 +371,14 @@ class TestNewScalarIndexing(TestCase):
         assert_array_equal(x[:, 1], [[0], [1]])
 
     def test_boolean_indexing(self):
-        A = arange(6)
+        A = np.arange(6)
         A.shape = (3, 2)
         x = asmatrix(A)
-        assert_array_equal(x[:, array([True, False])], x[:, 0])
-        assert_array_equal(x[array([True, False, False]),:], x[0,:])
+        assert_array_equal(x[:, np.array([True, False])], x[:, 0])
+        assert_array_equal(x[np.array([True, False, False]),:], x[0,:])
 
     def test_list_indexing(self):
-        A = arange(6)
+        A = np.arange(6)
         A.shape = (3, 2)
         x = asmatrix(A)
         assert_array_equal(x[:, [1, 0]], x[:, ::-1])
@@ -389,8 +387,8 @@ class TestNewScalarIndexing(TestCase):
 
 class TestPower(TestCase):
     def test_returntype(self):
-        a = array([[0, 1], [0, 0]])
-        assert_(type(matrix_power(a, 2)) is ndarray)
+        a = np.array([[0, 1], [0, 0]])
+        assert_(type(matrix_power(a, 2)) is np.ndarray)
         a = mat(a)
         assert_(type(matrix_power(a, 2)) is matrix)
 
@@ -400,7 +398,7 @@ class TestPower(TestCase):
 
 class TestShape(TestCase):
     def setUp(self):
-        self.a = array([[1], [2]])
+        self.a = np.array([[1], [2]])
         self.m = matrix([[1], [2]])
 
     def test_shape(self):
@@ -420,7 +418,7 @@ class TestShape(TestCase):
         assert_equal(self.m.flatten().shape, (1, 2))
 
     def test_numpy_ravel_order(self):
-        x = array([[1, 2, 3], [4, 5, 6]])
+        x = np.array([[1, 2, 3], [4, 5, 6]])
         assert_equal(np.ravel(x), [1, 2, 3, 4, 5, 6])
         assert_equal(np.ravel(x, order='F'), [1, 4, 2, 5, 3, 6])
         assert_equal(np.ravel(x.T), [1, 4, 2, 5, 3, 6])

--- a/numpy/matrixlib/tests/test_multiarray.py
+++ b/numpy/matrixlib/tests/test_multiarray.py
@@ -1,7 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.testing import *
+from numpy.testing import (
+    TestCase, run_module_suite, assert_, assert_equal, assert_array_equal
+)
 
 class TestView(TestCase):
     def test_type(self):

--- a/numpy/matrixlib/tests/test_regression.py
+++ b/numpy/matrixlib/tests/test_regression.py
@@ -1,18 +1,18 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import *
 import numpy as np
+from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
 
 rlevel = 1
 
 class TestRegression(TestCase):
-    def test_kron_matrix(self,level=rlevel):
-        """Ticket #71"""
+    def test_kron_matrix(self, level=rlevel):
+        # Ticket #71
         x = np.matrix('[1 0; 1 0]')
         assert_equal(type(np.kron(x, x)), type(x))
 
     def test_matrix_properties(self,level=rlevel):
-        """Ticket #125"""
+        # Ticket #125
         a = np.matrix([1.0], dtype=float)
         assert_(type(a.real) is np.matrix)
         assert_(type(a.imag) is np.matrix)
@@ -20,15 +20,15 @@ class TestRegression(TestCase):
         assert_(type(c) is np.ndarray)
         assert_(type(d) is np.ndarray)
 
-    def test_matrix_multiply_by_1d_vector(self, level=rlevel) :
-        """Ticket #473"""
-        def mul() :
+    def test_matrix_multiply_by_1d_vector(self, level=rlevel):
+        # Ticket #473
+        def mul():
             np.mat(np.eye(2))*np.ones(2)
 
         self.assertRaises(ValueError, mul)
 
     def test_matrix_std_argmax(self,level=rlevel):
-        """Ticket #83"""
+        # Ticket #83
         x = np.asmatrix(np.random.uniform(0, 1, (3, 3)))
         self.assertEqual(x.std().shape, ())
         self.assertEqual(x.argmax().shape, ())

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 from numpy.ctypeslib import ndpointer, load_library
 from numpy.distutils.misc_util import get_shared_lib_extension
-from numpy.testing import *
+from numpy.testing import TestCase, run_module_suite, dec
 
 try:
     cdll = load_library('multiarray', np.core.multiarray.__file__)
@@ -14,32 +14,36 @@ except ImportError:
     _HAS_CTYPE = False
 
 class TestLoadLibrary(TestCase):
-    @dec.skipif(not _HAS_CTYPE, "ctypes not available on this python installation")
-    @dec.knownfailureif(sys.platform=='cygwin', "This test is known to fail on cygwin")
+    @dec.skipif(not _HAS_CTYPE,
+                "ctypes not available on this python installation")
+    @dec.knownfailureif(sys.platform ==
+                        'cygwin', "This test is known to fail on cygwin")
     def test_basic(self):
         try:
-            cdll = load_library('multiarray',
-                                np.core.multiarray.__file__)
+            # Should succeed
+            load_library('multiarray', np.core.multiarray.__file__)
         except ImportError as e:
-            msg = "ctypes is not available on this python: skipping the test" \
-                  " (import error was: %s)" % str(e)
+            msg = ("ctypes is not available on this python: skipping the test"
+                   " (import error was: %s)" % str(e))
             print(msg)
 
-    @dec.skipif(not _HAS_CTYPE, "ctypes not available on this python installation")
-    @dec.knownfailureif(sys.platform=='cygwin', "This test is known to fail on cygwin")
+    @dec.skipif(not _HAS_CTYPE,
+                "ctypes not available on this python installation")
+    @dec.knownfailureif(sys.platform ==
+                        'cygwin', "This test is known to fail on cygwin")
     def test_basic2(self):
-        """Regression for #801: load_library with a full library name
-        (including extension) does not work."""
+        # Regression for #801: load_library with a full library name
+        # (including extension) does not work.
         try:
             try:
                 so = get_shared_lib_extension(is_python_ext=True)
-                cdll = load_library('multiarray%s' % so,
-                                    np.core.multiarray.__file__)
+                # Should succeed
+                load_library('multiarray%s' % so, np.core.multiarray.__file__)
             except ImportError:
                 print("No distutils available, skipping test.")
         except ImportError as e:
-            msg = "ctypes is not available on this python: skipping the test" \
-                  " (import error was: %s)" % str(e)
+            msg = ("ctypes is not available on this python: skipping the test"
+                   " (import error was: %s)" % str(e))
             print(msg)
 
 class TestNdpointer(TestCase):
@@ -57,7 +61,7 @@ class TestNdpointer(TestCase):
                           np.array([1], dt.newbyteorder('swap')))
         dtnames = ['x', 'y']
         dtformats = [np.intc, np.float64]
-        dtdescr = {'names' : dtnames, 'formats' : dtformats}
+        dtdescr = {'names': dtnames, 'formats': dtformats}
         dt = np.dtype(dtdescr)
         p = ndpointer(dtype=dt)
         self.assertTrue(p.from_param(np.zeros((10,), dt)))

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -5,36 +5,36 @@ import numpy.matlib
 from numpy.testing import assert_array_equal, assert_, run_module_suite
 
 def test_empty():
-    x = np.matlib.empty((2,))
+    x = numpy.matlib.empty((2,))
     assert_(isinstance(x, np.matrix))
     assert_(x.shape, (1, 2))
 
 def test_ones():
-    assert_array_equal(np.matlib.ones((2, 3)),
+    assert_array_equal(numpy.matlib.ones((2, 3)),
                        np.matrix([[ 1.,  1.,  1.],
                                  [ 1.,  1.,  1.]]))
 
-    assert_array_equal(np.matlib.ones(2), np.matrix([[ 1.,  1.]]))
+    assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
 def test_zeros():
-    assert_array_equal(np.matlib.zeros((2, 3)),
+    assert_array_equal(numpy.matlib.zeros((2, 3)),
                        np.matrix([[ 0.,  0.,  0.],
                                  [ 0.,  0.,  0.]]))
 
-    assert_array_equal(np.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
+    assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
 
 def test_identity():
-    x = np.matlib.identity(2, dtype=np.int)
+    x = numpy.matlib.identity(2, dtype=np.int)
     assert_array_equal(x, np.matrix([[1, 0], [0, 1]]))
 
 def test_eye():
-    x = np.matlib.eye(3, k=1, dtype=int)
+    x = numpy.matlib.eye(3, k=1, dtype=int)
     assert_array_equal(x, np.matrix([[ 0,  1,  0],
                                      [ 0,  0,  1],
                                      [ 0,  0,  0]]))
 
 def test_rand():
-    x = np.matlib.rand(3)
+    x = numpy.matlib.rand(3)
     # check matrix type, array would have shape (3,)
     assert_(x.ndim == 2)
 
@@ -45,7 +45,7 @@ def test_randn():
 
 def test_repmat():
     a1 = np.arange(4)
-    x = np.matlib.repmat(a1, 2, 2)
+    x = numpy.matlib.repmat(a1, 2, 2)
     y = np.array([[0, 1, 2, 3, 0, 1, 2, 3],
                   [0, 1, 2, 3, 0, 1, 2, 3]])
     assert_array_equal(x, y)


### PR DESCRIPTION
Additional style and pep8 fixups, mostly driven by fixing the previously ubiquitous

```
from numpy.testing import *
```

and a few other `import *` cases. There are still some in `f2py`, but that is a project for another day.
