### PR TITLE
BUG: Fix argsort vs sort in Masked arrays

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -200,6 +200,14 @@ All of the following functions in ``np.linalg`` now work when given input
 arrays with a 0 in the last two dimensions: `det``, ``slogdet``, ``pinv``,
 ``eigvals``, ``eigvalsh``, ``eig``, ``eigh``.
 
+``argsort`` on masked arrays takes the same default arguments as ``sort``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, ``argsort`` now places the masked values at the end of the sorted
+array, in the same way that ``sort`` already did. Additionally, the
+``end_with`` argument is added to ``argsort``, for consistency with ``sort``.
+Note that this argument is not added at the end, so breaks any code that
+passed ``fill_value`` as a positional argument.
+
 Changes
 =======
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -352,6 +352,18 @@ class TestUnique(TestCase):
         result = np.array([[-0.0, 0.0]])
         assert_array_equal(unique(data, axis=0), result, msg)
 
+    def test_unique_masked(self):
+        # issue 8664
+        x = np.array([64, 0, 1, 2, 3, 63, 63, 0, 0, 0, 1, 2, 0, 63, 0], dtype='uint8')
+        y = np.ma.masked_equal(x, 0)
+
+        v = np.unique(y)
+        v2, i, c = np.unique(y, return_index=True, return_counts=True)
+
+        msg = 'Unique returned different results when asked for index'
+        assert_array_equal(v.data, v2.data, msg)
+        assert_array_equal(v.mask, v2.mask, msg)
+
     def _run_axis_tests(self, dtype):
         data = np.array([[0, 1, 0, 0],
                          [1, 0, 0, 0],

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6500,20 +6500,19 @@ def power(a, b, third=None):
         result._data[invalid] = result.fill_value
     return result
 
-
-def argsort(a, axis=None, kind='quicksort', order=None, fill_value=None):
-    "Function version of the eponymous method."
-    if fill_value is None:
-        fill_value = default_fill_value(a)
-    d = filled(a, fill_value)
-    if axis is None:
-        return d.argsort(kind=kind, order=order)
-    return d.argsort(axis, kind=kind, order=order)
-argsort.__doc__ = MaskedArray.argsort.__doc__
-
 argmin = _frommethod('argmin')
 argmax = _frommethod('argmax')
 
+def argsort(a, axis=None, kind='quicksort', order=None, fill_value=None):
+    "Function version of the eponymous method."
+    a = np.asanyarray(a)
+
+    if isinstance(a, MaskedArray):
+        return a.argsort(axis=axis, kind=kind, order=order,
+                         fill_value=fill_value)
+    else:
+        return a.argsort(axis=axis, kind=kind, order=order)
+argsort.__doc__ = MaskedArray.argsort.__doc__
 
 def sort(a, axis=-1, kind='quicksort', order=None, endwith=True, fill_value=None):
     "Function version of the eponymous method."

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5449,20 +5449,9 @@ class MaskedArray(ndarray):
         if self is masked:
             return
 
-        if fill_value is None:
-            if endwith:
-                # nan > inf
-                if np.issubdtype(self.dtype, np.floating):
-                    filler = np.nan
-                else:
-                    filler = minimum_fill_value(self)
-            else:
-                filler = maximum_fill_value(self)
-        else:
-            filler = fill_value
+        sidx = self.argsort(axis=axis, kind=kind, order=order,
+                            fill_value=fill_value, endwith=endwith)
 
-        sidx = self.filled(filler).argsort(axis=axis, kind=kind,
-                                           order=order)
         # save meshgrid memory for 1d arrays
         if self.ndim == 1:
             idx = sidx

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5444,35 +5444,36 @@ class MaskedArray(ndarray):
         """
         if self._mask is nomask:
             ndarray.sort(self, axis=axis, kind=kind, order=order)
-        else:
-            if self is masked:
-                return self
-            if fill_value is None:
-                if endwith:
-                    # nan > inf
-                    if np.issubdtype(self.dtype, np.floating):
-                        filler = np.nan
-                    else:
-                        filler = minimum_fill_value(self)
-                else:
-                    filler = maximum_fill_value(self)
-            else:
-                filler = fill_value
+            return
 
-            sidx = self.filled(filler).argsort(axis=axis, kind=kind,
-                                               order=order)
-            # save meshgrid memory for 1d arrays
-            if self.ndim == 1:
-                idx = sidx
+        if self is masked:
+            return
+
+        if fill_value is None:
+            if endwith:
+                # nan > inf
+                if np.issubdtype(self.dtype, np.floating):
+                    filler = np.nan
+                else:
+                    filler = minimum_fill_value(self)
             else:
-                idx = np.meshgrid(*[np.arange(x) for x in self.shape], sparse=True,
-                                  indexing='ij')
-                idx[axis] = sidx
-            tmp_mask = self._mask[idx].flat
-            tmp_data = self._data[idx].flat
-            self._data.flat = tmp_data
-            self._mask.flat = tmp_mask
-        return
+                filler = maximum_fill_value(self)
+        else:
+            filler = fill_value
+
+        sidx = self.filled(filler).argsort(axis=axis, kind=kind,
+                                           order=order)
+        # save meshgrid memory for 1d arrays
+        if self.ndim == 1:
+            idx = sidx
+        else:
+            idx = np.meshgrid(*[np.arange(x) for x in self.shape], sparse=True,
+                              indexing='ij')
+            idx[axis] = sidx
+        tmp_mask = self._mask[idx].flat
+        tmp_data = self._data[idx].flat
+        self._data.flat = tmp_data
+        self._mask.flat = tmp_mask
 
     def min(self, axis=None, out=None, fill_value=None, keepdims=np._NoValue):
         """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6517,32 +6517,17 @@ argmax = _frommethod('argmax')
 
 def sort(a, axis=-1, kind='quicksort', order=None, endwith=True, fill_value=None):
     "Function version of the eponymous method."
-    a = narray(a, copy=True, subok=True)
+    a = np.array(a, copy=True, subok=True)
     if axis is None:
         a = a.flatten()
         axis = 0
-    if fill_value is None:
-        if endwith:
-            # nan > inf
-            if np.issubdtype(a.dtype, np.floating):
-                filler = np.nan
-            else:
-                filler = minimum_fill_value(a)
-        else:
-            filler = maximum_fill_value(a)
-    else:
-        filler = fill_value
 
-    sindx = filled(a, filler).argsort(axis=axis, kind=kind, order=order)
-
-    # save meshgrid memory for 1d arrays
-    if a.ndim == 1:
-        indx = sindx
+    if isinstance(a, MaskedArray):
+        a.sort(axis=axis, kind=kind, order=order,
+               endwith=endwith, fill_value=fill_value)
     else:
-        indx = np.meshgrid(*[np.arange(x) for x in a.shape], sparse=True,
-                           indexing='ij')
-        indx[axis] = sindx
-    return a[indx]
+        a.sort(axis=axis, kind=kind, order=order)
+    return a
 sort.__doc__ = MaskedArray.sort.__doc__
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5452,17 +5452,14 @@ class MaskedArray(ndarray):
         sidx = self.argsort(axis=axis, kind=kind, order=order,
                             fill_value=fill_value, endwith=endwith)
 
-        # save meshgrid memory for 1d arrays
+        # save memory for 1d arrays
         if self.ndim == 1:
             idx = sidx
         else:
-            idx = np.meshgrid(*[np.arange(x) for x in self.shape], sparse=True,
-                              indexing='ij')
+            idx = list(np.ix_(*[np.arange(x) for x in self.shape]))
             idx[axis] = sidx
-        tmp_mask = self._mask[idx].flat
-        tmp_data = self._data[idx].flat
-        self._data.flat = tmp_data
-        self._mask.flat = tmp_mask
+
+        self[...] = self[idx]
 
     def min(self, axis=None, out=None, fill_value=None, keepdims=np._NoValue):
         """

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3031,6 +3031,20 @@ class TestMaskedArrayMethods(TestCase):
         assert_equal(sortedx._data, [1, 2, -2, -1, 0])
         assert_equal(sortedx._mask, [1, 1, 0, 0, 0])
 
+    def test_argsort_matches_sort(self):
+        x = array([1, 4, 2, 3], mask=[0, 1, 0, 0], dtype=np.uint8)
+
+        for kwargs in [dict(),
+                       dict(endwith=True),
+                       dict(endwith=False),
+                       dict(fill_value=2),
+                       dict(fill_value=2, endwith=True),
+                       dict(fill_value=2, endwith=False)]:
+            sortedx = sort(x, **kwargs)
+            argsortedx = x[argsort(x, **kwargs)]
+            assert_equal(sortedx._data, argsortedx._data)
+            assert_equal(sortedx._mask, argsortedx._mask)
+
     def test_sort_2d(self):
         # Check sort of 2D array.
         # 2D array w/o mask


### PR DESCRIPTION
This fixes #8664, at the cost of a behavioural change in `argsort` -- masked values are now sorted to the end by default, whereas before they could end up being placed somewhere arbitrary in the middle. This brings the behaviour of `argsort` inline with `sort`.

In particular, `argsort` would use the default fill value, which for `int8` types would be `999999 % 256 = 63`. This sorted very misleadingly.

`sort` made the more sensible choice of using the maximum/minimum possible value.

This also fixes code duplication between the method and function forms of these operations