### PR TITLE
Allow extensions to be built with MinGW in a virtualenv

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -394,8 +394,7 @@ def _build_import_library_amd64():
     # didn't exist in virtualenv, maybe in base distribution?
     base_file = os.path.join(sys.base_prefix, 'libs', out_name)
     if os.path.isfile(base_file):
-        log.debug('Skip building import library: "%s" exists' %
-                  (base_file))
+        log.debug('Skip building import library: "%s" exists', base_file)
         return
 
     def_name = "python%d%d.def" % tuple(sys.version_info[:2])
@@ -423,17 +422,17 @@ def _build_import_library_x86():
         if os.path.isfile(base_lib):
             lib_file = base_lib
         else:
-            log.warn('Cannot build import library: "%s" not found' % (lib_file))
+            log.warn('Cannot build import library: "%s" not found', lib_file)
             return
     if os.path.isfile(out_file):
-        log.debug('Skip building import library: "%s" exists' % (out_file))
+        log.debug('Skip building import library: "%s" exists', out_file)
         return
     # didn't find in virtualenv, try base distribution, too
     base_file = os.path.join(sys.base_prefix, 'libs', out_name)
     if os.path.isfile(base_file):
-        log.debug('Skip building import library: "%s" exists' % (out_file))
+        log.debug('Skip building import library: "%s" exists', out_file)
         return
-    log.info('Building import library (ARCH=x86): "%s"' % (out_file))
+    log.info('Building import library (ARCH=x86): "%s"', out_file)
 
     from numpy.distutils import lib2def
 


### PR DESCRIPTION
If using the setting `compiler=mingw32` (in for instance setup.cfg) when building an extension (with `python3 setup.py develop`) in a virtualenv, the build will end with the error message:

    Building import library (arch=AMD64): "XXX\libpython35.a" (from XXX\python35.dll)

where XXX is the path to your virtualenv, because the compiler adapter for MinGW searches only the sys.prefix for the libs/ directory containing the import libraries, and these are not copied to the virtualenv when it is created.

This raises the bar for compiling extensions with the MinGW distribution because a special extra step (copy the directory from the base distribution to the virtualenv) is now required, adding a burden on all extension developers to add this to their descriptions.

This patch adds sys.base_prefix to the search paths, to pick up the import libraries from the base distribution automatically. It is tested with WinPython 3.5.2.2 on Windows 7 (using MinGW 6.2.0 (win32, seh, rt-v5) toolset).