### PR TITLE
Added pathlib support for several functions

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -169,6 +169,12 @@ The *__complex__* method has been implemented on the ndarray object
 Calling ``complex()`` on a size 1 array will now cast to a python
 complex.
 
+``pathlib.Path`` objects now supported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The standard ``np.load``, ``np.save``, ``np.loadtxt``, ``np.savez``, and similar
+functions can now take ``pathlib.Path`` objects as an argument instead of a
+filename or open file object.
+
 
 Changes
 =======

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -7,9 +7,13 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
            'asstr', 'open_latin1', 'long', 'basestring', 'sixu',
-           'integer_types']
+           'integer_types', 'is_pathlib_path', 'Path']
 
 import sys
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
 
 if sys.version_info[0] >= 3:
     import io
@@ -86,3 +90,10 @@ def asunicode_nested(x):
         return [asunicode_nested(y) for y in x]
     else:
         return asunicode(x)
+
+
+def is_pathlib_path(obj):
+    """
+    Check whether obj is a pathlib.Path object.
+    """
+    return Path is not None and isinstance(obj, Path)

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from .numeric import uint8, ndarray, dtype
-from numpy.compat import long, basestring
+from numpy.compat import long, basestring, is_pathlib_path
 
 __all__ = ['memmap']
 
@@ -39,7 +39,7 @@ class memmap(ndarray):
 
     Parameters
     ----------
-    filename : str or file-like object
+    filename : str, file-like object, or pathlib.Path instance
         The file name or file object to be used as the array data buffer.
     dtype : data-type, optional
         The data-type used to interpret the file contents.
@@ -82,7 +82,7 @@ class memmap(ndarray):
 
     Attributes
     ----------
-    filename : str
+    filename : str or pathlib.Path instance
         Path to the mapped file.
     offset : int
         Offset position in the file.
@@ -213,6 +213,9 @@ class memmap(ndarray):
         if hasattr(filename, 'read'):
             fid = filename
             own_file = False
+        elif is_pathlib_path(filename):
+            fid = filename.open((mode == 'c' and 'r' or mode)+'b')
+            own_file = True
         else:
             fid = open(filename, (mode == 'c' and 'r' or mode)+'b')
             own_file = True
@@ -267,6 +270,8 @@ class memmap(ndarray):
 
         if isinstance(filename, basestring):
             self.filename = os.path.abspath(filename)
+        elif is_pathlib_path(filename):
+            self.filename = filename.resolve()
         # py3 returns int for TemporaryFile().name
         elif (hasattr(filename, "name") and
               isinstance(filename.name, basestring)):

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile, TemporaryFile, mktemp, mkdtemp
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
+from numpy.compat import Path
 
 from numpy import arange, allclose, asarray
 from numpy.testing import (
@@ -70,6 +71,19 @@ class TestMemmap(TestCase):
         self.assertEqual(abspath, fp.filename)
         b = fp[:1]
         self.assertEqual(abspath, b.filename)
+        del b
+        del fp
+
+    @dec.skipif(Path is None, "No pathlib.Path")
+    def test_path(self):
+        tmpname = mktemp('', 'mmap', dir=self.tempdir)
+        fp = memmap(Path(tmpname), dtype=self.dtype, mode='w+',
+                       shape=self.shape)
+        abspath = os.path.abspath(tmpname)
+        fp[:] = self.data[:]
+        self.assertEqual(abspath, str(fp.filename))
+        b = fp[:1]
+        self.assertEqual(abspath, str(b.filename))
         del b
         del fp
 


### PR DESCRIPTION
Added support for pathlib.Path support for several functions, including `savetxt`, `loadtxt`, `load`, `savez`, `savez_compressed`, `ndfromtxt`, `recfromtxt`, and `recfromcsv`, along with testing. Fixes #6418.

Note that #6655 also addresses the same issue, and we should coordinate on this; I was a bit slow on making my changes, and @r0fls did some good work on his branch!

This could also use a bit of code review, I imagine.

CC @rgommers, @r0fls.
