### PR TITLE
BUG: Better check for invalid bounds in np.random.uniform.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1295,6 +1295,10 @@ cdef class RandomState:
         Py_INCREF(temp)  # needed to get around Pyrex's automatic reference-counting
                          # rules because EnsureArray steals a reference
         odiff = <ndarray>PyArray_EnsureArray(temp)
+
+        if not np.all(np.isfinite(odiff)):
+            raise OverflowError('Range exceeds valid bounds')
+
         return cont2_array(self.internal_state, rk_uniform, size, olow, odiff,
                            self.lock)
 

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -809,6 +809,8 @@ class TestRandomDist(TestCase):
         assert_raises(OverflowError, func, -np.inf, 0)
         assert_raises(OverflowError, func,  0,      np.inf)
         assert_raises(OverflowError, func,  fmin,   fmax)
+        assert_raises(OverflowError, func, [-np.inf], [0])
+        assert_raises(OverflowError, func, [0], [np.inf])
 
         # (fmax / 1e17) - fmin is within range, so this should not throw
         np.random.uniform(low=fmin, high=fmax / 1e17)


### PR DESCRIPTION
Closes #8226
