### PR TITLE
BUG: core: add missing error check after PyLong_AsSsize_t

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3981,6 +3981,9 @@ array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_
     }
     else if (PyLong_Check(max_work_obj)) {
         max_work = PyLong_AsSsize_t(max_work_obj);
+        if (PyErr_Occurred()) {
+            goto fail;
+        }
     }
 #if !defined(NPY_PY3K)
     else if (PyInt_Check(max_work_obj)) {

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -348,6 +348,12 @@ def test_shares_memory_api():
     assert_raises(np.TooHardError, np.shares_memory, a, b, max_work=long(1))
 
 
+def test_may_share_memory_bad_max_work():
+    x = np.zeros([1])
+    assert_raises(OverflowError, np.may_share_memory, x, x, max_work=10**100)
+    assert_raises(OverflowError, np.shares_memory, x, x, max_work=10**100)
+
+
 def test_internal_overlap_diophantine():
     def check(A, U, exists=None):
         X = solve_diophantine(A, U, 0, require_ub_nontrivial=1)


### PR DESCRIPTION
Trivial bugfix. PyLong can overflow ssize_t, so need to check error.
