### PR TITLE
BUG: simplify code remove strict aliasing violation

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -540,8 +540,7 @@ sse2_ordered_cmp_@kind@_@TYPE@(const @type@ a, const @type@ b)
     @vtype@ v = @vpre@_@VOP@_@vsufs@(@vpre@_load_@vsufs@(&a),
                                      @vpre@_load_@vsufs@(&b));
     @vpre@_store_@vsufs@(&tmp, v);
-    return sizeof(@type@) == 4 ?
-        (*(npy_uint32 *)&tmp) & 1 : (*(npy_uint64 *)&tmp) & 1;
+    return !(tmp == 0.);
 }
 
 static void


### PR DESCRIPTION
Didn't think the violation could cause issues but apparently some
compilers do mess it up. Also the old code is overly complicated, don't
know what I was thinking ...

Closes gh-6251
