### PR TITLE
Backport 7358,  BUG: constant padding expected wrong type in constant_values

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1052,7 +1052,7 @@ def _normalize_shape(ndarray, shape, cast_to_int=True):
             arr = arr.repeat(2, axis=1)
         elif arr.shape[0] == ndims:
             # Input correctly formatted, pass it on as `arr`
-            arr = shape
+            pass
         else:
             fmt = "Unable to create correctly shaped tuple from %s"
             raise ValueError(fmt % (shape,))

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -477,6 +477,19 @@ class TestConstant(TestCase):
             )
         assert_allclose(test, expected)
 
+    def test_check_constant_pad_2d(self):
+        arr = np.arange(4).reshape(2, 2)
+        test = np.lib.pad(arr, ((1, 2), (1, 3)), mode='constant',
+                          constant_values=((1, 2), (3, 4)))
+        expected = np.array(
+            [[3, 1, 1, 4, 4, 4],
+             [3, 0, 1, 4, 4, 4],
+             [3, 2, 3, 4, 4, 4],
+             [3, 2, 2, 4, 4, 4],
+             [3, 2, 2, 4, 4, 4]]
+        )
+        assert_allclose(test, expected)
+
 
 class TestLinearRamp(TestCase):
     def test_check_simple(self):


### PR DESCRIPTION
 BUG: constant padding expected wrong type in constant_values

Constant padding on 4 sides of a 2d array expected a numpy ndarray, and not a
array_like (tuple, list, ...) Detailed description is in the issue  #7353
