### PR TITLE
BUG: fix the error msg of empty hstack input

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -29,6 +29,12 @@ Future Changes
 Compatibility notes
 ===================
 
+
+Error type changes
+~~~~~~~~~~~~~~~~~~
+
+``numpy.hstack()`` now throws ValueError instead of IndexError when input is empty.
+
 Tuple object dtypes
 ~~~~~~~~~~~~~~~~~~~
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -283,7 +283,7 @@ def hstack(tup):
     """
     arrs = [atleast_1d(_m) for _m in tup]
     # As a special case, dimension 0 of 1-dimensional arrays is "horizontal"
-    if arrs[0].ndim == 1:
+    if arrs and arrs[0].ndim == 1:
         return _nx.concatenate(arrs, 0)
     else:
         return _nx.concatenate(arrs, 1)

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -123,6 +123,9 @@ class TestHstack(TestCase):
     def test_non_iterable(self):
         assert_raises(TypeError, hstack, 1)
 
+    def test_empty_input(self):
+        assert_raises(ValueError, hstack, ())
+
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -148,6 +151,9 @@ class TestHstack(TestCase):
 class TestVstack(TestCase):
     def test_non_iterable(self):
         assert_raises(TypeError, vstack, 1)
+
+    def test_empty_input(self):
+        assert_raises(ValueError, vstack, ())
 
     def test_0D_array(self):
         a = array(1)


### PR DESCRIPTION
Raise the meaningful error msg for np.hstack() under empty input.

Closes #8790