### PR TITLE
BUG: Fix for #6569, allowing build_ext --inplace

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -177,7 +177,8 @@ class NoseTester(object):
                 'swig_ext']
 
     def __init__(self, package=None, raise_warnings=None):
-        if raise_warnings is None and '.dev0' in np.__version__:
+        if raise_warnings is None and (
+                not hasattr(np, '__version__') or '.dev0' in np.__version__):
             raise_warnings = "develop"
         elif raise_warnings is None:
             raise_warnings = "release"


### PR DESCRIPTION
Fix for #6569, as discussed in the comments.

This does not test for reoccurence of this bug, or a similar one. To do so, I imagine we'd have to modify `travis.yml` or `travis-test.sh` to call `python setup.py build_ext --inplace`. Should I do that?

CC @rgommers 
