### PR TITLE
Deploy dev wheels to rackspace from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,13 @@ matrix:
             - python3-nose
     - python: 2.7
       env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
-    - python: 2.7
-      env: USE_WHEEL=1
+    - python: 3.5
+      env:
+       - USE_WHEEL=1
+       - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
+       # The following is generated with the command:
+       # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY
+       - secure: "IEicLPrP2uW+jW51GRwkONQpdPqMVtQL5bdroqR/U8r9TrXrbCVRhp4AP8JYZT0ptoBpmZWWGjmKBndB68QlMiUjQPowiFWt9Ka92CaqYdU7nqfWp9VImSndPmssjmCXJ1v1IjZPAMahp7Qnm0rWRmA0z9SomuRUQOJQ6s684vU="
     - python: 2.7
       env: PYTHONOPTIMIZE=2
 before_install:
@@ -73,3 +78,6 @@ before_install:
 
 script:
   - ./tools/travis-test.sh
+
+after_success:
+  - ./tools/travis-upload-wheel.sh

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -94,14 +94,16 @@ export PIP
 if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   # Build wheel
   $PIP install wheel
+  # ensure that the pip / setuptools versions deployed inside the venv are recent enough
+  $PIP install -U virtualenv
   $PYTHON setup.py bdist_wheel
   # Make another virtualenv to install into
-  virtualenv --python=python venv-for-wheel
+  virtualenv --python=`which $PYTHON` venv-for-wheel
   . venv-for-wheel/bin/activate
   # Move out of source directory to avoid finding local numpy
   pushd dist
-  $PIP install --pre --no-index --upgrade --find-links=. numpy
-  $PIP install nose
+  pip install --pre --no-index --upgrade --find-links=. numpy
+  pip install nose
   popd
   run_test
 elif [ "$USE_CHROOT" != "1" ]; then

--- a/tools/travis-upload-wheel.sh
+++ b/tools/travis-upload-wheel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+export CLOUD_CONTAINER_NAME=travis-dev-wheels
+
+if [[ ( $USE_WHEEL == 1 ) && \
+      ( "$TRAVIS_BRANCH" == "master" ) && \
+      ( "$TRAVIS_PULL_REQUEST" == "false" ) ]]; then
+    pip install wheelhouse_uploader
+    python -m wheelhouse_uploader upload --local-folder $TRAVIS_BUILD_DIR/dist/ $CLOUD_CONTAINER_NAME
+fi


### PR DESCRIPTION
This is a fix for #6493. The python 3.5 build with the `USE_WHEEL=1` option is now configured to upload a timestamped dev wheel to a public rackspace file container so that downstreams projects like scipy and scikit-learn can configure their own CI to test against the master branch of numpy without having to build it from source them-selves.

wheelhouse_uploader>=0.9 automatically timestamps the local segment of the version of any wheel file it uploads to make it possible for pip to download the last uploaded dev version of the project. Only the 5 last uploaded dev wheels for a given platform are kept on the rackspace container.

The `tools/travis-test.sh` script will only try to upload the wheels generated from the master branch, outside of any pull request (that is, only on travis builds triggered from merge commits in the master branch).

The rackspace API key for the user account `travis.numpy` is encrypted with the public key of the `github.com/numpy/numpy` repo using the `travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=deadbeefcafebabe` command. I can send the rackspace credentials to a few numpy maintainers by private emails if you wish to change those credentials later.

I tested it on my ogrisel/numpy travis account (with a different secure key) and it worked:
http://66ce22ef0bf26a5e2cca-4ffdece11fd3f72855e4665bc61c7445.r49.cf2.rackcdn.com/index.html

cc @njsmith @stefanv
