### PR TITLE
BLD: fix rebuilding after a failed build.  Closes gh-5467.

### DIFF
--- a/numpy/distutils/__init__.py
+++ b/numpy/distutils/__init__.py
@@ -11,13 +11,13 @@ from . import unixccompiler
 from .info import __doc__
 from .npy_pkg_config import *
 
+# If numpy is installed, add distutils.test()
 try:
     from . import __config__
-    _INSTALLED = True
-except ImportError:
-    _INSTALLED = False
-
-if _INSTALLED:
+    # Normally numpy is installed if the above import works, but an interrupted
+    # in-place build could also have left a __config__.py.  In that case the
+    # next import may still fail, so keep it inside the try block.
     from numpy.testing.nosetester import _numpy_tester
     test = _numpy_tester().test
-    bench = _numpy_tester().bench
+except ImportError:
+    pass


### PR DESCRIPTION
Also remove `distutils.bench()`, does't do anything here after the move to asv.
