### PR TITLE
TST: fix MemoryError on win32

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -593,6 +593,7 @@ class TestCreation(TestCase):
         for dt in types:
             d = np.zeros((30 * 1024**2,), dtype=dt)
             assert_(not d.any())
+            del(d)
 
     def test_zeros_obj(self):
         # test initialization from PyLong(0)


### PR DESCRIPTION
Fixes the MemoryError test error on 32-bit Python on Windows reported at #7316.

```
======================================================================
ERROR: test_zeros_big (test_multiarray.TestCreation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\numpy\core\tests\test_multiarray.py", line 586, in test_zeros_big
    d = np.zeros((30 * 1024**2,), dtype=dt)
MemoryError
```
