### PR TITLE
DOC: Removed broken link

### DIFF
--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -3,12 +3,6 @@
 Subclassing ndarray in python
 =============================
 
-Credits
--------
-
-This page is based with thanks on the wiki page on subclassing by Pierre
-Gerard-Marchant - http://www.scipy.org/Subclasses.
-
 Introduction
 ------------
 


### PR DESCRIPTION
Removed a broken link from the subclassing ndarray page in the user guide.
Removed credit to Pierre Gerard-Marchant, as this is out of place in the user guide. 
Closes #8673