### PR TITLE
DOC: fix several typos #8537.

### DIFF
--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -248,7 +248,8 @@ Indexing
 Array scalars can be indexed like 0-dimensional arrays: if *x* is an
 array scalar,
 
-- ``x[()]`` returns a 0-dimensional :class:`ndarray`
+- ``x[()]`` returns a copy of array scalar
+- ``x[...]`` returns a 0-dimensional :class:`ndarray`
 - ``x['field-name']`` returns the array scalar in the field *field-name*.
   (*x* can have fields, for example, when it corresponds to a structured data type.)
 
@@ -282,10 +283,10 @@ Defining new types
 ==================
 
 There are two ways to effectively define a new array scalar type
-(apart from composing structured types :ref:`dtypes <arrays.dtypes>` from 
-the built-in scalar types): One way is to simply subclass the 
-:class:`ndarray` and overwrite the methods of interest. This will work to 
-a degree, but internally certain behaviors are fixed by the data type of 
-the array.  To fully customize the data type of an array you need to 
-define a new data-type, and register it with NumPy. Such new types can only 
+(apart from composing structured types :ref:`dtypes <arrays.dtypes>` from
+the built-in scalar types): One way is to simply subclass the
+:class:`ndarray` and overwrite the methods of interest. This will work to
+a degree, but internally certain behaviors are fixed by the data type of
+the array.  To fully customize the data type of an array you need to
+define a new data-type, and register it with NumPy. Such new types can only
 be defined in C, using the :ref:`NumPy C-API <c-api>`.

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -713,27 +713,32 @@ Several arrays can be stacked together along different axes::
 
 The function `column_stack`
 stacks 1D arrays as columns into a 2D array. It is equivalent to
-`vstack` only for 1D arrays::
+`hstack` only for 2D arrays::
 
     >>> from numpy import newaxis
-    >>> np.column_stack((a,b))   # With 2D arrays
+    >>> np.column_stack((a,b))     # with 2D arrays
     array([[ 8.,  8.,  1.,  8.],
            [ 0.,  0.,  0.,  4.]])
     >>> a = np.array([4.,2.])
-    >>> b = np.array([2.,8.])
-    >>> a[:,newaxis]  # This allows to have a 2D columns vector
+    >>> b = np.array([3.,8.])
+    >>> np.column_stack((a,b))     # returns a 2D array
+    array([[ 4., 3.],
+           [ 2., 8.]])
+    >>> np.hstack((a,b))           # the result is different
+    array([ 4., 2., 3., 8.])
+    >>> a[:,newaxis]               # this allows to have a 2D columns vector
     array([[ 4.],
            [ 2.]])
     >>> np.column_stack((a[:,newaxis],b[:,newaxis]))
-    array([[ 4.,  2.],
+    array([[ 4.,  3.],
            [ 2.,  8.]])
-    >>> np.vstack((a[:,newaxis],b[:,newaxis])) # The behavior of vstack is different
-    array([[ 4.],
-           [ 2.],
-           [ 2.],
-           [ 8.]])
+    >>> np.hstack((a[:,newaxis],b[:,newaxis]))   # the result is the same
+    array([[ 4.,  3.],
+           [ 2.,  8.]])
 
-For arrays of with more than two dimensions,
+On the other hand, the function `row_stack` is equivalent to `vstack`
+for any input arrays.
+In general, for arrays of with more than two dimensions,
 `hstack` stacks along their second
 axes, `vstack` stacks along their
 first axes, and `concatenate`

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -200,8 +200,8 @@ one index array with y: ::
 
 What results is the construction of a new array where each value of
 the index array selects one row from the array being indexed and the
-resultant array has the resulting shape (size of row, number index
-elements).
+resultant array has the resulting shape (number of index elements,
+size of row).
 
 An example of where this may be useful is for a color lookup table
 where we want to map the values of an image into RGB triples for


### PR DESCRIPTION
I've made corrections to my previous PR #8544 (which I closed). 

I've also noticed that in documentation, it is nothing said that `np.int`, `np.float`, etc. returns Python's `int` and `float` instead of `array scalar`. The first time it was pretty confusing to me. If it's OK I will add a commit, but I don`t know the right place in documentation where to add this stuff.