### PR TITLE
TST/BUG: fromfile - fix test and expose bug with io class argument

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -723,7 +723,8 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     """Create an array from binary file data
 
     If file is a string then that file is opened, else it is assumed
-    to be a file object.
+    to be a file object. The file object must support random access
+    (i.e. it must have tell and seek methods).
 
     >>> from tempfile import TemporaryFile
     >>> a = np.empty(10,dtype='f8,i4,a5')

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -559,7 +559,7 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     FILE *fd;
     char *sep = "";
     char *format = "";
-    npy_off_t orig_pos;
+    npy_off_t orig_pos = 0;
     static char *kwlist[] = {"file", "sep", "format", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ss", kwlist,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2031,7 +2031,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     static char *kwlist[] = {"file", "dtype", "count", "sep", NULL};
     PyArray_Descr *type = NULL;
     int own;
-    npy_off_t orig_pos;
+    npy_off_t orig_pos = 0;
     FILE *fp;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3720,7 +3720,7 @@ class TestLexsort(TestCase):
         x = np.linspace(0., 1., 42*3).reshape(42, 3)
         assert_raises(ValueError, np.lexsort, x, axis=2)
 
-class TestIO(object):
+class TestIO(TestCase):
     """Test tofile, fromfile, tobytes, and fromstring"""
 
     def setUp(self):
@@ -3811,17 +3811,23 @@ class TestIO(object):
         y = np.fromstring(s, sep="@")
         assert_array_equal(x, y)
 
-    def test_unbuffered_fromfile(self):
+    def test_unseekable_fromfile(self):
         # gh-6246
         self.x.tofile(self.filename)
 
         def fail(*args, **kwargs):
-            raise io.IOError('Can not tell or seek')
+            raise IOError('Can not tell or seek')
 
         with io.open(self.filename, 'rb', buffering=0) as f:
             f.seek = fail
             f.tell = fail
-            y = np.fromfile(self.filename, dtype=self.dtype)
+            self.assertRaises(IOError, np.fromfile, f, dtype=self.dtype)
+
+    def test_io_open_unbuffered_fromfile(self):
+        # gh-6632
+        self.x.tofile(self.filename)
+        with io.open(self.filename, 'rb', buffering=0) as f:
+            y = np.fromfile(f, dtype=self.dtype)
             assert_array_equal(y, self.x.flat)
 
     def test_largish_file(self):
@@ -3835,6 +3841,13 @@ class TestIO(object):
             f.seek(d.nbytes)
             d.tofile(f)
             assert_equal(os.path.getsize(self.filename), d.nbytes * 2)
+
+    def test_io_open_buffered_fromfile(self):
+        # gh-6632
+        self.x.tofile(self.filename)
+        f = io.open(self.filename, 'rb', buffering=-1)
+        y = np.fromfile(f, dtype=self.dtype)
+        assert_array_equal(y, self.x.flat)
 
     def test_file_position_after_fromfile(self):
         # gh-4118

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -103,8 +103,9 @@ class RoundtripTest(object):
             if not isinstance(target_file, BytesIO):
                 target_file.close()
                 # holds an open file descriptor so it can't be deleted on win
-                if not isinstance(arr_reloaded, np.lib.npyio.NpzFile):
-                    os.remove(target_file.name)
+                if 'arr_reloaded' in locals():
+                    if not isinstance(arr_reloaded, np.lib.npyio.NpzFile):
+                        os.remove(target_file.name)
 
     def check_roundtrips(self, a):
         self.roundtrip(a)


### PR DESCRIPTION
This fixes an obvious typo in a test, however in doing so it also exposes a bug on Python 2.7. The bug was originally reported at https://github.com/mcmtroffaes/pathlib2/pull/7 and I stumbled on this whilst trying to fix it. Sadly the error message is rather unhelpful:

```
SystemError: error return without exception set
```

without further traceback into the numpy source, so I haven't been able to identify the source of this error yet.
