### PR TITLE
Clear signaling NaN exceptions

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1645,6 +1645,7 @@ NPY_NO_EXPORT void
             *((npy_bool *)op1) = @func@(in1) != 0;
         }
     }
+    npy_clear_floatstatus();
 }
 /**end repeat1**/
 
@@ -1982,6 +1983,7 @@ HALF_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
         const npy_half in1 = *(npy_half *)ip1;
         *((npy_bool *)op1) = @func@(in1) != 0;
     }
+    npy_clear_floatstatus();
 }
 /**end repeat**/
 
@@ -2464,6 +2466,7 @@ NPY_NO_EXPORT void
         const @ftype@ in1i = ((@ftype@ *)ip1)[1];
         *((npy_bool *)op1) = @func@(in1r) @OP@ @func@(in1i);
     }
+    npy_clear_floatstatus();
 }
 /**end repeat1**/
 

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -643,8 +643,6 @@ sse2_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, npy_intp n)
     LOOP_BLOCKED_END {
         op[i] = npy_@kind@(ip1[i]) != 0;
     }
-    /* silence exceptions from comparisons */
-    npy_clear_floatstatus();
 }
 
 /**end repeat1**/

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2156,5 +2156,11 @@ def test_rint_big_int():
     assert_equal(val, np.rint(val))
 
 
+def test_signaling_nan_exceptions():
+    with assert_no_warnings():
+        a = np.ndarray(shape=(), dtype='float32', buffer=b'\x00\xe0\xbf\xff')
+        np.isnan(a)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Seems that the float point exceptions raised when operating with signaling NaN has little meaning after some loops. But why clear the error status also from SIMD specialized loops , isn't it the same?

Fixes #7838, but exceptions still happen:

``` python
import numpy as np
np.seterr(all='raise')
a = np.load('weird_array.npy')
np.isfinite(a)
```

Results in

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    np.isfinite(a)
FloatingPointError: invalid value encountered in isfinite
```
