### PR TITLE
[doc] Fix title of governance section in docs

### DIFF
--- a/doc/source/dev/governance/index.rst
+++ b/doc/source/dev/governance/index.rst
@@ -1,5 +1,5 @@
 #####################
-Contributing to Numpy
+NumPy governance
 #####################
 
 .. toctree::


### PR DESCRIPTION
EXTREMELY IMPORTNAT FIX PLS MERGE ASAP THANKS

(Sorry, just noticed this copy/paste silliness -- check out the section nesting breadcrumb at the top of https://docs.scipy.org/doc/numpy-dev/dev/governance/governance.html)
