### PR TITLE
ENH: Add np.scale function

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -24,6 +24,10 @@ New functions
 
   * `np.histogram_bin_edges`, a function to get the edges of the bins used by a histogram
     without needing to calculate the histogram.
+* New ``np.rescale(arr, out_min, out_max, in_min, in_max, axis)`` function
+  linearly scales the values of the array from interval ``[in_min, in_max]``
+  to ``[out_min, out_max]``.
+
 
 Deprecations
 ============

--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -168,3 +168,4 @@ Miscellaneous
    real_if_close
 
    interp
+   rescale

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4401,7 +4401,7 @@ def append(arr, values, axis=None):
 
 
 def rescale(arr, out_min=0, out_max=1, in_min=None, in_max=None,
-            axis=None, return_params=False, out=None):
+            axis=None, return_params=False):
     """Linearly scale non-NaN values in array to the specified interval.
 
     .. versionadded:: 1.15.0
@@ -4431,8 +4431,6 @@ def rescale(arr, out_min=0, out_max=1, in_min=None, in_max=None,
         If True, also return `offset` and `scale` parameters so that
         ``offset + scale * x`` maps ``x`` from input interval onto
         output interval.
-    out : array_like, optional
-        Array of the same shape as `arr`, in which to store the result.
 
     Returns
     -------
@@ -4483,11 +4481,6 @@ def rescale(arr, out_min=0, out_max=1, in_min=None, in_max=None,
 
     res = arr * scale + offset
 
-    if out is None:
-        out = res
-    else:
-        out[...] = res
-
     if return_params:
-        return out, offset, scale
-    return out
+        return res, offset, scale
+    return res

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3030,11 +3030,6 @@ class TestRescale(object):
         assert_equal(offset, np.c_[0, -2/3].T)
         assert_equal(scale, np.c_[1/3, 1/3].T)
 
-    def test_out(self):
-        out = np.zeros_like(self.arr)
-        assert_equal(rescale(self.arr, self.arr.min(), self.arr.max(), out=out),
-                     self.arr)
-
     def test_nan(self):
         arr = np.array([[1, 2],
                         [1, 1]])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2982,9 +2982,9 @@ class TestRescale(object):
         self.arr3d = np.arange(8, dtype=float).reshape((2, 2, 2))
 
     def test_basic(self):
-        assert_equal(rescale(self.arr),
-                     [[0, .2, .4, .6],
-                      [1, .8, .6, .4]])
+        assert_allclose(rescale(self.arr),
+                        [[0, .2, .4, .6],
+                         [1, .8, .6, .4]])
         assert_equal(rescale(self.arr, self.arr.min(), self.arr.max()),
                      self.arr)
 
@@ -2998,9 +2998,9 @@ class TestRescale(object):
         assert_equal(rescale(self.arr, [1, 0, 1, 2], [2, 1, 1, 3], axis=0),
                      [[1, 0, 1, 3],
                       [2, 1, 1, 2]])
-        assert_equal(rescale(self.arr, [[0], [0]], [[1], [1]], axis=1),
-                     [[0, 1/3, 2/3, 1],
-                      [1, 2/3, 1/3, 0]])
+        assert_allclose(rescale(self.arr, [[0], [0]], [[1], [1]], axis=1),
+                        [[0, 1/3, 2/3, 1],
+                         [1, 2/3, 1/3, 0]])
         assert_equal(rescale(self.arr3d, out_max=3.5),
                      (self.arr3d / 2).reshape((2, 2, 2)))
 
@@ -3012,14 +3012,23 @@ class TestRescale(object):
         assert_equal(rescale(self.arr, axis=0),
                      [[0, 0, 0, 1],
                       [1, 1, 1, 0]])
-        assert_equal(rescale(self.arr, axis=1),
-                     [[0, 1/3, 2/3, 1],
-                      [1, 2/3, 1/3, 0]])
+        assert_allclose(rescale(self.arr, axis=1),
+                        [[0, 1/3, 2/3, 1],
+                         [1, 2/3, 1/3, 0]])
         assert_equal(rescale(self.arr3d, axis=2),
                      [[[0, 1],
                        [0, 1]],
                       [[0, 1],
                        [0, 1]]])
+
+    def test_return_params(self):
+        _, offset, scale = rescale(self.arr, return_params=True)
+        assert_equal(offset, 0)
+        assert_equal(scale, .2)
+
+        _, offset, scale = rescale(self.arr, axis=1, return_params=True)
+        assert_equal(offset, np.c_[0, -2/3].T)
+        assert_equal(scale, np.c_[1/3, 1/3].T)
 
     def test_out(self):
         out = np.zeros_like(self.arr)


### PR DESCRIPTION
This PR adds a scale function for scaling non-NaN array values in any dimension onto a desired interval. I found myself somewhat regularly using something like this and copying it into projects. I think a robust implementation should fit into numpy quite nicely.

I hope you too won't find it unimaginable to have something like this in numpy and at roughly the proposed location.
