### PR TITLE
ENH: Make _pointer_type_cache functional

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -315,7 +315,7 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
                   "_shape_" : shape,
                   "_ndim_" : ndim,
                   "_flags_" : num})
-    _pointer_type_cache[dtype] = klass
+    _pointer_type_cache[(dtype, shape, ndim, num)] = klass
     return klass
 
 if ctypes is not None:

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -101,6 +101,11 @@ class TestNdpointer(TestCase):
         self.assertTrue(p.from_param(x))
         self.assertRaises(TypeError, p.from_param, np.array([[1, 2], [3, 4]]))
 
+    def test_cache(self):
+        a1 = ndpointer(dtype=np.float64)
+        a2 = ndpointer(dtype=np.float64)
+        self.assertEqual(a1, a2)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fix #2303
Cache queries wont miss because the whole tuple is cached as key and not just dtype
Adapted from patch submitted by Colin Hogben
