### PR TITLE
MAINT: Decrease merge conflicts in release notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
+# Line endings for Windows scripts
 * text=auto
 tools/win32build/nsis_scripts/*.nsi.in eol=crlf
 
 # Numerical data files
 numpy/lib/tests/data/*.npy binary
+
+# Release notes, reduce number of conflicts.
+doc/release/*.rst merge=union


### PR DESCRIPTION
Merge conflicts due to the release notes has been an annoying
problem requiring a rebase of otherwise good PRs. The solution
here is to use the --union option when merging to those files.

Closes #8603.