### PR TITLE
adds lexsort for arrays with object dtype

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -68,6 +68,12 @@ Improvements
 The ``axis`` parameter was added to *np.gradient* for consistency.
 It allows to specify over which axes the gradient is calculated.
 
+*np.lexsort* now supports arrays with object data-type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The function now internally calls the generic ``npy_amergesort``
+when the type does not implement a merge-sort kind of ``argsort``
+method.
+
 Changes
 =======
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3207,6 +3207,22 @@ class TestLexsort(TestCase):
         expected_idx = np.array([2, 1, 0])
         assert_array_equal(idx, expected_idx)
 
+    def test_object(self):  # gh-6312
+        a = np.random.choice(10, 1000)
+        b = np.random.choice(['abc', 'xy', 'wz', 'efghi', 'qwst', 'x'], 1000)
+
+        for u in a, b:
+            left = np.lexsort((u.astype('O'),))
+            right = np.argsort(u, kind='mergesort')
+            assert_array_equal(left, right)
+
+        for u, v in (a, b), (b, a):
+            idx = np.lexsort((u, v))
+            assert_array_equal(idx, np.lexsort((u.astype('O'), v)))
+            assert_array_equal(idx, np.lexsort((u, v.astype('O'))))
+            u, v = np.array(u, dtype='object'), np.array(v, dtype='object')
+            assert_array_equal(idx, np.lexsort((u, v)))
+
 
 class TestIO(object):
     """Test tofile, fromfile, tobytes, and fromstring"""


### PR DESCRIPTION
on master:

``` python
>>> a = np.array(['a', 'c', 'b'], dtype='O')
>>> np.argsort(a, kind='mergesort')
array([0, 2, 1])
>>> np.lexsort((a,))
TypeError: merge sort not available for item 0
```

though i did some tests, it needs to be verified that this will not leak when it makes copy.
