### PR TITLE
Backport 7669, BUG: boolean assignment no GIL release when transfer needs API

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1258,7 +1258,9 @@ array_assign_boolean_subscript(PyArrayObject *self,
             return -1;
         }
 
-        NPY_BEGIN_THREADS_NDITER(iter);
+        if (!needs_api) {
+            NPY_BEGIN_THREADS_NDITER(iter);
+        }
 
         do {
             innersize = *NpyIter_GetInnerLoopSizePtr(iter);
@@ -1282,7 +1284,9 @@ array_assign_boolean_subscript(PyArrayObject *self,
             }
         } while (iternext(iter));
 
-        NPY_END_THREADS;
+        if (!needs_api) {
+            NPY_END_THREADS;
+        }
 
         NPY_AUXDATA_FREE(transferdata);
         NpyIter_Deallocate(iter);

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -158,6 +158,20 @@ class TestIndexing(TestCase):
         assert_raises(ValueError, f, a, [1, 2, 3])
         assert_raises(ValueError, f, a[:1], [1, 2, 3])
 
+    def test_boolean_assignment_needs_api(self):
+        # See also gh-7666
+        # This caused a segfault on Python 2 due to the GIL not being
+        # held when the iterator does not need it, but the transfer function
+        # does
+        arr = np.zeros(1000)
+        indx = np.zeros(1000, dtype=bool)
+        indx[:100] = True
+        arr[indx] = np.ones(100, dtype=object)
+
+        expected = np.zeros(1000)
+        expected[:100] = 1
+        assert_array_equal(arr, expected)
+
     def test_boolean_indexing_twodim(self):
         # Indexing a 2-dimensional array with
         # 2-dimensional boolean array


### PR DESCRIPTION
#7669

This caused bugs when the iteration does not need the API, but
the data copy does.

closes gh-7666
