### PR TITLE
Fix test code on cpuinfo's main function

### DIFF
--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -681,13 +681,13 @@ cpu = cpuinfo()
 #    cpu.is_Intel()
 #    cpu.is_Alpha()
 #
-#    print 'CPU information:',
+#    print('CPU information:'),
 #    for name in dir(cpuinfo):
 #        if name[0]=='_' and name[1]!='_':
 #            r = getattr(cpu,name[1:])()
 #            if r:
 #                if r!=1:
-#                    print '%s=%s' %(name[1:],r),
+#                    print('%s=%s' %(name[1:],r))
 #                else:
-#                    print name[1:],
-#    print
+#                    print(name[1:]),
+#    print()


### PR DESCRIPTION
Due to future print import (py3k style), the commented code should also
have the strings enclosed with parentheses or else it'll break when
uncommented.

That code is useful when updating the library for quick tests.
