### PR TITLE
TST: Only use 32 bit Python 2.7 to test numpy on appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ os: Visual Studio 2015
 environment:
   matrix:
     - PY_MAJOR_VER: 2
-      PYTHON_ARCH: "x86_64"
+      PYTHON_ARCH: "x86"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
     - PY_MAJOR_VER: 3


### PR DESCRIPTION
This avoids a test error on appveyor that might be fixed if Visual C++
Compiler for Python 2.7 is used. Numpy itself builds and runs on
appveyor with both 32 and 64 bit python 2.7, so this is only a test
issue. Another option might be to disable the test, but it may be useful
to some on other platforms.

Closes #6882.
