### PR TITLE
DOC: Fix a number sequence in docs

### DIFF
--- a/numpy/doc/misc.py
+++ b/numpy/doc/misc.py
@@ -138,7 +138,7 @@ Only a survey of the choices. Little detail on how each works.
    - Can write code in non-standard form which may become obsolete
    - Not as flexible as manual wrapping
 
-4) ctypes
+3) ctypes
 
  - Plusses:
 
@@ -160,7 +160,7 @@ Only a survey of the choices. Little detail on how each works.
    - can't use for writing code to be turned into C extensions, only a wrapper
      tool.
 
-5) SWIG (automatic wrapper generator)
+4) SWIG (automatic wrapper generator)
 
  - Plusses:
 
@@ -178,7 +178,7 @@ Only a survey of the choices. Little detail on how each works.
    - doesn't necessarily avoid reference counting issues or needing to know
      API's
 
-7) scipy.weave
+5) scipy.weave
 
  - Plusses:
 
@@ -192,7 +192,7 @@ Only a survey of the choices. Little detail on how each works.
    - Future very uncertain: it's the only part of Scipy not ported to Python 3
      and is effectively deprecated in favor of Cython.
 
-8) Psyco
+6) Psyco
 
  - Plusses:
 


### PR DESCRIPTION
I have found that there are two missing numbers in a sequence in the documentation.
http://docs.scipy.org/doc/numpy/user/misc.html#interfacing-to-c

It goes 1,2,3,5,7,8 with missing 4 and 6.
