### PR TITLE
Workaround for compiling in Windows

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -194,6 +194,8 @@ def check_long_double_representation(cmd):
             cmd.compiler.compile_options.remove("/GL")
         except ValueError:
             pass
+        except AttributeError:
+            pass
 
     # We need to use _compile because we need the object filename
     src, obj = cmd._compile(body, None, None, 'c')

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -192,9 +192,7 @@ def check_long_double_representation(cmd):
     if sys.platform == "win32" and not mingw32():
         try:
             cmd.compiler.compile_options.remove("/GL")
-        except ValueError:
-            pass
-        except AttributeError:
+        except (ValueError, AttributeError):
             pass
 
     # We need to use _compile because we need the object filename


### PR DESCRIPTION
Workaround for compiling `numpy` on a Windows machine; regards and _fixes_ following error message appearing when running `python setup.py install`:

> AttributeError: Mingw32CCompoler instance has no attribute 'compile_options'
