### PR TITLE
DOC: Clarify behavior in np.random.uniform

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1496,6 +1496,12 @@ cdef class RandomState:
 
         anywhere within the interval ``[a, b)``, and zero elsewhere.
 
+        When ``high`` == ``low``, values of ``low`` will be returned.
+        If ``high`` < ``low``, the results are officially undefined
+        and may eventually raise an error, i.e. do not rely on this
+        function to behave when passed arguments satisfying that
+        inequality condition.
+
         Examples
         --------
         Draw samples from the distribution:


### PR DESCRIPTION
Fixes issue in `np.random.uniform` in which it was generating numbers for invalid bounds such as
low = 0 and high = -1.  It now raises a `ValueError` instead like `np.random.randint` when such arguments are passed in.
