### PR TITLE
DOC: Removed an extra `:const:`

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -171,7 +171,7 @@ concepts to remember include:
 .. data:: newaxis
 
    The :const:`newaxis` object can be used in all slicing operations to 
-   create an axis of length one. :const: :const:`newaxis` is an alias for
+   create an axis of length one. :const:`newaxis` is an alias for
    'None', and 'None' can be used in place of this with the same result.
 
 


### PR DESCRIPTION
Pretty sure that was a typo.
