### PR TITLE
BENCH: speed up benchmark suite import time

### DIFF
--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .common import Benchmark, squares_, indexes_, indexes_rand_
+from .common import Benchmark, get_squares_, get_indexes_, get_indexes_rand_
 
 import sys
 import six
@@ -17,10 +17,10 @@ class Indexing(Benchmark):
     def setup(self, indexes, sel, op):
         sel = sel.replace('I', indexes)
 
-        ns = {'squares_': squares_,
+        ns = {'squares_': get_squares_(),
               'np': np,
-              'indexes_': indexes_,
-              'indexes_rand_': indexes_rand_}
+              'indexes_': get_indexes_(),
+              'indexes_rand_': get_indexes_rand_()}
 
         if sys.version_info[0] >= 3:
             code = "def run():\n    for a in squares_.values(): a[%s]%s"

--- a/benchmarks/benchmarks/bench_io.py
+++ b/benchmarks/benchmarks/bench_io.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .common import Benchmark, squares
+from .common import Benchmark, get_squares
 
 import numpy as np
 
@@ -57,5 +57,8 @@ class CopyTo(Benchmark):
 
 
 class Savez(Benchmark):
+    def setup(self):
+        self.squares = get_squares()
+
     def time_vb_savez_squares(self):
-        np.savez('tmp.npz', squares)
+        np.savez('tmp.npz', self.squares)

--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .common import Benchmark, squares_, indexes_rand
+from .common import Benchmark, get_squares_, get_indexes_rand, TYPES1
 
 import numpy as np
 
@@ -36,7 +36,7 @@ class Eindot(Benchmark):
 
 class Linalg(Benchmark):
     params = [['svd', 'pinv', 'det', 'norm'],
-              list(squares_.keys())]
+              TYPES1]
     param_names = ['op', 'type']
 
     def setup(self, op, typename):
@@ -46,10 +46,10 @@ class Linalg(Benchmark):
 
         if op == 'cholesky':
             # we need a positive definite
-            self.a = np.dot(squares_[typename],
-                            squares_[typename].T)
+            self.a = np.dot(get_squares_()[typename],
+                            get_squares_()[typename].T)
         else:
-            self.a = squares_[typename]
+            self.a = get_squares_()[typename]
 
         # check that dtype is supported at all
         try:
@@ -63,8 +63,8 @@ class Linalg(Benchmark):
 
 class Lstsq(Benchmark):
     def setup(self):
-        self.a = squares_['float64']
-        self.b = indexes_rand[:100].astype(np.float64)
+        self.a = get_squares_()['float64']
+        self.b = get_indexes_rand()[:100].astype(np.float64)
 
     def time_numpy_linalg_lstsq_a__b_float64(self):
         np.linalg.lstsq(self.a, self.b)

--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -1,16 +1,19 @@
 from __future__ import absolute_import, division, print_function
 
-from .common import Benchmark, TYPES1, squares
+from .common import Benchmark, TYPES1, get_squares
 
 import numpy as np
 
 
 class AddReduce(Benchmark):
+    def setup(self):
+        self.squares = get_squares().values()
+
     def time_axis_0(self):
-        [np.add.reduce(a, axis=0) for a in squares.values()]
+        [np.add.reduce(a, axis=0) for a in self.squares]
 
     def time_axis_1(self):
-        [np.add.reduce(a, axis=1) for a in squares.values()]
+        [np.add.reduce(a, axis=1) for a in self.squares]
 
 
 class AddReduceSeparate(Benchmark):
@@ -18,7 +21,7 @@ class AddReduceSeparate(Benchmark):
     param_names = ['axis', 'type']
 
     def setup(self, axis, typename):
-        self.a = squares[typename]
+        self.a = get_squares()[typename]
 
     def time_reduce(self, axis, typename):
         np.add.reduce(self.a, axis=axis)

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .common import Benchmark, squares_
+from .common import Benchmark, get_squares_
 
 import numpy as np
 
@@ -39,7 +39,7 @@ class Broadcast(Benchmark):
 class UFunc(Benchmark):
     params = [ufuncs]
     param_names = ['ufunc']
-    timeout = 2
+    timeout = 10
 
     def setup(self, ufuncname):
         np.seterr(all='ignore')
@@ -48,7 +48,7 @@ class UFunc(Benchmark):
         except AttributeError:
             raise NotImplementedError()
         self.args = []
-        for t, a in squares_.items():
+        for t, a in get_squares_().items():
             arg = (a,) * self.f.nin
             try:
                 self.f(*arg)


### PR DESCRIPTION
The input data generation in benchmarks/common.py takes ~ 1s, and it is
not used by most benchmarks. Generate it lazily instead, making sure the
generation is done in the setup() routines. Also, use numpy.random instead
of random.

Before:

```
$ time asv dev
...
real    6m13.719s
user    6m10.504s
sys 1m30.748s
```

After:

```
$ time asv dev
...
real    1m25.001s
user    1m24.868s
sys 1m27.272s
```

The speedup has fairly large impact on convenience for interactive use + generation of historical data.
