### PR TITLE
BUG: __array_ufunc__ should always be looked up on the type, never the instance

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -688,7 +688,7 @@ class AxisError(ValueError, IndexError):
         super(AxisError, self).__init__(msg)
 
 
-def array_ufunc_errmsg_formatter(ufunc, method, *inputs, **kwargs):
+def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
     """ Format the error message for when __array_ufunc__ gives up. """
     args_string = ', '.join(['{!r}'.format(arg) for arg in inputs] +
                             ['{}={!r}'.format(k, v)

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -329,7 +329,7 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* The array interface */
-    ip = PyArray_GetAttrString_SuppressException(obj, "__array_interface__");
+    ip = PyArray_LookupSpecial_OnInstance(obj, "__array_interface__");
     if (ip != NULL) {
         if (PyDict_Check(ip)) {
             PyObject *typestr;
@@ -362,7 +362,7 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* The array struct interface */
-    ip = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
+    ip = PyArray_LookupSpecial_OnInstance(obj, "__array_struct__");
     if (ip != NULL) {
         PyArrayInterface *inter;
         char buf[40];
@@ -397,7 +397,7 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
 #endif
 
     /* The __array__ attribute */
-    ip = PyArray_GetAttrString_SuppressException(obj, "__array__");
+    ip = PyArray_LookupSpecial_OnInstance(obj, "__array__");
     if (ip != NULL) {
         Py_DECREF(ip);
         ip = PyObject_CallMethod(obj, "__array__", NULL);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -753,7 +753,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     }
 
     /* obj has the __array_struct__ interface */
-    e = PyArray_GetAttrString_SuppressException(obj, "__array_struct__");
+    e = PyArray_LookupSpecial_OnInstance(obj, "__array_struct__");
     if (e != NULL) {
         int nd = -1;
         if (NpyCapsule_Check(e)) {
@@ -778,7 +778,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     }
 
     /* obj has the __array_interface__ interface */
-    e = PyArray_GetAttrString_SuppressException(obj, "__array_interface__");
+    e = PyArray_LookupSpecial_OnInstance(obj, "__array_interface__");
     if (e != NULL) {
         int nd = -1;
         if (PyDict_Check(e)) {
@@ -2062,7 +2062,7 @@ PyArray_FromStructInterface(PyObject *input)
     PyArrayObject *ret;
     char endian = NPY_NATBYTE;
 
-    attr = PyArray_GetAttrString_SuppressException(input, "__array_struct__");
+    attr = PyArray_LookupSpecial_OnInstance(input, "__array_struct__");
     if (attr == NULL) {
         return Py_NotImplemented;
     }
@@ -2176,7 +2176,7 @@ PyArray_FromInterface(PyObject *origin)
     npy_intp dims[NPY_MAXDIMS], strides[NPY_MAXDIMS];
     int dataflags = NPY_ARRAY_BEHAVED;
 
-    iface = PyArray_GetAttrString_SuppressException(origin,
+    iface = PyArray_LookupSpecial_OnInstance(origin,
                                                     "__array_interface__");
     if (iface == NULL) {
         return Py_NotImplemented;
@@ -2409,7 +2409,7 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
     PyObject *new;
     PyObject *array_meth;
 
-    array_meth = PyArray_GetAttrString_SuppressException(op, "__array__");
+    array_meth = PyArray_LookupSpecial_OnInstance(op, "__array__");
     if (array_meth == NULL) {
         return Py_NotImplemented;
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1024,7 +1024,7 @@ array_ufunc(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
     /* ndarray cannot handle overrides itself */
-    num_override_args = PyUFunc_WithOverride(normal_args, kwds, NULL);
+    num_override_args = PyUFunc_WithOverride(normal_args, kwds, NULL, NULL);
     if (num_override_args == -1) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -84,7 +84,7 @@ PyArray_GetPriority(PyObject *obj, double default_)
         return NPY_SCALAR_PRIORITY;
     }
 
-    ret = PyArray_GetAttrString_SuppressException(obj, "__array_priority__");
+    ret = PyArray_LookupSpecial_OnInstance(obj, "__array_priority__");
     if (ret == NULL) {
         return default_;
     }

--- a/numpy/core/src/private/binop_override.h
+++ b/numpy/core/src/private/binop_override.h
@@ -121,15 +121,14 @@ binop_should_defer(PyObject *self, PyObject *other, int inplace)
         self == NULL ||
         Py_TYPE(self) == Py_TYPE(other) ||
         PyArray_CheckExact(other) ||
-        PyArray_CheckAnyScalarExact(other) ||
-	_is_basic_python_type(other)) {
+        PyArray_CheckAnyScalarExact(other)) {
         return 0;
     }
     /*
      * Classes with __array_ufunc__ are living in the future, and only need to
      * check whether __array_ufunc__ equals None.
      */
-    attr = PyArray_GetAttrString_SuppressException(other, "__array_ufunc__");
+    attr = PyArray_LookupSpecial(other, "__array_ufunc__");
     if (attr) {
         defer = !inplace && (attr == Py_None);
         Py_DECREF(attr);

--- a/numpy/core/src/private/get_attr_string.h
+++ b/numpy/core/src/private/get_attr_string.h
@@ -4,49 +4,39 @@
 static NPY_INLINE npy_bool
 _is_basic_python_type(PyTypeObject *tp)
 {
-    PyTypeObject const * const known_types[] = {
+    return (
         /* Basic number types */
-        &PyBool_Type,
+        tp == &PyBool_Type ||
 #if !defined(NPY_PY3K)
-        &PyInt_Type,
+        tp == &PyInt_Type ||
 #endif
-        &PyLong_Type,
-        &PyFloat_Type,
-        &PyComplex_Type,
+        tp == &PyLong_Type ||
+        tp == &PyFloat_Type ||
+        tp == &PyComplex_Type ||
 
         /* Basic sequence types */
-        &PyList_Type,
-        &PyTuple_Type,
-        &PyDict_Type,
-        &PySet_Type,
-        &PyFrozenSet_Type,
-        &PyUnicode_Type,
-        &PyBytes_Type,
+        tp == &PyList_Type ||
+        tp == &PyTuple_Type ||
+        tp == &PyDict_Type ||
+        tp == &PySet_Type ||
+        tp == &PyFrozenSet_Type ||
+        tp == &PyUnicode_Type ||
+        tp == &PyBytes_Type ||
 #if !defined(NPY_PY3K)
-        &PyString_Type,
+        tp == &PyString_Type ||
 #endif
 
         /* other builtins */
-        &PySlice_Type,
-        Py_TYPE(Py_None),
-        Py_TYPE(Py_Ellipsis),
-        Py_TYPE(Py_NotImplemented),
+        tp == &PySlice_Type ||
+        tp == Py_TYPE(Py_None) ||
+        tp == Py_TYPE(Py_Ellipsis) ||
+        tp == Py_TYPE(Py_NotImplemented) ||
 
         /* TODO: ndarray, but we can't see PyArray_Type here */
 
-        /* sentinel */
-        NULL
-    };
-    PyTypeObject const * const * check_tp = known_types;
-
-    while (*check_tp) {
-        if (tp == *check_tp) {
-            return NPY_TRUE;
-        }
-        check_tp++;
-    }
-
-    return NPY_FALSE;
+        /* sentinel to swallow trailing || */
+        NPY_FALSE
+    );
 }
 
 /*

--- a/numpy/core/src/private/get_attr_string.h
+++ b/numpy/core/src/private/get_attr_string.h
@@ -53,7 +53,7 @@ _is_basic_python_type(PyTypeObject *tp)
  *
  * Returns attribute value on success, NULL on failure.
  */
-static PyObject *
+static NPY_INLINE PyObject *
 maybe_get_attr(PyObject *obj, char *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
@@ -94,7 +94,7 @@ maybe_get_attr(PyObject *obj, char *name)
  *
  * In future, could be made more like _Py_LookupSpecial
  */
-static PyObject *
+static NPY_INLINE PyObject *
 PyArray_LookupSpecial(PyObject *obj, char *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
@@ -115,7 +115,7 @@ PyArray_LookupSpecial(PyObject *obj, char *name)
  *
  * Kept for backwards compatibility. In future, we should deprecate this.
  */
-static PyObject *
+static NPY_INLINE PyObject *
 PyArray_LookupSpecial_OnInstance(PyObject *obj, char *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);

--- a/numpy/core/src/private/ufunc_override.c
+++ b/numpy/core/src/private/ufunc_override.c
@@ -28,7 +28,6 @@ get_non_default_array_ufunc(PyObject *obj)
     static PyObject *ndarray = NULL;
     static PyObject *ndarray_array_ufunc = NULL;
     PyObject *cls_array_ufunc;
-    int non_default;
 
     /* on first entry, import and cache ndarray and its __array_ufunc__ */
     if (ndarray == NULL) {

--- a/numpy/core/src/private/ufunc_override.c
+++ b/numpy/core/src/private/ufunc_override.c
@@ -37,8 +37,7 @@ has_non_default_array_ufunc(PyObject *obj)
         return 0;
     }
     /* does the class define __array_ufunc__? */
-    cls_array_ufunc = PyArray_GetAttrString_SuppressException(
-                          (PyObject *)Py_TYPE(obj), "__array_ufunc__");
+    cls_array_ufunc = PyArray_LookupSpecial(obj, "__array_ufunc__");
     if (cls_array_ufunc == NULL) {
         return 0;
     }
@@ -58,7 +57,7 @@ disables_array_ufunc(PyObject *obj)
     PyObject *array_ufunc;
     int disables;
 
-    array_ufunc = PyObject_GetAttrString(obj, "__array_ufunc__");
+    array_ufunc = PyArray_LookupSpecial(obj, "__array_ufunc__");
     disables = (array_ufunc == Py_None);
     Py_XDECREF(array_ufunc);
     return disables;

--- a/numpy/core/src/private/ufunc_override.h
+++ b/numpy/core/src/private/ufunc_override.h
@@ -11,5 +11,5 @@
  */
 NPY_NO_EXPORT int
 PyUFunc_WithOverride(PyObject *args, PyObject *kwds,
-                     PyObject **with_override);
+                     PyObject **with_override, PyObject **methods);
 #endif

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -45,9 +45,9 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
      */
     int i;
     int not_all_none;
-    int nin = ufunc->nin;
-    int nout = ufunc->nout;
-    int nargs = PyTuple_GET_SIZE(args);
+    npy_intp nin = ufunc->nin;
+    npy_intp nout = ufunc->nout;
+    npy_intp nargs = PyTuple_GET_SIZE(args);
     PyObject *obj;
 
     if (nargs < nin) {
@@ -119,7 +119,7 @@ normalize_reduce_args(PyUFuncObject *ufunc, PyObject *args,
     /*
      * ufunc.reduce(a[, axis, dtype, out, keepdims])
      */
-    int nargs = PyTuple_GET_SIZE(args);
+    npy_intp nargs = PyTuple_GET_SIZE(args);
     int i;
     PyObject *obj;
     static char *kwlist[] = {"array", "axis", "dtype", "out", "keepdims"};
@@ -163,7 +163,7 @@ normalize_accumulate_args(PyUFuncObject *ufunc, PyObject *args,
     /*
      * ufunc.accumulate(a[, axis, dtype, out])
      */
-    int nargs = PyTuple_GET_SIZE(args);
+    npy_intp nargs = PyTuple_GET_SIZE(args);
     int i;
     PyObject *obj;
     static char *kwlist[] = {"array", "axis", "dtype", "out", "keepdims"};
@@ -209,7 +209,7 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
      * the number of arguments has been checked in PyUFunc_GenericReduction.
      */
     int i;
-    int nargs = PyTuple_GET_SIZE(args);
+    npy_intp nargs = PyTuple_GET_SIZE(args);
     PyObject *obj;
     static char *kwlist[] = {"array", "indices", "axis", "dtype", "out"};
 
@@ -255,8 +255,8 @@ normalize_outer_args(PyUFuncObject *ufunc, PyObject *args,
      * all positional arguments should be inputs.
      * for the keywords, we only need to check 'sig' vs 'signature'.
      */
-    int nin = ufunc->nin;
-    int nargs = PyTuple_GET_SIZE(args);
+    npy_intp nin = ufunc->nin;
+    npy_intp nargs = PyTuple_GET_SIZE(args);
 
     if (nargs < nin) {
         PyErr_Format(PyExc_TypeError,
@@ -285,7 +285,7 @@ normalize_at_args(PyUFuncObject *ufunc, PyObject *args,
                   PyObject **normal_args, PyObject **normal_kwds)
 {
     /* ufunc.at(a, indices[, b]) */
-    int nargs = PyTuple_GET_SIZE(args);
+    npy_intp nargs = PyTuple_GET_SIZE(args);
 
     if (nargs < 2 || nargs > 3) {
         PyErr_Format(PyExc_TypeError,

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -43,7 +43,7 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
     /*
      * ufunc.__call__(*args, **kwds)
      */
-    int i;
+    npy_intp i;
     int not_all_none;
     npy_intp nin = ufunc->nin;
     npy_intp nout = ufunc->nout;
@@ -52,13 +52,14 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
 
     if (nargs < nin) {
         PyErr_Format(PyExc_TypeError,
-                     "ufunc() missing %d of %d required positional argument(s)",
-                     nin - nargs, nin);
+                     "ufunc() missing %"NPY_INTP_FMT" of %"NPY_INTP_FMT
+                     "required positional argument(s)", nin - nargs, nin);
         return -1;
     }
     if (nargs > nin+nout) {
         PyErr_Format(PyExc_TypeError,
-                     "ufunc() takes from %d to %d arguments but %d were given",
+                     "ufunc() takes from %"NPY_INTP_FMT" to %"NPY_INTP_FMT
+                     "arguments but %"NPY_INTP_FMT" were given",
                      nin, nin+nout, nargs);
         return -1;
     }
@@ -72,8 +73,8 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
     if (nargs > nin) {
         if(PyDict_GetItemString(*normal_kwds, "out")) {
             PyErr_Format(PyExc_TypeError,
-                         "argument given by name ('out') and position (%d)",
-                         nin);
+                         "argument given by name ('out') and position "
+                         "(%"NPY_INTP_FMT")", nin);
             return -1;
         }
         for (i = nin; i < nargs; i++) {
@@ -120,14 +121,14 @@ normalize_reduce_args(PyUFuncObject *ufunc, PyObject *args,
      * ufunc.reduce(a[, axis, dtype, out, keepdims])
      */
     npy_intp nargs = PyTuple_GET_SIZE(args);
-    int i;
+    npy_intp i;
     PyObject *obj;
     static char *kwlist[] = {"array", "axis", "dtype", "out", "keepdims"};
 
     if (nargs < 1 || nargs > 5) {
         PyErr_Format(PyExc_TypeError,
                      "ufunc.reduce() takes from 1 to 5 positional "
-                     "arguments but %d were given", nargs);
+                     "arguments but %"NPY_INTP_FMT" were given", nargs);
         return -1;
     }
     *normal_args = PyTuple_GetSlice(args, 0, 1);
@@ -138,8 +139,8 @@ normalize_reduce_args(PyUFuncObject *ufunc, PyObject *args,
     for (i = 1; i < nargs; i++) {
         if (PyDict_GetItemString(*normal_kwds, kwlist[i])) {
             PyErr_Format(PyExc_TypeError,
-                         "argument given by name ('%s') and position (%d)",
-                         kwlist[i], i);
+                         "argument given by name ('%s') and position "
+                         "(%"NPY_INTP_FMT")", kwlist[i], i);
             return -1;
         }
         obj = PyTuple_GET_ITEM(args, i);
@@ -164,14 +165,14 @@ normalize_accumulate_args(PyUFuncObject *ufunc, PyObject *args,
      * ufunc.accumulate(a[, axis, dtype, out])
      */
     npy_intp nargs = PyTuple_GET_SIZE(args);
-    int i;
+    npy_intp i;
     PyObject *obj;
     static char *kwlist[] = {"array", "axis", "dtype", "out", "keepdims"};
 
     if (nargs < 1 || nargs > 4) {
         PyErr_Format(PyExc_TypeError,
                      "ufunc.accumulate() takes from 1 to 4 positional "
-                     "arguments but %d were given", nargs);
+                     "arguments but %"NPY_INTP_FMT" were given", nargs);
         return -1;
     }
     *normal_args = PyTuple_GetSlice(args, 0, 1);
@@ -182,8 +183,8 @@ normalize_accumulate_args(PyUFuncObject *ufunc, PyObject *args,
     for (i = 1; i < nargs; i++) {
         if (PyDict_GetItemString(*normal_kwds, kwlist[i])) {
             PyErr_Format(PyExc_TypeError,
-                         "argument given by name ('%s') and position (%d)",
-                         kwlist[i], i);
+                         "argument given by name ('%s') and position "
+                         "(%"NPY_INTP_FMT")", kwlist[i], i);
             return -1;
         }
         obj = PyTuple_GET_ITEM(args, i);
@@ -208,7 +209,7 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
      * ufunc.reduceat(a, indicies[, axis, dtype, out])
      * the number of arguments has been checked in PyUFunc_GenericReduction.
      */
-    int i;
+    npy_intp i;
     npy_intp nargs = PyTuple_GET_SIZE(args);
     PyObject *obj;
     static char *kwlist[] = {"array", "indices", "axis", "dtype", "out"};
@@ -216,7 +217,7 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
     if (nargs < 2 || nargs > 5) {
         PyErr_Format(PyExc_TypeError,
                      "ufunc.reduceat() takes from 2 to 4 positional "
-                     "arguments but %d were given", nargs);
+                     "arguments but %"NPY_INTP_FMT" were given", nargs);
         return -1;
     }
     /* a and indicies */
@@ -228,8 +229,8 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
     for (i = 2; i < nargs; i++) {
         if (PyDict_GetItemString(*normal_kwds, kwlist[i])) {
             PyErr_Format(PyExc_TypeError,
-                         "argument given by name ('%s') and position (%d)",
-                         kwlist[i], i);
+                         "argument given by name ('%s') and position "
+                         "(%"NPY_INTP_FMT")", kwlist[i], i);
             return -1;
         }
         obj = PyTuple_GET_ITEM(args, i);
@@ -260,14 +261,14 @@ normalize_outer_args(PyUFuncObject *ufunc, PyObject *args,
 
     if (nargs < nin) {
         PyErr_Format(PyExc_TypeError,
-                     "ufunc.outer() missing %d of %d required positional "
-                     "argument(s)", nin - nargs, nin);
+                     "ufunc.outer() missing %"NPY_INTP_FMT" of %"NPY_INTP_FMT
+                     "required positional " "argument(s)", nin - nargs, nin);
         return -1;
     }
     if (nargs > nin) {
         PyErr_Format(PyExc_TypeError,
-                     "ufunc.outer() takes %d arguments but %d were given",
-                     nin, nargs);
+                     "ufunc.outer() takes %"NPY_INTP_FMT" arguments but"
+                     "%"NPY_INTP_FMT" were given", nin, nargs);
         return -1;
     }
 
@@ -290,7 +291,7 @@ normalize_at_args(PyUFuncObject *ufunc, PyObject *args,
     if (nargs < 2 || nargs > 3) {
         PyErr_Format(PyExc_TypeError,
                      "ufunc.at() takes from 2 to 3 positional "
-                     "arguments but %d were given", nargs);
+                     "arguments but %"NPY_INTP_FMT" were given", nargs);
         return -1;
     }
     *normal_args = PyTuple_GetSlice(args, 0, nargs);

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -496,7 +496,6 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
 
     /* Call __array_ufunc__ functions in correct order */
     while (1) {
-        PyObject *array_ufunc;
         PyObject *override_obj;
         PyObject *override_array_ufunc;
 


### PR DESCRIPTION
This also corrects a broken short-circuit when looking up `__array_ufunc__`.

Doesn't build on my machine, but msvc is not giving me useful errors.