### PR TITLE
Replace calling "uname -m" via sub-shell/pipe with direct call to platform.machine()

### DIFF
--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -110,24 +110,7 @@ class LinuxCPUInfo(CPUInfoBase):
         if self.info is not None:
             return
         info = [ {} ]
-        ok, output = getoutput('uname -m')
-        if ok:
-            info[0]['uname_m'] = output.strip()
-        try:
-            fo = open('/proc/cpuinfo')
-        except EnvironmentError:
-            e = get_exception()
-            warnings.warn(str(e), UserWarning, stacklevel=2)
-        else:
-            for line in fo:
-                name_value = [s.strip() for s in line.split(':', 1)]
-                if len(name_value) != 2:
-                    continue
-                name, value = name_value
-                if not info or name in info[-1]: # next processor
-                    info.append({})
-                info[-1][name] = value
-            fo.close()
+        info[0]['uname_m'] = platform.machine()
         self.__class__.info = info
 
     def _not_impl(self): pass


### PR DESCRIPTION
Hi, we are having issue with numpy running 'uname -m' in a subshell/pipe to determine the machine type (i.e. amd64, i386 etc). The problem is that numpy code is not masking SIGCHLD while creating a subshell/pipe. Therefore if the application happens to have a custom SIGCHLD handler already installed when numpy gets imported that one is going to be executed potentially confusing application and causing it to terminate or do some unwanted stuff. There several ways to address this issue:

1. Properly mask SIGCHLD within numpy before calling subshell if needed and unmask it when it's done
2. Use python's built-in PipeX module, which does masking and unmasking on its own AFAIK
3. Use machine.platform() instead, which should return the same information as 'uname -m'

In this patch we've opted for the fix (3), as the most simple one to implement. Please also note that in our case we are using embedded python interpreter, which is probably why we have different SIGCHLD handler than stock python. However it might be possible to trigger that issue by installing custom SIGCHLD handler before importing numpy.