### PR TITLE
DEP: Warn MaskedArray will return views of mask when sliced

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -20,6 +20,7 @@ Future Changes
 
 * Relaxed stride checking will become the default in 1.12.0.
 * Support for Python 2.6, 3.2, and 3.3 will be dropped in 1.12.0.
+* ``MaskedArray``s take views of data **and** masks when slicing in 1.12.0.
 
 
 Compatibility notes

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -539,6 +539,7 @@ class TestNanFunctions_Median(TestCase):
         for axis in [None, 0, 1]:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
+                warnings.simplefilter('ignore', FutureWarning)
                 assert_(np.isnan(np.nanmedian(mat, axis=axis)).all())
                 if axis is None:
                     assert_(len(w) == 1)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3105,6 +3105,14 @@ class MaskedArray(ndarray):
         Return the item described by i, as a masked array.
 
         """
+        # 2016.01.15 -- v1.11.0
+        warnings.warn(
+            "Currently, slicing will try to return a view of the data," +
+            " but will return a copy of the mask. In the future, it will try" +
+            " to return both as views.",
+            FutureWarning
+        )
+
         dout = self.data[indx]
         # We could directly use ndarray.__getitem__ on self.
         # But then we would have to modify __array_finalize__ to prevent the
@@ -3175,6 +3183,15 @@ class MaskedArray(ndarray):
         locations.
 
         """
+        # 2016.01.15 -- v1.11.0
+        warnings.warn(
+           "Currently, slicing will try to return a view of the data," +
+           " but will return a copy of the mask. In the future, it will try" +
+           " to return both as views. This means that using `__setitem__`" +
+           " will propagate values back through all masks that are present.",
+           FutureWarning
+        )
+
         if self is masked:
             raise MaskError('Cannot alter the masked element.')
         _data = self._data

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2223,6 +2223,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 xm[2] = masked
                 x += t(1)
@@ -2237,6 +2238,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
@@ -2267,6 +2269,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
@@ -2297,6 +2300,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
@@ -2314,6 +2318,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 x = arange(10, dtype=t) * t(2)
                 xm = arange(10, dtype=t) * t(2)
@@ -2330,6 +2335,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
@@ -2350,6 +2356,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 x = arange(10, dtype=t) * t(2)
                 xm = arange(10, dtype=t) * t(2)
@@ -2385,6 +2392,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
         for t in self.othertypes:
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
+                warnings.simplefilter('ignore', FutureWarning)
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/7012
Related: https://github.com/numpy/numpy/pull/5580

This deprecates the copying of masks when slicing `MaskedArray`s in favor of providing views when a view of the data is provided.

Notes the changing behavior in the 1.11.0 release notes.

Adds `FutureWarning`s in these places:
- `__getitem__`
- `__setitem__`
