### PR TITLE
ENH: Print object arrays containing lists unambiguously

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -332,6 +332,13 @@ New ``positive`` ufunc
 This ufunc corresponds to unary `+`, but unlike `+` on an ndarray it will raise
 an error if array values do not support numeric operations.
 
+Better ``repr`` of object arrays
+--------------------------------
+Object arrays that contain themselves no longer cause a recursion error.
+
+Object arrays that contain ``list`` objects are now printed in a way that makes
+clear the difference between a 2d object array, and a 1d object array of lists.
+
 Changes
 =======
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -102,6 +102,7 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
             - 'complexfloat'
             - 'longcomplexfloat' : composed of two 128-bit floats
             - 'numpystr' : types `numpy.string_` and `numpy.unicode_`
+            - 'object' : `np.object_` arrays
             - 'str' : all other strings
 
         Other keys that can be used to set a group of types at once are::

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -241,6 +241,13 @@ def _boolFormatter(x):
     else:
         return 'False'
 
+def _object_format(o):
+    """ Object arrays containing lists should be printed unambiguously """
+    if type(o) is list:
+        fmt = 'list({!r})'
+    else:
+        fmt = '{!r}'
+    return fmt.format(o)
 
 def repr_format(x):
     return repr(x)
@@ -256,6 +263,7 @@ def _get_formatdict(data, precision, suppress_small, formatter):
                   'longcomplexfloat': lambda: LongComplexFormat(precision),
                   'datetime': lambda: DatetimeFormat(data),
                   'timedelta': lambda: TimedeltaFormat(data),
+                  'object': lambda: _object_format,
                   'numpystr': lambda: repr_format,
                   'str': lambda: str}
 
@@ -326,6 +334,8 @@ def _get_format_function(data, precision, suppress_small, formatter):
         return formatdict['numpystr']()
     elif issubclass(dtypeobj, _nt.datetime64):
         return formatdict['datetime']()
+    elif issubclass(dtypeobj, _nt.object_):
+        return formatdict['object']()
     else:
         return formatdict['numpystr']()
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -52,6 +52,14 @@ class TestArrayRepr(object):
         assert_equal(repr(first),
             'array(array(array(..., dtype=object), dtype=object), dtype=object)')
 
+    def test_containing_list(self):
+        # printing square brackets directly would be ambiguuous
+        arr1d = np.array([None, None])
+        arr1d[0] = [1, 2]
+        arr1d[1] = [3]
+        assert_equal(repr(arr1d),
+            'array([list([1, 2]), list([3])], dtype=object)')
+
 
 class TestComplexArray(TestCase):
     def test_str(self):


### PR DESCRIPTION
Previously

    array([[1], [1, 1], [1, 1], [1]], dtype=object)

Now

    array([list([1]), list([1, 1]), list([1, 1]), list([1])], dtype=object)