### PR TITLE
BUG: guard against replacing constants without `'_'` spec

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2451,7 +2451,7 @@ def get_parameters(vars, global_params={}):
                 if not selected_kind_re.match(v):
                     v_ = v.split('_')
                     # In case there are additive parameters
-                    if len(v_)>1: 
+                    if len(v_) > 1: 
                         v = ''.join(v_[:-1]).lower().replace(v_[-1].lower(), '')
 
             # Currently this will not work for complex numbers.

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2451,7 +2451,8 @@ def get_parameters(vars, global_params={}):
                 if not selected_kind_re.match(v):
                     v_ = v.split('_')
                     # In case there are additive parameters
-                    v = ''.join(v_[:-1]).lower().replace(v_[-1].lower(), '')
+                    if len(v_)>1: 
+                        v = ''.join(v_[:-1]).lower().replace(v_[-1].lower(), '')
 
             # Currently this will not work for complex numbers.
             # There is missing code for extracting a complex number,

--- a/numpy/f2py/tests/src/parameter/constant_compound.f90
+++ b/numpy/f2py/tests/src/parameter/constant_compound.f90
@@ -1,0 +1,15 @@
+! Check that parameters are correct intercepted.
+! Constants with comma separations are commonly
+! used, for instance Pi = 3._dp
+subroutine foo_compound_int(x)
+  implicit none
+  integer, parameter :: ii = selected_int_kind(9)
+  integer(ii), intent(inout) :: x
+  dimension x(3)
+  integer(ii), parameter :: three = 3_ii
+  integer(ii), parameter :: two = 2_ii
+  integer(ii), parameter :: six = three * 1_ii * two
+
+  x(1) = x(1) + x(2) + x(3) * six
+  return
+end subroutine

--- a/numpy/f2py/tests/src/parameter/constant_non_compound.f90
+++ b/numpy/f2py/tests/src/parameter/constant_non_compound.f90
@@ -1,0 +1,23 @@
+! Check that parameters are correct intercepted.
+! Specifically that types of constants without 
+! compound kind specs are correctly inferred
+! adapted Gibbs iteration code from pymc 
+! for this test case 
+subroutine foo_non_compound_int(x)
+  implicit none
+  integer, parameter :: ii = selected_int_kind(9)
+
+  integer(ii)   maxiterates
+  parameter (maxiterates=2)
+
+  integer(ii)   maxseries
+  parameter (maxseries=2)
+
+  integer(ii)   wasize
+  parameter (wasize=maxiterates*maxseries)
+  integer(ii), intent(inout) :: x
+  dimension x(wasize)
+
+  x(1) = x(1) + x(2) + x(3) + x(4) * wasize
+  return
+end subroutine

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -19,6 +19,7 @@ class TestParameters(util.F2PyTest):
                _path('src', 'parameter', 'constant_integer.f90'),
                _path('src', 'parameter', 'constant_both.f90'),
                _path('src', 'parameter', 'constant_compound.f90'),
+               _path('src', 'parameter', 'constant_non_compound.f90'),
     ]
 
     @dec.slow
@@ -53,6 +54,13 @@ class TestParameters(util.F2PyTest):
         x = np.arange(3, dtype=np.int32)
         self.module.foo_compound_int(x)
         assert_equal(x, [0 + 1 + 2*6, 1, 2])
+
+    @dec.slow
+    def test_constant_non_compound_int(self):
+        # check values
+        x = np.arange(4, dtype=np.int32)
+        self.module.foo_non_compound_int(x)
+        assert_equal(x, [0 + 1 + 2 + 3*4, 1, 2, 3])
 
     @dec.slow
     def test_constant_integer_int(self):

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -18,6 +18,7 @@ class TestParameters(util.F2PyTest):
     sources = [_path('src', 'parameter', 'constant_real.f90'),
                _path('src', 'parameter', 'constant_integer.f90'),
                _path('src', 'parameter', 'constant_both.f90'),
+               _path('src', 'parameter', 'constant_compound.f90'),
     ]
 
     @dec.slow
@@ -41,6 +42,17 @@ class TestParameters(util.F2PyTest):
         x = np.arange(3, dtype=np.float64)
         self.module.foo_double(x)
         assert_equal(x, [0 + 1 + 2*3, 1, 2])
+
+    @dec.slow
+    def test_constant_compound_int(self):
+        # non-contiguous should raise error
+        x = np.arange(6, dtype=np.int32)[::2]
+        assert_raises(ValueError, self.module.foo_compound_int, x)
+
+        # check values with contiguous array
+        x = np.arange(3, dtype=np.int32)
+        self.module.foo_compound_int(x)
+        assert_equal(x, [0 + 1 + 2*6, 1, 2])
 
     @dec.slow
     def test_constant_integer_int(self):


### PR DESCRIPTION
In the reported problem snippet the attempt to infer the type of
    parameter (wasize=maxiterates*2)
leads to a lookup of maxiterates in the logic of get_parameters which finds
and correctly assigns to 'v' the value string '50000'
However, then in the logic proceds to attempt to split off any underscore-appended precision
spec from v_ which yields ['50000']  because there is no underscore.
Finally line
v = ''.join(v_[:-1]).lower().replace(v_[-1].lower(), '')
if not quarded by the newly introduced lengthtest sets v to empty because
[:-1]  of a list with one element yields an empty list.
Subsequently the type inference by running eval on an empty string fails with the error
message quoted.
The introduced length check appears to correct this problem.