### PR TITLE
MAINT: random: allow nonc==0 in noncentral_chisquare.

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -231,6 +231,9 @@ double rk_chisquare(rk_state *state, double df)
 
 double rk_noncentral_chisquare(rk_state *state, double df, double nonc)
 {
+    if (nonc == 0){
+        return rk_chisquare(state, df);
+    }
     if(1 < df)
     {
         const double Chi2 = rk_chisquare(state, df - 1);

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2219,7 +2219,7 @@ cdef class RandomState:
             Degrees of freedom, should be > 0 as of Numpy 1.10,
             should be > 1 for earlier versions.
         nonc : float
-            Non-centrality, should be > 0.
+            Non-centrality, should be non-negative.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  Default is None, in which case a
@@ -2285,8 +2285,8 @@ cdef class RandomState:
         if not PyErr_Occurred():
             if fdf <= 0:
                 raise ValueError("df <= 0")
-            if fnonc <= 0:
-                raise ValueError("nonc <= 0")
+            if fnonc < 0:
+                raise ValueError("nonc < 0")
             return cont2_array_sc(self.internal_state, rk_noncentral_chisquare,
                                   size, fdf, fnonc, self.lock)
 
@@ -2296,7 +2296,7 @@ cdef class RandomState:
         ononc = <ndarray>PyArray_FROM_OTF(nonc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
         if np.any(np.less_equal(odf, 0.0)):
             raise ValueError("df <= 0")
-        if np.any(np.less_equal(ononc, 0.0)):
+        if np.any(np.less(ononc, 0.0)):
             raise ValueError("nonc < 0")
         return cont2_array(self.internal_state, rk_noncentral_chisquare, size,
                            odf, ononc, self.lock)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -504,6 +504,13 @@ class TestRandomDist(TestCase):
                             [ 0.332334982684171  ,  0.15451287602753125]])
         np.testing.assert_array_almost_equal(actual, desired, decimal=14)
 
+        np.random.seed(self.seed)
+        actual = np.random.noncentral_chisquare(df=5, nonc=0, size=(3, 2))
+        desired = np.array([[9.597154162763948, 11.725484450296079],
+                            [10.413711048138335, 3.694475922923986],
+                            [13.484222138963087, 14.377255424602957]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+
     def test_noncentral_f(self):
         np.random.seed(self.seed)
         actual = np.random.noncentral_f(dfnum=5, dfden=2, nonc=1,


### PR DESCRIPTION
Noncentral chi-square reduces to a central chi-square for zero nonc, so just defer to that.

Backwards compatibility should be OK because previously nonc=0 was an error:

```
>>> np.__version__
'1.10.1'
>>> np.random.noncentral_chisquare(df=5, nonc=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mtrand.pyx", line 2280, in mtrand.RandomState.noncentral_chisquare (numpy/random/mtrand/mtrand.c:15876)
ValueError: nonc <= 0
```

(motivated by https://github.com/scipy/scipy/issues/5441)
