### PR TITLE
ENH: umath: ensure ufuncs are well-defined with memory overlapping inputs

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -90,6 +90,37 @@ it should be regarded as a band-aid until Mingwpy is fully functional.
 Changes
 =======
 
+Ufunc behavior for overlapping inputs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Operations where ufunc input and output operands have memory overlap
+produced undefined results in previous Numpy versions, due to data
+dependency issues. In Numpy 1.13.0, results from such operations are
+now defined to be the same as for equivalent operations where there is
+no memory overlap.
+
+Operations affected now make temporary copies, as needed to eliminate
+data dependency. As detecting these cases is computationally
+expensive, a heuristic is used, which may in rare cases result to
+needless temporary copies.
+
+To illustrate a previously undefined operation
+
+   >>> x = np.arange(16).astype(float)
+   >>> np.add(x[1:], x[:-1], out=x[1:])
+
+In Numpy 1.13.0 the last line is guaranteed to be equivalent to
+
+   >>> np.add(x[1:].copy(), x[:-1].copy(), out=x[1:])
+
+The change applies also to in-place binary operations, for example::
+
+    >>> x = np.random.rand(500, 500)
+    >>> x += x.T
+
+This statement is now guaranteed to be equivalent to ``x[...] = x + x.T``,
+whereas in previous Numpy versions the results were undefined.
+
 ``average`` now preserves subclasses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For ndarray subclasses, ``numpy.average`` will now return an instance of the

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -102,21 +102,33 @@ no memory overlap.
 Operations affected now make temporary copies, as needed to eliminate
 data dependency. As detecting these cases is computationally
 expensive, a heuristic is used, which may in rare cases result to
-needless temporary copies.
+needless temporary copies.  For operations where the data dependency
+is simple enough for the heuristic to analyze, temporary copies will
+not be made even if the arrays overlap, if it can be deduced copies
+are not necessary.  As an example,``np.add(a, b, out=a)`` will not
+involve copies.
 
 To illustrate a previously undefined operation
 
-   >>> x = np.arange(16).astype(float)
-   >>> np.add(x[1:], x[:-1], out=x[1:])
+>>> x = np.arange(16).astype(float)
+>>> np.add(x[1:], x[:-1], out=x[1:])
 
 In Numpy 1.13.0 the last line is guaranteed to be equivalent to
 
-   >>> np.add(x[1:].copy(), x[:-1].copy(), out=x[1:])
+>>> np.add(x[1:].copy(), x[:-1].copy(), out=x[1:])
 
-The change applies also to in-place binary operations, for example::
+A similar operation with simple non-problematic data dependence is
 
-    >>> x = np.random.rand(500, 500)
-    >>> x += x.T
+>>> x = np.arange(16).astype(float)
+>>> np.add(x[1:], x[:-1], out=x[:-1])
+
+It will continue to produce the same results as in previous Numpy
+versions, and will not involve unnecessary temporary copies.
+
+The change applies also to in-place binary operations, for example:
+
+>>> x = np.random.rand(500, 500)
+>>> x += x.T
 
 This statement is now guaranteed to be equivalent to ``x[...] = x + x.T``,
 whereas in previous Numpy versions the results were undefined.

--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -461,6 +461,33 @@ Construction and Destruction
             Then, call :c:func:`NpyIter_Reset` to allocate and fill the buffers
             with their initial values.
 
+        .. c:var:: NPY_ITER_COPY_IF_OVERLAP
+
+            If a write operand has overlap with a read operand, eliminate all
+            overlap by making temporary copies (with UPDATEIFCOPY for write
+            operands).
+
+            Overlapping means:
+
+            - For a (read, write) pair of operands, there is a memory address
+              that contains data common to both arrays, which can be reached
+              via *different* index/dtype/shape combinations.
+
+            - In particular, unless the arrays have the same shape, dtype,
+              strides, and start address, any shared common data byte accessible
+              by indexing implies overlap.
+
+            Because exact overlap detection has exponential runtime
+            in the number of dimensions, the decision is made based
+            on heuristics, which has false positives (needless copies in unusual
+            cases) but has no false negatives.
+
+            If read/write overlap exists and write operands are modified in the
+            iterator loop element-wise, this flag ensures the result of the
+            operation is the same as if all operands were copied.
+            In cases where copies would need to be made, **the result of the
+            computation may be undefined without this flag!**
+
     Flags that may be passed in ``op_flags[i]``, where ``0 <= i < nop``:
 
         .. c:var:: NPY_ITER_READWRITE

--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -608,17 +608,14 @@ Construction and Destruction
             returns true from the corresponding element in the ARRAYMASK
             operand.
 
-        .. c:var:: NPY_ITER_OVERLAP_ALLOW_SAME
+        .. c:var:: NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE
 
-            In memory overlap checks, operands with ``NPY_ITER_OVERLAP_ALLOW_SAME``
-            set are considered non-overlapping if they point to exactly the same array.
-            This means arrays with the same shape, dtype, strides, and start address.
-            In other cases, the default rules implied by
-            ``NPY_ITER_COPY_IF_OVERLAP`` apply.
+            In memory overlap checks, assume that operands with
+            ``NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE`` enabled are accessed only
+            in the iterator order.
 
-            This flag can be enabled on the set of operands that are accessed
-            only in the iterator order, i.e. the operation is element-wise,
-            to avoid unnecessary copies.
+            This enables the iterator to reason about data dependency,
+            possibly avoiding unnecessary copies.
 
             This flag has effect only if ``NPY_ITER_COPY_IF_OVERLAP`` is enabled
             on the iterator.

--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -474,7 +474,8 @@ Construction and Destruction
               via *different* index/dtype/shape combinations.
 
             - In particular, unless the arrays have the same shape, dtype,
-              strides, and start address, any shared common data byte accessible
+              strides, start address, and NPY_ITER_OVERLAP_NOT_SAME is not specified,
+              any shared common data byte accessible
               by indexing implies overlap.
 
             Because exact overlap detection has exponential runtime
@@ -617,6 +618,15 @@ Construction and Destruction
             elements in the buffer for which :c:func:`NpyMask_IsExposed`
             returns true from the corresponding element in the ARRAYMASK
             operand.
+
+        .. c:var:: NPY_ITER_OVERLAP_NOT_SAME
+
+            In the memory overlap checks done when ``NPY_ITER_COPY_IF_OVERLAP``
+            is specified, consider this array as overlapping even if it is
+            exactly the same as another array.
+
+            This flag should be set on arrays that are not accessed in the
+            iterator order.
 
 .. c:function:: NpyIter* NpyIter_AdvancedNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -169,6 +169,11 @@ add_newdoc('numpy.core', 'nditer',
             with one per iteration dimension, to be tracked.
           * "common_dtype" causes all the operands to be converted to
             a common data type, with copying or buffering as necessary.
+          * "copy_if_overlap" causes the iterator to determine if read
+            operands have overlap with write operands (except if
+            the arrays are exactly the same), and make temporary copies
+            as necessary to avoid overlap. False positives (needless
+            copying) are possible in some cases.
           * "delay_bufalloc" delays allocation of the buffers until
             a reset() call is made. Allows "allocate" operands to
             be initialized before their values are copied into the buffers.

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -212,7 +212,7 @@ add_newdoc('numpy.core', 'nditer',
             copies those elements indicated by this mask.
           * 'writemasked' indicates that only elements where the chosen
             'arraymask' operand is True will be written to.
-          * "overlap_allow_same" can be used to mark operands that are
+          * "overlap_assume_elementwise" can be used to mark operands that are
             accessed only in the iterator order, to allow less conservative
             copying when "copy_if_overlap" is present.
     op_dtypes : dtype or tuple of dtype(s), optional

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -170,9 +170,8 @@ add_newdoc('numpy.core', 'nditer',
           * "common_dtype" causes all the operands to be converted to
             a common data type, with copying or buffering as necessary.
           * "copy_if_overlap" causes the iterator to determine if read
-            operands have overlap with write operands (except if
-            the arrays are exactly the same), and make temporary copies
-            as necessary to avoid overlap. False positives (needless
+            operands have overlap with write operands, and make temporary
+            copies as necessary to avoid overlap. False positives (needless
             copying) are possible in some cases.
           * "delay_bufalloc" delays allocation of the buffers until
             a reset() call is made. Allows "allocate" operands to
@@ -213,6 +212,9 @@ add_newdoc('numpy.core', 'nditer',
             copies those elements indicated by this mask.
           * 'writemasked' indicates that only elements where the chosen
             'arraymask' operand is True will be written to.
+          * "overlap_allow_same" can be used to mark operands that are
+            accessed only in the iterator order, to allow less conservative
+            copying when "copy_if_overlap" is present.
     op_dtypes : dtype or tuple of dtype(s), optional
         The required data type(s) of the operands. If copying or buffering
         is enabled, the data will be converted to/from their original types.

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -35,5 +35,5 @@
 # Version 10 (NumPy 1.12) No change.
 0x0000000a = 9b8bce614655d3eb02acddcb508203cb
 
-# Version 10 (NumPy 1.13) Added PyArray_MapIterArrayCopyIfOverlap
+# Version 11 (NumPy 1.13) Added PyArray_MapIterArrayCopyIfOverlap
 0x0000000b = edb1ba83730c650fd9bc5772a919cda7

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -34,3 +34,6 @@
 # Version 10 (NumPy 1.11) No change.
 # Version 10 (NumPy 1.12) No change.
 0x0000000a = 9b8bce614655d3eb02acddcb508203cb
+
+# Version 10 (NumPy 1.13) Added PyArray_MapIterArrayCopyIfOverlap
+0x0000000b = edb1ba83730c650fd9bc5772a919cda7

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -344,6 +344,8 @@ multiarray_funcs_api = {
     # End 1.9 API
     'PyArray_CheckAnyScalarExact':          (300, NonNull(1)),
     # End 1.10 API
+    # End 1.11 API
+    'PyArray_MapIterArrayCopyIfOverlap':    (301,),
 }
 
 ufunc_types_api = {

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -344,8 +344,8 @@ multiarray_funcs_api = {
     # End 1.9 API
     'PyArray_CheckAnyScalarExact':          (300, NonNull(1)),
     # End 1.10 API
-    # End 1.11 API
     'PyArray_MapIterArrayCopyIfOverlap':    (301,),
+    # End 1.13 API
 }
 
 ufunc_types_api = {

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1045,8 +1045,8 @@ typedef void (NpyIter_GetMultiIndexFunc)(NpyIter *iter,
 #define NPY_ITER_WRITEMASKED                0x10000000
 /* This array is the mask for all WRITEMASKED operands */
 #define NPY_ITER_ARRAYMASK                  0x20000000
-/* Consider identical arrays non-overlapping for COPY_IF_OVERLAP */
-#define NPY_ITER_OVERLAP_ALLOW_SAME         0x40000000
+/* Assume iterator order data access for COPY_IF_OVERLAP */
+#define NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE 0x40000000
 
 #define NPY_ITER_GLOBAL_FLAGS               0x0000ffff
 #define NPY_ITER_PER_OP_FLAGS               0xffff0000

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1008,6 +1008,12 @@ typedef void (NpyIter_GetMultiIndexFunc)(NpyIter *iter,
 #define NPY_ITER_DELAY_BUFALLOC             0x00000800
 /* When NPY_KEEPORDER is specified, disable reversing negative-stride axes */
 #define NPY_ITER_DONT_NEGATE_STRIDES        0x00001000
+/*
+ * If output operands overlap with other operands (based on heuristics that
+ * has false positives but no false negatives), make temporary copies to
+ * eliminate overlap.
+ */
+#define NPY_ITER_COPY_IF_OVERLAP            0x00002000
 
 /*** Per-operand flags that may be passed to the iterator constructors ***/
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1045,11 +1045,8 @@ typedef void (NpyIter_GetMultiIndexFunc)(NpyIter *iter,
 #define NPY_ITER_WRITEMASKED                0x10000000
 /* This array is the mask for all WRITEMASKED operands */
 #define NPY_ITER_ARRAYMASK                  0x20000000
-/*
- * Consider this array as overlapping for COPY_IF_OVERLAP,
- * even if it is exactly the same as another array.
- */
-#define NPY_ITER_OVERLAP_NOT_SAME           0x40000000
+/* Consider identical arrays non-overlapping for COPY_IF_OVERLAP */
+#define NPY_ITER_OVERLAP_ALLOW_SAME         0x40000000
 
 #define NPY_ITER_GLOBAL_FLAGS               0x0000ffff
 #define NPY_ITER_PER_OP_FLAGS               0xffff0000

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1045,6 +1045,11 @@ typedef void (NpyIter_GetMultiIndexFunc)(NpyIter *iter,
 #define NPY_ITER_WRITEMASKED                0x10000000
 /* This array is the mask for all WRITEMASKED operands */
 #define NPY_ITER_ARRAYMASK                  0x20000000
+/*
+ * Consider this array as overlapping for COPY_IF_OVERLAP,
+ * even if it is exactly the same as another array.
+ */
+#define NPY_ITER_OVERLAP_NOT_SAME           0x40000000
 
 #define NPY_ITER_GLOBAL_FLAGS               0x0000ffff
 #define NPY_ITER_PER_OP_FLAGS               0xffff0000

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -911,6 +911,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'private', 'templ_common.h.src'),
             join('src', 'umath', 'simd.inc.src'),
             join(codegen_dir, 'generate_ufunc_api.py'),
+            join('src', 'private', 'lowlevel_strided_loops.h'),
             join('src', 'private', 'ufunc_override.h')] + npymath_sources
 
     config.add_extension('umath',

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -901,7 +901,8 @@ def configuration(parent_package='',top_path=None):
             join('src', 'umath', 'loops.c.src'),
             join('src', 'umath', 'ufunc_object.c'),
             join('src', 'umath', 'scalarmath.c.src'),
-            join('src', 'umath', 'ufunc_type_resolution.c')]
+            join('src', 'umath', 'ufunc_type_resolution.c'),
+            join('src', 'private', 'mem_overlap.c')]
 
     umath_deps = [
             generate_umath_py,
@@ -912,6 +913,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'umath', 'simd.inc.src'),
             join(codegen_dir, 'generate_ufunc_api.py'),
             join('src', 'private', 'lowlevel_strided_loops.h'),
+            join('src', 'private', 'mem_overlap.h'),
             join('src', 'private', 'ufunc_override.h')] + npymath_sources
 
     config.add_extension('umath',

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -38,7 +38,8 @@ C_ABI_VERSION = 0x01000009
 # 0x0000000a - 1.10.x
 # 0x0000000a - 1.11.x
 # 0x0000000a - 1.12.x
-C_API_VERSION = 0x0000000a
+# 0x0000000b - 1.13.x
+C_API_VERSION = 0x0000000b
 
 class MismatchCAPIWarning(Warning):
     pass

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3200,7 +3200,6 @@ PyArray_MapIterArrayCopyIfOverlap(PyArrayObject * a, PyObject * index,
         }
 
         if (PyArray_CopyInto(a_copy, a) != 0) {
-            Py_DECREF(a_copy);
             goto fail;
         }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3180,7 +3180,6 @@ PyArray_MapIterArrayCopyIfOverlap(PyArrayObject * a, PyObject * index,
     PyArrayObject *subspace = NULL;
     npy_index_info indices[NPY_MAXDIMS * 2 + 1];
     int i, index_num, ndim, fancy_ndim, index_type;
-    int need_copy = 0;
     PyArrayObject *a_copy = NULL;
 
     index_type = prepare_index(a, index, indices, &index_num,

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3262,11 +3262,7 @@ PyArray_MapIterArrayCopyIfOverlap(PyArrayObject * a, PyObject * index,
 
 /*NUMPY_API
  *
- * Use advanced indexing to iterate an array. Please note
- * that most of this public API is currently not guaranteed
- * to stay the same between versions. If you plan on using
- * it, please consider adding more utility functions here
- * to accommodate new features.
+ * Use advanced indexing to iterate an array.
  */
 NPY_NO_EXPORT PyObject *
 PyArray_MapIterArray(PyArrayObject * a, PyObject * index)

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1923,7 +1923,9 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
                  * Either they are equivalent, or the values must
                  * be a scalar
                  */
-                (PyArray_EQUIVALENTLY_ITERABLE(ind, tmp_arr) ||
+                (PyArray_EQUIVALENTLY_ITERABLE(ind, tmp_arr,
+                                               PyArray_TRIVIALLY_ITERABLE_OP_READ,
+                                               PyArray_TRIVIALLY_ITERABLE_OP_READ) ||
                  (PyArray_NDIM(tmp_arr) == 0 &&
                         PyArray_TRIVIALLY_ITERABLE(tmp_arr))) &&
                 /* Check if the type is equivalent to INTP */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3205,7 +3205,6 @@ PyArray_MapIterArrayCopyIfOverlap(PyArrayObject * a, PyObject * index,
 
         Py_INCREF(a);
         if (PyArray_SetUpdateIfCopyBase(a_copy, a) < 0) {
-            Py_DECREF(a);
             goto fail;
         }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -718,17 +718,18 @@ index_has_memory_overlap(PyArrayObject *self,
 
     if (index_type & (HAS_FANCY | HAS_BOOL)) {
         for (i = 0; i < num; ++i) {
-            if (indices[i].object != NULL && PyArray_Check(indices[i].object) &&
-                solve_may_share_memory(self, (PyArrayObject *)indices[i].object,
-                                       1) != 0) {
-
+            if (indices[i].object != NULL &&
+                    PyArray_Check(indices[i].object) &&
+                    solve_may_share_memory(self,
+                                           (PyArrayObject *)indices[i].object,
+                                           1) != 0) {
                 return 1;
             }
         }
     }
 
     if (extra_op != NULL && PyArray_Check(extra_op) &&
-        solve_may_share_memory(self, (PyArrayObject *)extra_op, 1) != 0) {
+            solve_may_share_memory(self, (PyArrayObject *)extra_op, 1) != 0) {
         return 1;
     }
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2749,6 +2749,9 @@ npyiter_allocate_arrays(NpyIter *iter,
                  * If the arrays are views to exactly the same data, no need
                  * to make copies, if the caller (eg ufunc) says it accesses
                  * data only in the iterator order.
+                 *
+                 * However, if there is internal overlap (e.g. a zero stride on
+                 * a non-unit dimension), a copy cannot be avoided.
                  */
                 if ((op_flags[iop] & NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE) &&
                     (op_flags[iother] & NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE) &&
@@ -2760,7 +2763,9 @@ npyiter_allocate_arrays(NpyIter *iter,
                     PyArray_CompareLists(PyArray_STRIDES(op[iop]),
                                          PyArray_STRIDES(op[iother]),
                                          PyArray_NDIM(op[iop])) &&
-                    PyArray_DESCR(op[iop]) == PyArray_DESCR(op[iother])) {
+                    PyArray_DESCR(op[iop]) == PyArray_DESCR(op[iother]) &&
+                    solve_may_have_internal_overlap(op[iop], 1) == 0) {
+
                     continue;
                 }
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2747,11 +2747,11 @@ npyiter_allocate_arrays(NpyIter *iter,
 
                 /*
                  * If the arrays are views to exactly the same data, no need
-                 * to make copies, because ufunc inner loops are assumed to
-                 * deal with that
+                 * to make copies, if the caller (eg ufunc) says it accesses
+                 * data only in the iterator order.
                  */
-                if (!(op_flags[iop] & NPY_ITER_OVERLAP_NOT_SAME) &&
-                    !(op_flags[iother] & NPY_ITER_OVERLAP_NOT_SAME) &&
+                if ((op_flags[iop] & NPY_ITER_OVERLAP_ALLOW_SAME) &&
+                    (op_flags[iother] & NPY_ITER_OVERLAP_ALLOW_SAME) &&
                     PyArray_BYTES(op[iop]) == PyArray_BYTES(op[iother]) &&
                     PyArray_NDIM(op[iop]) == PyArray_NDIM(op[iother]) &&
                     PyArray_CompareLists(PyArray_DIMS(op[iop]),

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -17,6 +17,8 @@
 
 #include "arrayobject.h"
 #include "templ_common.h"
+#include "mem_overlap.h"
+
 
 /* Internal helper functions private to this file */
 static int
@@ -2708,6 +2710,73 @@ npyiter_allocate_arrays(NpyIter *iter,
         bufferdata = NIT_BUFFERDATA(iter);
     }
 
+    if (flags & NPY_ITER_COPY_IF_OVERLAP) {
+        /* Perform operand memory overlap checks if requested */
+        for (iop = 0; iop < nop; ++iop) {
+            int may_share_memory = 0;
+            int iother;
+
+            if (op[iop] == NULL) {
+                /* Iterator will always allocate */
+                continue;
+            }
+
+            if (!(op_itflags[iop] & NPY_OP_ITFLAG_WRITE)) {
+                /*
+                 * Copy output operands only, not inputs.
+                 * A more sophisticated heuristic could be
+                 * substituted here later.
+                 */
+                continue;
+            }
+
+            for (iother = 0; iother < nop; ++iother) {
+                if (iother == iop || op[iother] == NULL) {
+                    continue;
+                }
+
+                if (!(op_itflags[iother] & NPY_OP_ITFLAG_READ)) {
+                    /* No data dependence for arrays not read from */
+                    continue;
+                }
+
+                if (op_itflags[iother] & NPY_OP_ITFLAG_FORCECOPY) {
+                    /* Already copied */
+                    continue;
+                }
+
+                /*
+                 * If the arrays are views to exactly the same data, no need
+                 * to make copies, because ufunc inner loops are assumed to
+                 * deal with that
+                 */
+                if (PyArray_BYTES(op[iop]) == PyArray_BYTES(op[iother]) &&
+                    PyArray_NDIM(op[iop]) == PyArray_NDIM(op[iother]) &&
+                    PyArray_CompareLists(PyArray_DIMS(op[iop]),
+                                         PyArray_DIMS(op[iother]),
+                                         PyArray_NDIM(op[iop])) &&
+                    PyArray_CompareLists(PyArray_STRIDES(op[iop]),
+                                         PyArray_STRIDES(op[iother]),
+                                         PyArray_NDIM(op[iop])) &&
+                    PyArray_DESCR(op[iop]) == PyArray_DESCR(op[iother])) {
+                    continue;
+                }
+
+                /*
+                 * Use max work = 1. If the arrays are large, it might
+                 * make sense to go further.
+                 */
+                may_share_memory = solve_may_share_memory(
+                    op[iop], op[iother], 1);
+
+                if (may_share_memory) {
+                    op_itflags[iop] |= NPY_OP_ITFLAG_FORCECOPY;
+                    break;
+                }
+            }
+        }
+    }
+
     for (iop = 0; iop < nop; ++iop) {
         /*
          * Check whether there are any WRITEMASKED REDUCE operands
@@ -2797,9 +2866,15 @@ npyiter_allocate_arrays(NpyIter *iter,
                 NBF_STRIDES(bufferdata)[iop] = 0;
             }
         }
-        /* If casting is required and permitted */
-        else if ((op_itflags[iop] & NPY_OP_ITFLAG_CAST) &&
-                   (op_flags[iop] & (NPY_ITER_COPY|NPY_ITER_UPDATEIFCOPY))) {
+        /*
+         * Make a temporary copy if,
+         * 1. If casting is required and permitted, or,
+         * 2. If force-copy is requested
+         */
+        else if (((op_itflags[iop] & NPY_OP_ITFLAG_CAST) &&
+                        (op_flags[iop] &
+                        (NPY_ITER_COPY|NPY_ITER_UPDATEIFCOPY))) ||
+                 (op_itflags[iop] & NPY_OP_ITFLAG_FORCECOPY)) {
             PyArrayObject *temp;
             int ondim = PyArray_NDIM(op[iop]);
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2750,8 +2750,8 @@ npyiter_allocate_arrays(NpyIter *iter,
                  * to make copies, if the caller (eg ufunc) says it accesses
                  * data only in the iterator order.
                  */
-                if ((op_flags[iop] & NPY_ITER_OVERLAP_ALLOW_SAME) &&
-                    (op_flags[iother] & NPY_ITER_OVERLAP_ALLOW_SAME) &&
+                if ((op_flags[iop] & NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE) &&
+                    (op_flags[iother] & NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE) &&
                     PyArray_BYTES(op[iop]) == PyArray_BYTES(op[iother]) &&
                     PyArray_NDIM(op[iop]) == PyArray_NDIM(op[iother]) &&
                     PyArray_CompareLists(PyArray_DIMS(op[iop]),

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2750,7 +2750,9 @@ npyiter_allocate_arrays(NpyIter *iter,
                  * to make copies, because ufunc inner loops are assumed to
                  * deal with that
                  */
-                if (PyArray_BYTES(op[iop]) == PyArray_BYTES(op[iother]) &&
+                if (!(op_flags[iop] & NPY_ITER_OVERLAP_NOT_SAME) &&
+                    !(op_flags[iother] & NPY_ITER_OVERLAP_NOT_SAME) &&
+                    PyArray_BYTES(op[iop]) == PyArray_BYTES(op[iother]) &&
                     PyArray_NDIM(op[iop]) == PyArray_NDIM(op[iother]) &&
                     PyArray_CompareLists(PyArray_DIMS(op[iop]),
                                          PyArray_DIMS(op[iother]),

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -122,6 +122,8 @@
 #define NPY_OP_ITFLAG_WRITEMASKED  0x0080
 /* The operand's data pointer is pointing into its buffer */
 #define NPY_OP_ITFLAG_USINGBUFFER  0x0100
+/* The operand must be copied (with UPDATEIFCOPY if also ITFLAG_WRITE) */
+#define NPY_OP_ITFLAG_FORCECOPY    0x0200
 
 /*
  * The data layout of the iterator is fully specified by

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -361,8 +361,8 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
                 }
                 break;
             case 'o':
-                if (strcmp(str, "overlap_allow_same") == 0) {
-                    flag = NPY_ITER_OVERLAP_ALLOW_SAME;
+                if (strcmp(str, "overlap_assume_elementwise") == 0) {
+                    flag = NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
                 }
                 break;
             case 'r':

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -360,6 +360,11 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
                         break;
                 }
                 break;
+            case 'o':
+                if (strcmp(str, "overlap_allow_same") == 0) {
+                    flag = NPY_ITER_OVERLAP_ALLOW_SAME;
+                }
+                break;
             case 'r':
                 if (length > 4) switch (str[4]) {
                     case 'o':

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -148,6 +148,11 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
                             flag = NPY_ITER_C_INDEX;
                         }
                         break;
+                    case 'i':
+                        if (strcmp(str, "copy_if_overlap") == 0) {
+                            flag = NPY_ITER_COPY_IF_OVERLAP;
+                        }
+                        break;
                     case 'n':
                         if (strcmp(str, "common_dtype") == 0) {
                             flag = NPY_ITER_COMMON_DTYPE;

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -720,20 +720,23 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2);
 
-    if (stride1 >= 0) {
+    /* Arrays with zero stride are never "ahead" since the element is reused
+       (at this point we know the arrays do overlap). */
+
+    if (stride1 > 0) {
         arr1_ahead = (stride1 >= stride2 &&
                       (npy_uintp)PyArray_BYTES(arr1) >= (npy_uintp)PyArray_BYTES(arr2));
     }
-    else {
+    else if (stride1 < 0) {
         arr1_ahead = (stride1 <= stride2 &&
                       (npy_uintp)PyArray_BYTES(arr1) <= (npy_uintp)PyArray_BYTES(arr2));
     }
 
-    if (stride2 >= 0) {
+    if (stride2 > 0) {
         arr2_ahead = (stride2 >= stride1 &&
                       (npy_uintp)PyArray_BYTES(arr2) >= (npy_uintp)PyArray_BYTES(arr1));
     }
-    else {
+    else if (stride2 < 0) {
         arr2_ahead = (stride2 <= stride1 &&
                       (npy_uintp)PyArray_BYTES(arr2) <= (npy_uintp)PyArray_BYTES(arr1));
     }

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -711,8 +711,10 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
         return 1;
     }
 
-    /* Arrays overlapping in memory may be equivalently iterable
-       if input arrays stride ahead faster than output arrays. */
+    /*
+     * Arrays overlapping in memory may be equivalently iterable if input
+     * arrays stride ahead faster than output arrays.
+     */
 
     size1 = PyArray_SIZE(arr1);
     size2 = PyArray_SIZE(arr2);
@@ -720,25 +722,27 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2);
 
-    /* Arrays with zero stride are never "ahead" since the element is reused
-       (at this point we know the arrays do overlap). */
+    /*
+     * Arrays with zero stride are never "ahead" since the element is reused
+     * (at this point we know the array extents overlap).
+     */
 
     if (stride1 > 0) {
         arr1_ahead = (stride1 >= stride2 &&
-                      (npy_uintp)PyArray_BYTES(arr1) >= (npy_uintp)PyArray_BYTES(arr2));
+                      PyArray_BYTES(arr1) >= PyArray_BYTES(arr2));
     }
     else if (stride1 < 0) {
         arr1_ahead = (stride1 <= stride2 &&
-                      (npy_uintp)PyArray_BYTES(arr1) <= (npy_uintp)PyArray_BYTES(arr2));
+                      PyArray_BYTES(arr1) <= PyArray_BYTES(arr2));
     }
 
     if (stride2 > 0) {
         arr2_ahead = (stride2 >= stride1 &&
-                      (npy_uintp)PyArray_BYTES(arr2) >= (npy_uintp)PyArray_BYTES(arr1));
+                      PyArray_BYTES(arr2) >= PyArray_BYTES(arr1));
     }
     else if (stride2 < 0) {
         arr2_ahead = (stride2 <= stride1 &&
-                      (npy_uintp)PyArray_BYTES(arr2) <= (npy_uintp)PyArray_BYTES(arr1));
+                      PyArray_BYTES(arr2) <= PyArray_BYTES(arr1));
     }
 
     return (!arr1_read || arr1_ahead) && (!arr2_read || arr2_ahead);

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -696,7 +696,7 @@ npy_bswap8_unaligned(char * x)
                                           PyArray_STRIDE(arr, 0) : \
                                           PyArray_ITEMSIZE(arr)))
 
-static int
+static NPY_INLINE int
 PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr2,
                                          int arr1_read, int arr2_read)
 {

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -696,7 +696,7 @@ npy_bswap8_unaligned(char * x)
                                           PyArray_STRIDE(arr, 0) : \
                                           PyArray_ITEMSIZE(arr)))
 
-static NPY_INLINE int
+static int
 PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr2,
                                          int arr1_read, int arr2_read)
 {

--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -2,6 +2,7 @@
 #define __LOWLEVEL_STRIDED_LOOPS_H
 #include "common.h"
 #include <npy_config.h>
+#include "mem_overlap.h"
 
 /*
  * NOTE: This API should remain private for the time being, to allow
@@ -662,7 +663,24 @@ npy_bswap8_unaligned(char * x)
  * Note: Equivalently iterable macro requires one of arr1 or arr2 be
  *       trivially iterable to be valid.
  */
-#define PyArray_EQUIVALENTLY_ITERABLE(arr1, arr2) ( \
+
+/**
+ * Determine whether two arrays are safe for trivial iteration in cases where
+ * some of the arrays may be modified.
+ *
+ * In-place iteration is safe if one of the following is true:
+ *
+ * - Both arrays are read-only
+ * - The arrays do not have overlapping memory (based on a check that may be too
+ *   strict)
+ * - The strides match, and the non-read-only array base addresses are equal or
+ *   before the read-only one, ensuring correct data dependency.
+ */
+
+#define PyArray_TRIVIALLY_ITERABLE_OP_NOREAD 0
+#define PyArray_TRIVIALLY_ITERABLE_OP_READ 1
+
+#define PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr2) (            \
                         PyArray_NDIM(arr1) == PyArray_NDIM(arr2) && \
                         PyArray_CompareLists(PyArray_DIMS(arr1), \
                                              PyArray_DIMS(arr2), \
@@ -673,6 +691,60 @@ npy_bswap8_unaligned(char * x)
                                               NPY_ARRAY_F_CONTIGUOUS)) \
                         )
 
+#define PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size, arr) ( \
+                        size == 1 ? 0 : ((PyArray_NDIM(arr) == 1) ? \
+                                          PyArray_STRIDE(arr, 0) : \
+                                          PyArray_ITEMSIZE(arr)))
+
+static NPY_INLINE int
+PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr2,
+                                         int arr1_read, int arr2_read)
+{
+    npy_intp size1, size2, stride1, stride2;
+    int arr1_ahead = 0, arr2_ahead = 0;
+
+    if (arr1_read && arr2_read) {
+        return 1;
+    }
+
+    if (solve_may_share_memory(arr1, arr2, 1) == 0) {
+        return 1;
+    }
+
+    /* Arrays overlapping in memory may be equivalently iterable
+       if input arrays stride ahead faster than output arrays. */
+
+    size1 = PyArray_SIZE(arr1);
+    size2 = PyArray_SIZE(arr2);
+
+    stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
+    stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2);
+
+    if (stride1 >= 0) {
+        arr1_ahead = (stride1 >= stride2 &&
+                      (npy_uintp)PyArray_BYTES(arr1) >= (npy_uintp)PyArray_BYTES(arr2));
+    }
+    else {
+        arr1_ahead = (stride1 <= stride2 &&
+                      (npy_uintp)PyArray_BYTES(arr1) <= (npy_uintp)PyArray_BYTES(arr2));
+    }
+
+    if (stride2 >= 0) {
+        arr2_ahead = (stride2 >= stride1 &&
+                      (npy_uintp)PyArray_BYTES(arr2) >= (npy_uintp)PyArray_BYTES(arr1));
+    }
+    else {
+        arr2_ahead = (stride2 <= stride1 &&
+                      (npy_uintp)PyArray_BYTES(arr2) <= (npy_uintp)PyArray_BYTES(arr1));
+    }
+
+    return (!arr1_read || arr1_ahead) && (!arr2_read || arr2_ahead);
+}
+
+#define PyArray_EQUIVALENTLY_ITERABLE(arr1, arr2, arr1_read, arr2_read) ( \
+                        PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr2) && \
+                        PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK( \
+                            arr1, arr2, arr1_read, arr2_read))
 #define PyArray_TRIVIALLY_ITERABLE(arr) ( \
                     PyArray_NDIM(arr) <= 1 || \
                     PyArray_CHKFLAGS(arr, NPY_ARRAY_C_CONTIGUOUS) || \
@@ -687,15 +759,16 @@ npy_bswap8_unaligned(char * x)
                                             PyArray_ITEMSIZE(arr)));
 
 
-#define PyArray_TRIVIALLY_ITERABLE_PAIR(arr1, arr2) (\
+#define PyArray_TRIVIALLY_ITERABLE_PAIR(arr1, arr2, arr1_read, arr2_read) (   \
                     PyArray_TRIVIALLY_ITERABLE(arr1) && \
                         (PyArray_NDIM(arr2) == 0 || \
-                         PyArray_EQUIVALENTLY_ITERABLE(arr1, arr2) || \
+                         PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr2) ||  \
                          (PyArray_NDIM(arr1) == 0 && \
                              PyArray_TRIVIALLY_ITERABLE(arr2) \
                          ) \
-                        ) \
-                    )
+                        ) && \
+                        PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr1, arr2, arr1_read, arr2_read) \
+                        )
 #define PyArray_PREPARE_TRIVIAL_PAIR_ITERATION(arr1, arr2, \
                                         count, \
                                         data1, data2, \
@@ -705,33 +778,32 @@ npy_bswap8_unaligned(char * x)
                     count = ((size1 > size2) || size1 == 0) ? size1 : size2; \
                     data1 = PyArray_BYTES(arr1); \
                     data2 = PyArray_BYTES(arr2); \
-                    stride1 = (size1 == 1 ? 0 : ((PyArray_NDIM(arr1) == 1) ? \
-                                                PyArray_STRIDE(arr1, 0) : \
-                                                PyArray_ITEMSIZE(arr1))); \
-                    stride2 = (size2 == 1 ? 0 : ((PyArray_NDIM(arr2) == 1) ? \
-                                                PyArray_STRIDE(arr2, 0) : \
-                                                PyArray_ITEMSIZE(arr2))); \
+                    stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1); \
+                    stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
                 }
 
-#define PyArray_TRIVIALLY_ITERABLE_TRIPLE(arr1, arr2, arr3) (\
+#define PyArray_TRIVIALLY_ITERABLE_TRIPLE(arr1, arr2, arr3, arr1_read, arr2_read, arr3_read) ( \
                 PyArray_TRIVIALLY_ITERABLE(arr1) && \
                     ((PyArray_NDIM(arr2) == 0 && \
                         (PyArray_NDIM(arr3) == 0 || \
-                            PyArray_EQUIVALENTLY_ITERABLE(arr1, arr3) \
+                            PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr3) \
                         ) \
                      ) || \
-                     (PyArray_EQUIVALENTLY_ITERABLE(arr1, arr2) && \
+                     (PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr2) && \
                         (PyArray_NDIM(arr3) == 0 || \
-                            PyArray_EQUIVALENTLY_ITERABLE(arr1, arr3) \
+                            PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr3) \
                         ) \
                      ) || \
                      (PyArray_NDIM(arr1) == 0 && \
                         PyArray_TRIVIALLY_ITERABLE(arr2) && \
                             (PyArray_NDIM(arr3) == 0 || \
-                                PyArray_EQUIVALENTLY_ITERABLE(arr2, arr3) \
+                                PyArray_EQUIVALENTLY_ITERABLE_BASE(arr2, arr3) \
                             ) \
                      ) \
-                    ) \
+                    ) && \
+                    PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr1, arr2, arr1_read, arr2_read) && \
+                    PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr1, arr3, arr1_read, arr3_read) && \
+                    PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr2, arr3, arr2_read, arr3_read) \
                 )
 
 #define PyArray_PREPARE_TRIVIAL_TRIPLE_ITERATION(arr1, arr2, arr3, \
@@ -746,15 +818,9 @@ npy_bswap8_unaligned(char * x)
                     data1 = PyArray_BYTES(arr1); \
                     data2 = PyArray_BYTES(arr2); \
                     data3 = PyArray_BYTES(arr3); \
-                    stride1 = (size1 == 1 ? 0 : ((PyArray_NDIM(arr1) == 1) ? \
-                                                PyArray_STRIDE(arr1, 0) : \
-                                                PyArray_ITEMSIZE(arr1))); \
-                    stride2 = (size2 == 1 ? 0 : ((PyArray_NDIM(arr2) == 1) ? \
-                                                PyArray_STRIDE(arr2, 0) : \
-                                                PyArray_ITEMSIZE(arr2))); \
-                    stride3 = (size3 == 1 ? 0 : ((PyArray_NDIM(arr3) == 1) ? \
-                                                PyArray_STRIDE(arr3, 0) : \
-                                                PyArray_ITEMSIZE(arr3))); \
+                    stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1); \
+                    stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
+                    stride3 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size3, arr3); \
                 }
 
 #endif

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -189,6 +189,7 @@ conform_reduce_result(int ndim, npy_bool *axis_flags,
         Py_INCREF(ret);
         if (PyArray_SetUpdateIfCopyBase(ret_copy, (PyArrayObject *)ret) < 0) {
             Py_DECREF(ret);
+            Py_DECREF(ret_copy);
             return NULL;
         }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1484,6 +1484,7 @@ iterator_loop(PyUFuncObject *ufunc,
             /* Call the __array_prepare__ functions for the new array */
             if (prepare_ufunc_output(ufunc, &op[nin+i],
                                      arr_prep[i], arr_prep_args, i) < 0) {
+                NpyIter_Deallocate(iter);
                 return -1;
             }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1440,7 +1440,8 @@ iterator_loop(PyUFuncObject *ufunc,
                  NPY_ITER_ZEROSIZE_OK |
                  NPY_ITER_BUFFERED |
                  NPY_ITER_GROWINNER |
-                 NPY_ITER_DELAY_BUFALLOC;
+                 NPY_ITER_DELAY_BUFALLOC |
+                 NPY_ITER_COPY_IF_OVERLAP;
 
     /*
      * Allocate the iterator.  Because the types of the inputs
@@ -1755,7 +1756,8 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                  NPY_ITER_REFS_OK |
                  NPY_ITER_ZEROSIZE_OK |
                  NPY_ITER_BUFFERED |
-                 NPY_ITER_GROWINNER;
+                 NPY_ITER_GROWINNER |
+                 NPY_ITER_COPY_IF_OVERLAP;
 
     /*
      * Allocate the iterator.  Because the types of the inputs
@@ -2294,7 +2296,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                  NPY_ITER_MULTI_INDEX |
                  NPY_ITER_REFS_OK |
                  NPY_ITER_REDUCE_OK |
-                 NPY_ITER_ZEROSIZE_OK;
+                 NPY_ITER_ZEROSIZE_OK |
+                 NPY_ITER_COPY_IF_OVERLAP;
 
     /* Create the iterator */
     iter = NpyIter_AdvancedNew(nop, op, iter_flags,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1418,7 +1418,7 @@ iterator_loop(PyUFuncObject *ufunc,
     for (i = 0; i < nin; ++i) {
         op_flags[i] = NPY_ITER_READONLY |
                       NPY_ITER_ALIGNED |
-                      NPY_ITER_OVERLAP_ALLOW_SAME;
+                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -1434,7 +1434,7 @@ iterator_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALLOCATE |
                       NPY_ITER_NO_BROADCAST |
                       NPY_ITER_NO_SUBTYPE |
-                      NPY_ITER_OVERLAP_ALLOW_SAME;
+                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
     }
 
     iter_flags = ufunc->iter_flags |
@@ -1730,7 +1730,7 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
         op_flags[i] = default_op_in_flags |
                       NPY_ITER_READONLY |
                       NPY_ITER_ALIGNED |
-                      NPY_ITER_OVERLAP_ALLOW_SAME;
+                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -1751,7 +1751,7 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALLOCATE |
                       NPY_ITER_NO_BROADCAST |
                       NPY_ITER_NO_SUBTYPE |
-                      NPY_ITER_OVERLAP_ALLOW_SAME;
+                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
     }
     if (wheremask != NULL) {
         op_flags[nop] = NPY_ITER_READONLY | NPY_ITER_ARRAYMASK;
@@ -2287,7 +2287,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         op_flags[i] = NPY_ITER_READONLY |
                       NPY_ITER_COPY |
                       NPY_ITER_ALIGNED |
-                      NPY_ITER_OVERLAP_ALLOW_SAME;
+                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -2303,7 +2303,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_ALIGNED|
                       NPY_ITER_ALLOCATE|
                       NPY_ITER_NO_BROADCAST|
-                      NPY_ITER_OVERLAP_ALLOW_SAME;
+                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
     }
 
     iter_flags = ufunc->iter_flags |

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1482,7 +1482,7 @@ iterator_loop(PyUFuncObject *ufunc,
             baseptrs[i] = PyArray_BYTES(op_it[i]);
         }
         for (i = nin; i < nop; ++i) {
-            baseptrs[i] = PyArray_BYTES(op[i]);
+            baseptrs[i] = PyArray_BYTES(op_it[i]);
         }
         if (NpyIter_ResetBasePointers(iter, baseptrs, NULL) != NPY_SUCCEED) {
             NpyIter_Deallocate(iter);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1417,7 +1417,8 @@ iterator_loop(PyUFuncObject *ufunc,
     /* Set up the flags */
     for (i = 0; i < nin; ++i) {
         op_flags[i] = NPY_ITER_READONLY |
-                      NPY_ITER_ALIGNED;
+                      NPY_ITER_ALIGNED |
+                      NPY_ITER_OVERLAP_ALLOW_SAME;
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -1432,7 +1433,8 @@ iterator_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALIGNED |
                       NPY_ITER_ALLOCATE |
                       NPY_ITER_NO_BROADCAST |
-                      NPY_ITER_NO_SUBTYPE;
+                      NPY_ITER_NO_SUBTYPE |
+                      NPY_ITER_OVERLAP_ALLOW_SAME;
     }
 
     iter_flags = ufunc->iter_flags |
@@ -1728,7 +1730,8 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
     for (i = 0; i < nin; ++i) {
         op_flags[i] = default_op_in_flags |
                       NPY_ITER_READONLY |
-                      NPY_ITER_ALIGNED;
+                      NPY_ITER_ALIGNED |
+                      NPY_ITER_OVERLAP_ALLOW_SAME;
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -1748,7 +1751,8 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
                       NPY_ITER_ALIGNED |
                       NPY_ITER_ALLOCATE |
                       NPY_ITER_NO_BROADCAST |
-                      NPY_ITER_NO_SUBTYPE;
+                      NPY_ITER_NO_SUBTYPE |
+                      NPY_ITER_OVERLAP_ALLOW_SAME;
     }
     if (wheremask != NULL) {
         op_flags[nop] = NPY_ITER_READONLY | NPY_ITER_ARRAYMASK;
@@ -2276,7 +2280,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     for (i = 0; i < nin; ++i) {
         op_flags[i] = NPY_ITER_READONLY |
                       NPY_ITER_COPY |
-                      NPY_ITER_ALIGNED;
+                      NPY_ITER_ALIGNED |
+                      NPY_ITER_OVERLAP_ALLOW_SAME;
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -2291,7 +2296,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_UPDATEIFCOPY|
                       NPY_ITER_ALIGNED|
                       NPY_ITER_ALLOCATE|
-                      NPY_ITER_NO_BROADCAST;
+                      NPY_ITER_NO_BROADCAST|
+                      NPY_ITER_OVERLAP_ALLOW_SAME;
     }
 
     iter_flags = ufunc->iter_flags |
@@ -3627,8 +3633,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                       NPY_ITER_ALIGNED;
         op_flags[1] = NPY_ITER_READONLY|
                       NPY_ITER_COPY|
-                      NPY_ITER_ALIGNED|
-                      NPY_ITER_OVERLAP_NOT_SAME;
+                      NPY_ITER_ALIGNED;
         op_flags[2] = NPY_ITER_READONLY;
 
         op_dtypes[1] = op_dtypes[0];

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3627,7 +3627,8 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                       NPY_ITER_ALIGNED;
         op_flags[1] = NPY_ITER_READONLY|
                       NPY_ITER_COPY|
-                      NPY_ITER_ALIGNED;
+                      NPY_ITER_ALIGNED|
+                      NPY_ITER_OVERLAP_NOT_SAME;
         op_flags[2] = NPY_ITER_READONLY;
 
         op_dtypes[1] = op_dtypes[0];

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1581,7 +1581,9 @@ execute_legacy_ufunc_loop(PyUFuncObject *ufunc,
             }
             else if (op[1] != NULL &&
                         PyArray_NDIM(op[1]) >= PyArray_NDIM(op[0]) &&
-                        PyArray_TRIVIALLY_ITERABLE_PAIR(op[0], op[1])) {
+                        PyArray_TRIVIALLY_ITERABLE_PAIR(op[0], op[1],
+                                                        PyArray_TRIVIALLY_ITERABLE_OP_READ,
+                                                        PyArray_TRIVIALLY_ITERABLE_OP_NOREAD)) {
 
                 /* Call the __prepare_array__ if necessary */
                 if (prepare_ufunc_output(ufunc, &op[1],
@@ -1598,7 +1600,9 @@ execute_legacy_ufunc_loop(PyUFuncObject *ufunc,
         else if (nin == 2 && nout == 1) {
             if (op[2] == NULL &&
                         (order == NPY_ANYORDER || order == NPY_KEEPORDER) &&
-                        PyArray_TRIVIALLY_ITERABLE_PAIR(op[0], op[1])) {
+                        PyArray_TRIVIALLY_ITERABLE_PAIR(op[0], op[1],
+                                                        PyArray_TRIVIALLY_ITERABLE_OP_READ,
+                                                        PyArray_TRIVIALLY_ITERABLE_OP_READ)) {
                 PyArrayObject *tmp;
                 /*
                  * Have to choose the input with more dimensions to clone, as
@@ -1637,7 +1641,10 @@ execute_legacy_ufunc_loop(PyUFuncObject *ufunc,
             else if (op[2] != NULL &&
                     PyArray_NDIM(op[2]) >= PyArray_NDIM(op[0]) &&
                     PyArray_NDIM(op[2]) >= PyArray_NDIM(op[1]) &&
-                    PyArray_TRIVIALLY_ITERABLE_TRIPLE(op[0], op[1], op[2])) {
+                    PyArray_TRIVIALLY_ITERABLE_TRIPLE(op[0], op[1], op[2],
+                                                      PyArray_TRIVIALLY_ITERABLE_OP_READ,
+                                                      PyArray_TRIVIALLY_ITERABLE_OP_READ,
+                                                      PyArray_TRIVIALLY_ITERABLE_OP_NOREAD)) {
 
                 /* Call the __prepare_array__ if necessary */
                 if (prepare_ufunc_output(ufunc, &op[2],

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1712,7 +1712,6 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
     npy_intp *strides;
     npy_intp *countptr;
 
-    PyArrayObject **op_it;
     npy_uint32 iter_flags;
 
     if (wheremask != NULL) {
@@ -1787,7 +1786,6 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
     needs_api = NpyIter_IterationNeedsAPI(iter);
 
     /* Call the __array_prepare__ functions where necessary */
-    op_it = NpyIter_GetOperandArray(iter);
     for (i = nin; i < nop; ++i) {
         PyArrayObject *op_tmp;
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1765,8 +1765,10 @@ execute_fancy_ufunc_loop(PyUFuncObject *ufunc,
     }
     for (i = nin; i < nop; ++i) {
         /*
-         * Because we don't write to all elements, the output arrays
-         * must be considered READWRITE by the iterator.
+         * We don't write to all elements, and the iterator may make
+         * UPDATEIFCOPY temporary copies. The output arrays must be considered
+         * READWRITE by the iterator, so that the elements we don't write to are
+         * copied to the possible temporary array.
          */
         op_flags[i] = default_op_out_flags |
                       NPY_ITER_READWRITE |

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -4,8 +4,8 @@ import sys
 import itertools
 
 import numpy as np
-from numpy.testing import (run_module_suite, assert_, assert_raises, assert_equal, assert_array_equal,
-                           assert_allclose)
+from numpy.testing import (run_module_suite, assert_, assert_raises, assert_equal,
+                           assert_array_equal, assert_allclose)
 
 from numpy.core.multiarray_tests import solve_diophantine, internal_overlap
 from numpy.core import umath_tests

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -703,6 +703,20 @@ class TestUFunc(object):
         self.check_unary_fuzz(do_reduceat, get_out_axis_size,
                               dtype=np.int16, count=500)
 
+    def test_binary_ufunc_reduceat_manual(self):
+        def check(ufunc, a, ind, out):
+            c1 = ufunc.reduceat(a.copy(), ind.copy(), out=out.copy())
+            c2 = ufunc.reduceat(a, ind, out=out)
+            assert_array_equal(c1, c2)
+
+        # Exactly same input/output arrays
+        a = np.arange(10000, dtype=np.int16)
+        check(np.add, a, a[::-1].copy(), a)
+
+        # Overlap with index
+        a = np.arange(10000, dtype=np.int16)
+        check(np.add, a, a[::-1], a)
+
     def test_unary_gufunc_fuzz(self):
         shapes = [7, 13, 8, 21, 29, 32]
         gufunc = umath_tests.euclidean_pdist
@@ -843,6 +857,21 @@ class TestUFunc(object):
                         check(x[-1:].reshape([]), y)
                         check(x[:1].reshape([]), y[::-1])
                         check(x[-1:].reshape([]), y[::-1])
+
+    def test_unary_ufunc_where_same(self):
+        # Check behavior at wheremask overlap
+        ufunc = np.invert
+
+        def check(a, out, mask):
+            c1 = ufunc(a, out=out.copy(), where=mask.copy())
+            c2 = ufunc(a, out=out, where=mask)
+            assert_array_equal(c1, c2)
+
+        # Check behavior with same input and output arrays
+        x = np.arange(100).astype(np.bool_)
+        check(x, x, x)
+        check(x, x.copy(), x)
+        check(x, x, x.copy())
 
     def test_binary_ufunc_1d_manual(self):
         ufunc = np.add

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -84,7 +84,7 @@ def _check_assignment(srcidx, dstidx):
 
 
 def test_overlapping_assignments():
-    """Test automatically generated assignments which overlap in memory."""
+    # Test automatically generated assignments which overlap in memory.
 
     inds = _indices(ndims)
 

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -750,6 +750,30 @@ class TestUFunc(object):
                 if (c != cx).any():
                     assert_equal(c, cx)
 
+    def test_ufunc_at_manual(self):
+        def check(ufunc, a, ind, b=None):
+            a0 = a.copy()
+            if b is None:
+                ufunc.at(a0, ind.copy())
+                c1 = a0.copy()
+                ufunc.at(a, ind)
+                c2 = a.copy()
+            else:
+                ufunc.at(a0, ind.copy(), b.copy())
+                c1 = a0.copy()
+                ufunc.at(a, ind, b)
+                c2 = a.copy()
+            assert_array_equal(c1, c2)
+
+        # Overlap with index
+        a = np.arange(10000, dtype=np.int16)
+        check(np.invert, a[::-1], a)
+
+        # Overlap with second data array
+        a = np.arange(100, dtype=np.int16)
+        ind = np.arange(0, 100, 2, dtype=np.int16)
+        check(np.add, a, ind, a[25:75])
+
     def test_unary_ufunc_1d_manual(self):
         # Exercise branches in PyArray_EQUIVALENTLY_ITERABLE
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1155,12 +1155,12 @@ def test_iter_copy_if_overlap():
     i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
     assert_(not np.shares_memory(*i.operands))
 
-    # Copy not needed with allow_same, 2 ops, exactly same arrays
+    # Copy not needed with elementwise, 2 ops, exactly same arrays
     x = arange(10)
     a = x
     b = x
-    i = nditer([a, b], ['copy_if_overlap'], [['readonly', 'overlap_allow_same'],
-                                             ['readwrite', 'overlap_allow_same']])
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly', 'overlap_assume_elementwise'],
+                                             ['readwrite', 'overlap_assume_elementwise']])
     assert_(i.operands[0] is a and i.operands[1] is b)
     i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
     assert_(i.operands[0] is a and not np.shares_memory(i.operands[1], b))

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2408,7 +2408,11 @@ def test_iter_reduction():
     assert_equal(i[1].strides, (0,))
     # Do the reduction
     for x, y in i:
-        y[...] += x
+        # Use a for loop instead of ``y[...] += x``
+        # (equivalent to ``y[...] = y[...].copy() + x``),
+        # because y has zero strides we use for the reduction
+        for j in range(len(y)):
+            y[j] += x[j]
     # Since no axes were specified, should have allocated a scalar
     assert_equal(i.operands[1].ndim, 0)
     assert_equal(i.operands[1], np.sum(a))
@@ -2459,7 +2463,11 @@ def test_iter_buffering_reduction():
     assert_equal(i[1].strides, (0,))
     # Do the reduction
     for x, y in i:
-        y[...] += x
+        # Use a for loop instead of ``y[...] += x``
+        # (equivalent to ``y[...] = y[...].copy() + x``),
+        # because y has zero strides we use for the reduction
+        for j in range(len(y)):
+            y[j] += x[j]
     assert_equal(b, np.sum(a, axis=1))
 
     # Iterator inner double loop was wrong on this one

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1155,12 +1155,15 @@ def test_iter_copy_if_overlap():
     i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
     assert_(not np.shares_memory(*i.operands))
 
-    # Copy not needed, 2 ops, exactly same arrays
+    # Copy not needed with allow_same, 2 ops, exactly same arrays
     x = arange(10)
     a = x
     b = x
-    i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly', 'overlap_allow_same'],
+                                             ['readwrite', 'overlap_allow_same']])
     assert_(i.operands[0] is a and i.operands[1] is b)
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
+    assert_(i.operands[0] is a and not np.shares_memory(i.operands[1], b))
 
     # Copy not needed, 2 ops, no overlap
     x = arange(10)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1139,6 +1139,91 @@ def test_iter_common_dtype():
     assert_equal(i.dtypes[1], np.dtype('c16'))
     assert_equal(i.dtypes[2], np.dtype('c16'))
 
+def test_iter_copy_if_overlap():
+    # Ensure the iterator makes copies on read/write overlap, if requested
+
+    # Copy not needed, 1 op
+    for flag in ['readonly', 'writeonly', 'readwrite']:
+        a = arange(10)
+        i = nditer([a], ['copy_if_overlap'], [[flag]])
+        assert_(i.operands[0] is a)
+
+    # Copy needed, 2 ops, read-write overlap
+    x = arange(10)
+    a = x[1:]
+    b = x[:-1]
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
+    assert_(not np.shares_memory(*i.operands))
+
+    # Copy not needed, 2 ops, exactly same arrays
+    x = arange(10)
+    a = x
+    b = x
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['readwrite']])
+    assert_(i.operands[0] is a and i.operands[1] is b)
+
+    # Copy not needed, 2 ops, no overlap
+    x = arange(10)
+    a = x[::2]
+    b = x[1::2]
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['writeonly']])
+    assert_(i.operands[0] is a and i.operands[1] is b)
+
+    # Copy needed, 2 ops, read-write overlap
+    x = arange(4, dtype=np.int8)
+    a = x[3:]
+    b = x.view(np.int32)[:1]
+    i = nditer([a, b], ['copy_if_overlap'], [['readonly'], ['writeonly']])
+    assert_(not np.shares_memory(*i.operands))
+
+    # Copy needed, 3 ops, read-write overlap
+    for flag in ['writeonly', 'readwrite']:
+        x = np.ones([10, 10])
+        a = x
+        b = x.T
+        c = x
+        i = nditer([a, b, c], ['copy_if_overlap'],
+                   [['readonly'], ['readonly'], [flag]])
+        a2, b2, c2 = i.operands
+        assert_(not np.shares_memory(a2, c2))
+        assert_(not np.shares_memory(b2, c2))
+
+    # Copy not needed, 3 ops, read-only overlap
+    x = np.ones([10, 10])
+    a = x
+    b = x.T
+    c = x
+    i = nditer([a, b, c], ['copy_if_overlap'],
+               [['readonly'], ['readonly'], ['readonly']])
+    a2, b2, c2 = i.operands
+    assert_(a is a2)
+    assert_(b is b2)
+    assert_(c is c2)
+
+    # Copy not needed, 3 ops, read-only overlap
+    x = np.ones([10, 10])
+    a = x
+    b = np.ones([10, 10])
+    c = x.T
+    i = nditer([a, b, c], ['copy_if_overlap'],
+               [['readonly'], ['writeonly'], ['readonly']])
+    a2, b2, c2 = i.operands
+    assert_(a is a2)
+    assert_(b is b2)
+    assert_(c is c2)
+
+    # Copy not needed, 3 ops, write-only overlap
+    x = np.arange(7)
+    a = x[:3]
+    b = x[3:6]
+    c = x[4:7]
+    i = nditer([a, b, c], ['copy_if_overlap'],
+               [['readonly'], ['writeonly'], ['writeonly']])
+    a2, b2, c2 = i.operands
+    assert_(a is a2)
+    assert_(b is b2)
+    assert_(c is c2)
+
 def test_iter_op_axes():
     # Check that custom axes work
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1462,7 +1462,9 @@ class TestSpecialMethods(TestCase):
 
         a = np.array([1]).view(type=with_prepare)
         x = np.add(a, a, a)
-        assert_(not np.shares_memory(x, a))  # returned array is always new
+        # Returned array is new, because of the strange
+        # __array_prepare__ above
+        assert_(not np.shares_memory(x, a))
         assert_equal(x, np.array([2]))
         assert_equal(type(x), with_prepare)
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1452,6 +1452,20 @@ class TestSpecialMethods(TestCase):
         assert_equal(x, np.array(2))
         assert_equal(type(x), with_prepare)
 
+    def test_prepare_out(self):
+
+        class with_prepare(np.ndarray):
+            __array_priority__ = 10
+
+            def __array_prepare__(self, arr, context):
+                return np.array(arr).view(type=with_prepare)
+
+        a = np.array([1]).view(type=with_prepare)
+        x = np.add(a, a, a)
+        assert_(not np.shares_memory(x, a))  # returned array is always new
+        assert_equal(x, np.array([2]))
+        assert_equal(type(x), with_prepare)
+
     def test_failing_prepare(self):
 
         class A(object):


### PR DESCRIPTION
Make ufuncs and ufunc operations to make temporary copies if input and output operands overlap in memory. Currently (cf. gh-6272, gh-1683) output from such operations is undefined. With this PR, the result is the same as if the operands were non-overlapping.

Fixes gh-1683

Adds new flags to NpyIter, and one new API function is added to deal with MapIter.

This PR does not fix up overlap handling in array assignment, that needs to be done later (and is slightly more hairy --- some common overlapping cases are in fact already handled). Unlike adding overlap-if-copy flag to NpyIter, it appears a similar flag would not be as useful in MapIter, as there are many special-cased code paths, and MapIter is not always made aware of all arrays operated on.

- [x] reread whole patch
- [x] re-check test coverage, and whether some of the tests are unnecessary
