### PR TITLE
BUG: `__array_ufunc__= None` -> TypeError

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -81,14 +81,11 @@ NumPy provides several hooks that classes can customize:
        same may happen with functions such as :func:`~numpy.median`,
        :func:`~numpy.min`, and :func:`~numpy.argsort`.
 
-
    Like with some other special methods in python, such as ``__hash__`` and
    ``__iter__``, it is possible to indicate that your class does *not*
-   support ufuncs by setting ``__array_ufunc__ = None``. With this,
-   inside ufuncs, your class will be treated as if it returned
-   :obj:`NotImplemented` (which will lead to an :exc:`TypeError`
-   unless another class also provides a :func:`__array_ufunc__` method
-   which knows what to do with your class).
+   support ufuncs by setting ``__array_ufunc__ = None``. Ufuncs always raise
+   :exc:`TypeError` when called on an object that sets
+   ``__array_ufunc__ = None``.
 
    The presence of :func:`__array_ufunc__` also influences how
    :class:`ndarray` handles binary operations like ``arr + obj`` and ``arr
@@ -102,10 +99,9 @@ NumPy provides several hooks that classes can customize:
 
    Alternatively, if ``obj.__array_ufunc__`` is set to :obj:`None`, then as a
    special case, special methods like ``ndarray.__add__`` will notice this
-   and *unconditionally* return :obj:`NotImplemented`, so that Python will
-   dispatch to ``obj.__radd__`` instead. This is useful if you want to define
-   a special object that interacts with arrays via binary operations, but
-   is not itself an array. For example, a units handling system might have
+   and *unconditionally* raise :exc:`TypeError`. This is useful if you want to
+   create objects that interact with arrays via binary operations, but
+   are not themselves arrays. For example, a units handling system might have
    an object ``m`` representing the "meters" unit, and want to support the
    syntax ``arr * m`` to represent that the array has units of "meters", but
    not want to otherwise interact with arrays via ufuncs or otherwise. This

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1012,6 +1012,7 @@ array_ufunc(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *ufunc, *method_name, *normal_args, *ufunc_method;
     PyObject *result = NULL;
+    int num_override_args;
 
     if (PyTuple_Size(args) < 2) {
         PyErr_SetString(PyExc_TypeError,
@@ -1023,7 +1024,11 @@ array_ufunc(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
     /* ndarray cannot handle overrides itself */
-    if (PyUFunc_WithOverride(normal_args, kwds, NULL)) {
+    num_override_args = PyUFunc_WithOverride(normal_args, kwds, NULL);
+    if (num_override_args == -1) {
+        return NULL;
+    }
+    if (num_override_args) {
         result = Py_NotImplemented;
         Py_INCREF(Py_NotImplemented);
         goto cleanup;
@@ -2527,7 +2532,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
     /*
      * While we could put these in `tp_sequence`, its' easier to define them
      * in terms of PyObject* arguments.
-     * 
+     *
      * We must provide these for compatibility with code that calls them
      * directly. They are already deprecated at a language level in python 2.7,
      * but are removed outright in python 3.


### PR DESCRIPTION
Fixes #9011, by making `__array_ufunc__ = None` on any operand cause `TypeError` to be raised.

I have also taken the opportunity to update the NEP, adjusting the language for this change and also added a recommendation for how to implement arithmetic alongside `__array_ufunc__` (xref #8892). This made me realize an important practical difference between @mhvk's options (1) and (2): option (1) is viral, in the sense that other objects implementing arithmetic with your object *also* need to follow NumPy's rules.

TODO:
- [x] Add tests
- [x] Fix failing tests
- [x] Document in NEP