### PR TITLE
MAINT: Fix copy and paste oversight.

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4488,7 +4488,7 @@ intern_strings(void)
 
     return npy_ma_str_array && npy_ma_str_array_prepare &&
            npy_ma_str_array_wrap && npy_ma_str_array_finalize &&
-           npy_ma_str_array_finalize && npy_ma_str_ufunc &&
+           npy_ma_str_buffer && npy_ma_str_ufunc &&
            npy_ma_str_order && npy_ma_str_copy && npy_ma_str_dtype &&
            npy_ma_str_ndmin;
 }


### PR DESCRIPTION
Variable npy_ma_str_array_finalize replaced with variable
npy_ma_str_buffer in return statement. Found with cppcheck.
