### PR TITLE
BUG: fix issues with signed zeros in scalar math complex division.

### DIFF
--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -329,13 +329,15 @@ static npy_half (*_basic_half_fmod)(npy_half, npy_half);
             /* divide by zero should yield a complex inf or nan */  \
             (outp)->real = in1r/in2r_abs;                           \
             (outp)->imag = in1i/in2i_abs;                           \
-        } else {                                                    \
+        }                                                           \
+        else {                                                      \
             @rtype@ rat = in2i/in2r;                                \
             @rtype@ scl = 1.0@c@/(in2r + in2i*rat);                 \
             (outp)->real = (in1r + in1i*rat)*scl;                   \
             (outp)->imag = (in1i - in1r*rat)*scl;                   \
         }                                                           \
-    } else {                                                        \
+    }                                                               \
+    else {                                                          \
         @rtype@ rat = in2r/in2i;                                    \
         @rtype@ scl = 1.0@c@/(in2i + in2r*rat);                     \
         (outp)->real = (in1r*rat + in1i)*scl;                       \

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -322,8 +322,8 @@ static npy_half (*_basic_half_fmod)(npy_half, npy_half);
     @rtype@ in1i = (a).imag;                                        \
     @rtype@ in2r = (b).real;                                        \
     @rtype@ in2i = (b).imag;                                        \
-    @rtype@ in2r_abs = fabs(in2r);                                  \
-    @rtype@ in2i_abs = fabs(in2i);                                  \
+    @rtype@ in2r_abs = npy_fabs@c@(in2r);                           \
+    @rtype@ in2i_abs = npy_fabs@c@(in2i);                           \
     if (in2r_abs >= in2i_abs) {                                     \
         if (in2r_abs == 0 && in2i_abs == 0) {                       \
             /* divide by zero should yield a complex inf or nan */  \
@@ -331,13 +331,13 @@ static npy_half (*_basic_half_fmod)(npy_half, npy_half);
             (outp)->imag = in1i/in2i_abs;                           \
         } else {                                                    \
             @rtype@ rat = in2i/in2r;                                \
-            @rtype@ scl = 1.0e0/(in2r + in2i*rat);                  \
+            @rtype@ scl = 1.0@c@/(in2r + in2i*rat);                 \
             (outp)->real = (in1r + in1i*rat)*scl;                   \
             (outp)->imag = (in1i - in1r*rat)*scl;                   \
         }                                                           \
     } else {                                                        \
         @rtype@ rat = in2r/in2i;                                    \
-        @rtype@ scl = 1.0e0/(in2i + in2r*rat);                      \
+        @rtype@ scl = 1.0@c@/(in2i + in2r*rat);                     \
         (outp)->real = (in1r*rat + in1i)*scl;                       \
         (outp)->imag = (in1i*rat - in1r)*scl;                       \
     }                                                               \

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -316,16 +316,30 @@ static npy_half (*_basic_half_fmod)(npy_half, npy_half);
     (outp)->real = (a).real * (b).real - (a).imag * (b).imag;   \
     (outp)->imag = (a).real * (b).imag + (a).imag * (b).real;   \
     } while(0)
-/* Note: complex division by zero must yield some complex inf */
+/* Algorithm identical to that in loops.c.src, for consistency */
 #define @name@_ctype_divide(a, b, outp) do{                         \
-    @rtype@ d = (b).real*(b).real + (b).imag*(b).imag;              \
-    if (d != 0) {                                                   \
-        (outp)->real = ((a).real*(b).real + (a).imag*(b).imag)/d;   \
-        (outp)->imag = ((a).imag*(b).real - (a).real*(b).imag)/d;   \
-    }                                                               \
-    else {                                                          \
-        (outp)->real = (a).real/d;                                  \
-        (outp)->imag = (a).imag/d;                                  \
+    @rtype@ in1r = (a).real;                                        \
+    @rtype@ in1i = (a).imag;                                        \
+    @rtype@ in2r = (b).real;                                        \
+    @rtype@ in2i = (b).imag;                                        \
+    @rtype@ in2r_abs = fabs(in2r);                                  \
+    @rtype@ in2i_abs = fabs(in2i);                                  \
+    if (in2r_abs >= in2i_abs) {                                     \
+        if (in2r_abs == 0 && in2i_abs == 0) {                       \
+            /* divide by zero should yield a complex inf or nan */  \
+            (outp)->real = in1r/in2r_abs;                           \
+            (outp)->imag = in1i/in2i_abs;                           \
+        } else {                                                    \
+            @rtype@ rat = in2i/in2r;                                \
+            @rtype@ scl = 1.0e0/(in2r + in2i*rat);                  \
+            (outp)->real = (in1r + in1i*rat)*scl;                   \
+            (outp)->imag = (in1i - in1r*rat)*scl;                   \
+        }                                                           \
+    } else {                                                        \
+        @rtype@ rat = in2r/in2i;                                    \
+        @rtype@ scl = 1.0e0/(in2i + in2r*rat);                      \
+        (outp)->real = (in1r*rat + in1i)*scl;                       \
+        (outp)->imag = (in1i*rat - in1r)*scl;                       \
     }                                                               \
     } while(0)
 #define @name@_ctype_true_divide @name@_ctype_divide

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -169,10 +169,10 @@ class TestComplexDivision(TestCase):
                     ((-0.0, 1.0), ( 0.0,-1.0), (-1.0,-0.0))
                 )
                 for cases in data:
-                    n=cases[0]
-                    d=cases[1]
-                    ex=cases[2]
-                    result = t(complex(n[0],n[1]))/t(complex(d[0],d[1]))
+                    n = cases[0]
+                    d = cases[1]
+                    ex = cases[2]
+                    result = t(complex(n[0], n[1])) / t(complex(d[0], d[1]))
                     # check real and imag parts separately to avoid comparison
                     # in array context, which does not account for signed zeros
                     assert_equal(result.real, ex[0])
@@ -183,23 +183,24 @@ class TestComplexDivision(TestCase):
             for t in [np.complex64, np.complex128]:
                 # tupled (numerator, denominator, expected)
                 # for testing as expected == numerator/denominator
-                data = (
+                data = list()
+
                 # trigger branch: real(fabs(denom)) > imag(fabs(denom))
                 # followed by else condition as neither are == 0
-                    (( 2.0, 1.0), ( 2.0, 1.0), (1.0, 0.0)),
+                data.append((( 2.0, 1.0), ( 2.0, 1.0), (1.0, 0.0)))
 
                 # trigger branch: real(fabs(denom)) > imag(fabs(denom))
                 # followed by if condition as both are == 0
                 # is performed in test_zero_division(), so this is skipped
 
                 # trigger else if branch: real(fabs(denom)) < imag(fabs(denom))
-                    (( 1.0, 2.0), ( 1.0, 2.0), (1.0, 0.0))
-                )
+                data.append((( 1.0, 2.0), ( 1.0, 2.0), (1.0, 0.0)))
+
                 for cases in data:
-                    n=cases[0]
-                    d=cases[1]
-                    ex=cases[2]
-                    result = t(complex(n[0],n[1]))/t(complex(d[0],d[1]))
+                    n = cases[0]
+                    d = cases[1]
+                    ex = cases[2]
+                    result = t(complex(n[0], n[1])) / t(complex(d[0], d[1]))
                     # check real and imag parts separately to avoid comparison
                     # in array context, which does not account for signed zeros
                     assert_equal(result.real, ex[0])

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -153,6 +153,58 @@ class TestComplexDivision(TestCase):
                 b = t(0.)
                 assert_(np.isnan(b/a))
 
+    def test_signed_zeros(self):
+        with np.errstate(all="ignore"):
+            for t in [np.complex64, np.complex128]:
+                # tupled (numerator, denominator, expected)
+                # for testing as expected == numerator/denominator
+                data = (
+                    (( 0.0,-1.0), ( 0.0, 1.0), (-1.0,-0.0)),
+                    (( 0.0,-1.0), ( 0.0,-1.0), ( 1.0,-0.0)),
+                    (( 0.0,-1.0), (-0.0,-1.0), ( 1.0, 0.0)),
+                    (( 0.0,-1.0), (-0.0, 1.0), (-1.0, 0.0)),
+                    (( 0.0, 1.0), ( 0.0,-1.0), (-1.0, 0.0)),
+                    (( 0.0,-1.0), ( 0.0,-1.0), ( 1.0,-0.0)),
+                    ((-0.0,-1.0), ( 0.0,-1.0), ( 1.0,-0.0)),
+                    ((-0.0, 1.0), ( 0.0,-1.0), (-1.0,-0.0))
+                )
+                for cases in data:
+                    n=cases[0]
+                    d=cases[1]
+                    ex=cases[2]
+                    result = t(complex(n[0],n[1]))/t(complex(d[0],d[1]))
+                    # check real and imag parts separately to avoid comparison
+                    # in array context, which does not account for signed zeros
+                    assert_equal(result.real, ex[0])
+                    assert_equal(result.imag, ex[1])
+
+    def test_branches(self):
+        with np.errstate(all="ignore"):
+            for t in [np.complex64, np.complex128]:
+                # tupled (numerator, denominator, expected)
+                # for testing as expected == numerator/denominator
+                data = (
+                # trigger branch: real(fabs(denom)) > imag(fabs(denom))
+                # followed by else condition as neither are == 0
+                    (( 2.0, 1.0), ( 2.0, 1.0), (1.0, 0.0)),
+
+                # trigger branch: real(fabs(denom)) > imag(fabs(denom))
+                # followed by if condition as both are == 0
+                # is performed in test_zero_division(), so this is skipped
+
+                # trigger else if branch: real(fabs(denom)) < imag(fabs(denom))
+                    (( 1.0, 2.0), ( 1.0, 2.0), (1.0, 0.0))
+                )
+                for cases in data:
+                    n=cases[0]
+                    d=cases[1]
+                    ex=cases[2]
+                    result = t(complex(n[0],n[1]))/t(complex(d[0],d[1]))
+                    # check real and imag parts separately to avoid comparison
+                    # in array context, which does not account for signed zeros
+                    assert_equal(result.real, ex[0])
+                    assert_equal(result.imag, ex[1])
+
 
 class TestConversion(TestCase):
     def test_int_from_long(self):


### PR DESCRIPTION
The current algorithm used in scalar math complex division appears to
incorrectly handle signed zeros. This patch duplicates the algorithm
used for complex division in the loops.c.src file into the
scalarmath.c.src file so the algorithms are consistent regardless of
context. Unit tests are added in the scalar context for testing the
correctness of sign when zeros are encountered and also to trip the new
branches in the now consistent algorithm.
