### PR TITLE
BLD: Shave another 5-6 minutes off combined Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ python:
 matrix:
   include:
     - python: 3.3
+      # Travis caching is not available infrastructre on the legacy
+      # architecture (i.e. when sudo=true), so skip Cython compiltion
       env: USE_CHROOT=1 ARCH=i386 DIST=trusty PYTHON=3.4
+           CYTHON_OPTS="--install-option=--no-cython-compile"
       sudo: true
       addons:
         apt:
@@ -62,11 +65,11 @@ before_install:
   - virtualenv --python=python venv
   - source venv/bin/activate
   - python -V
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade pip setuptools wheel
   - pip install nose
   # pip install coverage
-  # Speed up install by not compiling Cython
-  - pip install --install-option="--no-cython-compile" Cython
+  # Compile Cython when the resulting wheel will cached between builds
+  - pip install ${CYTHON_OPTS:-} Cython
   - popd
 
 script:


### PR DESCRIPTION
- Install wheel in the virtualenv, so pip builds Cython as a wheel & caches it
- Enable Cython compilation when the result will be cached
- Skip `pip install` outside chroot when we're building numpy in a chroot

The total time for all jobs drops from about 45 minutes to about [40 minutes](https://travis-ci.org/moreati/numpy/builds/74499272), once the Cython wheels have been cached.
