### PR TITLE
f2py.compile issues (#7683)

### DIFF
--- a/numpy/_import_tools.py
+++ b/numpy/_import_tools.py
@@ -52,7 +52,7 @@ class PackageLoader(object):
     def _init_info_modules(self, packages=None):
         """Initialize info_modules = {<package_name>: <package info.py module>}.
         """
-        import imp
+        from numpy.compat import npy_load_module
         info_files = []
         info_modules = self.info_modules
 
@@ -86,8 +86,7 @@ class PackageLoader(object):
                 filedescriptor = ('.py', 'U', 1)
 
             try:
-                info_module = imp.load_module(fullname+'.info',
-                                              open(info_file, filedescriptor[1]),
+                info_module = npy_load_module(fullname + '.info',
                                               info_file,
                                               filedescriptor)
             except Exception as msg:

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -7,7 +7,7 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
            'asstr', 'open_latin1', 'long', 'basestring', 'sixu',
-           'integer_types', 'is_pathlib_path', 'Path']
+           'integer_types', 'is_pathlib_path', 'npy_load_module', 'Path']
 
 import sys
 try:
@@ -91,9 +91,66 @@ def asunicode_nested(x):
     else:
         return asunicode(x)
 
-
 def is_pathlib_path(obj):
     """
     Check whether obj is a pathlib.Path object.
     """
     return Path is not None and isinstance(obj, Path)
+
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
+    def npy_load_module(name, fn, info=None):
+        """
+        Load a module.
+
+        .. versionadded:: 1.11.2
+
+        Parameters
+        ----------
+        name : str
+            Full module name.
+        fn : str
+            Path to module file.
+        info : tuple, optional
+            Only here for backward compatibility with Python 2.*.
+
+        Returns
+        -------
+        mod : module
+
+        """
+        import importlib
+        return importlib.machinery.SourceFileLoader(name, fn).load_module()
+else:
+    def npy_load_module(name, fn, info=None):
+        """
+        Load a module.
+
+        .. versionadded:: 1.11.2
+
+        Parameters
+        ----------
+        name : str
+            Full module name.
+        fn : str
+            Path to module file.
+        info : tuple, optional
+            Information as returned by `imp.find_module`
+            (suffix, mode, type).
+
+        Returns
+        -------
+        mod : module
+
+        """
+        import imp
+        import os
+        if info is None:
+            path = os.path.dirname(fn)
+            fo, fn, info = imp.find_module(name, [path])
+        else:
+            fo = open(fn, info[1])
+        try:
+            mod = imp.load_module(name, fo, fn, info)
+        finally:
+            fo.close()
+        return mod

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 import os
 import re
 import sys
-import imp
 import copy
 import glob
 import atexit
@@ -39,6 +38,7 @@ except NameError:
 
 from numpy.distutils.compat import get_exception
 from numpy.compat import basestring
+from numpy.compat import npy_load_module
 
 __all__ = ['Configuration', 'get_numpy_include_dirs', 'default_config_dict',
            'dict_append', 'appendpath', 'generate_config_py',
@@ -875,14 +875,11 @@ class Configuration(object):
         # In case setup_py imports local modules:
         sys.path.insert(0, os.path.dirname(setup_py))
         try:
-            fo_setup_py = open(setup_py, 'U')
             setup_name = os.path.splitext(os.path.basename(setup_py))[0]
             n = dot_join(self.name, subpackage_name, setup_name)
-            setup_module = imp.load_module('_'.join(n.split('.')),
-                                           fo_setup_py,
+            setup_module = npy_load_module('_'.join(n.split('.')),
                                            setup_py,
                                            ('.py', 'U', 1))
-            fo_setup_py.close()
             if not hasattr(setup_module, 'configuration'):
                 if not self.options['assume_default_configuration']:
                     self.warn('Assuming default configuration '\
@@ -1912,11 +1909,12 @@ class Configuration(object):
         for f in files:
             fn = njoin(self.local_path, f)
             if os.path.isfile(fn):
-                info = (open(fn), fn, ('.py', 'U', 1))
+                info = ('.py', 'U', 1)
                 name = os.path.splitext(os.path.basename(fn))[0]
                 n = dot_join(self.name, name)
                 try:
-                    version_module = imp.load_module('_'.join(n.split('.')),*info)
+                    version_module = npy_load_module('_'.join(n.split('.')),
+                                                     fn, info)
                 except ImportError:
                     msg = get_exception()
                     self.warn(str(msg))

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -22,25 +22,32 @@ def compile(source,
             verbose=True,
             source_fn=None,
             extension='.f'
-            ):
-    ''' Build extension module from processing source with f2py.
+           ):
+    """
+    Build extension module from processing source with f2py.
 
     Parameters
     ----------
     source : str
         Fortran source of module / subroutine to compile
     modulename : str, optional
-        the name of compiled python module
-    extra_args: str, optional
-        additional parameters passed to f2py
-    verbose: bool, optional
-        print f2py output to screen
-    extension: {'.f', '.f90'}, optional
-        filename extension influences the fortran compiler behavior
+        The name of the compiled python module
+    extra_args : str, optional
+        Additional parameters passed to f2py
+    verbose : bool, optional
+        Print f2py output to screen
+    source_fn : str, optional
+        Name of the file where the fortran source is written.
+        The default is to use a temporary file with the extension
+        provided by the `extension` parameter
+    extension : {'.f', '.f90'}, optional
+        Filename extension if `source_fn` is not provided.
+        The extension tells which fortran standard is used.
+        The default is `.f`, which implies F77 standard.
 
         .. versionadded:: 1.11.0
 
-    '''
+    """
     from numpy.distutils.exec_command import exec_command
     import tempfile
     if source_fn is None:

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1083,18 +1083,13 @@ def rundocs(filename=None, raise_on_error=True):
 
     >>> np.lib.test(doctests=True) #doctest: +SKIP
     """
+    from numpy.compat import npy_load_module
     import doctest
-    import imp
     if filename is None:
         f = sys._getframe(1)
         filename = f.f_globals['__file__']
     name = os.path.splitext(os.path.basename(filename))[0]
-    path = [os.path.dirname(filename)]
-    file, pathname, description = imp.find_module(name, path)
-    try:
-        m = imp.load_module(name, file, pathname, description)
-    finally:
-        file.close()
+    m = npy_load_module(name, filename)
 
     tests = doctest.DocTestFinder().find(m)
     runner = doctest.DocTestRunner(verbose=False)


### PR DESCRIPTION
- DOC: add to `f2py.compile`'s doctstring a description of the `source_fn` argument
- MAINT: avoid warnings about deprecated `imp.load_module` in `distutil.misc_util` with Python 3

That leaves one issue in #7683 that I have not yet figured out:

```
Could not locate executable C:ProgramsPython35python.exe
Executable C:ProgramsPython35python.exe does not exist
```

Looks like some string escaping issue, but nothing jumped at me looking at `distutil.exec_command.{exec_command,find_executable}` and I don't have a windows machine to test on. 
