### PR TITLE
BUG recarray slices should preserve subclass.

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -425,7 +425,7 @@ class recarray(ndarray):
 
     def __array_finalize__(self, obj):
         if self.dtype.type is not record:
-            # if self.dtype is not np.record, invoke __setattr__ which will 
+            # if self.dtype is not np.record, invoke __setattr__ which will
             # convert it to a record if it is a void dtype.
             self.dtype = self.dtype
 
@@ -496,13 +496,13 @@ class recarray(ndarray):
         return self.setfield(val, *res)
 
     def __getitem__(self, indx):
-        obj = ndarray.__getitem__(self, indx)
+        obj = super(recarray, self).__getitem__(indx)
 
         # copy behavior of getattr, except that here
         # we might also be returning a single element
         if isinstance(obj, ndarray):
             if obj.dtype.fields:
-                obj = obj.view(recarray)
+                obj = obj.view(type(self))
                 if issubclass(obj.dtype.type, nt.void):
                     return obj.view(dtype=(self.dtype.type, obj.dtype))
                 return obj

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -122,12 +122,19 @@ class TestFromrecords(TestCase):
         assert_equal(rv.dtype.type, np.record)
 
         #check that getitem also preserves np.recarray and np.record
-        r = np.rec.array(np.ones(4, dtype=[('a', 'i4'), ('b', 'i4'), 
+        r = np.rec.array(np.ones(4, dtype=[('a', 'i4'), ('b', 'i4'),
                                            ('c', 'i4,i4')]))
         assert_equal(r['c'].dtype.type, np.record)
         assert_equal(type(r['c']), np.recarray)
         assert_equal(r[['a', 'b']].dtype.type, np.record)
         assert_equal(type(r[['a', 'b']]), np.recarray)
+
+        #and that it preserves subclasses (gh-6949)
+        class C(np.recarray):
+            pass
+
+        c = r.view(C)
+        assert_equal(type(c['c']), C)
 
         # check that accessing nested structures keep record type, but
         # not for subarrays, non-void structures, non-structured voids


### PR DESCRIPTION
Aims to solve #6949 -- quite likely important for FITS records in astropy as well, so cc @embray.
