### PR TITLE
BUG: Fixed iteration over additional bad commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,7 @@ def parse_setuppy_commands():
         flake8="`setup.py flake8` is not supported, use flake8 standalone",
         )
     bad_commands['nosetests'] = bad_commands['test']
-    for commands in ('upload_docs', 'easy_install', 'bdist', 'bdist_dumb',
+    for command in ('upload_docs', 'easy_install', 'bdist', 'bdist_dumb',
                      'register', 'check', 'install_data', 'install_headers',
                      'install_lib', 'install_scripts', ):
         bad_commands[command] = "`setup.py %s` is not supported" % command


### PR DESCRIPTION
I found a typo within setup.py where the dictionary of _bad_commands_ is automatically populated from a list using a default error message.
The variable controlled with the **for** cycle is _commands_ while _command_ is used within the cycle body.
