### PR TITLE
MAINT: Split ufunc into two subtypes, and remove methods where innapropriate

### DIFF
--- a/numpy/core/code_generators/generate_ufunc_api.py
+++ b/numpy/core/code_generators/generate_ufunc_api.py
@@ -12,6 +12,8 @@ h_template = r"""
 #ifdef _UMATHMODULE
 
 extern NPY_NO_EXPORT PyTypeObject PyUFunc_Type;
+extern NPY_NO_EXPORT PyTypeObject PySUFunc_Type;
+extern NPY_NO_EXPORT PyTypeObject PyGUFunc_Type;
 
 %s
 

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -112,7 +112,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
     if (self == NULL) {
         return NULL;
     }
-    PyObject_Init((PyObject *)self, &PyUFunc_Type);
+    PyObject_Init((PyObject *)self, &PySUFunc_Type);
 
     self->userloops = NULL;
     self->nin = nin;
@@ -344,6 +344,10 @@ PyMODINIT_FUNC initumath(void)
 
     /* Initialize the types */
     if (PyType_Ready(&PyUFunc_Type) < 0)
+        return RETVAL;
+    if (PyType_Ready(&PyGUFunc_Type) < 0)
+        return RETVAL;
+    if (PyType_Ready(&PySUFunc_Type) < 0)
         return RETVAL;
 
     /* Add some symbolic constants to the module */


### PR DESCRIPTION
A trial python-side only implementation of #8867.

Members that `np.add` and other `np.scalar_ufunc`s no longer have:

* `signature

Members that `np.linalg._umath_linalg` and other `np.gufuncs` no longer have:

* `reduce`
* `reduce_at`
* `accumulate`

`np.gufunc` and `np.scalar_ufunc` are now subclasses of `np.ufunc`