### PR TITLE
BUG: Fix crash on 0d return value in apply_along_axis

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -137,6 +137,14 @@ function is faster than previous releases.
 
 .. _double double: https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format#Double-double_arithmetic
 
+Support for returning arrays of arbitrary dimensionality in `apply_along_axis`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, only scalars or 1D arrays could be returned by the function passed
+to `apply_along_axis`. Now, it can return an array of any dimensionality
+(including 0D), and the shape of this array replaces the axis of the array
+being iterated over.
+
+
 Changes
 =======
 

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -116,7 +116,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # insert as many axes as necessary to create the output
     outshape = arr.shape[:axis] + res.shape + arr.shape[axis+1:]
     outarr = zeros(outshape, res.dtype)
-    outarr = res.__array_wrap__(outarr)
+    outarr = res.__array_prepare__(outarr)
 
     # outarr, with inserted dimensions at the end
     # this means that outarr_view[i] = func1d(inarr_view[i])
@@ -127,6 +127,9 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     outarr_view[ind0] = res
     for ind in inds:
         outarr_view[ind] = asanyarray(func1d(inarr_view[ind], *args, **kwargs))
+
+    outarr = res.__array_wrap__(outarr)
+
     return outarr
 
 

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -96,11 +96,10 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # handle negative axes
     arr = asanyarray(arr)
     nd = arr.ndim
+    if not (-nd <= axis < nd):
+        raise IndexError('axis {0} out of bounds [-{1}, {1})'.format(axis, nd))
     if axis < 0:
         axis += nd
-    if axis >= nd:
-        raise ValueError("axis must be less than arr.ndim; axis=%d, rank=%d."
-            % (axis, nd))
 
     # arr, with the iteration axis at the end
     in_dims = list(range(nd))

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -9,6 +9,7 @@ from numpy.core.numeric import (
 from numpy.core.fromnumeric import product, reshape, transpose
 from numpy.core import vstack, atleast_3d
 from numpy.lib.index_tricks import ndindex
+from numpy.matrixlib.defmatrix import matrix  # this raises all the right alarm bells
 
 
 __all__ = [
@@ -116,7 +117,11 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # insert as many axes as necessary to create the output
     outshape = arr.shape[:axis] + res.shape + arr.shape[axis+1:]
     outarr = zeros(outshape, res.dtype)
-    outarr = res.__array_prepare__(outarr)
+    # matrices call reshape in __array_prepare__, and this is apparently ok!
+    if not isinstance(res, matrix):
+        outarr = res.__array_prepare__(outarr)
+    if outshape != outarr.shape:
+        raise ValueError('__array_prepare__ should not change the shape of the resultant array')
 
     # outarr, with inserted dimensions at the end
     # this means that outarr_view[i] = func1d(inarr_view[i])

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -120,6 +120,20 @@ class TestApplyAlongAxis(TestCase):
         self.test_0d_array(MinimalSubclass)
         self.test_axis_insertion(MinimalSubclass)
 
+    def test_axis_insertion_ma(self):
+        def f1to2(x):
+            """produces an assymmetric non-square matrix from x"""
+            assert_equal(x.ndim, 1)
+            res = x[::-1] * x[1:,None]
+            return np.ma.masked_where(res%5==0, res)
+        a = np.arange(6*3).reshape((6, 3))
+        res = apply_along_axis(f1to2, 0, a)
+        assert_(isinstance(res, np.ma.masked_array))
+        assert_equal(res.ndim, 3)
+        assert_array_equal(res[:,:,0].mask, f1to2(a[:,0]).mask)
+        assert_array_equal(res[:,:,1].mask, f1to2(a[:,1]).mask)
+        assert_array_equal(res[:,:,2].mask, f1to2(a[:,2]).mask)
+
     def test_tuple_func1d(self):
         def sample_1d(x):
             return x[1], x[0]

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -28,14 +28,20 @@ class TestApplyAlongAxis(TestCase):
                            [[27, 30, 33], [36, 39, 42], [45, 48, 51]])
 
     def test_preserve_subclass(self):
+        # this test is particularly malicious because matrix
+        # refuses to become 1d
         def double(row):
             return row * 2
         m = np.matrix([[0, 1], [2, 3]])
+        expected = np.matrix([[0, 2], [4, 6]])
+
         result = apply_along_axis(double, 0, m)
         assert_(isinstance(result, np.matrix))
-        assert_array_equal(
-            result, np.matrix([[0, 2], [4, 6]])
-        )
+        assert_array_equal(result, expected)
+
+        result = apply_along_axis(double, 1, m)
+        assert_(isinstance(result, np.matrix))
+        assert_array_equal(result, expected)
 
     def test_subclass(self):
         class MinimalSubclass(np.ndarray):


### PR DESCRIPTION
Also:
ENH: Support arbitrary dimensionality of return value
MAINT: remove special casing

Now supports
```python
>>> data = np.arange(6).reshape(2, 3)
>>> data
array([[0, 1, 2],
       [3, 4, 5]])
>>> np.apply_along_axis(np.diag, -1, data)  #would previously crash
array([[[0, 0, 0],
        [0, 1, 0],
        [0, 0, 2]],

       [[3, 0, 0],
        [0, 4, 0],
        [0, 0, 5]]])
>>> np.apply_along_axis(lambda x: np.array(np.sum(x)), 0, data)  #would previously crash
array([3, 5, 7])
```

Addresses [discussion from #8363](https://github.com/numpy/numpy/pull/8363#issuecomment-270027102)