### PR TITLE
TST: Fixed elements being shuffled

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3277,7 +3277,7 @@ def _ureduce(a, func, **kwargs):
     a : array_like
         Input array or object that can be converted to an array.
     func : callable
-        Reduction function Kapable of receiving an axis argument.
+        Reduction function capable of receiving a single axis argument.
         It is is called with `a` as first argument followed by `kwargs`.
      kwargs : keyword arguments
         additional keyword arguments to pass to `func`.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2389,8 +2389,8 @@ class TestPercentile(TestCase):
         assert_equal(np.percentile(x, [25, 60], axis=(0,)),
                      np.percentile(x, [25, 60], axis=0))
 
-        d = np.arange(3 * 5 * 7 * 11).reshape(3, 5, 7, 11)
-        np.random.shuffle(d)
+        d = np.arange(3 * 5 * 7 * 11).reshape((3, 5, 7, 11))
+        np.random.shuffle(d.ravel())
         assert_equal(np.percentile(d, 25,  axis=(0, 1, 2))[0],
                      np.percentile(d[:,:,:, 0].flatten(), 25))
         assert_equal(np.percentile(d, [10, 90], axis=(0, 1, 3))[:, 1],
@@ -2617,7 +2617,7 @@ class TestMedian(TestCase):
                         [3,  4])
 
         a4 = np.arange(3 * 4 * 5, dtype=np.float32).reshape((3, 4, 5))
-        map(np.random.shuffle, a4)
+        np.random.shuffle(a4.ravel())
         assert_allclose(np.median(a4, axis=None),
                         np.median(a4.copy(), axis=None, overwrite_input=True))
         assert_allclose(np.median(a4, axis=0),
@@ -2765,8 +2765,8 @@ class TestMedian(TestCase):
         assert_equal(np.median(x, axis=(0, )), np.median(x, axis=0))
         assert_equal(np.median(x, axis=(-1, )), np.median(x, axis=-1))
 
-        d = np.arange(3 * 5 * 7 * 11).reshape(3, 5, 7, 11)
-        np.random.shuffle(d)
+        d = np.arange(3 * 5 * 7 * 11).reshape((3, 5, 7, 11))
+        np.random.shuffle(d.ravel())
         assert_equal(np.median(d, axis=(0, 1, 2))[0],
                      np.median(d[:,:,:, 0].flatten()))
         assert_equal(np.median(d, axis=(0, 1, 3))[1],

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -5003,6 +5003,10 @@ cdef class RandomState:
 
         Modify a sequence in-place by shuffling its contents.
 
+        This function only shuffles the array along the first axis of a
+        multi-dimensional array. The order of sub-arrays is changed but
+        their contents remains the same.
+
         Parameters
         ----------
         x : array_like
@@ -5019,8 +5023,7 @@ cdef class RandomState:
         >>> arr
         [1 7 5 2 9 4 3 6 0 8]
 
-        This function only shuffles the array along the first index of a
-        multi-dimensional array:
+        Multi-dimensional arrays are only shuffled along the first axis:
 
         >>> arr = np.arange(9).reshape((3, 3))
         >>> np.random.shuffle(arr)


### PR DESCRIPTION
Did not affect the current test results, but it caused a problem in some scipy code I was working on. Also, made a couple of doc changes.

The issue with only shuffling the first axis is that many of the combinations of dimensions will partition the relevance portions of the array right back into original order, guaranteeing that the answer will appear to be correct even if the indices were off.

Since the indices in all the affected tests were correct, this is more of a potential problem than an actual one, and even that with extremely low probability of ever manifesting.
