### PR TITLE
ENH: added axis param for np.count_nonzero

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -106,3 +106,27 @@ class CorrConv(Benchmark):
 
     def time_convolve(self, size1, size2, mode):
         np.convolve(self.x1, self.x2, mode=mode)
+
+
+class CountNonzero(Benchmark):
+    param_names = ['numaxes', 'size', 'dtype']
+    params = [
+        [1, 2, 3],
+        [100, 10000, 1000000],
+        [bool, int, str, object]
+    ]
+
+    def setup(self, numaxes, size, dtype):
+        self.x = np.empty(shape=(
+            numaxes, size), dtype=dtype)
+
+    def time_count_nonzero(self, numaxes, size, dtype):
+        np.count_nonzero(self.x)
+
+    def time_count_nonzero_axis(self, numaxes, size, dtype):
+        np.count_nonzero(self.x, axis=self.x.ndim - 1)
+
+    def time_count_nonzero_multi_axis(self, numaxes, size, dtype):
+        if self.x.ndim >= 2:
+            np.count_nonzero(self.x, axis=(
+                self.x.ndim - 1, self.x.ndim - 2))

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -67,9 +67,6 @@ class Custom(Benchmark):
     def time_nonzero(self):
         np.nonzero(self.b)
 
-    def time_count_nonzero(self):
-        np.count_nonzero(self.b)
-
     def time_not_bool(self):
         (~self.b)
 

--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -138,6 +138,9 @@ Generalized ``flip``
 axis=1 respectively. The newly added ``flip`` function reverses the elements of
 an array along any given axis.
 
+* ``np.count_nonzero`` now has an ``axis`` parameter, allowing
+  non-zero counts to be generated on more than just a flattened
+  array object.
 
 BLIS support in ``numpy.distutils``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -942,34 +942,6 @@ add_newdoc('numpy.core.multiarray', 'zeros',
 
     """)
 
-add_newdoc('numpy.core.multiarray', 'count_nonzero',
-    """
-    count_nonzero(a)
-
-    Counts the number of non-zero values in the array ``a``.
-
-    Parameters
-    ----------
-    a : array_like
-        The array for which to count non-zeros.
-
-    Returns
-    -------
-    count : int or array of int
-        Number of non-zero values in the array.
-
-    See Also
-    --------
-    nonzero : Return the coordinates of all the non-zero values.
-
-    Examples
-    --------
-    >>> np.count_nonzero(np.eye(4))
-    4
-    >>> np.count_nonzero([[0,1,7,0,0],[3,0,0,2,19]])
-    5
-    """)
-
 add_newdoc('numpy.core.multiarray', 'set_typeDict',
     """set_typeDict(dict)
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1980,16 +1980,10 @@ fail:
 static PyObject *
 array_count_nonzero(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
 {
-    PyObject *array_in;
     PyArrayObject *array;
     npy_intp count;
 
-    if (!PyArg_ParseTuple(args, "O", &array_in)) {
-        return NULL;
-    }
-
-    array = (PyArrayObject *)PyArray_FromAny(array_in, NULL, 0, 0, 0, NULL);
-    if (array == NULL) {
+    if (!PyArg_ParseTuple(args, "O&", PyArray_Converter, &array)) {
         return NULL;
     }
 


### PR DESCRIPTION
Addresses feature request in #391 to add an axis parameter to `np.count_nonzero`.

Duplicate of #7138 after a forced push on another branch accidentally reset my origin branch for that PR to `master`, closing it automatically (I had reset hard on the #7138 branch to `master` so I could do the C refactoring @jaimefrio suggested in the spirit of #4330, whoops).
