### PR TITLE
Backport gh 6361

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -424,7 +424,7 @@ def array_split(ary, indices_or_sections, axis=0):
     # This "kludge" was introduced here to replace arrays shaped (0, 10)
     # or similar with an array shaped (0,).
     # There seems no need for this, so give a FutureWarning to remove later.
-    if sub_arys[-1].size == 0 and sub_arys[-1].ndim != 1:
+    if any(arr.size == 0 and arr.ndim != 1 for arr in sub_arys):
         warnings.warn("in the future np.array_split will retain the shape of "
                       "arrays with a zero size, instead of replacing them by "
                       "`array([])`, which always has a shape of (0,).",

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -111,6 +111,15 @@ class TestArraySplit(TestCase):
         compare_results(res, desired)
         assert_(a.dtype.type is res[-1].dtype.type)
 
+        # Same thing for manual splits:
+        res = assert_warns(FutureWarning, array_split, a, [0, 1, 2], axis=0)
+
+        # After removing the FutureWarning, the last should be zeros((0, 10))
+        desired = [np.array([]), np.array([np.arange(10)]),
+                   np.array([np.arange(10)])]
+        compare_results(res, desired)
+        assert_(a.dtype.type is res[-1].dtype.type)
+
     def test_integer_split_2D_cols(self):
         a = np.array([np.arange(10), np.arange(10)])
         res = array_split(a, 3, axis=-1)


### PR DESCRIPTION
```
BUG: Expanded warning conditions for array_split

Zero arrays can also occur with any of the partitions sub_arys[i]
induced by array_split, not just the final partition sub_arys[-1].

Modified by seberg.
Closes gh-5771
```
