### PR TITLE
ENH: Make no unshare mask future warnings less noisy

### DIFF
--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -41,8 +41,6 @@ Future Changes
 The following changes are scheduled for Numpy 1.12.0.
 
 * Support for Python 2.6, 3.2, and 3.3 will be dropped.
-* Slicing a ``MaskedArray`` will return views of both data **and** mask.
-  Currently the mask is returned as a copy.
 * Relaxed stride checking will become the default. See the 1.8.0 release
   notes for a more extended discussion of what this change implies.
 * The behavior of the datetime64 "not a time" (NaT) value will be changed
@@ -70,6 +68,33 @@ In a future release the following changes will be made.
   change.  That differs from the current behavior where arrays that are
   f_contiguous but not c_contiguous can be viewed as a dtype type of
   different size causing the first dimension to change.
+* Currently, taking a view of a masked array produces a confusing result.
+  For example, if we write ``masked_view = masked_original[:]``, then
+  ``masked_view``'s data array will be a view of ``masked_original``'s data
+  array, so modifications to one array's data will also affect the other:
+  ``masked_view[0] = 123; assert masked_original[0] == 123``. But currently,
+  the *mask* array is copied during assignment operations. While
+  mask is *initially* a view it is considered to be *shared*.
+  The first assignment to the masked array will thus cause an implicit
+  copy, so that changes of one array's mask will not affect the other:
+  ``masked_view[0] = np.ma.masked; assert masked_original[0] is not
+  np.ma.masked``.
+  A similar situation happens when explicitly constructing a masked
+  array using ``MaskedArray(data, mask)`` -- the returned array will have
+  a view of ``data`` and "shares" the ``mask``. In the future, these cases
+  will be normalized so that the data and mask arrays are treated the
+  same way, and modifications to either will propagate between views.
+  The mask will not be copied during assignment operations and instead
+  the original mask will be modified as well. In 1.11, numpy will issue a
+  ``MaskedArrayFutureWarning`` warning whenever user code modifies the mask
+  of a view and this may cause values to propagate to another array.
+  To silence these warnings, and make your code robust against the
+  upcoming changes, you have two options: if you want to keep the current
+  behavior, call ``masked_view.unshare_mask()`` before modifying the mask.
+  If you want to get the future behavior early, use
+  ``masked_view._sharedmask = False``. However, note that setting
+  the ``_sharedmask`` attribute will break following explicit calls to
+  ``masked_view.unshare_mask()``.
 
 
 Compatibility notes

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -689,6 +689,7 @@ def median(a, axis=None, out=None, overwrite_input=False):
     # insert indices of low and high median
     ind.insert(axis, h - 1)
     low = asorted[ind]
+    low._sharedmask = False
     ind[axis] = h
     high = asorted[ind]
     # duplicate high if odd number of elements so mean does nothing
@@ -1173,9 +1174,9 @@ def _covhelper(x, y=None, rowvar=True, allow_masked=True):
                 # Define some common mask
                 common_mask = np.logical_or(xmask, ymask)
                 if common_mask is not nomask:
-                    x.unshare_mask()
-                    y.unshare_mask()
                     xmask = x._mask = y._mask = ymask = common_mask
+                    x._sharedmask = False
+                    y._sharedmask = False
         x = ma.concatenate((x, y), axis)
         xnotmask = np.logical_not(np.concatenate((xmask, ymask), axis)).astype(int)
     x -= x.mean(axis=rowvar)[tup]
@@ -1326,6 +1327,7 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
         _denom = ma.sqrt(ma.multiply.outer(diag, diag))
     else:
         _denom = diagflat(diag)
+        _denom._sharedmask = False  # We know return is always a copy
         n = x.shape[1 - rowvar]
         if rowvar:
             for i in range(n - 1):


### PR DESCRIPTION
Mostly a rebase of the other one, mostly in case anyone still cares (yeah, I can't stop myself from just not liking ):
- I don't care about the refcount logic, but it reduces noise. Actually "fixes" the spurious warnings that those extra `_sharedmask = False` calls also fix in extras.py. Those warnings are caused by intermediate arrays without any user control.
- I don't care about a `MaskedArrayFutureWarning` as its own class, I believe at the point where we feel that we have to make it easier to suppress a warning, there is probably something not quite right (the warning should be avoided not silenced). But it left it because it does not hurt.
- Removed the "oldmask" logic. I think one warning per array should be enough in all cases and I doubt it will help with debugging possible issues much (or that anyone would bother anyway).
- Left the pointer to setting `_sharedmask = False` it is messing with internals, so it is ugly and I don't mind removing it.
- Current version is hit a lot by things that never call `unshare_mask`, i.e. field-indexing, hardmasks assign "masked". Putting the warning where the call is just does not break my brain and gets down the warning hits in the test suit to something like 6 (~28 without the refcount logic), from 65 hits (counting test failures when turning to error).
