### PR TITLE
MAINT: Simplify some tests using temppath context manager.

### DIFF
--- a/numpy/distutils/tests/test_npy_pkg_config.py
+++ b/numpy/distutils/tests/test_npy_pkg_config.py
@@ -1,10 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-from tempfile import mkstemp
 
 from numpy.distutils.npy_pkg_config import read_config, parse_flags
-from numpy.testing import TestCase, run_module_suite
+from numpy.testing import TestCase, run_module_suite, temppath
 
 simple = """\
 [meta]
@@ -39,41 +38,30 @@ simple_variable_d = {'cflags': '-I/foo/bar/include', 'libflags': '-L/foo/bar/lib
 
 class TestLibraryInfo(TestCase):
     def test_simple(self):
-        fd, filename = mkstemp('foo.ini')
-        try:
-            pkg = os.path.splitext(filename)[0]
-            try:
-                os.write(fd, simple.encode('ascii'))
-            finally:
-                os.close(fd)
-
+        with temppath('foo.ini') as path:
+            with open(path,  'w') as f:
+                f.write(simple)
+            pkg = os.path.splitext(path)[0]
             out = read_config(pkg)
-            self.assertTrue(out.cflags() == simple_d['cflags'])
-            self.assertTrue(out.libs() == simple_d['libflags'])
-            self.assertTrue(out.name == simple_d['name'])
-            self.assertTrue(out.version == simple_d['version'])
-        finally:
-            os.remove(filename)
+
+        self.assertTrue(out.cflags() == simple_d['cflags'])
+        self.assertTrue(out.libs() == simple_d['libflags'])
+        self.assertTrue(out.name == simple_d['name'])
+        self.assertTrue(out.version == simple_d['version'])
 
     def test_simple_variable(self):
-        fd, filename = mkstemp('foo.ini')
-        try:
-            pkg = os.path.splitext(filename)[0]
-            try:
-                os.write(fd, simple_variable.encode('ascii'))
-            finally:
-                os.close(fd)
-
+        with temppath('foo.ini') as path:
+            with open(path,  'w') as f:
+                f.write(simple_variable)
+            pkg = os.path.splitext(path)[0]
             out = read_config(pkg)
-            self.assertTrue(out.cflags() == simple_variable_d['cflags'])
-            self.assertTrue(out.libs() == simple_variable_d['libflags'])
-            self.assertTrue(out.name == simple_variable_d['name'])
-            self.assertTrue(out.version == simple_variable_d['version'])
 
-            out.vars['prefix'] = '/Users/david'
-            self.assertTrue(out.cflags() == '-I/Users/david/include')
-        finally:
-            os.remove(filename)
+        self.assertTrue(out.cflags() == simple_variable_d['cflags'])
+        self.assertTrue(out.libs() == simple_variable_d['libflags'])
+        self.assertTrue(out.name == simple_variable_d['name'])
+        self.assertTrue(out.version == simple_variable_d['version'])
+        out.vars['prefix'] = '/Users/david'
+        self.assertTrue(out.cflags() == '-I/Users/david/include')
 
 class TestParseFlags(TestCase):
     def test_simple_cflags(self):

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -19,7 +19,7 @@ import random
 
 from numpy.compat import asbytes, asstr
 import numpy.f2py
-from numpy.testing import SkipTest
+from numpy.testing import SkipTest, temppath
 
 try:
     from hashlib import md5
@@ -159,16 +159,11 @@ def build_code(source_code, options=[], skip=[], only=[], suffix=None,
     """
     if suffix is None:
         suffix = '.f'
-
-    fd, tmp_fn = tempfile.mkstemp(suffix=suffix)
-    os.write(fd, asbytes(source_code))
-    os.close(fd)
-
-    try:
-        return build_module([tmp_fn], options=options, skip=skip, only=only,
+    with temppath(suffix=suffix) as path:
+        with open(path, 'w') as f:
+            f.write(source_code)
+        return build_module([path], options=options, skip=skip, only=only,
                             module_name=module_name)
-    finally:
-        os.unlink(tmp_fn)
 
 #
 # Check if compilers are available at all...
@@ -209,22 +204,19 @@ sys.exit(99)
 """
     code = code % dict(syspath=repr(sys.path))
 
-    fd, script = tempfile.mkstemp(suffix='.py')
-    os.write(fd, asbytes(code))
-    os.close(fd)
+    with temppath(suffix='.py') as script:
+        with open(script, 'w') as f:
+            f.write(code)
 
-    try:
         cmd = [sys.executable, script, 'config']
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
         out, err = p.communicate()
-        m = re.search(asbytes(r'COMPILERS:(\d+),(\d+),(\d+)'), out)
-        if m:
-            _compiler_status = (bool(int(m.group(1))), bool(int(m.group(2))),
-                                bool(int(m.group(3))))
-    finally:
-        os.unlink(script)
 
+    m = re.search(asbytes(r'COMPILERS:(\d+),(\d+),(\d+)'), out)
+    if m:
+        _compiler_status = (bool(int(m.group(1))), bool(int(m.group(2))),
+                            bool(int(m.group(3))))
     # Finished
     return _compiler_status
 

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -15,7 +15,7 @@ import numpy.ma as ma
 from numpy import recarray
 from numpy.compat import asbytes, asbytes_nested
 from numpy.ma import masked, nomask
-from numpy.testing import TestCase, run_module_suite
+from numpy.testing import TestCase, run_module_suite, temppath
 from numpy.core.records import (
     fromrecords as recfromrecords, fromarrays as recfromarrays
     )
@@ -476,7 +476,7 @@ class TestMRecordsImport(TestCase):
 
     def test_fromtextfile(self):
         # Tests reading from a text file.
-        fcontent = asbytes(
+        fcontent = (
 """#
 'One (S)','Two (I)','Three (F)','Four (M)','Five (-)','Six (C)'
 'strings',1,1.0,'mixed column',,1
@@ -484,14 +484,10 @@ class TestMRecordsImport(TestCase):
 'strings',3,3.0E5,3,,1
 'strings',4,-1e-10,,,1
 """)
-        import os
-        import tempfile
-        (tmp_fd, tmp_fl) = tempfile.mkstemp()
-        os.write(tmp_fd, fcontent)
-        os.close(tmp_fd)
-        mrectxt = fromtextfile(tmp_fl, delimitor=',', varnames='ABCDEFG')
-        os.remove(tmp_fl)
-
+        with temppath() as path:
+            with open(path, 'w') as f:
+                f.write(fcontent)
+            mrectxt = fromtextfile(path, delimitor=',', varnames='ABCDEFG')
         self.assertTrue(isinstance(mrectxt, MaskedRecords))
         assert_equal(mrectxt.F, [1, 1, 1, 1])
         assert_equal(mrectxt.E._mask, [1, 1, 1, 1])

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -14,7 +14,7 @@ from nose.tools import assert_equal
 from numpy.testing.decorators import skipif
 from numpy.testing import assert_
 
-skipif_inplace = skipif(isfile(pathjoin(dirname(np.__file__),  '..', 'setup.py')))
+is_inplace = isfile(pathjoin(dirname(np.__file__),  '..', 'setup.py'))
 
 def run_command(cmd, check_code=True):
     """ Run command sequence `cmd` returning exit code, stdout, stderr
@@ -58,7 +58,7 @@ def run_command(cmd, check_code=True):
     return proc.returncode, stdout, stderr
 
 
-@skipif_inplace
+@skipif(is_inplace)
 def test_f2py():
     # test that we can run f2py script
     if sys.platform == 'win32':
@@ -77,6 +77,7 @@ def test_f2py():
                 assert_equal(stdout.strip(), asbytes('2'))
                 success = True
                 break
-            except OSError:
+            except:
                 pass
-        assert_(success, "Warning: neither %s nor %s found in path" % f2py_cmds)
+        msg = "Warning: neither %s nor %s found in path" % f2py_cmds
+        assert_(success, msg)


### PR DESCRIPTION
This replaces code of the pattern

```
fd, name = tempfile.mkstemp(...)
os.close(fd)
try:
   do stuff with name
finally:
    os.remove(name)
```

with

```
with temppath() as name:
    do stuff with name
```

A few more complicated cases are also handled. The remains some
particularly gnarly code the could probably be refactored to use
temppath, but that is a more demanding project.
