### PR TITLE
BUG: assert_allclose(..., equal_nan=False) doesn't raise AssertionError

### DIFF
--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -554,6 +554,18 @@ class TestAssertAllclose(unittest.TestCase):
             msg = exc.args[0]
         self.assertTrue("mismatch 25.0%" in msg)
 
+    def test_equal_nan(self):
+        a = np.array([np.nan])
+        b = np.array([np.nan])
+        # Should not raise:
+        assert_allclose(a, b, equal_nan=True)
+
+    def test_not_equal_nan(self):
+        a = np.array([np.nan])
+        b = np.array([np.nan])
+        self.assertRaises(AssertionError, assert_allclose, a, b,
+                          equal_nan=False)
+
 
 class TestArrayAlmostEqualNulp(unittest.TestCase):
 


### PR DESCRIPTION
As discussed in my comments for issue #8145, this patch adds the `equal_nan` argument to `assert_array_compare()`, and `assert_allclose()` passes the value it receives for the same argument through to `assert_array_compare()`.
