### PR TITLE
BUG: Revert some import * fixes in f2py.

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -22,19 +22,13 @@ import copy
 import re
 import os
 import sys
-from .auxfuncs import (
-    debugcapi, dictappend, errmess, gentitle, getcallprotoargument,
-    getcallstatement, getfortranname, getpymethoddef, getrestdoc,
-    getusercode, getusercode1, hasinitvalue, hasnote, hasresultnote,
-    isarray, iscomplex, iscomplexarray, iscomplexfunction, isexternal,
-    isfunction, isintent_aux, isintent_callback, isintent_dict,
-    isintent_hide, isintent_in, isintent_inout, isintent_out, ismodule,
-    isoptional, isrequired, isscalar, isstring, isstringarray,
-    isstringfunction, issubroutine, l_and, l_not, l_or, outmess
-)
-
 from .crackfortran import markoutercomma
 from . import cb_rules
+
+# The eviroment provided by auxfuncs.py is needed for some calls to eval.
+# As the needed functions cannot be determined by static inspection of the
+# code, it is safest to use import * pending a major refactoring of f2py.
+from .auxfuncs import *
 
 __all__ = [
     'getctype', 'getstrlength', 'getarrdims', 'getpydocsign',

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -149,12 +149,11 @@ import copy
 import platform
 
 from . import __version__
-from .auxfuncs import (
-    errmess, hascommon, isdouble, iscomplex, isexternal, isinteger,
-    isintent_aux, isintent_c, isintent_callback, isintent_in,
-    isintent_inout, isintent_inplace, islogical, isoptional, isscalar,
-    isstring, isstringarray, l_or, show
-)
+
+# The eviroment provided by auxfuncs.py is needed for some calls to eval.
+# As the needed functions cannot be determined by static inspection of the
+# code, it is safest to use import * pending a major refactoring of f2py.
+from .auxfuncs import *
 
 
 f2py_version = __version__.version

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -21,14 +21,14 @@ f2py_version = 'See `f2py -v`'
 
 import numpy as np
 
-from .auxfuncs import (
-    applyrules, dictappend, hasbody, hasnote, isallocatable, isfunction,
-    isintent_hide, ismodule, isprivate, isroutine, isstringarray, l_or,
-    outmess
-)
 from . import capi_maps
 from . import func2subr
 from .crackfortran import undo_rmbadname, undo_rmbadname1
+
+# The eviroment provided by auxfuncs.py is needed for some calls to eval.
+# As the needed functions cannot be determined by static inspection of the
+# code, it is safest to use import * pending a major refactoring of f2py.
+from .auxfuncs import *
 
 options = {}
 


### PR DESCRIPTION
The files
- capi_maps.py
- crackfortran.py
- f90mod_rules.py

previously used `from .auxfuncs import *` and also called `eval`
without an explicit enviroment. An attempt to use explicit imports
led to errors, and because static code analysis in not sufficient
to determine what functions need to be imported, it is safest to
continue using `import *` pending a major refactoring of f2py.

Closes #6563.
