### PR TITLE
MAINT: Update setup.py to reflect supported python versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ import subprocess
 import textwrap
 
 
-if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
-    raise RuntimeError("Python version 2.6, 2.7 or >= 3.2 required.")
+if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[0:2] < (3, 4):
+    raise RuntimeError("Python version 2.7 or >= 3.4 required.")
 
 if sys.version_info[0] >= 3:
     import builtins
@@ -47,11 +47,8 @@ License :: OSI Approved
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.2
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: Implementation :: CPython


### PR DESCRIPTION
Numpy 1.12.0 will support Python 2.7, 3.4 and 3.5 with support for
2.6, 3.2, and 3.3 dropped, so remove the latter.
