### PR TITLE
DOC: Fix description of isinf in nan_to_num

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -342,7 +342,7 @@ def nan_to_num(x):
 
     See Also
     --------
-    isinf : Shows which elements are negative or negative infinity.
+    isinf : Shows which elements are positive or negative infinity.
     isneginf : Shows which elements are negative infinity.
     isposinf : Shows which elements are positive infinity.
     isnan : Shows which elements are Not a Number (NaN).


### PR DESCRIPTION
Minor fix - Change `isinf` description in "See Also" section of `nan_to_num` documentation to "_positive_ or negative infinity" (instead of "_negative_ or negative infinity"). Must have been a typo.
