### PR TITLE
MAINT: Constrain `pip` and `setuptools` versions (Python 3.2 support) (NumPy 1.10.x Backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_install:
   - virtualenv --python=python venv
   - source venv/bin/activate
   - python -V
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade "pip<8.0.0" "setuptools<19.0"
   - pip install nose
   # pip install coverage
   # Speed up install by not compiling Cython


### PR DESCRIPTION
Appears that `pip` 8.0.0 and `setuptools` 19.0 drop Python 3.2 support, which is causing those builds to fail. This constrains them so that appropriate versions with Python 3.2 support will be installed.

Not sure this is necessary as 1.11.x is being prepared and 1.12.x is in development. Just in case it is.
