### PR TITLE
Clarify signature of numpy.pad.

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1114,7 +1114,7 @@ def _validate_lengths(narray, number_elements):
 # Public functions
 
 
-def pad(array, pad_width, mode=None, **kwargs):
+def pad(array, pad_width, mode, **kwargs):
     """
     Pads an array.
 
@@ -1355,9 +1355,6 @@ def pad(array, pad_width, mode=None, **kwargs):
             if i in ['end_values', 'constant_values']:
                 kwargs[i] = _normalize_shape(narray, kwargs[i],
                                              cast_to_int=False)
-    elif mode is None:
-        raise ValueError('Keyword "mode" must be a function or one of %s.' %
-                         (list(allowedkwargs.keys()),))
     else:
         # Drop back to old, slower np.apply_along_axis mode for user-supplied
         # vector function

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -993,7 +993,7 @@ class ValueError3(TestCase):
 
     def test_mode_not_set(self):
         arr = np.arange(30).reshape(5, 6)
-        assert_raises(ValueError, pad, arr, 4)
+        assert_raises(TypeError, pad, arr, 4)
 
     def test_malformed_pad_amount(self):
         arr = np.arange(30).reshape(5, 6)


### PR DESCRIPTION
`mode` is a required argument so just declare it as such.  This does not
prevent it from being passed as a keyword argument.
