### PR TITLE
DOC: improve comment in prepare_index

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -344,6 +344,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
              * Single integer index, there are two cases here.
              * It could be an array, a 0-d array is handled
              * a bit weird however, so need to special case it.
+             *
+             * Check for integers first, purely for performance
              */
 #if !defined(NPY_PY3K)
             if (PyInt_CheckExact(obj) || !PyArray_Check(obj)) {


### PR DESCRIPTION
This confused me a little, since `!PyArray_Check(obj)` is clearly a superset of `PyInt_CheckExact(obj)`, so this condition felt redundant. Presumably this is an optimization?

Is there any condition where `PyInt_CheckExact(obj)` is false, yet `!PyArray_Check(obj)` is true, where we don't just error out on the next lines?