### PR TITLE
BLD: fix for INTEL compiler build failure on linux when import msvc

### DIFF
--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -4,8 +4,6 @@ import sys
 
 from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.exec_command import find_executable
-if sys.platform == 'win32':
-    from distutils.msvc9compiler import MSVCCompiler
 from numpy.distutils.ccompiler import simple_version_match
 
 
@@ -58,6 +56,7 @@ class IntelEM64TCCompiler(UnixCCompiler):
 
 
 if sys.platform == 'win32':
+    from distutils.msvc9compiler import MSVCCompiler
     class IntelCCompilerW(MSVCCompiler):
         """
         A modified Intel compiler on Windows compatible with an MSVC-built Python.

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -1,8 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
+import sys
+
 from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.exec_command import find_executable
-from distutils.msvc9compiler import MSVCCompiler
+if sys.platform == 'win32':
+    from distutils.msvc9compiler import MSVCCompiler
 from numpy.distutils.ccompiler import simple_version_match
 
 
@@ -54,34 +57,37 @@ class IntelEM64TCCompiler(UnixCCompiler):
                              linker_so=compiler + ' -shared')
 
 
-class IntelCCompilerW(MSVCCompiler):
-    """
-    A modified Intel compiler on Windows compatible with an MSVC-built Python.
-    """
-    compiler_type = 'intelw'
+if sys.platform == 'win32':
+    class IntelCCompilerW(MSVCCompiler):
+        """
+        A modified Intel compiler on Windows compatible with an MSVC-built Python.
+        """
+        compiler_type = 'intelw'
 
-    def __init__(self, verbose=0, dry_run=0, force=0):
-        MSVCCompiler.__init__(self, verbose, dry_run, force)
-        version_match = simple_version_match(start='Intel\(R\).*?32,')
-        self.__version = version_match
+        def __init__(self, verbose=0, dry_run=0, force=0):
+            MSVCCompiler.__init__(self, verbose, dry_run, force)
+            version_match = simple_version_match(start='Intel\(R\).*?32,')
+            self.__version = version_match
 
-    def initialize(self, plat_name=None):
-        MSVCCompiler.initialize(self, plat_name)
-        self.cc = self.find_exe("icl.exe")
-        self.lib = self.find_exe("xilib")
-        self.linker = self.find_exe("xilink")
-        self.compile_options = ['/nologo', '/O3', '/MD', '/W3', '/Qstd=c99']
-        self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
+        def initialize(self, plat_name=None):
+            MSVCCompiler.initialize(self, plat_name)
+            self.cc = self.find_exe("icl.exe")
+            self.lib = self.find_exe("xilib")
+            self.linker = self.find_exe("xilink")
+            self.compile_options = ['/nologo', '/O3', '/MD', '/W3', '/Qstd=c99']
+            self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
                                       '/Qstd=c99', '/Z7', '/D_DEBUG']
 
 
-class IntelEM64TCCompilerW(IntelCCompilerW):
-    """
-    A modified Intel x86_64 compiler compatible with a 64bit MSVC-built Python.
-    """
-    compiler_type = 'intelemw'
+    class IntelEM64TCCompilerW(IntelCCompilerW):
+        """
+        A modified Intel x86_64 compiler compatible with a 64bit MSVC-built Python.
+        """
+        compiler_type = 'intelemw'
 
-    def __init__(self, verbose=0, dry_run=0, force=0):
-        MSVCCompiler.__init__(self, verbose, dry_run, force)
-        version_match = simple_version_match(start='Intel\(R\).*?64,')
-        self.__version = version_match
+        def __init__(self, verbose=0, dry_run=0, force=0):
+            MSVCCompiler.__init__(self, verbose, dry_run, force)
+            version_match = simple_version_match(start='Intel\(R\).*?64,')
+            self.__version = version_match
+
+

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -57,9 +57,10 @@ class IntelEM64TCCompiler(UnixCCompiler):
 
 if sys.platform == 'win32':
     from distutils.msvc9compiler import MSVCCompiler
+
     class IntelCCompilerW(MSVCCompiler):
         """
-        A modified Intel compiler on Windows compatible with an MSVC-built Python.
+        A modified Intel compiler compatible with an MSVC-built Python.
         """
         compiler_type = 'intelw'
 
@@ -73,14 +74,15 @@ if sys.platform == 'win32':
             self.cc = self.find_exe("icl.exe")
             self.lib = self.find_exe("xilib")
             self.linker = self.find_exe("xilink")
-            self.compile_options = ['/nologo', '/O3', '/MD', '/W3', '/Qstd=c99']
+            self.compile_options = ['/nologo', '/O3', '/MD', '/W3',
+                                    '/Qstd=c99']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
-                                      '/Qstd=c99', '/Z7', '/D_DEBUG']
-
+                                          '/Qstd=c99', '/Z7', '/D_DEBUG']
 
     class IntelEM64TCCompilerW(IntelCCompilerW):
         """
-        A modified Intel x86_64 compiler compatible with a 64bit MSVC-built Python.
+        A modified Intel x86_64 compiler compatible with
+        a 64bit MSVC-built Python.
         """
         compiler_type = 'intelemw'
 
@@ -88,5 +90,4 @@ if sys.platform == 'win32':
             MSVCCompiler.__init__(self, verbose, dry_run, force)
             version_match = simple_version_match(start='Intel\(R\).*?64,')
             self.__version = version_match
-
 


### PR DESCRIPTION
Intel compiler build on Linux fails due to MSVC related changes in master and 1.10.x:

NameError: name 'MSVCCompiler' is not defined

Try checking system platform before including MSVC related code for Windows. 
