### PR TITLE
ENH: Make it possible to call .view on object arrays

### DIFF
--- a/doc/source/reference/routines.dtype.rst
+++ b/doc/source/reference/routines.dtype.rst
@@ -53,3 +53,4 @@ Miscellaneous
    typename
    sctype2char
    mintypecode
+   find_dtype_offsets

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -225,12 +225,7 @@ def unique(ar, return_index=False, return_inverse=False,
     else:
         dtype = [('f{i}'.format(i=i), ar.dtype) for i in range(ar.shape[1])]
 
-    try:
-        consolidated = ar.view(dtype)
-    except TypeError:
-        # There's no good way to do this for object arrays, etc...
-        msg = 'The axis argument to unique is not supported for dtype {dt}'
-        raise TypeError(msg.format(dt=ar.dtype))
+    consolidated = ar.view(dtype)
 
     def reshape_uniq(uniq):
         uniq = uniq.view(orig_dtype)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -316,10 +316,6 @@ class TestUnique(TestCase):
         assert_array_equal(a2_inv, np.zeros(5))
 
     def test_unique_axis_errors(self):
-        assert_raises(TypeError, self._run_axis_tests, object)
-        assert_raises(TypeError, self._run_axis_tests,
-                      [('a', int), ('b', object)])
-
         assert_raises(ValueError, unique, np.arange(10), axis=2)
         assert_raises(ValueError, unique, np.arange(10), axis=-2)
 
@@ -338,6 +334,8 @@ class TestUnique(TestCase):
         types.append('timedelta64[D]')
         types.append([('a', int), ('b', int)])
         types.append([('a', int), ('b', float)])
+        types.append(object)
+        types.append([('a', int), ('b', object)])
 
         for dtype in types:
             self._run_axis_tests(dtype)

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -720,5 +720,15 @@ class TestAppendFieldsObj(TestCase):
                            dtype=[('A', object), ('B', float), ('C', int)])
         assert_equal(test, control)
 
+    def test_append_with_objects(self):
+        "Test append_fields when the appended data contains objects"
+        obj = self.data['obj']
+        x = np.array([(10, 1.), (20, 2.)], dtype=[('A', int), ('B', float)])
+        y = np.array([obj, obj], dtype=object)
+        test = append_fields(x, 'C', data=y, dtypes=object, usemask=False)
+        control = np.array([(10, 1.0, obj), (20, 2.0, obj)],
+                           dtype=[('A', int), ('B', float), ('C', object)])
+        assert_equal(test, control)
+
 if __name__ == '__main__':
     run_module_suite()

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -644,8 +644,11 @@ def find_dtype_offsets(dtype, find):
     # subarray type - repeat for each element
     if dtype.subdtype:
         subtype, shape = dtype.subdtype
-        base_offsets = subtype.itemsize * _nx.arange(_nx.prod(shape), dtype=_nx.intp)
-        return (base_offsets[:,None] + find_dtype_offsets(subtype, find=find)).ravel()
+        sub_offsets = find_dtype_offsets(subtype, find=find)
+        # don't invoke arange unless we have to, as it might be large
+        if sub_offsets.size:
+            base_offsets = subtype.itemsize * _nx.arange(_nx.prod(shape), dtype=_nx.intp)
+            return (base_offsets[:,None] + sub_offsets).ravel()
 
     # record type - combine the fields
     if dtype.fields:


### PR DESCRIPTION
Right now you can do this with primitive types:

```python
>>> np.zeros((2, 3), dtype=np.int).view([('a', np.int,3)])
array([[([0, 0, 0],)],
       [([0, 0, 0],)]], 
      dtype=[('a', '<i4', (3,))])
```

This adds

```python
>>> np.zeros((2, 3), dtype=object).view([('a', object,3)])
array([[([0, 0, 0],)],
       [([0, 0, 0],)]], 
      dtype=[('a', 'O', (3,))])
```

Which would previously error

This makes it possible to use `np.unique` on 2d object arrays