### PR TITLE
BUG: non-integers can end up in dtype offsets

### DIFF
--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -867,6 +867,7 @@ _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset)
         *offset = PyLong_AsSsize_t(off);
     }
     else {
+        PyErr_SetString(PyExc_IndexError, "can't convert offset");
         return -1;
     }
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1071,8 +1071,19 @@ _convert_from_dict(PyObject *obj, int align)
             if (!off) {
                 goto fail;
             }
-            offset = PyInt_AsLong(off);
-            PyTuple_SET_ITEM(tup, 1, off);
+            offset = PyArray_PyIntAsInt(off);
+            if (offset == -1 && PyErr_Occurred()) {
+                Py_DECREF(off);
+                goto fail;
+            }
+            Py_DECREF(off);
+            if (offset < 0) {
+                PyErr_Format(PyExc_ValueError, "offset %d cannot be negative",
+                             (int)offset);
+                goto fail;
+            }
+
+            PyTuple_SET_ITEM(tup, 1, PyInt_FromLong(offset));
             /* Flag whether the fields are specified out of order */
             if (offset < totalsize) {
                 has_out_of_order_fields = 1;
@@ -1186,7 +1197,7 @@ _convert_from_dict(PyObject *obj, int align)
     if (tmp == NULL) {
         PyErr_Clear();
     } else {
-        itemsize = (int)PyInt_AsLong(tmp);
+        itemsize = (int)PyArray_PyIntAsInt(tmp);
         if (itemsize == -1 && PyErr_Occurred()) {
             Py_DECREF(new);
             return NULL;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -272,6 +272,21 @@ class TestRecord(TestCase):
         for n in d.names:
             assert_equal(d.fields[n][0], np.dtype('?'))
 
+    def test_nonint_offsets(self):
+        # gh-8059
+        def make_dtype(off):
+            return np.dtype({'names': ['A'], 'formats': ['i4'], 
+                             'offsets': [off]})
+        
+        assert_raises(TypeError, make_dtype, 'ASD')
+        assert_raises(OverflowError, make_dtype, 2**70)
+        assert_raises(TypeError, make_dtype, 2.3)
+        assert_raises(ValueError, make_dtype, -10)
+
+        # no errors here:
+        dt = make_dtype(np.uint32(0))
+        np.zeros(1, dtype=dt)[0].item()
+
 
 class TestSubarray(TestCase):
     def test_single_subarray(self):


### PR DESCRIPTION
Fix is to convert offsets to python ints at dtype creation.
Fixes #8059
