### PR TITLE
ENH: Add bits attribute to np.finfo

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -164,8 +164,8 @@ Generalized Ufuncs will now unlock the GIL
 Generalized Ufuncs, including most of the linalg module, will now unlock
 the Python global interpreter lock.
 
-np.roll can now roll multiple axes at the same time
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``np.roll can now roll multiple axes at the same time``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``shift`` and ``axis`` arguments to ``roll`` are now broadcast against each
 other, and each specified axis is shifted accordingly.
 
@@ -179,6 +179,11 @@ complex.
 The standard ``np.load``, ``np.save``, ``np.loadtxt``, ``np.savez``, and similar
 functions can now take ``pathlib.Path`` objects as an argument instead of a
 filename or open file object.
+
+Add ``bits`` attribute to ``np.finfo``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This makes ``np.finfo`` consistent with ``np.iinfo`` which already has that
+attribute.
 
 
 Changes

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -30,6 +30,8 @@ class finfo(object):
 
     Attributes
     ----------
+    bits : int
+        The number of bits occupied by the type.
     eps : float
         The smallest representable positive number such that
         ``1.0 + eps != 1.0``.  Type of `eps` is an appropriate floating
@@ -157,6 +159,7 @@ class finfo(object):
             setattr(self, word, getattr(machar, word))
         for word in ['tiny', 'resolution', 'epsneg']:
             setattr(self, word, getattr(machar, word).flat[0])
+        self.bits = self.dtype.itemsize * 8
         self.max = machar.huge.flat[0]
         self.min = -self.max
         self.eps = machar.eps.flat[0]
@@ -174,12 +177,12 @@ class finfo(object):
         fmt = (
             'Machine parameters for %(dtype)s\n'
             '---------------------------------------------------------------\n'
-            'precision=%(precision)3s   resolution= %(_str_resolution)s\n'
-            'machep=%(machep)6s   eps=        %(_str_eps)s\n'
-            'negep =%(negep)6s   epsneg=     %(_str_epsneg)s\n'
-            'minexp=%(minexp)6s   tiny=       %(_str_tiny)s\n'
-            'maxexp=%(maxexp)6s   max=        %(_str_max)s\n'
-            'nexp  =%(nexp)6s   min=        -max\n'
+            'precision = %(precision)3s   resolution = %(_str_resolution)s\n'
+            'machep = %(machep)6s   eps =        %(_str_eps)s\n'
+            'negep =  %(negep)6s   epsneg =     %(_str_epsneg)s\n'
+            'minexp = %(minexp)6s   tiny =       %(_str_tiny)s\n'
+            'maxexp = %(maxexp)6s   max =        %(_str_max)s\n'
+            'nexp =   %(nexp)6s   min =        -max\n'
             '---------------------------------------------------------------\n'
             )
         return fmt % self.__dict__
@@ -200,6 +203,8 @@ class iinfo(object):
 
     Attributes
     ----------
+    bits : int
+        The number of bits occupied by the type.
     min : int
         The smallest integer expressible by the type.
     max : int

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -42,6 +42,19 @@ class TestLongdouble(TestCase):
         ftype2 = finfo(longdouble)
         assert_equal(id(ftype), id(ftype2))
 
+class TestFinfo(TestCase):
+    def test_basic(self):
+        dts = list(zip(['f2', 'f4', 'f8', 'c8', 'c16'],
+                       [np.float16, np.float32, np.float64, np.complex64,
+                        np.complex128]))
+        for dt1, dt2 in dts:
+            for attr in ('bits', 'eps', 'epsneg', 'iexp', 'machar', 'machep',
+                         'max', 'maxexp', 'min', 'minexp', 'negep', 'nexp',
+                         'nmant', 'precision', 'resolution', 'tiny'):
+                assert_equal(getattr(finfo(dt1), attr),
+                             getattr(finfo(dt2), attr), attr)
+        self.assertRaises(ValueError, finfo, 'i4')
+
 class TestIinfo(TestCase):
     def test_basic(self):
         dts = list(zip(['i1', 'i2', 'i4', 'i8',
@@ -49,8 +62,9 @@ class TestIinfo(TestCase):
                   [np.int8, np.int16, np.int32, np.int64,
                    np.uint8, np.uint16, np.uint32, np.uint64]))
         for dt1, dt2 in dts:
-            assert_equal(iinfo(dt1).min, iinfo(dt2).min)
-            assert_equal(iinfo(dt1).max, iinfo(dt2).max)
+            for attr in ('bits', 'min', 'max'):
+                assert_equal(getattr(iinfo(dt1), attr),
+                             getattr(iinfo(dt2), attr), attr)
         self.assertRaises(ValueError, iinfo, 'f4')
 
     def test_unsigned_max(self):


### PR DESCRIPTION
Fixup for #7471 adding release note.

Add a bits attribute to np.finfo, document the existence of this
attribute for both np.iinfo and np.finfo, plus some extra spacing
around the str labels to make the representation consistent
for both classes. 
