### PR TITLE
WIP: BLD: Add conda recipe to build development versions

### DIFF
--- a/conda_build.recipe/build.sh
+++ b/conda_build.recipe/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+# Set the version info based on python version.
+VERSION="$(python setup.py --version)"
+
+# Add the git hash if it is missing.
+if [[ "${VERSION}" == *+ ]];
+then
+    VERSION="${VERSION}$(git rev-parse --short HEAD)"
+fi
+
+# Set the version of the package.
+echo $VERSION > __conda_version__.txt
+
+# Simply install.
+$PYTHON setup.py install

--- a/conda_build.recipe/meta.yaml
+++ b/conda_build.recipe/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: numpy
+  version: "" # Set at build time.
+
+source:
+  git_url: ..
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - openblas    # [linux]
+    - python
+    - cython
+    - gcc         # [unix]
+
+  run:
+    - openblas    # [linux]
+    - python
+    - libgcc      # [unix]
+
+test:
+  imports:
+    - numpy
+
+about:
+  home: http://www.numpy.org
+  license: BSD
+  summary: "NumPy: array processing for numbers, strings, records, and objects."


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/issues/7024

Adds a conda recipe to build a development version of NumPy.

Still needs a test on Travis CI. Probably should be a new element in the matrix that installs a copy of miniconda and builds against it. This shouldn't be too hard to do, but would like to discuss it first.
