### PR TITLE
ENH: add signature argument to vectorize for vectorizing like generalized ufuncs

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -7,6 +7,7 @@ Highlights
 ==========
 
 * Order of operations in ``np.einsum`` now can be optimized for large speed improvements.
+* New ``signature`` argument to ``np.vectorize`` for vectorizing with core dimensions.
 
 Dropped Support
 ===============
@@ -327,6 +328,16 @@ an intermediate array to reduce this scaling to ``N^3`` or effectively
 ``np.dot(a, b).dot(c)``. Usage of intermediate tensors to reduce scaling has
 been applied to the general einsum summation notation. See ``np.einsum_path``
 for more details.
+
+New ``signature`` argument to ``np.vectorize``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This argument allows for vectorizing user defined functions with core
+dimensions, in the style of NumPy's
+:ref:`generalized universal functions<c-api.generalized-ufuncs>`. This allows
+for vectorizing a much broader class of functions. For example, an arbitrary
+distance metric that combines two vectors to produce a scalar could be
+vectorized with ``signature='(n),(n)->()'``. See ``np.vectorize`` for full
+details.
 
 Changes
 =======

--- a/doc/source/reference/c-api.generalized-ufuncs.rst
+++ b/doc/source/reference/c-api.generalized-ufuncs.rst
@@ -1,3 +1,5 @@
+.. _c-api.generalized-ufuncs:
+
 ==================================
 Generalized Universal Function API
 ==================================

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2661,7 +2661,6 @@ class vectorize(object):
                             % (len(input_core_dims), len(args)))
         args = tuple(asanyarray(arg) for arg in args)
 
-        # consider checking for size 0 inputs?
         broadcast_shape, dim_sizes = _parse_input_dimensions(
             args, input_core_dims)
         input_shapes = _calculate_shapes(broadcast_shape, dim_sizes,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2245,10 +2245,10 @@ def disp(mesg, device=None, linefeed=True):
 
 # See http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
 _DIMENSION_NAME = r'\w+'
-_CORE_DIMENSION_LIST = '(?:%s(?:,%s)*)?' % (_DIMENSION_NAME, _DIMENSION_NAME)
-_ARGUMENT = r'\(%s\)' % _CORE_DIMENSION_LIST
-_ARGUMENT_LIST = '%s(?:,%s)*' % (_ARGUMENT, _ARGUMENT)
-_SIGNATURE = '^%s->%s$' % (_ARGUMENT_LIST, _ARGUMENT_LIST)
+_CORE_DIMENSION_LIST = '(?:{0:}(?:,{0:})*)?'.format(_DIMENSION_NAME)
+_ARGUMENT = r'\({}\)'.format(_CORE_DIMENSION_LIST)
+_ARGUMENT_LIST = '{0:}(?:,{0:})*'.format(_ARGUMENT)
+_SIGNATURE = '^{0:}->{0:}$'.format(_ARGUMENT_LIST)
 
 
 def _parse_gufunc_signature(signature):
@@ -2634,7 +2634,7 @@ class vectorize(object):
         return res
 
     def _vectorize_call_with_signature(self, func, args):
-        """Vectorized call over positional argument with a signature."""
+        """Vectorized call over positional arguments with a signature."""
         input_core_dims, output_core_dims = self._in_and_out_core_dims
 
         if len(args) != len(input_core_dims):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1196,6 +1196,32 @@ class TestVectorize(TestCase):
         with assert_raises_regex(ValueError, 'wrong number of outputs'):
             f([1, 2])
 
+    def test_size_zero_output(self):
+        # see issue 5868
+        f = np.vectorize(lambda x: x)
+        x = np.zeros([0, 5], dtype=int)
+        with assert_raises_regex(ValueError, 'otypes'):
+            f(x)
+
+        f.otypes = 'i'
+        assert_array_equal(f(x), x)
+
+        f = np.vectorize(lambda x: x, signature='()->()')
+        with assert_raises_regex(ValueError, 'otypes'):
+            f(x)
+
+        f = np.vectorize(lambda x: x, signature='()->()', otypes='i')
+        assert_array_equal(f(x), x)
+
+        f = np.vectorize(lambda x: x, signature='(n)->(n)', otypes='i')
+        assert_array_equal(f(x), x)
+
+        f = np.vectorize(lambda x: x, signature='(n)->(n)')
+        assert_array_equal(f(x.T), x.T)
+
+        f = np.vectorize(lambda x: [x], signature='()->(n)', otypes='i')
+        with assert_raises_regex(ValueError, 'new output dimensions'):
+            f(x)
 
 
 class TestDigitize(TestCase):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import operator
 import warnings
 import sys
 
@@ -1013,7 +1014,11 @@ class TestVectorize(TestCase):
 
     def test_assigning_docstring(self):
         def foo(x):
+            """Original documentation"""
             return x
+
+        f = vectorize(foo)
+        assert_equal(f.__doc__, foo.__doc__)
 
         doc = "Provided documentation"
         f = vectorize(foo, doc=doc)
@@ -1068,6 +1073,129 @@ class TestVectorize(TestCase):
         f.otypes = 'i'
         x = np.arange(5)
         assert_array_equal(f(x), x)
+
+    def test_parse_gufunc_signature(self):
+        assert_equal(nfb._parse_gufunc_signature('(x)->()'), ([('x',)], [()]))
+        assert_equal(nfb._parse_gufunc_signature('(x,y)->()'),
+                     ([('x', 'y')], [()]))
+        assert_equal(nfb._parse_gufunc_signature('(x),(y)->()'),
+                     ([('x',), ('y',)], [()]))
+        assert_equal(nfb._parse_gufunc_signature('(x)->(y)'),
+                     ([('x',)], [('y',)]))
+        assert_equal(nfb._parse_gufunc_signature('(x)->(y),()'),
+                     ([('x',)], [('y',), ()]))
+        assert_equal(nfb._parse_gufunc_signature('(),(a,b,c),(d)->(d,e)'),
+                     ([(), ('a', 'b', 'c'), ('d',)], [('d', 'e')]))
+        with assert_raises(ValueError):
+            nfb._parse_gufunc_signature('(x)(y)->()')
+        with assert_raises(ValueError):
+            nfb._parse_gufunc_signature('(x),(y)->')
+        with assert_raises(ValueError):
+            nfb._parse_gufunc_signature('((x))->(x)')
+
+    def test_signature_simple(self):
+        def addsubtract(a, b):
+            if a > b:
+                return a - b
+            else:
+                return a + b
+
+        f = vectorize(addsubtract, signature='(),()->()')
+        r = f([0, 3, 6, 9], [1, 3, 5, 7])
+        assert_array_equal(r, [1, 6, 1, 2])
+
+    def test_siganture_mean_last(self):
+        def mean(a):
+            return a.mean()
+
+        f = vectorize(mean, signature='(n)->()')
+        r = f([[1, 3], [2, 4]])
+        assert_array_equal(r, [2, 3])
+
+    def test_siganture_center(self):
+        def center(a):
+            return a - a.mean()
+
+        f = vectorize(center, signature='(n)->(n)')
+        r = f([[1, 3], [2, 4]])
+        assert_array_equal(r, [[-1, 1], [-1, 1]])
+
+    def test_siganture_two_outputs(self):
+        f = vectorize(lambda x: (x, x), signature='()->(),()')
+        r = f([1, 2, 3])
+        assert_(isinstance(r, tuple) and len(r) == 2)
+        assert_array_equal(r[0], [1, 2, 3])
+        assert_array_equal(r[1], [1, 2, 3])
+
+    def test_siganture_outer(self):
+        f = vectorize(np.outer, signature='(a),(b)->(a,b)')
+        r = f([1, 2], [1, 2, 3])
+        assert_array_equal(r, [[1, 2, 3], [2, 4, 6]])
+
+        r = f([[[1, 2]]], [1, 2, 3])
+        assert_array_equal(r, [[[[1, 2, 3], [2, 4, 6]]]])
+
+        r = f([[1, 0], [2, 0]], [1, 2, 3])
+        assert_array_equal(r, [[[1, 2, 3], [0, 0, 0]],
+                               [[2, 4, 6], [0, 0, 0]]])
+
+        r = f([1, 2], [[1, 2, 3], [0, 0, 0]])
+        assert_array_equal(r, [[[1, 2, 3], [2, 4, 6]],
+                               [[0, 0, 0], [0, 0, 0]]])
+
+    def test_siganture_computed_size(self):
+        f = vectorize(lambda x: x[:-1], signature='(n)->(m)')
+        r = f([1, 2, 3])
+        assert_array_equal(r, [1, 2])
+
+        r = f([[1, 2, 3], [2, 3, 4]])
+        assert_array_equal(r, [[1, 2], [2, 3]])
+
+    def test_signature_excluded(self):
+
+        def foo(a, b=1):
+            return a + b
+
+        f = vectorize(foo, signature='()->()', excluded={'b'})
+        assert_array_equal(f([1, 2, 3]), [2, 3, 4])
+        assert_array_equal(f([1, 2, 3], b=0), [1, 2, 3])
+
+    def test_signature_otypes(self):
+        f = vectorize(lambda x: x, signature='(n)->(n)', otypes=['float64'])
+        r = f([1, 2, 3])
+        assert_equal(r.dtype, np.dtype('float64'))
+        assert_array_equal(r, [1, 2, 3])
+
+    def test_signature_invalid_inputs(self):
+        f = vectorize(operator.add, signature='(n),(n)->(n)')
+        with assert_raises_regex(TypeError, 'wrong number of positional'):
+            f([1, 2])
+        with assert_raises_regex(
+                ValueError, 'does not have enough dimensions'):
+            f(1, 2)
+        with assert_raises_regex(
+                ValueError, 'inconsistent size for core dimension'):
+            f([1, 2], [1, 2, 3])
+
+        f = vectorize(operator.add, signature='()->()')
+        with assert_raises_regex(TypeError, 'wrong number of positional'):
+            f(1, 2)
+
+    def test_signature_invalid_outputs(self):
+
+        f = vectorize(lambda x: x[:-1], signature='(n)->(n)')
+        with assert_raises_regex(
+                ValueError, 'inconsistent size for core dimension'):
+            f([1, 2, 3])
+
+        f = vectorize(lambda x: x, signature='()->(),()')
+        with assert_raises_regex(ValueError, 'wrong number of outputs'):
+            f(1)
+
+        f = vectorize(lambda x: (x, x), signature='()->()')
+        with assert_raises_regex(ValueError, 'wrong number of outputs'):
+            f([1, 2])
+
 
 
 class TestDigitize(TestCase):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1104,7 +1104,7 @@ class TestVectorize(TestCase):
         r = f([0, 3, 6, 9], [1, 3, 5, 7])
         assert_array_equal(r, [1, 6, 1, 2])
 
-    def test_siganture_mean_last(self):
+    def test_signature_mean_last(self):
         def mean(a):
             return a.mean()
 
@@ -1112,7 +1112,7 @@ class TestVectorize(TestCase):
         r = f([[1, 3], [2, 4]])
         assert_array_equal(r, [2, 3])
 
-    def test_siganture_center(self):
+    def test_signature_center(self):
         def center(a):
             return a - a.mean()
 
@@ -1120,14 +1120,14 @@ class TestVectorize(TestCase):
         r = f([[1, 3], [2, 4]])
         assert_array_equal(r, [[-1, 1], [-1, 1]])
 
-    def test_siganture_two_outputs(self):
+    def test_signature_two_outputs(self):
         f = vectorize(lambda x: (x, x), signature='()->(),()')
         r = f([1, 2, 3])
         assert_(isinstance(r, tuple) and len(r) == 2)
         assert_array_equal(r[0], [1, 2, 3])
         assert_array_equal(r[1], [1, 2, 3])
 
-    def test_siganture_outer(self):
+    def test_signature_outer(self):
         f = vectorize(np.outer, signature='(a),(b)->(a,b)')
         r = f([1, 2], [1, 2, 3])
         assert_array_equal(r, [[1, 2, 3], [2, 4, 6]])
@@ -1143,7 +1143,7 @@ class TestVectorize(TestCase):
         assert_array_equal(r, [[[1, 2, 3], [2, 4, 6]],
                                [[0, 0, 0], [0, 0, 0]]])
 
-    def test_siganture_computed_size(self):
+    def test_signature_computed_size(self):
         f = vectorize(lambda x: x[:-1], signature='(n)->(m)')
         r = f([1, 2, 3])
         assert_array_equal(r, [1, 2])


### PR DESCRIPTION
I brought this up on the mailing list today and received some support, so I
thought I would share a preliminary patch.

~~Still needs tests and more extensive documentation.~~

Example usage (from the docstring):

```
Vectorized calculation of Pearson correlation coefficient and its p-value:

>>> import scipy.stats
>>> pearsonr = np.vectorize(scipy.stats.pearsonr,
...                         signature='(n),(n)->(),()')
>>> pearsonr([[0, 1, 2, 3]], [[1, 2, 3, 4], [4, 3, 2, 1]])
(array([ 1., -1.]), array([ 0.,  0.]))

Vectorized convolution:

>>> convolve = np.vectorize(np.convolve, signature='(n),(m)->(k)')
>>> convolve(np.eye(4), [1, 2, 1])
array([[ 1.,  2.,  1.,  0.,  0.,  0.],
       [ 0.,  1.,  2.,  1.,  0.,  0.],
       [ 0.,  0.,  1.,  2.,  1.,  0.],
       [ 0.,  0.,  0.,  1.,  2.,  1.]])
```

A note on speed: a `vectorize` with `signature` has about 6x the fixed overhead of `vectorize` (60us vs 10us) and also a much larger overhead per loop (2us vs 100ns). I don't think these numbers will make any difference for the intended use case (only trivial Python functions runs in less than 10us) but I thought I would toss them out there anyways. I have yet to make any attempts at optimization.

``` python
# run on python 3.5.2
import numpy as np
import operator

vectorize_add = np.vectorize(operator.add, otypes='i')
guvectorize_add = np.vectorize(operator.add, signature='(),()->()', otypes='i')

x = np.ones(1000000, dtype=int)

%timeit vectorize_add(1, 1)
#100000 loops, best of 3: 10.6 µs per loop

%timeit guvectorize_add(1, 1)
#10000 loops, best of 3: 63.4 µs per loop

%timeit vectorize_add(x, x)
#10 loops, best of 3: 112 ms per loop

%timeit guvectorize_add(x, x)
#1 loop, best of 3: 2.22 s per loop
```

Also fixes #5868
