### PR TITLE
MAINT: fix mistake in doc upload rule

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -101,7 +101,7 @@ upload:
 	ssh $(USERNAME)@new.scipy.org mv $(UPLOAD_DIR)/numpy-html.zip \
 	    $(UPLOAD_DIR)/numpy-html-$(RELEASE).zip
 	ssh $(USERNAME)@new.scipy.org rm $(UPLOAD_DIR)/dist.tar.gz
-	ssh $(USERNAME)@new.scipy.org cp -r $(UPLOAD_DIR)/* /srv/docs_scipy_org/doc/numpy
+	ssh $(USERNAME)@new.scipy.org ln -snf numpy-$(RELEASE) /srv/docs_scipy_org/doc/numpy
 	ssh $(USERNAME)@new.scipy.org /srv/bin/fixperm-scipy_org.sh
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Fix mistake in doc upload makefile rule. The current release is a symlink.
