### PR TITLE
BUG: metadata is not copied to base_dtype

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -806,10 +806,18 @@ _use_inherit(PyArray_Descr *type, PyObject *newobj, int *errflag)
     }
     new->elsize = conv->elsize;
     if (PyDataType_HASFIELDS(conv)) {
+        Py_XDECREF(new->fields);
         new->fields = conv->fields;
         Py_XINCREF(new->fields);
+
+        Py_XDECREF(new->names);
         new->names = conv->names;
         Py_XINCREF(new->names);
+    }
+    if (conv->metadata != NULL) {
+        Py_XDECREF(new->metadata);
+        new->metadata = conv->metadata;
+        Py_XINCREF(new->metadata);
     }
     new->flags = conv->flags;
     Py_DECREF(conv);

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -408,6 +408,10 @@ class TestMetadata(TestCase):
         d = np.dtype([('a', np.dtype(int, metadata={'datum': 1}))])
         self.assertEqual(d['a'].metadata, {'datum': 1})
 
+    def base_metadata_copied(self):
+        d = np.dtype((np.void, np.dtype('i4,i4', metadata={'datum': 1})))
+        assert_equal(d.metadata, {'datum': 1})
+
 class TestString(TestCase):
     def test_complex_dtype_str(self):
         dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),


### PR DESCRIPTION
The (somewhat obsolete) metadata attribute of the `data_dtype` should be
carried over in dtype specifications of the form
`(base_dtype, data_dtype)`. Fixes #6771

Incidentally fixes a reference leak in `dtype(('i4,i4', 'i4,i4'))`
