### PR TITLE
MAINT: use manylinux1 wheel for cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,11 +87,7 @@ before_install:
   - source venv/bin/activate
   - python -V
   - pip install --upgrade pip setuptools
-  - pip install nose
-  - pip install pytz
-  # pip install coverage
-  # Speed up install by not compiling Cython
-  - pip install --install-option="--no-cython-compile" Cython
+  - pip install nose pytz cython
   - if [ -n "$USE_ASV" ]; then pip install asv; fi
   - popd
 


### PR DESCRIPTION
Now that cython publishes binary wheels for linux to PyPI we can use them to speed up the numpy build.

http://pypi.python.org/pypi/cython

Let's see if travis likes it.
