### PR TITLE
ENH: hard-code finfo parameters for known types

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -105,6 +105,22 @@ Performance improvements for ``packbits`` and ``unpackbits``
 The functions ``numpy.packbits`` with boolean input and ``numpy.unpackbits`` have
 been optimized to be a significantly faster for contiguous data.
 
+Fix for PPC long double floating point information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In previous versions of numpy, the ``finfo`` function returned invalid
+information about the `double double`_ format of the ``longdouble`` float type
+on Power PC (PPC).  The invalid values resulted from the failure of the numpy
+algorithm to deal with the `variable number of digits in the significand
+<https://www.ibm.com/support/knowledgecenter/en/ssw_aix_71/com.ibm.aix.genprogc/128bit_long_double_floating-point_datatype.htm>`_
+that are a feature of PPC long doubles.  This release by-passes the failing
+algorithm by using heuristics to detect the presence of the PPC double double
+format.  A side-effect of using these heuristics is that the ``finfo``
+function is faster than previous releases.
+
+.. _issues: https://github.com/numpy/numpy/issues/2669
+
+.. _double double: https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format#Double-double_arithmetic
+
 Changes
 =======
 

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -10,7 +10,6 @@ from . import numeric
 from . import numerictypes as ntypes
 from .numeric import array
 from .umath import nextafter, log2, log10, isnan, exp2
-from ..testing.utils import suppress_warnings
 
 
 def _frz(a):
@@ -91,7 +90,8 @@ class MachArLike(object):
         self._str_resolution = float_to_str(self.resolution)
 
 
-# Known parameters for float32
+# Known parameters for float32.
+# See docstring of MachAr class for description of parameters.
 _f32 = ntypes.float32
 _float32_ma = MachArLike(_f32,
                          machep=-23,
@@ -109,7 +109,8 @@ _float32_ma = MachArLike(_f32,
                          tiny=exp2(_f32(-126)))
 
 # Known parameters for float64
-_float64_ma = MachArLike(ntypes.float64,
+_f64 = ntypes.float64
+_float64_ma = MachArLike(_f64,
                          machep=-52,
                          negep=-53,
                          minexp=-1022,
@@ -119,10 +120,10 @@ _float64_ma = MachArLike(ntypes.float64,
                          ibeta=2,
                          irnd=5,
                          ngrd=0,
-                         eps=exp2(-52),
-                         epsneg=exp2(-53),
-                         huge=_get_next(ntypes.float64, numeric.inf, 0),
-                         tiny=exp2(-1022))
+                         eps=2.0 ** -52.0,
+                         epsneg=2.0 ** -53.0,
+                         huge=_get_next(_f64, numeric.inf, 0),
+                         tiny=2.0 ** -1022.0)
 
 # Known parameters for float80
 _ld = ntypes.longdouble
@@ -141,7 +142,10 @@ _float80_ma = MachArLike(_ld,
                          huge=_get_next(_ld, numeric.inf, 0),
                          tiny=exp2(_ld(-16382)))
 
-# Guessed / known parameters for double double
+# Guessed / known parameters for double double; see:
+# https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format#Double-double_arithmetic
+# These numbers have the same exponent range as float64, but extended number of
+# digits in the significand.
 _float_dd_ma = MachArLike(_ld,
                           machep=-105,
                           negep=-106,

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -133,8 +133,27 @@ _float64_ma = MachArLike(_f64,
                          huge=(1.0 - _epsneg_f64) / _tiny_f64 * _f64(4),
                          tiny=_tiny_f64)
 
-# Known parameters for float80 (Intel 80-bit extended precision)
+# Known parameters for IEEE 754 128-bit binary float
 _ld = ntypes.longdouble
+_epsneg_f128 = exp2(_ld(-113))
+_tiny_f128 = exp2(_ld(-16382))
+# Ignore runtime error when this is not f128
+with numeric.errstate(all='ignore'):
+    _huge_f128 = (_ld(1) - _epsneg_f128) / _tiny_f128 * _ld(4)
+_float128_ma = MachArLike(_ld,
+                         machep=-112,
+                         negep=-113,
+                         minexp=-16382,
+                         maxexp=16384,
+                         it=112,
+                         iexp=15,
+                         ibeta=2,
+                         irnd=5,
+                         ngrd=0,
+                         eps=exp2(_ld(-112)),
+                         epsneg=_epsneg_f128,
+                         huge=_huge_f128,
+                         tiny=_tiny_f128)
 
 # Known parameters for float80 (Intel 80-bit extended precision)
 _epsneg_f80 = exp2(_ld(-64))
@@ -196,6 +215,9 @@ _KNOWN_TYPES = {
     # double double; high, low order (e.g. PPC 64 le)
     b'\x9a\x99\x99\x99\x99\x99\xb9\xbf\x9a\x99\x99\x99\x99\x99Y<' :
     _float_dd_ma,
+    # IEEE 754 128-bit binary float
+    b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf' :
+    _float128_ma,
 }
 
 

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.core import finfo, iinfo
 from numpy import half, single, double, longdouble
 from numpy.testing import (
-    TestCase, run_module_suite, assert_equal
+    TestCase, run_module_suite, assert_equal, assert_
 )
 from numpy.core.getlimits import (_discovered_machar, _float16_ma, _float32_ma,
                                   _float64_ma, _float80_ma)
@@ -97,14 +97,25 @@ def assert_ma_equal(discovered, ma_like):
 
 def test_known_types():
     # Test we are correctly compiling parameters for known types
-    for dtype, ma_like in ((np.float16, _float16_ma),
+    for ftype, ma_like in ((np.float16, _float16_ma),
                            (np.float32, _float32_ma),
                            (np.float64, _float64_ma)):
-        assert_ma_equal(_discovered_machar(dtype), ma_like)
-    ld_ma = _discovered_machar(np.longdouble)
+        assert_ma_equal(_discovered_machar(ftype), ma_like)
+    # Suppress warning for broken discovery of double double on PPC
+    with np.errstate(all='ignore'):
+        ld_ma = _discovered_machar(np.longdouble)
     bytes = np.dtype(np.longdouble).itemsize
     if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
         assert_ma_equal(ld_ma, _float80_ma)
+
+
+def test_plausible_finfo():
+    # Assert that finfo returns reasonable results for all types
+    for ftype in np.sctypes['float'] + np.sctypes['complex']:
+        info = np.finfo(ftype)
+        assert_(info.nmant > 1)
+        assert_(info.minexp < -1)
+        assert_(info.maxexp > 1)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -10,7 +10,7 @@ from numpy.testing import (
     TestCase, run_module_suite, assert_equal, assert_
 )
 from numpy.core.getlimits import (_discovered_machar, _float16_ma, _float32_ma,
-                                  _float64_ma, _float80_ma)
+                                  _float64_ma, _float128_ma, _float80_ma)
 
 ##################################################
 
@@ -106,7 +106,11 @@ def test_known_types():
         ld_ma = _discovered_machar(np.longdouble)
     bytes = np.dtype(np.longdouble).itemsize
     if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
+        # 80-bit extended precision
         assert_ma_equal(ld_ma, _float80_ma)
+    elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
+        # IEE 754 128-bit
+        assert_ma_equal(ld_ma, _float128_ma)
 
 
 def test_plausible_finfo():

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -9,6 +9,8 @@ from numpy import half, single, double, longdouble
 from numpy.testing import (
     TestCase, run_module_suite, assert_equal
 )
+from numpy.core.getlimits import (_discover_machar, _float32_ma, _float64_ma,
+                                  _float80_ma)
 
 ##################################################
 
@@ -86,6 +88,23 @@ class TestRepr(TestCase):
 def test_instances():
     iinfo(10)
     finfo(3.0)
+
+
+def assert_ma_equal(discovered, ma_like):
+    for key, value in discovered.__dict__.items():
+        assert_equal(value, getattr(ma_like, key))
+
+
+def test_known_types():
+    # Test we are correctly compiling parameters for known types
+    for dtype, ma_like in ((np.float32, _float32_ma),
+                           (np.float64, _float64_ma)):
+        assert_ma_equal(_discover_machar(dtype), ma_like)
+    ld_ma = _discover_machar(np.longdouble)
+    bytes = np.dtype(np.longdouble).itemsize
+    if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
+        assert_ma_equal(ld_ma, _float80_ma)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -9,8 +9,8 @@ from numpy import half, single, double, longdouble
 from numpy.testing import (
     TestCase, run_module_suite, assert_equal
 )
-from numpy.core.getlimits import (_discover_machar, _float32_ma, _float64_ma,
-                                  _float80_ma)
+from numpy.core.getlimits import (_discovered_machar, _float16_ma, _float32_ma,
+                                  _float64_ma, _float80_ma)
 
 ##################################################
 
@@ -97,10 +97,11 @@ def assert_ma_equal(discovered, ma_like):
 
 def test_known_types():
     # Test we are correctly compiling parameters for known types
-    for dtype, ma_like in ((np.float32, _float32_ma),
+    for dtype, ma_like in ((np.float16, _float16_ma),
+                           (np.float32, _float32_ma),
                            (np.float64, _float64_ma)):
-        assert_ma_equal(_discover_machar(dtype), ma_like)
-    ld_ma = _discover_machar(np.longdouble)
+        assert_ma_equal(_discovered_machar(dtype), ma_like)
+    ld_ma = _discovered_machar(np.longdouble)
     bytes = np.dtype(np.longdouble).itemsize
     if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
         assert_ma_equal(ld_ma, _float80_ma)


### PR DESCRIPTION
Hard-code the MachAr parameters for float64, float32, 80-bit extended
precision, to save time, and provide skeleton for more difficult types
such as the double double on PPC; see
https://github.com/numpy/numpy/issues/2669