### PR TITLE
DOC: Several documentation fixes (broken links, incorrect sphinx syntax, duplicate sections)

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -205,7 +205,7 @@ From scratch
 
     If *subtype* is of an array subclass instead of the base
     :c:data:`&PyArray_Type<PyArray_Type>`, then *obj* is the object to pass to
-    the :obj:`__array_finalize__` method of the subclass.
+    the :obj:`~numpy.class.__array_finalize__` method of the subclass.
 
     If *data* is ``NULL``, then new memory will be allocated and *flags*
     can be non-zero to indicate a Fortran-style contiguous array. If
@@ -378,7 +378,7 @@ From other objects
     expose the array interface), then a new array will be created (and
     filled from *op* using the sequence protocol). The new array will
     have :c:data:`NPY_DEFAULT` as its flags member. The *context* argument
-    is passed to the :obj:`__array__` method of *op* and is only used if
+    is passed to the :obj:`~numpy.class.__array__` method of *op* and is only used if
     the array is constructed that way. Almost always this
     parameter is ``NULL``.
 
@@ -499,7 +499,7 @@ From other objects
     actually converting to an array. PyArray_FromAny calls this function
     to analyze its input.
 
-    In some cases, such as structured arrays and the __array__ interface,
+    In some cases, such as structured arrays and the :obj:`~numpy.class.__array__` interface,
     a data type needs to be used to make sense of the object.  When
     this is needed, provide a Descr for 'requested_dtype', otherwise
     provide NULL. This reference is not stolen. Also, if the requested
@@ -607,9 +607,9 @@ From other objects
 .. c:function:: PyObject* PyArray_FromArrayAttr(PyObject* op, PyArray_Descr* dtype, PyObject* context)
 
     Return an ndarray object from a Python object that exposes the
-    :obj:`__array__` method. The :obj:`__array__` method can take 0, 1, or 2
+    :obj:`~numpy.class.__array__` method. The :obj:`~numpy.class.__array__` method can take 0, 1, or 2
     arguments ([dtype, context]) where *context* is used to pass
-    information about where the :obj:`__array__` method is being called
+    information about where the :obj:`~numpy.class.__array__` method is being called
     from (currently only used in ufuncs).
 
 .. c:function:: PyObject* PyArray_ContiguousFromAny(PyObject* op, int typenum, int min_depth, int max_depth)
@@ -787,7 +787,7 @@ General check of Python Type
     conversion occurs. Otherwise, out will contain a borrowed
     reference to Py_NotImplemented and no error condition is set.
     This version allows setting of the type and context in the part of
-    the array interface that looks for the :obj:`__array__` attribute.
+    the array interface that looks for the :obj:`~numpy.class.__array__` attribute.
 
 .. c:function:: PyArray_IsZeroDim(op)
 
@@ -3188,7 +3188,7 @@ Priority
 
 .. c:function:: double PyArray_GetPriority(PyObject* obj, double def)
 
-    Return the :obj:`__array_priority__` attribute (converted to a
+    Return the :obj:`~numpy.class.__array_priority__` attribute (converted to a
     double) of *obj* or *def* if no attribute of that name
     exists. Fast returns that avoid the attribute lookup are provided
     for objects of type :c:data:`PyArray_Type`.

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -204,7 +204,7 @@ From scratch
     new array is *descr*.
 
     If *subtype* is of an array subclass instead of the base
-    :c:data:`&PyArray_Type`, then *obj* is the object to pass to
+    :c:data:`&PyArray_Type<PyArray_Type>`, then *obj* is the object to pass to
     the :obj:`__array_finalize__` method of the subclass.
 
     If *data* is ``NULL``, then new memory will be allocated and *flags*

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1545,7 +1545,7 @@ Conversion
 
 .. c:function:: PyObject* PyArray_GetField(PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
-    Equivalent to :meth:`ndarray.getfield` (*self*, *dtype*, *offset*). Return
+    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). Return
     a new array of the given *dtype* using the data in the current
     array at a specified *offset* in bytes. The *offset* plus the
     itemsize of the new array type must be less than *self*
@@ -1557,7 +1557,7 @@ Conversion
 
 .. c:function:: int PyArray_SetField(PyArrayObject* self, PyArray_Descr* dtype, int offset, PyObject* val)
 
-    Equivalent to :meth:`ndarray.setfield` (*self*, *val*, *dtype*, *offset*
+    Equivalent to :meth:`ndarray.setfield<numpy.ndarray.setfield>` (*self*, *val*, *dtype*, *offset*
     ). Set the field starting at *offset* in bytes and of the given
     *dtype* to *val*. The *offset* plus *dtype* ->elsize must be less
     than *self* ->descr->elsize or an error is raised. Otherwise, the
@@ -1569,14 +1569,14 @@ Conversion
 
 .. c:function:: PyObject* PyArray_Byteswap(PyArrayObject* self, Bool inplace)
 
-    Equivalent to :meth:`ndarray.byteswap` (*self*, *inplace*). Return an array
+    Equivalent to :meth:`ndarray.byteswap<numpy.ndarray.byteswap>` (*self*, *inplace*). Return an array
     whose data area is byteswapped. If *inplace* is non-zero, then do
     the byteswap inplace and return a reference to self. Otherwise,
     create a byteswapped copy and leave self unchanged.
 
 .. c:function:: PyObject* PyArray_NewCopy(PyArrayObject* old, NPY_ORDER order)
 
-    Equivalent to :meth:`ndarray.copy` (*self*, *fortran*). Make a copy of the
+    Equivalent to :meth:`ndarray.copy<numpy.ndarray.copy>` (*self*, *fortran*). Make a copy of the
     *old* array. The returned array is always aligned and writeable
     with data interpreted the same as the old array. If *order* is
     :c:data:`NPY_CORDER`, then a C-style contiguous array is returned. If
@@ -1587,12 +1587,12 @@ Conversion
 
 .. c:function:: PyObject* PyArray_ToList(PyArrayObject* self)
 
-    Equivalent to :meth:`ndarray.tolist` (*self*). Return a nested Python list
+    Equivalent to :meth:`ndarray.tolist<numpy.ndarray.tolist>` (*self*). Return a nested Python list
     from *self*.
 
 .. c:function:: PyObject* PyArray_ToString(PyArrayObject* self, NPY_ORDER order)
 
-    Equivalent to :meth:`ndarray.tobytes` (*self*, *order*). Return the bytes
+    Equivalent to :meth:`ndarray.tobytes<numpy.ndarray.tobytes>` (*self*, *order*). Return the bytes
     of this array in a Python string.
 
 .. c:function:: PyObject* PyArray_ToFile(PyArrayObject* self, FILE* fp, char* sep, char* format)
@@ -1629,7 +1629,7 @@ Conversion
 
 .. c:function:: PyObject* PyArray_View(PyArrayObject* self, PyArray_Descr* dtype, PyTypeObject *ptype)
 
-    Equivalent to :meth:`ndarray.view` (*self*, *dtype*). Return a new
+    Equivalent to :meth:`ndarray.view<numpy.ndarray.view>` (*self*, *dtype*). Return a new
     view of the array *self* as possibly a different data-type, *dtype*,
     and different array subclass *ptype*.
 
@@ -1656,14 +1656,14 @@ Shape Manipulation
 
 .. c:function:: PyObject* PyArray_Reshape(PyArrayObject* self, PyObject* shape)
 
-    Equivalent to :meth:`ndarray.reshape` (*self*, *shape*) where *shape* is a
+    Equivalent to :meth:`ndarray.reshape<numpy.ndarray.reshape>` (*self*, *shape*) where *shape* is a
     sequence. Converts *shape* to a :c:type:`PyArray_Dims` structure and
     calls :c:func:`PyArray_Newshape` internally.
     For back-ward compatibility -- Not recommended
 
 .. c:function:: PyObject* PyArray_Squeeze(PyArrayObject* self)
 
-    Equivalent to :meth:`ndarray.squeeze` (*self*). Return a new view of *self*
+    Equivalent to :meth:`ndarray.squeeze<numpy.ndarray.squeeze>` (*self*). Return a new view of *self*
     with all of the dimensions of length 1 removed from the shape.
 
 .. warning::
@@ -1673,13 +1673,13 @@ Shape Manipulation
 
 .. c:function:: PyObject* PyArray_SwapAxes(PyArrayObject* self, int a1, int a2)
 
-    Equivalent to :meth:`ndarray.swapaxes` (*self*, *a1*, *a2*). The returned
+    Equivalent to :meth:`ndarray.swapaxes<numpy.ndarray.swapaxes>` (*self*, *a1*, *a2*). The returned
     array is a new view of the data in *self* with the given axes,
     *a1* and *a2*, swapped.
 
 .. c:function:: PyObject* PyArray_Resize(PyArrayObject* self, PyArray_Dims* newshape, int refcheck, NPY_ORDER fortran)
 
-    Equivalent to :meth:`ndarray.resize` (*self*, *newshape*, refcheck
+    Equivalent to :meth:`ndarray.resize<numpy.ndarray.resize>` (*self*, *newshape*, refcheck
     ``=`` *refcheck*, order= fortran ). This function only works on
     single-segment arrays. It changes the shape of *self* inplace and
     will reallocate the memory for *self* if *newshape* has a
@@ -1695,7 +1695,7 @@ Shape Manipulation
 
 .. c:function:: PyObject* PyArray_Transpose(PyArrayObject* self, PyArray_Dims* permute)
 
-    Equivalent to :meth:`ndarray.transpose` (*self*, *permute*). Permute the
+    Equivalent to :meth:`ndarray.transpose<numpy.ndarray.transpose>` (*self*, *permute*). Permute the
     axes of the ndarray object *self* according to the data structure
     *permute* and return the result. If *permute* is ``NULL``, then
     the resulting array has its axes reversed. For example if *self*
@@ -1706,7 +1706,7 @@ Shape Manipulation
 
 .. c:function:: PyObject* PyArray_Flatten(PyArrayObject* self, NPY_ORDER order)
 
-    Equivalent to :meth:`ndarray.flatten` (*self*, *order*). Return a 1-d copy
+    Equivalent to :meth:`ndarray.flatten<numpy.ndarray.flatten>` (*self*, *order*). Return a 1-d copy
     of the array. If *order* is :c:data:`NPY_FORTRANORDER` the elements are
     scanned out in Fortran order (first-dimension varies the
     fastest). If *order* is :c:data:`NPY_CORDER`, the elements of ``self``
@@ -1728,7 +1728,7 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_TakeFrom(PyArrayObject* self, PyObject* indices, int axis, PyArrayObject* ret, NPY_CLIPMODE clipmode)
 
-    Equivalent to :meth:`ndarray.take` (*self*, *indices*, *axis*, *ret*,
+    Equivalent to :meth:`ndarray.take<numpy.ndarray.take>` (*self*, *indices*, *axis*, *ret*,
     *clipmode*) except *axis* =None in Python is obtained by setting
     *axis* = :c:data:`NPY_MAXDIMS` in C. Extract the items from self
     indicated by the integer-valued *indices* along the given *axis.*
@@ -1753,7 +1753,7 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Repeat(PyArrayObject* self, PyObject* op, int axis)
 
-    Equivalent to :meth:`ndarray.repeat` (*self*, *op*, *axis*). Copy the
+    Equivalent to :meth:`ndarray.repeat<numpy.ndarray.repeat>` (*self*, *op*, *axis*). Copy the
     elements of *self*, *op* times along the given *axis*. Either
     *op* is a scalar integer or a sequence of length *self*
     ->dimensions[ *axis* ] indicating how many times to repeat each
@@ -1761,7 +1761,7 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Choose(PyArrayObject* self, PyObject* op, PyArrayObject* ret, NPY_CLIPMODE clipmode)
 
-    Equivalent to :meth:`ndarray.choose` (*self*, *op*, *ret*, *clipmode*).
+    Equivalent to :meth:`ndarray.choose<numpy.ndarray.choose>` (*self*, *op*, *ret*, *clipmode*).
     Create a new array by selecting elements from the sequence of
     arrays in *op* based on the integer values in *self*. The arrays
     must all be broadcastable to the same shape and the entries in
@@ -1786,12 +1786,12 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Sort(PyArrayObject* self, int axis)
 
-    Equivalent to :meth:`ndarray.sort` (*self*, *axis*). Return an array with
+    Equivalent to :meth:`ndarray.sort<numpy.ndarray.sort>` (*self*, *axis*). Return an array with
     the items of *self* sorted along *axis*.
 
 .. c:function:: PyObject* PyArray_ArgSort(PyArrayObject* self, int axis)
 
-    Equivalent to :meth:`ndarray.argsort` (*self*, *axis*). Return an array of
+    Equivalent to :meth:`ndarray.argsort<numpy.ndarray.argsort>` (*self*, *axis*). Return an array of
     indices such that selection of these indices along the given
     ``axis`` would return a sorted version of *self*. If *self*
     ->descr is a data-type with fields defined, then
@@ -1822,7 +1822,7 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_SearchSorted(PyArrayObject* self, PyObject* values, NPY_SEARCHSIDE side, PyObject* perm)
 
-    Equivalent to :meth:`ndarray.searchsorted` (*self*, *values*, *side*,
+    Equivalent to :meth:`ndarray.searchsorted<numpy.ndarray.searchsorted>` (*self*, *values*, *side*,
     *perm*). Assuming *self* is a 1-d array in ascending order, then the
     output is an array of indices the same shape as *values* such that, if
     the elements in *values* were inserted before the indices, the order of
@@ -1840,7 +1840,7 @@ Item selection and manipulation
 
 .. c:function:: int PyArray_Partition(PyArrayObject *self, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
 
-    Equivalent to :meth:`ndarray.partition` (*self*, *ktharray*, *axis*,
+    Equivalent to :meth:`ndarray.partition<numpy.ndarray.partition>` (*self*, *ktharray*, *axis*,
     *kind*). Partitions the array so that the values of the element indexed by
     *ktharray* are in the positions they would be if the array is fully sorted
     and places all elements smaller than the kth before and all elements equal
@@ -1855,13 +1855,13 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_ArgPartition(PyArrayObject *op, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
 
-    Equivalent to :meth:`ndarray.argpartition` (*self*, *ktharray*, *axis*,
+    Equivalent to :meth:`ndarray.argpartition<numpy.ndarray.argpartition>` (*self*, *ktharray*, *axis*,
     *kind*). Return an array of indices such that selection of these indices
     along the given ``axis`` would return a partitioned version of *self*.
 
 .. c:function:: PyObject* PyArray_Diagonal(PyArrayObject* self, int offset, int axis1, int axis2)
 
-    Equivalent to :meth:`ndarray.diagonal` (*self*, *offset*, *axis1*, *axis2*
+    Equivalent to :meth:`ndarray.diagonal<numpy.ndarray.diagonal>` (*self*, *offset*, *axis1*, *axis2*
     ). Return the *offset* diagonals of the 2-d arrays defined by
     *axis1* and *axis2*.
 
@@ -1873,7 +1873,7 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Nonzero(PyArrayObject* self)
 
-    Equivalent to :meth:`ndarray.nonzero` (*self*). Returns a tuple of index
+    Equivalent to :meth:`ndarray.nonzero<numpy.ndarray.nonzero>` (*self*). Returns a tuple of index
     arrays that select elements of *self* that are nonzero. If (nd=
     :c:func:`PyArray_NDIM` ( ``self`` ))==1, then a single index array is
     returned. The index arrays have data type :c:data:`NPY_INTP`. If a
@@ -1881,7 +1881,7 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Compress(PyArrayObject* self, PyObject* condition, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.compress` (*self*, *condition*, *axis*
+    Equivalent to :meth:`ndarray.compress<numpy.ndarray.compress>` (*self*, *condition*, *axis*
     ). Return the elements along *axis* corresponding to elements of
     *condition* that are true.
 
@@ -1897,12 +1897,12 @@ Calculation
 
 .. c:function:: PyObject* PyArray_ArgMax(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.argmax` (*self*, *axis*). Return the index of
+    Equivalent to :meth:`ndarray.argmax<numpy.ndarray.argmax>` (*self*, *axis*). Return the index of
     the largest element of *self* along *axis*.
 
 .. c:function:: PyObject* PyArray_ArgMin(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.argmin` (*self*, *axis*). Return the index of
+    Equivalent to :meth:`ndarray.argmin<numpy.ndarray.argmin>` (*self*, *axis*). Return the index of
     the smallest element of *self* along *axis*.
 
 
@@ -1919,20 +1919,20 @@ Calculation
 
 .. c:function:: PyObject* PyArray_Max(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.max` (*self*, *axis*). Returns the largest
+    Equivalent to :meth:`ndarray.max<numpy.ndarray.max>` (*self*, *axis*). Returns the largest
     element of *self* along the given *axis*. When the result is a single
     element, returns a numpy scalar instead of an ndarray.
 
 .. c:function:: PyObject* PyArray_Min(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.min` (*self*, *axis*). Return the smallest
+    Equivalent to :meth:`ndarray.min<numpy.ndarray.min>` (*self*, *axis*). Return the smallest
     element of *self* along the given *axis*. When the result is a single
     element, returns a numpy scalar instead of an ndarray.
 
 
 .. c:function:: PyObject* PyArray_Ptp(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.ptp` (*self*, *axis*). Return the difference
+    Equivalent to :meth:`ndarray.ptp<numpy.ndarray.ptp>` (*self*, *axis*). Return the difference
     between the largest element of *self* along *axis* and the
     smallest element of *self* along *axis*. When the result is a single
     element, returns a numpy scalar instead of an ndarray.
@@ -1951,14 +1951,14 @@ Calculation
 
 .. c:function:: PyObject* PyArray_Mean(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.mean` (*self*, *axis*, *rtype*). Returns the
+    Equivalent to :meth:`ndarray.mean<numpy.ndarray.mean>` (*self*, *axis*, *rtype*). Returns the
     mean of the elements along the given *axis*, using the enumerated
     type *rtype* as the data type to sum in. Default sum behavior is
     obtained using :c:data:`NPY_NOTYPE` for *rtype*.
 
 .. c:function:: PyObject* PyArray_Trace(PyArrayObject* self, int offset, int axis1, int axis2, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.trace` (*self*, *offset*, *axis1*, *axis2*,
+    Equivalent to :meth:`ndarray.trace<numpy.ndarray.trace>` (*self*, *offset*, *axis1*, *axis2*,
     *rtype*). Return the sum (using *rtype* as the data type of
     summation) over the *offset* diagonal elements of the 2-d arrays
     defined by *axis1* and *axis2* variables. A positive offset
@@ -1967,62 +1967,62 @@ Calculation
 
 .. c:function:: PyObject* PyArray_Clip(PyArrayObject* self, PyObject* min, PyObject* max)
 
-    Equivalent to :meth:`ndarray.clip` (*self*, *min*, *max*). Clip an array,
+    Equivalent to :meth:`ndarray.clip<numpy.ndarray.clip>` (*self*, *min*, *max*). Clip an array,
     *self*, so that values larger than *max* are fixed to *max* and
     values less than *min* are fixed to *min*.
 
 .. c:function:: PyObject* PyArray_Conjugate(PyArrayObject* self)
 
-    Equivalent to :meth:`ndarray.conjugate` (*self*).
+    Equivalent to :meth:`ndarray.conjugate<numpy.ndarray.conjugate>` (*self*).
     Return the complex conjugate of *self*. If *self* is not of
     complex data type, then return *self* with a reference.
 
 .. c:function:: PyObject* PyArray_Round(PyArrayObject* self, int decimals, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.round` (*self*, *decimals*, *out*). Returns
+    Equivalent to :meth:`ndarray.round<numpy.ndarray.round>` (*self*, *decimals*, *out*). Returns
     the array with elements rounded to the nearest decimal place. The
     decimal place is defined as the :math:`10^{-\textrm{decimals}}`
     digit so that negative *decimals* cause rounding to the nearest 10's, 100's, etc. If out is ``NULL``, then the output array is created, otherwise the output is placed in *out* which must be the correct size and type.
 
 .. c:function:: PyObject* PyArray_Std(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.std` (*self*, *axis*, *rtype*). Return the
+    Equivalent to :meth:`ndarray.std<numpy.ndarray.std>` (*self*, *axis*, *rtype*). Return the
     standard deviation using data along *axis* converted to data type
     *rtype*.
 
 .. c:function:: PyObject* PyArray_Sum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.sum` (*self*, *axis*, *rtype*). Return 1-d
+    Equivalent to :meth:`ndarray.sum<numpy.ndarray.sum>` (*self*, *axis*, *rtype*). Return 1-d
     vector sums of elements in *self* along *axis*. Perform the sum
     after converting data to data type *rtype*.
 
 .. c:function:: PyObject* PyArray_CumSum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.cumsum` (*self*, *axis*, *rtype*). Return
+    Equivalent to :meth:`ndarray.cumsum<numpy.ndarray.cumsum>` (*self*, *axis*, *rtype*). Return
     cumulative 1-d sums of elements in *self* along *axis*. Perform
     the sum after converting data to data type *rtype*.
 
 .. c:function:: PyObject* PyArray_Prod(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.prod` (*self*, *axis*, *rtype*). Return 1-d
+    Equivalent to :meth:`ndarray.prod<numpy.ndarray.prod>` (*self*, *axis*, *rtype*). Return 1-d
     products of elements in *self* along *axis*. Perform the product
     after converting data to data type *rtype*.
 
 .. c:function:: PyObject* PyArray_CumProd(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.cumprod` (*self*, *axis*, *rtype*). Return
+    Equivalent to :meth:`ndarray.cumprod<numpy.ndarray.cumprod>` (*self*, *axis*, *rtype*). Return
     1-d cumulative products of elements in ``self`` along ``axis``.
     Perform the product after converting data to data type ``rtype``.
 
 .. c:function:: PyObject* PyArray_All(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.all` (*self*, *axis*). Return an array with
+    Equivalent to :meth:`ndarray.all<numpy.ndarray.all>` (*self*, *axis*). Return an array with
     True elements for every 1-d sub-array of ``self`` defined by
     ``axis`` in which all the elements are True.
 
 .. c:function:: PyObject* PyArray_Any(PyArrayObject* self, int axis, PyArrayObject* out)
 
-    Equivalent to :meth:`ndarray.any` (*self*, *axis*). Return an array with
+    Equivalent to :meth:`ndarray.any<numpy.ndarray.any>` (*self*, *axis*). Return an array with
     True elements for every 1-d sub-array of *self* defined by *axis*
     in which any of the elements are True.
 
@@ -2124,7 +2124,7 @@ Array Functions
     (:c:data:`NPY_KEEPORDER` is recommended), and when *dtype* is specified,
     *casting* indicates how permissive the data conversion should be.
 
-    See the :func:`einsum` function for more details.
+    See the :func:`~numpy.einsum` function for more details.
 
 .. c:function:: PyObject* PyArray_CopyAndTranspose(PyObject \* op)
 

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -3138,7 +3138,7 @@ Group 1
 
         Useful to release the GIL only if *loop_size* exceeds a
         minimum threshold, currently set to 500. Should be matched
-        with a .. c:macro::`NPY_END_THREADS` to regain the GIL.
+        with a :c:macro:`NPY_END_THREADS` to regain the GIL.
 
 Group 2
 """""""

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -21,7 +21,7 @@ Array structure and data access
 -------------------------------
 
 These macros all access the :c:type:`PyArrayObject` structure members. The input
-argument, arr, can be any :c:type:`PyObject *` that is directly interpretable
+argument, arr, can be any :c:type:`PyObject *<PyObject>` that is directly interpretable
 as a :c:type:`PyArrayObject *` (any instance of the :c:data:`PyArray_Type` and its
 sub-types).
 
@@ -833,7 +833,7 @@ Data-type checking
 
 For the typenum macros, the argument is an integer representing an
 enumerated array data type. For the array type checking macros the
-argument must be a :c:type:`PyObject *` that can be directly interpreted as a
+argument must be a :c:type:`PyObject *<PyObject>` that can be directly interpreted as a
 :c:type:`PyArrayObject *`.
 
 .. c:function:: PyTypeNum_ISUNSIGNED(num)
@@ -2371,7 +2371,7 @@ Broadcasting (multi-iterators)
 .. c:function:: PyObject* PyArray_MultiIterNew(int num, ...)
 
     A simplified interface to broadcasting. This function takes the
-    number of arrays to broadcast and then *num* extra ( :c:type:`PyObject *`
+    number of arrays to broadcast and then *num* extra ( :c:type:`PyObject *<PyObject>`
     ) arguments. These arguments are converted to arrays and iterators
     are created. :c:func:`PyArray_Broadcast` is then called on the resulting
     multi-iterator object. The resulting, broadcasted mult-iterator

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -124,7 +124,8 @@ sub-types).
     Get a Python object from the ndarray, *arr*, at the location
     pointed to by itemptr. Return ``NULL`` on failure.
 
-.. c:function:: int PyArray_SETITEM(PyArrayObject* arr, void* itemptr, PyObject* obj)
+.. c:function:: int PyArray_SETITEM( \
+        PyArrayObject* arr, void* itemptr, PyObject* obj)
 
     Convert obj and place it in the ndarray, *arr*, at the place
     pointed to by itemptr. Return -1 if an error occurs or 0 on
@@ -170,11 +171,14 @@ with misaligned data.
 
 .. c:function:: void* PyArray_GETPTR1(PyArrayObject* obj, npy_intp i)
 
-.. c:function:: void* PyArray_GETPTR2(PyArrayObject* obj, npy_intp i, npy_intp j)
+.. c:function:: void* PyArray_GETPTR2( \
+        PyArrayObject* obj, npy_intp i, npy_intp j)
 
-.. c:function:: void* PyArray_GETPTR3(PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k)
+.. c:function:: void* PyArray_GETPTR3( \
+        PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k)
 
-.. c:function:: void* PyArray_GETPTR4(PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k, npy_intp l)
+.. c:function:: void* PyArray_GETPTR4( \
+        PyArrayObject* obj, npy_intp i, npy_intp j, npy_intp k, npy_intp l)
 
     Quick, inline access to the element at the given coordinates in
     the ndarray, *obj*, which must have respectively 1, 2, 3, or 4
@@ -191,7 +195,9 @@ Creating arrays
 From scratch
 ^^^^^^^^^^^^
 
-.. c:function:: PyObject* PyArray_NewFromDescr(PyTypeObject* subtype, PyArray_Descr* descr, int nd, npy_intp* dims, npy_intp* strides, void* data, int flags, PyObject* obj)
+.. c:function:: PyObject* PyArray_NewFromDescr( \
+        PyTypeObject* subtype, PyArray_Descr* descr, int nd, npy_intp* dims, \
+        npy_intp* strides, void* data, int flags, PyObject* obj)
 
     This function steals a reference to *descr*.
 
@@ -223,7 +229,9 @@ From scratch
     provided *dims* and *strides* are copied into newly allocated
     dimension and strides arrays for the new array object.
 
-.. c:function:: PyObject* PyArray_NewLikeArray(PyArrayObject* prototype, NPY_ORDER order, PyArray_Descr* descr, int subok)
+.. c:function:: PyObject* PyArray_NewLikeArray( \
+        PyArrayObject* prototype, NPY_ORDER order, PyArray_Descr* descr, \
+        int subok)
 
     .. versionadded:: 1.6
 
@@ -245,7 +253,9 @@ From scratch
     *prototype* to create the new array, otherwise it will create a
     base-class array.
 
-.. c:function:: PyObject* PyArray_New(PyTypeObject* subtype, int nd, npy_intp* dims, int type_num, npy_intp* strides, void* data, int itemsize, int flags, PyObject* obj)
+.. c:function:: PyObject* PyArray_New( \
+        PyTypeObject* subtype, int nd, npy_intp* dims, int type_num, \
+        npy_intp* strides, void* data, int itemsize, int flags, PyObject* obj)
 
     This is similar to :c:func:`PyArray_DescrNew` (...) except you
     specify the data-type descriptor with *type_num* and *itemsize*,
@@ -273,7 +283,8 @@ From scratch
     This function cannot be used to create a flexible-type array (no
     itemsize given).
 
-.. c:function:: PyObject* PyArray_SimpleNewFromData(int nd, npy_intp* dims, int typenum, void* data)
+.. c:function:: PyObject* PyArray_SimpleNewFromData( \
+        int nd, npy_intp* dims, int typenum, void* data)
 
     Create an array wrapper around *data* pointed to by the given
     pointer. The array flags will have a default that the data area is
@@ -281,7 +292,8 @@ From scratch
     given by the *dims* c-array of length *nd*. The data-type of the
     array is indicated by *typenum*.
 
-.. c:function:: PyObject* PyArray_SimpleNewFromDescr(int nd, npy_intp* dims, PyArray_Descr* descr)
+.. c:function:: PyObject* PyArray_SimpleNewFromDescr( \
+        int nd, npy_intp* dims, PyArray_Descr* descr)
 
     This function steals a reference to *descr* if it is not NULL.
 
@@ -294,7 +306,8 @@ From scratch
     of) bigndarray---with the contents of *val* (evaluated as a byte).
     This macro calls memset, so obj must be contiguous.
 
-.. c:function:: PyObject* PyArray_Zeros(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
+.. c:function:: PyObject* PyArray_Zeros( \
+        int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
 
     Construct a new *nd* -dimensional array with shape given by *dims*
     and data type given by *dtype*. If *fortran* is non-zero, then a
@@ -302,12 +315,14 @@ From scratch
     created. Fill the memory with zeros (or the 0 object if *dtype*
     corresponds to :c:type:`NPY_OBJECT` ).
 
-.. c:function:: PyObject* PyArray_ZEROS(int nd, npy_intp* dims, int type_num, int fortran)
+.. c:function:: PyObject* PyArray_ZEROS( \
+        int nd, npy_intp* dims, int type_num, int fortran)
 
     Macro form of :c:func:`PyArray_Zeros` which takes a type-number instead
     of a data-type object.
 
-.. c:function:: PyObject* PyArray_Empty(int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
+.. c:function:: PyObject* PyArray_Empty( \
+        int nd, npy_intp* dims, PyArray_Descr* dtype, int fortran)
 
     Construct a new *nd* -dimensional array with shape given by *dims*
     and data type given by *dtype*. If *fortran* is non-zero, then a
@@ -316,18 +331,21 @@ From scratch
     corresponds to :c:type:`NPY_OBJECT` in which case the array is
     filled with :c:data:`Py_None`.
 
-.. c:function:: PyObject* PyArray_EMPTY(int nd, npy_intp* dims, int typenum, int fortran)
+.. c:function:: PyObject* PyArray_EMPTY( \
+        int nd, npy_intp* dims, int typenum, int fortran)
 
     Macro form of :c:func:`PyArray_Empty` which takes a type-number,
     *typenum*, instead of a data-type object.
 
-.. c:function:: PyObject* PyArray_Arange(double start, double stop, double step, int typenum)
+.. c:function:: PyObject* PyArray_Arange( \
+        double start, double stop, double step, int typenum)
 
     Construct a new 1-dimensional array of data-type, *typenum*, that
     ranges from *start* to *stop* (exclusive) in increments of *step*
     . Equivalent to **arange** (*start*, *stop*, *step*, dtype).
 
-.. c:function:: PyObject* PyArray_ArangeObj(PyObject* start, PyObject* stop, PyObject* step, PyArray_Descr* descr)
+.. c:function:: PyObject* PyArray_ArangeObj( \
+        PyObject* start, PyObject* stop, PyObject* step, PyArray_Descr* descr)
 
     Construct a new 1-dimensional array of data-type determined by
     ``descr``, that ranges from ``start`` to ``stop`` (exclusive) in
@@ -355,7 +373,9 @@ From scratch
 From other objects
 ^^^^^^^^^^^^^^^^^^
 
-.. c:function:: PyObject* PyArray_FromAny(PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, int requirements, PyObject* context)
+.. c:function:: PyObject* PyArray_FromAny( \
+        PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, \
+        int requirements, PyObject* context)
 
     This is the main function used to obtain an array from any nested
     sequence, or object that exposes the array interface, *op*. The
@@ -489,7 +509,10 @@ From other objects
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_UPDATEIFCOPY`
 
-.. c:function:: int PyArray_GetArrayParamsFromObject(PyObject* op, PyArray_Descr* requested_dtype, npy_bool writeable, PyArray_Descr** out_dtype, int* out_ndim, npy_intp* out_dims, PyArrayObject** out_arr, PyObject* context)
+.. c:function:: int PyArray_GetArrayParamsFromObject( \
+        PyObject* op, PyArray_Descr* requested_dtype, npy_bool writeable, \
+        PyArray_Descr** out_dtype, int* out_ndim, npy_intp* out_dims, \
+        PyArrayObject** out_arr, PyObject* context)
 
     .. versionadded:: 1.6
 
@@ -552,7 +575,9 @@ From other objects
         }
         ... use arr ...
 
-.. c:function:: PyObject* PyArray_CheckFromAny(PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, int requirements, PyObject* context)
+.. c:function:: PyObject* PyArray_CheckFromAny( \
+        PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, \
+        int requirements, PyObject* context)
 
     Nearly identical to :c:func:`PyArray_FromAny` (...) except
     *requirements* can contain :c:data:`NPY_ARRAY_NOTSWAPPED` (over-riding the
@@ -584,7 +609,8 @@ From other objects
     Make sure the returned array has strides that are multiples of the
     element size.
 
-.. c:function:: PyObject* PyArray_FromArray(PyArrayObject* op, PyArray_Descr* newtype, int requirements)
+.. c:function:: PyObject* PyArray_FromArray( \
+        PyArrayObject* op, PyArray_Descr* newtype, int requirements)
 
     Special case of :c:func:`PyArray_FromAny` for when *op* is already an
     array but it needs to be of a specific *newtype* (including
@@ -604,7 +630,8 @@ From other objects
     protocol. If the object does not contain this attribute then a
     borrowed reference to :c:data:`Py_NotImplemented` is returned.
 
-.. c:function:: PyObject* PyArray_FromArrayAttr(PyObject* op, PyArray_Descr* dtype, PyObject* context)
+.. c:function:: PyObject* PyArray_FromArrayAttr( \
+        PyObject* op, PyArray_Descr* dtype, PyObject* context)
 
     Return an ndarray object from a Python object that exposes the
     :obj:`~numpy.class.__array__` method. The :obj:`~numpy.class.__array__` method can take 0, 1, or 2
@@ -612,7 +639,8 @@ From other objects
     information about where the :obj:`~numpy.class.__array__` method is being called
     from (currently only used in ufuncs).
 
-.. c:function:: PyObject* PyArray_ContiguousFromAny(PyObject* op, int typenum, int min_depth, int max_depth)
+.. c:function:: PyObject* PyArray_ContiguousFromAny( \
+        PyObject* op, int typenum, int min_depth, int max_depth)
 
     This function returns a (C-style) contiguous and behaved function
     array from any nested sequence or array interface exporting
@@ -622,7 +650,8 @@ From other objects
     requirements set to :c:data:`NPY_DEFAULT` and the type_num member of the
     type argument set to *typenum*.
 
-.. c:function:: PyObject *PyArray_FromObject(PyObject *op, int typenum, int min_depth, int max_depth)
+.. c:function:: PyObject *PyArray_FromObject( \
+        PyObject *op, int typenum, int min_depth, int max_depth)
 
     Return an aligned and in native-byteorder array from any nested
     sequence or array-interface exporting object, op, of a type given by
@@ -638,7 +667,9 @@ From other objects
     but otherwise calls :c:func:`PyArray_FromAny` ( ``op``, NULL, 0, 0,
     :c:data:`NPY_ARRAY_ENSUREARRAY`).
 
-.. c:function:: PyObject* PyArray_FromString(char* string, npy_intp slen, PyArray_Descr* dtype, npy_intp num, char* sep)
+.. c:function:: PyObject* PyArray_FromString( \
+        char* string, npy_intp slen, PyArray_Descr* dtype, npy_intp num, \
+        char* sep)
 
     Construct a one-dimensional ndarray of a single type from a binary
     or (ASCII) text ``string`` of length ``slen``. The data-type of
@@ -651,7 +682,8 @@ From other objects
     data-types may not be readable in text mode and an error will be
     raised if that occurs. All errors return NULL.
 
-.. c:function:: PyObject* PyArray_FromFile(FILE* fp, PyArray_Descr* dtype, npy_intp num, char* sep)
+.. c:function:: PyObject* PyArray_FromFile( \
+        FILE* fp, PyArray_Descr* dtype, npy_intp num, char* sep)
 
     Construct a one-dimensional ndarray of a single type from a binary
     or text file. The open file pointer is ``fp``, the data-type of
@@ -664,7 +696,8 @@ From other objects
     separator. Some array types cannot be read in text mode in which
     case an error is raised.
 
-.. c:function:: PyObject* PyArray_FromBuffer(PyObject* buf, PyArray_Descr* dtype, npy_intp count, npy_intp offset)
+.. c:function:: PyObject* PyArray_FromBuffer( \
+        PyObject* buf, PyArray_Descr* dtype, npy_intp count, npy_intp offset)
 
     Construct a one-dimensional ndarray of a single type from an
     object, ``buf``, that exports the (single-segment) buffer protocol
@@ -728,12 +761,14 @@ From other objects
     Similar to :c:func:`PyArray_FROM_O` except it can take an argument of
     *typenum* specifying the type-number the returned array.
 
-.. c:function:: PyObject* PyArray_FROM_OTF(PyObject* obj, int typenum, int requirements)
+.. c:function:: PyObject* PyArray_FROM_OTF( \
+        PyObject* obj, int typenum, int requirements)
 
     Combination of :c:func:`PyArray_FROM_OF` and :c:func:`PyArray_FROM_OT`
     allowing both a *typenum* and a *flags* argument to be provided..
 
-.. c:function:: PyObject* PyArray_FROMANY(PyObject* obj, int typenum, int min, int max, int requirements)
+.. c:function:: PyObject* PyArray_FROMANY( \
+        PyObject* obj, int typenum, int min, int max, int requirements)
 
     Similar to :c:func:`PyArray_FromAny` except the data-type is
     specified using a typenumber. :c:func:`PyArray_DescrFromType`
@@ -741,7 +776,8 @@ From other objects
     macro also adds :c:data:`NPY_DEFAULT` to requirements if
     :c:data:`NPY_ARRAY_ENSURECOPY` is passed in as requirements.
 
-.. c:function:: PyObject *PyArray_CheckAxis(PyObject* obj, int* axis, int requirements)
+.. c:function:: PyObject *PyArray_CheckAxis( \
+        PyObject* obj, int* axis, int requirements)
 
     Encapsulate the functionality of functions and methods that take
     the axis= keyword and work properly with None as the axis
@@ -959,7 +995,8 @@ argument must be a :c:type:`PyObject *<PyObject>` that can be directly interpret
     Evaluates true if the data area of the ndarray *m* is **not** in
     machine byte-order according to the array's data-type descriptor.
 
-.. c:function:: Bool PyArray_EquivTypes(PyArray_Descr* type1, PyArray_Descr* type2)
+.. c:function:: Bool PyArray_EquivTypes( \
+        PyArray_Descr* type1, PyArray_Descr* type2)
 
     Return :c:data:`NPY_TRUE` if *type1* and *type2* actually represent
     equivalent types for this platform (the fortran member of each
@@ -967,7 +1004,8 @@ argument must be a :c:type:`PyObject *<PyObject>` that can be directly interpret
     :c:data:`NPY_LONG` and :c:data:`NPY_INT` are equivalent. Otherwise
     return :c:data:`NPY_FALSE`.
 
-.. c:function:: Bool PyArray_EquivArrTypes(PyArrayObject* a1, PyArrayObject * a2)
+.. c:function:: Bool PyArray_EquivArrTypes( \
+        PyArrayObject* a1, PyArrayObject * a2)
 
     Return :c:data:`NPY_TRUE` if *a1* and *a2* are arrays with equivalent
     types for this platform.
@@ -997,7 +1035,8 @@ Converting data types
     the elements of *arr* cast to the data-type *typenum* which must
     be one of the enumerated types and not a flexible type.
 
-.. c:function:: PyObject* PyArray_CastToType(PyArrayObject* arr, PyArray_Descr* type, int fortran)
+.. c:function:: PyObject* PyArray_CastToType( \
+        PyArrayObject* arr, PyArray_Descr* type, int fortran)
 
     Return a new array of the *type* specified, casting the elements
     of *arr* as appropriate. The fortran argument specifies the
@@ -1014,7 +1053,8 @@ Converting data types
     placed in out), and have a data type that is one of the builtin
     types.  Returns 0 on success and -1 if an error occurs.
 
-.. c:function:: PyArray_VectorUnaryFunc* PyArray_GetCastFunc(PyArray_Descr* from, int totype)
+.. c:function:: PyArray_VectorUnaryFunc* PyArray_GetCastFunc( \
+        PyArray_Descr* from, int totype)
 
     Return the low-level casting function to cast from the given
     descriptor to the builtin type number. If no casting function
@@ -1033,14 +1073,16 @@ Converting data types
     explicit requests. Flexible array types are not checked according
     to their lengths with this function.
 
-.. c:function:: int PyArray_CanCastTo(PyArray_Descr* fromtype, PyArray_Descr* totype)
+.. c:function:: int PyArray_CanCastTo( \
+        PyArray_Descr* fromtype, PyArray_Descr* totype)
 
     :c:func:`PyArray_CanCastTypeTo` supersedes this function in
     NumPy 1.6 and later.
 
     Equivalent to PyArray_CanCastTypeTo(fromtype, totype, NPY_SAFE_CASTING).
 
-.. c:function:: int PyArray_CanCastTypeTo(PyArray_Descr* fromtype, PyArray_Descr* totype, NPY_CASTING casting)
+.. c:function:: int PyArray_CanCastTypeTo( \
+        PyArray_Descr* fromtype, PyArray_Descr* totype, NPY_CASTING casting)
 
     .. versionadded:: 1.6
 
@@ -1055,7 +1097,8 @@ Converting data types
     or unicode type is big enough to hold the max value of the integer/float
     type being cast from.
 
-.. c:function:: int PyArray_CanCastArrayTo(PyArrayObject* arr, PyArray_Descr* totype, NPY_CASTING casting)
+.. c:function:: int PyArray_CanCastArrayTo( \
+        PyArrayObject* arr, PyArray_Descr* totype, NPY_CASTING casting)
 
     .. versionadded:: 1.6
 
@@ -1084,7 +1127,8 @@ Converting data types
     boolean, but will demote a signed integer to an unsigned integer
     when the scalar value is positive.
 
-.. c:function:: PyArray_Descr* PyArray_PromoteTypes(PyArray_Descr* type1, PyArray_Descr* type2)
+.. c:function:: PyArray_Descr* PyArray_PromoteTypes( \
+        PyArray_Descr* type1, PyArray_Descr* type2)
 
     .. versionadded:: 1.6
 
@@ -1093,7 +1137,9 @@ Converting data types
     associative. A string or unicode result will be the proper size for
     storing the max value of the input types converted to a string or unicode.
 
-.. c:function:: PyArray_Descr* PyArray_ResultType(npy_intp narrs, PyArrayObject**arrs, npy_intp ndtypes, PyArray_Descr**dtypes)
+.. c:function:: PyArray_Descr* PyArray_ResultType( \
+        npy_intp narrs, PyArrayObject**arrs, npy_intp ndtypes, \
+        PyArray_Descr**dtypes)
 
     .. versionadded:: 1.6
 
@@ -1134,7 +1180,8 @@ Converting data types
     return value is the enumerated typenumber that represents the
     data-type that *op* should have.
 
-.. c:function:: void PyArray_ArrayType(PyObject* op, PyArray_Descr* mintype, PyArray_Descr* outtype)
+.. c:function:: void PyArray_ArrayType( \
+        PyObject* op, PyArray_Descr* mintype, PyArray_Descr* outtype)
 
     This function is superceded by :c:func:`PyArray_ResultType`.
 
@@ -1144,7 +1191,8 @@ Converting data types
     itemsize member at least as big but perhaps bigger depending on
     the object *op*.
 
-.. c:function:: PyArrayObject** PyArray_ConvertToCommonType(PyObject* op, int* n)
+.. c:function:: PyArrayObject** PyArray_ConvertToCommonType( \
+        PyObject* op, int* n)
 
     The functionality this provides is largely superceded by iterator
     :c:type:`NpyIter` introduced in 1.6, with flag
@@ -1221,14 +1269,16 @@ New data types
     registered (checked only by the address of the pointer), then
     return the previously-assigned type-number.
 
-.. c:function:: int PyArray_RegisterCastFunc(PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
+.. c:function:: int PyArray_RegisterCastFunc( \
+        PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
 
     Register a low-level casting function, *castfunc*, to convert
     from the data-type, *descr*, to the given data-type number,
     *totype*. Any old casting function is over-written. A ``0`` is
     returned on success or a ``-1`` on failure.
 
-.. c:function:: int PyArray_RegisterCanCast(PyArray_Descr* descr, int totype, NPY_SCALARKIND scalar)
+.. c:function:: int PyArray_RegisterCanCast( \
+        PyArray_Descr* descr, int totype, NPY_SCALARKIND scalar)
 
     Register the data-type number, *totype*, as castable from
     data-type object, *descr*, of the given *scalar* kind. Use
@@ -1543,7 +1593,8 @@ Array method alternative API
 Conversion
 ^^^^^^^^^^
 
-.. c:function:: PyObject* PyArray_GetField(PyArrayObject* self, PyArray_Descr* dtype, int offset)
+.. c:function:: PyObject* PyArray_GetField( \
+        PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
     Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). Return
     a new array of the given *dtype* using the data in the current
@@ -1555,7 +1606,8 @@ Conversion
     be used to select specific bytes or groups of bytes from any array
     type.
 
-.. c:function:: int PyArray_SetField(PyArrayObject* self, PyArray_Descr* dtype, int offset, PyObject* val)
+.. c:function:: int PyArray_SetField( \
+        PyArrayObject* self, PyArray_Descr* dtype, int offset, PyObject* val)
 
     Equivalent to :meth:`ndarray.setfield<numpy.ndarray.setfield>` (*self*, *val*, *dtype*, *offset*
     ). Set the field starting at *offset* in bytes and of the given
@@ -1595,7 +1647,8 @@ Conversion
     Equivalent to :meth:`ndarray.tobytes<numpy.ndarray.tobytes>` (*self*, *order*). Return the bytes
     of this array in a Python string.
 
-.. c:function:: PyObject* PyArray_ToFile(PyArrayObject* self, FILE* fp, char* sep, char* format)
+.. c:function:: PyObject* PyArray_ToFile( \
+        PyArrayObject* self, FILE* fp, char* sep, char* format)
 
     Write the contents of *self* to the file pointer *fp* in C-style
     contiguous fashion. Write the data as binary bytes if *sep* is the
@@ -1627,7 +1680,8 @@ Conversion
     copied into every location. A -1 is returned if an error occurs,
     otherwise 0 is returned.
 
-.. c:function:: PyObject* PyArray_View(PyArrayObject* self, PyArray_Descr* dtype, PyTypeObject *ptype)
+.. c:function:: PyObject* PyArray_View( \
+        PyArrayObject* self, PyArray_Descr* dtype, PyTypeObject *ptype)
 
     Equivalent to :meth:`ndarray.view<numpy.ndarray.view>` (*self*, *dtype*). Return a new
     view of the array *self* as possibly a different data-type, *dtype*,
@@ -1646,7 +1700,8 @@ Conversion
 Shape Manipulation
 ^^^^^^^^^^^^^^^^^^
 
-.. c:function:: PyObject* PyArray_Newshape(PyArrayObject* self, PyArray_Dims* newshape, NPY_ORDER order)
+.. c:function:: PyObject* PyArray_Newshape( \
+        PyArrayObject* self, PyArray_Dims* newshape, NPY_ORDER order)
 
     Result will be a new array (pointing to the same memory location
     as *self* if possible), but having a shape given by *newshape*.
@@ -1677,7 +1732,9 @@ Shape Manipulation
     array is a new view of the data in *self* with the given axes,
     *a1* and *a2*, swapped.
 
-.. c:function:: PyObject* PyArray_Resize(PyArrayObject* self, PyArray_Dims* newshape, int refcheck, NPY_ORDER fortran)
+.. c:function:: PyObject* PyArray_Resize( \
+        PyArrayObject* self, PyArray_Dims* newshape, int refcheck, \
+        NPY_ORDER fortran)
 
     Equivalent to :meth:`ndarray.resize<numpy.ndarray.resize>` (*self*, *newshape*, refcheck
     ``=`` *refcheck*, order= fortran ). This function only works on
@@ -1693,7 +1750,8 @@ Shape Manipulation
     the data when constructing a differently-dimensioned array.
     Returns None on success and NULL on error.
 
-.. c:function:: PyObject* PyArray_Transpose(PyArrayObject* self, PyArray_Dims* permute)
+.. c:function:: PyObject* PyArray_Transpose( \
+        PyArrayObject* self, PyArray_Dims* permute)
 
     Equivalent to :meth:`ndarray.transpose<numpy.ndarray.transpose>` (*self*, *permute*). Permute the
     axes of the ndarray object *self* according to the data structure
@@ -1726,7 +1784,9 @@ Shape Manipulation
 Item selection and manipulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. c:function:: PyObject* PyArray_TakeFrom(PyArrayObject* self, PyObject* indices, int axis, PyArrayObject* ret, NPY_CLIPMODE clipmode)
+.. c:function:: PyObject* PyArray_TakeFrom( \
+        PyArrayObject* self, PyObject* indices, int axis, PyArrayObject* ret, \
+        NPY_CLIPMODE clipmode)
 
     Equivalent to :meth:`ndarray.take<numpy.ndarray.take>` (*self*, *indices*, *axis*, *ret*,
     *clipmode*) except *axis* =None in Python is obtained by setting
@@ -1737,21 +1797,25 @@ Item selection and manipulation
     *ret* argument can specify an output array rather than having one
     created internally.
 
-.. c:function:: PyObject* PyArray_PutTo(PyArrayObject* self, PyObject* values, PyObject* indices, NPY_CLIPMODE clipmode)
+.. c:function:: PyObject* PyArray_PutTo( \
+        PyArrayObject* self, PyObject* values, PyObject* indices, \
+        NPY_CLIPMODE clipmode)
 
     Equivalent to *self*.put(*values*, *indices*, *clipmode*
     ). Put *values* into *self* at the corresponding (flattened)
     *indices*. If *values* is too small it will be repeated as
     necessary.
 
-.. c:function:: PyObject* PyArray_PutMask(PyArrayObject* self, PyObject* values, PyObject* mask)
+.. c:function:: PyObject* PyArray_PutMask( \
+        PyArrayObject* self, PyObject* values, PyObject* mask)
 
     Place the *values* in *self* wherever corresponding positions
     (using a flattened context) in *mask* are true. The *mask* and
     *self* arrays must have the same total number of elements. If
     *values* is too small, it will be repeated as necessary.
 
-.. c:function:: PyObject* PyArray_Repeat(PyArrayObject* self, PyObject* op, int axis)
+.. c:function:: PyObject* PyArray_Repeat( \
+        PyArrayObject* self, PyObject* op, int axis)
 
     Equivalent to :meth:`ndarray.repeat<numpy.ndarray.repeat>` (*self*, *op*, *axis*). Copy the
     elements of *self*, *op* times along the given *axis*. Either
@@ -1759,7 +1823,9 @@ Item selection and manipulation
     ->dimensions[ *axis* ] indicating how many times to repeat each
     item along the axis.
 
-.. c:function:: PyObject* PyArray_Choose(PyArrayObject* self, PyObject* op, PyArrayObject* ret, NPY_CLIPMODE clipmode)
+.. c:function:: PyObject* PyArray_Choose( \
+        PyArrayObject* self, PyObject* op, PyArrayObject* ret, \
+        NPY_CLIPMODE clipmode)
 
     Equivalent to :meth:`ndarray.choose<numpy.ndarray.choose>` (*self*, *op*, *ret*, *clipmode*).
     Create a new array by selecting elements from the sequence of
@@ -1820,7 +1886,9 @@ Item selection and manipulation
     :c:func:`PyArray_Sort` (...) can also be used to sort the array
     directly.
 
-.. c:function:: PyObject* PyArray_SearchSorted(PyArrayObject* self, PyObject* values, NPY_SEARCHSIDE side, PyObject* perm)
+.. c:function:: PyObject* PyArray_SearchSorted( \
+        PyArrayObject* self, PyObject* values, NPY_SEARCHSIDE side, \
+        PyObject* perm)
 
     Equivalent to :meth:`ndarray.searchsorted<numpy.ndarray.searchsorted>` (*self*, *values*, *side*,
     *perm*). Assuming *self* is a 1-d array in ascending order, then the
@@ -1838,7 +1906,9 @@ Item selection and manipulation
     This is typically the result of a call to :c:func:`PyArray_ArgSort` (...)
     Binary search is used to find the required insertion points.
 
-.. c:function:: int PyArray_Partition(PyArrayObject *self, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
+.. c:function:: int PyArray_Partition( \
+        PyArrayObject *self, PyArrayObject * ktharray, int axis, \
+        NPY_SELECTKIND which)
 
     Equivalent to :meth:`ndarray.partition<numpy.ndarray.partition>` (*self*, *ktharray*, *axis*,
     *kind*). Partitions the array so that the values of the element indexed by
@@ -1853,13 +1923,16 @@ Item selection and manipulation
     order of names and construct a view of the array with that new data-type.
     Returns zero on success and -1 on failure.
 
-.. c:function:: PyObject* PyArray_ArgPartition(PyArrayObject *op, PyArrayObject * ktharray, int axis, NPY_SELECTKIND which)
+.. c:function:: PyObject* PyArray_ArgPartition( \
+        PyArrayObject *op, PyArrayObject * ktharray, int axis, \
+        NPY_SELECTKIND which)
 
     Equivalent to :meth:`ndarray.argpartition<numpy.ndarray.argpartition>` (*self*, *ktharray*, *axis*,
     *kind*). Return an array of indices such that selection of these indices
     along the given ``axis`` would return a partitioned version of *self*.
 
-.. c:function:: PyObject* PyArray_Diagonal(PyArrayObject* self, int offset, int axis1, int axis2)
+.. c:function:: PyObject* PyArray_Diagonal( \
+        PyArrayObject* self, int offset, int axis1, int axis2)
 
     Equivalent to :meth:`ndarray.diagonal<numpy.ndarray.diagonal>` (*self*, *offset*, *axis1*, *axis2*
     ). Return the *offset* diagonals of the 2-d arrays defined by
@@ -1879,7 +1952,8 @@ Item selection and manipulation
     returned. The index arrays have data type :c:data:`NPY_INTP`. If a
     tuple is returned (nd :math:`\neq` 1), then its length is nd.
 
-.. c:function:: PyObject* PyArray_Compress(PyArrayObject* self, PyObject* condition, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Compress( \
+        PyArrayObject* self, PyObject* condition, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.compress<numpy.ndarray.compress>` (*self*, *condition*, *axis*
     ). Return the elements along *axis* corresponding to elements of
@@ -1895,12 +1969,14 @@ Calculation
     effect that is obtained by passing in *axis* = :const:`None` in Python
     (treating the array as a 1-d array).
 
-.. c:function:: PyObject* PyArray_ArgMax(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_ArgMax( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.argmax<numpy.ndarray.argmax>` (*self*, *axis*). Return the index of
     the largest element of *self* along *axis*.
 
-.. c:function:: PyObject* PyArray_ArgMin(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_ArgMin( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.argmin<numpy.ndarray.argmin>` (*self*, *axis*). Return the index of
     the smallest element of *self* along *axis*.
@@ -1917,20 +1993,23 @@ Calculation
     is not NULL. The caller of the routine has the responsibility
     to ``DECREF`` out if not NULL or a memory-leak will occur.
 
-.. c:function:: PyObject* PyArray_Max(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Max( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.max<numpy.ndarray.max>` (*self*, *axis*). Returns the largest
     element of *self* along the given *axis*. When the result is a single
     element, returns a numpy scalar instead of an ndarray.
 
-.. c:function:: PyObject* PyArray_Min(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Min( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.min<numpy.ndarray.min>` (*self*, *axis*). Return the smallest
     element of *self* along the given *axis*. When the result is a single
     element, returns a numpy scalar instead of an ndarray.
 
 
-.. c:function:: PyObject* PyArray_Ptp(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Ptp( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.ptp<numpy.ndarray.ptp>` (*self*, *axis*). Return the difference
     between the largest element of *self* along *axis* and the
@@ -1949,14 +2028,17 @@ Calculation
     for the "add" and "multiply" ufuncs (which form the basis for
     mean, sum, cumsum, prod, and cumprod functions).
 
-.. c:function:: PyObject* PyArray_Mean(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Mean( \
+        PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.mean<numpy.ndarray.mean>` (*self*, *axis*, *rtype*). Returns the
     mean of the elements along the given *axis*, using the enumerated
     type *rtype* as the data type to sum in. Default sum behavior is
     obtained using :c:data:`NPY_NOTYPE` for *rtype*.
 
-.. c:function:: PyObject* PyArray_Trace(PyArrayObject* self, int offset, int axis1, int axis2, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Trace( \
+        PyArrayObject* self, int offset, int axis1, int axis2, int rtype, \
+        PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.trace<numpy.ndarray.trace>` (*self*, *offset*, *axis1*, *axis2*,
     *rtype*). Return the sum (using *rtype* as the data type of
@@ -1965,7 +2047,8 @@ Calculation
     chooses diagonals above the main diagonal. A negative offset
     selects diagonals below the main diagonal.
 
-.. c:function:: PyObject* PyArray_Clip(PyArrayObject* self, PyObject* min, PyObject* max)
+.. c:function:: PyObject* PyArray_Clip( \
+        PyArrayObject* self, PyObject* min, PyObject* max)
 
     Equivalent to :meth:`ndarray.clip<numpy.ndarray.clip>` (*self*, *min*, *max*). Clip an array,
     *self*, so that values larger than *max* are fixed to *max* and
@@ -1977,50 +2060,58 @@ Calculation
     Return the complex conjugate of *self*. If *self* is not of
     complex data type, then return *self* with a reference.
 
-.. c:function:: PyObject* PyArray_Round(PyArrayObject* self, int decimals, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Round( \
+        PyArrayObject* self, int decimals, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.round<numpy.ndarray.round>` (*self*, *decimals*, *out*). Returns
     the array with elements rounded to the nearest decimal place. The
     decimal place is defined as the :math:`10^{-\textrm{decimals}}`
     digit so that negative *decimals* cause rounding to the nearest 10's, 100's, etc. If out is ``NULL``, then the output array is created, otherwise the output is placed in *out* which must be the correct size and type.
 
-.. c:function:: PyObject* PyArray_Std(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Std( \
+        PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.std<numpy.ndarray.std>` (*self*, *axis*, *rtype*). Return the
     standard deviation using data along *axis* converted to data type
     *rtype*.
 
-.. c:function:: PyObject* PyArray_Sum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Sum( \
+        PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.sum<numpy.ndarray.sum>` (*self*, *axis*, *rtype*). Return 1-d
     vector sums of elements in *self* along *axis*. Perform the sum
     after converting data to data type *rtype*.
 
-.. c:function:: PyObject* PyArray_CumSum(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_CumSum( \
+        PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.cumsum<numpy.ndarray.cumsum>` (*self*, *axis*, *rtype*). Return
     cumulative 1-d sums of elements in *self* along *axis*. Perform
     the sum after converting data to data type *rtype*.
 
-.. c:function:: PyObject* PyArray_Prod(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Prod( \
+        PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.prod<numpy.ndarray.prod>` (*self*, *axis*, *rtype*). Return 1-d
     products of elements in *self* along *axis*. Perform the product
     after converting data to data type *rtype*.
 
-.. c:function:: PyObject* PyArray_CumProd(PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_CumProd( \
+        PyArrayObject* self, int axis, int rtype, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.cumprod<numpy.ndarray.cumprod>` (*self*, *axis*, *rtype*). Return
     1-d cumulative products of elements in ``self`` along ``axis``.
     Perform the product after converting data to data type ``rtype``.
 
-.. c:function:: PyObject* PyArray_All(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_All( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.all<numpy.ndarray.all>` (*self*, *axis*). Return an array with
     True elements for every 1-d sub-array of ``self`` defined by
     ``axis`` in which all the elements are True.
 
-.. c:function:: PyObject* PyArray_Any(PyArrayObject* self, int axis, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_Any( \
+        PyArrayObject* self, int axis, PyArrayObject* out)
 
     Equivalent to :meth:`ndarray.any<numpy.ndarray.any>` (*self*, *axis*). Return an array with
     True elements for every 1-d sub-array of *self* defined by *axis*
@@ -2033,7 +2124,9 @@ Functions
 Array Functions
 ^^^^^^^^^^^^^^^
 
-.. c:function:: int PyArray_AsCArray(PyObject** op, void* ptr, npy_intp* dims, int nd, int typenum, int itemsize)
+.. c:function:: int PyArray_AsCArray( \
+        PyObject** op, void* ptr, npy_intp* dims, int nd, int typenum, \
+        int itemsize)
 
     Sometimes it is useful to access a multidimensional array as a
     C-style multi-dimensional array so that algorithms can be
@@ -2103,7 +2196,8 @@ Array Functions
     second-to-last dimension of *obj2*. For 2-d arrays this is a
     matrix-product. Neither array is conjugated.
 
-.. c:function:: PyObject* PyArray_MatrixProduct2(PyObject* obj1, PyObject* obj, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_MatrixProduct2( \
+        PyObject* obj1, PyObject* obj, PyArrayObject* out)
 
     .. versionadded:: 1.6
 
@@ -2111,7 +2205,10 @@ Array Functions
     output array must have the correct shape, type, and be
     C-contiguous, or an exception is raised.
 
-.. c:function:: PyObject* PyArray_EinsteinSum(char* subscripts, npy_intp nop, PyArrayObject** op_in, PyArray_Descr* dtype, NPY_ORDER order, NPY_CASTING casting, PyArrayObject* out)
+.. c:function:: PyObject* PyArray_EinsteinSum( \
+        char* subscripts, npy_intp nop, PyArrayObject** op_in, \
+        PyArray_Descr* dtype, NPY_ORDER order, NPY_CASTING casting, \
+        PyArrayObject* out)
 
     .. versionadded:: 1.6
 
@@ -2131,7 +2228,8 @@ Array Functions
     A specialized copy and transpose function that works only for 2-d
     arrays. The returned array is a transposed copy of *op*.
 
-.. c:function:: PyObject* PyArray_Correlate(PyObject* op1, PyObject* op2, int mode)
+.. c:function:: PyObject* PyArray_Correlate( \
+        PyObject* op1, PyObject* op2, int mode)
 
     Compute the 1-d correlation of the 1-d arrays *op1* and *op2*
     . The correlation is computed at each output point by multiplying
@@ -2149,7 +2247,8 @@ Array Functions
     arguments are swapped, and the conjugate is never taken for complex arrays.
     See PyArray_Correlate2 for the usual signal processing correlation.
 
-.. c:function:: PyObject* PyArray_Correlate2(PyObject* op1, PyObject* op2, int mode)
+.. c:function:: PyObject* PyArray_Correlate2( \
+        PyObject* op1, PyObject* op2, int mode)
 
     Updated version of PyArray_Correlate, which uses the usual definition of
     correlation for 1d arrays. The correlation is computed at each output point
@@ -2166,7 +2265,8 @@ Array Functions
 
       z[k] = sum_n op1[n] * conj(op2[n+k])
 
-.. c:function:: PyObject* PyArray_Where(PyObject* condition, PyObject* x, PyObject* y)
+.. c:function:: PyObject* PyArray_Where( \
+        PyObject* condition, PyObject* x, PyObject* y)
 
     If both ``x`` and ``y`` are ``NULL``, then return
     :c:func:`PyArray_Nonzero` (*condition*). Otherwise, both *x* and *y*
@@ -2178,7 +2278,9 @@ Array Functions
 Other functions
 ^^^^^^^^^^^^^^^
 
-.. c:function:: Bool PyArray_CheckStrides(int elsize, int nd, npy_intp numbytes, npy_intp* dims, npy_intp* newstrides)
+.. c:function:: Bool PyArray_CheckStrides( \
+        int elsize, int nd, npy_intp numbytes, npy_intp* dims, \
+        npy_intp* newstrides)
 
     Determine if *newstrides* is a strides array consistent with the
     memory of an *nd* -dimensional array with shape ``dims`` and
@@ -2321,7 +2423,8 @@ this useful approach to looping over an array.
     negative then *\*axis* will be set to the axis having the smallest
     stride and that axis will be used.
 
-.. c:function:: PyObject *PyArray_BroadcastToShape(PyObject* arr, npy_intp *dimensions, int nd)
+.. c:function:: PyObject *PyArray_BroadcastToShape( \
+        PyObject* arr, npy_intp *dimensions, int nd)
 
     Return an array iterator that is broadcast to iterate as an array
     of the shape provided by *dimensions* and *nd*.
@@ -2346,7 +2449,8 @@ this useful approach to looping over an array.
 
     A pointer to the current element of the array.
 
-.. c:function:: void PyArray_ITER_GOTO(PyObject* iterator, npy_intp* destination)
+.. c:function:: void PyArray_ITER_GOTO( \
+        PyObject* iterator, npy_intp* destination)
 
     Set the *iterator* index, dataptr, and coordinates members to the
     location in the array indicated by the N-dimensional c-array,
@@ -2398,7 +2502,8 @@ Broadcasting (multi-iterators)
 
     Advance the pointer of only the *i* :math:`^{\textrm{th}}` iterator.
 
-.. c:function:: void PyArray_MultiIter_GOTO(PyObject* multi, npy_intp* destination)
+.. c:function:: void PyArray_MultiIter_GOTO( \
+        PyObject* multi, npy_intp* destination)
 
     Advance each iterator in a multi-iterator object, *multi*, to the
     given :math:`N` -dimensional *destination* where :math:`N` is the
@@ -2451,7 +2556,9 @@ hypercube. Neighborhood iterator automatically handle boundaries, thus making
 this kind of code much easier to write than manual boundaries handling, at the
 cost of a slight overhead.
 
-.. c:function:: PyObject* PyArray_NeighborhoodIterNew(PyArrayIterObject* iter, npy_intp bounds, int mode, PyArrayObject* fill_value)
+.. c:function:: PyObject* PyArray_NeighborhoodIterNew( \
+        PyArrayIterObject* iter, npy_intp bounds, int mode, \
+        PyArrayObject* fill_value)
 
     This function creates a new neighborhood iterator from an existing
     iterator.  The neighborhood will be computed relatively to the position
@@ -2518,13 +2625,15 @@ cost of a slight overhead.
             PyArrayNeighborhoodIter_Reset(neigh_iter);
        }
 
-.. c:function:: int PyArrayNeighborhoodIter_Reset(PyArrayNeighborhoodIterObject* iter)
+.. c:function:: int PyArrayNeighborhoodIter_Reset( \
+        PyArrayNeighborhoodIterObject* iter)
 
     Reset the iterator position to the first point of the neighborhood. This
     should be called whenever the iter argument given at
     PyArray_NeighborhoodIterObject is changed (see example)
 
-.. c:function:: int PyArrayNeighborhoodIter_Next(PyArrayNeighborhoodIterObject* iter)
+.. c:function:: int PyArrayNeighborhoodIter_Next( \
+        PyArrayNeighborhoodIterObject* iter)
 
     After this call, iter->dataptr points to the next point of the
     neighborhood. Calling this function after every point of the
@@ -2541,7 +2650,8 @@ Array Scalars
     if so, returns the appropriate array scalar. It should be used
     whenever 0-dimensional arrays could be returned to Python.
 
-.. c:function:: PyObject* PyArray_Scalar(void* data, PyArray_Descr* dtype, PyObject* itemsize)
+.. c:function:: PyObject* PyArray_Scalar( \
+        void* data, PyArray_Descr* dtype, PyObject* itemsize)
 
     Return an array scalar object of the given enumerated *typenum*
     and *itemsize* by **copying** from memory pointed to by *data*
@@ -2556,7 +2666,8 @@ Array Scalars
     *data* and swapping if the data in *arr* is not in machine
     byte-order.
 
-.. c:function:: PyObject* PyArray_FromScalar(PyObject* scalar, PyArray_Descr* outcode)
+.. c:function:: PyObject* PyArray_FromScalar( \
+        PyObject* scalar, PyArray_Descr* outcode)
 
     Return a 0-dimensional array of type determined by *outcode* from
     *scalar* which should be an array-scalar object. If *outcode* is
@@ -2571,7 +2682,8 @@ Array Scalars
     is copied into the memory of *ctypeptr*, for all other types, the
     actual data is copied into the address pointed to by *ctypeptr*.
 
-.. c:function:: void PyArray_CastScalarToCtype(PyObject* scalar, void* ctypeptr, PyArray_Descr* outcode)
+.. c:function:: void PyArray_CastScalarToCtype( \
+        PyObject* scalar, void* ctypeptr, PyArray_Descr* outcode)
 
     Return the data (cast to the data type indicated by *outcode*)
     from the array-scalar, *scalar*, into the memory pointed to by
@@ -2585,7 +2697,8 @@ Array Scalars
     except for reference counting and error-checking. Returns a new
     reference to the typeobject on success or ``NULL`` on failure.
 
-.. c:function:: NPY_SCALARKIND PyArray_ScalarKind(int typenum, PyArrayObject** arr)
+.. c:function:: NPY_SCALARKIND PyArray_ScalarKind( \
+        int typenum, PyArrayObject** arr)
 
     See the function :c:func:`PyArray_MinScalarType` for an alternative
     mechanism introduced in NumPy 1.6.0.
@@ -2601,7 +2714,8 @@ Array Scalars
     :c:data:`NPY_NOSCALAR` is also an enumerated value
     :c:type:`NPY_SCALARKIND` variables can take on.
 
-.. c:function:: int PyArray_CanCoerceScalar(char thistype, char neededtype, NPY_SCALARKIND scalar)
+.. c:function:: int PyArray_CanCoerceScalar( \
+        char thistype, char neededtype, NPY_SCALARKIND scalar)
 
     See the function :c:func:`PyArray_ResultType` for details of
     NumPy type promotion, updated in NumPy 1.6.0.
@@ -2650,7 +2764,8 @@ Data-type descriptors
     flexible data-types which need to have a new elsize member in
     order to be meaningful in array construction.
 
-.. c:function:: PyArray_Descr* PyArray_DescrNewByteorder(PyArray_Descr* obj, char newendian)
+.. c:function:: PyArray_Descr* PyArray_DescrNewByteorder( \
+        PyArray_Descr* obj, char newendian)
 
     Create a new data-type object with the byteorder set according to
     *newendian*. All referenced data-type objects (in subdescr and
@@ -2663,7 +2778,8 @@ Data-type descriptors
     referenced data-type descriptors) to have the corresponding byte-
     order.
 
-.. c:function:: PyArray_Descr* PyArray_DescrFromObject(PyObject* op, PyArray_Descr* mintype)
+.. c:function:: PyArray_Descr* PyArray_DescrFromObject( \
+        PyObject* op, PyArray_Descr* mintype)
 
     Determine an appropriate data-type object from the object *op*
     (which should be a "nested" sequence object) and the minimum
@@ -2696,7 +2812,8 @@ Data-type descriptors
     be used with the "O&" character code in :c:func:`PyArg_ParseTuple`
     processing.
 
-.. c:function:: int PyArray_DescrConverter2(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int PyArray_DescrConverter2( \
+        PyObject* obj, PyArray_Descr** dtype)
 
     Convert any compatible Python object, *obj*, to a data-type
     object in *dtype*. This version of the converter converts None
@@ -2704,12 +2821,14 @@ Data-type descriptors
     can also be used with the "O&" character in PyArg_ParseTuple
     processing.
 
-.. c:function:: int Pyarray_DescrAlignConverter(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int Pyarray_DescrAlignConverter( \
+        PyObject* obj, PyArray_Descr** dtype)
 
     Like :c:func:`PyArray_DescrConverter` except it aligns C-struct-like
     objects on word-boundaries as the compiler would.
 
-.. c:function:: int Pyarray_DescrAlignConverter2(PyObject* obj, PyArray_Descr** dtype)
+.. c:function:: int Pyarray_DescrAlignConverter2( \
+        PyObject* obj, PyArray_Descr** dtype)
 
     Like :c:func:`PyArray_DescrConverter2` except it aligns C-struct-like
     objects on word-boundaries as the compiler would.
@@ -2753,7 +2872,8 @@ to.
     . No matter what is returned, you must DECREF the object returned
     by this routine in *address* when you are done with it.
 
-.. c:function:: int PyArray_OutputConverter(PyObject* obj, PyArrayObject** address)
+.. c:function:: int PyArray_OutputConverter( \
+        PyObject* obj, PyArrayObject** address)
 
     This is a default converter for output arrays given to
     functions. If *obj* is :c:data:`Py_None` or ``NULL``, then *\*address*
@@ -2814,7 +2934,8 @@ to.
     with 'q' or 'Q') , :c:data:`NPY_HEAPSORT` (starts with 'h' or 'H'),
     or :c:data:`NPY_MERGESORT` (starts with 'm' or 'M').
 
-.. c:function:: int PyArray_SearchsideConverter(PyObject* obj, NPY_SEARCHSIDE* side)
+.. c:function:: int PyArray_SearchsideConverter( \
+        PyObject* obj, NPY_SEARCHSIDE* side)
 
     Convert Python strings into one of :c:data:`NPY_SEARCHLEFT` (starts with 'l'
     or 'L'), or :c:data:`NPY_SEARCHRIGHT` (starts with 'r' or 'R').
@@ -2825,20 +2946,23 @@ to.
    enumeration :c:data:`NPY_CORDER`, :c:data:`NPY_FORTRANORDER`,
    :c:data:`NPY_ANYORDER`, and :c:data:`NPY_KEEPORDER`.
 
-.. c:function:: int PyArray_CastingConverter(PyObject* obj, NPY_CASTING* casting)
+.. c:function:: int PyArray_CastingConverter( \
+        PyObject* obj, NPY_CASTING* casting)
 
    Convert the Python strings 'no', 'equiv', 'safe', 'same_kind', and
    'unsafe' into the :c:type:`NPY_CASTING` enumeration :c:data:`NPY_NO_CASTING`,
    :c:data:`NPY_EQUIV_CASTING`, :c:data:`NPY_SAFE_CASTING`,
    :c:data:`NPY_SAME_KIND_CASTING`, and :c:data:`NPY_UNSAFE_CASTING`.
 
-.. c:function:: int PyArray_ClipmodeConverter(PyObject* object, NPY_CLIPMODE* val)
+.. c:function:: int PyArray_ClipmodeConverter( \
+        PyObject* object, NPY_CLIPMODE* val)
 
     Convert the Python strings 'clip', 'wrap', and 'raise' into the
     :c:type:`NPY_CLIPMODE` enumeration :c:data:`NPY_CLIP`, :c:data:`NPY_WRAP`,
     and :c:data:`NPY_RAISE`.
 
-.. c:function:: int PyArray_ConvertClipmodeSequence(PyObject* object, NPY_CLIPMODE* modes, int n)
+.. c:function:: int PyArray_ConvertClipmodeSequence( \
+        PyObject* object, NPY_CLIPMODE* modes, int n)
 
    Converts either a sequence of clipmodes or a single clipmode into
    a C array of :c:type:`NPY_CLIPMODE` values. The number of clipmodes *n*
@@ -2864,7 +2988,8 @@ Other conversions
     scalars) to a (platform-pointer-sized) integer. On error, -1 is
     returned and an exception set.
 
-.. c:function:: int PyArray_IntpFromSequence(PyObject* seq, npy_intp* vals, int maxvals)
+.. c:function:: int PyArray_IntpFromSequence( \
+        PyObject* seq, npy_intp* vals, int maxvals)
 
     Convert any Python sequence (or single Python number) passed in as
     *seq* to (up to) *maxvals* pointer-sized integers and place them

--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -234,7 +234,9 @@ an incomplete struct.
 Construction and Destruction
 ----------------------------
 
-.. c:function:: NpyIter* NpyIter_New(PyArrayObject* op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, PyArray_Descr* dtype)
+.. c:function:: NpyIter* NpyIter_New( \
+        PyArrayObject* op, npy_uint32 flags, NPY_ORDER order, \
+        NPY_CASTING casting, PyArray_Descr* dtype)
 
     Creates an iterator for the given numpy array object ``op``.
 
@@ -282,7 +284,9 @@ Construction and Destruction
                             dtype);
         Py_DECREF(dtype);
 
-.. c:function:: NpyIter* NpyIter_MultiNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes)
+.. c:function:: NpyIter* NpyIter_MultiNew( \
+        npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, \
+        NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes)
 
     Creates an iterator for broadcasting the ``nop`` array objects provided
     in ``op``, using regular NumPy broadcasting rules.
@@ -620,7 +624,10 @@ Construction and Destruction
             This flag has effect only if ``NPY_ITER_COPY_IF_OVERLAP`` is enabled
             on the iterator.
 
-.. c:function:: NpyIter* NpyIter_AdvancedNew(npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
+.. c:function:: NpyIter* NpyIter_AdvancedNew( \
+        npy_intp nop, PyArrayObject** op, npy_uint32 flags, NPY_ORDER order, \
+        NPY_CASTING casting, npy_uint32* op_flags, PyArray_Descr** op_dtypes, \
+        int oa_ndim, int** op_axes, npy_intp* itershape, npy_intp buffersize)
 
     Extends :c:func:`NpyIter_MultiNew` with several advanced options providing
     more control over broadcasting and buffering.
@@ -765,7 +772,8 @@ Construction and Destruction
     non-NULL, the function may be safely called without holding
     the Python GIL.
 
-.. c:function:: int NpyIter_ResetToIterIndexRange(NpyIter* iter, npy_intp istart, npy_intp iend, char** errmsg)
+.. c:function:: int NpyIter_ResetToIterIndexRange( \
+        NpyIter* iter, npy_intp istart, npy_intp iend, char** errmsg)
 
     Resets the iterator and restricts it to the ``iterindex`` range
     ``[istart, iend)``.  See :c:func:`NpyIter_Copy` for an explanation of
@@ -792,7 +800,8 @@ Construction and Destruction
     non-NULL, the function may be safely called without holding
     the Python GIL.
 
-.. c:function:: int NpyIter_ResetBasePointers(NpyIter *iter, char** baseptrs, char** errmsg)
+.. c:function:: int NpyIter_ResetBasePointers( \
+        NpyIter *iter, char** baseptrs, char** errmsg)
 
     Resets the iterator back to its initial state, but using the values
     in ``baseptrs`` for the data instead of the pointers from the arrays
@@ -889,7 +898,8 @@ Construction and Destruction
     Gets the ``iterindex`` of the iterator, which is an index matching
     the iteration order of the iterator.
 
-.. c:function:: void NpyIter_GetIterIndexRange(NpyIter* iter, npy_intp* istart, npy_intp* iend)
+.. c:function:: void NpyIter_GetIterIndexRange( \
+        NpyIter* iter, npy_intp* istart, npy_intp* iend)
 
     Gets the ``iterindex`` sub-range that is being iterated.  If
     :c:data:`NPY_ITER_RANGED` was not specified, this always returns the
@@ -1042,7 +1052,8 @@ Construction and Destruction
     Fills ``nop`` flags. Sets ``outwriteflags[i]`` to 1 if
     ``op[i]`` can be written to, and to 0 if not.
 
-.. c:function:: int NpyIter_CreateCompatibleStrides(NpyIter* iter, npy_intp itemsize, npy_intp* outstrides)
+.. c:function:: int NpyIter_CreateCompatibleStrides( \
+        NpyIter* iter, npy_intp itemsize, npy_intp* outstrides)
 
     Builds a set of strides which are the same as the strides of an
     output array created using the :c:data:`NPY_ITER_ALLOCATE` flag, where NULL
@@ -1096,7 +1107,8 @@ Construction and Destruction
 Functions For Iteration
 -----------------------
 
-.. c:function:: NpyIter_IterNextFunc* NpyIter_GetIterNext(NpyIter* iter, char** errmsg)
+.. c:function:: NpyIter_IterNextFunc* NpyIter_GetIterNext( \
+        NpyIter* iter, char** errmsg)
 
     Returns a function pointer for iteration.  A specialized version
     of the function pointer may be calculated by this function
@@ -1194,7 +1206,8 @@ Functions For Iteration
             }
         } while (iternext());
 
-.. c:function:: NpyIter_GetMultiIndexFunc *NpyIter_GetGetMultiIndex(NpyIter* iter, char** errmsg)
+.. c:function:: NpyIter_GetMultiIndexFunc *NpyIter_GetGetMultiIndex( \
+        NpyIter* iter, char** errmsg)
 
     Returns a function pointer for getting the current multi-index
     of the iterator.  Returns NULL if the iterator is not tracking
@@ -1264,7 +1277,8 @@ functions provide that information.
     iteration, in particular if buffering is enabled.  This function
     may be safely called without holding the Python GIL.
 
-.. c:function:: void NpyIter_GetInnerFixedStrideArray(NpyIter* iter, npy_intp* out_strides)
+.. c:function:: void NpyIter_GetInnerFixedStrideArray( \
+        NpyIter* iter, npy_intp* out_strides)
 
     Gets an array of strides which are fixed, or will not change during
     the entire iteration.  For strides that may change, the value

--- a/doc/source/reference/c-api.iterator.rst
+++ b/doc/source/reference/c-api.iterator.rst
@@ -1250,7 +1250,7 @@ functions provide that information.
     This pointer may be cached before the iteration loop, calling
     ``iternext`` will not change it. This function may be safely
     called without holding the Python GIL.
-    
+
     **WARNING**: While the pointer may be cached, its values may
     change if the iterator is buffered.
 
@@ -1307,7 +1307,7 @@ Here is a conversion table for which functions to use with the new iterator:
 :c:func:`PyArrayIter_Check`            Will need to add this in Python exposure
 :c:func:`PyArray_ITER_RESET`           :c:func:`NpyIter_Reset`
 :c:func:`PyArray_ITER_NEXT`            Function pointer from :c:func:`NpyIter_GetIterNext`
-:c:func:`PyArray_ITER_DATA`            c:func:`NpyIter_GetDataPtrArray`
+:c:func:`PyArray_ITER_DATA`            :c:func:`NpyIter_GetDataPtrArray`
 :c:func:`PyArray_ITER_GOTO`            :c:func:`NpyIter_GotoMultiIndex`
 :c:func:`PyArray_ITER_GOTO1D`          :c:func:`NpyIter_GotoIndex` or
                                        :c:func:`NpyIter_GotoIterIndex`

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -6,7 +6,7 @@ Python Types and C-Structures
 
 Several new types are defined in the C-code. Most of these are
 accessible from Python, but a few are not exposed due to their limited
-use. Every new Python type has an associated :c:type:`PyObject *` with an
+use. Every new Python type has an associated :c:type:`PyObject *<PyObject>` with an
 internal structure that includes a pointer to a "method table" that
 defines how the new object behaves in Python. When you receive a
 Python object into C code, you always get a pointer to a

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -60,7 +60,7 @@ hierarchy of actual Python types.
 PyArray_Type
 ------------
 
-.. c:var: PyArray_Type
+.. c:var:: PyArray_Type
 
    The Python type of the ndarray is :c:data:`PyArray_Type`. In C, every
    ndarray is a pointer to a :c:type:`PyArrayObject` structure. The ob_type
@@ -165,7 +165,7 @@ PyArray_Type
 PyArrayDescr_Type
 -----------------
 
-.. c:var: PyArrayDescr_Type
+.. c:var:: PyArrayDescr_Type
 
    The :c:data:`PyArrayDescr_Type` is the built-in type of the
    data-type-descriptor objects used to describe how the bytes comprising
@@ -237,55 +237,55 @@ PyArrayDescr_Type
     array like behavior. Each bit in this member is a flag which are named
     as:
 
-    .. c:var: NPY_ITEM_REFCOUNT
+    .. c:var:: NPY_ITEM_REFCOUNT
 
-    .. c:var: NPY_ITEM_HASOBJECT
+    .. c:var:: NPY_ITEM_HASOBJECT
 
         Indicates that items of this data-type must be reference
         counted (using :c:func:`Py_INCREF` and :c:func:`Py_DECREF` ).
 
-    .. c:var: NPY_LIST_PICKLE
+    .. c:var:: NPY_LIST_PICKLE
 
         Indicates arrays of this data-type must be converted to a list
         before pickling.
 
-    .. c:var: NPY_ITEM_IS_POINTER
+    .. c:var:: NPY_ITEM_IS_POINTER
 
         Indicates the item is a pointer to some other data-type
 
-    .. c:var: NPY_NEEDS_INIT
+    .. c:var:: NPY_NEEDS_INIT
 
         Indicates memory for this data-type must be initialized (set
         to 0) on creation.
 
-    .. c:var: NPY_NEEDS_PYAPI
+    .. c:var:: NPY_NEEDS_PYAPI
 
         Indicates this data-type requires the Python C-API during
         access (so don't give up the GIL if array access is going to
         be needed).
 
-    .. c:var: NPY_USE_GETITEM
+    .. c:var:: NPY_USE_GETITEM
 
         On array access use the ``f->getitem`` function pointer
         instead of the standard conversion to an array scalar. Must
         use if you don't define an array scalar to go along with
         the data-type.
 
-    .. c:var: NPY_USE_SETITEM
+    .. c:var:: NPY_USE_SETITEM
 
         When creating a 0-d array from an array scalar use
         ``f->setitem`` instead of the standard copy from an array
         scalar. Must use if you don't define an array scalar to go
         along with the data-type.
 
-    .. c:var: NPY_FROM_FIELDS
+    .. c:var:: NPY_FROM_FIELDS
 
         The bits that are inherited for the parent data-type if these
         bits are set in any field of the data-type. Currently (
         :c:data:`NPY_NEEDS_INIT` \| :c:data:`NPY_LIST_PICKLE` \|
         :c:data:`NPY_ITEM_REFCOUNT` \| :c:data:`NPY_NEEDS_PYAPI` ).
 
-    .. c:var: NPY_OBJECT_DTYPE_FLAGS
+    .. c:var:: NPY_OBJECT_DTYPE_FLAGS
 
         Bits set for the object data-type: ( :c:data:`NPY_LIST_PICKLE`
         \| :c:data:`NPY_USE_GETITEM` \| :c:data:`NPY_ITEM_IS_POINTER` \|
@@ -648,7 +648,7 @@ for methods (tp_methods) and properties (tp_getset). The
 PyUFunc_Type
 ------------
 
-.. c:var: PyUFunc_Type
+.. c:var:: PyUFunc_Type
 
    The ufunc object is implemented by creation of the
    :c:data:`PyUFunc_Type`. It is a very simple type that implements only
@@ -801,7 +801,7 @@ PyUFunc_Type
 PyArrayIter_Type
 ----------------
 
-.. c:var: PyArrayIter_Type
+.. c:var:: PyArrayIter_Type
 
    This is an iterator object that makes it easy to loop over an
    N-dimensional array. It is the object returned from the flat
@@ -911,7 +911,7 @@ with it through the use of the macros :c:func:`PyArray_ITER_NEXT` (it),
 PyArrayMultiIter_Type
 ---------------------
 
-.. c:var: PyArrayMultiIter_Type
+.. c:var:: PyArrayMultiIter_Type
 
    This type provides an iterator that encapsulates the concept of
    broadcasting. It allows :math:`N` arrays to be broadcast together
@@ -973,7 +973,7 @@ PyArrayMultiIter_Type
 PyArrayNeighborhoodIter_Type
 ----------------------------
 
-.. c:var: PyArrayNeighborhoodIter_Type
+.. c:var:: PyArrayNeighborhoodIter_Type
 
    This is an iterator object that makes it easy to loop over an
    N-dimensional neighborhood.
@@ -987,7 +987,7 @@ PyArrayNeighborhoodIter_Type
 PyArrayFlags_Type
 -----------------
 
-.. c:var: PyArrayFlags_Type
+.. c:var:: PyArrayFlags_Type
 
    When the flags attribute is retrieved from Python, a special
    builtin object of this type is constructed. This special type makes
@@ -1226,7 +1226,7 @@ for completeness and assistance in understanding the code.
    to define a 1-d loop for a ufunc for every defined signature of a
    user-defined data-type.
 
-.. c:var: PyArrayMapIter_Type
+.. c:var:: PyArrayMapIter_Type
 
    Advanced indexing is handled with this Python type. It is simply a
    loose wrapper around the C-structure containing the variables

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -420,7 +420,8 @@ PyArrayDescr_Type
     functions can (and must) deal with mis-behaved arrays. The other
     functions require behaved memory segments.
 
-    .. c:member:: void cast(void *from, void *to, npy_intp n, void *fromarr, void *toarr)
+    .. c:member:: void cast( \
+            void *from, void *to, npy_intp n, void *fromarr, void *toarr)
 
         An array of function pointers to cast from the current type to
         all of the other builtin types. Each function casts a
@@ -446,7 +447,9 @@ PyArrayDescr_Type
         a zero is returned, otherwise, a negative one is returned (and
         a Python error set).
 
-    .. c:member:: void copyswapn(void *dest, npy_intp dstride, void *src, npy_intp sstride, npy_intp n, int swap, void *arr)
+    .. c:member:: void copyswapn( \
+            void *dest, npy_intp dstride, void *src, npy_intp sstride, \
+            npy_intp n, int swap, void *arr)
 
     .. c:member:: void copyswap(void *dest, void *src, int swap, void *arr)
 
@@ -472,7 +475,8 @@ PyArrayDescr_Type
         ``d2``, and -1 if * ``d1`` < * ``d2``. The array object ``arr`` is
         used to retrieve itemsize and field information for flexible arrays.
 
-    .. c:member:: int argmax(void* data, npy_intp n, npy_intp* max_ind, void* arr)
+    .. c:member:: int argmax( \
+            void* data, npy_intp n, npy_intp* max_ind, void* arr)
 
         A pointer to a function that retrieves the index of the
         largest of ``n`` elements in ``arr`` beginning at the element
@@ -481,7 +485,9 @@ PyArrayDescr_Type
         always 0. The index of the largest element is returned in
         ``max_ind``.
 
-    .. c:member:: void dotfunc(void* ip1, npy_intp is1, void* ip2, npy_intp is2, void* op, npy_intp n, void* arr)
+    .. c:member:: void dotfunc( \
+            void* ip1, npy_intp is1, void* ip2, npy_intp is2, void* op, \
+            npy_intp n, void* arr)
 
         A pointer to a function that multiplies two ``n`` -length
         sequences together, adds them, and places the result in
@@ -531,7 +537,8 @@ PyArrayDescr_Type
         computed by repeatedly adding this computed delta. The data
         buffer must be well-behaved.
 
-    .. c:member:: void fillwithscalar(void* buffer, npy_intp length, void* value, void* arr)
+    .. c:member:: void fillwithscalar( \
+            void* buffer, npy_intp length, void* value, void* arr)
 
         A pointer to a function that fills a contiguous ``buffer`` of
         the given ``length`` with a single scalar ``value`` whose
@@ -546,7 +553,8 @@ PyArrayDescr_Type
         and :c:data:`NPY_MERGESORT` are defined). These sorts are done
         in-place assuming contiguous and aligned data.
 
-    .. c:member:: int argsort(void* start, npy_intp* result, npy_intp length, void *arr)
+    .. c:member:: int argsort( \
+            void* start, npy_intp* result, npy_intp length, void *arr)
 
         An array of function pointers to sorting algorithms for this
         data type. The same sorting algorithms as for sort are
@@ -584,7 +592,8 @@ PyArrayDescr_Type
         can be cast to safely (this usually means without losing
         precision).
 
-    .. c:member:: void fastclip(void *in, npy_intp n_in, void *min, void *max, void *out)
+    .. c:member:: void fastclip( \
+            void *in, npy_intp n_in, void *min, void *max, void *out)
 
         A function that reads ``n_in`` items from ``in``, and writes to
         ``out`` the read value if it is within the limits pointed to by
@@ -592,7 +601,8 @@ PyArrayDescr_Type
         memory segments must be contiguous and behaved, and either
         ``min`` or ``max`` may be ``NULL``, but not both.
 
-    .. c:member:: void fastputmask(void *in, void *mask, npy_intp n_in, void *values, npy_intp nv)
+    .. c:member:: void fastputmask( \
+            void *in, void *mask, npy_intp n_in, void *values, npy_intp nv)
 
         A function that takes a pointer ``in`` to an array of ``n_in``
         items, a pointer ``mask`` to an array of ``n_in`` boolean
@@ -601,7 +611,10 @@ PyArrayDescr_Type
         in ``mask`` is non-zero, tiling ``vals`` as needed if
         ``nv < n_in``. All arrays must be contiguous and behaved.
 
-    .. c:member:: void fasttake(void *dest, void *src, npy_intp *indarray, npy_intp nindarray, npy_intp n_outer, npy_intp m_middle, npy_intp nelem, NPY_CLIPMODE clipmode)
+    .. c:member:: void fasttake( \
+            void *dest, void *src, npy_intp *indarray, npy_intp nindarray, \
+            npy_intp n_outer, npy_intp m_middle, npy_intp nelem, \
+            NPY_CLIPMODE clipmode)
 
         A function that takes a pointer ``src`` to a C contiguous,
         behaved segment, interpreted as a 3-dimensional array of shape
@@ -617,7 +630,8 @@ PyArrayDescr_Type
         indices smaller than 0 or larger than ``nindarray`` will be
         handled.
 
-    .. c:member:: int argmin(void* data, npy_intp n, npy_intp* min_ind, void* arr)
+    .. c:member:: int argmin( \
+            void* data, npy_intp n, npy_intp* min_ind, void* arr)
 
         A pointer to a function that retrieves the index of the
         smallest of ``n`` elements in ``arr`` beginning at the element

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -404,7 +404,7 @@ Importing the API
     created (and pointed to by a global variable) by import_ufunc. The
     global variable is either statically defined or allowed to be seen
     by other files depending on the state of
-    :c:data:`Py_UFUNC_UNIQUE_SYMBOL` and :c:data:`NO_IMPORT_UFUNC`.
+    :c:data:`PY_UFUNC_UNIQUE_SYMBOL` and :c:data:`NO_IMPORT_UFUNC`.
 
 .. index::
    pair: ufunc; C-API

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -65,9 +65,7 @@ Macros
 Functions
 ---------
 
-.. c:function:: PyObject* PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func,
-   void** data, char* types, int ntypes, int nin, int nout, int identity,
-   char* name, char* doc, int unused)
+.. c:function:: PyObject* PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func, void** data, char* types, int ntypes, int nin, int nout, int identity, char* name, char* doc, int unused)
 
     Create a new broadcasting universal function from required variables.
     Each ufunc builds around the notion of an element-by-element
@@ -124,9 +122,7 @@ Functions
     :param unused:
         Unused and present for backwards compatibility of the C-API.
 
-.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction* func,
-   void** data, char* types, int ntypes, int nin, int nout, int identity,
-   char* name, char* doc, int unused, char *signature)
+.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction* func, void** data, char* types, int ntypes, int nin, int nout, int identity, char* name, char* doc, int unused, char *signature)
 
    This function is very similar to PyUFunc_FromFuncAndData above, but has
    an extra *signature* argument, to define generalized universal functions.
@@ -139,8 +135,7 @@ Functions
         to calling PyUFunc_FromFuncAndData. A copy of the string is made,
         so the passed in buffer can be freed.
 
-.. c:function:: int PyUFunc_RegisterLoopForType(PyUFuncObject* ufunc,
-   int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
+.. c:function:: int PyUFunc_RegisterLoopForType(PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
 
     This function allows the user to register a 1-d loop with an
     already- created ufunc to be used whenever the ufunc is called
@@ -153,9 +148,7 @@ Functions
     in as *arg_types* which must be a pointer to memory at least as
     large as ufunc->nargs.
 
-.. c:function:: int PyUFunc_RegisterLoopForDescr(PyUFuncObject* ufunc,
-   PyArray_Descr* userdtype, PyUFuncGenericFunction function,
-   PyArray_Descr** arg_dtypes, void* data)
+.. c:function:: int PyUFunc_RegisterLoopForDescr(PyUFuncObject* ufunc, PyArray_Descr* userdtype, PyUFuncGenericFunction function, PyArray_Descr** arg_dtypes, void* data)
 
    This function behaves like PyUFunc_RegisterLoopForType above, except
    that it allows the user to register a 1-d loop using PyArray_Descr
@@ -163,9 +156,7 @@ Functions
    registered for structured array data-dtypes and custom data-types
    instead of scalar data-types.
 
-.. c:function:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc,
-   PyUFuncGenericFunction newfunc, int* signature,
-   PyUFuncGenericFunction* oldfunc)
+.. c:function:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc, PyUFuncGenericFunction newfunc, int* signature, PyUFuncGenericFunction* oldfunc)
 
     Replace a 1-d loop matching the given *signature* in the
     already-created *ufunc* with the new 1-d loop newfunc. Return the
@@ -175,8 +166,7 @@ Functions
     signature is an array of data-type numbers indicating the inputs
     followed by the outputs assumed by the 1-d loop.
 
-.. c:function:: int PyUFunc_GenericFunction(PyUFuncObject* self,
-   PyObject* args, PyObject* kwds, PyArrayObject** mps)
+.. c:function:: int PyUFunc_GenericFunction(PyUFuncObject* self, PyObject* args, PyObject* kwds, PyArrayObject** mps)
 
     A generic ufunc call. The ufunc is passed in as *self*, the arguments
     to the ufunc as *args* and *kwds*. The *mps* argument is an array of
@@ -203,12 +193,11 @@ Functions
     hardware is determined a -1 is returned, otherwise a 0 is
     returned.
 
-.. c:function::  void  PyUFunc_clearfperr()
+.. c:function:: void PyUFunc_clearfperr()
 
     Clear the IEEE error flags.
 
-.. c:function:: void PyUFunc_GetPyValues(char* name, int* bufsize,
-   int* errmask, PyObject** errobj)
+.. c:function:: void PyUFunc_GetPyValues(char* name, int* bufsize, int* errmask, PyObject** errobj)
 
     Get the Python values used for ufunc processing from the
     thread-local storage area unless the defaults have been set in
@@ -235,38 +224,27 @@ of these functions are suitable for placing directly in the array of
 functions stored in the functions member of the PyUFuncObject
 structure.
 
-.. c:function:: void PyUFunc_f_f_As_d_d(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_f_f_As_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_d_d(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_f_f(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_f_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_g_g(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_g_g(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_F_F_As_D_D(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_F_F_As_D_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_F_F(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_F_F(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_D_D(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_D_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_G_G(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_G_G(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_e_e(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_e_e(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_e_e_As_f_f(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_e_e_As_f_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_e_e_As_d_d(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_e_e_As_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     Type specific, core 1-d functions for ufuncs where each
     calculation is obtained by calling a function taking one input
@@ -281,38 +259,27 @@ structure.
     ndarrays of data type :c:data:`NPY_FLOAT` but calls out to a
     C-function that takes double and returns double.
 
-.. c:function:: void PyUFunc_ff_f_As_dd_d(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ff_f_As_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ff_f(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ff_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_dd_d(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_gg_g(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_gg_g(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_FF_F_As_DD_D(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_FF_F_As_DD_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_DD_D(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_DD_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_FF_F(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_FF_F(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_GG_G(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_GG_G(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ee_e(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ee_e(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ee_e_As_ff_f(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ee_e_As_ff_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ee_e_As_dd_d(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ee_e_As_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     Type specific, core 1-d functions for ufuncs where each
     calculation is obtained by calling a function taking two input
@@ -324,11 +291,9 @@ structure.
     of one data type but cast the values at each iteration of the loop
     to use the underlying function that takes a different data type.
 
-.. c:function:: void PyUFunc_O_O(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_O_O(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_OO_O(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_OO_O(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     One-input, one-output, and two-input, one-output core 1-d functions
     for the :c:data:`NPY_OBJECT` data type. These functions handle reference
@@ -337,16 +302,14 @@ structure.
     (PyObject*)`` for :c:func:`PyUFunc_O_O` or ``(PyObject*)(PyObject *,
     PyObject *)`` for :c:func:`PyUFunc_OO_O`.
 
-.. c:function:: void PyUFunc_O_O_method(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_O_O_method(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     This general purpose 1-d core function assumes that *func* is a string
     representing a method of the input object. For each
     iteration of the loop, the Python object is extracted from the array
     and its *func* method is called returning the result to the output array.
 
-.. c:function:: void PyUFunc_OO_O_method(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_OO_O_method(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     This general purpose 1-d core function assumes that *func* is a
     string representing a method of the input object that takes one
@@ -355,8 +318,7 @@ structure.
     function. The output of the function is stored in the third entry
     of *args*.
 
-.. c:function:: void PyUFunc_On_Om(char** args, npy_intp* dimensions,
-   npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_On_Om(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     This is the 1-d core function used by the dynamic ufuncs created
     by umath.frompyfunc(function, nin, nout). In this case *func* is a

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -65,7 +65,9 @@ Macros
 Functions
 ---------
 
-.. c:function:: PyObject* PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func, void** data, char* types, int ntypes, int nin, int nout, int identity, char* name, char* doc, int unused)
+.. c:function:: PyObject* PyUFunc_FromFuncAndData( \
+        PyUFuncGenericFunction* func, void** data, char* types, int ntypes, \
+        int nin, int nout, int identity, char* name, char* doc, int unused)
 
     Create a new broadcasting universal function from required variables.
     Each ufunc builds around the notion of an element-by-element
@@ -122,7 +124,9 @@ Functions
     :param unused:
         Unused and present for backwards compatibility of the C-API.
 
-.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction* func, void** data, char* types, int ntypes, int nin, int nout, int identity, char* name, char* doc, int unused, char *signature)
+.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignature( \
+        PyUFuncGenericFunction* func, void** data, char* types, int ntypes, \
+        int nin, int nout, int identity, char* name, char* doc, int unused, char *signature)
 
    This function is very similar to PyUFunc_FromFuncAndData above, but has
    an extra *signature* argument, to define generalized universal functions.
@@ -135,7 +139,9 @@ Functions
         to calling PyUFunc_FromFuncAndData. A copy of the string is made,
         so the passed in buffer can be freed.
 
-.. c:function:: int PyUFunc_RegisterLoopForType(PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
+.. c:function:: int PyUFunc_RegisterLoopForType( \
+        PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, \
+        int* arg_types, void* data)
 
     This function allows the user to register a 1-d loop with an
     already- created ufunc to be used whenever the ufunc is called
@@ -148,7 +154,9 @@ Functions
     in as *arg_types* which must be a pointer to memory at least as
     large as ufunc->nargs.
 
-.. c:function:: int PyUFunc_RegisterLoopForDescr(PyUFuncObject* ufunc, PyArray_Descr* userdtype, PyUFuncGenericFunction function, PyArray_Descr** arg_dtypes, void* data)
+.. c:function:: int PyUFunc_RegisterLoopForDescr( \
+        PyUFuncObject* ufunc, PyArray_Descr* userdtype, \
+        PyUFuncGenericFunction function, PyArray_Descr** arg_dtypes, void* data)
 
    This function behaves like PyUFunc_RegisterLoopForType above, except
    that it allows the user to register a 1-d loop using PyArray_Descr
@@ -156,7 +164,9 @@ Functions
    registered for structured array data-dtypes and custom data-types
    instead of scalar data-types.
 
-.. c:function:: int PyUFunc_ReplaceLoopBySignature(PyUFuncObject* ufunc, PyUFuncGenericFunction newfunc, int* signature, PyUFuncGenericFunction* oldfunc)
+.. c:function:: int PyUFunc_ReplaceLoopBySignature( \
+        PyUFuncObject* ufunc, PyUFuncGenericFunction newfunc, int* signature, \
+        PyUFuncGenericFunction* oldfunc)
 
     Replace a 1-d loop matching the given *signature* in the
     already-created *ufunc* with the new 1-d loop newfunc. Return the
@@ -166,7 +176,8 @@ Functions
     signature is an array of data-type numbers indicating the inputs
     followed by the outputs assumed by the 1-d loop.
 
-.. c:function:: int PyUFunc_GenericFunction(PyUFuncObject* self, PyObject* args, PyObject* kwds, PyArrayObject** mps)
+.. c:function:: int PyUFunc_GenericFunction( \
+        PyUFuncObject* self, PyObject* args, PyObject* kwds, PyArrayObject** mps)
 
     A generic ufunc call. The ufunc is passed in as *self*, the arguments
     to the ufunc as *args* and *kwds*. The *mps* argument is an array of
@@ -197,7 +208,8 @@ Functions
 
     Clear the IEEE error flags.
 
-.. c:function:: void PyUFunc_GetPyValues(char* name, int* bufsize, int* errmask, PyObject** errobj)
+.. c:function:: void PyUFunc_GetPyValues( \
+        char* name, int* bufsize, int* errmask, PyObject** errobj)
 
     Get the Python values used for ufunc processing from the
     thread-local storage area unless the defaults have been set in
@@ -224,27 +236,38 @@ of these functions are suitable for placing directly in the array of
 functions stored in the functions member of the PyUFuncObject
 structure.
 
-.. c:function:: void PyUFunc_f_f_As_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_f_f_As_d_d( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_d_d( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_f_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_f_f( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_g_g(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_g_g( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_F_F_As_D_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_F_F_As_D_D( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_F_F(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_F_F( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_D_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_D_D( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_G_G(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_G_G( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_e_e(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_e_e( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_e_e_As_f_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_e_e_As_f_f( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_e_e_As_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_e_e_As_d_d( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     Type specific, core 1-d functions for ufuncs where each
     calculation is obtained by calling a function taking one input
@@ -259,27 +282,38 @@ structure.
     ndarrays of data type :c:data:`NPY_FLOAT` but calls out to a
     C-function that takes double and returns double.
 
-.. c:function:: void PyUFunc_ff_f_As_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ff_f_As_dd_d( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ff_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ff_f( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_dd_d( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_gg_g(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_gg_g( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_FF_F_As_DD_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_FF_F_As_DD_D( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_DD_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_DD_D( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_FF_F(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_FF_F( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_GG_G(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_GG_G( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ee_e(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ee_e( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ee_e_As_ff_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ee_e_As_ff_f( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_ee_e_As_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_ee_e_As_dd_d( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     Type specific, core 1-d functions for ufuncs where each
     calculation is obtained by calling a function taking two input
@@ -291,9 +325,11 @@ structure.
     of one data type but cast the values at each iteration of the loop
     to use the underlying function that takes a different data type.
 
-.. c:function:: void PyUFunc_O_O(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_O_O( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
-.. c:function:: void PyUFunc_OO_O(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_OO_O( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     One-input, one-output, and two-input, one-output core 1-d functions
     for the :c:data:`NPY_OBJECT` data type. These functions handle reference
@@ -302,14 +338,16 @@ structure.
     (PyObject*)`` for :c:func:`PyUFunc_O_O` or ``(PyObject*)(PyObject *,
     PyObject *)`` for :c:func:`PyUFunc_OO_O`.
 
-.. c:function:: void PyUFunc_O_O_method(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_O_O_method( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     This general purpose 1-d core function assumes that *func* is a string
     representing a method of the input object. For each
     iteration of the loop, the Python object is extracted from the array
     and its *func* method is called returning the result to the output array.
 
-.. c:function:: void PyUFunc_OO_O_method(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_OO_O_method( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     This general purpose 1-d core function assumes that *func* is a
     string representing a method of the input object that takes one
@@ -318,7 +356,8 @@ structure.
     function. The output of the function is stored in the third entry
     of *args*.
 
-.. c:function:: void PyUFunc_On_Om(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+.. c:function:: void PyUFunc_On_Om( \
+        char** args, npy_intp* dimensions, npy_intp* steps, void* func)
 
     This is the 1-d core function used by the dynamic ufuncs created
     by umath.frompyfunc(function, nin, nout). In this case *func* is a

--- a/doc/source/reference/internals.code-explanations.rst
+++ b/doc/source/reference/internals.code-explanations.rst
@@ -460,12 +460,12 @@ Ufuncs allow other array-like classes to be passed seamlessly through
 the interface in that inputs of a particular class will induce the
 outputs to be of that same class. The mechanism by which this works is
 the following. If any of the inputs are not ndarrays and define the
-:obj:`__array_wrap__` method, then the class with the largest
-:obj:`__array_priority__` attribute determines the type of all the
+:obj:`~numpy.class.__array_wrap__` method, then the class with the largest
+:obj:`~numpy.class.__array_priority__` attribute determines the type of all the
 outputs (with the exception of any output arrays passed in). The
-:obj:`__array_wrap__` method of the input array will be called with the
+:obj:`~numpy.class.__array_wrap__` method of the input array will be called with the
 ndarray being returned from the ufunc as it's input. There are two
-calling styles of the :obj:`__array_wrap__` function supported. The first
+calling styles of the :obj:`~numpy.class.__array_wrap__` function supported. The first
 takes the ndarray as the first argument and a tuple of "context" as
 the second argument. The context is (ufunc, arguments, output argument
 number). This is the first call tried. If a TypeError occurs, then the

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -103,24 +103,24 @@ Output type determination
 The output of the ufunc (and its methods) is not necessarily an
 :class:`ndarray`, if all input arguments are not :class:`ndarrays <ndarray>`.
 
-All output arrays will be passed to the :obj:`__array_prepare__` and
-:obj:`__array_wrap__` methods of the input (besides
+All output arrays will be passed to the :obj:`~class.__array_prepare__` and
+:obj:`~class.__array_wrap__` methods of the input (besides
 :class:`ndarrays <ndarray>`, and scalars) that defines it **and** has
-the highest :obj:`__array_priority__` of any other input to the
-universal function. The default :obj:`__array_priority__` of the
-ndarray is 0.0, and the default :obj:`__array_priority__` of a subtype
-is 1.0. Matrices have :obj:`__array_priority__` equal to 10.0.
+the highest :obj:`~class.__array_priority__` of any other input to the
+universal function. The default :obj:`~class.__array_priority__` of the
+ndarray is 0.0, and the default :obj:`~class.__array_priority__` of a subtype
+is 1.0. Matrices have :obj:`~class.__array_priority__` equal to 10.0.
 
 All ufuncs can also take output arguments. If necessary, output will
 be cast to the data-type(s) of the provided output array(s). If a class
-with an :obj:`__array__` method is used for the output, results will be
-written to the object returned by :obj:`__array__`. Then, if the class
-also has an :obj:`__array_prepare__` method, it is called so metadata
+with an :obj:`~class.__array__` method is used for the output, results will be
+written to the object returned by :obj:`~class.__array__`. Then, if the class
+also has an :obj:`~class.__array_prepare__` method, it is called so metadata
 may be determined based on the context of the ufunc (the context
 consisting of the ufunc itself, the arguments passed to the ufunc, and
 the ufunc domain.) The array object returned by
-:obj:`__array_prepare__` is passed to the ufunc for computation.
-Finally, if the class also has an :obj:`__array_wrap__` method, the returned
+:obj:`~class.__array_prepare__` is passed to the ufunc for computation.
+Finally, if the class also has an :obj:`~class.__array_wrap__` method, the returned
 :class:`ndarray` result will be passed to that method just before
 passing control back to the caller.
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -173,7 +173,7 @@ each array is for PyArray_ITER_NEXT to be called for each of the inputs. This
 incrementing is automatically performed by
 :c:func:`PyArray_MultiIter_NEXT` ( ``obj`` ) macro (which can handle a
 multiterator ``obj`` as either a :c:type:`PyArrayMultiObject *` or a
-:c:type:`PyObject *`). The data from input number ``i`` is available using
+:c:type:`PyObject *<PyObject>`). The data from input number ``i`` is available using
 :c:func:`PyArray_MultiIter_DATA` ( ``obj``, ``i`` ) and the total (broadcasted)
 size as :c:func:`PyArray_MultiIter_SIZE` ( ``obj``). An example of using this
 feature follows.

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -284,8 +284,7 @@ functions for each conversion you want to support and then registering
 these functions with the data-type descriptor. A low-level casting
 function has the signature.
 
-.. c:function:: void castfunc( void* from, void* to, npy_intp n, void* fromarr,
-   void* toarr)
+.. c:function:: void castfunc( void* from, void* to, npy_intp n, void* fromarr, void* toarr)
 
     Cast ``n`` elements ``from`` one type ``to`` another. The data to
     cast from is in a contiguous, correctly-swapped and aligned chunk
@@ -358,8 +357,7 @@ previously created. Then you call :c:func:`PyUFunc_RegisterLoopForType`
 this function is ``0`` if the process was successful and ``-1`` with
 an error condition set if it was not successful.
 
-.. c:function:: int PyUFunc_RegisterLoopForType( PyUFuncObject* ufunc,
-   int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
+.. c:function:: int PyUFunc_RegisterLoopForType( PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
 
     *ufunc*
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -284,7 +284,8 @@ functions for each conversion you want to support and then registering
 these functions with the data-type descriptor. A low-level casting
 function has the signature.
 
-.. c:function:: void castfunc( void* from, void* to, npy_intp n, void* fromarr, void* toarr)
+.. c:function:: void castfunc( \
+        void* from, void* to, npy_intp n, void* fromarr, void* toarr)
 
     Cast ``n`` elements ``from`` one type ``to`` another. The data to
     cast from is in a contiguous, correctly-swapped and aligned chunk
@@ -357,7 +358,9 @@ previously created. Then you call :c:func:`PyUFunc_RegisterLoopForType`
 this function is ``0`` if the process was successful and ``-1`` with
 an error condition set if it was not successful.
 
-.. c:function:: int PyUFunc_RegisterLoopForType( PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, int* arg_types, void* data)
+.. c:function:: int PyUFunc_RegisterLoopForType( \
+        PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, \
+        int* arg_types, void* data)
 
     *ufunc*
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -428,10 +428,10 @@ type-object structure and populating it with functions and pointers to
 describe the desired behavior of the type. Typically, a new
 C-structure is also created to contain the instance-specific
 information needed for each object of the type as well. For example,
-:c:data:`&PyArray_Type` is a pointer to the type-object table for the ndarray
+:c:data:`&PyArray_Type<PyArray_Type>` is a pointer to the type-object table for the ndarray
 while a :c:type:`PyArrayObject *` variable is a pointer to a particular instance
 of an ndarray (one of the members of the ndarray structure is, in
-turn, a pointer to the type- object table :c:data:`&PyArray_Type`). Finally
+turn, a pointer to the type- object table :c:data:`&PyArray_Type<PyArray_Type>`). Finally
 :c:func:`PyType_Ready` (<pointer_to_type_object>) must be called for
 every new Python type.
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -500,13 +500,13 @@ The __array_finalize\__ method
    sub-type is created in such a fashion, however, neither the
    __new_\_ method nor the __init\__ method gets called. Instead, the
    sub-type is allocated and the appropriate instance-structure
-   members are filled in. Finally, the :obj:`__array_finalize__`
+   members are filled in. Finally, the :obj:`~numpy.class.__array_finalize__`
    attribute is looked-up in the object dictionary. If it is present
    and not None, then it can be either a CObject containing a pointer
    to a :c:func:`PyArray_FinalizeFunc` or it can be a method taking a
    single argument (which could be None).
 
-   If the :obj:`__array_finalize__` attribute is a CObject, then the pointer
+   If the :obj:`~numpy.class.__array_finalize__` attribute is a CObject, then the pointer
    must be a pointer to a function with the signature:
 
    .. code-block:: c
@@ -519,7 +519,7 @@ The __array_finalize\__ method
    is present). This routine can do anything it wants to. It should
    return a -1 on error and 0 otherwise.
 
-   If the :obj:`__array_finalize__` attribute is not None nor a CObject,
+   If the :obj:`~numpy.class.__array_finalize__` attribute is not None nor a CObject,
    then it must be a Python method that takes the parent array as an
    argument (which could be None if there is no parent), and returns
    nothing. Errors in this method will be caught and handled.
@@ -533,14 +533,14 @@ The __array_priority\__ attribute
    This attribute allows simple but flexible determination of which sub-
    type should be considered "primary" when an operation involving two or
    more sub-types arises. In operations where different sub-types are
-   being used, the sub-type with the largest :obj:`__array_priority__`
+   being used, the sub-type with the largest :obj:`~numpy.class.__array_priority__`
    attribute will determine the sub-type of the output(s). If two sub-
-   types have the same :obj:`__array_priority__` then the sub-type of the
+   types have the same :obj:`~numpy.class.__array_priority__` then the sub-type of the
    first argument determines the output. The default
-   :obj:`__array_priority__` attribute returns a value of 0.0 for the base
+   :obj:`~numpy.class.__array_priority__` attribute returns a value of 0.0 for the base
    ndarray type and 1.0 for a sub-type. This attribute can also be
    defined by objects that are not sub-types of the ndarray and can be
-   used to determine which :obj:`__array_wrap__` method should be called for
+   used to determine which :obj:`~numpy.class.__array_wrap__` method should be called for
    the return output.
 
 The __array_wrap\__ method
@@ -550,11 +550,11 @@ The __array_wrap\__ method
 
    Any class or type can define this method which should take an ndarray
    argument and return an instance of the type. It can be seen as the
-   opposite of the :obj:`__array__` method. This method is used by the
+   opposite of the :obj:`~numpy.class.__array__` method. This method is used by the
    ufuncs (and other NumPy functions) to allow other objects to pass
    through. For Python >2.4, it can also be used to write a decorator
    that converts a function that works only with ndarrays to one that
-   works with any type with :obj:`__array__` and :obj:`__array_wrap__` methods.
+   works with any type with :obj:`~numpy.class.__array__` and :obj:`~numpy.class.__array_wrap__` methods.
 
 .. index::
    pair: ndarray; subtyping

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -385,9 +385,9 @@ writeable). The syntax is
         and 4) any scalar object (becomes a zero-dimensional
         array). Sub-classes of the ndarray that otherwise fit the
         requirements will be passed through. If you want to ensure
-        a base-class ndarray, then use :c:data:`NPY_ENSUREARRAY` in the
+        a base-class ndarray, then use :c:data:`NPY_ARRAY_ENSUREARRAY` in the
         requirements flag. A copy is made only if necessary. If you
-        want to guarantee a copy, then pass in :c:data:`NPY_ENSURECOPY`
+        want to guarantee a copy, then pass in :c:data:`NPY_ARRAY_ENSURECOPY`
         to the requirements flag.
 
     *typenum*
@@ -415,7 +415,7 @@ writeable). The syntax is
 
         The object will be converted to the desired type only if it
         can be done without losing precision. Otherwise ``NULL`` will
-        be returned and an error raised. Use :c:data:`NPY_FORCECAST` in the
+        be returned and an error raised. Use :c:data:`NPY_ARRAY_FORCECAST` in the
         requirements flag to override this behavior.
 
     *requirements*
@@ -575,7 +575,7 @@ is obtained as :c:func:`PyArray_GETPTR3` (E, i, j, k).
 
 As explained previously, C-style contiguous arrays and Fortran-style
 contiguous arrays have particular striding patterns. Two array flags
-(:c:data:`NPY_C_CONTIGUOUS` and :c:data:`NPY_F_CONTIGUOUS`) indicate
+(:c:data:`NPY_ARRAY_C_CONTIGUOUS` and :c:data:`NPY_ARRAY_F_CONTIGUOUS`) indicate
 whether or not the striding pattern of a particular array matches the
 C-style contiguous or Fortran-style contiguous or neither. Whether or
 not the striding pattern matches a standard C or Fortran one can be

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -90,11 +90,14 @@ that do not require a separate extraction of the module dictionary.
 These are documented in the Python documentation, but repeated here
 for convenience:
 
-.. c:function:: int PyModule_AddObject(PyObject* module, char* name, PyObject* value)
+.. c:function:: int PyModule_AddObject( \
+        PyObject* module, char* name, PyObject* value)
 
-.. c:function:: int PyModule_AddIntConstant(PyObject* module, char* name, long value)
+.. c:function:: int PyModule_AddIntConstant( \
+        PyObject* module, char* name, long value)
 
-.. c:function:: int PyModule_AddStringConstant(PyObject* module, char* name, char* value)
+.. c:function:: int PyModule_AddStringConstant( \
+        PyObject* module, char* name, char* value)
 
     All three of these functions require the *module* object (the
     return value of Py_InitModule). The *name* is a string that
@@ -359,7 +362,8 @@ specific builtin data-type ( *e.g.* float), while specifying a
 particular set of requirements ( *e.g.* contiguous, aligned, and
 writeable). The syntax is
 
-.. c:function:: PyObject *PyArray_FROM_OTF(PyObject* obj, int typenum, int requirements)
+.. c:function:: PyObject *PyArray_FROM_OTF( \
+        PyObject* obj, int typenum, int requirements)
 
     Return an ndarray from any Python object, *obj*, that can be
     converted to an array. The number of dimensions in the returned
@@ -529,7 +533,8 @@ simpler forms exist that are easier to use.
     memory for the array can be set to zero if desired using
     :c:func:`PyArray_FILLWBYTE` (return_object, 0).
 
-.. c:function:: PyObject *PyArray_SimpleNewFromData( int nd, npy_intp* dims, int typenum, void* data)
+.. c:function:: PyObject *PyArray_SimpleNewFromData( \
+        int nd, npy_intp* dims, int typenum, void* data)
 
     Sometimes, you want to wrap memory allocated elsewhere into an
     ndarray object for downstream use. This routine makes it

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -381,7 +381,7 @@ writeable). The syntax is
         so that data does not have to be copied. Objects that can be
         converted to an array include: 1) any nested sequence object,
         2) any object exposing the array interface, 3) any object with
-        an :obj:`__array__` method (which should return an ndarray),
+        an :obj:`~numpy.class.__array__` method (which should return an ndarray),
         and 4) any scalar object (becomes a zero-dimensional
         array). Sub-classes of the ndarray that otherwise fit the
         requirements will be passed through. If you want to ensure

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -575,7 +575,7 @@ is obtained as :c:func:`PyArray_GETPTR3` (E, i, j, k).
 
 As explained previously, C-style contiguous arrays and Fortran-style
 contiguous arrays have particular striding patterns. Two array flags
-(:c:data:`NPY_C_CONTIGUOUS` and :cdata`NPY_F_CONTIGUOUS`) indicate
+(:c:data:`NPY_C_CONTIGUOUS` and :c:data:`NPY_F_CONTIGUOUS`) indicate
 whether or not the striding pattern of a particular array matches the
 C-style contiguous or Fortran-style contiguous or neither. Whether or
 not the striding pattern matches a standard C or Fortran one can be

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -210,9 +210,9 @@ The :c:func:`Py_BuildValue` (format_string, c_variables...) function makes
 it easy to build tuples of Python objects from C variables. Pay
 special attention to the difference between 'N' and 'O' in the format
 string or you can easily create memory leaks. The 'O' format string
-increments the reference count of the :c:type:`PyObject *` C-variable it
+increments the reference count of the :c:type:`PyObject *<PyObject>` C-variable it
 corresponds to, while the 'N' format string steals a reference to the
-corresponding :c:type:`PyObject *` C-variable. You should use 'N' if you have
+corresponding :c:type:`PyObject *<PyObject>` C-variable. You should use 'N' if you have
 already created a reference for the object and just want to give that
 reference to the tuple. You should use 'O' if you only have a borrowed
 reference to an object and need to create one to provide for the

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -1058,9 +1058,7 @@ What follows is the full specification of PyUFunc_FromFuncAndData, which
 automatically generates a ufunc from a C function with the correct signature.
 
 
-.. c:function:: PyObject *PyUFunc_FromFuncAndData( PyUFuncGenericFunction* func,
-   void** data, char* types, int ntypes, int nin, int nout, int identity,
-   char* name, char* doc, int unused)
+.. c:function:: PyObject *PyUFunc_FromFuncAndData( PyUFuncGenericFunction* func, void** data, char* types, int ntypes, int nin, int nout, int identity, char* name, char* doc, int unused)
 
     *func*
 
@@ -1069,8 +1067,7 @@ automatically generates a ufunc from a C function with the correct signature.
         ``PyUFuncGenericFunction`` function. This function has the following
         signature. An example of a valid 1d loop function is also given.
 
-        .. c:function:: void loop1d(char** args, npy_intp* dimensions,
-           npy_intp* steps, void* data)
+    .. c:function:: void loop1d(char** args, npy_intp* dimensions, npy_intp* steps, void* data)
 
         *args*
 

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -1058,7 +1058,9 @@ What follows is the full specification of PyUFunc_FromFuncAndData, which
 automatically generates a ufunc from a C function with the correct signature.
 
 
-.. c:function:: PyObject *PyUFunc_FromFuncAndData( PyUFuncGenericFunction* func, void** data, char* types, int ntypes, int nin, int nout, int identity, char* name, char* doc, int unused)
+.. c:function:: PyObject *PyUFunc_FromFuncAndData( \
+        PyUFuncGenericFunction* func, void** data, char* types, int ntypes, \
+        int nin, int nout, int identity, char* name, char* doc, int unused)
 
     *func*
 
@@ -1067,7 +1069,8 @@ automatically generates a ufunc from a C function with the correct signature.
         ``PyUFuncGenericFunction`` function. This function has the following
         signature. An example of a valid 1d loop function is also given.
 
-    .. c:function:: void loop1d(char** args, npy_intp* dimensions, npy_intp* steps, void* data)
+    .. c:function:: void loop1d( \
+            char** args, npy_intp* dimensions, npy_intp* steps, void* data)
 
         *args*
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -975,9 +975,9 @@ def eigvalsh(a, UPLO='L'):
     >>> a = np.array([[1, -2j], [2j, 5]])
     >>> LA.eigvalsh(a)
     array([ 0.17157288,  5.82842712])
-    
+
     >>> # demonstrate the treatment of the imaginary part of the diagonal
-    >>> a = np.array([[5+2j, 9-2j], [0+2j, 2-1j]]) 
+    >>> a = np.array([[5+2j, 9-2j], [0+2j, 2-1j]])
     >>> a
     array([[ 5.+2.j,  9.-2.j],
            [ 0.+2.j,  2.-1.j]])
@@ -1261,7 +1261,7 @@ def eigh(a, UPLO='L'):
             [ 0.00000000+0.38268343j,  0.00000000-0.92387953j]])
 
     >>> # demonstrate the treatment of the imaginary part of the diagonal
-    >>> a = np.array([[5+2j, 9-2j], [0+2j, 2-1j]]) 
+    >>> a = np.array([[5+2j, 9-2j], [0+2j, 2-1j]])
     >>> a
     array([[ 5.+2.j,  9.-2.j],
            [ 0.+2.j,  2.-1.j]])
@@ -2357,14 +2357,13 @@ def multi_dot(arrays):
     >>> # or
     >>> A.dot(B).dot(C).dot(D)
 
-
-    Example: multiplication costs of different parenthesizations
-    ------------------------------------------------------------
-
+    Notes
+    -----
     The cost for a matrix multiplication can be calculated with the
     following function::
 
-        def cost(A, B): return A.shape[0] * A.shape[1] * B.shape[1]
+        def cost(A, B):
+            return A.shape[0] * A.shape[1] * B.shape[1]
 
     Let's assume we have three matrices
     :math:`A_{10x100}, B_{100x5}, C_{5x50}$`.


### PR DESCRIPTION
The PR links PyObject references in narrative documentation and also fixes "invalid section header" warning in "linalg.multi_dot" docstring.

It seems weird that `:c:type:'PyObject *'` can't be resolved as link while `:c:type:'PyObject'` works. 😕 Is there something wrong in the intersphinx?

(This time with `[ci skip]`)