### PR TITLE
BUG: construct ma.array from np.array which contains padding

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -411,7 +411,8 @@ def _check_fill_value(fill_value, ndtype):
     fields = ndtype.fields
     if fill_value is None:
         if fields:
-            descr = ndtype.descr
+            # skip unnamed fields; they don't have corresponding entries in ndtype
+            descr = [pair for pair in ndtype.descr if pair[0]]
             fill_value = np.array(_recursive_set_default_fill_value(descr),
                                   dtype=ndtype,)
         else:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -212,6 +212,11 @@ class TestMaskedArray(TestCase):
         assert_equal(data, [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
         self.assertTrue(data.mask is nomask)
 
+    def test_creation_from_ndarray_with_padding(self):
+        x = np.array([('A', 0)], dtype={'names':['f0','f1'], 'formats':['S4','i8'], 'offsets':[0,8]})
+        data = array(x)
+        self.assertTrue(data.mask is nomask)
+
     def test_asarray(self):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         xm.fill_value = -9999

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -214,8 +214,7 @@ class TestMaskedArray(TestCase):
 
     def test_creation_from_ndarray_with_padding(self):
         x = np.array([('A', 0)], dtype={'names':['f0','f1'], 'formats':['S4','i8'], 'offsets':[0,8]})
-        data = array(x)
-        self.assertTrue(data.mask is nomask)
+        data = array(x) # used to fail due to 'V' padding field in x.dtype.descr
 
     def test_asarray(self):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d


### PR DESCRIPTION
A unit test included, which fails before this patch,
because dtype.descr has extra entries when padding is present.
