### PR TITLE
Backport #6558

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -100,6 +100,8 @@ upload:
 	    $(UPLOAD_DIR)/numpy-user-$(RELEASE).pdf
 	ssh $(USERNAME)@new.scipy.org mv $(UPLOAD_DIR)/numpy-html.zip \
 	    $(UPLOAD_DIR)/numpy-html-$(RELEASE).zip
+	ssh $(USERNAME)@new.scipy.org rm $(UPLOAD_DIR)/dist.tar.gz
+	ssh $(USERNAME)@new.scipy.org cp -r $(UPLOAD_DIR)/* /srv/docs_scipy_org/doc/numpy
 	ssh $(USERNAME)@new.scipy.org /srv/bin/fixperm-scipy_org.sh
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
 MAINT: minor update to "make upload" doc build command.

Ensure that http://docs.scipy.org/doc/numpy/reference/ also has the
content of the latest release.

[ci skip]
