### PR TITLE
Backport 6726

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -629,8 +629,6 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
 {
     PyArrayObject *self;
     _buffer_info_t *info = NULL;
-    int i;
-    Py_ssize_t sd;
 
     self = (PyArrayObject*)obj;
 
@@ -715,15 +713,19 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
          * regenerate strides from shape.
          */
         if (PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS) &&
-            !((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS)) {
-            sd = view->itemsize;
+                !((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS)) {
+            Py_ssize_t sd = view->itemsize;
+            int i;
+
             for (i = view->ndim-1; i >= 0; --i) {
                 view->strides[i] = sd;
                 sd *= view->shape[i];
             }
         }
         else if (PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS)) {
-            sd = view->itemsize;
+            Py_ssize_t sd = view->itemsize;
+            int i;
+
             for (i = 0; i < view->ndim; ++i) {
                 view->strides[i] = sd;
                 sd *= view->shape[i];

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -137,7 +137,7 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   . venv-for-wheel/bin/activate
   # Move out of source directory to avoid finding local numpy
   pushd dist
-  $PIP install --pre --upgrade --find-links . numpy
+  $PIP install --pre --no-index --upgrade --find-links=. numpy
   $PIP install nose
   popd
   run_test


### PR DESCRIPTION
BUG: Fix bugs exposed by relaxed stride rollback 

Fix two problems
- The travis ci wheels test was failing because the wrong wheel was being installed
- There were to variables that were unused when NPY_RELAXED_STRIDE_CHECKING=0.
