### PR TITLE
TST: Try upgrading setuptools, pip, virtualenv & remove 3.2 test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 python:
   - 2.6
   - 2.7
-  - 3.2
+  #- 3.2
   - 3.3
   - 3.4
   - 3.5
@@ -81,7 +81,7 @@ before_install:
   - virtualenv --python=python venv
   - source venv/bin/activate
   - python -V
-  - pip install --upgrade "pip<8.0.0" "setuptools<19.0"
+  - pip install --upgrade pip setuptools
   - pip install nose
   # pip install coverage
   # Speed up install by not compiling Cython

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -138,7 +138,7 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   $PIP install wheel
   # ensure that the pip / setuptools versions deployed inside
   # the venv are recent enough
-  $PIP install -U "virtualenv<14.0.0"
+  $PIP install -U virtualenv
   $PYTHON setup.py bdist_wheel
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel


### PR DESCRIPTION
We are having problems running one of the wheels tests, so try
dropping Python 3.2 tests that cause problems with newer versions.
