### PR TITLE
Potential fix for #6462

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3339,7 +3339,7 @@ def _median(a, axis=None, out=None, overwrite_input=False):
         indexer[axis] = slice(index-1, index+1)
 
     # Check if the array contains any nan's
-    if np.issubdtype(a.dtype, np.inexact):
+    if np.issubdtype(a.dtype, np.inexact) and sz > 0:
         # warn and return nans like mean would
         rout = mean(part[indexer], axis=axis, out=out)
         part = np.rollaxis(part, axis, part.ndim)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2597,6 +2597,34 @@ class TestMedian(TestCase):
             assert_equal(np.median(a, (0, 2)), b)
             assert_equal(len(w), 1)
 
+    def test_empty(self):
+        # empty arrays
+        a = np.array([], dtype=float)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_equal(np.median(a), np.nan)
+            assert_(w[0].category is RuntimeWarning)
+
+        # multiple dimensions
+        a = np.array([], dtype=float, ndmin=3)
+        # no axis
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_equal(np.median(a), np.nan)
+            assert_(w[0].category is RuntimeWarning)
+
+        # axis 0 and 1
+        b = np.array([], dtype=float, ndmin=2)
+        assert_equal(np.median(a, axis=0), b)
+        assert_equal(np.median(a, axis=1), b)
+
+        # axis 2
+        b = np.array(np.nan, dtype=float, ndmin=2)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', RuntimeWarning)
+            assert_equal(np.median(a, axis=2), b)
+            assert_(w[0].category is RuntimeWarning)
+
     def test_object(self):
         o = np.arange(7.)
         assert_(type(np.median(o.astype(object))), float)


### PR DESCRIPTION
This fixes the IndexError when taking the median of an empty array in the new median implementation (#6462). Taking the median over an axis of size 0 now returns a NaN as it had in previous implementations instead of the IndexError.
