### PR TITLE
Backport 7129, BUG: Fixed 'midpoint' interpolation of np.percentile in odd cases.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1027,7 +1027,7 @@ def select(condlist, choicelist, default=0):
     dtype = np.result_type(*choicelist)
 
     # Convert conditions to arrays and broadcast conditions and choices
-    # as the shape is needed for the result. Doing it seperatly optimizes
+    # as the shape is needed for the result. Doing it separately optimizes
     # for example when all choices are scalars.
     condlist = np.broadcast_arrays(*condlist)
     choicelist = np.broadcast_arrays(*choicelist)
@@ -1249,7 +1249,7 @@ def gradient(f, *varargs, **kwargs):
 
     # Convert datetime64 data into ints. Make dummy variable `y`
     # that is a view of ints if the data is datetime64, otherwise
-    # just set y equal to the the array `f`.
+    # just set y equal to the array `f`.
     if f.dtype.char in ["M", "m"]:
         y = f.view('int64')
     else:
@@ -3543,7 +3543,7 @@ def _percentile(a, q, axis=None, out=None,
     elif interpolation == 'higher':
         indices = ceil(indices).astype(intp)
     elif interpolation == 'midpoint':
-        indices = floor(indices) + 0.5
+        indices = 0.5 * (floor(indices) + ceil(indices))
     elif interpolation == 'nearest':
         indices = around(indices).astype(intp)
     elif interpolation == 'linear':

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2066,7 +2066,7 @@ def compare_results(res, desired):
         assert_array_equal(res[i], desired[i])
 
 
-class TestScoreatpercentile(TestCase):
+class TestPercentile(TestCase):
 
     def test_basic(self):
         x = np.arange(8) * 0.5
@@ -2115,6 +2115,10 @@ class TestScoreatpercentile(TestCase):
     def test_midpoint(self):
         assert_equal(np.percentile(range(10), 51,
                                    interpolation='midpoint'), 4.5)
+        assert_equal(np.percentile(range(11), 51,
+                                   interpolation='midpoint'), 5.5)
+        assert_equal(np.percentile(range(11), 50,
+                                   interpolation='midpoint'), 5)
 
     def test_nearest(self):
         assert_equal(np.percentile(range(10), 51,


### PR DESCRIPTION
Backport of #7129
