### PR TITLE
BUG: error in broadcast_arrays with as_strided array

### DIFF
--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -390,6 +390,14 @@ def test_writeable():
     _, result = broadcast_arrays(0, original)
     assert_equal(result.flags.writeable, False)
 
+    # regresssion test for GH6491
+    shape = (2,)
+    strides = [0]
+    tricky_array = as_strided(np.array(0), shape, strides)
+    other = np.zeros((1,))
+    first, second = broadcast_arrays(tricky_array, other)
+    assert_(first.shape == second.shape)
+
 
 def test_reference_types():
     input_array = np.array('a', dtype=object)


### PR DESCRIPTION
Fixes #6491

nb. this is an awkward solution -- I don't really understand why it works. I suspect it is working around some quirks of the logic for  checking if arrays can be made writeable, which is [surprisingly convoluted](https://github.com/numpy/numpy/blob/2d899ea2301e155b06acf585020866ca1953bce5/numpy/core/src/multiarray/common.c#L723). Note, for example, that `base` on an array from `as_strided` is a `stride_tricks.DummyArray`.
