### PR TITLE
ENH: Expand Argument Range of random_integers

### DIFF
--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -167,6 +167,17 @@ class TestRandomDist(TestCase):
                             [-48, -66]])
         np.testing.assert_array_equal(actual, desired)
 
+    def test_random_integers_max_int(self):
+        # Tests whether random_integers can generate the
+        # maximum allowed Python int that can be converted
+        # into a C long. Previous implementations of this
+        # method have thrown an OverflowError when attemping
+        # to generate this integer.
+        actual = np.random.random_integers(np.iinfo('l').max,
+                                           np.iinfo('l').max)
+        desired = np.iinfo('l').max
+        np.testing.assert_equal(actual, desired)
+
     def test_random_sample(self):
         np.random.seed(self.seed)
         actual = np.random.random_sample((3, 2))


### PR DESCRIPTION
Redistributes the code between the `randint` and `random_integers` methods so that we can generate integers up to and including `np.iinfo('l').max` with `random_integers`, which previously would have caused an `OverflowError`.

Previous behavior:

```
>>> import numpy as np
>>> np.random.random_integers(np.iinfo('l').max, np.iinfo('l').max)
Traceback (most recent call last):
  File "<pyshell#1>", line 1, in <module>
    np.random.random_integers(np.iinfo('l').max, np.iinfo('l').max)
  File "mtrand.pyx", line 1446, in mtrand.RandomState.random_integers (numpy\random\mtrand\mtrand.c:12401)
  File "mtrand.pyx", line 942, in mtrand.RandomState.randint (numpy\random\mtrand\mtrand.c:9558)
OverflowError: Python int too large to convert to C long
```

New behavior:

```
>>> import numpy as np
>>> np.random.random_integers(np.iinfo('l').max, np.iinfo('l').max) # 32-bit Python
2147483647
```
## (Optional, But Recommended) Depends on #6824

While the PR currently allows for the generation of up to and including `np.iinfo('l').max`, if #6824 is merged in, the PR will be revised to being able to generate random integers up to and including `np.iinfo('ll').max`.
