### PR TITLE
DOC: add reference to poisson rng

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -500,6 +500,11 @@ long rk_poisson_mult(rk_state *state, double lam)
     }
 }
 
+/*
+ * The transformed rejection method for generating Poisson random variables
+ * W. Hoermann
+ * Insurance: Mathematics and Economics 12, 39-45 (1993)
+ */
 #define LS2PI 0.91893853320467267
 #define TWELFTH 0.083333333333333333333333
 long rk_poisson_ptrs(rk_state *state, double lam)


### PR DESCRIPTION
[ci skip]

as googling numeric constants should not be the way to find the description of the code.
