### PR TITLE
TST: Suppressed warnings

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -111,6 +111,13 @@ previous implementation used in ``assert_array_almost_equal``. Due to the
 change in implementation some very delicate tests may fail that did not
 fail before.
 
+``NoseTester`` behaviour of warnings during testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When ``raise_warnings="develop"`` is given, all uncaught warnings will now
+be considered a test failure. Previously only selected ones were raised.
+Warnings which are not caught or raised (mostly when in release mode)
+will be shown once during the test cycle similar to the default python
+settings.
 
 ``assert_warns`` and ``deprecated`` decorator more specific
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -193,8 +200,8 @@ precision.
 New array creation function ``geomspace`` added
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The new function ``geomspace`` generates a geometric sequence.  It is similar
-to ``logspace``, but with start and stop specified directly: 
-``geomspace(start, stop)`` behaves the same as 
+to ``logspace``, but with start and stop specified directly:
+``geomspace(start, stop)`` behaves the same as
 ``logspace(log10(start), log10(stop))``.
 
 New context manager for testing warnings

--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -112,6 +112,18 @@ change in implementation some very delicate tests may fail that did not
 fail before.
 
 
+``assert_warns`` and ``deprecated`` decorator more specific
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``assert_warns`` function and context manager are now more specific
+to the given warning category. This increased specificity leads to them
+being handled according to the outer warning settings. This means that
+no warning may be raised in cases where a wrong category warning is given
+and ignored outside the context. Alternatively the increased specificity
+may mean that warnings that were incorrectly ignored will now be shown
+or raised. See also the new ``suppress_warnings`` context manager.
+The same is true for the ``deprecated`` decorator.
+
+
 C API
 ~~~~~
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -20,7 +20,7 @@ from functools import reduce
 from . import numerictypes as _nt
 from .umath import maximum, minimum, absolute, not_equal, isnan, isinf
 from .multiarray import (array, format_longfloat, datetime_as_string,
-                         datetime_data)
+                         datetime_data, dtype)
 from .fromnumeric import ravel
 from .numeric import asarray
 
@@ -734,7 +734,9 @@ class TimedeltaFormat(object):
     def __init__(self, data):
         if data.dtype.kind == 'm':
             nat_value = array(['NaT'], dtype=data.dtype)[0]
-            v = data[not_equal(data, nat_value)].view('i8')
+            int_dtype = dtype(data.dtype.byteorder + 'i8')
+            int_view = data.view(int_dtype)
+            v = int_view[not_equal(int_view, nat_value.view(int_dtype))]
             if len(v) > 0:
                 # Max str length of non-NaT elements
                 max_str_len = max(len(str(maximum.reduce(v))),
@@ -748,7 +750,8 @@ class TimedeltaFormat(object):
             self._nat = "'NaT'".rjust(max_str_len)
 
     def __call__(self, x):
-        if x + 1 == x:
+        # TODO: After NAT == NAT deprecation should be simplified:
+        if (x + 1).view('i8') == x.view('i8'):
             return self._nat
         else:
             return self.format % x.astype('i8')

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import pickle
-import warnings
 
 import numpy
 import numpy as np
@@ -9,7 +8,7 @@ import datetime
 from numpy.compat import asbytes
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_warns, dec
+    assert_warns, dec, suppress_warnings
 )
 
 # Use pytz to test out various time zones if available
@@ -129,10 +128,11 @@ class TestDateTime(TestCase):
         # regression tests for GH6452
         assert_equal(np.datetime64('NaT'),
                      np.datetime64('2000') + np.timedelta64('NaT'))
-        # nb. we may want to make NaT != NaT true in the future; this test
-        # verifies the existing behavior (and that it should not warn)
-        assert_(np.datetime64('NaT') == np.datetime64('NaT', 'us'))
-        assert_(np.datetime64('NaT', 'us') == np.datetime64('NaT'))
+        # nb. we may want to make NaT != NaT true in the future
+        with suppress_warnings() as sup:
+            sup.filter(FutureWarning, ".*NAT ==")
+            assert_(np.datetime64('NaT') == np.datetime64('NaT', 'us'))
+            assert_(np.datetime64('NaT', 'us') == np.datetime64('NaT'))
 
     def test_datetime_scalar_construction(self):
         # Construct with different units
@@ -572,6 +572,12 @@ class TestDateTime(TestCase):
         a = np.array([-1, 'NaT', 1234567], dtype='m')
         assert_equal(str(a), "[     -1   'NaT' 1234567]")
 
+        # Test with other byteorder:
+        a = np.array([-1, 'NaT', 1234567], dtype='>m')
+        assert_equal(str(a), "[     -1   'NaT' 1234567]")
+        a = np.array([-1, 'NaT', 1234567], dtype='<m')
+        assert_equal(str(a), "[     -1   'NaT' 1234567]")
+
     def test_pickle(self):
         # Check that pickle roundtripping works
         dt = np.dtype('M8[7D]')
@@ -989,8 +995,8 @@ class TestDateTime(TestCase):
             assert_raises(TypeError, np.multiply, 1.5, dta)
 
         # NaTs
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "invalid value encountered in multiply")
             nat = np.timedelta64('NaT')
             def check(a, b, res):
                 assert_equal(a * b, res)
@@ -1053,8 +1059,8 @@ class TestDateTime(TestCase):
             assert_raises(TypeError, np.divide, 1.5, dta)
 
         # NaTs
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning,  r".*encountered in true\_divide")
             nat = np.timedelta64('NaT')
             for tp in (int, float):
                 assert_equal(np.timedelta64(1) / tp(0), nat)
@@ -1092,27 +1098,31 @@ class TestDateTime(TestCase):
         td_nat = np.timedelta64('NaT', 'h')
         td_other = np.timedelta64(1, 'h')
 
-        for op in [np.equal, np.less, np.less_equal,
-                   np.greater, np.greater_equal]:
-            if op(dt_nat, dt_nat):
-                assert_warns(FutureWarning, op, dt_nat, dt_nat)
-            if op(dt_nat, dt_other):
-                assert_warns(FutureWarning, op, dt_nat, dt_other)
-            if op(dt_other, dt_nat):
-                assert_warns(FutureWarning, op, dt_other, dt_nat)
-            if op(td_nat, td_nat):
-                assert_warns(FutureWarning, op, td_nat, td_nat)
-            if op(td_nat, td_other):
-                assert_warns(FutureWarning, op, td_nat, td_other)
-            if op(td_other, td_nat):
-                assert_warns(FutureWarning, op, td_other, td_nat)
+        with suppress_warnings() as sup:
+            # The assert warns contexts will again see the warning:
+            sup.filter(FutureWarning, ".*NAT")
 
-        assert_warns(FutureWarning, np.not_equal, dt_nat, dt_nat)
-        assert_(np.not_equal(dt_nat, dt_other))
-        assert_(np.not_equal(dt_other, dt_nat))
-        assert_warns(FutureWarning, np.not_equal, td_nat, td_nat)
-        assert_(np.not_equal(td_nat, td_other))
-        assert_(np.not_equal(td_other, td_nat))
+            for op in [np.equal, np.less, np.less_equal,
+                       np.greater, np.greater_equal]:
+                if op(dt_nat, dt_nat):
+                    assert_warns(FutureWarning, op, dt_nat, dt_nat)
+                if op(dt_nat, dt_other):
+                    assert_warns(FutureWarning, op, dt_nat, dt_other)
+                if op(dt_other, dt_nat):
+                    assert_warns(FutureWarning, op, dt_other, dt_nat)
+                if op(td_nat, td_nat):
+                    assert_warns(FutureWarning, op, td_nat, td_nat)
+                if op(td_nat, td_other):
+                    assert_warns(FutureWarning, op, td_nat, td_other)
+                if op(td_other, td_nat):
+                    assert_warns(FutureWarning, op, td_other, td_nat)
+
+            assert_warns(FutureWarning, np.not_equal, dt_nat, dt_nat)
+            assert_(np.not_equal(dt_nat, dt_other))
+            assert_(np.not_equal(dt_other, dt_nat))
+            assert_warns(FutureWarning, np.not_equal, td_nat, td_nat)
+            assert_(np.not_equal(td_nat, td_other))
+            assert_(np.not_equal(td_other, td_nat))
 
     def test_datetime_minmax(self):
         # The metadata of the result should become the GCD

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -644,6 +644,8 @@ class TestTestDeprecated(object):
             warnings.warn("foo", category=DeprecationWarning)
 
         test_case_instance.assert_deprecated(foo)
+        test_case_instance.tearDown()
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -1,12 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import warnings
-
 import numpy as np
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_raises
+    assert_raises, suppress_warnings
     )
+
 
 class TestEinSum(TestCase):
     def test_einsum_errors(self):
@@ -282,8 +281,8 @@ class TestEinSum(TestCase):
             assert_equal(np.einsum(a, [0], b, [1]), np.outer(a, b))
 
         # Suppress the complex warnings for the 'as f8' tests
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', np.ComplexWarning)
+        with suppress_warnings() as sup:
+            sup.filter(np.ComplexWarning)
 
             # matvec(a,b) / a.dot(b) where a is matrix, b is vector
             for n in range(1, 17):

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -4,7 +4,7 @@ from numpy import (logspace, linspace, geomspace, dtype, array, finfo,
                    typecodes, arange, isnan, ndarray, sqrt)
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_array_equal, assert_allclose
+    assert_array_equal, assert_allclose, suppress_warnings
 )
 
 
@@ -205,8 +205,10 @@ class TestLinspace(TestCase):
     def test_corner(self):
         y = list(linspace(0, 1, 1))
         assert_(y == [0.0], y)
-        y = list(linspace(0, 1, 2.5))
-        assert_(y == [0.0, 1.0])
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, ".*safely interpreted as an integer")
+            y = list(linspace(0, 1, 2.5))
+            assert_(y == [0.0, 1.0])
 
     def test_type(self):
         t1 = linspace(0, 1, 0).dtype

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -12,7 +12,7 @@ from numpy.compat import Path
 from numpy import arange, allclose, asarray
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal,
-    dec
+    dec, suppress_warnings
 )
 
 class TestMemmap(TestCase):
@@ -146,13 +146,15 @@ class TestMemmap(TestCase):
         fp = memmap(self.tmpfp, dtype=self.dtype, shape=self.shape)
         fp[:] = self.data
 
-        for unary_op in [sum, average, product]:
-            result = unary_op(fp)
-            assert_(isscalar(result))
-            assert_(result.__class__ is self.data[0, 0].__class__)
+        with suppress_warnings() as sup:
+            sup.filter(FutureWarning, "np.average currently does not preserve")
+            for unary_op in [sum, average, product]:
+                result = unary_op(fp)
+                assert_(isscalar(result))
+                assert_(result.__class__ is self.data[0, 0].__class__)
 
-            assert_(unary_op(fp, axis=0).__class__ is ndarray)
-            assert_(unary_op(fp, axis=1).__class__ is ndarray)
+                assert_(unary_op(fp, axis=0).__class__ is ndarray)
+                assert_(unary_op(fp, axis=1).__class__ is ndarray)
 
         for binary_op in [add, subtract, multiply]:
             assert_(binary_op(fp, self.data).__class__ is ndarray)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-import warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
@@ -9,7 +8,7 @@ from numpy.compat import asbytes, sixu
 from numpy.core.multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_raises, dec, HAS_REFCOUNT
+    assert_raises, dec, HAS_REFCOUNT, suppress_warnings
     )
 
 
@@ -1624,8 +1623,8 @@ def test_iter_buffered_cast_byteswapped():
 
     assert_equal(a, 2*np.arange(10, dtype='f4'))
 
-    try:
-        warnings.simplefilter("ignore", np.ComplexWarning)
+    with suppress_warnings() as sup:
+        sup.filter(np.ComplexWarning)
 
         a = np.arange(10, dtype='f8').newbyteorder().byteswap()
         i = nditer(a, ['buffered', 'external_loop'],
@@ -1637,8 +1636,6 @@ def test_iter_buffered_cast_byteswapped():
             v[...] *= 2
 
         assert_equal(a, 2*np.arange(10, dtype='f8'))
-    finally:
-        warnings.simplefilter("default", np.ComplexWarning)
 
 def test_iter_buffered_cast_byteswapped_complex():
     # Test that buffering can handle a cast which requires swap->cast->copy

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -12,7 +12,7 @@ from numpy.random import rand, randint, randn
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_raises_regex, assert_array_equal, assert_almost_equal,
-    assert_array_almost_equal, dec, HAS_REFCOUNT
+    assert_array_almost_equal, dec, HAS_REFCOUNT, suppress_warnings
 )
 
 
@@ -1976,27 +1976,26 @@ class TestCreationFuncs(TestCase):
         fill_kwarg = {}
         if fill_value is not None:
             fill_kwarg = {'fill_value': fill_value}
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
-            for size, ndims, order, dtype in itertools.product(*par):
-                shape = ndims * [size]
 
-                # do not fill void type
-                if fill_kwarg and dtype.str.startswith('|V'):
-                    continue
+        for size, ndims, order, dtype in itertools.product(*par):
+            shape = ndims * [size]
 
-                arr = func(shape, order=order, dtype=dtype,
-                           **fill_kwarg)
+            # do not fill void type
+            if fill_kwarg and dtype.str.startswith('|V'):
+                continue
 
-                assert_equal(arr.dtype, dtype)
-                assert_(getattr(arr.flags, self.orders[order]))
+            arr = func(shape, order=order, dtype=dtype,
+                       **fill_kwarg)
 
-                if fill_value is not None:
-                    if dtype.str.startswith('|S'):
-                        val = str(fill_value)
-                    else:
-                        val = fill_value
-                    assert_equal(arr, dtype.type(val))
+            assert_equal(arr.dtype, dtype)
+            assert_(getattr(arr.flags, self.orders[order]))
+
+            if fill_value is not None:
+                if dtype.str.startswith('|S'):
+                    val = str(fill_value)
+                else:
+                    val = fill_value
+                assert_equal(arr, dtype.type(val))
 
     def test_zeros(self):
         self.check_function(np.zeros)

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -139,7 +139,7 @@ class TestRegression(TestCase):
         b = np.linspace(0, 10, 11)
         # This should return true for now, but will eventually raise an error:
         with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
+            sup.filter(FutureWarning)
             self.assertTrue(b != 'auto')
         self.assertTrue(b[0] != 'auto')
 
@@ -813,6 +813,7 @@ class TestRegression(TestCase):
         # and the boolean special case is not taken.
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning)
+            sup.filter(FutureWarning)
             sup.filter(np.VisibleDeprecationWarning)
             self.assertRaises(IndexError, ia, x, s, np.zeros(9, dtype=float))
             self.assertRaises(IndexError, ia, x, s, np.zeros(11, dtype=float))

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -2,14 +2,14 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import itertools
-import warnings
 import operator
 
 import numpy as np
 from numpy.testing.utils import _gen_alignment_data
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_almost_equal, assert_allclose, assert_array_equal, IS_PYPY
+    assert_almost_equal, assert_allclose, assert_array_equal, IS_PYPY,
+    suppress_warnings
 )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -238,9 +238,8 @@ class TestModulus(TestCase):
             assert_(rem >= -b, 'dt: %s' % dt)
 
         # Check nans, inf
-        with warnings.catch_warnings():
-            warnings.simplefilter('always')
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "invalid value encountered in remainder")
             for dt in np.typecodes['Float']:
                 fone = np.array(1.0, dtype=dt)
                 fzer = np.array(0.0, dtype=dt)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    dec, assert_allclose, assert_no_warnings
+    dec, assert_allclose, assert_no_warnings, suppress_warnings
 )
 
 
@@ -300,9 +300,8 @@ class TestRemainder(TestCase):
             assert_(rem >= -b, 'dt: %s' % dt)
 
         # Check nans, inf
-        with warnings.catch_warnings():
-            warnings.simplefilter('always')
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "invalid value encountered in remainder")
             for dt in np.typecodes['Float']:
                 fone = np.array(1.0, dtype=dt)
                 fzer = np.array(0.0, dtype=dt)

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -364,6 +364,7 @@ def _can_target(cmd, arch):
     """Return true if the architecture supports the -arch flag"""
     newcmd = cmd[:]
     fid, filename = tempfile.mkstemp(suffix=".f")
+    fid.close()
     try:
         d = os.path.dirname(filename)
         output = os.path.splitext(filename)[0] + ".o"

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -242,7 +242,7 @@ else:
         # tests are run in debug mode Python 3.
         tmp = open(os.devnull, 'w')
         p = sp.Popen(["gcc", "-print-multiarch"], stdout=sp.PIPE,
-                stderr=tmp)
+                     stderr=tmp)
     except (OSError, DistutilsError):
         # OSError if gcc is not installed, or SandboxViolation (DistutilsError
         # subclass) if an old setuptools bug is triggered (see gh-3160).
@@ -971,10 +971,11 @@ class mkl_info(system_info):
         paths = os.environ.get('LD_LIBRARY_PATH', '').split(os.pathsep)
         ld_so_conf = '/etc/ld.so.conf'
         if os.path.isfile(ld_so_conf):
-            for d in open(ld_so_conf, 'r'):
-                d = d.strip()
-                if d:
-                    paths.append(d)
+            with open(ld_so_conf, 'r') as f:
+                for d in f:
+                    d = d.strip()
+                    if d:
+                        paths.append(d)
         intel_mkl_dirs = []
         for path in paths:
             path_atoms = path.split(os.sep)

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -69,7 +69,9 @@ def have_compiler():
             return False
         cmd = [compiler.cc]
     try:
-        Popen(cmd, stdout=PIPE, stderr=PIPE)
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        p.stdout.close()
+        p.stderr.close()
     except OSError:
         return False
     return True

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -19,7 +19,7 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     TestCase, run_module_suite, assert_warns, assert_,
     assert_raises_regex, assert_raises, assert_allclose,
-    assert_array_equal, temppath, dec, IS_PYPY
+    assert_array_equal, temppath, dec, IS_PYPY, suppress_warnings
 )
 
 
@@ -282,8 +282,8 @@ class TestSavezLoad(RoundtripTest, TestCase):
             # collector, so we catch the warnings.  Because ResourceWarning
             # is unknown in Python < 3.x, we take the easy way out and
             # catch all warnings.
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
+            with suppress_warnings() as sup:
+                sup.filter(Warning)  # TODO: specify exact message
                 for i in range(1, 1025):
                     try:
                         np.load(tmp)["data"]
@@ -687,9 +687,8 @@ class TestLoadTxt(TestCase):
         assert_array_equal(x, a)
 
     def test_empty_file(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message="loadtxt: Empty input file:")
+        with suppress_warnings() as sup:
+            sup.filter(message="loadtxt: Empty input file:")
             c = TextIO()
             x = np.loadtxt(c)
             assert_equal(x.shape, (0,))
@@ -826,9 +825,8 @@ class TestLoadTxt(TestCase):
         assert_(x.shape == (3,))
 
         # Test ndmin kw with empty file.
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message="loadtxt: Empty input file:")
+        with suppress_warnings() as sup:
+            sup.filter(message="loadtxt: Empty input file:")
             f = TextIO()
             assert_(np.loadtxt(f, ndmin=2).shape == (0, 1,))
             assert_(np.loadtxt(f, ndmin=1).shape == (0,))
@@ -974,8 +972,8 @@ class TestFromTxt(TestCase):
         assert_equal(test, ctrl)
 
     def test_skip_footer_with_invalid(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(ConversionWarning)
             basestr = '1 1\n2 2\n3 3\n4 4\n5  \n6  \n7  \n'
             # Footer too small to get rid of all invalid values
             assert_raises(ValueError, np.genfromtxt,
@@ -1302,9 +1300,8 @@ M   33  21.99
 
     def test_empty_file(self):
         # Test that an empty file raises the proper warning.
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message="genfromtxt: Empty input file:")
+        with suppress_warnings() as sup:
+            sup.filter(message="genfromtxt: Empty input file:")
             data = TextIO()
             test = np.genfromtxt(data)
             assert_equal(test, np.array([]))
@@ -1751,8 +1748,8 @@ M   33  21.99
         assert_raises(ValueError, np.genfromtxt, TextIO(data), max_rows=4)
 
         # Test with invalid not raise
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(ConversionWarning)
 
             test = np.genfromtxt(TextIO(data), max_rows=4, invalid_raise=False)
             control = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]])

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -167,8 +167,8 @@ class TestNanFunctions_ArgminArgmax(TestCase):
     def test_result_values(self):
         for f, fcmp in zip(self.nanfuncs, [np.greater, np.less]):
             for row in _ndat:
-                with warnings.catch_warnings(record=True):
-                    warnings.simplefilter('always')
+                with suppress_warnings() as sup:
+                    sup.filter(RuntimeWarning, "invalid value encountered in")
                     ind = f(row)
                     val = row[ind]
                     # comparing with NaN is tricky as the result
@@ -589,8 +589,8 @@ class TestNanFunctions_Median(TestCase):
         w = np.random.random((4, 200)) * np.array(d.shape)[:, None]
         w = w.astype(np.intp)
         d[tuple(w)] = np.nan
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
             res = np.nanmedian(d, axis=None, keepdims=True)
             assert_equal(res.shape, (1, 1, 1, 1))
             res = np.nanmedian(d, axis=(0, 1), keepdims=True)
@@ -687,8 +687,8 @@ class TestNanFunctions_Median(TestCase):
         assert_raises(ValueError, np.nanmedian, d, axis=(1, 1))
 
     def test_float_special(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always', RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
             a = np.array([[np.inf,  np.nan], [np.nan, np.nan]])
             assert_equal(np.nanmedian(a, axis=0), [np.inf,  np.nan])
             assert_equal(np.nanmedian(a, axis=1), [np.inf,  np.nan])
@@ -725,8 +725,8 @@ class TestNanFunctions_Percentile(TestCase):
         w = np.random.random((4, 200)) * np.array(d.shape)[:, None]
         w = w.astype(np.intp)
         d[tuple(w)] = np.nan
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
             res = np.nanpercentile(d, 90, axis=None, keepdims=True)
             assert_equal(res.shape, (1, 1, 1, 1))
             res = np.nanpercentile(d, 90, axis=(0, 1), keepdims=True)
@@ -821,8 +821,8 @@ class TestNanFunctions_Percentile(TestCase):
         large_mat[:, :, 3:] *= 2
         for axis in [None, 0, 1]:
             for keepdim in [False, True]:
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter('always')
+                with suppress_warnings() as sup:
+                    sup.filter(RuntimeWarning, "All-NaN slice encountered")
                     val = np.percentile(mat, perc, axis=axis, keepdims=keepdim)
                     nan_val = np.nanpercentile(nan_mat, perc, axis=axis,
                                                keepdims=keepdim)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -318,7 +318,9 @@ class SharedNanFunctionsTestsMixin(object):
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 with suppress_warnings() as sup:
-                    sup.filter(np.ComplexWarning)
+                    if nf in {np.nanstd, np.nanvar} and c in 'FDG':
+                        # Giving the warning is a small bug, see gh-8000
+                        sup.filter(np.ComplexWarning)
                     tgt = rf(mat, dtype=np.dtype(c), axis=1).dtype.type
                     res = nf(mat, dtype=np.dtype(c), axis=1).dtype.type
                     assert_(res is tgt)
@@ -333,7 +335,9 @@ class SharedNanFunctionsTestsMixin(object):
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 with suppress_warnings() as sup:
-                    sup.filter(np.ComplexWarning)
+                    if nf in {np.nanstd, np.nanvar} and c in 'FDG':
+                        # Giving the warning is a small bug, see gh-8000
+                        sup.filter(np.ComplexWarning)
                     tgt = rf(mat, dtype=c, axis=1).dtype.type
                     res = nf(mat, dtype=c, axis=1).dtype.type
                     assert_(res is tgt)

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -5,7 +5,7 @@ from __future__ import division, absolute_import, print_function
 
 from numpy.testing import (
     TestCase, run_module_suite, assert_equal, assert_array_equal,
-    assert_array_max_ulp, assert_array_almost_equal, assert_raises
+    assert_array_max_ulp, assert_array_almost_equal, assert_raises,
     )
 
 from numpy import (

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -18,7 +18,7 @@ from numpy.linalg.linalg import _multi_dot_matrix_chain_order
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal,
     assert_almost_equal, assert_allclose, run_module_suite,
-    dec, SkipTest
+    dec, SkipTest, suppress_warnings
 )
 
 
@@ -861,8 +861,8 @@ class _TestNorm(object):
             assert_(issubclass(an.dtype.type, np.floating))
             assert_almost_equal(an, 0.0)
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", RuntimeWarning)
+            with suppress_warnings() as sup:
+                sup.filter(RuntimeWarning, "divide by zero encountered")
                 an = norm(at, -1)
                 assert_(issubclass(an.dtype.type, np.floating))
                 assert_almost_equal(an, 0.0)
@@ -906,8 +906,8 @@ class _TestNorm(object):
             assert_(issubclass(an.dtype.type, np.floating))
             assert_almost_equal(an, 2.0)
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", RuntimeWarning)
+            with suppress_warnings() as sup:
+                sup.filter(RuntimeWarning, "divide by zero encountered")
                 an = norm(at, -1)
                 assert_(issubclass(an.dtype.type, np.floating))
                 assert_almost_equal(an, 1.0)

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -2,6 +2,8 @@
 """
 from __future__ import division, absolute_import, print_function
 
+import warnings
+
 import numpy as np
 from numpy import linalg, arange, float64, array, dot, transpose
 from numpy.testing import (
@@ -110,8 +112,10 @@ class TestRegression(TestCase):
         self.assertRaises(ValueError, linalg.norm, testvector, ord='nuc')
         self.assertRaises(ValueError, linalg.norm, testvector, ord=np.inf)
         self.assertRaises(ValueError, linalg.norm, testvector, ord=-np.inf)
-        self.assertRaises((AttributeError, DeprecationWarning),
-                          linalg.norm, testvector, ord=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            self.assertRaises((AttributeError, DeprecationWarning),
+                              linalg.norm, testvector, ord=0)
         self.assertRaises(ValueError, linalg.norm, testvector, ord=-1)
         self.assertRaises(ValueError, linalg.norm, testvector, ord=-2)
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1032,12 +1032,7 @@ class _MaskedBinaryOperation:
         if m is not nomask and m.any():
             # any errors, just abort; impossible to guarantee masked values
             try:
-                np.copyto(result, 0, casting='unsafe', where=m)
-                # avoid using "*" since this may be overlaid
-                masked_da = umath.multiply(m, da)
-                # only add back if it can be cast safely
-                if np.can_cast(masked_da.dtype, result.dtype, casting='safe'):
-                    result += masked_da
+                np.copyto(result, da, casting='unsafe', where=m)
             except:
                 pass
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -595,11 +595,11 @@ class TestMaskedArray(TestCase):
         atest[idx] = btest[idx]
         assert_equal(atest, [20])
 
-    def test_filled_w_object_dtype(self):
+    def test_filled_with_object_dtype(self):
         a = np.ma.masked_all(1, dtype='O')
         assert_equal(a.filled('x')[0], 'x')
 
-    def test_filled_w_flexible_dtype(self):
+    def test_filled_with_flexible_dtype(self):
         # Test filled w/ flexible dtype
         flexi = array([(1, 1, 1)],
                       dtype=[('i', int), ('s', '|S8'), ('f', float)])
@@ -612,7 +612,7 @@ class TestMaskedArray(TestCase):
         assert_equal(flexi.filled(1),
                      np.array([(1, '1', 1.)], dtype=flexi.dtype))
 
-    def test_filled_w_mvoid(self):
+    def test_filled_with_mvoid(self):
         # Test filled w/ mvoid
         ndtype = [('a', int), ('b', float)]
         a = mvoid((1, 2.), mask=[(0, 1)], dtype=ndtype)
@@ -626,7 +626,7 @@ class TestMaskedArray(TestCase):
         a.fill_value = (-999, -999)
         assert_equal(tuple(a.filled()), (1, -999))
 
-    def test_filled_w_nested_dtype(self):
+    def test_filled_with_nested_dtype(self):
         # Test filled w/ nested dtype
         ndtype = [('A', int), ('B', [('BA', int), ('BB', int)])]
         a = array([(1, (1, 1)), (2, (2, 2))],
@@ -646,7 +646,7 @@ class TestMaskedArray(TestCase):
         assert_equal(Z.mask.dtype, numpy.dtype([('A', [('f0', '?', (2, 2)),
                                           ('f1', '?', (2, 2))], (2, 2))]))
 
-    def test_filled_w_f_order(self):
+    def test_filled_with_f_order(self):
         # Test filled w/ F-contiguous array
         a = array(np.array([(0, 1, 2), (4, 5, 6)], order='F'),
                   mask=np.array([(0, 0, 1), (1, 0, 0)], order='F'),
@@ -1341,7 +1341,7 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_equal(test, [False, True])
         assert_equal(test.mask, [False, False])
 
-    def test_eq_w_None(self):
+    def test_eq_with_None(self):
         # Really, comparisons with None should not be done, but check them
         # anyway. Note that pep8 will flag these tests.
         # Deprecation is in place for arrays, and when it happens this
@@ -1367,7 +1367,7 @@ class TestMaskedArrayArithmetic(TestCase):
             a = masked
             assert_equal(a == None, masked)
 
-    def test_eq_w_scalar(self):
+    def test_eq_with_scalar(self):
         a = array(1)
         assert_equal(a == 1, True)
         assert_equal(a == 0, False)
@@ -3682,7 +3682,7 @@ class TestMaskedArrayFunctions(TestCase):
         assert_almost_equal(x, y)
         assert_almost_equal(x._data, y._data)
 
-    def test_power_w_broadcasting(self):
+    def test_power_with_broadcasting(self):
         # Test power w/ broadcasting
         a2 = np.array([[1., 2., 3.], [4., 5., 6.]])
         a2m = array(a2, mask=[[1, 0, 0], [0, 0, 1]])

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -13,7 +13,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import (
-    TestCase, run_module_suite, assert_warns, clear_and_catch_warnings
+    TestCase, run_module_suite, assert_warns, suppress_warnings
     )
 from numpy.ma.testutils import (
     assert_, assert_array_equal, assert_equal, assert_almost_equal
@@ -826,12 +826,6 @@ class TestCov(TestCase):
                              x.shape[0] / frac))
 
 
-class catch_warn_mae(clear_and_catch_warnings):
-    """ Context manager to catch, reset warnings in ma.extras module
-    """
-    class_modules = (mae,)
-
-
 class TestCorrcoef(TestCase):
 
     def setUp(self):
@@ -843,10 +837,10 @@ class TestCorrcoef(TestCase):
         x, y = self.data, self.data2
         expected = np.corrcoef(x)
         expected2 = np.corrcoef(x, y)
-        with catch_warn_mae():
+        with suppress_warnings() as sup:
             warnings.simplefilter("always")
             assert_warns(DeprecationWarning, corrcoef, x, ddof=-1)
-            warnings.simplefilter("ignore")
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             # ddof has no or negligible effect on the function
             assert_almost_equal(np.corrcoef(x, ddof=0), corrcoef(x, ddof=0))
             assert_almost_equal(corrcoef(x, ddof=-1), expected)
@@ -858,12 +852,12 @@ class TestCorrcoef(TestCase):
         x, y = self.data, self.data2
         expected = np.corrcoef(x)
         # bias raises DeprecationWarning
-        with catch_warn_mae():
+        with suppress_warnings() as sup:
             warnings.simplefilter("always")
             assert_warns(DeprecationWarning, corrcoef, x, y, True, False)
             assert_warns(DeprecationWarning, corrcoef, x, y, True, True)
             assert_warns(DeprecationWarning, corrcoef, x, bias=False)
-            warnings.simplefilter("ignore")
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             # bias has no or negligible effect on the function
             assert_almost_equal(corrcoef(x, bias=1), expected)
 
@@ -873,8 +867,8 @@ class TestCorrcoef(TestCase):
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with catch_warn_mae():
-            warnings.simplefilter("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
 
@@ -884,8 +878,8 @@ class TestCorrcoef(TestCase):
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with catch_warn_mae():
-            warnings.simplefilter("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
 
@@ -898,8 +892,8 @@ class TestCorrcoef(TestCase):
         assert_almost_equal(np.corrcoef(nx), corrcoef(x))
         assert_almost_equal(np.corrcoef(nx, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with catch_warn_mae():
-            warnings.simplefilter("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             assert_almost_equal(np.corrcoef(nx, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
         try:
@@ -911,8 +905,8 @@ class TestCorrcoef(TestCase):
         assert_almost_equal(np.corrcoef(nx, nx[::-1]), corrcoef(x, x[::-1]))
         assert_almost_equal(np.corrcoef(nx, nx[::-1], rowvar=False),
                             corrcoef(x, x[::-1], rowvar=False))
-        with catch_warn_mae():
-            warnings.simplefilter("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             # ddof and bias have no or negligible effect on the function
             assert_almost_equal(np.corrcoef(nx, nx[::-1]),
                                 corrcoef(x, x[::-1], bias=1))
@@ -928,8 +922,8 @@ class TestCorrcoef(TestCase):
         test = corrcoef(x)
         control = np.corrcoef(x)
         assert_almost_equal(test[:-1, :-1], control[:-1, :-1])
-        with catch_warn_mae():
-            warnings.simplefilter("ignore")
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             # ddof and bias have no or negligible effect on the function
             assert_almost_equal(corrcoef(x, ddof=-2)[:-1, :-1],
                                 control[:-1, :-1])

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -764,7 +764,7 @@ class TestCov(TestCase):
     def setUp(self):
         self.data = array(np.random.rand(12))
 
-    def test_1d_wo_missing(self):
+    def test_1d_without_missing(self):
         # Test cov on 1D variable w/o missing values
         x = self.data
         assert_almost_equal(np.cov(x), cov(x))
@@ -772,7 +772,7 @@ class TestCov(TestCase):
         assert_almost_equal(np.cov(x, rowvar=False, bias=True),
                             cov(x, rowvar=False, bias=True))
 
-    def test_2d_wo_missing(self):
+    def test_2d_without_missing(self):
         # Test cov on 1 2D variable w/o missing values
         x = self.data.reshape(3, 4)
         assert_almost_equal(np.cov(x), cov(x))
@@ -780,7 +780,7 @@ class TestCov(TestCase):
         assert_almost_equal(np.cov(x, rowvar=False, bias=True),
                             cov(x, rowvar=False, bias=True))
 
-    def test_1d_w_missing(self):
+    def test_1d_with_missing(self):
         # Test cov 1 1D variable w/missing values
         x = self.data
         x[-1] = masked
@@ -804,7 +804,7 @@ class TestCov(TestCase):
         assert_almost_equal(np.cov(nx, nx[::-1], rowvar=False, bias=True),
                             cov(x, x[::-1], rowvar=False, bias=True))
 
-    def test_2d_w_missing(self):
+    def test_2d_with_missing(self):
         # Test cov on 2D variable w/ missing value
         x = self.data
         x[-1] = masked
@@ -861,7 +861,7 @@ class TestCorrcoef(TestCase):
             # bias has no or negligible effect on the function
             assert_almost_equal(corrcoef(x, bias=1), expected)
 
-    def test_1d_wo_missing(self):
+    def test_1d_without_missing(self):
         # Test cov on 1D variable w/o missing values
         x = self.data
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
@@ -872,7 +872,7 @@ class TestCorrcoef(TestCase):
             assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
 
-    def test_2d_wo_missing(self):
+    def test_2d_without_missing(self):
         # Test corrcoef on 1 2D variable w/o missing values
         x = self.data.reshape(3, 4)
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
@@ -883,7 +883,7 @@ class TestCorrcoef(TestCase):
             assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
 
-    def test_1d_w_missing(self):
+    def test_1d_with_missing(self):
         # Test corrcoef 1 1D variable w/missing values
         x = self.data
         x[-1] = masked
@@ -913,7 +913,7 @@ class TestCorrcoef(TestCase):
             assert_almost_equal(np.corrcoef(nx, nx[::-1]),
                                 corrcoef(x, x[::-1], ddof=2))
 
-    def test_2d_w_missing(self):
+    def test_2d_with_missing(self):
         # Test corrcoef on 2D variable w/ missing value
         x = self.data
         x[-1] = masked

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -148,11 +148,9 @@ class TestMRecords(TestCase):
         rdata = data.view(MaskedRecords)
         val = ma.array([10, 20, 30], mask=[1, 0, 0])
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            rdata['num'] = val
-            assert_equal(rdata.num, val)
-            assert_equal(rdata.num.mask, [1, 0, 0])
+        rdata['num'] = val
+        assert_equal(rdata.num, val)
+        assert_equal(rdata.num.mask, [1, 0, 0])
 
     def test_set_fields_mask(self):
         # Tests setting the mask of a field.

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -4,7 +4,8 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_, TestCase, assert_array_equal,
-                           assert_allclose, run_module_suite)
+                           assert_allclose, run_module_suite,
+                           suppress_warnings)
 from numpy.compat import sixu
 
 rlevel = 1
@@ -69,8 +70,9 @@ class TestRegression(TestCase):
         # See gh-3336
         x = np.ma.masked_equal([1, 2, 3, 4, 5], 4)
         y = np.array([2, 2.5, 3.1, 3, 5])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        # this test can be removed after deprecation.
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "bias and ddof have no effect")
             r0 = np.ma.corrcoef(x, y, ddof=0)
             r1 = np.ma.corrcoef(x, y, ddof=1)
             # ddof should not have an effect (it gets cancelled out)

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -14,7 +14,7 @@ from numpy import ndarray, float_
 import numpy.core.umath as umath
 from numpy.testing import (
     TestCase, assert_, assert_allclose, assert_array_almost_equal_nulp,
-    assert_raises, build_err_msg, run_module_suite,
+    assert_raises, build_err_msg, run_module_suite, suppress_warnings
     )
 import numpy.testing.utils as utils
 from .core import mask_or, getmask, masked_array, nomask, masked, filled
@@ -126,8 +126,10 @@ def assert_equal(actual, desired, err_msg=''):
         return _assert_equal_on_sequences(actual, desired, err_msg='')
     if not (isinstance(actual, ndarray) or isinstance(desired, ndarray)):
         msg = build_err_msg([actual, desired], err_msg,)
-        if not desired == actual:
-            raise AssertionError(msg)
+        with suppress_warnings() as sup:
+            sup.filter(FutureWarning, ".*NAT ==")
+            if not desired == actual:
+                raise AssertionError(msg)
         return
     # Case #4. arrays or equivalent
     if ((actual is masked) and not (desired is masked)) or \

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -3,7 +3,8 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.testing import (
         TestCase, run_module_suite, assert_, assert_raises, assert_equal,
-        assert_warns, assert_array_equal, assert_array_almost_equal)
+        assert_warns, assert_array_equal, assert_array_almost_equal,
+        suppress_warnings)
 from numpy import random
 from numpy.compat import asbytes
 import sys
@@ -260,13 +261,14 @@ class TestRandomDist(TestCase):
 
     def test_random_integers(self):
         np.random.seed(self.seed)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+        with suppress_warnings() as sup:
+            w = sup.record(DeprecationWarning)
             actual = np.random.random_integers(-99, 99, size=(3, 2))
-            desired = np.array([[31, 3],
-                                [-52, 41],
-                                [-48, -66]])
-            assert_array_equal(actual, desired)
+            assert_(len(w) == 1)
+        desired = np.array([[31, 3],
+                            [-52, 41],
+                            [-48, -66]])
+        assert_array_equal(actual, desired)
 
     def test_random_integers_max_int(self):
         # Tests whether random_integers can generate the
@@ -274,12 +276,14 @@ class TestRandomDist(TestCase):
         # into a C long. Previous implementations of this
         # method have thrown an OverflowError when attempting
         # to generate this integer.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+        with suppress_warnings() as sup:
+            w = sup.record(DeprecationWarning)
             actual = np.random.random_integers(np.iinfo('l').max,
                                                np.iinfo('l').max)
-            desired = np.iinfo('l').max
-            assert_equal(actual, desired)
+            assert_(len(w) == 1)
+
+        desired = np.iinfo('l').max
+        assert_equal(actual, desired)
 
     def test_random_integers_deprecated(self):
         with warnings.catch_warnings():

--- a/numpy/testing/decorators.py
+++ b/numpy/testing/decorators.py
@@ -15,10 +15,10 @@ function name, setup and teardown functions and so on - see
 """
 from __future__ import division, absolute_import, print_function
 
-import warnings
 import collections
 
-from .utils import SkipTest
+from .utils import SkipTest, assert_warns
+
 
 def slow(t):
     """
@@ -251,15 +251,8 @@ def deprecated(conditional=True):
 
         def _deprecated_imp(*args, **kwargs):
             # Poor man's replacement for the with statement
-            with warnings.catch_warnings(record=True) as l:
-                warnings.simplefilter('always')
+            with assert_warns(DeprecationWarning):
                 f(*args, **kwargs)
-                if not len(l) > 0:
-                    raise AssertionError("No warning raised when calling %s"
-                            % f.__name__)
-                if not l[0].category is DeprecationWarning:
-                    raise AssertionError("First warning for %s is not a "
-                            "DeprecationWarning( is %s)" % (f.__name__, l[0]))
 
         if isinstance(conditional, collections.Callable):
             cond = conditional()

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -1,8 +1,10 @@
 from __future__ import division, absolute_import, print_function
 
+import warnings
+
 from numpy.testing import (dec, assert_, assert_raises, run_module_suite,
                            SkipTest, KnownFailureException)
-import nose
+
 
 def test_slow():
     @dec.slow
@@ -172,10 +174,12 @@ def test_deprecated():
     assert_raises(AssertionError, non_deprecated_func)
     # should be silent
     deprecated_func()
-    # fails if deprecated decorator just disables test. See #1453.
-    assert_raises(ValueError, deprecated_func2)
-    # first warnings is not a DeprecationWarning
-    assert_raises(AssertionError, deprecated_func3)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")  # do not propagate unrelated warnings
+        # fails if deprecated decorator just disables test. See #1453.
+        assert_raises(ValueError, deprecated_func2)
+        # warning is not a DeprecationWarning
+        assert_raises(AssertionError, deprecated_func3)
 
 
 if __name__ == '__main__':

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -503,23 +503,21 @@ class TestWarns(unittest.TestCase):
             warnings.warn("yo", DeprecationWarning)
 
         failed = False
-        filters = sys.modules['warnings'].filters[:]
-        try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
             try:
-                # Should raise an AssertionError
+                # Should raise a DeprecationWarning
                 assert_warns(UserWarning, f)
                 failed = True
-            except AssertionError:
+            except DeprecationWarning:
                 pass
-        finally:
-            sys.modules['warnings'].filters = filters
 
         if failed:
             raise AssertionError("wrong warning caught by assert_warn")
 
 
 class TestAssertAllclose(unittest.TestCase):
-    
+
     def test_simple(self):
         x = 1e-3
         y = 1e-9

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -396,8 +396,12 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
         pass
 
     # Explicitly use __eq__ for comparison, ticket #2552
-    if not (desired == actual):
-        raise AssertionError(msg)
+    with suppress_warnings() as sup:
+        # TODO: Better handling will to needed when change happens!
+        sup.filter(DeprecationWarning, ".*NAT ==")
+        sup.filter(FutureWarning, ".*NAT ==")
+        if not (desired == actual):
+            raise AssertionError(msg)
 
 
 def print_assert_equal(test_string, actual, desired):
@@ -687,8 +691,9 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
         # pass (or maybe eventually catch the errors and return False, I
         # dunno, that's a little trickier and we can figure that out when the
         # time comes).
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, ".*==")
+            sup.filter(FutureWarning, ".*==")
             return comparison(*args, **kwargs)
 
     def isnumber(x):

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1658,16 +1658,12 @@ class WarningManager(object):
 @contextlib.contextmanager
 def _assert_warns_context(warning_class, name=None):
     __tracebackhide__ = True  # Hide traceback for py.test
-    with warnings.catch_warnings(record=True) as l:
-        warnings.simplefilter('always')
+    with suppress_warnings() as sup:
+        l = sup.record(warning_class)
         yield
         if not len(l) > 0:
             name_str = " when calling %s" % name if name is not None else ""
             raise AssertionError("No warning raised" + name_str)
-        if not l[0].category is warning_class:
-            name_str = "%s " % name if name is not None else ""
-            raise AssertionError("First warning %sis not a %s (is %s)"
-                                 % (name_str, warning_class, l[0]))
 
 
 def assert_warns(warning_class, *args, **kwargs):
@@ -1676,8 +1672,7 @@ def assert_warns(warning_class, *args, **kwargs):
 
     A warning of class warning_class should be thrown by the callable when
     invoked with arguments args and keyword arguments kwargs.
-    If a different type of warning is thrown, it will not be caught, and the
-    test case will be deemed to have suffered an error.
+    If a different type of warning is thrown, it will not be caught.
 
     If called with all arguments other than the warning class omitted, may be
     used as a context manager:

--- a/runtests.py
+++ b/runtests.py
@@ -113,7 +113,7 @@ def main(argv):
                               "Note that you need to commit your changes first!"))
     parser.add_argument("--raise-warnings", default=None, type=str,
                         choices=('develop', 'release'),
-                        help="if 'develop', some warnings are treated as errors")
+                        help="if 'develop', warnings are treated as errors")
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
     args = parser.parse_args(argv)


### PR DESCRIPTION
OK, this is a start, a context manager to suppress warnings a little better (nothing is prefect, though maybe I am missing something). And trying to remove all those "ignore" stuff everywhere mostly.

A few quite general warnings are still suppressed globally (where possible, sometimes needs local duplication), that may be fine. The switch to only show warnings in release mode is missing, and since some things never showed warnings for me, I sometimes removed it completely. This is not beta or rc, but I think you can get the idea.
