### PR TITLE
Backport 7658, BUG: fix incorrect printing of 1D masked arrays

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2698,8 +2698,11 @@ class MaskedArray(ndarray):
     _defaultmask = nomask
     _defaulthardmask = False
     _baseclass = ndarray
-    # Maximum number of elements per axis used when printing an array.
+
+    # Maximum number of elements per axis used when printing an array. The
+    # 1d case is handled separately because we need more values in this case.
     _print_width = 100
+    _print_width_1d = 1500
 
     def __new__(cls, data=None, mask=nomask, dtype=None, copy=False,
                 subok=True, ndmin=0, fill_value=None, keep_mask=True,
@@ -3776,9 +3779,11 @@ class MaskedArray(ndarray):
                     mask = m
                     # For big arrays, to avoid a costly conversion to the
                     # object dtype, extract the corners before the conversion.
+                    print_width = (self._print_width if self.ndim > 1
+                                   else self._print_width_1d)
                     for axis in range(self.ndim):
-                        if data.shape[axis] > self._print_width:
-                            ind = self._print_width // 2
+                        if data.shape[axis] > print_width:
+                            ind = print_width // 2
                             arr = np.split(data, (ind, -ind), axis=axis)
                             data = np.concatenate((arr[0], arr[2]), axis=axis)
                             arr = np.split(mask, (ind, -ind), axis=axis)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -451,6 +451,15 @@ class TestMaskedArray(TestCase):
                               '             mask = [False  True False],\n'
                               '       fill_value = 999999)\n')
 
+        a = np.ma.arange(2000)
+        a[1:50] = np.ma.masked
+        assert_equal(
+            repr(a),
+            'masked_array(data = [0 -- -- ..., 1997 1998 1999],\n'
+            '             mask = [False  True  True ..., False False False],\n'
+            '       fill_value = 999999)\n'
+        )
+
     def test_pickling(self):
         # Tests pickling
         a = arange(10)


### PR DESCRIPTION
Backport #7658 

Ref #7621. #6748 added `np.ma.MaskedArray._print_width` which is used to cut
a masked array before printing it (to save memory and cpu time during the
conversion to the object dtype). But this doesn't work correctly for 1D arrays,
for which up to 1000 values can be printed before cutting the array.

So this commit adds a new class variable `_print_width_1d` to handle the 1D case
separately.
