### PR TITLE
DOC: Add float_power to routines.math documentation autosummary

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -113,6 +113,7 @@ Arithmetic operations
    subtract
    true_divide
    floor_divide
+   float_power
 
    fmod
    mod


### PR DESCRIPTION
Currently `numpy.float_power` isn't listed in the avaiable math-routines and the float_power reference in [`np.power`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.power.html#numpy-power) isn't a link.