### PR TITLE
DOC: update Python versions requirements in the install docs

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -14,8 +14,8 @@ Prerequisites
 
 Building NumPy requires the following software installed:
 
-1) For Python 2, Python__ 2.6.x or newer.
-   For Python 3, Python__ 3.2.x or newer.
+1) For Python 2, Python__ 2.7.x or newer.
+   For Python 3, Python__ 3.4.x or newer.
 
    On Debian and derivative (Ubuntu): python python-dev
 


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/7108

By the way, I'm not sure about the Cython requirement. Would it be worth adding a CI configuration that uses the oldest supported Cython?
