### PR TITLE
BUG: Fixed mingw.lib error

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -313,7 +313,7 @@ class Gnu95FCompiler(GnuFCompiler):
                 if target:
                     d = os.path.normpath(self.get_libgcc_dir())
                     root = os.path.join(d, *((os.pardir,)*4))
-                    path = os.path.join(root, target, "lib")
+                    path = os.path.join(root, "lib")
                     mingwdir = os.path.normpath(path)
                     if os.path.exists(os.path.join(mingwdir, "libmingwex.a")):
                         opt.append(mingwdir)


### PR DESCRIPTION
Addresses issue in #647 in which attempts to compile `numpy` with MinGW and Fortran result in a missing `mingw.lib` error.  Implemented the change proposed in that issue, tested locally on my machine, and all tests pass.
