### PR TITLE
FIX: Fix MKL for Linux

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -55,7 +55,7 @@ class IntelFCompiler(BaseIntelFCompiler):
     def get_flags(self):
         return ['-fPIC']
 
-    def get_flags_opt(self):
+    def get_flags_opt(self):  # Scipy test failures with -O2
         return ['-xhost -openmp -fp-model strict -O1']
 
     def get_flags_arch(self):
@@ -119,7 +119,7 @@ class IntelEM64TFCompiler(IntelFCompiler):
     def get_flags(self):
         return ['-fPIC']
 
-    def get_flags_opt(self):
+    def get_flags_opt(self):  # Scipy test failures with -O2
         return ['-openmp -fp-model strict -O1']
 
     def get_flags_arch(self):

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -56,7 +56,7 @@ class IntelFCompiler(BaseIntelFCompiler):
         return ['-fPIC']
 
     def get_flags_opt(self):
-        return ['-xhost -openmp -fp-model strict']
+        return ['-xhost -openmp -fp-model strict -O1']
 
     def get_flags_arch(self):
         return []
@@ -120,7 +120,7 @@ class IntelEM64TFCompiler(IntelFCompiler):
         return ['-fPIC']
 
     def get_flags_opt(self):
-        return ['-openmp -fp-model strict']
+        return ['-openmp -fp-model strict -O1']
 
     def get_flags_arch(self):
         return ['-xSSE4.2']


### PR DESCRIPTION
The fix from line 172 (`return ['/O1']  # Scipy test failures with /O2`) for `IntelVisualFCompiler` were not applied to the Linux variants `IntelFCompiler` and `IntelEM64TFCompiler`, but on Linux I need `-O1` to avoid `scipy` bugs (https://github.com/scipy/scipy/issues/5621). This fixes the issue.
