### PR TITLE
BUG: np.sum with ``keepdims=True`` fails on masked_array

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4775,7 +4775,7 @@ class MaskedArray(ndarray):
         """
         return dot(self, b, out=out, strict=strict)
 
-    def sum(self, axis=None, dtype=None, out=None):
+    def sum(self, axis=None, dtype=None, out=None, keepdims=False):
         """
         Return the sum of the array elements over the given axis.
         Masked elements are set to 0 internally.
@@ -4795,6 +4795,9 @@ class MaskedArray(ndarray):
             Alternative output array in which to place the result. It must
             have the same shape and buffer length as the expected output
             but the type will be cast if necessary.
+        keepdims : bool, optional
+            If this is set to True, the axes which are reduced are left
+            in the result as dimensions with size one.
 
         Returns
         -------
@@ -4825,7 +4828,7 @@ class MaskedArray(ndarray):
         newmask = _check_mask_axis(_mask, axis)
         # No explicit output
         if out is None:
-            result = self.filled(0).sum(axis, dtype=dtype)
+            result = self.filled(0).sum(axis, dtype=dtype, keepdims=keepdims)
             rndim = getattr(result, 'ndim', 0)
             if rndim:
                 result = result.view(type(self))
@@ -4834,7 +4837,7 @@ class MaskedArray(ndarray):
                 result = masked
             return result
         # Explicit output
-        result = self.filled(0).sum(axis, dtype=dtype, out=out)
+        result = self.filled(0).sum(axis, dtype=dtype, out=out, keepdims=keepdims)
         if isinstance(out, MaskedArray):
             outmask = getattr(out, '_mask', nomask)
             if (outmask is nomask):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4262,6 +4262,29 @@ def test_default_fill_value_complex():
     # regression test for Python 3, where 'unicode' was not defined
     assert_(default_fill_value(1 + 1j) == 1.e20 + 0.0j)
 
+
+def test_sum_keepdims():
+
+    # Regression test for numpy/numpy#7312 which was due to masked_array.sum
+    # not supporting the keepdims option.
+
+    # First make sure keepdims works when called explicitly
+    result = np.sum(np.ma.masked_array([1, 2, 3], mask=[0, 0, 1]), keepdims=True)
+    assert result.shape == (1,)
+    assert result[0] == 3
+
+    # Also check that nanvar works correctly (which requires sum to support
+    # keepdims)
+    result = np.nanvar(np.ma.masked_array([1, 2, np.nan], mask=[0, 0, 1]))
+    assert result == 0.25
+
+    # Finally, also make sure that everything works correctly when using the
+    # 'out=' option
+    result = np.zeros(1)
+    np.sum(np.ma.masked_array([1, 2, 3], mask=[0, 0, 1]), keepdims=True, out=result)
+    assert result[0] == 3
+
+
 ###############################################################################
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
When calling `np.sum` on a masked array, and using the `keepdims` option, an error is raised:

```
In [1]: import numpy as np 

In [2]: np.sum(np.ma.masked_array([1,2,3],mask=[0,0,1]),keepdims=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-8-482ed005c74d> in <module>()
----> 1 np.sum(np.ma.masked_array([1,2,3],mask=[0,0,1]),keepdims=True)

/Users/tom/miniconda3/envs/production27/lib/python2.7/site-packages/numpy-1.12.0.dev0+0dbcd2f-py2.7-macosx-10.5-x86_64.egg/numpy/core/fromnumeric.pyc in sum(a, axis, dtype, out, keepdims)
   1843             pass
   1844         else:
-> 1845             return sum(axis=axis, dtype=dtype, out=out, **kwargs)
   1846     return _methods._sum(a, axis=axis, dtype=dtype,
   1847                          out=out, **kwargs)

TypeError: sum() got an unexpected keyword argument 'keepdims'
```
