### PR TITLE
BUG: fix test_api test that fails intermittently in python 3

### DIFF
--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -106,7 +106,7 @@ def test_array_array():
              dict(__array_struct__=a.__array_struct__))
     ## wasn't what I expected... is np.array(o) supposed to equal a ?
     ## instead we get a array([...], dtype=">V18")
-    assert_equal(str(np.array(o).data), str(a.data))
+    assert_equal(bytes(np.array(o).data), bytes(a.data))
 
     # test array
     o = type("o", (object,),


### PR DESCRIPTION
This test is very occasionally failing on my machine in python 3. In python 3 ndarray.data gives a memoryview object, and the str of a memoryview is just "<memory at [address of memoryview object]>", so the only reason the test usually works is because the first memoryview gets deallocated and then the second one gets allocated in exactly the same place. bytes gives you the actual underlying data in both 2 and 3.