### PR TITLE
TST: Fix tests in PR #8341 for NumPy 1.11.x

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3991,10 +3991,7 @@ class TestResize(TestCase):
 
     def test_int_shape(self):
         x = np.eye(3)
-        if IS_PYPY:
-            x.resize(3, refcheck=False)
-        else:
-            x.resize(3)
+        x.resize(3)
         assert_array_equal(x, np.eye(3)[0,:])
 
     def test_none_shape(self):
@@ -4017,10 +4014,7 @@ class TestResize(TestCase):
 
     def test_zeros_appended(self):
         x = np.eye(3)
-        if IS_PYPY:
-            x.resize(2, 3, 3, refcheck=False)
-        else:
-            x.resize(2, 3, 3)
+        x.resize(2, 3, 3)
         assert_array_equal(x[0], np.eye(3))
         assert_array_equal(x[1], np.zeros((3, 3)))
 


### PR DESCRIPTION
gh-8341 was a backport and the tests were fixed for pypy, but the
corresponding constant PYPY is undefined in 1.11.x.