### PR TITLE
MAINT: use env in shebang instead of absolute path to python

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function
 

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 takes templated file .xxx.src and produces .xxx file  where .xxx is
 .i or .c or .h, using the following template rules

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 
 process_file(filename)

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import division, absolute_import, print_function
 
 from os.path import join, sep, dirname

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Test functions for fftpack.helper module
 
 Copied from fftpack.helper by Pearu Peterson, October 2005


### PR DESCRIPTION
Fixes #8472 