### PR TITLE
MAINT: Temporarily disable __numpy_ufunc__ for 1.10

### DIFF
--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -195,6 +195,16 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     /* Pos of each override in args */
     int with_override_pos[NPY_MAXARGS];
 
+    /****************************************************************
+     * Temporarily disable this functionality for the 1.10 release.
+     * See gh-5844.
+     ****************************************************************/
+    *result = NULL;
+    return 0;
+    /****************************************************************
+     * Actual implementation follows:
+     ****************************************************************/
+
     /*
      * Check inputs
      */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1938,6 +1938,9 @@ class TestMethods(TestCase):
         assert_equal(c, np.dot(a, b))
 
     def test_dot_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return "A"
@@ -2261,6 +2264,9 @@ class TestBinop(object):
         # Check that __rmul__ and other right-hand operations have
         # precedence over __numpy_ufunc__
 
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         ops = {
             '__add__':      ('__radd__', np.add, True),
             '__sub__':      ('__rsub__', np.subtract, True),
@@ -2376,6 +2382,9 @@ class TestBinop(object):
             yield check, op_name, False
 
     def test_ufunc_override_rop_simple(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
+
         # Check parts of the binary op overriding behavior in an
         # explicit test case that is easier to understand.
         class SomeClass(object):
@@ -2480,6 +2489,9 @@ class TestBinop(object):
         assert_(isinstance(res, SomeClass3))
 
     def test_ufunc_override_normalize_signature(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         # gh-5674
         class SomeClass(object):
             def __numpy_ufunc__(self, ufunc, method, i, inputs, **kw):
@@ -4160,6 +4172,9 @@ class TestDot(TestCase):
         assert_equal(np.dot(3, arr), desired)
 
     def test_dot_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return "A"
@@ -4439,6 +4454,8 @@ class MatmulCommon():
         assert_equal(res, tgt12_21)
 
     def test_numpy_ufunc_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
 
         class A(np.ndarray):
             def __new__(cls, *args, **kwargs):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1200,6 +1200,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(ncu.maximum(a, C()), 0)
 
     def test_ufunc_override(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
 
         class A(object):
             def __numpy_ufunc__(self, func, method, pos, inputs, **kwargs):
@@ -1225,6 +1227,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res1[5], {})
 
     def test_ufunc_override_mro(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
 
         # Some multi arg functions for testing.
         def tres_mul(a, b, c):
@@ -1316,6 +1320,8 @@ class TestSpecialMethods(TestCase):
         assert_raises(TypeError, four_mul_ufunc, 1, c, c_sub, c)
 
     def test_ufunc_override_methods(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
 
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
@@ -1420,6 +1426,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res[4], (a, [4, 2], 'b0'))
 
     def test_ufunc_override_out(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5844
+        return
 
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
@@ -1454,6 +1462,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res7['out'][1], 'out1')
 
     def test_ufunc_override_exception(self):
+        # Temporarily disable __numpy_ufunc__ for 1.10; see gh-5864
+        return
 
         class A(object):
             def __numpy_ufunc__(self, *a, **kwargs):


### PR DESCRIPTION
Backport of #6102 to maintenance/1.10.0

Following discussion in gh-5844, we regretfully decided that we have to
disable **numpy_ufunc** again for 1.10. 
