### PR TITLE
BUG: distutils: fix issue with rpath in fcompiler/gnu.py

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -235,7 +235,9 @@ class GnuFCompiler(FCompiler):
         return []
 
     def runtime_library_dir_option(self, dir):
-        return '-Wl,-rpath="%s"' % dir
+        sep = ',' if sys.platform == 'darwin' else '='
+        return '-Wl,-rpath%s"%s"' % (sep, dir)
+
 
 class Gnu95FCompiler(GnuFCompiler):
     compiler_type = 'gnu95'


### PR DESCRIPTION
`-Wl,rpath=` is Linux-specific, OS X needs a comma.

This addresses gh-6486, which was already closed but not actually addressed.
