### PR TITLE
DOC: Clarify the effect of rcond in numpy.linalg.lstsq.

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1804,8 +1804,9 @@ def lstsq(a, b, rcond=-1):
         of `b`.
     rcond : float, optional
         Cut-off ratio for small singular values of `a`.
-        Singular values are set to zero if they are smaller than `rcond`
-        times the largest singular value of `a`.
+        For the purposes of rank determination, singular values are treated
+        as zero if they are smaller than `rcond` times the largest singular
+        value of `a`.
 
     Returns
     -------


### PR DESCRIPTION
The `rcond` `kwarg` to `numpy.linalg.lstsq` influences the rank
determination computation by specifying the level at which
singular values should be _treated_ as zero, it does not cause
the singular values to be "set" to zero.
