### PR TITLE
Backport 8028, DOC: Update 1.11.2 release notes.

### DIFF
--- a/doc/release/1.11.2-notes.rst
+++ b/doc/release/1.11.2-notes.rst
@@ -10,21 +10,21 @@ Pull Requests Merged
 
 Fixes overridden by later merges and release notes updates are omitted.
 
-- #7736 BUG: many functions silently drop 'keepdims' kwarg.
-- #7738 ENH: add extra kwargs and update doc of many MA methods.
+- #7736 BUG: Many functions silently drop 'keepdims' kwarg.
+- #7738 ENH: Add extra kwargs and update doc of many MA methods.
 - #7778 DOC: Update Numpy 1.11.1 release notes.
 - #7793 BUG: MaskedArray.count treats negative axes incorrectly.
-- #7816 BUG: fix array too big error for wide dtypes.
+- #7816 BUG: Fix array too big error for wide dtypes.
 - #7821 BUG: Make sure npy_mul_with_overflow_<type> detects overflow.
 - #7824 MAINT: Allocate fewer bytes for empty arrays.
 - #7847 MAINT,DOC: Fix some imp module uses and update f2py.compile docstring.
 - #7849 MAINT: Fix remaining uses of deprecated Python imp module.
 - #7851 BLD: Fix ATLAS version detection.
-- #7896 BUG: construct ma.array from np.array which contains padding.
-- #7904 BUG: fix float16 type not being called due to wrong ordering.
+- #7896 BUG: Construct ma.array from np.array which contains padding.
+- #7904 BUG: Fix float16 type not being called due to wrong ordering.
 - #7917 BUG: Production install of numpy should not require nose.
 - #7919 BLD: Fixed MKL detection for recent versions of this library.
-- #7920 BUG: fix for issue #7835 (ma.median of 1d).
+- #7920 BUG: Fix for issue #7835 (ma.median of 1d).
 - #7932 BUG: Monkey-patch _msvccompile.gen_lib_option like other compilers.
 - #7939 BUG: Check for HAVE_LDOUBLE_DOUBLE_DOUBLE_LE in npy_math_complex.
 - #7953 BUG: Guard against buggy comparisons in generic quicksort.
@@ -33,3 +33,6 @@ Fixes overridden by later merges and release notes updates are omitted.
 - #7972 BUG: MSVCCompiler grows 'lib' & 'include' env strings exponentially.
 - #8005 BLD: Remove __NUMPY_SETUP__ from builtins at end of setup.py.
 - #8010 MAINT: Remove leftover imp module imports.
+- #8020 BUG: Fix return of np.ma.count if keepdims is True and axis is None.
+- #8024 BUG: Fix numpy.ma.median.
+- #8031 BUG: Fix np.ma.median with only one non-masked value.


### PR DESCRIPTION
[ci skip]
