### PR TITLE
BUG: `np.lib.index_tricks.r_` mutates its own state

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -237,6 +237,8 @@ class AxisConcatenator(object):
     For detailed documentation on usage, see `r_`.
 
     """
+    # allow ma.mr_ to override this
+    concatenate = staticmethod(_nx.concatenate)
 
     def _retval(self, res):
         if self.matrix:
@@ -345,7 +347,7 @@ class AxisConcatenator(object):
             for k in scalars:
                 objs[k] = objs[k].astype(final_dtype)
 
-        res = _nx.concatenate(tuple(objs), axis=self.axis)
+        res = self.concatenate(tuple(objs), axis=self.axis)
         return self._retval(res)
 
     def __len__(self):

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -15,8 +15,6 @@ from .function_base import diff
 from numpy.core.multiarray import ravel_multi_index, unravel_index
 from numpy.lib.stride_tricks import as_strided
 
-makemat = matrixlib.matrix
-
 
 __all__ = [
     'ravel_multi_index', 'unravel_index', 'mgrid', 'ogrid', 'r_', 'c_',
@@ -238,6 +236,8 @@ class AxisConcatenator(object):
     """
     # allow ma.mr_ to override this
     concatenate = staticmethod(_nx.concatenate)
+    makemat = staticmethod(matrixlib.matrix)
+
     def __init__(self, axis=0, matrix=False, ndmin=1, trans1d=-1):
         self.axis = axis
         self.matrix = matrix
@@ -341,7 +341,7 @@ class AxisConcatenator(object):
 
         if matrix:
             oldndim = res.ndim
-            res = makemat(res)
+            res = self.makemat(res)
             if oldndim == 1 and col:
                 res = res.T
         return res

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -308,7 +308,7 @@ class AxisConcatenator(object):
                     raise ValueError("unknown special directive")
             elif type(item) in ScalarType:
                 newobj = array(item, ndmin=ndmin)
-                scalars.append(k)
+                scalars.append(len(objs))
                 scalar = True
                 scalartypes.append(newobj.dtype)
             else:

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -265,12 +265,12 @@ class AxisConcatenator(object):
         arraytypes = []
         scalartypes = []
 
-        for k in range(len(key)):
+        for k, item in enumerate(key):
             scalar = False
-            if isinstance(key[k], slice):
-                step = key[k].step
-                start = key[k].start
-                stop = key[k].stop
+            if isinstance(item, slice):
+                step = item.step
+                start = item.start
+                stop = item.stop
                 if start is None:
                     start = 0
                 if step is None:
@@ -284,17 +284,16 @@ class AxisConcatenator(object):
                     newobj = array(newobj, copy=False, ndmin=ndmin)
                     if trans1d != -1:
                         newobj = newobj.swapaxes(-1, trans1d)
-            elif isinstance(key[k], str):
+            elif isinstance(item, str):
                 if k != 0:
                     raise ValueError("special directives must be the "
                             "first entry.")
-                key0 = key[0]
-                if key0 in 'rc':
+                if item in 'rc':
                     matrix = True
-                    col = (key0 == 'c')
+                    col = (item == 'c')
                     continue
-                if ',' in key0:
-                    vec = key0.split(',')
+                if ',' in item:
+                    vec = item.split(',')
                     try:
                         axis, ndmin = [int(x) for x in vec[:2]]
                         if len(vec) == 3:
@@ -303,17 +302,17 @@ class AxisConcatenator(object):
                     except:
                         raise ValueError("unknown special directive")
                 try:
-                    axis = int(key[k])
+                    axis = int(item)
                     continue
                 except (ValueError, TypeError):
                     raise ValueError("unknown special directive")
-            elif type(key[k]) in ScalarType:
-                newobj = array(key[k], ndmin=ndmin)
+            elif type(item) in ScalarType:
+                newobj = array(item, ndmin=ndmin)
                 scalars.append(k)
                 scalar = True
                 scalartypes.append(newobj.dtype)
             else:
-                newobj = key[k]
+                newobj = item
                 if ndmin > 1:
                     tempobj = array(newobj, copy=False, subok=True)
                     newobj = array(newobj, copy=False, subok=True,

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -288,7 +288,7 @@ class AxisConcatenator(object):
                 if k != 0:
                     raise ValueError("special directives must be the "
                             "first entry.")
-                if item in 'rc':
+                if item in ('r', 'c'):
                     matrix = True
                     col = (item == 'c')
                     continue

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -187,6 +187,8 @@ class TestConcatenator(TestCase):
         assert_equal(np.array(ab_r), [[1,2,3,4]])
         assert_equal(np.array(ab_c), [[1],[2],[3],[4]])
 
+        assert_raises(ValueError, lambda: np.r_['rc', a, b])
+
     def test_matrix_builder(self):
         a = np.array([1])
         b = np.array([2])

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -174,6 +174,17 @@ class TestConcatenator(TestCase):
         assert_array_equal(d[:5, :], b)
         assert_array_equal(d[5:, :], c)
 
+    def test_matrix_builder(self):
+        a = np.array([1])
+        b = np.array([2])
+        c = np.array([3])
+        d = np.array([4])
+        actual = np.r_['a, b; c, d']
+        expected = np.bmat([[a, b], [c, d]])
+
+        assert_equal(actual, expected)
+        assert_equal(type(actual), type(expected))
+
 
 class TestNdenumerate(TestCase):
     def test_basic(self):

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -189,6 +189,11 @@ class TestConcatenator(TestCase):
 
         assert_raises(ValueError, lambda: np.r_['rc', a, b])
 
+    def test_matrix_scalar(self):
+        r = np.r_['r', [1, 2], 3]
+        assert_equal(type(r), np.matrix)
+        assert_equal(np.array(r), [[1,2,3]])
+
     def test_matrix_builder(self):
         a = np.array([1])
         b = np.array([2])

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -174,6 +174,19 @@ class TestConcatenator(TestCase):
         assert_array_equal(d[:5, :], b)
         assert_array_equal(d[5:, :], c)
 
+    def test_matrix(self):
+        a = [1, 2]
+        b = [3, 4]
+
+        ab_r = np.r_['r', a, b]
+        ab_c = np.r_['c', a, b]
+
+        assert_equal(type(ab_r), np.matrix)
+        assert_equal(type(ab_c), np.matrix)
+
+        assert_equal(np.array(ab_r), [[1,2,3,4]])
+        assert_equal(np.array(ab_c), [[1],[2],[3],[4]])
+
     def test_matrix_builder(self):
         a = np.array([1])
         b = np.array([2])

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1463,6 +1463,10 @@ class MAxisConcatenator(AxisConcatenator):
     """
     concatenate = staticmethod(concatenate)
 
+    @staticmethod
+    def makemat(arr):
+        return array(arr.data.view(np.matrix), mask=arr.mask)
+
     def __getitem__(self, key):
         # matrix builder syntax, like 'a, b; c, d'
         if isinstance(key, str):

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1461,60 +1461,15 @@ class MAxisConcatenator(AxisConcatenator):
     mr_class
 
     """
-
-    def __init__(self, axis=0):
-        AxisConcatenator.__init__(self, axis, matrix=False)
+    concatenate = staticmethod(concatenate)
 
     def __getitem__(self, key):
+        # matrix builder syntax, like 'a, b; c, d'
         if isinstance(key, str):
             raise MAError("Unavailable for masked array.")
-        if not isinstance(key, tuple):
-            key = (key,)
-        objs = []
-        scalars = []
-        final_dtypedescr = None
-        for k in range(len(key)):
-            scalar = False
-            if isinstance(key[k], slice):
-                step = key[k].step
-                start = key[k].start
-                stop = key[k].stop
-                if start is None:
-                    start = 0
-                if step is None:
-                    step = 1
-                if isinstance(step, complex):
-                    size = int(abs(step))
-                    newobj = np.linspace(start, stop, num=size)
-                else:
-                    newobj = np.arange(start, stop, step)
-            elif isinstance(key[k], str):
-                if (key[k] in 'rc'):
-                    self.matrix = True
-                    self.col = (key[k] == 'c')
-                    continue
-                try:
-                    self.axis = int(key[k])
-                    continue
-                except (ValueError, TypeError):
-                    raise ValueError("Unknown special directive")
-            elif type(key[k]) in np.ScalarType:
-                newobj = asarray([key[k]])
-                scalars.append(k)
-                scalar = True
-            else:
-                newobj = key[k]
-            objs.append(newobj)
-            if isinstance(newobj, ndarray) and not scalar:
-                if final_dtypedescr is None:
-                    final_dtypedescr = newobj.dtype
-                elif newobj.dtype > final_dtypedescr:
-                    final_dtypedescr = newobj.dtype
-        if final_dtypedescr is not None:
-            for k in scalars:
-                objs[k] = objs[k].astype(final_dtypedescr)
-        res = concatenate(tuple(objs), axis=self.axis)
-        return self._retval(res)
+
+        return super(MAxisConcatenator, self).__getitem__(key)
+
 
 class mr_class(MAxisConcatenator):
     """

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -308,6 +308,16 @@ class TestConcatenator(TestCase):
     def test_matrix_builder(self):
         assert_raises(np.ma.MAError, lambda: mr_['1, 2; 3, 4'])
 
+    def test_matrix(self):
+        actual = mr_['r', 1, 2, 3]
+        expected = np.ma.array(np.r_['r', 1, 2, 3])
+        assert_array_equal(actual, expected)
+
+        # outer type is masked array, inner type is matrix
+        assert_equal(type(actual), type(expected))
+        assert_equal(type(actual.data), type(expected.data))
+
+
 class TestNotMasked(TestCase):
     # Tests notmasked_edges and notmasked_contiguous.
 

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -14,7 +14,8 @@ import itertools
 
 import numpy as np
 from numpy.testing import (
-    TestCase, run_module_suite, assert_warns, suppress_warnings
+    TestCase, run_module_suite, assert_warns, suppress_warnings,
+    assert_raises
     )
 from numpy.ma.testutils import (
     assert_, assert_array_equal, assert_equal, assert_almost_equal
@@ -304,6 +305,8 @@ class TestConcatenator(TestCase):
         assert_array_equal(d[5:,:], b_2)
         assert_array_equal(d.mask, np.r_[m_1, m_2])
 
+    def test_matrix_builder(self):
+        assert_raises(np.ma.MAError, lambda: mr_['1, 2; 3, 4'])
 
 class TestNotMasked(TestCase):
     # Tests notmasked_edges and notmasked_contiguous.


### PR DESCRIPTION
Well, turns out that `np.r_` is buggy in all sort of exciting ways concerning that magic first argument.

Also, another case of _"`np.some_func` is broken and it turns out that `np.ma.some_func` has the same bugs but also the last few years of bug-fixes didn't get applied there"_

Fixes #8815
