### PR TITLE
BUG: mask nan to 1 in ordered compare

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -536,11 +536,13 @@ sse2_compress4_to_byte_@TYPE@(@vtype@ r1, @vtype@ r2, @vtype@ r3, @vtype@ * r4,
 static NPY_INLINE int
 sse2_ordered_cmp_@kind@_@TYPE@(const @type@ a, const @type@ b)
 {
+    @vtype@ one = @vpre@_set1_@vsuf@(1);
     @type@ tmp;
     @vtype@ v = @vpre@_@VOP@_@vsufs@(@vpre@_load_@vsufs@(&a),
                                      @vpre@_load_@vsufs@(&b));
+    v = @vpre@_and_@vsuf@(v, one);
     @vpre@_store_@vsufs@(&tmp, v);
-    return !(tmp == 0.);
+    return tmp;
 }
 
 static void


### PR DESCRIPTION
msvc2008 32 bit seems to miscompile it otherwise.
closes gh-6428
