### PR TITLE
Backport 6747

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -487,11 +487,25 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
 
 
     if ((newtype->elsize != PyArray_DESCR(self)->elsize) &&
-        (PyArray_NDIM(self) == 0 || !PyArray_ISONESEGMENT(self) ||
-         PyDataType_HASSUBARRAY(newtype))) {
+            (PyArray_NDIM(self) == 0 ||
+             !PyArray_ISONESEGMENT(self) ||
+             PyDataType_HASSUBARRAY(newtype))) {
         goto fail;
     }
-    if (PyArray_ISCONTIGUOUS(self)) {
+
+    /* Deprecate not C contiguous and a dimension changes */
+    if (newtype->elsize != PyArray_DESCR(self)->elsize &&
+            !PyArray_IS_C_CONTIGUOUS(self)) {
+        /* 11/27/2015 1.11.0 */
+        if (DEPRECATE("Changing the shape of non-C contiguous array by\n"
+                      "descriptor assignment is deprecated. To maintain\n"
+                      "the Fortran contiguity of a multidimensional Fortran\n"
+                      "array, use 'a.T.view(...).T' instead") < 0) {
+            return -1;
+        }
+    }
+
+    if (PyArray_IS_C_CONTIGUOUS(self)) {
         i = PyArray_NDIM(self) - 1;
     }
     else {

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -606,7 +606,7 @@ class TestBooleanIndexShapeMismatchDeprecation():
              arr.__getitem__, (slice(None), index))
 
 
-class TestFullDefaultDtype:
+class TestFullDefaultDtype(object):
     """np.full defaults to float when dtype is not set.  In the future, it will
     use the fill value's dtype.
     """
@@ -615,6 +615,20 @@ class TestFullDefaultDtype:
         assert_warns(FutureWarning, np.full, 1, 1)
         assert_warns(FutureWarning, np.full, 1, None)
         assert_no_warnings(np.full, 1, 1, float)
+
+
+class TestNonCContiguousViewDeprecation(_DeprecationTestCase):
+    """View of non-C-contiguous arrays deprecated in 1.11.0.
+
+    The deprecation will not be raised for arrays that are both C and F
+    contiguous, as C contiguous is dominant. There are more such arrays
+    with relaxed stride checking than without so the deprecation is not
+    as visible with relaxed stride checking in force.
+    """
+
+    def test_fortran_contiguous(self):
+        self.assert_deprecated(np.ones((2,2)).T.view, args=(np.complex,))
+        self.assert_deprecated(np.ones((2,2)).T.view, args=(np.int8,))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
DEP: Deprecate changing shape of non-C-contiguous array via descr.

This deprecates assignment of a new descriptor to the dtype attribute of
a non-C-contiguous array if it result in changing the shape. This
effectively bars viewing a multidimensional Fortran array using a dtype
that changes the element size along the first axis.

The reason for the deprecation is that, when relaxed strides checking is
enabled, arrays that are both C and Fortran contiguous are always
treated as C contiguous which breaks some code that depended the two
being mutually exclusive for arrays of dimension > 1. The intent of this
deprecation is to prepare the way to always enable relaxed stride
checking.
## Example

```
In [1]: import warnings

In [2]: warnings.simplefilter('always')

In [3]: a = ones((2, 1), order='F').view(complex)
/home/charris/.local/bin/ipython:1: DeprecationWarning: Changing the shape
of non-C contiguous array by descriptor assignment is deprecated. To
maintain the Fortran contiguity of a multidimensional Fortran array, use
'a.T.view(...).T' instead
```
