### PR TITLE
Backport 6094

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5880,33 +5880,15 @@ class mvoid(MaskedArray):
 
     def __str__(self):
         m = self._mask
-        if (m is nomask):
+        if m is nomask:
             return self._data.__str__()
-        m = tuple(m)
-        if (not any(m)):
-            return self._data.__str__()
-        r = self._data.tolist()
-        p = masked_print_option
-        if not p.enabled():
-            p = 'N/A'
-        else:
-            p = str(p)
-        r = [(str(_), p)[int(_m)] for (_, _m) in zip(r, m)]
-        return "(%s)" % ", ".join(r)
+        printopt = masked_print_option
+        rdtype = _recursive_make_descr(self._data.dtype, "O")
+        res = np.array([self._data]).astype(rdtype)
+        _recursive_printoption(res, self._mask, printopt)
+        return str(res[0])
 
-    def __repr__(self):
-        m = self._mask
-        if (m is nomask):
-            return self._data.__repr__()
-        m = tuple(m)
-        if not any(m):
-            return self._data.__repr__()
-        p = masked_print_option
-        if not p.enabled():
-            return self.filled(self.fill_value).__repr__()
-        p = str(p)
-        r = [(str(_), p)[int(_m)] for (_, _m) in zip(self._data.tolist(), m)]
-        return "(%s)" % ", ".join(r)
+    __repr__ = __str__
 
     def __iter__(self):
         "Defines an iterator for mvoid"

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -706,6 +706,42 @@ class TestMaskedArray(TestCase):
         finally:
             masked_print_option.set_display(ini_display)
 
+    def test_mvoid_multidim_print(self):
+
+        # regression test for gh-6019
+        t_ma = masked_array(data = [([1, 2, 3],)],
+                            mask = [([False, True, False],)],
+                            fill_value = ([999999, 999999, 999999],),
+                            dtype = [('a', '<i8', (3,))])
+        assert str(t_ma[0]) == "([1, --, 3],)"
+        assert repr(t_ma[0]) == "([1, --, 3],)"
+
+        # additonal tests with structured arrays
+
+        t_2d = masked_array(data = [([[1, 2], [3,4]],)],
+                            mask = [([[False, True], [True, False]],)],
+                            dtype = [('a', '<i8', (2,2))])
+        assert str(t_2d[0]) == "([[1, --], [--, 4]],)"
+        assert repr(t_2d[0]) == "([[1, --], [--, 4]],)"
+
+        t_0d = masked_array(data = [(1,2)],
+                            mask = [(True,False)],
+                            dtype = [('a', '<i8'), ('b', '<i8')])
+        assert str(t_0d[0]) == "(--, 2)"
+        assert repr(t_0d[0]) == "(--, 2)"
+
+        t_2d = masked_array(data = [([[1, 2], [3,4]], 1)],
+                            mask = [([[False, True], [True, False]], False)],
+                            dtype = [('a', '<i8', (2,2)), ('b', float)])
+        assert str(t_2d[0]) == "([[1, --], [--, 4]], 1.0)"
+        assert repr(t_2d[0]) == "([[1, --], [--, 4]], 1.0)"
+
+        t_ne = masked_array(data=[(1, (1, 1))],
+                            mask=[(True, (True, False))],
+                            dtype = [('a', '<i8'), ('b', 'i4,i4')])
+        assert str(t_ne[0]) == "(--, (--, 1))"
+        assert repr(t_ne[0]) == "(--, (--, 1))"
+
     def test_object_with_array(self):
         mx1 = masked_array([1.], mask=[True])
         mx2 = masked_array([1., 2.])


### PR DESCRIPTION
BUG: Fixed string representation of mvoid with multi-dimensional columns

This fixes a bug that caused the string representation of masked structured array rows with multi-dimensional columns to fail (numpy/numpy#6019), and includes a regression test.

Since **repr** suffered from a similar bug, and since previously **repr** returned the same as **str** for mvoid, we now set **repr** to reference the same method as **str**.
