### PR TITLE
backport #6546

### DIFF
--- a/numpy/core/src/multiarray/cblasfuncs.c
+++ b/numpy/core/src/multiarray/cblasfuncs.c
@@ -674,8 +674,8 @@ fail:
  *
  * This is for use by PyArray_InnerProduct. It is assumed on entry that the
  * arrays ap1 and ap2 have a common data type given by typenum that is
- * float, double, cfloat, or cdouble and have dimension <= 2, and have the
- * contiguous flag set. The * __numpy_ufunc__ nonsense is also assumed to
+ * float, double, cfloat, or cdouble and have dimension <= 2.
+ * The * __numpy_ufunc__ nonsense is also assumed to
  * have been taken care of.
  */
 
@@ -688,6 +688,24 @@ cblas_innerproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2)
     PyArrayObject *ret = NULL;
     npy_intp dimensions[NPY_MAXDIMS];
     PyTypeObject *subtype;
+
+    /* assure contiguous arrays */
+    if (!PyArray_IS_C_CONTIGUOUS(ap1)) {
+        PyObject *op1 = PyArray_NewCopy(ap1, NPY_CORDER);
+        Py_DECREF(ap1);
+        ap1 = (PyArrayObject *)op1;
+        if (ap1 == NULL) {
+            goto fail;
+        }
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(ap2)) {
+        PyObject *op2 = PyArray_NewCopy(ap2, NPY_CORDER);
+        Py_DECREF(ap2);
+        ap2 = (PyArrayObject *)op2;
+        if (ap2 == NULL) {
+          goto fail;
+        }
+    }
 
     if (PyArray_NDIM(ap1) == 0 || PyArray_NDIM(ap2) == 0) {
         /* One of ap1 or ap2 is a scalar */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4619,6 +4619,22 @@ class TestInner(TestCase):
         p = np.inner(a, a)
         assert_almost_equal(p, 0, decimal=14)
 
+    def test_inner_product_with_various_contiguities(self):
+        # github issue 6532
+        for dt in np.typecodes['AllInteger'] + np.typecodes['AllFloat'] + '?':
+            # check an inner product involving a matrix transpose
+            A = np.array([[1, 2], [3, 4]], dtype=dt)
+            B = np.array([[1, 3], [2, 4]], dtype=dt)
+            C = np.array([1, 1], dtype=dt)
+            desired = np.array([4, 6], dtype=dt)
+            assert_equal(np.inner(A.T, C), desired)
+            assert_equal(np.inner(B, C), desired)
+            # check an inner product involving an aliased and reversed view
+            a = np.arange(5).astype(dt)
+            b = a[::-1]
+            desired = np.array(10, dtype=dt).item()
+            assert_equal(np.inner(b, a), desired)
+
 
 class TestSummarization(TestCase):
     def test_1d(self):


### PR DESCRIPTION
BUG: fix inner() by copying if needed to enforce contiguity
