### PR TITLE
BUG: fix ma.median for empty ndarrays

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -717,6 +717,13 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     else:
         axis = normalize_axis_index(axis, asorted.ndim)
 
+    if asorted.shape[axis] == 0:
+        # for empty axis integer indices fail so use slicing to get same result
+        # as median (which is mean of empty slice = nan)
+        indexer = [slice(None)] * asorted.ndim
+        indexer[axis] = slice(0, 0)
+        return np.ma.mean(asorted[indexer], axis=axis, out=out)
+
     if asorted.ndim == 1:
         counts = count(asorted)
         idx, odd = divmod(count(asorted), 2)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1039,14 +1039,14 @@ class TestMedian(TestCase):
 
         # axis 0 and 1
         b = np.ma.masked_array(np.array([], dtype=float, ndmin=2))
-        assert_equal(np.median(a, axis=0), b)
-        assert_equal(np.median(a, axis=1), b)
+        assert_equal(np.ma.median(a, axis=0), b)
+        assert_equal(np.ma.median(a, axis=1), b)
 
         # axis 2
         b = np.ma.masked_array(np.array(np.nan, dtype=float, ndmin=2))
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
-            assert_equal(np.median(a, axis=2), b)
+            assert_equal(np.ma.median(a, axis=2), b)
             assert_(w[0].category is RuntimeWarning)
 
     def test_object(self):


### PR DESCRIPTION
return nan as it did in 1.11 and same as normal median.
closes gh-8703