### PR TITLE
Fixup #6696, updates to f2py.compile 

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -39,6 +39,7 @@ DeprecationWarning to error
 * Non-integers used as index values raise TypeError,
   e.g., in reshape, take, and specifying reduce axis.
 
+
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -62,21 +63,29 @@ mention it here for completeness.
 New Features
 ============
 
-* `np.histogram` now provides plugin estimators for automatically estimating the optimal
-number of bins. Passing one of ['auto', 'fd', 'scott', 'rice', 'sturges']
-as the argument to 'bins' results in the corresponding estimator being used.
+* `np.histogram` now provides plugin estimators for automatically
+  estimating the optimal number of bins. Passing one of ['auto', 'fd',
+  'scott', 'rice', 'sturges'] as the argument to 'bins' results in the
+  corresponding estimator being used.
 
-* A benchmark suite using `Airspeed Velocity <http://spacetelescope.github.io/asv/>`__
-has been added, converting the previous vbench-based one. You can run the suite locally
-via ``python runtests.py --bench``. For more details, see ``benchmarks/README.rst``.
+* A benchmark suite using `Airspeed Velocity
+  <http://spacetelescope.github.io/asv/>`__ has been added, converting the
+  previous vbench-based one. You can run the suite locally via ``python
+  runtests.py --bench``. For more details, see ``benchmarks/README.rst``.
 
 * A new function ``np.shares_memory`` that can check exactly whether two
-arrays have memory overlap is added. ``np.may_share_memory`` also now
-has an option to spend more effort to reduce false positives.
+  arrays have memory overlap is added. ``np.may_share_memory`` also now has
+  an option to spend more effort to reduce false positives.
 
-* ``SkipTest`` and ``KnownFailureException`` exception classes are exposed in the
-``numpy.testing`` namespace. Raise them in a test function to mark the test to
-be skipped or mark it as a known failure, respectively.
+* ``SkipTest`` and ``KnownFailureException`` exception classes are exposed
+  in the ``numpy.testing`` namespace. Raise them in a test function to mark
+  the test to be skipped or mark it as a known failure, respectively.
+
+* ``f2py.compile`` has a new ``extension`` keyword parameter that allows the
+  fortran extension to be specified for generated temp files. For instance,
+  the files can be specifies to be ``*.f90``. The ``verbose`` argument is
+  also activated, it was previously ignored.
+
 
 Improvements
 ============

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -38,6 +38,8 @@ def compile(source,
     extension: {'.f', '.f90'}, optional
         filename extension influences the fortran compiler behavior
 
+        .. versionadded:: 1.11.0
+
     '''
     from numpy.distutils.exec_command import exec_command
     import tempfile

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -19,16 +19,30 @@ main = f2py2e.main
 def compile(source,
             modulename='untitled',
             extra_args='',
-            verbose=1,
-            source_fn=None
+            verbose=True,
+            source_fn=None,
+            extension='.f'
             ):
     ''' Build extension module from processing source with f2py.
-    Read the source of this function for more information.
+
+    Parameters
+    ----------
+    source : str
+        Fortran source of module / subroutine to compile
+    modulename : str, optional
+        the name of compiled python module
+    extra_args: str, optional
+        additional parameters passed to f2py
+    verbose: bool, optional
+        print f2py output to screen
+    extension: {'.f', '.f90'}, optional
+        filename extension influences the fortran compiler behavior
+
     '''
     from numpy.distutils.exec_command import exec_command
     import tempfile
     if source_fn is None:
-        f = tempfile.NamedTemporaryFile(suffix='.f')
+        f = tempfile.NamedTemporaryFile(suffix=extension)
     else:
         f = open(source_fn, 'w')
 
@@ -36,13 +50,15 @@ def compile(source,
         f.write(source)
         f.flush()
 
-        args = ' -c -m %s %s %s' % (modulename, f.name, extra_args)
-        c = '%s -c "import numpy.f2py as f2py2e;f2py2e.main()" %s' % \
-            (sys.executable, args)
-        s, o = exec_command(c)
+        args = ' -c -m {} {} {}'.format(modulename, f.name, extra_args)
+        c = '{} -c "import numpy.f2py as f2py2e;f2py2e.main()" {}'
+        c = c.format(sys.executable, args)
+        status, output = exec_command(c)
+        if verbose:
+            print(output)
     finally:
         f.close()
-    return s
+    return status
 
 from numpy.testing import Tester
 test = Tester().test


### PR DESCRIPTION
Fixup of #6696.
- Verbose parameter was ignored earlier.
- Allowed .f90 extensions for tempfiles
