### PR TITLE
Faster random.shuffle via static typing.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4977,7 +4977,9 @@ cdef class RandomState:
 
         # Logic adapted from random.shuffle()
         if isinstance(x, np.ndarray):
-            if x.ndim == 1 and x.dtype.itemsize == np.dtype(np.intp).itemsize:
+            if (x.ndim == 1 and
+                x.dtype.itemsize == np.dtype(np.intp).itemsize and
+                not isinstance(x, np.ma.MaskedArray)):
                 # Directly shuffle the array if possible.
                 self._shuffle_intpsized(x.view(np.intp))
             else:

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -8,6 +8,7 @@ from numpy import random
 from numpy.compat import asbytes
 import sys
 
+
 class TestSeed(TestCase):
     def test_scalar(self):
         s = np.random.RandomState(0)
@@ -37,6 +38,7 @@ class TestSeed(TestCase):
         assert_raises(ValueError, np.random.RandomState, [4294967296])
         assert_raises(ValueError, np.random.RandomState, [1, 2, 4294967296])
         assert_raises(ValueError, np.random.RandomState, [1, -2, 4294967296])
+
 
 class TestBinomial(TestCase):
     def test_n_zero(self):
@@ -127,6 +129,7 @@ class TestSetState(TestCase):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
         self.prng.negative_binomial(0.5, 0.5)
+
 
 class TestRandint(TestCase):
 
@@ -379,13 +382,19 @@ class TestRandomDist(TestCase):
         # gh-3263
         a = np.ma.masked_values(np.reshape(range(20), (5,4)) % 3 - 1, -1)
         b = np.ma.masked_values(np.arange(20) % 3 - 1, -1)
-        ma = np.ma.count_masked(a)
-        mb = np.ma.count_masked(b)
+        a_orig = a.copy()
+        b_orig = b.copy()
         for i in range(50):
             np.random.shuffle(a)
-            self.assertEqual(ma, np.ma.count_masked(a))
+            assert_equal(
+                sorted(a.data[a.mask]), sorted(a_orig.data[a_orig.mask]))
+            assert_equal(
+                sorted(a.data[~a.mask]), sorted(a_orig.data[~a_orig.mask]))
             np.random.shuffle(b)
-            self.assertEqual(mb, np.ma.count_masked(b))
+            assert_equal(
+                sorted(b.data[b.mask]), sorted(b_orig.data[b_orig.mask]))
+            assert_equal(
+                sorted(b.data[~b.mask]), sorted(b_orig.data[~b_orig.mask]))
 
     def test_beta(self):
         np.random.seed(self.seed)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -355,9 +355,12 @@ class TestRandomDist(TestCase):
         np.testing.assert_equal(actual, desired)
 
     def test_shuffle(self):
-        # Test lists, arrays, and multidimensional versions of both:
+        # Test lists, arrays (of various dtypes), and multidimensional versions
+        # of both:
         for conv in [lambda x: x,
-                     np.asarray,
+                     lambda x: np.asarray(x).astype(np.int8),
+                     lambda x: np.asarray(x).astype(np.float32),
+                     lambda x: np.asarray(x).astype(np.complex64),
                      lambda x: [(i, i) for i in x],
                      lambda x: np.asarray([(i, i) for i in x])]:
             np.random.seed(self.seed)
@@ -387,12 +390,8 @@ class TestRandomDist(TestCase):
         for i in range(50):
             np.random.shuffle(a)
             assert_equal(
-                sorted(a.data[a.mask]), sorted(a_orig.data[a_orig.mask]))
-            assert_equal(
                 sorted(a.data[~a.mask]), sorted(a_orig.data[~a_orig.mask]))
             np.random.shuffle(b)
-            assert_equal(
-                sorted(b.data[b.mask]), sorted(b_orig.data[b_orig.mask]))
             assert_equal(
                 sorted(b.data[~b.mask]), sorted(b_orig.data[~b_orig.mask]))
 


### PR DESCRIPTION
This patch modifies random.shuffle so that (when working on a ndarray) an array
of indices is shuffled and then elements are take()n from that array in that
order.  This allows the inner loop to be statically typed (it turns out this
is not so easy to write a generic shuffling code using Cython fused types) and
thus much faster (~6x for me), at the expense of a threefold increase in memory
use (I guess take() needs to create a copy, and an additional array of indices
is created.).

See #5514.
