### PR TITLE
BUG: Don't leak internal exceptions when given an empty array

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -109,7 +109,10 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     inds = ndindex(inarr_view.shape[:-1])
 
     # invoke the function on the first item
-    ind0 = next(inds)
+    try:
+        ind0 = next(inds)
+    except StopIteration:
+        raise ValueError('Cannot apply_along_axis when any iteration dimensions are 0')
     res = asanyarray(func1d(inarr_view[ind0], *args, **kwargs))
 
     # build a buffer for storing evaluations of func1d.

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -140,6 +140,25 @@ class TestApplyAlongAxis(TestCase):
         res = np.apply_along_axis(sample_1d, 1, np.array([[1, 2], [3, 4]]))
         assert_array_equal(res, np.array([[2, 1], [4, 3]]))
 
+    def test_empty(self):
+        # can't apply_along_axis when there's no chance to call the function
+        def never_call(x):
+            assert_(False) # should never be reached
+
+        a = np.empty((0, 0))
+        assert_raises(ValueError, np.apply_along_axis, never_call, 0, a)
+        assert_raises(ValueError, np.apply_along_axis, never_call, 1, a)
+
+        # but it's sometimes ok with some non-zero dimensions
+        def empty_to_1(x):
+            assert_(len(x) == 0)
+            return 1
+
+        a = np.empty((10, 0))
+        actual = np.apply_along_axis(empty_to_1, 1, a)
+        assert_equal(actual, np.ones(10))
+        assert_raises(ValueError, np.apply_along_axis, empty_to_1, 0, a)
+
 
 class TestApplyOverAxes(TestCase):
     def test_simple(self):


### PR DESCRIPTION
Fixes #6927 (and its dupe, #7454)

This was made worse in #8441, which changed the exception from `IndexError`, which is likely to not be swallowed by user code, to a `StopIteration`, which would cause silent failure if used inside a generator