### PR TITLE
Backport 7903, BUG: fix float16 type not being called due to wrong ordering

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -695,6 +695,7 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.sqrt'),
           None,
+          TD('e', f='sqrt', astype={'e':'f'}),
           TD(inexactvec),
           TD(inexact, f='sqrt', astype={'e':'f'}),
           TD(P, f='sqrt'),

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1701,9 +1701,10 @@ get_functions(PyObject * mm)
      * generate_umath.py, the first to go into FLOAT/DOUBLE_sqrt
      * they have the same signature as the scalar variants so we need to skip
      * over them
+     * also skip float16 copy placed before
      */
-    i = 4;
-    j = 2;
+    i = 6;
+    j = 3;
     while (signatures[i] != NPY_FLOAT) {
         i += 2; j++;
     }

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -877,11 +877,11 @@ class _TestNorm(object):
 
             an = norm(at, 2)
             assert_(issubclass(an.dtype.type, np.floating))
-            assert_almost_equal(an, 2.0**(1.0/2.0))
+            assert_almost_equal(an, an.dtype.type(2.0)**an.dtype.type(1.0/2.0))
 
             an = norm(at, 4)
             assert_(issubclass(an.dtype.type, np.floating))
-            assert_almost_equal(an, 2.0**(1.0/4.0))
+            assert_almost_equal(an, an.dtype.type(2.0)**an.dtype.type(1.0/4.0))
 
             an = norm(at, np.inf)
             assert_(issubclass(an.dtype.type, np.floating))


### PR DESCRIPTION
#7903

closes gh-7897
