### PR TITLE
BUG: Allow 'shape': () in __array_interface__ regardless of the data source

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2304,12 +2304,7 @@ PyArray_FromInterface(PyObject *origin)
 
     /* Case for data access through buffer */
     else if (attr) {
-        if (n == 0) {
-            PyErr_SetString(PyExc_ValueError,
-                    "__array_interface__ shape must be at least size 1");
-            goto fail;
-        }
-        if (attr && (attr != Py_None)) {
+        if (attr != Py_None) {
             base = attr;
         }
         else {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6188,6 +6188,32 @@ def test_array_interface_itemsize():
     assert_equal(descr_t.itemsize, typestr_t.itemsize)
 
 
+def test_array_interface_empty_shape():
+    # See gh-7994
+    arr = np.array([1, 2, 3])
+    interface1 = dict(arr.__array_interface__)
+    interface1['shape'] = ()
+
+    class DummyArray1(object):
+        __array_interface__ = interface1
+
+    # NOTE: Because Py2 str/Py3 bytes supports the buffer interface, setting
+    # the interface data to bytes would invoke the bug this tests for, that
+    # __array_interface__ with shape=() is not allowed if the data is an object
+    # exposing the buffer interface
+    interface2 = dict(interface1)
+    interface2['data'] = arr[0].tobytes()
+
+    class DummyArray2(object):
+        __array_interface__ = interface2
+
+    arr1 = np.asarray(DummyArray1())
+    arr2 = np.asarray(DummyArray2())
+    arr3 = arr[:1].reshape(())
+    assert_equal(arr1, arr2)
+    assert_equal(arr1, arr3)
+
+
 def test_flat_element_deletion():
     it = np.ones(3).flat
     try:


### PR DESCRIPTION
In [this comment](https://github.com/numpy/numpy/pull/6659#issuecomment-243188178) I mentioned a problem creating a type with an `__array_interface__` with `'shape': ()`.  This happens to work if either no `'data'` key is specified, or if `'data'` is a tuple (as in the case for actual `ndarray` instances).

However, if `'data'` is an object that exposes a buffer interface, it needlessly disallows zero-dim shapes.  This check was first added in #444, but was found in #2897 to be "unnecessary".  But #2897 only removed the check in one case, but not the other.  But my testing indicates that the check should not be necessary in either case.

It's possible there used to be bugs with this, but I don't think there are anymore.  In either case the dimensions (and ndim) are passed to `PyArray_NewFromDescr` which handles `ndim == 0` appropriately for array scalars.
