### PR TITLE
BUG: Fix numpy.i support for numpy API < 1.7.

### DIFF
--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -81,6 +81,7 @@
 %#define array_descr(a)         (((PyArrayObject*)a)->descr)
 %#define array_flags(a)         (((PyArrayObject*)a)->flags)
 %#define array_enableflags(a,f) (((PyArrayObject*)a)->flags) = f
+%#define array_is_fortran(a)    (PyArray_ISFORTRAN((PyArrayObject*)a))
 %#else
 %#define is_array(a)            ((a) && PyArray_Check(a))
 %#define array_type(a)          PyArray_TYPE((PyArrayObject*)a)
@@ -93,10 +94,10 @@
 %#define array_descr(a)         PyArray_DESCR((PyArrayObject*)a)
 %#define array_flags(a)         PyArray_FLAGS((PyArrayObject*)a)
 %#define array_enableflags(a,f) PyArray_ENABLEFLAGS((PyArrayObject*)a,f)
+%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 %#endif
 %#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
 %#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
-%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 }
 
 /**********************************************************************/
@@ -295,7 +296,11 @@
       Py_INCREF(array_descr(ary));
       result = (PyArrayObject*) PyArray_FromArray(ary,
                                                   array_descr(ary),
+%#if NPY_API_VERSION < 0x00000007
+                                                  NPY_FORTRANORDER);
+%#else
                                                   NPY_ARRAY_F_CONTIGUOUS);
+%#endif
       *is_new_object = 1;
     }
     return result;


### PR DESCRIPTION
numpy API < 1.7 does not support NPY_ARRAY_F_CONTIGUOUS.or PyArray_IS_F_CONTIGUOUS. Supporting old APIs is useful as users tend to ship modern numpy.i files to compile against possibly older numpy installations.

I tested this fix by searching for the introduction of both constants (numpy 1.7), and compiling against numpy 1.3 and 1.10. This ought to be more than sufficient for this simple change. Note that the code for <=1.7 is equal to what used to be there (actually until 1.9).
