### PR TITLE
BLD: fixes for Intel compilers

### DIFF
--- a/numpy/core/src/npymath/npy_math_private.h
+++ b/numpy/core/src/npymath/npy_math_private.h
@@ -540,4 +540,11 @@ typedef union {
 } __npy_clongdouble_to_c99_cast;
 #endif /* !NPY_USE_C99_COMPLEX */
 
+/* Intel C for Windows uses POW for 64 bits longdouble*/
+#if defined(_MSC_VER) && defined(__INTEL_COMPILER)
+#if defined(HAVE_POWL) && (NPY_SIZEOF_LONGDOUBLE == 8)
+#undef HAVE_POWL
+#endif
+#endif /* _MSC_VER and __INTEL_COMPILER */
+
 #endif /* !_NPY_MATH_PRIVATE_H_ */

--- a/numpy/core/src/npymath/npy_math_private.h
+++ b/numpy/core/src/npymath/npy_math_private.h
@@ -486,8 +486,12 @@ do {                                                            \
  */
 #ifdef NPY_USE_C99_COMPLEX
 
-/* Microsoft C defines _MSC_VER */
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
+/*
+ * Microsoft C defines _MSC_VER
+ * Intel compiler does not use MSVC complex types, but defines _MSC_VER by
+ * default.
+ */
+#if defined(_MSC_VER) && (_MSC_VER < 1900) && !defined(__INTEL_COMPILER)
 typedef union {
         npy_cdouble npy_z;
         _Dcomplex c99_z;

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -420,7 +420,7 @@ class build_ext (old_build_ext):
 
         linker = self.compiler.link_shared_object
         # Always use system linker when using MSVC compiler.
-        if self.compiler.compiler_type=='msvc':
+        if self.compiler.compiler_type in ('msvc', 'intelw', 'intelemw'):
             # expand libraries with fcompiler libraries as we are
             # not using fcompiler linker
             self._libs_with_msvc_and_fortran(fcompiler, libraries, library_dirs)

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -39,7 +39,8 @@ class config(old_config):
         old_config._check_compiler(self)
         from numpy.distutils.fcompiler import FCompiler, new_fcompiler
 
-        if sys.platform == 'win32' and self.compiler.compiler_type == 'msvc':
+        if sys.platform == 'win32' and (self.compiler.compiler_type in
+                                        ('msvc', 'intelw', 'intelemw')):
             # XXX: hack to circumvent a python 2.6 bug with msvc9compiler:
             # initialize call query_vcvarsall, which throws an IOError, and
             # causes an error along the way without much information. We try to

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.exec_command import find_executable
-from numpy.distutils.msvc9compiler import MSVCCompiler
+from distutils.msvc9compiler import MSVCCompiler
 from numpy.distutils.ccompiler import simple_version_match
 
 
@@ -40,6 +40,7 @@ class IntelEM64TCCompiler(UnixCCompiler):
     compiler_type = 'intelem'
     cc_exe = 'icc -m64 -fPIC'
     cc_args = "-fPIC"
+
     def __init__(self, verbose=0, dry_run=0, force=0):
         UnixCCompiler.__init__(self, verbose, dry_run, force)
         self.cc_exe = 'icc -m64 -fPIC'
@@ -66,9 +67,9 @@ class IntelCCompilerW(MSVCCompiler):
         MSVCCompiler.initialize(self, plat_name)
         self.cc = self.find_exe("icl.exe")
         self.linker = self.find_exe("xilink")
-        self.compile_options = ['/nologo', '/O3', '/MD', '/W3']
-        self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/Z7',
-                                      '/D_DEBUG']
+        self.compile_options = ['/nologo', '/O3', '/MD', '/W3', '/Qstd=c99']
+        self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
+                                      '/Qstd=c99', '/Z7', '/D_DEBUG']
 
 
 class IntelEM64TCCompilerW(IntelCCompilerW):

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -19,6 +19,7 @@ class IntelCCompiler(UnixCCompiler):
         self.set_executables(compiler=compiler,
                              compiler_so=compiler,
                              compiler_cxx=compiler,
+                             archiver='xiar' + ' cru',
                              linker_exe=compiler,
                              linker_so=compiler + ' -shared')
 
@@ -48,6 +49,7 @@ class IntelEM64TCCompiler(UnixCCompiler):
         self.set_executables(compiler=compiler,
                              compiler_so=compiler,
                              compiler_cxx=compiler,
+                             archiver='xiar' + ' cru',
                              linker_exe=compiler,
                              linker_so=compiler + ' -shared')
 
@@ -66,6 +68,7 @@ class IntelCCompilerW(MSVCCompiler):
     def initialize(self, plat_name=None):
         MSVCCompiler.initialize(self, plat_name)
         self.cc = self.find_exe("icl.exe")
+        self.lib = self.find_exe("xilib")
         self.linker = self.find_exe("xilink")
         self.compile_options = ['/nologo', '/O3', '/MD', '/W3', '/Qstd=c99']
         self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',


### PR DESCRIPTION
- Fix a few bugs (incorrect import, add `/MANIFEST` for Intel C compilers)
- Enable C99 complex support
- Fix issue with complex types on Windows
- IPO support (xiar/xilib)
- Fix issue with POWL on Windows (see commit message for details).

Thanks to Intel for this patch.

The second commit (IPO support) I'm not sure about - I seem to remember a previous discussion about yes/no using `xiar` that I cannot find back. Anyone remember?
