### PR TITLE
POC: show how to replace part of umathmodule with Cython

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -918,7 +918,11 @@ def configuration(parent_package='',top_path=None):
             join('src', 'private', 'templ_common.h.src'),
             join('src', 'umath', 'simd.inc.src'),
             join(codegen_dir, 'generate_ufunc_api.py'),
-            join('src', 'private', 'ufunc_override.h')] + npymath_sources
+            join('src', 'private', 'ufunc_override.h'),
+            join('src', 'umath', '*.pyx'),
+            join('src', 'umath', '*.pxd'),
+            join('src', 'umath', 'umath_type_resolve.h'),
+            join('src', 'umath', 'umath_cython_boilerplate.h'),] + npymath_sources
 
     if not ENABLE_SEPARATE_COMPILATION:
         umath_deps.extend(umath_src)

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -909,7 +909,8 @@ def configuration(parent_package='',top_path=None):
             join('src', 'umath', 'loops.c.src'),
             join('src', 'umath', 'ufunc_object.c'),
             join('src', 'umath', 'scalarmath.c.src'),
-            join('src', 'umath', 'ufunc_type_resolution.c')]
+            join('src', 'umath', 'ufunc_type_resolution.c'),
+            join('src', 'umath', 'umath_type_resolve.c')]
 
     umath_deps = [
             generate_umath_py,

--- a/numpy/core/src/umath/numpy_base.pxd
+++ b/numpy/core/src/umath/numpy_base.pxd
@@ -64,19 +64,6 @@ cdef extern from "numpy/arrayobject.h":
 
         NPY_INTP
 
-    ctypedef class numpy.dtype [object PyArray_Descr]:
-        # Use PyDataType_* macros when possible, however there are no macros
-        # for accessing some of the fields, so some are defined.
-        cdef char kind
-        cdef char type
-        cdef char byteorder
-        cdef char flags
-        cdef int type_num
-        cdef int itemsize "elsize"
-        cdef int alignment
-        cdef dict fields
-        cdef tuple names
-
     PyArray_Descr* PyArray_DescrFromType (int)
 
     ctypedef struct PyArrayObject:

--- a/numpy/core/src/umath/numpy_base.pxd
+++ b/numpy/core/src/umath/numpy_base.pxd
@@ -1,0 +1,138 @@
+from cpython.object cimport PyObject
+from cpython.ref cimport PyTypeObject
+
+
+cdef extern from "Python.h":
+    ctypedef int Py_intptr_t
+
+
+cdef extern from "numpy/arrayobject.h":
+    # XXX Remove later
+    cdef void** PyArray_API
+
+    cdef enum NPY_TYPES:
+        NPY_BOOL
+        NPY_BYTE
+        NPY_UBYTE
+        NPY_SHORT
+        NPY_USHORT
+        NPY_INT
+        NPY_UINT
+        NPY_LONG
+        NPY_ULONG
+        NPY_LONGLONG
+        NPY_ULONGLONG
+        NPY_FLOAT
+        NPY_DOUBLE
+        NPY_LONGDOUBLE
+        NPY_CFLOAT
+        NPY_CDOUBLE
+        NPY_CLONGDOUBLE
+        NPY_OBJECT
+        NPY_STRING
+        NPY_UNICODE
+        NPY_VOID
+        NPY_NTYPES
+        NPY_NOTYPE
+
+        NPY_INT8
+        NPY_INT16
+        NPY_INT32
+        NPY_INT64
+        NPY_INT128
+        NPY_INT256
+        NPY_UINT8
+        NPY_UINT16
+        NPY_UINT32
+        NPY_UINT64
+        NPY_UINT128
+        NPY_UINT256
+        NPY_FLOAT16
+        NPY_FLOAT32
+        NPY_FLOAT64
+        NPY_FLOAT80
+        NPY_FLOAT96
+        NPY_FLOAT128
+        NPY_FLOAT256
+        NPY_COMPLEX32
+        NPY_COMPLEX64
+        NPY_COMPLEX128
+        NPY_COMPLEX160
+        NPY_COMPLEX192
+        NPY_COMPLEX256
+        NPY_COMPLEX512
+
+        NPY_INTP
+
+    ctypedef class numpy.dtype [object PyArray_Descr]:
+        # Use PyDataType_* macros when possible, however there are no macros
+        # for accessing some of the fields, so some are defined.
+        cdef char kind
+        cdef char type
+        cdef char byteorder
+        cdef char flags
+        cdef int type_num
+        cdef int itemsize "elsize"
+        cdef int alignment
+        cdef dict fields
+        cdef tuple names
+
+    PyArray_Descr* PyArray_DescrFromType (int)
+
+    ctypedef struct PyArrayObject:
+        # For use in situations where ndarray can't replace PyArrayObject*,
+        # like PyArrayObject**.
+        pass
+
+    ctypedef enum NPY_CASTING:
+            NPY_NO_CASTING
+            NPY_EQUIV_CASTING
+            NPY_SAFE_CASTING
+            NPY_SAME_KIND_CASTING
+            NPY_UNSAFE_CASTING
+
+    ctypedef Py_intptr_t npy_intp
+
+    ctypedef struct PyArray_ArrFuncs:
+        pass
+
+    ctypedef struct PyArray_ArrayDescr:
+        PyArray_Descr *base
+        PyObject *shape
+
+    cdef PyTypeObject *PyArrayDescr_Type
+
+    ctypedef struct PyArray_Descr:
+        Py_ssize_t ob_refcnt
+        PyTypeObject *ob_type
+        PyTypeObject *typeobj
+        char kind
+        char type
+        char byteorder
+        int flags
+        int type_num
+        int elsize
+        int alignment
+        PyArray_ArrayDescr *subarray
+        PyObject *fields
+        PyObject *names
+        PyArray_ArrFuncs *f
+
+
+cdef extern from "numpy/ufuncobject.h":
+
+    ctypedef void (*PyUFuncGenericFunction) (char **, npy_intp *, npy_intp *, void *)
+
+    ctypedef struct  PyUFuncObject:
+        int nin, nout, nargs
+        int identity
+        PyUFuncGenericFunction *functions
+        void **data
+        int ntypes
+        int check_return
+        char *name
+        char *types
+        char *doc
+        void *ptr
+        PyObject *obj
+        PyObject *userloops

--- a/numpy/core/src/umath/umath_cython_boilerplate.h
+++ b/numpy/core/src/umath/umath_cython_boilerplate.h
@@ -1,0 +1,16 @@
+#define _UMATHMODULE
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include "npy_config.h"
+
+#ifdef ENABLE_SEPARATE_COMPILATION
+#define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
+#define NO_IMPORT_ARRAY
+#endif
+
+#undef PyMODINIT_FUNC
+#if defined(NPY_PY3K)
+#define PyMODINIT_FUNC NPY_NO_EXPORT PyObject*
+#else
+#define PyMODINIT_FUNC NPY_NO_EXPORT void
+#endif

--- a/numpy/core/src/umath/umath_type_resolve.pyx
+++ b/numpy/core/src/umath/umath_type_resolve.pyx
@@ -1,14 +1,14 @@
-from cpython.ref import Py_INCREF
+from cpython.ref cimport Py_INCREF
 from cpython cimport PyObject
 
 from libc.stdio cimport printf
 
+cdef extern from "umath_cython_boilerplate.h":
+     pass
+
 from numpy_base cimport (PyUFuncObject, NPY_CASTING, PyArrayObject,
                          PyArray_Descr, NPY_OBJECT, PyArray_DescrFromType,
                          PyArray_API)
-
-from numpy cimport import_array
-
 
 
 cdef public int object_ufunc_type_resolver(PyUFuncObject *ufunc,
@@ -19,12 +19,7 @@ cdef public int object_ufunc_type_resolver(PyUFuncObject *ufunc,
     cdef int i
     cdef int nop = ufunc.nin + ufunc.nout
 
-    printf("hello\n\n")
-    printf("%p\n", PyArray_API)
-    printf("%p\n", PyArray_DescrFromType)
     out_dtypes[0] = PyArray_DescrFromType(NPY_OBJECT)
-
-    print("----------- ufuunc_type_resolver")
 
     if out_dtypes[0] is NULL:
         return -1
@@ -34,6 +29,3 @@ cdef public int object_ufunc_type_resolver(PyUFuncObject *ufunc,
         out_dtypes[i] = out_dtypes[0]
 
     return 0
-
-
-#import_array()

--- a/numpy/core/src/umath/umath_type_resolve.pyx
+++ b/numpy/core/src/umath/umath_type_resolve.pyx
@@ -1,0 +1,39 @@
+from cpython.ref import Py_INCREF
+from cpython cimport PyObject
+
+from libc.stdio cimport printf
+
+from numpy_base cimport (PyUFuncObject, NPY_CASTING, PyArrayObject,
+                         PyArray_Descr, NPY_OBJECT, PyArray_DescrFromType,
+                         PyArray_API)
+
+from numpy cimport import_array
+
+
+
+cdef public int object_ufunc_type_resolver(PyUFuncObject *ufunc,
+                                           NPY_CASTING casting,
+                                           PyArrayObject **operands,
+                                           PyObject* type_tup,
+                                           PyArray_Descr **out_dtypes):
+    cdef int i
+    cdef int nop = ufunc.nin + ufunc.nout
+
+    printf("hello\n\n")
+    printf("%p\n", PyArray_API)
+    printf("%p\n", PyArray_DescrFromType)
+    out_dtypes[0] = PyArray_DescrFromType(NPY_OBJECT)
+
+    print("----------- ufuunc_type_resolver")
+
+    if out_dtypes[0] is NULL:
+        return -1
+
+    for i in range(1, nop):
+        Py_INCREF(<object>out_dtypes[0])
+        out_dtypes[i] = out_dtypes[0]
+
+    return 0
+
+
+#import_array()

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -32,6 +32,7 @@
 
 #include "numpy/npy_math.h"
 
+
 /*
  *****************************************************************************
  **                    INCLUDE GENERATED CODE                               **
@@ -44,31 +45,16 @@
 #include "__umath_generated.c"
 #include "__ufunc_api.c"
 
+
+#pragma push_macro("PyMODINIT_FUNC")
+#undef PyMODINIT_FUNC
+#include "umath_type_resolve.h"
+#pragma pop_macro("PyMODINIT_FUNC")
+
+
 NPY_NO_EXPORT int initscalarmath(PyObject *);
 
 static PyUFuncGenericFunction pyfunc_functions[] = {PyUFunc_On_Om};
-
-static int
-object_ufunc_type_resolver(PyUFuncObject *ufunc,
-                                NPY_CASTING casting,
-                                PyArrayObject **operands,
-                                PyObject *type_tup,
-                                PyArray_Descr **out_dtypes)
-{
-    int i, nop = ufunc->nin + ufunc->nout;
-
-    out_dtypes[0] = PyArray_DescrFromType(NPY_OBJECT);
-    if (out_dtypes[0] == NULL) {
-        return -1;
-    }
-
-    for (i = 1; i < nop; ++i) {
-        Py_INCREF(out_dtypes[0]);
-        out_dtypes[i] = out_dtypes[0];
-    }
-
-    return 0;
-}
 
 static int
 object_ufunc_loop_selector(PyUFuncObject *ufunc,
@@ -344,6 +330,12 @@ PyMODINIT_FUNC initumath(void)
         }
         return RETVAL;
     }
+
+    #if PY_MAJOR_VERSION < 3
+      m = initumath_type_resolve();
+    #else
+      m = PyInit_umath_type_resolve();
+    #endif
 
     /* Initialize the types */
     if (PyType_Ready(&PyUFunc_Type) < 0)

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -47,8 +47,16 @@
 
 
 #pragma push_macro("PyMODINIT_FUNC")
+
 #undef PyMODINIT_FUNC
+#if defined(NPY_PY3K)
+#define PyMODINIT_FUNC NPY_NO_EXPORT PyObject*
+#else
+#define PyMODINIT_FUNC NPY_NO_EXPORT void
+#endif
+
 #include "umath_type_resolve.h"
+
 #pragma pop_macro("PyMODINIT_FUNC")
 
 
@@ -330,12 +338,6 @@ PyMODINIT_FUNC initumath(void)
         }
         return RETVAL;
     }
-
-    #if PY_MAJOR_VERSION < 3
-      m = initumath_type_resolve();
-    #else
-      m = PyInit_umath_type_resolve();
-    #endif
 
     /* Initialize the types */
     if (PyType_Ready(&PyUFunc_Type) < 0)

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -422,14 +422,13 @@ PyMODINIT_FUNC initumath(void)
     initscalarmath(m);
 
 #if PY_MAJOR_VERSION < 3
-    mm = initumath_type_resolve();
+    initumath_type_resolve();
 #else
     mm = PyInit_umath_type_resolve();
-#endif
     if (!mm) {
         return RETVAL;
     }
-
+#endif
 
     if (!intern_strings()) {
         goto err;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -314,7 +314,7 @@ PyMODINIT_FUNC PyInit_umath(void)
 PyMODINIT_FUNC initumath(void)
 #endif
 {
-    PyObject *m, *d, *s, *s2, *c_api;
+    PyObject *m, *mm, *d, *s, *s2, *c_api;
     int UFUNC_FLOATING_POINT_SUPPORT = 1;
 
 #ifdef NO_UFUNC_FLOATING_POINT_SUPPORT
@@ -420,6 +420,16 @@ PyMODINIT_FUNC initumath(void)
     PyDict_SetItemString(d, "mod", s2);
 
     initscalarmath(m);
+
+#if PY_MAJOR_VERSION < 3
+    mm = initumath_type_resolve();
+#else
+    mm = PyInit_umath_type_resolve();
+#endif
+    if (!mm) {
+        return RETVAL;
+    }
+
 
     if (!intern_strings()) {
         goto err;

--- a/setup.py
+++ b/setup.py
@@ -188,12 +188,12 @@ class sdist_checked(sdist):
         check_submodules()
         sdist.run(self)
 
-def generate_cython():
+def generate_cython(root_path):
     cwd = os.path.abspath(os.path.dirname(__file__))
     print("Cythonizing sources")
     p = subprocess.call([sys.executable,
                           os.path.join(cwd, 'tools', 'cythonize.py'),
-                          'numpy/random'],
+                          root_path],
                          cwd=cwd)
     if p != 0:
         raise RuntimeError("Running cythonize failed!")
@@ -245,7 +245,8 @@ def setup_package():
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
             # Generate Cython sources, unless building from source release
-            generate_cython()
+            generate_cython('numpy/random')
+            generate_cython('numpy/core/src/umath')
         metadata['configuration'] = configuration
 
     try:


### PR DESCRIPTION
This is a Proof-of-Concept PR showing how parts of umathmodule can be replaced by Cython.

A test for this piece of functionality:

```
import numpy as np
from math import radians
from numpy.testing import assert_almost_equal

uradians = np.frompyfunc(radians, 1, 1)
uradians(1)
```
