### PR TITLE
DEP: Fix escaped string characters deprecated in Python 3.6.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3722,7 +3722,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('itemset',
 
     Parameters
     ----------
-    \*args : Arguments
+    \\*args : Arguments
         If one argument: a scalar, only used in case `a` is of size 1.
         If two arguments: the last argument is the value to be set
         and must be a scalar, the first argument specifies a single array

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1243,8 +1243,8 @@ def tensordot(a, b, axes=2):
     Notes
     -----
     Three common use cases are:
-        * ``axes = 0`` : tensor product :math:`a\otimes b`
-        * ``axes = 1`` : tensor dot product :math:`a\cdot b`
+        * ``axes = 0`` : tensor product :math:`a\\otimes b`
+        * ``axes = 1`` : tensor dot product :math:`a\\cdot b`
         * ``axes = 2`` : (default) tensor double contraction :math:`a:b`
 
     When `axes` is integer_like, the sequence for evaluation will be: first

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -18,8 +18,9 @@ from distutils.errors import DistutilsError, DistutilsSetupError
 # after it's installed
 #import numpy.f2py
 from numpy.distutils import log
-from numpy.distutils.misc_util import fortran_ext_match, \
-     appendpath, is_string, is_sequence, get_cmd
+from numpy.distutils.misc_util import (
+    fortran_ext_match, appendpath, is_string, is_sequence, get_cmd
+    )
 from numpy.distutils.from_template import process_file as process_f_file
 from numpy.distutils.conv_template import process_file as process_c_file
 
@@ -755,9 +756,9 @@ def _find_swig_target(target_dir, name):
 #### F2PY related auxiliary functions ####
 
 _f2py_module_name_match = re.compile(r'\s*python\s*module\s*(?P<name>[\w_]+)',
-                                re.I).match
-_f2py_user_module_name_match = re.compile(r'\s*python\s*module\s*(?P<name>[\w_]*?'\
-                                     '__user__[\w_]*)', re.I).match
+                                     re.I).match
+_f2py_user_module_name_match = re.compile(r'\s*python\s*module\s*(?P<name>[\w_]*?'
+                                          r'__user__[\w_]*)', re.I).match
 
 def get_f2py_modulename(source):
     name = None

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -93,7 +93,7 @@ class CPUInfoBase(object):
 
     def __get_nbits(self):
         abits = platform.architecture()[0]
-        nbits = re.compile('(\d+)bit').search(abits).group(1)
+        nbits = re.compile(r'(\d+)bit').search(abits).group(1)
         return nbits
 
     def _is_32bit(self):
@@ -495,8 +495,8 @@ class Win32CPUInfo(CPUInfoBase):
             else:
                 import _winreg as winreg
 
-            prgx = re.compile(r"family\s+(?P<FML>\d+)\s+model\s+(?P<MDL>\d+)"\
-                              "\s+stepping\s+(?P<STP>\d+)", re.IGNORECASE)
+            prgx = re.compile(r"family\s+(?P<FML>\d+)\s+model\s+(?P<MDL>\d+)"
+                              r"\s+stepping\s+(?P<STP>\d+)", re.IGNORECASE)
             chnd=winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, self.pkey)
             pnum=0
             while True:

--- a/numpy/distutils/fcompiler/compaq.py
+++ b/numpy/distutils/fcompiler/compaq.py
@@ -58,8 +58,8 @@ class CompaqVisualFCompiler(FCompiler):
 
     compiler_type = 'compaqv'
     description = 'DIGITAL or Compaq Visual Fortran Compiler'
-    version_pattern = r'(DIGITAL|Compaq) Visual Fortran Optimizing Compiler'\
-                      ' Version (?P<version>[^\s]*).*'
+    version_pattern = (r'(DIGITAL|Compaq) Visual Fortran Optimizing Compiler'
+                       r' Version (?P<version>[^\s]*).*')
 
     compile_switch = '/compile_only'
     object_switch = '/object:'

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -15,7 +15,7 @@ from numpy.distutils.compat import get_exception
 
 compilers = ['GnuFCompiler', 'Gnu95FCompiler']
 
-TARGET_R = re.compile("Target: ([a-zA-Z0-9_\-]*)")
+TARGET_R = re.compile(r"Target: ([a-zA-Z0-9_\-]*)")
 
 # XXX: handle cross compilation
 def is_win64():

--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -36,7 +36,7 @@ class IBMFCompiler(FCompiler):
             xlf = find_executable('xlf')
             if os.path.exists(xlf) and os.path.exists(lslpp):
                 s, o = exec_command(lslpp + ' -Lc xlfcmp')
-                m = re.search('xlfcmp:(?P<version>\d+([.]\d+)+)', o)
+                m = re.search(r'xlfcmp:(?P<version>\d+([.]\d+)+)', o)
                 if m: version = m.group('version')
 
         xlf_dir = '/etc/opt/ibmcmp/xlf'

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -202,7 +202,7 @@ class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     compiler_type = 'intelvem'
     description = 'Intel Visual Fortran Compiler for 64-bit apps'
 
-    version_match = simple_version_match(start='Intel\(R\).*?64,')
+    version_match = simple_version_match(start=r'Intel\(R\).*?64,')
 
     def get_flags_arch(self):
         return ['']

--- a/numpy/distutils/fcompiler/vast.py
+++ b/numpy/distutils/fcompiler/vast.py
@@ -10,8 +10,8 @@ class VastFCompiler(GnuFCompiler):
     compiler_type = 'vast'
     compiler_aliases = ()
     description = 'Pacific-Sierra Research Fortran 90 Compiler'
-    version_pattern = r'\s*Pacific-Sierra Research vf90 '\
-                      '(Personal|Professional)\s+(?P<version>[^\s]*)'
+    version_pattern = (r'\s*Pacific-Sierra Research vf90 '
+                       r'(Personal|Professional)\s+(?P<version>[^\s]*)')
 
     # VAST f90 does not support -o with -c. So, object files are created
     # to the current directory and then moved to build directory

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -93,7 +93,7 @@ def find_repl_patterns(astr):
     names = {}
     for rep in reps:
         name = rep[0].strip() or unique_key(names)
-        repl = rep[1].replace('\,', '@comma@')
+        repl = rep[1].replace(r'\,', '@comma@')
         thelist = conv(repl)
         names[name] = thelist
     return names
@@ -125,13 +125,13 @@ def unique_key(adict):
 
 template_name_re = re.compile(r'\A\s*(\w[\w\d]*)\s*\Z')
 def expand_sub(substr, names):
-    substr = substr.replace('\>', '@rightarrow@')
-    substr = substr.replace('\<', '@leftarrow@')
+    substr = substr.replace(r'\>', '@rightarrow@')
+    substr = substr.replace(r'\<', '@leftarrow@')
     lnames = find_repl_patterns(substr)
     substr = named_re.sub(r"<\1>", substr)  # get rid of definition templates
 
     def listrepl(mobj):
-        thelist = conv(mobj.group(1).replace('\,', '@comma@'))
+        thelist = conv(mobj.group(1).replace(r'\,', '@comma@'))
         if template_name_re.match(thelist):
             return "<%s>" % (thelist)
         name = None

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -79,7 +79,7 @@ if platform.system() == 'Windows':
 
         def __init__(self, verbose=0, dry_run=0, force=0):
             MSVCCompiler.__init__(self, verbose, dry_run, force)
-            version_match = simple_version_match(start='Intel\(R\).*?32,')
+            version_match = simple_version_match(start=r'Intel\(R\).*?32,')
             self.__version = version_match
 
         def initialize(self, plat_name=None):
@@ -101,5 +101,5 @@ if platform.system() == 'Windows':
 
         def __init__(self, verbose=0, dry_run=0, force=0):
             MSVCCompiler.__init__(self, verbose, dry_run, force)
-            version_match = simple_version_match(start='Intel\(R\).*?64,')
+            version_match = simple_version_match(start=r'Intel\(R\).*?64,')
             self.__version = version_match

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -76,7 +76,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
                                  stdout=subprocess.PIPE)
             out_string = p.stdout.read()
             p.stdout.close()
-            result = re.search('(\d+\.\d+)', out_string)
+            result = re.search(r'(\d+\.\d+)', out_string)
             if result:
                 self.gcc_version = StrictVersion(result.group(1))
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1901,7 +1901,7 @@ class Configuration(object):
         -----
         This method scans files named
         __version__.py, <packagename>_version.py, version.py, and
-        __svn_version__.py for string variables version, __version\__, and
+        __svn_version__.py for string variables version, __version__, and
         <packagename>_version, until a version number is found.
         """
         version = getattr(self, 'version', None)

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -12,7 +12,7 @@ else:
 __all__ = ['FormatError', 'PkgNotFound', 'LibraryInfo', 'VariableSet',
         'read_config', 'parse_flags']
 
-_VAR = re.compile('\$\{([a-zA-Z0-9_-]+)\}')
+_VAR = re.compile(r'\$\{([a-zA-Z0-9_-]+)\}')
 
 class FormatError(IOError):
     """
@@ -427,7 +427,7 @@ if __name__ == '__main__':
         section = "default"
 
     if options.define_variable:
-        m = re.search('([\S]+)=([\S]+)', options.define_variable)
+        m = re.search(r'([\S]+)=([\S]+)', options.define_variable)
         if not m:
             raise ValueError("--define-variable option should be of " \
                              "the form --define-variable=foo=bar")

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -549,16 +549,16 @@ beforethisafter = r'\s*(?P<before>%s(?=\s*(\b(%s)\b)))' + \
     r'\s*(?P<this>(\b(%s)\b))' + \
     r'\s*(?P<after>%s)\s*\Z'
 ##
-fortrantypes = 'character|logical|integer|real|complex|double\s*(precision\s*(complex|)|complex)|type(?=\s*\([\w\s,=(*)]*\))|byte'
+fortrantypes = r'character|logical|integer|real|complex|double\s*(precision\s*(complex|)|complex)|type(?=\s*\([\w\s,=(*)]*\))|byte'
 typespattern = re.compile(
     beforethisafter % ('', fortrantypes, fortrantypes, '.*'), re.I), 'type'
 typespattern4implicit = re.compile(beforethisafter % (
     '', fortrantypes + '|static|automatic|undefined', fortrantypes + '|static|automatic|undefined', '.*'), re.I)
 #
 functionpattern = re.compile(beforethisafter % (
-    '([a-z]+[\w\s(=*+-/)]*?|)', 'function', 'function', '.*'), re.I), 'begin'
+    r'([a-z]+[\w\s(=*+-/)]*?|)', 'function', 'function', '.*'), re.I), 'begin'
 subroutinepattern = re.compile(beforethisafter % (
-    '[a-z\s]*?', 'subroutine', 'subroutine', '.*'), re.I), 'begin'
+    r'[a-z\s]*?', 'subroutine', 'subroutine', '.*'), re.I), 'begin'
 # modulepattern=re.compile(beforethisafter%('[a-z\s]*?','module','module','.*'),re.I),'begin'
 #
 groupbegins77 = r'program|block\s*data'
@@ -570,11 +570,11 @@ beginpattern90 = re.compile(
     beforethisafter % ('', groupbegins90, groupbegins90, '.*'), re.I), 'begin'
 groupends = r'end|endprogram|endblockdata|endmodule|endpythonmodule|endinterface'
 endpattern = re.compile(
-    beforethisafter % ('', groupends, groupends, '[\w\s]*'), re.I), 'end'
+    beforethisafter % ('', groupends, groupends, r'[\w\s]*'), re.I), 'end'
 # endifs='end\s*(if|do|where|select|while|forall)'
-endifs = '(end\s*(if|do|where|select|while|forall))|(module\s*procedure)'
+endifs = r'(end\s*(if|do|where|select|while|forall))|(module\s*procedure)'
 endifpattern = re.compile(
-    beforethisafter % ('[\w]*?', endifs, endifs, '[\w\s]*'), re.I), 'endif'
+    beforethisafter % (r'[\w]*?', endifs, endifs, r'[\w\s]*'), re.I), 'endif'
 #
 implicitpattern = re.compile(
     beforethisafter % ('', 'implicit', 'implicit', '.*'), re.I), 'implicit'
@@ -593,9 +593,9 @@ privatepattern = re.compile(
 intrisicpattern = re.compile(
     beforethisafter % ('', 'intrisic', 'intrisic', '.*'), re.I), 'intrisic'
 intentpattern = re.compile(beforethisafter % (
-    '', 'intent|depend|note|check', 'intent|depend|note|check', '\s*\(.*?\).*'), re.I), 'intent'
+    '', 'intent|depend|note|check', 'intent|depend|note|check', r'\s*\(.*?\).*'), re.I), 'intent'
 parameterpattern = re.compile(
-    beforethisafter % ('', 'parameter', 'parameter', '\s*\(.*'), re.I), 'parameter'
+    beforethisafter % ('', 'parameter', 'parameter', r'\s*\(.*'), re.I), 'parameter'
 datapattern = re.compile(
     beforethisafter % ('', 'data', 'data', '.*'), re.I), 'data'
 callpattern = re.compile(

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -300,7 +300,7 @@ class NameValidator(object):
     """
     #
     defaultexcludelist = ['return', 'file', 'print']
-    defaultdeletechars = set("""~!@#$%^&*()-=+~\|]}[{';: /?.>,<""")
+    defaultdeletechars = set(r"""~!@#$%^&*()-=+~\|]}[{';: /?.>,<""")
     #
 
     def __init__(self, excludelist=None, deletechars=None,

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1244,7 +1244,7 @@ def chebgrid2d(x, y, c):
 
     This function returns the values:
 
-    .. math:: p(a,b) = \sum_{i,j} c_{i,j} * T_i(a) * T_j(b),
+    .. math:: p(a,b) = \\sum_{i,j} c_{i,j} * T_i(a) * T_j(b),
 
     where the points `(a, b)` consist of all pairs formed by taking
     `a` from `x` and `b` from `y`. The resulting points form a grid with
@@ -1898,7 +1898,7 @@ def chebgauss(deg):
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
     These sample points and weights will correctly integrate polynomials of
     degree :math:`2*deg - 1` or less over the interval :math:`[-1, 1]` with
-    the weight function :math:`f(x) = 1/\sqrt{1 - x^2}`.
+    the weight function :math:`f(x) = 1/\\sqrt{1 - x^2}`.
 
     Parameters
     ----------
@@ -1921,9 +1921,9 @@ def chebgauss(deg):
     be problematic. For Gauss-Chebyshev there are closed form solutions for
     the sample points and weights. If n = `deg`, then
 
-    .. math:: x_i = \cos(\pi (2 i - 1) / (2 n))
+    .. math:: x_i = \\cos(\\pi (2 i - 1) / (2 n))
 
-    .. math:: w_i = \pi / n
+    .. math:: w_i = \\pi / n
 
     """
     ideg = int(deg)
@@ -1940,7 +1940,7 @@ def chebweight(x):
     """
     The weight function of the Chebyshev polynomials.
 
-    The weight function is :math:`1/\sqrt{1 - x^2}` and the interval of
+    The weight function is :math:`1/\\sqrt{1 - x^2}` and the interval of
     integration is :math:`[-1, 1]`. The Chebyshev polynomials are
     orthogonal, but not normalized, with respect to this weight function.
 

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1007,7 +1007,7 @@ def hermgrid2d(x, y, c):
 
     This function returns the values:
 
-    .. math:: p(a,b) = \sum_{i,j} c_{i,j} * H_i(a) * H_j(b)
+    .. math:: p(a,b) = \\sum_{i,j} c_{i,j} * H_i(a) * H_j(b)
 
     where the points `(a, b)` consist of all pairs formed by taking
     `a` from `x` and `b` from `y`. The resulting points form a grid with
@@ -1719,8 +1719,8 @@ def hermgauss(deg):
 
     Computes the sample points and weights for Gauss-Hermite quadrature.
     These sample points and weights will correctly integrate polynomials of
-    degree :math:`2*deg - 1` or less over the interval :math:`[-\inf, \inf]`
-    with the weight function :math:`f(x) = \exp(-x^2)`.
+    degree :math:`2*deg - 1` or less over the interval :math:`[-\\inf, \\inf]`
+    with the weight function :math:`f(x) = \\exp(-x^2)`.
 
     Parameters
     ----------
@@ -1784,8 +1784,8 @@ def hermweight(x):
     """
     Weight function of the Hermite polynomials.
 
-    The weight function is :math:`\exp(-x^2)` and the interval of
-    integration is :math:`[-\inf, \inf]`. the Hermite polynomials are
+    The weight function is :math:`\\exp(-x^2)` and the interval of
+    integration is :math:`[-\\inf, \\inf]`. the Hermite polynomials are
     orthogonal, but not normalized, with respect to this weight function.
 
     Parameters

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1005,7 +1005,7 @@ def hermegrid2d(x, y, c):
 
     This function returns the values:
 
-    .. math:: p(a,b) = \sum_{i,j} c_{i,j} * H_i(a) * H_j(b)
+    .. math:: p(a,b) = \\sum_{i,j} c_{i,j} * H_i(a) * H_j(b)
 
     where the points `(a, b)` consist of all pairs formed by taking
     `a` from `x` and `b` from `y`. The resulting points form a grid with
@@ -1717,8 +1717,8 @@ def hermegauss(deg):
 
     Computes the sample points and weights for Gauss-HermiteE quadrature.
     These sample points and weights will correctly integrate polynomials of
-    degree :math:`2*deg - 1` or less over the interval :math:`[-\inf, \inf]`
-    with the weight function :math:`f(x) = \exp(-x^2/2)`.
+    degree :math:`2*deg - 1` or less over the interval :math:`[-\\inf, \\inf]`
+    with the weight function :math:`f(x) = \\exp(-x^2/2)`.
 
     Parameters
     ----------
@@ -1781,8 +1781,8 @@ def hermegauss(deg):
 def hermeweight(x):
     """Weight function of the Hermite_e polynomials.
 
-    The weight function is :math:`\exp(-x^2/2)` and the interval of
-    integration is :math:`[-\inf, \inf]`. the HermiteE polynomials are
+    The weight function is :math:`\\exp(-x^2/2)` and the interval of
+    integration is :math:`[-\\inf, \\inf]`. the HermiteE polynomials are
     orthogonal, but not normalized, with respect to this weight function.
 
     Parameters

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1007,7 +1007,7 @@ def laggrid2d(x, y, c):
 
     This function returns the values:
 
-    .. math:: p(a,b) = \sum_{i,j} c_{i,j} * L_i(a) * L_j(b)
+    .. math:: p(a,b) = \\sum_{i,j} c_{i,j} * L_i(a) * L_j(b)
 
     where the points `(a, b)` consist of all pairs formed by taking
     `a` from `x` and `b` from `y`. The resulting points form a grid with
@@ -1674,8 +1674,8 @@ def laggauss(deg):
 
     Computes the sample points and weights for Gauss-Laguerre quadrature.
     These sample points and weights will correctly integrate polynomials of
-    degree :math:`2*deg - 1` or less over the interval :math:`[0, \inf]`
-    with the weight function :math:`f(x) = \exp(-x)`.
+    degree :math:`2*deg - 1` or less over the interval :math:`[0, \\inf]`
+    with the weight function :math:`f(x) = \\exp(-x)`.
 
     Parameters
     ----------
@@ -1736,7 +1736,7 @@ def lagweight(x):
     """Weight function of the Laguerre polynomials.
 
     The weight function is :math:`exp(-x)` and the interval of integration
-    is :math:`[0, \inf]`. The Laguerre polynomials are orthogonal, but not
+    is :math:`[0, \\inf]`. The Laguerre polynomials are orthogonal, but not
     normalized, with respect to this weight function.
 
     Parameters

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1045,7 +1045,7 @@ def leggrid2d(x, y, c):
 
     This function returns the values:
 
-    .. math:: p(a,b) = \sum_{i,j} c_{i,j} * L_i(a) * L_j(b)
+    .. math:: p(a,b) = \\sum_{i,j} c_{i,j} * L_i(a) * L_j(b)
 
     where the points `(a, b)` consist of all pairs formed by taking
     `a` from `x` and `b` from `y`. The resulting points form a grid with

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -787,7 +787,7 @@ def polyvalfromroots(x, r, tensor=True):
 
     If `r` is of length `N`, this function returns the value
 
-    .. math:: p(x) = \prod_{n=1}^{N} (x - r_n)
+    .. math:: p(x) = \\prod_{n=1}^{N} (x - r_n)
 
     The parameter `x` is converted to an array only if it is a tuple or a
     list, otherwise it is treated as a scalar. In either case, either `x`

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -432,7 +432,7 @@ class NoseTester(object):
             #       be implemented).
             warnings.filterwarnings("ignore", message=".*getargspec.*",
                                     category=DeprecationWarning,
-                                    module="nose\.")
+                                    module=r"nose\.")
 
             from .noseclasses import NumpyTestProgram
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -2048,7 +2048,7 @@ class suppress_warnings(object):
                 warnings.filterwarnings(
                     "always", category=category, message=message)
             else:
-                module_regex = module.__name__.replace('.', '\.') + '$'
+                module_regex = module.__name__.replace('.', r'\.') + '$'
                 warnings.filterwarnings(
                     "always", category=category, message=message,
                     module=module_regex)
@@ -2138,7 +2138,7 @@ class suppress_warnings(object):
                 warnings.filterwarnings(
                     "always", category=cat, message=mess)
             else:
-                module_regex = mod.__name__.replace('.', '\.') + '$'
+                module_regex = mod.__name__.replace('.', r'\.') + '$'
                 warnings.filterwarnings(
                     "always", category=cat, message=mess,
                     module=module_regex)


### PR DESCRIPTION
In Python 3.6 a number of escape sequences that were previously accepted -- for instance `"\("` that was translated to `"\\("` -- are deprecated. To retain the previous behavior either raw strings must be used or the backslash must be properly escaped itself.