### PR TITLE
MAINT: Warn users when calling np.ma.MaskedArray.partition function.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5635,6 +5635,18 @@ class MaskedArray(ndarray):
         np.subtract(out, min_value, out=out, casting='unsafe')
         return out
 
+    def partition(self, *args, **kwargs):
+        warnings.warn("Warning: 'partition' will ignore the 'mask' "
+                      "of the {}.".format(self.__class__.__name__),
+                      stacklevel=2)
+        return super(MaskedArray, self).partition(*args, **kwargs)
+
+    def argpartition(self, *args, **kwargs):
+        warnings.warn("Warning: 'argpartition' will ignore the 'mask' "
+                      "of the {}.".format(self.__class__.__name__),
+                      stacklevel=2)
+        return super(MaskedArray, self).argpartition(*args, **kwargs)
+
     def take(self, indices, axis=None, out=None, mode='raise'):
         """
         """


### PR DESCRIPTION
Using the `np.median` function on `MaskedArray`s uses the not-overriden
`partition` method of a plain `np.ndarray` without error or warning. (#7330)
This PR overrides the `partition` method on `MaskedArray`s but simply to
throw a Warning. This will make users aware that something ignores the
mask without breaking backwards-compatibility.