### PR TITLE
DOC: Fix an argument in 'Numpy for Matlab Users'.

### DIFF
--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -237,7 +237,7 @@ General Purpose Equivalents
      - ``scipy.integrate.ode(f).set_integrator('dopri5')``
      - integrate an ODE with Runge-Kutta 4,5
    * - ``ode15s``
-     - ``scipy.integrate.ode(f).set_integrator('vode', method='bdf', order=15)``
+     - ``scipy.integrate.ode(f).set_integrator('vode', method='bdf', order=5)``
      - integrate an ODE with BDF method
 
 Linear Algebra Equivalents


### PR DESCRIPTION
I've seen at least three occurrences (a couple on stackoverflow, and one
private email) of someone using the argument 'order=15' in a call to the
'set_integrator' method of 'scipy.integrate.ode'.  Presumably this is
because of the suggestion in the "NumPy for Matlab Users" guide to
replace 'ode15s' with 'scipy.integrate.ode(f).set_integrator('vode',
method='bdf', order=15)'.  The stiff solver in 'vode'--presumably the
solver of interest for someone using 'ode15s'--has a maximum order of 5,
and the non-stiff solver has maximum order of 12.  (The maximum order of
'ode15s' is also 5; the '15' in the name refers to the variable order
ranging from 1 to 5.)
