### PR TITLE
BUG: ndarray.conjugate broken for custom dtypes (unlike np.conjugate)

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -28,6 +28,8 @@ Deprecations
 * Use of the C-API ``NPY_CHAR`` type number deprecated since version 1.7 will
   now raise deprecation warnings at runtime. Extensions built with older f2py
   versions need to be recompiled to remove the warning.
+* Calling ``ndarray.conjugate`` on non-numeric dtypes is deprecated (it
+  should match the behavior of ``np.conjugate``, which throws an error).
 
 
 Build System Changes

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -1186,6 +1186,14 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
     }
     else {
         PyArrayObject *ret;
+        if (!PyArray_ISNUMBER(self)) {
+            /* 2017-05-04, 1.13 */
+            if (DEPRECATE("attempting to conjugate non-numeric dtype; this "
+                          "will error in the future to match the behavior of "
+                          "np.conjugate") < 0) {
+                return NULL;
+            }
+        }
         if (out) {
             if (PyArray_AssignArray(out, self,
                         NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -1173,7 +1173,8 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
 NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
-    if (PyArray_ISCOMPLEX(self) || PyArray_ISOBJECT(self)) {
+    if (PyArray_ISCOMPLEX(self) || PyArray_ISOBJECT(self) ||
+            PyArray_ISUSERDEF(self)) {
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -420,6 +420,18 @@ class TestClassicIntDivision(_DeprecationTestCase):
                 self.assert_deprecated(op.div, args=(a,b))
                 dt2 = dt1
 
+class TestNonNumericConjugate(_DeprecationTestCase):
+    """
+    Deprecate no-op behavior of ndarray.conjugate on non-numeric dtypes,
+    which conflicts with the error behavior of np.conjugate.
+    """
+    def test_conjugate(self):
+        for a in np.array(5), np.array(5j):
+            self.assert_not_deprecated(a.conjugate)
+        for a in (np.array('s'), np.array('2016', 'M'),
+                np.array((1, 2), [('a', int), ('b', int)])):
+            self.assert_deprecated(a.conjugate)
+
 
 class TestNPY_CHAR(_DeprecationTestCase):
     # 2017-05-03, 1.13.0


### PR DESCRIPTION
In #4730, @andyjost noted that `ndarray.conjugate` was broken for arrays of objects. This was fixed in #4887 by @juliantaylor by extending the conditions guarding a no-op fall-through to exclude both complex- and object-typed arrays. Unfortunately this solution is not complete, because custom dtypes may be conjugateable without being objects. This patch simply removes the fall-through, which actually makes the behaviors of the `np.conjugate` ufunc and `ndarray.conjugate` the same as documented.

This will be slower if `ndarray.conjugate` is used (needlessly) on real data; but then, it's now the same speed as `np.conjugate`. (Is numpy exploiting the specific no-op behavior of `ndarray.conjugate` anywhere?)

This is especially relevant to @moble's https://github.com/moble/quaternion library, which will silently no-op when using `ndarray.conjugate` on non-zero-dim arrays.