### PR TITLE
TST: Add initial appveyor configuration with no optimized BLAS.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+skip_tags: true
+clone_depth: 1
+
+os: Visual Studio 2015
+
+environment:
+  PYTHON_ARCH: "x86_64"
+  matrix:
+    - PY_MAJOR_VER: 2
+    - PY_MAJOR_VER: 3
+
+matrix:
+  #fast_finish: true
+  allow_failures:
+    - PY_MAJOR_VER: 2
+    - PY_MAJOR_VER: 3
+
+build_script:
+  - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
+  - cmd: C:\Miniconda.exe /S /D=C:\Py
+  - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
+  - conda config --set always_yes yes
+  - conda update conda
+  - conda install cython nose
+  - pip install . -vvv
+
+test_script:
+  - python runtests.py -v -n


### PR DESCRIPTION
This adds a minimal preliminary appveyor build script to test with Python 2.7/MSVC 2008 and Python 3.5/MSVC 2015. Both sets of tests are marked to allow failures since various tests don't currently pass. The issues that show up there should be taken care of in other PRs. The main idea here is to get something simple working now.

Someone with write-access to the repo should set up a free account so these tests can run for the main numpy repo. I've tested this thus far by running the tests on my fork. The free accounts only allow one build worker to be running at a given time, so I've only put two builds in the build matrix.
