### PR TITLE
Backport gh 6372

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1371,7 +1371,7 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
 
 
 def ravel(a, order='C'):
-    """Return a flattened array.
+    """Return a contiguous flattened array.
 
     A 1-D array, containing the elements of the input, is returned.  A copy is
     made only if needed.
@@ -1415,6 +1415,7 @@ def ravel(a, order='C'):
     ndarray.flat : 1-D iterator over an array.
     ndarray.flatten : 1-D array copy of the elements of an array
                       in row-major order.
+    ndarray.reshape : Change the shape of an array without changing its data.
 
     Notes
     -----
@@ -1424,6 +1425,9 @@ def ravel(a, order='C'):
     implies that the index along the first axis varies slowest, and
     the index along the last quickest.  The opposite holds for
     column-major, Fortran-style index ordering.
+
+    When a view is desired in as many cases as possible, ``arr.reshape(-1)``
+    may be preferable.
 
     Examples
     --------

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2077,40 +2077,36 @@ class TestMethods(TestCase):
         assert_equal(a.ravel(order='K'), [2, 3, 0, 1])
         assert_(a.ravel(order='K').flags.owndata)
 
+        # Test simple 1-d copy behaviour:
+        a = np.arange(10)[::2]
+        assert_(a.ravel('K').flags.owndata)
+        assert_(a.ravel('C').flags.owndata)
+        assert_(a.ravel('F').flags.owndata)
+
         # Not contiguous and 1-sized axis with non matching stride
         a = np.arange(2**3 * 2)[::2]
         a = a.reshape(2, 1, 2, 2).swapaxes(-1, -2)
         strides = list(a.strides)
         strides[1] = 123
         a.strides = strides
-        assert_(np.may_share_memory(a.ravel(order='K'), a))
+        assert_(a.ravel(order='K').flags.owndata)
         assert_equal(a.ravel('K'), np.arange(0, 15, 2))
 
-        # General case of possible ravel that is not contiguous but
-        # works and includes a 1-sized axis with non matching stride
-        a = a.swapaxes(-1, -2)  # swap back to C-order
-        assert_(np.may_share_memory(a.ravel(order='C'), a))
-        assert_(np.may_share_memory(a.ravel(order='K'), a))
-
-        a = a.T  # swap all to Fortran order
-        assert_(np.may_share_memory(a.ravel(order='F'), a))
-        assert_(np.may_share_memory(a.ravel(order='K'), a))
-
-        # Test negative strides:
-        a = np.arange(4)[::-1].reshape(2, 2)
-        assert_(np.may_share_memory(a.ravel(order='C'), a))
-        assert_(np.may_share_memory(a.ravel(order='K'), a))
-        assert_equal(a.ravel('C'), [3, 2, 1, 0])
-        assert_equal(a.ravel('K'), [3, 2, 1, 0])
-
-        # Test keeporder with weirdly strided 1-sized dims (1-d first stride)
-        a = np.arange(8)[::2].reshape(1, 2, 2, 1)  # neither C, nor F order
+        # contiguous and 1-sized axis with non matching stride works:
+        a = np.arange(2**3)
+        a = a.reshape(2, 1, 2, 2).swapaxes(-1, -2)
         strides = list(a.strides)
-        strides[0] = -12
-        strides[-1] = 0
+        strides[1] = 123
         a.strides = strides
         assert_(np.may_share_memory(a.ravel(order='K'), a))
-        assert_equal(a.ravel('K'), a.ravel('C'))
+        assert_equal(a.ravel(order='K'), np.arange(2**3))
+
+        # Test negative strides (not very interesting since non-contiguous):
+        a = np.arange(4)[::-1].reshape(2, 2)
+        assert_(a.ravel(order='C').flags.owndata)
+        assert_(a.ravel(order='K').flags.owndata)
+        assert_equal(a.ravel('C'), [3, 2, 1, 0])
+        assert_equal(a.ravel('K'), [3, 2, 1, 0])
 
         # 1-element tidy strides test (NPY_RELAXED_STRIDES_CHECKING):
         a = np.array([[1]])
@@ -2127,7 +2123,7 @@ class TestMethods(TestCase):
             assert_equal(a.ravel(order), [0])
             assert_(np.may_share_memory(a.ravel(order), a))
 
-        #Test that certain non-inplace ravels work right (mostly) for 'K':
+        # Test that certain non-inplace ravels work right (mostly) for 'K':
         b = np.arange(2**4 * 2)[::2].reshape(2, 2, 2, 2)
         a = b[..., ::2]
         assert_equal(a.ravel('K'), [0, 4, 8, 12, 16, 20, 24, 28])
@@ -2140,6 +2136,22 @@ class TestMethods(TestCase):
         assert_equal(a.ravel('C'), [0, 2, 4, 6, 8, 10, 12, 14])
         assert_equal(a.ravel('A'), [0, 2, 4, 6, 8, 10, 12, 14])
         assert_equal(a.ravel('F'), [0, 8, 4, 12, 2, 10, 6, 14])
+
+    def test_ravel_subclass(self):
+        class ArraySubclass(np.ndarray):
+            pass
+
+        a = np.arange(10).view(ArraySubclass)
+        assert_(isinstance(a.ravel('C'), ArraySubclass))
+        assert_(isinstance(a.ravel('F'), ArraySubclass))
+        assert_(isinstance(a.ravel('A'), ArraySubclass))
+        assert_(isinstance(a.ravel('K'), ArraySubclass))
+
+        a = np.arange(10)[::2].view(ArraySubclass)
+        assert_(isinstance(a.ravel('C'), ArraySubclass))
+        assert_(isinstance(a.ravel('F'), ArraySubclass))
+        assert_(isinstance(a.ravel('A'), ArraySubclass))
+        assert_(isinstance(a.ravel('K'), ArraySubclass))
 
     def test_swapaxes(self):
         a = np.arange(1*2*3*4).reshape(1, 2, 3, 4).copy()


### PR DESCRIPTION
REV: Make sure ravel returns a contiguous array

This is a bit more then it used to do, so it is not a complete
revert. Some of the "weird" cases where a copy was unnecessarily
done will now only be gone with RELAXED_STRIDES_CHECKING.
