### PR TITLE
COMPAT: notify garbage collector when memory is allocated

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -39,7 +39,19 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
             return cache[nelem].ptrs[--(cache[nelem].available)];
         }
     }
-    return alloc(nelem * esz);
+#ifdef _PyPyGC_AddMemoryPressure
+    {
+        size_t size = nelem * esz;
+        void * ret = alloc(size);
+        if (ret != NULL)
+        {
+            _PyPyPyGC_AddMemoryPressure(size);
+        }
+        return ret;
+    }
+#else
+     return alloc(nelem * esz);
+#endif
 }
 
 /*


### PR DESCRIPTION
PyPy's garbage collector (GC) starts a cycle based on an algorithm that takes into account allocated memory. It must be told about allocations outside of python. This patch triggers more frequent GC cycles when ndarrays are allocated in a tight loop, which while not efficient will now at least run to completion without allocating all the free memory in the system.