### PR TITLE
CI: does Cython 0.19 really work?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_install:
   - pip install nose
   # pip install coverage
   # Speed up install by not compiling Cython
-  - pip install --install-option="--no-cython-compile" Cython
+  - pip install --install-option="--no-cython-compile" Cython==0.19
   - if [ -n "$USE_ASV" ]; then pip install asv; fi
   - popd
 


### PR DESCRIPTION
This test PR hardcodes Cython==0.19, so it probably would not make sense to merge.

The numpy docs say that this is the oldest supported Cython. Check it on TravisCI.
