### PR TITLE
BUG: Fix undefined behaviour induced by bad `__array_wrap__`

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4395,6 +4395,7 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
                 continue;
             }
             res = PyObject_CallFunction(wrap, "O(OOi)", mps[j], ufunc, args, i);
+            /* Handle __array_wrap__ that does not accept a context argument */
             if (res == NULL && PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_Clear();
                 res = PyObject_CallFunctionObjArgs(wrap, mps[j], NULL);
@@ -4402,9 +4403,6 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
             Py_DECREF(wrap);
             if (res == NULL) {
                 goto fail;
-            }
-            else if (res == Py_None) {
-                Py_DECREF(res);
             }
             else {
                 Py_DECREF(mps[j]);

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1422,6 +1422,19 @@ class TestSpecialMethods(TestCase):
         a = A()
         self.assertRaises(RuntimeError, ncu.maximum, a, a)
 
+    def test_none_wrap(self):
+        # Tests that issue #8507 is resolved. Previously, this would segfault
+
+        class A(object):
+            def __array__(self):
+                return np.zeros(1)
+
+            def __array_wrap__(self, arr, context=None):
+                return None
+
+        a = A()
+        assert_equal(ncu.maximum(a, a), None)
+
     def test_default_prepare(self):
 
         class with_wrap(object):


### PR DESCRIPTION
This fixes #8507.

The semantics of `__array_wrap__` are now that if the return value is None, the argument passed in is assumed as the return value.

The previous semantics were to segfault.