### PR TITLE
DOC: Clarified when a copy is made in numpy.asarray

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -480,8 +480,8 @@ def asarray(a, dtype=None, order=None):
     -------
     out : ndarray
         Array interpretation of `a`.  No copy is performed if the input
-        is already an ndarray.  If `a` is a subclass of ndarray, a base
-        class ndarray is returned.
+        is already an ndarray with matching dtype and order.  If `a` is a
+        subclass of ndarray, a base class ndarray is returned.
 
     See Also
     --------


### PR DESCRIPTION
`numpy.asarray` does copy the input if the specified dtype and/or order differ from the input even if it is an ndarray.

Not sure if the wording `with matching dtype and order` is perfect. Suggestions are welcome.