### PR TITLE
BUG: fix nanpercentile not returning scalar with axis argument

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1134,7 +1134,7 @@ def _nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     See nanpercentile for parameter usage
 
     """
-    if axis is None:
+    if axis is None or a.ndim == 1:
         part = a.ravel()
         result = _nanpercentile1d(part, q, overwrite_input, interpolation)
     else:

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -805,7 +805,11 @@ class TestNanFunctions_Percentile(TestCase):
                 assert_(len(w) == 0)
 
     def test_scalar(self):
-        assert_(np.nanpercentile(0., 100) == 0.)
+        assert_equal(np.nanpercentile(0., 100), 0.)
+        a = np.arange(6)
+        r = np.nanpercentile(a, 50, axis=0)
+        assert_equal(r, 2.5)
+        assert_(np.isscalar(r))
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))


### PR DESCRIPTION
Backport of #8366.

Closes gh-8220

Example of bug:
```
In [5]: np.nanpercentile(a, 50, axis=0)
Out[5]: array(2.5)
```
The result should be a scalar, not a scalar array.