### PR TITLE
DEP: Emit FutureWarning for NAT comparisons.

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1117,8 +1117,8 @@ NPY_NO_EXPORT void
 }
 
 /**begin repeat1
- * #kind = equal, not_equal, greater, greater_equal, less, less_equal#
- * #OP =  ==, !=, >, >=, <, <=#
+ * #kind = equal, greater, greater_equal, less, less_equal#
+ * #OP =  ==, >, >=, <, <=#
  */
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
@@ -1126,10 +1126,48 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
-        *((npy_bool *)op1) = in1 @OP@ in2;
+        const npy_bool res = in1 @OP@ in2;
+        *((npy_bool *)op1) = res;
+
+        if ((in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) && res) {
+            NPY_ALLOW_C_API_DEF
+            NPY_ALLOW_C_API;
+            /* 2016-01-18, 1.11 */
+            if (DEPRECATE_FUTUREWARNING(
+                    "In the future, 'NAT @OP@ x' and 'x @OP@ NAT' "
+                    "will always be False.") < 0) {
+                NPY_DISABLE_C_API;
+                return;
+            }
+            NPY_DISABLE_C_API;
+        }
     }
 }
 /**end repeat1**/
+
+NPY_NO_EXPORT void
+@TYPE@_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    BINARY_LOOP {
+        const @type@ in1 = *(@type@ *)ip1;
+        const @type@ in2 = *(@type@ *)ip2;
+        *((npy_bool *)op1) = in1 != in2;
+
+        if (in1 == NPY_DATETIME_NAT && in1 == NPY_DATETIME_NAT) {
+            NPY_ALLOW_C_API_DEF
+            NPY_ALLOW_C_API;
+            /* 2016-01-18, 1.11 */
+            if (DEPRECATE_FUTUREWARNING(
+                    "In the future, NAT != NAT will be True "
+                    "rather than False.") < 0) {
+                NPY_DISABLE_C_API;
+                return;
+            }
+            NPY_DISABLE_C_API;
+        }
+    }
+}
+
 
 /**begin repeat1
  * #kind = maximum, minimum#

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1086,6 +1086,34 @@ class TestDateTime(TestCase):
         assert_equal(np.greater(a, b), [0, 1, 0, 1, 0])
         assert_equal(np.greater_equal(a, b), [1, 1, 0, 1, 0])
 
+    def test_datetime_compare_nat(self):
+        dt_nat = np.datetime64('NaT', 'D')
+        dt_other = np.datetime64('2000-01-01')
+        td_nat = np.timedelta64('NaT', 'h')
+        td_other = np.timedelta64(1, 'h')
+
+        for op in [np.equal, np.less, np.less_equal,
+                   np.greater, np.greater_equal]:
+            if op(dt_nat, dt_nat):
+                assert_warns(FutureWarning, op, dt_nat, dt_nat)
+            if op(dt_nat, dt_other):
+                assert_warns(FutureWarning, op, dt_nat, dt_other)
+            if op(dt_other, dt_nat):
+                assert_warns(FutureWarning, op, dt_other, dt_nat)
+            if op(td_nat, td_nat):
+                assert_warns(FutureWarning, op, td_nat, td_nat)
+            if op(td_nat, td_other):
+                assert_warns(FutureWarning, op, td_nat, td_other)
+            if op(td_other, td_nat):
+                assert_warns(FutureWarning, op, td_other, td_nat)
+
+        assert_warns(FutureWarning, np.not_equal, dt_nat, dt_nat)
+        assert_(np.not_equal(dt_nat, dt_other))
+        assert_(np.not_equal(dt_other, dt_nat))
+        assert_warns(FutureWarning, np.not_equal, td_nat, td_nat)
+        assert_(np.not_equal(td_nat, td_other))
+        assert_(np.not_equal(td_other, td_nat))
+
     def test_datetime_minmax(self):
         # The metadata of the result should become the GCD
         # of the operand metadata


### PR DESCRIPTION
In Numpy 1.13 the plan is for NAT comparisons to behave like NaN
comparisons, e.g., False except for 'NAT != NAT', which will be
True. See the discussion at #7019 for details.

Needs tests but thought I would put this up for consideration. The question in my mind is whether to warn whenever a NAT appears, or only for NAT op NAT combinations where the value has changed. Currently it is the latter.
