### PR TITLE
Backport 7655, BLD: Remove Intel compiler flag -xSSE4.2

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -123,7 +123,7 @@ class IntelEM64TFCompiler(IntelFCompiler):
         return ['-openmp -fp-model strict -O1']
 
     def get_flags_arch(self):
-        return ['-xSSE4.2']
+        return ['']
 
 # Is there no difference in the version string between the above compilers
 # and the Visual compilers?
@@ -205,7 +205,7 @@ class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     version_match = simple_version_match(start='Intel\(R\).*?64,')
 
     def get_flags_arch(self):
-        return ['/QaxSSE4.2']
+        return ['']
 
 
 if __name__ == '__main__':

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -54,7 +54,7 @@ class IntelEM64TCCompiler(UnixCCompiler):
     def __init__(self, verbose=0, dry_run=0, force=0):
         UnixCCompiler.__init__(self, verbose, dry_run, force)
         self.cc_exe = ('icc -m64 -fPIC -fp-model strict -O3 '
-                       '-fomit-frame-pointer -openmp -xSSE4.2')
+                       '-fomit-frame-pointer -openmp')
         compiler = self.cc_exe
         if platform.system() == 'Darwin':
             shared_flag = '-Wl,-undefined,dynamic_lookup'
@@ -88,7 +88,7 @@ if platform.system() == 'Windows':
             self.lib = self.find_exe('xilib')
             self.linker = self.find_exe('xilink')
             self.compile_options = ['/nologo', '/O3', '/MD', '/W3',
-                                    '/Qstd=c99', '/QaxSSE4.2']
+                                    '/Qstd=c99']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
                                           '/Qstd=c99', '/Z7', '/D_DEBUG']
 


### PR DESCRIPTION
The consensus seems to be that hardcoding SSE4.2 results in poor code
for architectures lacking the feature.

Closes #7287.
