### PR TITLE
BENCH: use initialized memory for count_nonzero benchmark

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -137,8 +137,8 @@ class CountNonzero(Benchmark):
     ]
 
     def setup(self, numaxes, size, dtype):
-        self.x = np.empty(shape=(
-            numaxes, size), dtype=dtype)
+        self.x = np.arange(numaxes * size).reshape(numaxes, size)
+        self.x = (self.x % 3).astype(dtype)
 
     def time_count_nonzero(self, numaxes, size, dtype):
         np.count_nonzero(self.x)

--- a/doc/source/dev/gitwash/development_workflow.rst
+++ b/doc/source/dev/gitwash/development_workflow.rst
@@ -174,6 +174,7 @@ what not to do; the reader has to go look for context elsewhere.
 Standard acronyms to start the commit message with are::
 
    API: an (incompatible) API change
+   BENCH: changes to the benchmark suite
    BLD: change related to building numpy
    BUG: bug fix
    DEP: deprecate something, or remove a deprecated object


### PR DESCRIPTION
For the bool case uninitialized memory can randomly go into the slow
path handling values different than 0 or 1.