### PR TITLE
MAINT: Use Python 3.5 instead of 3.5-dev for travis 3.5 testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
-  - 3.5-dev
+  - 3.5
 matrix:
   include:
     - python: 3.3


### PR DESCRIPTION
Python 3.5 has been released, so update 3.5 testing version.
