### PR TITLE
API: Change default axis argument for argsort.

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -20,6 +20,10 @@ Dropped Support
 Deprecations
 ============
 
+ * ``np.ma.argsort`` should be called with an explicit `axis` argument when
+   applied to arrays with more than 2 dimensions, as the default value of
+   this argument (``None``) is inconsistent with the rest of numpy (``-1``).
+
 
 Build System Changes
 ====================

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -93,33 +93,6 @@ nomask = MaskType(0)
 class MaskedArrayFutureWarning(FutureWarning):
     pass
 
-def _deprecate_argsort_axis(arr, axis):
-    """
-    Takes the array argsort was called upon, and the axis argument
-    it was called with.
-
-    np.ma.argsort has a long-term bug where the default of the axis argument
-    is wrong (gh-8701), which now must be kept for backwards compatibiity.
-    Thankfully, this only makes a difference when arrays are 2- or more-
-    dimensional, so we only need a warning then.
-    """
-    if axis is np._NoValue:
-        if arr.ndim <= 1:
-            # no warning needed - switch to -1 to avoid surprising subclasses
-            return -1
-        else:
-            # 2017-04-10, numpy 1.13.0
-            warnings.warn(
-                "Unlike np.argsort, np.sort, np.ma.sort, and the "
-                "documentation for this function, the default is "
-                "axis=None, not axis=-1. In future, the default will be "
-                "-1. To squash this warning, specify the axis argument "
-                "explicitly.",
-                MaskedArrayFutureWarning, stacklevel=2)
-            return None
-    else:
-        return axis
-
 
 def doc_note(initialdoc, note):
     """
@@ -5255,7 +5228,7 @@ class MaskedArray(ndarray):
             out.__setmask__(self._mask)
         return out
 
-    def argsort(self, axis=np._NoValue, kind='quicksort', order=None,
+    def argsort(self, axis=-1, kind='quicksort', order=None,
                 endwith=True, fill_value=None):
         """
         Return an ndarray of indices that sort the array along the
@@ -5310,8 +5283,6 @@ class MaskedArray(ndarray):
         array([1, 0, 2])
 
         """
-
-        axis = _deprecate_argsort_axis(self, axis)
 
         if fill_value is None:
             if endwith:
@@ -6532,10 +6503,9 @@ def power(a, b, third=None):
 argmin = _frommethod('argmin')
 argmax = _frommethod('argmax')
 
-def argsort(a, axis=np._NoValue, kind='quicksort', order=None, endwith=True, fill_value=None):
+def argsort(a, axis=-1, kind='quicksort', order=None, endwith=True, fill_value=None):
     "Function version of the eponymous method."
     a = np.asanyarray(a)
-    axis = _deprecate_argsort_axis(a, axis)
 
     if isinstance(a, MaskedArray):
         return a.argsort(axis=axis, kind=kind, order=order,

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -8,34 +8,5 @@ from numpy.testing import TestCase, run_module_suite, assert_warns
 from numpy.ma.testutils import assert_equal
 
 
-class TestArgsort(TestCase):
-	""" gh-8701 """
-	def _test_base(self, argsort, cls):
-		arr_0d = np.array(1).view(cls)
-		argsort(arr_0d)
-
-		arr_1d = np.array([1, 2, 3]).view(cls)
-		argsort(arr_1d)
-
-		# argsort has a bad default for >1d arrays
-		arr_2d = np.array([[1, 2], [3, 4]]).view(cls)
-		result = assert_warns(
-			np.ma.core.MaskedArrayFutureWarning, argsort, arr_2d)
-		assert_equal(result, argsort(arr_2d, axis=None))
-
-		# should be no warnings for explictly specifiying it
-		argsort(arr_2d, axis=None)
-		argsort(arr_2d, axis=-1)
-
-	def test_function_ndarray(self):
-		return self._test_base(np.ma.argsort, np.ndarray)
-
-	def test_function_maskedarray(self):
-		return self._test_base(np.ma.argsort, np.ma.MaskedArray)
-
-	def test_method(self):
-		return self._test_base(np.ma.MaskedArray.argsort, np.ma.MaskedArray)
-
-
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -1,0 +1,41 @@
+"""Test deprecation and future warnings.
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from numpy.testing import TestCase, run_module_suite, assert_warns
+from numpy.ma.testutils import assert_equal
+
+
+class TestArgsort(TestCase):
+	""" gh-8701 """
+	def _test_base(self, argsort, cls):
+		arr_0d = np.array(1).view(cls)
+		argsort(arr_0d)
+
+		arr_1d = np.array([1, 2, 3]).view(cls)
+		argsort(arr_1d)
+
+		# argsort has a bad default for >1d arrays
+		arr_2d = np.array([[1, 2], [3, 4]]).view(cls)
+		result = assert_warns(
+			np.ma.core.MaskedArrayFutureWarning, argsort, arr_2d)
+		assert_equal(result, argsort(arr_2d, axis=None))
+
+		# should be no warnings for explictly specifiying it
+		argsort(arr_2d, axis=None)
+		argsort(arr_2d, axis=-1)
+
+	def test_function_ndarray(self):
+		return self._test_base(np.ma.argsort, np.ndarray)
+
+	def test_function_maskedarray(self):
+		return self._test_base(np.ma.argsort, np.ma.MaskedArray)
+
+	def test_method(self):
+		return self._test_base(np.ma.MaskedArray.argsort, np.ma.MaskedArray)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Now matches:
 * its own documentation
 * everything else

Fixes #8701 

---

Should this be considered a breaking change? Do we want to go through a deprecation cycle that requires this argument to be specified explicitly when needed? Something like \<snip\> #8918 

Continuing from a forgotten discussion with @juliantaylor at https://github.com/numpy/numpy/pull/8678#discussion_r102762155