### PR TITLE
BUG: return values of exec_command were swapped

### DIFF
--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -252,7 +252,7 @@ def _exec_command(command, use_shell=None, use_tee = None, **env):
                                 universal_newlines=True)
     except EnvironmentError:
         # Return 127, as os.spawn*() and /bin/sh do
-        return '', 127
+        return 127, ''
     text, err = proc.communicate()
     # Another historical oddity
     if text[-1:] == '\n':


### PR DESCRIPTION
This caused a nonsensical failure on my windows machine.

The failure are still there, but at least the complaint is not "return code is `""`, expected 0".

It seems that `cd '.'` is not a valid command on windows, due to quoting