### PR TITLE
BUG: make sure numpy imports on python 2.6 when nose is unavailable

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -47,8 +47,12 @@ try:
     from unittest.case import SkipTest
 except ImportError:
     # on py2.6 unittest.case is not available. Ask nose for a replacement.
-    SkipTest = import_nose().SkipTest
-
+    try:
+        import nose
+        SkipTest = nose.SkipTest
+    except (ImportError, AttributeError):
+        # if nose is not available, testing won't work anyway
+        pass
 
 verbose = 0
 


### PR DESCRIPTION
Backport of #7499, which should be closed as this fix is only needed for 1.11.x.
