### PR TITLE
BUG: Remove memory leak in np.place

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -375,6 +375,7 @@ arr_insert(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
         } else {
             Py_XDECREF(values);
             Py_XDECREF(mask);
+            Py_XDECREF(array);
             Py_RETURN_NONE;
         }
     }


### PR DESCRIPTION
Title is self-explanatory.  Closes #7714.

cc @aboettcher
