### PR TITLE
ENH: cache large memory allocations on systems with MADV_FREE

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -152,7 +152,8 @@ def check_math_capabilities(config, moredefs, mathlibs):
 
     for h in OPTIONAL_HEADERS:
         if config.check_func("", decl=False, call=False, headers=[h]):
-            moredefs.append((fname2def(h).replace(".", "_"), 1))
+            h = h.replace(".", "_").replace(os.path.sep, "_")
+            moredefs.append((fname2def(h), 1))
 
     for tup in OPTIONAL_INTRINSICS:
         headers = None

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -109,7 +109,7 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
         "copysign", "nextafter", "ftello", "fseeko",
         "strtoll", "strtoull", "cbrt", "strtold_l", "fallocate",
-        "backtrace"]
+        "backtrace", "madvise"]
 
 
 OPTIONAL_HEADERS = [
@@ -119,6 +119,7 @@ OPTIONAL_HEADERS = [
                 "features.h",  # for glibc version linux
                 "xlocale.h",  # see GH#8367
                 "dlfcn.h", # dladdr
+                "sys/mman.h", # madvise
 ]
 
 # optional gcc compiler builtins and their call arguments and optional a

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -10,7 +10,7 @@
 #define PyTraceMalloc_Untrack _PyTraceMalloc_Untrack
 #endif
 #else
-#define PyTraceMalloc_Track(...)
+#define PyTraceMalloc_Track(...) -2
 #define PyTraceMalloc_Untrack(...)
 #endif
 
@@ -23,6 +23,213 @@
 #include "alloc.h"
 
 #include <assert.h>
+#include <stdio.h>
+
+#ifdef HAVE_SYS_MMAN_H
+#include <sys/mman.h>
+
+#if defined MADV_FREE && defined HAVE_MADVISE
+/* mark memory reclaimable by other processes */
+#define MADVISE_FREE(ptr, size)\
+    madvise((void*)((npy_uintp)ptr + (4096 - ((npy_uintp)ptr % 4096))), \
+            size, MADV_FREE)
+#define NPY_ENABLE_LARGECACHE
+#include <unistd.h>
+#endif
+#endif
+#ifndef MADVISE_FREE
+#define MADVISE_FREE(ptr, size) 1
+#endif
+
+/*
+ * Large memory allocation cache.
+ * Large allocations on glibc systems need to be faulted into the process
+ * before use each use. This can account for a significant fraction of the
+ * runtime of frequent array allocation and deallocation.  This can be avoidded
+ * by caching used memory blocks inside numpy for later reuse.  To not waste
+ * the memory in the cache we mark the memory as reclaimable by other processes
+ * (or numpy itself) with MADV_FREE. Should we try to use memory claimed by
+ * other processes we will receive newly faulted memory instead just as if it
+ * were freed normally.
+ * MADV_FREE is supported on Linux >= 4.5 and BSD.
+ *
+ * The cache is intentionally very simple queue storing the last large
+ * deallocations in a queue. New allocations pick the first block of memory
+ * that matches in size from the cache. It does not pick larger blocks, while
+ * the memory can be reclaimed by other processes it is not available for the
+ * page cache used to buffer IO.
+ * On each deallocation the cache is aged and if no entries have been removed
+ * for too long the oldest memory block is properly deallocated to avoid that
+ * large unused blocks stay in the cache too long.
+ * In most cases where it is relevant are fast allocation/deallocation cycles
+ * that appear in operations with temporaries or indexing. A simple small cache
+ * is sufficient for this.
+ * It will cache at most half of the available physical memory so that there is
+ * always enough free to be used in the page cache.
+ */
+
+/* threshold in bytes for large allocation to be considered for the cache */
+#define NPY_LARGE_ALLOC 4096 * 128
+#define LCACHE_MAXENTRIES 50
+typedef struct {
+    npy_uintp size;
+    void * ptr;
+} lcache_bucket;
+static unsigned int lcache_entries = 0;
+#ifdef NPY_ENABLE_LARGECACHE
+static unsigned int lcache_nentries = 16;
+#else
+static unsigned int lcache_nentries = 0;
+#endif
+static npy_uintp lcache_size = 0;
+static npy_uintp lcache_maxsize = -1;
+static lcache_bucket lcache[LCACHE_MAXENTRIES];
+static unsigned int lcache_age = 0;
+
+static void remove_lcache_entry(npy_uintp idx, void (*dealloc)(void *))
+{
+    dealloc(lcache[idx].ptr);
+    lcache_size -= lcache[idx].size;
+    lcache_entries--;
+    lcache[idx].ptr = NULL;
+    lcache[idx].size = 0;
+    lcache_age = 0;
+}
+
+/* set the large allocation cache max size, 0 disables and clears it */
+NPY_NO_EXPORT unsigned int
+npy_set_lcache_size(unsigned int size)
+{
+#ifdef NPY_ENABLE_LARGECACHE
+    unsigned int i, old_size = lcache_size;
+    void * ptr;
+    size = size > LCACHE_MAXENTRIES ? LCACHE_MAXENTRIES : size;
+
+    /* disable cache if MADV_FREE does not work */
+    ptr = malloc(4096 * 10);
+    if (MADVISE_FREE(ptr, 4096) != 0) {
+        size = 0;
+    }
+    free(ptr);
+
+    /* not enough address space on 32 bit to cache large data */
+    if (sizeof(ptr) < 8) {
+        size = 0;
+    }
+
+    /* disable caching when kernel has overcommit disabled */
+    {
+        FILE * f = fopen("/proc/sys/vm/overcommit_memory", "r");
+        if (f == NULL) {
+            size = 0;
+        }
+        else {
+            if (fgetc(f) == '2') {
+                size = 0;
+            }
+            fclose(f);
+        }
+    }
+
+    /*
+     * cache at most half the available ram so there is enough left for the
+     * page cache used to buffer IO
+     */
+    {
+        npy_intp pages = sysconf(_SC_PHYS_PAGES);
+        npy_intp page_size = sysconf(_SC_PAGE_SIZE);
+        lcache_maxsize = (pages * page_size / 2);
+    }
+
+    for (i=size; i < lcache_size; i++) {
+        PyDataMem_FREE(lcache[i].ptr);
+        lcache_size -= lcache[i].size;
+        lcache[i].ptr = NULL;
+        lcache[i].size = 0;
+    }
+    lcache_nentries = size;
+    return old_size;
+#else
+    lcache_size = 0;
+    return 0;
+#endif
+}
+
+/* fast cache toggle for disabling during tracing */
+static void enable_lcache(int enable)
+{
+    static unsigned int old_lcache_nentries;
+    if (!enable) {
+        unsigned int i;
+        for (i=0; i < lcache_size; i++) {
+            PyDataMem_FREE(lcache[i].ptr);
+            lcache_size -= lcache[i].size;
+            lcache[i].ptr = NULL;
+            lcache[i].size = 0;
+        }
+        if (lcache_nentries != 0) {
+            old_lcache_nentries = lcache_nentries;
+        }
+        lcache_nentries = 0;
+    }
+    else {
+        if (old_lcache_nentries != 0) {
+            lcache_nentries = old_lcache_nentries;
+        }
+    }
+
+}
+
+
+/* place a block into the cache, marking it as reclaimable */
+static void add_to_lcache(void * ptr, npy_uintp size, void (*dealloc)(void *))
+{
+    if (lcache_size + size > lcache_maxsize || lcache_nentries == 0) {
+        dealloc(ptr);
+        return;
+    }
+    if (MADVISE_FREE(ptr, size) == 0) {
+        if (lcache_entries == lcache_nentries) {
+            remove_lcache_entry(lcache_entries - 1, dealloc);
+        }
+        if (lcache_entries > 0) {
+            memmove(lcache + 1, lcache, sizeof(lcache[0]) * lcache_entries);
+        }
+        lcache[0].ptr = ptr;
+        lcache[0].size = size;
+        lcache_size += size;
+        lcache_entries++;
+        return;
+    }
+    else {
+        dealloc(ptr);
+    }
+}
+
+
+/* retrieve a memory block from the cache or allocate if empty */
+static void * remove_from_lcache(npy_uintp size, void * (*alloc)(size_t))
+{
+    npy_uintp i;
+
+    /* find a matching entry */
+    for (i=0; i < lcache_entries; i++) {
+        if (lcache[i].size == size) {
+            void * ptr = lcache[i].ptr;
+            lcache_size -= lcache[i].size;
+            if (i < lcache_entries) {
+                memmove(&lcache[i], &lcache[i] + 1,
+                        sizeof(lcache[0]) * (lcache_entries - i - 1));
+            }
+            lcache_entries--;
+            /* successful retrieve, reset age as more successes may follow */
+            lcache_age = 0;
+            return ptr;
+        }
+    }
+    return alloc(size);
+}
+
 
 #define NBUCKETS 1024 /* number of buckets for data*/
 #define NBUCKETS_DIM 16 /* number of buckets for dimensions/strides */
@@ -52,19 +259,11 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
             return cache[nelem].ptrs[--(cache[nelem].available)];
         }
     }
-#ifdef _PyPyGC_AddMemoryPressure
-    {
-        size_t size = nelem * esz;
-        void * ret = alloc(size);
-        if (ret != NULL)
-        {
-            _PyPyPyGC_AddMemoryPressure(size);
-        }
-        return ret;
+    else if (nelem > NPY_LARGE_ALLOC) {
+        return remove_from_lcache(nelem * esz, alloc);
     }
-#else
-     return alloc(nelem * esz);
-#endif
+
+    return alloc(nelem * esz);
 }
 
 /*
@@ -75,11 +274,20 @@ static NPY_INLINE void
 _npy_free_cache(void * p, npy_uintp nelem, npy_uint msz,
                 cache_bucket * cache, void (*dealloc)(void *))
 {
+    /* remove stale entries from the large allocation cache */
+    lcache_age++;
+    if (NPY_UNLIKELY(lcache_age > 2000) && lcache_entries > 0) {
+        remove_lcache_entry(lcache_entries - 1, dealloc);
+    }
     if (p != NULL && nelem < msz) {
         if (cache[nelem].available < NCACHE) {
             cache[nelem].ptrs[cache[nelem].available++] = p;
             return;
         }
+    }
+    else if (p != NULL && nelem > NPY_LARGE_ALLOC) {
+        add_to_lcache(p, nelem, dealloc);
+        return;
     }
     dealloc(p);
 }
@@ -177,6 +385,7 @@ PyDataMem_SetEventHook(PyDataMem_EventHookFunc *newhook,
     PyDataMem_EventHookFunc *temp;
     NPY_ALLOW_C_API_DEF
     NPY_ALLOW_C_API
+    enable_lcache(newhook == NULL);
     temp = _PyDataMem_eventhook;
     _PyDataMem_eventhook = newhook;
     if (old_data != NULL) {
@@ -194,6 +403,7 @@ NPY_NO_EXPORT void *
 PyDataMem_NEW(size_t size)
 {
     void *result;
+    int tracking;
 
     result = malloc(size);
     if (_PyDataMem_eventhook != NULL) {
@@ -205,7 +415,13 @@ PyDataMem_NEW(size_t size)
         }
         NPY_DISABLE_C_API
     }
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    tracking = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    enable_lcache(tracking == -2 && _PyDataMem_eventhook == NULL);
+#ifdef _PyPyGC_AddMemoryPressure
+    if (result) {
+        _PyPyPyGC_AddMemoryPressure(size);
+    }
+#endif
     return result;
 }
 
@@ -216,6 +432,7 @@ NPY_NO_EXPORT void *
 PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
 {
     void *result;
+    int tracking;
 
     result = calloc(size, elsize);
     if (_PyDataMem_eventhook != NULL) {
@@ -227,7 +444,14 @@ PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
         }
         NPY_DISABLE_C_API
     }
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    tracking = PyTraceMalloc_Track(NPY_TRACE_DOMAIN,
+                                   (npy_uintp)result, elsize * size);
+    enable_lcache(tracking == -2 && _PyDataMem_eventhook == NULL);
+#ifdef _PyPyGC_AddMemoryPressure
+    if (result) {
+        _PyPyPyGC_AddMemoryPressure(elsize * size);
+    }
+#endif
     return result;
 }
 
@@ -257,12 +481,14 @@ NPY_NO_EXPORT void *
 PyDataMem_RENEW(void *ptr, size_t size)
 {
     void *result;
+    unsigned int tracking;
 
     result = realloc(ptr, size);
     if (result != ptr) {
-	PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
+        PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
     }
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    tracking = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    enable_lcache(tracking == -2 && _PyDataMem_eventhook == NULL);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
         NPY_ALLOW_C_API

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -6,6 +6,9 @@
 
 #define NPY_TRACE_DOMAIN 389047
 
+NPY_NO_EXPORT unsigned int
+npy_set_lcache_size(unsigned int size);
+
 NPY_NO_EXPORT void *
 npy_alloc_cache(npy_uintp sz);
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2962,6 +2962,16 @@ fail:
 }
 
 static PyObject *
+array_set_memory_cache_size(PyObject *NPY_UNUSED(self), PyObject * args)
+{
+    int size;
+    if (!PyArg_ParseTuple(args, "i", &size)) {
+        return NULL;
+    }
+    return PyInt_FromLong(npy_set_lcache_size(size));
+}
+
+static PyObject *
 array_set_string_function(PyObject *NPY_UNUSED(self), PyObject *args,
         PyObject *kwds)
 {
@@ -4090,6 +4100,9 @@ static struct PyMethodDef array_module_methods[] = {
     {"_reconstruct",
         (PyCFunction)array__reconstruct,
         METH_VARARGS, NULL},
+    {"set_memory_cache_size",
+        (PyCFunction)array_set_memory_cache_size,
+         METH_VARARGS, NULL},
     {"set_string_function",
         (PyCFunction)array_set_string_function,
         METH_VARARGS|METH_KEYWORDS, NULL},
@@ -4676,6 +4689,9 @@ PyMODINIT_FUNC initmultiarray(void) {
     PyDict_SetItemString(d, "busdaycalendar",
                             (PyObject *)&NpyBusDayCalendar_Type);
     set_flaginfo(d);
+
+    /* initialize memory cache, also disables it when appropriate */
+    npy_set_lcache_size(16);
 
     if (!intern_strings()) {
         goto err;


### PR DESCRIPTION
    Large allocations on glibc systems need to be faulted into the process
    before use each use. This can account for a significant fraction of the
    runtime of frequent array allocation and deallocation.  This can be avoidded
    by caching used memory blocks inside numpy for later reuse.  To not waste
    the memory in the cache we mark the memory as reclaimable by other processes
    (or numpy itself) with MADV_FREE. Should we try to use memory claimed by
    other processes we will receive newly faulted memory instead just as if it
    were freed normally.
    MADV_FREE is supported on Linux >= 4.5 and BSD.
    
    The cache is intentionally very simple queue storing the last large
    deallocations in a queue. New allocations pick the first block of memory
    that matches in size from the cache. It does not pick larger blocks,
    while the memory can be reclaimed by other processes it is not available
    for the page cache used to buffer IO.
    On each deallocation the cache is aged and if no entries have been
    removed for too long the oldest memory block is properly deallocated to
    avoid that large unused blocks stay in the cache too long.
    In most cases where it is relevant are fast allocation/deallocation
    cycles that appear in operations with temporaries or indexing. A simple
    small cache is sufficient for this.
    It will cache at most half of the available physical memory so that
    there is always enough free to be used in the page cache.

still a prototype missing documentation and cleanup, but should be usable to test how effective it is in practice.