### PR TITLE
DOC: Correct default stop index value for negative stepping.

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -85,7 +85,7 @@ concepts to remember include:
 - Assume *n* is the number of elements in the dimension being
   sliced. Then, if *i* is not given it defaults to 0 for *k > 0* and
   *n - 1* for *k < 0* . If *j* is not given it defaults to *n* for *k > 0*
-  and -1 for *k < 0* . If *k* is not given it defaults to 1. Note that
+  and *-n-1* for *k < 0* . If *k* is not given it defaults to 1. Note that
   ``::`` is the same as ``:`` and means select all indices along this
   axis.
 


### PR DESCRIPTION
On line 88 the default value for stop index 'j' in the basic slice syntax is i:j:k for negative values of k is given as -1

Line 88:    and -1 for *k < 0* . If *k* is not given it defaults to 1. Note that

Proposing that this should be changed to -n-1:

Line 88:   and *-n-1* for *k < 0* . If *k* is not given it defaults to 1. Note that

The issue was discussed and  was approved by a project member see the following link :
https://github.com/numpy/numpy/issues/9010#issuecomment-298095768