### PR TITLE
DOC: Include nextafter and spacing function in documentation.

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -98,6 +98,8 @@ Floating point routines
    copysign
    frexp
    ldexp
+   nextafter
+   spacing
 
 Arithmetic operations
 ---------------------


### PR DESCRIPTION
Fixes #8831 

@eric-wieser Our hunch was correct. Locally it worked fine by including them in `doc/source/reference/routines.math.rst`. :)