### PR TITLE
Fix for loading of files with filnames encoded in unicode.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -65,7 +65,7 @@ def seek_gzip_factory(f):
         def tell(self):
             return self.offset
 
-    if isinstance(f,(str, unicode)):
+    if isinstance(f,(str, unicode)):  # Allow unicode filenamens for loadtxt
         f = GzipFile(f)
     elif isinstance(f, gzip.GzipFile):
         # cast to our GzipFile if its already a gzip.GzipFile

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -65,7 +65,7 @@ def seek_gzip_factory(f):
         def tell(self):
             return self.offset
 
-    if isinstance(f, str):
+    if isinstance(f,(str, unicode)):
         f = GzipFile(f)
     elif isinstance(f, gzip.GzipFile):
         # cast to our GzipFile if its already a gzip.GzipFile


### PR DESCRIPTION
This is a simple fix for loading of files with filnames encoded in unicode. 
An alternate fix would be using _is_string_like(f) instead of  isinstance(f,(str, unicode)).
