### PR TITLE
REL: Do not include merge commits in Changelog.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -617,8 +617,9 @@ SHA256
 
 def write_log_task(options, filename='Changelog'):
     st = subprocess.Popen(
-            ['git', 'log',  '%s..%s' % (LOG_START, LOG_END)],
-            stdout=subprocess.PIPE)
+        ['git', 'log', '--no-merges', '--use-mailmap',
+         '%s..%s' % (LOG_START, LOG_END)],
+        stdout=subprocess.PIPE)
 
     out = st.communicate()[0]
     a = open(filename, 'w')


### PR DESCRIPTION
Cleans up the Changelog.

This leaves out the merge commits from the generated changelog. Because we merge everything except when branching or tagging a release, there is a lot of redundancy in the Changelog. An alternative would be to only show the merges, but that leaves out information when more than one commit is in the merge.

[ci skip]
