### PR TITLE
BUG: nested use of parameters in definition of arrays in numpy.f2py

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2624,11 +2624,12 @@ def analyzevars(block):
                     if d in params:
                         d = str(params[d])
                     for p in list(params.keys()):
-                        m = re.match(
-                            r'(?P<before>.*?)\b' + p + r'\b(?P<after>.*)', d, re.I)
-                        if m:
+                        re_1 = re.compile(r'(?P<before>.*?)\b' + p + r'\b(?P<after>.*)', re.I)
+                        m = re_1.match(d)
+                        while m:
                             d = m.group('before') + \
                                 str(params[p]) + m.group('after')
+                            m = re_1.match(d)
                     if d == star:
                         dl = [star]
                     else:


### PR DESCRIPTION
Nested use of paramaters in definition of dimension caused problmes.
Issue #5877.

For example

```
  parameter (i=7)
  common buf(nvar*(nvar+1) * (n + 1))
```

this is a fix as suggested by pearu on github.
