### PR TITLE
ENH: Add broadcast.ndim to match code elsewhere

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -547,9 +547,25 @@ add_newdoc('numpy.core', 'broadcast', ('iters',
 
     """))
 
-add_newdoc('numpy.core', 'broadcast', ('nd',
+add_newdoc('numpy.core', 'broadcast', ('ndim',
     """
     Number of dimensions of broadcasted result.
+
+    .. versionadded:: 1.12.0
+
+    Examples
+    --------
+    >>> x = np.array([1, 2, 3])
+    >>> y = np.array([[4], [5], [6]])
+    >>> b = np.broadcast(x, y)
+    >>> b.ndim
+    2
+
+    """))
+
+add_newdoc('numpy.core', 'broadcast', ('nd',
+    """
+    Number of dimensions of broadcasted result. Alias for `ndim`.
 
     Examples
     --------

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1696,6 +1696,10 @@ static PyMemberDef arraymultiter_members[] = {
         T_INT,
         offsetof(PyArrayMultiIterObject, nd),
         READONLY, NULL},
+    {"ndim",
+        T_INT,
+        offsetof(PyArrayMultiIterObject, nd),
+        READONLY, NULL},
     {NULL, 0, 0, 0, NULL},
 };
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2495,7 +2495,7 @@ class TestBroadcast(TestCase):
                 np.broadcast(arrs[0], np.broadcast(*arrs[1:-1]), arrs[-1])]
         for mit in mits:
             assert_equal(mit.shape, (5, 6, 7))
-            assert_equal(mit.nd, 3)
+            assert_equal(mit.ndim, 3)
             assert_equal(mit.numiter, 4)
             for a, ia in zip(arrs, mit.iters):
                 assert_(a is ia.base)
@@ -2505,7 +2505,7 @@ class TestBroadcast(TestCase):
         arrs = [np.empty((5, 6, 7))]
         mit = np.broadcast(*arrs)
         assert_equal(mit.shape, (5, 6, 7))
-        assert_equal(mit.nd, 3)
+        assert_equal(mit.ndim, 3)
         assert_equal(mit.numiter, 1)
         assert_(arrs[0] is mit.iters[0].base)
 


### PR DESCRIPTION
`broadcast.nd` is an unusual name, but needs to be left for compatibility

Both `ndarray` and `nditer` call it `ndim`, so broadcast objects should too.
