### PR TITLE
DOC: Include docstring for cbrt, spacing and fabs in documentation

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -508,6 +508,7 @@ Math operations
     mod
     fmod
     absolute
+    fabs
     rint
     sign
     conj
@@ -520,6 +521,7 @@ Math operations
     log1p
     sqrt
     square
+    cbrt
     reciprocal
 
 .. tip::
@@ -651,9 +653,11 @@ single operation.
     isfinite
     isinf
     isnan
+    fabs
     signbit
     copysign
     nextafter
+    spacing
     modf
     ldexp
     frexp


### PR DESCRIPTION
This includes links to `numpy.cbrt`, `numpy.spacing` and `numpy.fabs` in the list of ufuncs (http://docs.scipy.org/doc/numpy/reference/ufuncs.html#available-ufuncs). For the "math" section `numpy.cbrt` was already included in #7938

I haven't been able to build the documentation locally (not because of the PR though). So I'm not quite sure if this produces conflicts like the missing target (dead link) for `numpy.nextafter` in http://docs.scipy.org/doc/numpy/reference/ufuncs.html#floating-functions.
