### PR TITLE
DOC: Improve histogram2d() example.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -199,7 +199,10 @@ texinfo_documents = [
 # -----------------------------------------------------------------------------
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
-intersphinx_mapping = {'http://docs.python.org/dev': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/dev', None),
+    'matplotlib': ('http://matplotlib.org', None)
+}
 
 
 # -----------------------------------------------------------------------------

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -599,52 +599,40 @@ def histogram2d(x, y, bins=10, range=None, normed=False, weights=None):
     Construct a 2-D histogram with variable bin width. First define the bin
     edges:
 
-    >>> xedges = [0, 1, 1.5, 3, 5]
+    >>> xedges = [0, 1, 3, 5]
     >>> yedges = [0, 2, 3, 4, 6]
 
     Next we create a histogram H with random bin content:
 
-    >>> x = np.random.normal(3, 1, 100)
+    >>> x = np.random.normal(2, 1, 100)
     >>> y = np.random.normal(1, 1, 100)
-    >>> H, xedges, yedges = np.histogram2d(y, x, bins=(xedges, yedges))
+    >>> H, xedges, yedges = np.histogram2d(x, y, bins=(xedges, yedges))
+    >>> H = H.T  # Let each row list bins with common y range.
 
-    Or we fill the histogram H with a determined bin content:
-
-    >>> H = np.ones((4, 4)).cumsum().reshape(4, 4)
-    >>> print(H[::-1])  # This shows the bin content in the order as plotted
-    [[ 13.  14.  15.  16.]
-     [  9.  10.  11.  12.]
-     [  5.   6.   7.   8.]
-     [  1.   2.   3.   4.]]
-
-    Imshow can only do an equidistant representation of bins:
+    :func:`imshow <matplotlib.pyplot.imshow>` can only display square bins:
 
     >>> fig = plt.figure(figsize=(7, 3))
-    >>> ax = fig.add_subplot(131)
-    >>> ax.set_title('imshow: equidistant')
-    >>> im = plt.imshow(H, interpolation='nearest', origin='low',
-    ...            extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]])
+    >>> ax = fig.add_subplot(131, title='imshow: square bins')
+    >>> plt.imshow(H, interpolation='nearest', origin='low',
+    ...         extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]])
 
-    pcolormesh can display exact bin edges:
+    :func:`pcolormesh <matplotlib.pyplot.pcolormesh>` can display actual edges:
 
-    >>> ax = fig.add_subplot(132)
-    >>> ax.set_title('pcolormesh: exact bin edges')
+    >>> ax = fig.add_subplot(132, title='pcolormesh: actual edges',
+    ...         aspect='equal')
     >>> X, Y = np.meshgrid(xedges, yedges)
     >>> ax.pcolormesh(X, Y, H)
-    >>> ax.set_aspect('equal')
 
-    NonUniformImage displays exact bin edges with interpolation:
+    :class:`NonUniformImage <matplotlib.image.NonUniformImage>` can be used to
+    display actual bin edges with interpolation:
 
-    >>> ax = fig.add_subplot(133)
-    >>> ax.set_title('NonUniformImage: interpolated')
+    >>> ax = fig.add_subplot(133, title='NonUniformImage: interpolated',
+    ...         aspect='equal', xlim=xedges[[0, -1]], ylim=yedges[[0, -1]])
     >>> im = mpl.image.NonUniformImage(ax, interpolation='bilinear')
-    >>> xcenters = xedges[:-1] + 0.5 * (xedges[1:] - xedges[:-1])
-    >>> ycenters = yedges[:-1] + 0.5 * (yedges[1:] - yedges[:-1])
+    >>> xcenters = (xedges[:-1] + xedges[1:]) / 2
+    >>> ycenters = (yedges[:-1] + yedges[1:]) / 2
     >>> im.set_data(xcenters, ycenters, H)
     >>> ax.images.append(im)
-    >>> ax.set_xlim(xedges[0], xedges[-1])
-    >>> ax.set_ylim(yedges[0], yedges[-1])
-    >>> ax.set_aspect('equal')
     >>> plt.show()
 
     """


### PR DESCRIPTION
A couple of small improvements:
- made the bins matrix non-square for a slightly more general example;
- unswapped variables in the histogram call (that only flipped the data coordinates);
- added a transposition of the resulting counts matrix (needed for all three plots);
- dropped the fixed histogram override (unnecessary and too symmetric to discern the orientation);
- turned some inessential matplotlib statements into keyword arguments;
- simplified expressions for xy-lims and centers;
- added links to matplotlib entities.

Here's a rendition of the example with the changes: [numpy-ref-p1139.pdf](https://github.com/numpy/numpy/files/510957/numpy-ref-p1139.pdf).

On a side note, how about using something like [extlinks](http://www.sphinx-doc.org/en/stable/ext/extlinks.html) (so the matplotlib links could be inlined).

See also #8115.
