### PR TITLE
MAINT: Update Intel compiler options.

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -56,7 +56,9 @@ class IntelFCompiler(BaseIntelFCompiler):
         return ['-fPIC']
 
     def get_flags_opt(self):  # Scipy test failures with -O2
-        return ['-xhost -openmp -fp-model strict -O1']
+        v = self.get_version()
+        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
+        return ['-xhost -fp-model strict -O1 -{}'.format(mpopt)]
 
     def get_flags_arch(self):
         return []
@@ -120,7 +122,9 @@ class IntelEM64TFCompiler(IntelFCompiler):
         return ['-fPIC']
 
     def get_flags_opt(self):  # Scipy test failures with -O2
-        return ['-openmp -fp-model strict -O1']
+        v = self.get_version()
+        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
+        return ['-fp-model strict -O1 -{}'.format(mpopt)]
 
     def get_flags_arch(self):
         return ['']

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -17,9 +17,13 @@ class IntelCCompiler(UnixCCompiler):
 
     def __init__(self, verbose=0, dry_run=0, force=0):
         UnixCCompiler.__init__(self, verbose, dry_run, force)
+
+        v = self.get_version()
+        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
         self.cc_exe = ('icc -fPIC -fp-model strict -O3 '
-                       '-fomit-frame-pointer -openmp')
+                       '-fomit-frame-pointer -{}').format(mpopt)
         compiler = self.cc_exe
+
         if platform.system() == 'Darwin':
             shared_flag = '-Wl,-undefined,dynamic_lookup'
         else:
@@ -53,9 +57,13 @@ class IntelEM64TCCompiler(UnixCCompiler):
 
     def __init__(self, verbose=0, dry_run=0, force=0):
         UnixCCompiler.__init__(self, verbose, dry_run, force)
+
+        v = self.get_version()
+        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
         self.cc_exe = ('icc -m64 -fPIC -fp-model strict -O3 '
-                       '-fomit-frame-pointer -openmp')
+                       '-fomit-frame-pointer -{}').format(mpopt)
         compiler = self.cc_exe
+
         if platform.system() == 'Darwin':
             shared_flag = '-Wl,-undefined,dynamic_lookup'
         else:


### PR DESCRIPTION
The '-openmp' option was deprecated in Intel version 15 and removed
in version 18. The replacement is '-qopenmp'.

Closes #8941.

[skip ci]