### PR TITLE
DOC: Wrong return type of np.random.choice and wrong variable name in parameter description.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1026,7 +1026,7 @@ cdef class RandomState:
         -----------
         a : 1-D array-like or int
             If an ndarray, a random sample is generated from its elements.
-            If an int, the random sample is generated as if a was np.arange(n)
+            If an int, the random sample is generated as if a were np.arange(a)
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  Default is None, in which case a
@@ -1040,7 +1040,7 @@ cdef class RandomState:
 
         Returns
         --------
-        samples : 1-D ndarray, shape (size,)
+        samples : single item or ndarray
             The generated random samples
 
         Raises


### PR DESCRIPTION
This fixes some minor documentation issues in `np.random.choice`:

- The first parameter is called `a` and not `n` as indicated by the `np.arange(n)` comparison.
- The return value can be a scalar, a 1D array or an ND-array, currently the documentation suggests that it always returns a 1D array and the shape (possibly the size as well?).