### PR TITLE
MAINT: Expose void-scalar "base" attribute in python

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1303,6 +1303,18 @@ gentype_base_get(PyObject *NPY_UNUSED(self))
     Py_RETURN_NONE;
 }
 
+static PyObject *
+voidtype_base_get(PyVoidScalarObject *self)
+{
+    if (self->base == NULL) {
+        Py_RETURN_NONE;
+    }
+    else {
+        Py_INCREF(self->base);
+        return self->base;
+    }
+}
+
 
 static PyArray_Descr *
 _realdescr_fromcomplexscalar(PyObject *self, int *typenum)
@@ -2098,6 +2110,11 @@ static PyGetSetDef voidtype_getsets[] = {
         (getter)voidtype_dtypedescr_get,
         (setter)0,
         "dtype object",
+        NULL},
+    {"base",
+        (getter)voidtype_base_get,
+        (setter)0,
+        "base object",
         NULL},
     {NULL, NULL, NULL, NULL, NULL}
 };

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -994,6 +994,11 @@ class TestStructured(TestCase):
             assert_equal(yy.itemsize, 0)
             assert_equal(xx, yy)
 
+    def test_base_attr(self):
+        a = np.zeros(3, dtype='i4,f4')
+        b = a[0]
+        assert_(b.base is a)
+
 
 class TestBool(TestCase):
     def test_test_interning(self):


### PR DESCRIPTION
This is a minor oversight I noticed a while ago: void scalars to not expose their `base` attribute correctly in python, eg

```
>>> a = np.zeros(3, dtype='i4,f4')
>>> b = a[0]
>>> b.base
None
```

This has been a mild annoyance for me when debugging a couple time in the past.

Fixed here.
