### PR TITLE
ENH: halve the memory requirement of np.cov

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2286,7 +2286,9 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None, fweights=None, aweights=None):
         X_T = X.T
     else:
         X_T = (X*w).T
-    return (dot(X, X_T.conj())/fact).squeeze()
+    c = dot(X, X_T.conj())
+    c /= fact
+    return c.squeeze()
 
 
 def corrcoef(x, y=None, rowvar=1, bias=np._NoValue, ddof=np._NoValue):


### PR DESCRIPTION
This prevents the allocation of a second n²-sized array in `np.cov`. Together with #6396, it reduces the memory requirement of `np.corrcoef` by a factor three, also speeding it up (57s for the benchmark I reported there).
