### PR TITLE
ENH: Compute many inner products quickly

### DIFF
--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -15,6 +15,7 @@ pinv            Pseudo-inverse (Moore-Penrose) calculated using a singular
                 value decomposition
 matrix_power    Integer power of a square matrix
 matrix_rank     Calculate matrix rank using an SVD-based method
+inner_prods     Computes many inner products.
 =============== ==========================================================
 
 =============== ==========================================================

--- a/numpy/linalg/info.py
+++ b/numpy/linalg/info.py
@@ -11,6 +11,7 @@ Linear algebra basics:
 - pinv            Pseudo-inverse (Moore-Penrose) calculated using a singular
                   value decomposition
 - matrix_power    Integer power of a square matrix
+- inner_prods     Computes many inner products
 
 Eigenvalues and decompositions:
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2224,6 +2224,56 @@ def norm(x, ord=None, axis=None, keepdims=False):
         raise ValueError("Improper number of dimensions to norm.")
 
 
+def inner_prods(X, A=None):
+    r"""
+    This function computes many inner products of the form :math:`x_i^T A x_i`
+
+    Parameters
+    ----------
+    X : array_like
+        The matrix of feature vectors. Every row in this ndarray is a feature
+        vector. This array must be 2-D.
+    A : array_like, optional.
+        To be used when computing :math:`x_i^T A x_i`. If this parameter is not
+        specified (default), this function returns :math:`[x_1^T x_1, \ldots,
+        x_n^T x_n]`. When it is specified, it returns :math:`[x_1^T A x_1, \ldots,
+        x_n^T A x_n]`.
+
+    Returns
+    -------
+    inner_products :  a vector of inner products. Each element in this vector is an
+        inner product corresponding to a row in ``X``. The return value is of the form
+
+    .. math::
+
+        [x_1^T\cdot A \cdot x_1, x_2^T \cdot A \cdot x_2, \ldots,
+        x_n^T \cdot A \cdot xn]
+
+
+    when X is of the form ``np.ndarray([x1, x2, ..., xn])`` and each element
+    ``xi`` is a 1D ndarray (of the same length).
+
+    Example
+    -------
+    >>> # compute p inner products
+    >>> p, n = 300, 100
+    >>> A = np.random.randn(n, n)
+    >>> # every row of X is a vector
+    >>> X = np.random.randn(p, n)
+    >>>
+    >>> # computing the inner products with a for-loop
+    >>> inner_slow = np.array([np.inner(x, A.dot(x)) for x in X])
+    >>> inner_fast = inner_prods(X, A) # I see about a 9x speedup here
+    >>> assert np.allclose(inner_slow, inner_fast)
+    """
+    X = np.asarray(X)
+    assert X.ndim == 2, "Pass a matrix of feature vectors in"
+    if A is None:
+        return norm(X, axis=1)**2
+    A = np.asarray(A)
+    return (X.T * A.dot(X.T)).sum(axis=0)
+
+
 # multi_dot
 
 def multi_dot(arrays):

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2266,11 +2266,11 @@ def inner_prods(X, A=None):
     >>> inner_fast = inner_prods(X, A) # I see about a 9x speedup here
     >>> assert np.allclose(inner_slow, inner_fast)
     """
-    X = np.asarray(X)
+    X = asarray(X)
     assert X.ndim == 2, "Pass a matrix of feature vectors in"
     if A is None:
         return norm(X, axis=1)**2
-    A = np.asarray(A)
+    A = asarray(A)
     return (X.T * A.dot(X.T)).sum(axis=0)
 
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy import array, single, double, csingle, cdouble, dot, identity
 from numpy import multiply, atleast_2d, inf, asarray, matrix
 from numpy import linalg
-from numpy.linalg import matrix_power, norm, matrix_rank, multi_dot
+from numpy.linalg import matrix_power, norm, matrix_rank, multi_dot, inner_prods
 from numpy.linalg.linalg import _multi_dot_matrix_chain_order
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal,
@@ -1105,6 +1105,16 @@ class _TestNorm(object):
         assert_raises(ValueError, norm, B, None, 3)
         assert_raises(ValueError, norm, B, None, (2, 3))
         assert_raises(ValueError, norm, B, None, (0, 1, 2))
+
+    def test_inner_prods(self):
+        np.random.seed(42)
+        p, n = 300, 100
+        A = np.random.randn(n, n, dtype=self.dt)
+        X = np.random.randn(p, n, dtype=self.dt)
+
+        assert_equal(inner_prods(X, A), np.array([np.inner(x, A.dot(x))
+                                                            for x in X]))
+        assert_equal(inner_prods(X), np.array([np.inner(x, x) for x in X]))
 
 
 class TestNorm_NonSystematic(object):


### PR DESCRIPTION
I had a use case where I had to 50k vectors that I had to compute the inner product `x.T @ A @ x`, each with the same 1k x 1k matrix `A`. Computing these 50k inner products had to take less than a second, and my first instinct was to look at NumPy for a corresponding function, but a fellow labmate showed me it was easy to formulate with some clever matrix multiplication.

The function `inner_prods` implements this matrix multiplication.

``` python
# my use case, more or less
# each row in X is a vector to be taking inner product
X = np.random.randn(int(50e3), 1000)
A = np.random.randn(1000, 1000)
inner_slowest = np.diag(X.T @ A @ X)
inner_slow = [np.inner(x, A @ x) for x in X]
inner_faster = inner_prods(X, A)
inner_faster_implementation = (X.T * A @ X.T).sum(axis=0)
```

I have implemented this function, and cover the case when `A = I` (the identity matrix). To do this, I made `A` an optional parameter and use `norm(X, axis=1)**2`.

I have timed this and on my machine I see a speedup of roughly 10x between `inner_slow` and `inner_faster` (not with 50k vectors, that takes a while).

**Questions:**
- Is this the proper name for this function? I also tossed around `inners` and `many_inner_prods` but decided to go halfway between the two.
- Do I need to implement more testing? Should I cover more use cases (e.g., dtype=object)?
