### PR TITLE
REL: add `python_requires` to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -357,6 +357,7 @@ def setup_package():
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked},
+        python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
This allows pip to figure out the last compatible version
with a particular Python version before attempting to
install.

Support for this field was added to setuptools last year:
https://github.com/pypa/setuptools/pull/631