### PR TITLE
ENH: Add dtype argument to random.randint.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,6 @@ environment:
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
 
-matrix:
-  #fast_finish: true
-  allow_failures:
-    - PY_MAJOR_VER: 2
-    - PY_MAJOR_VER: 3
-
 build_script:
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
   - cmd: C:\Miniconda.exe /S /D=C:\Py

--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -86,6 +86,23 @@ New Features
   the files can be specifies to be ``*.f90``. The ``verbose`` argument is
   also activated, it was previously ignored.
 
+* A ``dtype`` parameter has been added to ``np.random.randint``
+  Random ndarrays of the following types can now be generated:
+
+  - np.bool,
+  - np.int8, np.uint8,
+  - np.int16, np.uint16,
+  - np.int32, np.uint32,
+  - np.int64, np.uint64,
+  - np.int_ (long), np.intp
+
+  The specification is by precision rather than by C type. Hence, on some
+  platforms np.int64 may be a `long` instead of `long long` even if the
+  specified dtype is `long long` because the two may have the same
+  precision. The resulting type depends on which c type numpy uses for the
+  given precision. The byteorder specification is also ignored, the
+  generated arrays are always in native byte order.
+
 
 Improvements
 ============

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -7,6 +7,9 @@
 #include <npy_config.h>
 #endif
 
+/* need Python.h for npy_intp, npy_uintp */
+#include <Python.h>
+
 /*
  * gcc does not unroll even with -O3
  * use with care, unrolling on modern cpus rarely speeds things up

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -778,7 +778,7 @@ static PyObject *
 test_as_c_array(PyObject *NPY_UNUSED(self), PyObject *args)
 {
     PyArrayObject *array_obj;
-    npy_intp dims[3];   // max 3-dim
+    npy_intp dims[3];   /* max 3-dim */
     npy_intp i=0, j=0, k=0;
     npy_intp num_dims = 0;
     PyArray_Descr *descr = NULL;

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -110,17 +110,19 @@ def test_diophantine_fuzz():
         numbers = []
         while min(feasible_count, infeasible_count) < min_count:
             # Ensure big and small integer problems
-            A_max = 1 + rng.randint(0, 11)**6
-            U_max = rng.randint(0, 11)**6
+            A_max = 1 + rng.randint(0, 11, dtype=np.intp)**6
+            U_max = rng.randint(0, 11, dtype=np.intp)**6
 
             A_max = min(max_int, A_max)
             U_max = min(max_int-1, U_max)
 
-            A = tuple(rng.randint(1, A_max+1) for j in range(ndim))
-            U = tuple(rng.randint(0, U_max+2) for j in range(ndim))
+            A = tuple(rng.randint(1, A_max+1, dtype=np.intp)
+                      for j in range(ndim))
+            U = tuple(rng.randint(0, U_max+2, dtype=np.intp)
+                      for j in range(ndim))
 
             b_ub = min(max_int-2, sum(a*ub for a, ub in zip(A, U)))
-            b = rng.randint(-1, b_ub+2)
+            b = rng.randint(-1, b_ub+2, dtype=np.intp)
 
             if ndim == 0 and feasible_count < min_count:
                 b = 0
@@ -258,9 +260,9 @@ def check_may_share_memory_easy_fuzz(get_max_work, same_steps, min_count):
     rng = np.random.RandomState(1234)
 
     def random_slice(n, step):
-        start = rng.randint(0, n+1)
-        stop = rng.randint(start, n+1)
-        if rng.randint(0, 2) == 0:
+        start = rng.randint(0, n+1, dtype=np.intp)
+        stop = rng.randint(start, n+1, dtype=np.intp)
+        if rng.randint(0, 2, dtype=np.intp) == 0:
             stop, start = start, stop
             step *= -1
         return slice(start, stop, step)
@@ -269,12 +271,14 @@ def check_may_share_memory_easy_fuzz(get_max_work, same_steps, min_count):
     infeasible = 0
 
     while min(feasible, infeasible) < min_count:
-        steps = tuple(rng.randint(1, 11) if rng.randint(0, 5) == 0 else 1
+        steps = tuple(rng.randint(1, 11, dtype=np.intp)
+                      if rng.randint(0, 5, dtype=np.intp) == 0 else 1
                       for j in range(x.ndim))
         if same_steps:
             steps2 = steps
         else:
-            steps2 = tuple(rng.randint(1, 11) if rng.randint(0, 5) == 0 else 1
+            steps2 = tuple(rng.randint(1, 11, dtype=np.intp)
+                           if rng.randint(0, 5, dtype=np.intp) == 0 else 1
                            for j in range(x.ndim))
 
         t1 = np.arange(x.ndim)
@@ -374,9 +378,9 @@ def test_internal_overlap_slices():
     rng = np.random.RandomState(1234)
 
     def random_slice(n, step):
-        start = rng.randint(0, n+1)
-        stop = rng.randint(start, n+1)
-        if rng.randint(0, 2) == 0:
+        start = rng.randint(0, n+1, dtype=np.intp)
+        stop = rng.randint(start, n+1, dtype=np.intp)
+        if rng.randint(0, 2, dtype=np.intp) == 0:
             stop, start = start, stop
             step *= -1
         return slice(start, stop, step)
@@ -385,7 +389,8 @@ def test_internal_overlap_slices():
     min_count = 5000
 
     while cases < min_count:
-        steps = tuple(rng.randint(1, 11) if rng.randint(0, 5) == 0 else 1
+        steps = tuple(rng.randint(1, 11, dtype=np.intp)
+                      if rng.randint(0, 5, dtype=np.intp) == 0 else 1
                       for j in range(x.ndim))
         t1 = np.arange(x.ndim)
         rng.shuffle(t1)
@@ -469,10 +474,12 @@ def test_internal_overlap_fuzz():
     rng = np.random.RandomState(1234)
 
     while min(overlap, no_overlap) < min_count:
-        ndim = rng.randint(1, 4)
+        ndim = rng.randint(1, 4, dtype=np.intp)
 
-        strides = tuple(rng.randint(-1000, 1000) for j in range(ndim))
-        shape = tuple(rng.randint(1, 30) for j in range(ndim))
+        strides = tuple(rng.randint(-1000, 1000, dtype=np.intp)
+                        for j in range(ndim))
+        shape = tuple(rng.randint(1, 30, dtype=np.intp)
+                      for j in range(ndim))
 
         a = as_strided(x, strides=strides, shape=shape)
         result = check_internal_overlap(a)

--- a/numpy/random/mtrand/mt_compat.h
+++ b/numpy/random/mtrand/mt_compat.h
@@ -1,0 +1,68 @@
+/*
+ * This is a convenience header file providing compatibility utilities
+ * for supporting Python 2 and Python 3 in the same code base.
+ *
+ * It can be removed when Python 2.6 is dropped as PyCapsule is available
+ * in both Python 3.1+ and Python 2.7.
+ */
+
+#ifndef _MT_COMPAT_H_
+#define _MT_COMPAT_H_
+
+#include <Python.h>
+#include <numpy/npy_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*
+ * PyCObject functions adapted to PyCapsules.
+ *
+ * The main job here is to get rid of the improved error handling
+ * of PyCapsules. It's a shame...
+ */
+#if PY_VERSION_HEX >= 0x03000000
+
+static NPY_INLINE PyObject *
+NpyCapsule_FromVoidPtr(void *ptr, void (*dtor)(PyObject *))
+{
+    PyObject *ret = PyCapsule_New(ptr, NULL, dtor);
+    if (ret == NULL) {
+        PyErr_Clear();
+    }
+    return ret;
+}
+
+static NPY_INLINE void *
+NpyCapsule_AsVoidPtr(PyObject *obj)
+{
+    void *ret = PyCapsule_GetPointer(obj, NULL);
+    if (ret == NULL) {
+        PyErr_Clear();
+    }
+    return ret;
+}
+
+#else
+
+static NPY_INLINE PyObject *
+NpyCapsule_FromVoidPtr(void *ptr, void (*dtor)(void *))
+{
+    return PyCObject_FromVoidPtr(ptr, dtor);
+}
+
+static NPY_INLINE void *
+NpyCapsule_AsVoidPtr(PyObject *ptr)
+{
+    return PyCObject_AsVoidPtr(ptr);
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _COMPAT_H_ */

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -67,6 +67,17 @@ cdef extern from "randomkit.h":
     rk_error rk_altfill(void *buffer, size_t size, int strong,
             rk_state *state) nogil
     double rk_gauss(rk_state *state) nogil
+    void rk_random_uint64(npy_uint64 off, npy_uint64 rng, npy_intp cnt,
+                          npy_uint64 *out, rk_state *state) nogil
+    void rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_intp cnt,
+                          npy_uint32 *out, rk_state *state) nogil
+    void rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_intp cnt,
+                          npy_uint16 *out, rk_state *state) nogil
+    void rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_intp cnt,
+                         npy_uint8 *out, rk_state *state) nogil
+    void rk_random_bool(npy_bool off, npy_bool rng, npy_intp cnt,
+                        npy_bool *out, rk_state *state) nogil
+
 
 cdef extern from "distributions.h":
     # do not need the GIL, but they do need a lock on the state !! */
@@ -131,6 +142,7 @@ cimport cython
 import numpy as np
 import operator
 import warnings
+
 try:
     from threading import Lock
 except ImportError:
@@ -574,6 +586,304 @@ def _shape_from_size(size, d):
            shape = tuple(size) + (d,)
     return shape
 
+
+# Set up dictionary of integer types and relevant functions.
+#
+# The dictionary is keyed by dtype(...).name and the values
+# are a tuple (low, high, function), where low and high are
+# the bounds of the largest half open interval `[low, high)`
+# and the function is the relevant function to call for
+# that precision.
+#
+# The functions are all the same except for changed types in
+# a few places. It would be easy to template them.
+
+def _rand_bool(low, high, size, rngstate):
+    """
+    _rand_bool(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_bool off, rng, buf
+    cdef npy_bool *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_bool>(high - low)
+    off = <npy_bool>(low)
+    if size is None:
+        rk_random_bool(off, rng, 1, &buf, state)
+        return buf
+    else:
+        array = <ndarray>np.empty(size, np.bool_)
+        cnt = PyArray_SIZE(array)
+        out = <npy_bool *>PyArray_DATA(array)
+        with nogil:
+            rk_random_bool(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_int8(low, high, size, rngstate):
+    """
+    _rand_int8(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint8 off, rng, buf
+    cdef npy_uint8 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint8>(high - low)
+    off = <npy_uint8>(<npy_int8>low)
+    if size is None:
+        rk_random_uint8(off, rng, 1, &buf, state)
+        return <npy_int8>buf
+    else:
+        array = <ndarray>np.empty(size, np.int8)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint8 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint8(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_int16(low, high, size, rngstate):
+    """
+    _rand_int16(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint16 off, rng, buf
+    cdef npy_uint16 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint16>(high - low)
+    off = <npy_uint16>(<npy_int16>low)
+    if size is None:
+        rk_random_uint16(off, rng, 1, &buf, state)
+        return <npy_int16>buf
+    else:
+        array = <ndarray>np.empty(size, np.int16)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint16 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint16(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_int32(low, high, size, rngstate):
+    """
+    _rand_int32(self, low, high, size, rngstate)
+
+    Return random np.int32 integers between `low` and `high`, inclusive.
+
+    Return random integers from the "discrete uniform" distribution in the
+    closed interval [`low`, `high`).  If `high` is None (the default),
+    then results are from [0, `low`). On entry the arguments are presumed
+    to have been validated for size and order for the np.int32 type.
+
+    Parameters
+    ----------
+    low : int
+        Lowest (signed) integer to be drawn from the distribution (unless
+        ``high=None``, in which case this parameter is the *highest* such
+        integer).
+    high : int
+        If provided, the largest (signed) integer to be drawn from the
+        distribution (see above for behavior if ``high=None``).
+    size : int or tuple of ints
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  Default is None, in which case a
+        single value is returned.
+    rngstate : encapsulated pointer to rk_state
+        The specific type depends on the python version. In Python 2 it is
+        a PyCObject, in Python 3 a PyCapsule object.
+
+    Returns
+    -------
+    out : python scalar or ndarray of np.int32
+          `size`-shaped array of random integers from the appropriate
+          distribution, or a single such random int if `size` not provided.
+
+    """
+    cdef npy_uint32 off, rng, buf
+    cdef npy_uint32 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint32>(high - low)
+    off = <npy_uint32>(<npy_int32>low)
+    if size is None:
+        rk_random_uint32(off, rng, 1, &buf, state)
+        return <npy_int32>buf
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint32 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint32(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_int64(low, high, size, rngstate):
+    """
+    _rand_int64(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint64 off, rng, buf
+    cdef npy_uint64 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint64>(high - low)
+    off = <npy_uint64>(<npy_int64>low)
+    if size is None:
+        rk_random_uint64(off, rng, 1, &buf, state)
+        return <npy_int64>buf
+    else:
+        array = <ndarray>np.empty(size, np.int64)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint64 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint64(off, rng, cnt, out, state)
+        return array
+
+def _rand_uint8(low, high, size, rngstate):
+    """
+    _rand_uint8(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint8 off, rng, buf
+    cdef npy_uint8 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint8>(high - low)
+    off = <npy_uint8>(low)
+    if size is None:
+        rk_random_uint8(off, rng, 1, &buf, state)
+        return buf
+    else:
+        array = <ndarray>np.empty(size, np.uint8)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint8 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint8(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_uint16(low, high, size, rngstate):
+    """
+    _rand_uint16(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint16 off, rng, buf
+    cdef npy_uint16 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint16>(high - low)
+    off = <npy_uint16>(low)
+    if size is None:
+        rk_random_uint16(off, rng, 1, &buf, state)
+        return buf
+    else:
+        array = <ndarray>np.empty(size, np.uint16)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint16 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint16(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_uint32(low, high, size, rngstate):
+    """
+    _rand_uint32(self, low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint32 off, rng, buf
+    cdef npy_uint32 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint32>(high - low)
+    off = <npy_uint32>(low)
+    if size is None:
+        rk_random_uint32(off, rng, 1, &buf, state)
+        return <npy_uint32>buf
+    else:
+        array = <ndarray>np.empty(size, np.uint32)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint32 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint32(off, rng, cnt, out, state)
+        return array
+
+
+def _rand_uint64(low, high, size, rngstate):
+    """
+    _rand_uint64(low, high, size, rngstate)
+
+    See `_rand_int32` for documentation, only the return type changes.
+
+    """
+    cdef npy_uint64 off, rng, buf
+    cdef npy_uint64 *out
+    cdef ndarray array "arrayObject"
+    cdef npy_intp cnt
+    cdef rk_state *state = <rk_state *>NpyCapsule_AsVoidPtr(rngstate)
+
+    rng = <npy_uint64>(high - low)
+    off = <npy_uint64>(low)
+    if size is None:
+        rk_random_uint64(off, rng, 1, &buf, state)
+        return <npy_uint64>buf
+    else:
+        array = <ndarray>np.empty(size, np.uint64)
+        cnt = PyArray_SIZE(array)
+        out = <npy_uint64 *>PyArray_DATA(array)
+        with nogil:
+            rk_random_uint64(off, rng, cnt, out, state)
+        return array
+
+# Look up table for randint functions keyed by type name. The stored data
+# is a tuple (lbnd, ubnd, func), where lbnd is the smallest value for the
+# type, ubnd is one greater than the largest value, and func is the
+# function to call.
+_randint_type = {
+    'bool': (0, 2, _rand_bool),
+    'int8': (-2**7, 2**7, _rand_int8),
+    'int16': (-2**15, 2**15, _rand_int16),
+    'int32': (-2**31, 2**31, _rand_int32),
+    'int64': (-2**63, 2**63, _rand_int64),
+    'uint8': (0, 2**8, _rand_uint8),
+    'uint16': (0, 2**16, _rand_uint16),
+    'uint32': (0, 2**32, _rand_uint32),
+    'uint64': (0, 2**64, _rand_uint64)
+    }
+
+
 cdef class RandomState:
     """
     RandomState(seed=None)
@@ -618,11 +928,12 @@ cdef class RandomState:
     """
     cdef rk_state *internal_state
     cdef object lock
+    cdef object state_address
     poisson_lam_max = np.iinfo('l').max - np.sqrt(np.iinfo('l').max)*10
 
     def __init__(self, seed=None):
         self.internal_state = <rk_state*>PyMem_Malloc(sizeof(rk_state))
-
+        self.state_address = NpyCapsule_FromVoidPtr(self.internal_state, NULL)
         self.lock = Lock()
         self.seed(seed)
 
@@ -885,15 +1196,15 @@ cdef class RandomState:
         """
         return disc0_array(self.internal_state, rk_long, size, self.lock)
 
-    def randint(self, low, high=None, size=None):
+    def randint(self, low, high=None, size=None, dtype='l'):
         """
-        randint(low, high=None, size=None)
+        randint(low, high=None, size=None, dtype='l')
 
         Return random integers from `low` (inclusive) to `high` (exclusive).
 
-        Return random integers from the "discrete uniform" distribution in the
-        "half-open" interval [`low`, `high`). If `high` is None (the default),
-        then results are from [0, `low`).
+        Return random integers from the "discrete uniform" distribution of
+        the specified dtype in the "half-open" interval [`low`, `high`). If
+        `high` is None (the default), then results are from [0, `low`).
 
         Parameters
         ----------
@@ -908,6 +1219,13 @@ cdef class RandomState:
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  Default is None, in which case a
             single value is returned.
+        dtype : dtype, optional
+            Desired dtype of the result. All dtypes are determined by their
+            name, i.e., 'int64', 'int`, etc, so byteorder is not available
+            and a specific precision may have different C types depending
+            on the platform. The default value is 'l' (C long).
+
+            .. versionadded:: 1.11.0
 
         Returns
         -------
@@ -936,14 +1254,24 @@ cdef class RandomState:
                [3, 2, 2, 0]])
 
         """
-        if high is not None and low >= high:
-            raise ValueError("low >= high")
-
         if high is None:
             high = low
             low = 0
 
-        return self.random_integers(low, high - 1, size)
+        key = np.dtype(dtype).name
+        if not key in _randint_type:
+            raise TypeError('Unsupported dtype "%s" for randint' % key)
+        lowbnd, highbnd, randfunc = _randint_type[key]
+
+        if low < lowbnd:
+            raise ValueError("low is out of bounds for %s" % (key,))
+        if high > highbnd:
+            raise ValueError("high is out of bounds for %s" % (key,))
+        if low >= high:
+            raise ValueError("low >= high")
+
+        with self.lock:
+            return randfunc(low, high - 1, size, self.state_address)
 
     def bytes(self, npy_intp length):
         """
@@ -1356,11 +1684,13 @@ cdef class RandomState:
         """
         random_integers(low, high=None, size=None)
 
-        Return random integers between `low` and `high`, inclusive.
+        Random integers of type np.int between `low` and `high`, inclusive.
 
-        Return random integers from the "discrete uniform" distribution in the
-        closed interval [`low`, `high`].  If `high` is None (the default),
-        then results are from [1, `low`].
+        Return random integers of type np.int from the "discrete uniform"
+        distribution in the closed interval [`low`, `high`].  If `high` is
+        None (the default), then results are from [1, `low`]. The np.int
+        type translates to the C long type used by Python 2 for "short"
+        integers and its precision is platform dependent.
 
         Parameters
         ----------
@@ -1426,37 +1756,13 @@ cdef class RandomState:
         >>> plt.show()
 
         """
-        if high is not None and low > high:
-            raise ValueError("low > high")
-
-        cdef long lo, hi, rv
-        cdef unsigned long diff
-        cdef long *array_data
-        cdef ndarray array "arrayObject"
-        cdef npy_intp length
-        cdef npy_intp i
-
         if high is None:
-            lo = 1
-            hi = low
-        else:
-            lo = low
-            hi = high
+            high = low
+            low = 1
 
-        diff = <unsigned long>hi - <unsigned long>lo
-        if size is None:
-            with self.lock:
-                rv = lo + <long>rk_interval(diff, self. internal_state)
-            return rv
-        else:
-            array = <ndarray>np.empty(size, int)
-            length = PyArray_SIZE(array)
-            array_data = <long *>PyArray_DATA(array)
-            with self.lock, nogil:
-                for i from 0 <= i < length:
-                    rv = lo + <long>rk_interval(diff, self. internal_state)
-                    array_data[i] = rv
-            return array
+        return self.randint(low, high + 1, size=size, dtype='l')
+
+
 
     # Complicated, continuous distributions:
     def standard_normal(self, size=None):

--- a/numpy/random/mtrand/numpy.pxd
+++ b/numpy/random/mtrand/numpy.pxd
@@ -2,6 +2,12 @@
 
 cdef extern from "numpy/npy_no_deprecated_api.h": pass
 
+cdef extern from "mt_compat.h":
+
+    object NpyCapsule_FromVoidPtr(void *ptr, void (*dtor)(object o))
+    void * NpyCapsule_AsVoidPtr(object o)
+    
+
 cdef extern from "numpy/arrayobject.h":
 
     cdef enum NPY_TYPES:
@@ -71,7 +77,17 @@ cdef extern from "numpy/arrayobject.h":
         double real
         double imag
 
+    ctypedef int npy_int
     ctypedef int npy_intp
+    ctypedef int npy_int64
+    ctypedef int npy_uint64
+    ctypedef int npy_int32
+    ctypedef int npy_uint32
+    ctypedef int npy_int16
+    ctypedef int npy_uint16
+    ctypedef int npy_int8
+    ctypedef int npy_uint8
+    ctypedef int npy_bool
 
     ctypedef extern class numpy.dtype [object PyArray_Descr]: pass
 

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -56,10 +56,12 @@
  *                 defaults to "/dev/urandom"
  */
 
-#include <stddef.h>
-
 #ifndef _RANDOMKIT_
 #define _RANDOMKIT_
+
+#include <stddef.h>
+#include <numpy/npy_common.h>
+
 
 #define RK_STATE_LEN 624
 
@@ -147,6 +149,41 @@ extern unsigned long rk_ulong(rk_state *state);
  * Returns a random unsigned long between 0 and max inclusive.
  */
 extern unsigned long rk_interval(unsigned long max, rk_state *state);
+
+/*
+ * Fills an array with cnt random npy_uint64 between off and off + rng
+ * inclusive. The numbers wrap if rng is sufficiently large.
+ */
+extern void rk_random_uint64(npy_uint64 off, npy_uint64 rng, npy_intp cnt,
+                             npy_uint64 *out, rk_state *state);
+
+/*
+ * Fills an array with cnt random npy_uint32 between off and off + rng
+ * inclusive. The numbers wrap if rng is sufficiently large.
+ */
+extern void rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_intp cnt,
+                             npy_uint32 *out, rk_state *state);
+
+/*
+ * Fills an array with cnt random npy_uint16 between off and off + rng
+ * inclusive. The numbers wrap if rng is sufficiently large.
+ */
+extern void rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_intp cnt,
+                             npy_uint16 *out, rk_state *state);
+
+/*
+ * Fills an array with cnt random npy_uint8 between off and off + rng
+ * inclusive. The numbers wrap if rng is sufficiently large.
+ */
+extern void rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_intp cnt,
+                            npy_uint8 *out, rk_state *state);
+
+/*
+ * Fills an array with cnt random npy_bool between off and off + rng
+ * inclusive. It is assumed tha npy_bool as the same size as npy_uint8.
+ */
+extern void rk_random_bool(npy_bool off, npy_bool rng, npy_intp cnt,
+                           npy_bool *out, rk_state *state);
 
 /*
  * Returns a random double between 0.0 and 1.0, 1.0 excluded.

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -50,8 +50,10 @@ setup_base()
         | grep -E "warning\>" \
         | tee warnings
       # Check for an acceptable number of warnings. Some warnings are out of
-      # our control, so adjust the number as needed.
-      [[ $(wc -l < warnings) -lt 1 ]]
+      # our control, so adjust the number as needed. At the moment a
+      # cython generated code produces a warning about '-2147483648L', but
+      # the code seems to compile OK.
+      [[ $(wc -l < warnings) -lt 2 ]]
     fi
   else
     sysflags="$($PYTHON -c "from distutils import sysconfig; \


### PR DESCRIPTION
~~This is a WIP, in particular, the examples need fixing, tests need to be added, and a decision should be made whether to access these functions through a dtype argument in the current `random_integers` function. If the latter is chosen rk_functions for uint8, uint16, and maybe bool need to be added for efficiency, on the other hand, less new documentation needs to be written ;)~~

The following dtypes are now available from the new `dtype` argument added to randint.

```
* np.bool,
* np.int8, np.uint8,
* np.int16, np.uint16,
* np.int32, np.uint32,
* np.int64, np.uint64,
* np.int_ (long), np.intp
```

Tests for all the new functionality are needed, but things seem to work. It should also be almost trivial to template the code added to mtrant.pyx, the 9 added functions only differ in using different types.

When merged #6812 will be closed and the integer part of #6790 will be done..

~~Alternate PR's addressing this are #6824 and #6869, but I like this one as far as it goes.~~
