### PR TITLE
Backport 7152,BUG: mode kwargs passed as unicode to np.pad raises an exception

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1337,7 +1337,7 @@ def pad(array, pad_width, mode, **kwargs):
         'reflect_type': 'even',
         }
 
-    if isinstance(mode, str):
+    if isinstance(mode, np.compat.basestring):
         # Make sure have allowed kwargs appropriate for mode
         for key in kwargs:
             if key not in allowedkwargs[mode]:

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -953,6 +953,17 @@ class TestNdarrayPadWidth(TestCase):
         assert_array_equal(a, b)
 
 
+class TestUnicodeInput(TestCase):
+    def test_unicode_mode(self):
+        try:
+            constant_mode = unicode('constant')
+        except NameError:
+            constant_mode = 'constant'
+        a = np.pad([1], 2, mode=constant_mode)
+        b = np.array([0, 0, 1, 0, 0])
+        assert_array_equal(a, b)
+
+
 class ValueError1(TestCase):
     def test_check_simple(self):
         arr = np.arange(30)


### PR DESCRIPTION
isinstance(mode, str) is False in python2.7 when mode is of unicode
type, and mode is then mistakenly assumed to be a callable. See #7112
