### PR TITLE
TST: Fixed f2py test for Anaconda non-win32

### DIFF
--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -74,14 +74,9 @@ def test_f2py():
         success = stdout.strip() == asbytes('2')
         assert_(success, "Warning: f2py not found in path")
     else:
-        # unclear what f2py cmd was installed as, check plain (f2py),
-        # with major version (f2py3), or major/minor version (f2py3.4)
-        code, stdout, stderr = run_command([sys.executable, '-V'])
-
-        # for some reason, 'python -V' returns version in 'stderr' for
-        # Python 2.x but in 'stdout' for Python 3.x
-        version = (stdout or stderr)[7:].strip()
-        major, minor, revision = version.decode('utf-8').split('.')
+        version = sys.version_info
+        major = str(version.major)
+        minor = str(version.minor)
 
         f2py_cmds = ('f2py', 'f2py' + major, 'f2py' + major + '.' + minor)
         success = False


### PR DESCRIPTION
When you run `python -V` under Anaconda (or Miniconda), it returns for example, `Python 3.4.3 :: Continuum Analytics, Inc.` However, the original parsing of `version` in `test_f2py` assumed there was nothing following the version number, causing a `ValueError` because you can't assign three variables to four components that you get from splitting on the `.`
