### PR TITLE
WIP: MAINT: print 0d arrays using scalar str/repr

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -43,3 +43,14 @@ Improvements
 
 Changes
 =======
+
+0d arrays now print their elements like numpy scalars
+-----------------------------------------------------
+0d arrays used to be printed by calling ``style(a.item())`` where
+style was either ``str`` or ``repr``. Now they are printed as ``style(a[()])``.
+
+integer scalars are now unaffected by ``np.set_string_function``
+----------------------------------------------------------------
+Previously the str/repr of integer scalars could be controlled by
+``np.set_string_function``, unlike most other numpy scalars. This is no longer
+the case.

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -43,14 +43,3 @@ Improvements
 
 Changes
 =======
-
-0d arrays now print their elements like other arrays
-----------------------------------------------------
-0d arrays now use the array2string formatters to print their elements, like
-other arrays. The `style` argument of array2string is now non-functional.
-
-integer scalars are now unaffected by ``np.set_string_function``
-----------------------------------------------------------------
-Previously the str/repr of integer scalars could be controlled by
-``np.set_string_function``, unlike most other numpy scalars. This is no longer
-the case.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1936,7 +1936,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     '[0 1 2]'
 
     """
-    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
+    return array2string(a, max_line_width, precision, suppress_small, ' ', "", str)
 
 
 def set_string_function(f, repr=True):

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -328,29 +328,45 @@ gentype_nonzero_number(PyObject *m1)
 static PyObject *
 gentype_str(PyObject *self)
 {
-    PyObject *arr, *ret = NULL;
+    PyObject  *item, *item_str;
 
-    arr = PyArray_FromScalar(self, NULL);
-    if (arr != NULL) {
-        ret = PyObject_Str((PyObject *)arr);
-        Py_DECREF(arr);
+    item = gentype_generic_method(self, NULL, NULL, "item");
+    if (item == NULL) {
+        return NULL;
     }
-    return ret;
-}
 
+    item_str = PyObject_Str(item);
+    Py_DECREF(item);
+    return item_str;
+}
 
 static PyObject *
 gentype_repr(PyObject *self)
 {
-    PyObject *arr, *ret = NULL;
+    PyObject *item, *item_str;
 
-    arr = PyArray_FromScalar(self, NULL);
-    if (arr != NULL) {
-        /* XXX: Why are we using str here? */
-        ret = PyObject_Str((PyObject *)arr);
-        Py_DECREF(arr);
+    item = gentype_generic_method(self, NULL, NULL, "item");
+    if (item == NULL) {
+        return NULL;
     }
-    return ret;
+
+    item_str = PyObject_Repr(item);
+    Py_DECREF(item);
+    return item_str;
+}
+
+static PyObject *
+genint_type_str(PyObject *self)
+{
+    PyObject  *item, *item_str;
+    item = gentype_generic_method(self, NULL, NULL, "item");
+    if (item == NULL) {
+        return NULL;
+    }
+
+    item_str = PyObject_Str(item);
+    Py_DECREF(item);
+    return item_str;
 }
 
 /*
@@ -606,6 +622,22 @@ static PyObject *
     return ret;
 }
 /**end repeat**/
+
+static PyObject *
+voidtype_str(PyObject *self){
+    PyObject *arr, *ret = NULL;
+
+    if (!PyDataType_HASFIELDS(((PyVoidScalarObject*)self)->descr)) {
+        return gentype_str(self);
+    }
+
+    arr = PyArray_FromScalar(self, NULL);
+    if (arr != NULL) {
+        ret = PyObject_Str((PyObject *)arr);
+        Py_DECREF(arr);
+    }
+    return ret;
+}
 
 static PyObject *
 datetimetype_repr(PyObject *self)
@@ -4102,6 +4134,8 @@ initialize_numeric_types(void)
     PyVoidArrType_Type.tp_getset = voidtype_getsets;
     PyVoidArrType_Type.tp_as_mapping = &voidtype_as_mapping;
     PyVoidArrType_Type.tp_as_sequence = &voidtype_as_sequence;
+    PyVoidArrType_Type.tp_repr = voidtype_str;
+    PyVoidArrType_Type.tp_str = voidtype_str;
 
     PyIntegerArrType_Type.tp_getset = inttype_getsets;
 
@@ -4184,6 +4218,19 @@ initialize_numeric_types(void)
     PyTimedeltaArrType_Type.tp_@name@ = timedeltatype_@name@;
 
     /**end repeat**/
+
+
+    /**begin repeat
+     * #Type = Bool, Byte, UByte, Short, UShort, Int, UInt, Long,
+     *         ULong, LongLong, ULongLong#
+     */
+
+    /* both str/repr use genint_type_str to avoid trailing "L" of longs */
+    Py@Type@ArrType_Type.tp_str = genint_type_str;
+    Py@Type@ArrType_Type.tp_repr = genint_type_str;
+
+    /**end repeat**/
+
 
     PyHalfArrType_Type.tp_print = halftype_print;
     PyFloatArrType_Type.tp_print = floattype_print;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -338,6 +338,7 @@ gentype_str(PyObject *self)
     return ret;
 }
 
+
 static PyObject *
 gentype_repr(PyObject *self)
 {
@@ -350,20 +351,6 @@ gentype_repr(PyObject *self)
         Py_DECREF(arr);
     }
     return ret;
-}
-
-static PyObject *
-genint_type_str(PyObject *self)
-{
-    PyObject  *item, *item_str;
-    item = gentype_generic_method(self, NULL, NULL, "item");
-    if (item == NULL) {
-        return NULL;
-    }
-
-    item_str = PyObject_Str(item);
-    Py_DECREF(item);
-    return item_str;
 }
 
 /*
@@ -4197,19 +4184,6 @@ initialize_numeric_types(void)
     PyTimedeltaArrType_Type.tp_@name@ = timedeltatype_@name@;
 
     /**end repeat**/
-
-
-    /**begin repeat
-     * #Type = Bool, Byte, UByte, Short, UShort, Int, UInt, Long,
-     *         ULong, LongLong, ULongLong#
-     */
-
-    /* both str/repr use genint_type_str to avoid trailing "L" of longs */
-    Py@Type@ArrType_Type.tp_str = genint_type_str;
-    Py@Type@ArrType_Type.tp_repr = genint_type_str;
-
-    /**end repeat**/
-
 
     PyHalfArrType_Type.tp_print = halftype_print;
     PyFloatArrType_Type.tp_print = floattype_print;

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -242,6 +242,28 @@ class TestPrintOptions:
         np.set_printoptions(formatter={'float_kind':None})
         assert_equal(repr(x), "array([ 0.,  1.,  2.])")
 
+    def test_0d_arrays(self):
+        if sys.version_info[0] >= 3:
+            assert_equal(str(np.array('café', np.unicode_)), 'café')
+            assert_equal(repr(np.array('café', np.unicode_)),
+                         "array('café',\n      dtype='<U4')")
+            assert_equal(str(np.array('café', np.unicode_)), 'café')
+        else:
+            assert_equal(repr(np.array(u'café', np.unicode_)),
+                         "array(u'caf\\xe9',\n      dtype='<U4')")
+        assert_equal(str(np.array('test', np.str_)), 'test')
+
+        a = np.zeros(1, dtype=[('a', '<i4', (3,))])
+        assert_equal(str(a[0]), '([0, 0, 0],)')
+
+        assert_equal(repr(np.datetime64('2005-02-25')[...]),
+            "array(numpy.datetime64('2005-02-25'), dtype='datetime64[D]')")
+
+        # 0d arrays are *not* affected by printoptions
+        x = np.array(1)
+        np.set_printoptions(formatter={'all':lambda x: "test"})
+        assert_equal(repr(x), "array(1)")
+
 def test_unicode_object_array():
     import sys
     if sys.version_info[0] >= 3:

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -115,6 +115,12 @@ class TestArray2String(TestCase):
         assert_(np.array2string(a) == '[0 1 2]')
         assert_(np.array2string(a, max_line_width=4) == '[0 1\n 2]')
 
+    def test_style_keyword(self):
+        """This should only apply to 0-D arrays. See #1218."""
+        stylestr = np.array2string(np.array(1.5),
+                                   style=lambda x: "Value in 0-D array: " + str(x))
+        assert_(stylestr == 'Value in 0-D array: 1.5')
+
     def test_format_function(self):
         """Test custom format function for each element in array."""
         def _format_function(x):
@@ -235,14 +241,6 @@ class TestPrintOptions:
         assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
         np.set_printoptions(formatter={'float_kind':None})
         assert_equal(repr(x), "array([ 0.,  1.,  2.])")
-
-    def test_0d_arrays(self):
-        assert_equal(repr(np.datetime64('2005-02-25')[...]),
-                     "array('2005-02-25', dtype='datetime64[D]')")
-
-        x = np.array(1)
-        np.set_printoptions(formatter={'all':lambda x: "test"})
-        assert_equal(repr(x), "array(test)")
 
 def test_unicode_object_array():
     import sys


### PR DESCRIPTION
Continued from discussion at #8983, to investigate option 3:

  * The old behavior for 0d arrays was to print `str(x.item())`. 
  * This PR's behavior is to print `arrayprint.formatter(x)`.
  * A third unexplored option is to print `str(x)`, ie rely on the string functions in `scalartypes.c.src`.

Two further comments on option 3:

For option 3 to work will need to modify the scalar fallbacks `gentype_repr` and `gentype_str` to not promote to 0d arrays, to avoid recursion issues noted in that PR. Here I made them print `str(x.item())`. After the proposed definitions of `genint_type_repr` and `voidtype_repr` in #8981 and #8983,  `gentype_repr` and str will be unused by numpy itself so this shouldn't cause problems. 

I am also having trouble deciding between `str(x[()])` or `repr(x[()])` for 0d arrays (see the line changed in `_formatArray`). Both of them break current behavior. I'm still working on this but I'll paste the current failed tests in comments below.