### PR TITLE
Backport PR 6975

### DIFF
--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -93,6 +93,12 @@
 #undef HAVE_CATANH
 #undef HAVE_CATANHF
 #undef HAVE_CATANHL
+#undef HAVE_CACOS
+#undef HAVE_CACOSF
+#undef HAVE_CACOSL
+#undef HAVE_CACOSH
+#undef HAVE_CACOSHF
+#undef HAVE_CACOSHL
 #endif
 #undef TRIG_OK
 


### PR DESCRIPTION
Backports the PR ( https://github.com/numpy/numpy/pull/6975 ).

> BUG: Add more complex trig functions to glibc < 2.16 blacklist.
> 
> Added functions are
> 
>    cacos
>    cacosf
>    cacosl
>    cacosh
>    cacoshf
>    cacoshl
> 
> Closes #6063.

cc @charris
