### PR TITLE
BENCH: add correlate/convolve benchmarks.

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -2,78 +2,78 @@ from __future__ import absolute_import, division, print_function
 
 from .common import Benchmark
 
-import numpy
+import numpy as np
 
 
 class Core(Benchmark):
     def setup(self):
         self.l100 = range(100)
         self.l50 = range(50)
-        self.l = [numpy.arange(1000), numpy.arange(1000)]
-        self.l10x10 = numpy.ones((10, 10))
+        self.l = [np.arange(1000), np.arange(1000)]
+        self.l10x10 = np.ones((10, 10))
 
     def time_array_1(self):
-        numpy.array(1)
+        np.array(1)
 
     def time_array_empty(self):
-        numpy.array([])
+        np.array([])
 
     def time_array_l1(self):
-        numpy.array([1])
+        np.array([1])
 
     def time_array_l100(self):
-        numpy.array(self.l100)
+        np.array(self.l100)
 
     def time_array_l(self):
-        numpy.array(self.l)
+        np.array(self.l)
 
     def time_vstack_l(self):
-        numpy.vstack(self.l)
+        np.vstack(self.l)
 
     def time_hstack_l(self):
-        numpy.hstack(self.l)
+        np.hstack(self.l)
 
     def time_dstack_l(self):
-        numpy.dstack(self.l)
+        np.dstack(self.l)
 
     def time_arange_100(self):
-        numpy.arange(100)
+        np.arange(100)
 
     def time_zeros_100(self):
-        numpy.zeros(100)
+        np.zeros(100)
 
     def time_ones_100(self):
-        numpy.ones(100)
+        np.ones(100)
 
     def time_empty_100(self):
-        numpy.empty(100)
+        np.empty(100)
 
     def time_eye_100(self):
-        numpy.eye(100)
+        np.eye(100)
 
     def time_identity_100(self):
-        numpy.identity(100)
+        np.identity(100)
 
     def time_eye_3000(self):
-        numpy.eye(3000)
+        np.eye(3000)
 
     def time_identity_3000(self):
-        numpy.identity(3000)
+        np.identity(3000)
 
     def time_diag_l100(self):
-        numpy.diag(self.l100)
+        np.diag(self.l100)
 
     def time_diagflat_l100(self):
-        numpy.diagflat(self.l100)
+        np.diagflat(self.l100)
 
     def time_diagflat_l50_l50(self):
-        numpy.diagflat([self.l50, self.l50])
+        np.diagflat([self.l50, self.l50])
 
     def time_triu_l10x10(self):
-        numpy.triu(self.l10x10)
+        np.triu(self.l10x10)
 
     def time_tril_l10x10(self):
-        numpy.tril(self.l10x10)
+        np.tril(self.l10x10)
 
 
 class MA(Benchmark):
@@ -82,10 +82,27 @@ class MA(Benchmark):
         self.t100 = ([True] * 100)
 
     def time_masked_array(self):
-        numpy.ma.masked_array()
+        np.ma.masked_array()
 
     def time_masked_array_l100(self):
-        numpy.ma.masked_array(self.l100)
+        np.ma.masked_array(self.l100)
 
     def time_masked_array_l100_t100(self):
-        numpy.ma.masked_array(self.l100, self.t100)
+        np.ma.masked_array(self.l100, self.t100)
+
+
+class CorrConv(Benchmark):
+    params = [[50, 1000, 1e5],
+              [10, 100, 1000, 1e4],
+              ['valid', 'same', 'full']]
+    param_names = ['size1', 'size2', 'mode']
+
+    def setup(self, size1, size2, mode):
+        self.x1 = np.linspace(0, 1, num=size1)
+        self.x2 = np.cos(np.linspace(0, 2*np.pi, num=size2))
+
+    def time_correlate(self, size1, size2, mode):
+        np.correlate(self.x1, self.x2, mode=mode)
+
+    def time_convolve(self, size1, size2, mode):
+        np.convolve(self.x1, self.x2, mode=mode)


### PR DESCRIPTION
Related to gh-5978, which makes significant changes to these functions.

Output:

```
[  0.00%] ·· Benchmarking /usr/bin/python
[ 50.00%] ··· Running bench_core.CorrConv.time_convolve                                              ok
[ 50.00%] ···· 
               ========== ========= ========== ========== ==========
               --                                 mode              
               -------------------- --------------------------------
                 size1      size2     valid       same       full   
               ========== ========= ========== ========== ==========
                   50         10     46.30μs    31.43μs    32.99μs  
                   50        100     48.34μs    56.88μs    78.45μs  
                   50        1000    464.67μs   259.96μs   510.50μs 
                   50      10000.0    4.06ms     3.82ms     3.03ms  
                  1000        10     123.68μs   21.80μs    130.21μs 
                  1000       100     181.35μs   629.60μs   470.75μs 
                  1000       1000    48.17μs     2.80ms     3.79ms  
                  1000     10000.0   28.42ms    11.40ms    32.60ms  
                100000.0      10      6.96ms     2.68ms     9.54ms  
                100000.0     100     24.32ms    35.93ms    27.21ms  
                100000.0     1000    20.84ms    21.34ms    21.35ms  
                100000.0   10000.0   225.43ms   243.65ms   253.61ms 
               ========== ========= ========== ========== ==========

[100.00%] ··· Running bench_core.CorrConv.time_correlate                                             ok
[100.00%] ···· 
               ========== ========= ========== ========== ==========
               --                                 mode              
               -------------------- --------------------------------
                 size1      size2     valid       same       full   
               ========== ========= ========== ========== ==========
                   50         10     30.45μs    38.19μs    19.76μs  
                   50        100     90.23μs    97.56μs    115.63μs 
                   50        1000    256.14μs   206.78μs   519.70μs 
                   50      10000.0    3.11ms     2.65ms     2.13ms  
                  1000        10     38.81μs    87.11μs    69.46μs  
                  1000       100     277.78μs   615.10μs   310.64μs 
                  1000       1000    42.39μs     2.58ms     3.77ms  
                  1000     10000.0   29.27ms    11.78ms    31.05ms  
                100000.0      10      9.39ms     9.35ms     8.62ms  
                100000.0     100     29.83ms    52.04ms    51.65ms  
                100000.0     1000    146.30ms   21.51ms    20.61ms  
                100000.0   10000.0   232.52ms   246.62ms   253.96ms 
               ========== ========= ========== ========== ==========
```
