### PR TITLE
Use PyMem_RawMalloc on Python 3.4 and newer

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -328,9 +328,20 @@ struct NpyAuxData_tag {
 #define NPY_USE_PYMEM 1
 
 #if NPY_USE_PYMEM == 1
-#define PyArray_malloc PyMem_Malloc
-#define PyArray_free PyMem_Free
-#define PyArray_realloc PyMem_Realloc
+   /* numpy sometimes calls PyArray_malloc() with the GIL released. On Python
+      3.3 and older, it was safe to call PyMem_Malloc() with the GIL released.
+      On Python 3.4 and newer, it's better to use PyMem_RawMalloc() to be able
+      to use tracemalloc. On Python 3.6, calling PyMem_Malloc() with the GIL
+      released is now a fatal error in debug mode. */
+#  if PY_VERSION_HEX >= 0x03040000
+#    define PyArray_malloc PyMem_RawMalloc
+#    define PyArray_free PyMem_RawFree
+#    define PyArray_realloc PyMem_RawRealloc
+#  else
+#    define PyArray_malloc PyMem_Malloc
+#    define PyArray_free PyMem_Free
+#    define PyArray_realloc PyMem_Realloc
+#  endif
 #else
 #define PyArray_malloc malloc
 #define PyArray_free free


### PR DESCRIPTION
Change PyArray_malloc() macro to use PyMem_RawMalloc() on Python 3.4
and newer. This macro can be called indirectly from ufunc_at() which
releases the GIL, whereas PyMem_Malloc() requires the GIL to be held:
https://docs.python.org/dev/c-api/memory.html#memory-interface

PyMem_RawMalloc() can be called without the GIL.
