### PR TITLE
DOC: typo in the docstring of `random.multinomial`

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4460,8 +4460,21 @@ cdef class RandomState:
 
         A loaded dice is more likely to land on number 6:
 
-        >>> np.random.multinomial(100, [1/7.]*5)
-        array([13, 16, 13, 16, 42])
+        >>> np.random.multinomial(100, [1/7.]*5 + [2/7.])
+        array([11, 16, 14, 17, 16, 26])
+
+        The probability inputs should already be normalized. The value of the
+        last entry is always ignored and assumed to take up any leftover
+        probability mass. To sample a biased coin which has twice as much
+        weight on one side than the other should *not* be sampled like so:
+
+        >>> np.random.multinomial(100, [1.0, 2.0])  # WRONG
+        array([100,   0])
+
+        but rather, like so:
+
+        >>> np.random.multinomial(100, [1.0 / 3, 2.0 / 3])  # RIGHT
+        array([38, 62])
 
         """
         cdef npy_intp d


### PR DESCRIPTION
The last example in the docstring of np.random.multinomial is a bit confusing: it talks about a "loaded dice" but draws variates from a five-element distribution. 

It seems to me that the example was supposed to demonstrate the convention that the last element of the `pvals` array is modified to make the probabilities sum to one:

```
In [26]: rndm = np.random.RandomState(1234)

In [27]: rndm.multinomial(1000, [1/7.]*6)
Out[27]: array([137, 142, 148, 136, 164, 273])

In [28]: rndm = np.random.RandomState(1234)

In [29]: rndm.multinomial(1000, [1/7.]*5 + [2/7.])
Out[29]: array([137, 142, 148, 136, 164, 273])
```

Hence modify the docstring to match the code. 

[ci skip]
