### PR TITLE
BLD: preserve library order

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -13,6 +13,13 @@ Dropped Support
 * Support for Python 2.6, 3.2, and 3.3 has been dropped.
 
 
+Build System Changes
+====================
+
+* Library order is preserved, instead of being reordered to match that of
+  the directories.
+
+
 Future Changes
 ==============
 


### PR DESCRIPTION
Before, the list of libraries was resorted to match the order of library_dirs. Now, the opposite occurs: library_dirs is resorted to match the library order.

Ran into this problem while trying to build numpy for a Bluegene/Q. [The order static libraries are passed to the linker is important](http://eli.thegreenplace.net/2013/07/09/library-order-in-static-linking).
