### PR TITLE
BUG: Fixed 'midpoint' interpolation of np.percentile in odd cases.

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -32,8 +32,13 @@ default order for arrays that are now both.
 
 ``MaskedArray`` takes view of data **and** mask when slicing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 XXX
+
+
+``np.percentile`` 'midpoint' interpolation method fixed for exact indices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'midpoint' interpolator now gives the same result as 'lower' and 'higher' when
+the two coincide. Previous behavior of 'lower' + 0.5 is fixed.
 
 
 DeprecationWarning to error

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3541,7 +3541,7 @@ def _percentile(a, q, axis=None, out=None,
     elif interpolation == 'higher':
         indices = ceil(indices).astype(intp)
     elif interpolation == 'midpoint':
-        indices = floor(indices) + 0.5
+        indices = 0.5 * (floor(indices) + ceil(indices))
     elif interpolation == 'nearest':
         indices = around(indices).astype(intp)
     elif interpolation == 'linear':

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2055,7 +2055,7 @@ def compare_results(res, desired):
         assert_array_equal(res[i], desired[i])
 
 
-class TestScoreatpercentile(TestCase):
+class TestPercentile(TestCase):
 
     def test_basic(self):
         x = np.arange(8) * 0.5
@@ -2104,6 +2104,10 @@ class TestScoreatpercentile(TestCase):
     def test_midpoint(self):
         assert_equal(np.percentile(range(10), 51,
                                    interpolation='midpoint'), 4.5)
+        assert_equal(np.percentile(range(11), 51,
+                                   interpolation='midpoint'), 5.5)
+        assert_equal(np.percentile(range(11), 50,
+                                   interpolation='midpoint'), 5)
 
     def test_nearest(self):
         assert_equal(np.percentile(range(10), 51,


### PR DESCRIPTION
`interpolation='midpoint'` must return the same as `interpolation='higher'` and `interpolation='lower'` when the two are the same, not 'lower' + 0.5 as it was doing.

Another way of putting it: the 50th percentile of an array with an odd number of elements is the middle of the (sorted) array, no matter what the `interpolation` argument is.

I updated the test to deal with odd instead of even number of elements in the input array.

If this fix gets backported, it should go back as far as 1.0.9, when the `interpolation` keyword was introduced.
