### PR TITLE
BUG: fix wrong odd determination in packbits

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1509,7 +1509,7 @@ pack_inner(const char *inptr,
         __m128i zero = _mm_setzero_si128();
         /* don't handle non-full 8-byte remainder */
         npy_intp vn_out = n_out - (remain ? 1 : 0);
-        vn_out -= (vn_out & 2);
+        vn_out -= (vn_out & 1);
         for (index = 0; index < vn_out; index += 2) {
             unsigned int r;
             /* swap as packbits is "big endian", note x86 can load unaligned */

--- a/numpy/lib/tests/test_packbits.py
+++ b/numpy/lib/tests/test_packbits.py
@@ -213,6 +213,15 @@ def test_packbits_large():
     assert_raises(TypeError, np.packbits, np.array(a, dtype=float))
 
 
+def test_packbits_very_large():
+    # test some with a larger arrays gh-8637
+    # code is covered earlier but larger array makes crash on bug more likely
+    for s in range(950, 1050):
+        for dt in '?bBhHiIlLqQ':
+            x = np.ones((200, s), dtype=bool)
+            np.packbits(x, axis=1)
+
+
 def test_unpackbits():
     # Copied from the docstring.
     a = np.array([[2], [7], [23]], dtype=np.uint8)


### PR DESCRIPTION
closes gh-8637

dumb mistake added when replacing a unsigned cast + modulo with the and to make it more readable ...
current testsuite does throw valgrind errors but does not crash