### PR TITLE
BUG: Make sure we don't divide by zero

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -603,6 +603,8 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         #  it is included here because the covariance of Multivariate Student-T
         #  (which is implied by a Bayesian uncertainty analysis) includes it.
         #  Plus, it gives a slightly more conservative estimate of uncertainty.
+        if (len(x) - order - 2.0) < 1:
+            raise ValueError("need at least three degrees of freedom for covariance matrix")
         fac = resids / (len(x) - order - 2.0)
         if y.ndim == 1:
             return c, Vbase * fac

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -604,7 +604,8 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         #  (which is implied by a Bayesian uncertainty analysis) includes it.
         #  Plus, it gives a slightly more conservative estimate of uncertainty.
         if (len(x) - order - 2.0) < 1:
-            raise ValueError("the number of data points must exceed the degree + 3 for covariance matrix")
+            raise ValueError("the number of data points must exceed "
+                             "the degree + 3 for covariance matrix")
         fac = resids / (len(x) - order - 2.0)
         if y.ndim == 1:
             return c, Vbase * fac

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -604,7 +604,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         #  (which is implied by a Bayesian uncertainty analysis) includes it.
         #  Plus, it gives a slightly more conservative estimate of uncertainty.
         if (len(x) - order - 2.0) < 1:
-            raise ValueError("need at least three degrees of freedom for covariance matrix")
+            raise ValueError("the number of data points must exceed the degree + 3 for covariance matrix")
         fac = resids / (len(x) - order - 2.0)
         if y.ndim == 1:
             return c, Vbase * fac


### PR DESCRIPTION
This should fix the issue I discussed in
https://mail.scipy.org/pipermail/numpy-discussion/2013-July/067076.html

Without the ValueError added here, polyfit can (and does) return negative or nan variances with no warning.
