### PR TITLE
BUG/TST: Fix #7259, do not "force scalar" for already scalar str/bytes

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3527,7 +3527,14 @@ class MaskedArray(ndarray):
         """
         if self._fill_value is None:
             self._fill_value = _check_fill_value(None, self.dtype)
-        return self._fill_value[()]
+
+        # Temporary workaround to account for the fact that str and bytes
+        # scalars cannot be indexed with (), whereas all other numpy
+        # scalars can. See issues #7259 and #7267.
+        # The if-block can be removed after #7267 has been fixed.
+        if isinstance(self._fill_value, ndarray):
+            return self._fill_value[()]
+        return self._fill_value
 
     def set_fill_value(self, value=None):
         """

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1819,6 +1819,13 @@ class TestFillingValues(TestCase):
         y = x.view(dtype=np.int32)
         assert_(y.fill_value == 999999)
 
+    def test_fillvalue_bytes_or_str(self):
+        # Test whether fill values work as expected for structured dtypes
+        # containing bytes or str.  See issue #7259.
+        a = empty(shape=(3, ), dtype="(2)3S,(2)3U")
+        assert_equal(a["f0"].fill_value, default_fill_value(b"spam"))
+        assert_equal(a["f1"].fill_value, default_fill_value("eggs"))
+
 
 class TestUfuncs(TestCase):
     # Test class for the application of ufuncs on MaskedArrays.


### PR DESCRIPTION
Fix for #7259.  Since commit f8f753b, fill_value was forced scalar by
indexing with [()].  This works for most numpy scalars, but not for U
(str) and S (bytes).  This commit falls back to the pre-f8f753b version
when forcing to scalar fails for fill_value of dtypes with kind U and S.
Also add a test to see that this works in practice.
