### PR TITLE
Backport 7659, BUG: Temporary fix for str(mvoid) for object field types

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5954,7 +5954,14 @@ class mvoid(MaskedArray):
             return self._data.__str__()
         printopt = masked_print_option
         rdtype = _recursive_make_descr(self._data.dtype, "O")
-        res = np.array([self._data]).astype(rdtype)
+
+        # temporary hack to fix gh-7493. A more permanent fix
+        # is proposed in gh-6053, after which the next two
+        # lines should be changed to
+        # res = np.array([self._data], dtype=rdtype)
+        res = np.empty(1, rdtype)
+        res[:1] = self._data
+
         _recursive_printoption(res, self._mask, printopt)
         return str(res[0])
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -757,6 +757,10 @@ class TestMaskedArray(TestCase):
         finally:
             masked_print_option.set_display(ini_display)
 
+        # also check if there are object datatypes (see gh-7493)
+        mx = array([(1,), (2,)], dtype=[('a', 'O')])
+        assert_equal(str(mx[0]), "(1,)")
+
     def test_mvoid_multidim_print(self):
 
         # regression test for gh-6019


### PR DESCRIPTION
Fixes #7493, using a temporary hack, to be properly fixed later
(eg with #6053)

Printing a Masked-Void instance broke if the instance has a field of
Object dtype because assignment involving structured dtypes with objects
doesn't work. Fix is to use dtype-transfer code which avoid the bug.
