### PR TITLE
MAINT: Add '0x' to API version error for clarity.

### DIFF
--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -84,13 +84,13 @@ _import_array(void)
   /* Perform runtime check of C API version */
   if (NPY_VERSION != PyArray_GetNDArrayCVersion()) {
       PyErr_Format(PyExc_RuntimeError, "module compiled against "\
-             "ABI version %%x but this version of numpy is %%x", \
+             "ABI version 0x%%x but this version of numpy is 0x%%x", \
              (int) NPY_VERSION, (int) PyArray_GetNDArrayCVersion());
       return -1;
   }
   if (NPY_FEATURE_VERSION > PyArray_GetNDArrayCFeatureVersion()) {
       PyErr_Format(PyExc_RuntimeError, "module compiled against "\
-             "API version %%x but this version of numpy is %%x", \
+             "API version 0x%%x but this version of numpy is 0x%%x", \
              (int) NPY_FEATURE_VERSION, (int) PyArray_GetNDArrayCFeatureVersion());
       return -1;
   }


### PR DESCRIPTION
This tiny change makes the error message for API version problems ~~use decimal, not hex.~~ [Edit: now just uses `0x` prefix for clarity.]  Otherwise, the error complains about `version 9` vs. `version a`, which isn't immediately clear:

```
RuntimeError: exceptions.RuntimeError: module compiled against API version a but this version of numpy is 9
```
