### PR TITLE
DEP: Deprecate changing shape of non-C-contiguous array via descr.

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -18,6 +18,8 @@ Dropped Support
 Future Changes
 ==============
 
+* Relaxed stride checking will become the default.
+
 
 Compatibility notes
 ===================
@@ -36,7 +38,7 @@ DeprecationWarning to error
 * Non-integers used as index values raise TypeError,
   e.g., in reshape, take, and specifying reduce axis.
 
-FutureWarning to changed behavior 
+FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * In ``np.lib.split`` an empty array in the result always had dimension
@@ -96,3 +98,16 @@ Changes
 Deprecations
 ============
 
+Views of arrays in Fortran order
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The f_contiguous flag was used to signal that views as a dtypes that
+changed the element size would change the first index. This was always a
+bit problematical for arrays that were both f_contiguous and c_contiguous
+because c_contiguous took precendence. Relaxed stride checking results in
+more such dual contiguous arrays and breaks some existing code as a result.
+Note that this also affects changing the dtype by assigning to the dtype
+attribute of an array. The aim of this deprecation is to restrict views to
+c_contiguous arrays at some future time. A work around that is backward
+compatible is to use `a.T.view(...).T` instead. A parameter will also be
+added to the view method to explicitly ask for Fortran order views, but
+that will not be backward compatible.

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -375,7 +375,7 @@ class TestBooleanIndexShapeMismatchDeprecation():
              arr.__getitem__, (slice(None), index))
 
 
-class TestFullDefaultDtype:
+class TestFullDefaultDtype(object):
     """np.full defaults to float when dtype is not set.  In the future, it will
     use the fill value's dtype.
     """
@@ -384,6 +384,20 @@ class TestFullDefaultDtype:
         assert_warns(FutureWarning, np.full, 1, 1)
         assert_warns(FutureWarning, np.full, 1, None)
         assert_no_warnings(np.full, 1, 1, float)
+
+
+class TestNonCContiguousViewDeprecation(_DeprecationTestCase):
+    """View of non-C-contiguous arrays deprecated in 1.11.0.
+
+    The deprecation will not be raised for arrays that are both C and F
+    contiguous, as C contiguous is dominant. There are more such arrays
+    with relaxed stride checking than without so the deprecation is not
+    as visible with relaxed stride checking in force.
+    """
+
+    def test_fortran_contiguous(self):
+        self.assert_deprecated(np.ones((2,2)).T.view, args=(np.complex,))
+        self.assert_deprecated(np.ones((2,2)).T.view, args=(np.int8,))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This deprecates assignment of a new descriptor to the dtype attribute of
a non-C-contiguous array if it result in changing the shape. This
effectively bars viewing a multidimensional Fortran array using a dtype
that changes the element size along the first axis.

The reason for the deprecation is that, when relaxed strides checking is
enabled, arrays that are both C and Fortran contiguous are always
treated as C contiguous which breaks some code that depended the two
being mutually exclusive for arrays of dimension > 1. The intent of this
deprecation is to prepare the way to always enable relaxed stride
checking.
## Example

```
In [1]: import warnings

In [2]: warnings.simplefilter('always')

In [3]: a = ones((2, 1), order='F').view(complex)
/home/charris/.local/bin/ipython:1: DeprecationWarning: Changing the shape
of non-C contiguous array by descriptor assignment is deprecated. To
maintain the Fortran contiguity of a multidimensional Fortran array, use
'a.T.view(...).T' instead
```
