### PR TITLE
Fix two undefined variable errors in numpy.ma that caused two different bugs

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -32,7 +32,7 @@ import numpy.core.numerictypes as ntypes
 from numpy import ndarray, amax, amin, iscomplexobj, bool_, _NoValue
 from numpy import array as narray
 from numpy.lib.function_base import angle
-from numpy.compat import getargspec, formatargspec, long, basestring
+from numpy.compat import getargspec, formatargspec, long, basestring, unicode, bytes, sixu
 from numpy import expand_dims as n_expand_dims
 
 if sys.version_info[0] >= 3:
@@ -143,10 +143,10 @@ default_filler = {'b': True,
                   'f': 1.e20,
                   'i': 999999,
                   'O': '?',
-                  'S': 'N/A',
+                  'S': b'N/A',
                   'u': 999999,
                   'V': '???',
-                  'U': 'N/A'
+                  'U': sixu('N/A')
                   }
 
 # Add datetime64 and timedelta64 types
@@ -217,7 +217,7 @@ def default_fill_value(obj):
         defval = default_filler['f']
     elif isinstance(obj, int) or isinstance(obj, long):
         defval = default_filler['i']
-    elif isinstance(obj, str):
+    elif isinstance(obj, bytes):
         defval = default_filler['S']
     elif isinstance(obj, unicode):
         defval = default_filler['U']

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3128,6 +3128,15 @@ class TestMaskedArrayMathMethods(TestCase):
         mXX.dot(mYY, r1)
         assert_almost_equal(r, r1)
 
+    def test_dot_shape_mismatch(self):
+        # regression test
+        x = masked_array([[1,2],[3,4]], mask=[[0,1],[0,0]])
+        y = masked_array([[1,2],[3,4]], mask=[[0,1],[0,0]])
+        z = masked_array([[0,1],[3,3]])
+        x.dot(y, out=z)
+        assert_almost_equal(z.filled(0), [[1, 0], [15, 16]])
+        assert_almost_equal(z.mask, [[0, 1], [0, 0]])
+
     def test_varstd(self):
         # Tests var & std on MaskedArrays.
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1460,7 +1460,7 @@ class TestFillingValues(TestCase):
         fval = _check_fill_value(0, "|S3")
         assert_equal(fval, asbytes("0"))
         fval = _check_fill_value(None, "|S3")
-        assert_equal(fval, default_fill_value("|S3"))
+        assert_equal(fval, default_fill_value(b"camelot!"))
         self.assertRaises(TypeError, _check_fill_value, 1e+20, int)
         self.assertRaises(TypeError, _check_fill_value, 'stuff', int)
 
@@ -4105,5 +4105,10 @@ def test_append_masked_array_along_axis():
     assert_array_equal(result.mask, expected.mask)
 
 
+def test_default_fill_value_complex():
+    # regression test for Python 3, where 'unicode' was not defined
+    assert default_fill_value(1 + 1j) == 1.e20 + 0.0j
+
+###############################################################################
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
For the unicode issue, we could also simply map `unicode = str` on Python 3+, which has the benefit of making static code analysis tools happier.
