### PR TITLE
BUG: Fix handling of mixed-type arrays in histogram

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -24,7 +24,7 @@ from numpy.core.numerictypes import typecodes, number
 from numpy.lib.twodim_base import diag
 from .utils import deprecate
 from numpy.core.multiarray import (
-    _insert, add_docstring, digitize, bincount, 
+    _insert, add_docstring, digitize, bincount,
     interp as compiled_interp, interp_complex as compiled_interp_complex
     )
 from numpy.core.umath import _add_newdoc_ufunc as add_newdoc_ufunc
@@ -660,7 +660,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     if mn > mx:
         raise ValueError(
             'max must be larger than min in range parameter.')
-    if not np.all(np.isfinite([mn, mx])):
+    if not np.all(np.isfinite(np.hstack([mn, mx]))):
         raise ValueError(
             'range parameter must be finite.')
     if mn == mx:
@@ -1792,7 +1792,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
 
     Returns
     -------
-    y : float or complex (corresponding to fp) or ndarray 
+    y : float or complex (corresponding to fp) or ndarray
         The interpolated values, same shape as `x`.
 
     Raises
@@ -1899,7 +1899,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
             return interp_func(x, xp, fp, left, right)
         else:
             return interp_func(x, xp, fp, left, right).item()
-                
+
 def angle(z, deg=0):
     """
     Return the angle of the complex argument.


### PR DESCRIPTION
Arrays that contain both floats and single-element float arrays behave inconsistently in np.histogram:

Running this works as expected:
```python
>>> np.histogram(np.asarray([np.array([0.4]) for i in range(10)] + [-np.inf]))
ValueError: range parameter must be finite.
```
Running this does not:
```python
>>> np.histogram(np.asarray([np.array([0.4]) for i in range(10)] + [np.inf]))
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

Similarly, this gives the expected result:
```python
>>> np.histogram(np.asarray([np.array([0.5]) for i in range(10)] + [.50000000000000001]))
(array([ 0,  0,  0,  0,  0, 11,  0,  0,  0,  0]),
 array([ 0. ,  0.1,  0.2,  0.3,  0.4,  0.5,  0.6,  0.7,  0.8,  0.9,  1. ]))
```

Running this does not:
```
>>> np.histogram(np.asarray([np.array([0.5]) for i in range(10)] + [.5000000000000001]))
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

Since arrays and floats both implement max() and min(), the bounds-checking code at the beginning of histogram() will happily take the max and min, and then inconsistently infer the dtype _depending on the size of the array's contents_, e.g.:

```python
>>> np.asarray([4, np.array([np.inf])]).dtype`
dtype('float64')

>>> np.asarray([np.array([-np.inf]), 4]).dtype`
dtype('O')
```
