### PR TITLE
DOC: Turn SciPy references into links.

### DIFF
--- a/doc/EXAMPLE_DOCSTRING.rst.txt
+++ b/doc/EXAMPLE_DOCSTRING.rst.txt
@@ -42,9 +42,8 @@ out : ndarray
 See Also
 --------
 normal
-scipy.stats.distributions.norm : Provides random variates, as well as
-                                 probability density function, cumulative
-                                 density function, etc.
+scipy.stats.norm : Provides random variates, as well as probability density
+                   function, cumulative density function, etc.
 
 Notes
 -----

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -201,6 +201,7 @@ texinfo_documents = [
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
     'python': ('https://docs.python.org/dev', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('http://matplotlib.org', None)
 }
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2672,10 +2672,10 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.lomax.pdf : probability density function, distribution or
+        scipy.stats.lomax : probability density function, distribution or
             cumulative density function, etc.
-        scipy.stats.genpareto.pdf : probability density function, distribution
-            or cumulative density function, etc.
+        scipy.stats.genpareto : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1564,8 +1564,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.norm : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.norm : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -1818,8 +1818,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.gamma : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.gamma : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -1908,8 +1908,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.gamma : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.gamma : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -2009,8 +2009,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.f : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.f : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -2566,8 +2566,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.vonmises : probability density function,
-            distribution, or cumulative density function, etc.
+        scipy.stats.vonmises : probability density function, distribution, or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -2672,10 +2672,10 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.lomax.pdf : probability density function,
-            distribution or cumulative density function, etc.
-        scipy.stats.distributions.genpareto.pdf : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.lomax.pdf : probability density function, distribution or
+            cumulative density function, etc.
+        scipy.stats.genpareto.pdf : probability density function, distribution
+            or cumulative density function, etc.
 
         Notes
         -----
@@ -2774,9 +2774,9 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.weibull_max
-        scipy.stats.distributions.weibull_min
-        scipy.stats.distributions.genextreme
+        scipy.stats.weibull_max
+        scipy.stats.weibull_min
+        scipy.stats.genextreme
         gumbel
 
         Notes
@@ -3220,8 +3220,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.logistic : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.logistic : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -3700,8 +3700,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.binom : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.binom : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -4004,8 +4004,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.zipf : probability density function,
-            distribution, or cumulative density function, etc.
+        scipy.stats.zipf : probability density function, distribution, or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -4166,8 +4166,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.hypergeom : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.hypergeom : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----
@@ -4280,8 +4280,8 @@ cdef class RandomState:
 
         See Also
         --------
-        scipy.stats.distributions.logser : probability density function,
-            distribution or cumulative density function, etc.
+        scipy.stats.logser : probability density function, distribution or
+            cumulative density function, etc.
 
         Notes
         -----


### PR DESCRIPTION
Added SciPy intersphinx inventory to make references clickable (for example in "See also" sections in [convolve](https://docs.scipy.org/doc/numpy/reference/generated/numpy.convolve.html) or [polyfit](https://docs.scipy.org/doc/numpy/reference/generated/numpy.polynomial.polynomial.polyfit.html#numpy.polynomial.polynomial.polyfit)). Some `scipy.stats` references also needed updating (such as those in [vonmises](https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.vonmises.html) or [zipf](https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.zipf.html); note that to see the effect one needs to rebuild `mtrand.so` before building the documentation).
