### PR TITLE
BUG: Fix broken pickle in MaskedArray when dtype is object (Return list instead of string when dtype is object)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5860,12 +5860,12 @@ class MaskedArray(ndarray):
 
         """
         cf = 'CF'[self.flags.fnc]
+        is_obj = self.dtype.kind == 'O'
         state = (1,
                  self.shape,
                  self.dtype,
                  self.flags.fnc,
-                 self._data.tobytes(cf),
-                 # self._data.tolist(),
+                 (self._data.tolist() if is_obj else self._data.tobytes(cf)),
                  getmaskarray(self).tobytes(cf),
                  # getmaskarray(self).tolist(),
                  self._fill_value,

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5860,17 +5860,8 @@ class MaskedArray(ndarray):
 
         """
         cf = 'CF'[self.flags.fnc]
-        is_obj = self.dtype.kind == 'O'
-        state = (1,
-                 self.shape,
-                 self.dtype,
-                 self.flags.fnc,
-                 (self._data.tolist() if is_obj else self._data.tobytes(cf)),
-                 getmaskarray(self).tobytes(cf),
-                 # getmaskarray(self).tolist(),
-                 self._fill_value,
-                 )
-        return state
+        data_state = super(MaskedArray, self).__reduce__()[2]
+        return data_state + (getmaskarray(self).tobytes(cf), self._fill_value)
 
     def __setstate__(self, state):
         """Restore the internal state of the masked array, for

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -489,7 +489,9 @@ class TestMaskedArray(TestCase):
                 a_pickled = pickle.loads(a.dumps())
                 assert_equal(a_pickled._mask, a._mask)
                 assert_equal(a_pickled._data, a._data)
-                if dtype is not object:
+                if dtype in (object, int):
+                    assert_equal(a_pickled.fill_value, 999)
+                else:
                     assert_equal(a_pickled.fill_value, dtype(999))
                 assert_array_equal(a_pickled.mask, mask)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -478,13 +478,20 @@ class TestMaskedArray(TestCase):
         # Tests pickling
         for dtype in (int, float, str, object):
             a = arange(10).astype(dtype)
-            a[::3] = masked
             a.fill_value = 999
-            a_pickled = pickle.loads(a.dumps())
-            assert_equal(a_pickled._mask, a._mask)
-            assert_equal(a_pickled._data, a._data)
-            if dtype is not object:
-                assert_equal(a_pickled.fill_value, dtype(999))
+
+            masks = ([0, 0, 0, 1, 0, 1, 0, 1, 0, 1],  # partially masked
+                     True,                            # Fully masked
+                     False)                           # Fully unmasked
+
+            for mask in masks:
+                a.mask = mask
+                a_pickled = pickle.loads(a.dumps())
+                assert_equal(a_pickled._mask, a._mask)
+                assert_equal(a_pickled._data, a._data)
+                if dtype is not object:
+                    assert_equal(a_pickled.fill_value, dtype(999))
+                assert_array_equal(a_pickled.mask, mask)
 
     def test_pickling_subbaseclass(self):
         # Test pickling w/ a subclass of ndarray

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -476,13 +476,15 @@ class TestMaskedArray(TestCase):
 
     def test_pickling(self):
         # Tests pickling
-        a = arange(10)
-        a[::3] = masked
-        a.fill_value = 999
-        a_pickled = pickle.loads(a.dumps())
-        assert_equal(a_pickled._mask, a._mask)
-        assert_equal(a_pickled._data, a._data)
-        assert_equal(a_pickled.fill_value, 999)
+        for dtype in (int, float, str, object):
+            a = arange(10).astype(dtype)
+            a[::3] = masked
+            a.fill_value = 999
+            a_pickled = pickle.loads(a.dumps())
+            assert_equal(a_pickled._mask, a._mask)
+            assert_equal(a_pickled._data, a._data)
+            if dtype is not object:
+                assert_equal(a_pickled.fill_value, dtype(999))
 
     def test_pickling_subbaseclass(self):
         # Test pickling w/ a subclass of ndarray


### PR DESCRIPTION
Fixes #1940 and #8113 

Is this fix correct? Should this be extended to `mrecords` too?

@pierregm @teoliphant 
