### PR TITLE
DOC: Spell out note for `dstack`

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -367,7 +367,8 @@ def dstack(tup):
 
     Notes
     -----
-    Equivalent to ``np.concatenate(tup, axis=2)``.
+    Equivalent to ``np.concatenate(tup, axis=2)`` if `tup` contains arrays that
+    are at least 3-dimensional.
 
     Examples
     --------


### PR DESCRIPTION
Following up on #8837, this adds to the documentation on `dstack` the notes from `hstack` and `vstack` about dimensionality requirements.