### PR TITLE
Backport 6668

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -38,6 +38,7 @@ Issues Fixed
 * gh-6618 NPY_FORTRANORDER in make_fortran() in numpy.i
 * gh-6636 Memory leak in nested dtypes in numpy.recarray
 * gh-6641 Subsetting recarray by fields yields a structured array.
+* gh-6667 ma.make_mask handles ma.nomask input incorrectly.
 
 Merged PRs
 ==========
@@ -78,6 +79,7 @@ The following PRs in master have been backported to 1.10.2
 * gh-6642 BUG: Fix memleak in _convert_from_dict.
 * gh-6643 ENH: make recarray.getitem return a recarray.
 * gh-6653 BUG: Fix ma dot to always return masked array.
+* gh-6668 BUG: ma.make_mask should always return nomask for nomask argument.
 
 Initial support for mingwpy was reverted as it was causing problems for
 non-windows builds.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1495,9 +1495,10 @@ def make_mask(m, copy=False, shrink=True, dtype=MaskType):
     shrink : bool, optional
         Whether to shrink `m` to ``nomask`` if all its values are False.
     dtype : dtype, optional
-        Data-type of the output mask. By default, the output mask has
-        a dtype of MaskType (bool). If the dtype is flexible, each field
-        has a boolean dtype.
+        Data-type of the output mask. By default, the output mask has a
+        dtype of MaskType (bool). If the dtype is flexible, each field has
+        a boolean dtype. This is ignored when `m` is ``nomask``, in which
+        case ``nomask`` is always returned.
 
     Returns
     -------
@@ -1547,7 +1548,7 @@ def make_mask(m, copy=False, shrink=True, dtype=MaskType):
           dtype=[('man', '|b1'), ('mouse', '|b1')])
 
     """
-    if m is nomask and shrink:
+    if m is nomask:
         return nomask
     elif isinstance(m, ndarray):
         # We won't return after this point to make sure we can shrink the mask

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -11,7 +11,9 @@ __author__ = "Pierre GF Gerard-Marchant"
 import warnings
 import pickle
 import operator
+import itertools
 from functools import reduce
+
 
 import numpy as np
 import numpy.ma.core
@@ -3711,6 +3713,15 @@ class TestMaskedArrayFunctions(TestCase):
         test = make_mask(mask, dtype=mask.dtype)
         assert_equal(test.dtype, bdtype)
         assert_equal(test, np.array([(0, 0), (0, 1)], dtype=bdtype))
+
+        # test that nomask is returned when m is nomask.
+        bools = [True, False]
+        dtypes = [MaskType, np.float]
+        msgformat = 'copy=%s, shrink=%s, dtype=%s'
+        for cpy, shr, dt in itertools.product(bools, bools, dtypes):
+            res = make_mask(nomask, copy=cpy, shrink=shr, dtype=dt)
+            assert_(res is nomask, msgformat % (cpy, shr, dt))
+
 
     def test_mask_or(self):
         # Initialize


### PR DESCRIPTION
BUG: ma.make_mask should always return nomask for nomask argument. …

When the mask argument was nomask, commit 8da9c71 changed the behavior
to depend on shrink=True as well, resulting in array(False) false being
returned when shrink=True, which in turn led to bugs because nomask is a
singleton and is detected by `mask is nomask`. That dectection fails
when nomask is replaced by array(False).
