### PR TITLE
MAINT: Use np.concatenate instead of np.vstack

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1324,7 +1324,8 @@ def piecewise(x, condlist, funclist, *args, **kw):
         totlist = np.logical_or.reduce(condlist, axis=0)
         # Only able to stack vertically if the array is 1d or less
         if x.ndim <= 1:
-            condlist = np.vstack([condlist, ~totlist])
+            totlist = np.any(condlist, axis=0, keepdims=True)
+            condlist = np.concatenate([condlist, ~totlist], axis=0)
         else:
             condlist = [asarray(c, dtype=bool) for c in condlist]
             totlist = condlist[0]
@@ -2965,7 +2966,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
 
     >>> x = [-2.1, -1,  4.3]
     >>> y = [3,  1.1,  0.12]
-    >>> X = np.vstack((x,y))
+    >>> X = np.stack((x, y), axis=0)
     >>> print(np.cov(X))
     [[ 11.71        -4.286     ]
      [ -4.286        2.14413333]]
@@ -3003,7 +3004,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         y = array(y, copy=False, ndmin=2, dtype=dtype)
         if not rowvar and y.shape[0] != 1:
             y = y.T
-        X = np.vstack((X, y))
+        X = np.concatenate((X, y), axis=0)
 
     if ddof is None:
         if bias == 0:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1321,17 +1321,8 @@ def piecewise(x, condlist, funclist, *args, **kw):
         x = x[None]
         zerod = True
     if n == n2 - 1:  # compute the "otherwise" condition.
-        totlist = np.logical_or.reduce(condlist, axis=0)
-        # Only able to stack vertically if the array is 1d or less
-        if x.ndim <= 1:
-            totlist = np.any(condlist, axis=0, keepdims=True)
-            condlist = np.concatenate([condlist, ~totlist], axis=0)
-        else:
-            condlist = [asarray(c, dtype=bool) for c in condlist]
-            totlist = condlist[0]
-            for k in range(1, n):
-                totlist |= condlist[k]
-            condlist.append(~totlist)
+        condelse = ~np.any(condlist, axis=0, keepdims=True)
+        condlist = np.concatenate([condlist, condelse], axis=0)
         n += 1
 
     y = zeros(x.shape, x.dtype)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1122,7 +1122,6 @@ class TestCov(TestCase):
                             (np.cov(xf, rowvar=False, bias=True) *
                              x.shape[0] / frac))
 
-
 class TestCorrcoef(TestCase):
 
     def setUp(self):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1122,6 +1122,7 @@ class TestCov(TestCase):
                             (np.cov(xf, rowvar=False, bias=True) *
                              x.shape[0] / frac))
 
+
 class TestCorrcoef(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
The code for vstack says it is "supported for backward compatibility" so numpy itself should not use this function in other functions.

Here I changed function calls from vstack to concatenate with axis=0 to remove references to the vstack function.

My motivation is that I went to push something to Theano which does not have a vstack function and will not implement it because the vstack function in numpy is deprecated. I think it would help when porting the code in the future if this was changed over to only used supported functions.