### PR TITLE
 MAINT: Mark some tests with slow decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,6 @@ matrix:
             - python3-dev
             - python3-nose
             - python3-setuptools
-    - python: 2.7
-      env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
-    - python: 2.7
-      env: USE_WHEEL=1
     - python: 3.5
       env: USE_WHEEL=1 RUN_FULL_TESTS=1
     - python: 3.5
@@ -72,6 +68,10 @@ matrix:
       env:
        - PYTHONOPTIMIZE=2
        - USE_ASV=1
+    - python: 2.7
+      env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
+    - python: 2.7
+      env: USE_WHEEL=1
     - python: 2.7
       env:
        - BLAS=None

--- a/numpy/core/tests/test_extint128.py
+++ b/numpy/core/tests/test_extint128.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.core.multiarray_tests as mt
 from numpy.compat import long
 
-from numpy.testing import assert_raises, assert_equal
+from numpy.testing import assert_raises, assert_equal, dec
 
 
 INT64_MAX = np.iinfo(np.int64).max
@@ -183,6 +183,7 @@ def test_gt_128():
                 assert_equal(d, c)
 
 
+@dec.slow
 def test_divmod_128_64():
     with exc_iter(INT128_VALUES, INT64_POS_VALUES) as it:
         for a, b in it:

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -5,7 +5,7 @@ import itertools
 
 import numpy as np
 from numpy.testing import (run_module_suite, assert_, assert_raises, assert_equal,
-                           assert_array_equal, assert_allclose)
+                           assert_array_equal, assert_allclose, dec)
 
 from numpy.core.multiarray_tests import solve_diophantine, internal_overlap
 from numpy.core import umath_tests
@@ -97,6 +97,7 @@ def test_overlapping_assignments():
         yield _check_assignment, srcidx, dstidx
 
 
+@dec.slow
 def test_diophantine_fuzz():
     # Fuzz test the diophantine solver
     rng = np.random.RandomState(1234)
@@ -373,6 +374,7 @@ def check_may_share_memory_easy_fuzz(get_max_work, same_steps, min_count):
                 infeasible += 1
 
 
+@dec.slow
 def test_may_share_memory_easy_fuzz():
     # Check that overlap problems with common strides are always
     # solved with little work.
@@ -382,6 +384,7 @@ def test_may_share_memory_easy_fuzz():
                                      min_count=2000)
 
 
+@dec.slow
 def test_may_share_memory_harder_fuzz():
     # Overlap problems with not necessarily common strides take more
     # work.
@@ -683,6 +686,7 @@ class TestUFunc(object):
                         # Check result
                         assert_copy_equivalent(operation, [a], out=b_out, axis=axis)
 
+    @dec.slow
     def test_unary_ufunc_call_fuzz(self):
         self.check_unary_fuzz(np.invert, None, np.int16)
 
@@ -893,6 +897,7 @@ class TestUFunc(object):
         check(x, x.copy(), x)
         check(x, x, x.copy())
 
+    @dec.slow
     def test_binary_ufunc_1d_manual(self):
         ufunc = np.add
 


### PR DESCRIPTION
They all are in released versions so running them all the time should not be required anymore.
Also move the full test travis job further up for better scheduling.

Reduces fast test time from 110s to 45s for me.
