### PR TITLE
DEP: Deprecate changing shape of non-C-contiguous array via descr.

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -487,11 +487,25 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
 
 
     if ((newtype->elsize != PyArray_DESCR(self)->elsize) &&
-        (PyArray_NDIM(self) == 0 || !PyArray_ISONESEGMENT(self) ||
-         PyDataType_HASSUBARRAY(newtype))) {
+            (PyArray_NDIM(self) == 0 ||
+             !PyArray_ISONESEGMENT(self) ||
+             PyDataType_HASSUBARRAY(newtype))) {
         goto fail;
     }
-    if (PyArray_ISCONTIGUOUS(self)) {
+
+    /* Deprecate not C contiguous and a dimension changes */
+    if (newtype->elsize != PyArray_DESCR(self)->elsize &&
+            !PyArray_IS_C_CONTIGUOUS(self)) {
+        /* 11/27/2015 1.10.2 */
+        if (DEPRECATE("Changing the shape of non-C contiguous array by "
+                      "descriptor assignment is deprecated. To maintain "
+                      "the Fortran contiguity of a multidimensional Fortran "
+                      "array, use 'a.T.view(...).T' instead") < 0) {
+            return -1;
+        }
+    }
+
+    if (PyArray_IS_C_CONTIGUOUS(self)) {
         i = PyArray_NDIM(self) - 1;
     }
     else {


### PR DESCRIPTION
This deprecates assignment of a new descriptor to the dtype attribute of
a non-C-contiguous array if it result in changing the shape. This
effectively bars viewing a multidimensional Fortran array using a dtype
that changes the element size along the first axis.

The reason for the deprecation is that, when relaxed strides checking is
enabled, arrays that are both C and Fortran contiguous are always
treated as C contiguous which breaks some code that depended the two
being mutually exclusive for arrays of dimension > 1. The intent of this
deprecation is to prepare the way to always enable relaxed stride
checking.
## Example

```
In [1]: import warnings

In [2]: warnings.simplefilter('always')

In [3]: a = ones((2, 1), order='F').view(complex)
/home/charris/.local/bin/ipython:1: DeprecationWarning: Changing the shape
of non-C contiguous array by descriptor assignment is deprecated. To
maintain the Fortran contiguity of a multidimensional Fortran array, use
'a.T.view(...).T' instead
```
