### PR TITLE
MAINT: Simplify if statement

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2935,7 +2935,7 @@ class MaskedArray(ndarray):
         Copies some attributes of obj to self.
 
         """
-        if obj is not None and isinstance(obj, ndarray):
+        if isinstance(obj, ndarray):
             _baseclass = type(obj)
         else:
             _baseclass = ndarray


### PR DESCRIPTION
`isinstance(obj, ndarray)` will return `False` if `(obj is None)` in any case,
so no need to check whether `(obj is not None)` before it. All tests
pass on my build (the most recent one at the time of making this PR).
However, this might have been done for backward compatibility (CI tests all pass, though).