### PR TITLE
BUG: Explicitly fill in None for np.empty_like

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1164,7 +1164,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_NewLikeArray(PyArrayObject *prototype, NPY_ORDER order,
                      PyArray_Descr *dtype, int subok)
 {
-    PyObject *ret = NULL;
+    PyArrayObject *ret = NULL;
     int ndim = PyArray_NDIM(prototype);
 
     /* If no override data type, use the one from the prototype */
@@ -1195,14 +1195,14 @@ PyArray_NewLikeArray(PyArrayObject *prototype, NPY_ORDER order,
 
     /* If it's not KEEPORDER, this is simple */
     if (order != NPY_KEEPORDER) {
-        ret = PyArray_NewFromDescr(subok ? Py_TYPE(prototype) : &PyArray_Type,
-                                        dtype,
-                                        ndim,
-                                        PyArray_DIMS(prototype),
-                                        NULL,
-                                        NULL,
-                                        order,
-                                        subok ? (PyObject *)prototype : NULL);
+        ret = (PyArrayObject *)PyArray_NewFromDescr(subok ? Py_TYPE(prototype) : &PyArray_Type,
+                                                        dtype,
+                                                        ndim,
+                                                        PyArray_DIMS(prototype),
+                                                        NULL,
+                                                        NULL,
+                                                        order,
+                                                        subok ? (PyObject *)prototype : NULL);
     }
     /* KEEPORDER needs some analysis of the strides */
     else {
@@ -1224,17 +1224,26 @@ PyArray_NewLikeArray(PyArrayObject *prototype, NPY_ORDER order,
         }
 
         /* Finally, allocate the array */
-        ret = PyArray_NewFromDescr(subok ? Py_TYPE(prototype) : &PyArray_Type,
-                                        dtype,
-                                        ndim,
-                                        shape,
-                                        strides,
-                                        NULL,
-                                        0,
-                                        subok ? (PyObject *)prototype : NULL);
+        ret = (PyArrayObject *)PyArray_NewFromDescr(subok ? Py_TYPE(prototype) : &PyArray_Type,
+                                                        dtype,
+                                                        ndim,
+                                                        shape,
+                                                        strides,
+                                                        NULL,
+                                                        0,
+                                                        subok ? (PyObject *)prototype : NULL);
     }
 
-    return ret;
+    /* see gh-7854 */   
+    if (PyArray_DESCR(ret)->type_num == NPY_OBJECT) {
+        PyArray_FillObjectArray(ret, Py_None);
+        if (PyErr_Occurred()) {
+            Py_DECREF(ret);
+            return NULL;
+        }
+    }
+
+    return (PyObject *)ret;
 }
 
 /*NUMPY_API

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2027,6 +2027,12 @@ class TestLikeFuncs(TestCase):
     def test_empty_like(self):
         self.check_like_function(np.empty_like, None)
 
+        # see gh-7854
+        arr = np.empty_like([None])
+        exp = np.array([None])
+        assert_array_equal(arr, exp)
+        self.assertEqual(bytes(arr.data), bytes(exp.data))
+
     def test_filled_like(self):
         self.check_like_function(np.full_like, 0, True)
         self.check_like_function(np.full_like, 1, True)


### PR DESCRIPTION
Explicitly fills in returned array with `Py_None` if the resulting `dtype` is `object` to avoid data
corruption, which led to segfaults in `pandas`.

Closes #7854.
Closes <a href="https://github.com/pydata/pandas/issues/13717">#13717</a> (`pandas`).

cc @bashtage @jreback
