### PR TITLE
MAINT: fix broken and outdated link in HOWTO_DOCUMENT.  Closes gh-6107.

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -620,10 +620,6 @@ Other points to keep in mind
   and are not often necessary. One situation in which a warning can
   be useful is for marking a known bug that is not yet fixed.
 
-* Questions and Answers : For general questions on how to write docstrings
-  that are not answered in this document, refer to
-  `<http://docs.scipy.org/numpy/Questions+Answers/>`_.
-
 * array_like : For functions that take arguments which can have not only
   a type `ndarray`, but also types that can be converted to an ndarray
   (i.e. scalar types, sequence types), those arguments can be documented


### PR DESCRIPTION
[ci skip]
