### PR TITLE
BUG: Fix binary_repr for negative numbers

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -154,10 +154,18 @@ Deprecations
 
 Assignment of ndarray object's ``data`` attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Assigning the 'data' attribute is an inherently unsafe operation as pointed 
+Assigning the 'data' attribute is an inherently unsafe operation as pointed
 out in gh-7083. Such a capability will be removed in the future.
 
 Unsafe int casting of the num attribute in linspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``np.linspace`` now raises DeprecationWarning when num cannot be safely 
+``np.linspace`` now raises DeprecationWarning when num cannot be safely
 interpreted as an integer.
+
+Insufficient bit width parameter to ``binary_repr``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If a 'width' parameter is passed into ``binary_repr`` that is insufficient to
+represent the number in base 2 (positive) or 2's complement (negative) form,
+the function used to silently ignore the parameter and return a representation
+using the minimal number of bits needed for the form in question. Such behavior
+is now considered unsafe from a user perspective and will raise an error in the future.

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -579,19 +579,45 @@ class TestArrayDataAttributeAssignmentDeprecation(_DeprecationTestCase):
 
 
 class TestLinspaceInvalidNumParameter(_DeprecationTestCase):
-    """Argument to the num parameter in linspace that cannot be 
+    """Argument to the num parameter in linspace that cannot be
     safely interpreted as an integer is deprecated in 1.12.0.
 
-    Argument to the num parameter in linspace that cannot be 
-    safely interpreted as an integer should not be allowed. 
+    Argument to the num parameter in linspace that cannot be
+    safely interpreted as an integer should not be allowed.
     In the interest of not breaking code that passes
     an argument that could still be interpreted as an integer, a
-    DeprecationWarning will be issued for the time being to give 
+    DeprecationWarning will be issued for the time being to give
     developers time to refactor relevant code.
     """
     def test_float_arg(self):
         # 2016-02-25, PR#7328
         self.assert_deprecated(np.linspace, args=(0, 10, 2.5))
+
+
+class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTestCase):
+    """
+    If a 'width' parameter is passed into ``binary_repr`` that is insufficient to
+    represent the number in base 2 (positive) or 2's complement (negative) form,
+    the function used to silently ignore the parameter and return a representation
+    using the minimal number of bits needed for the form in question. Such behavior
+    is now considered unsafe from a user perspective and will raise an error in the future.
+    """
+
+    def test_insufficient_width_positive(self):
+        args = (10,)
+        kwargs = {'width': 2}
+
+        self.message = ("Insufficient bit width provided. This behavior "
+                        "will raise an error in the future.")
+        self.assert_deprecated(np.binary_repr, args=args, kwargs=kwargs)
+
+    def test_insufficient_width_negative(self):
+        args = (-5,)
+        kwargs = {'width': 2}
+
+        self.message = ("Insufficient bit width provided. This behavior "
+                        "will raise an error in the future.")
+        self.assert_deprecated(np.binary_repr, args=args, kwargs=kwargs)
 
 
 class TestTestDeprecated(object):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1021,12 +1021,25 @@ class TestBinaryRepr(TestCase):
     def test_zero(self):
         assert_equal(np.binary_repr(0), '0')
 
-    def test_large(self):
-        assert_equal(np.binary_repr(10736848), '101000111101010011010000')
+    def test_positive(self):
+        assert_equal(np.binary_repr(10), '1010')
+        assert_equal(np.binary_repr(12522),
+                     '11000011101010')
+        assert_equal(np.binary_repr(10736848),
+                     '101000111101010011010000')
 
     def test_negative(self):
         assert_equal(np.binary_repr(-1), '-1')
-        assert_equal(np.binary_repr(-1, width=8), '11111111')
+        assert_equal(np.binary_repr(-10), '-1010')
+        assert_equal(np.binary_repr(-12522),
+                     '-11000011101010')
+        assert_equal(np.binary_repr(-10736848),
+                     '-101000111101010011010000')
+
+    def test_sufficient_width(self):
+        assert_equal(np.binary_repr(0, width=5), '00000')
+        assert_equal(np.binary_repr(10, width=7), '0001010')
+        assert_equal(np.binary_repr(-5, width=7), '1111011')
 
 
 class TestBaseRepr(TestCase):


### PR DESCRIPTION
Addresses issue in #7168 in which passing in negative numbers with insufficient `width` parameters resulted in completely incorrect two's complement representations (e.g. all zero's) or even an error. Now, it will return the two's complement with width equal to the minimum number of bits needed to represent the complement.
