### PR TITLE
ENH: Add index_tricks.as_index_tuple

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -159,6 +159,11 @@ being iterated over.
 For consistency with ``ndarray`` and ``broadcast``, ``d.ndim`` is a shorthand
 for ``len(d.shape)``.
 
+``as_index_tuple`` function in ``index_tricks``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Exposes the internal normalization that happens when indexing with non-tuple
+objects to convert them into tuples. Useful for correctly overriding or
+wrapping ndarray.__getitem__
 
 Improvements
 ============

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5403,6 +5403,22 @@ add_newdoc('numpy.core.multiarray', 'unpackbits',
 
     """)
 
+add_newdoc('numpy.core.multiarray', 'as_index_tuple',
+    """
+    as_index_tuple(index)
+
+    Normalizes an index argument, like that passed to `__getitem__`, into a tuple.
+    Follows the invariant that `x[index]` is identical to `x[as_index_tuple(index)].
+
+    Examples
+    --------
+    >>> as_index_tuple(1)
+    (1,)
+    >>> as_index_tuple([1, 2, None])
+    (1, 2, None)
+    >>> as_index_tuple([1, 2, 3])
+    ([1, 2, 3])
+    """)
 
 ##############################################################################
 #

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -221,7 +221,7 @@ prepare_index_tuple(PyObject *index)
     /* If the index is not a tuple, convert it into (index,) */
     if (!make_tuple && !PyTuple_CheckExact(index)) {
         make_tuple = 1;
-        index_as_tuple = Py_BuildValue("(O)", index);
+        index_as_tuple = PyTuple_Pack(1, index);
     }
     /* Otherwise, check if the tuple is too long */
     else if (PyTuple_GET_SIZE(index_as_tuple) > NPY_MAXDIMS * 2) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -218,22 +218,19 @@ prepare_index_tuple(PyObject *index)
         }
     }
 
-    /* If the index is not a tuple, conver it into (index,) */
+    /* If the index is not a tuple, convert it into (index,) */
     if (!make_tuple && !PyTuple_CheckExact(index)) {
         make_tuple = 1;
         index_as_tuple = Py_BuildValue("(O)", index);
     }
     /* Otherwise, check if the tuple is too long */
-    else {
-        n = PyTuple_GET_SIZE(index_as_tuple);
-        if (n > NPY_MAXDIMS * 2) {
-            PyErr_SetString(PyExc_IndexError,
-                            "too many indices for array");
-            if (make_tuple) {
-                Py_DECREF(index_as_tuple);
-            }
-            return NULL;
+    else if (PyTuple_GET_SIZE(index_as_tuple) > NPY_MAXDIMS * 2) {
+        PyErr_SetString(PyExc_IndexError,
+                        "too many indices for array");
+        if (make_tuple) {
+            Py_DECREF(index_as_tuple);
         }
+        return NULL;
     }
 
     /* if we didn't make a tuple, then we're creating another reference */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -139,9 +139,10 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
     *ret = (PyArrayObject *)new;
 }
 
-
 /**
- * Prepare an index argument into a tuple
+ * Prepare an index argument into a c-array of indices.
+ *
+ * Returns the number of indices, or -1 on failure
  *
  * This mainly implements the following section from the advanced indexing docs:
  * > In order to remain backward compatible with a common usage in Numeric,
@@ -150,100 +151,137 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
  * > or the newaxis object, but not for integer arrays or other embedded
  * > sequences.
  *
- * This also promotes scalars to 1-tuples, and downcasts tuple subclasses
+ * This promotes scalars to 1-tuples.
  *
  * @param the index object, which may or may not be a tuple
  *
- * @returns the index converted to a tuple, if possible, else NULL on an error
- *          It is the caller's responsibility to call Py_DECREF on a non-null
- *          result, even if it is the same as the input.
+ * @returns the index converted to null-terminated pyobject array. The caller
+ *          must call PyArray_Free
  */
-NPY_NO_EXPORT PyObject *
-prepare_index_tuple(PyObject *index)
+NPY_NO_EXPORT npy_intp
+prepare_index_tuple(PyObject *index, PyObject **result)
 {
-    int i;
-    npy_intp n;
-    npy_bool make_tuple = 0;
+    npy_intp n, i;
+    npy_bool commit_to_unpack;
 
-    PyObject *index_as_tuple = index;
-
-    if (!PyTuple_CheckExact(index)
-            /* Next three are just to avoid slow checks */
-#if !defined(NPY_PY3K)
-            && (!PyInt_CheckExact(index))
-#else
-            && (!PyLong_CheckExact(index))
-#endif
-            && (index != Py_None)
-            && (!PySlice_Check(index))
-            && (!PyArray_Check(index))
-            && (PySequence_Check(index))) {
-        /*
-         * Sequences < NPY_MAXDIMS with any slice objects
-         * or newaxis, Ellipsis or other arrays or sequences
-         * embedded, are considered equivalent to an indexing
-         * tuple. (`a[[[1,2], [3,4]]] == a[[1,2], [3,4]]`)
-         */
-
-        if (PyTuple_Check(index)) {
-            /* If it is already a tuple, make it an exact tuple anyway */
-            n = 0;
-            make_tuple = 1;
-        }
-        else {
-            n = PySequence_Size(index);
-        }
-        if (n < 0 || n >= NPY_MAXDIMS) {
-            n = 0;
+    /* fast route for passing a tuple */
+    if (PyTuple_CheckExact(index)) {
+        n = PyTuple_GET_SIZE(index);
+        if (n > NPY_MAXDIMS * 2) {
+            PyErr_SetString(PyExc_IndexError,
+                            "too many indices for array");
+            return -1;
         }
         for (i = 0; i < n; i++) {
-            PyObject *tmp_obj = PySequence_GetItem(index, i);
-            /* if getitem fails (unusual) treat this as a single index */
+            result[i] = PyTuple_GET_ITEM(index, i);
+        }
+        return n;
+    }
+
+    /* Obvious single-entry cases */
+    if (0
+#if !defined(NPY_PY3K)
+            || PyInt_CheckExact(index)
+#else
+            || PyLong_CheckExact(index)
+#endif
+            || index == Py_None
+            || PySlice_Check(index)
+            || PyArray_Check(index)
+            || !PySequence_Check(index)) {
+
+        result[0] = index;
+        return 1;
+    }
+
+    /* passing a tuple subclass - needs to handle errors */
+    if (PyTuple_Check(index)) {
+        n = PySequence_Size(index);
+        if (n < 0) {
+            return -1;
+        }
+        if (n > NPY_MAXDIMS * 2) {
+            PyErr_SetString(PyExc_IndexError,
+                            "too many indices for array");
+            return -1;
+        }
+        for (i = 0; i < n; i++) {
+            result[i] = PySequence_GetItem(index, i);
+            if (result[i] == NULL) {
+                return -1;
+            }
+        }
+        return n;
+    }
+
+    /* At this point, we're left with a non-tuple, non-array, sequence:
+     * typically, a list
+     *
+     * Sequences < NPY_MAXDIMS with any slice objects
+     * or newaxis, Ellipsis or other arrays or sequences
+     * embedded, are considered equivalent to an indexing
+     * tuple. (`a[[[1,2], [3,4]]] == a[[1,2], [3,4]]`)
+     */
+
+    /* if len fails, treat like a scalar */
+    n = PySequence_Size(index);
+    if (n < 0) {
+        PyErr_Clear();
+        result[0] = index;
+        return 1;
+    }
+
+    /* for some reason, anything that's long but not too long is turned into
+     * a single index. The *2 is missing here for backward-compatibility. */
+    if (n >= NPY_MAXDIMS) {
+        result[0] = index;
+        return 1;
+    }
+
+    /* Some other type of short sequence - assume we should unpack it like a
+     * tuple, until we find something that proves us wrong */
+    commit_to_unpack = 0;
+    for (i = 0; i < n; i++) {
+        PyObject *tmp_obj = result[i] = PySequence_GetItem(index, i);
+
+        if (commit_to_unpack) {
+            /* propagate errors */
+            if (tmp_obj == NULL) {
+                return -1;
+            }
+        }
+        else {
+            /* if getitem fails (unusual) before we've committed, then
+             * commit to not unpacking */
             if (tmp_obj == NULL) {
                 PyErr_Clear();
-                make_tuple = 0;
                 break;
             }
-            if (PyArray_Check(tmp_obj) || PySequence_Check(tmp_obj)
-                    || PySlice_Check(tmp_obj) || tmp_obj == Py_Ellipsis
+
+            /* decide if we should treat this sequence like a tuple */
+            if (PyArray_Check(tmp_obj)
+                    || PySequence_Check(tmp_obj)
+                    || PySlice_Check(tmp_obj)
+                    || tmp_obj == Py_Ellipsis
                     || tmp_obj == Py_None) {
-                make_tuple = 1;
-                Py_DECREF(tmp_obj);
-                break;
-            }
-            Py_DECREF(tmp_obj);
-        }
-
-        if (make_tuple) {
-            /* We want to interpret it as a tuple, so make it one */
-            index_as_tuple = PySequence_Tuple(index);
-            if (index_as_tuple == NULL) {
-                return NULL;
+                commit_to_unpack = 1;
             }
         }
+
+        Py_DECREF(tmp_obj);
     }
 
-    /* If the index is not a tuple, convert it into (index,) */
-    if (!make_tuple && !PyTuple_CheckExact(index)) {
-        make_tuple = 1;
-        index_as_tuple = PyTuple_Pack(1, index);
-    }
-    /* Otherwise, check if the tuple is too long */
-    else if (PyTuple_GET_SIZE(index_as_tuple) > NPY_MAXDIMS * 2) {
-        PyErr_SetString(PyExc_IndexError,
-                        "too many indices for array");
-        if (make_tuple) {
-            Py_DECREF(index_as_tuple);
-        }
-        return NULL;
+    /* unpacking was the right thing to do, and we already did it */
+    if (commit_to_unpack) {
+        return n;
     }
 
-    /* if we didn't make a tuple, then we're creating another reference */
-    if (!make_tuple) {
-        Py_INCREF(index);
+    /* got to the end, never found an indication that we should have unpacked */
+    else {
+        /* we already filled result, but it doesn't matter */
+        result[0] = index;
+        return 1;
     }
-
-    return index_as_tuple;
 }
 
 /**
@@ -286,12 +324,12 @@ prepare_index(PyArrayObject *self, PyObject *index,
     int index_type = 0;
     int ellipsis_pos = -1;
 
-    index = prepare_index_tuple(index);
-    if (index == NULL) {
+    PyObject *raw_indices[NPY_MAXDIMS*2];
+
+    index_ndim = prepare_index_tuple(index, raw_indices);
+    if (index_ndim == -1) {
         return -1;
     }
-
-    index_ndim = (int) PyTuple_GET_SIZE(index);
 
     /*
      * Parse all indices into the `indices` array of index_info structs
@@ -308,7 +346,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
                             "too many indices for array");
             goto failed_building_indices;
         }
-        obj = PyTuple_GET_ITEM(index, get_idx++);
+
+        obj = raw_indices[get_idx++];
 
         /**** Try the cascade of possible indices ****/
 
@@ -712,7 +751,6 @@ prepare_index(PyArrayObject *self, PyObject *index,
     *ndim = new_ndim + fancy_ndim;
     *out_fancy_ndim = fancy_ndim;
 
-    Py_DECREF(index);
 
     return index_type;
 
@@ -720,7 +758,6 @@ prepare_index(PyArrayObject *self, PyObject *index,
     for (i=0; i < curr_idx; i++) {
         Py_XDECREF(indices[i].object);
     }
-    Py_DECREF(index);
     return -1;
 }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -143,15 +143,20 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
 /**
  * Prepare an index argument into a tuple
  *
- * The index might be a multi-dimensional index, but not yet a tuple
- * this makes it a tuple in that case. This also promotes scalars to 1-tuples.
+ * This mainly implements the following section from the advanced indexing docs:
+ * > In order to remain backward compatible with a common usage in Numeric,
+ * > basic slicing is also initiated if the selection object is any non-ndarray
+ * > sequence (such as a list) containing slice objects, the Ellipsis object,
+ * > or the newaxis object, but not for integer arrays or other embedded
+ * > sequences.
  *
- * It is the callers repsonsibility to call Py_DECREF on a non-null result,
- * even if it is the same as the input.
+ * This also promotes scalars to 1-tuples, and downcasts tuple subclasses
  *
  * @param the index object, which may or may not be a tuple
  *
  * @returns the index converted to a tuple, if possible, else NULL on an error
+ *          It is the caller's responsibility to call Py_DECREF on a non-null
+ *          result, even if it is the same as the input.
  */
 NPY_NO_EXPORT PyObject *
 prepare_index_tuple(PyObject *index)

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -285,6 +285,40 @@ prepare_index_tuple(PyObject *index, PyObject **result)
 }
 
 /**
+ * Expose prepare_index_tuple to python code
+ */
+NPY_NO_EXPORT PyObject *
+as_index_tuple(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    PyObject *obj;
+    PyObject *result;
+    PyObject *prepared[NPY_MAXDIMS*2];
+    npy_intp i, n;
+
+    if (!PyArg_ParseTuple(args, "O", &obj)) {
+        return NULL;
+    }
+    n = prepare_index_tuple(obj, prepared);
+    if (n < 0) {
+        return NULL;
+    }
+
+    result = PyTuple_New(n);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < n; i++) {
+        PyObject *val = prepared[i];
+        Py_INCREF(val);
+        PyTuple_SET_ITEM(result, i, val);
+    }
+
+    return result;
+}
+
+
+/**
  * Prepare an npy_index_object from the python slicing object.
  *
  * This function handles all index preparations with the exception

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -141,52 +141,27 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
 
 
 /**
- * Prepare an npy_index_object from the python slicing object.
+ * Prepare an index argument into a tuple
  *
- * This function handles all index preparations with the exception
- * of field access. It fills the array of index_info structs correctly.
- * It already handles the boolean array special case for fancy indexing,
- * i.e. if the index type is boolean, it is exactly one matching boolean
- * array. If the index type is fancy, the boolean array is already
- * converted to integer arrays. There is (as before) no checking of the
- * boolean dimension.
+ * The index might be a multi-dimensional index, but not yet a tuple
+ * this makes it a tuple in that case. This also promotes scalars to 1-tuples.
  *
- * Checks everything but the bounds.
+ * It is the callers repsonsibility to call Py_DECREF on a non-null result,
+ * even if it is the same as the input.
  *
- * @param the array being indexed
- * @param the index object
- * @param index info struct being filled (size of NPY_MAXDIMS * 2 + 1)
- * @param number of indices found
- * @param dimension of the indexing result
- * @param dimension of the fancy/advanced indices part
- * @param whether to allow the boolean special case
+ * @param the index object, which may or may not be a tuple
  *
- * @returns the index_type or -1 on failure and fills the number of indices.
+ * @returns the index converted to a tuple, if possible, else NULL on an error
  */
-NPY_NO_EXPORT int
-prepare_index(PyArrayObject *self, PyObject *index,
-              npy_index_info *indices,
-              int *num, int *ndim, int *out_fancy_ndim, int allow_boolean)
+NPY_NO_EXPORT PyObject *
+prepare_index_tuple(PyObject *index)
 {
-    int new_ndim, fancy_ndim, used_ndim, index_ndim;
-    int curr_idx, get_idx;
-
     int i;
     npy_intp n;
-
     npy_bool make_tuple = 0;
-    PyObject *obj = NULL;
-    PyArrayObject *arr;
 
-    int index_type = 0;
-    int ellipsis_pos = -1;
+    PyObject *index_as_tuple = index;
 
-    /*
-     * The index might be a multi-dimensional index, but not yet a tuple
-     * this makes it a tuple in that case.
-     *
-     * TODO: Refactor into its own function.
-     */
     if (!PyTuple_CheckExact(index)
             /* Next three are just to avoid slow checks */
 #if !defined(NPY_PY3K)
@@ -236,28 +211,85 @@ prepare_index(PyArrayObject *self, PyObject *index,
 
         if (make_tuple) {
             /* We want to interpret it as a tuple, so make it one */
-            index = PySequence_Tuple(index);
-            if (index == NULL) {
-                return -1;
+            index_as_tuple = PySequence_Tuple(index);
+            if (index_as_tuple == NULL) {
+                return NULL;
             }
         }
     }
 
-    /* If the index is not a tuple, handle it the same as (index,) */
-    if (!PyTuple_CheckExact(index)) {
-        obj = index;
-        index_ndim = 1;
+    /* If the index is not a tuple, conver it into (index,) */
+    if (!make_tuple && !PyTuple_CheckExact(index)) {
+        make_tuple = 1;
+        index_as_tuple = Py_BuildValue("(O)", index);
     }
+    /* Otherwise, check if the tuple is too long */
     else {
-        n = PyTuple_GET_SIZE(index);
+        n = PyTuple_GET_SIZE(index_as_tuple);
         if (n > NPY_MAXDIMS * 2) {
             PyErr_SetString(PyExc_IndexError,
                             "too many indices for array");
-            goto fail;
+            if (make_tuple) {
+                Py_DECREF(index_as_tuple);
+            }
+            return NULL;
         }
-        index_ndim = (int)n;
-        obj = NULL;
     }
+
+    /* if we didn't make a tuple, then we're creating another reference */
+    if (!make_tuple) {
+        Py_INCREF(index);
+    }
+
+    return index_as_tuple;
+}
+
+/**
+ * Prepare an npy_index_object from the python slicing object.
+ *
+ * This function handles all index preparations with the exception
+ * of field access. It fills the array of index_info structs correctly.
+ * It already handles the boolean array special case for fancy indexing,
+ * i.e. if the index type is boolean, it is exactly one matching boolean
+ * array. If the index type is fancy, the boolean array is already
+ * converted to integer arrays. There is (as before) no checking of the
+ * boolean dimension.
+ *
+ * Checks everything but the bounds.
+ *
+ * @param the array being indexed
+ * @param the index object
+ * @param index info struct being filled (size of NPY_MAXDIMS * 2 + 1)
+ * @param number of indices found
+ * @param dimension of the indexing result
+ * @param dimension of the fancy/advanced indices part
+ * @param whether to allow the boolean special case
+ *
+ * @returns the index_type or -1 on failure and fills the number of indices.
+ */
+NPY_NO_EXPORT int
+prepare_index(PyArrayObject *self, PyObject *index,
+              npy_index_info *indices,
+              int *num, int *ndim, int *out_fancy_ndim, int allow_boolean)
+{
+    int new_ndim, fancy_ndim, used_ndim, index_ndim;
+    int curr_idx, get_idx;
+
+    int i;
+    npy_intp n;
+
+    PyObject *obj = NULL;
+    PyArrayObject *arr;
+
+    int index_type = 0;
+    int ellipsis_pos = -1;
+
+    index = prepare_index_tuple(index);
+    if (index == NULL) {
+        return -1;
+    }
+
+    index_ndim = (int) PyTuple_GET_SIZE(index);
 
     /*
      * Parse all indices into the `indices` array of index_info structs
@@ -274,15 +306,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
                             "too many indices for array");
             goto failed_building_indices;
         }
-
-        /* Check for single index. obj is already set then. */
-        if ((curr_idx != 0) || (obj == NULL)) {
-            obj = PyTuple_GET_ITEM(index, get_idx++);
-        }
-        else {
-            /* only one loop */
-            get_idx += 1;
-        }
+        obj = PyTuple_GET_ITEM(index, get_idx++);
 
         /**** Try the cascade of possible indices ****/
 
@@ -686,9 +710,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
     *ndim = new_ndim + fancy_ndim;
     *out_fancy_ndim = fancy_ndim;
 
-    if (make_tuple) {
-        Py_DECREF(index);
-    }
+    Py_DECREF(index);
 
     return index_type;
 
@@ -696,10 +718,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
     for (i=0; i < curr_idx; i++) {
         Py_XDECREF(indices[i].object);
     }
-  fail:
-    if (make_tuple) {
-        Py_DECREF(index);
-    }
+    Py_DECREF(index);
     return -1;
 }
 

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -47,6 +47,9 @@ array_subscript(PyArrayObject *self, PyObject *op);
 NPY_NO_EXPORT int
 array_assign_item(PyArrayObject *self, Py_ssize_t i, PyObject *v);
 
+NPY_NO_EXPORT PyObject *
+as_index_tuple(PyObject *NPY_UNUSED(self), PyObject *args);
+
 /*
  * Prototypes for Mapping calls --- not part of the C-API
  * because only useful as part of a getitem call.

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -60,6 +60,7 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "compiled_base.h"
 #include "mem_overlap.h"
+#include "mapping.h" /* for as_index_tuple */
 
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
@@ -4293,6 +4294,8 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"normalize_axis_index", (PyCFunction)normalize_axis_index,
         METH_VARARGS | METH_KEYWORDS, NULL},
+    {"as_index_tuple", (PyCFunction)as_index_tuple,
+        METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -12,7 +12,7 @@ from numpy.core.numerictypes import find_common_type, issubdtype
 from . import function_base
 import numpy.matrixlib as matrix
 from .function_base import diff
-from numpy.core.multiarray import ravel_multi_index, unravel_index
+from numpy.core.multiarray import ravel_multi_index, unravel_index, as_index_tuple
 from numpy.lib.stride_tricks import as_strided
 
 makemat = matrix.matrix


### PR DESCRIPTION
Expose the function added in #8278 to help with #8275.
This was motivated by [some confusion about the trigger for advanced indexing](http://stackoverflow.com/q/40598824/102441)

Are these functions in the right places?

