### PR TITLE
BUG: immutable _arraymethod function in ma.core

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -401,6 +401,14 @@ class TestMaskedArray(TestCase):
         assert_not_equal(y._data.ctypes.data, x._data.ctypes.data)
         assert_not_equal(y._mask.ctypes.data, x._mask.ctypes.data)
 
+    def test_copy_immutable(self):
+        # Tests that the copy method is immutable, GitHub issue #5247
+        a = np.ma.array([1, 2, 3])
+        b = np.ma.array([4, 5, 6])
+        a_copy_method = a.copy
+        b.copy
+        assert_equal(a_copy_method(), [1, 2, 3])
+
     def test_deepcopy(self):
         from copy import deepcopy
         a = array([0, 1, 2], mask=[False, True, False])


### PR DESCRIPTION
Replace the _arraymethod class in ma.core with a function factory which
returns class method wrappers around basic array methods. These methods are
bound to the MaskedArray instance and are immutable.

Previously _arraymethod was a class which would incorrectly operate on the
MaskedArray object which last accessed the particular named function.

closes #5247
