### PR TITLE
COMPAT: PyPy calls clongdouble_int which raises a warning

### DIFF
--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -10,7 +10,7 @@ from numpy.testing.utils import _gen_alignment_data
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
     assert_almost_equal, assert_allclose, assert_array_equal, IS_PYPY,
-    suppress_warnings
+    suppress_warnings, dec,
 )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -401,9 +401,22 @@ class TestConversion(TestCase):
     def test_longdouble_int(self):
         # gh-627
         x = np.longdouble(np.inf)
+        assert_raises(OverflowError, int, x)
+        with suppress_warnings() as sup:
+            sup.record(np.ComplexWarning)
+            x = np.clongdouble(np.inf)
+            assert_raises(OverflowError, int, x)
+            self.assertEqual(len(sup.log), 1)
+
+    @dec.knownfailureif(not IS_PYPY)
+    def test_clongdouble___int__(self):
+        x = np.longdouble(np.inf)
         assert_raises(OverflowError, x.__int__)
-        x = np.clongdouble(np.inf)
-        assert_raises(OverflowError, x.__int__)
+        with suppress_warnings() as sup:
+            sup.record(np.ComplexWarning)
+            x = np.clongdouble(np.inf)
+            assert_raises(OverflowError, x.__int__)
+            self.assertEqual(len(sup.log), 1)
 
     def test_numpy_scalar_relational_operators(self):
         # All integer


### PR DESCRIPTION
Python calls ``x.tp_as_number.nb_int`` for either ``int(x)`` or ``x.__int__()``. However, if that function pointer is modified after ``PyType_Ready``, CPython will call the function registered when ``PyType_Ready`` is called for ``x.__int__()``, but the new function for ``int(x)``. 

In this case, the only difference between ``clongdouble_int`` (the new function switched in during ``add_scalarmath()``) and ``clongdoubletype_int`` (the original function during ``PyType_Ready`` is that the latter one raises a Warning.

On PyPy we always call the new function, so tests (and live code) that use ``x.__int__()`` must accommodate for the warning. Code that calls ``int(x)`` will raise a warning on both platforms