### PR TITLE
BUG: npy_acosh fallback too simple.

### DIFF
--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -221,7 +221,20 @@ double npy_hypot(double x, double y)
 #ifndef HAVE_ACOSH
 double npy_acosh(double x)
 {
-    return 2*npy_log(npy_sqrt((x + 1.0)/2) + npy_sqrt((x - 1.0)/2));
+    if (x < 1.0) {
+        return NPY_NAN;
+    }
+
+    if (npy_isfinite(x)) {
+        if (x > 1e8) {
+             return npy_log(x) + NPY_LOGE2;
+        }
+        else {
+            double u = x - 1.0;
+            return npy_log1p(u + npy_sqrt(2*u + u*u));
+        }
+    }
+    return x;
 }
 #endif
 


### PR DESCRIPTION
Fixes gh-6712.

Comparing the old implementation against mpmath with 1000 digits:
![figure_1](https://cloud.githubusercontent.com/assets/2314641/12211330/1cf28072-b62e-11e5-8a7a-ea51e229563d.png)
and the new implementation:
![figure_2](https://cloud.githubusercontent.com/assets/2314641/12211336/255a5fbe-b62e-11e5-9913-33f19d742bd0.png)
