### PR TITLE
Improve may_share_memory performance + fix non-ndarray inputs

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3826,6 +3826,45 @@ add_newdoc('numpy.core.multiarray', 'shares_memory',
     """)
 
 
+add_newdoc('numpy.core.multiarray', 'may_share_memory',
+    """
+    may_share_memory(a, b, max_work=None)
+
+    Determine if two arrays might share memory
+
+    A return of True does not necessarily mean that the two arrays
+    share any element.  It just means that they *might*.
+
+    Only the memory bounds of a and b are checked by default.
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Input arrays
+    max_work : int, optional
+        Effort to spend on solving the overlap problem.  See
+        `shares_memory` for details.  Default for ``may_share_memory``
+        is to do a bounds check.
+
+    Returns
+    -------
+    out : bool
+
+    See Also
+    --------
+    shares_memory
+
+    Examples
+    --------
+    >>> np.may_share_memory(np.array([1,2]), np.array([5,8,9]))
+    False
+    >>> x = np.zeros([3, 4])
+    >>> np.may_share_memory(x[:,0], x[:,1])
+    True
+
+    """)
+
+
 add_newdoc('numpy.core.multiarray', 'ndarray', ('newbyteorder',
     """
     arr.newbyteorder(new_order='S')

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -1,6 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-__all__ = ['logspace', 'linspace', 'may_share_memory']
+__all__ = ['logspace', 'linspace']
 
 from . import numeric as _nx
 from .numeric import result_type, NaN, shares_memory, MAY_SHARE_BOUNDS, TooHardError
@@ -201,46 +201,3 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     if dtype is None:
         return _nx.power(base, y)
     return _nx.power(base, y).astype(dtype)
-
-
-def may_share_memory(a, b, max_work=None):
-    """Determine if two arrays can share memory
-
-    A return of True does not necessarily mean that the two arrays
-    share any element.  It just means that they *might*.
-
-    Only the memory bounds of a and b are checked by default.
-
-    Parameters
-    ----------
-    a, b : ndarray
-        Input arrays
-    max_work : int, optional
-        Effort to spend on solving the overlap problem.  See
-        `shares_memory` for details.  Default for ``may_share_memory``
-        is to do a bounds check.
-
-    Returns
-    -------
-    out : bool
-
-    See Also
-    --------
-    shares_memory
-
-    Examples
-    --------
-    >>> np.may_share_memory(np.array([1,2]), np.array([5,8,9]))
-    False
-    >>> x = np.zeros([3, 4])
-    >>> np.may_share_memory(x[:,0], x[:,1])
-    True
-
-    """
-    if max_work is None:
-        max_work = MAY_SHARE_BOUNDS
-    try:
-        return shares_memory(a, b, max_work=max_work)
-    except (TooHardError, OverflowError):
-        # Unable to determine, assume yes
-        return True

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -41,7 +41,8 @@ __all__ = [
     'Inf', 'inf', 'infty', 'Infinity', 'nan', 'NaN', 'False_', 'True_',
     'bitwise_not', 'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE',
     'ALLOW_THREADS', 'ComplexWarning', 'full', 'full_like', 'matmul',
-    'shares_memory', 'MAY_SHARE_BOUNDS', 'MAY_SHARE_EXACT', 'TooHardError',
+    'shares_memory', 'may_share_memory', 'MAY_SHARE_BOUNDS', 'MAY_SHARE_EXACT',
+    'TooHardError',
     ]
 
 if sys.version_info[0] < 3:
@@ -384,6 +385,7 @@ fromiter = multiarray.fromiter
 fromfile = multiarray.fromfile
 frombuffer = multiarray.frombuffer
 shares_memory = multiarray.shares_memory
+may_share_memory = multiarray.may_share_memory
 if sys.version_info[0] < 3:
     newbuffer = multiarray.newbuffer
     getbuffer = multiarray.getbuffer

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3992,6 +3992,8 @@ static PyObject *
 array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_work,
                          int raise_exceptions)
 {
+    PyObject * self_obj = NULL;
+    PyObject * other_obj = NULL;
     PyArrayObject * self = NULL;
     PyArrayObject * other = NULL;
     PyObject *max_work_obj = NULL;
@@ -4004,11 +4006,33 @@ array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_
 
     max_work = default_max_work;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&O&|O", kwlist,
-                                     PyArray_Converter, &self,
-                                     PyArray_Converter, &other,
-                                     &max_work_obj)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwlist,
+                                     &self_obj, &other_obj, &max_work_obj)) {
         return NULL;
+    }
+
+    if (PyArray_Check(self_obj)) {
+        self = (PyArrayObject*)self_obj;
+        Py_INCREF(self);
+    }
+    else {
+        /* Use FromAny to enable checking overlap for objects exposing array
+           interfaces etc. */
+        self = (PyArrayObject*)PyArray_FromAny(self_obj, NULL, 0, 0, 0, NULL);
+        if (self == NULL) {
+            goto fail;
+        }
+    }
+
+    if (PyArray_Check(other_obj)) {
+        other = (PyArrayObject*)other_obj;
+        Py_INCREF(other);
+    }
+    else {
+        other = (PyArrayObject*)PyArray_FromAny(other_obj, NULL, 0, 0, 0, NULL);
+        if (other == NULL) {
+            goto fail;
+        }
     }
 
     if (max_work_obj == NULL || max_work_obj == Py_None) {

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -482,5 +482,33 @@ def test_internal_overlap_fuzz():
             no_overlap += 1
 
 
+def test_non_ndarray_inputs():
+    # Regression check for gh-5604
+
+    class MyArray(object):
+        def __init__(self, data):
+            self.data = data
+
+        @property
+        def __array_interface__(self):
+            return self.data.__array_interface__
+
+    class MyArray2(object):
+        def __init__(self, data):
+            self.data = data
+
+        def __array__(self):
+            return self.data
+
+    for cls in [MyArray, MyArray2]:
+        x = np.arange(5)
+
+        assert_(np.may_share_memory(cls(x[::2]), x[1::2]))
+        assert_(not np.shares_memory(cls(x[::2]), x[1::2]))
+
+        assert_(np.shares_memory(cls(x[1::3]), x[::2]))
+        assert_(np.may_share_memory(cls(x[1::3]), x[::2]))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Reimplement may_share_memory in C to improve its performance.

Also, don't use PyArray_Converter in may_share_memory. The converter function has NPY_ARRAY_CARRAY enabled, which can cause false negatives for non-ndarray inputs.

Benchmark:

```
$ python runtests.py --bench-compare master,HEAD time_mmap_slicing
...
   before     after       ratio
  [4be9ce7b] [f2be3a2f]
-    2.24ms     1.06ms      0.47  bench_indexing.IndexingSeparate.time_mmap_slicing
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

Fixes gh-6677, gh-5604
