### PR TITLE
DOC: Fix typo in Triangular Distribution PDF

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -3520,7 +3520,7 @@ cdef class RandomState:
 
         .. math:: P(x;l, m, r) = \\begin{cases}
                   \\frac{2(x-l)}{(r-l)(m-l)}& \\text{for $l \\leq x \\leq m$},\\\\
-                  \\frac{2(m-x)}{(r-l)(r-m)}& \\text{for $m \\leq x \\leq r$},\\\\
+                  \\frac{2(r-x)}{(r-l)(r-m)}& \\text{for $m \\leq x \\leq r$},\\\\
                   0& \\text{otherwise}.
                   \\end{cases}
 


### PR DESCRIPTION
The definition of the probability density function for the Triangular distribution in the documentation was wrong.

See [this ipython notebook](http://nbviewer.ipython.org/gist/MaPePeR/dae062fac2df8b0bce8f) for plots.
