### PR TITLE
BUG: Fix array printing with precision=0.

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -626,9 +626,12 @@ class FloatFormat(object):
 
 
 def _digits(x, precision, format):
-    s = format % x
-    z = s.rstrip('0')
-    return precision - len(s) + len(z)
+    if precision > 0:
+        s = format % x
+        z = s.rstrip('0')
+        return precision - len(s) + len(z)
+    else:
+        return 0
 
 
 class IntegerFormat(object):

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -129,6 +129,16 @@ class TestPrintOptions:
         np.set_printoptions(precision=4)
         assert_equal(repr(x), "array([ 1.5   ,  0.    ,  1.2346])")
 
+    def test_precision_zero(self):
+        np.set_printoptions(precision=0)
+        for values, string in (
+                ([0.], " 0."), ([.3], " 0."), ([-.3], "-0."), ([.7], " 1."),
+                ([1.5], " 2."), ([-1.5], "-2."), ([-15.34], "-15."),
+                ([100.], " 100."), ([.2, -1, 122.51], "   0.,   -1.,  123."),
+                ([0], "0"), ([-12], "-12"), ([complex(.3, -.7)], " 0.-1.j")):
+            x = np.array(values)
+            assert_equal(repr(x), "array([%s])" % string)
+
     def test_formatter(self):
         x = np.arange(3)
         np.set_printoptions(formatter={'all':lambda x: str(x-1)})


### PR DESCRIPTION
Not a particularly significant matter, but trying something as follows:

``` python
import numpy as np
np.set_printoptions(precision=0)
print(np.array([.1]))
```

results in:

```
ValueError: unsupported format character '-' (0x2d) at index 4
```

This is easily fixed by handling the case of rounding to integers when counting significant digits.

I've also included instances of ties-to-even rounding in the test case, after the docstring for [rint()](http://docs.scipy.org/doc/numpy/reference/generated/numpy.rint.html), but maybe that's too specific (IEEE 754 defines more rounding modes).
