### PR TITLE
BUG: Add void field at end of dtype.descr to match itemsize

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -121,6 +121,10 @@ def _array_descr(descriptor):
         offset += field[0].itemsize
         result.append(tup)
 
+    if descriptor.itemsize > offset:
+        num = descriptor.itemsize - offset
+        result.append(('', '|V%d' % num))
+
     return result
 
 # Build a new array from the information in a pickle.

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -535,7 +535,7 @@ class TestString(TestCase):
         # Pull request #4722
         np.array(["", ""]).astype(object)
 
-class TestDtypeAttributeDeletion(object):
+class TestDtypeAttributeDeletion(TestCase):
 
     def test_dtype_non_writable_attributes_deletion(self):
         dt = np.dtype(np.double)
@@ -551,6 +551,19 @@ class TestDtypeAttributeDeletion(object):
         attr = ["names"]
         for s in attr:
             assert_raises(AttributeError, delattr, dt, s)
+
+
+class TestDtypeAttributes(TestCase):
+    def test_descr_has_trailing_void(self):
+        # see gh-6359
+        dtype = np.dtype({
+            'names': ['A', 'B'],
+            'formats': ['f4', 'f4'],
+            'offsets': [0, 8],
+            'itemsize': 16})
+        new_dtype = np.dtype(dtype.descr)
+        assert_equal(new_dtype.itemsize, 16)
+
 
 class TestDtypeAttributes(TestCase):
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5390,6 +5390,16 @@ def test_array_interface():
     assert_equal(np.array(ArrayLike()), 1)
 
 
+def test_array_interface_itemsize():
+    # See gh-6361
+    my_dtype = np.dtype({'names': ['A', 'B'], 'formats': ['f4', 'f4'],
+                         'offsets': [0, 8], 'itemsize': 16})
+    a = np.ones(10, dtype=my_dtype)
+    descr_t = np.dtype(a.__array_interface__['descr'])
+    typestr_t = np.dtype(a.__array_interface__['typestr'])
+    assert_equal(descr_t.itemsize, typestr_t.itemsize)
+
+
 def test_flat_element_deletion():
     it = np.ones(3).flat
     try:


### PR DESCRIPTION
dtype.descr returns void fields to explain the padding part of
the dtype. The last void field for the itemsize itself was however
not included.

Closes gh-6359
