### PR TITLE
DEP: Remove warning for `full` when dtype is set.

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -291,10 +291,10 @@ def full(shape, fill_value, dtype=None, order='C'):
 
     """
     a = empty(shape, dtype, order)
-    if array(fill_value).dtype != a.dtype:
+    if dtype is None and array(fill_value).dtype != a.dtype:
         warnings.warn(
-            "in the future, full(..., {0!r}) will return an array of {1!r}".
-            format(fill_value, array(fill_value).dtype), FutureWarning)
+            "in the future, full({0}, {1!r}) will return an array of {2!r}".
+            format(shape, fill_value, array(fill_value).dtype), FutureWarning)
     multiarray.copyto(a, fill_value, casting='unsafe')
     return a
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -10,8 +10,9 @@ import operator
 import warnings
 
 import numpy as np
-from numpy.testing import (run_module_suite, assert_raises,
-                           assert_warns, assert_array_equal, assert_)
+from numpy.testing import (
+    run_module_suite, assert_raises, assert_warns, assert_no_warnings,
+    assert_array_equal, assert_)
 
 
 class _DeprecationTestCase(object):
@@ -382,6 +383,7 @@ class TestFullDefaultDtype:
     def test_full_default_dtype(self):
         assert_warns(FutureWarning, np.full, 1, 1)
         assert_warns(FutureWarning, np.full, 1, None)
+        assert_no_warnings(np.full, 1, 1, float)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See @rkern's comment in #6382.
