### PR TITLE
DOC: Remove empty Example section in `legfit`

### DIFF
--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1507,9 +1507,6 @@ def legfit(x, y, deg, rcond=None, full=False, w=None):
     .. [1] Wikipedia, "Curve fitting",
            http://en.wikipedia.org/wiki/Curve_fitting
 
-    Examples
-    --------
-
     """
     x = np.asarray(x) + 0.0
     y = np.asarray(y) + 0.0


### PR DESCRIPTION
I was just poking around at numpydoc, and saw that this section was empty, 
So I removed it, otherwise when exploring with IPython you can wonder "Why do the example no show up?". The sphinx extension see to already take care of not showing empty sections. 

Thanks. 