### PR TITLE
Only set '-O2' as opt flags on is_not_win

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -217,9 +217,13 @@ class GnuFCompiler(FCompiler):
                 opt = ['-O2 -march=pentium4 -mtune=generic -mfpmath=sse -msse2'
                        ' -mlong-double-64 -mincoming-stack-boundary=2' 
                        ' -ffpe-summary=invalid,zero']
-            else:
+            elif is_win64():
                 opt = ['-O2 -march=x86-64 -DMS_WIN64 -mtune=generic -msse2'
                        ' -mlong-double-64 -ffpe-summary=invalid,zero']
+            else:
+                # Don't set opt on Linux and rely on CFLAGS of the
+                # distributions
+                opt = ['-O2']
         else:
             opt = ['-O2']
 


### PR DESCRIPTION
The current flags include '-march=x86-64', which causes build failures if e.g.
scipy is built on ARM. It would be better to rely on the default CFLAGS of the
linux distributions instead of adding more flags other than '-O2'.

Would something like the attached patch possible to not set any flags other than '-O2' on linux?
Or should the else part be a `is_win64` instead?
