### PR TITLE
MAINT: Make no relaxed stride checking the default for 1.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.4
-      env: NPY_RELAXED_STRIDES_CHECKING=0
+      env: NPY_RELAXED_STRIDES_CHECKING=1
     - python: 2.7
       env: USE_BENTO=1
     - python: 2.7

--- a/numpy/core/bscript
+++ b/numpy/core/bscript
@@ -35,7 +35,7 @@ def make_relpath(f):
     return os.path.relpath(f, os.path.abspath(os.path.dirname(__file__)))
 
 ENABLE_SEPARATE_COMPILATION = (os.environ.get('NPY_SEPARATE_COMPILATION', "1") != "0")
-NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0")
+NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0")
 
 NUMPYCONFIG_SYM = []
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -19,7 +19,7 @@ from setup_common import *
 ENABLE_SEPARATE_COMPILATION = (os.environ.get('NPY_SEPARATE_COMPILATION', "1") != "0")
 # Set to True to enable relaxed strides checking. This (mostly) means
 # that `strides[dim]` is ignored if `shape[dim] == 1` when setting flags.
-NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0")
+NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0")
 
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force

--- a/tools/test-installed-numpy.py
+++ b/tools/test-installed-numpy.py
@@ -38,7 +38,7 @@ import numpy
 
 # Check that NPY_RELAXED_STRIDES_CHECKING is active when set.
 # The same flags check is also used in the tests to switch behavior.
-if (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0"):
+if (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0"):
     if not numpy.ones((10, 1), order='C').flags.f_contiguous:
         print('NPY_RELAXED_STRIDES_CHECKING set, but not active.')
         sys.exit(1)


### PR DESCRIPTION
Because of various back compatibility problems with relaxed stride
checking, make NPY_RELAXED_STRIDE_CHECKING=0 the default for the v1.10.2
release. See pull request #6684 and issue #6678 for discussion.
