### PR TITLE
MRG: fix multiarray tests

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4178,11 +4178,9 @@ class TestDot(TestCase):
         assert_raises(TypeError, c.dot, b)
 
     def test_accelerate_framework_sgemv_fix(self):
-        if sys.platform != 'darwin':
-            return
 
         def aligned_array(shape, align, dtype, order='C'):
-            d = np.dtype()
+            d = dtype(0)
             N = np.prod(shape)
             tmp = np.zeros(N * d.nbytes + align, dtype=np.uint8)
             address = tmp.__array_interface__["data"][0]

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1016,7 +1016,7 @@ class TestMethods(TestCase):
         # test sorting of complex arrays requiring byte-swapping, gh-5441
         for endianess in '<>':
             for dt in np.typecodes['Complex']:
-                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=dt)
+                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianess + dt)
                 c = arr.copy()
                 c.sort()
                 msg = 'byte-swapped complex sort, dtype={0}'.format(dt)
@@ -1212,7 +1212,7 @@ class TestMethods(TestCase):
         # test argsort of complex arrays requiring byte-swapping, gh-5441
         for endianess in '<>':
             for dt in np.typecodes['Complex']:
-                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=dt)
+                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianess + dt)
                 msg = 'byte-swapped complex argsort, dtype={0}'.format(dt)
                 assert_equal(arr.argsort(),
                              np.arange(len(arr), dtype=np.intp), msg)


### PR DESCRIPTION
We were getting an error in the Accelerate aligned array tests because of an
edit to the test function.  Travis missed it because the tests were only being
run on OSX.  Fix and run tests on all platforms.

The endianness checks for complex arrays somehow stopped being endian - fix.
