### PR TITLE
ENH: add scalar special cases for boolean logical loops

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -703,6 +703,27 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 }
 /**end repeat**/
 
+#define BOOL_SCALAR_OP(cond, in_idx, inp, value) \
+    if (!(cond)) { \
+        if (steps[in_idx] == 1 && steps[2] == 1) { \
+            memcpy(args[2], args[in_idx], dimensions[0]); \
+        } \
+        else { \
+            BINARY_LOOP { \
+                *op1 = *inp; \
+            } \
+        } \
+    } \
+    else { \
+        if (steps[2] == 1) { \
+            memset(args[2], value, dimensions[0]); \
+        } \
+        else { \
+            BINARY_LOOP { \
+                *op1 = value; \
+            } \
+        } \
+    }
 
 /**begin repeat
  * #kind = logical_and, logical_or#
@@ -763,7 +784,24 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
         }
     }
     else {
-        if (run_binary_simd_@kind@_BOOL(args, dimensions, steps)) {
+        /*
+         * scalar operations can occur e.g. in masked arrays where a
+         * stride 0 array is used to represent no or full mask
+         */
+        if (steps[0] == 0) {
+            if (steps[1] == 0) {
+                /* only the memset part of the loop */
+                const npy_bool res = (*args[0] @OP@ *args[1]);
+                BOOL_SCALAR_OP(1, 1, ip2, res);
+            }
+            else {
+                BOOL_SCALAR_OP((*args[0] @SC@ 0), 1, ip2, !@and@);
+            }
+        }
+        else if (steps[1] == 0) {
+            BOOL_SCALAR_OP((*args[1] @SC@ 0), 0, ip1, !@and@);
+        }
+        else if (run_binary_simd_@kind@_BOOL(args, dimensions, steps)) {
             return;
         }
         else {
@@ -788,9 +826,14 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
         return;
     }
     else {
-        UNARY_LOOP {
-            npy_bool in1 = *(npy_bool *)ip1;
-            *((npy_bool *)op1) = in1 @OP@ 0;
+        if (steps[0] == 0 && steps[1] == 1) {
+            memset(args[1], *args[0] @OP@ 0, dimensions[0]);
+        }
+        else {
+            UNARY_LOOP {
+                npy_bool in1 = *(npy_bool *)ip1;
+                *((npy_bool *)op1) = in1 @OP@ 0;
+            }
         }
     }
 }

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -288,6 +288,17 @@ class TestBoolArray(TestCase):
         np.abs(self.t, out=self.o)
         assert_array_equal(self.o, self.t)
 
+        # test scalar array specialization
+        norm = np.zeros(114, dtype=bool)[1:]
+        scalar_f = np.ndarray(buffer=np.zeros((), dtype=bool), strides=(0,),
+                              shape=norm.shape, dtype=bool)
+        scalar_t = np.ndarray(buffer=np.ones((), dtype=bool), strides=(0,),
+                              shape=norm.shape, dtype=bool)
+        assert_array_equal(~scalar_f, ~norm)
+        assert_array_equal(np.abs(scalar_f), norm)
+        assert_array_equal(~scalar_t, norm)
+        assert_array_equal(np.abs(scalar_t), ~norm)
+
     def test_logical_and_or_xor(self):
         assert_array_equal(self.t | self.t, self.t)
         assert_array_equal(self.f | self.f, self.f)
@@ -310,16 +321,44 @@ class TestBoolArray(TestCase):
 
         assert_array_equal(self.nm & self.t, self.nm)
         assert_array_equal(self.im & self.f, False)
+        assert_array_equal(self.t & self.nm, self.nm)
+        assert_array_equal(self.f & self.im, False)
         assert_array_equal(self.nm & True, self.nm)
         assert_array_equal(self.im & False, self.f)
+        assert_array_equal(True  & self.nm, self.nm)
+        assert_array_equal(False & self.im, self.f)
         assert_array_equal(self.nm | self.t, self.t)
         assert_array_equal(self.im | self.f, self.im)
+        assert_array_equal(self.t | self.nm, self.t)
+        assert_array_equal(self.f | self.im, self.im)
         assert_array_equal(self.nm | True, self.t)
         assert_array_equal(self.im | False, self.im)
+        assert_array_equal(True  | self.nm , self.t)
+        assert_array_equal(False | self.im, self.im)
         assert_array_equal(self.nm ^ self.t, self.im)
         assert_array_equal(self.im ^ self.f, self.im)
+        assert_array_equal(self.t ^ self.nm, self.im)
+        assert_array_equal(self.f ^ self.im, self.im)
         assert_array_equal(self.nm ^ True, self.im)
         assert_array_equal(self.im ^ False, self.im)
+        assert_array_equal(True  ^ self.nm, self.im)
+        assert_array_equal(False ^ self.im, self.im)
+
+        # test scalar array specialization
+        norm = np.zeros(114, dtype=bool)[1:]
+        scalar_f = np.ndarray(buffer=np.zeros((), dtype=bool), strides=(0,),
+                              shape=norm.shape, dtype=bool)
+        scalar_t = np.ndarray(buffer=np.ones((), dtype=bool), strides=(0,),
+                              shape=norm.shape, dtype=bool)
+        assert_array_equal(scalar_f & scalar_t, norm)
+        assert_array_equal(scalar_t & scalar_t, ~norm)
+        assert_array_equal(scalar_f & scalar_f, norm)
+        assert_array_equal(scalar_f | scalar_t, ~norm)
+        assert_array_equal(scalar_t | scalar_t, ~norm)
+        assert_array_equal(scalar_f | scalar_f, norm)
+        assert_array_equal(scalar_f ^ scalar_t, ~norm)
+        assert_array_equal(scalar_t ^ scalar_t, norm)
+        assert_array_equal(scalar_f ^ scalar_f, norm)
 
 
 class TestBoolCmp(TestCase):


### PR DESCRIPTION
Scalar logical loops just boil down to memcpy or memset. While not very
useful in general, some cases like masked arrays can profit when
creating zero stride boolean arrays for readonly views.