### PR TITLE
ENH: use caching memory allocator in more places

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -126,8 +126,11 @@ npy_free_cache(void * p, npy_uintp sz)
 NPY_NO_EXPORT void *
 npy_alloc_cache_dim(npy_uintp sz)
 {
-    /* dims + strides */
-    if (NPY_UNLIKELY(sz < 2)) {
+    /*
+     * make sure any temporary allocation can be used for array metadata which
+     * uses one memory block for both dimensions and strides
+     */
+    if (sz < 2) {
         sz = 2;
     }
     return _npy_alloc_cache(sz, sizeof(npy_intp), NBUCKETS_DIM, dimcache,
@@ -137,8 +140,8 @@ npy_alloc_cache_dim(npy_uintp sz)
 NPY_NO_EXPORT void
 npy_free_cache_dim(void * p, npy_uintp sz)
 {
-    /* dims + strides */
-    if (NPY_UNLIKELY(sz < 2)) {
+    /* see npy_alloc_cache_dim */
+    if (sz < 2) {
         sz = 2;
     }
     _npy_free_cache(p, sz, NBUCKETS_DIM, dimcache,

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -21,4 +21,16 @@ npy_alloc_cache_dim(npy_uintp sz);
 NPY_NO_EXPORT void
 npy_free_cache_dim(void * p, npy_uintp sd);
 
+static NPY_INLINE void
+npy_free_cache_dim_obj(PyArray_Dims dims)
+{
+    npy_free_cache_dim(dims.ptr, dims.len);
+}
+
+static NPY_INLINE void
+npy_free_cache_dim_array(PyArrayObject * arr)
+{
+    npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+}
+
 #endif

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1518,14 +1518,14 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
         }
     }
 
-    PyDimMem_FREE(dims.ptr);
-    PyDimMem_FREE(strides.ptr);
+    npy_free_cache_dim_obj(dims);
+    npy_free_cache_dim_obj(strides);
     return (PyObject *)ret;
 
  fail:
     Py_XDECREF(descr);
-    PyDimMem_FREE(dims.ptr);
-    PyDimMem_FREE(strides.ptr);
+    npy_free_cache_dim_obj(dims);
+    npy_free_cache_dim_obj(strides);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -700,7 +700,7 @@ VOID_getitem(void *input, void *vap)
         PyArrayObject *ret;
 
         if (!(PyArray_IntpConverter(descr->subarray->shape, &shape))) {
-            PyDimMem_FREE(shape.ptr);
+            npy_free_cache_dim_obj(shape);
             PyErr_SetString(PyExc_ValueError,
                     "invalid shape in fixed-type tuple.");
             return NULL;
@@ -709,7 +709,7 @@ VOID_getitem(void *input, void *vap)
         ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type,
                 descr->subarray->base, shape.len, shape.ptr,
                 NULL, ip, PyArray_FLAGS(ap)&(~NPY_ARRAY_F_CONTIGUOUS), NULL);
-        PyDimMem_FREE(shape.ptr);
+        npy_free_cache_dim_obj(shape);
         if (!ret) {
             return NULL;
         }
@@ -838,7 +838,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
         PyArray_Dims shape = {NULL, -1};
         PyArrayObject *ret;
         if (!(PyArray_IntpConverter(descr->subarray->shape, &shape))) {
-            PyDimMem_FREE(shape.ptr);
+            npy_free_cache_dim_obj(shape);
             PyErr_SetString(PyExc_ValueError,
                     "invalid shape in fixed-type tuple.");
             return -1;
@@ -847,7 +847,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
         ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type,
                         descr->subarray->base, shape.len, shape.ptr,
                         NULL, ip, PyArray_FLAGS(ap), NULL);
-        PyDimMem_FREE(shape.ptr);
+        npy_free_cache_dim_obj(shape);
         if (!ret) {
             return -1;
         }

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -10,6 +10,7 @@
 #include "npy_config.h"
 #include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "lowlevel_strided_loops.h" /* for npy_bswap8 */
+#include "alloc.h"
 
 
 /*
@@ -1091,7 +1092,7 @@ arr_ravel_multi_index(PyObject *self, PyObject *args, PyObject *kwds)
     for (i = 0; i < dimensions.len; ++i) {
         Py_XDECREF(op[i]);
     }
-    PyDimMem_FREE(dimensions.ptr);
+    npy_free_cache_dim_obj(dimensions);
     NpyIter_Deallocate(iter);
     return PyArray_Return(ret);
 
@@ -1100,7 +1101,7 @@ fail:
     for (i = 0; i < dimensions.len; ++i) {
         Py_XDECREF(op[i]);
     }
-    PyDimMem_FREE(dimensions.ptr);
+    npy_free_cache_dim_obj(dimensions);
     NpyIter_Deallocate(iter);
     return NULL;
 }
@@ -1352,7 +1353,7 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
 
     Py_DECREF(ret_arr);
     Py_XDECREF(indices);
-    PyDimMem_FREE(dimensions.ptr);
+    npy_free_cache_dim_obj(dimensions);
     NpyIter_Deallocate(iter);
 
     return ret_tuple;
@@ -1362,7 +1363,7 @@ fail:
     Py_XDECREF(ret_arr);
     Py_XDECREF(dtype);
     Py_XDECREF(indices);
-    PyDimMem_FREE(dimensions.ptr);
+    npy_free_cache_dim_obj(dimensions);
     NpyIter_Deallocate(iter);
     return NULL;
 }

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -15,6 +15,7 @@
 #include "arraytypes.h"
 
 #include "conversion_utils.h"
+#include "alloc.h"
 
 static int
 PyArray_PyIntAsInt_ErrMsg(PyObject *o, const char * msg) NPY_GCC_NONNULL(2);
@@ -119,7 +120,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
         return NPY_FAIL;
     }
     if (len > 0) {
-        seq->ptr = PyDimMem_NEW(len);
+        seq->ptr = npy_alloc_cache_dim(len);
         if (seq->ptr == NULL) {
             PyErr_NoMemory();
             return NPY_FAIL;
@@ -128,7 +129,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
     seq->len = len;
     nd = PyArray_IntpFromIndexSequence(obj, (npy_intp *)seq->ptr, len);
     if (nd == -1 || nd != len) {
-        PyDimMem_FREE(seq->ptr);
+        npy_free_cache_dim_obj(*seq);
         seq->ptr = NULL;
         return NPY_FAIL;
     }

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -23,6 +23,7 @@
 #include "npy_sort.h"
 #include "npy_partition.h"
 #include "npy_binsearch.h"
+#include "alloc.h"
 
 /*NUMPY_API
  * Take
@@ -765,7 +766,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
         Py_XDECREF(mps[i]);
     }
     Py_DECREF(ap);
-    PyDataMem_FREE(mps);
+    npy_free_cache(mps, n * sizeof(mps[0]));
     if (out != NULL && out != obj) {
         Py_INCREF(out);
         Py_DECREF(obj);
@@ -779,7 +780,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
         Py_XDECREF(mps[i]);
     }
     Py_XDECREF(ap);
-    PyDataMem_FREE(mps);
+    npy_free_cache(mps, n * sizeof(mps[0]));
     PyArray_XDECREF_ERR(obj);
     return NULL;
 }
@@ -827,7 +828,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(op));
 
     if (needcopy) {
-        buffer = PyDataMem_NEW(N * elsize);
+        buffer = npy_alloc_cache(N * elsize);
         if (buffer == NULL) {
             ret = -1;
             goto fail;
@@ -914,7 +915,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     }
 
 fail:
-    PyDataMem_FREE(buffer);
+    npy_free_cache(buffer, N * elsize);
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
     if (ret < 0 && !PyErr_Occurred()) {
         /* Out of memory during sorting or buffer creation */
@@ -978,7 +979,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(op));
 
     if (needcopy) {
-        valbuffer = PyDataMem_NEW(N * elsize);
+        valbuffer = npy_alloc_cache(N * elsize);
         if (valbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -986,7 +987,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     }
 
     if (needidxbuffer) {
-        idxbuffer = (npy_intp *)PyDataMem_NEW(N * sizeof(npy_intp));
+        idxbuffer = (npy_intp *)npy_alloc_cache(N * sizeof(npy_intp));
         if (idxbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1076,8 +1077,8 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     }
 
 fail:
-    PyDataMem_FREE(valbuffer);
-    PyDataMem_FREE(idxbuffer);
+    npy_free_cache(valbuffer, N * elsize);
+    npy_free_cache(idxbuffer, N * sizeof(npy_intp));
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
     if (ret < 0) {
         if (!PyErr_Occurred()) {
@@ -1493,13 +1494,13 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
         char *valbuffer, *indbuffer;
         int *swaps;
 
-        valbuffer = PyDataMem_NEW(N*maxelsize);
+        valbuffer = npy_alloc_cache(N * maxelsize);
         if (valbuffer == NULL) {
             goto fail;
         }
-        indbuffer = PyDataMem_NEW(N*sizeof(npy_intp));
+        indbuffer = npy_alloc_cache(N * sizeof(npy_intp));
         if (indbuffer == NULL) {
-            PyDataMem_FREE(indbuffer);
+            npy_free_cache(indbuffer, N * sizeof(npy_intp));
             goto fail;
         }
         swaps = malloc(n*sizeof(int));
@@ -1531,8 +1532,8 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
 #else
                 if (rcode < 0) {
 #endif
-                    PyDataMem_FREE(valbuffer);
-                    PyDataMem_FREE(indbuffer);
+                    npy_free_cache(valbuffer, N * maxelsize);
+                    npy_free_cache(indbuffer, N * sizeof(npy_intp));
                     free(swaps);
                     goto fail;
                 }
@@ -1542,8 +1543,8 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                                          sizeof(npy_intp), N, sizeof(npy_intp));
             PyArray_ITER_NEXT(rit);
         }
-        PyDataMem_FREE(valbuffer);
-        PyDataMem_FREE(indbuffer);
+        npy_free_cache(valbuffer, N * maxelsize);
+        npy_free_cache(indbuffer, N * sizeof(npy_intp));
         free(swaps);
     }
     else {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1853,12 +1853,12 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     ret = (PyArrayObject *)PyArray_Empty(shape.len, shape.ptr,
                                             typecode, is_f_order);
 
-    PyDimMem_FREE(shape.ptr);
+    npy_free_cache_dim_obj(shape);
     return (PyObject *)ret;
 
 fail:
     Py_XDECREF(typecode);
-    PyDimMem_FREE(shape.ptr);
+    npy_free_cache_dim_obj(shape);
     return NULL;
 }
 
@@ -2007,12 +2007,12 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     ret = (PyArrayObject *)PyArray_Zeros(shape.len, shape.ptr,
                                         typecode, (int) is_f_order);
 
-    PyDimMem_FREE(shape.ptr);
+    npy_free_cache_dim_obj(shape);
     return (PyObject *)ret;
 
 fail:
     Py_XDECREF(typecode);
-    PyDimMem_FREE(shape.ptr);
+    npy_free_cache_dim_obj(shape);
     return (PyObject *)ret;
 }
 
@@ -2947,7 +2947,7 @@ array__reconstruct(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
     ret = PyArray_NewFromDescr(subtype, dtype,
             (int)shape.len, shape.ptr, NULL, NULL, 0, NULL);
-    PyDimMem_FREE(shape.ptr);
+    npy_free_cache_dim_obj(shape);
 
     evil_global_disable_warn_O4O8_flag = 0;
 
@@ -2957,7 +2957,7 @@ fail:
     evil_global_disable_warn_O4O8_flag = 0;
 
     Py_XDECREF(dtype);
-    PyDimMem_FREE(shape.ptr);
+    npy_free_cache_dim_obj(shape);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -15,6 +15,7 @@
 #include <numpy/arrayobject.h>
 #include "npy_config.h"
 #include "npy_pycompat.h"
+#include "alloc.h"
 
 typedef struct NewNpyArrayIterObject_tag NewNpyArrayIterObject;
 
@@ -758,7 +759,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
                     &op_axes_in,
                     PyArray_IntpConverter, &itershape,
                     &buffersize)) {
-        PyDimMem_FREE(itershape.ptr);
+        npy_free_cache_dim_obj(itershape);
         return -1;
     }
 
@@ -804,7 +805,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
         }
     }
     else if (itershape.ptr != NULL) {
-        PyDimMem_FREE(itershape.ptr);
+        npy_free_cache_dim_obj(itershape);
         itershape.ptr = NULL;
     }
 
@@ -832,7 +833,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
         self->finished = 0;
     }
 
-    PyDimMem_FREE(itershape.ptr);
+    npy_free_cache_dim_obj(itershape);
 
     /* Release the references we got to the ops and dtypes */
     for (iop = 0; iop < nop; ++iop) {
@@ -843,7 +844,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     return 0;
 
 fail:
-    PyDimMem_FREE(itershape.ptr);
+    npy_free_cache_dim_obj(itershape);
     for (iop = 0; iop < nop; ++iop) {
         Py_XDECREF(op[iop]);
         Py_XDECREF(op_request_dtypes[iop]);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -24,6 +24,7 @@
 #include "scalartypes.h"
 #include "_datetime.h"
 #include "datetime_strings.h"
+#include "alloc.h"
 
 #include <stdlib.h>
 
@@ -1356,10 +1357,9 @@ gentype_imag_get(PyObject *self)
         int elsize;
         typecode = PyArray_DescrFromScalar(self);
         elsize = typecode->elsize;
-        temp = PyDataMem_NEW(elsize);
-        memset(temp, '\0', elsize);
+        temp = npy_alloc_cache_zero(elsize);
         ret = PyArray_Scalar(temp, typecode, NULL);
-        PyDataMem_FREE(temp);
+        npy_free_cache(temp, elsize);
     }
 
     Py_XDECREF(typecode);
@@ -2488,7 +2488,7 @@ static void
 void_dealloc(PyVoidScalarObject *v)
 {
     if (v->flags & NPY_ARRAY_OWNDATA) {
-        PyDataMem_FREE(v->obval);
+        npy_free_cache(v->obval, Py_SIZE(v));
     }
     Py_XDECREF(v->descr);
     Py_XDECREF(v->base);
@@ -2904,9 +2904,7 @@ static PyObject *
 void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
 {
     PyObject *obj, *arr;
-    npy_ulonglong memu = 1;
     PyObject *new = NULL;
-    char *destptr;
 
     if (!PyArg_ParseTuple(args, "O:void", &obj)) {
         return NULL;
@@ -2928,7 +2926,8 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
     }
     if (new && PyLong_Check(new)) {
         PyObject *ret;
-        memu = PyLong_AsUnsignedLongLong(new);
+        char *destptr;
+        npy_ulonglong memu = PyLong_AsUnsignedLongLong(new);
         Py_DECREF(new);
         if (PyErr_Occurred() || (memu > NPY_MAX_INT)) {
             PyErr_Clear();
@@ -2937,13 +2936,13 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
                     (int) NPY_MAX_INT);
             return NULL;
         }
-        destptr = PyDataMem_NEW((int) memu);
+        destptr = npy_alloc_cache_zero(memu);
         if (destptr == NULL) {
             return PyErr_NoMemory();
         }
         ret = type->tp_alloc(type, 0);
         if (ret == NULL) {
-            PyDataMem_FREE(destptr);
+            npy_free_cache(destptr, memu);
             return PyErr_NoMemory();
         }
         ((PyVoidScalarObject *)ret)->obval = destptr;
@@ -2954,7 +2953,6 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
         ((PyVoidScalarObject *)ret)->flags = NPY_ARRAY_BEHAVED |
                                              NPY_ARRAY_OWNDATA;
         ((PyVoidScalarObject *)ret)->base = NULL;
-        memset(destptr, '\0', (size_t) memu);
         return ret;
     }
 

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -19,6 +19,7 @@
 
 #include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "common.h" /* for convert_shape_to_string */
+#include "alloc.h"
 
 static int
 _fix_unknown_dimension(PyArray_Dims *newshape, PyArrayObject *arr);
@@ -316,7 +317,7 @@ PyArray_Reshape(PyArrayObject *self, PyObject *shape)
         return NULL;
     }
     ret = PyArray_Newshape(self, &newdims, NPY_CORDER);
-    PyDimMem_FREE(newdims.ptr);
+    npy_free_cache_dim_obj(newdims);
     return ret;
 }
 


### PR DESCRIPTION
In particular use it in PyArray_IntpConverter which is used in many
function entrypoints.