### PR TITLE
DOC: Fix some very minor spelling/grammar mistakes in docs

### DIFF
--- a/doc/source/reference/internals.code-explanations.rst
+++ b/doc/source/reference/internals.code-explanations.rst
@@ -105,7 +105,7 @@ which work very simply.
 For the general case, the iteration works by keeping track of a list
 of coordinate counters in the iterator object. At each iteration, the
 last coordinate counter is increased (starting from 0). If this
-counter is smaller then one less than the size of the array in that
+counter is smaller than one less than the size of the array in that
 dimension (a pre-computed and stored value), then the counter is
 increased and the dataptr member is increased by the strides in that
 dimension and the macro ends. If the end of a dimension is reached,
@@ -369,7 +369,7 @@ return arrays are constructed. If any provided output array doesn't
 have the correct type (or is mis-aligned) and is smaller than the
 buffer size, then a new output array is constructed with the special
 UPDATEIFCOPY flag set so that when it is DECREF'd on completion of the
-function, it's contents will be copied back into the output array.
+function, its contents will be copied back into the output array.
 Iterators for the output arguments are then processed.
 
 Finally, the decision is made about how to execute the looping
@@ -475,7 +475,7 @@ function is called with just the ndarray as the first argument.
 Methods
 -------
 
-Their are three methods of ufuncs that require calculation similar to
+There are three methods of ufuncs that require calculation similar to
 the general-purpose ufuncs. These are reduce, accumulate, and
 reduceat. Each of these methods requires a setup command followed by a
 loop. There are four loop styles possible for the methods


### PR DESCRIPTION
Fixes are all in the "Numpy C Code Explanations" page. There might be more language mistakes there, since I just read through the page quickly and skipped some sections.