### PR TITLE
ENH: add hermitian=False kwarg to np.linalg.matrix_rank

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -241,6 +241,12 @@ Changes
 0d arrays now use the array2string formatters to print their elements, like
 other arrays. The ``style`` argument of ``array2string`` is now non-functional.
 
+``np.linalg.matrix_rank`` is more efficient for hermitian matrices
+------------------------------------------------------------------
+The keyword argument ``hermitian`` was added to toggle between standard
+SVD-based matrix rank calculation and the more efficient eigenvalue-based
+method for symmetric/hermitian matrices.
+
 Integer scalars are now unaffected by ``np.set_string_function``
 ----------------------------------------------------------------
 Previously the str/repr of integer scalars could be controlled by

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1383,6 +1383,19 @@ class TestMatrixRank(object):
         # works on scalar
         yield assert_equal, matrix_rank(1), 1
 
+    def test_symmetric_rank(self):
+        yield assert_equal, 4, matrix_rank(np.eye(4), hermitian=True)
+        yield assert_equal, 1, matrix_rank(np.ones((4, 4)), hermitian=True)
+        yield assert_equal, 0, matrix_rank(np.zeros((4, 4)), hermitian=True)
+        # rank deficient matrix
+        I = np.eye(4)
+        I[-1, -1] = 0.
+        yield assert_equal, 3, matrix_rank(I, hermitian=True)
+        # manually supplied tolerance
+        I[-1, -1] = 1e-8
+        yield assert_equal, 4, matrix_rank(I, hermitian=True, tol=0.99e-8)
+        yield assert_equal, 3, matrix_rank(I, hermitian=True, tol=1.01e-8)
+
 
 def test_reduced_rank():
     # Test matrices with reduced rank


### PR DESCRIPTION
With a symmetric matrix, the more efficient `eigvalsh` method can be used to find singular values.

This PR also make some minor docstring fixes, and uses the more efficient `count_nonzero` method.