### PR TITLE
BUG: import full module path in npy_load_module

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -118,7 +118,7 @@ if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
         mod : module
 
         """
-        import importlib
+        import importlib.machinery
         return importlib.machinery.SourceFileLoader(name, fn).load_module()
 else:
     def npy_load_module(name, fn, info=None):


### PR DESCRIPTION
Use the full module path when importing importlib.machinery for use in the
npy_load_module function. Just importing importlib is not sufficient in certain
cases, for example Python 3.4.

closes #8147
