### PR TITLE
DOC: added example with empty indices for a scalar, #8138

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -863,6 +863,9 @@ def einsum(*operands, **kwargs):
     >>> np.einsum('..., ...', 3, c)
     array([[ 0,  3,  6],
            [ 9, 12, 15]])
+    >>> np.einsum(',ij', 3, C)
+    array([[ 0,  3,  6],
+           [ 9, 12, 15]])
     >>> np.einsum(3, [Ellipsis], c, [Ellipsis])
     array([[ 0,  3,  6],
            [ 9, 12, 15]])


### PR DESCRIPTION
Added an example to einsum showing how you can leave indices blank for a scalar.  This is my first ever pull request to an open source project.  Closes issue #8138 
