### PR TITLE
BLD: mingwpy fixes

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -103,6 +103,8 @@ def win32_checks(deflist):
         deflist.append('FORCE_NO_LONG_DOUBLE_FORMATTING')
 
 def check_math_capabilities(config, moredefs, mathlibs):
+    from numpy.distutils.misc_util import mingw32
+    
     def check_func(func_name):
         return config.check_func(func_name, libraries=mathlibs,
                                  decl=True, call=True)
@@ -172,7 +174,8 @@ def check_math_capabilities(config, moredefs, mathlibs):
 
     # C99 functions: float and long double versions
     check_funcs(C99_FUNCS_SINGLE)
-    check_funcs(C99_FUNCS_EXTENDED)
+    if not mingw32():
+        check_funcs(C99_FUNCS_EXTENDED)
 
 def check_complex(config, mathlibs):
     priv = []

--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -61,6 +61,11 @@
 
 #endif
 
+/* Disable broken mingw-w64 hypot function */
+#if defined(__MINGW32__) 
+#undef HAVE_HYPOT
+#endif
+
 
 /* Intel C for Windows uses POW for 64 bits longdouble*/
 #if defined(_MSC_VER) && defined(__INTEL_COMPILER)

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -24,7 +24,6 @@ def is_win32():
     return sys.platform == "win32" and platform.architecture()[0] == "32bit"
 
 if is_win64():
-    #_EXTRAFLAGS = ["-fno-leading-underscore"]
     _EXTRAFLAGS = []
 else:
     _EXTRAFLAGS = []
@@ -215,10 +214,12 @@ class GnuFCompiler(FCompiler):
                 # use -mincoming-stack-boundary=2
                 # due to the change to 16 byte stack alignment since GCC 4.6
                 # but 32 bit Windows ABI defines 4 bytes stack alignment
-                opt = ['-O2 -march=core2 -mtune=generic -mfpmath=sse -msse2 '
-                       '-mincoming-stack-boundary=2']
+                opt = ['-O2 -march=pentium4 -mtune=generic -mfpmath=sse -msse2'
+                       ' -mlong-double-64 -mincoming-stack-boundary=2' 
+                       ' -ffpe-summary=invalid,zero']
             else:
-                opt = ['-O2 -march=x86-64 -DMS_WIN64 -mtune=generic -msse2']
+                opt = ['-O2 -march=x86-64 -DMS_WIN64 -mtune=generic -msse2'
+                       ' -mlong-double-64 -ffpe-summary=invalid,zero']
         else:
             opt = ['-O2']
 
@@ -270,11 +271,11 @@ class Gnu95FCompiler(GnuFCompiler):
         'version_cmd'  : ["<F90>", "-dumpversion"],
         'compiler_f77' : [None, "-Wall", "-g", "-ffixed-form",
                           "-fno-second-underscore"] + _EXTRAFLAGS,
-        'compiler_f90' : [None, "-Wall", "-g",
+        'compiler_f90' : [None, "-Wall",
                           "-fno-second-underscore"] + _EXTRAFLAGS,
         'compiler_fix' : [None, "-Wall",  "-g","-ffixed-form",
                           "-fno-second-underscore"] + _EXTRAFLAGS,
-        'linker_so'    : ["<F90>", "-Wall", "-g"],
+        'linker_so'    : ["<F90>", "-Wall"],
         'archiver'     : ["ar", "-cr"],
         'ranlib'       : ["ranlib"],
         'linker_exe'   : [None, "-Wall"]

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -95,9 +95,10 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         # Before build with MinGW-W64 generate the python import library
         # with gendef and dlltool according to the MingW-W64 FAQ.
         # Use the MinGW-W64 provided msvc runtime import libraries.
+        # The mingwpy package deploys it's own import libraries.
         # Don't call build_import_library() and build_msvcr_library.
 
-        if 'MinGW-W64' not in str(out_string):
+        if 'MinGW-W64' not in str(out_string) and 'mingwpy' not in str(out_string):
 
             # **changes: eric jones 4/11/01
             # 1. Check for import library on Windows.  Build if it doesn't
@@ -131,10 +132,10 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             else:
                 # gcc-4 series releases do not support -mno-cygwin option
                 self.set_executables(
-                    compiler='gcc -march=x86-64 -mtune=generic -DMS_WIN64'
-                             ' -O2 -msse2 -Wall',
-                    compiler_so='gcc -march=x86-64 -mtune=generic -DMS_WIN64'
-                                ' -O2 -msse2 -Wall -Wstrict-prototypes',
+                    compiler='gcc -O2 -march=x86-64 -mtune=generic -DMS_WIN64'
+                             ' -msse2 -mlong-double-64 -Wall',
+                    compiler_so='gcc -O2 -march=x86-64 -mtune=generic -DMS_WIN64'
+                                ' -msse2 -mlong-double-64 -Wall -Wstrict-prototypes',
                     linker_exe='gcc',
                     linker_so='gcc -shared -Wl,-gc-sections -Wl,-s')
         else:
@@ -158,11 +159,11 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
                 # build needs '-mincoming-stack-boundary=2' due to ABI
                 # incompatibility to Win32 ABI
                 self.set_executables(
-                    compiler='gcc -O2 -march=core2 -mtune=generic'
-                             ' -mfpmath=sse -msse2'
+                    compiler='gcc -O2 -march=pentium4 -mtune=generic'
+                             ' -mfpmath=sse -msse2 -mlong-double-64'
                              ' -mincoming-stack-boundary=2 -Wall',
-                    compiler_so='gcc -O2 -march=core2 -mtune=generic'
-                                ' -mfpmath=sse -msse2'
+                    compiler_so='gcc -O2 -march=pentium4 -mtune=generic'
+                                ' -mfpmath=sse -msse2 -mlong-double-64'
                                 ' -mincoming-stack-boundary=2 -Wall'
                                 ' -Wstrict-prototypes',
                     linker_exe='g++ ',

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -381,9 +381,22 @@ def mingw32():
     """Return true when using mingw32 environment.
     """
     if sys.platform=='win32':
-        if os.environ.get('OSTYPE', '')=='msys':
+        # mingw32 compiler configured in %USERPROFILE%\pydistutils.cfg 
+        # or distutils\distutils.cfg
+        from distutils.dist import Distribution
+        _dist = Distribution()
+        _dist.parse_config_files()
+        _bld = _dist.get_option_dict('build')
+        if _bld and 'mingw32' in _bld.get('compiler'):
             return True
-        if os.environ.get('MSYSTEM', '')=='MINGW32':
+        # parse setup.py command line: --compiler=mingw32 or -c mingw32
+        elif (_i for _i in sys.argv if 'mingw32' in _i) and \
+             (_i for _i in sys.argv if ('setup.py') in _i):
+            return True
+        # using msys or msys2 shell
+        elif os.environ.get('OSTYPE', '')=='msys':
+            return True
+        elif os.environ.get('MSYSTEM', '') in ('MINGW32', 'MINGW64'):
             return True
     return False
 

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1751,24 +1751,6 @@ class openblas_lapack_info(openblas_info):
                 res = False
         finally:
             shutil.rmtree(tmpdir)
-        if sys.platform == 'win32' and not res:
-            c = distutils.ccompiler.new_compiler(compiler='mingw32')
-            tmpdir = tempfile.mkdtemp()
-            src = os.path.join(tmpdir, 'source.c')
-            out = os.path.join(tmpdir, 'a.out')
-            try:
-                with open(src, 'wt') as f:
-                    f.write(s)
-                obj = c.compile([src], output_dir=tmpdir)
-                try:
-                    c.link_executable(obj, out, libraries=info['libraries'],
-                                      library_dirs=info['library_dirs'],
-                                      extra_postargs=extra_args)
-                    res = True
-                except distutils.ccompiler.LinkError:
-                    res = False
-            finally:
-                shutil.rmtree(tmpdir)
         return res
 
 


### PR DESCRIPTION
latest patches for OpenBLAS/mingwpy builds on Windows. Features longdouble==double fake to better match MSVC behaviour. Better mingw32 detection.
