### PR TITLE
Index iter bug

### DIFF
--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -1221,6 +1221,9 @@ functions provide that information.
     This pointer may be cached before the iteration loop, calling
     ``iternext`` will not change it. This function may be safely
     called without holding the Python GIL.
+    
+    **WARNING**: While the pointer may be cached, its values may
+    change if the iterator is buffered.
 
 .. c:function:: npy_intp* NpyIter_GetInnerLoopSizePtr(NpyIter* iter)
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2501,7 +2501,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
     NpyIter_IterNextFunc *op_iternext;
     npy_intp outer_dim, indval;
     int outer_axis;
-    npy_intp itersize, iterstride;
+    npy_intp itersize, *iterstride;
     char **iterptr;
     PyArray_Descr *intp_type;
     int i;
@@ -2572,7 +2572,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
 
         NPY_BEGIN_THREADS_NDITER(op_iter);
         iterptr = NpyIter_GetDataPtrArray(op_iter);
-        iterstride = NpyIter_GetInnerStrideArray(op_iter)[0];
+        iterstride = NpyIter_GetInnerStrideArray(op_iter);
         do {
             itersize = *NpyIter_GetInnerLoopSizePtr(op_iter);
             while (itersize--) {
@@ -2583,7 +2583,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
                     NpyIter_Deallocate(op_iter);
                     return -1;
                 }
-                *iterptr += iterstride;
+                *iterptr += *iterstride;
             }
         } while (op_iternext(op_iter));
 

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -404,6 +404,22 @@ class TestIndexing(TestCase):
         arr = np.zeros((1,), dtype=[('f1', 'i8'), ('f2', 'i8')])
         assert_array_equal(arr[SequenceLike()], arr[SequenceLike(),])
 
+    def test_indexing_array_weird_strides(self):
+        # See also gh-6221
+        # the shapes used here come from the issue and create the correct
+        # size for the iterator buffering size.
+        x = np.ones(10)
+        x2 = np.ones((10, 2))
+        ind = np.arange(10)[:, None, None, None]
+        ind = np.broadcast_to(ind, (10, 55, 4, 4))
+
+        # single advanced index case
+        assert_array_equal(x[ind], x[ind.copy()])
+        # higher dimensional advanced index
+        zind = np.zeros(4, dtype=np.intp)
+        assert_array_equal(x2[ind, zind], x2[ind.copy(), zind])
+
+
 class TestFieldIndexing(TestCase):
     def test_scalar_return_type(self):
         # Field access on an array should return an array, even if it


### PR DESCRIPTION
Fixes the wrong indexing check due to bad iterator. I think this is a candidate for backporting.

I did not test if it is worth it to cache the value in the inner loop (not sure if it can make a difference anyway), but I doubt it.
Also added a warning to the documentation, it might be that grow inner loop flag has to be set as well to trigger this.
