### PR TITLE
MAINT: Fix building extensions with MinGW in WinPython 3.4

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -83,8 +83,9 @@ for instance). Note that this does not remove the need for Mingwpy; if you make
 extensive use of the runtime, you will most likely run into issues_. Instead,
 it should be regarded as a band-aid until Mingwpy is fully functional.
 
-The MinGW toolset can now also be used together with the moveable WinPython 3.4
-distribution, for programs that uses a PySide Qt4 front-end.
+Extensions can also be compiled using the MinGW toolset using the runtime
+library from the (moveable) WinPython 3.4 distribution, which can be useful for
+programs with a PySide1/Qt4 front-end.
 
 .. _MinGW: https://sf.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/6.2.0/threads-win32/seh/
 

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -83,6 +83,9 @@ for instance). Note that this does not remove the need for Mingwpy; if you make
 extensive use of the runtime, you will most likely run into issues_. Instead,
 it should be regarded as a band-aid until Mingwpy is fully functional.
 
+The MinGW toolset can now also be used together with the moveable WinPython 3.4
+distribution, for programs that uses a PySide Qt4 front-end.
+
 .. _MinGW: https://sf.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/6.2.0/threads-win32/seh/
 
 .. _issues: https://mingwpy.github.io/issues.html

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -258,10 +258,9 @@ def find_python_dll():
     # - in system32,
     # - ortherwise (Sxs), I don't know how to get it.
     lib_dirs = [sys.prefix, sys.base_prefix, os.path.join(sys.prefix, 'lib')]
-    try:
-        lib_dirs.append(os.path.join(os.environ['SYSTEMROOT'], 'system32'))
-    except KeyError:
-        pass
+
+    if 'SYSTEMROOT' in os.environ:
+        lib_dirs.append(os.path.join(os.environ['SYSTEMROOT'], 'System32'))
 
     for d in lib_dirs:
         dll = os.path.join(d, dllname)

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -457,7 +457,7 @@ def _build_import_library_x86():
 
     dll_name = "python%d%d.dll" % tuple(sys.version_info[:2])
     args = (dll_name, def_file, out_file)
-    cmd = 'dlltool --dllname %s --def %s --output-lib %s' % args
+    cmd = 'dlltool --dllname "%s" --def "%s" --output-lib "%s"' % args
     status = os.system(cmd)
     # for now, fail silently
     if status:

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -423,10 +423,19 @@ def _build_import_library_amd64():
 def _build_import_library_x86():
     """ Build the import libraries for Mingw32-gcc on Windows
     """
-    lib_name = "python%d%d.lib" % tuple(sys.version_info[:2])
-    lib_file = os.path.join(sys.prefix, 'libs', lib_name)
     out_name = "libpython%d%d.a" % tuple(sys.version_info[:2])
     out_file = os.path.join(sys.prefix, 'libs', out_name)
+    if os.path.isfile(out_file):
+        log.debug('Skip building import library: "%s" exists', out_file)
+        return
+    # didn't find in virtualenv, try base distribution, too
+    base_file = os.path.join(sys.base_prefix, 'libs', out_name)
+    if os.path.isfile(base_file):
+        log.debug('Skip building import library: "%s" exists', base_file)
+        return
+
+    lib_name = "python%d%d.lib" % tuple(sys.version_info[:2])
+    lib_file = os.path.join(sys.prefix, 'libs', lib_name)
     if not os.path.isfile(lib_file):
         # didn't find library file in virtualenv, try base distribution, too,
         # and use that instead if found there
@@ -436,14 +445,6 @@ def _build_import_library_x86():
         else:
             log.warn('Cannot build import library: "%s" not found', lib_file)
             return
-    if os.path.isfile(out_file):
-        log.debug('Skip building import library: "%s" exists', out_file)
-        return
-    # didn't find in virtualenv, try base distribution, too
-    base_file = os.path.join(sys.base_prefix, 'libs', out_name)
-    if os.path.isfile(base_file):
-        log.debug('Skip building import library: "%s" exists', out_file)
-        return
     log.info('Building import library (ARCH=x86): "%s"', out_file)
 
     from numpy.distutils import lib2def

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -411,7 +411,9 @@ def _check_for_import_lib():
     major_version, minor_version = tuple(sys.version_info[:2])
 
     # patterns for the file name of the library itself
-    patterns = ['libpython%d%d.a', 'libpython%d.%d.dll.a']
+    patterns = ['libpython%d%d.a',
+                'libpython%d%d.dll.a',
+                'libpython%d.%d.dll.a']
 
     # directory trees that may contain the library
     stems = [sys.prefix]

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -455,7 +455,7 @@ def _build_import_library_x86():
     dlist, flist = lib2def.parse_nm(nm_output)
     lib2def.output_def(dlist, flist, lib2def.DEF_HEADER, open(def_file, 'w'))
 
-    dll_name = "python%d%d.dll" % tuple(sys.version_info[:2])
+    dll_name = find_python_dll ()
     args = (dll_name, def_file, out_file)
     cmd = 'dlltool --dllname "%s" --def "%s" --output-lib "%s"' % args
     status = os.system(cmd)

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -257,7 +257,7 @@ def find_python_dll():
     if sys.base_prefix != sys.prefix:
         stems.append(sys.base_prefix)
 
-    sub_dirs = ['', 'lib']
+    sub_dirs = ['', 'lib', 'bin']
     # generate possible combinations of directory trees and sub-directories
     lib_dirs = []
     for stem in stems:
@@ -411,7 +411,7 @@ def _check_for_import_lib():
     major_version, minor_version = tuple(sys.version_info[:2])
 
     # patterns for the file name of the library itself
-    patterns = ['libpython%d%d.a']
+    patterns = ['libpython%d%d.a', 'libpython%d.%d.dll.a']
 
     # directory trees that may contain the library
     stems = [sys.prefix]
@@ -419,7 +419,7 @@ def _check_for_import_lib():
         stems.append(sys.base_prefix)
 
     # possible subdirectories within those trees where it is placed
-    sub_dirs = ['libs']
+    sub_dirs = ['libs', 'lib']
 
     # generate a list of candidate locations
     candidates = []


### PR DESCRIPTION
I encountered a program that uses PySide for the presentation front-end. PySide does not support Python 3.5 as development was shifted to PySide2 before Qt 4.8.7 was released, and it was easier to use a 3.4 distribution instead of [building it myself](http://stackoverflow.com/questions/32848962/how-to-build-qt-4-8-6-with-visual-studio-2015-without-official-support). Several recent Linux distributions also uses Python 3.4 as default, so it is not unreasonable to settle for this in a cross-platform setting.

WinPython 3.4 is a moveable distribution, so it can coexist with other versions. However, it uses a slightly different naming convention for the import library. This is akin to the problem in #8362, so most of the work
was already done. I made the code a little more generic and added the necessary entries. I haven't been able to test it on MSYS2, but it works for me.

Tested with WinPython 3.4.4.3 (and also that it still works on 3.5.2.2), using MinGW 6.2.0 (win32, seh, rt-v5), on Windows 7 Service Pack 1.