### PR TITLE
BUG: Fix unicode(unicode_array_0d) on python 2.7

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2505,6 +2505,12 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         (PyCFunction)array_ufunc,
         METH_VARARGS | METH_KEYWORDS, NULL},
 
+#ifndef NPY_PY3K
+    {"__unicode__",
+        (PyCFunction)array_unicode,
+        METH_NOARGS, NULL},
+#endif
+
     /* for the sys module */
     {"__sizeof__",
         (PyCFunction) array_sizeof,

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -225,3 +225,35 @@ array_format(PyArrayObject *self, PyObject *args)
         );
     }
 }
+
+#ifndef NPY_PY3K
+
+NPY_NO_EXPORT PyObject *
+array_unicode(PyArrayObject *self)
+{
+    PyObject *uni;
+
+    if (PyArray_NDIM(self) == 0) {
+        PyObject *item = PyArray_ToScalar(PyArray_DATA(self), self);
+        if (item == NULL){
+            return NULL;
+        }
+
+        /* defer to invoking `unicode` on the scalar */
+        uni = PyObject_CallFunctionObjArgs(
+            (PyObject *)&PyUnicode_Type, item, NULL);
+        Py_DECREF(item);
+    }
+    else {
+        /* Do what unicode(self) would normally do */
+        PyObject *str = PyObject_Str((PyObject *)self);
+        if (str == NULL){
+            return NULL;
+        }
+        uni = PyUnicode_FromObject(str);
+        Py_DECREF(str);
+    }
+    return uni;
+}
+
+#endif

--- a/numpy/core/src/multiarray/strfuncs.h
+++ b/numpy/core/src/multiarray/strfuncs.h
@@ -13,4 +13,9 @@ array_str(PyArrayObject *self);
 NPY_NO_EXPORT PyObject *
 array_format(PyArrayObject *self, PyObject *args);
 
+#ifndef NPY_PY3K
+    NPY_NO_EXPORT PyObject *
+    array_unicode(PyArrayObject *self);
+#endif
+
 #endif

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -254,8 +254,10 @@ class TestPrintOptions(object):
         assert_equal(repr(x), "array([0., 1., 2.])")
 
     def test_0d_arrays(self):
+        unicode = type(u'')
+        assert_equal(unicode(np.array(u'café', np.unicode_)), u'café')
+
         if sys.version_info[0] >= 3:
-            assert_equal(str(np.array('café', np.unicode_)), 'café')
             assert_equal(repr(np.array('café', np.unicode_)),
                          "array('café',\n      dtype='<U4')")
         else:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3867,6 +3867,10 @@ class MaskedArray(ndarray):
     def __str__(self):
         return str(self._insert_masked_print())
 
+    if sys.version_info.major < 3:
+        def __unicode__(self):
+            return unicode(self._insert_masked_print())
+
     def __repr__(self):
         """
         Literal string representation.
@@ -6237,6 +6241,10 @@ class MaskedConstant(MaskedArray):
 
     def __str__(self):
         return str(masked_print_option._display)
+
+    if sys.version_info.major < 3:
+        def __unicode__(self):
+            return unicode(masked_print_option._display)
 
     def __repr__(self):
         if self is MaskedConstant.__singleton:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -500,6 +500,16 @@ class TestMaskedArray(object):
             '       fill_value = 999999)\n'
         )
 
+    def test_0d_unicode(self):
+        u = u'caf\xe9'
+        utype = type(u)
+
+        arr_nomask = np.ma.array(u)
+        arr_masked = np.ma.array(u, mask=True)
+
+        assert_equal(utype(arr_nomask), u)
+        assert_equal(utype(arr_masked), u'--')
+
     def test_pickling(self):
         # Tests pickling
         for dtype in (int, float, str, object):


### PR DESCRIPTION
<s>Related to #9139, first two commits stand alone in #9202 </s>

Now <s>a commit from #9332</s> <s>a single commit on top of #9784</s>, standalone.

This is like #9332, but:
* Can't be affected by `np.set_string_function` (is this a good thing?)
* Also fixes `unicode` such that they convert to python unicode scalars

Results on python 2.7:
```
>>> str(np.array('test'))
'test'
>>> unicode(np.array(u'café'))
u'café'
```
