### PR TITLE
BUG: Make returned unravel_index arrays writeable

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1234,7 +1234,7 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
                                 ret_dims, NPY_INTP,
                                 ret_strides,
                                 PyArray_BYTES(ret_arr) + i*sizeof(npy_intp),
-                                0, 0, NULL);
+                                0, NPY_ARRAY_WRITEABLE, NULL);
         if (view == NULL) {
             goto fail;
         }

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -86,6 +86,12 @@ class TestRavelUnravelIndex(TestCase):
         assert_raises(
             ValueError, np.ravel_multi_index, [5, 1, -1, 2], (4, 3, 7, 12))
 
+    def test_writeability(self):
+        # See gh-7269
+        x, y = np.unravel_index([1, 2, 3], (4, 5))
+        self.assertTrue(x.flags.writeable)
+        self.assertTrue(y.flags.writeable)
+
 
 class TestGrid(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Title is self-explanatory.  Closes #7269.

@anntzer @seberg 
