### PR TITLE
Add out of bound check for as_strided

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -51,6 +51,17 @@ In an N-dimensional array, the user can now choose the axis along which to look
 for duplicate N-1-dimensional elements using ``numpy.unique``. The original
 behaviour is recovered if ``axis=None`` (default).
 
+``check_bounds`` keyword argument for ``as_strided`` and ``resample`` function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A ``check_bound`` keyword argument is added to
+``numpy.lib.stride_tricks.as_strided``.
+If ``check_bounds=True`` is passed to ``as_strided``, raise ``ValueError`` when
+given shape and strides lead out of bound on NumPy array.
+Default for a ``check_bounds`` keyword argument is ``False``, without checking
+out of bounds, as same as prior version of this function.
+
+And new ``numpy.lib.stride_tricks.resample`` function, equivalent to ``as_strided``
+with ``check_bounds=True``, is available.
 
 Improvements
 ============

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -51,17 +51,14 @@ In an N-dimensional array, the user can now choose the axis along which to look
 for duplicate N-1-dimensional elements using ``numpy.unique``. The original
 behaviour is recovered if ``axis=None`` (default).
 
-``check_bounds`` keyword argument for ``as_strided`` and ``resample`` function
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``check_bounds`` keyword argument for ``as_strided``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A ``check_bound`` keyword argument is added to
 ``numpy.lib.stride_tricks.as_strided``.
 If ``check_bounds=True`` is passed to ``as_strided``, raise ``ValueError`` when
 given shape and strides lead out of bound on NumPy array.
 Default for a ``check_bounds`` keyword argument is ``False``, without checking
 out of bounds, as same as prior version of this function.
-
-And new ``numpy.lib.stride_tricks.resample`` function, equivalent to ``as_strided``
-with ``check_bounds=True``, is available.
 
 Improvements
 ============

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -57,8 +57,8 @@ A ``check_bound`` keyword argument is added to
 ``numpy.lib.stride_tricks.as_strided``.
 If ``check_bounds=True`` is passed to ``as_strided``, raise ``ValueError`` when
 given shape and strides lead out of bound on NumPy array.
-Default for a ``check_bounds`` keyword argument is ``False``, without checking
-out of bounds, as same as prior version of this function.
+Default for a ``check_bounds`` keyword argument is ``'warn'``, checking
+out of bound and warn ``FutureWarning`` when call leads out of bounds for now.
 
 Improvements
 ============

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -443,10 +443,10 @@ def test_internal_overlap_manual():
     check_internal_overlap(x, False) # 1-dim
     check_internal_overlap(x.reshape([]), False) # 0-dim
 
-    a = as_strided(x, strides=(3, 4), shape=(4, 4))
+    a = as_strided(x, strides=(3, 4), shape=(4, 4), check_bounds=False)
     check_internal_overlap(a, False)
 
-    a = as_strided(x, strides=(3, 4), shape=(5, 4))
+    a = as_strided(x, strides=(3, 4), shape=(5, 4), check_bounds=False)
     check_internal_overlap(a, True)
 
     a = as_strided(x, strides=(0,), shape=(0,))
@@ -458,13 +458,13 @@ def test_internal_overlap_manual():
     a = as_strided(x, strides=(0,), shape=(2,))
     check_internal_overlap(a, True)
 
-    a = as_strided(x, strides=(0, -9993), shape=(87, 22))
+    a = as_strided(x, strides=(0, -9993), shape=(87, 22), check_bounds=False)
     check_internal_overlap(a, True)
 
-    a = as_strided(x, strides=(0, -9993), shape=(1, 22))
+    a = as_strided(x, strides=(0, -9993), shape=(1, 22), check_bounds=False)
     check_internal_overlap(a, False)
 
-    a = as_strided(x, strides=(0, -9993), shape=(0, 22))
+    a = as_strided(x, strides=(0, -9993), shape=(0, 22), check_bounds=False)
     check_internal_overlap(a, False)
 
 
@@ -487,7 +487,7 @@ def test_internal_overlap_fuzz():
         shape = tuple(rng.randint(1, 30, dtype=np.intp)
                       for j in range(ndim))
 
-        a = as_strided(x, strides=strides, shape=shape)
+        a = as_strided(x, strides=strides, shape=shape, check_bounds=False)
         result = check_internal_overlap(a)
 
         if result:

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -443,10 +443,10 @@ def test_internal_overlap_manual():
     check_internal_overlap(x, False) # 1-dim
     check_internal_overlap(x.reshape([]), False) # 0-dim
 
-    a = as_strided(x, strides=(3, 4), shape=(4, 4), check_bounds=False)
+    a = as_strided(x, strides=(3, 4), shape=(4, 4))
     check_internal_overlap(a, False)
 
-    a = as_strided(x, strides=(3, 4), shape=(5, 4), check_bounds=False)
+    a = as_strided(x, strides=(3, 4), shape=(5, 4))
     check_internal_overlap(a, True)
 
     a = as_strided(x, strides=(0,), shape=(0,))
@@ -458,13 +458,13 @@ def test_internal_overlap_manual():
     a = as_strided(x, strides=(0,), shape=(2,))
     check_internal_overlap(a, True)
 
-    a = as_strided(x, strides=(0, -9993), shape=(87, 22), check_bounds=False)
+    a = as_strided(x, strides=(0, -9993), shape=(87, 22))
     check_internal_overlap(a, True)
 
-    a = as_strided(x, strides=(0, -9993), shape=(1, 22), check_bounds=False)
+    a = as_strided(x, strides=(0, -9993), shape=(1, 22))
     check_internal_overlap(a, False)
 
-    a = as_strided(x, strides=(0, -9993), shape=(0, 22), check_bounds=False)
+    a = as_strided(x, strides=(0, -9993), shape=(0, 22))
     check_internal_overlap(a, False)
 
 
@@ -487,7 +487,7 @@ def test_internal_overlap_fuzz():
         shape = tuple(rng.randint(1, 30, dtype=np.intp)
                       for j in range(ndim))
 
-        a = as_strided(x, strides=strides, shape=shape, check_bounds=False)
+        a = as_strided(x, strides=strides, shape=shape)
         result = check_internal_overlap(a)
 
         if result:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -193,7 +193,8 @@ class TestAttributes(TestCase):
         self.assertRaises(RuntimeError, make_array, 8, 3, 1)
         # Check that the true extent of the array is used.
         # Test relies on as_strided base not exposing a buffer.
-        x = np.lib.stride_tricks.as_strided(np.arange(1), (10, 10), (0, 0))
+        x = np.lib.stride_tricks.as_strided(np.arange(1), (10, 10), (0, 0),
+                                            check_bounds=False)
 
         def set_strides(arr, strides):
             arr.strides = strides
@@ -202,7 +203,8 @@ class TestAttributes(TestCase):
 
         # Test for offset calculations:
         x = np.lib.stride_tricks.as_strided(np.arange(10, dtype=np.int8)[-1],
-                                                    shape=(10,), strides=(-1,))
+                                            shape=(10,), strides=(-1,),
+                                            check_bounds=False)
         self.assertRaises(ValueError, set_strides, x[::-1], -1)
         a = x[::-1]
         a.strides = 1

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -193,8 +193,7 @@ class TestAttributes(TestCase):
         self.assertRaises(RuntimeError, make_array, 8, 3, 1)
         # Check that the true extent of the array is used.
         # Test relies on as_strided base not exposing a buffer.
-        x = np.lib.stride_tricks.as_strided(np.arange(1), (10, 10), (0, 0),
-                                            check_bounds=False)
+        x = np.lib.stride_tricks.as_strided(np.arange(1), (10, 10), (0, 0))
 
         def set_strides(arr, strides):
             arr.strides = strides
@@ -203,8 +202,7 @@ class TestAttributes(TestCase):
 
         # Test for offset calculations:
         x = np.lib.stride_tricks.as_strided(np.arange(10, dtype=np.int8)[-1],
-                                            shape=(10,), strides=(-1,),
-                                            check_bounds=False)
+                                                    shape=(10,), strides=(-1,))
         self.assertRaises(ValueError, set_strides, x[::-1], -1)
         a = x[::-1]
         a.strides = 1

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2067,8 +2067,7 @@ def test_iter_buffered_reduce_reuse():
                     # last stride is reduced and because of that not
                     # important for this test, as it is the inner stride.
                     strides = (xs * a.itemsize, ys * a.itemsize, a.itemsize)
-                    arr = np.lib.stride_tricks.as_strided(
-                        a, (3, 3, 3), strides, check_bounds=False)
+                    arr = np.lib.stride_tricks.as_strided(a, (3, 3, 3), strides)
 
                     for skip in [0, 1]:
                         yield arr, op_axes, skip

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2067,7 +2067,8 @@ def test_iter_buffered_reduce_reuse():
                     # last stride is reduced and because of that not
                     # important for this test, as it is the inner stride.
                     strides = (xs * a.itemsize, ys * a.itemsize, a.itemsize)
-                    arr = np.lib.stride_tricks.as_strided(a, (3, 3, 3), strides)
+                    arr = np.lib.stride_tricks.as_strided(
+                        a, (3, 3, 3), strides, check_bounds=False)
 
                     for skip in [0, 1]:
                         yield arr, op_axes, skip

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2329,7 +2329,8 @@ def _parse_input_dimensions(args, input_core_dims):
     for arg, core_dims in zip(args, input_core_dims):
         _update_dim_sizes(dim_sizes, arg, core_dims)
         ndim = arg.ndim - len(core_dims)
-        dummy_array = np.lib.stride_tricks.as_strided(0, arg.shape[:ndim])
+        dummy_array = np.lib.stride_tricks.as_strided(0, arg.shape[:ndim],
+                                                      check_bounds=False)
         broadcast_args.append(dummy_array)
     broadcast_shape = np.lib.stride_tricks._broadcast_shape(*broadcast_args)
     return broadcast_shape, dim_sizes

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2329,8 +2329,7 @@ def _parse_input_dimensions(args, input_core_dims):
     for arg, core_dims in zip(args, input_core_dims):
         _update_dim_sizes(dim_sizes, arg, core_dims)
         ndim = arg.ndim - len(core_dims)
-        dummy_array = np.lib.stride_tricks.as_strided(0, arg.shape[:ndim],
-                                                      check_bounds=False)
+        dummy_array = np.lib.stride_tricks.as_strided(0, arg.shape[:ndim])
         broadcast_args.append(dummy_array)
     broadcast_shape = np.lib.stride_tricks._broadcast_shape(*broadcast_args)
     return broadcast_shape, dim_sizes

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -35,46 +35,6 @@ def _maybe_view_as_subclass(original_array, new_array):
     return new_array
 
 
-def resample(x, shape=None, strides=None, subok=False, writable=True):
-    """
-    Create a view into the array with the given shape and strides
-    with checking shape and strides will lead out of bounds.
-    Equivalent to `as_strided` with check_bounds=True.
-
-    .. versionadded:: 1.13.0
-
-    Parameters
-    ----------
-    x : ndarray
-        Array to create a new.
-    shape : sequence of int, optional
-        The shape of the new array. Defaults to ``x.shape``.
-    strides : sequence of int, optional
-        The strides of the new array. Defaults to ``x.strides``.
-    subok : bool, optional
-        If True, subclasses are preserved.
-    writeable : bool, optional
-        If set to False, the returned array will always be readonly.
-        Otherwise it will be writable if the original array was. It
-        is advisable to set this to False if possible (see Notes).
-
-    Returns
-    -------
-    view : ndarray
-
-    Raises
-    ------
-    ValueError
-        Raised when given shape and strides lead out of bound of returned array
-
-    See also
-    --------
-    as_strided: return same view with given shape and strides
-                without checking out of bound.
-    """
-    return as_strided(x, shape, strides, subok, writable, check_bounds=True)
-
-
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
                check_bounds=False):
     """

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -36,7 +36,7 @@ def _maybe_view_as_subclass(original_array, new_array):
 
 
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
-               check_bounds=True):
+               check_bounds=False):
     """
     Create a view into the array with the given shape and strides.
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -41,7 +41,8 @@ def _actual_bytes(x):
     return np.sum((np.array(x.shape) - 1) * np.array(x.strides)) + x.itemsize
 
 
-def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
+def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
+               check_bounds=False):
     """
     Create a view into the array with the given shape and strides.
 
@@ -73,7 +74,8 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
     Raises
     ------
     ValueError
-        Raised when given shape and strides lead out of bound of returned array
+        Raised when check_bounds is True and given shape and strides lead
+        out of bound of returned array
 
     See also
     --------
@@ -112,7 +114,7 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
 
     array = np.asarray(DummyArray(interface, base=x))
 
-    if _actual_bytes(array) > _actual_bytes(x):
+    if check_bounds and _actual_bytes(array) > _actual_bytes(x):
         raise ValueError("given shape and strides exceed array bound")
 
     if array.dtype.fields is None and x.dtype.fields is not None:

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -6,6 +6,7 @@ NumPy reference guide.
 
 """
 from __future__ import division, absolute_import, print_function
+import warnings
 
 import numpy as np
 
@@ -36,7 +37,7 @@ def _maybe_view_as_subclass(original_array, new_array):
 
 
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
-               check_bounds=False):
+               check_bounds='warn'):
     """
     Create a view into the array with the given shape and strides.
 
@@ -123,8 +124,15 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
         x_low, x_high = np.byte_bounds(x)
         a_low, a_high = np.byte_bounds(array)
         if x.size == 0 or a_low < x_low or x_high < a_high:
-            raise ValueError(("given shape and strides will cause "
-                              "out of bounds of original array"))
+            if check_bounds == 'warn':
+                warnings.warn(("In the future, this will raise ValueError "
+                               "if called without check_bounds=False, "
+                               "given shape and strides will cause "
+                               "out of bounds of original array"),
+                              FutureWarning)
+            else:
+                raise ValueError(("given shape and strides will cause "
+                                  "out of bounds of original array"))
 
     view = _maybe_view_as_subclass(x, array)
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -46,7 +46,7 @@ def _actual_tail(x):
 
 
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
-               check_bounds=False):
+               check_bounds=True):
     """
     Create a view into the array with the given shape and strides.
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -35,6 +35,44 @@ def _maybe_view_as_subclass(original_array, new_array):
     return new_array
 
 
+def resample(x, shape=None, strides=None, subok=False, writable=True):
+    """
+    Create a view into the array with the given shape and strides
+    with checking shape and strides will lead out of bounds.
+    Equivalent to `as_strided` with check_bounds=True.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array to create a new.
+    shape : sequence of int, optional
+        The shape of the new array. Defaults to ``x.shape``.
+    strides : sequence of int, optional
+        The strides of the new array. Defaults to ``x.strides``.
+    subok : bool, optional
+        If True, subclasses are preserved.
+    writeable : bool, optional
+        If set to False, the returned array will always be readonly.
+        Otherwise it will be writable if the original array was. It
+        is advisable to set this to False if possible (see Notes).
+
+    Returns
+    -------
+    view : ndarray
+
+    Raises
+    ------
+    ValueError
+        Raised when given shape and strides lead out of bound of returned array
+
+    See also
+    --------
+    as_strided: return same view with given shape and strides
+                without checking out of bound.
+    """
+    return as_strided(x, shape, strides, subok, writable, check_bounds=True)
+
+
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
                check_bounds=False):
     """

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -35,6 +35,12 @@ def _maybe_view_as_subclass(original_array, new_array):
     return new_array
 
 
+def _actual_bytes(x):
+    if not isinstance(x, np.ndarray):
+        x = np.array(x)
+    return np.sum((np.array(x.shape) - 1) * np.array(x.strides)) + x.itemsize
+
+
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
     """
     Create a view into the array with the given shape and strides.
@@ -63,6 +69,11 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
     Returns
     -------
     view : ndarray
+
+    Raises
+    ------
+    ValueError
+        Raised when given shape and strides lead out of bound of returned array
 
     See also
     --------
@@ -100,6 +111,9 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
         interface['strides'] = tuple(strides)
 
     array = np.asarray(DummyArray(interface, base=x))
+
+    if _actual_bytes(array) > _actual_bytes(x):
+        raise ValueError("given shape and strides exceed array bound")
 
     if array.dtype.fields is None and x.dtype.fields is not None:
         # This should only happen if x.dtype is [('', 'Vx')]

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -67,6 +67,10 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
         Otherwise it will be writable if the original array was. It
         is advisable to set this to False if possible (see Notes).
 
+    check_bounds : bool, optional
+        If set to True, check returned array will cause out of bounds of
+        original array, and raises ValueError on exceeding out of bounds.
+
     Returns
     -------
     view : ndarray
@@ -114,8 +118,11 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
 
     array = np.asarray(DummyArray(interface, base=x))
 
-    if check_bounds and _actual_bytes(array) > _actual_bytes(x):
-        raise ValueError("given shape and strides exceed array bound")
+    # check under/over reaching head/tail address
+    if (check_bounds and (np.any(np.array(strides) < 0) or
+                          _actual_bytes(array) > _actual_bytes(x))):
+        raise ValueError(("given shape and strides will cause"
+                          "out of bounds of original array"))
 
     if array.dtype.fields is None and x.dtype.fields is not None:
         # This should only happen if x.dtype is [('', 'Vx')]

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -35,16 +35,6 @@ def _maybe_view_as_subclass(original_array, new_array):
     return new_array
 
 
-def _actual_head(x):
-    return sum((sh - 1) * (st if st < 0 else 0)
-               for sh, st in zip(x.shape, x.strides))
-
-
-def _actual_tail(x):
-    return sum((sh - 1) * (st if st > 0 else 0)
-               for sh, st in zip(x.shape, x.strides))
-
-
 def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
                check_bounds=True):
     """
@@ -127,10 +117,12 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
         array.dtype = x.dtype
 
     # check under/over reaching head/tail address
-    if check_bounds and (_actual_head(array) < _actual_head(x) or
-                         _actual_tail(x) < _actual_tail(array)):
-        raise ValueError(("given shape and strides will cause"
-                          "out of bounds of original array"))
+    if check_bounds:
+        x_low, x_high = np.byte_bounds(x)
+        a_low, a_high = np.byte_bounds(array)
+        if a_low < x_low or x_high < a_high:
+            raise ValueError(("given shape and strides will cause"
+                              "out of bounds of original array"))
 
     view = _maybe_view_as_subclass(x, array)
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -129,7 +129,7 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
                                "if called without check_bounds=False, "
                                "given shape and strides will cause "
                                "out of bounds of original array"),
-                              FutureWarning)
+                              FutureWarning, stacklevel=2)
             else:
                 raise ValueError(("given shape and strides will cause "
                                   "out of bounds of original array"))

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -41,6 +41,8 @@ def resample(x, shape=None, strides=None, subok=False, writable=True):
     with checking shape and strides will lead out of bounds.
     Equivalent to `as_strided` with check_bounds=True.
 
+    .. versionadded:: 1.13.0
+
     Parameters
     ----------
     x : ndarray
@@ -100,6 +102,8 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
         is advisable to set this to False if possible (see Notes).
 
     check_bounds : bool, optional
+        .. versionadded:: 1.13
+
         If set to True, check returned array will cause out of bounds of
         original array, and raises ValueError on out of bounds.
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -63,7 +63,7 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
 
     check_bounds : bool, optional
         If set to True, check returned array will cause out of bounds of
-        original array, and raises ValueError on exceeding out of bounds.
+        original array, and raises ValueError on out of bounds.
 
     Returns
     -------
@@ -121,7 +121,7 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
         x_low, x_high = np.byte_bounds(x)
         a_low, a_high = np.byte_bounds(array)
         if a_low < x_low or x_high < a_high:
-            raise ValueError(("given shape and strides will cause"
+            raise ValueError(("given shape and strides will cause "
                               "out of bounds of original array"))
 
     view = _maybe_view_as_subclass(x, array)

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -120,7 +120,7 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
     if check_bounds:
         x_low, x_high = np.byte_bounds(x)
         a_low, a_high = np.byte_bounds(array)
-        if a_low < x_low or x_high < a_high:
+        if x.size == 0 or a_low < x_low or x_high < a_high:
             raise ValueError(("given shape and strides will cause "
                               "out of bounds of original array"))
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -123,16 +123,16 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True,
 
     array = np.asarray(DummyArray(interface, base=x))
 
+    if array.dtype.fields is None and x.dtype.fields is not None:
+        # This should only happen if x.dtype is [('', 'Vx')]
+        array.dtype = x.dtype
+
     head_orig, tail_orig = _actual_range(x)
     head_new, tail_new = _actual_range(array)
     # check under/over reaching head/tail address
     if check_bounds and (head_new < head_orig or tail_orig < tail_new):
         raise ValueError(("given shape and strides will cause"
                           "out of bounds of original array"))
-
-    if array.dtype.fields is None and x.dtype.fields is not None:
-        # This should only happen if x.dtype is [('', 'Vx')]
-        array.dtype = x.dtype
 
     view = _maybe_view_as_subclass(x, array)
 

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -318,13 +318,15 @@ def test_as_strided():
     assert_equal(a.dtype, a_view.dtype)
 
     # Make sure that raises ValueError when shape, strides lead out of bounds
-    a = np.empty((4,), dtype=dt)
+    a = np.empty((4,))
     assert_raises(ValueError, as_strided,
                   a, (5,), a.strides, check_bounds=True)
     assert_raises(ValueError, as_strided,
                   a, a.shape, (a.itemsize + 1,), check_bounds=True)
     assert_raises(ValueError, as_strided,
                   a, a.shape, (-a.itemsize,), check_bounds=True)
+    a = np.empty((2, 0))
+    assert_raises(ValueError, as_strided, a, a.shape, a.strides, check_bounds=True)
 
 def as_strided_writeable():
     arr = np.ones(10)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -317,7 +317,7 @@ def test_as_strided():
     a_view = as_strided(a, shape=(3, 4), strides=(0, a.itemsize))
     assert_equal(a.dtype, a_view.dtype)
 
-    # Make sure that raises ValueError when shape, strides exceed bounds
+    # Make sure that raises ValueError when shape, strides lead out of bounds
     a = np.empty((4,), dtype=dt)
     assert_raises(ValueError, as_strided,
                   a, (5,), a.strides, check_bounds=True)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -319,8 +319,10 @@ def test_as_strided():
 
     # Make sure that raises ValueError when shape, strides exceed bounds
     a = np.empty((4,), dtype=dt)
-    assert_raises(ValueError, as_strided, a, (5,), a.strides)
-    assert_raises(ValueError, as_strided, a, a.shape, (a.itemsize + 1,))
+    assert_raises(ValueError, as_strided,
+                  a, (5,), a.strides, check_bounds=True)
+    assert_raises(ValueError, as_strided,
+                  a, a.shape, (a.itemsize + 1,), check_bounds=True)
 
 def as_strided_writeable():
     arr = np.ones(10)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -323,6 +323,8 @@ def test_as_strided():
                   a, (5,), a.strides, check_bounds=True)
     assert_raises(ValueError, as_strided,
                   a, a.shape, (a.itemsize + 1,), check_bounds=True)
+    assert_raises(ValueError, as_strided,
+                  a, a.shape, (-a.itemsize,), check_bounds=True)
 
 def as_strided_writeable():
     arr = np.ones(10)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -317,6 +317,11 @@ def test_as_strided():
     a_view = as_strided(a, shape=(3, 4), strides=(0, a.itemsize))
     assert_equal(a.dtype, a_view.dtype)
 
+    # Make sure that raises ValueError when shape, strides exceed bounds
+    a = np.empty((4,), dtype=dt)
+    assert_raises(ValueError, as_strided, a, (5,), a.strides)
+    assert_raises(ValueError, as_strided, a, a.shape, (a.itemsize + 1,))
+
 def as_strided_writeable():
     arr = np.ones(10)
     view = as_strided(arr, writeable=False)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -275,18 +275,18 @@ def _stride_comb_iter(x):
         if x.ndim >= 1 and x.shape[-1] == 1:
             s = list(x.strides)
             s[-1] = 0
-            xi = np.lib.stride_tricks.as_strided(x, strides=s)
+            xi = np.lib.stride_tricks.as_strided(x, strides=s, check_bounds=False)
             yield xi, "stride_xxx_0"
         if x.ndim >= 2 and x.shape[-2] == 1:
             s = list(x.strides)
             s[-2] = 0
-            xi = np.lib.stride_tricks.as_strided(x, strides=s)
+            xi = np.lib.stride_tricks.as_strided(x, strides=s, check_bounds=False)
             yield xi, "stride_xxx_0_x"
         if x.ndim >= 2 and x.shape[:-2] == (1, 1):
             s = list(x.strides)
             s[-1] = 0
             s[-2] = 0
-            xi = np.lib.stride_tricks.as_strided(x, strides=s)
+            xi = np.lib.stride_tricks.as_strided(x, strides=s, check_bounds=False)
             yield xi, "stride_xxx_0_0"
 
 for src in (SQUARE_CASES,


### PR DESCRIPTION
`numpy.lib.stride_trick.as_strided` is useful but dangerous function, it may lead out of bounds memory access when one give illegal shape and strides.

This pull request checks out of bounds by calculating/comparing actual bytes of original and returned arrays in memory, and raises `ValueError` when out of bounds.