### PR TITLE
BUG: Fix/workaround for #6719

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -61,7 +61,7 @@ def process_pyx(fromfile, tofile):
     except ImportError:
         pass
 
-    flags = ['--fast-fail']
+    flags = ['--fast-fail', '--directive', 'cdivision=True']
     if tofile.endswith('.cxx'):
         flags += ['--cplus']
 


### PR DESCRIPTION
numpy/random/mtrand/mtrand.pyx contains a line where cython fails to
compile, complaining “Pythonic division not allowed without gil”.  By
passing '--directive cdivision=true' to cython, it can compile again.
