### PR TITLE
Update add_newdocs.py

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4445,7 +4445,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('partition',
     Examples
     --------
     >>> a = np.array([3, 4, 2, 1])
-    >>> a.partition(a, 3)
+    >>> a.partition(3)
     >>> a
     array([2, 1, 3, 4])
 


### PR DESCRIPTION
Just a small documentation fix. ndarray.partition(kth, axis=-1, kind='introselect', order=None)

> > > import numpy as np
> > > a=np.array([3,4,2,1])
> > > a.partition(a,3)
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > > ValueError: axis(=3) out of bounds
> > > a.partition(3)
> > > a
> > > array([2, 1, 3, 4])
