### PR TITLE
MAINT, ENH: Refactor numpy ** operators for numpy scalar integer powers

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -76,15 +76,29 @@ DeprecationWarning to error
 
 ``power`` and ``**`` raise errors for integer to negative integer powers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The previous behavior was
+The previous behavior depended on whether numpy scalar integers or numpy
+integer arrays were involved.
 
-* zero to negative integer powers returned least integral value.
-* 1, -1 to negative integer powers returned correct values
-* all remaining integers returned zero when raised to negative integer powers.
+For arrays
 
-All of these cases now raise a ``ValueError``. It was felt that a simple rule
-was the best way to go rather than have special exceptions for the units. If
-you need negative powers, use an inexact type.
+* Zero to negative integer powers returned least integral value.
+* Both 1, -1 to negative integer powers returned correct values.
+* The remaining integers returned zero when raised to negative integer powers.
+
+For scalars
+
+* Zero to negative integer powers returned least integral value.
+* Both 1, -1 to negative integer powers returned correct values.
+* The remaining integers sometimes returned zero, sometimes the
+  correct float depending on the integer type combination.
+
+All of these cases now raise a ``ValueError`` except for those integer
+combinations whose common type is float, for instance uint64 and int8. It was
+felt that a simple rule was the best way to go rather than have special
+exceptions for the integer units. If you need negative powers, use an inexact
+type.
+
+
 
 Relaxed stride checking is the default
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -218,6 +218,7 @@ static void
  * #upc = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
  *        LONG, ULONG, LONGLONG, ULONGLONG#
  */
+#if 0
 static void
 @name@_ctype_power(@type@ a, @type@ b, @type@ *out) {
     @type@ temp, ix, mult;
@@ -242,6 +243,7 @@ static void
     }
     *out = ix;
 }
+#endif
 /**end repeat**/
 
 
@@ -413,12 +415,17 @@ half_ctype_divmod(npy_half a, npy_half b, npy_half *out1, npy_half *out2) {
  */
 static npy_@name@ (*_basic_@name@_pow)(@type@ a, @type@ b);
 
+#if 0
 static void
 @name@_ctype_power(@type@ a, @type@ b, @type@ *out)
 {
     *out = _basic_@name@_pow(a, b);
 }
+#endif
+
 /**end repeat**/
+
+#if 0
 static void
 half_ctype_power(npy_half a, npy_half b, npy_half *out)
 {
@@ -427,6 +434,7 @@ half_ctype_power(npy_half a, npy_half b, npy_half *out)
     const npy_float outf = _basic_float_pow(af,bf);
     *out = npy_float_to_half(outf);
 }
+#endif
 
 /**begin repeat
  * #name = byte, ubyte, short, ushort, int, uint,
@@ -499,11 +507,14 @@ static void
 
 static void (*_basic_@name@_pow)(@type@ *, @type@ *, @type@ *);
 
+#if 0
 static void
 @name@_ctype_power(@type@ a, @type@ b, @type@ *out)
 {
     _basic_@name@_pow(&a, &b, out);
 }
+#endif
+
 /**end repeat**/
 
 
@@ -957,7 +968,6 @@ static PyObject *
 static PyObject *
 @name@_power(PyObject *a, PyObject *b, PyObject *NPY_UNUSED(c))
 {
-    PyObject *ret;
     @type@ arg1, arg2;
 
     switch (_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
@@ -971,10 +981,12 @@ static PyObject *
             }
             return PyGenericArrType_Type.tp_as_number->nb_power(a, b, NULL);
         case -3:
+        default:
             /*
              * special case for longdouble and clongdouble
              * because they have a recursive getitem in their dtype
              */
+
             Py_INCREF(Py_NotImplemented);
             return Py_NotImplemented;
     }

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -954,6 +954,33 @@ static PyObject *
  * #one = 1*10, NPY_HALF_ONE, 1*6#
  */
 
+static PyObject *
+@name@_power(PyObject *a, PyObject *b, PyObject *NPY_UNUSED(c))
+{
+    PyObject *ret;
+    @type@ arg1, arg2;
+
+    switch (_@name@_convert2_to_ctypes(a, &arg1, b, &arg2)) {
+        case 0:
+        case -1:
+            return PyArray_Type.tp_as_number->nb_power(a, b, NULL);
+        case -2:
+            /* use default handling */
+            if (PyErr_Occurred()) {
+                return NULL;
+            }
+            return PyGenericArrType_Type.tp_as_number->nb_power(a, b, NULL);
+        case -3:
+            /*
+             * special case for longdouble and clongdouble
+             * because they have a recursive getitem in their dtype
+             */
+            Py_INCREF(Py_NotImplemented);
+            return Py_NotImplemented;
+    }
+}
+
+#if 0
 #if @cmplx@
 static PyObject *
 @name@_power(PyObject *a, PyObject *b, PyObject *NPY_UNUSED(c))
@@ -1183,6 +1210,7 @@ static PyObject *
     return ret;
 }
 
+#endif
 #endif
 
 /**end repeat**/

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -124,23 +124,41 @@ class TestPower(TestCase):
             else:
                 assert_almost_equal(b, 6765201, err_msg=msg)
 
-    def test_negative_power(self):
-        typelist = [np.int8, np.int16, np.int32, np.int64]
-        for t in typelist:
-            a = t(2)
-            b = t(-4)
-            result = a**b
-            msg = ("error with %r:"
-                   "got %r, expected %r") % (t, result, 0.0625)
-            assert_(result == 0.0625, msg)
+    def test_integers_to_negative_integer_power(self):
+        # Note that the combination of uint64 with a signed integer
+        # has common type np.float. The other combinations should all
+        # raise a ValueError for integer ** negative integer.
+        exp = [np.array(-1, dt)[()] for dt in 'bhilq']
 
-            c = t(4)
-            d = t(-15)
-            result = c**d
-            expected = 4.0**-15.0
-            msg = ("error with %r:"
-                   "got %r, expected %r") % (t, result, expected)
-            assert_almost_equal(result, expected, err_msg=msg)
+        # 1 ** -1 possible special case
+        base = [np.array(1, dt)[()] for dt in 'bhilqBHILQ']
+        for i1, i2 in itertools.product(base, exp):
+            if i1.dtype.name != 'uint64':
+                assert_raises(ValueError, operator.pow, i1, i2)
+            else:
+                res = operator.pow(i1, i2)
+                assert_(res.dtype.type is np.float64)
+                assert_almost_equal(res, 1.)
+
+        # -1 ** -1 possible special case
+        base = [np.array(-1, dt)[()] for dt in 'bhilq']
+        for i1, i2 in itertools.product(base, exp):
+            if i1.dtype.name != 'uint64':
+                assert_raises(ValueError, operator.pow, i1, i2)
+            else:
+                res = operator.pow(i1, i2)
+                assert_(res.dtype.type is np.float64)
+                assert_almost_equal(res, -1.)
+
+        # 2 ** -1 perhaps generic
+        base = [np.array(2, dt)[()] for dt in 'bhilqBHILQ']
+        for i1, i2 in itertools.product(base, exp):
+            if i1.dtype.name != 'uint64':
+                assert_raises(ValueError, operator.pow, i1, i2)
+            else:
+                res = operator.pow(i1, i2)
+                assert_(res.dtype.type is np.float64)
+                assert_almost_equal(res, .5)
 
     def test_mixed_types(self):
         typelist = [np.int8, np.int16, np.float16,


### PR DESCRIPTION
The previous behavior depended on whether numpy scalar integers or numpy integer arrays were involved.

For arrays
- Zero to negative integer powers returned least integral value.
- Both 1, -1 to negative integer powers returned correct values.
- The remaining integers returned zero when raised to negative integer powers.

For scalars
- Zero to negative integer powers returned least integral value.
- Both 1, -1 to negative integer powers returned correct values.
- The remaining integers sometimes returned zero, sometimes the correct float depending   on the integer type combination.

All of these cases now raise a `ValueError` except for those integer combinations whose common type is float, for instance uint64 and int8. It was felt that a simple rule was the best way to go rather than have special exceptions for the integer units. If you need negative powers, use an inexact type.

Note that the `np.power` ufunc is used for everything. At this point I think it is more important to settle the behavior than optimize for speed. There are now some bits of code I left in that are currently unused.
