### PR TITLE
ENH: decoupled the codes to use all cache buckets and optimized *zeros* for small chunks of memory. 

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -37,7 +37,7 @@ NPY_NO_EXPORT void *
 npy_alloc_cache(npy_uintp sz)
 {
     assert(sz > 0);
-    if (sz <= NBUCKETS_DATA && datacache[sz-1].available > 0) {
+    if (sz-1 < NBUCKETS_DATA && datacache[sz-1].available > 0) {
         return datacache[sz-1].ptrs[--(datacache[sz-1].available)];
     }
     return PyDataMem_NEW(sz);
@@ -50,7 +50,7 @@ npy_alloc_cache_zero(npy_uintp sz)
     void * p;
     assert(sz > 0);
     NPY_BEGIN_THREADS_DEF;
-    if (sz <= NBUCKETS_DATA && datacache[sz-1].available > 0) {
+    if (sz-1 < NBUCKETS_DATA && datacache[sz-1].available > 0) {
         p = datacache[sz-1].ptrs[--(datacache[sz-1].available)];
         memset(p, 0, sz);
         return p;

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -60,6 +60,11 @@ _npy_free_cache(void * p, npy_uintp nelem, npy_uint msz,
 }
 
 
+static NPY_INLINE void *
+_PyDataMem_NEW_ZEROED_RAW(size_t size) {
+    return PyDataMem_NEW_ZEROED(size, 1);
+}
+
 /*
  * array data cache, sz is number of bytes to allocate
  */
@@ -69,6 +74,7 @@ npy_alloc_cache(npy_uintp sz)
     return _npy_alloc_cache(sz, 1, NBUCKETS, datacache, &PyDataMem_NEW);
 }
 
+
 /* zero initialized data, sz is number of bytes to allocate */
 NPY_NO_EXPORT void *
 npy_alloc_cache_zero(npy_uintp sz)
@@ -76,11 +82,7 @@ npy_alloc_cache_zero(npy_uintp sz)
     void * p;
     NPY_BEGIN_THREADS_DEF;
     if (sz < NBUCKETS) {
-        p = _npy_alloc_cache(sz, 1, NBUCKETS, datacache, &PyDataMem_NEW);
-        if (p) {
-            memset(p, 0, sz);
-        }
-        return p;
+        return _npy_alloc_cache(sz, 1, NBUCKETS, datacache, &_PyDataMem_NEW_ZEROED_RAW);
     }
     NPY_BEGIN_THREADS;
     p = PyDataMem_NEW_ZEROED(sz, 1);

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -28,6 +28,7 @@ typedef struct {
 static data_cache_bucket datacache[NBUCKETS_DATA];
 static dim_cache_bucket dimcache[NBUCKETS_DIM];
 
+
 /*
  * array data cache, sz is number of bytes to allocate
  */
@@ -40,13 +41,15 @@ npy_alloc_cache(npy_uintp sz)
     return PyDataMem_NEW(sz);
 }
 
-/* zero initialized data, sz is number of bytes to allocate */
+/*
+ * zero initialized data, sz is number of bytes to allocate
+ */
 NPY_NO_EXPORT void *
 npy_alloc_cache_zero(npy_uintp sz)
 {
     void * p;    
     if (sz > 0 && sz-1 < NBUCKETS_DATA && datacache[sz-1].available > 0) {
-        p = datacache[sz-1].ptrs[--(datacache[sz-1].available)];
+            p = datacache[sz-1].ptrs[--(datacache[sz-1].available)];
         memset(p, 0, sz);
         return p;
     }
@@ -59,7 +62,7 @@ NPY_NO_EXPORT void
 npy_free_cache(void * p, npy_uintp sz)
 {
     if (p != NULL && sz > 0 && sz-1 < NBUCKETS_DATA &&
-        datacache[sz-1].available < NCACHE_DATA) {
+            datacache[sz-1].available < NCACHE_DATA) {
         datacache[sz-1].ptrs[datacache[sz-1].available++] = p;
         return ;
     }
@@ -80,7 +83,7 @@ npy_alloc_cache_dim(npy_uintp sz)
     }
 
     if (sz-2 < NBUCKETS_DIM && dimcache[sz-2].available > 0) {
-            return dimcache[sz-2].ptrs[--(dimcache[sz-2].available)];
+        return dimcache[sz-2].ptrs[--(dimcache[sz-2].available)];
     }
     /* type of dimension elements is npy_intp */
     p = PyArray_malloc(sz * sizeof(npy_intp));
@@ -96,7 +99,7 @@ npy_free_cache_dim(void * p, npy_uintp sz)
     }
     
     if (p != NULL && sz-2 < NBUCKETS_DIM &&
-        dimcache[sz-2].available < NCACHE_DIM) {
+            dimcache[sz-2].available < NCACHE_DIM) {
         dimcache[sz-2].ptrs[dimcache[sz-2].available++] = p;
         return ;
     }
@@ -134,15 +137,15 @@ PyDataMem_SetEventHook(PyDataMem_EventHookFunc *newhook,
 {
     PyDataMem_EventHookFunc *temp;
     NPY_ALLOW_C_API_DEF
-    NPY_ALLOW_C_API
-    temp = _PyDataMem_eventhook;
+        NPY_ALLOW_C_API
+        temp = _PyDataMem_eventhook;
     _PyDataMem_eventhook = newhook;
     if (old_data != NULL) {
         *old_data = _PyDataMem_eventhook_user_data;
     }
     _PyDataMem_eventhook_user_data = user_data;
     NPY_DISABLE_C_API
-    return temp;
+        return temp;
 }
 
 /*NUMPY_API
@@ -156,13 +159,13 @@ PyDataMem_NEW(size_t size)
     result = malloc(size);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
-        NPY_ALLOW_C_API
-        if (_PyDataMem_eventhook != NULL) {
-            (*_PyDataMem_eventhook)(NULL, result, size,
-                                    _PyDataMem_eventhook_user_data);
-        }
+            NPY_ALLOW_C_API
+            if (_PyDataMem_eventhook != NULL) {
+                (*_PyDataMem_eventhook)(NULL, result, size,
+                                        _PyDataMem_eventhook_user_data);
+            }
         NPY_DISABLE_C_API
-    }
+            }
     return result;
 }
 
@@ -177,13 +180,13 @@ PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
     result = calloc(size, elsize);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
-        NPY_ALLOW_C_API
-        if (_PyDataMem_eventhook != NULL) {
-            (*_PyDataMem_eventhook)(NULL, result, size * elsize,
-                                    _PyDataMem_eventhook_user_data);
-        }
+            NPY_ALLOW_C_API
+            if (_PyDataMem_eventhook != NULL) {
+                (*_PyDataMem_eventhook)(NULL, result, size * elsize,
+                                        _PyDataMem_eventhook_user_data);
+            }
         NPY_DISABLE_C_API
-    }
+            }
     return result;
 }
 
@@ -196,13 +199,13 @@ PyDataMem_FREE(void *ptr)
     free(ptr);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
-        NPY_ALLOW_C_API
-        if (_PyDataMem_eventhook != NULL) {
-            (*_PyDataMem_eventhook)(ptr, NULL, 0,
-                                    _PyDataMem_eventhook_user_data);
-        }
+            NPY_ALLOW_C_API
+            if (_PyDataMem_eventhook != NULL) {
+                (*_PyDataMem_eventhook)(ptr, NULL, 0,
+                                        _PyDataMem_eventhook_user_data);
+            }
         NPY_DISABLE_C_API
-    }
+            }
 }
 
 /*NUMPY_API
@@ -216,12 +219,12 @@ PyDataMem_RENEW(void *ptr, size_t size)
     result = realloc(ptr, size);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
-        NPY_ALLOW_C_API
-        if (_PyDataMem_eventhook != NULL) {
-            (*_PyDataMem_eventhook)(ptr, result, size,
-                                    _PyDataMem_eventhook_user_data);
-        }
+            NPY_ALLOW_C_API
+            if (_PyDataMem_eventhook != NULL) {
+                (*_PyDataMem_eventhook)(ptr, result, size,
+                                        _PyDataMem_eventhook_user_data);
+            }
         NPY_DISABLE_C_API
-    }
+            }
     return result;
 }

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -9,8 +9,6 @@
 #include <numpy/npy_common.h>
 #include "npy_config.h"
 
-#include <assert.h>
-
 #define NBUCKETS_DATA 1024 /* number of buckets for data*/
 #define NBUCKETS_DIM 16 /* number of buckets for dimensions/strides */
 #define NCACHE_DATA 7 /* number of cache entries per data bucket */
@@ -47,16 +45,13 @@ NPY_NO_EXPORT void *
 npy_alloc_cache_zero(npy_uintp sz)
 {
     void * p;    
-    NPY_BEGIN_THREADS_DEF;
     if (sz > 0 && sz-1 < NBUCKETS_DATA && datacache[sz-1].available > 0) {
         p = datacache[sz-1].ptrs[--(datacache[sz-1].available)];
         memset(p, 0, sz);
         return p;
     }
     
-    NPY_BEGIN_THREADS;
     p = PyDataMem_NEW_ZEROED(sz, 1);
-    NPY_END_THREADS;
     return p;
 }
 

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -36,8 +36,9 @@ static dim_cache_bucket dimcache[NBUCKETS_DIM];
 NPY_NO_EXPORT void *
 npy_alloc_cache(npy_uintp sz)
 {
-    if (sz < NBUCKETS_DATA && datacache[sz].available > 0) {
-        return datacache[sz].ptrs[--(datacache[sz].available)];
+    assert(sz > 0);
+    if (sz <= NBUCKETS_DATA && datacache[sz-1].available > 0) {
+        return datacache[sz-1].ptrs[--(datacache[sz-1].available)];
     }
     return PyDataMem_NEW(sz);
 }
@@ -47,9 +48,10 @@ NPY_NO_EXPORT void *
 npy_alloc_cache_zero(npy_uintp sz)
 {
     void * p;
+    assert(sz > 0);
     NPY_BEGIN_THREADS_DEF;
-    if (sz < NBUCKETS_DATA && datacache[sz].available > 0) {
-        p = datacache[sz].ptrs[--(datacache[sz].available)];
+    if (sz <= NBUCKETS_DATA && datacache[sz-1].available > 0) {
+        p = datacache[sz-1].ptrs[--(datacache[sz-1].available)];
         memset(p, 0, sz);
         return p;
     }
@@ -63,8 +65,9 @@ npy_alloc_cache_zero(npy_uintp sz)
 NPY_NO_EXPORT void
 npy_free_cache(void * p, npy_uintp sz)
 {
-    if (p != NULL && sz < NBUCKETS_DATA && datacache[sz].available < NCACHE_DATA) {
-        datacache[sz].ptrs[datacache[sz].available++] = p;
+    assert(sz > 0);
+    if (p != NULL && sz-1 < NBUCKETS_DATA && datacache[sz-1].available < NCACHE_DATA) {
+        datacache[sz-1].ptrs[datacache[sz-1].available++] = p;
         return ;
     }
     PyDataMem_FREE(p);
@@ -82,11 +85,10 @@ npy_alloc_cache_dim(npy_uintp sz)
     if (NPY_UNLIKELY(sz < 2)) {
         sz = 2;
     }
-    
-    if (sz < NBUCKETS_DIM && dimcache[sz].available > 0) {
-            return dimcache[sz].ptrs[--(dimcache[sz].available)];
-    }
-    
+
+    if (sz-2 < NBUCKETS_DIM && dimcache[sz-2].available > 0) {
+            return dimcache[sz-2].ptrs[--(dimcache[sz-2].available)];
+    }    
     p = PyArray_malloc(sz * sizeof(npy_intp));
     return p;
 }
@@ -99,8 +101,8 @@ npy_free_cache_dim(void * p, npy_uintp sz)
         sz = 2;
     }
     
-    if (p != NULL && sz < NBUCKETS_DIM && dimcache[sz].available < NCACHE_DIM) {
-        dimcache[sz].ptrs[dimcache[sz].available++] = p;
+    if (p != NULL && sz-2 < NBUCKETS_DIM && dimcache[sz-2].available < NCACHE_DIM) {
+        dimcache[sz-2].ptrs[dimcache[sz-2].available++] = p;
         return ;
     }
     PyArray_free(p);


### PR DESCRIPTION
0. created cache for dimension data, the NCACHE_DIM needs to be discussed. Here I increased it a little because it's unfair that we allowed to cache way more array data than dimension data (1024x7 >> 16x7).   
1. avoided using memory allocation as callback function.  this allows we optimize out most of the *memset()* cost for small memory chunks in *npy_alloc_cache_zero()*.  In the old codes, if `*sz < NBUCKETS*`, it would call *memset* once, no matter the memory was from the cache or newly allocated. 
2. reused all cache buckets. previously, the `data_cache[0]` and `dim_cache[0, 1]` was not used. 