### PR TITLE
ENH: add np.block to improve upon np.bmat

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -163,8 +163,23 @@ for ``len(d.shape)``.
 ``np.block`` function for creating blocked arrays
 -------------------------------------------------
 Add a new ``block`` function to the current stacking functions ``vstack``,
-``hstack``, and ``stack``. It is similar to Matlab's square bracket
-notation for creating block matrices.
+``hstack``, and ``stack``. This allows concatenation across multiple axes
+simultaneously, with a similar syntax to array creation, but where elements
+can themselves be arrays. For instance::
+
+    >>> A = np.eye(2) * 2
+    >>> B = np.eye(3) * 3
+    >>> np.block([
+    ...     [A,               np.zeros((2, 3))],
+    ...     [np.ones((3, 2)), B               ]
+    ... ])
+    array([[ 2.,  0.,  0.,  0.,  0.],
+           [ 0.,  2.,  0.,  0.,  0.],
+           [ 1.,  1.,  3.,  0.,  0.],
+           [ 1.,  1.,  0.,  3.,  0.],
+           [ 1.,  1.,  0.,  0.,  3.]])
+
+It is similar to Matlab's square bracket notation for creating block matrices.
 
 Improvements
 ============

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -160,6 +160,11 @@ being iterated over.
 For consistency with ``ndarray`` and ``broadcast``, ``d.ndim`` is a shorthand
 for ``len(d.shape)``.
 
+``np.block`` function for creating blocked arrays
+-------------------------------------------------
+Add a new ``block`` function to the current stacking functions ``vstack``,
+``hstack``, and ``stack``. It is similar to Matlab's square bracket
+notation for creating block matrices.
 
 Improvements
 ============

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -179,6 +179,9 @@ can themselves be arrays. For instance::
            [ 1.,  1.,  0.,  3.,  0.],
            [ 1.,  1.,  0.,  0.,  3.]])
 
+While primarily useful for block matrices, this works for arbitrary dimensions
+of arrays.
+
 It is similar to Matlab's square bracket notation for creating block matrices.
 
 Improvements

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -72,6 +72,7 @@ Joining arrays
    dstack
    hstack
    vstack
+   block
 
 Splitting arrays
 ================

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -1,10 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-__all__ = ['atleast_1d', 'atleast_2d', 'atleast_3d', 'vstack', 'hstack',
-           'stack']
+__all__ = ['atleast_1d', 'atleast_2d', 'atleast_3d', 'block', 'hstack',
+           'stack', 'vstack']
+
 
 from . import numeric as _nx
-from .numeric import asanyarray, newaxis
+from .numeric import array, asanyarray, newaxis
 from .multiarray import normalize_axis_index
 
 def atleast_1d(*arys):
@@ -207,6 +208,7 @@ def vstack(tup):
     dstack : Stack arrays in sequence depth wise (along third dimension).
     concatenate : Join a sequence of arrays along an existing axis.
     vsplit : Split array into a list of multiple sub-arrays vertically.
+    block : Assemble arrays from blocks.
 
     Notes
     -----
@@ -262,6 +264,7 @@ def hstack(tup):
     dstack : Stack arrays in sequence depth wise (along third axis).
     concatenate : Join a sequence of arrays along an existing axis.
     hsplit : Split array along second axis.
+    block : Create block arrays.
 
     Notes
     -----
@@ -289,6 +292,7 @@ def hstack(tup):
     else:
         return _nx.concatenate(arrs, 1)
 
+
 def stack(arrays, axis=0):
     """
     Join a sequence of arrays along a new axis.
@@ -315,6 +319,7 @@ def stack(arrays, axis=0):
     --------
     concatenate : Join a sequence of arrays along an existing axis.
     split : Split array into a list of multiple sub-arrays of equal size.
+    block : Create block arrays.
 
     Examples
     --------
@@ -354,3 +359,105 @@ def stack(arrays, axis=0):
     sl = (slice(None),) * axis + (_nx.newaxis,)
     expanded_arrays = [arr[sl] for arr in arrays]
     return _nx.concatenate(expanded_arrays, axis=axis)
+
+
+def block(*arrays):
+    """
+    Create a block array consisting of other arrays.
+
+    You can create a 2-D blocked array with the same notation you use for
+    `np.array`.
+
+    Parameters
+    ----------
+    arrays : sequence of sequence of ndarrays
+        1-D arrays are treated as row vectors.
+
+    Returns
+    -------
+    blocked : ndarray
+        The 2-D array assembled from the given blocks.
+
+    See Also
+    --------
+    stack : Stack arrays in sequence along a new dimension.
+    hstack : Stack arrays in sequence horizontally (column wise).
+    vstack : Stack arrays in sequence vertically (row wise).
+    dstack : Stack arrays in sequence depth wise (along third dimension).
+    concatenate : Join a sequence of arrays together.
+    vsplit : Split array into a list of multiple sub-arrays vertically.
+
+    Notes
+    -----
+    ``block`` is similar to Matlab's "square bracket stacking": ``[A A; B B]``
+
+    Examples
+    --------
+    Stacking in a row:
+    >>> A = np.array([[1, 2, 3]])
+    >>> B = np.array([[2, 3, 4]])
+    >>> block([A, B])
+    array([[1, 2, 3, 2, 3, 4]])
+
+    Stacking in a column:
+    >>> A = np.array([[1, 2, 3]])
+    >>> B = np.array([[2, 3, 4]])
+    >>> block(A, B)
+    array([[1, 2, 3],
+           [2, 3, 4]])
+
+    1-D vectors are treated as row arrays
+    >>> a = np.array([1, 1])
+    >>> b = np.array([2, 2])
+    >>> block([a, b])
+    array([[1, 1, 2, 2]])
+
+    >>> a = np.array([1, 1])
+    >>> b = np.array([2, 2])
+    >>> block(a, b)
+    array([[1, 1],
+           [2, 2]])
+
+    The tuple notation also works:
+    >>> A = np.ones((2, 2))
+    >>> B = 2 * A
+    >>> block((A, B))
+    array([[1, 1, 2, 2],
+           [1, 1, 2, 2]])
+
+    Block array with arbitrary shaped elements
+    >>> One = np.array([[1, 1, 1]])
+    >>> Two = np.array([[2, 2, 2]])
+    >>> Three = np.array([[3, 3, 3, 3, 3, 3]])
+    >>> four = np.array([4, 4, 4, 4, 4, 4])
+    >>> five = np.array([5])
+    >>> six = np.array([6, 6, 6, 6, 6])
+    >>> Zeros = np.zeros((2, 6), dtype=int)
+    >>> block([One, Two],
+    ...        Three,
+    ...        four,
+    ...        [five, six],
+    ...        Zeros)
+    array([[1, 1, 1, 2, 2, 2],
+           [3, 3, 3, 3, 3, 3],
+           [4, 4, 4, 4, 4, 4],
+           [5, 6, 6, 6, 6, 6],
+           [0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0]])
+
+
+    """
+    if len(arrays) < 1:
+        raise TypeError("need at least one array to create a block array")
+
+    result = []
+    for row in arrays:
+        if isinstance(row, (list, tuple)):
+            result.append(hstack(row))
+        else:
+            result.append(row)
+
+    if len(result) > 1:
+        return vstack(result)
+    else:
+        return atleast_2d(result[0])

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -264,7 +264,7 @@ def hstack(tup):
     dstack : Stack arrays in sequence depth wise (along third axis).
     concatenate : Join a sequence of arrays along an existing axis.
     hsplit : Split array along second axis.
-    block : Create block arrays.
+    block : Assemble arrays from blocks.
 
     Notes
     -----
@@ -319,7 +319,7 @@ def stack(arrays, axis=0):
     --------
     concatenate : Join a sequence of arrays along an existing axis.
     split : Split array into a list of multiple sub-arrays of equal size.
-    block : Create block arrays.
+    block : Assemble arrays from blocks.
 
     Examples
     --------
@@ -363,7 +363,7 @@ def stack(arrays, axis=0):
 
 def block(*arrays):
     """
-    Create a block array consisting of other arrays.
+    Assemble an array from nested lists of blocks.
 
     You can create a 2-D blocked array with the same notation you use for
     `np.array`.

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -456,7 +456,7 @@ def block(arrays):
 
     Parameters
     ----------
-    arrays : nested list of ndarrays or scalars
+    arrays : nested list of array_like or scalars (but not tuples)
         If passed a single ndarray or scalar (a nested list of depth 0), this
         is returned unmodified (and not copied).
 
@@ -597,6 +597,19 @@ def block(arrays):
     list_ndim = None
     any_empty = False
     for index, value, entering in rec.walk(arrays):
+        if type(value) is tuple:
+            # not strictly necessary, but saves us from:
+            #  - more than one way to do things - no point treating tuples like
+            #    lists
+            #  - horribly confusing behaviour that results when tuples are
+            #    treated like ndarray
+            raise TypeError(
+                '{} is a tuple. '
+                'Only lists can be used to arrange blocks, and np.block does '
+                'not allow implicit conversion from tuple to ndarray.'.format(
+                    format_index(index)
+                )
+            )
         if not entering:
             curr_depth = len(index)
         elif len(value) == 0:

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -399,33 +399,12 @@ class TestBlock(TestCase):
         six_1d = np.array([6, 6, 6, 6, 6])
         zero_2d = np.zeros((2, 6))
 
-        result = block([[one_2d, two_2d],
-                        three_2d,
-                        four_1d,
-                        [five_0d, six_1d],
-                        zero_2d])
         expected = np.array([[1, 1, 1, 2, 2, 2],
                              [3, 3, 3, 3, 3, 3],
                              [4, 4, 4, 4, 4, 4],
                              [5, 6, 6, 6, 6, 6],
                              [0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0]])
-        assert_equal(result, expected)
-
-        # additional [] around rows should not have any influence
-        result = block([[one_2d, two_2d],
-                        three_2d,
-                        [four_1d],
-                        [five_0d, six_1d],
-                        zero_2d])
-        assert_equal(result, expected)
-
-        result = block([[one_2d, two_2d],
-                        [three_2d],
-                        [four_1d],
-                        [five_0d, six_1d],
-                        zero_2d])
-        assert_equal(result, expected)
 
         result = block([[one_2d, two_2d],
                         [three_2d],
@@ -453,7 +432,7 @@ class TestBlock(TestCase):
                 two
             ],
             [five, six],
-            zero
+            [zero]
         ])
         expected = np.array([[1, 1, 1, 2, 2, 2],
                              [3, 3, 3, 2, 2, 2],
@@ -529,9 +508,22 @@ class TestBlock(TestCase):
         assert_equal(np.block(1),         np.array(1))
         assert_equal(np.block(np.eye(3)), np.eye(3))
 
-    def test_empty_input(self):
-        assert_raises(ValueError, np.block, [])
-        assert_raises(ValueError, np.block, [[]])
+    def test_invalid_nesting(self):
+        msg = 'depths are mismatched'
+        assert_raises_regex(ValueError, msg, np.block, [1, [2]])
+        assert_raises_regex(ValueError, msg, np.block, [1, []])
+        assert_raises_regex(ValueError, msg, np.block, [[1], 2])
+        assert_raises_regex(ValueError, msg, np.block, [[], 2])
+        assert_raises_regex(ValueError, msg, np.block, [
+            [[1], [2]],
+            [[3, 4]],
+            [5]  # missing brackets
+        ])
+
+    def test_empty_lists(self):
+        assert_raises_regex(ValueError, 'empty', np.block, [])
+        assert_raises_regex(ValueError, 'empty', np.block, [[]])
+        assert_raises_regex(ValueError, 'empty', np.block, [[1], []])
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -335,24 +335,24 @@ def test_stack():
 
 class TestBlock(TestCase):
     def test_block_simple_row_wise(self):
-        A = np.ones((2, 2))
-        B = 2 * A
+        a_2d = np.ones((2, 2))
+        b_2d = 2 * a_2d
         desired = np.array([[1, 1, 2, 2],
                             [1, 1, 2, 2]])
-        result = block([A, B])
+        result = block([a_2d, b_2d])
         assert_equal(desired, result)
         # with tuples
-        result = block((A, B))
+        result = block((a_2d, b_2d))
         assert_equal(desired, result)
 
     def test_block_simple_column_wise(self):
-        A = np.ones((2, 2))
-        B = 2 * A
+        a_2d = np.ones((2, 2))
+        b_2d = 2 * a_2d
         expected = np.array([[1, 1],
                              [1, 1],
                              [2, 2],
                              [2, 2]])
-        result = block([[A], [B]])
+        result = block([[a_2d], [b_2d]])
         assert_equal(expected, result)
 
     def test_block_with_1d_arrays_row_wise(self):
@@ -373,17 +373,17 @@ class TestBlock(TestCase):
 
     def test_block_with_1d_arrays_column_wise(self):
         # # # 1-D vectors are treated as row arrays
-        a = np.array([1, 2, 3])
-        b = np.array([2, 3, 4])
+        a_1d = np.array([1, 2, 3])
+        b_1d = np.array([2, 3, 4])
         expected = np.array([[1, 2, 3],
                              [2, 3, 4]])
-        result = block([[a], [b]])
+        result = block([[a_1d], [b_1d]])
         assert_equal(expected, result)
 
     def test_block_mixed_1d_and_2d(self):
-        A = np.ones((2, 2))
-        B = np.array([2, 2])
-        result = block([[A], [B]])
+        a_2d = np.ones((2, 2))
+        b_1d = np.array([2, 2])
+        result = block([[a_2d], [b_1d]])
         expected = np.array([[1, 1],
                              [1, 1],
                              [2, 2]])
@@ -391,19 +391,19 @@ class TestBlock(TestCase):
 
     def test_block_complicated(self):
         # a bit more complicated
-        One = np.array([[1, 1, 1]])
-        Two = np.array([[2, 2, 2]])
-        Three = np.array([[3, 3, 3, 3, 3, 3]])
-        four = np.array([4, 4, 4, 4, 4, 4])
-        five = np.array([5])
-        six = np.array([6, 6, 6, 6, 6])
-        Zeros = np.zeros((2, 6))
+        one_2d = np.array([[1, 1, 1]])
+        two_2d = np.array([[2, 2, 2]])
+        three_2d = np.array([[3, 3, 3, 3, 3, 3]])
+        four_1d = np.array([4, 4, 4, 4, 4, 4])
+        five_0d = np.array(5)
+        six_1d = np.array([6, 6, 6, 6, 6])
+        zero_2d = np.zeros((2, 6))
 
-        result = block([[One, Two],
-                        Three,
-                        four,
-                        [five, six],
-                        Zeros])
+        result = block([[one_2d, two_2d],
+                        three_2d,
+                        four_1d,
+                        [five_0d, six_1d],
+                        zero_2d])
         expected = np.array([[1, 1, 1, 2, 2, 2],
                              [3, 3, 3, 3, 3, 3],
                              [4, 4, 4, 4, 4, 4],
@@ -413,25 +413,25 @@ class TestBlock(TestCase):
         assert_equal(result, expected)
 
         # additional [] around rows should not have any influence
-        result = block([[One, Two],
-                        Three,
-                        [four],
-                        [five, six],
-                        Zeros])
+        result = block([[one_2d, two_2d],
+                        three_2d,
+                        [four_1d],
+                        [five_0d, six_1d],
+                        zero_2d])
         assert_equal(result, expected)
 
-        result = block([[One, Two],
-                        [Three],
-                        [four],
-                        [five, six],
-                        Zeros])
+        result = block([[one_2d, two_2d],
+                        [three_2d],
+                        [four_1d],
+                        [five_0d, six_1d],
+                        zero_2d])
         assert_equal(result, expected)
 
-        result = block([[One, Two],
-                        [Three],
-                        [four],
-                        [five, six],
-                        [Zeros]])
+        result = block([[one_2d, two_2d],
+                        [three_2d],
+                        [four_1d],
+                        [five_0d, six_1d],
+                        [zero_2d]])
         assert_equal(result, expected)
 
     def test_3d(self):

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -1,11 +1,14 @@
 from __future__ import division, absolute_import, print_function
 
+import warnings
 import numpy as np
-from numpy.compat import long
 from numpy.core import (array, arange, atleast_1d, atleast_2d, atleast_3d,
-                        vstack, hstack, newaxis, concatenate, stack)
-from numpy.testing import (TestCase, assert_, assert_raises, assert_array_equal,
-                           assert_equal, run_module_suite, assert_raises_regex)
+                        block, vstack, hstack, newaxis, concatenate, stack)
+from numpy.testing import (TestCase, assert_, assert_raises,
+                           assert_array_equal, assert_equal, run_module_suite,
+                           assert_raises_regex, assert_almost_equal)
+
+from numpy.compat import long
 
 class TestAtleast1d(TestCase):
     def test_0D_array(self):
@@ -328,6 +331,127 @@ def test_stack():
     m = np.matrix([[1, 2], [3, 4]])
     assert_raises_regex(ValueError, 'shape too large to be a matrix',
                         stack, [m, m])
+
+
+class TestBlock(TestCase):
+    def test_block_simple_row_wise(self):
+        A = np.ones((2, 2))
+        B = 2 * A
+        desired = np.array([[1, 1, 2, 2],
+                            [1, 1, 2, 2]])
+        result = block([A, B])
+        assert_equal(desired, result)
+        # with tuples
+        result = block((A, B))
+        assert_almost_equal(desired, result)
+
+    def test_block_simple_column_wise(self):
+        A = np.ones((2, 2))
+        B = 2 * A
+        expected = np.array([[1, 1],
+                             [1, 1],
+                             [2, 2],
+                             [2, 2]])
+        result = block(A, B)
+        assert_almost_equal(expected, result)
+
+    def test_block_needless_brackts(self):
+        A = np.ones((2, 2))
+        B = 2 * A
+        expected = np.array([[1, 1],
+                             [1, 1],
+                             [2, 2],
+                             [2, 2]])
+        result = block([A], [B])  # here are the needless brackets
+        assert_almost_equal(expected, result)
+
+    def test_block_with_1d_arrays_row_wise(self):
+        # # # 1-D vectors are treated as row arrays
+        a = np.array([1, 2, 3])
+        b = np.array([2, 3, 4])
+        expected = np.array([[1, 2, 3, 2, 3, 4]])
+        result = block([a, b])
+        assert_almost_equal(expected, result)
+
+    def test_block_with_1d_arrays_multiple_rows(self):
+        a = np.array([1, 2, 3])
+        b = np.array([2, 3, 4])
+        expected = np.array([[1, 2, 3, 2, 3, 4],
+                             [1, 2, 3, 2, 3, 4]])
+        result = block([a, b], [a, b])
+        assert_almost_equal(expected, result)
+
+    def test_block_with_1d_arrays_column_wise(self):
+        # # # 1-D vectors are treated as row arrays
+        a = np.array([1, 2, 3])
+        b = np.array([2, 3, 4])
+        expected = np.array([[1, 2, 3],
+                             [2, 3, 4]])
+        result = block(a, b)
+        assert_almost_equal(expected, result)
+
+    def test_block_mixed_1d_and_2d(self):
+        A = np.ones((2, 2))
+        B = np.array([2, 2])
+        result = block(A, B)
+        expected = np.array([[1, 1],
+                             [1, 1],
+                             [2, 2]])
+        assert_almost_equal(expected, result)
+
+    def test_block_complex(self):
+        # # # a bit more complex
+        One = np.array([[1, 1, 1]])
+        Two = np.array([[2, 2, 2]])
+        Three = np.array([[3, 3, 3, 3, 3, 3]])
+        four = np.array([4, 4, 4, 4, 4, 4])
+        five = np.array([5])
+        six = np.array([6, 6, 6, 6, 6])
+        Zeros = np.zeros((2, 6))
+
+        result = block([One, Two],
+                       Three,
+                       four,
+                       [five, six],
+                       Zeros)
+        expected = np.array([[1, 1, 1, 2, 2, 2],
+                             [3, 3, 3, 3, 3, 3],
+                             [4, 4, 4, 4, 4, 4],
+                             [5, 6, 6, 6, 6, 6],
+                             [0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0]])
+        assert_almost_equal(result, expected)
+
+        # additional [] around rows should not have any influence
+        result = block([One, Two],
+                       Three,
+                       [four],
+                       [five, six],
+                       Zeros)
+        assert_almost_equal(result, expected)
+
+        result = block([One, Two],
+                       [Three],
+                       [four],
+                       [five, six],
+                       Zeros)
+        assert_almost_equal(result, expected)
+
+        result = block([One, Two],
+                       [Three],
+                       [four],
+                       [five, six],
+                       [Zeros])
+        assert_almost_equal(result, expected)
+
+    def test_block_with_mismatched_shape(self):
+        a = np.array([0, 0])
+        b = np.eye(2)
+        assert_raises(ValueError, np.block, (a, b))
+        assert_raises(ValueError, np.block, (b, a))
+
+    def test_not_list_or_tuple_as_input(self):
+        assert_raises(TypeError, np.block)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -341,9 +341,6 @@ class TestBlock(TestCase):
                             [1, 1, 2, 2]])
         result = block([a_2d, b_2d])
         assert_equal(desired, result)
-        # with tuples
-        result = block((a_2d, b_2d))
-        assert_equal(desired, result)
 
     def test_block_simple_column_wise(self):
         a_2d = np.ones((2, 2))
@@ -501,8 +498,8 @@ class TestBlock(TestCase):
     def test_block_with_mismatched_shape(self):
         a = np.array([0, 0])
         b = np.eye(2)
-        assert_raises(ValueError, np.block, (a, b))
-        assert_raises(ValueError, np.block, (b, a))
+        assert_raises(ValueError, np.block, [a, b])
+        assert_raises(ValueError, np.block, [b, a])
 
     def test_no_lists(self):
         assert_equal(np.block(1),         np.array(1))
@@ -524,6 +521,10 @@ class TestBlock(TestCase):
         assert_raises_regex(ValueError, 'empty', np.block, [])
         assert_raises_regex(ValueError, 'empty', np.block, [[]])
         assert_raises_regex(ValueError, 'empty', np.block, [[1], []])
+
+    def test_tuple(self):
+        assert_raises_regex(TypeError, 'tuple', np.block, ([1, 2], [3, 4]))
+        assert_raises_regex(TypeError, 'tuple', np.block, [(1, 2), (3, 4)])
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -434,6 +434,36 @@ class TestBlock(TestCase):
                         [zero_2d]])
         assert_equal(result, expected)
 
+    def test_nested(self):
+        one = np.array([1, 1, 1])
+        two = np.array([[2, 2, 2], [2, 2, 2], [2, 2, 2]])
+        three = np.array([3, 3, 3])
+        four = np.array([4, 4, 4])
+        five = np.array(5)
+        six = np.array([6, 6, 6, 6, 6])
+        zero = np.zeros((2, 6))
+
+        result = np.block([
+            [
+                np.block([
+                   [one],
+                   [three],
+                   [four]
+                ]),
+                two
+            ],
+            [five, six],
+            zero
+        ])
+        expected = np.array([[1, 1, 1, 2, 2, 2],
+                             [3, 3, 3, 2, 2, 2],
+                             [4, 4, 4, 2, 2, 2],
+                             [5, 6, 6, 6, 6, 6],
+                             [0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0]])
+
+        assert_equal(result, expected)
+
     def test_3d(self):
         a000 = np.ones((2, 2, 2), int) * 1
 

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -352,24 +352,14 @@ class TestBlock(TestCase):
                              [1, 1],
                              [2, 2],
                              [2, 2]])
-        result = block(A, B)
-        assert_equal(expected, result)
-
-    def test_block_needless_brackts(self):
-        A = np.ones((2, 2))
-        B = 2 * A
-        expected = np.array([[1, 1],
-                             [1, 1],
-                             [2, 2],
-                             [2, 2]])
-        result = block([A], [B])  # here are the needless brackets
+        result = block([[A], [B]])
         assert_equal(expected, result)
 
     def test_block_with_1d_arrays_row_wise(self):
         # # # 1-D vectors are treated as row arrays
         a = np.array([1, 2, 3])
         b = np.array([2, 3, 4])
-        expected = np.array([[1, 2, 3, 2, 3, 4]])
+        expected = np.array([1, 2, 3, 2, 3, 4])
         result = block([a, b])
         assert_equal(expected, result)
 
@@ -378,7 +368,7 @@ class TestBlock(TestCase):
         b = np.array([2, 3, 4])
         expected = np.array([[1, 2, 3, 2, 3, 4],
                              [1, 2, 3, 2, 3, 4]])
-        result = block([a, b], [a, b])
+        result = block([[a, b], [a, b]])
         assert_equal(expected, result)
 
     def test_block_with_1d_arrays_column_wise(self):
@@ -387,20 +377,20 @@ class TestBlock(TestCase):
         b = np.array([2, 3, 4])
         expected = np.array([[1, 2, 3],
                              [2, 3, 4]])
-        result = block(a, b)
+        result = block([[a], [b]])
         assert_equal(expected, result)
 
     def test_block_mixed_1d_and_2d(self):
         A = np.ones((2, 2))
         B = np.array([2, 2])
-        result = block(A, B)
+        result = block([[A], [B]])
         expected = np.array([[1, 1],
                              [1, 1],
                              [2, 2]])
         assert_equal(expected, result)
 
-    def test_block_complex(self):
-        # # # a bit more complex
+    def test_block_complicated(self):
+        # a bit more complicated
         One = np.array([[1, 1, 1]])
         Two = np.array([[2, 2, 2]])
         Three = np.array([[3, 3, 3, 3, 3, 3]])
@@ -409,11 +399,11 @@ class TestBlock(TestCase):
         six = np.array([6, 6, 6, 6, 6])
         Zeros = np.zeros((2, 6))
 
-        result = block([One, Two],
-                       Three,
-                       four,
-                       [five, six],
-                       Zeros)
+        result = block([[One, Two],
+                        Three,
+                        four,
+                        [five, six],
+                        Zeros])
         expected = np.array([[1, 1, 1, 2, 2, 2],
                              [3, 3, 3, 3, 3, 3],
                              [4, 4, 4, 4, 4, 4],
@@ -423,26 +413,81 @@ class TestBlock(TestCase):
         assert_equal(result, expected)
 
         # additional [] around rows should not have any influence
-        result = block([One, Two],
-                       Three,
-                       [four],
-                       [five, six],
-                       Zeros)
+        result = block([[One, Two],
+                        Three,
+                        [four],
+                        [five, six],
+                        Zeros])
         assert_equal(result, expected)
 
-        result = block([One, Two],
-                       [Three],
-                       [four],
-                       [five, six],
-                       Zeros)
+        result = block([[One, Two],
+                        [Three],
+                        [four],
+                        [five, six],
+                        Zeros])
         assert_equal(result, expected)
 
-        result = block([One, Two],
-                       [Three],
-                       [four],
-                       [five, six],
-                       [Zeros])
+        result = block([[One, Two],
+                        [Three],
+                        [four],
+                        [five, six],
+                        [Zeros]])
         assert_equal(result, expected)
+
+    def test_3d(self):
+        a000 = np.ones((2, 2, 2), int) * 1
+
+        a100 = np.ones((3, 2, 2), int) * 2
+        a010 = np.ones((2, 3, 2), int) * 3
+        a001 = np.ones((2, 2, 3), int) * 4
+
+        a011 = np.ones((2, 3, 3), int) * 5
+        a101 = np.ones((3, 2, 3), int) * 6
+        a110 = np.ones((3, 3, 2), int) * 7
+
+        a111 = np.ones((3, 3, 3), int) * 8
+
+        result = np.block([
+            [
+                [a000, a001],
+                [a010, a011],
+            ],
+            [
+                [a100, a101],
+                [a110, a111],
+            ]
+        ])
+        expected = array([[[1, 1, 4, 4, 4],
+                           [1, 1, 4, 4, 4],
+                           [3, 3, 5, 5, 5],
+                           [3, 3, 5, 5, 5],
+                           [3, 3, 5, 5, 5]],
+
+                          [[1, 1, 4, 4, 4],
+                           [1, 1, 4, 4, 4],
+                           [3, 3, 5, 5, 5],
+                           [3, 3, 5, 5, 5],
+                           [3, 3, 5, 5, 5]],
+
+                          [[2, 2, 6, 6, 6],
+                           [2, 2, 6, 6, 6],
+                           [7, 7, 8, 8, 8],
+                           [7, 7, 8, 8, 8],
+                           [7, 7, 8, 8, 8]],
+
+                          [[2, 2, 6, 6, 6],
+                           [2, 2, 6, 6, 6],
+                           [7, 7, 8, 8, 8],
+                           [7, 7, 8, 8, 8],
+                           [7, 7, 8, 8, 8]],
+
+                          [[2, 2, 6, 6, 6],
+                           [2, 2, 6, 6, 6],
+                           [7, 7, 8, 8, 8],
+                           [7, 7, 8, 8, 8],
+                           [7, 7, 8, 8, 8]]])
+
+        assert_array_equal(result, expected)
 
     def test_block_with_mismatched_shape(self):
         a = np.array([0, 0])
@@ -450,8 +495,13 @@ class TestBlock(TestCase):
         assert_raises(ValueError, np.block, (a, b))
         assert_raises(ValueError, np.block, (b, a))
 
-    def test_not_list_or_tuple_as_input(self):
-        assert_raises(TypeError, np.block)
+    def test_no_lists(self):
+        assert_equal(np.block(1),         np.array(1))
+        assert_equal(np.block(np.eye(3)), np.eye(3))
+
+    def test_empty_input(self):
+        assert_raises(ValueError, np.block, [])
+        assert_raises(ValueError, np.block, [[]])
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -343,7 +343,7 @@ class TestBlock(TestCase):
         assert_equal(desired, result)
         # with tuples
         result = block((A, B))
-        assert_almost_equal(desired, result)
+        assert_equal(desired, result)
 
     def test_block_simple_column_wise(self):
         A = np.ones((2, 2))
@@ -353,7 +353,7 @@ class TestBlock(TestCase):
                              [2, 2],
                              [2, 2]])
         result = block(A, B)
-        assert_almost_equal(expected, result)
+        assert_equal(expected, result)
 
     def test_block_needless_brackts(self):
         A = np.ones((2, 2))
@@ -363,7 +363,7 @@ class TestBlock(TestCase):
                              [2, 2],
                              [2, 2]])
         result = block([A], [B])  # here are the needless brackets
-        assert_almost_equal(expected, result)
+        assert_equal(expected, result)
 
     def test_block_with_1d_arrays_row_wise(self):
         # # # 1-D vectors are treated as row arrays
@@ -371,7 +371,7 @@ class TestBlock(TestCase):
         b = np.array([2, 3, 4])
         expected = np.array([[1, 2, 3, 2, 3, 4]])
         result = block([a, b])
-        assert_almost_equal(expected, result)
+        assert_equal(expected, result)
 
     def test_block_with_1d_arrays_multiple_rows(self):
         a = np.array([1, 2, 3])
@@ -379,7 +379,7 @@ class TestBlock(TestCase):
         expected = np.array([[1, 2, 3, 2, 3, 4],
                              [1, 2, 3, 2, 3, 4]])
         result = block([a, b], [a, b])
-        assert_almost_equal(expected, result)
+        assert_equal(expected, result)
 
     def test_block_with_1d_arrays_column_wise(self):
         # # # 1-D vectors are treated as row arrays
@@ -388,7 +388,7 @@ class TestBlock(TestCase):
         expected = np.array([[1, 2, 3],
                              [2, 3, 4]])
         result = block(a, b)
-        assert_almost_equal(expected, result)
+        assert_equal(expected, result)
 
     def test_block_mixed_1d_and_2d(self):
         A = np.ones((2, 2))
@@ -397,7 +397,7 @@ class TestBlock(TestCase):
         expected = np.array([[1, 1],
                              [1, 1],
                              [2, 2]])
-        assert_almost_equal(expected, result)
+        assert_equal(expected, result)
 
     def test_block_complex(self):
         # # # a bit more complex
@@ -420,7 +420,7 @@ class TestBlock(TestCase):
                              [5, 6, 6, 6, 6, 6],
                              [0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0]])
-        assert_almost_equal(result, expected)
+        assert_equal(result, expected)
 
         # additional [] around rows should not have any influence
         result = block([One, Two],
@@ -428,21 +428,21 @@ class TestBlock(TestCase):
                        [four],
                        [five, six],
                        Zeros)
-        assert_almost_equal(result, expected)
+        assert_equal(result, expected)
 
         result = block([One, Two],
                        [Three],
                        [four],
                        [five, six],
                        Zeros)
-        assert_almost_equal(result, expected)
+        assert_equal(result, expected)
 
         result = block([One, Two],
                        [Three],
                        [four],
                        [five, six],
                        [Zeros])
-        assert_almost_equal(result, expected)
+        assert_equal(result, expected)
 
     def test_block_with_mismatched_shape(self):
         a = np.array([0, 0])

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1137,8 +1137,8 @@ def bmat(obj, ldict=None, gdict=None):
     Parameters
     ----------
     obj : str or array_like
-        Input data.  Names of variables in the current scope may be
-        referenced, even if `obj` is a string.
+        Input data. If a string, variables in the current scope may be
+        referenced by name.
     ldict : dict, optional
         A dictionary that replaces local operands in current frame.
         Ignored if `obj` is not a string or `gdict` is `None`.
@@ -1153,7 +1153,9 @@ def bmat(obj, ldict=None, gdict=None):
 
     See Also
     --------
-    matrix
+    block :
+        A generalization of this function for N-d arrays, that returns normal
+        `ndarray`s.
 
     Examples
     --------


### PR DESCRIPTION
This continues where #7768 left off (which continues where #5057 left off). The first commit is just a rebase of #7768 onto master, with the release notes moved to the latest release.

Changes since then:
* 2D arrays are not special. This does not auto-promote results to 2D.
* Works for ND arrays
* No longer accepts `*args`, for consistency with `stack` and `concatenate`


The semantics are essentially:
1. <s>Normalize the list of lists to be of uniform depth</s>
2. `reshape` all the list elements to be at least as many dimensions as the list depth (#7804 ?)
3. `concatenate` from the innermost list to the outermost, working backwards from the last dimension - elements can have extra leading dimensions

### Proposed restrictions
Things that we should decide on before merging:
* [x] Make tuples forbidden, require that inputs be lists of lists. This frees us up to let `tuples` mean something else in future (perhaps records, like they do in `np.array` with structured dtypes).
* [x] Require that list depth match explicitly: make `np.block([[a, b], c])` illegal, must be spelt `np.block([[a, b], [c]])` (currently these are equivalent - this change would make step 1 a check, not a normalization). This makes things look more like the `np.array` constructor, but forces users to be more verbose

### Future Enhancements
Moved to #8899