### PR TITLE
BUG: ma.median alternate fix for #7592

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -27,7 +27,7 @@ import warnings
 
 from . import core as ma
 from .core import (
-    MaskedArray, MAError, add, array, asarray, concatenate, filled,
+    MaskedArray, MAError, add, array, asarray, concatenate, filled, count,
     getmask, getmaskarray, make_mask_descr, masked, masked_array, mask_or,
     nomask, ones, sort, zeros, getdata, get_masked_subclass, dot,
     mask_rowcols
@@ -652,6 +652,10 @@ def _median(a, axis=None, out=None, overwrite_input=False):
         axis = 0
     elif axis < 0:
         axis += a.ndim
+
+    if asorted.ndim == 1:
+        idx, odd = divmod(count(asorted), 2)
+        return asorted[idx - (not odd) : idx + 1].mean()
 
     counts = asorted.shape[axis] - (asorted.mask).sum(axis=axis)
     h = counts // 2

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -665,10 +665,10 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     ind = np.meshgrid(*axes_grid, sparse=True, indexing='ij')
     # insert indices of low and high median
     ind.insert(axis, h - 1)
-    low = asorted[ind]
+    low = asorted[tuple(ind)]
     low._sharedmask = False
     ind[axis] = h
-    high = asorted[ind]
+    high = asorted[tuple(ind)]
     # duplicate high if odd number of elements so mean does nothing
     odd = counts % 2 == 1
     if asorted.ndim == 1:

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -662,6 +662,19 @@ class TestMedian(TestCase):
         assert_equal(np.ma.median(np.arange(9)), 4.)
         assert_equal(np.ma.median(range(9)), 4)
 
+    def test_masked_1d(self):
+        "test the examples given in the docstring of ma.median"
+        x = array(np.arange(8), mask=[0]*4 + [1]*4)
+        assert_equal(np.ma.median(x), 1.5)
+        assert_equal(np.ma.median(x).shape, (), "shape mismatch")
+        x = array(np.arange(10).reshape(2, 5), mask=[0]*6 + [1]*4)
+        assert_equal(np.ma.median(x), 2.5)
+        assert_equal(np.ma.median(x).shape, (), "shape mismatch")
+
+    def test_1d_shape_consistency(self):
+        assert_equal(np.ma.median(array([1,2,3],mask=[0,0,0])).shape,
+                     np.ma.median(array([1,2,3],mask=[0,1,0])).shape )
+
     def test_2d(self):
         # Tests median w/ 2D
         (n, p) = (101, 30)


### PR DESCRIPTION
Please see discussion in #7592
For the 1d case: use the original solution (copied from original code, before merge of #4760)
For the n-dim case: leave implementation as before.
- The new test cases added in #7592 pass
- Result of 1d case is scalar (rather than 0d masked array).
