### PR TITLE
BUG: distutils, add compatibility python parallelization

### DIFF
--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -569,14 +569,14 @@ class build_src(build_ext.build_ext):
         if not os.path.isfile(target_file):
             raise DistutilsError("f2py target file %r not generated" % (target_file,))
 
-        target_c = os.path.join(self.build_src, 'fortranobject.c')
-        target_h = os.path.join(self.build_src, 'fortranobject.h')
+        build_dir = os.path.join(self.build_src, target_dir)
+        target_c = os.path.join(build_dir, 'fortranobject.c')
+        target_h = os.path.join(build_dir, 'fortranobject.h')
         log.info("  adding '%s' to sources." % (target_c))
         new_sources.append(target_c)
-        if self.build_src not in extension.include_dirs:
-            log.info("  adding '%s' to include_dirs." \
-                     % (self.build_src))
-            extension.include_dirs.append(self.build_src)
+        if build_dir not in extension.include_dirs:
+            log.info("  adding '%s' to include_dirs." % (build_dir))
+            extension.include_dirs.append(build_dir)
 
         if not skip_f2py:
             import numpy.f2py


### PR DESCRIPTION
BUG: distutils, place fortranobject files in subfolder

Placing them all under the same name in the top level folder breaks when
using the parallel extension compilation option of python 3.5.

BUG: distutils, add compatiblity python parallelization

Python 3.5 also added build parallelization at the extension level
instead of the file leve numpy uses.
This causes two problems:

- numpy.distutils is not threadsafe with duplicated source files
When source files are duplicated in multiple extensions the output
objects are overwritten which can truncate in a parallel context.
This is fixed by keeping track of the files being worked on and wait
for completion if another thread is already using the object name.

- The parallelization on two nested levels causes oversubscription.
When building multiple extensions with multiple source files the number
of jobs running is multiplied.
This is fixed by adding a semaphore that limits the number of jobs numpy
starts to the defined amount.

closes gh-7139