### PR TITLE
DOC:  See also np.load and np.memmap in np.lib.format.open_memmap

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -97,6 +97,10 @@ class memmap(ndarray):
         changes to disk before removing the object.
 
 
+    See also
+    --------
+    lib.format.open_memmap : Create or load a memory-mapped ``.npy`` file.
+
     Notes
     -----
     The memmap object can be used anywhere an ndarray is accepted.

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -316,6 +316,7 @@ def load(file, mmap_mode=None, allow_pickle=True, fix_imports=True,
     --------
     save, savez, savez_compressed, loadtxt
     memmap : Create a memory-map to an array stored in a file on disk.
+    lib.format.open_memmap : Create or load a memory-mapped ``.npy`` file.
 
     Notes
     -----


### PR DESCRIPTION
`np.load` supports memmap_mode to open existing .npy files as memory-mapped files.
`np.memmap` supports creating or loading raw binary files as memory-mapped files.
Neither support creating .npy files as memory-mapped files, which is handy when writing data that is too large to keep in memory at once while still retaining the advantages of the .npy format (shape/dtype information and easy loading). `np.lib.format.open_memmap` allows just this, but is difficult to find (even if you already know it exists!).

This adds a link to `np.lib.format.open_memmap` from `np.load` and `np.memmap`.
