### PR TITLE
BUG: Financial function nper() incorrect for zero-rate annuities.

### DIFF
--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -276,7 +276,7 @@ def nper(rate, pmt, pv, fv=0, when='end'):
             use_zero_rate = True
 
     if use_zero_rate:
-        return (-fv + pv) / (pmt + 0.0)
+        return -(fv + pv) / (pmt + 0.0)
     else:
         A = -(fv + pv)/(pmt+0.0)
         B = np.log((-fv+z) / (pv+z))/np.log(1.0+rate)

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -60,6 +60,12 @@ class TestFinancial(TestCase):
     def test_nper(self):
         assert_almost_equal(np.nper(0.075, -2000, 0, 100000.),
                             21.54, 2)
+        assert_almost_equal(np.nper(0.00001, -100, 5000, 0),
+                            50.01, 2)
+        assert_almost_equal(np.nper(0.0, -100, 5000, 0),
+                            50.00, 2)
+        assert_almost_equal(np.nper(0.0, -1, -1, 0),
+                            -1.00, 2)
 
     def test_nper2(self):
         assert_almost_equal(np.nper(0.0, -2000, 0, 100000.),


### PR DESCRIPTION
When rate=0.0, the sign on present value was wrong, causing most
degenerate cases to be incorrect.