### PR TITLE
DOC: typo in arrays.interface.rst #6516

### DIFF
--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -310,7 +310,7 @@ Differences with Array interface (Version 2)
 ============================================
 
 The version 2 interface was very similar.  The differences were
-largely asthetic.  In particular:
+largely aesthetic.  In particular:
 
 1. The PyArrayInterface structure had no descr member at the end
    (and therefore no flag ARR_HAS_DESCR)


### PR DESCRIPTION
fixed typo on line 313 of arrays.interface.rst : asthetic --> a_e_sthetic.
