### PR TITLE
STY: Fix GitHub rendering of ordered lists >9

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -325,129 +325,129 @@ The sections of the docstring are:
 
 10. **Notes**
 
-   An optional section that provides additional information about the
-   code, possibly including a discussion of the algorithm. This
-   section may include mathematical equations, written in
-   `LaTeX <http://www.latex-project.org/>`_ format::
+    An optional section that provides additional information about the
+    code, possibly including a discussion of the algorithm. This
+    section may include mathematical equations, written in
+    `LaTeX <http://www.latex-project.org/>`_ format::
 
-     The FFT is a fast implementation of the discrete Fourier transform:
+      The FFT is a fast implementation of the discrete Fourier transform:
 
-     .. math:: X(e^{j\omega } ) = x(n)e^{ - j\omega n}
+      .. math:: X(e^{j\omega } ) = x(n)e^{ - j\omega n}
 
-   Equations can also be typeset underneath the math directive::
+    Equations can also be typeset underneath the math directive::
 
-     The discrete-time Fourier time-convolution property states that
+      The discrete-time Fourier time-convolution property states that
 
-     .. math::
+      .. math::
 
-          x(n) * y(n) \Leftrightarrow X(e^{j\omega } )Y(e^{j\omega } )\\
-          another equation here
+           x(n) * y(n) \Leftrightarrow X(e^{j\omega } )Y(e^{j\omega } )\\
+           another equation here
 
-   Math can furthermore be used inline, i.e.
+    Math can furthermore be used inline, i.e.
 
-   ::
+    ::
 
-     The value of :math:`\omega` is larger than 5.
+      The value of :math:`\omega` is larger than 5.
 
-   Variable names are displayed in typewriter font, obtained by using
-   ``\mathtt{var}``::
+    Variable names are displayed in typewriter font, obtained by using
+    ``\mathtt{var}``::
 
-     We square the input parameter `alpha` to obtain
-     :math:`\mathtt{alpha}^2`.
+      We square the input parameter `alpha` to obtain
+      :math:`\mathtt{alpha}^2`.
 
-   Note that LaTeX is not particularly easy to read, so use equations
-   sparingly.
+    Note that LaTeX is not particularly easy to read, so use equations
+    sparingly.
 
-   Images are allowed, but should not be central to the explanation;
-   users viewing the docstring as text must be able to comprehend its
-   meaning without resorting to an image viewer.  These additional
-   illustrations are included using::
+    Images are allowed, but should not be central to the explanation;
+    users viewing the docstring as text must be able to comprehend its
+    meaning without resorting to an image viewer.  These additional
+    illustrations are included using::
 
-     .. image:: filename
+      .. image:: filename
 
-   where filename is a path relative to the reference guide source
-   directory.
+    where filename is a path relative to the reference guide source
+    directory.
 
 11. **References**
 
-   References cited in the **notes** section may be listed here,
-   e.g. if you cited the article below using the text ``[1]_``,
-   include it as in the list as follows::
+    References cited in the **notes** section may be listed here,
+    e.g. if you cited the article below using the text ``[1]_``,
+    include it as in the list as follows::
 
-     .. [1] O. McNoleg, "The integration of GIS, remote sensing,
-        expert systems and adaptive co-kriging for environmental habitat
-        modelling of the Highland Haggis using object-oriented, fuzzy-logic
-        and neural-network techniques," Computers & Geosciences, vol. 22,
-        pp. 585-588, 1996.
+      .. [1] O. McNoleg, "The integration of GIS, remote sensing,
+         expert systems and adaptive co-kriging for environmental habitat
+         modelling of the Highland Haggis using object-oriented, fuzzy-logic
+         and neural-network techniques," Computers & Geosciences, vol. 22,
+         pp. 585-588, 1996.
 
-   which renders as
+    which renders as
 
-   .. [1] O. McNoleg, "The integration of GIS, remote sensing,
-      expert systems and adaptive co-kriging for environmental habitat
-      modelling of the Highland Haggis using object-oriented, fuzzy-logic
-      and neural-network techniques," Computers & Geosciences, vol. 22,
-      pp. 585-588, 1996.
+    .. [1] O. McNoleg, "The integration of GIS, remote sensing,
+       expert systems and adaptive co-kriging for environmental habitat
+       modelling of the Highland Haggis using object-oriented, fuzzy-logic
+       and neural-network techniques," Computers & Geosciences, vol. 22,
+       pp. 585-588, 1996.
 
-   Referencing sources of a temporary nature, like web pages, is
-   discouraged.  References are meant to augment the docstring, but
-   should not be required to understand it.  References are numbered, starting
-   from one, in the order in which they are cited.
+    Referencing sources of a temporary nature, like web pages, is
+    discouraged.  References are meant to augment the docstring, but
+    should not be required to understand it.  References are numbered, starting
+    from one, in the order in which they are cited.
 
 12. **Examples**
 
-   An optional section for examples, using the `doctest
-   <http://docs.python.org/library/doctest.html>`_ format.
-   This section is meant to illustrate usage, not to provide a
-   testing framework -- for that, use the ``tests/`` directory.
-   While optional, this section is very strongly encouraged.
+    An optional section for examples, using the `doctest
+    <http://docs.python.org/library/doctest.html>`_ format.
+    This section is meant to illustrate usage, not to provide a
+    testing framework -- for that, use the ``tests/`` directory.
+    While optional, this section is very strongly encouraged.
 
-   When multiple examples are provided, they should be separated by
-   blank lines. Comments explaining the examples should have blank
-   lines both above and below them::
+    When multiple examples are provided, they should be separated by
+    blank lines. Comments explaining the examples should have blank
+    lines both above and below them::
 
-     >>> np.add(1, 2)
-     3
+      >>> np.add(1, 2)
+      3
 
-     Comment explaining the second example
+      Comment explaining the second example
 
-     >>> np.add([1, 2], [3, 4])
-     array([4, 6])
+      >>> np.add([1, 2], [3, 4])
+      array([4, 6])
 
-   For tests with a result that is random or platform-dependent, mark the
-   output as such::
+    For tests with a result that is random or platform-dependent, mark the
+    output as such::
 
-     >>> import numpy.random
-     >>> np.random.rand(2)
-     array([ 0.35773152,  0.38568979])  #random
+      >>> import numpy.random
+      >>> np.random.rand(2)
+      array([ 0.35773152,  0.38568979])  #random
 
-   You can run examples as doctests using::
+    You can run examples as doctests using::
 
-     >>> np.test(doctests=True)
-     >>> np.linalg.test(doctests=True)  # for a single module
+      >>> np.test(doctests=True)
+      >>> np.linalg.test(doctests=True)  # for a single module
 
-   In IPython it is also possible to run individual examples simply by
-   copy-pasting them in doctest mode::
+    In IPython it is also possible to run individual examples simply by
+    copy-pasting them in doctest mode::
 
-     In [1]: %doctest_mode
-     Exception reporting mode: Plain
-     Doctest mode is: ON
-     >>> %paste
-      import numpy.random
-      np.random.rand(2)
-     ## -- End pasted text --
-     array([ 0.8519522 ,  0.15492887])
+      In [1]: %doctest_mode
+      Exception reporting mode: Plain
+      Doctest mode is: ON
+      >>> %paste
+       import numpy.random
+       np.random.rand(2)
+      ## -- End pasted text --
+      array([ 0.8519522 ,  0.15492887])
 
 
-   It is not necessary to use the doctest markup ``<BLANKLINE>`` to
-   indicate empty lines in the output. Note that the option to run
-   the examples through ``numpy.test`` is provided for checking if the
-   examples work, not for making the examples part of the testing framework.
+    It is not necessary to use the doctest markup ``<BLANKLINE>`` to
+    indicate empty lines in the output. Note that the option to run
+    the examples through ``numpy.test`` is provided for checking if the
+    examples work, not for making the examples part of the testing framework.
 
-   The examples may assume that ``import numpy as np`` is executed before
-   the example code in *numpy*. Additional examples may make use of
-   *matplotlib* for plotting, but should import it explicitly, e.g.,
-   ``import matplotlib.pyplot as plt``. All other imports, including the
-   demonstrated function, must be explicit.
+    The examples may assume that ``import numpy as np`` is executed before
+    the example code in *numpy*. Additional examples may make use of
+    *matplotlib* for plotting, but should import it explicitly, e.g.,
+    ``import matplotlib.pyplot as plt``. All other imports, including the
+    demonstrated function, must be explicit.
 
 
 Documenting classes


### PR DESCRIPTION
No content changes. Numbers 10-12 [in this section](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#id5) of the documentation guide were not rendering correctly.

The fix was adding a single additional leading space to each line, correcting the indent for double-digit elements in the ordered list.
