### PR TITLE
DOC: Correct shape of edges in np.histogram2d

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -569,9 +569,9 @@ def histogram2d(x, y, bins=10, range=None, normed=False, weights=None):
         The bi-dimensional histogram of samples `x` and `y`. Values in `x`
         are histogrammed along the first dimension and values in `y` are
         histogrammed along the second dimension.
-    xedges : ndarray, shape(nx,)
+    xedges : ndarray, shape(nx+1,)
         The bin edges along the first dimension.
-    yedges : ndarray, shape(ny,)
+    yedges : ndarray, shape(ny+1,)
         The bin edges along the second dimension.
 
     See Also


### PR DESCRIPTION
Update histogram2d docstring (according to #8979): If nx and ny are the bin counts (as stated in the bins argument's text), then the return H has indeed shape (nx, ny). However, the returned xedges and yedges will then have shape (nx+1,) and (ny+1,) respectively (and not as it is currently written (nx,) and (ny,)).