### PR TITLE
Document runtests extra argv

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -32,6 +32,13 @@ This builds Numpy first, so the first time it may take a few minutes.  If
 you specify ``-n``, the tests are run against the version of NumPy (if
 any) found on current PYTHONPATH.
 
+When specifying a target using ``-s``, ``-t``, or ``--python``, additional
+arguments may be forwarded to the target embedded by ``runtests.py`` by passing
+the extra arguments after a bare ``--``. For example, to run a test method with
+the ``--pdb`` flag forwarded to nose, run the following::
+
+    $ python runtests.py -t numpy/core/tests/test_ufunc.py:TestUfunc.test_sum -- --pdb
+
 Using ``runtests.py`` is the recommended approach to running tests.
 There are also a number of alternatives to it, for example in-place
 build or installing to a virtualenv. See the FAQ below for details.

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -37,7 +37,7 @@ arguments may be forwarded to the target embedded by ``runtests.py`` by passing
 the extra arguments after a bare ``--``. For example, to run a test method with
 the ``--pdb`` flag forwarded to nose, run the following::
 
-    $ python runtests.py -t numpy/core/tests/test_ufunc.py:TestUfunc.test_sum -- --pdb
+    $ python runtests.py -t numpy/tests/test_scripts.py:test_f2py -- --pdb
 
 Using ``runtests.py`` is the recommended approach to running tests.
 There are also a number of alternatives to it, for example in-place

--- a/runtests.py
+++ b/runtests.py
@@ -9,7 +9,7 @@ Examples::
     $ python runtests.py
     $ python runtests.py -s {SAMPLE_SUBMODULE}
     $ python runtests.py -t {SAMPLE_TEST}
-    $ python runtests.py -t {SAMPLE_TEST} -- {ARGUMENTS_FOR_NOSE}
+    $ python runtests.py -t {SAMPLE_TEST} -- {SAMPLE_NOSE_ARGUMENTS}
     $ python runtests.py --ipython
     $ python runtests.py --python somescript.py
     $ python runtests.py --bench
@@ -36,7 +36,7 @@ PROJECT_MODULE = "numpy"
 PROJECT_ROOT_FILES = ['numpy', 'LICENSE.txt', 'setup.py']
 SAMPLE_TEST = "numpy/linalg/tests/test_linalg.py:test_byteorder_check"
 SAMPLE_SUBMODULE = "linalg"
-ARGUMENTS_FOR_NOSE = "--pdb"
+SAMPLE_NOSE_ARGUMENTS = "--pdb"
 
 EXTRA_PATH = ['/usr/lib/ccache', '/usr/lib/f90cache',
               '/usr/local/lib/ccache', '/usr/local/lib/f90cache']

--- a/runtests.py
+++ b/runtests.py
@@ -9,6 +9,7 @@ Examples::
     $ python runtests.py
     $ python runtests.py -s {SAMPLE_SUBMODULE}
     $ python runtests.py -t {SAMPLE_TEST}
+    $ python runtests.py -t {SAMPLE_TEST} -- {ARGUMENTS_FOR_NOSE}
     $ python runtests.py --ipython
     $ python runtests.py --python somescript.py
     $ python runtests.py --bench
@@ -35,6 +36,7 @@ PROJECT_MODULE = "numpy"
 PROJECT_ROOT_FILES = ['numpy', 'LICENSE.txt', 'setup.py']
 SAMPLE_TEST = "numpy/linalg/tests/test_linalg.py:test_byteorder_check"
 SAMPLE_SUBMODULE = "linalg"
+ARGUMENTS_FOR_NOSE = "--pdb"
 
 EXTRA_PATH = ['/usr/lib/ccache', '/usr/lib/f90cache',
               '/usr/local/lib/ccache', '/usr/local/lib/f90cache']


### PR DESCRIPTION
This is useful for things like passing `--pdb` to make nose drop into
a pdb post-mortem on exception.

I was looking for a way to do this while working on https://github.com/numpy/numpy/pull/7856 and ended up finding this by digging through the source.
