### PR TITLE
ENH: usecols now accepts an int when only one column has to be read

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -61,6 +61,11 @@ New Features
 Improvements
 ============
 
+*np.loadtxt* now supports a single integer as ``usecol`` argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Instead of using ``usecol=(n,)`` to read the nth column of a file
+it is now allowed to use ``usecol=n``. Also the error message is
+more user friendly when a non-integer is passed as a column index.
 
 
 Changes


### PR DESCRIPTION
As explained on the Numpy-discussion mailing list I've seen many students, coming from Matlab, struggling against the usecols argument of loadtxt when they had to read only one column in a file.

This simple PR aims at making loadtxt more user friendly for newcomers, usecol behavior has been modified to accept either an int or a sequence when a single column has to be read. 
