### PR TITLE
Cleanup warnings

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4070,6 +4070,17 @@ array_may_share_memory(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *
     return array_shares_memory_impl(args, kwds, NPY_MAY_SHARE_BOUNDS, 0);
 }
 
+static PyObject *
+arr_set_warn_on_write(PyObject *NPY_UNUSED(ignored), PyObject *arr) {
+    if (!PyArray_Check(arr)) {
+        PyErr_SetString(PyExc_ValueError, "argument must be a numpy array.");
+        return NULL;
+    }
+    PyArray_ENABLEFLAGS((PyArrayObject *)arr, NPY_ARRAY_WARN_ON_WRITE);
+
+    Py_RETURN_NONE;
+}
+
 
 static struct PyMethodDef array_module_methods[] = {
     {"_get_ndarray_c_version",
@@ -4243,6 +4254,8 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"unpackbits", (PyCFunction)io_unpack,
         METH_VARARGS | METH_KEYWORDS, NULL},
+    {"_set_warn_on_write", (PyCFunction)arr_set_warn_on_write,
+        METH_O, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4070,17 +4070,6 @@ array_may_share_memory(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *
     return array_shares_memory_impl(args, kwds, NPY_MAY_SHARE_BOUNDS, 0);
 }
 
-static PyObject *
-arr_set_warn_on_write(PyObject *NPY_UNUSED(ignored), PyObject *arr) {
-    if (!PyArray_Check(arr)) {
-        PyErr_SetString(PyExc_ValueError, "argument must be a numpy array.");
-        return NULL;
-    }
-    PyArray_ENABLEFLAGS((PyArrayObject *)arr, NPY_ARRAY_WARN_ON_WRITE);
-
-    Py_RETURN_NONE;
-}
-
 
 static struct PyMethodDef array_module_methods[] = {
     {"_get_ndarray_c_version",
@@ -4254,8 +4243,6 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"unpackbits", (PyCFunction)io_unpack,
         METH_VARARGS | METH_KEYWORDS, NULL},
-    {"_set_warn_on_write", (PyCFunction)arr_set_warn_on_write,
-        METH_O, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -9,7 +9,7 @@ import datetime
 from numpy.compat import asbytes
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_warns, dec
+    assert_warns, dec, suppressed_warning
 )
 
 # Use pytz to test out various time zones if available
@@ -21,10 +21,11 @@ except ImportError:
 
 
 # Ignore all NaT comparison warnings here
-warnings.filterwarnings("ignore", category=FutureWarning,
-                        message=".*NAT\ (==|!=|<|>|<=|>=)\ (x|NAT).*False.")
+sup = suppressed_warning(category=FutureWarning,
+                         message=".*NAT\ (==|!=|<|>|<=|>=)\ (x|NAT).*False.")
 
 
+@sup.wrapped_class
 class TestDateTime(TestCase):
     def test_datetime_dtype_creation(self):
         for unit in ['Y', 'M', 'W', 'D',
@@ -1904,8 +1905,8 @@ class TestDateTime(TestCase):
         a = np.datetime64('2038-01-20T13:21:14')
         assert_equal(str(a), '2038-01-20T13:21:14')
 
-class TestDateTimeData(TestCase):
 
+class TestDateTimeData(TestCase):
     def test_basic(self):
         a = np.array(['1980-03-23'], dtype=np.datetime64)
         assert_equal(np.datetime_data(a.dtype), ('D', 1))

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -20,6 +20,11 @@ except ImportError:
     _has_pytz = False
 
 
+# Ignore all NaT comparison warnings here
+warnings.filterwarnings("ignore", category=FutureWarning,
+                        message=".*NAT\ (==|!=|<|>|<=|>=)\ (x|NAT).*False.")
+
+
 class TestDateTime(TestCase):
     def test_datetime_dtype_creation(self):
         for unit in ['Y', 'M', 'W', 'D',

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -5,8 +5,7 @@ import warnings
 import numpy as np
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_raises
-    )
+    assert_raises, suppressed_warning)
 
 class TestEinSum(TestCase):
     def test_einsum_errors(self):
@@ -282,9 +281,7 @@ class TestEinSum(TestCase):
             assert_equal(np.einsum(a, [0], b, [1]), np.outer(a, b))
 
         # Suppress the complex warnings for the 'as f8' tests
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', np.ComplexWarning)
-
+        with suppressed_warning(np.ComplexWarning):
             # matvec(a,b) / a.dot(b) where a is matrix, b is vector
             for n in range(1, 17):
                 a = np.arange(4*n, dtype=dtype).reshape(4, n)

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -261,8 +261,8 @@ class TestIndexing(TestCase):
     def test_uncontiguous_subspace_assignment(self):
         # During development there was a bug activating a skip logic
         # based on ndim instead of size.
-        a = np.full((3, 4, 2), -1)
-        b = np.full((3, 4, 2), -1)
+        a = np.full((3, 4, 2), -1.)
+        b = np.full((3, 4, 2), -1.)
 
         a[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).T
         b[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).T.copy()

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -769,7 +769,7 @@ class TestStructured(TestCase):
         # start raising an error eventually. What we really care about in this
         # test is just that it doesn't return True.
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", category=FutureWarning)
             assert_equal(x == y, False)
 
         x = np.zeros((1,), dtype=[('a', ('f4', (2, 1))), ('b', 'i1')])
@@ -778,7 +778,7 @@ class TestStructured(TestCase):
         # start raising an error eventually. What we really care about in this
         # test is just that it doesn't return True.
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", category=FutureWarning)
             assert_equal(x == y, False)
 
         # Check that structured arrays that are different only in

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -9,7 +9,7 @@ from numpy.compat import asbytes, sixu
 from numpy.core.multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_raises, dec
+    assert_raises, dec, suppressed_warning
     )
 
 
@@ -1616,9 +1616,7 @@ def test_iter_buffered_cast_byteswapped():
 
     assert_equal(a, 2*np.arange(10, dtype='f4'))
 
-    try:
-        warnings.simplefilter("ignore", np.ComplexWarning)
-
+    with suppressed_warning(np.ComplexWarning):
         a = np.arange(10, dtype='f8').newbyteorder().byteswap()
         i = nditer(a, ['buffered', 'external_loop'],
                        [['readwrite', 'nbo', 'aligned']],
@@ -1629,8 +1627,7 @@ def test_iter_buffered_cast_byteswapped():
             v[...] *= 2
 
         assert_equal(a, 2*np.arange(10, dtype='f8'))
-    finally:
-        warnings.simplefilter("default", np.ComplexWarning)
+
 
 def test_iter_buffered_cast_byteswapped_complex():
     # Test that buffering can handle a cast which requires swap->cast->copy

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1847,7 +1847,7 @@ class TestCreationFuncs(TestCase):
         if fill_value is not None:
             fill_kwarg = {'fill_value': fill_value}
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter('ignore', FutureWarning)
             for size, ndims, order, type, bytes in itertools.product(*par):
                 shape = ndims * [size]
                 try:
@@ -1882,8 +1882,8 @@ class TestCreationFuncs(TestCase):
         self.check_function(np.empty)
 
     def test_filled(self):
-        self.check_function(np.full, 0.)
-        self.check_function(np.full, 1.)
+        self.check_function(np.full, 0)
+        self.check_function(np.full, 1)
 
     def test_for_reference_leak(self):
         # Make sure we have an object for reference

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1882,8 +1882,8 @@ class TestCreationFuncs(TestCase):
         self.check_function(np.empty)
 
     def test_filled(self):
-        self.check_function(np.full, 0)
-        self.check_function(np.full, 1)
+        self.check_function(np.full, 0.)
+        self.check_function(np.full, 1.)
 
     def test_for_reference_leak(self):
         # Make sure we have an object for reference
@@ -1895,7 +1895,7 @@ class TestCreationFuncs(TestCase):
         assert_(sys.getrefcount(dim) == beg)
         np.empty([dim]*10)
         assert_(sys.getrefcount(dim) == beg)
-        np.full([dim]*10, 0)
+        np.full([dim]*10, 0.)
         assert_(sys.getrefcount(dim) == beg)
 
 
@@ -2072,7 +2072,7 @@ class TestConvolve(TestCase):
     def test_object(self):
         d = [1.] * 100
         k = [1.] * 3
-        assert_array_almost_equal(np.convolve(d, k)[2:-2], np.full(98, 3))
+        assert_array_almost_equal(np.convolve(d, k)[2:-2], np.full(98, 3.))
 
     def test_no_overwrite(self):
         d = np.ones(100)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -551,19 +551,24 @@ class TestGradient(TestCase):
                       np.array([1., 1.]), np.array([1., 1.]))
 
     def test_masked(self):
-        # Make sure that gradient supports subclasses like masked arrays
-        x = np.ma.array([[1, 1], [3, 4]],
-                        mask=[[False, False], [False, False]])
-        out = gradient(x)[0]
-        assert_equal(type(out), type(x))
-        # And make sure that the output and input don't have aliased mask
-        # arrays
-        assert_(x.mask is not out.mask)
-        # Also check that edge_order=2 doesn't alter the original mask
-        x2 = np.ma.arange(5)
-        x2[2] = np.ma.masked
-        np.gradient(x2, edge_order=2)
-        assert_array_equal(x2.mask, [False, False, True, False, False])
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "always", category=FutureWarning,
+                message="Currently, slicing will try to return a view of")
+
+            # Make sure that gradient supports subclasses like masked arrays
+            x = np.ma.array([[1, 1], [3, 4]],
+                            mask=[[False, False], [False, False]])
+            out = gradient(x)[0]
+            assert_equal(type(out), type(x))
+            # And make sure that the output and input don't have aliased mask
+            # arrays
+            assert_(x.mask is not out.mask)
+            # Also check that edge_order=2 doesn't alter the original mask
+            x2 = np.ma.arange(5)
+            x2[2] = np.ma.masked
+            np.gradient(x2, edge_order=2)
+            assert_array_equal(x2.mask, [False, False, True, False, False])
 
     def test_datetime64(self):
         # Make sure gradient() can handle special types like datetime64
@@ -1037,20 +1042,25 @@ class TestTrapz(TestCase):
         assert_almost_equal(r, qz)
 
     def test_masked(self):
-        # Testing that masked arrays behave as if the function is 0 where
-        # masked
-        x = np.arange(5)
-        y = x * x
-        mask = x == 2
-        ym = np.ma.array(y, mask=mask)
-        r = 13.0  # sum(0.5 * (0 + 1) * 1.0 + 0.5 * (9 + 16))
-        assert_almost_equal(trapz(ym, x), r)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "always", category=FutureWarning,
+                message="Currently, slicing will try to return a view of")
 
-        xm = np.ma.array(x, mask=mask)
-        assert_almost_equal(trapz(ym, xm), r)
+            # Testing that masked arrays behave as if the function is 0 where
+            # masked
+            x = np.arange(5)
+            y = x * x
+            mask = x == 2
+            ym = np.ma.array(y, mask=mask)
+            r = 13.0  # sum(0.5 * (0 + 1) * 1.0 + 0.5 * (9 + 16))
+            assert_almost_equal(trapz(ym, x), r)
 
-        xm = np.ma.array(x, mask=mask)
-        assert_almost_equal(trapz(y, xm), r)
+            xm = np.ma.array(x, mask=mask)
+            assert_almost_equal(trapz(ym, xm), r)
+
+            xm = np.ma.array(x, mask=mask)
+            assert_almost_equal(trapz(y, xm), r)
 
     def test_matrix(self):
         # Test to make sure matrices give the same answer as ndarrays

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -720,5 +720,7 @@ class TestAppendFieldsObj(TestCase):
                            dtype=[('A', object), ('B', float), ('C', int)])
         assert_equal(test, control)
 
+
 if __name__ == '__main__':
     run_module_suite()
+

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -19,7 +19,8 @@ import numpy as np
 import numpy.ma.core
 import numpy.core.fromnumeric as fromnumeric
 import numpy.core.umath as umath
-from numpy.testing import TestCase, run_module_suite, assert_raises
+from numpy.testing import (
+    TestCase, run_module_suite, assert_raises, suppressed_warning)
 from numpy import ndarray
 from numpy.compat import asbytes, asbytes_nested
 from numpy.ma.testutils import (
@@ -48,6 +49,15 @@ from numpy.ma.core import (
 pi = np.pi
 
 
+sup = suppressed_warning(FutureWarning,
+    "Currently, slicing will try to return a view of the data, "
+    "but will return a copy of the mask. In the future, it will "
+    "try to return both as views. This means that using "
+    "`__setitem__` will propagate values back through all masks "
+    "that are present.")
+
+
+@sup.wrapped_class
 class TestMaskedArray(TestCase):
     # Base test class for MaskedArrays.
 
@@ -806,6 +816,7 @@ class TestMaskedArray(TestCase):
         assert_(mx2[0] == 0.)
 
 
+@sup.wrapped_class
 class TestMaskedArrayArithmetic(TestCase):
     # Base test class for MaskedArrays.
 
@@ -1344,6 +1355,7 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(a.mask, [0, 0, 0, 0, 1])
 
 
+@sup.wrapped_class
 class TestMaskedArrayAttributes(TestCase):
 
     def test_keepmask(self):
@@ -1537,6 +1549,7 @@ class TestMaskedArrayAttributes(TestCase):
         assert_equal(m._mask, np.ma.nomask)
 
 
+@sup.wrapped_class
 class TestFillingValues(TestCase):
 
     def test_check_on_scalar(self):
@@ -1820,6 +1833,7 @@ class TestFillingValues(TestCase):
         assert_(y.fill_value == 999999)
 
 
+@sup.wrapped_class
 class TestUfuncs(TestCase):
     # Test class for the application of ufuncs on MaskedArrays.
 
@@ -1937,6 +1951,7 @@ class TestUfuncs(TestCase):
         assert_(a / me_too == "Me2rdiv")
 
 
+@sup.wrapped_class
 class TestMaskedArrayInPlaceArithmetics(TestCase):
     # Test MaskedArray Arithmetics
 
@@ -2446,6 +2461,7 @@ class TestMaskedArrayInPlaceArithmetics(TestCase):
                 assert_equal(len(w), 0, "Failed on type=%s." % t)
 
 
+@sup.wrapped_class
 class TestMaskedArrayMethods(TestCase):
     # Test class for miscellaneous MaskedArrays methods.
     def setUp(self):
@@ -3110,6 +3126,7 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(MaskedArray.cumsum(marray.T, 0), control.cumsum(0))
 
 
+@sup.wrapped_class
 class TestMaskedArrayMathMethods(TestCase):
 
     def setUp(self):
@@ -3368,6 +3385,7 @@ class TestMaskedArrayMathMethods(TestCase):
         assert_equal(a.max(1), [3, 6])
 
 
+@sup.wrapped_class
 class TestMaskedArrayMathMethodsComplex(TestCase):
     # Test class for miscellaneous MaskedArrays methods.
     def setUp(self):
@@ -3421,6 +3439,7 @@ class TestMaskedArrayMathMethodsComplex(TestCase):
                                 mX[:, k].compressed().std())
 
 
+@sup.wrapped_class
 class TestMaskedArrayFunctions(TestCase):
     # Test class for miscellaneous functions.
 
@@ -3982,6 +4001,7 @@ class TestMaskedArrayFunctions(TestCase):
         assert_equal(test, 42)
 
 
+@sup.wrapped_class
 class TestMaskedFields(TestCase):
 
     def setUp(self):
@@ -4138,6 +4158,7 @@ class TestMaskedFields(TestCase):
             assert_equal(len(rec), len(self.data['ddtype']))
 
 
+@sup.wrapped_class
 class TestMaskedView(TestCase):
 
     def setUp(self):
@@ -4244,6 +4265,7 @@ def test_append_masked_array():
     assert_array_equal(result.mask, expected_mask)
 
 
+@sup.wrapped
 def test_append_masked_array_along_axis():
     a = np.ma.masked_equal([1,2,3], value=2)
     b = np.ma.masked_values([[4, 5, 6], [7, 8, 9]], 7)
@@ -4263,6 +4285,8 @@ def test_default_fill_value_complex():
     # regression test for Python 3, where 'unicode' was not defined
     assert_(default_fill_value(1 + 1j) == 1.e20 + 0.0j)
 
+
 ###############################################################################
 if __name__ == "__main__":
     run_module_suite()
+

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1186,3 +1186,4 @@ class TestShapeBase(TestCase):
 
 if __name__ == "__main__":
     run_module_suite()
+

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -13,7 +13,8 @@ import warnings
 
 import numpy as np
 from numpy.testing import (
-    TestCase, run_module_suite, assert_warns, clear_and_catch_warnings
+    TestCase, run_module_suite, assert_warns, clear_and_catch_warnings,
+    suppressed_warning
     )
 from numpy.ma.testutils import (
     assert_, assert_array_equal, assert_equal, assert_almost_equal
@@ -33,6 +34,15 @@ from numpy.ma.extras import (
 import numpy.ma.extras as mae
 
 
+sup = suppressed_warning(FutureWarning,
+    "Currently, slicing will try to return a view of the data, "
+    "but will return a copy of the mask. In the future, it will "
+    "try to return both as views. This means that using "
+    "`__setitem__` will propagate values back through all masks "
+    "that are present.")
+
+
+@sup.wrapped_class
 class TestGeneric(TestCase):
     #
     def test_masked_all(self):
@@ -138,6 +148,7 @@ class TestGeneric(TestCase):
         assert_equal(test, None)
 
 
+@sup.wrapped_class
 class TestAverage(TestCase):
     # Several tests of average. Why so many ? Good point...
     def test_testAverage1(self):
@@ -269,6 +280,7 @@ class TestAverage(TestCase):
         assert_almost_equal(wav1.imag, expected1.imag)
 
 
+@sup.wrapped_class
 class TestConcatenator(TestCase):
     # Tests for mr_, the equivalent of r_ for masked arrays.
 
@@ -304,6 +316,7 @@ class TestConcatenator(TestCase):
         assert_array_equal(d.mask, np.r_[m_1, m_2])
 
 
+@sup.wrapped_class
 class TestNotMasked(TestCase):
     # Tests notmasked_edges and notmasked_contiguous.
 
@@ -365,6 +378,7 @@ class TestNotMasked(TestCase):
         assert_equal(tmp[2][-2], slice(0, 6, None))
 
 
+@sup.wrapped_class
 class TestCompressFunctions(TestCase):
 
     def test_compress_nd(self):
@@ -618,6 +632,7 @@ class TestCompressFunctions(TestCase):
         assert_equal(a, res)
 
 
+@sup.wrapped_class
 class TestApplyAlongAxis(TestCase):
     # Tests 2D functions
     def test_3d(self):
@@ -712,6 +727,7 @@ class TestMedian(TestCase):
         assert_(type(r) == MaskedArray)
 
 
+@sup.wrapped_class
 class TestCov(TestCase):
 
     def setUp(self):
@@ -785,6 +801,7 @@ class catch_warn_mae(clear_and_catch_warnings):
     class_modules = (mae,)
 
 
+@sup.wrapped_class
 class TestCorrcoef(TestCase):
 
     def setUp(self):
@@ -950,6 +967,7 @@ class TestPolynomial(TestCase):
             assert_almost_equal(a, a_)
 
 
+@sup.wrapped_class
 class TestArraySetOps(TestCase):
 
     def test_unique_onlist(self):

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -437,7 +437,15 @@ class NoseTester(object):
 
             argv, plugins = self.prepare_test_args(
                     label, verbose, extra_argv, doctests, coverage)
+
+            warnings_before = warnings.filters[:]
+
             t = NumpyTestProgram(argv=argv, exit=False, plugins=plugins)
+
+            if warnings_before != warnings.filters:
+                raise AssertionError(
+                    "warnings changed during test; catch_warnings should be "
+                    "used everywhere")            
 
         return t.result
 

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -378,6 +378,7 @@ class NoseTester(object):
         >>> result.knownfail #doctest: +SKIP
         []
         """
+
         # cap verbosity at 3 because nose becomes *very* verbose beyond that
         verbose = min(verbose, 3)
 

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -445,7 +445,8 @@ class NoseTester(object):
             if warnings_before != warnings.filters:
                 raise AssertionError(
                     "warnings changed during test; catch_warnings should be "
-                    "used everywhere")            
+                    "used everywhere. New ones are: {}".format(
+                        set(warnings.filters) - set(warnings_before)))            
 
         return t.result
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -9,7 +9,7 @@ import sys
 import re
 import operator
 import warnings
-from functools import partial
+from functools import partial, wraps
 import shutil
 import contextlib
 from tempfile import mkdtemp, mkstemp
@@ -31,7 +31,8 @@ __all__ = ['assert_equal', 'assert_almost_equal', 'assert_approx_equal',
            'assert_', 'assert_array_almost_equal_nulp', 'assert_raises_regex',
            'assert_array_max_ulp', 'assert_warns', 'assert_no_warnings',
            'assert_allclose', 'IgnoreException', 'clear_and_catch_warnings',
-           'SkipTest', 'KnownFailureException', 'temppath', 'tempdir']
+           'SkipTest', 'KnownFailureException', 'temppath', 'tempdir',
+           'suppressed_warning']
 
 
 class KnownFailureException(Exception):
@@ -1875,6 +1876,54 @@ def temppath(*args, **kwargs):
         yield path
     finally:
         os.remove(path)
+
+
+class suppressed_warning(object):
+    def __init__(self, category, message):
+        super(suppressed_warning, self).__init__()
+        self.message = message
+        self.category = category
+        self.mess_pattern = re.compile(message, re.I)
+        self._entered = False
+
+    def __enter__(self):
+        self._orig_show = warnings.showwarning
+        self._filters = warnings.filters[:]
+        if self._entered:
+            raise RuntimeError("cannot enter suppressed_warnings twice.")
+        self._entered = True
+
+        warnings.filterwarnings(
+            "always", category=self.category)
+        warnings.showwarning = self.showwarning
+
+    def __exit__(self, *exc_info):
+        warnings.showwarning = self._orig_show
+        warnings.filters[:] = self._filters
+        self._entered = False
+
+    def showwarning(self, message, category, filename, lineno,
+                    file=None, line=None):
+        if (issubclass(category, self.category) and
+                self.mess_pattern.match(message.args[0]) is not None):
+            return
+        self._orig_show(message, category, filename, lineno,
+                        file=file, line=line)
+
+    def wrapped(self, func):
+        @wraps(func)
+        def new_func(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+
+        return new_func
+
+    def wrapped_class(self, cls):
+        for name, method in cls.__dict__.items():
+            if name.startswith('test_') and callable(method):
+                setattr(cls, name, self.wrapped(method))
+
+        return cls
 
 
 class clear_and_catch_warnings(warnings.catch_warnings):


### PR DESCRIPTION
This is hell broke lose of course, the decorator is pretty ugly, but what can you do?!

We have some pretty prominent FutureWarnings, getting rid of them is hard/a lot of work, the decorator is a start to have at least _some_ approach other then catching every single test individually.

This is a **start**, and I do not think I can really finish it myself, but....
