### PR TITLE
Update outdated Nose URL to nose.readthedocs.io

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -34,7 +34,7 @@ Building NumPy requires the following software installed:
    This is required for testing numpy, but not for using it.
 
 Python__ http://www.python.org
-nose__ http://somethingaboutorange.com/mrl/projects/nose/
+nose__ http://nose.readthedocs.io
 
 
 .. note:: 

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -9,7 +9,7 @@ Introduction
 ''''''''''''
 
 SciPy uses the `Nose testing system
-<http://www.somethingaboutorange.com/mrl/projects/nose>`__, with some
+<http://nose.readthedocs.io>`__, with some
 minor convenience features added.  Nose is an extension of the unit
 testing framework offered by `unittest.py
 <http://docs.python.org/lib/module-unittest.html>`__. Our goal is that

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -64,7 +64,7 @@ def import_nose():
 
     if not nose_is_good:
         msg = ('Need nose >= %d.%d.%d for tests - see '
-               'http://somethingaboutorange.com/mrl/projects/nose' %
+               'http://nose.readthedocs.io' %
                minimum_nose_version)
         raise ImportError(msg)
 


### PR DESCRIPTION
The old URL, http://somethingaboutorange.com/mrl/projects/nose/, unexplainably leads to a clickbait article called "MOST DANGEROUS PRESCRIPTION MEDICATIONS AND MEDICAL DEVICES OF 2016". I'm not even kidding.

The three instances changed are all instances of "somethingaboutorange" in the codebase.
