### PR TITLE
Backport 6642

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -22,6 +22,7 @@ Issues Fixed
 
 * gh-6462 Median of empty array produces IndexError.
 * gh-6467 Performance regression for record array access.
+* gh-6475 np.allclose returns a memmap when one of its arguments is a memmap.
 * gh-6491 Error in broadcasting stride_tricks array.
 * gh-6495 Unrecognized command line option '-ffpe-summary' in gfortran.
 * gh-6497 Failure of reduce operation on recarrays.
@@ -32,7 +33,7 @@ Issues Fixed
 * gh-6590 Fortran Array problem in numpy 1.10.
 * gh-6602 Random __all__ missing choice and dirichlet.
 * gh-6618 NPY_FORTRANORDER in make_fortran() in numpy.i
-* gh-6475 np.allclose returns a memmap when one of its arguments is a memmap.
+* gh-6636 Memory leak in nested dtypes in numpy.recarray
 * gh-6641 Subsetting recarray by fields yields a structured array.
 
 Merged PRs
@@ -71,6 +72,7 @@ The following PRs in master have been backported to 1.10.2
 * gh-6614 BUG: Add choice and dirichlet to numpy.random.__all__.
 * gh-6621 BUG: Fix swig make_fortran function.
 * gh-6628 BUG: Make allclose return python bool.
+* gh-6642 BUG: Fix memleak in _convert_from_dict.
 * gh-6643 ENH: make recarray.getitem return a recarray.
 
 Initial support for mingwpy was reverted as it was causing problems for

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -36,6 +36,19 @@ static PyObject *typeDict = NULL;   /* Must be explicitly loaded */
 static PyArray_Descr *
 _use_inherit(PyArray_Descr *type, PyObject *newobj, int *errflag);
 
+
+/*
+ * Returns value of PyMapping_GetItemString but as a borrowed reference instead
+ * of a new reference.
+ */
+static PyObject *
+Borrowed_PyMapping_GetItemString(PyObject *o, char *key)
+{
+    PyObject *ret = PyMapping_GetItemString(o, key);
+    Py_XDECREF(ret);
+    return ret;
+}
+
 /*
  * Creates a dtype object from ctypes inputs.
  *
@@ -946,17 +959,19 @@ _convert_from_dict(PyObject *obj, int align)
     if (fields == NULL) {
         return (PyArray_Descr *)PyErr_NoMemory();
     }
-    /* Use PyMapping_GetItemString to support dictproxy objects as well */
-    names = PyMapping_GetItemString(obj, "names");
-    descrs = PyMapping_GetItemString(obj, "formats");
+    /*
+     * Use PyMapping_GetItemString to support dictproxy objects as well.
+     */
+    names = Borrowed_PyMapping_GetItemString(obj, "names");
+    descrs = Borrowed_PyMapping_GetItemString(obj, "formats");
     if (!names || !descrs) {
         Py_DECREF(fields);
         PyErr_Clear();
         return _use_fields_dict(obj, align);
     }
     n = PyObject_Length(names);
-    offsets = PyMapping_GetItemString(obj, "offsets");
-    titles = PyMapping_GetItemString(obj, "titles");
+    offsets = Borrowed_PyMapping_GetItemString(obj, "offsets");
+    titles = Borrowed_PyMapping_GetItemString(obj, "titles");
     if (!offsets || !titles) {
         PyErr_Clear();
     }
@@ -974,7 +989,7 @@ _convert_from_dict(PyObject *obj, int align)
      * If a property 'aligned' is in the dict, it overrides the align flag
      * to be True if it not already true.
      */
-    tmp = PyMapping_GetItemString(obj, "aligned");
+    tmp = Borrowed_PyMapping_GetItemString(obj, "aligned");
     if (tmp == NULL) {
         PyErr_Clear();
     } else {
@@ -1148,7 +1163,7 @@ _convert_from_dict(PyObject *obj, int align)
     }
 
     /* Override the itemsize if provided */
-    tmp = PyMapping_GetItemString(obj, "itemsize");
+    tmp = Borrowed_PyMapping_GetItemString(obj, "itemsize");
     if (tmp == NULL) {
         PyErr_Clear();
     } else {
@@ -1180,7 +1195,7 @@ _convert_from_dict(PyObject *obj, int align)
     }
 
     /* Add the metadata if provided */
-    metadata = PyMapping_GetItemString(obj, "metadata");
+    metadata = Borrowed_PyMapping_GetItemString(obj, "metadata");
 
     if (metadata == NULL) {
         PyErr_Clear();


### PR DESCRIPTION
```
BUG: Fix memleak in _convert_from_dict

Fixes a memleak introduced in #5920, where PyDict_GetItemString
was replaced by PyMapping_GetItemString which returns a new ref.

Fixes #6636
```
