### PR TITLE
BUG: Fix unicode with byte swap transfer and copyswap

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -18,6 +18,7 @@
 #include "npy_sort.h"
 #include "common.h"
 #include "ctors.h"
+#include "lowlevel_strided_loops.h"
 #include "usertypes.h"
 #include "_datetime.h"
 #include "arrayobject.h"
@@ -2284,21 +2285,19 @@ UNICODE_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
         }
     }
 
-    n *= itemsize;
     if (swap) {
-        char *a, *b, c;
+        int i;
+        char *_dst;
+        itemsize = itemsize / 4;
 
-        /* n is the number of unicode characters to swap */
-        n >>= 2;
-        for (a = (char *)dst; n > 0; n--) {
-            b = a + 3;
-            c = *a;
-            *a++ = *b;
-            *b-- = c;
-            c = *a;
-            *a++ = *b;
-            *b-- = c;
-            a += 2;
+        while (n > 0) {
+            _dst = dst;
+            for (i=0; i < itemsize; i++) {
+                npy_bswap4_unaligned(_dst);
+                _dst += 4;
+            }
+            dst += dstride;
+            --n;
         }
     }
 }
@@ -2326,17 +2325,14 @@ UNICODE_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
     }
 
     if (swap) {
-        char *a, *b, c;
-        itemsize >>= 2;
-        for (a = (char *)dst; itemsize>0; itemsize--) {
-            b = a + 3;
-            c = *a;
-            *a++ = *b;
-            *b-- = c;
-            c = *a;
-            *a++ = *b;
-            *b-- = c;
-            a += 2;
+        int i;
+        char *_dst;
+        itemsize = itemsize / 4;
+
+        _dst = dst;       
+        for (i=0; i < itemsize; i++) {
+            npy_bswap4_unaligned(_dst);
+            _dst += 4;
         }
     }
 }

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -3521,8 +3521,13 @@ PyArray_GetDTypeCopySwapFn(int aligned,
                                     itemsize);
         *outtransferdata = NULL;
     }
+    else if (dtype->kind == 'U') {
+        return wrap_copy_swap_function(aligned,
+                                       src_stride, dst_stride, dtype, 1,
+                                       outstransfer, outtransferdata);
+    }
     /* If it's not complex, one swap */
-    else if(dtype->kind != 'c') {
+    else if (dtype->kind != 'c') {
         *outstransfer = PyArray_GetStridedCopySwapFn(aligned,
                                     src_stride, dst_stride,
                                     itemsize);

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -142,6 +142,7 @@ _strided_to_strided_copy_references(char *dst, npy_intp dst_stride,
     }
 }
 
+
 /************************** ZERO-PADDED COPY ******************************/
 
 /* Does a zero-padded copy */
@@ -209,14 +210,49 @@ _strided_to_strided_truncate_copy(char *dst, npy_intp dst_stride,
     }
 }
 
+/*
+ * Does a strided to strided zero-padded or truncated copy for the case where
+ * unicode swapping is needed.
+ */
+static void
+_strided_to_strided_unicode_copyswap(char *dst, npy_intp dst_stride,
+                        char *src, npy_intp src_stride,
+                        npy_intp N, npy_intp src_itemsize,
+                        NpyAuxData *data)
+{
+    _strided_zero_pad_data *d = (_strided_zero_pad_data *)data;
+    npy_intp dst_itemsize = d->dst_itemsize;
+    npy_intp zero_size = dst_itemsize - src_itemsize;
+    npy_intp copy_size = zero_size > 0 ? src_itemsize : dst_itemsize;
+    char *_dst;
+    npy_intp characters = dst_itemsize / 4;
+    int i;
+
+    while (N > 0) {
+        memcpy(dst, src, copy_size);
+        if (zero_size > 0) {
+            memset(dst + src_itemsize, 0, zero_size);
+        }
+        _dst = dst;
+        for (i=0; i < characters; i++) {
+            npy_bswap4_unaligned(_dst);
+            _dst += 4;
+        }
+        src += src_stride;
+        dst += dst_stride;
+        --N;
+    }
+}
+
+
 NPY_NO_EXPORT int
-PyArray_GetStridedZeroPadCopyFn(int aligned,
+PyArray_GetStridedZeroPadCopyFn(int aligned, int unicode_swap,
                             npy_intp src_stride, npy_intp dst_stride,
                             npy_intp src_itemsize, npy_intp dst_itemsize,
                             PyArray_StridedUnaryOp **out_stransfer,
                             NpyAuxData **out_transferdata)
 {
-    if (src_itemsize == dst_itemsize) {
+    if ((src_itemsize == dst_itemsize) && !unicode_swap) {
         *out_stransfer = PyArray_GetStridedCopyFn(aligned, src_stride,
                                 dst_stride, src_itemsize);
         *out_transferdata = NULL;
@@ -233,7 +269,10 @@ PyArray_GetStridedZeroPadCopyFn(int aligned,
         d->base.free = (NpyAuxData_FreeFunc *)&PyArray_free;
         d->base.clone = &_strided_zero_pad_data_clone;
 
-        if (src_itemsize < dst_itemsize) {
+        if (unicode_swap) {
+            *out_stransfer = &_strided_to_strided_unicode_copyswap;
+        }
+        else if (src_itemsize < dst_itemsize) {
             *out_stransfer = &_strided_to_strided_zero_pad_copy;
         }
         else {
@@ -518,7 +557,7 @@ _strided_to_strided_wrap_copy_swap(char *dst, npy_intp dst_stride,
     d->copyswapn(dst, dst_stride, src, src_stride, N, d->swap, d->arr);
 }
 
-/* This only gets used for custom data types */
+/* This only gets used for custom data types and for Unicode when swapping */
 static int
 wrap_copy_swap_function(int aligned,
                 npy_intp src_stride, npy_intp dst_stride,
@@ -3628,11 +3667,19 @@ PyArray_GetDTypeTransferFunction(int aligned,
             }
         }
 
-        /* The special types, which have no byte-order */
+        /* The special types, which have no or subelement byte-order */
         switch (src_type_num) {
+            case NPY_UNICODE:
+                /* Wrap the copy swap function when swapping is necessary */
+                if (PyArray_ISNBO(src_dtype->byteorder) !=
+                        PyArray_ISNBO(dst_dtype->byteorder)) {
+                    return wrap_copy_swap_function(aligned,
+                                    src_stride, dst_stride,
+                                    src_dtype, 1,
+                                    out_stransfer, out_transferdata);
+                }
             case NPY_VOID:
             case NPY_STRING:
-            case NPY_UNICODE:
                 *out_stransfer = PyArray_GetStridedCopyFn(0,
                                     src_stride, dst_stride,
                                     src_itemsize);
@@ -3705,10 +3752,17 @@ PyArray_GetDTypeTransferFunction(int aligned,
     /* Check for different-sized strings, unicodes, or voids */
     if (src_type_num == dst_type_num) {
         switch (src_type_num) {
-        case NPY_STRING:
         case NPY_UNICODE:
+            if (PyArray_ISNBO(src_dtype->byteorder) !=
+                                 PyArray_ISNBO(dst_dtype->byteorder)) {
+                return PyArray_GetStridedZeroPadCopyFn(0, 1,
+                                        src_stride, dst_stride,
+                                        src_dtype->elsize, dst_dtype->elsize,
+                                        out_stransfer, out_transferdata);
+            }
+        case NPY_STRING:
         case NPY_VOID:
-            return PyArray_GetStridedZeroPadCopyFn(0,
+            return PyArray_GetStridedZeroPadCopyFn(0, 0,
                                     src_stride, dst_stride,
                                     src_dtype->elsize, dst_dtype->elsize,
                                     out_stransfer, out_transferdata);

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -126,7 +126,7 @@ PyArray_GetStridedCopySwapPairFn(int aligned,
  * Returns NPY_SUCCEED or NPY_FAIL
  */
 NPY_NO_EXPORT int
-PyArray_GetStridedZeroPadCopyFn(int aligned,
+PyArray_GetStridedZeroPadCopyFn(int aligned, int unicode_swap,
                             npy_intp src_stride, npy_intp dst_stride,
                             npy_intp src_itemsize, npy_intp dst_itemsize,
                             PyArray_StridedUnaryOp **outstransfer,

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -317,7 +317,7 @@ class byteorder_values:
         # Check byteorder of single-dimensional objects
         ua = np.array([self.ucs_value*self.ulen]*2, dtype='U%s' % self.ulen)
         ua2 = ua.newbyteorder()
-        self.assertTrue(ua[0] != ua2[0])
+        self.assertTrue((ua != ua2).all())
         self.assertTrue(ua[-1] != ua2[-1])
         ua3 = ua2.newbyteorder()
         # Arrays must be equal after the round-trip
@@ -326,13 +326,42 @@ class byteorder_values:
     def test_valuesMD(self):
         # Check byteorder of multi-dimensional objects
         ua = np.array([[[self.ucs_value*self.ulen]*2]*3]*4,
-                   dtype='U%s' % self.ulen)
+                      dtype='U%s' % self.ulen)
         ua2 = ua.newbyteorder()
-        self.assertTrue(ua[0, 0, 0] != ua2[0, 0, 0])
+        self.assertTrue((ua != ua2).all())
         self.assertTrue(ua[-1, -1, -1] != ua2[-1, -1, -1])
         ua3 = ua2.newbyteorder()
         # Arrays must be equal after the round-trip
         assert_equal(ua, ua3)
+
+    def test_values_cast(self):
+        # Check byteorder of when casting the array for a strided and
+        # contiguous array:
+        test1 = np.array([self.ucs_value*self.ulen]*2, dtype='U%s' % self.ulen)
+        test2 = np.repeat(test1, 2)[::2]
+        for ua in (test1, test2):
+            ua2 = ua.astype(dtype=ua.dtype.newbyteorder())
+            self.assertTrue((ua == ua2).all())
+            self.assertTrue(ua[-1] == ua2[-1])
+            ua3 = ua2.astype(dtype=ua.dtype)
+            # Arrays must be equal after the round-trip
+            assert_equal(ua, ua3)
+
+    def test_values_updowncast(self):
+        # Check byteorder of when casting the array to a longer and shorter
+        # string length for strided and contiguous arrays
+        test1 = np.array([self.ucs_value*self.ulen]*2, dtype='U%s' % self.ulen)
+        test2 = np.repeat(test1, 2)[::2]
+        for ua in (test1, test2):
+            # Cast to a longer type with zero padding
+            longer_type = np.dtype('U%s' % (self.ulen+1)).newbyteorder()
+            ua2 = ua.astype(dtype=longer_type)
+            self.assertTrue((ua == ua2).all())
+            self.assertTrue(ua[-1] == ua2[-1])
+            # Cast back again with truncating:
+            ua3 = ua2.astype(dtype=ua.dtype)
+            # Arrays must be equal after the round-trip
+            assert_equal(ua, ua3)
 
 
 class test_byteorder_1_ucs2(byteorder_values, TestCase):

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -4,7 +4,8 @@ import sys
 
 import numpy as np
 from numpy.compat import asbytes, unicode, sixu
-from numpy.testing import TestCase, run_module_suite, assert_equal
+from numpy.testing import (
+    TestCase, run_module_suite, assert_, assert_equal, assert_array_equal)
 
 # Guess the UCS length for this python interpreter
 if sys.version_info[:2] >= (3, 3):
@@ -50,6 +51,20 @@ else:
 ucs2_value = sixu('\u0900')
 # Value that cannot be represented in UCS2 interpreters (but can in UCS4)
 ucs4_value = sixu('\U00100900')
+
+
+def test_string_cast():
+    str_arr = np.array(["1234", "1234\0\0"], dtype='S')
+    uni_arr1 = str_arr.astype('>U')
+    uni_arr2 = str_arr.astype('<U')
+
+    if sys.version_info[0] < 3:
+        assert_array_equal(str_arr, uni_arr1)
+        assert_array_equal(str_arr, uni_arr2)
+    else:
+        assert_(str_arr != uni_arr1)
+        assert_(str_arr != uni_arr2)
+    assert_array_equal(uni_arr1, uni_arr2)
 
 
 ############################################################


### PR DESCRIPTION
These fixes should make unicode byteswapping not be
completely broken. The code is not so much designed for absolute
speed.
## 

Tests still needed any comments appreciated. I tried to keep things simple, so used the copyswap function wrappers....
