### PR TITLE
ENH: Changing FFT cache to a bounded LRU cache

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -185,6 +185,13 @@ Add ``bits`` attribute to ``np.finfo``
 This makes ``np.finfo`` consistent with ``np.iinfo`` which already has that
 attribute.
 
+Caches in `np.fft` are now bounded in total size and item count
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The caches in `np.fft` that speed up successive FFTs of the same length can no
+longer grow without bounds. They have been replaced with LRU (least recently
+used) caches that automatically evict no longer needed items if either the
+memory size or item count limit has been reached.
+
 
 Changes
 =======

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -38,9 +38,10 @@ __all__ = ['fft', 'ifft', 'rfft', 'irfft', 'hfft', 'ihfft', 'rfftn',
 from numpy.core import (array, asarray, zeros, swapaxes, shape, conjugate,
                         take, sqrt)
 from . import fftpack_lite as fftpack
+from .helper import _FFTCache
 
-_fft_cache = {}
-_real_fft_cache = {}
+_fft_cache = _FFTCache(max_size_in_mb=100, max_item_count=32)
+_real_fft_cache = _FFTCache(max_size_in_mb=100, max_item_count=32)
 
 
 def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal
 from numpy import fft
 from numpy import pi
+from numpy.fft.helper import _FFTCache
 
 
 class TestFFTShift(TestCase):
@@ -72,6 +73,92 @@ class TestIRFFTN(TestCase):
 
         # Should not raise error
         fft.irfftn(a, axes=axes)
+
+
+class TestFFTCache(TestCase):
+
+    def test_basic_behaviour(self):
+        c = _FFTCache(max_size_in_mb=1, max_item_count=4)
+        # Setting
+        c[1] = [np.ones(2, dtype=np.float32)]
+        c[2] = [np.zeros(2, dtype=np.float32)]
+        # Getting
+        assert_array_almost_equal(c[1][0], np.ones(2, dtype=np.float32))
+        assert_array_almost_equal(c[2][0], np.zeros(2, dtype=np.float32))
+        # Setdefault
+        c.setdefault(1, [np.array([1, 2], dtype=np.float32)])
+        assert_array_almost_equal(c[1][0], np.ones(2, dtype=np.float32))
+        c.setdefault(3, [np.array([1, 2], dtype=np.float32)])
+        assert_array_almost_equal(c[3][0], np.array([1, 2], dtype=np.float32))
+
+        self.assertEqual(len(c._dict), 3)
+
+    def test_automatic_pruning(self):
+        # Thats around 2600 single precision samples.
+        c = _FFTCache(max_size_in_mb=0.01, max_item_count=4)
+        c[1] = [np.ones(200, dtype=np.float32)]
+        c[2] = [np.ones(200, dtype=np.float32)]
+
+        # Don't raise errors.
+        c[1], c[2], c[1], c[2]
+
+        # This is larger than the limit but should still be kept.
+        c[3] = [np.ones(3000, dtype=np.float32)]
+        # Should exist.
+        c[1], c[2], c[3]
+        # Add one more.
+        c[4] = [np.ones(3000, dtype=np.float32)]
+
+        # The other three should no longer exist.
+        with self.assertRaises(KeyError):
+            c[1]
+        with self.assertRaises(KeyError):
+            c[2]
+        with self.assertRaises(KeyError):
+            c[3]
+
+        # Now test the max item count pruning.
+        c = _FFTCache(max_size_in_mb=0.01, max_item_count=2)
+        c[1] = [np.empty(2)]
+        c[2] = [np.empty(2)]
+        # Can still be accessed.
+        c[2], c[1]
+
+        c[3] = [np.empty(2)]
+
+        # 1 and 3 can still be accessed - c[2] has been touched least recently
+        # and is thus evicted.
+        c[1], c[3]
+
+        with self.assertRaises(KeyError):
+            c[2]
+
+        c[1], c[3]
+
+        # One last test. We will add a single large item that is slightly
+        # bigger then the cache size. Some small items can still be added.
+        c = _FFTCache(max_size_in_mb=0.01, max_item_count=5)
+        c[1] = [np.ones(3000, dtype=np.float32)]
+        c[1]
+        c[2] = [np.ones(2, dtype=np.float32)]
+        c[3] = [np.ones(2, dtype=np.float32)]
+        c[4] = [np.ones(2, dtype=np.float32)]
+        c[1], c[2], c[3], c[4]
+
+        # One more big item.
+        c[5] = [np.ones(3000, dtype=np.float32)]
+
+        # c[1] no longer in the cache. Rest still in the cache.
+        c[2], c[3], c[4], c[5]
+        with self.assertRaises(KeyError):
+            c[1]
+
+        # Another big item - should now be the only item in the cache.
+        c[6] = [np.ones(4000, dtype=np.float32)]
+        for _i in range(1, 6):
+            with self.assertRaises(KeyError):
+                c[_i]
+        c[6]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The currently existing simple dictionary cache can grow without limit. With this PR neither cache can grow much larger than 100MB (arbitrary limit). It is implemented as an LRU (least recently used) cache so it will always remove items that have been get/set least recently. This should still reap most benefits of the original cache implementation without the potential to use a large amount of memory.

The following snippet will fill a lot of memory without this patch:

``` python
import numpy as np

for i in range(10000):
    print(i)
    np.fft.ifft(np.empty(10000 + i, dtype=np.complex128))
```

This is not just a theoretical issue - we've encountered this in practice here: obspy/obspy#1424

I'm not entirely sure if the additional complexity is really worth it but I don't see a simpler solution to achieve the same effect. The proposed LRU cache will always retain the most recently used items and throws away old ones as soon as the specified memory limit is reached. Thus most users will still benefit from the cache. I think it still works correctly when used in threaded code but I did not extensively test it.

It currently has a limit of 100 MB for each cache which is an arbitrary limit that works for my use cases.

The PR is currently based on the current master - let me know if you want it rebased on some other branch.
