### PR TITLE
BUG: fix set memmap offset attribute correctly when offset is greater than mmap.ALLOCATIONGRANULARITY

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -144,3 +144,9 @@ Previously, ``np.testing.assert_array_less`` ignored all infinite values. This
 is not the expected behavior both according to documentation and intuitively.
 Now, -inf < x < inf is considered ``True`` for any real number x and all
 other cases fail.
+
+``offset`` attribute value in ``memmap`` objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``offset`` attribute in a ``memmap`` object is now set to the
+offset into the file. This is a behaviour change only for offsets
+greater than ``mmap.ALLOCATIONGRANULARITY``.

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -260,11 +260,11 @@ class memmap(ndarray):
 
         start = offset - offset % mmap.ALLOCATIONGRANULARITY
         bytes -= start
-        offset -= start
+        array_offset = offset - start
         mm = mmap.mmap(fid.fileno(), bytes, access=acc, offset=start)
 
         self = ndarray.__new__(subtype, shape, dtype=descr, buffer=mm,
-            offset=offset, order=order)
+                               offset=array_offset, order=order)
         self._mmap = mm
         self.offset = offset
         self.mode = mode

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -4,6 +4,7 @@ import sys
 import os
 import shutil
 from tempfile import NamedTemporaryFile, TemporaryFile, mktemp, mkdtemp
+import mmap
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
@@ -188,6 +189,11 @@ class TestMemmap(TestCase):
         assert_(fp[1:, :-1].__class__ is MemmapSubClass)
         assert(fp[[0, 1]].__class__ is MemmapSubClass)
 
+    def test_mmap_offset_greater_than_allocation_granularity(self):
+        size = 5 * mmap.ALLOCATIONGRANULARITY
+        offset = mmap.ALLOCATIONGRANULARITY + 1
+        fp = memmap(self.tmpfp, shape=size, mode='w+', offset=offset)
+        assert_(fp.offset == offset)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
A snippet reproducing the problem:

```py
import mmap
import tempfile

import numpy as np


with tempfile.NamedTemporaryFile() as f:
    size = 5 * mmap.ALLOCATIONGRANULARITY
    offset = mmap.ALLOCATIONGRANULARITY + 1
    print('offset:', offset)
    memmap = np.memmap(f.name, shape=size, mode='w+', offset=offset)
    print('memmap.offset:', memmap.offset)
```

Output:
```
offset: 4097
memmap.offset: 1
```

I was expecting `memmap.offset` to be identical to `offset` which is passed into `np.memmap` as an argument. Instead it is `offset % mmap.ALLOCATIONGRANULARITY`.

The documentation of the `offset` attribute does fit with my expectation:
```
Attributes
----------
...
offset : int
    Offset position in the file.
```