### PR TITLE
Allow for larger int64s in random.randint

### DIFF
--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -144,9 +144,19 @@ extern long rk_long(rk_state *state);
 extern unsigned long rk_ulong(rk_state *state);
 
 /*
+ * Returns a random unsigned long long between 0 and ULONGLONG_MAX inclusive
+ */
+extern unsigned long long rk_ulonglong(rk_state *state);
+
+/*
  * Returns a random unsigned long between 0 and max inclusive.
  */
 extern unsigned long rk_interval(unsigned long max, rk_state *state);
+
+/*
+ * Returns a random unsigned long long between 0 and max inclusive.
+ */
+extern unsigned long long rk_ll_interval(unsigned long long max, rk_state *state);
 
 /*
  * Returns a random double between 0.0 and 1.0, 1.0 excluded.

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -159,6 +159,18 @@ class TestRandomDist(TestCase):
                             [-48, -66]])
         np.testing.assert_array_equal(actual, desired)
 
+    def test_large_int64_randint(self):
+        # See Issue #6812
+        np.random.seed(self.seed)
+        actual = np.random.randint(np.iinfo(np.int64).min,
+                                   np.iinfo(np.int64).max, 10)
+        desired = np.array([2191376711989041151, 1690157618316108847,
+                            7169946713346608947, 7224755809774414763,
+                            -782741873214082756, 5131664369514206857,
+                            -4296915062901047764, 9151544378226042618,
+                            739620276746913830, 692151521286146367])
+        np.testing.assert_array_equal(actual, desired)
+
     def test_random_integers(self):
         np.random.seed(self.seed)
         actual = np.random.random_integers(-99, 99, size=(3, 2))


### PR DESCRIPTION
Addresses enhancement requested in #6812 in which attempts to generate random, large 64-bit integers was causing overflow issues in Windows.  This PR allows such generation to be done.
