### PR TITLE
BUG: Fix np.clip bug NaN handling for Visual Studio 2015

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3763,6 +3763,12 @@ static void
         }
     }
     else {
+// Visual Studio 2015 loop vectorizer handles NaN in an unexpected manner, see:
+// https://github.com/numpy/numpy/issues/7601
+// https://connect.microsoft.com/VisualStudio/feedback/details/2723801/unexpected-nan-handling-in-vectorized-loop
+#if (_MSC_VER == 1900)
+#pragma loop( no_vector )
+#endif
         for (i = 0; i < ni; i++) {
             if (@lt@(in[i], min_val)) {
                 out[i]   = min_val;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3452,6 +3452,12 @@ class TestClip(TestCase):
         x = val.clip(max=4)
         assert_(np.all(x <= 4))
 
+    def test_nan(self):
+        input_arr = np.array([-2., np.nan, 0.5, 3., 0.25, np.nan])
+        result = input_arr.clip(-1, 1)
+        expected = np.array([-1., np.nan, 0.5, 1., 0.25, np.nan])
+        assert_array_equal(result, expected)
+
 
 class TestCompress(TestCase):
     def test_axis(self):


### PR DESCRIPTION
Fix #7601.

The work-around is to disable the loop vectorization for Visual studio 2015. Let me know if there is a better way to achieve the same results.

I added a test that highlights the issue (only python 3.5).

In a separate branch I made sure that the test was failing without the loop vectorization disabled: [AppVeyor build](https://ci.appveyor.com/project/lesteve/numpy/build/1.0.8).

and that disabling the loop vectorization fixed the problem: [AppVeyor build](https://ci.appveyor.com/project/lesteve/numpy/build/1.0.7).
