### PR TITLE
BUG: Guarantee non-zero is one in arctan2

### DIFF
--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -130,7 +130,7 @@ double npy_atan2(double y, double x)
         return npy_atan(y);
     }
 
-    m = 2 * npy_signbit(x) + npy_signbit(y);
+    m = 2 * (npy_signbit((x)) != 0) + (npy_signbit((y)) != 0);
     if (y == 0.0) {
         switch(m) {
         case 0:


### PR DESCRIPTION
In numpy/core/src/npymath/npy_math.c.src there is a state machine
sequence that assumes signbit returns either a 1 or 0. However, all
the online documentation states that it will return either a 0 or a
nonzero value, which seems to be determined by the OS. These changes
allow the code to work with a zero or nonzero value.
- Andres Guzman-ballen, Intel
