### PR TITLE
MAINT: corrcoef, memory usage optimization

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2349,7 +2349,11 @@ def corrcoef(x, y=None, rowvar=1, bias=np._NoValue, ddof=np._NoValue):
     except ValueError:  # scalar covariance
         # nan if incorrect value (nan, inf, 0), 1 otherwise
         return c / c
-    return c / sqrt(multiply.outer(d, d))
+    d = sqrt(d)
+    # calculate "c / multiply.outer(d, d)" row-wise ... for memory and speed
+    for i in range(0, d.size):
+        c[i,:] /= (d * d[i])
+    return c
 
 
 def blackman(M):


### PR DESCRIPTION
We calculate sqrt on the small vector rather than on that huge
product matrix and we combine the "outer" product with element-wise
devision. So even though we have a slower loop over the rows now ... this
code snippet runs about 3 times faster than before.

However the speed improvement of the whole function is not really
significant because cov() takes 80-99% of the time (dependent on
blas/lapack implementation and number of CPU cores).

More important is that we will safe 1/3 memory. For example corrcoef()
for a [23k, m]  matrix needs 8GB now instead of 12GB.
