### PR TITLE
BUG: ma.testutils.assert_equal on nans throws AssertionError #6661

### DIFF
--- a/numpy/ma/tests/test_testutils.py
+++ b/numpy/ma/tests/test_testutils.py
@@ -1,0 +1,94 @@
+from numpy.testing import assert_raises
+from numpy.testing import run_module_suite
+from numpy.ma.core import MaskError
+import numpy as np
+import numpy.ma as ma
+from numpy.ma.testutils import assert_equal
+
+
+class TestAssertEqual:
+    def test_dictionary(self):
+        dict_a = {'foo': 'bar', 'foo2': 'bar2'}
+        dict_b = {'foo': 'bar', 'foo2': 'bar2', 'foo3': 'bar3'}
+        dict_c = {'foo': 'bar', 'foo2': 'bar2', 'foo3': 'baz1'}
+        tup_1 = ('foo')
+        array_1 = np.array([1, 2])
+
+        assert_equal({}, {})
+        assert_equal(dict_a, dict_a)
+        assert_equal(dict_b, dict_b)
+
+        assert_raises(AssertionError, assert_equal, dict_a, dict_b)
+        assert_raises(AssertionError, assert_equal, dict_b, dict_c)
+        assert_raises(AssertionError, assert_equal, dict_a, dict_c)
+        assert_raises(AssertionError, assert_equal, dict_a, 1)
+        assert_raises(AssertionError, assert_equal, dict_a, {})
+        assert_raises(AssertionError, assert_equal, dict_a, [])
+        assert_raises(AssertionError, assert_equal, dict_a, tup_1)
+        assert_raises(AssertionError, assert_equal, dict_a, array_1)
+
+    def test_nan(self):
+        assert_equal(np.nan, np.nan)
+
+        assert_raises(AssertionError, assert_equal, np.nan, 1)
+        assert_raises(AssertionError, assert_equal, np.nan, {})
+        assert_raises(AssertionError, assert_equal, np.nan, [1])
+        assert_raises(AssertionError, assert_equal, np.nan, 1.0)
+
+    def test_list(self):
+        assert_equal([], [])
+        assert_equal([1], [1])
+        assert_raises(AssertionError, assert_equal, [1], [2])
+        assert_raises(AssertionError, assert_equal, 1, [2])
+        assert_raises(AssertionError, assert_equal, [1], 2)
+        assert_raises(AssertionError, assert_equal, [1], 1)
+        assert_raises(AssertionError, assert_equal, 1, [1])
+
+    def test_tuple(self):
+        tup_1 = ('foo')
+        tup_2 = ('foo', 'bar', 'baz')
+
+        assert_equal((), ())
+        assert_equal(tup_1, tup_1)
+        assert_equal(tup_2, tup_2)
+
+        assert_raises(AssertionError, assert_equal, tup_1, tup_2)
+        assert_raises(AssertionError, assert_equal, tup_1, 1)
+        assert_raises(AssertionError, assert_equal, tup_1, np.nan)
+        assert_raises(AssertionError, assert_equal, tup_1, ['foo'])
+
+    def test_masked_array(self):
+        masked_1 = ma.masked_all((3, 3))
+        masked_2 = ma.masked_all((2, 2))
+        assert_equal(masked_1, masked_1)
+        assert_equal(masked_2, masked_2)
+        assert_raises(MaskError, assert_equal, masked_1, 2)
+        assert_raises(MaskError, assert_equal, [1], masked_1)
+        assert_raises(ValueError, assert_equal, masked_1, masked_2)
+
+    def test_array(self):
+        array_1 = np.array([1, np.nan])
+        array_2 = np.array([1, 2, 3])
+        array_3 = np.array([1, 2, 3])
+
+        assert_equal(array_1, array_1)
+        assert_equal(array_2, array_3)
+        assert_equal(array_1, [1, np.nan])
+
+        assert_raises(AssertionError, assert_equal, array_1, array_2)
+        assert_raises(AssertionError, assert_equal, array_2, array_1)
+        assert_raises(AssertionError, assert_equal, array_1, np.nan)
+        assert_raises(AssertionError, assert_equal, array_1, 1)
+
+    def test_string(self):
+        assert_equal('', '')
+        assert_equal('a', 'a')
+
+        assert_raises(AssertionError, assert_equal, 'a', 'b')
+        assert_raises(AssertionError, assert_equal, 'a', 1)
+        assert_raises(AssertionError, assert_equal, 'a', [1])
+        assert_raises(AssertionError, assert_equal, 'a', np.nan)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -91,6 +91,21 @@ def _assert_equal_on_sequences(actual, desired, err_msg=''):
     return
 
 
+def _assert_equal_both_non_masked(actual, desired, err_msg=''):
+    """
+    Asserts the equality of two non masked arrays
+
+    """
+    if (isinstance(desired, (list, tuple)) and
+            isinstance(actual, (list, tuple))):
+        return _assert_equal_on_sequences(actual, desired, err_msg)
+    elif (isinstance(actual, np.matrix) or
+            isinstance(desired, np.matrix)):
+        return assert_array_equal(actual, desired, err_msg)
+    else:
+        return utils.assert_equal(actual, desired, err_msg)
+
+
 def assert_equal_records(a, b):
     """
     Asserts that two records are equal.
@@ -111,37 +126,22 @@ def assert_equal(actual, desired, err_msg=''):
     Asserts that two items are equal.
 
     """
-    # Case #1: dictionary .....
-    if isinstance(desired, dict):
-        if not isinstance(actual, dict):
-            raise AssertionError(repr(type(actual)))
-        assert_equal(len(actual), len(desired), err_msg)
-        for k, i in desired.items():
-            if k not in actual:
-                raise AssertionError("%s not in %s" % (k, actual))
-            assert_equal(actual[k], desired[k], 'key=%r\n%s' % (k, err_msg))
-        return
-    # Case #2: lists .....
-    if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
-        return _assert_equal_on_sequences(actual, desired, err_msg='')
-    if not (isinstance(actual, ndarray) or isinstance(desired, ndarray)):
-        msg = build_err_msg([actual, desired], err_msg,)
-        if not desired == actual:
-            raise AssertionError(msg)
-        return
-    # Case #4. arrays or equivalent
-    if ((actual is masked) and not (desired is masked)) or \
-            ((desired is masked) and not (actual is masked)):
-        msg = build_err_msg([actual, desired],
-                            err_msg, header='', names=('x', 'y'))
+    # Delegate assertion if actual isn't masked and desired isn't masked.
+    if not (isinstance(actual, masked_array) or
+            isinstance(desired, masked_array)):
+        return _assert_equal_both_non_masked(actual, desired, err_msg)
+
+    # Masked only compares with masked.
+    if (actual is masked) != (desired is masked):
+        msg = build_err_msg([actual, desired], err_msg, header='', names=('x', 'y'))
         raise ValueError(msg)
-    actual = np.array(actual, copy=False, subok=True)
-    desired = np.array(desired, copy=False, subok=True)
-    (actual_dtype, desired_dtype) = (actual.dtype, desired.dtype)
-    if actual_dtype.char == "S" and desired_dtype.char == "S":
-        return _assert_equal_on_sequences(actual.tolist(),
-                                          desired.tolist(),
-                                          err_msg='')
+
+    actual = np.asanyarray(actual)
+    desired = np.asanyarray(desired)
+    if actual.dtype.char == "S" and desired.dtype.char == "S":
+        actual = actual.tolist()
+        desired = desired.tolist()
+        return _assert_equal_on_sequences(actual, desired, err_msg)
     return assert_array_equal(actual, desired, err_msg)
 
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -347,6 +347,8 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
     try:
         # isscalar test to check cases such as [np.nan] != np.nan
         if isscalar(desired) != isscalar(actual):
+            if desired == actual:
+                return
             raise AssertionError(msg)
 
         # If one of desired/actual is not finite, handle it specially here:


### PR DESCRIPTION
Fixes #6661 and makes `np.ma.testutils.assert_equal`'s functionality more closely match `np.testing.assert_equal`

Previous Functionality:

```
>>> import numpy as np
>>> from numpy.ma.testutils import assert_equal
>>> from numpy.testing import assert_equal as a_e
>>> a_e(np.nan, np.nan)
>>> assert_equal(np.nan, np.nan)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "numpy/ma/testutils.py", line 130, in assert_equal
    raise AssertionError(msg)
AssertionError:
Items are not equal:
 ACTUAL: nan
 DESIRED: nan
```

Modified Functionality:

```
>>> import numpy as np
>>> from numpy.ma.testutils import assert_equal
>>> from numpy.testing import assert_equal as a_e
>>> a_e(np.nan, np.nan)
>>> assert_equal(np.nan, np.nan)
```
