### PR TITLE
Handle g95 on NetBSD

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -715,7 +715,7 @@ _default_compilers = (
     ('irix.*', ('mips', 'gnu', 'gnu95',)),
     ('aix.*', ('ibm', 'gnu', 'gnu95',)),
     # os.name mappings
-    ('posix', ('gnu', 'gnu95',)),
+    ('posix', ('gnu', 'gnu95', 'g95',)),
     ('nt', ('gnu', 'gnu95',)),
     ('mac', ('gnu95', 'gnu', 'pg')),
     )

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -57,7 +57,7 @@ class GnuFCompiler(FCompiler):
                     return ('gfortran', m.group(1))
         else:
             # Output probably from --version, try harder:
-            m = re.search(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
+            m = re.search(r'95.*?([0-9-.]+)', version_string)
             if m:
                 return ('gfortran', m.group(1))
             m = re.search(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)


### PR DESCRIPTION
$ uname -rms
NetBSD 7.99.33 amd64

$ g95 --version
G95 (GCC 4.1.2 (g95 0.93!) Jul 24 2016)
Copyright (C) 2002-2008 Free Software Foundation, Inc.

G95 comes with NO WARRANTY, to the extent permitted by law.
You may redistribute copies of G95
under the terms of the GNU General Public License.
For more information about these matters, see the file named COPYING
