### PR TITLE
BLD: Distutils doesn't warn unless compiler_cxx is empty

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -385,7 +385,7 @@ def CCompiler_customize(self, dist, need_cxx=0):
                     a, b = 'cc', 'c++'
                 self.compiler_cxx = [self.compiler[0].replace(a, b)]\
                                     + self.compiler[1:]
-        else:
+        elif not self.compiler_cxx:
             if hasattr(self, 'compiler'):
                 log.warn("#### %s #######" % (self.compiler,))
             log.warn('Missing compiler_cxx fix for '+self.__class__.__name__)


### PR DESCRIPTION
Backport #6185.
Warns on OS X with MacPorts Python because it doesn't recognize clang.
There isn't actually a problem, though, as distutils.sysconfig has done
its job just fine.  Proposed fix.
