### PR TITLE
TST: Use explicit NaT in test_structure_format

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -141,7 +141,7 @@ class TestArray2String(TestCase):
 
         # for issue #5692
         A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
-        A[5:].fill(np.nan)
+        A[5:].fill(np.datetime64('NaT'))
         assert_equal(np.array2string(A),
                 "[('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) " +
                 "('1970-01-01T00:00:00',)\n ('1970-01-01T00:00:00',) " +


### PR DESCRIPTION
Using np.nan to fill a datetime64 array with NaT depends on the undefined
behavior of a float64 to int64 cast, which may have different behaviors
on non-x64 platforms. See #8325. For this reason np.datetime64('NaT')
should be used fill or set datetime64 arrays with NaT.