### PR TITLE
Add bytes to numpy.sctypes in Python 3.

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -192,6 +192,12 @@ from these operations.
 Also, reduction of a memmap (e.g.  ``.sum(axis=None``) now returns a numpy
 scalar instead of a 0d memmap.
 
+numpy.sctypes now includes bytes on Python3 too
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, it included str (bytes) and unicode on Python2, but only str
+(unicode) on Python3.
+
+
 Deprecations
 ============
 

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -438,7 +438,7 @@ sctypes = {'int': [],
            'uint':[],
            'float':[],
            'complex':[],
-           'others':[bool, object, str, unicode, void]}
+           'others':[bool, object, bytes, unicode, void]}
 
 def _add_array_type(typename, bits):
     try:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3479,11 +3479,11 @@ class TestCompress(TestCase):
 class TestPutmask(object):
     def tst_basic(self, x, T, mask, val):
         np.putmask(x, mask, val)
-        assert_(np.all(x[mask] == T(val)))
-        assert_(x.dtype == T)
+        assert_equal(x[mask], T(val))
+        assert_equal(x.dtype, T)
 
     def test_ip_types(self):
-        unchecked_types = [str, unicode, np.void, object]
+        unchecked_types = [bytes, unicode, np.void, object]
 
         x = np.random.random(1000)*100
         mask = x < 40
@@ -3526,7 +3526,7 @@ class TestTake(object):
         assert_array_equal(x.take(ind, axis=0), x)
 
     def test_ip_types(self):
-        unchecked_types = [str, unicode, np.void, object]
+        unchecked_types = [bytes, unicode, np.void, object]
 
         x = np.random.random(24)*100
         x.shape = 2, 3, 4


### PR DESCRIPTION
Trivial fix to #7071.
This works both on Python2 and Python3 now that 2.6 is not supported anymore.
