### PR TITLE
ENH: Fix alignment of repr for array subclasses

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -174,6 +174,11 @@ being iterated over.
 For consistency with ``ndarray`` and ``broadcast``, ``d.ndim`` is a shorthand
 for ``len(d.shape)``.
 
+Better default repr for ``ndarray`` subclasses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Subclasses of ndarray with no ``repr`` specialization now correctly indent
+their data and type lines.
+
 
 Changes
 =======

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1890,35 +1890,35 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     'array([ 0.000001,  0.      ,  2.      ,  3.      ])'
 
     """
+    if type(arr) is not ndarray:
+        class_name = type(arr).__name__
+    else:
+        class_name = "array"
+
     if arr.size > 0 or arr.shape == (0,):
         lst = array2string(arr, max_line_width, precision, suppress_small,
-                           ', ', "array(")
+                           ', ', class_name + "(")
     else:  # show zero-length shape unless it is (0,)
         lst = "[], shape=%s" % (repr(arr.shape),)
-
-    if arr.__class__ is not ndarray:
-        cName = arr.__class__.__name__
-    else:
-        cName = "array"
 
     skipdtype = (arr.dtype.type in _typelessdata) and arr.size > 0
 
     if skipdtype:
-        return "%s(%s)" % (cName, lst)
+        return "%s(%s)" % (class_name, lst)
     else:
         typename = arr.dtype.name
         # Quote typename in the output if it is "complex".
         if typename and not (typename[0].isalpha() and typename.isalnum()):
             typename = "'%s'" % typename
 
-        lf = ''
+        lf = ' '
         if issubclass(arr.dtype.type, flexible):
             if arr.dtype.names:
                 typename = "%s" % str(arr.dtype)
             else:
                 typename = "'%s'" % str(arr.dtype)
-            lf = '\n'+' '*len("array(")
-        return cName + "(%s, %sdtype=%s)" % (lst, lf, typename)
+            lf = '\n'+' '*len(class_name + "(")
+        return "%s(%s,%sdtype=%s)" % (class_name, lst, lf, typename)
 
 
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -14,6 +14,28 @@ class TestArrayRepr(object):
         x = np.array([np.nan, np.inf])
         assert_equal(repr(x), 'array([ nan,  inf])')
 
+    def test_subclass(self):
+        class sub(np.ndarray): pass
+
+        # one dimensional
+        x1d = np.array([1, 2]).view(sub)
+        assert_equal(repr(x1d), 'sub([1, 2])')
+
+        # two dimensional
+        x2d = np.array([[1, 2], [3, 4]]).view(sub)
+        assert_equal(repr(x2d),
+            'sub([[1, 2],\n'
+            '     [3, 4]])')
+
+        # two dimensional with flexible dtype
+        xstruct = np.ones((2,2), dtype=[('a', 'i4')]).view(sub)
+        assert_equal(repr(xstruct),
+            "sub([[(1,), (1,)],\n"
+            "     [(1,), (1,)]],\n"
+            "    dtype=[('a', '<i4')])"
+        )
+
+
 class TestComplexArray(TestCase):
     def test_str(self):
         rvals = [0, 1, -1, np.inf, -np.inf, np.nan]


### PR DESCRIPTION
Test case:

```python
>>> class foo(np.ndarray): pass
>>> np.eye(2).view(foo)  #before
foo([[ 1.,  0.],
       [ 0.,  1.]])
>>> np.eye(2).view(foo)  #after
foo([[ 1.,  0.],
     [ 0.,  1.]])
```

<s>Where should this test go?</s> Added to `test_arrayprint.py`