### PR TITLE
BUG/TST: Fix for #6724, make numpy.ma.mvoid consistent with numpy.void

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5869,6 +5869,18 @@ class mvoid(MaskedArray):
 
         """
         m = self._mask
+        if isinstance(m[indx], ndarray):
+            # Can happen when indx is a multi-dimensional field:
+            # A = ma.masked_array(data=[([0,1],)], mask=[([True,
+            #                     False],)], dtype=[("A", ">i2", (2,))])
+            # x = A[0]; y = x["A"]; then y.mask["A"].size==2
+            # and we can not say masked/unmasked.
+            # The result is no longer mvoid!
+            # See also issue #6724.
+            return masked_array(
+                data=self._data[indx], mask=m[indx],
+                fill_value=self._fill_value[indx],
+                hard_mask=self._hardmask)
         if m is not nomask and m[indx]:
             return masked
         return self._data[indx]

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -712,6 +712,14 @@ class TestMaskedArray(TestCase):
         self.assertTrue(f['a'] is masked)
         assert_equal(f[1], 4)
 
+        # exotic dtype
+        A = masked_array(data=[([0,1],)],
+                         mask=[([True, False],)],
+                         dtype=[("A", ">i2", (2,))])
+        assert_equal(A[0]["A"], A["A"][0])
+        assert_equal(A[0]["A"], masked_array(data=[0, 1],
+                         mask=[True, False], dtype=">i2"))
+
     def test_mvoid_iter(self):
         # Test iteration on __getitem__
         ndtype = [('a', int), ('b', int)]


### PR DESCRIPTION
This is an alternative fix for #6724.  The other fix is in #6755.

Make indexing on numpy.ma.mvoid consistent with indexing on numpy.void.
Changes behaviour in rare cases (see below). Fixes #6724.  Sometimes,
indexing ma.mvoid results in a non-scalar mask.  For example, dimension
increases if indexing with a multi-dimensional field.  Previously, this
led to a ValueError (truth value ambiguous).  With this commit, indexing
now returns an ma.masked_array so that there is no loss of information.

Note that there is a precedence for returning from void to array.  `Z =
zeros((2,), dtype="(2,)i2,(2,)i2")`, then Z[0] is a void, but `Z[0][0]
and Z[0]["f1"]` are array.  This commit therefore implements behaviour
such that `numpy.ma.mvoid` is consistent with `numpy.void`.

Also adds a related test.

The behaviour changes in cases where for a masked array `X`, `X.dtype["A"]`
is multidimensional but size 1, such as in the example below.  Any case
where `X.dtype["A"]` is multidimensional but with size>1 would previously
fail.

Old behaviour:

```
In [15]: X = ma.masked_array(data=[([0],)], mask=[([False],)],
        dtype=[("A", "(1,1)i2", (1,1))])

In [16]: X[0]["A"]
Out[16]: array([[[[0]]]], dtype=int16)

In [17]: X = ma.masked_array(data=[([0],)], mask=[([True],)],
        dtype=[("A", "(1,1)i2", (1,1))])

In [18]: X[0]["A"]
Out[18]: masked
```

New behaviour:

```
In [1]: X = ma.masked_array(data=[([0],)], mask=[([False],)],
        dtype=[("A", "(1,1)i2", (1,1))])

In [2]: X[0]["A"]
Out[2]:
masked_array(data =
 [[[[0]]]],
             mask =
 [[[[False]]]],
       fill_value = [[[[16959]]]])

In [3]: X = ma.masked_array(data=[([0],)], mask=[([True],)],
        dtype=[("A", "(1,1)i2", (1,1))])

In [4]: X[0]["A"]
Out[4]:
masked_array(data =
 [[[[--]]]],
             mask =
 [[[[ True]]]],
       fill_value = [[[[16959]]]])
```

The new behaviour is more consistent with indexing the data themselves:

```
In [7]: X.data[0]["A"]
Out[7]: array([[[[0]]]], dtype=int16)
```

In theory, this change in behaviour can break code, but I would consider
it very unlikely.
