### PR TITLE
TST, MAINT: Make sure exceptions of `inner` and `dot` match for different cases

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -59,6 +59,13 @@ to preserve struct layout). These were never used for anything, so
 it's unlikely that any third-party code is using them either, but we
 mention it here for completeness.
 
+*np.dot* now raises ``TypeError`` instead of ``ValueError``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This behaviour mimics that of other functions such as ``np.inner``. If the two
+arguments cannot be cast to a common type, it could have raised a ``TypeError``
+or ``ValueError`` depending on their order. Now, ``np.dot`` will now always
+raise a ``TypeError``.
+
 
 New Features
 ============
@@ -173,6 +180,13 @@ Instead, ``np.broadcast`` can be used in all cases.
 This behaviour mimics that of other functions such as ``np.diagonal`` and
 ensures, e.g., that for masked arrays ``np.trace(ma)`` and ``ma.trace()`` give
 the same result.
+
+*np.dot* now raises ``TypeError`` instead of ``ValueError``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This behaviour mimics that of other functions such as ``np.inner``. If the two
+arguments cannot be cast to a common type, it could have raised a ``TypeError``
+or ``ValueError`` depending on their order. Now, ``np.dot`` will now always
+raise a ``TypeError``.
 
 Deprecations
 ============

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -827,6 +827,7 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     typenum = PyArray_ObjectType(op2, typenum);
     typec = PyArray_DescrFromType(typenum);
     if (typec == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Cannot find a common data type.");
         goto fail;
     }
 
@@ -912,7 +913,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     typenum = PyArray_ObjectType(op2, typenum);
     typec = PyArray_DescrFromType(typenum);
     if (typec == NULL) {
-        PyErr_SetString(PyExc_ValueError, "Cannot find a common data type.");
+        PyErr_SetString(PyExc_TypeError, "Cannot find a common data type.");
         return NULL;
     }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2045,7 +2045,7 @@ class TestMethods(TestCase):
         c = 1.
         A = np.array((1,1), dtype='i,i')
 
-        assert_raises(ValueError, np.dot, c, A)
+        assert_raises(TypeError, np.dot, c, A)
         assert_raises(TypeError, np.dot, A, c)
 
     def test_diagonal(self):


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/pull/6988

Fixes an issue with `dot` where it was  `ValueError` or a `TypeError` depending on the order of its arguments. This differs from `inner`, which always raises a `TypeError`. Below is an example of the current behavior, which seems odd. This PR makes all cases raise a `TypeError`.

```
>>> import numpy
>>> import numpy as np
>>> np.inner(1., np.array((1,1), dtype='i,i'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: invalid type promotion
>>> np.inner(np.array((1,1), dtype='i,i'), 1.)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Cannot cast array data from dtype([('f0', '<i4'), ('f1', '<i4')]) to dtype('float64') according to the rule 'safe'
>>> np.dot(1., np.array((1,1), dtype='i,i'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Cannot find a common data type.
>>> np.dot(np.array((1,1), dtype='i,i'), 1.)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Cannot cast array data from dtype([('f0', '<i4'), ('f1', '<i4')]) to dtype('float64') according to the rule 'safe'
```
