### PR TITLE
Added test for gh-8433 Inconsistent handling of integer overflow between Windows and Linux

### DIFF
--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -275,9 +275,9 @@ class TestRecord(TestCase):
     def test_nonint_offsets(self):
         # gh-8059
         def make_dtype(off):
-            return np.dtype({'names': ['A'], 'formats': ['i4'], 
+            return np.dtype({'names': ['A'], 'formats': ['i4'],
                              'offsets': [off]})
-        
+
         assert_raises(TypeError, make_dtype, 'ASD')
         assert_raises(OverflowError, make_dtype, 2**70)
         assert_raises(TypeError, make_dtype, 2.3)
@@ -618,6 +618,15 @@ def test_rational_dtype():
     # test that dtype detection finds user-defined types
     x = rational(1)
     assert_equal(np.array([x,x]).dtype, np.dtype(rational))
+
+
+def test_dtype_handles_overflow():
+    # test for bug gh-8433
+    a = np.full((2, 2), np.iinfo(np.int32).max, dtype=np.int32)
+    b = a.sum(axis=0)
+    assert_equal(b, np.array([4294967294, 4294967294]))
+    assert_equal(b.dtype, np.int64)
+    assert_equal(a.trace(), 4294967294)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a test for bug #8433 . I currently don't know where to begin on fixing the issue. I made the PR just to test on the CI machines where version consistency is assured. If AppVeyor fails, but Travis passes, then the symptom of the bug will be fully demonstrated. 