### PR TITLE
ENH: Add ma.convolve and ma.correlate for #6458

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -249,6 +249,13 @@ context manager will work as expected. Additionally, it is possible
 to use the context manager as a decorator which can be useful when
 multiple tests give need to hide the same warning.
 
+New masked array functions ``ma.convolve`` and ``ma.correlate`` added
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These functions wrapped the non-masked versions, but propagate through masked
+values. There are two different propagation modes. The default causes masked
+values to contaminate the result with masks, but the other mode only outputs
+masks if there is no alternative.
+
 
 Improvements
 ============

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7373,8 +7373,8 @@ def _convolve_or_correlate(f, a, v, mode, propagate_mask):
     if propagate_mask:
         # results which are contributed to by either item in any pair being invalid
         mask = (
-            f(getmaskarray(a), np.ones(v.shape, dtype=np.bool), mode=mode)
-          | f(np.ones(a.shape, dtype=np.bool), getmaskarray(v), mode=mode)
+            f(getmaskarray(a), np.ones(np.shape(v), dtype=np.bool), mode=mode)
+          | f(np.ones(np.shape(a), dtype=np.bool), getmaskarray(v), mode=mode)
         )
         data = f(getdata(a), getdata(v), mode=mode)
     else:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7367,6 +7367,9 @@ outerproduct = outer
 
 
 def _convolve_or_correlate(f, a, v, mode, propagate_mask):
+    """
+    Helper function for ma.correlate and ma.convolve
+    """
     if propagate_mask:
         # results which are contributed to by either item in any pair being invalid
         mask = (
@@ -7400,7 +7403,7 @@ def correlate(a, v, mode='valid', propagate_mask=True):
 
     Returns
     -------
-    out : ndarray
+    out : MaskedArray
         Discrete cross-correlation of `a` and `v`.
 
     See Also
@@ -7428,7 +7431,7 @@ def convolve(a, v, mode='full', propagate_mask=True):
 
     Returns
     -------
-    out : ndarray
+    out : MaskedArray
         Discrete, linear convolution of `a` and `v`.
 
     See Also

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7366,8 +7366,8 @@ outer.__doc__ = doc_note(np.outer.__doc__,
 outerproduct = outer
 
 
-def _convolve_or_correlate(f, a, v, mode, contagious):
-    if contagious:
+def _convolve_or_correlate(f, a, v, mode, propagate_mask):
+    if propagate_mask:
         # results which are contributed to by either item in any pair being invalid
         mask = (
             f(getmaskarray(a), np.ones(v.shape, dtype=np.bool), mode=mode)
@@ -7382,7 +7382,7 @@ def _convolve_or_correlate(f, a, v, mode, contagious):
     return masked_array(data, mask=mask)
 
 
-def correlate(a, v, mode='valid', contagious=True):
+def correlate(a, v, mode='valid', propagate_mask=True):
     """
     Cross-correlation of two 1-dimensional sequences.
 
@@ -7393,10 +7393,9 @@ def correlate(a, v, mode='valid', contagious=True):
     mode : {'valid', 'same', 'full'}, optional
         Refer to the `np.convolve` docstring.  Note that the default
         is 'valid', unlike `convolve`, which uses 'full'.
-    contagious : bool
-        If True, then if any masked element is included in the sum for a result
-        element, then the result is masked.
-        If False, then the result element is only masked if no non-masked cells
+    propagate_mask : bool
+        If True, then a result element is masked if any masked element contributes towards it.
+        If False, then a result element is only masked if no non-masked element
         contribute towards it
 
     Returns
@@ -7408,10 +7407,10 @@ def correlate(a, v, mode='valid', contagious=True):
     --------
     numpy.correlate : Equivalent function in the top-level NumPy module.
     """
-    return _convolve_or_correlate(np.correlate, a, v, mode, contagious)
+    return _convolve_or_correlate(np.correlate, a, v, mode, propagate_mask)
 
 
-def convolve(a, v, mode='full', contagious=True):
+def convolve(a, v, mode='full', propagate_mask=True):
     """
     Returns the discrete, linear convolution of two one-dimensional sequences.
 
@@ -7421,7 +7420,7 @@ def convolve(a, v, mode='full', contagious=True):
         Input sequences.
     mode : {'valid', 'same', 'full'}, optional
         Refer to the `np.convolve` docstring.
-    contagious : bool
+    propagate_mask : bool
         If True, then if any masked element is included in the sum for a result
         element, then the result is masked.
         If False, then the result element is only masked if no non-masked cells
@@ -7436,7 +7435,7 @@ def convolve(a, v, mode='full', contagious=True):
     --------
     numpy.convolve : Equivalent function in the top-level NumPy module.
     """
-    return _convolve_or_correlate(np.convolve, a, v, mode, contagious)
+    return _convolve_or_correlate(np.convolve, a, v, mode, propagate_mask)
 
 
 def allequal(a, b, fill_value=True):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4092,7 +4092,7 @@ class TestMaskedArrayFunctions(TestCase):
         test = np.ma.convolve(a, b)
         assert_equal(test, masked_equal([0, 1, -1, -1, 7, 4], -1))
 
-        test = np.ma.convolve(a, b, contagious=False)
+        test = np.ma.convolve(a, b, propagate_mask=False)
         assert_equal(test, masked_equal([0, 1, 1, 3, 7, 4], -1))
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4095,6 +4095,16 @@ class TestMaskedArrayFunctions(TestCase):
         test = np.ma.convolve(a, b, propagate_mask=False)
         assert_equal(test, masked_equal([0, 1, 1, 3, 7, 4], -1))
 
+        test = np.ma.convolve([1, 1], [1, 1, 1])
+        assert_equal(test, masked_equal([1, 2, 2, 1], -1))
+
+        a = [1, 1]
+        b = masked_equal([1, -1, -1, 1], -1)
+        test = np.ma.convolve(a, b, propagate_mask=False)
+        assert_equal(test, masked_equal([1, 1, -1, 1, 1], -1))
+        test = np.ma.convolve(a, b, propagate_mask=True)
+        assert_equal(test, masked_equal([-1, -1, -1, -1, -1], -1))
+
 
 class TestMaskedFields(TestCase):
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4086,6 +4086,15 @@ class TestMaskedArrayFunctions(TestCase):
         test = np.ma.compressed(M(shape=(0,1,2)))
         assert_equal(test, 42)
 
+    def test_convolve(self):
+        a = masked_equal(np.arange(5), 2)
+        b = np.array([1, 1])
+        test = np.ma.convolve(a, b)
+        assert_equal(test, masked_equal([0, 1, -1, -1, 7, 4], -1))
+
+        test = np.ma.convolve(a, b, contagious=False)
+        assert_equal(test, masked_equal([0, 1, 1, 3, 7, 4], -1))
+
 
 class TestMaskedFields(TestCase):
 


### PR DESCRIPTION
Implements the function requested in #6458

`contagious` parameter could probably be better named

No tests for correlate, but it should be pretty apparent that if it works for one it works for both
