### PR TITLE
DOC: Update 1.10.x release notes.

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -53,7 +53,7 @@ Compatibility notes
 numpy version string
 ~~~~~~~~~~~~~~~~~~~~
 The numpy version string for development builds has been changed from
-``x.y.z.dev-githash`` to ``x.y.z.dev+githash`` (note the +) in order to comply
+``x.y.z.dev-githash`` to ``x.y.z.dev0+githash`` (note the +) in order to comply
 with PEP 440.
 
 relaxed stride checking


### PR DESCRIPTION
Version format was incorrect, was x.y.z.dev+githash instead of
x.y.z.dev0+githash

Needs a backport to 1.10.x
