### PR TITLE
Backport 7338, TST: Use pytz CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ before_install:
   - python -V
   - pip install --upgrade pip setuptools
   - pip install nose
+  - pip install pytz
   # pip install coverage
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose
+  - conda install cython nose pytz
   - pip install . -vvv
 
 test_script:


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/issues/7336
Related: https://github.com/numpy/numpy/pull/7337
Related: https://github.com/numpy/numpy/issues/7338

This should allow for some tests that require `pytz` to run during CI.
