### PR TITLE
BLD: Switch order of test for lapack_mkl and openblas_lapack

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1488,14 +1488,14 @@ class lapack_opt_info(system_info):
 
     def calc_info(self):
 
-        openblas_info = get_info('openblas_lapack')
-        if openblas_info:
-            self.set_info(**openblas_info)
-            return
-
         lapack_mkl_info = get_info('lapack_mkl')
         if lapack_mkl_info:
             self.set_info(**lapack_mkl_info)
+            return
+
+        openblas_info = get_info('openblas_lapack')
+        if openblas_info:
+            self.set_info(**openblas_info)
             return
 
         atlas_info = get_info('atlas_3_10_threads')


### PR DESCRIPTION
The check for openblas_lapack comes before the check for lapack_mkl in lapack_opt_info.  This means that if openblas is installed on the system in one of the usual places, distutils will find it and use it even when mkl is specific in site.cfg.  Reverse the order, so it checks mkl's lapack first and then openblas, lets it use mkl when requested. (See  #6669)
