### PR TITLE
BUG: Production install of numpy should not require nose.

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -51,8 +51,10 @@ except ImportError:
         import nose
         SkipTest = nose.SkipTest
     except (ImportError, AttributeError):
-        # if nose is not available, testing won't work anyway
-        pass
+        # If nose is not available, testing won't work anyway,
+        # but we need something to import in numpy/testing/decorators.py.
+        # See gh-7498.
+        SkipTest = None
 
 verbose = 0
 


### PR DESCRIPTION
This fixes a Python 2.6 specific problem resulting from a failed import
of SkipTest. SkipTest was not part of unittest until Python 2.7 and the
fallback was to import it from nose.

Closes #7498.

[ci skip]
