### PR TITLE
DEV: add CC-0 public domain dedication to governance document

### DIFF
--- a/doc/source/dev/governance/governance.rst
+++ b/doc/source/dev/governance/governance.rst
@@ -389,3 +389,12 @@ Acknowledgements
 Substantial portions of this document were adapted from the
 `Jupyter/IPython project's governance document
 <https://github.com/jupyter/governance/blob/master/governance.md>`_.
+
+License
+=======
+
+To the extent possible under law, the authors have waived all
+copyright and related or neighboring rights to the NumPy project
+governance and decision-making document, as per the `CC-0 public
+domain dedication / license
+<https://creativecommons.org/publicdomain/zero/1.0/>`_.


### PR DESCRIPTION
We want to allow other projects to steal from us, like we stole from
Jupyter/IPython :-). This relicensing / public domain dedication is
possible because all text here is either by me (and thus copyright me)
or else taken from the Jupyter/IPython document, and their document is
also under CC-0 as per https://github.com/jupyter/governance/pull/9
