### PR TITLE
ENH: implement __complex__

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -155,6 +155,12 @@ Generalized Ufuncs, including most of the linalg module, will now unlock
 the Python global interpreter lock.
 
 
+The *__complex__* method has been implemented on the ndarray object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Calling ``complex()`` on a size 1 array will now cast to a python
+complex.
+
+
 Changes
 =======
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2326,12 +2326,10 @@ array_complex(PyArrayObject *self, PyObject *NPY_UNUSED(args))
     }
 
     if (!PyArray_CanCastArrayTo(self, dtype, NPY_SAME_KIND_CASTING) &&
-        !(PyArray_TYPE(self) == NPY_OBJECT) &&
-        !(PyArray_TYPE(self) == NPY_STRING) &&
-        !(PyArray_TYPE(self) == NPY_UNICODE)) {
+            !(PyArray_TYPE(self) == NPY_OBJECT)) {
         PyObject *err, *msg_part;
         Py_DECREF(dtype);
-        err = PyString_FromString("unable to convert dtype: ");
+        err = PyString_FromString("unable to convert ");
         if (err == NULL) {
             return NULL;
         }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2494,14 +2494,6 @@ class TestMethods(TestCase):
             cp = complex(c)
             assert_equal(cp, c, msg)
 
-        s = np.array([[['1+2j']]], 'S')
-        sp = complex(s)
-        assert_equal(sp, 1+2j)
-
-        u = np.array([[['1+2j']]], 'U')
-        up = complex(u)
-        assert_equal(up, 1+2j)
-
 
 class TestBinop(object):
     def test_inplace(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2494,6 +2494,28 @@ class TestMethods(TestCase):
             cp = complex(c)
             assert_equal(cp, c, msg)
 
+    def test__complex__should_not_work(self):
+        dtypes = ['i1', 'i2', 'i4', 'i8',
+                  'u1', 'u2', 'u4', 'u8',
+                  'f', 'd', 'g', 'F', 'D', 'G',
+                  '?', 'O']
+        for dt in dtypes:
+            a = np.array([1, 2, 3], dtype=dt)
+            assert_raises(TypeError, complex, a)
+
+        dt = np.dtype([('a', 'f8'), ('b', 'i1')])
+        b = np.array((1.0, 3), dtype=dt)
+        assert_raises(TypeError, complex, b)
+
+        c = np.array([(1.0, 3), (2e-3, 7)], dtype=dt)
+        assert_raises(TypeError, complex, c)
+
+        d = np.array('1+1j')
+        assert_raises(TypeError, complex, d)
+
+        e = np.array(['1+1j'], 'U')
+        assert_raises(TypeError, complex, e)
+
 
 class TestBinop(object):
     def test_inplace(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2476,6 +2476,33 @@ class TestMethods(TestCase):
         assert_raises(AttributeError, lambda: a.conj())
         assert_raises(AttributeError, lambda: a.conjugate())
 
+    def test__complex__(self):
+        dtypes = ['i1', 'i2', 'i4', 'i8',
+                  'u1', 'u2', 'u4', 'u8',
+                  'f', 'd', 'g', 'F', 'D', 'G',
+                  '?', 'O']
+        for dt in dtypes:
+            a = np.array(7, dtype=dt)
+            b = np.array([7], dtype=dt)
+            c = np.array([[[[[7]]]]], dtype=dt)
+
+            msg = 'dtype: {0}'.format(dt)
+            ap = complex(a)
+            assert_equal(ap, a, msg)
+            bp = complex(b)
+            assert_equal(bp, b, msg)
+            cp = complex(c)
+            assert_equal(cp, c, msg)
+
+        s = np.array([[['1+2j']]], 'S')
+        sp = complex(s)
+        assert_equal(sp, 1+2j)
+
+        u = np.array([[['1+2j']]], 'U')
+        up = complex(u)
+        assert_equal(up, 1+2j)
+
+
 class TestBinop(object):
     def test_inplace(self):
         # test refcount 1 inplace conversion


### PR DESCRIPTION
Fixes gh-2491.

There is still some asymmetry here.  Calling `float()` or `complex()` on a `np.string_` scalar will try to convert the string to a float or a complex.  But this still doesn't work for `size = 1` arrays.  

```
In [2]: float(np.array(['1.1']))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-981e3b7ad7d1> in <module>()
----> 1 float(np.array(['1.1']))

TypeError: don't know how to convert scalar number to float

In [3]: float(np.array(['1.1'])[0])
Out[3]: 1.1

In [4]: complex(np.array(['1.1']))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-a230266b5899> in <module>()
----> 1 complex(np.array(['1.1']))

TypeError: cannot convert to complex

In [5]: complex(np.array(['1.1'])[0])
Out[5]: (1.1+0j)
```
