### PR TITLE
TST, DOC: Added Broadcasting Tests in test_random.py

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2296,9 +2296,9 @@ cdef class RandomState:
         fdfden = PyFloat_AsDouble(dfden)
         if not PyErr_Occurred():
             if fdfnum <= 0:
-                raise ValueError("shape <= 0")
+                raise ValueError("dfnum <= 0")
             if fdfden <= 0:
-                raise ValueError("scale <= 0")
+                raise ValueError("dfden <= 0")
             return cont2_array_sc(self.internal_state, rk_f, size, fdfnum,
                                   fdfden, self.lock)
 
@@ -3426,7 +3426,8 @@ cdef class RandomState:
         Returns
         -------
         samples : ndarray or scalar
-                  where the values are all integers in  [0, n].
+            Samples from logistic distribution, shaped according to
+            `size`. Otherwise, a single value is returned.
 
         See Also
         --------
@@ -4284,7 +4285,7 @@ cdef class RandomState:
         -------
         out : ndarray
             Samples from the geometric distribution, shaped according to
-            `size`.
+            `size`. Otherwise, a single value is returned.
 
         Examples
         --------
@@ -4350,7 +4351,8 @@ cdef class RandomState:
         Returns
         -------
         samples : ndarray or scalar
-            The values are all integers in  [0, n].
+            Samples from the hypergeometric distribution, shaped
+            according to `size`. Otherwise, a single value is returned.
 
         See Also
         --------
@@ -4466,7 +4468,8 @@ cdef class RandomState:
         Returns
         -------
         samples : ndarray or scalar
-                  where the values are all integers in  [0, n].
+            Samples from the logseries distribution, shaped according to
+            `size`. Otherwise, a single value is returned.
 
         See Also
         --------

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1460,21 +1460,22 @@ cdef class RandomState:
 
         Parameters
         ----------
-        low : float, optional
+        low : float or array_like of floats, optional
             Lower boundary of the output interval.  All values generated will be
             greater than or equal to low.  The default value is 0.
-        high : float
+        high : float or array_like of floats
             Upper boundary of the output interval.  All values generated will be
             less than high.  The default value is 1.0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``low`` and ``high`` are both scalars.
+            Otherwise, ``np.broadcast(low, high).size`` samples are drawn.
 
         Returns
         -------
-        out : ndarray
-            Drawn samples, with shape `size`.
+        out : ndarray or scalar
+            Drawn samples from the parameterized uniform distribution.
 
         See Also
         --------
@@ -1791,14 +1792,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        loc : float
+        loc : float or array_like of floats
             Mean ("centre") of the distribution.
-        scale : float
+        scale : float or array_like of floats
             Standard deviation (spread or "width") of the distribution.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``loc`` and ``scale`` are both scalars.
+            Otherwise, ``np.broadcast(loc, scale).size`` samples are drawn.
+
+        Returns
+        -------
+        out : ndarray or scalar
+            Drawn samples from the parameterized normal distribution.
 
         See Also
         --------
@@ -1898,20 +1905,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        a : float
+        a : float or array_like of floats
             Alpha, non-negative.
-        b : float
+        b : float or array_like of floats
             Beta, non-negative.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``a`` and ``b`` are both scalars.
+            Otherwise, ``np.broadcast(a, b).size`` samples are drawn.
 
         Returns
         -------
-        out : ndarray
-            Array of the given shape, containing values drawn from a
-            Beta distribution.
+        out : ndarray or scalar
+            Drawn samples from the parameterized beta distribution.
 
         """
         cdef ndarray oa, ob
@@ -1960,12 +1967,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        scale : float
+        scale : float or array_like of floats
             The scale parameter, :math:`\\beta = 1/\\lambda`.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``scale`` is a scalar.  Otherwise,
+            ``np.array(scale).size`` samples are drawn.
+
+        Returns
+        -------
+        out : ndarray or scalar
+            Drawn samples from the parameterized exponential distribution.
 
         References
         ----------
@@ -2038,17 +2051,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        shape : float
+        shape : float or array_like of floats
             Parameter, should be > 0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``shape`` is a scalar.  Otherwise,
+            ``np.array(shape).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            The drawn samples.
+        out : ndarray or scalar
+            Drawn samples from the parameterized standard gamma distribution.
 
         See Also
         --------
@@ -2125,19 +2139,21 @@ cdef class RandomState:
 
         Parameters
         ----------
-        shape : scalar > 0
-            The shape of the gamma distribution.
-        scale : scalar > 0, optional
-            The scale of the gamma distribution.  Default is equal to 1.
+        shape : float or array_like of floats
+            The shape of the gamma distribution. Should be greater than zero.
+        scale : float or array_like of floats, optional
+            The scale of the gamma distribution. Should be greater than zero.
+            Default is equal to 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``shape`` and ``scale`` are both scalars.
+            Otherwise, ``np.broadcast(shape, scale).size`` samples are drawn.
 
         Returns
         -------
-        out : ndarray, float
-            Returns one sample unless `size` parameter is specified.
+        out : ndarray or scalar
+            Drawn samples from the parameterized gamma distribution.
 
         See Also
         --------
@@ -2225,19 +2241,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        dfnum : float
+        dfnum : int or array_like of ints
             Degrees of freedom in numerator. Should be greater than zero.
-        dfden : float
+        dfden : int or array_like of ints
             Degrees of freedom in denominator. Should be greater than zero.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``dfnum`` and ``dfden`` are both scalars.
+            Otherwise, ``np.broadcast(dfnum, dfden).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            Samples from the Fisher distribution.
+        out : ndarray or scalar
+            Drawn samples from the parameterized Fisher distribution.
 
         See Also
         --------
@@ -2326,21 +2343,23 @@ cdef class RandomState:
 
         Parameters
         ----------
-        dfnum : int
+        dfnum : int or array_like of ints
             Parameter, should be > 1.
-        dfden : int
+        dfden : int or array_like of ints
             Parameter, should be > 1.
-        nonc : float
+        nonc : float or array_like of floats
             Parameter, should be >= 0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``dfnum``, ``dfden``, and ``nonc``
+            are all scalars.  Otherwise, ``np.broadcast(dfnum, dfden, nonc).size``
+            samples are drawn.
 
         Returns
         -------
-        samples : scalar or ndarray
-            Drawn samples.
+        out : ndarray or scalar
+            Drawn samples from the parameterized noncentral Fisher distribution.
 
         Notes
         -----
@@ -2422,18 +2441,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        df : int
+        df : int or array_like of ints
              Number of degrees of freedom.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``df`` is a scalar.  Otherwise,
+            ``np.array(df).size`` samples are drawn.
 
         Returns
         -------
-        output : ndarray
-            Samples drawn from the distribution, packed in a `size`-shaped
-            array.
+        out : ndarray or scalar
+            Drawn samples from the parameterized chi-square distribution.
 
         Raises
         ------
@@ -2501,15 +2520,21 @@ cdef class RandomState:
 
         Parameters
         ----------
-        df : int
+        df : int or array_like of ints
             Degrees of freedom, should be > 0 as of Numpy 1.10,
             should be > 1 for earlier versions.
-        nonc : float
+        nonc : float or array_like of floats
             Non-centrality, should be non-negative.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``df`` and ``nonc`` are both scalars.
+            Otherwise, ``np.broadcast(df, nonc).size`` samples are drawn.
+
+        Returns
+        -------
+        out : ndarray or scalar
+            Drawn samples from the parameterized noncentral chi-square distribution.
 
         Notes
         -----
@@ -2664,17 +2689,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        df : int
+        df : int or array_like of ints
             Degrees of freedom, should be > 0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``df`` is a scalar.  Otherwise,
+            ``np.array(df).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            Drawn samples.
+        out : ndarray or scalar
+            Drawn samples from the parameterized standard Student's t distribution.
 
         Notes
         -----
@@ -2772,19 +2798,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        mu : float
+        mu : float or array_like of floats
             Mode ("center") of the distribution.
-        kappa : float
+        kappa : float or array_like of floats
             Dispersion of the distribution, has to be >=0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``mu`` and ``kappa`` are both scalars.
+            Otherwise, ``np.broadcast(mu, kappa).size`` samples are drawn.
 
         Returns
         -------
-        samples : scalar or ndarray
-            The returned samples, which are in the interval [-pi, pi].
+        out : ndarray or scalar
+            Drawn samples from the parameterized von Mises distribution.
 
         See Also
         --------
@@ -2880,12 +2907,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        shape : float, > 0.
-            Shape of the distribution.
+        a : float or array_like of floats
+            Shape of the distribution. Should be greater than zero.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``a`` is a scalar.  Otherwise,
+            ``np.array(a).size`` samples are drawn.
+
+        Returns
+        -------
+        out : ndarray or scalar
+            Drawn samples from the parameterized Pareto distribution.
 
         See Also
         --------
@@ -2976,16 +3009,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        a : float
-            Shape of the distribution.
+        a : float or array_like of floats
+            Shape of the distribution. Should be greater than zero.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``a`` is a scalar.  Otherwise,
+            ``np.array(a).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray
+        out : ndarray or scalar
+            Drawn samples from the parameterized Weibull distribution.
 
         See Also
         --------
@@ -3078,17 +3113,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        a : float
-            parameter, > 0
+        a : float or array_like of floats
+            Parameter of the distribution. Should be greater than zero.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``a`` is a scalar.  Otherwise,
+            ``np.array(a).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            The returned samples lie in [0, 1].
+        out : ndarray or scalar
+            Drawn samples from the parameterized power distribution.
 
         Raises
         ------
@@ -3192,18 +3228,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        loc : float, optional
-            The position, :math:`\\mu`, of the distribution peak.
-        scale : float, optional
-            :math:`\\lambda`, the exponential decay.
+        loc : float or array_like of floats, optional
+            The position, :math:`\\mu`, of the distribution peak. Default is 0.
+        scale : float or array_like of floats, optional
+            :math:`\\lambda`, the exponential decay. Default is 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``loc`` and ``scale`` are both scalars.
+            Otherwise, ``np.broadcast(loc, scale).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or float
+        out : ndarray or scalar
+            Drawn samples from the parameterized Laplace distribution.
 
         Notes
         -----
@@ -3286,18 +3324,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        loc : float
-            The location of the mode of the distribution.
-        scale : float
-            The scale parameter of the distribution.
+        loc : float or array_like of floats, optional
+            The location of the mode of the distribution. Default is 0.
+        scale : float or array_like of floats, optional
+            The scale parameter of the distribution. Default is 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``loc`` and ``scale`` are both scalars.
+            Otherwise, ``np.broadcast(loc, scale).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
+        out : ndarray or scalar
+            Drawn samples from the parameterized Gumbel distribution.
 
         See Also
         --------
@@ -3414,20 +3454,21 @@ cdef class RandomState:
 
         Parameters
         ----------
-        loc : float
-
-        scale : float > 0.
-
+        loc : float or array_like of floats, optional
+            Parameter of the distribution. Default is 0.
+        scale : float or array_like of floats, optional
+            Parameter of the distribution. Should be greater than zero.
+            Default is 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``loc`` and ``scale`` are both scalars.
+            Otherwise, ``np.broadcast(loc, scale).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            Samples from logistic distribution, shaped according to
-            `size`. Otherwise, a single value is returned.
+        out : ndarray or scalar
+            Drawn samples from the parameterized logistic distribution.
 
         See Also
         --------
@@ -3508,20 +3549,21 @@ cdef class RandomState:
 
         Parameters
         ----------
-        mean : float
-            Mean value of the underlying normal distribution
-        sigma : float, > 0.
-            Standard deviation of the underlying normal distribution
+        mean : float or array_like of floats, optional
+            Mean value of the underlying normal distribution. Default is 0.
+        sigma : float or array_like of floats, optional
+            Standard deviation of the underlying normal distribution. Should
+            be greater than zero. Default is 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``mean`` and ``sigma`` are both scalars.
+            Otherwise, ``np.broadcast(mean, sigma).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or float
-            The desired samples. An array of the same shape as `size` if given,
-            if `size` is None a float is returned.
+        out : ndarray or scalar
+            Drawn samples from the parameterized log-normal distribution.
 
         See Also
         --------
@@ -3631,12 +3673,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        scale : scalar
-            Scale, also equals the mode. Should be >= 0.
+        scale : float or array_like of floats, optional
+            Scale, also equals the mode. Should be >= 0. Default is 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``scale`` is a scalar.  Otherwise,
+            ``np.array(scale).size`` samples are drawn.
+
+        Returns
+        -------
+        out : ndarray or scalar
+            Drawn samples from the parameterized Rayleigh distribution.
 
         Notes
         -----
@@ -3712,19 +3760,20 @@ cdef class RandomState:
 
         Parameters
         ----------
-        mean : scalar
+        mean : float or array_like of floats
             Distribution mean, should be > 0.
-        scale : scalar
+        scale : float or array_like of floats
             Scale parameter, should be >= 0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``mean`` and ``scale`` are both scalars.
+            Otherwise, ``np.broadcast(mean, scale).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            Drawn sample, all greater than zero.
+        out : ndarray or scalar
+            Drawn samples from the parameterized Wald distribution.
 
         Notes
         -----
@@ -3784,7 +3833,8 @@ cdef class RandomState:
         """
         triangular(left, mode, right, size=None)
 
-        Draw samples from the triangular distribution.
+        Draw samples from the triangular distribution over the
+        interval ``[left, right]``.
 
         The triangular distribution is a continuous probability
         distribution with lower limit left, peak at mode, and upper
@@ -3793,22 +3843,24 @@ cdef class RandomState:
 
         Parameters
         ----------
-        left : scalar
+        left : float or array_like of floats
             Lower limit.
-        mode : scalar
+        mode : float or array_like of floats
             The value where the peak of the distribution occurs.
             The value should fulfill the condition ``left <= mode <= right``.
-        right : scalar
+        right : float or array_like of floats
             Upper limit, should be larger than `left`.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``left``, ``mode``, and ``right``
+            are all scalars.  Otherwise, ``np.broadcast(left, mode, right).size``
+            samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            The returned samples all lie in the interval [left, right].
+        out : ndarray or scalar
+            Drawn samples from the parameterized triangular distribution.
 
         Notes
         -----
@@ -3884,19 +3936,22 @@ cdef class RandomState:
 
         Parameters
         ----------
-        n : float (but truncated to an integer)
-                parameter, >= 0.
-        p : float
-                parameter, >= 0 and <=1.
+        n : int or array_like of ints
+            Parameter of the distribution, >= 0. Floats are also accepted,
+            but they will be truncated to integers.
+        p : float or array_like of floats
+            Parameter of the distribution, >= 0 and <=1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``n`` and ``p`` are both scalars.
+            Otherwise, ``np.broadcast(n, p).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-                  where the values are all integers in  [0, n].
+        out : ndarray or scalar
+            Drawn samples from the parameterized binomial distribution, where
+            each sample is equal to the number of successes over the n trials.
 
         See Also
         --------
@@ -3996,19 +4051,24 @@ cdef class RandomState:
 
         Parameters
         ----------
-        n : int
-            Parameter, > 0.
-        p : float
-            Parameter, >= 0 and <=1.
+        n : int or array_like of ints
+            Parameter of the distribution, > 0. Floats are also accepted,
+            but they will be truncated to integers.
+        p : float or array_like of floats
+            Parameter of the distribution, >= 0 and <=1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``n`` and ``p`` are both scalars.
+            Otherwise, ``np.broadcast(n, p).size`` samples are drawn.
 
         Returns
         -------
-        samples : int or ndarray of ints
-            Drawn samples.
+        out : ndarray or scalar
+            Drawn samples from the parameterized negative binomial distribution,
+            where each sample is equal to N, the number of trials it took to
+            achieve n - 1 successes, N - (n - 1) failures, and a success on the,
+            (N + n)th trial.
 
         Notes
         -----
@@ -4091,18 +4151,19 @@ cdef class RandomState:
 
         Parameters
         ----------
-        lam : float or sequence of float
+        lam : float or array_like of floats
             Expectation of interval, should be >= 0. A sequence of expectation
             intervals must be broadcastable over the requested size.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``lam`` is a scalar. Otherwise,
+            ``np.array(lam).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            The drawn samples, of shape *size*, if it was provided.
+        out : ndarray or scalar
+            Drawn samples from the parameterized Poisson distribution.
 
         Notes
         -----
@@ -4182,17 +4243,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        a : float > 1
-            Distribution parameter.
+        a : float or array_like of floats
+            Distribution parameter. Should be greater than 1.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``a`` is a scalar. Otherwise,
+            ``np.array(a).size`` samples are drawn.
 
         Returns
         -------
-        samples : scalar or ndarray
-            The returned samples are greater than or equal to one.
+        out : ndarray or scalar
+            Drawn samples from the parameterized Zipf distribution.
 
         See Also
         --------
@@ -4274,18 +4336,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        p : float
+        p : float or array_like of floats
             The probability of success of an individual trial.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``p`` is a scalar.  Otherwise,
+            ``np.array(p).size`` samples are drawn.
 
         Returns
         -------
-        out : ndarray
-            Samples from the geometric distribution, shaped according to
-            `size`. Otherwise, a single value is returned.
+        out : ndarray or scalar
+            Drawn samples from the parameterized geometric distribution.
 
         Examples
         --------
@@ -4336,23 +4398,24 @@ cdef class RandomState:
 
         Parameters
         ----------
-        ngood : int or array_like
+        ngood : int or array_like of ints
             Number of ways to make a good selection.  Must be nonnegative.
-        nbad : int or array_like
+        nbad : int or array_like of ints
             Number of ways to make a bad selection.  Must be nonnegative.
-        nsample : int or array_like
+        nsample : int or array_like of ints
             Number of items sampled.  Must be at least 1 and at most
             ``ngood + nbad``.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``ngood``, ``nbad``, and ``nsample``
+            are all scalars.  Otherwise, ``np.broadcast(ngood, nbad, nsample).size``
+            samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            Samples from the hypergeometric distribution, shaped
-            according to `size`. Otherwise, a single value is returned.
+        out : ndarray or scalar
+            Drawn samples from the parameterized hypergeometric distribution.
 
         See Also
         --------
@@ -4456,20 +4519,18 @@ cdef class RandomState:
 
         Parameters
         ----------
-        loc : float
-
-        scale : float > 0.
-
+        p : float or array_like of floats
+            Shape parameter for the distribution.  Must be in the range (0, 1).
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-            ``m * n * k`` samples are drawn.  Default is None, in which case a
-            single value is returned.
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``p`` is a scalar.  Otherwise,
+            ``np.array(p).size`` samples are drawn.
 
         Returns
         -------
-        samples : ndarray or scalar
-            Samples from the logseries distribution, shaped according to
-            `size`. Otherwise, a single value is returned.
+        out : ndarray or scalar
+            Drawn samples from the parameterized logarithmic series distribution.
 
         See Also
         --------

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -3,12 +3,11 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.testing import (
         TestCase, run_module_suite, assert_, assert_raises, assert_equal,
-        assert_warns)
+        assert_warns, assert_array_equal, assert_array_almost_equal)
 from numpy import random
 from numpy.compat import asbytes
 import sys
 import warnings
-
 
 
 class TestSeed(TestCase):
@@ -50,7 +49,7 @@ class TestBinomial(TestCase):
         zeros = np.zeros(2, dtype='int')
         for p in [0, .5, 1]:
             assert_(random.binomial(0, p) == 0)
-            np.testing.assert_array_equal(random.binomial(zeros, p), zeros)
+            assert_array_equal(random.binomial(zeros, p), zeros)
 
     def test_p_is_nan(self):
         # Issue #4571.
@@ -148,10 +147,10 @@ class TestRandint(TestCase):
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
-            assert_raises(ValueError, self.rfunc, lbnd - 1 , ubnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, lbnd , ubnd + 1, dtype=dt)
-            assert_raises(ValueError, self.rfunc, ubnd , lbnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, 1 , 0, dtype=dt)
+            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
+            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
+            assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
+            assert_raises(ValueError, self.rfunc, 1, 0, dtype=dt)
 
     def test_rng_zero_and_extremes(self):
         for dt in self.itype:
@@ -223,7 +222,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.61879477158567997, 0.59162362775974664],
                             [0.88868358904449662, 0.89165480011560816],
                             [0.4575674820298663, 0.7781880808593471]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_randn(self):
         np.random.seed(self.seed)
@@ -231,7 +230,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[1.34016345771863121, 1.73759122771936081],
                            [1.498988344300628, -0.2286433324536169],
                            [2.031033998682787, 2.17032494605655257]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_randint(self):
         np.random.seed(self.seed)
@@ -239,7 +238,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_random_integers(self):
         np.random.seed(self.seed)
@@ -247,7 +246,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_random_integers_max_int(self):
         # Tests whether random_integers can generate the
@@ -258,7 +257,7 @@ class TestRandomDist(TestCase):
         actual = np.random.random_integers(np.iinfo('l').max,
                                            np.iinfo('l').max)
         desired = np.iinfo('l').max
-        np.testing.assert_equal(actual, desired)
+        assert_equal(actual, desired)
 
     def test_random_integers_deprecated(self):
         with warnings.catch_warnings():
@@ -280,38 +279,38 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.61879477158567997, 0.59162362775974664],
                             [0.88868358904449662, 0.89165480011560816],
                             [0.4575674820298663, 0.7781880808593471]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_choice_uniform_replace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 4)
         desired = np.array([2, 3, 2, 3])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_replace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
         desired = np.array([1, 1, 2, 2])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_choice_uniform_noreplace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 3, replace=False)
         desired = np.array([0, 1, 3])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):
         np.random.seed(self.seed)
         actual = np.random.choice(4, 3, replace=False,
                                   p=[0.1, 0.3, 0.5, 0.1])
         desired = np.array([2, 3, 1])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_choice_noninteger(self):
         np.random.seed(self.seed)
         actual = np.random.choice(['a', 'b', 'c', 'd'], 4)
         desired = np.array(['c', 'd', 'c', 'd'])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_choice_exceptions(self):
         sample = np.random.choice
@@ -320,13 +319,13 @@ class TestRandomDist(TestCase):
         assert_raises(ValueError, sample, [[1, 2], [3, 4]], 3)
         assert_raises(ValueError, sample, [], 3)
         assert_raises(ValueError, sample, [1, 2, 3, 4], 3,
-                                          p=[[0.25, 0.25], [0.25, 0.25]])
+                      p=[[0.25, 0.25], [0.25, 0.25]])
         assert_raises(ValueError, sample, [1, 2], 3, p=[0.4, 0.4, 0.2])
         assert_raises(ValueError, sample, [1, 2], 3, p=[1.1, -0.1])
         assert_raises(ValueError, sample, [1, 2], 3, p=[0.4, 0.4])
         assert_raises(ValueError, sample, [1, 2, 3], 4, replace=False)
-        assert_raises(ValueError, sample, [1, 2, 3], 2, replace=False,
-                                          p=[1, 0, 0])
+        assert_raises(ValueError, sample, [1, 2, 3], 2,
+                      replace=False, p=[1, 0, 0])
 
     def test_choice_return_shape(self):
         p = [0.1, 0.9]
@@ -368,7 +367,7 @@ class TestRandomDist(TestCase):
         np.random.seed(self.seed)
         actual = np.random.bytes(10)
         desired = asbytes('\x82Ui\x9e\xff\x97+Wf\xa5')
-        np.testing.assert_equal(actual, desired)
+        assert_equal(actual, desired)
 
     def test_shuffle(self):
         # Test lists, arrays (of various dtypes), and multidimensional versions
@@ -391,11 +390,11 @@ class TestRandomDist(TestCase):
             np.random.shuffle(alist)
             actual = alist
             desired = conv([0, 1, 9, 6, 2, 4, 5, 8, 7, 3])
-            np.testing.assert_array_equal(actual, desired)
+            assert_array_equal(actual, desired)
 
     def test_shuffle_masked(self):
         # gh-3263
-        a = np.ma.masked_values(np.reshape(range(20), (5,4)) % 3 - 1, -1)
+        a = np.ma.masked_values(np.reshape(range(20), (5, 4)) % 3 - 1, -1)
         b = np.ma.masked_values(np.arange(20) % 3 - 1, -1)
         a_orig = a.copy()
         b_orig = b.copy()
@@ -414,15 +413,15 @@ class TestRandomDist(TestCase):
                 [[1.45341850513746058e-02, 5.31297615662868145e-04],
                  [1.85366619058432324e-06, 4.19214516800110563e-03],
                  [1.58405155108498093e-04, 1.26252891949397652e-04]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_binomial(self):
         np.random.seed(self.seed)
         actual = np.random.binomial(100.123, .456, size=(3, 2))
         desired = np.array([[37, 43],
-                         [42, 48],
-                         [46, 45]])
-        np.testing.assert_array_equal(actual, desired)
+                            [42, 48],
+                            [46, 45]])
+        assert_array_equal(actual, desired)
 
     def test_chisquare(self):
         np.random.seed(self.seed)
@@ -430,7 +429,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[63.87858175501090585, 68.68407748911370447],
                             [65.77116116901505904, 47.09686762438974483],
                             [72.3828403199695174, 74.18408615260374006]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=13)
+        assert_array_almost_equal(actual, desired, decimal=13)
 
     def test_dirichlet(self):
         np.random.seed(self.seed)
@@ -442,7 +441,7 @@ class TestRandomDist(TestCase):
                              [0.58964023305154301, 0.41035976694845688]],
                             [[0.59266909280647828, 0.40733090719352177],
                              [0.56974431743975207, 0.43025568256024799]]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_dirichlet_size(self):
         # gh-3173
@@ -462,7 +461,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[1.08342649775011624, 1.00607889924557314],
                             [2.46628830085216721, 2.49668106809923884],
                             [0.68717433461363442, 1.69175666993575979]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_f(self):
         np.random.seed(self.seed)
@@ -470,7 +469,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[1.21975394418575878, 1.75135759791559775],
                             [1.44803115017146489, 1.22108959480396262],
                             [1.02176975757740629, 1.34431827623300415]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_gamma(self):
         np.random.seed(self.seed)
@@ -478,7 +477,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[24.60509188649287182, 28.54993563207210627],
                             [26.13476110204064184, 12.56988482927716078],
                             [31.71863275789960568, 33.30143302795922011]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_geometric(self):
         np.random.seed(self.seed)
@@ -486,7 +485,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[8, 7],
                             [17, 17],
                             [5, 12]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_gumbel(self):
         np.random.seed(self.seed)
@@ -494,7 +493,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.19591898743416816, 0.34405539668096674],
                             [-1.4492522252274278, -1.47374816298446865],
                             [1.10651090478803416, -0.69535848626236174]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_hypergeometric(self):
         np.random.seed(self.seed)
@@ -502,25 +501,25 @@ class TestRandomDist(TestCase):
         desired = np.array([[10, 10],
                             [10, 10],
                             [9, 9]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
         # Test nbad = 0
         actual = np.random.hypergeometric(5, 0, 3, size=4)
         desired = np.array([3, 3, 3, 3])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
         actual = np.random.hypergeometric(15, 0, 12, size=4)
         desired = np.array([12, 12, 12, 12])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
         # Test ngood = 0
         actual = np.random.hypergeometric(0, 5, 3, size=4)
         desired = np.array([0, 0, 0, 0])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
         actual = np.random.hypergeometric(0, 15, 12, size=4)
         desired = np.array([0, 0, 0, 0])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_laplace(self):
         np.random.seed(self.seed)
@@ -528,7 +527,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.66599721112760157, 0.52829452552221945],
                             [3.12791959514407125, 3.18202813572992005],
                             [-0.05391065675859356, 1.74901336242837324]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_logistic(self):
         np.random.seed(self.seed)
@@ -536,7 +535,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[1.09232835305011444, 0.8648196662399954],
                             [4.27818590694950185, 4.33897006346929714],
                             [-0.21682183359214885, 2.63373365386060332]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_lognormal(self):
         np.random.seed(self.seed)
@@ -544,7 +543,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[16.50698631688883822, 36.54846706092654784],
                             [22.67886599981281748, 0.71617561058995771],
                             [65.72798501792723869, 86.84341601437161273]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=13)
+        assert_array_almost_equal(actual, desired, decimal=13)
 
     def test_logseries(self):
         np.random.seed(self.seed)
@@ -552,7 +551,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[2, 2],
                             [6, 17],
                             [3, 6]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_multinomial(self):
         np.random.seed(self.seed)
@@ -563,7 +562,7 @@ class TestRandomDist(TestCase):
                              [2, 1, 4, 3, 6, 4]],
                             [[4, 4, 2, 5, 2, 3],
                              [4, 3, 4, 2, 3, 4]]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_multivariate_normal(self):
         np.random.seed(self.seed)
@@ -578,12 +577,12 @@ class TestRandomDist(TestCase):
                              [-1.77505606019580053, 10.]],
                             [[-0.54970369430044119, 10.],
                              [0.29768848031692957, 10.]]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
         # Check for default size, was raising deprecation warning
         actual = np.random.multivariate_normal(mean, cov)
         desired = np.array([-0.79441224511977482, 10.])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
         # Check that non positive-semidefinite covariance raises warning
         mean = [0, 0]
@@ -596,7 +595,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[848, 841],
                             [892, 611],
                             [779, 647]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
     def test_noncentral_chisquare(self):
         np.random.seed(self.seed)
@@ -604,20 +603,20 @@ class TestRandomDist(TestCase):
         desired = np.array([[23.91905354498517511, 13.35324692733826346],
                             [31.22452661329736401, 16.60047399466177254],
                             [5.03461598262724586, 17.94973089023519464]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
         actual = np.random.noncentral_chisquare(df=.5, nonc=.2, size=(3, 2))
-        desired = np.array([[ 1.47145377828516666,  0.15052899268012659],
-                            [ 0.00943803056963588,  1.02647251615666169],
-                            [ 0.332334982684171  ,  0.15451287602753125]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        desired = np.array([[1.47145377828516666,  0.15052899268012659],
+                            [0.00943803056963588,  1.02647251615666169],
+                            [0.332334982684171,  0.15451287602753125]])
+        assert_array_almost_equal(actual, desired, decimal=14)
 
         np.random.seed(self.seed)
         actual = np.random.noncentral_chisquare(df=5, nonc=0, size=(3, 2))
         desired = np.array([[9.597154162763948, 11.725484450296079],
                             [10.413711048138335, 3.694475922923986],
                             [13.484222138963087, 14.377255424602957]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_noncentral_f(self):
         np.random.seed(self.seed)
@@ -626,7 +625,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[1.40598099674926669, 0.34207973179285761],
                             [3.57715069265772545, 7.92632662577829805],
                             [0.43741599463544162, 1.1774208752428319]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_normal(self):
         np.random.seed(self.seed)
@@ -634,7 +633,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[2.80378370443726244, 3.59863924443872163],
                             [3.121433477601256, -0.33382987590723379],
                             [4.18552478636557357, 4.46410668111310471]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_pareto(self):
         np.random.seed(self.seed)
@@ -655,9 +654,9 @@ class TestRandomDist(TestCase):
         np.random.seed(self.seed)
         actual = np.random.poisson(lam=.123456789, size=(3, 2))
         desired = np.array([[0, 0],
-                         [1, 0],
-                         [0, 0]])
-        np.testing.assert_array_equal(actual, desired)
+                            [1, 0],
+                            [0, 0]])
+        assert_array_equal(actual, desired)
 
     def test_poisson_exceptions(self):
         lambig = np.iinfo('l').max
@@ -673,7 +672,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.02048932883240791, 0.01424192241128213],
                             [0.38446073748535298, 0.39499689943484395],
                             [0.00177699707563439, 0.13115505880863756]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_rayleigh(self):
         np.random.seed(self.seed)
@@ -681,7 +680,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[13.8882496494248393, 13.383318339044731],
                             [20.95413364294492098, 21.08285015800712614],
                             [11.06066537006854311, 17.35468505778271009]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_standard_cauchy(self):
         np.random.seed(self.seed)
@@ -689,7 +688,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.77127660196445336, -6.55601161955910605],
                             [0.93582023391158309, -2.07479293013759447],
                             [-4.74601644297011926, 0.18338989290760804]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_exponential(self):
         np.random.seed(self.seed)
@@ -697,7 +696,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.96441739162374596, 0.89556604882105506],
                             [2.1953785836319808, 2.22243285392490542],
                             [0.6116915921431676, 1.50592546727413201]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_gamma(self):
         np.random.seed(self.seed)
@@ -705,7 +704,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[5.50841531318455058, 6.62953470301903103],
                             [5.93988484943779227, 2.31044849402133989],
                             [7.54838614231317084, 8.012756093271868]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_standard_normal(self):
         np.random.seed(self.seed)
@@ -713,7 +712,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[1.34016345771863121, 1.73759122771936081],
                             [1.498988344300628, -0.2286433324536169],
                             [2.031033998682787, 2.17032494605655257]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_t(self):
         np.random.seed(self.seed)
@@ -721,7 +720,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.97140611862659965, -0.08830486548450577],
                             [1.36311143689505321, -0.55317463909867071],
                             [-0.18473749069684214, 0.61181537341755321]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_triangular(self):
         np.random.seed(self.seed)
@@ -730,7 +729,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[12.68117178949215784, 12.4129206149193152],
                             [16.20131377335158263, 16.25692138747600524],
                             [11.20400690911820263, 14.4978144835829923]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_uniform(self):
         np.random.seed(self.seed)
@@ -738,16 +737,16 @@ class TestRandomDist(TestCase):
         desired = np.array([[6.99097932346268003, 6.73801597444323974],
                             [9.50364421400426274, 9.53130618907631089],
                             [5.48995325769805476, 8.47493103280052118]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_uniform_range_bounds(self):
         fmin = np.finfo('float').min
         fmax = np.finfo('float').max
 
         func = np.random.uniform
-        np.testing.assert_raises(OverflowError, func, -np.inf, 0)
-        np.testing.assert_raises(OverflowError, func,  0,      np.inf)
-        np.testing.assert_raises(OverflowError, func,  fmin,   fmax)
+        assert_raises(OverflowError, func, -np.inf, 0)
+        assert_raises(OverflowError, func,  0,      np.inf)
+        assert_raises(OverflowError, func,  fmin,   fmax)
 
         # (fmax / 1e17) - fmin is within range, so this should not throw
         np.random.uniform(low=fmin, high=fmax / 1e17)
@@ -758,7 +757,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[2.28567572673902042, 2.89163838442285037],
                             [0.38198375564286025, 2.57638023113890746],
                             [1.19153771588353052, 1.83509849681825354]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_vonmises_small(self):
         # check infinite loop, gh-4720
@@ -772,7 +771,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[3.82935265715889983, 5.13125249184285526],
                             [0.35045403618358717, 1.50832396872003538],
                             [0.24124319895843183, 0.22031101461955038]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=14)
+        assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_weibull(self):
         np.random.seed(self.seed)
@@ -780,7 +779,7 @@ class TestRandomDist(TestCase):
         desired = np.array([[0.97097342648766727, 0.91422896443565516],
                             [1.89517770034962929, 1.91414357960479564],
                             [0.67057783752390987, 1.39494046635066793]])
-        np.testing.assert_array_almost_equal(actual, desired, decimal=15)
+        assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_zipf(self):
         np.random.seed(self.seed)
@@ -788,10 +787,566 @@ class TestRandomDist(TestCase):
         desired = np.array([[66, 29],
                             [1, 1],
                             [3, 13]])
-        np.testing.assert_array_equal(actual, desired)
+        assert_array_equal(actual, desired)
 
 
-class TestThread(object):
+class TestBroadcast(TestCase):
+    # tests that functions that broadcast behave
+    # correctly when presented with non-scalar arguments
+    def setUp(self):
+        self.seed = 123456789
+
+    def setSeed(self):
+        np.random.seed(self.seed)
+
+    # TODO: Include test for randint once it can broadcast
+    # Can steal the test written in PR #6938
+
+    def test_uniform(self):
+        low = [0]
+        high = [1]
+        uniform = np.random.uniform
+        desired = np.array([0.53283302478975902,
+                            0.53413660089041659,
+                            0.50955303552646702])
+
+        self.setSeed()
+        actual = uniform(low * 3, high)
+        assert_array_almost_equal(actual, desired, decimal=14)
+
+        self.setSeed()
+        actual = uniform(low, high * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+
+    def test_normal(self):
+        loc = [0]
+        scale = [1]
+        bad_scale = [-1]
+        normal = np.random.normal
+        desired = np.array([2.2129019979039612,
+                            2.1283977976520019,
+                            1.8417114045748335])
+
+        self.setSeed()
+        actual = normal(loc * 3, scale)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, normal, loc * 3, bad_scale)
+
+        self.setSeed()
+        actual = normal(loc, scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, normal, loc, bad_scale * 3)
+
+    def test_beta(self):
+        a = [1]
+        b = [2]
+        bad_a = [-1]
+        bad_b = [-2]
+        beta = np.random.beta
+        desired = np.array([0.19843558305989056,
+                            0.075230336409423643,
+                            0.24976865978980844])
+
+        self.setSeed()
+        actual = beta(a * 3, b)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, beta, bad_a * 3, b)
+        assert_raises(ValueError, beta, a * 3, bad_b)
+
+        self.setSeed()
+        actual = beta(a, b * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, beta, bad_a, b * 3)
+        assert_raises(ValueError, beta, a, bad_b * 3)
+
+    def test_exponential(self):
+        scale = [1]
+        bad_scale = [-1]
+        exponential = np.random.exponential
+        desired = np.array([0.76106853658845242,
+                            0.76386282278691653,
+                            0.71243813125891797])
+
+        self.setSeed()
+        actual = exponential(scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, exponential, bad_scale * 3)
+
+    def test_standard_gamma(self):
+        shape = [1]
+        bad_shape = [-1]
+        std_gamma = np.random.standard_gamma
+        desired = np.array([0.76106853658845242,
+                            0.76386282278691653,
+                            0.71243813125891797])
+
+        self.setSeed()
+        actual = std_gamma(shape * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, std_gamma, bad_shape * 3)
+
+    def test_gamma(self):
+        shape = [1]
+        scale = [2]
+        bad_shape = [-1]
+        bad_scale = [-2]
+        gamma = np.random.gamma
+        desired = np.array([1.5221370731769048,
+                            1.5277256455738331,
+                            1.4248762625178359])
+
+        self.setSeed()
+        actual = gamma(shape * 3, scale)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, gamma, bad_shape * 3, scale)
+        assert_raises(ValueError, gamma, shape * 3, bad_scale)
+
+        self.setSeed()
+        actual = gamma(shape, scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, gamma, bad_shape, scale * 3)
+        assert_raises(ValueError, gamma, shape, bad_scale * 3)
+
+    def test_f(self):
+        dfnum = [1]
+        dfden = [2]
+        bad_dfnum = [-1]
+        bad_dfden = [-2]
+        f = np.random.f
+        desired = np.array([0.80038951638264799,
+                            0.86768719635363512,
+                            2.7251095168386801])
+
+        self.setSeed()
+        actual = f(dfnum * 3, dfden)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, f, bad_dfnum * 3, dfden)
+        assert_raises(ValueError, f, dfnum * 3, bad_dfden)
+
+        self.setSeed()
+        actual = f(dfnum, dfden * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, f, bad_dfnum, dfden * 3)
+        assert_raises(ValueError, f, dfnum, bad_dfden * 3)
+
+    def test_noncentral_f(self):
+        dfnum = [2]
+        dfden = [3]
+        nonc = [4]
+        bad_dfnum = [0]
+        bad_dfden = [-1]
+        bad_nonc = [-2]
+        nonc_f = np.random.noncentral_f
+        desired = np.array([9.1393943263705211,
+                            13.025456344595602,
+                            8.8018098359100545])
+
+        self.setSeed()
+        actual = nonc_f(dfnum * 3, dfden, nonc)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, nonc_f, bad_dfnum * 3, dfden, nonc)
+        assert_raises(ValueError, nonc_f, dfnum * 3, bad_dfden, nonc)
+        assert_raises(ValueError, nonc_f, dfnum * 3, dfden, bad_nonc)
+
+        self.setSeed()
+        actual = nonc_f(dfnum, dfden * 3, nonc)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, nonc_f, bad_dfnum, dfden * 3, nonc)
+        assert_raises(ValueError, nonc_f, dfnum, bad_dfden * 3, nonc)
+        assert_raises(ValueError, nonc_f, dfnum, dfden * 3, bad_nonc)
+
+        self.setSeed()
+        actual = nonc_f(dfnum, dfden, nonc * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, nonc_f, bad_dfnum, dfden, nonc * 3)
+        assert_raises(ValueError, nonc_f, dfnum, bad_dfden, nonc * 3)
+        assert_raises(ValueError, nonc_f, dfnum, dfden, bad_nonc * 3)
+
+    def test_chisquare(self):
+        df = [1]
+        bad_df = [-1]
+        chisquare = np.random.chisquare
+        desired = np.array([0.57022801133088286,
+                            0.51947702108840776,
+                            0.1320969254923558])
+
+        self.setSeed()
+        actual = chisquare(df * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, chisquare, bad_df * 3)
+
+    def test_noncentral_chisquare(self):
+        df = [1]
+        nonc = [2]
+        bad_df = [-1]
+        bad_nonc = [-2]
+        nonc_chi = np.random.noncentral_chisquare
+        desired = np.array([9.0015599467913763,
+                            4.5804135049718742,
+                            6.0872302432834564])
+
+        self.setSeed()
+        actual = nonc_chi(df * 3, nonc)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, nonc_chi, bad_df * 3, nonc)
+        assert_raises(ValueError, nonc_chi, df * 3, bad_nonc)
+
+        self.setSeed()
+        actual = nonc_chi(df, nonc * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, nonc_chi, bad_df, nonc * 3)
+        assert_raises(ValueError, nonc_chi, df, bad_nonc * 3)
+
+    def test_standard_t(self):
+        df = [1]
+        bad_df = [-1]
+        t = np.random.standard_t
+        desired = np.array([3.0702872575217643,
+                            5.8560725167361607,
+                            1.0274791436474273])
+
+        self.setSeed()
+        actual = t(df * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, t, bad_df * 3)
+
+    def test_vonmises(self):
+        mu = [2]
+        kappa = [1]
+        bad_kappa = [-1]
+        vonmises = np.random.vonmises
+        desired = np.array([2.9883443664201312,
+                            -2.7064099483995943,
+                            -1.8672476700665914])
+
+        self.setSeed()
+        actual = vonmises(mu * 3, kappa)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, vonmises, mu * 3, bad_kappa)
+
+        self.setSeed()
+        actual = vonmises(mu, kappa * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, vonmises, mu, bad_kappa * 3)
+
+    def test_pareto(self):
+        a = [1]
+        bad_a = [-1]
+        pareto = np.random.pareto
+        desired = np.array([1.1405622680198362,
+                            1.1465519762044529,
+                            1.0389564467453547])
+
+        self.setSeed()
+        actual = pareto(a * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, pareto, bad_a * 3)
+
+    def test_weibull(self):
+        a = [1]
+        bad_a = [-1]
+        weibull = np.random.weibull
+        desired = np.array([0.76106853658845242,
+                            0.76386282278691653,
+                            0.71243813125891797])
+
+        self.setSeed()
+        actual = weibull(a * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, weibull, bad_a * 3)
+
+    def test_power(self):
+        a = [1]
+        bad_a = [-1]
+        power = np.random.power
+        desired = np.array([0.53283302478975902,
+                            0.53413660089041659,
+                            0.50955303552646702])
+
+        self.setSeed()
+        actual = power(a * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, power, bad_a * 3)
+
+    def test_laplace(self):
+        loc = [0]
+        scale = [1]
+        bad_scale = [-1]
+        laplace = np.random.laplace
+        desired = np.array([0.067921356028507157,
+                            0.070715642226971326,
+                            0.019290950698972624])
+
+        self.setSeed()
+        actual = laplace(loc * 3, scale)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, laplace, loc * 3, bad_scale)
+
+        self.setSeed()
+        actual = laplace(loc, scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, laplace, loc, bad_scale * 3)
+
+    def test_gumbel(self):
+        loc = [0]
+        scale = [1]
+        bad_scale = [-1]
+        gumbel = np.random.gumbel
+        desired = np.array([0.2730318639556768,
+                            0.26936705726291116,
+                            0.33906220393037939])
+
+        self.setSeed()
+        actual = gumbel(loc * 3, scale)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, gumbel, loc * 3, bad_scale)
+
+        self.setSeed()
+        actual = gumbel(loc, scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, gumbel, loc, bad_scale * 3)
+
+    def test_logistic(self):
+        loc = [0]
+        scale = [1]
+        bad_scale = [-1]
+        logistic = np.random.logistic
+        desired = np.array([0.13152135837586171,
+                            0.13675915696285773,
+                            0.038216792802833396])
+
+        self.setSeed()
+        actual = logistic(loc * 3, scale)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, logistic, loc * 3, bad_scale)
+
+        self.setSeed()
+        actual = logistic(loc, scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, logistic, loc, bad_scale * 3)
+
+    def test_lognormal(self):
+        mean = [0]
+        sigma = [1]
+        bad_sigma = [-1]
+        lognormal = np.random.lognormal
+        desired = np.array([9.1422086044848427,
+                            8.4013952870126261,
+                            6.3073234116578671])
+
+        self.setSeed()
+        actual = lognormal(mean * 3, sigma)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, lognormal, mean * 3, bad_sigma)
+
+        self.setSeed()
+        actual = lognormal(mean, sigma * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, lognormal, mean, bad_sigma * 3)
+
+    def test_rayleigh(self):
+        scale = [1]
+        bad_scale = [-1]
+        rayleigh = np.random.rayleigh
+        desired = np.array([1.2337491937897689,
+                            1.2360119924878694,
+                            1.1936818095781789])
+
+        self.setSeed()
+        actual = rayleigh(scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, rayleigh, bad_scale * 3)
+
+    def test_wald(self):
+        mean = [0.5]
+        scale = [1]
+        bad_mean = [0]
+        bad_scale = [-2]
+        wald = np.random.wald
+        desired = np.array([0.11873681120271318,
+                            0.12450084820795027,
+                            0.9096122728408238])
+
+        self.setSeed()
+        actual = wald(mean * 3, scale)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, wald, bad_mean * 3, scale)
+        assert_raises(ValueError, wald, mean * 3, bad_scale)
+
+        self.setSeed()
+        actual = wald(mean, scale * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, wald, bad_mean, scale * 3)
+        assert_raises(ValueError, wald, mean, bad_scale * 3)
+
+    def test_triangular(self):
+        left = [1]
+        right = [3]
+        mode = [2]
+        bad_left_one = [3]
+        bad_mode_one = [4]
+        bad_left_two, bad_mode_two = right * 2
+        triangular = np.random.triangular
+        desired = np.array([2.03339048710429,
+                            2.0347400359389356,
+                            2.0095991069536208])
+
+        self.setSeed()
+        actual = triangular(left * 3, mode, right)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, triangular, bad_left_one * 3, mode, right)
+        assert_raises(ValueError, triangular, left * 3, bad_mode_one, right)
+        assert_raises(ValueError, triangular, bad_left_two * 3, bad_mode_two, right)
+
+        self.setSeed()
+        actual = triangular(left, mode * 3, right)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, triangular, bad_left_one, mode * 3, right)
+        assert_raises(ValueError, triangular, left, bad_mode_one * 3, right)
+        assert_raises(ValueError, triangular, bad_left_two, bad_mode_two * 3, right)
+
+        self.setSeed()
+        actual = triangular(left, mode, right * 3)
+        assert_array_almost_equal(actual, desired, decimal=14)
+        assert_raises(ValueError, triangular, bad_left_one, mode, right * 3)
+        assert_raises(ValueError, triangular, left, bad_mode_one, right * 3)
+        assert_raises(ValueError, triangular, bad_left_two, bad_mode_two, right * 3)
+
+    def test_binomial(self):
+        n = [1]
+        p = [0.5]
+        bad_n = [-1]
+        bad_p_one = [-1]
+        bad_p_two = [1.5]
+        binom = np.random.binomial
+        desired = np.array([1, 1, 1])
+
+        self.setSeed()
+        actual = binom(n * 3, p)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, binom, bad_n * 3, p)
+        assert_raises(ValueError, binom, n * 3, bad_p_one)
+        assert_raises(ValueError, binom, n * 3, bad_p_two)
+
+        self.setSeed()
+        actual = binom(n, p * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, binom, bad_n, p * 3)
+        assert_raises(ValueError, binom, n, bad_p_one * 3)
+        assert_raises(ValueError, binom, n, bad_p_two * 3)
+
+    def test_negative_binomial(self):
+        n = [1]
+        p = [0.5]
+        bad_n = [-1]
+        bad_p_one = [-1]
+        bad_p_two = [1.5]
+        neg_binom = np.random.negative_binomial
+        desired = np.array([1, 0, 1])
+
+        self.setSeed()
+        actual = neg_binom(n * 3, p)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, neg_binom, bad_n * 3, p)
+        assert_raises(ValueError, neg_binom, n * 3, bad_p_one)
+        assert_raises(ValueError, neg_binom, n * 3, bad_p_two)
+
+        self.setSeed()
+        actual = neg_binom(n, p * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, neg_binom, bad_n, p * 3)
+        assert_raises(ValueError, neg_binom, n, bad_p_one * 3)
+        assert_raises(ValueError, neg_binom, n, bad_p_two * 3)
+
+    def test_poisson(self):
+        max_lam = np.random.RandomState().poisson_lam_max
+
+        lam = [1]
+        bad_lam_one = [-1]
+        bad_lam_two = [max_lam * 2]
+        poisson = np.random.poisson
+        desired = np.array([1, 1, 0])
+
+        self.setSeed()
+        actual = poisson(lam * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, poisson, bad_lam_one * 3)
+        assert_raises(ValueError, poisson, bad_lam_two * 3)
+
+    def test_zipf(self):
+        a = [2]
+        bad_a = [0]
+        zipf = np.random.zipf
+        desired = np.array([2, 2, 1])
+
+        self.setSeed()
+        actual = zipf(a * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, zipf, bad_a * 3)
+
+    def test_geometric(self):
+        p = [0.5]
+        bad_p_one = [-1]
+        bad_p_two = [1.5]
+        geom = np.random.geometric
+        desired = np.array([2, 2, 2])
+
+        self.setSeed()
+        actual = geom(p * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, geom, bad_p_one * 3)
+        assert_raises(ValueError, geom, bad_p_two * 3)
+
+    def test_hypergeometric(self):
+        ngood = [1]
+        nbad = [2]
+        nsample = [2]
+        bad_ngood = [-1]
+        bad_nbad = [-2]
+        bad_nsample_one = [0]
+        bad_nsample_two = [4]
+        hypergeom = np.random.hypergeometric
+        desired = np.array([1, 1, 1])
+
+        self.setSeed()
+        actual = hypergeom(ngood * 3, nbad, nsample)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, hypergeom, bad_ngood * 3, nbad, nsample)
+        assert_raises(ValueError, hypergeom, ngood * 3, bad_nbad, nsample)
+        assert_raises(ValueError, hypergeom, ngood * 3, nbad, bad_nsample_one)
+        assert_raises(ValueError, hypergeom, ngood * 3, nbad, bad_nsample_two)
+
+        self.setSeed()
+        actual = hypergeom(ngood, nbad * 3, nsample)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, hypergeom, bad_ngood, nbad * 3, nsample)
+        assert_raises(ValueError, hypergeom, ngood, bad_nbad * 3, nsample)
+        assert_raises(ValueError, hypergeom, ngood, nbad * 3, bad_nsample_one)
+        assert_raises(ValueError, hypergeom, ngood, nbad * 3, bad_nsample_two)
+
+        self.setSeed()
+        actual = hypergeom(ngood, nbad, nsample * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, hypergeom, bad_ngood, nbad, nsample * 3)
+        assert_raises(ValueError, hypergeom, ngood, bad_nbad, nsample * 3)
+        assert_raises(ValueError, hypergeom, ngood, nbad, bad_nsample_one * 3)
+        assert_raises(ValueError, hypergeom, ngood, nbad, bad_nsample_two * 3)
+
+    def test_logseries(self):
+        p = [0.5]
+        bad_p_one = [2]
+        bad_p_two = [-1]
+        logseries = np.random.logseries
+        desired = np.array([1, 1, 1])
+
+        self.setSeed()
+        actual = logseries(p * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, logseries, bad_p_one * 3)
+        assert_raises(ValueError, logseries, bad_p_two * 3)
+
+
+class TestThread(TestCase):
     # make sure each state produces the same sequence even in threads
     def setUp(self):
         self.seeds = range(4)
@@ -813,10 +1368,10 @@ class TestThread(object):
             function(np.random.RandomState(s), o)
 
         # these platforms change x87 fpu precision mode in threads
-        if (np.intp().dtype.itemsize == 4 and sys.platform == "win32"):
-            np.testing.assert_array_almost_equal(out1, out2)
+        if np.intp().dtype.itemsize == 4 and sys.platform == "win32":
+            assert_array_almost_equal(out1, out2)
         else:
-            np.testing.assert_array_equal(out1, out2)
+            assert_array_equal(out1, out2)
 
     def test_normal(self):
         def gen_random(state, out):
@@ -831,8 +1386,7 @@ class TestThread(object):
     def test_multinomial(self):
         def gen_random(state, out):
             out[...] = state.multinomial(10, [1/6.]*6, size=10000)
-        self.check_function(gen_random, sz=(10000,6))
-
+        self.check_function(gen_random, sz=(10000, 6))
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Follow-up from #6997 in which I found that there was almost no testing for the broadcasting behavior of methods defined to broadcast in `mtrand.pyx`.  Clarified documentation for these broadcastable functions with regards to output size depending on whether `size` is `None` and whether the inputs are all scalars.
