### PR TITLE
ENH: savez: temporary file alongside with target file and improve exception message upon IOError

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -644,6 +644,8 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
                 fid.close()
                 fid = None
                 zipf.write(tmpfile, arcname=fname)
+            except IOError as exc:
+                raise IOError("Failed to write to %s: %s" % (tmpfile, exc))
             finally:
                 if fid:
                     fid.close()

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -630,8 +630,8 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
 
     # Since target file might be big enough to exceed capacity of a global
     # temporary directory, create temp file side-by-side with the target file.
-    file_path, file_name = os.path.split(file)
-    fd, tmpfile = tempfile.mkstemp(prefix=file_name, dir=file_path, suffix='-numpy.npy')
+    file_dir, file_prefix = os.path.split(file) if _is_string_like(file) else (None, 'tmp')
+    fd, tmpfile = tempfile.mkstemp(prefix=file_prefix, dir=file_dir, suffix='-numpy.npy')
     os.close(fd)
     try:
         for key, val in namedict.items():

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -627,7 +627,11 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
     zipf = zipfile_factory(file, mode="w", compression=compression)
 
     # Stage arrays in a temporary file on disk, before writing to zip.
-    fd, tmpfile = tempfile.mkstemp(suffix='-numpy.npy')
+
+    # Since target file might be big enough to exceed capacity of a global
+    # temporary directory, create temp file side-by-side with the target file.
+    file_path, file_name = os.path.split(file)
+    fd, tmpfile = tempfile.mkstemp(prefix=file_name, dir=file_path, suffix='-numpy.npy')
     os.close(fd)
     try:
         for key, val in namedict.items():


### PR DESCRIPTION
Should fully resolve #5336 -- for output of large files temporary files would be created alongside with target ones, so it would be logical to expect sufficient amount of storage available (unlike under TEMPDIR).  Also error message would carry the filename of the tempfile in question which could better direct user toward possible problems on the target partition.

I haven't tested it locally, neither looked into where to provide such a test -- let's see first if travis says Ok.  If testing desired -- point to location where to provide one. Cheers!
