### PR TITLE
BUG: Preserve field order in join_by, avoids FutureWarning

### DIFF
--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.ma as ma
 from numpy.ma.mrecords import MaskedRecords
 from numpy.ma.testutils import assert_equal
-from numpy.testing import TestCase, run_module_suite, assert_
+from numpy.testing import TestCase, run_module_suite, assert_, assert_raises
 from numpy.lib.recfunctions import (
     drop_fields, rename_fields, get_fieldstructure, recursive_fill_fields,
     find_duplicates, merge_arrays, append_fields, stack_arrays, join_by
@@ -632,6 +632,19 @@ class TestJoinBy(TestCase):
                                  (0, 0, 0, 1), (0, 0, 0, 1)],
                            dtype=[('a', int), ('b', int), ('c', int), ('d', int)])
         assert_equal(test, control)
+
+    def test_different_field_order(self):
+        # gh-8940
+        a = np.zeros(3, dtype=[('a', 'i4'), ('b', 'f4'), ('c', 'u1')])
+        b = np.ones(3, dtype=[('c', 'u1'), ('b', 'f4'), ('a', 'i4')])
+        # this should not give a FutureWarning:
+        j = join_by(['c', 'b'], a, b, jointype='inner', usemask=False)
+        assert_equal(j.dtype.names, ['b', 'c', 'a1', 'a2'])
+
+    def test_duplicate_keys(self):
+        a = np.zeros(3, dtype=[('a', 'i4'), ('b', 'f4'), ('c', 'u1')])
+        b = np.ones(3, dtype=[('c', 'u1'), ('b', 'f4'), ('a', 'i4')])
+        assert_raises(ValueError, join_by, ['a', 'b', 'b'], a, b)
 
 
 class TestJoinBy2(TestCase):


### PR DESCRIPTION
Fixes #8940 

Note this also changes the behavior of `join_by` a little bit, in a way which I think fixes yet another hidden bug:

Previously, for `join_by(['k', 'l'], a, b)` the result dtype's first two fields would be `k` and `l`, but in the order they were in the dtype of array `a`. Eg, if `l` occurred in `a.dtype.names` before `k`, the output order would be `l,k`. The order of fields in `b` was irrelevant.

Eg
```python
>>> a = np.zeros(3, dtype=[('a', 'i4'), ('b', 'f4'), ('c', 'u1')])
>>> b = np.ones(3, dtype=[('c', 'u1'), ('b', 'f4'), ('a', 'i4')])
>>> join_by(['a','b'], a,b, jointype='inner').dtype.names
('a', 'b', 'c1', 'c2')
>>> join_by(['a','b'], b, a, jointype='inner').dtype.names
('b', 'a', 'c1', 'c2')
```

With this PR, the same line will always give back the fields in the order of the first argument to `join_by` (`k,l` in this case) and the order of those fields in `a` and `b` is irrelevant.

This is actually important because the docstring for `join_by` emphasizes that `The output is sorted along the key.`, but never specifies by what it means by `key`. In the old code, the array was effectively sorted according to something related to the order of the fields in array `a`. In this PR, the `key`'s order is always the order of the `key` (first) argument to `join_by`. The required update to one of the tests shows an example of the problem.