### PR TITLE
MAINT: clearer exception message when importing multiarray fails.

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -11,7 +11,18 @@ for envkey in ['OPENBLAS_MAIN_FREE', 'GOTOBLAS_MAIN_FREE']:
     if envkey not in os.environ:
         os.environ[envkey] = '1'
         env_added.append(envkey)
-from . import multiarray
+
+try:
+    from . import multiarray
+except ImportError:
+    msg = """
+Importing the multiarray numpy extension module failed.  Most
+likely you are trying to import a failed build of numpy.
+If you're working with a numpy git repo, try `git clean -xdf` (removes all
+files not under version control).  Otherwise reinstall numpy.
+"""
+    raise ImportError(msg)
+
 for envkey in env_added:
     del os.environ[envkey]
 del envkey


### PR DESCRIPTION
This regularly confuses users, see for example gh-5529.

The path via which the multiarray import is reached has changed a few times
in the last couple of years, but multiarray is always the first extension
module to be imported, so this looks like a reasonable place to add the
message.
