### PR TITLE
BUG, TST: Fix python3-dbg bug in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,27 +71,7 @@ matrix:
        - PYTHONOPTIMIZE=2
        - USE_ASV=1
 before_install:
-  - uname -a
-  - free -m
-  - df -h
-  - ulimit -a
-  - mkdir builds
-  - pushd builds
-  # Build into own virtualenv
-  # We therefore control our own environment, avoid travis' numpy
-  #
-  # Some change in virtualenv 14.0.5 caused `test_f2py` to fail. So, we have
-  # pinned `virtualenv` to the last known working version to avoid this failure.
-  # Appears we had some issues with certificates on Travis. It looks like
-  # bumping to 14.0.6 will help.
-  - pip install -U 'virtualenv==14.0.6'
-  - virtualenv --python=python venv
-  - source venv/bin/activate
-  - python -V
-  - pip install --upgrade pip setuptools
-  - pip install nose pytz cython
-  - if [ -n "$USE_ASV" ]; then pip install asv; fi
-  - popd
+  - ./tools/travis-before-install.sh
 
 script:
   - ./tools/travis-test.sh

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+uname -a
+free -m
+df -h
+ulimit -a
+mkdir builds
+pushd builds
+
+# Build into own virtualenv
+# We therefore control our own environment, avoid travis' numpy
+#
+# Some change in virtualenv 14.0.5 caused `test_f2py` to fail. So, we have
+# pinned `virtualenv` to the last known working version to avoid this failure.
+# Appears we had some issues with certificates on Travis. It looks like
+# bumping to 14.0.6 will help.
+pip install -U 'virtualenv==14.0.6'
+
+if [ -n "$USE_DEBUG" ]
+then
+  virtualenv --python=python3-dbg venv
+else
+  virtualenv --python=python venv
+fi
+
+source venv/bin/activate
+python -V
+pip install --upgrade pip setuptools
+pip install nose pytz cython
+if [ -n "$USE_ASV" ]; then pip install asv; fi
+popd

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -11,14 +11,11 @@ if [ -r /usr/lib/libeatmydata/libeatmydata.so ]; then
   export LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so
 fi
 
+source builds/venv/bin/activate
+
 # travis venv tests override python
 PYTHON=${PYTHON:-python}
 PIP=${PIP:-pip}
-
-# explicit python version needed here
-if [ -n "$USE_DEBUG" ]; then
-  PYTHON="python3-dbg"
-fi
 
 if [ -n "$PYTHON_OO" ]; then
   PYTHON="${PYTHON} -OO"


### PR DESCRIPTION
With USE_DEBUG=1, the wrong python was being used to create the `virtualenv`, meaning that installed
packages (e.g. `Cython`) were being installed to the wrong location.  This was discovered in #6938.
