### PR TITLE
WIP: MAINT: Made clip into an ufunc

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -877,6 +877,12 @@ defdict = {
           TypeDescription('d', None, 'd', 'di'),
           TypeDescription('g', None, 'g', 'gi'),
           ],
+          ),
+'clip' :
+    Ufunc(3, 1, None,
+          docstrings.get('numpy.core.umath.clip'),
+          None,
+          TD(noobj),
           )
 }
 
@@ -910,6 +916,17 @@ chartotype2 = {'e': 'ee_e',
                'G': 'GG_G',
                'O': 'OO_O',
                'P': 'OO_O_method'}
+
+chartotype3 = {'e': 'eee_e',
+               'f': 'fff_f',
+               'd': 'ddd_d',
+               'g': 'ggg_g',
+               'F': 'FFF_F',
+               'D': 'DDD_D',
+               'G': 'GGG_G',
+               'O': 'OOO_O',
+               'P': 'OOO_O_method'}
+
 #for each name
 # 1) create functions, data, and signature
 # 2) fill in functions and data in InitOperators
@@ -930,9 +947,11 @@ def make_arrays(funcdict):
         k = 0
         sub = 0
 
-        if uf.nin > 1:
-            assert uf.nin == 2
-            thedict = chartotype2  # two inputs and one output
+        if uf.nin > 2:
+            assert uf.nin == 3
+            thedict = chartotype3  # three inputs and one output
+        elif uf.nin == 2:
+            thedict = chartotype2
         else:
             thedict = chartotype1  # one input and one output
 

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -881,7 +881,7 @@ defdict = {
 'clip' :
     Ufunc(3, 1, None,
           docstrings.get('numpy.core.umath.clip'),
-          None,
+          'PyUFunc_ClipTypeResolver',
           TD(noobj),
           )
 }

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3669,3 +3669,54 @@ add_newdoc('numpy.core.umath', 'ldexp',
     array([ 0.,  1.,  2.,  3.,  4.,  5.])
 
     """)
+
+add_newdoc('numpy.core.umath', 'clip',
+    """
+    Clip (limit) the values in an array.
+
+    Given an interval, values outside the interval are clipped to
+    the interval edges.  For example, if an interval of ``[0, 1]``
+    is specified, values smaller than 0 become 0, and values larger
+    than 1 become 1.
+
+    Parameters
+    ----------
+    a : array_like
+        Array containing elements to clip.
+    a_min : scalar or array_like
+        Minimum value.
+    a_max : scalar or array_like
+        Maximum value.  If `a_min` or `a_max` are array_like, then they will
+        be broadcasted to the shape of `a`.
+    out : ndarray, optional
+        The results will be placed in this array. It may be the input
+        array for in-place clipping.  `out` must be of the right shape
+        to hold the output.  Its type is preserved.
+
+    Returns
+    -------
+    clipped_array : ndarray
+        An array with the elements of `a`, but where values
+        < `a_min` are replaced with `a_min`, and those > `a_max`
+        with `a_max`.
+
+    See Also
+    --------
+    numpy.doc.ufuncs : Section "Output arguments"
+
+    Examples
+    --------
+    >>> a = np.arange(10)
+    >>> np.clip(a, 1, 8)
+    array([1, 1, 2, 3, 4, 5, 6, 7, 8, 8])
+    >>> a
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> np.clip(a, 3, 6, out=a)
+    array([3, 3, 3, 3, 4, 5, 6, 6, 6, 6])
+    >>> a = np.arange(10)
+    >>> a
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> np.clip(a, [3,4,1,1,1,4,4,4,4,4], 8)
+    array([3, 4, 2, 3, 4, 5, 6, 7, 8, 8])
+
+    """)

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3686,8 +3686,8 @@ add_newdoc('numpy.core.umath', 'clip',
     a_min : scalar or array_like
         Minimum value.
     a_max : scalar or array_like
-        Maximum value.  If `a_min` or `a_max` are array_like, then they will
-        be broadcasted to the shape of `a`.
+        Maximum value.  If `a_min` or `a_max` are array_like, then the
+        three arrays will be broadcasted to match their shapes.
     out : ndarray, optional
         The results will be placed in this array. It may be the input
         array for in-place clipping.  `out` must be of the right shape
@@ -3716,7 +3716,7 @@ add_newdoc('numpy.core.umath', 'clip',
     >>> a = np.arange(10)
     >>> a
     array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    >>> np.clip(a, [3,4,1,1,1,4,4,4,4,4], 8)
+    >>> np.clip(a, [3, 4, 1, 1, 1, 4, 4, 4, 4, 4], 8)
     array([3, 4, 2, 3, 4, 5, 6, 7, 8, 8])
 
     """)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -20,7 +20,7 @@ _dt_ = nt.sctype2char
 # functions that are methods
 __all__ = [
     'alen', 'all', 'alltrue', 'amax', 'amin', 'any', 'argmax',
-    'argmin', 'argpartition', 'argsort', 'around', 'choose', 'clip',
+    'argmin', 'argpartition', 'argsort', 'around', 'choose',
     'compress', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'mean',
     'ndim', 'nonzero', 'partition', 'prod', 'product', 'ptp', 'put',
     'rank', 'ravel', 'repeat', 'reshape', 'resize', 'round_',
@@ -1668,63 +1668,6 @@ def compress(condition, a, axis=None, out=None):
 
     """
     return _wrapfunc(a, 'compress', condition, axis=axis, out=out)
-
-
-def clip(a, a_min, a_max, out=None):
-    """
-    Clip (limit) the values in an array.
-
-    Given an interval, values outside the interval are clipped to
-    the interval edges.  For example, if an interval of ``[0, 1]``
-    is specified, values smaller than 0 become 0, and values larger
-    than 1 become 1.
-
-    Parameters
-    ----------
-    a : array_like
-        Array containing elements to clip.
-    a_min : scalar or array_like or `None`
-        Minimum value. If `None`, clipping is not performed on lower
-        interval edge. Not more than one of `a_min` and `a_max` may be
-        `None`.
-    a_max : scalar or array_like or `None`
-        Maximum value. If `None`, clipping is not performed on upper
-        interval edge. Not more than one of `a_min` and `a_max` may be
-        `None`. If `a_min` or `a_max` are array_like, then the three
-        arrays will be broadcasted to match their shapes.
-    out : ndarray, optional
-        The results will be placed in this array. It may be the input
-        array for in-place clipping.  `out` must be of the right shape
-        to hold the output.  Its type is preserved.
-
-    Returns
-    -------
-    clipped_array : ndarray
-        An array with the elements of `a`, but where values
-        < `a_min` are replaced with `a_min`, and those > `a_max`
-        with `a_max`.
-
-    See Also
-    --------
-    numpy.doc.ufuncs : Section "Output arguments"
-
-    Examples
-    --------
-    >>> a = np.arange(10)
-    >>> np.clip(a, 1, 8)
-    array([1, 1, 2, 3, 4, 5, 6, 7, 8, 8])
-    >>> a
-    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    >>> np.clip(a, 3, 6, out=a)
-    array([3, 3, 3, 3, 4, 5, 6, 6, 6, 6])
-    >>> a = np.arange(10)
-    >>> a
-    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    >>> np.clip(a, [3, 4, 1, 1, 1, 4, 4, 4, 4, 4], 8)
-    array([3, 4, 2, 3, 4, 5, 6, 7, 8, 8])
-
-    """
-    return _wrapfunc(a, 'clip', a_min, a_max, out=out)
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -891,6 +891,11 @@ _slow_array_clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObjec
 NPY_NO_EXPORT PyObject *
 PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *out)
 {
+    if (out == NULL) {
+        return PyObject_CallFunction(n_ops.clip, "OOO", self, min, max);
+    }
+    return PyObject_CallFunction(n_ops.clip, "OOOO", self, min, max, out);
+
     PyArray_FastClipFunc *func;
     int outgood = 0, ingood = 0;
     PyArrayObject *maxa = NULL;

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -115,6 +115,7 @@ PyArray_SetNumericOps(PyObject *dict)
     SET(minimum);
     SET(rint);
     SET(conjugate);
+    SET(clip);
     return 0;
 }
 
@@ -168,6 +169,7 @@ PyArray_GetNumericOps(void)
     GET(minimum);
     GET(rint);
     GET(conjugate);
+    GET(clip);
     return dict;
 
  fail:

--- a/numpy/core/src/multiarray/number.h
+++ b/numpy/core/src/multiarray/number.h
@@ -39,6 +39,7 @@ typedef struct {
     PyObject *minimum;
     PyObject *rint;
     PyObject *conjugate;
+    PyObject *clip;
 } NumericOps;
 
 extern NPY_NO_EXPORT NumericOps n_ops;

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -231,13 +231,6 @@
     npy_intp i;\
     for(i = 0; i < n; i++, ip1 += is1, ip2 += is2, op1 += os1, op2 += os2)
 
-#define TERNARY_LOOP\
-    char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *op1 = args[3];\
-    npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2], os1 = steps[3];\
-    npy_intp n = dimensions[0];\
-    npy_intp i;\
-    for(i = 0; i < n; i++, ip1 += is1, ip2 += is2, ip3 += is3, op1 += os1)
-
 /******************************************************************************
  **                          GENERIC FLOAT LOOPS                             **
  *****************************************************************************/
@@ -811,26 +804,6 @@ BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
     }
 }
 
-NPY_NO_EXPORT void
-BOOL_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    TERNARY_LOOP {
-        const npy_bool in = *((npy_bool *)ip1) != 0;
-        const npy_bool min = *((npy_bool *)ip2) != 0;
-        const npy_bool max = *((npy_bool *)ip3) != 0;
-
-        if (in < min) {
-            *((npy_bool *)op1) = min;
-        }
-        else if (in > max) {
-            *((npy_bool *)op1) = max;
-        }
-        else {
-            *((npy_bool *)op1) = in;
-        }
-    }
-}
-
 
 /*
  *****************************************************************************
@@ -1070,26 +1043,6 @@ NPY_NO_EXPORT void
             *((@type@ *)op1)= in1 % in2;
         }
 
-    }
-}
-
-NPY_NO_EXPORT void
-@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    TERNARY_LOOP {
-        const @type@ in = *((@type@ *)ip1);
-        const @type@ min = *((@type@ *)ip2);
-        const @type@ max = *((@type@ *)ip3);
-
-        if (in < min) {
-            *((@type@ *)op1) = min;
-        }
-        else if (in > max) {
-            *((@type@ *)op1) = max;
-        }
-        else {
-            *((@type@ *)op1) = in;
-        }
     }
 }
 
@@ -1412,27 +1365,6 @@ NPY_NO_EXPORT void
     }
 }
 /**end repeat1**/
-
-
-NPY_NO_EXPORT void
-@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    TERNARY_LOOP {
-        const @type@ in = *((@type@ *)ip1);
-        const @type@ min = *((@type@ *)ip2);
-        const @type@ max = *((@type@ *)ip3);
-
-        if (in < min) {
-            *((@type@ *)op1) = min;
-        }
-        else if (in > max) {
-            *((@type@ *)op1) = max;
-        }
-        else {
-            *((@type@ *)op1) = in;
-        }
-    }
-}
 
 /**end repeat**/
 
@@ -2110,26 +2042,6 @@ NPY_NO_EXPORT void
     }
 }
 
-NPY_NO_EXPORT void
-@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    TERNARY_LOOP {
-        const @type@ in = *((@type@ *)ip1);
-        const @type@ min = *((@type@ *)ip2);
-        const @type@ max = *((@type@ *)ip3);
-
-        if (in < min) {
-            *((@type@ *)op1) = min;
-        }
-        else if (in > max) {
-            *((@type@ *)op1) = max;
-        }
-        else {
-            *((@type@ *)op1) = in;
-        }
-    }
-}
-
 #define @TYPE@_true_divide @TYPE@_divide
 
 /**end repeat**/
@@ -2453,26 +2365,6 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
             else {
                 *((npy_half *)op1) = npy_float_to_half(npy_ldexpf(in1, NPY_MIN_INT));
             }
-        }
-    }
-}
-
-NPY_NO_EXPORT void
-HALF_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    TERNARY_LOOP {
-        const npy_half in = *((npy_half *)ip1);
-        const npy_half min = *((npy_half *)ip2);
-        const npy_half max = *((npy_half *)ip3);
-
-        if (npy_half_lt(in, min)) {
-            *((npy_half *)op1) = min;
-        }
-        else if (npy_half_gt(in, max)) {
-            *((npy_half *)op1) = max;
-        }
-        else {
-            *((npy_half *)op1) = in;
         }
     }
 }
@@ -2884,32 +2776,6 @@ NPY_NO_EXPORT void
 }
 /**end repeat1**/
 
-NPY_NO_EXPORT void
-@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    TERNARY_LOOP {
-        const @ftype@ inr = ((@ftype@ *)ip1)[0];
-        const @ftype@ ini = ((@ftype@ *)ip1)[1];
-        const @ftype@ minr = ((@ftype@ *)ip2)[0];
-        const @ftype@ mini = ((@ftype@ *)ip2)[1];
-        const @ftype@ maxr = ((@ftype@ *)ip3)[0];
-        const @ftype@ maxi = ((@ftype@ *)ip3)[1];
-
-        if (CLT(inr, ini, minr, mini)) {
-            ((@ftype@ *)op1)[0] = minr;
-            ((@ftype@ *)op1)[1] = mini;
-        }
-        else if (CGT(inr, ini, maxr, maxi)) {
-            ((@ftype@ *)op1)[0] = maxr;
-            ((@ftype@ *)op1)[1] = maxi;
-        }
-        else {
-            ((@ftype@ *)op1)[0] = inr;
-            ((@ftype@ *)op1)[1] = ini;
-        }
-    }
-}
-
 #define @TYPE@_true_divide @TYPE@_divide
 
 /**end repeat**/
@@ -3008,3 +2874,131 @@ OBJECT_sign(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
  **                              END LOOPS                                  **
  *****************************************************************************
  */
+
+
+
+/*
+ *****************************************************************************
+ **                              CLIP LOOPS                                 **
+ *****************************************************************************
+ */
+
+
+
+#define TERNARY_LOOP\
+    char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *op1 = args[3];\
+    npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2], os1 = steps[3];\
+    npy_intp n = dimensions[0];\
+    npy_intp i;\
+    for(i = 0; i < n; i++, ip1 += is1, ip2 += is2, ip3 += is3, op1 += os1)
+
+#define _LESS_THAN(a, b) ((a) < (b))
+#define _GREATER_THAN(a, b) ((a) > (b))
+
+/*
+ * In fastclip, 'b' was already checked for NaN, so the half comparison
+ * only needs to check 'a' for NaN.
+ */
+
+#define _HALF_LESS_THAN(a, b) (!npy_half_isnan(a) && npy_half_lt_nonan(a, b))
+#define _HALF_GREATER_THAN(a, b) (!npy_half_isnan(a) && npy_half_lt_nonan(b, a))
+
+/**begin repeat
+ *
+ * #TYPE = BOOL,
+ *         BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *         DATETIME, TIMEDELTA#
+ * #type = npy_bool,
+ *         npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
+ *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
+ *         npy_half, npy_float, npy_double, npy_longdouble,
+ *         npy_datetime, npy_timedelta#
+ * #isfloat = 0*11, 1*4, 0*2#
+ * #isnan = nop*11, npy_half_isnan, npy_isnan*3, nop*2#
+ * #lt = _LESS_THAN*11, _HALF_LESS_THAN, _LESS_THAN*5#
+ * #gt = _GREATER_THAN*11, _HALF_GREATER_THAN, _GREATER_THAN*5#
+ */
+
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const @type@ in = *((@type@ *)ip1);
+        const @type@ min = *((@type@ *)ip2);
+        const @type@ max = *((@type@ *)ip3);
+        if (@lt@(in, min)) {
+            *((@type@ *)op1) = min;
+        }
+        else if (@gt@(in, max)) {
+            *((@type@ *)op1) = max;
+        }
+        else {
+            *((@type@ *)op1) = in;
+        }        
+    }
+}
+
+/**end repeat**/
+
+#undef _LESS_THAN
+#undef _GREATER_THAN
+#undef _HALF_LESS_THAN
+#undef _HALF_GREATER_THAN
+
+
+#define CGE(xr,xi,yr,yi) ((xr > yr && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && xi >= yi))
+#define CLE(xr,xi,yr,yi) ((xr < yr && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && xi <= yi))
+#define CGT(xr,xi,yr,yi) ((xr > yr && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && xi > yi))
+#define CLT(xr,xi,yr,yi) ((xr < yr && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && xi < yi))
+#define CEQ(xr,xi,yr,yi) (xr == yr && xi == yi)
+#define CNE(xr,xi,yr,yi) (xr != yr || xi != yi)
+
+
+/**begin repeat
+ * complex types
+ * #TYPE = CFLOAT, CDOUBLE, CLONGDOUBLE#
+ * #ftype = npy_float, npy_double, npy_longdouble#
+ * #c = f, , l#
+ * #C = F, , L#
+ */
+
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const @ftype@ inr = ((@ftype@ *)ip1)[0];
+        const @ftype@ ini = ((@ftype@ *)ip1)[1];
+        const @ftype@ minr = ((@ftype@ *)ip2)[0];
+        const @ftype@ mini = ((@ftype@ *)ip2)[1];
+        const @ftype@ maxr = ((@ftype@ *)ip3)[0];
+        const @ftype@ maxi = ((@ftype@ *)ip3)[1];
+
+        if (CLT(inr, ini, minr, mini)) {
+            ((@ftype@ *)op1)[0] = minr;
+            ((@ftype@ *)op1)[1] = mini;
+        }
+        else if (CGT(inr, ini, maxr, maxi)) {
+            ((@ftype@ *)op1)[0] = maxr;
+            ((@ftype@ *)op1)[1] = maxi;
+        }
+        else {
+            ((@ftype@ *)op1)[0] = inr;
+            ((@ftype@ *)op1)[1] = ini;
+        }
+    }
+}
+
+
+/**end repeat**/
+#undef CGE
+#undef CLE
+#undef CGT
+#undef CLT
+#undef CEQ
+#undef CNE

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -231,6 +231,13 @@
     npy_intp i;\
     for(i = 0; i < n; i++, ip1 += is1, ip2 += is2, op1 += os1, op2 += os2)
 
+#define TERNARY_LOOP\
+    char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *op1 = args[3];\
+    npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2], os1 = steps[3];\
+    npy_intp n = dimensions[0];\
+    npy_intp i;\
+    for(i = 0; i < n; i++, ip1 += is1, ip2 += is2, ip3 += is3, op1 += os1)
+
 /******************************************************************************
  **                          GENERIC FLOAT LOOPS                             **
  *****************************************************************************/
@@ -804,6 +811,26 @@ BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
     }
 }
 
+NPY_NO_EXPORT void
+BOOL_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const npy_bool in = *((npy_bool *)ip1) != 0;
+        const npy_bool min = *((npy_bool *)ip2) != 0;
+        const npy_bool max = *((npy_bool *)ip3) != 0;
+
+        if (in < min) {
+            *((npy_bool *)op1) = min;
+        }
+        else if (in > max) {
+            *((npy_bool *)op1) = max;
+        }
+        else {
+            *((npy_bool *)op1) = in;
+        }
+    }
+}
+
 
 /*
  *****************************************************************************
@@ -1043,6 +1070,26 @@ NPY_NO_EXPORT void
             *((@type@ *)op1)= in1 % in2;
         }
 
+    }
+}
+
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const @type@ in = *((@type@ *)ip1);
+        const @type@ min = *((@type@ *)ip2);
+        const @type@ max = *((@type@ *)ip3);
+
+        if (in < min) {
+            *((@type@ *)op1) = min;
+        }
+        else if (in > max) {
+            *((@type@ *)op1) = max;
+        }
+        else {
+            *((@type@ *)op1) = in;
+        }
     }
 }
 
@@ -1365,6 +1412,27 @@ NPY_NO_EXPORT void
     }
 }
 /**end repeat1**/
+
+
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const @type@ in = *((@type@ *)ip1);
+        const @type@ min = *((@type@ *)ip2);
+        const @type@ max = *((@type@ *)ip3);
+
+        if (in < min) {
+            *((@type@ *)op1) = min;
+        }
+        else if (in > max) {
+            *((@type@ *)op1) = max;
+        }
+        else {
+            *((@type@ *)op1) = in;
+        }
+    }
+}
 
 /**end repeat**/
 
@@ -2042,6 +2110,26 @@ NPY_NO_EXPORT void
     }
 }
 
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const @type@ in = *((@type@ *)ip1);
+        const @type@ min = *((@type@ *)ip2);
+        const @type@ max = *((@type@ *)ip3);
+
+        if (in < min) {
+            *((@type@ *)op1) = min;
+        }
+        else if (in > max) {
+            *((@type@ *)op1) = max;
+        }
+        else {
+            *((@type@ *)op1) = in;
+        }
+    }
+}
+
 #define @TYPE@_true_divide @TYPE@_divide
 
 /**end repeat**/
@@ -2365,6 +2453,26 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
             else {
                 *((npy_half *)op1) = npy_float_to_half(npy_ldexpf(in1, NPY_MIN_INT));
             }
+        }
+    }
+}
+
+NPY_NO_EXPORT void
+HALF_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const npy_half in = *((npy_half *)ip1);
+        const npy_half min = *((npy_half *)ip2);
+        const npy_half max = *((npy_half *)ip3);
+
+        if (npy_half_lt(in, min)) {
+            *((npy_half *)op1) = min;
+        }
+        else if (npy_half_gt(in, max)) {
+            *((npy_half *)op1) = max;
+        }
+        else {
+            *((npy_half *)op1) = in;
         }
     }
 }
@@ -2775,6 +2883,32 @@ NPY_NO_EXPORT void
     }
 }
 /**end repeat1**/
+
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    TERNARY_LOOP {
+        const @ftype@ inr = ((@ftype@ *)ip1)[0];
+        const @ftype@ ini = ((@ftype@ *)ip1)[1];
+        const @ftype@ minr = ((@ftype@ *)ip2)[0];
+        const @ftype@ mini = ((@ftype@ *)ip2)[1];
+        const @ftype@ maxr = ((@ftype@ *)ip3)[0];
+        const @ftype@ maxi = ((@ftype@ *)ip3)[1];
+
+        if (CLT(inr, ini, minr, mini)) {
+            ((@ftype@ *)op1)[0] = minr;
+            ((@ftype@ *)op1)[1] = mini;
+        }
+        else if (CGT(inr, ini, maxr, maxi)) {
+            ((@ftype@ *)op1)[0] = maxr;
+            ((@ftype@ *)op1)[1] = maxi;
+        }
+        else {
+            ((@ftype@ *)op1)[0] = inr;
+            ((@ftype@ *)op1)[1] = ini;
+        }
+    }
+}
 
 #define @TYPE@_true_divide @TYPE@_divide
 

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -144,7 +144,7 @@ NPY_NO_EXPORT void
 @S@@TYPE@_divmod(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
-U@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+@S@@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 /**end repeat1**/
 

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -29,7 +29,7 @@
 
 /**begin repeat
  * #kind = equal, not_equal, greater, greater_equal, less, less_equal,
- *         logical_and, logical_or, absolute, logical_not#
+ *         logical_and, logical_or, absolute, logical_not, clip#
  **/
 NPY_NO_EXPORT void
 BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
@@ -142,6 +142,9 @@ NPY_NO_EXPORT void
 
 NPY_NO_EXPORT void
 @S@@TYPE@_divmod(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
+U@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 /**end repeat1**/
 
@@ -262,6 +265,9 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
 #define @TYPE@_true_divide @TYPE@_divide
 
 /**end repeat**/
@@ -374,6 +380,10 @@ NPY_NO_EXPORT void
 C@TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 /**end repeat1**/
 
+
+NPY_NO_EXPORT void
+C@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
 #define C@TYPE@_true_divide C@TYPE@_divide
 
 /**end repeat**/
@@ -429,6 +439,8 @@ NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 /**end repeat1**/
 
+NPY_NO_EXPORT void
+@TYPE@_clip(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 /**end repeat**/
 
 NPY_NO_EXPORT void

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -37,6 +37,13 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
                                           PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
+PyUFunc_SimpleTernaryOperationTypeResolver(PyUFuncObject *ufunc,
+                                NPY_CASTING casting,
+                                PyArrayObject **operands,
+                                PyObject *type_tup,
+                                PyArray_Descr **out_dtypes);
+
+NPY_NO_EXPORT int
 PyUFunc_AbsoluteTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
                              PyArrayObject **operands,
@@ -84,6 +91,13 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
                              PyArrayObject **operands,
                              PyObject *type_tup,
                              PyArray_Descr **out_dtypes);
+
+NPY_NO_EXPORT int
+PyUFunc_ClipTypeResolver(PyUFuncObject *ufunc,
+                                NPY_CASTING casting,
+                                PyArrayObject **operands,
+                                PyObject *type_tup,
+                                PyArray_Descr **out_dtypes);
 
 /*
  * Does a linear search for the best inner loop of the ufunc.

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1695,11 +1695,17 @@ class TestClip(TestCase):
 
     def test_clip_nan(self):
         d = np.arange(7.)
-        assert_equal(d.clip(min=np.nan), d)
-        assert_equal(d.clip(max=np.nan), d)
-        assert_equal(d.clip(min=np.nan, max=np.nan), d)
-        assert_equal(d.clip(min=-2, max=np.nan), d)
-        assert_equal(d.clip(min=np.nan, max=10), d)
+        assert_array_equal(d.clip(min=np.nan), d)
+        assert_array_equal(d.clip(max=np.nan), d)
+        assert_array_equal(d.clip(min=np.nan, max=np.nan), d)
+        assert_array_equal(d.clip(min=-2, max=np.nan), d)
+        assert_array_equal(d.clip(min=np.nan, max=10), d)
+
+    def test_clip_nan2(self):
+        a = np.array([np.NaN])
+        assert_array_equal(a.clip(min=2), a)
+        assert_array_equal(a.clip(max=2), a)
+        assert_array_equal(a.clip(min=2, max=2), a)
 
     def test_clip_with_out_order_c_to_f(self):
         # Ensure that the clip() function takes an out with different order from input.

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1701,6 +1701,32 @@ class TestClip(TestCase):
         assert_equal(d.clip(min=-2, max=np.nan), d)
         assert_equal(d.clip(min=np.nan, max=10), d)
 
+    def test_clip_with_out_order_c_to_f(self):
+        # Ensure that the clip() function takes an out with different order from input.
+        a = self._generate_data(self.nr, self.nc)
+        out = a.copy(order='F')
+        out2 = a.copy(order='F')
+        m = -0.5
+        M = 0.6
+        self.fastclip(a, m, M, out=out)
+        self.clip(a, m, M, out=out2)
+
+        assert_array_strict_equal(out, out2)
+        self.assertTrue(np.isfortran(out))
+
+    def test_clip_with_out_order_f_to_c(self):
+        # Ensure that the clip() function takes an out with different order from input.
+        a = self._generate_data(self.nr, self.nc).copy(order='F')
+        out = a.copy(order='C')
+        out2 = a.copy(order='C')
+        m = -0.5
+        M = 0.6
+        self.fastclip(a, m, M, out=out)
+        self.clip(a, m, M, out=out2)
+
+        assert_array_strict_equal(out, out2)
+        self.assertFalse(np.isfortran(out))
+
 
 class TestAllclose(object):
     rtol = 1e-5


### PR DESCRIPTION
In order to solve issue #7633, it was suggested at #7873 to make clip into an ufunc.
This is an partial implementation of that. Left to do:
- Implement proper typecasting
- Properly handle None and NaN
- Add a faster loop to loops.c.src to speed up if min or max are not arrays
- Update the docs
- Create benchmarks and test the new implementation's performance
- Remove remnants of the old implementation from
  - `numeric.py`
  - `fromnumeric.py`
  - `numpy_api.py`
  - `multiarray_api.*`
  - `arraytypes.*.src`
  - `calculation.*`

But before I continue, I'd like to ask the following:
- Am I on the right track?
- How do I implement proper type casting? Now for example `test_clip_with_out_array_int32` fails with message `TypeError: ufunc 'clip' output (typecode 'd') could not be coerced to provided output parameter (typecode 'i') according to the casting rule ''same_kind''` because not all the arguments are of the same type.
- In `arraytypes.c` `fastclip` is written down very concisely by doing almost all types at once. In  `loops.c.src`, however, all definitions are split into the main categories (ints, floats, etc.). So far, I've followed that expanded approach, but the concise version seems nicer. Is it acceptable to add the concise combined version to the bottom of `loops.c.src` instead?
