### PR TITLE
Fixup 6799, DOC: doc mistake in ifft - closes #6798.

### DIFF
--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -203,12 +203,16 @@ def ifft(a, n=None, axis=-1, norm=None):
     see `numpy.fft`.
 
     The input should be ordered in the same way as is returned by `fft`,
-    i.e., ``a[0]`` should contain the zero frequency term,
-    ``a[1:n/2]`` should contain the positive-frequency terms, and
-    ``a[n/2+1:]`` should contain the negative-frequency terms, in order of
-    decreasingly negative frequency. For an even number of input points,
-    ``A[n/2]`` represents both positive and negative Nyquist frequency.
-    See `numpy.fft` for details.
+    i.e.,
+
+    * ``a[0]`` should contain the zero frequency term,
+    * ``a[1:n//2]`` should contain the positive-frequency terms,
+    * ``a[n//2 + 1:]`` should contain the negative-frequency terms, in
+      increasing order starting from the most negative frequency.
+
+    For an even number of input points, ``A[n//2]`` represents the sum of
+    the values at the positive and negative Nyquist frequencies, as the two
+    are aliased together. See `numpy.fft` for details.
 
     Parameters
     ----------
@@ -265,9 +269,9 @@ def ifft(a, n=None, axis=-1, norm=None):
     >>> n[40:60] = np.exp(1j*np.random.uniform(0, 2*np.pi, (20,)))
     >>> s = np.fft.ifft(n)
     >>> plt.plot(t, s.real, 'b-', t, s.imag, 'r--')
-    [<matplotlib.lines.Line2D object at 0x...>, <matplotlib.lines.Line2D object at 0x...>]
+    ...
     >>> plt.legend(('real', 'imaginary'))
-    <matplotlib.legend.Legend object at 0x...>
+    ...
     >>> plt.show()
 
     """

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -204,9 +204,11 @@ def ifft(a, n=None, axis=-1, norm=None):
 
     The input should be ordered in the same way as is returned by `fft`,
     i.e., ``a[0]`` should contain the zero frequency term,
-    ``a[1:n/2+1]`` should contain the positive-frequency terms, and
+    ``a[1:n/2]`` should contain the positive-frequency terms, and
     ``a[n/2+1:]`` should contain the negative-frequency terms, in order of
-    decreasingly negative frequency.  See `numpy.fft` for details.
+    decreasingly negative frequency. For an even number of input points,
+    ``A[n/2]`` represents both positive and negative Nyquist frequency.
+    See `numpy.fft` for details.
 
     Parameters
     ----------


### PR DESCRIPTION
This updates the docstring updates done in #6799.
