### PR TITLE
BUG: Fix apply_along_axis() for when func1d() returns a non-ndarray.

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -127,7 +127,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
                 ind[n] = 0
                 n -= 1
             i.put(indlist, ind)
-            res = func1d(arr[tuple(i.tolist())], *args, **kwargs)
+            res = asanyarray(func1d(arr[tuple(i.tolist())], *args, **kwargs))
             outarr[tuple(i.tolist())] = res
             k += 1
         if res.shape == ():

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -58,6 +58,12 @@ class TestApplyAlongAxis(TestCase):
         assert isinstance(res, MinimalSubclass)
         assert_array_equal(res, np.array([6, 6, 6]).view(MinimalSubclass))
 
+    def test_tuple_func1d(self):
+        def sample_1d(x):
+            return x[1], x[0]
+        res = np.apply_along_axis(sample_1d, 1, np.array([[1, 2], [3, 4]]))
+        assert_array_equal(res, np.array([[2, 1], [4, 3]]))
+
 
 class TestApplyOverAxes(TestCase):
     def test_simple(self):


### PR DESCRIPTION
Backport of #8426.

* BUG: Closes issue #8419

Fixes issue in apply_along_axis() where func1d() returns a non ndarray

* BUG: Fix apply_along_axis() when func1d() returns a non-ndarray

Closes issue #8419. Fixes issue in apply_along_axis() where
func1d() returns a non ndarray by calling asanyarray() on
result. This commit fixes a too long line in the test case.