### PR TITLE
BUG: Fix np.average for object arrays

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1135,7 +1135,7 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = wgt.swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)
-        if (scl == 0.0).any():
+        if np.any(scl == 0.0):
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import operator
 import warnings
 import sys
+import decimal
 
 import numpy as np
 from numpy.testing import (
@@ -340,6 +341,12 @@ class TestAverage(TestCase):
             a = np.array([[1,2],[3,4]], dtype=at)
             w = np.array([[1,2],[3,4]], dtype=wt)
             assert_equal(np.average(a, weights=w).dtype, np.dtype(rt))
+
+    def test_object_dtype(self):
+        a = np.array([decimal.Decimal(x) for x in range(10)])
+        w = np.array([decimal.Decimal(1) for _ in range(10)])
+        w /= w.sum()
+        assert_almost_equal(a.mean(0), average(a, weights=w)) 
 
 class TestSelect(TestCase):
     choices = [np.array([1, 2, 3]),


### PR DESCRIPTION
Moved test for Object arrays from test_basic to test_object_dtype