### PR TITLE
BUG/TST: Fix #6760 by correctly describing mask on nested subdtypes

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1248,7 +1248,7 @@ def _recursive_make_descr(datatype, newtype=bool_):
     # Is this some kind of composite a la (np.float,2)
     elif datatype.subdtype:
         mdescr = list(datatype.subdtype)
-        mdescr[0] = newtype
+        mdescr[0] = _recursive_make_descr(datatype.subdtype[0], newtype)
         return tuple(mdescr)
     else:
         return newtype

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -608,6 +608,13 @@ class TestMaskedArray(TestCase):
         control = np.array([(0, 1), (2, 0)], dtype=a['B'].dtype)
         assert_equal(test, control)
 
+        # test if mask gets set correctly (see #6760)
+        Z = numpy.ma.zeros(2, numpy.dtype([("A", "(2,2)i1,(2,2)i1", (2,2))]))
+        assert_equal(Z.data.dtype, numpy.dtype([('A', [('f0', 'i1', (2, 2)),
+                                          ('f1', 'i1', (2, 2))], (2, 2))]))
+        assert_equal(Z.mask.dtype, numpy.dtype([('A', [('f0', '?', (2, 2)),
+                                          ('f1', '?', (2, 2))], (2, 2))]))
+
     def test_filled_w_f_order(self):
         # Test filled w/ F-contiguous array
         a = array(np.array([(0, 1, 2), (4, 5, 6)], order='F'),


### PR DESCRIPTION
Fix #6760.  In ma.core._recursive_make_descr, consider the case where a
subdtype does itself have named fields.  This ensures the correct mask for
an array like `ma.zeros(2, dtype([("A", "(2,2)i1,(2,2)i1", (2,2))]))`.
