### PR TITLE
ENH: Don't use temp files in npyio.savez

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -621,7 +621,7 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
     # component of the so-called standard library.
     import zipfile
     # Import deferred for startup time improvement
-    import tempfile
+    import io
 
     if isinstance(file, basestring):
         if not file.endswith('.npz'):
@@ -645,33 +645,17 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
 
     zipf = zipfile_factory(file, mode="w", compression=compression)
 
-    # Stage arrays in a temporary file on disk, before writing to zip.
-
-    # Since target file might be big enough to exceed capacity of a global
-    # temporary directory, create temp file side-by-side with the target file.
-    file_dir, file_prefix = os.path.split(file) if _is_string_like(file) else (None, 'tmp')
-    fd, tmpfile = tempfile.mkstemp(prefix=file_prefix, dir=file_dir, suffix='-numpy.npy')
-    os.close(fd)
     try:
         for key, val in namedict.items():
             fname = key + '.npy'
-            fid = open(tmpfile, 'wb')
-            try:
-                format.write_array(fid, np.asanyarray(val),
-                                   allow_pickle=allow_pickle,
-                                   pickle_kwargs=pickle_kwargs)
-                fid.close()
-                fid = None
-                zipf.write(tmpfile, arcname=fname)
-            except IOError as exc:
-                raise IOError("Failed to write to %s: %s" % (tmpfile, exc))
-            finally:
-                if fid:
-                    fid.close()
-    finally:
-        os.remove(tmpfile)
+            fid = io.BytesIO()
+            format.write_array(fid, np.asanyarray(val),
+                               allow_pickle=allow_pickle,
+                               pickle_kwargs=pickle_kwargs)
+            zipf.writestr(fname, fid.getvalue())
 
-    zipf.close()
+    finally:
+        zipf.close()
 
 
 def _getconv(dtype):


### PR DESCRIPTION
When using savez, we used to write temporary files, at first in the
global temporary directory, and after #7133 alongside the output file.
But there is no reason to do that, since we can simply keep the file
in a `io.BytesIO` object.
This approach is simpler, more performent and less error prone.
It also solves an unreported bug I had on windows, where my `%TEMP%`
somehow got filled with npy temporary files.
