### PR TITLE
BUG: Unpickled void scalars should be contiguous

### DIFF
--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -799,7 +799,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             Py_INCREF(descr);
             vobj->obval = NULL;
             Py_SIZE(vobj) = itemsize;
-            vobj->flags = NPY_ARRAY_BEHAVED | NPY_ARRAY_OWNDATA;
+            vobj->flags = NPY_ARRAY_CARRAY | NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_OWNDATA;
             swap = 0;
             if (PyDataType_HASFIELDS(descr)) {
                 if (base) {

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -299,6 +299,13 @@ class TestRecord(TestCase):
         assert_equal(a, pickle.loads(pickle.dumps(a)))
         assert_equal(a[0], pickle.loads(pickle.dumps(a[0])))
 
+    def test_pickle_3(self):
+        # Issue #7140
+        a = self.data
+        pa = pickle.loads(pickle.dumps(a[0]))
+        assert_(pa.flags.c_contiguous)
+        assert_(pa.flags.f_contiguous)
+
     def test_objview_record(self):
         # https://github.com/numpy/numpy/issues/2599
         dt = np.dtype([('foo', 'i8'), ('bar', 'O')])

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -305,6 +305,8 @@ class TestRecord(TestCase):
         pa = pickle.loads(pickle.dumps(a[0]))
         assert_(pa.flags.c_contiguous)
         assert_(pa.flags.f_contiguous)
+        assert_(pa.flags.writeable)
+        assert_(pa.flags.aligned)
 
     def test_objview_record(self):
         # https://github.com/numpy/numpy/issues/2599


### PR DESCRIPTION
Void scalars are both C- and Fortran-contiguous, so pickling and
unpickling them should result in a new void scalar that also has
these flags set. Fixes #7140.
