### PR TITLE
ENH: Make dtype iterable

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3812,6 +3812,15 @@ _subscript_by_index(PyArray_Descr *self, Py_ssize_t i)
 }
 
 static PyObject *
+descr_item(PyArray_Descr *self, Py_ssize_t i)
+{
+    if (_check_has_fields(self) < 0) {
+        return NULL;
+    }
+    return _subscript_by_index(self, i);
+}
+
+static PyObject *
 descr_subscript(PyArray_Descr *self, PyObject *op)
 {
     if (_check_has_fields(self) < 0) {
@@ -3843,7 +3852,7 @@ static PySequenceMethods descr_as_sequence = {
     (lenfunc) descr_length,                  /* sq_length */
     (binaryfunc) NULL,                       /* sq_concat */
     (ssizeargfunc) descr_repeat,             /* sq_repeat */
-    (ssizeargfunc) NULL,                     /* sq_item */
+    (ssizeargfunc) descr_item,               /* sq_item */
     (ssizessizeargfunc) NULL,                /* sq_slice */
     (ssizeobjargproc) NULL,                  /* sq_ass_item */
     (ssizessizeobjargproc) NULL,             /* sq_ass_slice */

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -306,6 +306,16 @@ class TestRecord(object):
         assert_dtype_equal(dt[-2], dt[0])
         assert_raises(IndexError, lambda: dt[-3])
 
+        # check conversion to list works fine
+        dt_list = list(dt)
+        assert_dtype_equal(dt_list[0], np.dtype(np.int8))
+        assert_dtype_equal(dt_list[1], np.dtype((np.float32, 3)))
+
+        dt2 = np.dtype([('c', np.bool_), ('d', np.int16)])
+        dt_zip = list(zip(dt, dt2))
+        assert_equal(dt_zip[0], (np.int8, np.bool_))
+        assert_equal(dt_zip[1], ((np.float32, 3), np.int16))
+
 
 class TestSubarray(object):
     def test_single_subarray(self):


### PR DESCRIPTION
We already are able to index structured dtypes with integers to access their fields, and we can already do `len(dtype)` to get the number of fields. (Although the first of these had no tests).

It seems that if we're going to expose this, we should expose `iter(dtype)` as well.