### PR TITLE
ENH: Adding type checks to set_printoptions()

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -59,6 +59,9 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     ----------
     precision : int, optional
         Number of digits of precision for floating point output (default 8).
+        We type check this argument, as it is the first argument and we wish to
+        catch the common mistake of passing an unpacked dict (which will later
+        cause print() to fail with an opaque error).
     threshold : int, optional
         Total number of array elements which trigger summarization
         rather than full repr (default 1000).
@@ -161,6 +164,8 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     if edgeitems is not None:
         _summaryEdgeItems = edgeitems
     if precision is not None:
+        if not isinstance(precision, int):
+            raise TypeError("set_printoptions requires the argument 'precision' to be of type int")
         _float_output_precision = precision
     if suppress is not None:
         _float_output_suppress_small = not not suppress

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -23,6 +23,7 @@ from .multiarray import (array, format_longfloat, datetime_as_string,
                          datetime_data)
 from .fromnumeric import ravel
 from .numeric import asarray
+import operator
 
 if sys.version_info[0] >= 3:
     _MAXINT = sys.maxsize
@@ -59,9 +60,6 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     ----------
     precision : int, optional
         Number of digits of precision for floating point output (default 8).
-        We type check this argument, as it is the first argument and we wish to
-        catch the common mistake of passing an unpacked dict (which will later
-        cause print() to fail with an opaque error).
     threshold : int, optional
         Total number of array elements which trigger summarization
         rather than full repr (default 1000).
@@ -158,21 +156,19 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     global _formatter
 
     if linewidth is not None:
-        _line_width = linewidth
+        _line_width = operator.index(linewidth)
     if threshold is not None:
-        _summaryThreshold = threshold
+        _summaryThreshold = operator.index(threshold)
     if edgeitems is not None:
-        _summaryEdgeItems = edgeitems
+        _summaryEdgeItems = operator.index(edgeitems)
     if precision is not None:
-        if not isinstance(precision, int):
-            raise TypeError("set_printoptions requires the argument 'precision' to be of type int")
-        _float_output_precision = precision
+        _float_output_precision = operator.index(precision)
     if suppress is not None:
         _float_output_suppress_small = not not suppress
     if nanstr is not None:
-        _nan_str = nanstr
+        _nan_str = str(nanstr)
     if infstr is not None:
-        _inf_str = infstr
+        _inf_str = str(infstr)
     _formatter = formatter
 
 def get_printoptions():

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -7,7 +7,7 @@ import sys
 import numpy as np
 from numpy.compat import sixu
 from numpy.testing import (
-     TestCase, run_module_suite, assert_, assert_equal
+     TestCase, run_module_suite, assert_, assert_equal, assert_raises
 )
 
 class TestArrayRepr(object):
@@ -156,6 +156,10 @@ class TestPrintOptions:
         assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
         np.set_printoptions(formatter={'float_kind':None})
         assert_equal(repr(x), "array([ 0.,  1.,  2.])")
+
+    def test_type_check(self):
+        d = {}
+        assert_raises(TypeError, np.set_printoptions, d)
 
 def test_unicode_object_array():
     import sys


### PR DESCRIPTION
See issue #7852.

We raise a TypeError if the first argument isn't of the expected type. Not very Pythonic, but otherwise set_printoptions() doesn't fail, but will cause any subsequent calls to print() to fail with an opaque error. In particular someone could mistakenly pass a dict (rather than an unpacked dict).
