### PR TITLE
BUG: fix packbits and unpackbits to correctly handle empty arrays

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -5319,7 +5319,8 @@ add_newdoc('numpy.core.multiarray', 'packbits',
     Parameters
     ----------
     myarray : array_like
-        An integer type array whose elements should be packed to bits.
+        An array of integers or booleans whose elements should be packed to
+        bits.
     axis : int, optional
         The dimension over which bit-packing is done.
         ``None`` implies packing the flattened array.

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1551,10 +1551,6 @@ pack_bits(PyObject *input, int axis)
     if (new == NULL) {
         return NULL;
     }
-    /* Handle empty array separately */
-    if (PyArray_SIZE(new) == 0) {
-        return PyArray_Copy(new);
-    }
 
     if (PyArray_NDIM(new) == 0) {
         char *optr, *iptr;
@@ -1656,10 +1652,6 @@ unpack_bits(PyObject *input, int axis)
     Py_DECREF(inp);
     if (new == NULL) {
         return NULL;
-    }
-    /* Handle zero-dim array separately */
-    if (PyArray_SIZE(new) == 0) {
-        return PyArray_Copy(new);
     }
 
     if (PyArray_NDIM(new) == 0) {

--- a/numpy/lib/tests/test_packbits.py
+++ b/numpy/lib/tests/test_packbits.py
@@ -8,13 +8,47 @@ def test_packbits():
     # Copied from the docstring.
     a = [[[1, 0, 1], [0, 1, 0]],
          [[1, 1, 0], [0, 0, 1]]]
-    for dtype in [np.bool, np.uint8, np.int]:
-        arr = np.array(a, dtype=dtype)
+    for dt in '?bBhHiIlLqQ':
+        arr = np.array(a, dtype=dt)
         b = np.packbits(arr, axis=-1)
         assert_equal(b.dtype, np.uint8)
         assert_array_equal(b, np.array([[[160], [64]], [[192], [32]]]))
 
     assert_raises(TypeError, np.packbits, np.array(a, dtype=float))
+
+
+def test_packbits_empty():
+    shapes = [
+        (0,), (10, 20, 0), (10, 0, 20), (0, 10, 20), (20, 0, 0), (0, 20, 0),
+        (0, 0, 20), (0, 0, 0),
+    ]
+    for dt in '?bBhHiIlLqQ':
+        for shape in shapes:
+            a = np.empty(shape, dtype=dt)
+            b = np.packbits(a)
+            assert_equal(b.dtype, np.uint8)
+            assert_equal(b.shape, (0,))
+
+
+def test_packbits_empty_with_axis():
+    # Original shapes and lists of packed shapes for different axes.
+    shapes = [
+        ((0,), [(0,)]),
+        ((10, 20, 0), [(2, 20, 0), (10, 3, 0), (10, 20, 0)]),
+        ((10, 0, 20), [(2, 0, 20), (10, 0, 20), (10, 0, 3)]),
+        ((0, 10, 20), [(0, 10, 20), (0, 2, 20), (0, 10, 3)]),
+        ((20, 0, 0), [(3, 0, 0), (20, 0, 0), (20, 0, 0)]),
+        ((0, 20, 0), [(0, 20, 0), (0, 3, 0), (0, 20, 0)]),
+        ((0, 0, 20), [(0, 0, 20), (0, 0, 20), (0, 0, 3)]),
+        ((0, 0, 0), [(0, 0, 0), (0, 0, 0), (0, 0, 0)]),
+    ]
+    for dt in '?bBhHiIlLqQ':
+        for in_shape, out_shapes in shapes:
+            for ax, out_shape in enumerate(out_shapes):
+                a = np.empty(in_shape, dtype=dt)
+                b = np.packbits(a, axis=ax)
+                assert_equal(b.dtype, np.uint8)
+                assert_equal(b.shape, out_shape)
 
 
 def test_unpackbits():
@@ -25,3 +59,30 @@ def test_unpackbits():
     assert_array_equal(b, np.array([[0, 0, 0, 0, 0, 0, 1, 0],
                                     [0, 0, 0, 0, 0, 1, 1, 1],
                                     [0, 0, 0, 1, 0, 1, 1, 1]]))
+
+
+def test_unpackbits_empty():
+    a = np.empty((0,), dtype=np.uint8)
+    b = np.unpackbits(a)
+    assert_equal(b.dtype, np.uint8)
+    assert_array_equal(b, np.empty((0,)))
+
+
+def test_unpackbits_empty_with_axis():
+    # Lists of packed shapes for different axes and unpacked shapes.
+    shapes = [
+        ([(0,)], (0,)),
+        ([(2, 24, 0), (16, 3, 0), (16, 24, 0)], (16, 24, 0)),
+        ([(2, 0, 24), (16, 0, 24), (16, 0, 3)], (16, 0, 24)),
+        ([(0, 16, 24), (0, 2, 24), (0, 16, 3)], (0, 16, 24)),
+        ([(3, 0, 0), (24, 0, 0), (24, 0, 0)], (24, 0, 0)),
+        ([(0, 24, 0), (0, 3, 0), (0, 24, 0)], (0, 24, 0)),
+        ([(0, 0, 24), (0, 0, 24), (0, 0, 3)], (0, 0, 24)),
+        ([(0, 0, 0), (0, 0, 0), (0, 0, 0)], (0, 0, 0)),
+    ]
+    for in_shapes, out_shape in shapes:
+        for ax, in_shape in enumerate(in_shapes):
+            a = np.empty(in_shape, dtype=np.uint8)
+            b = np.unpackbits(a, axis=ax)
+            assert_equal(b.dtype, np.uint8)
+            assert_equal(b.shape, out_shape)


### PR DESCRIPTION


This small PR addresses several problems of numpy.packbits pointed out in Issue #8324.

As discussed in Issue #8324, numpy.packbits have problems with regard to empty input arrays. Specifically:

*   the output does not necessarily always have uint8 dtype,
*   the shape of the returned array is inconsistent when axis is specified, and
*   there is a leak of an object (new).

The fundamental reason for these problems is common: function pack_bits in compiled_base.c handles empty arrays separately, in a rough manner. I could not figure out a good reason why we should handle empty arrays separately. Rather, I found that this part is indeed unnecessary, i.e., without this, pack_bits can handle empty arrays correctly, as confirmed in my new tests. So, I propose to remove that part to fix these problems.
