### PR TITLE
TST: Enable NPY_RELAXED_STRIDES_DEBUG environment variable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
     - python: 2.7
       env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
     - python: 2.7
-      env: USE_WHEEL=1
+      env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1
     - python: 2.7
       env:
        - BLAS=None

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -120,7 +120,7 @@ behaviour is recovered if ``axis=None`` (default).
 
 ``np.gradient`` now supports unevenly spaced data
 ------------------------------------------------
-Users can now specify a not-constant spacing for data. 
+Users can now specify a not-constant spacing for data.
 In particular ``np.gradient`` can now take:
 
 1. A single scalar to specify a sample distance for all dimensions.
@@ -131,12 +131,12 @@ In particular ``np.gradient`` can now take:
 4. Any combination of N scalars/arrays with the meaning of 2. and 3.
 
 This means that, e.g., it is now possible to do the following::
-    
+
     >>> f = np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float)
     >>> dx = 2.
     >>> y = [1., 1.5, 3.5]
     >>> np.gradient(f, dx, y)
-    [array([[ 1. ,  1. , -0.5], [ 1. ,  1. , -0.5]]), 
+    [array([[ 1. ,  1. , -0.5], [ 1. ,  1. , -0.5]]),
      array([[ 2. ,  2. ,  2. ], [ 2. ,  1.7,  0.5]])]
 
 ``np.heaviside`` computes the Heaviside function
@@ -183,6 +183,20 @@ While primarily useful for block matrices, this works for arbitrary dimensions
 of arrays.
 
 It is similar to Matlab's square bracket notation for creating block matrices.
+
+Numpy may be built with relaxed stride checking debugging
+---------------------------------------------------------
+Setting NPY_RELAXED_STRIDES_DEBUG=1 in the enviroment when relaxed stride
+checking is enabled will cause numpy to be compiled with the affected strides
+set to the maximum value of npy_intp in order to help detect invalid usage of
+the strides in downstream projects. When enabled, invalid usage often results
+in an error being raised, but the exact type of error depends on the details of
+the code. TypeError and OverflowError have been observed in the wild.
+
+It was previously the case that this option was disabled for releases and
+enabled in master and changing between the two required editing the code. It is
+now disabled by default but can be enabled for test builds.
+
 
 Improvements
 ============
@@ -385,7 +399,7 @@ offset into the file. This is a behaviour change only for offsets
 greater than ``mmap.ALLOCATIONGRANULARITY``.
 
 ``np.real`` and ``np.imag`` return scalars for scalar inputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------------
 Previously, ``np.real`` and ``np.imag`` used to return array objects when
 provided a scalar input, which was inconsistent with other functions like
 ``np.angle`` and ``np.conj``.

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -20,6 +20,12 @@ from setup_common import *
 # that `strides[dim]` is ignored if `shape[dim] == 1` when setting flags.
 NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "1") != "0")
 
+# Put NPY_RELAXED_STRIDES_DEBUG=1 in the environment if you want numpy to use a
+# bogus value for affected strides in order to help smoke out bad stride usage
+# when relaxed stride checking is enabled.
+NPY_RELAXED_STRIDES_DEBUG = (os.environ.get('NPY_RELAXED_STRIDES_DEBUG', "0") != "0")
+NPY_RELAXED_STRIDES_DEBUG = NPY_RELAXED_STRIDES_DEBUG and NPY_RELAXED_STRIDES_CHECKING
+
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force
 # config.h generation inside an Extension class, and as such sharing
@@ -436,8 +442,13 @@ def configuration(parent_package='',top_path=None):
             # Inline check
             inline = config_cmd.check_inline()
 
+            # Use relaxed stride checking
             if NPY_RELAXED_STRIDES_CHECKING:
                 moredefs.append(('NPY_RELAXED_STRIDES_CHECKING', 1))
+
+            # Use bogus stride debug aid when relaxed strides are enabled
+            if NPY_RELAXED_STRIDES_DEBUG:
+                moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 1))
 
             # Get long double representation
             if sys.platform != 'darwin':
@@ -541,6 +552,9 @@ def configuration(parent_package='',top_path=None):
 
             if NPY_RELAXED_STRIDES_CHECKING:
                 moredefs.append(('NPY_RELAXED_STRIDES_CHECKING', 1))
+
+            if NPY_RELAXED_STRIDES_DEBUG:
+                moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 1))
 
             # Check wether we can use inttypes (C99) formats
             if config_cmd.check_decl('PRIdPTR', headers=['inttypes.h']):

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3831,10 +3831,12 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             else {
                 not_cf_contig = 0;
             }
+#if NPY_RELAXED_STRIDES_DEBUG
+            /* For testing purpose only */
             if (dims[i] == 1) {
-                /* For testing purpose only */
                 strides[i] = NPY_MAX_INTP;
             }
+#endif /* NPY_RELAXED_STRIDES_DEBUG */
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }
 #if NPY_RELAXED_STRIDES_CHECKING
@@ -3859,10 +3861,12 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
             else {
                 not_cf_contig = 0;
             }
+#if NPY_RELAXED_STRIDES_DEBUG
+            /* For testing purpose only */
             if (dims[i] == 1) {
-                /* For testing purpose only */
                 strides[i] = NPY_MAX_INTP;
             }
+#endif /* NPY_RELAXED_STRIDES_DEBUG */
 #endif /* NPY_RELAXED_STRIDES_CHECKING */
         }
 #if NPY_RELAXED_STRIDES_CHECKING


### PR DESCRIPTION
Setting NPY_RELAXED_STRIDES_DEBUG=1 in the enviroment when relaxed
stride checking is enabled will cause numpy to be compiled with affected
strides set to bogus values in order to help smoke out incorrect usage
of strides in downstream projects.