### PR TITLE
BUG: Avoid bare except clauses

### DIFF
--- a/doc/cdoc/numpyfilter.py
+++ b/doc/cdoc/numpyfilter.py
@@ -75,7 +75,7 @@ def load_cache():
         f = open(CACHE_FILE, 'rb')
         try:
             cache = pickle.load(f)
-        except:
+        except Exception:
             cache = {}
         finally:
             f.close()

--- a/doc/f2py/collectinput.py
+++ b/doc/f2py/collectinput.py
@@ -34,11 +34,11 @@ else:
     from commands import getoutput
 
 try: fn=sys.argv[2]
-except:
+except Exception:
     try: fn='inputless_'+sys.argv[1]
-    except: stdoutflag=1
+    except Exception: stdoutflag=1
 try: fi=sys.argv[1]
-except: fi=()
+except Exception: fi=()
 if not stdoutflag:
     sys.stdout=open(fn, 'w')
 
@@ -63,9 +63,9 @@ for l in fileinput.input(fi):
         if i>-1:
             fn=l[i+1:]
             try: f=open(fn, 'r'); flag=1; f.close()
-            except:
+            except Exception:
                 try: f=open(fn+'.tex', 'r'); flag=1;fn=fn+'.tex'; f.close()
-                except: flag=0
+                except Exception: flag=0
             if flag==0:
                 sys.stderr.write('Could not open a file: '+fn+'\n')
                 print(l+l1)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -306,19 +306,19 @@ def linkcode_resolve(domain, info):
     for part in fullname.split('.'):
         try:
             obj = getattr(obj, part)
-        except:
+        except Exception:
             return None
 
     try:
         fn = inspect.getsourcefile(obj)
-    except:
+    except Exception:
         fn = None
     if not fn:
         return None
 
     try:
         source, lineno = inspect.getsourcelines(obj)
-    except:
+    except Exception:
         lineno = None
 
     if lineno:

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -272,7 +272,7 @@ def find_functions(filename, tag='API'):
                     state = SCANNING
                 else:
                     function_args.append(line)
-        except:
+        except Exception:
             print(filename, lineno + 1)
             raise
     fo.close()

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1278,7 +1278,7 @@ def tensordot(a, b, axes=2):
     """
     try:
         iter(axes)
-    except:
+    except Exception:
         axes_a = list(range(-axes, 0))
         axes_b = list(range(0, axes))
     else:
@@ -2597,7 +2597,7 @@ def array_equal(a1, a2):
     """
     try:
         a1, a2 = asarray(a1), asarray(a2)
-    except:
+    except Exception:
         return False
     if a1.shape != a2.shape:
         return False
@@ -2641,11 +2641,11 @@ def array_equiv(a1, a2):
     """
     try:
         a1, a2 = asarray(a1), asarray(a2)
-    except:
+    except Exception:
         return False
     try:
         multiarray.broadcast(a1, a2)
-    except:
+    except Exception:
         return False
 
     return bool(asarray(a1 == a2).all())

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -597,7 +597,7 @@ def issctype(rep):
         if res and res != object_:
             return True
         return False
-    except:
+    except Exception:
         return False
 
 def obj2sctype(rep, default=None):
@@ -652,7 +652,7 @@ def obj2sctype(rep, default=None):
         return rep.dtype.type
     try:
         res = dtype(rep)
-    except:
+    except Exception:
         return default
     return res.type
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -473,7 +473,7 @@ class recarray(ndarray):
         newattr = attr not in self.__dict__
         try:
             ret = object.__setattr__(self, attr, val)
-        except:
+        except Exception:
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}
             if attr not in fielddict:
                 exctype, value = sys.exc_info()[:2]
@@ -487,7 +487,7 @@ class recarray(ndarray):
                 # internal attribute.
                 try:
                     object.__delattr__(self, attr)
-                except:
+                except Exception:
                     return ret
         try:
             res = fielddict[attr][:2]

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -187,7 +187,7 @@ def check_complex(config, mathlibs):
         if os.uname()[0] == "Interix":
             warnings.warn("Disabling broken complex support. See #1365", stacklevel=2)
             return priv, pub
-    except:
+    except Exception:
         # os.uname not available on all platforms. blanket except ugly but safe
         pass
 

--- a/numpy/core/tests/test_extint128.py
+++ b/numpy/core/tests/test_extint128.py
@@ -59,7 +59,7 @@ def exc_iter(*args):
 
     try:
         yield iterate()
-    except:
+    except Exception:
         import traceback
         msg = "At: %r\n%s" % (repr(value[0]),
                               traceback.format_exc())

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -847,7 +847,7 @@ class TestMultiIndexingAutomated(TestCase):
                 try:
                     flat_indx = np.ravel_multi_index(np.nonzero(indx),
                                     arr.shape[ax:ax+indx.ndim], mode='raise')
-                except:
+                except Exception:
                     error_unless_broadcast_to_empty = True
                     # fill with 0s instead, and raise error later
                     flat_indx = np.array([0]*indx.sum(), dtype=np.intp)
@@ -946,7 +946,7 @@ class TestMultiIndexingAutomated(TestCase):
                         try:
                             mi = np.ravel_multi_index(indx[1:], orig_slice,
                                                       mode='raise')
-                        except:
+                        except Exception:
                             # This happens with 0-sized orig_slice (sometimes?)
                             # here it is a ValueError, but indexing gives a:
                             raise IndexError('invalid index into 0-sized')

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6355,7 +6355,7 @@ def test_flat_element_deletion():
         del it[1:2]
     except TypeError:
         pass
-    except:
+    except Exception:
         raise AssertionError
 
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2641,7 +2641,7 @@ def test_iter_element_deletion():
         del it[1:2]
     except TypeError:
         pass
-    except:
+    except Exception:
         raise AssertionError
 
 def test_iter_allocated_array_dtypes():

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1807,7 +1807,7 @@ class TestRegression(TestCase):
             a['f2'] = 1
         except ValueError:
             pass
-        except:
+        except Exception:
             raise AssertionError
 
     def test_ticket_1608(self):

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -283,7 +283,7 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
         if num is None:
             try:
                 flags = [x.strip().upper() for x in flags]
-            except:
+            except Exception:
                 raise TypeError("invalid flags specification")
             num = _num_fromflags(flags)
     try:

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -417,7 +417,7 @@ def CCompiler_show_customization(self):
             log.info("compiler '%s' is set to %s" % (attrname, attr))
     try:
         self.get_version()
-    except:
+    except Exception:
         pass
     if log._global_log.threshold<2:
         print('*'*80)

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -441,7 +441,7 @@ int main (void)
                 src, obj, exe = self._link(body, headers, include_dirs,
                                            libraries, library_dirs, lang)
                 grabber.restore()
-            except:
+            except Exception:
                 output = grabber.data
                 grabber.restore()
                 raise

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -75,7 +75,7 @@ class CPUInfoBase(object):
     def _try_call(self, func):
         try:
             return func()
-        except:
+        except Exception:
             pass
 
     def __getattr__(self, name):
@@ -336,7 +336,7 @@ class IRIXCPUInfo(CPUInfoBase):
 
     def get_ip(self):
         try: return self.info.get('MACHINE')
-        except: pass
+        except Exception: pass
     def __machine(self, n):
         return self.info.get('MACHINE').lower() == 'ip%s' % (n)
     def _is_IP19(self): return self.__machine(19)
@@ -523,7 +523,7 @@ class Win32CPUInfo(CPUInfoBase):
                                     info[-1]["Family"]=int(srch.group("FML"))
                                     info[-1]["Model"]=int(srch.group("MDL"))
                                     info[-1]["Stepping"]=int(srch.group("STP"))
-        except:
+        except Exception:
             print(sys.exc_info()[1], '(ignoring)')
         self.__class__.info = info
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -461,7 +461,7 @@ def is_sequence(seq):
         return False
     try:
         len(seq)
-    except:
+    except Exception:
         return False
     return True
 
@@ -1836,7 +1836,7 @@ class Configuration(object):
                     close_fds=True)
             sout = p.stdout
             m = re.match(r'(?P<revision>\d+)', sout.read())
-        except:
+        except Exception:
             pass
         os.chdir(cwd)
         if m:
@@ -1873,7 +1873,7 @@ class Configuration(object):
                     close_fds=True)
             sout = p.stdout
             m = re.match(r'(?P<revision>\d+)', sout.read())
-        except:
+        except Exception:
             pass
         os.chdir(cwd)
         if m:

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1782,7 +1782,7 @@ class openblas_lapack_info(openblas_info):
         # Add the additional "extra" arguments
         try:
             extra_args = info['extra_link_args']
-        except:
+        except Exception:
             extra_args = []
         try:
             with open(src, 'wt') as f:

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -162,15 +162,15 @@ class TestSystemInfoReading(TestCase):
         # Do each removal separately
         try:
             shutil.rmtree(self._dir1)
-        except:
+        except Exception:
             pass
         try:
             shutil.rmtree(self._dir2)
-        except:
+        except Exception:
             pass
         try:
             os.remove(self._sitecfg)
-        except:
+        except Exception:
             pass
 
     def test_all(self):

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -328,7 +328,7 @@ def getarrdims(a, var, verbose=0):
         ret['size'] = '*'.join(dim)
         try:
             ret['size'] = repr(eval(ret['size']))
-        except:
+        except Exception:
             pass
         ret['dims'] = ','.join(dim)
         ret['rank'] = repr(len(dim))
@@ -485,7 +485,7 @@ def getinit(a, var):
                 else:
                     v = eval(v, {}, {})
                     ret['init.r'], ret['init.i'] = str(v.real), str(v.imag)
-            except:
+            except Exception:
                 raise ValueError(
                     'getinit: expected complex number `(r,i)\' but got `%s\' as initial value of %r.' % (init, a))
             if isarray(var):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1036,13 +1036,13 @@ def analyzeline(m, case, line):
             try:
                 del groupcache[groupcounter]['vars'][name][
                     groupcache[groupcounter]['vars'][name]['attrspec'].index('external')]
-            except:
+            except Exception:
                 pass
         if block in ['function', 'subroutine']:  # set global attributes
             try:
                 groupcache[groupcounter]['vars'][name] = appenddecl(
                     groupcache[groupcounter]['vars'][name], groupcache[groupcounter - 2]['vars'][''])
-            except:
+            except Exception:
                 pass
             if case == 'callfun':  # return type
                 if result and result in groupcache[groupcounter]['vars']:
@@ -1052,7 +1052,7 @@ def analyzeline(m, case, line):
             # if groupcounter>1: # name is interfaced
             try:
                 groupcache[groupcounter - 2]['interfaced'].append(name)
-            except:
+            except Exception:
                 pass
         if block == 'function':
             t = typespattern[0].match(m.group('before') + ' ' + name)
@@ -1174,7 +1174,7 @@ def analyzeline(m, case, line):
         for e in markoutercomma(ll).split('@,@'):
             try:
                 k, initexpr = [x.strip() for x in e.split('=')]
-            except:
+            except Exception:
                 outmess(
                     'analyzeline: could not extract name,expr in parameter statement "%s" of "%s"\n' % (e, ll))
                 continue
@@ -1251,7 +1251,7 @@ def analyzeline(m, case, line):
                     if '-' in r:
                         try:
                             begc, endc = [x.strip() for x in r.split('-')]
-                        except:
+                        except Exception:
                             outmess(
                                 'analyzeline: expected "<char>-<char>" instead of "%s" in range list of implicit statement\n' % r)
                             continue
@@ -1790,7 +1790,7 @@ def setmesstext(block):
 
     try:
         filepositiontext = 'In: %s:%s\n' % (block['from'], block['name'])
-    except:
+    except Exception:
         pass
 
 
@@ -2108,7 +2108,7 @@ def getlincoef(e, xset):  # e = a*x+b ; x in xset
     try:
         c = int(myeval(e, {}, {}))
         return 0, c, None
-    except:
+    except Exception:
         pass
     if getlincoef_re_1.match(e):
         return 1, 0, e
@@ -2150,7 +2150,7 @@ def getlincoef(e, xset):  # e = a*x+b ; x in xset
                 c2 = myeval(ee, {}, {})
                 if (a * 0.5 + b == c and a * 1.5 + b == c2):
                     return a, b, x
-            except:
+            except Exception:
                 pass
             break
     return None, None, None
@@ -2162,11 +2162,11 @@ def getarrlen(dl, args, star='*'):
     edl = []
     try:
         edl.append(myeval(dl[0], {}, {}))
-    except:
+    except Exception:
         edl.append(dl[0])
     try:
         edl.append(myeval(dl[1], {}, {}))
-    except:
+    except Exception:
         edl.append(dl[1])
     if isinstance(edl[0], int):
         p1 = 1 - edl[0]
@@ -2186,7 +2186,7 @@ def getarrlen(dl, args, star='*'):
         d = '%s-(%s)+1' % (dl[1], dl[0])
     try:
         return repr(myeval(d, {}, {})), None, None
-    except:
+    except Exception:
         pass
     d1, d2 = getlincoef(dl[0], args), getlincoef(dl[1], args)
     if None not in [d1[0], d2[0]]:
@@ -2579,7 +2579,7 @@ def analyzevars(block):
                 l = vars[n]['charselector']['len']
                 try:
                     l = str(eval(l, {}, params))
-                except:
+                except Exception:
                     pass
                 vars[n]['charselector']['len'] = l
 
@@ -2588,7 +2588,7 @@ def analyzevars(block):
                 l = vars[n]['kindselector']['kind']
                 try:
                     l = str(eval(l, {}, params))
-                except:
+                except Exception:
                     pass
                 vars[n]['kindselector']['kind'] = l
 
@@ -2819,7 +2819,7 @@ def analyzevars(block):
                                 try:
                                     kindselect['kind'] = eval(
                                         kindselect['kind'], {}, params)
-                                except:
+                                except Exception:
                                     pass
                             vars[n]['kindselector'] = kindselect
                         if charselect:
@@ -3230,7 +3230,7 @@ def vars2fortran(block, vars, args, tab='', as_interface=False):
                 try:
                     v = eval(v)
                     v = '(%s,%s)' % (v.real, v.imag)
-                except:
+                except Exception:
                     pass
             vardef = '%s :: %s=%s' % (vardef, a, v)
         else:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4531,7 +4531,7 @@ def add_newdoc(place, obj, doc):
         elif isinstance(doc, list):
             for val in doc:
                 add_docstring(getattr(new, val[0]), val[1].strip())
-    except:
+    except Exception:
         pass
 
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -299,7 +299,7 @@ class AxisConcatenator(object):
                         if len(vec) == 3:
                             trans1d = int(vec[2])
                         continue
-                    except:
+                    except Exception:
                         raise ValueError("unknown special directive")
                 try:
                     axis = int(item)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -424,7 +424,7 @@ def load(file, mmap_mode=None, allow_pickle=True, fix_imports=True,
                                  "non-pickled data")
             try:
                 return pickle.load(fid, **pickle_kwargs)
-            except:
+            except Exception:
                 raise IOError(
                     "Failed to interpret file %s as a pickle" % repr(file))
     finally:

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -811,7 +811,7 @@ def test_large_file_support():
         # avoid actually writing 5GB
         import subprocess as sp
         sp.check_call(["truncate", "-s", "5368709120", tf_name])
-    except:
+    except Exception:
         raise SkipTest("Could not create 5GB large file")
     # write a small array to the end
     with open(tf_name, "wb") as f:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1067,7 +1067,7 @@ class TestVectorize(TestCase):
         import random
         try:
             vectorize(random.randrange)  # Should succeed
-        except:
+        except Exception:
             raise AssertionError()
 
     def test_keywords2_ticket_2100(self):

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -174,7 +174,7 @@ class TestRegression(TestCase):
         try:
             try:
                 np.who({'foo': np.array(1)})
-            except:
+            except Exception:
                 raise AssertionError("ticket #1243")
         finally:
             sys.stdout.close()
@@ -206,7 +206,7 @@ class TestRegression(TestCase):
         dlist = [np.float64, np.int32, np.int32]
         try:
             append_fields(base, names, data, dlist)
-        except:
+        except Exception:
             raise AssertionError()
 
     def test_loadtxt_fields_subarrays(self):
@@ -238,7 +238,7 @@ class TestRegression(TestCase):
         a = np.zeros(2, dtype=np.bool)
         try:
             np.nansum(a)
-        except:
+        except Exception:
             raise AssertionError()
 
     def test_py3_compat(self):

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -557,7 +557,7 @@ def info(object=None, maxwidth=76, output=sys.stdout, toplevel='numpy'):
                 if len(arglist) > 1:
                     arglist[1] = "("+arglist[1]
                     arguments = ", ".join(arglist[1:])
-        except:
+        except Exception:
             pass
 
         if len(name+arguments) > maxwidth:
@@ -689,7 +689,7 @@ def source(object, output=sys.stdout):
     try:
         print("In file: %s\n" % inspect.getsourcefile(object), file=output)
         print(inspect.getsource(object), file=output)
-    except:
+    except Exception:
         print("Not available for this object.", file=output)
 
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2177,7 +2177,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
     elif not isinstance(axis, tuple):
         try:
             axis = int(axis)
-        except:
+        except Exception:
             raise TypeError("'axis' must be None, an integer or a tuple of integers")
         axis = (axis,)
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1550,7 +1550,7 @@ def test_xerbla_override():
             np.linalg.lapack_lite.xerbla()
         except ValueError:
             pass
-        except:
+        except Exception:
             os._exit(os.EX_CONFIG)
 
         try:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1068,7 +1068,7 @@ class _MaskedBinaryOperation:
             # any errors, just abort; impossible to guarantee masked values
             try:
                 np.copyto(result, da, casting='unsafe', where=m)
-            except:
+            except Exception:
                 pass
 
         # Transforms to a (subclass of) MaskedArray
@@ -1214,7 +1214,7 @@ class _DomainedBinaryOperation:
             # only add back if it can be cast safely
             if np.can_cast(masked_da.dtype, result.dtype, casting='safe'):
                 result += masked_da
-        except:
+        except Exception:
             pass
 
         # Transforms to a (subclass of) MaskedArray

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -778,7 +778,7 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     # not necessary for scalar True/False masks
     try:
         np.copyto(low.mask, high.mask, where=odd)
-    except:
+    except Exception:
         pass
 
     if np.issubdtype(asorted.dtype, np.inexact):

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -276,7 +276,7 @@ class MaskedRecords(MaskedArray, object):
         try:
             # Is attr a generic attribute ?
             ret = object.__setattr__(self, attr, val)
-        except:
+        except Exception:
             # Not a generic attribute: exit if it's not a valid field
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}
             optinfo = ndarray.__getattribute__(self, '_optinfo') or {}
@@ -294,7 +294,7 @@ class MaskedRecords(MaskedArray, object):
                 # internal attribute.
                 try:
                     object.__delattr__(self, attr)
-                except:
+                except Exception:
                     return ret
         # Let's try to set the field
         try:

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -737,7 +737,7 @@ class TestMedian(TestCase):
                 for axis, over in args:
                     try:
                         np.ma.median(x, axis=axis, overwrite_input=over)
-                    except:
+                    except Exception:
                         raise AssertionError(msg % (mask, ndmin, axis, over))
 
                 # Invalid axis values should raise exception

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -295,7 +295,7 @@ class matrix(N.ndarray):
             # Determine when we should have a column array
             try:
                 n = len(index)
-            except:
+            except Exception:
                 n = 0
             if n > 1 and isscalar(index[1]):
                 out.shape = (sh, 1)

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -312,7 +312,7 @@ class ABCPolyBase(object):
             coef = self._add(self.coef, othercoef)
         except TypeError as e:
             raise e
-        except:
+        except Exception:
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
@@ -322,7 +322,7 @@ class ABCPolyBase(object):
             coef = self._sub(self.coef, othercoef)
         except TypeError as e:
             raise e
-        except:
+        except Exception:
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
@@ -332,7 +332,7 @@ class ABCPolyBase(object):
             coef = self._mul(self.coef, othercoef)
         except TypeError as e:
             raise e
-        except:
+        except Exception:
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
@@ -367,7 +367,7 @@ class ABCPolyBase(object):
             quo, rem = self._div(self.coef, othercoef)
         except (TypeError, ZeroDivisionError) as e:
             raise e
-        except:
+        except Exception:
             return NotImplemented
         quo = self.__class__(quo, self.domain, self.window)
         rem = self.__class__(rem, self.domain, self.window)
@@ -381,21 +381,21 @@ class ABCPolyBase(object):
     def __radd__(self, other):
         try:
             coef = self._add(other, self.coef)
-        except:
+        except Exception:
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
     def __rsub__(self, other):
         try:
             coef = self._sub(other, self.coef)
-        except:
+        except Exception:
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
     def __rmul__(self, other):
         try:
             coef = self._mul(other, self.coef)
-        except:
+        except Exception:
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
@@ -425,7 +425,7 @@ class ABCPolyBase(object):
             quo, rem = self._div(other, self.coef)
         except ZeroDivisionError as e:
             raise e
-        except:
+        except Exception:
             return NotImplemented
         quo = self.__class__(quo, self.domain, self.window)
         rem = self.__class__(rem, self.domain, self.window)

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1225,7 +1225,7 @@ def chebval2d(x, y, c):
     """
     try:
         x, y = np.array((x, y), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y are incompatible')
 
     c = chebval(x, c)
@@ -1338,7 +1338,7 @@ def chebval3d(x, y, z, c):
     """
     try:
         x, y, z = np.array((x, y, z), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y, z are incompatible')
 
     c = chebval(x, c)

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -988,7 +988,7 @@ def hermval2d(x, y, c):
     """
     try:
         x, y = np.array((x, y), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y are incompatible')
 
     c = hermval(x, c)
@@ -1101,7 +1101,7 @@ def hermval3d(x, y, z, c):
     """
     try:
         x, y, z = np.array((x, y, z), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y, z are incompatible')
 
     c = hermval(x, c)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -986,7 +986,7 @@ def hermeval2d(x, y, c):
     """
     try:
         x, y = np.array((x, y), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y are incompatible')
 
     c = hermeval(x, c)
@@ -1099,7 +1099,7 @@ def hermeval3d(x, y, z, c):
     """
     try:
         x, y, z = np.array((x, y, z), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y, z are incompatible')
 
     c = hermeval(x, c)

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -988,7 +988,7 @@ def lagval2d(x, y, c):
     """
     try:
         x, y = np.array((x, y), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y are incompatible')
 
     c = lagval(x, c)
@@ -1101,7 +1101,7 @@ def lagval3d(x, y, z, c):
     """
     try:
         x, y, z = np.array((x, y, z), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y, z are incompatible')
 
     c = lagval(x, c)

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1026,7 +1026,7 @@ def legval2d(x, y, c):
     """
     try:
         x, y = np.array((x, y), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y are incompatible')
 
     c = legval(x, c)
@@ -1139,7 +1139,7 @@ def legval3d(x, y, z, c):
     """
     try:
         x, y, z = np.array((x, y, z), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y, z are incompatible')
 
     c = legval(x, c)

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -913,7 +913,7 @@ def polyval2d(x, y, c):
     """
     try:
         x, y = np.array((x, y), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y are incompatible')
 
     c = polyval(x, c)
@@ -1026,7 +1026,7 @@ def polyval3d(x, y, z, c):
     """
     try:
         x, y, z = np.array((x, y, z), copy=0)
-    except:
+    except Exception:
         raise ValueError('x, y, z are incompatible')
 
     c = polyval(x, c)

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -182,7 +182,7 @@ def as_series(alist, trim=True):
     else:
         try:
             dtype = np.common_type(*arrays)
-        except:
+        except Exception:
             raise ValueError("Coefficient arrays have no common type")
         ret = [np.array(a, copy=1, dtype=dtype) for a in arrays]
     return ret

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -210,7 +210,7 @@ elif sys.platform[:5] == 'linux':
             l = f.readline().split(' ')
             f.close()
             return int(l[22])
-        except:
+        except Exception:
             return
 else:
     def memusage():
@@ -239,7 +239,7 @@ if sys.platform[:5] == 'linux':
             l = f.readline().split(' ')
             f.close()
             return int(l[13])
-        except:
+        except Exception:
             return int(100*(time.time()-_load_time[0]))
 else:
     # os.getpid is not in all platforms available.

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -87,7 +87,7 @@ def test_f2py():
                 assert_equal(stdout.strip(), b'2')
                 success = True
                 break
-            except:
+            except Exception:
                 pass
         msg = "Warning: neither %s nor %s nor %s found in path" % f2py_cmds
         assert_(success, msg)

--- a/pavement.py
+++ b/pavement.py
@@ -477,7 +477,7 @@ def _create_dmg(pyver, src_dir, volname=None):
 def dmg(options):
     try:
         pyver = options.dmg.python_version
-    except:
+    except Exception:
         pyver = DEFAULT_PYTHON
     idirs = options.installers.installersdir
 

--- a/tools/allocation_tracking/track_allocations.py
+++ b/tools/allocation_tracking/track_allocations.py
@@ -76,7 +76,7 @@ class AllocationTracker(object):
         # then actual code.
         try:
             return inspect.stack()[4][1:]
-        except:
+        except Exception:
             return inspect.stack()[0][1:]
 
     def check_line_changed(self):
@@ -125,7 +125,7 @@ class AllocationTracker(object):
                     try:
                         filename, line, module, code, index = val
                         val = "{0}({1}): {2}".format(filename, line, code[index])
-                    except:
+                    except Exception:
                         # sometimes this info is not available (from eval()?)
                         val = str(val)
                 f.write("  <TD>{0}</TD>".format(val))


### PR DESCRIPTION
Bare except is very rarely the right thing, as it swallows `SystemExit` and `KeyboardInterrupt`

`Exception` isn't much better, but fixing that requires more thought (and can always be done later)

This was a straight find and replace, but ignoring `tempita` since that's supposedly copied from elsewhere