### PR TITLE
BUG: Fix test_from_object_array_unicode (test_defchararray.TestBasic)…

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -52,6 +52,7 @@ maintainer email:  oliphant.travis@ieee.org
 #include "array_assign.h"
 #include "alloc.h"
 #include "mem_overlap.h"
+#include "numpyos.h"
 
 /*NUMPY_API
   Compute the size of an array (in number of items)
@@ -880,18 +881,13 @@ _mystrncmp(char *s1, char *s2, int len1, int len2)
 
 #define SMALL_STRING 2048
 
-#if defined(isspace)
-#undef isspace
-#define isspace(c)  ((c==' ')||(c=='\t')||(c=='\n')||(c=='\r')||(c=='\v')||(c=='\f'))
-#endif
-
 static void _rstripw(char *s, int n)
 {
     int i;
     for (i = n - 1; i >= 1; i--) { /* Never strip to length 0. */
         int c = s[i];
 
-        if (!c || isspace(c)) {
+        if (!c || NumPyOS_ascii_isspace((int)c)) {
             s[i] = 0;
         }
         else {
@@ -905,7 +901,7 @@ static void _unistripw(npy_ucs4 *s, int n)
     int i;
     for (i = n - 1; i >= 1; i--) { /* Never strip to length 0. */
         npy_ucs4 c = s[i];
-        if (!c || isspace(c)) {
+        if (!c || NumPyOS_ascii_isspace((int)c)) {
             s[i] = 0;
         }
         else {

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -339,7 +339,7 @@ ASCII_FORMAT(long double, l, double)
  * Same as isspace under C locale
  */
 NPY_NO_EXPORT int
-NumPyOS_ascii_isspace(char c)
+NumPyOS_ascii_isspace(int c)
 {
     return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t'
                     || c == '\v';

--- a/numpy/core/src/multiarray/numpyos.h
+++ b/numpy/core/src/multiarray/numpyos.h
@@ -29,6 +29,6 @@ NPY_NO_EXPORT int
 NumPyOS_ascii_ftoLf(FILE *fp, long double *value);
 
 NPY_NO_EXPORT int
-NumPyOS_ascii_isspace(char c);
+NumPyOS_ascii_isspace(int c);
 
 #endif


### PR DESCRIPTION
… on Windows debug

"isspace" crashes with an assert on debug when the character is not ASCII, in Windows
