### PR TITLE
TST,BUG: Make test_mvoid_multidim_print work for 32 bit systems.

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -756,7 +756,7 @@ class TestMaskedArray(TestCase):
         t_ma = masked_array(data = [([1, 2, 3],)],
                             mask = [([False, True, False],)],
                             fill_value = ([999999, 999999, 999999],),
-                            dtype = [('a', '<i8', (3,))])
+                            dtype = [('a', '<i4', (3,))])
         assert_(str(t_ma[0]) == "([1, --, 3],)")
         assert_(repr(t_ma[0]) == "([1, --, 3],)")
 


### PR DESCRIPTION
The test currently uses an `<i8` type which is converted to a Python
long integer when running on a 32 bit system with Python 2. That changes
the string printed by appending `L` to the printed integer value and
results in a failed test.

This should fix the first test failure reported by Christoph in #6807.
