### PR TITLE
MAINT: Ensure that loadtxt prints a better error

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -840,6 +840,9 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
     def pack_items(items, packing):
         """Pack items into nested lists based on re-packing info."""
+        if len(items) != len(packing):
+            raise ValueError("Cannot load file into a dtype "
+                             "with the wrong number of fields")
         if packing is None:
             return items[0]
         elif packing is tuple:


### PR DESCRIPTION
if field counts don't match.
resolves #6388 

Note that if 'items' is a generator, like in #6388 example code, 
then you will get an error stating that len() of NoneType doesn't 
work. (even if I put in a test for NoneType).

I didn't think that would be likely in actual code, hence this patch.
