### PR TITLE
Update 7672, BUG: Make sure we don't divide by zero 

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -599,9 +599,9 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         #  it is included here because the covariance of Multivariate Student-T
         #  (which is implied by a Bayesian uncertainty analysis) includes it.
         #  Plus, it gives a slightly more conservative estimate of uncertainty.
-        if (len(x) - order - 2.0) < 1:
-            raise ValueError("the number of data points must exceed "
-                             "the degree + 3 for covariance matrix")
+        if len(x) <= order + 2:
+            raise ValueError("the number of data points must exceed order + 2 "
+                             "for Bayesian estimate the covariance matrix")
         fac = resids / (len(x) - order - 2.0)
         if y.ndim == 1:
             return c, Vbase * fac

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -599,6 +599,9 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         #  it is included here because the covariance of Multivariate Student-T
         #  (which is implied by a Bayesian uncertainty analysis) includes it.
         #  Plus, it gives a slightly more conservative estimate of uncertainty.
+        if (len(x) - order - 2.0) < 1:
+            raise ValueError("the number of data points must exceed "
+                             "the degree + 3 for covariance matrix")
         fac = resids / (len(x) - order - 2.0)
         if y.ndim == 1:
             return c, Vbase * fac

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -81,7 +81,7 @@ poly1d([ 2.])
 import numpy as np
 from numpy.testing import (
     run_module_suite, TestCase, assert_, assert_equal, assert_array_equal,
-    assert_almost_equal, assert_array_almost_equal, rundocs
+    assert_almost_equal, assert_array_almost_equal, assert_raises, rundocs
     )
 
 
@@ -134,6 +134,12 @@ class TestDocs(TestCase):
         y = np.polyval(c, x)
         err = [1, -1, 1, -1, 1, -1, 1]
         weights = np.arange(8, 1, -1)**2/7.0
+
+        # Check exception when too few points for variance estimate. Note that
+        # the Bayesian estimate requires the number of data points to exceed
+        # degree + 3.
+        assert_raises(ValueError, np.polyfit,
+                      [0, 1, 3], [0, 1, 3], deg=0, cov=True)
 
         # check 1D case
         m, cov = np.polyfit(x, y+err, 2, cov=True)


### PR DESCRIPTION
Update #7672. Add test and simplify the check in polyfit.

This should fix the issue discussed at
https://mail.scipy.org/pipermail/numpy-discussion/2013-July/067076.html

Without the ValueError added here, polyfit can (and does) return
negative or nan variances with no warning.
