### PR TITLE
MAINT: Include from __future__ boilerplate in some files missing it.

### DIFF
--- a/numpy/_build_utils/apple_accelerate.py
+++ b/numpy/_build_utils/apple_accelerate.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import os
 import sys
 import re

--- a/numpy/compat/tests/test_compat.py
+++ b/numpy/compat/tests/test_compat.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 from os.path import join
 
 from numpy.compat import isfileobj

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -2,6 +2,7 @@
 """ Test printing of scalar types.
 
 """
+from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import TestCase, run_module_suite

--- a/numpy/distutils/msvc9compiler.py
+++ b/numpy/distutils/msvc9compiler.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import os
 import distutils.msvc9compiler
 from distutils.msvc9compiler import *

--- a/numpy/distutils/msvccompiler.py
+++ b/numpy/distutils/msvccompiler.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import os
 import distutils.msvccompiler
 from distutils.msvccompiler import *

--- a/numpy/f2py/__main__.py
+++ b/numpy/f2py/__main__.py
@@ -1,4 +1,6 @@
 # See http://cens.ioc.ee/projects/f2py2e/
+from __future__ import division, print_function
+
 import os
 import sys
 for mode in ["g3-numpy", "2e-numeric", "2e-numarray", "2e-numpy"]:

--- a/numpy/lib/tests/test_packbits.py
+++ b/numpy/lib/tests/test_packbits.py
@@ -1,5 +1,6 @@
-import numpy as np
+from __future__ import division, absolute_import, print_function
 
+import numpy as np
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
 

--- a/numpy/linalg/tests/test_deprecations.py
+++ b/numpy/linalg/tests/test_deprecations.py
@@ -1,6 +1,8 @@
 """Test deprecation and future warnings.
 
 """
+from __future__ import division, absolute_import, print_function
+
 import numpy as np
 from numpy.testing import assert_warns, run_module_suite
 

--- a/pavement.py
+++ b/pavement.py
@@ -54,7 +54,7 @@ TODO
     - fix bdist_mpkg: we build the same source twice -> how to make sure we use
       the same underlying python for egg install in venv and for bdist_mpkg
 """
-from __future__ import division, absolute_import, print_function
+from __future__ import division, print_function
 
 # What need to be installed to build everything on mac os x:
 #   - wine: python 2.6 and 2.5 + makensis + cpuid plugin + mingw, all in the PATH

--- a/runtests.py
+++ b/runtests.py
@@ -24,6 +24,7 @@ Generate C code coverage listing under build/lcov/:
     $ python runtests.py --lcov-html
 
 """
+from __future__ import division, print_function
 
 #
 # This is a generic test runner script for projects using Numpy's test

--- a/tools/win32build/build-cpucaps.py
+++ b/tools/win32build/build-cpucaps.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 import os
 import subprocess
 # build cpucaps.dll


### PR DESCRIPTION
Some newer *.py files are missing the `from __future__` boilerplate
that helps assure Python2 and Python3 compatibility.
