### PR TITLE
DOC: Fixed minor typo in William Gosset's name

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2470,7 +2470,7 @@ cdef class RandomState:
         a good estimate of the true mean.
 
         The derivation of the t-distribution was first published in
-        1908 by William Gisset while working for the Guinness Brewery
+        1908 by William Gosset while working for the Guinness Brewery
         in Dublin. Due to proprietary issues, he had to publish under
         a pseudonym, and so he used the name Student.
 


### PR DESCRIPTION
Sorry, this is a really minor typo fix. However, I felt it is important to spell one's name correctly.

See
* https://en.wikipedia.org/wiki/Student%27s_t-distribution
* https://en.wikipedia.org/wiki/William_Sealy_Gosset