### PR TITLE
Pypy fixes

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4080,6 +4080,7 @@ initialize_numeric_types(void)
     /*
      * need to add dummy versions with filled-in nb_index
      * in-order for PyType_Ready to fill in .__index__() method
+     * also fill array_type_as_number struct with reasonable defaults
      */
 
     /**begin repeat
@@ -4088,6 +4089,7 @@ initialize_numeric_types(void)
      * #NAME = Byte, Short, Int, Long, LongLong, UByte, UShort,
      *         UInt, ULong, ULongLong#
      */
+    @name@_arrtype_as_number = gentype_as_number;
     Py@NAME@ArrType_Type.tp_as_number = &@name@_arrtype_as_number;
     Py@NAME@ArrType_Type.tp_as_number->nb_index = (unaryfunc)@name@_index;
 

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -126,8 +126,13 @@ class GnuFCompiler(FCompiler):
                 # from it.
                 import distutils.sysconfig as sc
                 g = {}
-                filename = sc.get_makefile_filename()
-                sc.parse_makefile(filename, g)
+                try:
+                    get_makefile_filename = sc.get_makefile_filename
+                except AttributeError:
+                    pass # i.e. PyPy
+                else: 
+                    filename = get_makefile_filename()
+                    sc.parse_makefile(filename, g)
                 target = g.get('MACOSX_DEPLOYMENT_TARGET', '10.3')
                 os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
                 if target == '10.3':


### PR DESCRIPTION
two simple fixes for PyPy:
1. When PyType_Ready is called, function slots like tp_as_number.nb_add are wrapped into a Python function and put into the Python type object. Any that are NULL are ignored. Later, when umath is imported, these are overloaded for scalars. Before this patch the functions were NULL when PyType_Ready was called, so PyPy was ignoring the overload.
2. PyPy has no Makefile
