### PR TITLE
ENH: retune apply_along_axis nanmedian cutoff

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -869,7 +869,8 @@ def _nanmedian(a, axis=None, out=None, overwrite_input=False):
     else:
         # for small medians use sort + indexing which is still faster than
         # apply_along_axis
-        if a.shape[axis] < 1000:
+        # benchmarked with shuffled (50, 50, x) containing a few NaN
+        if a.shape[axis] < 600:
             return _nanmedian_small(a, axis, out, overwrite_input)
         result = np.apply_along_axis(_nanmedian1d, axis, a, overwrite_input)
         if out is not None:


### PR DESCRIPTION
Old value was erroneously obtained on a sorted array which is a best
case for the median of 3 pivoted introsort.