### PR TITLE
DOC: apply_along_axis missing whitespace inserted (before colon)

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -35,7 +35,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
         Input array.
     args : any
         Additional arguments to `func1d`.
-    kwargs: any
+    kwargs : any
         Additional named arguments to `func1d`.
 
         .. versionadded:: 1.9.0


### PR DESCRIPTION
The missing whitespace lead to inconsistent rendering in the
online documentation (see [numpy.apply_along_axis](http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.apply_along_axis.html)). [ci skip]
