### PR TITLE
MAINT: Removed supurious assert in histogram estimators

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -85,9 +85,6 @@ def _hist_optim_numbins_estimator(a, estimator):
         will choose the appropriate estimator and return it's estimate for the optimal
         number of bins.
     """
-    assert isinstance(estimator, basestring)
-    # private function should not be called otherwise
-
     if a.size == 0:
         return 1
 


### PR DESCRIPTION
This assert is superfluous. Both possible usages are already being handled:
1. The function is nominally private for use by `histogram`. In this case it is always called in an `if isinstance(bins, basestring):` block ([Line 346](https://github.com/madphysicist/numpy/blob/master/numpy/lib/function_base.py#L346) in `master`)
2. In the unlikely event that someone calls this function externally (e.g. to get access to the estimator functionality), the `except KeyError:` block on [Line 157](https://github.com/madphysicist/numpy/blob/master/numpy/lib/function_base.py#L157) will handle the situation better than the assertion since it will not be optimized away and will actually deliver a useful message.
