### PR TITLE
BLD: revert C99 complex for msvc14

### DIFF
--- a/numpy/core/src/npymath/npy_math_private.h
+++ b/numpy/core/src/npymath/npy_math_private.h
@@ -491,7 +491,7 @@ do {                                                            \
  * Intel compiler does not use MSVC complex types, but defines _MSC_VER by
  * default.
  */
-#if defined(_MSC_VER) && (_MSC_VER < 1900) && !defined(__INTEL_COMPILER)
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 typedef union {
         npy_cdouble npy_z;
         _Dcomplex c99_z;


### PR DESCRIPTION
This partially reverts  #6141. Sorry.
Turns out that MSVC 2015 C99 support is still incomplete. See also #4896.
Needs backport to 1.10.x.
