### PR TITLE
Fix indexing on `ma.mvoid` to be consistent with `void`; fixes #6724

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5869,6 +5869,18 @@ class mvoid(MaskedArray):
 
         """
         m = self._mask
+        if m[indx].size > 1:
+            # Can happen when indx is a multi-dimensional field:
+            # A = ma.masked_array(data=[([0,1],)], mask=[([True,
+            #                     False],)], dtype=[("A", ">i2", (2,))])
+            # x = A[0]; y = x["A"]; then y.mask["A"].size==2
+            # and we can not say masked/unmasked.
+            # The result is no longer mvoid!
+            # See also issue #6724.
+            return masked_array(
+                data=self._data[indx], mask=m[indx],
+                fill_value=self._fill_value[indx],
+                hard_mask=self._hardmask)
         if m is not nomask and m[indx]:
             return masked
         return self._data[indx]

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -712,6 +712,14 @@ class TestMaskedArray(TestCase):
         self.assertTrue(f['a'] is masked)
         assert_equal(f[1], 4)
 
+        # exotic dtype
+        A = masked_array(data=[([0,1],)],
+                         mask=[([True, False],)],
+                         dtype=[("A", ">i2", (2,))])
+        assert_equal(A[0]["A"], A["A"][0])
+        assert_equal(A[0]["A"], masked_array(data=[0, 1],
+                         mask=[True, False], dtype=">i2"))
+
     def test_mvoid_iter(self):
         # Test iteration on __getitem__
         ndtype = [('a', int), ('b', int)]


### PR DESCRIPTION
Repair indexing on `ma.mvoid` so that it is consistent with `void`.  Changes only behaviour currently broken.  Fixes #6724.  

Currently, or a standard `ndarray`, given `Z = zeros((2,), dtype="(2,)i2,(2,)i2")`, `Z[0]` is `void` but `Z[0][0]` and `Z[0]["f1"]` are `ndarray`.  However, trying the same with `ma.mvoid` results in `ValueError`.  With this commit, indexing a `ma.mvoid` with a similar dtype results in `ma.masked_array`.
