### PR TITLE
Fix issue #7021

### DIFF
--- a/numpy/core/src/multiarray/datetime_busday.c
+++ b/numpy/core/src/multiarray/datetime_busday.c
@@ -288,6 +288,7 @@ apply_business_day_offset(npy_datetime date, npy_int64 offset,
 
     /* If we get a NaT, just return it */
     if (date == NPY_DATETIME_NAT) {
+        *out = NPY_DATETIME_NAT;
         return 0;
     }
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1588,6 +1588,15 @@ class TestDateTime(TestCase):
         assert_equal(np.busday_offset('2007-04-07', -11, weekmask='SatSun'),
                      np.datetime64('2007-02-25'))
 
+        # NaT values when roll is not raise
+        assert_equal(np.busday_offset(np.datetime64('NaT'), 1, roll='nat'),
+                     np.datetime64('NaT'))
+        assert_equal(np.busday_offset(np.datetime64('NaT'), 1, roll='following'),
+                     np.datetime64('NaT'))
+        assert_equal(np.busday_offset(np.datetime64('NaT'), 1, roll='preceding'),
+                     np.datetime64('NaT'))
+
+
     def test_datetime_busdaycalendar(self):
         # Check that it removes NaT, duplicates, and weekends
         # and sorts the result.


### PR DESCRIPTION
Fixes issue in `numpy.busday_offset`. `NaT` values in array give `NaT` when `roll` is set to any value except `raise`
