### PR TITLE
MAINT: Fix deprecated escape sequences

### DIFF
--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -94,7 +94,7 @@ class SourceFiles:
 
     def clean_path(self, path):
         path = path[len(self.prefix):]
-        return re.sub("[^A-Za-z0-9\.]", '_', path)
+        return re.sub(r"[^A-Za-z0-9\.]", '_', path)
 
     def write_text(self, root):
         for path, source in self.files.items():
@@ -121,8 +121,8 @@ class SourceFiles:
 def collect_stats(files, fd, pattern):
     # TODO: Handle compressed callgrind files
     line_regexs = [
-        re.compile("(?P<lineno>[0-9]+)(\s[0-9]+)+"),
-        re.compile("((jump)|(jcnd))=([0-9]+)\s(?P<lineno>[0-9]+)")
+        re.compile(r"(?P<lineno>[0-9]+)(\s[0-9]+)+"),
+        re.compile(r"((jump)|(jcnd))=([0-9]+)\s(?P<lineno>[0-9]+)")
         ]
 
     current_file = None

--- a/tools/find_deprecated_escaped_characters.py
+++ b/tools/find_deprecated_escaped_characters.py
@@ -31,37 +31,35 @@ def main(root):
     None
 
     """
+    import ast
+    import tokenize
+    import warnings
+    from pathlib import Path
+
     count = 0
-
-    if sys.version_info[:2] >= (3, 6):
-        import ast
-        import tokenize
-        import warnings
-        from pathlib import Path
-
-        base = Path(root)
-        paths = base.rglob("*.py") if base.is_dir() else [base]
-        for path in paths:
-            # use tokenize to auto-detect encoding on systems where no
-            # default encoding is defined (e.g. LANG='C')
-            with tokenize.open(str(path)) as f:
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter('always')
-                    tree = ast.parse(f.read())
-                if w:
-                    print("file: ", str(path))
-                    for e in w:
-                        print('line: ', e.lineno, ': ', e.message)
-                    print()
-                    count += len(w)
-    else:
-        raise RuntimeError("Python version must be >= 3.6")
-
+    base = Path(root)
+    paths = base.rglob("*.py") if base.is_dir() else [base]
+    for path in paths:
+        # use tokenize to auto-detect encoding on systems where no
+        # default encoding is defined (e.g. LANG='C')
+        with tokenize.open(str(path)) as f:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                tree = ast.parse(f.read())
+            if w:
+                print("file: ", str(path))
+                for e in w:
+                    print('line: ', e.lineno, ': ', e.message)
+                print()
+                count += len(w)
     print("Errors Found", count)
 
 
 if __name__ == "__main__":
     from argparse import ArgumentParser
+
+    if sys.version_info[:2] < (3, 6):
+        raise RuntimeError("Python version must be >= 3.6")
 
     parser = ArgumentParser(description="Find deprecated escaped characters")
     parser.add_argument('root', help='directory or file to be checked')

--- a/tools/find_deprecated_escaped_characters.py
+++ b/tools/find_deprecated_escaped_characters.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
-"""
+r"""
 Look for escape sequences deprecated in Python 3.6.
 
-Python 3.6 deprecates a number of non-escape sequences starting with `\` that
+Python 3.6 deprecates a number of non-escape sequences starting with '\' that
 were accepted before. For instance, '\(' was previously accepted but must now
 be written as '\\(' or r'\('.
 

--- a/tools/win32build/build.py
+++ b/tools/win32build/build.py
@@ -16,9 +16,9 @@ import os
 import shutil
 from os.path import join as pjoin, split as psplit, dirname
 
-PYEXECS = {"2.5" : "C:\python25\python.exe",
-        "2.4" : "C:\python24\python24.exe",
-        "2.6" : "C:\python26\python26.exe"}
+PYEXECS = {"2.5" : r"C:\python25\python.exe",
+        "2.4" : r"C:\python24\python24.exe",
+        "2.6" : r"C:\python26\python26.exe"}
 
 _SSE3_CFG = r"""[atlas]
 library_dirs = C:\local\lib\yop\sse3"""


### PR DESCRIPTION
- Fix the Python 3.6 deprecated escape sequences found in the `tools` directory.
- Refactor `tools/find_deprecated_escaped_characters.py`.

The files in `tools/swig/tests` are not fixed, they are not even Python3 compatible at this point.