### PR TITLE
BUG: numpy.piecewise for scalar inputs

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1299,7 +1299,6 @@ def piecewise(x, condlist, funclist, *args, **kw):
                                    isinstance(condlist[0], ndarray))):
         condlist = [condlist]
     condlist = array(condlist, dtype=bool)
-    n = len(condlist)
     # This is a hack to work around problems with NumPy's
     #  handling of 0-d arrays and boolean indexing with
     #  numpy.bool_ scalars
@@ -1309,6 +1308,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
         zerod = True
         if condlist.shape[-1] != 1:
             condlist = condlist.T
+    n = len(condlist)
     if n == n2 - 1:  # compute the "otherwise" condition.
         totlist = np.logical_or.reduce(condlist, axis=0)
         # Only able to stack vertically if the array is 1d or less

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2129,6 +2129,16 @@ class TestPiecewise(TestCase):
         x = piecewise(3, [True, False, False], [4, 2, 0])
         assert_equal(x, 4)
 
+        x = piecewise(3, [False, True, False], [4, 2, 0])
+        assert_equal(x, 2)
+
+    def test_scalar_domains_with_default(self):
+        x = piecewise(3, [False, False, False], [4, 2, 0, 1])
+        assert_equal(x, 1)
+
+        x = piecewise(3, [False, True, False], [4, 2, 0, 1])
+        assert_equal(x, 2)
+
     def test_default(self):
         # No value specified for x[1], should be 0
         x = piecewise([1, 2], [True, False], [2])


### PR DESCRIPTION
fixing incorrect behavior for scalar inputs

BEFORE:
piecewise(3, [True, False, False], [4, 2, 0]) -> 4 Ok
piecewise(3, [False, True, False], [4, 2, 0]) -> 0 Bad

AFTER
piecewise(3, [True, False, False], [4, 2, 0]) -> 4 Ok
piecewise(3, [False, True, False], [4, 2, 0]) -> 2 Ok

This is because the length of "condlist" is checked before the list is fully arranged.
