### PR TITLE
BUG: resizing empty array with complex dtype failed

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1134,7 +1134,7 @@ def resize(a, new_shape):
     a = ravel(a)
     Na = len(a)
     if not Na:
-        return mu.zeros(new_shape, a.dtype.char)
+        return mu.zeros(new_shape, a.dtype)
     total_size = um.multiply.reduce(new_shape)
     n_copies = int(total_size / Na)
     extra = total_size % Na

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -30,7 +30,15 @@ class TestResize(TestCase):
     def test_zeroresize(self):
         A = np.array([[1, 2], [3, 4]])
         Ar = np.resize(A, (0,))
-        assert_equal(Ar, np.array([]))
+        assert_array_equal(Ar, np.array([]))
+        assert_equal(A.dtype, Ar.dtype)
+
+    def test_reshape_from_zero(self):
+        # See also gh-6740
+        A = np.zeros(0, dtype=[('a', np.float32, 1)])
+        Ar = np.resize(A, (2, 1))
+        assert_array_equal(Ar, np.zeros((2, 1), Ar.dtype))
+        assert_equal(A.dtype, Ar.dtype)
 
 
 class TestNonarrayArgs(TestCase):


### PR DESCRIPTION
This is because the dtype was passed into the new array as a
char, and many dtypes do not have a valid char representation.

Closes gh-6740
