### PR TITLE
Resizing an array but not its data.

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1735,16 +1735,20 @@ Shape Manipulation
 
 .. c:function:: PyObject* PyArray_Resize( \
         PyArrayObject* self, PyArray_Dims* newshape, int refcheck, \
-        NPY_ORDER fortran)
+        NPY_ORDER fortran, int mustown)
 
     Equivalent to :meth:`ndarray.resize<numpy.ndarray.resize>` (*self*, *newshape*, refcheck
-    ``=`` *refcheck*, order= fortran ). This function only works on
+    ``=`` *refcheck*, order= fortran, mustown ``=`` *mustown* ). This function only works on
     single-segment arrays. It changes the shape of *self* inplace and
     will reallocate the memory for *self* if *newshape* has a
     different total number of elements then the old shape. If
     reallocation is necessary, then *self* must own its data, have
     *self* - ``>base==NULL``, have *self* - ``>weakrefs==NULL``, and
     (unless refcheck is 0) not be referenced by any other array.
+    If *mustown* is 0, all array metadata is modified according to the resize
+    operation, but the data itself is not changed in any way.
+    This is useful if the data is managed by someone else, such as memmap, and
+    has already been resized as necessary.
     The fortran argument can be :c:data:`NPY_ANYORDER`, :c:data:`NPY_CORDER`,
     or :c:data:`NPY_FORTRANORDER`. It currently has no effect. Eventually
     it could be used to determine how the resize operation should view

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -316,6 +316,10 @@ class memmap(ndarray):
         if self.base is not None and hasattr(self.base, 'flush'):
             self.base.flush()
 
+    def resize(self, new_shape):
+        self._mmap.resize(self.itemsize*np.prod(new_shape))
+        super(memmap, self).resize(new_shape, mustown=False)
+
     def __array_wrap__(self, arr, context=None):
         arr = super(memmap, self).__array_wrap__(arr, context)
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1082,14 +1082,15 @@ array_copy_keeporder(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"refcheck", NULL};
+    static char *kwlist[] = {"refcheck", "mustown", NULL};
     Py_ssize_t size = PyTuple_Size(args);
     int refcheck = 1;
+    int mustown = 1;
     PyArray_Dims newshape;
     PyObject *ret, *obj;
 
 
-    if (!NpyArg_ParseKeywords(kwds, "|i", kwlist,  &refcheck)) {
+    if (!NpyArg_ParseKeywords(kwds, "|ii", kwlist,  &refcheck, &mustown)) {
         return NULL;
     }
 
@@ -1110,7 +1111,7 @@ array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    ret = PyArray_Resize(self, &newshape, refcheck, NPY_CORDER);
+    ret = PyArray_Resize(self, &newshape, refcheck, NPY_CORDER, mustown);
     PyDimMem_FREE(newshape.ptr);
     if (ret == NULL) {
         return NULL;

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -38,7 +38,7 @@ _putzero(char *optr, PyObject *zero, PyArray_Descr *dtype);
  */
 NPY_NO_EXPORT PyObject *
 PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
-               NPY_ORDER order)
+               NPY_ORDER order, int mustown)
 {
     npy_intp oldsize, newsize;
     int new_nd=newshape->len, k, n, elsize;
@@ -79,7 +79,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
     }
     oldsize = PyArray_SIZE(self);
 
-    if (oldsize != newsize) {
+    if (oldsize != newsize && mustown) {
         if (!(PyArray_FLAGS(self) & NPY_ARRAY_OWNDATA)) {
             PyErr_SetString(PyExc_ValueError,
                     "cannot resize this array: it does not own its data");
@@ -126,7 +126,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         ((PyArrayObject_fields *)self)->data = new_data;
     }
 
-    if ((newsize > oldsize) && PyArray_ISWRITEABLE(self)) {
+    if ((newsize > oldsize) && (PyArray_FLAGS(self) & NPY_ARRAY_OWNDATA) && PyArray_ISWRITEABLE(self)) {
         /* Fill new memory with zeros */
         elsize = PyArray_DESCR(self)->elsize;
         if (PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_ITEM_REFCOUNT)) {


### PR DESCRIPTION
This is a proof-of-concept for a fix to issue #4198. Before I go further with it (more doc+test, bikeshedding), I'd like feedback from numpy devs.

This adds a `mustown` parameter to `ndarray.resize`, if it is set to `False`, all metadata is updated as in an actual `resize` but the data isn't touched. This is for the use-case where the data is backed by another buffer (such as a memmap) which has already been resized externally. It also overwrites the `np.memmap.resize` such that it resizes the memmaped file first. For a little more context, see #4198.

I tested with the following, which "seems to work for me," but I'd like actual feedback before I go and write unittests and doc.

low-level:

```python
import numpy as np
buf = np.memmap('bla.bin', mode='w+', dtype=int, shape=10)
buf._mmap.resize(buf.itemsize*20)
np.ndarray.resize(buf, 20, mustown=False)
buf[:] = np.arange(len(buf))
print(buf)
```

high-level:

```python
buf2 = np.memmap('blub.bin', mode='w+', dtype=np.float32, shape=10)
buf2.resize(15)
buf2[:] = np.arange(len(buf2))
print(buf2)
np.testing.assert_array_equal(buf, buf2)
```

A little more indirect, but as suggested in the memmap docs:

```python
buf3 = np.memmap('blob.bin', mode='w+', dtype=int, shape=5)
arr3 = np.ndarray.__new__(np.ndarray, dtype=int, shape=5, buffer=buf3)
buf3.resize(15)
arr3.resize(15, mustown=False)
arr3[:] = np.arange(len(arr3))
print(arr3)
np.testing.assert_array_equal(buf, arr3)
```