### PR TITLE
BUG: Fix bugs for np.ma.count and copy on builtin types (issue #8019)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6390,12 +6390,7 @@ class _frommethod:
             arr = args[0]
             args[0] = a
             a = arr
-        # Get the method from the array (if possible)
         method_name = self.__name__
-        method = getattr(a, method_name, None)
-        if method is not None:
-            return method(*args, **params)
-        # Still here ? Then a is not a MaskedArray
         method = getattr(MaskedArray, method_name, None)
         if method is not None:
             return method(MaskedArray(a), *args, **params)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6392,7 +6392,7 @@ class _frommethod:
             a = arr
         marr = asanyarray(a)
         method_name = self.__name__
-        method = getattr(MaskedArray, method_name, None)
+        method = getattr(type(marr), method_name, None)
         if method is not None:
             return method(marr, *args, **params)
         # Still here ? OK, let's call the corresponding np function

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6390,13 +6390,14 @@ class _frommethod:
             arr = args[0]
             args[0] = a
             a = arr
+        marr = asanyarray(a)
         method_name = self.__name__
         method = getattr(MaskedArray, method_name, None)
         if method is not None:
-            return method(MaskedArray(a), *args, **params)
+            return method(marr, *args, **params)
         # Still here ? OK, let's call the corresponding np function
         method = getattr(np, method_name)
-        return method(a, *args, **params)
+        return method(marr, *args, **params)
 
 
 all = _frommethod('all')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -433,6 +433,11 @@ class TestMaskedArray(TestCase):
         assert_not_equal(y._data.ctypes.data, x._data.ctypes.data)
         assert_not_equal(y._mask.ctypes.data, x._mask.ctypes.data)
 
+    def test_copy_on_python_builtins(self):
+        # Tests copy works on python builtins (issue#8019)
+        self.assertTrue(isMaskedArray(np.ma.copy([1,2,3])))
+        self.assertTrue(isMaskedArray(np.ma.copy((1,2,3))))
+
     def test_copy_immutable(self):
         # Tests that the copy method is immutable, GitHub issue #5247
         a = np.ma.array([1, 2, 3])
@@ -1020,6 +1025,11 @@ class TestMaskedArrayArithmetic(TestCase):
         assert_(isinstance(res, ndarray))
         assert_(res.dtype.type is np.intp)
         assert_raises(ValueError, ott.count, axis=1)
+
+    def test_count_on_python_builtins(self):
+        # Tests count works on python builtins (issue#8019)
+        assert_equal(3, count([1,2,3]))
+        assert_equal(2, count((1,2)))
 
     def test_minmax_func(self):
         # Tests minimum and maximum.


### PR DESCRIPTION
As explained in issue #8019 `list` has a `count` (in Python3) and copy method, and `_frommethod.__call__` tries to call them instead of `np.ma.MaskedArray.count` and `np.ma.MaskedArray.copy`.
By using methods on MaskedArray always, we can resolve this issue (unexpected call of builtin object methods).
I think this fix is fine because docstring on _frommethod says “Define functions from existing MaskedArray methods”.
