### PR TITLE
BUG: Fix PyPy crash in PyUFunc_GenericReduction.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3906,7 +3906,6 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
         }
         /* Until removed outright by https://github.com/numpy/numpy/pull/8187 */
         if (bad_keepdimarg != NULL) {
-            Py_DECREF(bad_keepdimarg);
             if (DEPRECATE_FUTUREWARNING(
                     "keepdims argument has no effect on accumulate, and will be "
                     "removed in future") < 0) {


### PR DESCRIPTION
The cause is an unneeded `Py_DECREF` which is harmless in CPython but causes a crash in PyPy. 