### PR TITLE
ENH ufunc called on memmap return a ndarray

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -177,6 +177,13 @@ were doing. This caused a complication in the downstream 'pandas' library
 that encountered an issue with 'numpy' compatibility. Now, all array-like
 methods in this module are called with keyword arguments instead.
 
+Operations on np.memmap objects return numpy arrays in most cases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously operations on a memmap (e.g. adding 1 to it) object would
+misleadingly return a memmap instance even if the result was actually
+not memmapped. Also reduction of a memmap (e.g.  ``.sum(axis=None``)
+return a numpy scalar instead of a 0d memmap.
+
 Deprecations
 ============
 

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -309,3 +309,24 @@ class memmap(ndarray):
         """
         if self.base is not None and hasattr(self.base, 'flush'):
             self.base.flush()
+
+    def __array_wrap__(self, arr, context=None):
+        arr = super(memmap, self).__array_wrap__(arr, context)
+
+        # Return a memmap if a memmap was given as the output of the
+        # ufunc. Leave the arr class unchanged if self is not a memmap
+        # to keep original memmap subclasses behavior
+        if self is arr or type(self) is not memmap:
+            return arr
+        # Return scalar instead of 0d memmap, e.g. for np.sum with
+        # axis=None
+        if arr.shape == ():
+            return arr[()]
+        # Return ndarray otherwise
+        return arr.view(np.ndarray)
+
+    def __getitem__(self, index):
+        res = super(memmap, self).__getitem__(index)
+        if type(res) is memmap and res._mmap is None:
+            return res.view(type=ndarray)
+        return res


### PR DESCRIPTION
Special case for reduction functions (e.g. np.sum with axis=None) that
return a numpy scalar.

Fix #7403. Implemented `__array_wrap__` following @ahaldane's suggestion. Should fix #667 as well.
