### PR TITLE
remove refcount semantics, now a.resize() almost always requires refc…

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4123,6 +4123,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('resize',
     ValueError
         If `a` does not own its own data or references or views to it exist,
         and the data memory must be changed.
+        PyPy only: will always raise if the data memory must be changed, since
+        there is no reliable way to determine if references or views to it
+        exist.
 
     SystemError
         If the `order` keyword argument is specified. This behaviour is a

--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -116,9 +116,10 @@ extern "C" CONFUSE_EMACS
 
 #define PyArray_FILLWBYTE(obj, val) memset(PyArray_DATA(obj), val, \
                                            PyArray_NBYTES(obj))
-
+#ifndef PYPY_VERSION
 #define PyArray_REFCOUNT(obj) (((PyObject *)(obj))->ob_refcnt)
 #define NPY_REFCOUNT PyArray_REFCOUNT
+#endif
 #define NPY_MAX_ELSIZE (2 * NPY_SIZEOF_LONGDOUBLE)
 
 #define PyArray_ContiguousFromAny(op, type, min_depth, max_depth) \

--- a/numpy/core/include/numpy/noprefix.h
+++ b/numpy/core/include/numpy/noprefix.h
@@ -203,7 +203,9 @@
 #define MAX_UINTP NPY_MAX_UINTP
 #define INTP_FMT NPY_INTP_FMT
 
+#ifndef PYPY_VERSION
 #define REFCOUNT PyArray_REFCOUNT
 #define MAX_ELSIZE NPY_MAX_ELSIZE
+#endif
 
 #endif

--- a/numpy/core/include/numpy/oldnumeric.h
+++ b/numpy/core/include/numpy/oldnumeric.h
@@ -1,8 +1,10 @@
 #include "arrayobject.h"
 
+#ifndef PYPY_VERSION
 #ifndef REFCOUNT
 #  define REFCOUNT NPY_REFCOUNT
 #  define MAX_ELSIZE 16
+#endif
 #endif
 
 #define PyArray_UNSIGNED_TYPES

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -87,7 +87,15 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         }
 
         if (refcheck) {
+#ifdef PYPY_VERSION
+            PyErr_SetString(PyExc_ValueError,
+                    "cannot resize an array with refcheck=True on PyPy.\n"
+                    "Use the resize function or refcheck=False");
+             
+            return NULL;
+#else            
             refcnt = PyArray_REFCOUNT(self);
+#endif            
         }
         else {
             refcnt = 1;
@@ -96,8 +104,8 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
                 || (PyArray_BASE(self) != NULL)
                 || (((PyArrayObject_fields *)self)->weakreflist != NULL)) {
             PyErr_SetString(PyExc_ValueError,
-                    "cannot resize an array that "\
-                    "references or is referenced\n"\
+                    "cannot resize an array that "
+                    "references or is referenced\n"
                     "by another array in this way.  Use the resize function");
             return NULL;
         }

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -13,7 +13,7 @@ from itertools import chain
 
 import numpy as np
 from numpy.testing import (
-        run_module_suite, TestCase, assert_, assert_equal,
+        run_module_suite, TestCase, assert_, assert_equal, IS_PYPY,
         assert_almost_equal, assert_array_equal, assert_array_almost_equal,
         assert_raises, assert_warns, dec, suppress_warnings
         )
@@ -1293,9 +1293,15 @@ class TestRegression(TestCase):
                 for k in range(3):
                     # Try to ensure that x->data contains non-zero floats
                     x = np.array([123456789e199], dtype=np.float64)
-                    x.resize((m, 0))
+                    if IS_PYPY:
+                        x.resize((m, 0), refcheck=False)
+                    else:
+                        x.resize((m, 0))
                     y = np.array([123456789e199], dtype=np.float64)
-                    y.resize((0, n))
+                    if IS_PYPY:
+                        y.resize((0, n),refcheck=False)
+                    else:
+                        y.resize((0, n))
 
                     # `dot` should just return zero (m,n) matrix
                     z = np.dot(x, y)


### PR DESCRIPTION
The refcount semantics on PyPy do not provide a reliable way to determine if other references to the buffer are alive. So I propose to more stringently require refcheck=False for a.resize(). I also undefined the refcount-related entries in the NumPy headers, so downstream issues will be detected earlier.

Note that with this commit, NumPy now fails only 33 tests on a nightly PyPy.
