### PR TITLE
Backport 6596

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -6,17 +6,31 @@ adds various build and release improvements.
 
 Numpy 1.10.1 supports Python 2.6 - 2.7 and 3.2 - 3.5.
 
+
+Compatibility notes
+===================
+
+fix swig bug in ``numpy.i``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Relaxed stride checking revealed a bug in ``array_is_fortran(a)``, that was
+using PyArray_ISFORTRAN to check for Fortran contiguity instead of
+PyArray_IS_F_CONTIGUOUS. You may want to regenerate swigged files using the
+updated numpy.i
+
+
 Issues Fixed
 ============
 
-* gh-6563 Intent(out) broken in recent versions of f2py.
-* gh-6530 The partition function errors out on empty input.
-* gh-6498 Mention change in default casting rule in 1.10 release notes.
-* gh-6497 Failure of reduce operation on recarrays.
-* gh-6495 Unrecognized command line option '-ffpe-summary' in gfortran.
-* gh-6491 Error in broadcasting stride_tricks array.
-* gh-6467 Performance regression for record array access.
 * gh-6462 Median of empty array produces IndexError.
+* gh-6467 Performance regression for record array access.
+* gh-6491 Error in broadcasting stride_tricks array.
+* gh-6495 Unrecognized command line option '-ffpe-summary' in gfortran.
+* gh-6497 Failure of reduce operation on recarrays.
+* gh-6498 Mention change in default casting rule in 1.10 release notes.
+* gh-6530 The partition function errors out on empty input.
+* gh-6563 Intent(out) broken in recent versions of f2py.
+* gh-6575 BUG: Split produces empty arrays with wrong number of dimensions
+* gh-6590 Fortran Array problem in numpy 1.10.
 
 Merged PRs
 ==========
@@ -47,11 +61,19 @@ The following PRs in master have been backported to 1.10.2
 * gh-6562 BUG: Disable view safety checks in recarray.
 * gh-6567 BUG: Revert some import * fixes in f2py.
 * gh-6577 BUG: Fix for #6569, allowing build_ext --inplace
-* gh-6579 MAINT: Fix mistake in doc upload rule
+* gh-6579 MAINT: Fix mistake in doc upload rule.
+* gh-6596 BUG: Fix swig for relaxed stride checking.
 
-The following PR reverted initial work for mingwpy.
+Initial support for mingwpy was reverted as it was causing problems for
+non-windows builds.
 
-* gh-6536 BUG: revert gh-5614 to fix non-windows build problems
+* gh-6536 BUG: Revert gh-5614 to fix non-windows build problems
+
+A fix for np.lib.split was reverted because it resulted in "fixing"
+behavior will be present in the Numpy 1.11 and was already present in
+Numpy 1.9. See the discussion of the issue at gh-6575 for clarification.
+
+* gh-6576 BUG: Revert gh-6376 to fix split behavior for empty arrays.
 
 Notes
 =====

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -693,8 +693,12 @@ def require(a, dtype=None, requirements=None):
 
 def isfortran(a):
     """
-    Returns True if array is arranged in Fortran-order in memory
-    and not C-order.
+    Returns True if the array is Fortran contiguous but *not* C contiguous.
+
+    This function is obsolete and, because of changes due to relaxed stride
+    checking, its return value for the same array may differ for versions
+    of Numpy >= 1.10 and previous versions. If you only want to check if an
+    array is Fortran contiguous use ``a.flags.f_contiguous`` instead.
 
     Parameters
     ----------

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -96,7 +96,7 @@
 %#endif
 %#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
 %#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
-%#define array_is_fortran(a)    (PyArray_ISFORTRAN((PyArrayObject*)a))
+%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 }
 
 /**********************************************************************/


### PR DESCRIPTION
```
BUG: Fix use of PyArray_ISFORTRAN in numpy.i.

PyArray_ISFORTRAN was used to implement array_is_fortran in numpy.i when
what was wanted was PyArray_IS_F_CONTIGUOUS. The difference is that
PyArray_ISFORTRAN will return False if the array is c_contiguous.
Previous to relaxed stride checking this did not matter, but currently
arrays with ndim > 1 may be both C and Fortran contiguous and that
results in errors when PyArray_ISFORTRAN is mistakenly used to check for
Fortran contiguity.
```

[ci skip]
