### PR TITLE
ENH: add helper for ifft padding to numpy.fft

### DIFF
--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -250,13 +250,15 @@ def ifft(a, n=None, axis=-1, norm=None):
     fft : The one-dimensional (forward) FFT, of which `ifft` is the inverse
     ifft2 : The two-dimensional inverse FFT.
     ifftn : The n-dimensional inverse FFT.
+    ifftpad : Pad the spectrum preserving low frequencies
 
     Notes
     -----
     If the input parameter `n` is larger than the size of the input, the input
     is padded by appending zeros at the end.  Even though this is the common
     approach, it might lead to surprising results.  If a different padding is
-    desired, it must be performed before calling `ifft`.
+    desired, it must be performed before calling `ifft` (e.g. by using the
+    `ifftpad` function).
 
     Examples
     --------

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -6,12 +6,12 @@ from __future__ import division, absolute_import, print_function
 
 from numpy.compat import integer_types
 from numpy.core import (
-        asarray, concatenate, arange, take, integer, empty
+        asarray, concatenate, arange, take, integer, empty, zeros
         )
 
 # Created by Pearu Peterson, September 2002
 
-__all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
+__all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'ifftpad']
 
 integer_types = integer_types + (integer,)
 
@@ -222,3 +222,46 @@ def rfftfreq(n, d=1.0):
     N = n//2 + 1
     results = arange(0, N, dtype=int)
     return results * val
+
+
+def ifftpad(a, n, scale=True):
+    """
+    Pad the spectrum at high frequencies.
+
+    The padding done by the `ifft` function appends zeros to the end of the
+    spectrum which shifts the frequencies and can make the resulting signal
+    differ from the non-padded version. This function pads the spectrum
+    by putting the zeros in the middle where the highest frequencies are.
+    Taking the `ifft` of this padded version result in a signal that is
+    an interpolated version of the unpadded signal, which is what is expected.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array, can be complex.
+    n : int
+        Length of the padded spectrum.
+        `n` should be larger than the length of the input.
+    scale : bool, optional
+        Whether to scale the spectrum or not. The `ifft` function
+        divides by the input length which will be the incorrect length
+        for a padded spectrum. Setting this parameter will pre-scale
+        the spectrum so that dividing by the padded length will be correct.
+
+    Returns
+    -------
+    out : ndarray
+        The spectrum padded to length `n`. Possibly scaled as well.
+
+    Examples
+    --------
+    >>> spectrum = np.array([0, 1, 2, -3, -2, -1])
+    >>> np.fft.ifftpad(spectrum, 10, scale=False)
+    array([ 0.,  1.,  2.,  0.,  0.,  0.,  0., -3., -2., -1.])
+    """
+    spectrum = concatenate((a[:len(a) // 2],
+                            zeros(n - len(a)),
+                            a[len(a) // 2:]))
+    if scale:
+        spectrum *= (n / len(a))
+    return spectrum

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -7,7 +7,7 @@ Copied from fftpack.helper by Pearu Peterson, October 2005
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal
+from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, assert_raises
 from numpy import fft
 from numpy import pi
 
@@ -72,6 +72,26 @@ class TestIRFFTN(TestCase):
 
         # Should not raise error
         fft.irfftn(a, axes=axes)
+
+
+class TestIFFTPad(TestCase):
+
+    def helper(self, length):
+        spectrum = np.random.random(length) + 1j * np.random.random(length)
+        signal = fft.ifft(spectrum)
+        signal_padded_incorrect = fft.ifft(spectrum, length * 2)
+        signal_padded_correct = fft.ifft(fft.ifftpad(spectrum, length * 2))
+
+        assert_array_almost_equal(signal, signal_padded_correct[::2])
+
+        with assert_raises(AssertionError):
+            assert_array_almost_equal(signal, signal_padded_incorrect[::2])
+
+    def test_even(self):
+        self.helper(12)
+
+    def test_odd(self):
+        self.helper(11)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See issue #1346

I'm not sure whether this should be a separate helper function or a flag to the `ifft` function, so I went with the easier way of making a helper function. I'm also not sure how to properly handle `ndarrays` with more than one dimension.
