### PR TITLE
ENH: Add np.quantile

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -11,6 +11,8 @@ New functions
 =============
 
 * ``quantile`` function, an interface to ``percentile`` without factors of 100
+* ``nanquantile`` function, an interface to ``nanpercentile`` without factors
+  of 100
 
 Deprecations
 ============
@@ -31,10 +33,11 @@ C API changes
 New Features
 ============
 
-``np.quantile``
----------------
-Like ``np.percentile``, but takes quantiles in [0, 1] rather than percentiles in
-[0, 100].
+``np.quantile`` and ``np.nanquantile``
+--------------------------------------
+Like ``np.percentile`` and ``np.nanpercentile``, but takes quantiles in [0, 1]
+rather than percentiles in [0, 100]. ``np.percentile`` is now a thin wrapper
+around ``np.quantile`` with the extra step of dividing by 100.
 
 
 Improvements

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -10,6 +10,7 @@ Highlights
 New functions
 =============
 
+* ``quantile`` function, an interface to ``percentile`` without factors of 100
 
 Deprecations
 ============
@@ -29,6 +30,11 @@ C API changes
 
 New Features
 ============
+
+``np.quantile``
+---------------
+Like ``np.percentile``, but takes quantiles in [0, 1] rather than percentiles in
+[0, 100].
 
 
 Improvements

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -47,7 +47,8 @@ __all__ = [
     'histogram', 'histogramdd', 'bincount', 'digitize', 'cov', 'corrcoef',
     'msort', 'median', 'sinc', 'hamming', 'hanning', 'bartlett',
     'blackman', 'kaiser', 'trapz', 'i0', 'add_newdoc', 'add_docstring',
-    'meshgrid', 'delete', 'insert', 'append', 'interp', 'add_newdoc_ufunc'
+    'meshgrid', 'delete', 'insert', 'append', 'interp', 'add_newdoc_ufunc',
+    'quantile'
     ]
 
 
@@ -4285,8 +4286,36 @@ def percentile(a, q, axis=None, out=None,
     >>> assert not np.all(a == b)
 
     """
-    q = array(q, dtype=np.float64, copy=True)
-    r, k = _ureduce(a, func=_percentile, q=q, axis=axis, out=out,
+    return quantile(a, np.true_divide(q, 100), axis, out,
+           overwrite_input, interpolation, keepdims)
+
+
+def quantile(a, q, axis=None, out=None,
+             overwrite_input=False, interpolation='linear', keepdims=False):
+    """
+    Compute the qth quantile of the data along the specified axis.
+
+    Takes exactly the same arguments as `percentile`, but with q in [0, 1],
+    rather than [0, 100]
+
+    ..versionadded:: 1.15.0
+
+    See Also
+    --------
+    percentile
+
+    Examples
+    --------
+    >>> a = np.array([[10, 7, 4], [3, 2, 1]])
+    >>> a
+    array([[10,  7,  4],
+           [ 3,  2,  1]])
+    >>> np.quantile(a, 0.5)
+    3.5
+    """
+
+    q = asarray(q, dtype=np.float64)
+    r, k = _ureduce(a, func=_quantile, q=q, axis=axis, out=out,
                     overwrite_input=overwrite_input,
                     interpolation=interpolation)
     if keepdims:
@@ -4295,8 +4324,8 @@ def percentile(a, q, axis=None, out=None,
         return r
 
 
-def _percentile(a, q, axis=None, out=None,
-                overwrite_input=False, interpolation='linear', keepdims=False):
+def _quantile(a, q, axis=None, out=None,
+              overwrite_input=False, interpolation='linear', keepdims=False):
     a = asarray(a)
     if q.ndim == 0:
         # Do not allow 0-d arrays because following code fails for scalar
@@ -4308,14 +4337,12 @@ def _percentile(a, q, axis=None, out=None,
     # avoid expensive reductions, relevant for arrays with < O(1000) elements
     if q.size < 10:
         for i in range(q.size):
-            if q[i] < 0. or q[i] > 100.:
+            if q[i] < 0. or q[i] > 1.:
                 raise ValueError("Percentiles must be in the range [0,100]")
-            q[i] /= 100.
     else:
         # faster than any()
-        if np.count_nonzero(q < 0.) or np.count_nonzero(q > 100.):
+        if np.count_nonzero(q < 0.) or np.count_nonzero(q > 1.):
             raise ValueError("Percentiles must be in the range [0,100]")
-        q /= 100.
 
     # prepare a for partioning
     if overwrite_input:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4183,19 +4183,59 @@ def percentile(a, q, axis=None, out=None,
     """
     Compute the qth percentile of the data along the specified axis.
 
-    Returns the qth percentile(s) of the array elements.
+    The ``q``\ th percentile is synonymous with the `quantile` at ``q/100``.
+
+    Parameters
+    ----------
+    q : real number in range of [0,100] (or sequence of real numbers)
+        Percentile to compute, which must be between 0 and 100 inclusive.
+        This is divided by 100 and passed on to `quantile`.
+
+    All the other parameters have the same meaning as they do in `quantile`.
+
+    See also
+    --------
+    quantile
+    mean
+    median : equivalent to ``percentile(..., 50)``
+    nanpercentile
+
+    Examples
+    --------
+    >>> a = np.array([[10, 7, 4], [3, 2, 1]])
+    >>> a
+    array([[10,  7,  4],
+           [ 3,  2,  1]])
+    >>> np.percentile(a, 50)
+    3.5
+    >>> np.quantile(a, 0.5)
+    3.5
+
+
+    """
+    q = np.true_divide(q, 100)  # handles the asarray for us too
+    return quantile(a, q, axis, out, overwrite_input, interpolation, keepdims)
+
+
+def quantile(a, q, axis=None, out=None,
+             overwrite_input=False, interpolation='linear', keepdims=False):
+    """
+    Compute the `q`th quantile of the data along the specified axis.
+
+    ..versionadded:: 1.15.0
 
     Parameters
     ----------
     a : array_like
         Input array or object that can be converted to an array.
-    q : float in range of [0,100] (or sequence of floats)
-        Percentile to compute, which must be between 0 and 100 inclusive.
+    q : float in range of [0,1] (or sequence of floats)
+        Quantile to compute, which must be between 0.0 and 1.0 inclusive.
     axis : {int, sequence of int, None}, optional
-        Axis or axes along which the percentiles are computed. The
-        default is to compute the percentile(s) along a flattened
-        version of the array. A sequence of axes is supported since
-        version 1.9.0.
+        Axis or axes along which the quantiles are computed. The
+        default is to compute the quantile(s) along a flattened
+        version of the array.
+        .. versionchanged:: 1.9.0
+           A sequence of axes is supported
     out : ndarray, optional
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,
@@ -4203,7 +4243,7 @@ def percentile(a, q, axis=None, out=None,
     overwrite_input : bool, optional
         If True, then allow use of memory of input array `a`
         calculations. The input array will be modified by the call to
-        `percentile`. This will save memory when you do not need to
+        `quantile`. This will save memory when you do not need to
         preserve the contents of the input array. In this case you
         should not make any assumptions about the contents of the input
         `a` after this function completes -- treat it as undefined.
@@ -4232,10 +4272,10 @@ def percentile(a, q, axis=None, out=None,
 
     Returns
     -------
-    percentile : scalar or ndarray
-        If `q` is a single percentile and `axis=None`, then the result
-        is a scalar. If multiple percentiles are given, first axis of
-        the result corresponds to the percentiles. The other axes are
+    quantile : scalar or ndarray
+        If `q` is a single quantile and `axis=None`, then the result
+        is a scalar. If multiple quantiles are given, first axis of
+        the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
         contains integers or floats smaller than ``float64``, the output
         data-type is ``float64``. Otherwise, the output data-type is the
@@ -4244,65 +4284,18 @@ def percentile(a, q, axis=None, out=None,
 
     See Also
     --------
-    mean, median, nanpercentile
+    mean, median, nanpercentile, percentile
 
     Notes
     -----
-    Given a vector ``V`` of length ``N``, the ``q``-th percentile of
-    ``V`` is the value ``q/100`` of the way from the minimum to the
+    Given a vector ``V`` of length ``N``, the ``q``-th quantile of
+    ``V`` is the value ``q`` of the way from the minimum to the
     maximum in a sorted copy of ``V``. The values and distances of
     the two nearest neighbors as well as the `interpolation` parameter
-    will determine the percentile if the normalized ranking does not
+    will determine the quantile if the normalized ranking does not
     match the location of ``q`` exactly. This function is the same as
-    the median if ``q=50``, the same as the minimum if ``q=0`` and the
-    same as the maximum if ``q=100``.
-
-    Examples
-    --------
-    >>> a = np.array([[10, 7, 4], [3, 2, 1]])
-    >>> a
-    array([[10,  7,  4],
-           [ 3,  2,  1]])
-    >>> np.percentile(a, 50)
-    3.5
-    >>> np.percentile(a, 50, axis=0)
-    array([[ 6.5,  4.5,  2.5]])
-    >>> np.percentile(a, 50, axis=1)
-    array([ 7.,  2.])
-    >>> np.percentile(a, 50, axis=1, keepdims=True)
-    array([[ 7.],
-           [ 2.]])
-
-    >>> m = np.percentile(a, 50, axis=0)
-    >>> out = np.zeros_like(m)
-    >>> np.percentile(a, 50, axis=0, out=out)
-    array([[ 6.5,  4.5,  2.5]])
-    >>> m
-    array([[ 6.5,  4.5,  2.5]])
-
-    >>> b = a.copy()
-    >>> np.percentile(b, 50, axis=1, overwrite_input=True)
-    array([ 7.,  2.])
-    >>> assert not np.all(a == b)
-
-    """
-    return quantile(a, np.true_divide(q, 100), axis, out,
-           overwrite_input, interpolation, keepdims)
-
-
-def quantile(a, q, axis=None, out=None,
-             overwrite_input=False, interpolation='linear', keepdims=False):
-    """
-    Compute the qth quantile of the data along the specified axis.
-
-    Takes exactly the same arguments as `percentile`, but with q in [0, 1],
-    rather than [0, 100]
-
-    ..versionadded:: 1.15.0
-
-    See Also
-    --------
-    percentile
+    the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and the
+    same as the maximum if ``q=1.0``.
 
     Examples
     --------
@@ -4312,8 +4305,31 @@ def quantile(a, q, axis=None, out=None,
            [ 3,  2,  1]])
     >>> np.quantile(a, 0.5)
     3.5
-    """
+    >>> np.quantile(a, 0.5, axis=0)
+    array([[ 6.5,  4.5,  2.5]])
+    >>> np.quantile(a, 0.5, axis=1)
+    array([ 7.,  2.])
+    >>> np.quantile(a, 0.5, axis=1, keepdims=True)
+    array([[ 7.],
+           [ 2.]])
 
+    >>> m = np.quantile(a, 0.5, axis=0)
+    >>> out = np.zeros_like(m)
+    >>> np.quantile(a, 0.5, axis=0, out=out)
+    array([[ 6.5,  4.5,  2.5]])
+    >>> m
+    array([[ 6.5,  4.5,  2.5]])
+
+    >>> b = a.copy()
+    >>> np.quantile(b, 0.5, axis=1, overwrite_input=True)
+    array([ 7.,  2.])
+    >>> assert not np.all(a == b)
+
+    See Also
+    --------
+    percentile
+
+    """
     q = asarray(q, dtype=np.float64)
     r, k = _ureduce(a, func=_quantile, q=q, axis=axis, out=out,
                     overwrite_input=overwrite_input,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4178,6 +4178,19 @@ def _median(a, axis=None, out=None, overwrite_input=False):
         return mean(part[indexer], axis=axis, out=out)
 
 
+def _valid_quantile(q):
+    # avoid expensive reductions, relevant for arrays with < O(1000) elements
+    if q.ndim == 1 and q.size < 10:
+        for i in range(q.size):
+            if q[i] < 0.0 or q[i] > 1.0:
+                return False
+    else:
+        # faster than any()
+        if np.count_nonzero(q < 0.0) or np.count_nonzero(q > 1.0):
+            return False
+    return True
+
+
 def percentile(a, q, axis=None, out=None,
                overwrite_input=False, interpolation='linear', keepdims=False):
     """
@@ -4214,6 +4227,8 @@ def percentile(a, q, axis=None, out=None,
 
     """
     q = np.true_divide(q, 100)  # handles the asarray for us too
+    if not _valid_quantile(q):
+        raise ValueError("Percentiles must be in the range [0, 100]")
     return quantile(a, q, axis, out, overwrite_input, interpolation, keepdims)
 
 
@@ -4331,6 +4346,8 @@ def quantile(a, q, axis=None, out=None,
 
     """
     q = asarray(q, dtype=np.float64)
+    if not _valid_quantile(q):
+        raise ValueError("Quantiles must be in the range [0.0, 1.0]")
     r, k = _ureduce(a, func=_quantile, q=q, axis=axis, out=out,
                     overwrite_input=overwrite_input,
                     interpolation=interpolation)
@@ -4349,16 +4366,6 @@ def _quantile(a, q, axis=None, out=None,
         q = q[None]
     else:
         zerod = False
-
-    # avoid expensive reductions, relevant for arrays with < O(1000) elements
-    if q.size < 10:
-        for i in range(q.size):
-            if q[i] < 0. or q[i] > 1.:
-                raise ValueError("Percentiles must be in the range [0,100]")
-    else:
-        # faster than any()
-        if np.count_nonzero(q < 0.) or np.count_nonzero(q > 1.):
-            raise ValueError("Percentiles must be in the range [0,100]")
 
     # prepare a for partioning
     if overwrite_input:

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -16,6 +16,7 @@ Functions
 - `nanvar` -- variance of non-NaN values
 - `nanstd` -- standard deviation of non-NaN values
 - `nanmedian` -- median of non-NaN values
+- `nanquantile` -- qth quantile of non-NaN values
 - `nanpercentile` -- qth percentile of non-NaN values
 
 """
@@ -23,13 +24,13 @@ from __future__ import division, absolute_import, print_function
 
 import warnings
 import numpy as np
-from numpy.lib.function_base import _ureduce as _ureduce
+from numpy.lib.function_base import _ureduce, _valid_quantile
 
 
 __all__ = [
     'nansum', 'nanmax', 'nanmin', 'nanargmax', 'nanargmin', 'nanmean',
-    'nanmedian', 'nanpercentile', 'nanvar', 'nanstd', 'nanprod',
-    'nancumsum', 'nancumprod'
+    'nanmedian', 'nanquantile', 'nanvar', 'nanstd', 'nanprod',
+    'nancumsum', 'nancumprod', 'nanpercentile', 'nanquantile'
     ]
 
 
@@ -1038,77 +1039,46 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     Parameters
     ----------
     a : array_like
-        Input array or object that can be converted to an array.
-    q : float in range of [0,100] (or sequence of floats)
-        Percentile to compute, which must be between 0 and 100
-        inclusive.
-    axis : {int, sequence of int, None}, optional
-        Axis or axes along which the percentiles are computed. The
-        default is to compute the percentile(s) along a flattened
-        version of the array. A sequence of axes is supported since
-        version 1.9.0.
-    out : ndarray, optional
-        Alternative output array in which to place the result. It must
-        have the same shape and buffer length as the expected output,
-        but the type (of the output) will be cast if necessary.
-    overwrite_input : bool, optional
-        If True, then allow use of memory of input array `a` for
-        calculations. The input array will be modified by the call to
-        `percentile`. This will save memory when you do not need to
-        preserve the contents of the input array. In this case you
-        should not make any assumptions about the contents of the input
-        `a` after this function completes -- treat it as undefined.
-        Default is False. If `a` is not already an array, this parameter
-        will have no effect as `a` will be converted to an array
-        internally regardless of the value of this parameter.
-    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
-        This optional parameter specifies the interpolation method to
-        use when the desired quantile lies between two data points
-        ``i < j``:
-            * linear: ``i + (j - i) * fraction``, where ``fraction`` is
-              the fractional part of the index surrounded by ``i`` and
-              ``j``.
-            * lower: ``i``.
-            * higher: ``j``.
-            * nearest: ``i`` or ``j``, whichever is nearest.
-            * midpoint: ``(i + j) / 2``.
-    keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left in
-        the result as dimensions with size one. With this option, the
-        result will broadcast correctly against the original array `a`.
+        Input array or object that can be converted to an array, containing
+        nan values to be ignored
 
-        If this is anything but the default value it will be passed
-        through (in the special case of an empty array) to the
-        `mean` function of the underlying array.  If the array is
-        a sub-class and `mean` does not have the kwarg `keepdims` this
-        will raise a RuntimeError.
-
-    Returns
-    -------
-    percentile : scalar or ndarray
-        If `q` is a single percentile and `axis=None`, then the result
-        is a scalar. If multiple percentiles are given, first axis of
-        the result corresponds to the percentiles. The other axes are
-        the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+    Other parameters are inherited from `quantile`.
 
     See Also
     --------
-    nanmean, nanmedian, percentile, median, mean
+    percentile
+    nanmean, nanmedian, nanquantile
+    """
+    q = np.true_divide(q, 100)
+    # redo the check here, so we can give a better error message
+    if not _valid_quantile(q):
+        raise ValueError("Percentiles must be in the range [0, 100]")
+    return nanquantile(
+        a, q, axis, out, overwrite_input, interpolation, keepdims)
 
-    Notes
-    -----
-    Given a vector ``V`` of length ``N``, the ``q``-th percentile of
-    ``V`` is the value ``q/100`` of the way from the minimum to the
-    maximum in a sorted copy of ``V``. The values and distances of
-    the two nearest neighbors as well as the `interpolation` parameter
-    will determine the percentile if the normalized ranking does not
-    match the location of ``q`` exactly. This function is the same as
-    the median if ``q=50``, the same as the minimum if ``q=0`` and the
-    same as the maximum if ``q=100``.
+
+def nanquantile(a, q, axis=None, out=None, overwrite_input=False,
+                interpolation='linear', keepdims=np._NoValue):
+    """
+    Compute the qth quantile of the data along the specified axis,
+    while ignoring nan values.
+
+    Returns the qth quantile(s) of the array elements.
+
+    .. versionadded:: 1.15.0
+
+    Parameters
+    ----------
+    a : array_like
+        Input array or object that can be converted to an array, containing
+        nan values to be ignored
+
+    Other parameters are inherited from `quantile`.
+
+    See Also
+    --------
+    quantile
+    nanmean, nanmedian
 
     Examples
     --------
@@ -1117,24 +1087,24 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     >>> a
     array([[ 10.,  nan,   4.],
           [  3.,   2.,   1.]])
-    >>> np.percentile(a, 50)
+    >>> np.quantile(a, 0.5)
     nan
-    >>> np.nanpercentile(a, 50)
+    >>> np.nanquantile(a, 0.5)
     3.5
-    >>> np.nanpercentile(a, 50, axis=0)
+    >>> np.nanquantile(a, 0.5, axis=0)
     array([ 6.5,  2.,   2.5])
-    >>> np.nanpercentile(a, 50, axis=1, keepdims=True)
+    >>> np.nanquantile(a, 0.5, axis=1, keepdims=True)
     array([[ 7.],
            [ 2.]])
-    >>> m = np.nanpercentile(a, 50, axis=0)
+    >>> m = np.nanquantile(a, 0.5, axis=0)
     >>> out = np.zeros_like(m)
-    >>> np.nanpercentile(a, 50, axis=0, out=out)
+    >>> np.nanquantile(a, 0.5, axis=0, out=out)
     array([ 6.5,  2.,   2.5])
     >>> m
     array([ 6.5,  2. ,  2.5])
 
     >>> b = a.copy()
-    >>> np.nanpercentile(b, 50, axis=1, overwrite_input=True)
+    >>> np.nanquantile(b, 0.5, axis=1, overwrite_input=True)
     array([  7.,  2.])
     >>> assert not np.all(a==b)
 
@@ -1142,12 +1112,12 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
 
     a = np.asanyarray(a)
     q = np.asanyarray(q)
-    # apply_along_axis in _nanpercentile doesn't handle empty arrays well,
+    # apply_along_axis in _nanquantile doesn't handle empty arrays well,
     # so deal them upfront
     if a.size == 0:
         return np.nanmean(a, axis, out=out, keepdims=keepdims)
 
-    r, k = _ureduce(a, func=_nanpercentile, q=q, axis=axis, out=out,
+    r, k = _ureduce(a, func=_nanquantile, q=q, axis=axis, out=out,
                     overwrite_input=overwrite_input,
                     interpolation=interpolation)
     if keepdims and keepdims is not np._NoValue:
@@ -1156,22 +1126,22 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
         return r
 
 
-def _nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
-                   interpolation='linear'):
+def _nanquantile(a, q, axis=None, out=None, overwrite_input=False,
+                 interpolation='linear'):
     """
     Private function that doesn't support extended axis or keepdims.
     These methods are extended to this function using _ureduce
-    See nanpercentile for parameter usage
+    See nanquantile for parameter usage
 
     """
     if axis is None or a.ndim == 1:
         part = a.ravel()
-        result = _nanpercentile1d(part, q, overwrite_input, interpolation)
+        result = _nanquantile1d(part, q, overwrite_input, interpolation)
     else:
-        result = np.apply_along_axis(_nanpercentile1d, axis, a, q,
+        result = np.apply_along_axis(_nanquantile1d, axis, a, q,
                                      overwrite_input, interpolation)
         # apply_along_axis fills in collapsed axis with results.
-        # Move that axis to the beginning to match percentile's
+        # Move that axis to the beginning to match quantile's
         # convention.
         if q.ndim != 0:
             result = np.moveaxis(result, axis, 0)
@@ -1181,17 +1151,17 @@ def _nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     return result
 
 
-def _nanpercentile1d(arr1d, q, overwrite_input=False, interpolation='linear'):
+def _nanquantile1d(arr1d, q, overwrite_input=False, interpolation='linear'):
     """
-    Private function for rank 1 arrays. Compute percentile ignoring NaNs.
-    See nanpercentile for parameter usage
+    Private function for rank 1 arrays. Compute quantile ignoring NaNs.
+    See nanquantile for parameter usage
     """
     arr1d, overwrite_input = _remove_nan_1d(arr1d,
         overwrite_input=overwrite_input)
     if arr1d.size == 0:
         return np.full(q.shape, np.nan)[()]  # convert to scalar
 
-    return np.percentile(arr1d, q, overwrite_input=overwrite_input,
+    return np.quantile(arr1d, q, overwrite_input=overwrite_input,
                          interpolation=interpolation)
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3216,6 +3216,28 @@ class TestPercentile(object):
                 a, [0.3, 0.6], (0, 2), interpolation='nearest'), b)
 
 
+class TestQuantile(object):
+    # most of this is already tested by TestPercentile
+
+    def test_basic(self):
+        x = np.arange(8) * 0.5
+        assert_equal(np.quantile(x, 0), 0.)
+        assert_equal(np.quantile(x, 1), 3.5)
+        assert_equal(np.quantile(x, 0.5), 1.75)
+
+    def test_no_p_overwrite(self):
+        # this is worth retesting, beause quantile does not make a copy
+        p0 = np.array([0, 0.75, 0.25, 0.5, 1.0])
+        p = p0.copy()
+        np.quantile(np.arange(100.), p, interpolation="midpoint")
+        assert_array_equal(p, p0)
+
+        p0 = p0.tolist()
+        p = p.tolist()
+        np.quantile(np.arange(100.), p, interpolation="midpoint")
+        assert_array_equal(p, p0)
+
+
 class TestMedian(object):
 
     def test_basic(self):


### PR DESCRIPTION
Breaks off from #9211.

`quantile` is arguably a cleaner interface than `percentile`, as it removes the need to multiply by 100