### PR TITLE
TST: Bump `virtualenv` to 14.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,9 @@ before_install:
   #
   # Some change in virtualenv 14.0.5 caused `test_f2py` to fail. So, we have
   # pinned `virtualenv` to the last known working version to avoid this failure.
-  - pip install -U 'virtualenv==14.0.4'
+  # Appears we had some issues with certificates on Travis. It looks like
+  # bumping to 14.0.6 will help.
+  - pip install -U 'virtualenv==14.0.6'
   - virtualenv --python=python venv
   - source venv/bin/activate
   - python -V


### PR DESCRIPTION
Appears that we may be suffering from this bug ( https://github.com/pypa/pip/issues/2494 ). A suggested fix was using this patch ( https://github.com/pypa/virtualenv/pull/866 ), which is included in `virtualenv` 14.0.6. Here we attempt to pin `virtualenv` to 14.0.6. Hopefully, this is the end of our issues with this.
