### PR TITLE
MAINT: Use PyArray_FROM_* macros

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -385,8 +385,9 @@ From other objects
     *dtype* argument needs to be a :c:type:`PyArray_Descr` structure
     indicating the desired data-type (including required
     byteorder). The *dtype* argument may be NULL, indicating that any
-    data-type (and byteorder) is acceptable. Unless ``FORCECAST`` is
-    present in ``flags``, this call will generate an error if the data
+    data-type (and byteorder) is acceptable. Unless
+    :c:data:`NPY_ARRAY_FORCECAST` is present in ``flags``,
+    this call will generate an error if the data
     type cannot be safely obtained from the object. If you want to use
     ``NULL`` for the *dtype* and ensure the array is notswapped then
     use :c:func:`PyArray_CheckFromAny`. A value of 0 for either of the
@@ -397,13 +398,13 @@ From other objects
     may be 0. Also, if *op* is not already an array (or does not
     expose the array interface), then a new array will be created (and
     filled from *op* using the sequence protocol). The new array will
-    have :c:data:`NPY_DEFAULT` as its flags member. The *context* argument
+    have :c:data:`NPY_ARRAY_DEFAULT` as its flags member. The *context* argument
     is passed to the :obj:`~numpy.class.__array__` method of *op* and is only used if
     the array is constructed that way. Almost always this
     parameter is ``NULL``.
 
     In versions 1.6 and earlier of NumPy, the following flags
-    did not have the _ARRAY_ macro namespace in them. That form
+    did not have the ``_ARRAY_`` macro namespace in them. That form
     of the constant names is deprecated in 1.7.
 
     .. c:var:: NPY_ARRAY_C_CONTIGUOUS
@@ -533,7 +534,7 @@ From other objects
     If writing to the value in 'op' is desired, set the boolean
     'writeable' to 1.  This raises an error when 'op' is a scalar, list
     of lists, or other non-writeable 'op'. This differs from passing
-    NPY_ARRAY_WRITEABLE to PyArray_FromAny, where the writeable array may
+    :c:data:`NPY_ARRAY_WRITEABLE` to PyArray_FromAny, where the writeable array may
     be a copy of the input.
 
     When success (0 return value) is returned, either out_arr
@@ -647,7 +648,7 @@ From other objects
     object, *op*, of (non-flexible) type given by the enumerated
     *typenum*, of minimum depth *min_depth*, and of maximum depth
     *max_depth*. Equivalent to a call to :c:func:`PyArray_FromAny` with
-    requirements set to :c:data:`NPY_DEFAULT` and the type_num member of the
+    requirements set to :c:data:`NPY_ARRAY_DEFAULT` and the type_num member of the
     type argument set to *typenum*.
 
 .. c:function:: PyObject *PyArray_FromObject( \
@@ -773,7 +774,7 @@ From other objects
     Similar to :c:func:`PyArray_FromAny` except the data-type is
     specified using a typenumber. :c:func:`PyArray_DescrFromType`
     (*typenum*) is passed directly to :c:func:`PyArray_FromAny`. This
-    macro also adds :c:data:`NPY_DEFAULT` to requirements if
+    macro also adds :c:data:`NPY_ARRAY_DEFAULT` to requirements if
     :c:data:`NPY_ARRAY_ENSURECOPY` is passed in as requirements.
 
 .. c:function:: PyObject *PyArray_CheckAxis( \

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -665,7 +665,7 @@ From other objects
     This function **steals a reference** to ``op`` and makes sure that
     ``op`` is a base-class ndarray. It special cases array scalars,
     but otherwise calls :c:func:`PyArray_FromAny` ( ``op``, NULL, 0, 0,
-    :c:data:`NPY_ARRAY_ENSUREARRAY`).
+    :c:data:`NPY_ARRAY_ENSUREARRAY`, NULL).
 
 .. c:function:: PyObject* PyArray_FromString( \
         char* string, npy_intp slen, PyArray_Descr* dtype, npy_intp num, \

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1362,8 +1362,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         if (PyArray_TYPE(self) == NPY_VOID) {
             int _res;
 
-            array_other = (PyArrayObject *)PyArray_FromAny(other, NULL, 0, 0, 0,
-                                                           NULL);
+            array_other = (PyArrayObject *)PyArray_FROM_O(other);
             /*
              * If not successful, indicate that the items cannot be compared
              * this way.
@@ -1440,8 +1439,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
         if (PyArray_TYPE(self) == NPY_VOID) {
             int _res;
 
-            array_other = (PyArrayObject *)PyArray_FromAny(other, NULL, 0, 0, 0,
-                                                           NULL);
+            array_other = (PyArrayObject *)PyArray_FROM_O(other);
             /*
              * If not successful, indicate that the items cannot be compared
              * this way.

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -874,7 +874,7 @@ static int sequence_to_arrays(PyObject *seq,
             return -1;
         }
 
-        op[i] = (PyArrayObject *)PyArray_FromAny(item, NULL, 0, 0, 0, NULL);
+        op[i] = (PyArrayObject *)PyArray_FROM_O(item);
         if (op[i] == NULL) {
             while (--i >= 0) {
                 Py_DECREF(op[i]);
@@ -1209,8 +1209,7 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
     unravel_size = PyArray_MultiplyList(dimensions.ptr, dimensions.len);
 
     if (!PyArray_Check(indices0)) {
-        indices = (PyArrayObject*)PyArray_FromAny(indices0,
-                                                    NULL, 0, 0, 0, NULL);
+        indices = (PyArrayObject*)PyArray_FROM_O(indices0);
         if (indices == NULL) {
             goto fail;
         }

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -45,8 +45,7 @@ PyArray_Converter(PyObject *object, PyObject **address)
         return NPY_SUCCEED;
     }
     else {
-        *address = PyArray_FromAny(object, NULL, 0, 0,
-                                NPY_ARRAY_CARRAY, NULL);
+        *address = PyArray_FROM_OF(object, NPY_ARRAY_CARRAY);
         if (*address == NULL) {
             return NPY_FAIL;
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2558,7 +2558,7 @@ PyArray_EnsureArray(PyObject *op)
         new = PyArray_FromScalar(op, NULL);
     }
     else {
-        new = PyArray_FromAny(op, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL);
+        new = PyArray_FROM_OF(op, NPY_ARRAY_ENSUREARRAY);
     }
     Py_XDECREF(op);
     return new;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2535,7 +2535,8 @@ PyArray_FromDims(int nd, int *d, int type)
 /* end old calls */
 
 /*NUMPY_API
- * This is a quick wrapper around PyArray_FromAny(op, NULL, 0, 0, ENSUREARRAY)
+ * This is a quick wrapper around
+ * PyArray_FromAny(op, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL)
  * that special cases Arrays and PyArray_Scalars up front
  * It *steals a reference* to the object
  * It also guarantees that the result is PyArray_Type

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -1364,8 +1364,7 @@ array_datetime_as_string(PyObject *NPY_UNUSED(self), PyObject *args,
     /* Claim a reference to timezone for later */
     Py_XINCREF(timezone_obj);
 
-    op[0] = (PyArrayObject *)PyArray_FromAny(arr_in,
-                                    NULL, 0, 0, 0, NULL);
+    op[0] = (PyArrayObject *)PyArray_FROM_O(arr_in);
     if (op[0] == NULL) {
         goto fail;
     }

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -755,7 +755,7 @@ array_real_set(PyArrayObject *self, PyObject *val)
         Py_INCREF(self);
         ret = self;
     }
-    new = (PyArrayObject *)PyArray_FromAny(val, NULL, 0, 0, 0, NULL);
+    new = (PyArrayObject *)PyArray_FROM_O(val);
     if (new == NULL) {
         Py_DECREF(ret);
         return -1;
@@ -816,7 +816,7 @@ array_imag_set(PyArrayObject *self, PyObject *val)
         if (ret == NULL) {
             return -1;
         }
-        new = (PyArrayObject *)PyArray_FromAny(val, NULL, 0, 0, 0, NULL);
+        new = (PyArrayObject *)PyArray_FROM_O(val);
         if (new == NULL) {
             Py_DECREF(ret);
             return -1;

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1553,7 +1553,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args, PyObject *k
             }
         }
         else {
-            arr = PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
+            arr = PyArray_FROM_O(obj);
             if (arr == NULL) {
                 goto fail;
             }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -379,7 +379,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
 
         if (!PyArray_Check(obj)) {
             PyArrayObject *tmp_arr;
-            tmp_arr = (PyArrayObject *)PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
+            tmp_arr = (PyArrayObject *)PyArray_FROM_O(obj);
             if (tmp_arr == NULL) {
                 /* TODO: Should maybe replace the error here? */
                 goto failed_building_indices;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2541,8 +2541,7 @@ einsum_sub_op_from_str(PyObject *args, PyObject **str_obj, char **subscripts,
     for (i = 0; i < nop; ++i) {
         PyObject *obj = PyTuple_GET_ITEM(args, i+1);
 
-        op[i] = (PyArrayObject *)PyArray_FromAny(obj,
-                                NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL);
+        op[i] = (PyArrayObject *)PyArray_FROM_OF(obj, NPY_ARRAY_ENSUREARRAY);
         if (op[i] == NULL) {
             goto fail;
         }
@@ -2683,8 +2682,7 @@ einsum_sub_op_from_lists(PyObject *args,
             }
         }
 
-        op[i] = (PyArrayObject *)PyArray_FromAny(obj,
-                                NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL);
+        op[i] = (PyArrayObject *)PyArray_FROM_OF(obj, NPY_ARRAY_ENSUREARRAY);
         if (op[i] == NULL) {
             goto fail;
         }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -594,8 +594,7 @@ PyArray_Concatenate(PyObject *op, int axis)
             narrays = iarrays;
             goto fail;
         }
-        arrays[iarrays] = (PyArrayObject *)PyArray_FromAny(item, NULL,
-                                            0, 0, 0, NULL);
+        arrays[iarrays] = (PyArrayObject *)PyArray_FROM_O(item);
         Py_DECREF(item);
         if (arrays[iarrays] == NULL) {
             narrays = iarrays;
@@ -1088,7 +1087,7 @@ PyArray_CopyAndTranspose(PyObject *op)
     PyArray_Dims new_axes;
 
     /* Make sure we have an array */
-    arr = (PyArrayObject *)PyArray_FromAny(op, NULL, 0, 0, 0, NULL);
+    arr = (PyArrayObject *)PyArray_FROM_O(op);
     if (arr == NULL) {
         return NULL;
     }
@@ -3085,7 +3084,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     PyArrayObject *arr, *ax, *ay;
     PyObject *ret = NULL;
 
-    arr = (PyArrayObject *)PyArray_FromAny(condition, NULL, 0, 0, 0, NULL);
+    arr = (PyArrayObject *)PyArray_FROM_O(condition);
     if (arr == NULL) {
         return NULL;
     }
@@ -3101,8 +3100,8 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         return NULL;
     }
 
-    ax = (PyArrayObject*)PyArray_FromAny(x, NULL, 0, 0, 0 ,NULL);
-    ay = (PyArrayObject*)PyArray_FromAny(y, NULL, 0, 0, 0 ,NULL);
+    ax = (PyArrayObject*)PyArray_FROM_O(x);
+    ay = (PyArrayObject*)PyArray_FROM_O(y);
     if (ax == NULL || ay == NULL) {
         goto fail;
     }
@@ -3282,8 +3281,7 @@ array_can_cast_safely(PyObject *NPY_UNUSED(self), PyObject *args,
     else if (PyArray_IsScalar(from_obj, Generic) ||
                                 PyArray_IsPythonNumber(from_obj)) {
         PyArrayObject *arr;
-        arr = (PyArrayObject *)PyArray_FromAny(from_obj,
-                                        NULL, 0, 0, 0, NULL);
+        arr = (PyArrayObject *)PyArray_FROM_O(from_obj);
         if (arr == NULL) {
             goto finish;
         }
@@ -3345,7 +3343,7 @@ array_min_scalar_type(PyObject *NPY_UNUSED(dummy), PyObject *args)
         return NULL;
     }
 
-    array = (PyArrayObject *)PyArray_FromAny(array_in, NULL, 0, 0, 0, NULL);
+    array = (PyArrayObject *)PyArray_FROM_O(array_in);
     if (array == NULL) {
         return NULL;
     }
@@ -3385,8 +3383,7 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *args)
         }
         else if (PyArray_IsScalar(obj, Generic) ||
                                     PyArray_IsPythonNumber(obj)) {
-            arr[narr] = (PyArrayObject *)PyArray_FromAny(obj,
-                                        NULL, 0, 0, 0, NULL);
+            arr[narr] = (PyArrayObject *)PyArray_FROM_O(obj);
             if (arr[narr] == NULL) {
                 goto finish;
             }
@@ -3997,7 +3994,7 @@ array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_
     else {
         /* Use FromAny to enable checking overlap for objects exposing array
            interfaces etc. */
-        self = (PyArrayObject*)PyArray_FromAny(self_obj, NULL, 0, 0, 0, NULL);
+        self = (PyArrayObject*)PyArray_FROM_O(self_obj);
         if (self == NULL) {
             goto fail;
         }
@@ -4008,7 +4005,7 @@ array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_
         Py_INCREF(other);
     }
     else {
-        other = (PyArrayObject*)PyArray_FromAny(other_obj, NULL, 0, 0, 0, NULL);
+        other = (PyArrayObject*)PyArray_FROM_O(other_obj);
         if (other == NULL) {
             goto fail;
         }

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -694,8 +694,8 @@ npyiter_convert_ops(PyObject *op_in, PyObject *op_flags_in,
             if (op_flags[iop]&(NPY_ITER_READWRITE|NPY_ITER_WRITEONLY)) {
                 fromanyflags |= NPY_ARRAY_UPDATEIFCOPY;
             }
-            ao = (PyArrayObject *)PyArray_FromAny((PyObject *)op[iop],
-                                            NULL, 0, 0, fromanyflags, NULL);
+            ao = (PyArrayObject *)PyArray_FROM_OF((PyObject *)op[iop],
+                                                  fromanyflags);
             if (ao == NULL) {
                 if (PyErr_Occurred() &&
                             PyErr_ExceptionMatches(PyExc_TypeError)) {


### PR DESCRIPTION
If we have these defined, we may as well use the internally, right?