### PR TITLE
Fix a false positive OverflowError in Python 3.x when value above 0x7…

### DIFF
--- a/tools/swig/pyfragments.swg
+++ b/tools/swig/pyfragments.swg
@@ -75,15 +75,22 @@
   SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
   {
     PyArray_Descr * ulongDescr = PyArray_DescrNewFromType(NPY_ULONG);
-    if (PyInt_Check(obj)) {
+    %#if PY_VERSION_HEX < 0x03000000
+    if (PyInt_Check(obj)) 
+    {
       long v = PyInt_AsLong(obj);
-      if (v >= 0) {
-	if (val) *val = v;
-	return SWIG_OK;
-      } else {
-	return SWIG_OverflowError;
+      if (v >= 0) 
+      {
+        if (val) *val = v;
+	    return SWIG_OK;
+      } 
+      else 
+      {
+	    return SWIG_OverflowError;
       }
-    } else if (PyLong_Check(obj)) {
+    } else 
+    %#endif
+    if (PyLong_Check(obj)) {
       unsigned long v = PyLong_AsUnsignedLong(obj);
       if (!PyErr_Occurred()) {
 	if (val) *val = v;


### PR DESCRIPTION
…FFFFFF are passed to a function accepting "unsigned int".

This is a port of a fix in pyprimtype.swg from which several code snippets where copy pasted into swig/pyfragments.swg in the past.

Please see SWIG changes log (2015-12-23) for more details:

http://www.swig.org/Release/CHANGES.current

[...]

2015-12-23: ahnolds  [Python] Fixes for conversion of signed and unsigned integer types 

[...]
