### PR TITLE
MAIN: fix to #7382, make scl in np.average writeable

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1027,7 +1027,8 @@ def average(a, axis=None, weights=None, returned=False):
         avg = np.multiply(a, wgt, dtype=result_dtype).sum(axis)/scl
 
     if returned:
-        scl = np.broadcast_to(scl, avg.shape)
+        if scl.shape != avg.shape:
+            scl = np.broadcast_to(scl, avg.shape).copy()
         return avg, scl
     else:
         return avg


### PR DESCRIPTION
In #7382 we make `np.average` use `broadcast_to` when returning `scl`, but as pointed out in #5706, `broadcast_to` returns a read-only array, which might cause problems. This PR fixes that by adding a `.copy()`, and also avoiding the broadcast/copy if not needed.
