### PR TITLE
TST: Install `pytz` in the CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ before_install:
   - python -V
   - pip install --upgrade pip setuptools
   - pip install nose
+  - pip install pytz
   # pip install coverage
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose
+  - conda install cython nose pytz
   - pip install . -vvv
 
 test_script:


### PR DESCRIPTION
Fixes: https://github.com/numpy/numpy/issues/7335
Related: https://github.com/numpy/numpy/issues/7336

This should allow for some tests that require `pytz` to run during CI.
