### PR TITLE
BUG : financial.pmt modifies input (issue #8055)

### DIFF
--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -207,7 +207,7 @@ def pmt(rate, nper, pv, fv=0, when='end'):
 
     """
     when = _convert_when(when)
-    (rate, nper, pv, fv, when) = map(np.asarray, [rate, nper, pv, fv, when])
+    (rate, nper, pv, fv, when) = map(np.array, [rate, nper, pv, fv, when])
     temp = (1 + rate)**nper
     mask = (rate == 0.0)
     np.copyto(rate, 1.0, where=mask)


### PR DESCRIPTION
See [issue #8055](https://github.com/numpy/numpy/issues/8055) I've just changed  `np.asarray` to `np.array` so a copy of `rate` could be made as @jaimefrio  suggested. I must precise I'm new to Python and numpy.
