### PR TITLE
BUG operations involving MaskedArray with output given do not return output

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2988,8 +2988,11 @@ class MaskedArray(ndarray):
         Wraps the numpy array and sets the mask according to context.
 
         """
-        result = obj.view(type(self))
-        result._update_from(self)
+        if obj is self:  # for in-place operations
+            result = obj
+        else:
+            result = obj.view(type(self))
+            result._update_from(self)
 
         if context is not None:
             result._mask = result._mask.copy()
@@ -3017,7 +3020,7 @@ class MaskedArray(ndarray):
                     except KeyError:
                         # Domain not recognized, use fill_value instead
                         fill_value = self.fill_value
-                    result = result.copy()
+
                     np.copyto(result, fill_value, where=d)
 
                     # Update the mask
@@ -3028,7 +3031,7 @@ class MaskedArray(ndarray):
                         m = (m | d)
 
             # Make sure the mask has the proper size
-            if result.shape == () and m:
+            if result is not self and result.shape == () and m:
                 return masked
             else:
                 result._mask = m

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4494,6 +4494,15 @@ def test_default_fill_value_complex():
     # regression test for Python 3, where 'unicode' was not defined
     assert_(default_fill_value(1 + 1j) == 1.e20 + 0.0j)
 
+
+def test_ufunc_with_output():
+    # check that giving an output argument always returns that output.
+    # Regression test for gh-8416.
+    x = array([1., 2., 3.], mask=[0, 0, 1])
+    y = np.add(x, 1., out=x)
+    assert_(y is x)
+
+
 ###############################################################################
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
EDIT -- turned into a PR.

Fixes an inconsistency found in #8414:
```
import numpy as np
a = np.ma.MaskedArray([1., 2.])
b = np.ma.MaskedArray(1.)
c = a.sum(out=b)
c is b
# True
d = np.true_divide(c, 2., out=b)
d is b
# False
```
Here, `d is b` should be `True`. That it is `False`s suggested `__array_wrap__` is not implemented quite correctly, probably missing a special path for `if self is obj` -- this PR fixes that.