### PR TITLE
BUG: Preserve array order in np.delete

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4097,7 +4097,7 @@ def delete(arr, obj, axis=None):
         if wrap:
             return wrap(arr)
         else:
-            return arr.copy()
+            return arr.copy(order=arrorder)
 
     slobj = [slice(None)]*ndim
     N = arr.shape[axis]
@@ -4110,9 +4110,9 @@ def delete(arr, obj, axis=None):
 
         if numtodel <= 0:
             if wrap:
-                return wrap(arr.copy())
+                return wrap(arr.copy(order=arrorder))
             else:
-                return arr.copy()
+                return arr.copy(order=arrorder)
 
         # Invert if step is negative:
         if step < 0:
@@ -4333,7 +4333,7 @@ def insert(arr, obj, values, axis=None):
         warnings.warn(
             "in the future the special handling of scalars will be removed "
             "from insert and raise an error", DeprecationWarning)
-        arr = arr.copy()
+        arr = arr.copy(order=arrorder)
         arr[...] = values
         if wrap:
             return wrap(arr)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -533,6 +533,16 @@ class TestDelete(TestCase):
         assert_(isinstance(delete(a, slice(1, 2)), SubClass))
         assert_(isinstance(delete(a, slice(1, -2)), SubClass))
 
+    def test_array_order_preserve(self):
+        # See gh-7113
+        k = np.arange(10).reshape(2, 5, order='F')
+        m = delete(k, slice(60, None), axis=1)
+
+        # 'k' is Fortran ordered, and 'm' should have the
+        # same ordering as 'k' and NOT become C ordered
+        assert_equal(m.flags.c_contiguous, k.flags.c_contiguous)
+        assert_equal(m.flags.f_contiguous, k.flags.f_contiguous)
+
 
 class TestGradient(TestCase):
 


### PR DESCRIPTION
Title is self-explanatory.  Closes #7113.
