### PR TITLE
Backport gh 6441

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -205,7 +205,7 @@ class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     version_match = simple_version_match(start='Intel\(R\).*?64,')
 
     def get_flags_arch(self):
-        return ['/QxSSE4.2']
+        return ['/QaxSSE4.2']
 
 
 if __name__ == '__main__':

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -78,7 +78,7 @@ if platform.system() == 'Windows':
             self.lib = self.find_exe('xilib')
             self.linker = self.find_exe('xilink')
             self.compile_options = ['/nologo', '/O3', '/MD', '/W3',
-                                    '/Qstd=c99', '/QxSSE4.2']
+                                    '/Qstd=c99', '/QaxSSE4.2']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
                                           '/Qstd=c99', '/Z7', '/D_DEBUG']
 


### PR DESCRIPTION
BLD: do not build exclusively for SSE4.2 processor

For Intel icc.
