### PR TITLE
BUG: Prevent crash for length-0 input to fromrecords

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -624,7 +624,6 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
 
     return _array
 
-# shape must be 1-d if you use list of lists...
 def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
                 titles=None, aligned=False, byteorder=None):
     """ create a recarray from a list of records in text form
@@ -655,10 +654,9 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
     [(456, 'dbe', 1.2) (2, 'de', 1.3)]
     """
 
-    nfields = len(recList[0])
     if formats is None and dtype is None:  # slower
         obj = sb.array(recList, dtype=object)
-        arrlist = [sb.array(obj[..., i].tolist()) for i in range(nfields)]
+        arrlist = [sb.array(obj[..., i].tolist()) for i in range(obj.shape[-1])]
         return fromarrays(arrlist, formats=formats, shape=shape, names=names,
                           titles=titles, aligned=aligned, byteorder=byteorder)
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -28,6 +28,32 @@ class TestFromrecords(TestCase):
             assert_equal(r['col2'].dtype.itemsize, 3)
         assert_equal(r['col3'].dtype.kind, 'f')
 
+    def test_fromrecords_0len(self):
+        """ Verify fromrecords works with a 0-length input """
+        dtype = [('a', np.float), ('b', np.float)]
+        r = np.rec.fromrecords([], dtype=dtype)
+        assert_equal(r.shape, (0,))
+
+    def test_fromrecords_2d(self):
+        data = [
+            [(1, 2), (3, 4), (5, 6)],
+            [(6, 5), (4, 3), (2, 1)]
+        ]
+        expected_a = [[1, 3, 5], [6, 4, 2]]
+        expected_b = [[2, 4, 6], [5, 3, 1]]
+
+        # try with dtype
+        r1 = np.rec.fromrecords(data, dtype=[('a', int), ('b', int)])
+        assert_equal(r1['a'], expected_a)
+        assert_equal(r1['b'], expected_b)
+
+        # try with names
+        r2 = np.rec.fromrecords(data, names=['a', 'b'])
+        assert_equal(r2['a'], expected_a)
+        assert_equal(r2['b'], expected_b)
+
+        assert_equal(r1, r2)
+
     def test_method_array(self):
         r = np.rec.array(asbytes('abcdefg') * 100, formats='i2,a3,i4', shape=3, byteorder='big')
         assert_equal(r[1].item(), (25444, asbytes('efg'), 1633837924))


### PR DESCRIPTION
When the dtype is provided, passing a length-0 input is perfectly sensible