### PR TITLE
Backport 6643

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -17,7 +17,6 @@ using PyArray_ISFORTRAN to check for Fortran contiguity instead of
 PyArray_IS_F_CONTIGUOUS. You may want to regenerate swigged files using the
 updated numpy.i
 
-
 Issues Fixed
 ============
 
@@ -34,6 +33,7 @@ Issues Fixed
 * gh-6602 Random __all__ missing choice and dirichlet.
 * gh-6618 NPY_FORTRANORDER in make_fortran() in numpy.i
 * gh-6475 np.allclose returns a memmap when one of its arguments is a memmap.
+* gh-6641 Subsetting recarray by fields yields a structured array.
 
 Merged PRs
 ==========
@@ -71,6 +71,7 @@ The following PRs in master have been backported to 1.10.2
 * gh-6614 BUG: Add choice and dirichlet to numpy.random.__all__.
 * gh-6621 BUG: Fix swig make_fortran function.
 * gh-6628 BUG: Make allclose return python bool.
+* gh-6643 ENH: make recarray.getitem return a recarray.
 
 Initial support for mingwpy was reverted as it was causing problems for
 non-windows builds.

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -502,6 +502,7 @@ class recarray(ndarray):
         # we might also be returning a single element
         if isinstance(obj, ndarray):
             if obj.dtype.fields:
+                obj = obj.view(recarray)
                 if issubclass(obj.dtype.type, nt.void):
                     return obj.view(dtype=(self.dtype.type, obj.dtype))
                 return obj

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -121,6 +121,14 @@ class TestFromrecords(TestCase):
         assert_equal(type(rv), np.recarray)
         assert_equal(rv.dtype.type, np.record)
 
+        #check that getitem also preserves np.recarray and np.record
+        r = np.rec.array(np.ones(4, dtype=[('a', 'i4'), ('b', 'i4'), 
+                                           ('c', 'i4,i4')]))
+        assert_equal(r['c'].dtype.type, np.record)
+        assert_equal(type(r['c']), np.recarray)
+        assert_equal(r[['a', 'b']].dtype.type, np.record)
+        assert_equal(type(r[['a', 'b']]), np.recarray)
+
         # check that accessing nested structures keep record type, but
         # not for subarrays, non-void structures, non-structured voids
         test_dtype = [('a', 'f4,f4'), ('b', 'V8'), ('c', ('f4',2)),


### PR DESCRIPTION
```
ENH: make recarray.getitem return a recarray

recarray.__getitem__ should return a recarray when the returned value
had structured type (it's documented to do so).

Fixes #6641
```
