### PR TITLE
DOC: note in h/v/dstack points users to stack/concatenate

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -184,6 +184,10 @@ def vstack(tup):
     Take a sequence of arrays and stack them vertically to make a single
     array. Rebuild arrays divided by `vsplit`.
 
+    This function continues to be supported for backward compatibility, but
+    you should prefer ``np.concatenate`` or ``np.stack`` (keep in mind that
+    ``np.stack`` was added in numpy version 1.10).
+
     Parameters
     ----------
     tup : sequence of ndarrays
@@ -235,6 +239,10 @@ def hstack(tup):
 
     Take a sequence of arrays and stack them horizontally to make
     a single array. Rebuild arrays divided by `hsplit`.
+
+    This function continues to be supported for backward compatibility, but
+    you should prefer ``np.concatenate`` or ``np.stack`` (keep in mind that
+    ``np.stack`` was added in numpy version 1.10).
 
     Parameters
     ----------

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -185,8 +185,8 @@ def vstack(tup):
     array. Rebuild arrays divided by `vsplit`.
 
     This function continues to be supported for backward compatibility, but
-    you should prefer ``np.concatenate`` or ``np.stack`` (keep in mind that
-    ``np.stack`` was added in numpy version 1.10).
+    you should prefer ``np.concatenate`` or ``np.stack``. The ``np.stack``
+    function was added in NumPy 1.10.
 
     Parameters
     ----------
@@ -241,8 +241,8 @@ def hstack(tup):
     a single array. Rebuild arrays divided by `hsplit`.
 
     This function continues to be supported for backward compatibility, but
-    you should prefer ``np.concatenate`` or ``np.stack`` (keep in mind that
-    ``np.stack`` was added in numpy version 1.10).
+    you should prefer ``np.concatenate`` or ``np.stack``. The ``np.stack``
+    function was added in NumPy 1.10.
 
     Parameters
     ----------

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -326,8 +326,8 @@ def dstack(tup):
     3D array for processing.
 
     This function continues to be supported for backward compatibility, but
-    you should prefer ``np.concatenate`` or ``np.stack`` (keep in mind that
-    ``np.stack`` was added in numpy version 1.10).
+    you should prefer ``np.concatenate`` or ``np.stack``. The ``np.stack``
+    function was added in NumPy 1.10.
 
     Parameters
     ----------

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -325,6 +325,10 @@ def dstack(tup):
     This is a simple way to stack 2D arrays (images) into a single
     3D array for processing.
 
+    This function continues to be supported for backward compatibility, but
+    you should prefer ``np.concatenate`` or ``np.stack`` (keep in mind that
+    ``np.stack`` was added in numpy version 1.10).
+
     Parameters
     ----------
     tup : sequence of arrays


### PR DESCRIPTION
Warns users that they should be using `stack` and `concatenate` rather than the `*stack` functions. Discussion at #5605 shows why using stack/concatenate should be preferred (in particular [this comment](https://github.com/numpy/numpy/pull/5605#issuecomment-85180204)).

Also see the discussion at #7183, and previous PR #7191. 

@shoyer something along these lines is what you had in mind, right? Please let me know if this is the correct location for this message (it could also be placed under Notes), and whether it is sufficiently explicit.
