### PR TITLE
BLD: enable SSE2 for 32-bit msvc 9 and 10 compilers

### DIFF
--- a/numpy/distutils/msvccompiler.py
+++ b/numpy/distutils/msvccompiler.py
@@ -2,6 +2,8 @@ import os
 import distutils.msvccompiler
 from distutils.msvccompiler import *
 
+from .system_info import platform_bits
+
 
 class MSVCCompiler(distutils.msvccompiler.MSVCCompiler):
     def __init__(self, verbose=0, dry_run=0, force=0):
@@ -15,3 +17,6 @@ class MSVCCompiler(distutils.msvccompiler.MSVCCompiler):
             os.environ['lib'] = environ_lib + os.environ['lib']
         if environ_include is not None:
             os.environ['include'] = environ_include + os.environ['include']
+        if platform_bits == 32:
+            self.compile_options += ['/arch:SSE2']
+            self.compile_options_debug += ['/arch:SSE2']


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/6428
