### PR TITLE
BUG: interpret 'c' PEP3118/struct type as 'S1'.

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -370,6 +370,7 @@ def _view_is_safe(oldtype, newtype):
 
 _pep3118_native_map = {
     '?': '?',
+    'c': 'S1',
     'b': 'b',
     'B': 'B',
     'h': 'h',
@@ -396,6 +397,7 @@ _pep3118_native_typechars = ''.join(_pep3118_native_map.keys())
 
 _pep3118_standard_map = {
     '?': '?',
+    'c': 'S1',
     'b': 'b',
     'B': 'B',
     'h': 'i2',

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5690,6 +5690,12 @@ class TestPEP3118Dtype(object):
 
         self._check('(3)T{ix}', ({'f0': ('i', 0), '': (VV(1), 4)}, (3,)))
 
+    def test_char_vs_string(self):
+        dt = np.dtype('c')
+        self._check('c', dt)
+
+        dt = np.dtype([('f0', 'S1', (4,)), ('f1', 'S4')])
+        self._check('4c4s', dt)
 
 class TestNewBufferProtocol(object):
     def _check_roundtrip(self, obj):


### PR DESCRIPTION
Before this, a 'c' type code in a PEP3118 buffer would result in
failure to construct a NumPy array.  Now it's interpreted as a
single character, as in Python's struct module.  This means
'4c' is an array of 4 strings of size 1, while '4s' is (as before)
a single string of size 4.
