### PR TITLE
DOC: 'highest' is exclusive for randint()

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -916,8 +916,8 @@ cdef class RandomState:
         ----------
         low : int
             Lowest (signed) integer to be drawn from the distribution (unless
-            ``high=None``, in which case this parameter is the *highest* such
-            integer).
+            ``high=None``, in which case this parameter is one above the
+            *highest* such integer).
         high : int, optional
             If provided, one above the largest (signed) integer to be drawn
             from the distribution (see above for behavior if ``high=None``).


### PR DESCRIPTION
The docstring for `numpy.random.randint()` incorrectly describes the `low` parameter in the case that `high` is `None`.  It claims `low` is then the highest integer to be drawn.  In fact it is a strict upper bound on the drawn integers, as correctly stated in the description of `high`.  This PR fixes the description of `low` by using the language of `high`'s description.
