### PR TITLE
ENH: moveaxis function

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -103,6 +103,8 @@ New Features
   given precision. The byteorder specification is also ignored, the
   generated arrays are always in native byte order.
 
+* ``np.moveaxis`` allows for moving one or more array axes to a new position
+  by explicitly providing source and destination axes.
 
 Improvements
 ============

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -26,6 +26,7 @@ Transpose-like operations
 .. autosummary::
    :toctree: generated/
 
+   moveaxis
    rollaxis
    swapaxes
    ndarray.T

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -518,7 +518,7 @@ def transpose(a, axes=None):
 
     See Also
     --------
-    rollaxis
+    moveaxis
     argsort
 
     Notes

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -11,7 +11,8 @@ from numpy.core import umath
 from numpy.random import rand, randint, randn
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_array_equal, assert_almost_equal, assert_array_almost_equal, dec
+    assert_raises_regex, assert_array_equal, assert_almost_equal,
+    assert_array_almost_equal, dec
 )
 
 
@@ -2027,6 +2028,80 @@ class TestRollaxis(TestCase):
             assert_(np.all(res[i0, i1, i2, i3] == a))
             assert_(res.shape == self.tgtshape[(4 - ip, 4 - jp)])
             assert_(not res.flags['OWNDATA'])
+
+
+class TestMoveaxis(TestCase):
+    def test_move_to_end(self):
+        x = np.random.randn(5, 6, 7)
+        for source, expected in [(0, (6, 7, 5)),
+                                 (1, (5, 7, 6)),
+                                 (2, (5, 6, 7)),
+                                 (-1, (5, 6, 7))]:
+            actual = np.moveaxis(x, source, -1).shape
+            assert_(actual, expected)
+
+    def test_move_new_position(self):
+        x = np.random.randn(1, 2, 3, 4)
+        for source, destination, expected in [
+                (0, 1, (2, 1, 3, 4)),
+                (1, 2, (1, 3, 2, 4)),
+                (1, -1, (1, 3, 4, 2)),
+                ]:
+            actual = np.moveaxis(x, source, destination).shape
+            assert_(actual, expected)
+
+    def test_preserve_order(self):
+        x = np.zeros((1, 2, 3, 4))
+        for source, destination in [
+                (0, 0),
+                (3, -1),
+                (-1, 3),
+                ([0, -1], [0, -1]),
+                ([2, 0], [2, 0]),
+                (range(4), range(4)),
+                ]:
+            actual = np.moveaxis(x, source, destination).shape
+            assert_(actual, (1, 2, 3, 4))
+
+    def test_move_multiples(self):
+        x = np.zeros((0, 1, 2, 3))
+        for source, destination, expected in [
+                ([0, 1], [2, 3], (2, 3, 0, 1)),
+                ([2, 3], [0, 1], (2, 3, 0, 1)),
+                ([0, 1, 2], [2, 3, 0], (2, 3, 0, 1)),
+                ([3, 0], [1, 0], (0, 3, 1, 2)),
+                ([0, 3], [0, 1], (0, 3, 1, 2)),
+                ]:
+            actual = np.moveaxis(x, source, destination).shape
+            assert_(actual, expected)
+
+    def test_errors(self):
+        x = np.random.randn(1, 2, 3)
+        assert_raises_regex(ValueError, 'invalid axis .* `source`',
+                            np.moveaxis, x, 3, 0)
+        assert_raises_regex(ValueError, 'invalid axis .* `source`',
+                            np.moveaxis, x, -4, 0)
+        assert_raises_regex(ValueError, 'invalid axis .* `destination`',
+                            np.moveaxis, x, 0, 5)
+        assert_raises_regex(ValueError, 'repeated axis in `source`',
+                            np.moveaxis, x, [0, 0], [0, 1])
+        assert_raises_regex(ValueError, 'repeated axis in `destination`',
+                            np.moveaxis, x, [0, 1], [1, 1])
+        assert_raises_regex(ValueError, 'must have the same number',
+                            np.moveaxis, x, 0, [0, 1])
+        assert_raises_regex(ValueError, 'must have the same number',
+                            np.moveaxis, x, [0, 1], [0])
+
+    def test_array_likes(self):
+        x = np.ma.zeros((1, 2, 3))
+        result = np.moveaxis(x, 0, 0)
+        assert_(x.shape, result.shape)
+        assert_(isinstance(result, np.ma.MaskedArray))
+
+        x = [1, 2, 3]
+        result = np.moveaxis(x, 0, 0)
+        assert_(x, list(result))
+        assert_(isinstance(result, np.ndarray))
 
 
 class TestCross(TestCase):


### PR DESCRIPTION
Fixes #2039

This function provides a much more intuitive interface than `np.rollaxis`, which has a confusing behavior with the position of the `start` argument:
http://stackoverflow.com/questions/29891583/reason-why-numpy-rollaxis-is-so-confusing

In particular, it makes it easy to move the first axis to the end without reordering the other axes: `moveaxis(a, 0, -1)` (compare to `rollaxis(a, 0, a.ndim)`). It is also a better name name for moving axes than `rollaxis`.

This functionality, and even the specific name `rollaxis` was independently suggested several times over the years in discussions on the mailing list and GitHub (#2039), but never made it into a pull request:
https://mail.scipy.org/pipermail/numpy-discussion/2010-September/052882.html

My version adds support for a sequence of axis arguments. I find this behavior convenient, e.g., to move the first two axes of an array to the end, use `moveaxis(a, [0, 1], [-2, -1])`. The ability to specific source and destination locations is often more intuitive than supplying a list of arguments to `transpose`. This also allows us to nicely generalize NumPy's existing axis manipulation routines:

``` python
def transpose(a, order=None):
    if order is None:
        order = reversed(range(a.ndim))
    return moveaxes(a, order, range(a.ndim))

def swapaxes(a, axis1, axis2):
    return moveaxes(a, [axis1, axis2], [axis2, axis1])

def rollaxis(a, axis, start=0):
    if axis < start:
        start -= 1
    return moveaxes(a, axis, start)
```
