### PR TITLE
BUG: Fix np.average for object arrays

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1135,7 +1135,7 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = wgt.swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)
-        if (scl == 0.0).any():
+        if (type(scl)==np.bool_ and (scl == 0.0).any()) or scl == 0.0:
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1135,7 +1135,7 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = wgt.swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)
-        if (type(scl)==np.bool_ and (scl == 0.0).any()) or scl == 0.0:
+        if np.any(scl == 0.0):
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 


### PR DESCRIPTION
Fixes type incompatibility with Decimal arrays (#8696), idea for fix by user @NateyB