### PR TITLE
DOC: clarify purpose of Attributes section

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -461,7 +461,7 @@ here, the **Parameters** section of the docstring details the constructors
 parameters.
 
 An **Attributes** section, located below the **Parameters** section,
-may be used to describe class variables::
+may be used to describe non-method attributes of the class::
 
   Attributes
   ----------


### PR DESCRIPTION
According to the official [Python documentation](https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables), term "class variables" denotes attributes shared by all instances of the class. The current version of the Numpy/Scipy documentation guide uses the term to mean non-method attributes. This commit replaces the confusing term with a more appropriate one.
