### PR TITLE
DOC: add cbrt to math summary page

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -139,6 +139,7 @@ Miscellaneous
    clip
 
    sqrt
+   cbrt
    square
 
    absolute


### PR DESCRIPTION
[ci skip]
