### PR TITLE
DOC: added a whitespace so that sphinx directive displays correctly

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -303,7 +303,7 @@ advanced usage and will not typically be used.
     parameter. Keyword 'out' arguments are incompatible with positional
     ones.
 
-    ..versionadded:: 1.10
+    .. versionadded:: 1.10
 
     The 'out' keyword argument is expected to be a tuple with one entry per
     output (which can be `None` for arrays to be allocated by the ufunc).


### PR DESCRIPTION
This fixes the incorrectly not-rendered `..versionadded:: 1.10` [in the `out` parameter description here](https://docs.scipy.org/doc/numpy/reference/ufuncs.html#optional-keyword-arguments).