### PR TITLE
BUG: Fixed regressions in np.piecewise in ref to #5737 and #5729.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -944,9 +944,10 @@ def piecewise(x, condlist, funclist, *args, **kw):
             condlist = condlist.T
     if n == n2 - 1:  # compute the "otherwise" condition.
         totlist = np.logical_or.reduce(condlist, axis=0)
-        try:
+        # Only able to stack vertically if the array is 1d or less
+        if x.ndim <= 1:
             condlist = np.vstack([condlist, ~totlist])
-        except:
+        else:
             condlist = [asarray(c, dtype=bool) for c in condlist]
             totlist = condlist[0]
             for k in range(1, n):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -944,11 +944,15 @@ def piecewise(x, condlist, funclist, *args, **kw):
             condlist = condlist.T
     if n == n2 - 1:  # compute the "otherwise" condition.
         totlist = np.logical_or.reduce(condlist, axis=0)
-        condlist = np.vstack([condlist, ~totlist])
+        try:
+            condlist = np.vstack([condlist, ~totlist])
+        except:
+            condlist = [asarray(c, dtype=bool) for c in condlist]
+            totlist = condlist[0]
+            for k in range(1, n):
+                totlist |= condlist[k]
+            condlist.append(~totlist)
         n += 1
-    if (n != n2):
-        raise ValueError(
-                "function list and condition list must be the same")
 
     y = zeros(x.shape, x.dtype)
     for k in range(n):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1862,6 +1862,10 @@ class TestPiecewise(TestCase):
         x = piecewise([1, 2], [[True, False], [False, True]], [3, 4])
         assert_array_equal(x, [3, 4])
 
+    def test_scalar_domains_three_conditions(self):
+        x = piecewise(3, [True, False, False], [4, 2, 0])
+        assert_equal(x, 4)
+
     def test_default(self):
         # No value specified for x[1], should be 0
         x = piecewise([1, 2], [True, False], [2])
@@ -1885,6 +1889,13 @@ class TestPiecewise(TestCase):
     def test_0d_comparison(self):
         x = 3
         piecewise(x, [x <= 3, x > 3], [4, 0])  # Should succeed.
+
+    def test_multidimensional_extrafunc(self):
+        x = np.array([[-2.5, -1.5, -0.5],
+                      [0.5, 1.5, 2.5]])
+        y = piecewise(x, [x < 0, x >= 2], [-1, 1, 3])
+        assert_array_equal(y, np.array([[-1., -1., -1.],
+                                        [3., 3., 1.]]))
 
 
 class TestBincount(TestCase):


### PR DESCRIPTION
Fixed regressions in np.piecewise that were generated as a result of the 0d fixes in #4792.

Unit tests were appropriately added.

The fix for #5737 was created by reusing the old condition creation method which works better for multidimensional arrays.

The fix for #5729 was created by removing the n != n2 as it is not necessary and piecewise still works with the same expected behavior (confirmed via unit tests).
