### PR TITLE
MAINT: Constrain `pip` and `setuptools` versions (Python 3.2 support) (NumPy 1.9.x Backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - python -V
   - pip install --upgrade "pip<8.0.0" "setuptools<19.0"
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel Cython
+  - sudo apt-get update -yq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - pip install nose
   # pip install coverage
   - python -V
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade "pip<8.0.0" "setuptools<19.0"
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel Cython
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
+sudo: true
 language: python
 python:
   - 2.6


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/pull/6350

Appears that `pip` 8.0.0 and `setuptools` 19.0 drop Python 3.2 support, which is causing those builds to fail. This constrains them so that appropriate versions with Python 3.2 support will be installed.

Not sure this is necessary as several releases of 1.10.x are out, 1.11.x is being prepared, and 1.12.x is in development. Just in case it is.
