### PR TITLE
BUG: Fix test_f2py so it runs correctly in runtests.py.

### DIFF
--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -77,6 +77,6 @@ def test_f2py():
                 assert_equal(stdout.strip(), asbytes('2'))
                 success = True
                 break
-            except OSError:
+            except:
                 pass
         assert_(success, "Warning: neither %s nor %s found in path" % f2py_cmds)


### PR DESCRIPTION
The loop checking for command line versions can terminate early as
the errors are not always of OSError type. In particular, runtests.py
may only install the command with the python version and the check fails.
run.

I thought I had already fixed this, but apparently not.
