### PR TITLE
MAINT: Use AxisError in more places

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -6739,7 +6739,7 @@ add_newdoc('numpy.core.multiarray', 'busday_count',
 
 add_newdoc('numpy.core.multiarray', 'normalize_axis_index',
     """
-    normalize_axis_index(axis, ndim)
+    normalize_axis_index(axis, ndim, msg_prefix=None)
 
     Normalizes an axis index, `axis`, such that is a valid positive index into
     the shape of array with `ndim` dimensions. Raises an AxisError with an
@@ -6756,6 +6756,8 @@ add_newdoc('numpy.core.multiarray', 'normalize_axis_index',
     ndim : int
         The number of dimensions of the array that `axis` should be normalized
         against
+    msg_prefix : str
+        A prefix to put before the message, typically the name of the argument
 
     Returns
     -------
@@ -6780,6 +6782,10 @@ add_newdoc('numpy.core.multiarray', 'normalize_axis_index',
     Traceback (most recent call last):
     ...
     AxisError: axis 3 is out of bounds for array of dimension 3
+    >>> normalize_axis_index(-4, ndim=3, msg_prefix='axes_arg')
+    Traceback (most recent call last):
+    ...
+    AxisError: axes_arg: axis -4 is out of bounds for array of dimension 3
     """)
 
 ##############################################################################

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -631,4 +631,17 @@ class TooHardError(RuntimeError):
     pass
 
 class AxisError(ValueError, IndexError):
-    pass
+    """ Axis supplied was invalid. """
+    def __init__(self, axis, ndim=None, msg_prefix=None):
+        # single-argument form just delegates to base class
+        if ndim is None and msg_prefix is None:
+            msg = axis
+
+        # do the string formatting here, to save work in the C code
+        else:
+            msg = ("axis {} is out of bounds for array of dimension {}"
+                   .format(axis, ndim))
+            if msg_prefix is not None:
+                msg = "{}: {}".format(msg_prefix, msg)
+
+        super(AxisError, self).__init__(msg)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1752,11 +1752,9 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     a = asarray(a)
     b = asarray(b)
     # Check axisa and axisb are within bounds
-    axis_msg = "'axis{0}' out of bounds"
-    if axisa < -a.ndim or axisa >= a.ndim:
-        raise ValueError(axis_msg.format('a'))
-    if axisb < -b.ndim or axisb >= b.ndim:
-        raise ValueError(axis_msg.format('b'))
+    axisa = normalize_axis_index(axisa, a.ndim, msg_prefix='axisa')
+    axisb = normalize_axis_index(axisb, b.ndim, msg_prefix='axisb')
+
     # Move working axis to the end of the shape
     a = rollaxis(a, axisa, a.ndim)
     b = rollaxis(b, axisb, b.ndim)
@@ -1770,8 +1768,7 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     if a.shape[-1] == 3 or b.shape[-1] == 3:
         shape += (3,)
         # Check axisc is within bounds
-        if axisc < -len(shape) or axisc >= len(shape):
-            raise ValueError(axis_msg.format('c'))
+        axisc = normalize_axis_index(axisc, len(shape), msg_prefix='axisc')
     dtype = promote_types(a.dtype, b.dtype)
     cp = empty(shape, dtype)
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1460,16 +1460,14 @@ def roll(a, shift, axis=None):
         return roll(a.ravel(), shift, 0).reshape(a.shape)
 
     else:
+        axis = _validate_axis(axis, a.ndim, allow_duplicate=True)
         broadcasted = broadcast(shift, axis)
         if broadcasted.ndim > 1:
             raise ValueError(
                 "'shift' and 'axis' should be scalars or 1D sequences")
         shifts = {ax: 0 for ax in range(a.ndim)}
         for sh, ax in broadcasted:
-            if -a.ndim <= ax < a.ndim:
-                shifts[ax % a.ndim] += sh
-            else:
-                raise ValueError("'axis' entry is out of bounds")
+            shifts[ax] += sh
 
         rolls = [((slice(None), slice(None)),)] * a.ndim
         for ax, offset in shifts.items():
@@ -1544,13 +1542,13 @@ def rollaxis(a, axis, start=0):
     return a.transpose(axes)
 
 
-def _validate_axis(axis, ndim, argname=None):
+def _validate_axis(axis, ndim, argname=None, allow_duplicate=False):
     try:
         axis = [operator.index(axis)]
     except TypeError:
         axis = list(axis)
     axis = [normalize_axis_index(ax, ndim, argname) for ax in axis]
-    if len(set(axis)) != len(axis):
+    if not allow_duplicate and len(set(axis)) != len(axis):
         if argname:
             raise ValueError('repeated axis in `%s` argument' % argname)
         else:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -441,7 +441,7 @@ def count_nonzero(a, axis=None):
         nullstr = a.dtype.type('')
         return (a != nullstr).sum(axis=axis, dtype=np.intp)
 
-    axis = asarray(_validate_axis(axis, a.ndim, 'axis'))
+    axis = asarray(_validate_axis(axis, a.ndim))
     counts = np.apply_along_axis(multiarray.count_nonzero, axis[0], a)
 
     if axis.size == 1:
@@ -1544,17 +1544,17 @@ def rollaxis(a, axis, start=0):
     return a.transpose(axes)
 
 
-def _validate_axis(axis, ndim, argname):
+def _validate_axis(axis, ndim, argname=None):
     try:
         axis = [operator.index(axis)]
     except TypeError:
         axis = list(axis)
-    axis = [a + ndim if a < 0 else a for a in axis]
-    if not builtins.all(0 <= a < ndim for a in axis):
-        raise AxisError('invalid axis for this array in `%s` argument' %
-                         argname)
+    axis = [normalize_axis_index(ax, ndim, argname) for ax in axis]
     if len(set(axis)) != len(axis):
-        raise ValueError('repeated axis in `%s` argument' % argname)
+        if argname:
+            raise ValueError('repeated axis in `%s` argument' % argname)
+        else:
+            raise ValueError('repeated axis')
     return axis
 
 

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -138,9 +138,11 @@ check_and_adjust_index(npy_intp *index, npy_intp max_item, int axis,
  * Returns -1 and sets an exception if *axis is an invalid axis for
  * an array of dimension ndim, otherwise adjusts it in place to be
  * 0 <= *axis < ndim, and returns 0.
+ *
+ * msg_prefix: borrowed reference, a string to prepend to the message
  */
 static NPY_INLINE int
-check_and_adjust_axis(int *axis, int ndim)
+check_and_adjust_axis_msg(int *axis, int ndim, PyObject *msg_prefix)
 {
     /* Check that index is valid, taking into account negative indices */
     if (NPY_UNLIKELY((*axis < -ndim) || (*axis >= ndim))) {
@@ -149,6 +151,8 @@ check_and_adjust_axis(int *axis, int ndim)
          * we don't have access to npy_cache_import here
          */
         static PyObject *AxisError_cls = NULL;
+        PyObject *exc;
+
         if (AxisError_cls == NULL) {
             PyObject *mod = PyImport_ImportModule("numpy.core._internal");
 
@@ -158,9 +162,15 @@ check_and_adjust_axis(int *axis, int ndim)
             }
         }
 
-        PyErr_Format(AxisError_cls,
-                     "axis %d is out of bounds for array of dimension %d",
-                     *axis, ndim);
+        /* Invoke the AxisError constructor */
+        exc = PyObject_CallFunction(AxisError_cls, "iiO",
+                                    *axis, ndim, msg_prefix);
+        if (exc == NULL) {
+            return -1;
+        }
+        PyErr_SetObject(AxisError_cls, exc);
+        Py_DECREF(exc);
+
         return -1;
     }
     /* adjust negative indices */
@@ -168,6 +178,11 @@ check_and_adjust_axis(int *axis, int ndim)
         *axis += ndim;
     }
     return 0;
+}
+static NPY_INLINE int
+check_and_adjust_axis(int *axis, int ndim)
+{
+    return check_and_adjust_axis_msg(axis, ndim, Py_None);
 }
 
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4106,16 +4106,16 @@ array_may_share_memory(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *
 static PyObject *
 normalize_axis_index(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"axis", "ndim", NULL};
+    static char *kwlist[] = {"axis", "ndim", "msg_prefix", NULL};
     int axis;
     int ndim;
+    PyObject *msg_prefix = Py_None;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ii:normalize_axis_index",
-                                     kwlist, &axis, &ndim)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ii|O:normalize_axis_index",
+                                     kwlist, &axis, &ndim, &msg_prefix)) {
         return NULL;
     }
-
-    if(check_and_adjust_axis(&axis, ndim) < 0) {
+    if (check_and_adjust_axis_msg(&axis, ndim, msg_prefix) < 0) {
         return NULL;
     }
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2517,13 +2517,13 @@ class TestCross(TestCase):
         u = np.ones((10, 3, 5))
         v = np.ones((2, 5))
         assert_equal(np.cross(u, v, axisa=1, axisb=0).shape, (10, 5, 3))
-        assert_raises(ValueError, np.cross, u, v, axisa=1, axisb=2)
-        assert_raises(ValueError, np.cross, u, v, axisa=3, axisb=0)
+        assert_raises(np.AxisError, np.cross, u, v, axisa=1, axisb=2)
+        assert_raises(np.AxisError, np.cross, u, v, axisa=3, axisb=0)
         u = np.ones((10, 3, 5, 7))
         v = np.ones((5, 7, 2))
         assert_equal(np.cross(u, v, axisa=1, axisc=2).shape, (10, 5, 3, 7))
-        assert_raises(ValueError, np.cross, u, v, axisa=-5, axisb=2)
-        assert_raises(ValueError, np.cross, u, v, axisa=1, axisb=-4)
+        assert_raises(np.AxisError, np.cross, u, v, axisa=-5, axisb=2)
+        assert_raises(np.AxisError, np.cross, u, v, axisa=1, axisb=-4)
         # gh-5885
         u = np.ones((3, 4, 2))
         for axisc in range(-2, 2):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2425,11 +2425,11 @@ class TestMoveaxis(TestCase):
 
     def test_errors(self):
         x = np.random.randn(1, 2, 3)
-        assert_raises_regex(np.AxisError, 'invalid axis .* `source`',
+        assert_raises_regex(np.AxisError, 'source.*out of bounds',
                             np.moveaxis, x, 3, 0)
-        assert_raises_regex(np.AxisError, 'invalid axis .* `source`',
+        assert_raises_regex(np.AxisError, 'source.*out of bounds',
                             np.moveaxis, x, -4, 0)
-        assert_raises_regex(np.AxisError, 'invalid axis .* `destination`',
+        assert_raises_regex(np.AxisError, 'destination.*out of bounds',
                             np.moveaxis, x, 0, 5)
         assert_raises_regex(ValueError, 'repeated axis in `source`',
                             np.moveaxis, x, [0, 0], [0, 1])

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1679,21 +1679,10 @@ def gradient(f, *varargs, **kwargs):
     axes = kwargs.pop('axis', None)
     if axes is None:
         axes = tuple(range(N))
-    # check axes to have correct type and no duplicate entries
-    if isinstance(axes, int):
-        axes = (axes,)
-    if not isinstance(axes, tuple):
-        raise TypeError("A tuple of integers or a single integer is required")
-
-    # normalize axis values:
-    axes = tuple(x + N if x < 0 else x for x in axes)
-    if max(axes) >= N or min(axes) < 0:
-        raise ValueError("'axis' entry is out of bounds")
+    else:
+        axes = _nx._validate_axis(axes, N)
 
     len_axes = len(axes)
-    if len(set(axes)) != len_axes:
-        raise ValueError("duplicate value in 'axis'")
-
     n = len(varargs)
     if n == 0:
         dx = [1.0] * len_axes

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1680,7 +1680,7 @@ def gradient(f, *varargs, **kwargs):
     if axes is None:
         axes = tuple(range(N))
     else:
-        axes = _nx._validate_axis(axes, N)
+        axes = _nx.normalize_axis_tuple(axes, N)
 
     len_axes = len(axes)
     n = len(varargs)
@@ -3972,7 +3972,7 @@ def _ureduce(a, func, **kwargs):
     if axis is not None:
         keepdim = list(a.shape)
         nd = a.ndim
-        axis = _nx._validate_axis(axis, nd)
+        axis = _nx.normalize_axis_tuple(axis, nd)
 
         for ax in axis:
             keepdim[ax] = 1

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2973,11 +2973,14 @@ class TestPercentile(TestCase):
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
-        assert_raises(IndexError, np.percentile, d, axis=-5, q=25)
-        assert_raises(IndexError, np.percentile, d, axis=(0, -5), q=25)
-        assert_raises(IndexError, np.percentile, d, axis=4, q=25)
-        assert_raises(IndexError, np.percentile, d, axis=(0, 4), q=25)
+        assert_raises(np.AxisError, np.percentile, d, axis=-5, q=25)
+        assert_raises(np.AxisError, np.percentile, d, axis=(0, -5), q=25)
+        assert_raises(np.AxisError, np.percentile, d, axis=4, q=25)
+        assert_raises(np.AxisError, np.percentile, d, axis=(0, 4), q=25)
+        # each of these refers to the same axis twice
         assert_raises(ValueError, np.percentile, d, axis=(1, 1), q=25)
+        assert_raises(ValueError, np.percentile, d, axis=(-1, -1), q=25)
+        assert_raises(ValueError, np.percentile, d, axis=(3, -1), q=25)
 
     def test_keepdims(self):
         d = np.ones((3, 5, 7, 11))
@@ -3349,10 +3352,10 @@ class TestMedian(TestCase):
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
-        assert_raises(IndexError, np.median, d, axis=-5)
-        assert_raises(IndexError, np.median, d, axis=(0, -5))
-        assert_raises(IndexError, np.median, d, axis=4)
-        assert_raises(IndexError, np.median, d, axis=(0, 4))
+        assert_raises(np.AxisError, np.median, d, axis=-5)
+        assert_raises(np.AxisError, np.median, d, axis=(0, -5))
+        assert_raises(np.AxisError, np.median, d, axis=4)
+        assert_raises(np.AxisError, np.median, d, axis=(0, 4))
         assert_raises(ValueError, np.median, d, axis=(1, 1))
 
     def test_keepdims(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -902,9 +902,9 @@ class TestGradient(TestCase):
         # test maximal number of varargs
         assert_raises(TypeError, gradient, x, 1, 2, axis=1)
 
-        assert_raises(ValueError, gradient, x, axis=3)
-        assert_raises(ValueError, gradient, x, axis=-3)
-        assert_raises(TypeError, gradient, x, axis=[1,])
+        assert_raises(np.AxisError, gradient, x, axis=3)
+        assert_raises(np.AxisError, gradient, x, axis=-3)
+        # assert_raises(TypeError, gradient, x, axis=[1,])
         
     def test_timedelta64(self):
         # Make sure gradient() can handle special types like timedelta64

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -684,10 +684,10 @@ class TestNanFunctions_Median(TestCase):
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
-        assert_raises(IndexError, np.nanmedian, d, axis=-5)
-        assert_raises(IndexError, np.nanmedian, d, axis=(0, -5))
-        assert_raises(IndexError, np.nanmedian, d, axis=4)
-        assert_raises(IndexError, np.nanmedian, d, axis=(0, 4))
+        assert_raises(np.AxisError, np.nanmedian, d, axis=-5)
+        assert_raises(np.AxisError, np.nanmedian, d, axis=(0, -5))
+        assert_raises(np.AxisError, np.nanmedian, d, axis=4)
+        assert_raises(np.AxisError, np.nanmedian, d, axis=(0, 4))
         assert_raises(ValueError, np.nanmedian, d, axis=(1, 1))
 
     def test_float_special(self):
@@ -843,10 +843,10 @@ class TestNanFunctions_Percentile(TestCase):
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
-        assert_raises(IndexError, np.nanpercentile, d, q=5, axis=-5)
-        assert_raises(IndexError, np.nanpercentile, d, q=5, axis=(0, -5))
-        assert_raises(IndexError, np.nanpercentile, d, q=5, axis=4)
-        assert_raises(IndexError, np.nanpercentile, d, q=5, axis=(0, 4))
+        assert_raises(np.AxisError, np.nanpercentile, d, q=5, axis=-5)
+        assert_raises(np.AxisError, np.nanpercentile, d, q=5, axis=(0, -5))
+        assert_raises(np.AxisError, np.nanpercentile, d, q=5, axis=4)
+        assert_raises(np.AxisError, np.nanpercentile, d, q=5, axis=(0, 4))
         assert_raises(ValueError, np.nanpercentile, d, q=5, axis=(1, 1))
 
     def test_multiple_percentiles(self):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -43,6 +43,7 @@ from numpy.compat import (
     )
 from numpy import expand_dims as n_expand_dims
 from numpy.core.multiarray import normalize_axis_index
+from numpy.core.numeric import _validate_axis
 
 
 if sys.version_info[0] >= 3:
@@ -4369,10 +4370,7 @@ class MaskedArray(ndarray):
                     return np.array(self.size, dtype=np.intp, ndmin=self.ndim)
                 return self.size
 
-            axes = axis if isinstance(axis, tuple) else (axis,)
-            axes = tuple(normalize_axis_index(a, self.ndim) for a in axes)
-            if len(axes) != len(set(axes)):
-                raise ValueError("duplicate value in 'axis'")
+            axes = _validate_axis(axis, self.ndim)
             items = 1
             for ax in axes:
                 items *= self.shape[ax]

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4362,7 +4362,7 @@ class MaskedArray(ndarray):
 
             if self.shape is ():
                 if axis not in (None, 0):
-                    raise np.AxisError("'axis' entry is out of bounds")
+                    raise np.AxisError(axis=axis, ndim=self.ndim)
                 return 1
             elif axis is None:
                 if kwargs.get('keepdims', False):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -43,7 +43,7 @@ from numpy.compat import (
     )
 from numpy import expand_dims as n_expand_dims
 from numpy.core.multiarray import normalize_axis_index
-from numpy.core.numeric import _validate_axis
+from numpy.core.numeric import normalize_axis_tuple
 
 
 if sys.version_info[0] >= 3:
@@ -4370,7 +4370,7 @@ class MaskedArray(ndarray):
                     return np.array(self.size, dtype=np.intp, ndmin=self.ndim)
                 return self.size
 
-            axes = _validate_axis(axis, self.ndim)
+            axes = normalize_axis_tuple(axis, self.ndim)
             items = 1
             for ax in axes:
                 items *= self.shape[ax]

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -37,6 +37,7 @@ import numpy as np
 from numpy import ndarray, array as nxarray
 import numpy.core.umath as umath
 from numpy.core.multiarray import normalize_axis_index
+from numpy.core.numeric import _validate_axis
 from numpy.lib.function_base import _ureduce
 from numpy.lib.index_tricks import AxisConcatenator
 
@@ -816,18 +817,11 @@ def compress_nd(x, axis=None):
     x = asarray(x)
     m = getmask(x)
     # Set axis to tuple of ints
-    if isinstance(axis, int):
-        axis = (axis,)
-    elif axis is None:
+    if axis is None:
         axis = tuple(range(x.ndim))
-    elif not isinstance(axis, tuple):
-        raise ValueError('Invalid type for axis argument')
-    # Check axis input
-    axis = [ax + x.ndim if ax < 0 else ax for ax in axis]
-    if not all(0 <= ax < x.ndim for ax in axis):
-        raise ValueError("'axis' entry is out of bounds")
-    if len(axis) != len(set(axis)):
-        raise ValueError("duplicate value in 'axis'")
+    else:
+        axis = _validate_axis(axis, x.ndim)
+
     # Nothing is masked: return x
     if m is nomask or not m.any():
         return x._data

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -37,7 +37,7 @@ import numpy as np
 from numpy import ndarray, array as nxarray
 import numpy.core.umath as umath
 from numpy.core.multiarray import normalize_axis_index
-from numpy.core.numeric import _validate_axis
+from numpy.core.numeric import normalize_axis_tuple
 from numpy.lib.function_base import _ureduce
 from numpy.lib.index_tricks import AxisConcatenator
 
@@ -820,7 +820,7 @@ def compress_nd(x, axis=None):
     if axis is None:
         axis = tuple(range(x.ndim))
     else:
-        axis = _validate_axis(axis, x.ndim)
+        axis = normalize_axis_tuple(axis, x.ndim)
 
     # Nothing is masked: return x
     if m is nomask or not m.any():

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -732,7 +732,7 @@ class TestMedian(TestCase):
                 for axis, over in args:
                     try:
                         np.ma.median(x, axis=axis, overwrite_input=over)
-                    except IndexError:
+                    except np.AxisError:
                         pass
                     else:
                         raise AssertionError(msg % (mask, ndmin, axis, over))


### PR DESCRIPTION
Behavioural changes:

* Lots of code throws `AxisError` instead of `IndexError` or `ValueError` - but this is backwards-compatible, since `AxisError` derives from both (#8584)
* `_ureduce` detects duplicate arguments correctly - previously, `np.median([1, 2], axis=(0,0))` would fail, but `np.median([1, 2], axis=(-1,-1))` and `np.median([1, 2], axis=(0,-1))` would be fine. Now all three raise `ValueError`.
* `np.gradient` now accepts `axis=[1,2]` as well as `axis=(1,2)`. This might not be desirable, but is consistent with the majority of other functions. Now that this all goes through one place, we could deprecate it in future.
* `np.core.numeric._validate_axis` is slightly more public at `np.core.numeric.normalize_axis_tuple`, to complement `np.core.multiarray.normalize_axis_index`
* Functions taking a single axis argument now all call `operator.index`, rather than just a random subset of them.