### PR TITLE
MAINT: Fix remaining uses of deprecated Python imp module.

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -10,9 +10,10 @@ from os.path import join
 from numpy.distutils import log
 from distutils.dep_util import newer
 from distutils.sysconfig import get_config_var
-from numpy._build_utils.apple_accelerate import (uses_accelerate_framework,
-                                                 get_sgemv_fix)
-
+from numpy._build_utils.apple_accelerate import (
+    uses_accelerate_framework, get_sgemv_fix
+    )
+from numpy.compat import npy_load_module
 from setup_common import *
 
 # Set to True to enable relaxed strides checking. This (mostly) means
@@ -386,9 +387,8 @@ def configuration(parent_package='',top_path=None):
 
     generate_umath_py = join(codegen_dir, 'generate_umath.py')
     n = dot_join(config.name, 'generate_umath')
-    generate_umath = imp.load_module('_'.join(n.split('.')),
-                                     open(generate_umath_py, 'U'), generate_umath_py,
-                                     ('.py', 'U', 1))
+    generate_umath = npy_load_module('_'.join(n.split('.')),
+                                     generate_umath_py, ('.py', 'U', 1))
 
     header_dir = 'include/numpy'  # this is relative to config.path_in_package
 

--- a/runtests.py
+++ b/runtests.py
@@ -148,14 +148,17 @@ def main(argv):
     if args.python:
         # Debugging issues with warnings is much easier if you can see them
         print("Enabling display of all warnings")
-        import warnings; warnings.filterwarnings("always")
+        import warnings
+        import types
+
+        warnings.filterwarnings("always")
         if extra_argv:
             # Don't use subprocess, since we don't want to include the
             # current path in PYTHONPATH.
             sys.argv = extra_argv
             with open(extra_argv[0], 'r') as f:
                 script = f.read()
-            sys.modules['__main__'] = imp.new_module('__main__')
+            sys.modules['__main__'] = types.ModuleType('__main__')
             ns = dict(__name__='__main__',
                       __file__=extra_argv[0])
             exec_(script, ns)


### PR DESCRIPTION
The imp module will be deprecated in future Python, so remove the two remaining uses in numpy. 
