### PR TITLE
ENH: remove unneeded spaces in float/bool reprs, fixes 0d str

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -310,25 +310,15 @@ This option controls printing of the sign of floating-point types, and may be
 one of the characters '-', '+' or ' ', or the string 'legacy'. With '+' numpy
 always prints the sign of positive values, with ' ' it always prints a space
 (whitespace character) in the sign position of positive values, and with '-' it
-will omit the sign character for positive values. The new default is '-'.
+will omit the sign character for positive values, and with 'legacy' it will
+behave like ' ' except no space is printed in 0d arrays. The new default is '-'.
 
-Setting ``sign='legacy'`` will behave like ' ' except that no space is printed
-in 0d arrays, and also includes a space before ``True`` values in size-1 bool
-arrays. This approximates the behavior of numpy 1.13 and before.
-
-Unneeded whitespace in float and bool array printing removed
-------------------------------------------------------------
+Unneeded whitespace in float array printing removed
+---------------------------------------------------
 The new default of ``sign='-'`` (see last note) means that the ``repr`` of
 float arrays now often omits the whitespace characters previously used to
 display the sign. This new behavior can be disabled to mostly reproduce numpy
-1.13 behavior by calling:
-
-    >>> np.set_printoptions(sign='legacy')
-
-Additionally, the ``repr`` of bool arrays with only one element now omits the
-whitespace before a ``True`` value, so that ``repr(array([True]))`` now returns
-``'array([True])'`` instead of ``'array([ True])'``. This is disabled by
-setting ``sign='legacy'``.
+1.13 behavior by calling ``np.set_printoptions(sign='legacy')``.
 
 ``threshold`` and ``edgeitems`` options added to ``np.array2string``
 -----------------------------------------------------------------

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -304,3 +304,10 @@ source to the destination.
 Using field "titles" in multiple-field indexing is now disallowed, as is
 repeating a field name in a multiple-field index.
 
+Removed unneeded whitespace in float and bool array printing
+------------------------------------------------------------
+The ``repr`` of float arrays now omits the whitespace character previsouly used
+to display the sign if possible, for example if the array has all-positive
+values.  Similarly, the ``repr`` of bool arrays with only one element now omits
+the whitespace before a ``True`` value, so that ``repr(array([True]))`` now
+returns ``'array([True])'`` instead of ``'array([ True])'``.

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -304,10 +304,27 @@ source to the destination.
 Using field "titles" in multiple-field indexing is now disallowed, as is
 repeating a field name in a multiple-field index.
 
-Removed unneeded whitespace in float and bool array printing
+``sign`` option added to ``np.setprintoptions`` and ``np.array2string``
+-----------------------------------------------------------------------
+This option controls printing of the sign of floating-point types, and may be
+one of the characters '-', '+' or ' '. With '-' numpy only prints the sign of
+negative values, with '+' it prints the sign of both negative an positive
+values, and with ' ' it prints a space (whitespace character) in the sign
+position of positive values, except in 0d arrays. The new default is '-'.
+
+Unneeded whitespace in float and bool array printing removed
 ------------------------------------------------------------
-The ``repr`` of float arrays now omits the whitespace character previsouly used
-to display the sign if possible, for example if the array has all-positive
-values.  Similarly, the ``repr`` of bool arrays with only one element now omits
-the whitespace before a ``True`` value, so that ``repr(array([True]))`` now
-returns ``'array([True])'`` instead of ``'array([ True])'``.
+The new default of ``sign='-'`` (see last note) means that the ``repr`` of
+float arrays now often omits the whitespace character previously used to
+display the sign. This new behavior can be disabled using the ``sign=' '``
+option to ``np.set_printoptions`` described above, to mostly reproduce numpy
+1.13 behavior.
+
+Additionally, the ``repr`` of bool arrays with only one element now omits the
+whitespace before a ``True`` value, so that ``repr(array([True]))`` now returns
+``'array([True])'`` instead of ``'array([ True])'``.
+
+``threshold`` and ``edgeitems`` options added to ``np.array2string``
+-----------------------------------------------------------------
+These options could previously be controlled using ``np.set_printoptions``, but
+now can be changed on a per-call basis as arguments to ``np.array2string``.

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -307,22 +307,28 @@ repeating a field name in a multiple-field index.
 ``sign`` option added to ``np.setprintoptions`` and ``np.array2string``
 -----------------------------------------------------------------------
 This option controls printing of the sign of floating-point types, and may be
-one of the characters '-', '+' or ' '. With '-' numpy only prints the sign of
-negative values, with '+' it prints the sign of both negative an positive
-values, and with ' ' it prints a space (whitespace character) in the sign
-position of positive values, except in 0d arrays. The new default is '-'.
+one of the characters '-', '+' or ' ', or the string 'legacy'. With '+' numpy
+always prints the sign of positive values, with ' ' it always prints a space
+(whitespace character) in the sign position of positive values, and with '-' it
+will omit the sign character for positive values. The new default is '-'.
+
+Setting ``sign='legacy'`` will behave like ' ' except that no space is printed
+in 0d arrays, and also includes a space before ``True`` values in size-1 bool
+arrays. This approximates the behavior of numpy 1.13 and before.
 
 Unneeded whitespace in float and bool array printing removed
 ------------------------------------------------------------
 The new default of ``sign='-'`` (see last note) means that the ``repr`` of
-float arrays now often omits the whitespace character previously used to
-display the sign. This new behavior can be disabled using the ``sign=' '``
-option to ``np.set_printoptions`` described above, to mostly reproduce numpy
-1.13 behavior.
+float arrays now often omits the whitespace characters previously used to
+display the sign. This new behavior can be disabled to mostly reproduce numpy
+1.13 behavior by calling:
+
+    >>> np.set_printoptions(sign='legacy')
 
 Additionally, the ``repr`` of bool arrays with only one element now omits the
 whitespace before a ``True`` value, so that ``repr(array([True]))`` now returns
-``'array([True])'`` instead of ``'array([ True])'``.
+``'array([True])'`` instead of ``'array([ True])'``. This is disabled by
+setting ``sign='legacy'``.
 
 ``threshold`` and ``edgeitems`` options added to ``np.array2string``
 -----------------------------------------------------------------

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -11,7 +11,7 @@ from numpy.testing import (
 class TestArrayRepr(object):
     def test_nan_inf(self):
         x = np.array([np.nan, np.inf])
-        assert_equal(repr(x), 'array([ nan,  inf])')
+        assert_equal(repr(x), 'array([nan, inf])')
 
     def test_subclass(self):
         class sub(np.ndarray): pass
@@ -68,45 +68,45 @@ class TestComplexArray(object):
         dtypes = [np.complex64, np.cdouble, np.clongdouble]
         actual = [str(np.array([c], dt)) for c in cvals for dt in dtypes]
         wanted = [
-            '[ 0.+0.j]',    '[ 0.+0.j]',    '[ 0.0+0.0j]',
-            '[ 0.+1.j]',    '[ 0.+1.j]',    '[ 0.0+1.0j]',
-            '[ 0.-1.j]',    '[ 0.-1.j]',    '[ 0.0-1.0j]',
-            '[ 0.+infj]',   '[ 0.+infj]',   '[ 0.0+infj]',
-            '[ 0.-infj]',   '[ 0.-infj]',   '[ 0.0-infj]',
-            '[ 0.+nanj]',   '[ 0.+nanj]',   '[ 0.0+nanj]',
-            '[ 1.+0.j]',    '[ 1.+0.j]',    '[ 1.0+0.0j]',
-            '[ 1.+1.j]',    '[ 1.+1.j]',    '[ 1.0+1.0j]',
-            '[ 1.-1.j]',    '[ 1.-1.j]',    '[ 1.0-1.0j]',
-            '[ 1.+infj]',   '[ 1.+infj]',   '[ 1.0+infj]',
-            '[ 1.-infj]',   '[ 1.-infj]',   '[ 1.0-infj]',
-            '[ 1.+nanj]',   '[ 1.+nanj]',   '[ 1.0+nanj]',
+            '[0.+0.j]',    '[0.+0.j]',    '[ 0.0+0.0j]',
+            '[0.+1.j]',    '[0.+1.j]',    '[ 0.0+1.0j]',
+            '[0.-1.j]',    '[0.-1.j]',    '[ 0.0-1.0j]',
+            '[0.+infj]',   '[0.+infj]',   '[ 0.0+infj]',
+            '[0.-infj]',   '[0.-infj]',   '[ 0.0-infj]',
+            '[0.+nanj]',   '[0.+nanj]',   '[ 0.0+nanj]',
+            '[1.+0.j]',    '[1.+0.j]',    '[ 1.0+0.0j]',
+            '[1.+1.j]',    '[1.+1.j]',    '[ 1.0+1.0j]',
+            '[1.-1.j]',    '[1.-1.j]',    '[ 1.0-1.0j]',
+            '[1.+infj]',   '[1.+infj]',   '[ 1.0+infj]',
+            '[1.-infj]',   '[1.-infj]',   '[ 1.0-infj]',
+            '[1.+nanj]',   '[1.+nanj]',   '[ 1.0+nanj]',
             '[-1.+0.j]',    '[-1.+0.j]',    '[-1.0+0.0j]',
             '[-1.+1.j]',    '[-1.+1.j]',    '[-1.0+1.0j]',
             '[-1.-1.j]',    '[-1.-1.j]',    '[-1.0-1.0j]',
             '[-1.+infj]',   '[-1.+infj]',   '[-1.0+infj]',
             '[-1.-infj]',   '[-1.-infj]',   '[-1.0-infj]',
             '[-1.+nanj]',   '[-1.+nanj]',   '[-1.0+nanj]',
-            '[ inf+0.j]',   '[ inf+0.j]',   '[ inf+0.0j]',
-            '[ inf+1.j]',   '[ inf+1.j]',   '[ inf+1.0j]',
-            '[ inf-1.j]',   '[ inf-1.j]',   '[ inf-1.0j]',
-            '[ inf+infj]',  '[ inf+infj]',  '[ inf+infj]',
-            '[ inf-infj]',  '[ inf-infj]',  '[ inf-infj]',
-            '[ inf+nanj]',  '[ inf+nanj]',  '[ inf+nanj]',
+            '[inf+0.j]',   '[inf+0.j]',   '[ inf+0.0j]',
+            '[inf+1.j]',   '[inf+1.j]',   '[ inf+1.0j]',
+            '[inf-1.j]',   '[inf-1.j]',   '[ inf-1.0j]',
+            '[inf+infj]',  '[inf+infj]',  '[ inf+infj]',
+            '[inf-infj]',  '[inf-infj]',  '[ inf-infj]',
+            '[inf+nanj]',  '[inf+nanj]',  '[ inf+nanj]',
             '[-inf+0.j]',   '[-inf+0.j]',   '[-inf+0.0j]',
             '[-inf+1.j]',   '[-inf+1.j]',   '[-inf+1.0j]',
             '[-inf-1.j]',   '[-inf-1.j]',   '[-inf-1.0j]',
             '[-inf+infj]',  '[-inf+infj]',  '[-inf+infj]',
             '[-inf-infj]',  '[-inf-infj]',  '[-inf-infj]',
             '[-inf+nanj]',  '[-inf+nanj]',  '[-inf+nanj]',
-            '[ nan+0.j]',   '[ nan+0.j]',   '[ nan+0.0j]',
-            '[ nan+1.j]',   '[ nan+1.j]',   '[ nan+1.0j]',
-            '[ nan-1.j]',   '[ nan-1.j]',   '[ nan-1.0j]',
-            '[ nan+infj]',  '[ nan+infj]',  '[ nan+infj]',
-            '[ nan-infj]',  '[ nan-infj]',  '[ nan-infj]',
-            '[ nan+nanj]',  '[ nan+nanj]',  '[ nan+nanj]']
+            '[nan+0.j]',   '[nan+0.j]',   '[ nan+0.0j]',
+            '[nan+1.j]',   '[nan+1.j]',   '[ nan+1.0j]',
+            '[nan-1.j]',   '[nan-1.j]',   '[ nan-1.0j]',
+            '[nan+infj]',  '[nan+infj]',  '[ nan+infj]',
+            '[nan-infj]',  '[nan-infj]',  '[ nan-infj]',
+            '[nan+nanj]',  '[nan+nanj]',  '[ nan+nanj]']
 
         for res, val in zip(actual, wanted):
-            assert_(res == val)
+            assert_equal(res, val)
 
 class TestArray2String(object):
     def test_basic(self):
@@ -157,7 +157,7 @@ class TestArray2String(object):
         dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
         x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)
         assert_equal(np.array2string(x),
-                "[('Sarah', [ 8.,  7.]) ('John', [ 6.,  7.])]")
+                "[('Sarah', [8., 7.]) ('John', [6., 7.])]")
 
         # for issue #5692
         A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
@@ -180,7 +180,7 @@ class TestArray2String(object):
         # See #8172
         array_scalar = np.array(
                 (1., 2.1234567890123456789, 3.), dtype=('f8,f8,f8'))
-        assert_equal(np.array2string(array_scalar), "( 1.,  2.12345679,  3.)")
+        assert_equal(np.array2string(array_scalar), "(1., 2.12345679, 3.)")
 
 
 class TestPrintOptions(object):
@@ -194,17 +194,17 @@ class TestPrintOptions(object):
 
     def test_basic(self):
         x = np.array([1.5, 0, 1.234567890])
-        assert_equal(repr(x), "array([ 1.5       ,  0.        ,  1.23456789])")
+        assert_equal(repr(x), "array([1.5       , 0.        , 1.23456789])")
         np.set_printoptions(precision=4)
-        assert_equal(repr(x), "array([ 1.5   ,  0.    ,  1.2346])")
+        assert_equal(repr(x), "array([1.5   , 0.    , 1.2346])")
 
     def test_precision_zero(self):
         np.set_printoptions(precision=0)
         for values, string in (
-                ([0.], " 0."), ([.3], " 0."), ([-.3], "-0."), ([.7], " 1."),
-                ([1.5], " 2."), ([-1.5], "-2."), ([-15.34], "-15."),
-                ([100.], " 100."), ([.2, -1, 122.51], "   0.,   -1.,  123."),
-                ([0], "0"), ([-12], "-12"), ([complex(.3, -.7)], " 0.-1.j")):
+                ([0.], "0."), ([.3], "0."), ([-.3], "-0."), ([.7], "1."),
+                ([1.5], "2."), ([-1.5], "-2."), ([-15.34], "-15."),
+                ([100.], "100."), ([.2, -1, 122.51], "  0.,  -1., 123."),
+                ([0], "0"), ([-12], "-12"), ([complex(.3, -.7)], "0.-1.j")):
             x = np.array(values)
             assert_equal(repr(x), "array([%s])" % string)
 
@@ -234,7 +234,7 @@ class TestPrintOptions(object):
         np.set_printoptions(formatter={'float':lambda x: str(x-1)})
         assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
         np.set_printoptions(formatter={'float_kind':None})
-        assert_equal(repr(x), "array([ 0.,  1.,  2.])")
+        assert_equal(repr(x), "array([0., 1., 2.])")
 
     def test_0d_arrays(self):
         assert_equal(repr(np.datetime64('2005-02-25')[...]),
@@ -248,15 +248,25 @@ class TestPrintOptions(object):
         x = np.array([1., 2., 3.])
         y = np.array([1., 2., -10.])
         z = np.array([100., 2., -1.])
+        w = np.array([-100., 2., 1.])
 
         assert_equal(repr(x), 'array([1., 2., 3.])')
         assert_equal(repr(y), 'array([  1.,   2., -10.])')
         assert_equal(repr(np.array(y[0])), 'array(1.)')
         assert_equal(repr(np.array(y[-1])), 'array(-10.)')
-        assert_equal(repr(z), 'array([ 100.,    2.,   -1.])')
+        assert_equal(repr(z), 'array([100.,   2.,  -1.])')
+        assert_equal(repr(w), 'array([-100.,    2.,    1.])')
 
         assert_equal(repr(np.array([np.nan, np.inf])), 'array([nan, inf])')
         assert_equal(repr(np.array([np.nan, -np.inf])), 'array([ nan, -inf])')
+
+        x = np.array([np.inf, 100000, 1.1234])
+        y = np.array([np.inf, 100000, -1.1234])
+        z = np.array([np.inf, 1.1234, -1e120])
+        np.set_printoptions(precision=2)
+        assert_equal(repr(x), 'array([     inf, 1.00e+05, 1.12e+00])')
+        assert_equal(repr(y), 'array([      inf,  1.00e+05, -1.12e+00])')
+        assert_equal(repr(z), 'array([       inf,  1.12e+000, -1.00e+120])')
 
     def test_bool_spacing(self):
         assert_equal(repr(np.array([True,  True])),

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -244,6 +244,33 @@ class TestPrintOptions(object):
         np.set_printoptions(formatter={'all':lambda x: "test"})
         assert_equal(repr(x), "array(test)")
 
+    def test_float_spacing(self):
+        x = np.array([1., 2., 3.])
+        y = np.array([1., 2., -10.])
+        z = np.array([100., 2., -1.])
+
+        assert_equal(repr(x), 'array([1., 2., 3.])')
+        assert_equal(repr(y), 'array([  1.,   2., -10.])')
+        assert_equal(repr(np.array(y[0])), 'array(1.)')
+        assert_equal(repr(np.array(y[-1])), 'array(-10.)')
+        assert_equal(repr(z), 'array([ 100.,    2.,   -1.])')
+
+        assert_equal(repr(np.array([np.nan, np.inf])), 'array([nan, inf])')
+        assert_equal(repr(np.array([np.nan, -np.inf])), 'array([ nan, -inf])')
+
+    def test_bool_spacing(self):
+        assert_equal(repr(np.array([True,  True])),
+                     'array([ True,  True], dtype=bool)')
+        assert_equal(repr(np.array([True, False])),
+                     'array([ True, False], dtype=bool)')
+        assert_equal(repr(np.array([True])),
+                     'array([True], dtype=bool)')
+        assert_equal(repr(np.array(True)),
+                     'array(True, dtype=bool)')
+        assert_equal(repr(np.array(False)),
+                     'array(False, dtype=bool)')
+
+
 def test_unicode_object_array():
     import sys
     if sys.version_info[0] >= 3:

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -280,6 +280,19 @@ class TestPrintOptions(object):
         assert_equal(repr(np.array(False)),
                      'array(False, dtype=bool)')
 
+    def test_sign_spacing(self):
+        a = np.arange(4.)
+        assert_equal(repr(a), 'array([0., 1., 2., 3.])')
+        assert_equal(repr(np.array(1.)), 'array(1.)')
+
+        np.set_printoptions(sign=' ')
+        assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
+        assert_equal(repr(np.array(1.)), 'array(1.)')
+
+        np.set_printoptions(sign='+')
+        assert_equal(repr(a), 'array([+0., +1., +2., +3.])')
+        assert_equal(repr(np.array(1.)), 'array(+1.)')
+
 
 def test_unicode_object_array():
     import sys

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -297,6 +297,12 @@ class TestPrintOptions(object):
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
         assert_equal(repr(np.array(1.)), 'array(1.)')
 
+    def test_sign_spacing_structured(self):
+        a = np.ones(2, dtype='f,f')
+        assert_equal(repr(a), "array([(1., 1.), (1., 1.)],\n"
+                              "      dtype=[('f0', '<f4'), ('f1', '<f4')])")
+        assert_equal(repr(a[0]), "(1., 1.)")
+
 
 def test_unicode_object_array():
     import sys

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -274,7 +274,7 @@ class TestPrintOptions(object):
         assert_equal(repr(np.array([True, False])),
                      'array([ True, False], dtype=bool)')
         assert_equal(repr(np.array([True])),
-                     'array([True], dtype=bool)')
+                     'array([ True], dtype=bool)')
         assert_equal(repr(np.array(True)),
                      'array(True, dtype=bool)')
         assert_equal(repr(np.array(False)),
@@ -282,20 +282,26 @@ class TestPrintOptions(object):
 
     def test_sign_spacing(self):
         a = np.arange(4.)
+        b = np.array([1.234e9])
+
         assert_equal(repr(a), 'array([0., 1., 2., 3.])')
         assert_equal(repr(np.array(1.)), 'array(1.)')
+        assert_equal(repr(b), 'array([1.23400000e+09])')
 
         np.set_printoptions(sign=' ')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
         assert_equal(repr(np.array(1.)), 'array( 1.)')
+        assert_equal(repr(b), 'array([ 1.23400000e+09])')
 
         np.set_printoptions(sign='+')
         assert_equal(repr(a), 'array([+0., +1., +2., +3.])')
         assert_equal(repr(np.array(1.)), 'array(+1.)')
+        assert_equal(repr(b), 'array([+1.23400000e+09])')
 
         np.set_printoptions(sign='legacy')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
         assert_equal(repr(np.array(1.)), 'array(1.)')
+        assert_equal(repr(b), 'array([  1.23400000e+09])')
 
     def test_sign_spacing_structured(self):
         a = np.ones(2, dtype='f,f')

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -287,11 +287,15 @@ class TestPrintOptions(object):
 
         np.set_printoptions(sign=' ')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
-        assert_equal(repr(np.array(1.)), 'array(1.)')
+        assert_equal(repr(np.array(1.)), 'array( 1.)')
 
         np.set_printoptions(sign='+')
         assert_equal(repr(a), 'array([+0., +1., +2., +3.])')
         assert_equal(repr(np.array(1.)), 'array(+1.)')
+
+        np.set_printoptions(sign='legacy')
+        assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
+        assert_equal(repr(np.array(1.)), 'array(1.)')
 
 
 def test_unicode_object_array():

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -858,7 +858,7 @@ class TestRegression(object):
 
     def test_sign_bit(self):
         x = np.array([0, -0.0, 0])
-        assert_equal(str(np.abs(x)), '[ 0.  0.  0.]')
+        assert_equal(str(np.abs(x)), '[0. 0. 0.]')
 
     def test_flat_index_byteswap(self):
         for dt in (np.dtype('<i4'), np.dtype('>i4')):

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -7,64 +7,64 @@ from numpy.testing import run_module_suite, assert_equal
 class TestStr(object):
     def test_polynomial_str(self):
         res = str(poly.Polynomial([0, 1]))
-        tgt = 'poly([ 0.  1.])'
+        tgt = 'poly([0. 1.])'
         assert_equal(res, tgt)
 
     def test_chebyshev_str(self):
         res = str(poly.Chebyshev([0, 1]))
-        tgt = 'cheb([ 0.  1.])'
+        tgt = 'cheb([0. 1.])'
         assert_equal(res, tgt)
 
     def test_legendre_str(self):
         res = str(poly.Legendre([0, 1]))
-        tgt = 'leg([ 0.  1.])'
+        tgt = 'leg([0. 1.])'
         assert_equal(res, tgt)
 
     def test_hermite_str(self):
         res = str(poly.Hermite([0, 1]))
-        tgt = 'herm([ 0.  1.])'
+        tgt = 'herm([0. 1.])'
         assert_equal(res, tgt)
 
     def test_hermiteE_str(self):
         res = str(poly.HermiteE([0, 1]))
-        tgt = 'herme([ 0.  1.])'
+        tgt = 'herme([0. 1.])'
         assert_equal(res, tgt)
 
     def test_laguerre_str(self):
         res = str(poly.Laguerre([0, 1]))
-        tgt = 'lag([ 0.  1.])'
+        tgt = 'lag([0. 1.])'
         assert_equal(res, tgt)
 
 
 class TestRepr(object):
     def test_polynomial_str(self):
         res = repr(poly.Polynomial([0, 1]))
-        tgt = 'Polynomial([ 0.,  1.], domain=[-1,  1], window=[-1,  1])'
+        tgt = 'Polynomial([0., 1.], domain=[-1,  1], window=[-1,  1])'
         assert_equal(res, tgt)
 
     def test_chebyshev_str(self):
         res = repr(poly.Chebyshev([0, 1]))
-        tgt = 'Chebyshev([ 0.,  1.], domain=[-1,  1], window=[-1,  1])'
+        tgt = 'Chebyshev([0., 1.], domain=[-1,  1], window=[-1,  1])'
         assert_equal(res, tgt)
 
     def test_legendre_repr(self):
         res = repr(poly.Legendre([0, 1]))
-        tgt = 'Legendre([ 0.,  1.], domain=[-1,  1], window=[-1,  1])'
+        tgt = 'Legendre([0., 1.], domain=[-1,  1], window=[-1,  1])'
         assert_equal(res, tgt)
 
     def test_hermite_repr(self):
         res = repr(poly.Hermite([0, 1]))
-        tgt = 'Hermite([ 0.,  1.], domain=[-1,  1], window=[-1,  1])'
+        tgt = 'Hermite([0., 1.], domain=[-1,  1], window=[-1,  1])'
         assert_equal(res, tgt)
 
     def test_hermiteE_repr(self):
         res = repr(poly.HermiteE([0, 1]))
-        tgt = 'HermiteE([ 0.,  1.], domain=[-1,  1], window=[-1,  1])'
+        tgt = 'HermiteE([0., 1.], domain=[-1,  1], window=[-1,  1])'
         assert_equal(res, tgt)
 
     def test_laguerre_repr(self):
         res = repr(poly.Laguerre([0, 1]))
-        tgt = 'Laguerre([ 0.,  1.], domain=[0, 1], window=[0, 1])'
+        tgt = 'Laguerre([0., 1.], domain=[0, 1], window=[0, 1])'
         assert_equal(res, tgt)
 
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -159,9 +159,9 @@ class TestBuildErrorMessage(unittest.TestCase):
         err_msg = 'There is a mismatch'
 
         a = build_err_msg([x, y], err_msg)
-        b = ('\nItems are not equal: There is a mismatch\n ACTUAL: array([ '
-             '1.00001,  2.00002,  3.00003])\n DESIRED: array([ 1.00002,  '
-             '2.00003,  3.00004])')
+        b = ('\nItems are not equal: There is a mismatch\n ACTUAL: array(['
+             '1.00001, 2.00002, 3.00003])\n DESIRED: array([1.00002, '
+             '2.00003, 3.00004])')
         self.assertEqual(a, b)
 
     def test_build_err_msg_no_verbose(self):
@@ -179,8 +179,8 @@ class TestBuildErrorMessage(unittest.TestCase):
         err_msg = 'There is a mismatch'
 
         a = build_err_msg([x, y], err_msg, names=('FOO', 'BAR'))
-        b = ('\nItems are not equal: There is a mismatch\n FOO: array([ '
-             '1.00001,  2.00002,  3.00003])\n BAR: array([ 1.00002,  2.00003,  '
+        b = ('\nItems are not equal: There is a mismatch\n FOO: array(['
+             '1.00001, 2.00002, 3.00003])\n BAR: array([1.00002, 2.00003, '
              '3.00004])')
         self.assertEqual(a, b)
 
@@ -190,9 +190,9 @@ class TestBuildErrorMessage(unittest.TestCase):
         err_msg = 'There is a mismatch'
 
         a = build_err_msg([x, y], err_msg, precision=10)
-        b = ('\nItems are not equal: There is a mismatch\n ACTUAL: array([ '
-             '1.000000001,  2.00002    ,  3.00003    ])\n DESIRED: array([ '
-             '1.000000002,  2.00003    ,  3.00004    ])')
+        b = ('\nItems are not equal: There is a mismatch\n ACTUAL: array(['
+             '1.000000001, 2.00002    , 3.00003    ])\n DESIRED: array(['
+             '1.000000002, 2.00003    , 3.00004    ])')
         self.assertEqual(a, b)
 
 
@@ -433,8 +433,8 @@ class TestAlmostEqual(_GenericTest, unittest.TestCase):
 
         # test with a different amount of decimal digits
         # note that we only check for the formatting of the arrays themselves
-        b = ('x: array([ 1.00000000001,  2.00000000002,  3.00003     '
-             ' ])\n y: array([ 1.00000000002,  2.00000000003,  3.00004      ])')
+        b = ('x: array([1.00000000001, 2.00000000002, 3.00003     '
+             ' ])\n y: array([1.00000000002, 2.00000000003, 3.00004      ])')
         try:
             self._assert_func(x, y, decimal=12)
         except AssertionError as e:
@@ -443,8 +443,8 @@ class TestAlmostEqual(_GenericTest, unittest.TestCase):
 
         # with the default value of decimal digits, only the 3rd element differs
         # note that we only check for the formatting of the arrays themselves
-        b = ('x: array([ 1.     ,  2.     ,  3.00003])\n y: array([ 1.     ,  '
-             '2.     ,  3.00004])')
+        b = ('x: array([1.     , 2.     , 3.00003])\n y: array([1.     , '
+             '2.     , 3.00004])')
         try:
             self._assert_func(x, y)
         except AssertionError as e:


### PR DESCRIPTION
See discussion in #8983 

This removes the leading space in the string representation of arrays of floating-point type if it is not needed (ie, all positive values), eg:

old behavior:
```python
>>> np.array([1., 2., 3.])
array([ 1.,  2.,  3.])
```
New behavior:
```python
>>> np.array([1., 2., 3.])
array([1., 2., 3.])
```

This noticebly improves the appearance of 0d arrays, so that `np.array(1.0)` prints as itself, instead of as `np.array( 1.0)` as happens after #8983.

It does the same for boolean arrays with only one element, so 0d boolean arrays print as `array(True, dtype=bool)` instead of `array( True, dtype=bool)`.

(longfloats still have a space I think, but I would rather not tackle that here because I think it requires a big rewrite of longfloat formatter)
