### PR TITLE
[FIX] fix NoseTester's raise_warning default

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -185,8 +185,12 @@ else:
     pkgload.__doc__ = PackageLoader.__call__.__doc__
 
     from .testing import Tester
-    test = Tester().test
-    bench = Tester().bench
+    if ".dev0" in __version__:
+        test = Tester(raise_warnings="develop").test
+        bench = Tester(raise_warnings="develop").bench
+    else:
+        test = Tester(raise_warnings="release").test
+        bench = Tester(raise_warnings="release").bench
 
     from . import core
     from .core import *

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -184,13 +184,11 @@ else:
 
     pkgload.__doc__ = PackageLoader.__call__.__doc__
 
+    # We don't actually use this ourselves anymore, but I'm not 100% sure that
+    # no-one else in the world is using it (though I hope not)
     from .testing import Tester
-    if ".dev0" in __version__:
-        test = Tester(raise_warnings="develop").test
-        bench = Tester(raise_warnings="develop").bench
-    else:
-        test = Tester(raise_warnings="release").test
-        bench = Tester(raise_warnings="release").bench
+    test = testing.nosetester._numpy_tester().test
+    bench = testing.nosetester._numpy_tester().bench
 
     from . import core
     from .core import *

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -55,9 +55,9 @@ __all__ += getlimits.__all__
 __all__ += shape_base.__all__
 
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench
 
 # Make it possible so that ufuncs can be pickled
 #  Here are the loading and unloading functions

--- a/numpy/distutils/__init__.py
+++ b/numpy/distutils/__init__.py
@@ -18,6 +18,6 @@ except ImportError:
     _INSTALLED = False
 
 if _INSTALLED:
-    from numpy.testing import Tester
-    test = Tester().test
-    bench = Tester().bench
+    from numpy.testing.nosetester import _numpy_tester
+    test = _numpy_tester().test
+    bench = _numpy_tester().bench

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -62,6 +62,6 @@ def compile(source,
         f.close()
     return status
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -6,6 +6,6 @@ from .info import __doc__
 from .fftpack import *
 from .helper import *
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -41,6 +41,6 @@ __all__ += npyio.__all__
 __all__ += financial.__all__
 __all__ += nanfunctions.__all__
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -50,6 +50,6 @@ from .info import __doc__
 
 from .linalg import *
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().test
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/ma/__init__.py
+++ b/numpy/ma/__init__.py
@@ -51,6 +51,6 @@ __all__ = ['core', 'extras']
 __all__ += core.__all__
 __all__ += extras.__all__
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/matrixlib/__init__.py
+++ b/numpy/matrixlib/__init__.py
@@ -7,6 +7,6 @@ from .defmatrix import *
 
 __all__ = defmatrix.__all__
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/polynomial/__init__.py
+++ b/numpy/polynomial/__init__.py
@@ -22,6 +22,6 @@ from .hermite import Hermite
 from .hermite_e import HermiteE
 from .laguerre import Laguerre
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/random/__init__.py
+++ b/numpy/random/__init__.py
@@ -117,6 +117,6 @@ def __RandomState_ctor():
     """
     return RandomState(seed=0)
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+from numpy.testing.nosetester import _numpy_tester
+test = _numpy_tester().test
+bench = _numpy_tester().bench

--- a/numpy/testing/__init__.py
+++ b/numpy/testing/__init__.py
@@ -12,4 +12,4 @@ from unittest import TestCase
 from . import decorators as dec
 from .nosetester import run_module_suite, NoseTester as Tester
 from .utils import *
-test = Tester().test
+test = nosetester._numpy_tester().test

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -159,6 +159,12 @@ class NoseTester(object):
           - "release" : equals ``()``, don't raise on any warnings.
 
         Default is "release".
+    depth : int, optional
+        If `package` is None, then this can be used to initialize from the
+        module of the caller of (the caller of (...)) the code that
+        initializes `NoseTester`. Default of 0 means the module of the
+        immediate caller; higher values are useful for utility routines that
+        want to initialize `NoseTester` objects on behalf of other code.
 
     """
     # Stuff to exclude from tests. These are from numpy.distutils
@@ -168,7 +174,7 @@ class NoseTester(object):
                 'pyrex_ext',
                 'swig_ext']
 
-    def __init__(self, package=None, raise_warnings="release"):
+    def __init__(self, package=None, raise_warnings="release", depth=0):
         # Back-compat: 'None' used to mean either "release" or "develop"
         # depending on whether this was a release or develop version of
         # numpy. Those semantics were fine for testing numpy, but not so
@@ -182,7 +188,7 @@ class NoseTester(object):
 
         package_name = None
         if package is None:
-            f = sys._getframe(1)
+            f = sys._getframe(1 + depth)
             package_path = f.f_locals.get('__file__', None)
             if package_path is None:
                 raise AssertionError
@@ -511,3 +517,10 @@ class NoseTester(object):
         add_plugins = [Unplugger('doctest')]
 
         return nose.run(argv=argv, addplugins=add_plugins)
+
+def _numpy_tester():
+    if hasattr(np, "__version__") and ".dev0" in np.__version__:
+        mode = "develop"
+    else:
+        mode = "release"
+    return NoseTester(raise_warnings=mode, depth=1)

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -158,15 +158,7 @@ class NoseTester(object):
           - "develop" : equals ``(DeprecationWarning, RuntimeWarning)``
           - "release" : equals ``()``, don't raise on any warnings.
 
-        See Notes for more details.
-
-    Notes
-    -----
-    The default for `raise_warnings` is
-    ``(DeprecationWarning, RuntimeWarning)`` for development versions of NumPy,
-    and ``()`` for released versions.  The purpose of this switching behavior
-    is to catch as many warnings as possible during development, but not give
-    problems for packaging of released versions.
+        Default is "release".
 
     """
     # Stuff to exclude from tests. These are from numpy.distutils
@@ -176,11 +168,16 @@ class NoseTester(object):
                 'pyrex_ext',
                 'swig_ext']
 
-    def __init__(self, package=None, raise_warnings=None):
-        if raise_warnings is None and (
-                not hasattr(np, '__version__') or '.dev0' in np.__version__):
-            raise_warnings = "develop"
-        elif raise_warnings is None:
+    def __init__(self, package=None, raise_warnings="release"):
+        # Back-compat: 'None' used to mean either "release" or "develop"
+        # depending on whether this was a release or develop version of
+        # numpy. Those semantics were fine for testing numpy, but not so
+        # helpful for downstream projects like scipy that use
+        # numpy.testing. (They want to set this based on whether *they* are a
+        # release or develop version, not whether numpy is.) So we continue to
+        # accept 'None' for back-compat, but it's now just an alias for the
+        # default "release".
+        if raise_warnings is None:
             raise_warnings = "release"
 
         package_name = None


### PR DESCRIPTION
Our test-runner's raise_warning mode traditionally has varied depending
on whether we have a development or release version of numpy: for
development versions we raise on warnings, and for release versions we
don't. This is all very sensible... _if_ you're running numpy's test
suite. But our test-runner is also used by other packages like scipy,
and it doesn't make sense for scipy's raise_warning mode to vary
depending on whether _numpy_ is a development or release version. (It
should vary depending on whether the scipy-under-test is a development
or release version.) So this commit moves the numpy-version-dependent
raise_warning logic out of the generic NoseTester class and into
numpy-specific code.

(See scipy/scipy#5609 for more discussion.)
