### PR TITLE
MAINT: avoid memcpy when i == j

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4828,6 +4828,7 @@ cdef class RandomState:
         cdef npy_intp i, j
         for i in reversed(range(1, n)):
             j = rk_interval(i, self.internal_state)
+            if i == j : continue # i == j is not needed and memcpy is undefined.
             string.memcpy(buf, data + j * stride, itemsize)
             string.memcpy(data + j * stride, data + i * stride, itemsize)
             string.memcpy(data + i * stride, buf, itemsize)


### PR DESCRIPTION
Valgrind complains about memcpy with overlapping address in mtrand.c
It happens when i == j in this loop.

Closer inspection the i == j iteration is not needed (it is a swap).
So, skip it and avoid depending on undefined behavior of memcpy.

related read:

https://sourceware.org/bugzilla/show_bug.cgi?id=12518