### PR TITLE
ENH: Improve announce to find github squash-merge commits.

### DIFF
--- a/tools/announce.py
+++ b/tools/announce.py
@@ -65,10 +65,20 @@ def get_authors(revision_range):
 
 
 def get_prs(repo, revision_range):
-    merges = this_repo.git.log('--oneline', '--merges', revision_range)
+    # get pull request numbers from merges
+    merges = this_repo.git.log(
+        '--oneline', '--merges', revision_range)
     issues = re.findall(u"Merge pull request \#(\d*)", merges)
-    prnums = [int(s) for s in issues]
-    prs =  [repo.get_pull(n) for n in sorted(prnums)]
+    merge_prnums = [int(s) for s in issues]
+
+    # get pull request numbers from fast forward squash-merges
+    commits = this_repo.git.log(
+        '--oneline', '--no-merges', '--first-parent', revision_range)
+    issues = re.findall(u'.*\(\#(\d+)\)\n', commits)
+    squash_prnums = [int(s) for s in issues]
+
+    # get PR data from github repo
+    prs = [repo.get_pull(n) for n in sorted(merge_prnums + squash_prnums)]
     return prs
 
 


### PR DESCRIPTION
Currently when the squash-merge button is hit on github, the PR title
with "(#PR)" appended is used as the commit message summary line when
the merge is fast-forwarded. This PR adds the ability to pick out the
corresponding PR numbers from the git log output.

Note that github may change this in the future and one early squash
merge in the 1.12.0 release did not have the PR number appended.
