### PR TITLE
BUG: Fixed masked array behavior for scalar inputs to np.ma.atleast_*d

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -146,7 +146,7 @@ def atleast_3d(*arys):
     >>> x = np.arange(12.0).reshape(4,3)
     >>> np.atleast_3d(x).shape
     (4, 3, 1)
-    >>> np.atleast_3d(x).base is x
+    >>> np.atleast_3d(x).base is x.base  # x is a reshape, so not base itself
     True
 
     >>> for arr in np.atleast_3d([1, 2], [[1, 2]], [[[1, 2]]]):

--- a/numpy/lib/info.py
+++ b/numpy/lib/info.py
@@ -67,9 +67,9 @@ Shape Manipulation
 ------------------
 ================ ===================
 squeeze          Return a with length-one dimensions removed.
-atleast_1d       Force arrays to be > 1D
-atleast_2d       Force arrays to be > 2D
-atleast_3d       Force arrays to be > 3D
+atleast_1d       Force arrays to be >= 1D
+atleast_2d       Force arrays to be >= 2D
+atleast_3d       Force arrays to be >= 3D
 vstack           Stack arrays vertically (row on row)
 hstack           Stack arrays horizontally (column on column)
 column_stack     Stack 1D arrays as columns into 2D array

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1202,7 +1202,7 @@ class TestArraySetOps(TestCase):
 
 class TestShapeBase(TestCase):
 
-    def test_atleast2d(self):
+    def test_atleast_2d(self):
         # Test atleast_2d
         a = masked_array([0, 1, 2], mask=[0, 1, 0])
         b = atleast_2d(a)
@@ -1210,21 +1210,46 @@ class TestShapeBase(TestCase):
         assert_equal(b.mask.shape, b.data.shape)
         assert_equal(a.shape, (3,))
         assert_equal(a.mask.shape, a.data.shape)
+        assert_equal(b.mask.shape, b.data.shape)
 
     def test_shape_scalar(self):
         # the atleast and diagflat function should work with scalars
         # GitHub issue #3367
+        # Additionally, the atleast functions should accept multiple scalars
+        # correctly
         b = atleast_1d(1.0)
-        assert_equal(b.shape, (1, ))
-        assert_equal(b.mask.shape, b.data.shape)
+        assert_equal(b.shape, (1,))
+        assert_equal(b.mask.shape, b.shape)
+        assert_equal(b.data.shape, b.shape)
+
+        b = atleast_1d(1.0, 2.0)
+        for a in b:
+            assert_equal(a.shape, (1,))
+            assert_equal(a.mask.shape, a.shape)
+            assert_equal(a.data.shape, a.shape)
 
         b = atleast_2d(1.0)
         assert_equal(b.shape, (1, 1))
-        assert_equal(b.mask.shape, b.data.shape)
+        assert_equal(b.mask.shape, b.shape)
+        assert_equal(b.data.shape, b.shape)
+
+        b = atleast_2d(1.0, 2.0)
+        for a in b:
+            assert_equal(a.shape, (1, 1))
+            assert_equal(a.mask.shape, a.shape)
+            assert_equal(a.data.shape, a.shape)
 
         b = atleast_3d(1.0)
         assert_equal(b.shape, (1, 1, 1))
-        assert_equal(b.mask.shape, b.data.shape)
+        assert_equal(b.mask.shape, b.shape)
+        assert_equal(b.data.shape, b.shape)
+
+        b = atleast_3d(1.0, 2.0)
+        for a in b:
+            assert_equal(a.shape, (1, 1, 1))
+            assert_equal(a.mask.shape, a.shape)
+            assert_equal(a.data.shape, a.shape)
+
 
         b = diagflat(1.0)
         assert_equal(b.shape, (1, 1))


### PR DESCRIPTION
The changes in this bug are extracted from #7804, where they are duplicated. This PR is intended to be non-controversial since it is just a bug-fix.
