### PR TITLE
MAINT: Make no relaxed stride checking the default for 1.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
           packages:
             - debootstrap
     - python: 3.4
-      env: USE_DEBUG=1
+      env: USE_DEBUG=1 NPY_RELAXED_STRIDES_CHECKING=1
       sudo: true
       dist: trusty
       addons:
@@ -60,7 +60,7 @@ matrix:
             - python3-nose
             - python3-setuptools
     - python: 2.7
-      env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
+      env: NPY_RELAXED_STRIDES_CHECKING=1 PYTHON_OO=1
     - python: 2.7
       env: USE_WHEEL=1
     - python: 3.5

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -17,7 +17,7 @@ from setup_common import *
 
 # Set to True to enable relaxed strides checking. This (mostly) means
 # that `strides[dim]` is ignored if `shape[dim] == 1` when setting flags.
-NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0")
+NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0")
 
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force

--- a/tools/test-installed-numpy.py
+++ b/tools/test-installed-numpy.py
@@ -38,7 +38,7 @@ import numpy
 
 # Check that NPY_RELAXED_STRIDES_CHECKING is active when set.
 # The same flags check is also used in the tests to switch behavior.
-if (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0"):
+if (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "0") != "0"):
     if not numpy.ones((10, 1), order='C').flags.f_contiguous:
         print('NPY_RELAXED_STRIDES_CHECKING set, but not active.')
         sys.exit(1)


### PR DESCRIPTION
Because of various back compatibility problems with relaxed stride
checking, make NPY_RELAXED_STRIDE_CHECKING=0 the default for the v1.11.0
release. See pull request #6684 and issue #6678 for discussion.
