### PR TITLE
BUG: only benchmark complex256 if it exists

### DIFF
--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 from .common import Benchmark, get_squares_, get_indexes_, get_indexes_rand_
 
+from os.path import join as pjoin
+import shutil
 import sys
 import six
 from numpy import memmap, float32, array
 import numpy as np
+from tempfile import mkdtemp
 
 
 class Indexing(Benchmark):
@@ -37,8 +40,14 @@ class Indexing(Benchmark):
 
 class IndexingSeparate(Benchmark):
     def setup(self):
-        self.fp = memmap('tmp.dat', dtype=float32, mode='w+', shape=(50, 60))
+        self.tmp_dir = mkdtemp()
+        self.fp = memmap(pjoin(self.tmp_dir, 'tmp.dat'),
+                         dtype=float32, mode='w+', shape=(50, 60))
         self.indexes = array([3, 4, 6, 10, 20])
+
+    def teardown(self):
+        del self.fp
+        shutil.rmtree(self.tmp_dir)
 
     def time_mmap_slicing(self):
         for i in range(1000):

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -22,8 +22,9 @@ TYPES1 = [
     'int32', 'float32',
     'int64', 'float64',  'complex64',
     'longfloat', 'complex128',
-    'complex256',
 ]
+if 'complex256' in numpy.typeDict:
+    TYPES1.append('complex256')
 
 
 def memoize(func):


### PR DESCRIPTION
Only benchmark complex256 type if numpy has it (MSVC windows builds do
not).
