### PR TITLE
TST: fix io test that doesn't close file

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4051,8 +4051,8 @@ class TestIO(TestCase):
     def test_io_open_buffered_fromfile(self):
         # gh-6632
         self.x.tofile(self.filename)
-        f = io.open(self.filename, 'rb', buffering=-1)
-        y = np.fromfile(f, dtype=self.dtype)
+        with io.open(self.filename, 'rb', buffering=-1) as f:
+            y = np.fromfile(f, dtype=self.dtype)
         assert_array_equal(y, self.x.flat)
 
     def test_file_position_after_fromfile(self):


### PR DESCRIPTION
Fix is to test_io_open_buffered_fromfile

Whenever I run tests I have been getting this stuff printed in the middle of the test output:
```
Exception ignored in: <_io.FileIO name='/tmp/tmp4g2d4y05/tmp0v65u9_2' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/tmp4g2d4y05/tmp0v65u9_2'>
```
This PR fixes that.