### PR TITLE
BUG: np.piecewise not working for scalars

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1225,9 +1225,9 @@ def piecewise(x, condlist, funclist, *args, **kw):
 
     Parameters
     ----------
-    x : ndarray
+    x : ndarray or scalar
         The input domain.
-    condlist : list of bool arrays
+    condlist : list of bool arrays or bool scalars
         Each boolean array corresponds to a function in `funclist`.  Wherever
         `condlist[i]` is True, `funclist[i](x)` is used as the output value.
 
@@ -1296,12 +1296,21 @@ def piecewise(x, condlist, funclist, *args, **kw):
     >>> np.piecewise(x, [x < 0, x >= 0], [lambda x: -x, lambda x: x])
     array([ 2.5,  1.5,  0.5,  0.5,  1.5,  2.5])
 
+    Apply the same function to a scalar value.
+
+    >>> y = -2
+    >>> np.piecewise(y, [y < 0, y >= 0], [lambda x: -x, lambda x: x])
+    array(2)
+
     """
     x = asanyarray(x)
     n2 = len(funclist)
     if (isscalar(condlist) or not (isinstance(condlist[0], list) or
                                    isinstance(condlist[0], ndarray))):
-        condlist = [condlist]
+        if not isscalar(condlist) and x.size == 1 and x.ndim == 0:
+            condlist = [[c] for c in condlist]
+        else:
+            condlist = [condlist]
     condlist = array(condlist, dtype=bool)
     n = len(condlist)
     # This is a hack to work around problems with NumPy's
@@ -1311,8 +1320,6 @@ def piecewise(x, condlist, funclist, *args, **kw):
     if x.ndim == 0:
         x = x[None]
         zerod = True
-        if condlist.shape[-1] != 1:
-            condlist = condlist.T
     if n == n2 - 1:  # compute the "otherwise" condition.
         totlist = np.logical_or.reduce(condlist, axis=0)
         # Only able to stack vertically if the array is 1d or less

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2299,9 +2299,19 @@ class TestPiecewise(TestCase):
         assert_(y.ndim == 0)
         assert_(y == 1)
 
+        # With 3 ranges (It was failing, before)
+        y = piecewise(x, [False, False, True], [1, 2, 3])
+        assert_array_equal(y, 3)
+
     def test_0d_comparison(self):
         x = 3
-        piecewise(x, [x <= 3, x > 3], [4, 0])  # Should succeed.
+        y = piecewise(x, [x <= 3, x > 3], [4, 0])  # Should succeed.
+        assert_equal(y, 4)
+
+        # With 3 ranges (It was failing, before)
+        x = 4
+        y = piecewise(x, [x <= 3, (x > 3) * (x <= 5), x > 5], [1, 2, 3])
+        assert_array_equal(y, 2)
 
     def test_multidimensional_extrafunc(self):
         x = np.array([[-2.5, -1.5, -0.5],


### PR DESCRIPTION
Backport of #8194.

I was using np.piecewise to create a piecewise lambda function, and I realized that the way it is written it only allows to work with ndarrays, and not with list of scalars for the condlist argument. 

Similarly to may other functions in np which can handle both ndarrays and native types, this also should.

I am making the following function:

``` python
import numpy as np

def buildPieceWise(x):
    condlist=[x<-1,(x>=-1)*(x<1),x>1]
    funclist=[lambda x: -x, 0, lambda x:x]
    return np.piecewise(x,condlist,funclist)
```

This works fine:

``` python
>>>print buildPieceWise(np.linspace(-2,2,11))
[ 2.   1.6  1.2  0.   0.   0.   0.   0.   1.2  1.6  2. ]
```

But this fails:

``` python
>>>print buildPieceWise(-1.5)
C:\Anaconda\lib\site-packages\numpy\lib\function_base.pyc in piecewise(x, condlist, funclist, *args, **kw)
    773     if (n != n2):
    774         raise ValueError(
--> 775                 "function list and condition list must be the same")
ValueError: function list and condition list must be the same
```

And the reason is that internally, it is detecting that my masklist is `[False,False,True]`, this part of the code:

``` python
if (isscalar(condlist) or not (isinstance(condlist[0], list) or
                                   isinstance(condlist[0], ndarray))):
        condlist = [condlist]
```

makes len(condlist)==1.

I have replaced that condition by:

``` python
if (isscalar(condlist) or not (isinstance(condlist[0], list) or
                                   isinstance(condlist[0], ndarray))):
        if not isscalar(condlist) and x.size == 1 and len(x.shape) == 0:
            condlist = [[c] for c in condlist]
        else:
            condlist = [condlist]
```

This makes it work in both cases:

``` python
import numpy as np

def buildPieceWise(x):
    condlist=[x<-1,(x>=-1)*(x<1),x>1]
    funclist=[lambda x: -x, 0, lambda x:x]
    return np.piecewise(x,condlist,funclist)
```

```
>>>print buildPieceWise(np.linspace(-2,2,11))
>>>print buildPieceWise(-1.5)
[ 2.   1.6  1.2  0.   0.   0.   0.   0.   1.2  1.6  2. ]
1.5
```
