### PR TITLE
ENH: Add support for coercing structured arrays into dicts

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -93,6 +93,7 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 #define PyUString_Size PyUnicode_Size
 #define PyUString_InternFromString PyUnicode_InternFromString
 #define PyUString_Format PyUnicode_Format
+#define PyUString_AsUTF8 PyUnicode_AsUTF8
 
 #else
 
@@ -122,6 +123,7 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 #define PyUString_Size PyString_Size
 #define PyUString_InternFromString PyString_InternFromString
 #define PyUString_Format PyString_Format
+#define PyUString_AsUTF8 PyString_AsString
 
 #endif /* NPY_PY3K */
 

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -184,7 +184,7 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
     if (ret == NULL) {
         return NULL;
     }
-    fd2 = PyNumber_AsSsize_t(ret, NULL);
+    fd2 = (int) PyNumber_AsSsize_t(ret, NULL);
     Py_DECREF(ret);
 
     /* Convert to FILE* handle */

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1786,8 +1786,8 @@ _attr_name_as_utf8(PyObject *attr_name)
         PyString_AsString uses the "Default encoding", which is probabably good
         enough
         */
-        attr_name_utf8 = PyString_AsString(attr_name);
-        if (attr_name_utf8 == NULL) {
+        c_attr_name = PyString_AsString(attr_name);
+        if (c_attr_name == NULL) {
             return NULL;
         }
     }

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -463,7 +463,8 @@ dump_data(char **string, Py_ssize_t *n, Py_ssize_t *max_n, char *data, int nd,
     PyArray_Descr *descr=PyArray_DESCR(self);
     PyObject *op = NULL, *sp = NULL;
     char *ostring;
-    npy_intp i, N, ret = 0;
+    npy_intp i, N;
+    int ret = 0;
 
 #define CHECK_MEMORY do {                           \
         if (extend(string, *n, max_n) == NULL) {    \
@@ -1201,7 +1202,7 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
         PyObject *key, *value, *temp2;
         PyObject *op;
         Py_ssize_t pos = 0;
-        npy_intp result_ndim = PyArray_NDIM(self) > PyArray_NDIM(other) ?
+        int result_ndim = PyArray_NDIM(self) > PyArray_NDIM(other) ?
                             PyArray_NDIM(self) : PyArray_NDIM(other);
 
         op = (cmp_op == Py_EQ ? n_ops.logical_and : n_ops.logical_or);
@@ -1534,7 +1535,7 @@ NPY_NO_EXPORT int
 PyArray_ElementStrides(PyObject *obj)
 {
     PyArrayObject *arr;
-    int itemsize;
+    npy_intp itemsize;
     int i, ndim;
     npy_intp *strides;
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1887,6 +1887,18 @@ static PyObject *
 }
 /**end repeat**/
 
+static PyObject *
+voidtype_keys(PyObject *self, PyObject *NPY_UNUSED(args))
+{
+    PyArrayObject *arr = PyArray_FROM_O(self);
+    PyArray_Descr *descr = PyArray_DESCR(arr);
+    if (!PyDataType_HASFIELDS(descr)) {
+        PyErr_SetString(PyExc_TypeError, "Only structured arrays can be used as mappings");
+        return NULL;
+    }
+    return PyObject_CallMethod(descr->fields, "keys", "");
+}
+
 /*
  * need to fill in doc-strings for these methods on import -- copy from
  * array docstrings
@@ -2122,6 +2134,11 @@ static PyMethodDef voidtype_methods[] = {
     {"setfield",
         (PyCFunction)voidtype_setfield,
         METH_VARARGS | METH_KEYWORDS, NULL},
+
+    {"keys",
+        (PyCFunction)voidtype_keys,
+        METH_NOARGS, NULL},
+
     {NULL, NULL, 0, NULL}
 };
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1026,6 +1026,48 @@ class TestStructured(TestCase):
         b = a[0]
         assert_(b.base is a)
 
+    def test_kwarg_splat(self):
+        a = np.zeros(3, dtype='i4,f4')
+        b = a[0]
+        def f(f0, f1):
+            return f0, f1
+
+        # test arrays
+        f0, f1 = f(**a)
+        assert_equal(f0, a['f0'])
+        assert_equal(f1, a['f1'])
+
+        # test scalars
+        f0, f1 = f(**b)
+        assert_equal(f0, b['f0'])
+        assert_equal(f1, b['f1'])
+
+        c = np.zeros((3,2))
+        assert_raises(TypeError, lambda: f(**c))
+
+    def test_keys_only_on_void(self):
+        a = np.zeros(3, dtype='i4,f4')
+        assert_equal(sorted(a.keys()), ['f0', 'f1'])
+        assert_('keys' in dir(a))
+        assert_equal(sorted(a[0].keys()), ['f0', 'f1'])
+        assert_('keys' in dir(a[0]))
+
+        b = np.zeros(3)
+        assert_('keys' not in dir(b))
+        assert_raises(AttributeError, getattr, b, 'keys')
+        assert_('keys' not in dir(b[0]))
+        assert_raises(AttributeError, getattr, b[0], 'keys')
+
+
+    def test_dict_conversion(self):
+        a = np.zeros(3, dtype='i4,f4')
+        b = a[0]
+        assert_equal(dict(a), dict(f0=a['f0'], f1=a['f1']))
+        assert_equal(dict(b), dict(f0=b['f0'], f1=b['f1']))
+
+        c = np.zeros(3)
+        assert_raises(TypeError, dict, c)
+
 
 class TestBool(TestCase):
     def test_test_interning(self):

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -290,7 +290,7 @@ class TestMatrixReturn(TestCase):
             'partition', 'argpartition',
             'take', 'tofile', 'tolist', 'tostring', 'tobytes', 'all', 'any',
             'sum', 'argmax', 'argmin', 'min', 'max', 'mean', 'var', 'ptp',
-            'prod', 'std', 'ctypes', 'itemset',
+            'prod', 'std', 'ctypes', 'itemset', 'keys'
             ]
         for attrib in dir(a):
             if attrib.startswith('_') or attrib in excluded_methods:


### PR DESCRIPTION
Fixes #7552


This enables code like the following, by exposing a `keys` method:

```python
def foo(a, b):
    print(a, b)

data = np.empty(20, dtype=[('a', np.float32), ('b', np.float32)])
foo(**data)

data_as_dict = dict(data)  # this would previous treat the data as {a: b}, but now does the same as above
foo(**data_as_dict)
```

As a side effect, this changes the error message of code like this:

```python
x = np.zeros((4, 2), np.void)
x_as_dict = dict(x)  # TypeError: void not hashable
                     # now TypeError: Only structured arrays can be used as mappings
x_as_dict = dict(list(x)) # TypeError: void not hashable, before and after
```