### PR TITLE
DOC: Remove "ones_like" from ufuncs list (it is not)

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -521,7 +521,6 @@ Math operations
     sqrt
     square
     reciprocal
-    ones_like
 
 .. tip::
 


### PR DESCRIPTION
Mentioned here: http://stackoverflow.com/questions/37625478/why-is-ones-like-listed-as-a-ufunc
