### PR TITLE
BUG: Fix a non-constant expression used as structure initializer.

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1809,7 +1809,11 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     &array_as_number,                           /* tp_as_number */
     &array_as_sequence,                         /* tp_as_sequence */
     &array_as_mapping,                          /* tp_as_mapping */
-    PyObject_HashNotImplemented,                /* tp_hash */
+    /*
+     * The tp_hash slot will be set PyObject_HashNotImplemented when the
+     * module is loaded.
+     */
+    (hashfunc)0,                                /* tp_hash */
     (ternaryfunc)0,                             /* tp_call */
     (reprfunc)array_str,                        /* tp_str */
     (getattrofunc)0,                            /* tp_getattro */
@@ -1820,7 +1824,7 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
      | Py_TPFLAGS_CHECKTYPES
      | Py_TPFLAGS_HAVE_NEWBUFFER
 #endif
-     | Py_TPFLAGS_BASETYPE),                  /* tp_flags */
+     | Py_TPFLAGS_BASETYPE),                    /* tp_flags */
     0,                                          /* tp_doc */
 
     (traverseproc)0,                            /* tp_traverse */

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4480,6 +4480,13 @@ PyMODINIT_FUNC initmultiarray(void) {
     if (!d) {
         goto err;
     }
+
+    /*
+     * Before calling PyType_Ready, initialize the tp_hash slot in
+     * PyArray_Type to work around mingw32 not being able initialize
+     * static structure slots with functions from the Python C_API.
+     */
+    PyArray_Type.tp_hash = PyObject_HashNotImplemented;
     if (PyType_Ready(&PyArray_Type) < 0) {
         return RETVAL;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5658,6 +5658,10 @@ class TestSizeOf(TestCase):
 
 class TestHashing(TestCase):
 
+    def test_arrays_not_hashable(self):
+        x = np.ones(3)
+        assert_raises(TypeError, hash, x)
+
     def test_collections_hashable(self):
         x = np.array([])
         self.assertFalse(isinstance(x, collections.Hashable))


### PR DESCRIPTION
PyObject_HashNotImplemented was being used to initialize the tp_hash
slot in the PyArray_Type structure. In mingw32 (gcc version 3.4) that
results in a compile error. The function initialization seems to work
for more recent compilers, as the determination of what is considered
'non-constant' is left to the vendor and has changed.
