### PR TITLE
MAINT: cleanup dead code/arguments/fields from ufuncs

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -35,6 +35,16 @@ Deprecated to error
   e.g., in reshape, take, and specifying reduce axis.
 
 
+C API
+~~~~~
+
+Removed the ``check_return`` and ``inner_loop_selector`` members of
+the ``PyUFuncObject`` struct (replacing them with ``reserved`` slots
+to preserve struct layout). These were never used for anything, so
+it's unlikely that any third-party code is using them either, but we
+mention it here for completeness.
+
+
 New Features
 ============
 

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -681,7 +681,7 @@ PyUFunc_Type
           PyUFuncGenericFunction *functions;
           void **data;
           int ntypes;
-          int check_return;
+          int reserved1;
           const char *name;
           char *types;
           const char *doc;
@@ -747,11 +747,6 @@ PyUFunc_Type
        The number of supported data types for the ufunc. This number
        specifies how many different 1-d loops (of the builtin data types) are
        available.
-
-   .. c:member:: int PyUFuncObject.check_return
-
-       Obsolete and unused. However, it is set by the corresponding entry in
-       the main ufunc creation routine: :c:func:`PyUFunc_FromFuncAndData` (...).
 
    .. c:member:: char *PyUFuncObject.name
 

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -67,7 +67,7 @@ Functions
 
 .. c:function:: PyObject* PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func,
    void** data, char* types, int ntypes, int nin, int nout, int identity,
-   char* name, char* doc, int check_return)
+   char* name, char* doc, int unused)
 
     Create a new broadcasting universal function from required variables.
     Each ufunc builds around the notion of an element-by-element
@@ -121,15 +121,12 @@ Functions
         dynamically determined from the object and available when
         accessing the **__doc__** attribute of the ufunc.
 
-    :param check_return:
-        Unused and present for backwards compatibility of the C-API. A
-        corresponding *check_return* integer does exist in the ufunc
-        structure and it does get set with this value when the ufunc
-        object is created.
+    :param unused:
+        Unused and present for backwards compatibility of the C-API.
 
 .. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction* func,
    void** data, char* types, int ntypes, int nin, int nout, int identity,
-   char* name, char* doc, int check_return, char *signature)
+   char* name, char* doc, int unused, char *signature)
 
    This function is very similar to PyUFunc_FromFuncAndData above, but has
    an extra *signature* argument, to define generalized universal functions.

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -1060,7 +1060,7 @@ automatically generates a ufunc from a C function with the correct signature.
 
 .. c:function:: PyObject *PyUFunc_FromFuncAndData( PyUFuncGenericFunction* func,
    void** data, char* types, int ntypes, int nin, int nout, int identity,
-   char* name, char* doc, int check_return)
+   char* name, char* doc, int unused)
 
     *func*
 
@@ -1170,10 +1170,9 @@ automatically generates a ufunc from a C function with the correct signature.
         response to ``{ufunc_name}.__doc__``). Do not include the function
         signature or the name as this is generated automatically.
 
-    *check_return*
+    *unused*
 
-        Not presently used, but this integer value does get set in the
-        structure-member of similar name.
+        Unused; kept for compatiblity. Just set it to zero.
 
 .. index::
    pair: ufunc; adding new

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -20,17 +20,6 @@ typedef void (*PyUFuncGenericFunction)
 
 /*
  * The most generic one-dimensional inner loop for
- * a standard element-wise ufunc. This typedef is also
- * more consistent with the other NumPy function pointer typedefs
- * than PyUFuncGenericFunction.
- */
-typedef void (PyUFunc_StridedInnerLoopFunc)(
-                char **dataptrs, npy_intp *strides,
-                npy_intp count,
-                NpyAuxData *innerloopdata);
-
-/*
- * The most generic one-dimensional inner loop for
  * a masked standard element-wise ufunc. "Masked" here means that it skips
  * doing calculations on any items for which the maskptr array has a true
  * value.
@@ -112,13 +101,6 @@ typedef int (PyUFunc_LegacyInnerLoopSelectionFunc)(
                             PyUFuncGenericFunction *out_innerloop,
                             void **out_innerloopdata,
                             int *out_needs_api);
-typedef int (PyUFunc_InnerLoopSelectionFunc)(
-                            struct _tagPyUFuncObject *ufunc,
-                            PyArray_Descr **dtypes,
-                            npy_intp *fixed_strides,
-                            PyUFunc_StridedInnerLoopFunc **out_innerloop,
-                            NpyAuxData **out_innerloopdata,
-                            int *out_needs_api);
 typedef int (PyUFunc_MaskedInnerLoopSelectionFunc)(
                             struct _tagPyUFuncObject *ufunc,
                             PyArray_Descr **dtypes,
@@ -148,8 +130,8 @@ typedef struct _tagPyUFuncObject {
         /* The number of elements in 'functions' and 'data' */
         int ntypes;
 
-        /* Does not appear to be used */
-        int check_return;
+        /* Used to be unused field 'check_return' */
+        int reserved1;
 
         /* The name of the ufunc */
         const char *name;
@@ -204,11 +186,11 @@ typedef struct _tagPyUFuncObject {
          */
         PyUFunc_LegacyInnerLoopSelectionFunc *legacy_inner_loop_selector;
         /*
-         * A function which returns an inner loop for the new mechanism
-         * in NumPy 1.7 and later. If provided, this is used, otherwise
-         * if NULL the legacy_inner_loop_selector is used instead.
+         * This was blocked off to be the "new" inner loop selector in 1.7,
+         * but this was never implemented. (This is also why the above
+         * selector is called the "legacy" selector.)
          */
-        PyUFunc_InnerLoopSelectionFunc *inner_loop_selector;
+        void *reserved2;
         /*
          * A function which returns a masked inner loop for the ufunc.
          */

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -123,7 +123,6 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     self->identity = PyUFunc_None;
     self->functions = pyfunc_functions;
     self->ntypes = 1;
-    self->check_return = 0;
 
     /* generalized ufunc */
     self->core_enabled = 0;


### PR DESCRIPTION
The check_return argument and ufunc object field was never used; ditto
for the "new" inner loop selector (which was never implemented), along
with associated typedefs. Since I was looking at this code anyway trying
to figure out which parts were actually in use, I figured I'd clear up
some of the brush to make it easier next time...
