### PR TITLE
Backport 7174, DOC: Fix broken pandas link in 1.11.0 release notes

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -76,12 +76,13 @@ printing it would convert from or to local time::
     >>>> np.datetime64('2000-01-01T00:00:00')
     numpy.datetime64('2000-01-01T00:00:00-0800')  # note the timezone offset -08:00
 
+
 A consensus of datetime64 users agreed that this behavior is undesirable
-and at odds with how datetime64 is usually used (e.g., by pandas_). For
-most use cases, a timezone naive datetime type is preferred, similar to the
-``datetime.datetime`` type in the Python standard library. Accordingly,
-datetime64 no longer assumes that input is in local time, nor does it print
-local times::
+and at odds with how datetime64 is usually used (e.g., by `pandas
+<http://pandas.pydata.org>`__). For most use cases, a timezone naive datetime
+type is preferred, similar to the ``datetime.datetime`` type in the Python
+standard library. Accordingly, datetime64 no longer assumes that input is in
+local time, nor does it print local times::
 
     >>>> np.datetime64('2000-01-01T00:00:00')
     numpy.datetime64('2000-01-01T00:00:00')
@@ -99,14 +100,12 @@ As a corollary to this change, we no longer prohibit casting between datetimes
 with date units and datetimes with time units. With timezone naive datetimes,
 the rule for casting from dates to times is no longer ambiguous.
 
-pandas_: http://pandas.pydata.org
-
 ``linalg.norm`` return type changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The return type of the ``linalg.norm`` function is now floating point without
 exception.  Some of the norm types previously returned integers.
 
-and returns floating results.polynomial fit changes
+polynomial fit changes
 ~~~~~~~~~~~~~~~~~~~~~~
 The various fit functions in the numpy polynomial package no longer accept
 non-integers for degree specification.


### PR DESCRIPTION
[ci skip]
