### PR TITLE
ENH: Use `__array_ufunc__ = None` in polynomial convenience classes.

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -415,3 +415,10 @@ greater than ``mmap.ALLOCATIONGRANULARITY``.
 Previously, ``np.real`` and ``np.imag`` used to return array objects when
 provided a scalar input, which was inconsistent with other functions like
 ``np.angle`` and ``np.conj``.
+
+The polynomial convenience classes cannot be passed to ufuncs
+-------------------------------------------------------------
+The ABCPolyBase class, from which the convenience classes are derived, sets
+``__array_ufun__ = None`` in order of opt out of ufuncs. If a polynomial
+convenience class instance is passed as an argument to a ufunc, a ``TypeError``
+will now be raised.

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -64,8 +64,8 @@ class ABCPolyBase(object):
     # Not hashable
     __hash__ = None
 
-    # Don't let participate in array operations. Value doesn't matter.
-    __array_priority__ = 1000
+    # Opt out of numpy ufuncs and Python ops with ndarray subclasses.
+    __array_ufunc__ = None
 
     # Limit runaway size. T_n^m has degree n*m
     maxpower = 100

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -53,6 +53,7 @@ def test_class_methods():
         yield check_cutdeg, Poly
         yield check_truncate, Poly
         yield check_trim, Poly
+        yield check_ufunc_override, Poly
 
 
 #
@@ -573,6 +574,13 @@ def check_mapparms(Poly):
     w = 2*d + 1
     p = Poly([1], domain=d, window=w)
     assert_almost_equal([1, 2], p.mapparms())
+
+
+def check_ufunc_override(Poly):
+    p = Poly([1, 2, 3])
+    x = np.ones(3)
+    assert_raises(TypeError, np.add, p, x)
+    assert_raises(TypeError, np.add, x, p)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `__array_ufunc__ = None` to ABCPolyBase. This ensures that polynomial
convenience classes will not participate in ufuncs and will have priority
when combined with an ndarray in a Python binary operator.

`__array_priority__` is removed, as it is no longer needed.