### PR TITLE
MAINT: Speedup field access by removing unneeded safety checks

### DIFF
--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -47,3 +47,26 @@ class IndexingSeparate(Benchmark):
     def time_mmap_fancy_indexing(self):
         for i in range(1000):
             self.fp[self.indexes]
+
+
+class IndexingStructured0D(Benchmark):
+    def setup(self):
+        self.dt = np.dtype([('a', 'f4', 256)])
+
+        self.A = np.zeros((), self.dt)
+        self.B = self.A.copy()
+
+        self.a = np.zeros(1, self.dt)[0]
+        self.b = self.a.copy()
+
+    def time_array_slice(self):
+        self.B['a'][:] = self.A['a']
+
+    def time_array_all(self):
+        self.B['a'] = self.A['a']
+
+    def time_scalar_slice(self):
+        self.b['a'][:] = self.a['a']
+
+    def time_scalar_all(self):
+        self.b['a'] = self.a['a']

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -621,31 +621,6 @@ OBJECT_setitem(PyObject *op, void *ov, void *NPY_UNUSED(ap))
 
 /* VOID */
 
-/* unpack tuple of dtype->fields (descr, offset, title[not-needed]) */
-static int
-unpack_field(PyObject * value, PyArray_Descr ** descr, npy_intp * offset)
-{
-    PyObject * off;
-    if (PyTuple_GET_SIZE(value) < 2) {
-        return -1;
-    }
-    *descr = (PyArray_Descr *)PyTuple_GET_ITEM(value, 0);
-    off  = PyTuple_GET_ITEM(value, 1);
-
-    if (PyInt_Check(off)) {
-        *offset = PyInt_AsSsize_t(off);
-    }
-    else if (PyLong_Check(off)) {
-        *offset = PyLong_AsSsize_t(off);
-    }
-    else {
-        return -1;
-    }
-
-    return 0;
-}
-
-
 static PyObject *
 VOID_getitem(void *input, void *vap)
 {
@@ -674,7 +649,7 @@ VOID_getitem(void *input, void *vap)
             PyArray_Descr *new;
             key = PyTuple_GET_ITEM(names, i);
             tup = PyDict_GetItem(descr->fields, key);
-            if (unpack_field(tup, &new, &offset) < 0) {
+            if (_unpack_field(tup, &new, &offset) < 0) {
                 Py_DECREF(ret);
                 ((PyArrayObject_fields *)ap)->descr = descr;
                 return NULL;
@@ -811,7 +786,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
             npy_intp offset;
             key = PyTuple_GET_ITEM(names, i);
             tup = PyDict_GetItem(descr->fields, key);
-            if (unpack_field(tup, &new, &offset) < 0) {
+            if (_unpack_field(tup, &new, &offset) < 0) {
                 ((PyArrayObject_fields *)ap)->descr = descr;
                 return -1;
             }
@@ -2178,7 +2153,7 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (unpack_field(value, &new, &offset) < 0) {
+            if (_unpack_field(value, &new, &offset) < 0) {
                 ((PyArrayObject_fields *)arr)->descr = descr;
                 return;
             }
@@ -2247,7 +2222,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (unpack_field(value, &new, &offset) < 0) {
+            if (_unpack_field(value, &new, &offset) < 0) {
                 ((PyArrayObject_fields *)arr)->descr = descr;
                 return;
             }
@@ -2560,7 +2535,7 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (unpack_field(value, &new, &offset) < 0) {
+            if (_unpack_field(value, &new, &offset) < 0) {
                 PyErr_Clear();
                 continue;
             }
@@ -2876,7 +2851,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         npy_intp offset;
         key = PyTuple_GET_ITEM(names, i);
         tup = PyDict_GetItem(descr->fields, key);
-        if (unpack_field(tup, &new, &offset) < 0) {
+        if (_unpack_field(tup, &new, &offset) < 0) {
             goto finish;
         }
         /* descr is the only field checked by compare or copyswap */

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -909,3 +909,21 @@ _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset)
 
     return 0;
 }
+
+/*
+ * check whether arrays with datatype dtype might have object fields. This will
+ * only happen for structured dtypes (which may have hidden objects even if the
+ * HASOBJECT flag is false), object dtypes, or subarray dtypes whose base type
+ * is either of these.
+ */
+NPY_NO_EXPORT int
+_may_have_objects(PyArray_Descr *dtype)
+{
+    PyArray_Descr *base = dtype;
+    if (PyDataType_HASSUBARRAY(dtype)) {
+        base = dtype->subarray->base;
+    }
+
+    return (PyDataType_HASFIELDS(base) ||
+            PyDataType_FLAGCHK(base, NPY_ITEM_HASOBJECT) );
+}

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -876,3 +876,36 @@ end:
     Py_XDECREF(shape1_i);
     Py_XDECREF(shape2_j);
 }
+
+/**
+ * unpack tuple of dtype->fields (descr, offset, title[not-needed])
+ *
+ * @param "value" should be the tuple.
+ *
+ * @return "descr" will be set to the field's dtype
+ * @return "offset" will be set to the field's offset
+ *
+ * returns -1 on failure, 0 on success.
+ */
+NPY_NO_EXPORT int
+_unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset)
+{
+    PyObject * off;
+    if (PyTuple_GET_SIZE(value) < 2) {
+        return -1;
+    }
+    *descr = (PyArray_Descr *)PyTuple_GET_ITEM(value, 0);
+    off  = PyTuple_GET_ITEM(value, 1);
+
+    if (PyInt_Check(off)) {
+        *offset = PyInt_AsSsize_t(off);
+    }
+    else if (PyLong_Check(off)) {
+        *offset = PyLong_AsSsize_t(off);
+    }
+    else {
+        return -1;
+    }
+
+    return 0;
+}

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -89,6 +89,15 @@ NPY_NO_EXPORT int
 _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset);
 
 /*
+ * check whether arrays with datatype dtype might have object fields. This will
+ * only happen for structured dtypes (which may have hidden objects even if the
+ * HASOBJECT flag is false), object dtypes, or subarray dtypes whose base type
+ * is either of these.
+ */
+NPY_NO_EXPORT int
+_may_have_objects(PyArray_Descr *dtype);
+
+/*
  * Returns -1 and sets an exception if *index is an invalid index for
  * an array of size max_item, otherwise adjusts it in place to be
  * 0 <= *index < max_item, and returns 0.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -75,6 +75,18 @@ convert_shape_to_string(npy_intp n, npy_intp *vals, char *ending);
 NPY_NO_EXPORT void
 dot_alignment_error(PyArrayObject *a, int i, PyArrayObject *b, int j);
 
+/**
+ * unpack tuple of dtype->fields (descr, offset, title[not-needed])
+ *
+ * @param "value" should be the tuple.
+ *
+ * @return "descr" will be set to the field's dtype
+ * @return "offset" will be set to the field's offset
+ *
+ * returns -1 on failure, 0 on success.
+ */
+NPY_NO_EXPORT int
+_unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset);
 
 /*
  * Returns -1 and sets an exception if *index is an invalid index for

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1250,51 +1250,190 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
     return PyArray_EnsureAnyArray(array_subscript(self, op));
 }
 
+/*
+ * Attempts to subscript an array using a field name or list of field names.
+ *
+ * If an error occurred, return 0 and set view to NULL. If the subscript is not
+ * a string or list of strings, return -1 and set view to NULL. Otherwise
+ * return 0 and set view to point to a new view into arr for the given fields.
+ */
 NPY_NO_EXPORT int
-obj_is_string_or_stringlist(PyObject *op)
+_get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
 {
-#if defined(NPY_PY3K)
-    if (PyUnicode_Check(op)) {
-#else
-    if (PyString_Check(op) || PyUnicode_Check(op)) {
-#endif
-        return 1;
-    }
-    else if (PySequence_Check(op) && !PyTuple_Check(op)) {
-        int seqlen, i;
-        PyObject *obj = NULL;
-        seqlen = PySequence_Size(op);
+    *view = NULL;
 
-        /* quit if we come across a 0-d array (seqlen==-1) or a 0-len array */
-        if (seqlen == -1) {
-            PyErr_Clear();
+    /* first check for a single field name */
+#if defined(NPY_PY3K)
+    if (PyUnicode_Check(ind)) {
+#else
+    if (PyString_Check(ind) || PyUnicode_Check(ind)) {
+#endif
+        PyObject *tup;
+        PyArray_Descr *fieldtype;
+        npy_intp offset;
+
+        /* get the field offset and dtype */
+        tup = PyDict_GetItem(PyArray_DESCR(arr)->fields, ind);
+        if (tup == NULL){
+            PyObject *errmsg = PyUString_FromString("no field of name ");
+            PyUString_Concat(&errmsg, ind);
+            PyErr_SetObject(PyExc_ValueError, errmsg);
+            Py_DECREF(errmsg);
             return 0;
         }
+        if (_unpack_field(tup, &fieldtype, &offset) < 0) {
+            return 0;
+        }
+
+        /* view the array at the new offset+dtype */
+        Py_INCREF(fieldtype);
+        *view = (PyArrayObject*)PyArray_NewFromDescr(
+                                    Py_TYPE(arr),
+                                    fieldtype,
+                                    PyArray_NDIM(arr),
+                                    PyArray_SHAPE(arr),
+                                    PyArray_STRIDES(arr),
+                                    PyArray_DATA(arr) + offset,
+                                    PyArray_FLAGS(arr),
+                                    (PyObject *)arr);
+        if (*view == NULL) {
+            return 0;
+        }
+        Py_INCREF(arr);
+        if (PyArray_SetBaseObject(*view, (PyObject *)arr) < 0) {
+            Py_DECREF(*view);
+            *view = NULL;
+        }
+        return 0;
+    }
+    /* next check for a list of field names */
+    else if (PySequence_Check(ind) && !PyTuple_Check(ind)) {
+        int seqlen, i;
+        PyObject *name = NULL, *tup;
+        PyObject *fields, *names;
+        PyArray_Descr *view_dtype;
+
+        /* variables needed to make a copy, to remove in the future */
+        static PyObject *copyfunc = NULL;
+        PyObject *viewcopy;
+
+        seqlen = PySequence_Size(ind);
+
+        /* quit if have a 0-d array (seqlen==-1) or a 0-len array */
+        if (seqlen == -1) {
+            PyErr_Clear();
+            return -1;
+        }
         if (seqlen == 0) {
+            return -1;
+        }
+
+        fields = PyDict_New();
+        if (fields == NULL) {
+            return 0;
+        }
+        names = PyTuple_New(seqlen);
+        if (names == NULL) {
+            Py_DECREF(fields);
             return 0;
         }
 
         for (i = 0; i < seqlen; i++) {
-            obj = PySequence_GetItem(op, i);
-            if (obj == NULL) {
-                /* only happens for strange sequence objects. Silently fail */
+            name = PySequence_GetItem(ind, i);
+            if (name == NULL) {
+                /* only happens for strange sequence objects */
                 PyErr_Clear();
-                return 0;
+                Py_DECREF(fields);
+                Py_DECREF(names);
+                return -1;
             }
 
 #if defined(NPY_PY3K)
-            if (!PyUnicode_Check(obj)) {
+            if (!PyUnicode_Check(name)) {
 #else
-            if (!PyString_Check(obj) && !PyUnicode_Check(obj)) {
+            if (!PyString_Check(name) && !PyUnicode_Check(name)) {
 #endif
-                Py_DECREF(obj);
+                Py_DECREF(name);
+                Py_DECREF(fields);
+                Py_DECREF(names);
+                return -1;
+            }
+
+            tup = PyDict_GetItem(PyArray_DESCR(arr)->fields, name);
+            if (tup == NULL){
+                PyObject *errmsg = PyUString_FromString("no field of name ");
+                PyUString_ConcatAndDel(&errmsg, name);
+                PyErr_SetObject(PyExc_ValueError, errmsg);
+                Py_DECREF(errmsg);
+                Py_DECREF(fields);
+                Py_DECREF(names);
                 return 0;
             }
-            Py_DECREF(obj);
+            if (PyDict_SetItem(fields, name, tup) < 0) {
+                Py_DECREF(name);
+                Py_DECREF(fields);
+                Py_DECREF(names);
+                return 0;
+            }
+            if (PyTuple_SetItem(names, i, name) < 0) {
+                Py_DECREF(fields);
+                Py_DECREF(names);
+                return 0;
+            }
         }
-        return 1;
+
+        view_dtype = PyArray_DescrNewFromType(NPY_VOID);
+        if (view_dtype == NULL) {
+            Py_DECREF(fields);
+            Py_DECREF(names);
+            return 0;
+        }
+        view_dtype->elsize = PyArray_DESCR(arr)->elsize;
+        view_dtype->names = names;
+        view_dtype->fields = fields;
+        view_dtype->flags = PyArray_DESCR(arr)->flags;
+
+        *view = (PyArrayObject*)PyArray_NewFromDescr(
+                                    Py_TYPE(arr),
+                                    view_dtype,
+                                    PyArray_NDIM(arr),
+                                    PyArray_SHAPE(arr),
+                                    PyArray_STRIDES(arr),
+                                    PyArray_DATA(arr),
+                                    PyArray_FLAGS(arr),
+                                    (PyObject *)arr);
+        if (*view == NULL) {
+            return 0;
+        }
+        Py_INCREF(arr);
+        if (PyArray_SetBaseObject(*view, (PyObject *)arr) < 0) {
+            Py_DECREF(*view);
+            *view = NULL;
+            return 0;
+        }
+
+        /*
+         * Return copy for now (future plan to return the view above). All the
+         * following code in this block can then be replaced by "return 0;"
+         */
+        npy_cache_import("numpy.core._internal", "_copy_fields", &copyfunc);
+        if (copyfunc == NULL) {
+            Py_DECREF(*view);
+            *view = NULL;
+            return 0;
+        }
+
+        viewcopy = PyObject_CallFunction(copyfunc, "O", *view);
+        if (viewcopy == NULL) {
+            Py_DECREF(*view);
+            *view = NULL;
+            return 0;
+        }
+        Py_DECREF(*view);
+        *view = (PyArrayObject*)viewcopy;
+        return 0;
     }
-    return 0;
+    return -1;
 }
 
 /*
@@ -1318,25 +1457,20 @@ array_subscript(PyArrayObject *self, PyObject *op)
     PyArrayMapIterObject * mit = NULL;
 
     /* return fields if op is a string index */
-    if (PyDataType_HASFIELDS(PyArray_DESCR(self)) &&
-            obj_is_string_or_stringlist(op)) {
-        PyObject *obj;
-        static PyObject *indexfunc = NULL;
-        npy_cache_import("numpy.core._internal", "_index_fields", &indexfunc);
-        if (indexfunc == NULL) {
-            return NULL;
-        }
+    if (PyDataType_HASFIELDS(PyArray_DESCR(self))) {
+        PyArrayObject *view;
+        int ret = _get_field_view(self, op, &view);
+        if (ret == 0){
+            if (view == NULL) {
+                return NULL;
+            }
 
-        obj = PyObject_CallFunction(indexfunc, "OO", self, op);
-        if (obj == NULL) {
-            return NULL;
+            /* warn if writing to a copy. copies will have no base */
+            if (PyArray_BASE(view) == NULL) {
+                PyArray_ENABLEFLAGS(view, NPY_ARRAY_WARN_ON_WRITE);
+            }
+            return (PyObject*)view;
         }
-
-        /* warn if writing to a copy. copies will have no base */
-        if (PyArray_BASE((PyArrayObject*)obj) == NULL) {
-            PyArray_ENABLEFLAGS((PyArrayObject*)obj, NPY_ARRAY_WARN_ON_WRITE);
-        }
-        return obj;
     }
 
     /* Prepare the indices */
@@ -1671,37 +1805,31 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
     }
 
     /* field access */
-    if (PyDataType_HASFIELDS(PyArray_DESCR(self)) &&
-            obj_is_string_or_stringlist(ind)) {
-        PyObject *obj;
-        static PyObject *indexfunc = NULL;
+    if (PyDataType_HASFIELDS(PyArray_DESCR(self))){
+        PyArrayObject *view;
+        int ret = _get_field_view(self, ind, &view);
+        if (ret == 0){
 
 #if defined(NPY_PY3K)
-        if (!PyUnicode_Check(ind)) {
+            if (!PyUnicode_Check(ind)) {
 #else
-        if (!PyString_Check(ind) && !PyUnicode_Check(ind)) {
+            if (!PyString_Check(ind) && !PyUnicode_Check(ind)) {
 #endif
-            PyErr_SetString(PyExc_ValueError,
-                            "multi-field assignment is not supported");
-        }
+                PyErr_SetString(PyExc_ValueError,
+                                "multi-field assignment is not supported");
+                return -1;
+            }
 
-        npy_cache_import("numpy.core._internal", "_index_fields", &indexfunc);
-        if (indexfunc == NULL) {
-            return -1;
+            if (view == NULL) {
+                return -1;
+            }
+            if (PyArray_CopyObject(view, op) < 0) {
+                Py_DECREF(view);
+                return -1;
+            }
+            Py_DECREF(view);
+            return 0;
         }
-
-        obj = PyObject_CallFunction(indexfunc, "OO", self, ind);
-        if (obj == NULL) {
-            return -1;
-        }
-
-        if (PyArray_CopyObject((PyArrayObject*)obj, op) < 0) {
-            Py_DECREF(obj);
-            return -1;
-        }
-        Py_DECREF(obj);
-
-        return 0;
     }
 
     /* Prepare the indices */

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1681,13 +1681,15 @@ voidtype_setfield(PyVoidScalarObject *self, PyObject *args, PyObject *kwds)
      *     b['x'][0] = arange(3)  # uses ndarray setitem
      *
      * Ndarray's setfield would try to broadcast the lhs. Instead we use
-     * ndarray getfield to get the field safely, then setitem to set the value
-     * without broadcast. Note we also want subarrays to be set properly, ie
+     * ndarray getfield to get the field safely, then setitem with an empty
+     * tuple to set the value without broadcast. Note we also want subarrays to
+     * be set properly, ie
      *
      *     a = np.zeros(1, dtype=[('x', 'i', 5)])
      *     a[0]['x'] = 1
      *
-     * sets all values to 1. Setitem does this.
+     * sets all values to 1. "getfield + setitem with empty tuple" takes
+     * care of both object arrays and subarrays.
      */
     PyObject *getfield_args, *value, *arr, *meth, *arr_field, *emptytuple;
 
@@ -1726,15 +1728,15 @@ voidtype_setfield(PyVoidScalarObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    /* 2. Fill the resulting array using setitem */
+    /* 2. Assign the value using setitem with empty tuple. */
     emptytuple = PyTuple_New(0);
     if (PyObject_SetItem(arr_field, emptytuple, value) < 0) {
         Py_DECREF(arr_field);
         Py_DECREF(emptytuple);
         return NULL;
     }
-    Py_DECREF(arr_field);
     Py_DECREF(emptytuple);
+    Py_DECREF(arr_field);
 
     Py_RETURN_NONE;
 }
@@ -2158,10 +2160,13 @@ voidtype_length(PyVoidScalarObject *self)
 }
 
 static PyObject *
+voidtype_subscript(PyVoidScalarObject *self, PyObject *ind);
+
+static PyObject *
 voidtype_item(PyVoidScalarObject *self, Py_ssize_t n)
 {
     npy_intp m;
-    PyObject *flist=NULL, *fieldind, *fieldparam, *fieldinfo, *ret;
+    PyObject *flist=NULL;
 
     if (!(PyDataType_HASFIELDS(self->descr))) {
         PyErr_SetString(PyExc_IndexError,
@@ -2177,22 +2182,16 @@ voidtype_item(PyVoidScalarObject *self, Py_ssize_t n)
         PyErr_Format(PyExc_IndexError, "invalid index (%d)", (int) n);
         return NULL;
     }
-    /* no error checking needed: descr->names is well structured */
-    fieldind = PyTuple_GET_ITEM(flist, n);
-    fieldparam = PyDict_GetItem(self->descr->fields, fieldind);
-    fieldinfo = PyTuple_GetSlice(fieldparam, 0, 2);
-    ret = voidtype_getfield(self, fieldinfo, NULL);
-    Py_DECREF(fieldinfo);
-    return ret;
-}
 
+    return voidtype_subscript(self, PyTuple_GetItem(flist, n));
+}
 
 /* get field by name or number */
 static PyObject *
 voidtype_subscript(PyVoidScalarObject *self, PyObject *ind)
 {
     npy_intp n;
-    PyObject *ret, *fieldinfo, *fieldparam;
+    PyObject *ret, *args;
 
     if (!(PyDataType_HASFIELDS(self->descr))) {
         PyErr_SetString(PyExc_IndexError,
@@ -2205,14 +2204,9 @@ voidtype_subscript(PyVoidScalarObject *self, PyObject *ind)
 #else
     if (PyBytes_Check(ind) || PyUnicode_Check(ind)) {
 #endif
-        /* look up in fields */
-        fieldparam = PyDict_GetItem(self->descr->fields, ind);
-        if (!fieldparam) {
-            goto fail;
-        }
-        fieldinfo = PyTuple_GetSlice(fieldparam, 0, 2);
-        ret = voidtype_getfield(self, fieldinfo, NULL);
-        Py_DECREF(fieldinfo);
+        args = Py_BuildValue("(O)", ind);
+        ret = gentype_generic_method((PyObject *)self, args, NULL, "__getitem__");
+        Py_DECREF(args);
         return ret;
     }
 
@@ -2229,11 +2223,13 @@ fail:
 }
 
 static int
+voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val);
+
+static int
 voidtype_ass_item(PyVoidScalarObject *self, Py_ssize_t n, PyObject *val)
 {
     npy_intp m;
-    PyObject *flist=NULL, *fieldinfo, *newtup;
-    PyObject *res;
+    PyObject *flist=NULL;
 
     if (!(PyDataType_HASFIELDS(self->descr))) {
         PyErr_SetString(PyExc_IndexError,
@@ -2247,24 +2243,11 @@ voidtype_ass_item(PyVoidScalarObject *self, Py_ssize_t n, PyObject *val)
         n += m;
     }
     if (n < 0 || n >= m) {
-        goto fail;
-    }
-    fieldinfo = PyDict_GetItem(self->descr->fields,
-            PyTuple_GET_ITEM(flist, n));
-    newtup = Py_BuildValue("(OOO)", val,
-            PyTuple_GET_ITEM(fieldinfo, 0),
-            PyTuple_GET_ITEM(fieldinfo, 1));
-    res = voidtype_setfield(self, newtup, NULL);
-    Py_DECREF(newtup);
-    if (!res) {
+        PyErr_Format(PyExc_IndexError, "invalid index (%d)", (int) n);
         return -1;
     }
-    Py_DECREF(res);
-    return 0;
 
-fail:
-    PyErr_Format(PyExc_IndexError, "invalid index (%d)", (int) n);
-    return -1;
+    return voidtype_ass_subscript(self, PyTuple_GetItem(flist, n), val);
 }
 
 static int
@@ -2272,8 +2255,7 @@ voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val)
 {
     npy_intp n;
     char *msg = "invalid index";
-    PyObject *fieldinfo, *newtup;
-    PyObject *res;
+    PyObject *args;
 
     if (!PyDataType_HASFIELDS(self->descr)) {
         PyErr_SetString(PyExc_IndexError,
@@ -2292,20 +2274,49 @@ voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val)
 #else
     if (PyBytes_Check(ind) || PyUnicode_Check(ind)) {
 #endif
-        /* look up in fields */
-        fieldinfo = PyDict_GetItem(self->descr->fields, ind);
-        if (!fieldinfo) {
-            goto fail;
-        }
-        newtup = Py_BuildValue("(OOO)", val,
-                PyTuple_GET_ITEM(fieldinfo, 0),
-                PyTuple_GET_ITEM(fieldinfo, 1));
-        res = voidtype_setfield(self, newtup, NULL);
-        Py_DECREF(newtup);
-        if (!res) {
+        /*
+         * Much like in voidtype_setfield, we cannot simply use ndarray's
+         * __setitem__ since assignment to void scalars should not broadcast
+         * the lhs. Instead we get a view through __getitem__ and then assign
+         * the value using setitem with an empty tuple (which treats both
+         * object arrays and subarrays properly).
+         *
+         * Also we do not want to use voidtype_setfield here, since we do
+         * not need to do the (slow) view safety checks, since we already
+         * know the dtype/offset are safe.
+         */
+
+        PyObject *arr, *arr_field, *meth, *emptytuple;
+
+        /* 1. Convert to 0-d array and use getitem */
+        arr = PyArray_FromScalar((PyObject*)self, NULL);
+        if (arr == NULL) {
             return -1;
         }
-        Py_DECREF(res);
+        meth = PyObject_GetAttrString(arr, "__getitem__");
+        if (meth == NULL) {
+            Py_DECREF(arr);
+            return -1;
+        }
+        args = Py_BuildValue("(O)", ind);
+        arr_field = PyObject_CallObject(meth, args);
+        Py_DECREF(meth);
+        Py_DECREF(arr);
+        Py_DECREF(args);
+
+        if(arr_field == NULL){
+            return -1;
+        }
+
+        /* 2. Assign the value using setitem with empty tuple. */
+        emptytuple = PyTuple_New(0);
+        if (PyObject_SetItem(arr_field, emptytuple, val) < 0) {
+            Py_DECREF(arr_field);
+            Py_DECREF(emptytuple);
+            return -1;
+        }
+        Py_DECREF(emptytuple);
+        Py_DECREF(arr_field);
         return 0;
     }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3754,8 +3754,8 @@ class TestRecord(TestCase):
             b[0][fn1] = 2
             assert_equal(b[fn1], 2)
             # Subfield
-            assert_raises(IndexError, b[0].__setitem__, fnn, 1)
-            assert_raises(IndexError, b[0].__getitem__, fnn)
+            assert_raises(ValueError, b[0].__setitem__, fnn, 1)
+            assert_raises(ValueError, b[0].__getitem__, fnn)
             # Subfield
             fn3 = func('f3')
             sfn1 = func('sf1')


### PR DESCRIPTION
#5548 causes a big slowdown in the specific case of accessing/assigning fields of structured arrays with large (eg 1kb) dtypes. Oops! I noticed this while investigating #1984. The problem is #5548 implemented an algorithm which checks view safety byte-by-byte (slow) under the assumption that most dtypes are only a small number of bytes. That's bad if the dtype is very large, as in the test script of #1984.

One fix is to speed the safety-check algorithm up, but it also turns out that the checks aren't needed in many cases. For example, during field indexing they aren't needed because we're merely viewing fields that already exist, which is therefore safe. So I've bypassed the safety checks by rewriting that indexing code (in C) so it avoids using `PyArray_View`. 

I also made corresponding voidtype methods call the ndarray methods to get the same benefits. Incidentally this also enables some functionality that was missing from voidtype relative to ndarray. Eg, you can now do `arr[0][['a', 'b']]` and it will give you a more correct error message. 

Safety checks are still important for get/setfield and for views. But even there we can skip the checks early if we know that the datatypes aren't structured or aren't of object type. 

Timing info for the test script in #1984, run as `./test.py 10000`

Numpy 1.9.2:

```
array,  B['a'][:] = A['a']      0.00852 seconds
array,  B['a']    = A['a']      0.00648 seconds
scalar, B['a'][:] = A['a']      0.016 seconds
scalar, B['a']    = A['a']      0.132 seconds
```

Master:

```
array,  B['a'][:] = A['a']      16.4 seconds
array,  B['a']    = A['a']      16.3 seconds
scalar, B['a'][:] = A['a']      16.1 seconds
scalar, B['a']    = A['a']      16.6 seconds
```

This PR:

```
array,  B['a'][:] = A['a']      0.00733 seconds
array,  B['a']    = A['a']      0.00673 seconds
scalar, B['a'][:] = A['a']      0.0171 seconds
scalar, B['a']    = A['a']      0.0151 seconds
```

Later I'll look into a faster algorithm for the structured safety checks.

I think this PR also fixes #1984, if 0.0151s is fast enough! 

By the way, I think get/setfield are no longer used anywhere internally in numpy.
