### PR TITLE
MAINT: Include the function name in all argument error messages

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1620,7 +1620,7 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
      * strides, and swapped info For now, let's just use this to create an
      * empty, contiguous array of a specific type and shape.
      */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&LO&O&",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&LO&O&:ndarray",
                                      kwlist, PyArray_IntpConverter,
                                      &dims,
                                      PyArray_DescrConverter,

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -101,7 +101,7 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     double *weights , *dans;
     static char *kwlist[] = {"list", "weights", "minlength", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO:bincount",
                 kwlist, &list, &weight, &mlength)) {
             goto fail;
     }
@@ -217,7 +217,7 @@ arr_digitize(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
 
     static char *kwlist[] = {"x", "bins", "right", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i:digitize", kwlist,
                                      &obj_x, &obj_bins, &right)) {
         goto fail;
     }
@@ -533,7 +533,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
     NPY_BEGIN_THREADS_DEF;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "OOO|OO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "OOO|OO:interp", kwlist,
                                      &x, &xp, &fp, &left, &right)) {
         return NULL;
     }
@@ -686,8 +686,8 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
     NPY_BEGIN_THREADS_DEF;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "OOO|OO", kwlist,
-                                     &x, &xp, &fp, &left, &right)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "OOO|OO:interp_complex",
+                                     kwlist, &x, &xp, &fp, &left, &right)) {
         return NULL;
     }
 
@@ -1409,13 +1409,13 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
 
 #if defined(NPY_PY3K)
-    if (!PyArg_ParseTuple(args, "OO!", &obj, &PyUnicode_Type, &str)) {
+    if (!PyArg_ParseTuple(args, "OO!:add_docstring", &obj, &PyUnicode_Type, &str)) {
         return NULL;
     }
 
     docstr = PyBytes_AS_STRING(PyUnicode_AsUTF8String(str));
 #else
-    if (!PyArg_ParseTuple(args, "OO!", &obj, &PyString_Type, &str)) {
+    if (!PyArg_ParseTuple(args, "OO!:add_docstring", &obj, &PyString_Type, &str)) {
         return NULL;
     }
 
@@ -1805,7 +1805,7 @@ io_pack(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     int axis = NPY_MAXDIMS;
     static char *kwlist[] = {"in", "axis", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords( args, kwds, "O|O&" , kwlist,
+    if (!PyArg_ParseTupleAndKeywords( args, kwds, "O|O&:pack" , kwlist,
                 &obj, PyArray_AxisConverter, &axis)) {
         return NULL;
     }
@@ -1819,7 +1819,7 @@ io_unpack(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     int axis = NPY_MAXDIMS;
     static char *kwlist[] = {"in", "axis", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords( args, kwds, "O|O&" , kwlist,
+    if (!PyArg_ParseTupleAndKeywords( args, kwds, "O|O&:unpack" , kwlist,
                 &obj, PyArray_AxisConverter, &axis)) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -152,7 +152,7 @@ array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args)
 {
     PyObject *dict;
 
-    if (!PyArg_ParseTuple(args, "O", &dict)) {
+    if (!PyArg_ParseTuple(args, "O:set_typeDict", &dict)) {
         return NULL;
     }
     /* Decrement old reference (if any)*/
@@ -2267,7 +2267,7 @@ arraydescr_new(PyTypeObject *NPY_UNUSED(subtype),
 
     static char *kwlist[] = {"dtype", "align", "copy", "metadata", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O!:dtype", kwlist,
                 &odescr,
                 PyArray_BoolConverter, &align,
                 PyArray_BoolConverter, &copy,
@@ -2566,7 +2566,8 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
     }
     switch (PyTuple_GET_SIZE(PyTuple_GET_ITEM(args,0))) {
     case 9:
-        if (!PyArg_ParseTuple(args, "(iOOOOiiiO)", &version, &endian_obj,
+        if (!PyArg_ParseTuple(args, "(iOOOOiiiO):__setstate__",
+                    &version, &endian_obj,
                     &subarray, &names, &fields, &elsize,
                     &alignment, &int_dtypeflags, &metadata)) {
             PyErr_Clear();
@@ -2574,21 +2575,24 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
         }
         break;
     case 8:
-        if (!PyArg_ParseTuple(args, "(iOOOOiii)", &version, &endian_obj,
+        if (!PyArg_ParseTuple(args, "(iOOOOiii):__setstate__",
+                    &version, &endian_obj,
                     &subarray, &names, &fields, &elsize,
                     &alignment, &int_dtypeflags)) {
             return NULL;
         }
         break;
     case 7:
-        if (!PyArg_ParseTuple(args, "(iOOOOii)", &version, &endian_obj,
+        if (!PyArg_ParseTuple(args, "(iOOOOii):__setstate__",
+                    &version, &endian_obj,
                     &subarray, &names, &fields, &elsize,
                     &alignment)) {
             return NULL;
         }
         break;
     case 6:
-        if (!PyArg_ParseTuple(args, "(iOOOii)", &version,
+        if (!PyArg_ParseTuple(args, "(iOOOii):__setstate__",
+                    &version,
                     &endian_obj, &subarray, &fields,
                     &elsize, &alignment)) {
             return NULL;
@@ -2596,7 +2600,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
         break;
     case 5:
         version = 0;
-        if (!PyArg_ParseTuple(args, "(OOOii)",
+        if (!PyArg_ParseTuple(args, "(OOOii):__setstate__",
                     &endian_obj, &subarray, &fields, &elsize,
                     &alignment)) {
             return NULL;
@@ -3082,7 +3086,7 @@ arraydescr_newbyteorder(PyArray_Descr *self, PyObject *args)
 {
     char endian=NPY_SWAP;
 
-    if (!PyArg_ParseTuple(args, "|O&", PyArray_ByteorderConverter,
+    if (!PyArg_ParseTuple(args, "|O&:newbyteorder", PyArray_ByteorderConverter,
                 &endian)) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -129,7 +129,7 @@ array_take(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_CLIPMODE mode = NPY_RAISE;
     static char *kwlist[] = {"indices", "axis", "out", "mode", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O&:take", kwlist,
                                      &indices,
                                      PyArray_AxisConverter, &dimension,
                                      PyArray_OutputConverter, &out,
@@ -144,7 +144,7 @@ static PyObject *
 array_fill(PyArrayObject *self, PyObject *args)
 {
     PyObject *obj;
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
+    if (!PyArg_ParseTuple(args, "O:fill", &obj)) {
         return NULL;
     }
     if (PyArray_FillWithScalar(self, obj) < 0) {
@@ -160,7 +160,7 @@ array_put(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_CLIPMODE mode = NPY_RAISE;
     static char *kwlist[] = {"indices", "values", "mode", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O&:put", kwlist,
                                      &indices,
                                      &values,
                                      PyArray_ClipmodeConverter, &mode))
@@ -186,7 +186,7 @@ array_reshape(PyArrayObject *self, PyObject *args, PyObject *kwds)
         if (PyTuple_GET_ITEM(args, 0) == Py_None) {
             return PyArray_View(self, NULL, NULL);
         }
-        if (!PyArg_ParseTuple(args, "O&", PyArray_IntpConverter,
+        if (!PyArg_ParseTuple(args, "O&:reshape", PyArray_IntpConverter,
                               &newshape)) {
             return NULL;
         }
@@ -216,7 +216,7 @@ array_squeeze(PyArrayObject *self, PyObject *args, PyObject *kwds)
     npy_bool axis_flags[NPY_MAXDIMS];
 
     static char *kwlist[] = {"axis", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:squeeze", kwlist,
                                      &axis_in)) {
         return NULL;
     }
@@ -242,7 +242,7 @@ array_view(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArray_Descr *dtype = NULL;
 
     static char *kwlist[] = {"dtype", "type", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:view", kwlist,
                                      &out_dtype,
                                      &out_type)) {
         return NULL;
@@ -288,7 +288,7 @@ array_argmax(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *out = NULL;
     static char *kwlist[] = {"axis", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&:argmax", kwlist,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_OutputConverter, &out))
         return NULL;
@@ -303,7 +303,7 @@ array_argmin(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *out = NULL;
     static char *kwlist[] = {"axis", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&:argmin", kwlist,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_OutputConverter, &out))
         return NULL;
@@ -330,7 +330,7 @@ array_ptp(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *out = NULL;
     static char *kwlist[] = {"axis", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&:ptp", kwlist,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_OutputConverter, &out))
         return NULL;
@@ -344,7 +344,7 @@ array_swapaxes(PyArrayObject *self, PyObject *args)
 {
     int axis1, axis2;
 
-    if (!PyArg_ParseTuple(args, "ii", &axis1, &axis2)) {
+    if (!PyArg_ParseTuple(args, "ii:swapaxes", &axis1, &axis2)) {
         return NULL;
     }
     return PyArray_SwapAxes(self, axis1, axis2);
@@ -407,7 +407,7 @@ array_getfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
     int offset = 0;
     static char *kwlist[] = {"dtype", "offset", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|i:getfield", kwlist,
                                      PyArray_DescrConverter, &dtype,
                                      &offset)) {
         Py_XDECREF(dtype);
@@ -452,7 +452,7 @@ array_setfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyObject *value;
     static char *kwlist[] = {"value", "dtype", "offset", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|i:setfield", kwlist,
                                      &value,
                                      PyArray_DescrConverter, &dtype,
                                      &offset)) {
@@ -521,7 +521,7 @@ array_byteswap(PyArrayObject *self, PyObject *args)
 {
     npy_bool inplace = NPY_FALSE;
 
-    if (!PyArg_ParseTuple(args, "|O&",
+    if (!PyArg_ParseTuple(args, "|O&:byteswap",
                             PyArray_BoolConverter, &inplace)) {
         return NULL;
     }
@@ -544,7 +544,7 @@ array_tobytes(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_ORDER order = NPY_CORDER;
     static char *kwlist[] = {"order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:tobytes", kwlist,
                                      PyArray_OrderConverter, &order)) {
         return NULL;
     }
@@ -566,7 +566,7 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     npy_off_t orig_pos;
     static char *kwlist[] = {"file", "sep", "format", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ss", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ss:tofile", kwlist,
                                      &file,
                                      &sep,
                                      &format)) {
@@ -787,7 +787,7 @@ array_astype(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_ORDER order = NPY_KEEPORDER;
     int forcecopy = 1, subok = 1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&ii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&ii:astype", kwlist,
                             PyArray_DescrConverter, &dtype,
                             PyArray_OrderConverter, &order,
                             PyArray_CastingConverter, &casting,
@@ -962,7 +962,7 @@ array_getarray(PyArrayObject *self, PyObject *args)
     PyArray_Descr *newtype = NULL;
     PyObject *ret;
 
-    if (!PyArg_ParseTuple(args, "|O&",
+    if (!PyArg_ParseTuple(args, "|O&:__array__",
                             PyArray_DescrConverter, &newtype)) {
         Py_XDECREF(newtype);
         return NULL;
@@ -1013,7 +1013,7 @@ array_copy(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_ORDER order = NPY_CORDER;
     static char *kwlist[] = {"order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:copy", kwlist,
                                      PyArray_OrderConverter, &order)) {
         return NULL;
     }
@@ -1025,7 +1025,7 @@ array_copy(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_copy_keeporder(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    if (!PyArg_ParseTuple(args, "")) {
+    if (!PyArg_ParseTuple(args, ":__copy__")) {
         return NULL;
     }
     return PyArray_NewCopy(self, NPY_KEEPORDER);
@@ -1078,7 +1078,7 @@ array_repeat(PyArrayObject *self, PyObject *args, PyObject *kwds) {
     int axis = NPY_MAXDIMS;
     static char *kwlist[] = {"repeats", "axis", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&:repeat", kwlist,
                                      &repeats,
                                      PyArray_AxisConverter, &axis)) {
         return NULL;
@@ -1096,7 +1096,7 @@ array_choose(PyArrayObject *self, PyObject *args, PyObject *kwds)
     Py_ssize_t n = PyTuple_Size(args);
 
     if (n <= 1) {
-        if (!PyArg_ParseTuple(args, "O", &choices)) {
+        if (!PyArg_ParseTuple(args, "O:choose", &choices)) {
             return NULL;
         }
     }
@@ -1124,7 +1124,7 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArray_Descr *newd;
     static char *kwlist[] = {"axis", "kind", "order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&O:sort", kwlist,
                                     &axis,
                                     PyArray_SortkindConverter, &sortkind,
                                     &order)) {
@@ -1183,7 +1183,7 @@ array_partition(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyObject * kthobj;
 
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iO&O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iO&O:partition", kwlist,
                                      &kthobj,
                                      &axis,
                                      PyArray_SelectkindConverter, &sortkind,
@@ -1246,7 +1246,7 @@ array_argsort(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArray_Descr *newd, *saved=NULL;
     static char *kwlist[] = {"axis", "kind", "order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O:argsort", kwlist,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_SortkindConverter, &sortkind,
                                      &order)) {
@@ -1299,7 +1299,7 @@ array_argpartition(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyObject * kthobj;
     PyArrayObject * ktharray;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&O:argpartition", kwlist,
                                      &kthobj,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_SelectkindConverter, &sortkind,
@@ -1421,7 +1421,7 @@ array_deepcopy(PyArrayObject *self, PyObject *args)
     npy_intp stride, count;
     PyObject *copy, *deepcopy;
 
-    if (!PyArg_ParseTuple(args, "O", &visit)) {
+    if (!PyArg_ParseTuple(args, "O:__deepcopy__", &visit)) {
         return NULL;
     }
     copied_array = (PyArrayObject*) PyArray_NewCopy(self, NPY_KEEPORDER);
@@ -1630,7 +1630,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
     /* This will free any memory associated with a and
        use the string in setstate as the (writeable) memory.
     */
-    if (!PyArg_ParseTuple(args, "(iO!O!iO)",
+    if (!PyArg_ParseTuple(args, "(iO!O!iO):__setstate__",
                             &version,
                             &PyTuple_Type, &shape,
                             &PyArrayDescr_Type, &typecode,
@@ -1638,7 +1638,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
                             &rawdata)) {
         PyErr_Clear();
         version = 0;
-        if (!PyArg_ParseTuple(args, "(O!O!iO)",
+        if (!PyArg_ParseTuple(args, "(O!O!iO):__setstate__",
                             &PyTuple_Type, &shape,
                             &PyArrayDescr_Type, &typecode,
                             &is_f_order,
@@ -1898,7 +1898,7 @@ array_dump(PyArrayObject *self, PyObject *args)
     PyObject *file = NULL;
     int ret;
 
-    if (!PyArg_ParseTuple(args, "O", &file)) {
+    if (!PyArg_ParseTuple(args, "O:dump", &file)) {
         return NULL;
     }
     ret = PyArray_Dump((PyObject *)self, file, 2);
@@ -1985,7 +1985,7 @@ array_cumsum(PyArrayObject *self, PyObject *args, PyObject *kwds)
     int rtype;
     static char *kwlist[] = {"axis", "dtype", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O&:cumsum", kwlist,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_DescrConverter2, &dtype,
                                      PyArray_OutputConverter, &out)) {
@@ -2013,7 +2013,7 @@ array_cumprod(PyArrayObject *self, PyObject *args, PyObject *kwds)
     int rtype;
     static char *kwlist[] = {"axis", "dtype", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O&:cumprod", kwlist,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_DescrConverter2, &dtype,
                                      PyArray_OutputConverter, &out)) {
@@ -2039,7 +2039,7 @@ array_dot(PyArrayObject *self, PyObject *args, PyObject *kwds)
     char* kwlist[] = {"b", "out", NULL };
 
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kwlist, &b, &o)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:dot", kwlist, &b, &o)) {
         return NULL;
     }
 
@@ -2112,7 +2112,7 @@ array_compress(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *out = NULL;
     static char *kwlist[] = {"condition", "axis", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&:compress", kwlist,
                                      &condition,
                                      PyArray_AxisConverter, &axis,
                                      PyArray_OutputConverter, &out)) {
@@ -2142,7 +2142,7 @@ array_trace(PyArrayObject *self, PyObject *args, PyObject *kwds)
     int rtype;
     static char *kwlist[] = {"offset", "axis1", "axis2", "dtype", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iiiO&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iiiO&O&:trace", kwlist,
                                      &offset,
                                      &axis1,
                                      &axis2,
@@ -2167,7 +2167,7 @@ array_clip(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *out = NULL;
     static char *kwlist[] = {"min", "max", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOO&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOO&:clip", kwlist,
                                      &min,
                                      &max,
                                      PyArray_OutputConverter, &out)) {
@@ -2186,7 +2186,7 @@ array_conjugate(PyArrayObject *self, PyObject *args)
 {
 
     PyArrayObject *out = NULL;
-    if (!PyArg_ParseTuple(args, "|O&",
+    if (!PyArg_ParseTuple(args, "|O&:conjugate",
                           PyArray_OutputConverter,
                           &out)) {
         return NULL;
@@ -2202,7 +2202,7 @@ array_diagonal(PyArrayObject *self, PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"offset", "axis1", "axis2", NULL};
     PyArrayObject *ret;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iii:diagonal", kwlist,
                                      &offset,
                                      &axis1,
                                      &axis2)) {
@@ -2220,7 +2220,7 @@ array_flatten(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_ORDER order = NPY_CORDER;
     static char *kwlist[] = {"order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:flatten", kwlist,
                             PyArray_OrderConverter, &order)) {
         return NULL;
     }
@@ -2234,7 +2234,7 @@ array_ravel(PyArrayObject *self, PyObject *args, PyObject *kwds)
     NPY_ORDER order = NPY_CORDER;
     static char *kwlist[] = {"order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:ravel", kwlist,
                             PyArray_OrderConverter, &order)) {
         return NULL;
     }
@@ -2249,7 +2249,7 @@ array_round(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *out = NULL;
     static char *kwlist[] = {"decimals", "out", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&:round", kwlist,
                                      &decimals,
                                      PyArray_OutputConverter, &out)) {
         return NULL;
@@ -2270,7 +2270,7 @@ array_setflags(PyArrayObject *self, PyObject *args, PyObject *kwds)
 
     PyArrayObject_fields *fa = (PyArrayObject_fields *)self;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOO:setflags", kwlist,
                                      &write_flag,
                                      &align_flag,
                                      &uic))
@@ -2335,7 +2335,7 @@ array_newbyteorder(PyArrayObject *self, PyObject *args)
     char endian = NPY_SWAP;
     PyArray_Descr *new;
 
-    if (!PyArg_ParseTuple(args, "|O&", PyArray_ByteorderConverter,
+    if (!PyArg_ParseTuple(args, "|O&:newbyteorder", PyArray_ByteorderConverter,
                           &endian)) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1678,7 +1678,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
     }
 
 full_path:
-    if(!PyArg_ParseTupleAndKeywords(args, kws, "O|O&O&O&O&i", kwd,
+    if(!PyArg_ParseTupleAndKeywords(args, kws, "O|O&O&O&O&i:array", kwd,
                 &op,
                 PyArray_DescrConverter2, &type,
                 PyArray_BoolConverter, &copy,
@@ -1781,7 +1781,7 @@ array_copyto(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     PyArrayObject *dst = NULL, *src = NULL, *wheremask = NULL;
     NPY_CASTING casting = NPY_SAME_KIND_CASTING;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O&|O&O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O&|O&O:copyto", kwlist,
                 &PyArray_Type, &dst,
                 &PyArray_Converter, &src,
                 &PyArray_CastingConverter, &casting,
@@ -1828,7 +1828,7 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     npy_bool is_f_order;
     PyArrayObject *ret = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&:empty", kwlist,
                 PyArray_IntpConverter, &shape,
                 PyArray_DescrConverter, &typecode,
                 PyArray_OrderConverter, &order)) {
@@ -1871,7 +1871,7 @@ array_empty_like(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     PyArrayObject *ret = NULL;
     int subok = 1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&i:empty_like", kwlist,
                 &PyArray_Converter, &prototype,
                 &PyArray_DescrConverter2, &dtype,
                 &PyArray_OrderConverter, &order,
@@ -1907,7 +1907,7 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     PyObject *ret;
 
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|O:scalar", kwlist,
                 &PyArrayDescr_Type, &typecode, &obj)) {
         return NULL;
     }
@@ -1982,7 +1982,7 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     npy_bool is_f_order = NPY_FALSE;
     PyArrayObject *ret = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&:zeros", kwlist,
                 PyArray_IntpConverter, &shape,
                 PyArray_DescrConverter, &typecode,
                 PyArray_OrderConverter, &order)) {
@@ -2020,7 +2020,7 @@ array_count_nonzero(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     PyArrayObject *array;
     npy_intp count;
 
-    if (!PyArg_ParseTuple(args, "O&", PyArray_Converter, &array)) {
+    if (!PyArg_ParseTuple(args, "O&:count_nonzero", PyArray_Converter, &array)) {
         return NULL;
     }
 
@@ -2049,7 +2049,7 @@ array_fromstring(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds
     PyArray_Descr *descr = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,
-                "s#|O&" NPY_SSIZE_T_PYFMT "s", kwlist,
+                "s#|O&" NPY_SSIZE_T_PYFMT "s:fromstring", kwlist,
                 &data, &s, PyArray_DescrConverter, &descr, &nin, &sep)) {
         Py_XDECREF(descr);
         return NULL;
@@ -2072,7 +2072,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     FILE *fp;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,
-                "O|O&" NPY_SSIZE_T_PYFMT "s", kwlist,
+                "O|O&" NPY_SSIZE_T_PYFMT "s:fromfile", kwlist,
                 &file, PyArray_DescrConverter, &type, &nin, &sep)) {
         Py_XDECREF(type);
         return NULL;
@@ -2122,7 +2122,7 @@ array_fromiter(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     PyArray_Descr *descr = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,
-                "OO&|" NPY_SSIZE_T_PYFMT, kwlist,
+                "OO&|" NPY_SSIZE_T_PYFMT ":fromiter", kwlist,
                 &iter, PyArray_DescrConverter, &descr, &nin)) {
         Py_XDECREF(descr);
         return NULL;
@@ -2139,7 +2139,7 @@ array_frombuffer(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds
     PyArray_Descr *type = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds,
-                "O|O&" NPY_SSIZE_T_PYFMT NPY_SSIZE_T_PYFMT, kwlist,
+                "O|O&" NPY_SSIZE_T_PYFMT NPY_SSIZE_T_PYFMT ":frombuffer", kwlist,
                 &obj, PyArray_DescrConverter, &type, &nin, &offset)) {
         Py_XDECREF(type);
         return NULL;
@@ -2157,7 +2157,7 @@ array_concatenate(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     int axis = 0;
     static char *kwlist[] = {"seq", "axis", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&:concatenate", kwlist,
                 &a0, PyArray_AxisConverter, &axis)) {
         return NULL;
     }
@@ -2169,7 +2169,7 @@ array_innerproduct(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     PyObject *b0, *a0;
 
-    if (!PyArg_ParseTuple(args, "OO", &a0, &b0)) {
+    if (!PyArg_ParseTuple(args, "OO:innerproduct", &a0, &b0)) {
         return NULL;
     }
     return PyArray_Return((PyArrayObject *)PyArray_InnerProduct(a0, b0));
@@ -2203,7 +2203,7 @@ array_matrixproduct(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject* kwds)
         return override;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwlist, &a, &v, &o)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O:matrixproduct", kwlist, &a, &v, &o)) {
         return NULL;
     }
     if (o == Py_None) {
@@ -2233,7 +2233,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyArray_DotFunc *vdot;
     NPY_BEGIN_THREADS_DEF;
 
-    if (!PyArg_ParseTuple(args, "OO", &op1, &op2)) {
+    if (!PyArg_ParseTuple(args, "OO:vdot", &op1, &op2)) {
         return NULL;
     }
 
@@ -2377,7 +2377,7 @@ array_matmul(PyObject *NPY_UNUSED(m), PyObject *args, PyObject* kwds)
         return override;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O:matmul", kwlist,
                                      &in1, &in2, &out)) {
         return NULL;
     }
@@ -2855,7 +2855,7 @@ array_fastCopyAndTranspose(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     PyObject *a0;
 
-    if (!PyArg_ParseTuple(args, "O", &a0)) {
+    if (!PyArg_ParseTuple(args, "O:_fastCopyAndTranspose", &a0)) {
         return NULL;
     }
     return PyArray_Return((PyArrayObject *)PyArray_CopyAndTranspose(a0));
@@ -2868,7 +2868,7 @@ array_correlate(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     int mode = 0;
     static char *kwlist[] = {"a", "v", "mode", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i:correlate", kwlist,
                 &a0, &shape, &mode)) {
         return NULL;
     }
@@ -2882,7 +2882,7 @@ array_correlate2(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     int mode = 0;
     static char *kwlist[] = {"a", "v", "mode", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|i:correlate2", kwlist,
                 &a0, &shape, &mode)) {
         return NULL;
     }
@@ -2895,7 +2895,7 @@ array_arange(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws) {
     static char *kwd[]= {"start", "stop", "step", "dtype", NULL};
     PyArray_Descr *typecode = NULL;
 
-    if(!PyArg_ParseTupleAndKeywords(args, kws, "O|OOO&", kwd,
+    if(!PyArg_ParseTupleAndKeywords(args, kws, "O|OOO&:arange", kwd,
                 &o_start,
                 &o_stop,
                 &o_step,
@@ -2971,7 +2971,7 @@ array__reconstruct(PyObject *NPY_UNUSED(dummy), PyObject *args)
 
     evil_global_disable_warn_O4O8_flag = 1;
 
-    if (!PyArg_ParseTuple(args, "O!O&O&",
+    if (!PyArg_ParseTuple(args, "O!O&O&:_reconstruct",
                 &PyType_Type, &subtype,
                 PyArray_IntpConverter, &shape,
                 PyArray_DescrConverter, &dtype)) {
@@ -3006,7 +3006,7 @@ array_set_string_function(PyObject *NPY_UNUSED(self), PyObject *args,
     int repr = 1;
     static char *kwlist[] = {"f", "repr", NULL};
 
-    if(!PyArg_ParseTupleAndKeywords(args, kwds, "|Oi", kwlist, &op, &repr)) {
+    if(!PyArg_ParseTupleAndKeywords(args, kwds, "|Oi:set_string_function", kwlist, &op, &repr)) {
         return NULL;
     }
     /* reset the array_repr function to built-in */
@@ -3232,7 +3232,7 @@ array_where(PyObject *NPY_UNUSED(ignored), PyObject *args)
 {
     PyObject *obj = NULL, *x = NULL, *y = NULL;
 
-    if (!PyArg_ParseTuple(args, "O|OO", &obj, &x, &y)) {
+    if (!PyArg_ParseTuple(args, "O|OO:where", &obj, &x, &y)) {
         return NULL;
     }
     return PyArray_Where(obj, x, y);
@@ -3245,7 +3245,7 @@ array_lexsort(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     PyObject *obj;
     static char *kwlist[] = {"keys", "axis", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i", kwlist, &obj, &axis)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i:lexsort", kwlist, &obj, &axis)) {
         return NULL;
     }
     return PyArray_Return((PyArrayObject *)PyArray_LexSort(obj, axis));
@@ -3263,7 +3263,7 @@ array_can_cast_safely(PyObject *NPY_UNUSED(self), PyObject *args,
     NPY_CASTING casting = NPY_SAFE_CASTING;
     static char *kwlist[] = {"from", "to", "casting", NULL};
 
-    if(!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|O&", kwlist,
+    if(!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|O&:can_cast", kwlist,
                 &from_obj,
                 PyArray_DescrConverter2, &d2,
                 PyArray_CastingConverter, &casting)) {
@@ -3315,7 +3315,7 @@ array_promote_types(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyArray_Descr *d1 = NULL;
     PyArray_Descr *d2 = NULL;
     PyObject *ret = NULL;
-    if(!PyArg_ParseTuple(args, "O&O&",
+    if(!PyArg_ParseTuple(args, "O&O&:promote_types",
                 PyArray_DescrConverter2, &d1, PyArray_DescrConverter2, &d2)) {
         goto finish;
     }
@@ -3341,7 +3341,7 @@ array_min_scalar_type(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyArrayObject *array;
     PyObject *ret = NULL;
 
-    if(!PyArg_ParseTuple(args, "O", &array_in)) {
+    if(!PyArg_ParseTuple(args, "O:min_scalar_type", &array_in)) {
         return NULL;
     }
 
@@ -3438,7 +3438,7 @@ new_buffer(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     int size;
 
-    if(!PyArg_ParseTuple(args, "i", &size)) {
+    if(!PyArg_ParseTuple(args, "i:buffer", &size)) {
         return NULL;
     }
     return PyBuffer_New(size);
@@ -3454,7 +3454,7 @@ buffer_buffer(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"object", "offset", "size", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                "O|" NPY_SSIZE_T_PYFMT NPY_SSIZE_T_PYFMT, kwlist,
+                "O|" NPY_SSIZE_T_PYFMT NPY_SSIZE_T_PYFMT ":get_buffer", kwlist,
                 &obj, &offset, &size)) {
         return NULL;
     }
@@ -3502,7 +3502,7 @@ as_buffer(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"mem", "size", "readonly", "check", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                "O" NPY_SSIZE_T_PYFMT "|O&O&", kwlist,
+                "O" NPY_SSIZE_T_PYFMT "|O&O&:int_asbuffer", kwlist,
                 &mem, &size, PyArray_BoolConverter, &ro,
                 PyArray_BoolConverter, &check)) {
         return NULL;
@@ -3568,7 +3568,7 @@ format_longfloat(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"x", "precision", NULL};
     static char repr[100];
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OI:format_longfloat", kwlist,
                 &obj, &precision)) {
         return NULL;
     }
@@ -3599,7 +3599,8 @@ compare_chararrays(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     static char msg[] = "comparision must be '==', '!=', '<', '>', '<=', '>='";
     static char *kwlist[] = {"a1", "a2", "cmp", "rstrip", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOs#O&", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOs#O&:compare_chararrays",
+                kwlist,
                 &array, &other, &cmp_str, &strlength,
                 PyArray_BoolConverter, &rstrip)) {
         return NULL;
@@ -3942,7 +3943,7 @@ test_interrupt(PyObject *NPY_UNUSED(self), PyObject *args)
     int kind = 0;
     int a = 0;
 
-    if (!PyArg_ParseTuple(args, "|i", &kind)) {
+    if (!PyArg_ParseTuple(args, "|i:test_interrupt", &kind)) {
         return NULL;
     }
     if (kind) {
@@ -3984,7 +3985,7 @@ array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_
 
     max_work = default_max_work;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O:shares_memory_impl", kwlist,
                                      &self_obj, &other_obj, &max_work_obj)) {
         return NULL;
     }
@@ -4109,8 +4110,8 @@ normalize_axis_index(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     int axis;
     int ndim;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ii", kwlist,
-                                     &axis, &ndim)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ii:normalize_axis_index",
+                                     kwlist, &axis, &ndim)) {
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -748,7 +748,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
         return -1;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&OOO&O&OO&i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&OOO&O&OO&i:nditer", kwlist,
                     &op_in,
                     NpyIter_GlobalFlagsConverter, &flags,
                     &op_flags_in,
@@ -1303,7 +1303,7 @@ npyiter_remove_axis(NewNpyArrayIterObject *self, PyObject *args)
         return NULL;
     }
 
-    if (!PyArg_ParseTuple(args, "i", &axis)) {
+    if (!PyArg_ParseTuple(args, "i:remove_axis", &axis)) {
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1521,7 +1521,7 @@ gentype_getarray(PyObject *scalar, PyObject *args)
     PyArray_Descr *outcode=NULL;
     PyObject *ret;
 
-    if (!PyArg_ParseTuple(args, "|O&", &PyArray_DescrConverter,
+    if (!PyArg_ParseTuple(args, "|O&:__array__", &PyArray_DescrConverter,
                 &outcode)) {
         Py_XDECREF(outcode);
         return NULL;
@@ -1597,7 +1597,7 @@ gentype_byteswap(PyObject *self, PyObject *args)
 {
     npy_bool inplace = NPY_FALSE;
 
-    if (!PyArg_ParseTuple(args, "|O&", PyArray_BoolConverter, &inplace)) {
+    if (!PyArg_ParseTuple(args, "|O&:byteswap", PyArray_BoolConverter, &inplace)) {
         return NULL;
     }
     if (inplace) {
@@ -1841,7 +1841,7 @@ gentype_dump(PyObject *self, PyObject *args)
     PyObject *file = NULL;
     int ret;
 
-    if (!PyArg_ParseTuple(args, "O", &file)) {
+    if (!PyArg_ParseTuple(args, "O:dump", &file)) {
         return NULL;
     }
     ret = PyArray_Dump(self, file, 2);
@@ -2602,6 +2602,7 @@ static PyObject *
      */
     _WORK@work@
 
+    /* TODO: include type name in error message, which is not @name@ */
     if (!PyArg_ParseTuple(args, "|O", &obj)) {
         return NULL;
     }
@@ -2718,6 +2719,7 @@ static PyObject *
     PyObject *obj = NULL, *meta_obj = NULL;
     Py@Name@ScalarObject *ret;
 
+    /* TODO: include type name in error message, which is not @name@ */
     if (!PyArg_ParseTuple(args, "|OO", &obj, &meta_obj)) {
         return NULL;
     }
@@ -2776,7 +2778,7 @@ bool_arrtype_new(PyTypeObject *NPY_UNUSED(type), PyObject *args, PyObject *NPY_U
     PyObject *obj = NULL;
     PyArrayObject *arr;
 
-    if (!PyArg_ParseTuple(args, "|O", &obj)) {
+    if (!PyArg_ParseTuple(args, "|O:bool_", &obj)) {
         return NULL;
     }
     if (obj == NULL) {
@@ -2936,7 +2938,7 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
     PyObject *new = NULL;
     char *destptr;
 
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
+    if (!PyArg_ParseTuple(args, "O:void", &obj)) {
         return NULL;
     }
     /*

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3933,7 +3933,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     if (operation == UFUNC_REDUCEAT) {
         PyArray_Descr *indtype;
         indtype = PyArray_DescrFromType(NPY_INTP);
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO&O&", reduceat_kwlist,
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO&O&:reduceat", reduceat_kwlist,
                                         &op,
                                         &obj_ind,
                                         &axes_in,
@@ -3951,7 +3951,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     }
     else if (operation == UFUNC_ACCUMULATE) {
         PyObject *bad_keepdimarg = NULL;
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&O", accumulate_kwlist,
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&O:accumulate",
+                                        accumulate_kwlist,
                                         &op,
                                         &axes_in,
                                         PyArray_DescrConverter2, &otype,
@@ -3971,7 +3972,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
         }
     }
     else {
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&i", reduce_kwlist,
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O&i:reduce",
+                                        reduce_kwlist,
                                         &op,
                                         &axes_in,
                                         PyArray_DescrConverter2, &otype,
@@ -4549,7 +4551,7 @@ ufunc_seterr(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyObject *val;
     static char *msg = "Error object must be a list of length 3";
 
-    if (!PyArg_ParseTuple(args, "O", &val)) {
+    if (!PyArg_ParseTuple(args, "O:seterrobj", &val)) {
         return NULL;
     }
     if (!PyList_CheckExact(val) || PyList_GET_SIZE(val) != 3) {
@@ -5283,7 +5285,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         return NULL;
     }
 
-    if (!PyArg_ParseTuple(args, "OO|O", &op1, &idx, &op2)) {
+    if (!PyArg_ParseTuple(args, "OO|O:at", &op1, &idx, &op2)) {
         return NULL;
     }
 

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -94,7 +94,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     Py_ssize_t fname_len = -1;
     int offset[2];
 
-    if (!PyArg_ParseTuple(args, "Oii", &function, &nin, &nout)) {
+    if (!PyArg_ParseTuple(args, "Oii:frompyfunc", &function, &nin, &nout)) {
         return NULL;
     }
     if (!PyCallable_Check(function)) {
@@ -210,13 +210,13 @@ add_newdoc_ufunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
     char *docstr, *newdocstr;
 
 #if defined(NPY_PY3K)
-    if (!PyArg_ParseTuple(args, "O!O!", &PyUFunc_Type, &ufunc,
+    if (!PyArg_ParseTuple(args, "O!O!:_add_newdoc_ufunc", &PyUFunc_Type, &ufunc,
                                         &PyUnicode_Type, &str)) {
         return NULL;
     }
     docstr = PyBytes_AS_STRING(PyUnicode_AsUTF8String(str));
 #else
-    if (!PyArg_ParseTuple(args, "O!O!", &PyUFunc_Type, &ufunc,
+    if (!PyArg_ParseTuple(args, "O!O!:_add_newdoc_ufunc", &PyUFunc_Type, &ufunc,
                                          &PyString_Type, &str)) {
          return NULL;
     }

--- a/numpy/fft/fftpack_litemodule.c
+++ b/numpy/fft/fftpack_litemodule.c
@@ -18,7 +18,7 @@ fftpack_cfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     npy_intp nsave;
     int npts, nrepeats, i;
 
-    if(!PyArg_ParseTuple(args, "OO", &op1, &op2)) {
+    if(!PyArg_ParseTuple(args, "OO:cfftf", &op1, &op2)) {
         return NULL;
     }
     data = (PyArrayObject *)PyArray_CopyFromObject(op1,
@@ -71,7 +71,7 @@ fftpack_cfftb(PyObject *NPY_UNUSED(self), PyObject *args)
     npy_intp nsave;
     int npts, nrepeats, i;
 
-    if(!PyArg_ParseTuple(args, "OO", &op1, &op2)) {
+    if(!PyArg_ParseTuple(args, "OO:cfftb", &op1, &op2)) {
         return NULL;
     }
     data = (PyArrayObject *)PyArray_CopyFromObject(op1,
@@ -121,7 +121,7 @@ fftpack_cffti(PyObject *NPY_UNUSED(self), PyObject *args)
     npy_intp dim;
     long n;
 
-    if (!PyArg_ParseTuple(args, "l", &n)) {
+    if (!PyArg_ParseTuple(args, "l:cffti", &n)) {
         return NULL;
     }
     /*Magic size needed by npy_cffti*/
@@ -153,7 +153,7 @@ fftpack_rfftf(PyObject *NPY_UNUSED(self), PyObject *args)
     npy_intp nsave;
     int npts, nrepeats, i, rstep;
 
-    if(!PyArg_ParseTuple(args, "OO", &op1, &op2)) {
+    if(!PyArg_ParseTuple(args, "OO:rfftf", &op1, &op2)) {
         return NULL;
     }
     data = (PyArrayObject *)PyArray_ContiguousFromObject(op1,
@@ -223,7 +223,7 @@ fftpack_rfftb(PyObject *NPY_UNUSED(self), PyObject *args)
     npy_intp nsave;
     int npts, nrepeats, i;
 
-    if(!PyArg_ParseTuple(args, "OO", &op1, &op2)) {
+    if(!PyArg_ParseTuple(args, "OO:rfftb", &op1, &op2)) {
         return NULL;
     }
     data = (PyArrayObject *)PyArray_ContiguousFromObject(op1,
@@ -282,7 +282,7 @@ fftpack_rffti(PyObject *NPY_UNUSED(self), PyObject *args)
   npy_intp dim;
   long n;
 
-  if (!PyArg_ParseTuple(args, "l", &n)) {
+  if (!PyArg_ParseTuple(args, "l:rffti", &n)) {
       return NULL;
   }
   /*Magic size needed by npy_rffti*/

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -110,7 +110,7 @@ lapack_lite_dgelsd(PyObject *NPY_UNUSED(self), PyObject *args)
     PyObject *iwork;
     int lwork;
     int info;
-    TRY(PyArg_ParseTuple(args,"iiiOiOiOdiOiOi",
+    TRY(PyArg_ParseTuple(args,"iiiOiOiOdiOiOi:dgelsd",
                          &m,&n,&nrhs,&a,&lda,&b,&ldb,&s,&rcond,
                          &rank,&work,&lwork,&iwork,&info));
 
@@ -143,7 +143,7 @@ lapack_lite_dgeqrf(PyObject *NPY_UNUSED(self), PyObject *args)
         int lda;
         int info;
 
-        TRY(PyArg_ParseTuple(args,"iiOiOOii",&m,&n,&a,&lda,&tau,&work,&lwork,&info));
+        TRY(PyArg_ParseTuple(args,"iiOiOOii:dgeqrf",&m,&n,&a,&lda,&tau,&work,&lwork,&info));
 
         /* check objects and convert to right storage order */
         TRY(check_object(a,NPY_DOUBLE,"a","NPY_DOUBLE","dgeqrf"));
@@ -172,7 +172,7 @@ lapack_lite_dorgqr(PyObject *NPY_UNUSED(self), PyObject *args)
         int lda;
         int info;
 
-        TRY(PyArg_ParseTuple(args,"iiiOiOOii",  &m, &n, &k, &a, &lda, &tau, &work, &lwork, &info));
+        TRY(PyArg_ParseTuple(args,"iiiOiOOii:dorgqr",  &m, &n, &k, &a, &lda, &tau, &work, &lwork, &info));
         TRY(check_object(a,NPY_DOUBLE,"a","NPY_DOUBLE","dorgqr"));
         TRY(check_object(tau,NPY_DOUBLE,"tau","NPY_DOUBLE","dorgqr"));
         TRY(check_object(work,NPY_DOUBLE,"work","NPY_DOUBLE","dorgqr"));
@@ -207,7 +207,7 @@ lapack_lite_zgelsd(PyObject *NPY_UNUSED(self), PyObject *args)
     PyObject *rwork;
     PyObject *iwork;
     int info;
-    TRY(PyArg_ParseTuple(args,"iiiOiOiOdiOiOOi",
+    TRY(PyArg_ParseTuple(args,"iiiOiOiOdiOiOOi:zgelsd",
                          &m,&n,&nrhs,&a,&lda,&b,&ldb,&s,&rcond,
                          &rank,&work,&lwork,&rwork,&iwork,&info));
 
@@ -239,7 +239,7 @@ lapack_lite_zgeqrf(PyObject *NPY_UNUSED(self), PyObject *args)
         int lda;
         int info;
 
-        TRY(PyArg_ParseTuple(args,"iiOiOOii",&m,&n,&a,&lda,&tau,&work,&lwork,&info));
+        TRY(PyArg_ParseTuple(args,"iiOiOOii:zgeqrf",&m,&n,&a,&lda,&tau,&work,&lwork,&info));
 
 /* check objects and convert to right storage order */
         TRY(check_object(a,NPY_CDOUBLE,"a","NPY_CDOUBLE","zgeqrf"));
@@ -266,7 +266,7 @@ lapack_lite_zungqr(PyObject *NPY_UNUSED(self), PyObject *args)
         int lda;
         int info;
 
-        TRY(PyArg_ParseTuple(args,"iiiOiOOii",  &m, &n, &k, &a, &lda, &tau, &work, &lwork, &info));
+        TRY(PyArg_ParseTuple(args,"iiiOiOOii:zungqr",  &m, &n, &k, &a, &lda, &tau, &work, &lwork, &info));
         TRY(check_object(a,NPY_CDOUBLE,"a","NPY_CDOUBLE","zungqr"));
         TRY(check_object(tau,NPY_CDOUBLE,"tau","NPY_CDOUBLE","zungqr"));
         TRY(check_object(work,NPY_CDOUBLE,"work","NPY_CDOUBLE","zungqr"));


### PR DESCRIPTION
Performed using the following regex, replacing with `$0:$1`. Some manual cleanup
was then required

```regex
^[a-z]+_(\w+)(?:(?!\}).*\n)+.*PyArg_ParseTuple(AndKeywords)?\(args[^"]+"[^:"]+(?=")
```