### PR TITLE
DOC: Updated minor typos in function_base.py and test_function_base.py

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -124,7 +124,7 @@ def _hist_optim_numbins_estimator(a, estimator):
 
     def fd(x):
         """
-        Freedman Diaconis rule using Inter Quartile Range (IQR) for binwidth
+        Freedman Diaconis rule using interquartile range (IQR) for binwidth
         Considered a variation of the Scott rule with more robustness as the IQR
         is less affected by outliers than the standard deviation. However the IQR depends on
         fewer points than the sd so it is less accurate, especially for long tailed distributions.
@@ -3233,22 +3233,22 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     ----------
     a : array_like
         Input array or object that can be converted to an array.
-    axis : int or sequence of int, optional
-        Axis along which the medians are computed. The default (axis=None)
+    axis : {int, sequence of int, None}, optional
+        Axis or axes along which the medians are computed. The default
         is to compute the median along a flattened version of the array.
         A sequence of axes is supported since version 1.9.0.
     out : ndarray, optional
-        Alternative output array in which to place the result. It must have
-        the same shape and buffer length as the expected output, but the
-        type (of the output) will be cast if necessary.
+        Alternative output array in which to place the result. It must
+        have the same shape and buffer length as the expected output,
+        but the type (of the output) will be cast if necessary.
     overwrite_input : bool, optional
-       If True, then allow use of memory of input array (a) for
+       If True, then allow use of memory of input array `a` for
        calculations. The input array will be modified by the call to
-       median. This will save memory when you do not need to preserve the
-       contents of the input array. Treat the input as undefined, but it
-       will probably be fully or partially sorted. Default is False. Note
-       that, if `overwrite_input` is True and the input is not already an
-       ndarray, an error will be raised.
+       `median`. This will save memory when you do not need to preserve
+       the contents of the input array. Treat the input as undefined,
+       but it will probably be fully or partially sorted. Default is
+       False. If `overwrite_input` is ``True`` and `a` is not already an
+       `ndarray`, an error will be raised.
     keepdims : bool, optional
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
@@ -3256,15 +3256,14 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
 
         .. versionadded:: 1.9.0
 
-
     Returns
     -------
     median : ndarray
-        A new array holding the result (unless `out` is specified, in which
-        case that array is returned instead).  If the input contains
-        integers, or floats of smaller precision than 64, then the output
-        data-type is float64.  Otherwise, the output data-type is the same
-        as that of the input.
+        A new array holding the result. If the input contains integers
+        or floats smaller than ``float64``, then the output data-type is
+        ``np.float64``.  Otherwise, the data-type of the output is the
+        same as that of the input. If `out` is specified, that array is
+        returned instead.
 
     See Also
     --------
@@ -3272,10 +3271,10 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
 
     Notes
     -----
-    Given a vector V of length N, the median of V is the middle value of
-    a sorted copy of V, ``V_sorted`` - i.e., ``V_sorted[(N-1)/2]``, when N is
-    odd.  When N is even, it is the average of the two middle values of
-    ``V_sorted``.
+    Given a vector ``V`` of length ``N``, the median of ``V`` is the
+    middle value of a sorted copy of ``V``, ``V_sorted`` - i
+    e., ``V_sorted[(N-1)/2]``, when ``N`` is odd, and the average of the
+    two middle values of ``V_sorted`` when ``N`` is even.
 
     Examples
     --------
@@ -3396,28 +3395,32 @@ def percentile(a, q, axis=None, out=None,
         Input array or object that can be converted to an array.
     q : float in range of [0,100] (or sequence of floats)
         Percentile to compute, which must be between 0 and 100 inclusive.
-    axis : int or sequence of int, optional
-        Axis along which the percentiles are computed. The default (None)
-        is to compute the percentiles along a flattened version of the array.
-        A sequence of axes is supported since version 1.9.0.
+    axis : {int, sequence of int, None}, optional
+        Axis or axes along which the percentiles are computed. The
+        default is to compute the percentile(s) along a flattened
+        version of the array. A sequence of axes is supported since
+        version 1.9.0.
     out : ndarray, optional
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,
         but the type (of the output) will be cast if necessary.
     overwrite_input : bool, optional
-        If True, then allow use of memory of input array `a` for calculations.
-        The input array will be modified by the call to `percentile`. This will
-        save memory when you do not need to preserve the contents of the input
-        array. In this case you should not make any assumptions about the
-        contents of the input `a` after this function completes -- treat it as
-        undefined. Default is False. If `a` is not already an array, this
-        parameter will have no effect as `a` will be converted to an array
+        If True, then allow use of memory of input array `a` 
+        calculations. The input array will be modified by the call to
+        `percentile`. This will save memory when you do not need to
+        preserve the contents of the input array. In this case you
+        should not make any assumptions about the contents of the input
+        `a` after this function completes -- treat it as undefined.
+        Default is False. If `a` is not already an array, this parameter
+        will have no effect as `a` will be converted to an array
         internally regardless of the value of this parameter.
     interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
-        This optional parameter specifies the interpolation method to use
-        when the desired quantile lies between two data points ``i < j``:
-            * linear: ``i + (j - i) * fraction``, where ``fraction`` is the
-              fractional part of the index surrounded by ``i`` and ``j``.
+        This optional parameter specifies the interpolation method to
+        use when the desired quantile lies between two data points
+        ``i < j``:
+            * linear: ``i + (j - i) * fraction``, where ``fraction``
+              is the fractional part of the index surrounded by ``i``
+              and ``j``.
             * lower: ``i``.
             * higher: ``j``.
             * nearest: ``i`` or ``j``, whichever is nearest.
@@ -3425,35 +3428,38 @@ def percentile(a, q, axis=None, out=None,
 
         .. versionadded:: 1.9.0
     keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left in the
-        result as dimensions with size one. With this option, the result will
-        broadcast correctly against the original array `a`.
+        If this is set to True, the axes which are reduced are left in
+        the result as dimensions with size one. With this option, the
+        result will broadcast correctly against the original array `a`.
 
         .. versionadded:: 1.9.0
 
     Returns
     -------
     percentile : scalar or ndarray
-        If `q` is a single percentile and `axis=None`, then the result is a
-        scalar. If multiple percentiles are given, the result is an an array.
-        The percentiles are listed in the first axis. The remaining axes are the
-        reduced axes of the input `a`. If the input contains integers or floats
-        of smaller precision than 64, then the output data-type is float64.
-        Otherwise, the output data-type is the same as that of the input. If
-        `out` is specified, that array is returned instead. 
+        If `q` is a single percentile and `axis=None`, then the result
+        is a scalar. If multiple percentiles are given, first axis of
+        the result corresponds to the percentiles. The other axes are
+        the axes that remain after the reduction of `a`. If the input 
+        contains integers or floats smaller than ``float64``, the output
+        data-type is ``float64``. Otherwise, the output data-type is the
+        same as that of the input. If `out` is specified, that array is
+        returned instead.
 
     See Also
     --------
-    mean, median
+    mean, median, nanpercentile
 
     Notes
     -----
-    Given a vector V of length N, the q-th percentile of V is the q-th ranked
-    value in a sorted copy of V. The values and distances of the two nearest
-    neighbors as well as the `interpolation` parameter will determine the
-    percentile if the normalized ranking does not match q exactly. This function
-    is the same as the median if ``q=50``, the same as the minimum if ``q=0``
-    and the same as the maximum if ``q=100``.
+    Given a vector ``V`` of length ``N``, the ``q``-th percentile of
+    ``V`` is the value ``q/100`` of the way from the mimumum to the
+    maximum in in a sorted copy of ``V``. The values and distances of
+    the two nearest neighbors as well as the `interpolation` parameter
+    will determine the percentile if the normalized ranking does not
+    match the location of ``q`` exactly. This function is the same as
+    the median if ``q=50``, the same as the minimum if ``q=0`` and the
+    same as the maximum if ``q=100``.
 
     Examples
     --------
@@ -3621,7 +3627,7 @@ def _percentile(a, q, axis=None, out=None,
             r = add(x1, x2)
 
     if np.any(n):
-        warnings.warn("Invalid value encountered in median",
+        warnings.warn("Invalid value encountered in percentile",
                               RuntimeWarning)
         if zerod:
             if ap.ndim == 1:
@@ -3733,7 +3739,8 @@ def trapz(y, x=None, dx=1.0, axis=-1):
 
 #always succeed
 def add_newdoc(place, obj, doc):
-    """Adds documentation to obj which is in module place.
+    """
+    Adds documentation to obj which is in module place.
 
     If doc is a string add it to obj as a docstring
 
@@ -3751,7 +3758,7 @@ def add_newdoc(place, obj, doc):
     in new-style classes or built-in functions. Because this
     routine never raises an error the caller must check manually
     that the docstrings were changed.
-       """
+    """
     try:
         new = getattr(__import__(place, globals(), {}, [obj]), obj)
         if isinstance(doc, str):

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -729,8 +729,9 @@ def _nanmedian(a, axis=None, out=None, overwrite_input=False):
 
 def _nanmedian_small(a, axis=None, out=None, overwrite_input=False):
     """
-    sort + indexing median, faster for small medians along multiple dimensions
-    due to the high overhead of apply_along_axis
+    sort + indexing median, faster for small medians along multiple
+    dimensions due to the high overhead of apply_along_axis
+
     see nanmedian for parameter usage
     """
     a = np.ma.masked_array(a, np.isnan(a))
@@ -754,36 +755,35 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     ----------
     a : array_like
         Input array or object that can be converted to an array.
-    axis : int, optional
-        Axis along which the medians are computed. The default (axis=None)
+    axis : {int, sequence of int, None}, optional
+        Axis or axes along which the medians are computed. The default
         is to compute the median along a flattened version of the array.
         A sequence of axes is supported since version 1.9.0.
     out : ndarray, optional
-        Alternative output array in which to place the result. It must have
-        the same shape and buffer length as the expected output, but the
-        type (of the output) will be cast if necessary.
+        Alternative output array in which to place the result. It must
+        have the same shape and buffer length as the expected output,
+        but the type (of the output) will be cast if necessary.
     overwrite_input : bool, optional
-       If True, then allow use of memory of input array (a) for
+       If True, then allow use of memory of input array `a` for
        calculations. The input array will be modified by the call to
-       median. This will save memory when you do not need to preserve
+       `median`. This will save memory when you do not need to preserve
        the contents of the input array. Treat the input as undefined,
        but it will probably be fully or partially sorted. Default is
-       False. Note that, if `overwrite_input` is True and the input
-       is not already an ndarray, an error will be raised.
+       False. If `overwrite_input` is ``True`` and `a` is not already an
+       `ndarray`, an error will be raised.
     keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left
-        in the result as dimensions with size one. With this option,
-        the result will broadcast correctly against the original `arr`.
-
-
+        If this is set to True, the axes which are reduced are left in
+        the result as dimensions with size one. With this option, the
+        result will broadcast correctly against the original `arr`.
 
     Returns
     -------
     median : ndarray
-        A new array holding the result. If the input contains integers, or
-        floats of smaller precision than 64, then the output data-type is
-        float64.  Otherwise, the output data-type is the same as that of the
-        input.
+        A new array holding the result. If the input contains integers
+        or floats smaller than ``float64``, then the output data-type is
+        ``np.float64``.  Otherwise, the data-type of the output is the
+        same as that of the input. If `out` is specified, that array is
+        returned instead.
 
     See Also
     --------
@@ -791,10 +791,10 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
 
     Notes
     -----
-    Given a vector V of length N, the median of V is the middle value of
-    a sorted copy of V, ``V_sorted`` - i.e., ``V_sorted[(N-1)/2]``, when N is
-    odd.  When N is even, it is the average of the two middle values of
-    ``V_sorted``.
+    Given a vector ``V`` of length ``N``, the median of ``V`` is the
+    middle value of a sorted copy of ``V``, ``V_sorted`` - i.e.,
+    ``V_sorted[(N-1)/2]``, when ``N`` is odd and the average of the two
+    middle values of ``V_sorted`` when ``N`` is even.
 
     Examples
     --------
@@ -838,10 +838,10 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
 def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
                   interpolation='linear', keepdims=False):
     """
-    Compute the qth percentile of the data along the specified axis, while
-    ignoring nan values.
+    Compute the qth percentile of the data along the specified axis,
+    while ignoring nan values.
 
-    Returns the qth percentile of the array elements.
+    Returns the qth percentile(s) of the array elements.
 
     .. versionadded:: 1.9.0
 
@@ -850,11 +850,13 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     a : array_like
         Input array or object that can be converted to an array.
     q : float in range of [0,100] (or sequence of floats)
-        Percentile to compute which must be between 0 and 100 inclusive.
-    axis : int or sequence of int, optional
-        Axis along which the percentiles are computed. The default (None)
-        is to compute the percentiles along a flattened version of the array.
-        A sequence of axes is supported since version 1.9.0.
+        Percentile to compute, which must be between 0 and 100
+        inclusive.
+    axis : {int, sequence of int, None}, optional
+        Axis or axes along which the percentiles are computed. The
+        default is to compute the percentile(s) along a flattened
+        version of the array. A sequence of axes is supported since
+        version 1.9.0.
     out : ndarray, optional
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,
@@ -862,39 +864,40 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     overwrite_input : bool, optional
         If True, then allow use of memory of input array `a` for
         calculations. The input array will be modified by the call to
-        percentile. This will save memory when you do not need to preserve
-        the contents of the input array. In this case you should not make
-        any assumptions about the content of the passed in array `a` after
-        this function completes -- treat it as undefined. Default is False.
-        Note that, if the `a` input is not already an array this parameter
-        will have no effect, `a` will be converted to an array internally
-        regardless of the value of this parameter.
+        `percentile`. This will save memory when you do not need to
+        preserve the contents of the input array. In this case you
+        should not make any assumptions about the contents of the input
+        `a` after this function completes -- treat it as undefined.
+        Default is False. If `a` is not already an array, this parameter
+        will have no effect as `a` will be converted to an array
+        internally regardless of the value of this parameter.
     interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
-        This optional parameter specifies the interpolation method to use,
-        when the desired quantile lies between two data points `i` and `j`:
-            * linear: `i + (j - i) * fraction`, where `fraction` is the
-              fractional part of the index surrounded by `i` and `j`.
-            * lower: `i`.
-            * higher: `j`.
-            * nearest: `i` or `j` whichever is nearest.
-            * midpoint: (`i` + `j`) / 2.
-
+        This optional parameter specifies the interpolation method to
+        use when the desired quantile lies between two data points
+        ``i < j``:
+            * linear: ``i + (j - i) * fraction``, where ``fraction`` is
+              the fractional part of the index surrounded by ``i`` and
+              ``j``.
+            * lower: ``i``.
+            * higher: ``j``.
+            * nearest: ``i`` or ``j``, whichever is nearest.
+            * midpoint: ``(i + j) / 2``.
     keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left
-        in the result as dimensions with size one. With this option,
-        the result will broadcast correctly against the original `arr`.
-
+        If this is set to True, the axes which are reduced are left in
+        the result as dimensions with size one. With this option, the
+        result will broadcast correctly against the original array `a`.
 
     Returns
     -------
-    nanpercentile : scalar or ndarray
-        If a single percentile `q` is given and axis=None a scalar is
-        returned.  If multiple percentiles `q` are given an array holding
-        the result is returned. The results are listed in the first axis.
-        (If `out` is specified, in which case that array is returned
-        instead).  If the input contains integers, or floats of smaller
-        precision than 64, then the output data-type is float64. Otherwise,
-        the output data-type is the same as that of the input.
+    percentile : scalar or ndarray
+        If `q` is a single percentile and `axis=None`, then the result
+        is a scalar. If multiple percentiles are given, first axis of
+        the result corresponds to the percentiles. The other axes are
+        the axes that remain after the reduction of `a`. If the input 
+        contains integers or floats smaller than ``float64``, the output
+        data-type is ``float64``. Otherwise, the output data-type is the
+        same as that of the input. If `out` is specified, that array is
+        returned instead.
 
     See Also
     --------
@@ -902,12 +905,14 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
 
     Notes
     -----
-    Given a vector V of length N, the q-th percentile of V is the q-th ranked
-    value in a sorted copy of V.  The values and distances of the two
-    nearest neighbors as well as the `interpolation` parameter will
-    determine the percentile if the normalized ranking does not match q
-    exactly. This function is the same as the median if ``q=50``, the same
-    as the minimum if ``q=0``and the same as the maximum if ``q=100``.
+    Given a vector ``V`` of length ``N``, the ``q``-th percentile of
+    ``V`` is the value ``q/100`` of the way from the mimumum to the
+    maximum in in a sorted copy of ``V``. The values and distances of
+    the two nearest neighbors as well as the `interpolation` parameter
+    will determine the percentile if the normalized ranking does not
+    match the location of ``q`` exactly. This function is the same as
+    the median if ``q=50``, the same as the minimum if ``q=0`` and the
+    same as the maximum if ``q=100``.
 
     Examples
     --------
@@ -921,24 +926,21 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     >>> np.nanpercentile(a, 50)
     3.5
     >>> np.nanpercentile(a, 50, axis=0)
-    array([[ 6.5,  4.5,  2.5]])
-    >>> np.nanpercentile(a, 50, axis=1)
+    array([ 6.5,  2.,   2.5])
+    >>> np.nanpercentile(a, 50, axis=1, keepdims=True)
     array([[ 7.],
            [ 2.]])
     >>> m = np.nanpercentile(a, 50, axis=0)
     >>> out = np.zeros_like(m)
-    >>> np.nanpercentile(a, 50, axis=0, out=m)
-    array([[ 6.5,  4.5,  2.5]])
+    >>> np.nanpercentile(a, 50, axis=0, out=out)
+    array([ 6.5,  2.,   2.5])
     >>> m
-    array([[ 6.5,  4.5,  2.5]])
+    array([ 6.5,  2. ,  2.5])
+
     >>> b = a.copy()
     >>> np.nanpercentile(b, 50, axis=1, overwrite_input=True)
-    array([[ 7.],
-           [ 2.]])
+    array([  7.,  2.])
     >>> assert not np.all(a==b)
-    >>> b = a.copy()
-    >>> np.nanpercentile(b, 50, axis=None, overwrite_input=True)
-    array([ 3.5])
 
     """
 
@@ -987,9 +989,10 @@ def _nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
 
 def _nanpercentile1d(arr1d, q, overwrite_input=False, interpolation='linear'):
     """
-    Private function for rank 1 arrays. Compute percentile ignoring NaNs.
-    See nanpercentile for parameter usage
+    Private function for rank 1 arrays. Compute percentile ignoring
+    NaNs.
 
+    See nanpercentile for parameter usage
     """
     c = np.isnan(arr1d)
     s = np.where(c)[0]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2100,7 +2100,7 @@ class TestPercentile(TestCase):
         # Test defaults
         assert_equal(np.percentile(range(10), 50), 4.5)
 
-        # explicitly specify interpolation_method 'fraction' (the default)
+        # explicitly specify interpolation_method 'linear' (the default)
         assert_equal(np.percentile(range(10), 50,
                                    interpolation='linear'), 4.5)
 
@@ -2421,6 +2421,7 @@ class TestPercentile(TestCase):
                          np.array([np.nan] * 2))
             assert_(w[0].category is RuntimeWarning)
             assert_(w[1].category is RuntimeWarning)
+            assert_(w[2].category is RuntimeWarning)
 
         a = np.arange(24, dtype=float).reshape(2, 3, 4)
         a[1, 2, 3] = np.nan


### PR DESCRIPTION
Main correction was to fix up outputs in `nanpercentile` examples and make the docs look more like those of `percentile`.
