### PR TITLE
MAINT: ensure benchmark suite is importable on old numpy versions

### DIFF
--- a/benchmarks/benchmarks/bench_random.py
+++ b/benchmarks/benchmarks/bench_random.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from .common import Benchmark
 
 import numpy as np
-from numpy.lib import NumpyVersion
 
 
 class Random(Benchmark):
@@ -54,6 +53,7 @@ class Randint_dtype(Benchmark):
     params = ['bool', 'uint8', 'uint16', 'uint32', 'uint64']
 
     def setup(self, name):
+        from numpy.lib import NumpyVersion
         if NumpyVersion(np.__version__) < '1.11.0.dev0':
             raise NotImplementedError
 


### PR DESCRIPTION
The benchmark suite would best be importable also for old 
numpy versions. Move the import preventing that downwards 
(it's OK for it to fail inside benchmark setup).