### PR TITLE
MAINT: Update FutureWarning message.

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -4,6 +4,7 @@ NumPy 1.13.0 Release Notes
 
 This release supports Python 2.7 and 3.4 - 3.6.
 
+  
 Highlights
 ==========
 
@@ -33,11 +34,20 @@ Deprecations
 Build System Changes
 ====================
 
- * ``numpy.distutils`` now automatically determines C-file dependencies with
-   GCC compatible compilers.
+* ``numpy.distutils`` now automatically determines C-file dependencies with
+  GCC compatible compilers.
+
 
 Future Changes
 ==============
+
+* Assignment between structured arrays with different field names will change
+  in NumPy 1.14. Previously, fields in the dst would be set to the value of the
+  identically-named field in the src. In numpy 1.14 fields will instead be
+  assigned 'by position': The n-th field of the dst will be set to the n-th
+  field of the src array. Note that the ``FutureWarning`` raised in NumPy 1.12
+  incorrectly reported this change as scheduled for NumPy 1.13 rather than
+  NumPy 1.14.
 
 
 Compatibility notes

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2750,9 +2750,9 @@ get_fields_transfer_function(int aligned,
 
         const char *msg =
             "Assignment between structured arrays with different field names "
-            "will change in numpy 1.13.\n\n"
+            "will change in numpy 1.14.\n\n"
             "Previously fields in the dst would be set to the value of the "
-            "identically-named field in the src. In numpy 1.13 fields will "
+            "identically-named field in the src. In numpy 1.14 fields will "
             "instead be assigned 'by position': The Nth field of the dst "
             "will be set to the Nth field of the src array.\n\n"
             "See the release notes for details";


### PR DESCRIPTION
The future structured array assignment change warned about in
dtype_transfer.c will take place in NumPy 1.14, not 1.13.