### PR TITLE
BUG: Make runtests.py --shell behave better on windows

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -183,8 +183,8 @@ def main(argv):
     if args.shell:
         shell = os.environ.get('SHELL', 'sh')
         print("Spawning a Unix shell...")
-        os.execv(shell, [shell] + extra_argv)
-        sys.exit(1)
+        subprocess.call([shell] + extra_argv)
+        sys.exit(0)
 
     if args.coverage:
         dst_dir = os.path.join(ROOT_DIR, 'build', 'coverage')

--- a/runtests.py
+++ b/runtests.py
@@ -181,8 +181,8 @@ def main(argv):
         sys.exit(0)
 
     if args.shell:
-        shell = os.environ.get('SHELL', 'sh')
-        print("Spawning a Unix shell...")
+        shell = os.environ.get('SHELL', 'cmd' if os.name == 'nt' else 'sh')
+        print("Spawning a shell ({})...".format(shell))
         subprocess.call([shell] + extra_argv)
         sys.exit(0)
 

--- a/runtests.py
+++ b/runtests.py
@@ -142,7 +142,7 @@ def main(argv):
         site_dir, site_dir_noarch = build_project(args)
         sys.path.insert(0, site_dir)
         sys.path.insert(0, site_dir_noarch)
-        os.environ['PYTHONPATH'] = site_dir + ':' + site_dir_noarch
+        os.environ['PYTHONPATH'] = site_dir + os.pathsep + site_dir_noarch
 
     extra_argv = args.args[:]
     if extra_argv and extra_argv[0] == '--':


### PR DESCRIPTION
Previously this did not do the right thing.

This still requires the `SHELL` var to be set, but at least does the right thing when run from git bash.