### PR TITLE
MAINT: ensure isclose returns scalar when called with two scalars closes #7014

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2467,7 +2467,11 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
             # Make NaN == NaN
             both_nan = isnan(x) & isnan(y)
             cond[both_nan] = both_nan[both_nan]
-        return cond
+
+        if isscalar(a) and isscalar(b):
+            return bool(cond)
+        else:
+            return cond
 
 def array_equal(a1, a2):
     """

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1589,7 +1589,11 @@ class TestIsclose(object):
 
     def tst_isclose_allclose(self, x, y):
         msg = "isclose.all() and allclose aren't same for %s and %s"
-        assert_array_equal(np.isclose(x, y).all(), np.allclose(x, y), msg % (x, y))
+        msg2 = "isclose and allclose aren't same for %s and %s"
+        if np.isscalar(x) and np.isscalar(y):
+            assert_(np.isclose(x, y) == np.allclose(x, y), msg=msg % (x, y))
+        else:
+            assert_array_equal(np.isclose(x, y).all(), np.allclose(x, y), msg % (x, y))
 
     def test_ip_all_isclose(self):
         self.setup()
@@ -1649,6 +1653,14 @@ class TestIsclose(object):
         np.isclose(x, y)
         assert_array_equal(x, np.array([np.inf, 1]))
         assert_array_equal(y, np.array([0, np.inf]))
+
+    def test_non_finite_scalar(self):
+        # GH7014, when two scalars are compared the output should also be a
+        # scalar
+        assert_(np.isclose(np.inf, -np.inf) is False)
+        assert_(np.isclose(0, np.inf) is False)
+        assert_(type(np.isclose(0, np.inf)) is bool)
+
 
 class TestStdVar(TestCase):
     def setUp(self):


### PR DESCRIPTION
The documentation for np.isclose says:

> Returns a boolean array of where a and b are equal within the given tolerance. If both a and b are scalars, returns a single boolean value.

This is true for comparing two finite scalars, a single boolean value is returned:

```
>>> np.isclose(0, 1)
False
```

However, a boolean array is returned when one or more of the scalars is non-finite:

```
>>> np.isclose(0, np.inf)
array([False], dtype=bool)
```

I would expect (from the documentation) the above to return a single boolean value, not an array. I note that both values in the last example are scalars:

```
>>> np.isscalar(0)
True
>>> np.isscalar(np.inf)
True
```
