### PR TITLE
BUG: don't silence `__array_wrap__` errors in `ufunc.reduce`

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1568,13 +1568,14 @@ class TestSpecialMethods(object):
 
         class A(object):
             def __array__(self):
-                return np.zeros(1)
+                return np.zeros(2)
 
             def __array_wrap__(self, arr, context):
                 raise RuntimeError
 
         a = A()
         assert_raises(RuntimeError, ncu.maximum, a, a)
+        assert_raises(RuntimeError, ncu.maximum.reduce, a)
 
     def test_failing_out_wrap(self):
 

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -52,7 +52,8 @@ class TestUfunclike(object):
                 return res
 
             def __array_wrap__(self, obj, context=None):
-                obj.metadata = self.metadata
+                if isinstance(obj, MyArray):
+                    obj.metadata = self.metadata
                 return obj
 
             def __array_finalize__(self, obj):


### PR DESCRIPTION
Raised by https://github.com/numpy/numpy/issues/5819#issuecomment-298057066.

* Classes that declared `__array_wrap__(self, obj, context)`, with no default argument for `context`, would find that this method was never called by `reduce`
* Any errors that happen inside `__array_wrap__` were silenced, and the result downcast to ndarray
