### PR TITLE
TST: Fail quickly on AppVeyor for superseded PR builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,11 @@ environment:
       PYTHON_ARCH: "x86"
 
 build_script:
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
   - cmd: C:\Miniconda.exe /S /D=C:\Py
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%


### PR DESCRIPTION
ref https://github.com/numpy/numpy/pull/7172#issuecomment-183859811

There's also the "rolling builds" option that should be equivalent to this, but you may not always want that since it can skip building some commits to master.
