### PR TITLE
MAINT: Remove python <2.7,<3.3 string/unicode workarounds

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -9,15 +9,15 @@ from __future__ import division, absolute_import, print_function
 import re
 import sys
 
-from numpy.compat import asbytes, basestring
+from numpy.compat import basestring
 from .multiarray import dtype, array, ndarray
 import ctypes
 from .numerictypes import object_
 
 if (sys.byteorder == 'little'):
-    _nbo = asbytes('<')
+    _nbo = b'<'
 else:
-    _nbo = asbytes('>')
+    _nbo = b'>'
 
 def _makenames_list(adict, align):
     allfields = []
@@ -136,17 +136,16 @@ def _reconstruct(subtype, shape, dtype):
 
 # format_re was originally from numarray by J. Todd Miller
 
-format_re = re.compile(asbytes(
-                           r'(?P<order1>[<>|=]?)'
-                           r'(?P<repeats> *[(]?[ ,0-9L]*[)]? *)'
-                           r'(?P<order2>[<>|=]?)'
-                           r'(?P<dtype>[A-Za-z0-9.?]*(?:\[[a-zA-Z0-9,.]+\])?)'))
-sep_re = re.compile(asbytes(r'\s*,\s*'))
-space_re = re.compile(asbytes(r'\s+$'))
+format_re = re.compile(br'(?P<order1>[<>|=]?)'
+                       br'(?P<repeats> *[(]?[ ,0-9L]*[)]? *)'
+                       br'(?P<order2>[<>|=]?)'
+                       br'(?P<dtype>[A-Za-z0-9.?]*(?:\[[a-zA-Z0-9,.]+\])?)')
+sep_re = re.compile(br'\s*,\s*')
+space_re = re.compile(br'\s+$')
 
 # astr is a string (perhaps comma separated)
 
-_convorder = {asbytes('='): _nbo}
+_convorder = {b'=': _nbo}
 
 def _commastring(astr):
     startindex = 0
@@ -171,9 +170,9 @@ def _commastring(astr):
                         (len(result)+1, astr))
                 startindex = mo.end()
 
-        if order2 == asbytes(''):
+        if order2 == b'':
             order = order1
-        elif order1 == asbytes(''):
+        elif order1 == b'':
             order = order2
         else:
             order1 = _convorder.get(order1, order1)
@@ -184,10 +183,10 @@ def _commastring(astr):
                     (order1, order2))
             order = order1
 
-        if order in [asbytes('|'), asbytes('='), _nbo]:
-            order = asbytes('')
+        if order in [b'|', b'=', _nbo]:
+            order = b''
         dtype = order + dtype
-        if (repeats == asbytes('')):
+        if (repeats == b''):
             newitem = dtype
         else:
             newitem = (dtype, eval(repeats))

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -248,7 +248,7 @@ class memmap(ndarray):
 
         if mode == 'w+' or (mode == 'r+' and flen < bytes):
             fid.seek(bytes - 1, 0)
-            fid.write(np.compat.asbytes('\0'))
+            fid.write(b'\0')
             fid.flush()
 
         if mode == 'c':

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 import numpy as np
-from numpy.compat import sixu
 from numpy.testing import (
      run_module_suite, assert_, assert_equal, assert_array_equal,
      assert_raises, HAS_REFCOUNT
@@ -248,7 +247,7 @@ def test_array_astype():
     b = a.astype('S')
     assert_equal(a, b)
     assert_equal(b.dtype, np.dtype('S100'))
-    a = np.array([sixu('a')*100], dtype='O')
+    a = np.array([u'a'*100], dtype='O')
     b = a.astype('U')
     assert_equal(a, b)
     assert_equal(b.dtype, np.dtype('U100'))
@@ -258,7 +257,7 @@ def test_array_astype():
     b = a.astype('S')
     assert_equal(a, b)
     assert_equal(b.dtype, np.dtype('S10'))
-    a = np.array([sixu('a')*10], dtype='O')
+    a = np.array([u'a'*10], dtype='O')
     b = a.astype('U')
     assert_equal(a, b)
     assert_equal(b.dtype, np.dtype('U10'))
@@ -266,19 +265,19 @@ def test_array_astype():
     a = np.array(123456789012345678901234567890, dtype='O').astype('S')
     assert_array_equal(a, np.array(b'1234567890' * 3, dtype='S30'))
     a = np.array(123456789012345678901234567890, dtype='O').astype('U')
-    assert_array_equal(a, np.array(sixu('1234567890' * 3), dtype='U30'))
+    assert_array_equal(a, np.array(u'1234567890' * 3, dtype='U30'))
 
     a = np.array([123456789012345678901234567890], dtype='O').astype('S')
     assert_array_equal(a, np.array(b'1234567890' * 3, dtype='S30'))
     a = np.array([123456789012345678901234567890], dtype='O').astype('U')
-    assert_array_equal(a, np.array(sixu('1234567890' * 3), dtype='U30'))
+    assert_array_equal(a, np.array(u'1234567890' * 3, dtype='U30'))
 
     a = np.array(123456789012345678901234567890, dtype='S')
     assert_array_equal(a, np.array(b'1234567890' * 3, dtype='S30'))
     a = np.array(123456789012345678901234567890, dtype='U')
-    assert_array_equal(a, np.array(sixu('1234567890' * 3), dtype='U30'))
+    assert_array_equal(a, np.array(u'1234567890' * 3, dtype='U30'))
 
-    a = np.array(sixu('a\u0140'), dtype='U')
+    a = np.array(u'a\u0140', dtype='U')
     b = np.ndarray(buffer=a, dtype='uint32', shape=2)
     assert_(b.size == 2)
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -4,7 +4,6 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 import numpy as np
-from numpy.compat import sixu
 from numpy.testing import (
      TestCase, run_module_suite, assert_, assert_equal
 )
@@ -223,7 +222,7 @@ def test_unicode_object_array():
         expected = "array(['é'], dtype=object)"
     else:
         expected = "array([u'\\xe9'], dtype=object)"
-    x = np.array([sixu('\xe9')], dtype=object)
+    x = np.array([u'\xe9'], dtype=object)
     assert_equal(repr(x), expected)
 
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -5,7 +5,6 @@ import pickle
 import numpy
 import numpy as np
 import datetime
-from numpy.compat import asbytes
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_warns, dec, suppress_warnings
@@ -586,18 +585,18 @@ class TestDateTime(TestCase):
         assert_equal(pickle.loads(pickle.dumps(dt)), dt)
 
         # Check that loading pickles from 1.6 works
-        pkl = "cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \
-              "(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'D'\np6\n" + \
-              "I7\nI1\nI1\ntp7\ntp8\ntp9\nb."
-        assert_equal(pickle.loads(asbytes(pkl)), np.dtype('<M8[7D]'))
-        pkl = "cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \
-              "(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'W'\np6\n" + \
-              "I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
-        assert_equal(pickle.loads(asbytes(pkl)), np.dtype('<M8[W]'))
-        pkl = "cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \
-              "(I4\nS'>'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'us'\np6\n" + \
-              "I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
-        assert_equal(pickle.loads(asbytes(pkl)), np.dtype('>M8[us]'))
+        pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \
+              b"(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'D'\np6\n" + \
+              b"I7\nI1\nI1\ntp7\ntp8\ntp9\nb."
+        assert_equal(pickle.loads(pkl), np.dtype('<M8[7D]'))
+        pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \
+              b"(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'W'\np6\n" + \
+              b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
+        assert_equal(pickle.loads(pkl), np.dtype('<M8[W]'))
+        pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \
+              b"(I4\nS'>'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'us'\np6\n" + \
+              b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
+        assert_equal(pickle.loads(pkl), np.dtype('>M8[us]'))
 
     def test_setstate(self):
         "Verify that datetime dtype __setstate__ can handle bad arguments"

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -4,7 +4,6 @@ import sys
 
 import numpy as np
 from numpy.core.multiarray import _vec_string
-from numpy.compat import sixu
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal
 )
@@ -22,12 +21,12 @@ class TestBasic(TestCase):
                                [b'long', b'0123456789']])
 
     def test_from_object_array_unicode(self):
-        A = np.array([['abc', sixu('Sigma \u03a3')],
+        A = np.array([['abc', u'Sigma \u03a3'],
                       ['long   ', '0123456789']], dtype='O')
         self.assertRaises(ValueError, np.char.array, (A,))
         B = np.char.array(A, **kw_unicode_true)
         assert_equal(B.dtype.itemsize, 10 * np.array('a', 'U').dtype.itemsize)
-        assert_array_equal(B, [['abc', sixu('Sigma \u03a3')],
+        assert_array_equal(B, [['abc', u'Sigma \u03a3'],
                                ['long', '0123456789']])
 
     def test_from_string_array(self):
@@ -48,7 +47,7 @@ class TestBasic(TestCase):
         assert_(C[0, 0] == A[0, 0])
 
     def test_from_unicode_array(self):
-        A = np.array([['abc', sixu('Sigma \u03a3')],
+        A = np.array([['abc', u'Sigma \u03a3'],
                       ['long   ', '0123456789']])
         assert_equal(A.dtype.type, np.unicode_)
         B = np.char.array(A)
@@ -67,7 +66,7 @@ class TestBasic(TestCase):
 
     def test_unicode_upconvert(self):
         A = np.char.array(['abc'])
-        B = np.char.array([sixu('\u03a3')])
+        B = np.char.array([u'\u03a3'])
         assert_(issubclass((A + B).dtype.type, np.unicode_))
 
     def test_from_string(self):
@@ -77,7 +76,7 @@ class TestBasic(TestCase):
         assert_(issubclass(A.dtype.type, np.string_))
 
     def test_from_unicode(self):
-        A = np.char.array(sixu('\u03a3'))
+        A = np.char.array(u'\u03a3')
         assert_equal(len(A), 1)
         assert_equal(len(A[0]), 1)
         assert_equal(A.itemsize, 4)
@@ -203,9 +202,9 @@ class TestInformation(TestCase):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']]).view(np.chararray)
-        self.B = np.array([[sixu(' \u03a3 '), sixu('')],
-                           [sixu('12345'), sixu('MixedCase')],
-                           [sixu('123 \t 345 \0 '), sixu('UPPER')]]).view(np.chararray)
+        self.B = np.array([[u' \u03a3 ', u''],
+                           [u'12345', u'MixedCase'],
+                           [u'123 \t 345 \0 ', u'UPPER']]).view(np.chararray)
 
     def test_len(self):
         assert_(issubclass(np.char.str_len(self.A).dtype.type, np.integer))
@@ -310,9 +309,9 @@ class TestMethods(TestCase):
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']],
                           dtype='S').view(np.chararray)
-        self.B = np.array([[sixu(' \u03a3 '), sixu('')],
-                           [sixu('12345'), sixu('MixedCase')],
-                           [sixu('123 \t 345 \0 '), sixu('UPPER')]]).view(np.chararray)
+        self.B = np.array([[u' \u03a3 ', u''],
+                           [u'12345', u'MixedCase'],
+                           [u'123 \t 345 \0 ', u'UPPER']]).view(np.chararray)
 
     def test_capitalize(self):
         tgt = [[b' abc ', b''],
@@ -321,7 +320,7 @@ class TestMethods(TestCase):
         assert_(issubclass(self.A.capitalize().dtype.type, np.string_))
         assert_array_equal(self.A.capitalize(), tgt)
 
-        tgt = [[sixu(' \u03c3 '), ''],
+        tgt = [[u' \u03c3 ', ''],
                ['12345', 'Mixedcase'],
                ['123 \t 345 \0 ', 'Upper']]
         assert_(issubclass(self.B.capitalize().dtype.type, np.unicode_))
@@ -400,9 +399,9 @@ class TestMethods(TestCase):
         assert_(issubclass(self.A.lower().dtype.type, np.string_))
         assert_array_equal(self.A.lower(), tgt)
 
-        tgt = [[sixu(' \u03c3 '), sixu('')],
-               [sixu('12345'), sixu('mixedcase')],
-               [sixu('123 \t 345 \0 '), sixu('upper')]]
+        tgt = [[u' \u03c3 ', u''],
+               [u'12345', u'mixedcase'],
+               [u'123 \t 345 \0 ', u'upper']]
         assert_(issubclass(self.B.lower().dtype.type, np.unicode_))
         assert_array_equal(self.B.lower(), tgt)
 
@@ -418,7 +417,7 @@ class TestMethods(TestCase):
                [b'23 \t 345 \x00', b'UPPER']]
         assert_array_equal(self.A.lstrip([b'1', b'M']), tgt)
 
-        tgt = [[sixu('\u03a3 '), ''],
+        tgt = [[u'\u03a3 ', ''],
                ['12345', 'MixedCase'],
                ['123 \t 345 \0 ', 'UPPER']]
         assert_(issubclass(self.B.lstrip().dtype.type, np.unicode_))
@@ -443,9 +442,9 @@ class TestMethods(TestCase):
 
         if sys.version_info[0] < 3:
             # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
-            R = self.A.replace(b'a', sixu('\u03a3'))
-            tgt = [[sixu(' \u03a3bc '), ''],
-                   ['12345', sixu('MixedC\u03a3se')],
+            R = self.A.replace(b'a', u'\u03a3')
+            tgt = [[u' \u03a3bc ', ''],
+                   ['12345', u'MixedC\u03a3se'],
                    ['123 \t 345 \x00', 'UPPER']]
             assert_(issubclass(R.dtype.type, np.unicode_))
             assert_array_equal(R, tgt)
@@ -497,7 +496,7 @@ class TestMethods(TestCase):
                ]
         assert_array_equal(self.A.rstrip([b'5', b'ER']), tgt)
 
-        tgt = [[sixu(' \u03a3'), ''],
+        tgt = [[u' \u03a3', ''],
                ['12345', 'MixedCase'],
                ['123 \t 345', 'UPPER']]
         assert_(issubclass(self.B.rstrip().dtype.type, np.unicode_))
@@ -515,7 +514,7 @@ class TestMethods(TestCase):
                [b'23 \t 345 \x00', b'UPP']]
         assert_array_equal(self.A.strip([b'15', b'EReM']), tgt)
 
-        tgt = [[sixu('\u03a3'), ''],
+        tgt = [[u'\u03a3', ''],
                ['12345', 'MixedCase'],
                ['123 \t 345', 'UPPER']]
         assert_(issubclass(self.B.strip().dtype.type, np.unicode_))
@@ -543,9 +542,9 @@ class TestMethods(TestCase):
         assert_(issubclass(self.A.swapcase().dtype.type, np.string_))
         assert_array_equal(self.A.swapcase(), tgt)
 
-        tgt = [[sixu(' \u03c3 '), sixu('')],
-               [sixu('12345'), sixu('mIXEDcASE')],
-               [sixu('123 \t 345 \0 '), sixu('upper')]]
+        tgt = [[u' \u03c3 ', u''],
+               [u'12345', u'mIXEDcASE'],
+               [u'123 \t 345 \0 ', u'upper']]
         assert_(issubclass(self.B.swapcase().dtype.type, np.unicode_))
         assert_array_equal(self.B.swapcase(), tgt)
 
@@ -556,9 +555,9 @@ class TestMethods(TestCase):
         assert_(issubclass(self.A.title().dtype.type, np.string_))
         assert_array_equal(self.A.title(), tgt)
 
-        tgt = [[sixu(' \u03a3 '), sixu('')],
-               [sixu('12345'), sixu('Mixedcase')],
-               [sixu('123 \t 345 \0 '), sixu('Upper')]]
+        tgt = [[u' \u03a3 ', u''],
+               [u'12345', u'Mixedcase'],
+               [u'123 \t 345 \0 ', u'Upper']]
         assert_(issubclass(self.B.title().dtype.type, np.unicode_))
         assert_array_equal(self.B.title(), tgt)
 
@@ -569,9 +568,9 @@ class TestMethods(TestCase):
         assert_(issubclass(self.A.upper().dtype.type, np.string_))
         assert_array_equal(self.A.upper(), tgt)
 
-        tgt = [[sixu(' \u03a3 '), sixu('')],
-               [sixu('12345'), sixu('MIXEDCASE')],
-               [sixu('123 \t 345 \0 '), sixu('UPPER')]]
+        tgt = [[u' \u03a3 ', u''],
+               [u'12345', u'MIXEDCASE'],
+               [u'123 \t 345 \0 ', u'UPPER']]
         assert_(issubclass(self.B.upper().dtype.type, np.unicode_))
         assert_array_equal(self.B.upper(), tgt)
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -71,7 +71,7 @@ class TestBasic(TestCase):
         assert_(issubclass((A + B).dtype.type, np.unicode_))
 
     def test_from_string(self):
-        A = np.char.array(asbytes('abc'))
+        A = np.char.array(b'abc')
         assert_equal(len(A), 1)
         assert_equal(len(A[0]), 3)
         assert_(issubclass(A.dtype.type, np.string_))
@@ -155,7 +155,7 @@ class TestChar(TestCase):
 
     def test_it(self):
         assert_equal(self.A.shape, (4,))
-        assert_equal(self.A.upper()[:2].tobytes(), asbytes('AB'))
+        assert_equal(self.A.upper()[:2].tobytes(), b'AB')
 
 class TestComparisons(TestCase):
     def setUp(self):
@@ -332,11 +332,11 @@ class TestMethods(TestCase):
         C = self.A.center([10, 20])
         assert_array_equal(np.char.str_len(C), [[10, 20], [10, 20], [12, 20]])
 
-        C = self.A.center(20, asbytes('#'))
-        assert_(np.all(C.startswith(asbytes('#'))))
-        assert_(np.all(C.endswith(asbytes('#'))))
+        C = self.A.center(20, b'#')
+        assert_(np.all(C.startswith(b'#')))
+        assert_(np.all(C.endswith(b'#')))
 
-        C = np.char.center(asbytes('FOO'), [[10, 20], [15, 8]])
+        C = np.char.center(b'FOO', [[10, 20], [15, 8]])
         tgt = asbytes_nested([['   FOO    ', '        FOO         '],
                               ['      FOO      ', '  FOO   ']])
         assert_(issubclass(C.dtype.type, np.string_))
@@ -344,7 +344,7 @@ class TestMethods(TestCase):
 
     def test_decode(self):
         if sys.version_info[0] >= 3:
-            A = np.char.array([asbytes('\\u03a3')])
+            A = np.char.array([b'\\u03a3'])
             assert_(A.decode('unicode-escape')[0] == '\u03a3')
         else:
             A = np.char.array(['736563726574206d657373616765'])
@@ -356,7 +356,7 @@ class TestMethods(TestCase):
 
     def test_expandtabs(self):
         T = self.A.expandtabs()
-        assert_(T[2, 0] == asbytes('123      345 \0'))
+        assert_(T[2, 0] == b'123      345 \0')
 
     def test_join(self):
         if sys.version_info[0] >= 3:
@@ -382,12 +382,12 @@ class TestMethods(TestCase):
         C = self.A.ljust([10, 20])
         assert_array_equal(np.char.str_len(C), [[10, 20], [10, 20], [12, 20]])
 
-        C = self.A.ljust(20, asbytes('#'))
-        assert_array_equal(C.startswith(asbytes('#')), [
+        C = self.A.ljust(20, b'#')
+        assert_array_equal(C.startswith(b'#'), [
                 [False, True], [False, False], [False, False]])
-        assert_(np.all(C.endswith(asbytes('#'))))
+        assert_(np.all(C.endswith(b'#')))
 
-        C = np.char.ljust(asbytes('FOO'), [[10, 20], [15, 8]])
+        C = np.char.ljust(b'FOO', [[10, 20], [15, 8]])
         tgt = asbytes_nested([['FOO       ', 'FOO                 '],
                               ['FOO            ', 'FOO     ']])
         assert_(issubclass(C.dtype.type, np.string_))
@@ -443,7 +443,7 @@ class TestMethods(TestCase):
 
         if sys.version_info[0] < 3:
             # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
-            R = self.A.replace(asbytes('a'), sixu('\u03a3'))
+            R = self.A.replace(b'a', sixu('\u03a3'))
             tgt = [[sixu(' \u03a3bc '), ''],
                    ['12345', sixu('MixedC\u03a3se')],
                    ['123 \t 345 \x00', 'UPPER']]
@@ -456,12 +456,12 @@ class TestMethods(TestCase):
         C = self.A.rjust([10, 20])
         assert_array_equal(np.char.str_len(C), [[10, 20], [10, 20], [12, 20]])
 
-        C = self.A.rjust(20, asbytes('#'))
-        assert_(np.all(C.startswith(asbytes('#'))))
-        assert_array_equal(C.endswith(asbytes('#')),
+        C = self.A.rjust(20, b'#')
+        assert_(np.all(C.startswith(b'#')))
+        assert_array_equal(C.endswith(b'#'),
                            [[False, True], [False, False], [False, False]])
 
-        C = np.char.rjust(asbytes('FOO'), [[10, 20], [15, 8]])
+        C = np.char.rjust(b'FOO', [[10, 20], [15, 8]])
         tgt = asbytes_nested([['       FOO', '                 FOO'],
                               ['            FOO', '     FOO']])
         assert_(issubclass(C.dtype.type, np.string_))
@@ -476,7 +476,7 @@ class TestMethods(TestCase):
         assert_array_equal(P, tgt)
 
     def test_rsplit(self):
-        A = self.A.rsplit(asbytes('3'))
+        A = self.A.rsplit(b'3')
         tgt = asbytes_nested([[[' abc '], ['']],
                               [['12', '45'], ['MixedCase']],
                               [['12', ' \t ', '45 \x00 '], ['UPPER']]])
@@ -522,7 +522,7 @@ class TestMethods(TestCase):
         assert_array_equal(self.B.strip(), tgt)
 
     def test_split(self):
-        A = self.A.split(asbytes('3'))
+        A = self.A.split(b'3')
         tgt = asbytes_nested([
                               [[' abc '], ['']],
                               [['12', '45'], ['MixedCase']],
@@ -688,7 +688,7 @@ class TestOperations(TestCase):
         assert_(sl2.base is arr)
         assert_(sl2.base.base is arr.base)
 
-        assert_(arr[0, 0] == asbytes('abc'))
+        assert_(arr[0, 0] == b'abc')
 
 
 def test_empty_indexing():

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -4,7 +4,7 @@ import sys
 
 import numpy as np
 from numpy.core.multiarray import _vec_string
-from numpy.compat import asbytes, asbytes_nested, sixu
+from numpy.compat import sixu
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal
 )
@@ -18,8 +18,8 @@ class TestBasic(TestCase):
                       ['long   ', '0123456789']], dtype='O')
         B = np.char.array(A)
         assert_equal(B.dtype.itemsize, 10)
-        assert_array_equal(B, asbytes_nested([['abc', '2'],
-                                              ['long', '0123456789']]))
+        assert_array_equal(B, [[b'abc', b'2'],
+                               [b'long', b'0123456789']])
 
     def test_from_object_array_unicode(self):
         A = np.array([['abc', sixu('Sigma \u03a3')],
@@ -31,8 +31,8 @@ class TestBasic(TestCase):
                                ['long', '0123456789']])
 
     def test_from_string_array(self):
-        A = np.array(asbytes_nested([['abc', 'foo'],
-                                     ['long   ', '0123456789']]))
+        A = np.array([[b'abc', b'foo'],
+                      [b'long   ', b'0123456789']])
         assert_equal(A.dtype.type, np.string_)
         B = np.char.array(A)
         assert_array_equal(B, A)
@@ -315,9 +315,9 @@ class TestMethods(TestCase):
                            [sixu('123 \t 345 \0 '), sixu('UPPER')]]).view(np.chararray)
 
     def test_capitalize(self):
-        tgt = asbytes_nested([[' abc ', ''],
-                              ['12345', 'Mixedcase'],
-                              ['123 \t 345 \0 ', 'Upper']])
+        tgt = [[b' abc ', b''],
+               [b'12345', b'Mixedcase'],
+               [b'123 \t 345 \0 ', b'Upper']]
         assert_(issubclass(self.A.capitalize().dtype.type, np.string_))
         assert_array_equal(self.A.capitalize(), tgt)
 
@@ -337,8 +337,8 @@ class TestMethods(TestCase):
         assert_(np.all(C.endswith(b'#')))
 
         C = np.char.center(b'FOO', [[10, 20], [15, 8]])
-        tgt = asbytes_nested([['   FOO    ', '        FOO         '],
-                              ['      FOO      ', '  FOO   ']])
+        tgt = [[b'   FOO    ', b'        FOO         '],
+               [b'      FOO      ', b'  FOO   ']]
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
@@ -388,15 +388,15 @@ class TestMethods(TestCase):
         assert_(np.all(C.endswith(b'#')))
 
         C = np.char.ljust(b'FOO', [[10, 20], [15, 8]])
-        tgt = asbytes_nested([['FOO       ', 'FOO                 '],
-                              ['FOO            ', 'FOO     ']])
+        tgt = [[b'FOO       ', b'FOO                 '],
+               [b'FOO            ', b'FOO     ']]
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
     def test_lower(self):
-        tgt = asbytes_nested([[' abc ', ''],
-                              ['12345', 'mixedcase'],
-                              ['123 \t 345 \0 ', 'upper']])
+        tgt = [[b' abc ', b''],
+               [b'12345', b'mixedcase'],
+               [b'123 \t 345 \0 ', b'upper']]
         assert_(issubclass(self.A.lower().dtype.type, np.string_))
         assert_array_equal(self.A.lower(), tgt)
 
@@ -407,16 +407,16 @@ class TestMethods(TestCase):
         assert_array_equal(self.B.lower(), tgt)
 
     def test_lstrip(self):
-        tgt = asbytes_nested([['abc ', ''],
-                              ['12345', 'MixedCase'],
-                              ['123 \t 345 \0 ', 'UPPER']])
+        tgt = [[b'abc ', b''],
+               [b'12345', b'MixedCase'],
+               [b'123 \t 345 \0 ', b'UPPER']]
         assert_(issubclass(self.A.lstrip().dtype.type, np.string_))
         assert_array_equal(self.A.lstrip(), tgt)
 
-        tgt = asbytes_nested([[' abc', ''],
-                              ['2345', 'ixedCase'],
-                              ['23 \t 345 \x00', 'UPPER']])
-        assert_array_equal(self.A.lstrip(asbytes_nested(['1', 'M'])), tgt)
+        tgt = [[b' abc', b''],
+               [b'2345', b'ixedCase'],
+               [b'23 \t 345 \x00', b'UPPER']]
+        assert_array_equal(self.A.lstrip([b'1', b'M']), tgt)
 
         tgt = [[sixu('\u03a3 '), ''],
                ['12345', 'MixedCase'],
@@ -425,19 +425,19 @@ class TestMethods(TestCase):
         assert_array_equal(self.B.lstrip(), tgt)
 
     def test_partition(self):
-        P = self.A.partition(asbytes_nested(['3', 'M']))
-        tgt = asbytes_nested([[(' abc ', '', ''), ('', '', '')],
-                             [('12', '3', '45'), ('', 'M', 'ixedCase')],
-                             [('12', '3', ' \t 345 \0 '), ('UPPER', '', '')]])
+        P = self.A.partition([b'3', b'M'])
+        tgt = [[(b' abc ', b'', b''), (b'', b'', b'')],
+               [(b'12', b'3', b'45'), (b'', b'M', b'ixedCase')],
+               [(b'12', b'3', b' \t 345 \0 '), (b'UPPER', b'', b'')]]
         assert_(issubclass(P.dtype.type, np.string_))
         assert_array_equal(P, tgt)
 
     def test_replace(self):
-        R = self.A.replace(asbytes_nested(['3', 'a']),
-                           asbytes_nested(['##########', '@']))
-        tgt = asbytes_nested([[' abc ', ''],
-                              ['12##########45', 'MixedC@se'],
-                              ['12########## \t ##########45 \x00', 'UPPER']])
+        R = self.A.replace([b'3', b'a'],
+                           [b'##########', b'@'])
+        tgt = [[b' abc ', b''],
+               [b'12##########45', b'MixedC@se'],
+               [b'12########## \t ##########45 \x00', b'UPPER']]
         assert_(issubclass(R.dtype.type, np.string_))
         assert_array_equal(R, tgt)
 
@@ -462,40 +462,40 @@ class TestMethods(TestCase):
                            [[False, True], [False, False], [False, False]])
 
         C = np.char.rjust(b'FOO', [[10, 20], [15, 8]])
-        tgt = asbytes_nested([['       FOO', '                 FOO'],
-                              ['            FOO', '     FOO']])
+        tgt = [[b'       FOO', b'                 FOO'],
+               [b'            FOO', b'     FOO']]
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
     def test_rpartition(self):
-        P = self.A.rpartition(asbytes_nested(['3', 'M']))
-        tgt = asbytes_nested([[('', '', ' abc '), ('', '', '')],
-                              [('12', '3', '45'), ('', 'M', 'ixedCase')],
-                              [('123 \t ', '3', '45 \0 '), ('', '', 'UPPER')]])
+        P = self.A.rpartition([b'3', b'M'])
+        tgt = [[(b'', b'', b' abc '), (b'', b'', b'')],
+               [(b'12', b'3', b'45'), (b'', b'M', b'ixedCase')],
+               [(b'123 \t ', b'3', b'45 \0 '), (b'', b'', b'UPPER')]]
         assert_(issubclass(P.dtype.type, np.string_))
         assert_array_equal(P, tgt)
 
     def test_rsplit(self):
         A = self.A.rsplit(b'3')
-        tgt = asbytes_nested([[[' abc '], ['']],
-                              [['12', '45'], ['MixedCase']],
-                              [['12', ' \t ', '45 \x00 '], ['UPPER']]])
+        tgt = [[[b' abc '], [b'']],
+               [[b'12', b'45'], [b'MixedCase']],
+               [[b'12', b' \t ', b'45 \x00 '], [b'UPPER']]]
         assert_(issubclass(A.dtype.type, np.object_))
         assert_equal(A.tolist(), tgt)
 
     def test_rstrip(self):
         assert_(issubclass(self.A.rstrip().dtype.type, np.string_))
 
-        tgt = asbytes_nested([[' abc', ''],
-                              ['12345', 'MixedCase'],
-                              ['123 \t 345', 'UPPER']])
+        tgt = [[b' abc', b''],
+               [b'12345', b'MixedCase'],
+               [b'123 \t 345', b'UPPER']]
         assert_array_equal(self.A.rstrip(), tgt)
 
-        tgt = asbytes_nested([[' abc ', ''],
-                              ['1234', 'MixedCase'],
-                              ['123 \t 345 \x00', 'UPP']
-                              ])
-        assert_array_equal(self.A.rstrip(asbytes_nested(['5', 'ER'])), tgt)
+        tgt = [[b' abc ', b''],
+               [b'1234', b'MixedCase'],
+               [b'123 \t 345 \x00', b'UPP']
+               ]
+        assert_array_equal(self.A.rstrip([b'5', b'ER']), tgt)
 
         tgt = [[sixu(' \u03a3'), ''],
                ['12345', 'MixedCase'],
@@ -504,16 +504,16 @@ class TestMethods(TestCase):
         assert_array_equal(self.B.rstrip(), tgt)
 
     def test_strip(self):
-        tgt = asbytes_nested([['abc', ''],
-                              ['12345', 'MixedCase'],
-                              ['123 \t 345', 'UPPER']])
+        tgt = [[b'abc', b''],
+               [b'12345', b'MixedCase'],
+               [b'123 \t 345', b'UPPER']]
         assert_(issubclass(self.A.strip().dtype.type, np.string_))
         assert_array_equal(self.A.strip(), tgt)
 
-        tgt = asbytes_nested([[' abc ', ''],
-                              ['234', 'ixedCas'],
-                              ['23 \t 345 \x00', 'UPP']])
-        assert_array_equal(self.A.strip(asbytes_nested(['15', 'EReM'])), tgt)
+        tgt = [[b' abc ', b''],
+               [b'234', b'ixedCas'],
+               [b'23 \t 345 \x00', b'UPP']]
+        assert_array_equal(self.A.strip([b'15', b'EReM']), tgt)
 
         tgt = [[sixu('\u03a3'), ''],
                ['12345', 'MixedCase'],
@@ -523,10 +523,10 @@ class TestMethods(TestCase):
 
     def test_split(self):
         A = self.A.split(b'3')
-        tgt = asbytes_nested([
-                              [[' abc '], ['']],
-                              [['12', '45'], ['MixedCase']],
-                              [['12', ' \t ', '45 \x00 '], ['UPPER']]])
+        tgt = [
+               [[b' abc '], [b'']],
+               [[b'12', b'45'], [b'MixedCase']],
+               [[b'12', b' \t ', b'45 \x00 '], [b'UPPER']]]
         assert_(issubclass(A.dtype.type, np.object_))
         assert_equal(A.tolist(), tgt)
 
@@ -537,9 +537,9 @@ class TestMethods(TestCase):
         assert_(len(A[0]) == 3)
 
     def test_swapcase(self):
-        tgt = asbytes_nested([[' ABC ', ''],
-                              ['12345', 'mIXEDcASE'],
-                              ['123 \t 345 \0 ', 'upper']])
+        tgt = [[b' ABC ', b''],
+               [b'12345', b'mIXEDcASE'],
+               [b'123 \t 345 \0 ', b'upper']]
         assert_(issubclass(self.A.swapcase().dtype.type, np.string_))
         assert_array_equal(self.A.swapcase(), tgt)
 
@@ -550,9 +550,9 @@ class TestMethods(TestCase):
         assert_array_equal(self.B.swapcase(), tgt)
 
     def test_title(self):
-        tgt = asbytes_nested([[' Abc ', ''],
-                              ['12345', 'Mixedcase'],
-                              ['123 \t 345 \0 ', 'Upper']])
+        tgt = [[b' Abc ', b''],
+               [b'12345', b'Mixedcase'],
+               [b'123 \t 345 \0 ', b'Upper']]
         assert_(issubclass(self.A.title().dtype.type, np.string_))
         assert_array_equal(self.A.title(), tgt)
 
@@ -563,9 +563,9 @@ class TestMethods(TestCase):
         assert_array_equal(self.B.title(), tgt)
 
     def test_upper(self):
-        tgt = asbytes_nested([[' ABC ', ''],
-                              ['12345', 'MIXEDCASE'],
-                              ['123 \t 345 \0 ', 'UPPER']])
+        tgt = [[b' ABC ', b''],
+               [b'12345', b'MIXEDCASE'],
+               [b'123 \t 345 \0 ', b'UPPER']]
         assert_(issubclass(self.A.upper().dtype.type, np.string_))
         assert_array_equal(self.A.upper(), tgt)
 

--- a/numpy/core/tests/test_longdouble.py
+++ b/numpy/core/tests/test_longdouble.py
@@ -7,7 +7,6 @@ from numpy.testing import (
     run_module_suite, assert_, assert_equal, dec, assert_raises,
     assert_array_equal, TestCase, temppath,
 )
-from numpy.compat import sixu
 from test_print import in_foreign_locale
 
 LD_INFO = np.finfo(np.longdouble)
@@ -40,7 +39,7 @@ def test_repr_roundtrip():
 
 
 def test_unicode():
-    np.longdouble(sixu("1.2"))
+    np.longdouble(u"1.2")
 
 
 def test_string():

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4310,7 +4310,7 @@ class TestRecord(TestCase):
     else:
         def test_unicode_field_titles(self):
             # Unicode field titles are added to field dict on Py2
-            title = unicode('b')
+            title = u'b'
             dt = np.dtype([((title, 'a'), int)])
             dt[title]
             dt['a']
@@ -4323,7 +4323,7 @@ class TestRecord(TestCase):
 
         def test_unicode_field_names(self):
             # Unicode field names are not allowed on Py2
-            title = unicode('b')
+            title = u'b'
             assert_raises(TypeError, np.dtype, [(title, int)])
             assert_raises(TypeError, np.dtype, [(('a', title), int)])
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 
 
 import numpy as np
-from numpy.compat import getexception, strchar, unicode
+from numpy.compat import strchar, unicode
 from test_print import in_foreign_locale
 from numpy.core.multiarray_tests import (
     test_neighborhood_iterator, test_neighborhood_iterator_oob,
@@ -208,8 +208,8 @@ class TestAttributes(TestCase):
             try:
                 r = np.ndarray([size], dtype=int, buffer=x,
                                offset=offset*x.itemsize)
-            except:
-                raise RuntimeError(getexception())
+            except Exception as e:
+                raise RuntimeError(e)
             r.strides = strides = strides*x.itemsize
             return r
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 
 
 import numpy as np
-from numpy.compat import getexception, strchar, unicode, sixu
+from numpy.compat import getexception, strchar, unicode
 from test_print import in_foreign_locale
 from numpy.core.multiarray_tests import (
     test_neighborhood_iterator, test_neighborhood_iterator_oob,
@@ -3278,8 +3278,8 @@ class TestStringCompare(TestCase):
         assert_array_equal(g1 >= g2, [x >= g2 for x in g1])
 
     def test_unicode(self):
-        g1 = np.array([sixu("This"), sixu("is"), sixu("example")])
-        g2 = np.array([sixu("This"), sixu("was"), sixu("example")])
+        g1 = np.array([u"This", u"is", u"example"])
+        g2 = np.array([u"This", u"was", u"example"])
         assert_array_equal(g1 == g2, [g1[i] == g2[i] for i in [0, 1, 2]])
         assert_array_equal(g1 != g2, [g1[i] != g2[i] for i in [0, 1, 2]])
         assert_array_equal(g1 <= g2, [g1[i] <= g2[i] for i in [0, 1, 2]])
@@ -4387,8 +4387,8 @@ class TestRecord(TestCase):
             raise SkipTest('non ascii unicode field indexing skipped; '
                            'raises segfault on python 2.x')
         else:
-            assert_raises(ValueError, a.__setitem__, sixu('\u03e0'), 1)
-            assert_raises(ValueError, a.__getitem__, sixu('\u03e0'))
+            assert_raises(ValueError, a.__setitem__, u'\u03e0', 1)
+            assert_raises(ValueError, a.__getitem__, u'\u03e0')
 
     def test_field_names_deprecation(self):
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 
 
 import numpy as np
-from numpy.compat import asbytes, getexception, strchar, unicode, sixu
+from numpy.compat import getexception, strchar, unicode, sixu
 from test_print import in_foreign_locale
 from numpy.core.multiarray_tests import (
     test_neighborhood_iterator, test_neighborhood_iterator_oob,
@@ -3159,46 +3159,46 @@ class TestPickling(TestCase):
     # version 0 pickles, using protocol=2 to pickle
     # version 0 doesn't have a version field
     def test_version0_int8(self):
-        s = '\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x04\x85cnumpy\ndtype\nq\x04U\x02i1K\x00K\x01\x87Rq\x05(U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x04\x01\x02\x03\x04tb.'
+        s = b'\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x04\x85cnumpy\ndtype\nq\x04U\x02i1K\x00K\x01\x87Rq\x05(U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x04\x01\x02\x03\x04tb.'
         a = np.array([1, 2, 3, 4], dtype=np.int8)
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
     def test_version0_float32(self):
-        s = '\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x04\x85cnumpy\ndtype\nq\x04U\x02f4K\x00K\x01\x87Rq\x05(U\x01<NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x10\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@tb.'
+        s = b'\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x04\x85cnumpy\ndtype\nq\x04U\x02f4K\x00K\x01\x87Rq\x05(U\x01<NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x10\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@tb.'
         a = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
     def test_version0_object(self):
-        s = '\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x02\x85cnumpy\ndtype\nq\x04U\x02O8K\x00K\x01\x87Rq\x05(U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89]q\x06(}q\x07U\x01aK\x01s}q\x08U\x01bK\x02setb.'
+        s = b'\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x02\x85cnumpy\ndtype\nq\x04U\x02O8K\x00K\x01\x87Rq\x05(U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89]q\x06(}q\x07U\x01aK\x01s}q\x08U\x01bK\x02setb.'
         a = np.array([{'a': 1}, {'b': 2}])
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
     # version 1 pickles, using protocol=2 to pickle
     def test_version1_int8(self):
-        s = '\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x01K\x04\x85cnumpy\ndtype\nq\x04U\x02i1K\x00K\x01\x87Rq\x05(K\x01U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x04\x01\x02\x03\x04tb.'
+        s = b'\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x01K\x04\x85cnumpy\ndtype\nq\x04U\x02i1K\x00K\x01\x87Rq\x05(K\x01U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x04\x01\x02\x03\x04tb.'
         a = np.array([1, 2, 3, 4], dtype=np.int8)
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
     def test_version1_float32(self):
-        s = '\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x01K\x04\x85cnumpy\ndtype\nq\x04U\x02f4K\x00K\x01\x87Rq\x05(K\x01U\x01<NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x10\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@tb.'
+        s = b'\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x01K\x04\x85cnumpy\ndtype\nq\x04U\x02f4K\x00K\x01\x87Rq\x05(K\x01U\x01<NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89U\x10\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@tb.'
         a = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
     def test_version1_object(self):
-        s = '\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x01K\x02\x85cnumpy\ndtype\nq\x04U\x02O8K\x00K\x01\x87Rq\x05(K\x01U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89]q\x06(}q\x07U\x01aK\x01s}q\x08U\x01bK\x02setb.'
+        s = b'\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\nndarray\nq\x02K\x00\x85U\x01b\x87Rq\x03(K\x01K\x02\x85cnumpy\ndtype\nq\x04U\x02O8K\x00K\x01\x87Rq\x05(K\x01U\x01|NNJ\xff\xff\xff\xffJ\xff\xff\xff\xfftb\x89]q\x06(}q\x07U\x01aK\x01s}q\x08U\x01bK\x02setb.'
         a = np.array([{'a': 1}, {'b': 2}])
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
     def test_subarray_int_shape(self):
-        s = "cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\np1\n(I0\ntp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n(S'V6'\np8\nI0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nN(S'a'\np12\ng3\ntp13\n(dp14\ng12\n(g7\n(S'V4'\np15\nI0\nI1\ntp16\nRp17\n(I3\nS'|'\np18\n(g7\n(S'i1'\np19\nI0\nI1\ntp20\nRp21\n(I3\nS'|'\np22\nNNNI-1\nI-1\nI0\ntp23\nb(I2\nI2\ntp24\ntp25\nNNI4\nI1\nI0\ntp26\nbI0\ntp27\nsg3\n(g7\n(S'V2'\np28\nI0\nI1\ntp29\nRp30\n(I3\nS'|'\np31\n(g21\nI2\ntp32\nNNI2\nI1\nI0\ntp33\nbI4\ntp34\nsI6\nI1\nI0\ntp35\nbI00\nS'\\x01\\x01\\x01\\x01\\x01\\x02'\np36\ntp37\nb."
+        s = b"cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\np1\n(I0\ntp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n(S'V6'\np8\nI0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nN(S'a'\np12\ng3\ntp13\n(dp14\ng12\n(g7\n(S'V4'\np15\nI0\nI1\ntp16\nRp17\n(I3\nS'|'\np18\n(g7\n(S'i1'\np19\nI0\nI1\ntp20\nRp21\n(I3\nS'|'\np22\nNNNI-1\nI-1\nI0\ntp23\nb(I2\nI2\ntp24\ntp25\nNNI4\nI1\nI0\ntp26\nbI0\ntp27\nsg3\n(g7\n(S'V2'\np28\nI0\nI1\ntp29\nRp30\n(I3\nS'|'\np31\n(g21\nI2\ntp32\nNNI2\nI1\nI0\ntp33\nbI4\ntp34\nsI6\nI1\nI0\ntp35\nbI00\nS'\\x01\\x01\\x01\\x01\\x01\\x02'\np36\ntp37\nb."
         a = np.array([(1, (1, 2))], dtype=[('a', 'i1', (2, 2)), ('b', 'i1', 2)])
-        p = self._loads(asbytes(s))
+        p = self._loads(s)
         assert_equal(a, p)
 
 
@@ -4011,33 +4011,33 @@ class TestIO(object):
             assert_equal(pos, 10, err_msg=err_msg)
 
     def _check_from(self, s, value, **kw):
-        y = np.fromstring(asbytes(s), **kw)
+        y = np.fromstring(s, **kw)
         assert_array_equal(y, value)
 
         f = open(self.filename, 'wb')
-        f.write(asbytes(s))
+        f.write(s)
         f.close()
         y = np.fromfile(self.filename, **kw)
         assert_array_equal(y, value)
 
     def test_nan(self):
         self._check_from(
-            "nan +nan -nan NaN nan(foo) +NaN(BAR) -NAN(q_u_u_x_)",
+            b"nan +nan -nan NaN nan(foo) +NaN(BAR) -NAN(q_u_u_x_)",
             [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
             sep=' ')
 
     def test_inf(self):
         self._check_from(
-            "inf +inf -inf infinity -Infinity iNfInItY -inF",
+            b"inf +inf -inf infinity -Infinity iNfInItY -inF",
             [np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf],
             sep=' ')
 
     def test_numbers(self):
-        self._check_from("1.234 -1.234 .3 .3e55 -123133.1231e+133",
+        self._check_from(b"1.234 -1.234 .3 .3e55 -123133.1231e+133",
                          [1.234, -1.234, .3, .3e55, -123133.1231e+133], sep=' ')
 
     def test_binary(self):
-        self._check_from('\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@',
+        self._check_from(b'\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@',
                          np.array([1, 2, 3, 4]),
                          dtype='<f4')
 
@@ -4067,40 +4067,40 @@ class TestIO(object):
             pass
 
     def test_string(self):
-        self._check_from('1,2,3,4', [1., 2., 3., 4.], sep=',')
+        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], sep=',')
 
     def test_counted_string(self):
-        self._check_from('1,2,3,4', [1., 2., 3., 4.], count=4, sep=',')
-        self._check_from('1,2,3,4', [1., 2., 3.], count=3, sep=',')
-        self._check_from('1,2,3,4', [1., 2., 3., 4.], count=-1, sep=',')
+        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], count=4, sep=',')
+        self._check_from(b'1,2,3,4', [1., 2., 3.], count=3, sep=',')
+        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], count=-1, sep=',')
 
     def test_string_with_ws(self):
-        self._check_from('1 2  3     4   ', [1, 2, 3, 4], dtype=int, sep=' ')
+        self._check_from(b'1 2  3     4   ', [1, 2, 3, 4], dtype=int, sep=' ')
 
     def test_counted_string_with_ws(self):
-        self._check_from('1 2  3     4   ', [1, 2, 3], count=3, dtype=int,
+        self._check_from(b'1 2  3     4   ', [1, 2, 3], count=3, dtype=int,
                          sep=' ')
 
     def test_ascii(self):
-        self._check_from('1 , 2 , 3 , 4', [1., 2., 3., 4.], sep=',')
-        self._check_from('1,2,3,4', [1., 2., 3., 4.], dtype=float, sep=',')
+        self._check_from(b'1 , 2 , 3 , 4', [1., 2., 3., 4.], sep=',')
+        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], dtype=float, sep=',')
 
     def test_malformed(self):
-        self._check_from('1.234 1,234', [1.234, 1.], sep=' ')
+        self._check_from(b'1.234 1,234', [1.234, 1.], sep=' ')
 
     def test_long_sep(self):
-        self._check_from('1_x_3_x_4_x_5', [1, 3, 4, 5], sep='_x_')
+        self._check_from(b'1_x_3_x_4_x_5', [1, 3, 4, 5], sep='_x_')
 
     def test_dtype(self):
         v = np.array([1, 2, 3, 4], dtype=np.int_)
-        self._check_from('1,2,3,4', v, sep=',', dtype=np.int_)
+        self._check_from(b'1,2,3,4', v, sep=',', dtype=np.int_)
 
     def test_dtype_bool(self):
         # can't use _check_from because fromstring can't handle True/False
         v = np.array([True, False, True, False], dtype=np.bool_)
-        s = '1,0,-2.3,0'
+        s = b'1,0,-2.3,0'
         f = open(self.filename, 'wb')
-        f.write(asbytes(s))
+        f.write(s)
         f.close()
         y = np.fromfile(self.filename, sep=',', dtype=np.bool_)
         assert_(y.dtype == '?')
@@ -4152,7 +4152,7 @@ class TestFromBuffer(object):
                 yield self.tst_basic, buf, x.flat, {'dtype':dt}
 
     def test_empty(self):
-        yield self.tst_basic, asbytes(''), np.array([]), {}
+        yield self.tst_basic, b'', np.array([]), {}
 
 
 class TestFlat(TestCase):
@@ -4286,17 +4286,17 @@ class TestRecord(TestCase):
         def test_bytes_fields(self):
             # Bytes are not allowed in field names and not recognized in titles
             # on Py3
-            assert_raises(TypeError, np.dtype, [(asbytes('a'), int)])
-            assert_raises(TypeError, np.dtype, [(('b', asbytes('a')), int)])
+            assert_raises(TypeError, np.dtype, [(b'a', int)])
+            assert_raises(TypeError, np.dtype, [(('b', b'a'), int)])
 
-            dt = np.dtype([((asbytes('a'), 'b'), int)])
-            assert_raises(ValueError, dt.__getitem__, asbytes('a'))
+            dt = np.dtype([((b'a', 'b'), int)])
+            assert_raises(ValueError, dt.__getitem__, b'a')
 
             x = np.array([(1,), (2,), (3,)], dtype=dt)
-            assert_raises(IndexError, x.__getitem__, asbytes('a'))
+            assert_raises(IndexError, x.__getitem__, b'a')
 
             y = x[0]
-            assert_raises(IndexError, y.__getitem__, asbytes('a'))
+            assert_raises(IndexError, y.__getitem__, b'a')
 
         def test_multiple_field_name_unicode(self):
             def test_assign_unicode():
@@ -4336,10 +4336,10 @@ class TestRecord(TestCase):
         if is_py3:
             funcs = (str,)
             # byte string indexing fails gracefully
-            assert_raises(IndexError, a.__setitem__, asbytes('f1'), 1)
-            assert_raises(IndexError, a.__getitem__, asbytes('f1'))
-            assert_raises(IndexError, a['f1'].__setitem__, asbytes('sf1'), 1)
-            assert_raises(IndexError, a['f1'].__getitem__, asbytes('sf1'))
+            assert_raises(IndexError, a.__setitem__, b'f1', 1)
+            assert_raises(IndexError, a.__getitem__, b'f1')
+            assert_raises(IndexError, a['f1'].__setitem__, b'sf1', 1)
+            assert_raises(IndexError, a['f1'].__getitem__, b'sf1')
         else:
             funcs = (str, unicode)
         for func in funcs:
@@ -5960,7 +5960,7 @@ class TestNewBufferProtocol(object):
               ]
         x = np.array(
                 [(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                    asbytes('aaaa'), 'bbbb', asbytes('xxx'), True, 1.0)],
+                    b'aaaa', 'bbbb', b'xxx', True, 1.0)],
                 dtype=dt)
         self._check_roundtrip(x)
 
@@ -6097,7 +6097,7 @@ class TestNewBufferProtocol(object):
               ]
         x = np.array(
                 [(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                    asbytes('aaaa'), 'bbbb', asbytes('   '), True, 1.0)],
+                    b'aaaa', 'bbbb', b'   ', True, 1.0)],
                 dtype=dt)
         y = memoryview(x)
         assert_equal(y.shape, (1,))

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
-from numpy.compat import asbytes, sixu
+from numpy.compat import sixu
 from numpy.core.multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
@@ -2118,7 +2118,7 @@ def test_iter_buffering_string():
     assert_raises(TypeError, nditer, a, ['buffered'], ['readonly'],
                   op_dtypes='S2')
     i = nditer(a, ['buffered'], ['readonly'], op_dtypes='S6')
-    assert_equal(i[0], asbytes('abc'))
+    assert_equal(i[0], b'abc')
     assert_equal(i[0].dtype, np.dtype('S6'))
 
     a = np.array(['abc', 'a', 'abcd'], dtype=np.unicode)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -5,7 +5,6 @@ import warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
-from numpy.compat import sixu
 from numpy.core.multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
@@ -2126,7 +2125,7 @@ def test_iter_buffering_string():
     assert_raises(TypeError, nditer, a, ['buffered'], ['readonly'],
                     op_dtypes='U2')
     i = nditer(a, ['buffered'], ['readonly'], op_dtypes='U6')
-    assert_equal(i[0], sixu('abc'))
+    assert_equal(i[0], u'abc')
     assert_equal(i[0].dtype, np.dtype('U6'))
 
 def test_iter_buffering_growinner():

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 import numpy as np
-from numpy.compat import asunicode
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal
 )
@@ -63,8 +62,8 @@ NbufferT = [
     # x     Info                                                color info        y                  z
     #       value y2 Info2                            name z2         Name Value
     #                name   value    y3       z3
-    ([3, 2], (6j, 6., (b'nn', [6j, 4j], [6., 4.], [1, 2]), b'NN', True), b'cc', (asunicode('NN'), 6j), [[6., 4.], [6., 4.]], 8),
-    ([4, 3], (7j, 7., (b'oo', [7j, 5j], [7., 5.], [2, 1]), b'OO', False), b'dd', (asunicode('OO'), 7j), [[7., 5.], [7., 5.]], 9),
+    ([3, 2], (6j, 6., (b'nn', [6j, 4j], [6., 4.], [1, 2]), b'NN', True), b'cc', (u'NN', 6j), [[6., 4.], [6., 4.]], 8),
+    ([4, 3], (7j, 7., (b'oo', [7j, 5j], [7., 5.], [2, 1]), b'OO', False), b'dd', (u'OO', 7j), [[7., 5.], [7., 5.]], 9),
     ]
 
 

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 import numpy as np
-from numpy.compat import asbytes, asunicode
+from numpy.compat import asunicode
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal
 )
@@ -63,8 +63,8 @@ NbufferT = [
     # x     Info                                                color info        y                  z
     #       value y2 Info2                            name z2         Name Value
     #                name   value    y3       z3
-    ([3, 2], (6j, 6., (asbytes('nn'), [6j, 4j], [6., 4.], [1, 2]), asbytes('NN'), True), asbytes('cc'), (asunicode('NN'), 6j), [[6., 4.], [6., 4.]], 8),
-    ([4, 3], (7j, 7., (asbytes('oo'), [7j, 5j], [7., 5.], [2, 1]), asbytes('OO'), False), asbytes('dd'), (asunicode('OO'), 7j), [[7., 5.], [7., 5.]], 9),
+    ([3, 2], (6j, 6., (b'nn', [6j, 4j], [6., 4.], [1, 2]), b'NN', True), b'cc', (asunicode('NN'), 6j), [[6., 4.], [6., 4.]], 8),
+    ([4, 3], (7j, 7., (b'oo', [7j, 5j], [7., 5.], [2, 1]), b'OO', False), b'dd', (asunicode('OO'), 7j), [[7., 5.], [7., 5.]], 9),
     ]
 
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -7,7 +7,6 @@ import warnings
 from os import path
 
 import numpy as np
-from numpy.compat import asbytes
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal,
     assert_array_almost_equal, assert_raises, assert_warns
@@ -55,18 +54,18 @@ class TestFromrecords(TestCase):
         assert_equal(r1, r2)
 
     def test_method_array(self):
-        r = np.rec.array(asbytes('abcdefg') * 100, formats='i2,a3,i4', shape=3, byteorder='big')
-        assert_equal(r[1].item(), (25444, asbytes('efg'), 1633837924))
+        r = np.rec.array(b'abcdefg' * 100, formats='i2,a3,i4', shape=3, byteorder='big')
+        assert_equal(r[1].item(), (25444, b'efg', 1633837924))
 
     def test_method_array2(self):
         r = np.rec.array([(1, 11, 'a'), (2, 22, 'b'), (3, 33, 'c'), (4, 44, 'd'), (5, 55, 'ex'),
                      (6, 66, 'f'), (7, 77, 'g')], formats='u1,f4,a1')
-        assert_equal(r[1].item(), (2, 22.0, asbytes('b')))
+        assert_equal(r[1].item(), (2, 22.0, b'b'))
 
     def test_recarray_slices(self):
         r = np.rec.array([(1, 11, 'a'), (2, 22, 'b'), (3, 33, 'c'), (4, 44, 'd'), (5, 55, 'ex'),
                      (6, 66, 'f'), (7, 77, 'g')], formats='u1,f4,a1')
-        assert_equal(r[1::2][1].item(), (4, 44.0, asbytes('d')))
+        assert_equal(r[1::2][1].item(), (4, 44.0, b'd'))
 
     def test_recarray_fromarrays(self):
         x1 = np.array([1, 2, 3, 4])
@@ -279,10 +278,10 @@ class TestFromrecords(TestCase):
         assert_equal(a[0].bar['A'], 1)
         assert_equal(a[0]['bar'].A, 1)
         assert_equal(a[0]['bar']['A'], 1)
-        assert_equal(a[0].qux.D, asbytes('fgehi'))
-        assert_equal(a[0].qux['D'], asbytes('fgehi'))
-        assert_equal(a[0]['qux'].D, asbytes('fgehi'))
-        assert_equal(a[0]['qux']['D'], asbytes('fgehi'))
+        assert_equal(a[0].qux.D, b'fgehi')
+        assert_equal(a[0].qux['D'], b'fgehi')
+        assert_equal(a[0]['qux'].D, b'fgehi')
+        assert_equal(a[0]['qux']['D'], b'fgehi')
 
     def test_zero_width_strings(self):
         # Test for #6430, based on the test case from #1901

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -18,7 +18,7 @@ from numpy.testing import (
         assert_raises, assert_warns, dec, suppress_warnings
         )
 from numpy.testing.utils import _assert_valid_refcount, HAS_REFCOUNT
-from numpy.compat import asbytes, asunicode, long, sixu
+from numpy.compat import asbytes, asunicode, long
 
 rlevel = 1
 
@@ -146,7 +146,7 @@ class TestRegression(TestCase):
     def test_unicode_swapping(self, level=rlevel):
         # Ticket #79
         ulen = 1
-        ucs_value = sixu('\U0010FFFF')
+        ucs_value = u'\U0010FFFF'
         ua = np.array([[[ucs_value*ulen]*2]*3]*4, dtype='U%s' % ulen)
         ua.newbyteorder()  # Should succeed.
 
@@ -1183,7 +1183,7 @@ class TestRegression(TestCase):
         for i in range(1, 9):
             msg = 'unicode offset: %d chars' % i
             t = np.dtype([('a', 'S%d' % i), ('b', 'U2')])
-            x = np.array([(b'a', sixu('b'))], dtype=t)
+            x = np.array([(b'a', u'b')], dtype=t)
             if sys.version_info[0] >= 3:
                 assert_equal(str(x), "[(b'a', 'b')]", err_msg=msg)
             else:
@@ -1377,21 +1377,21 @@ class TestRegression(TestCase):
 
     def test_unicode_to_string_cast(self):
         # Ticket #1240.
-        a = np.array([[sixu('abc'), sixu('\u03a3')],
-                      [sixu('asdf'), sixu('erw')]],
+        a = np.array([[u'abc', u'\u03a3'],
+                      [u'asdf', u'erw']],
                      dtype='U')
         self.assertRaises(UnicodeEncodeError, np.array, a, 'S4')
 
     def test_mixed_string_unicode_array_creation(self):
-        a = np.array(['1234', sixu('123')])
+        a = np.array(['1234', u'123'])
         assert_(a.itemsize == 16)
-        a = np.array([sixu('123'), '1234'])
+        a = np.array([u'123', '1234'])
         assert_(a.itemsize == 16)
-        a = np.array(['1234', sixu('123'), '12345'])
+        a = np.array(['1234', u'123', '12345'])
         assert_(a.itemsize == 20)
-        a = np.array([sixu('123'), '1234', sixu('12345')])
+        a = np.array([u'123', '1234', u'12345'])
         assert_(a.itemsize == 20)
-        a = np.array([sixu('123'), '1234', sixu('1234')])
+        a = np.array([u'123', '1234', u'1234'])
         assert_(a.itemsize == 16)
 
     def test_misaligned_objects_segfault(self):
@@ -1973,7 +1973,7 @@ class TestRegression(TestCase):
         if sys.version_info[0] >= 3:
             a = np.array(['abcd'])
         else:
-            a = np.array([sixu('abcd')])
+            a = np.array([u'abcd'])
         assert_equal(a.dtype.itemsize, 16)
 
     def test_unique_stable(self):
@@ -2042,8 +2042,8 @@ class TestRegression(TestCase):
         import numpy as np
         a = np.array([['Hello', 'Foob']], dtype='U5', order='F')
         arr = np.ndarray(shape=[1, 2, 5], dtype='U1', buffer=a)
-        arr2 = np.array([[[sixu('H'), sixu('e'), sixu('l'), sixu('l'), sixu('o')],
-                          [sixu('F'), sixu('o'), sixu('o'), sixu('b'), sixu('')]]])
+        arr2 = np.array([[[u'H', u'e', u'l', u'l', u'o'],
+                          [u'F', u'o', u'o', u'b', u'']]])
         assert_array_equal(arr, arr2)
 
     def test_assign_from_sequence_error(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -366,9 +366,9 @@ class TestRegression(TestCase):
     def test_chararray_rstrip(self, level=rlevel):
         # Ticket #222
         x = np.chararray((1,), 5)
-        x[0] = asbytes('a   ')
+        x[0] = b'a   '
         x = x.rstrip()
-        assert_equal(x[0], asbytes('a'))
+        assert_equal(x[0], b'a')
 
     def test_object_array_shape(self, level=rlevel):
         # Ticket #239
@@ -415,23 +415,23 @@ class TestRegression(TestCase):
         test_data = [
             # (original, py2_pickle)
             (np.unicode_('\u6f2c'),
-             asbytes("cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n"
-                     "(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\n"
-                     "I0\ntp6\nbS',o\\x00\\x00'\np7\ntp8\nRp9\n.")),
+             b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n"
+             b"(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\n"
+             b"I0\ntp6\nbS',o\\x00\\x00'\np7\ntp8\nRp9\n."),
 
             (np.array([9e123], dtype=np.float64),
-             asbytes("cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\n"
-                     "p1\n(I0\ntp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\n"
-                     "p7\n(S'f8'\np8\nI0\nI1\ntp9\nRp10\n(I3\nS'<'\np11\nNNNI-1\nI-1\n"
-                     "I0\ntp12\nbI00\nS'O\\x81\\xb7Z\\xaa:\\xabY'\np13\ntp14\nb.")),
+             b"cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\n"
+             b"p1\n(I0\ntp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\n"
+             b"p7\n(S'f8'\np8\nI0\nI1\ntp9\nRp10\n(I3\nS'<'\np11\nNNNI-1\nI-1\n"
+             b"I0\ntp12\nbI00\nS'O\\x81\\xb7Z\\xaa:\\xabY'\np13\ntp14\nb."),
 
             (np.array([(9e123,)], dtype=[('name', float)]),
-             asbytes("cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\np1\n"
-                     "(I0\ntp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n"
-                     "(S'V8'\np8\nI0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nN(S'name'\np12\ntp13\n"
-                     "(dp14\ng12\n(g7\n(S'f8'\np15\nI0\nI1\ntp16\nRp17\n(I3\nS'<'\np18\nNNNI-1\n"
-                     "I-1\nI0\ntp19\nbI0\ntp20\nsI8\nI1\nI0\ntp21\n"
-                     "bI00\nS'O\\x81\\xb7Z\\xaa:\\xabY'\np22\ntp23\nb.")),
+             b"cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\np1\n"
+             b"(I0\ntp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n"
+             b"(S'V8'\np8\nI0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nN(S'name'\np12\ntp13\n"
+             b"(dp14\ng12\n(g7\n(S'f8'\np15\nI0\nI1\ntp16\nRp17\n(I3\nS'<'\np18\nNNNI-1\n"
+             b"I-1\nI0\ntp19\nbI0\ntp20\nsI8\nI1\nI0\ntp21\n"
+             b"bI00\nS'O\\x81\\xb7Z\\xaa:\\xabY'\np22\ntp23\nb."),
         ]
 
         if sys.version_info[:2] >= (3, 4):
@@ -577,7 +577,7 @@ class TestRegression(TestCase):
 
     def test_numeric_carray_compare(self, level=rlevel):
         # Ticket #341
-        assert_equal(np.array(['X'], 'c'), asbytes('X'))
+        assert_equal(np.array(['X'], 'c'), b'X')
 
     def test_string_array_size(self, level=rlevel):
         # Ticket #342
@@ -691,8 +691,8 @@ class TestRegression(TestCase):
 
     def test_junk_in_string_fields_of_recarray(self, level=rlevel):
         # Ticket #483
-        r = np.array([[asbytes('abc')]], dtype=[('var1', '|S20')])
-        assert_(asbytes(r['var1'][0][0]) == asbytes('abc'))
+        r = np.array([[b'abc']], dtype=[('var1', '|S20')])
+        assert_(asbytes(r['var1'][0][0]) == b'abc')
 
     def test_take_output(self, level=rlevel):
         # Ensure that 'take' honours output parameter.
@@ -1183,7 +1183,7 @@ class TestRegression(TestCase):
         for i in range(1, 9):
             msg = 'unicode offset: %d chars' % i
             t = np.dtype([('a', 'S%d' % i), ('b', 'U2')])
-            x = np.array([(asbytes('a'), sixu('b'))], dtype=t)
+            x = np.array([(b'a', sixu('b'))], dtype=t)
             if sys.version_info[0] >= 3:
                 assert_equal(str(x), "[(b'a', 'b')]", err_msg=msg)
             else:
@@ -1499,7 +1499,7 @@ class TestRegression(TestCase):
 
     def test_fromstring_crash(self):
         # Ticket #1345: the following should not cause a crash
-        np.fromstring(asbytes('aa, aa, 1.0'), sep=',')
+        np.fromstring(b'aa, aa, 1.0', sep=',')
 
     def test_ticket_1539(self):
         dtypes = [x for x in np.typeDict.values()
@@ -1593,7 +1593,7 @@ class TestRegression(TestCase):
 
         f.seek(40)
         data = f.read(3)
-        assert_equal(data, asbytes("\x01\x02\x03"))
+        assert_equal(data, b"\x01\x02\x03")
 
         f.seek(80)
         f.read(4)
@@ -1750,8 +1750,8 @@ class TestRegression(TestCase):
 
     def test_setting_rank0_string(self):
         "Ticket #1736"
-        s1 = asbytes("hello1")
-        s2 = asbytes("hello2")
+        s1 = b"hello1"
+        s2 = b"hello2"
         a = np.zeros((), dtype="S10")
         a[()] = s1
         assert_equal(a, np.array(s1))
@@ -1766,9 +1766,9 @@ class TestRegression(TestCase):
 
     def test_string_astype(self):
         "Ticket #1748"
-        s1 = asbytes('black')
-        s2 = asbytes('white')
-        s3 = asbytes('other')
+        s1 = b'black'
+        s2 = b'white'
+        s3 = b'other'
         a = np.array([[s1], [s2], [s3]])
         assert_equal(a.dtype, np.dtype('S5'))
         b = a.astype(np.dtype('S0'))
@@ -1776,7 +1776,7 @@ class TestRegression(TestCase):
 
     def test_ticket_1756(self):
         # Ticket #1756
-        s = asbytes('0123456789abcdef')
+        s = b'0123456789abcdef'
         a = np.array([s]*5)
         for i in range(1, 17):
             a1 = np.array(a, "|S%d" % i)
@@ -1843,10 +1843,10 @@ class TestRegression(TestCase):
         # encoding='latin1' work correctly.
 
         # Python2 output for pickle.dumps(numpy.array([129], dtype='b'))
-        data = asbytes("cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\np1\n(I0\n"
-                       "tp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n(S'i1'\np8\n"
-                       "I0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nNNNI-1\nI-1\nI0\ntp12\nbI00\nS'\\x81'\n"
-                       "p13\ntp14\nb.")
+        data = (b"cnumpy.core.multiarray\n_reconstruct\np0\n(cnumpy\nndarray\np1\n(I0\n"
+                b"tp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n(S'i1'\np8\n"
+                b"I0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nNNNI-1\nI-1\nI0\ntp12\nbI00\nS'\\x81'\n"
+                b"p13\ntp14\nb.")
         if sys.version_info[0] >= 3:
             # This should work:
             result = pickle.loads(data, encoding='latin1')
@@ -1862,21 +1862,21 @@ class TestRegression(TestCase):
         datas = [
             # (original, python2_pickle, koi8r_validity)
             (np.unicode_('\u6bd2'),
-             asbytes("cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n"
-                     "(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\nI0\n"
-                     "tp6\nbS'\\xd2k\\x00\\x00'\np7\ntp8\nRp9\n."),
+             (b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n"
+              b"(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\nI0\n"
+              b"tp6\nbS'\\xd2k\\x00\\x00'\np7\ntp8\nRp9\n."),
              'invalid'),
 
             (np.float64(9e123),
-             asbytes("cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'f8'\n"
-                     "p2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI-1\nI-1\nI0\ntp6\n"
-                     "bS'O\\x81\\xb7Z\\xaa:\\xabY'\np7\ntp8\nRp9\n."),
+             (b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'f8'\n"
+              b"p2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI-1\nI-1\nI0\ntp6\n"
+              b"bS'O\\x81\\xb7Z\\xaa:\\xabY'\np7\ntp8\nRp9\n."),
              'invalid'),
 
-            (np.bytes_(asbytes('\x9c')),  # different 8-bit code point in KOI8-R vs latin1
-             asbytes("cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'S1'\np2\n"
-                     "I0\nI1\ntp3\nRp4\n(I3\nS'|'\np5\nNNNI1\nI1\nI0\ntp6\nbS'\\x9c'\np7\n"
-                     "tp8\nRp9\n."),
+            (np.bytes_(b'\x9c'),  # different 8-bit code point in KOI8-R vs latin1
+             (b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'S1'\np2\n"
+              b"I0\nI1\ntp3\nRp4\n(I3\nS'|'\np5\nNNNI1\nI1\nI0\ntp6\nbS'\\x9c'\np7\n"
+              b"tp8\nRp9\n."),
              'different'),
         ]
         if sys.version_info[0] >= 3:

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -18,7 +18,7 @@ from numpy.testing import (
         assert_raises, assert_warns, dec, suppress_warnings
         )
 from numpy.testing.utils import _assert_valid_refcount, HAS_REFCOUNT
-from numpy.compat import asbytes, asunicode, asbytes_nested, long, sixu
+from numpy.compat import asbytes, asunicode, long, sixu
 
 rlevel = 1
 
@@ -1175,7 +1175,7 @@ class TestRegression(TestCase):
 
     def test_char_array_creation(self, level=rlevel):
         a = np.array('123', dtype='c')
-        b = np.array(asbytes_nested(['1', '2', '3']))
+        b = np.array([b'1', b'2', b'3'])
         assert_equal(a, b)
 
     def test_unaligned_unicode_access(self, level=rlevel):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 import numpy.core.umath_tests as umt
 import numpy.core.operand_flag_tests as opflag_tests
-from numpy.compat import asbytes
 from numpy.core.test_rational import rational, test_add, test_add_rationals
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
@@ -45,8 +44,8 @@ class TestUfunc(TestCase):
 
     def test_pickle_withstring(self):
         import pickle
-        astring = asbytes("cnumpy.core\n_ufunc_reconstruct\np0\n"
-                "(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
+        astring = (b"cnumpy.core\n_ufunc_reconstruct\np0\n"
+                   b"(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
         assert_(pickle.loads(astring) is np.cos)
 
     def test_reduceat_shifting_sum(self):

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 import numpy as np
-from numpy.compat import unicode, sixu
+from numpy.compat import unicode
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal)
 
@@ -32,7 +32,7 @@ if sys.version_info[:2] >= (3, 3):
         else:
             return np.prod(v.shape) * v.itemsize
 else:
-    if len(buffer(sixu('u'))) == 4:
+    if len(buffer(u'u')) == 4:
         ucs4 = True
     else:
         ucs4 = False
@@ -45,9 +45,9 @@ else:
 # In both cases below we need to make sure that the byte swapped value (as
 # UCS4) is still a valid unicode:
 # Value that can be represented in UCS2 interpreters
-ucs2_value = sixu('\u0900')
+ucs2_value = u'\u0900'
 # Value that cannot be represented in UCS2 interpreters (but can in UCS4)
-ucs4_value = sixu('\U00100900')
+ucs4_value = u'\U00100900'
 
 
 def test_string_cast():
@@ -78,7 +78,7 @@ class create_zeros(object):
         # Check the length of the data buffer
         self.assertTrue(buffer_length(ua) == nbytes)
         # Small check that data in array element is ok
-        self.assertTrue(ua_scalar == sixu(''))
+        self.assertTrue(ua_scalar == u'')
         # Encode to ascii and double check
         self.assertTrue(ua_scalar.encode('ascii') == b'')
         # Check buffer lengths for scalars

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 import numpy as np
-from numpy.compat import asbytes, unicode, sixu
+from numpy.compat import unicode, sixu
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_array_equal)
 
@@ -80,7 +80,7 @@ class create_zeros(object):
         # Small check that data in array element is ok
         self.assertTrue(ua_scalar == sixu(''))
         # Encode to ascii and double check
-        self.assertTrue(ua_scalar.encode('ascii') == asbytes(''))
+        self.assertTrue(ua_scalar.encode('ascii') == b'')
         # Check buffer lengths for scalars
         if ucs4:
             self.assertTrue(buffer_length(ua_scalar) == 0)

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 from numpy import array
-from numpy.compat import asbytes
 from numpy.testing import run_module_suite, assert_, dec
 import util
 
@@ -11,22 +10,22 @@ class TestReturnCharacter(util.F2PyTest):
     def check_function(self, t):
         tname = t.__doc__.split()[0]
         if tname in ['t0', 't1', 's0', 's1']:
-            assert_(t(23) == asbytes('2'))
+            assert_(t(23) == b'2')
             r = t('ab')
-            assert_(r == asbytes('a'), repr(r))
+            assert_(r == b'a', repr(r))
             r = t(array('ab'))
-            assert_(r == asbytes('a'), repr(r))
+            assert_(r == b'a', repr(r))
             r = t(array(77, 'u1'))
-            assert_(r == asbytes('M'), repr(r))
+            assert_(r == b'M', repr(r))
             #assert_(_raises(ValueError, t, array([77,87])))
             #assert_(_raises(ValueError, t, array(77)))
         elif tname in ['ts', 'ss']:
-            assert_(t(23) == asbytes('23        '), repr(t(23)))
-            assert_(t('123456789abcdef') == asbytes('123456789a'))
+            assert_(t(23) == b'23        ', repr(t(23)))
+            assert_(t('123456789abcdef') == b'123456789a')
         elif tname in ['t5', 's5']:
-            assert_(t(23) == asbytes('23   '), repr(t(23)))
-            assert_(t('ab') == asbytes('ab   '), repr(t('ab')))
-            assert_(t('123456789abcdef') == asbytes('12345'))
+            assert_(t(23) == b'23   ', repr(t(23)))
+            assert_(t('ab') == b'ab   ', repr(t('ab')))
+            assert_(t('123456789abcdef') == b'12345')
         else:
             raise NotImplementedError
 

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -213,7 +213,7 @@ sys.exit(99)
                              stderr=subprocess.STDOUT)
         out, err = p.communicate()
 
-    m = re.search(asbytes(r'COMPILERS:(\d+),(\d+),(\d+)'), out)
+    m = re.search(br'COMPILERS:(\d+),(\d+),(\d+)', out)
     if m:
         _compiler_status = (bool(int(m.group(1))), bool(int(m.group(2))),
                             bool(int(m.group(3))))

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -44,7 +44,7 @@ def _is_bytes_like(obj):
     Check whether obj behaves like a bytes object.
     """
     try:
-        obj + asbytes('')
+        obj + b''
     except (TypeError, ValueError):
         return False
     return True
@@ -189,7 +189,7 @@ class LineSplitter(object):
         return lambda input: [_.strip() for _ in method(input)]
     #
 
-    def __init__(self, delimiter=None, comments=asbytes('#'), autostrip=True):
+    def __init__(self, delimiter=None, comments=b'#', autostrip=True):
         self.comments = comments
         # Delimiter is a character
         if isinstance(delimiter, unicode):
@@ -218,7 +218,7 @@ class LineSplitter(object):
     def _delimited_splitter(self, line):
         if self.comments is not None:
             line = line.split(self.comments)[0]
-        line = line.strip(asbytes(" \r\n"))
+        line = line.strip(b" \r\n")
         if not line:
             return []
         return line.split(self.delimiter)
@@ -227,7 +227,7 @@ class LineSplitter(object):
     def _fixedwidth_splitter(self, line):
         if self.comments is not None:
             line = line.split(self.comments)[0]
-        line = line.strip(asbytes("\r\n"))
+        line = line.strip(b"\r\n")
         if not line:
             return []
         fixed = self.delimiter
@@ -434,9 +434,9 @@ def str2bool(value):
 
     """
     value = value.upper()
-    if value == asbytes('TRUE'):
+    if value == b'TRUE':
         return True
-    elif value == asbytes('FALSE'):
+    elif value == b'FALSE':
         return False
     else:
         raise ValueError("Invalid boolean")
@@ -529,7 +529,7 @@ class StringConverter(object):
     _mapper.extend([(nx.floating, float, nx.nan),
                     (complex, _bytes_to_complex, nx.nan + 0j),
                     (nx.longdouble, nx.longdouble, nx.nan),
-                    (nx.string_, bytes, asbytes('???'))])
+                    (nx.string_, bytes, b'???')])
 
     (_defaulttype, _defaultfunc, _defaultfill) = zip(*_mapper)
 
@@ -631,7 +631,7 @@ class StringConverter(object):
                 # None
                 if default is None:
                     try:
-                        default = self.func(asbytes('0'))
+                        default = self.func(b'0')
                     except ValueError:
                         default = None
                 dtype = self._getdtype(default)
@@ -676,11 +676,11 @@ class StringConverter(object):
                     self.func = lambda x: int(float(x))
         # Store the list of strings corresponding to missing values.
         if missing_values is None:
-            self.missing_values = set([asbytes('')])
+            self.missing_values = set([b''])
         else:
             if isinstance(missing_values, bytes):
-                missing_values = missing_values.split(asbytes(","))
-            self.missing_values = set(list(missing_values) + [asbytes('')])
+                missing_values = missing_values.split(b",")
+            self.missing_values = set(list(missing_values) + [b''])
         #
         self._callingfunction = self._strict_call
         self.type = self._dtypeortype(dtype)
@@ -801,7 +801,7 @@ class StringConverter(object):
             self.iterupgrade(value)
 
     def update(self, func, default=None, testing_value=None,
-               missing_values=asbytes(''), locked=False):
+               missing_values=b'', locked=False):
         """
         Set StringConverter attributes directly.
 
@@ -838,7 +838,7 @@ class StringConverter(object):
             self.type = self._dtypeortype(self._getdtype(default))
         else:
             try:
-                tester = func(testing_value or asbytes('1'))
+                tester = func(testing_value or b'1')
             except (TypeError, ValueError):
                 tester = None
             self.type = self._dtypeortype(self._getdtype(tester))

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -161,7 +161,7 @@ if sys.version_info[0] >= 3:
 else:
     import cPickle as pickle
 
-MAGIC_PREFIX = asbytes('\x93NUMPY')
+MAGIC_PREFIX = b'\x93NUMPY'
 MAGIC_LEN = len(MAGIC_PREFIX) + 2
 BUFFER_SIZE = 2**18  # size of buffer for reading npz files in bytes
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -397,7 +397,7 @@ def load(file, mmap_mode=None, allow_pickle=True, fix_imports=True,
 
     try:
         # Code to distinguish from NumPy binary files and pickles.
-        _ZIP_PREFIX = asbytes('PK\x03\x04')
+        _ZIP_PREFIX = b'PK\x03\x04'
         N = len(format.MAGIC_PREFIX)
         magic = fid.read(N)
         # If the file size is less than N, we need to make sure not
@@ -856,7 +856,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
         # Compile regex for comments beforehand
         comments = (re.escape(comment) for comment in comments)
-        regex_comments = re.compile(asbytes('|').join(comments))
+        regex_comments = re.compile(b'|'.join(comments))
     user_converters = converters
     if delimiter is not None:
         delimiter = asbytes(delimiter)
@@ -958,7 +958,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         line = asbytes(line)
         if comments is not None:
             line = regex_comments.split(asbytes(line), maxsplit=1)[0]
-        line = line.strip(asbytes('\r\n'))
+        line = line.strip(b'\r\n')
         if line:
             return line.split(delimiter)
         else:
@@ -1576,11 +1576,11 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             if names is True:
                 if comments in first_line:
                     first_line = (
-                        asbytes('').join(first_line.split(comments)[1:]))
+                        b''.join(first_line.split(comments)[1:]))
             first_values = split_line(first_line)
     except StopIteration:
         # return an empty array if the datafile is empty
-        first_line = asbytes('')
+        first_line = b''
         first_values = []
         warnings.warn('genfromtxt: Empty input file: "%s"' % fname, stacklevel=2)
 
@@ -1605,7 +1605,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     if names is True:
         names = validate_names([_bytes_to_name(_.strip())
                                 for _ in first_values])
-        first_line = asbytes('')
+        first_line = b''
     elif _is_string_like(names):
         names = validate_names([_.strip() for _ in names.split(',')])
     elif names:
@@ -1644,7 +1644,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     user_missing_values = missing_values or ()
 
     # Define the list of missing_values (one column: one list)
-    missing_values = [list([asbytes('')]) for _ in range(nbcols)]
+    missing_values = [list([b'']) for _ in range(nbcols)]
 
     # We have a dictionary: process it field by field
     if isinstance(user_missing_values, dict):
@@ -1684,7 +1684,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                 entry.append(value)
     # We have a string : apply it to all entries
     elif isinstance(user_missing_values, bytes):
-        user_value = user_missing_values.split(asbytes(","))
+        user_value = user_missing_values.split(b",")
         for entry in missing_values:
             entry.extend(user_value)
     # We have something else: apply it to all entries
@@ -1977,7 +1977,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     if usemask and names:
         for (name, conv) in zip(names or (), converters):
             missing_values = [conv(_) for _ in conv.missing_values
-                              if _ != asbytes('')]
+                              if _ != b'']
             for mval in missing_values:
                 outputmask[name] |= (output[name] == mval)
     # Construct the final array

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -5,7 +5,6 @@ import sys
 from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
 from shutil import rmtree
 
-from numpy.compat import asbytes
 from numpy.testing import (
     run_module_suite, TestCase, assert_, SkipTest
     )
@@ -53,7 +52,7 @@ http_fakefile = 'fake.txt'
 malicious_files = ['/etc/shadow', '../../shadow',
                    '..\\system.dat', 'c:\\windows\\system.dat']
 
-magic_line = asbytes('three is the magic number')
+magic_line = b'three is the magic number'
 
 
 # Utility functions used by many TestCases

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -5,7 +5,6 @@ import time
 from datetime import date
 
 import numpy as np
-from numpy.compat import asbytes_nested
 from numpy.testing import (
     run_module_suite, TestCase, assert_, assert_equal, assert_allclose,
     assert_raises
@@ -23,59 +22,59 @@ class TestLineSplitter(TestCase):
         "Test LineSplitter w/o delimiter"
         strg = b" 1 2 3 4  5 # test"
         test = LineSplitter()(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '5']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'5'])
         test = LineSplitter('')(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '5']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'5'])
 
     def test_space_delimiter(self):
         "Test space delimiter"
         strg = b" 1 2 3 4  5 # test"
         test = LineSplitter(b' ')(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5'])
         test = LineSplitter(b'  ')(strg)
-        assert_equal(test, asbytes_nested(['1 2 3 4', '5']))
+        assert_equal(test, [b'1 2 3 4', b'5'])
 
     def test_tab_delimiter(self):
         "Test tab delimiter"
         strg = b" 1\t 2\t 3\t 4\t 5  6"
         test = LineSplitter(b'\t')(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '5  6']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'5  6'])
         strg = b" 1  2\t 3  4\t 5  6"
         test = LineSplitter(b'\t')(strg)
-        assert_equal(test, asbytes_nested(['1  2', '3  4', '5  6']))
+        assert_equal(test, [b'1  2', b'3  4', b'5  6'])
 
     def test_other_delimiter(self):
         "Test LineSplitter on delimiter"
         strg = b"1,2,3,4,,5"
         test = LineSplitter(b',')(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5'])
         #
         strg = b" 1,2,3,4,,5 # test"
         test = LineSplitter(b',')(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5'])
 
     def test_constant_fixed_width(self):
         "Test LineSplitter w/ fixed-width fields"
         strg = b"  1  2  3  4     5   # test"
         test = LineSplitter(3)(strg)
-        assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5', '']))
+        assert_equal(test, [b'1', b'2', b'3', b'4', b'', b'5', b''])
         #
         strg = b"  1     3  4  5  6# test"
         test = LineSplitter(20)(strg)
-        assert_equal(test, asbytes_nested(['1     3  4  5  6']))
+        assert_equal(test, [b'1     3  4  5  6'])
         #
         strg = b"  1     3  4  5  6# test"
         test = LineSplitter(30)(strg)
-        assert_equal(test, asbytes_nested(['1     3  4  5  6']))
+        assert_equal(test, [b'1     3  4  5  6'])
 
     def test_variable_fixed_width(self):
         strg = b"  1     3  4  5  6# test"
         test = LineSplitter((3, 6, 6, 3))(strg)
-        assert_equal(test, asbytes_nested(['1', '3', '4  5', '6']))
+        assert_equal(test, [b'1', b'3', b'4  5', b'6'])
         #
         strg = b"  1     3  4  5  6# test"
         test = LineSplitter((6, 6, 9))(strg)
-        assert_equal(test, asbytes_nested(['1', '3  4', '5  6']))
+        assert_equal(test, [b'1', b'3  4', b'5  6'])
 
 # -----------------------------------------------------------------------------
 
@@ -238,7 +237,7 @@ class TestStringConverter(TestCase):
         converter = StringConverter(int, default=0,
                                     missing_values=b"N/A")
         assert_equal(
-            converter.missing_values, set(asbytes_nested(['', 'N/A'])))
+            converter.missing_values, set([b'', b'N/A']))
 
     def test_int64_dtype(self):
         "Check that int64 integer types can be specified"

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -5,7 +5,7 @@ import time
 from datetime import date
 
 import numpy as np
-from numpy.compat import asbytes, asbytes_nested
+from numpy.compat import asbytes_nested
 from numpy.testing import (
     run_module_suite, TestCase, assert_, assert_equal, assert_allclose,
     assert_raises
@@ -21,7 +21,7 @@ class TestLineSplitter(TestCase):
 
     def test_no_delimiter(self):
         "Test LineSplitter w/o delimiter"
-        strg = asbytes(" 1 2 3 4  5 # test")
+        strg = b" 1 2 3 4  5 # test"
         test = LineSplitter()(strg)
         assert_equal(test, asbytes_nested(['1', '2', '3', '4', '5']))
         test = LineSplitter('')(strg)
@@ -29,51 +29,51 @@ class TestLineSplitter(TestCase):
 
     def test_space_delimiter(self):
         "Test space delimiter"
-        strg = asbytes(" 1 2 3 4  5 # test")
-        test = LineSplitter(asbytes(' '))(strg)
+        strg = b" 1 2 3 4  5 # test"
+        test = LineSplitter(b' ')(strg)
         assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5']))
-        test = LineSplitter(asbytes('  '))(strg)
+        test = LineSplitter(b'  ')(strg)
         assert_equal(test, asbytes_nested(['1 2 3 4', '5']))
 
     def test_tab_delimiter(self):
         "Test tab delimiter"
-        strg = asbytes(" 1\t 2\t 3\t 4\t 5  6")
-        test = LineSplitter(asbytes('\t'))(strg)
+        strg = b" 1\t 2\t 3\t 4\t 5  6"
+        test = LineSplitter(b'\t')(strg)
         assert_equal(test, asbytes_nested(['1', '2', '3', '4', '5  6']))
-        strg = asbytes(" 1  2\t 3  4\t 5  6")
-        test = LineSplitter(asbytes('\t'))(strg)
+        strg = b" 1  2\t 3  4\t 5  6"
+        test = LineSplitter(b'\t')(strg)
         assert_equal(test, asbytes_nested(['1  2', '3  4', '5  6']))
 
     def test_other_delimiter(self):
         "Test LineSplitter on delimiter"
-        strg = asbytes("1,2,3,4,,5")
-        test = LineSplitter(asbytes(','))(strg)
+        strg = b"1,2,3,4,,5"
+        test = LineSplitter(b',')(strg)
         assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5']))
         #
-        strg = asbytes(" 1,2,3,4,,5 # test")
-        test = LineSplitter(asbytes(','))(strg)
+        strg = b" 1,2,3,4,,5 # test"
+        test = LineSplitter(b',')(strg)
         assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5']))
 
     def test_constant_fixed_width(self):
         "Test LineSplitter w/ fixed-width fields"
-        strg = asbytes("  1  2  3  4     5   # test")
+        strg = b"  1  2  3  4     5   # test"
         test = LineSplitter(3)(strg)
         assert_equal(test, asbytes_nested(['1', '2', '3', '4', '', '5', '']))
         #
-        strg = asbytes("  1     3  4  5  6# test")
+        strg = b"  1     3  4  5  6# test"
         test = LineSplitter(20)(strg)
         assert_equal(test, asbytes_nested(['1     3  4  5  6']))
         #
-        strg = asbytes("  1     3  4  5  6# test")
+        strg = b"  1     3  4  5  6# test"
         test = LineSplitter(30)(strg)
         assert_equal(test, asbytes_nested(['1     3  4  5  6']))
 
     def test_variable_fixed_width(self):
-        strg = asbytes("  1     3  4  5  6# test")
+        strg = b"  1     3  4  5  6# test"
         test = LineSplitter((3, 6, 6, 3))(strg)
         assert_equal(test, asbytes_nested(['1', '3', '4  5', '6']))
         #
-        strg = asbytes("  1     3  4  5  6# test")
+        strg = b"  1     3  4  5  6# test"
         test = LineSplitter((6, 6, 9))(strg)
         assert_equal(test, asbytes_nested(['1', '3  4', '5  6']))
 
@@ -157,7 +157,7 @@ class TestStringConverter(TestCase):
         assert_equal(converter._status, 0)
 
         # test int
-        assert_equal(converter.upgrade(asbytes('0')), 0)
+        assert_equal(converter.upgrade(b'0'), 0)
         assert_equal(converter._status, 1)
 
         # On systems where integer defaults to 32-bit, the statuses will be
@@ -166,30 +166,30 @@ class TestStringConverter(TestCase):
         status_offset = int(nx.dtype(nx.integer).itemsize < nx.dtype(nx.int64).itemsize)
 
         # test int > 2**32
-        assert_equal(converter.upgrade(asbytes('17179869184')), 17179869184)
+        assert_equal(converter.upgrade(b'17179869184'), 17179869184)
         assert_equal(converter._status, 1 + status_offset)
 
         # test float
-        assert_allclose(converter.upgrade(asbytes('0.')), 0.0)
+        assert_allclose(converter.upgrade(b'0.'), 0.0)
         assert_equal(converter._status, 2 + status_offset)
 
         # test complex
-        assert_equal(converter.upgrade(asbytes('0j')), complex('0j'))
+        assert_equal(converter.upgrade(b'0j'), complex('0j'))
         assert_equal(converter._status, 3 + status_offset)
 
         # test str
-        assert_equal(converter.upgrade(asbytes('a')), asbytes('a'))
+        assert_equal(converter.upgrade(b'a'), b'a')
         assert_equal(converter._status, len(converter._mapper) - 1)
 
     def test_missing(self):
         "Tests the use of missing values."
-        converter = StringConverter(missing_values=(asbytes('missing'),
-                                                    asbytes('missed')))
-        converter.upgrade(asbytes('0'))
-        assert_equal(converter(asbytes('0')), 0)
-        assert_equal(converter(asbytes('')), converter.default)
-        assert_equal(converter(asbytes('missing')), converter.default)
-        assert_equal(converter(asbytes('missed')), converter.default)
+        converter = StringConverter(missing_values=(b'missing',
+                                                    b'missed'))
+        converter.upgrade(b'0')
+        assert_equal(converter(b'0'), 0)
+        assert_equal(converter(b''), converter.default)
+        assert_equal(converter(b'missing'), converter.default)
+        assert_equal(converter(b'missed'), converter.default)
         try:
             converter('miss')
         except ValueError:
@@ -200,11 +200,11 @@ class TestStringConverter(TestCase):
         dateparser = _bytes_to_date
         StringConverter.upgrade_mapper(dateparser, date(2000, 1, 1))
         convert = StringConverter(dateparser, date(2000, 1, 1))
-        test = convert(asbytes('2001-01-01'))
+        test = convert(b'2001-01-01')
         assert_equal(test, date(2001, 1, 1))
-        test = convert(asbytes('2009-01-01'))
+        test = convert(b'2009-01-01')
         assert_equal(test, date(2009, 1, 1))
-        test = convert(asbytes(''))
+        test = convert(b'')
         assert_equal(test, date(2000, 1, 1))
 
     def test_string_to_object(self):
@@ -215,43 +215,43 @@ class TestStringConverter(TestCase):
 
     def test_keep_default(self):
         "Make sure we don't lose an explicit default"
-        converter = StringConverter(None, missing_values=asbytes(''),
+        converter = StringConverter(None, missing_values=b'',
                                     default=-999)
-        converter.upgrade(asbytes('3.14159265'))
+        converter.upgrade(b'3.14159265')
         assert_equal(converter.default, -999)
         assert_equal(converter.type, np.dtype(float))
         #
         converter = StringConverter(
-            None, missing_values=asbytes(''), default=0)
-        converter.upgrade(asbytes('3.14159265'))
+            None, missing_values=b'', default=0)
+        converter.upgrade(b'3.14159265')
         assert_equal(converter.default, 0)
         assert_equal(converter.type, np.dtype(float))
 
     def test_keep_default_zero(self):
         "Check that we don't lose a default of 0"
         converter = StringConverter(int, default=0,
-                                    missing_values=asbytes("N/A"))
+                                    missing_values=b"N/A")
         assert_equal(converter.default, 0)
 
     def test_keep_missing_values(self):
         "Check that we're not losing missing values"
         converter = StringConverter(int, default=0,
-                                    missing_values=asbytes("N/A"))
+                                    missing_values=b"N/A")
         assert_equal(
             converter.missing_values, set(asbytes_nested(['', 'N/A'])))
 
     def test_int64_dtype(self):
         "Check that int64 integer types can be specified"
         converter = StringConverter(np.int64, default=0)
-        val = asbytes("-9223372036854775807")
+        val = b"-9223372036854775807"
         assert_(converter(val) == -9223372036854775807)
-        val = asbytes("9223372036854775807")
+        val = b"9223372036854775807"
         assert_(converter(val) == 9223372036854775807)
 
     def test_uint64_dtype(self):
         "Check that uint64 integer types can be specified"
         converter = StringConverter(np.uint64, default=0)
-        val = asbytes("9223372043271415339")
+        val = b"9223372043271415339"
         assert_(converter(val) == 9223372043271415339)
 
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -986,10 +986,7 @@ class TestNdarrayPadWidth(TestCase):
 
 class TestUnicodeInput(TestCase):
     def test_unicode_mode(self):
-        try:
-            constant_mode = unicode('constant')
-        except NameError:
-            constant_mode = 'constant'
+        constant_mode = u'constant'
         a = np.pad([1], 2, mode=constant_mode)
         b = np.array([0, 0, 1, 0, 0])
         assert_array_equal(a, b)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -284,7 +284,6 @@ import warnings
 from io import BytesIO
 
 import numpy as np
-from numpy.compat import sixu
 from numpy.testing import (
     run_module_suite, assert_, assert_array_equal, assert_raises, raises,
     dec, SkipTest
@@ -545,7 +544,7 @@ def test_pickle_python2_python3():
         import __builtin__
         xrange = __builtin__.xrange
 
-    expected = np.array([None, xrange, sixu('\u512a\u826f'),
+    expected = np.array([None, xrange, u'\u512a\u826f',
                          b'\xe4\xb8\x8d\xe8\x89\xaf'],
                         dtype=object)
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -284,7 +284,7 @@ import warnings
 from io import BytesIO
 
 import numpy as np
-from numpy.compat import asbytes_nested, sixu
+from numpy.compat import sixu
 from numpy.testing import (
     run_module_suite, assert_, assert_array_equal, assert_raises, raises,
     dec, SkipTest
@@ -682,23 +682,23 @@ def test_write_version():
             raise AssertionError("we should have raised a ValueError for the bad version %r" % (version,))
 
 
-bad_version_magic = asbytes_nested([
-    '\x93NUMPY\x01\x01',
-    '\x93NUMPY\x00\x00',
-    '\x93NUMPY\x00\x01',
-    '\x93NUMPY\x02\x00',
-    '\x93NUMPY\x02\x02',
-    '\x93NUMPY\xff\xff',
-])
-malformed_magic = asbytes_nested([
-    '\x92NUMPY\x01\x00',
-    '\x00NUMPY\x01\x00',
-    '\x93numpy\x01\x00',
-    '\x93MATLB\x01\x00',
-    '\x93NUMPY\x01',
-    '\x93NUMPY',
-    '',
-])
+bad_version_magic = [
+    b'\x93NUMPY\x01\x01',
+    b'\x93NUMPY\x00\x00',
+    b'\x93NUMPY\x00\x01',
+    b'\x93NUMPY\x02\x00',
+    b'\x93NUMPY\x02\x02',
+    b'\x93NUMPY\xff\xff',
+]
+malformed_magic = [
+    b'\x92NUMPY\x01\x00',
+    b'\x00NUMPY\x01\x00',
+    b'\x93numpy\x01\x00',
+    b'\x93MATLB\x01\x00',
+    b'\x93NUMPY\x01',
+    b'\x93NUMPY',
+    b'',
+]
 
 def test_read_magic():
     s1 = BytesIO()

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -284,7 +284,7 @@ import warnings
 from io import BytesIO
 
 import numpy as np
-from numpy.compat import asbytes, asbytes_nested, sixu
+from numpy.compat import asbytes_nested, sixu
 from numpy.testing import (
     run_module_suite, assert_, assert_array_equal, assert_raises, raises,
     dec, SkipTest
@@ -546,7 +546,7 @@ def test_pickle_python2_python3():
         xrange = __builtin__.xrange
 
     expected = np.array([None, xrange, sixu('\u512a\u826f'),
-                         asbytes('\xe4\xb8\x8d\xe8\x89\xaf')],
+                         b'\xe4\xb8\x8d\xe8\x89\xaf'],
                         dtype=object)
 
     for fname in ['py2-objarr.npy', 'py2-objarr.npz',
@@ -778,11 +778,11 @@ def test_bad_header():
     # header of length less than 2 should fail
     s = BytesIO()
     assert_raises(ValueError, format.read_array_header_1_0, s)
-    s = BytesIO(asbytes('1'))
+    s = BytesIO(b'1')
     assert_raises(ValueError, format.read_array_header_1_0, s)
 
     # header shorter than indicated size should fail
-    s = BytesIO(asbytes('\x01\x00'))
+    s = BytesIO(b'\x01\x00')
     assert_raises(ValueError, format.read_array_header_1_0, s)
 
     # headers without the exact keys required should fail

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -532,7 +532,7 @@ class TestLoadTxt(TestCase):
         c.write('# comment\n1,2,3,5\n')
         c.seek(0)
         x = np.loadtxt(c, dtype=int, delimiter=',',
-                       comments=unicode('#'))
+                       comments=u'#')
         a = np.array([1, 2, 3, 5], int)
         assert_array_equal(x, a)
 

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -15,7 +15,6 @@ from numpy import (
     )
 
 import numpy as np
-from numpy.compat import asbytes_nested
 
 
 def get_mat(n):
@@ -91,7 +90,7 @@ class TestEye(TestCase):
 
     def test_strings(self):
         assert_equal(eye(2, 2, dtype='S3'),
-                     asbytes_nested([['1', ''], ['', '1']]))
+                     [[b'1', b''], [b'', b'1']])
 
     def test_bool(self):
         assert_equal(eye(2, 2, dtype=bool), [[True, False], [False, True]])

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -29,14 +29,13 @@ from numpy.core.multiarray import normalize_axis_index
 from numpy.lib import triu, asfarray
 from numpy.linalg import lapack_lite, _umath_linalg
 from numpy.matrixlib.defmatrix import matrix_power
-from numpy.compat import asbytes
 
 # For Python2/3 compatibility
-_N = asbytes('N')
-_V = asbytes('V')
-_A = asbytes('A')
-_S = asbytes('S')
-_L = asbytes('L')
+_N = b'N'
+_V = b'V'
+_A = b'A'
+_S = b'S'
+_L = b'L'
 
 fortran_int = intc
 

--- a/numpy/linalg/tests/test_build.py
+++ b/numpy/linalg/tests/test_build.py
@@ -7,8 +7,6 @@ import re
 from numpy.linalg import lapack_lite
 from numpy.testing import TestCase, dec, run_module_suite
 
-from numpy.compat import asbytes_nested
-
 
 class FindDependenciesLdd(object):
 
@@ -49,7 +47,7 @@ class TestF77Mismatch(TestCase):
     def test_lapack(self):
         f = FindDependenciesLdd()
         deps = f.grep_dependencies(lapack_lite.__file__,
-                                   asbytes_nested(['libg2c', 'libgfortran']))
+                                   [b'libg2c', b'libgfortran'])
         self.assertFalse(len(deps) > 1,
                          """Both g77 and gfortran runtimes linked in lapack_lite ! This is likely to
 cause random crashes and wrong results. See numpy INSTALL.txt for more

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -39,7 +39,7 @@ from numpy import ndarray, amax, amin, iscomplexobj, bool_, _NoValue
 from numpy import array as narray
 from numpy.lib.function_base import angle
 from numpy.compat import (
-    getargspec, formatargspec, long, basestring, unicode, bytes, sixu
+    getargspec, formatargspec, long, basestring, unicode, bytes
     )
 from numpy import expand_dims as n_expand_dims
 from numpy.core.multiarray import normalize_axis_index
@@ -159,7 +159,7 @@ default_filler = {'b': True,
                   'S': b'N/A',
                   'u': 999999,
                   'V': '???',
-                  'U': sixu('N/A')
+                  'U': u'N/A'
                   }
 
 # Add datetime64 and timedelta64 types

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1696,7 +1696,7 @@ class TestFillingValues(TestCase):
         assert_equal(fval, default_fill_value(0))
 
         fval = _check_fill_value(0, "|S3")
-        assert_equal(fval, asbytes("0"))
+        assert_equal(fval, b"0")
         fval = _check_fill_value(None, "|S3")
         assert_equal(fval, default_fill_value(b"camelot!"))
         self.assertRaises(TypeError, _check_fill_value, 1e+20, int)
@@ -1709,7 +1709,7 @@ class TestFillingValues(TestCase):
         # A check on a list should return a single record
         fval = _check_fill_value([-999, -12345678.9, "???"], ndtype)
         self.assertTrue(isinstance(fval, ndarray))
-        assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
+        assert_equal(fval.item(), [-999, -12345678.9, b"???"])
         # A check on None should output the defaults
         fval = _check_fill_value(None, ndtype)
         self.assertTrue(isinstance(fval, ndarray))
@@ -1720,7 +1720,7 @@ class TestFillingValues(TestCase):
         fill_val = np.array((-999, -12345678.9, "???"), dtype=ndtype)
         fval = _check_fill_value(fill_val, ndtype)
         self.assertTrue(isinstance(fval, ndarray))
-        assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
+        assert_equal(fval.item(), [-999, -12345678.9, b"???"])
 
         #.....Using a flexible type w/ a different type shouldn't matter
         # BEHAVIOR in 1.5 and earlier: match structured types by position
@@ -1733,20 +1733,20 @@ class TestFillingValues(TestCase):
         with assert_warns(FutureWarning):
             fval = _check_fill_value(fill_val, ndtype)
         self.assertTrue(isinstance(fval, ndarray))
-        assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
+        assert_equal(fval.item(), [-999, -12345678.9, b"???"])
 
         #.....Using an object-array shouldn't matter either
         fill_val = np.ndarray(shape=(1,), dtype=object)
-        fill_val[0] = (-999, -12345678.9, asbytes("???"))
+        fill_val[0] = (-999, -12345678.9, b"???")
         fval = _check_fill_value(fill_val, object)
         self.assertTrue(isinstance(fval, ndarray))
-        assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
+        assert_equal(fval.item(), [-999, -12345678.9, b"???"])
         # NOTE: This test was never run properly as "fill_value" rather than
         # "fill_val" was assigned.  Written properly, it fails.
         #fill_val = np.array((-999, -12345678.9, "???"))
         #fval = _check_fill_value(fill_val, ndtype)
         #self.assertTrue(isinstance(fval, ndarray))
-        #assert_equal(fval.item(), [-999, -12345678.9, asbytes("???")])
+        #assert_equal(fval.item(), [-999, -12345678.9, b"???"])
         #.....One-field-only flexible type should work as well
         ndtype = [("a", int)]
         fval = _check_fill_value(-999999999, ndtype)
@@ -1786,14 +1786,14 @@ class TestFillingValues(TestCase):
         mtype = [('f', float), ('s', '|S3')]
         x = array([(1, 'a'), (2, 'b'), (pi, 'pi')], dtype=mtype)
         x.fill_value = 999
-        assert_equal(x.fill_value.item(), [999., asbytes('999')])
+        assert_equal(x.fill_value.item(), [999., b'999'])
         assert_equal(x['f'].fill_value, 999)
-        assert_equal(x['s'].fill_value, asbytes('999'))
+        assert_equal(x['s'].fill_value, b'999')
 
         x.fill_value = (9, '???')
-        assert_equal(x.fill_value.item(), (9, asbytes('???')))
+        assert_equal(x.fill_value.item(), (9, b'???'))
         assert_equal(x['f'].fill_value, 9)
-        assert_equal(x['s'].fill_value, asbytes('???'))
+        assert_equal(x['s'].fill_value, b'???')
 
         x = array([1, 2, 3.1])
         x.fill_value = 999
@@ -3217,8 +3217,8 @@ class TestMaskedArrayMethods(TestCase):
                   dtype=[('a', int), ('b', float), ('c', '|S8')])
         x[-1] = masked
         assert_equal(x.tolist(),
-                     [(1, 1.1, asbytes('one')),
-                      (2, 2.2, asbytes('two')),
+                     [(1, 1.1, b'one'),
+                      (2, 2.2, b'two'),
                       (None, None, None)])
         # ... on structured array w/ masked fields
         a = array([(1, 2,), (3, 4)], mask=[(0, 1), (0, 0)],

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1757,7 +1757,7 @@ class TestFillingValues(TestCase):
         # Tests the behavior of fill_value during conversion
         # We had a tailored comment to make sure special attributes are
         # properly dealt with
-        a = array(asbytes_nested(['3', '4', '5']))
+        a = array([b'3', b'4', b'5'])
         a._optinfo.update({'comment':"updated!"})
 
         b = array(a, dtype=int)
@@ -4279,7 +4279,7 @@ class TestMaskedFields(TestCase):
 
         assert_equal(base_c.dtype, '|S8')
         assert_equal(base_c._data,
-                     asbytes_nested(['pi', 'two', 'three', 'four', 'five']))
+                     [b'pi', b'two', b'three', b'four', b'five'])
 
     def test_set_record_slice(self):
         base = self.data['base']
@@ -4294,7 +4294,7 @@ class TestMaskedFields(TestCase):
 
         assert_equal(base_c.dtype, '|S8')
         assert_equal(base_c._data,
-                     asbytes_nested(['pi', 'pi', 'pi', 'four', 'five']))
+                     [b'pi', b'pi', b'pi', b'four', b'five'])
 
     def test_mask_element(self):
         "Check record access"

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -13,7 +13,6 @@ import pickle
 import numpy as np
 import numpy.ma as ma
 from numpy import recarray
-from numpy.compat import asbytes_nested
 from numpy.ma import masked, nomask
 from numpy.testing import TestCase, run_module_suite, temppath
 from numpy.core.records import (
@@ -39,7 +38,7 @@ class TestMRecords(TestCase):
         # Generic setup
         ilist = [1, 2, 3, 4, 5]
         flist = [1.1, 2.2, 3.3, 4.4, 5.5]
-        slist = asbytes_nested(['one', 'two', 'three', 'four', 'five'])
+        slist = [b'one', b'two', b'three', b'four', b'five']
         ddtype = [('a', int), ('b', float), ('c', '|S8')]
         mask = [0, 1, 0, 0, 1]
         self.base = ma.array(list(zip(ilist, flist, slist)),
@@ -233,7 +232,7 @@ class TestMRecords(TestCase):
         assert_equal(mbase.b._data, [5., 5., 3.3, 4.4, 5.5])
         assert_equal(mbase.b._mask, [0, 0, 0, 0, 1])
         assert_equal(mbase.c._data,
-                     asbytes_nested(['5', '5', 'three', 'four', 'five']))
+                     [b'5', b'5', b'three', b'four', b'five'])
         assert_equal(mbase.b._mask, [0, 0, 0, 0, 1])
 
         mbase = base.view(mrecarray).copy()
@@ -243,7 +242,7 @@ class TestMRecords(TestCase):
         assert_equal(mbase.b._data, [1.1, 2.2, 3.3, 4.4, 5.5])
         assert_equal(mbase.b._mask, [1, 1, 0, 0, 1])
         assert_equal(mbase.c._data,
-                     asbytes_nested(['one', 'two', 'three', 'four', 'five']))
+                     [b'one', b'two', b'three', b'four', b'five'])
         assert_equal(mbase.b._mask, [1, 1, 0, 0, 1])
 
     def test_setslices_hardmask(self):
@@ -256,7 +255,7 @@ class TestMRecords(TestCase):
             assert_equal(mbase.a._data, [1, 2, 3, 5, 5])
             assert_equal(mbase.b._data, [1.1, 2.2, 3.3, 5, 5.5])
             assert_equal(mbase.c._data,
-                         asbytes_nested(['one', 'two', 'three', '5', 'five']))
+                         [b'one', b'two', b'three', b'5', b'five'])
             assert_equal(mbase.a._mask, [0, 1, 0, 0, 1])
             assert_equal(mbase.b._mask, mbase.a._mask)
             assert_equal(mbase.b._mask, mbase.c._mask)

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -13,7 +13,7 @@ import pickle
 import numpy as np
 import numpy.ma as ma
 from numpy import recarray
-from numpy.compat import asbytes, asbytes_nested
+from numpy.compat import asbytes_nested
 from numpy.ma import masked, nomask
 from numpy.testing import TestCase, run_module_suite, temppath
 from numpy.core.records import (
@@ -69,7 +69,7 @@ class TestMRecords(TestCase):
         mbase_first = mbase[0]
         assert_(isinstance(mbase_first, mrecarray))
         assert_equal(mbase_first.dtype, mbase.dtype)
-        assert_equal(mbase_first.tolist(), (1, 1.1, asbytes('one')))
+        assert_equal(mbase_first.tolist(), (1, 1.1, b'one'))
         # Used to be mask, now it's recordmask
         assert_equal(mbase_first.recordmask, nomask)
         assert_equal(mbase_first._mask.item(), (False, False, False))
@@ -126,7 +126,7 @@ class TestMRecords(TestCase):
         assert_equal(mbase.c.mask, [1]*5)
         assert_equal(mbase.c.recordmask, [1]*5)
         assert_equal(ma.getmaskarray(mbase['c']), [1]*5)
-        assert_equal(ma.getdata(mbase['c']), [asbytes('N/A')]*5)
+        assert_equal(ma.getdata(mbase['c']), [b'N/A']*5)
         assert_equal(mbase._mask.tolist(),
                      np.array([(0, 0, 1),
                                (0, 1, 1),
@@ -328,8 +328,8 @@ class TestMRecords(TestCase):
                           fill_value=(99999, 99999., 'N/A'))
 
         assert_equal(mrec.tolist(),
-                     [(1, 1.1, None), (2, 2.2, asbytes('two')),
-                      (None, None, asbytes('three'))])
+                     [(1, 1.1, None), (2, 2.2, b'two'),
+                      (None, None, b'three')])
 
     def test_withnames(self):
         # Test the creation w/ format and names
@@ -341,7 +341,7 @@ class TestMRecords(TestCase):
         # Test that 'exotic' formats are processed properly
         easy = mrecarray(1, dtype=[('i', int), ('s', '|S8'), ('f', float)])
         easy[0] = masked
-        assert_equal(easy.filled(1).item(), (1, asbytes('1'), 1.))
+        assert_equal(easy.filled(1).item(), (1, b'1', 1.))
 
         solo = mrecarray(1, dtype=[('f0', '<f8', (2, 2))])
         solo[0] = masked
@@ -405,12 +405,12 @@ class TestMRecordsImport(TestCase):
         # Generic setup
         _a = ma.array([1, 2, 3], mask=[0, 0, 1], dtype=int)
         _b = ma.array([1.1, 2.2, 3.3], mask=[0, 0, 1], dtype=float)
-        _c = ma.array(list(map(asbytes, ['one', 'two', 'three'])),
+        _c = ma.array([b'one', b'two', b'three'],
                       mask=[0, 0, 1], dtype='|S8')
         ddtype = [('a', int), ('b', float), ('c', '|S8')]
         mrec = fromarrays([_a, _b, _c], dtype=ddtype,
-                          fill_value=(asbytes('99999'), asbytes('99999.'),
-                                      asbytes('N/A')))
+                          fill_value=(b'99999', b'99999.',
+                                      b'N/A'))
         nrec = recfromarrays((_a._data, _b._data, _c._data), dtype=ddtype)
         self.data = (mrec, nrec, ddtype)
 

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import (assert_, TestCase, assert_array_equal,
                            assert_allclose, run_module_suite,
                            suppress_warnings)
-from numpy.compat import sixu
 
 rlevel = 1
 
@@ -44,7 +43,7 @@ class TestRegression(TestCase):
 
     def test_masked_array_repr_unicode(self):
         # Ticket #1256
-        repr(np.ma.array(sixu("Unicode")))
+        repr(np.ma.array(u"Unicode"))
 
     def test_atleast_2d(self):
         # Ticket #1559

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -7,7 +7,6 @@ from numpy.testing import (
         assert_warns, assert_no_warnings, assert_array_equal,
         assert_array_almost_equal, suppress_warnings)
 from numpy import random
-from numpy.compat import asbytes
 import sys
 import warnings
 
@@ -393,7 +392,7 @@ class TestRandomDist(TestCase):
     def test_bytes(self):
         np.random.seed(self.seed)
         actual = np.random.bytes(10)
-        desired = asbytes('\x82Ui\x9e\xff\x97+Wf\xa5')
+        desired = b'\x82Ui\x9e\xff\x97+Wf\xa5'
         assert_equal(actual, desired)
 
     def test_shuffle(self):

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -9,7 +9,7 @@ from os.path import join as pathjoin, isfile, dirname, basename
 import sys
 from subprocess import Popen, PIPE
 import numpy as np
-from numpy.compat.py3k import basestring, asbytes
+from numpy.compat.py3k import basestring
 from nose.tools import assert_equal
 from numpy.testing.decorators import skipif
 from numpy.testing import assert_
@@ -71,7 +71,7 @@ def test_f2py():
             f2py_cmd = r"%s\Scripts\f2py.py" % exe_dir
 
         code, stdout, stderr = run_command([sys.executable, f2py_cmd, '-v'])
-        success = stdout.strip() == asbytes('2')
+        success = stdout.strip() == b'2'
         assert_(success, "Warning: f2py not found in path")
     else:
         version = sys.version_info
@@ -84,7 +84,7 @@ def test_f2py():
         for f2py_cmd in f2py_cmds:
             try:
                 code, stdout, stderr = run_command([f2py_cmd, '-v'])
-                assert_equal(stdout.strip(), asbytes('2'))
+                assert_equal(stdout.strip(), b'2')
                 success = True
                 break
             except:


### PR DESCRIPTION
This transforms strings to use the `u` and `b` prefixes for unicode and bytes:

 * `asbytes('hello')` &rarr; `b'hello'`
 * `asbytes_nested(['a', 'b'])` &rarr; `[b'a', b'b']`
 * `asunicode('hello')` &rarr; `u'hello'`
 * `unicode('hello')` &rarr; `u'hello'`
 * `sixu('hello')` &rarr; `u'hello'`

This is fine because `b` is supported on 2.7 and 3.x, and `u` is supported on 2.x and 3.3+. Our minimum versions are now 2.7 and 3.4?

What we can't do is transform `asbytes("tests %d" % num)`, because %-formatting
fails on bytes in python 3.x < 3.5.

As a result, <s>`asunicode` and</s> `sixu` are now not used anywhere.