### PR TITLE
ENH: Allow inplace also as keyword parameter for ndarray.byteswap

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3292,7 +3292,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('astype',
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('byteswap',
     """
-    a.byteswap(inplace)
+    a.byteswap(inplace=False)
 
     Swap the bytes of the array elements
 
@@ -3315,7 +3315,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('byteswap',
     >>> A = np.array([1, 256, 8755], dtype=np.int16)
     >>> map(hex, A)
     ['0x1', '0x100', '0x2233']
-    >>> A.byteswap(True)
+    >>> A.byteswap(inplace=True)
     array([  256,     1, 13090], dtype=int16)
     >>> map(hex, A)
     ['0x100', '0x1', '0x3322']

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -517,12 +517,13 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
 
 
 static PyObject *
-array_byteswap(PyArrayObject *self, PyObject *args)
+array_byteswap(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
     npy_bool inplace = NPY_FALSE;
+    static char *kwlist[] = {"inplace", NULL};
 
-    if (!PyArg_ParseTuple(args, "|O&:byteswap",
-                            PyArray_BoolConverter, &inplace)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:byteswap", kwlist,
+                                     PyArray_BoolConverter, &inplace)) {
         return NULL;
     }
     return PyArray_Byteswap(self, inplace);
@@ -2569,7 +2570,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"byteswap",
         (PyCFunction)array_byteswap,
-        METH_VARARGS, NULL},
+        METH_VARARGS | METH_KEYWORDS, NULL},
     {"choose",
         (PyCFunction)array_choose,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1548,11 +1548,13 @@ static Py_ssize_t
 gentype_getreadbuf(PyObject *, Py_ssize_t, void **);
 
 static PyObject *
-gentype_byteswap(PyObject *self, PyObject *args)
+gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
 {
     npy_bool inplace = NPY_FALSE;
+    static char *kwlist[] = {"inplace", NULL};
 
-    if (!PyArg_ParseTuple(args, "|O&:byteswap", PyArray_BoolConverter, &inplace)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:byteswap", kwlist,
+                                     PyArray_BoolConverter, &inplace)) {
         return NULL;
     }
     if (inplace) {
@@ -1628,7 +1630,7 @@ voidtype_setfield(PyVoidScalarObject *self, PyObject *args, PyObject *kwds)
      * However, as a special case, void-scalar assignment broadcasts
      * differently from ndarrays when assigning to an object field: Assignment
      * to an ndarray object field broadcasts, but assignment to a void-scalar
-     * object-field should not, in order to allow nested ndarrays. 
+     * object-field should not, in order to allow nested ndarrays.
      * These lines should then behave identically:
      *
      *     b = np.zeros(1, dtype=[('x', 'O')])
@@ -1867,7 +1869,7 @@ static PyMethodDef gentype_methods[] = {
         METH_VARARGS, NULL},
     {"byteswap",
         (PyCFunction)gentype_byteswap,
-        METH_VARARGS, NULL},
+        METH_VARARGS | METH_KEYWORDS, NULL},
     {"astype",
         (PyCFunction)gentype_astype,
         METH_VARARGS, NULL},


### PR DESCRIPTION
Fixes #9095 