### PR TITLE
BUG: allow extension of common blocks rather than overwriting in numpy.f2py

### DIFF
--- a/doc/source/f2py/signature-file.rst
+++ b/doc/source/f2py/signature-file.rst
@@ -178,12 +178,13 @@ Common block statements:
 
     <shortentitydecl> := <name> [ ( <arrayspec> ) ] [ , <shortentitydecl> ]
 
-  One ``python module`` block should not contain two or more
-  ``common`` blocks with the same name. Otherwise, the latter ones are
-  ignored. The types of variables in ``<shortentitydecl>`` are defined
-  using ``<argument type declarations>``. Note that the corresponding
-  ``<argument type declarations>`` may contain array specifications;
-  then you don't need to specify these in ``<shortentitydecl>``.
+  If a ``python module`` block contains two or more ``common`` blocks
+  with the same name, the variables from the additional declarations
+  are appened.  The types of variables in ``<shortentitydecl>`` are
+  defined using ``<argument type declarations>``. Note that the
+  corresponding ``<argument type declarations>`` may contain array
+  specifications; then you don't need to specify these in
+  ``<shortentitydecl>``.
 
 Other statements:
   The ``<other statement>`` part refers to any other Fortran language

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1372,11 +1372,8 @@ def analyzeline(m, case, line):
         if 'common' in groupcache[groupcounter]:
             commonkey = groupcache[groupcounter]['common']
         for c in cl:
-            if c[0] in commonkey:
-                outmess(
-                    'analyzeline: previously defined common block encountered. Skipping.\n')
-                continue
-            commonkey[c[0]] = []
+            if c[0] not in commonkey:
+                commonkey[c[0]] = []
             for i in [x.strip() for x in markoutercomma(c[1]).split('@,@')]:
                 if i:
                     commonkey[c[0]].append(i)


### PR DESCRIPTION
This is in accordance with how FORTRAN77 handles multiple occurrences of
common blocks.  Documentation has been updated accordingly.  This is the pull request for Issue  #5876
