### PR TITLE
DOC: Fixed broken link to scipy developer zone

### DIFF
--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -40,7 +40,7 @@ Our main means of communication are:
 
 - `Old NumPy Trac <http://projects.scipy.org/numpy>`__ (no longer used)
 
-More information about the development of NumPy can be found at our `Developer Zone <http://scipy.org/Developer_Zone>`__.
+More information about the development of NumPy can be found at our `Developer Zone <https://scipy.scipy.org/scipylib/dev-zone.html>`__.
 
 If you want to fix issues in this documentation, the easiest way
 is to participate in `our ongoing documentation marathon


### PR DESCRIPTION
Developer zone link was out of date--now it goes to the right page.