### PR TITLE
BUG: Include relevant files from numpy/linalg/lapack_lite in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include numpy/random/mtrand/generate_mtrand_c.py
 recursive-include numpy/random/mtrand *.pyx *.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed
 recursive-include numpy/_build_utils *
+recursive-include numpy/linalg/lapack_lite *.c *.h
 # Add sdist files whose use depends on local configuration.
 include numpy/core/src/multiarray/cblasfuncs.c
 include numpy/core/src/multiarray/python_xerbla.c


### PR DESCRIPTION
After 1e436a5 *.h and *.c files from numpy/linalg/lapack_lite were no
longer included in source distributions. Fix this by adding them to
MANIFEST.in.

Closes #6694.
