### PR TITLE
ENH: Allow site.cfg information with libraries key

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -663,7 +663,10 @@ class system_info(object):
         return [b for b in [a.strip() for a in libs.split(',')] if b]
 
     def get_libraries(self, key='libraries'):
-        return self.get_libs(key, '')
+        if hasattr(self, '_lib_names'):
+            return self.get_libs(key, default=self._lib_names)
+        else:
+            return self.get_libs(key, '')
 
     def library_extensions(self):
         static_exts = ['.a']


### PR DESCRIPTION
This PR fixes the case when users create a site.cfg to fix
library locations, but does not change the library names.

Now numpy.distutils correctly checks all options related to
libraries by defaulting to the library from the class via _lib_names
