### PR TITLE
TST: fix #6542, add tests to check non-iterable argument raises in hstack and related functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ before_install:
   - python -V
   - pip install --upgrade pip setuptools
   - pip install nose
+  - pip install pytz
   # pip install coverage
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose
+  - conda install cython nose pytz
   - pip install . -vvv
 
 test_script:

--- a/doc/neps/missing-data.rst
+++ b/doc/neps/missing-data.rst
@@ -413,11 +413,11 @@ New ndarray Methods
 New functions added to the numpy namespace are::
 
     np.isna(arr) [IMPLEMENTED]
-        Returns a boolean array with True whereever the array is masked
+        Returns a boolean array with True wherever the array is masked
         or matches the NA bitpattern, and False elsewhere
 
     np.isavail(arr)
-        Returns a boolean array with False whereever the array is masked
+        Returns a boolean array with False wherever the array is masked
         or matches the NA bitpattern, and True elsewhere
 
 New functions added to the ndarray are::

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -155,7 +155,7 @@ This approach to the interface consists of the object having an
        dimension. Each entry must be an integer (a Python
        :const:`int` or :const:`long`). As with shape, the values may
        be larger than can be represented by a C "int" or "long"; the
-       calling code should handle this appropiately, either by
+       calling code should handle this appropriately, either by
        raising an error, or by using :c:type:`Py_LONG_LONG` in C. The
        default is :const:`None` which implies a C-style contiguous
        memory buffer.  In this model, the last dimension of the array

--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -1,7 +1,7 @@
 """Subset of inspect module from upstream python
 
 We use this instead of upstream because upstream inspect is slow to import, and
-significanly contributes to numpy import times. Importing this copy has almost
+significantly contributes to numpy import times. Importing this copy has almost
 no overhead.
 
 """

--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -27,7 +27,7 @@ extern "C" CONFUSE_EMACS
 #include "__multiarray_api.h"
 
 
-/* C-API that requries previous API to be defined */
+/* C-API that requires previous API to be defined */
 
 #define PyArray_DescrCheck(op) (((PyObject*)(op))->ob_type==&PyArrayDescr_Type)
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -661,7 +661,7 @@ typedef struct tagPyArrayObject_fields {
      * views occur.
      *
      * For creation from buffer object it
-     * points to an object that shold be
+     * points to an object that should be
      * decref'd on deletion
      *
      * For UPDATEIFCOPY flag this is an
@@ -813,7 +813,7 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_ELEMENTSTRIDES  0x0080
 
 /*
- * Array data is aligned on the appropiate memory address for the type
+ * Array data is aligned on the appropriate memory address for the type
  * stored according to how the compiler would align things (e.g., an
  * array of integers (4 bytes each) starts on a memory address that's
  * a multiple of 4)

--- a/numpy/core/include/numpy/numpyconfig.h
+++ b/numpy/core/include/numpy/numpyconfig.h
@@ -6,7 +6,7 @@
 /*
  * On Mac OS X, because there is only one configuration stage for all the archs
  * in universal builds, any macro which depends on the arch needs to be
- * harcoded
+ * hardcoded
  */
 #ifdef __APPLE__
     #undef NPY_SIZEOF_LONG

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1180,9 +1180,9 @@ def tensordot(a, b, axes=2):
     Notes
     -----
     Three common use cases are:
-        ``axes = 0`` : tensor product $a\otimes b$
-        ``axes = 1`` : tensor dot product $a\cdot b$
-        ``axes = 2`` : (default) tensor double contraction $a:b$
+        * ``axes = 0`` : tensor product :math:`a\otimes b`
+        * ``axes = 1`` : tensor dot product :math:`a\cdot b`
+        * ``axes = 2`` : (default) tensor double contraction :math:`a:b`
 
     When `axes` is integer_like, the sequence for evaluation will be: first
     the -Nth axis in `a` and 0th axis in `b`, and the -1th axis in `a` and

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -218,7 +218,7 @@ append_metastr_to_string(PyArray_DatetimeMetaData *meta,
  * to UTC time, otherwise it returns the struct with the local time.
  *
  * Returns -1 on error, 0 on success, and 1 (with no error set)
- * if obj doesn't have the neeeded date or datetime attributes.
+ * if obj doesn't have the needed date or datetime attributes.
  */
 NPY_NO_EXPORT int
 convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -142,7 +142,7 @@ NPY_NO_EXPORT void *_PyDataMem_eventhook_user_data;
  * When the hook is called, the GIL will be held by the calling
  * thread.  The hook should be written to be reentrant, if it performs
  * operations that might cause new allocation events (such as the
- * creation/descruction numpy objects, or creating/destroying Python
+ * creation/destruction numpy objects, or creating/destroying Python
  * objects which might cause a gc)
  */
 NPY_NO_EXPORT PyDataMem_EventHookFunc *

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -107,7 +107,7 @@ raw_array_assign_array(int ndim, npy_intp *shape,
 }
 
 /*
- * Assigns the array from 'src' to 'dst, whereever the 'wheremask'
+ * Assigns the array from 'src' to 'dst, wherever the 'wheremask'
  * value is True. The strides must already have been broadcast.
  *
  * Returns 0 on success, -1 on failure.
@@ -230,7 +230,7 @@ PyArray_AssignArray(PyArrayObject *dst, PyArrayObject *src,
     }
 
     /*
-     * Performance fix for expresions like "a[1000:6000] += x".  In this
+     * Performance fix for expressions like "a[1000:6000] += x".  In this
      * case, first an in-place add is done, followed by an assignment,
      * equivalently expressed like this:
      *

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -96,7 +96,7 @@ PyArray_SetUpdateIfCopyBase(PyArrayObject *arr, PyArrayObject *base)
     }
 
     /*
-     * Any writes to 'arr' will magicaly turn into writes to 'base', so we
+     * Any writes to 'arr' will magically turn into writes to 'base', so we
      * should warn if necessary.
      */
     if (PyArray_FLAGS(base) & NPY_ARRAY_WARN_ON_WRITE) {

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -575,7 +575,7 @@ STRING_setitem(PyObject *op, void *ov, void *vap)
     }
     memcpy(ov, ptr, PyArray_MIN(PyArray_DESCR(ap)->elsize,len));
     /*
-     * If string lenth is smaller than room in array
+     * If string length is smaller than room in array
      * Then fill the rest of the element size with NULL
      */
     if (PyArray_DESCR(ap)->elsize > len) {

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -1101,7 +1101,7 @@ build_shape_string(npy_intp n, npy_intp *vals)
  *          validate this!
  *          If an axis flagged for removal has a shape larger then one,
  *          the aligned flag (and in the future the contiguous flags),
- *          may need explicite update.
+ *          may need explicit update.
  *          (check also NPY_RELAXED_STRIDES_CHECKING)
  *
  * For example, this can be used to remove the reduction axes

--- a/numpy/core/src/npymath/npy_math.c.src
+++ b/numpy/core/src/npymath/npy_math.c.src
@@ -2,7 +2,7 @@
  * vim:syntax=c
  * A small module to implement missing C99 math capabilities required by numpy
  *
- * Please keep this independant of python ! Only basic types (npy_longdouble)
+ * Please keep this independent of python ! Only basic types (npy_longdouble)
  * can be used, otherwise, pure C, without any use of Python facilities
  *
  * How to add a function to this section
@@ -29,7 +29,7 @@
  *    ii) Avoid as much as possible to declare any function here. Declaring
  *    functions is not portable: some platforms define some function inline
  *    with a non standard identifier, for example, or may put another
- *    idendifier which changes the calling convention of the function. If you
+ *    identifier which changes the calling convention of the function. If you
  *    really have to, ALWAYS declare it for the one platform you are dealing
  *    with:
  *

--- a/numpy/core/src/npysort/selection.c.src
+++ b/numpy/core/src/npysort/selection.c.src
@@ -7,7 +7,7 @@
  * http://ndevilla.free.fr/median/median/
  *
  * Quick select with median of 3 pivot is usually the fastest,
- * but the worst case scenario can be quadratic complexcity,
+ * but the worst case scenario can be quadratic complexity,
  * e.g. np.roll(np.arange(x), x / 2)
  * To avoid this if it recurses too much it falls back to the
  * worst case linear median of median of group 5 pivot strategy.

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -27,7 +27,7 @@
 /*
  * Allocates a result array for a reduction operation, with
  * dimensions matching 'arr' except set to 1 with 0 stride
- * whereever axis_flags is True. Dropping the reduction axes
+ * wherever axis_flags is True. Dropping the reduction axes
  * from the result must be done later by the caller once the
  * computation is complete.
  *

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -72,7 +72,7 @@ class _VisibleDeprecationTestCase(object):
         exceptions : Exception or tuple of Exceptions
             Exception to expect when turning the warnings into an error.
             The default checks for DeprecationWarnings. If exceptions is
-            empty the function is expected to run successfull.
+            empty the function is expected to run successfully.
         args : tuple
             Arguments for `function`
         kwargs : dict
@@ -173,7 +173,7 @@ class _DeprecationTestCase(object):
         exceptions : Exception or tuple of Exceptions
             Exception to expect when turning the warnings into an error.
             The default checks for DeprecationWarnings. If exceptions is
-            empty the function is expected to run successfull.
+            empty the function is expected to run successfully.
         args : tuple
             Arguments for `function`
         kwargs : dict

--- a/numpy/core/tests/test_machar.py
+++ b/numpy/core/tests/test_machar.py
@@ -17,7 +17,7 @@ class TestMachAr(TestCase):
 
     def test_underlow(self):
         # Regression test for #759:
-        # instanciating MachAr for dtype = np.float96 raises spurious warning.
+        # instantiating MachAr for dtype = np.float96 raises spurious warning.
         with errstate(all='raise'):
             try:
                 self._run_machar_highprec()

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -120,6 +120,9 @@ class TestAtleast3d(TestCase):
 
 
 class TestHstack(TestCase):
+    def test_non_iterable(self):
+        assert_raises(TypeError, hstack, 1)
+
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -143,6 +146,9 @@ class TestHstack(TestCase):
 
 
 class TestVstack(TestCase):
+    def test_non_iterable(self):
+        assert_raises(TypeError, vstack, 1)
+
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -265,6 +271,9 @@ class TestConcatenate(TestCase):
 
 
 def test_stack():
+    # non-iterable input
+    assert_raises(TypeError, stack, 1)
+
     # 0d input
     for input_ in [(1, 2, 3),
                    [np.int32(1), np.int32(2), np.int32(3)],

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -24,7 +24,7 @@ from numpy.distutils.from_template import process_file as process_f_file
 from numpy.distutils.conv_template import process_file as process_c_file
 
 def subst_vars(target, source, d):
-    """Substitute any occurence of @foo@ by d['foo'] from source file into
+    """Substitute any occurrence of @foo@ by d['foo'] from source file into
     target."""
     var = re.compile('@([a-zA-Z_]+)@')
     fs = open(source, 'r')

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -17,12 +17,12 @@ i.e.
  */
 /**end repeat1**/
 
-When using nested loops, you can optionally exlude particular
+When using nested loops, you can optionally exclude particular
 combinations of the variables using (inside the comment portion of the inner loop):
 
  :exclude: var1=value1, var2=value2, ...
 
-This will exlude the pattern where var1 is value1 and var2 is value2 when
+This will exclude the pattern where var1 is value1 and var2 is value2 when
 the result is being generated.
 
 
@@ -149,7 +149,7 @@ def parse_values(astr):
     # empty values, i.e., ()*4 yields ',,,'. The result is
     # split at ',' and a list of values returned.
     astr = parenrep.sub(paren_repl, astr)
-    # replaces occurences of xxx*3 with xxx, xxx, xxx
+    # replaces occurrences of xxx*3 with xxx, xxx, xxx
     astr = ','.join([plainrep.sub(paren_repl, x.strip())
                      for x in astr.split(',')])
     return astr.split(',')

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -94,14 +94,14 @@ class FCompiler(CCompiler):
     """
 
     # These are the environment variables and distutils keys used.
-    # Each configuration descripition is
+    # Each configuration description is
     # (<hook name>, <environment variable>, <key in distutils.cfg>, <convert>)
     # The hook names are handled by the self._environment_hook method.
     #  - names starting with 'self.' call methods in this class
     #  - names starting with 'exe.' return the key in the executables dict
     #  - names like 'flags.YYY' return self.get_flag_YYY()
     # convert is either None or a function to convert a string to the
-    # appropiate type used.
+    # appropriate type used.
 
     distutils_vars = EnvironmentConfig(
         distutils_section='config_fc',
@@ -287,7 +287,7 @@ class FCompiler(CCompiler):
 
     def find_executables(self):
         """Go through the self.executables dictionary, and attempt to
-        find and assign appropiate executables.
+        find and assign appropriate executables.
 
         Executable names are looked for in the environment (environment
         variables, the distutils.cfg, and command line), the 0th-element of
@@ -297,7 +297,7 @@ class FCompiler(CCompiler):
         or the Fortran 90 compiler executable is used, unless overridden
         by an environment setting.
 
-        Subclasses should call this if overriden.
+        Subclasses should call this if overridden.
         """
         assert self._is_customised
         exe_cache = self._exe_cache

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -172,7 +172,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
              extra_postargs=None,
              build_temp=None,
              target_lang=None):
-        # Include the appropiate MSVC runtime library if Python was built
+        # Include the appropriate MSVC runtime library if Python was built
         # with MSVC >= 7.0 (MinGW standard is msvcrt)
         runtime_library = msvc_runtime_library()
         if runtime_library:

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -72,7 +72,7 @@ The file 'site.cfg' is looked for in
 The first one found is used to get system configuration options The
 format is that used by ConfigParser (i.e., Windows .INI style). The
 section ALL has options that are the default for each section. The
-available sections are fftw, atlas, and x11. Appropiate defaults are
+available sections are fftw, atlas, and x11. Appropriate defaults are
 used if nothing is specified.
 
 The order of finding the locations of resources is the following:

--- a/numpy/doc/byteswapping.py
+++ b/numpy/doc/byteswapping.py
@@ -78,7 +78,7 @@ affect the relationship between the byte ordering of the array and the
 underlying memory it is looking at:
 
 * Change the byte-ordering information in the array dtype so that it
-  interprets the undelying data as being in a different byte order.
+  interprets the underlying data as being in a different byte order.
   This is the role of ``arr.newbyteorder()``
 * Change the byte-ordering of the underlying data, leaving the dtype
   interpretation as it was.  This is what ``arr.byteswap()`` does.

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -182,7 +182,7 @@ Glossary
          >>> [item**2 for item in x]
          [1, 4, 9]
 
-       It is often used in combintion with ``enumerate``::
+       It is often used in combination with ``enumerate``::
          >>> keys = ['a','b','c']
          >>> for n, k in enumerate(keys):
          ...     print("Key %d: %s" % (n, k))

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -158,8 +158,8 @@ Indexing Multi-dimensional arrays
 
 Things become more complex when multidimensional arrays are indexed,
 particularly with multidimensional index arrays. These tend to be
-more unusal uses, but theyare permitted, and they are useful for some
-problems. We'll  start with thesimplest multidimensional case (using
+more unusual uses, but they are permitted, and they are useful for some
+problems. We'll  start with the simplest multidimensional case (using
 the array y from the previous examples): ::
 
  >>> y[np.array([0,2,4]), np.array([0,1,2])]
@@ -211,7 +211,7 @@ such an array with an image with shape (ny, nx) with dtype=np.uint8
 lookup table) will result in an array of shape (ny, nx, 3) where a
 triple of RGB values is associated with each pixel location.
 
-In general, the shape of the resulant array will be the concatenation
+In general, the shape of the resultant array will be the concatenation
 of the shape of the index array (or the shape that all the index arrays
 were broadcast to) with the shape of any unused dimensions (those not
 indexed) in the array being indexed.

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -231,7 +231,7 @@ where our object creation housekeeping usually goes.
 * For view casting and new-from-template, the equivalent of
   ``ndarray.__new__(MySubClass,...`` is called, at the C level.
 
-The arguments that ``__array_finalize__`` recieves differ for the three
+The arguments that ``__array_finalize__`` receives differ for the three
 methods of instance creation above.
 
 The following code allows us to look at the call sequences and arguments:

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -6,7 +6,7 @@ low-level details.  Through datasource, a researcher can obtain and use a
 file with one function call, regardless of location of the file.
 
 DataSource is meant to augment standard python libraries, not replace them.
-It should work seemlessly with standard file IO operations and the os
+It should work seamlessly with standard file IO operations and the os
 module.
 
 DataSource files can originate locally or remotely:
@@ -317,7 +317,7 @@ class DataSource (object):
         return a path to that local file.
 
         The search will include possible compressed versions of the file
-        and return the first occurence found.
+        and return the first occurrence found.
 
         """
 

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1052,7 +1052,7 @@ def _normalize_shape(ndarray, shape, cast_to_int=True):
             arr = arr.repeat(2, axis=1)
         elif arr.shape[0] == ndims:
             # Input correctly formatted, pass it on as `arr`
-            arr = shape
+            pass
         else:
             fmt = "Unable to create correctly shaped tuple from %s"
             raise ValueError(fmt % (shape,))

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3336,7 +3336,7 @@ def _ureduce(a, func, **kwargs):
     func : callable
         Reduction function capable of receiving a single axis argument.
         It is is called with `a` as first argument followed by `kwargs`.
-     kwargs : keyword arguments
+    kwargs : keyword arguments
         additional keyword arguments to pass to `func`.
 
     Returns

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -477,6 +477,19 @@ class TestConstant(TestCase):
             )
         assert_allclose(test, expected)
 
+    def test_check_constant_pad_2d(self):
+        arr = np.arange(4).reshape(2, 2)
+        test = np.lib.pad(arr, ((1, 2), (1, 3)), mode='constant',
+                          constant_values=((1, 2), (3, 4)))
+        expected = np.array(
+            [[3, 1, 1, 4, 4, 4],
+             [3, 0, 1, 4, 4, 4],
+             [3, 2, 3, 4, 4, 4],
+             [3, 2, 2, 4, 4, 4],
+             [3, 2, 2, 4, 4, 4]]
+        )
+        assert_allclose(test, expected)
+
 
 class TestLinearRamp(TestCase):
     def test_check_simple(self):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -220,7 +220,7 @@ class TestHsplit(TestCase):
 
     """
     def test_non_iterable(self):
-        assert_raises(ValueError, hsplit, 1,1)
+        assert_raises(ValueError, hsplit, 1, 1)
 
     def test_0D_array(self):
         a = np.array(1)
@@ -249,15 +249,11 @@ class TestVsplit(TestCase):
 
     """
     def test_non_iterable(self):
-        assert_raises(ValueError, vsplit, 1,1)
+        assert_raises(ValueError, vsplit, 1, 1)
 
     def test_0D_array(self):
         a = np.array(1)
-        try:
-            vsplit(a, 2)
-            assert_(0)
-        except ValueError:
-            pass
+        assert_raises(ValueError, vsplit, a, 2)
 
     def test_1D_array(self):
         a = np.array([1, 2, 3, 4])
@@ -278,15 +274,11 @@ class TestVsplit(TestCase):
 class TestDsplit(TestCase):
     # Only testing for integer splits.
     def test_non_iterable(self):
-        assert_raises(ValueError, dsplit, 1,1)
+        assert_raises(ValueError, dsplit, 1, 1)
 
     def test_0D_array(self):
         a = np.array(1)
-        try:
-            dsplit(a, 2)
-            assert_(0)
-        except ValueError:
-            pass
+        assert_raises(ValueError, dsplit, a, 2)
 
     def test_1D_array(self):
         a = np.array([1, 2, 3, 4])

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.lib.shape_base import (
     apply_along_axis, apply_over_axes, array_split, split, hsplit, dsplit,
-    vsplit, dstack, kron, tile
+    vsplit, dstack, column_stack, kron, tile
     )
 from numpy.testing import (
     run_module_suite, TestCase, assert_, assert_equal, assert_array_equal,
@@ -175,8 +175,15 @@ class TestSplit(TestCase):
         a = np.arange(10)
         assert_raises(ValueError, split, a, 3)
 
+class TestColumnStack(TestCase):
+    def test_non_iterable(self):
+        assert_raises(TypeError, column_stack, 1)
+
 
 class TestDstack(TestCase):
+    def test_non_iterable(self):
+        assert_raises(TypeError, dstack, 1)
+
     def test_0D_array(self):
         a = np.array(1)
         b = np.array(2)
@@ -212,6 +219,9 @@ class TestHsplit(TestCase):
     """Only testing for integer splits.
 
     """
+    def test_non_iterable(self):
+        assert_raises(ValueError, hsplit, 1,1)
+
     def test_0D_array(self):
         a = np.array(1)
         try:
@@ -238,6 +248,17 @@ class TestVsplit(TestCase):
     """Only testing for integer splits.
 
     """
+    def test_non_iterable(self):
+        assert_raises(ValueError, vsplit, 1,1)
+
+    def test_0D_array(self):
+        a = np.array(1)
+        try:
+            vsplit(a, 2)
+            assert_(0)
+        except ValueError:
+            pass
+
     def test_1D_array(self):
         a = np.array([1, 2, 3, 4])
         try:
@@ -256,6 +277,24 @@ class TestVsplit(TestCase):
 
 class TestDsplit(TestCase):
     # Only testing for integer splits.
+    def test_non_iterable(self):
+        assert_raises(ValueError, dsplit, 1,1)
+
+    def test_0D_array(self):
+        a = np.array(1)
+        try:
+            dsplit(a, 2)
+            assert_(0)
+        except ValueError:
+            pass
+
+    def test_1D_array(self):
+        a = np.array([1, 2, 3, 4])
+        try:
+            dsplit(a, 2)
+            assert_(0)
+        except ValueError:
+            pass
 
     def test_2D_array(self):
         a = np.array([[1, 2, 3, 4],

--- a/numpy/linalg/lapack_lite/README
+++ b/numpy/linalg/lapack_lite/README
@@ -21,8 +21,8 @@ properly. Assuming that you have an unpacked LAPACK source tree in
 $ python ./make_lite.py wrapped_routines ~/LAPACK new-lite/
 
 This will grab the right routines, with dependencies, put them into the
-appropiate ``blas_lite.f``, ``dlapack_lite.f``, or ``zlapack_lite.f`` files,
-run ``f2c`` over them, then do some scrubbing similiar to that done to
+appropriate ``blas_lite.f``, ``dlapack_lite.f``, or ``zlapack_lite.f`` files,
+run ``f2c`` over them, then do some scrubbing similar to that done to
 generate the CLAPACK_ distribution.
 
 .. _CLAPACK: http://netlib.org/clapack/index.html

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -223,7 +223,7 @@ def removeHeader(source):
     return lines.getValue()
 
 def replaceDlamch(source):
-    """Replace dlamch_ calls with appropiate macros"""
+    """Replace dlamch_ calls with appropriate macros"""
     def repl(m):
         s = m.group(1)
         return dict(E='EPSILON', P='PRECISION', S='SAFEMINIMUM',

--- a/numpy/linalg/lapack_lite/zlapack_lite.c
+++ b/numpy/linalg/lapack_lite/zlapack_lite.c
@@ -10044,7 +10044,7 @@ L80:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine DLAED2.
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -29,7 +29,7 @@ from numpy.ma.testutils import (
     )
 from numpy.ma.core import (
     MAError, MaskError, MaskType, MaskedArray, abs, absolute, add, all,
-    allclose, allequal, alltrue, angle, anom, arange, arccos, arctan2,
+    allclose, allequal, alltrue, angle, anom, arange, arccos, arccosh, arctan2,
     arcsin, arctan, argsort, array, asarray, choose, concatenate,
     conjugate, cos, cosh, count, default_fill_value, diag, divide, empty,
     empty_like, equal, exp, flatten_mask, filled, fix_invalid,
@@ -1943,6 +1943,33 @@ class TestUfuncs(TestCase):
         assert_(a * me_too == "Me2rmul")
         assert_(a / me_too == "Me2rdiv")
 
+    def test_no_masked_nan_warnings(self):
+        # check that a nan in masked position does not
+        # cause ufunc warnings
+
+        m = np.ma.array([0.5, np.nan], mask=[0,1])
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
+
+            # test unary and binary ufuncs
+            exp(m)
+            add(m, 1)
+            m > 0
+
+            # test different unary domains
+            sqrt(m)
+            log(m)
+            tan(m)
+            arcsin(m)
+            arccos(m)
+            arccosh(m)
+
+            # test binary domains
+            divide(m, 2)
+
+            # also check that allclose uses ma ufuncs, to avoid warning
+            allclose(m, 0.5)
 
 class TestMaskedArrayInPlaceArithmetics(TestCase):
     # Test MaskedArray Arithmetics

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -998,7 +998,7 @@ class TestArraySetOps(TestCase):
         control = array([1, 1, 1, 4], mask=[1, 0, 0, 1])
         test = ediff1d(x)
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_tobegin(self):
@@ -1007,13 +1007,13 @@ class TestArraySetOps(TestCase):
         test = ediff1d(x, to_begin=masked)
         control = array([0, 1, 1, 1, 4], mask=[1, 1, 0, 0, 1])
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
         #
         test = ediff1d(x, to_begin=[1, 2, 3])
         control = array([1, 2, 3, 1, 1, 1, 4], mask=[0, 0, 0, 1, 0, 0, 1])
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_toend(self):
@@ -1022,13 +1022,13 @@ class TestArraySetOps(TestCase):
         test = ediff1d(x, to_end=masked)
         control = array([1, 1, 1, 4, 0], mask=[1, 0, 0, 1, 1])
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
         #
         test = ediff1d(x, to_end=[1, 2, 3])
         control = array([1, 1, 1, 4, 1, 2, 3], mask=[1, 0, 0, 1, 0, 0, 0])
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_tobegin_toend(self):
@@ -1037,14 +1037,14 @@ class TestArraySetOps(TestCase):
         test = ediff1d(x, to_end=masked, to_begin=masked)
         control = array([0, 1, 1, 1, 4, 0], mask=[1, 1, 0, 0, 1, 1])
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
         #
         test = ediff1d(x, to_end=[1, 2, 3], to_begin=masked)
         control = array([0, 1, 1, 1, 4, 1, 2, 3],
                         mask=[1, 1, 0, 0, 1, 0, 0, 0])
         assert_equal(test, control)
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_ndarray(self):
@@ -1054,13 +1054,13 @@ class TestArraySetOps(TestCase):
         control = array([1, 1, 1, 1], mask=[0, 0, 0, 0])
         assert_equal(test, control)
         self.assertTrue(isinstance(test, MaskedArray))
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
         #
         test = ediff1d(x, to_end=masked, to_begin=masked)
         control = array([0, 1, 1, 1, 1, 0], mask=[1, 0, 0, 0, 0, 1])
         self.assertTrue(isinstance(test, MaskedArray))
-        assert_equal(test.data, control.data)
+        assert_equal(test.filled(0), control.filled(0))
         assert_equal(test.mask, control.mask)
 
     def test_intersect1d(self):

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -156,7 +156,7 @@ def matrix_power(M, n):
     >>> q = np.zeros((4, 4))
     >>> q[0:2, 0:2] = -i
     >>> q[2:4, 2:4] = i
-    >>> q # one of the three quarternion units not equal to 1
+    >>> q # one of the three quaternion units not equal to 1
     array([[ 0., -1.,  0.,  0.],
            [ 1.,  0.,  0.,  0.],
            [ 0.,  0.,  0.,  1.],

--- a/tools/win32build/build.py
+++ b/tools/win32build/build.py
@@ -1,7 +1,7 @@
 """Python script to build windows binaries to be fed to the "superpack".
 
 The script is pretty dumb: it assumes python executables are installed the
-standard way, and the location for blas/lapack/atlas is harcoded.
+standard way, and the location for blas/lapack/atlas is hardcoded.
 
 TODO:
     - integrate the x86analysis script to check built binaries
@@ -106,7 +106,7 @@ def get_binary_name(arch):
 
 def get_windist_exec(pyver):
     """Return the name of the installer built by wininst command."""
-    # Yeah, the name logic is harcoded in distutils. We have to reproduce it
+    # Yeah, the name logic is hardcoded in distutils. We have to reproduce it
     # here
     if BUILD_MSI:
         ext = '.msi'

--- a/tools/win32build/prepare_bootstrap.py
+++ b/tools/win32build/prepare_bootstrap.py
@@ -9,7 +9,7 @@ import re
 
 def get_sdist_tarball():
     """Return the name of the installer built by wininst command."""
-    # Yeah, the name logic is harcoded in distutils. We have to reproduce it
+    # Yeah, the name logic is hardcoded in distutils. We have to reproduce it
     # here
     name = "numpy-%s.zip" % get_numpy_version()
     return name


### PR DESCRIPTION
Collaboration with @clauslang, @ClaudiaWinklmayr, @zukkini:

-test that calls to hstack, vstack, stack, hsplit, vsplit, dsplit, dstack with non-iterable inputs raise errors
