### PR TITLE
ENH: Added submodule numpy.random_intel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ benchmarks/numpy
 cythonize.dat
 numpy/random/mtrand/mtrand.c
 numpy/random/mtrand/randint_helpers.pxi
+numpy/random_intel/mklrand/mklrand.c

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -164,6 +164,7 @@ else:
     from . import fft
     from . import polynomial
     from . import random
+    from . import random_intel
     from . import ctypeslib
     from . import ma
     from . import matrixlib as _mat
@@ -185,7 +186,7 @@ else:
     __all__.extend(core.__all__)
     __all__.extend(_mat.__all__)
     __all__.extend(lib.__all__)
-    __all__.extend(['linalg', 'fft', 'random', 'ctypeslib', 'ma'])
+    __all__.extend(['linalg', 'fft', 'random', 'random_intel', 'ctypeslib', 'ma'])
 
 
     # Filter annoying Cython warnings that serve no good purpose.

--- a/numpy/random_intel/__init__.py
+++ b/numpy/random_intel/__init__.py
@@ -1,0 +1,126 @@
+"""
+========================
+Random Number Generation
+========================
+
+==================== =========================================================
+Utility functions
+==============================================================================
+random               Uniformly distributed values of a given shape.
+bytes                Uniformly distributed random bytes.
+random_integers      Uniformly distributed integers in a given range.
+random_sample        Uniformly distributed floats in a given range.
+random               Alias for random_sample
+ranf                 Alias for random_sample
+sample               Alias for random_sample
+choice               Generate a weighted random sample from a given array-like
+permutation          Randomly permute a sequence / generate a random sequence.
+shuffle              Randomly permute a sequence in place.
+seed                 Seed the random number generator.
+==================== =========================================================
+
+==================== =========================================================
+Compatibility functions
+==============================================================================
+rand                 Uniformly distributed values.
+randn                Normally distributed values.
+ranf                 Uniformly distributed floating point numbers.
+randint              Uniformly distributed integers in a given range.
+==================== =========================================================
+
+==================== =========================================================
+Univariate distributions
+==============================================================================
+beta                 Beta distribution over ``[0, 1]``.
+binomial             Binomial distribution.
+chisquare            :math:`\\chi^2` distribution.
+exponential          Exponential distribution.
+f                    F (Fisher-Snedecor) distribution.
+gamma                Gamma distribution.
+geometric            Geometric distribution.
+gumbel               Gumbel distribution.
+hypergeometric       Hypergeometric distribution.
+laplace              Laplace distribution.
+logistic             Logistic distribution.
+lognormal            Log-normal distribution.
+logseries            Logarithmic series distribution.
+negative_binomial    Negative binomial distribution.
+noncentral_chisquare Non-central chi-square distribution.
+noncentral_f         Non-central F distribution.
+normal               Normal / Gaussian distribution.
+pareto               Pareto distribution.
+poisson              Poisson distribution.
+power                Power distribution.
+rayleigh             Rayleigh distribution.
+triangular           Triangular distribution.
+uniform              Uniform distribution.
+vonmises             Von Mises circular distribution.
+wald                 Wald (inverse Gaussian) distribution.
+weibull              Weibull distribution.
+zipf                 Zipf's distribution over ranked data.
+==================== =========================================================
+
+==================== =========================================================
+Multivariate distributions
+==============================================================================
+dirichlet            Multivariate generalization of Beta distribution.
+multinomial          Multivariate generalization of the binomial distribution.
+multivariate_normal  Multivariate generalization of the normal distribution.
+==================== =========================================================
+
+==================== =========================================================
+Standard distributions
+==============================================================================
+standard_cauchy      Standard Cauchy-Lorentz distribution.
+standard_exponential Standard exponential distribution.
+standard_gamma       Standard Gamma distribution.
+standard_normal      Standard normal distribution.
+standard_t           Standard Student's t-distribution.
+==================== =========================================================
+
+==================== =========================================================
+Internal functions
+==============================================================================
+get_state            Get tuple representing internal state of generator.
+set_state            Set state of generator.
+==================== =========================================================
+
+"""
+from __future__ import division, absolute_import, print_function
+
+from numpy.distutils.system_info import get_info
+
+if get_info('mkl'):
+    import warnings
+
+    # To get sub-modules
+    from .info import __doc__, __all__
+
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="numpy.ndarray size changed")
+        from .mklrand import *
+
+        # Some aliases:
+        ranf = random = sample = random_sample
+        __all__.extend(['ranf', 'random', 'sample'])
+
+
+        def __RandomState_ctor():
+            """Return a RandomState instance.
+            
+            This function exists solely to assist (un)pickling.
+            
+            Note that the state of the RandomState returned here is irrelevant, as this function's
+            entire purpose is to return a newly allocated RandomState whose state pickle can set.
+            Consequently the RandomState returned by this function is a freshly allocated copy
+            with a seed=0.
+            
+            See https://github.com/numpy/numpy/issues/4763 for a detailed discussion
+            
+            """
+            return RandomState(seed=0)
+            
+        from numpy.testing.nosetester import _numpy_tester
+        test = _numpy_tester().test
+        bench = _numpy_tester().bench

--- a/numpy/random_intel/__init__.py
+++ b/numpy/random_intel/__init__.py
@@ -96,31 +96,30 @@ if get_info('mkl'):
     # To get sub-modules
     from .info import __doc__, __all__
 
-
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="numpy.ndarray size changed")
         from .mklrand import *
 
-        # Some aliases:
-        ranf = random = sample = random_sample
-        __all__.extend(['ranf', 'random', 'sample'])
+    # Some aliases:
+    ranf = random = sample = random_sample
+    __all__.extend(['ranf', 'random', 'sample'])
 
 
-        def __RandomState_ctor():
-            """Return a RandomState instance.
+    def __RandomState_ctor():
+        """Return a RandomState instance.
             
-            This function exists solely to assist (un)pickling.
+        This function exists solely to assist (un)pickling.
             
-            Note that the state of the RandomState returned here is irrelevant, as this function's
-            entire purpose is to return a newly allocated RandomState whose state pickle can set.
-            Consequently the RandomState returned by this function is a freshly allocated copy
-            with a seed=0.
+        Note that the state of the RandomState returned here is irrelevant, as this function's
+        entire purpose is to return a newly allocated RandomState whose state pickle can set.
+        Consequently the RandomState returned by this function is a freshly allocated copy
+        with a seed=0.
             
-            See https://github.com/numpy/numpy/issues/4763 for a detailed discussion
+        See https://github.com/numpy/numpy/issues/4763 for a detailed discussion
             
-            """
-            return RandomState(seed=0)
+        """
+        return RandomState(seed=0)
             
-        from numpy.testing.nosetester import _numpy_tester
-        test = _numpy_tester().test
-        bench = _numpy_tester().bench
+    from numpy.testing.nosetester import _numpy_tester
+    test = _numpy_tester().test
+    bench = _numpy_tester().bench

--- a/numpy/random_intel/info.py
+++ b/numpy/random_intel/info.py
@@ -1,0 +1,140 @@
+"""
+========================
+Random Number Generation
+========================
+
+==================== =========================================================
+Utility functions
+==============================================================================
+random_sample        Uniformly distributed floats over ``[0, 1)``.
+random               Alias for `random_sample`.
+bytes                Uniformly distributed random bytes.
+random_integers      Uniformly distributed integers in a given range.
+permutation          Randomly permute a sequence / generate a random sequence.
+shuffle              Randomly permute a sequence in place.
+seed                 Seed the random number generator.
+choice               Random sample from 1-D array.
+
+==================== =========================================================
+
+==================== =========================================================
+Compatibility functions
+==============================================================================
+rand                 Uniformly distributed values.
+randn                Normally distributed values.
+ranf                 Uniformly distributed floating point numbers.
+randint              Uniformly distributed integers in a given range.
+==================== =========================================================
+
+==================== =========================================================
+Univariate distributions
+==============================================================================
+beta                 Beta distribution over ``[0, 1]``.
+binomial             Binomial distribution.
+chisquare            :math:`\\chi^2` distribution.
+exponential          Exponential distribution.
+f                    F (Fisher-Snedecor) distribution.
+gamma                Gamma distribution.
+geometric            Geometric distribution.
+gumbel               Gumbel distribution.
+hypergeometric       Hypergeometric distribution.
+laplace              Laplace distribution.
+logistic             Logistic distribution.
+lognormal            Log-normal distribution.
+logseries            Logarithmic series distribution.
+negative_binomial    Negative binomial distribution.
+noncentral_chisquare Non-central chi-square distribution.
+noncentral_f         Non-central F distribution.
+normal               Normal / Gaussian distribution.
+pareto               Pareto distribution.
+poisson              Poisson distribution.
+power                Power distribution.
+rayleigh             Rayleigh distribution.
+triangular           Triangular distribution.
+uniform              Uniform distribution.
+vonmises             Von Mises circular distribution.
+wald                 Wald (inverse Gaussian) distribution.
+weibull              Weibull distribution.
+zipf                 Zipf's distribution over ranked data.
+==================== =========================================================
+
+==================== =========================================================
+Multivariate distributions
+==============================================================================
+dirichlet            Multivariate generalization of Beta distribution.
+multinomial          Multivariate generalization of the binomial distribution.
+multivariate_normal  Multivariate generalization of the normal distribution.
+multinormal_cholesky Multivariate generalization of the normal distribution.
+==================== =========================================================
+
+==================== =========================================================
+Standard distributions
+==============================================================================
+standard_cauchy      Standard Cauchy-Lorentz distribution.
+standard_exponential Standard exponential distribution.
+standard_gamma       Standard Gamma distribution.
+standard_normal      Standard normal distribution.
+standard_t           Standard Student's t-distribution.
+==================== =========================================================
+
+==================== =========================================================
+Internal functions
+==============================================================================
+get_state            Get tuple representing internal state of generator.
+set_state            Set state of generator.
+==================== =========================================================
+
+"""
+from __future__ import division, absolute_import, print_function
+
+depends = ['core']
+
+__all__ = [
+    'beta',
+    'binomial',
+    'bytes',
+    'chisquare',
+    'choice',
+    'dirichlet',
+    'exponential',
+    'f',
+    'gamma',
+    'geometric',
+    'get_state',
+    'gumbel',
+    'hypergeometric',
+    'laplace',
+    'logistic',
+    'lognormal',
+    'logseries',
+    'multinomial',
+    'multivariate_normal',
+    'negative_binomial',
+    'noncentral_chisquare',
+    'noncentral_f',
+    'normal',
+    'pareto',
+    'permutation',
+    'poisson',
+    'power',
+    'rand',
+    'randint',
+    'randn',
+    'random_integers',
+    'random_sample',
+    'rayleigh',
+    'seed',
+    'set_state',
+    'shuffle',
+    'standard_cauchy',
+    'standard_exponential',
+    'standard_gamma',
+    'standard_normal',
+    'standard_t',
+    'triangular',
+    'uniform',
+    'vonmises',
+    'wald',
+    'weibull',
+    'zipf'
+]

--- a/numpy/random_intel/mklrand/Python.pxi
+++ b/numpy/random_intel/mklrand/Python.pxi
@@ -20,7 +20,6 @@ cdef extern from "Python.h":
 
     # Memory API
     void* PyMem_Malloc(size_t n)
-    void* PyMem_Calloc(size_t s, size_t n)
     void* PyMem_Realloc(void* buf, size_t n)
     void PyMem_Free(void* buf)
 
@@ -28,20 +27,6 @@ cdef extern from "Python.h":
     void Py_XDECREF(object obj)
     void Py_INCREF(object obj)
     void Py_XINCREF(object obj)
-
-    # CObject API
-# If this is uncommented it needs to be fixed to use PyCapsule
-# for Python >= 3.0
-#
-#    ctypedef void (*destructor1)(void* cobj)
-#    ctypedef void (*destructor2)(void* cobj, void* desc)
-#    int PyCObject_Check(object p)
-#    object PyCObject_FromVoidPtr(void* cobj, destructor1 destr)
-#    object PyCObject_FromVoidPtrAndDesc(void* cobj, void* desc,
-#        destructor2 destr)
-#    void* PyCObject_AsVoidPtr(object self)
-#    void* PyCObject_GetDesc(object self)
-#    int PyCObject_SetVoidPtr(object self, void* cobj)
 
     # TypeCheck API
     int PyFloat_Check(object obj)

--- a/numpy/random_intel/mklrand/Python.pxi
+++ b/numpy/random_intel/mklrand/Python.pxi
@@ -1,0 +1,58 @@
+# :Author:    Robert Kern
+# :Copyright: 2004, Enthought, Inc.
+# :License:   BSD Style
+
+
+cdef extern from "Python.h":
+    # Not part of the Python API, but we might as well define it here.
+    # Note that the exact type doesn't actually matter for Pyrex.
+    ctypedef int size_t
+
+    # String API
+    char* PyString_AsString(object string)
+    char* PyString_AS_STRING(object string)
+    object PyString_FromString(char* c_string)
+    object PyString_FromStringAndSize(char* c_string, int length)
+
+    # Float API
+    double PyFloat_AsDouble(object ob)
+    long PyInt_AsLong(object ob)
+
+    # Memory API
+    void* PyMem_Malloc(size_t n)
+    void* PyMem_Calloc(size_t s, size_t n)
+    void* PyMem_Realloc(void* buf, size_t n)
+    void PyMem_Free(void* buf)
+
+    void Py_DECREF(object obj)
+    void Py_XDECREF(object obj)
+    void Py_INCREF(object obj)
+    void Py_XINCREF(object obj)
+
+    # CObject API
+# If this is uncommented it needs to be fixed to use PyCapsule
+# for Python >= 3.0
+#
+#    ctypedef void (*destructor1)(void* cobj)
+#    ctypedef void (*destructor2)(void* cobj, void* desc)
+#    int PyCObject_Check(object p)
+#    object PyCObject_FromVoidPtr(void* cobj, destructor1 destr)
+#    object PyCObject_FromVoidPtrAndDesc(void* cobj, void* desc,
+#        destructor2 destr)
+#    void* PyCObject_AsVoidPtr(object self)
+#    void* PyCObject_GetDesc(object self)
+#    int PyCObject_SetVoidPtr(object self, void* cobj)
+
+    # TypeCheck API
+    int PyFloat_Check(object obj)
+    int PyInt_Check(object obj)
+
+    # Error API
+    int PyErr_Occurred()
+    void PyErr_Clear()
+
+cdef extern from "string.h":
+    void *memcpy(void *s1, void *s2, int n)
+
+cdef extern from "math.h":
+    double fabs(double x)

--- a/numpy/random_intel/mklrand/generate_mklrand_c.py
+++ b/numpy/random_intel/mklrand/generate_mklrand_c.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from __future__ import division, absolute_import, print_function
+
+import sys
+import re
+import os
+
+unused_internal_funcs = ['__Pyx_PrintItem',
+                         '__Pyx_PrintNewline',
+                         '__Pyx_ReRaise',
+                         #'__Pyx_GetExcValue',
+                         '__Pyx_ArgTypeTest',
+                         '__Pyx_SetVtable',
+                         '__Pyx_GetVtable',
+                         '__Pyx_CreateClass']
+
+if __name__ == '__main__':
+    # Use cython here so that long docstrings are broken up.
+    # This is needed for some VC++ compilers.
+    os.system('cython mklrand.pyx')
+    mklrand_c = open('mklrand.c', 'r')
+    processed = open('mklrand_pp.c', 'w')
+    unused_funcs_str = '(' + '|'.join(unused_internal_funcs) + ')'
+    uifpat = re.compile(r'static \w+ \*?'+unused_funcs_str+r'.*/\*proto\*/')
+    linepat = re.compile(r'/\* ".*/mklrand.pyx":')
+    for linenum, line in enumerate(mklrand_c):
+        m = re.match(r'^(\s+arrayObject\w*\s*=\s*[(])[(]PyObject\s*[*][)]',
+                     line)
+        if m:
+            line = '%s(PyArrayObject *)%s' % (m.group(1), line[m.end():])
+        m = uifpat.match(line)
+        if m:
+            line = ''
+        m = re.search(unused_funcs_str, line)
+        if m:
+            print("%s was declared unused, but is used at line %d" % (m.group(),
+                                                                    linenum+1), file=sys.stderr)
+        line = linepat.sub(r'/* "mklrand.pyx":', line)
+        processed.write(line)
+    mklrand_c.close()
+    processed.close()
+    os.rename('mklrand_pp.c', 'mklrand.c')

--- a/numpy/random_intel/mklrand/mkl_distributions.cpp
+++ b/numpy/random_intel/mklrand/mkl_distributions.cpp
@@ -18,21 +18,26 @@ vrk_double_vec(vrk_state *state, const int len, double *res)
     if(len < 1)
         return;
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res,
+            d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 
 void
-vrk_uniform_vec(vrk_state *state, const int len, double *res, const double low, const double high)
+vrk_uniform_vec(vrk_state *state, const int len, double *res,
+    const double low, const double high)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, low, high);
+    err = vdRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res,
+        low, high);
     assert(err == VSL_STATUS_OK);
 
 }
@@ -47,20 +52,25 @@ vrk_standard_normal_vec_ICDF(vrk_state *state, const int len, double *res)
     if(len < 1)
         return;
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, d_zero, d_one);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_normal_vec_ICDF(vrk_state *state, const int len, double *res, const double loc, const double scale)
+vrk_normal_vec_ICDF(vrk_state *state, const int len, double *res,
+    const double loc, const double scale)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, loc, scale);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res,
+        loc, scale);
     assert(err == VSL_STATUS_OK);
 
 }
@@ -75,20 +85,25 @@ vrk_standard_normal_vec_BM1(vrk_state *state, const int len, double *res)
     if(len < 1)
         return;
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER, state->stream, len, res, d_zero, d_one);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_BOXMULLER, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_normal_vec_BM1(vrk_state *state, const int len, double *res, const double loc, const double scale)
+vrk_normal_vec_BM1(vrk_state *state, const int len, double *res,
+    const double loc, const double scale)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER, state->stream, len, res, loc, scale);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_BOXMULLER, state->stream, len, res,
+        loc, scale);
     assert(err == VSL_STATUS_OK);
 
 }
@@ -103,20 +118,25 @@ vrk_standard_normal_vec_BM2(vrk_state *state, const int len, double *res)
     if(len < 1)
         return;
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, state->stream, len, res, d_zero, d_one);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_normal_vec_BM2(vrk_state *state, const int len, double *res, const double loc, const double scale)
+vrk_normal_vec_BM2(vrk_state *state, const int len, double *res,
+    const double loc, const double scale)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, state->stream, len, res, loc, scale);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, state->stream, len, res,
+        loc, scale);
     assert(err == VSL_STATUS_OK);
 
 }
@@ -131,13 +151,16 @@ vrk_standard_exponential_vec(vrk_state *state, const int len, double *res)
     if(len < 1)
         return;
 
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngExponential(
+        VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_exponential_vec(vrk_state *state, const int len, double *res, const double scale)
+vrk_exponential_vec(vrk_state *state, const int len, double *res,
+    const double scale)
 {
     int err;
     const double d_zero = 0.0;
@@ -145,7 +168,9 @@ vrk_exponential_vec(vrk_state *state, const int len, double *res, const double s
     if(len < 1)
         return;
 
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, scale);
+    err = vdRngExponential(
+        VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res,
+        d_zero, scale);
     assert(err == VSL_STATUS_OK);
 
 }
@@ -160,13 +185,16 @@ vrk_standard_cauchy_vec(vrk_state *state, const int len, double *res)
     if(len < 1)
         return;
 
-    err = vdRngCauchy(VSL_RNG_METHOD_CAUCHY_ICDF, state->stream, len, res, d_zero, d_one);
+    err = vdRngCauchy(
+        VSL_RNG_METHOD_CAUCHY_ICDF, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_standard_gamma_vec(vrk_state *state, const int len, double *res, const double shape)
+vrk_standard_gamma_vec(vrk_state *state, const int len, double *res,
+    const double shape)
 {
     int err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -174,13 +202,16 @@ vrk_standard_gamma_vec(vrk_state *state, const int len, double *res, const doubl
     if(len < 1)
         return;
 
-    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, d_one);
+    err = vdRngGamma(
+        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res,
+        shape, d_zero, d_one);
 
     assert(err == VSL_STATUS_OK);
 }
 
 void
-vrk_gamma_vec(vrk_state *state, const int len, double *res, const double shape, const double scale)
+vrk_gamma_vec(vrk_state *state, const int len, double *res,
+    const double shape, const double scale)
 {
     int err;
     const double d_zero = 0.0;
@@ -188,7 +219,9 @@ vrk_gamma_vec(vrk_state *state, const int len, double *res, const double shape, 
     if(len < 1)
         return;
 
-    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, scale);
+    err = vdRngGamma(
+        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res,
+        shape, d_zero, scale);
 
     assert(err == VSL_STATUS_OK);
 
@@ -197,7 +230,8 @@ vrk_gamma_vec(vrk_state *state, const int len, double *res, const double shape, 
 
 /*  X ~ Z * (G*(2/df))**-0.5 */
 void
-vrk_standard_t_vec(vrk_state *state, const int len, double *res, const double df)
+vrk_standard_t_vec(vrk_state *state, const int len, double *res,
+    const double df)
 {
     int err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -207,7 +241,9 @@ vrk_standard_t_vec(vrk_state *state, const int len, double *res, const double df
     if(len < 1)
         return;
 
-    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, 1.0/shape);
+    err = vdRngGamma(
+        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res,
+        shape, d_zero, 1.0/shape);
     assert(err == VSL_STATUS_OK);
 
     vmdInvSqrt(len, res, res, VML_HA);
@@ -215,7 +251,9 @@ vrk_standard_t_vec(vrk_state *state, const int len, double *res, const double df
     sn = (double *) mkl_malloc(len*sizeof(double), 64);
     assert(sn != NULL);
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, sn, d_zero, d_one);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, sn,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
     vmdMul(len, res, sn, res, VML_HA);
@@ -225,7 +263,8 @@ vrk_standard_t_vec(vrk_state *state, const int len, double *res, const double df
 
 /* chisquare(df) ~ G(df/2, 2) */
 void
-vrk_chisquare_vec(vrk_state *state, const int len, double *res, const double df)
+vrk_chisquare_vec(vrk_state *state, const int len, double *res,
+    const double df)
 {
     int err;
     const double d_zero = 0.0, d_two = 2.0;
@@ -234,7 +273,9 @@ vrk_chisquare_vec(vrk_state *state, const int len, double *res, const double df)
     if(len < 1)
         return;
 
-    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, d_two);
+    err = vdRngGamma(
+        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res,
+        shape, d_zero, d_two);
     assert(err == VSL_STATUS_OK);
 
 }
@@ -250,7 +291,9 @@ vrk_pareto_vec(vrk_state *state, const int len, double *res, const double alp)
     if (len<1)
         return;
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
     /* res[i] = pow(res[i], neg_rec_alp) */
@@ -272,7 +315,9 @@ vrk_weibull_vec(vrk_state *state, const int len, double *res, const double alp)
     if (len<1)
         return;
 
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngExponential(
+        VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
     vmdPowx(len, res, rec_alp, res, VML_HA);
@@ -290,7 +335,9 @@ vrk_power_vec(vrk_state *state, const int len, double *res, const double alp)
     if (len<1)
         return;
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
     /* res[i] = pow(res[i], rec_alp) */
@@ -300,7 +347,8 @@ vrk_power_vec(vrk_state *state, const int len, double *res, const double alp)
 
 /*  scale * sqrt(2.0 * E(1))  */
 void
-vrk_rayleigh_vec(vrk_state *state, const int len, double *res, const double scale)
+vrk_rayleigh_vec(vrk_state *state, const int len, double *res,
+    const double scale)
 {
     int i, err;
     const double d_zero = 0.0, d_two = 2.0;
@@ -308,7 +356,9 @@ vrk_rayleigh_vec(vrk_state *state, const int len, double *res, const double scal
     if (len<1)
         return;
 
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, d_two);
+    err = vdRngExponential(
+        VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res,
+        d_zero, d_two);
     assert(err == VSL_STATUS_OK);
 
     vmdSqrt(len, res, res, VML_HA);
@@ -319,7 +369,8 @@ vrk_rayleigh_vec(vrk_state *state, const int len, double *res, const double scal
 }
 
 void
-vrk_beta_vec(vrk_state *state, const int len, double *res, const double a, const double b)
+vrk_beta_vec(vrk_state *state, const int len, double *res,
+    const double a, const double b)
 {
     int err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -327,14 +378,17 @@ vrk_beta_vec(vrk_state *state, const int len, double *res, const double a, const
     if(len < 1)
         return;
 
-    err = vdRngBeta(VSL_RNG_METHOD_BETA_CJA_ACCURATE, state->stream, len, res, a, b, d_zero, d_one);
+    err = vdRngBeta(
+        VSL_RNG_METHOD_BETA_CJA_ACCURATE, state->stream, len, res,
+        a, b, d_zero, d_one);
 
     assert(err == VSL_STATUS_OK);
 }
 
 /*  F(df_num, df_den) ~ G( df_num/2, 2/df_num) / G(df_den/2, 2/df_den))  */
 void
-vrk_f_vec(vrk_state *state, const int len, double *res, const double df_num, const double df_den)
+vrk_f_vec(vrk_state *state, const int len, double *res,
+    const double df_num, const double df_den)
 {
     int err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -344,7 +398,9 @@ vrk_f_vec(vrk_state *state, const int len, double *res, const double df_num, con
     if(len < 1)
         return;
 
-    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, scale);
+    err = vdRngGamma(
+        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res,
+        shape, d_zero, scale);
     assert(err == VSL_STATUS_OK);
 
     den = (double *) mkl_malloc(len*sizeof(double), 64);
@@ -352,7 +408,9 @@ vrk_f_vec(vrk_state *state, const int len, double *res, const double df_num, con
 
     shape = 0.5*df_den;
     scale = 2.0/df_den;
-    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, den, shape, d_zero, scale);
+    err = vdRngGamma(
+        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, den,
+        shape, d_zero, scale);
     assert(err == VSL_STATUS_OK);
 
     vmdDiv(len, res, den, res, VML_HA);
@@ -365,7 +423,8 @@ vrk_f_vec(vrk_state *state, const int len, double *res, const double df_num, con
    for df <=1, X ~ Chi2( df + 2*I), where I ~ Poisson( nonc/2.0)
 */
 void
-vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const double df, const double nonc)
+vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res,
+    const double df, const double nonc)
 {
     int i, err;
     const double d_zero = 0.0, d_one = 1.0, d_two = 2.0;
@@ -379,13 +438,17 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
 
         shape = 0.5*(df - 1.0);
         /* res has chi^2 with (df - 1) */
-        err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, d_two);
+        err = vdRngGamma(
+            VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res,
+            shape, d_zero, d_two);
 
         nvec = (double *) mkl_malloc(len*sizeof(double), 64);
         assert(nvec != NULL);
 
         loc = sqrt(nonc);
-        err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, nvec, loc, d_one);
+        err = vdRngGaussian(
+            VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, nvec,
+            loc, d_one);
         assert(err == VSL_STATUS_OK);
 
         /* squaring could result in an overflow */
@@ -399,14 +462,15 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
             return vrk_chisquare_vec(state, len, res, df);
         }
         if(df < 1) {
-            /* noncentral_chisquare(df, nonc) ~ G( df/2 + Poisson(nonc/2), 2) */
+            /* noncentral_chisquare(df, nonc) ~ G(df/2 + Poisson(nonc/2), 2) */
             double lambda;
             int *pvec = (int *) mkl_malloc(len*sizeof(int), 64);
 
             assert(pvec != NULL);
 
             lambda = 0.5*nonc;
-            err = viRngPoisson(VSL_RNG_METHOD_POISSON_PTPE, state->stream, len, pvec, lambda);
+            err = viRngPoisson(
+                VSL_RNG_METHOD_POISSON_PTPE, state->stream, len, pvec, lambda);
             assert(err == VSL_STATUS_OK);
 
             shape = 0.5*df;
@@ -421,10 +485,13 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
                 #pragma ivdep
                 for(i=0; i <len; i++) idx[i] = i;
 
-                std::sort(idx, idx + len, [pvec](int i1, int i2){ return pvec[i1] < pvec[i2]; } );
-                /* idx now contains original indexes of ordered Poisson outputs */
+                /* argsort via sort with comparator */
+                std::sort(idx, idx + len,
+                    [pvec](int i1, int i2){ return pvec[i1] < pvec[i2]; } );
+                /* idx now contains original indexes of ordered Poisson vars */
 
-                /* allocate workspace to store samples of gamma, enough to hold entire output */
+                /* allocate workspace to store samples of gamma,
+                   enough to hold entire output */
                 tmp = (double *) mkl_malloc( len * sizeof(double), 64);
                 assert( tmp != NULL );
 
@@ -435,8 +502,10 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
                     for(j=i+1; (j < len) && (pvec[idx[j]] == cv); j++) {}
 
                     assert(j > i);
-                    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, j - i, tmp,
-                                shape + cv, d_zero, d_two);
+                    err = vdRngGamma(
+                        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream,
+                        j - i, tmp,
+                        shape + cv, d_zero, d_two);
                     assert(err == VSL_STATUS_OK);
 
                     #pragma ivdep
@@ -451,7 +520,8 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
             } else {
 
                 for(i=0; i<len; i++) {
-                    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, 1,
+                    err = vdRngGamma(
+                        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, 1,
                         res + i, shape + pvec[i], d_zero, d_two);
                     assert(err == VSL_STATUS_OK);
                 }
@@ -462,13 +532,17 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
             float *fuvec = NULL;
 
             /* noncentral_chisquare(1, nonc) ~ sqrt(nonc)*(-1)^[U<0.5] + Z */
-            err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, d_zero, d_one);
+            err = vdRngGaussian(
+                VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res,
+                d_zero, d_one);
             loc = sqrt(nonc);
 
             fuvec = (float *) mkl_malloc(len*sizeof(float), 64);
             assert(fuvec != NULL);
 
-            err = vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, fuvec, (const float) d_zero, (const float) d_one);
+            err = vsRngUniform(
+                VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, fuvec,
+                (const float) d_zero, (const float) d_one);
             assert(err == VSL_STATUS_OK);
 
             #pragma ivdep
@@ -481,35 +555,42 @@ vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const
 }
 
 void
-vrk_laplace_vec(vrk_state *state, const int len, double *res, const double loc, const double scale)
+vrk_laplace_vec(vrk_state *state, const int len, double *res,
+    const double loc, const double scale)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = vdRngLaplace(VSL_RNG_METHOD_LAPLACE_ICDF, state->stream, len, res, loc, scale);
+    err = vdRngLaplace(
+        VSL_RNG_METHOD_LAPLACE_ICDF, state->stream, len, res,
+        loc, scale);
     assert(err == VSL_STATUS_OK);
 
 }
 
 
 void
-vrk_gumbel_vec(vrk_state *state, const int len, double *res, const double loc, const double scale)
+vrk_gumbel_vec(vrk_state *state, const int len, double *res,
+    const double loc, const double scale)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = vdRngGumbel(VSL_RNG_METHOD_GUMBEL_ICDF, state->stream, len, res, loc, scale);
+    err = vdRngGumbel(
+        VSL_RNG_METHOD_GUMBEL_ICDF, state->stream, len, res,
+        loc, scale);
     assert(err == VSL_STATUS_OK);
 
 }
 
 /*   Logistic(loc, scale) ~ loc + scale * log(u/(1.0 - u)) */
 void
-vrk_logistic_vec(vrk_state *state, const int len, double *res, const double loc, const double scale)
+vrk_logistic_vec(vrk_state *state, const int len, double *res,
+    const double loc, const double scale)
 {
     int i, err;
     const double d_one = 1.0, d_mone = -1.0, d_zero = 0.0;
@@ -517,10 +598,13 @@ vrk_logistic_vec(vrk_state *state, const int len, double *res, const double loc,
     if(len < 1)
         return;
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
-    /* can MKL optimize computation of the logit function  p \mapsto \ln(p/(1-p)) */
+    /* can MKL optimize computation of the logit function
+       p \mapsto \ln(p/(1-p))                             */
     #pragma ivdep
     for(i=0; i<len; i++) res[i] = log(res[i]/(1.0 - res[i]));
 
@@ -529,7 +613,8 @@ vrk_logistic_vec(vrk_state *state, const int len, double *res, const double loc,
 }
 
 void
-vrk_lognormal_vec_ICDF(vrk_state *state, const int len, double *res, const double mean, const double sigma)
+vrk_lognormal_vec_ICDF(vrk_state *state, const int len, double *res,
+    const double mean, const double sigma)
 {
     int err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -537,13 +622,16 @@ vrk_lognormal_vec_ICDF(vrk_state *state, const int len, double *res, const doubl
     if(len < 1)
         return;
 
-    err = vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF_ACCURATE, state->stream, len, res, mean, sigma, d_zero, d_one);
+    err = vdRngLognormal(
+        VSL_RNG_METHOD_LOGNORMAL_ICDF_ACCURATE, state->stream, len, res,
+        mean, sigma, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_lognormal_vec_BM(vrk_state *state, const int len, double *res, const double mean, const double sigma)
+vrk_lognormal_vec_BM(vrk_state *state, const int len, double *res,
+    const double mean, const double sigma)
 {
     int err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -551,21 +639,26 @@ vrk_lognormal_vec_BM(vrk_state *state, const int len, double *res, const double 
     if(len < 1)
         return;
 
-    err = vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2_ACCURATE, state->stream, len, res, mean, sigma, d_zero, d_one);
+    err = vdRngLognormal(
+        VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2_ACCURATE, state->stream, len, res,
+        mean, sigma, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
 }
 
 /* direct transformation method */
 void
-vrk_wald_vec(vrk_state *state, const int len, double *res, const double mean, const double scale)
+vrk_wald_vec(vrk_state *state, const int len, double *res,
+    const double mean, const double scale)
 {
     int i, err;
     const double d_zero = 0., d_one = 1.0;
     double *uvec = NULL;
     double gsc = 0.5*sqrt(mean / scale);
 
-    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, d_zero, gsc);
+    err = vdRngGaussian(
+        VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res,
+        d_zero, gsc);
     assert(err == VSL_STATUS_OK);
 
     /* Y = mean/(4 scale) * Z^2 */
@@ -583,7 +676,9 @@ vrk_wald_vec(vrk_state *state, const int len, double *res, const double mean, co
     uvec = (double *) mkl_malloc(len*sizeof(double), 64);
     assert(uvec != NULL);
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, uvec, d_zero, d_one);
+    err = vdRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, uvec,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -611,7 +706,8 @@ vrk_wald_vec(vrk_state *state, const int len, double *res, const double mean, co
    (but corrected to match the algorithm in R and Python)
 */
 static void
-vrk_vonmises_vec_small_kappa(vrk_state *state, const int len, double *res, const double mu, const double kappa)
+vrk_vonmises_vec_small_kappa(vrk_state *state, const int len, double *res,
+    const double mu, const double kappa)
 {
     int i, err, n, size;
     double rho_over_kappa, rho, r, s_kappa, Z, W, Y, V;
@@ -636,9 +732,14 @@ vrk_vonmises_vec_small_kappa(vrk_state *state, const int len, double *res, const
     for(n = 0; n < len; )
     {
         size = len - n;
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, size, Uvec, d_zero, M_PI);
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, size, Uvec,
+            d_zero, M_PI);
         assert(err == VSL_STATUS_OK);
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, size, Vvec, d_zero, d_one);
+
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, size, Vvec,
+            d_zero, d_one);
         assert(err == VSL_STATUS_OK);
 
         for(i = 0; i < size; i++ ) {
@@ -654,7 +755,9 @@ vrk_vonmises_vec_small_kappa(vrk_state *state, const int len, double *res, const
     mkl_free(Uvec);
 
     VFvec = (float *) Vvec;
-    err = vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, VFvec, (float) d_zero, (float) d_one);
+    err = vsRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, VFvec,
+        (float) d_zero, (float) d_one);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -672,11 +775,13 @@ vrk_vonmises_vec_small_kappa(vrk_state *state, const int len, double *res, const
 }
 
 static void
-vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res, const double mu, const double kappa)
+vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res,
+    const double mu, const double kappa)
 {
     int i, err, n, size;
     double r_over_two_kappa, recip_two_kappa;
-    double s_minus_one, hpt, r_over_two_kappa_minus_one, rho_minus_one, neg_W_minus_one;
+    double s_minus_one, hpt, r_over_two_kappa_minus_one,
+           rho_minus_one, neg_W_minus_one;
     double *Uvec = NULL, *Vvec = NULL;
     float *VFvec = NULL;
     const double d_zero = 0.0, d_one = 1.0;
@@ -687,9 +792,16 @@ vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res, const
 
     /* variables here are dwindling to zero as kappa grows */
     hpt = sqrt(1 + recip_two_kappa * recip_two_kappa);
-    r_over_two_kappa_minus_one = recip_two_kappa * (1 + recip_two_kappa / (1 + hpt));
+
+    r_over_two_kappa_minus_one =
+        recip_two_kappa * (1 + recip_two_kappa / (1 + hpt));
+
     r_over_two_kappa = 1 + r_over_two_kappa_minus_one;
-    rho_minus_one = r_over_two_kappa_minus_one - sqrt(2 * r_over_two_kappa * recip_two_kappa);
+
+    rho_minus_one =
+        r_over_two_kappa_minus_one -
+        sqrt(2 * r_over_two_kappa * recip_two_kappa);
+
     s_minus_one = rho_minus_one*(0.5 * rho_minus_one/(1 + rho_minus_one));
 
     Uvec = (double *) mkl_malloc(len * sizeof(double), 64);
@@ -700,31 +812,35 @@ vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res, const
     for(n = 0; n < len; )
     {
         size = len - n;
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, size, Uvec, d_zero, 0.5*M_PI);
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, size, Uvec,
+            d_zero, 0.5*M_PI);
         assert(err == VSL_STATUS_OK);
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, size, Vvec, d_zero, d_one);
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, size, Vvec,
+            d_zero, d_one);
         assert(err == VSL_STATUS_OK);
 
         #pragma ivdep
         for(i = 0; i < size; i++ ) {
-	    double sn, cn, sn2, cn2;
-	    double neg_W_minus_one, V, Y;
+           double sn, cn, sn2, cn2;
+           double neg_W_minus_one, V, Y;
 
-	    sn = sin(Uvec[i]);  cn = cos(Uvec[i]); V = Vvec[i];
-	    sn2 = sn*sn;  cn2 = cn*cn;
+           sn = sin(Uvec[i]);  cn = cos(Uvec[i]); V = Vvec[i];
+           sn2 = sn*sn;  cn2 = cn*cn;
 
             neg_W_minus_one = s_minus_one * sn2 / (0.5*s_minus_one + cn2);
             Y = kappa * (s_minus_one + neg_W_minus_one);
 
             if ((Y*(2 - Y) >= V) || (log(Y/V) + 1 >= Y)) {
-	        Y = neg_W_minus_one * (2 - neg_W_minus_one);
-		if (Y < 0)
-		    Y = 0.;
-		else
-		    if (Y > 1.0)
-		        Y = 1.0;
+                Y = neg_W_minus_one * (2 - neg_W_minus_one);
+                if (Y < 0)
+                    Y = 0.;
+                else
+                    if (Y > 1.0)
+                        Y = 1.0;
 
-	        res[n++] = asin(sqrt(Y));
+                resi[n++] = asin(sqrt(Y));
             }
         }
     }
@@ -732,7 +848,9 @@ vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res, const
     mkl_free(Uvec);
 
     VFvec = (float *) Vvec;
-    err = vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, VFvec, (float) d_zero, (float) d_one);
+    err = vsRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, VFvec,
+        (float) d_zero, (float) d_one);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -749,7 +867,8 @@ vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res, const
 }
 
 void
-vrk_vonmises_vec(vrk_state *state, const int len, double *res, const double mu, const double kappa)
+vrk_vonmises_vec(vrk_state *state, const int len, double *res,
+    const double mu, const double kappa)
 {
     if(len < 1)
         return;
@@ -762,7 +881,8 @@ vrk_vonmises_vec(vrk_state *state, const int len, double *res, const double mu, 
 }
 
 void
-vrk_noncentral_f_vec(vrk_state *state, const int len, double *res, const double df_num, const double df_den, const double nonc)
+vrk_noncentral_f_vec(vrk_state *state, const int len, double *res,
+    const double df_num, const double df_den, const double nonc)
 {
     int i;
     double *den = NULL, fctr;
@@ -794,7 +914,8 @@ vrk_noncentral_f_vec(vrk_state *state, const int len, double *res, const double 
 
 
 void
-vrk_triangular_vec(vrk_state *state, const int len, double *res, const double x_min, const double x_mode, const double x_max)
+vrk_triangular_vec(vrk_state *state, const int len, double *res,
+    const double x_min, const double x_mode, const double x_max)
 {
     int i, err;
     const double d_zero = 0.0, d_one = 1.0;
@@ -803,7 +924,9 @@ vrk_triangular_vec(vrk_state *state, const int len, double *res, const double x_
     if (len < 1)
         return;
 
-    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    err = vdRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res,
+        d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
     {
@@ -835,13 +958,17 @@ vrk_triangular_vec(vrk_state *state, const int len, double *res, const double x_
         #pragma ivdep
         for(i = 0; i < len; i++) {
             double ui = res[i];
-            res[i] = (ui > ratio) ? x_max - sqrt((1.0 - ui) * rpr) : x_min + sqrt(ui*lpr);
+
+            res[i] = (ui > ratio) ?
+                x_max - sqrt((1.0 - ui) * rpr) :
+                x_min + sqrt(ui*lpr);
         }
     }
 }
 
 void
-vrk_binomial_vec(vrk_state *state, const int len, int *res, const int n, const double p)
+vrk_binomial_vec(vrk_state *state, const int len, int *res,
+    const int n, const double p)
 {
     int err;
 
@@ -855,7 +982,8 @@ vrk_binomial_vec(vrk_state *state, const int len, int *res, const int n, const d
         for(i=0; i < len; i++) res[i] = 0;
     }
     else {
-        err = viRngBinomial(VSL_RNG_METHOD_BINOMIAL_BTPE, state->stream, len, res, n, p);
+        err = viRngBinomial(
+            VSL_RNG_METHOD_BINOMIAL_BTPE, state->stream, len, res, n, p);
         assert(err == VSL_STATUS_OK);
     }
 }
@@ -868,83 +996,99 @@ vrk_geometric_vec(vrk_state *state, const int len, int *res, const double p)
     if(len < 1)
         return;
 
-    err = viRngGeometric(VSL_RNG_METHOD_GEOMETRIC_ICDF, state->stream, len, res, p);
+    err = viRngGeometric(
+        VSL_RNG_METHOD_GEOMETRIC_ICDF, state->stream, len, res, p);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_negbinomial_vec(vrk_state *state, const int len, int *res, const double a, const double p)
+vrk_negbinomial_vec(vrk_state *state, const int len, int *res,
+    const double a, const double p)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = viRngNegbinomial(VSL_RNG_METHOD_NEGBINOMIAL_NBAR, state->stream, len, res, a, p);
+    err = viRngNegbinomial(
+        VSL_RNG_METHOD_NEGBINOMIAL_NBAR, state->stream, len, res, a, p);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_hypergeometric_vec(vrk_state *state, const int len, int *res, const int lot_s,
-        const int sampling_s, const int marked_s)
+vrk_hypergeometric_vec(vrk_state *state, const int len, int *res,
+    const int lot_s, const int sampling_s, const int marked_s)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = viRngHypergeometric(VSL_RNG_METHOD_HYPERGEOMETRIC_H2PE, state->stream, len, res,
-                lot_s, sampling_s, marked_s);
+    err = viRngHypergeometric(
+        VSL_RNG_METHOD_HYPERGEOMETRIC_H2PE, state->stream, len, res,
+        lot_s, sampling_s, marked_s);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_poisson_vec_PTPE(vrk_state *state, const int len, int *res, const double lambda)
+vrk_poisson_vec_PTPE(vrk_state *state, const int len, int *res,
+    const double lambda)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = viRngPoisson(VSL_RNG_METHOD_POISSON_PTPE, state->stream, len, res, lambda);
+    err = viRngPoisson(
+        VSL_RNG_METHOD_POISSON_PTPE, state->stream, len, res,
+        lambda);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_poisson_vec_POISNORM(vrk_state *state, const int len, int *res, const double lambda)
+vrk_poisson_vec_POISNORM(vrk_state *state, const int len, int *res,
+    const double lambda)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, state->stream, len, res, lambda);
+    err = viRngPoisson(
+        VSL_RNG_METHOD_POISSON_POISNORM, state->stream, len, res,
+        lambda);
     assert(err == VSL_STATUS_OK);
 
 }
 
+/* MKL provides a way to efficiently sample from product distribution
+   of Poisson distributions with given vector of rates, *lambdas */
 void
-vrk_poisson_vec_V(vrk_state *state, const int len, int *res, double *lambdas)
+vrk_poisson_vec_V(vrk_state *state, const int len, int *res,
+    double *lambdas)
 {
     int err;
 
     if(len < 1)
         return;
 
-    err = viRngPoissonV(VSL_RNG_METHOD_POISSONV_POISNORM, state->stream, len, res, lambdas);
+    err = viRngPoissonV(
+        VSL_RNG_METHOD_POISSONV_POISNORM, state->stream, len, res,
+        lambdas);
     assert(err == VSL_STATUS_OK);
 
 }
 
 
 void
-vrk_zipf_long_vec(vrk_state *state, const int len, long *res, const double a)
+vrk_zipf_long_vec(vrk_state *state, const int len, long *res,
+    const double a)
 {
-    int i, err, n_accepted, batch_size;
+    int i, err, n_accepted, batch_s;
     double T, U, V, am1, b;
     double *Uvec = NULL, *Vvec = NULL;
     long X;
@@ -961,22 +1105,27 @@ vrk_zipf_long_vec(vrk_state *state, const int len, long *res, const double a)
     Vvec = (double *) mkl_malloc(len * sizeof(double), 64);
     assert(Vvec != NULL);
 
-    for(n_accepted=0; n_accepted < len; ) {
-        batch_size = len - n_accepted;
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, batch_size, Uvec, d_zero, d_one);
+    for(n_accepted = 0; n_accepted < len; ) {
+        batch_s = len - n_accepted;
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, batch_s, Uvec,
+            d_zero, d_one);
         assert(err == VSL_STATUS_OK);
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batch_size, Vvec, d_zero, d_one);
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, batch_s, Vvec,
+            d_zero, d_one);
         assert(err == VSL_STATUS_OK);
 
         #pragma ivdep
-        for(i = 0; i < batch_size; i++) {
+        for(i = 0; i < batch_s; i++) {
             U = d_one - Uvec[i]; V = Vvec[i];
             X = (long)floor(pow(U, (-1.0)/am1));
             /* The real result may be above what can be represented in a signed
              * long. It will get casted to -sys.maxint-1. Since this is
-             * a straightforward rejection algorithm, we can just reject this value
-             * in the rejection condition below. This function then models a Zipf
-             * distribution truncated to sys.maxint.
+             * a straightforward rejection algorithm, we can just reject this
+             * value in the rejection condition below.
+             * This function then models a Zipf  distribution truncated to
+             * sys.maxint.
              */
             T = pow(d_one + d_one/X, am1);
             if ( (X > 0) && ( (V * X) * (T - d_one)/(b - d_one) <= T/b) ) {
@@ -991,9 +1140,10 @@ vrk_zipf_long_vec(vrk_state *state, const int len, long *res, const double a)
 }
 
 void
-vrk_logseries_vec(vrk_state *state, const int len, int *res, const double theta)
+vrk_logseries_vec(vrk_state *state, const int len, int *res,
+    const double theta)
 {
-    int i, err, n_accepted, batch_size;
+    int i, err, n_accepted, batch_s;
     double q, r, V;
     double *Uvec = NULL, *Vvec = NULL;
     int result;
@@ -1010,14 +1160,19 @@ vrk_logseries_vec(vrk_state *state, const int len, int *res, const double theta)
     assert(Vvec != NULL);
 
     for(n_accepted=0; n_accepted < len; ) {
-        batch_size = len - n_accepted;
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batch_size, Uvec, d_zero, d_one);
+        batch_s = len - n_accepted;
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, batch_s, Uvec,
+            d_zero, d_one);
         assert(err == VSL_STATUS_OK);
-        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, batch_size, Vvec, d_zero, d_one);
+        err = vdRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, batch_s, Vvec,
+            d_zero, d_one);
         assert(err == VSL_STATUS_OK);
 
         #pragma ivdep
-        for(i = 0; i < batch_size; i++) {
+        for(i = 0; i < batch_s; i++) {
+
             V = Vvec[i];
             if (V >= theta) {
                 res[n_accepted++] = 1;
@@ -1052,20 +1207,24 @@ vrk_logseries_vec(vrk_state *state, const int len, int *res, const double theta)
 
 /* samples discrete uniforms from [low, high) */
 void
-vrk_discrete_uniform_vec(vrk_state *state, const int len, int *res, const int low, const int high)
+vrk_discrete_uniform_vec(vrk_state *state, const int len, int *res,
+    const int low, const int high)
 {
     int err;
 
     if (len  < 1)
         return;
 
-    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, res, low, high);
+    err = viRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, res,
+        low, high);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_discrete_uniform_long_vec(vrk_state *state, const int len, long *res, const long low, const long high)
+vrk_discrete_uniform_long_vec(vrk_state *state, const int len, long *res,
+    const long low, const long high)
 {
     int err;
     unsigned long max;
@@ -1087,7 +1246,9 @@ vrk_discrete_uniform_long_vec(vrk_state *state, const int len, long *res, const 
         int *buf = (int*) mkl_malloc( len*sizeof(int), 64);
         assert(buf != NULL);
 
-        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, -1, (const int) max);
+        err = viRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+            -1, (const int) max);
         assert(err == VSL_STATUS_OK);
 
         #pragma ivdep
@@ -1117,7 +1278,9 @@ vrk_discrete_uniform_long_vec(vrk_state *state, const int len, long *res, const 
         while(n_accepted < len) {
             int k, batchSize = len - n_accepted;
 
-            err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batchSize, (unsigned MKL_INT64 *) buf);
+            err = viRngUniformBits64(
+                VSL_RNG_METHOD_UNIFORM_STD, state->stream, batchSize,
+                (unsigned MKL_INT64 *) buf);
             assert(err == VSL_STATUS_OK);
 
             for(k=0; k < batchSize; k++) {
@@ -1139,9 +1302,13 @@ vrk_ulong_vec(vrk_state *state, const int len, unsigned long *res)
     int err;
 
 #if ULONG_MAX <= 0xffffffffUL
-    err = viRngUniformBits32(VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len, (unsigned MKL_INT*) res);
+    err = viRngUniformBits32(
+        VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len,
+        (unsigned MKL_INT*) res);
 #else
-    err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORMBITS64_STD, state->stream, len, (unsigned MKL_INT64*) res);
+    err = viRngUniformBits64(
+        VSL_RNG_METHOD_UNIFORMBITS64_STD, state->stream, len,
+        (unsigned MKL_INT64*) res);
 #endif
 
     assert(err == VSL_STATUS_OK);
@@ -1162,7 +1329,8 @@ vrk_long_vec(vrk_state *state, const int len, long *res)
 }
 
 void
-vrk_rand_bool_vec(vrk_state *state, const int len, npy_bool *res, const npy_bool lo, const npy_bool hi)
+vrk_rand_bool_vec(vrk_state *state, const int len, npy_bool *res,
+    const npy_bool lo, const npy_bool hi)
 {
     int err, i;
     int *buf = NULL;
@@ -1181,7 +1349,9 @@ vrk_rand_bool_vec(vrk_state *state, const int len, npy_bool *res, const npy_bool
     buf = (int *) mkl_malloc(len * sizeof(int), 64);
     assert( buf != NULL);
 
-    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    err = viRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+        (const int) lo, (const int) hi + 1);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -1191,7 +1361,8 @@ vrk_rand_bool_vec(vrk_state *state, const int len, npy_bool *res, const npy_bool
 }
 
 void
-vrk_rand_uint8_vec(vrk_state *state, const int len, npy_uint8 *res, const npy_uint8 lo, const npy_uint8 hi)
+vrk_rand_uint8_vec(vrk_state *state, const int len, npy_uint8 *res,
+    const npy_uint8 lo, const npy_uint8 hi)
 {
     int err, i;
     int *buf = NULL;
@@ -1210,7 +1381,9 @@ vrk_rand_uint8_vec(vrk_state *state, const int len, npy_uint8 *res, const npy_ui
     buf = (int *) mkl_malloc(len * sizeof(int), 64);
     assert( buf != NULL);
 
-    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    err = viRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+        (const int) lo, (const int) hi + 1);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -1221,7 +1394,8 @@ vrk_rand_uint8_vec(vrk_state *state, const int len, npy_uint8 *res, const npy_ui
 }
 
 void
-vrk_rand_int8_vec(vrk_state *state, const int len, npy_int8 *res, const npy_int8 lo, const npy_int8 hi)
+vrk_rand_int8_vec(vrk_state *state, const int len, npy_int8 *res,
+    const npy_int8 lo, const npy_int8 hi)
 {
     int err, i;
     int *buf = NULL;
@@ -1240,7 +1414,8 @@ vrk_rand_int8_vec(vrk_state *state, const int len, npy_int8 *res, const npy_int8
     buf = (int *) mkl_malloc(len * sizeof(int), 64);
     assert( buf != NULL);
 
-    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+        (const int) lo, (const int) hi + 1);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -1250,7 +1425,8 @@ vrk_rand_int8_vec(vrk_state *state, const int len, npy_int8 *res, const npy_int8
 }
 
 void
-vrk_rand_uint16_vec(vrk_state *state, const int len, npy_uint16 *res, const npy_uint16 lo, const npy_uint16 hi)
+vrk_rand_uint16_vec(vrk_state *state, const int len, npy_uint16 *res,
+    const npy_uint16 lo, const npy_uint16 hi)
 {
     int err, i;
     int *buf = NULL;
@@ -1269,7 +1445,9 @@ vrk_rand_uint16_vec(vrk_state *state, const int len, npy_uint16 *res, const npy_
     buf = (int *) mkl_malloc(len * sizeof(int), 64);
     assert( buf != NULL);
 
-    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    err = viRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+        (const int) lo, (const int) hi + 1);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -1279,7 +1457,8 @@ vrk_rand_uint16_vec(vrk_state *state, const int len, npy_uint16 *res, const npy_
 }
 
 void
-vrk_rand_int16_vec(vrk_state *state, const int len, npy_int16 *res, const npy_int16 lo, const npy_int16 hi)
+vrk_rand_int16_vec(vrk_state *state, const int len, npy_int16 *res,
+    const npy_int16 lo, const npy_int16 hi)
 {
     int err, i;
     int *buf = NULL;
@@ -1298,7 +1477,9 @@ vrk_rand_int16_vec(vrk_state *state, const int len, npy_int16 *res, const npy_in
     buf = (int *) mkl_malloc(len * sizeof(int), 64);
     assert( buf != NULL);
 
-    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    err = viRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+        (const int) lo, (const int) hi + 1);
     assert(err == VSL_STATUS_OK);
 
     #pragma ivdep
@@ -1308,7 +1489,8 @@ vrk_rand_int16_vec(vrk_state *state, const int len, npy_int16 *res, const npy_in
 }
 
 void
-vrk_rand_uint32_vec(vrk_state *state, const int len, npy_uint32 *res, const npy_uint32 lo, const npy_uint32 hi)
+vrk_rand_uint32_vec(vrk_state *state, const int len, npy_uint32 *res,
+    const npy_uint32 lo, const npy_uint32 hi)
 {
     int err;
     unsigned int intm = INT_MAX;
@@ -1318,7 +1500,9 @@ vrk_rand_uint32_vec(vrk_state *state, const int len, npy_uint32 *res, const npy_
 
     /* optimization for lo = 0 and hi = 2**32-1 */
     if (!(lo || ~hi)) {
-        err = viRngUniformBits32(VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len, (unsigned MKL_INT *) res);
+        err = viRngUniformBits32(
+            VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len,
+            (unsigned MKL_INT *) res);
         assert(err == VSL_STATUS_OK);
 
         return;
@@ -1332,20 +1516,25 @@ vrk_rand_uint32_vec(vrk_state *state, const int len, npy_uint32 *res, const npy_
         /* if lo is non-zero, shift one more to accommodate possibility of hi being ULONG_MAX */
         if (lo) shft++;
 
-        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res, (const int) (lo - shft), (const int) (hi - shft + 1U));
+        err = viRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res,
+            (const int) (lo - shft), (const int) (hi - shft + 1U));
         assert(err == VSL_STATUS_OK);
 
         #pragma ivdep
         for(i=0; i < len; i++) res[i] += shft;
 
     } else {
-        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res, (const int) lo, (const int) hi + 1);
+        err = viRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res,
+            (const int) lo, (const int) hi + 1);
         assert(err == VSL_STATUS_OK);
     }
 }
 
 void
-vrk_rand_int32_vec(vrk_state *state, const int len, npy_int32 *res, const npy_int32 lo, const npy_int32 hi)
+vrk_rand_int32_vec(vrk_state *state, const int len, npy_int32 *res,
+    const npy_int32 lo, const npy_int32 hi)
 {
     int err;
     int intm = INT_MAX;
@@ -1356,19 +1545,23 @@ vrk_rand_int32_vec(vrk_state *state, const int len, npy_int32 *res, const npy_in
     if(hi >= intm) {
         int i;
 
-        vrk_rand_uint32_vec(state, len, (npy_uint32 *) res, 0U, (npy_uint32) (hi - lo));
+        vrk_rand_uint32_vec(state, len, (npy_uint32 *) res,
+            0U, (npy_uint32) (hi - lo));
 
         #pragma ivdep
         for(i=0; i < len; i++) res[i] += lo;
 
     } else {
-        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res, (const int) lo, (const int) hi + 1);
+        err = viRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res,
+            (const int) lo, (const int) hi + 1);
         assert(err == VSL_STATUS_OK);
     }
 }
 
 void
-vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_uint64 lo, const npy_uint64 hi)
+vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res,
+    const npy_uint64 lo, const npy_uint64 hi)
 {
     npy_uint64 rng;
     int i, err;
@@ -1378,7 +1571,9 @@ vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_
 
     /* optimization for lo = 0 and hi = 2**64-1 */
     if (!(lo || ~hi)) {
-        err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORMBITS64_STD, state->stream, len, (unsigned MKL_INT64 *) res);
+        err = viRngUniformBits64(
+            VSL_RNG_METHOD_UNIFORMBITS64_STD, state->stream, len,
+            (unsigned MKL_INT64 *) res);
         assert(err == VSL_STATUS_OK);
 
         return;
@@ -1398,7 +1593,9 @@ vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_
         int *buf = (int*) mkl_malloc(len * sizeof(int), 64);
         assert(buf != NULL);
 
-        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, 0, (const int) rng);
+        err = viRngUniform(
+            VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf,
+            0, (const int) rng);
         assert(err == VSL_STATUS_OK);
 
         #pragma ivdep
@@ -1424,7 +1621,9 @@ vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_
         while(n_accepted < len) {
             int k, batchSize = len - n_accepted;
 
-            err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batchSize, (unsigned MKL_INT64 *) buf);
+            err = viRngUniformBits64(
+                VSL_RNG_METHOD_UNIFORM_STD, state->stream, batchSize,
+                (unsigned MKL_INT64 *) buf);
             assert(err == VSL_STATUS_OK);
 
             for(k=0; k < batchSize; k++) {
@@ -1440,7 +1639,8 @@ vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_
 }
 
 void
-vrk_rand_int64_vec(vrk_state *state, const int len, npy_int64 *res, const npy_int64 lo, const npy_int64 hi)
+vrk_rand_int64_vec(vrk_state *state, const int len, npy_int64 *res,
+    const npy_int64 lo, const npy_int64 hi)
 {
     npy_uint64 rng;
     int i, err;
@@ -1457,15 +1657,17 @@ vrk_rand_int64_vec(vrk_state *state, const int len, npy_int64 *res, const npy_in
 
 }
 
+
 const MKL_INT cholesky_storage_flags[3] = {
     VSL_MATRIX_STORAGE_FULL,
     VSL_MATRIX_STORAGE_PACKED,
     VSL_MATRIX_STORAGE_DIAGONAL
 };
 
+
 void
-vrk_multinormal_vec_ICDF(vrk_state *state, const int len, double *res, const int dim, double * mean_vec, double *ch,
-    const ch_st_enum storage_flag)
+vrk_multinormal_vec_ICDF(vrk_state *state, const int len, double *res,
+    const int dim, double *mean_vec, double *ch, const ch_st_enum storage_flag)
 {
     int err;
     const MKL_INT storage_mode = cholesky_storage_flags[storage_flag];
@@ -1476,31 +1678,36 @@ vrk_multinormal_vec_ICDF(vrk_state *state, const int len, double *res, const int
 }
 
 void
-vrk_multinormal_vec_BM1(vrk_state *state, const int len, double *res, const int dim, double * mean_vec, double *ch,
-    const ch_st_enum storage_flag)
+vrk_multinormal_vec_BM1(vrk_state *state, const int len, double *res,
+    const int dim, double *mean_vec, double *ch, const ch_st_enum storage_flag)
 {
     int err;
     const MKL_INT storage_mode = cholesky_storage_flags[storage_flag];
 
-    err = vdRngGaussianMV(VSL_RNG_METHOD_GAUSSIANMV_BOXMULLER, state->stream, len, res, dim, storage_mode, mean_vec, ch);
+    err = vdRngGaussianMV(
+        VSL_RNG_METHOD_GAUSSIANMV_BOXMULLER, state->stream, len, res,
+        dim, storage_mode, mean_vec, ch);
     assert(err == VSL_STATUS_OK);
 
 }
 
 void
-vrk_multinormal_vec_BM2(vrk_state *state, const int len, double *res, const int dim, double * mean_vec, double *ch,
-    const ch_st_enum storage_flag)
+vrk_multinormal_vec_BM2(vrk_state *state, const int len, double *res,
+    const int dim, double *mean_vec, double *ch, const ch_st_enum storage_flag)
 {
     int err;
     const MKL_INT storage_mode = cholesky_storage_flags[storage_flag];
 
-    err = vdRngGaussianMV(VSL_RNG_METHOD_GAUSSIANMV_BOXMULLER2, state->stream, len, res, dim, storage_mode, mean_vec, ch);
+    err = vdRngGaussianMV(
+        VSL_RNG_METHOD_GAUSSIANMV_BOXMULLER2, state->stream, len, res,
+        dim, storage_mode, mean_vec, ch);
     assert(err == VSL_STATUS_OK);
 
 }
 
-/* This code is taken from distribution.c, and is currently unused. It is retained here for
-   possible future optimization of sampling from multinomial */
+/* This code is taken from distribution.c, and is currently unused.
+   It is retained here for possible future optimization of sampling
+   from multinomial */
 
 static double vrk_double(vrk_state *state) {
     double res;

--- a/numpy/random_intel/mklrand/mkl_distributions.cpp
+++ b/numpy/random_intel/mklrand/mkl_distributions.cpp
@@ -1,0 +1,1689 @@
+#include <stddef.h>       /* for NULL */
+#include <limits.h>       /* for ULONG_MAX */
+#include <assert.h>
+#include <math.h>         /* fmod, fabs */
+#include <cmath>          /* expm1 */
+#include <algorithm>      /* std::sort */
+
+#include "mkl.h"
+#include "mkl_vml.h"
+#include "mkl_distributions.h"
+
+void
+vrk_double_vec(vrk_state *state, const int len, double *res)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_uniform_vec(vrk_state *state, const int len, double *res, const double low, const double high)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, low, high);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_standard_normal_vec_ICDF(vrk_state *state, const int len, double *res)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_normal_vec_ICDF(vrk_state *state, const int len, double *res, const double loc, const double scale)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, loc, scale);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_standard_normal_vec_BM1(vrk_state *state, const int len, double *res)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_normal_vec_BM1(vrk_state *state, const int len, double *res, const double loc, const double scale)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER, state->stream, len, res, loc, scale);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_standard_normal_vec_BM2(vrk_state *state, const int len, double *res)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_normal_vec_BM2(vrk_state *state, const int len, double *res, const double loc, const double scale)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, state->stream, len, res, loc, scale);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_standard_exponential_vec(vrk_state *state, const int len, double *res)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_exponential_vec(vrk_state *state, const int len, double *res, const double scale)
+{
+    int err;
+    const double d_zero = 0.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, scale);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_standard_cauchy_vec(vrk_state *state, const int len, double *res)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngCauchy(VSL_RNG_METHOD_CAUCHY_ICDF, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_standard_gamma_vec(vrk_state *state, const int len, double *res, const double shape)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, d_one);
+
+    assert(err == VSL_STATUS_OK);
+}
+
+void
+vrk_gamma_vec(vrk_state *state, const int len, double *res, const double shape, const double scale)
+{
+    int err;
+    const double d_zero = 0.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, scale);
+
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+/*  X ~ Z * (G*(2/df))**-0.5 */
+void
+vrk_standard_t_vec(vrk_state *state, const int len, double *res, const double df)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+    double shape = df/2;
+    double *sn = NULL;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, 1.0/shape);
+    assert(err == VSL_STATUS_OK);
+
+    vmdInvSqrt(len, res, res, VML_HA);
+
+    sn = (double *) mkl_malloc(len*sizeof(double), 64);
+    assert(sn != NULL);
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, sn, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    vmdMul(len, res, sn, res, VML_HA);
+    mkl_free(sn);
+
+}
+
+/* chisquare(df) ~ G(df/2, 2) */
+void
+vrk_chisquare_vec(vrk_state *state, const int len, double *res, const double df)
+{
+    int err;
+    const double d_zero = 0.0, d_two = 2.0;
+    double shape = 0.5*df;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, d_two);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+/*    P ~ U^(-1/a) - 1 =  */
+void
+vrk_pareto_vec(vrk_state *state, const int len, double *res, const double alp)
+{
+    int i, err;
+    const double d_zero = 0.0, d_one = 1.0;
+    double neg_rec_alp = -1.0/alp;
+
+    if (len<1)
+        return;
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    /* res[i] = pow(res[i], neg_rec_alp) */
+    vmdPowx(len, res, neg_rec_alp, res, VML_HA);
+
+    #pragma ivdep
+    for(i=0; i < len; i++) res[i] -= 1.0;
+
+}
+
+/*  W ~ E^(1/alp) */
+void
+vrk_weibull_vec(vrk_state *state, const int len, double *res, const double alp)
+{
+    int i, err;
+    const double d_zero = 0.0, d_one = 1.0;
+    double rec_alp = 1.0/alp;
+
+    if (len<1)
+        return;
+
+    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    vmdPowx(len, res, rec_alp, res, VML_HA);
+
+}
+
+/*  pow(1 - exp(-E(1))), 1./a) == pow(U, 1./a) */
+void
+vrk_power_vec(vrk_state *state, const int len, double *res, const double alp)
+{
+    int i, err;
+    const double d_zero = 0.0, d_one = 1.0;
+    double rec_alp = 1.0/alp;
+
+    if (len<1)
+        return;
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    /* res[i] = pow(res[i], rec_alp) */
+    vmdPowx(len, res, rec_alp, res, VML_HA);
+
+}
+
+/*  scale * sqrt(2.0 * E(1))  */
+void
+vrk_rayleigh_vec(vrk_state *state, const int len, double *res, const double scale)
+{
+    int i, err;
+    const double d_zero = 0.0, d_two = 2.0;
+
+    if (len<1)
+        return;
+
+    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, state->stream, len, res, d_zero, d_two);
+    assert(err == VSL_STATUS_OK);
+
+    vmdSqrt(len, res, res, VML_HA);
+
+    #pragma ivdep
+    for(i=0; i < len; i++) res[i] *= scale;
+
+}
+
+void
+vrk_beta_vec(vrk_state *state, const int len, double *res, const double a, const double b)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngBeta(VSL_RNG_METHOD_BETA_CJA_ACCURATE, state->stream, len, res, a, b, d_zero, d_one);
+
+    assert(err == VSL_STATUS_OK);
+}
+
+/*  F(df_num, df_den) ~ G( df_num/2, 2/df_num) / G(df_den/2, 2/df_den))  */
+void
+vrk_f_vec(vrk_state *state, const int len, double *res, const double df_num, const double df_den)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+    double shape = 0.5*df_num, scale = 2.0/df_num;
+    double *den = NULL;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, scale);
+    assert(err == VSL_STATUS_OK);
+
+    den = (double *) mkl_malloc(len*sizeof(double), 64);
+    assert(den != NULL);
+
+    shape = 0.5*df_den;
+    scale = 2.0/df_den;
+    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, den, shape, d_zero, scale);
+    assert(err == VSL_STATUS_OK);
+
+    vmdDiv(len, res, den, res, VML_HA);
+    mkl_free(den);
+
+}
+
+/*
+   for df > 1, X ~ Chi2(df - 1) + ( sqrt(nonc) + Z)^2
+   for df <=1, X ~ Chi2( df + 2*I), where I ~ Poisson( nonc/2.0)
+*/
+void
+vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const double df, const double nonc)
+{
+    int i, err;
+    const double d_zero = 0.0, d_one = 1.0, d_two = 2.0;
+    double shape, loc;
+
+    if (len < 1)
+        return;
+
+    if (df > 1) {
+        double *nvec;
+
+        shape = 0.5*(df - 1.0);
+        /* res has chi^2 with (df - 1) */
+        err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, len, res, shape, d_zero, d_two);
+
+        nvec = (double *) mkl_malloc(len*sizeof(double), 64);
+        assert(nvec != NULL);
+
+        loc = sqrt(nonc);
+        err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, nvec, loc, d_one);
+        assert(err == VSL_STATUS_OK);
+
+        /* squaring could result in an overflow */
+        vmdSqr(len, nvec, nvec, VML_HA);
+        vmdAdd(len, res, nvec, res, VML_HA);
+
+        mkl_free(nvec);
+
+    } else {
+        if (df == 0.) {
+            return vrk_chisquare_vec(state, len, res, df);
+        }
+        if(df < 1) {
+            /* noncentral_chisquare(df, nonc) ~ G( df/2 + Poisson(nonc/2), 2) */
+            double lambda;
+            int *pvec = (int *) mkl_malloc(len*sizeof(int), 64);
+
+            assert(pvec != NULL);
+
+            lambda = 0.5*nonc;
+            err = viRngPoisson(VSL_RNG_METHOD_POISSON_PTPE, state->stream, len, pvec, lambda);
+            assert(err == VSL_STATUS_OK);
+
+            shape = 0.5*df;
+
+            if(0.125 * len > sqrt(lambda))  {
+                int *idx = NULL;
+                double *tmp = NULL;
+
+                idx = (int *) mkl_malloc(len * sizeof(int), 64);
+                assert( idx != NULL );
+
+                #pragma ivdep
+                for(i=0; i <len; i++) idx[i] = i;
+
+                std::sort(idx, idx + len, [pvec](int i1, int i2){ return pvec[i1] < pvec[i2]; } );
+                /* idx now contains original indexes of ordered Poisson outputs */
+
+                /* allocate workspace to store samples of gamma, enough to hold entire output */
+                tmp = (double *) mkl_malloc( len * sizeof(double), 64);
+                assert( tmp != NULL );
+
+                for(i = 0; i < len; ) {
+                    int k, j, cv = pvec[idx[i]];
+
+                    #pragma ivdep
+                    for(j=i+1; (j < len) && (pvec[idx[j]] == cv); j++) {}
+
+                    assert(j > i);
+                    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, j - i, tmp,
+                                shape + cv, d_zero, d_two);
+                    assert(err == VSL_STATUS_OK);
+
+                    #pragma ivdep
+                    for(k = i; k < j; k++) res[idx[k]] = tmp[k - i];
+
+                    i = j;
+                }
+
+                mkl_free(tmp);
+                mkl_free(idx);
+
+            } else {
+
+                for(i=0; i<len; i++) {
+                    err = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, state->stream, 1,
+                        res + i, shape + pvec[i], d_zero, d_two);
+                    assert(err == VSL_STATUS_OK);
+                }
+            }
+
+            mkl_free(pvec);
+        } else {
+            float *fuvec = NULL;
+
+            /* noncentral_chisquare(1, nonc) ~ sqrt(nonc)*(-1)^[U<0.5] + Z */
+            err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, d_zero, d_one);
+            loc = sqrt(nonc);
+
+            fuvec = (float *) mkl_malloc(len*sizeof(float), 64);
+            assert(fuvec != NULL);
+
+            err = vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, fuvec, (const float) d_zero, (const float) d_one);
+            assert(err == VSL_STATUS_OK);
+
+            #pragma ivdep
+            for(i=0; i<len; i++) res[i] += (fuvec[i] < 0.5) ? -loc : loc;
+
+            mkl_free(fuvec);
+        }
+    }
+
+}
+
+void
+vrk_laplace_vec(vrk_state *state, const int len, double *res, const double loc, const double scale)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = vdRngLaplace(VSL_RNG_METHOD_LAPLACE_ICDF, state->stream, len, res, loc, scale);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_gumbel_vec(vrk_state *state, const int len, double *res, const double loc, const double scale)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = vdRngGumbel(VSL_RNG_METHOD_GUMBEL_ICDF, state->stream, len, res, loc, scale);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+/*   Logistic(loc, scale) ~ loc + scale * log(u/(1.0 - u)) */
+void
+vrk_logistic_vec(vrk_state *state, const int len, double *res, const double loc, const double scale)
+{
+    int i, err;
+    const double d_one = 1.0, d_mone = -1.0, d_zero = 0.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    /* can MKL optimize computation of the logit function  p \mapsto \ln(p/(1-p)) */
+    #pragma ivdep
+    for(i=0; i<len; i++) res[i] = log(res[i]/(1.0 - res[i]));
+
+    #pragma ivdep
+    for(i=0; i<len; i++) res[i] = loc + scale*res[i];
+}
+
+void
+vrk_lognormal_vec_ICDF(vrk_state *state, const int len, double *res, const double mean, const double sigma)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF_ACCURATE, state->stream, len, res, mean, sigma, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_lognormal_vec_BM(vrk_state *state, const int len, double *res, const double mean, const double sigma)
+{
+    int err;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    err = vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2_ACCURATE, state->stream, len, res, mean, sigma, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+/* direct transformation method */
+void
+vrk_wald_vec(vrk_state *state, const int len, double *res, const double mean, const double scale)
+{
+    int i, err;
+    const double d_zero = 0., d_one = 1.0;
+    double *uvec = NULL;
+    double gsc = 0.5*sqrt(mean / scale);
+
+    err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, state->stream, len, res, d_zero, gsc);
+    assert(err == VSL_STATUS_OK);
+
+    /* Y = mean/(4 scale) * Z^2 */
+    vmdSqr(len, res, res, VML_HA);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) {
+        if(res[i] <= 1.0) {
+            res[i] = 1.0 + res[i] - sqrt( res[i] * (res[i] + 2.0));
+        } else {
+            res[i] = 1.0 - 2.0/(1.0 + sqrt( 1 + 2.0/res[i]));
+        }
+    }
+
+    uvec = (double *) mkl_malloc(len*sizeof(double), 64);
+    assert(uvec != NULL);
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, uvec, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i=0; i<len; i++) {
+        if (uvec[i]*(1.0 + res[i]) <= 1.0)
+            res[i] = mean*res[i];
+        else
+            res[i] = mean/res[i];
+    }
+
+    mkl_free(uvec);
+
+}
+
+#ifndef M_PI
+/*  128-bits worth of pi */
+#define M_PI 3.141592653589793238462643383279502884197
+#endif
+
+
+/* Uses the rejection algorithm compared against the wrapped Cauchy
+   distribution suggested by Best and Fisher and documented in
+   Chapter 9 of Luc's Non-Uniform Random Variate Generation.
+   http://cg.scs.carleton.ca/~luc/rnbookindex.html
+   (but corrected to match the algorithm in R and Python)
+*/
+static void
+vrk_vonmises_vec_small_kappa(vrk_state *state, const int len, double *res, const double mu, const double kappa)
+{
+    int i, err, n, size;
+    double rho_over_kappa, rho, r, s_kappa, Z, W, Y, V;
+    double *Uvec = NULL, *Vvec = NULL;
+    float *VFvec = NULL;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    assert(0. < kappa <= 1.0);
+
+    r = 1 + sqrt(1 + 4*kappa*kappa);
+    rho_over_kappa = (2) / (r + sqrt(2*r));
+    rho = rho_over_kappa * kappa;
+
+    /* s times kappa */
+    s_kappa = (1 + rho*rho)/(2*rho_over_kappa);
+
+    Uvec = (double *) mkl_malloc(len*sizeof(double), 64);
+    assert(Uvec != NULL);
+    Vvec = (double *) mkl_malloc(len*sizeof(double), 64);
+    assert(Vvec != NULL);
+
+    for(n = 0; n < len; )
+    {
+        size = len - n;
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, size, Uvec, d_zero, M_PI);
+        assert(err == VSL_STATUS_OK);
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, size, Vvec, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+
+        for(i = 0; i < size; i++ ) {
+            Z = cos(Uvec[i]);  V = Vvec[i];
+            W = (kappa + s_kappa * Z) / (s_kappa + kappa * Z);
+            Y = s_kappa - kappa * W;
+            if ((Y*(2 - Y) >= V) || (log(Y/V) + 1 >= Y)) {
+                res[n++] = acos(W);
+            }
+        }
+    }
+
+    mkl_free(Uvec);
+
+    VFvec = (float *) Vvec;
+    err = vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, VFvec, (float) d_zero, (float) d_one);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) {
+        double mod, resi;
+
+        resi = (VFvec[i] < 0.5) ? mu - res[i] : mu + res[i];
+        mod = fabs(resi);
+        mod = (fmod(mod + M_PI, 2*M_PI) - M_PI);
+        res[i] = (resi < 0) ? -mod : mod;
+    }
+
+    mkl_free(Vvec);
+
+}
+
+static void
+vrk_vonmises_vec_large_kappa(vrk_state *state, const int len, double *res, const double mu, const double kappa)
+{
+    int i, err, n, size;
+    double r_over_two_kappa, recip_two_kappa;
+    double s_minus_one, hpt, r_over_two_kappa_minus_one, rho_minus_one, neg_W_minus_one;
+    double *Uvec = NULL, *Vvec = NULL;
+    float *VFvec = NULL;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    assert(kappa > 1.0);
+
+    recip_two_kappa = 1 / (2 * kappa);
+
+    /* variables here are dwindling to zero as kappa grows */
+    hpt = sqrt(1 + recip_two_kappa * recip_two_kappa);
+    r_over_two_kappa_minus_one = recip_two_kappa * (1 + recip_two_kappa / (1 + hpt));
+    r_over_two_kappa = 1 + r_over_two_kappa_minus_one;
+    rho_minus_one = r_over_two_kappa_minus_one - sqrt(2 * r_over_two_kappa * recip_two_kappa);
+    s_minus_one = rho_minus_one*(0.5 * rho_minus_one/(1 + rho_minus_one));
+
+    Uvec = (double *) mkl_malloc(len * sizeof(double), 64);
+    assert(Uvec != NULL);
+    Vvec = (double *) mkl_malloc(len * sizeof(double), 64);
+    assert(Vvec != NULL);
+
+    for(n = 0; n < len; )
+    {
+        size = len - n;
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, size, Uvec, d_zero, 0.5*M_PI);
+        assert(err == VSL_STATUS_OK);
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, size, Vvec, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+
+        #pragma ivdep
+        for(i = 0; i < size; i++ ) {
+	    double sn, cn, sn2, cn2;
+	    double neg_W_minus_one, V, Y;
+
+	    sn = sin(Uvec[i]);  cn = cos(Uvec[i]); V = Vvec[i];
+	    sn2 = sn*sn;  cn2 = cn*cn;
+
+            neg_W_minus_one = s_minus_one * sn2 / (0.5*s_minus_one + cn2);
+            Y = kappa * (s_minus_one + neg_W_minus_one);
+
+            if ((Y*(2 - Y) >= V) || (log(Y/V) + 1 >= Y)) {
+	        Y = neg_W_minus_one * (2 - neg_W_minus_one);
+		if (Y < 0)
+		    Y = 0.;
+		else
+		    if (Y > 1.0)
+		        Y = 1.0;
+
+	        res[n++] = asin(sqrt(Y));
+            }
+        }
+    }
+
+    mkl_free(Uvec);
+
+    VFvec = (float *) Vvec;
+    err = vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, VFvec, (float) d_zero, (float) d_one);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) {
+        double mod, resi;
+
+        resi = (VFvec[i] < 0.5) ? mu - res[i] : mu + res[i];
+        mod = fabs(resi);
+        mod = (fmod(mod + M_PI, 2*M_PI) - M_PI);
+        res[i] = (resi < 0) ? -mod : mod;
+    }
+
+    mkl_free(Vvec);
+}
+
+void
+vrk_vonmises_vec(vrk_state *state, const int len, double *res, const double mu, const double kappa)
+{
+    if(len < 1)
+        return;
+
+    if(kappa > 1.0)
+        vrk_vonmises_vec_large_kappa(state, len, res, mu, kappa);
+    else
+        vrk_vonmises_vec_small_kappa(state, len, res, mu, kappa);
+
+}
+
+void
+vrk_noncentral_f_vec(vrk_state *state, const int len, double *res, const double df_num, const double df_den, const double nonc)
+{
+    int i;
+    double *den = NULL, fctr;
+
+    if(len < 1)
+        return;
+
+    if(nonc == 0.)
+        return vrk_f_vec(state, len, res, df_num, df_den);
+
+    vrk_noncentral_chisquare_vec(state, len, res, df_num, nonc);
+
+    den = (double *) mkl_malloc(len*sizeof(double), 64);
+
+    if(den == NULL)
+        return;
+
+    vrk_noncentral_chisquare_vec(state, len, den, df_den, nonc);
+
+    vmdDiv(len, res, den, res, VML_HA);
+
+    mkl_free(den);
+    fctr = df_den/df_num;
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) res[i] *= fctr;
+
+}
+
+
+void
+vrk_triangular_vec(vrk_state *state, const int len, double *res, const double x_min, const double x_mode, const double x_max)
+{
+    int i, err;
+    const double d_zero = 0.0, d_one = 1.0;
+    double ratio, lpr, rpr;
+
+    if (len < 1)
+        return;
+
+    err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, len, res, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+
+    {
+        double wtot, wl, wr;
+
+        wtot = x_max - x_min;
+        wl = x_mode - x_min;
+        wr = x_max - x_mode;
+
+        ratio = wl / wtot;
+        lpr = wl * wtot;
+        rpr = wr * wtot;
+    }
+
+    assert( 0 <= ratio && ratio <= 1);
+
+    if (ratio <= 0) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) {
+            /* U and 1 - U are equal in distribution */
+            res[i] = x_max - sqrt(res[i] * rpr);
+        }
+    } else if (ratio >= 1) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) {
+            res[i] = x_min + sqrt(res[i]*lpr);
+        }
+    } else {
+        #pragma ivdep
+        for(i = 0; i < len; i++) {
+            double ui = res[i];
+            res[i] = (ui > ratio) ? x_max - sqrt((1.0 - ui) * rpr) : x_min + sqrt(ui*lpr);
+        }
+    }
+}
+
+void
+vrk_binomial_vec(vrk_state *state, const int len, int *res, const int n, const double p)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    if (n==0) {
+        int i;
+
+        #pragma ivdep
+        for(i=0; i < len; i++) res[i] = 0;
+    }
+    else {
+        err = viRngBinomial(VSL_RNG_METHOD_BINOMIAL_BTPE, state->stream, len, res, n, p);
+        assert(err == VSL_STATUS_OK);
+    }
+}
+
+void
+vrk_geometric_vec(vrk_state *state, const int len, int *res, const double p)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = viRngGeometric(VSL_RNG_METHOD_GEOMETRIC_ICDF, state->stream, len, res, p);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_negbinomial_vec(vrk_state *state, const int len, int *res, const double a, const double p)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = viRngNegbinomial(VSL_RNG_METHOD_NEGBINOMIAL_NBAR, state->stream, len, res, a, p);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_hypergeometric_vec(vrk_state *state, const int len, int *res, const int lot_s,
+        const int sampling_s, const int marked_s)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = viRngHypergeometric(VSL_RNG_METHOD_HYPERGEOMETRIC_H2PE, state->stream, len, res,
+                lot_s, sampling_s, marked_s);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_poisson_vec_PTPE(vrk_state *state, const int len, int *res, const double lambda)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = viRngPoisson(VSL_RNG_METHOD_POISSON_PTPE, state->stream, len, res, lambda);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_poisson_vec_POISNORM(vrk_state *state, const int len, int *res, const double lambda)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, state->stream, len, res, lambda);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_poisson_vec_V(vrk_state *state, const int len, int *res, double *lambdas)
+{
+    int err;
+
+    if(len < 1)
+        return;
+
+    err = viRngPoissonV(VSL_RNG_METHOD_POISSONV_POISNORM, state->stream, len, res, lambdas);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+
+void
+vrk_zipf_long_vec(vrk_state *state, const int len, long *res, const double a)
+{
+    int i, err, n_accepted, batch_size;
+    double T, U, V, am1, b;
+    double *Uvec = NULL, *Vvec = NULL;
+    long X;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    am1 = a - d_one;
+    b = pow(2.0, am1);
+
+    Uvec = (double *) mkl_malloc(len * sizeof(double), 64);
+    assert(Uvec != NULL);
+    Vvec = (double *) mkl_malloc(len * sizeof(double), 64);
+    assert(Vvec != NULL);
+
+    for(n_accepted=0; n_accepted < len; ) {
+        batch_size = len - n_accepted;
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, batch_size, Uvec, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batch_size, Vvec, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+
+        #pragma ivdep
+        for(i = 0; i < batch_size; i++) {
+            U = d_one - Uvec[i]; V = Vvec[i];
+            X = (long)floor(pow(U, (-1.0)/am1));
+            /* The real result may be above what can be represented in a signed
+             * long. It will get casted to -sys.maxint-1. Since this is
+             * a straightforward rejection algorithm, we can just reject this value
+             * in the rejection condition below. This function then models a Zipf
+             * distribution truncated to sys.maxint.
+             */
+            T = pow(d_one + d_one/X, am1);
+            if ( (X > 0) && ( (V * X) * (T - d_one)/(b - d_one) <= T/b) ) {
+                res[n_accepted++] = X;
+            }
+        }
+    }
+
+    mkl_free(Vvec);
+    mkl_free(Uvec);
+
+}
+
+void
+vrk_logseries_vec(vrk_state *state, const int len, int *res, const double theta)
+{
+    int i, err, n_accepted, batch_size;
+    double q, r, V;
+    double *Uvec = NULL, *Vvec = NULL;
+    int result;
+    const double d_zero = 0.0, d_one = 1.0;
+
+    if(len < 1)
+        return;
+
+    r = log(d_one - theta);
+
+    Uvec = (double *) mkl_malloc(len * sizeof(double), 64);
+    assert(Uvec != NULL);
+    Vvec = (double *) mkl_malloc(len * sizeof(double), 64);
+    assert(Vvec != NULL);
+
+    for(n_accepted=0; n_accepted < len; ) {
+        batch_size = len - n_accepted;
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batch_size, Uvec, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+        err = vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, state->stream, batch_size, Vvec, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+
+        #pragma ivdep
+        for(i = 0; i < batch_size; i++) {
+            V = Vvec[i];
+            if (V >= theta) {
+                res[n_accepted++] = 1;
+            } else {
+#if __cplusplus > 199711L
+                q = -expm1(r * Uvec[i]);
+#else
+                /*  exp(x) - 1 == 2 * exp(x/2) * sinh(x/2)  */
+                q = r * Uvec[i];
+                if (q > 1.) {
+                    q = 1.0 - exp(q);
+                } else {
+                    q = 0.5 * q;
+                    q = -2.0 * exp(q) * sinh(q);
+                }
+#endif
+                if (V <= q*q) {
+                    result = (int) floor(1 + log(V)/log(q));
+                    if(result > 0) {
+                        res[n_accepted++] = result;
+                    }
+                } else {
+                    res[n_accepted++] = (V < q) ? 2 : 1;
+                }
+            }
+        }
+    }
+
+    mkl_free(Vvec);
+
+}
+
+/* samples discrete uniforms from [low, high) */
+void
+vrk_discrete_uniform_vec(vrk_state *state, const int len, int *res, const int low, const int high)
+{
+    int err;
+
+    if (len  < 1)
+        return;
+
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, res, low, high);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_discrete_uniform_long_vec(vrk_state *state, const int len, long *res, const long low, const long high)
+{
+    int err;
+    unsigned long max;
+    int i;
+
+    if (len  < 1)
+        return;
+
+
+    max = ((unsigned long) high) - ((unsigned long) low) - 1UL;
+    if(max == 0) {
+        #pragma ivdep
+        for(i=0; i < len; i++) res[i] = low;
+
+        return;
+    }
+
+    if (max <= (unsigned long) INT_MAX) {
+        int *buf = (int*) mkl_malloc( len*sizeof(int), 64);
+        assert(buf != NULL);
+
+        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, -1, (const int) max);
+        assert(err == VSL_STATUS_OK);
+
+        #pragma ivdep
+        for(i=0; i < len; i++) res[i] = low + ((long) buf[i]) + 1L;
+
+        mkl_free(buf);
+
+    } else {
+        unsigned long mask = max;
+        unsigned long *buf = NULL;
+        int n_accepted;
+
+        /* Smallest bit mask >= max */
+        mask |= mask >> 1;
+        mask |= mask >> 2;
+        mask |= mask >> 4;
+        mask |= mask >> 8;
+        mask |= mask >> 16;
+#if ULONG_MAX > 0xffffffffUL
+        mask |= mask >> 32;
+#endif
+
+        buf = (unsigned long *) mkl_malloc( len*sizeof(long), 64);
+        assert(buf != NULL);
+        n_accepted = 0;
+
+        while(n_accepted < len) {
+            int k, batchSize = len - n_accepted;
+
+            err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batchSize, (unsigned MKL_INT64 *) buf);
+            assert(err == VSL_STATUS_OK);
+
+            for(k=0; k < batchSize; k++) {
+                unsigned long value = buf[k] & mask;
+                if ( value <= max) {
+                    res[n_accepted++] = low + value;
+                }
+            }
+        }
+
+        mkl_free(buf);
+    }
+}
+
+
+void
+vrk_ulong_vec(vrk_state *state, const int len, unsigned long *res)
+{
+    int err;
+
+#if ULONG_MAX <= 0xffffffffUL
+    err = viRngUniformBits32(VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len, (unsigned MKL_INT*) res);
+#else
+    err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORMBITS64_STD, state->stream, len, (unsigned MKL_INT64*) res);
+#endif
+
+    assert(err == VSL_STATUS_OK);
+}
+
+void
+vrk_long_vec(vrk_state *state, const int len, long *res)
+{
+    int i;
+    unsigned long *ulptr = (unsigned long*) res;
+
+    vrk_ulong_vec(state, len, ulptr);
+
+    #pragma ivdep
+    for(i=0; i<len; i++)
+        res[i] = (long) (ulptr[i] >> 1);
+
+}
+
+void
+vrk_rand_bool_vec(vrk_state *state, const int len, npy_bool *res, const npy_bool lo, const npy_bool hi)
+{
+    int err, i;
+    int *buf = NULL;
+
+    if(len < 1)
+        return;
+
+    if (lo == hi) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) res[i] = lo;
+
+        return;
+    }
+
+    assert( (lo == 0) && (hi == 1) );
+    buf = (int *) mkl_malloc(len * sizeof(int), 64);
+    assert( buf != NULL);
+
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) res[i] = (npy_bool) buf[i];
+
+    mkl_free(buf);
+}
+
+void
+vrk_rand_uint8_vec(vrk_state *state, const int len, npy_uint8 *res, const npy_uint8 lo, const npy_uint8 hi)
+{
+    int err, i;
+    int *buf = NULL;
+
+    if(len < 1)
+        return;
+
+    if (lo == hi) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) res[i] = lo;
+
+        return;
+    }
+
+    assert( lo < hi );
+    buf = (int *) mkl_malloc(len * sizeof(int), 64);
+    assert( buf != NULL);
+
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) res[i] = (npy_uint8) buf[i];
+
+    mkl_free(buf);
+
+}
+
+void
+vrk_rand_int8_vec(vrk_state *state, const int len, npy_int8 *res, const npy_int8 lo, const npy_int8 hi)
+{
+    int err, i;
+    int *buf = NULL;
+
+    if(len < 1)
+        return;
+
+    if (lo == hi) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) res[i] = lo;
+
+        return;
+    }
+
+    assert( lo < hi );
+    buf = (int *) mkl_malloc(len * sizeof(int), 64);
+    assert( buf != NULL);
+
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) res[i] = (npy_int8) buf[i];
+
+    mkl_free(buf);
+}
+
+void
+vrk_rand_uint16_vec(vrk_state *state, const int len, npy_uint16 *res, const npy_uint16 lo, const npy_uint16 hi)
+{
+    int err, i;
+    int *buf = NULL;
+
+    if(len < 1)
+        return;
+
+    if (lo == hi) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) res[i] = lo;
+
+        return;
+    }
+
+    assert( lo < hi );
+    buf = (int *) mkl_malloc(len * sizeof(int), 64);
+    assert( buf != NULL);
+
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) res[i] = (npy_uint16) buf[i];
+
+    mkl_free(buf);
+}
+
+void
+vrk_rand_int16_vec(vrk_state *state, const int len, npy_int16 *res, const npy_int16 lo, const npy_int16 hi)
+{
+    int err, i;
+    int *buf = NULL;
+
+    if(len < 1)
+        return;
+
+    if (lo == hi) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) res[i] = lo;
+
+        return;
+    }
+
+    assert( lo < hi );
+    buf = (int *) mkl_malloc(len * sizeof(int), 64);
+    assert( buf != NULL);
+
+    err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, (const int) lo, (const int) hi + 1);
+    assert(err == VSL_STATUS_OK);
+
+    #pragma ivdep
+    for(i = 0; i < len; i++) res[i] = (npy_int16) buf[i];
+
+    mkl_free(buf);
+}
+
+void
+vrk_rand_uint32_vec(vrk_state *state, const int len, npy_uint32 *res, const npy_uint32 lo, const npy_uint32 hi)
+{
+    int err;
+    unsigned int intm = INT_MAX;
+
+    if (len < 1)
+        return;
+
+    /* optimization for lo = 0 and hi = 2**32-1 */
+    if (!(lo || ~hi)) {
+        err = viRngUniformBits32(VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len, (unsigned MKL_INT *) res);
+        assert(err == VSL_STATUS_OK);
+
+        return;
+    }
+
+    if (hi >= intm) {
+
+        npy_int32 shft = ((npy_uint32) intm) + ((npy_uint32) 1);
+        int i;
+
+        /* if lo is non-zero, shift one more to accommodate possibility of hi being ULONG_MAX */
+        if (lo) shft++;
+
+        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res, (const int) (lo - shft), (const int) (hi - shft + 1U));
+        assert(err == VSL_STATUS_OK);
+
+        #pragma ivdep
+        for(i=0; i < len; i++) res[i] += shft;
+
+    } else {
+        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res, (const int) lo, (const int) hi + 1);
+        assert(err == VSL_STATUS_OK);
+    }
+}
+
+void
+vrk_rand_int32_vec(vrk_state *state, const int len, npy_int32 *res, const npy_int32 lo, const npy_int32 hi)
+{
+    int err;
+    int intm = INT_MAX;
+
+    if (len < 1)
+        return;
+
+    if(hi >= intm) {
+        int i;
+
+        vrk_rand_uint32_vec(state, len, (npy_uint32 *) res, 0U, (npy_uint32) (hi - lo));
+
+        #pragma ivdep
+        for(i=0; i < len; i++) res[i] += lo;
+
+    } else {
+        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, (int *) res, (const int) lo, (const int) hi + 1);
+        assert(err == VSL_STATUS_OK);
+    }
+}
+
+void
+vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_uint64 lo, const npy_uint64 hi)
+{
+    npy_uint64 rng;
+    int i, err;
+
+    if(len < 1)
+        return;
+
+    /* optimization for lo = 0 and hi = 2**64-1 */
+    if (!(lo || ~hi)) {
+        err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORMBITS64_STD, state->stream, len, (unsigned MKL_INT64 *) res);
+        assert(err == VSL_STATUS_OK);
+
+        return;
+    }
+
+    rng = hi - lo;
+    if(!rng) {
+        #pragma ivdep
+        for(i = 0; i < len; i++) res[i] = lo;
+
+        return;
+    }
+
+    rng++;
+
+    if(rng <= (npy_uint64) INT_MAX) {
+        int *buf = (int*) mkl_malloc(len * sizeof(int), 64);
+        assert(buf != NULL);
+
+        err = viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, state->stream, len, buf, 0, (const int) rng);
+        assert(err == VSL_STATUS_OK);
+
+        #pragma ivdep
+        for(i=0; i < len; i++) res[i] = lo + ((npy_uint64) buf[i]);
+
+        mkl_free(buf);
+
+    } else {
+        npy_uint64 mask = rng;
+        npy_uint64 *buf = NULL;
+        int n_accepted = 0;
+
+        mask |= mask >> 1;
+        mask |= mask >> 2;
+        mask |= mask >> 4;
+        mask |= mask >> 8;
+        mask |= mask >> 16;
+        mask |= mask >> 32;
+
+        buf = (npy_uint64 *) mkl_malloc(len * sizeof(npy_uint64), 64);
+        assert(buf != NULL);
+
+        while(n_accepted < len) {
+            int k, batchSize = len - n_accepted;
+
+            err = viRngUniformBits64(VSL_RNG_METHOD_UNIFORM_STD, state->stream, batchSize, (unsigned MKL_INT64 *) buf);
+            assert(err == VSL_STATUS_OK);
+
+            for(k=0; k < batchSize; k++) {
+                npy_uint64 value = buf[k] & mask;
+                if ( value <= rng) {
+                    res[n_accepted++] = lo + value;
+                }
+            }
+        }
+
+        mkl_free(buf);
+    }
+}
+
+void
+vrk_rand_int64_vec(vrk_state *state, const int len, npy_int64 *res, const npy_int64 lo, const npy_int64 hi)
+{
+    npy_uint64 rng;
+    int i, err;
+
+    if (len < 1)
+        return;
+
+    rng = ((npy_uint64) hi) - ((npy_uint64) lo);
+
+    vrk_rand_uint64_vec(state, len, (npy_uint64 *) res, 0, rng);
+
+    for(i = 0; i < len; i++)
+        res[i] = res[i] + lo;
+
+}
+
+const MKL_INT cholesky_storage_flags[3] = {
+    VSL_MATRIX_STORAGE_FULL,
+    VSL_MATRIX_STORAGE_PACKED,
+    VSL_MATRIX_STORAGE_DIAGONAL
+};
+
+void
+vrk_multinormal_vec_ICDF(vrk_state *state, const int len, double *res, const int dim, double * mean_vec, double *ch,
+    const ch_st_enum storage_flag)
+{
+    int err;
+    const MKL_INT storage_mode = cholesky_storage_flags[storage_flag];
+
+    err = vdRngGaussianMV(VSL_RNG_METHOD_GAUSSIANMV_ICDF, state->stream, len, res, dim, storage_mode, mean_vec, ch);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_multinormal_vec_BM1(vrk_state *state, const int len, double *res, const int dim, double * mean_vec, double *ch,
+    const ch_st_enum storage_flag)
+{
+    int err;
+    const MKL_INT storage_mode = cholesky_storage_flags[storage_flag];
+
+    err = vdRngGaussianMV(VSL_RNG_METHOD_GAUSSIANMV_BOXMULLER, state->stream, len, res, dim, storage_mode, mean_vec, ch);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+void
+vrk_multinormal_vec_BM2(vrk_state *state, const int len, double *res, const int dim, double * mean_vec, double *ch,
+    const ch_st_enum storage_flag)
+{
+    int err;
+    const MKL_INT storage_mode = cholesky_storage_flags[storage_flag];
+
+    err = vdRngGaussianMV(VSL_RNG_METHOD_GAUSSIANMV_BOXMULLER2, state->stream, len, res, dim, storage_mode, mean_vec, ch);
+    assert(err == VSL_STATUS_OK);
+
+}
+
+/* This code is taken from distribution.c, and is currently unused. It is retained here for
+   possible future optimization of sampling from multinomial */
+
+static double vrk_double(vrk_state *state) {
+    double res;
+
+    vrk_double_vec(state, 1, &res);
+
+    return res;
+}
+
+#ifndef min
+#define min(x,y) (((x)<(y))?(x):(y))
+#endif
+
+static long vrk_binomial_btpe(vrk_state *state, long n, double p)
+{
+    double r,q,fm,p1,xm,xl,xr,c,laml,lamr,p2,p3,p4;
+    double a,u,v,s,F,rho,t,A,nrq,x1,x2,f1,f2,z,z2,w,w2,x;
+    long m,y,k,i;
+
+    r = min(p, 1.0-p);
+    q = 1.0 - r;
+    fm = n*r+r;
+    m = (long)floor(fm);
+    p1 = floor(2.195*sqrt(n*r*q)-4.6*q) + 0.5;
+    xm = m + 0.5;
+    xl = xm - p1;
+    xr = xm + p1;
+    c = 0.134 + 20.5/(15.3 + m);
+    a = (fm - xl)/(fm-xl*r);
+    laml = a*(1.0 + a/2.0);
+    a = (xr - fm)/(xr*q);
+    lamr = a*(1.0 + a/2.0);
+    p2 = p1*(1.0 + 2.0*c);
+    p3 = p2 + c/laml;
+    p4 = p3 + c/lamr;
+
+  /* sigh ... */
+  Step10:
+    nrq = n*r*q;
+    u = vrk_double(state)*p4;
+    v = vrk_double(state);
+    if (u > p1) goto Step20;
+    y = (long)floor(xm - p1*v + u);
+    goto Step60;
+
+  Step20:
+    if (u > p2) goto Step30;
+    x = xl + (u - p1)/c;
+    v = v*c + 1.0 - fabs(m - x + 0.5)/p1;
+    if (v > 1.0) goto Step10;
+    y = (long)floor(x);
+    goto Step50;
+
+  Step30:
+    if (u > p3) goto Step40;
+    y = (long)floor(xl + log(v)/laml);
+    if (y < 0) goto Step10;
+    v = v*(u-p2)*laml;
+    goto Step50;
+
+  Step40:
+    y = (long)floor(xr - log(v)/lamr);
+    if (y > n) goto Step10;
+    v = v*(u-p3)*lamr;
+
+  Step50:
+    k = labs(y - m);
+    if ((k > 20) && (k < ((nrq)/2.0 - 1))) goto Step52;
+
+    s = r/q;
+    a = s*(n+1);
+    F = 1.0;
+    if (m < y)
+    {
+        for (i=m+1; i<=y; i++)
+        {
+            F *= (a/i - s);
+        }
+    }
+    else if (m > y)
+    {
+        for (i=y+1; i<=m; i++)
+        {
+            F /= (a/i - s);
+        }
+    }
+    if (v > F) goto Step10;
+    goto Step60;
+
+    Step52:
+    rho = (k/(nrq))*((k*(k/3.0 + 0.625) + 0.16666666666666666)/nrq + 0.5);
+    t = -k*k/(2*nrq);
+    A = log(v);
+    if (A < (t - rho)) goto Step60;
+    if (A > (t + rho)) goto Step10;
+
+    x1 = y+1;
+    f1 = m+1;
+    z = n+1-m;
+    w = n-y+1;
+    x2 = x1*x1;
+    f2 = f1*f1;
+    z2 = z*z;
+    w2 = w*w;
+    if (A > (xm*log(f1/x1)
+           + (n-m+0.5)*log(z/w)
+           + (y-m)*log(w*r/(x1*q))
+           + (13680.-(462.-(132.-(99.-140./f2)/f2)/f2)/f2)/f1/166320.
+           + (13680.-(462.-(132.-(99.-140./z2)/z2)/z2)/z2)/z/166320.
+           + (13680.-(462.-(132.-(99.-140./x2)/x2)/x2)/x2)/x1/166320.
+           + (13680.-(462.-(132.-(99.-140./w2)/w2)/w2)/w2)/w/166320.))
+    {
+        goto Step10;
+    }
+
+  Step60:
+    if (p > 0.5)
+    {
+        y = n - y;
+    }
+
+    return y;
+}
+
+static long vrk_binomial_inversion(vrk_state *state, long n, double p)
+{
+    double q, qn, np, px, U;
+    long X, bound;
+
+    q = 1.0 - p;
+    qn = exp(n * log(q));
+    np = n*p;
+    bound = min(n, np + 10.0*sqrt(np*q + 1));
+
+    X = 0;
+    px = qn;
+    U = vrk_double(state);
+    while (U > px)
+    {
+        X++;
+        if (X > bound)
+        {
+            X = 0;
+            px = qn;
+            U = vrk_double(state);
+        } else
+        {
+            U -= px;
+            px  = ((n-X+1) * p * px)/(X*q);
+        }
+    }
+    return X;
+}
+
+#undef min
+
+static long vrk_binomial(vrk_state *state, long n, double p)
+{
+    double q;
+
+    if (p <= 0.5)
+    {
+        if (p*n <= 30.0)
+        {
+            return vrk_binomial_inversion(state, n, p);
+        }
+        else
+        {
+            return vrk_binomial_btpe(state, n, p);
+        }
+    }
+    else
+    {
+        q = 1.0-p;
+        if (q*n <= 30.0)
+        {
+            return n - vrk_binomial_inversion(state, n, q);
+        }
+        else
+        {
+            return n - vrk_binomial_btpe(state, n, q);
+        }
+    }
+
+}
+

--- a/numpy/random_intel/mklrand/mkl_distributions.h
+++ b/numpy/random_intel/mklrand/mkl_distributions.h
@@ -1,0 +1,107 @@
+#include <stddef.h>
+#include "randomkit.h"
+
+#ifndef _MKL_DISTRIBUTIONS_H_
+#define _MKL_DISTRIBUTIONS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    MATRIX = 0,
+    PACKED = 1,
+    DIAGONAL = 2
+} ch_st_enum;
+
+extern void vrk_double_vec(vrk_state *state, const int len, double *res);
+extern void vrk_uniform_vec(vrk_state *state, const int len, double *res, const double low, const double high);
+extern void vrk_standard_normal_vec_ICDF(vrk_state *state, const int len, double *res);
+extern void vrk_standard_normal_vec_BM1(vrk_state *state, const int len, double *res);
+extern void vrk_standard_normal_vec_BM2(vrk_state *state, const int len, double *res);
+
+extern void vrk_normal_vec_ICDF(vrk_state *state, const int len, double *res, const double loc, const double scale);
+extern void vrk_normal_vec_BM1(vrk_state *state, const int len, double *res, const double loc, const double scale);
+extern void vrk_normal_vec_BM2(vrk_state *state, const int len, double *res, const double loc, const double scale);
+
+extern void vrk_standard_t_vec(vrk_state *state, const int len, double *res, const double df);
+extern void vrk_chisquare_vec(vrk_state *state, const int len, double *res, const double df);
+
+extern void vrk_standard_exponential_vec(vrk_state *state, int len, double *res);
+extern void vrk_standard_cauchy_vec(vrk_state *state, int len, double *res);
+
+extern void vrk_standard_gamma_vec(vrk_state *state, const int len, double *res, const double shape);
+extern void vrk_exponential_vec(vrk_state *state, const int len, double *res, const double scale);
+extern void vrk_gamma_vec(vrk_state *state, const int len, double *res, const double shape, const double scale);
+
+extern void vrk_pareto_vec(vrk_state *state, const int len, double *res, const double alph);
+extern void vrk_power_vec(vrk_state *state, const int len, double *res, const double alph);
+
+extern void vrk_weibull_vec(vrk_state *state, const int len, double *res, const double alph);
+
+extern void vrk_rayleigh_vec(vrk_state *state, const int len, double *res, const double scale);
+
+extern void vrk_beta_vec(vrk_state *state, const int len, double *res, const double p, const double q);
+extern void vrk_f_vec(vrk_state *state, const int len, double *res, const double df_num, const double df_den);
+
+extern void vrk_noncentral_chisquare_vec(vrk_state *state, const int len, double *res, const double df, const double nonc);
+
+extern void vrk_laplace_vec(vrk_state *vec, const int len, double *res, const double loc, const double scale);
+extern void vrk_gumbel_vec(vrk_state *vec, const int len, double *res, const double loc, const double scale);
+extern void vrk_logistic_vec(vrk_state *vec, const int len, double *res, const double loc, const double scale);
+
+extern void vrk_lognormal_vec_ICDF(vrk_state *state, const int len, double *res, const double mean, const double sigma);
+extern void vrk_lognormal_vec_BM(vrk_state *state, const int len, double *res, const double mean, const double sigma);
+
+extern void vrk_wald_vec(vrk_state *state, const int len, double *res, const double mean, const double scale);
+
+extern void vrk_vonmises_vec(vrk_state *state, const int len, double *res, const double mu, const double kappa);
+
+extern void vrk_noncentral_f_vec(vrk_state *state, int len, double *res, double df_num, double df_den, double nonc);
+extern void vrk_triangular_vec(vrk_state *state, int len, double *res, double left, double mode, double right);
+
+extern void vrk_binomial_vec(vrk_state *state, const int len, int *res, const int n, const double p);
+extern void vrk_geometric_vec(vrk_state *state, const int len, int *res, const double p);
+extern void vrk_negbinomial_vec(vrk_state *state, const int len, int *res, const double a, const double p);
+extern void vrk_hypergeometric_vec(vrk_state *state, const int len, int *res, const int ls, const int ss, const int ms);
+extern void vrk_poisson_vec_PTPE(vrk_state *state, const int len, int *res, const double lambda);
+extern void vrk_poisson_vec_POISNORM(vrk_state *state, const int len, int *res, const double lambda);
+
+extern void vrk_poisson_vec_V(vrk_state *state, const int len, int *res, double *lambdas);
+
+extern void vrk_zipf_long_vec(vrk_state *state, const int len, long *res, const double alp);
+
+extern void vrk_logseries_vec(vrk_state *state, const int len, int *res, const double alp);
+
+extern void vrk_discrete_uniform_vec(vrk_state *state, const int len, int *res, const int low, const int high);
+
+extern void vrk_discrete_uniform_long_vec(vrk_state *state, const int len, long *res, const long low, const long high);
+
+extern void vrk_rand_int64_vec(vrk_state *state, const int len, npy_int64 *res, const npy_int64 lo, const npy_int64 hi);
+extern void vrk_rand_uint64_vec(vrk_state *state, const int len, npy_uint64 *res, const npy_uint64 lo, const npy_uint64 hi);
+extern void vrk_rand_int32_vec(vrk_state *state, const int len, npy_int32 *res, const npy_int32 lo, const npy_int32 hi);
+extern void vrk_rand_uint32_vec(vrk_state *state, const int len, npy_uint32 *res, const npy_uint32 lo, const npy_uint32 hi);
+extern void vrk_rand_int16_vec(vrk_state *state, const int len, npy_int16 *res, const npy_int16 lo, const npy_int16 hi);
+extern void vrk_rand_uint16_vec(vrk_state *state, const int len, npy_uint16 *res, const npy_uint16 lo, const npy_uint16 hi);
+extern void vrk_rand_int8_vec(vrk_state *state, const int len, npy_int8 *res, const npy_int8 lo, const npy_int8 hi);
+extern void vrk_rand_uint8_vec(vrk_state *state, const int len, npy_uint8 *res, const npy_uint8 lo, const npy_uint8 hi);
+extern void vrk_rand_bool_vec(vrk_state *state, const int len, npy_bool *res, const npy_bool lo, const npy_bool hi);
+
+extern void vrk_ulong_vec(vrk_state *state, const int len, unsigned long *res);
+extern void vrk_long_vec(vrk_state *state, const int len, long *res);
+
+extern void vrk_multinormal_vec_ICDF(vrk_state *state, const int len, double *res, const int dim,
+    double *mean_vec, double *ch, const ch_st_enum storage_mode);
+
+extern void vrk_multinormal_vec_BM1(vrk_state *state, const int len, double *res, const int dim,
+    double *mean_vec, double *ch, const ch_st_enum storage_mode);
+
+extern void vrk_multinormal_vec_BM2(vrk_state *state, const int len, double *res, const int dim,
+    double *mean_vec, double *ch, const ch_st_enum storage_mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/numpy/random_intel/mklrand/mklrand.pyx
+++ b/numpy/random_intel/mklrand/mklrand.pyx
@@ -1,0 +1,5871 @@
+# mklrand.pyx -- A Pyrex wrapper of Jean-Sebastien Roy's RandomKit
+#
+# Copyright 2005 Robert Kern (robert.kern@gmail.com)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+include "Python.pxi"
+include "numpy.pxd"
+
+from libc.string cimport memset, memcpy
+
+cdef extern from "math.h":
+    double floor(double x)
+
+cdef extern from "numpy/npy_math.h":
+    int npy_isfinite(double x)
+
+cdef extern from "mklrand_py_helper.h":
+    object empty_py_bytes(npy_intp length, void **bytesVec)
+    char* py_bytes_DataPtr(object b)
+    int is_bytes_object(object b)
+
+cdef extern from "randomkit.h":
+
+    ctypedef struct vrk_state:
+        pass
+
+    ctypedef enum vrk_error:
+        RK_NOERR = 0
+        RK_ENODEV = 1
+        RK_ERR_MAX = 2
+
+    ctypedef enum vrk_brng_t:
+        MT19937 = 0
+        SFMT19937 = 1
+        WH = 2
+        MT2203 = 3
+        MCG31 = 4
+        R250 = 5
+        MRG32K3A = 6
+        MCG59 = 7
+        PHILOX4X32X10 = 8
+
+    void vrk_fill(void *buffer, size_t size, vrk_state *state) nogil
+
+    void vrk_dealloc_stream(vrk_state *state)
+    void vrk_seed_mkl(vrk_state * state, unsigned int seed, vrk_brng_t brng, unsigned int stream_id)
+    void vrk_seed_mkl_array(vrk_state * state, unsigned int * seed_vec, int seed_len, vrk_brng_t brng, unsigned int stream_id)
+    vrk_error vrk_randomseed_mkl(vrk_state * state, vrk_brng_t brng, unsigned int stream_id)
+    int vrk_get_stream_size(vrk_state * state) nogil
+    void vrk_get_state_mkl(vrk_state * state, char * buf)
+    int vrk_set_state_mkl(vrk_state * state, char * buf)
+    int vrk_get_brng_mkl(vrk_state *state) nogil
+    int vrk_leapfrog_stream_mkl(vrk_state *state, int k, int nstreams) nogil
+    int vrk_skipahead_stream_mkl(vrk_state *state, long long int nskips) nogil
+
+
+cdef extern from "mkl_distributions.h":
+    void vrk_double_vec(vrk_state *state, int len, double *res) nogil
+    void vrk_uniform_vec(vrk_state *state, int len, double *res, double dlow, double dhigh) nogil
+
+    void vrk_normal_vec_BM1(vrk_state *state, int len, double *res, double mean, double sigma) nogil
+    void vrk_normal_vec_BM2(vrk_state *state, int len, double *res, double mean, double sigma) nogil
+    void vrk_normal_vec_ICDF(vrk_state *state, int len, double *res, double mean, double sigma) nogil
+
+    void vrk_standard_normal_vec_BM1(vrk_state *state, int len, double *res) nogil
+    void vrk_standard_normal_vec_BM2(vrk_state *state, int len, double *res) nogil
+    void vrk_standard_normal_vec_ICDF(vrk_state *state, int len, double *res) nogil
+
+    void vrk_standard_exponential_vec(vrk_state *state, int len, double *res) nogil
+    void vrk_exponential_vec(vrk_state *state, int len, double *res, double scale) nogil
+
+    void vrk_standard_cauchy_vec(vrk_state *state, int len, double *res) nogil
+    void vrk_standard_gamma_vec(vrk_state *state, int len, double *res, double shape) nogil
+    void vrk_gamma_vec(vrk_state *state, int len, double *res, double shape, double scale) nogil
+
+    void vrk_beta_vec(vrk_state *state, int len, double *res, double p, double q) nogil
+
+    void vrk_chisquare_vec(vrk_state *state, int len, double *res, double df) nogil
+    void vrk_standard_t_vec(vrk_state *state, int len, double *res, double df) nogil
+
+    void vrk_rayleigh_vec(vrk_state *state, int len, double *res, double sigma) nogil
+    void vrk_pareto_vec(vrk_state *state, int len, double *res, double alp) nogil
+    void vrk_power_vec(vrk_state *state, int len, double *res, double alp) nogil
+    void vrk_weibull_vec(vrk_state *state, int len, double *res, double alp) nogil
+    void vrk_f_vec(vrk_state *state, int len, double *res, double df_num, double df_den) nogil
+    void vrk_noncentral_chisquare_vec(vrk_state *state, int len, double *res, double df, double nonc) nogil
+    void vrk_laplace_vec(vrk_state *state, int len, double *res, double loc, double scale) nogil
+    void vrk_gumbel_vec(vrk_state *state, int len, double *res, double loc, double scale) nogil
+    void vrk_logistic_vec(vrk_state *state, int len, double *res, double loc, double scale) nogil
+    void vrk_wald_vec(vrk_state *state, int len, double *res, double mean, double scale) nogil
+    void vrk_lognormal_vec_ICDF(vrk_state *state, int len, double *res, double mean, double scale) nogil
+    void vrk_lognormal_vec_BM(vrk_state *state, int len, double *res, double mean, double scale) nogil
+    void vrk_vonmises_vec(vrk_state *state, int len, double *res, double mu, double kappa) nogil
+
+    void vrk_noncentral_f_vec(vrk_state *state, int len, double *res, double df_num, double df_den, double nonc) nogil
+    void vrk_triangular_vec(vrk_state *state, int len, double *res, double left, double mode, double right) nogil
+
+    void vrk_geometric_vec(vrk_state *state, int len, int *res, double p) nogil
+    void vrk_negbinomial_vec(vrk_state *state, int len, int *res, double a, double p) nogil
+    void vrk_binomial_vec(vrk_state *state, int len, int *res, int n, double p) nogil
+    void vrk_hypergeometric_vec(vrk_state *state, int len, int *res, int ls, int ss, int ms) nogil
+
+    void vrk_poisson_vec_PTPE(vrk_state *state, int len, int *res, double lam) nogil
+    void vrk_poisson_vec_POISNORM(vrk_state *state, int len, int *res, double lam) nogil
+    void vrk_poisson_vec_V(vrk_state *state, int len, int *res, double *lam_vec) nogil
+
+    void vrk_zipf_long_vec(vrk_state *state, int len, long *res, double alpha) nogil
+    void vrk_logseries_vec(vrk_state *state, int len, int *res, double theta) nogil
+
+    # random integers madness
+    void vrk_discrete_uniform_vec(vrk_state *state, int len, int *res, int low, int high) nogil
+    void vrk_discrete_uniform_long_vec(vrk_state *state, int len, long *res, long low, long high) nogil
+    void vrk_rand_bool_vec(vrk_state *state, int len, npy_bool *res, npy_bool low, npy_bool high) nogil
+    void vrk_rand_uint8_vec(vrk_state *state, int len, npy_uint8 *res, npy_uint8 low, npy_uint8 high) nogil
+    void vrk_rand_int8_vec(vrk_state *state, int len, npy_int8 *res, npy_int8 low, npy_int8 high) nogil
+    void vrk_rand_uint16_vec(vrk_state *state, int len, npy_uint16 *res, npy_uint16 low, npy_uint16 high) nogil
+    void vrk_rand_int16_vec(vrk_state *state, int len, npy_int16 *res, npy_int16 low, npy_int16 high) nogil
+    void vrk_rand_uint32_vec(vrk_state *state, int len, npy_uint32 *res, npy_uint32 low, npy_uint32 high) nogil
+    void vrk_rand_int32_vec(vrk_state *state, int len, npy_int32 *res, npy_int32 low, npy_int32 high) nogil
+    void vrk_rand_uint64_vec(vrk_state *state, int len, npy_uint64 *res, npy_uint64 low, npy_uint64 high) nogil
+    void vrk_rand_int64_vec(vrk_state *state, int len, npy_int64 *res, npy_int64 low, npy_int64 high) nogil
+
+    void vrk_long_vec(vrk_state *state, int len, long *res) nogil
+
+    ctypedef enum ch_st_enum:
+        MATRIX = 0
+        PACKED = 1
+        DIAGONAL = 2
+
+    void vrk_multinormal_vec_ICDF(vrk_state *state, int len, double *res, int dim, double *mean_vec, double *ch, ch_st_enum storage_mode) nogil
+    void vrk_multinormal_vec_BM1(vrk_state *state, int len, double *res, int dim, double *mean_vec, double *ch, ch_st_enum storage_mode) nogil
+    void vrk_multinormal_vec_BM2(vrk_state *state, int len, double *res, int dim, double *mean_vec, double *ch, ch_st_enum storage_mode) nogil
+
+
+ctypedef void (* vrk_cont0_vec)(vrk_state *state, int len, double *res) nogil
+ctypedef void (* vrk_cont1_vec)(vrk_state *state, int len, double *res, double a) nogil
+ctypedef void (* vrk_cont2_vec)(vrk_state *state, int len, double *res, double a, double b) nogil
+ctypedef void (* vrk_cont3_vec)(vrk_state *state, int len, double *res, double a, double b, double c) nogil
+
+ctypedef long (* vrk_disc0)(vrk_state *state) nogil
+ctypedef long (* vrk_discnp)(vrk_state *state, long n, double p) nogil
+ctypedef long (* vrk_discdd)(vrk_state *state, double n, double p) nogil
+ctypedef long (* vrk_discnmN)(vrk_state *state, long n, long m, long N) nogil
+ctypedef long (* vrk_discd)(vrk_state *state, double a) nogil
+
+ctypedef void (* vrk_disc0_vec)(vrk_state *state, int len, int *res) nogil
+ctypedef void (* vrk_disc0_vec_long)(vrk_state *state, int len, long *res) nogil
+ctypedef void (* vrk_discnp_vec)(vrk_state *state, int len, int *res, int n, double a) nogil
+ctypedef void (* vrk_discdd_vec)(vrk_state *state, int len, int *res, double n, double p) nogil
+ctypedef void (* vrk_discnmN_vec)(vrk_state *state, int len, int *res, int n, int m, int N) nogil
+ctypedef void (* vrk_discd_vec)(vrk_state *state, int len, int *res, double a) nogil
+ctypedef void (* vrk_discd_long_vec)(vrk_state *state, int len, long *res, double a) nogil
+ctypedef void (* vrk_discdptr_vec)(vrk_state *state, int len, int *res, double *a) nogil
+
+
+# Initialize numpy
+import_array()
+
+cimport cython
+import numpy as np
+import operator
+import warnings
+try:
+    from threading import Lock
+except ImportError:
+    from dummy_threading import Lock
+
+cdef object vec_cont0_array(vrk_state *state, vrk_cont0_vec func, object size,
+                        object lock):
+    cdef double *array_data
+    cdef double res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        length = PyArray_SIZE(array)
+        array_data = <double *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data)
+
+        return array
+
+cdef object vec_cont1_array_sc(vrk_state *state, vrk_cont1_vec func, object size, double a,
+                        object lock):
+    cdef double *array_data
+    cdef double res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, a)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        length = PyArray_SIZE(array)
+        array_data = <double *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, a)
+
+        return array
+
+
+cdef object vec_cont1_array(vrk_state *state, vrk_cont1_vec func, object size,
+                        ndarray oa, object lock):
+    cdef double *array_data
+    cdef double *oa_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp i, n, imax, res_size
+    cdef flatiter itera
+    cdef broadcast multi
+
+    if size is None:
+        array = <ndarray>PyArray_SimpleNew(PyArray_NDIM(oa),
+                PyArray_DIMS(oa) , NPY_DOUBLE)
+        imax = PyArray_SIZE(array)
+        array_data = <double *>PyArray_DATA(array)
+        itera = <flatiter>PyArray_IterNew(<object>oa)
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                func(state, 1, array_data + i, (<double *>(itera.dataptr))[0])
+                PyArray_ITER_NEXT(itera)
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        array_data = <double *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(2, <void *>array, <void *>oa)
+        res_size = PyArray_SIZE(array);
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        multi = <broadcast> PyArray_MultiIterNew(1, <void *>oa)
+        imax = multi.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                func(state, n, array_data + n*i, oa_data[0])
+                PyArray_MultiIter_NEXT(multi)
+        array.shape = (multi.shape + array.shape)[:array.ndim]
+        multi_ndim = len(multi.shape)
+        array = array.transpose(tuple(range(multi_ndim, array.ndim)) + tuple(range(0, multi_ndim)))
+
+    return array
+
+cdef object vec_cont2_array_sc(vrk_state *state, vrk_cont2_vec func, object size, double a,
+                        double b, object lock):
+    cdef double *array_data
+    cdef double res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, a, b)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        length = PyArray_SIZE(array)
+        array_data = <double *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, a, b)
+
+        return array
+
+cdef object vec_cont2_array(vrk_state *state, vrk_cont2_vec func, object size,
+                        ndarray oa, ndarray ob, object lock):
+    cdef double *array_data
+    cdef double *oa_data
+    cdef double *ob_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp i, n, imax, res_size
+    cdef broadcast multi
+
+    if size is None:
+        multi = <broadcast> PyArray_MultiIterNew(2, <void *>oa, <void *>ob)
+        array = <ndarray> PyArray_SimpleNew(multi.nd, multi.dimensions, NPY_DOUBLE)
+        array_data = <double *>PyArray_DATA(array)
+        with lock, nogil:
+            for i from 0 <= i < multi.size:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                ob_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, 1, &array_data[i], oa_data[0], ob_data[0])
+                PyArray_MultiIter_NEXT(multi)
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        array_data = <double *>PyArray_DATA(array)
+        multi = <broadcast >PyArray_MultiIterNew(3, <void*>array, <void *>oa, <void *>ob)
+        res_size = PyArray_SIZE(array);
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        multi = <broadcast> PyArray_MultiIterNew(2, <void *>oa, <void *>ob)
+        imax = multi.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                ob_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, n, array_data + n*i, oa_data[0], ob_data[0])
+                PyArray_MultiIter_NEXT(multi)
+        array.shape = (multi.shape + array.shape)[:array.ndim]
+        multi_ndim = len(multi.shape)
+        array = array.transpose(tuple(range(multi_ndim, array.ndim)) + tuple(range(0, multi_ndim)))
+
+    return array
+
+
+cdef object vec_cont3_array_sc(vrk_state *state, vrk_cont3_vec func, object size, double a,
+                        double b, double c, object lock):
+    cdef double *array_data
+    cdef double res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, a, b, c)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        length = PyArray_SIZE(array)
+        array_data = <double *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, a, b, c)
+
+        return array
+
+cdef object vec_cont3_array(vrk_state *state, vrk_cont3_vec func, object size,
+                        ndarray oa, ndarray ob, ndarray oc, object lock):
+    cdef double *array_data
+    cdef double *oa_data
+    cdef double *ob_data
+    cdef double *oc_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp i, res_size, n, imax
+    cdef broadcast multi
+
+    if size is None:
+        multi = <broadcast> PyArray_MultiIterNew(3, <void *>oa, <void *>ob, <void *>oc)
+        array = <ndarray> PyArray_SimpleNew(multi.nd, multi.dimensions, NPY_DOUBLE)
+        array_data = <double *>PyArray_DATA(array)
+        with lock, nogil:
+            for i from 0 <= i < multi.size:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                ob_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                oc_data = <double *>PyArray_MultiIter_DATA(multi, 2)
+                func(state, 1, &array_data[i], oa_data[0], ob_data[0], oc_data[0])
+                PyArray_MultiIter_NEXT(multi)
+    else:
+        array = <ndarray>np.empty(size, np.float64)
+        array_data = <double *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(4, <void*>array, <void *>oa,
+                                                <void *>ob, <void *>oc)
+        res_size = PyArray_SIZE(array)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        multi = <broadcast> PyArray_MultiIterNew(3, <void *>oa, <void *>ob, <void *>oc)
+        imax = multi.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                ob_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                oc_data = <double *>PyArray_MultiIter_DATA(multi, 2)
+                func(state, n, array_data + n*i, oa_data[0], ob_data[0], oc_data[0])
+                PyArray_MultiIter_NEXT(multi)
+        array.shape = (multi.shape + array.shape)[:array.ndim]
+        multi_ndim = len(multi.shape)
+        array = array.transpose(tuple(range(multi_ndim, array.ndim)) + tuple(range(0, multi_ndim)))
+
+    return array
+
+cdef object vec_disc0_array(vrk_state *state, vrk_disc0_vec func, object size,
+                        object lock):
+    cdef int *array_data
+    cdef int res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data)
+
+        return array
+
+cdef object vec_long_disc0_array(vrk_state *state, vrk_disc0_vec_long func, object size,
+                        object lock):
+    cdef long *array_data
+    cdef long res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.uint)
+        length = PyArray_SIZE(array)
+        array_data = <long *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data)
+
+        return array
+
+
+cdef object vec_discnp_array_sc(vrk_state *state, vrk_discnp_vec func, object size,
+                            int n, double p, object lock):
+    cdef int *array_data
+    cdef int res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, n, p)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, n, p)
+        return array
+
+
+cdef object vec_discnp_array(vrk_state *state, vrk_discnp_vec func, object size,
+                         ndarray on, ndarray op, object lock):
+    cdef int *array_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i, n, imax, res_size
+    cdef double *op_data
+    cdef int *on_data
+    cdef broadcast multi
+
+    if size is None:
+        multi = <broadcast> PyArray_MultiIterNew(2, <void *>on, <void *>op)
+        array = <ndarray> PyArray_SimpleNew(multi.nd, multi.dimensions, NPY_INT)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            for i from 0 <= i < multi.size:
+                on_data = <int *>PyArray_MultiIter_DATA(multi, 0)
+                op_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, 1, &array_data[i], on_data[0], op_data[0])
+                PyArray_MultiIter_NEXT(multi)
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        array_data = <int *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(3, <void*>array, <void *>on, <void *>op)
+        res_size = PyArray_SIZE(array)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        multi = <broadcast> PyArray_MultiIterNew(2, <void *>on, <void *>op)
+        imax = multi.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                on_data = <int *>PyArray_MultiIter_DATA(multi, 0)
+                op_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, n, array_data + n * i, on_data[0], op_data[0])
+                PyArray_MultiIter_NEXT(multi)
+        array.shape = (multi.shape + array.shape)[:array.ndim]
+        multi_ndim = len(multi.shape)
+        array = array.transpose(tuple(range(multi_ndim, array.ndim)) + tuple(range(0, multi_ndim)))
+
+    return array
+
+
+cdef object vec_discdd_array_sc(vrk_state *state, vrk_discdd_vec func, object size,
+                            double n, double p, object lock):
+    cdef int *array_data
+    cdef int res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, n, p)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, n, p)
+
+        return array
+
+
+cdef object vec_discdd_array(vrk_state *state, vrk_discdd_vec func, object size,
+                         ndarray on, ndarray op, object lock):
+    cdef int *array_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp i, imax, n, res_size
+    cdef double *op_data
+    cdef double *on_data
+    cdef broadcast multi
+
+    if size is None:
+        multi = <broadcast> PyArray_MultiIterNew(2, <void *>on, <void *>op)
+        array = <ndarray> PyArray_SimpleNew(multi.nd, multi.dimensions, NPY_INT)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            for i from 0 <= i < multi.size:
+                on_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                op_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, 1, &array_data[i], on_data[0], op_data[0])
+                PyArray_MultiIter_NEXT(multi)
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        array_data = <int *>PyArray_DATA(array)
+        res_size = PyArray_SIZE(array)
+        multi = <broadcast>PyArray_MultiIterNew(3, <void*>array, <void *>on, <void *>op)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        multi = <broadcast> PyArray_MultiIterNew(2, <void *>on, <void *>op)
+        imax = multi.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                on_data = <double *>PyArray_MultiIter_DATA(multi, 0)
+                op_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, n, array_data + n * i, on_data[0], op_data[0])
+                PyArray_MultiIter_NEXT(multi)
+        array.shape = (multi.shape + array.shape)[:array.ndim]
+        multi_ndim = len(multi.shape)
+        array = array.transpose(tuple(range(multi_ndim, array.ndim)) + tuple(range(0, multi_ndim)))
+
+    return array
+
+
+cdef object vec_discnmN_array_sc(vrk_state *state, vrk_discnmN_vec func, object size,
+                             int n, int m, int N, object lock):
+    cdef int *array_data
+    cdef int res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, n, m, N)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, n, m, N)
+        return array
+
+
+cdef object vec_discnmN_array(vrk_state *state, vrk_discnmN_vec func, object size,
+                          ndarray on, ndarray om, ndarray oN, object lock):
+    cdef int *array_data
+    cdef int *on_data
+    cdef int *om_data
+    cdef int *oN_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp i
+    cdef broadcast multi, multi2
+    cdef npy_intp imax, n, res_size
+
+    if size is None:
+        multi = <broadcast> PyArray_MultiIterNew(3, <void *>on, <void *>om, <void *>oN)
+        array = <ndarray> PyArray_SimpleNew(multi.nd, multi.dimensions, NPY_INT)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            for i from 0 <= i < multi.size:
+                on_data = <int *>PyArray_MultiIter_DATA(multi, 0)
+                om_data = <int *>PyArray_MultiIter_DATA(multi, 1)
+                oN_data = <int *>PyArray_MultiIter_DATA(multi, 2)
+                func(state, 1, array_data + i, on_data[0], om_data[0], oN_data[0])
+                PyArray_MultiIter_NEXT(multi)
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        array_data = <int *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(4, <void*>array, <void *>on, <void *>om,
+                                                <void *>oN)
+        res_size = PyArray_SIZE(array)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        multi = <broadcast> PyArray_MultiIterNew(3, <void *>on, <void *>om, <void *>oN)
+        imax = multi.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                on_data = <int *>PyArray_MultiIter_DATA(multi, 0)
+                om_data = <int *>PyArray_MultiIter_DATA(multi, 1)
+                oN_data = <int *>PyArray_MultiIter_DATA(multi, 2)
+                func(state, n, array_data + n*i, on_data[0], om_data[0], oN_data[0])
+                PyArray_MultiIter_NEXT(multi)
+        array.shape = (multi.shape + array.shape)[:array.ndim]
+        multi_ndim = len(multi.shape)
+        array = array.transpose(tuple(range(multi_ndim, array.ndim)) + tuple(range(0, multi_ndim)))
+
+    return array
+
+cdef object vec_discd_array_sc(vrk_state *state, vrk_discd_vec func, object size,
+                           double a, object lock):
+    cdef int *array_data
+    cdef int res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, a)
+        return res
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, a)
+
+        return array
+
+cdef object vec_long_discd_array_sc(vrk_state *state, vrk_discd_long_vec func, object size,
+                           double a, object lock):
+    cdef long *array_data
+    cdef long res
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length
+    cdef npy_intp i
+
+    if size is None:
+        func(state, 1, &res, a)
+        return res
+    else:
+        array = <ndarray>np.empty(size, int)
+        length = PyArray_SIZE(array)
+        array_data = <long *>PyArray_DATA(array)
+        with lock, nogil:
+            func(state, length, array_data, a)
+
+        return array
+
+cdef object vec_discd_array(vrk_state *state, vrk_discd_vec func, object size, ndarray oa,
+                        object lock):
+    cdef int *array_data
+    cdef double *oa_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length, res_size
+    cdef npy_intp i, imax, n
+    cdef broadcast multi
+    cdef flatiter itera
+
+    if size is None:
+        array = <ndarray>PyArray_SimpleNew(PyArray_NDIM(oa),
+                PyArray_DIMS(oa), NPY_INT)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        itera = <flatiter>PyArray_IterNew(<object>oa)
+        with lock, nogil:
+            for i from 0 <= i < length:
+                func(state, 1, &array_data[i], (<double *>(itera.dataptr))[0])
+                PyArray_ITER_NEXT(itera)
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        array_data = <int *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(2, <void *>array, <void *>oa)
+        res_size = PyArray_SIZE(array)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        imax = oa.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, n, array_data + n*i, oa_data[0])
+                PyArray_MultiIter_NEXTi(multi, 1)
+        array.shape = (oa.shape + array.shape)[:array.ndim]
+        array = array.transpose(tuple(range(oa.ndim, array.ndim)) + tuple(range(0, oa.ndim)))
+    return array
+
+cdef object vec_long_discd_array(vrk_state *state, vrk_discd_long_vec func, object size, ndarray oa,
+                        object lock):
+    cdef long *array_data
+    cdef double *oa_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length, res_size
+    cdef npy_intp i, imax, n
+    cdef broadcast multi
+    cdef flatiter itera
+
+    if size is None:
+        array = <ndarray>PyArray_SimpleNew(PyArray_NDIM(oa),
+                PyArray_DIMS(oa), NPY_LONG)
+        length = PyArray_SIZE(array)
+        array_data = <long *>PyArray_DATA(array)
+        itera = <flatiter>PyArray_IterNew(<object>oa)
+        with lock, nogil:
+            for i from 0 <= i < length:
+                func(state, 1, array_data + i, (<double *>(itera.dataptr))[0])
+                PyArray_ITER_NEXT(itera)
+    else:
+        array = <ndarray>np.empty(size, int)
+        array_data = <long *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(2, <void *>array, <void *>oa)
+        res_size = PyArray_SIZE(array)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        imax = oa.size
+        n = res_size / imax
+        with lock, nogil:
+            for i from 0 <= i < imax:
+                oa_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                func(state, n, array_data + n*i, oa_data[0])
+                PyArray_MultiIter_NEXTi(multi, 1)
+        array.shape = (oa.shape + array.shape)[:array.ndim]
+        array = array.transpose(tuple(range(oa.ndim, array.ndim)) + tuple(range(0, oa.ndim)))
+    return array
+
+cdef object vec_Poisson_array(vrk_state *state, vrk_discdptr_vec func1, vrk_discd_vec func2, object size, ndarray olambda,
+                        object lock):
+    cdef int *array_data
+    cdef double *oa_data
+    cdef ndarray array "arrayObject"
+    cdef npy_intp length, res_size
+    cdef npy_intp i, imax, n
+    cdef broadcast multi
+    cdef flatiter itera
+
+    if size is None:
+        array = <ndarray>PyArray_SimpleNew(PyArray_NDIM(olambda),
+                PyArray_DIMS(olambda), NPY_INT)
+        length = PyArray_SIZE(array)
+        array_data = <int *>PyArray_DATA(array)
+        oa_data = <double *>PyArray_DATA(olambda)
+        with lock, nogil:
+            func1(state, length, array_data, oa_data)
+    else:
+        array = <ndarray>np.empty(size, np.int32)
+        array_data = <int *>PyArray_DATA(array)
+        multi = <broadcast>PyArray_MultiIterNew(2, <void *>array, <void *>olambda)
+        res_size = PyArray_SIZE(array)
+        if (multi.size != res_size):
+            raise ValueError("size is not compatible with inputs")
+
+        imax = olambda.size
+        n = res_size / imax
+        if imax < n:
+            with lock, nogil:
+                for i from 0 <= i < imax:
+                    oa_data = <double *>PyArray_MultiIter_DATA(multi, 1)
+                    func2(state, n, array_data + n*i, oa_data[0])
+                    PyArray_MultiIter_NEXTi(multi, 1)
+            array.shape = (olambda.shape + array.shape)[:array.ndim]
+            array = array.transpose(tuple(range(olambda.ndim, array.ndim)) + tuple(range(0, olambda.ndim)))
+        else:
+            oa_data = <double *>PyArray_DATA(olambda);
+            with lock, nogil:
+                for i from 0 <= i < n:
+                    func1(state, imax, array_data + imax*i, oa_data)
+
+    return array
+
+
+cdef double kahan_sum(double *darr, npy_intp n) nogil:
+    cdef double c, y, t, sum
+    cdef npy_intp i
+    sum = darr[0]
+    c = 0.0
+    for i from 1 <= i < n:
+        y = darr[i] - c
+        t = sum + y
+        c = (t-sum) - y
+        sum = t
+    return sum
+
+# computes dim*(dim + 1)/2  -- number of elements in lower-triangular part of a square matrix of shape (dim, dim)
+cdef inline int packed_cholesky_size(int dim):
+    cdef int dh, lsb
+
+    dh = (dim >> 1)
+    lsb = (dim & 1)
+    return (lsb + dh) * (dim + (1 - lsb))
+
+def _shape_from_size(size, d):
+    if size is None:
+        shape = (d,)
+    else:
+        try:
+           shape = (operator.index(size), d)
+        except TypeError:
+           shape = tuple(size) + (d,)
+    return shape
+
+# sampling methods enum
+ICDF = 0
+BOXMULLER = 1
+BOXMULLER2 = 2
+POISNORM = 3
+PTPE = 4
+
+_method_alias_dict_gaussian = {'ICDF': ICDF, 'Inversion': ICDF,
+                      'BoxMuller': BOXMULLER, 'Box-Muller': BOXMULLER,
+                      'BoxMuller2': BOXMULLER2, 'Box-Muller2': BOXMULLER2}
+
+_method_alias_dict_gaussian_short = {'ICDF': ICDF, 'Inversion': ICDF,
+                            'BoxMuller': BOXMULLER, 'Box-Muller': BOXMULLER}
+
+_method_alias_dict_poisson = {'PTPE' : PTPE, 'Poisson-Normal': POISNORM, 'POISNORM' : POISNORM}
+
+def choose_method(method, mlist, alias_dict = None):
+    if (method not in mlist):
+        if (alias_dict is None) or (not isinstance(alias_dict, dict)):
+            # issue warning
+            return mlist[0]
+        else:
+            if method not in alias_dict.keys():
+                return mlist[0]
+            else:
+                return alias_dict[method]
+    else:
+        return method
+
+_brng_dict = {
+    'MT19937' : MT19937,
+    'SFMT19937' : SFMT19937,
+    'WH' : WH,
+    'MT2203': MT2203,
+    'MCG31' : MCG31,
+    'R250' : R250,
+    'MRG32K3A' : MRG32K3A,
+    'MCG59' : MCG59,
+    'PHILOX4X32X10' : PHILOX4X32X10
+}
+
+_brng_dict_stream_max = {
+    MT19937: 1,
+    SFMT19937: 1,
+    WH: 273,
+    MT2203: 6024,
+    MCG31: 1,
+    R250: 1,
+    MRG32K3A: 1,
+    MCG59: 1,
+    PHILOX4X32X10: 1
+}
+
+def _default_fallback_brng_token_(brng):
+    cdef vrk_brng_t brng_token
+    warnings.warn(("The basic random generator specification {given} is not recognized. "
+                   "\"MT19937\" will be used instead").format(given=brng),
+                  UserWarning)
+    brng_token = MT19937
+    return brng_token
+
+def _parse_brng_token_(brng):
+    cdef vrk_brng_t brng_token
+
+    if isinstance(brng, str):
+        tmp = _brng_dict.get(brng.upper(), None)
+        if tmp is None:
+            brng_token = _default_fallback_brng_token_(brng)
+        else:
+            brng_token = tmp
+    elif isinstance(brng, int):
+        brng_token = operator.index(brng)
+    else:
+        brng_token = _default_fallback_brng_token_(brng)
+
+    return brng_token
+
+def _parse_brng_argument(brng):
+    cdef vrk_brng_t brng_token
+    cdef unsigned int stream_id = 0
+
+    if isinstance(brng, (list, tuple)) and len(brng) == 2:
+        bt, s = brng;
+        brng_token = _parse_brng_token_(bt)
+        smax = _brng_dict_stream_max[brng_token]
+        if isinstance(s, int):
+            s = s % smax
+            if (s != brng[1]):
+                warnings.warn(("The generator index {actual} is not between 0 and {max}, "
+                        "index {choice} will be used.").format(actual=brng[-1], max=smax-1, choice=s),
+                        UserWarning)
+            stream_id = s
+    else:
+        brng_token = _parse_brng_token_(brng)
+
+    return (brng_token, stream_id)
+
+def _brng_id_to_name(int brng_id):
+    cdef object nm
+    cdef object brng_name = None
+    for nm in _brng_dict:
+        if _brng_dict[nm] == brng_id:
+            brng_name = nm
+
+    return brng_name
+
+
+cdef class RandomState:
+    """
+    RandomState(seed=None, brng='MT19937')
+
+    Container for the Mersenne Twister pseudo-random number generator.
+
+    `RandomState` exposes a number of methods for generating random numbers
+    drawn from a variety of probability distributions. In addition to the
+    distribution-specific arguments, each method takes a keyword argument
+    `size` that defaults to ``None``. If `size` is ``None``, then a single
+    value is generated and returned. If `size` is an integer, then a 1-D
+    array filled with generated values is returned. If `size` is a tuple,
+    then an array with that shape is filled and returned.
+
+    *Compatibility Notice*
+    This version of numpy.random has been rewritten to use MKL's vector
+    statistics functionality, that provides efficient implementation of
+    the MT19937 and many other basic psuedo-random number generation
+    algorithms as well as efficient sampling from other common statistical
+    distributions. As a consequence this version is NOT seed-compatible with
+    the original numpy.random.
+
+    Parameters
+    ----------
+    seed : {None, int, array_like}, optional
+        Random seed initializing the pseudo-random number generator.
+        Can be an integer, an array (or other sequence) of integers of
+        any length, or ``None`` (the default).
+        If `seed` is ``None``, then `RandomState` will try to read data from
+        ``/dev/urandom`` (or the Windows analogue) if available or seed from
+        the clock otherwise.
+    brng : {'MT19937', 'SFMT19937', 'MT2203', 'R250',
+            'WH', 'MCG31', 'MCG59', 'MRG32K3A', 'PHILOX4X32X10'}, optional
+        Basic pseudo-random number generation algorithms, provided by
+        Intel MKL. The default choice is 'MT19937' - the Mersenne Twister.
+
+    Notes
+    -----
+    The Python stdlib module "random" also contains a Mersenne Twister
+    pseudo-random number generator with a number of methods that are similar
+    to the ones available in `RandomState`. `RandomState`, besides being
+    NumPy-aware, has the advantage that it provides a much larger number
+    of probability distributions to choose from.
+
+    References
+    -----
+    MKL Documentation: https://software.intel.com/en-us/intel-mkl/documentation
+
+    """
+    cdef vrk_state *internal_state
+    cdef object lock
+    poisson_lam_max = np.iinfo('l').max - np.sqrt(np.iinfo('l').max)*10
+
+    def __init__(self, seed=None, brng='MT19937'):
+        self.internal_state = <vrk_state*>PyMem_Malloc(sizeof(vrk_state))
+        memset(self.internal_state, 0, sizeof(vrk_state))
+
+        self.lock = Lock()
+        self.seed(seed, brng)
+
+    def __dealloc__(self):
+        if self.internal_state != NULL:
+            vrk_dealloc_stream(self.internal_state)
+            PyMem_Free(self.internal_state)
+            self.internal_state = NULL
+
+    def seed(self, seed=None, brng='MT19937'):
+        """
+        seed(seed=None, brng='MT19937')
+
+        Seed the generator.
+
+        This method is called when `RandomState` is initialized. It can be
+        called again to re-seed the generator. For details, see `RandomState`.
+
+        Parameters
+        ----------
+        seed : int or array_like, optional
+            Seed for `RandomState`.
+            Must be convertible to 32 bit unsigned integers.
+        brng : {'MT19937', 'SFMT19937', 'MT2203', 'R250',
+                'WH', 'MCG31', 'MCG59', 'MRG32K3A', 'PHILOX4X32X10'}, optional
+            Basic pseudo-random number generation algorithms, provided by
+            Intel MKL. The default choice is 'MT19937' - the Mersenne Twister.
+
+        See Also
+        --------
+        RandomState
+
+        References
+        --------
+        MKL Documentation: https://software.intel.com/en-us/intel-mkl/documentation
+
+        """
+        cdef vrk_error errcode
+        cdef vrk_brng_t brng_token = MT19937
+        cdef unsigned int stream_id
+        cdef ndarray obj "arrayObject_obj"
+
+        brng_token, stream_id = _parse_brng_argument(brng);
+        try:
+            if seed is None:
+                with self.lock:
+                    errcode = vrk_randomseed_mkl(self.internal_state, brng_token, stream_id)
+            else:
+                idx = operator.index(seed)
+                if idx > int(2**32 - 1) or idx < 0:
+                    raise ValueError("Seed must be between 0 and 4294967295")
+                with self.lock:
+                    vrk_seed_mkl(self.internal_state, idx, brng_token, stream_id)
+        except TypeError:
+            obj = np.asarray(seed)
+            if not obj.dtype is dtype('uint64'):
+                obj = obj.astype(np.int64, casting='safe')
+            if ((obj > int(2**32 - 1)) | (obj < 0)).any():
+                raise ValueError("Seed must be between 0 and 4294967295")
+            obj = obj.astype('uint32', casting='unsafe')
+            with self.lock:
+                vrk_seed_mkl_array(self.internal_state, <unsigned int *>PyArray_DATA(obj),
+                                          PyArray_DIM(obj, 0), brng_token, stream_id)
+
+    def get_state(self):
+        """
+        get_state()
+
+        Return a tuple representing the internal state of the generator.
+
+        For more details, see `set_state`.
+
+        Returns
+        -------
+        out : tuple(str, bytes)
+            The returned tuple has the following items:
+
+            1. the string, defaulting to 'MT19937', specifying the
+               basic psedo-random number generation algorithm.
+            2. a bytes object holding content of Intel MKL's stream for the
+               given BRNG.
+
+        See Also
+        --------
+        set_state
+
+        Notes
+        -----
+        `set_state` and `get_state` are not needed to work with any of the
+        random distributions in NumPy. If the internal state is manually altered,
+        the user should know exactly what he/she is doing.
+
+        References
+        -----
+        MKL Documentation: https://software.intel.com/en-us/intel-mkl/documentation
+
+        """
+        cdef int state_buffer_size
+        cdef int brng_id
+        cdef void *bytesPtr
+
+        with self.lock:
+            state_buffer_size = vrk_get_stream_size(self.internal_state)
+        bytestring = empty_py_bytes(state_buffer_size, &bytesPtr)
+        with self.lock:
+            brng_id = vrk_get_brng_mkl(self.internal_state)
+            vrk_get_state_mkl(self.internal_state, <char *>bytesPtr)
+
+        brng_name = _brng_id_to_name(brng_id)
+        return (brng_name, bytestring)
+
+    def set_state(self, state):
+        """
+        set_state(state)
+
+        Set the internal state of the generator from a tuple.
+
+        For use if one has reason to manually (re-)set the internal state of the
+        chosen pseudo-random number generating algorithm.
+
+        Parameters
+        ----------
+        state : tuple(str, bytes)
+            The `state` tuple has the following items:
+
+            1. the string, defaulting to 'MT19937', specifying the
+               basic psedo-random number generation algorithm.
+            2. a bytes object holding content of Intel MKL's stream for the
+               given BRNG.
+
+        Returns
+        -------
+        out : None
+            Returns 'None' on success.
+
+        See Also
+        --------
+        get_state
+
+        Notes
+        -----
+        `set_state` and `get_state` are not needed to work with any of the
+        random distributions in NumPy. If the internal state is manually altered,
+        the user should know exactly what he/she is doing.
+
+        For backwards compatibility, the form (str, array of 624 uints, int) is
+        also accepted although in such a case keys are used to seed the generator,
+        and position index pos is ignored: ``state = ('MT19937', keys, pos)``.
+
+        References
+        ----------
+        MKL Documentation: https://software.intel.com/en-us/intel-mkl/documentation
+
+        """
+        cdef char *bytes_ptr
+        cdef int brng_id
+        cdef ndarray obj "arrayObject_obj"
+
+        state_len = len(state)
+        if(state_len != 2):
+            if (state_len == 3 or state_len == 5):
+                algo_name, key, pos = state[:3]
+                if algo_name != 'MT19937':
+                    raise ValueError("The legacy state input algorithm must be 'MT19937'")
+                try:
+                    obj = <ndarray> PyArray_ContiguousFromObject(key, NPY_ULONG, 1, 1)
+                except TypeError:
+                    # compatibility -- could be an older pickle
+                    obj = <ndarray> PyArray_ContiguousFromObject(key, NPY_LONG, 1, 1)
+                self.seed(obj, brng = algo_name)
+                return
+            raise ValueError("The argument to set_state must be a list of 2 elements")
+
+        algorithm_name = state[0]
+        if algorithm_name not in _brng_dict.keys():
+            raise ValueError("basic number generator algorithm must be one of ['" + "',".join(_brng_dict.keys()) + "']")
+
+        stream_buf = state[1]
+        if not is_bytes_object(stream_buf):
+            raise ValueError('state is expected to be bytes')
+
+        bytes_ptr = py_bytes_DataPtr(stream_buf)
+
+        with self.lock:
+            err = vrk_set_state_mkl(self.internal_state, bytes_ptr)
+            if(err):
+                raise ValueError('The stream state buffer is corrupted')
+            brng_id = vrk_get_brng_mkl(self.internal_state)
+            if (_brng_dict[algorithm_name] is not brng_id):
+                raise ValueError('The algorithm name does not match content of the buffer')
+
+    # Pickling support:
+    def __getstate__(self):
+        return self.get_state()
+
+    def __setstate__(self, state):
+        self.set_state(state)
+
+    def __reduce__(self):
+        return (np.random_intel.__RandomState_ctor, (), self.get_state())
+
+    def leapfrog(self, int k, int nstreams):
+        """
+        leapfrog(k, nstreams)
+
+        Initializes the current state generator using leap-frog method,
+        if supported for the basic random pseudo-random number generation
+        algorithm.
+        """
+        cdef int err, brng_id
+
+        err = vrk_leapfrog_stream_mkl(self.internal_state, k, nstreams);
+
+        if err == -1:
+            raise ValueError('The stream state buffer is corrupted')
+        elif err == 1:
+            with self.lock:
+                brng_id = vrk_get_brng_mkl(self.internal_state)
+            raise ValueError("Leap-frog method of stream initialization is not supported for " + str(_brng_id_to_name(brng_id)))
+
+    def skipahead(self, long long int nskips):
+        """
+        skipahead(nskips)
+
+        Initializes the current state generator using skip-ahead method,
+        if supported for the basic random pseudo-random number generation
+        algorithm.
+        """
+        cdef int err, brng_id
+
+        err = vrk_skipahead_stream_mkl(self.internal_state, nskips);
+
+        if err == -1:
+            raise ValueError('The stream state buffer is corrupted')
+        elif err == 1:
+            with self.lock:
+                brng_id = vrk_get_brng_mkl(self.internal_state)
+            raise ValueError("Skip-ahead method of stream initialization is not supported for " + str(_brng_id_to_name(brng_id)))
+
+    # Basic distributions:
+    def random_sample(self, size=None):
+        """
+        random_sample(size=None)
+
+        Return random floats in the half-open interval [0.0, 1.0).
+
+        Results are from the "continuous uniform" distribution over the
+        stated interval.  To sample :math:`Unif[a, b), b > a` multiply
+        the output of `random_sample` by `(b-a)` and add `a`::
+
+          (b - a) * random_sample() + a
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : float or ndarray of floats
+            Array of random floats of shape `size` (unless ``size=None``, in which
+            case a single float is returned).
+
+        Examples
+        --------
+        >>> np.random.random_sample()
+        0.47108547995356098
+        >>> type(np.random.random_sample())
+        <type 'float'>
+        >>> np.random.random_sample((5,))
+        array([ 0.30220482,  0.86820401,  0.1654503 ,  0.11659149,  0.54323428])
+
+        Three-by-two array of random numbers from [-5, 0):
+
+        >>> 5 * np.random.random_sample((3, 2)) - 5
+        array([[-3.99149989, -0.52338984],
+               [-2.99091858, -0.79479508],
+               [-1.23204345, -1.75224494]])
+
+        """
+        return vec_cont0_array(self.internal_state, vrk_double_vec, size, self.lock)
+
+    def tomaxint(self, size=None):
+        """
+        tomaxint(size=None)
+
+        Random integers between 0 and ``sys.maxint``, inclusive.
+
+        Return a sample of uniformly distributed random integers in the interval
+        [0, ``sys.maxint``].
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : ndarray
+            Drawn samples, with shape `size`.
+
+        See Also
+        --------
+        randint : Uniform sampling over a given half-open interval of integers.
+        random_integers : Uniform sampling over a given closed interval of
+            integers.
+
+        Examples
+        --------
+        >>> RS = np.random.RandomState() # need a RandomState object
+        >>> RS.tomaxint((2,2,2))
+        array([[[1170048599, 1600360186],
+                [ 739731006, 1947757578]],
+               [[1871712945,  752307660],
+                [1601631370, 1479324245]]])
+        >>> import sys
+        >>> sys.maxint
+        2147483647
+        >>> RS.tomaxint((2,2,2)) < sys.maxint
+        array([[[ True,  True],
+                [ True,  True]],
+               [[ True,  True],
+                [ True,  True]]], dtype=bool)
+
+        """
+        return vec_long_disc0_array(self.internal_state, vrk_long_vec, size, self.lock)
+
+    # Set up dictionary of integer types and relevant functions.
+    #
+    # The dictionary is keyed by dtype(...).name and the values
+    # are a tuple (low, high, function), where low and high are
+    # the bounds of the largest half open interval `[low, high)`
+    # and the function is the relevant function to call for
+    # that precision.
+    #
+    # The functions are all the same except for changed types in
+    # a few places. It would be easy to template them.
+
+    def _choose_randint_type(self, dtype):
+        _randint_type = {
+            'bool': (0, 2, self._rand_bool),
+            'int8': (-2**7, 2**7, self._rand_int8),
+            'int16': (-2**15, 2**15, self._rand_int16),
+            'int32': (-2**31, 2**31, self._rand_int32),
+            'int64': (-2**63, 2**63, self._rand_int64),
+            'uint8': (0, 2**8, self._rand_uint8),
+            'uint16': (0, 2**16, self._rand_uint16),
+            'uint32': (0, 2**32, self._rand_uint32),
+            'uint64': (0, 2**64, self._rand_uint64)
+        }
+
+        key = np.dtype(dtype).name
+        if not key in _randint_type:
+            raise TypeError('Unsupported dtype "%s" for randint' % key)
+        return _randint_type[key]
+
+    # generates typed random integer in [low, high]
+    def _rand_bool(self, npy_bool low, npy_bool high, size):
+        """
+        _rand_bool(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_bool buf
+        cdef npy_bool *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_bool_vec(self.internal_state, 1, &buf, low, high)
+            return np.bool_(buf)
+        else:
+            array = <ndarray>np.empty(size, np.bool_)
+            cnt = PyArray_SIZE(array)
+            out = <npy_bool *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_bool_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_int8(self, npy_int8 low, npy_int8 high, size):
+        """
+        _rand_int8(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_int8 buf
+        cdef npy_int8 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_int8_vec(self.internal_state, 1, &buf, low, high)
+            return np.int8(<npy_int8>buf)
+        else:
+            array = <ndarray>np.empty(size, np.int8)
+            cnt = PyArray_SIZE(array)
+            out = <npy_int8 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_int8_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_int16(self, npy_int16 low, npy_int16 high, size):
+        """
+        _rand_int16(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_int16 buf
+        cdef npy_int16 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_int16_vec(self.internal_state, 1, &buf, low, high)
+            return np.int16(<npy_int16>buf)
+        else:
+            array = <ndarray>np.empty(size, np.int16)
+            cnt = PyArray_SIZE(array)
+            out = <npy_int16 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_int16_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_int32(self, npy_int32 low, npy_int32 high, size):
+        """
+        _rand_int32(self, low, high, size)
+
+        Return random np.int32 integers between `low` and `high`, inclusive.
+
+        Return random integers from the "discrete uniform" distribution in the
+        closed interval [`low`, `high`]. On entry the arguments are presumed
+        to have been validated for size and order for the np.int32 type.
+
+        Parameters
+        ----------
+        low : int
+            Lowest (signed) integer to be drawn from the distribution.
+        high : int
+            Highest (signed) integer to be drawn from the distribution.
+        size : int or tuple of ints
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : python scalar or ndarray of np.int32
+              `size`-shaped array of random integers from the appropriate
+              distribution, or a single such random int if `size` not provided.
+
+        """
+        cdef npy_int32 buf
+        cdef npy_int32 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_int32_vec(self.internal_state, 1, &buf, low, high)
+            return np.int32(buf)
+        else:
+            array = <ndarray>np.empty(size, np.int32)
+            cnt = PyArray_SIZE(array)
+            out = <npy_int32 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_int32_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_int64(self, npy_int64 low, npy_int64 high, size):
+        """
+        _rand_int64(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_int64 buf
+        cdef npy_int64 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_int64_vec(self.internal_state, 1, &buf, low, high)
+            return np.int64(buf)
+        else:
+            array = <ndarray>np.empty(size, np.int64)
+            cnt = PyArray_SIZE(array)
+            out = <npy_int64 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_int64_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+    def _rand_uint8(self, npy_uint8 low, npy_uint8 high, size):
+        """
+        _rand_uint8(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_uint8 buf
+        cdef npy_uint8 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_uint8_vec(self.internal_state, 1, &buf, low, high)
+            return np.uint8(buf)
+        else:
+            array = <ndarray>np.empty(size, np.uint8)
+            cnt = PyArray_SIZE(array)
+            out = <npy_uint8 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_uint8_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_uint16(self, npy_uint16 low, npy_uint16 high, size):
+        """
+        _rand_uint16(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_uint16 off, rng, buf
+        cdef npy_uint16 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_uint16_vec(self.internal_state, 1, &buf, low, high)
+            return np.uint16(buf)
+        else:
+            array = <ndarray>np.empty(size, np.uint16)
+            cnt = PyArray_SIZE(array)
+            out = <npy_uint16 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_uint16_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_uint32(self, npy_uint32 low, npy_uint32 high, size):
+        """
+        _rand_uint32(self, low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_uint32 buf
+        cdef npy_uint32 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_uint32_vec(self.internal_state, 1, &buf, low, high)
+            return np.uint32(buf)
+        else:
+            array = <ndarray>np.empty(size, np.uint32)
+            cnt = PyArray_SIZE(array)
+            out = <npy_uint32 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_uint32_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def _rand_uint64(self, npy_uint64 low, npy_uint64 high, size):
+        """
+        _rand_uint64(low, high, size)
+
+        See `_rand_int32` for documentation, only the return type changes.
+
+        """
+        cdef npy_uint64 buf
+        cdef npy_uint64 *out
+        cdef ndarray array "arrayObject"
+        cdef npy_intp cnt
+
+        if size is None:
+            vrk_rand_uint64_vec(self.internal_state, 1, &buf, low, high)
+            return np.uint64(buf)
+        else:
+            array = <ndarray>np.empty(size, np.uint64)
+            cnt = PyArray_SIZE(array)
+            out = <npy_uint64 *>PyArray_DATA(array)
+            with nogil:
+                vrk_rand_uint64_vec(self.internal_state, cnt, out, low, high)
+            return array
+
+
+    def randint(self, low, high=None, size=None, dtype=int):
+        """
+        randint(low, high=None, size=None, dtype=int)
+
+        Return random integers from `low` (inclusive) to `high` (exclusive).
+
+        Return random integers from the "discrete uniform" distribution of
+        the specified dtype in the "half-open" interval [`low`, `high`). If
+        `high` is None (the default), then results are from [0, `low`).
+
+        Parameters
+        ----------
+        low : int
+            Lowest (signed) integer to be drawn from the distribution (unless
+            ``high=None``, in which case this parameter is the *highest* such
+            integer).
+        high : int, optional
+            If provided, one above the largest (signed) integer to be drawn
+            from the distribution (see above for behavior if ``high=None``).
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        dtype : dtype, optional
+            Desired dtype of the result. All dtypes are determined by their
+            name, i.e., 'int64', 'int', etc, so byteorder is not available
+            and a specific precision may have different C types depending
+            on the platform. The default value is 'np.int'.
+
+            .. versionadded:: 1.11.0
+
+        Returns
+        -------
+        out : int or ndarray of ints
+            `size`-shaped array of random integers from the appropriate
+            distribution, or a single such random int if `size` not provided.
+
+        See Also
+        --------
+        random.random_integers : similar to `randint`, only for the closed
+            interval [`low`, `high`], and 1 is the lowest value if `high` is
+            omitted. In particular, this other one is the one to use to generate
+            uniformly distributed discrete non-integers.
+
+        Examples
+        --------
+        >>> np.random.randint(2, size=10)
+        array([1, 0, 0, 0, 1, 1, 0, 0, 1, 0])
+        >>> np.random.randint(1, size=10)
+        array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+        Generate a 2 x 4 array of ints between 0 and 4, inclusive:
+
+        >>> np.random.randint(5, size=(2, 4))
+        array([[4, 0, 2, 1],
+               [3, 2, 2, 0]])
+
+        """
+        if high is None:
+            high = low
+            low = 0
+
+        lowbnd, highbnd, randfunc = self._choose_randint_type(dtype)
+
+        if low < lowbnd:
+            raise ValueError("low is out of bounds for %s" % (np.dtype(dtype).name,))
+        if high > highbnd:
+            raise ValueError("high is out of bounds for %s" % (np.dtype(dtype).name,))
+        if low >= high:
+            raise ValueError("low >= high")
+
+        with self.lock:
+            ret = randfunc(low, high - 1, size)
+
+            if size is None:
+                if dtype in (np.bool, np.int, np.long):
+                    return dtype(ret)
+
+            return ret
+
+
+    def randint_untyped(self, low, high=None, size=None):
+        """
+        randint_untyped(low, high=None, size=None, dtype=int)
+
+        Return random integers from `low` (inclusive) to `high` (exclusive).
+
+        Return random integers from the "discrete uniform" distribution of
+        the specified dtype in the "half-open" interval [`low`, `high`). If
+        `high` is None (the default), then results are from [0, `low`).
+
+        Parameters
+        ----------
+        low : int
+            Lowest (signed) integer to be drawn from the distribution (unless
+            ``high=None``, in which case this parameter is the *highest* such
+            integer).
+        high : int, optional
+            If provided, one above the largest (signed) integer to be drawn
+            from the distribution (see above for behavior if ``high=None``).
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : int or ndarray of ints
+            `size`-shaped array of random integers from the appropriate
+            distribution, or a single such random int if `size` not provided.
+
+        See Also
+        --------
+        random.random_integers : similar to `randint`, only for the closed
+            interval [`low`, `high`], and 1 is the lowest value if `high` is
+            omitted. In particular, this other one is the one to use to generate
+            uniformly distributed discrete non-integers.
+
+        Examples
+        --------
+        >>> np.random.randint(2, size=10)
+        array([1, 0, 0, 0, 1, 1, 0, 0, 1, 0])
+        >>> np.random.randint(1, size=10)
+        array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+        Generate a 2 x 4 array of ints between 0 and 4, inclusive:
+
+        >>> np.random.randint(5, size=(2, 4))
+        array([[4, 0, 2, 1],
+               [3, 2, 2, 0]])
+
+        """
+        cdef long lo, hi
+        cdef long *array_long_data
+        cdef int * array_int_data
+        cdef ndarray array "arrayObject"
+        cdef npy_intp length
+        cdef int rv_int
+        cdef long rv_long
+
+        if high is None:
+            lo = 0
+            hi = low
+        else:
+            lo = low
+            hi = high
+
+        if lo >= hi :
+            raise ValueError("low >= high")
+
+        if ((<int> lo) == lo) and ((<int>hi) == hi):
+            if size is None:
+                vrk_discrete_uniform_vec(self.internal_state, 1, &rv_int, <int>lo, <int>hi)
+                return rv_int
+            else:
+                array = <ndarray>np.empty(size, np.int32)
+                length = PyArray_SIZE(array)
+                array_int_data = <int*>PyArray_DATA(array)
+                with self.lock, nogil:
+                    vrk_discrete_uniform_vec(self.internal_state, length, array_int_data, <int>lo, <int>hi)
+                return array
+        else:
+            if size is None:
+                vrk_discrete_uniform_long_vec(self.internal_state, 1, &rv_long, lo, hi)
+                return rv_long
+            else:
+                array = <ndarray>np.empty(size, int)
+                length = PyArray_SIZE(array)
+                array_long_data = <long*>PyArray_DATA(array)
+                with self.lock, nogil:
+                    vrk_discrete_uniform_long_vec(self.internal_state, length, array_long_data, lo, hi)
+                return array
+
+    def bytes(self, npy_intp length):
+        """
+        bytes(length)
+
+        Return random bytes.
+
+        Parameters
+        ----------
+        length : int
+            Number of random bytes.
+
+        Returns
+        -------
+        out : str
+            String of length `length`.
+
+        Examples
+        --------
+        >>> np.random.bytes(10)
+        ' eh\\x85\\x022SZ\\xbf\\xa4' #random
+
+        """
+        cdef void *bytes
+        bytestring = empty_py_bytes(length, &bytes)
+        with self.lock, nogil:
+            vrk_fill(bytes, length, self.internal_state)
+        return bytestring
+
+
+    def choice(self, a, size=None, replace=True, p=None):
+        """
+        choice(a, size=None, replace=True, p=None)
+
+        Generates a random sample from a given 1-D array
+
+                .. versionadded:: 1.7.0
+
+        Parameters
+        -----------
+        a : 1-D array-like or int
+            If an ndarray, a random sample is generated from its elements.
+            If an int, the random sample is generated as if a was np.arange(n)
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        replace : boolean, optional
+            Whether the sample is with or without replacement
+        p : 1-D array-like, optional
+            The probabilities associated with each entry in a.
+            If not given the sample assumes a uniform distribution over all
+            entries in a.
+
+        Returns
+        --------
+        samples : 1-D ndarray, shape (size,)
+            The generated random samples
+
+        Raises
+        -------
+        ValueError
+            If a is an int and less than zero, if a or p are not 1-dimensional,
+            if a is an array-like of size 0, if p is not a vector of
+            probabilities, if a and p have different lengths, or if
+            replace=False and the sample size is greater than the population
+            size
+
+        See Also
+        ---------
+        randint, shuffle, permutation
+
+        Examples
+        ---------
+        Generate a uniform random sample from np.arange(5) of size 3:
+
+        >>> np.random.choice(5, 3)
+        array([0, 3, 4])
+        >>> #This is equivalent to np.random.randint(0,5,3)
+
+        Generate a non-uniform random sample from np.arange(5) of size 3:
+
+        >>> np.random.choice(5, 3, p=[0.1, 0, 0.3, 0.6, 0])
+        array([3, 3, 0])
+
+        Generate a uniform random sample from np.arange(5) of size 3 without
+        replacement:
+
+        >>> np.random.choice(5, 3, replace=False)
+        array([3,1,0])
+        >>> #This is equivalent to np.random.permutation(np.arange(5))[:3]
+
+        Generate a non-uniform random sample from np.arange(5) of size
+        3 without replacement:
+
+        >>> np.random.choice(5, 3, replace=False, p=[0.1, 0, 0.3, 0.6, 0])
+        array([2, 3, 0])
+
+        Any of the above can be repeated with an arbitrary array-like
+        instead of just integers. For instance:
+
+        >>> aa_milne_arr = ['pooh', 'rabbit', 'piglet', 'Christopher']
+        >>> np.random.choice(aa_milne_arr, 5, p=[0.5, 0.1, 0.1, 0.3])
+        array(['pooh', 'pooh', 'pooh', 'Christopher', 'piglet'],
+              dtype='|S11')
+
+        """
+
+        # Format and Verify input
+        a = np.array(a, copy=False)
+        if a.ndim == 0:
+            try:
+                # __index__ must return an integer by python rules.
+                pop_size = operator.index(a.item())
+            except TypeError:
+                raise ValueError("a must be 1-dimensional or an integer")
+            if pop_size <= 0:
+                raise ValueError("a must be greater than 0")
+        elif a.ndim != 1:
+            raise ValueError("a must be 1-dimensional")
+        else:
+            pop_size = a.shape[0]
+            if pop_size is 0:
+                raise ValueError("a must be non-empty")
+
+        if p is not None:
+            d = len(p)
+
+            atol = np.sqrt(np.finfo(np.float64).eps)
+            if isinstance(p, np.ndarray):
+                if np.issubdtype(p.dtype, np.floating):
+                    atol = max(atol, np.sqrt(np.finfo(p.dtype).eps))
+
+            p = <ndarray>PyArray_ContiguousFromObject(p, NPY_DOUBLE, 1, 1)
+            pix = <double*>PyArray_DATA(p)
+
+            if p.ndim != 1:
+                raise ValueError("p must be 1-dimensional")
+            if p.size != pop_size:
+                raise ValueError("a and p must have same size")
+            if np.logical_or.reduce(p < 0):
+                raise ValueError("probabilities are not non-negative")
+            if abs(kahan_sum(pix, d) - 1.) > atol:
+                raise ValueError("probabilities do not sum to 1")
+
+        shape = size
+        if shape is not None:
+            size = np.prod(shape, dtype=np.intp)
+        else:
+            size = 1
+
+        # Actual sampling
+        if replace:
+            if p is not None:
+                cdf = p.cumsum()
+                cdf /= cdf[-1]
+                uniform_samples = self.random_sample(shape)
+                idx = cdf.searchsorted(uniform_samples, side='right')
+                idx = np.array(idx, copy=False) # searchsorted returns a scalar
+            else:
+                idx = self.randint(0, pop_size, size=shape)
+        else:
+            if size > pop_size:
+                raise ValueError("Cannot take a larger sample than "
+                                 "population when 'replace=False'")
+
+            if p is not None:
+                if np.count_nonzero(p > 0) < size:
+                    raise ValueError("Fewer non-zero entries in p than size")
+                n_uniq = 0
+                p = p.copy()
+                found = np.zeros(shape, dtype=np.int)
+                flat_found = found.ravel()
+                while n_uniq < size:
+                    x = self.rand(size - n_uniq)
+                    if n_uniq > 0:
+                        p[flat_found[0:n_uniq]] = 0
+                    cdf = np.cumsum(p)
+                    cdf /= cdf[-1]
+                    new = cdf.searchsorted(x, side='right')
+                    _, unique_indices = np.unique(new, return_index=True)
+                    unique_indices.sort()
+                    new = new.take(unique_indices)
+                    flat_found[n_uniq:n_uniq + new.size] = new
+                    n_uniq += new.size
+                idx = found
+            else:
+                idx = self.permutation(pop_size)[:size]
+                if shape is not None:
+                    idx.shape = shape
+
+        if shape is None and isinstance(idx, np.ndarray):
+            # In most cases a scalar will have been made an array
+            idx = idx.item(0)
+
+        #Use samples as indices for a if a is array-like
+        if a.ndim == 0:
+            return idx
+
+        if shape is not None and idx.ndim == 0:
+            # If size == () then the user requested a 0-d array as opposed to
+            # a scalar object when size is None. However a[idx] is always a
+            # scalar and not an array. So this makes sure the result is an
+            # array, taking into account that np.array(item) may not work
+            # for object arrays.
+            res = np.empty((), dtype=a.dtype)
+            res[()] = a[idx]
+            return res
+
+        return a[idx]
+
+
+    def uniform(self, low=0.0, high=1.0, size=None):
+        """
+        uniform(low=0.0, high=1.0, size=None)
+
+        Draw samples from a uniform distribution.
+
+        Samples are uniformly distributed over the half-open interval
+        ``[low, high)`` (includes low, but excludes high).  In other words,
+        any value within the given interval is equally likely to be drawn
+        by `uniform`.
+
+        Parameters
+        ----------
+        low : float, optional
+            Lower boundary of the output interval.  All values generated will be
+            greater than or equal to low.  The default value is 0.
+        high : float
+            Upper boundary of the output interval.  All values generated will be
+            less than high.  The default value is 1.0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : ndarray
+            Drawn samples, with shape `size`.
+
+        See Also
+        --------
+        randint : Discrete uniform distribution, yielding integers.
+        random_integers : Discrete uniform distribution over the closed
+                          interval ``[low, high]``.
+        random_sample : Floats uniformly distributed over ``[0, 1)``.
+        random : Alias for `random_sample`.
+        rand : Convenience function that accepts dimensions as input, e.g.,
+               ``rand(2,2)`` would generate a 2-by-2 array of floats,
+               uniformly distributed over ``[0, 1)``.
+
+        Notes
+        -----
+        The probability density function of the uniform distribution is
+
+        .. math:: p(x) = \\frac{1}{b - a}
+
+        anywhere within the interval ``[a, b)``, and zero elsewhere.
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> s = np.random.uniform(-1,0,1000)
+
+        All values are within the given interval:
+
+        >>> np.all(s >= -1)
+        True
+        >>> np.all(s < 0)
+        True
+
+        Display the histogram of the samples, along with the
+        probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, 15, normed=True)
+        >>> plt.plot(bins, np.ones_like(bins), linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray olow, ohigh
+        cdef double flow, fhigh
+        cdef object temp
+
+        flow = PyFloat_AsDouble(low)
+        fhigh = PyFloat_AsDouble(high)
+        if not npy_isfinite(flow) or not npy_isfinite(fhigh):
+            raise OverflowError('Range exceeds valid bounds')
+        if flow >= fhigh:
+            raise ValueError("low >= high")
+
+        if not PyErr_Occurred():
+            return vec_cont2_array_sc(self.internal_state, vrk_uniform_vec, size, flow,
+                                  fhigh, self.lock)
+
+        PyErr_Clear()
+        olow = <ndarray>PyArray_FROM_OTF(low, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        ohigh = <ndarray>PyArray_FROM_OTF(high, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+
+        if not np.all(np.isfinite(olow)) or not np.all(np.isfinite(ohigh)):
+            raise OverflowError('Range exceeds valid bounds')
+
+        if np.any(olow >= ohigh):
+            raise ValueError("low >= high")
+
+        return vec_cont2_array(self.internal_state, vrk_uniform_vec, size, olow, ohigh,
+                           self.lock)
+
+    def rand(self, *args):
+        """
+        rand(d0, d1, ..., dn)
+
+        Random values in a given shape.
+
+        Create an array of the given shape and propagate it with
+        random samples from a uniform distribution
+        over ``[0, 1)``.
+
+        Parameters
+        ----------
+        d0, d1, ..., dn : int, optional
+            The dimensions of the returned array, should all be positive.
+            If no argument is given a single Python float is returned.
+
+        Returns
+        -------
+        out : ndarray, shape ``(d0, d1, ..., dn)``
+            Random values.
+
+        See Also
+        --------
+        random
+
+        Notes
+        -----
+        This is a convenience function. If you want an interface that
+        takes a shape-tuple as the first argument, refer to
+        np.random.random_sample .
+
+        Examples
+        --------
+        >>> np.random.rand(3,2)
+        array([[ 0.14022471,  0.96360618],  #random
+               [ 0.37601032,  0.25528411],  #random
+               [ 0.49313049,  0.94909878]]) #random
+
+        """
+        if len(args) == 0:
+            return self.random_sample()
+        else:
+            return self.random_sample(size=args)
+
+    def randn(self, *args):
+        """
+        randn(d0, d1, ..., dn)
+
+        Return a sample (or samples) from the "standard normal" distribution.
+
+        If positive, int_like or int-convertible arguments are provided,
+        `randn` generates an array of shape ``(d0, d1, ..., dn)``, filled
+        with random floats sampled from a univariate "normal" (Gaussian)
+        distribution of mean 0 and variance 1 (if any of the :math:`d_i` are
+        floats, they are first converted to integers by truncation). A single
+        float randomly sampled from the distribution is returned if no
+        argument is provided.
+
+        This is a convenience function.  If you want an interface that takes a
+        tuple as the first argument, use `numpy.random.standard_normal` instead.
+
+        Parameters
+        ----------
+        d0, d1, ..., dn : int, optional
+            The dimensions of the returned array, should be all positive.
+            If no argument is given a single Python float is returned.
+
+        Returns
+        -------
+        Z : ndarray or float
+            A ``(d0, d1, ..., dn)``-shaped array of floating-point samples from
+            the standard normal distribution, or a single such float if
+            no parameters were supplied.
+
+        See Also
+        --------
+        random.standard_normal : Similar, but takes a tuple as its argument.
+
+        Notes
+        -----
+        For random samples from :math:`N(\\mu, \\sigma^2)`, use:
+
+        ``sigma * np.random.randn(...) + mu``
+
+        Examples
+        --------
+        >>> np.random.randn()
+        2.1923875335537315 #random
+
+        Two-by-four array of samples from N(3, 6.25):
+
+        >>> 2.5 * np.random.randn(2, 4) + 3
+        array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],  #random
+               [ 0.39924804,  4.68456316,  4.99394529,  4.84057254]]) #random
+
+        """
+        if len(args) == 0:
+            return self.standard_normal()
+        else:
+            return self.standard_normal(args)
+
+
+    def random_integers(self, low, high=None, size=None):
+        """
+        random_integers(low, high=None, size=None)
+
+        Random integers of type np.int between `low` and `high`, inclusive.
+
+        Return random integers of type np.int from the "discrete uniform"
+        distribution in the closed interval [`low`, `high`].  If `high` is
+        None (the default), then results are from [1, `low`]. The np.int
+        type translates to the C long type used by Python 2 for "short"
+        integers and its precision is platform dependent.
+
+        This function has been deprecated. Use randint instead.
+
+        .. deprecated:: 1.11.0
+
+        Parameters
+        ----------
+        low : int
+            Lowest (signed) integer to be drawn from the distribution (unless
+            ``high=None``, in which case this parameter is the *highest* such
+            integer).
+        high : int, optional
+            If provided, the largest (signed) integer to be drawn from the
+            distribution (see above for behavior if ``high=None``).
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : int or ndarray of ints
+            `size`-shaped array of random integers from the appropriate
+            distribution, or a single such random int if `size` not provided.
+
+        See Also
+        --------
+        random.randint : Similar to `random_integers`, only for the half-open
+            interval [`low`, `high`), and 0 is the lowest value if `high` is
+            omitted.
+
+        Notes
+        -----
+        To sample from N evenly spaced floating-point numbers between a and b,
+        use::
+
+          a + (b - a) * (np.random.random_integers(N) - 1) / (N - 1.)
+
+        Examples
+        --------
+        >>> np.random.random_integers(5)
+        4
+        >>> type(np.random.random_integers(5))
+        <type 'int'>
+        >>> np.random.random_integers(5, size=(3.,2.))
+        array([[5, 4],
+               [3, 3],
+               [4, 5]])
+
+        Choose five random numbers from the set of five evenly-spaced
+        numbers between 0 and 2.5, inclusive (*i.e.*, from the set
+        :math:`{0, 5/8, 10/8, 15/8, 20/8}`):
+
+        >>> 2.5 * (np.random.random_integers(5, size=(5,)) - 1) / 4.
+        array([ 0.625,  1.25 ,  0.625,  0.625,  2.5  ])
+
+        Roll two six sided dice 1000 times and sum the results:
+
+        >>> d1 = np.random.random_integers(1, 6, 1000)
+        >>> d2 = np.random.random_integers(1, 6, 1000)
+        >>> dsums = d1 + d2
+
+        Display results as a histogram:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(dsums, 11, normed=True)
+        >>> plt.show()
+
+        """
+        if high is None:
+            warnings.warn(("This function is deprecated. Please call "
+                           "randint(1, {low} + 1) instead".format(low=low)),
+                          DeprecationWarning)
+            high = low
+            low = 1
+
+        else:
+            warnings.warn(("This function is deprecated. Please call "
+                           "randint({low}, {high} + 1) instead".format(
+                low=low, high=high)), DeprecationWarning)
+
+        return self.randint(low, high + 1, size=size, dtype='l')
+
+    # Complicated, continuous distributions:
+    def standard_normal(self, size=None, method=ICDF):
+        """
+        standard_normal(size=None, method='ICDF')
+
+        Draw samples from a standard Normal distribution (mean=0, stdev=1).
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        method : 'ICDF, 'BoxMuller', 'BoxMuller2', optional
+            Sampling method used by Intel MKL. Can also be specified using
+            tokens np.random.ICDF, np.random.BOXMULLER, np.random.BOXMULLER2
+
+        Returns
+        -------
+        out : float or ndarray
+            Drawn samples.
+
+        Examples
+        --------
+        >>> s = np.random.standard_normal(8000)
+        >>> s
+        array([ 0.6888893 ,  0.78096262, -0.89086505, ...,  0.49876311, #random
+               -0.38672696, -0.4685006 ])                               #random
+        >>> s.shape
+        (8000,)
+        >>> s = np.random.standard_normal(size=(3, 4, 2))
+        >>> s.shape
+        (3, 4, 2)
+
+        """
+        method = choose_method(method, [ICDF, BOXMULLER, BOXMULLER2], _method_alias_dict_gaussian)
+        if method is ICDF:
+            return vec_cont0_array(self.internal_state, vrk_standard_normal_vec_ICDF, size, self.lock)
+        elif method is BOXMULLER2:
+            return vec_cont0_array(self.internal_state, vrk_standard_normal_vec_BM2, size, self.lock)
+        else:
+            return vec_cont0_array(self.internal_state, vrk_standard_normal_vec_BM1, size, self.lock);
+
+    def normal(self, loc=0.0, scale=1.0, size=None, method=ICDF):
+        """
+        normal(loc=0.0, scale=1.0, size=None, method='ICDF')
+
+        Draw random samples from a normal (Gaussian) distribution.
+
+        The probability density function of the normal distribution, first
+        derived by De Moivre and 200 years later by both Gauss and Laplace
+        independently [2]_, is often called the bell curve because of
+        its characteristic shape (see the example below).
+
+        The normal distributions occurs often in nature.  For example, it
+        describes the commonly occurring distribution of samples influenced
+        by a large number of tiny, random disturbances, each with its own
+        unique distribution [2]_.
+
+        Parameters
+        ----------
+        loc : float
+            Mean ("centre") of the distribution.
+        scale : float
+            Standard deviation (spread or "width") of the distribution.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        method : 'ICDF, 'BoxMuller', 'BoxMuller2', optional
+            Sampling method used by Intel MKL. Can also be specified using
+            tokens np.random.ICDF, np.random.BOXMULLER, np.random.BOXMULLER2
+
+        See Also
+        --------
+        scipy.stats.distributions.norm : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Gaussian distribution is
+
+        .. math:: p(x) = \\frac{1}{\\sqrt{ 2 \\pi \\sigma^2 }}
+                         e^{ - \\frac{ (x - \\mu)^2 } {2 \\sigma^2} },
+
+        where :math:`\\mu` is the mean and :math:`\\sigma` the standard
+        deviation. The square of the standard deviation, :math:`\\sigma^2`,
+        is called the variance.
+
+        The function has its peak at the mean, and its "spread" increases with
+        the standard deviation (the function reaches 0.607 times its maximum at
+        :math:`x + \\sigma` and :math:`x - \\sigma` [2]_).  This implies that
+        `numpy.random.normal` is more likely to return samples lying close to
+        the mean, rather than those far away.
+
+        References
+        ----------
+        .. [1] Wikipedia, "Normal distribution",
+               http://en.wikipedia.org/wiki/Normal_distribution
+        .. [2] P. R. Peebles Jr., "Central Limit Theorem" in "Probability,
+               Random Variables and Random Signal Principles", 4th ed., 2001,
+               pp. 51, 51, 125.
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> mu, sigma = 0, 0.1 # mean and standard deviation
+        >>> s = np.random.normal(mu, sigma, 1000)
+
+        Verify the mean and the variance:
+
+        >>> abs(mu - np.mean(s)) < 0.01
+        True
+
+        >>> abs(sigma - np.std(s, ddof=1)) < 0.01
+        True
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, 30, normed=True)
+        >>> plt.plot(bins, 1/(sigma * np.sqrt(2 * np.pi)) *
+        ...                np.exp( - (bins - mu)**2 / (2 * sigma**2) ),
+        ...          linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray oloc, oscale
+        cdef double floc, fscale
+
+        floc = PyFloat_AsDouble(loc)
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            method = choose_method(method, [ICDF, BOXMULLER, BOXMULLER2], _method_alias_dict_gaussian)
+            if method is ICDF:
+                return vec_cont2_array_sc(self.internal_state, vrk_normal_vec_ICDF, size, floc, fscale, self.lock)
+            elif method is BOXMULLER2:
+                return vec_cont2_array_sc(self.internal_state, vrk_normal_vec_BM2, size, floc, fscale, self.lock)
+            else:
+                return vec_cont2_array_sc(self.internal_state, vrk_normal_vec_BM1, size, floc, fscale, self.lock)
+
+        PyErr_Clear()
+
+        oloc = <ndarray>PyArray_FROM_OTF(loc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oscale = <ndarray>PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oscale, 0)):
+            raise ValueError("scale <= 0")
+        method = choose_method(method, [ICDF, BOXMULLER, BOXMULLER2], _method_alias_dict_gaussian)
+        if method is ICDF:
+            return vec_cont2_array(self.internal_state, vrk_normal_vec_ICDF, size, oloc, oscale, self.lock)
+        elif method is BOXMULLER2:
+            return vec_cont2_array(self.internal_state, vrk_normal_vec_BM2, size, oloc, oscale, self.lock)
+        else:
+            return vec_cont2_array(self.internal_state, vrk_normal_vec_BM1, size, oloc, oscale, self.lock)
+
+    def beta(self, a, b, size=None):
+        """
+        beta(a, b, size=None)
+
+        Draw samples from a Beta distribution.
+
+        The Beta distribution is a special case of the Dirichlet distribution,
+        and is related to the Gamma distribution.  It has the probability
+        distribution function
+
+        .. math:: f(x; a,b) = \\frac{1}{B(\\alpha, \\beta)} x^{\\alpha - 1}
+                                                         (1 - x)^{\\beta - 1},
+
+        where the normalisation, B, is the beta function,
+
+        .. math:: B(\\alpha, \\beta) = \\int_0^1 t^{\\alpha - 1}
+                                     (1 - t)^{\\beta - 1} dt.
+
+        It is often seen in Bayesian inference and order statistics.
+
+        Parameters
+        ----------
+        a : float
+            Alpha, non-negative.
+        b : float
+            Beta, non-negative.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : ndarray
+            Array of the given shape, containing values drawn from a
+            Beta distribution.
+
+        """
+        cdef ndarray oa, ob
+        cdef double fa, fb
+
+        fa = PyFloat_AsDouble(a)
+        fb = PyFloat_AsDouble(b)
+        if not PyErr_Occurred():
+            if fa <= 0:
+                raise ValueError("a <= 0")
+            if fb <= 0:
+                raise ValueError("b <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_beta_vec, size, fa, fb,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        oa = <ndarray>PyArray_FROM_OTF(a, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        ob = <ndarray>PyArray_FROM_OTF(b, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oa, 0)):
+            raise ValueError("a <= 0")
+        if np.any(np.less_equal(ob, 0)):
+            raise ValueError("b <= 0")
+        return vec_cont2_array(self.internal_state, vrk_beta_vec, size, oa, ob,
+                           self.lock)
+
+    def exponential(self, scale=1.0, size=None):
+        """
+        exponential(scale=1.0, size=None)
+
+        Draw samples from an exponential distribution.
+
+        Its probability density function is
+
+        .. math:: f(x; \\frac{1}{\\beta}) = \\frac{1}{\\beta} \\exp(-\\frac{x}{\\beta}),
+
+        for ``x > 0`` and 0 elsewhere. :math:`\\beta` is the scale parameter,
+        which is the inverse of the rate parameter :math:`\\lambda = 1/\\beta`.
+        The rate parameter is an alternative, widely used parameterization
+        of the exponential distribution [3]_.
+
+        The exponential distribution is a continuous analogue of the
+        geometric distribution.  It describes many common situations, such as
+        the size of raindrops measured over many rainstorms [1]_, or the time
+        between page requests to Wikipedia [2]_.
+
+        Parameters
+        ----------
+        scale : float
+            The scale parameter, :math:`\\beta = 1/\\lambda`.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        References
+        ----------
+        .. [1] Peyton Z. Peebles Jr., "Probability, Random Variables and
+               Random Signal Principles", 4th ed, 2001, p. 57.
+        .. [2] "Poisson Process", Wikipedia,
+               http://en.wikipedia.org/wiki/Poisson_process
+        .. [3] "Exponential Distribution, Wikipedia,
+               http://en.wikipedia.org/wiki/Exponential_distribution
+
+        """
+        cdef ndarray oscale
+        cdef double fscale
+
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_exponential_vec, size,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+
+        oscale = <ndarray> PyArray_FROM_OTF(scale, NPY_DOUBLE,
+                                            NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oscale, 0.0)):
+            raise ValueError("scale <= 0")
+        return vec_cont1_array(self.internal_state, vrk_exponential_vec, size, oscale,
+                           self.lock)
+
+    def standard_exponential(self, size=None):
+        """
+        standard_exponential(size=None)
+
+        Draw samples from the standard exponential distribution.
+
+        `standard_exponential` is identical to the exponential distribution
+        with a scale parameter of 1.
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : float or ndarray
+            Drawn samples.
+
+        Examples
+        --------
+        Output a 3x8000 array:
+
+        >>> n = np.random.standard_exponential((3, 8000))
+
+        """
+        return vec_cont0_array(self.internal_state, vrk_standard_exponential_vec, size,
+                           self.lock)
+
+    def standard_gamma(self, shape, size=None):
+        """
+        standard_gamma(shape, size=None)
+
+        Draw samples from a standard Gamma distribution.
+
+        Samples are drawn from a Gamma distribution with specified parameters,
+        shape (sometimes designated "k") and scale=1.
+
+        Parameters
+        ----------
+        shape : float
+            Parameter, should be > 0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            The drawn samples.
+
+        See Also
+        --------
+        scipy.stats.distributions.gamma : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Gamma distribution is
+
+        .. math:: p(x) = x^{k-1}\\frac{e^{-x/\\theta}}{\\theta^k\\Gamma(k)},
+
+        where :math:`k` is the shape and :math:`\\theta` the scale,
+        and :math:`\\Gamma` is the Gamma function.
+
+        The Gamma distribution is often used to model the times to failure of
+        electronic components, and arises naturally in processes for which the
+        waiting times between Poisson distributed events are relevant.
+
+        References
+        ----------
+        .. [1] Weisstein, Eric W. "Gamma Distribution." From MathWorld--A
+               Wolfram Web Resource.
+               http://mathworld.wolfram.com/GammaDistribution.html
+        .. [2] Wikipedia, "Gamma-distribution",
+               http://en.wikipedia.org/wiki/Gamma-distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> shape, scale = 2., 1. # mean and width
+        >>> s = np.random.standard_gamma(shape, 1000000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> import scipy.special as sps
+        >>> count, bins, ignored = plt.hist(s, 50, normed=True)
+        >>> y = bins**(shape-1) * ((np.exp(-bins/scale))/ \\
+        ...                       (sps.gamma(shape) * scale**shape))
+        >>> plt.plot(bins, y, linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray oshape
+        cdef double fshape
+
+        fshape = PyFloat_AsDouble(shape)
+        if not PyErr_Occurred():
+            if fshape <= 0:
+                raise ValueError("shape <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_standard_gamma_vec,
+                                  size, fshape, self.lock)
+
+        PyErr_Clear()
+        oshape = <ndarray> PyArray_FROM_OTF(shape, NPY_DOUBLE,
+                                            NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oshape, 0.0)):
+            raise ValueError("shape <= 0")
+        return vec_cont1_array(self.internal_state, vrk_standard_gamma_vec, size,
+                           oshape, self.lock)
+
+    def gamma(self, shape, scale=1.0, size=None):
+        """
+        gamma(shape, scale=1.0, size=None)
+
+        Draw samples from a Gamma distribution.
+
+        Samples are drawn from a Gamma distribution with specified parameters,
+        `shape` (sometimes designated "k") and `scale` (sometimes designated
+        "theta"), where both parameters are > 0.
+
+        Parameters
+        ----------
+        shape : scalar > 0
+            The shape of the gamma distribution.
+        scale : scalar > 0, optional
+            The scale of the gamma distribution.  Default is equal to 1.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : ndarray, float
+            Returns one sample unless `size` parameter is specified.
+
+        See Also
+        --------
+        scipy.stats.distributions.gamma : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Gamma distribution is
+
+        .. math:: p(x) = x^{k-1}\\frac{e^{-x/\\theta}}{\\theta^k\\Gamma(k)},
+
+        where :math:`k` is the shape and :math:`\\theta` the scale,
+        and :math:`\\Gamma` is the Gamma function.
+
+        The Gamma distribution is often used to model the times to failure of
+        electronic components, and arises naturally in processes for which the
+        waiting times between Poisson distributed events are relevant.
+
+        References
+        ----------
+        .. [1] Weisstein, Eric W. "Gamma Distribution." From MathWorld--A
+               Wolfram Web Resource.
+               http://mathworld.wolfram.com/GammaDistribution.html
+        .. [2] Wikipedia, "Gamma-distribution",
+               http://en.wikipedia.org/wiki/Gamma-distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> shape, scale = 2., 2. # mean and dispersion
+        >>> s = np.random.gamma(shape, scale, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> import scipy.special as sps
+        >>> count, bins, ignored = plt.hist(s, 50, normed=True)
+        >>> y = bins**(shape-1)*(np.exp(-bins/scale) /
+        ...                      (sps.gamma(shape)*scale**shape))
+        >>> plt.plot(bins, y, linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray oshape, oscale
+        cdef double fshape, fscale
+
+        fshape = PyFloat_AsDouble(shape)
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fshape <= 0:
+                raise ValueError("shape <= 0")
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_gamma_vec, size, fshape,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+        oshape = <ndarray>PyArray_FROM_OTF(shape, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oscale = <ndarray>PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oshape, 0.0)):
+            raise ValueError("shape <= 0")
+        if np.any(np.less_equal(oscale, 0.0)):
+            raise ValueError("scale <= 0")
+        return vec_cont2_array(self.internal_state, vrk_gamma_vec, size, oshape, oscale,
+                           self.lock)
+
+    def f(self, dfnum, dfden, size=None):
+        """
+        f(dfnum, dfden, size=None)
+
+        Draw samples from an F distribution.
+
+        Samples are drawn from an F distribution with specified parameters,
+        `dfnum` (degrees of freedom in numerator) and `dfden` (degrees of
+        freedom in denominator), where both parameters should be greater than
+        zero.
+
+        The random variate of the F distribution (also known as the
+        Fisher distribution) is a continuous probability distribution
+        that arises in ANOVA tests, and is the ratio of two chi-square
+        variates.
+
+        Parameters
+        ----------
+        dfnum : float
+            Degrees of freedom in numerator. Should be greater than zero.
+        dfden : float
+            Degrees of freedom in denominator. Should be greater than zero.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            Samples from the Fisher distribution.
+
+        See Also
+        --------
+        scipy.stats.distributions.f : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The F statistic is used to compare in-group variances to between-group
+        variances. Calculating the distribution depends on the sampling, and
+        so it is a function of the respective degrees of freedom in the
+        problem.  The variable `dfnum` is the number of samples minus one, the
+        between-groups degrees of freedom, while `dfden` is the within-groups
+        degrees of freedom, the sum of the number of samples in each group
+        minus the number of groups.
+
+        References
+        ----------
+        .. [1] Glantz, Stanton A. "Primer of Biostatistics.", McGraw-Hill,
+               Fifth Edition, 2002.
+        .. [2] Wikipedia, "F-distribution",
+               http://en.wikipedia.org/wiki/F-distribution
+
+        Examples
+        --------
+        An example from Glantz[1], pp 47-40:
+
+        Two groups, children of diabetics (25 people) and children from people
+        without diabetes (25 controls). Fasting blood glucose was measured,
+        case group had a mean value of 86.1, controls had a mean value of
+        82.2. Standard deviations were 2.09 and 2.49 respectively. Are these
+        data consistent with the null hypothesis that the parents diabetic
+        status does not affect their children's blood glucose levels?
+        Calculating the F statistic from the data gives a value of 36.01.
+
+        Draw samples from the distribution:
+
+        >>> dfnum = 1. # between group degrees of freedom
+        >>> dfden = 48. # within groups degrees of freedom
+        >>> s = np.random.f(dfnum, dfden, 1000)
+
+        The lower bound for the top 1% of the samples is :
+
+        >>> sort(s)[-10]
+        7.61988120985
+
+        So there is about a 1% chance that the F statistic will exceed 7.62,
+        the measured value is 36, so the null hypothesis is rejected at the 1%
+        level.
+
+        """
+        cdef ndarray odfnum, odfden
+        cdef double fdfnum, fdfden
+
+        fdfnum = PyFloat_AsDouble(dfnum)
+        fdfden = PyFloat_AsDouble(dfden)
+        if not PyErr_Occurred():
+            if fdfnum <= 0:
+                raise ValueError("shape <= 0")
+            if fdfden <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_f_vec, size, fdfnum,
+                                  fdfden, self.lock)
+
+        PyErr_Clear()
+
+        odfnum = <ndarray>PyArray_FROM_OTF(dfnum, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        odfden = <ndarray>PyArray_FROM_OTF(dfden, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(odfnum, 0.0)):
+            raise ValueError("dfnum <= 0")
+        if np.any(np.less_equal(odfden, 0.0)):
+            raise ValueError("dfden <= 0")
+        return vec_cont2_array(self.internal_state, vrk_f_vec, size, odfnum, odfden,
+                           self.lock)
+
+    def noncentral_f(self, dfnum, dfden, nonc, size=None):
+        """
+        noncentral_f(dfnum, dfden, nonc, size=None)
+
+        Draw samples from the noncentral F distribution.
+
+        Samples are drawn from an F distribution with specified parameters,
+        `dfnum` (degrees of freedom in numerator) and `dfden` (degrees of
+        freedom in denominator), where both parameters > 1.
+        `nonc` is the non-centrality parameter.
+
+        Parameters
+        ----------
+        dfnum : int
+            Parameter, should be > 1.
+        dfden : int
+            Parameter, should be > 1.
+        nonc : float
+            Parameter, should be >= 0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : scalar or ndarray
+            Drawn samples.
+
+        Notes
+        -----
+        When calculating the power of an experiment (power = probability of
+        rejecting the null hypothesis when a specific alternative is true) the
+        non-central F statistic becomes important.  When the null hypothesis is
+        true, the F statistic follows a central F distribution. When the null
+        hypothesis is not true, then it follows a non-central F statistic.
+
+        References
+        ----------
+        .. [1] Weisstein, Eric W. "Noncentral F-Distribution."
+               From MathWorld--A Wolfram Web Resource.
+               http://mathworld.wolfram.com/NoncentralF-Distribution.html
+        .. [2] Wikipedia, "Noncentral F distribution",
+               http://en.wikipedia.org/wiki/Noncentral_F-distribution
+
+        Examples
+        --------
+        In a study, testing for a specific alternative to the null hypothesis
+        requires use of the Noncentral F distribution. We need to calculate the
+        area in the tail of the distribution that exceeds the value of the F
+        distribution for the null hypothesis.  We'll plot the two probability
+        distributions for comparison.
+
+        >>> dfnum = 3 # between group deg of freedom
+        >>> dfden = 20 # within groups degrees of freedom
+        >>> nonc = 3.0
+        >>> nc_vals = np.random.noncentral_f(dfnum, dfden, nonc, 1000000)
+        >>> NF = np.histogram(nc_vals, bins=50, normed=True)
+        >>> c_vals = np.random.f(dfnum, dfden, 1000000)
+        >>> F = np.histogram(c_vals, bins=50, normed=True)
+        >>> plt.plot(F[1][1:], F[0])
+        >>> plt.plot(NF[1][1:], NF[0])
+        >>> plt.show()
+
+        """
+        cdef ndarray odfnum, odfden, ononc
+        cdef double fdfnum, fdfden, fnonc
+
+        fdfnum = PyFloat_AsDouble(dfnum)
+        fdfden = PyFloat_AsDouble(dfden)
+        fnonc = PyFloat_AsDouble(nonc)
+        if not PyErr_Occurred():
+            if fdfnum <= 1:
+                raise ValueError("dfnum <= 1")
+            if fdfden <= 0:
+                raise ValueError("dfden <= 0")
+            if fnonc < 0:
+                raise ValueError("nonc < 0")
+            return vec_cont3_array_sc(self.internal_state, vrk_noncentral_f_vec, size,
+                                  fdfnum, fdfden, fnonc, self.lock)
+
+        PyErr_Clear()
+
+        odfnum = <ndarray>PyArray_FROM_OTF(dfnum, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        odfden = <ndarray>PyArray_FROM_OTF(dfden, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        ononc = <ndarray>PyArray_FROM_OTF(nonc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+
+        if np.any(np.less_equal(odfnum, 1.0)):
+            raise ValueError("dfnum <= 1")
+        if np.any(np.less_equal(odfden, 0.0)):
+            raise ValueError("dfden <= 0")
+        if np.any(np.less(ononc, 0.0)):
+            raise ValueError("nonc < 0")
+        return vec_cont3_array(self.internal_state, vrk_noncentral_f_vec, size, odfnum,
+                           odfden, ononc, self.lock)
+
+    def chisquare(self, df, size=None):
+        """
+        chisquare(df, size=None)
+
+        Draw samples from a chi-square distribution.
+
+        When `df` independent random variables, each with standard normal
+        distributions (mean 0, variance 1), are squared and summed, the
+        resulting distribution is chi-square (see Notes).  This distribution
+        is often used in hypothesis testing.
+
+        Parameters
+        ----------
+        df : int
+             Number of degrees of freedom.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        output : ndarray
+            Samples drawn from the distribution, packed in a `size`-shaped
+            array.
+
+        Raises
+        ------
+        ValueError
+            When `df` <= 0 or when an inappropriate `size` (e.g. ``size=-1``)
+            is given.
+
+        Notes
+        -----
+        The variable obtained by summing the squares of `df` independent,
+        standard normally distributed random variables:
+
+        .. math:: Q = \\sum_{i=0}^{\\mathtt{df}} X^2_i
+
+        is chi-square distributed, denoted
+
+        .. math:: Q \\sim \\chi^2_k.
+
+        The probability density function of the chi-squared distribution is
+
+        .. math:: p(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}
+                         x^{k/2 - 1} e^{-x/2},
+
+        where :math:`\\Gamma` is the gamma function,
+
+        .. math:: \\Gamma(x) = \\int_0^{-\\infty} t^{x - 1} e^{-t} dt.
+
+        References
+        ----------
+        .. [1] NIST "Engineering Statistics Handbook"
+               http://www.itl.nist.gov/div898/handbook/eda/section3/eda3666.htm
+
+        Examples
+        --------
+        >>> np.random.chisquare(2,4)
+        array([ 1.89920014,  9.00867716,  3.13710533,  5.62318272])
+
+        """
+        cdef ndarray odf
+        cdef double fdf
+
+        fdf = PyFloat_AsDouble(df)
+        if not PyErr_Occurred():
+            if fdf <= 0:
+                raise ValueError("df <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_chisquare_vec, size, fdf,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        odf = <ndarray>PyArray_FROM_OTF(df, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(odf, 0.0)):
+            raise ValueError("df <= 0")
+        return vec_cont1_array(self.internal_state, vrk_chisquare_vec, size, odf,
+                           self.lock)
+
+    def noncentral_chisquare(self, df, nonc, size=None):
+        """
+        noncentral_chisquare(df, nonc, size=None)
+
+        Draw samples from a noncentral chi-square distribution.
+
+        The noncentral :math:`\\chi^2` distribution is a generalisation of
+        the :math:`\\chi^2` distribution.
+
+        Parameters
+        ----------
+        df : int
+            Degrees of freedom, should be > 0 as of Numpy 1.10,
+            should be > 1 for earlier versions.
+        nonc : float
+            Non-centrality, should be non-negative.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Notes
+        -----
+        The probability density function for the noncentral Chi-square
+        distribution is
+
+        .. math:: P(x;df,nonc) = \\sum^{\\infty}_{i=0}
+                               \\frac{e^{-nonc/2}(nonc/2)^{i}}{i!}
+                               \\P_{Y_{df+2i}}(x),
+
+        where :math:`Y_{q}` is the Chi-square with q degrees of freedom.
+
+        In Delhi (2007), it is noted that the noncentral chi-square is
+        useful in bombing and coverage problems, the probability of
+        killing the point target given by the noncentral chi-squared
+        distribution.
+
+        References
+        ----------
+        .. [1] Delhi, M.S. Holla, "On a noncentral chi-square distribution in
+               the analysis of weapon systems effectiveness", Metrika,
+               Volume 15, Number 1 / December, 1970.
+        .. [2] Wikipedia, "Noncentral chi-square distribution"
+               http://en.wikipedia.org/wiki/Noncentral_chi-square_distribution
+
+        Examples
+        --------
+        Draw values from the distribution and plot the histogram
+
+        >>> import matplotlib.pyplot as plt
+        >>> values = plt.hist(np.random.noncentral_chisquare(3, 20, 100000),
+        ...                   bins=200, normed=True)
+        >>> plt.show()
+
+        Draw values from a noncentral chisquare with very small noncentrality,
+        and compare to a chisquare.
+
+        >>> plt.figure()
+        >>> values = plt.hist(np.random.noncentral_chisquare(3, .0000001, 100000),
+        ...                   bins=np.arange(0., 25, .1), normed=True)
+        >>> values2 = plt.hist(np.random.chisquare(3, 100000),
+        ...                    bins=np.arange(0., 25, .1), normed=True)
+        >>> plt.plot(values[1][0:-1], values[0]-values2[0], 'ob')
+        >>> plt.show()
+
+        Demonstrate how large values of non-centrality lead to a more symmetric
+        distribution.
+
+        >>> plt.figure()
+        >>> values = plt.hist(np.random.noncentral_chisquare(3, 20, 100000),
+        ...                   bins=200, normed=True)
+        >>> plt.show()
+
+        """
+        cdef ndarray odf, ononc
+        cdef double fdf, fnonc
+        fdf = PyFloat_AsDouble(df)
+        fnonc = PyFloat_AsDouble(nonc)
+        if not PyErr_Occurred():
+            if fdf <= 0:
+                raise ValueError("df <= 0")
+            if fnonc < 0:
+                raise ValueError("nonc < 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_noncentral_chisquare_vec,
+                                  size, fdf, fnonc, self.lock)
+
+        PyErr_Clear()
+
+        odf = <ndarray>PyArray_FROM_OTF(df, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        ononc = <ndarray>PyArray_FROM_OTF(nonc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(odf, 0.0)):
+            raise ValueError("df <= 0")
+        if np.any(np.less(ononc, 0.0)):
+            raise ValueError("nonc < 0")
+        return vec_cont2_array(self.internal_state, vrk_noncentral_chisquare_vec, size,
+                           odf, ononc, self.lock)
+
+    def standard_cauchy(self, size=None):
+        """
+        standard_cauchy(size=None)
+
+        Draw samples from a standard Cauchy distribution with mode = 0.
+
+        Also known as the Lorentz distribution.
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            The drawn samples.
+
+        Notes
+        -----
+        The probability density function for the full Cauchy distribution is
+
+        .. math:: P(x; x_0, \\gamma) = \\frac{1}{\\pi \\gamma \\bigl[ 1+
+                  (\\frac{x-x_0}{\\gamma})^2 \\bigr] }
+
+        and the Standard Cauchy distribution just sets :math:`x_0=0` and
+        :math:`\\gamma=1`
+
+        The Cauchy distribution arises in the solution to the driven harmonic
+        oscillator problem, and also describes spectral line broadening. It
+        also describes the distribution of values at which a line tilted at
+        a random angle will cut the x axis.
+
+        When studying hypothesis tests that assume normality, seeing how the
+        tests perform on data from a Cauchy distribution is a good indicator of
+        their sensitivity to a heavy-tailed distribution, since the Cauchy looks
+        very much like a Gaussian distribution, but with heavier tails.
+
+        References
+        ----------
+        .. [1] NIST/SEMATECH e-Handbook of Statistical Methods, "Cauchy
+              Distribution",
+              http://www.itl.nist.gov/div898/handbook/eda/section3/eda3663.htm
+        .. [2] Weisstein, Eric W. "Cauchy Distribution." From MathWorld--A
+              Wolfram Web Resource.
+              http://mathworld.wolfram.com/CauchyDistribution.html
+        .. [3] Wikipedia, "Cauchy distribution"
+              http://en.wikipedia.org/wiki/Cauchy_distribution
+
+        Examples
+        --------
+        Draw samples and plot the distribution:
+
+        >>> s = np.random.standard_cauchy(1000000)
+        >>> s = s[(s>-25) & (s<25)]  # truncate distribution so it plots well
+        >>> plt.hist(s, bins=100)
+        >>> plt.show()
+
+        """
+        return vec_cont0_array(self.internal_state, vrk_standard_cauchy_vec, size,
+                           self.lock)
+
+    def standard_t(self, df, size=None):
+        """
+        standard_t(df, size=None)
+
+        Draw samples from a standard Student's t distribution with `df` degrees
+        of freedom.
+
+        A special case of the hyperbolic distribution.  As `df` gets
+        large, the result resembles that of the standard normal
+        distribution (`standard_normal`).
+
+        Parameters
+        ----------
+        df : int
+            Degrees of freedom, should be > 0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            Drawn samples.
+
+        Notes
+        -----
+        The probability density function for the t distribution is
+
+        .. math:: P(x, df) = \\frac{\\Gamma(\\frac{df+1}{2})}{\\sqrt{\\pi df}
+                  \\Gamma(\\frac{df}{2})}\\Bigl( 1+\\frac{x^2}{df} \\Bigr)^{-(df+1)/2}
+
+        The t test is based on an assumption that the data come from a
+        Normal distribution. The t test provides a way to test whether
+        the sample mean (that is the mean calculated from the data) is
+        a good estimate of the true mean.
+
+        The derivation of the t-distribution was first published in
+        1908 by William Gisset while working for the Guinness Brewery
+        in Dublin. Due to proprietary issues, he had to publish under
+        a pseudonym, and so he used the name Student.
+
+        References
+        ----------
+        .. [1] Dalgaard, Peter, "Introductory Statistics With R",
+               Springer, 2002.
+        .. [2] Wikipedia, "Student's t-distribution"
+               http://en.wikipedia.org/wiki/Student's_t-distribution
+
+        Examples
+        --------
+        From Dalgaard page 83 [1]_, suppose the daily energy intake for 11
+        women in Kj is:
+
+        >>> intake = np.array([5260., 5470, 5640, 6180, 6390, 6515, 6805, 7515, \\
+        ...                    7515, 8230, 8770])
+
+        Does their energy intake deviate systematically from the recommended
+        value of 7725 kJ?
+
+        We have 10 degrees of freedom, so is the sample mean within 95% of the
+        recommended value?
+
+        >>> s = np.random.standard_t(10, size=100000)
+        >>> np.mean(intake)
+        6753.636363636364
+        >>> intake.std(ddof=1)
+        1142.1232221373727
+
+        Calculate the t statistic, setting the ddof parameter to the unbiased
+        value so the divisor in the standard deviation will be degrees of
+        freedom, N-1.
+
+        >>> t = (np.mean(intake)-7725)/(intake.std(ddof=1)/np.sqrt(len(intake)))
+        >>> import matplotlib.pyplot as plt
+        >>> h = plt.hist(s, bins=100, normed=True)
+
+        For a one-sided t-test, how far out in the distribution does the t
+        statistic appear?
+
+        >>> np.sum(s<t) / float(len(s))
+        0.0090699999999999999  #random
+
+        So the p-value is about 0.009, which says the null hypothesis has a
+        probability of about 99% of being true.
+
+        """
+        cdef ndarray odf
+        cdef double fdf
+
+        fdf = PyFloat_AsDouble(df)
+        if not PyErr_Occurred():
+            if fdf <= 0:
+                raise ValueError("df <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_standard_t_vec, size,
+                                  fdf, self.lock)
+
+        PyErr_Clear()
+
+        odf = <ndarray> PyArray_FROM_OTF(df, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(odf, 0.0)):
+            raise ValueError("df <= 0")
+        return vec_cont1_array(self.internal_state, vrk_standard_t_vec, size, odf,
+                           self.lock)
+
+    def vonmises(self, mu, kappa, size=None):
+        """
+        vonmises(mu, kappa, size=None)
+
+        Draw samples from a von Mises distribution.
+
+        Samples are drawn from a von Mises distribution with specified mode
+        (mu) and dispersion (kappa), on the interval [-pi, pi].
+
+        The von Mises distribution (also known as the circular normal
+        distribution) is a continuous probability distribution on the unit
+        circle.  It may be thought of as the circular analogue of the normal
+        distribution.
+
+        Parameters
+        ----------
+        mu : float
+            Mode ("center") of the distribution.
+        kappa : float
+            Dispersion of the distribution, has to be >=0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : scalar or ndarray
+            The returned samples, which are in the interval [-pi, pi].
+
+        See Also
+        --------
+        scipy.stats.distributions.vonmises : probability density function,
+            distribution, or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the von Mises distribution is
+
+        .. math:: p(x) = \\frac{e^{\\kappa cos(x-\\mu)}}{2\\pi I_0(\\kappa)},
+
+        where :math:`\\mu` is the mode and :math:`\\kappa` the dispersion,
+        and :math:`I_0(\\kappa)` is the modified Bessel function of order 0.
+
+        The von Mises is named for Richard Edler von Mises, who was born in
+        Austria-Hungary, in what is now the Ukraine.  He fled to the United
+        States in 1939 and became a professor at Harvard.  He worked in
+        probability theory, aerodynamics, fluid mechanics, and philosophy of
+        science.
+
+        References
+        ----------
+        .. [1] Abramowitz, M. and Stegun, I. A. (Eds.). "Handbook of
+               Mathematical Functions with Formulas, Graphs, and Mathematical
+               Tables, 9th printing," New York: Dover, 1972.
+        .. [2] von Mises, R., "Mathematical Theory of Probability
+               and Statistics", New York: Academic Press, 1964.
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> mu, kappa = 0.0, 4.0 # mean and dispersion
+        >>> s = np.random.vonmises(mu, kappa, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> from scipy.special import i0
+        >>> plt.hist(s, 50, normed=True)
+        >>> x = np.linspace(-np.pi, np.pi, num=51)
+        >>> y = np.exp(kappa*np.cos(x-mu))/(2*np.pi*i0(kappa))
+        >>> plt.plot(x, y, linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray omu, okappa
+        cdef double fmu, fkappa
+
+        fmu = PyFloat_AsDouble(mu)
+        fkappa = PyFloat_AsDouble(kappa)
+        if not PyErr_Occurred():
+            if fkappa < 0:
+                raise ValueError("kappa < 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_vonmises_vec, size, fmu,
+                                  fkappa, self.lock)
+
+        PyErr_Clear()
+
+        omu = <ndarray> PyArray_FROM_OTF(mu, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        okappa = <ndarray> PyArray_FROM_OTF(kappa, NPY_DOUBLE,
+                                            NPY_ARRAY_ALIGNED)
+        if np.any(np.less(okappa, 0.0)):
+            raise ValueError("kappa < 0")
+        return vec_cont2_array(self.internal_state, vrk_vonmises_vec, size, omu, okappa,
+                           self.lock)
+
+    def pareto(self, a, size=None):
+        """
+        pareto(a, size=None)
+
+        Draw samples from a Pareto II or Lomax distribution with
+        specified shape.
+
+        The Lomax or Pareto II distribution is a shifted Pareto
+        distribution. The classical Pareto distribution can be
+        obtained from the Lomax distribution by adding 1 and
+        multiplying by the scale parameter ``m`` (see Notes).  The
+        smallest value of the Lomax distribution is zero while for the
+        classical Pareto distribution it is ``mu``, where the standard
+        Pareto distribution has location ``mu = 1``.  Lomax can also
+        be considered as a simplified version of the Generalized
+        Pareto distribution (available in SciPy), with the scale set
+        to one and the location set to zero.
+
+        The Pareto distribution must be greater than zero, and is
+        unbounded above.  It is also known as the "80-20 rule".  In
+        this distribution, 80 percent of the weights are in the lowest
+        20 percent of the range, while the other 20 percent fill the
+        remaining 80 percent of the range.
+
+        Parameters
+        ----------
+        shape : float, > 0.
+            Shape of the distribution.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        See Also
+        --------
+        scipy.stats.distributions.lomax.pdf : probability density function,
+            distribution or cumulative density function, etc.
+        scipy.stats.distributions.genpareto.pdf : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Pareto distribution is
+
+        .. math:: p(x) = \\frac{a m^a}{(1+x)^{a+1}}
+
+        where :math:`a` is the shape and :math:`m` the scale.
+
+        The Pareto distribution, named after the Italian economist
+        Vilfredo Pareto, is a power law probability distribution
+        useful in many real world problems.  Outside the field of
+        economics it is generally referred to as the Bradford
+        distribution. Pareto developed the distribution to describe
+        the distribution of wealth in an economy.  It has also found
+        use in insurance, web page access statistics, oil field sizes,
+        and many other problems, including the download frequency for
+        projects in Sourceforge [1]_.  It is one of the so-called
+        "fat-tailed" distributions.
+
+
+        References
+        ----------
+        .. [1] Francis Hunt and Paul Johnson, On the Pareto Distribution of
+               Sourceforge projects.
+        .. [2] Pareto, V. (1896). Course of Political Economy. Lausanne.
+        .. [3] Reiss, R.D., Thomas, M.(2001), Statistical Analysis of Extreme
+               Values, Birkhauser Verlag, Basel, pp 23-30.
+        .. [4] Wikipedia, "Pareto distribution",
+               http://en.wikipedia.org/wiki/Pareto_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> a, m = 3., 2.  # shape and mode
+        >>> s = (np.random.pareto(a, 1000) + 1) * m
+
+        Display the histogram of the samples, along with the probability
+        density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, _ = plt.hist(s, 100, normed=True)
+        >>> fit = a*m**a / bins**(a+1)
+        >>> plt.plot(bins, max(count)*fit/max(fit), linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray oa
+        cdef double fa
+
+        fa = PyFloat_AsDouble(a)
+        if not PyErr_Occurred():
+            if fa <= 0:
+                raise ValueError("a <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_pareto_vec, size, fa,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        oa = <ndarray>PyArray_FROM_OTF(a, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oa, 0.0)):
+            raise ValueError("a <= 0")
+        return vec_cont1_array(self.internal_state, vrk_pareto_vec, size, oa, self.lock)
+
+    def weibull(self, a, size=None):
+        """
+        weibull(a, size=None)
+
+        Draw samples from a Weibull distribution.
+
+        Draw samples from a 1-parameter Weibull distribution with the given
+        shape parameter `a`.
+
+        .. math:: X = (-ln(U))^{1/a}
+
+        Here, U is drawn from the uniform distribution over (0,1].
+
+        The more common 2-parameter Weibull, including a scale parameter
+        :math:`\\lambda` is just :math:`X = \\lambda(-ln(U))^{1/a}`.
+
+        Parameters
+        ----------
+        a : float
+            Shape of the distribution.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray
+
+        See Also
+        --------
+        scipy.stats.distributions.weibull_max
+        scipy.stats.distributions.weibull_min
+        scipy.stats.distributions.genextreme
+        gumbel
+
+        Notes
+        -----
+        The Weibull (or Type III asymptotic extreme value distribution
+        for smallest values, SEV Type III, or Rosin-Rammler
+        distribution) is one of a class of Generalized Extreme Value
+        (GEV) distributions used in modeling extreme value problems.
+        This class includes the Gumbel and Frechet distributions.
+
+        The probability density for the Weibull distribution is
+
+        .. math:: p(x) = \\frac{a}
+                         {\\lambda}(\\frac{x}{\\lambda})^{a-1}e^{-(x/\\lambda)^a},
+
+        where :math:`a` is the shape and :math:`\\lambda` the scale.
+
+        The function has its peak (the mode) at
+        :math:`\\lambda(\\frac{a-1}{a})^{1/a}`.
+
+        When ``a = 1``, the Weibull distribution reduces to the exponential
+        distribution.
+
+        References
+        ----------
+        .. [1] Waloddi Weibull, Royal Technical University, Stockholm,
+               1939 "A Statistical Theory Of The Strength Of Materials",
+               Ingeniorsvetenskapsakademiens Handlingar Nr 151, 1939,
+               Generalstabens Litografiska Anstalts Forlag, Stockholm.
+        .. [2] Waloddi Weibull, "A Statistical Distribution Function of
+               Wide Applicability", Journal Of Applied Mechanics ASME Paper
+               1951.
+        .. [3] Wikipedia, "Weibull distribution",
+               http://en.wikipedia.org/wiki/Weibull_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> a = 5. # shape
+        >>> s = np.random.weibull(a, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> x = np.arange(1,100.)/50.
+        >>> def weib(x,n,a):
+        ...     return (a / n) * (x / n)**(a - 1) * np.exp(-(x / n)**a)
+
+        >>> count, bins, ignored = plt.hist(np.random.weibull(5.,1000))
+        >>> x = np.arange(1,100.)/50.
+        >>> scale = count.max()/weib(x, 1., 5.).max()
+        >>> plt.plot(x, weib(x, 1., 5.)*scale)
+        >>> plt.show()
+
+        """
+        cdef ndarray oa
+        cdef double fa
+
+        fa = PyFloat_AsDouble(a)
+        if not PyErr_Occurred():
+            if fa <= 0:
+                raise ValueError("a <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_weibull_vec, size, fa,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        oa = <ndarray>PyArray_FROM_OTF(a, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oa, 0.0)):
+            raise ValueError("a <= 0")
+        return vec_cont1_array(self.internal_state, vrk_weibull_vec, size, oa,
+                           self.lock)
+
+    def power(self, a, size=None):
+        """
+        power(a, size=None)
+
+        Draws samples in [0, 1] from a power distribution with positive
+        exponent a - 1.
+
+        Also known as the power function distribution.
+
+        Parameters
+        ----------
+        a : float
+            parameter, > 0
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            The returned samples lie in [0, 1].
+
+        Raises
+        ------
+        ValueError
+            If a < 1.
+
+        Notes
+        -----
+        The probability density function is
+
+        .. math:: P(x; a) = ax^{a-1}, 0 \\le x \\le 1, a>0.
+
+        The power function distribution is just the inverse of the Pareto
+        distribution. It may also be seen as a special case of the Beta
+        distribution.
+
+        It is used, for example, in modeling the over-reporting of insurance
+        claims.
+
+        References
+        ----------
+        .. [1] Christian Kleiber, Samuel Kotz, "Statistical size distributions
+               in economics and actuarial sciences", Wiley, 2003.
+        .. [2] Heckert, N. A. and Filliben, James J. "NIST Handbook 148:
+               Dataplot Reference Manual, Volume 2: Let Subcommands and Library
+               Functions", National Institute of Standards and Technology
+               Handbook Series, June 2003.
+               http://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/powpdf.pdf
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> a = 5. # shape
+        >>> samples = 1000
+        >>> s = np.random.power(a, samples)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, bins=30)
+        >>> x = np.linspace(0, 1, 100)
+        >>> y = a*x**(a-1.)
+        >>> normed_y = samples*np.diff(bins)[0]*y
+        >>> plt.plot(x, normed_y)
+        >>> plt.show()
+
+        Compare the power function distribution to the inverse of the Pareto.
+
+        >>> from scipy import stats
+        >>> rvs = np.random.power(5, 1000000)
+        >>> rvsp = np.random.pareto(5, 1000000)
+        >>> xx = np.linspace(0,1,100)
+        >>> powpdf = stats.powerlaw.pdf(xx,5)
+
+        >>> plt.figure()
+        >>> plt.hist(rvs, bins=50, normed=True)
+        >>> plt.plot(xx,powpdf,'r-')
+        >>> plt.title('np.random.power(5)')
+
+        >>> plt.figure()
+        >>> plt.hist(1./(1.+rvsp), bins=50, normed=True)
+        >>> plt.plot(xx,powpdf,'r-')
+        >>> plt.title('inverse of 1 + np.random.pareto(5)')
+
+        >>> plt.figure()
+        >>> plt.hist(1./(1.+rvsp), bins=50, normed=True)
+        >>> plt.plot(xx,powpdf,'r-')
+        >>> plt.title('inverse of stats.pareto(5)')
+
+        """
+        cdef ndarray oa
+        cdef double fa
+
+        fa = PyFloat_AsDouble(a)
+        if not PyErr_Occurred():
+            if fa <= 0:
+                raise ValueError("a <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_power_vec, size, fa,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        oa = <ndarray>PyArray_FROM_OTF(a, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oa, 0.0)):
+            raise ValueError("a <= 0")
+        return vec_cont1_array(self.internal_state, vrk_power_vec, size, oa, self.lock)
+
+    def laplace(self, loc=0.0, scale=1.0, size=None):
+        """
+        laplace(loc=0.0, scale=1.0, size=None)
+
+        Draw samples from the Laplace or double exponential distribution with
+        specified location (or mean) and scale (decay).
+
+        The Laplace distribution is similar to the Gaussian/normal distribution,
+        but is sharper at the peak and has fatter tails. It represents the
+        difference between two independent, identically distributed exponential
+        random variables.
+
+        Parameters
+        ----------
+        loc : float, optional
+            The position, :math:`\\mu`, of the distribution peak.
+        scale : float, optional
+            :math:`\\lambda`, the exponential decay.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or float
+
+        Notes
+        -----
+        It has the probability density function
+
+        .. math:: f(x; \\mu, \\lambda) = \\frac{1}{2\\lambda}
+                                       \\exp\\left(-\\frac{|x - \\mu|}{\\lambda}\\right).
+
+        The first law of Laplace, from 1774, states that the frequency
+        of an error can be expressed as an exponential function of the
+        absolute magnitude of the error, which leads to the Laplace
+        distribution. For many problems in economics and health
+        sciences, this distribution seems to model the data better
+        than the standard Gaussian distribution.
+
+        References
+        ----------
+        .. [1] Abramowitz, M. and Stegun, I. A. (Eds.). "Handbook of
+               Mathematical Functions with Formulas, Graphs, and Mathematical
+               Tables, 9th printing," New York: Dover, 1972.
+        .. [2] Kotz, Samuel, et. al. "The Laplace Distribution and
+               Generalizations, " Birkhauser, 2001.
+        .. [3] Weisstein, Eric W. "Laplace Distribution."
+               From MathWorld--A Wolfram Web Resource.
+               http://mathworld.wolfram.com/LaplaceDistribution.html
+        .. [4] Wikipedia, "Laplace Distribution",
+               http://en.wikipedia.org/wiki/Laplace_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution
+
+        >>> loc, scale = 0., 1.
+        >>> s = np.random.laplace(loc, scale, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, 30, normed=True)
+        >>> x = np.arange(-8., 8., .01)
+        >>> pdf = np.exp(-abs(x-loc)/scale)/(2.*scale)
+        >>> plt.plot(x, pdf)
+
+        Plot Gaussian for comparison:
+
+        >>> g = (1/(scale * np.sqrt(2 * np.pi)) *
+        ...      np.exp(-(x - loc)**2 / (2 * scale**2)))
+        >>> plt.plot(x,g)
+
+        """
+        cdef ndarray oloc, oscale
+        cdef double floc, fscale
+
+        floc = PyFloat_AsDouble(loc)
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_laplace_vec, size, floc,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+        oloc = PyArray_FROM_OTF(loc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oscale = PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oscale, 0.0)):
+            raise ValueError("scale <= 0")
+        return vec_cont2_array(self.internal_state, vrk_laplace_vec, size, oloc, oscale,
+                           self.lock)
+
+    def gumbel(self, loc=0.0, scale=1.0, size=None):
+        """
+        gumbel(loc=0.0, scale=1.0, size=None)
+
+        Draw samples from a Gumbel distribution.
+
+        Draw samples from a Gumbel distribution with specified location and
+        scale.  For more information on the Gumbel distribution, see
+        Notes and References below.
+
+        Parameters
+        ----------
+        loc : float
+            The location of the mode of the distribution.
+        scale : float
+            The scale parameter of the distribution.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+
+        See Also
+        --------
+        scipy.stats.gumbel_l
+        scipy.stats.gumbel_r
+        scipy.stats.genextreme
+        weibull
+
+        Notes
+        -----
+        The Gumbel (or Smallest Extreme Value (SEV) or the Smallest Extreme
+        Value Type I) distribution is one of a class of Generalized Extreme
+        Value (GEV) distributions used in modeling extreme value problems.
+        The Gumbel is a special case of the Extreme Value Type I distribution
+        for maximums from distributions with "exponential-like" tails.
+
+        The probability density for the Gumbel distribution is
+
+        .. math:: p(x) = \\frac{e^{-(x - \\mu)/ \\beta}}{\\beta} e^{ -e^{-(x - \\mu)/
+                  \\beta}},
+
+        where :math:`\\mu` is the mode, a location parameter, and
+        :math:`\\beta` is the scale parameter.
+
+        The Gumbel (named for German mathematician Emil Julius Gumbel) was used
+        very early in the hydrology literature, for modeling the occurrence of
+        flood events. It is also used for modeling maximum wind speed and
+        rainfall rates.  It is a "fat-tailed" distribution - the probability of
+        an event in the tail of the distribution is larger than if one used a
+        Gaussian, hence the surprisingly frequent occurrence of 100-year
+        floods. Floods were initially modeled as a Gaussian process, which
+        underestimated the frequency of extreme events.
+
+        It is one of a class of extreme value distributions, the Generalized
+        Extreme Value (GEV) distributions, which also includes the Weibull and
+        Frechet.
+
+        The function has a mean of :math:`\\mu + 0.57721\\beta` and a variance
+        of :math:`\\frac{\\pi^2}{6}\\beta^2`.
+
+        References
+        ----------
+        .. [1] Gumbel, E. J., "Statistics of Extremes,"
+               New York: Columbia University Press, 1958.
+        .. [2] Reiss, R.-D. and Thomas, M., "Statistical Analysis of Extreme
+               Values from Insurance, Finance, Hydrology and Other Fields,"
+               Basel: Birkhauser Verlag, 2001.
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> mu, beta = 0, 0.1 # location and scale
+        >>> s = np.random.gumbel(mu, beta, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, 30, normed=True)
+        >>> plt.plot(bins, (1/beta)*np.exp(-(bins - mu)/beta)
+        ...          * np.exp( -np.exp( -(bins - mu) /beta) ),
+        ...          linewidth=2, color='r')
+        >>> plt.show()
+
+        Show how an extreme value distribution can arise from a Gaussian process
+        and compare to a Gaussian:
+
+        >>> means = []
+        >>> maxima = []
+        >>> for i in range(0,1000) :
+        ...    a = np.random.normal(mu, beta, 1000)
+        ...    means.append(a.mean())
+        ...    maxima.append(a.max())
+        >>> count, bins, ignored = plt.hist(maxima, 30, normed=True)
+        >>> beta = np.std(maxima) * np.sqrt(6) / np.pi
+        >>> mu = np.mean(maxima) - 0.57721*beta
+        >>> plt.plot(bins, (1/beta)*np.exp(-(bins - mu)/beta)
+        ...          * np.exp(-np.exp(-(bins - mu)/beta)),
+        ...          linewidth=2, color='r')
+        >>> plt.plot(bins, 1/(beta * np.sqrt(2 * np.pi))
+        ...          * np.exp(-(bins - mu)**2 / (2 * beta**2)),
+        ...          linewidth=2, color='g')
+        >>> plt.show()
+
+        """
+        cdef ndarray oloc, oscale
+        cdef double floc, fscale
+
+        floc = PyFloat_AsDouble(loc)
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_gumbel_vec, size, floc,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+        oloc = PyArray_FROM_OTF(loc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oscale = PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oscale, 0.0)):
+            raise ValueError("scale <= 0")
+        return vec_cont2_array(self.internal_state, vrk_gumbel_vec, size, oloc, oscale,
+                           self.lock)
+
+    def logistic(self, loc=0.0, scale=1.0, size=None):
+        """
+        logistic(loc=0.0, scale=1.0, size=None)
+
+        Draw samples from a logistic distribution.
+
+        Samples are drawn from a logistic distribution with specified
+        parameters, loc (location or mean, also median), and scale (>0).
+
+        Parameters
+        ----------
+        loc : float
+
+        scale : float > 0.
+
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+                  where the values are all integers in  [0, n].
+
+        See Also
+        --------
+        scipy.stats.distributions.logistic : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Logistic distribution is
+
+        .. math:: P(x) = P(x) = \\frac{e^{-(x-\\mu)/s}}{s(1+e^{-(x-\\mu)/s})^2},
+
+        where :math:`\\mu` = location and :math:`s` = scale.
+
+        The Logistic distribution is used in Extreme Value problems where it
+        can act as a mixture of Gumbel distributions, in Epidemiology, and by
+        the World Chess Federation (FIDE) where it is used in the Elo ranking
+        system, assuming the performance of each player is a logistically
+        distributed random variable.
+
+        References
+        ----------
+        .. [1] Reiss, R.-D. and Thomas M. (2001), "Statistical Analysis of
+               Extreme Values, from Insurance, Finance, Hydrology and Other
+               Fields," Birkhauser Verlag, Basel, pp 132-133.
+        .. [2] Weisstein, Eric W. "Logistic Distribution." From
+               MathWorld--A Wolfram Web Resource.
+               http://mathworld.wolfram.com/LogisticDistribution.html
+        .. [3] Wikipedia, "Logistic-distribution",
+               http://en.wikipedia.org/wiki/Logistic_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> loc, scale = 10, 1
+        >>> s = np.random.logistic(loc, scale, 10000)
+        >>> count, bins, ignored = plt.hist(s, bins=50)
+
+        #   plot against distribution
+
+        >>> def logist(x, loc, scale):
+        ...     return exp((loc-x)/scale)/(scale*(1+exp((loc-x)/scale))**2)
+        >>> plt.plot(bins, logist(bins, loc, scale)*count.max()/\\
+        ... logist(bins, loc, scale).max())
+        >>> plt.show()
+
+        """
+        cdef ndarray oloc, oscale
+        cdef double floc, fscale
+
+        floc = PyFloat_AsDouble(loc)
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_logistic_vec, size, floc,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+        oloc = PyArray_FROM_OTF(loc, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oscale = PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oscale, 0.0)):
+            raise ValueError("scale <= 0")
+        return vec_cont2_array(self.internal_state, vrk_logistic_vec, size, oloc,
+                           oscale, self.lock)
+
+    def lognormal(self, mean=0.0, sigma=1.0, size=None, method=ICDF):
+        """
+        lognormal(mean=0.0, sigma=1.0, size=None, method='ICDF')
+
+        Draw samples from a log-normal distribution.
+
+        Draw samples from a log-normal distribution with specified mean,
+        standard deviation, and array shape.  Note that the mean and standard
+        deviation are not the values for the distribution itself, but of the
+        underlying normal distribution it is derived from.
+
+        Parameters
+        ----------
+        mean : float
+            Mean value of the underlying normal distribution
+        sigma : float, > 0.
+            Standard deviation of the underlying normal distribution
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        method : 'ICDF, 'BoxMuller', optional
+            Sampling method used by Intel MKL. Can also be specified using
+            tokens np.random.ICDF, np.random.BOXMULLER
+
+        Returns
+        -------
+        samples : ndarray or float
+            The desired samples. An array of the same shape as `size` if given,
+            if `size` is None a float is returned.
+
+        See Also
+        --------
+        scipy.stats.lognorm : probability density function, distribution,
+            cumulative density function, etc.
+
+        Notes
+        -----
+        A variable `x` has a log-normal distribution if `log(x)` is normally
+        distributed.  The probability density function for the log-normal
+        distribution is:
+
+        .. math:: p(x) = \\frac{1}{\\sigma x \\sqrt{2\\pi}}
+                         e^{(-\\frac{(ln(x)-\\mu)^2}{2\\sigma^2})}
+
+        where :math:`\\mu` is the mean and :math:`\\sigma` is the standard
+        deviation of the normally distributed logarithm of the variable.
+        A log-normal distribution results if a random variable is the *product*
+        of a large number of independent, identically-distributed variables in
+        the same way that a normal distribution results if the variable is the
+        *sum* of a large number of independent, identically-distributed
+        variables.
+
+        References
+        ----------
+        .. [1] Limpert, E., Stahel, W. A., and Abbt, M., "Log-normal
+               Distributions across the Sciences: Keys and Clues,"
+               BioScience, Vol. 51, No. 5, May, 2001.
+               http://stat.ethz.ch/~stahel/lognormal/bioscience.pdf
+        .. [2] Reiss, R.D. and Thomas, M., "Statistical Analysis of Extreme
+               Values," Basel: Birkhauser Verlag, 2001, pp. 31-32.
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> mu, sigma = 3., 1. # mean and standard deviation
+        >>> s = np.random.lognormal(mu, sigma, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, 100, normed=True, align='mid')
+
+        >>> x = np.linspace(min(bins), max(bins), 10000)
+        >>> pdf = (np.exp(-(np.log(x) - mu)**2 / (2 * sigma**2))
+        ...        / (x * sigma * np.sqrt(2 * np.pi)))
+
+        >>> plt.plot(x, pdf, linewidth=2, color='r')
+        >>> plt.axis('tight')
+        >>> plt.show()
+
+        Demonstrate that taking the products of random samples from a uniform
+        distribution can be fit well by a log-normal probability density
+        function.
+
+        >>> # Generate a thousand samples: each is the product of 100 random
+        >>> # values, drawn from a normal distribution.
+        >>> b = []
+        >>> for i in range(1000):
+        ...    a = 10. + np.random.random(100)
+        ...    b.append(np.product(a))
+
+        >>> b = np.array(b) / np.min(b) # scale values to be positive
+        >>> count, bins, ignored = plt.hist(b, 100, normed=True, align='mid')
+        >>> sigma = np.std(np.log(b))
+        >>> mu = np.mean(np.log(b))
+
+        >>> x = np.linspace(min(bins), max(bins), 10000)
+        >>> pdf = (np.exp(-(np.log(x) - mu)**2 / (2 * sigma**2))
+        ...        / (x * sigma * np.sqrt(2 * np.pi)))
+
+        >>> plt.plot(x, pdf, color='r', linewidth=2)
+        >>> plt.show()
+
+        """
+        cdef ndarray omean, osigma
+        cdef double fmean, fsigma
+
+        fmean = PyFloat_AsDouble(mean)
+        fsigma = PyFloat_AsDouble(sigma)
+
+        if not PyErr_Occurred():
+            if fsigma <= 0:
+                raise ValueError("sigma <= 0")
+            method = choose_method(method, [ICDF, BOXMULLER], _method_alias_dict_gaussian_short)
+            if method is ICDF:
+                return vec_cont2_array_sc(self.internal_state, vrk_lognormal_vec_ICDF, size,
+                                  fmean, fsigma, self.lock)
+            else:
+                return vec_cont2_array_sc(self.internal_state, vrk_lognormal_vec_BM, size,
+                                  fmean, fsigma, self.lock)
+
+        PyErr_Clear()
+
+        omean = PyArray_FROM_OTF(mean, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        osigma = PyArray_FROM_OTF(sigma, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(osigma, 0.0)):
+            raise ValueError("sigma <= 0.0")
+
+        method = choose_method(method, [ICDF, BOXMULLER], _method_alias_dict_gaussian_short)
+        if method is ICDF:
+            return vec_cont2_array(self.internal_state, vrk_lognormal_vec_ICDF, size,
+                                  omean, osigma, self.lock)
+        else:
+            return vec_cont2_array(self.internal_state, vrk_lognormal_vec_BM, size,
+                                  omean, osigma, self.lock)
+
+
+    def rayleigh(self, scale=1.0, size=None):
+        """
+        rayleigh(scale=1.0, size=None)
+
+        Draw samples from a Rayleigh distribution.
+
+        The :math:`\\chi` and Weibull distributions are generalizations of the
+        Rayleigh.
+
+        Parameters
+        ----------
+        scale : scalar
+            Scale, also equals the mode. Should be >= 0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Notes
+        -----
+        The probability density function for the Rayleigh distribution is
+
+        .. math:: P(x;scale) = \\frac{x}{scale^2}e^{\\frac{-x^2}{2 \\cdotp scale^2}}
+
+        The Rayleigh distribution would arise, for example, if the East
+        and North components of the wind velocity had identical zero-mean
+        Gaussian distributions.  Then the wind speed would have a Rayleigh
+        distribution.
+
+        References
+        ----------
+        .. [1] Brighton Webs Ltd., "Rayleigh Distribution,"
+               http://www.brighton-webs.co.uk/distributions/rayleigh.asp
+        .. [2] Wikipedia, "Rayleigh distribution"
+               http://en.wikipedia.org/wiki/Rayleigh_distribution
+
+        Examples
+        --------
+        Draw values from the distribution and plot the histogram
+
+        >>> values = hist(np.random.rayleigh(3, 100000), bins=200, normed=True)
+
+        Wave heights tend to follow a Rayleigh distribution. If the mean wave
+        height is 1 meter, what fraction of waves are likely to be larger than 3
+        meters?
+
+        >>> meanvalue = 1
+        >>> modevalue = np.sqrt(2 / np.pi) * meanvalue
+        >>> s = np.random.rayleigh(modevalue, 1000000)
+
+        The percentage of waves larger than 3 meters is:
+
+        >>> 100.*sum(s>3)/1000000.
+        0.087300000000000003
+
+        """
+        cdef ndarray oscale
+        cdef double fscale
+
+        fscale = PyFloat_AsDouble(scale)
+
+        if not PyErr_Occurred():
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont1_array_sc(self.internal_state, vrk_rayleigh_vec, size,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+
+        oscale = <ndarray>PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(oscale, 0.0)):
+            raise ValueError("scale <= 0.0")
+        return vec_cont1_array(self.internal_state, vrk_rayleigh_vec, size, oscale,
+                           self.lock)
+
+    def wald(self, mean, scale, size=None):
+        """
+        wald(mean, scale, size=None)
+
+        Draw samples from a Wald, or inverse Gaussian, distribution.
+
+        As the scale approaches infinity, the distribution becomes more like a
+        Gaussian. Some references claim that the Wald is an inverse Gaussian
+        with mean equal to 1, but this is by no means universal.
+
+        The inverse Gaussian distribution was first studied in relationship to
+        Brownian motion. In 1956 M.C.K. Tweedie used the name inverse Gaussian
+        because there is an inverse relationship between the time to cover a
+        unit distance and distance covered in unit time.
+
+        Parameters
+        ----------
+        mean : scalar
+            Distribution mean, should be > 0.
+        scale : scalar
+            Scale parameter, should be >= 0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            Drawn sample, all greater than zero.
+
+        Notes
+        -----
+        The probability density function for the Wald distribution is
+
+        .. math:: P(x;mean,scale) = \\sqrt{\\frac{scale}{2\\pi x^3}}e^
+                                    \\frac{-scale(x-mean)^2}{2\\cdotp mean^2x}
+
+        As noted above the inverse Gaussian distribution first arise
+        from attempts to model Brownian motion. It is also a
+        competitor to the Weibull for use in reliability modeling and
+        modeling stock returns and interest rate processes.
+
+        References
+        ----------
+        .. [1] Brighton Webs Ltd., Wald Distribution,
+               http://www.brighton-webs.co.uk/distributions/wald.asp
+        .. [2] Chhikara, Raj S., and Folks, J. Leroy, "The Inverse Gaussian
+               Distribution: Theory : Methodology, and Applications", CRC Press,
+               1988.
+        .. [3] Wikipedia, "Wald distribution"
+               http://en.wikipedia.org/wiki/Wald_distribution
+
+        Examples
+        --------
+        Draw values from the distribution and plot the histogram:
+
+        >>> import matplotlib.pyplot as plt
+        >>> h = plt.hist(np.random.wald(3, 2, 100000), bins=200, normed=True)
+        >>> plt.show()
+
+        """
+        cdef ndarray omean, oscale
+        cdef double fmean, fscale
+
+        fmean = PyFloat_AsDouble(mean)
+        fscale = PyFloat_AsDouble(scale)
+        if not PyErr_Occurred():
+            if fmean <= 0:
+                raise ValueError("mean <= 0")
+            if fscale <= 0:
+                raise ValueError("scale <= 0")
+            return vec_cont2_array_sc(self.internal_state, vrk_wald_vec, size, fmean,
+                                  fscale, self.lock)
+
+        PyErr_Clear()
+        omean = PyArray_FROM_OTF(mean, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oscale = PyArray_FROM_OTF(scale, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(omean,0.0)):
+            raise ValueError("mean <= 0.0")
+        elif np.any(np.less_equal(oscale,0.0)):
+            raise ValueError("scale <= 0.0")
+        return vec_cont2_array(self.internal_state, vrk_wald_vec, size, omean, oscale,
+                           self.lock)
+
+    def triangular(self, left, mode, right, size=None):
+        """
+        triangular(left, mode, right, size=None)
+
+        Draw samples from the triangular distribution.
+
+        The triangular distribution is a continuous probability
+        distribution with lower limit left, peak at mode, and upper
+        limit right. Unlike the other distributions, these parameters
+        directly define the shape of the pdf.
+
+        Parameters
+        ----------
+        left : scalar
+            Lower limit.
+        mode : scalar
+            The value where the peak of the distribution occurs.
+            The value should fulfill the condition ``left <= mode <= right``.
+        right : scalar
+            Upper limit, should be larger than `left`.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            The returned samples all lie in the interval [left, right].
+
+        Notes
+        -----
+        The probability density function for the triangular distribution is
+
+        .. math:: P(x;l, m, r) = \\begin{cases}
+                  \\frac{2(x-l)}{(r-l)(m-l)}& \\text{for $l \\leq x \\leq m$},\\\\
+                  \\frac{2(r-x)}{(r-l)(r-m)}& \\text{for $m \\leq x \\leq r$},\\\\
+                  0& \\text{otherwise}.
+                  \\end{cases}
+
+        The triangular distribution is often used in ill-defined
+        problems where the underlying distribution is not known, but
+        some knowledge of the limits and mode exists. Often it is used
+        in simulations.
+
+        References
+        ----------
+        .. [1] Wikipedia, "Triangular distribution"
+               http://en.wikipedia.org/wiki/Triangular_distribution
+
+        Examples
+        --------
+        Draw values from the distribution and plot the histogram:
+
+        >>> import matplotlib.pyplot as plt
+        >>> h = plt.hist(np.random.triangular(-3, 0, 8, 100000), bins=200,
+        ...              normed=True)
+        >>> plt.show()
+
+        """
+        cdef ndarray oleft, omode, oright
+        cdef double fleft, fmode, fright
+
+        fleft = PyFloat_AsDouble(left)
+        fright = PyFloat_AsDouble(right)
+        fmode = PyFloat_AsDouble(mode)
+        if not PyErr_Occurred():
+            if fleft > fmode:
+                raise ValueError("left > mode")
+            if fmode > fright:
+                raise ValueError("mode > right")
+            if fleft == fright:
+                raise ValueError("left == right")
+            return vec_cont3_array_sc(self.internal_state, vrk_triangular_vec, size,
+                                  fleft, fmode, fright, self.lock)
+
+        PyErr_Clear()
+        oleft = <ndarray>PyArray_FROM_OTF(left, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        omode = <ndarray>PyArray_FROM_OTF(mode, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        oright = <ndarray>PyArray_FROM_OTF(right, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+
+        if np.any(np.greater(oleft, omode)):
+            raise ValueError("left > mode")
+        if np.any(np.greater(omode, oright)):
+            raise ValueError("mode > right")
+        if np.any(np.equal(oleft, oright)):
+            raise ValueError("left == right")
+        return vec_cont3_array(self.internal_state, vrk_triangular_vec, size, oleft,
+                           omode, oright, self.lock)
+
+    # Complicated, discrete distributions:
+    def binomial(self, n, p, size=None):
+        """
+        binomial(n, p, size=None)
+
+        Draw samples from a binomial distribution.
+
+        Samples are drawn from a binomial distribution with specified
+        parameters, n trials and p probability of success where
+        n an integer >= 0 and p is in the interval [0,1]. (n may be
+        input as a float, but it is truncated to an integer in use)
+
+        Parameters
+        ----------
+        n : float (but truncated to an integer)
+                parameter, >= 0.
+        p : float
+                parameter, >= 0 and <=1.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+                  where the values are all integers in  [0, n].
+
+        See Also
+        --------
+        scipy.stats.distributions.binom : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the binomial distribution is
+
+        .. math:: P(N) = \\binom{n}{N}p^N(1-p)^{n-N},
+
+        where :math:`n` is the number of trials, :math:`p` is the probability
+        of success, and :math:`N` is the number of successes.
+
+        When estimating the standard error of a proportion in a population by
+        using a random sample, the normal distribution works well unless the
+        product p*n <=5, where p = population proportion estimate, and n =
+        number of samples, in which case the binomial distribution is used
+        instead. For example, a sample of 15 people shows 4 who are left
+        handed, and 11 who are right handed. Then p = 4/15 = 27%. 0.27*15 = 4,
+        so the binomial distribution should be used in this case.
+
+        References
+        ----------
+        .. [1] Dalgaard, Peter, "Introductory Statistics with R",
+               Springer-Verlag, 2002.
+        .. [2] Glantz, Stanton A. "Primer of Biostatistics.", McGraw-Hill,
+               Fifth Edition, 2002.
+        .. [3] Lentner, Marvin, "Elementary Applied Statistics", Bogden
+               and Quigley, 1972.
+        .. [4] Weisstein, Eric W. "Binomial Distribution." From MathWorld--A
+               Wolfram Web Resource.
+               http://mathworld.wolfram.com/BinomialDistribution.html
+        .. [5] Wikipedia, "Binomial-distribution",
+               http://en.wikipedia.org/wiki/Binomial_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> n, p = 10, .5  # number of trials, probability of each trial
+        >>> s = np.random.binomial(n, p, 1000)
+        # result of flipping a coin 10 times, tested 1000 times.
+
+        A real world example. A company drills 9 wild-cat oil exploration
+        wells, each with an estimated probability of success of 0.1. All nine
+        wells fail. What is the probability of that happening?
+
+        Let's do 20,000 trials of the model, and count the number that
+        generate zero positive results.
+
+        >>> sum(np.random.binomial(9, 0.1, 20000) == 0)/20000.
+        # answer = 0.38885, or 38%.
+
+        """
+        cdef ndarray on, op
+        cdef long ln
+        cdef double fp
+
+        fp = PyFloat_AsDouble(p)
+        ln = PyInt_AsLong(n)
+        if not PyErr_Occurred():
+            if ln < 0:
+                raise ValueError("n < 0")
+            if fp < 0:
+                raise ValueError("p < 0")
+            elif fp > 1:
+                raise ValueError("p > 1")
+            elif np.isnan(fp):
+                raise ValueError("p is nan")
+            if n > int(2**31-1):
+                raise ValueError("n > 2147483647")
+            else:
+                return vec_discnp_array_sc(self.internal_state, vrk_binomial_vec, size, <int> ln,
+                            fp, self.lock)
+
+
+        PyErr_Clear()
+
+        on = <ndarray>PyArray_FROM_OTF(n, NPY_LONG, NPY_ARRAY_IN_ARRAY)
+        op = <ndarray>PyArray_FROM_OTF(p, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        if np.any(np.less(n, 0)):
+            raise ValueError("n < 0")
+        if np.any(np.less(op, 0)):
+            raise ValueError("p < 0")
+        if np.any(np.greater(op, 1)):
+            raise ValueError("p > 1")
+        if np.any(np.greater(n, int(2**31-1))):
+            raise ValueError("n > 2147483647")
+
+        on = on.astype(np.int32, casting='unsafe')
+        return vec_discnp_array(self.internal_state, vrk_binomial_vec, size, on, op,
+                            self.lock)
+
+    def negative_binomial(self, n, p, size=None):
+        """
+        negative_binomial(n, p, size=None)
+
+        Draw samples from a negative binomial distribution.
+
+        Samples are drawn from a negative binomial distribution with specified
+        parameters, `n` trials and `p` probability of success where `n` is an
+        integer > 0 and `p` is in the interval [0, 1].
+
+        Parameters
+        ----------
+        n : int
+            Parameter, > 0.
+        p : float
+            Parameter, >= 0 and <=1.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : int or ndarray of ints
+            Drawn samples.
+
+        Notes
+        -----
+        The probability density for the negative binomial distribution is
+
+        .. math:: P(N;n,p) = \\binom{N+n-1}{n-1}p^{n}(1-p)^{N},
+
+        where :math:`n-1` is the number of successes, :math:`p` is the
+        probability of success, and :math:`N+n-1` is the number of trials.
+        The negative binomial distribution gives the probability of n-1
+        successes and N failures in N+n-1 trials, and success on the (N+n)th
+        trial.
+
+        If one throws a die repeatedly until the third time a "1" appears,
+        then the probability distribution of the number of non-"1"s that
+        appear before the third "1" is a negative binomial distribution.
+
+        References
+        ----------
+        .. [1] Weisstein, Eric W. "Negative Binomial Distribution." From
+               MathWorld--A Wolfram Web Resource.
+               http://mathworld.wolfram.com/NegativeBinomialDistribution.html
+        .. [2] Wikipedia, "Negative binomial distribution",
+               http://en.wikipedia.org/wiki/Negative_binomial_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        A real world example. A company drills wild-cat oil
+        exploration wells, each with an estimated probability of
+        success of 0.1.  What is the probability of having one success
+        for each successive well, that is what is the probability of a
+        single success after drilling 5 wells, after 6 wells, etc.?
+
+        >>> s = np.random.negative_binomial(1, 0.1, 100000)
+        >>> for i in range(1, 11):
+        ...    probability = sum(s<i) / 100000.
+        ...    print i, "wells drilled, probability of one success =", probability
+
+        """
+        cdef ndarray on
+        cdef ndarray op
+        cdef double fn
+        cdef double fp
+
+        fp = PyFloat_AsDouble(p)
+        fn = PyFloat_AsDouble(n)
+        if not PyErr_Occurred():
+            if fn <= 0:
+                raise ValueError("n <= 0")
+            if fp < 0:
+                raise ValueError("p < 0")
+            elif fp > 1:
+                raise ValueError("p > 1")
+            return vec_discdd_array_sc(self.internal_state, vrk_negbinomial_vec,
+                                   size, fn, fp, self.lock)
+
+        PyErr_Clear()
+
+        on = <ndarray>PyArray_FROM_OTF(n, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        op = <ndarray>PyArray_FROM_OTF(p, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        if np.any(np.less_equal(n, 0)):
+            raise ValueError("n <= 0")
+        if np.any(np.less(p, 0)):
+            raise ValueError("p < 0")
+        if np.any(np.greater(p, 1)):
+            raise ValueError("p > 1")
+        return vec_discdd_array(self.internal_state, vrk_negbinomial_vec, size,
+                            on, op, self.lock)
+
+    def poisson(self, lam=1.0, size=None, method=POISNORM):
+        """
+        poisson(lam=1.0, size=None, method='POISNORM')
+
+        Draw samples from a Poisson distribution.
+
+        The Poisson distribution is the limit of the binomial distribution
+        for large N.
+
+        Parameters
+        ----------
+        lam : float or sequence of float
+            Expectation of interval, should be >= 0. A sequence of expectation
+            intervals must be broadcastable over the requested size.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        method : 'POISNORM, 'PTPE', optional
+            Sampling method used by Intel MKL. Can also be specified using
+            tokens np.random.POISNORM, np.random.PTPE
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            The drawn samples, of shape *size*, if it was provided.
+
+        Notes
+        -----
+        The Poisson distribution
+
+        .. math:: f(k; \\lambda)=\\frac{\\lambda^k e^{-\\lambda}}{k!}
+
+        For events with an expected separation :math:`\\lambda` the Poisson
+        distribution :math:`f(k; \\lambda)` describes the probability of
+        :math:`k` events occurring within the observed
+        interval :math:`\\lambda`.
+
+        Because the output is limited to the range of the C long type, a
+        ValueError is raised when `lam` is within 10 sigma of the maximum
+        representable value.
+
+        References
+        ----------
+        .. [1] Weisstein, Eric W. "Poisson Distribution."
+               From MathWorld--A Wolfram Web Resource.
+               http://mathworld.wolfram.com/PoissonDistribution.html
+        .. [2] Wikipedia, "Poisson distribution",
+               http://en.wikipedia.org/wiki/Poisson_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> import numpy as np
+        >>> s = np.random.poisson(5, 10000)
+
+        Display histogram of the sample:
+
+        >>> import matplotlib.pyplot as plt
+        >>> count, bins, ignored = plt.hist(s, 14, normed=True)
+        >>> plt.show()
+
+        Draw each 100 values for lambda 100 and 500:
+
+        >>> s = np.random.poisson(lam=(100., 500.), size=(100, 2))
+
+        """
+        cdef ndarray olam
+        cdef double flam
+        flam = PyFloat_AsDouble(lam)
+        if not PyErr_Occurred():
+            if lam < 0:
+                raise ValueError("lam < 0")
+            if lam > self.poisson_lam_max:
+                raise ValueError("lam value too large")
+            method = choose_method(method, [POISNORM, PTPE], _method_alias_dict_poisson);
+            if method is POISNORM:
+                return vec_discd_array_sc(self.internal_state, vrk_poisson_vec_POISNORM, size, flam, self.lock)
+            else:
+                return vec_discd_array_sc(self.internal_state, vrk_poisson_vec_PTPE, size, flam, self.lock)
+
+        PyErr_Clear()
+
+        olam = <ndarray>PyArray_FROM_OTF(lam, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        if np.any(np.less(olam, 0)):
+            raise ValueError("lam < 0")
+        if np.any(np.greater(olam, self.poisson_lam_max)):
+            raise ValueError("lam value too large.")
+        method = choose_method(method, [POISNORM, PTPE], _method_alias_dict_poisson);
+        if method is POISNORM:
+            return vec_Poisson_array(self.internal_state, vrk_poisson_vec_V, vrk_poisson_vec_POISNORM, size, olam, self.lock)
+        else:
+            return vec_discd_array(self.internal_state, vrk_poisson_vec_PTPE, size, olam, self.lock)
+
+
+    def zipf(self, a, size=None):
+        """
+        zipf(a, size=None)
+
+        Draw samples from a Zipf distribution.
+
+        Samples are drawn from a Zipf distribution with specified parameter
+        `a` > 1.
+
+        The Zipf distribution (also known as the zeta distribution) is a
+        continuous probability distribution that satisfies Zipf's law: the
+        frequency of an item is inversely proportional to its rank in a
+        frequency table.
+
+        Parameters
+        ----------
+        a : float > 1
+            Distribution parameter.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : scalar or ndarray
+            The returned samples are greater than or equal to one.
+
+        See Also
+        --------
+        scipy.stats.distributions.zipf : probability density function,
+            distribution, or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Zipf distribution is
+
+        .. math:: p(x) = \\frac{x^{-a}}{\\zeta(a)},
+
+        where :math:`\\zeta` is the Riemann Zeta function.
+
+        It is named for the American linguist George Kingsley Zipf, who noted
+        that the frequency of any word in a sample of a language is inversely
+        proportional to its rank in the frequency table.
+
+        References
+        ----------
+        .. [1] Zipf, G. K., "Selected Studies of the Principle of Relative
+               Frequency in Language," Cambridge, MA: Harvard Univ. Press,
+               1932.
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> a = 2. # parameter
+        >>> s = np.random.zipf(a, 1000)
+
+        Display the histogram of the samples, along with
+        the probability density function:
+
+        >>> import matplotlib.pyplot as plt
+        >>> import scipy.special as sps
+        Truncate s values at 50 so plot is interesting
+        >>> count, bins, ignored = plt.hist(s[s<50], 50, normed=True)
+        >>> x = np.arange(1., 50.)
+        >>> y = x**(-a)/sps.zetac(a)
+        >>> plt.plot(x, y/max(y), linewidth=2, color='r')
+        >>> plt.show()
+
+        """
+        cdef ndarray oa
+        cdef double fa
+
+        fa = PyFloat_AsDouble(a)
+        if not PyErr_Occurred():
+            if fa <= 1.0:
+                raise ValueError("a <= 1.0")
+            return vec_long_discd_array_sc(self.internal_state, vrk_zipf_long_vec, size, fa,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        oa = <ndarray>PyArray_FROM_OTF(a, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        if np.any(np.less_equal(oa, 1.0)):
+            raise ValueError("a <= 1.0")
+        return vec_long_discd_array(self.internal_state, vrk_zipf_long_vec, size, oa, self.lock)
+
+    def geometric(self, p, size=None):
+        """
+        geometric(p, size=None)
+
+        Draw samples from the geometric distribution.
+
+        Bernoulli trials are experiments with one of two outcomes:
+        success or failure (an example of such an experiment is flipping
+        a coin).  The geometric distribution models the number of trials
+        that must be run in order to achieve success.  It is therefore
+        supported on the positive integers, ``k = 1, 2, ...``.
+
+        The probability mass function of the geometric distribution is
+
+        .. math:: f(k) = (1 - p)^{k - 1} p
+
+        where `p` is the probability of success of an individual trial.
+
+        Parameters
+        ----------
+        p : float
+            The probability of success of an individual trial.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        out : ndarray
+            Samples from the geometric distribution, shaped according to
+            `size`.
+
+        Examples
+        --------
+        Draw ten thousand values from the geometric distribution,
+        with the probability of an individual success equal to 0.35:
+
+        >>> z = np.random.geometric(p=0.35, size=10000)
+
+        How many trials succeeded after a single run?
+
+        >>> (z == 1).sum() / 10000.
+        0.34889999999999999 #random
+
+        """
+        cdef ndarray op
+        cdef double fp
+
+        fp = PyFloat_AsDouble(p)
+        if not PyErr_Occurred():
+            if fp < 0.0:
+                raise ValueError("p < 0.0")
+            if fp > 1.0:
+                raise ValueError("p > 1.0")
+            return vec_discd_array_sc(self.internal_state, vrk_geometric_vec, size, fp,
+                                  self.lock)
+
+        PyErr_Clear()
+
+
+        op = <ndarray>PyArray_FROM_OTF(p, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        if np.any(np.less(op, 0.0)):
+            raise ValueError("p < 0.0")
+        if np.any(np.greater(op, 1.0)):
+            raise ValueError("p > 1.0")
+        return vec_discd_array(self.internal_state, vrk_geometric_vec, size, op,
+                           self.lock)
+
+    def hypergeometric(self, ngood, nbad, nsample, size=None):
+        """
+        hypergeometric(ngood, nbad, nsample, size=None)
+
+        Draw samples from a Hypergeometric distribution.
+
+        Samples are drawn from a hypergeometric distribution with specified
+        parameters, ngood (ways to make a good selection), nbad (ways to make
+        a bad selection), and nsample = number of items sampled, which is less
+        than or equal to the sum ngood + nbad.
+
+        Parameters
+        ----------
+        ngood : int or array_like
+            Number of ways to make a good selection.  Must be nonnegative.
+        nbad : int or array_like
+            Number of ways to make a bad selection.  Must be nonnegative.
+        nsample : int or array_like
+            Number of items sampled.  Must be at least 1 and at most
+            ``ngood + nbad``.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(d1, d2, d3)``, then
+            ``d1 * d2 * d3`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+            The values are all integers in  [0, n].
+
+        See Also
+        --------
+        scipy.stats.distributions.hypergeom : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Hypergeometric distribution is
+
+        .. math:: P(x) = \\frac{\\binom{m}{x}\\binom{N-m}{n-x}}{\\binom{N}{n}},
+
+        where :math:`0 \\le x \\le m` and :math:`n+m-N \\le x \\le n`
+
+        for P(x) the probability of x successes, m = ngood, N = ngood + nbad, and
+        n = number of samples.
+
+        Consider an urn with black and white marbles in it, ngood of them
+        black and nbad are white. If you draw nsample balls without
+        replacement, then the hypergeometric distribution describes the
+        distribution of black balls in the drawn sample.
+
+        Note that this distribution is very similar to the binomial
+        distribution, except that in this case, samples are drawn without
+        replacement, whereas in the Binomial case samples are drawn with
+        replacement (or the sample space is infinite). As the sample space
+        becomes large, this distribution approaches the binomial.
+
+        References
+        ----------
+        .. [1] Lentner, Marvin, "Elementary Applied Statistics", Bogden
+               and Quigley, 1972.
+        .. [2] Weisstein, Eric W. "Hypergeometric Distribution." From
+               MathWorld--A Wolfram Web Resource.
+               http://mathworld.wolfram.com/HypergeometricDistribution.html
+        .. [3] Wikipedia, "Hypergeometric-distribution",
+               http://en.wikipedia.org/wiki/Hypergeometric_distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> ngood, nbad, nsamp = 100, 2, 10
+        # number of good, number of bad, and number of samples
+        >>> s = np.random.hypergeometric(ngood, nbad, nsamp, 1000)
+        >>> hist(s)
+        #   note that it is very unlikely to grab both bad items
+
+        Suppose you have an urn with 15 white and 15 black marbles.
+        If you pull 15 marbles at random, how likely is it that
+        12 or more of them are one color?
+
+        >>> s = np.random.hypergeometric(15, 15, 15, 100000)
+        >>> sum(s>=12)/100000. + sum(s<=3)/100000.
+        #   answer = 0.003 ... pretty unlikely!
+
+        """
+        cdef ndarray ongood, onbad, onsample, otot
+        cdef long lngood, lnbad, lnsample, lntot
+
+        lngood = PyInt_AsLong(ngood)
+        lnbad = PyInt_AsLong(nbad)
+        lnsample = PyInt_AsLong(nsample)
+        if not PyErr_Occurred():
+            if lngood < 0:
+                raise ValueError("ngood < 0")
+            if lnbad < 0:
+                raise ValueError("nbad < 0")
+            if lnsample < 1:
+                raise ValueError("nsample < 1")
+            if ((<int> lngood) != lngood) or ((<int> lnbad) != lnbad) or ((<int> lnsample) != lnsample):
+                raise ValueError("All parameters should not exceed 2147483647")
+            lntot = lngood + lnbad
+            if lntot < lnsample:
+                raise ValueError("ngood + nbad < nsample")
+            return vec_discnmN_array_sc(self.internal_state, vrk_hypergeometric_vec,
+                                    size, lntot, lnsample, lngood, self.lock)
+
+        PyErr_Clear()
+
+        ongood = <ndarray>PyArray_FROM_OTF(ngood, NPY_LONG, NPY_ARRAY_IN_ARRAY)
+        onbad = <ndarray>PyArray_FROM_OTF(nbad, NPY_LONG, NPY_ARRAY_IN_ARRAY)
+        onsample = <ndarray>PyArray_FROM_OTF(nsample, NPY_LONG, NPY_ARRAY_IN_ARRAY)
+        if np.any(np.less(ongood, 0)):
+            raise ValueError("ngood < 0")
+        if np.any(np.less(onbad, 0)):
+            raise ValueError("nbad < 0")
+        if np.any(np.less(onsample, 1)):
+            raise ValueError("nsample < 1")
+        otot = np.add(ongood, onbad);
+        if np.any(np.less_equal(otot, 0)):
+            raise ValueError("Number of balls in each urn should not exceed 2147483647")
+        if np.any(np.less(otot,onsample)):
+            raise ValueError("ngood + nbad < nsample")
+
+        otot = otot.astype(np.int32, casting='unsafe')
+        onsample = onsample.astype(np.int32, casting='unsafe')
+        ongood = ongood.astype(np.int32, casting='unsafe')
+        return vec_discnmN_array(self.internal_state, vrk_hypergeometric_vec, size,
+                             otot, onsample, ongood, self.lock)
+
+    def logseries(self, p, size=None):
+        """
+        logseries(p, size=None)
+
+        Draw samples from a logarithmic series distribution.
+
+        Samples are drawn from a log series distribution with specified
+        shape parameter, 0 < ``p`` < 1.
+
+        Parameters
+        ----------
+        loc : float
+
+        scale : float > 0.
+
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray or scalar
+                  where the values are all integers in  [0, n].
+
+        See Also
+        --------
+        scipy.stats.distributions.logser : probability density function,
+            distribution or cumulative density function, etc.
+
+        Notes
+        -----
+        The probability density for the Log Series distribution is
+
+        .. math:: P(k) = \\frac{-p^k}{k \\ln(1-p)},
+
+        where p = probability.
+
+        The log series distribution is frequently used to represent species
+        richness and occurrence, first proposed by Fisher, Corbet, and
+        Williams in 1943 [2].  It may also be used to model the numbers of
+        occupants seen in cars [3].
+
+        References
+        ----------
+        .. [1] Buzas, Martin A.; Culver, Stephen J.,  Understanding regional
+               species diversity through the log series distribution of
+               occurrences: BIODIVERSITY RESEARCH Diversity & Distributions,
+               Volume 5, Number 5, September 1999 , pp. 187-195(9).
+        .. [2] Fisher, R.A,, A.S. Corbet, and C.B. Williams. 1943. The
+               relation between the number of species and the number of
+               individuals in a random sample of an animal population.
+               Journal of Animal Ecology, 12:42-58.
+        .. [3] D. J. Hand, F. Daly, D. Lunn, E. Ostrowski, A Handbook of Small
+               Data Sets, CRC Press, 1994.
+        .. [4] Wikipedia, "Logarithmic-distribution",
+               http://en.wikipedia.org/wiki/Logarithmic-distribution
+
+        Examples
+        --------
+        Draw samples from the distribution:
+
+        >>> a = .6
+        >>> s = np.random.logseries(a, 10000)
+        >>> count, bins, ignored = plt.hist(s)
+
+        #   plot against distribution
+
+        >>> def logseries(k, p):
+        ...     return -p**k/(k*log(1-p))
+        >>> plt.plot(bins, logseries(bins, a)*count.max()/
+                     logseries(bins, a).max(), 'r')
+        >>> plt.show()
+
+        """
+        cdef ndarray op
+        cdef double fp
+
+        fp = PyFloat_AsDouble(p)
+        if not PyErr_Occurred():
+            if fp <= 0.0:
+                raise ValueError("p <= 0.0")
+            if fp >= 1.0:
+                raise ValueError("p >= 1.0")
+            return vec_discd_array_sc(self.internal_state, vrk_logseries_vec, size, fp,
+                                  self.lock)
+
+        PyErr_Clear()
+
+        op = <ndarray>PyArray_FROM_OTF(p, NPY_DOUBLE, NPY_ARRAY_ALIGNED)
+        if np.any(np.less_equal(op, 0.0)):
+            raise ValueError("p <= 0.0")
+        if np.any(np.greater_equal(op, 1.0)):
+            raise ValueError("p >= 1.0")
+        return vec_discd_array(self.internal_state, vrk_logseries_vec, size, op,
+                           self.lock)
+
+    # Multivariate distributions:
+    def multivariate_normal(self, mean, cov, size=None):
+        """
+        multivariate_normal(mean, cov[, size])
+
+        Draw random samples from a multivariate normal distribution.
+
+        The multivariate normal, multinormal or Gaussian distribution is a
+        generalization of the one-dimensional normal distribution to higher
+        dimensions.  Such a distribution is specified by its mean and
+        covariance matrix.  These parameters are analogous to the mean
+        (average or "center") and variance (standard deviation, or "width,"
+        squared) of the one-dimensional normal distribution.
+
+        Parameters
+        ----------
+        mean : 1-D array_like, of length N
+            Mean of the N-dimensional distribution.
+        cov : 2-D array_like, of shape (N, N)
+            Covariance matrix of the distribution. It must be symmetric and
+            positive-semidefinite for proper sampling.
+        size : int or tuple of ints, optional
+            Given a shape of, for example, ``(m,n,k)``, ``m*n*k`` samples are
+            generated, and packed in an `m`-by-`n`-by-`k` arrangement.  Because
+            each sample is `N`-dimensional, the output shape is ``(m,n,k,N)``.
+            If no shape is specified, a single (`N`-D) sample is returned.
+
+        Returns
+        -------
+        out : ndarray
+            The drawn samples, of shape *size*, if that was provided.  If not,
+            the shape is ``(N,)``.
+
+            In other words, each entry ``out[i,j,...,:]`` is an N-dimensional
+            value drawn from the distribution.
+
+        Notes
+        -----
+        The mean is a coordinate in N-dimensional space, which represents the
+        location where samples are most likely to be generated.  This is
+        analogous to the peak of the bell curve for the one-dimensional or
+        univariate normal distribution.
+
+        Covariance indicates the level to which two variables vary together.
+        From the multivariate normal distribution, we draw N-dimensional
+        samples, :math:`X = [x_1, x_2, ... x_N]`.  The covariance matrix
+        element :math:`C_{ij}` is the covariance of :math:`x_i` and :math:`x_j`.
+        The element :math:`C_{ii}` is the variance of :math:`x_i` (i.e. its
+        "spread").
+
+        Instead of specifying the full covariance matrix, popular
+        approximations include:
+
+          - Spherical covariance (*cov* is a multiple of the identity matrix)
+          - Diagonal covariance (*cov* has non-negative elements, and only on
+            the diagonal)
+
+        This geometrical property can be seen in two dimensions by plotting
+        generated data-points:
+
+        >>> mean = [0, 0]
+        >>> cov = [[1, 0], [0, 100]]  # diagonal covariance
+
+        Diagonal covariance means that points are oriented along x or y-axis:
+
+        >>> import matplotlib.pyplot as plt
+        >>> x, y = np.random.multivariate_normal(mean, cov, 5000).T
+        >>> plt.plot(x, y, 'x')
+        >>> plt.axis('equal')
+        >>> plt.show()
+
+        Note that the covariance matrix must be positive semidefinite (a.k.a.
+        nonnegative-definite). Otherwise, the behavior of this method is
+        undefined and backwards compatibility is not guaranteed.
+
+        References
+        ----------
+        .. [1] Papoulis, A., "Probability, Random Variables, and Stochastic
+               Processes," 3rd ed., New York: McGraw-Hill, 1991.
+        .. [2] Duda, R. O., Hart, P. E., and Stork, D. G., "Pattern
+               Classification," 2nd ed., New York: Wiley, 2001.
+
+        Examples
+        --------
+        >>> mean = (1, 2)
+        >>> cov = [[1, 0], [0, 1]]
+        >>> x = np.random.multivariate_normal(mean, cov, (3, 3))
+        >>> x.shape
+        (3, 3, 2)
+
+        The following is probably true, given that 0.6 is roughly twice the
+        standard deviation:
+
+        >>> list((x[0,0,:] - mean) < 0.6)
+        [True, True]
+
+        """
+        from numpy.dual import svd
+
+        # Check preconditions on arguments
+        mean = np.array(mean)
+        cov = np.array(cov)
+        if size is None:
+            shape = []
+        elif isinstance(size, (int, long, np.integer)):
+            shape = [size]
+        else:
+            shape = size
+
+        if len(mean.shape) != 1:
+               raise ValueError("mean must be 1 dimensional")
+        if (len(cov.shape) != 2) or (cov.shape[0] != cov.shape[1]):
+               raise ValueError("cov must be 2 dimensional and square")
+        if mean.shape[0] != cov.shape[0]:
+               raise ValueError("mean and cov must have same length")
+
+        # Compute shape of output and create a matrix of independent
+        # standard normally distributed random numbers. The matrix has rows
+        # with the same length as mean and as many rows are necessary to
+        # form a matrix of shape final_shape.
+        final_shape = list(shape[:])
+        final_shape.append(mean.shape[0])
+        x = self.standard_normal(final_shape).reshape(-1, mean.shape[0])
+
+        # Transform matrix of standard normals into matrix where each row
+        # contains multivariate normals with the desired covariance.
+        # Compute A such that dot(transpose(A),A) == cov.
+        # Then the matrix products of the rows of x and A has the desired
+        # covariance. Note that sqrt(s)*v where (u,s,v) is the singular value
+        # decomposition of cov is such an A.
+        #
+        # Also check that cov is positive-semidefinite. If so, the u.T and v
+        # matrices should be equal up to roundoff error if cov is
+        # symmetrical and the singular value of the corresponding row is
+        # not zero. We continue to use the SVD rather than Cholesky in
+        # order to preserve current outputs. Note that symmetry has not
+        # been checked.
+        (u, s, v) = svd(cov)
+        neg = (np.sum(u.T * v, axis=1) < 0) & (s > 0)
+        if np.any(neg):
+            s[neg] = 0.
+            warnings.warn("covariance is not positive-semidefinite.",
+                          RuntimeWarning)
+
+        x = np.dot(x, np.sqrt(s)[:, None] * v)
+        x += mean
+        x.shape = tuple(final_shape)
+        return x
+
+    def multinormal_cholesky(self, mean, ch, size=None, method=ICDF):
+        """
+        multivariate_normal(mean, ch, size=None, method='ICDF')
+
+        Draw random samples from a multivariate normal distribution.
+
+        The multivariate normal, multinormal or Gaussian distribution is a
+        generalization of the one-dimensional normal distribution to higher
+        dimensions.  Such a distribution is specified by its mean and
+        covariance matrix, specified by its lower triangular Cholesky factor.
+        These parameters are analogous to the mean
+        (average or "center") and standard deviation, or "width,"
+        of the one-dimensional normal distribution.
+
+        Parameters
+        ----------
+        mean : 1-D array_like, of length N
+            Mean of the N-dimensional distribution.
+        ch : 2-D array_like, of shape (N, N)
+            Cholesky factor of the covariance matrix of the distribution. Only lower-triangular
+            part of the matrix is actually used.
+        size : int or tuple of ints, optional
+            Given a shape of, for example, ``(m,n,k)``, ``m*n*k`` samples are
+            generated, and packed in an `m`-by-`n`-by-`k` arrangement.  Because
+            each sample is `N`-dimensional, the output shape is ``(m,n,k,N)``.
+            If no shape is specified, a single (`N`-D) sample is returned.
+        method : 'ICDF, 'BoxMuller', 'BoxMuller2', optional
+            Sampling method used by Intel MKL. Can also be specified using
+            tokens np.random.ICDF, np.random.BOXMULLER, np.random.BOXMULLER2
+
+        Returns
+        -------
+        out : ndarray
+            The drawn samples, of shape *size*, if that was provided.  If not,
+            the shape is ``(N,)``.
+
+            In other words, each entry ``out[i,j,...,:]`` is an N-dimensional
+            value drawn from the distribution.
+
+        Notes
+        -----
+        The mean is a coordinate in N-dimensional space, which represents the
+        location where samples are most likely to be generated.  This is
+        analogous to the peak of the bell curve for the one-dimensional or
+        univariate normal distribution.
+
+        Covariance indicates the level to which two variables vary together.
+        From the multivariate normal distribution, we draw N-dimensional
+        samples, :math:`X = [x_1, x_2, ... x_N]`.  The covariance matrix
+        element :math:`C_{ij}` is the covariance of :math:`x_i` and :math:`x_j`.
+        The element :math:`C_{ii}` is the variance of :math:`x_i` (i.e. its
+        "spread").
+
+        Instead of specifying the full covariance matrix, popular
+        approximations include:
+
+          - Spherical covariance (*cov* is a multiple of the identity matrix)
+          - Diagonal covariance (*cov* has non-negative elements, and only on
+            the diagonal)
+
+        This geometrical property can be seen in two dimensions by plotting
+        generated data-points:
+
+        >>> mean = [0, 0]
+        >>> cov = [[1, 0], [0, 100]]  # diagonal covariance
+
+        Diagonal covariance means that points are oriented along x or y-axis:
+
+        >>> import matplotlib.pyplot as plt
+        >>> x, y = np.random.multivariate_normal(mean, cov, 5000).T
+        >>> plt.plot(x, y, 'x')
+        >>> plt.axis('equal')
+        >>> plt.show()
+
+        Note that the covariance matrix must be positive semidefinite (a.k.a.
+        nonnegative-definite). Otherwise, the behavior of this method is
+        undefined and backwards compatibility is not guaranteed.
+
+        References
+        ----------
+        .. [1] Papoulis, A., "Probability, Random Variables, and Stochastic
+               Processes," 3rd ed., New York: McGraw-Hill, 1991.
+        .. [2] Duda, R. O., Hart, P. E., and Stork, D. G., "Pattern
+               Classification," 2nd ed., New York: Wiley, 2001.
+
+        Examples
+        --------
+        >>> mean = (1, 2)
+        >>> cov = [[1, 0], [0, 1]]
+        >>> x = np.random.multivariate_normal(mean, cov, (3, 3))
+        >>> x.shape
+        (3, 3, 2)
+
+        The following is probably true, given that 0.6 is roughly twice the
+        standard deviation:
+
+        >>> list((x[0,0,:] - mean) < 0.6)
+        [True, True]
+
+        """
+        cdef ndarray resarr "arrayObject_resarr"
+        cdef ndarray marr "arrayObject_marr"
+        cdef ndarray tarr "arrayObject_tarr"
+        cdef double *res_data
+        cdef double *mean_data
+        cdef double *t_data
+        cdef npy_intp dim, n
+        cdef ch_st_enum storage_mode
+
+        # Check preconditions on arguments
+        marr = <ndarray>PyArray_FROM_OTF(mean, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+        tarr = <ndarray>PyArray_FROM_OTF(ch, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY)
+
+        if size is None:
+            shape = []
+        elif isinstance(size, (int, long, np.integer)):
+            shape = [size]
+        else:
+            shape = size
+
+        if marr.ndim != 1:
+               raise ValueError("mean must be 1 dimensional")
+        dim = marr.shape[0];
+        if (tarr.ndim == 2):
+            storage_mode = MATRIX
+            if (tarr.shape[0] != tarr.shape[1]):
+                   raise ValueError("ch must be a square lower triangular 2-dimensional array or a row-packed one-dimensional representation of such")
+            if dim != tarr.shape[0]:
+                   raise ValueError("mean and ch must have consistent shapes")
+        elif (tarr.ndim == 1):
+            if (tarr.shape[0] == dim):
+                storage_mode = DIAGONAL
+            elif (tarr.shape[0] == packed_cholesky_size(dim)):
+                storage_mode = PACKED
+            else:
+                raise ValueError("ch must be a square lower triangular 2-dimensional array or a row-packed one-dimensional representation of such")
+        else:
+            raise ValueError("ch must be a square lower triangular 2-dimensional array or a row-packed one-dimensional representation of such")
+
+        # Compute shape of output and create a matrix of independent
+        # standard normally distributed random numbers. The matrix has rows
+        # with the same length as mean and as many rows are necessary to
+        # form a matrix of shape final_shape.
+        final_shape = list(shape[:])
+        final_shape.append(int(dim))
+
+        resarr = <ndarray>np.empty(final_shape, np.float64)
+        res_data = <double*>PyArray_DATA(resarr)
+        mean_data = <double*>PyArray_DATA(marr)
+        t_data = <double*>PyArray_DATA(tarr)
+
+        n = PyArray_SIZE(resarr) / dim
+
+        method = choose_method(method, [ICDF, BOXMULLER2, BOXMULLER], _method_alias_dict_gaussian)
+        if (method is ICDF):
+            vrk_multinormal_vec_ICDF(self.internal_state, n, res_data, dim, mean_data, t_data, storage_mode)
+        elif (method is BOXMULLER2):
+            vrk_multinormal_vec_BM2(self.internal_state, n, res_data, dim, mean_data, t_data, storage_mode)
+        else:
+            vrk_multinormal_vec_BM1(self.internal_state, n, res_data, dim, mean_data, t_data, storage_mode)
+
+        return resarr
+
+    def multinomial(self, int n, object pvals, size=None):
+        """
+        multinomial(n, pvals, size=None, method='ICDF')
+
+        Draw samples from a multinomial distribution.
+
+        The multinomial distribution is a multivariate generalisation of the
+        binomial distribution.  Take an experiment with one of ``p``
+        possible outcomes.  An example of such an experiment is throwing a dice,
+        where the outcome can be 1 through 6.  Each sample drawn from the
+        distribution represents `n` such experiments.  Its values,
+        ``X_i = [X_0, X_1, ..., X_p]``, represent the number of times the
+        outcome was ``i``.
+
+        Parameters
+        ----------
+        n : int
+            Number of experiments.
+        pvals : sequence of floats, length p
+            Probabilities of each of the ``p`` different outcomes.  These
+            should sum to 1 (however, the last element is always assumed to
+            account for the remaining probability, as long as
+            ``sum(pvals[:-1]) <= 1)``.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+        method : 'ICDF, 'BoxMuller', 'BoxMuller2', optional
+            Sampling method used by Intel MKL. Can also be specified using
+            tokens np.random.ICDF, np.random.BOXMULLER, np.random.BOXMULLER2
+
+        Returns
+        -------
+        out : ndarray
+            The drawn samples, of shape *size*, if that was provided.  If not,
+            the shape is ``(N,)``.
+
+            In other words, each entry ``out[i,j,...,:]`` is an N-dimensional
+            value drawn from the distribution.
+
+        Examples
+        --------
+        Throw a dice 20 times:
+
+        >>> np.random.multinomial(20, [1/6.]*6, size=1)
+        array([[4, 1, 7, 5, 2, 1]])
+
+        It landed 4 times on 1, once on 2, etc.
+
+        Now, throw the dice 20 times, and 20 times again:
+
+        >>> np.random.multinomial(20, [1/6.]*6, size=2)
+        array([[3, 4, 3, 3, 4, 3],
+               [2, 4, 3, 4, 0, 7]])
+
+        For the first run, we threw 3 times 1, 4 times 2, etc.  For the second,
+        we threw 2 times 1, 4 times 2, etc.
+
+        A loaded die is more likely to land on number 6:
+
+        >>> np.random.multinomial(100, [1/7.]*5 + [2./7.])
+        array([11, 16, 14, 17, 16, 26])
+
+        The probability inputs should be normalized. As an implementation
+        detail, the value of the last entry is ignored and assumed to take
+        up any leftover probability mass, but this should not be relied on.
+        A biased coin which has twice as much weight on one side as on the
+        other should be sampled like so:
+
+        >>> np.random.multinomial(100, [1.0 / 3, 2.0 / 3])  # RIGHT
+        array([38, 62])
+
+        not like:
+
+        >>> np.random.multinomial(100, [1.0, 2.0])  # WRONG
+        array([100,   0])
+
+        """
+        cdef npy_intp d
+        cdef ndarray parr "arrayObject_parr", mnarr "arrayObject_mnarr"
+        cdef double *pix
+        cdef int *mnix
+        cdef npy_intp i, j, sz
+        cdef double Sum
+        cdef int dn
+
+        d = len(pvals)
+        parr = <ndarray>PyArray_ContiguousFromObject(pvals, NPY_DOUBLE, 1, 1)
+        pix = <double*>PyArray_DATA(parr)
+
+        if kahan_sum(pix, d-1) > (1.0 + 1e-12):
+            raise ValueError("sum(pvals[:-1]) > 1.0")
+
+        shape = _shape_from_size(size, d)
+
+        multin = np.zeros(shape, np.int32)
+        mnarr = <ndarray>multin
+        mnix = <int*>PyArray_DATA(mnarr)
+        sz = PyArray_SIZE(mnarr)
+        with self.lock, nogil, cython.cdivision(True):
+            i = 0
+            while i < sz:
+                Sum = 1.0
+                dn = n
+                for j from 0 <= j < d-1:
+#                    mnix[i+j] = vrk_binomial(self.internal_state, dn, pix[j]/Sum)
+                    vrk_binomial_vec(self.internal_state, 1, mnix + (i+j), dn, pix[j]/Sum)
+                    dn = dn - mnix[i+j]
+                    if dn <= 0:
+                        break
+                    Sum = Sum - pix[j]
+                if dn > 0:
+                    mnix[i+d-1] = dn
+
+                i = i + d
+
+        return multin
+
+
+    def dirichlet(self, object alpha, size=None):
+        """
+        dirichlet(alpha, size=None)
+
+        Draw samples from the Dirichlet distribution.
+
+        Draw `size` samples of dimension k from a Dirichlet distribution. A
+        Dirichlet-distributed random variable can be seen as a multivariate
+        generalization of a Beta distribution. Dirichlet pdf is the conjugate
+        prior of a multinomial in Bayesian inference.
+
+        Parameters
+        ----------
+        alpha : array
+            Parameter of the distribution (k dimension for sample of
+            dimension k).
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  Default is None, in which case a
+            single value is returned.
+
+        Returns
+        -------
+        samples : ndarray,
+            The drawn samples, of shape (size, alpha.ndim).
+
+        Notes
+        -----
+        .. math:: X \\approx \\prod_{i=1}^{k}{x^{\\alpha_i-1}_i}
+
+        Uses the following property for computation: for each dimension,
+        draw a random sample y_i from a standard gamma generator of shape
+        `alpha_i`, then
+        :math:`X = \\frac{1}{\\sum_{i=1}^k{y_i}} (y_1, \\ldots, y_n)` is
+        Dirichlet distributed.
+
+        References
+        ----------
+        .. [1] David McKay, "Information Theory, Inference and Learning
+               Algorithms," chapter 23,
+               http://www.inference.phy.cam.ac.uk/mackay/
+        .. [2] Wikipedia, "Dirichlet distribution",
+               http://en.wikipedia.org/wiki/Dirichlet_distribution
+
+        Examples
+        --------
+        Taking an example cited in Wikipedia, this distribution can be used if
+        one wanted to cut strings (each of initial length 1.0) into K pieces
+        with different lengths, where each piece had, on average, a designated
+        average length, but allowing some variation in the relative sizes of
+        the pieces.
+
+        >>> s = np.random.dirichlet((10, 5, 3), 20).transpose()
+
+        >>> plt.barh(range(20), s[0])
+        >>> plt.barh(range(20), s[1], left=s[0], color='g')
+        >>> plt.barh(range(20), s[2], left=s[0]+s[1], color='r')
+        >>> plt.title("Lengths of Strings")
+
+        """
+        #=================
+        # Pure python algo
+        #=================
+        #alpha   = N.atleast_1d(alpha)
+        #k       = alpha.size
+
+        #if n == 1:
+        #    val = N.zeros(k)
+        #    for i in range(k):
+        #        val[i]   = sgamma(alpha[i], n)
+        #    val /= N.sum(val)
+        #else:
+        #    val = N.zeros((k, n))
+        #    for i in range(k):
+        #        val[i]   = sgamma(alpha[i], n)
+        #    val /= N.sum(val, axis = 0)
+        #    val = val.T
+
+        #return val
+        cdef npy_intp   k
+        cdef npy_intp   totsize
+        cdef ndarray    alpha_arr, val_arr
+        cdef double     *alpha_data
+        cdef double     *val_data
+        cdef npy_intp   i, j
+        cdef double     invacc, acc
+        cdef broadcast  multi1, multi2
+
+        alpha_arr = <ndarray>PyArray_FROM_OTF(alpha, NPY_DOUBLE, NPY_ARRAY_ALIGNED);
+        if (alpha_arr.ndim != 1):
+            raise ValueError("Parameter alpha is not a vector")
+
+        k     = len(alpha)
+        shape = _shape_from_size(size, k)
+
+        diric    = self.standard_gamma(alpha_arr, shape)
+
+        val_arr  = <ndarray>diric
+        totsize = PyArray_SIZE(val_arr)
+
+        # Use of iterators is faster than calling PyArray_ContiguousFromObject and iterating in C
+        multi1 = PyArray_MultiIterNew(2, <void *>val_arr, <void *>alpha_arr);
+        multi2 = PyArray_MultiIterNew(2, <void *>val_arr, <void *>alpha_arr);
+
+        i = 0
+        with self.lock, nogil:
+            while i < totsize:
+                acc = 0.0
+                for j from 0 <= j < k:
+                    val_data = <double*> PyArray_MultiIter_DATA(multi1, 0)
+                    acc += val_data[0]
+                    PyArray_MultiIter_NEXTi(multi1, 0)
+                invacc = 1.0/acc;
+                for j from 0 <= j < k:
+                    val_data = <double*> PyArray_MultiIter_DATA(multi2, 0);
+                    val_data[0] *= invacc
+                    PyArray_MultiIter_NEXTi(multi2, 0)
+                i += k
+
+        return diric
+
+    # Shuffling and permutations:
+    def shuffle(self, object x):
+        """
+        shuffle(x)
+
+        Modify a sequence in-place by shuffling its contents.
+
+        Parameters
+        ----------
+        x : array_like
+            The array or list to be shuffled.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> arr = np.arange(10)
+        >>> np.random.shuffle(arr)
+        >>> arr
+        [1 7 5 2 9 4 3 6 0 8]
+
+        This function only shuffles the array along the first index of a
+        multi-dimensional array:
+
+        >>> arr = np.arange(9).reshape((3, 3))
+        >>> np.random.shuffle(arr)
+        >>> arr
+        array([[3, 4, 5],
+               [6, 7, 8],
+               [0, 1, 2]])
+
+        """
+        cdef:
+            npy_intp i, j, n = len(x), stride, itemsize
+            char* x_ptr
+            char* buf_ptr
+            cdef ndarray u "arrayObject_u"
+            cdef double *u_data
+
+        if (n == 0):
+            return
+
+        u = <ndarray>self.random_sample(n-1)
+        u_data = <double*>PyArray_DATA(u)
+
+        if type(x) is np.ndarray and x.ndim == 1 and x.size:
+            # Fast, statically typed path: shuffle the underlying buffer.
+            # Only for non-empty, 1d objects of class ndarray (subclasses such
+            # as MaskedArrays may not support this approach).
+            x_ptr = <char*><size_t>x.ctypes.data
+            stride = x.strides[0]
+            itemsize = x.dtype.itemsize
+            # As the array x could contain python objects we use a buffer
+            # of bytes for the swaps to avoid leaving one of the objects
+            # within the buffer and erroneously decrementing it's refcount
+            # when the function exits.
+            buf = np.empty(itemsize, dtype=np.int8) # GC'd at function exit
+            buf_ptr = <char*><size_t>buf.ctypes.data
+            with self.lock:
+                # We trick gcc into providing a specialized implementation for
+                # the most common case, yielding a ~33% performance improvement.
+                # Note that apparently, only one branch can ever be specialized.
+                if itemsize == sizeof(npy_intp):
+                    self._shuffle_raw(n, sizeof(npy_intp), stride, x_ptr, buf_ptr, u_data)
+                else:
+                    self._shuffle_raw(n, itemsize, stride, x_ptr, buf_ptr, u_data)
+        elif isinstance(x, np.ndarray) and x.ndim > 1 and x.size:
+            # Multidimensional ndarrays require a bounce buffer.
+            buf = np.empty_like(x[0])
+            with self.lock:
+                for i in reversed(range(1, n)):
+                    j = <npy_intp>floor( (i + 1) * u_data[i - 1])
+                    if (j < i):
+                        buf[...] = x[j]
+                        x[j] = x[i]
+                        x[i] = buf
+        else:
+            # Untyped path.
+            with self.lock:
+                for i in reversed(range(1, n)):
+                    j = <npy_intp>floor( (i + 1) * u_data[i - 1])
+                    x[i], x[j] = x[j], x[i]
+
+    cdef inline _shuffle_raw(self, npy_intp n, npy_intp itemsize,
+                             npy_intp stride, char* data, char* buf, double* udata):
+        cdef npy_intp i, j
+        for i in reversed(range(1, n)):
+            j = <npy_intp>floor( (i + 1) * udata[i - 1])
+            memcpy(buf, data + j * stride, itemsize)
+            memcpy(data + j * stride, data + i * stride, itemsize)
+            memcpy(data + i * stride, buf, itemsize)
+
+    def permutation(self, object x):
+        """
+        permutation(x)
+
+        Randomly permute a sequence, or return a permuted range.
+
+        If `x` is a multi-dimensional array, it is only shuffled along its
+        first index.
+
+        Parameters
+        ----------
+        x : int or array_like
+            If `x` is an integer, randomly permute ``np.arange(x)``.
+            If `x` is an array, make a copy and shuffle the elements
+            randomly.
+
+        Returns
+        -------
+        out : ndarray
+            Permuted sequence or array range.
+
+        Examples
+        --------
+        >>> np.random.permutation(10)
+        array([1, 7, 4, 3, 0, 9, 2, 5, 8, 6])
+
+        >>> np.random.permutation([1, 4, 9, 12, 15])
+        array([15,  1,  9,  4, 12])
+
+        >>> arr = np.arange(9).reshape((3, 3))
+        >>> np.random.permutation(arr)
+        array([[6, 7, 8],
+               [0, 1, 2],
+               [3, 4, 5]])
+
+        """
+        if isinstance(x, (int, long, np.integer)):
+            arr = np.arange(x)
+        else:
+            arr = np.array(x)
+        self.shuffle(arr)
+        return arr
+
+
+_rand = RandomState()
+seed = _rand.seed
+get_state = _rand.get_state
+set_state = _rand.set_state
+random_sample = _rand.random_sample
+choice = _rand.choice
+randint = _rand.randint
+bytes = _rand.bytes
+uniform = _rand.uniform
+rand = _rand.rand
+randn = _rand.randn
+random_integers = _rand.random_integers
+standard_normal = _rand.standard_normal
+normal = _rand.normal
+beta = _rand.beta
+exponential = _rand.exponential
+standard_exponential = _rand.standard_exponential
+standard_gamma = _rand.standard_gamma
+gamma = _rand.gamma
+f = _rand.f
+noncentral_f = _rand.noncentral_f
+chisquare = _rand.chisquare
+noncentral_chisquare = _rand.noncentral_chisquare
+standard_cauchy = _rand.standard_cauchy
+standard_t = _rand.standard_t
+vonmises = _rand.vonmises
+pareto = _rand.pareto
+weibull = _rand.weibull
+power = _rand.power
+laplace = _rand.laplace
+gumbel = _rand.gumbel
+logistic = _rand.logistic
+lognormal = _rand.lognormal
+rayleigh = _rand.rayleigh
+wald = _rand.wald
+triangular = _rand.triangular
+
+binomial = _rand.binomial
+negative_binomial = _rand.negative_binomial
+poisson = _rand.poisson
+zipf = _rand.zipf
+geometric = _rand.geometric
+hypergeometric = _rand.hypergeometric
+logseries = _rand.logseries
+
+multivariate_normal = _rand.multivariate_normal
+multinormal_cholesky = _rand.multinormal_cholesky
+multinomial = _rand.multinomial
+dirichlet = _rand.dirichlet
+
+shuffle = _rand.shuffle
+permutation = _rand.permutation

--- a/numpy/random_intel/mklrand/mklrand_py_helper.h
+++ b/numpy/random_intel/mklrand/mklrand_py_helper.h
@@ -1,0 +1,41 @@
+#ifndef _MKLRAND_PY_HELPER_H_
+#define _MKLRAND_PY_HELPER_H_
+
+#include <Python.h>
+
+static PyObject *empty_py_bytes(npy_intp length, void **bytesVec)
+{
+    PyObject *b;
+#if PY_MAJOR_VERSION >= 3
+    b = PyBytes_FromStringAndSize(NULL, length);
+    if (b) {
+        *bytesVec = PyBytes_AS_STRING(b);
+    }
+#else
+    b = PyString_FromStringAndSize(NULL, length);
+    if (b) {
+        *bytesVec = PyString_AS_STRING(b);
+    }
+#endif
+    return b;
+}
+
+static char *py_bytes_DataPtr(PyObject *b)
+{
+#if PY_MAJOR_VERSION >= 3
+    return PyBytes_AS_STRING(b);
+#else
+    return PyString_AS_STRING(b);
+#endif
+}
+
+static int is_bytes_object(PyObject *b)
+{
+#if PY_MAJOR_VERSION >= 3
+    return PyBytes_Check(b);
+#else
+    return PyString_Check(b);
+#endif
+}
+
+#endif /* _MKLRAND_PY_HELPER_H_ */

--- a/numpy/random_intel/mklrand/numpy.pxd
+++ b/numpy/random_intel/mklrand/numpy.pxd
@@ -1,0 +1,152 @@
+# :Author:    Travis Oliphant
+
+cdef extern from "numpy/npy_no_deprecated_api.h": pass
+
+cdef extern from "numpy/arrayobject.h":
+
+    cdef enum NPY_TYPES:
+        NPY_BOOL
+        NPY_BYTE
+        NPY_UBYTE
+        NPY_SHORT
+        NPY_USHORT
+        NPY_INT
+        NPY_UINT
+        NPY_LONG
+        NPY_ULONG
+        NPY_LONGLONG
+        NPY_ULONGLONG
+        NPY_FLOAT
+        NPY_DOUBLE
+        NPY_LONGDOUBLE
+        NPY_CFLOAT
+        NPY_CDOUBLE
+        NPY_CLONGDOUBLE
+        NPY_OBJECT
+        NPY_STRING
+        NPY_UNICODE
+        NPY_VOID
+        NPY_NTYPES
+        NPY_NOTYPE
+
+    cdef enum requirements:
+        NPY_ARRAY_C_CONTIGUOUS
+        NPY_ARRAY_F_CONTIGUOUS
+        NPY_ARRAY_OWNDATA
+        NPY_ARRAY_FORCECAST
+        NPY_ARRAY_ENSURECOPY
+        NPY_ARRAY_ENSUREARRAY
+        NPY_ARRAY_ELEMENTSTRIDES
+        NPY_ARRAY_ALIGNED
+        NPY_ARRAY_NOTSWAPPED
+        NPY_ARRAY_WRITEABLE
+        NPY_ARRAY_UPDATEIFCOPY
+        NPY_ARR_HAS_DESCR
+
+        NPY_ARRAY_BEHAVED
+        NPY_ARRAY_BEHAVED_NS
+        NPY_ARRAY_CARRAY
+        NPY_ARRAY_CARRAY_RO
+        NPY_ARRAY_FARRAY
+        NPY_ARRAY_FARRAY_RO
+        NPY_ARRAY_DEFAULT
+
+        NPY_ARRAY_IN_ARRAY
+        NPY_ARRAY_OUT_ARRAY
+        NPY_ARRAY_INOUT_ARRAY
+        NPY_ARRAY_IN_FARRAY
+        NPY_ARRAY_OUT_FARRAY
+        NPY_ARRAY_INOUT_FARRAY
+
+        NPY_ARRAY_UPDATE_ALL
+
+    cdef enum defines:
+        NPY_MAXDIMS
+
+    ctypedef struct npy_cdouble:
+        double real
+        double imag
+
+    ctypedef struct npy_cfloat:
+        double real
+        double imag
+
+    ctypedef int npy_int
+    ctypedef int npy_intp
+    ctypedef int npy_int64
+    ctypedef int npy_uint64
+    ctypedef int npy_int32
+    ctypedef int npy_uint32
+    ctypedef int npy_int16
+    ctypedef int npy_uint16
+    ctypedef int npy_int8
+    ctypedef int npy_uint8
+    ctypedef int npy_bool
+
+    ctypedef extern class numpy.dtype [object PyArray_Descr]: pass
+
+    ctypedef extern class numpy.ndarray [object PyArrayObject]: pass
+
+    ctypedef extern class numpy.flatiter [object PyArrayIterObject]:
+        cdef int  nd_m1
+        cdef npy_intp index, size
+        cdef ndarray ao
+        cdef char *dataptr
+
+    ctypedef extern class numpy.broadcast [object PyArrayMultiIterObject]:
+        cdef int numiter
+        cdef npy_intp size, index
+        cdef int nd
+        cdef npy_intp *dimensions
+        cdef void **iters
+
+    object PyArray_ZEROS(int ndims, npy_intp* dims, NPY_TYPES type_num, int fortran)
+    object PyArray_EMPTY(int ndims, npy_intp* dims, NPY_TYPES type_num, int fortran)
+    dtype PyArray_DescrFromTypeNum(NPY_TYPES type_num)
+    object PyArray_SimpleNew(int ndims, npy_intp* dims, NPY_TYPES type_num)
+    int PyArray_Check(object obj)
+    object PyArray_ContiguousFromAny(object obj, NPY_TYPES type,
+        int mindim, int maxdim)
+    object PyArray_ContiguousFromObject(object obj, NPY_TYPES type,
+        int mindim, int maxdim)
+    npy_intp PyArray_SIZE(ndarray arr)
+    npy_intp PyArray_NBYTES(ndarray arr)
+    object PyArray_FromAny(object obj, dtype newtype, int mindim, int maxdim,
+                            int requirements, object context)
+    object PyArray_FROMANY(object obj, NPY_TYPES type_num, int min,
+                           int max, int requirements)
+    object PyArray_NewFromDescr(object subtype, dtype newtype, int nd,
+                                npy_intp* dims, npy_intp* strides, void* data,
+                                int flags, object parent)
+
+    object PyArray_FROM_OTF(object obj, NPY_TYPES type, int flags)
+    object PyArray_EnsureArray(object)
+
+    object PyArray_MultiIterNew(int n, ...)
+
+    char *PyArray_MultiIter_DATA(broadcast multi, int i) nogil
+    void PyArray_MultiIter_NEXTi(broadcast multi, int i) nogil
+    void PyArray_MultiIter_NEXT(broadcast multi) nogil
+
+    object PyArray_IterNew(object arr)
+    void PyArray_ITER_NEXT(flatiter it) nogil
+
+    dtype PyArray_DescrFromType(int)
+
+    void import_array()
+
+# include functions that were once macros in the new api
+
+    int PyArray_NDIM(ndarray arr)
+    char * PyArray_DATA(ndarray arr)
+    npy_intp * PyArray_DIMS(ndarray arr)
+    npy_intp * PyArray_STRIDES(ndarray arr)
+    npy_intp PyArray_DIM(ndarray arr, int idim)
+    npy_intp PyArray_STRIDE(ndarray arr, int istride)
+    object PyArray_BASE(ndarray arr)
+    dtype PyArray_DESCR(ndarray arr)
+    int PyArray_FLAGS(ndarray arr)
+    npy_intp PyArray_ITEMSIZE(ndarray arr)
+    int PyArray_TYPE(ndarray arr)
+    int PyArray_CHKFLAGS(ndarray arr, int flags)
+    object PyArray_GETITEM(ndarray arr, char *itemptr)

--- a/numpy/random_intel/mklrand/randomkit.c
+++ b/numpy/random_intel/mklrand/randomkit.c
@@ -1,0 +1,426 @@
+/* Random kit 1.3 */
+
+/*
+ * Copyright (c) 2003-2005, Jean-Sebastien Roy (js@jeannot.org)
+ *
+ * The vrk_random and vrk_seed functions algorithms and the original design of
+ * the Mersenne Twister RNG:
+ *
+ *   Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ *   3. The names of its contributors may not be used to endorse or promote
+ *   products derived from this software without specific prior written
+ *   permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ *   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Original algorithm for the implementation of vrk_interval function from
+ * Richard J. Wagner's implementation of the Mersenne Twister RNG, optimised by
+ * Magnus Jonsson.
+ *
+ * Constants used in the vrk_double implementation by Isaku Wada.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* static char const rcsid[] =
+  "@(#) $Jeannot: randomkit.c,v 1.28 2005/07/21 22:14:09 js Exp $"; */
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+#include <assert.h>
+
+#ifdef _WIN32
+/*
+ * Windows
+ * XXX: we have to use this ugly defined(__GNUC__) because it is not easy to
+ * detect the compiler used in distutils itself
+ */
+#if (defined(__GNUC__) && defined(NPY_NEEDS_MINGW_TIME_WORKAROUND))
+
+/*
+ * FIXME: ideally, we should set this to the real version of MSVCRT. We need
+ * something higher than 0x601 to enable _ftime64 and co
+ */
+#define __MSVCRT_VERSION__ 0x0700
+#include <time.h>
+#include <sys/timeb.h>
+
+/*
+ * mingw msvcr lib import wrongly export _ftime, which does not exist in the
+ * actual msvc runtime for version >= 8; we make it an alias to _ftime64, which
+ * is available in those versions of the runtime
+ */
+#define _FTIME(x) _ftime64((x))
+#else
+#include <time.h>
+#include <sys/timeb.h>
+#define _FTIME(x) _ftime((x))
+#endif
+
+#ifndef RK_NO_WINCRYPT
+/* Windows crypto */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0400
+#endif
+#include <windows.h>
+#include <wincrypt.h>
+#endif
+
+#else
+/* Unix */
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+#include "randomkit.h"
+
+#ifndef RK_DEV_URANDOM
+#define RK_DEV_URANDOM "/dev/urandom"
+#endif
+
+#ifndef RK_DEV_RANDOM
+#define RK_DEV_RANDOM "/dev/random"
+#endif
+
+char *vrk_strerror[RK_ERR_MAX] =
+{
+    "no error",
+    "random device unvavailable"
+};
+
+/* static functions */
+static unsigned long vrk_hash(unsigned long key);
+
+void
+vrk_dealloc_stream(vrk_state *state)
+{
+    VSLStreamStatePtr stream = state->stream;
+
+    if(stream) {
+        vslDeleteStream(&stream);
+    }
+}
+
+const MKL_INT brng_list[BRNG_KINDS] = {
+    VSL_BRNG_MT19937,
+    VSL_BRNG_SFMT19937,
+    VSL_BRNG_WH,
+    VSL_BRNG_MT2203,
+    VSL_BRNG_MCG31,
+    VSL_BRNG_R250,
+    VSL_BRNG_MRG32K3A,
+    VSL_BRNG_MCG59,
+    VSL_BRNG_PHILOX4X32X10
+};
+
+int vrk_get_brng_mkl(vrk_state *state)
+{
+    int i, mkl_brng_id = vslGetStreamStateBrng(state->stream);
+
+    if ((VSL_BRNG_MT2203 <= mkl_brng_id) && (mkl_brng_id < VSL_BRNG_MT2203 + 6024))
+        mkl_brng_id = VSL_BRNG_MT2203;
+    else if ((VSL_BRNG_WH <= mkl_brng_id ) && (mkl_brng_id < VSL_BRNG_WH + 273))
+        mkl_brng_id = VSL_BRNG_WH;
+
+    for(i = 0; i < BRNG_KINDS; i++)
+        if(mkl_brng_id == brng_list[i])
+            return i;
+
+    return -1;
+}
+
+void vrk_seed_mkl(vrk_state *state, const unsigned int seed, const vrk_brng_t brng, const unsigned int stream_id)
+{
+    VSLStreamStatePtr stream_loc;
+    int err = VSL_STATUS_OK;
+    const MKL_INT mkl_brng = brng_list[brng];
+
+    if(NULL == state->stream) {
+        err = vslNewStream(&(state->stream), mkl_brng + stream_id, seed);
+
+        assert(err == VSL_STATUS_OK);
+    } else {
+        err = vslNewStream(&stream_loc, mkl_brng + stream_id, seed);
+        assert(err == VSL_STATUS_OK);
+
+        err = vslDeleteStream(&(state->stream));
+        assert(err == VSL_STATUS_OK);
+
+        state->stream = stream_loc;
+    }
+
+}
+
+void
+vrk_seed_mkl_array(vrk_state *state, const unsigned int seed_vec[], const int seed_len,
+    const vrk_brng_t brng, const unsigned int stream_id)
+{
+    VSLStreamStatePtr stream_loc;
+    int err = VSL_STATUS_OK;
+    const MKL_INT mkl_brng = brng_list[brng];
+
+    if(NULL == state->stream) {
+
+        err = vslNewStreamEx(&(state->stream), mkl_brng + stream_id, (MKL_INT) seed_len, seed_vec);
+
+        assert(err == VSL_STATUS_OK);
+
+    } else {
+
+        err = vslNewStreamEx(&stream_loc, mkl_brng + stream_id, (MKL_INT) seed_len, seed_vec);
+        if(err == VSL_STATUS_OK) {
+
+            err = vslDeleteStream(&(state->stream));
+            assert(err == VSL_STATUS_OK);
+
+            state->stream = stream_loc;
+
+         }
+
+    }
+}
+
+vrk_error
+vrk_randomseed_mkl(vrk_state *state, const vrk_brng_t brng, const unsigned int stream_id)
+{
+#ifndef _WIN32
+    struct timeval tv;
+#else
+    struct _timeb  tv;
+#endif
+    int i, no_err;
+    unsigned int *seed_array;
+    size_t buf_size = 624;
+    size_t seed_array_len = buf_size*sizeof(unsigned int);
+
+    seed_array =  (unsigned int *) malloc(seed_array_len);
+    no_err = vrk_devfill(seed_array, seed_array_len, 0) == RK_NOERR;
+
+    if (no_err) {
+        /* ensures non-zero seed */
+        seed_array[0] |= 0x80000000UL;
+        vrk_seed_mkl_array(state, seed_array, buf_size, brng, stream_id);
+        free(seed_array);
+
+        return RK_NOERR;
+    } else {
+        free(seed_array);
+    }
+
+#ifndef _WIN32
+    gettimeofday(&tv, NULL);
+    vrk_seed_mkl(state, vrk_hash(getpid()) ^ vrk_hash(tv.tv_sec) ^ vrk_hash(tv.tv_usec)
+            ^ vrk_hash(clock()), brng, stream_id);
+#else
+    _FTIME(&tv);
+    vrk_seed_mkl(state, vrk_hash(tv.time) ^ vrk_hash(tv.millitm) ^ vrk_hash(clock()), brng, stream_id);
+#endif
+
+    return RK_ENODEV;
+}
+
+/*
+ *  Python needs this to determine the amount memory to allocate for the buffer
+ */
+int vrk_get_stream_size(vrk_state *state)
+{
+    return vslGetStreamSize(state->stream);
+}
+
+void
+vrk_get_state_mkl(vrk_state *state, char * buf)
+{
+    int err = vslSaveStreamM(state->stream, buf);
+
+    assert(err == VSL_STATUS_OK);
+
+}
+
+int
+vrk_set_state_mkl(vrk_state *state, char * buf)
+{
+    int err = vslLoadStreamM(&(state->stream), buf);
+
+    return (err == VSL_STATUS_OK) ? 0 : 1;
+}
+
+int
+vrk_leapfrog_stream_mkl(vrk_state *state, const MKL_INT k, const MKL_INT nstreams)
+{
+    int err;
+
+    err = vslLeapfrogStream(state->stream, k, nstreams);
+
+    switch(err) {
+        case VSL_STATUS_OK:
+            return 0;
+        case VSL_RNG_ERROR_LEAPFROG_UNSUPPORTED:
+            return 1;
+        default:
+            return -1;
+    }
+}
+
+int
+vrk_skipahead_stream_mkl(vrk_state *state, const long long int nskip)
+{
+    int err;
+
+    err = vslSkipAheadStream(state->stream, nskip);
+
+    switch(err) {
+        case VSL_STATUS_OK:
+            return 0;
+        case VSL_RNG_ERROR_SKIPAHEAD_UNSUPPORTED:
+            return 1;
+        default:
+            return -1;
+    }
+}
+
+
+/* Thomas Wang 32 bits integer hash function */
+static unsigned long
+vrk_hash(unsigned long key)
+{
+    key += ~(key << 15);
+    key ^=  (key >> 10);
+    key +=  (key << 3);
+    key ^=  (key >> 6);
+    key += ~(key << 11);
+    key ^=  (key >> 16);
+    return key;
+}
+
+
+void
+vrk_random_vec(vrk_state *state, const int len, unsigned int *res)
+{
+    viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD, state->stream, len, res);
+}
+
+
+void
+vrk_fill(void *buffer, size_t size, vrk_state *state)
+{
+    unsigned int r;
+    unsigned char *buf = buffer;
+    int err, len;
+
+    /* len = size / 4 */
+    len = (size >> 2);
+    err = viRngUniformBits32(VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, len, (unsigned int *) buf);
+    assert(err == VSL_STATUS_OK);
+
+    /* size = size % 4 */
+    size &= 0x03;
+    if (!size) {
+        return;
+    }
+
+    buf += (len << 2);
+    err = viRngUniformBits32(VSL_RNG_METHOD_UNIFORMBITS32_STD, state->stream, 1, &r);
+    assert(err == VSL_STATUS_OK);
+
+    for (; size; r >>= 8, size --) {
+        *(buf++) = (unsigned char)(r & 0xFF);
+    }
+}
+
+vrk_error
+vrk_devfill(void *buffer, size_t size, int strong)
+{
+#ifndef _WIN32
+    FILE *rfile;
+    int done;
+
+    if (strong) {
+        rfile = fopen(RK_DEV_RANDOM, "rb");
+    }
+    else {
+        rfile = fopen(RK_DEV_URANDOM, "rb");
+    }
+    if (rfile == NULL) {
+        return RK_ENODEV;
+    }
+    done = fread(buffer, size, 1, rfile);
+    fclose(rfile);
+    if (done) {
+        return RK_NOERR;
+    }
+#else
+
+#ifndef RK_NO_WINCRYPT
+    HCRYPTPROV hCryptProv;
+    BOOL done;
+
+    if (!CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL,
+            CRYPT_VERIFYCONTEXT) || !hCryptProv) {
+        return RK_ENODEV;
+    }
+    done = CryptGenRandom(hCryptProv, size, (unsigned char *)buffer);
+    CryptReleaseContext(hCryptProv, 0);
+    if (done) {
+        return RK_NOERR;
+    }
+#endif
+
+#endif
+    return RK_ENODEV;
+}
+
+vrk_error
+vrk_altfill(void *buffer, size_t size, int strong, vrk_state *state)
+{
+    vrk_error err;
+
+    err = vrk_devfill(buffer, size, strong);
+    if (err) {
+        vrk_fill(buffer, size, state);
+    }
+    return err;
+}

--- a/numpy/random_intel/mklrand/randomkit.h
+++ b/numpy/random_intel/mklrand/randomkit.h
@@ -1,0 +1,137 @@
+/* Random kit 1.3 */
+
+/*
+ * Copyright (c) 2003-2005, Jean-Sebastien Roy (js@jeannot.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* @(#) $Jeannot: randomkit.h,v 1.24 2005/07/21 22:14:09 js Exp $ */
+
+
+/*
+ * Useful macro:
+ *  RK_DEV_RANDOM: the device used for random seeding.
+ *                 defaults to "/dev/urandom"
+ */
+
+#include <stddef.h>
+#include "mkl_vsl.h"
+#include "numpy/npy_common.h"
+
+#ifndef _I_RANDOMKIT_
+#define _I_RANDOMKIT_
+
+typedef struct vrk_state_
+{
+    VSLStreamStatePtr stream;
+} vrk_state;
+
+typedef enum {
+    RK_NOERR = 0, /* no error */
+    RK_ENODEV = 1, /* no RK_DEV_RANDOM device */
+    RK_ERR_MAX = 2
+} vrk_error;
+
+/* if changing this, also adjust brng_list[BRNG_KINDS] in randomkit.c */
+#define BRNG_KINDS 9
+
+typedef enum {
+    MT19937       = 0,
+    SFMT19937     = 1,
+    WH            = 2,
+    MT2203        = 3,
+    MCG31         = 4,
+    R250          = 5,
+    MRG32K3A      = 6,
+    MCG59         = 7,
+    PHILOX4X32X10 = 8
+} vrk_brng_t;
+
+
+/* error strings */
+extern char *vrk_strerror[RK_ERR_MAX];
+
+/* Maximum generated random value */
+#define RK_MAX 0xFFFFFFFFUL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize the RNG state using the given seed.
+ */
+
+
+/*
+ * Initialize the RNG state using a random seed.
+ * Uses /dev/random or, when unavailable, the clock (see randomkit.c).
+ * Returns RK_NOERR when no errors occurs.
+ * Returns RK_ENODEV when the use of RK_DEV_RANDOM failed (for example because
+ * there is no such device). In this case, the RNG was initialized using the
+ * clock.
+ */
+
+/*
+ * Initialize the RNG state using the given seed.
+ */
+extern void vrk_dealloc_stream(vrk_state *state);
+extern void vrk_seed_mkl(vrk_state *state, const unsigned int seed, const vrk_brng_t brng, const unsigned int stream_id);
+extern void vrk_seed_mkl_array(vrk_state *state, const unsigned int *seed_vec,
+    const int seed_len, const vrk_brng_t brng, const unsigned int stream_id);
+extern vrk_error vrk_randomseed_mkl(vrk_state *state, const vrk_brng_t brng, const unsigned int stream_id);
+extern int vrk_get_stream_size(vrk_state *state);
+extern void vrk_get_state_mkl(vrk_state *state, char * buf);
+extern int vrk_set_state_mkl(vrk_state *state, char * buf);
+extern int vrk_get_brng_mkl(vrk_state *state);
+
+extern int vrk_leapfrog_stream_mkl(vrk_state *state, const int k, const int nstreams);
+extern int vrk_skipahead_stream_mkl(vrk_state *state, const long long int nskip);
+
+/*
+ * fill the buffer with size random bytes
+ */
+extern void vrk_fill(void *buffer, size_t size, vrk_state *state);
+
+/*
+ * fill the buffer with randombytes from the random device
+ * Returns RK_ENODEV if the device is unavailable, or RK_NOERR if it is
+ * On Unix, if strong is defined, RK_DEV_RANDOM is used. If not, RK_DEV_URANDOM
+ * is used instead. This parameter has no effect on Windows.
+ * Warning: on most unixes RK_DEV_RANDOM will wait for enough entropy to answer
+ * which can take a very long time on quiet systems.
+ */
+extern vrk_error vrk_devfill(void *buffer, size_t size, int strong);
+
+/*
+ * fill the buffer using vrk_devfill if the random device is available and using
+ * vrk_fill if is is not
+ * parameters have the same meaning as vrk_fill and vrk_devfill
+ * Returns RK_ENODEV if the device is unavailable, or RK_NOERR if it is
+ */
+extern vrk_error vrk_altfill(void *buffer, size_t size, int strong,
+                            vrk_state *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _I_RANDOMKIT_ */

--- a/numpy/random_intel/setup.py
+++ b/numpy/random_intel/setup.py
@@ -1,0 +1,73 @@
+from __future__ import division, print_function
+
+from os.path import join, split, dirname
+import sys
+from distutils.msvccompiler import get_build_version as get_msvc_build_version
+
+
+def needs_mingw_ftime_workaround():
+    # We need the mingw workaround for _ftime if the msvc runtime version is
+    # 7.1 or above and we build with mingw ...
+    # ... but we can't easily detect compiler version outside distutils command
+    # context, so we will need to detect in randomkit whether we build with gcc
+    msver = get_msvc_build_version()
+    if msver and msver >= 8:
+        return True
+
+    return False
+
+
+def configuration(parent_package='',top_path=None):
+    from numpy.distutils.misc_util import Configuration, get_mathlibs
+    from numpy.distutils.system_info import get_info
+    config = Configuration('random_intel', parent_package, top_path)
+
+    if not get_info('mkl'):
+        return config
+
+    def generate_libraries(ext, build_dir):
+        libs = get_mathlibs()
+        if sys.platform == 'win32':
+            libs.append('Advapi32')
+        ext.libraries.extend(libs)
+        return None
+
+    # enable unix large file support on 32 bit systems
+    # (64 bit off_t, lseek -> lseek64 etc.)
+    defs = [('_FILE_OFFSET_BITS', '64'),
+            ('_LARGEFILE_SOURCE', '1'),
+            ('_LARGEFILE64_SOURCE', '1')]
+    if needs_mingw_ftime_workaround():
+        defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))
+
+    libs = ['mkl_rt', 'mkl_dists']
+    # Configure mklrand
+    Q = '/Q' if sys.platform.startswith('win') or sys.platform == 'cygwin' else '-'
+    config.add_library('mkl_dists',
+                         sources=join('mklrand', 'mkl_distributions.cpp'),
+                         libraries=libs,
+                         extra_compiler_args=[Q + 'std=c++11'],
+                         depends=[join('mklrand', '*.h'),],
+                         define_macros=defs,
+                         )
+
+    config.add_extension('mklrand',
+                         sources=[join('mklrand', x) for x in
+                                  ['mklrand.c', 'randomkit.c']]+[generate_libraries],
+                         libraries=libs,
+                         depends=[join('mklrand', '*.h'),
+                                  join('mklrand', '*.pyx'),
+                                  join('mklrand', '*.pxi'),],
+                         define_macros=defs,
+                         )
+
+    config.add_data_files(('.', join('mklrand', 'randomkit.h')))
+    config.add_data_files(('.', join('mklrand', 'mkl_distributions.h')))
+    config.add_data_dir('tests')
+
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(configuration=configuration)

--- a/numpy/random_intel/tests/test_random.py
+++ b/numpy/random_intel/tests/test_random.py
@@ -1,0 +1,916 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from numpy.testing import (
+        TestCase, run_module_suite, assert_, assert_raises, assert_equal,
+        assert_warns)
+from numpy import random_intel as rnd
+from numpy.compat import asbytes
+import sys
+import warnings
+
+
+class TestSeed_Intel(TestCase):
+    def test_scalar(self):
+        evs_zero_seed = {
+            'MT19937' : 844, 'SFMT19937' : 857,
+            'WH' : 0,        'MT2203' : 890,
+            'MCG31' : 0,     'R250' : 229,
+            'MRG32K3A' : 0,  'MCG59' : 0      }
+        for brng_algo in evs_zero_seed:
+            s = rnd.RandomState(0, brng = brng_algo)
+            assert_equal(s.get_state()[0], brng_algo)
+            assert_equal(s.randint(1000), evs_zero_seed[brng_algo])
+        evs_max_seed = {
+            'MT19937' : 635,  'SFMT19937' : 25,
+            'WH' : 100,       'MT2203' : 527,
+            'MCG31' : 0,      'R250' : 229,
+            'MRG32K3A' : 961, 'MCG59' : 0     }
+        for brng_algo in evs_max_seed:
+            s = rnd.RandomState(4294967295, brng = brng_algo)
+            assert_equal(s.get_state()[0], brng_algo)
+            assert_equal(s.randint(1000), evs_max_seed[brng_algo])
+
+    def test_array(self):
+        s = rnd.RandomState(range(10), brng='MT19937')
+        assert_equal(s.randint(1000), 410)
+        s = rnd.RandomState(np.arange(10), brng='MT19937')
+        assert_equal(s.randint(1000), 410)
+        s = rnd.RandomState([0], brng='MT19937')
+        assert_equal(s.randint(1000), 844)
+        s = rnd.RandomState([4294967295], brng='MT19937')
+        assert_equal(s.randint(1000), 635)
+
+    def test_invalid_scalar(self):
+        # seed must be an unsigned 32 bit integers
+        assert_raises(TypeError, rnd.RandomState, -0.5)
+        assert_raises(ValueError, rnd.RandomState, -1)
+
+    def test_invalid_array(self):
+        # seed must be an unsigned 32 bit integers
+        assert_raises(TypeError, rnd.RandomState, [-0.5])
+        assert_raises(ValueError, rnd.RandomState, [-1])
+        assert_raises(ValueError, rnd.RandomState, [4294967296])
+        assert_raises(ValueError, rnd.RandomState, [1, 2, 4294967296])
+        assert_raises(ValueError, rnd.RandomState, [1, -2, 4294967296])
+
+class TestBinomial_Intel(TestCase):
+    def test_n_zero(self):
+        # Tests the corner case of n == 0 for the binomial distribution.
+        # binomial(0, p) should be zero for any p in [0, 1].
+        # This test addresses issue #3480.
+        zeros = np.zeros(2, dtype='int')
+        for p in [0, .5, 1]:
+            assert_(rnd.binomial(0, p) == 0)
+            np.testing.assert_array_equal(rnd.binomial(zeros, p), zeros)
+
+    def test_p_is_nan(self):
+        # Issue #4571.
+        assert_raises(ValueError, rnd.binomial, 1, np.nan)
+
+
+class TestMultinomial_Intel(TestCase):
+    def test_basic(self):
+        rnd.multinomial(100, [0.2, 0.8])
+
+    def test_zero_probability(self):
+        rnd.multinomial(100, [0.2, 0.8, 0.0, 0.0, 0.0])
+
+    def test_int_negative_interval(self):
+        assert_(-5 <= rnd.randint(-5, -1) < -1)
+        x = rnd.randint(-5, -1, 5)
+        assert_(np.all(-5 <= x))
+        assert_(np.all(x < -1))
+
+    def test_size(self):
+        # gh-3173
+        p = [0.5, 0.5]
+        assert_equal(rnd.multinomial(1, p, np.uint32(1)).shape, (1, 2))
+        assert_equal(rnd.multinomial(1, p, np.uint32(1)).shape, (1, 2))
+        assert_equal(rnd.multinomial(1, p, np.uint32(1)).shape, (1, 2))
+        assert_equal(rnd.multinomial(1, p, [2, 2]).shape, (2, 2, 2))
+        assert_equal(rnd.multinomial(1, p, (2, 2)).shape, (2, 2, 2))
+        assert_equal(rnd.multinomial(1, p, np.array((2, 2))).shape,
+                     (2, 2, 2))
+
+        assert_raises(TypeError, rnd.multinomial, 1, p,
+                      np.float(1))
+
+
+class TestSetState_Intel(TestCase):
+    def setUp(self):
+        self.seed = 1234567890
+        self.prng = rnd.RandomState(self.seed)
+        self.state = self.prng.get_state()
+
+    def test_basic(self):
+        old = self.prng.tomaxint(16)
+        self.prng.set_state(self.state)
+        new = self.prng.tomaxint(16)
+        assert_(np.all(old == new))
+
+    def test_gaussian_reset(self):
+        # Make sure the cached every-other-Gaussian is reset.
+        old = self.prng.standard_normal(size=3)
+        self.prng.set_state(self.state)
+        new = self.prng.standard_normal(size=3)
+        assert_(np.all(old == new))
+
+    def test_gaussian_reset_in_media_res(self):
+        # When the state is saved with a cached Gaussian, make sure the
+        # cached Gaussian is restored.
+        self.prng.standard_normal()
+        state = self.prng.get_state()
+        old = self.prng.standard_normal(size=3)
+        self.prng.set_state(state)
+        new = self.prng.standard_normal(size=3)
+        assert_(np.all(old == new))
+
+    def test_backwards_compatibility(self):
+        # Make sure we can accept old state tuples that do not have the
+        # cached Gaussian value.
+        if len(self.state) == 5:
+            old_state = self.state[:-2]
+            x1 = self.prng.standard_normal(size=16)
+            self.prng.set_state(old_state)
+            x2 = self.prng.standard_normal(size=16)
+            self.prng.set_state(self.state)
+            x3 = self.prng.standard_normal(size=16)
+            assert_(np.all(x1 == x2))
+            assert_(np.all(x1 == x3))
+
+    def test_negative_binomial(self):
+        # Ensure that the negative binomial results take floating point
+        # arguments without truncation.
+        self.prng.negative_binomial(0.5, 0.5)
+
+class TestRandint_Intel(TestCase):
+
+    rfunc = rnd.randint
+
+    # valid integer/boolean types
+    itype = [np.bool_, np.int8, np.uint8, np.int16, np.uint16,
+             np.int32, np.uint32, np.int64, np.uint64]
+
+    def test_unsupported_type(self):
+        assert_raises(TypeError, self.rfunc, 1, dtype=np.float)
+
+    def test_bounds_checking(self):
+        for dt in self.itype:
+            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
+            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
+            assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
+            assert_raises(ValueError, self.rfunc, 1, 0, dtype=dt)
+
+    def test_rng_zero_and_extremes(self):
+        for dt in self.itype:
+            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            tgt = ubnd - 1
+            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            tgt = lbnd
+            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            tgt = (lbnd + ubnd)//2
+            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+
+    def test_in_bounds_fuzz(self):
+        # Don't use fixed seed
+        rnd.seed()
+        for dt in self.itype[1:]:
+            for ubnd in [4, 8, 16]:
+                vals = self.rfunc(2, ubnd, size=2**16, dtype=dt)
+                assert_(vals.max() < ubnd)
+                assert_(vals.min() >= 2)
+        vals = self.rfunc(0, 2, size=2**16, dtype=np.bool)
+        assert_(vals.max() < 2)
+        assert_(vals.min() >= 0)
+
+    def test_repeatability(self):
+        import hashlib
+        # We use a md5 hash of generated sequences of 1000 samples
+        # in the range [0, 6) for all but np.bool, where the range
+        # is [0, 2). Hashes are for little endian numbers.
+        tgt = {'bool': '4fee98a6885457da67c39331a9ec336f',
+               'int16': '80a5ff69c315ab6f80b03da1d570b656',
+               'int32': '15a3c379b6c7b0f296b162194eab68bc',
+               'int64': 'ea9875f9334c2775b00d4976b85a1458',
+               'int8': '0f56333af47de94930c799806158a274',
+               'uint16': '80a5ff69c315ab6f80b03da1d570b656',
+               'uint32': '15a3c379b6c7b0f296b162194eab68bc',
+               'uint64': 'ea9875f9334c2775b00d4976b85a1458',
+               'uint8': '0f56333af47de94930c799806158a274'}
+
+        for dt in self.itype[1:]:
+            rnd.seed(1234, brng='MT19937')
+
+            # view as little endian for hash
+            if sys.byteorder == 'little':
+                val = self.rfunc(0, 6, size=1000, dtype=dt)
+            else:
+                val = self.rfunc(0, 6, size=1000, dtype=dt).byteswap()
+
+            res = hashlib.md5(val.view(np.int8)).hexdigest()
+            print("")
+            assert_(tgt[np.dtype(dt).name] == res)
+
+        # bools do not depend on endianess
+        rnd.seed(1234, brng='MT19937')
+        val = self.rfunc(0, 2, size=1000, dtype=np.bool).view(np.int8)
+        res = hashlib.md5(val).hexdigest()
+        assert_(tgt[np.dtype(np.bool).name] == res)
+
+    def test_respect_dtype_singleton(self):
+        # See gh-7203
+        for dt in self.itype:
+            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+
+            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            self.assertEqual(sample.dtype, np.dtype(dt))
+
+        for dt in (np.bool, np.int, np.long):
+            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
+            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+
+            # gh-7284: Ensure that we get Python data types
+            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            self.assertFalse(hasattr(sample, 'dtype'))
+            self.assertEqual(type(sample), dt)
+
+
+class TestRandomDist_Intel(TestCase):
+    # Make sure the random distribution returns the correct value for a
+    # given seed. Low value of decimal argument is intended, since functional
+    # transformations's implementation or approximations thereof used to produce non-uniform
+    # random variates can vary across platforms, yet be statistically indistinguishable to the end user,
+    # that is no computationally feasible statistical experiment can detect the difference.
+
+    def setUp(self):
+        self.seed = 1234567890
+        self.brng = 'SFMT19937'
+
+    def test_rand(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.rand(3, 2)
+        desired = np.array([[0.9838694715872407, 0.019142669625580311],
+                            [0.1767608025111258, 0.70966427633538842],
+                            [0.518550637178123, 0.98780936631374061]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_randn(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.randn(3, 2)
+        desired = np.array([[2.1411609928913298, -2.0717866791744819],
+                            [-0.92778018318550248, 0.55240420724917727],
+                            [0.04651632135517459, 2.2510674226058036]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_randint(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.randint(-99, 99, size=(3, 2))
+        desired = np.array([[95, -96], [-65, 41], [3, 96]])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_random_integers(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.random_integers(-99, 99, size=(3, 2))
+        desired = np.array([[96, -96], [-64, 42], [4, 97]])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_random_integers_max_int(self):
+        # Tests whether random_integers can generate the
+        # maximum allowed Python int that can be converted
+        # into a C long. Previous implementations of this
+        # method have thrown an OverflowError when attempting
+        # to generate this integer.
+        actual = rnd.random_integers(np.iinfo('l').max,
+                                           np.iinfo('l').max)
+        desired = np.iinfo('l').max
+        np.testing.assert_equal(actual, desired)
+
+    def test_random_integers_deprecated(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+
+            # DeprecationWarning raised with high == None
+            assert_raises(DeprecationWarning,
+                          rnd.random_integers,
+                          np.iinfo('l').max)
+
+            # DeprecationWarning raised with high != None
+            assert_raises(DeprecationWarning,
+                          rnd.random_integers,
+                          np.iinfo('l').max, np.iinfo('l').max)
+
+    def test_random_sample(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.random_sample((3, 2))
+        desired = np.array([[0.9838694715872407, 0.01914266962558031],
+                            [0.1767608025111258, 0.7096642763353884],
+                            [0.518550637178123, 0.9878093663137406]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_choice_uniform_replace(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.choice(4, 4)
+        desired = np.array([3, 0, 0, 2])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_choice_nonuniform_replace(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
+        desired = np.array([3, 0, 0, 1])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_choice_uniform_noreplace(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.choice(4, 3, replace=False)
+        desired = np.array([2, 1, 3])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_choice_nonuniform_noreplace(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.choice(4, 3, replace=False,
+                                  p=[0.1, 0.3, 0.5, 0.1])
+        desired = np.array([3, 0, 1])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_choice_noninteger(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.choice(['a', 'b', 'c', 'd'], 4)
+        desired = np.array(['d', 'a', 'a', 'c'])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_choice_exceptions(self):
+        sample = rnd.choice
+        assert_raises(ValueError, sample, -1, 3)
+        assert_raises(ValueError, sample, 3., 3)
+        assert_raises(ValueError, sample, [[1, 2], [3, 4]], 3)
+        assert_raises(ValueError, sample, [], 3)
+        assert_raises(ValueError, sample, [1, 2, 3, 4], 3,
+                                          p=[[0.25, 0.25], [0.25, 0.25]])
+        assert_raises(ValueError, sample, [1, 2], 3, p=[0.4, 0.4, 0.2])
+        assert_raises(ValueError, sample, [1, 2], 3, p=[1.1, -0.1])
+        assert_raises(ValueError, sample, [1, 2], 3, p=[0.4, 0.4])
+        assert_raises(ValueError, sample, [1, 2, 3], 4, replace=False)
+        assert_raises(ValueError, sample, [1, 2, 3], 2, replace=False,
+                                          p=[1, 0, 0])
+
+    def test_choice_return_shape(self):
+        p = [0.1, 0.9]
+        # Check scalar
+        assert_(np.isscalar(rnd.choice(2, replace=True)))
+        assert_(np.isscalar(rnd.choice(2, replace=False)))
+        assert_(np.isscalar(rnd.choice(2, replace=True, p=p)))
+        assert_(np.isscalar(rnd.choice(2, replace=False, p=p)))
+        assert_(np.isscalar(rnd.choice([1, 2], replace=True)))
+        assert_(rnd.choice([None], replace=True) is None)
+        a = np.array([1, 2])
+        arr = np.empty(1, dtype=object)
+        arr[0] = a
+        assert_(rnd.choice(arr, replace=True) is a)
+
+        # Check 0-d array
+        s = tuple()
+        assert_(not np.isscalar(rnd.choice(2, s, replace=True)))
+        assert_(not np.isscalar(rnd.choice(2, s, replace=False)))
+        assert_(not np.isscalar(rnd.choice(2, s, replace=True, p=p)))
+        assert_(not np.isscalar(rnd.choice(2, s, replace=False, p=p)))
+        assert_(not np.isscalar(rnd.choice([1, 2], s, replace=True)))
+        assert_(rnd.choice([None], s, replace=True).ndim == 0)
+        a = np.array([1, 2])
+        arr = np.empty(1, dtype=object)
+        arr[0] = a
+        assert_(rnd.choice(arr, s, replace=True).item() is a)
+
+        # Check multi dimensional array
+        s = (2, 3)
+        p = [0.1, 0.1, 0.1, 0.1, 0.4, 0.2]
+        assert_(rnd.choice(6, s, replace=True).shape, s)
+        assert_(rnd.choice(6, s, replace=False).shape, s)
+        assert_(rnd.choice(6, s, replace=True, p=p).shape, s)
+        assert_(rnd.choice(6, s, replace=False, p=p).shape, s)
+        assert_(rnd.choice(np.arange(6), s, replace=True).shape, s)
+
+    def test_bytes(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.bytes(10)
+        desired = asbytes('\xa4\xde\xde{\xb4\x88\xe6\x84*2')
+        np.testing.assert_equal(actual, desired)
+
+    def test_shuffle(self):
+        # Test lists, arrays (of various dtypes), and multidimensional versions
+        # of both, c-contiguous or not:
+        for conv in [lambda x: np.array([]),
+                     lambda x: x,
+                     lambda x: np.asarray(x).astype(np.int8),
+                     lambda x: np.asarray(x).astype(np.float32),
+                     lambda x: np.asarray(x).astype(np.complex64),
+                     lambda x: np.asarray(x).astype(object),
+                     lambda x: [(i, i) for i in x],
+                     lambda x: np.asarray([[i, i] for i in x]),
+                     lambda x: np.vstack([x, x]).T,
+                     # gh-4270
+                     lambda x: np.asarray([(i, i) for i in x],
+                                          [("a", object, 1),
+                                           ("b", np.int32, 1)])]:
+            rnd.seed(self.seed, self.brng)
+            alist = conv([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])
+            rnd.shuffle(alist)
+            actual = alist
+            desired = conv([9, 8, 5, 1, 6, 4, 7, 2, 3, 0])
+            np.testing.assert_array_equal(actual, desired)
+
+
+    def test_shuffle_masked(self):
+        # gh-3263
+        a = np.ma.masked_values(np.reshape(range(20), (5,4)) % 3 - 1, -1)
+        b = np.ma.masked_values(np.arange(20) % 3 - 1, -1)
+        a_orig = a.copy()
+        b_orig = b.copy()
+        for i in range(50):
+            rnd.shuffle(a)
+            assert_equal(
+                sorted(a.data[~a.mask]), sorted(a_orig.data[~a_orig.mask]))
+            rnd.shuffle(b)
+            assert_equal(
+                sorted(b.data[~b.mask]), sorted(b_orig.data[~b_orig.mask]))
+
+
+    def test_beta(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.beta(.1, .9, size=(3, 2))
+        desired = np.array(
+            [[0.9856952034381025, 4.35869375658114e-08],
+             [0.0014230232791189966, 1.4981856288121975e-06],
+             [1.426135763875603e-06, 4.5801786040477326e-07]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+
+    def test_binomial(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.binomial(100.123, .456, size=(3, 2))
+        desired = np.array([[43, 48], [55, 48], [46, 53]])
+        np.testing.assert_array_equal(actual, desired)
+
+
+    def test_chisquare(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.chisquare(50, size=(3, 2))
+        desired = np.array([[50.955833609920589, 50.133178918244099],
+                    [61.513615847062013, 50.757127871422448],
+                    [52.79816819717081, 49.973023331993552]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+
+    def test_dirichlet(self):
+        rnd.seed(self.seed, self.brng)
+        alpha = np.array([51.72840233779265162, 39.74494232180943953])
+        actual = rnd.dirichlet(alpha, size=(3, 2))
+        desired = np.array([[[0.6332947001908874, 0.36670529980911254],
+                             [0.5376828907571894, 0.4623171092428107]],
+                            [[0.6835615930093024, 0.3164384069906976],
+                             [0.5452378139016114, 0.45476218609838875]],
+                            [[0.6498494402738553, 0.3501505597261446],
+                             [0.5622024400324822, 0.43779755996751785]]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+
+    def test_dirichlet_size(self):
+        # gh-3173
+        p = np.array([51.72840233779265162, 39.74494232180943953])
+        assert_equal(rnd.dirichlet(p, np.uint32(1)).shape, (1, 2))
+        assert_equal(rnd.dirichlet(p, np.uint32(1)).shape, (1, 2))
+        assert_equal(rnd.dirichlet(p, np.uint32(1)).shape, (1, 2))
+        assert_equal(rnd.dirichlet(p, [2, 2]).shape, (2, 2, 2))
+        assert_equal(rnd.dirichlet(p, (2, 2)).shape, (2, 2, 2))
+        assert_equal(rnd.dirichlet(p, np.array((2, 2))).shape, (2, 2, 2))
+
+        assert_raises(TypeError, rnd.dirichlet, p, np.float(1))
+
+
+    def test_exponential(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.exponential(1.1234, size=(3, 2))
+        desired = np.array([[0.01826877748252199, 4.4439855151117005],
+                            [1.9468048583654507, 0.38528493864979607],
+                            [0.7377565464231758, 0.013779117663987912]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+
+    def test_f(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.f(12, 77, size=(3, 2))
+        desired = np.array([[1.325076177478387, 0.8670927327120197],
+                            [2.1190792007836827, 0.9095296301824258],
+                            [1.4953697422236187, 0.9547125618834837]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=9)
+
+
+    def test_gamma(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.gamma(5, 3, size=(3, 2))
+        desired = np.array([[15.073510060334929, 14.525495858042685],
+                            [22.73897210140115, 14.94044782480266],
+                            [16.327929995271095, 14.419692564592896]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+
+    def test_geometric(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.geometric(.123456789, size=(3, 2))
+        desired = np.array([[0, 30], [13, 2], [4, 0]])
+        np.testing.assert_array_equal(actual, desired)
+
+
+    def test_gumbel(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.gumbel(loc=.123456789, scale=2.0, size=(3, 2))
+        desired = np.array([[-8.114386462751979, 2.873840411460178],
+                            [1.2231161758452016, -2.0168070493213532],
+                            [-0.7175455966332102, -8.678464904504784]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+
+    def test_hypergeometric(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.hypergeometric(10.1, 5.5, 14, size=(3, 2))
+        desired = np.array([[10, 9], [9, 10], [9, 10]])
+        np.testing.assert_array_equal(actual, desired)
+
+        # Test nbad = 0
+        actual = rnd.hypergeometric(5, 0, 3, size=4)
+        desired = np.array([3, 3, 3, 3])
+        np.testing.assert_array_equal(actual, desired)
+
+        actual = rnd.hypergeometric(15, 0, 12, size=4)
+        desired = np.array([12, 12, 12, 12])
+        np.testing.assert_array_equal(actual, desired)
+
+        # Test ngood = 0
+        actual = rnd.hypergeometric(0, 5, 3, size=4)
+        desired = np.array([0, 0, 0, 0])
+        np.testing.assert_array_equal(actual, desired)
+
+        actual = rnd.hypergeometric(0, 15, 12, size=4)
+        desired = np.array([0, 0, 0, 0])
+        np.testing.assert_array_equal(actual, desired)
+
+
+    def test_laplace(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.laplace(loc=.123456789, scale=2.0, size=(3, 2))
+        desired = np.array([[0.15598087210935016, -3.3424589282252994],
+                            [-1.189978401356375, 3.0607925598732253],
+                            [0.0030946589024587745, 3.14795824463997]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+
+    def test_logistic(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.logistic(loc=.123456789, scale=2.0, size=(3, 2))
+        desired = np.array([[8.345015961402696, -7.749557532940552],
+                            [-2.9534419690278444, 1.910964962531448],
+                            [0.2719300361499433, 8.913100396613983]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+
+    def test_lognormal(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.lognormal(mean=.123456789, sigma=2.0, size=(3, 2))
+        desired = np.array([[81.92291750917155, 0.01795087229603931],
+                            [0.1769118704670423, 3.415299544410577],
+                            [1.2417099625339398, 102.0631392685238]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=6)
+        actual = rnd.lognormal(mean=.123456789, sigma=2.0, size=(3,2),
+                                     method='Box-Muller2')
+        desired = np.array([[0.2585388231094821, 0.43734953048924663],
+                            [26.050836228611697, 26.76266237820882],
+                            [0.24216420175675096, 0.2481945765083541]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+
+    def test_logseries(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.logseries(p=.923456789, size=(3, 2))
+        desired = np.array([[18, 1], [1, 1], [5, 19]])
+        np.testing.assert_array_equal(actual, desired)
+
+
+    def test_multinomial(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.multinomial(20, [1/6.]*6, size=(3, 2))
+        desired = np.array([[[7, 0, 2, 4, 4, 3], [7, 1, 2, 6, 4, 0]],
+                            [[2, 2, 3, 4, 6, 3], [1, 2, 5, 5, 6, 1]],
+                            [[2, 7, 4, 1, 2, 4], [3, 5, 2, 5, 4, 1]]])
+        np.testing.assert_array_equal(actual, desired)
+
+
+    def test_multivariate_normal(self):
+        rnd.seed(self.seed, self.brng)
+        mean = (.123456789, 10)
+        # Hmm... not even symmetric.
+        cov = [[1, 0], [1, 0]]
+        size = (3, 2)
+        actual = rnd.multivariate_normal(mean, cov, size)
+        desired = np.array([[[-2.42282709811266, 10.0],
+                             [1.2267795840027274, 10.0]],
+                            [[0.06813924868067336, 10.0],
+                             [1.001190462507746, 10.0]],
+                            [[-1.74157261455869, 10.0],
+                             [1.0400952859037553, 10.0]]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+        # Check for default size, was raising deprecation warning
+        actual = rnd.multivariate_normal(mean, cov)
+        desired = np.array([1.0579899448949994, 10.0])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+        # Check that non positive-semidefinite covariance raises warning
+        mean = [0, 0]
+        cov = [[1, 1 + 1e-10], [1 + 1e-10, 1]]
+        assert_warns(RuntimeWarning, rnd.multivariate_normal, mean, cov)
+
+
+    def test_multinormal_cholesky(self):
+        rnd.seed(self.seed, self.brng)
+        mean = (.123456789, 10)
+        # lower-triangular cholesky matrix
+        chol_mat = [[1, 0], [-0.5, 1]]
+        size = (3, 2)
+        actual = rnd.multinormal_cholesky(mean, chol_mat, size, method='ICDF')
+        desired = np.array([[[2.26461778189133, 6.857632824379853],
+                             [-0.8043233941855025, 11.01629429884193]],
+                            [[0.1699731103551746, 12.227809261928217],
+                             [-0.6146263106001378, 9.893801873973892]],
+                            [[1.691753328795276, 10.797627196240155],
+                             [-0.647341237129921, 9.626899489691816]]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+
+    def test_negative_binomial(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.negative_binomial(n=100, p=.12345, size=(3, 2))
+        desired = np.array([[667, 679], [677, 676], [779, 648]])
+        np.testing.assert_array_equal(actual, desired)
+
+
+    def test_noncentral_chisquare(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.noncentral_chisquare(df=5, nonc=5, size=(3, 2))
+        desired = np.array([[5.871334619375055, 8.756238913383225],
+                            [17.29576535176833, 3.9028417087862177],
+                            [5.1315133729432505, 9.942717979531027]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+        actual = rnd.noncentral_chisquare(df=.5, nonc=.2, size=(3, 2))
+        desired = np.array([[0.0008971007339949436, 0.08948578998156566],
+                            [0.6721835871997511, 2.8892645287699352],
+                            [5.0858149962761007e-05, 1.7315797643658821]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+
+    def test_noncentral_f(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.noncentral_f(dfnum=5, dfden=2, nonc=1,
+                                        size=(3, 2))
+        desired = np.array([[0.2216297348371284, 0.7632696724492449],
+                            [98.67664232828238, 0.9500319825372799],
+                            [0.3489618249246971, 1.5035633972571092]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+    def test_normal(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.normal(loc=.123456789, scale=2.0, size=(3, 2))
+        desired = np.array([[4.405778774782659, -4.020116569348963],
+                            [-1.732103577371005, 1.2282652034983546],
+                            [0.21648943171034918, 4.625591634211608]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.normal(loc=.123456789, scale=2.0, size=(3, 2), method="BoxMuller")
+        desired = np.array([[0.16673479781277187, -3.4809986872165952],
+                            [-0.05193761082535492, 3.249201213154922],
+                            [-0.11915582299214138, 3.555636100927892]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=8)
+
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.normal(loc=.123456789, scale=2.0, size=(3, 2), method="BoxMuller2")
+        desired = np.array([[0.16673479781277187, 0.48153966449249175],
+                            [-3.4809986872165952, -0.8101190082826486],
+                            [-0.051937610825354905, 2.4088402362484342]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+
+    def test_pareto(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.pareto(a=.123456789, size=(3, 2))
+        desired = np.array(
+            [[0.14079174875385214, 82372044085468.92],
+             [1247881.6368437486, 15.086855668610944],
+             [203.2638558933401, 0.10445383654349749]])
+        # For some reason on 32-bit x86 Ubuntu 12.10 the [1, 0] entry in this
+        # matrix differs by 24 nulps. Discussion:
+        #   http://mail.scipy.org/pipermail/numpy-discussion/2012-September/063801.html
+        # Consensus is that this is probably some gcc quirk that affects
+        # rounding but not in any important way, so we just use a looser
+        # tolerance on this test:
+        np.testing.assert_array_almost_equal_nulp(actual, desired, nulp=30)
+
+    def test_poisson(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.poisson(lam=.123456789, size=(3, 2))
+        desired = np.array([[1, 0], [0, 0], [0, 1]])
+        np.testing.assert_array_equal(actual, desired)
+
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.poisson(lam=1234.56789, size=(3, 2))
+        desired = np.array([[1310, 1162], [1202, 1254], [1236, 1314]])
+        np.testing.assert_array_equal(actual, desired)
+
+    def test_poisson_exceptions(self):
+        lambig = np.iinfo('l').max
+        lamneg = -1
+        assert_raises(ValueError, rnd.poisson, lamneg)
+        assert_raises(ValueError, rnd.poisson, [lamneg]*10)
+        assert_raises(ValueError, rnd.poisson, lambig)
+        assert_raises(ValueError, rnd.poisson, [lambig]*10)
+
+    def test_power(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.power(a=.123456789, size=(3, 2))
+        desired = np.array([[0.8765841803224415, 1.2140041091640163e-14],
+                            [8.013574117268635e-07, 0.06216255187464781],
+                            [0.004895628723087296, 0.9054248959192386]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_rayleigh(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.rayleigh(scale=10, size=(3, 2))
+        desired = np.array([[1.80344345931194, 28.127692489122378],
+                            [18.6169699930609, 8.282068232120208],
+                            [11.460520015934597, 1.5662406536967712]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+    def test_standard_cauchy(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.standard_cauchy(size=(3, 2))
+        desired = np.array([[19.716487700629912, -16.608240276131227],
+                            [-1.6117703817332278, 0.7739915895826882],
+                            [0.058344614106131, 26.09825325697747]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=9)
+
+    def test_standard_exponential(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.standard_exponential(size=(3, 2))
+        desired = np.array([[0.016262041554675085, 3.955835423813157],
+                            [1.7329578586126497, 0.3429632710074738],
+                            [0.6567175951781875, 0.012265548926462446]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_standard_gamma(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.standard_gamma(shape=3, size=(3, 2))
+        desired = np.array([[2.939330965027084, 2.799606052259993],
+                            [4.988193705918075, 2.905305108691164],
+                            [3.2630929395548147, 2.772756340265377]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+    def test_standard_normal(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.standard_normal(size=(3, 2))
+        desired = np.array([[2.1411609928913298, -2.071786679174482],
+                            [-0.9277801831855025, 0.5524042072491773],
+                            [0.04651632135517459, 2.2510674226058036]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.standard_normal(size=(3, 2), method='BoxMuller2')
+        desired = np.array([[0.021639004406385935, 0.17904143774624587],
+                            [-1.8022277381082976, -0.4667878986413243],
+                            [-0.08769719991267745, 1.1426917236242171]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=7)
+
+    def test_standard_t(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.standard_t(df=10, size=(3, 2))
+        desired = np.array([[-0.783927044239963, 0.04762883516531178],
+                            [0.7624597987725193, -1.8045540288955506],
+                            [-1.2657694296239195, 0.307870906117017]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_triangular(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.triangular(left=5.12, mode=10.23, right=20.34,
+                                      size=(3, 2))
+        desired = np.array([[18.764540652669638, 6.340166306695037],
+                            [8.827752689522429, 13.65605077739865],
+                            [11.732872979633328, 18.970392754850423]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_uniform(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.uniform(low=1.23, high=10.54, size=(3, 2))
+        desired = np.array([[10.38982478047721, 1.408218254214153],
+                            [2.8756430713785814, 7.836974412682466],
+                            [6.057706432128325, 10.426505200380925]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_uniform_range_bounds(self):
+        fmin = np.finfo('float').min
+        fmax = np.finfo('float').max
+
+        func = rnd.uniform
+        np.testing.assert_raises(OverflowError, func, -np.inf, 0)
+        np.testing.assert_raises(OverflowError, func,  0,      np.inf)
+        # this should not throw any error, since rng can be sampled as fmin*u + fmax*(1-u)
+        # for 0<u<1 and it stays completely in range
+        rnd.uniform(fmin, fmax)
+
+        # (fmax / 1e17) - fmin is within range, so this should not throw
+        rnd.uniform(low=fmin, high=fmax / 1e17)
+
+    def test_vonmises(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.vonmises(mu=1.23, kappa=1.54, size=(3, 2))
+        desired = np.array([[1.1027657269593822, 1.2539311427727782],
+                            [2.0281801137277764, 1.3262040229028056],
+                            [0.9510301598100863, 2.0284972823322818]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_vonmises_small(self):
+        # check infinite loop, gh-4720
+        rnd.seed(self.seed, self.brng)
+        r = rnd.vonmises(mu=0., kappa=1.1e-8, size=10**6)
+        np.testing.assert_(np.isfinite(r).all())
+
+    def test_wald(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.wald(mean=1.23, scale=1.54, size=(3, 2))
+        desired = np.array([[0.3465678392232347, 0.3594497155916536],
+                            [2.192908727996422, 1.7408141717513501],
+                            [1.1943709105062374, 0.3273455943060196]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_weibull(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.weibull(a=1.23, size=(3, 2))
+        desired = np.array([[0.035129404330214734, 3.058859465984936],
+                            [1.5636393343788513, 0.4189406773709585],
+                            [0.710439924774508, 0.02793103204502023]])
+        np.testing.assert_array_almost_equal(actual, desired, decimal=10)
+
+    def test_zipf(self):
+        rnd.seed(self.seed, self.brng)
+        actual = rnd.zipf(a=1.23, size=(3, 2))
+        desired = np.array([[62062919, 1], [24, 209712763], [2, 24]])
+        np.testing.assert_array_equal(actual, desired)
+
+
+class TestThread_Intel(object):
+    # make sure each state produces the same sequence even in threads
+    def setUp(self):
+        self.seeds = range(4)
+
+    def check_function(self, function, sz):
+        from threading import Thread
+
+        out1 = np.empty((len(self.seeds),) + sz)
+        out2 = np.empty((len(self.seeds),) + sz)
+
+        # threaded generation
+        t = [Thread(target=function, args=(rnd.RandomState(s), o))
+             for s, o in zip(self.seeds, out1)]
+        [x.start() for x in t]
+        [x.join() for x in t]
+
+        # the same serial
+        for s, o in zip(self.seeds, out2):
+            function(rnd.RandomState(s), o)
+
+        # these platforms change x87 fpu precision mode in threads
+        if (np.intp().dtype.itemsize == 4 and sys.platform == "win32"):
+            np.testing.assert_array_almost_equal(out1, out2)
+        else:
+            np.testing.assert_array_equal(out1, out2)
+
+    def test_normal(self):
+        def gen_random(state, out):
+            out[...] = state.normal(size=10000)
+        self.check_function(gen_random, sz=(10000,))
+
+    def test_exp(self):
+        def gen_random(state, out):
+            out[...] = state.exponential(scale=np.ones((100, 1000)))
+        self.check_function(gen_random, sz=(100, 1000))
+
+    def test_multinomial(self):
+        def gen_random(state, out):
+            out[...] = state.multinomial(10, [1/6.]*6, size=10000)
+        self.check_function(gen_random, sz=(10000,6))
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/random_intel/tests/test_regression.py
+++ b/numpy/random_intel/tests/test_regression.py
@@ -1,0 +1,146 @@
+from __future__ import division, absolute_import, print_function
+
+import sys
+from numpy.testing import (TestCase, run_module_suite, assert_,
+                           assert_array_equal, assert_raises)
+from numpy import random_intel as rnd
+from numpy.compat import long
+import numpy as np
+
+
+class TestRegression_Intel(TestCase):
+
+    def test_VonMises_range(self):
+        # Make sure generated random variables are in [-pi, pi].
+        # Regression test for ticket #986.
+        for mu in np.linspace(-7., 7., 5):
+            r = rnd.vonmises(mu, 1, 50)
+            assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
+
+    def test_hypergeometric_range(self):
+        # Test for ticket #921
+        assert_(np.all(rnd.hypergeometric(3, 18, 11, size=10) < 4))
+        assert_(np.all(rnd.hypergeometric(18, 3, 11, size=10) > 0))
+
+        # Test for ticket #5623
+        args = [
+            (2**20 - 2, 2**20 - 2, 2**20 - 2),  # Check for 32-bit systems
+            (2 ** 30 - 1, 2 ** 30 - 2, 2 ** 30 - 1)
+        ]
+        for arg in args:
+            assert_(rnd.hypergeometric(*arg) > 0)
+
+    def test_logseries_convergence(self):
+        # Test for ticket #923
+        N = 1000
+        rnd.seed(0)
+        rvsn = rnd.logseries(0.8, size=N)
+        # these two frequency counts should be close to theoretical
+        # numbers with this large sample
+        # theoretical large N result is 0.49706795
+        freq = np.sum(rvsn == 1) / float(N)
+        msg = "Frequency was %f, should be > 0.45" % freq
+        assert_(freq > 0.45, msg)
+        # theoretical large N result is 0.19882718
+        freq = np.sum(rvsn == 2) / float(N)
+        msg = "Frequency was %f, should be < 0.23" % freq
+        assert_(freq < 0.23, msg)
+
+    def test_permutation_longs(self):
+        rnd.seed(1234)
+        a = rnd.permutation(12)
+        rnd.seed(1234)
+        b = rnd.permutation(long(12))
+        assert_array_equal(a, b)
+
+    def test_randint_range(self):
+        # Test for ticket #1690
+        lmax = np.iinfo('l').max
+        lmin = np.iinfo('l').min
+        try:
+            rnd.randint(lmin, lmax)
+        except:
+            raise AssertionError
+
+    def test_shuffle_mixed_dimension(self):
+        # Test for trac ticket #2074
+        for t in [[1, 2, 3, None],
+                  [(1, 1), (2, 2), (3, 3), None],
+                  [1, (2, 2), (3, 3), None],
+                  [(1, 1), 2, 3, None]]:
+            rnd.seed(12345, brng='MT2203')
+            shuffled = list(t)
+            rnd.shuffle(shuffled)
+            assert_array_equal(shuffled, [t[0], t[2], t[1], t[3]])
+
+    def test_call_within_randomstate(self):
+        # Check that custom RandomState does not call into global state
+        m = rnd.RandomState()
+        res = np.array([5, 7, 5, 4, 5, 5, 6, 9, 6, 1])
+        for i in range(3):
+            rnd.seed(i)
+            m.seed(4321, brng='SFMT19937')
+            # If m.state is not honored, the result will change
+            assert_array_equal(m.choice(10, size=10, p=np.ones(10)/10.), res)
+
+    def test_multivariate_normal_size_types(self):
+        # Test for multivariate_normal issue with 'size' argument.
+        # Check that the multivariate_normal size argument can be a
+        # numpy integer.
+        rnd.multivariate_normal([0], [[0]], size=1)
+        rnd.multivariate_normal([0], [[0]], size=np.int_(1))
+        rnd.multivariate_normal([0], [[0]], size=np.int64(1))
+
+    def test_beta_small_parameters(self):
+        # Test that beta with small a and b parameters does not produce
+        # NaNs due to roundoff errors causing 0 / 0, gh-5851
+        rnd.seed(1234567890)
+        x = rnd.beta(0.0001, 0.0001, size=100)
+        assert_(not np.any(np.isnan(x)), 'Nans in rnd.beta')
+
+    def test_choice_sum_of_probs_tolerance(self):
+        # The sum of probs should be 1.0 with some tolerance.
+        # For low precision dtypes the tolerance was too tight.
+        # See numpy github issue 6123.
+        rnd.seed(1234)
+        a = [1, 2, 3]
+        counts = [4, 4, 2]
+        for dt in np.float16, np.float32, np.float64:
+            probs = np.array(counts, dtype=dt) / sum(counts)
+            c = rnd.choice(a, p=probs)
+            assert_(c in a)
+            assert_raises(ValueError, rnd.choice, a, p=probs*0.9)
+
+    def test_shuffle_of_array_of_different_length_strings(self):
+        # Test that permuting an array of different length strings
+        # will not cause a segfault on garbage collection
+        # Tests gh-7710
+        rnd.seed(1234)
+
+        a = np.array(['a', 'a' * 1000])
+
+        for _ in range(100):
+            rnd.shuffle(a)
+
+        # Force Garbage Collection - should not segfault.
+        import gc
+        gc.collect()
+
+
+    def test_shuffle_of_array_of_objects(self):
+        # Test that permuting an array of objects will not cause
+        # a segfault on garbage collection.
+        # See gh-7719
+        rnd.seed(1234)
+        a = np.array([np.arange(1), np.arange(4)])
+
+        for _ in range(1000):
+            rnd.shuffle(a)
+
+        # Force Garbage Collection - should not segfault.
+        import gc
+        gc.collect()
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/random_intel/tests/test_regression.py
+++ b/numpy/random_intel/tests/test_regression.py
@@ -3,13 +3,21 @@ from __future__ import division, absolute_import, print_function
 import sys
 from numpy.testing import (TestCase, run_module_suite, assert_,
                            assert_array_equal, assert_raises)
+from numpy.testing.decorators import skipif
 from numpy import random_intel as rnd
 from numpy.compat import long
 import numpy as np
 
+from numpy.distutils.system_info import get_info
+if get_info('mkl'):
+    skip_test = False
+else:
+    skip_test = True
+
 
 class TestRegression_Intel(TestCase):
 
+    @skipif(skip_test)
     def test_VonMises_range(self):
         # Make sure generated random variables are in [-pi, pi].
         # Regression test for ticket #986.
@@ -17,6 +25,8 @@ class TestRegression_Intel(TestCase):
             r = rnd.vonmises(mu, 1, 50)
             assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
 
+
+    @skipif(skip_test)
     def test_hypergeometric_range(self):
         # Test for ticket #921
         assert_(np.all(rnd.hypergeometric(3, 18, 11, size=10) < 4))
@@ -30,6 +40,8 @@ class TestRegression_Intel(TestCase):
         for arg in args:
             assert_(rnd.hypergeometric(*arg) > 0)
 
+
+    @skipif(skip_test)
     def test_logseries_convergence(self):
         # Test for ticket #923
         N = 1000
@@ -46,6 +58,8 @@ class TestRegression_Intel(TestCase):
         msg = "Frequency was %f, should be < 0.23" % freq
         assert_(freq < 0.23, msg)
 
+
+    @skipif(skip_test)
     def test_permutation_longs(self):
         rnd.seed(1234)
         a = rnd.permutation(12)
@@ -53,6 +67,8 @@ class TestRegression_Intel(TestCase):
         b = rnd.permutation(long(12))
         assert_array_equal(a, b)
 
+
+    @skipif(skip_test)
     def test_randint_range(self):
         # Test for ticket #1690
         lmax = np.iinfo('l').max
@@ -62,6 +78,8 @@ class TestRegression_Intel(TestCase):
         except:
             raise AssertionError
 
+
+    @skipif(skip_test)
     def test_shuffle_mixed_dimension(self):
         # Test for trac ticket #2074
         for t in [[1, 2, 3, None],
@@ -73,6 +91,8 @@ class TestRegression_Intel(TestCase):
             rnd.shuffle(shuffled)
             assert_array_equal(shuffled, [t[0], t[2], t[1], t[3]])
 
+
+    @skipif(skip_test)
     def test_call_within_randomstate(self):
         # Check that custom RandomState does not call into global state
         m = rnd.RandomState()
@@ -83,6 +103,8 @@ class TestRegression_Intel(TestCase):
             # If m.state is not honored, the result will change
             assert_array_equal(m.choice(10, size=10, p=np.ones(10)/10.), res)
 
+
+    @skipif(skip_test)
     def test_multivariate_normal_size_types(self):
         # Test for multivariate_normal issue with 'size' argument.
         # Check that the multivariate_normal size argument can be a
@@ -91,6 +113,8 @@ class TestRegression_Intel(TestCase):
         rnd.multivariate_normal([0], [[0]], size=np.int_(1))
         rnd.multivariate_normal([0], [[0]], size=np.int64(1))
 
+
+    @skipif(skip_test)
     def test_beta_small_parameters(self):
         # Test that beta with small a and b parameters does not produce
         # NaNs due to roundoff errors causing 0 / 0, gh-5851
@@ -98,6 +122,8 @@ class TestRegression_Intel(TestCase):
         x = rnd.beta(0.0001, 0.0001, size=100)
         assert_(not np.any(np.isnan(x)), 'Nans in rnd.beta')
 
+
+    @skipif(skip_test)
     def test_choice_sum_of_probs_tolerance(self):
         # The sum of probs should be 1.0 with some tolerance.
         # For low precision dtypes the tolerance was too tight.
@@ -111,6 +137,8 @@ class TestRegression_Intel(TestCase):
             assert_(c in a)
             assert_raises(ValueError, rnd.choice, a, p=probs*0.9)
 
+
+    @skipif(skip_test)
     def test_shuffle_of_array_of_different_length_strings(self):
         # Test that permuting an array of different length strings
         # will not cause a segfault on garbage collection
@@ -127,6 +155,7 @@ class TestRegression_Intel(TestCase):
         gc.collect()
 
 
+    @skipif(skip_test)
     def test_shuffle_of_array_of_objects(self):
         # Test that permuting an array of objects will not cause
         # a segfault on garbage collection.

--- a/numpy/setup.py
+++ b/numpy/setup.py
@@ -18,6 +18,7 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('matrixlib')
     config.add_subpackage('polynomial')
     config.add_subpackage('random')
+    config.add_subpackage('random_intel')
     config.add_subpackage('testing')
     config.add_data_dir('doc')
     config.add_data_dir('tests')

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -75,6 +75,8 @@ if sys.version_info >= (3, 4):
                 continue
             if path == base / "random" / "__init__.py":
                 continue
+            if path == base / "random_intel" / "__init__.py":
+                continue
             # use tokenize to auto-detect encoding on systems where no
             # default encoding is defined (e.g. LANG='C')
             with tokenize.open(str(path)) as file:

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,13 @@ def generate_cython():
                           'numpy/random'],
                          cwd=cwd)
     if p != 0:
-        raise RuntimeError("Running cythonize failed!")
+        raise RuntimeError("Running cythonize on numpy/random failed!")
+    p = subprocess.call([sys.executable,
+                          os.path.join(cwd, 'tools', 'cythonize.py'),
+                          'numpy/random_intel'],
+                         cwd=cwd)
+    if p != 0:
+        raise RuntimeError("Running cythonize on numpy/random_intel failed!")
 
 
 def parse_setuppy_commands():


### PR DESCRIPTION
`numpy.random_intel` is MKL-based alternative for `numpy.random`, first
featured in the [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python).

It implements all distributions of `numpy.random` as well as
`numpy.random_intel.multinormal_cholesky`, which allows for fast
sampling from multinormal distribution when the Cholesky factor
is known ahead of time.

Module `numpy.random_intel` implements sampling from all distributions
in a vectorized fashion, just like MKL does, which allows MKL to use
vectorized instructions for efficiency. 

That means that instead of mtrand's `rk_normal` which produces a single 
variate sampled from normal distribution,  mklrand offers `vrk_normal_vec`, 
which produces a vector of variates of requested size.

EDIT: link to mailing list design discussion on this feature: https://mail.scipy.org/pipermail/numpy-discussion/2016-July/075822.html
