### PR TITLE
CI: run benchmark suite in travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,9 @@ matrix:
        # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY
        - secure: "IEicLPrP2uW+jW51GRwkONQpdPqMVtQL5bdroqR/U8r9TrXrbCVRhp4AP8JYZT0ptoBpmZWWGjmKBndB68QlMiUjQPowiFWt9Ka92CaqYdU7nqfWp9VImSndPmssjmCXJ1v1IjZPAMahp7Qnm0rWRmA0z9SomuRUQOJQ6s684vU="
     - python: 2.7
-      env: PYTHONOPTIMIZE=2
+      env:
+       - PYTHONOPTIMIZE=2
+       - USE_ASV=1
 before_install:
   - uname -a
   - free -m
@@ -74,6 +76,7 @@ before_install:
   # pip install coverage
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython
+  - if [ -n "$USE_ASV" ]; then pip install asv; fi
   - popd
 
 script:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -75,6 +75,17 @@ run_test()
   $PYTHON ../tools/test-installed-numpy.py # --mode=full
   # - coverage run --source=$INSTALLDIR --rcfile=../.coveragerc $(which $PYTHON) ../tools/test-installed-numpy.py
   # - coverage report --rcfile=../.coveragerc --show-missing
+
+  if [ -n "$USE_ASV" ]; then
+    pushd ../benchmarks
+    $PYTHON `which asv` machine --machine travis
+    $PYTHON `which asv` dev 2>&1| tee asv-output.log
+    if grep -q Traceback asv-output.log; then
+        echo "Some benchmarks have errors!"
+        exit 1
+    fi
+    popd
+  fi
 }
 
 # travis venv tests override python


### PR DESCRIPTION
This should ensure the suite stays in working condition, not to produce
reliable timing information.

gh-6829 reduces the time somewhat, so it probably is short enough for travis after that.
