### PR TITLE
Fixed inability to deal with paths with percent in them. 

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -129,9 +129,13 @@ import warnings
 from glob import glob
 from functools import reduce
 if sys.version_info[0] < 3:
-    from ConfigParser import NoOptionError, RawConfigParser
+    from ConfigParser import NoOptionError
+    from ConfigParser import RawConfigParser as ConfigParser
 else:
-    from configparser import NoOptionError, RawConfigParser
+    from configparser import NoOptionError
+    from configparser import RawConfigParser as ConfigParser
+    # It seems that some people are importing ConfigParser from here so is good to keep its class name
+    # Use of RawConfigParser is needed in order to be able to load path names with percent in them, like `feature%2Fcool` (git flow branch names)
 
 from distutils.errors import DistutilsError
 from distutils.dist import Distribution
@@ -479,8 +483,7 @@ class system_info(object):
                     'src_dirs': os.pathsep.join(default_src_dirs),
                     'search_static_first': str(self.search_static_first),
                     'extra_compile_args': '', 'extra_link_args': ''}
-        # Use of RawConfigParser is needed in order to be able to load path names with percent in them, like `feature%2Fcool` (git flow branch names)
-        self.cp = RawConfigParser(defaults)
+        self.cp = ConfigParser(defaults)
         self.files = []
         self.files.extend(get_standard_file('.numpy-site.cfg'))
         self.files.extend(get_standard_file('site.cfg'))

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -129,9 +129,9 @@ import warnings
 from glob import glob
 from functools import reduce
 if sys.version_info[0] < 3:
-    from ConfigParser import NoOptionError, ConfigParser
+    from ConfigParser import NoOptionError, RawConfigParser
 else:
-    from configparser import NoOptionError, ConfigParser
+    from configparser import NoOptionError, RawConfigParser
 
 from distutils.errors import DistutilsError
 from distutils.dist import Distribution
@@ -479,7 +479,8 @@ class system_info(object):
                     'src_dirs': os.pathsep.join(default_src_dirs),
                     'search_static_first': str(self.search_static_first),
                     'extra_compile_args': '', 'extra_link_args': ''}
-        self.cp = ConfigParser(defaults)
+        # Use of RawConfigParser is needed in order to be able to load path names with percent in them, like `feature%2Fcool` (git flow branch names)
+        self.cp = RawConfigParser(defaults)
         self.files = []
         self.files.extend(get_standard_file('.numpy-site.cfg'))
         self.files.extend(get_standard_file('site.cfg'))


### PR DESCRIPTION
Fixed #7572 by allowing usage of percent inside filenames which is something quite common for those using `git flow` where branches can have names like `feature/cool` which are translated to `feature%2Fcool` when translated to directory names.
