### PR TITLE
DEP: Drop deprecated boolean indexing behavior and update to new.

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -46,6 +46,7 @@ See Changes section for more detail.
 * ``subtract(bool_, bool_)``, TypeError when subtracting boolean from boolean.
 * ``np.equal, np.not_equal``, object identity doesn't override failed comparison.
 * ``np.equal, np.not_equal``, object identity doesn't override non-boolean comparison.
+* Boolean indexing deprecated behavior dropped. See Changes below for details.
 
 FutureWarning to changed behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -94,4 +95,20 @@ Previously, these functions always treated identical objects as equal. This had
 the effect of overriding comparison failures, comparison of objects that did
 not return booleans, such as np.arrays, and comparison of objects where the
 results differed from object identity, such as NaNs.
+
+Boolean indexing changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+* Boolean array-likes (such as lists of python bools) are always treated as
+  boolean indexes.
+
+* Boolean scalars (including python ``True``) are legal boolean indexes and
+  never treated as integers.
+
+* Boolean indexes must match the dimension of the axis that they index.
+
+* Boolean indexes used on the lhs of an assigment must match the dimensions of
+  the rhs.
+
+* Boolean indexing into scalar arrays return a new 1-d array.  This means that
+  ``array(1)[array(True)]`` gives ``array([1])`` and not the original array.
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -336,33 +336,6 @@ class TestAlterdotRestoredotDeprecations(_DeprecationTestCase):
         self.assert_deprecated(np.restoredot)
 
 
-class TestBooleanIndexShapeMismatchDeprecation():
-    """Tests deprecation for boolean indexing where the boolean array
-    does not match the input array along the given dimensions.
-    """
-    message = r"boolean index did not match indexed array"
-
-    def test_simple(self):
-        arr = np.ones((5, 4, 3))
-        index = np.array([True])
-        #self.assert_deprecated(arr.__getitem__, args=(index,))
-        assert_warns(np.VisibleDeprecationWarning,
-                     arr.__getitem__, index)
-
-        index = np.array([False] * 6)
-        #self.assert_deprecated(arr.__getitem__, args=(index,))
-        assert_warns(np.VisibleDeprecationWarning,
-             arr.__getitem__, index)
-
-        index = np.zeros((4, 4), dtype=bool)
-        #self.assert_deprecated(arr.__getitem__, args=(index,))
-        assert_warns(np.VisibleDeprecationWarning,
-             arr.__getitem__, index)
-        #self.assert_deprecated(arr.__getitem__, args=((slice(None), index),))
-        assert_warns(np.VisibleDeprecationWarning,
-             arr.__getitem__, (slice(None), index))
-
-
 class TestDatetime64Timezone(_DeprecationTestCase):
     """Parsing of datetime64 with timezones deprecated in 1.11.0, because
     datetime64 is now timezone naive rather than UTC only.

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -807,16 +807,9 @@ class TestRegression(TestCase):
         def ia(x, s, v):
             x[(s > 0)] = v
 
-        # After removing deprecation, the following are ValueErrors.
-        # This might seem odd as compared to the value error below. This
-        # is due to the fact that the new code always uses "nonzero" logic
-        # and the boolean special case is not taken.
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
-            sup.filter(FutureWarning)
-            sup.filter(np.VisibleDeprecationWarning)
-            self.assertRaises(IndexError, ia, x, s, np.zeros(9, dtype=float))
-            self.assertRaises(IndexError, ia, x, s, np.zeros(11, dtype=float))
+        self.assertRaises(IndexError, ia, x, s, np.zeros(9, dtype=float))
+        self.assertRaises(IndexError, ia, x, s, np.zeros(11, dtype=float))
+
         # Old special case (different code path):
         self.assertRaises(ValueError, ia, x.flat, s, np.zeros(9, dtype=float))
         self.assertRaises(ValueError, ia, x.flat, s, np.zeros(11, dtype=float))


### PR DESCRIPTION
This affects mostly old boolean indexing behavior that was deprecated in NumPy 1.9. At the time the new behavior was causing errors in a number of downstream projects, hopefully that has been taken care of.
