### PR TITLE
DOC: Spell out note for `hstack`

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -265,7 +265,8 @@ def hstack(tup):
 
     Notes
     -----
-    Equivalent to ``np.concatenate(tup, axis=1)``
+    Equivalent to ``np.concatenate(tup, axis=1)`` if `tup` contains arrays that
+    are at least 2-dimensional.
 
     Examples
     --------


### PR DESCRIPTION
This adds to the documentation on `hstack` the note from `vstack` about the dimensionality requirement.