### PR TITLE
Fix a couple of distribution problems

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,9 @@ include numpy/random/mtrand/generate_mtrand_c.py
 recursive-include numpy/random/mtrand *.pyx *.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed
 recursive-include numpy/_build_utils *
+# Add sdist files whose use depends on local configuration.
+include numpy/core/src/multiarray/cblasfuncs.c
+include numpy/core/src/multiarray/python_xerbla.c
 # Adding scons build related files not found by distutils
 recursive-include numpy/core/code_generators *.py *.txt
 recursive-include numpy/core *.in *.h

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -736,6 +736,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'array_assign.h'),
             join('src', 'multiarray', 'buffer.h'),
             join('src', 'multiarray', 'calculation.h'),
+            join('src', 'multiarray', 'cblasfuncs.h'),
             join('src', 'multiarray', 'common.h'),
             join('src', 'multiarray', 'convert_datatype.h'),
             join('src', 'multiarray', 'convert.h'),
@@ -839,6 +840,8 @@ def configuration(parent_package='',top_path=None):
     blas_info = get_info('blas_opt', 0)
     if blas_info and ('HAVE_CBLAS', None) in blas_info.get('define_macros', []):
         extra_info = blas_info
+        # These files are also in MANIFEST.in so that they are always in
+        # the source distribution independently of HAVE_CBLAS.
         multiarray_src.extend([join('src', 'multiarray', 'cblasfuncs.c'),
                                join('src', 'multiarray', 'python_xerbla.c'),
                                ])

--- a/numpy/lib/tests/test__version.py
+++ b/numpy/lib/tests/test__version.py
@@ -48,6 +48,19 @@ def test_dev_a_b_rc_mixed():
     assert_(NumpyVersion('1.9.0a2.dev-6acvda54') < '1.9.0a2')
 
 
+def test_dev0_version():
+    assert_(NumpyVersion('1.9.0.dev0+Unknown') < '1.9.0')
+    for ver in ['1.9.0', '1.9.0a1', '1.9.0b2', '1.9.0b2.dev0+ffffffff']:
+        assert_(NumpyVersion('1.9.0.dev0+f16acvda') < ver)
+
+    assert_(NumpyVersion('1.9.0.dev0+f16acvda') == '1.9.0.dev0+11111111')
+
+
+def test_dev0_a_b_rc_mixed():
+    assert_(NumpyVersion('1.9.0a2.dev0+f16acvda') == '1.9.0a2.dev0+11111111')
+    assert_(NumpyVersion('1.9.0a2.dev0+6acvda54') < '1.9.0a2')
+
+
 def test_raises():
     for ver in ['1.9', '1,9.0', '1.7.x']:
         assert_raises(ValueError, NumpyVersion, ver)

--- a/pavement.py
+++ b/pavement.py
@@ -89,7 +89,7 @@ try:
         GIT_REVISION = "Unknown"
 
     if not setup_py.ISRELEASED:
-        FULLVERSION += '.dev-' + GIT_REVISION[:7]
+        FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 finally:
     sys.path.pop(0)
 


### PR DESCRIPTION
- Fix pavement.py to use PEP440 naming for development distributions.
- Add `cblasfuncs.c` and `python_xerbla.c` to `MANIFEST.in`

The last fixes a dependency of source distributions on `HAVE_CBLAS`, which is determined by the local configuration.
