### PR TITLE
Fix use of __doc__ in setup.py for -OO mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ matrix:
       env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
     - python: 2.7
       env: USE_WHEEL=1
+    - python: 2.7
+      env: PYTHONOPTIMIZE=2
 before_install:
   - uname -a
   - free -m

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ basic linear algebra and random number generation.
 """
 from __future__ import division, print_function
 
-DOCLINES = __doc__.split("\n")
+DOCLINES = (__doc__ or '').split("\n")
 
 import os
 import sys


### PR DESCRIPTION
Currently setup will fail when using `pip install numpy` if the `-OO` flag is used (also enabled via `PYTHONOPTIMIZE=2`) because docstrings are stripped (which is the point of the mode).

Very minor change that allows the docstring to be missing for this case.
