### PR TITLE
EHN: Using in-mem temporary files rather than in-disk for building zip archive in _savez 

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import numpy as np
 import numpy.ma as ma
 from numpy.lib._iotools import ConverterError, ConversionWarning
+from numpy.lib.npyio import _savez, DeleteOnContextExitNamedTemporaryFile
 from numpy.compat import asbytes, bytes, unicode
 from numpy.ma.testutils import assert_equal
 from numpy.testing import (
@@ -302,6 +303,17 @@ class TestSavezLoad(RoundtripTest, TestCase):
             fp = data.zip.fp
             data.close()
             assert_(fp.closed)
+
+    def test_in_mem_tempfiles(self):
+        # Check _savez with in-mem temporary files.
+        a = np.array([[1, 2], [3, 4]], float)
+        b = np.array([[1 + 2j, 2 + 7j], [3 - 6j, 4 + 12j]], complex)
+        with DeleteOnContextExitNamedTemporaryFile(suffix='.npz') as fid:
+            _savez(file=fid.name, args=[], kwds={'a':a,'b':b},
+                   compress=False, disk_temp_files=False)
+            l = np.load(fid.name)
+            assert_equal(a, l['a'])
+            assert_equal(b, l['b'])
 
 
 class TestSaveTxt(TestCase):


### PR DESCRIPTION
Temporary files are used in the _savez function to stage data during
archiving. The choice is done through new keyword arg: disk_temp_files
If set to True, use in-disk temporary files (default_option).
If set to False, use in-mem temporary files.

Please note that the in-mem files are based on BytesIO.
In python2 BytesIO lacks getbuffer method which returns the content of
the file without copying it. Thus in python2, getvalue is used which is
less memory efficient. In python3 getbuffer is privileged.

This pull request is based on an other pull request #6545.
