### PR TITLE
xlocale.h is not available in newlib / Cygwin

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -113,6 +113,7 @@ OPTIONAL_HEADERS = [
                 "xmmintrin.h",  # SSE
                 "emmintrin.h",  # SSE2
                 "features.h",  # for glibc version linux
+                "xlocale.h"  # see GH#8367
 ]
 
 # optional gcc compiler builtins and their call arguments and optional a

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -15,7 +15,13 @@
 
 #ifdef HAVE_STRTOLD_L
 #include <stdlib.h>
-#include <xlocale.h>
+#ifdef HAVE_XLOCALE_H
+    /*
+     * the defines from xlocale.h are included in locale.h on some sytems;
+     * see gh-8367
+     */
+    #include <xlocale.h>
+#endif
 #endif
 
 


### PR DESCRIPTION
All the symbols defined in xlocale.h are instead found in locale.h