### PR TITLE
DOC, MAINT: Enforce np.ndarray arg for np.put and np.place

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -445,7 +445,13 @@ def put(a, ind, v, mode='raise'):
     array([ 0,  1,  2,  3, -5])
 
     """
-    return a.put(ind, v, mode)
+    try:
+        put = a.put
+    except AttributeError:
+        raise TypeError("argument 1 must be numpy.ndarray, "
+                        "not {name}".format(name=type(a).__name__))
+
+    return put(ind, v, mode)
 
 
 def swapaxes(a, axis1, axis2):

--- a/numpy/core/tests/test_fromnumeric.py
+++ b/numpy/core/tests/test_fromnumeric.py
@@ -1,0 +1,17 @@
+from __future__ import division, absolute_import, print_function
+
+from numpy import put
+from numpy.testing import TestCase, assert_raises
+
+
+class TestPut(TestCase):
+
+    def test_bad_array(self):
+        # We want to raise a TypeError in the
+        # case that a non-ndarray object is passed
+        # in since `np.put` modifies in place and
+        # hence would do nothing to a non-ndarray
+        v = 5
+        indx = [0, 2]
+        bad_array = [1, 2, 3]
+        assert_raises(TypeError, put, bad_array, indx, v)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1779,7 +1779,7 @@ def place(arr, mask, vals):
 
     Parameters
     ----------
-    arr : array_like
+    arr : ndarray
         Array to put data into.
     mask : array_like
         Boolean mask array. Must have the same size as `a`.
@@ -1801,6 +1801,10 @@ def place(arr, mask, vals):
            [44, 55, 44]])
 
     """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("argument 1 must be numpy.ndarray, "
+                        "not {name}".format(name=type(arr).__name__))
+
     return _insert(arr, mask, vals)
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -674,6 +674,10 @@ class TestExtins(TestCase):
         assert_array_equal(b, [3, 2, 2, 3, 3])
 
     def test_place(self):
+        # Make sure that non-np.ndarray objects
+        # raise an error instead of doing nothing
+        assert_raises(TypeError, place, [1, 2, 3], [True, False], [0, 1])
+
         a = np.array([1, 4, 3, 2, 5, 8, 7])
         place(a, [0, 1, 0, 1, 0, 1, 0], [2, 4, 6])
         assert_array_equal(a, [1, 2, 3, 4, 5, 6, 7])

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -85,10 +85,6 @@ class TestRegression(TestCase):
         assert_(x != y)
         assert_(x == x)
 
-    def test_mem_insert(self, level=rlevel):
-        # Ticket #572
-        np.lib.place(1, 1, 1)
-
     def test_polyfit_build(self):
         # Ticket #628
         ref = [-1.06123820e-06, 5.70886914e-04, -1.13822012e-01,


### PR DESCRIPTION
`np.put` and `np.place` do something only when the first argument is an instance of `np.ndarray`. These changes will cause a `TypeError` to be thrown in either function should that requirement not be satisfied, which would be more useful to see when debugging.
