### PR TITLE
ENH: add support for BLIS to numpy.distutils

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -88,6 +88,13 @@ to the returned array is expected to avoid accidental
 unpredictable writes.
 
 
+BLIS support in ``numpy.distutils``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Building against the BLAS implementation provided by the BLIS library is now
+supported.  See the ``[blis]`` section in ``site.cfg.example`` (in the root of
+the numpy repo or source distribution).
+
+
 Improvements
 ============
 

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -130,6 +130,12 @@
 # include_dirs = /opt/OpenBLAS/include
 # runtime_library_dirs = /opt/OpenBLAS/lib
 
+# [blis]
+# libraries = blis
+# library_dirs = /home/username/blis/lib
+# include_dirs = /home/username/blis/include/blis
+# runtime_library_dirs = /home/username/blis/lib
+
 # MKL
 #----
 # MKL is Intel's very optimized yet proprietary implementation of BLAS and

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -130,6 +130,21 @@
 # include_dirs = /opt/OpenBLAS/include
 # runtime_library_dirs = /opt/OpenBLAS/lib
 
+# BLIS
+# ----
+# BLIS (https://github.com/flame/blis) also provides a BLAS interface.  It's a
+# relatively new library, its performance in some cases seems to match that of
+# MKL and OpenBLAS, but it hasn't been benchmarked with Numpy or Scipy yet.
+#
+# Notes on compiling BLIS itself:
+#   - the CBLAS interface (needed by Numpy) isn't built by default; define
+#     BLIS_ENABLE_CBLAS to build it.
+#   - ``./configure auto`` doesn't support 32-bit builds, see gh-7294 for
+#     details.
+# Notes on compiling Numpy against BLIS:
+#   - ``include_dirs`` below should be the directory where the BLIS cblas.h
+#     header is installed.
+#
 # [blis]
 # libraries = blis
 # library_dirs = /home/username/blis/lib


### PR DESCRIPTION
Note: the status of BLIS and some experiments/benchmarks in using it are discussed in gh-5479.

Besides adding a `blis_info` class plus the corresponding changes to `site.cfg.example`, a few things that generate spurious logging (checks for empty paths) are cleaned up.

Edit: mention that #5479 is now closed and #7372 has a more extensive discussion of BLIS.