### PR TITLE
BUG: Make sqrt handle 16 bit floats.

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -216,7 +216,6 @@ cmplx = 'FDG'
 cmplxO = cmplx + O
 cmplxP = cmplx + P
 inexact = flts + cmplx
-inexactvec = 'fd'
 noint = inexact+O
 nointP = inexact+P
 allP = bints+times+flts+cmplxP
@@ -696,7 +695,6 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.sqrt'),
           None,
-          TD(inexactvec),
           TD(inexact, f='sqrt', astype={'e':'f'}),
           TD(P, f='sqrt'),
           ),


### PR DESCRIPTION
The numpy/core/code_generators/generate_umath.py entry for sqrt
had `TD(inexactvec)` before `TD(inexact, f='sqrt', astype={'e':'f'}),
with the result that 16 bit floats always returned float. The
solution here is to remove that line together with the definition of
inexactvec as the latter is not used anywhere else.

Closes #7897.
