### PR TITLE
Fix building extensions with MinGW for Python 3.5

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -74,6 +74,18 @@ behaviour is recovered if ``axis=None`` (default).
 Improvements
 ============
 
+Partial support for 64-bit f2py extensions with MinGW
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Extensions that incorporate Fortran libraries can now be built using the free
+MinGW_ toolset, also under Python 3.5. This works best for extensions that only
+do calculations and uses the runtime modestly (reading and writing from files,
+for instance). Note that this does not remove the need for Mingwpy; if you make
+extensive use of the runtime, you will most likely run into issues_. Instead,
+it should be regarded as a band-aid until Mingwpy is fully functional.
+
+.. _MinGW: https://sf.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/6.2.0/threads-win32/seh/
+
+.. _issues: https://mingwpy.github.io/issues.html
 
 Changes
 =======

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -37,6 +37,15 @@ from distutils.errors import (DistutilsExecError, CompileError,
 from numpy.distutils.misc_util import (msvc_runtime_library,
                                        get_build_architecture)
 
+def get_msvcr_replacement():
+    """Replacement for outdated version of get_msvcr from cygwinccompiler"""
+    msvcr = msvc_runtime_library()
+    return [] if msvcr is None else [msvcr]
+
+# monkey-patch cygwinccompiler with our updated version from misc_util
+# to avoid getting an exception raised on Python 3.5
+distutils.cygwinccompiler.get_msvcr = get_msvcr_replacement
+
 # Useful to generate table of symbols from a dll
 _START = re.compile(r'\[Ordinal/Name Pointer\] Table')
 _TABLE = re.compile(r'^\s+\[([\s*[0-9]*)\] ([a-zA-Z0-9_]*)')

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -35,6 +35,8 @@ from distutils.msvccompiler import get_build_version as get_build_msvc_version
 from distutils.errors import (DistutilsExecError, CompileError,
                               UnknownFileError)
 from numpy.distutils.misc_util import (msvc_runtime_library,
+                                       msvc_runtime_version,
+                                       msvc_runtime_major,
                                        get_build_architecture)
 
 def get_msvcr_replacement():
@@ -109,8 +111,9 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
             self.define_macro('NPY_MINGW_USE_CUSTOM_MSVCR')
 
         # Define the MSVC version as hint for MinGW
-        msvcr_version = '0x%03i0' % int(msvc_runtime_library().lstrip('msvcr'))
-        self.define_macro('__MSVCRT_VERSION__', msvcr_version)
+        msvcr_version = msvc_runtime_version()
+        if msvcr_version:
+            self.define_macro('__MSVCRT_VERSION__', '0x%04i' % msvcr_version)
 
         # MS_WIN64 should be defined when building for amd64 on windows,
         # but python headers define it only for MS compilers, which has all
@@ -335,7 +338,8 @@ def build_msvcr_library(debug=False):
     msvcr_name = msvc_runtime_library()
 
     # Skip using a custom library for versions < MSVC 8.0
-    if int(msvcr_name.lstrip('msvcr')) < 80:
+    msvcr_ver = msvc_runtime_major()
+    if msvcr_ver and msvcr_ver < 80:
         log.debug('Skip building msvcr library:'
                   ' custom functionality not present')
         return False
@@ -541,12 +545,8 @@ def check_embedded_msvcr_match_linked(msver):
     """msver is the ms runtime version used for the MANIFEST."""
     # check msvcr major version are the same for linking and
     # embedding
-    msvcv = msvc_runtime_library()
-    if msvcv:
-        assert msvcv.startswith("msvcr"), msvcv
-        # Dealing with something like "mscvr90" or "mscvr100", the last
-        # last digit is the minor release, want int("9") or int("10"):
-        maj = int(msvcv[5:-1])
+    maj = msvc_runtime_major()
+    if maj:
         if not maj == int(msver):
             raise ValueError(
                   "Discrepancy between linked msvcr " \

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -403,7 +403,10 @@ def msvc_runtime_library():
     "Return name of MSVC runtime library if Python was built with MSVC >= 7"
     ver = msvc_runtime_major ()
     if ver:
-        return "msvcr%i" % ver
+        if ver < 140:
+            return "msvcr%i" % ver
+        else:
+            return "vcruntime%i" % ver
     else:
         return None
 
@@ -414,6 +417,7 @@ def msvc_runtime_major():
              1400:  80,  # MSVC 8
              1500:  90,  # MSVC 9  (aka 2008)
              1600: 100,  # MSVC 10 (aka 2010)
+             1900: 140,  # MSVC 14 (aka 2015)
     }.get(msvc_runtime_version(), None)
     return major
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -390,21 +390,32 @@ def mingw32():
             return True
     return False
 
-def msvc_runtime_library():
-    "Return name of MSVC runtime library if Python was built with MSVC >= 7"
+def msvc_runtime_version():
+    "Return version of MSVC runtime library, as defined by __MSC_VER__ macro"
     msc_pos = sys.version.find('MSC v.')
     if msc_pos != -1:
-        msc_ver = sys.version[msc_pos+6:msc_pos+10]
-        lib = {'1300': 'msvcr70',    # MSVC 7.0
-               '1310': 'msvcr71',    # MSVC 7.1
-               '1400': 'msvcr80',    # MSVC 8
-               '1500': 'msvcr90',    # MSVC 9 (VS 2008)
-               '1600': 'msvcr100',   # MSVC 10 (aka 2010)
-              }.get(msc_ver, None)
+        msc_ver = int(sys.version[msc_pos+6:msc_pos+10])
     else:
-        lib = None
-    return lib
+        msc_ver = None
+    return msc_ver
 
+def msvc_runtime_library():
+    "Return name of MSVC runtime library if Python was built with MSVC >= 7"
+    ver = msvc_runtime_major ()
+    if ver:
+        return "msvcr%i" % ver
+    else:
+        return None
+
+def msvc_runtime_major():
+    "Return major version of MSVC runtime coded like get_build_msvc_version"
+    major = {1300:  70,  # MSVC 7.0
+             1310:  71,  # MSVC 7.1
+             1400:  80,  # MSVC 8
+             1500:  90,  # MSVC 9  (aka 2008)
+             1600: 100,  # MSVC 10 (aka 2010)
+    }.get(msvc_runtime_version(), None)
+    return major
 
 #########################
 


### PR DESCRIPTION
On Windows, with Python 3.5; if using the setting `compiler=mingw32` (in for instance `setup.cfg`) and then building with `python3 setup.py develop`, the build will end with the error message:

    ValueError: Unknown MS Compiler version 1900

because the version string that is compiled into Python 3.5 indicates that it is built with Microsoft Visual Studio 2015, and this is unknown to the list coded into the distutils module.

This is unfortunate, as it precludes using the easily accessible MinGW distribution's free GNU Fortran compiler to build extensions.

This changeset adds support for the runtime used in Python 3.5. It is tested with WinPython 3.5.2.2 and MinGW 6.2.0 (win32, seh, rt-v5). It should be noted that the resulting .pyd still has a dependency on MSVCRT.DLL (and not VCRUNTIME140), but so does PYTHON35.DLL indirectly through WS2_32.DLL.