### PR TITLE
Backport #7087, BLD: fix compilation on non glibc-Linuxes

### DIFF
--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -70,8 +70,8 @@
 #endif /* defined(_MSC_VER) && defined(__INTEL_COMPILER) */
 
 
-/* Disable broken gnu trig functions on linux */
-#if defined(__linux__) && defined(__GNUC__)
+/* Disable broken glibc trig functions on linux */
+#if defined(__linux__) && defined(__GLIBC__)
 
 #if defined(HAVE_FEATURES_H)
 #include <features.h>
@@ -102,6 +102,6 @@
 #endif
 #undef TRIG_OK
 
-#endif /* defined(__linux__) && defined(__GNUC__) */
+#endif /* defined(__linux__) && defined(__GLIBC__) */
 
 #endif


### PR DESCRIPTION
Non-glibc Linuxes dont have the __GLIBC_PREREQ function and compilation of numpy
fails on such platforms. To avoid this the TRIG_OK check should be done only in
the glibc environment

The patch is taken from AlpineLinux repository
http://git.alpinelinux.org/cgit/aports/tree/testing/py-numpy/numpy-1.10.0-musl.patch?id=2e5c4bfcf1c9746edd58a8e684d01403f234e71d
