### PR TITLE
DOC: array "See also" link to full and full_like instead of fill

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -686,7 +686,7 @@ add_newdoc('numpy.core.multiarray', 'array',
 
     See Also
     --------
-    empty, empty_like, zeros, zeros_like, ones, ones_like, fill
+    empty, empty_like, zeros, zeros_like, ones, ones_like, full, full_like
 
     Examples
     --------


### PR DESCRIPTION
`ndarray.fill` (not `fill`) is not appropriate here because it is a list how
to create arrays not how to fill them. [ci skip]

Also the current link didn't "link", see http://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html
