### PR TITLE
BUG: Fix segfault in PyArray_OrderConverter

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -535,6 +535,13 @@ PyArray_OrderConverter(PyObject *object, NPY_ORDER *val)
         PyObject *tmp;
         int ret;
         tmp = PyUnicode_AsASCIIString(object);
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_ValueError, "Invalid unicode string passed in "
+                                              "for the array ordering. "
+                                              "Please pass in 'C', 'F', 'A' "
+                                              "or 'K' instead");
+            return NPY_FAIL;
+        }
         ret = PyArray_OrderConverter(tmp, val);
         Py_DECREF(tmp);
         return ret;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6437,6 +6437,10 @@ class TestUnicodeArrayNonzero(TestCase):
         a[0] = ' \0 \0'
         self.assertTrue(a)
 
+def test_orderconverter_with_nonASCII_unicode_ordering():
+    # gh-7475
+    a = np.arange(5)
+    assert_raises(ValueError, a.flatten, order=u'\xe2')
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This fixes a bug in PyArray_OrderConverter where
if a unicode string is passed in which cannot
be converted to ASCII then Py_DECREF would
be called on a null pointer.

Fixes #7475 
