### PR TITLE
TST: fix a set of test errors in master.

### DIFF
--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -635,6 +635,7 @@ def test_version_2_0():
     assert_raises(ValueError, format.write_array, f, d, (1, 0))
 
 
+@dec.slow
 def test_version_2_0_memmap():
     # requires more than 2 byte for header
     dt = [(("%d" % i) * 100, float) for i in range(500)]

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -837,8 +837,15 @@ def test_large_file_support():
 
 
 @dec.slow
+@dec.skipif(np.dtype(np.intp).itemsize < 8, "test requires 64-bit system")
 def test_large_archive():
-    a = np.empty((2 ** 30, 2), dtype=np.uint8)
+    # Regression test for product of saving arrays with dimensions of array
+    # having a product that doesn't fit in int32.  See gh-7598 for details.
+    try:
+        a = np.empty((2**30, 2), dtype=np.uint8)
+    except MemoryError:
+        raise SkipTest("Could not create large file")
+
     fname = os.path.join(tempdir, "large_archive")
 
     with open(fname, "wb") as f:
@@ -847,7 +854,7 @@ def test_large_archive():
     with open(fname, "rb") as f:
         new_a = np.load(f)["arr"]
 
-    assert a.shape == new_a.shape
+    assert_(a.shape == new_a.shape)
 
 
 if __name__ == "__main__":

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -19,9 +19,8 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     TestCase, run_module_suite, assert_warns, assert_,
     assert_raises_regex, assert_raises, assert_allclose,
-    assert_array_equal,temppath
+    assert_array_equal, temppath, dec
 )
-from numpy.testing.utils import tempdir
 
 
 class TextIO(BytesIO):
@@ -158,6 +157,7 @@ class RoundtripTest(object):
         a = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
         self.check_roundtrips(a)
 
+    @dec.slow
     def test_format_2_0(self):
         dt = [(("%d" % i) * 100, float) for i in range(500)]
         a = np.ones(1000, dtype=dt)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1869,7 +1869,7 @@ class TestPathUsage(TestCase):
             data = np.load(path)
             assert_array_equal(data['lab'], 'place holder')
             data.close()
-    
+
     @np.testing.dec.skipif(Path is None, "No pathlib.Path")
     def test_genfromtxt(self):
         with temppath(suffix='.txt') as path:
@@ -1878,49 +1878,52 @@ class TestPathUsage(TestCase):
             np.savetxt(path, a)
             data = np.genfromtxt(path)
             assert_array_equal(a, data)
-    
+
     @np.testing.dec.skipif(Path is None, "No pathlib.Path")
     def test_ndfromtxt(self):
         # Test outputing a standard ndarray
         with temppath(suffix='.txt') as path:
             path = Path(path)
             with path.open('w') as f:
-                f.write('1 2\n3 4')
+                f.write(u'1 2\n3 4')
+
             control = np.array([[1, 2], [3, 4]], dtype=int)
             test = np.ndfromtxt(path, dtype=int)
             assert_array_equal(test, control)
-    
+
     @np.testing.dec.skipif(Path is None, "No pathlib.Path")
     def test_mafromtxt(self):
         # From `test_fancy_dtype_alt` above
         with temppath(suffix='.txt') as path:
             path = Path(path)
             with path.open('w') as f:
-                f.write('1,2,3.0\n4,5,6.0\n')
-                
+                f.write(u'1,2,3.0\n4,5,6.0\n')
+
             test = np.mafromtxt(path, delimiter=',')
             control = ma.array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)])
             assert_equal(test, control)
-    
+
     @np.testing.dec.skipif(Path is None, "No pathlib.Path")
     def test_recfromtxt(self):
         with temppath(suffix='.txt') as path:
             path = Path(path)
             with path.open('w') as f:
-                f.write('A,B\n0,1\n2,3')
+                f.write(u'A,B\n0,1\n2,3')
+
             kwargs = dict(delimiter=",", missing_values="N/A", names=True)
             test = np.recfromtxt(path, **kwargs)
             control = np.array([(0, 1), (2, 3)],
                                dtype=[('A', np.int), ('B', np.int)])
             self.assertTrue(isinstance(test, np.recarray))
             assert_equal(test, control)
-    
+
     @np.testing.dec.skipif(Path is None, "No pathlib.Path")
     def test_recfromcsv(self):
         with temppath(suffix='.txt') as path:
             path = Path(path)
             with path.open('w') as f:
-                f.write('A,B\n0,1\n2,3')
+                f.write(u'A,B\n0,1\n2,3')
+
             kwargs = dict(missing_values="N/A", names=True, case_sensitive=True)
             test = np.recfromcsv(path, dtype=None, **kwargs)
             control = np.array([(0, 1), (2, 3)],

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -5,7 +5,7 @@ from __future__ import division, absolute_import, print_function
 
 from numpy.testing import (
     TestCase, run_module_suite, assert_equal, assert_array_equal,
-    assert_array_max_ulp, assert_array_almost_equal, assert_raises, rand,
+    assert_array_max_ulp, assert_array_almost_equal, assert_raises
     )
 
 from numpy import (
@@ -254,7 +254,7 @@ class TestHistogram2d(TestCase):
         assert_array_almost_equal(H, answer, 3)
 
     def test_all_outliers(self):
-        r = rand(100) + 1. + 1e6  # histogramdd rounds by decimal=6
+        r = np.random.rand(100) + 1. + 1e6  # histogramdd rounds by decimal=6
         H, xed, yed = histogram2d(r, r, (4, 5), range=([0, 1], [0, 1]))
         assert_array_equal(H, 0)
 
@@ -267,10 +267,10 @@ class TestHistogram2d(TestCase):
 
     def test_binparameter_combination(self):
         x = array(
-            [0, 0.09207008,  0.64575234,  0.12875982,  0.47390599,  
+            [0, 0.09207008,  0.64575234,  0.12875982,  0.47390599,
              0.59944483, 1])
         y = array(
-            [0, 0.14344267,  0.48988575,  0.30558665,  0.44700682,  
+            [0, 0.14344267,  0.48988575,  0.30558665,  0.44700682,
              0.15886423, 1])
         edges = (0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1)
         H, xe, ye = histogram2d(x, y, (edges, 4))


### PR DESCRIPTION
These are the ones I ran into on 32-bit Linux with current master and `Pathlib` installed on Python 2.7:

```
======================================================================
ERROR: test_format.test_large_archive
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/.local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/rgommers/Code/numpy/numpy/lib/tests/test_format.py", line 841, in test_large_archive
    a = np.empty((2 ** 30, 2), dtype=np.uint8)
ValueError: array is too big; `arr.size * arr.dtype.itemsize` is larger than the maximum possible size.

======================================================================
ERROR: test_mafromtxt (test_io.TestPathUsage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/Code/numpy/numpy/testing/decorators.py", line 147, in skipper_func
    return f(*args, **kwargs)
  File "/home/rgommers/Code/numpy/numpy/lib/tests/test_io.py", line 1899, in test_mafromtxt
    f.write('1,2,3.0\n4,5,6.0\n')
TypeError: must be unicode, not str

======================================================================
ERROR: test_ndfromtxt (test_io.TestPathUsage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/Code/numpy/numpy/testing/decorators.py", line 147, in skipper_func
    return f(*args, **kwargs)
  File "/home/rgommers/Code/numpy/numpy/lib/tests/test_io.py", line 1888, in test_ndfromtxt
    f.write('1 2\n3 4')
TypeError: must be unicode, not str

======================================================================
ERROR: test_recfromcsv (test_io.TestPathUsage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/Code/numpy/numpy/testing/decorators.py", line 147, in skipper_func
    return f(*args, **kwargs)
  File "/home/rgommers/Code/numpy/numpy/lib/tests/test_io.py", line 1923, in test_recfromcsv
    f.write('A,B\n0,1\n2,3')
TypeError: must be unicode, not str

======================================================================
ERROR: test_recfromtxt (test_io.TestPathUsage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/Code/numpy/numpy/testing/decorators.py", line 147, in skipper_func
    return f(*args, **kwargs)
  File "/home/rgommers/Code/numpy/numpy/lib/tests/test_io.py", line 1910, in test_recfromtxt
    f.write('A,B\n0,1\n2,3')
TypeError: must be unicode, not str

======================================================================
ERROR: test_all_outliers (test_twodim_base.TestHistogram2d)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/Code/numpy/numpy/lib/tests/test_twodim_base.py", line 257, in test_all_outliers
    r = rand(100) + 1. + 1e6  # histogramdd rounds by decimal=6
  File "/home/rgommers/Code/numpy/numpy/lib/utils.py", line 99, in newfunc
    warnings.warn(depdoc, DeprecationWarning)
DeprecationWarning: `rand` is deprecated!
numpy.testing.rand is deprecated in numpy 1.11. Use numpy.random.rand instead.

----------------------------------------------------------------------
```
