### PR TITLE
BUG: Fix correlate segfaults with size zero arguments

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -971,6 +971,11 @@ def correlate(a, v, mode='valid'):
     array([ 0.0+0.j ,  3.0+1.j ,  1.5+1.5j,  1.0+0.j ,  0.5+0.5j])
 
     """
+	#check for empty sequences (Issue 7625)
+    if len(array(a, copy=False, ndmin=1)) == 0:
+        raise ValueError('a cannot be empty')
+    if len(array(v, copy=False, ndmin=1)) == 0:
+        raise ValueError('v cannot be empty')
     mode = _mode_from_name(mode)
     return multiarray.correlate2(a, v, mode)
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -971,7 +971,7 @@ def correlate(a, v, mode='valid'):
     array([ 0.0+0.j ,  3.0+1.j ,  1.5+1.5j,  1.0+0.j ,  0.5+0.5j])
 
     """
-	#check for empty sequences (Issue 7625)
+    #check for empty sequences (Issue 7625)
     if len(array(a, copy=False, ndmin=1)) == 0:
         raise ValueError('a cannot be empty')
     if len(array(v, copy=False, ndmin=1)) == 0:

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2216,7 +2216,7 @@ class TestCorrelate(TestCase):
         assert_array_almost_equal(z, r_z)
         
     def test_zero_size(self):   		
-    	with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             np.correlate(np.array(()), np.ones(1000), mode='full')
         with self.assertRaises(ValueError):
             np.correlate(np.ones(1000), np.array(()), mode='full')

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2214,6 +2214,13 @@ class TestCorrelate(TestCase):
         r_z = r_z[::-1].conjugate()
         z = np.correlate(y, x, mode='full')
         assert_array_almost_equal(z, r_z)
+        
+    def test_zero_size(self):   		
+    	with self.assertRaises(ValueError):
+            np.correlate(np.array(()), np.ones(1000), mode='full')
+        with self.assertRaises(ValueError):
+            np.correlate(np.ones(1000), np.array(()), mode='full')
+    	 
 
 
 class TestConvolve(TestCase):


### PR DESCRIPTION
Hi,
I've met the same error reported in #7625 in numpy version 1.13.0, thus I thought nobody actually fixed this bug (and I could not find any pull request referring to it).

The most weird thing is that the bug happens sometimes only, producing a segfault error, sometimes it does not. It is specially recurrent when trying to call correlate with a zero size array and a large sized array ( >= 1000).

I've followed the suggestion in the original Issue and placed a size check just like happens in the convolve function, as it does not make much sense to me that the function should accept zero sized arguments anyway. 
Also, I've added one test to verify this issue and if a ValueError is raised when using correlate with zero sized argument.

This is my first Pull Request here, any feedbacks on it are welcome.