### PR TITLE
BLD: do not build exclusively for SSE4.2 processors

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -205,7 +205,7 @@ class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     version_match = simple_version_match(start='Intel\(R\).*?64,')
 
     def get_flags_arch(self):
-        return ['/QxSSE4.2']
+        return ['/QaxSSE4.2']
 
 
 if __name__ == '__main__':

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -78,7 +78,7 @@ if platform.system() == 'Windows':
             self.lib = self.find_exe('xilib')
             self.linker = self.find_exe('xilink')
             self.compile_options = ['/nologo', '/O3', '/MD', '/W3',
-                                    '/Qstd=c99', '/QxSSE4.2']
+                                    '/Qstd=c99', '/QaxSSE4.2']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
                                           '/Qstd=c99', '/Z7', '/D_DEBUG']
 


### PR DESCRIPTION
On Windows, the Intel C and Fortan compilers will generate specialized code to run exclusively on processors with SSE4.2. With this patch the Intel compilers will generate code specialized for SSE4.2 processors while also generating generic IA-32 instructions.

From the icl.exe command line help:

```
Qx<code>
          generate specialized code to run exclusively on processors
          indicated by <code> as described below

/Qax<code1>[,<code2>,...]
          generate code specialized for processors specified by <codes>
          while also generating generic IA-32 instructions.
          <codes> includes one or more of the following:
```
