### PR TITLE
MAINT: Don't internally use the one-argument where

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -838,7 +838,7 @@ def argwhere(a):
     ``np.argwhere(a)`` is the same as ``np.transpose(np.nonzero(a))``.
 
     The output of ``argwhere`` is not suitable for indexing arrays.
-    For this purpose use ``where(a)`` instead.
+    For this purpose use ``nonzero(a)`` instead.
 
     Examples
     --------

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -422,7 +422,7 @@ object: ::
         [37, 40, 43],
         [46, 49, 52]])
 
-For this reason it is possible to use the output from the np.where()
+For this reason it is possible to use the output from the np.nonzero()
 function directly as an index since it always returns a tuple of index
 arrays.
 

--- a/numpy/doc/misc.py
+++ b/numpy/doc/misc.py
@@ -14,7 +14,8 @@ original value was)
 Note: cannot use equality to test NaNs. E.g.: ::
 
  >>> myarr = np.array([1., 0., np.nan, 3.])
- >>> np.where(myarr == np.nan)
+ >>> np.nonzero(myarr == np.nan)
+ (array([], dtype=int64),)
  >>> np.nan == np.nan  # is always False! Use special numpy functions instead.
  False
  >>> myarr[myarr == np.nan] = 0. # doesn't work

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -974,7 +974,7 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
             on_edge = (around(sample[:, i], decimal) ==
                        around(edges[i][-1], decimal))
             # Shift these points one bin to the left.
-            Ncount[i][where(on_edge & not_smaller_than_edge)[0]] -= 1
+            Ncount[i][nonzero(on_edge & not_smaller_than_edge)[0]] -= 1
 
     # Flattened histogram matrix (1D)
     # Reshape is used so that overlarge arrays

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -837,7 +837,7 @@ def _nanmedian1d(arr1d, overwrite_input=False):
     See nanmedian for parameter usage
     """
     c = np.isnan(arr1d)
-    s = np.where(c)[0]
+    s = np.nonzero(c)[0]
     if s.size == arr1d.size:
         warnings.warn("All-NaN slice encountered", RuntimeWarning, stacklevel=3)
         return np.nan
@@ -1161,7 +1161,7 @@ def _nanpercentile1d(arr1d, q, overwrite_input=False, interpolation='linear'):
     See nanpercentile for parameter usage
     """
     c = np.isnan(arr1d)
-    s = np.where(c)[0]
+    s = np.nonzero(c)[0]
     if s.size == arr1d.size:
         warnings.warn("All-NaN slice encountered", RuntimeWarning, stacklevel=3)
         if q.ndim == 0:

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -6,6 +6,7 @@ from __future__ import division, absolute_import, print_function
 from numpy.core.numeric import (
     absolute, asanyarray, arange, zeros, greater_equal, multiply, ones,
     asarray, where, int8, int16, int32, int64, empty, promote_types, diagonal,
+    nonzero
     )
 from numpy.core import iinfo, transpose
 
@@ -717,7 +718,7 @@ def mask_indices(n, mask_func, k=0):
     """
     m = ones((n, n), int)
     a = mask_func(m, k)
-    return where(a != 0)
+    return nonzero(a != 0)
 
 
 def tril_indices(n, k=0, m=None):
@@ -797,7 +798,7 @@ def tril_indices(n, k=0, m=None):
            [-10, -10, -10, -10]])
 
     """
-    return where(tri(n, m, k=k, dtype=bool))
+    return nonzero(tri(n, m, k=k, dtype=bool))
 
 
 def tril_indices_from(arr, k=0):
@@ -907,7 +908,7 @@ def triu_indices(n, k=0, m=None):
            [ 12,  13,  14,  -1]])
 
     """
-    return where(~tri(n, m, k=k-1, dtype=bool))
+    return nonzero(~tri(n, m, k=k-1, dtype=bool))
 
 
 def triu_indices_from(arr, k=0):

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -236,7 +236,7 @@ def trimcoef(c, tol=0):
         raise ValueError("tol must be non-negative")
 
     [c] = as_series([c])
-    [ind] = np.where(np.abs(c) > tol)
+    [ind] = np.nonzero(np.abs(c) > tol)
     if len(ind) == 0:
         return c[:1]*0
     else:


### PR DESCRIPTION
nonzero is a clearer spelling