### PR TITLE
BUG: stop pickle from making copies of builtin dtypes.

### DIFF
--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -355,9 +355,9 @@ PyArrayDescr_Type
 
 .. c:member:: PyObject *PyArray_Descr.fields
 
-    For built-in data types, this is set to ``Py_None``. Otherwise,
-    if this is non-``NULL``, then this data-type-descriptor has fields
-    described by a Python dictionary whose keys are names (and also
+    For built-in data types, this is set to ``Py_None``. For other data types
+    without fields, it is ``NULL``. Otherwise, it is a pointer to a
+    Python dictionary whose keys are names (and also
     titles if given) and whose values are tuples that describe the
     fields. Recall that a data-type-descriptor always describes a
     fixed-length set of bytes. A field is a named sub-region of that

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -355,13 +355,14 @@ PyArrayDescr_Type
 
 .. c:member:: PyObject *PyArray_Descr.fields
 
-    If this is non-NULL, then this data-type-descriptor has fields
+    For built-in data types, this is set to ``Py_None``. Otherwise,
+    if this is non-``NULL``, then this data-type-descriptor has fields
     described by a Python dictionary whose keys are names (and also
     titles if given) and whose values are tuples that describe the
     fields. Recall that a data-type-descriptor always describes a
     fixed-length set of bytes. A field is a named sub-region of that
     total, fixed-length collection. A field is described by a tuple
-    composed of another data- type-descriptor and a byte
+    composed of another data-type-descriptor and a byte
     offset. Optionally, the tuple may contain a title which is
     normally a Python string. These tuples are placed in this
     dictionary keyed by name (and also title if given).

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2363,7 +2363,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
     PyObject *state;
     char endian;
     int elsize, alignment, no_state;
-    static PyObject * np_dtype;
+    static PyObject *np_dtype;
 
     /* for most built-in dtypes, no extra state needs to be saved */
     no_state = self->fields == Py_None &&

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2360,9 +2360,16 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
     PyObject *ret, *mod, *obj;
     PyObject *state;
     char endian;
-    int elsize, alignment;
+    int elsize, alignment, builtin;
 
-    ret = PyTuple_New(3);
+    builtin = self->fields == Py_None;
+    if (builtin) {
+        /* don't need to save any state for builtin dtypes */
+        ret = PyTuple_New(2);
+    }
+    else {
+        ret = PyTuple_New(3);
+    }
     if (ret == NULL) {
         return NULL;
     }
@@ -2391,7 +2398,10 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         }
         obj = PyUString_FromFormat("%c%d",self->kind, elsize);
     }
-    PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(Nii)", obj, 0, 1));
+    PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(Nii)", obj, 0, !builtin));
+    if (builtin) {
+        return ret;
+    }
 
     /*
      * Now return the state which is at least byteorder,

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2383,6 +2383,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         Py_DECREF(ret);
         return NULL;
     }
+    Py_INCREF(np_dtype);
     PyTuple_SET_ITEM(ret, 0, np_dtype);
 
     endian = self->byteorder;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -614,7 +614,7 @@ class TestDtypeAttributes(TestCase):
 class TestPickling(TestCase):
 
     def test_roundtrip(self):
-        dtypes = ['i', '<i', '>i', [('a', 'f'), ('b', 'b')], 'U', 'V', 'U2',
+        dtypes = ['i', '<i', '>i', [('a', 'f'), ('b', 'b')], 'U', 'U2',
                   'V2', 'O', [('a', 'f', (2, 2))], 'timedelta64[s]',
                   'datetime64[h]']
         for dtype in dtypes:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -637,8 +637,7 @@ class TestPickling(TestCase):
         # check that endianness is handled correctly - this pickle was
         # generated using pickle.dumps(np.dtype('f')) in a little-endian
         # environment
-        le_pickle = (b'\x80\x03cnumpy\ndtype\nq\x00X\x03\x00\x00\x00<f4q\x01K'
-                     b'\x00K\x00\x87q\x02Rq\x03.')
+        le_pickle = (b"cnumpy\ndtype\np0\n(S'<f4'\np1\nI0\nI0\ntp2\nRp3\n.")
         # this is what would be generated in a big-endian environment
         be_pickle = le_pickle.replace(b'<', b'>')
         le_dt = pickle.loads(le_pickle)

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import pickle
 
 import numpy as np
 from numpy.core.test_rational import rational
@@ -608,6 +609,29 @@ class TestDtypeAttributes(TestCase):
         class user_def_subcls(np.void):
             pass
         assert_equal(np.dtype(user_def_subcls).name, 'user_def_subcls')
+
+
+class TestPickling(TestCase):
+
+    def test_roundtrip(self):
+        dtypes = ['i', '<i', '>i', 'V2', [('a', 'f'), ('b', 'U')],
+                  [('a', 'f', (2, 2))], 'm', 'M']
+        for dtype in dtypes:
+            dt = np.dtype(dtype)
+            dt2 = pickle.loads(pickle.dumps(dt))
+            assert_equal(dt, dt2)
+
+    def test_builtin(self):
+        # gh-4317
+        dt = np.dtype(float)
+        dt2 = pickle.loads(pickle.dumps(dt))
+        assert_(dt2 is dt)
+        assert_equal(dt2.isbuiltin, 1)
+
+        dt = np.dtype(float, copy=True)
+        dt2 = pickle.loads(pickle.dumps(dt))
+        assert_equal(dt, dt2)
+        assert_equal(dt2.isbuiltin, 0)
 
 
 def test_rational_dtype():


### PR DESCRIPTION
Fixes #4317. Also add a minor clarification to the C API docs.