### PR TITLE
ENH: add cyclic GC support to object arrays. Closes #6581.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -988,6 +988,13 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     }
 
     fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
+    if (!PyDataType_REFCHK(descr)) {
+        /*
+         * tp_alloc will have enabled GC tracking, but it's only necessary
+         * for object arrays
+         */
+        PyObject_GC_UnTrack(fa);
+    }
     if (fa == NULL) {
         Py_DECREF(descr);
         return NULL;

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1413,7 +1413,7 @@ PyArray_MultiIterFromObjects(PyObject **mps, int n, int nadd, ...)
             break;
         }
         else {
-            if (PyDataType_REFCHK(PyArray_DESCR(arr))) {
+            if (PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)arr))) {
                 needs_gc_tracking = 1;
             }
             multi->iters[i] = (PyArrayIterObject *)PyArray_IterNew(arr);
@@ -1482,7 +1482,7 @@ PyArray_MultiIterNew(int n, ...)
             break;
         }
         else {
-            if (PyDataType_REFCHK(PyArray_DESCR(arr))) {
+            if (PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)arr))) {
                 needs_gc_tracking = 1;
             }
             multi->iters[i] = (PyArrayIterObject *)PyArray_IterNew(arr);
@@ -1572,7 +1572,7 @@ arraymultiter_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
                 if (it == NULL) {
                     goto fail;
                 }
-                if (PyDataType_REFCHK(PyArray_DESCR(arr))) {
+                if (PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)arr))) {
                     needs_gc_tracking = 1;
                 }
                 multi->iters[i++] = it;
@@ -1587,7 +1587,7 @@ arraymultiter_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
             if (it == NULL) {
                 goto fail;
             }
-            if (PyDataType_REFCHK(PyArray_DESCR(arr))) {
+            if (PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)arr))) {
                 needs_gc_tracking = 1;
             }
             multi->iters[i++] = it;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4559,7 +4559,6 @@ PyMODINIT_FUNC initmultiarray(void) {
     PyArrayIter_Type.tp_iter = PyObject_SelfIter;
     NpyIter_Type.tp_iter = PyObject_SelfIter;
     PyArrayMultiIter_Type.tp_iter = PyObject_SelfIter;
-    PyArrayMultiIter_Type.tp_free = PyArray_free;
     if (PyType_Ready(&PyArrayIter_Type) < 0) {
         return RETVAL;
     }
@@ -4569,7 +4568,6 @@ PyMODINIT_FUNC initmultiarray(void) {
     if (PyType_Ready(&PyArrayMultiIter_Type) < 0) {
         return RETVAL;
     }
-    PyArrayNeighborhoodIter_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&PyArrayNeighborhoodIter_Type) < 0) {
         return RETVAL;
     }
@@ -4584,7 +4582,6 @@ PyMODINIT_FUNC initmultiarray(void) {
     if (PyType_Ready(&PyArrayFlags_Type) < 0) {
         return RETVAL;
     }
-    NpyBusDayCalendar_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&NpyBusDayCalendar_Type) < 0) {
         return RETVAL;
     }


### PR DESCRIPTION
There are a few things I'm uncertain about here:

- Currently `ndarray` has custom `tp_alloc` and `tp_free` functions, but they don't seem to do anything different to the defaults. Combining cyclic garbage support with custom `tp_alloc` and `tp_free` functions is apparently difficult and I couldn't get it to work, so I just got rid of them. Is that acceptable? It doesn't cause any harm as far as I can tell.

- I don't really understand `UPDATEIFCOPY`. With the more normal use of `base`, the appropriate thing to do is to visit it in `array_traverse` (because `base` can participate in reference cycles) but ignore it in `array_clear` (because you can't have a reference cycle purely consisting of `base`s, AFAIK). I have a feeling we might need to do something special for arrays with `UPDATEIFCOPY` set.

- the `array_traverse` code is largely copied from `PyArray_INCREF`, and I included the code that deals with discontiguous and misaligned arrays. However, `PyArray_INCREF` and friends need to support arrays that don't own their own data, but `array_traverse` (or at least this section of it) doesn't. Is it possible to have a discontiguous or misaligned object array (or array with object fields) that owns its data? If not, `array_traverse` can be simplified quite a bit.

- there are couple of places in `array_dealloc` where the array's refcount is incremented to prevent numpy API calls from triggering `array_dealloc` again (which would be catastrophic). This is harmless, but it makes it difficult to debug GC stuff, because it makes the total refcount go up every time an object array (or an array with `UPDATEIFCOPY` set) is created and then collected. Is there a straightforward way of avoiding this? I can't think of anything.