### PR TITLE
BUG/TST: Fix for #6729

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3695,7 +3695,7 @@ class MaskedArray(ndarray):
             if m is nomask:
                 res = self._data
             else:
-                if m.shape == ():
+                if m.shape == () and m.itemsize==len(m.dtype):
                     if m.dtype.names:
                         m = m.view((bool, len(m.dtype)))
                         if m.any():

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -625,6 +625,18 @@ class TestMaskedArray(TestCase):
         control = "[(--, (2, --)) (4, (--, 6.0))]"
         assert_equal(str(test), control)
 
+        # Test 0-d array with multi-dimensional dtype
+        t_2d0 = masked_array(data = (0, [[0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0]],
+                                    0.0),
+                             mask = (False, [[True, False, True],
+                                             [False, False, True]],
+                                     False),
+                             dtype = "int, (2,3)float, float")
+        control = "(0, [[--, 0.0, --], [0.0, 0.0, --]], 0.0)"
+        assert_equal(str(t_2d0), control)
+
+
     def test_flatten_structured_array(self):
         # Test flatten_structured_array on arrays
         # On ndarray


### PR DESCRIPTION
Fix representation of a structured masked array with dimension zero.
The effect of representing a masked array with dimension zero is now
similar to respresenting an mvoid.  This commit fixes #6729.
