### PR TITLE
DOC: Fix "See also" links in linalg.

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -257,7 +257,7 @@ def tensorsolve(a, b, axes=None):
 
     See Also
     --------
-    tensordot, tensorinv, einsum
+    numpy.tensordot, tensorinv, numpy.einsum
 
     Examples
     --------
@@ -416,7 +416,7 @@ def tensorinv(a, ind=2):
 
     See Also
     --------
-    tensordot, tensorsolve
+    numpy.tensordot, tensorsolve
 
     Examples
     --------


### PR DESCRIPTION
On pages for [tensorinv](http://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.tensorinv.html#numpy.linalg.tensorinv) and [tensorsolve](http://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.tensorsolve.html#numpy.linalg.tensorsolve).
