### PR TITLE
Distutils shouldn't warn unless compiler_cxx is empty

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -385,7 +385,7 @@ def CCompiler_customize(self, dist, need_cxx=0):
                     a, b = 'cc', 'c++'
                 self.compiler_cxx = [self.compiler[0].replace(a, b)]\
                                     + self.compiler[1:]
-        else:
+        elif not self.compiler_cxx:
             if hasattr(self, 'compiler'):
                 log.warn("#### %s #######" % (self.compiler,))
             log.warn('Missing compiler_cxx fix for '+self.__class__.__name__)


### PR DESCRIPTION
Numpy distutils produces a misleading warning on OS X (currently 10.10.4, but this is an old issue) with MacPorts Python (currently 3.4.3, but I used to have this problem under 2.7.10) because it doesn't recognize clang.  A minimal example is

```
import numpy.distutils
numpy.distutils.unixccompiler.UnixCCompiler().customize(None, True)
```

On my machine, this produces the output

```
#### ['/usr/bin/clang', '-Wno-unused-result', '-fno-common', '-dynamic', '-DNDEBUG', '-g', '-fwrapv', '-O3', '-Wall', '-Wstrict-prototypes', '-pipe', '-Os'] #######
Missing compiler_cxx fix for UnixCCompiler
```

There isn't actually a problem, though, as distutils.sysconfig has done its job just fine.  Even though the warning shows arguments for a C compiler, the `UnixCCompiler.compiler_cxx` property is populated.  Proposed fix is to suppress the warning when the `compiler_cxx` property is nonempty.
