### PR TITLE
MAINT: PyPy3 compatibility: sys.getsizeof()

### DIFF
--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -15,7 +15,17 @@ if sys.version_info[:2] >= (3, 3):
     def buffer_length(arr):
         if isinstance(arr, unicode):
             arr = str(arr)
-            return (sys.getsizeof(arr+"a") - sys.getsizeof(arr)) * len(arr)
+            if not arr:
+                charmax = 0
+            else:
+                charmax = max([ord(c) for c in arr])
+            if charmax < 256:
+                size = 1
+            elif charmax < 65536:
+                size = 2
+            else:
+                size = 4
+            return size * len(arr)
         v = memoryview(arr)
         if v.shape is None:
             return len(v) * v.itemsize


### PR DESCRIPTION
I'm currently working on ensuring compatibility of the upcoming pypy3.5 with numpy[*].

This use of `sys.getsizeof()` causes many spurious test failures on pypy3, because `sys.getsizeof()` is CPython-specific. Since there doesn't seem to be a pure-Python way of getting the size of the
internal PEP393 Unicode representation, I'm recomputing it using documented
invariants instead.

[*]: If you're interested, you can grab a Linux nightly from [here](http://buildbot.pypy.org/nightly/py3.5/) and check for yourself. Most things already work, barring the occasional puzzling segfault.