### PR TITLE
MAINT, STY: Removed unused variable in f2py/f90mod_rules.py

### DIFF
--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -49,7 +49,7 @@ def findf90modules(m):
 fgetdims1 = """\
       external f2pysetdata
       logical ns
-      integer r,i,j
+      integer r,i
       integer(%d) s(*)
       ns = .FALSE.
       if (allocated(d)) then


### PR DESCRIPTION
As pointed out in issue #6894, I have removed the declaration of unused variable at line 52 in the file numpy/f2py/f90mod_rules.py. 
Please review. Thanks.
