### PR TITLE
ENH: Make isfinite work with datetime/timedelta.

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -116,6 +116,7 @@ class Ufunc(object):
     nout : number of output arguments
     identity : identity element for a two-argument function
     docstring : docstring for the ufunc
+    typereso : type resolver used to dispatch the ufunc
     type_descriptions : list of TypeDescription objects
     """
     def __init__(self, nin, nout, identity, docstring, typereso,
@@ -794,8 +795,8 @@ defdict = {
 'isfinite':
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isfinite'),
-          None,
-          TD(inexact, out='?'),
+          'PyUFunc_UnaryPredicateTypeResolver',
+          TD(noobj, out='?'),
           ),
 'signbit':
     Ufunc(1, 1, None,

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -766,13 +766,21 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 /**end repeat**/
 
 NPY_NO_EXPORT void
-BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data))
+
+BOOL_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     OUTPUT_LOOP {
         *((npy_bool *)op1) = 1;
     }
 }
 
+NPY_NO_EXPORT void
+BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data))
+{
+    OUTPUT_LOOP {
+        *((npy_bool *)op1) = 1;
+    }
+}
 
 /*
  *****************************************************************************
@@ -799,6 +807,14 @@ NPY_NO_EXPORT void
 {
     OUTPUT_LOOP {
         *((@type@ *)op1) = 1;
+    }
+}
+
+NPY_NO_EXPORT void
+@TYPE@_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    OUTPUT_LOOP {
+        *((npy_bool *)op1) = 1;
     }
 }
 
@@ -1180,6 +1196,15 @@ TIMEDELTA_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNU
  * #type = npy_datetime, npy_timedelta#
  * #TYPE = DATETIME, TIMEDELTA#
  */
+
+NPY_NO_EXPORT void
+@TYPE@_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    UNARY_LOOP {
+        const @type@ in1 = *((@type@ *) ip1);
+        *((npy_bool *) op1) = (in1 != NPY_DATETIME_NAT);
+    }
+}
 
 NPY_NO_EXPORT void
 @TYPE@__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data))

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -29,7 +29,7 @@
 
 /**begin repeat
  * #kind = equal, not_equal, greater, greater_equal, less, less_equal,
- *         logical_and, logical_or, absolute, logical_not#
+ *         logical_and, logical_or, absolute, logical_not, isfinite#
  **/
 NPY_NO_EXPORT void
 BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
@@ -60,6 +60,9 @@ BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
 
 NPY_NO_EXPORT void
 @S@@TYPE@__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));
+
+NPY_NO_EXPORT void
+@S@@TYPE@_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 /**begin repeat2
  * #isa = , _avx2#
@@ -403,6 +406,8 @@ TIMEDELTA_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNU
 /**begin repeat
  * #TYPE = DATETIME, TIMEDELTA#
  */
+NPY_NO_EXPORT void
+@TYPE@_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
 @TYPE@__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -313,7 +313,6 @@ PyUFunc_SimpleUnaryOperationTypeResolver(PyUFuncObject *ufunc,
     }
 
     if (type_tup == NULL) {
-        /* Input types are the result type */
         out_dtypes[0] = ensure_dtype_nbo(PyArray_DESCR(operands[0]));
         if (out_dtypes[0] == NULL) {
             return -1;

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -16,6 +16,13 @@ PyUFunc_SimpleUnaryOperationTypeResolver(PyUFuncObject *ufunc,
                                          PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
+PyUFunc_UnaryPredicateTypeResolver(PyUFuncObject *ufunc,
+                                   NPY_CASTING casting,
+                                   PyArrayObject **operands,
+                                   PyObject *type_tup,
+                                   PyArray_Descr **out_dtypes);
+
+NPY_NO_EXPORT int
 PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
                              PyArrayObject **operands,

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+from itertools import product
 import pickle
 
 import numpy
@@ -18,12 +19,26 @@ try:
 except ImportError:
     _has_pytz = False
 
+ALL_DATETIME_UNITS = [
+    'Y',
+    'M',
+    'W',
+    'D',
+    'h',
+    'm',
+    's',
+    'ms',
+    'us',
+    'ns',
+    'ps',
+    'fs',
+    'as',
+]
+
 
 class TestDateTime(TestCase):
     def test_datetime_dtype_creation(self):
-        for unit in ['Y', 'M', 'W', 'D',
-                     'h', 'm', 's', 'ms', 'us',
-                     'ns', 'ps', 'fs', 'as']:
+        for unit in ALL_DATETIME_UNITS:
             dt1 = np.dtype('M8[750%s]' % unit)
             assert_(dt1 == np.dtype('datetime64[750%s]' % unit))
             dt2 = np.dtype('m8[%s]' % unit)
@@ -1912,6 +1927,24 @@ class TestDateTime(TestCase):
         # Test parsing a date after Y2038
         a = np.datetime64('2038-01-20T13:21:14')
         assert_equal(str(a), '2038-01-20T13:21:14')
+
+    def test_datetime_isfinite(self):
+
+        for type_, unit in product([np.datetime64, np.timedelta64],
+                                   ALL_DATETIME_UNITS):
+            nat = type_('NaT', unit)
+            self.assertFalse(
+                np.isfinite(nat),
+                "isfinite(NaT) should be False",
+            )
+
+            for i in range(5):
+                notnat = type_(i, unit)
+                self.assertTrue(
+                    np.isfinite(notnat),
+                    "isfinite(non-NaT) should be True",
+                )
+
 
 class TestDateTimeData(TestCase):
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1315,8 +1315,8 @@ class TestSpecialMethods(TestCase):
         func, args, i = x.context
         self.assertTrue(func is ncu.minimum)
         self.assertEqual(len(args), 2)
-        assert_equal(args[0], a)
-        assert_equal(args[1], a)
+        self.assertTrue(args[0] is a)
+        self.assertTrue(args[1] is a)
         self.assertEqual(i, 0)
 
     def test_wrap_with_iterable(self):

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -366,6 +366,7 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
         try:
             assert_equal(actualr, desiredr)
             assert_equal(actuali, desiredi)
+            return
         except AssertionError:
             raise AssertionError(msg)
 
@@ -388,9 +389,13 @@ def assert_equal(actual,desired,err_msg='',verbose=True):
                 if not desired == actual:
                     raise AssertionError(msg)
             return
-        elif desired == 0 and actual == 0:
-            if not signbit(desired) == signbit(actual):
-                raise AssertionError(msg)
+
+        # For inexact types (float and complexfloat), 0.0 and -0.0 are distinct
+        # values, but they compare equal. Explicitly assert that signbits match
+        # to catch this case.
+        if signbit(desired) != signbit(actual):
+            raise AssertionError(msg)
+
     # If TypeError or ValueError raised while using isnan and co, just handle
     # as before
     except (TypeError, ValueError, NotImplementedError):


### PR DESCRIPTION
- Adds new ufunc definitions for isfinite for datetime/timedelta.
- Fixes an issue where `ufunc_loop_matches` would always return False
  for datetime inputs with units, because it used
  `PyArray_CanCast{Type,Array}To` to check if the input array was
  compatible with a target dtype, but the target dtype is created with
  `PyArray_DescrFromType`, which means it will never have any unit
  metadata.
  
  The cleanest fix for this, I think, would be to copy the unit metadata
  from the dtype of the input array to the temporary dtype used to
  determine casting safety, but that requires the ability to call
  `get_datetime_metadata_from_dtype`, which is defined in `multiarray`
  from `ufunc_loop_matches`, which is defined in `umath`, and I couldn't
  figure out how do make that happen correctly (I think I need to create
  a public wrapper and put it in `numpy_api.py`?).
  
  The somewhat hacky fix is to short-circuit if the type number being
  checked matches the type of the input being checked. This avoids
  calling `PyArray_CanCastTo` in the case where we have exactly-equal
  types.  It's not totally clear to me whether this is safe though.
