### PR TITLE
TST: fix OverflowError on win-amd64

### DIFF
--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -27,7 +27,7 @@ class TestRegression(TestCase):
             (2**20 - 2, 2**20 - 2, 2**20 - 2),  # Check for 32-bit systems
         ]
         is_64bits = sys.maxsize > 2**32
-        if is_64bits:
+        if is_64bits and sys.platform != 'win32':
             args.append((2**40 - 2, 2**40 - 2, 2**40 - 2)) # Check for 64-bit systems
         for arg in args:
             assert_(np.random.hypergeometric(*arg) > 0)


### PR DESCRIPTION
```
ERROR: test_hypergeometric_range (test_regression.TestRegression)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\numpy\random\tests\test_regression.py", line 33, in test_hypergeometric_range
    assert_(np.random.hypergeometric(*arg) > 0)
  File "mtrand.pyx", line 4136, in mtrand.RandomState.hypergeometric (numpy\random\mtrand\mtrand.c:25459)
OverflowError: Python int too large to convert to C long
```
