### PR TITLE
MAINT: Remove `__setslice__` and `__getslice__`

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -65,6 +65,17 @@ implement ``__len__`` as the number of record fields, ``bool`` of scalar dtypes
 would evaluate to ``False``, which was unintuitive. Now ``bool(dtype) == True``
 for all dtypes.
 
+``__getslice__`` and ``__setslice__`` have been removed from ``ndarray``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When subclassing np.ndarray in Python 2.7, it is no longer _necessary_ to
+implement ``__*slice__`` on the derived class, as ``__*item__`` will intercept
+these calls correctly.
+
+Any code that did implement these will work exactly as before, with the
+obvious exception of any code that tries to directly call
+``ndarray.__getslice__`` (e.g. through ``super(...).__getslice__``). In
+this case, ``.__getitem__(slice(start, end))`` will act as a replacement.
+
 
 C API
 ~~~~~

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -36,8 +36,8 @@ objects, the :const:`Ellipsis` object, or the :const:`newaxis` object,
 but not for integer arrays or other embedded sequences.
 
 .. index::
-   triple: ndarray; special methods; get slice
-   triple: ndarray; special methods; set slice
+   triple: ndarray; special methods; getitem
+   triple: ndarray; special methods; setitem
    single: ellipsis
    single: newaxis
 

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -36,8 +36,8 @@ objects, the :const:`Ellipsis` object, or the :const:`newaxis` object,
 but not for integer arrays or other embedded sequences.
 
 .. index::
-   triple: ndarray; special methods; getslice
-   triple: ndarray; special methods; setslice
+   triple: ndarray; special methods; get slice
+   triple: ndarray; special methods; set slice
    single: ellipsis
    single: newaxis
 

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -595,8 +595,6 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
    ndarray.__len__
    ndarray.__getitem__
    ndarray.__setitem__
-   ndarray.__getslice__
-   ndarray.__setslice__
    ndarray.__contains__
 
 Conversion; the operations :func:`complex()`, :func:`int()`,

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -417,8 +417,6 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
    MaskedArray.__getitem__
    MaskedArray.__setitem__
    MaskedArray.__delitem__
-   MaskedArray.__getslice__
-   MaskedArray.__setslice__
    MaskedArray.__contains__
 
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2416,9 +2416,9 @@ NPY_NO_EXPORT PySequenceMethods npyiter_as_sequence = {
     (binaryfunc)NULL,                       /*sq_concat*/
     (ssizeargfunc)NULL,                     /*sq_repeat*/
     (ssizeargfunc)npyiter_seq_item,         /*sq_item*/
-    (ssizessizeargfunc)npyiter_seq_slice,   /*sq_slice*/
+    (ssizessizeargfunc)NULL,                /*sq_slice*/
     (ssizeobjargproc)npyiter_seq_ass_item,  /*sq_ass_item*/
-    (ssizessizeobjargproc)npyiter_seq_ass_slice,/*sq_ass_slice*/
+    (ssizessizeobjargproc)NULL,             /*sq_ass_slice*/
     (objobjproc)NULL,                       /*sq_contains */
     (binaryfunc)NULL,                       /*sq_inplace_concat */
     (ssizeargfunc)NULL,                     /*sq_inplace_repeat */

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -209,9 +209,6 @@ class nd_grid(object):
             else:
                 return _nx.arange(start, stop, step)
 
-    def __getslice__(self, i, j):
-        return _nx.arange(i, j)
-
     def __len__(self):
         return 0
 
@@ -336,10 +333,6 @@ class AxisConcatenator(object):
                 objs[k] = objs[k].astype(final_dtype)
 
         res = _nx.concatenate(tuple(objs), axis=self.axis)
-        return self._retval(res)
-
-    def __getslice__(self, i, j):
-        res = _nx.arange(i, j)
         return self._retval(res)
 
     def __len__(self):

--- a/numpy/lib/user_array.py
+++ b/numpy/lib/user_array.py
@@ -51,14 +51,8 @@ class container(object):
     def __getitem__(self, index):
         return self._rc(self.array[index])
 
-    def __getslice__(self, i, j):
-        return self._rc(self.array[i:j])
-
     def __setitem__(self, index, value):
         self.array[index] = asarray(value, self.dtype)
-
-    def __setslice__(self, i, j, value):
-        self.array[i:j] = asarray(value, self.dtype)
 
     def __abs__(self):
         return self._rc(absolute(self.array))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3331,26 +3331,6 @@ class MaskedArray(ndarray):
             except (AttributeError, TypeError):
                 pass
 
-    def __getslice__(self, i, j):
-        """
-        x.__getslice__(i, j) <==> x[i:j]
-
-        Return the slice described by (i, j).  The use of negative indices
-        is not supported.
-
-        """
-        return self.__getitem__(slice(i, j))
-
-    def __setslice__(self, i, j, value):
-        """
-        x.__setslice__(i, j, value) <==> x[i:j]=value
-
-        Set the slice (i,j) of a to value. If value is masked, mask those
-        locations.
-
-        """
-        self.__setitem__(slice(i, j), value)
-
     def __setmask__(self, mask, copy=False):
         """
         Set the mask.

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -873,7 +873,6 @@ class TestMedian(TestCase):
     def test_nan(self):
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
-            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             for mask in (False, np.zeros(6, dtype=np.bool)):
                 dm = np.ma.array([[1, np.nan, 3], [1, 2, 3]])
                 dm.mask = mask
@@ -923,7 +922,6 @@ class TestMedian(TestCase):
         a[2] = np.nan
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
-            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             assert_array_equal(np.ma.median(a), np.nan)
             assert_array_equal(np.ma.median(a, axis=0), np.nan)
             assert_(w.log[0].category is RuntimeWarning)
@@ -938,7 +936,6 @@ class TestMedian(TestCase):
         # no axis
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
-            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_array_equal(np.ma.median(a), np.nan)
             assert_(np.isscalar(np.ma.median(a)))
@@ -1028,7 +1025,6 @@ class TestMedian(TestCase):
         a = np.ma.masked_array(np.array([], dtype=float))
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
-            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             assert_array_equal(np.ma.median(a), np.nan)
             assert_(w.log[0].category is RuntimeWarning)
 
@@ -1037,7 +1033,6 @@ class TestMedian(TestCase):
         # no axis
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
-            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_array_equal(np.ma.median(a), np.nan)
             assert_(w.log[0].category is RuntimeWarning)

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -420,8 +420,6 @@ class NoseTester(object):
                 sup.filter(DeprecationWarning,
                            r"sys\.exc_clear\(\) not supported in 3\.x",
                            module=threading)
-                sup.filter(DeprecationWarning, message=r"in 3\.x, __setslice__")
-                sup.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
                 sup.filter(DeprecationWarning, message=r"buffer\(\) not supported in 3\.x")
                 sup.filter(DeprecationWarning, message=r"CObject type is not supported in 3\.x")
                 sup.filter(DeprecationWarning, message=r"comparing unequal types not supported in 3\.x")


### PR DESCRIPTION
This code was only here for Python 2.5 compatibility, but numpy requires 2.7 at minimum.

This involves:

* Removing all the `__[gs]etslice__` method from python files
* Removing the `sq_slice` and `sq_slice_ass` slots from C files, so that the python files do not have to override the base implementations