### PR TITLE
ENH: Improve support for POWER7 and POWER8 machines

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -178,6 +178,17 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
         display = '\n'.join(display)
     else:
         ccomp = self.compiler_so
+
+        from .cpuinfo import cpu
+        if cpu.is_power8() or cpu.is_power7():
+            # Avoid IBM extended double as machar algorithm doesn't converge.
+            # See https://gcc.gnu.org/wiki/Ieee128PowerPC for more info.
+            ldbl_as_dbl = ('-mlong-double-64',)
+            if (len(set(ccomp) & set(ldbl_as_dbl)) == 0):
+                # Only add if not already there
+                ccomp.extend(ldbl_as_dbl)
+                self.compiler_so = ccomp
+
         display = "C compiler: %s\n" % (' '.join(ccomp),)
     log.info(display)
     macros, objects, extra_postargs, pp_opts, build = \

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -298,6 +298,16 @@ class LinuxCPUInfo(CPUInfoBase):
     def _has_3dnowext(self):
         return re.match(r'.*?\b3dnowext\b', self.info[0]['flags']) is not None
 
+    # POWER series
+    def _is_ppc64le(self):
+        return self.info[0]['uname_m']=='ppc64le'
+
+    def _is_power7(self):
+        return re.match(r'^POWER7', self.info[0]['cpu']) is not None
+
+    def _is_power8(self):
+        return re.match(r'^POWER8', self.info[0]['cpu']) is not None
+
 class IRIXCPUInfo(CPUInfoBase):
     info = None
 

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -30,6 +30,17 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
         # add flags for (almost) sane C++ handling
         ccomp += ['-AA']
         self.compiler_so = ccomp
+
+    from .cpuinfo import cpu
+    if cpu.is_power8() or cpu.is_power7():
+        # Avoid IBM extended double as machar algorithm doesn't converge.
+        # See https://gcc.gnu.org/wiki/Ieee128PowerPC for more info.
+        ldbl_as_dbl = ('-mlong-double-64',)
+        if (len(set(ccomp) & set(ldbl_as_dbl)) == 0):
+            # Only add if not already there
+            ccomp.extend(ldbl_as_dbl)
+            self.compiler_so = ccomp
+
     # ensure OPT environment variable is read
     if 'OPT' in os.environ:
         from distutils.sysconfig import get_config_vars

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -12,6 +12,7 @@ from numpy.testing import (
     run_module_suite, assert_, assert_equal, SkipTest
 )
 from numpy.core.multiarray import typeinfo
+from numpy.distutils.cpuinfo import cpu
 import util
 
 wrap = None
@@ -119,12 +120,17 @@ _cast_dict['DOUBLE'] = _cast_dict['INT'] + ['UINT', 'FLOAT', 'DOUBLE']
 
 _cast_dict['CFLOAT'] = _cast_dict['FLOAT'] + ['CFLOAT']
 
+# These architectures have the IBM Extended precision implemented as long
+# double, which is not compatible with machar detection so long double is
+# compiled to behave as a double.
+longdouble_is_double = cpu.is_power8() or cpu.is_power7()
+
 # 32 bit system malloc typically does not provide the alignment required by
 # 16 byte long double types this means the inout intent cannot be satisfied
 # and several tests fail as the alignment flag can be randomly true or fals
 # when numpy gains an aligned allocator the tests could be enabled again
 if ((intp().dtype.itemsize != 4 or clongdouble().dtype.alignment <= 8) and
-        sys.platform != 'win32'):
+        sys.platform != 'win32' and not longdouble_is_double):
     _type_names.extend(['LONGDOUBLE', 'CDOUBLE', 'CLONGDOUBLE'])
     _cast_dict['LONGDOUBLE'] = _cast_dict['LONG'] + \
         ['ULONG', 'FLOAT', 'DOUBLE', 'LONGDOUBLE']


### PR DESCRIPTION
I noticed that those PowerPC machines (as ppc64le architecture) were not passing
all tests of numpy. Mainly because of how `long double` type is implemented:
https://gcc.gnu.org/wiki/Ieee128PowerPC#A1.3_Sizes

It uses IBM Extended Double and machar algorithm doesn't converge to determine
the long double precision. For that reason I chose to change the `long double`
size to be 8 bytes (just as `double`). The consequence of doing that is that
only the precision (mantissa size) is decreased as the exponent remains the
same.

Tests are all passing after I removed `long double` type of one of them.
