### PR TITLE
BUG: regression in fortran array views due to relaxed strides

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3792,10 +3792,6 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             else {
                 not_cf_contig = 0;
             }
-            if (dims[i] == 1) {
-                /* For testing purpose only */
-                strides[i] = NPY_MAX_INTP;
-            }
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }
 #if NPY_RELAXED_STRIDES_CHECKING
@@ -3819,10 +3815,6 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
 #if NPY_RELAXED_STRIDES_CHECKING
             else {
                 not_cf_contig = 0;
-            }
-            if (dims[i] == 1) {
-                /* For testing purpose only */
-                strides[i] = NPY_MAX_INTP;
             }
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5459,7 +5459,32 @@ class TestNewBufferProtocol(object):
             assert_(strides[-1] == 8)
 
     def test_1d_fortran_view(self):
+	# bug report case (gh-6678)
         np.array([[1.], [2.]], dtype='float32', order='F').view('complex64')
+	
+	# test arrays which are both C- and F- contiguous
+        f1x4 = np.array([[1,  2,  3,  4]], order='F', dtype='f4')
+        f4x1 = np.array([[1],[2],[3],[4]], order='F', dtype='f4')
+        c1x4 = np.array([[1,  2,  3,  4]], order='C', dtype='f4')
+        c4x1 = np.array([[1],[2],[3],[4]], order='C', dtype='f4')
+
+	assert_equal(f1x4.view('i2').shape, (2,4))
+	assert_equal(f4x1.view('i2').shape, (8,1))
+	assert_equal(c1x4.view('i2').shape, (1,8))
+	assert_equal(c4x1.view('i2').shape, (4,2))
+
+	assert_raises(f1x4.view('c8'), ValueError)
+	assert_equal( f4x1.view('c8').shape, (2,1))
+	assert_equal( c1x4.view('c8').shape, (1,2))
+	assert_raises(c4x1.view('c8'), ValueError)
+
+	# test arrays with many dimensions
+	a = np.empty((2,4,6), dtype='f4', order='C')
+	b = np.empty((2,4,6), dtype='f4', order='F')
+	c = np.empty((2,6,4), dtype='f4', order='C').transpose((0,2,1))
+	assert_equal(a.view('c8').shape, (2,4,3))
+	assert_equal(b.view('c8').shape, (1,4,6))
+	assert_raises(c.view('c8'), ValueError)
 
 
 class TestArrayAttributeDeletion(object):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5459,32 +5459,42 @@ class TestNewBufferProtocol(object):
             assert_(strides[-1] == 8)
 
     def test_1d_fortran_view(self):
-	# bug report case (gh-6678)
+        # bug report case (gh-6678)
         np.array([[1.], [2.]], dtype='float32', order='F').view('complex64')
-	
-	# test arrays which are both C- and F- contiguous
+
+        # test arrays which are both C- and F- contiguous
         f1x4 = np.array([[1,  2,  3,  4]], order='F', dtype='f4')
         f4x1 = np.array([[1],[2],[3],[4]], order='F', dtype='f4')
         c1x4 = np.array([[1,  2,  3,  4]], order='C', dtype='f4')
         c4x1 = np.array([[1],[2],[3],[4]], order='C', dtype='f4')
 
-	assert_equal(f1x4.view('i2').shape, (2,4))
-	assert_equal(f4x1.view('i2').shape, (8,1))
-	assert_equal(c1x4.view('i2').shape, (1,8))
-	assert_equal(c4x1.view('i2').shape, (4,2))
+        assert_equal(f1x4.view('i2').shape, (2,4))
+        assert_equal(f4x1.view('i2').shape, (8,1))
+        assert_equal(c1x4.view('i2').shape, (1,8))
+        assert_equal(c4x1.view('i2').shape, (4,2))
 
-	assert_raises(f1x4.view('c8'), ValueError)
-	assert_equal( f4x1.view('c8').shape, (2,1))
-	assert_equal( c1x4.view('c8').shape, (1,2))
-	assert_raises(c4x1.view('c8'), ValueError)
+        assert_raises(ValueError, f1x4.view, 'c8')
+        assert_equal( f4x1.view('c8').shape, (2,1))
+        assert_equal( c1x4.view('c8').shape, (1,2))
+        assert_raises(ValueError, c4x1.view, 'c8')
 
-	# test arrays with many dimensions
-	a = np.empty((2,4,6), dtype='f4', order='C')
-	b = np.empty((2,4,6), dtype='f4', order='F')
-	c = np.empty((2,6,4), dtype='f4', order='C').transpose((0,2,1))
-	assert_equal(a.view('c8').shape, (2,4,3))
-	assert_equal(b.view('c8').shape, (1,4,6))
-	assert_raises(c.view('c8'), ValueError)
+        # test arrays with many dimensions
+        a = np.empty((2,4,6), dtype='f4', order='C')
+        b = np.empty((2,4,6), dtype='f4', order='F')
+        c = np.empty((2,6,4), dtype='f4', order='C').transpose((0,2,1))
+        assert_equal(a.view('c8').shape, (2,4,3))
+        assert_equal(b.view('c8').shape, (1,4,6))
+        assert_raises(ValueError, c.view, 'c8')
+
+        x = np.ones((1, 10), order='F', dtype='f4')
+        y = np.ones((1, 10), order='C', dtype='f4')
+        z = np.asarray(x, order='C')
+        assert_equal(x.view('i2').shape, (2,10))
+        assert_equal(y.view('i2').shape, (1,20))
+        assert_equal(z.view('i2').shape, (1,20))
+        assert_raises(ValueError, x.view, 'c8')
+        assert_equal(y.view('c8').shape, (1,5))
+        assert_equal(z.view('c8').shape, (1,5))
 
 
 class TestArrayAttributeDeletion(object):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5458,6 +5458,9 @@ class TestNewBufferProtocol(object):
             shape, strides = get_buffer_info(arr, ['C_CONTIGUOUS'])
             assert_(strides[-1] == 8)
 
+    def test_1d_fortran_view(self):
+        np.array([[1.], [2.]], dtype='float32', order='F').view('complex64')
+
 
 class TestArrayAttributeDeletion(object):
 


### PR DESCRIPTION
This fixes #6678 so that views of fortran arrays with size-1 dims can be viewed as larger dtypes. It is backward compatible and keeps relaxed strides in place. 

At this point it is just to get an idea what it might look like. I am suggesting that for 1.10.2 we might use this PR but maybe with an extra deprecation warning (still to be decided) for anyone attempting such a view. Then in 1.11 we could implement the replacement functionality (eg, an 'order' keyword for views).
