### PR TITLE
BUG: Enforce Order Param for MaskedArray Construction

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -120,6 +120,15 @@ The function now internally calls the generic ``npy_amergesort``
 when the type does not implement a merge-sort kind of ``argsort``
 method.
 
+*np.ma.core.MaskedArray* now supports an ``order`` argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When constructing a new ``MaskedArray`` instance, it can be
+configured with an ``order`` argument analogous to the one
+when calling ``np.ndarray``. The addition of this argument
+allows for the proper processing of an ``order`` argument
+in several MaskedArray-related utility functions such as
+``np.ma.core.array`` and ``np.ma.core.asarray``.
+
 Memory and speed improvements for masked arrays
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Creating a masked array with ``mask=True`` (resp. ``mask=False``) now uses

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2642,9 +2642,9 @@ class MaskedArray(ndarray):
 
     Construction::
 
-      x = MaskedArray(data, mask=nomask, dtype=None,
-                      copy=False, subok=True, ndmin=0, fill_value=None,
-                      keep_mask=True, hard_mask=None, shrink=True)
+      x = MaskedArray(data, mask=nomask, dtype=None, copy=False, subok=True,
+                      ndmin=0, fill_value=None, keep_mask=True, hard_mask=None,
+                      shrink=True, order=None)
 
     Parameters
     ----------
@@ -2677,6 +2677,14 @@ class MaskedArray(ndarray):
         cannot be unmasked. Default is False.
     shrink : bool, optional
         Whether to force compression of an empty mask. Default is True.
+    order : {'C', 'F', 'A'}, optional
+        Specify the order of the array.  If order is 'C', then the array
+        will be in C-contiguous order (last-index varies the fastest).
+        If order is 'F', then the returned array will be in
+        Fortran-contiguous order (first-index varies the fastest).
+        If order is 'A' (default), then the returned array may be
+        in any order (either C-, Fortran-contiguous, or even discontiguous),
+        unless a copy is required, in which case it will be C-contiguous.
 
     """
 
@@ -2688,9 +2696,8 @@ class MaskedArray(ndarray):
     _print_width = 100
 
     def __new__(cls, data=None, mask=nomask, dtype=None, copy=False,
-                subok=True, ndmin=0, fill_value=None,
-                keep_mask=True, hard_mask=None, shrink=True,
-                **options):
+                subok=True, ndmin=0, fill_value=None, keep_mask=True,
+                hard_mask=None, shrink=True, order=None, **options):
         """
         Create a new masked array from scratch.
 
@@ -2700,7 +2707,8 @@ class MaskedArray(ndarray):
 
         """
         # Process data.
-        _data = np.array(data, dtype=dtype, copy=copy, subok=True, ndmin=ndmin)
+        _data = np.array(data, dtype=dtype, copy=copy,
+                         order=order, subok=True, ndmin=ndmin)
         _baseclass = getattr(data, '_baseclass', type(_data))
         # Check that we're not erasing the mask.
         if isinstance(data, MaskedArray) and (data.shape != _data.shape):
@@ -6086,10 +6094,9 @@ masked = masked_singleton = MaskedConstant()
 masked_array = MaskedArray
 
 
-def array(data, dtype=None, copy=False, order=False,
-          mask=nomask, fill_value=None,
-          keep_mask=True, hard_mask=False, shrink=True, subok=True, ndmin=0,
-          ):
+def array(data, dtype=None, copy=False, order=None,
+          mask=nomask, fill_value=None, keep_mask=True,
+          hard_mask=False, shrink=True, subok=True, ndmin=0):
     """
     Shortcut to MaskedArray.
 
@@ -6097,10 +6104,10 @@ def array(data, dtype=None, copy=False, order=False,
     compatibility.
 
     """
-    # we should try to put 'order' somewhere
-    return MaskedArray(data, mask=mask, dtype=dtype, copy=copy, subok=subok,
-                       keep_mask=keep_mask, hard_mask=hard_mask,
-                       fill_value=fill_value, ndmin=ndmin, shrink=shrink)
+    return MaskedArray(data, mask=mask, dtype=dtype, copy=copy,
+                       subok=subok, keep_mask=keep_mask,
+                       hard_mask=hard_mask, fill_value=fill_value,
+                       ndmin=ndmin, shrink=shrink, order=order)
 array.__doc__ = masked_array.__doc__
 
 
@@ -7530,7 +7537,9 @@ def asarray(a, dtype=None, order=None):
     <class 'numpy.ma.core.MaskedArray'>
 
     """
-    return masked_array(a, dtype=dtype, copy=False, keep_mask=True, subok=False)
+    order = order or 'C'
+    return masked_array(a, dtype=dtype, copy=False, keep_mask=True,
+                        subok=False, order=order)
 
 
 def asanyarray(a, dtype=None):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -222,6 +222,22 @@ class TestMaskedArray(TestCase):
         assert_equal(xmm.fill_value, xm.fill_value)
         assert_equal(xmm._hardmask, xm._hardmask)
 
+    def test_asarray_default_order(self):
+        # See Issue #6646
+        m = np.eye(3).T
+        self.assertFalse(m.flags.c_contiguous)
+
+        new_m = asarray(m)
+        self.assertTrue(new_m.flags.c_contiguous)
+
+    def test_asarray_enforce_order(self):
+        # See Issue #6646
+        m = np.eye(3).T
+        self.assertFalse(m.flags.c_contiguous)
+
+        new_m = asarray(m, order='C')
+        self.assertTrue(new_m.flags.c_contiguous)
+
     def test_fix_invalid(self):
         # Checks fix_invalid.
         with np.errstate(invalid='ignore'):


### PR DESCRIPTION
Addresses the issue in #6646 in which the `order` parameter was not being enforced.  This PR adds the `order` parameter to the `__new__` override in `MaskedArray` construction, enabling it to be enforced in methods like `np.ma.core.array` and `np.ma.core.asarray`.
