### PR TITLE
BUG: Fix race condition with new FFT cache

### DIFF
--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -281,6 +281,7 @@ class _FFTCache(object):
             self._dict.popitem(last=False)
 
     def _check_size(self):
-        item_sizes = [_i[0].nbytes for _i in self._dict.values() if _i]
+        item_sizes = [sum(_j.nbytes for _j in _i)
+                      for _i in self._dict.values() if _i]
         max_size = max(self._max_size_in_bytes, 1.5 * max(item_sizes))
         return sum(item_sizes) > max_size

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -4,7 +4,8 @@ Discrete Fourier Transforms - helper.py
 """
 from __future__ import division, absolute_import, print_function
 
-from collections import OrderedDict
+import collections
+import threading
 
 from numpy.compat import integer_types
 from numpy.core import (
@@ -228,7 +229,7 @@ def rfftfreq(n, d=1.0):
 
 class _FFTCache(object):
     """
-    Cache for the FFT init functions as an LRU (least recently used) cache.
+    Cache for the FFT twiddle factors as an LRU (least recently used) cache.
 
     Parameters
     ----------
@@ -250,31 +251,64 @@ class _FFTCache(object):
     def __init__(self, max_size_in_mb, max_item_count):
         self._max_size_in_bytes = max_size_in_mb * 1024 ** 2
         self._max_item_count = max_item_count
-        # Much simpler than inheriting from it and having to work around
-        # recursive behaviour.
-        self._dict = OrderedDict()
+        self._dict = collections.OrderedDict()
+        self._lock = threading.Lock()
 
-    def setdefault(self, key, value):
-        return self._dict.setdefault(key, value)
+    def put_twiddle_factors(self, n, factors):
+        """
+        Store twiddle factors for an FFT of length n in the cache.
 
-    def __getitem__(self, key):
-        # pop + add to move it to the end.
-        value = self._dict.pop(key)
-        self._dict[key] = value
-        self._prune_dict()
-        return value
+        Putting multiple twiddle factors for a certain n will store it multiple
+        times.
 
-    def __setitem__(self, key, value):
-        # Just setting is it not enough to move it to the end if it already
-        # exists.
-        try:
-            del self._dict[key]
-        except:
-            pass
-        self._dict[key] = value
-        self._prune_dict()
+        Parameters
+        ----------
+        n : int
+            Data length for the FFT.
+        factors : ndarray
+            The actual twiddle values.
+        """
+        with self._lock:
+            # Pop + later add to move it to the end for LRU behavior.
+            # Internally everything is stored in a dictionary whose values are
+            # lists.
+            try:
+                value = self._dict.pop(n)
+            except KeyError:
+                value = []
+            value.append(factors)
+            self._dict[n] = value
+            self._prune_cache()
 
-    def _prune_dict(self):
+    def pop_twiddle_factors(self, n):
+        """
+        Pop twiddle factors for an FFT of length n from the cache.
+
+        Will return None if the requested twiddle factors are not available in
+        the cache.
+
+        Parameters
+        ----------
+        n : int
+            Data length for the FFT.
+
+        Returns
+        -------
+        out : ndarray or None
+            The retrieved twiddle factors if available, else None.
+        """
+        with self._lock:
+            if n not in self._dict or not self._dict[n]:
+                return None
+            # Pop + later add to move it to the end for LRU behavior.
+            all_values = self._dict.pop(n)
+            value = all_values.pop()
+            # Only put pack if there are still some arrays left in the list.
+            if all_values:
+                self._dict[n] = all_values
+            return value
+
+    def _prune_cache(self):
         # Always keep at least one item.
         while len(self._dict) > 1 and (
                 len(self._dict) > self._max_item_count or self._check_size()):
@@ -283,5 +317,7 @@ class _FFTCache(object):
     def _check_size(self):
         item_sizes = [sum(_j.nbytes for _j in _i)
                       for _i in self._dict.values() if _i]
+        if not item_sizes:
+            return False
         max_size = max(self._max_size_in_bytes, 1.5 * max(item_sizes))
         return sum(item_sizes) > max_size


### PR DESCRIPTION
This is a follow up to #7686 and fixes a race condition introduced with that PR.

Setting and getting items is now protected by a lock ensuring thread safety. The size of a cache entry is now also calculated by summing over all arrays in the list.

A comment: The cache behaves like a dictionary whose values are lists. Each list contains the twiddle factors for an FFT of a certain length, potentially multiple times. Duplicating the twiddle factors is necessary in a threaded case as they can only be used by a single thread concurrently. Multiple parallel threads calculating FFTs of equal lengths (an IMHO quite realistic use case) would otherwise either have to wait for the other threads to finish or constantly recalculate the twiddle factors, both greatly impacting performance. The cache always behaved like this even when it was just a simple dictionary.
