### PR TITLE
Backport 7285, BUG: Make randint backwards compatible with pandas

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1189,7 +1189,7 @@ cdef class RandomState:
         """
         return disc0_array(self.internal_state, rk_long, size, self.lock)
 
-    def randint(self, low, high=None, size=None, dtype='l'):
+    def randint(self, low, high=None, size=None, dtype=int):
         """
         randint(low, high=None, size=None, dtype='l')
 
@@ -1216,7 +1216,7 @@ cdef class RandomState:
             Desired dtype of the result. All dtypes are determined by their
             name, i.e., 'int64', 'int', etc, so byteorder is not available
             and a specific precision may have different C types depending
-            on the platform. The default value is 'l' (C long).
+            on the platform. The default value is 'np.int'.
 
             .. versionadded:: 1.11.0
 
@@ -1264,7 +1264,13 @@ cdef class RandomState:
             raise ValueError("low >= high")
 
         with self.lock:
-            return randfunc(low, high - 1, size, self.state_address)
+            ret = randfunc(low, high - 1, size, self.state_address)
+
+            if size is None:
+                if dtype in (np.bool, np.int, np.long):
+                    return dtype(ret)
+
+            return ret
 
     def bytes(self, npy_intp length):
         """

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -138,7 +138,7 @@ class TestRandint(TestCase):
     rfunc = np.random.randint
 
     # valid integer/boolean types
-    itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
+    itype = [np.bool_, np.int8, np.uint8, np.int16, np.uint16,
              np.int32, np.uint32, np.int64, np.uint64]
 
     def test_unsupported_type(self):
@@ -146,17 +146,17 @@ class TestRandint(TestCase):
 
     def test_bounds_checking(self):
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
-            assert_raises(ValueError, self.rfunc, lbnd - 1 , ubnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, lbnd , ubnd + 1, dtype=dt)
-            assert_raises(ValueError, self.rfunc, ubnd , lbnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, 1 , 0, dtype=dt)
+            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
+            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
+            assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
+            assert_raises(ValueError, self.rfunc, 1, 0, dtype=dt)
 
     def test_rng_zero_and_extremes(self):
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
             tgt = ubnd - 1
             assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
             tgt = lbnd
@@ -212,11 +212,20 @@ class TestRandint(TestCase):
     def test_respect_dtype_singleton(self):
         # See gh-7203
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
 
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
             self.assertEqual(sample.dtype, np.dtype(dt))
+
+        for dt in (np.bool, np.int, np.long):
+            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+
+            # gh-7284: Ensure that we get Python data types
+            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            self.assertFalse(hasattr(sample, 'dtype'))
+            self.assertEqual(type(sample), dt)
 
 
 class TestRandomDist(TestCase):


### PR DESCRIPTION
The 'pandas' library expects Python integers to be
returned, so this commit changes the API so that
the default is 'np.int' which converts to native
Python integer types when a singleton is being
generated with this function.
