### PR TITLE
MAINT: refine error message for __array_ufunc__ not implemented

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -695,9 +695,10 @@ def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
                              for k, v in kwargs.items()])
     args = inputs + kwargs.get('out', ())
     types_string = ', '.join(repr(type(arg).__name__) for arg in args)
-    return ('operand type(s) do not implement __array_ufunc__'
-            '({!r}, {!r}, {}): {}'
+    return ('operand type(s) all returned NotImplemented from '
+            '__array_ufunc__({!r}, {!r}, {}): {}'
             .format(ufunc, method, args_string, types_string))
+
 
 def _ufunc_doc_signature_formatter(ufunc):
     """

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1931,14 +1931,14 @@ class TestSpecialMethods(TestCase):
             def __array_ufunc__(self, *args, **kwargs):
                 return NotImplemented
 
-        msg = ("operand type(s) do not implement __array_ufunc__("
-               "<ufunc 'negative'>, '__call__', <*>): 'A'")
+        msg = ("operand type(s) all returned NotImplemented from "
+               "__array_ufunc__(<ufunc 'negative'>, '__call__', <*>): 'A'")
         with assert_raises_regex(TypeError, fnmatch.translate(msg)):
             np.negative(A())
 
-        msg = ("operand type(s) do not implement __array_ufunc__("
-               "<ufunc 'add'>, '__call__', <*>, <object *>, out=(1,)): "
-               "'A', 'object', 'int'")
+        msg = ("operand type(s) all returned NotImplemented from "
+               "__array_ufunc__(<ufunc 'add'>, '__call__', <*>, <object *>, "
+               "out=(1,)): 'A', 'object', 'int'")
         with assert_raises_regex(TypeError, fnmatch.translate(msg)):
             np.add(A(), object(), out=1)
 


### PR DESCRIPTION
Same as https://github.com/numpy/numpy/pull/9089 but targeted at maintenance/1.13.x