### PR TITLE
DEP: Handle expired deprecations.

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -30,6 +30,8 @@ Compatibility notes
 DeprecationWarning to error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Non-integer partition index now raises TypeError.
+
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -30,7 +30,8 @@ Compatibility notes
 DeprecationWarning to error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Non-integer partition index now raises TypeError.
+* ``partition``, TypeError when non-integer partition index is used.
+* ``NpyIter_AdvancedNew``, ValueError when `oa_ndim == 0` and `op_axes` is NULL
 
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -29,17 +29,22 @@ Compatibility notes
 
 DeprecationWarning to error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+See Changes section for more detail.
 
 * ``partition``, TypeError when non-integer partition index is used.
 * ``NpyIter_AdvancedNew``, ValueError when `oa_ndim == 0` and `op_axes` is NULL
 * ``negative(bool_)``, TypeError when negative applied to booleans.
 * ``subtract(bool_, bool_)``, TypeError when subtracting boolean from boolean.
+* ``np.equal, np.not_equal``, object identity doesn't override failed comparison.
+* ``np.equal, np.not_equal``, object identity doesn't override non-boolean comparison.
 
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+See Changes section for more detail.
 
 * ``numpy.average`` preserves subclasses
 * ``array == None`` and ``array != None`` do element-wise comparison.
+* ``np.equal, np.not_equal``, object identity doesn't override comparison result.
 
 
 C API
@@ -73,4 +78,11 @@ array scalar.
 ``array == None`` and ``array != None`` do element-wise comparison
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Previously these operations returned scalars ``False`` and ``True`` respectively.
+
+``np.equal, np.not_equal`` for object arrays ignores object identity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, these functions always treated identical objects as equal. This had
+the effect of overriding comparison failures, comparison of objects that did
+not return booleans, such as np.arrays, and comparison of objects where the
+results differed from object identity, such as NaNs.
 

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -33,9 +33,8 @@ DeprecationWarning to error
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ``numpy.average`` now preserves subclasses, matching the behavior of most
-  other numpy functions such as ``mean``.  As a consequence, also calls that
-  returned a scalar may now return a subclass array scalar.
+* ``numpy.average`` preserves subclasses
+* ``array == None`` and ``array != None`` do element-wise comparison.
 
 
 C API
@@ -65,3 +64,8 @@ For ndarray subclasses, ``numpy.average`` will now return an instance of the
 subclass, matching the behavior of most other numpy functions such as ``mean``.
 As a consequence, also calls that returned a scalar may now return a subclass
 array scalar.
+
+``array == None`` and ``array != None`` do element-wise comparison
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously these operations returned scalars ``False`` and ``True`` respectively.
+

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -32,6 +32,7 @@ DeprecationWarning to error
 
 * ``partition``, TypeError when non-integer partition index is used.
 * ``NpyIter_AdvancedNew``, ValueError when `oa_ndim == 0` and `op_axes` is NULL
+* Negative boolean, TypeError when unary ``-`` operator applied to boolean.
 
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -32,7 +32,8 @@ DeprecationWarning to error
 
 * ``partition``, TypeError when non-integer partition index is used.
 * ``NpyIter_AdvancedNew``, ValueError when `oa_ndim == 0` and `op_axes` is NULL
-* Negative boolean, TypeError when unary ``-`` operator applied to boolean.
+* ``negative(bool_)``, TypeError when negative applied to booleans.
+* ``subtract(bool_, bool_)``, TypeError when subtracting boolean from boolean.
 
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1354,16 +1354,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
                 n_ops.less_equal);
         break;
     case Py_EQ:
-        if (other == Py_None) {
-            /* 2013-07-25, 1.7 */
-            if (DEPRECATE_FUTUREWARNING("comparison to `None` will result in "
-                    "an elementwise object comparison in the future.") < 0) {
-                return NULL;
-            }
-            Py_INCREF(Py_False);
-            return Py_False;
-        }
-
         /*
          * The ufunc does not support void/structured types, so these
          * need to be handled specifically. Only a few cases are supported.
@@ -1442,16 +1432,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         }
         break;
     case Py_NE:
-        if (other == Py_None) {
-            /* 2013-07-25, 1.8 */
-            if (DEPRECATE_FUTUREWARNING("comparison to `None` will result in "
-                    "an elementwise object comparison in the future.") < 0) {
-                return NULL;
-            }
-            Py_INCREF(Py_True);
-            return Py_True;
-        }
-
         /*
          * The ufunc does not support void/structured types, so these
          * need to be handled specifically. Only a few cases are supported.

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1161,11 +1161,8 @@ partition_prep_kth_array(PyArrayObject * ktharray,
     npy_intp nkth, i;
 
     if (!PyArray_CanCastSafely(PyArray_TYPE(ktharray), NPY_INTP)) {
-        /* 2013-05-18, 1.8 */
-        if (DEPRECATE("Calling partition with a non integer index"
-                      " will result in an error in the future") < 0) {
-            return NULL;
-        }
+        PyErr_Format(PyExc_TypeError, "Partition index must be integer");
+        return NULL;
     }
 
     if (PyArray_NDIM(ktharray) > 1) {

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -161,17 +161,14 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
      * Before 1.8, if `oa_ndim == 0`, this meant `op_axes != NULL` was an error.
      * With 1.8, `oa_ndim == -1` takes this role, while op_axes in that case
      * enforces a 0-d iterator. Using `oa_ndim == 0` with `op_axes == NULL`
-     * is thus deprecated with version 1.8.
+     * is thus an error in 1.13 after deprecation.
      */
     if ((oa_ndim == 0) && (op_axes == NULL)) {
-        char* mesg = "using `oa_ndim == 0` when `op_axes` is NULL is "
-                     "deprecated. Use `oa_ndim == -1` or the MultiNew "
-                     "iterator for NumPy <1.8 compatibility";
-        if (DEPRECATE(mesg) < 0) {
-            /* 2013-02-23, 1.8 */
-            return NULL;
-        }
-        oa_ndim = -1;
+        PyErr_Format(PyExc_ValueError,
+            "Using `oa_ndim == 0` when `op_axes` is NULL. "
+            "Use `oa_ndim == -1` or the MultiNew "
+            "iterator for NumPy <1.8 compatibility");
+        return NULL;
     }
 
     /* Error check 'oa_ndim' and 'op_axes', which must be used together */

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2670,61 +2670,19 @@ OBJECT_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUS
         in2 = in2 ? in2 : Py_None;
 
         /*
-         * Do not use RichCompareBool because it includes an identity check
-         * (for == and !=).
-         * This is wrong for elementwise behaviour, since it means
+         * Do not use RichCompareBool because it includes an identity check for
+         * == and !=. This is wrong for elementwise behaviour, since it means
          * that NaN can be equal to NaN and an array is equal to itself.
          */
         ret_obj = PyObject_RichCompare(in1, in2, Py_@OP@);
         if (ret_obj == NULL) {
-#if @identity@ != -1
-            if (in1 == in2) {
-                /* 2014-01-26, 1.9 */
-                PyErr_Clear();
-                if (DEPRECATE("numpy @kind@ will not check object identity "
-                              "in the future. The comparison error will "
-                              "be raised.") < 0) {
-                    return;
-                }
-                *((npy_bool *)op1) = @identity@;
-                continue;
-            }
-#endif
             return;
         }
         ret = PyObject_IsTrue(ret_obj);
         Py_DECREF(ret_obj);
         if (ret == -1) {
-#if @identity@ != -1
-            if (in1 == in2) {
-                /* 2014-01-26, 1.9 */
-                PyErr_Clear();
-                if (DEPRECATE("numpy @kind@ will not check object identity "
-                              "in the future. The error trying to get the "
-                              "boolean value of the comparison result will "
-                              "be raised.") < 0) {
-                    return;
-                }
-                *((npy_bool *)op1) = @identity@;
-                continue;
-            }
-#endif
             return;
         }
-#if @identity@ != -1
-        if ((in1 == in2) && ((npy_bool)ret != @identity@)) {
-            /* 2014-01-26, 1.9 */
-            if (DEPRECATE_FUTUREWARNING(
-                        "numpy @kind@ will not check object identity "
-                        "in the future. The comparison did not return the "
-                        "same result as suggested by the identity (`is`)) "
-                        "and will change.") < 0) {
-                return;
-            }
-            *((npy_bool *)op1) = @identity@;
-            continue;
-        }
-#endif
         *((npy_bool *)op1) = (npy_bool)ret;
     }
 }

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -796,12 +796,11 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
 
         /* The type resolver would have upcast already */
         if (out_dtypes[0]->type_num == NPY_BOOL) {
-            /* 2013-12-05, 1.9 */
-            if (DEPRECATE("numpy boolean subtract, the `-` operator, is "
-                          "deprecated, use the bitwise_xor, the `^` operator, "
-                          "or the logical_xor function instead.") < 0) {
-                return -1;
-            }
+            PyErr_Format(PyExc_TypeError,
+                "numpy boolean subtract, the `-` operator, is deprecated, "
+                "use the bitwise_xor, the `^` operator, or the logical_xor "
+                "function instead.");
+            return -1;
         }
         return ret;
     }

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -368,10 +368,10 @@ PyUFunc_SimpleUnaryOperationTypeResolver(PyUFuncObject *ufunc,
 
 NPY_NO_EXPORT int
 PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
-                                NPY_CASTING casting,
-                                PyArrayObject **operands,
-                                PyObject *type_tup,
-                                PyArray_Descr **out_dtypes)
+                             NPY_CASTING casting,
+                             PyArrayObject **operands,
+                             PyObject *type_tup,
+                             PyArray_Descr **out_dtypes)
 {
     int ret;
     ret = PyUFunc_SimpleUnaryOperationTypeResolver(ufunc, casting, operands,
@@ -382,12 +382,10 @@ PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
 
     /* The type resolver would have upcast already */
     if (out_dtypes[0]->type_num == NPY_BOOL) {
-        /* 2013-12-05, 1.9 */
-        if (DEPRECATE("numpy boolean negative, the `-` operator, is "
-                      "deprecated, use the `~` operator or the logical_not "
-                      "function instead.") < 0) {
-            return -1;
-        }
+        PyErr_Format(PyExc_TypeError,
+            "The numpy boolean negative, the `-` operator, is not supported, "
+            "use the `~` operator or the logical_not function instead.");
+        return -1;
     }
 
     return ret;

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -226,24 +226,6 @@ class _DeprecationTestCase(object):
                         exceptions=tuple(), args=args, kwargs=kwargs)
 
 
-class TestBooleanUnaryMinusDeprecation(_DeprecationTestCase):
-    """Test deprecation of unary boolean `-`. While + and * are well
-    defined, unary - is not and even a corrected form seems to have
-    no real uses.
-
-    The deprecation process was started in NumPy 1.9.
-    """
-    message = r"numpy boolean negative, the `-` operator, .*"
-
-    def test_unary_minus_operator_deprecation(self):
-        array = np.array([True])
-        generic = np.bool_(True)
-
-        # Unary minus/negative ufunc:
-        self.assert_deprecated(operator.neg, args=(array,))
-        self.assert_deprecated(operator.neg, args=(generic,))
-
-
 class TestBooleanBinaryMinusDeprecation(_DeprecationTestCase):
     """Test deprecation of binary boolean `-`. While + and * are well
     defined, binary  - is not and even a corrected form seems to have

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -307,40 +307,6 @@ class TestComparisonDeprecations(_DeprecationTestCase):
         # following works (and returns False) due to dtype mismatch:
         a == []
 
-    def test_none_comparison(self):
-        # Test comparison of None, which should result in element-wise
-        # comparison in the future. [1, 2] == None should be [False, False].
-        with warnings.catch_warnings():
-            warnings.filterwarnings('always', '', FutureWarning)
-            assert_warns(FutureWarning, operator.eq, np.arange(3), None)
-            assert_warns(FutureWarning, operator.ne, np.arange(3), None)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error', '', FutureWarning)
-            assert_raises(FutureWarning, operator.eq, np.arange(3), None)
-            assert_raises(FutureWarning, operator.ne, np.arange(3), None)
-
-    def test_scalar_none_comparison(self):
-        # Scalars should still just return False and not give a warnings.
-        # The comparisons are flagged by pep8, ignore that.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', FutureWarning)
-            assert_(not np.float32(1) == None)
-            assert_(not np.str_('test') == None)
-            # This is dubious (see below):
-            assert_(not np.datetime64('NaT') == None)
-
-            assert_(np.float32(1) != None)
-            assert_(np.str_('test') != None)
-            # This is dubious (see below):
-            assert_(np.datetime64('NaT') != None)
-        assert_(len(w) == 0)
-
-        # For documentation purposes, this is why the datetime is dubious.
-        # At the time of deprecation this was no behaviour change, but
-        # it has to be considered when the deprecations are done.
-        assert_(np.equal(np.datetime64('NaT'), None))
-
     def test_void_dtype_equality_failures(self):
         class NotArray(object):
             def __array__(self):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -323,58 +323,6 @@ class TestComparisonDeprecations(_DeprecationTestCase):
                         assert_warns(DeprecationWarning, f, arg1, arg2)
 
 
-class TestIdentityComparisonDeprecations(_DeprecationTestCase):
-    """This tests the equal and not_equal object ufuncs identity check
-    deprecation. This was due to the usage of PyObject_RichCompareBool.
-
-    This tests that for example for `a = np.array([np.nan], dtype=object)`
-    `a == a` it is warned that False and not `np.nan is np.nan` is returned.
-
-    Should be kept in sync with TestComparisonDeprecations and new tests
-    added when the deprecation is over. Requires only removing of @identity@
-    (and blocks) from the ufunc loops.c.src of the OBJECT comparisons.
-    """
-
-    message = "numpy .* will not check object identity in the future."
-
-    def test_identity_equality_mismatch(self):
-        a = np.array([np.nan], dtype=object)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings('always', '', FutureWarning)
-            assert_warns(FutureWarning, np.equal, a, a)
-            assert_warns(FutureWarning, np.not_equal, a, a)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error', '', FutureWarning)
-            assert_raises(FutureWarning, np.equal, a, a)
-            assert_raises(FutureWarning, np.not_equal, a, a)
-            # And the other do not warn:
-            with np.errstate(invalid='ignore'):
-                np.less(a, a)
-                np.greater(a, a)
-                np.less_equal(a, a)
-                np.greater_equal(a, a)
-
-    def test_comparison_error(self):
-        class FunkyType(object):
-            def __eq__(self, other):
-                raise TypeError("I won't compare")
-
-            def __ne__(self, other):
-                raise TypeError("I won't compare")
-
-        a = np.array([FunkyType()])
-        self.assert_deprecated(np.equal, args=(a, a))
-        self.assert_deprecated(np.not_equal, args=(a, a))
-
-    def test_bool_error(self):
-        # The comparison result cannot be interpreted as a bool
-        a = np.array([np.array([1, 2, 3]), None], dtype=object)
-        self.assert_deprecated(np.equal, args=(a, a))
-        self.assert_deprecated(np.not_equal, args=(a, a))
-
-
 class TestAlterdotRestoredotDeprecations(_DeprecationTestCase):
     """The alterdot/restoredot functions are deprecated.
 
@@ -587,7 +535,7 @@ class TestTestDeprecated(object):
 
 class TestClassicIntDivision(_DeprecationTestCase):
     """
-    See #7949. Deprecate the numeric-style dtypes with -3 flag in python 2 
+    See #7949. Deprecate the numeric-style dtypes with -3 flag in python 2
     if used for division
     List of data types: http://docs.scipy.org/doc/numpy/user/basics.types.html
     """
@@ -601,9 +549,9 @@ class TestClassicIntDivision(_DeprecationTestCase):
             import operator as op
             dt2 = 'bool_'
             for dt1 in deprecated_types:
-                a = np.array([1,2,3], dtype=dt1)    
-                b = np.array([1,2,3], dtype=dt2)    
-                self.assert_deprecated(op.div, args=(a,b)) 
+                a = np.array([1,2,3], dtype=dt1)
+                b = np.array([1,2,3], dtype=dt2)
+                self.assert_deprecated(op.div, args=(a,b))
                 dt2 = dt1
 
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -226,24 +226,6 @@ class _DeprecationTestCase(object):
                         exceptions=tuple(), args=args, kwargs=kwargs)
 
 
-class TestBooleanBinaryMinusDeprecation(_DeprecationTestCase):
-    """Test deprecation of binary boolean `-`. While + and * are well
-    defined, binary  - is not and even a corrected form seems to have
-    no real uses.
-
-    The deprecation process was started in NumPy 1.9.
-    """
-    message = r"numpy boolean subtract, the `-` operator, .*"
-
-    def test_operator_deprecation(self):
-        array = np.array([True])
-        generic = np.bool_(True)
-
-        # Minus operator/subtract ufunc:
-        self.assert_deprecated(operator.sub, args=(array, array))
-        self.assert_deprecated(operator.sub, args=(generic, generic))
-
-
 class TestRankDeprecation(_DeprecationTestCase):
     """Test that np.rank is deprecated. The function should simply be
     removed. The VisibleDeprecationWarning may become unnecessary.

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1819,6 +1819,24 @@ class TestMethods(TestCase):
         assert_raises(ValueError, d_obj.partition, 10)
         assert_raises(ValueError, d_obj.partition, -11)
 
+    def test_argpartition_integer(self):
+        # Test non-integer values in kth raise an error/
+        d = np.arange(10)
+        assert_raises(TypeError, d.argpartition, 9.)
+        # Test also for generic type argpartition, which uses sorting
+        # and used to not bound check kth
+        d_obj = np.arange(10, dtype=object)
+        assert_raises(TypeError, d_obj.argpartition, 9.)
+
+    def test_partition_integer(self):
+        # Test out of range values in kth raise an error, gh-5469
+        d = np.arange(10)
+        assert_raises(TypeError, d.partition, 9.)
+        # Test also for generic type partition, which uses sorting
+        # and used to not bound check kth
+        d_obj = np.arange(10, dtype=object)
+        assert_raises(TypeError, d_obj.partition, 9.)
+
     def test_partition_empty_array(self):
         # check axis handling for multidimensional empty arrays
         a = np.array([])

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1194,6 +1194,16 @@ class TestArrayComparisons(TestCase):
         assert_(res)
         assert_(type(res) is bool)
 
+    def test_none_compares_elementwise(self):
+        a = np.array([None, 1, None], dtype=object)
+        assert_equal(a == None, [True, False, True])
+        assert_equal(a != None, [False, True, False])
+
+        a = np.ones(3)
+        assert_equal(a == None, [False, False, False])
+        assert_equal(a != None, [True, True, True])
+
+
     def test_array_equiv(self):
         res = np.array_equiv(np.array([1, 2]), np.array([1, 2]))
         assert_(res)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -547,6 +547,20 @@ class TestMultiply(TestCase):
             assert_array_equal(np.int_(3) * arr_like, np.full(3, 3))
 
 
+class TestNegative(TestCase):
+    def test_exceptions(self):
+        a = np.ones((), dtype=np.bool_)[()]
+        assert_raises(TypeError, operator.neg, a)
+
+    def test_result(self):
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning) 
+            for dt in types:
+                a = np.ones((), dtype=dt)[()]
+                assert_equal(operator.neg(a) + a, 0)
+
+
 class TestAbs(TestCase):
 
     def _test_abs_func(self, absfunc):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import warnings
 import itertools
 import operator
 
@@ -429,6 +430,27 @@ class TestConversion(TestCase):
                         "type %s and %s failed" % (dt1, dt2))
                 assert_(np.array(-1, dtype=dt1)[()] == np.array(-1, dtype=dt2)[()],
                         "type %s and %s failed" % (dt1, dt2))
+
+    def test_scalar_comparison_to_none(self):
+        # Scalars should just return False and not give a warnings.
+        # The comparisons are flagged by pep8, ignore that.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', FutureWarning)
+            assert_(not np.float32(1) == None)
+            assert_(not np.str_('test') == None)
+            # This is dubious (see below):
+            assert_(not np.datetime64('NaT') == None)
+
+            assert_(np.float32(1) != None)
+            assert_(np.str_('test') != None)
+            # This is dubious (see below):
+            assert_(np.datetime64('NaT') != None)
+        assert_(len(w) == 0)
+
+        # For documentation purposes, this is why the datetime is dubious.
+        # At the time of deprecation this was no behaviour change, but
+        # it has to be considered when the deprecations are done.
+        assert_(np.equal(np.datetime64('NaT'), None))
 
 
 #class TestRepr(TestCase):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -555,10 +555,24 @@ class TestNegative(TestCase):
     def test_result(self):
         types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
         with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning) 
+            sup.filter(RuntimeWarning)
             for dt in types:
                 a = np.ones((), dtype=dt)[()]
                 assert_equal(operator.neg(a) + a, 0)
+
+
+class TestSubtract(TestCase):
+    def test_exceptions(self):
+        a = np.ones((), dtype=np.bool_)[()]
+        assert_raises(TypeError, operator.sub, a, a)
+
+    def test_result(self):
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            for dt in types:
+                a = np.ones((), dtype=dt)[()]
+                assert_equal(operator.sub(a, a), 0)
 
 
 class TestAbs(TestCase):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1005,6 +1005,7 @@ class TestBool(TestCase):
     def test_exceptions(self):
         a = np.ones(1, dtype=np.bool_)
         assert_raises(TypeError, np.negative, a)
+        assert_raises(TypeError, np.subtract, a, a)
 
     def test_truth_table_logical(self):
         # 2, 3 and 4 serves as true values

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -173,6 +173,44 @@ class TestOut(TestCase):
                 assert_(w[0].category is DeprecationWarning)
 
 
+class TestComparisons(TestCase):
+    def test_ignore_object_identity_in_equal(self):
+        # Check error raised when comparing identical objects whose comparison
+        # is not a simple boolean, e.g., arrays that are compared elementwise.
+        a = np.array([np.array([1, 2, 3]), None], dtype=object)
+        assert_raises(ValueError, np.equal, a, a)
+
+        # Check error raised when comparing identical non-comparable objects.
+        class FunkyType(object):
+            def __eq__(self, other):
+                raise TypeError("I won't compare")
+
+        a = np.array([FunkyType()])
+        assert_raises(TypeError, np.equal, a, a)
+
+        # Check identity doesn't override comparison mismatch.
+        a = np.array([np.nan], dtype=object)
+        assert_equal(np.equal(a, a), [False])
+
+    def test_ignore_object_identity_in_not_equal(self):
+        # Check error raised when comparing identical objects whose comparison
+        # is not a simple boolean, e.g., arrays that are compared elementwise.
+        a = np.array([np.array([1, 2, 3]), None], dtype=object)
+        assert_raises(ValueError, np.not_equal, a, a)
+
+        # Check error raised when comparing identical non-comparable objects.
+        class FunkyType(object):
+            def __ne__(self, other):
+                raise TypeError("I won't compare")
+
+        a = np.array([FunkyType()])
+        assert_raises(TypeError, np.not_equal, a, a)
+
+        # Check identity doesn't override comparison mismatch.
+        a = np.array([np.nan], dtype=object)
+        assert_equal(np.not_equal(a, a), [True])
+
+
 class TestDivision(TestCase):
     def test_division_int(self):
         # int division should follow Python

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1002,6 +1002,10 @@ class TestFmin(_FilterInvalids):
 
 
 class TestBool(TestCase):
+    def test_exceptions(self):
+        a = np.ones(1, dtype=np.bool_)
+        assert_raises(TypeError, np.negative, a)
+
     def test_truth_table_logical(self):
         # 2, 3 and 4 serves as true values
         input1 = [0, 0, 3, 2]

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1,4 +1,4 @@
-# pylint: disable-msg=W0401,W0511,W0611,W0612,W0614,R0201,E1102
+# pylint: disable-msg=W0400,W0511,W0611,W0612,W0614,R0201,E1102
 """Tests suite for MaskedArray & subclassing.
 
 :author: Pierre Gerard-Marchant
@@ -1361,19 +1361,18 @@ class TestMaskedArrayArithmetic(TestCase):
         # With partial mask
         with suppress_warnings() as sup:
             sup.filter(FutureWarning, "Comparison to `None`")
-            a = array([1, 2], mask=[0, 1])
-            assert_equal(a == None, False)
-            assert_equal(a.data == None, False)
-            assert_equal(a.mask == None, False)
-            assert_equal(a != None, True)
+            a = array([None, 1], mask=[0, 1])
+            assert_equal(a == None, array([True, False], mask=[0, 1]))
+            assert_equal(a.data == None, [True, False])
+            assert_equal(a != None, array([False, True], mask=[0, 1]))
             # With nomask
-            a = array([1, 2], mask=False)
-            assert_equal(a == None, False)
-            assert_equal(a != None, True)
+            a = array([None, 1], mask=False)
+            assert_equal(a == None, [True, False])
+            assert_equal(a != None, [False, True])
             # With complete mask
-            a = array([1, 2], mask=True)
-            assert_equal(a == None, False)
-            assert_equal(a != None, True)
+            a = array([None, 2], mask=True)
+            assert_equal(a == None, array([False, True], mask=True))
+            assert_equal(a != None, array([True, False], mask=True))
             # Fully masked, even comparison to None should return "masked"
             a = masked
             assert_equal(a == None, masked)


### PR DESCRIPTION
Changes

_Deprecations to error_

* `partition`, TypeError when non-integer partition index is used.
* `NpyIter_AdvancedNew`, ValueError when `oa_ndim == 0` and `op_axes` is NULL
* `negative(bool_)`, TypeError when negative applied to booleans.
* `subtract(bool_, bool_)`, TypeError when subtracting boolean from boolean.
* ``np.equal, np.not_equal``, object identity doesn't override failed comparison.
* ``np.equal, np.not_equal``, object identity doesn't override non-boolean comparison.

_FutureWarnings to changed behavior_

* `array == None` and `array != None` do element-wise comparison.
* ``np.equal, np.not_equal``, object identity doesn't override comparison result.
