### PR TITLE
DOC,BUG: Fix some latex generation problems.

### DIFF
--- a/doc/release/1.10.3-notes.rst
+++ b/doc/release/1.10.3-notes.rst
@@ -19,4 +19,5 @@ the PR number for the original PR against master is listed.
 * gh-6884 REL: Update pavement.py and setup.py to reflect current version.
 * gh-6916 BUG: Fix test_f2py so it runs correctly in runtests.py.
 * gh-6924 BUG: Fix segfault gh-6922.
+* gh-6943 DOC,BUG: Fix some latex generation problems.
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3829,13 +3829,13 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('newbyteorder',
     ----------
     new_order : string, optional
         Byte order to force; a value from the byte order specifications
-        above. `new_order` codes can be any of::
+        below. `new_order` codes can be any of:
 
-         * 'S' - swap dtype from current to opposite endian
-         * {'<', 'L'} - little endian
-         * {'>', 'B'} - big endian
-         * {'=', 'N'} - native order
-         * {'|', 'I'} - ignore (no change to byte order)
+        * 'S' - swap dtype from current to opposite endian
+        * {'<', 'L'} - little endian
+        * {'>', 'B'} - big endian
+        * {'=', 'N'} - native order
+        * {'|', 'I'} - ignore (no change to byte order)
 
         The default value ('S') results in swapping the current
         byte order. The code does a case-insensitive check on the first
@@ -6298,16 +6298,15 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('newbyteorder',
     Parameters
     ----------
     new_order : string, optional
-        Byte order to force; a value from the byte order
-        specifications below.  The default value ('S') results in
-        swapping the current byte order.
-        `new_order` codes can be any of::
+        Byte order to force; a value from the byte order specifications
+        below.  The default value ('S') results in swapping the current
+        byte order.  `new_order` codes can be any of:
 
-         * 'S' - swap dtype from current to opposite endian
-         * {'<', 'L'} - little endian
-         * {'>', 'B'} - big endian
-         * {'=', 'N'} - native order
-         * {'|', 'I'} - ignore (no change to byte order)
+        * 'S' - swap dtype from current to opposite endian
+        * {'<', 'L'} - little endian
+        * {'>', 'B'} - big endian
+        * {'=', 'N'} - native order
+        * {'|', 'I'} - ignore (no change to byte order)
 
         The code does a case-insensitive check on the first letter of
         `new_order` for these alternatives.  For example, any of '>'
@@ -7170,10 +7169,10 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('newbyteorder',
 
     The `new_order` code can be any from the following:
 
+    * 'S' - swap dtype from current to opposite endian
     * {'<', 'L'} - little endian
     * {'>', 'B'} - big endian
     * {'=', 'N'} - native order
-    * 'S' - swap dtype from current to opposite endian
     * {'|', 'I'} - ignore (no change to byte order)
 
     Parameters

--- a/numpy/lib/user_array.py
+++ b/numpy/lib/user_array.py
@@ -1,5 +1,6 @@
 """
 Standard container-class for easy multiple-inheritance.
+
 Try to inherit from the ndarray instead of using this class as this is not
 complete.
 
@@ -16,7 +17,19 @@ from numpy.compat import long
 
 
 class container(object):
+    """
+    container(data, dtype=None, copy=True)
 
+    Standard container-class for easy multiple-inheritance.
+
+    Methods
+    -------
+    copy
+    tostring
+    byteswap
+    astype
+
+    """
     def __init__(self, data, dtype=None, copy=True):
         self.array = array(data, dtype, copy=copy)
 
@@ -219,15 +232,19 @@ class container(object):
         return self._rc(greater_equal(self.array, other))
 
     def copy(self):
+        ""
         return self._rc(self.array.copy())
 
     def tostring(self):
+        ""
         return self.array.tostring()
 
     def byteswap(self):
+        ""
         return self._rc(self.array.byteswap())
 
     def astype(self, typecode):
+        ""
         return self._rc(self.array.astype(typecode))
 
     def _rc(self, a):


### PR DESCRIPTION
Some of the documentation for newbyteorder, copy and pasted in several
spots, had paragraphs ending in `::`, initiating a sphinx generated
Verbatim environment and resulting in "LaTeX Error: Too deeply nested".

The user_array.container class needed non-empty class documentation.
That that caused a problem is probably a numpydoc bug, but it is easy to
fix.

[skip ci]
