### PR TITLE
BUG: Refcount leak in recarray. Fixes #7581

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -496,7 +496,11 @@ class recarray(ndarray):
         return self.setfield(val, *res)
 
     def __getitem__(self, indx):
-        obj = super(recarray, self).__getitem__(indx)
+        try:
+            obj = super(recarray, self).__getitem__(indx)
+        except:
+            del self  # prevents reference leaks
+            raise
 
         # copy behavior of getattr, except that here
         # we might also be returning a single element

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -328,6 +328,15 @@ class TestRecord(TestCase):
         # https://github.com/numpy/numpy/issues/4806
         arr = np.zeros((3,), dtype=[('x', int), ('y', int)])
         assert_raises(ValueError, lambda: arr[['nofield']])
+        
+    def test_ref_count(self):
+        # https://github.com/numpy/numpy/issues/7581
+        arr = np.recarray(2, dtype=[('x', int)])
+        assert_equal(sys.getrefcount(arr), 2)
+        # this bug does not appear with assert_raises
+        with self.assertRaises(IndexError):
+            arr[20]
+        assert_equal(sys.getrefcount(arr), 2)
 
 def test_find_duplicate():
     l1 = [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
Possibly at the expense of debugability
