### PR TITLE
TST: Add test for #6469

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1279,6 +1279,12 @@ class TestHistogram(TestCase):
         a, b = histogram([], bins=([0, 1]))
         assert_array_equal(a, np.array([0]))
         assert_array_equal(b, np.array([0, 1]))
+        
+    def test_error_binnum_type (self):
+        # Tests if right Error is raised if bins argument is float
+        vals = np.linspace(0.0, 1.0, num=100)
+        histogram(vals, 5)
+        assert_raises(TypeError, histogram, vals, 2.4)   
 
     def test_finite_range(self):
         # Normal ranges should be fine


### PR DESCRIPTION
This pull request adds a test for issue #6469:
The issue itself has been fixed in 34b582aadae8272e7b7209f7a05594e9258ba217 .
Checks that TypeError is raised if in function histogram argument bins is a float.
This pull request is part of a BCCN Berlin student project featuring @whops @rahul-nt @MaxKirstein @inesw
