### PR TITLE
BUG: do not change size 0 description when viewing data

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -937,7 +937,9 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
             PyErr_SetString(PyExc_TypeError, "Empty data-type");
             Py_DECREF(descr);
             return NULL;
-        } else if (PyDataType_ISSTRING(descr) && !allow_emptystring) {
+        }
+        else if (PyDataType_ISSTRING(descr) && !allow_emptystring &&
+                 data == NULL) {
             PyArray_DESCR_REPLACE(descr);
             if (descr == NULL) {
                 return NULL;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1073,6 +1073,9 @@ class TestStructured(TestCase):
         xx = x['S'].reshape((2, 2))
         assert_equal(xx.itemsize, 0)
         assert_equal(xx, [[b'', b''], [b'', b'']])
+        # check for no uninitialized memory due to viewing S0 array
+        assert_equal(xx[:].dtype, xx.dtype)
+        assert_array_equal(eval(repr(xx), dict(array=np.array)), xx)
 
         b = io.BytesIO()
         np.save(b, xx)


### PR DESCRIPTION
If the array being viewed is a zero sized array, e.g. 'S0' from
structured types, do not change the description to itemsize 1 as this
would expose uninitialized data, e.g. in
TestStructured.test_zero_width_string

See also #6430