### PR TITLE
DOC: Prepare for 1.10.4 release.

### DIFF
--- a/doc/release/1.10.3-notes.rst
+++ b/doc/release/1.10.3-notes.rst
@@ -1,39 +1,4 @@
 NumPy 1.10.3 Release Notes
 **************************
 
-This release is a bugfix source release motivated by a segfault regression.
-No windows binaries are provided for this release, as there appear to be
-bugs in the toolchain we use to generate those files. Hopefully that
-problem will be fixed for the next release. In the meantime, we suggest
-using one of the providers of windows binaries.
-
-Compatibility notes
-===================
-
-* The trace function now calls the trace method on subclasses of ndarray,
-  except for matrix, for which the current behavior is preserved. This is
-  to help with the units package of AstroPy and hopefully will not cause
-  problems.
-
-Issues Fixed
-============
-
-* gh-6922 BUG: numpy.recarray.sort segfaults on Windows.
-* gh-6937 BUG: busday_offset does the wrong thing with modifiedpreceding roll.
-* gh-6949 BUG: Type is lost when slicing a subclass of recarray.
-
-Merged PRs
-==========
-
-The following PRs have been merged into 1.10.3. When the PR is a backport,
-the PR number for the original PR against master is listed.
-
-* gh-6840 TST: Update travis testing script in 1.10.x
-* gh-6843 BUG: Fix use of python 3 only FileNotFoundError in test_f2py.
-* gh-6884 REL: Update pavement.py and setup.py to reflect current version.
-* gh-6916 BUG: Fix test_f2py so it runs correctly in runtests.py.
-* gh-6924 BUG: Fix segfault gh-6922.
-* gh-6942 Fix datetime roll='modifiedpreceding' bug.
-* gh-6943 DOC,BUG: Fix some latex generation problems.
-* gh-6950 BUG trace is not subclass aware, np.trace(ma) != ma.trace().
-* gh-6952 BUG recarray slices should preserve subclass.
+N/A this release did not happen due to various screwups involving PyPi.

--- a/doc/release/1.10.4-notes.rst
+++ b/doc/release/1.10.4-notes.rst
@@ -1,0 +1,39 @@
+NumPy 1.10.4 Release Notes
+**************************
+
+This release is a bugfix source release motivated by a segfault regression.
+No windows binaries are provided for this release, as there appear to be
+bugs in the toolchain we use to generate those files. Hopefully that
+problem will be fixed for the next release. In the meantime, we suggest
+using one of the providers of windows binaries.
+
+Compatibility notes
+===================
+
+* The trace function now calls the trace method on subclasses of ndarray,
+  except for matrix, for which the current behavior is preserved. This is
+  to help with the units package of AstroPy and hopefully will not cause
+  problems.
+
+Issues Fixed
+============
+
+* gh-6922 BUG: numpy.recarray.sort segfaults on Windows.
+* gh-6937 BUG: busday_offset does the wrong thing with modifiedpreceding roll.
+* gh-6949 BUG: Type is lost when slicing a subclass of recarray.
+
+Merged PRs
+==========
+
+The following PRs have been merged into 1.10.3. When the PR is a backport,
+the PR number for the original PR against master is listed.
+
+* gh-6840 TST: Update travis testing script in 1.10.x
+* gh-6843 BUG: Fix use of python 3 only FileNotFoundError in test_f2py.
+* gh-6884 REL: Update pavement.py and setup.py to reflect current version.
+* gh-6916 BUG: Fix test_f2py so it runs correctly in runtests.py.
+* gh-6924 BUG: Fix segfault gh-6922.
+* gh-6942 Fix datetime roll='modifiedpreceding' bug.
+* gh-6943 DOC,BUG: Fix some latex generation problems.
+* gh-6950 BUG trace is not subclass aware, np.trace(ma) != ma.trace().
+* gh-6952 BUG recarray slices should preserve subclass.

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -2,7 +2,8 @@
 Release Notes
 *************
 
-.. include:: ../release/1.11.0-notes.rst
+.. include:: ../release/1.10.4-notes.rst
+.. include:: ../release/1.10.3-notes.rst
 .. include:: ../release/1.10.2-notes.rst
 .. include:: ../release/1.10.1-notes.rst
 .. include:: ../release/1.10.0-notes.rst


### PR DESCRIPTION
There were problems with the PyPi upload, so make a 1.10.4 release.
The new 1.10.4-notes are copies of the old 1.10.3-notes, and the
latter have been marked void.

[ci skip]
