### PR TITLE
ENH: Add subok parameter to np.copy function

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1060,7 +1060,7 @@ def select(condlist, choicelist, default=0):
     return result
 
 
-def copy(a, order='K'):
+def copy(a, order='K', subok=False):
     """
     Return an array copy of the given object.
 
@@ -1075,6 +1075,9 @@ def copy(a, order='K'):
         as possible. (Note that this function and :meth:ndarray.copy are very
         similar, but have different default values for their order=
         arguments.)
+    subok : bool, optional
+        If True, then sub-classes will be passed-through, otherwise
+        the returned array will be forced to be a base-class array (default).
 
     Returns
     -------
@@ -1104,7 +1107,7 @@ def copy(a, order='K'):
     False
 
     """
-    return array(a, order=order, copy=True)
+    return array(a, order=order, subok=subok, copy=True)
 
 # Basic operations
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -85,6 +85,15 @@ class TestCopy(TestCase):
         assert_(not a_fort_copy.flags.c_contiguous)
         assert_(a_fort_copy.flags.f_contiguous)
 
+    def test_subok(self):
+        # Pass through sub-class when subok argument is True
+        # GH issue 3474
+        mx = np.ma.array([1, 2, 3])
+        assert np.ma.isMaskedArray(np.copy(mx, subok=True))
+        assert not np.ma.isMaskedArray(np.copy(mx, subok=False))
+        # default is to force base class
+        assert not np.ma.isMaskedArray(np.copy(mx))
+
 
 class TestAverage(TestCase):
 


### PR DESCRIPTION
The subok parameter determines if sub-classes are passed through.  Setting the argument to True will cause sub-classes, such as MaskedArrays, to be returned after copying.  The default, False, force the copy to be of the base-class, to maintain backwards compatibility.
