### PR TITLE
Switch to the PyPI version of plex to generate lapack_lite

### DIFF
--- a/numpy/linalg/lapack_lite/README
+++ b/numpy/linalg/lapack_lite/README
@@ -9,9 +9,9 @@ required by the ``LinearAlgebra`` module, and wrapped by the ``lapack_lite``
 module. The scripts in this directory can be used to create these files
 automatically from a directory of LAPACK source files.
 
-You'll need `Plex 1.1.4`_ installed to do the appropriate scrubbing.
+You'll need `plex 2.0.0dev`_, available from PyPI, installed to do the appropriate scrubbing.
 
-.. _Plex 1.1.4: http://www.cosc.canterbury.ac.nz/~greg/python/Plex/
+.. _plex 2.0.0dev: https://pypi.python.org/pypi/plex/
 
 The routines that ``lapack_litemodule.c`` wraps are listed in
 ``wrapped_routines``, along with a few exceptions that aren't picked up

--- a/numpy/linalg/lapack_lite/README.rst
+++ b/numpy/linalg/lapack_lite/README.rst
@@ -9,7 +9,9 @@ required by the ``LinearAlgebra`` module, and wrapped by the ``lapack_lite``
 module. The scripts in this directory can be used to create these files
 automatically from a directory of LAPACK source files.
 
-You'll need `plex 2.0.0dev`_, available from PyPI, installed to do the appropriate scrubbing.
+You'll need `plex 2.0.0dev`_, available from PyPI, installed to do the
+appropriate scrubbing. As of writing, **this is only available for python 2.7**,
+and is unlikely to ever be ported to python 3.
 
 .. _plex 2.0.0dev: https://pypi.python.org/pypi/plex/
 
@@ -18,7 +20,7 @@ The routines that ``lapack_litemodule.c`` wraps are listed in
 properly. Assuming that you have an unpacked LAPACK source tree in
 ``~/LAPACK``, you generate the new routines in a directory ``new-lite/`` with::
 
-$ python ./make_lite.py wrapped_routines ~/LAPACK new-lite/
+$ python2 ./make_lite.py wrapped_routines ~/LAPACK new-lite/
 
 This will grab the right routines, with dependencies, put them into the
 appropriate ``blas_lite.f``, ``dlapack_lite.f``, or ``zlapack_lite.f`` files,

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -4,8 +4,8 @@ from __future__ import division, absolute_import, print_function
 import sys, os
 from io import StringIO
 import re
-from Plex import Scanner, Str, Lexicon, Opt, Bol, State, AnyChar, TEXT, IGNORE
-from Plex.Traditional import re as Re
+from plex import Scanner, Str, Lexicon, Opt, Bol, State, AnyChar, TEXT, IGNORE
+from plex.traditional import re as Re
 
 class MyScanner(Scanner):
     def __init__(self, info, name='<default>'):

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -2,7 +2,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys, os
-from io import StringIO
+from io import BytesIO
 import re
 from plex import Scanner, Str, Lexicon, Opt, Bol, State, AnyChar, TEXT, IGNORE
 from plex.traditional import re as Re
@@ -21,8 +21,8 @@ def sep_seq(sequence, sep):
     return pat
 
 def runScanner(data, scanner_class, lexicon=None):
-    info = StringIO(data)
-    outfo = StringIO()
+    info = BytesIO(data)
+    outfo = BytesIO()
     if lexicon is not None:
         scanner = scanner_class(lexicon, info)
     else:
@@ -189,7 +189,7 @@ def cleanComments(source):
             return SourceLines
 
     state = SourceLines
-    for line in StringIO(source):
+    for line in BytesIO(source):
         state = state(line)
     comments.flushTo(lines)
     return lines.getValue()
@@ -217,7 +217,7 @@ def removeHeader(source):
         return OutOfHeader
 
     state = LookingForHeader
-    for line in StringIO(source):
+    for line in BytesIO(source):
         state = state(line)
     return lines.getValue()
 

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -4,8 +4,7 @@ from __future__ import division, absolute_import, print_function
 import sys, os
 from io import StringIO
 import re
-
-from Plex import *
+from Plex import Scanner, Str, Lexicon, Opt, Bol, State, AnyChar, TEXT, IGNORE
 from Plex.Traditional import re as Re
 
 class MyScanner(Scanner):

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -21,7 +21,7 @@ HEADER = '''\
 NOTE: This is generated code. Look in Misc/lapack_lite for information on
       remaking this file.
 */
-#include "Numeric/f2c.h"
+#include "f2c.h"
 
 #ifdef HAVE_CONFIG
 #include "config.h"


### PR DESCRIPTION
The previous version, 1.1.4, was not even packaged with a `setup.py`, making installation harder. Now it can just be installed (manually) from PIP.

This was tested with the lapack 3.0.0 source (not the debian lapack3 package as was used before), and was found to have identical output before and after this changeset.