### PR TITLE
DOC: Update ufunc documentation

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -431,7 +431,7 @@ keyword, and an *out* keyword, and the arrays must all have dimension >= 1.
 The *axis* keyword specifies the axis of the array over which the reduction
 will take place and may be negative, 
 in which case it counts from the last to the first axis. 
-Generally, it is an integer, though for `:meth:`ufunc.reduce`, it can also be a
+Generally, it is an integer, though for :meth:`ufunc.reduce`, it can also be a
 a tuple of `int` to reduce over several axes at once, or `None`, to reduce over
 all axes. 
 The *dtype* keyword allows you to manage a very common problem that arises

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -431,7 +431,7 @@ keyword, and an *out* keyword, and the arrays must all have dimension >= 1.
 The *axis* keyword specifies the axis of the array over which the reduction
 will take place and may be negative, 
 in which case it counts from the last to the first axis. 
-Generally, it is an integer, though for :meth:`ufunc.reduce`, it can also be a
+Generally, it is an integer, though for :meth:`ufunc.reduce`, it can also be
 a tuple of `int` to reduce over several axes at once, or `None`, to reduce over
 all axes. 
 The *dtype* keyword allows you to manage a very common problem that arises

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -429,11 +429,9 @@ Attempting to call these methods on other ufuncs will cause a
 :exc:`ValueError`. The reduce-like methods all take an *axis* keyword, a *dtype*
 keyword, and an *out* keyword, and the arrays must all have dimension >= 1.
 The *axis* keyword specifies the axis of the array over which the reduction
-will take place and may be negative, 
-in which case it counts from the last to the first axis. 
-Generally, it is an integer, though for :meth:`ufunc.reduce`, it can also be
-a tuple of `int` to reduce over several axes at once, or `None`, to reduce over
-all axes. 
+will take place (with negative values counting backwards). Generally, it is an
+integer, though for :meth:`ufunc.reduce`, it can also be a tuple of `int` to
+reduce over several axes at once, or `None`, to reduce over all axes. 
 The *dtype* keyword allows you to manage a very common problem that arises
 when naively using :meth:`ufunc.reduce`. Sometimes you may
 have an array of a certain data type and wish to add up all of its

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -429,9 +429,13 @@ Attempting to call these methods on other ufuncs will cause a
 :exc:`ValueError`. The reduce-like methods all take an *axis* keyword, a *dtype*
 keyword, and an *out* keyword, and the arrays must all have dimension >= 1.
 The *axis* keyword specifies the axis of the array over which the reduction
-will take place and may be negative, but must be an integer. The
-*dtype* keyword allows you to manage a very common problem that arises
-when naively using :ref:`{op}.reduce <ufunc.reduce>`. Sometimes you may
+will take place and may be negative, 
+in which case it counts from the last to the first axis. 
+Generally, it is an integer, though for `:meth:`ufunc.reduce`, it can also be a
+a tuple of `int` to reduce over several axes at once, or `None`, to reduce over
+all axes. 
+The *dtype* keyword allows you to manage a very common problem that arises
+when naively using :meth:`ufunc.reduce`. Sometimes you may
 have an array of a certain data type and wish to add up all of its
 elements, but the result does not fit into the data type of the
 array. This commonly happens if you have an array of single-byte


### PR DESCRIPTION
fixes #9131 ,
ufuncs.rst now mentions that the axis may be assigned a tuple of ints.
Also fixed broken "{op}.reduce" link on the webpage in the same article