### PR TITLE
BUG: Fixed behavior of assert_array_less for +/-inf

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -137,3 +137,10 @@ with the covariance matrix by using two new keyword arguments:
   presence of a matrix that is not positive semidefinite. Valid options are
   ``ignore``, ``warn`` and ``raise``. The default value, ``warn`` keeps the
   the behavior used on previous releases.
+
+``assert_array_less`` compares ``np.inf`` and ``-np.inf`` now
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, ``np.testing.assert_array_less`` ignored all infinite values. This
+is not the expected behavior both according to documentation and intuitively.
+Now, -inf < x < inf is considered ``True`` for any real number x and all
+other cases fail.

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -432,6 +432,146 @@ class TestApproxEqual(unittest.TestCase):
                 lambda: self._assert_func(ainf, anan))
 
 
+class TestArrayAssertLess(unittest.TestCase):
+
+    def setUp(self):
+        self._assert_func = assert_array_less
+
+    def test_simple_arrays(self):
+        x = np.array([1.1, 2.2])
+        y = np.array([1.2, 2.3])
+
+        self._assert_func(x, y)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+        y = np.array([1.0, 2.3])
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, y))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+    def test_rank2(self):
+        x = np.array([[1.1, 2.2], [3.3, 4.4]])
+        y = np.array([[1.2, 2.3], [3.4, 4.5]])
+
+        self._assert_func(x, y)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+        y = np.array([[1.0, 2.3], [3.4, 4.5]])
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, y))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+    def test_rank3(self):
+        x = np.ones(shape=(2, 2, 2))
+        y = np.ones(shape=(2, 2, 2))+1
+
+        self._assert_func(x, y)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+        y[0, 0, 0] = 0
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, y))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+    def test_simple_items(self):
+        x = 1.1
+        y = 2.2
+
+        self._assert_func(x, y)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+        y = np.array([2.2, 3.3])
+
+        self._assert_func(x, y)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(y, x))
+
+        y = np.array([1.0, 3.3])
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, y))
+
+    def test_nan_noncompare(self):
+        anan = np.array(np.nan)
+        aone = np.array(1)
+        ainf = np.array(np.inf)
+        self._assert_func(anan, anan)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(aone, anan))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(anan, aone))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(anan, ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(ainf, anan))
+
+    def test_nan_noncompare_array(self):
+        x = np.array([1.1, 2.2, 3.3])
+        anan = np.array(np.nan)
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, anan))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(anan, x))
+
+        x = np.array([1.1, 2.2, np.nan])
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, anan))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(anan, x))
+
+        y = np.array([1.0, 2.0, np.nan])
+
+        self._assert_func(y, x)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, y))
+
+    def test_inf_compare(self):
+        aone = np.array(1)
+        ainf = np.array(np.inf)
+
+        self._assert_func(aone, ainf)
+        self._assert_func(-ainf, aone)
+        self._assert_func(-ainf, ainf)
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(ainf, aone))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(aone, -ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(ainf, ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(ainf, -ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(-ainf, -ainf))
+
+    def test_inf_compare_array(self):
+        x = np.array([1.1, 2.2, np.inf])
+        ainf = np.array(np.inf)
+
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(ainf, x))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(x, -ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(-x, -ainf))
+        self.assertRaises(AssertionError,
+                          lambda: self._assert_func(-ainf, -x))
+        self._assert_func(-ainf, x)
+
+
 class TestRaises(unittest.TestCase):
 
     def setUp(self):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -291,6 +291,9 @@ class TestArrayAlmostEqual(_GenericTest, unittest.TestCase):
         a[0, 0] = np.inf
         self.assertRaises(AssertionError,
                 lambda: self._assert_func(a, b))
+        b[0, 0] = -np.inf
+        self.assertRaises(AssertionError,
+                lambda: self._assert_func(a, b))
 
     def test_subclass(self):
         a = np.array([[1., 2.], [3., 4.]])
@@ -337,6 +340,8 @@ class TestAlmostEqual(_GenericTest, unittest.TestCase):
         self._assert_func(-np.inf, -np.inf)
         self.assertRaises(AssertionError,
                 lambda: self._assert_func(np.inf, 1))
+        self.assertRaises(AssertionError,
+                lambda: self._assert_func(-np.inf, np.inf))
 
     def test_simple_item(self):
         self._test_not_equal(1, 2)


### PR DESCRIPTION
At the moment `assert_array_less` in `np.testing` does not correctly treat +/-inf (see #2418). This is fixed by changing the underlying call to `assert_array_compare`, which now has an parameter `equal_inf` to compare infs rather than to ignore them analogous to the already present parameter `equal_nan`. The default is set to reproduce the old behavior and thus to not break existing code.