### PR TITLE
Revert 5614

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -152,38 +152,6 @@ is broken). gcc 4.4 will hopefully be able to run natively.
 This is the only tested way to get a numpy with a FULL blas/lapack (scipy
 does not work because of C++).
 
-Carl Kleffner's mingw-w64 toolchain
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Carl Kleffner has been working on mingw-w64 / OpenBLAS support and has put
-together toolchains for that option. The toolchains are available at 
-https://bitbucket.org/carlkl/mingw-w64-for-python/downloads. The site.cfg
-should be configured like so:
-
-   [openblas]
-   libraries = openblaspy
-   library_dirs = <openblaspath>/lib
-   include_dirs = <openblaspath>/include
-
-The libopenblaspy.dll from <openblaspath>/bin must be copied to numpy/core
-before the build. For this mingw-w64 toolchain manual creation of the python
-import libs is necessary, i.e.:
-
-   gendef python2.7.dll
-   dlltool -D python27.dll -d python27.def -l libpython27.dll.a
-   move libpython27.dll.a libs\libpython27.dll.a
-
-For python-2.6 up to python 3.2 use
-https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_win32_vc90.tar.xz
-or
-https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_amd64_vc90.tar.xz
-
-For python-3.3 and python-3.4 use
-https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_win32_vc100.tar.xz
-or
-https://bitbucket.org/carlkl/mingw-w64-for-python/downloads/mingwpy_amd64_vc100.tar.xz
- 
-
 MS compilers
 ------------
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4476,6 +4476,15 @@ PyMODINIT_FUNC initmultiarray(void) {
         goto err;
     }
 
+#if defined(MS_WIN64) && defined(__GNUC__)
+  PyErr_WarnEx(PyExc_Warning,
+        "Numpy built with MINGW-W64 on Windows 64 bits is experimental, " \
+        "and only available for \n" \
+        "testing. You are advised not to use it for production. \n\n" \
+        "CRASHES ARE TO BE EXPECTED - PLEASE REPORT THEM TO NUMPY DEVELOPERS",
+        1);
+#endif
+
     /* Initialize access to the PyDateTime API */
     numpy_pydatetime_import();
 

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -87,30 +87,17 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         elif self.linker_dll == 'gcc':
             self.linker = 'g++'
 
-        p = subprocess.Popen(['gcc', '--version'], shell=True,
-                             stdout=subprocess.PIPE)
-        out_string = p.stdout.read()
-        p.stdout.close()
+        # **changes: eric jones 4/11/01
+        # 1. Check for import library on Windows.  Build if it doesn't exist.
 
-        # Before build with MinGW-W64 generate the python import library
-        # with gendef and dlltool according to the MingW-W64 FAQ.
-        # Use the MinGW-W64 provided msvc runtime import libraries.
-        # Don't call build_import_library() and build_msvcr_library.
+        build_import_library()
 
-        if 'MinGW-W64' not in str(out_string):
-
-            # **changes: eric jones 4/11/01
-            # 1. Check for import library on Windows.  Build if it doesn't
-            # exist.
-            build_import_library()
-
-            # Check for custom msvc runtime library on Windows. Build if it
-            # doesn't exist.
-            msvcr_success = build_msvcr_library()
-            msvcr_dbg_success = build_msvcr_library(debug=True)
-            if msvcr_success or msvcr_dbg_success:
-                # add preprocessor statement for using customized msvcr lib
-                self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
+        # Check for custom msvc runtime library on Windows. Build if it doesn't exist.
+        msvcr_success = build_msvcr_library()
+        msvcr_dbg_success = build_msvcr_library(debug=True)
+        if msvcr_success or msvcr_dbg_success:
+            # add preprocessor statement for using customized msvcr lib
+            self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
 
         # Define the MSVC version as hint for MinGW
         msvcr_version = '0x%03i0' % int(msvc_runtime_library().lstrip('msvcr'))
@@ -131,12 +118,10 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             else:
                 # gcc-4 series releases do not support -mno-cygwin option
                 self.set_executables(
-                    compiler='gcc -march=x86-64 -mtune=generic -DMS_WIN64'
-                             ' -O2 -msse2 -Wall',
-                    compiler_so='gcc -march=x86-64 -mtune=generic -DMS_WIN64'
-                                ' -O2 -msse2 -Wall -Wstrict-prototypes',
-                    linker_exe='gcc',
-                    linker_so='gcc -shared -Wl,-gc-sections -Wl,-s')
+                    compiler='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall',
+                    compiler_so='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall -Wstrict-prototypes',
+                    linker_exe='gcc -g',
+                    linker_so='gcc -g -shared')
         else:
             if self.gcc_version <= "3.0.0":
                 self.set_executables(
@@ -154,21 +139,13 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
                     linker_exe='g++ -mno-cygwin',
                     linker_so='g++ -mno-cygwin -shared')
             else:
-                # gcc-4 series releases do not support -mno-cygwin option i686
-                # build needs '-mincoming-stack-boundary=2' due to ABI
-                # incompatibility to Win32 ABI
-                self.set_executables(
-                    compiler='gcc -O2 -march=core2 -mtune=generic'
-                             ' -mfpmath=sse -msse2'
-                             ' -mincoming-stack-boundary=2 -Wall',
-                    compiler_so='gcc -O2 -march=core2 -mtune=generic'
-                                ' -mfpmath=sse -msse2'
-                                ' -mincoming-stack-boundary=2 -Wall'
-                                ' -Wstrict-prototypes',
-                    linker_exe='g++ ',
-                    linker_so='g++ -shared -Wl,-gc-sections -Wl,-s')
-        # added for python2.3 support we can't pass it through set_executables
-        # because pre 2.2 would fail
+                # gcc-4 series releases do not support -mno-cygwin option
+                self.set_executables(compiler='gcc -O2 -Wall',
+                                     compiler_so='gcc -O2 -Wall -Wstrict-prototypes',
+                                     linker_exe='g++ ',
+                                     linker_so='g++ -shared')
+        # added for python2.3 support
+        # we can't pass it through set_executables because pre 2.2 would fail
         self.compiler_cxx = ['g++']
 
         # Maybe we should also append -mthreads, but then the finished dlls

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1751,24 +1751,6 @@ class openblas_lapack_info(openblas_info):
                 res = False
         finally:
             shutil.rmtree(tmpdir)
-        if sys.platform == 'win32' and not res:
-            c = distutils.ccompiler.new_compiler(compiler='mingw32')
-            tmpdir = tempfile.mkdtemp()
-            src = os.path.join(tmpdir, 'source.c')
-            out = os.path.join(tmpdir, 'a.out')
-            try:
-                with open(src, 'wt') as f:
-                    f.write(s)
-                obj = c.compile([src], output_dir=tmpdir)
-                try:
-                    c.link_executable(obj, out, libraries=info['libraries'],
-                                      library_dirs=info['library_dirs'],
-                                      extra_postargs=extra_args)
-                    res = True
-                except distutils.ccompiler.LinkError:
-                    res = False
-            finally:
-                shutil.rmtree(tmpdir)
         return res
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -707,7 +707,7 @@ class TestVectorize(TestCase):
         args = np.array([0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2 * np.pi])
         r1 = f(args)
         r2 = np.cos(args)
-        assert_array_almost_equal(r1, r2)
+        assert_array_equal(r1, r2)
 
     def test_keywords(self):
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -707,7 +707,7 @@ class TestVectorize(TestCase):
         args = np.array([0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2 * np.pi])
         r1 = f(args)
         r2 = np.cos(args)
-        assert_array_equal(r1, r2)
+        assert_array_almost_equal(r1, r2)
 
     def test_keywords(self):
 

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,6 @@ def setup_package():
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked},
-        package_data={'numpy.core': ['libopenblaspy.dll']},
     )
 
     # Run build


### PR DESCRIPTION
The preparations for mingwpy in #5614 cause problems on non-windows platforms. Revert them for numpy 1.10.2. See #6495 and #6473. 
