### PR TITLE
Correct reference to Johnk's algorithm

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -188,7 +188,7 @@ double rk_beta(rk_state *state, double a, double b)
     if ((a <= 1.0) && (b <= 1.0))
     {
         double U, V, X, Y;
-        /* Use Jonk's algorithm */
+        /* Use Johnk's algorithm */
 
         while (1)
         {


### PR DESCRIPTION
It's possible "Jonk's" is an alternate spelling, but I couldn't find it. And, in Devroye (1986), it's "Johnk". This is a pedantic correction, but it helps when `CTRL`-`F`-ing the reference.
