### PR TITLE
BUG: Fix handling of clip out= argument order properly

### DIFF
--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -1103,7 +1103,8 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
     if (!outgood && PyArray_ISONESEGMENT(out) &&
                         PyArray_CHKFLAGS(out, NPY_ARRAY_ALIGNED) &&
                         PyArray_ISNOTSWAPPED(out) &&
-                        PyArray_EquivTypes(PyArray_DESCR(out), indescr)) {
+                        PyArray_EquivTypes(PyArray_DESCR(out), indescr) &&
+                        PyArray_ISFORTRAN(newin) == PyArray_ISFORTRAN(out)) {
         outgood = 1;
     }
 
@@ -1113,7 +1114,7 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
      */
     if (!outgood) {
         int oflags;
-        if (PyArray_ISFORTRAN(out))
+        if (PyArray_ISFORTRAN(newin))
             oflags = NPY_ARRAY_FARRAY;
         else
             oflags = NPY_ARRAY_CARRAY;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1571,6 +1571,30 @@ class TestClip(TestCase):
         assert_equal(d.clip(min=-2, max=np.nan), d)
         assert_equal(d.clip(min=np.nan, max=10), d)
 
+    def test_clip_with_out_order_c_to_f(self):
+        # Ensure that the clip() function takes an out with different order from input.
+        a = self._generate_data(self.nr, self.nc)
+        out = a.copy(order='F')
+        out2 = a.copy(order='F')
+        m = -0.5
+        M = 0.6
+        np.clip(a, m, M, out=out)
+        self.clip(a, m, M, out=out2)
+
+        assert_array_strict_equal(out, out2)
+
+    def test_clip_with_out_order_f_to_c(self):
+        # Ensure that the clip() function takes an out with different order from input.
+        a = self._generate_data(self.nr, self.nc).copy(order='F')
+        out = a.copy(order='C')
+        out2 = a.copy(order='C')
+        m = -0.5
+        M = 0.6
+        np.clip(a, m, M, out=out)
+        self.clip(a, m, M, out=out2)
+
+        assert_array_strict_equal(out, out2)
+
 
 class TestAllclose(object):
     rtol = 1e-5


### PR DESCRIPTION
Since fastclip doesn't allow for the in and out to have different orders, this fix forces the output to have the same order as the input.

Closes #7633

Alternatively, I could call the slow clip function in this case or change the in array to the proper order if needed. Would either of those methods be preferable?
