### PR TITLE
BUG: bool(dtype) is True

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -56,6 +56,15 @@ See Changes section for more detail.
 * ``array == None`` and ``array != None`` do element-wise comparison.
 * ``np.equal, np.not_equal``, object identity doesn't override comparison result.
 
+dtypes are now always true
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously ``bool(dtype)`` would fall back to the default python
+implementation, which checked if ``len(dtype) > 0``. Since ``dtype`` objects
+implement ``__len__`` as the number of record fields, ``bool`` of scalar dtypes
+would evaluate to ``False``, which was unintuitive. Now ``bool(dtype) == True``
+for all dtypes.
+
 
 C API
 ~~~~~

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3651,6 +3651,31 @@ arraydescr_richcompare(PyArray_Descr *self, PyObject *other, int cmp_op)
     return result;
 }
 
+static int
+descr_nonzero(PyObject *self)
+{
+    /* `bool(np.dtype(...)) == True` for all dtypes. Needed to override default
+     * nonzero implementation, which checks if `len(object) > 0`. */
+    return 1;
+}
+
+static PyNumberMethods descr_as_number = {
+    (binaryfunc)0,                          /* nb_add */
+    (binaryfunc)0,                          /* nb_subtract */
+    (binaryfunc)0,                          /* nb_multiply */
+    #if defined(NPY_PY3K)
+    #else
+    (binaryfunc)0,                          /* nb_divide */
+    #endif
+    (binaryfunc)0,                          /* nb_remainder */
+    (binaryfunc)0,                          /* nb_divmod */
+    (ternaryfunc)0,                         /* nb_power */
+    (unaryfunc)0,                           /* nb_negative */
+    (unaryfunc)0,                           /* nb_positive */
+    (unaryfunc)0,                           /* nb_absolute */
+    (inquiry)descr_nonzero,                 /* nb_nonzero */
+};
+
 /*************************************************************************
  ****************   Implement Mapping Protocol ***************************
  *************************************************************************/
@@ -3800,7 +3825,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
     0,                                          /* tp_compare */
 #endif
     (reprfunc)arraydescr_repr,                  /* tp_repr */
-    0,                                          /* tp_as_number */
+    &descr_as_number,                           /* tp_as_number */
     &descr_as_sequence,                         /* tp_as_sequence */
     &descr_as_mapping,                          /* tp_as_mapping */
     0,                                          /* tp_hash */

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -620,5 +620,12 @@ def test_rational_dtype():
     assert_equal(np.array([x,x]).dtype, np.dtype(rational))
 
 
+def test_dtypes_are_true():
+    # test for gh-6294
+    assert bool(np.dtype('f8'))
+    assert bool(np.dtype('i8'))
+    assert bool(np.dtype([('a', 'i8'), ('b', 'f4')]))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Previously `bool(dtype(...))` would fallback to the default
implementation of `__nonzero__`, which checks if `len(object) > 0`.
Since `dtype` objects implement `__len__` as the number of record
fields, `bool` of scalar dtypes like `bool(dtype('i8'))` would evaluate
as `False`. This fixes that by implementing `__nonzero__` to always
return True.

Fixes #6294.