### PR TITLE
BUG: Fix repr longdouble if don't have support srttold_l

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -109,7 +109,7 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
         "copysign", "nextafter", "ftello", "fseeko",
         "strtoll", "strtoull", "cbrt", "strtold_l", "fallocate",
-        "backtrace"]
+        "backtrace", "strtold"]
 
 
 OPTIONAL_HEADERS = [

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -13,7 +13,7 @@
 
 #include "npy_pycompat.h"
 
-#ifdef HAVE_STRTOLD_L
+#if defined(HAVE_STRTOLD_L) || defined(HAVE_STRTOLD)
 #include <stdlib.h>
 #ifdef HAVE_XLOCALE_H
     /*
@@ -577,6 +577,13 @@ NumPyOS_ascii_strtold(const char *s, char** endptr)
     else {
         *endptr = (char*)s;
         result = 0;
+    }
+    return result;
+#elif defined(HAVE_STRTOLD)
+    errno = 0;
+    result = strtold(s, endptr);
+    if (errno) {
+        *endptr = (char*)s;
     }
     return result;
 #else


### PR DESCRIPTION
On OpenBSD don't have strtold_l and I see next fail:

```
FAIL: test_longdouble.test_repr_roundtrip
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python2.7/site-packages/numpy/core/tests/test_longdouble.py", line 35, in test_repr_r
    "repr was %s" % repr(o))
  File "/usr/local/lib/python2.7/site-packages/numpy/testing/utils.py", line 425, in assert_equal
    raise AssertionError(msg)
AssertionError:.
Items are not equal: repr was 1.0000000000000000001
 ACTUAL: 1.0
 DESIRED: 1.0000000000000000001
```


