### PR TITLE
MAINT: Change `call_fortran` into `callfortran` in comments.

### DIFF
--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -15,7 +15,7 @@ wrapper_function(args)
     get_b_from_python
     if (successful) {
 
-      call_fortran
+      callfortran
       if (successful) {
 
         put_a_to_python


### PR DESCRIPTION
It was committed mistakenly in #7134. `callfortran` is used a lot really.
