### PR TITLE
BLD: Remove fallback CBLAS detection looking for cblas.h.

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1676,37 +1676,12 @@ class blas_info(system_info):
 
     def calc_info(self):
         lib_dirs = self.get_lib_dirs()
-
         blas_libs = self.get_libs('blas_libs', self._lib_names)
         info = self.check_libs(lib_dirs, blas_libs, [])
         if info is None:
             return
-        if self.has_cblas():
-            info['language'] = 'c'
-            info['define_macros'] = [('HAVE_CBLAS', None)]
-        else:
-            info['language'] = 'f77'  # XXX: is it generally true?
+        info['language'] = 'f77'  # XXX: is it generally true?
         self.set_info(**info)
-
-    def has_cblas(self):
-        # primitive cblas check by looking for the header
-        res = False
-        c = distutils.ccompiler.new_compiler()
-        tmpdir = tempfile.mkdtemp()
-        s = """#include <cblas.h>"""
-        src = os.path.join(tmpdir, 'source.c')
-        try:
-            with open(src, 'wt') as f:
-                f.write(s)
-            try:
-                c.compile([src], output_dir=tmpdir,
-                          include_dirs=self.get_include_dirs())
-                res = True
-            except distutils.ccompiler.CompileError:
-                res = False
-        finally:
-            shutil.rmtree(tmpdir)
-        return res
 
 
 class openblas_info(blas_info):


### PR DESCRIPTION
The current check raises DistutilsPlatformError when mingw32 is used because the default
ccompiler is msvc. That is fixable, but does not seem worth the trouble
as looking for a cblas.h file for a last effort to detect cblas seems a
bit fragile in any case. I think it is better handled elsewhere on a
case by case basis in combination with site.cfg.
