### PR TITLE
Revert "Merge pull request #7001 from shoyer/NaT-comparison"

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -739,8 +739,8 @@ class DatetimeFormat(object):
 class TimedeltaFormat(object):
     def __init__(self, data):
         if data.dtype.kind == 'm':
-            # select non-NaT elements
-            v = data[data == data].view('i8')
+            nat_value = array(['NaT'], dtype=data.dtype)[0]
+            v = data[not_equal(data, nat_value)].view('i8')
             if len(v) > 0:
                 # Max str length of non-NaT elements
                 max_str_len = max(len(str(maximum.reduce(v))),
@@ -754,7 +754,7 @@ class TimedeltaFormat(object):
             self._nat = "'NaT'".rjust(max_str_len)
 
     def __call__(self, x):
-        if x != x:
+        if x + 1 == x:
             return self._nat
         else:
             return self.format % x.astype('i8')

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1673,7 +1673,7 @@ voidtype_setfield(PyVoidScalarObject *self, PyObject *args, PyObject *kwds)
      * However, as a special case, void-scalar assignment broadcasts
      * differently from ndarrays when assigning to an object field: Assignment
      * to an ndarray object field broadcasts, but assignment to a void-scalar
-     * object-field should not, in order to allow nested ndarrays.
+     * object-field should not, in order to allow nested ndarrays. 
      * These lines should then behave identically:
      *
      *     b = np.zeros(1, dtype=[('x', 'O')])

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1117,8 +1117,8 @@ NPY_NO_EXPORT void
 }
 
 /**begin repeat1
- * #kind = equal, greater, greater_equal, less, less_equal#
- * #OP =  ==, >, >=, <, <=#
+ * #kind = equal, not_equal, greater, greater_equal, less, less_equal#
+ * #OP =  ==, !=, >, >=, <, <=#
  */
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
@@ -1126,30 +1126,10 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
-        if (in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) {
-            *((npy_bool *)op1) = NPY_FALSE;
-        }
-        else {
-            *((npy_bool *)op1) = in1 @OP@ in2;
-        }
+        *((npy_bool *)op1) = in1 @OP@ in2;
     }
 }
 /**end repeat1**/
-
-NPY_NO_EXPORT void
-@TYPE@_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ in2 = *(@type@ *)ip2;
-        if (in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) {
-            *((npy_bool *)op1) = NPY_TRUE;
-        }
-        else {
-            *((npy_bool *)op1) = in1 != in2;
-        }
-    }
-}
 
 /**begin repeat1
  * #kind = maximum, minimum#

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -130,11 +130,10 @@ class TestDateTime(TestCase):
         # regression tests for GH6452
         assert_equal(np.datetime64('NaT'),
                      np.datetime64('2000') + np.timedelta64('NaT'))
-        assert_equal(np.datetime64('NaT'), np.datetime64('NaT', 'us'))
-        assert_equal(np.timedelta64('NaT'), np.timedelta64('NaT', 'us'))
-        # neither of these should issue a warning
-        assert_(np.datetime64('NaT') != np.datetime64('NaT', 'us'))
-        assert_(np.datetime64('NaT', 'us') != np.datetime64('NaT'))
+        # nb. we may want to make NaT != NaT true in the future; this test
+        # verifies the existing behavior (and that it should not warn)
+        assert_(np.datetime64('NaT') == np.datetime64('NaT', 'us'))
+        assert_(np.datetime64('NaT', 'us') == np.datetime64('NaT'))
 
     def test_datetime_scalar_construction(self):
         # Construct with different units
@@ -553,9 +552,6 @@ class TestDateTime(TestCase):
                             "'%s'" % np.datetime_as_string(x, timezone='UTC')}),
                      "['2011-03-16T13:55Z', '1920-01-01T03:12Z']")
 
-        a = np.array(['NaT', 'NaT'], dtype='datetime64[ns]')
-        assert_equal(str(a), "['NaT' 'NaT']")
-
         # Check that one NaT doesn't corrupt subsequent entries
         a = np.array(['2010', 'NaT', '2030']).astype('M')
         assert_equal(str(a), "['2010' 'NaT' '2030']")
@@ -662,7 +658,7 @@ class TestDateTime(TestCase):
             b[8] = 'NaT'
 
             assert_equal(b.astype(object).astype(unit), b,
-                         "Error roundtripping unit %s" % unit)
+                            "Error roundtripping unit %s" % unit)
         # With time units
         for unit in ['M8[as]', 'M8[16fs]', 'M8[ps]', 'M8[us]',
                      'M8[300as]', 'M8[20us]']:
@@ -678,7 +674,7 @@ class TestDateTime(TestCase):
             b[8] = 'NaT'
 
             assert_equal(b.astype(object).astype(unit), b,
-                         "Error roundtripping unit %s" % unit)
+                            "Error roundtripping unit %s" % unit)
 
     def test_month_truncation(self):
         # Make sure that months are truncating correctly
@@ -1084,26 +1080,6 @@ class TestDateTime(TestCase):
         assert_equal(np.less_equal(a, b), [1, 0, 1, 0, 1])
         assert_equal(np.greater(a, b), [0, 1, 0, 1, 0])
         assert_equal(np.greater_equal(a, b), [1, 1, 0, 1, 0])
-
-    def test_datetime_compare_nat(self):
-        dt_nat = np.datetime64('NaT', 'D')
-        dt_other = np.datetime64('2000-01-01')
-        td_nat = np.timedelta64('NaT', 'h')
-        td_other = np.timedelta64(1, 'h')
-        for op in [np.equal, np.less, np.less_equal,
-                   np.greater, np.greater_equal]:
-            assert_(not op(dt_nat, dt_nat))
-            assert_(not op(dt_nat, dt_other))
-            assert_(not op(dt_other, dt_nat))
-            assert_(not op(td_nat, td_nat))
-            assert_(not op(td_nat, td_other))
-            assert_(not op(td_other, td_nat))
-        assert_(np.not_equal(dt_nat, dt_nat))
-        assert_(np.not_equal(dt_nat, dt_other))
-        assert_(np.not_equal(dt_other, dt_nat))
-        assert_(np.not_equal(td_nat, td_nat))
-        assert_(np.not_equal(td_nat, td_other))
-        assert_(np.not_equal(td_other, td_nat))
 
     def test_datetime_minmax(self):
         # The metadata of the result should become the GCD

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -154,7 +154,7 @@ class TestAverage(TestCase):
         ott = ott.reshape(2, 2)
         ott[:, 1] = masked
         assert_equal(average(ott, axis=0), [2.0, 0.0])
-        assert_equal(average(ott, axis=1).mask[0], True)
+        assert_equal(average(ott, axis=1).mask[0], [True])
         assert_equal([2., 0.], average(ott, axis=0))
         result, wts = average(ott, axis=0, returned=1)
         assert_equal(wts, [1., 0.])

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -125,7 +125,10 @@ def assert_equal(actual, desired, err_msg=''):
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         return _assert_equal_on_sequences(actual, desired, err_msg='')
     if not (isinstance(actual, ndarray) or isinstance(desired, ndarray)):
-        return utils.assert_equal(actual, desired)
+        msg = build_err_msg([actual, desired], err_msg,)
+        if not desired == actual:
+            raise AssertionError(msg)
+        return
     # Case #4. arrays or equivalent
     if ((actual is masked) and not (desired is masked)) or \
             ((desired is masked) and not (actual is masked)):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -11,7 +11,7 @@ from numpy.testing import (
     assert_warns, assert_no_warnings, assert_allclose, assert_approx_equal,
     assert_array_almost_equal_nulp, assert_array_max_ulp,
     clear_and_catch_warnings, run_module_suite,
-    assert_string_equal, assert_, tempdir, temppath,
+    assert_string_equal, assert_, tempdir, temppath, 
     )
 import unittest
 
@@ -118,25 +118,6 @@ class TestArrayEqual(_GenericTest, unittest.TestCase):
 
         c = np.array([1, 2, 3])
         self._test_not_equal(c, b)
-
-    def test_nat_array_datetime(self):
-        a = np.array([np.datetime64('2000-01'), np.datetime64('NaT')])
-        b = np.array([np.datetime64('2000-01'), np.datetime64('NaT')])
-        self._test_equal(a, b)
-
-        c = np.array([np.datetime64('NaT'), np.datetime64('NaT')])
-        self._test_not_equal(c, b)
-
-    def test_nat_array_timedelta(self):
-        a = np.array([np.timedelta64(1, 'h'), np.timedelta64('NaT')])
-        b = np.array([np.timedelta64(1, 'h'), np.timedelta64('NaT')])
-        self._test_equal(a, b)
-
-        c = np.array([np.timedelta64('NaT'), np.timedelta64('NaT')])
-        self._test_not_equal(c, b)
-
-        d = np.array([np.datetime64('NaT'), np.datetime64('NaT')])
-        self._test_not_equal(c, d)
 
     def test_string_arrays(self):
         """Test two arrays with different shapes are found not equal."""
@@ -245,16 +226,6 @@ class TestEqual(TestArrayEqual):
         y = np.array([complex(1, 2), complex(1, 2)])
         self._assert_func(x, x)
         self._test_not_equal(x, y)
-
-    def test_nat(self):
-        dt = np.datetime64('2000-01-01')
-        dt_nat = np.datetime64('NaT')
-        td_nat = np.timedelta64('NaT')
-        self._assert_func(dt_nat, dt_nat)
-        self._assert_func(td_nat, td_nat)
-        self._test_not_equal(dt_nat, td_nat)
-        self._test_not_equal(dt, td_nat)
-        self._test_not_equal(dt, dt_nat)
 
 
 class TestArrayAlmostEqual(_GenericTest, unittest.TestCase):
@@ -486,7 +457,7 @@ class TestWarns(unittest.TestCase):
 
 
 class TestAssertAllclose(unittest.TestCase):
-
+    
     def test_simple(self):
         x = 1e-3
         y = 1e-9


### PR DESCRIPTION
This reverts commit 7141f40b58ed1e7071cde78ab7bc8ab37e9c5983,
reversing changes made to 8fa6e3bef26a6d4a2c92f2824129aa4409be2590.

The original broke some pandas tests, see #7019. The current plan to get this
in is
- reversion
- issue FutureWarning in 1.11 and 1.12
- make the change in 1.13.
