### PR TITLE
DOC: Backport place np.average in inline code

### DIFF
--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -67,7 +67,7 @@ Future Changes
 
 * In 1.13 NAT will always compare False except for ``NAT != NAT``,
   which will be True.  In short, NAT will behave like NaN
-* In 1.13 np.average will preserve subclasses, to match the behavior of most
+* In 1.13 ``np.average`` will preserve subclasses, to match the behavior of most
   other numpy functions such as np.mean. In particular, this means calls which
   returned a scalar may return a 0-d subclass object instead.
 
@@ -121,7 +121,7 @@ FutureWarning to changed behavior
 
 * ``np.full`` now returns an array of the fill-value's dtype if no dtype is
   given, instead of defaulting to float.
-* np.average will emit a warning if the argument is a subclass of ndarray,
+* ``np.average`` will emit a warning if the argument is a subclass of ndarray,
   as the subclass will be preserved starting in 1.13. (see Future Changes)
 
 ``power`` and ``**`` raise errors for integer to negative integer powers


### PR DESCRIPTION
Backports commit ( 0f343f8c53d2725a0859f5aa613fe1d9a3b97942 ) from `master`.

xref: https://github.com/numpy/numpy/pull/8490