### PR TITLE
ENH: avoid allocations in getmaskarray

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2556,7 +2556,7 @@ def flatten_structured_array(a):
         out = np.array([tuple(flatten_sequence(d.item())) for d in a._data])
         out = out.view(MaskedArray)
         out._mask = np.array([tuple(flatten_sequence(d.item()))
-                              for d in getmaskarray(a)])
+                              for d in _viewmaskarray(a)])
     else:
         out = np.array([tuple(flatten_sequence(d.item())) for d in a])
     if len(inishape) > 1:


### PR DESCRIPTION
Public API still has to return a full array, but we can avoid a lot of copying and memory by returning `np.broadcast_to(np.zeros((), dtype), shape)` instead of `np.zeros(dtype, shape)` when `arr.mask is nomask`.

This seems to add 2us overhead for small arrays, and starts to break even at around 10000 elements

Most of the time here is lost to the `ndarray` constructor, when really all we want to do is modify `->strides` and `->shape` without checking