### PR TITLE
ENH: fix small reduction performance after array_ufunc

### DIFF
--- a/numpy/core/src/private/ufunc_override.c
+++ b/numpy/core/src/private/ufunc_override.c
@@ -32,8 +32,8 @@ has_non_default_array_ufunc(PyObject *obj)
                                                      "__array_ufunc__");
     }
 
-    /* Fast return for ndarray */
-    if ((PyObject *)Py_TYPE(obj) == ndarray) {
+    /* Fast return for ndarray and basic types */
+    if ((PyObject *)Py_TYPE(obj) == ndarray || _is_basic_python_type(obj)) {
         return 0;
     }
     /* does the class define __array_ufunc__? */


### PR DESCRIPTION
has_non_default_array_ufunc() calls the extremely expensive
PyObject_GetAttr function on every argument of reductions, as they have a
lot of basic python arguments this caused a 50% performance reduction.