### PR TITLE
Regression: np.linspace no longer respects subclasses

### DIFF
--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 from numpy import (logspace, linspace, dtype, array, finfo, typecodes, arange,
-                   isnan)
+                   isnan, ndarray)
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_array_equal
@@ -114,6 +114,19 @@ class TestLinspace(TestCase):
         a = PhysicalQuantity(0.0)
         b = PhysicalQuantity(1.0)
         assert_equal(linspace(a, b), linspace(0.0, 1.0))
+
+    def test_subclass(self):
+        class PhysicalQuantity2(ndarray):
+            __array_priority__ = 10
+
+        a = array(0).view(PhysicalQuantity2)
+        b = array(1).view(PhysicalQuantity2)
+        ls = linspace(a, b)
+        assert type(ls) is PhysicalQuantity2
+        assert_equal(ls, linspace(0.0, 1.0))
+        ls = linspace(a, b, 1)
+        assert type(ls) is PhysicalQuantity2
+        assert_equal(ls, linspace(0.0, 1.0, 1))
 
     def test_denormal_numbers(self):
         # Regression test for gh-5437. Will probably fail when compiled


### PR DESCRIPTION
Got this report at https://github.com/astropy/astropy/issues/4543:

**Numpy 1.9.3**

``` python
>>> np.linspace(-1 * u.m, 1 * u.m, 10)
<Quantity [-1.        ,-0.77777778,-0.55555556,-0.33333333,-0.11111111,
            0.11111111, 0.33333333, 0.55555556, 0.77777778, 1.        ] m>
```

**Numpy 1.10**

```
>>> np.linspace(-1 * u.m, 1 * u.m, 10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/miniconda3/envs/np110/lib/python2.7/site-packages/numpy/core/function_base.py", line 115, in linspace
    y[-1] = stop
ValueError: setting an array element with a sequence.
```

This occurs because a multiplication with `step` was changed to being in-place, which ignores subclasses.  Will try to make fix next week but putting this up now since I'd hope to have the fix in 1.11. 
