### PR TITLE
Backport 6924

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2795,7 +2795,9 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                 if (nip1 == NULL) {
                     goto finish;
                 }
-                new->f->copyswap(nip1, ip1 + offset, swap, dummy);
+                memcpy(nip1, ip1 + offset, new->elsize);
+                if (swap)
+                    new->f->copyswap(nip1, NULL, swap, dummy);
             }
             if (swap || !npy_is_aligned(nip2, new->alignment)) {
                 /* create buffer and copy */
@@ -2806,7 +2808,9 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                     }
                     goto finish;
                 }
-                new->f->copyswap(nip2, ip2 + offset, swap, dummy);
+                memcpy(nip2, ip2 + offset, new->elsize);
+                if (swap)
+                    new->f->copyswap(nip2, NULL, swap, dummy);
             }
         }
         res = new->f->compare(nip1, nip2, dummy);

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2177,5 +2177,11 @@ class TestRegression(TestCase):
         # gh-6530 / gh-6553
         assert_array_equal(np.percentile(np.arange(10), []), np.array([]))
 
+    def test_void_compare_segfault(self):
+        # gh-6922. The following should not segfault
+        a = np.ones(3, dtype=[('object', 'O'), ('int', '<i2')])
+        a.sort()
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
BUG: #6922:  Fix segfault introduced in 23901aa.

Fix troublesome parts of gh-5929. Copyswap cannot be relied upon for void types containing objects.
