### PR TITLE
BUG: numpy.ma functions can be called with only keyword arguments

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7536,7 +7536,7 @@ class _convert2ma:
             doc = sig + doc
         return doc
 
-    def __call__(self, a, *args, **params):
+    def __call__(self, *args, **params):
         # Find the common parameters to the call and the definition
         _extras = self._extras
         common_params = set(params).intersection(_extras)
@@ -7544,7 +7544,7 @@ class _convert2ma:
         for p in common_params:
             _extras[p] = params.pop(p)
         # Get the result
-        result = self._func.__call__(a, *args, **params).view(MaskedArray)
+        result = self._func.__call__(*args, **params).view(MaskedArray)
         if "fill_value" in common_params:
             result.fill_value = _extras.get("fill_value", None)
         if "hardmask" in common_params:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1670,6 +1670,18 @@ class TestFillingValues(TestCase):
         a = identity(3, fill_value=0., dtype=complex)
         assert_equal(a.fill_value, 0.)
 
+    def test_shape_argument(self):
+        # Test that shape can be provides as an argument
+        # GH issue 6106
+        a = empty(shape=(3, ))
+        assert_equal(a.shape, (3, ))
+
+        a = ones(shape=(3, ), dtype=float)
+        assert_equal(a.shape, (3, ))
+
+        a = zeros(shape=(3, ), dtype=complex)
+        assert_equal(a.shape, (3, ))
+
     def test_fillvalue_in_view(self):
         # Test the behavior of fill_value in view
 


### PR DESCRIPTION
numpy.ma.empty, zeros, ones, etc can be called using only keyword arguments
without a positional argument.  Previously a single positional argument was
required.

For example:

np.ma.zeros(shape=(10, ))

closes #6106
