### PR TITLE
ENH: create meshgrids from tabular data

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4360,9 +4360,9 @@ def meshgridify(*xi, **kwargs):
     conventional `meshgrid` function is not applicable and meshgridify is very
     useful.
 
-    >>> [X, Y, Z] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
+    >>> X, Y, Z = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
 
-    For example, for direct controuplotting of tabular data.
+    For example, for direct contourplotting of tabular data.
 
     >>> x = np.array(0, 0, 0, 1, 1, 1, 2, 2, 2)
     >>> y = np.array(0, 1, 2, 0, 1, 2, 0, 1, 2)
@@ -4385,8 +4385,6 @@ def meshgridify(*xi, **kwargs):
     raveled_mgrid = [m.ravel() for m in mgrid]
     value_dict = dict(zip(zip(*xi), f))
     result = [value_dict.get(key, np.nan) for key in zip(*raveled_mgrid)]
-    # return [*mgrid, np.array(result).reshape(mgrid[0].shape)]
-    # return mgrid.append(np.array(result).reshape(mgrid[0].shape))
     return mgrid + [np.array(result).reshape(mgrid[0].shape)]
 
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4327,7 +4327,7 @@ def meshgrid(*xi, **kwargs):
             return np.broadcast_arrays(*output)
 
 
-def meshgridify(*xi, f=None, **kwargs):
+def meshgridify(*xi, **kwargs):
     """
     Converts tabular data to meshgrid format.
 
@@ -4346,7 +4346,8 @@ def meshgridify(*xi, f=None, **kwargs):
     X1, X2,..., Xn, Z : ndarray
         Returns meshgrid arrays X1, X2, ..., Xn with dimensions n, created from
         the coordinate vectors `x1`, `x2`, ..., `xn`. When `f` is given, an
-        array fitting to the coordinates given in X1, X2, ..., Xn is also returned.
+        array fitting to the coordinates given in X1, X2, ..., Xn is also
+        returned.
 
     See Also
     --------
@@ -4356,7 +4357,8 @@ def meshgridify(*xi, f=None, **kwargs):
     --------
     If there is no function to apply to a meshgrid to obtain the according
     function values, but only a table of coordinate-value pairs is given, the
-    conventional `meshgrid` function is not applicable and meshgridify is very useful.
+    conventional `meshgrid` function is not applicable and meshgridify is very
+    useful.
 
     >>> [X, Y, Z] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
 
@@ -4367,6 +4369,7 @@ def meshgridify(*xi, f=None, **kwargs):
     >>> z = np.array(0, 1, 2, 1, 2, 3, 2, 3, 4)
     >>> h = plt.contourf(*meshgridify(x, y, f=z))
     """
+    f = kwargs.pop('f', None)
     nvalues = [len(x) for x in xi]
     if f is not None:
         nvalues.append(len(f))
@@ -4382,7 +4385,9 @@ def meshgridify(*xi, f=None, **kwargs):
     raveled_mgrid = [m.ravel() for m in mgrid]
     value_dict = dict(zip(zip(*xi), f))
     result = [value_dict.get(key, np.nan) for key in zip(*raveled_mgrid)]
-    return [*mgrid, np.array(result).reshape(mgrid[0].shape)]
+    # return [*mgrid, np.array(result).reshape(mgrid[0].shape)]
+    # return mgrid.append(np.array(result).reshape(mgrid[0].shape))
+    return mgrid + [np.array(result).reshape(mgrid[0].shape)]
 
 
 def delete(arr, obj, axis=None):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -43,7 +43,8 @@ __all__ = [
     'histogram', 'histogramdd', 'bincount', 'digitize', 'cov', 'corrcoef',
     'msort', 'median', 'sinc', 'hamming', 'hanning', 'bartlett',
     'blackman', 'kaiser', 'trapz', 'i0', 'add_newdoc', 'add_docstring',
-    'meshgrid', 'delete', 'insert', 'append', 'interp', 'add_newdoc_ufunc'
+    'meshgrid', 'meshgridify', 'delete', 'insert', 'append', 'interp',
+    'add_newdoc_ufunc'
     ]
 
 
@@ -4324,6 +4325,64 @@ def meshgrid(*xi, **kwargs):
             return [x * mult_fact for x in output]
         else:
             return np.broadcast_arrays(*output)
+
+
+def meshgridify(*xi, f=None, **kwargs):
+    """
+    Converts tabular data to meshgrid format.
+
+    Returns array of function values `f` fitting to meshgrid arrays created
+    from `xi`. If no `f` is given, only a meshgrid from `xi` is returned.
+
+    Parameters
+    ----------
+    x1, x2,..., xn : array_like
+        1-D arrays representing the coordinates of a grid.
+    f : array-like, optional
+        Function values for coordinate tuples in `xi`.
+
+    Returns
+    -------
+    X1, X2,..., Xn, Z : ndarray
+        Returns meshgrid arrays X1, X2, ..., Xn with dimensions n, created from
+        the coordinate vectors `x1`, `x2`, ..., `xn`. When `f` is given, an
+        array fitting to the coordinates given in X1, X2, ..., Xn is also returned.
+
+    See Also
+    --------
+    np.meshgrid : Construct a multi-dimensional "meshgrid".
+
+    Examples
+    --------
+    If there is no function to apply to a meshgrid to obtain the according
+    function values, but only a table of coordinate-value pairs is given, the
+    conventional `meshgrid` function is not applicable and meshgridify is very useful.
+
+    >>> [X, Y, Z] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
+
+    For example, for direct controuplotting of tabular data.
+
+    >>> x = np.array(0, 0, 0, 1, 1, 1, 2, 2, 2)
+    >>> y = np.array(0, 1, 2, 0, 1, 2, 0, 1, 2)
+    >>> z = np.array(0, 1, 2, 1, 2, 3, 2, 3, 4)
+    >>> h = plt.contourf(*meshgridify(x, y, f=z))
+    """
+    nvalues = [len(x) for x in xi]
+    if f is not None:
+        nvalues.append(len(f))
+
+    if len(set(nvalues)) > 1:
+        raise ValueError("All input arrays must have the same length.")
+
+    unique_xi = [np.unique(x) for x in xi]
+    if f is None:
+        return meshgrid(*unique_xi, **kwargs)
+
+    mgrid = meshgrid(*unique_xi, **kwargs)
+    raveled_mgrid = [m.ravel() for m in mgrid]
+    value_dict = dict(zip(zip(*xi), f))
+    result = [value_dict.get(key, np.nan) for key in zip(*raveled_mgrid)]
+    return [*mgrid, np.array(result).reshape(mgrid[0].shape)]
 
 
 def delete(arr, obj, axis=None):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2094,7 +2094,7 @@ class TestMeshgrid(TestCase):
 class TestMeshgridify(TestCase):
 
     def test_simple(self):
-        [X, Y, Z] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
+        X, Y, Z = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
         assert_array_equal(X, np.array([[1, 2],
                                         [1, 2]]))
         assert_array_equal(Y, np.array([[3, 3],
@@ -2103,14 +2103,14 @@ class TestMeshgridify(TestCase):
                                         [1, 3]]))
 
     def test_only_meshgrid(self):
-        [X, Y] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4])
+        X, Y = meshgridify([1, 1, 2, 2], [3, 4, 3, 4])
         assert_array_equal(X, np.array([[1, 2],
                                         [1, 2]]))
         assert_array_equal(Y, np.array([[3, 3],
                                         [4, 4]]))
 
     def test_missing_value(self):
-        [X, Y, Z] = meshgridify([1, 1, 2], [3, 4, 3], f=[0, 1, 2])
+        X, Y, Z = meshgridify([1, 1, 2], [3, 4, 3], f=[0, 1, 2])
         assert_array_equal(X, np.array([[1, 2],
                                         [1, 2]]))
         assert_array_equal(Y, np.array([[3, 3],
@@ -2119,7 +2119,7 @@ class TestMeshgridify(TestCase):
                                         [1, np.nan]]))
 
     def test_single_coordinate(self):
-        [X, Z] = meshgridify([1, 2, 3, 4], f=[4, 3, 2, 1])
+        X, Z = meshgridify([1, 2, 3, 4], f=[4, 3, 2, 1])
         assert_array_equal(X, np.array([1, 2, 3, 4]))
         assert_array_equal(Z, np.array([4, 3, 2, 1]))
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -16,9 +16,9 @@ from numpy.random import rand
 from numpy.lib import (
     add_newdoc_ufunc, angle, average, bartlett, blackman, corrcoef, cov,
     delete, diff, digitize, extract, flipud, gradient, hamming, hanning,
-    histogram, histogramdd, i0, insert, interp, kaiser, meshgrid, msort,
-    piecewise, place, rot90, select, setxor1d, sinc, split, trapz, trim_zeros,
-    unwrap, unique, vectorize
+    histogram, histogramdd, i0, insert, interp, kaiser, meshgrid, meshgridify,
+    msort, piecewise, place, rot90, select, setxor1d, sinc, split, trapz,
+    trim_zeros, unwrap, unique, vectorize
 )
 
 from numpy.compat import long
@@ -2089,6 +2089,43 @@ class TestMeshgrid(TestCase):
         # https://github.com/numpy/numpy/issues/4755
         assert_raises(TypeError, meshgrid,
                       [1, 2, 3], [4, 5, 6, 7], indices='ij')
+
+
+class TestMeshgridify(TestCase):
+
+    def test_simple(self):
+        [X, Y, Z] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4], f=[0, 1, 2, 3])
+        assert_array_equal(X, np.array([[1, 2],
+                                        [1, 2]]))
+        assert_array_equal(Y, np.array([[3, 3],
+                                        [4, 4]]))
+        assert_array_equal(Z, np.array([[0, 2],
+                                        [1, 3]]))
+
+    def test_only_meshgrid(self):
+        [X, Y] = meshgridify([1, 1, 2, 2], [3, 4, 3, 4])
+        assert_array_equal(X, np.array([[1, 2],
+                                        [1, 2]]))
+        assert_array_equal(Y, np.array([[3, 3],
+                                        [4, 4]]))
+
+    def test_missing_value(self):
+        [X, Y, Z] = meshgridify([1, 1, 2], [3, 4, 3], f=[0, 1, 2])
+        assert_array_equal(X, np.array([[1, 2],
+                                        [1, 2]]))
+        assert_array_equal(Y, np.array([[3, 3],
+                                        [4, 4]]))
+        assert_array_equal(Z, np.array([[0, 2],
+                                        [1, np.nan]]))
+
+    def test_single_coordinate(self):
+        [X, Z] = meshgridify([1, 2, 3, 4], f=[4, 3, 2, 1])
+        assert_array_equal(X, np.array([1, 2, 3, 4]))
+        assert_array_equal(Z, np.array([4, 3, 2, 1]))
+
+    def test_invalid_arguments(self):
+        assert_raises(ValueError, meshgridify,
+                      [1, 2, 3], f=[4, 5, 6, 7])
 
 
 class TestPiecewise(TestCase):


### PR DESCRIPTION
This allows the direct creation of meshgrid formatted data from tabular data.
For example, for contourplots of expensively calculated data, no function has to be applied to a meshgrid to obtain the according function values. The tabular data is instead directly shaped into meshgrid format.

```
 x = np.array(0, 0, 0, 1, 1, 1, 2, 2, 2)
 y = np.array(0, 1, 2, 0, 1, 2, 0, 1, 2)
 z = np.array(0, 1, 2, 1, 2, 3, 2, 3, 4)
 plt.contourf(*meshgridify(x, y, f=z))
```
