### PR TITLE
BUG: Prevent stackoverflow on self-containing arrays

### DIFF
--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -794,6 +794,10 @@ _array_nonzero(PyArrayObject *mp)
             return -1;
         }
         res = PyArray_DESCR(mp)->f->nonzero(PyArray_DATA(mp), mp);
+        /* nonzero has no way to indicate an error, but one can occur */
+        if (PyErr_Occurred()) {
+            res = -1;
+        }
         Py_LeaveRecursiveCall();
         return res;
     }

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -789,7 +789,13 @@ _array_nonzero(PyArrayObject *mp)
 
     n = PyArray_SIZE(mp);
     if (n == 1) {
-        return PyArray_DESCR(mp)->f->nonzero(PyArray_DATA(mp), mp);
+        int res;
+        if (Py_EnterRecursiveCall(" while converting array to bool")) {
+            return -1;
+        }
+        res = PyArray_DESCR(mp)->f->nonzero(PyArray_DATA(mp), mp);
+        Py_LeaveRecursiveCall();
+        return res;
     }
     else if (n == 0) {
         return 0;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6404,6 +6404,28 @@ class TestConversion(TestCase):
                 assert_(np.array(-1, dtype=dt1) == np.array(-1, dtype=dt2),
                         "type %s and %s failed" % (dt1, dt2))
 
+    def test_to_bool_scalar(self):
+        assert_equal(bool(np.array([False])), False)
+        assert_equal(bool(np.array([True])), True)
+        assert_equal(bool(np.array([[42]])), True)
+        assert_raises(ValueError, bool, np.array([1, 2]))
+
+        class NotConvertible(object):
+            def __bool__(self):
+                raise NotImplementedError
+            __nonzero__ = __bool__  # python 2
+
+        assert_raises(NotImplementedError, bool, np.array(NotConvertible()))
+        assert_raises(NotImplementedError, bool, np.array([NotConvertible()]))
+
+        self_containing = np.array([None])
+        self_containing[0] = self_containing
+        try:
+            Error = RecursionError
+        except NameError:
+            Error = RuntimeError  # python < 3.5
+        assert_raises(Error, bool, self_containing)  # previously stack overflow
+
 
 class TestWhere(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Approaches #8306. This still errors, but it does so at a python level, without
a segfault.

This makes the following not segfault:

```
a = np.array([None])
a[0] = a
bool(a)
```

On the other hand, it still behaves incorrectly

```
In [8]: bool(a)
---------------------------------------------------------------------------
RecursionError                            Traceback (most recent call last)
RecursionError: maximum recursion depth exceeded while converting array to bool

During handling of the above exception, another exception occurred:

SystemError                               Traceback (most recent call last)
<ipython-input-8-7af9bc0b6a67> in <module>()
----> 1 bool(a)

SystemError: <class 'bool'> returned a result with an error set
```

But that's a different bug (#9078)