### PR TITLE
Maint: Removed extra space from `ureduce`

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3336,7 +3336,7 @@ def _ureduce(a, func, **kwargs):
     func : callable
         Reduction function capable of receiving a single axis argument.
         It is is called with `a` as first argument followed by `kwargs`.
-     kwargs : keyword arguments
+    kwargs : keyword arguments
         additional keyword arguments to pass to `func`.
 
     Returns


### PR DESCRIPTION
This is just me being OCD. I am not sure this even merits a full commit, much less a PR, but here goes anyway.
