### PR TITLE
DOC: clarify usage of 'argparse' return value (see #4724).

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -848,7 +848,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     -------
     index_array : ndarray, int
         Array of indices that sort `a` along the specified axis.
-        In other words, ``a[index_array]`` yields a sorted `a`.
+        If `a` is one-dimensional, ``a[index_array]`` yields a sorted `a`.
 
     See Also
     --------


### PR DESCRIPTION
In response to Ticket #4724, explain that the 'index_array' returned by
'argparse' can only be used to (directly) sort a one-dimensional input
array.  Replaces PR #6513.
