### PR TITLE
MAINT, TST: Remove duplicated code for testing the two types of deprecation warning

### DIFF
--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -22,10 +22,11 @@ except ImportError:
     _has_pytz = False
 
 
-class _VisibleDeprecationTestCase(object):
+class _DeprecationTestCase(object):
     # Just as warning: warnings uses re.match, so the start of this message
     # must match.
     message = ''
+    warning_cls = DeprecationWarning
 
     def setUp(self):
         self.warn_ctx = warnings.catch_warnings(record=True)
@@ -37,119 +38,17 @@ class _VisibleDeprecationTestCase(object):
         # try to keep the tests cleanly giving only the right warning type.
         # (While checking them set to "error" those are ignored anyway)
         # We still have them show up, because otherwise they would be raised
-        warnings.filterwarnings("always", category=np.VisibleDeprecationWarning)
+        warnings.filterwarnings("always", category=self.warning_cls)
         warnings.filterwarnings("always", message=self.message,
-                                category=np.VisibleDeprecationWarning)
+                                category=self.warning_cls)
 
     def tearDown(self):
         self.warn_ctx.__exit__()
 
     def assert_deprecated(self, function, num=1, ignore_others=False,
                           function_fails=False,
-                          exceptions=(np.VisibleDeprecationWarning,),
+                          exceptions=np._NoValue,
                           args=(), kwargs={}):
-        """Test if VisibleDeprecationWarnings are given and raised.
-
-        This first checks if the function when called gives `num`
-        VisibleDeprecationWarnings, after that it tries to raise these
-        VisibleDeprecationWarnings and compares them with `exceptions`.
-        The exceptions can be different for cases where this code path
-        is simply not anticipated and the exception is replaced.
-
-        Parameters
-        ----------
-        function : callable
-            The function to test
-        num : int
-            Number of VisibleDeprecationWarnings to expect. This should
-            normally be 1.
-        ignore_others : bool
-            Whether warnings of the wrong type should be ignored (note that
-            the message is not checked)
-        function_fails : bool
-            If the function would normally fail, setting this will check for
-            warnings inside a try/except block.
-        exceptions : Exception or tuple of Exceptions
-            Exception to expect when turning the warnings into an error.
-            The default checks for DeprecationWarnings. If exceptions is
-            empty the function is expected to run successfully.
-        args : tuple
-            Arguments for `function`
-        kwargs : dict
-            Keyword arguments for `function`
-        """
-        # reset the log
-        self.log[:] = []
-
-        try:
-            function(*args, **kwargs)
-        except (Exception if function_fails else tuple()):
-            pass
-
-        # just in case, clear the registry
-        num_found = 0
-        for warning in self.log:
-            if warning.category is np.VisibleDeprecationWarning:
-                num_found += 1
-            elif not ignore_others:
-                raise AssertionError(
-                        "expected DeprecationWarning but got: %s" %
-                        (warning.category,))
-        if num is not None and num_found != num:
-            msg = "%i warnings found but %i expected." % (len(self.log), num)
-            lst = [w.category for w in self.log]
-            raise AssertionError("\n".join([msg] + lst))
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error", message=self.message,
-                                    category=np.VisibleDeprecationWarning)
-            try:
-                function(*args, **kwargs)
-                if exceptions != tuple():
-                    raise AssertionError(
-                            "No error raised during function call")
-            except exceptions:
-                if exceptions == tuple():
-                    raise AssertionError(
-                            "Error raised during function call")
-
-    def assert_not_deprecated(self, function, args=(), kwargs={}):
-        """Test if VisibleDeprecationWarnings are given and raised.
-
-        This is just a shorthand for:
-
-        self.assert_deprecated(function, num=0, ignore_others=True,
-                        exceptions=tuple(), args=args, kwargs=kwargs)
-        """
-        self.assert_deprecated(function, num=0, ignore_others=True,
-                        exceptions=tuple(), args=args, kwargs=kwargs)
-
-
-class _DeprecationTestCase(object):
-    # Just as warning: warnings uses re.match, so the start of this message
-    # must match.
-    message = ''
-
-    def setUp(self):
-        self.warn_ctx = warnings.catch_warnings(record=True)
-        self.log = self.warn_ctx.__enter__()
-
-        # Do *not* ignore other DeprecationWarnings. Ignoring warnings
-        # can give very confusing results because of
-        # http://bugs.python.org/issue4180 and it is probably simplest to
-        # try to keep the tests cleanly giving only the right warning type.
-        # (While checking them set to "error" those are ignored anyway)
-        # We still have them show up, because otherwise they would be raised
-        warnings.filterwarnings("always", category=DeprecationWarning)
-        warnings.filterwarnings("always", message=self.message,
-                                    category=DeprecationWarning)
-
-    def tearDown(self):
-        self.warn_ctx.__exit__()
-
-    def assert_deprecated(self, function, num=1, ignore_others=False,
-                        function_fails=False,
-                        exceptions=(DeprecationWarning,), args=(), kwargs={}):
         """Test if DeprecationWarnings are given and raised.
 
         This first checks if the function when called gives `num`
@@ -182,6 +81,9 @@ class _DeprecationTestCase(object):
         # reset the log
         self.log[:] = []
 
+        if exceptions is np._NoValue:
+            exceptions = (self.warning_cls,)
+
         try:
             function(*args, **kwargs)
         except (Exception if function_fails else tuple()):
@@ -190,12 +92,12 @@ class _DeprecationTestCase(object):
         # just in case, clear the registry
         num_found = 0
         for warning in self.log:
-            if warning.category is DeprecationWarning:
+            if warning.category is self.warning_cls:
                 num_found += 1
             elif not ignore_others:
                 raise AssertionError(
-                        "expected DeprecationWarning but got: %s" %
-                        (warning.category,))
+                        "expected %s but got: %s" %
+                        (self.warning_cls.__name__, warning.category))
         if num is not None and num_found != num:
             msg = "%i warnings found but %i expected." % (len(self.log), num)
             lst = [str(w.category) for w in self.log]
@@ -203,7 +105,7 @@ class _DeprecationTestCase(object):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message=self.message,
-                                    category=DeprecationWarning)
+                                    category=self.warning_cls)
             try:
                 function(*args, **kwargs)
                 if exceptions != tuple():
@@ -215,7 +117,7 @@ class _DeprecationTestCase(object):
                             "Error raised during function call")
 
     def assert_not_deprecated(self, function, args=(), kwargs={}):
-        """Test if DeprecationWarnings are given and raised.
+        """Test that warnings are not raised.
 
         This is just a shorthand for:
 
@@ -224,6 +126,10 @@ class _DeprecationTestCase(object):
         """
         self.assert_deprecated(function, num=0, ignore_others=True,
                         exceptions=tuple(), args=args, kwargs=kwargs)
+
+
+class _VisibleDeprecationTestCase(_DeprecationTestCase):
+    warning_cls = np.VisibleDeprecationWarning
 
 
 class TestRankDeprecation(_DeprecationTestCase):


### PR DESCRIPTION
AFAICT, these two classes [were exact copy-pastes](https://www.diffchecker.com/V4AnyB1o), with `DeprecationWarning` changed to `VisibleDeprecationWarning`