### PR TITLE
unweighted histogram with 2+ dimensions should return array with int dtype

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -611,10 +611,16 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
             # Shift these points one bin to the left.
             Ncount[i][where(on_edge & not_smaller_than_edge)[0]] -= 1
 
+    # Histogram is an integer or a float array depending on the weights.
+    if weights is None:
+        ntype = np.dtype(np.intp)
+    else:
+        ntype = weights.dtype
+
     # Flattened histogram matrix (1D)
     # Reshape is used so that overlarge arrays
     # will raise an error.
-    hist = zeros(nbin, float).reshape(-1)
+    hist = zeros(nbin, ntype).reshape(-1)
 
     # Compute the sample indices in the flattened histogram matrix.
     ni = nbin.argsort()


### PR DESCRIPTION
n-d histogram operations `np.histogram2d()` and `np.histogramdd()` return the result always in a `float` dtype. Like `np.histogram()` also `np.histogram2d()` and `np.histogramdd()` should return the result with the appropriate `dtype`. For unweighted operations (`weights=None`) this should be an integer type. (Not sure about `normed` kwarg which I never used and which also influences the appropriate dtype and is deprecated for 1-d histogram but not in n-d histograms -- at least according to docs.)

before:
![screenshot from 2015-10-31 16 24 22](https://cloud.githubusercontent.com/assets/1842780/10864376/90fde02e-7fec-11e5-9e69-8bd071f33994.png)

after:
![screenshot from 2015-10-31 16 24 32](https://cloud.githubusercontent.com/assets/1842780/10864377/952e4bfc-7fec-11e5-95a6-81ffca9d94eb.png)

n.b. `histogram()` even returns `int` dtype if `weights` are of `int` dtype. :+1: 

Side note: The most appropriate `dtype` for these result arrays would actually be an unsigned `uint` type (EDIT: at least for no weights and non-negative integer weights). But that only affects the maximum representable `int` value with same memory consumption and is far less important, than avoiding float issues, I guess. (same goes for e.g. `np.bincount(.., weights=None)` which returns `int` dtype and could also use an `uint` dtype)
