### PR TITLE
MAINT: Remove leftover imp module imports.

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function
 
-import imp
 import os
 import sys
 import pickle

--- a/runtests.py
+++ b/runtests.py
@@ -60,7 +60,6 @@ sys.path.pop(0)
 import shutil
 import subprocess
 import time
-import imp
 from argparse import ArgumentParser, REMAINDER
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))


### PR DESCRIPTION
There were two remaining imports of the deprecated imp module, neither
of which seems to have been used beyond the import.
