### PR TITLE
TST: on Windows run f2py from the Scripts directory

### DIFF
--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -60,6 +60,10 @@ def run_command(cmd, check_code=True):
 @skipif_inplace
 def test_f2py():
     # test that we can run f2py script
-    f2py_cmd = 'f2py' + basename(sys.executable)[6:]
-    code, stdout, stderr = run_command([f2py_cmd, '-v'])
+    if sys.platform == 'win32':
+        f2py_cmd = r"%s\Scripts\f2py.py" % dirname(sys.executable)
+        code, stdout, stderr = run_command([sys.executable, f2py_cmd, '-v'])
+    else:
+        f2py_cmd = 'f2py' + basename(sys.executable)[6:]
+        code, stdout, stderr = run_command([f2py_cmd, '-v'])
     assert_equal(stdout.strip(), asbytes('2'))


### PR DESCRIPTION
There is no `f2py.exe` on Windows:

```
======================================================================
ERROR: test_scripts.test_f2py
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\numpy\testing\decorators.py", line 146, in skipper_func
    return f(*args, **kwargs)
  File "X:\Python34\lib\site-packages\numpy\tests\test_scripts.py", line 64, in test_f2py
    code, stdout, stderr = run_command([f2py_cmd, '-v'])
  File "X:\Python34\lib\site-packages\numpy\tests\test_scripts.py", line 48, in run_command
    proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
  File "X:\Python34\lib\subprocess.py", line 859, in __init__
    restore_signals, start_new_session)
  File "X:\Python34\lib\subprocess.py", line 1112, in _execute_child
    startupinfo)
FileNotFoundError: [WinError 2] The system cannot find the file specified
```
