### PR TITLE
ENH: fix str/repr for 0d-arrays and int* scalars

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -43,3 +43,14 @@ Improvements
 
 Changes
 =======
+
+0d arrays now print their elements like other arrays
+----------------------------------------------------
+0d arrays now use the array2string formatters to print their elements, like
+other arrays. The `style` argument of array2string is now non-functional.
+
+integer scalars are now unaffected by ``np.set_string_function``
+----------------------------------------------------------------
+Previously the str/repr of integer scalars could be controlled by
+``np.set_string_function``, unlike most other numpy scalars. This is no longer
+the case.

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -15,6 +15,13 @@ __docformat__ = 'restructuredtext'
 # and by Perry Greenfield 2000-4-1 for numarray
 # and by Travis Oliphant  2005-8-22 for numpy
 
+
+# Note: Both scalartypes.c.src and arrayprint.py implement strs for numpy
+# scalars but for different purposes. scalartypes.c.src has str/reprs for when
+# the scalar is printed on its own, while arrayprint.py has strs for when
+# scalars are printed inside an ndarray. Only the latter strs are currently
+# user-customizable.
+
 import sys
 import functools
 if sys.version_info[0] >= 3:
@@ -28,12 +35,14 @@ else:
     except ImportError:
         from dummy_thread import get_ident
 
+import numpy as np
 from . import numerictypes as _nt
 from .umath import maximum, minimum, absolute, not_equal, isnan, isinf
 from .multiarray import (array, format_longfloat, datetime_as_string,
                          datetime_data, dtype)
 from .fromnumeric import ravel
 from .numeric import asarray
+import warnings
 
 if sys.version_info[0] >= 3:
     _MAXINT = sys.maxsize
@@ -399,7 +408,7 @@ def _recursive_guard(fillvalue='...'):
 @_recursive_guard()
 def array2string(a, max_line_width=None, precision=None,
                  suppress_small=None, separator=' ', prefix="",
-                 style=repr, formatter=None):
+                 style=np._NoValue, formatter=None):
     """
     Return a string representation of an array.
 
@@ -425,9 +434,10 @@ def array2string(a, max_line_width=None, precision=None,
 
         The length of the prefix string is used to align the
         output correctly.
-    style : function, optional
-        A function that accepts an ndarray and returns a string.  Used only
-        when the shape of `a` is equal to ``()``, i.e. for 0-D arrays.
+    style : _NoValue, optional
+        Has no effect, do not use.
+
+        .. deprecated:: 1.14.0
     formatter : dict of callables, optional
         If not None, the keys should indicate the type(s) that the respective
         formatting function applies to.  Callables should return a string.
@@ -494,6 +504,11 @@ def array2string(a, max_line_width=None, precision=None,
 
     """
 
+    # Deprecation 05-16-2017  v1.14
+    if style is not np._NoValue:
+        warnings.warn("'style' argument is deprecated and no longer functional",
+                      DeprecationWarning, stacklevel=3)
+
     if max_line_width is None:
         max_line_width = _line_width
 
@@ -506,16 +521,7 @@ def array2string(a, max_line_width=None, precision=None,
     if formatter is None:
         formatter = _formatter
 
-    if a.shape == ():
-        x = a.item()
-        if a.dtype.fields is not None:
-            arr = array([x], dtype=a.dtype)
-            format_function = _get_format_function(
-                    arr, precision, suppress_small, formatter)
-            lst = format_function(arr[0])
-        else:
-            lst = style(x)
-    elif functools.reduce(product, a.shape) == 0:
+    if a.size == 0:
         # treat as a null array if any of shape elements == 0
         lst = "[]"
     else:
@@ -542,7 +548,7 @@ def _formatArray(a, format_function, rank, max_line_len,
 
     """
     if rank == 0:
-        raise ValueError("rank shouldn't be zero.")
+        return format_function(a[()]) + '\n'
 
     if summary_insert and 2*edge_items < len(a):
         leading_items = edge_items
@@ -809,22 +815,21 @@ class DatetimeFormat(object):
 
 class TimedeltaFormat(object):
     def __init__(self, data):
-        if data.dtype.kind == 'm':
-            nat_value = array(['NaT'], dtype=data.dtype)[0]
-            int_dtype = dtype(data.dtype.byteorder + 'i8')
-            int_view = data.view(int_dtype)
-            v = int_view[not_equal(int_view, nat_value.view(int_dtype))]
-            if len(v) > 0:
-                # Max str length of non-NaT elements
-                max_str_len = max(len(str(maximum.reduce(v))),
-                                  len(str(minimum.reduce(v))))
-            else:
-                max_str_len = 0
-            if len(v) < len(data):
-                # data contains a NaT
-                max_str_len = max(max_str_len, 5)
-            self.format = '%' + str(max_str_len) + 'd'
-            self._nat = "'NaT'".rjust(max_str_len)
+        nat_value = array(['NaT'], dtype=data.dtype)[0]
+        int_dtype = dtype(data.dtype.byteorder + 'i8')
+        int_view = data.view(int_dtype)
+        v = int_view[not_equal(int_view, nat_value.view(int_dtype))]
+        if len(v) > 0:
+            # Max str length of non-NaT elements
+            max_str_len = max(len(str(maximum.reduce(v))),
+                              len(str(minimum.reduce(v))))
+        else:
+            max_str_len = 0
+        if len(v) < len(data):
+            # data contains a NaT
+            max_str_len = max(max_str_len, 5)
+        self.format = '%' + str(max_str_len) + 'd'
+        self._nat = "'NaT'".rjust(max_str_len)
 
     def __call__(self, x):
         # TODO: After NAT == NAT deprecation should be simplified:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1936,7 +1936,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     '[0 1 2]'
 
     """
-    return array2string(a, max_line_width, precision, suppress_small, ' ', "", str)
+    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
 
 
 def set_string_function(f, repr=True):

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -338,7 +338,6 @@ gentype_str(PyObject *self)
     return ret;
 }
 
-
 static PyObject *
 gentype_repr(PyObject *self)
 {
@@ -351,6 +350,20 @@ gentype_repr(PyObject *self)
         Py_DECREF(arr);
     }
     return ret;
+}
+
+static PyObject *
+genint_type_str(PyObject *self)
+{
+    PyObject  *item, *item_str;
+    item = gentype_generic_method(self, NULL, NULL, "item");
+    if (item == NULL) {
+        return NULL;
+    }
+
+    item_str = PyObject_Str(item);
+    Py_DECREF(item);
+    return item_str;
 }
 
 /*
@@ -4184,6 +4197,19 @@ initialize_numeric_types(void)
     PyTimedeltaArrType_Type.tp_@name@ = timedeltatype_@name@;
 
     /**end repeat**/
+
+
+    /**begin repeat
+     * #Type = Bool, Byte, UByte, Short, UShort, Int, UInt, Long,
+     *         ULong, LongLong, ULongLong#
+     */
+
+    /* both str/repr use genint_type_str to avoid trailing "L" of longs */
+    Py@Type@ArrType_Type.tp_str = genint_type_str;
+    Py@Type@ArrType_Type.tp_repr = genint_type_str;
+
+    /**end repeat**/
+
 
     PyHalfArrType_Type.tp_print = halftype_print;
     PyFloatArrType_Type.tp_print = floattype_print;

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -115,12 +115,6 @@ class TestArray2String(TestCase):
         assert_(np.array2string(a) == '[0 1 2]')
         assert_(np.array2string(a, max_line_width=4) == '[0 1\n 2]')
 
-    def test_style_keyword(self):
-        """This should only apply to 0-D arrays. See #1218."""
-        stylestr = np.array2string(np.array(1.5),
-                                   style=lambda x: "Value in 0-D array: " + str(x))
-        assert_(stylestr == 'Value in 0-D array: 1.5')
-
     def test_format_function(self):
         """Test custom format function for each element in array."""
         def _format_function(x):
@@ -241,6 +235,14 @@ class TestPrintOptions:
         assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
         np.set_printoptions(formatter={'float_kind':None})
         assert_equal(repr(x), "array([ 0.,  1.,  2.])")
+
+    def test_0d_arrays(self):
+        assert_equal(repr(np.datetime64('2005-02-25')[...]),
+                     "array('2005-02-25', dtype='datetime64[D]')")
+
+        x = np.array(1)
+        np.set_printoptions(formatter={'all':lambda x: "test"})
+        assert_equal(repr(x), "array(test)")
 
 def test_unicode_object_array():
     import sys


### PR DESCRIPTION
0d arrays now respect the printoptions:

Before this PR:
```python
>>> np.set_printoptions(formatter={'all': lambda x: "test"})
>>> array(1)
array(1)
```

With this PR:
```python
>>> np.set_printoptions(formatter={'all': lambda x: "test"})
>>> array(1)
array(test)
```

This PR also cleans up a lot of array2string, and eliminates a lot of unnecessary evaluated code. In particular, the `IntegerFormat` and other constructors are now only called if the array has the corresponding type. Before, all the constructors for every type were called every time array2string was called.
