### PR TITLE
BUG: Make iscomplexobj compatible with custom dtypes again

### DIFF
--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -183,6 +183,15 @@ class TestIscomplexobj(TestCase):
         dummy = DummyPd()
         assert_(iscomplexobj(dummy))
 
+    def test_custom_dtype_duck(self):
+        class MyArray(list):
+            @property
+            def dtype(self):
+                return complex
+
+        a = MyArray([1+0j, 2+0j, 3+0j])
+        assert_(iscomplexobj(a))
+
 
 class TestIsrealobj(TestCase):
     def test_basic(self):

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -268,12 +268,10 @@ def iscomplexobj(x):
     """
     try:
         dtype = x.dtype
+        type_ = dtype.type
     except AttributeError:
-        dtype = asarray(x).dtype
-    try:
-        return issubclass(dtype.type, _nx.complexfloating)
-    except AttributeError:
-        return False
+        type_ = asarray(x).dtype.type
+    return issubclass(type_, _nx.complexfloating)
 
 
 def isrealobj(x):


### PR DESCRIPTION
Backport #8602.

This change makes iscomplexobj compatible with custom array types
using custom dtypes, that are not fully compatible to Numpys dtypes,
which can nevertheless be coerced to a numpy array with asarray
again, as has been the behaviour before PR #7936.