### PR TITLE
ENH: removing memory allocations from polyval for ~2x speedup

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -678,7 +678,10 @@ def polyval(p, x):
         x = NX.asarray(x)
         y = NX.zeros_like(x)
     for i in range(len(p)):
-        y = y * x + p[i]
+        # separate out the Horner operation y = y*x + p[i],
+        # so there are fewer memory allocations
+        y *= x
+        y += p[i]
     return y
 
 def polyadd(a1, a2):

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -776,7 +776,11 @@ def polyval(x, c, tensor=True):
 
     c0 = c[-1] + x*0
     for i in range(2, len(c) + 1):
-        c0 = c[-i] + c0*x
+        # separate out the Horner operation c0 = c[-i] + c0*x,
+        # so there are fewer memory allocations
+        c0 *= x
+        c0 += c[-i]
+
     return c0
 
 


### PR DESCRIPTION
Separating out the multiply-add from Horner's method in both polyval functions in order to reduce memory allocations per loop. While simple, it seems to produce a speedup between 1.5 and 6 depending on the size of the evaluation points.`
![polyval](https://cloud.githubusercontent.com/assets/1014675/15658012/5491e906-2685-11e6-894b-776e2c33782e.png)

`
