### PR TITLE
Fix bug in ravel_multi_index for big indices (Issue #7546)

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -8,6 +8,7 @@
 #include "numpy/npy_3kcompat.h"
 #include "numpy/npy_math.h"
 #include "npy_config.h"
+#include "templ_common.h" /* for npy_mul_with_overflow_intp */
 
 
 /*
@@ -1005,14 +1006,24 @@ arr_ravel_multi_index(PyObject *self, PyObject *args, PyObject *kwds)
             s = 1;
             for (i = dimensions.len-1; i >= 0; --i) {
                 ravel_strides[i] = s;
-                s *= dimensions.ptr[i];
+                if (npy_mul_with_overflow_intp(&s, s, dimensions.ptr[i])) {
+                    PyErr_SetString(PyExc_ValueError,
+                        "invalid dims: array size defined by dims is larger "
+                        "than the maximum possible size.");
+                    goto fail;
+                }
             }
             break;
         case NPY_FORTRANORDER:
             s = 1;
             for (i = 0; i < dimensions.len; ++i) {
                 ravel_strides[i] = s;
-                s *= dimensions.ptr[i];
+                if (npy_mul_with_overflow_intp(&s, s, dimensions.ptr[i])) {
+                    PyErr_SetString(PyExc_ValueError,
+                        "invalid dims: array size defined by dims is larger "
+                        "than the maximum possible size.");
+                    goto fail;
+                }
             }
             break;
         default:

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -962,11 +962,11 @@ end_while:
 NPY_NO_EXPORT PyObject *
 arr_ravel_multi_index(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    int i, s;
+    int i;
     PyObject *mode0=NULL, *coords0=NULL;
     PyArrayObject *ret = NULL;
     PyArray_Dims dimensions={0,0};
-    npy_intp ravel_strides[NPY_MAXDIMS];
+    npy_intp s, ravel_strides[NPY_MAXDIMS];
     NPY_ORDER order = NPY_CORDER;
     NPY_CLIPMODE modes[NPY_MAXDIMS];
 

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -47,11 +47,24 @@ class TestRavelUnravelIndex(TestCase):
             [[3, 6, 6], [4, 5, 1]])
         assert_equal(np.unravel_index(1621, (6, 7, 8, 9)), [3, 1, 4, 1])
 
-        # ravel_multi_index for big indices (issue#7546)
+    def test_big_indices(self):
+        # ravel_multi_index for big indices (issue #7546)
         arr = ([1, 29], [3, 5], [3, 117], [19, 2], [2379, 1284], [2, 2], [0, 1])
         assert_equal(
             np.ravel_multi_index(arr, (41, 7, 120, 36, 2706, 8, 6)),
             [5627771580, 117259570957])
+
+        # test overflow checking for too big array (issue #7546)
+        dummy_arr = ([0],[0])
+        half_max = np.iinfo(np.intp).max // 2
+        assert_equal(
+            np.ravel_multi_index(dummy_arr, (half_max, 2)), [0])
+        assert_raises(ValueError,
+            np.ravel_multi_index, dummy_arr, (half_max+1, 2))
+        assert_equal(
+            np.ravel_multi_index(dummy_arr, (half_max, 2), order='F'), [0])
+        assert_raises(ValueError,
+            np.ravel_multi_index, dummy_arr, (half_max+1, 2), order='F')
 
     def test_dtypes(self):
         # Test with different data types

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -47,6 +47,12 @@ class TestRavelUnravelIndex(TestCase):
             [[3, 6, 6], [4, 5, 1]])
         assert_equal(np.unravel_index(1621, (6, 7, 8, 9)), [3, 1, 4, 1])
 
+        # ravel_multi_index for big indices (issue#7546)
+        arr = ([1, 29], [3, 5], [3, 117], [19, 2], [2379, 1284], [2, 2], [0, 1])
+        assert_equal(
+            np.ravel_multi_index(arr, (41, 7, 120, 36, 2706, 8, 6)),
+            [5627771580, 117259570957])
+
     def test_dtypes(self):
         # Test with different data types
         for dtype in [np.int16, np.uint16, np.int32,

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -49,10 +49,12 @@ class TestRavelUnravelIndex(TestCase):
 
     def test_big_indices(self):
         # ravel_multi_index for big indices (issue #7546)
-        arr = ([1, 29], [3, 5], [3, 117], [19, 2], [2379, 1284], [2, 2], [0, 1])
-        assert_equal(
-            np.ravel_multi_index(arr, (41, 7, 120, 36, 2706, 8, 6)),
-            [5627771580, 117259570957])
+        if np.intp == np.int64:
+            arr = ([1, 29], [3, 5], [3, 117], [19, 2],
+                   [2379, 1284], [2, 2], [0, 1])
+            assert_equal(
+                np.ravel_multi_index(arr, (41, 7, 120, 36, 2706, 8, 6)),
+                [5627771580, 117259570957])
 
         # test overflow checking for too big array (issue #7546)
         dummy_arr = ([0],[0])


### PR DESCRIPTION
I fixed bug on Issue #7546 .
##### 1st commit:

As @jaimefrio said, I just changed type of variable `s` from `int` to `npy_intp`.
##### 2nd commit (not confident):

I added checking for array size overflow using npy_mul_with_overflow_intp, similar to PR #7463 .
It's my understanding that in PR #7463 @seberg checked wheather `arr.size * arr.dtype.itemsize` is greater than `np.iinfo(np.intp).max`.
However, in ravel_multi_index we don't know the type of the array defined by `dims` argument.
So, I just checked whether `arr.size` is greater than `np.iinfo(np.intp).max`. Is this fix okay?
