### PR TITLE
DOC: Clarifying the meaning of small values for `suppress` print option.

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -71,6 +71,8 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     suppress : bool, optional
         Whether or not suppress printing of small floating point values
         using scientific notation (default False).
+        A number is "very small" if it is smaller than the current printing
+        precision.
     nanstr : str, optional
         String representation of floating point not-a-number (default nan).
     infstr : str, optional

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -69,10 +69,11 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         The number of characters per line for the purpose of inserting
         line breaks (default 75).
     suppress : bool, optional
-        Whether or not suppress printing of small floating point values
-        using scientific notation (default False).
-        A number is "very small" if it is smaller than the current printing
-        precision.
+        If True, always print floating point numbers using fixed point
+        notation, in which case numbers equal to zero in the current precision
+        will print as zero.  If False, then scientific notation is used when
+        absolute value of the smallest number is < 1e-4 or the ratio of the
+        maximum absolute value to the minimum is > 1e3. The default is False.
     nanstr : str, optional
         String representation of floating point not-a-number (default nan).
     infstr : str, optional


### PR DESCRIPTION
I want to clarify the meaning of "small" values for the "suppress" option of numpy.set_printoptions(). It was clarified nowhere else in the documentation, unless one looks deeper into the less known functions such as array2string.