### PR TITLE
Backport 6697

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -96,7 +96,7 @@ extern "C" CONFUSE_EMACS
                                                       NULL)
 
 #define PyArray_FROM_OT(m,type) PyArray_FromAny(m,                            \
-                                PyArray_DescrFromType(type), 0, 0, 0, NULL);
+                                PyArray_DescrFromType(type), 0, 0, 0, NULL)
 
 #define PyArray_FROM_OTF(m, type, flags) \
         PyArray_FromAny(m, PyArray_DescrFromType(type), 0, 0, \


### PR DESCRIPTION
MAINT: fix spurious semicolon in macro definition of PyArray_FROM_OT

There is a spurious semicolon (;) character at the end of the macro
definition of PyArray_FROM_OT, in the header file ndarrayobject.h.  This
prevents the macro from being used like a function, e.g. one can't write
like

```
if ( !(arr = PyArray_FROM_OT( ... )) )
    ... ...
```

After removing the semicolon, the macro can be used like a C function.
