### PR TITLE
TST: Ellipsis indexing creates a view

### DIFF
--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -141,10 +141,10 @@ class TestIndexing(TestCase):
         assert_raises(IndexError, a.__getitem__, b)
 
     def test_ellipsis_index(self):
-        # Ellipsis index does not create a view
         a = np.array([[1, 2, 3],
                       [4, 5, 6],
                       [7, 8, 9]])
+        assert_(a[...] is not a)
         assert_equal(a[...], a)
         # `a[...]` was `a` in numpy <1.9.
         assert_(a[...].base is a)


### PR DESCRIPTION
It used to be the case that one would get the exact same object back. However, since 1.9 this is no longer the case. In particular, it looks like PR ( https://github.com/numpy/numpy/pull/3798 ) made this change. Therefore we clean out this outdated comment and add an `is` test to make it clearer this is the case. Probably should also make others aware about this change as this [old SO answer]( http://stackoverflow.com/a/14692844 ) is a bit misleading about what happens in modern NumPy.

xref: https://github.com/numpy/numpy/pull/3798/files#diff-c39521d89f7e61d6c0c445d93b62f7dcR138