### PR TITLE
DOC: fix var. reference in percentile docstring

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3411,7 +3411,7 @@ def percentile(a, q, axis=None, out=None,
     keepdims : bool, optional
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
-        the result will broadcast correctly against the original `arr`.
+        the result will broadcast correctly against the original array `a`.
 
         .. versionadded:: 1.9.0
 


### PR DESCRIPTION
The argument for the original input array is named `a`
but in the docstring it was at some point referred to as `arr`.

[skip ci]
