### PR TITLE
DOC: remove empty jargon reference in glossary

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -5,8 +5,3 @@ Glossary
 .. toctree::
 
 .. automodule:: numpy.doc.glossary
-
-Jargon
-------
-
-.. automodule:: numpy.doc.jargon


### PR DESCRIPTION
The referenced module "numpy.doc.jargon" does not exist anymore.

The linked module was removed in https://github.com/numpy/numpy/commit/9d63530e0b7d0a880a0f49713c48ef6f0c11b315. This PR should take care of the trailing (empty) headline in https://docs.scipy.org/doc/numpy-dev/glossary.html#jargon.