### PR TITLE
MRG:  allow distributors to run custom init

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -106,6 +106,18 @@ Building against the BLAS implementation provided by the BLIS library is now
 supported.  See the ``[blis]`` section in ``site.cfg.example`` (in the root of
 the numpy repo or source distribution).
 
+Hook in ``numpy/__init__.py`` to run distribution-specific checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Binary distributions of numpy may need to run specific hardware checks or load
+specific libraries during numpy initialization.  For example, if we are
+distributing numpy with a BLAS library that requires SSE2 instructions, we
+would like to check the machine on which numpy is running does have SSE2 in
+order to give an informative error.
+
+Add a hook in ``numpy/__init__.py`` to import a ``numpy/_distributor_init.py``
+file that will remain empty (bar a docstring) in the standard numpy source,
+but that can be overwritten by people making binary distributions of numpy.
 
 Improvements
 ============

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -190,6 +190,9 @@ else:
     test = testing.nosetester._numpy_tester().test
     bench = testing.nosetester._numpy_tester().bench
 
+    # Allow distributors to run custom init code
+    from . import _distributor_init
+
     from . import core
     from .core import *
     from . import compat

--- a/numpy/_distributor_init.py
+++ b/numpy/_distributor_init.py
@@ -1,0 +1,10 @@
+""" Distributor init file
+
+Distributors: you can add custom code here to support particular distributions
+of numpy.
+
+For example, this is a good place to put any checks for hardware requirements.
+
+The numpy standard source distribution will not put code in this file, so you
+can safely replace this file with your own version.
+"""


### PR DESCRIPTION
Give hook to allow platform-specific installs to modify the
initialization of numpy.  Particular use-case is to allow check for SSE2
on Windows when shipping with ATLAS wheel.
