### PR TITLE
DEP: deprecate calling ma.argsort without an axis

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -28,6 +28,9 @@ Deprecations
 * Use of the C-API ``NPY_CHAR`` type number deprecated since version 1.7 will
   now raise deprecation warnings at runtime. Extensions built with older f2py
   versions need to be recompiled to remove the warning.
+* ``np.ma.argsort`` should be called with an explicit `axis` argument when
+  applied to arrays with more than 2 dimensions, as the default value of
+  this argument (``None``) is inconsistent with the rest of numpy (``-1``).
 
 
 Build System Changes

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -1,0 +1,41 @@
+"""Test deprecation and future warnings.
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from numpy.testing import TestCase, run_module_suite, assert_warns
+from numpy.ma.testutils import assert_equal
+
+
+class TestArgsort(TestCase):
+	""" gh-8701 """
+	def _test_base(self, argsort, cls):
+		arr_0d = np.array(1).view(cls)
+		argsort(arr_0d)
+
+		arr_1d = np.array([1, 2, 3]).view(cls)
+		argsort(arr_1d)
+
+		# argsort has a bad default for >1d arrays
+		arr_2d = np.array([[1, 2], [3, 4]]).view(cls)
+		result = assert_warns(
+			np.ma.core.MaskedArrayFutureWarning, argsort, arr_2d)
+		assert_equal(result, argsort(arr_2d, axis=None))
+
+		# should be no warnings for explictly specifiying it
+		argsort(arr_2d, axis=None)
+		argsort(arr_2d, axis=-1)
+
+	def test_function_ndarray(self):
+		return self._test_base(np.ma.argsort, np.ndarray)
+
+	def test_function_maskedarray(self):
+		return self._test_base(np.ma.argsort, np.ma.MaskedArray)
+
+	def test_method(self):
+		return self._test_base(np.ma.MaskedArray.argsort, np.ma.MaskedArray)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Only deprecated when this would be ambiguous.

Approaches #8701