### PR TITLE
BUG: Fixes #7395, operator.index now fails on numpy.bool_

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2830,7 +2830,9 @@ static PyObject *
 static PyObject *
 bool_index(PyObject *a)
 {
-    return PyInt_FromLong(PyArrayScalar_VAL(a, Bool));
+    PyErr_SetString(PyExc_TypeError, 
+                    "A boolean scalar cannot be converted to an index");
+    return NULL;
 }
 
 /* Arithmetic methods -- only so we can override &, |, ^. */


### PR DESCRIPTION
Attempt to fix the bug described in #7395. If this needs a depreciation warning I can change the Err to Warning and maybe add a test (?)
