### PR TITLE
ENH: skip or avoid gc/objectmodel differences btwn pypy and cpython

### DIFF
--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.compat import sixu
 from numpy.testing import (
      run_module_suite, assert_, assert_equal, assert_array_equal,
-     assert_raises
+     assert_raises, HAS_REFCOUNT
 )
 
 # Switch between new behaviour when NPY_RELAXED_STRIDES_CHECKING is set.
@@ -19,23 +19,26 @@ def test_array_array():
     tndarray = type(ones11)
     # Test is_ndarray
     assert_equal(np.array(ones11, dtype=np.float64), ones11)
-    old_refcount = sys.getrefcount(tndarray)
-    np.array(ones11)
-    assert_equal(old_refcount, sys.getrefcount(tndarray))
+    if HAS_REFCOUNT:
+        old_refcount = sys.getrefcount(tndarray)
+        np.array(ones11)
+        assert_equal(old_refcount, sys.getrefcount(tndarray))
 
     # test None
     assert_equal(np.array(None, dtype=np.float64),
                  np.array(np.nan, dtype=np.float64))
-    old_refcount = sys.getrefcount(tobj)
-    np.array(None, dtype=np.float64)
-    assert_equal(old_refcount, sys.getrefcount(tobj))
+    if HAS_REFCOUNT:
+        old_refcount = sys.getrefcount(tobj)
+        np.array(None, dtype=np.float64)
+        assert_equal(old_refcount, sys.getrefcount(tobj))
 
     # test scalar
     assert_equal(np.array(1.0, dtype=np.float64),
                  np.ones((), dtype=np.float64))
-    old_refcount = sys.getrefcount(np.float64)
-    np.array(np.array(1.0, dtype=np.float64), dtype=np.float64)
-    assert_equal(old_refcount, sys.getrefcount(np.float64))
+    if HAS_REFCOUNT:
+        old_refcount = sys.getrefcount(np.float64)
+        np.array(np.array(1.0, dtype=np.float64), dtype=np.float64)
+        assert_equal(old_refcount, sys.getrefcount(np.float64))
 
     # test string
     S2 = np.dtype((str, 2))

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_raises,
-    assert_array_equal
+    assert_array_equal, HAS_REFCOUNT
 )
 
 
@@ -55,12 +55,14 @@ class TestTake(TestCase):
             b = np.array([2, 2, 4, 5, 3, 5])
             a.take(b, out=a[:6])
             del a
-            assert_(all(sys.getrefcount(o) == 3 for o in objects))
+            if HAS_REFCOUNT:
+                assert_(all(sys.getrefcount(o) == 3 for o in objects))
             # not contiguous, example:
             a = np.array(objects * 2)[::2]
             a.take(b, out=a[:6])
             del a
-            assert_(all(sys.getrefcount(o) == 3 for o in objects))
+            if HAS_REFCOUNT:
+                assert_(all(sys.getrefcount(o) == 3 for o in objects))
 
     def test_unicode_mode(self):
         d = np.arange(10)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -9,7 +9,7 @@ from numpy.compat import asbytes, sixu
 from numpy.core.multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
-    assert_raises, dec
+    assert_raises, dec, HAS_REFCOUNT
     )
 
 
@@ -34,6 +34,7 @@ def iter_iterindices(i):
         i.iternext()
     return ret
 
+@dec.skipif(not HAS_REFCOUNT, "python does not have sys.getrefcount")
 def test_iter_refcount():
     # Make sure the iterator doesn't leak
 
@@ -1000,17 +1001,20 @@ def test_iter_object_arrays_basic():
 
     obj = {'a':3,'b':'d'}
     a = np.array([[1, 2, 3], None, obj, None], dtype='O')
-    rc = sys.getrefcount(obj)
+    if HAS_REFCOUNT:
+        rc = sys.getrefcount(obj)
 
     # Need to allow references for object arrays
     assert_raises(TypeError, nditer, a)
-    assert_equal(sys.getrefcount(obj), rc)
+    if HAS_REFCOUNT:
+        assert_equal(sys.getrefcount(obj), rc)
 
     i = nditer(a, ['refs_ok'], ['readonly'])
     vals = [x_[()] for x_ in i]
     assert_equal(np.array(vals, dtype='O'), a)
     vals, i, x = [None]*3
-    assert_equal(sys.getrefcount(obj), rc)
+    if HAS_REFCOUNT:
+        assert_equal(sys.getrefcount(obj), rc)
 
     i = nditer(a.reshape(2, 2).T, ['refs_ok', 'buffered'],
                         ['readonly'], order='C')
@@ -1018,14 +1022,16 @@ def test_iter_object_arrays_basic():
     vals = [x_[()] for x_ in i]
     assert_equal(np.array(vals, dtype='O'), a.reshape(2, 2).ravel(order='F'))
     vals, i, x = [None]*3
-    assert_equal(sys.getrefcount(obj), rc)
+    if HAS_REFCOUNT:
+        assert_equal(sys.getrefcount(obj), rc)
 
     i = nditer(a.reshape(2, 2).T, ['refs_ok', 'buffered'],
                         ['readwrite'], order='C')
     for x in i:
         x[...] = None
     vals, i, x = [None]*3
-    assert_equal(sys.getrefcount(obj), rc-1)
+    if HAS_REFCOUNT:
+        assert_(sys.getrefcount(obj) == rc-1)
     assert_equal(a, np.array([None]*4, dtype='O'))
 
 def test_iter_object_arrays_conversions():
@@ -1061,10 +1067,12 @@ def test_iter_object_arrays_conversions():
     i = nditer(a, ['refs_ok', 'buffered'], ['readwrite'],
                     casting='unsafe', op_dtypes='O')
     ob = i[0][()]
-    rc = sys.getrefcount(ob)
+    if HAS_REFCOUNT:
+        rc = sys.getrefcount(ob)
     for x in i:
         x[...] += 1
-    assert_equal(sys.getrefcount(ob), rc-1)
+    if HAS_REFCOUNT:
+        assert_(sys.getrefcount(ob) == rc-1)
     assert_equal(a, np.arange(6)+98172489)
 
 def test_iter_common_dtype():
@@ -1704,7 +1712,8 @@ def test_iter_buffered_cast_structured_type():
     a[0] = (0.5, 0.5, [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]], 0.5)
     a[1] = (1.5, 1.5, [[1.5, 1.5, 1.5], [1.5, 1.5, 1.5]], 1.5)
     a[2] = (2.5, 2.5, [[2.5, 2.5, 2.5], [2.5, 2.5, 2.5]], 2.5)
-    rc = sys.getrefcount(a[0])
+    if HAS_REFCOUNT:
+        rc = sys.getrefcount(a[0])
     i = nditer(a, ['buffered', 'refs_ok'], ['readonly'],
                     casting='unsafe',
                     op_dtypes=sdt)
@@ -1719,7 +1728,8 @@ def test_iter_buffered_cast_structured_type():
     assert_equal(vals[1]['d'], 1.5)
     assert_equal(vals[0].dtype, np.dtype(sdt))
     vals, i, x = [None]*3
-    assert_equal(sys.getrefcount(a[0]), rc)
+    if HAS_REFCOUNT:
+        assert_equal(sys.getrefcount(a[0]), rc)
 
     # struct type -> simple (takes the first value)
     sdt = [('a', 'f4'), ('b', 'i8'), ('d', 'O')]

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -12,7 +12,7 @@ from numpy.random import rand, randint, randn
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_raises_regex, assert_array_equal, assert_almost_equal,
-    assert_array_almost_equal, dec
+    assert_array_almost_equal, dec, HAS_REFCOUNT
 )
 
 
@@ -2011,6 +2011,7 @@ class TestCreationFuncs(TestCase):
         self.check_function(np.full, 0)
         self.check_function(np.full, 1)
 
+    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
     def test_for_reference_leak(self):
         # Make sure we have an object for reference
         dim = 1

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.testing.utils import _gen_alignment_data
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_almost_equal, assert_allclose, assert_array_equal
+    assert_almost_equal, assert_allclose, assert_array_equal, IS_PYPY
 )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -454,16 +454,18 @@ class TestRepr(object):
             yield self._test_type_repr, t
 
 
-class TestSizeOf(TestCase):
+if not IS_PYPY:
+    # sys.getsizeof() is not valid on PyPy
+    class TestSizeOf(TestCase):
 
-    def test_equal_nbytes(self):
-        for type in types:
-            x = type(0)
-            assert_(sys.getsizeof(x) > x.nbytes)
+        def test_equal_nbytes(self):
+            for type in types:
+                x = type(0)
+                assert_(sys.getsizeof(x) > x.nbytes)
 
-    def test_error(self):
-        d = np.float32()
-        assert_raises(TypeError, d.__sizeof__, "a")
+        def test_error(self):
+            d = np.float32()
+            assert_raises(TypeError, d.__sizeof__, "a")
 
 
 class TestMultiply(TestCase):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -10,6 +10,7 @@ from numpy.testing import (
     assert_allclose, assert_array_max_ulp, assert_warns,
     assert_raises_regex, dec, clear_and_catch_warnings
 )
+from numpy.testing.utils import HAS_REFCOUNT
 import numpy.lib.function_base as nfb
 from numpy.random import rand
 from numpy.lib import (
@@ -17,7 +18,7 @@ from numpy.lib import (
     delete, diff, digitize, extract, flipud, gradient, hamming, hanning,
     histogram, histogramdd, i0, insert, interp, kaiser, meshgrid, msort,
     piecewise, place, rot90, select, setxor1d, sinc, split, trapz, trim_zeros,
-    unwrap, unique, vectorize,
+    unwrap, unique, vectorize
 )
 
 from numpy.compat import long
@@ -2232,6 +2233,7 @@ class TestBincount(TestCase):
                             "minlength must be positive",
                             lambda: np.bincount(x, minlength=0))
 
+    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
     def test_dtype_reference_leaks(self):
         # gh-6805
         intp_refcount = sys.getrefcount(np.dtype(np.intp))

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -19,7 +19,7 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     TestCase, run_module_suite, assert_warns, assert_,
     assert_raises_regex, assert_raises, assert_allclose,
-    assert_array_equal, temppath, dec
+    assert_array_equal, temppath, dec, IS_PYPY
 )
 
 
@@ -266,6 +266,7 @@ class TestSavezLoad(RoundtripTest, TestCase):
                 fp.seek(0)
                 assert_(not fp.closed)
 
+    @np.testing.dec.skipif(IS_PYPY, "context manager required on PyPy")
     def test_closing_fid(self):
         # Test that issue #1517 (too many opened files) remains closed
         # It might be a "weak" test since failed to get triggered on

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3279,12 +3279,13 @@ class MaskedArray(ndarray):
             # We want to remove the unshare logic from this place in the
             # future. Note that _sharedmask has lots of false positives.
             if not self._isfield:
+                notthree = getattr(sys, 'getrefcount', False) and (sys.getrefcount(_mask) != 3)
                 if self._sharedmask and not (
                         # If no one else holds a reference (we have two
                         # references (_mask and self._mask) -- add one for
                         # getrefcount) and the array owns its own data
                         # copying the mask should do nothing.
-                        (sys.getrefcount(_mask) == 3) and _mask.flags.owndata):
+                        (not notthree) and _mask.flags.owndata):
                     # 2016.01.15 -- v1.11.0
                     warnings.warn(
                        "setting an item on a masked array which has a shared "

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -32,7 +32,8 @@ __all__ = ['assert_equal', 'assert_almost_equal', 'assert_approx_equal',
            'assert_', 'assert_array_almost_equal_nulp', 'assert_raises_regex',
            'assert_array_max_ulp', 'assert_warns', 'assert_no_warnings',
            'assert_allclose', 'IgnoreException', 'clear_and_catch_warnings',
-           'SkipTest', 'KnownFailureException', 'temppath', 'tempdir']
+           'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
+           'HAS_REFCOUNT']
 
 
 class KnownFailureException(Exception):
@@ -43,6 +44,8 @@ class KnownFailureException(Exception):
 KnownFailureTest = KnownFailureException  # backwards compat
 verbose = 0
 
+IS_PYPY = '__pypy__' in sys.modules
+HAS_REFCOUNT = getattr(sys, 'getrefcount', None) is not None
 
 def assert_(val, msg=''):
     """
@@ -1274,6 +1277,8 @@ def _assert_valid_refcount(op):
     Check that ufuncs don't mishandle refcount of object `1`.
     Used in a few regression tests.
     """
+    if not HAS_REFCOUNT:
+        return True
     import numpy as np
 
     b = np.arange(100*100).reshape(100, 100)


### PR DESCRIPTION
three classes of fixes when running tests with PyPy:
- skip test_closing_fid
- skip all tests of `sys.getsizeof()`
- always return True where `sys.getrefcount()` is used by defining a hackish AlwaysTrue class
