### PR TITLE
TST: Mark datetime test as a known failure on Python's below 2.7.

### DIFF
--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -741,6 +741,7 @@ class TestDatetime64Timezone(_DeprecationTestCase):
         self.assert_deprecated(np.datetime64, args=('2000-01-01T00Z',))
 
     @dec.skipif(not _has_pytz, "The pytz module is not available.")
+    @dec.knownfailureif(sys.version_info[0:2] < (2, 7))
     def test_datetime(self):
         tz = pytz.timezone('US/Eastern')
         dt = datetime.datetime(2000, 1, 1, 0, 0, tzinfo=tz)


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/7336

Appears that there is an attribute used by this test, `total_seconds` of `timedelta` objects that is not introduced until Python 2.7. So, this does not exist on Python 2.6. Here we mark this test as a known failure on Python's below 2.7.
