### PR TITLE
DOC: #7881 Fix the link to record arrays

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1268,7 +1268,7 @@ times the number of vectors.
 Indexing with strings
 ---------------------
 
-See `RecordArrays <RecordArrays.html>`__.
+See `RecordArrays <basics.rec.html#record-arrays>`__.
 
 Linear Algebra
 ==============


### PR DESCRIPTION
Fixes the link to record arrays in Quickstart. #7881
