### PR TITLE
DOC: Document Datetime, Timedelta dtype kinds

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -230,6 +230,8 @@ Array-protocol type strings (see :ref:`arrays.interface`)
    ``'u'``            unsigned integer
    ``'f'``            floating-point
    ``'c'``            complex-floating point
+   ``'m'``            timedelta
+   ``'M'``            datetime
    ``'O'``            (Python) objects
    ``'S'``, ``'a'``   (byte-)string
    ``'U'``            Unicode

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -88,6 +88,8 @@ This approach to the interface consists of the object having an
        ``u``  Unsigned integer
        ``f``  Floating point
        ``c``  Complex floating point
+       ``m``  Timedelta
+       ``M``  Datetime
        ``O``  Object (i.e. the memory contains a pointer to :c:type:`PyObject`)
        ``S``  String (fixed-length sequence of char)
        ``U``  Unicode (fixed-length sequence of :c:type:`Py_UNICODE`)

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -6223,7 +6223,7 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('itemsize',
 
 add_newdoc('numpy.core.multiarray', 'dtype', ('kind',
     """
-    A character code (one of 'biufcOSUV') identifying the general kind of data.
+    A character code (one of 'biufcmMOSUV') identifying the general kind of data.
 
     =  ======================
     b  boolean
@@ -6231,6 +6231,8 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('kind',
     u  unsigned integer
     f  floating-point
     c  complex floating-point
+    m  timedelta
+    M  datetime
     O  object
     S  (byte-)string
     U  Unicode


### PR DESCRIPTION
The `dtype` kinds for `Datetime` and `Timedelta` types are missing from the documentation.
