### PR TITLE
Fix swig for relaxed stride checking

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -6,9 +6,22 @@ adds various build and release improvements.
 
 Numpy 1.10.1 supports Python 2.6 - 2.7 and 3.2 - 3.5.
 
+
+Compatibility notes
+===================
+
+fix swig bug in ``numpy.i``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Relaxed stride checking revealed a bug in ``array_is_fortran(a)``, that was
+using PyArray_ISFORTRAN to check for Fortran contiguity instead of
+PyArray_IS_F_CONTIGUOUS. You may want to regenerate swigged files using the
+updated numpy.i
+
+
 Issues Fixed
 ============
 
+* gh-6590 Fortran Array problem in numpy 1.10.
 * gh-6563 Intent(out) broken in recent versions of f2py.
 * gh-6530 The partition function errors out on empty input.
 * gh-6498 Mention change in default casting rule in 1.10 release notes.
@@ -47,11 +60,16 @@ The following PRs in master have been backported to 1.10.2
 * gh-6562 BUG: Disable view safety checks in recarray.
 * gh-6567 BUG: Revert some import * fixes in f2py.
 * gh-6577 BUG: Fix for #6569, allowing build_ext --inplace
-* gh-6579 MAINT: Fix mistake in doc upload rule
+* gh-6579 MAINT: Fix mistake in doc upload rule.
+* gh-6596 BUG: Fix swig for relaxed stride checking.
 
 The following PR reverted initial work for mingwpy.
 
 * gh-6536 BUG: Revert gh-5614 to fix non-windows build problems
+
+And the this PR reverted a fix for np.lib.split that undid some behavior
+that will be standard in 1.11.
+
 * gh-6576 BUG: Revert gh-6376 to fix split behavior for empty arrays.
 
 Notes

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -696,8 +696,12 @@ def require(a, dtype=None, requirements=None):
 
 def isfortran(a):
     """
-    Returns True if array is arranged in Fortran-order in memory
-    and not C-order.
+    Returns True if the array is Fortran contiguous but *not* C contiguous.
+
+    This function is obsolete and, because of changes due to relaxed stride
+    checking, its return value for the same array may differ for versions
+    of Numpy >= 1.10 and previous versions. If you only want to check if an
+    array is Fortran contiguous use ``a.flags.f_contiguous`` instead.
 
     Parameters
     ----------

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -96,7 +96,7 @@
 %#endif
 %#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
 %#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
-%#define array_is_fortran(a)    (PyArray_ISFORTRAN((PyArrayObject*)a))
+%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 }
 
 /**********************************************************************/


### PR DESCRIPTION
Should fix #6590. The fix here is in two parts
- Use `PyArray_IS_F_CONTIGUOUS` in `array_is_fortran` in `numpy.i`.
- Change `isfortran` documentation to emphasize that it is not a check for Fortran contiguity.
- Warn about the fix to `numpy.i` in the 1.10.0 release notes.

Strictly speaking, the warning should probably be in the 1.10.2 release notes, but I figure more people will read the 1.10.0 release notes to check for changes than the notes for the later point releases. Feel free to argue the point ;)
