### PR TITLE
BUG: Fix travis ci testing for new google infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,25 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
+
+# Run jobs on container-based infrastructure, can be overridden per job
+sudo: false
+
+# Travis whitelists the installable packages, additions can be requested
+#   https://github.com/travis-ci/apt-package-whitelist
+addons:
+  apt:
+    packages: &common_packages
+      - gfortran
+      - libatlas-dev
+      - libatlas-base-dev
+      # Speedup builds, particularly when USE_CHROOT=1
+      - eatmydata
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 python:
   - 2.6
   - 2.7
@@ -12,8 +31,21 @@ matrix:
   include:
     - python: 3.3
       env: USE_CHROOT=1 ARCH=i386 DIST=trusty PYTHON=3.4
+      sudo: true
+      addons:
+        apt:
+          packages:
+            - *common_packages
+            - debootstrap
     - python: 3.2
       env: USE_DEBUG=1
+      addons:
+        apt:
+          packages:
+            - *common_packages
+            - python3-dbg
+            - python3-dev
+            - python3-nose
     - python: 2.7
       env: NPY_SEPARATE_COMPILATION=0 PYTHON_OO=1
     - python: 3.4
@@ -35,13 +67,12 @@ before_install:
   # We therefore control our own environment, avoid travis' numpy
   - virtualenv --python=python venv
   - source venv/bin/activate
-  - pip install nose
-  # pip install coverage
   - python -V
   - pip install --upgrade pip setuptools
+  - pip install nose
+  # pip install coverage
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython
-  - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   - popd
 
 script:


### PR DESCRIPTION
Travis ci has updated their default infrastructure and this breaks
the heritage infrastructure that 1.10 testing relied on. The fix
here is to copy the testing from the master branch and modify it
to run for 1.10. In particular, bento and single file compilation
testing needed to be added back in and the relaxed stride default
disabled.

Closes #6781.
