### PR TITLE
Fixed identity for bitwise_and

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -493,7 +493,7 @@ defdict = {
           TD(flts, f="logaddexp2", astype={'e':'f'})
           ),
 'bitwise_and':
-    Ufunc(2, 1, One,
+    Ufunc(2, 1, ReorderableNone,
           docstrings.get('numpy.core.umath.bitwise_and'),
           None,
           TD(bints),


### PR DESCRIPTION
One makes the reduce() function useless for numbers other than zero or one.
