### PR TITLE
ENH: clarify error message of broadcast

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1458,8 +1458,8 @@ PyArray_MultiIterFromObjects(PyObject **mps, int n, int nadd, ...)
     ntot = n + nadd;
     if (ntot < 2 || ntot > NPY_MAXARGS) {
         PyErr_Format(PyExc_ValueError,
-                     "Need between 2 and (%d) "                 \
-                     "array objects (inclusive).", NPY_MAXARGS);
+                     "Need at least 2 and at most %d "
+                     "array objects.", NPY_MAXARGS);
         return NULL;
     }
     multi = PyArray_malloc(sizeof(PyArrayMultiIterObject));
@@ -1524,8 +1524,8 @@ PyArray_MultiIterNew(int n, ...)
 
     if (n < 2 || n > NPY_MAXARGS) {
         PyErr_Format(PyExc_ValueError,
-                     "Need between 2 and (%d) "                 \
-                     "array objects (inclusive).", NPY_MAXARGS);
+                     "Need at least 2 and at most %d "
+                     "array objects.", NPY_MAXARGS);
         return NULL;
     }
 
@@ -1608,7 +1608,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args, PyObject *k
             return NULL;
         }
         PyErr_Format(PyExc_ValueError,
-                     "Need at least two and fewer than (%d) "
+                     "Need at least 2 and at most %d "
                      "array objects.", NPY_MAXARGS);
         return NULL;
     }


### PR DESCRIPTION
Fix for #6898. What about the [brackets around the maximum number of arguments](https://github.com/numpy/numpy/blob/004639d07fd161d1394f5dda1b6ed42c777f3c80/numpy/core/src/multiarray/iterators.c#L1611)? Could also be removed while we're at it.
