### PR TITLE
MAINT: Deprecated PyObject_Compare in favor of PyObject_RichCompareBool. Fixes #6265

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -325,7 +325,7 @@ PyObject_Cmp(PyObject *i1, PyObject *i2, int *cmp)
 {
     int v;
     v = PyObject_RichCompareBool(i1, i2, Py_LT);
-    if (v == 0) {
+    if (v == 1) {
         *cmp = -1;
         return 1;
     }
@@ -334,7 +334,7 @@ PyObject_Cmp(PyObject *i1, PyObject *i2, int *cmp)
     }
 
     v = PyObject_RichCompareBool(i1, i2, Py_GT);
-    if (v == 0) {
+    if (v == 1) {
         *cmp = 1;
         return 1;
     }
@@ -343,7 +343,7 @@ PyObject_Cmp(PyObject *i1, PyObject *i2, int *cmp)
     }
 
     v = PyObject_RichCompareBool(i1, i2, Py_EQ);
-    if (v == 0) {
+    if (v == 1) {
         *cmp = 0;
         return 1;
     }

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2784,7 +2784,7 @@ OBJECT_compare(PyObject **ip1, PyObject **ip2, PyArrayObject *NPY_UNUSED(ap))
         }
         return 1;
     }
-#if defined(NPY_PY3K)
+
     if (PyObject_RichCompareBool(*ip1, *ip2, Py_LT) == 1) {
         return -1;
     }
@@ -2794,9 +2794,6 @@ OBJECT_compare(PyObject **ip1, PyObject **ip2, PyArrayObject *NPY_UNUSED(ap))
     else {
         return 0;
     }
-#else
-    return PyObject_Compare(*ip1, *ip2);
-#endif
 }
 
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1443,13 +1443,9 @@ _equivalent_fields(PyObject *field1, PyObject *field2) {
     if (field1 == NULL || field2 == NULL) {
         return 0;
     }
-#if defined(NPY_PY3K)
+
     val = PyObject_RichCompareBool(field1, field2, Py_EQ);
     if (val != 1 || PyErr_Occurred()) {
-#else
-    val = PyObject_Compare(field1, field2);
-    if (val != 0 || PyErr_Occurred()) {
-#endif
         same = 0;
     }
     else {
@@ -1476,13 +1472,8 @@ _equivalent_subarrays(PyArray_ArrayDescr *sub1, PyArray_ArrayDescr *sub2)
         return 0;
     }
 
-#if defined(NPY_PY3K)
     val = PyObject_RichCompareBool(sub1->shape, sub2->shape, Py_EQ);
     if (val != 1 || PyErr_Occurred()) {
-#else
-    val = PyObject_Compare(sub1->shape, sub2->shape);
-    if (val != 0 || PyErr_Occurred()) {
-#endif
         PyErr_Clear();
         return 0;
     }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2618,41 +2618,42 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
 NPY_NO_EXPORT void
 OBJECT_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-#if defined(NPY_PY3K)
     PyObject *zero = PyLong_FromLong(0);
+
     UNARY_LOOP {
         PyObject *in1 = *(PyObject **)ip1;
         PyObject **out = (PyObject **)op1;
+        PyObject *ret = NULL;
         int v;
-        PyObject *ret;
-        if (PyObject_Cmp(in1 ? in1 : Py_None, zero, &v) == -1) {
-            return;
+
+        if (in1 == NULL) {
+            in1 = Py_None;
         }
-        ret = PyLong_FromLong(v);
-        if (PyErr_Occurred()) {
-            Py_DECREF(zero);
-            return;
+
+        if ((v = PyObject_RichCompareBool(in1, zero, Py_LT)) == 1) {
+            ret = PyLong_FromLong(-1);
+        }
+        else if (v == 0 &&
+                (v = PyObject_RichCompareBool(in1, zero, Py_GT)) == 1) {
+            ret = PyLong_FromLong(1);
+        }
+        else if (v == 0 &&
+                (v = PyObject_RichCompareBool(in1, zero, Py_EQ)) == 1) {
+            ret = PyLong_FromLong(0);
+        }
+        else if (v == 0) {
+            /* in1 is NaN */
+            PyErr_SetString(PyExc_TypeError,
+                    "unorderable types for comparison");
+        }
+
+        if (ret == NULL) {
+            break;
         }
         Py_XDECREF(*out);
         *out = ret;
     }
-    Py_DECREF(zero);
-#else
-    PyObject *zero = PyInt_FromLong(0);
-    UNARY_LOOP {
-        PyObject *in1 = *(PyObject **)ip1;
-        PyObject **out = (PyObject **)op1;
-        PyObject *ret = PyInt_FromLong(
-                            PyObject_Compare(in1 ? in1 : Py_None, zero));
-        if (PyErr_Occurred()) {
-            Py_DECREF(zero);
-            return;
-        }
-        Py_XDECREF(*out);
-        *out = ret;
-    }
-    Py_DECREF(zero);
-#endif
+    Py_XDECREF(zero);
 }
 
 /*

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -935,6 +935,22 @@ class TestSign(TestCase):
             assert_equal(res, tgt)
             assert_equal(out, tgt)
 
+    def test_sign_dtype_object(self):
+        # In reference to github issue #6229
+
+        foo = np.array([-.1, 0, .1])
+        a = np.sign(foo.astype(np.object))
+        b = np.sign(foo)
+
+        assert_array_equal(a, b)
+
+    def test_sign_dtype_nan_object(self):
+        # In reference to github issue #6229
+        def test_nan():
+            foo = np.array([np.nan])
+            a = np.sign(foo.astype(np.object))
+
+        assert_raises(TypeError, test_nan)
 
 class TestMinMax(TestCase):
     def test_minmax_blocked(self):


### PR DESCRIPTION
@jaimefrio I made the changes as discussed in #6265 . I ran all tests for Python2 and Python3 through `python runtests.py` / `python3 runtests.py` and did not encounter any failure.

As far as the `PyObject_Cmp` function in `npy_3kcompat.h` goes, I did not change that. I although did fix the only part of code base that uses it with `PyObject_RichCompareBool`. 
As far as `PyObject_Cmp` goes, should I remove it or add a deprecation warning ?
