### PR TITLE
Backport 8030, BUG: fix np.ma.median with only one non-masked value

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -671,9 +671,8 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     ind = np.meshgrid(*axes_grid, sparse=True, indexing='ij')
 
     # insert indices of low and high median
-    ind.insert(axis, h - 1)
+    ind.insert(axis, np.maximum(0, h - 1))
     low = asorted[tuple(ind)]
-    low._sharedmask = False
     ind[axis] = h
     high = asorted[tuple(ind)]
 

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -790,6 +790,15 @@ class TestMedian(TestCase):
         assert_equal(r, out)
         assert_(type(r) == MaskedArray)
 
+    def test_single_non_masked_value_on_axis(self):
+        data = [[1., 0.],
+                [0., 3.],
+                [0., 0.]]
+        masked_arr = np.ma.masked_equal(data, 0)
+        expected = [1., 3.]
+        assert_array_equal(np.ma.median(masked_arr, axis=0),
+                           expected)
+
 
 class TestCov(TestCase):
 


### PR DESCRIPTION
#8030

Also add test.
