### PR TITLE
BUG: fixes #8123 Histogram precision issue due to higher precision in internal mn, mx

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -237,6 +237,10 @@ def _get_outer_edges(a, range):
         first_edge = first_edge - 0.5
         last_edge = last_edge + 0.5
 
+    if a.dtype.kind not in ['i']:
+        first_edge = a.dtype.type(first_edge)
+        last_edge = a.dtype.type(last_edge)
+
     return first_edge, last_edge
 
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -299,6 +299,15 @@ class TestHistogram(object):
         assert_equal(d_edge.dtype, dates.dtype)
         assert_equal(t_edge.dtype, td)
 
+    def test_precision_data_and_range(self):
+        tiny_shift = 1e-8
+        count, x_loc = np.histogram(
+            np.array([1.0], np.float32),
+            bins=1,
+            range=np.array([1.0 + tiny_shift, 2.0], np.float64)
+        )
+        assert_equal(count, 1)
+
 
 class TestHistogramOptimBinNums(object):
     """


### PR DESCRIPTION
When the input data hsa a lower precision than the specified ranges and error is raised in bincount.
This has been addressed in issues #8123 

The problem is caused by higher precision ````mn````, ````mx````. In this pull request, i cast ````mn```` and ````mx```` to the same type as the input data 

(messed up the previous pull request...could not reopen it)