### PR TITLE
BUG: Don't signal FP exceptions in np.absolute

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1840,6 +1840,7 @@ NPY_NO_EXPORT void
             *((@type@ *)op1) = tmp + 0;
         }
     }
+    npy_clear_floatstatus();
 }
 
 NPY_NO_EXPORT void

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1269,22 +1269,20 @@ class TestAbsoluteNegative(TestCase):
                 np.negative(inp, out=out)
                 assert_equal(out, tgt, err_msg=msg)
 
-                # will throw invalid flag depending on compiler optimizations
-                with np.errstate(invalid='ignore'):
-                    for v in [np.nan, -np.inf, np.inf]:
-                        for i in range(inp.size):
-                            d = np.arange(inp.size, dtype=dt)
-                            inp[:] = -d
-                            inp[i] = v
-                            d[i] = -v if v == -np.inf else v
-                            assert_array_equal(np.abs(inp), d, err_msg=msg)
-                            np.abs(inp, out=out)
-                            assert_array_equal(out, d, err_msg=msg)
+                for v in [np.nan, -np.inf, np.inf]:
+                    for i in range(inp.size):
+                        d = np.arange(inp.size, dtype=dt)
+                        inp[:] = -d
+                        inp[i] = v
+                        d[i] = -v if v == -np.inf else v
+                        assert_array_equal(np.abs(inp), d, err_msg=msg)
+                        np.abs(inp, out=out)
+                        assert_array_equal(out, d, err_msg=msg)
 
-                            assert_array_equal(-inp, -1*inp, err_msg=msg)
-                            d = -1 * inp
-                            np.negative(inp, out=out)
-                            assert_array_equal(out, d, err_msg=msg)
+                        assert_array_equal(-inp, -1*inp, err_msg=msg)
+                        d = -1 * inp
+                        np.negative(inp, out=out)
+                        assert_array_equal(out, d, err_msg=msg)
 
     def test_lower_align(self):
         # check data that is not aligned to element size


### PR DESCRIPTION
Fixes #8686

This PR centers around this piece of code in `numpy/core/src/umath/loops.c.src`:
```c
UNARY_LOOP {
    const @type@ in1 = *(@type@ *)ip1;
    const @type@ tmp = in1 > 0 ? in1 : -in1;
    /* add 0 to clear -0.0 */
    *((@type@ *)op1) = tmp + 0;
}
```

If in1 is `NaN`, the C99 standard requires that the comparison `in1 > 0` signals `FE_INVALID`, but the usual semantics for the absolute function are that no FP exceptions should be generated (eg compare to C `fabs` and Python `abs`). This was probably never noticed due to a bug in GCC x86 where all floating point comparisons do not signal exceptions, however Clang on x86 and GCC on other architectures (including ARM and MIPS) do signal an FP exception here.

Fix by rewriting the loop to use `npy_fabs` instead. Also fix a similar occurrence in `simd.inc.src`. The `test_abs_neg_blocked` is adjusted not to ignore `FE_INVALID` errors because now both absolute and negate should never produce any FP exceptions.