### PR TITLE
ENH: Add support for PEP 3118 buffers with offsets (non-contiguous)

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1263,7 +1263,7 @@ int
 _copy_from_pil_style(char* dest, int ndim, char *buf, npy_intp *shape,
                      npy_intp *strides, npy_intp *suboffsets, npy_intp itemsize)
 {
-    int ax, last_axis;
+    int ax, last_axis = 0;
     npy_intp indices[NPY_MAXDIMS];
     void **pointers[NPY_MAXDIMS];
     char *pointer = (char*)buf;
@@ -1274,8 +1274,8 @@ _copy_from_pil_style(char* dest, int ndim, char *buf, npy_intp *shape,
         pointers[ax] = (void **)pointer;
         if (suboffsets[ax] >= 0) {
             last_axis = ax;
-	        pointer = *((char**)pointer) + suboffsets[ax];
-	    }
+            pointer = *((char**)pointer) + suboffsets[ax];
+        }
     }
     /* compute blocksize */
     blocksize = itemsize;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1263,11 +1263,16 @@ int
 _copy_from_pil_style(char* dest, int ndim, char *buf, npy_intp *shape,
                      npy_intp *strides, npy_intp *suboffsets, npy_intp itemsize)
 {
-    int ax, last_axis = 0;
     npy_intp indices[NPY_MAXDIMS];
     void **pointers[NPY_MAXDIMS];
     char *pointer = (char*)buf;
     npy_intp blocksize;
+    int ax;
+    /* Since suboffsets cannot be all negative, last_axis will be inevitably
+     * reset in the initialization loop below.  However, the compiler cannot
+     * know this, so we preset last_axis to an arbitrary value. */
+    int last_axis = 0;
+
     /* Initialize indices and pointers. */
     for (ax = 0; ax < ndim; ++ax) {
         indices[ax] = 0;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1415,11 +1415,7 @@ _array_from_buffer_3118(PyObject *obj, PyObject **out)
          r = PyArray_NewFromDescr(&PyArray_Type, descr,
                                   nd, shape, strides, NULL, 0, NULL);
          if (r == NULL)
-            goto fail;
-         if (PyArray_SetBaseObject((PyArrayObject *)r, memoryview) < 0) {
-            Py_DECREF(r);
-            goto fail;
-         }
+            goto fail2;
          _copy_from_pil_style((char *)PyArray_DATA((PyArrayObject *)r), nd,
                               (char *)view->buf, shape, view->strides,
                               view->suboffsets, view->itemsize);
@@ -1430,6 +1426,7 @@ _array_from_buffer_3118(PyObject *obj, PyObject **out)
 
 fail:
     Py_XDECREF(descr);
+fail2:
     Py_DECREF(memoryview);
     return -1;
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5921,6 +5921,20 @@ class TestNewBufferProtocol(object):
             shape, strides = get_buffer_info(arr, ['C_CONTIGUOUS'])
             assert_(strides[-1] == 8)
 
+    def test_pil_style(self):
+        try:
+            import _testbuffer
+        except ImportError:
+            raise SkipTest("_testbuffer is not available")
+
+        for shape in [(2, 3), (2, 3, 4)]:
+            data = list(range(np.prod(shape)))
+            buffer = _testbuffer.ndarray(data, shape, format='i',
+                                         flags=_testbuffer.ND_PIL)
+            a = np.array(buffer)
+            b = np.array(data, dtype='i').reshape(shape)
+            yield assert_equal, a, b
+
 
 class TestArrayAttributeDeletion(object):
 


### PR DESCRIPTION
Added support for PEP 3118 PIL-style buffers in multiarray
constructor.

Closes #5412.
