### PR TITLE
DOC: Update float32 mean example in docstring

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2844,7 +2844,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
     >>> a[0, :] = 1.0
     >>> a[1, :] = 0.1
     >>> np.mean(a)
-    0.546875
+    0.54999924
 
     Computing the mean in float64 is more accurate:
 


### PR DESCRIPTION
Computing the `np.mean()` of a `float32` array is less inaccurate than it used to be (see e.g. #5681). This just updates the docstring to the value returned by the current 1.11 release and dev versions.

This should be caught in a doctest, but there are a lot of other errors for me when I try doing that. I'm probably missing a simpler way to isolate this single doctest.
