### PR TITLE
API: Make datetime64 timezone naive

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -186,6 +186,10 @@ if the matrix product is between a matrix and its transpose, it will use
 
 **Note:** Requires the transposed and non-transposed matrices to share data.
 
+*np.testing.assert_warns* can now be used as a context manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This matches the behavior of ``assert_raises``.
+
 Changes
 =======
 Pyrex support was removed from ``numpy.distutils``.  The method

--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -7,6 +7,8 @@ This release supports Python 2.6 - 2.7 and 3.2 - 3.5.
 Highlights
 ==========
 
+* The datetime64 type is now timezone naive. See "datetime64 changes" below
+  for more details.
 
 Dropped Support
 ===============
@@ -24,6 +26,41 @@ Future Changes
 
 Compatibility notes
 ===================
+
+datetime64 changes
+~~~~~~~~~~~~~~~~~~
+
+In prior versions of NumPy the experimental datetime64 type always stored
+times in UTC. By default, creating a datetime64 object from a string or
+printing it would convert from or to local time::
+
+    # old behavior
+    >>>> np.datetime64('2000-01-01T00:00:00')
+    numpy.datetime64('2000-01-01T00:00:00-0800')  # note the timezone offset -08:00
+
+A concensus of datetime64 users agreed that this behavior is undesirable
+and at odds with how datetime64 is usually used (e.g., by pandas_). For
+most use cases, a timezone naive datetime type is preferred, similar to the
+``datetime.datetime`` type in the Python standard library. Accordingly,
+datetime64 no longer assumes that input is in local time, nor does it print
+local times::
+
+    >>>> np.datetime64('2000-01-01T00:00:00')
+    numpy.datetime64('2000-01-01T00:00:00')
+
+For backwards compatibility, datetime64 still parses timezone offsets, which
+it handles by converting to UTC. However, the resulting datetime is timezone
+naive::
+
+    >>> np.datetime64('2000-01-01T00:00:00-08')
+    DeprecationWarning: parsing timezone aware datetimes is deprecated; this will raise an error in the future
+    numpy.datetime64('2000-01-01T08:00:00')
+
+As a corollary to this change, we no longer prohibit casting between datetimes
+with date units and datetimes with timeunits. With timezone naive datetimes,
+the rule for casting from dates to times is no longer ambiguous.
+
+pandas_: http://pandas.pydata.org
 
 DeprecationWarning to error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -45,16 +45,10 @@ some additional SI-prefix seconds-based units.
     >>> np.datetime64('2005-02', 'D')
     numpy.datetime64('2005-02-01')
 
-    Using UTC "Zulu" time:
-
-    >>> np.datetime64('2005-02-25T03:30Z')
-    numpy.datetime64('2005-02-24T21:30-0600')
-
-    ISO 8601 specifies to use the local time zone
-    if none is explicitly given:
+    From a date and time:
 
     >>> np.datetime64('2005-02-25T03:30')
-    numpy.datetime64('2005-02-25T03:30-0600')
+    numpy.datetime64('2005-02-25T03:30')
 
 When creating an array of datetimes from a string, it is still possible
 to automatically select the unit from the inputs, by using the
@@ -99,23 +93,6 @@ because the moment of time is still being represented exactly.
 
     >>> np.datetime64('2010-03-14T15Z') == np.datetime64('2010-03-14T15:00:00.00Z')
     True
-
-An important exception to this rule is between datetimes with
-:ref:`date units <arrays.dtypes.dateunits>` and datetimes with
-:ref:`time units <arrays.dtypes.timeunits>`. This is because this kind
-of conversion generally requires a choice of timezone and
-particular time of day on the given date.
-
-.. admonition:: Example
-
-    >>> np.datetime64('2003-12-25', 's')
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    TypeError: Cannot parse "2003-12-25" as unit 's' using casting rule 'same_kind'
-
-    >>> np.datetime64('2003-12-25') == np.datetime64('2003-12-25T00Z')
-    False
-
 
 Datetime and Timedelta Arithmetic
 =================================
@@ -352,6 +329,41 @@ Some examples::
     weekmask = "Mon Tue Wed Thu Fri"
     # any amount of whitespace is allowed; abbreviations are case-sensitive.
     weekmask = "MonTue Wed  Thu\tFri"
+
+Changes with NumPy 1.11
+=======================
+
+In prior versions of NumPy, the datetime64 type always stored
+times in UTC. By default, creating a datetime64 object from a string or
+printing it would convert from or to local time::
+
+    # old behavior
+    >>>> np.datetime64('2000-01-01T00:00:00')
+    numpy.datetime64('2000-01-01T00:00:00-0800')  # note the timezone offset -08:00
+
+A concensus of datetime64 users agreed that this behavior is undesirable
+and at odds with how datetime64 is usually used (e.g., by pandas_). For
+most use cases, a timezone naive datetime type is preferred, similar to the
+``datetime.datetime`` type in the Python standard library. Accordingly,
+datetime64 no longer assumes that input is in local time, nor does it print
+local times::
+
+    >>>> np.datetime64('2000-01-01T00:00:00')
+    numpy.datetime64('2000-01-01T00:00:00')
+
+For backwards compatibility, datetime64 still parses timezone offsets, which
+it handles by converting to UTC. However, the resulting datetime is timezone
+naive::
+
+    >>> np.datetime64('2000-01-01T00:00:00-08')
+    DeprecationWarning: parsing timezone aware datetimes is deprecated; this will raise an error in the future
+    numpy.datetime64('2000-01-01T08:00:00')
+
+As a corollary to this change, we no longer prohibit casting between datetimes
+with date units and datetimes with timeunits. With timezone naive datetimes,
+the rule for casting from dates to times is no longer ambiguous.
+
+pandas_: http://pandas.pydata.org
 
 Differences Between 1.6 and 1.7 Datetimes
 =========================================

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -708,9 +708,9 @@ class ComplexFormat(object):
             i = i + 'j'
         return r + i
 
+
 class DatetimeFormat(object):
-    def __init__(self, x, unit=None,
-                timezone=None, casting='same_kind'):
+    def __init__(self, x, unit=None, timezone=None, casting='same_kind'):
         # Get the unit from the dtype
         if unit is None:
             if x.dtype.kind == 'M':
@@ -718,15 +718,9 @@ class DatetimeFormat(object):
             else:
                 unit = 's'
 
-        # If timezone is default, make it 'local' or 'UTC' based on the unit
         if timezone is None:
-            # Date units -> UTC, time units -> local
-            if unit in ('Y', 'M', 'W', 'D'):
-                self.timezone = 'UTC'
-            else:
-                self.timezone = 'local'
-        else:
-            self.timezone = timezone
+            timezone = 'naive'
+        self.timezone = timezone
         self.unit = unit
         self.casting = casting
 

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -1316,9 +1316,6 @@ datetime_metadata_divides(
 
 /*
  * This provides the casting rules for the DATETIME data type units.
- *
- * Notably, there is a barrier between 'date units' and 'time units'
- * for all but 'unsafe' casting.
  */
 NPY_NO_EXPORT npy_bool
 can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
@@ -1331,31 +1328,26 @@ can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
             return 1;
 
         /*
-         * Only enforce the 'date units' vs 'time units' barrier with
-         * 'same_kind' casting.
+         * Can cast between all units with 'same_kind' casting.
          */
         case NPY_SAME_KIND_CASTING:
             if (src_unit == NPY_FR_GENERIC || dst_unit == NPY_FR_GENERIC) {
                 return src_unit == NPY_FR_GENERIC;
             }
             else {
-                return (src_unit <= NPY_FR_D && dst_unit <= NPY_FR_D) ||
-                       (src_unit > NPY_FR_D && dst_unit > NPY_FR_D);
+                return 1;
             }
 
         /*
-         * Enforce the 'date units' vs 'time units' barrier and that
-         * casting is only allowed towards more precise units with
-         * 'safe' casting.
+         * Casting is only allowed towards more precise units with 'safe'
+         * casting.
          */
         case NPY_SAFE_CASTING:
             if (src_unit == NPY_FR_GENERIC || dst_unit == NPY_FR_GENERIC) {
                 return src_unit == NPY_FR_GENERIC;
             }
             else {
-                return (src_unit <= dst_unit) &&
-                       ((src_unit <= NPY_FR_D && dst_unit <= NPY_FR_D) ||
-                        (src_unit > NPY_FR_D && dst_unit > NPY_FR_D));
+                return (src_unit <= dst_unit);
             }
 
         /* Enforce equality with 'no' or 'equiv' casting */
@@ -2254,6 +2246,14 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
             PyObject *offset;
             int seconds_offset, minutes_offset;
 
+            /* 2016-01-14, 1.11 */
+            PyErr_Clear();
+            if (DEPRECATE(
+                    "parsing timezone aware datetimes is deprecated; "
+                    "this will raise an error in the future") < 0) {
+                return -1;
+            }
+
             /* The utcoffset function should return a timedelta */
             offset = PyObject_CallMethod(tmp, "utcoffset", "O", obj);
             if (offset == NULL) {
@@ -2386,7 +2386,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
         /* Parse the ISO date */
         if (parse_iso_8601_datetime(str, len, meta->base, casting,
-                                &dts, NULL, &bestunit, NULL) < 0) {
+                                &dts, &bestunit, NULL) < 0) {
             Py_DECREF(bytes);
             return -1;
         }
@@ -3500,7 +3500,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
 
                 tmp_meta.base = -1;
                 if (parse_iso_8601_datetime(tmp_buffer, maxlen, -1,
-                                    NPY_UNSAFE_CASTING, &dts, NULL,
+                                    NPY_UNSAFE_CASTING, &dts,
                                     &tmp_meta.base, NULL) < 0) {
                     goto fail;
                 }
@@ -3509,7 +3509,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
             else {
                 tmp_meta.base = -1;
                 if (parse_iso_8601_datetime(data, tmp - data, -1,
-                                    NPY_UNSAFE_CASTING, &dts, NULL,
+                                    NPY_UNSAFE_CASTING, &dts,
                                     &tmp_meta.base, NULL) < 0) {
                     goto fail;
                 }

--- a/numpy/core/src/multiarray/datetime_strings.h
+++ b/numpy/core/src/multiarray/datetime_strings.h
@@ -23,10 +23,6 @@
  *           to be cast to the 'unit' parameter.
  *
  * 'out' gets filled with the parsed date-time.
- * 'out_local' gets set to 1 if the parsed time was in local time,
- *      to 0 otherwise. The values 'now' and 'today' don't get counted
- *      as local, and neither do UTC +/-#### timezone offsets, because
- *      they aren't using the computer's local timezone offset.
  * 'out_bestunit' gives a suggested unit based on the amount of
  *      resolution provided in the string, or -1 for NaT.
  * 'out_special' gets set to 1 if the parsed time was 'today',
@@ -41,7 +37,6 @@ parse_iso_8601_datetime(char *str, Py_ssize_t len,
                     NPY_DATETIMEUNIT unit,
                     NPY_CASTING casting,
                     npy_datetimestruct *out,
-                    npy_bool *out_local,
                     NPY_DATETIMEUNIT *out_bestunit,
                     npy_bool *out_special);
 
@@ -76,7 +71,7 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  */
 NPY_NO_EXPORT int
 make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
-                    int local, NPY_DATETIMEUNIT base, int tzoffset,
+                    int local, int utc, NPY_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting);
 
 /*

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -868,7 +868,7 @@ _strided_to_strided_datetime_to_string(char *dst, npy_intp dst_stride,
          * to use PyErr_Occurred().
          */
         make_iso_8601_datetime(&dts, dst, dst_itemsize,
-                                0, d->src_meta.base, -1,
+                                0, 0, d->src_meta.base, -1,
                                 NPY_UNSAFE_CASTING);
 
         dst += dst_stride;
@@ -901,7 +901,7 @@ _strided_to_strided_string_to_datetime(char *dst, npy_intp dst_stride,
 
             if (parse_iso_8601_datetime(tmp_buffer, src_itemsize,
                                     d->dst_meta.base, NPY_SAME_KIND_CASTING,
-                                    &dts, NULL, NULL, NULL) < 0) {
+                                    &dts, NULL, NULL) < 0) {
                 dt = NPY_DATETIME_NAT;
             }
         }
@@ -909,7 +909,7 @@ _strided_to_strided_string_to_datetime(char *dst, npy_intp dst_stride,
         else {
             if (parse_iso_8601_datetime(src, tmp - src,
                                     d->dst_meta.base, NPY_SAME_KIND_CASTING,
-                                    &dts, NULL, NULL, NULL) < 0) {
+                                    &dts, NULL, NULL) < 0) {
                 dt = NPY_DATETIME_NAT;
             }
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -647,7 +647,6 @@ datetimetype_repr(PyObject *self)
     npy_datetimestruct dts;
     PyObject *ret;
     char iso[NPY_DATETIME_MAX_ISO8601_STRLEN];
-    int local;
     NPY_DATETIMEUNIT unit;
 
     if (!PyArray_IsScalar(self, Datetime)) {
@@ -663,16 +662,8 @@ datetimetype_repr(PyObject *self)
         return NULL;
     }
 
-    local = (scal->obmeta.base > NPY_FR_D);
-    /*
-     * Because we're defaulting to local time, display hours with
-     * minutes precision, so that 30-minute timezone offsets can work.
-     */
     unit = scal->obmeta.base;
-    if (unit == NPY_FR_h) {
-        unit = NPY_FR_m;
-    }
-    if (make_iso_8601_datetime(&dts, iso, sizeof(iso), local,
+    if (make_iso_8601_datetime(&dts, iso, sizeof(iso), 0, 0,
                             unit, -1, NPY_SAFE_CASTING) < 0) {
         return NULL;
     }
@@ -758,7 +749,6 @@ datetimetype_str(PyObject *self)
     PyDatetimeScalarObject *scal;
     npy_datetimestruct dts;
     char iso[NPY_DATETIME_MAX_ISO8601_STRLEN];
-    int local;
     NPY_DATETIMEUNIT unit;
 
     if (!PyArray_IsScalar(self, Datetime)) {
@@ -774,16 +764,8 @@ datetimetype_str(PyObject *self)
         return NULL;
     }
 
-    local = (scal->obmeta.base > NPY_FR_D);
-    /*
-     * Because we're defaulting to local time, display hours with
-     * minutes precision, so that 30-minute timezone offsets can work.
-     */
     unit = scal->obmeta.base;
-    if (unit == NPY_FR_h) {
-        unit = NPY_FR_m;
-    }
-    if (make_iso_8601_datetime(&dts, iso, sizeof(iso), local,
+    if (make_iso_8601_datetime(&dts, iso, sizeof(iso), 0, 0,
                             unit, -1, NPY_SAFE_CASTING) < 0) {
         return NULL;
     }

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -465,6 +465,21 @@ class TestWarns(unittest.TestCase):
         assert_equal(before_filters, after_filters,
                      "assert_warns does not preserver warnings state")
 
+    def test_context_manager(self):
+
+        before_filters = sys.modules['warnings'].filters[:]
+        with assert_warns(UserWarning):
+            warnings.warn("yo")
+        after_filters = sys.modules['warnings'].filters
+
+        def no_warnings():
+            with assert_no_warnings():
+                warnings.warn("yo")
+
+        assert_raises(AssertionError, no_warnings)
+        assert_equal(before_filters, after_filters,
+                     "assert_warns does not preserver warnings state")
+
     def test_warn_wrong_warning(self):
         def f():
             warnings.warn("yo", DeprecationWarning)

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1736,6 +1736,8 @@ def assert_warns(warning_class, *args, **kwargs):
         with assert_warns(SomeWarning):
             do_something()
 
+    The ability to be used as a context manager is new in NumPy v1.11.0.
+
     .. versionadded:: 1.4.0
 
     Parameters
@@ -1782,6 +1784,8 @@ def assert_no_warnings(*args, **kwargs):
 
         with assert_no_warnings():
             do_something()
+
+    The ability to be used as a context manager is new in NumPy v1.11.0.
 
     .. versionadded:: 1.7.0
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1706,7 +1706,22 @@ class WarningManager(object):
         self._module.showwarning = self._showwarning
 
 
-def assert_warns(warning_class, func, *args, **kw):
+@contextlib.contextmanager
+def _assert_warns_context(warning_class, name=None):
+    __tracebackhide__ = True  # Hide traceback for py.test
+    with warnings.catch_warnings(record=True) as l:
+        warnings.simplefilter('always')
+        yield
+        if not len(l) > 0:
+            name_str = " when calling %s" % name if name is not None else ""
+            raise AssertionError("No warning raised" + name_str)
+        if not l[0].category is warning_class:
+            name_str = "%s " % name if name is not None else ""
+            raise AssertionError("First warning %sis not a %s (is %s)"
+                                 % (name_str, warning_class, l[0]))
+
+
+def assert_warns(warning_class, *args, **kwargs):
     """
     Fail unless the given callable throws the specified warning.
 
@@ -1714,6 +1729,12 @@ def assert_warns(warning_class, func, *args, **kw):
     invoked with arguments args and keyword arguments kwargs.
     If a different type of warning is thrown, it will not be caught, and the
     test case will be deemed to have suffered an error.
+
+    If called with all arguments other than the warning class omitted, may be
+    used as a context manager:
+
+        with assert_warns(SomeWarning):
+            do_something()
 
     .. versionadded:: 1.4.0
 
@@ -1733,21 +1754,34 @@ def assert_warns(warning_class, func, *args, **kw):
     The value returned by `func`.
 
     """
+    if not args:
+        return _assert_warns_context(warning_class)
+
+    func = args[0]
+    args = args[1:]
+    with _assert_warns_context(warning_class, name=func.__name__):
+        return func(*args, **kwargs)
+
+
+@contextlib.contextmanager
+def _assert_no_warnings_context(name=None):
     __tracebackhide__ = True  # Hide traceback for py.test
     with warnings.catch_warnings(record=True) as l:
         warnings.simplefilter('always')
-        result = func(*args, **kw)
-        if not len(l) > 0:
-            raise AssertionError("No warning raised when calling %s"
-                    % func.__name__)
-        if not l[0].category is warning_class:
-            raise AssertionError("First warning for %s is not a "
-                    "%s( is %s)" % (func.__name__, warning_class, l[0]))
-    return result
+        yield
+        if len(l) > 0:
+            name_str = " when calling %s" % name if name is not None else ""
+            raise AssertionError("Got warnings%s: %s" % (name_str, l))
 
-def assert_no_warnings(func, *args, **kw):
+
+def assert_no_warnings(*args, **kwargs):
     """
     Fail if the given callable produces any warnings.
+
+    If called with all arguments omitted, may be used as a context manager:
+
+        with assert_no_warnings():
+            do_something()
 
     .. versionadded:: 1.7.0
 
@@ -1765,14 +1799,13 @@ def assert_no_warnings(func, *args, **kw):
     The value returned by `func`.
 
     """
-    __tracebackhide__ = True  # Hide traceback for py.test
-    with warnings.catch_warnings(record=True) as l:
-        warnings.simplefilter('always')
-        result = func(*args, **kw)
-        if len(l) > 0:
-            raise AssertionError("Got warnings when calling %s: %s"
-                    % (func.__name__, l))
-    return result
+    if not args:
+        return _assert_no_warnings_context()
+
+    func = args[0]
+    args = args[1:]
+    with _assert_no_warnings_context(name=func.__name__):
+        return func(*args, **kwargs)
 
 
 def _gen_alignment_data(dtype=float32, type='binary', max_size=24):


### PR DESCRIPTION
Fixes #3290

With apologies to @mwiebe, this rips out most of the time zone parsing from the datetime64 type.

I think we mostly sorted out the API design in [discussions last year](http://thread.gmane.org/gmane.comp.python.numeric.general/57184), but nonetheless I'll be posting this to the mailing list shortly to get feedback.

Old behavior:

```
# string parsing and printing defaults to your local timezone :(
>>> np.datetime64('2000-01-01T00')
numpy.datetime64('2000-01-01T00:00-0800','h')
```

New behavior:

```
# datetime64 is parsed and printed as timezone naive
>>> np.datetime64('2000-01-01T00')
numpy.datetime64('2000-01-01T00','h')

# you can still supply a timezone, but you get a deprecation warning
>>> np.datetime64('2000-01-01T00Z')
DeprecationWarning: parsing timezone aware datetimes is deprecated; this
will raise an error in the future
numpy.datetime64('2000-01-01T00','h')
```

Still be resolved: How should we handle the function `np.datetime_as_string`? As far as I can tell, it was never advertised in the public API and mostly exists for testing, but it still exists in the main numpy namespace :(. If we can remove it, then we can delete and simplify a lot more code related to timezone parsing and display. If not, we'll need to do a bit of work so we can distinguish between the string representations of timezone naive and UTC.

cc @PythonCHB @jreback
