### PR TITLE
BUG: integer 0 to a negative power should error.

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -921,7 +921,17 @@ NPY_NO_EXPORT void
           *((@type@ *)op1) = 1;
           continue;
         }
-        if (in2 < 0 || in1 == 0) {
+
+        if (in1 == 0 && in2 < 0) {
+            NPY_ALLOW_C_API_DEF
+            NPY_ALLOW_C_API;
+            PyErr_SetString(PyExc_ZeroDivisionError,
+                    "0 cannot be raised to a negative power.");
+            NPY_DISABLE_C_API;
+            return;
+        }
+
+        if (in2 < 0) {
             *((@type@ *)op1) = 0;
             continue;
         }

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1239,19 +1239,6 @@ class TestRegression(TestCase):
         "Ticket #947."
         self.assertRaises(ValueError, lambda: np.array([1], ndmin=33))
 
-    def test_errobj_reference_leak(self, level=rlevel):
-        # Ticket #955
-        with np.errstate(all="ignore"):
-            z = int(0)
-            p = np.int32(-1)
-
-            gc.collect()
-            n_before = len(gc.get_objects())
-            z**p  # this shouldn't leak a reference to errobj
-            gc.collect()
-            n_after = len(gc.get_objects())
-            assert_(n_before >= n_after, (n_before, n_after))
-
     def test_void_scalar_with_titles(self, level=rlevel):
         # No ticket
         data = [('john', 4), ('mary', 5)]

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -434,6 +434,15 @@ class TestPower(TestCase):
         arr = np.arange(-10, 10)
         assert_equal(np.power(arr, 0), np.ones_like(arr))
 
+    def test_integer_zero_to_negative_power(self):
+        dtypes = ['i1', 'i2', 'i4', 'i8']
+        for dt in dtypes:
+            a = np.array([0, 1, 2, 3], dtype=dt)
+            barray = np.array([0, 1, 2, -3], dtype=dt)
+            bscalar = barray[-1]
+            assert_raises(ZeroDivisionError, np.power, a[:, None], barray)
+            assert_raises(ZeroDivisionError, np.power, a, bscalar)
+
 
 class TestLog2(TestCase):
     def test_log2_values(self):


### PR DESCRIPTION
Fixes gh-7510.

The test removed from test_regression errors with these changes, since prior to taking #7459 it would go via the ufunc.
