### PR TITLE
BUG: fixed regression in np.histogram which caused input floating-point values to be modified

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -232,7 +232,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
                 tmp_a = tmp_a[keep]
                 if tmp_w is not None:
                     tmp_w = tmp_w[keep]
-            tmp_a = np.array(tmp_a, dtype=float, copy=False)
+            tmp_a = tmp_a.astype(float)
             tmp_a -= mn
             tmp_a *= norm
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1221,6 +1221,13 @@ class TestHistogram(TestCase):
         wa, wb = histogram(values, bins=2, range=[1, 3], weights=weights)
         assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
 
+    def test_no_side_effects(self):
+        # This is a regression test that ensures that values passed to
+        # ``histogram`` are unchanged.
+        values = np.array([1.3, 2.5, 2.3])
+        np.histogram(values, range=[-10, 10], bins=100)
+        assert_array_almost_equal(values, [1.3, 2.5, 2.3])
+
     def test_empty(self):
         a, b = histogram([], bins=([0, 1]))
         assert_array_equal(a, np.array([0]))


### PR DESCRIPTION
@jaimefrio @rgommers @nayyarv - this should solve the issue described in #6120 related to in-place modifications of the input array, but I think @jaimefrio is also right that the original test needs fixing too.

This results in a 5-7% loss in performance, but this is very little compared to the original factor of 10x performance gain, so nothing to worry about.

Sorry for introducing this bug!
