### PR TITLE
ENH: Option to return covariance matrix of fitted coeffecients for polynomial fitters

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -723,7 +723,7 @@ class ABCPolyBase(object):
 
     @classmethod
     def fit(cls, x, y, deg, domain=None, rcond=None, full=False, w=None,
-        window=None):
+        window=None, cov=False):
         """Least squares fit to data.
 
         Return a series instance that is the least squares fit to the data
@@ -775,6 +775,11 @@ class ABCPolyBase(object):
 
             .. versionadded:: 1.6.0
 
+        cov : bool, optional
+        Return the estimate and the covariance matrix of the estimate
+        If full is True, then cov is not returned.
+
+
         Returns
         -------
         new_series : series
@@ -788,6 +793,13 @@ class ABCPolyBase(object):
             rank -- the numerical rank of the scaled Vandermonde matrix
             sv -- singular values of the scaled Vandermonde matrix
             rcond -- value of `rcond`.
+
+        V : ndarray, shape (M,M) or (M,M,K)
+            Present only if `full` = False and `cov`=True.  The covariance
+            matrix of the polynomial coefficient estimates.  The diagonal of
+            this matrix are the variance estimates for each coefficient.  If y
+            is a 2-D array, then the covariance matrix for the `k`-th data set
+            are in ``V[:,:,k]``
 
             For more details, see `linalg.lstsq`.
 
@@ -805,6 +817,9 @@ class ABCPolyBase(object):
         if full:
             [coef, status] = res
             return cls(coef, domain=domain, window=window), status
+        elif cov:
+            [coef, V] = res
+            return cls(coef, domain=domain, window=window), V
         else:
             coef = res
             return cls(coef, domain=domain, window=window)

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1594,7 +1594,7 @@ def chebvander3d(x, y, z, deg):
     return v.reshape(v.shape[:-3] + (-1,))
 
 
-def chebfit(x, y, deg, rcond=None, full=False, w=None):
+def chebfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least squares fit of Chebyshev series to data.
 
@@ -1636,6 +1636,9 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
         ``(x[i],y[i])`` to the fit is weighted by `w[i]`. Ideally the
         weights are chosen so that the errors of the products ``w[i]*y[i]``
         all have the same variance.  The default value is None.
+    cov : bool, optional
+        Return the estimate and the covariance matrix of the estimate
+        If full is True, then cov is not returned.
 
         .. versionadded:: 1.5.0
 
@@ -1653,6 +1656,13 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
         rank -- the numerical rank of the scaled Vandermonde matrix
         sv -- singular values of the scaled Vandermonde matrix
         rcond -- value of `rcond`.
+
+    V : ndarray, shape (M,M) or (M,M,K)
+        Present only if `full` = False and `cov`=True.  The covariance
+        matrix of the polynomial coefficient estimates.  The diagonal of
+        this matrix are the variance estimates for each coefficient.  If y
+        is a 2-D array, then the covariance matrix for the `k`-th data set
+        are in ``V[:,:,k]``
 
         For more details, see `linalg.lstsq`.
 
@@ -1786,6 +1796,19 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
 
     if full:
         return c, [resids, rank, s, rcond]
+    elif cov:
+        lhs = lhs.T / scl
+        Vbase = la.inv(np.dot(lhs.T, lhs))
+        Vbase /= np.outer(scl, scl)
+        # Some literature ignores the extra -2.0 factor in the denominator, but
+        #  it is included here because the covariance of Multivariate Student-T
+        #  (which is implied by a Bayesian uncertainty analysis) includes it.
+        #  Plus, it gives a slightly more conservative estimate of uncertainty.
+        fac = resids / (len(x) - order - 2.0)
+        if y.ndim == 1:
+            return c, Vbase * fac
+        else:
+            return c, Vbase[:, :, np.newaxis] * fac
     else:
         return c
 

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1365,7 +1365,7 @@ def hermvander3d(x, y, z, deg):
     return v.reshape(v.shape[:-3] + (-1,))
 
 
-def hermfit(x, y, deg, rcond=None, full=False, w=None):
+def hermfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least squares fit of Hermite series to data.
 
@@ -1407,6 +1407,9 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
         ``(x[i],y[i])`` to the fit is weighted by `w[i]`. Ideally the
         weights are chosen so that the errors of the products ``w[i]*y[i]``
         all have the same variance.  The default value is None.
+    cov : bool, optional
+        Return the estimate and the covariance matrix of the estimate
+        If full is True, then cov is not returned.
 
     Returns
     -------
@@ -1422,6 +1425,13 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
         rank -- the numerical rank of the scaled Vandermonde matrix
         sv -- singular values of the scaled Vandermonde matrix
         rcond -- value of `rcond`.
+
+    V : ndarray, shape (M,M) or (M,M,K)
+        Present only if `full` = False and `cov`=True.  The covariance
+        matrix of the polynomial coefficient estimates.  The diagonal of
+        this matrix are the variance estimates for each coefficient.  If y
+        is a 2-D array, then the covariance matrix for the `k`-th data set
+        are in ``V[:,:,k]``
 
         For more details, see `linalg.lstsq`.
 
@@ -1562,6 +1572,19 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
 
     if full:
         return c, [resids, rank, s, rcond]
+    elif cov:
+        lhs = lhs.T / scl
+        Vbase = la.inv(np.dot(lhs.T, lhs))
+        Vbase /= np.outer(scl, scl)
+        # Some literature ignores the extra -2.0 factor in the denominator, but
+        #  it is included here because the covariance of Multivariate Student-T
+        #  (which is implied by a Bayesian uncertainty analysis) includes it.
+        #  Plus, it gives a slightly more conservative estimate of uncertainty.
+        fac = resids / (len(x) - order - 2.0)
+        if y.ndim == 1:
+            return c, Vbase * fac
+        else:
+            return c, Vbase[:, :, np.newaxis] * fac
     else:
         return c
 

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1364,7 +1364,7 @@ def lagvander3d(x, y, z, deg):
     return v.reshape(v.shape[:-3] + (-1,))
 
 
-def lagfit(x, y, deg, rcond=None, full=False, w=None):
+def lagfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least squares fit of Laguerre series to data.
 
@@ -1406,6 +1406,9 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
         ``(x[i],y[i])`` to the fit is weighted by `w[i]`. Ideally the
         weights are chosen so that the errors of the products ``w[i]*y[i]``
         all have the same variance.  The default value is None.
+    cov : bool, optional
+        Return the estimate and the covariance matrix of the estimate
+        If full is True, then cov is not returned.
 
     Returns
     -------
@@ -1421,6 +1424,13 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
         rank -- the numerical rank of the scaled Vandermonde matrix
         sv -- singular values of the scaled Vandermonde matrix
         rcond -- value of `rcond`.
+
+    V : ndarray, shape (M,M) or (M,M,K)
+        Present only if `full` = False and `cov`=True.  The covariance
+        matrix of the polynomial coefficient estimates.  The diagonal of
+        this matrix are the variance estimates for each coefficient.  If y
+        is a 2-D array, then the covariance matrix for the `k`-th data set
+        are in ``V[:,:,k]``
 
         For more details, see `linalg.lstsq`.
 
@@ -1561,6 +1571,19 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
 
     if full:
         return c, [resids, rank, s, rcond]
+    elif cov:
+        lhs = lhs.T / scl
+        Vbase = la.inv(np.dot(lhs.T, lhs))
+        Vbase /= np.outer(scl, scl)
+        # Some literature ignores the extra -2.0 factor in the denominator, but
+        #  it is included here because the covariance of Multivariate Student-T
+        #  (which is implied by a Bayesian uncertainty analysis) includes it.
+        #  Plus, it gives a slightly more conservative estimate of uncertainty.
+        fac = resids / (len(x) - order - 2.0)
+        if y.ndim == 1:
+            return c, Vbase * fac
+        else:
+            return c, Vbase[:, :, np.newaxis] * fac
     else:
         return c
 

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1282,7 +1282,7 @@ def polyvander3d(x, y, z, deg):
     return v.reshape(v.shape[:-3] + (-1,))
 
 
-def polyfit(x, y, deg, rcond=None, full=False, w=None):
+def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least-squares fit of a polynomial to data.
 
@@ -1327,6 +1327,9 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
         ``(x[i],y[i])`` to the fit is weighted by `w[i]`. Ideally the
         weights are chosen so that the errors of the products ``w[i]*y[i]``
         all have the same variance.  The default value is None.
+    cov : bool, optional
+        Return the estimate and the covariance matrix of the estimate
+        If full is True, then cov is not returned.
 
         .. versionadded:: 1.5.0
 
@@ -1344,6 +1347,13 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
         rank -- the numerical rank of the scaled Vandermonde matrix
         sv -- singular values of the scaled Vandermonde matrix
         rcond -- value of `rcond`.
+
+    V : ndarray, shape (M,M) or (M,M,K)
+        Present only if `full` = False and `cov`=True.  The covariance
+        matrix of the polynomial coefficient estimates.  The diagonal of
+        this matrix are the variance estimates for each coefficient.  If y
+        is a 2-D array, then the covariance matrix for the `k`-th data set
+        are in ``V[:,:,k]``
 
         For more details, see `linalg.lstsq`.
 
@@ -1497,6 +1507,19 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
 
     if full:
         return c, [resids, rank, s, rcond]
+    elif cov:
+        lhs = lhs.T / scl
+        Vbase = la.inv(np.dot(lhs.T, lhs))
+        Vbase /= np.outer(scl, scl)
+        # Some literature ignores the extra -2.0 factor in the denominator, but
+        #  it is included here because the covariance of Multivariate Student-T
+        #  (which is implied by a Bayesian uncertainty analysis) includes it.
+        #  Plus, it gives a slightly more conservative estimate of uncertainty.
+        fac = resids / (len(x) - order - 2.0)
+        if y.ndim == 1:
+            return c, Vbase * fac
+        else:
+            return c, Vbase[:, :, np.newaxis] * fac
     else:
         return c
 

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -469,6 +469,20 @@ class TestFitting(TestCase):
         assert_almost_equal(cheb.chebval(x, coef2), y)
         assert_almost_equal(coef1, coef2)
 
+        # Test covariance matrix
+        # 1d
+        x = np.linspace(0, 2, 6)
+        y = f(x)
+        _, V = cheb.chebfit(x, y, 2, cov=True)
+        cov = np.array([[0.4356, -0.6687, 0.1435],
+                        [-0.6687, 1.2057, -0.2777],
+                        [0.1435, -0.2777, 0.0694]])
+        assert_almost_equal(V, cov, decimal=4)
+
+        # 2d
+        _, V = cheb.chebfit(x, np.array([y, y]).T, 2, cov=True)
+        assert_almost_equal(V[:, :, 1], cov, decimal=4)
+
 
 class TestCompanion(TestCase):
 

--- a/numpy/polynomial/tests/test_hermite.py
+++ b/numpy/polynomial/tests/test_hermite.py
@@ -457,6 +457,20 @@ class TestFitting(TestCase):
         assert_almost_equal(herm.hermval(x, coef2), y)
         assert_almost_equal(coef1, coef2)
 
+        # Test covariance matrix
+        # 1d
+        x = np.linspace(0, 2, 6)
+        y = f(x)
+        _, V = herm.hermfit(x, y, 2, cov=True)
+        cov = np.array([[0.4356, -0.3344, 0.0717],
+                        [-0.3344, 0.3014, -0.0694],
+                        [0.0717, -0.0694, 0.0174]])
+        assert_almost_equal(V, cov, decimal=4)
+
+        # 2d
+        _, V = herm.hermfit(x, np.array([y, y]).T, 2, cov=True)
+        assert_almost_equal(V[:, :, 1], cov, decimal=4)
+
 
 class TestCompanion(TestCase):
 

--- a/numpy/polynomial/tests/test_hermite_e.py
+++ b/numpy/polynomial/tests/test_hermite_e.py
@@ -458,6 +458,20 @@ class TestFitting(TestCase):
         assert_almost_equal(herme.hermeval(x, coef2), y)
         assert_almost_equal(coef1, coef2)
 
+        # Test covariance matrix
+        # 1d
+        x = np.linspace(0, 2, 6)
+        y = f(x)
+        _, V = herme.hermefit(x, y, 2, cov=True)
+        cov = np.array([[0.792, -0.9465, 0.4258],
+                        [-0.9465, 1.2057, -0.5554],
+                        [0.4258, -0.5554, 0.2777]])
+        assert_almost_equal(V, cov, decimal=4)
+
+        # 2d
+        _, V = herme.hermefit(x, np.array([y, y]).T, 2, cov=True)
+        assert_almost_equal(V[:, :, 1], cov, decimal=4)
+
 
 class TestCompanion(TestCase):
 

--- a/numpy/polynomial/tests/test_laguerre.py
+++ b/numpy/polynomial/tests/test_laguerre.py
@@ -439,6 +439,20 @@ class TestFitting(TestCase):
         assert_almost_equal(lag.lagfit(x, x, 1), [1, -1])
         assert_almost_equal(lag.lagfit(x, x, [0, 1]), [1, -1])
 
+        # Test covariance matrix
+        # 1d
+        x = np.linspace(0, 2, 6)
+        y = f(x)
+        _, V = lag.lagfit(x, y, 2, cov=True)
+        cov = np.array([[0.1232, -0.2962, 0.2962],
+                        [-0.2962, 1.2057, -1.1109],
+                        [0.2962, -1.1109, 1.1109]])
+        assert_almost_equal(V, cov, decimal=4)
+
+        # 2d
+        _, V = lag.lagfit(x, np.array([y, y]).T, 2, cov=True)
+        assert_almost_equal(V[:, :, 1], cov, decimal=4)
+
 
 class TestCompanion(TestCase):
 

--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -458,6 +458,19 @@ class TestFitting(TestCase):
         assert_almost_equal(leg.legval(x, coef2), y)
         assert_almost_equal(coef1, coef2)
 
+        # Test covariance matrix
+        # 1d
+        x = np.linspace(0, 2, 6)
+        y = f(x)
+        _, V = leg.legfit(x, y, 2, cov=True)
+        cov = np.array([[0.3476, -0.5762, 0.1605],
+                        [-0.5762, 1.2057, -0.3703],
+                        [0.1605, -0.3703, 0.1234]])
+        assert_almost_equal(V, cov, decimal=4)
+
+        # 2d
+        _, V = leg.legfit(x, np.array([y, y]).T, 2, cov=True)
+        assert_almost_equal(V[:, :, 1], cov, decimal=4)
 
 class TestCompanion(TestCase):
 

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -549,6 +549,22 @@ class TestMisc(TestCase):
         assert_almost_equal(poly.polyval(x, coef2), y)
         assert_almost_equal(coef1, coef2)
 
+        # Test covariance matrix
+        # 1d
+        x = np.linspace(0, 2, 7)
+        c = np.array([1., 2., 3.])
+        err = [1, -1, 1, -1, 1, -1, 1]
+        y = poly.polyval(x, c)
+        _, V = poly.polyfit(x, y + err, 2, cov=True)
+        cov = [[2.322, -4.2449, 1.6327],
+               [-4.2449, 12.7347, -5.8776],
+               [1.6327, -5.8776, 2.9388]]
+        assert_almost_equal(V, cov, decimal=4)
+
+        # 2d
+        _, V = poly.polyfit(x, np.array([y, y]).T + np.array(err)[:, np.newaxis], 2, cov=True)
+        assert_almost_equal(cov, V[:, :, 1], decimal=4)
+
     def test_polytrim(self):
         coef = [2, -1, 1, 0]
 


### PR DESCRIPTION
This is for fitters in the polynomial module.

Implementation is the same as numpy.polyfit.

See issue #7780. Was sent round the mailing list last week - no complaints.
