### PR TITLE
DOC: Change to matrix.argmax docstring so it reflects what the code does

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -783,7 +783,7 @@ class matrix(N.ndarray):
 
     def argmax(self, axis=None, out=None):
         """
-        Indices of the maximum values along an axis.
+        Index of the maximum value along an axis, if multiple returns the first one
 
         Parameters
         ----------


### PR DESCRIPTION
DOC: Fixing docstring so it reflects what the code does

In [222]: x = np.matrix(np.arange(12).reshape((3,4))); x
Out[222]:
matrix([[ 0,  1,  2,  3],
        [ 4,  5,  6,  7],
        [ 8,  9, 10, 11]])

In [223]: x.argmax()
Out[223]: 11

In [224]: x[1,1]=11

In [225]: x.argmax()
Out[225]: 5
