### PR TITLE
ENH: Add import time benchmarks.

### DIFF
--- a/benchmarks/benchmarks/bench_import.py
+++ b/benchmarks/benchmarks/bench_import.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, division, print_function
+
+from subprocess import call
+from sys import executable
+from timeit import default_timer
+
+from .common import Benchmark
+
+
+class Import(Benchmark):
+    timer = default_timer
+
+    def execute(self, command):
+        call((executable, '-c', command))
+
+    def time_numpy(self):
+        self.execute('import numpy')
+
+    def time_numpy_inspect(self):
+        # What are the savings from avoiding to import the inspect module?
+        self.execute('import numpy, inspect')
+
+    def time_fft(self):
+        self.execute('from numpy import fft')
+
+    def time_linalg(self):
+        self.execute('from numpy import linalg')
+
+    def time_ma(self):
+        self.execute('from numpy import ma')
+
+    def time_matlib(self):
+        self.execute('from numpy import matlib')
+
+    def time_random(self):
+        self.execute('from numpy import random')


### PR DESCRIPTION
This should make it easy to monitor impact of changes on import times or make a retrospective analysis.

The benchmarks are more or less equivalent to `time python -c 'import numpy'` and simple variants of it. For a comparison, some [results](https://github.com/numpy/numpy/files/531096/import-times.txt) collected by [looping `time`](https://github.com/numpy/numpy/files/531100/times.sh.txt).
