### PR TITLE
DOC: Fix erroneous return type description for np.roots.

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -167,7 +167,7 @@ def roots(p):
     Returns
     -------
     out : ndarray
-        An array containing the complex roots of the polynomial.
+        An array containing the roots of the polynomial.
 
     Raises
     ------


### PR DESCRIPTION
np.roots() does not always return complex roots, the
roots of a polynomial depend its coefficients and
therefore may be in the real or complex domain.

e.g.

```
>>> (np.roots([1,2,3])).dtype
dtype('complex128')
>>> (np.roots([1,2,])).dtype
dtype('float64')
```
