### PR TITLE
loadtxt fails on files with leading spaces if separator is also space

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -864,7 +864,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         line = asbytes(line)
         if comments is not None:
             line = regex_comments.split(asbytes(line), maxsplit=1)[0]
-        line = line.strip(asbytes('\r\n'))
+        #add space to .strip() so lines with leading spaces are read
+        line = line.strip(asbytes('\r\n '))
         if line:
             return line.split(delimiter)
         else:


### PR DESCRIPTION
' 1.0 2.0 3.0' -> split() -> ['', 1.0, 2.0, 3.0] -> ValueError: could not convert string to float

Can be fixed by adding ' ' to .strip() or by calling .strip() twice

```
line = line.strip(asbytes('\r\n '))
line = line.strip().strip(asbytes('\r\n'))
line = line.strip(asbytes('\r\n')).strip()
```

I am not sure which solution is best and chose the first one.
