### PR TITLE
BUG: don't silence warnings in ufunc.reduce

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -874,6 +874,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'umath', 'loops.h.src'),
             join('src', 'umath', 'loops.c.src'),
             join('src', 'umath', 'ufunc_object.c'),
+            join('src', 'umath', 'extobj.c'),
             join('src', 'umath', 'scalarmath.c.src'),
             join('src', 'umath', 'ufunc_type_resolution.c'),
             join('src', 'umath', 'override.c'),

--- a/numpy/core/src/umath/extobj.c
+++ b/numpy/core/src/umath/extobj.c
@@ -1,0 +1,317 @@
+#define _UMATHMODULE
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include <Python.h>
+
+#include "npy_config.h"
+
+#define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
+#define NO_IMPORT_ARRAY
+
+#include "npy_pycompat.h"
+
+#include "extobj.h"
+#include "numpy/ufuncobject.h"
+
+#include "ufunc_object.h"  /* for npy_um_str_pyvals_name */
+
+#if USE_USE_DEFAULTS==1
+static int PyUFunc_NUM_NODEFAULTS = 0;
+
+/*
+ * This is a strategy to buy a little speed up and avoid the dictionary
+ * look-up in the default case.  It should work in the presence of
+ * threads.  If it is deemed too complicated or it doesn't actually work
+ * it could be taken out.
+ */
+NPY_NO_EXPORT int
+ufunc_update_use_defaults(void)
+{
+    PyObject *errobj = NULL;
+    int errmask, bufsize;
+    int res;
+
+    PyUFunc_NUM_NODEFAULTS += 1;
+    res = PyUFunc_GetPyValues("test", &bufsize, &errmask, &errobj);
+    PyUFunc_NUM_NODEFAULTS -= 1;
+    if (res < 0) {
+        Py_XDECREF(errobj);
+        return -1;
+    }
+    if ((errmask != UFUNC_ERR_DEFAULT) || (bufsize != NPY_BUFSIZE)
+            || (PyTuple_GET_ITEM(errobj, 1) != Py_None)) {
+        PyUFunc_NUM_NODEFAULTS += 1;
+    }
+    else if (PyUFunc_NUM_NODEFAULTS > 0) {
+        PyUFunc_NUM_NODEFAULTS -= 1;
+    }
+    Py_XDECREF(errobj);
+    return 0;
+}
+#endif
+
+/*
+ * fpstatus is the ufunc_formatted hardware status
+ * errmask is the handling mask specified by the user.
+ * errobj is a Python object with (string, callable object or None)
+ * or NULL
+ */
+
+/*
+ * 2. for each of the flags
+ * determine whether to ignore, warn, raise error, or call Python function.
+ * If ignore, do nothing
+ * If warn, print a warning and continue
+ * If raise return an error
+ * If call, call a user-defined function with string
+ */
+
+NPY_NO_EXPORT int
+_error_handler(int method, PyObject *errobj, char *errtype, int retstatus, int *first)
+{
+    PyObject *pyfunc, *ret, *args;
+    char *name = PyBytes_AS_STRING(PyTuple_GET_ITEM(errobj,0));
+    char msg[100];
+
+    NPY_ALLOW_C_API_DEF
+
+    /* don't need C API for a simple print */
+    if (method == UFUNC_ERR_PRINT) {
+        if (*first) {
+            fprintf(stderr, "Warning: %s encountered in %s\n", errtype, name);
+            *first = 0;
+        }
+        return 0;
+    }
+
+    NPY_ALLOW_C_API;
+    switch(method) {
+    case UFUNC_ERR_WARN:
+        PyOS_snprintf(msg, sizeof(msg), "%s encountered in %s", errtype, name);
+        if (PyErr_Warn(PyExc_RuntimeWarning, msg) < 0) {
+            goto fail;
+        }
+        break;
+    case UFUNC_ERR_RAISE:
+        PyErr_Format(PyExc_FloatingPointError, "%s encountered in %s",
+                errtype, name);
+        goto fail;
+    case UFUNC_ERR_CALL:
+        pyfunc = PyTuple_GET_ITEM(errobj, 1);
+        if (pyfunc == Py_None) {
+            PyErr_Format(PyExc_NameError,
+                    "python callback specified for %s (in " \
+                    " %s) but no function found.",
+                    errtype, name);
+            goto fail;
+        }
+        args = Py_BuildValue("NN", PyUString_FromString(errtype),
+                PyInt_FromLong((long) retstatus));
+        if (args == NULL) {
+            goto fail;
+        }
+        ret = PyObject_CallObject(pyfunc, args);
+        Py_DECREF(args);
+        if (ret == NULL) {
+            goto fail;
+        }
+        Py_DECREF(ret);
+        break;
+    case UFUNC_ERR_LOG:
+        if (first) {
+            *first = 0;
+            pyfunc = PyTuple_GET_ITEM(errobj, 1);
+            if (pyfunc == Py_None) {
+                PyErr_Format(PyExc_NameError,
+                        "log specified for %s (in %s) but no " \
+                        "object with write method found.",
+                        errtype, name);
+                goto fail;
+            }
+            PyOS_snprintf(msg, sizeof(msg),
+                    "Warning: %s encountered in %s\n", errtype, name);
+            ret = PyObject_CallMethod(pyfunc, "write", "s", msg);
+            if (ret == NULL) {
+                goto fail;
+            }
+            Py_DECREF(ret);
+        }
+        break;
+    }
+    NPY_DISABLE_C_API;
+    return 0;
+
+fail:
+    NPY_DISABLE_C_API;
+    return -1;
+}
+
+
+
+NPY_NO_EXPORT PyObject *
+get_global_ext_obj(void)
+{
+    PyObject *thedict;
+    PyObject *ref = NULL;
+
+#if USE_USE_DEFAULTS==1
+    if (PyUFunc_NUM_NODEFAULTS != 0) {
+#endif
+        thedict = PyThreadState_GetDict();
+        if (thedict == NULL) {
+            thedict = PyEval_GetBuiltins();
+        }
+        ref = PyDict_GetItem(thedict, npy_um_str_pyvals_name);
+#if USE_USE_DEFAULTS==1
+    }
+#endif
+
+    return ref;
+}
+
+
+/*
+ * Extracts some values from the global pyvals tuple.
+ * all destinations may be NULL, in which case they are not retrieved
+ * ref - should hold the global tuple
+ * name - is the name of the ufunc (ufuncobj->name)
+ *
+ * bufsize - receives the buffer size to use
+ * errmask - receives the bitmask for error handling
+ * errobj - receives the python object to call with the error,
+ *          if an error handling method is 'call'
+ */
+NPY_NO_EXPORT int
+_extract_pyvals(PyObject *ref, const char *name, int *bufsize,
+                int *errmask, PyObject **errobj)
+{
+    PyObject *retval;
+
+    /* default errobj case, skips dictionary lookup */
+    if (ref == NULL) {
+        if (errmask) {
+            *errmask = UFUNC_ERR_DEFAULT;
+        }
+        if (errobj) {
+            *errobj = Py_BuildValue("NO", PyBytes_FromString(name), Py_None);
+        }
+        if (bufsize) {
+            *bufsize = NPY_BUFSIZE;
+        }
+        return 0;
+    }
+
+    if (!PyList_Check(ref) || (PyList_GET_SIZE(ref)!=3)) {
+        PyErr_Format(PyExc_TypeError,
+                "%s must be a length 3 list.", UFUNC_PYVALS_NAME);
+        return -1;
+    }
+
+    if (bufsize != NULL) {
+        *bufsize = PyInt_AsLong(PyList_GET_ITEM(ref, 0));
+        if ((*bufsize == -1) && PyErr_Occurred()) {
+            return -1;
+        }
+        if ((*bufsize < NPY_MIN_BUFSIZE) ||
+                (*bufsize > NPY_MAX_BUFSIZE) ||
+                (*bufsize % 16 != 0)) {
+            PyErr_Format(PyExc_ValueError,
+                    "buffer size (%d) is not in range "
+                    "(%"NPY_INTP_FMT" - %"NPY_INTP_FMT") or not a multiple of 16",
+                    *bufsize, (npy_intp) NPY_MIN_BUFSIZE,
+                    (npy_intp) NPY_MAX_BUFSIZE);
+            return -1;
+        }
+    }
+
+    if (errmask != NULL) {
+        *errmask = PyInt_AsLong(PyList_GET_ITEM(ref, 1));
+        if (*errmask < 0) {
+            if (PyErr_Occurred()) {
+                return -1;
+            }
+            PyErr_Format(PyExc_ValueError,
+                         "invalid error mask (%d)",
+                         *errmask);
+            return -1;
+        }
+    }
+
+    if (errobj != NULL) {
+        *errobj = NULL;
+        retval = PyList_GET_ITEM(ref, 2);
+        if (retval != Py_None && !PyCallable_Check(retval)) {
+            PyObject *temp;
+            temp = PyObject_GetAttrString(retval, "write");
+            if (temp == NULL || !PyCallable_Check(temp)) {
+                PyErr_SetString(PyExc_TypeError,
+                                "python object must be callable or have " \
+                                "a callable write method");
+                Py_XDECREF(temp);
+                return -1;
+            }
+            Py_DECREF(temp);
+        }
+
+        *errobj = Py_BuildValue("NO", PyBytes_FromString(name), retval);
+        if (*errobj == NULL) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * check the floating point status
+ *  - errmask: mask of status to check
+ *  - extobj: ufunc pyvals object
+ *            may be null, in which case the thread global one is fetched
+ *  - ufunc_name: name of ufunc
+ */
+NPY_NO_EXPORT int
+_check_ufunc_fperr(int errmask, PyObject *extobj, const char *ufunc_name) {
+    int fperr;
+    PyObject *errobj = NULL;
+    int ret;
+    int first = 1;
+
+    if (!errmask) {
+        return 0;
+    }
+    fperr = PyUFunc_getfperr();
+    if (!fperr) {
+        return 0;
+    }
+
+    /* Get error object globals */
+    if (extobj == NULL) {
+        extobj = get_global_ext_obj();
+    }
+    if (_extract_pyvals(extobj, ufunc_name,
+                        NULL, NULL, &errobj) < 0) {
+        Py_XDECREF(errobj);
+        return -1;
+    }
+
+    ret = PyUFunc_handlefperr(errmask, errobj, fperr, &first);
+    Py_XDECREF(errobj);
+
+    return ret;
+}
+
+
+NPY_NO_EXPORT int
+_get_bufsize_errmask(PyObject * extobj, const char *ufunc_name,
+                     int *buffersize, int *errormask)
+{
+    /* Get the buffersize and errormask */
+    if (extobj == NULL) {
+        extobj = get_global_ext_obj();
+    }
+    if (_extract_pyvals(extobj, ufunc_name,
+                        buffersize, errormask, NULL) < 0) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/numpy/core/src/umath/extobj.h
+++ b/numpy/core/src/umath/extobj.h
@@ -1,0 +1,32 @@
+#ifndef _NPY_PRIVATE__EXTOBJ_H_
+#define _NPY_PRIVATE__EXTOBJ_H_
+
+#include <numpy/ndarraytypes.h>  /* for NPY_NO_EXPORT */
+
+NPY_NO_EXPORT int
+_error_handler(int method, PyObject *errobj, char *errtype, int retstatus, int *first);
+
+NPY_NO_EXPORT PyObject *
+get_global_ext_obj(void);
+
+NPY_NO_EXPORT int
+_extract_pyvals(PyObject *ref, const char *name, int *bufsize,
+                int *errmask, PyObject **errobj);
+
+NPY_NO_EXPORT int
+_check_ufunc_fperr(int errmask, PyObject *extobj, const char *ufunc_name);
+
+NPY_NO_EXPORT int
+_get_bufsize_errmask(PyObject * extobj, const char *ufunc_name,
+                     int *buffersize, int *errormask);
+
+/********************/
+#define USE_USE_DEFAULTS 1
+/********************/
+
+#if USE_USE_DEFAULTS==1
+NPY_NO_EXPORT int
+ufunc_update_use_defaults(void);
+#endif
+
+#endif

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1862,6 +1862,7 @@ NPY_NO_EXPORT void
             *((@type@ *)op1) = (in1 @OP@ in2 || npy_isnan(in2)) ? in1 : in2;
         }
     }
+    npy_clear_floatstatus();
 }
 /**end repeat1**/
 
@@ -2200,6 +2201,7 @@ HALF_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
         const npy_half in2 = *(npy_half *)ip2;
         *((npy_half *)op1) = (@OP@(in1, in2) || npy_half_isnan(in2)) ? in1 : in2;
     }
+    npy_clear_floatstatus();
 }
 /**end repeat**/
 
@@ -2749,6 +2751,7 @@ NPY_NO_EXPORT void
             ((@ftype@ *)op1)[1] = in2i;
         }
     }
+    npy_clear_floatstatus();
 }
 /**end repeat1**/
 

--- a/numpy/core/src/umath/reduction.h
+++ b/numpy/core/src/umath/reduction.h
@@ -137,6 +137,7 @@ typedef int (PyArray_ReduceLoopFunc)(NpyIter *iter,
  * data        : Data which is passed to assign_identity and the inner loop.
  * buffersize  : Buffer size for the iterator. For the default, pass in 0.
  * funcname    : The name of the reduction function, for error messages.
+ * errormask   : forwarded from _get_bufsize_errmask
  */
 NPY_NO_EXPORT PyArrayObject *
 PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
@@ -149,6 +150,7 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
                       int subok,
                       PyArray_AssignReduceIdentityFunc *assign_identity,
                       PyArray_ReduceLoopFunc *loop,
-                      void *data, npy_intp buffersize, const char *funcname);
+                      void *data, npy_intp buffersize, const char *funcname,
+                      int errormask);
 
 #endif

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -46,6 +46,7 @@
 #include "ufunc_object.h"
 #include "override.h"
 #include "npy_import.h"
+#include "extobj.h"
 
 /********** PRINTF DEBUG TRACING **************/
 #define NPY_UF_DBG_TRACING 0
@@ -63,19 +64,10 @@
 #endif
 /**********************************************/
 
-
-/********************/
-#define USE_USE_DEFAULTS 1
-/********************/
-
 /* ---------------------------------------------------------------- */
 
 static int
 _does_loop_use_arrays(void *data);
-
-static int
-_extract_pyvals(PyObject *ref, const char *name, int *bufsize,
-                int *errmask, PyObject **errobj);
 
 static int
 assign_reduce_identity_zero(PyArrayObject *result, void *data);
@@ -85,103 +77,6 @@ assign_reduce_identity_minusone(PyArrayObject *result, void *data);
 
 static int
 assign_reduce_identity_one(PyArrayObject *result, void *data);
-
-
-/*
- * fpstatus is the ufunc_formatted hardware status
- * errmask is the handling mask specified by the user.
- * errobj is a Python object with (string, callable object or None)
- * or NULL
- */
-
-/*
- * 2. for each of the flags
- * determine whether to ignore, warn, raise error, or call Python function.
- * If ignore, do nothing
- * If warn, print a warning and continue
- * If raise return an error
- * If call, call a user-defined function with string
- */
-
-static int
-_error_handler(int method, PyObject *errobj, char *errtype, int retstatus, int *first)
-{
-    PyObject *pyfunc, *ret, *args;
-    char *name = PyBytes_AS_STRING(PyTuple_GET_ITEM(errobj,0));
-    char msg[100];
-
-    NPY_ALLOW_C_API_DEF
-
-    /* don't need C API for a simple print */
-    if (method == UFUNC_ERR_PRINT) {
-        if (*first) {
-            fprintf(stderr, "Warning: %s encountered in %s\n", errtype, name);
-            *first = 0;
-        }
-        return 0;
-    }
-
-    NPY_ALLOW_C_API;
-    switch(method) {
-    case UFUNC_ERR_WARN:
-        PyOS_snprintf(msg, sizeof(msg), "%s encountered in %s", errtype, name);
-        if (PyErr_Warn(PyExc_RuntimeWarning, msg) < 0) {
-            goto fail;
-        }
-        break;
-    case UFUNC_ERR_RAISE:
-        PyErr_Format(PyExc_FloatingPointError, "%s encountered in %s",
-                errtype, name);
-        goto fail;
-    case UFUNC_ERR_CALL:
-        pyfunc = PyTuple_GET_ITEM(errobj, 1);
-        if (pyfunc == Py_None) {
-            PyErr_Format(PyExc_NameError,
-                    "python callback specified for %s (in " \
-                    " %s) but no function found.",
-                    errtype, name);
-            goto fail;
-        }
-        args = Py_BuildValue("NN", PyUString_FromString(errtype),
-                PyInt_FromLong((long) retstatus));
-        if (args == NULL) {
-            goto fail;
-        }
-        ret = PyObject_CallObject(pyfunc, args);
-        Py_DECREF(args);
-        if (ret == NULL) {
-            goto fail;
-        }
-        Py_DECREF(ret);
-        break;
-    case UFUNC_ERR_LOG:
-        if (first) {
-            *first = 0;
-            pyfunc = PyTuple_GET_ITEM(errobj, 1);
-            if (pyfunc == Py_None) {
-                PyErr_Format(PyExc_NameError,
-                        "log specified for %s (in %s) but no " \
-                        "object with write method found.",
-                        errtype, name);
-                goto fail;
-            }
-            PyOS_snprintf(msg, sizeof(msg),
-                    "Warning: %s encountered in %s\n", errtype, name);
-            ret = PyObject_CallMethod(pyfunc, "write", "s", msg);
-            if (ret == NULL) {
-                goto fail;
-            }
-            Py_DECREF(ret);
-        }
-        break;
-    }
-    NPY_DISABLE_C_API;
-    return 0;
-
-fail:
-    NPY_DISABLE_C_API;
-    return -1;
-}
 
 
 /*UFUNC_API*/
@@ -237,49 +132,6 @@ NPY_NO_EXPORT void
 PyUFunc_clearfperr()
 {
     npy_clear_floatstatus();
-}
-
-
-#if USE_USE_DEFAULTS==1
-static int PyUFunc_NUM_NODEFAULTS = 0;
-#endif
-
-static PyObject *
-get_global_ext_obj(void)
-{
-    PyObject *thedict;
-    PyObject *ref = NULL;
-
-#if USE_USE_DEFAULTS==1
-    if (PyUFunc_NUM_NODEFAULTS != 0) {
-#endif
-        thedict = PyThreadState_GetDict();
-        if (thedict == NULL) {
-            thedict = PyEval_GetBuiltins();
-        }
-        ref = PyDict_GetItem(thedict, npy_um_str_pyvals_name);
-#if USE_USE_DEFAULTS==1
-    }
-#endif
-
-    return ref;
-}
-
-
-static int
-_get_bufsize_errmask(PyObject * extobj, const char *ufunc_name,
-                     int *buffersize, int *errormask)
-{
-    /* Get the buffersize and errormask */
-    if (extobj == NULL) {
-        extobj = get_global_ext_obj();
-    }
-    if (_extract_pyvals(extobj, ufunc_name,
-                        buffersize, errormask, NULL) < 0) {
-        return -1;
-    }
-
-    return 0;
 }
 
 /*
@@ -424,97 +276,6 @@ _find_array_prepare(PyObject *args, PyObject *kwds,
     }
     Py_XDECREF(prep);
     return;
-}
-
-/*
- * Extracts some values from the global pyvals tuple.
- * all destinations may be NULL, in which case they are not retrieved
- * ref - should hold the global tuple
- * name - is the name of the ufunc (ufuncobj->name)
- *
- * bufsize - receives the buffer size to use
- * errmask - receives the bitmask for error handling
- * errobj - receives the python object to call with the error,
- *          if an error handling method is 'call'
- */
-static int
-_extract_pyvals(PyObject *ref, const char *name, int *bufsize,
-                int *errmask, PyObject **errobj)
-{
-    PyObject *retval;
-
-    /* default errobj case, skips dictionary lookup */
-    if (ref == NULL) {
-        if (errmask) {
-            *errmask = UFUNC_ERR_DEFAULT;
-        }
-        if (errobj) {
-            *errobj = Py_BuildValue("NO", PyBytes_FromString(name), Py_None);
-        }
-        if (bufsize) {
-            *bufsize = NPY_BUFSIZE;
-        }
-        return 0;
-    }
-
-    if (!PyList_Check(ref) || (PyList_GET_SIZE(ref)!=3)) {
-        PyErr_Format(PyExc_TypeError,
-                "%s must be a length 3 list.", UFUNC_PYVALS_NAME);
-        return -1;
-    }
-
-    if (bufsize != NULL) {
-        *bufsize = PyInt_AsLong(PyList_GET_ITEM(ref, 0));
-        if ((*bufsize == -1) && PyErr_Occurred()) {
-            return -1;
-        }
-        if ((*bufsize < NPY_MIN_BUFSIZE) ||
-                (*bufsize > NPY_MAX_BUFSIZE) ||
-                (*bufsize % 16 != 0)) {
-            PyErr_Format(PyExc_ValueError,
-                    "buffer size (%d) is not in range "
-                    "(%"NPY_INTP_FMT" - %"NPY_INTP_FMT") or not a multiple of 16",
-                    *bufsize, (npy_intp) NPY_MIN_BUFSIZE,
-                    (npy_intp) NPY_MAX_BUFSIZE);
-            return -1;
-        }
-    }
-
-    if (errmask != NULL) {
-        *errmask = PyInt_AsLong(PyList_GET_ITEM(ref, 1));
-        if (*errmask < 0) {
-            if (PyErr_Occurred()) {
-                return -1;
-            }
-            PyErr_Format(PyExc_ValueError,
-                         "invalid error mask (%d)",
-                         *errmask);
-            return -1;
-        }
-    }
-
-    if (errobj != NULL) {
-        *errobj = NULL;
-        retval = PyList_GET_ITEM(ref, 2);
-        if (retval != Py_None && !PyCallable_Check(retval)) {
-            PyObject *temp;
-            temp = PyObject_GetAttrString(retval, "write");
-            if (temp == NULL || !PyCallable_Check(temp)) {
-                PyErr_SetString(PyExc_TypeError,
-                                "python object must be callable or have " \
-                                "a callable write method");
-                Py_XDECREF(temp);
-                return -1;
-            }
-            Py_DECREF(temp);
-        }
-
-        *errobj = Py_BuildValue("NO", PyBytes_FromString(name), retval);
-        if (*errobj == NULL) {
-            return -1;
-        }
-    }
-    return 0;
 }
 
 
@@ -1954,44 +1715,6 @@ make_arr_prep_args(npy_intp nin, PyObject *args, PyObject *kwds)
 }
 
 /*
- * check the floating point status
- *  - errmask: mask of status to check
- *  - extobj: ufunc pyvals object
- *            may be null, in which case the thread global one is fetched
- *  - ufunc_name: name of ufunc
- */
-static int
-_check_ufunc_fperr(int errmask, PyObject *extobj, const char *ufunc_name) {
-    int fperr;
-    PyObject *errobj = NULL;
-    int ret;
-    int first = 1;
-
-    if (!errmask) {
-        return 0;
-    }
-    fperr = PyUFunc_getfperr();
-    if (!fperr) {
-        return 0;
-    }
-
-    /* Get error object globals */
-    if (extobj == NULL) {
-        extobj = get_global_ext_obj();
-    }
-    if (_extract_pyvals(extobj, ufunc_name,
-                        NULL, NULL, &errobj) < 0) {
-        Py_XDECREF(errobj);
-        return -1;
-    }
-
-    ret = PyUFunc_handlefperr(errmask, errobj, fperr, &first);
-    Py_XDECREF(errobj);
-
-    return ret;
-}
-
-/*
  * Validate the core dimensions of all the operands, and collect all of
  * the labelled core dimensions into 'core_dim_sizes'.
  * 
@@ -2107,7 +1830,6 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
     }
     return 0;
 }
-
 
 static int
 PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
@@ -4509,39 +4231,6 @@ ufunc_geterr(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyList_SET_ITEM(res, 2, Py_None); Py_INCREF(Py_None);
     return res;
 }
-
-#if USE_USE_DEFAULTS==1
-/*
- * This is a strategy to buy a little speed up and avoid the dictionary
- * look-up in the default case.  It should work in the presence of
- * threads.  If it is deemed too complicated or it doesn't actually work
- * it could be taken out.
- */
-static int
-ufunc_update_use_defaults(void)
-{
-    PyObject *errobj = NULL;
-    int errmask, bufsize;
-    int res;
-
-    PyUFunc_NUM_NODEFAULTS += 1;
-    res = PyUFunc_GetPyValues("test", &bufsize, &errmask, &errobj);
-    PyUFunc_NUM_NODEFAULTS -= 1;
-    if (res < 0) {
-        Py_XDECREF(errobj);
-        return -1;
-    }
-    if ((errmask != UFUNC_ERR_DEFAULT) || (bufsize != NPY_BUFSIZE)
-            || (PyTuple_GET_ITEM(errobj, 1) != Py_None)) {
-        PyUFunc_NUM_NODEFAULTS += 1;
-    }
-    else if (PyUFunc_NUM_NODEFAULTS > 0) {
-        PyUFunc_NUM_NODEFAULTS -= 1;
-    }
-    Py_XDECREF(errobj);
-    return 0;
-}
-#endif
 
 NPY_NO_EXPORT PyObject *
 ufunc_seterr(PyObject *NPY_UNUSED(dummy), PyObject *args)

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3616,7 +3616,6 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     PyObject *obj_ind, *context;
     PyArrayObject *indices = NULL;
     PyArray_Descr *otype = NULL;
-    PyObject *out_obj = NULL;
     PyArrayObject *out = NULL;
     int keepdims = 0;
     static char *reduce_kwlist[] = {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2867,7 +2867,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
                                    keepdims, 0,
                                    assign_identity,
                                    reduce_loop,
-                                   ufunc, buffersize, ufunc_name);
+                                   ufunc, buffersize, ufunc_name, errormask);
 
     Py_DECREF(dtype);
     return result;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3423,8 +3423,13 @@ class TestArgmax(TestCase):
 
     def test_combinations(self):
         for arr, pos in self.nan_arr:
+            with suppress_warnings() as sup:
+                sup.filter(RuntimeWarning,
+                           "invalid value encountered in reduce")
+                max_val = np.max(arr)
+
             assert_equal(np.argmax(arr), pos, err_msg="%r" % arr)
-            assert_equal(arr[np.argmax(arr)], np.max(arr), err_msg="%r" % arr)
+            assert_equal(arr[np.argmax(arr)], max_val, err_msg="%r" % arr)
 
     def test_output_shape(self):
         # see also gh-616
@@ -3552,8 +3557,13 @@ class TestArgmin(TestCase):
 
     def test_combinations(self):
         for arr, pos in self.nan_arr:
+            with suppress_warnings() as sup:
+                sup.filter(RuntimeWarning,
+                           "invalid value encountered in reduce")
+                min_val = np.min(arr)
+
             assert_equal(np.argmin(arr), pos, err_msg="%r" % arr)
-            assert_equal(arr[np.argmin(arr)], np.min(arr), err_msg="%r" % arr)
+            assert_equal(arr[np.argmin(arr)], min_val, err_msg="%r" % arr)
 
     def test_minimum_signed_integers(self):
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1299,8 +1299,11 @@ class TestMinMax(TestCase):
                     inp[:] = np.arange(inp.size, dtype=dt)
                     inp[i] = np.nan
                     emsg = lambda: '%r\n%s' % (inp, msg)
-                    assert_(np.isnan(inp.max()), msg=emsg)
-                    assert_(np.isnan(inp.min()), msg=emsg)
+                    with suppress_warnings() as sup:
+                        sup.filter(RuntimeWarning,
+                                   "invalid value encountered in reduce")
+                        assert_(np.isnan(inp.max()), msg=emsg)
+                        assert_(np.isnan(inp.min()), msg=emsg)
 
                     inp[i] = 1e10
                     assert_equal(inp.max(), 1e10, err_msg=msg)


### PR DESCRIPTION
Needed a file of helper functions so that this was actually visible in `reduction.c`. This move is in the first commit.

Fix itself is trivial once things are visible.

Fixes #8954