### PR TITLE
BUG: Prevent power(uint64, int64) casting to float

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -356,7 +356,27 @@ offset into the file. This is a behaviour change only for offsets
 greater than ``mmap.ALLOCATIONGRANULARITY``.
 
 ``np.real`` and ``np.imag`` return scalars for scalar inputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------------
 Previously, ``np.real`` and ``np.imag`` used to return array objects when
 provided a scalar input, which was inconsistent with other functions like
 ``np.angle`` and ``np.conj``.
+
+``np.power`` does not upcast integer types of the same size but different sign
+------------------------------------------------------------------------------
+Previously, ``np.power(uint, int)``, for some sized integer type would return a
+larger type than either ``uint`` or ``int``. This caused undesirable decaying
+to a ``float64`` when working with ``uint64`` and ``int64``.
+
+A consequence of this is that some overflows are more likely to occur
+.. code::
+
+   >>> u8 = np.uint8
+   >>> s8 = np.int8
+   >>> np.power(s8(2), s8(7))
+   -128  # same as before
+   >>> np.power(u8(2), u8(7))
+   128  # same as before
+   >>> np.power(s8(2), u8(7))
+   -128  # now int8, previously int16 and did not overflow
+   >>> np.power(u8(2), s8(7))
+   128   # now uint8, previously int16

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -366,7 +366,10 @@ defdict = {
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.power'),
           None,
-          TD(ints),
+          [TypeDescription(i, FullTypeDescr, i+i2, i)
+           for i in ints
+           for i2 in [i.lower(), i.upper()]
+          ],
           TD(inexact, f='pow', astype={'e':'f'}),
           TD(O, f='npy_ObjectPower'),
           ),

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -952,45 +952,6 @@ NPY_NO_EXPORT void
     }
 }
 
-NPY_NO_EXPORT void
-@TYPE@_power(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    BINARY_LOOP {
-        @type@ in1 = *(@type@ *)ip1;
-        @type@ in2 = *(@type@ *)ip2;
-        @type@ out;
-
-#if @SIGNED@
-        if (in2 < 0) {
-            NPY_ALLOW_C_API_DEF
-            NPY_ALLOW_C_API;
-            PyErr_SetString(PyExc_ValueError,
-                    "Integers to negative integer powers are not allowed.");
-            NPY_DISABLE_C_API;
-            return;
-        }
-#endif
-        if (in2 == 0) {
-            *((@type@ *)op1) = 1;
-            continue;
-        }
-        if (in1 == 1) {
-            *((@type@ *)op1) = 1;
-            continue;
-        }
-
-        out = in2 & 1 ? in1 : 1;
-        in2 >>= 1;
-        while (in2 > 0) {
-            in1 *= in1;
-            if (in2 & 1) {
-                out *= in1;
-            }
-            in2 >>= 1;
-        }
-        *((@type@ *) op1) = out;
-    }
-}
 
 NPY_NO_EXPORT void
 @TYPE@_fmod(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
@@ -1131,6 +1092,61 @@ NPY_NO_EXPORT void
     }
 }
 
+/**end repeat**/
+
+
+/**begin repeat
+ * #TYPE  = ( BYTE,  SHORT,  INT,  LONG,  LONGLONG,
+ *           UBYTE, USHORT, UINT, ULONG, ULONGLONG)*2#
+ * #C     = (b,h,i,l,q,
+ *           B,H,I,L,Q)*2#
+ * #C2    = (b,h,i,l,q)*2,
+ *          (B,H,I,L,Q)*2#
+ * #type  = (npy_byte , npy_short , npy_int , npy_long , npy_longlong,
+ *           npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong)*2#
+ * #type2 = (npy_byte , npy_short , npy_int , npy_long , npy_longlong )*2,
+ *          (npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong)*2#
+ * #SIGNED2 = 1*10,10*10#
+ */
+NPY_NO_EXPORT void
+@TYPE@_@C@@C2@_@C@_power(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    BINARY_LOOP {
+        @type@ in1 = *(@type@ *)ip1;
+        @type2@ in2 = *(@type2@ *)ip2;
+        @type@ out;
+
+#if @SIGNED2@
+        if (in2 < 0) {
+            NPY_ALLOW_C_API_DEF
+            NPY_ALLOW_C_API;
+            PyErr_SetString(PyExc_ValueError,
+                    "Integers to negative integer powers are not allowed.");
+            NPY_DISABLE_C_API;
+            return;
+        }
+#endif
+        if (in2 == 0) {
+            *((@type@ *)op1) = 1;
+            continue;
+        }
+        if (in1 == 1) {
+            *((@type@ *)op1) = 1;
+            continue;
+        }
+
+        out = in2 & 1 ? in1 : 1;
+        in2 >>= 1;
+        while (in2 > 0) {
+            in1 *= in1;
+            if (in2 & 1) {
+                out *= in1;
+            }
+            in2 >>= 1;
+        }
+        *((@type@ *) op1) = out;
+    }
+}
 /**end repeat**/
 
 /*

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -152,6 +152,23 @@ NPY_NO_EXPORT void
 U@TYPE@_remainder(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 /**end repeat**/
 
+/**begin repeat
+ * #TYPE  = ( BYTE,  SHORT,  INT,  LONG,  LONGLONG,
+ *           UBYTE, USHORT, UINT, ULONG, ULONGLONG)*2#
+ * #C     = (b,h,i,l,q,
+ *           B,H,I,L,Q)*2#
+ * #C2    = (b,h,i,l,q)*2,
+ *          (B,H,I,L,Q)*2#
+ * #type  = (npy_byte , npy_short , npy_int , npy_long , npy_longlong,
+ *           npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong)*2#
+ * #type2 = (npy_byte , npy_short , npy_int , npy_long , npy_longlong )*2,
+ *          (npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong)*2#
+ * #SIGNED2 = 0*10,1*10#
+ */
+NPY_NO_EXPORT void
+@TYPE@_@C@@C2@_@C@_power(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+/**end repeat**/
+
 /*
  *****************************************************************************
  **                             FLOAT LOOPS                                 **

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -134,32 +134,17 @@ class TestPower(TestCase):
         # 1 ** -1 possible special case
         base = [np.array(1, dt)[()] for dt in 'bhilqBHILQ']
         for i1, i2 in itertools.product(base, exp):
-            if i1.dtype.name != 'uint64':
-                assert_raises(ValueError, operator.pow, i1, i2)
-            else:
-                res = operator.pow(i1, i2)
-                assert_(res.dtype.type is np.float64)
-                assert_almost_equal(res, 1.)
+            assert_raises(ValueError, operator.pow, i1, i2)
 
         # -1 ** -1 possible special case
         base = [np.array(-1, dt)[()] for dt in 'bhilq']
         for i1, i2 in itertools.product(base, exp):
-            if i1.dtype.name != 'uint64':
-                assert_raises(ValueError, operator.pow, i1, i2)
-            else:
-                res = operator.pow(i1, i2)
-                assert_(res.dtype.type is np.float64)
-                assert_almost_equal(res, -1.)
+            assert_raises(ValueError, operator.pow, i1, i2)
 
         # 2 ** -1 perhaps generic
         base = [np.array(2, dt)[()] for dt in 'bhilqBHILQ']
         for i1, i2 in itertools.product(base, exp):
-            if i1.dtype.name != 'uint64':
-                assert_raises(ValueError, operator.pow, i1, i2)
-            else:
-                res = operator.pow(i1, i2)
-                assert_(res.dtype.type is np.float64)
-                assert_almost_equal(res, .5)
+            assert_raises(ValueError, operator.pow, i1, i2)
 
     def test_mixed_types(self):
         typelist = [np.int8, np.int16, np.float16,

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -502,6 +502,33 @@ class TestPower(TestCase):
             assert_raises(ValueError, np.power, one, b)
             assert_raises(ValueError, np.power, one, minusone)
 
+    def test_power_mixedsign(self):
+        """
+        When given a signed and unsigned integer of the same size, the
+        result match the type of the first argument
+        """
+        inttypes = [
+            (np.int8, np.uint8),
+            (np.int16, np.uint16),
+            (np.int32, np.uint32),
+            (np.int64, np.uint64)
+        ]
+        for stype, utype in inttypes:
+            av = stype(6)
+            bv = utype(2)
+
+            for conv in [lambda x: x, np.array, lambda x: np.array([x])]:
+                a = conv(av)
+                b = conv(bv)
+
+                apb = np.power(a, b)
+                assert_equal(apb.dtype, a.dtype)
+                assert_equal(apb, 36)
+
+                bpa = np.power(b, a)
+                assert_equal(bpa.dtype, b.dtype)
+                assert_equal(bpa, 64)
+
 
 class TestFloat_power(TestCase):
     def test_type_conversion(self):


### PR DESCRIPTION
Partials resolves #8809

Previously, the signatures were:
* `power(int, int) -> int`
* `power(uint, uint) -> uint`

So when we pass a mixture of `int` and `uint`, we find a common type `t = common(int, uint)`, and invoke `power(t, t) -> t`. 
This is bad, because `common(int64, uint64)` is `float64`

This PR defines:
* `power(int, uint) -> int`
   same as `power(int, int)`, without an error check
* `power(uint, int) -> uint`:
  same as `power(uint, uint)`, with an error check

Obviously, there is a cost associated with reducing the size of the output type - overflows happen sooner.

But what we have right now is inconsistent - from a mathematical perspective `power(uint, int)` has a strictly _smaller_ range of values that can be produced than `power(uint, uint)` - so why do we allocate a _larger_ output type for it?
