### PR TITLE
BUG: needs_right_binop_forward() checks PyArray_CheckScalar() when bailing

### DIFF
--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -137,7 +137,7 @@ needs_right_binop_forward(PyObject *self, PyObject *other,
         return 0;
     }
     if ((!inplace_op && PyType_IsSubtype(Py_TYPE(other), Py_TYPE(self))) ||
-        !PyArray_Check(self)) {
+        (!PyArray_Check(self) && !PyArray_CheckScalar(self))) {
         /*
          * Bail out if Python would already have called the right-hand
          * operation.

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1294,5 +1294,29 @@ def test_clear_and_catch_warnings_inherit():
     assert_equal(my_mod.__warningregistry__, {})
 
 
+class CustomArray(np.ndarray):
+    __numpy_ufunc__ = ""
+    def __radd__(self, a):
+        return a + 42
+    def __rmul__(self, a):
+        return a + 42
+
+
+class TestCustomArray(unittest.TestCase):
+    """Test of user arrays that inherent from ndarray"""
+
+    def test_radd(self):
+        res = np.int32(0) + CustomArray((1,))
+        self.assertEqual(res, 42)
+        res = np.array([0]) + CustomArray((1,))
+        self.assertEqual(res, 42)
+
+    def test_rmul(self):
+        res = np.int32(0) * CustomArray((1,))
+        self.assertEqual(res, 42)
+        res = np.array([0]) * CustomArray((1,))
+        self.assertEqual(res, 42)
+
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
Consider a custom class that inherent from ` ndarray` and defines `__numpy_ufunc__` and `__radd__()`. When adding a `ndarray` with the custom class, `__radd__()` is called as expected. However, when adding a scalar type such as `int32`, `__radd__()` is not called.

The following code illustrate the problem:
```python
import numpy as np
class MyArray(np.ndarray):
    def __init__(self, shape):
        super(MyArray, self).__init__(shape)
        self.__numpy_ufunc__ = ""
    def __radd__(self, a):
        print ("radd")

b = MyArray((2,2))
print ("ndarray + MyArray: ")
np.array([2]) + b

print ("Scalar + MyArray: ")
np.int32(2) + b
```
The result now is:
```
ndarray + MyArray: 
radd
Scalar + MyArray: 
```
With this PR, the result is: 
```
ndarray + MyArray: 
radd
Scalar + MyArray: 
radd
```
