### PR TITLE
BUG: fixes #7572, percent in path

### DIFF
--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -5,9 +5,9 @@ import re
 import os
 
 if sys.version_info[0] < 3:
-    from ConfigParser import SafeConfigParser, NoOptionError
+    from ConfigParser import RawConfigParser, NoOptionError
 else:
-    from configparser import ConfigParser, SafeConfigParser, NoOptionError
+    from configparser import RawConfigParser, NoOptionError
 
 __all__ = ['FormatError', 'PkgNotFound', 'LibraryInfo', 'VariableSet',
         'read_config', 'parse_flags']
@@ -259,11 +259,7 @@ def parse_config(filename, dirs=None):
     else:
         filenames = [filename]
 
-    if sys.version[:3] > '3.1':
-        # SafeConfigParser is deprecated in py-3.2 and renamed to ConfigParser
-        config = ConfigParser()
-    else:
-        config = SafeConfigParser()
+    config = RawConfigParser()
 
     n = config.read(filenames)
     if not len(n) >= 1:

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -129,9 +129,15 @@ import warnings
 from glob import glob
 from functools import reduce
 if sys.version_info[0] < 3:
-    from ConfigParser import NoOptionError, ConfigParser
+    from ConfigParser import NoOptionError
+    from ConfigParser import RawConfigParser as ConfigParser
 else:
-    from configparser import NoOptionError, ConfigParser
+    from configparser import NoOptionError
+    from configparser import RawConfigParser as ConfigParser
+# It seems that some people are importing ConfigParser from here so is 
+# good to keep its class name. Use of RawConfigParser is needed in 
+# order to be able to load path names with percent in them, like 
+# `feature%2Fcool` which is common on git flow branch names.
 
 from distutils.errors import DistutilsError
 from distutils.dist import Distribution

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -8,6 +8,7 @@
 # will also be checked for the file ~/.numpy-site.cfg .
 
 # The format of the file is that of the standard library's ConfigParser module.
+# No interpolation is allowed, RawConfigParser class being used to load it.
 #
 #   http://docs.python.org/3/library/configparser.html
 #


### PR DESCRIPTION
Fixes #7572 -- the failure to install numpy in virtual environments that are created in paths that do contain percent sign in them. Bug that occurs only with Python 3 because the changed behaviour of ConfigParser between py2 and py3.

Introduction of interpolation support in py3 introduce this bug, as now the code fails to load ini files with percent sign in them.
