### PR TITLE
BUG: Make a copy of an array in dot method when its stride is zero.

### DIFF
--- a/numpy/core/src/multiarray/cblasfuncs.c
+++ b/numpy/core/src/multiarray/cblasfuncs.c
@@ -636,6 +636,17 @@ cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
                 goto fail;
             }
         }
+        if (PyArray_STRIDE(ap2, 0) == 0) {
+            /* We need to make a copy because gemv forbids incX == 0  */
+            PyObject *new;
+
+            new = PyArray_Copy(ap2);
+            Py_DECREF (ap2);
+            ap2 = (PyArrayObject *)new;
+            if (new == NULL) {
+              goto fail;
+            }
+        }
         NPY_BEGIN_ALLOW_THREADS
         if (PyArray_ISCONTIGUOUS(ap1)) {
             Order = CblasRowMajor;
@@ -661,6 +672,18 @@ cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
             ap2 = (PyArrayObject *)new;
             if (new == NULL) {
                 goto fail;
+            }
+        }
+        if ((ap1shape == _row && PyArray_STRIDE(ap1, 1) == 0) ||
+                (ap1shape != _row && PyArray_STRIDE(ap1, 0) == 0)) {
+            /* We need to make a copy because gemv forbids incX == 0  */
+            PyObject *new;
+
+            new = PyArray_Copy(ap1);
+            Py_DECREF (ap1);
+            ap1 = (PyArrayObject *)new;
+            if (new == NULL) {
+              goto fail;
             }
         }
         NPY_BEGIN_ALLOW_THREADS

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2438,6 +2438,29 @@ class TestMethods(TestCase):
             assert_raises(ValueError, np.dot, a, b, out=b[::2])
             assert_raises(ValueError, np.dot, a, b, out=b.T)
 
+    def test_dot_zero_strides(self):
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        for dt in types:
+            # stride is zero
+            a0 = np.broadcast_to(np.zeros(1, dt), (2))
+            # non-zero
+            a1 = np.zeros(2, dt)
+
+            # zero, zero
+            b0 = np.broadcast_to(np.zeros(1, dt), (2, 2))
+            # zero, non-zero
+            b1 = np.broadcast_to(np.zeros(2, dt), (2, 2))
+            # non-zero, zero
+            b2 = np.broadcast_to(np.zeros(2, dt)[:, None], (2, 2))
+            # non-zero, non-zero
+            b3 = np.zeros((2, 2), dt)
+
+            for a, b in itertools.product([a0, a1], [b0, b1, b2, b3]):
+                c = a.dot(b)
+                assert_equal(c, [0, 0])
+                d = b.dot(a)
+                assert_equal(d, [0, 0])
+
     def test_diagonal(self):
         a = np.arange(12).reshape((3, 4))
         assert_equal(a.diagonal(), [0, 5, 10])


### PR DESCRIPTION
gemv function in BLAS, that is used in dot method, does not permit zero stride.
To use this function we need to make a copy of a given array.

fix #9165