### PR TITLE
BUG: masked-array median of 1d array should be scalar

### DIFF
--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -662,6 +662,19 @@ class TestMedian(TestCase):
         assert_equal(np.ma.median(np.arange(9)), 4.)
         assert_equal(np.ma.median(range(9)), 4)
 
+    def test_masked_1d(self):
+        "test the examples given in the docstring of ma.median"
+        x = array(np.arange(8), mask=[0]*4 + [1]*4)
+        assert_equal(np.ma.median(x), 1.5)
+        assert_equal(np.ma.median(x).shape, (), "shape mismatch")
+        x = array(np.arange(10).reshape(2, 5), mask=[0]*6 + [1]*4)
+        assert_equal(np.ma.median(x), 2.5)
+        assert_equal(np.ma.median(x).shape, (), "shape mismatch")
+
+    def test_1d_shape_consistency(self):
+        assert_equal(np.ma.median(array([1,2,3],mask=[0,0,0])).shape,
+                     np.ma.median(array([1,2,3],mask=[0,1,0])).shape )
+
     def test_2d(self):
         # Tests median w/ 2D
         (n, p) = (101, 30)


### PR DESCRIPTION
It seems like PR #4760, which improved the n-dimensional performance of ma.median, has broken the behavior for the 1d case. The previous behavior seems more correct, because:

(a) It matches the behavior of the non-masked median.
(b) It matches the examples given in the doc-strings.
(c) It matches a simpler rule: a median of n-dim array is n-1 dimensional.

This pull request fixes that, and adds a test that fails in the unfixed code. 

Details:
It appears that the issue can be traced back to a special-case in numpy's "advanced indexing" algorithm, where a list of scalars is treated as a 1d array.
The fix works by avoiding this special case. The items of the index are forced to be arrays (in particular, scalars are converted to 0d arrays), so advanced indexing works in a consistent manner.
I wrote it this way to explicitly highlight the fact that the 1d result should be consistent with higher dimensional cases. 
However, it is possible that an "if dim==1" would be more readable...
