### PR TITLE
BUG: skip invalid path distutils warning for empty strings

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -629,7 +629,7 @@ class system_info(object):
         dirs.extend(default_dirs)
         ret = []
         for d in dirs:
-            if not os.path.isdir(d):
+            if len(d) > 0 and not os.path.isdir(d):
                 warnings.warn('Specified path %s is invalid.' % d)
                 continue
 


### PR DESCRIPTION
empty strings are the default for the new rpath,
extra_compile_args and extra_link_args sections
