### PR TITLE
MAINT: make `assert_allclose` behavior on `nan`s match pre 1.12

### DIFF
--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -7,8 +7,9 @@ import os
 import numpy as np
 from numpy.testing import (
     assert_equal, assert_array_equal, assert_almost_equal,
-    assert_array_almost_equal, build_err_msg, raises, assert_raises,
-    assert_warns, assert_no_warnings, assert_allclose, assert_approx_equal,
+    assert_array_almost_equal, assert_array_less, build_err_msg,
+    raises, assert_raises, assert_warns, assert_no_warnings,
+    assert_allclose, assert_approx_equal,
     assert_array_almost_equal_nulp, assert_array_max_ulp,
     clear_and_catch_warnings, suppress_warnings, run_module_suite,
     assert_string_equal, assert_, tempdir, temppath,
@@ -565,6 +566,17 @@ class TestAssertAllclose(unittest.TestCase):
         b = np.array([np.nan])
         self.assertRaises(AssertionError, assert_allclose, a, b,
                           equal_nan=False)
+
+    def test_equal_nan_default(self):
+        # Make sure equal_nan default behavior remains unchanged. (All
+        # of these functions use assert_array_compare under the hood.)
+        # None of these should raise.
+        a = np.array([np.nan])
+        b = np.array([np.nan])
+        assert_array_equal(a, b)
+        assert_array_almost_equal(a, b)
+        assert_array_less(a, b)
+        assert_allclose(a, b)
 
 
 class TestArrayAlmostEqualNulp(unittest.TestCase):

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -1330,7 +1330,7 @@ def _assert_valid_refcount(op):
     del d  # for pyflakes
 
 
-def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=False,
+def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
                     err_msg='', verbose=True):
     """
     Raises an AssertionError if two objects are not equal up to desired


### PR DESCRIPTION
Before:

``` python
>>> import numpy as np
>>> np.__version__
'1.11.2'
>>> np.testing.assert_array_equal(np.nan, np.nan)
>>> np.testing.assert_array_almost_equal(np.nan, np.nan)
>>> np.testing.assert_array_less(np.nan, np.nan)
>>> np.testing.assert_allclose(np.nan, np.nan)
```

Now:

``` python
>>> np.__version__
'1.12.0.dev0+6da5f00'
>>> np.testing.assert_array_equal(np.nan, np.nan)
>>> np.testing.assert_array_almost_equal(np.nan, np.nan)
>>> np.testing.assert_array_less(np.nan, np.nan)
>>> np.testing.assert_allclose(np.nan, np.nan)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/Josh/Projects/numpy-dev/python3/numpy/numpy/testing/utils.py", line 1388, in assert_allclose
    verbose=verbose, header=header, equal_nan=equal_nan)
  File "/Users/Josh/Projects/numpy-dev/python3/numpy/numpy/testing/utils.py", line 773, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Not equal to tolerance rtol=1e-07, atol=0

(mismatch 100.0%)
 x: array(nan)
 y: array(nan)
```

Admittedly `np.assert_allclose(np.nan, np.nan)` raising seems more natural, but the changes make some old tests fail. For context see:

https://github.com/scipy/scipy/issues/6696
https://github.com/scipy/scipy/pull/6697
