### PR TITLE
Restore histogram consistency

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1407,6 +1407,17 @@ class TestHistogram(TestCase):
         assert_raises(ValueError, histogram, vals, range=[np.nan,0.75])
         assert_raises(ValueError, histogram, vals, range=[0.25,np.inf])
 
+    def test_bin_edge_cases(self):
+        # Ensure that floating-point computations correctly place edge cases.
+        arr = np.array([337, 404, 739, 806, 1007, 1811, 2012])
+        hist, edges = np.histogram(arr, bins=8296, range=(2, 2280))
+        mask = hist > 0
+        left_edges = edges[:-1][mask]
+        right_edges = edges[1:][mask]
+        for x, left, right in zip(arr, left_edges, right_edges):
+            self.assertGreaterEqual(x, left)
+            self.assertLess(x, right)
+
 
 class TestHistogramOptimBinNums(TestCase):
     """


### PR DESCRIPTION
@charris This should do it. Not sure about the performance.

The method here is to use the computed index as the initial guess, check the data against the bin that it points to, and adjust up or down by 1 as needed.

Fuzz test: https://gist.github.com/rkern/840b67903e0d033ede1ad47f54aa4200

Fixes #7628
