### PR TITLE
BUG: Readd fallback CBLAS detection on linux.

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1678,8 +1678,36 @@ class blas_info(system_info):
         info = self.check_libs(lib_dirs, blas_libs, [])
         if info is None:
             return
-        info['language'] = 'f77'  # XXX: is it generally true?
+        if platform.system() != 'Windows' and self.has_cblas():
+            # The check for windows is needed because has_cblas uses the
+            # same compiler that was used to compile Python and msvc is
+            # often not installed when mingw is being used. This rough
+            # treatment is not desirable, but windows is tricky.
+            info['language'] = 'c'
+            info['define_macros'] = [('HAVE_CBLAS', None)]
+        else:
+            info['language'] = 'f77'  # XXX: is it generally true?
         self.set_info(**info)
+
+    def has_cblas(self):
+        # primitive cblas check by looking for the header
+        res = False
+        c = distutils.ccompiler.new_compiler()
+        tmpdir = tempfile.mkdtemp()
+        s = """#include <cblas.h>"""
+        src = os.path.join(tmpdir, 'source.c')
+        try:
+            with open(src, 'wt') as f:
+                f.write(s)
+            try:
+                c.compile([src], output_dir=tmpdir,
+                          include_dirs=self.get_include_dirs())
+                res = True
+            except distutils.ccompiler.CompileError:
+                res = False
+        finally:
+            shutil.rmtree(tmpdir)
+        return res
 
 
 class openblas_info(blas_info):


### PR DESCRIPTION
Fallback CBLAS detection was removed in gh-6183 because it led to
problems on windows platforms when msvc was not installed. As a result
of that fix, CBLAS detection fails for some Linux installations. The
solution here is to add back the fallback detection but make it specific
to Linux.

Closes #6675.
