### PR TITLE
ENH: #7845. histogram2d and histogramdd can return int array when relevant

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -878,10 +878,15 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
         N, D = sample.shape
 
     nbin = empty(D, int)
+    ntype = np.dtype(np.intp)
     edges = D*[None]
     dedges = D*[None]
     if weights is not None:
+        ntype = weights.dtype
         weights = asarray(weights)
+
+    if normed:
+        ntype = np.dtype(np.float64)
 
     try:
         M = len(bins)
@@ -970,7 +975,7 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
     # Flattened histogram matrix (1D)
     # Reshape is used so that overlarge arrays
     # will raise an error.
-    hist = zeros(nbin, float).reshape(-1)
+    hist = zeros(nbin, ntype).reshape(-1)
 
     # Compute the sample indices in the flattened histogram matrix.
     ni = nbin.argsort()

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1761,6 +1761,16 @@ class TestHistogramdd(TestCase):
         assert_raises(ValueError, histogramdd, vals,
                       range=[[0.0, 1.0], [np.nan, 0.75], [0.25, 0.5]])
 
+    def test_type(self):
+        vals = np.random.random((10, 3))
+        w = np.ones(10, float)
+        assert_(np.issubdtype(np.histogramdd(vals)[0].dtype, int))
+        assert_(np.issubdtype(np.histogramdd(vals, weights=w)[0].dtype, float))
+        w = np.ones(10, int)
+        assert_(np.issubdtype(np.histogramdd(vals, weights=w)[0].dtype, int))
+        assert_(np.issubdtype(np.histogramdd(vals, normed=True)[0].dtype, float))
+        assert_(np.issubdtype(np.histogramdd(vals, weights=w, normed=True)[0].dtype, float))
+
 
 class TestUnique(TestCase):
 


### PR DESCRIPTION
In line with `histogram`. A float array is only returned when `weights` is a float array or `normed=True`

#7845