### PR TITLE
BUG: make np.squeeze always return an array, never a scalar

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -76,6 +76,11 @@ obvious exception of any code that tries to directly call
 ``ndarray.__getslice__`` (e.g. through ``super(...).__getslice__``). In
 this case, ``.__getitem__(slice(start, end))`` will act as a replacement.
 
+``np.squeeze`` always returns an array when passed a scalar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, this was only the case when passed a python scalar, and it did not
+do array promotion when passed a numpy scalar.
+
 
 C API
 ~~~~~

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1579,8 +1579,7 @@ gentype_squeeze(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "")) {
         return NULL;
     }
-    Py_INCREF(self);
-    return self;
+    return PyArray_FromScalar(self, NULL);
 }
 
 static Py_ssize_t

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -147,6 +147,9 @@ class TestNonarrayArgs(TestCase):
         A = [[[1, 1, 1], [2, 2, 2], [3, 3, 3]]]
         assert_(np.squeeze(A).shape == (3, 3))
 
+        assert_(isinstance(np.squeeze(1), np.ndarray))
+        assert_(isinstance(np.squeeze(np.int32(1)), np.ndarray))
+
     def test_std(self):
         A = [[1, 2, 3], [4, 5, 6]]
         assert_almost_equal(np.std(A), 1.707825127659933)


### PR DESCRIPTION
Fixes #8588 

Since the documentation says the return value is an `ndarray`, it seems that the bug was in `numpy.generic.squeeze`