### PR TITLE
Backport 7180, BUG: Fixed previous attempt to fix dimension mismatch in nanpercentile

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -979,7 +979,8 @@ def _nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
         # Move that axis to the beginning to match percentile's
         # convention.
         if q.ndim != 0:
-            result = np.swapaxes(result, 0, axis)
+            result = np.rollaxis(result, axis)   
+
     if out is not None:
         out[...] = result
     return result

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -711,7 +711,7 @@ class TestNanFunctions_Percentile(TestCase):
         # For checking consistency in higher dimensional case
         large_mat = np.ones((3, 4, 5))
         large_mat[:, 0:2:4, :] = 0
-        large_mat[:, :, 3:] = 2*large_mat[:, :, 3:]
+        large_mat[:, :, 3:] *= 2
         for axis in [None, 0, 1]:
             for keepdim in [False, True]:
                 with warnings.catch_warnings(record=True) as w:
@@ -726,6 +726,9 @@ class TestNanFunctions_Percentile(TestCase):
                     nan_val = np.nanpercentile(large_mat, perc, axis=axis,
                                                keepdims=keepdim)
                     assert_equal(nan_val, val)
+
+        megamat = np.ones((3, 4, 5, 6))
+        assert_equal(np.nanpercentile(megamat, perc, axis=(1, 2)).shape, (2, 3, 6))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#7180

nanpercentile was conforming to dimension convention of percentile incorrectly.
percentile outputs results for the different percentiles along the first
dimension of the output. nanpercentile was moving the reduction axis to the
front using swapaxes, which would move the first axis out of place if there
were more than two in the array. Added a test with more than two axes to
demonstrate and used rollaxis instead of swapaxes to do the interhange.
