### PR TITLE
Backport 7587, BUG: linalg.norm(): Don't convert object arrays to float 

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -23,7 +23,7 @@ from numpy.core import (
     csingle, cdouble, inexact, complexfloating, newaxis, ravel, all, Inf, dot,
     add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
     finfo, errstate, geterrobj, longdouble, rollaxis, amin, amax, product, abs,
-    broadcast, atleast_2d, intp, asanyarray, isscalar
+    broadcast, atleast_2d, intp, asanyarray, isscalar, object_
     )
 from numpy.lib import triu, asfarray
 from numpy.linalg import lapack_lite, _umath_linalg
@@ -2112,7 +2112,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
     """
     x = asarray(x)
 
-    if not issubclass(x.dtype.type, inexact):
+    if not issubclass(x.dtype.type, (inexact, object_)):
         x = x.astype(float)
 
     # Immediately handle some default, simple, fast, and common cases.

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -90,6 +90,12 @@ class TestRegression(TestCase):
                 assert_equal(np.linalg.matrix_rank(a), 1)
                 assert_array_less(1, np.linalg.norm(a, ord=2))
 
+    def test_norm_object_array(self):
+        # gh-7575
+        norm = linalg.norm(np.array([np.array([0, 1]), 0, 0], dtype=object))
+        assert_array_equal(norm, [0, 1])
+        self.assertEqual(norm.dtype, np.dtype('float64'))
+
 
 if __name__ == '__main__':
     run_module_suite()

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -92,9 +92,49 @@ class TestRegression(TestCase):
 
     def test_norm_object_array(self):
         # gh-7575
-        norm = linalg.norm(np.array([np.array([0, 1]), 0, 0], dtype=object))
+        testvector = np.array([np.array([0, 1]), 0, 0], dtype=object)
+
+        norm = linalg.norm(testvector)
         assert_array_equal(norm, [0, 1])
         self.assertEqual(norm.dtype, np.dtype('float64'))
+
+        norm = linalg.norm(testvector, ord=1)
+        assert_array_equal(norm, [0, 1])
+        self.assertNotEqual(norm.dtype, np.dtype('float64'))
+
+        norm = linalg.norm(testvector, ord=2)
+        assert_array_equal(norm, [0, 1])
+        self.assertEqual(norm.dtype, np.dtype('float64'))
+
+        self.assertRaises(ValueError, linalg.norm, testvector, ord='fro')
+        self.assertRaises(ValueError, linalg.norm, testvector, ord='nuc')
+        self.assertRaises(ValueError, linalg.norm, testvector, ord=np.inf)
+        self.assertRaises(ValueError, linalg.norm, testvector, ord=-np.inf)
+        self.assertRaises((AttributeError, DeprecationWarning),
+                          linalg.norm, testvector, ord=0)
+        self.assertRaises(ValueError, linalg.norm, testvector, ord=-1)
+        self.assertRaises(ValueError, linalg.norm, testvector, ord=-2)
+
+        testmatrix = np.array([[np.array([0, 1]), 0, 0],
+                               [0,                0, 0]], dtype=object)
+
+        norm = linalg.norm(testmatrix)
+        assert_array_equal(norm, [0, 1])
+        self.assertEqual(norm.dtype, np.dtype('float64'))
+
+        norm = linalg.norm(testmatrix, ord='fro')
+        assert_array_equal(norm, [0, 1])
+        self.assertEqual(norm.dtype, np.dtype('float64'))
+
+        self.assertRaises(TypeError, linalg.norm, testmatrix, ord='nuc')
+        self.assertRaises(ValueError, linalg.norm, testmatrix, ord=np.inf)
+        self.assertRaises(ValueError, linalg.norm, testmatrix, ord=-np.inf)
+        self.assertRaises(ValueError, linalg.norm, testmatrix, ord=0)
+        self.assertRaises(ValueError, linalg.norm, testmatrix, ord=1)
+        self.assertRaises(ValueError, linalg.norm, testmatrix, ord=-1)
+        self.assertRaises(TypeError, linalg.norm, testmatrix, ord=2)
+        self.assertRaises(TypeError, linalg.norm, testmatrix, ord=-2)
+        self.assertRaises(ValueError, linalg.norm, testmatrix, ord=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backport of #7587,
