### PR TITLE
Backport 7931, BUG: Check for HAVE_LDOUBLE_DOUBLE_DOUBLE_LE in npy_math_complex.

### DIFF
--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -1565,6 +1565,7 @@ _real_part_reciprocalf(npy_float x, npy_float y)
 #undef BIAS
 #undef CUTOFF
 #endif
+
 #if @precision@ == 2
 #define BIAS (DBL_MAX_EXP - 1)
 /*  more guard digits are useful iff there is extra precision. */
@@ -1604,8 +1605,11 @@ _real_part_reciprocal(npy_double x, npy_double y)
 #undef BIAS
 #undef CUTOFF
 #endif
+
 #if @precision@ == 3
-#ifndef HAVE_LDOUBLE_DOUBLE_DOUBLE_BE
+#if !defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_BE) && \
+    !defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_LE)
+
 #define BIAS (LDBL_MAX_EXP - 1)
 #define CUTOFF (LDBL_MANT_DIG / 2 + 1)
 static NPY_INLINE npy_longdouble
@@ -1638,13 +1642,16 @@ _real_part_reciprocall(npy_longdouble x,
 }
 #undef BIAS
 #undef CUTOFF
+
 #else
+
 static NPY_INLINE npy_longdouble
 _real_part_reciprocall(npy_longdouble x,
     npy_longdouble y)
 {
     return x/(x*x + y*y);
 }
+
 #endif
 #endif
 


### PR DESCRIPTION
Backport #7931.

The `_real_part_reciprocal` function is coded in two ways, one depending
on functions specific to IEEE floating point and the other using generic
code that should always work.  Because PPC long double is not IEEE the
generic version should always be chosen for that architecture, but that
is currently only done when the PPC is configured as big endian.  This
PR makes sure that the generic version is also chosen when the PPC is
configured as little endian.

Closes #7836.
