### PR TITLE
DEP: deprecate np.testing.rand

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -158,3 +158,10 @@ parameter in methods like ```array.flatten``` or ```array.ravel```
 that were not one of the following: 'C', 'F', 'A', 'K' (note that
 all of these possible values are unicode- and case-insensitive).
 Such behaviour will not be allowed in future releases.
+
+Random number generator in the ``testing`` namespace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Python standard library random number generator was previously exposed in the
+``testing`` namespace as ``testing.rand``. Using this generator is not
+recommended and it will be removed in a future release. Use generators from
+``numpy.random`` namespace instead.

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -16,6 +16,7 @@ from tempfile import mkdtemp, mkstemp
 
 from .nosetester import import_nose
 from numpy.core import float32, empty, arange, array_repr, ndarray
+from numpy.lib.utils import deprecate
 
 if sys.version_info[0] >= 3:
     from io import StringIO
@@ -122,6 +123,8 @@ def gisinf(x):
             raise TypeError("isinf not supported for this type")
     return st
 
+@deprecate(message="numpy.testing.rand is deprecated in numpy 1.11. "
+                   "Use numpy.random.rand instead.")
 def rand(*args):
     """Returns an array of random numbers with the given shape.
 


### PR DESCRIPTION
This exposes stdlib's random number generator and makes life a little unpredictable for those users who think that they have reproducibility by seeding the generator from numpy.random. 
See, e.g., https://github.com/scipy/scipy/pull/5661 and https://github.com/scipy/scipy/issues/5629.
