### PR TITLE
MAINT: Removed Spelling Mistakes and Unused Variables in np.random Modules

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -232,7 +232,6 @@ cdef object cont2_array(rk_state *state, rk_cont2 func, object size,
     cdef double *oa_data
     cdef double *ob_data
     cdef ndarray array "arrayObject"
-    cdef npy_intp length
     cdef npy_intp i
     cdef broadcast multi
 
@@ -288,7 +287,6 @@ cdef object cont3_array(rk_state *state, rk_cont3 func, object size,
     cdef double *ob_data
     cdef double *oc_data
     cdef ndarray array "arrayObject"
-    cdef npy_intp length
     cdef npy_intp i
     cdef broadcast multi
 
@@ -358,7 +356,6 @@ cdef object discnp_array(rk_state *state, rk_discnp func, object size,
                          ndarray on, ndarray op, object lock):
     cdef long *array_data
     cdef ndarray array "arrayObject"
-    cdef npy_intp length
     cdef npy_intp i
     cdef double *op_data
     cdef long *on_data
@@ -412,7 +409,6 @@ cdef object discdd_array(rk_state *state, rk_discdd func, object size,
                          ndarray on, ndarray op, object lock):
     cdef long *array_data
     cdef ndarray array "arrayObject"
-    cdef npy_intp length
     cdef npy_intp i
     cdef double *op_data
     cdef double *on_data
@@ -469,7 +465,6 @@ cdef object discnmN_array(rk_state *state, rk_discnmN func, object size,
     cdef long *om_data
     cdef long *oN_data
     cdef ndarray array "arrayObject"
-    cdef npy_intp length
     cdef npy_intp i
     cdef broadcast multi
 

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -171,7 +171,7 @@ class TestRandomDist(TestCase):
         # Tests whether random_integers can generate the
         # maximum allowed Python int that can be converted
         # into a C long. Previous implementations of this
-        # method have thrown an OverflowError when attemping
+        # method have thrown an OverflowError when attempting
         # to generate this integer.
         actual = np.random.random_integers(np.iinfo('l').max,
                                            np.iinfo('l').max)


### PR DESCRIPTION
I just can't enough of these `numpy.random` modules, can I? :smile:  I think that's five PR's now?

Title is self-explanatory.
