### PR TITLE
TST: Update 3.6-dev tests to 3.6 after Python final release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
-  - 3.6-dev
+  - 3.6
 matrix:
   include:
     - python: 2.7


### PR DESCRIPTION
Update .travis.yml. Appveyor is still testing 3.5, but should be updating that shortly now that it has 3.6.