### PR TITLE
BUG, MAINT: check that histogram range parameters are finite.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -336,8 +336,12 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     if (range is not None):
         mn, mx = range
         if (mn > mx):
-            raise AttributeError(
+            raise ValueError(
                 'max must be larger than min in range parameter.')
+        if not np.all(np.isfinite([mn, mx])):
+            raise ValueError(
+                'range parameter must be finite.')
+
 
     if isinstance(bins, basestring):
         bins = _hist_optim_numbins_estimator(a, bins)
@@ -422,7 +426,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     else:
         bins = asarray(bins)
         if (np.diff(bins) < 0).any():
-            raise AttributeError(
+            raise ValueError(
                 'bins must increase monotonically.')
 
         # Initialize empty histogram
@@ -533,7 +537,7 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
     try:
         M = len(bins)
         if M != D:
-            raise AttributeError(
+            raise ValueError(
                 'The dimension of bins must be equal to the dimension of the '
                 ' sample x.')
     except TypeError:
@@ -551,6 +555,9 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
             smin = atleast_1d(array(sample.min(0), float))
             smax = atleast_1d(array(sample.max(0), float))
     else:
+        if not np.all(np.isfinite(range)):
+            raise ValueError(
+                'range parameter must be finite.')
         smin = zeros(D)
         smax = zeros(D)
         for i in arange(D):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1267,6 +1267,13 @@ class TestHistogram(TestCase):
         assert_array_equal(a, np.array([0]))
         assert_array_equal(b, np.array([0, 1]))
 
+    def test_finite_range(self):
+        # Normal ranges should be fine
+        vals = np.linspace(0.0, 1.0, num=100)
+        histogram(vals, range=[0.25,0.75])
+        assert_raises(ValueError, histogram, vals, range=[np.nan,0.75])
+        assert_raises(ValueError, histogram, vals, range=[0.25,np.inf])
+        
 
 class TestHistogramOptimBinNums(TestCase):
     """
@@ -1488,6 +1495,16 @@ class TestHistogramdd(TestCase):
         hist, _ = histogramdd(x, bins=bins)
         assert_(hist[0] == 0.0)
         assert_(hist[1] == 0.0)
+
+    def test_finite_range(self):
+        vals = np.random.random((100,3))
+        histogramdd(vals, range=[[0.0,1.0],[0.25,0.75],[0.25,0.5]])
+        assert_raises(ValueError, histogramdd, vals, 
+                      range=[[0.0,1.0],[0.25,0.75],[0.25,np.inf]])
+        assert_raises(ValueError, histogramdd, vals, 
+                      range=[[0.0,1.0],[np.nan,0.75],[0.25,0.5]])
+
+
 
 
 class TestUnique(TestCase):


### PR DESCRIPTION
This assures that the values in the `range` parameter are finite, avoiding meaningless results.  See [Scipy Issue #5221](https://github.com/matplotlib/matplotlib/issues/5221), and [[Numpy-discussion]histogram gives meaningless results with non-finite range](https://mail.scipy.org/pipermail/numpy-discussion/2015-November/074161.html).
