### PR TITLE
Revert #6271 from charris/change-deprecated-indexes-to-error

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -152,7 +152,6 @@ to preserve struct layout). These were never used for anything, so
 it's unlikely that any third-party code is using them either, but we
 mention it here for completeness.
 
-
 New Features
 ============
 

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -798,14 +798,18 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
 #endif
     PyObject *obj, *err;
 
-    /*
-     * Be a bit stricter and not allow bools.
-     * np.bool_ is also disallowed as Boolean arrays do not currently
-     * support index.
-     */
-    if (!o || PyBool_Check(o) || PyArray_IsScalar(o, Bool)) {
+    if (!o) {
         PyErr_SetString(PyExc_TypeError, msg);
         return -1;
+    }
+
+    /* Be a bit stricter and not allow bools, np.bool_ is handled later */
+    if (PyBool_Check(o)) {
+        /* 2013-04-13, 1.8 */
+        if (DEPRECATE("using a boolean instead of an integer"
+                      " will result in an error in the future") < 0) {
+            return -1;
+        }
     }
 
     /*
@@ -833,22 +837,84 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
         return (npy_intp)long_value;
     }
 
+    /* Disallow numpy.bool_. Boolean arrays do not currently support index. */
+    if (PyArray_IsScalar(o, Bool)) {
+        /* 2013-06-09, 1.8 */
+        if (DEPRECATE("using a boolean instead of an integer"
+                      " will result in an error in the future") < 0) {
+            return -1;
+        }
+    }
+
     /*
      * The most general case. PyNumber_Index(o) covers everything
      * including arrays. In principle it may be possible to replace
      * the whole function by PyIndex_AsSSize_t after deprecation.
      */
     obj = PyNumber_Index(o);
-    if (obj == NULL) {
+    if (obj) {
+#if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(obj);
+#else
+        long_value = PyLong_AsLong(obj);
+#endif
+        Py_DECREF(obj);
+        goto finish;
+    }
+    else {
+        /*
+         * Set the TypeError like PyNumber_Index(o) would after trying
+         * the general case.
+         */
+        PyErr_Clear();
+    }
+
+    /*
+     * For backward compatibility check the number C-Api number protcol
+     * This should be removed up the finish label after deprecation.
+     */
+    if (Py_TYPE(o)->tp_as_number != NULL &&
+        Py_TYPE(o)->tp_as_number->nb_int != NULL) {
+        obj = Py_TYPE(o)->tp_as_number->nb_int(o);
+        if (obj == NULL) {
+            return -1;
+        }
+ #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(obj);
+ #else
+        long_value = PyLong_AsLong(obj);
+ #endif
+        Py_DECREF(obj);
+    }
+#if !defined(NPY_PY3K)
+    else if (Py_TYPE(o)->tp_as_number != NULL &&
+             Py_TYPE(o)->tp_as_number->nb_long != NULL) {
+        obj = Py_TYPE(o)->tp_as_number->nb_long(o);
+        if (obj == NULL) {
+            return -1;
+        }
+  #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
+        long_value = PyLong_AsLongLong(obj);
+  #else
+        long_value = PyLong_AsLong(obj);
+  #endif
+        Py_DECREF(obj);
+    }
+#endif
+    else {
+        PyErr_SetString(PyExc_TypeError, msg);
         return -1;
     }
-#if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
-    long_value = PyLong_AsLongLong(obj);
-#else
-    long_value = PyLong_AsLong(obj);
-#endif
-    Py_DECREF(obj);
+    /* Give a deprecation warning, unless there was already an error */
+    if (!error_converting(long_value)) {
+        /* 2013-04-13, 1.8 */
+        if (DEPRECATE("using a non-integer number instead of an integer"
+                      " will result in an error in the future") < 0) {
+            return -1;
+        }
+    }
 
+ finish:
     if (error_converting(long_value)) {
         err = PyErr_Occurred();
         /* Only replace TypeError's here, which are the normal errors. */
@@ -857,9 +923,9 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
         }
         return -1;
     }
-    goto overflow_check; /* silence unused warning */
 
-overflow_check:
+    goto overflow_check; /* silence unused warning */
+ overflow_check:
 #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)
   #if (NPY_SIZEOF_LONGLONG > NPY_SIZEOF_INTP)
     if ((long_value < NPY_MIN_INTP) || (long_value > NPY_MAX_INTP)) {

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -4,12 +4,14 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
+
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"
+#include "npy_import.h"
 
 #include "common.h"
 #include "arraytypes.h"
@@ -797,6 +799,10 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
     long long_value = -1;
 #endif
     PyObject *obj, *err;
+    static PyObject *VisibleDeprecation = NULL;
+
+    npy_cache_import(
+        "numpy", "VisibleDeprecationWarning", &VisibleDeprecation);
 
     if (!o) {
         PyErr_SetString(PyExc_TypeError, msg);
@@ -806,8 +812,11 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
     /* Be a bit stricter and not allow bools, np.bool_ is handled later */
     if (PyBool_Check(o)) {
         /* 2013-04-13, 1.8 */
-        if (DEPRECATE("using a boolean instead of an integer"
-                      " will result in an error in the future") < 0) {
+        if (PyErr_WarnEx(
+                VisibleDeprecation,
+                "using a boolean instead of an integer"
+                " will result in an error in the future",
+                1) < 0) {
             return -1;
         }
     }
@@ -840,8 +849,11 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
     /* Disallow numpy.bool_. Boolean arrays do not currently support index. */
     if (PyArray_IsScalar(o, Bool)) {
         /* 2013-06-09, 1.8 */
-        if (DEPRECATE("using a boolean instead of an integer"
-                      " will result in an error in the future") < 0) {
+        if (PyErr_WarnEx(
+                VisibleDeprecation,
+                "using a boolean instead of an integer"
+                " will result in an error in the future",
+                1) < 0) {
             return -1;
         }
     }
@@ -908,8 +920,11 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
     /* Give a deprecation warning, unless there was already an error */
     if (!error_converting(long_value)) {
         /* 2013-04-13, 1.8 */
-        if (DEPRECATE("using a non-integer number instead of an integer"
-                      " will result in an error in the future") < 0) {
+        if (PyErr_WarnEx(
+                VisibleDeprecation,
+                "using a non-integer number instead of an integer"
+                " will result in an error in the future",
+                1) < 0) {
             return -1;
         }
     }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -286,13 +286,35 @@ prepare_index(PyArrayObject *self, PyObject *index,
 
         /* Index is an ellipsis (`...`) */
         if (obj == Py_Ellipsis) {
-            /* At most one ellipsis in an index */
+            /*
+             * If there is more then one Ellipsis, it is replaced. Deprecated,
+             * since it is hard to imagine anyone using two Ellipsis and
+             * actually planning on all but the first being automatically
+             * replaced with a slice.
+             */
             if (index_type & HAS_ELLIPSIS) {
-                PyErr_Format(PyExc_IndexError,
-                    "an index can only have a single ellipsis ('...')");
-                goto failed_building_indices;
+                /* 2013-04-14, 1.8 */
+                if (DEPRECATE(
+                        "an index can only have a single Ellipsis (`...`); "
+                        "replace all but one with slices (`:`).") < 0) {
+                    goto failed_building_indices;
+                }
+                index_type |= HAS_SLICE;
+
+                indices[curr_idx].type = HAS_SLICE;
+                indices[curr_idx].object = PySlice_New(NULL, NULL, NULL);
+
+                if (indices[curr_idx].object == NULL) {
+                    goto failed_building_indices;
+                }
+
+                used_ndim += 1;
+                new_ndim += 1;
+                curr_idx += 1;
+                continue;
             }
             index_type |= HAS_ELLIPSIS;
+
             indices[curr_idx].type = HAS_ELLIPSIS;
             indices[curr_idx].object = NULL;
             /* number of slices it is worth, won't update if it is 0: */
@@ -395,8 +417,102 @@ prepare_index(PyArrayObject *self, PyObject *index,
                     goto failed_building_indices;
                 }
             }
-            else {
+            /*
+             * Special case to allow 0-d boolean indexing with
+             * scalars. Should be removed after boolean-array
+             * like as integer-array like deprecation.
+             * (does not cover ufunc.at, because it does not use the
+             * boolean special case, but that should not matter...)
+             * Since all but strictly boolean indices are invalid,
+             * there is no need for any further conversion tries.
+             */
+            else if (PyArray_NDIM(self) == 0) {
                 arr = tmp_arr;
+            }
+            else {
+                /*
+                 * These Checks can be removed after deprecation, since
+                 * they should then be either correct already or error out
+                 * later just like a normal array.
+                 */
+                if (PyArray_ISBOOL(tmp_arr)) {
+                    /* 2013-04-14, 1.8 */
+                    if (DEPRECATE_FUTUREWARNING(
+                            "in the future, boolean array-likes will be "
+                            "handled as a boolean array index") < 0) {
+                        Py_DECREF(tmp_arr);
+                        goto failed_building_indices;
+                    }
+                    if (PyArray_NDIM(tmp_arr) == 0) {
+                        /*
+                         * Need to raise an error here, since the
+                         * DeprecationWarning before was not triggered.
+                         * TODO: A `False` triggers a Deprecation *not* a
+                         *       a FutureWarning.
+                         */
+                        PyErr_SetString(PyExc_IndexError,
+                                "in the future, 0-d boolean arrays will be "
+                                "interpreted as a valid boolean index");
+                        Py_DECREF(tmp_arr);
+                        goto failed_building_indices;
+                    }
+                    else {
+                        arr = tmp_arr;
+                    }
+                }
+                /*
+                 * Note: Down the road, the integers will be cast to intp.
+                 *       The user has to make sure they can be safely cast.
+                 *       If not, we might index wrong instead of an giving
+                 *       an error.
+                 */
+                else if (!PyArray_ISINTEGER(tmp_arr)) {
+                    if (PyArray_NDIM(tmp_arr) == 0) {
+                        /* match integer deprecation warning */
+                        /* 2013-09-25, 1.8 */
+                        if (DEPRECATE(
+                                    "using a non-integer number instead of an "
+                                    "integer will result in an error in the "
+                                    "future") < 0) {
+
+                            /* The error message raised in the future */
+                            PyErr_SetString(PyExc_IndexError,
+                                "only integers, slices (`:`), ellipsis (`...`), "
+                                "numpy.newaxis (`None`) and integer or boolean "
+                                "arrays are valid indices");
+                            Py_DECREF((PyObject *)tmp_arr);
+                            goto failed_building_indices;
+                        }
+                    }
+                    else {
+                        /* 2013-09-25, 1.8 */
+                        if (DEPRECATE(
+                                    "non integer (and non boolean) array-likes "
+                                    "will not be accepted as indices in the "
+                                    "future") < 0) {
+
+                            /* Error message to be raised in the future */
+                            PyErr_SetString(PyExc_IndexError,
+                                "non integer (and non boolean) array-likes will "
+                                "not be accepted as indices in the future");
+                            Py_DECREF((PyObject *)tmp_arr);
+                            goto failed_building_indices;
+                        }
+                    }
+                }
+
+                arr = (PyArrayObject *)PyArray_FromArray(tmp_arr,
+                                            PyArray_DescrFromType(NPY_INTP),
+                                            NPY_ARRAY_FORCECAST);
+
+                if (arr == NULL) {
+                    /* Since this will be removed, handle this later */
+                    PyErr_Clear();
+                    arr = tmp_arr;
+                }
+                else {
+                    Py_DECREF((PyObject *)tmp_arr);
+                }
             }
         }
         else {

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -1025,10 +1025,17 @@ _array_copy_nice(PyArrayObject *self)
 static PyObject *
 array_index(PyArrayObject *v)
 {
-    if (!PyArray_ISINTEGER(v) || PyArray_NDIM(v) != 0) {
-        PyErr_SetString(PyExc_TypeError,
-            "only integer scalar arrays can be converted to a scalar index");
+    if (!PyArray_ISINTEGER(v) || PyArray_SIZE(v) != 1) {
+        PyErr_SetString(PyExc_TypeError, "only integer arrays with "     \
+                        "one element can be converted to an index");
         return NULL;
+    }
+    if (PyArray_NDIM(v) != 0) {
+        /* 2013-04-20, 1.8 */
+        if (DEPRECATE("converting an array with ndim > 0 to an index"
+                      " will result in an error in the future") < 0) {
+            return NULL;
+        }
     }
     return PyArray_DESCR(v)->f->getitem(PyArray_DATA(v), v);
 }

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -1025,6 +1025,11 @@ _array_copy_nice(PyArrayObject *self)
 static PyObject *
 array_index(PyArrayObject *v)
 {
+    static PyObject *VisibleDeprecation = NULL;
+
+    npy_cache_import(
+        "numpy", "VisibleDeprecationWarning", &VisibleDeprecation);
+
     if (!PyArray_ISINTEGER(v) || PyArray_SIZE(v) != 1) {
         PyErr_SetString(PyExc_TypeError, "only integer arrays with "     \
                         "one element can be converted to an index");
@@ -1032,8 +1037,11 @@ array_index(PyArrayObject *v)
     }
     if (PyArray_NDIM(v) != 0) {
         /* 2013-04-20, 1.8 */
-        if (DEPRECATE("converting an array with ndim > 0 to an index"
-                      " will result in an error in the future") < 0) {
+        if (PyErr_WarnEx(
+                VisibleDeprecation,
+                "converting an array with ndim > 0 to an index"
+                " will result in an error in the future",
+                1) < 0) {
             return NULL;
         }
     }

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -123,6 +123,237 @@ class _DeprecationTestCase(object):
                         exceptions=tuple(), args=args, kwargs=kwargs)
 
 
+class TestFloatNonIntegerArgumentDeprecation(_DeprecationTestCase):
+    """
+    These test that ``DeprecationWarning`` is given when you try to use
+    non-integers as arguments to for indexing and slicing e.g. ``a[0.0:5]``
+    and ``a[0.5]``, or other functions like ``array.reshape(1., -1)``.
+
+    After deprecation, changes need to be done inside conversion_utils.c
+    in PyArray_PyIntAsIntp and possibly PyArray_IntpConverter.
+    In iterators.c the function slice_GetIndices could be removed in favor
+    of its python equivalent and in mapping.c the function _tuple_of_integers
+    can be simplified (if ``np.array([1]).__index__()`` is also deprecated).
+
+    As for the deprecation time-frame: via Ralf Gommers,
+
+    "Hard to put that as a version number, since we don't know if the
+    version after 1.8 will be 6 months or 2 years after. I'd say 2
+    years is reasonable."
+
+    I interpret this to mean 2 years after the 1.8 release. Possibly
+    giving a PendingDeprecationWarning before that (which is visible
+    by default)
+
+    """
+    message = "using a non-integer number instead of an integer " \
+              "will result in an error in the future"
+
+    def test_indexing(self):
+        a = np.array([[[5]]])
+
+        def assert_deprecated(*args, **kwargs):
+            self.assert_deprecated(*args, exceptions=(IndexError,), **kwargs)
+
+        assert_deprecated(lambda: a[0.0])
+        assert_deprecated(lambda: a[0, 0.0])
+        assert_deprecated(lambda: a[0.0, 0])
+        assert_deprecated(lambda: a[0.0,:])
+        assert_deprecated(lambda: a[:, 0.0])
+        assert_deprecated(lambda: a[:, 0.0,:])
+        assert_deprecated(lambda: a[0.0,:,:])
+        assert_deprecated(lambda: a[0, 0, 0.0])
+        assert_deprecated(lambda: a[0.0, 0, 0])
+        assert_deprecated(lambda: a[0, 0.0, 0])
+        assert_deprecated(lambda: a[-1.4])
+        assert_deprecated(lambda: a[0, -1.4])
+        assert_deprecated(lambda: a[-1.4, 0])
+        assert_deprecated(lambda: a[-1.4,:])
+        assert_deprecated(lambda: a[:, -1.4])
+        assert_deprecated(lambda: a[:, -1.4,:])
+        assert_deprecated(lambda: a[-1.4,:,:])
+        assert_deprecated(lambda: a[0, 0, -1.4])
+        assert_deprecated(lambda: a[-1.4, 0, 0])
+        assert_deprecated(lambda: a[0, -1.4, 0])
+
+        # Test that the slice parameter deprecation warning doesn't mask
+        # the scalar index warning.
+        assert_deprecated(lambda: a[0.0:, 0.0], num=2)
+        assert_deprecated(lambda: a[0.0:, 0.0,:], num=2)
+
+    def test_valid_indexing(self):
+        a = np.array([[[5]]])
+        assert_not_deprecated = self.assert_not_deprecated
+
+        assert_not_deprecated(lambda: a[np.array([0])])
+        assert_not_deprecated(lambda: a[[0, 0]])
+        assert_not_deprecated(lambda: a[:, [0, 0]])
+        assert_not_deprecated(lambda: a[:, 0,:])
+        assert_not_deprecated(lambda: a[:,:,:])
+
+    def test_slicing(self):
+        a = np.array([[5]])
+
+        def assert_deprecated(*args, **kwargs):
+            self.assert_deprecated(*args, exceptions=(IndexError,), **kwargs)
+
+        # start as float.
+        assert_deprecated(lambda: a[0.0:])
+        assert_deprecated(lambda: a[0:, 0.0:2])
+        assert_deprecated(lambda: a[0.0::2, :0])
+        assert_deprecated(lambda: a[0.0:1:2,:])
+        assert_deprecated(lambda: a[:, 0.0:])
+        # stop as float.
+        assert_deprecated(lambda: a[:0.0])
+        assert_deprecated(lambda: a[:0, 1:2.0])
+        assert_deprecated(lambda: a[:0.0:2, :0])
+        assert_deprecated(lambda: a[:0.0,:])
+        assert_deprecated(lambda: a[:, 0:4.0:2])
+        # step as float.
+        assert_deprecated(lambda: a[::1.0])
+        assert_deprecated(lambda: a[0:, :2:2.0])
+        assert_deprecated(lambda: a[1::4.0, :0])
+        assert_deprecated(lambda: a[::5.0,:])
+        assert_deprecated(lambda: a[:, 0:4:2.0])
+        # mixed.
+        assert_deprecated(lambda: a[1.0:2:2.0], num=2)
+        assert_deprecated(lambda: a[1.0::2.0], num=2)
+        assert_deprecated(lambda: a[0:, :2.0:2.0], num=2)
+        assert_deprecated(lambda: a[1.0:1:4.0, :0], num=2)
+        assert_deprecated(lambda: a[1.0:5.0:5.0,:], num=3)
+        assert_deprecated(lambda: a[:, 0.4:4.0:2.0], num=3)
+        # should still get the DeprecationWarning if step = 0.
+        assert_deprecated(lambda: a[::0.0], function_fails=True)
+
+    def test_valid_slicing(self):
+        a = np.array([[[5]]])
+        assert_not_deprecated = self.assert_not_deprecated
+
+        assert_not_deprecated(lambda: a[::])
+        assert_not_deprecated(lambda: a[0:])
+        assert_not_deprecated(lambda: a[:2])
+        assert_not_deprecated(lambda: a[0:2])
+        assert_not_deprecated(lambda: a[::2])
+        assert_not_deprecated(lambda: a[1::2])
+        assert_not_deprecated(lambda: a[:2:2])
+        assert_not_deprecated(lambda: a[1:2:2])
+
+    def test_non_integer_argument_deprecations(self):
+        a = np.array([[5]])
+
+        self.assert_deprecated(np.reshape, args=(a, (1., 1., -1)), num=2)
+        self.assert_deprecated(np.reshape, args=(a, (np.array(1.), -1)))
+        self.assert_deprecated(np.take, args=(a, [0], 1.))
+        self.assert_deprecated(np.take, args=(a, [0], np.float64(1.)))
+
+    def test_non_integer_sequence_multiplication(self):
+        # Numpy scalar sequence multiply should not work with non-integers
+        def mult(a, b):
+            return a * b
+
+        self.assert_deprecated(mult, args=([1], np.float_(3)))
+        self.assert_not_deprecated(mult, args=([1], np.int_(3)))
+
+    def test_reduce_axis_float_index(self):
+        d = np.zeros((3,3,3))
+        self.assert_deprecated(np.min, args=(d, 0.5))
+        self.assert_deprecated(np.min, num=1, args=(d, (0.5, 1)))
+        self.assert_deprecated(np.min, num=1, args=(d, (1, 2.2)))
+        self.assert_deprecated(np.min, num=2, args=(d, (.2, 1.2)))
+
+
+class TestBooleanArgumentDeprecation(_DeprecationTestCase):
+    """This tests that using a boolean as integer argument/indexing is
+    deprecated.
+
+    This should be kept in sync with TestFloatNonIntegerArgumentDeprecation
+    and like it is handled in PyArray_PyIntAsIntp.
+    """
+    message = "using a boolean instead of an integer " \
+              "will result in an error in the future"
+
+    def test_bool_as_int_argument(self):
+        a = np.array([[[1]]])
+
+        self.assert_deprecated(np.reshape, args=(a, (True, -1)))
+        self.assert_deprecated(np.reshape, args=(a, (np.bool_(True), -1)))
+        # Note that operator.index(np.array(True)) does not work, a boolean
+        # array is thus also deprecated, but not with the same message:
+        assert_raises(TypeError, operator.index, np.array(True))
+        self.assert_deprecated(np.take, args=(a, [0], False))
+        self.assert_deprecated(lambda: a[False:True:True], exceptions=IndexError, num=3)
+        self.assert_deprecated(lambda: a[False, 0], exceptions=IndexError)
+        self.assert_deprecated(lambda: a[False, 0, 0], exceptions=IndexError)
+
+
+class TestArrayToIndexDeprecation(_DeprecationTestCase):
+    """This tests that creating an an index from an array is deprecated
+    if the array is not 0d.
+
+    This can probably be deprecated somewhat faster then the integer
+    deprecations. The deprecation period started with NumPy 1.8.
+    For deprecation this needs changing of array_index in number.c
+    """
+    message = "converting an array with ndim \> 0 to an index will result " \
+              "in an error in the future"
+
+    def test_array_to_index_deprecation(self):
+        # This drops into the non-integer deprecation, which is ignored here,
+        # so no exception is expected. The raising is effectively tested above.
+        a = np.array([[[1]]])
+
+        self.assert_deprecated(operator.index, args=(np.array([1]),))
+        self.assert_deprecated(np.reshape, args=(a, (a, -1)), exceptions=())
+        self.assert_deprecated(np.take, args=(a, [0], a), exceptions=())
+        # Check slicing. Normal indexing checks arrays specifically.
+        self.assert_deprecated(lambda: a[a:a:a], exceptions=(), num=3)
+
+class TestNonIntegerArrayLike(_DeprecationTestCase):
+    """Tests that array likes, i.e. lists give a deprecation warning
+    when they cannot be safely cast to an integer.
+    """
+    message = "non integer \(and non boolean\) array-likes will not be " \
+              "accepted as indices in the future"
+
+    def test_basic(self):
+        a = np.arange(10)
+        self.assert_deprecated(a.__getitem__, args=([0.5, 1.5],),
+                               exceptions=IndexError)
+        self.assert_deprecated(a.__getitem__, args=((['1', '2'],),),
+                               exceptions=IndexError)
+
+        self.assert_not_deprecated(a.__getitem__, ([],))
+
+    def test_boolean_futurewarning(self):
+        a = np.arange(10)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('always')
+            assert_warns(FutureWarning, a.__getitem__, [True])
+            # Unfortunatly, the deprecation warning takes precedence:
+            #assert_warns(FutureWarning, a.__getitem__, True)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            assert_raises(FutureWarning, a.__getitem__, [True])
+            #assert_raises(FutureWarning, a.__getitem__, True)
+
+
+class TestMultipleEllipsisDeprecation(_DeprecationTestCase):
+    message = "an index can only have a single Ellipsis \(`...`\); replace " \
+              "all but one with slices \(`:`\)."
+
+    def test_basic(self):
+        a = np.arange(10)
+        self.assert_deprecated(a.__getitem__, args=((Ellipsis, Ellipsis),))
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', '', DeprecationWarning)
+            # Just check that this works:
+            b = a[...,...]
+            assert_array_equal(a, b)
+            assert_raises(IndexError, a.__getitem__, ((Ellipsis, ) * 3,))
+
+
 class TestBooleanUnaryMinusDeprecation(_DeprecationTestCase):
     """Test deprecation of unary boolean `-`. While + and * are well
     defined, unary - is not and even a corrected form seems to have

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1948,25 +1948,19 @@ class TestBincount(TestCase):
 
     def test_with_incorrect_minlength(self):
         x = np.array([], dtype=int)
-        assert_raises_regex(TypeError,
-                            "'str' object cannot be interpreted",
+        assert_raises_regex(TypeError, "an integer is required",
                             lambda: np.bincount(x, minlength="foobar"))
-        assert_raises_regex(ValueError,
-                            "must be positive",
+        assert_raises_regex(ValueError, "must be positive",
                             lambda: np.bincount(x, minlength=-1))
-        assert_raises_regex(ValueError,
-                            "must be positive",
+        assert_raises_regex(ValueError, "must be positive",
                             lambda: np.bincount(x, minlength=0))
 
         x = np.arange(5)
-        assert_raises_regex(TypeError,
-                            "'str' object cannot be interpreted",
+        assert_raises_regex(TypeError, "an integer is required",
                             lambda: np.bincount(x, minlength="foobar"))
-        assert_raises_regex(ValueError,
-                            "minlength must be positive",
+        assert_raises_regex(ValueError, "minlength must be positive",
                             lambda: np.bincount(x, minlength=-1))
-        assert_raises_regex(ValueError,
-                            "minlength must be positive",
+        assert_raises_regex(ValueError, "minlength must be positive",
                             lambda: np.bincount(x, minlength=0))
 
 


### PR DESCRIPTION
This reverts commit 0b0206c1617841ed2e5324de752ee8ede2cce791, reversing
changes made to 438cdd3d75a0bb606e7ab7f96e59744c9b78d748.

This reverts all the changes of indexing deprecation warnings to errors
that were done prior to branching Numpy 1.11.x. It is easier to make a
clean reversion here than to pick out those bits involving integer
indexing specifically. As the aim of this reversion is to give
downstream projects a bit more time to adapt I don't think the slight
overkill is worth worrying about, especially if downstream projects
start paying close attention to deprecations.

The 1.11.0-notes also need updating, but I will submit a separate PR
against master for that.

Closes #7162.
