### PR TITLE
TST: Improve testing of read-only mmaps

### DIFF
--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -41,6 +41,7 @@ class TestMemmap(TestCase):
                        shape=self.shape)
         assert_(allclose(self.data, newfp))
         assert_array_equal(self.data, newfp)
+        self.assertEqual(newfp.flags.writeable, False)
 
     def test_open_with_filename(self):
         tmpname = mktemp('', 'mmap', dir=self.tempdir)


### PR DESCRIPTION
I haven't seen any test that `mmap(..., mode='r')` actually works as advertised. Such a test would have saved me some time tracking down a pypy3 bug, so here's a simple one.