### PR TITLE
BUG: Compilation crashes in MSVC when LIB or INCLUDE is not set

### DIFF
--- a/numpy/distutils/msvc9compiler.py
+++ b/numpy/distutils/msvc9compiler.py
@@ -11,15 +11,15 @@ def _merge(old, new):
 
     Here `old` is the environment string before the base class initialize
     function is called and `new` is the string after the call. The new string
-    will be a fixed string if it is not obtained from the current enviroment,
-    or the same as the old string if obtained from the same enviroment. The aim
+    will be a fixed string if it is not obtained from the current environment,
+    or the same as the old string if obtained from the same environment. The aim
     here is not to append the new string if it is already contained in the old
     string so as to limit the growth of the environment string.
 
     Parameters
     ----------
     old : string
-        Previous enviroment string.
+        Previous environment string.
     new : string
         New environment string.
 
@@ -29,10 +29,10 @@ def _merge(old, new):
         Updated environment string.
 
     """
-    if new in old:
-        return old
     if not old:
         return new
+    if new in old:
+        return old
 
     # Neither new nor old is empty. Give old priority.
     return ';'.join([old, new])


### PR DESCRIPTION
#9115 backport.

