### PR TITLE
np.full now defaults to the filling value's dtype.

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -84,6 +84,8 @@ more explanation.
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* ``np.full`` now returns an array of the fill-value's dtype if no dtype is
+  given, instead of defaulting to float.
 
 C API
 ~~~~~

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -262,9 +262,8 @@ def full(shape, fill_value, dtype=None, order='C'):
     fill_value : scalar
         Fill value.
     dtype : data-type, optional
-        The desired data-type for the array, e.g., `np.int8`.  Default
-        is `float`, but will change to `np.array(fill_value).dtype` in a
-        future release.
+        The desired data-type for the array  The default, `None`, means
+         `np.array(fill_value).dtype`.
     order : {'C', 'F'}, optional
         Whether to store multidimensional data in C- or Fortran-contiguous
         (row- or column-wise) order in memory.
@@ -289,16 +288,14 @@ def full(shape, fill_value, dtype=None, order='C'):
     >>> np.full((2, 2), np.inf)
     array([[ inf,  inf],
            [ inf,  inf]])
-    >>> np.full((2, 2), 10, dtype=np.int)
+    >>> np.full((2, 2), 10)
     array([[10, 10],
            [10, 10]])
 
     """
+    if dtype is None:
+        dtype = array(fill_value).dtype
     a = empty(shape, dtype, order)
-    if dtype is None and array(fill_value).dtype != a.dtype:
-        warnings.warn(
-            "in the future, full({0}, {1!r}) will return an array of {2!r}".
-            format(shape, fill_value, array(fill_value).dtype), FutureWarning)
     multiarray.copyto(a, fill_value, casting='unsafe')
     return a
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -485,17 +485,6 @@ class TestBooleanIndexShapeMismatchDeprecation():
              arr.__getitem__, (slice(None), index))
 
 
-class TestFullDefaultDtype(object):
-    """np.full defaults to float when dtype is not set.  In the future, it will
-    use the fill value's dtype.
-    """
-
-    def test_full_default_dtype(self):
-        assert_warns(FutureWarning, np.full, 1, 1)
-        assert_warns(FutureWarning, np.full, 1, None)
-        assert_no_warnings(np.full, 1, 1, float)
-
-
 class TestDatetime64Timezone(_DeprecationTestCase):
     """Parsing of datetime64 with timezones deprecated in 1.11.0, because
     datetime64 is now timezone naive rather than UTC only.


### PR DESCRIPTION
See #6366.
