### PR TITLE
DOC: fix minor docstring typos

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1289,7 +1289,7 @@ def split(a, sep=None, maxsplit=None):
     For each element in `a`, return a list of the words in the
     string, using `sep` as the delimiter string.
 
-    Calls `str.rsplit` element-wise.
+    Calls `str.split` element-wise.
 
     Parameters
     ----------
@@ -1383,7 +1383,7 @@ def strip(a, chars=None):
     For each element in `a`, return a copy with the leading and
     trailing characters removed.
 
-    Calls `str.rstrip` element-wise.
+    Calls `str.strip` element-wise.
 
     Parameters
     ----------


### PR DESCRIPTION
Seems like they were copy-paste errors.