### PR TITLE
Changed lines for successfull MSVC 14.0 compiling

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1293,7 +1293,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
                                     PyArray_NDIM(arr),
                                     PyArray_SHAPE(arr),
                                     PyArray_STRIDES(arr),
-                                    PyArray_DATA(arr) + offset,
+                                    ((char *)PyArray_DATA(arr)) + offset,
                                     PyArray_FLAGS(arr),
                                     (PyObject *)arr);
         if (*view == NULL) {

--- a/numpy/core/src/private/mem_overlap.c
+++ b/numpy/core/src/private/mem_overlap.c
@@ -479,6 +479,7 @@ NPY_VISIBILITY_HIDDEN mem_overlap_t
 solve_diophantine(unsigned int n, diophantine_term_t *E, npy_int64 b,
                   Py_ssize_t max_work, int require_ub_nontrivial, npy_int64 *x)
 {
+    mem_overlap_t res;
     unsigned int j;
 
     for (j = 0; j < n; ++j) {
@@ -535,15 +536,27 @@ solve_diophantine(unsigned int n, diophantine_term_t *E, npy_int64 b,
         return MEM_OVERLAP_NO;
     }
     else {
-        diophantine_term_t Ep[n];
-        npy_int64 Epsilon[n], Gamma[n];
         Py_ssize_t count = 0;
+        diophantine_term_t *Ep = NULL;
+        npy_int64 *Epsilon = NULL, *Gamma = NULL;
 
-        if (diophantine_precompute(n, E, Ep, Gamma, Epsilon)) {
-            return MEM_OVERLAP_OVERFLOW;
+        Ep = malloc(n * sizeof(diophantine_term_t));
+        Epsilon = malloc(n * sizeof(npy_int64));
+        Gamma = malloc(n * sizeof(npy_int64));
+        if (Ep == NULL || Epsilon == NULL || Gamma == NULL) {
+            res = MEM_OVERLAP_ERROR;
         }
-        return diophantine_dfs(n, n-1, E, Ep, Gamma, Epsilon, b, max_work,
-                               require_ub_nontrivial, x, &count);
+        else if (diophantine_precompute(n, E, Ep, Gamma, Epsilon)) {
+            res = MEM_OVERLAP_OVERFLOW;
+        }
+        else {
+            res = diophantine_dfs(n, n-1, E, Ep, Gamma, Epsilon, b, max_work,
+                                  require_ub_nontrivial, x, &count);
+        }
+        free(Ep);
+        free(Gamma);
+        free(Epsilon);
+        return res;
     }
 }
 


### PR DESCRIPTION
Edited lines in ../numpy/core/src/multiarray/mapping.c and ../numpy/core/src/private/mem_overlap.c, namely functions that are not legally defined for MSVC 14.0. Need testing if the free (pointer) functions are properly placed in mem_overlap.c

This fixes the errors when trying to compile with MSVC 14.0 for python 3.5
