### PR TITLE
DOC: update binary-op / ufunc interactions and recommendations in ufunc overrides NEP

### DIFF
--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -620,8 +620,8 @@ make more sense to ask classes like ``MyObject`` to implement a full
 ``__array_ufunc__`` [6]_. In the end, allowing classes to opt out was
 preferred, and the above reasoning led us to agree on a similar
 implementation for :class:`ndarray` itself. We decided to require disabling
-ufuncs to opt out to ensure that a class cannot define Ufuncs to return
-different results than the corresponding binary operations (i.e., if
+ufuncs to opt out in order to ensure that a class cannot define Ufuncs to
+return different results than the corresponding binary operations (i.e., if
 ``np.add(x, y)`` is defined, it should match ``x + y``).
 
 .. [9] http://bugs.python.org/issue30140
@@ -658,8 +658,8 @@ Symbol Operator     NumPy Ufunc(s)
 ``&``  ``and_``     :func:`bitwise_and`
 ``^``  ``xor_``     :func:`bitwise_xor`
 ``|``  ``or_``      :func:`bitwise_or`
-\      ``divmod``   :func:`floor_divide`, :func:`mod` [*]_
-``@``  ``matmul``   Not yet implemented
+NA     ``divmod``   :func:`floor_divide`, :func:`mod` [*]_
+``@``  ``matmul``   Not yet implemented as a ufunc
 ====== ============ =========================================
 
 .. [*] In the future, NumPy may switch to use a single ufunc ``divmod_`` instead.

--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -466,10 +466,11 @@ implements the following behavior:
 - Otherwise, :class:`ndarray` unilaterally calls the corresponding Ufunc.
   Ufuncs never return ``NotImplemented``, so **reflexive methods such
   as** ``other.__rmul__`` **cannot be used to override arithmetic with
-  NumPy arrays if** ``__array_ufunc__`` **is set**. Instead, the resulting
-  behavior can be modified by implementing ``__array_ufunc__`` in a
-  consistent fashion for the corresponding Ufunc (e.g., ``np.multiply``, see
-  :ref:`neps.ufunc-overrides.list-of-operators`).
+  NumPy arrays if** ``__array_ufunc__`` **is set** to any value other than
+  ``None``. Instead, their behavior needs to be changed by implementing
+  ``__array_ufunc__`` in a fashion consistent with the corresponding Ufunc,
+  e.g., ``np.multiply``. See :ref:`neps.ufunc-overrides.list-of-operators`
+  for a list of affected operators and their corresponding ufuncs.
 
 A class wishing to modify the interaction with :class:`ndarray` in
 binary operations therefore has two options:

--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -629,7 +629,7 @@ implementation for :class:`ndarray` itself. The opt-out mechanism requires
 disabling Ufuncs so a class cannot define a Ufuncs to return a different
 result than the corresponding binary operations (i.e., if
 ``np.add(x, y)`` is defined, it should match ``x + y``). Our goal was to
-simply the dispatch logic for binary operations with NumPy arrays
+simplify the dispatch logic for binary operations with NumPy arrays
 as much as possible, by making it possible to use Python's dispatch rules
 or NumPy's dispatch rules, but not some mixture of both at the same time.
 


### PR DESCRIPTION
Split off and extended from #9014

Adds:
- More explicit language about how binary operators work, hopefully assuming less knowledge about how Python defines binary operations (I'm guessing this NEP will be read by users not as  familiar with them as we are).
- A recommendation to use "Option (1)" for implementing special methods on array-like classes.
- More explanation of our reasoning for why opting out of numpy style binary operations requires `__array_ufunc__ = None`.
- A table of binary operators and corresponding numpy ufuncs. I think this will be useful for implementors, e.g., for someone writing a unit library or another mixin class like `NDArrayOperatorsMixin`.

Because we have listed authors on the NEP, I would like to make sure that every listed author approves of the document before we merge this change:

- [ ] @cowlicks
- [ ] @pv 
- [X] @mhvk 
- [x] @njsmith 

(Feel free to check off your name on this list if you have edit rights, or I will do so, after you've responded affirmatively in a comment.)

