### PR TITLE
MAINT: FutureWarning for changes to np.average subclass handling

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -18,6 +18,9 @@ Future Changes
 
 * In 1.13 NAT will always compare False except for ``NAT != NAT``,
   which will be True.  In short, NAT will behave like NaN
+* In 1.13 np.average will preserve subclasses, to match the behavior of most
+  other numpy functions such as np.mean. In particular, this means calls which
+  returned a scalar may return a 0-d subclass object instead.
 
 
 Compatibility notes
@@ -86,6 +89,9 @@ FutureWarning to changed behavior
 
 * ``np.full`` now returns an array of the fill-value's dtype if no dtype is
   given, instead of defaulting to float.
+* np.average will emit a warning if the argument is a subclass of ndarray,
+  as the subclass will be preserved starting in 1.13. (see Future Changes)
+
 
 C API
 ~~~~~

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1002,7 +1002,19 @@ def average(a, axis=None, weights=None, returned=False):
     TypeError: Axis must be specified when shapes of a and weights differ.
 
     """
-    a = np.asanyarray(a)
+    # 3/19/2016 1.12.0:
+    # replace the next few lines with "a = np.asanyarray(a)"
+    if (type(a) not in (np.ndarray, np.matrix) and
+            issubclass(type(a), np.ndarray)):
+        warnings.warn("np.average currently does not preserve subclasses, but "
+                      "will do so in the future to match the behavior of most "
+                      "other numpy functions such as np.mean. In particular, "
+                      "this means calls which returned a scalar may return a "
+                      "0-d subclass object instead.",
+                      FutureWarning, stacklevel=2)
+
+    if not isinstance(a, np.matrix):
+        a = np.asarray(a)
 
     if weights is None:
         avg = a.mean(axis)


### PR DESCRIPTION
This slightly rolls back the changes to np.average in #7382, so that we emit a `FutureWarning` if `np.average` is called on an `ndarray` subclass. In the future, `np.average` will preserve subclasses, just like `np.mean` and almost all other numpy methods.

This is to fix #7403. Note that the specific case in #7403 will probably also be fixed by #7406, but this PR should make sure we aren't more generally breaking anyone's code (for now).
