### PR TITLE
BLD: fix compiler_cxx check failure

### DIFF
--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -63,6 +63,7 @@ if sys.platform == 'win32':
         A modified Intel compiler compatible with an MSVC-built Python.
         """
         compiler_type = 'intelw'
+        compiler_cxx = 'icl'
 
         def __init__(self, verbose=0, dry_run=0, force=0):
             MSVCCompiler.__init__(self, verbose, dry_run, force)


### PR DESCRIPTION
A recent change in ccompiler.py caused Scipy build failure with Intel C++ Compiler on Windows:

  File "C:*\Python-3.4.2\lib\site-packages\numpy\distutils\ccompiler.py", line 388, in CCompiler_customize
    elif not self.compiler_cxx:
AttributeError: 'IntelEM64TCCompilerW' object has no attribute 'compiler_cxx'

The fix is simple. Need to merge the fix to 1.10.x branch as well.
