### PR TITLE
Backport 7723, Change mkl_info.dir_env_var from MKL to MKLROOT

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -960,7 +960,7 @@ class djbfft_info(system_info):
 
 class mkl_info(system_info):
     section = 'mkl'
-    dir_env_var = 'MKL'
+    dir_env_var = 'MKLROOT'
     _lib_mkl = ['mkl', 'vml', 'guide']
 
     def get_mkl_rootdir(self):


### PR DESCRIPTION
#7723

Reference: https://software.intel.com/en-us/node/528500. That is MKL 1.10.3, 1.10.0 came out in 2008.
