### PR TITLE
ENH: Better error message for invalid axis

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -289,7 +289,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
         memset(out_axis_flags, 0, ndim);
 
         axis = PyArray_PyIntAsInt_ErrMsg(axis_in,
-                                   "an integer is required for the axis");
+                               "an integer or tuple is required for the axis");
         axis_orig = axis;
 
         if (error_converting(axis)) {

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -289,7 +289,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
         memset(out_axis_flags, 0, ndim);
 
         axis = PyArray_PyIntAsInt_ErrMsg(axis_in,
-                               "an integer or tuple is required for the axis");
+                            "an integer or tuple is required for the axis");
         axis_orig = axis;
 
         if (error_converting(axis)) {
@@ -847,6 +847,7 @@ PyArray_PyIntAsIntp_ErrMsg(PyObject *o, const char * msg)
      */
     obj = PyNumber_Index(o);
     if (obj == NULL) {
+        PyErr_SetString(PyExc_TypeError, msg);
         return -1;
     }
 #if (NPY_SIZEOF_LONG < NPY_SIZEOF_INTP)

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3982,7 +3982,9 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     }
     /* Try to interpret axis as an integer */
     else {
-        int axis = PyArray_PyIntAsInt(axes_in);
+        int axis = PyArray_PyIntAsInt_ErrMsg(axes_in,
+                               "an integer or tuple is required for the axis");
+
         /* TODO: PyNumber_Index would be good to use here */
         if (axis == -1 && PyErr_Occurred()) {
             Py_XDECREF(otype);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -26,7 +26,7 @@ from numpy.core.multiarray_tests import (
     test_inplace_increment, get_buffer_info, test_as_c_array,
     )
 from numpy.testing import (
-    TestCase, run_module_suite, assert_, assert_raises,
+    TestCase, run_module_suite, assert_, assert_raises, assert_raises_regex,
     assert_equal, assert_almost_equal, assert_array_equal,
     assert_array_almost_equal, assert_allclose,
     assert_array_less, runstring, dec, SkipTest, temppath
@@ -1174,6 +1174,8 @@ class TestMethods(TestCase):
         assert_equal(a.squeeze(axis=(0,)), [[1], [2], [3]])
         assert_raises(ValueError, a.squeeze, axis=(1,))
         assert_equal(a.squeeze(axis=(2,)), [[1, 2, 3]])
+        assert_raises_regex(ValueError, "integer or tuple",
+                            a.squeeze, axis=[2])
 
     def test_transpose(self):
         a = np.array([[1, 2], [3, 4]])

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -7,8 +7,8 @@ from numpy.compat import asbytes
 from numpy.core.test_rational import rational, test_add, test_add_rationals
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    assert_no_warnings
+    assert_raises_regex, assert_array_equal, assert_almost_equal,
+    assert_array_almost_equal, assert_no_warnings
 )
 
 
@@ -1197,6 +1197,7 @@ class TestUfunc(TestCase):
         assert_raises(TypeError, f, d, axis="invalid")
         assert_raises(TypeError, f, d, axis="invalid", dtype=None,
                       keepdims=True)
+        assert_raises_regex(TypeError, "integer or tuple", f, d, axis=[0])
         # invalid dtype
         assert_raises(TypeError, f, d, 0, "invalid")
         assert_raises(TypeError, f, d, dtype="invalid")
@@ -1212,7 +1213,7 @@ class TestUfunc(TestCase):
         assert_raises(TypeError, f, d, 0, keepdims="invalid", dtype="invalid",
                      out=None)
 
-        # invalid keyord
+        # invalid keyword
         assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
         assert_raises(TypeError, f, d, invalid=0)
         assert_raises(TypeError, f, d, 0, keepdims=True, invalid="invalid",


### PR DESCRIPTION
xref #7915

Currently, writing array.max(axis=[0, 1]) doesn't mention you can use a tuple
for the axis argument -- it just says "an integer is required".
