### PR TITLE
DOC: change all non-code instances of Numpy to NumPy

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -1,8 +1,8 @@
 Building and installing NumPy
 +++++++++++++++++++++++++++++
 
-**IMPORTANT**: the below notes are about building Numpy, which for most users
-is *not* the recommended way to install Numpy.  Instead, use either a complete
+**IMPORTANT**: the below notes are about building NumPy, which for most users
+is *not* the recommended way to install NumPy.  Instead, use either a complete
 scientific Python distribution (recommended) or a binary installer - see
 http://scipy.org/install.html.
 
@@ -39,13 +39,13 @@ nose__ http://somethingaboutorange.com/mrl/projects/nose/
 
 .. note:: 
 
-   If you want to build Numpy in order to work on Numpy itself, use
+   If you want to build NumPy in order to work on NumPy itself, use
    ``runtests.py``.  For more details, see
    http://docs.scipy.org/doc/numpy-dev/dev/development_environment.html
 
 .. note::
 
-   More extensive information on building Numpy (and Scipy) is maintained at
+   More extensive information on building NumPy (and Scipy) is maintained at
    http://scipy.org/scipylib/building/index.html
 
 
@@ -68,8 +68,8 @@ NPY_NUM_BUILD_JOBS.
 Choosing compilers
 ==================
 
-Numpy needs a C compiler, and for development versions also Cython.  A Fortran
-compiler isn't needed to build Numpy itself; the ``numpy.f2py`` tests will be
+NumPy needs a C compiler, and for development versions also Cython.  A Fortran
+compiler isn't needed to build NumPy itself; the ``numpy.f2py`` tests will be
 skipped when running the test suite if no Fortran compiler is available.  For
 building Scipy a Fortran compiler is needed though, so we include some details
 on Fortran compilers in the rest of this section.
@@ -91,7 +91,7 @@ good `application note <https://software.intel.com/en-us/articles/numpyscipy-wit
 on this.
 
 If you want to use a free compiler toolchain, the recommended compiler is MingwPy__.
-The older MinGW32 compiler set used to produce older .exe installers for Numpy
+The older MinGW32 compiler set used to produce older .exe installers for NumPy
 itself is still available at https://github.com/numpy/numpy-vendor, but not
 recommended for use anymore.
 
@@ -103,7 +103,7 @@ Building with optimized BLAS support
 
 Configuring which BLAS/LAPACK is used if you have multiple libraries installed,
 or you have only one installed but in a non-standard location, is done via a
-``site.cfg`` file.  See the ``site.cfg.example`` shipped with Numpy for more
+``site.cfg`` file.  See the ``site.cfg.example`` shipped with NumPy for more
 details.
 
 Windows
@@ -117,7 +117,7 @@ For an overview of the state of BLAS/LAPACK libraries on Windows, see
 OS X
 ----
 
-OS X ships the Accelerate framework, which Numpy can build against without any
+OS X ships the Accelerate framework, which NumPy can build against without any
 manual configuration.  Other BLAS/LAPACK implementations (OpenBLAS, Intel MKL,
 ATLAS) will also work.
 
@@ -149,7 +149,7 @@ Or by preloading a specific BLAS library with::
 Build issues
 ============
 
-If you run into build issues and need help, the Numpy
+If you run into build issues and need help, the NumPy
 `mailing list <http://scipy.org/scipylib/mailing-lists.html>`_ is the best
-place to ask.  If the issue is clearly a bug in Numpy, please file an issue (or
+place to ask.  If the issue is clearly a bug in NumPy, please file an issue (or
 even better, a pull request) at https://github.com/numpy/numpy.

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -4,7 +4,7 @@
 NumPy benchmarks
 ================
 
-Benchmarking Numpy with Airspeed Velocity.
+Benchmarking NumPy with Airspeed Velocity.
 
 
 Usage
@@ -12,11 +12,11 @@ Usage
 
 Airspeed Velocity manages building and Python virtualenvs by itself,
 unless told otherwise. Some of the benchmarking features in
-``runtests.py`` also tell ASV to use the Numpy compiled by
+``runtests.py`` also tell ASV to use the NumPy compiled by
 ``runtests.py``. To run the benchmarks, you do not need to install a
-development version of Numpy to your current Python environment.
+development version of NumPy to your current Python environment.
 
-Run a benchmark against currently checked out Numpy version (don't
+Run a benchmark against currently checked out NumPy version (don't
 record the result)::
 
     python runtests.py --bench bench_core
@@ -46,9 +46,9 @@ See `ASV documentation`_ for basics on how to write benchmarks.
 
 Some things to consider:
 
-- The benchmark suite should be importable with any Numpy version.
+- The benchmark suite should be importable with any NumPy version.
 
-- The benchmark parameters etc. should not depend on which Numpy version
+- The benchmark parameters etc. should not depend on which NumPy version
   is installed.
 
 - Try to keep the runtime of the benchmark reasonable.

--- a/doc/C_STYLE_GUIDE.rst.txt
+++ b/doc/C_STYLE_GUIDE.rst.txt
@@ -6,7 +6,7 @@ The NumPy C coding conventions are based on Python PEP-0007 by Guido van
 Rossum with a few added strictures. There are many C coding conventions and
 it must be emphasized that the primary goal of the NumPy conventions isn't
 to choose the 'best', about which there is certain to be disagreement, but
-to achieve uniformity. Because the Numpy conventions are very close to
+to achieve uniformity. Because the NumPy conventions are very close to
 those in PEP-0007, that PEP is used as a template below with the NumPy
 additions and variations in the appropriate spots.
 
@@ -17,7 +17,7 @@ Introduction
 ------------
 
 This document gives coding conventions for the C code comprising
-the C implementation of Numpy. Note, rules are there to be broken.
+the C implementation of NumPy. Note, rules are there to be broken.
 Two good reasons to break a particular rule:
 
 1. When applying the rule would make the code less readable, even
@@ -53,7 +53,7 @@ C dialect
   Note: this will change with the proposed transition to C++.
 
 * No compiler warnings with major compilers (gcc, VC++, a few others).
-  Note: Numpy still produces compiler warnings that need to be addressed.
+  Note: NumPy still produces compiler warnings that need to be addressed.
 
 
 Code lay-out
@@ -195,7 +195,7 @@ Code lay-out
 Naming conventions
 ------------------
 
-* There has been no consistent prefix for Numpy public functions, but
+* There has been no consistent prefix for NumPy public functions, but
   they all begin with a prefix of some sort, followed by an underscore, and
   are in camel case: ``PyArray_DescrAlignConverter``, ``NpyIter_GetIterNext``.
   In the future the names should be of the form ``Npy*_PublicFunction``,
@@ -213,7 +213,7 @@ Naming conventions
 Function documentation
 ----------------------
 
-Numpy doesn't have a C function documentation standard at this time, but
+NumPy doesn't have a C function documentation standard at this time, but
 needs one. Most numpy functions are not documented in the code and that
 should change. One possibility is Doxygen with a plugin so that the same
 NumPy style used for Python functions can also be used for documenting

--- a/doc/HOWTO_BUILD_DOCS.rst.txt
+++ b/doc/HOWTO_BUILD_DOCS.rst.txt
@@ -3,7 +3,7 @@ Building the NumPy API and reference docs
 =========================================
 
 We currently use Sphinx_ for generating the API and reference
-documentation for Numpy.  You will need Sphinx 1.0.1 or newer.
+documentation for NumPy.  You will need Sphinx 1.0.1 or newer.
 
 If you only want to get the documentation, note that pre-built
 versions can be found at
@@ -18,7 +18,7 @@ in several different formats.
 Instructions
 ------------
 
-If you obtained Numpy via git, get also the git submodules that contain
+If you obtained NumPy via git, get also the git submodules that contain
 additional parts required for building the documentation::
 
     git submodule init
@@ -30,15 +30,15 @@ be installed with or without completely installing Matplotlib: see the
 Matplotlib documentation for more information.
 
 Since large parts of the main documentation are stored in
-docstrings, you will need to first build Numpy, and install it so
+docstrings, you will need to first build NumPy, and install it so
 that the correct version is imported by
 
     >>> import numpy
 
-Note that you can eg. install Numpy to a temporary location and set
+Note that you can eg. install NumPy to a temporary location and set
 the PYTHONPATH environment variable appropriately.
 
-After Numpy is installed, write::
+After NumPy is installed, write::
 
     make html
 
@@ -59,11 +59,11 @@ Instead of the above, you can also do::
 
    make dist
 
-which will rebuild Numpy, install it to a temporary location, and
+which will rebuild NumPy, install it to a temporary location, and
 build the documentation in all formats. This will most likely again
 only work on Unix platforms.
 
-The documentation for Numpy distributed at http://docs.scipy.org in html and
+The documentation for NumPy distributed at http://docs.scipy.org in html and
 pdf format is also built with ``make dist``.  See `HOWTO RELEASE`_ for details on
 how to update http://docs.scipy.org.
 
@@ -73,9 +73,9 @@ how to update http://docs.scipy.org.
 Sphinx extensions
 -----------------
 
-Numpy's documentation uses several custom extensions to Sphinx.  These
+NumPy's documentation uses several custom extensions to Sphinx.  These
 are shipped in the ``sphinxext/`` directory (as git submodules, as discussed
-above), and are automatically enabled when building Numpy's documentation.
+above), and are automatically enabled when building NumPy's documentation.
 
 If you want to make use of these extensions in third-party
 projects, they are available on PyPi_ as the numpydoc_ package.

--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -141,7 +141,7 @@ The sections of the docstring are:
    A section (use if applicable) to warn users that the object is deprecated.
    Section contents should include:
 
-   * In what Numpy version the object was deprecated, and when it will be
+   * In what NumPy version the object was deprecated, and when it will be
      removed.
 
    * Reason for deprecation if this is useful information (e.g., object
@@ -154,8 +154,8 @@ The sections of the docstring are:
 
    ::
 
-     .. note:: Deprecated in Numpy 1.6
-               `ndobj_old` will be removed in Numpy 2.0, it is replaced by
+     .. note:: Deprecated in NumPy 1.6
+               `ndobj_old` will be removed in NumPy 2.0, it is replaced by
                `ndobj_new` because the latter works also with array subclasses.
 
 3. **Extended Summary**
@@ -529,7 +529,7 @@ as appropriate.
 
 Documenting class instances
 ---------------------------
-Instances of classes that are part of the Numpy API (for example `np.r_`
+Instances of classes that are part of the NumPy API (for example `np.r_`
 `np,c_`, `np.index_exp`, etc.) may require some care. To give these
 instances a useful docstring, we do the following:
 

--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -154,8 +154,8 @@ The sections of the docstring are:
 
    ::
 
-     .. note:: Deprecated in NumPy 1.6
-               `ndobj_old` will be removed in NumPy 2.0, it is replaced by
+     .. note:: Deprecated in NumPy 1.6.0
+               `ndobj_old` will be removed in NumPy 2.0.0, it is replaced by
                `ndobj_new` because the latter works also with array subclasses.
 
 3. **Extended Summary**

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -302,7 +302,7 @@ to public keyservers, with a command such as::
 
 Apply patch to fix bogus strides
 --------------------------------
-NPY_RELAXED_STRIDE_CHECKING was made the default in Numpy 1.10 and bogus
+NPY_RELAXED_STRIDE_CHECKING was made the default in NumPy 1.10 and bogus
 strides are used in the development branch to smoke out problems. The
 `patch <https://github.com/numpy/numpy/pull/5996>`_ should be updated if
 necessary and applied to the release branch to rationalize the strides.

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -302,7 +302,7 @@ to public keyservers, with a command such as::
 
 Apply patch to fix bogus strides
 --------------------------------
-NPY_RELAXED_STRIDE_CHECKING was made the default in NumPy 1.10 and bogus
+NPY_RELAXED_STRIDE_CHECKING was made the default in NumPy 1.10.0 and bogus
 strides are used in the development branch to smoke out problems. The
 `patch <https://github.com/numpy/numpy/pull/5996>`_ should be updated if
 necessary and applied to the release branch to rationalize the strides.

--- a/doc/Py3K.rst.txt
+++ b/doc/Py3K.rst.txt
@@ -11,7 +11,7 @@ Developer notes on the transition to Python 3
 General
 =======
 
-Numpy has now been ported to Python 3.
+NumPy has now been ported to Python 3.
 
 Some glitches may still be present; however, we are not aware of any
 significant ones, the test suite passes.
@@ -125,7 +125,7 @@ F2py is ported to Py3.
 Bytes vs. strings
 -----------------
 
-At many points in Numpy, bytes literals are needed. These can be created via
+At many points in NumPy, bytes literals are needed. These can be created via
 numpy.compat.asbytes and asbytes_nested.
 
 
@@ -245,7 +245,7 @@ Any new ones that need to be added should be added in this file.
 
 .. todo::
 
-   Remove PyString_* eventually -- having a call to one of these in Numpy
+   Remove PyString_* eventually -- having a call to one of these in NumPy
    sources is a sign of an error...
 
 
@@ -527,7 +527,7 @@ There are two issues related to the str/bytes change:
 This entry discusses return values etc. only, the 'S' dtype is a
 separate topic.
 
-All uses of PyString in Numpy should be changed to one of
+All uses of PyString in NumPy should be changed to one of
 
 - PyBytes: one-byte character strings in Py2 and Py3
 - PyUString (defined in npy_3kconfig.h): PyString in Py2, PyUnicode in Py3
@@ -554,7 +554,7 @@ Some specific decisions that have been made so far:
 
 * descriptor.c: dtype field names are UString
 
-  At some places in Numpy code, there are some guards for Unicode field
+  At some places in NumPy code, there are some guards for Unicode field
   names. However, the dtype constructor accepts only strings as field names,
   so we should assume field names are *always* UString.
 
@@ -604,7 +604,7 @@ PyUnicode
 PyUnicode in Py3 is pretty much as it was in Py2, except that it is
 now the only "real" string type.
 
-In Py3, Unicode and Bytes are not comparable, ie., 'a' != b'a'.  Numpy
+In Py3, Unicode and Bytes are not comparable, ie., 'a' != b'a'.  NumPy
 comparison routines were handled to act in the same way, leaving
 comparison between Unicode and Bytes undefined.
 
@@ -627,17 +627,17 @@ PyInt
 -----
 
 There is no limited-range integer type any more in Py3.  It makes no
-sense to inherit Numpy ints from Py3 ints.
+sense to inherit NumPy ints from Py3 ints.
 
 Currently, the following is done:
 
-1) Numpy's integer types no longer inherit from Python integer.
+1) NumPy's integer types no longer inherit from Python integer.
 2) int is taken dtype-equivalent to NPY_LONG
 3) ints are converted to NPY_LONG
 
 PyInt methods are currently replaced by PyLong, via macros in npy_3kcompat.h.
 
-Dtype decision rules were changed accordingly, so that Numpy understands
+Dtype decision rules were changed accordingly, so that NumPy understands
 Py3 int translate to NPY_LONG as far as dtypes are concerned.
 
 array([1]).dtype will be the default NPY_LONG integer.
@@ -645,7 +645,7 @@ array([1]).dtype will be the default NPY_LONG integer.
 .. todo::
 
    Not inheriting from `int` on Python 3 makes the following not work:
-   ``np.intp("0xff", 16)`` -- because the Numpy type does not take
+   ``np.intp("0xff", 16)`` -- because the NumPy type does not take
    the second argument. This could perhaps be fixed...
 
 
@@ -707,7 +707,7 @@ Module initialization
 
 The module initialization API changed in Python 3.1.
 
-Most Numpy modules are now converted.
+Most NumPy modules are now converted.
 
 
 PyTypeObject
@@ -871,7 +871,7 @@ obtained must be closed with fclose after use.
 
    Should probably be done much later on...
 
-   Adapt all Numpy I/O to use the PyFile_* methods or the low-level
+   Adapt all NumPy I/O to use the PyFile_* methods or the low-level
    IO routines. In any case, it's unlikely that C stdio can be used any more.
 
    Perhaps using PyFile_* makes numpy.tofile e.g. to a gzip to work?
@@ -914,4 +914,4 @@ PyCObject / PyCapsule
 The PyCObject API is removed in Python 3.2, so we need to rewrite it
 using PyCapsule.
 
-Numpy was changed to use the Capsule API, using NpyCapsule* wrappers.
+NumPy was changed to use the Capsule API, using NpyCapsule* wrappers.

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -382,5 +382,5 @@ Tests on random data are good, but since test failures are meant to expose
 new bugs or regressions, a test that passes most of the time but fails
 occasionally with no code changes is not helpful. Make the random data
 deterministic by setting the random number seed before generating it.  Use
-either Python's ``random.seed(some_number)`` or Numpy's
+either Python's ``random.seed(some_number)`` or NumPy's
 ``numpy.random.seed(some_number)``, depending on the source of random numbers.

--- a/doc/cdoc/README
+++ b/doc/cdoc/README
@@ -1,7 +1,7 @@
 cdoc
 ====
 
-This is a simple Doxygen project for building Numpy C code documentation,
+This is a simple Doxygen project for building NumPy C code documentation,
 with docstrings extracted from the C sources themselves.
 
 The understood syntax for documentation in the C source is

--- a/doc/neps/missing-data.rst
+++ b/doc/neps/missing-data.rst
@@ -884,7 +884,7 @@ a few different access patterns people use to get ahold of the numpy array data,
 here we examine a few of them to see what numpy can do. These examples are
 found from doing google searches of numpy C API array access.
 
-Numpy Documentation - How to extend NumPy
+NumPy Documentation - How to extend NumPy
 -----------------------------------------
 
 http://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html#dealing-with-array-objects

--- a/doc/neps/new-iterator-ufunc.rst
+++ b/doc/neps/new-iterator-ufunc.rst
@@ -51,7 +51,7 @@ NumPy defaults to returning C-contiguous arrays from UFuncs.  This can
 result in extremely poor memory access patterns when dealing with data
 that is structured differently.  A simple timing example illustrates
 this with a more than eight times performance hit from adding
-Fortran-contiguous arrays together.  All timings are done using Numpy
+Fortran-contiguous arrays together.  All timings are done using NumPy
 2.0dev (Nov 22, 2010) on an Athlon 64 X2 4200+, with a 64-bit OS.::
 
     In [1]: import numpy as np

--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -176,7 +176,7 @@ The ``__numpy_ufunc__`` mechanism is fully independent of Python's
 standard operator override mechanism, and the two do not interact
 directly.
 
-They however have indirect interactions, because Numpy's ``ndarray``
+They however have indirect interactions, because NumPy's ``ndarray``
 type implements its binary operations via Ufuncs. Effectively, we have::
 
     class ndarray(object):
@@ -208,14 +208,14 @@ undesirable behavior.
 
 The reason why this occurs is: because ``MyObject`` is not an ndarray
 subclass, Python resolves the expression ``b * a`` by calling first
-``b.__mul__``. Since Numpy implements this via an Ufunc, the call is
+``b.__mul__``. Since NumPy implements this via an Ufunc, the call is
 forwarded to ``__numpy_ufunc__`` and not to ``__rmul__``.  Note that if
 ``MyObject`` is a subclass of ``ndarray``, Python calls ``a.__rmul__``
 first. The issue is therefore that ``__numpy_ufunc__`` implements
 "virtual subclassing" of ndarray behavior, without actual subclassing.
 
 This issue can be resolved by a modification of the binary operation
-methods in Numpy::
+methods in NumPy::
 
     class ndarray(object):
         ...

--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -3,13 +3,13 @@
   <p><strong>Parts of the documentation:</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("user/index") }}">Numpy User Guide</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("user/index") }}">NumPy User Guide</a><br/>
          <span class="linkdescr">start here</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">Numpy Reference</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">NumPy Reference</a><br/>
          <span class="linkdescr">reference documentation</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("f2py/index") }}">F2Py Guide</a><br/>
          <span class="linkdescr">f2py documentation</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("dev/index") }}">Numpy Developer Guide</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("dev/index") }}">NumPy Developer Guide</a><br/>
          <span class="linkdescr">contributing to NumPy</span></p>
     </td></tr>
   </table>
@@ -34,28 +34,28 @@
     <td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("bugs") }}">Reporting bugs</a></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("about") }}">About NumPy</a></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("neps/index") }}">Numpy Enhancement Proposals</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("neps/index") }}">NumPy Enhancement Proposals</a><br/>
     </td><td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("release") }}">Release Notes</a></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("license") }}">License of Numpy</a></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("license") }}">License of NumPy</a></p>
     </td></tr>
   </table>
 
   <h2>Acknowledgements</h2>
   <p>
     Large parts of this manual originate from Travis E. Oliphant's book
-    <a href="http://www.tramy.us/">"Guide to Numpy"</a> (which generously entered
+    <a href="http://www.tramy.us/">"Guide to NumPy"</a> (which generously entered
     Public Domain in August 2008). The reference documentation for many of
     the functions are written by numerous contributors and developers of
-    Numpy, both prior to and during the
-    <a href="http://docs.scipy.org/numpy/">Numpy Documentation Marathon</a>.
+    NumPy, both prior to and during the
+    <a href="http://docs.scipy.org/numpy/">NumPy Documentation Marathon</a>.
   </p>
   <p>
     The preferred way to update the documentation is by submitting a pull
     request on Github (see the 
     <a href="http://docs.scipy.org/doc/numpy-dev/dev/">Developer Guide</a>.
-    The <a href="http://docs.scipy.org/numpy/">Numpy Documentation Wiki</a>
+    The <a href="http://docs.scipy.org/numpy/">NumPy Documentation Wiki</a>
     can also still be used to submit documentation fixes.
-    Please help us to further improve the Numpy documentation!
+    Please help us to further improve the NumPy documentation!
   </p>
 {% endblock %}

--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -25,7 +25,7 @@ by *Numarray* and can also be used to replace *Numarray*.
 NumPy community
 ---------------
 
-Numpy is a distributed, volunteer, open-source project. *You* can help
+NumPy is a distributed, volunteer, open-source project. *You* can help
 us make it better; if you believe something should be improved either
 in functionality or in documentation, don't hesitate to contact us --- or
 even better, contact us and participate in fixing the problem.
@@ -36,11 +36,11 @@ Our main means of communication are:
 
 - `Mailing lists <http://scipy.org/Mailing_Lists>`__
 
-- `Numpy Issues <https://github.com/numpy/numpy/issues>`__ (bug reports go here)
+- `NumPy Issues <https://github.com/numpy/numpy/issues>`__ (bug reports go here)
 
-- `Old Numpy Trac <http://projects.scipy.org/numpy>`__ (no longer used)
+- `Old NumPy Trac <http://projects.scipy.org/numpy>`__ (no longer used)
 
-More information about the development of Numpy can be found at
+More information about the development of NumPy can be found at
 http://scipy.org/Developer_Zone
 
 If you want to fix issues in this documentation, the easiest way

--- a/doc/source/bugs.rst
+++ b/doc/source/bugs.rst
@@ -5,7 +5,7 @@ Reporting bugs
 File bug reports or feature requests, and make contributions
 (e.g. code patches), by opening a "new issue" on GitHub:
 
-- Numpy Issues: http://github.com/numpy/numpy/issues
+- NumPy Issues: http://github.com/numpy/numpy/issues
 
 Please give as much information as you can in the ticket. It is extremely
 useful if you can supply a small self-contained code snippet that reproduces

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -189,7 +189,7 @@ latex_use_modindex = False
 # -----------------------------------------------------------------------------
 
 texinfo_documents = [
-  ("contents", 'numpy', 'Numpy Documentation', _stdauthor, 'Numpy',
+  ("contents", 'numpy', 'NumPy Documentation', _stdauthor, 'NumPy',
    "NumPy: array processing for numbers, strings, records, and objects.",
    'Programming',
    1),
@@ -203,7 +203,7 @@ intersphinx_mapping = {'http://docs.python.org/dev': None}
 
 
 # -----------------------------------------------------------------------------
-# Numpy extensions
+# NumPy extensions
 # -----------------------------------------------------------------------------
 
 # If we want to do a phantom import from an XML file for all autodocs

--- a/doc/source/contents.rst
+++ b/doc/source/contents.rst
@@ -1,5 +1,5 @@
 #####################
-Numpy manual contents
+NumPy manual contents
 #####################
 
 .. toctree::

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -11,7 +11,7 @@ Since NumPy contains parts written in C and Cython that need to be
 compiled before use, make sure you have the necessary compilers and Python
 development headers installed - see :ref:`building-from-source`.
 
-Having compiled code also means that importing Numpy from the development
+Having compiled code also means that importing NumPy from the development
 sources needs some additional steps, which are explained below.  For the rest
 of this chapter we assume that you have set up your git repo as described in
 :ref:`using-git`.
@@ -28,7 +28,7 @@ do one of::
     $ python runtests.py --bench
     $ python runtests.py -g -m full
 
-This builds Numpy first, so the first time it may take a few minutes.  If
+This builds NumPy first, so the first time it may take a few minutes.  If
 you specify ``-n``, the tests are run against the version of NumPy (if
 any) found on current PYTHONPATH.
 
@@ -169,7 +169,7 @@ repo, use one of::
 Debugging
 ---------
 
-Another frequently asked question is "How do I debug C code inside Numpy?".
+Another frequently asked question is "How do I debug C code inside NumPy?".
 The easiest way to do this is to first write a Python script that invokes the C
 code whose execution you want to debug. For instance ``mytest.py``::
 

--- a/doc/source/dev/gitwash/development_workflow.rst
+++ b/doc/source/dev/gitwash/development_workflow.rst
@@ -470,10 +470,10 @@ backport.
 Pushing changes to the main repo
 ================================
 
-*This is only relevant if you have commit rights to the main Numpy repo.*
+*This is only relevant if you have commit rights to the main NumPy repo.*
 
 When you have a set of "ready" changes in a feature branch ready for
-Numpy's ``master`` or ``maintenance`` branches, you can push
+NumPy's ``master`` or ``maintenance`` branches, you can push
 them to ``upstream`` as follows:
 
 1. First, merge or rebase on the target branch.

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -1,5 +1,5 @@
 #####################
-Contributing to Numpy
+Contributing to NumPy
 #####################
 
 .. toctree::

--- a/doc/source/f2py/distutils.rst
+++ b/doc/source/f2py/distutils.rst
@@ -2,7 +2,7 @@
 Using via `numpy.distutils`
 =============================
 
-:mod:`numpy.distutils` is part of Numpy extending standard Python ``distutils``
+:mod:`numpy.distutils` is part of NumPy extending standard Python ``distutils``
 to deal with Fortran sources and F2PY signature files, e.g. compile Fortran
 sources, call F2PY to construct extension modules, etc.
 

--- a/doc/source/f2py/getting-started.rst
+++ b/doc/source/f2py/getting-started.rst
@@ -95,7 +95,7 @@ Python the Fortran subroutine ``FIB`` is accessible via ``fib1.fib``::
     F2PY implements basic compatibility checks between related
     arguments in order to avoid any unexpected crashes.
 
-  * When a Numpy array, that is Fortran contiguous and has a dtype
+  * When a NumPy array, that is Fortran contiguous and has a dtype
     corresponding to presumed Fortran type, is used as an input array
     argument, then its C pointer is directly passed to Fortran.
 
@@ -209,7 +209,7 @@ In Python::
   * Clearly, the signature of ``fib2.fib`` now corresponds to the
     intention of Fortran subroutine ``FIB`` more closely: given the
     number ``n``, ``fib2.fib`` returns the first ``n`` Fibonacci numbers
-    as a Numpy array. Also, the new Python signature ``fib2.fib``
+    as a NumPy array. Also, the new Python signature ``fib2.fib``
     rules out any surprises that we experienced with ``fib1.fib``.
 
   * Note that by default using single ``intent(out)`` also implies

--- a/doc/source/f2py/python-usage.rst
+++ b/doc/source/f2py/python-usage.rst
@@ -66,7 +66,7 @@ String arguments
 
 F2PY generated wrapper functions accept (almost) any Python object as
 a string argument, ``str`` is applied for non-string objects.
-Exceptions are Numpy arrays that must have type code ``'c'`` or
+Exceptions are NumPy arrays that must have type code ``'c'`` or
 ``'1'`` when used as string arguments.
 
 A string can have arbitrary length when using it as a string argument
@@ -95,7 +95,7 @@ Array arguments
 ================
 
 In general, array arguments of F2PY generated wrapper functions accept
-arbitrary sequences that can be transformed to Numpy array objects.
+arbitrary sequences that can be transformed to NumPy array objects.
 An exception is ``intent(inout)`` array arguments that always must be
 proper-contiguous and have proper type, otherwise an exception is
 raised. Another exception is ``intent(inplace)`` array arguments that
@@ -103,13 +103,13 @@ attributes will be changed in-situ if the argument has different type
 than expected (see ``intent(inplace)`` attribute for more
 information).
 
-In general, if a Numpy array is proper-contiguous and has a proper
+In general, if a NumPy array is proper-contiguous and has a proper
 type then it is directly passed to wrapped Fortran/C function.
 Otherwise, an element-wise copy of an input array is made and the
 copy, being proper-contiguous and with proper type, is used as an
 array argument.
 
-There are two types of proper-contiguous Numpy arrays:
+There are two types of proper-contiguous NumPy arrays:
 
 * Fortran-contiguous arrays when data is stored column-wise,
   i.e. indexing of data as stored in memory starts from the lowest
@@ -130,7 +130,7 @@ and C-contiguous if the order is as follows::
   A[0,0] A[0,1] A[1,0] A[1,1]
 
 To test whether an array is C-contiguous, use ``.iscontiguous()``
-method of Numpy arrays.  To test for Fortran contiguity, all
+method of NumPy arrays.  To test for Fortran contiguity, all
 F2PY generated extension modules provide a function
 ``has_column_major_storage(<array>)``. This function is equivalent to
 ``<array>.flags.f_contiguous`` but more efficient.
@@ -313,7 +313,7 @@ with the current extension module, but not to other extension modules
 (this restriction is due to how Python imports shared libraries).  In
 Python, the F2PY wrappers to ``common`` blocks are ``fortran`` type
 objects that have (dynamic) attributes related to data members of
-common blocks. When accessed, these attributes return as Numpy array
+common blocks. When accessed, these attributes return as NumPy array
 objects (multidimensional arrays are Fortran-contiguous) that
 directly link to data members in common blocks. Data members can be
 changed by direct assignment or by in-place changes to the

--- a/doc/source/f2py/signature-file.rst
+++ b/doc/source/f2py/signature-file.rst
@@ -348,9 +348,9 @@ The following attributes are used by F2PY:
   + ``inout``
       The argument is considered as an input/output or *in situ*
       output argument. ``intent(inout)`` arguments can be only
-      "contiguous" Numpy arrays with proper type and size.  Here
+      "contiguous" NumPy arrays with proper type and size.  Here
       "contiguous" can be either in Fortran or C sense. The latter one
-      coincides with the contiguous concept used in Numpy and is
+      coincides with the contiguous concept used in NumPy and is
       effective only if ``intent(c)`` is used. Fortran contiguity
       is assumed by default.
 
@@ -360,7 +360,7 @@ The following attributes are used by F2PY:
   + ``inplace``
       The argument is considered as an input/output or *in situ*
       output argument. ``intent(inplace)`` arguments must be
-      Numpy arrays with proper size. If the type of an array is
+      NumPy arrays with proper size. If the type of an array is
       not "proper" or the array is non-contiguous then the array
       will be changed in-place to fix the type and make it contiguous.
 

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -1,5 +1,5 @@
 *************
-Numpy License
+NumPy License
 *************
 
 Copyright (c) 2005, NumPy Developers

--- a/doc/source/neps/index.rst
+++ b/doc/source/neps/index.rst
@@ -1,10 +1,10 @@
 ===========================
-Numpy Enhancement Proposals
+NumPy Enhancement Proposals
 ===========================
 
-Numpy Enhancement Proposals (NEPs) describe proposed changes to Numpy.
+NumPy Enhancement Proposals (NEPs) describe proposed changes to NumPy.
 NEPs are modeled on Python Enhancement Proposals (PEPs), and are typically
-written up when large changes to Numpy are proposed.
+written up when large changes to NumPy are proposed.
 
 This page provides an overview of all NEPs, making only a distinction between
 the ones that have been implemented and those that have not been implemented.

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -37,14 +37,14 @@ Special attributes and methods
 
 .. seealso:: :ref:`Subclassing ndarray <basics.subclassing>`
 
-Numpy provides several hooks that classes can customize:
+NumPy provides several hooks that classes can customize:
 
 .. method:: class.__numpy_ufunc__(ufunc, method, i, inputs, **kwargs)
 
    .. versionadded:: 1.11
 
    Any class (ndarray subclass or not) can define this method to
-   override behavior of Numpy's ufuncs. This works quite similarly to
+   override behavior of NumPy's ufuncs. This works quite similarly to
    Python's ``__mul__`` and other binary operation routines.
 
    - *ufunc* is the ufunc object that was called.
@@ -336,7 +336,7 @@ Record arrays (:mod:`numpy.rec`)
 .. seealso:: :ref:`routines.array-creation.rec`, :ref:`routines.dtype`,
              :ref:`arrays.dtypes`.
 
-Numpy provides the :class:`recarray` class which allows accessing the
+NumPy provides the :class:`recarray` class which allows accessing the
 fields of a structured array as attributes, and a corresponding
 scalar data type object :class:`record`.
 

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -29,14 +29,14 @@ following aspects of the data:
    pair: dtype; scalar
 
 To describe the type of scalar data, there are several :ref:`built-in
-scalar types <arrays.scalars.built-in>` in Numpy for various precision
+scalar types <arrays.scalars.built-in>` in NumPy for various precision
 of integers, floating-point numbers, *etc*. An item extracted from an
 array, *e.g.*, by indexing, will be a Python object whose type is the
 scalar type associated with the data type of the array.
 
 Note that the scalar types are not :class:`dtype` objects, even though
 they can be used in place of one whenever a data type specification is
-needed in Numpy.
+needed in NumPy.
 
 .. index::
    pair: dtype; field
@@ -459,7 +459,7 @@ Type strings
 :class:`dtype`
 ==============
 
-Numpy data type descriptions are instances of the :class:`dtype` class.
+NumPy data type descriptions are instances of the :class:`dtype` class.
 
 Attributes
 ----------

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -3,7 +3,7 @@
 Indexing
 ========
 
-.. sectionauthor:: adapted from "Guide to Numpy" by Travis E. Oliphant
+.. sectionauthor:: adapted from "Guide to NumPy" by Travis E. Oliphant
 
 .. currentmodule:: numpy
 

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -560,7 +560,7 @@ Matrix Multiplication:
 .. note::
 
    Matrix operators ``@`` and ``@=`` were introduced in Python 3.5
-   following PEP465. NumPy 1.10 has a preliminary implementation of ``@``
+   following PEP465. NumPy 1.10.0 has a preliminary implementation of ``@``
    for testing purposes. Further documentation can be found in the
    :func:`matmul` documentation.
 

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -103,7 +103,7 @@ the bytes are interpreted is defined by the :ref:`data-type object
 
 A segment of memory is inherently 1-dimensional, and there are many
 different schemes for arranging the items of an *N*-dimensional array
-in a 1-dimensional block. Numpy is flexible, and :class:`ndarray`
+in a 1-dimensional block. NumPy is flexible, and :class:`ndarray`
 objects can accommodate any *strided indexing scheme*. In a strided
 scheme, the N-dimensional index :math:`(n_0, n_1, ..., n_{N-1})`
 corresponds to the offset (in bytes):
@@ -155,7 +155,7 @@ base offset itself is a multiple of `self.itemsize`.
 .. note::
 
     Points (1) and (2) are not yet applied by default. Beginning with
-    Numpy 1.8.0, they are applied consistently only if the environment
+    NumPy 1.8.0, they are applied consistently only if the environment
     variable ``NPY_RELAXED_STRIDES_CHECKING=1`` was defined when NumPy
     was built. Eventually this will become the default.
 
@@ -440,7 +440,7 @@ Each of the arithmetic operations (``+``, ``-``, ``*``, ``/``, ``//``,
 ``%``, ``divmod()``, ``**`` or ``pow()``, ``<<``, ``>>``, ``&``,
 ``^``, ``|``, ``~``) and the comparisons (``==``, ``<``, ``>``,
 ``<=``, ``>=``, ``!=``) is equivalent to the corresponding
-:term:`universal function` (or :term:`ufunc` for short) in Numpy.  For
+:term:`universal function` (or :term:`ufunc` for short) in NumPy.  For
 more information, see the section on :ref:`Universal Functions
 <ufuncs>`.
 
@@ -560,7 +560,7 @@ Matrix Multiplication:
 .. note::
 
    Matrix operators ``@`` and ``@=`` were introduced in Python 3.5
-   following PEP465. Numpy 1.10 has a preliminary implementation of ``@``
+   following PEP465. NumPy 1.10 has a preliminary implementation of ``@``
    for testing purposes. Further documentation can be found in the
    :func:`matmul` documentation.
 

--- a/doc/source/reference/arrays.rst
+++ b/doc/source/reference/arrays.rst
@@ -20,7 +20,7 @@ with every array. In addition to basic types (integers, floats,
 
 An item extracted from an array, *e.g.*, by indexing, is represented
 by a Python object whose type is one of the :ref:`array scalar types
-<arrays.scalars>` built in Numpy. The array scalars allow easy manipulation
+<arrays.scalars>` built in NumPy. The array scalars allow easy manipulation
 of also more complicated arrangements of data.
 
 .. figure:: figures/threefundamental.png

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -94,7 +94,7 @@ Python Boolean scalar.
    :class:`int` built-in under Python 3, because type :class:`int` is no
    longer a fixed-width integer type.
 
-.. tip:: The default data type in Numpy is :class:`float_`.
+.. tip:: The default data type in NumPy is :class:`float_`.
 
 In the tables below, ``platform?`` means that the type may not be
 available on all platforms. Compatibility with different C or Python
@@ -288,4 +288,4 @@ the built-in scalar types): One way is to simply subclass the
 a degree, but internally certain behaviors are fixed by the data type of 
 the array.  To fully customize the data type of an array you need to 
 define a new data-type, and register it with NumPy. Such new types can only 
-be defined in C, using the :ref:`Numpy C-API <c-api>`.
+be defined in C, using the :ref:`NumPy C-API <c-api>`.

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -2291,7 +2291,7 @@ an element copier function as a primitive.::
 Array Iterators
 ---------------
 
-As of Numpy 1.6, these array iterators are superceded by
+As of NumPy 1.6, these array iterators are superceded by
 the new array iterator, :c:type:`NpyIter`.
 
 An array iterator is a simple way to access the elements of an

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -2291,7 +2291,7 @@ an element copier function as a primitive.::
 Array Iterators
 ---------------
 
-As of NumPy 1.6, these array iterators are superceded by
+As of NumPy 1.6.0, these array iterators are superceded by
 the new array iterator, :c:type:`NpyIter`.
 
 An array iterator is a simple way to access the elements of an

--- a/doc/source/reference/c-api.config.rst
+++ b/doc/source/reference/c-api.config.rst
@@ -4,14 +4,14 @@ System configuration
 .. sectionauthor:: Travis E. Oliphant
 
 When NumPy is built, information about system configuration is
-recorded, and is made available for extension modules using Numpy's C
+recorded, and is made available for extension modules using NumPy's C
 API.  These are mostly defined in ``numpyconfig.h`` (included in
 ``ndarrayobject.h``). The public symbols are prefixed by ``NPY_*``.
-Numpy also offers some functions for querying information about the
+NumPy also offers some functions for querying information about the
 platform in use.
 
-For private use, Numpy also constructs a ``config.h`` in the NumPy
-include directory, which is not exported by Numpy (that is a python
+For private use, NumPy also constructs a ``config.h`` in the NumPy
+include directory, which is not exported by NumPy (that is a python
 extension which use the numpy C API will not see those symbols), to
 avoid namespace pollution.
 

--- a/doc/source/reference/c-api.coremath.rst
+++ b/doc/source/reference/c-api.coremath.rst
@@ -1,4 +1,4 @@
-Numpy core libraries
+NumPy core libraries
 ====================
 
 .. sectionauthor:: David Cournapeau
@@ -10,7 +10,7 @@ Starting from numpy 1.3.0, we are working on separating the pure C,
 making the code cleaner, and enabling code reuse by other extensions outside
 numpy (scipy, etc...).
 
-Numpy core math library
+NumPy core math library
 -----------------------
 
 The numpy core math library ('npymath') is a first step in this direction. This

--- a/doc/source/reference/c-api.generalized-ufuncs.rst
+++ b/doc/source/reference/c-api.generalized-ufuncs.rst
@@ -4,7 +4,7 @@ Generalized Universal Function API
 
 There is a general need for looping over not only functions on scalars
 but also over functions on vectors (or arrays).
-This concept is realized in Numpy by generalizing the universal functions
+This concept is realized in NumPy by generalizing the universal functions
 (ufuncs).  In regular ufuncs, the elementary function is limited to
 element-by-element operations, whereas the generalized version (gufuncs)
 supports "sub-array" by "sub-array" operations.  The Perl vector library PDL
@@ -60,7 +60,7 @@ output array of the right size. If the size of a core dimension of an output
 cannot be determined from a passed in input or output array, an error will be
 raised.
 
-Note: Prior to Numpy 1.10.0, less strict checks were in place: missing core
+Note: Prior to NumPy 1.10.0, less strict checks were in place: missing core
 dimensions were created by prepending 1's to the shape as necessary, core
 dimensions with the same label were broadcast together, and undetermined
 dimensions were created with size 1.

--- a/doc/source/reference/c-api.rst
+++ b/doc/source/reference/c-api.rst
@@ -1,7 +1,7 @@
 .. _c-api:
 
 ###########
-Numpy C-API
+NumPy C-API
 ###########
 
 .. sectionauthor:: Travis E. Oliphant

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -11,7 +11,7 @@ NumPy Reference
 .. module:: numpy
 
 This reference manual details functions, modules, and objects
-included in Numpy, describing what they are and what they do.
+included in NumPy, describing what they are and what they do.
 For learning how to use NumPy, see also :ref:`user`.
 
 
@@ -31,11 +31,11 @@ Acknowledgements
 ================
 
 Large parts of this manual originate from Travis E. Oliphant's book
-`Guide to Numpy <http://www.tramy.us/>`__ (which generously entered
+`Guide to NumPy <http://www.tramy.us/>`__ (which generously entered
 Public Domain in August 2008). The reference documentation for many of
 the functions are written by numerous contributors and developers of
-Numpy, both prior to and during the
-`Numpy Documentation Marathon
+NumPy, both prior to and during the
+`NumPy Documentation Marathon
 <http://scipy.org/Developer_Zone/DocMarathon2008>`__.
 
 Please help to improve NumPy's documentation! Instructions on how to

--- a/doc/source/reference/internals.code-explanations.rst
+++ b/doc/source/reference/internals.code-explanations.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: numpy
 
 *************************
-Numpy C Code Explanations
+NumPy C Code Explanations
 *************************
 
     Fanaticism consists of redoubling your efforts when you have forgotten

--- a/doc/source/reference/internals.rst
+++ b/doc/source/reference/internals.rst
@@ -1,5 +1,5 @@
 ***************
-Numpy internals
+NumPy internals
 ***************
 
 .. toctree::

--- a/doc/source/reference/routines.help.rst
+++ b/doc/source/reference/routines.help.rst
@@ -1,6 +1,6 @@
 .. _routines.help:
 
-Numpy-specific help functions
+NumPy-specific help functions
 =============================
 
 .. currentmodule:: numpy

--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -3,7 +3,7 @@ Input and output
 
 .. currentmodule:: numpy
 
-Numpy binary files (NPY, NPZ)
+NumPy binary files (NPY, NPZ)
 -----------------------------
 .. autosummary::
    :toctree: generated/

--- a/doc/source/reference/routines.numarray.rst
+++ b/doc/source/reference/routines.numarray.rst
@@ -2,4 +2,4 @@
 Numarray compatibility
 **********************
 
-The numarray module was removed in Numpy 1.9.
+The numarray module was removed in NumPy 1.9.

--- a/doc/source/reference/routines.numarray.rst
+++ b/doc/source/reference/routines.numarray.rst
@@ -2,4 +2,4 @@
 Numarray compatibility
 **********************
 
-The numarray module was removed in NumPy 1.9.
+The numarray module was removed in NumPy 1.9.0.

--- a/doc/source/reference/routines.oldnumeric.rst
+++ b/doc/source/reference/routines.oldnumeric.rst
@@ -4,4 +4,4 @@ Old Numeric compatibility
 
 .. currentmodule:: numpy
 
-The oldnumeric module was removed in Numpy 1.9.0.
+The oldnumeric module was removed in NumPy 1.9.0.

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -32,7 +32,7 @@ Memory ranges
    shares_memory
    may_share_memory
 
-Numpy version comparison
+NumPy version comparison
 ------------------------
 .. autosummary::
    :toctree: generated/

--- a/doc/source/reference/routines.polynomials.classes.rst
+++ b/doc/source/reference/routines.polynomials.classes.rst
@@ -39,7 +39,7 @@ All of the classes have the same methods, and especially they implement the
 Python numeric operators +, -, \*, //, %, divmod, \*\*, ==,
 and !=. The last two can be a bit problematic due to floating point
 roundoff errors. We now give a quick demonstration of the various
-operations using Numpy version 1.7.0.
+operations using NumPy version 1.7.0.
 
 Basics
 ------

--- a/doc/source/reference/swig.interface-file.rst
+++ b/doc/source/reference/swig.interface-file.rst
@@ -1,4 +1,4 @@
-Numpy.i: a SWIG Interface File for NumPy
+NumPy.i: a SWIG Interface File for NumPy
 ========================================
 
 Introduction
@@ -555,7 +555,7 @@ If you get a Python error that looks like the following::
 and the argument you are passing is an integer extracted from a
 NumPy array, then you have stumbled upon this problem.  The
 solution is to modify the `SWIG`_ type conversion system to accept
-Numpy array scalars in addition to the standard integer types.
+NumPy array scalars in addition to the standard integer types.
 Fortunately, this capabilitiy has been provided for you.  Simply copy
 the file::
 

--- a/doc/source/reference/swig.interface-file.rst
+++ b/doc/source/reference/swig.interface-file.rst
@@ -1,4 +1,4 @@
-NumPy.i: a SWIG Interface File for NumPy
+numpy.i: a SWIG Interface File for NumPy
 ========================================
 
 Introduction

--- a/doc/source/reference/swig.rst
+++ b/doc/source/reference/swig.rst
@@ -1,5 +1,5 @@
 **************
-Numpy and SWIG
+NumPy and SWIG
 **************
 
 .. sectionauthor:: Bill Spotz

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: adapted from "Guide to Numpy" by Travis E. Oliphant
+.. sectionauthor:: adapted from "Guide to NumPy" by Travis E. Oliphant
 
 .. _ufuncs:
 
@@ -20,7 +20,7 @@ is, a ufunc is a ":term:`vectorized`" wrapper for a function that
 takes a fixed number of scalar inputs and produces a fixed number of
 scalar outputs.
 
-In Numpy, universal functions are instances of the
+In NumPy, universal functions are instances of the
 :class:`numpy.ufunc` class. Many of the built-in functions are
 implemented in compiled C code, but :class:`ufunc` instances can also
 be produced using the :func:`frompyfunc` factory function.

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -4,7 +4,7 @@
 Importing data with :func:`~numpy.genfromtxt`
 *********************************************
 
-Numpy provides several functions to create arrays from tabular data.
+NumPy provides several functions to create arrays from tabular data.
 We focus here on the :func:`~numpy.genfromtxt` function.
 
 In a nutshell, :func:`~numpy.genfromtxt` runs two main loops.  The first
@@ -325,7 +325,7 @@ takes any format string::
 Validating names
 ----------------
 
-Numpy arrays with a structured dtype can also be viewed as
+NumPy arrays with a structured dtype can also be viewed as
 :class:`~numpy.recarray`, where a field can be accessed as if it were an
 attribute.  For that reason, we may need to make sure that the field name
 doesn't contain any space or invalid character, or that it does not

--- a/doc/source/user/basics.io.rst
+++ b/doc/source/user/basics.io.rst
@@ -1,5 +1,5 @@
 **************
-I/O with Numpy
+I/O with NumPy
 **************
 
 .. toctree::

--- a/doc/source/user/basics.rst
+++ b/doc/source/user/basics.rst
@@ -1,5 +1,5 @@
 ************
-Numpy basics
+NumPy basics
 ************
 
 .. toctree::

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -47,8 +47,8 @@ Building NumPy requires the following software installed:
 
 4) Cython
 
-   To build development versions of Numpy, you'll need a recent version of
-   Cython.  Released Numpy sources on PyPi include the C files generated from
+   To build development versions of NumPy, you'll need a recent version of
+   Cython.  Released NumPy sources on PyPi include the C files generated from
    Cython code, so for released versions having Cython installed isn't needed.
 
 Basic Installation
@@ -121,7 +121,7 @@ is almost always a very bad idea.
 Disabling ATLAS and other accelerated libraries
 -----------------------------------------------
 
-Usage of ATLAS and other accelerated libraries in Numpy can be disabled
+Usage of ATLAS and other accelerated libraries in NumPy can be disabled
 via::
 
     BLAS=None LAPACK=None ATLAS=None python setup.py build

--- a/doc/source/user/c-info.rst
+++ b/doc/source/user/c-info.rst
@@ -1,5 +1,5 @@
 #################
-Using Numpy C-API
+Using NumPy C-API
 #################
 
 .. toctree::

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -18,7 +18,7 @@ Before reading this, it may help to familiarize yourself with the basics
 of C extensions for Python by reading/skimming the tutorials in Section 1
 of `Extending and Embedding the Python Interpreter
 <http://docs.python.org/extending/index.html>`_ and in `How to extend
-Numpy <http://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html>`_
+NumPy <http://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html>`_
 
 The umath module is a computer-generated C-module that creates many
 ufuncs. It provides a great many examples of how to create a universal
@@ -245,9 +245,9 @@ logit ufuncs constructed below, the logit ufuncs were almost exactly
 depending on the nature of the function.
 
 
-.. _`sec:Numpy-one-loop`:
+.. _`sec:NumPy-one-loop`:
 
-Example Numpy ufunc for one dtype
+Example NumPy ufunc for one dtype
 =================================
 
 .. index::
@@ -273,7 +273,7 @@ the primary thing that must be changed to create your own ufunc.
         /*
          * single_type_logit.c
          * This is the C code for creating your own
-         * Numpy ufunc for a logit function.
+         * NumPy ufunc for a logit function.
          *
          * In this code we only define the ufunc for
          * a single dtype. The computations that must
@@ -443,9 +443,9 @@ array([       -inf, -1.09861229,  0.        ,  1.09861229,         inf])
 
 
 
-.. _`sec:Numpy-many-loop`:
+.. _`sec:NumPy-many-loop`:
 
-Example Numpy ufunc with multiple dtypes
+Example NumPy ufunc with multiple dtypes
 ========================================
 
 .. index::
@@ -473,7 +473,7 @@ the primary thing that must be changed to create your own ufunc.
         /*
          * multi_type_logit.c
          * This is the C code for creating your own
-         * Numpy ufunc for a logit function.
+         * NumPy ufunc for a logit function.
          *
          * Each function of the form type_logit defines the
          * logit function for a different numpy dtype. Each
@@ -728,9 +728,9 @@ array([       -inf, -1.09861229,  0.        ,  1.09861229,         inf])
 
 
 
-.. _`sec:Numpy-many-arg`:
+.. _`sec:NumPy-many-arg`:
 
-Example Numpy ufunc with multiple arguments/return values
+Example NumPy ufunc with multiple arguments/return values
 =========================================================
 
 Our final example is a ufunc with multiple arguments. It is a modification
@@ -738,7 +738,7 @@ of the code for a logit ufunc for data with a single dtype. We
 compute (A*B, logit(A*B)).
 
 We only give the C code as the setup.py file is exactly the same as
-the setup.py file in `Example Numpy ufunc for one dtype`_, except that
+the setup.py file in `Example NumPy ufunc for one dtype`_, except that
 the line
 
     .. code-block:: python
@@ -767,7 +767,7 @@ as well as all other properties of a ufunc.
         /*
          * multi_arg_logit.c
          * This is the C code for creating your own
-         * Numpy ufunc for a multiple argument, multiple
+         * NumPy ufunc for a multiple argument, multiple
          * return value ufunc. The places where the
          * ufunc computation is carried out are marked
          * with comments.
@@ -885,9 +885,9 @@ as well as all other properties of a ufunc.
         #endif
 
 
-.. _`sec:Numpy-struct-dtype`:
+.. _`sec:NumPy-struct-dtype`:
 
-Example Numpy ufunc with structured array dtype arguments
+Example NumPy ufunc with structured array dtype arguments
 =========================================================
 
 This example shows how to create a ufunc for a structured array dtype.
@@ -898,7 +898,7 @@ custom dtypes and structured array dtypes. We need to also call
 PyUFunc_RegisterLoopForDescr to finish setting up the ufunc.
 
 We only give the C code as the setup.py file is exactly the same as
-the setup.py file in `Example Numpy ufunc for one dtype`_, except that
+the setup.py file in `Example NumPy ufunc for one dtype`_, except that
 the line
 
     .. code-block:: python
@@ -925,7 +925,7 @@ The C file is given below.
         /*
          * add_triplet.c
          * This is the C code for creating your own
-         * Numpy ufunc for a structured array dtype.
+         * NumPy ufunc for a structured array dtype.
          *
          * Details explaining the Python-C API can be found under
          * 'Extending and Embedding' and 'Python/C API' at

--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -1,7 +1,7 @@
 .. _numpy-for-matlab-users:
 
 ======================
-Numpy for Matlab users
+NumPy for Matlab users
 ======================
 
 Introduction
@@ -63,7 +63,7 @@ Some Key Differences
 'array' or 'matrix'? Which should I use?
 ========================================
 
-Numpy provides, in addition to ``np.ndarray``, an additional matrix type
+NumPy provides, in addition to ``np.ndarray``, an additional matrix type
 that you may see used in some existing code. Which one to use?
 
 Short answer
@@ -84,7 +84,7 @@ product, matrix vector multiplication etc.).
 Long answer
 -----------
 
-Numpy contains both an ``array`` class and a ``matrix`` class. The
+NumPy contains both an ``array`` class and a ``matrix`` class. The
 ``array`` class is intended to be a general-purpose n-dimensional array
 for many kinds of numerical computing, while ``matrix`` is intended to
 facilitate linear algebra computations specifically. In practice there
@@ -171,7 +171,7 @@ The ``array`` is thus much more advisable to use.
 Facilities for Matrix Users
 ===========================
 
-Numpy has some features that facilitate the use of the ``matrix`` type,
+NumPy has some features that facilitate the use of the ``matrix`` type,
 which hopefully make things easier for Matlab converts.
 
 -  A ``matlib`` module has been added that contains matrix versions of
@@ -521,21 +521,21 @@ Linear Algebra Equivalents
 
    * - ``a & b``
      - ``logical_and(a,b)``
-     - element-by-element AND operator (Numpy ufunc) :ref:`See note
+     - element-by-element AND operator (NumPy ufunc) :ref:`See note
        LOGICOPS <numpy-for-matlab-users.notes>`
 
    * - ``a | b``
      - ``logical_or(a,b)``
-     - element-by-element OR operator (Numpy ufunc) :ref:`See note LOGICOPS
+     - element-by-element OR operator (NumPy ufunc) :ref:`See note LOGICOPS
        <numpy-for-matlab-users.notes>`
 
    * - ``bitand(a,b)``
      - ``a & b``
-     - bitwise AND operator (Python native and Numpy ufunc)
+     - bitwise AND operator (Python native and NumPy ufunc)
 
    * - ``bitor(a,b)``
      - ``a | b``
-     - bitwise OR operator (Python native and Numpy ufunc)
+     - bitwise OR operator (Python native and NumPy ufunc)
 
    * - ``inv(a)``
      - ``linalg.inv(a)``
@@ -657,41 +657,41 @@ numpy to have a similarly terse range construction mechanism. Note that
 *indexed* using square brackets, which allows the use of Python's slice
 syntax in the arguments.
 
-\ **LOGICOPS**: & or \| in Numpy is bitwise AND/OR, while in Matlab &
+\ **LOGICOPS**: & or \| in NumPy is bitwise AND/OR, while in Matlab &
 and \| are logical AND/OR. The difference should be clear to anyone with
 significant programming experience. The two can appear to work the same,
 but there are important differences. If you would have used Matlab's &
-or \| operators, you should use the Numpy ufuncs
+or \| operators, you should use the NumPy ufuncs
 logical\_and/logical\_or. The notable differences between Matlab's and
-Numpy's & and \| operators are:
+NumPy's & and \| operators are:
 
--  Non-logical {0,1} inputs: Numpy's output is the bitwise AND of the
+-  Non-logical {0,1} inputs: NumPy's output is the bitwise AND of the
    inputs. Matlab treats any non-zero value as 1 and returns the logical
-   AND. For example (3 & 4) in Numpy is 0, while in Matlab both 3 and 4
+   AND. For example (3 & 4) in NumPy is 0, while in Matlab both 3 and 4
    are considered logical true and (3 & 4) returns 1.
 
--  Precedence: Numpy's & operator is higher precedence than logical
+-  Precedence: NumPy's & operator is higher precedence than logical
    operators like < and >; Matlab's is the reverse.
 
 If you know you have boolean arguments, you can get away with using
-Numpy's bitwise operators, but be careful with parentheses, like this: z
-= (x > 1) & (x < 2). The absence of Numpy operator forms of logical\_and
+NumPy's bitwise operators, but be careful with parentheses, like this: z
+= (x > 1) & (x < 2). The absence of NumPy operator forms of logical\_and
 and logical\_or is an unfortunate consequence of Python's design.
 
 **RESHAPE and LINEAR INDEXING**: Matlab always allows multi-dimensional
-arrays to be accessed using scalar or linear indices, Numpy does not.
+arrays to be accessed using scalar or linear indices, NumPy does not.
 Linear indices are common in Matlab programs, e.g. find() on a matrix
-returns them, whereas Numpy's find behaves differently. When converting
+returns them, whereas NumPy's find behaves differently. When converting
 Matlab code it might be necessary to first reshape a matrix to a linear
 sequence, perform some indexing operations and then reshape back. As
 reshape (usually) produces views onto the same storage, it should be
 possible to do this fairly efficiently. Note that the scan order used by
-reshape in Numpy defaults to the 'C' order, whereas Matlab uses the
+reshape in NumPy defaults to the 'C' order, whereas Matlab uses the
 Fortran order. If you are simply converting to a linear sequence and
 back this doesn't matter. But if you are converting reshapes from Matlab
 code which relies on the scan order, then this Matlab code: z =
 reshape(x,3,4); should become z = x.reshape(3,4,order='F').copy() in
-Numpy.
+NumPy.
 
 Customizing Your Environment
 ============================

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -25,7 +25,7 @@ The Basics
 
 NumPy's main object is the homogeneous multidimensional array. It is a
 table of elements (usually numbers), all of the same type, indexed by a
-tuple of positive integers. In Numpy dimensions are called *axes*. The
+tuple of positive integers. In NumPy dimensions are called *axes*. The
 number of axes is *rank*.
 
 For example, the coordinates of a point in 3D space ``[1, 2, 1]`` is an
@@ -39,7 +39,7 @@ length of 3.
     [[ 1., 0., 0.],
      [ 0., 1., 2.]]
 
-Numpy's array class is called ``ndarray``. It is also known by the alias
+NumPy's array class is called ``ndarray``. It is also known by the alias
 ``array``. Note that ``numpy.array`` is not the same as the Standard
 Python Library class ``array.array``, which only handles one-dimensional
 arrays and offers less functionality. The more important attributes of
@@ -612,7 +612,7 @@ The shape of an array can be changed with various commands:
 The order of the elements in the array resulting from ravel() is
 normally "C-style", that is, the rightmost index "changes the fastest",
 so the element after a[0,0] is a[0,1]. If the array is reshaped to some
-other shape, again the array is treated as "C-style". Numpy normally
+other shape, again the array is treated as "C-style". NumPy normally
 creates arrays stored in this order, so ravel() will usually not need to
 copy its argument, but if the array was made by taking slices of another
 array or created with unusual options, it may need to be copied. The

--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -2,7 +2,7 @@
 """
 summarize.py
 
-Show a summary about which Numpy functions are documented and which are not.
+Show a summary about which NumPy functions are documented and which are not.
 
 """
 from __future__ import division, absolute_import, print_function
@@ -114,7 +114,7 @@ def check_numpy():
 
 def get_undocumented(documented, module, module_name=None, skip=[]):
     """
-    Find out which items in Numpy are not documented.
+    Find out which items in NumPy are not documented.
 
     Returns
     -------

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -65,7 +65,7 @@ fft
 polynomial
     Polynomial tools
 testing
-    Numpy testing tools
+    NumPy testing tools
 f2py
     Fortran to Python Interface Generator.
 distutils
@@ -83,7 +83,7 @@ dual
 matlib
     Make everything matrices.
 __version__
-    Numpy version string
+    NumPy version string
 
 Viewing documentation using IPython
 -----------------------------------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2014,7 +2014,7 @@ add_newdoc('numpy.core', 'matmul',
       were elements.
 
     .. warning::
-       This function is preliminary and included in NumPy 1.10 for testing
+       This function is preliminary and included in NumPy 1.10.0 for testing
        and documentation. Its semantics will not change, but the number and
        order of the optional arguments will.
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -296,7 +296,7 @@ add_newdoc('numpy.core', 'nditer',
     Notes
     -----
     `nditer` supersedes `flatiter`.  The iterator implementation behind
-    `nditer` is also exposed by the Numpy C API.
+    `nditer` is also exposed by the NumPy C API.
 
     The Python exposure supplies two iteration interfaces, one which follows
     the Python iterator protocol, and another which mirrors the C-style
@@ -570,7 +570,7 @@ add_newdoc('numpy.core', 'broadcast', ('ndim',
 
 add_newdoc('numpy.core', 'broadcast', ('nd',
     """
-    Number of dimensions of broadcasted result. For code intended for Numpy
+    Number of dimensions of broadcasted result. For code intended for NumPy
     1.12.0 and later the more consistent `ndim` is preferred.
 
     Examples
@@ -2014,7 +2014,7 @@ add_newdoc('numpy.core', 'matmul',
       were elements.
 
     .. warning::
-       This function is preliminary and included in Numpy 1.10 for testing
+       This function is preliminary and included in NumPy 1.10 for testing
        and documentation. Its semantics will not change, but the number and
        order of the optional arguments will.
 
@@ -4841,7 +4841,7 @@ add_newdoc('numpy.core.umath', 'frompyfunc',
     """
     frompyfunc(func, nin, nout)
 
-    Takes an arbitrary Python function and returns a Numpy ufunc.
+    Takes an arbitrary Python function and returns a NumPy ufunc.
 
     Can be used, for example, to add broadcasting to a built-in Python
     function (see Examples section).
@@ -4858,7 +4858,7 @@ add_newdoc('numpy.core.umath', 'frompyfunc',
     Returns
     -------
     out : ufunc
-        Returns a Numpy universal function (``ufunc``) object.
+        Returns a NumPy universal function (``ufunc``) object.
 
     See Also
     --------
@@ -4888,7 +4888,7 @@ add_newdoc('numpy.core.umath', 'geterrobj',
     Return the current object that defines floating-point error handling.
 
     The error object contains all information that defines the error handling
-    behavior in Numpy. `geterrobj` is used internally by the other
+    behavior in NumPy. `geterrobj` is used internally by the other
     functions that get and set error handling behavior (`geterr`, `seterr`,
     `geterrcall`, `seterrcall`).
 
@@ -4952,7 +4952,7 @@ add_newdoc('numpy.core.umath', 'seterrobj',
     Set the object that defines floating-point error handling.
 
     The error object contains all information that defines the error handling
-    behavior in Numpy. `seterrobj` is used internally by the other
+    behavior in NumPy. `seterrobj` is used internally by the other
     functions that set error handling behavior (`seterr`, `seterrcall`).
 
     Parameters
@@ -5028,7 +5028,7 @@ add_newdoc('numpy.core.multiarray', 'digitize',
     Parameters
     ----------
     x : array_like
-        Input array to be binned. Prior to Numpy 1.10.0, this array had to
+        Input array to be binned. Prior to NumPy 1.10.0, this array had to
         be 1-dimensional, but can now have any shape.
     bins : array_like
         Array of bins. It has to be 1-dimensional and monotonic.
@@ -6235,7 +6235,7 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('isbuiltin',
     2  if the dtype is for a user-defined numpy type
        A user-defined type uses the numpy C-API machinery to extend
        numpy to handle a new array type. See
-       :ref:`user.user-defined-data-types` in the Numpy manual.
+       :ref:`user.user-defined-data-types` in the NumPy manual.
     =  ========================================================================
 
     Examples
@@ -7623,7 +7623,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 ##############################################################################
 
 add_newdoc('numpy.core.numerictypes', 'bool_',
-    """Numpy's Boolean type.  Character code: ``?``.  Alias: bool8""")
+    """NumPy's Boolean type.  Character code: ``?``.  Alias: bool8""")
 
 add_newdoc('numpy.core.numerictypes', 'complex64',
     """

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -366,7 +366,7 @@ def _view_is_safe(oldtype, newtype):
     return
 
 # Given a string containing a PEP 3118 format specifier,
-# construct a Numpy dtype
+# construct a NumPy dtype
 
 _pep3118_native_map = {
     '?': '?',

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -22,7 +22,7 @@
 
 # Version 9 (NumPy 1.8) Added interface for partition functions,
 # PyArray_NEW_ZEROED, commented out as the hash changed in
-# NumPy 1.9 due to annotation.
+# NumPy 1.9.0 due to annotation.
 #0x00000009 = 327bd114df09c2eb7a0bcc6901e2a3ed
 
 # Version 9 (NumPy 1.9) Added function annotations.

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -22,7 +22,7 @@
 
 # Version 9 (NumPy 1.8) Added interface for partition functions,
 # PyArray_NEW_ZEROED, commented out as the hash changed in
-# Numpy 1.9 due to annotation.
+# NumPy 1.9 due to annotation.
 #0x00000009 = 327bd114df09c2eb7a0bcc6901e2a3ed
 
 # Version 9 (NumPy 1.9) Added function annotations.

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -151,7 +151,7 @@ void *PyArray_API[] = {
 
 c_api_header = """
 ===========
-Numpy C-API
+NumPy C-API
 ===========
 """
 

--- a/numpy/core/code_generators/generate_ufunc_api.py
+++ b/numpy/core/code_generators/generate_ufunc_api.py
@@ -204,7 +204,7 @@ def do_generate_api(targets, sources):
     fid = open(doc_file, 'w')
     fid.write('''
 =================
-Numpy Ufunc C-API
+NumPy Ufunc C-API
 =================
 ''')
     for func in ufunc_api_list:

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1530,7 +1530,7 @@ add_newdoc('numpy.core.umath', 'isfinite',
     Not a Number, positive infinity and negative infinity are considered
     to be non-finite.
 
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
     Also that positive infinity is not equivalent to negative infinity. But
     infinity is equivalent to positive infinity.  Errors result if the
@@ -1597,7 +1597,7 @@ add_newdoc('numpy.core.umath', 'isinf',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754).
 
     Errors result if the second argument is supplied when the first
@@ -1650,7 +1650,7 @@ add_newdoc('numpy.core.umath', 'isnan',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
 
     Examples

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1680,7 +1680,7 @@ class chararray(ndarray):
        `dtype` `object_`, `string_` or `unicode_`, and use the free functions
        in the `numpy.char` module for fast vectorized string operations.
 
-    Versus a regular Numpy array of type `str` or `unicode`, this
+    Versus a regular NumPy array of type `str` or `unicode`, this
     class adds the following functionality:
 
       1) values automatically have whitespace removed from the end
@@ -1817,7 +1817,7 @@ class chararray(ndarray):
         else:
             dtype = string_
 
-        # force itemsize to be a Python long, since using Numpy integer
+        # force itemsize to be a Python long, since using NumPy integer
         # types results in itemsize.itemsize being used as the size of
         # strings in the new array.
         itemsize = long(itemsize)
@@ -2486,7 +2486,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
        in :mod:`numpy.char <numpy.core.defchararray>` for fast
        vectorized string operations instead.
 
-    Versus a regular Numpy array of type `str` or `unicode`, this
+    Versus a regular NumPy array of type `str` or `unicode`, this
     class adds the following functionality:
 
       1) values automatically have whitespace removed from the end
@@ -2552,12 +2552,12 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
             if sys.maxunicode == 0xffff:
                 # On a narrow Python build, the buffer for Unicode
                 # strings is UCS2, which doesn't match the buffer for
-                # Numpy Unicode types, which is ALWAYS UCS4.
+                # NumPy Unicode types, which is ALWAYS UCS4.
                 # Therefore, we need to convert the buffer.  On Python
                 # 2.6 and later, we can use the utf_32 codec.  Earlier
                 # versions don't have that codec, so we convert to a
                 # numerical array that matches the input buffer, and
-                # then use Numpy to convert it to UCS4.  All of this
+                # then use NumPy to convert it to UCS4.  All of this
                 # should happen in native endianness.
                 if sys.hexversion >= 0x2060000:
                     obj = obj.encode('utf_32')
@@ -2593,7 +2593,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
             itemsize = obj.itemsize
             # itemsize is in 8-bit chars, so for Unicode, we need
             # to divide by the size of a single Unicode character,
-            # which for Numpy is always 4
+            # which for NumPy is always 4
             if issubclass(obj.dtype.type, unicode_):
                 itemsize //= 4
 
@@ -2642,7 +2642,7 @@ def asarray(obj, itemsize=None, unicode=None, order=None):
     Convert the input to a `chararray`, copying the data only if
     necessary.
 
-    Versus a regular Numpy array of type `str` or `unicode`, this
+    Versus a regular NumPy array of type `str` or `unicode`, this
     class adds the following functionality:
 
       1) values automatically have whitespace removed from the end

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -471,8 +471,8 @@ def swapaxes(a, axis1, axis2):
     Returns
     -------
     a_swapped : ndarray
-        For Numpy >= 1.10, if `a` is an ndarray, then a view of `a` is
-        returned; otherwise a new array is created. For earlier Numpy
+        For NumPy >= 1.10, if `a` is an ndarray, then a view of `a` is
+        returned; otherwise a new array is created. For earlier NumPy
         versions a view of `a` is returned only if the order of the
         axes is changed, otherwise the input array is returned.
 
@@ -1059,7 +1059,7 @@ def searchsorted(a, v, side='left', sorter=None):
     -----
     Binary search is used to find the required insertion points.
 
-    As of Numpy 1.4.0 `searchsorted` works with real/complex arrays containing
+    As of NumPy 1.4.0 `searchsorted` works with real/complex arrays containing
     `nan` values. The enhanced sort order is documented in `sort`.
 
     Examples
@@ -2631,7 +2631,7 @@ def rank(a):
     Notes
     -----
     In the old Numeric package, `rank` was the term used for the number of
-    dimensions, but in Numpy `ndim` is used instead.
+    dimensions, but in NumPy `ndim` is used instead.
 
     Examples
     --------
@@ -2737,7 +2737,7 @@ def around(a, decimals=0, out=None):
 
     Notes
     -----
-    For values exactly halfway between rounded decimal values, Numpy
+    For values exactly halfway between rounded decimal values, NumPy
     rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0,
     -0.5 and 0.5 round to 0.0, etc. Results may also be surprising due
     to the inexact representation of decimal fractions in the IEEE

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -471,7 +471,7 @@ def swapaxes(a, axis1, axis2):
     Returns
     -------
     a_swapped : ndarray
-        For NumPy >= 1.10, if `a` is an ndarray, then a view of `a` is
+        For NumPy >= 1.10.0, if `a` is an ndarray, then a view of `a` is
         returned; otherwise a new array is created. For earlier NumPy
         versions a view of `a` is returned only if the order of the
         axes is changed, otherwise the input array is returned.

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -372,21 +372,21 @@ typedef struct {npy_longdouble real, imag;} npy_clongdouble;
 #endif
 #if NPY_SIZEOF_COMPLEX_DOUBLE != 2 * NPY_SIZEOF_DOUBLE
 #error npy_cdouble definition is not compatible with C99 complex definition ! \
-        Please contact Numpy maintainers and give detailed information about your \
+        Please contact NumPy maintainers and give detailed information about your \
         compiler and platform
 #endif
 typedef struct { double real, imag; } npy_cdouble;
 
 #if NPY_SIZEOF_COMPLEX_FLOAT != 2 * NPY_SIZEOF_FLOAT
 #error npy_cfloat definition is not compatible with C99 complex definition ! \
-        Please contact Numpy maintainers and give detailed information about your \
+        Please contact NumPy maintainers and give detailed information about your \
         compiler and platform
 #endif
 typedef struct { float real, imag; } npy_cfloat;
 
 #if NPY_SIZEOF_COMPLEX_LONGDOUBLE != 2 * NPY_SIZEOF_LONGDOUBLE
 #error npy_clongdouble definition is not compatible with C99 complex definition ! \
-        Please contact Numpy maintainers and give detailed information about your \
+        Please contact NumPy maintainers and give detailed information about your \
         compiler and platform
 #endif
 typedef struct { npy_longdouble real, imag; } npy_clongdouble;

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -21,7 +21,7 @@ class memmap(ndarray):
     """Create a memory-map to an array stored in a *binary* file on disk.
 
     Memory-mapped files are used for accessing small segments of large files
-    on disk, without reading the entire file into memory.  Numpy's
+    on disk, without reading the entire file into memory.  NumPy's
     memmap's are array-like objects.  This differs from Python's ``mmap``
     module, which uses file-like objects.
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1505,7 +1505,7 @@ def rollaxis(a, axis, start=0):
     Returns
     -------
     res : ndarray
-        For NumPy >= 1.10 a view of `a` is always returned. For earlier
+        For NumPy >= 1.10.0 a view of `a` is always returned. For earlier
         NumPy versions a view of `a` is returned only if the order of the
         axes is changed, otherwise the input array is returned.
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -759,7 +759,7 @@ def isfortran(a):
 
     This function is obsolete and, because of changes due to relaxed stride
     checking, its return value for the same array may differ for versions
-    of NumPy >= 1.10 and previous versions. If you only want to check if an
+    of NumPy >= 1.10.0 and previous versions. If you only want to check if an
     array is Fortran contiguous use ``a.flags.f_contiguous`` instead.
 
     Parameters
@@ -1170,7 +1170,7 @@ def alterdot():
     arrays with larger dimensionalities use the built in functions and are
     not accelerated.
 
-    .. note:: Deprecated in NumPy 1.10
+    .. note:: Deprecated in NumPy 1.10.0
               The cblas functions have been integrated into the multarray
               module and alterdot now longer does anything. It will be
               removed in NumPy 1.11.0.
@@ -1195,7 +1195,7 @@ def restoredot():
     an accelerated BLAS, or when being very careful about benchmarking
     linear algebra operations.
 
-    .. note:: Deprecated in NumPy 1.10
+    .. note:: Deprecated in NumPy 1.10.0
               The cblas functions have been integrated into the multarray
               module and restoredot now longer does anything. It will be
               removed in NumPy 1.11.0.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -759,7 +759,7 @@ def isfortran(a):
 
     This function is obsolete and, because of changes due to relaxed stride
     checking, its return value for the same array may differ for versions
-    of Numpy >= 1.10 and previous versions. If you only want to check if an
+    of NumPy >= 1.10 and previous versions. If you only want to check if an
     array is Fortran contiguous use ``a.flags.f_contiguous`` instead.
 
     Parameters
@@ -1158,11 +1158,11 @@ def alterdot():
     """
     Change `dot`, `vdot`, and `inner` to use accelerated BLAS functions.
 
-    Typically, as a user of Numpy, you do not explicitly call this
-    function. If Numpy is built with an accelerated BLAS, this function is
-    automatically called when Numpy is imported.
+    Typically, as a user of NumPy, you do not explicitly call this
+    function. If NumPy is built with an accelerated BLAS, this function is
+    automatically called when NumPy is imported.
 
-    When Numpy is built with an accelerated BLAS like ATLAS, these
+    When NumPy is built with an accelerated BLAS like ATLAS, these
     functions are replaced to make use of the faster implementations.  The
     faster implementations only affect float32, float64, complex64, and
     complex128 arrays. Furthermore, the BLAS API only includes
@@ -1170,10 +1170,10 @@ def alterdot():
     arrays with larger dimensionalities use the built in functions and are
     not accelerated.
 
-    .. note:: Deprecated in Numpy 1.10
+    .. note:: Deprecated in NumPy 1.10
               The cblas functions have been integrated into the multarray
               module and alterdot now longer does anything. It will be
-              removed in Numpy 1.11.0.
+              removed in NumPy 1.11.0.
 
     See Also
     --------
@@ -1195,10 +1195,10 @@ def restoredot():
     an accelerated BLAS, or when being very careful about benchmarking
     linear algebra operations.
 
-    .. note:: Deprecated in Numpy 1.10
+    .. note:: Deprecated in NumPy 1.10
               The cblas functions have been integrated into the multarray
               module and restoredot now longer does anything. It will be
-              removed in Numpy 1.11.0.
+              removed in NumPy 1.11.0.
 
     See Also
     --------
@@ -1505,8 +1505,8 @@ def rollaxis(a, axis, start=0):
     Returns
     -------
     res : ndarray
-        For Numpy >= 1.10 a view of `a` is always returned. For earlier
-        Numpy versions a view of `a` is returned only if the order of the
+        For NumPy >= 1.10 a view of `a` is always returned. For earlier
+        NumPy versions a view of `a` is returned only if the order of the
         axes is changed, otherwise the input array is returned.
 
     See Also

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -387,7 +387,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             break;
         }
         case NPY_UNICODE: {
-            /* Numpy Unicode is always 4-byte */
+            /* NumPy Unicode is always 4-byte */
             char buf[128];
             assert(descr->elsize % 4 == 0);
             PyOS_snprintf(buf, sizeof(buf), "%dw", descr->elsize / 4);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1646,7 +1646,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         Py_INCREF(rawdata);
 
 #if defined(NPY_PY3K)
-        /* Backward compatibility with Python 2 Numpy pickles */
+        /* Backward compatibility with Python 2 NumPy pickles */
         if (PyUnicode_Check(rawdata)) {
             PyObject *tmp;
             tmp = PyUnicode_AsLatin1String(rawdata);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1895,7 +1895,7 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
         }
         else {
 #if defined(NPY_PY3K)
-            /* Backward compatibility with Python 2 Numpy pickles */
+            /* Backward compatibility with Python 2 NumPy pickles */
             if (PyUnicode_Check(obj)) {
                 tmpobj = PyUnicode_AsLatin1String(obj);
                 obj = tmpobj;

--- a/numpy/core/src/umath/struct_ufunc_test.c.src
+++ b/numpy/core/src/umath/struct_ufunc_test.c.src
@@ -10,7 +10,7 @@
 /*
  * struct_ufunc_test.c
  * This is the C code for creating your own
- * Numpy ufunc for a structured array dtype.
+ * NumPy ufunc for a structured array dtype.
  *
  * Details explaining the Python-C API can be found under
  * 'Extending and Embedding' and 'Python/C API' at

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -731,7 +731,7 @@ static PyTypeObject PyRational_Type = {
     0,                                        /* tp_version_tag */
 };
 
-/* Numpy support */
+/* NumPy support */
 
 static PyObject*
 npyrational_getitem(void* data, void* arr) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2047,7 +2047,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      * Validate the core dimensions of all the operands, and collect all of
      * the labelled core dimensions into 'core_dim_sizes'.
      *
-     * The behavior has been changed in Numpy 1.10.0, and the following
+     * The behavior has been changed in NumPy 1.10.0, and the following
      * requirements must be fulfilled or an error will be raised:
      *  * Arguments, both input and output, must have at least as many
      *    dimensions as the corresponding number of core dimensions. In

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -296,7 +296,7 @@ class TestIndexing(TestCase):
         assert_raises(IndexError, a.__getitem__, (np.array([0]),) * 32)
 
     def test_scalar_array_bool(self):
-        # Numpy bools can be used as boolean index (python ones as of yet not)
+        # NumPy bools can be used as boolean index (python ones as of yet not)
         a = np.array(1)
         assert_equal(a[np.bool_(True)], a[np.array(True)])
         assert_equal(a[np.bool_(False)], a[np.array(False)])
@@ -1133,7 +1133,7 @@ class TestFloatNonIntegerArgument(TestCase):
         assert_raises(TypeError, np.take, a, [0], np.float64(1.))
 
     def test_non_integer_sequence_multiplication(self):
-        # Numpy scalar sequence multiply should not work with non-integers
+        # NumPy scalar sequence multiply should not work with non-integers
         def mult(a, b):
             return a * b
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1734,7 +1734,7 @@ class TestRegression(TestCase):
         b = np.array(a, dtype=object)
         a[()] = b
         assert_raises(TypeError, int, a)
-        # Numpy has no tp_traverse currently, so circular references
+        # NumPy has no tp_traverse currently, so circular references
         # cannot be detected. So resolve it:
         a[()] = 0
 
@@ -1983,7 +1983,7 @@ class TestRegression(TestCase):
     def test_string_truncation_ucs2(self):
         # Ticket #2081. Python compiled with two byte unicode
         # can lead to truncation if itemsize is not properly
-        # adjusted for Numpy's four byte unicode.
+        # adjusted for NumPy's four byte unicode.
         if sys.version_info[0] >= 3:
             a = np.array(['abcd'])
         else:

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -95,7 +95,7 @@ else:
 
         But there are cross-platform considerations, such as library file extensions,
         plus the fact Windows will just load the first library it finds with that name.  
-        Numpy supplies the load_library function as a convenience.
+        NumPy supplies the load_library function as a convenience.
 
         Parameters
         ----------

--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -6,7 +6,7 @@ Array basics
 Array types and conversions between types
 =========================================
 
-Numpy supports a much greater variety of numerical types than Python does.
+NumPy supports a much greater variety of numerical types than Python does.
 This section shows which are available, and how to modify an array's data-type.
 
 ==========  ==========================================================
@@ -43,7 +43,7 @@ complex128  Complex number, represented by two 64-bit floats (real
 Additionally to ``intc`` the platform dependent C integer types ``short``,
 ``long``, ``longlong`` and their unsigned versions are defined.
 
-Numpy numerical types are instances of ``dtype`` (data-type) objects, each
+NumPy numerical types are instances of ``dtype`` (data-type) objects, each
 having unique characteristics.  Once you have imported NumPy using
 
   ::
@@ -124,7 +124,7 @@ properties of the type, such as whether it is an integer::
 Array Scalars
 =============
 
-Numpy generally returns elements of arrays as array scalars (a scalar
+NumPy generally returns elements of arrays as array scalars (a scalar
 with an associated dtype).  Array scalars differ from Python scalars, but
 for the most part they can be used interchangeably (the primary
 exception is for versions of Python older than v2.x, where integer array
@@ -152,12 +152,12 @@ is possible in numpy depends on the hardware and on the development
 environment: specifically, x86 machines provide hardware floating-point
 with 80-bit precision, and while most C compilers provide this as their
 ``long double`` type, MSVC (standard for Windows builds) makes
-``long double`` identical to ``double`` (64 bits). Numpy makes the
+``long double`` identical to ``double`` (64 bits). NumPy makes the
 compiler's ``long double`` available as ``np.longdouble`` (and
 ``np.clongdouble`` for the complex numbers). You can find out what your
 numpy provides with``np.finfo(np.longdouble)``.
 
-Numpy does not provide a dtype with more precision than C
+NumPy does not provide a dtype with more precision than C
 ``long double``s; in particular, the 128-bit IEEE quad precision
 data type (FORTRAN's ``REAL*16``) is not available.
 

--- a/numpy/doc/constants.py
+++ b/numpy/doc/constants.py
@@ -3,7 +3,7 @@
 Constants
 =========
 
-Numpy includes several constants:
+NumPy includes several constants:
 
 %(constant_list)s
 """
@@ -82,7 +82,7 @@ add_newdoc('numpy', 'NINF',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
     Also that positive infinity is not equivalent to negative infinity. But
     infinity is equivalent to positive infinity.
@@ -122,7 +122,7 @@ add_newdoc('numpy', 'NZERO',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). Negative zero is considered to be a finite number.
 
     Examples
@@ -193,7 +193,7 @@ add_newdoc('numpy', 'PZERO',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). Positive zero is considered to be a finite number.
 
     Examples
@@ -253,7 +253,7 @@ add_newdoc('numpy', 'inf',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
     Also that positive infinity is not equivalent to negative infinity. But
     infinity is equivalent to positive infinity.
@@ -298,7 +298,7 @@ add_newdoc('numpy', 'nan',
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
 
     `NaN` and `NAN` are aliases of `nan`.

--- a/numpy/doc/creation.py
+++ b/numpy/doc/creation.py
@@ -19,7 +19,7 @@ This section will not cover means of replicating, joining, or otherwise
 expanding or mutating existing arrays. Nor will it cover creating object
 arrays or structured arrays. Both of those are covered in their own sections.
 
-Converting Python array_like Objects to Numpy Arrays
+Converting Python array_like Objects to NumPy Arrays
 ====================================================
 
 In general, numerical data arranged in an array-like structure in Python can
@@ -38,10 +38,10 @@ Examples: ::
      and types
  >>> x = np.array([[ 1.+0.j, 2.+0.j], [ 0.+0.j, 0.+0.j], [ 1.+1.j, 3.+0.j]])
 
-Intrinsic Numpy Array Creation
+Intrinsic NumPy Array Creation
 ==============================
 
-Numpy has built-in functions for creating arrays from scratch:
+NumPy has built-in functions for creating arrays from scratch:
 
 zeros(shape) will create an array filled with 0 values with the specified
 shape. The default dtype is float64.

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -305,7 +305,7 @@ Glossary
            [1, 2, 3, 4, 5, 6]
 
        Row-major order is also known as the C order, as the C programming
-       language uses it. New Numpy arrays are by default in row-major order.
+       language uses it. New NumPy arrays are by default in row-major order.
 
    self
        Often seen in method signatures, ``self`` refers to the instance

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -65,7 +65,7 @@ inefficient as a new temporary array is created after the first index
 that is subsequently indexed by 2.
 
 Note to those used to IDL or Fortran memory order as it relates to
-indexing.  Numpy uses C-order indexing. That means that the last
+indexing.  NumPy uses C-order indexing. That means that the last
 index usually represents the most rapidly changing memory location,
 unlike Fortran or IDL, where the first index represents the most
 rapidly changing location in memory. This difference represents a
@@ -111,7 +111,7 @@ specific function.
 Index arrays
 ============
 
-Numpy arrays may be indexed with other arrays (or any other sequence-
+NumPy arrays may be indexed with other arrays (or any other sequence-
 like object that can be converted to an array, such as lists, with the
 exception of tuples; see the end of this document for why this is). The
 use of index arrays ranges from simple, straightforward cases to

--- a/numpy/doc/internals.py
+++ b/numpy/doc/internals.py
@@ -6,13 +6,13 @@ Array Internals
 Internal organization of numpy arrays
 =====================================
 
-It helps to understand a bit about how numpy arrays are handled under the covers to help understand numpy better. This section will not go into great detail. Those wishing to understand the full details are referred to Travis Oliphant's book "Guide to Numpy".
+It helps to understand a bit about how numpy arrays are handled under the covers to help understand numpy better. This section will not go into great detail. Those wishing to understand the full details are referred to Travis Oliphant's book "Guide to NumPy".
 
-Numpy arrays consist of two major components, the raw array data (from now on,
+NumPy arrays consist of two major components, the raw array data (from now on,
 referred to as the data buffer), and the information about the raw array data.
 The data buffer is typically what people think of as arrays in C or Fortran,
 a contiguous (and fixed) block of memory containing fixed sized data items.
-Numpy also contains a significant set of data that describes how to interpret
+NumPy also contains a significant set of data that describes how to interpret
 the data in the data buffer. This extra information contains (among other things):
 
  1) The basic data element's size in bytes
@@ -109,7 +109,7 @@ The situation with
 numpy makes this issue yet more complicated. The internal machinery of numpy
 arrays is flexible enough to accept any ordering of indices. One can simply
 reorder indices by manipulating the internal stride information for arrays
-without reordering the data at all. Numpy will know how to map the new index
+without reordering the data at all. NumPy will know how to map the new index
 order to the data without moving the data.
 
 So if this is true, why not choose

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -6,7 +6,7 @@ Structured Arrays
 Introduction
 ============
 
-Numpy provides powerful capabilities to create arrays of structured datatype.
+NumPy provides powerful capabilities to create arrays of structured datatype.
 These arrays permit one to manipulate the data by named fields. A simple 
 example will show what is meant.: ::
 
@@ -79,7 +79,7 @@ The type specifiers can take 4 different forms: ::
      Don't use these in new code!
   d) Single character type specifiers (e.g H for unsigned short ints).
      Avoid using these unless you must. Details can be found in the
-     Numpy book
+     NumPy book
 
 These different styles can be mixed within the same string (but why would you
 want to do that?). Furthermore, each type specifier can be prefixed

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -97,7 +97,7 @@ Implications for subclassing
 
 If we subclass ndarray, we need to deal not only with explicit
 construction of our array type, but also :ref:`view-casting` or
-:ref:`new-from-template`.  Numpy has the machinery to do this, and this
+:ref:`new-from-template`.  NumPy has the machinery to do this, and this
 machinery that makes subclassing slightly non-standard.
 
 There are two aspects to the machinery that ndarray uses to support
@@ -523,7 +523,7 @@ Extra gotchas - custom ``__del__`` methods and ndarray.base
 One of the problems that ndarray solves is keeping track of memory
 ownership of ndarrays and their views.  Consider the case where we have
 created an ndarray, ``arr`` and have taken a slice with ``v = arr[1:]``.
-The two objects are looking at the same memory.  Numpy keeps track of
+The two objects are looking at the same memory.  NumPy keeps track of
 where the data came from for a particular array or view, with the
 ``base`` attribute:
 

--- a/numpy/doc/ufuncs.py
+++ b/numpy/doc/ufuncs.py
@@ -6,7 +6,7 @@ Universal Functions
 Ufuncs are, generally speaking, mathematical functions or operations that are
 applied element-by-element to the contents of an array. That is, the result
 in each output array element only depends on the value in the corresponding
-input array (or arrays) and on no other array elements. Numpy comes with a
+input array (or arrays) and on no other array elements. NumPy comes with a
 large suite of ufuncs, and scipy extends that suite substantially. The simplest
 example is the addition operator: ::
 

--- a/numpy/dual.py
+++ b/numpy/dual.py
@@ -5,7 +5,7 @@ Scipy_ can be built to use accelerated or otherwise improved libraries
 for FFTs, linear algebra, and special functions. This module allows
 developers to transparently support these accelerated functions when
 scipy is available but still support users who have only installed
-Numpy.
+NumPy.
 
 .. _Scipy : http://www.scipy.org
 

--- a/numpy/lib/_version.py
+++ b/numpy/lib/_version.py
@@ -1,4 +1,4 @@
-"""Utility to compare (Numpy) version strings.
+"""Utility to compare (NumPy) version strings.
 
 The NumpyVersion class allows properly comparing numpy version strings.
 The LooseVersion and StrictVersion classes that distutils provides don't
@@ -18,7 +18,7 @@ __all__ = ['NumpyVersion']
 class NumpyVersion():
     """Parse and compare numpy version strings.
 
-    Numpy has the following versioning scheme (numbers given are examples; they
+    NumPy has the following versioning scheme (numbers given are examples; they
     can be > 9) in principle):
 
     - Released version: '1.8.0', '1.8.1', etc.
@@ -40,7 +40,7 @@ class NumpyVersion():
     Parameters
     ----------
     vstring : str
-        Numpy version string (``np.__version__``).
+        NumPy version string (``np.__version__``).
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -489,8 +489,8 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         based on the actual data within `range`, the bin count will fill
         the entire range including portions containing no data.
     normed : bool, optional
-        This keyword is deprecated in NumPy 1.6 due to confusing/buggy
-        behavior. It will be removed in NumPy 2.0. Use the ``density``
+        This keyword is deprecated in NumPy 1.6.0 due to confusing/buggy
+        behavior. It will be removed in NumPy 2.0.0. Use the ``density``
         keyword instead. If ``False``, the result will contain the
         number of samples in each bin. If ``True``, the result is the
         value of the probability *density* function at the bin,
@@ -809,7 +809,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         else:
             return n, bins
     else:
-        # deprecated, buggy behavior. Remove for NumPy 2.0
+        # deprecated, buggy behavior. Remove for NumPy 2.0.0
         if normed:
             db = array(np.diff(bins), float)
             return n/(n*db).sum(), bins

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -489,8 +489,8 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         based on the actual data within `range`, the bin count will fill
         the entire range including portions containing no data.
     normed : bool, optional
-        This keyword is deprecated in Numpy 1.6 due to confusing/buggy
-        behavior. It will be removed in Numpy 2.0. Use the ``density``
+        This keyword is deprecated in NumPy 1.6 due to confusing/buggy
+        behavior. It will be removed in NumPy 2.0. Use the ``density``
         keyword instead. If ``False``, the result will contain the
         number of samples in each bin. If ``True``, the result is the
         value of the probability *density* function at the bin,
@@ -809,7 +809,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         else:
             return n, bins
     else:
-        # deprecated, buggy behavior. Remove for Numpy 2.0
+        # deprecated, buggy behavior. Remove for NumPy 2.0
         if normed:
             db = array(np.diff(bins), float)
             return n/(n*db).sum(), bins

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -453,7 +453,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     Return the sum of array elements over a given axis treating Not a
     Numbers (NaNs) as zero.
 
-    In NumPy versions <= 1.8 Nan is returned for slices that are all-NaN or
+    In NumPy versions <= 1.8.0 Nan is returned for slices that are all-NaN or
     empty. In later versions zero is returned.
 
     Parameters

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -204,7 +204,7 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue):
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
     Positive infinity is treated as a very large number and negative
     infinity is treated as a very small (i.e. negative) number.
@@ -311,7 +311,7 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue):
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
     Positive infinity is treated as a very large number and negative
     infinity is treated as a very small (i.e. negative) number.
@@ -453,7 +453,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     Return the sum of array elements over a given axis treating Not a
     Numbers (NaNs) as zero.
 
-    In Numpy versions <= 1.8 Nan is returned for slices that are all-NaN or
+    In NumPy versions <= 1.8 Nan is returned for slices that are all-NaN or
     empty. In later versions zero is returned.
 
     Parameters

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -376,9 +376,9 @@ def load(file, mmap_mode=None, allow_pickle=True, fix_imports=True,
 
     if encoding not in ('ASCII', 'latin1', 'bytes'):
         # The 'encoding' value for pickle also affects what encoding
-        # the serialized binary data of Numpy arrays is loaded
+        # the serialized binary data of NumPy arrays is loaded
         # in. Pickle does not pass on the encoding information to
-        # Numpy. The unpickling code in numpy.core.multiarray is
+        # NumPy. The unpickling code in numpy.core.multiarray is
         # written to assume that unicode data appearing where binary
         # should be is in 'latin1'. 'bytes' is also safe, as is 'ASCII'.
         #
@@ -466,7 +466,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Notes
     -----
     For a description of the ``.npy`` format, see the module docstring
-    of `numpy.lib.format` or the Numpy Enhancement Proposal
+    of `numpy.lib.format` or the NumPy Enhancement Proposal
     http://docs.scipy.org/doc/numpy/neps/npy-format.html
 
     Examples
@@ -552,7 +552,7 @@ def savez(file, *args, **kwds):
     variables they contain.  The archive is not compressed and each file
     in the archive contains one variable in ``.npy`` format. For a
     description of the ``.npy`` format, see `numpy.lib.format` or the
-    Numpy Enhancement Proposal
+    NumPy Enhancement Proposal
     http://docs.scipy.org/doc/numpy/neps/npy-format.html
 
     When opening the saved ``.npz`` file with `load` a `NpzFile` object is
@@ -1428,7 +1428,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     References
     ----------
-    .. [1] Numpy User Guide, section `I/O with Numpy
+    .. [1] NumPy User Guide, section `I/O with NumPy
            <http://docs.scipy.org/doc/numpy/user/basics.io.genfromtxt.html>`_.
 
     Examples

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -350,7 +350,7 @@ def nan_to_num(x):
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754). This means that Not a Number is not equivalent to infinity.
 
 

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -82,7 +82,7 @@ def isposinf(x, y=None):
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754).
 
     Errors result if the second argument is also supplied when `x` is a
@@ -145,7 +145,7 @@ def isneginf(x, y=None):
 
     Notes
     -----
-    Numpy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754).
 
     Errors result if the second argument is also supplied when x is a scalar

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -241,10 +241,10 @@ def byte_bounds(a):
 
 def who(vardict=None):
     """
-    Print the Numpy arrays in the given dictionary.
+    Print the NumPy arrays in the given dictionary.
 
     If there is no dictionary passed in or `vardict` is None then returns
-    Numpy arrays in the globals() dictionary (all Numpy arrays in the
+    NumPy arrays in the globals() dictionary (all NumPy arrays in the
     namespace).
 
     Parameters
@@ -646,7 +646,7 @@ def info(object=None, maxwidth=76, output=sys.stdout, toplevel='numpy'):
 
 def source(object, output=sys.stdout):
     """
-    Print or write to a file the source code for a Numpy object.
+    Print or write to a file the source code for a NumPy object.
 
     The source code is only returned for objects written in Python. Many
     functions and classes are defined in C and will therefore not return

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -677,7 +677,7 @@ def qr(a, mode='reduced'):
     `a` is of type `matrix`, all the return values will be matrices too.
 
     New 'reduced', 'complete', and 'raw' options for mode were added in
-    NumPy 1.8 and the old option 'full' was made an alias of 'reduced'.  In
+    NumPy 1.8.0 and the old option 'full' was made an alias of 'reduced'.  In
     addition the options 'full' and 'economic' were deprecated.  Because
     'full' was the previous default and 'reduced' is the new default,
     backward compatibility can be maintained by letting `mode` default.

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -677,7 +677,7 @@ def qr(a, mode='reduced'):
     `a` is of type `matrix`, all the return values will be matrices too.
 
     New 'reduced', 'complete', and 'raw' options for mode were added in
-    Numpy 1.8 and the old option 'full' was made an alias of 'reduced'.  In
+    NumPy 1.8 and the old option 'full' was made an alias of 'reduced'.  In
     addition the options 'full' and 'economic' were deprecated.  Because
     'full' was the previous default and 'reduced' is the new default,
     backward compatibility can be maintained by letting `mode` default.

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -742,7 +742,7 @@ class ABCPolyBase(object):
         deg : int or 1-D array_like
             Degree(s) of the fitting polynomials. If `deg` is a single integer
             all terms up to and including the `deg`'th term are included in the
-            fit. For Numpy versions >= 1.11 a list of integers specifying the
+            fit. For NumPy versions >= 1.11 a list of integers specifying the
             degrees of the terms to include may be used instead.
         domain : {None, [beg, end], []}, optional
             Domain to use for the returned series. If ``None``,

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -742,7 +742,7 @@ class ABCPolyBase(object):
         deg : int or 1-D array_like
             Degree(s) of the fitting polynomials. If `deg` is a single integer
             all terms up to and including the `deg`'th term are included in the
-            fit. For NumPy versions >= 1.11 a list of integers specifying the
+            fit. For NumPy versions >= 1.11.0 a list of integers specifying the
             degrees of the terms to include may be used instead.
         domain : {None, [beg, end], []}, optional
             Domain to use for the returned series. If ``None``,

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1620,7 +1620,7 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For NumPy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11.0 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1620,7 +1620,7 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For Numpy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1391,7 +1391,7 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For NumPy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11.0 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1391,7 +1391,7 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For Numpy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1388,7 +1388,7 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For Numpy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1388,7 +1388,7 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For NumPy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11.0 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1390,7 +1390,7 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For Numpy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1390,7 +1390,7 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For NumPy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11.0 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1421,7 +1421,7 @@ def legfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For NumPy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11.0 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1421,7 +1421,7 @@ def legfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For Numpy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit. Singular values smaller than

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1309,7 +1309,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For Numpy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit.  Singular values smaller

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1309,7 +1309,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     deg : int or 1-D array_like
         Degree(s) of the fitting polynomials. If `deg` is a single integer
         all terms up to and including the `deg`'th term are included in the
-        fit. For NumPy versions >= 1.11 a list of integers specifying the
+        fit. For NumPy versions >= 1.11.0 a list of integers specifying the
         degrees of the terms to include may be used instead.
     rcond : float, optional
         Relative condition number of the fit.  Singular values smaller

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2547,7 +2547,7 @@ cdef class RandomState:
         Parameters
         ----------
         df : int or array_like of ints
-            Degrees of freedom, should be > 0 as of Numpy 1.10,
+            Degrees of freedom, should be > 0 as of NumPy 1.10,
             should be > 1 for earlier versions.
         nonc : float or array_like of floats
             Non-centrality, should be non-negative.

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2547,7 +2547,7 @@ cdef class RandomState:
         Parameters
         ----------
         df : int or array_like of ints
-            Degrees of freedom, should be > 0 as of NumPy 1.10,
+            Degrees of freedom, should be > 0 as of NumPy 1.10.0,
             should be > 1 for earlier versions.
         nonc : float or array_like of floats
             Non-centrality, should be non-negative.

--- a/runtests.py
+++ b/runtests.py
@@ -28,7 +28,7 @@ Generate C code coverage listing under build/lcov/:
 from __future__ import division, print_function
 
 #
-# This is a generic test runner script for projects using Numpy's test
+# This is a generic test runner script for projects using NumPy's test
 # framework. Change the following values to adapt to your project:
 #
 

--- a/setup.py
+++ b/setup.py
@@ -255,18 +255,18 @@ def parse_setuppy_commands():
 
               - `pip install .`       (from a git repo or downloaded source
                                        release)
-              - `pip install numpy`   (last Numpy release on PyPi)
+              - `pip install numpy`   (last NumPy release on PyPi)
 
             """))
         return True
 
     if '--help' in sys.argv[1:] or '-h' in sys.argv[1]:
         print(textwrap.dedent("""
-            Numpy-specific help
+            NumPy-specific help
             -------------------
 
-            To install Numpy from here with reliable uninstall, we recommend
-            that you use `pip install .`. To install the latest Numpy release
+            To install NumPy from here with reliable uninstall, we recommend
+            that you use `pip install .`. To install the latest NumPy release
             from PyPi, use `pip install numpy`.
 
             For help with build/installation issues, please ask on the

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -90,7 +90,7 @@
 # Atlas
 # -----
 # Atlas is an open source optimized implementation of the BLAS and Lapack
-# routines. Numpy will try to build against Atlas by default when available in
+# routines. NumPy will try to build against Atlas by default when available in
 # the system library dirs. To build numpy against a custom installation of
 # Atlas you can add an explicit section such as the following. Here we assume
 # that Atlas was configured with ``prefix=/opt/atlas``.
@@ -135,14 +135,14 @@
 # ----
 # BLIS (https://github.com/flame/blis) also provides a BLAS interface.  It's a
 # relatively new library, its performance in some cases seems to match that of
-# MKL and OpenBLAS, but it hasn't been benchmarked with Numpy or Scipy yet.
+# MKL and OpenBLAS, but it hasn't been benchmarked with NumPy or Scipy yet.
 #
 # Notes on compiling BLIS itself:
-#   - the CBLAS interface (needed by Numpy) isn't built by default; define
+#   - the CBLAS interface (needed by NumPy) isn't built by default; define
 #     BLIS_ENABLE_CBLAS to build it.
 #   - ``./configure auto`` doesn't support 32-bit builds, see gh-7294 for
 #     details.
-# Notes on compiling Numpy against BLIS:
+# Notes on compiling NumPy against BLIS:
 #   - ``include_dirs`` below should be the directory where the BLIS cblas.h
 #     header is installed.
 #

--- a/tools/c_coverage/HOWTO_C_COVERAGE.txt
+++ b/tools/c_coverage/HOWTO_C_COVERAGE.txt
@@ -27,7 +27,7 @@ For most cases, it is good enough to do::
   > c_coverage_collect.sh python -c "import numpy; numpy.test()"
   > c_coverage_report.py callgrind.out.pid
 
-which will run all of the Numpy unit tests, create a directory called
+which will run all of the NumPy unit tests, create a directory called
 `coverage` and place the coverage results there.
 
 In a more advanced scenario, you may wish to run individual unit tests
@@ -41,7 +41,7 @@ To collect coverage results, you merely run the python interpreter
 under valgrind's callgrind tool.  The `c_coverage_collect.sh` helper
 script will pass all of the required arguments to valgrind.
 
-For example, in typical usage, you may want to run all of the Numpy
+For example, in typical usage, you may want to run all of the NumPy
 unit tests::
 
   > c_coverage_collect.sh python -c "import numpy; numpy.test()"
@@ -99,7 +99,7 @@ HTML reports
 The HTML report highlights the code that was run in green.
 
 The HTML report has special support for the "generated" functions in
-Numpy.  Each run line of code also contains a number in square
+NumPy.  Each run line of code also contains a number in square
 brackets indicating the number of different generated functions the
 line was run in.  Hovering the mouse over the line will display a list
 of the versions of the function in which the line was run.  These
@@ -112,6 +112,6 @@ Caveats
 The coverage results occasionally misses lines that clearly must have
 been run.  This usually can be traced back to the compiler optimizer
 removing lines because they are tautologically impossible or to
-combine lines together.  Compiling Numpy without optimizations helps,
+combine lines together.  Compiling NumPy without optimizations helps,
 but not completely.  Even despite this flaw, this tool is still
 helpful in identifying large missed blocks or functions.

--- a/tools/numpy-macosx-installer/art/dmgbackground.svg
+++ b/tools/numpy-macosx-installer/art/dmgbackground.svg
@@ -11649,7 +11649,7 @@ vU/54W6oo0GROeM/veMNBRRE7rWB9Q4H8mdDTv+nwe+evyS3TH57xxtzjOZOx9uueWP+5o735/+U
      id="tspan7191"
      x="223.51202"
      y="46.072498"
-     style="font-size:28.66733551px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;font-family:Utopia;-inkscape-font-specification:Utopia">Numpy</tspan></text>
+     style="font-size:28.66733551px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;font-family:Utopia;-inkscape-font-specification:Utopia">NumPy</tspan></text>
 
 
 

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -71,7 +71,7 @@ setup_chroot()
   #   linux32 python setup.py build
   # when travis updates to ubuntu 14.04
   #
-  # Numpy may not distinguish between 64 and 32 bit ATLAS in the
+  # NumPy may not distinguish between 64 and 32 bit ATLAS in the
   # configuration stage.
   DIR=$1
   set -u

--- a/tools/win32build/nsis_scripts/numpy-superinstaller.nsi.in
+++ b/tools/win32build/nsis_scripts/numpy-superinstaller.nsi.in
@@ -15,7 +15,7 @@ SetCompressor /Solid LZMA ; Useful to disable compression under development
 ;General
 
 ;Name and file
-Name "Numpy super installer"
+Name "NumPy super installer"
 OutFile "@NUMPY_INSTALLER_NAME@"
 
 ;Default installation folder


### PR DESCRIPTION
Instances remain for NumpyVersion and Numpy.rec.fromarrays that are
references to code.

see issue #7986
