### PR TITLE
Faster real_if_close.

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -424,7 +424,7 @@ def real_if_close(a,tol=100):
         from numpy.core import getlimits
         f = getlimits.finfo(a.dtype.type)
         tol = f.eps * tol
-    if _nx.allclose(a.imag, 0, atol=tol):
+    if _nx.all(_nx.absolute(a.imag) < tol):
         a = a.real
     return a
 


### PR DESCRIPTION
Because of the complexity of `allclose`, `real_if_close(t)` used to be
~2.5-3x slower than, say, `t + t`.  This patch makes it approximately as
fast.
