### PR TITLE
MAINT: Make no relaxed stride checking the default for 1.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.4
-      env: NPY_RELAXED_STRIDES_CHECKING=0
+      env: NPY_RELAXED_STRIDES_CHECKING=1
     - python: 2.7
       env: USE_BENTO=1
     - python: 2.7

--- a/numpy/core/bscript
+++ b/numpy/core/bscript
@@ -35,7 +35,7 @@ def make_relpath(f):
     return os.path.relpath(f, os.path.abspath(os.path.dirname(__file__)))
 
 ENABLE_SEPARATE_COMPILATION = (os.environ.get('NPY_SEPARATE_COMPILATION', "1") != "0")
-NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0")
+NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0")
 
 NUMPYCONFIG_SYM = []
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -19,7 +19,7 @@ from setup_common import *
 ENABLE_SEPARATE_COMPILATION = (os.environ.get('NPY_SEPARATE_COMPILATION', "1") != "0")
 # Set to True to enable relaxed strides checking. This (mostly) means
 # that `strides[dim]` is ignored if `shape[dim] == 1` when setting flags.
-NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0")
+NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0")
 
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -629,8 +629,6 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
 {
     PyArrayObject *self;
     _buffer_info_t *info = NULL;
-    int i;
-    Py_ssize_t sd;
 
     self = (PyArrayObject*)obj;
 
@@ -715,15 +713,19 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
          * regenerate strides from shape.
          */
         if (PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS) &&
-            !((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS)) {
-            sd = view->itemsize;
+                !((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS)) {
+            Py_ssize_t sd = view->itemsize;
+            int i;
+
             for (i = view->ndim-1; i >= 0; --i) {
                 view->strides[i] = sd;
                 sd *= view->shape[i];
             }
         }
         else if (PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS)) {
-            sd = view->itemsize;
+            Py_ssize_t sd = view->itemsize;
+            int i;
+
             for (i = 0; i < view->ndim; ++i) {
                 view->strides[i] = sd;
                 sd *= view->shape[i];

--- a/tools/test-installed-numpy.py
+++ b/tools/test-installed-numpy.py
@@ -38,7 +38,7 @@ import numpy
 
 # Check that NPY_RELAXED_STRIDES_CHECKING is active when set.
 # The same flags check is also used in the tests to switch behavior.
-if (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0"):
+if (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0"):
     if not numpy.ones((10, 1), order='C').flags.f_contiguous:
         print('NPY_RELAXED_STRIDES_CHECKING set, but not active.')
         sys.exit(1)

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -137,7 +137,7 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   . venv-for-wheel/bin/activate
   # Move out of source directory to avoid finding local numpy
   pushd dist
-  $PIP install --pre --upgrade --find-links . numpy
+  $PIP install --pre --no-index --upgrade --find-links=. numpy
   $PIP install nose
   popd
   run_test


### PR DESCRIPTION
Because of various back compatibility problems with relaxed stride
checking, make NPY_RELAXED_STRIDE_CHECKING=0 the default for the v1.10.2
release. See pull request #6684 and issue #6678 for discussion.
