### PR TITLE
Clarify error on repr failure in assert_equal.

### DIFF
--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -227,6 +227,19 @@ class TestEqual(TestArrayEqual):
         self._assert_func(x, x)
         self._test_not_equal(x, y)
 
+    def test_error_message(self):
+        try:
+            self._assert_func(np.array([1, 2]), np.matrix([1, 2]))
+        except AssertionError as e:
+            self.assertEqual(
+                str(e),
+                "\nArrays are not equal\n\n"
+                "(shapes (2,), (1, 2) mismatch)\n"
+                " x: array([1, 2])\n"
+                " y: [repr failed for <matrix>: The truth value of an array "
+                "with more than one element is ambiguous. Use a.any() or "
+                "a.all()]")
+
 
 class TestArrayAlmostEqual(_GenericTest, unittest.TestCase):
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -252,8 +252,8 @@ def build_err_msg(arrays, err_msg, header='Items are not equal:',
 
             try:
                 r = r_func(a)
-            except:
-                r = '[repr failed]'
+            except Exception as exc:
+                r = '[repr failed for <{}>: {}]'.format(type(a).__name__, exc)
             if r.count('\n') > 3:
                 r = '\n'.join(r.splitlines()[:3])
                 r += '...'


### PR DESCRIPTION
```
assert_equal(np.array([0, 1]), np.matrix([0, 1]))
```

used to print

```
 x: array([0, 1])
 y: [repr failed]
```

now prints

```
 x: array([0, 1])
 y: [repr failed for <matrix>: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()]
```

(the goal is to make test failures easier to debug)
