### PR TITLE
Cast array size to int64 when loading from archive

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -623,7 +623,7 @@ def read_array(fp, allow_pickle=True, pickle_kwargs=None):
     if len(shape) == 0:
         count = 1
     else:
-        count = numpy.multiply.reduce(shape)
+        count = numpy.multiply.reduce(shape, dtype=numpy.int64)
 
     # Now read the actual data.
     if dtype.hasobject:

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -836,5 +836,19 @@ def test_large_file_support():
     assert_array_equal(r, d)
 
 
+@dec.slow
+def test_large_archive():
+    a = np.empty((2 ** 30, 2), dtype=np.uint8)
+    fname = os.path.join(tempdir, "large_archive")
+
+    with open(fname, "wb") as f:
+        np.savez(f, arr=a)
+
+    with open(fname, "rb") as f:
+        new_a = np.load(f)["arr"]
+
+    assert a.shape == new_a.shape
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
When loading an array from a `npz` archive, the size of the array is computed via [`numpy.multiply.reduce(shape)`](https://github.com/numpy/numpy/blob/master/numpy/lib/format.py#L626).  This defaults to `int32` on some systems, including 64bit systems where it is possible to create arrays large enough to cause that value to overflow.  Here is a minimal example illustrating the problem:

```
import platform
import sys

import numpy as np

print(platform.architecture())
print(sys.version)
print("np version:", np.__version__)
print("default int type:", np.int_)

a = np.empty((2**30, 2), dtype=np.uint8)
with open("tmp.npz", "wb") as f:
    np.savez(f, a)

print(a.shape)
print(np.multiply.reduce(a.shape))

with open("tmp.npz", "rb") as f:
    data = np.load(f)
    new_a = data["arr_0"]
```

output on my system:

```
('64bit', 'WindowsPE')
3.4.4 |Continuum Analytics, Inc.| (default, Feb 16 2016, 09:54:04) [MSC v.1600 64 bit (AMD64)]
np version: 1.11.0
default int type: <class 'numpy.int32'>
(1073741824, 2)
-2147483648
Traceback (most recent call last):
  File "<...>/tmp.py", line 20, in <module>
    new_a = data["arr_0"]
  File "<...>\lib\site-packages\numpy\lib\npyio.py", line 224, in __getitem__
    pickle_kwargs=self.pickle_kwargs)
  File "<...>\lib\site-packages\numpy\lib\format.py", line 660, in read_array
    array = numpy.empty(count, dtype=dtype)
ValueError: negative dimensions are not allowed
```

I think the solution is just to change it to `numpy.multiply.reduce(shape, dtype=numpy.int64)`
