### PR TITLE
BUG: do not memcpy ptr to freed object

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1916,7 +1916,7 @@ PyArray_Zero(PyArrayObject *arr)
 {
     char *zeroval;
     int ret, storeflags;
-    PyObject *obj;
+    static PyObject * zero_obj = NULL;
 
     if (_check_object_rec(PyArray_DESCR(arr)) < 0) {
         return NULL;
@@ -1927,17 +1927,26 @@ PyArray_Zero(PyArrayObject *arr)
         return NULL;
     }
 
-    obj=PyInt_FromLong((long) 0);
+    if (zero_obj == NULL) {
+        zero_obj = PyInt_FromLong((long) 0);
+        if (zero_obj == NULL) {
+            return NULL;
+        }
+    }
     if (PyArray_ISOBJECT(arr)) {
-        memcpy(zeroval, &obj, sizeof(PyObject *));
-        Py_DECREF(obj);
+        /* XXX this is dangerous, the caller probably is not
+           aware that zeroval is actually a static PyObject*
+           In the best case they will only use it as-is, but
+           if they simply memcpy it into a ndarray without using
+           setitem(), refcount errors will occur
+        */
+        memcpy(zeroval, &zero_obj, sizeof(PyObject *));
         return zeroval;
     }
     storeflags = PyArray_FLAGS(arr);
     PyArray_ENABLEFLAGS(arr, NPY_ARRAY_BEHAVED);
-    ret = PyArray_DESCR(arr)->f->setitem(obj, zeroval, arr);
+    ret = PyArray_DESCR(arr)->f->setitem(zero_obj, zeroval, arr);
     ((PyArrayObject_fields *)arr)->flags = storeflags;
-    Py_DECREF(obj);
     if (ret < 0) {
         PyDataMem_FREE(zeroval);
         return NULL;
@@ -1953,7 +1962,7 @@ PyArray_One(PyArrayObject *arr)
 {
     char *oneval;
     int ret, storeflags;
-    PyObject *obj;
+    static PyObject * one_obj = NULL;
 
     if (_check_object_rec(PyArray_DESCR(arr)) < 0) {
         return NULL;
@@ -1964,18 +1973,27 @@ PyArray_One(PyArrayObject *arr)
         return NULL;
     }
 
-    obj = PyInt_FromLong((long) 1);
+    if (one_obj == NULL) {
+        one_obj = PyInt_FromLong((long) 1);
+        if (one_obj == NULL) {
+            return NULL;
+        }
+    }
     if (PyArray_ISOBJECT(arr)) {
-        memcpy(oneval, &obj, sizeof(PyObject *));
-        Py_DECREF(obj);
+        /* XXX this is dangerous, the caller probably is not
+           aware that oneval is actually a static PyObject*
+           In the best case they will only use it as-is, but
+           if they simply memcpy it into a ndarray without using
+           setitem(), refcount errors will occur
+        */
+        memcpy(oneval, &one_obj, sizeof(PyObject *));
         return oneval;
     }
 
     storeflags = PyArray_FLAGS(arr);
     PyArray_ENABLEFLAGS(arr, NPY_ARRAY_BEHAVED);
-    ret = PyArray_DESCR(arr)->f->setitem(obj, oneval, arr);
+    ret = PyArray_DESCR(arr)->f->setitem(one_obj, oneval, arr);
     ((PyArrayObject_fields *)arr)->flags = storeflags;
-    Py_DECREF(obj);
     if (ret < 0) {
         PyDataMem_FREE(oneval);
         return NULL;


### PR DESCRIPTION
Running scipy tests with pypy 5.7.0 crashed in these functions when called with array([None]). The returned block of memory holds a pointer-to-Pyobject, but that object has been decref'ed and the pypy garbage collector is free to release the memory. Note that on CPython, small ints are immortal so this does not show up on that interpreter

This does cause permanent allocation of a static variable, but clears the segfault.

I left the decref commented out to make the change more clear, if the idea is acceptable I will amend the pull request to remove the commented out code