### PR TITLE
REV: Remove `__setslice__` and `__getslice__`

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -80,17 +80,6 @@ implement ``__len__`` as the number of record fields, ``bool`` of scalar dtypes
 would evaluate to ``False``, which was unintuitive. Now ``bool(dtype) == True``
 for all dtypes.
 
-``__getslice__`` and ``__setslice__`` have been removed from ``ndarray``
-------------------------------------------------------------------------
-When subclassing np.ndarray in Python 2.7, it is no longer _necessary_ to
-implement ``__*slice__`` on the derived class, as ``__*item__`` will intercept
-these calls correctly.
-
-Any code that did implement these will work exactly as before, with the
-obvious exception of any code that tries to directly call
-``ndarray.__getslice__`` (e.g. through ``super(...).__getslice__``). In
-this case, ``.__getitem__(slice(start, end))`` will act as a replacement.
-
 
 New Features
 ============

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -595,6 +595,8 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
    ndarray.__len__
    ndarray.__getitem__
    ndarray.__setitem__
+   ndarray.__getslice__
+   ndarray.__setslice__
    ndarray.__contains__
 
 Conversion; the operations :func:`complex()`, :func:`int()`,

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -417,6 +417,8 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
    MaskedArray.__getitem__
    MaskedArray.__setitem__
    MaskedArray.__delitem__
+   MaskedArray.__getslice__
+   MaskedArray.__setslice__
    MaskedArray.__contains__
 
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2426,9 +2426,9 @@ NPY_NO_EXPORT PySequenceMethods npyiter_as_sequence = {
     (binaryfunc)NULL,                       /*sq_concat*/
     (ssizeargfunc)NULL,                     /*sq_repeat*/
     (ssizeargfunc)npyiter_seq_item,         /*sq_item*/
-    (ssizessizeargfunc)NULL,                /*sq_slice*/
+    (ssizessizeargfunc)npyiter_seq_slice,   /*sq_slice*/
     (ssizeobjargproc)npyiter_seq_ass_item,  /*sq_ass_item*/
-    (ssizessizeobjargproc)NULL,             /*sq_ass_slice*/
+    (ssizessizeobjargproc)npyiter_seq_ass_slice,/*sq_ass_slice*/
     (objobjproc)NULL,                       /*sq_contains */
     (binaryfunc)NULL,                       /*sq_inplace_concat */
     (ssizeargfunc)NULL,                     /*sq_inplace_repeat */

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -27,6 +27,90 @@ array_any_nonzero(PyArrayObject *mp);
    we fill it in here so that PySequence_XXXX calls work as expected
 */
 
+
+static PyObject *
+array_slice(PyArrayObject *self, Py_ssize_t ilow, Py_ssize_t ihigh)
+{
+    PyArrayObject *ret;
+    PyArray_Descr *dtype;
+    Py_ssize_t dim0;
+    char *data;
+    npy_intp shape[NPY_MAXDIMS];
+
+    if (PyArray_NDIM(self) == 0) {
+        PyErr_SetString(PyExc_ValueError, "cannot slice a 0-d array");
+        return NULL;
+    }
+
+    dim0 = PyArray_DIM(self, 0);
+    if (ilow < 0) {
+        ilow = 0;
+    }
+    else if (ilow > dim0) {
+        ilow = dim0;
+    }
+    if (ihigh < ilow) {
+        ihigh = ilow;
+    }
+    else if (ihigh > dim0) {
+        ihigh = dim0;
+    }
+
+    data = PyArray_DATA(self);
+    if (ilow < ihigh) {
+        data += ilow * PyArray_STRIDE(self, 0);
+    }
+
+    /* Same shape except dimension 0 */
+    shape[0] = ihigh - ilow;
+    memcpy(shape+1, PyArray_DIMS(self) + 1,
+                        (PyArray_NDIM(self)-1)*sizeof(npy_intp));
+
+    dtype = PyArray_DESCR(self);
+    Py_INCREF(dtype);
+    ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self), dtype,
+                             PyArray_NDIM(self), shape,
+                             PyArray_STRIDES(self), data,
+                             PyArray_FLAGS(self),
+                             (PyObject *)self);
+    if (ret == NULL) {
+        return NULL;
+    }
+    Py_INCREF(self);
+    if (PyArray_SetBaseObject(ret, (PyObject *)self) < 0) {
+        Py_DECREF(ret);
+        return NULL;
+    }
+    PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
+
+    return (PyObject *)ret;
+}
+
+
+static int
+array_assign_slice(PyArrayObject *self, Py_ssize_t ilow,
+                Py_ssize_t ihigh, PyObject *v) {
+    int ret;
+    PyArrayObject *tmp;
+
+    if (v == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                        "cannot delete array elements");
+        return -1;
+    }
+    if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
+        return -1;
+    }
+    tmp = (PyArrayObject *)array_slice(self, ilow, ihigh);
+    if (tmp == NULL) {
+        return -1;
+    }
+    ret = PyArray_CopyObject(tmp, v);
+    Py_DECREF(tmp);
+
+    return ret;
+}
+
 static int
 array_contains(PyArrayObject *self, PyObject *el)
 {
@@ -50,9 +134,9 @@ NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
     (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
     (ssizeargfunc)NULL,
     (ssizeargfunc)array_item,
-    (ssizessizeargfunc)NULL,
-    (ssizeobjargproc)array_assign_item,     /*sq_ass_item*/
-    (ssizessizeobjargproc)NULL,             /*sq_ass_slice*/
+    (ssizessizeargfunc)array_slice,
+    (ssizeobjargproc)array_assign_item,        /*sq_ass_item*/
+    (ssizessizeobjargproc)array_assign_slice,  /*sq_ass_slice*/
     (objobjproc) array_contains,            /*sq_contains */
     (binaryfunc) NULL,                      /*sg_inplace_concat */
     (ssizeargfunc)NULL,

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -222,6 +222,9 @@ class nd_grid(object):
             else:
                 return _nx.arange(start, stop, step)
 
+    def __getslice__(self, i, j):
+        return _nx.arange(i, j)
+
     def __len__(self):
         return 0
 
@@ -346,6 +349,10 @@ class AxisConcatenator(object):
                 objs[k] = objs[k].astype(final_dtype)
 
         res = _nx.concatenate(tuple(objs), axis=self.axis)
+        return self._retval(res)
+
+    def __getslice__(self, i, j):
+        res = _nx.arange(i, j)
         return self._retval(res)
 
     def __len__(self):

--- a/numpy/lib/user_array.py
+++ b/numpy/lib/user_array.py
@@ -51,8 +51,14 @@ class container(object):
     def __getitem__(self, index):
         return self._rc(self.array[index])
 
+    def __getslice__(self, i, j):
+        return self._rc(self.array[i:j])
+
     def __setitem__(self, index, value):
         self.array[index] = asarray(value, self.dtype)
+
+    def __setslice__(self, i, j, value):
+        self.array[i:j] = asarray(value, self.dtype)
 
     def __abs__(self):
         return self._rc(absolute(self.array))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3346,6 +3346,26 @@ class MaskedArray(ndarray):
             except (AttributeError, TypeError):
                 pass
 
+    def __getslice__(self, i, j):
+        """
+        x.__getslice__(i, j) <==> x[i:j]
+
+        Return the slice described by (i, j).  The use of negative indices
+        is not supported.
+
+        """
+        return self.__getitem__(slice(i, j))
+
+    def __setslice__(self, i, j, value):
+        """
+        x.__setslice__(i, j, value) <==> x[i:j]=value
+
+        Set the slice (i,j) of a to value. If value is masked, mask those
+        locations.
+
+        """
+        self.__setitem__(slice(i, j), value)
+
     def __setmask__(self, mask, copy=False):
         """
         Set the mask.

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -873,6 +873,7 @@ class TestMedian(TestCase):
     def test_nan(self):
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
+            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             for mask in (False, np.zeros(6, dtype=np.bool)):
                 dm = np.ma.array([[1, np.nan, 3], [1, 2, 3]])
                 dm.mask = mask
@@ -922,6 +923,7 @@ class TestMedian(TestCase):
         a[2] = np.nan
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
+            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             assert_array_equal(np.ma.median(a), np.nan)
             assert_array_equal(np.ma.median(a, axis=0), np.nan)
             assert_(w.log[0].category is RuntimeWarning)
@@ -936,6 +938,7 @@ class TestMedian(TestCase):
         # no axis
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
+            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_array_equal(np.ma.median(a), np.nan)
             assert_(np.isscalar(np.ma.median(a)))
@@ -1025,6 +1028,7 @@ class TestMedian(TestCase):
         a = np.ma.masked_array(np.array([], dtype=float))
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
+            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             assert_array_equal(np.ma.median(a), np.nan)
             assert_(w.log[0].category is RuntimeWarning)
 
@@ -1033,6 +1037,7 @@ class TestMedian(TestCase):
         # no axis
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
+            w.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_array_equal(np.ma.median(a), np.nan)
             assert_(w.log[0].category is RuntimeWarning)

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -420,6 +420,8 @@ class NoseTester(object):
                 sup.filter(DeprecationWarning,
                            r"sys\.exc_clear\(\) not supported in 3\.x",
                            module=threading)
+                sup.filter(DeprecationWarning, message=r"in 3\.x, __setslice__")
+                sup.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
                 sup.filter(DeprecationWarning, message=r"buffer\(\) not supported in 3\.x")
                 sup.filter(DeprecationWarning, message=r"CObject type is not supported in 3\.x")
                 sup.filter(DeprecationWarning, message=r"comparing unequal types not supported in 3\.x")


### PR DESCRIPTION
This reverts commit 994f8a1dbb137fd4daf881184972637964983ad8 and
bec587c6e5068fb19d57cdbe2ed36e953ca97005 from gh-8592.

This is essentially a cosmetic change that breaks backward compatibility
with in use programs like astropy 1.3.