### PR TITLE
MAINT: Add Mingw distutils support for Python compiled using MSVCR 14.

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -60,7 +60,6 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         # we need to support 3.2 which doesn't match the standard
         # get_versions methods regex
         if self.gcc_version is None:
-            import re
             p = subprocess.Popen(['gcc', '-dumpversion'], shell=True,
                                  stdout=subprocess.PIPE)
             out_string = p.stdout.read()
@@ -100,7 +99,8 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
 
         # Define the MSVC version as hint for MinGW
-        msvcr_version = '0x%03i0' % int(msvc_runtime_library().lstrip('msvcr'))
+        v = int(re.sub(r'[^\d]+','',msvc_runtime_library()))
+        msvcr_version = '0x%03i0' % v
         self.define_macro('__MSVCRT_VERSION__', msvcr_version)
 
         # MS_WIN64 should be defined when building for amd64 on windows,

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -398,6 +398,7 @@ def msvc_runtime_library():
                '1400': 'msvcr80',    # MSVC 8
                '1500': 'msvcr90',    # MSVC 9 (VS 2008)
                '1600': 'msvcr100',   # MSVC 10 (aka 2010)
+               '1900': 'vcruntime140', # MSVC 14 (VS 2015)
               }.get(msc_ver, None)
     else:
         lib = None


### PR DESCRIPTION
```
Attempting to compile extensions with Mingw, cygwin, etc. for Python
distributions compiled using Visual Studio 2015 would result in errors
related to the MSVC version names.  This commit adds support to the Numpy
distutils modules for the new naming convention.

This is related to https://bugs.python.org/issue25251 and requires the
attached patch for distutils/cygwinccompiler.py.
```
