### PR TITLE
BUG: enforce signed char in extint128

### DIFF
--- a/numpy/core/src/private/npy_extint128.h
+++ b/numpy/core/src/private/npy_extint128.h
@@ -3,7 +3,7 @@
 
 
 typedef struct {
-    char sign;
+    signed char sign;
     npy_uint64 lo, hi;
 } npy_extint128_t;
 


### PR DESCRIPTION
Whether a "char" is signed or unsigned is left undefined by the C standard.
Some platforms such as armv7l actually seem to have an "unsigned" C char.
Enforce a signed char where relevant.

(fixes test_extint128 and test_mem_overlap on Raspberry Pi 2)
