### PR TITLE
MAINT: typo in histogram docstring

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -638,7 +638,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     >>> rng = np.random.RandomState(10)  # deterministic random data
     >>> a = np.hstack((rng.normal(size=1000),
     ...                rng.normal(loc=5, scale=2, size=1000)))
-    >>> plt.hist(a, bins='auto')  # plt.hist passes it's arguments to np.histogram
+    >>> plt.hist(a, bins='auto')  # plt.hist passes its arguments to np.histogram
     >>> plt.title("Histogram with 'auto' bins")
     >>> plt.show()
 


### PR DESCRIPTION
"it's arguments" should be "its arguments"