### PR TITLE
MAINT: Make the refactor suggested in prepare_index

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -223,22 +223,19 @@ prepare_index_tuple(PyObject *index)
         }
     }
 
-    /* If the index is not a tuple, conver it into (index,) */
+    /* If the index is not a tuple, convert it into (index,) */
     if (!make_tuple && !PyTuple_CheckExact(index)) {
         make_tuple = 1;
         index_as_tuple = Py_BuildValue("(O)", index);
     }
     /* Otherwise, check if the tuple is too long */
-    else {
-        n = PyTuple_GET_SIZE(index_as_tuple);
-        if (n > NPY_MAXDIMS * 2) {
-            PyErr_SetString(PyExc_IndexError,
-                            "too many indices for array");
-            if (make_tuple) {
-                Py_DECREF(index_as_tuple);
-            }
-            return NULL;
+    else if (PyTuple_GET_SIZE(index_as_tuple) > NPY_MAXDIMS * 2) {
+        PyErr_SetString(PyExc_IndexError,
+                        "too many indices for array");
+        if (make_tuple) {
+            Py_DECREF(index_as_tuple);
         }
+        return NULL;
     }
 
     /* if we didn't make a tuple, then we're creating another reference */

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -247,7 +247,9 @@ unpack_indices(PyObject *index, PyObject **result, npy_intp result_n)
         if (tup == NULL) {
             return -1;
         }
-        return unpack_tuple(tup, result, result_n);
+        n = unpack_tuple(tup, result, result_n);
+        Py_DECREF(tup);
+        return n;
     }
 
     /*
@@ -368,7 +370,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
     int index_type = 0;
     int ellipsis_pos = -1;
 
-    /* 
+    /*
      * The choice of only unpacking `2*NPY_MAXDIMS` items is historic.
      * The longest "reasonable" index that produces a result of <= 32 dimensions
      * is `(0,)*np.MAXDIMS + (None,)*np.MAXDIMS`. Longer indices can exist, but

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -243,7 +243,7 @@ unpack_indices(PyObject *index, PyObject **result, npy_intp result_n)
      * allocation, but doesn't need to be a fast path anyway
      */
     if (PyTuple_Check(index)) {
-        PyTupleObject *tup = PySequence_Tuple(index);
+        PyTupleObject *tup = (PyTupleObject *) PySequence_Tuple(index);
         if (tup == NULL) {
             return -1;
         }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -179,7 +179,7 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
     npy_intp n, i;
     npy_bool commit_to_unpack;
 
-    /* fast route for passing a tuple */
+    /* Fast route for passing a tuple */
     if (PyTuple_CheckExact(index)) {
         n = PyTuple_GET_SIZE(index);
         if (n > NPY_MAXDIMS * 2) {
@@ -211,7 +211,7 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
         return 1;
     }
 
-    /* passing a tuple subclass - needs to handle errors */
+    /* Passing a tuple subclass - needs to handle errors */
     if (PyTuple_Check(index)) {
         n = PySequence_Size(index);
         if (n < 0) {
@@ -233,7 +233,8 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
         return n;
     }
 
-    /* At this point, we're left with a non-tuple, non-array, sequence:
+    /*
+     * At this point, we're left with a non-tuple, non-array, sequence:
      * typically, a list
      *
      * Sequences < NPY_MAXDIMS with any slice objects
@@ -251,16 +252,20 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
         return 1;
     }
 
-    /* for some reason, anything that's long but not too long is turned into
-     * a single index. The *2 is missing here for backward-compatibility. */
+    /*
+     * For some reason, anything that's long but not too long is turned into
+     * a single index. The *2 is missing here for backward-compatibility.
+     */
     if (n >= NPY_MAXDIMS) {
         Py_INCREF(index);
         result[0] = index;
         return 1;
     }
 
-    /* Some other type of short sequence - assume we should unpack it like a
-     * tuple, until we find something that proves us wrong */
+    /*
+     * Some other type of short sequence - assume we should unpack it like a
+     * tuple, and then decide whether that was actually necessary.
+     */
     commit_to_unpack = 0;
     for (i = 0; i < n; i++) {
         PyObject *tmp_obj = result[i] = PySequence_GetItem(index, i);
@@ -273,8 +278,10 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
             }
         }
         else {
-            /* if getitem fails (unusual) before we've committed, then
-             * commit to not unpacking */
+            /*
+             * if getitem fails (unusual) before we've committed, then stop
+             * unpacking
+             */
             if (tmp_obj == NULL) {
                 multi_DECREF(result, i);
                 PyErr_Clear();

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -228,7 +228,6 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
                 multi_DECREF(result, i);
                 return -1;
             }
-            Py_INCREF(result[i]);
         }
         return n;
     }
@@ -283,7 +282,6 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
              * unpacking
              */
             if (tmp_obj == NULL) {
-                multi_DECREF(result, i);
                 PyErr_Clear();
                 break;
             }
@@ -305,8 +303,8 @@ unpack_indices(PyObject *index, PyObject *result[2*NPY_MAXDIMS])
     }
     /* got to the end, never found an indication that we should have unpacked */
     else {
-        /* we already filled result, so empty it first */
-        multi_DECREF(result, n);
+        /* we partially filled result, so empty it first */
+        multi_DECREF(result, i);
 
         Py_INCREF(index);
         result[0] = index;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -226,7 +226,7 @@ prepare_index_tuple(PyObject *index)
     /* If the index is not a tuple, convert it into (index,) */
     if (!make_tuple && !PyTuple_CheckExact(index)) {
         make_tuple = 1;
-        index_as_tuple = Py_BuildValue("(O)", index);
+        index_as_tuple = PyTuple_Pack(1, index);
     }
     /* Otherwise, check if the tuple is too long */
     else if (PyTuple_GET_SIZE(index_as_tuple) > NPY_MAXDIMS * 2) {


### PR DESCRIPTION
Split off from #8276 

Extracting the tuple-conversion logic into its own function.

Things I'd like feedback on:

* <s>This might worsen performance slightly for scalar indices, as it now forces the tuple conversion. Is there an easy way to tell if this is significant? Is the clarity vs efficiency tradeoff acceptable here?</s>
* Have I messed up my reference counting?
* Are these functions in the right places?

Update: new approach that:
* Avoids calling `__getitem__` more than once on the provided sequence, if it is converted on a tuple:
  * More performant than `master` for `a[[0, None]]`
* Avoids allocating any new python objects, instead using a tuple-like buffer on the stack
