### PR TITLE
DEP: Remove alter/restore dot methods

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -62,6 +62,7 @@ See Changes section for more detail.
 * ``np.equal, np.not_equal``, object identity doesn't override failed comparison.
 * ``np.equal, np.not_equal``, object identity doesn't override non-boolean comparison.
 * Deprecated boolean indexing behavior dropped. See Changes below for details.
+* Deprecated ``np.alterdot()`` and ``np.restoredot()`` removed.
 
 FutureWarning to changed behavior
 ---------------------------------

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -18,8 +18,6 @@ Performance tuning
 .. autosummary::
    :toctree: generated/
 
-   alterdot
-   restoredot
    setbufsize
    getbufsize
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -53,7 +53,7 @@ __all__ = [
     'min_scalar_type', 'result_type', 'asarray', 'asanyarray',
     'ascontiguousarray', 'asfortranarray', 'isfortran', 'empty_like',
     'zeros_like', 'ones_like', 'correlate', 'convolve', 'inner', 'dot',
-    'outer', 'vdot', 'alterdot', 'restoredot', 'roll',
+    'outer', 'vdot', 'roll',
     'rollaxis', 'moveaxis', 'cross', 'tensordot', 'array2string',
     'get_printoptions', 'set_printoptions', 'array_repr', 'array_str',
     'set_string_function', 'little_endian', 'require', 'fromiter',
@@ -1152,62 +1152,6 @@ def outer(a, b, out=None):
     a = asarray(a)
     b = asarray(b)
     return multiply(a.ravel()[:, newaxis], b.ravel()[newaxis,:], out)
-
-
-def alterdot():
-    """
-    Change `dot`, `vdot`, and `inner` to use accelerated BLAS functions.
-
-    Typically, as a user of NumPy, you do not explicitly call this
-    function. If NumPy is built with an accelerated BLAS, this function is
-    automatically called when NumPy is imported.
-
-    When NumPy is built with an accelerated BLAS like ATLAS, these
-    functions are replaced to make use of the faster implementations.  The
-    faster implementations only affect float32, float64, complex64, and
-    complex128 arrays. Furthermore, the BLAS API only includes
-    matrix-matrix, matrix-vector, and vector-vector products. Products of
-    arrays with larger dimensionalities use the built in functions and are
-    not accelerated.
-
-    .. note:: Deprecated in NumPy 1.10.0
-              The cblas functions have been integrated into the multarray
-              module and alterdot now longer does anything. It will be
-              removed in NumPy 1.11.0.
-
-    See Also
-    --------
-    restoredot : `restoredot` undoes the effects of `alterdot`.
-
-    """
-    # 2014-08-13, 1.10
-    warnings.warn("alterdot no longer does anything.",
-                  DeprecationWarning, stacklevel=2)
-
-
-def restoredot():
-    """
-    Restore `dot`, `vdot`, and `innerproduct` to the default non-BLAS
-    implementations.
-
-    Typically, the user will only need to call this when troubleshooting
-    and installation problem, reproducing the conditions of a build without
-    an accelerated BLAS, or when being very careful about benchmarking
-    linear algebra operations.
-
-    .. note:: Deprecated in NumPy 1.10.0
-              The cblas functions have been integrated into the multarray
-              module and restoredot now longer does anything. It will be
-              removed in NumPy 1.11.0.
-
-    See Also
-    --------
-    alterdot : `restoredot` undoes the effects of `alterdot`.
-
-    """
-    # 2014-08-13, 1.10
-    warnings.warn("restoredot no longer does anything.",
-                  DeprecationWarning, stacklevel=2)
 
 
 def tensordot(a, b, axes=2):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -229,19 +229,6 @@ class TestComparisonDeprecations(_DeprecationTestCase):
                         assert_warns(DeprecationWarning, f, arg1, arg2)
 
 
-class TestAlterdotRestoredotDeprecations(_DeprecationTestCase):
-    """The alterdot/restoredot functions are deprecated.
-
-    These functions no longer do anything in numpy 1.10, so
-    they should not be used.
-
-    """
-
-    def test_alterdot_restoredot_deprecation(self):
-        self.assert_deprecated(np.alterdot)
-        self.assert_deprecated(np.restoredot)
-
-
 class TestDatetime64Timezone(_DeprecationTestCase):
     """Parsing of datetime64 with timezones deprecated in 1.11.0, because
     datetime64 is now timezone naive rather than UTC only.


### PR DESCRIPTION
`alterdot` and `restoredot` was to be removed in `1.11.0`.