### PR TITLE
ENH: implement voidtype_repr and voidtype_str

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -403,6 +403,18 @@ elements uniquely.
 Numpy complex-floating-scalars with values like ``inf*j`` or ``nan*j`` now
 print as ``infj`` and ``nanj``, like the pure-python ``complex`` type.
 
+``void`` datatype elements are now printed in hex notation
+----------------------------------------------------------
+A hex representation compatible with the python ``bytes`` type is now printed
+for unstructured ``np.void`` elements (eg, ``V4`` datatype). Previously, in
+python2 the raw void data of the element was printed to stdout, or in python3
+the integer byte values were shown.
+
+printing style for ``void`` datatypes is now independently customizable
+-----------------------------------------------------------------------
+The printing style of ``np.void`` arrays is now independently customizable
+using the ``formatter`` argument to ``np.set_printoptions``, using the
+``'void'`` key, instead of the catch-all ``numpystr`` key as before.
 
 Changes
 =======

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -291,6 +291,9 @@ def _object_format(o):
 def repr_format(x):
     return repr(x)
 
+def str_format(x):
+    return str(x)
+
 def _get_formatdict(data, **opt):
     prec, fmode = opt['precision'], opt['floatmode']
     supp, sign = opt['suppress'], opt['sign']
@@ -307,6 +310,7 @@ def _get_formatdict(data, **opt):
         'datetime': lambda: DatetimeFormat(data),
         'timedelta': lambda: TimedeltaFormat(data),
         'object': lambda: _object_format,
+        'void': lambda: str_format,
         'numpystr': lambda: repr_format,
         'str': lambda: str}
 
@@ -366,6 +370,8 @@ def _get_format_function(data, **options):
         return formatdict['datetime']()
     elif issubclass(dtypeobj, _nt.object_):
         return formatdict['object']()
+    elif issubclass(dtypeobj, _nt.void):
+        return formatdict['void']()
     else:
         return formatdict['numpystr']()
 
@@ -470,6 +476,7 @@ def array2string(a, max_line_width=None, precision=None,
             - 'longfloat' : 128-bit floats
             - 'complexfloat'
             - 'longcomplexfloat' : composed of two 128-bit floats
+            - 'void' : type `numpy.void`
             - 'numpystr' : types `numpy.string_` and `numpy.unicode_`
             - 'str' : all other strings
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -365,93 +365,78 @@ def stack(arrays, axis=0, out=None):
     return _nx.concatenate(expanded_arrays, axis=axis, out=out)
 
 
-def _block_check_depths_match(arrays, parent_index=[]):
+class _Recurser(object):
     """
-    Recursive function checking that the depths of nested lists in `arrays`
-    all match. Mismatch raises a ValueError as described in the block
-    docstring below.
-
-    The entire index (rather than just the depth) needs to be calculated
-    for each innermost list, in case an error needs to be raised, so that
-    the index of the offending list can be printed as part of the error.
-
-    The parameter `parent_index` is the full index of `arrays` within the
-    nested lists passed to _block_check_depths_match at the top of the
-    recursion.
-    The return value is a pair. The first item returned is the full index
-    of an element (specifically the first element) from the bottom of the
-    nesting in `arrays`. An empty list at the bottom of the nesting is
-    represented by a `None` index.
-    The second item is the maximum of the ndims of the arrays nested in
-    `arrays`.
+    Utility class for recursing over nested iterables
     """
-    def format_index(index):
-        idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
-        return 'arrays' + idx_str
-    if type(arrays) is tuple:
-        # not strictly necessary, but saves us from:
-        #  - more than one way to do things - no point treating tuples like
-        #    lists
-        #  - horribly confusing behaviour that results when tuples are
-        #    treated like ndarray
-        raise TypeError(
-            '{} is a tuple. '
-            'Only lists can be used to arrange blocks, and np.block does '
-            'not allow implicit conversion from tuple to ndarray.'.format(
-                format_index(parent_index)
-            )
-        )
-    elif type(arrays) is list and len(arrays) > 0:
-        idxs_ndims = (_block_check_depths_match(arr, parent_index + [i])
-                      for i, arr in enumerate(arrays))
+    def __init__(self, recurse_if):
+        self.recurse_if = recurse_if
 
-        first_index, max_arr_ndim = next(idxs_ndims)
-        for index, ndim in idxs_ndims:
-            if ndim > max_arr_ndim:
-                max_arr_ndim = ndim
-            if len(index) != len(first_index):
-                raise ValueError(
-                    "List depths are mismatched. First element was at depth "
-                    "{}, but there is an element at depth {} ({})".format(
-                        len(first_index),
-                        len(index),
-                        format_index(index)
-                    )
-                )
-        return first_index, max_arr_ndim
-    elif type(arrays) is list and len(arrays) == 0:
-        # We've 'bottomed out' on an empty list
-        return parent_index + [None], 0
-    else:
-        # We've 'bottomed out' - arrays is either a scalar or an array
-        return parent_index, _nx.ndim(arrays)
+    def map_reduce(self, x, f_map=lambda x, **kwargs: x,
+                            f_reduce=lambda x, **kwargs: x,
+                            f_kwargs=lambda **kwargs: kwargs,
+                            **kwargs):
+        """
+        Iterate over the nested list, applying:
+        * ``f_map`` (T -> U) to items
+        * ``f_reduce`` (Iterable[U] -> U) to mapped items
+
+        For instance, ``map_reduce([[1, 2], 3, 4])`` is::
+
+            f_reduce([
+              f_reduce([
+                f_map(1),
+                f_map(2)
+              ]),
+              f_map(3),
+              f_map(4)
+            ]])
 
 
-def _block(arrays, max_depth, result_ndim):
-    """
-    Internal implementation of block. `arrays` is the argument passed to
-    block. `max_depth` is the depth of nested lists within `arrays` and
-    `result_ndim` is the greatest of the dimensions of the arrays in
-    `arrays` and the depth of the lists in `arrays` (see block docstring
-    for details).
-    """
-    def atleast_nd(a, ndim):
-        # Ensures `a` has at least `ndim` dimensions by prepending
-        # ones to `a.shape` as necessary
-        return array(a, ndmin=ndim, copy=False, subok=True)
+        State can be passed down through the calls with `f_kwargs`,
+        to iterables of mapped items. When kwargs are passed, as in
+        ``map_reduce([[1, 2], 3, 4], **kw)``, this becomes::
 
-    def block_recursion(arrays, depth=0):
-        if depth < max_depth:
-            if len(arrays) == 0:
-                raise ValueError('Lists cannot be empty')
-            arrs = [block_recursion(arr, depth+1) for arr in arrays]
-            return _nx.concatenate(arrs, axis=-(max_depth-depth))
-        else:
-            # We've 'bottomed out' - arrays is either a scalar or an array
-            # type(arrays) is not list
-            return atleast_nd(arrays, result_ndim)
+            kw1 = f_kwargs(**kw)
+            kw2 = f_kwargs(**kw1)
+            f_reduce([
+              f_reduce([
+                f_map(1), **kw2)
+                f_map(2,  **kw2)
+              ],      **kw1),
+              f_map(3, **kw1),
+              f_map(4, **kw1)
+            ]],     **kw)
+        """
+        def f(x, **kwargs):
+            if not self.recurse_if(x):
+                return f_map(x, **kwargs)
+            else:
+                next_kwargs = f_kwargs(**kwargs)
+                return f_reduce((
+                    f(xi, **next_kwargs)
+                    for xi in x
+                ), **kwargs)
+        return f(x, **kwargs)
 
-    return block_recursion(arrays)
+    def walk(self, x, index=()):
+        """
+        Iterate over x, yielding (index, value, entering), where
+
+        * ``index``: a tuple of indices up to this point
+        * ``value``: equal to ``x[index[0]][...][index[-1]]``. On the first iteration, is
+                     ``x`` itself
+        * ``entering``: bool. The result of ``recurse_if(value)``
+        """
+        do_recurse = self.recurse_if(x)
+        yield index, x, do_recurse
+
+        if not do_recurse:
+            return
+        for i, xi in enumerate(x):
+            # yield from ...
+            for v in self.walk(xi, index + (i,)):
+                yield v
 
 
 def block(arrays):
@@ -602,6 +587,81 @@ def block(arrays):
 
 
     """
-    bottom_index, arr_ndim = _block_check_depths_match(arrays)
-    list_ndim = len(bottom_index)
-    return _block(arrays, list_ndim, max(arr_ndim, list_ndim))
+    def atleast_nd(x, ndim):
+        x = asanyarray(x)
+        diff = max(ndim - x.ndim, 0)
+        return x[(None,)*diff + (Ellipsis,)]
+
+    def format_index(index):
+        return 'arrays' + ''.join('[{}]'.format(i) for i in index)
+
+    rec = _Recurser(recurse_if=lambda x: type(x) is list)
+
+    # ensure that the lists are all matched in depth
+    list_ndim = None
+    any_empty = False
+    for index, value, entering in rec.walk(arrays):
+        if type(value) is tuple:
+            # not strictly necessary, but saves us from:
+            #  - more than one way to do things - no point treating tuples like
+            #    lists
+            #  - horribly confusing behaviour that results when tuples are
+            #    treated like ndarray
+            raise TypeError(
+                '{} is a tuple. '
+                'Only lists can be used to arrange blocks, and np.block does '
+                'not allow implicit conversion from tuple to ndarray.'.format(
+                    format_index(index)
+                )
+            )
+        if not entering:
+            curr_depth = len(index)
+        elif len(value) == 0:
+            curr_depth = len(index) + 1
+            any_empty = True
+        else:
+            continue
+
+        if list_ndim is not None and list_ndim != curr_depth:
+            raise ValueError(
+                "List depths are mismatched. First element was at depth {}, "
+                "but there is an element at depth {} ({})".format(
+                    list_ndim,
+                    curr_depth,
+                    format_index(index)
+                )
+            )
+        list_ndim = curr_depth
+
+    # do this here so we catch depth mismatches first
+    if any_empty:
+        raise ValueError('Lists cannot be empty')
+
+    # convert all the arrays to ndarrays
+    arrays = rec.map_reduce(arrays,
+        f_map=asanyarray,
+        f_reduce=list
+    )
+
+    # determine the maximum dimension of the elements
+    elem_ndim = rec.map_reduce(arrays,
+        f_map=lambda xi: xi.ndim,
+        f_reduce=max
+    )
+    ndim = max(list_ndim, elem_ndim)
+
+    # first axis to concatenate along
+    first_axis = ndim - list_ndim
+
+    # Make all the elements the same dimension
+    arrays = rec.map_reduce(arrays,
+        f_map=lambda xi: atleast_nd(xi, ndim),
+        f_reduce=list
+    )
+
+    # concatenate innermost lists on the right, outermost on the left
+    return rec.map_reduce(arrays,
+        f_reduce=lambda xs, axis: _nx.concatenate(list(xs), axis=axis),
+        f_kwargs=lambda axis: dict(axis=axis+1),
+        axis=first_axis
+    )

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -495,10 +495,61 @@ static PyObject *
 }
 /**end repeat**/
 
-static PyObject *
-voidtype_str(PyObject *self)
+
+/*
+ * Convert array of bytes to a string representation much like bytes.__repr__,
+ * but convert all bytes (including ASCII) to the `\x00` notation with
+ * uppercase hex codes (FF not ff).
+ *
+ * Largely copied from _Py_strhex_impl in CPython implementation
+ */
+static NPY_INLINE PyObject *
+_void_to_hex(const char* argbuf, const Py_ssize_t arglen,
+             const char *schars, const char *bprefix, const char *echars)
 {
-    if (PyDataType_HASFIELDS(((PyVoidScalarObject*)self)->descr)) {
+    PyObject *retval;
+    int extrachars, slen;
+    char *retbuf;
+    Py_ssize_t i, j;
+    char const *hexdigits = "0123456789ABCDEF";
+
+    extrachars = strlen(schars) + strlen(echars);
+    slen = extrachars + arglen*(2 + strlen(bprefix));
+
+    if (arglen > (PY_SSIZE_T_MAX / 2) - extrachars) {
+        return PyErr_NoMemory();
+    }
+
+    retbuf = (char *)PyMem_Malloc(slen);
+    if (!retbuf) {
+        return PyErr_NoMemory();
+    }
+
+    memcpy(retbuf, schars, strlen(schars));
+    j = strlen(schars);
+
+    for (i = 0; i < arglen; i++) {
+        unsigned char c;
+        memcpy(&retbuf[j], bprefix, strlen(bprefix));
+        j += strlen(bprefix);
+        c = (argbuf[i] >> 4) & 0xf;
+        retbuf[j++] = hexdigits[c];
+        c = argbuf[i] & 0xf;
+        retbuf[j++] = hexdigits[c];
+    }
+    memcpy(&retbuf[j], echars, strlen(echars));
+
+    retval = PyUString_FromStringAndSize(retbuf, slen);
+    PyMem_Free(retbuf);
+
+    return retval;
+}
+
+static PyObject *
+voidtype_repr(PyObject *self)
+{
+    PyVoidScalarObject *s = (PyVoidScalarObject*) self;
+    if (PyDataType_HASFIELDS(s->descr)) {
         static PyObject *reprfunc = NULL;
 
         npy_cache_import("numpy.core.arrayprint",
@@ -509,18 +560,25 @@ voidtype_str(PyObject *self)
 
         return PyObject_CallFunction(reprfunc, "O", self);
     }
-    else {
-        PyObject *item, *item_str;
+    return _void_to_hex(s->obval, s->descr->elsize, "void(b'", "\\x", "')");
+}
 
-        item = gentype_generic_method(self, NULL, NULL, "item");
-        if (item == NULL) {
+static PyObject *
+voidtype_str(PyObject *self)
+{
+    PyVoidScalarObject *s = (PyVoidScalarObject*) self;
+    if (PyDataType_HASFIELDS(s->descr)) {
+        static PyObject *reprfunc = NULL;
+
+        npy_cache_import("numpy.core.arrayprint",
+                         "_void_scalar_repr", &reprfunc);
+        if (reprfunc == NULL) {
             return NULL;
         }
 
-        item_str = PyObject_Str(item);
-        Py_DECREF(item);
-        return item_str;
+        return PyObject_CallFunction(reprfunc, "O", self);
     }
+    return _void_to_hex(s->obval, s->descr->elsize, "b'", "\\x", "'");
 }
 
 static PyObject *
@@ -4006,7 +4064,7 @@ initialize_numeric_types(void)
     PyVoidArrType_Type.tp_getset = voidtype_getsets;
     PyVoidArrType_Type.tp_as_mapping = &voidtype_as_mapping;
     PyVoidArrType_Type.tp_as_sequence = &voidtype_as_sequence;
-    PyVoidArrType_Type.tp_repr = voidtype_str;
+    PyVoidArrType_Type.tp_repr = voidtype_repr;
     PyVoidArrType_Type.tp_str = voidtype_str;
 
     PyIntegerArrType_Type.tp_getset = inttype_getsets;

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -186,6 +186,19 @@ class TestArray2String(object):
                 (1., 2.1234567890123456789, 3.), dtype=('f8,f8,f8'))
         assert_equal(np.array2string(array_scalar), "(1., 2.12345679, 3.)")
 
+    def test_unstructured_void_repr(self):
+        a = np.array([27, 91, 50, 75,  7, 65, 10,  8,
+                      27, 91, 51, 49,109, 82,101,100], dtype='u1').view('V8')
+        assert_equal(repr(a[0]), r"void(b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08')")
+        assert_equal(str(a[0]), r"b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08'")
+        assert_equal(repr(a),
+            r"array([b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08'," "\n"
+            r"       b'\x1B\x5B\x33\x31\x6D\x52\x65\x64']," "\n"
+            r"      dtype='|V8')")
+
+        assert_equal(eval(repr(a), vars(np)), a)
+        assert_equal(eval(repr(a[0]), vars(np)), a[0])
+
 
 class TestPrintOptions(object):
     """Test getting and setting global print options."""

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -560,28 +560,6 @@ class TestBlock(object):
         assert_raises_regex(TypeError, 'tuple', np.block, ([1, 2], [3, 4]))
         assert_raises_regex(TypeError, 'tuple', np.block, [(1, 2), (3, 4)])
 
-    def test_different_ndims(self):
-        a = 1.
-        b = 2 * np.ones((1, 2))
-        c = 3 * np.ones((1, 1, 3))
-
-        result = np.block([a, b, c])
-        expected = np.array([[[1., 2., 2., 3., 3., 3.]]])
-
-        assert_equal(result, expected)
-
-    def test_different_ndims_depths(self):
-        a = 1.
-        b = 2 * np.ones((1, 2))
-        c = 3 * np.ones((1, 2, 3))
-
-        result = np.block([[a, b], [c]])
-        expected = np.array([[[1., 2., 2.],
-                              [3., 3., 3.],
-                              [3., 3., 3.]]])
-
-        assert_equal(result, expected)
-
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This PR implements `voidtype_repr` and `voidtype_str` to output something more sensible.

Currently, unstructured void types print their raw values directly to output, allowing you to do some funny things:
```python
>>> np.array([27, 91, 50, 75,  7, 65, 10, 8, 
              27, 91, 51, 49,109, 82,101,100], dtype='u1').view('V8')
       A
, Red], 
      dtype='|V8')
```
(if you paste this into an ANSI terminal the output willl be red colored and the terminal will beep)

In this PR I've implemented that the hex representation of the byte-string will be printed:
```
>>> np.array([27, 91, 50, 75,  7, 65, 10, 8, 
              27, 91, 51, 49,109, 82,101,100], dtype='u1').view('V8')
array([1b5b324b07410a08, 1b5b33316d526564],
      dtype='|V8')
```

I also toyed with printing something like `<memory>`, `<V8>`, `<memory at 123456>` for the elements. Better suggestions are welcome.