### PR TITLE
Backport 6621

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -32,6 +32,7 @@ Issues Fixed
 * gh-6575 BUG: Split produces empty arrays with wrong number of dimensions
 * gh-6590 Fortran Array problem in numpy 1.10.
 * gh-6602 Random __all__ missing choice and dirichlet.
+* gh-6618 NPY_FORTRANORDER in make_fortran() in numpy.i
 
 Merged PRs
 ==========
@@ -67,6 +68,7 @@ The following PRs in master have been backported to 1.10.2
 * gh-6596 BUG: Fix swig for relaxed stride checking.
 * gh-6606 DOC: Update 1.10.2 release notes.
 * gh-6614 BUG: Add choice and dirichlet to numpy.random.__all__.
+* gh-6621 BUG: Fix swig make_fortran function.
 
 Initial support for mingwpy was reverted as it was causing problems for
 non-windows builds.

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -295,7 +295,7 @@
       Py_INCREF(array_descr(ary));
       result = (PyArrayObject*) PyArray_FromArray(ary,
                                                   array_descr(ary),
-                                                  NPY_FORTRANORDER);
+                                                  NPY_ARRAY_F_CONTIGUOUS);
       *is_new_object = 1;
     }
     return result;


### PR DESCRIPTION
BUG: Fix swig make_fortran function.

The function was calling PyArray_FromArray with NPY_FORTRANORDER instead
of NPY_ARRAY_F_CONTIGUOUS. The first is of type NPY_ORDER and the second
is a flag.

Closes #6618. [ci skip]
