### PR TITLE
BUG: fix denormal linspace test for longdouble

### DIFF
--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy import (logspace, linspace, geomspace, dtype, array, finfo,
-                   typecodes, arange, isnan, ndarray, sqrt)
+from numpy import (logspace, linspace, geomspace, dtype, array, sctypes,
+                   arange, isnan, ndarray, sqrt, nextafter)
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_array_equal, assert_allclose, suppress_warnings
@@ -301,9 +301,9 @@ class TestLinspace(TestCase):
     def test_denormal_numbers(self):
         # Regression test for gh-5437. Will probably fail when compiled
         # with ICC, which flushes denormals to zero
-        for dt in (dtype(f) for f in typecodes['Float']):
-            stop = finfo(dt).tiny * finfo(dt).resolution
-            assert_(any(linspace(0, stop, 10, endpoint=False, dtype=dt)))
+        for ftype in sctypes['float']:
+            stop = nextafter(ftype(0), ftype(1)) * 5  # A denormal number
+            assert_(any(linspace(0, stop, 10, endpoint=False, dtype=ftype)))
 
     def test_equivalent_to_arange(self):
         for j in range(1000):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2126,6 +2126,12 @@ def test_nextafterf():
 def test_nextafterl():
     return _test_nextafter(np.longdouble)
 
+def test_nextafter_0():
+    for t, direction in itertools.product(np.sctypes['float'], (1, -1)):
+        tiny = np.finfo(t).tiny
+        assert_(0. < direction * np.nextafter(t(0), t(direction)) < tiny)
+        assert_equal(np.nextafter(t(0), t(direction)) / t(2.1), direction * 0.0)
+
 def _test_spacing(t):
     one = t(1)
     eps = np.finfo(t).eps


### PR DESCRIPTION
Linspace test was testing for case where simply dividing the range by
the number of samples generates 0, as the case for very small denormals.
The implementation generating the denormal only worked to exercise that
code for float64.  Make a small denormal that does exercise that case,
as least for longdouble, as well as float64.

Closes gh-8565.