### PR TITLE
Backport 7586, BUG: Make np.ma.take works on scalars

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5628,9 +5628,10 @@ class MaskedArray(ndarray):
         maskindices = getattr(indices, '_mask', nomask)
         if maskindices is not nomask:
             indices = indices.filled(0)
-        # Get the data
+        # Get the data, promoting scalars to 0d arrays with [...] so that
+        # .view works correctly
         if out is None:
-            out = _data.take(indices, axis=axis, mode=mode).view(cls)
+            out = _data.take(indices, axis=axis, mode=mode)[...].view(cls)
         else:
             np.take(_data, indices, axis=axis, mode=mode, out=out)
         # Get the mask
@@ -5641,7 +5642,8 @@ class MaskedArray(ndarray):
                 outmask = _mask.take(indices, axis=axis, mode=mode)
                 outmask |= maskindices
             out.__setmask__(outmask)
-        return out
+        # demote 0d arrays back to scalars, for consistency with ndarray.take
+        return out[()]
 
     # Array methods
     copy = _arraymethod('copy')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2955,6 +2955,10 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(x.take([[0, 1], [0, 1]]),
                      masked_array([[10, 20], [10, 20]], [[0, 1], [0, 1]]))
 
+        # assert_equal crashes when passed np.ma.mask
+        self.assertTrue(x[1] is np.ma.masked)
+        self.assertTrue(x.take(1) is np.ma.masked)
+
         x = array([[10, 20, 30], [40, 50, 60]], mask=[[0, 0, 1], [1, 0, 0, ]])
         assert_equal(x.take([0, 2], axis=1),
                      array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))


### PR DESCRIPTION
By promoting and demoting between scalars and arrays where appropriate
