### PR TITLE
MAINT: Cleaned up mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,16 +10,14 @@
 
 Aaron Baecker <abaecker@localhost> abaecker <abaecker@localhost>
 Abdul Muneer <abdulmuneer@gmail.com> abdulmuneer <abdulmuneer@gmail.com>
-Adam Ginsburg <adam.g.ginsburg@gmail.com> Adam Ginsburg <adam.g.ginsburg@gmail.com>
 Adam Ginsburg <adam.g.ginsburg@gmail.com> Adam Ginsburg <keflavich@gmail.com>
-Allan Haldane <allan.haldane@gmail.com> ahaldane <ealloc@gmail.com>
 Albert Jornet Puig <albert.jornet@ic3.cat> jurnix <albert.jornet@ic3.cat>
+Alexander Belopolsky <abalkin@enlnt.com> Alexander Belopolsky <a@enlnt.com>
 Alex Griffing <argriffi@ncsu.edu> alex <argriffi@ncsu.edu>
 Alex Griffing <argriffi@ncsu.edu> argriffing <argriffi@ncsu.edu>
 Alex Griffing <argriffi@ncsu.edu> argriffing <argriffing@gmail.com>
 Alex Griffing <argriffi@ncsu.edu> argriffing <argriffing@users.noreply.github.com>
-Alexander Belopolsky <abalkin@enlnt.com> Alexander Belopolsky <a@enlnt.com>
-Alok Singhal <gandalf013@gmail.com> Alok Singhal <gandalf013@gmail.com>
+Allan Haldane <allan.haldane@gmail.com> ahaldane <ealloc@gmail.com>
 Alok Singhal <gandalf013@gmail.com> Alok Singhal <alok@merfinllc.com>
 Amir Sarabadani <ladsgroup@gmail.com> amir <ladsgroup@gmail.com>
 Anatoly Techtonik <techtonik@gmail.com> anatoly techtonik <techtonik@gmail.com>
@@ -28,8 +26,8 @@ Anne Archibald <peridot.faceted@gmail.com> aarchiba <peridot.faceted@gmail.com>
 Anne Archibald <peridot.faceted@gmail.com> Anne Archibald <archibald@astron.nl>
 Anže Starič <anze.staric@gmail.com> astaric <anze.staric@gmail.com>
 Aron Ahmadia <aron@ahmadia.net> ahmadia <aron@ahmadia.net>
-Arun Persaud <apersaud@lbl.gov> Arun Persaud <apersaud@lbl.gov>
 Arun Persaud <apersaud@lbl.gov> Arun Persaud <arun@nubati.net>
+Åsmund Hjulstad <ahju@statoil.com> Åsmund Hjulstad <asmund@hjulstad.com>
 Auke Wiggers <wiggers.auke@gmail.com> auke <wiggers.auke@gmail.com>
 Badhri Narayanan Krishnakumar <badhrinarayanan.k@gmail.com> badhrink <badhrinarayanan.k@gmail.com>
 Behzad Nouri <behzadnouri@gmail.com> behzad nouri <behzadnouri@gmail.com>
@@ -42,19 +40,17 @@ Bryan Van de Ven <bryanv@continuum.io> Bryan Van de Ven <bryan@Laptop-3.local>
 Bryan Van de Ven <bryanv@continuum.io> Bryan Van de Ven <bryan@laptop.local>
 Carl Kleffner <cmkleffner@gmail.com> carlkl <cmkleffner@gmail.com>
 Chris Burns <chris.burns@localhost> chris.burns <chris.burns@localhost>
-Chris Kerr <debdepba@dasganma.tk> Chris Kerr <debdepba@dasganma.tk>
 Chris Kerr <debdepba@dasganma.tk> Chris Kerr <cjk34@cam.ac.uk>
-Christoph Gohlke <cgohlke@uci.edu> Christolph Gohlke <cgohlke@uci.edu>
+Christopher Hanley <chanley@gmail.com> chanley <chanley@gmail.com>
 Christoph Gohlke <cgohlke@uci.edu> cgholke <?@?>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
-Christopher Hanley <chanley@gmail.com> chanley <chanley@gmail.com>
-Daniel <dabi@blazemail.com> Daniel <dabi@blazemail.com>
-Daniel J Farrell <danieljfarrel@me.com> danieljfarrell <danieljfarrel@me.com>
-Daniel Rasmussen <daniel.rasmussen@appliedbrainresearch.com> drasmuss <daniel.rasmussen@appliedbrainresearch.com>
-Daniel Müllner <Daniel Müllner muellner@math.stanford.edu> Daniel <muellner@localhost.localdomain>
-Daniel Müllner <Daniel Müllner muellner@math.stanford.edu> dmuellner <Daniel Müllner muellner@math.stanford.edu>
+Christoph Gohlke <cgohlke@uci.edu> Christolph Gohlke <cgohlke@uci.edu>
 Daniel da Silva <mail@danieldasilva.org> Daniel da Silva <daniel@meltingwax.net>
 Daniel da Silva <mail@danieldasilva.org> Daniel da Silva <var.mail.daniel@gmail.com>
+Daniel J Farrell <danieljfarrel@me.com> danieljfarrell <danieljfarrel@me.com>
+Daniel Müllner <Daniel Müllner muellner@math.stanford.edu> Daniel <muellner@localhost.localdomain>
+Daniel Müllner <Daniel Müllner muellner@math.stanford.edu> dmuellner <Daniel Müllner muellner@math.stanford.edu>
+Daniel Rasmussen <daniel.rasmussen@appliedbrainresearch.com> drasmuss <daniel.rasmussen@appliedbrainresearch.com>
 David Huard <david.huard@gmail.com> dhuard <dhuard@localhost>
 David M Cooke <cookedm@localhost>  cookedm <cookedm@localhost>
 David Ochoa <ochoadavid@gmail.com> ochoadavid <ochoadavid@gmail.com>
@@ -63,52 +59,46 @@ Derek Homeier <derek@astro.physik.uni-goettingen.de> Derek Homeir <derek@astro.p
 Derek Homeier <derek@astro.physik.uni-goettingen.de> Derek Homier <derek@astro.physik.uni-goettingen.de>
 Egor Zindy <ezindy@gmail.com> zindy <ezindy@gmail.com>
 Endolith <endolith@gmail.com>
-Eric Fode <ericfode@gmail.com> Eric Fode <ericfode@gmail.com>
 Eric Fode <ericfode@gmail.com> Eric Fode <ericfode@linuxlaptop.(none)>
 Eric Quintero <eric.antonio.quintero@gmail.com> e-q <eric.antonio.quintero@gmail.com>
 Ernest N. Mamikonyan <ernest.mamikonyan@gmail.com> mamikony <ernest.mamikonyan@sig.com>
-Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeny.burovskiy@gmail.com>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeni@burovski.me>
 Evgeny Toder <evgeny.toder@jpmorgan.com> eltjpm <evgeny.toder@jpmorgan.com>
 Fernando Perez <Fernando.Perez@berkeley.edu> Fernando Perez <fperez@fperez.org>
 Friedrich Dunne <dunneff@tcd.ie> dunneff <dunneff@tcd.ie>
 Gael Varoquaux <gael.varoquaux@normalesup.org> GaelVaroquaux <gael.varoquaux@normalesup.org>
-Gerrit Holl <g.holl@reading.ac.uk> Gerrit Holl <g.holl@reading.ac.uk>
 Gerrit Holl <gerrit.holl@utoronto.ca> Gerrit Holl <g.holl@reading.ac.uk>
 Giuseppe Venturini <ggventurini@users.noreply.github.com> ggventurini <ggventurini@users.noreply.github.com>
 Golnaz Irannejad <golnazirannejad@gmail.com> golnazir <golnazirannejad@gmail.com>
 Gopal Singh Meena <gopalmeena94@gmail.com> gopalmeena <gopalmeena94@gmail.com>
 Greg Knoll <gregory@bccn-berlin.de> gkBCCN <gregory@bccn-berlin.de>
+Greg Yang <sorcererofdm@gmail.com> eulerreich <sorcererofdm@gmail.com>
 Greg Young <gfyoung17@gmail.com> gfyoung <gfyoung17@gmail.com>
 Greg Young <gfyoung17@gmail.com> gfyoung <gfyoung@mit.edu>
-Greg Yang <sorcererofdm@gmail.com> eulerreich <sorcererofdm@gmail.com>
-Jason Grout <jason-github@creativetrax.com> Jason Grout <jason-github@creativetrax.com>
-Jason Grout <jason-github@creativetrax.com> Jason Grout <jason.grout@drake.edu>
-Jason King <pizza@netspace.net.au> jason king <pizza@netspace.net.au>
-Joseph Martinot-Lagarde <contrebasse@gmail.com> Joseph Martinot-Lagarde <contrebasse@gmail.com>
-Joseph Martinot-Lagarde <contrebasse@gmail.com> Joseph Martinot-Lagarde <joseph.martinot-lagarde@onera.fr>
-Julien Lhermitte <jrmlhermitte@gmail.com> Julien Lhermitte <jrmlhermitte@gmail.com>
-Julien Lhermitte <jrmlhermitte@gmail.com> Julien Lhermitte <lhermitte@bnl.gov>
-Julien Schueller <julien.schueller@gmail.com> jschueller <julien.schueller@gmail.com>
 Han Genuit <hangenuit@gmail.com> 87 <hangenuit@gmail.com>
-Han Genuit <hangenuit@gmail.com> Han <hangenuit@gmail.com>
 Han Genuit <hangenuit@gmail.com> hangenuit@gmail.com <hangenuit@gmail.com>
+Han Genuit <hangenuit@gmail.com> Han <hangenuit@gmail.com>
 Hanno Klemm <hanno.klemm@maerskoil.com> hklemm <hanno.klemm@maerskoil.com>
 Irvin Probst <irvin.probst@ensta-bretagne.fr> I--P <irvin.probst@ensta-bretagne.fr>
-Jaime Fernandez <jaime.frio@gmail.com> Jaime <jaime.frio@gmail.com>
 Jaime Fernandez <jaime.frio@gmail.com> Jaime Fernandez <jaime.fernandez@hp.com>
 Jaime Fernandez <jaime.frio@gmail.com> jaimefrio <jaime.frio@gmail.com>
+Jaime Fernandez <jaime.frio@gmail.com> Jaime <jaime.frio@gmail.com>
 Jarrod Millman <millman@berkeley.edu> Jarrod Millman <jarrod.millman@gmail.com>
+Jason Grout <jason-github@creativetrax.com> Jason Grout <jason.grout@drake.edu>
+Jason King <pizza@netspace.net.au> jason king <pizza@netspace.net.au>
 Jay Bourque <jay.bourque@continuum.io> jayvius <jay.bourque@continuum.io>
 Jerome Kelleher <jerome.kelleher@ed.ac.uk> jeromekelleher <jerome.kelleher@ed.ac.uk>
 Johannes Schönberger <hannesschoenberger@gmail.com> Johannes Schönberger <jschoenberger@demuc.de>
 Joseph Fox-Rabinovitz <jfoxrabinovitz@gmail.com> Joseph Fox-Rabinovitz <joseph.r.fox-rabinovitz@nasa.gov>
 Joseph Fox-Rabinovitz <jfoxrabinovitz@gmail.com> Mad Physicist <madphysicist@users.noreply.github.com>
+Joseph Martinot-Lagarde <contrebasse@gmail.com> Joseph Martinot-Lagarde <joseph.martinot-lagarde@onera.fr>
 Julian Taylor <juliantaylor108@gmail.com> Julian Taylor <jtaylor.debian@googlemail.com>
 Julian Taylor <juliantaylor108@gmail.com> Julian Taylor <juliantaylor108@googlemail.com>
+Julien Lhermitte <jrmlhermitte@gmail.com> Julien Lhermitte <lhermitte@bnl.gov>
+Julien Schueller <julien.schueller@gmail.com> jschueller <julien.schueller@gmail.com>
 Khaled Ben Abdallah Okuda <khaled.ben.okuda@gmail.com> KhaledTo <khaled.ben.okuda@gmail.com>
-Lars Buitinck <larsmans@gmail.com> Lars Buitinck <L.J.Buitinck@uva.nl>
 Lars Buitinck <larsmans@gmail.com> Lars Buitinck <l.buitinck@esciencecenter.nl>
+Lars Buitinck <larsmans@gmail.com> Lars Buitinck <L.J.Buitinck@uva.nl>
 Luis Pedro Coelho <luis@luispedro.org> Luis Pedro Coelho <lpc@cmu.edu>
 Luke Zoltan Kelley <lkelley@cfa.harvard.edu> lzkelley <lkelley@cfa.harvard.edu>
 Manoj Kumar <manojkumarsivaraj334@gmail.com> MechCoder <manojkumarsivaraj334@gmail.com>
@@ -122,22 +112,23 @@ Martin Teichmann <martin.teichmann@xfel.eu> Martin Teichmann <lkb.teichmann@gmai
 Mattheus Ueckermann <empeeu@yahoo.com> empeeu <empeeu@yahoo.com>
 Matthew Harrigan <harrigan.matthew@gmail.com> MattHarrigan <harrigan.matthew@gmail.com>
 Matti Picus <matti.picus@gmail.com> mattip <matti.picus@gmail.com>
-Michael Droettboom <mdboom@gmail.com> mdroe <mdroe@localhost>
-Michael Martin <mmartin4242@gmail.com> mmartin <mmartin4242@gmail.com>
-Michael  K. Tran  <trankmichael@gmail.com> mtran <trankmichael@gmail.com>
 Michael Behrisch <oss@behrisch.de> behrisch <behrisch@users.sourceforge.net>
+Michael Droettboom <mdboom@gmail.com> mdroe <mdroe@localhost>
+Michael  K. Tran  <trankmichael@gmail.com> mtran <trankmichael@gmail.com>
+Michael Martin <mmartin4242@gmail.com> mmartin <mmartin4242@gmail.com>
 Nathaniel J. Smith <njs@pobox.com> njsmith <njs@pobox.com>
 Naveen Arunachalam <notatroll.troll@gmail.com> naveenarun <notatroll.troll@gmail.com>
 Nicolas Scheffer <nicolas.scheffer@sri.com> Nicolas Scheffer <scheffer@speech.sri.com>
 Ondřej Čertík <ondrej.certik@gmail.com> Ondrej Certik <ondrej.certik@gmail.com>
+Óscar Villellas Guillén <oscar.villellas@continuum.io> ovillellas <oscar.villellas@continuum.io>
 Pat Miller <patmiller@localhost> patmiller <patmiller@localhost>
 Paul Ivanov <pi@berkeley.edu> Paul Ivanov <paul.ivanov@local>
 Paul Jacobson <hpj3@myuw.net> hpaulj <hpj3@myuw.net>
 Pearu Peterson <pearu.peterson@gmail.com> Pearu Peterson <pearu@pearu-laptop.(none)>
 Peter J Cock <p.j.a.cock@googlemail.com> peterjc <p.j.a.cock@googlemail.com>
 Phil Elson <pelson.pub@gmail.com>
-Pierre GM <pierregmcode@gmail.com> pierregm <pierregm@localhost>
 Pierre GM <pierregmcode@gmail.com> pierregm <pierregmcode@gmail.com>
+Pierre GM <pierregmcode@gmail.com> pierregm <pierregm@localhost>
 Prabhu Ramachandran <prabhu@localhost> prabhu <prabhu@localhost>
 Ralf Gommers <ralf.gommers@gmail.com> Ralf Gommers <ralf.gommers@googlemail.com>
 Ralf Gommers <ralf.gommers@gmail.com> rgommers <ralf.gommers@googlemail.com>
@@ -145,23 +136,20 @@ Rehas Sachdeva <aquannie@gmail.com> rehassachdeva <aquannie@gmail.com>
 Ritta Narita <narittan@gmail.com> RittaNarita <narittan@gmail.com>
 Robert Kern <rkern@enthought.com> Robert Kern <robert.kern@gmail.com>
 Robert LU <robberphex@gmail.com> RobberPhex <robberphex@gmail.com>
-Ronan Lamy <ronan.lamy@gmail.com> Ronan Lamy <ronan.lamy@gmail.com>
 Ronan Lamy <ronan.lamy@gmail.com> Ronan Lamy <Ronan.Lamy@normalesup.org>
 Russell Hewett <rhewett@mit.edu> rhewett <rhewett@mit.edu>
 Ryan Blakemore <rbtnet@gmail.com> ryanblak <rbtnet@gmail.com>
 Sam Preston <j.sam.preston@gmail.com> jspreston <j.sam.preston@gmail.com>
 Sam Radhakrishnan <sk09idm@gmail.com> = <=>
 Sam Radhakrishnan <sk09idm@gmail.com> sam09 <sk09idm@gmail.com>
-Saurabh Mehta <e.samehta@gmail.com>
 Saullo Giovani <saullogiovani@gmail.com> saullogiovani <saullogiovani@gmail.com>
+Saurabh Mehta <e.samehta@gmail.com>
 Sebastian Berg <sebastian@sipsolutions.net> seberg <sebastian@sipsolutions.net>
 Shota Kawabuchi <shota.kawabuchi+GitHub@gmail.com> skwbc <shota.kawabuchi+GitHub@gmail.com>
 Stefan van der Walt <stefanv@berkeley.edu> Stefan van der Walt <sjvdwalt@gmail.com>
 Stefan van der Walt <stefanv@berkeley.edu> Stefan van der Walt <stefan@sun.ac.za>
-Stephan Hoyer <shoyer@gmail.com> Stephan Hoyer <shoyer@gmail.com>
 Stephan Hoyer <shoyer@gmail.com> Stephan Hoyer <shoyer@climate.com>
 Steven J Kern <kern.steven0@gmail.com>
-Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@bnl.gov>
 Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@bnl.gov>
 Tim Cera <tim@cerazone.net> tim cera <tcera@sjrwmd.com>
 Tom Poole <t.b.poole@gmail.com> tpoole <t.b.poole@gmail.com>
@@ -171,5 +159,3 @@ Valentin Haenel <valentin@haenel.co> Valentin Haenel <valentin.haenel@gmx.de>
 Warren Weckesser <warren.weckesser@enthought.com> Warren Weckesser <warren.weckesser@gmail.com>
 Wendell Smith <wendellwsmith@gmail.com> Wendell Smith <wackywendell@gmail.com>
 William Spotz <wfspotz@sandia.gov@localhost> wfspotz@sandia.gov <wfspotz@sandia.gov@localhost>
-Åsmund Hjulstad <ahju@statoil.com> Åsmund Hjulstad <asmund@hjulstad.com>
-Óscar Villellas Guillén <oscar.villellas@continuum.io> ovillellas <oscar.villellas@continuum.io>


### PR DESCRIPTION
This is a followup to #8182

Ran the following commands:

    sort .mailmap > .mailmap2
    # Cleanup comment lines that were moved around>
    mv .mailmap2 .mailmap
    uniq .mailmap > .mailmap2
    mv .mailmap2 .mailmap
    sed 's/\(.* <.*>\) \1//' .mailmap > .mailmap2
    mv .mailmap2 .mailmap

The following entries were removed:

```
Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@bnl.gov>

Adam Ginsburg <adam.g.ginsburg@gmail.com> Adam Ginsburg <adam.g.ginsburg@gmail.com>
Alok Singhal <gandalf013@gmail.com> Alok Singhal <gandalf013@gmail.com>
Arun Persaud <apersaud@lbl.gov> Arun Persaud <apersaud@lbl.gov>
Chris Kerr <debdepba@dasganma.tk> Chris Kerr <debdepba@dasganma.tk>
Daniel <dabi@blazemail.com> Daniel <dabi@blazemail.com>
Eric Fode <ericfode@gmail.com> Eric Fode <ericfode@gmail.com>
Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeny.burovskiy@gmail.com>
Gerrit Holl <g.holl@reading.ac.uk> Gerrit Holl <g.holl@reading.ac.uk>
Jason Grout <jason-github@creativetrax.com> Jason Grout <jason-github@creativetrax.com>
Joseph Martinot-Lagarde <contrebasse@gmail.com> Joseph Martinot-Lagarde <contrebasse@gmail.com>
Julien Lhermitte <jrmlhermitte@gmail.com> Julien Lhermitte <jrmlhermitte@gmail.com>
Ronan Lamy <ronan.lamy@gmail.com> Ronan Lamy <ronan.lamy@gmail.com>
Stephan Hoyer <shoyer@gmail.com> Stephan Hoyer <shoyer@gmail.com>
```
The first one is the only true duplicate.
