### PR TITLE
BUG: Fix problems detecting runtime for MSYS2 compiler on Windows

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -348,15 +348,24 @@ def build_msvcr_library(debug=False):
     if os.name != 'nt':
         return False
 
-    msvcr_name = msvc_runtime_library()
+    # If the version number is None, then we couldn't find the MSVC runtime at
+    # all, because we are running on a Python distribution which is customed
+    # compiled; trust that the compiler is the same as the one available to us
+    # now, and that it is capable of linking with the correct runtime without
+    # any extra options.
+    msvcr_ver = msvc_runtime_major()
+    if msvcr_ver is None:
+        log.debug('Skip building import library: '
+                  'Runtime is not compiled with MSVC')
+        return False
 
     # Skip using a custom library for versions < MSVC 8.0
-    msvcr_ver = msvc_runtime_major()
-    if msvcr_ver and msvcr_ver < 80:
+    if msvcr_ver < 80:
         log.debug('Skip building msvcr library:'
                   ' custom functionality not present')
         return False
 
+    msvcr_name = msvc_runtime_library()
     if debug:
         msvcr_name += 'd'
 

--- a/numpy/distutils/msvccompiler.py
+++ b/numpy/distutils/msvccompiler.py
@@ -42,12 +42,12 @@ class MSVCCompiler(_MSVCCompiler):
     def __init__(self, verbose=0, dry_run=0, force=0):
         _MSVCCompiler.__init__(self, verbose, dry_run, force)
 
-    def initialize(self, plat_name=None):
+    def initialize(self):
         # The 'lib' and 'include' variables may be overwritten
         # by MSVCCompiler.initialize, so save them for later merge.
         environ_lib = os.getenv('lib', '')
         environ_include = os.getenv('include', '')
-        _MSVCCompiler.initialize(self, plat_name)
+        _MSVCCompiler.initialize(self)
 
         # Merge current and previous values of 'lib' and 'include'
         os.environ['lib'] = _merge(environ_lib, os.environ['lib'])


### PR DESCRIPTION
This set of patches fixes problems in the compiler setup code when attempting to compile Numpy on Windows with a Python distribution which is not compiled with MSVC (but with for instance the GNU compiler in MSYS2). The old code contained some tests which assumed that a version string from the MSVC compiler was present in the system information string.