### PR TITLE
Enable Visual Studio 2015 C99 features

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -163,7 +163,7 @@ double npy_spacing(double x);
     #ifndef NPY_HAVE_DECL_ISNAN
         #define npy_isnan(x) ((x) != (x))
     #else
-        #ifdef _MSC_VER
+        #if defined(_MSC_VER) && (_MSC_VER < 1900)
             #define npy_isnan(x) _isnan((x))
         #else
             #define npy_isnan(x) isnan(x)
@@ -194,7 +194,7 @@ double npy_spacing(double x);
     #ifndef NPY_HAVE_DECL_ISINF
         #define npy_isinf(x) (!npy_isfinite(x) && !npy_isnan(x))
     #else
-        #ifdef _MSC_VER
+        #if defined(_MSC_VER) && (_MSC_VER < 1900)
             #define npy_isinf(x) (!_finite((x)) && !_isnan((x)))
         #else
             #define npy_isinf(x) isinf((x))

--- a/numpy/core/src/npymath/npy_math_private.h
+++ b/numpy/core/src/npymath/npy_math_private.h
@@ -487,7 +487,7 @@ do {                                                            \
 #ifdef NPY_USE_C99_COMPLEX
 
 /* Microsoft C defines _MSC_VER */
-if defined(_MSC_VER) && (_MSC_VER < 1900)
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
 typedef union {
         npy_cdouble npy_z;
         _Dcomplex c99_z;

--- a/numpy/core/src/npymath/npy_math_private.h
+++ b/numpy/core/src/npymath/npy_math_private.h
@@ -487,7 +487,7 @@ do {                                                            \
 #ifdef NPY_USE_C99_COMPLEX
 
 /* Microsoft C defines _MSC_VER */
-#ifdef _MSC_VER
+if defined(_MSC_VER) && (_MSC_VER < 1900)
 typedef union {
         npy_cdouble npy_z;
         _Dcomplex c99_z;

--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -32,7 +32,7 @@
 #endif
 
 /* Disable broken MS math functions */
-#if defined(_MSC_VER) || defined(__MINGW32_VERSION)
+#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__MINGW32_VERSION)
 
 #undef HAVE_ATAN2
 #undef HAVE_ATAN2F
@@ -41,6 +41,23 @@
 #undef HAVE_HYPOT
 #undef HAVE_HYPOTF
 #undef HAVE_HYPOTL
+
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
+
+#undef HAVE_CASIN
+#undef HAVE_CASINF
+#undef HAVE_CASINL
+#undef HAVE_CASINH
+#undef HAVE_CASINHF
+#undef HAVE_CASINHL
+#undef HAVE_CATAN
+#undef HAVE_CATANF
+#undef HAVE_CATANL
+#undef HAVE_CATANH
+#undef HAVE_CATANHF
+#undef HAVE_CATANHL
 
 #endif
 


### PR DESCRIPTION
Tested with Visual Studio 2015 Community, without MKL, and Python 3.5.0b4, 32 and 64 bit.

Travis CI failures seem unrelated.
