### PR TITLE
BUG: Fix PyObject_Cmp in npy_3kcompat.h.

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -325,7 +325,7 @@ PyObject_Cmp(PyObject *i1, PyObject *i2, int *cmp)
 {
     int v;
     v = PyObject_RichCompareBool(i1, i2, Py_LT);
-    if (v == 0) {
+    if (v == 1) {
         *cmp = -1;
         return 1;
     }
@@ -334,7 +334,7 @@ PyObject_Cmp(PyObject *i1, PyObject *i2, int *cmp)
     }
 
     v = PyObject_RichCompareBool(i1, i2, Py_GT);
-    if (v == 0) {
+    if (v == 1) {
         *cmp = 1;
         return 1;
     }
@@ -343,7 +343,7 @@ PyObject_Cmp(PyObject *i1, PyObject *i2, int *cmp)
     }
 
     v = PyObject_RichCompareBool(i1, i2, Py_EQ);
-    if (v == 0) {
+    if (v == 1) {
         *cmp = 0;
         return 1;
     }

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -935,6 +935,13 @@ class TestSign(TestCase):
             assert_equal(res, tgt)
             assert_equal(out, tgt)
 
+    def test_sign_dtype_object(self):
+        # In reference to github issue #6229
+        foo = np.array([-.1, 0, .1])
+        a = np.sign(foo.astype(np.object))
+        b = np.sign(foo)
+        assert_array_equal(a, b)
+
 
 class TestMinMax(TestCase):
     def test_minmax_blocked(self):


### PR DESCRIPTION
The old version was interpreting a PyObject_RichCompareBool return of 0
as success when it actually means failure. The fix is to replace 0 by 1.
