### PR TITLE
Backport 7735, BUG: fix issue on OS X with Python 3.x, npymath.ini not installed.

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -126,13 +126,13 @@ def allpath(name):
     return os.path.join(*splitted)
 
 def rel_path(path, parent_path):
-    """Return path relative to parent_path.
-    """
-    pd = os.path.abspath(parent_path)
-    apath = os.path.abspath(path)
-    if len(apath)<len(pd):
+    """Return path relative to parent_path."""
+    # Use realpath to avoid issues with symlinked dirs (see gh-7707)
+    pd = os.path.realpath(os.path.abspath(parent_path))
+    apath = os.path.realpath(os.path.abspath(path))
+    if len(apath) < len(pd):
         return path
-    if apath==pd:
+    if apath == pd:
         return ''
     if pd == apath[:len(pd)]:
         assert apath[len(pd)] in [os.sep], repr((path, apath[len(pd)]))

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -4,7 +4,7 @@ from __future__ import division, absolute_import, print_function
 from os.path import join, sep, dirname
 
 from numpy.distutils.misc_util import (
-    appendpath, minrelpath, gpaths, get_shared_lib_extension
+    appendpath, minrelpath, gpaths, get_shared_lib_extension, get_info
 )
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal
@@ -74,6 +74,13 @@ class TestSharedExtension(TestCase):
             assert_equal(ext, '.dll')
         # just check for no crash
         assert_(get_shared_lib_extension(is_python_ext=True))
+
+
+def test_installed_npymath_ini():
+    # Regression test for gh-7707.  If npymath.ini wasn't installed, then this
+    # will give an error.
+    info = get_info('npymath')
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport of #7735.

Closes gh-7707.  Happened for `pip install .` or another location (including a
remote git repo).
