### PR TITLE
TST: Remove unused env from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@
 [tox]
 envlist =
   py27,py34,
-  py27-monolithic,py34-monolithic,
   py27-not-relaxed-strides,py34-not-relaxed-strides
 
 [testenv]
@@ -35,14 +34,6 @@ deps=
   nose
 changedir={envdir}
 commands={envpython} {toxinidir}/tools/test-installed-numpy.py --mode=full {posargs:}
-
-[testenv:py27-monolithic]
-basepython=python2.7
-env=NPY_SEPARATE_COMPILATION=0
-
-[testenv:py34-monolithic]
-basepython=python3.4
-env=NPY_SEPARATE_COMPILATION=0
 
 [testenv:py27-not-relaxed-strides]
 basepython=python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@
 
 [tox]
 envlist =
-  py27,py34,
+  py27,py34,py35,py36,
   py27-not-relaxed-strides,py34-not-relaxed-strides
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,9 @@
 
 [tox]
 envlist =
-  py26,py27,py32,py33,py34,
-  py27-monolithic,py33-monolithic,py34-monolithic,
-  py27-not-relaxed-strides,py33-not-relaxed-strides,py34-not-relaxed-strides
+  py27,py34,
+  py27-monolithic,py34-monolithic,
+  py27-not-relaxed-strides,py34-not-relaxed-strides
 
 [testenv]
 deps=
@@ -40,20 +40,12 @@ commands={envpython} {toxinidir}/tools/test-installed-numpy.py --mode=full {posa
 basepython=python2.7
 env=NPY_SEPARATE_COMPILATION=0
 
-[testenv:py33-monolithic]
-basepython=python3.3
-env=NPY_SEPARATE_COMPILATION=0
-
 [testenv:py34-monolithic]
 basepython=python3.4
 env=NPY_SEPARATE_COMPILATION=0
 
 [testenv:py27-not-relaxed-strides]
 basepython=python2.7
-env=NPY_RELAXED_STRIDES_CHECKING=0
-
-[testenv:py33-not-relaxed-strides]
-basepython=python3.3
 env=NPY_RELAXED_STRIDES_CHECKING=0
 
 [testenv:py34-not-relaxed-strides]


### PR DESCRIPTION
Drop support Pytnon 2.6, 3.2 and 3.3
This was removed in 1.12.0

Drop NPY_SEPARATE_COMPILATION option.
This was removed in 1.11.0