### PR TITLE
MAINT: let average preserve subclass information.

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -33,6 +33,11 @@ DeprecationWarning to error
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* ``numpy.average`` now preserves subclasses, matching the behavior of most
+  other numpy functions such as ``mean``.  As a consequence, also calls that
+  returned a scalar may now return a subclass array scalar.
+
+
 C API
 ~~~~~
 
@@ -53,3 +58,10 @@ Improvements
 
 Changes
 =======
+
+``average`` now preserves subclasses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For ndarray subclasses, ``numpy.average`` will now return an instance of the
+subclass, matching the behavior of most other numpy functions such as ``mean``.
+As a consequence, also calls that returned a scalar may now return a subclass
+array scalar.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1092,19 +1092,7 @@ def average(a, axis=None, weights=None, returned=False):
     TypeError: Axis must be specified when shapes of a and weights differ.
 
     """
-    # 3/19/2016 1.12.0:
-    # replace the next few lines with "a = np.asanyarray(a)"
-    if (type(a) not in (np.ndarray, np.matrix) and
-            issubclass(type(a), np.ndarray)):
-        warnings.warn("np.average currently does not preserve subclasses, but "
-                      "will do so in the future to match the behavior of most "
-                      "other numpy functions such as np.mean. In particular, "
-                      "this means calls which returned a scalar may return a "
-                      "0-d subclass object instead.",
-                      FutureWarning, stacklevel=2)
-
-    if not isinstance(a, np.matrix):
-        a = np.asarray(a)
+    a = np.asanyarray(a)
 
     if weights is None:
         avg = a.mean(axis)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -321,11 +321,8 @@ class TestAverage(TestCase):
         a = np.array([[1,2],[3,4]]).view(subclass)
         w = np.array([[1,2],[3,4]]).view(subclass)
 
-        with suppress_warnings() as sup:
-            # Note that the warning is spurious, because the test checks
-            # for weights while a is ignored.
-            sup.filter(FutureWarning, "np.average currently does not preserve")
-            assert_equal(type(np.average(a, weights=w)), subclass)
+        assert_equal(type(np.average(a)), subclass)
+        assert_equal(type(np.average(a, weights=w)), subclass)
 
         # also test matrices
         a = np.matrix([[1,2],[3,4]])


### PR DESCRIPTION
This behaviour matches that for most other numpy functions (such as np.mean).  It was initially slated for 1.12 (#7382), but replaced by a FutureWarning (#7433).  Hence, this is for 1.13.