### PR TITLE
Temporarily disable __numpy_ufunc__

### DIFF
--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -198,6 +198,12 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     /* Pos of each override in args */
     int with_override_pos[NPY_MAXARGS];
 
+    /* 2016-01-29: Disable for now in master -- can re-enable once details are
+     * sorted out. All commented bits are tagged NUMPY_UFUNC_DISABLED. -njs
+     */
+    result = NULL;
+    return 0;
+
     /*
      * Check inputs
      */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4615,24 +4615,6 @@ class TestDot(TestCase):
         assert_equal(np.dot(arr, 3), desired)
         assert_equal(np.dot(3, arr), desired)
 
-    def test_dot_override(self):
-        class A(object):
-            def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
-                return "A"
-
-        class B(object):
-            def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
-                return NotImplemented
-
-        a = A()
-        b = B()
-        c = np.array([[1]])
-
-        assert_equal(np.dot(a, b), "A")
-        assert_equal(c.dot(a), "A")
-        assert_raises(TypeError, np.dot, b, c)
-        assert_raises(TypeError, c.dot, b)
-
     def test_accelerate_framework_sgemv_fix(self):
 
         def aligned_array(shape, align, dtype, order='C'):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2136,6 +2136,9 @@ class TestMethods(TestCase):
         assert_equal(c, np.dot(a, b))
 
     def test_dot_override(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
+
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
                 return "A"
@@ -2543,6 +2546,9 @@ class TestBinop(object):
         assert_array_equal(res, l[4] + l[4])
 
     def test_ufunc_override_rop_precedence(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
+
         # Check that __rmul__ and other right-hand operations have
         # precedence over __numpy_ufunc__
 
@@ -2661,6 +2667,9 @@ class TestBinop(object):
             yield check, op_name, False
 
     def test_ufunc_override_rop_simple(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
+
         # Check parts of the binary op overriding behavior in an
         # explicit test case that is easier to understand.
         class SomeClass(object):
@@ -2765,6 +2774,9 @@ class TestBinop(object):
         assert_(isinstance(res, SomeClass3))
 
     def test_ufunc_override_normalize_signature(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
+
         # gh-5674
         class SomeClass(object):
             def __numpy_ufunc__(self, ufunc, method, i, inputs, **kw):
@@ -2781,6 +2793,9 @@ class TestBinop(object):
         assert_equal(kw['signature'], 'ii->i')
 
     def test_numpy_ufunc_index(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
+
         # Check that index is set appropriately, also if only an output
         # is passed on (latter is another regression tests for github bug 4753)
         class CheckIndex(object):
@@ -2818,6 +2833,9 @@ class TestBinop(object):
         assert_equal(np.add(a, dummy, out=a), 0)
 
     def test_out_override(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
+
         # regression test for github bug 4753
         class OutClass(np.ndarray):
             def __numpy_ufunc__(self, ufunc, method, i, inputs, **kw):
@@ -4875,6 +4893,8 @@ class MatmulCommon():
         assert_equal(res, tgt12_21)
 
     def test_numpy_ufunc_override(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
 
         class A(np.ndarray):
             def __new__(cls, *args, **kwargs):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1215,7 +1215,24 @@ class TestSpecialMethods(TestCase):
         assert_equal(ncu.maximum(a, B()), 0)
         assert_equal(ncu.maximum(a, C()), 0)
 
+    def test_ufunc_override_disabled(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        # This test should be removed when __numpy_ufunc__ is re-enabled.
+
+        class MyArray(object):
+            def __numpy_ufunc__(self, *args, **kwargs):
+                self._numpy_ufunc_called = True
+
+        my_array = MyArray()
+        real_array = np.ones(10)
+        assert_raises(TypeError, lambda: real_array + my_array)
+        assert_raises(TypeError, np.add, real_array, my_array)
+        assert not hasattr(my_array, "_numpy_ufunc_called")
+
+
     def test_ufunc_override(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
 
         class A(object):
             def __numpy_ufunc__(self, func, method, pos, inputs, **kwargs):
@@ -1241,6 +1258,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res1[5], {})
 
     def test_ufunc_override_mro(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
 
         # Some multi arg functions for testing.
         def tres_mul(a, b, c):
@@ -1332,6 +1351,8 @@ class TestSpecialMethods(TestCase):
         assert_raises(TypeError, four_mul_ufunc, 1, c, c_sub, c)
 
     def test_ufunc_override_methods(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
 
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
@@ -1436,6 +1457,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res[4], (a, [4, 2], 'b0'))
 
     def test_ufunc_override_out(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
 
         class A(object):
             def __numpy_ufunc__(self, ufunc, method, pos, inputs, **kwargs):
@@ -1470,6 +1493,8 @@ class TestSpecialMethods(TestCase):
         assert_equal(res7['out'][1], 'out1')
 
     def test_ufunc_override_exception(self):
+        # 2016-01-29: NUMPY_UFUNC_DISABLED
+        return
 
         class A(object):
             def __numpy_ufunc__(self, *a, **kwargs):


### PR DESCRIPTION
Given that we accidentally released 1.11b2 with `__numpy_ufunc__` still
enabled, we should probably just disable it in master for now.

When ready to re-enable, grep for NUMPY_UFUNC_DISABLED. Or just revert
bac094c.

Note that this pull request also contains an additional commit that
removes a duplicate test -- that doesn't need reverting.

Needs backport to 1.11 branch.
