### PR TITLE
BUG: scalar argument to ma.atleast_* return arrays

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -270,6 +270,10 @@ class _fromnxfunction:
                 _d = func(tuple([np.asarray(a) for a in x]), **params)
                 _m = func(tuple([getmaskarray(a) for a in x]), **params)
                 return masked_array(_d, mask=_m)
+            else:
+                _d = func(np.asarray(x), **params)
+                _m = func(getmaskarray(x), **params)
+                return masked_array(_d, mask=_m)
         else:
             arrays = []
             args = list(args)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -23,11 +23,12 @@ from numpy.ma.core import (
     nomask, ones, zeros, count
     )
 from numpy.ma.extras import (
-    atleast_2d, mr_, dot, polyfit, cov, corrcoef, median, average, unique,
-    setxor1d, setdiff1d, union1d, intersect1d, in1d, ediff1d,
-    apply_over_axes, apply_along_axis, compress_nd, compress_rowcols,
+    atleast_1d, atleast_2d, atleast_3d, mr_, dot, polyfit, cov, corrcoef,
+    median, average, unique, setxor1d, setdiff1d, union1d, intersect1d, in1d,
+    ediff1d, apply_over_axes, apply_along_axis, compress_nd, compress_rowcols,
     mask_rowcols, clump_masked, clump_unmasked, flatnotmasked_contiguous,
-    notmasked_contiguous, notmasked_edges, masked_all, masked_all_like
+    notmasked_contiguous, notmasked_edges, masked_all, masked_all_like,
+    diagflat
     )
 import numpy.ma.extras as mae
 
@@ -1146,6 +1147,25 @@ class TestShapeBase(TestCase):
         assert_equal(b.mask.shape, b.data.shape)
         assert_equal(a.shape, (3,))
         assert_equal(a.mask.shape, a.data.shape)
+
+    def test_shape_scalar(self):
+        # the atleast and diagflat function should work with scalars
+        # GitHub issue #3367
+        b = atleast_1d(1.0)
+        assert_equal(b.shape, (1, ))
+        assert_equal(b.mask.shape, b.data.shape)
+
+        b = atleast_2d(1.0)
+        assert_equal(b.shape, (1, 1))
+        assert_equal(b.mask.shape, b.data.shape)
+
+        b = atleast_3d(1.0)
+        assert_equal(b.shape, (1, 1, 1))
+        assert_equal(b.mask.shape, b.data.shape)
+
+        b = diagflat(1.0)
+        assert_equal(b.shape, (1, 1))
+        assert_equal(b.mask.shape, b.data.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The np.ma.atleast_1d, np.ma.atleast_2d, np.ma.atleast_3d and np.ma.diagflat
function return arrays when given a scalar in the same manner as their non-ma
counterparts.  Previously these function would return None.

Additionally, the np.ma vstack, row_stack, hstack, column_stack, dstack, and
hsplit functions now raise an expection when given a scalar argument.

closes #3367
