### PR TITLE
MAINT: Constrain `pip` and `setuptools` versions (Python 3.2 support) (NumPy 1.11.x Backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_install:
   - virtualenv --python=python venv
   - source venv/bin/activate
   - python -V
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade "pip<8.0.0" "setuptools<19.0"
   - pip install nose
   # pip install coverage
   # Speed up install by not compiling Cython


### PR DESCRIPTION
Appears that `pip` 8.0.0 and `setuptools` 19.0 drop Python 3.2 support, which is causing those builds to fail. This constrains them so that appropriate versions with Python 3.2 support will be installed.
