### PR TITLE
ENH: enabled extra_link_args in OpenBLAS segment

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1703,6 +1703,10 @@ class openblas_info(blas_info):
         if info is None:
             return
 
+        # Add extra info for OpenBLAS
+        extra_info = self.calc_extra_info()
+        dict_append(info, **extra_info)
+
         if not self.check_embedded_lapack(info):
             return
 
@@ -1729,13 +1733,19 @@ class openblas_lapack_info(openblas_info):
         }"""
         src = os.path.join(tmpdir, 'source.c')
         out = os.path.join(tmpdir, 'a.out')
+        # Add the additional "extra" arguments
+        try:
+            extra_args = info['extra_link_args']
+        except:
+            extra_args = []
         try:
             with open(src, 'wt') as f:
                 f.write(s)
             obj = c.compile([src], output_dir=tmpdir)
             try:
                 c.link_executable(obj, out, libraries=info['libraries'],
-                                  library_dirs=info['library_dirs'])
+                                  library_dirs=info['library_dirs'],
+                                  extra_postargs=extra_args)
                 res = True
             except distutils.ccompiler.LinkError:
                 res = False
@@ -1752,7 +1762,8 @@ class openblas_lapack_info(openblas_info):
                 obj = c.compile([src], output_dir=tmpdir)
                 try:
                     c.link_executable(obj, out, libraries=info['libraries'],
-                                    library_dirs=info['library_dirs'])
+                                      library_dirs=info['library_dirs'],
+                                      extra_postargs=extra_args)
                     res = True
                 except distutils.ccompiler.LinkError:
                     res = False

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -68,7 +68,7 @@
 #           extra_compile_args = -g -ftree-vectorize
 #
 #   extra_link_args
-#       Add additional arguments to when libraries/executables
+#       Add additional arguments when libraries/executables
 #       are linked.
 #       Simple variable with no parsing done. 
 #       Provide a single line with all complete flags.


### PR DESCRIPTION
The `extra_link_args` is sadly not intrinsically used
for many parts of the system_info code.

This commit adds the linking properties stored
when using `extra_link_args` in the openblas section
to bypass any difficulties in the usage of OpenBLAS.

This is especially helpful when linking against external
LAPACK libraries which requires `-lgfortran` and possibly
`-lm` for correct linking.

This PR is more general than #5855 without making `site.cfg` more complex, which I think is good.

This PR supersedes #5855 and is a complement to the already merged PR #5597 
#5855 will be closed to prefer this PR.
