### PR TITLE
BUG: Fix dot and inner type/value exception failures

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1926,14 +1926,34 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     /* Raise an error if the casting rule isn't followed */
     if (!PyArray_CanCastArrayTo(arr, newtype, casting)) {
         PyObject *errmsg;
+        PyArray_Descr *arr_descr = NULL;
+        PyObject *arr_descr_repr = NULL;
+        PyObject *newtype_repr = NULL;
 
+        PyErr_Clear();
         errmsg = PyUString_FromString("Cannot cast array data from ");
-        PyUString_ConcatAndDel(&errmsg,
-                PyObject_Repr((PyObject *)PyArray_DESCR(arr)));
+        arr_descr = PyArray_DESCR(arr);
+        if (arr_descr == NULL) {
+            Py_DECREF(newtype);
+            Py_DECREF(errmsg);
+            return NULL;
+        }
+        arr_descr_repr = PyObject_Repr((PyObject *)arr_descr);
+        if (arr_descr_repr == NULL) {
+            Py_DECREF(newtype);
+            Py_DECREF(errmsg);
+            return NULL;
+        }
+        PyUString_ConcatAndDel(&errmsg, arr_descr_repr);
         PyUString_ConcatAndDel(&errmsg,
                 PyUString_FromString(" to "));
-        PyUString_ConcatAndDel(&errmsg,
-                PyObject_Repr((PyObject *)newtype));
+        newtype_repr = PyObject_Repr((PyObject *)newtype);
+        if (newtype_repr == NULL) {
+            Py_DECREF(newtype);
+            Py_DECREF(errmsg);
+            return NULL;
+        }
+        PyUString_ConcatAndDel(&errmsg, newtype_repr);
         PyUString_ConcatAndDel(&errmsg,
                 PyUString_FromFormat(" according to the rule %s",
                         npy_casting_to_string(casting)));

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4832,6 +4832,13 @@ if sys.version_info[:2] >= (3, 5):
 
 class TestInner(TestCase):
 
+    def test_inner_type_mismatch(self):
+        c = 1.
+        A = np.array((1,1), dtype='i,i')
+
+        assert_raises(TypeError, np.inner, c, A)
+        assert_raises(TypeError, np.inner, A, c)
+
     def test_inner_scalar_and_vector(self):
         for dt in np.typecodes['AllInteger'] + np.typecodes['AllFloat'] + '?':
             sca = np.array(3, dtype=dt)[()]

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2041,6 +2041,13 @@ class TestMethods(TestCase):
         assert_raises(TypeError, np.dot, b, c)
         assert_raises(TypeError, c.dot, b)
 
+    def test_dot_type_mismatch(self):
+        c = 1.
+        A = np.array((1,1), dtype='i,i')
+
+        assert_raises(ValueError, np.dot, c, A)
+        assert_raises(TypeError, np.dot, A, c)
+
     def test_diagonal(self):
         a = np.arange(12).reshape((3, 4))
         assert_equal(a.diagonal(), [0, 5, 10])


### PR DESCRIPTION
Partial fix: https://github.com/numpy/numpy/issues/6990

**TL;DR:** Bug fix to catch a possible second exception while building an exception message. Includes tests for `dot` and `inner` where this bug was first discovered.

**History:** Initially, this PR began as tests for the current behavior of `dot` and `inner` when they have some mismatched types that cannot be coerced into some common working type. However, this resulted in discovering a special class of bugs in C where an exception could occur during the creation of the exception message, but was not being handled. This bug has been carefully described with a list of instances in this bug report (  https://github.com/numpy/numpy/issues/6990 ). As a result, this contains a fix for one instance of this bug and tests to verify that this instance is fixed.
