### PR TITLE
MAINT: Make Tempita explicit dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ before_install:
   - source venv/bin/activate
   - python -V
   - pip install --upgrade pip setuptools
-  - pip install nose pytz cython
+  - pip install nose pytz cython Tempita
   - if [ -n "$USE_ASV" ]; then pip install asv; fi
   - popd
 

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -29,7 +29,10 @@ Building NumPy requires the following software installed:
 
 2) Cython >= 0.19 (for development versions of numpy, not for released
                    versions)
-3) nose__ (optional) 1.0 or later
+3) Tempita >= 0.5.1 (for development versions of numpy, not for released
+                     versions; while this library comes with Cython, it is
+                     discouraged to rely on such availability in the long-run)
+4) nose__ (optional) 1.0 or later
 
    This is required for testing numpy, but not for using it.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install cython nose pytz
+  - conda install cython nose pytz Tempita
   - pip install . -vvv
 
 test_script:

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -84,10 +84,7 @@ def process_pyx(fromfile, tofile):
 
 def process_tempita_pyx(fromfile, tofile):
     try:
-        try:
-            from Cython import Tempita as tempita
-        except ImportError:
-            import tempita
+        import tempita
     except ImportError:
         raise Exception('Building %s requires Tempita: '
                         'pip install --user Tempita' % VENDOR)
@@ -103,10 +100,7 @@ def process_tempita_pyx(fromfile, tofile):
 
 def process_tempita_pxi(fromfile, tofile):
     try:
-        try:
-            from Cython import Tempita as tempita
-        except ImportError:
-            import tempita
+        import tempita
     except ImportError:
         raise Exception('Building %s requires Tempita: '
                         'pip install --user Tempita' % VENDOR)


### PR DESCRIPTION
Currently, we rely on `Tempita` from the `Cython` package. However, that is just a vendorization
detail that we shouldn't rely on.  Explicitly rely on `Tempita` itself so that we don't have to worry about this detail anymore.

Related discussion can be found <a href="https://groups.google.com/forum/#!msg/cython-users/LViuQUs4iQo/-fDcdNUFBwAJ">here</a> and <a href="https://github.com/numpy/numpy/pull/6938#discussion_r80430619">here</a>.

cc @rkern
