### PR TITLE
MAINT: Fix ResourceWarning new in Python 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6-dev
 matrix:
   include:
     - python: 2.7

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -72,6 +72,7 @@ def have_compiler():
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
         p.stdout.close()
         p.stderr.close()
+        p.wait()
     except OSError:
         return False
     return True


### PR DESCRIPTION
In Python 2.6 the process destructor emits a ResourceWarning if the process has not terminated when destruction occurs. Fix by calling the wait method before return.

The Popen class may be used as a context manager in Python 3.2+, unfortunately that does not include 2.7.

Also add testing with Python 3.6-dev.
