### PR TITLE
REL: Reset strides for RELAXED_STRIDE_CHECKING for 1.12 releases.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3812,10 +3812,6 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             else {
                 not_cf_contig = 0;
             }
-            if (dims[i] == 1) {
-                /* For testing purpose only */
-                strides[i] = NPY_MAX_INTP;
-            }
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }
 #if NPY_RELAXED_STRIDES_CHECKING
@@ -3839,10 +3835,6 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
 #if NPY_RELAXED_STRIDES_CHECKING
             else {
                 not_cf_contig = 0;
-            }
-            if (dims[i] == 1) {
-                /* For testing purpose only */
-                strides[i] = NPY_MAX_INTP;
             }
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }


### PR DESCRIPTION
Strides in some cases are set to NPY_MAX_INTP to smoke out illegal usage
in packages that use Numpy. We don't want that for the releases, so fix
it.