### PR TITLE
BUG: check_api_dict does not correctly handle tuple values

### DIFF
--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -417,14 +417,17 @@ def merge_api_dicts(dicts):
 
 def check_api_dict(d):
     """Check that an api dict is valid (does not use the same index twice)."""
+    # remove the extra value fields that aren't the index
+    index_d = {k: v[0] for k, v in d.items()}
+
     # We have if a same index is used twice: we 'revert' the dict so that index
     # become keys. If the length is different, it means one index has been used
     # at least twice
-    revert_dict = dict([(v, k) for k, v in d.items()])
-    if not len(revert_dict) == len(d):
+    revert_dict = {v: k for k, v in index_d.items()}
+    if not len(revert_dict) == len(index_d):
         # We compute a dict index -> list of associated items
         doubled = {}
-        for name, index in d.items():
+        for name, index in index_d.items():
             try:
                 doubled[index].append(name)
             except KeyError:
@@ -436,9 +439,9 @@ Same index has been used twice in api definition: %s
         raise ValueError(msg)
 
     # No 'hole' in the indexes may be allowed, and it must starts at 0
-    indexes = set(v[0] for v in d.values())
+    indexes = set(index_d.values())
     expected = set(range(len(indexes)))
-    if not indexes == expected:
+    if indexes != expected:
         diff = expected.symmetric_difference(indexes)
         msg = "There are some holes in the API indexing: " \
               "(symmetric diff is %s)" % diff

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -432,13 +432,12 @@ def check_api_dict(d):
                 doubled[index].append(name)
             except KeyError:
                 doubled[index] = [name]
-        msg = "Same index has been used twice in api definition: {}".format(
-            ''.join(
-                '\n\tindex %d -> %s' % (index, names)
-                for index, names in doubled.items() if len(names) != 1
-            )
+        fmt = "Same index has been used twice in api definition: {}"
+        val = ''.join(
+            '\n\tindex {} -> {}'.format(index, names)
+            for index, names in doubled.items() if len(names) != 1
         )
-        raise ValueError(msg)
+        raise ValueError(fmt.format(val))
 
     # No 'hole' in the indexes may be allowed, and it must starts at 0
     indexes = set(index_d.values())

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -432,10 +432,12 @@ def check_api_dict(d):
                 doubled[index].append(name)
             except KeyError:
                 doubled[index] = [name]
-        msg = """\
-Same index has been used twice in api definition: %s
-""" % ['index %d -> %s' % (index, names) for index, names in doubled.items() \
-                                          if len(names) != 1]
+        msg = "Same index has been used twice in api definition: {}".format(
+            ''.join(
+                '\n\tindex %d -> %s' % (index, names)
+                for index, names in doubled.items() if len(names) != 1
+            )
+        )
         raise ValueError(msg)
 
     # No 'hole' in the indexes may be allowed, and it must starts at 0


### PR DESCRIPTION
It seems that at some point we augmented the indices with extra data. But this
data should not be included when determining uniqueness.

Previously, this would crash if there actually was a collision, rather than
printing a useful message