### PR TITLE
Fix datetime roll='modifiedpreceding' bug

### DIFF
--- a/numpy/core/src/multiarray/datetime_busday.c
+++ b/numpy/core/src/multiarray/datetime_busday.c
@@ -889,7 +889,7 @@ PyArray_BusDayRollConverter(PyObject *roll_in, NPY_BUSDAY_ROLL *roll)
                     break;
                 case 'p':
                     if (strcmp(str, "modifiedpreceding") == 0) {
-                        *roll = NPY_BUSDAY_MODIFIEDFOLLOWING;
+                        *roll = NPY_BUSDAY_MODIFIEDPRECEDING;
                         goto finish;
                     }
                     break;

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1524,6 +1524,12 @@ class TestDateTime(TestCase):
         assert_equal(
                 np.busday_offset('2010-10-30', 0, roll='modifiedpreceding'),
                 np.datetime64('2010-10-29'))
+        assert_equal(
+                np.busday_offset('2010-10-16', 0, roll='modifiedfollowing'),
+                np.datetime64('2010-10-18'))
+        assert_equal(
+                np.busday_offset('2010-10-16', 0, roll='modifiedpreceding'),
+                np.datetime64('2010-10-15'))
         # roll='raise' by default
         assert_raises(ValueError, np.busday_offset, '2011-06-04', 0)
 


### PR DESCRIPTION
This fixes #6937.
