### PR TITLE
ENH: Tempfile context manager

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -19,7 +19,7 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     TestCase, run_module_suite, assert_warns, assert_,
     assert_raises_regex, assert_raises, assert_allclose,
-    assert_array_equal,
+    assert_array_equal,temppath
 )
 from numpy.testing.utils import tempdir
 
@@ -259,26 +259,17 @@ class TestSavezLoad(RoundtripTest, TestCase):
     def test_not_closing_opened_fid(self):
         # Test that issue #2178 is fixed:
         # verify could seek on 'loaded' file
-
-        fd, tmp = mkstemp(suffix='.npz')
-        os.close(fd)
-        try:
-            fp = open(tmp, 'wb')
-            np.savez(fp, data='LOVELY LOAD')
-            fp.close()
-
-            fp = open(tmp, 'rb', 10000)
-            fp.seek(0)
-            assert_(not fp.closed)
-            np.load(fp)['data']
-            # fp must not get closed by .load
-            assert_(not fp.closed)
-            fp.seek(0)
-            assert_(not fp.closed)
-
-        finally:
-            fp.close()
-            os.remove(tmp)
+        with temppath(suffix='.npz') as tmp:
+            with open(tmp, 'wb') as fp:
+                np.savez(fp, data='LOVELY LOAD')
+            with open(tmp, 'rb', 10000) as fp:
+                fp.seek(0)
+                assert_(not fp.closed)
+                np.load(fp)['data']
+                # fp must not get closed by .load
+                assert_(not fp.closed)
+                fp.seek(0)
+                assert_(not fp.closed)
 
     def test_closing_fid(self):
         # Test that issue #1517 (too many opened files) remains closed

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -788,11 +788,13 @@ def test_tempdir():
             pass
     assert_(not os.path.isdir(tdir))
 
+    raised = False
     try:
         with tempdir() as tdir:
             raise ValueError()
     except ValueError:
-        pass
+        raised = True
+    assert_(raised)
     assert_(not os.path.isdir(tdir))
 
 
@@ -803,11 +805,13 @@ def test_temppath():
             pass
     assert_(not os.path.isfile(fpath))
 
+    raised = False
     try:
         with temppath() as fpath:
             raise ValueError()
     except ValueError:
-        pass
+        raised = True
+    assert_(raised)
     assert_(not os.path.isfile(fpath))
 
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import warnings
 import sys
+import os
 
 import numpy as np
 from numpy.testing import (
@@ -10,7 +11,7 @@ from numpy.testing import (
     assert_warns, assert_no_warnings, assert_allclose, assert_approx_equal,
     assert_array_almost_equal_nulp, assert_array_max_ulp,
     clear_and_catch_warnings, run_module_suite,
-    assert_string_equal
+    assert_string_equal, assert_, tempdir, temppath, 
     )
 import unittest
 
@@ -778,6 +779,36 @@ def test_clear_and_catch_warnings():
         warnings.simplefilter('ignore')
         warnings.warn('Another warning')
     assert_warn_len_equal(my_mod, 2)
+
+
+def test_tempdir():
+    with tempdir() as tdir:
+        fpath = os.path.join(tdir, 'tmp')
+        with open(fpath, 'w'):
+            pass
+    assert_(not os.path.isdir(tdir))
+
+    try:
+        with tempdir() as tdir:
+            raise ValueError()
+    except ValueError:
+        pass
+    assert_(not os.path.isdir(tdir))
+
+
+
+def test_temppath():
+    with temppath() as fpath:
+        with open(fpath, 'w') as f:
+            pass
+    assert_(not os.path.isfile(fpath))
+
+    try:
+        with temppath() as fpath:
+            raise ValueError()
+    except ValueError:
+        pass
+    assert_(not os.path.isfile(fpath))
 
 
 class my_cacw(clear_and_catch_warnings):


### PR DESCRIPTION
Context manager intended for use when the same temporary file needs to be opened and closed more than once. The context manager creates the file, closes it, and returns the path to the file. On exit from the context block the file is removed. The file should be closed before
exiting the context as an error will be raised on windows if not.

Also fix up the `tempdir` context manager to deal with exceptions.

Tests are added for both `temppath` and `tempdir` and  test_not_closing_opened_fid is refactored as an example.
