### PR TITLE
BUG: allow graceful recovery for no Liux compiler

### DIFF
--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -3,6 +3,8 @@ from __future__ import division, print_function
 import os
 import shutil
 from tempfile import mkstemp, mkdtemp
+from subprocess import Popen, PIPE
+from distutils.errors import DistutilsError
 
 from numpy.distutils import ccompiler
 from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
@@ -53,6 +55,27 @@ void bar(void) {
    printf("Hello bar");
 }
 """
+
+def have_compiler():
+    """ Return True if there appears to be an executable compiler
+    """
+    compiler = ccompiler.new_compiler()
+    try:
+        cmd = compiler.compiler  # Unix compilers
+    except AttributeError:
+        try:
+            compiler.initialize()  # MSVC is different
+        except DistutilsError:
+            return False
+        cmd = [compiler.cc]
+    try:
+        Popen(cmd, stdout=PIPE, stderr=PIPE)
+    except OSError:
+        return False
+    return True
+
+
+HAVE_COMPILER = have_compiler()
 
 
 class test_system_info(system_info):
@@ -171,38 +194,39 @@ class TestSystemInfoReading(TestCase):
         extra = tsi.calc_extra_info()
         assert_equal(extra['extra_link_args'], ['-Wl,-rpath=' + self._lib2])
 
+    @skipif(not HAVE_COMPILER)
     def test_compile1(self):
         # Compile source and link the first source
         c = ccompiler.new_compiler()
+        previousDir = os.getcwd()
         try:
             # Change directory to not screw up directories
-            previousDir = os.getcwd()
             os.chdir(self._dir1)
             c.compile([os.path.basename(self._src1)], output_dir=self._dir1)
             # Ensure that the object exists
             assert_(os.path.isfile(self._src1.replace('.c', '.o')) or
                     os.path.isfile(self._src1.replace('.c', '.obj')))
+        finally:
             os.chdir(previousDir)
-        except OSError:
-            pass
 
+    @skipif(not HAVE_COMPILER)
     @skipif('msvc' in repr(ccompiler.new_compiler()))
     def test_compile2(self):
         # Compile source and link the second source
         tsi = self.c_temp2
         c = ccompiler.new_compiler()
         extra_link_args = tsi.calc_extra_info()['extra_link_args']
+        previousDir = os.getcwd()
         try:
             # Change directory to not screw up directories
-            previousDir = os.getcwd()
             os.chdir(self._dir2)
             c.compile([os.path.basename(self._src2)], output_dir=self._dir2,
                       extra_postargs=extra_link_args)
             # Ensure that the object exists
             assert_(os.path.isfile(self._src2.replace('.c', '.o')))
+        finally:
             os.chdir(previousDir)
-        except OSError:
-            pass
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
If there is no compiler on Linux, the error we were getting was CompileError
rather than the OSError the test was expecting.

This had the nasty side-effect of leaving us in a deleted temporary directory,
causing later test failures.
