### PR TITLE
REL: Prepare for 1.11.x branch.

### DIFF
--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -31,4 +31,5 @@
 0x00000009 = 982c4ebb6e7e4c194bf46b1535b4ef1b
 
 # Version 10 (NumPy 1.10) Added PyArray_CheckAnyScalarExact
+# Version 10 (NumPy 1.11) No change.
 0x0000000a = 9b8bce614655d3eb02acddcb508203cb

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -36,6 +36,7 @@ C_ABI_VERSION = 0x01000009
 # 0x00000009 - 1.8.x
 # 0x00000009 - 1.9.x
 # 0x0000000a - 1.10.x
+# 0x0000000a - 1.11.x
 C_API_VERSION = 0x0000000a
 
 class MismatchCAPIWarning(Warning):

--- a/pavement.py
+++ b/pavement.py
@@ -102,7 +102,7 @@ finally:
 RELEASE_NOTES = 'doc/release/1.11.0-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.10.0b1'
+LOG_START = 'v1.10.0'
 LOG_END = 'master'
 
 


### PR DESCRIPTION
- Add comment to cversions.txt (no change)
- Add comment to setup_common.py (no change)
- Nothing done for numpy/core/include/numpy/numpyconfig.h
- Update log start to 1.10.0 in pavement.py.
