### PR TITLE
DOC: Remove isreal and iscomplex from ufunc list

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -649,8 +649,6 @@ single operation.
 
 .. autosummary::
 
-    isreal
-    iscomplex
     isfinite
     isinf
     isnan


### PR DESCRIPTION
I do not think that these two function are ufuncs since they do not
 have an optional [, out] argument. From the doc:
- All ufuncs can also take output arguments.
