### PR TITLE
ENH: Do not check the type of module.__dict__ explicit in test.

### DIFF
--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -64,7 +64,7 @@ def test_array_array():
                      np.ones((), dtype=U5))
 
     builtins = getattr(__builtins__, '__dict__', __builtins__)
-    assert_(isinstance(builtins, dict))
+    assert_(hasattr(builtins, 'get'))
 
     # test buffer
     _buffer = builtins.get("buffer")


### PR DESCRIPTION
This patch is for Pyston compatibility. In Pyston, the type of `module.__dict__`
is attrwrapper, which is a dict like type. The test in here is not really care
for particular type, but instead cares for particular behaviour. So change the
expilit type check to a interface check. This check can also get passed in CPython and PyPy.
@njsmith 
