### PR TITLE
WIP: allow loss of precision for clongdouble

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1895,6 +1895,10 @@ class TestComplexFunctions(object):
         info = np.finfo(dtype)
         real_dtype = dtype(0.).real.dtype
         eps = info.eps
+        # It's not guaranteed that the system-provided arc functions are
+        # accurate down to a few epsilons - e.g. on Linux 64-bit, PPC). So,
+        # allow option for more leeway on long complex tests.
+        effective_eps = max(eps, 2.5e-18)
 
         def check(x, rtol):
             x = x.astype(real_dtype)
@@ -1925,13 +1929,7 @@ class TestComplexFunctions(object):
         x_series = np.logspace(-20, -3.001, 200)
         x_basic = np.logspace(-2.999, 0, 10, endpoint=False)
 
-        if dtype is np.longcomplex:
-            # It's not guaranteed that the system-provided arc functions
-            # are accurate down to a few epsilons. (Eg. on Linux 64-bit)
-            # So, give more leeway for long complex tests here:
-            check(x_series, 50*eps)
-        else:
-            check(x_series, 2.1*eps)
+        check(x_series, 2.1 * effective_eps)
         check(x_basic, 2*eps/1e-3)
 
         # Check a few points


### PR DESCRIPTION
Now we have the correct eps value for PPC longdouble, we no longer skip
the arc* functions with clongcomplex, and these reveal precision
failures.

Allow some precision loss for clongcomplex, that is less than for the
default complex, but maybe a lot more than clongcomplex eps.

See #8298 for original report of precision failure.  This commit fixes that
precision failure, but reveals:

```
======================================================================
FAIL: test_umath.TestComplexFunctions.test_loss_of_precision_longcomplex
----------------------------------------------------------------------
Traceback (most recent call last):
    File "/home/mb312/.virtualenvs/test/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
        self.test(*self.arg)
    File "/home/mb312/dev_trees/numpy/numpy/testing/decorators.py", line 217, in knownfailer
        return f(*args, **kwargs)
    File "/home/mb312/dev_trees/numpy/numpy/core/tests/test_umath.py", line 1980, in test_loss_of_precision_longcomplex
        self.check_loss_of_precision(np.longcomplex)
    File "/home/mb312/dev_trees/numpy/numpy/core/tests/test_umath.py", line 1970, in check_loss_of_precision
        check(func, pts, 1)
    File "/home/mb312/dev_trees/numpy/numpy/core/tests/test_umath.py", line 1965, in check
        assert_(np.all(good), (func, z0[~good]))
    File "/home/mb312/dev_trees/numpy/numpy/testing/utils.py", line 90, in assert_
        raise AssertionError(smsg)
AssertionError: (<ufunc 'arctanh'>, array([ 0.0-0.001j,  0.0+0.001j], dtype=complex256))
```

In fact, the errors are rather extreme:

```
(Pdb) print(d)
1
(Pdb) func(zp) - func(zm)
array([ 1.4142136e-20+2.8284271e-26j,  1.000001e-20+0.0j,
        1.4142136e-20-2.8284271e-26j,  0.1732868+0.0j,  0.1732868+0.0j,
        1.4142136e-20-2.8284271e-26j,  1.000001e-20+0.0j,
        1.4142136e-20+2.8284271e-26j], dtype=complex256)
```

Maybe it would be reasonable to guarantee that (c)longdouble is at least as
accurate as (c)double.