### PR TITLE
DOC: Improve documentation of None as interval bounds in clip.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1667,10 +1667,12 @@ def clip(a, a_min, a_max, out=None):
     ----------
     a : array_like
         Array containing elements to clip.
-    a_min : scalar or array_like
-        Minimum value.
-    a_max : scalar or array_like
-        Maximum value.  If `a_min` or `a_max` are array_like, then the
+    a_min : scalar or array_like or `None`
+        Minimum value. If `None`, clipping is not performed on lower
+        interval edge.
+    a_max : scalar or array_like or `None`
+        Maximum value. If `None`, clipping is not performed on upper
+        interval edge. If `a_min` or `a_max` are array_like, then the
         three arrays will be broadcasted to match their shapes.
     out : ndarray, optional
         The results will be placed in this array. It may be the input

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1669,11 +1669,13 @@ def clip(a, a_min, a_max, out=None):
         Array containing elements to clip.
     a_min : scalar or array_like or `None`
         Minimum value. If `None`, clipping is not performed on lower
-        interval edge.
+        interval edge. Not more than one of `a_min` and `a_max` may be
+        `None`.
     a_max : scalar or array_like or `None`
         Maximum value. If `None`, clipping is not performed on upper
-        interval edge. If `a_min` or `a_max` are array_like, then the
-        three arrays will be broadcasted to match their shapes.
+        interval edge. Not more than one of `a_min` and `a_max` may be
+        `None`. If `a_min` or `a_max` are array_like, then the three
+        arrays will be broadcasted to match their shapes.
     out : ndarray, optional
         The results will be placed in this array. It may be the input
         array for in-place clipping.  `out` must be of the right shape


### PR DESCRIPTION
Adding a little clarification to documentation about using `None` as interval bounds on `np.clip()` as per #8552  