### PR TITLE
Backport 6538: BUG: ma.masked_values does not shrink mask if requested

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1544,7 +1544,7 @@ def make_mask(m, copy=False, shrink=True, dtype=MaskType):
           dtype=[('man', '|b1'), ('mouse', '|b1')])
 
     """
-    if m is nomask:
+    if m is nomask and shrink:
         return nomask
     elif isinstance(m, ndarray):
         # We won't return after this point to make sure we can shrink the mask
@@ -2247,7 +2247,7 @@ def masked_values(x, value, rtol=1e-5, atol=1e-8, copy=True, shrink=True):
     else:
         condition = umath.equal(xnew, value)
         mask = nomask
-    mask = mask_or(mask, make_mask(condition, shrink=shrink))
+    mask = mask_or(mask, make_mask(condition, shrink=shrink), shrink=shrink)
     return masked_array(xnew, mask=mask, copy=copy, fill_value=value)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1109,6 +1109,11 @@ class TestMaskedArrayArithmetic(TestCase):
         a /= 1.
         assert_equal(a.mask, [0, 0, 0])
 
+    def test_noshink_on_creation(self):
+        # Check that the mask is not shrunk on array creation when not wanted
+        a = np.ma.masked_values([1., 2.5, 3.1], 1.5, shrink=False)
+        assert_equal(a.mask, [0, 0, 0])
+
     def test_mod(self):
         # Tests mod
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d


### PR DESCRIPTION
When called with the shrink parameter set to False, np.ma.masked_values
will create a False filled array mask and not shrink the mask.
Previously the mask would be shrunk to a single False scalar.

closes #2674
