### PR TITLE
Update 7476, DEP: deprecate Numeric-style typecodes, closes #2148

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1539,6 +1539,32 @@ finish:
             }
 #endif
             if (item) {
+                /* Check for a deprecated Numeric-style typecode */
+                if (PyBytes_Check(obj)) {
+                    char *type = NULL;
+                    Py_ssize_t len = 0;
+                    char *dep_tps[] = {"Bool", "Complex", "Float", "Int",
+                                       "Object0", "String0", "Timedelta64",
+                                       "Unicode0", "UInt", "Unicode0",
+                                       "Void0"};
+                    int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
+                    int i;
+
+                    if (PyBytes_AsStringAndSize(obj, &type, &len) < 0) {
+                        goto error;
+                    }
+                    for (i = 0; i < ndep_tps; ++i) {
+                        char *dep_tp = dep_tps[i];
+
+                        if (strncmp(type, dep_tp, strlen(dep_tp)) == 0) {
+                            if (DEPRECATE("Numeric-style type codes are "
+                                          "deprecated and will result in "
+                                          "an error in the future.") < 0) {
+                                goto fail;
+                            }
+                        }
+                    }
+                }
                 return PyArray_DescrConverter(item, at);
             }
         }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1545,8 +1545,7 @@ finish:
                     Py_ssize_t len = 0;
                     char *dep_tps[] = {"Bool", "Complex", "Float", "Int",
                                        "Object0", "String0", "Timedelta64",
-                                       "Unicode0", "UInt", "Unicode0",
-                                       "Void0"};
+                                       "Unicode0", "UInt", "Void0"};
                     int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
                     int i;
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -198,7 +198,7 @@ class _DeprecationTestCase(object):
                         (warning.category,))
         if num is not None and num_found != num:
             msg = "%i warnings found but %i expected." % (len(self.log), num)
-            lst = [w.category for w in self.log]
+            lst = [str(w.category) for w in self.log]
             raise AssertionError("\n".join([msg] + lst))
 
         with warnings.catch_warnings():
@@ -619,13 +619,17 @@ class TestNumericStyleTypecodes(_DeprecationTestCase):
     _add_aliases in numerictypes.py.
     """
     def test_all_dtypes(self):
-        deprecated_types = ['Bool', 'Complex32', 'Complex64', 'Float16',
-                            'Float32', 'Float64', 'Int8', 'Int16', 'Int32',
-                            'Int64' 'Object0', 'String0', 'Timedelta64',
-                            'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Unicode0',
-                            'Void0']
-        for deprecated_type in deprecated_types:
-            self.assert_deprecated(np.dtype, args=(deprecated_type,))
+        deprecated_types = [
+            'Bool', 'Complex32', 'Complex64', 'Float16', 'Float32', 'Float64',
+            'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Timedelta64',
+            'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Void0'
+            ]
+        if sys.version_info[0] < 3:
+            deprecated_types.extend(['Unicode0', 'String0'])
+
+        for dt in deprecated_types:
+            self.assert_deprecated(np.dtype, exceptions=(TypeError,),
+                                   args=(dt,))
 
 
 class TestTestDeprecated(object):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -609,6 +609,25 @@ class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTest
         self.assert_deprecated(np.binary_repr, args=args, kwargs=kwargs)
 
 
+class TestNumericStyleTypecodes(_DeprecationTestCase):
+    """
+    Deprecate the old numeric-style dtypes, which are especially
+    confusing for complex types, e.g. Complex32 -> complex64. When the
+    deprecation cycle is complete, the check for the strings should be
+    removed from PyArray_DescrConverter in descriptor.c, and the
+    deprecated keys should not be added as capitalized aliases in
+    _add_aliases in numerictypes.py.
+    """
+    def test_all_dtypes(self):
+        deprecated_types = ['Bool', 'Complex32', 'Complex64', 'Float16',
+                            'Float32', 'Float64', 'Int8', 'Int16', 'Int32',
+                            'Int64' 'Object0', 'String0', 'Timedelta64',
+                            'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Unicode0',
+                            'Void0']
+        for deprecated_type in deprecated_types:
+            self.assert_deprecated(np.dtype, args=(deprecated_type,))
+
+
 class TestTestDeprecated(object):
     def test_assert_deprecated(self):
         test_case_instance = _DeprecationTestCase()


### PR DESCRIPTION
Update of #7476.
