### PR TITLE
ENH: Make 'low' optional in randint

### DIFF
--- a/benchmarks/benchmarks/bench_random.py
+++ b/benchmarks/benchmarks/bench_random.py
@@ -34,11 +34,11 @@ class Randint(Benchmark):
 
     def time_randint_fast(self):
         """Compare to uint32 below"""
-        np.random.randint(0, 2**30, size=10**5)
+        np.random.randint(low=0, high=2**30, size=10**5)
 
     def time_randint_slow(self):
         """Compare to uint32 below"""
-        np.random.randint(0, 2**30 + 1, size=10**5)
+        np.random.randint(low=0, high=2**30 + 1, size=10**5)
 
 
 class Randint_dtype(Benchmark):
@@ -59,9 +59,9 @@ class Randint_dtype(Benchmark):
 
     def time_randint_fast(self, name):
         high = self.high[name]
-        np.random.randint(0, high, size=10**5, dtype=name)
+        np.random.randint(low=0, high=high, size=10**5, dtype=name)
 
     def time_randint_slow(self, name):
         high = self.high[name]
-        np.random.randint(0, high + 1, size=10**5, dtype=name)
+        np.random.randint(low=0, high=high + 1, size=10**5, dtype=name)
 

--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -104,5 +104,17 @@ Added 'doane' and 'sqrt' estimators to ``histogram`` via the ``bins`` argument.
 Changes
 =======
 
+``np.randint`` can handle more ``low=None`` and ``high=None`` combinations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If ``low=None`` and ``high=None``, random numbers will be generated over the
+range [``lowbnd``, ``highbnd``), where ``lowbnd`` and ``highbnd`` equal
+``np.iinfo(dtype).min`` and ``np.iinfo(dtype).max`` respectively.
+
+If only ``low=None``, random numbers will be generated over the range [``lowbnd``,
+``high``), where ``lowbnd`` is defined as previously. If only ``high=None``, random
+numbers will still be generated over the range [``0``, ``low``) provided ``low`` >= 0.
+Otherwise, numbers will be generated over [``low``, ``highbnd``), where ``highbnd`` is
+defined as previously.
+
 Deprecations
 ============

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3680,7 +3680,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('item',
 
     Examples
     --------
-    >>> x = np.random.randint(9, size=(3, 3))
+    >>> x = np.random.randint(low=9, size=(3, 3))
     >>> x
     array([[3, 1, 7],
            [2, 8, 3],

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -110,19 +110,19 @@ def test_diophantine_fuzz():
         numbers = []
         while min(feasible_count, infeasible_count) < min_count:
             # Ensure big and small integer problems
-            A_max = 1 + rng.randint(0, 11, dtype=np.intp)**6
-            U_max = rng.randint(0, 11, dtype=np.intp)**6
+            A_max = 1 + rng.randint(low=0, high=11, dtype=np.intp)**6
+            U_max = rng.randint(low=0, high=11, dtype=np.intp)**6
 
             A_max = min(max_int, A_max)
             U_max = min(max_int-1, U_max)
 
-            A = tuple(rng.randint(1, A_max+1, dtype=np.intp)
+            A = tuple(rng.randint(low=1, high=A_max+1, dtype=np.intp)
                       for j in range(ndim))
-            U = tuple(rng.randint(0, U_max+2, dtype=np.intp)
+            U = tuple(rng.randint(low=0, high=U_max+2, dtype=np.intp)
                       for j in range(ndim))
 
             b_ub = min(max_int-2, sum(a*ub for a, ub in zip(A, U)))
-            b = rng.randint(-1, b_ub+2, dtype=np.intp)
+            b = rng.randint(low=-1, high=b_ub+2, dtype=np.intp)
 
             if ndim == 0 and feasible_count < min_count:
                 b = 0
@@ -260,9 +260,9 @@ def check_may_share_memory_easy_fuzz(get_max_work, same_steps, min_count):
     rng = np.random.RandomState(1234)
 
     def random_slice(n, step):
-        start = rng.randint(0, n+1, dtype=np.intp)
-        stop = rng.randint(start, n+1, dtype=np.intp)
-        if rng.randint(0, 2, dtype=np.intp) == 0:
+        start = rng.randint(low=0, high=n+1, dtype=np.intp)
+        stop = rng.randint(low=start, high=n+1, dtype=np.intp)
+        if rng.randint(low=0, high=2, dtype=np.intp) == 0:
             stop, start = start, stop
             step *= -1
         return slice(start, stop, step)
@@ -271,14 +271,14 @@ def check_may_share_memory_easy_fuzz(get_max_work, same_steps, min_count):
     infeasible = 0
 
     while min(feasible, infeasible) < min_count:
-        steps = tuple(rng.randint(1, 11, dtype=np.intp)
-                      if rng.randint(0, 5, dtype=np.intp) == 0 else 1
+        steps = tuple(rng.randint(low=1, high=11, dtype=np.intp)
+                      if rng.randint(low=0, high=5, dtype=np.intp) == 0 else 1
                       for j in range(x.ndim))
         if same_steps:
             steps2 = steps
         else:
-            steps2 = tuple(rng.randint(1, 11, dtype=np.intp)
-                           if rng.randint(0, 5, dtype=np.intp) == 0 else 1
+            steps2 = tuple(rng.randint(low=1, high=11, dtype=np.intp)
+                           if rng.randint(low=0, high=5, dtype=np.intp) == 0 else 1
                            for j in range(x.ndim))
 
         t1 = np.arange(x.ndim)
@@ -378,9 +378,9 @@ def test_internal_overlap_slices():
     rng = np.random.RandomState(1234)
 
     def random_slice(n, step):
-        start = rng.randint(0, n+1, dtype=np.intp)
-        stop = rng.randint(start, n+1, dtype=np.intp)
-        if rng.randint(0, 2, dtype=np.intp) == 0:
+        start = rng.randint(low=0, high=n+1, dtype=np.intp)
+        stop = rng.randint(low=start, high=n+1, dtype=np.intp)
+        if rng.randint(low=0, high=2, dtype=np.intp) == 0:
             stop, start = start, stop
             step *= -1
         return slice(start, stop, step)
@@ -389,8 +389,8 @@ def test_internal_overlap_slices():
     min_count = 5000
 
     while cases < min_count:
-        steps = tuple(rng.randint(1, 11, dtype=np.intp)
-                      if rng.randint(0, 5, dtype=np.intp) == 0 else 1
+        steps = tuple(rng.randint(low=1, high=11, dtype=np.intp)
+                      if rng.randint(low=0, high=5, dtype=np.intp) == 0 else 1
                       for j in range(x.ndim))
         t1 = np.arange(x.ndim)
         rng.shuffle(t1)
@@ -474,11 +474,11 @@ def test_internal_overlap_fuzz():
     rng = np.random.RandomState(1234)
 
     while min(overlap, no_overlap) < min_count:
-        ndim = rng.randint(1, 4, dtype=np.intp)
+        ndim = rng.randint(low=1, high=4, dtype=np.intp)
 
-        strides = tuple(rng.randint(-1000, 1000, dtype=np.intp)
+        strides = tuple(rng.randint(low=-1000, high=1000, dtype=np.intp)
                         for j in range(ndim))
-        shape = tuple(rng.randint(1, 30, dtype=np.intp)
+        shape = tuple(rng.randint(low=1, high=30, dtype=np.intp)
                       for j in range(ndim))
 
         a = as_strided(x, strides=strides, shape=shape)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2017,8 +2017,8 @@ class TestMethods(TestCase):
             for i in range(1, j - 2):
                 d = np.arange(j)
                 np.random.shuffle(d)
-                d = d % np.random.randint(2, 30)
-                idx = np.random.randint(d.size)
+                d = d % np.random.randint(low=2, high=30)
+                idx = np.random.randint(low=d.size)
                 kth = [0, idx, i, i + 1]
                 tgt = np.sort(d)[kth]
                 assert_array_equal(np.partition(d, kth)[kth], tgt,

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1004,8 +1004,8 @@ class TestIndex(TestCase):
     def test_boolean(self):
         a = rand(3, 5, 8)
         V = rand(5, 8)
-        g1 = randint(0, 5, size=15)
-        g2 = randint(0, 8, size=15)
+        g1 = randint(low=0, high=5, size=15)
+        g2 = randint(low=0, high=8, size=15)
         V[g1, g2] = -V[g1, g2]
         assert_((np.array([a[0][V > 0], a[1][V > 0], a[2][V > 0]]) == a[:, V > 0]).all())
 

--- a/numpy/lib/tests/test_arrayterator.py
+++ b/numpy/lib/tests/test_arrayterator.py
@@ -13,13 +13,13 @@ def test():
     np.random.seed(np.arange(10))
 
     # Create a random array
-    ndims = randint(5)+1
-    shape = tuple(randint(10)+1 for dim in range(ndims))
+    ndims = randint(low=5)+1
+    shape = tuple(randint(low=10)+1 for dim in range(ndims))
     els = reduce(mul, shape)
     a = np.arange(els)
     a.shape = shape
 
-    buf_size = randint(2*els)
+    buf_size = randint(low=2*els)
     b = Arrayterator(a, buf_size)
 
     # Check that each block has at most ``buf_size`` elements
@@ -30,9 +30,9 @@ def test():
     assert_(list(b.flat) == list(a.flat))
 
     # Slice arrayterator
-    start = [randint(dim) for dim in shape]
-    stop = [randint(dim)+1 for dim in shape]
-    step = [randint(dim)+1 for dim in shape]
+    start = [randint(low=dim) for dim in shape]
+    stop = [randint(low=dim)+1 for dim in shape]
+    step = [randint(low=dim)+1 for dim in shape]
     slice_ = tuple(slice(*t) for t in zip(start, stop, step))
     c = b[slice_]
     d = a[slice_]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2571,7 +2571,7 @@ class TestMedian(TestCase):
                        [0, 1],
                        [6, 7],
                        [4, 5]])
-        for a in [a3, np.random.randint(0, 100, size=(2, 3, 4))]:
+        for a in [a3, np.random.randint(low=0, high=100, size=(2, 3, 4))]:
             orig = a.copy()
             np.median(a, axis=None)
             for ax in range(a.ndim):

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -518,7 +518,7 @@ class TestNanFunctions_Median(TestCase):
         for s in [5, 20, 51, 200, 1000]:
             d = np.random.randn(4, s)
             # Randomly set some elements to NaN:
-            w = np.random.randint(0, d.size, size=d.size // 5)
+            w = np.random.randint(low=0, high=d.size, size=d.size // 5)
             d.ravel()[w] = np.nan
             d[:,0] = 1.  # ensure at least one good value
             # use normal median without nans to compare

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -147,13 +147,13 @@ class TestRegression(TestCase):
         def dp():
             n = 3
             a = np.ones((n,)*5)
-            i = np.random.randint(0, n, size=thesize)
+            i = np.random.randint(low=0, high=n, size=thesize)
             a[np.ix_(i, i, i, i, i)] = 0
 
         def dp2():
             n = 3
             a = np.ones((n,)*5)
-            i = np.random.randint(0, n, size=thesize)
+            i = np.random.randint(low=0, high=n, size=thesize)
             a[np.ix_(i, i, i, i, i)]
 
         self.assertRaises(ValueError, dp)

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -347,7 +347,7 @@ class TestTile(TestCase):
         reps = [(2,), (1, 2), (2, 1), (2, 2), (2, 3, 2), (3, 2)]
         shape = [(3,), (2, 3), (3, 4, 3), (3, 2, 3), (4, 3, 2, 4), (2, 2)]
         for s in shape:
-            b = randint(0, 10, size=s)
+            b = randint(low=0, high=10, size=s)
             for r in reps:
                 a = np.ones(r, b.dtype)
                 large = tile(b, r)

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -60,7 +60,7 @@ class TestRegression(TestCase):
         lmax = np.iinfo('l').max
         lmin = np.iinfo('l').min
         try:
-            random.randint(lmin, lmax)
+            random.randint(low=lmin, high=lmax)
         except:
             raise AssertionError
 


### PR DESCRIPTION
Added functionality to accept a combination of `low` and `high` parameter values such as
`(None, None)` or `(None, <number>)`. The `(None, None)` option is different from `np.empty` because it doesn't fill an array with just `Py_None` values.  Such options are useful for example if you want to generate numbers for various given `dtype` arguments but don't want to have to keep passing in `low` every time.

The resulting behavior is then defined as follows:

1) `low == None` and `high == None`

Numbers are generated over the range `[lowbnd, highbnd)`, where `lowbnd = np.iinfo(dtype).min`, and `highbnd = np.iinfo(dtype).max`, where `dtype` is the provided integral type.

2) `low != None` and `high == None`

If `low >= 0`, numbers are <b>still</b> generated over the range `[0, low)`, but if `low` < 0, numbers
are generated over the range `[low, highbnd)`, where `highbnd` is defined as above.

3) `low == None` and `high != None`

Numbers are generated over the range `[lowbnd, high)`, where `lowbnd` is defined as above.
