### PR TITLE
Fixup 8146, DOC: Clarify when PyArray_{Max, Min, Ptp} return scalars.

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1921,6 +1921,7 @@ Calculation
 
     Equivalent to :meth:`ndarray.max` (*self*, *axis*). Return the largest
     element of *self* along the given *axis*.
+    If it return only 1 element, return a numpy scalar, not an ndarray.
 
 .. c:function:: PyObject* PyArray_Min(PyArrayObject* self, int axis, PyArrayObject* out)
 
@@ -2098,7 +2099,7 @@ Array Functions
     second-to-last dimension of *obj2*. For 2-d arrays this is a
     matrix-product. Neither array is conjugated.
 
-.. c:function:: PyObject* PyArray_MatrixProduct2(PyObject* obj1, PyObject* obj, PyObject* out)
+.. c:function:: PyObject* PyArray_MatrixProduct2(PyObject* obj1, PyObject* obj, PyArrayObject* out)
 
     .. versionadded:: 1.6
 

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1919,20 +1919,24 @@ Calculation
 
 .. c:function:: PyObject* PyArray_Max(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.max` (*self*, *axis*). Return the largest
-    element of *self* along the given *axis*.
-    If it return only 1 element, return a numpy scalar, not an ndarray.
+    Equivalent to :meth:`ndarray.max` (*self*, *axis*). Returns the largest
+    element of *self* along the given *axis*. When the result is a single
+    element, returns a numpy scalar instead of an ndarray.
 
 .. c:function:: PyObject* PyArray_Min(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.min` (*self*, *axis*). Return the smallest
-    element of *self* along the given *axis*.
+    element of *self* along the given *axis*. When the result is a single
+    element, returns a numpy scalar instead of an ndarray.
+
 
 .. c:function:: PyObject* PyArray_Ptp(PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.ptp` (*self*, *axis*). Return the difference
     between the largest element of *self* along *axis* and the
-    smallest element of *self* along *axis*.
+    smallest element of *self* along *axis*. When the result is a single
+    element, returns a numpy scalar instead of an ndarray.
+
 
 
 


### PR DESCRIPTION
Fixup of #8146.
