### PR TITLE
DEP: Remove split `FutureWarning` for empty arrays in the result.

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -20,7 +20,8 @@ Highlights
 * Addition of `nanprod` to the set of nanfunctions.
 * Support for the '@' operator in Python 3.5.
 
-Dropped Support:
+Dropped Support
+===============
 
 * The _dotblas module has been removed. CBLAS Support is now in
   Multiarray.
@@ -35,15 +36,22 @@ Dropped Support:
 * Keywords ``skiprows`` and ``missing`` removed from np.genfromtxt.
 * Keyword ``old_behavior`` removed from np.correlate.
 
-Future Changes:
+Future Changes
+==============
 
 * In array comparisons like ``arr1 == arr2``, many corner cases
   involving strings or structured dtypes that used to return scalars
   now issue ``FutureWarning`` or ``DeprecationWarning``, and in the
   future will be change to either perform elementwise comparisons or
   raise an error.
-* The SafeEval class will be removed.
-* The alterdot and restoredot functions will be removed.
+* In ``np.lib.split`` an empty array in the result always had dimension
+  ``(0,)`` no matter the dimensions of the array being split. In Numpy 1.11
+  that behavior will be changed so that the dimensions will be preserved. A
+  ``FutureWarning`` for this change has been in place since Numpy 1.9 but,
+  due to a bug, sometimes no warning was raised and the dimensions were
+  already preserved.
+* The SafeEval class will be removed in Numpy 1.11.
+* The alterdot and restoredot functions will be removed in Numpy 1.11.
 
 See below for more details on these changes.
 

--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -8,20 +8,22 @@ Highlights
 ==========
 
 
-Dropped Support:
+Dropped Support
+===============
 
 * Bento build support and related files have been removed.
 * Single file build support and related files have been removed.
 
 
-Future Changes:
+Future Changes
+==============
 
 
 Compatibility notes
 ===================
 
-Deprecated to error
-~~~~~~~~~~~~~~~~~~~
+DeprecationWarning to error
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Indexing with floats raises IndexError,
   e.g., a[0, 0.0].
@@ -34,6 +36,15 @@ Deprecated to error
 * Non-integers used as index values raise TypeError,
   e.g., in reshape, take, and specifying reduce axis.
 
+FutureWarning to changed behavior 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* In ``np.lib.split`` an empty array in the result always had dimension
+  ``(0,)`` no matter the dimensions of the array being split. This
+  has been changed so that the dimensions will be preserved. A
+  ``FutureWarning`` for this change has been in place since Numpy 1.9 but,
+  due to a bug, sometimes no warning was raised and the dimensions were
+  already preserved.
 
 C API
 ~~~~~

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -421,17 +421,8 @@ def array_split(ary, indices_or_sections, axis=0):
         end = div_points[i + 1]
         sub_arys.append(_nx.swapaxes(sary[st:end], axis, 0))
 
-    # This "kludge" was introduced here to replace arrays shaped (0, 10)
-    # or similar with an array shaped (0,).
-    # There seems no need for this, so give a FutureWarning to remove later.
-    if any(arr.size == 0 and arr.ndim != 1 for arr in sub_arys):
-        warnings.warn("in the future np.array_split will retain the shape of "
-                      "arrays with a zero size, instead of replacing them by "
-                      "`array([])`, which always has a shape of (0,).",
-                      FutureWarning)
-        sub_arys = _replace_zero_by_x_arrays(sub_arys)
-
     return sub_arys
+
 
 def split(ary,indices_or_sections,axis=0):
     """

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -103,21 +103,17 @@ class TestArraySplit(TestCase):
 
     def test_integer_split_2D_rows(self):
         a = np.array([np.arange(10), np.arange(10)])
-        res = assert_warns(FutureWarning, array_split, a, 3, axis=0)
-
-        # After removing the FutureWarning, the last should be zeros((0, 10))
-        desired = [np.array([np.arange(10)]), np.array([np.arange(10)]),
-                   np.array([])]
-        compare_results(res, desired)
+        res = array_split(a, 3, axis=0)
+        tgt = [np.array([np.arange(10)]), np.array([np.arange(10)]),
+                   np.zeros((0, 10))]
+        compare_results(res, tgt)
         assert_(a.dtype.type is res[-1].dtype.type)
 
         # Same thing for manual splits:
-        res = assert_warns(FutureWarning, array_split, a, [0, 1, 2], axis=0)
-
-        # After removing the FutureWarning, the last should be zeros((0, 10))
-        desired = [np.array([]), np.array([np.arange(10)]),
-                   np.array([np.arange(10)])]
-        compare_results(res, desired)
+        res = array_split(a, [0, 1, 2], axis=0)
+        tgt = [np.zeros((0, 10)), np.array([np.arange(10)]),
+               np.array([np.arange(10)])]
+        compare_results(res, tgt)
         assert_(a.dtype.type is res[-1].dtype.type)
 
     def test_integer_split_2D_cols(self):
@@ -132,12 +128,10 @@ class TestArraySplit(TestCase):
         """ This will fail if we change default axis
         """
         a = np.array([np.arange(10), np.arange(10)])
-        res = assert_warns(FutureWarning, array_split, a, 3)
-
-        # After removing the FutureWarning, the last should be zeros((0, 10))
-        desired = [np.array([np.arange(10)]), np.array([np.arange(10)]),
-                   np.array([])]
-        compare_results(res, desired)
+        res = array_split(a, 3)
+        tgt = [np.array([np.arange(10)]), np.array([np.arange(10)]),
+                   np.zeros((0, 10))]
+        compare_results(res, tgt)
         assert_(a.dtype.type is res[-1].dtype.type)
         # perhaps should check higher dimensions
 


### PR DESCRIPTION
DEP: Remove FutureWarning from np.lib.split and go to future.

Previously an empty array resulting from split always had dimension 1-D.
In Numpy 1.9 a FutureWarning was raised to notify users that it was
planned to preserve the dimensions of empty arrays in a future numpy
release. This removes the FutureWarning and implements preservation of
dimensions.

Note that there was a bug in numpy 1.9 and the dimensions of empty
arrays was already preserved in some cases and no warning was issued.
This PR fixes that inconsistency by preserving the dimensions in all
cases rather than fixing the bug, as the dimension preserving behavior
was already depended on by some users. See the discussion in gh-6575
about this change.
