### PR TITLE
BUG: Memory Leak in _GenericBinaryOutFunction

### DIFF
--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -830,28 +830,24 @@ _GenericBinaryOutFunction(PyArrayObject *m1, PyObject *m2, PyArrayObject *out,
         return PyObject_CallFunction(op, "OO", m1, m2);
     }
     else {
-        PyObject *args, *kw, *ret;
+        PyObject *args, *ret;
+        static PyObject *kw = NULL;
+
+        if (kw == NULL) {
+            kw = Py_BuildValue("{s:s}", "casting", "unsafe");
+            if (kw == NULL) {
+                return NULL;
+            }
+        }
 
         args = Py_BuildValue("OOO", m1, m2, out);
         if (args == NULL) {
-            return NULL;
-        }
-        kw = PyDict_New();
-        if (kw == NULL) {
-            Py_DECREF(args);
-            return NULL;
-        }
-        if (PyDict_SetItemString(kw, "casting",
-                        PyUString_FromString("unsafe")) < 0) {
-            Py_DECREF(args);
-            Py_DECREF(kw);
             return NULL;
         }
 
         ret = PyObject_Call(op, args, kw);
 
         Py_DECREF(args);
-        Py_DECREF(kw);
 
         return ret;
     }


### PR DESCRIPTION
_GenericBinaryOutFunction was leaking constructing a string
each time it was called which wasn't deallocated on some
versions of python (due to string interning rules). This
fixes this by storing the **kwargs that are passed into
the op statically so that they are only constructed
the first time that _GenericBinaryOutFunction is called.

Credit to @seberg for finding the location of the
bug and providing an initial version of the fix.

Fixes #6672
