### PR TITLE
TST: fix forgotten change of not creating errors from test warnings i 1.10.x

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -177,7 +177,7 @@ class NoseTester(object):
                 'pyrex_ext',
                 'swig_ext']
 
-    def __init__(self, package=None, raise_warnings="develop"):
+    def __init__(self, package=None, raise_warnings="release"):
         package_name = None
         if package is None:
             f = sys._getframe(1)


### PR DESCRIPTION
See https://github.com/numpy/numpy/blob/master/doc/HOWTO_RELEASE.rst.txt#handle-test-warnings

Closes https://github.com/scipy/scipy/issues/5331#issuecomment-147504218
