### PR TITLE
DEP: Warn about assigning 'data' attribute of ndarray

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -118,3 +118,8 @@ Changes
 
 Deprecations
 ============
+
+Assignment of ndarray object's ``data`` attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Assigning the 'data' attribute is an inherently unsafe operation as pointed out
+in gh-7083. Such a capability will be removed in the future.

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -321,16 +321,20 @@ array_data_get(PyArrayObject *self)
 #endif
 }
 
-/*
- * TODO: Given view semantics, I think this function is a really
- *       bad idea, and should be removed!
- */
 static int
 array_data_set(PyArrayObject *self, PyObject *op)
 {
     void *buf;
     Py_ssize_t buf_len;
     int writeable=1;
+
+    /* 2016-19-02, 1.12 */
+    int ret = DEPRECATE("Assigning the 'data' attribute is an "
+                        "inherently unsafe operation and will "
+                        "be removed in the future.");
+    if (ret < 0) {
+        return -1;
+    }
 
     if (op == NULL) {
         PyErr_SetString(PyExc_AttributeError,

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -560,6 +560,24 @@ class TestInvalidOrderParameterInputForFlattenArrayDeprecation(_DeprecationTestC
         self.assert_deprecated(x.flatten, args=("FACK",))
 
 
+class TestArrayDataAttributeAssignmentDeprecation(_DeprecationTestCase):
+    """Assigning the 'data' attribute of an ndarray is unsafe as pointed
+     out in gh-7093. Eventually, such assignment should NOT be allowed, but
+     in the interests of maintaining backwards compatibility, only a Deprecation-
+     Warning will be raised instead for the time being to give developers time to
+     refactor relevant code.
+    """
+
+    def test_data_attr_assignment(self):
+        a = np.arange(10)
+        b = np.linspace(0, 1, 10)
+
+        self.message = ("Assigning the 'data' attribute is an "
+                        "inherently unsafe operation and will "
+                        "be removed in the future.")
+        self.assert_deprecated(a.__setattr__, args=('data', b.data))
+
+
 class TestTestDeprecated(object):
     def test_assert_deprecated(self):
         test_case_instance = _DeprecationTestCase()


### PR DESCRIPTION
I don't like unsafe operations either.  Closes #7093.

@njsmith 
