### PR TITLE
DOC: add nanprod to the list of math routines

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -54,6 +54,7 @@ Sums, products, differences
 
    prod
    sum
+   nanprod
    nansum
    cumprod
    cumsum


### PR DESCRIPTION
This was otherwise undocumented, so the nanprod.rst page wasn't being generated.
