### PR TITLE
BUG: incorrect type for objects whose __len__ fails

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -476,6 +476,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
      * __len__ is not defined.
      */
     if (maxdims == 0 || !PySequence_Check(obj) || PySequence_Size(obj) < 0) {
+        // clear any PySequence_Size error, which corrupts further calls to it
+        PyErr_Clear();
+
         if (*out_dtype == NULL || (*out_dtype)->type_num != NPY_OBJECT) {
             Py_XDECREF(*out_dtype);
             *out_dtype = PyArray_DescrFromType(NPY_OBJECT);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -716,6 +716,20 @@ class TestCreation(TestCase):
 
         assert_raises(ValueError, np.array, C()) # segfault?
 
+    def test_failed_len_sequence(self):
+        # gh-7393
+        class A(object):
+            def __init__(self, data):
+                self._data = data
+            def __getitem__(self, item):
+                return type(self)(self._data[item])
+            def __len__(self):
+                return len(self._data)
+
+        # len(d) should give 3, but len(d[0]) will fail
+        d = A([1,2,3])
+        assert_equal(len(np.array(d)), 3)
+
 
 class TestStructured(TestCase):
     def test_subarray_field_access(self):


### PR DESCRIPTION
Fixes #7393, see discussion there. Caused by a bug introduced in #7266.

This reverts the behavior of the following code be the same as before #7266 

``` python
class A(object):
    def __init__(self, data):
        self._data = data
    def __getitem__(self, item):
        return type(self)(self._data[item])

d = A([1,2,3])
np.array(d)
# array([A(1), A(2), A(3)], dtype=object)
```
