### PR TITLE
Backport gh-6439: BLD: import setuptools to allow compile with VS2008 python2.7 sdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,8 +238,12 @@ def setup_package():
         FULLVERSION, GIT_REVISION = get_version_info()
         metadata['version'] = FULLVERSION
     else:
-        if len(sys.argv) >= 2 and sys.argv[1] == 'bdist_wheel':
-            # bdist_wheel needs setuptools
+        if (len(sys.argv) >= 2 and sys.argv[1] == 'bdist_wheel' or
+                sys.version_info[0] < 3 and sys.platform == "win32"):
+            # bdist_wheel and the MS python2.7 VS sdk needs setuptools
+            # the latter can also be triggered by (see python issue23246)
+            # SET DISTUTILS_USE_SDK=1
+            # SET MSSdk=1
             import setuptools
         from numpy.distutils.core import setup
         cwd = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Needed to build numpy with Microsoft Visual C++ Compiler for Python 2.7
Otherwise one gets an Unable to find vcvarsall.bat error

SET DISTUTILS_USE_SDK=1
SET MSSdk=1

triggers the same from distutils.
