### PR TITLE
ENH: optimize corrcoef for memory use and speed

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2350,7 +2350,9 @@ def corrcoef(x, y=None, rowvar=1, bias=np._NoValue, ddof=np._NoValue):
     except ValueError:  # scalar covariance
         # nan if incorrect value (nan, inf, 0), 1 otherwise
         return c / c
-    return c / sqrt(multiply.outer(d, d))
+    d = np.sqrt(d)
+    c /= np.multiply.outer(d, d)
+    return c
 
 
 def blackman(M):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1597,6 +1597,12 @@ class TestCorrCoef(TestCase):
             assert_array_equal(corrcoef(np.array([]).reshape(2, 0)),
                                np.array([[np.nan, np.nan], [np.nan, np.nan]]))
 
+    def test_extreme(self):
+        x = [[1e-100, 1e100], [1e100, 1e-100]]
+        with np.errstate(all='raise'):
+            c = corrcoef(x)
+        assert_array_equal(c, np.array([[1., -1.], [-1., 1.]]))
+
 
 class TestCov(TestCase):
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T


### PR DESCRIPTION
Alternative to #6396. Skips allocation of one n²-sized matrix.

On a Linux box with plenty of memory and single-threaded OpenBLAS,
the test script

``` py
a = np.random.RandomState(42).randn(23000, 5)
for i in range(10):
    corrcoef(a)
```

used to take:

```
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:48.61
Maximum resident set size (kbytes): 12419876
```

Now:

```
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:16.25
Maximum resident set size (kbytes): 8286992
```
