### PR TITLE
ENH: Add np.asanycontiguousarray

### DIFF
--- a/doc/source/reference/routines.array-creation.rst
+++ b/doc/source/reference/routines.array-creation.rst
@@ -32,6 +32,8 @@ From existing data
    asarray
    asanyarray
    ascontiguousarray
+   asfortranarray
+   asanycontiguousarray
    asmatrix
    copy
    frombuffer

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -54,9 +54,10 @@ Changing kind of array
    asarray
    asanyarray
    asmatrix
+   ascontiguousarray
    asfarray
    asfortranarray
-   ascontiguousarray
+   asanycontiguousarray
    asarray_chkfinite
    asscalar
    require

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -304,14 +304,28 @@ class TestArrayConstruction(TestCase):
         assert_array_equal(d, [[1, 5, 3], [1,2,3]])
 
     def test_array_cont(self):
-        d = np.ones(10)[::2]
-        assert_(np.ascontiguousarray(d).flags.c_contiguous)
-        assert_(np.ascontiguousarray(d).flags.f_contiguous)
-        assert_(np.asfortranarray(d).flags.c_contiguous)
-        assert_(np.asfortranarray(d).flags.f_contiguous)
-        d = np.ones((10, 10))[::2,::2]
-        assert_(np.ascontiguousarray(d).flags.c_contiguous)
-        assert_(np.asfortranarray(d).flags.f_contiguous)
+        a = np.ones(12)
+        b = a.reshape(3, 4)
+        for arr in (a, a[::2], b, b.T, b[::2]):
+            res = np.ascontiguousarray(arr)
+            assert_(res.flags.c_contiguous)
+            assert_equal(res.flags.f_contiguous, res.ndim <= 1)
+            # It's a view if the original is C-contiguous, otherwise it's a copy
+            assert_equal(res.ctypes.data == arr.ctypes.data,
+                         arr.flags.c_contiguous)
+
+            res = np.asfortranarray(arr)
+            assert_(res.flags.f_contiguous)
+            assert_equal(res.flags.c_contiguous, arr.ndim <= 1)
+            # It's a view if the original is F-contiguous, otherwise it's a copy
+            assert_equal(res.ctypes.data == arr.ctypes.data,
+                         arr.flags.f_contiguous)
+
+            res = np.asanycontiguousarray(arr)
+            assert_(res.flags.c_contiguous or res.flags.f_contiguous)
+            # It's a view if the original is contiguous, otherwise it's a copy
+            assert_equal(res.ctypes.data == arr.ctypes.data,
+                         arr.flags.c_contiguous or arr.flags.f_contiguous)
 
 
 class TestAssignment(TestCase):


### PR DESCRIPTION
Numpy has np.ascontiguousarray() and np.asfortranarray(), but doesn't have
a function to return an array of either contiguity depending on the input,
making a copy only when necessary.
