### PR TITLE
BUG: Incrementing the wrong reference on return

### DIFF
--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -89,7 +89,7 @@ npy_ObjectLogicalOr(PyObject *i1, PyObject *i2)
         return i2;
     }
     else if (i2 == NULL) {
-        Py_INCREF(i2);
+        Py_INCREF(i1);
         return i1;
     }
     else {


### PR DESCRIPTION
How did this work before? If `i2` is `NULL`, `Py_INCREF` will generally crash. That pretty much means that this branch was never excercised in a test or elsewhere?
