### PR TITLE
backport 6472

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
   - 2.7
   - 3.2
   - 3.3
-  - 3.5-dev
+  - 3.4
+  - 3.5
 matrix:
   include:
     - python: 3.3


### PR DESCRIPTION
MAINT: Use Python 3.5 instead of 3.5-dev for travis 3.5 testing.

Python 3.5 has been released, so update 3.5 testing version.
