### PR TITLE
BUG: Disable 32-bit msvc9 compiler optimizations for npy_rint

### DIFF
--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -260,6 +260,9 @@ double npy_atanh(double x)
 #endif
 
 #ifndef HAVE_RINT
+#if defined(_MSC_VER) && (_MSC_VER == 1500) && !defined(_WIN64)
+#pragma optimize("", off)
+#endif
 double npy_rint(double x)
 {
     double y, r;
@@ -280,6 +283,9 @@ double npy_rint(double x)
     }
     return y;
 }
+#if defined(_MSC_VER) && (_MSC_VER == 1500) && !defined(_WIN64)
+#pragma optimize("", on)
+#endif
 #endif
 
 #ifndef HAVE_TRUNC


### PR DESCRIPTION
Fixes `test_umath.test_rint_big_int` failure on 32-bit msvc9 builds reported at  #6807
