### PR TITLE
BLD: fix various issues for Intel Fortran and GFortran

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -215,7 +215,7 @@ class GnuFCompiler(FCompiler):
                 # use -mincoming-stack-boundary=2
                 # due to the change to 16 byte stack alignment since GCC 4.6
                 # but 32 bit Windows ABI defines 4 bytes stack alignment
-                opt = ['-O2 -march=core2 -mtune=generic -mfpmath=sse -msse2'
+                opt = ['-O2 -march=core2 -mtune=generic -mfpmath=sse -msse2 '
                        '-mincoming-stack-boundary=2']
             else:
                 opt = ['-O2 -march=x86-64 -DMS_WIN64 -mtune=generic -msse2']

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -173,7 +173,7 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
         return ['/O1']  # Scipy test failures with /O2
 
     def get_flags_arch(self):
-        return ["/arch:IA-32", "/QaxSSE3"]
+        return ["/arch:IA32", "/QaxSSE3"]
 
     def runtime_library_dir_option(self, dir):
         raise NotImplementedError


### PR DESCRIPTION
Closes gh-6095. Note that I haven't been able to test this, fixes are based on Intel docs and the description in gh-6095.  

Note: each commit message has a more detailed description and links to the relevant page of the Intel docs.
