### PR TITLE
DEP: deprecate ndarray.conjugate's no-op fall through for non-numeric types

### DIFF
--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -39,6 +39,8 @@ Deprecations
   deprecated. ``np.maximum``. ``np.ma.minimum(x)`` should now be spelt
   ``np.ma.minimum.reduce(x)``, which is consistent with how this would be done
   with ``np.minimum``.
+* Calling ``ndarray.conjugate`` on non-numeric dtypes is deprecated (it
+  should match the behavior of ``np.conjugate``, which throws an error).
 
 Build System Changes
 ====================

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -1187,6 +1187,14 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
     }
     else {
         PyArrayObject *ret;
+        if (!PyArray_ISNUMBER(self)) {
+            /* 2017-05-04, 1.13 */
+            if (DEPRECATE("attempting to conjugate non-numeric dtype; this "
+                          "will error in the future to match the behavior of "
+                          "np.conjugate") < 0) {
+                return NULL;
+            }
+        }
         if (out) {
             if (PyArray_AssignArray(out, self,
                         NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -423,6 +423,19 @@ class TestClassicIntDivision(_DeprecationTestCase):
                 dt2 = dt1
 
 
+class TestNonNumericConjugate(_DeprecationTestCase):
+    """
+    Deprecate no-op behavior of ndarray.conjugate on non-numeric dtypes,
+    which conflicts with the error behavior of np.conjugate.
+    """
+    def test_conjugate(self):
+        for a in np.array(5), np.array(5j):
+            self.assert_not_deprecated(a.conjugate)
+        for a in (np.array('s'), np.array('2016', 'M'),
+                np.array((1, 2), [('a', int), ('b', int)])):
+            self.assert_deprecated(a.conjugate)
+
+
 class TestNPY_CHAR(_DeprecationTestCase):
     # 2017-05-03, 1.13.0
     def test_npy_char_deprecation(self):


### PR DESCRIPTION
While `np.conjugate` errors on non-numeric types, `ndarray.conjugate` silently returns its argument, even though both are documented as being equivalent. This is due to a fall-through condition in `ndarray.conjugate` which is useful for real data (e.g., https://github.com/numpy/numpy/blob/master/numpy/lib/function_base.py#L3087) but not meaningful for non-numeric data.

This PR deprecates the fall-through for non-numeric dtypes, bringing `ndarray.conjugate` closer to `np.conjugate` by favoring its fail-fast behavior.

This was originally part of #9003.