### PR TITLE
BUG: Make allclose return python bool.

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -33,6 +33,7 @@ Issues Fixed
 * gh-6590 Fortran Array problem in numpy 1.10.
 * gh-6602 Random __all__ missing choice and dirichlet.
 * gh-6618 NPY_FORTRANORDER in make_fortran() in numpy.i
+* gh-6475 np.allclose returns a memmap when one of its arguments is a memmap.
 
 Merged PRs
 ==========
@@ -69,6 +70,7 @@ The following PRs in master have been backported to 1.10.2
 * gh-6606 DOC: Update 1.10.2 release notes.
 * gh-6614 BUG: Add choice and dirichlet to numpy.random.__all__.
 * gh-6621 BUG: Fix swig make_fortran function.
+* gh-6628 BUG: Make allclose return python bool.
 
 Initial support for mingwpy was reverted as it was causing problems for
 non-windows builds.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2278,7 +2278,8 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     True
 
     """
-    return all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
+    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
+    return bool(res)
 
 def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1471,6 +1471,16 @@ class TestAllclose(object):
         x = np.array([1.0, np.nan])
         assert_(np.allclose(x, x, equal_nan=True))
 
+    def test_return_class_is_ndarray(self):
+        # Issue gh-6475
+        # Check that allclose does not preserve subtypes
+        class Foo(np.ndarray):
+            def __new__(cls, *args, **kwargs):
+                return np.array(*args, **kwargs).view(cls)
+
+        a = Foo([1])
+        assert_(type(np.allclose(a, a)) is bool)
+
 
 class TestIsclose(object):
     rtol = 1e-5


### PR DESCRIPTION
The function was returning an ndarray subtype when at least one
of the arguments was a subtype.

Closes #6475.
