### PR TITLE
BUG: don't create array with invalid memory in where

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -206,6 +206,9 @@ static NPY_GCC_OPT_3 void
 #else
     npy_uint64 temp0, temp1;
 #endif
+    if (N == 0) {
+        return;
+    }
 #if @is_aligned@ && @elsize@ != 16
     /* sanity check */
     assert(npy_is_aligned(dst, _ALIGN(@type@)));

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6619,6 +6619,14 @@ class TestWhere(TestCase):
         assert_equal(np.where(True, a, b), "abcd")
         assert_equal(np.where(False, b, a), "abcd")
 
+    def test_empty_result(self):
+        # pass empty where result through an assignment which reads the data of
+        # empty arrays, error detectable with valgrind, see gh-8922
+        x = np.zeros((1, 1))
+        ibad = np.vstack(np.where(x == 99.))
+        assert_array_equal(ibad,
+                           np.atleast_2d(np.array([[],[]], dtype=np.intp)))
+
 
 if not IS_PYPY:
     # sys.getsizeof() is not valid on PyPy


### PR DESCRIPTION
When creating the tuple view of np.where, make sure the arrays point to
valid memory when they are empty.
Numpy assumes that even empty arrays have valid memory, e.g. in the
source stride == 0 assignments.
Closes gh-8922.