### PR TITLE
ENH: properly account for trailing padding in PEP3118

### DIFF
--- a/doc/release/upcoming_changes/7798.improvement.rst
+++ b/doc/release/upcoming_changes/7798.improvement.rst
@@ -1,0 +1,16 @@
+Trailing Padding now supported in PEP3118 buffer inferface
+----------------------------------------------------------
+Previously, structured types with trailing padding such as
+`np.dtype({'formats': ['i1'], 'names': ['a'], 'itemsize': 4})` could not
+roundtrip through the PEP3118 interface using a memoryview, as in
+`a == np.array(memoryview(a))`.  Now, such trailing padding is preserved.
+
+More technically, the PEP3118 interface now supports PEP3118 format strings as
+follows: Within "T{}", in aligned @ mode, trailing padding is automatically
+assumed in the same way as C structs and numpy aligned dtypes. Outside of T{}
+trailing padding is not automatically added or assumed in inputs, following
+python's struct module, but is explicitly added by padding with "x" or unnamed
+zero-sized trailing elements. 0-sized unnamed elements, like "0i", can now be
+added anywhere in the format string, and in @ mode this will add padding bytes
+up to that type's alignment offset, and otherwise is ignored, as described in
+the python struct docs.

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -689,8 +689,17 @@ def __dtype_from_pep3118(stream, is_subdtype):
 
         field_spec['itemsize'] = offset
 
-    # extra final padding for aligned types
-    if stream.byteorder == '@':
+    # extra final padding for aligned types:
+    # Inside of T{}, if in aligned mode, we add trailing padding like in a
+    # C struct so the end of the struct is aligned.
+    # Note that this behavior is *not* described by the PEP3118 spec, which
+    # does not say anything about T{} trailing padding. Note also that the Py
+    # struct docs say that trailing padding should *not* be implicitly added
+    # when outside of T{}, and the user should explicitly add a 0-sized
+    # trailing field to add padding, however struct does not implement T{}. So,
+    # here numpy is taking the initiative to specify how trailing padding works
+    # inside T{}, while we mimic struct outside of T{}.
+    if is_subdtype and stream.byteorder == '@':
         field_spec['itemsize'] += (-offset) % common_alignment
 
     # Check if this was a simple 1-item type, and unwrap it

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -289,9 +289,10 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             /* Insert padding manually */
             if (*offset > new_offset) {
                 PyErr_SetString(
-                    PyExc_ValueError, "The buffer interface does not support "
-                                      "overlapping fields or out-of-order "
-                                      "fields");
+                    PyExc_ValueError,
+                    "dtypes with overlapping or out-of-order fields are not "
+                    "representable as buffers. Consider reordering the fields."
+                );
                 return -1;
             }
             /* add padding bytes: repeat-count plus 'x' */


### PR DESCRIPTION
This changes how numpy treats trailing padding in the PEP3118 buffer interface, to fix #7797.

Previously, dtypes with trailing padding would have their trailing padding truncated when converted to  memoryview using pep3118. Now trailing padding is maintained.

Then, I also needed to modify the pep3118-to-array conversion to stop explicitly adding void fields for the trailing padding. This way code of the form `np.array(memoryview(arr))` will give back the original array even if there is trailing padding.

One thing I still need to think about is what to do for "aligned" types. The pep3118 doc is not clear what "alignment" means. It appears that `ix` and `ixxx` are supposed to mean the same thing: a structure of 8 bytes containing an integer in the first 4 bytes and 4 bytes of padding, but I am not 100% sure that is right.
