### PR TITLE
DOC: Document our backcompat guarantees for np.random #6084

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -585,7 +585,9 @@ cdef class RandomState:
     `size` that defaults to ``None``. If `size` is ``None``, then a single
     value is generated and returned. If `size` is an integer, then a 1-D
     array filled with generated values is returned. If `size` is a tuple,
-    then an array with that shape is filled and returned.
+    then an array with that shape is filled and returned.  It should also be
+    noted that when using a given seed, the same sequence of 'RandomState'
+    function calls will always yield the same results.
 
     Parameters
     ----------

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -588,8 +588,8 @@ cdef class RandomState:
     then an array with that shape is filled and returned.
 
     * Compatibility Guarantee*
-    When using a fixed seed and a fixed series of calls to 'RandomState' methods
-    will always produce the same results regardless of platform or numpy
+    A fixed seed and a fixed series of calls to 'RandomState' methods will
+    always produce the same results regardless of platform or numpy
     version. Small differences in floating point values may occur due to
     rounding differences between compilers.
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -585,9 +585,13 @@ cdef class RandomState:
     `size` that defaults to ``None``. If `size` is ``None``, then a single
     value is generated and returned. If `size` is an integer, then a 1-D
     array filled with generated values is returned. If `size` is a tuple,
-    then an array with that shape is filled and returned.  It should also be
-    noted that when using a given seed, the same sequence of 'RandomState'
-    function calls will always yield the same results.
+    then an array with that shape is filled and returned.
+
+    * Compatibility Guarantee*
+    When using a fixed seed and a fixed series of calls to 'RandomState' methods
+    will always produce the same results regardless of platform or numpy
+    version. Small differences in floating point values may occur due to
+    rounding differences between compilers.
 
     Parameters
     ----------


### PR DESCRIPTION
updated the np.RandomState documentation to address/include the RandomState stability guarantee described in issue #6084
