### PR TITLE
BUG: Don't modify types after PyType_Ready

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4367,14 +4367,14 @@ setup_scalartypes(PyObject *NPY_UNUSED(dict))
     Py##child##ArrType_Type.tp_bases =                                  \
         Py_BuildValue("(OO)", &Py##parent2##ArrType_Type,               \
                       &Py##parent1##_Type);                             \
+    Py##child##ArrType_Type.tp_hash = Py##parent1##_Type.tp_hash;       \
     if (PyType_Ready(&Py##child##ArrType_Type) < 0) {                   \
         PyErr_Print();                                                  \
         PyErr_Format(PyExc_SystemError,                                 \
                      "could not initialize Py%sArrType_Type",           \
                      #child);                                           \
         return -1;                                                      \
-    }                                                                   \
-    Py##child##ArrType_Type.tp_hash = Py##parent1##_Type.tp_hash;
+    }
 
 /*
  * In Py3K, int is no longer a fixed-width integer type, so don't

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2235,6 +2235,18 @@ class TestRegression(TestCase):
         a = np.ones(1, dtype=('O', [('name', 'O')]))
         assert_equal(a[0], 1)
 
+    def test_correct_hash_dict(self):
+        # gh-8887 - __hash__ would be None despite tp_hash being set
+        all_types = set(np.typeDict.values()) - {np.void}
+        for t in all_types:
+            val = t()
+
+            try:
+                hash(val)
+            except TypeError as e:
+                assert_equal(t.__hash__, None)
+            else:
+                assert_(t.__hash__ != None)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This would previously cause hashing to work even though `__hash__` is None.

Fixes #8887