### PR TITLE
BUG: Add HOME to the git environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def git_version():
     def _minimal_ext_cmd(cmd):
         # construct minimal environment
         env = {}
-        for k in ['SYSTEMROOT', 'PATH']:
+        for k in ['SYSTEMROOT', 'PATH', 'HOME']:
             v = os.environ.get(k)
             if v is not None:
                 env[k] = v


### PR DESCRIPTION
git config files can contain ~ expansions that require $HOME to be defined.
Some installations of git have these in the global defaults now.

Before:

```
~/git/numpy master
❯ cat /usr/local/etc/gitconfig
[include]
    path = ~/.gitcinclude

[credential]
    helper = osxkeychain

~/git/numpy master
❯ python setup.py --version
error: could not expand include path '~/.gitcinclude'
fatal: bad config line 3 in file /usr/local/etc/gitconfig
error: could not expand include path '~/.gitcinclude'
fatal: bad config line 3 in file /usr/local/etc/gitconfig
/Users/rkern/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/setuptools/dist.py:294: UserWarning: The version specified (u'1.13.0.dev0+') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % self.metadata.version
1.13.0.dev0+
```

After:
```
~/git/numpy fix/git-home
❯ python setup.py --version
1.13.0.dev0+c0be995
```