### PR TITLE
Make savetxt() up to 10 times faster for short rows

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1129,10 +1129,8 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             error = ValueError('fmt has wrong number of %% formats:  %s' % fmt)
             if n_fmt_chars == 1:
                 if iscomplex_X:
-                    fmt = [' (%s+%sj)' % (fmt, fmt), ] * ncol
-                else:
-                    fmt = [fmt, ] * ncol
-                format = delimiter.join(fmt)
+                    fmt = ' (%s+%sj)' % (fmt, fmt)
+                format = ((fmt + delimiter) * ncol)[:-1]
             elif iscomplex_X and n_fmt_chars != (2 * ncol):
                 raise error
             elif ((not iscomplex_X) and n_fmt_chars != ncol):

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1147,11 +1147,8 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             fh.write(asbytes(comments + header + newline))
         if iscomplex_X:
             for row in X:
-                row2 = []
-                for number in row:
-                    row2.append(number.real)
-                    row2.append(number.imag)
-                fh.write(asbytes(format % tuple(row2) + newline))
+                row = np.vstack((row.real,row.imag)).T.reshape([ncol * 2])
+                fh.write(asbytes(format % tuple(row) + newline))
         else:
             for row in X:
                 try:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1145,18 +1145,15 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         if len(header) > 0:
             header = header.replace('\n', '\n' + comments)
             fh.write(asbytes(comments + header + newline))
-        if iscomplex_X:
-            for row in X:
-                row = np.vstack((row.real,row.imag)).T.reshape([ncol * 2])
+        for row in X:
+            if iscomplex_X:
+                row = np.vstack((row.real,row.imag)).T.reshape([-1])
+            try:
                 fh.write(asbytes(format % tuple(row) + newline))
-        else:
-            for row in X:
-                try:
-                    fh.write(asbytes(format % tuple(row) + newline))
-                except TypeError:
-                    raise TypeError("Mismatch between array dtype ('%s') and "
-                                    "format specifier ('%s')"
-                                    % (str(X.dtype), format))
+            except TypeError:
+                raise TypeError("Mismatch between array dtype ('%s') and "
+                                "format specifier ('%s')"
+                                % (str(X.dtype), format))
         if len(footer) > 0:
             footer = footer.replace('\n', '\n' + comments)
             fh.write(asbytes(comments + footer + newline))


### PR DESCRIPTION
In the first 3 commits we are doing a bit cleanup to make the 4th enhancement patch more simple to read. The 5th "refactor structured dtype" is out of my own interest but while I were on it I thought it's just obligatory to add this.
