### PR TITLE
BUG: Support array str and repr functions from subinterpreters

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -501,7 +501,10 @@ PyArray_SetStringFunction(PyObject *op, int repr)
 {
 
     PyObject *module_internal;
-
+    /* 
+     * Store the function in the _internal module so that it 
+     * can be safely used and customized in subinterpreters.
+     */
     module_internal = PyImport_ImportModule("numpy.core._internal");
     if (module_internal != NULL) {
         if (repr) {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -33,6 +33,7 @@ maintainer email:  oliphant.travis@ieee.org
 #include "npy_config.h"
 
 #include "npy_pycompat.h"
+#include "npy_import.h"
 
 #include "common.h"
 
@@ -430,93 +431,6 @@ array_dealloc(PyArrayObject *self)
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-/*
- * Extend string. On failure, returns NULL and leaves *strp alone.
- * XXX we do this in multiple places; time for a string library?
- */
-static char *
-extend(char **strp, Py_ssize_t n, Py_ssize_t *maxp)
-{
-    char *str = *strp;
-    Py_ssize_t new_cap;
-
-    if (n >= *maxp - 16) {
-        new_cap = *maxp * 2;
-
-        if (new_cap <= *maxp) {     /* overflow */
-            return NULL;
-        }
-        str = PyArray_realloc(*strp, new_cap);
-        if (str != NULL) {
-            *strp = str;
-            *maxp = new_cap;
-        }
-    }
-    return str;
-}
-
-static int
-dump_data(char **string, Py_ssize_t *n, Py_ssize_t *max_n, char *data, int nd,
-          npy_intp *dimensions, npy_intp *strides, PyArrayObject* self)
-{
-    PyArray_Descr *descr=PyArray_DESCR(self);
-    PyObject *op = NULL, *sp = NULL;
-    char *ostring;
-    npy_intp i, N, ret = 0;
-
-#define CHECK_MEMORY do {                           \
-        if (extend(string, *n, max_n) == NULL) {    \
-            ret = -1;                               \
-            goto end;                               \
-        }                                           \
-    } while (0)
-
-    if (nd == 0) {
-        if ((op = descr->f->getitem(data, self)) == NULL) {
-            return -1;
-        }
-        sp = PyObject_Repr(op);
-        if (sp == NULL) {
-            ret = -1;
-            goto end;
-        }
-        ostring = PyString_AsString(sp);
-        N = PyString_Size(sp)*sizeof(char);
-        *n += N;
-        CHECK_MEMORY;
-        memmove(*string + (*n - N), ostring, N);
-    }
-    else {
-        CHECK_MEMORY;
-        (*string)[*n] = '[';
-        *n += 1;
-        for (i = 0; i < dimensions[0]; i++) {
-            if (dump_data(string, n, max_n,
-                          data + (*strides)*i,
-                          nd - 1, dimensions + 1,
-                          strides + 1, self) < 0) {
-                return -1;
-            }
-            CHECK_MEMORY;
-            if (i < dimensions[0] - 1) {
-                (*string)[*n] = ',';
-                (*string)[*n+1] = ' ';
-                *n += 2;
-            }
-        }
-        CHECK_MEMORY;
-        (*string)[*n] = ']';
-        *n += 1;
-    }
-
-#undef CHECK_MEMORY
-
-end:
-    Py_XDECREF(op);
-    Py_XDECREF(sp);
-    return ret;
-}
-
 /*NUMPY_API
  * Prints the raw data of the ndarray in a form useful for debugging
  * low-level C issues.
@@ -579,46 +493,6 @@ PyArray_DebugPrint(PyArrayObject *obj)
     fflush(stdout);
 }
 
-static PyObject *
-array_repr_builtin(PyArrayObject *self, int repr)
-{
-    PyObject *ret;
-    char *string;
-    /* max_n initial value is arbitrary, dump_data will extend it */
-    Py_ssize_t n = 0, max_n = PyArray_NBYTES(self) * 4 + 7;
-
-    if ((string = PyArray_malloc(max_n)) == NULL) {
-        return PyErr_NoMemory();
-    }
-
-    if (dump_data(&string, &n, &max_n, PyArray_DATA(self),
-                  PyArray_NDIM(self), PyArray_DIMS(self),
-                  PyArray_STRIDES(self), self) < 0) {
-        PyArray_free(string);
-        return NULL;
-    }
-
-    if (repr) {
-        if (PyArray_ISEXTENDED(self)) {
-            ret = PyUString_FromFormat("array(%s, '%c%d')",
-                                       string,
-                                       PyArray_DESCR(self)->type,
-                                       PyArray_DESCR(self)->elsize);
-        }
-        else {
-            ret = PyUString_FromFormat("array(%s, '%c')",
-                                       string,
-                                       PyArray_DESCR(self)->type);
-        }
-    }
-    else {
-        ret = PyUString_FromStringAndSize(string, n);
-    }
-
-    PyArray_free(string);
-    return ret;
-}
-
 /*NUMPY_API
  * Set the array print function to be a Python function.
  */
@@ -659,51 +533,41 @@ PyArray_SetDatetimeParseFunction(PyObject *op)
 static PyObject *
 array_repr(PyArrayObject *self)
 {
-    PyObject *module_internal, *callable, *s, *arglist;
+    PyObject *s, *arglist;
+    PyObject *reprfunc = NULL;
 
-    module_internal = PyImport_ImportModule("numpy.core._internal");
-    if (module_internal == NULL) {
-        s = NULL;
+    npy_cache_import("numpy.core._internal", "_pyarray_repr_function", &reprfunc);
+    if (reprfunc == NULL) {
+        return NULL;
     }
     else {
-        callable = PyDict_GetItemString(PyModule_GetDict(module_internal), "_pyarray_repr_function");
-
-        if (callable == NULL) {
-            s = array_repr_builtin(self, 1);
-        }
-        else {
-            arglist = Py_BuildValue("(O)", self);
-            s = PyEval_CallObject(callable, arglist);
-            Py_DECREF(arglist);
-        }
+        arglist = Py_BuildValue("(O)", self);
+        s = PyEval_CallObject(reprfunc, arglist);
+        Py_DECREF(arglist);
+        Py_DECREF(reprfunc);
     }
     return s;
 }
+
 
 static PyObject *
 array_str(PyArrayObject *self)
 {
-    PyObject *module_internal, *callable, *s, *arglist;
+    PyObject *s, *arglist;
+    PyObject *strfunc = NULL;
 
-    module_internal = PyImport_ImportModule("numpy.core._internal");
-    if (module_internal == NULL) {
-        s = NULL;
+    npy_cache_import("numpy.core._internal", "_pyarray_str_function", &strfunc);
+    if (strfunc == NULL) {
+        return NULL;
     }
     else {
-        callable = PyDict_GetItemString(PyModule_GetDict(module_internal), "_pyarray_str_function");
-
-        if (callable == NULL) {
-            s = array_repr_builtin(self, 1);
-        }
-        else {
-            arglist = Py_BuildValue("(O)", self);
-            s = PyEval_CallObject(callable, arglist);
-            Py_DECREF(arglist);
-        }
+        arglist = Py_BuildValue("(O)", self);
+        s = PyEval_CallObject(strfunc, arglist);
+        Py_DECREF(arglist);
+        Py_DECREF(strfunc);
     }
     return s;
 }
-
 
 
 /*NUMPY_API


### PR DESCRIPTION
Move the str and repr function objects into the _internal module
so each subinterpreter has its own copy, fixes #3961
