### PR TITLE
DOC: Corrected allowed keywords in add_(installed_)library

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1512,8 +1512,8 @@ class Configuration(object):
                 * macros
                 * include_dirs
                 * extra_compiler_args
-                * extra_f77_compiler_args
-                * extra_f90_compiler_args
+                * extra_f77_compile_args
+                * extra_f90_compile_args
                 * f2py_options
                 * language
 
@@ -1565,8 +1565,8 @@ class Configuration(object):
                 * macros
                 * include_dirs
                 * extra_compiler_args
-                * extra_f77_compiler_args
-                * extra_f90_compiler_args
+                * extra_f77_compile_args
+                * extra_f90_compile_args
                 * f2py_options
                 * language
 


### PR DESCRIPTION
Docstring listed `extra_f77_compiler_args` and `extra_f90_compiler_args`
as allowed keywords of `add_library` and `add_installed_library` of `numpy.disutils`, 
but per `command/build_clib.py`, lines 193-194
the recognized keywords are in fact `extra_f77_compile_args` and
`extra_f90_compile_args`.

The keyword `extra_compiler_args`, although non-confirmant both for
Fortran keywords and to the keywords of add_extension, is consistent
with the implementation (see line 200 of `build_clib.py`).

See short discussion at 

https://mail.scipy.org/pipermail/numpy-discussion/2016-August/075904.html
