### PR TITLE
BUG: Remove extra digit in binary_repr at limit

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2206,7 +2206,7 @@ def binary_repr(num, width=None):
         designated form.
 
         If the `width` value is insufficient, it will be ignored, and `num` will
-        be returned in binary(`num` > 0) or two's complement (`num` < 0) form
+        be returned in binary (`num` > 0) or two's complement (`num` < 0) form
         with its width equal to the minimum number of bits needed to represent
         the number in the designated form. This behavior is deprecated and will
         later raise an error.
@@ -2276,10 +2276,16 @@ def binary_repr(num, width=None):
 
         else:
             poswidth = len(bin(-num)[2:])
-            twocomp = 2**(poswidth + 1) + num
 
+            # See gh-8679: remove extra digit
+            # for numbers at boundaries.
+            if 2**(poswidth - 1) == -num:
+                poswidth -= 1
+
+            twocomp = 2**(poswidth + 1) + num
             binary = bin(twocomp)[2:]
             binwidth = len(binary)
+
             outwidth = max(binwidth, width)
             warn_if_insufficient(width, binwidth)
             return '1' * (outwidth - binwidth) + binary

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1149,6 +1149,18 @@ class TestBinaryRepr(TestCase):
         assert_equal(np.binary_repr(10, width=7), '0001010')
         assert_equal(np.binary_repr(-5, width=7), '1111011')
 
+    def test_neg_width_boundaries(self):
+        # see gh-8670
+
+        # Ensure that the example in the issue does not
+        # break before proceeding to a more thorough test.
+        assert_equal(np.binary_repr(-128, width=8), '10000000')
+
+        for width in range(1, 11):
+            num = -2**(width - 1)
+            exp = '1' + (width - 1) * '0'
+            assert_equal(np.binary_repr(num, width=width), exp)
+
 
 class TestBaseRepr(TestCase):
     def test_base3(self):


### PR DESCRIPTION
For negative numbers at the limit for a given number of digits, we were appending an extra digit.

Closes #8670.