### PR TITLE
Document empty(..., object) initialization to None.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -752,8 +752,8 @@ add_newdoc('numpy.core.multiarray', 'empty',
     Returns
     -------
     out : ndarray
-        Array of uninitialized (arbitrary) data with the given
-        shape, dtype, and order.
+        Array of uninitialized (arbitrary) data of the given shape, dtype, and
+        order.  Object arrays will be initialized to None.
 
     See Also
     --------


### PR DESCRIPTION
Behavior goes back at least to 1.6.2.

Fixes #6367.
