### PR TITLE
Backport 6369

### DIFF
--- a/doc/release/1.10.3-notes.rst
+++ b/doc/release/1.10.3-notes.rst
@@ -1,0 +1,22 @@
+NumPy 1.10.3 Release Notes
+**************************
+
+This release is a bugfix release motivated by a segfault regression.
+
+Issues Fixed
+============
+
+* gh-6922 BUG: numpy.recarray.sort segfaults on Windows
+
+Merged PRs
+==========
+
+The following PRs have been merged into 1.10.3. When the PR is a backport,
+the PR number for the original PR against master is listed.
+
+* gh-6840 TST: Update travis testing script in 1.10.x
+* gh-6843 BUG: Fix use of python 3 only FileNotFoundError in test_f2py.
+* gh-6884 REL: Update pavement.py and setup.py to reflect current version.
+* gh-6916 BUG: Fix test_f2py so it runs correctly in runtests.py.
+* gh-6924 BUG: Fix segfault gh-6922.
+


### PR DESCRIPTION
DOC: Create Numpy 1.10.3 release notes.

[ci skip]
