### PR TITLE
BUG: Fix fid.close() to use os.close(fid)

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -364,7 +364,7 @@ def _can_target(cmd, arch):
     """Return true if the architecture supports the -arch flag"""
     newcmd = cmd[:]
     fid, filename = tempfile.mkstemp(suffix=".f")
-    fid.close()
+    os.close(fid)
     try:
         d = os.path.dirname(filename)
         output = os.path.splitext(filename)[0] + ".o"


### PR DESCRIPTION
The error snuk in with some other file closing fixes and found by
Warren Weckesser.

Closes gh-8013
