### PR TITLE
DOC: document behaviour of sign for complex numbers

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2799,12 +2799,13 @@ add_newdoc('numpy.core.umath', 'sign',
     """
     Returns an element-wise indication of the sign of a number.
 
-    The `sign` function returns ``-1 if x < 0, 0 if x==0, 1 if x > 0``.
+    The `sign` function returns ``-1 if x < 0, 0 if x==0, 1 if x > 0``.  nan
+    is returned for nan inputs.
 
-    For complex inputs, the `sign` function returns:
-    ``-1+0j if x.real < 0,
-    1+0j if x.real > 0,
-    sign(x.imag)+0j if x.real == 0.``
+    For complex inputs, the `sign` function returns
+    ``sign(x.real) + 0j if x.real != 0 else sign(x.imag) + 0j``.
+
+    complex(nan, 0) is returned for complex nan inputs.
 
     Parameters
     ----------

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2801,6 +2801,11 @@ add_newdoc('numpy.core.umath', 'sign',
 
     The `sign` function returns ``-1 if x < 0, 0 if x==0, 1 if x > 0``.
 
+    For complex inputs, the `sign` function returns:
+    ``-1+0j if x.real < 0,
+    1+0j if x.real > 0,
+    sign(x.imag)+0j if x.real == 0.``
+
     Parameters
     ----------
     x : array_like
@@ -2811,12 +2816,20 @@ add_newdoc('numpy.core.umath', 'sign',
     y : ndarray
       The sign of `x`.
 
+    Notes
+    -----
+    There is more than one definition of sign in common use for complex
+    numbers.  The definition used here is equivalent to :math:`x/\\sqrt{x*x}`
+    which is different from a common alternative, :math:`x/|x|`.
+
     Examples
     --------
     >>> np.sign([-5., 4.5])
     array([-1.,  1.])
     >>> np.sign(0)
     0
+    >>> np.sign(5-2j)
+    (1+0j)
 
     """)
 


### PR DESCRIPTION
I noticed that the behaviour of sign for complex inputs is different than what is implemented in Mathematica or Matlab.  This is not a bug, but just due to a different definition (numpy's behavior matches the definition of csgn here:  https://en.wikipedia.org/wiki/Sign_function#Complex_signum).

This has apparently caused confusion in the past:  #1848
