### PR TITLE
BLD: Speed up Travis builds by 10-15 minutes, move to container-based architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,21 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
+
+# Run jobs on container-based infrastructure, can be overridden per job
+sudo: false
+
+# Travis whitelists the installable packages, additions can be requested
+#   https://github.com/travis-ci/apt-package-whitelist
+addons:
+  apt:
+    packages: &common_packages
+      - gfortran
+      - libatlas-dev
+      - libatlas-base-dev
+      # Speedup builds, particularly when USE_CHROOT=1
+      - eatmydata
+
 python:
   - 2.6
   - 2.7
@@ -11,8 +26,21 @@ matrix:
   include:
     - python: 3.3
       env: USE_CHROOT=1 ARCH=i386 DIST=trusty PYTHON=3.4
+      sudo: true
+      addons:
+        apt:
+          packages:
+            - *common_packages
+            - debootstrap
     - python: 3.2
       env: USE_DEBUG=1
+      addons:
+        apt:
+          packages:
+            - *common_packages
+            - python3-dbg
+            - python3-dev
+            - python3-nose
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.4
@@ -38,7 +66,6 @@ before_install:
   - pip install --upgrade pip setuptools
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython
-  - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   - popd
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 python:
   - 2.6
   - 2.7
@@ -60,11 +64,11 @@ before_install:
   # We therefore control our own environment, avoid travis' numpy
   - virtualenv --python=python venv
   - source venv/bin/activate
-  - pip install nose
-  # pip install coverage
   - python -V
   - pip install --upgrade pip setuptools
   # Speed up install by not compiling Cython
+  - pip install nose
+  # pip install coverage
   - pip install --install-option="--no-cython-compile" Cython
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ before_install:
   - source venv/bin/activate
   - python -V
   - pip install --upgrade pip setuptools
-  # Speed up install by not compiling Cython
   - pip install nose
   # pip install coverage
+  # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython
   - popd
 

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-# travis boxes give you 1.5 cpus
+# Travis legacy boxes give you 1.5 CPUs, container-based boxes give you 2 CPUs
 export NPY_NUM_BUILD_JOBS=2
 
 # setup env
@@ -47,12 +47,7 @@ setup_chroot()
   # CC="gcc -m32" LDSHARED="gcc -m32 -shared" LDFLAGS="-m32 -shared" linux32 python setup.py build
   # when travis updates to ubuntu 14.04
   DIR=$1
-  # speeds up setup as we don't have eatmydata during bootstrap
-  sudo mkdir -p $DIR
-  sudo mount -t tmpfs -o size=4G tmpfs $DIR
   set -u
-  sudo apt-get update
-  sudo apt-get -qq -y --force-yes install debootstrap eatmydata
   sudo debootstrap --variant=buildd --include=fakeroot,build-essential --arch=$ARCH --foreign $DIST $DIR
   sudo chroot $DIR ./debootstrap/debootstrap --second-stage
   sudo rsync -a $TRAVIS_BUILD_DIR $DIR/
@@ -117,8 +112,6 @@ PYTHON=${PYTHON:-python}
 PIP=${PIP:-pip}
 
 if [ -n "$USE_DEBUG" ]; then
-  sudo apt-get update
-  sudo apt-get install -qq -y --force-yes python3-dbg python3-dev python3-nose
   PYTHON=python3-dbg
 fi
 


### PR DESCRIPTION
Runs jobs on [container-based architecture](http://docs.travis-ci.com/user/workers/container-based-infrastructure/), except when USE_CHROOT=1
Uses libeatmydata for all jobs  & removes the tmpfs workaround
Enables [caching](http://docs.travis-ci.com/user/caching/) of pip downloads & wheels.

Without this PR the Travis build takes 55-60 minutes, with this PR it takes ~45 minutes.
