### PR TITLE
BUG: Fix `MaskedArray.__setitem__`

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3264,7 +3264,7 @@ class MaskedArray(ndarray):
             return
 
         # Get the _data part of the new value
-        dval = value
+        dval = getattr(value, '_data', value)
         # Get the _mask part of the new value
         mval = getattr(value, '_mask', nomask)
         if nbfields and mval is nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4256,6 +4256,13 @@ class TestMaskedFields(TestCase):
         a[0]['a'] = 2
         assert_equal(a.mask, control)
 
+    def test_setitem_scalar(self):
+        # 8510
+        mask_0d = np.ma.masked_array(1, mask=True)
+        arr = np.ma.arange(3)
+        arr[0] = mask_0d
+        assert_array_equal(arr.mask, [True, False, False])
+
     def test_element_len(self):
         # check that len() works for mvoid (Github issue #576)
         for rec in self.data['base']:


### PR DESCRIPTION
Fixes #8510.

The root cause here is that `np.ma.getdata` does a conversion to np.ndarray that we don't want to happen.

This conversion in general is a bad idea, because when delegating to base numpy functions, it doesn't allow that function to do the correct conversion with extra information.