### PR TITLE
BUG: Enforce dtype for randint singletons

### DIFF
--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -116,9 +116,9 @@ def test_diophantine_fuzz():
             A_max = min(max_int, A_max)
             U_max = min(max_int-1, U_max)
 
-            A = tuple(rng.randint(1, A_max+1, dtype=np.intp)
+            A = tuple(int(rng.randint(1, A_max+1, dtype=np.intp))
                       for j in range(ndim))
-            U = tuple(rng.randint(0, U_max+2, dtype=np.intp)
+            U = tuple(int(rng.randint(0, U_max+2, dtype=np.intp))
                       for j in range(ndim))
 
             b_ub = min(max_int-2, sum(a*ub for a, ub in zip(A, U)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -582,7 +582,7 @@ def _rand_bool(low, high, size, rngstate):
     off = <npy_bool>(low)
     if size is None:
         rk_random_bool(off, rng, 1, &buf, state)
-        return buf
+        return np.bool_(<npy_bool>buf)
     else:
         array = <ndarray>np.empty(size, np.bool_)
         cnt = PyArray_SIZE(array)
@@ -609,7 +609,7 @@ def _rand_int8(low, high, size, rngstate):
     off = <npy_uint8>(<npy_int8>low)
     if size is None:
         rk_random_uint8(off, rng, 1, &buf, state)
-        return <npy_int8>buf
+        return np.int8(<npy_int8>buf)
     else:
         array = <ndarray>np.empty(size, np.int8)
         cnt = PyArray_SIZE(array)
@@ -636,7 +636,7 @@ def _rand_int16(low, high, size, rngstate):
     off = <npy_uint16>(<npy_int16>low)
     if size is None:
         rk_random_uint16(off, rng, 1, &buf, state)
-        return <npy_int16>buf
+        return np.int16(<npy_int16>buf)
     else:
         array = <ndarray>np.empty(size, np.int16)
         cnt = PyArray_SIZE(array)
@@ -687,7 +687,7 @@ def _rand_int32(low, high, size, rngstate):
     off = <npy_uint32>(<npy_int32>low)
     if size is None:
         rk_random_uint32(off, rng, 1, &buf, state)
-        return <npy_int32>buf
+        return np.int32(<npy_int32>buf)
     else:
         array = <ndarray>np.empty(size, np.int32)
         cnt = PyArray_SIZE(array)
@@ -714,7 +714,7 @@ def _rand_int64(low, high, size, rngstate):
     off = <npy_uint64>(<npy_int64>low)
     if size is None:
         rk_random_uint64(off, rng, 1, &buf, state)
-        return <npy_int64>buf
+        return np.int64(<npy_int64>buf)
     else:
         array = <ndarray>np.empty(size, np.int64)
         cnt = PyArray_SIZE(array)
@@ -740,7 +740,7 @@ def _rand_uint8(low, high, size, rngstate):
     off = <npy_uint8>(low)
     if size is None:
         rk_random_uint8(off, rng, 1, &buf, state)
-        return buf
+        return np.uint8(<npy_uint8>buf)
     else:
         array = <ndarray>np.empty(size, np.uint8)
         cnt = PyArray_SIZE(array)
@@ -767,7 +767,7 @@ def _rand_uint16(low, high, size, rngstate):
     off = <npy_uint16>(low)
     if size is None:
         rk_random_uint16(off, rng, 1, &buf, state)
-        return buf
+        return np.uint16(<npy_uint16>buf)
     else:
         array = <ndarray>np.empty(size, np.uint16)
         cnt = PyArray_SIZE(array)
@@ -794,7 +794,7 @@ def _rand_uint32(low, high, size, rngstate):
     off = <npy_uint32>(low)
     if size is None:
         rk_random_uint32(off, rng, 1, &buf, state)
-        return <npy_uint32>buf
+        return np.uint32(<npy_uint32>buf)
     else:
         array = <ndarray>np.empty(size, np.uint32)
         cnt = PyArray_SIZE(array)
@@ -821,7 +821,7 @@ def _rand_uint64(low, high, size, rngstate):
     off = <npy_uint64>(low)
     if size is None:
         rk_random_uint64(off, rng, 1, &buf, state)
-        return <npy_uint64>buf
+        return np.uint64(<npy_uint64>buf)
     else:
         array = <ndarray>np.empty(size, np.uint64)
         cnt = PyArray_SIZE(array)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -208,6 +208,15 @@ class TestRandint(TestCase):
         res = hashlib.md5(val).hexdigest()
         assert_(tgt[np.dtype(np.bool).name] == res)
 
+    def test_respect_dtype_singleton(self):
+        # See gh-7203
+        for dt in self.itype:
+            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+
+            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            self.assertEqual(sample.dtype, np.dtype(dt))
+
 
 class TestRandomDist(TestCase):
     # Make sure the random distribution returns the correct value for a


### PR DESCRIPTION
Addresses issue in #7203 in which specifying the `dtype` for a single integer was not being respected.  This PR makes the `randint` API consistent across all `size` specifications in that only numbers of `numpy` dtypes are returned, which already occurs when you generate arrays using `randint`.
