### PR TITLE
ENH: Weighted quantile

### DIFF
--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1219,8 +1219,8 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
 
 
 def _nanpercentile_dispatcher(
-        a, q, axis=None, weights=None, out=None, overwrite_input=None,
-        method=None, keepdims=None, *, interpolation=None):
+        a, q, axis=None, out=None, overwrite_input=None,
+        method=None, keepdims=None, *, weights=None, interpolation=None):
     return (a, q, out)
 
 
@@ -1229,12 +1229,12 @@ def nanpercentile(
         a,
         q,
         axis=None,
-        weights=None,
         out=None,
         overwrite_input=False,
         method="linear",
         keepdims=np._NoValue,
         *,
+        weights=None,
         interpolation=None,
 ):
     """
@@ -1385,9 +1385,9 @@ def nanpercentile(
         a, q, axis, weights, out, overwrite_input, method, keepdims)
 
 
-def _nanquantile_dispatcher(a, q, axis=None, weights=None, out=None,
+def _nanquantile_dispatcher(a, q, axis=None, out=None,
                             overwrite_input=None, method=None, keepdims=None,
-                            *, interpolation=None):
+                            *, weights=None, interpolation=None):
     return (a, q, out)
 
 
@@ -1396,12 +1396,12 @@ def nanquantile(
         a,
         q,
         axis=None,
-        weights=None,
         out=None,
         overwrite_input=False,
         method="linear",
         keepdims=np._NoValue,
         *,
+        weights=None,
         interpolation=None,
 ):
     """
@@ -1570,12 +1570,7 @@ def _nanquantile_unchecked(
         return np.nanmean(a, axis, out=out, keepdims=keepdims)
 
     if weights is not None:
-<<<<<<< HEAD
         weights = fnb._validate_and_ureduce_weights(a, axis, weights)
-        weights[np.isnan(a)] = np.nan  # for _nanquantile_1d
-=======
-        weights = function_base._validate_and_ureduce_weights(a, axis, weights)
->>>>>>> ENH: Tests and documentation for weights arg to quantile/percentile in lib.function_base and nanquantile/nanpercentile in lib.nanfunctions (#9211).
 
     return fnb._ureduce(a,
                         func=_nanquantile_ureduce_func,
@@ -1657,8 +1652,9 @@ def _nanquantile_1d(arr1d, q, wgt1d=None, overwrite_input=False,
         # convert to scalar
         return np.full(q.shape, np.nan, dtype=arr1d.dtype)[()]
 
-    return function_base._quantile_unchecked(
-        arr1d, q, overwrite_input=overwrite_input, method=method)
+    return fnb._quantile_unchecked(
+        arr1d, q, weights=wgt1d, overwrite_input=overwrite_input,
+        method=method)
 
 
 def _nanvar_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3023,10 +3023,10 @@ class TestPercentile:
 
     def test_api(self):
         d = np.ones(5)
-        np.percentile(d, 5, None, None, False)
-        np.percentile(d, 5, None, None, False, 'linear')
+        np.percentile(d, 5, None, None, None, False)
+        np.percentile(d, 5, None, None, None, False, 'linear')
         o = np.ones((1,))
-        np.percentile(d, 5, None, o, False, 'linear')
+        np.percentile(d, 5, None, None, o, False, 'linear')
 
     def test_complex(self):
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='G')

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3023,10 +3023,10 @@ class TestPercentile:
 
     def test_api(self):
         d = np.ones(5)
-        np.percentile(d, 5, None, None, None, False)
-        np.percentile(d, 5, None, None, None, False, 'linear')
+        np.percentile(d, 5, None, None, False)
+        np.percentile(d, 5, None, None, False, 'linear')
         o = np.ones((1,))
-        np.percentile(d, 5, None, None, o, False, 'linear')
+        np.percentile(d, 5, None, o, False, 'linear')
 
     def test_complex(self):
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='G')
@@ -3861,15 +3861,8 @@ class TestQuantile:
         assert_almost_equal(actual, expected)
 
         # mix of numeric types
-        # due to renormalization triggered by weight < 1,
         # this is expected to be the same as weights = [1, 2, 3]
-        weights = [decimal.Decimal(0.5), 1, 1.5]
-        actual = np.quantile(ar, q=q, axis=axis, weights=weights,
-                             method=method)
-        assert_almost_equal(actual, expected)
-
-        # show that normalization means sum of weights is irrelavant
-        weights = [0.1, 0.2, 0.3]
+        weights = [decimal.Decimal(1.0), 2, 3.0]
         actual = np.quantile(ar, q=q, axis=axis, weights=weights,
                              method=method)
         assert_almost_equal(actual, expected)
@@ -3880,12 +3873,6 @@ class TestQuantile:
                              method=method)
         ar_012 = np.stack((ar[1, :], ar[2, :], ar[2, :]), axis=axis)
         expected = np.quantile(ar_012, q=q, axis=axis, method=method)
-        assert_almost_equal(actual, expected)
-
-        # weight entries < 1
-        weights = [0.0, 0.001, 0.002]
-        actual = np.quantile(ar, q=q, axis=axis, weights=weights,
-                             method=method)
         assert_almost_equal(actual, expected)
 
     def test_weights_flags(self):
@@ -3902,6 +3889,8 @@ class TestQuantile:
             np.quantile(ar, q=q, axis=axis, weights=[1, np.nan])
         with assert_raises_regex(ValueError, "Negative weight not allowed"):
             np.quantile(ar, q=q, axis=axis, weights=[1, -1])
+        with assert_raises_regex(ValueError, "Partial weight"):
+            np.quantile(ar, q=q, axis=axis, weights=[1, 0.1])
         with assert_raises_regex(ZeroDivisionError, "Weights sum to zero"):
             np.quantile(ar, q=q, axis=axis, weights=[0, 0])
 

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -4,6 +4,7 @@ import pytest
 import inspect
 
 import numpy as np
+import numpy.lib.function_base as nfb
 from numpy._core.numeric import normalize_axis_tuple
 from numpy.exceptions import AxisError, ComplexWarning
 from numpy.lib._nanfunctions_impl import _nan_mask, _replace_nan
@@ -1277,12 +1278,7 @@ class TestNanFunctions_Quantile:
         assert np.isnan(out).all()
         assert out.dtype == array.dtype
 
-    @pytest.mark.parametrize(
-        "method",
-        ['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
-         'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear',
-         'median_unbiased', 'normal_unbiased',
-         'nearest', 'lower', 'higher', 'midpoint'])
+    @pytest.mark.parametrize("method", list(nfb._QuantileMethods.keys()))
     def test_weights_all_ones(self, method):
         """Test that all weights == 1 gives same results as no weights."""
         ar = np.arange(24).reshape(2, 3, 4).astype(float)
@@ -1321,12 +1317,7 @@ class TestNanFunctions_Quantile:
         actual = np.nanquantile(ar, q=q, weights=weights, method=method)
         assert_almost_equal(actual, expected)
 
-    @pytest.mark.parametrize(
-        "method",
-        ['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
-         'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear',
-         'median_unbiased', 'normal_unbiased',
-         'nearest', 'lower', 'higher', 'midpoint'])
+    @pytest.mark.parametrize("method", list(nfb._QuantileMethods.keys()))
     def test_multiple_axes(self, method):
         """Test that weights work on multiple axes."""
         ar = np.arange(12).reshape(3, 4).astype(float)
@@ -1340,12 +1331,7 @@ class TestNanFunctions_Quantile:
                                 method=method)
         assert_almost_equal(actual, expected)
 
-    @pytest.mark.parametrize(
-        "method",
-        ['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
-         'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear',
-         'median_unbiased', 'normal_unbiased',
-         'nearest', 'lower', 'higher', 'midpoint'])
+    @pytest.mark.parametrize("method", list(nfb._QuantileMethods.keys()))
     def test_various_weights(self, method):
         """Test various weights arg scenarios."""
         ar = np.arange(12).reshape(3, 4).astype(float)


### PR DESCRIPTION
Creates `quantile()` function that allows `weights` input.

Fixes #6326, #8935

---

The following are plotted the same way as the graphs [at the bottom of the `np.percentile` docs](http://www.numpy.org/devdocs/reference/generated/numpy.percentile.html), but with an added weights argument:

`weights=[1, 2, 3, 4]`:
![weights_1_2_3_4](https://user-images.githubusercontent.com/5572303/40265781-c7310218-5af3-11e8-83b4-0f560b452307.png)

`weights = [2, 1, 1, 2]`:
![weights_2_1_1_2](https://user-images.githubusercontent.com/5572303/40265788-df53cbbe-5af3-11e8-9271-33c28c5bfa3b.png)


