### PR TITLE
TST: fix test_basic failure on Windows

### DIFF
--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -99,7 +99,7 @@ class TestExecCommand(TestCase):
         self.pyexe = get_pythonexe()
 
     def check_nt(self, **kws):
-        s, o = exec_command.exec_command('echo path=%path%')
+        s, o = exec_command.exec_command('cmd /C echo path=%path%')
         self.assertEqual(s, 0)
         self.assertNotEqual(o, '')
 


### PR DESCRIPTION
Echo is a command in the Windows command interpreter

Fix one test failure of numpy-1.13.0rc1+mkl on Windows:
```
NumPy version 1.13.0rc1
NumPy relaxed strides checking option: True
NumPy is installed in X:\Python36\lib\site-packages\numpy
Python version 3.6.1 (v3.6.1:69c0db5, Mar 21 2017, 18:41:36) [MSC v.1900 64 bit (AMD64)]
nose version 1.3.7
<snip>
======================================================================
FAIL: test_basic (test_exec_command.TestExecCommand)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python36\lib\site-packages\numpy\distutils\tests\test_exec_command.py", line 212, in test_basic
    self.check_nt(use_tee=0)
  File "X:\Python36\lib\site-packages\numpy\distutils\tests\test_exec_command.py", line 103, in check_nt
    self.assertEqual(s, 0)
AssertionError: 127 != 0

----------------------------------------------------------------------
Ran 6191 tests in 25.453s

FAILED (KNOWNFAIL=8, SKIP=11, failures=1) 
```
