### PR TITLE
ENH: Improve the efficiency of indices

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -162,3 +162,8 @@ class UnpackBits(Benchmark):
 
     def time_unpackbits_axis1(self):
         np.unpackbits(self.d2, axis=1)
+
+
+class Indices(Benchmark):
+    def time_indices(self):
+        np.indices((1000, 500))

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2089,15 +2089,12 @@ def indices(dimensions, dtype=int):
     """
     dimensions = tuple(dimensions)
     N = len(dimensions)
-    if N == 0:
-        return array([], dtype=dtype)
+    shape = (1,)*N
     res = empty((N,)+dimensions, dtype=dtype)
     for i, dim in enumerate(dimensions):
-        tmp = arange(dim, dtype=dtype)
-        tmp.shape = (1,)*i + (dim,)+(1,)*(N-i-1)
-        newdim = dimensions[:i] + (1,) + dimensions[i+1:]
-        val = zeros(newdim, dtype)
-        add(tmp, val, res[i])
+        res[i] = arange(dim, dtype=dtype).reshape(
+            shape[:i] + (dim,) + shape[i+1:]
+        )
     return res
 
 


### PR DESCRIPTION
Previously, this special cased something that needed no special case (`len(dims) == 0`), and did
addition with zero for no reason at all.

[The profiling that raised this](http://stackoverflow.com/a/42302983/102441)