### PR TITLE
BUG: Ensure Errors are correctly checked when PyFloat_AsDouble is called

### DIFF
--- a/numpy/random/mtrand/Python.pxi
+++ b/numpy/random/mtrand/Python.pxi
@@ -15,7 +15,7 @@ cdef extern from "Python.h":
     object PyString_FromStringAndSize(char* c_string, int length)
 
     # Float API
-    double PyFloat_AsDouble(object ob)
+    double PyFloat_AsDouble(object ob) except? -1.0
     long PyInt_AsLong(object ob)
 
     # Memory API

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -822,6 +822,20 @@ class TestRandomDist(TestCase):
         # DBL_MAX by increasing fmin a bit
         np.random.uniform(low=np.nextafter(fmin, 1), high=fmax / 1e17)
 
+    def test_uniform_propogates_exeptions(self):
+        # Tests that uniform correctly propogates exceptions
+        # when called with a type which throws when converted to
+        # a float
+        #
+        # Regression test for gh: 8865
+
+        class ThrowableType(np.ndarray):
+            def __float__(self):
+                raise ValueError
+
+        x = np.array(1.0).view(ThrowableType)
+        assert_raises(ValueError, np.uniform, x, x)
+
     def test_vonmises(self):
         np.random.seed(self.seed)
         actual = np.random.vonmises(mu=1.23, kappa=1.54, size=(3, 2))

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -834,7 +834,7 @@ class TestRandomDist(TestCase):
                 raise ValueError
 
         x = np.array(1.0).view(ThrowableType)
-        assert_raises(ValueError, np.uniform, x, x)
+        assert_raises(ValueError, np.random.uniform, x, x)
 
     def test_vonmises(self):
         np.random.seed(self.seed)


### PR DESCRIPTION
There was an error in np.random.uniform where if np.random.uniform
were called with a type that throwed exceptions when it was converted
to a float this exception wouldn't be raised.

This bug was due to an issue where PyFloat_AsDouble was called but
no check for PyErr_Occurred was performed after.

This PR fixes the issue by ensuring that Cython will always emit a
call to PyErr_Occurred if PyFloat_AsDouble returns -1.0

Fixes: #8865