### PR TITLE
BUG: Fix structured array format functions 

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -316,18 +316,6 @@ def _get_format_function(data, precision, suppress_small, formatter):
 def _array2string(a, max_line_width, precision, suppress_small, separator=' ',
                   prefix="", formatter=None):
 
-    if max_line_width is None:
-        max_line_width = _line_width
-
-    if precision is None:
-        precision = _float_output_precision
-
-    if suppress_small is None:
-        suppress_small = _float_output_suppress_small
-
-    if formatter is None:
-        formatter = _formatter
-
     if a.size > _summaryThreshold:
         summary_insert = "..., "
         data = _leading_trailing(a)
@@ -458,11 +446,27 @@ def array2string(a, max_line_width=None, precision=None,
 
     """
 
+    if max_line_width is None:
+        max_line_width = _line_width
+
+    if precision is None:
+        precision = _float_output_precision
+
+    if suppress_small is None:
+        suppress_small = _float_output_suppress_small
+
+    if formatter is None:
+        formatter = _formatter
+
     if a.shape == ():
         x = a.item()
-        if isinstance(x, tuple):
-            x = _convert_arrays(x)
-        lst = style(x)
+        if a.dtype.fields is not None:
+            arr = asarray([x], dtype=a.dtype)
+            format_function = _get_format_function(
+                    arr, precision, suppress_small, formatter)
+            lst = format_function(arr[0])
+        else:
+            lst = style(x)
     elif reduce(product, a.shape) == 0:
         # treat as a null array if any of shape elements == 0
         lst = "[]"
@@ -470,6 +474,7 @@ def array2string(a, max_line_width=None, precision=None,
         lst = _array2string(a, max_line_width, precision, suppress_small,
                             separator, prefix, formatter=formatter)
     return lst
+
 
 def _extendLine(s, line, word, max_line_len, next_line_prefix):
     if len(line.rstrip()) + len(word.rstrip()) >= max_line_len:

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -117,7 +117,7 @@ class TestArray2String(TestCase):
         dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
         x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)
         assert_equal(np.array2string(x),
-                "[('Sarah', array([ 8.,  7.])) ('John', array([ 6.,  7.]))]")
+                "[('Sarah', [ 8.,  7.]) ('John', [ 6.,  7.])]")
 
         # for issue #5692
         A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
@@ -127,6 +127,15 @@ class TestArray2String(TestCase):
                 "('1970-01-01T00:00:00',)\n ('1970-01-01T00:00:00',) " +
                 "('1970-01-01T00:00:00',) ('NaT',) ('NaT',)\n " +
                 "('NaT',) ('NaT',) ('NaT',)]")
+
+        # See #8160
+        struct_int = np.array([([1, -1],), ([123, 1],)], dtype=[('B', 'i4', 2)])
+        assert_equal(np.array2string(struct_int),
+                "[([  1,  -1],) ([123,   1],)]")
+        struct_2dint = np.array([([[0, 1], [2, 3]],), ([[12, 0], [0, 0]],)],
+                dtype=[('B', 'i4', (2, 2))])
+        assert_equal(np.array2string(struct_2dint),
+                "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]")
 
 
 class TestPrintOptions:

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -137,6 +137,11 @@ class TestArray2String(TestCase):
         assert_equal(np.array2string(struct_2dint),
                 "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]")
 
+        # See #8172
+        array_scalar = np.array(
+                (1., 2.1234567890123456789, 3.), dtype=('f8,f8,f8'))
+        assert_equal(np.array2string(array_scalar), "( 1.,  2.12345679,  3.)")
+
 
 class TestPrintOptions:
     """Test getting and setting global print options."""


### PR DESCRIPTION
#### 1st commit
- Preserving structured array element format, this commit fixes subarray format changed in PR #8160.
- This commit also changes iterator for field name from `dtype_.descr` to `dtype_.names`. 
#### 2nd commit

Closes #8172 
### Reason of a test failure

test_format_on_flex_array_element (test_regression.TestRegression) fails because of the following `TypeError`.

```
In [1]: import numpy as np
   ...: 
   ...: dt = np.dtype([('date', '<M8[D]'), ('val', '<f8')])
   ...: arr = np.array([('2000-01-01', 1)], dt)
   ...: arr[0]

TypeError: input must have type NumPy datetime
```

It is because `array2string` calls `.item()` method of `arr[0]` and `.item()` casts the type of `date` field from `numpy.datetime64` to `datetime.time`.
Then `DatetimeFormat` calls `datetime_as_string` with the `datetime.time` object and `TypeError` raised (See followings).

```
In [11]: x = arr[0].item(); x
Out[11]: (datetime.date(2000, 1, 1), 1.0)

In [12]: type(x[0])
Out[12]: datetime.date

In [13]: np.datetime_as_string(x[0])
TypeError: input must have type NumPy datetime

In [14]: type(arr[0][0])
Out[14]: numpy.datetime64

In [15]: np.datetime_as_string(arr[0][0])
Out[15]: '2000-01-01'
```

I don't understand the mechanism of this casting yet. 
If this is a bug we should fix it. 
If this is not a bug, I have to fix the code to treat this error in this PR.
