### PR TITLE
BUG: Fix np.average for object arrays

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1135,7 +1135,7 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = wgt.swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)
-        if (scl == 0.0).any():
+        if np.any(scl == 0.0):
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import operator
 import warnings
 import sys
+import decimal
 
 import numpy as np
 from numpy.testing import (
@@ -257,6 +258,11 @@ class TestAverage(TestCase):
 
         y6 = np.matrix(rand(5, 5))
         assert_array_equal(y6.mean(0), average(y6, 0))
+
+        y7 = np.array([decimal.Decimal(x) for x in range(10)])
+        w7 = np.array([decimal.Decimal(1) for _ in range(10)])
+        w7 /= w7.sum()
+        assert_almost_equal(y7.mean(0), average(y7, weights=w7)) 
 
     def test_weights(self):
         y = np.arange(10)


### PR DESCRIPTION
Addresses issue #8696, with corresponding test for 1D Decimal object array