### PR TITLE
Fix test_system_info errors and failures on Windows

### DIFF
--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -25,7 +25,7 @@ def get_class(name, notfound_action=1):
 
 simple_site = """
 [ALL]
-library_dirs = {dir1:s}:{dir2:s}
+library_dirs = {dir1:s}{pathsep:s}{dir2:s}
 libraries = {lib1:s},{lib2:s}
 extra_compile_args = -I/fake/directory
 runtime_library_dirs = {dir1:s}
@@ -108,7 +108,8 @@ class TestSystemInfoReading(TestCase):
             'dir1': self._dir1,
             'lib1': self._lib1,
             'dir2': self._dir2,
-            'lib2': self._lib2
+            'lib2': self._lib2,
+            'pathsep': os.pathsep
         })
         # Write site.cfg
         fd, self._sitecfg = mkstemp()

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -179,7 +179,8 @@ class TestSystemInfoReading(TestCase):
             os.chdir(self._dir1)
             c.compile([os.path.basename(self._src1)], output_dir=self._dir1)
             # Ensure that the object exists
-            assert_(os.path.isfile(self._src1.replace('.c', '.o')))
+            assert_(os.path.isfile(self._src1.replace('.c', '.o')) or
+                    os.path.isfile(self._src1.replace('.c', '.obj')))
             os.chdir(previousDir)
         except OSError:
             pass

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -6,6 +6,7 @@ from tempfile import mkstemp, mkdtemp
 
 from numpy.distutils import ccompiler
 from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
+from numpy.testing.decorators import skipif
 from numpy.distutils.system_info import system_info, ConfigParser
 from numpy.distutils.system_info import default_lib_dirs, default_include_dirs
 
@@ -185,6 +186,7 @@ class TestSystemInfoReading(TestCase):
         except OSError:
             pass
 
+    @skipif('msvc' in repr(ccompiler.new_compiler()))
     def test_compile2(self):
         # Compile source and link the second source
         tsi = self.c_temp2


### PR DESCRIPTION
Fixes three test errors/failures on Windows. Tested on win-amd64-py3.4.

```
======================================================================
ERROR: test_compile2 (test_system_info.TestSystemInfoReading)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\distutils\msvc9compiler.py", line 546, in compile
    extra_postargs)
  File "X:\Python34\lib\site-packages\numpy\distutils\ccompiler.py", line 28, in <lambda>
    m = lambda self, *args, **kw: func(self, *args, **kw)
  File "X:\Python34\lib\site-packages\numpy\distutils\ccompiler.py", line 72, in CCompiler_spawn
    raise DistutilsExecError('Command "%s" failed with exit status %d%s' % (cmd, s, msg))
distutils.errors.DistutilsExecError: <snip>

======================================================================
FAIL: test_all (test_system_info.TestSystemInfoReading)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\numpy\distutils\tests\test_system_info.py", line 150, in test_all
    assert_equal(tsi.get_lib_dirs(), [self._dir1, self._dir2])
  File "X:\Python34\lib\site-packages\numpy\testing\utils.py", line 288, in assert_equal
    assert_equal(len(actual), len(desired), err_msg, verbose)
  File "X:\Python34\lib\site-packages\numpy\testing\utils.py", line 354, in assert_equal
    raise AssertionError(msg)
AssertionError:
Items are not equal:
 ACTUAL: 0
 DESIRED: 2

======================================================================
FAIL: test_compile1 (test_system_info.TestSystemInfoReading)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\numpy\distutils\tests\test_system_info.py", line 182, in test_compile1
    assert_(os.path.isfile(self._src1.replace('.c', '.o')))
  File "X:\Python34\lib\site-packages\numpy\testing\utils.py", line 53, in assert_
    raise AssertionError(smsg)
AssertionError
```
