### PR TITLE
Raise IOError on not a file in python2

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -320,7 +320,13 @@ static NPY_INLINE FILE *
 npy_PyFile_Dup2(PyObject *file,
                 const char *NPY_UNUSED(mode), npy_off_t *NPY_UNUSED(orig_pos))
 {
-    return PyFile_AsFile(file);
+    FILE * fp = PyFile_AsFile(file);
+    if (fp == NULL) {
+        PyErr_SetString(PyExc_IOError,
+                        "first argument must be an open file");
+        return NULL;
+    }
+    return fp;
 }
 
 static NPY_INLINE int

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -583,8 +583,6 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 
     fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
     if (fd == NULL) {
-        PyErr_SetString(PyExc_IOError,
-                "first argument must be a string or open file");
         goto fail;
     }
     if (PyArray_ToFile(self, fd, sep, format) < 0) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3582,6 +3582,14 @@ class TestIO(object):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
+    def test_nofile(self):
+        # this should probably be supported as a file
+        # but for now test for proper errors
+        b = io.BytesIO()
+        assert_raises(IOError, np.fromfile, b, np.uint8, 80)
+        d = np.ones(7);
+        assert_raises(IOError, lambda x: x.tofile(b), d)
+
     def test_bool_fromstring(self):
         v = np.array([True, False, True, False], dtype=np.bool_)
         y = np.fromstring('1 0 -2.3 0.0', sep=' ', dtype=np.bool_)


### PR DESCRIPTION
The change in 5225e4c2007 did not account for PyFile_AsFile does not
raise an error on invalid input, add the handling to equalize our
wr5225e4c2007 apper function.
closes gh-7200
