### PR TITLE
DOC: BLD: fix lots of Sphinx warnings/errors.

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.10.0 Release Notes
-**************************
+==========================
 
 This release supports Python 2.6 - 2.7 and 3.2 - 3.5.
 
@@ -59,7 +60,7 @@ Compatibility notes
 ===================
 
 Default casting rule change
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 Default casting for inplace operations has changed to ``'same_kind'``. For
 instance, if n is an array of integers, and f is an array of floats, then
 ``n += f`` will result in a ``TypeError``, whereas in previous Numpy
@@ -69,13 +70,13 @@ compatible way by rewriting it as ``np.add(n, f, out=n, casting='unsafe')``.
 The old ``'unsafe'`` default has been deprecated since Numpy 1.7.
 
 numpy version string
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 The numpy version string for development builds has been changed from
 ``x.y.z.dev-githash`` to ``x.y.z.dev0+githash`` (note the +) in order to comply
 with PEP 440.
 
 relaxed stride checking
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 NPY_RELAXED_STRIDE_CHECKING is now true by default.
 
 UPDATE: In 1.10.2 the default value of  NPY_RELAXED_STRIDE_CHECKING was
@@ -85,12 +86,12 @@ dimension changing views of f_contiguous not c_contiguous arrays was also
 added.
 
 Concatenation of 1d arrays along any but ``axis=0`` raises ``IndexError``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------------------
 Using axis != 0 has raised a DeprecationWarning since NumPy 1.7, it now
 raises an error.
 
 *np.ravel*, *np.diagonal* and *np.diag* now preserve subtypes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------
 There was inconsistent behavior between *x.ravel()* and *np.ravel(x)*, as
 well as between *x.diagonal()* and *np.diagonal(x)*, with the methods
 preserving subtypes while the functions did not. This has been fixed and
@@ -100,13 +101,13 @@ compatibility and still return 1-D arrays as before. If you need to
 preserve the matrix subtype, use the methods instead of the functions.
 
 *rollaxis* and *swapaxes* always return a view
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 Previously, a view was returned except when no change was made in the order
 of the axes, in which case the input array was returned.  A view is now
 returned in all cases.
 
 *nonzero* now returns base ndarrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 Previously, an inconsistency existed between 1-D inputs (returning a
 base ndarray) and higher dimensional ones (which preserved subclasses).
 Behavior has been unified, and the return will now be a base ndarray.
@@ -114,7 +115,7 @@ Subclasses can still override this behavior by providing their own
 *nonzero* method.
 
 C API
-~~~~~
+-----
 The changes to *swapaxes* also apply to the *PyArray_SwapAxes* C function,
 which now returns a view in all cases.
 
@@ -128,7 +129,7 @@ The change to the concatenation function DeprecationWarning also affects
 PyArray_ConcatenateArrays,
 
 recarray field return types
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 Previously the returned types for recarray fields accessed by attribute and by
 index were inconsistent, and fields of string type were returned as chararrays.
 Now, fields accessed by either attribute or indexing will return an ndarray for
@@ -138,14 +139,14 @@ whitespace is trimmed from chararrays but kept in ndarrays of string type.
 Also, the dtype.type of nested structured fields is now inherited.
 
 recarray views
-~~~~~~~~~~~~~~
+--------------
 Viewing an ndarray as a recarray now automatically converts the dtype to
 np.record. See new record array documentation. Additionally, viewing a recarray
 with a non-structured dtype no longer converts the result's type to ndarray -
 the result will remain a recarray.
 
 'out' keyword argument of ufuncs now accepts tuples of arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------
 When using the 'out' keyword argument of a ufunc, a tuple of arrays, one per
 ufunc output, can be provided. For ufuncs with a single output a single array
 is also a valid 'out' keyword argument. Previously a single array could be
@@ -154,24 +155,24 @@ output for ufuncs with multiple outputs, is deprecated, and will result in a
 `DeprecationWarning` now and an error in the future.
 
 byte-array indices now raises an IndexError
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 Indexing an ndarray using a byte-string in Python 3 now raises an IndexError
 instead of a ValueError.
 
 Masked arrays containing objects with arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 For such (rare) masked arrays, getting a single masked item no longer returns a
 corrupted masked array, but a fully masked version of the item.
 
 Median warns and returns nan when invalid values are encountered
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------------------
 Similar to mean, median and percentile now emits a Runtime warning and
 returns `NaN` in slices where a `NaN` is present.
 To compute the median or percentile while ignoring invalid values use the
 new `nanmedian` or `nanpercentile` functions.
 
 Functions available from numpy.ma.testutils have changed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------
 All functions from numpy.testing were once available from
 numpy.ma.testutils but not all of them were redefined to work with masked
 arrays. Most of those functions have now been removed from
@@ -184,7 +185,7 @@ New Features
 ============
 
 Reading extra flags from site.cfg
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 Previously customization of compilation of dependency libraries and numpy
 itself was only accomblishable via code changes in the distutils package.
 Now numpy.distutils reads in the following extra flags from each group of the
@@ -198,34 +199,34 @@ Now numpy.distutils reads in the following extra flags from each group of the
 This should, at least partially, complete user customization.
 
 *np.cbrt* to compute cube root for real floats
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 *np.cbrt* wraps the C99 cube root function *cbrt*.
 Compared to *np.power(x, 1./3.)* it is well defined for negative real floats
 and a bit faster.
 
 numpy.distutils now allows parallel compilation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 By passing *--parallel=n* or *-j n* to *setup.py build* the compilation of
 extensions is now performed in *n* parallel processes.
 The parallelization is limited to files within one extension so projects using
 Cython will not profit because it builds extensions from single files.
 
 *genfromtxt* has a new ``max_rows`` argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 A ``max_rows`` argument has been added to *genfromtxt* to limit the
 number of rows read in a single call. Using this functionality, it is
 possible to read in multiple arrays stored in a single file by making
 repeated calls to the function.
 
 New function *np.broadcast_to* for invoking array broadcasting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------
 *np.broadcast_to* manually broadcasts an array to a given shape according to
 numpy's broadcasting rules. The functionality is similar to broadcast_arrays,
 which in fact has been rewritten to use broadcast_to internally, but only a
 single array is necessary.
 
 New context manager *clear_and_catch_warnings* for testing warnings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------------
 When Python emits a warning, it records that this warning has been emitted in
 the module that caused the warning, in a module attribute
 ``__warningregistry__``.  Once this has happened, it is not possible to emit
@@ -237,7 +238,7 @@ you will not be able to emit the warning or test it. The context manager
 and resets them on exit, meaning that warnings can be re-raised.
 
 *cov* has new ``fweights`` and ``aweights`` arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 The ``fweights`` and ``aweights`` arguments add new functionality to
 covariance calculations by applying two types of weighting to observation
 vectors. An array of ``fweights`` indicates the number of repeats of each
@@ -245,7 +246,7 @@ observation vector, and an array of ``aweights`` provides their relative
 importance or probability.
 
 Support for the '@' operator in Python 3.5+
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 Python 3.5 adds support for a matrix multiplication operator '@' proposed
 in PEP465. Preliminary support for that has been implemented, and an
 equivalent function ``matmul`` has also been added for testing purposes and
@@ -253,7 +254,7 @@ use in earlier Python versions. The function is preliminary and the order
 and number of its optional arguments can be expected to change.
 
 New argument ``norm`` to fft functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 The default normalization has the direct transforms unscaled and the inverse
 transforms are scaled by :math:`1/n`. It is possible to obtain unitary
 transforms by setting the keyword argument ``norm`` to ``"ortho"`` (default is
@@ -265,21 +266,21 @@ Improvements
 ============
 
 *np.digitize* using binary search
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 *np.digitize* is now implemented in terms of *np.searchsorted*. This means
 that a binary search is used to bin the values, which scales much better
 for larger number of bins than the previous linear search. It also removes
 the requirement for the input array to be 1-dimensional.
 
 *np.poly* now casts integer inputs to float
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 *np.poly* will now cast 1-dimensional input arrays of integer type to double
 precision floating point, to prevent integer overflow when computing the monic
 polynomial. It is still possible to obtain higher precision results by
 passing in an array of object type, filled e.g. with Python ints.
 
 *np.interp* can now be used with periodic functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------------
 *np.interp* now has a new parameter *period* that supplies the period of the
 input data *xp*. In such case, the input data is properly normalized to the
 given period and one end point is added to each extremity of *xp* in order to
@@ -287,19 +288,19 @@ close the previous and the next period cycles, resulting in the correct
 interpolation behavior.
 
 *np.pad* supports more input types for ``pad_width`` and ``constant_values``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------------------------------
 ``constant_values`` parameters now accepts NumPy arrays and float values.
 NumPy arrays are supported as input for ``pad_width``, and an exception is
 raised if its values are not of integral type.
 
 *np.argmax* and *np.argmin* now support an ``out`` argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------------
 The ``out`` parameter was added to *np.argmax* and *np.argmin* for consistency
 with *ndarray.argmax* and *ndarray.argmin*. The new parameter behaves exactly
 as it does in those methods.
 
 More system C99 complex functions detected and used
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------------
 All of the functions ``in complex.h`` are now detected. There are new
 fallback implementations of the following functions.
 
@@ -312,31 +313,31 @@ As a result of these improvements, there will be some small changes in
 returned values, especially for corner cases.
 
 *np.loadtxt* support for the strings produced by the ``float.hex`` method
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------------------
 The strings produced by ``float.hex`` look like ``0x1.921fb54442d18p+1``,
 so this is not the hex used to represent unsigned integer types.
 
 *np.isclose* properly handles minimal values of integer dtypes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------
 In order to properly handle minimal values of integer types, *np.isclose* will
 now cast to the float dtype during comparisons. This aligns its behavior with
 what was provided by *np.allclose*.
 
 *np.allclose* uses *np.isclose* internally.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 *np.allclose* now uses *np.isclose* internally and inherits the ability to
 compare NaNs as equal by setting ``equal_nan=True``. Subclasses, such as
 *np.ma.MaskedArray*, are also preserved now.
 
 *np.genfromtxt* now handles large integers correctly
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------
 *np.genfromtxt* now correctly handles integers larger than ``2**31-1`` on
 32-bit systems and larger than ``2**63-1`` on 64-bit systems (it previously
 crashed with an ``OverflowError`` in these cases). Integers larger than
 ``2**63-1`` are converted to floating-point values.
 
 *np.load*, *np.save* have pickle backward compatibility flags
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------
 
 The functions *np.load* and *np.save* have additional keyword
 arguments for controlling backward compatibility of pickled Python
@@ -344,7 +345,7 @@ objects. This enables Numpy on Python 3 to load npy files containing
 object arrays that were generated on Python 2.
 
 MaskedArray support for more complicated base classes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 Built-in assumptions that the baseclass behaved like a plain array are being
 removed. In particular, setting and getting elements and ranges will respect
 baseclass overrides of ``__setitem__`` and ``__getitem__``, and arithmetic
@@ -354,13 +355,13 @@ Changes
 =======
 
 dotblas functionality moved to multiarray
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 The cblas versions of dot, inner, and vdot have been integrated into
 the multiarray module. In particular, vdot is now a multiarray function,
 which it was not before.
 
 stricter check of gufunc signature compliance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------
 Inputs to generalized universal functions are now more strictly checked
 against the function's signature: all core dimensions are now required to
 be present in input arrays; core dimensions with the same label must have
@@ -368,12 +369,12 @@ the exact same size; and output core dimension's must be specified, either
 by a same label input core dimension or by a passed-in output array.
 
 views returned from *np.einsum* are writeable
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------
 Views returned by *np.einsum* will now be writeable whenever the input
 array is writeable.
 
 *np.argmin* skips NaT values
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 *np.argmin* now skips NaT values in datetime64 and timedelta64 arrays,
 making it consistent with *np.min*, *np.argmax* and *np.max*.
@@ -383,7 +384,7 @@ Deprecations
 ============
 
 Array comparisons involving strings or structured dtypes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------
 
 Normally, comparison operations on arrays perform elementwise
 comparisons and return arrays of booleans. But in some corner cases,
@@ -418,21 +419,21 @@ comparison operations, e.g.::
   # -> [False, False]
 
 SafeEval
-~~~~~~~~
+--------
 The SafeEval class in numpy/lib/utils.py is deprecated and will be removed
 in the next release.
 
 alterdot, restoredot
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 The alterdot and restoredot functions no longer do anything, and are
 deprecated.
 
 pkgload, PackageLoader
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 These ways of loading packages are now deprecated.
 
 bias, ddof arguments to corrcoef
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 The values for the ``bias`` and ``ddof`` arguments to the ``corrcoef``
 function canceled in the division implied by the correlation coefficient and
@@ -447,7 +448,7 @@ as its position will change with the removal of ``bias``.  ``allow_masked``
 will in due course become a keyword-only argument.
 
 dtype string representation changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 Since 1.6, creating a dtype object from its string representation, e.g.
 ``'f4'``, would issue a deprecation warning if the size did not correspond
 to an existing type, and default to creating a dtype of the default size

--- a/doc/release/1.10.1-notes.rst
+++ b/doc/release/1.10.1-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.10.1 Release Notes
-**************************
+==========================
 
 This release deals with a few build problems that showed up in 1.10.0. Most
 users would not have seen these problems. The differences are:

--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.10.2 Release Notes
-**************************
+==========================
 
 This release deals with a number of bugs that turned up in 1.10.1 and
 adds various build and release improvements.
@@ -11,20 +12,20 @@ Compatibility notes
 ===================
 
 Relaxed stride checking is no longer the default
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------
 There were back compatibility problems involving views changing the dtype of
 multidimensional Fortran arrays that need to be dealt with over a longer
 timeframe.
 
 Fix swig bug in ``numpy.i``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 Relaxed stride checking revealed a bug in ``array_is_fortran(a)``, that was
 using PyArray_ISFORTRAN to check for Fortran contiguity instead of
 PyArray_IS_F_CONTIGUOUS. You may want to regenerate swigged files using the
 updated numpy.i
 
 Deprecate views changing dimensions in fortran order
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------
 This deprecates assignment of a new descriptor to the dtype attribute of
 a non-C-contiguous array if it result in changing the shape. This
 effectively bars viewing a multidimensional Fortran array using a dtype

--- a/doc/release/1.10.3-notes.rst
+++ b/doc/release/1.10.3-notes.rst
@@ -1,4 +1,5 @@
+==========================
 NumPy 1.10.3 Release Notes
-**************************
+==========================
 
 N/A this release did not happen due to various screwups involving PyPi.

--- a/doc/release/1.10.4-notes.rst
+++ b/doc/release/1.10.4-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.10.4 Release Notes
-**************************
+==========================
 
 This release is a bugfix source release motivated by a segfault regression.
 No windows binaries are provided for this release, as there appear to be

--- a/doc/release/1.11.0-notes.rst
+++ b/doc/release/1.11.0-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.11.0 Release Notes
-**************************
+==========================
 
 This release supports Python 2.6 - 2.7 and 3.2 - 3.5 and contains a number
 of enhancements and improvements. Note also the build system changes listed
@@ -78,7 +79,7 @@ Compatibility notes
 ===================
 
 datetime64 changes
-~~~~~~~~~~~~~~~~~~
+------------------
 In prior versions of NumPy the experimental datetime64 type always stored
 times in UTC. By default, creating a datetime64 object from a string or
 printing it would convert from or to local time::
@@ -112,24 +113,24 @@ with date units and datetimes with time units. With timezone naive datetimes,
 the rule for casting from dates to times is no longer ambiguous.
 
 ``linalg.norm`` return type changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 The return type of the ``linalg.norm`` function is now floating point without
 exception.  Some of the norm types previously returned integers.
 
 polynomial fit changes
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 The various fit functions in the numpy polynomial package no longer accept
 non-integers for degree specification.
 
 *np.dot* now raises ``TypeError`` instead of ``ValueError``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------------
 This behaviour mimics that of other functions such as ``np.inner``. If the two
 arguments cannot be cast to a common type, it could have raised a ``TypeError``
 or ``ValueError`` depending on their order. Now, ``np.dot`` will now always
 raise a ``TypeError``.
 
 FutureWarning to changed behavior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 
 * In ``np.lib.split`` an empty array in the result always had dimension
   ``(0,)`` no matter the dimensions of the array being split. This
@@ -139,7 +140,7 @@ FutureWarning to changed behavior
   already preserved.
 
 ``%`` and ``//`` operators
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 These operators are implemented with the ``remainder`` and ``floor_divide``
 functions respectively. Those functions are now based around ``fmod`` and are
 computed together so as to be compatible with each other and with the Python
@@ -152,7 +153,7 @@ is always returned for both functions when the divisor is zero,
 ``divmod(-1.0, inf)`` returns ``(-1.0, inf)``.
 
 C API
-~~~~~
+-----
 
 Removed the ``check_return`` and ``inner_loop_selector`` members of
 the ``PyUFuncObject`` struct (replacing them with ``reserved`` slots
@@ -162,7 +163,7 @@ mention it here for completeness.
 
 
 object dtype detection for old-style classes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 
 In python 2, objects which are instances of old-style user-defined classes no
 longer automatically count as 'object' type in the dtype-detection handler.
@@ -232,17 +233,17 @@ Improvements
 ============
 
 ``np.gradient`` now supports an ``axis`` argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------
 The ``axis`` parameter was added to ``np.gradient`` for consistency.  It
 allows to specify over which axes the gradient is calculated.
 
 ``np.lexsort`` now supports arrays with object data-type
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------
 The function now internally calls the generic ``npy_amergesort`` when the
 type does not implement a merge-sort kind of ``argsort`` method.
 
 ``np.ma.core.MaskedArray`` now supports an ``order`` argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------
 When constructing a new ``MaskedArray`` instance, it can be configured with
 an ``order`` argument analogous to the one when calling ``np.ndarray``. The
 addition of this argument allows for the proper processing of an ``order``
@@ -250,19 +251,19 @@ argument in several MaskedArray-related utility functions such as
 ``np.ma.core.array`` and ``np.ma.core.asarray``.
 
 Memory and speed improvements for masked arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 Creating a masked array with ``mask=True`` (resp. ``mask=False``) now uses
 ``np.ones`` (resp. ``np.zeros``) to create the mask, which is faster and
 avoid a big memory peak. Another optimization was done to avoid a memory
 peak and useless computations when printing a masked array.
 
 ``ndarray.tofile`` now uses fallocate on linux
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 The function now uses the fallocate system call to reserve sufficient
 disk space on file systems that support it.
 
 Optimizations for operations of the form ``A.T @ A`` and ``A @ A.T``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------------
 Previously, ``gemm`` BLAS operations were used for all matrix products. Now,
 if the matrix product is between a matrix and its transpose, it will use
 ``syrk`` BLAS operations for a performance boost. This optimization has been
@@ -271,11 +272,11 @@ extended to ``@``, ``numpy.dot``, ``numpy.inner``, and ``numpy.matmul``.
 **Note:** Requires the transposed and non-transposed matrices to share data.
 
 ``np.testing.assert_warns`` can now be used as a context manager
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------------------
 This matches the behavior of ``assert_raises``.
 
 Speed improvement for np.random.shuffle
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------
 ``np.random.shuffle`` is now much faster for 1d ndarrays.
 
 
@@ -283,14 +284,14 @@ Changes
 =======
 
 Pyrex support was removed from ``numpy.distutils``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------
 The method ``build_src.generate_a_pyrex_source`` will remain available; it
 has been monkeypatched by users to support Cython instead of Pyrex.  It's
 recommended to switch to a better supported method of build Cython
 extensions though.
 
 ``np.broadcast`` can now be called with a single argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------------------
 The resulting object in that case will simply mimic iteration over
 a single array. This change obsoletes distinctions like
 
@@ -302,20 +303,20 @@ a single array. This change obsoletes distinctions like
 Instead, ``np.broadcast`` can be used in all cases.
 
 ``np.trace`` now respects array subclasses
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------
 This behaviour mimics that of other functions such as ``np.diagonal`` and
 ensures, e.g., that for masked arrays ``np.trace(ma)`` and ``ma.trace()`` give
 the same result.
 
 ``np.dot`` now raises ``TypeError`` instead of ``ValueError``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------
 This behaviour mimics that of other functions such as ``np.inner``. If the two
 arguments cannot be cast to a common type, it could have raised a ``TypeError``
 or ``ValueError`` depending on their order. Now, ``np.dot`` will now always
 raise a ``TypeError``.
 
 ``linalg.norm`` return type changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 The ``linalg.norm`` function now does all its computations in floating point
 and returns floating results. This change fixes bugs due to integer overflow
 and the failure of abs with signed integers of minimum value, e.g., int8(-128).
@@ -326,7 +327,7 @@ Deprecations
 ============
 
 Views of arrays in Fortran order
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 The F_CONTIGUOUS flag was used to signal that views using a dtype that
 changed the element size would change the first index. This was always
 problematical for arrays that were both F_CONTIGUOUS and C_CONTIGUOUS
@@ -340,7 +341,7 @@ added to the view method to explicitly ask for Fortran order views, but
 that will not be backward compatible.
 
 Invalid arguments for array ordering
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 It is currently possible to pass in arguments for the ``order``
 parameter in methods like ``array.flatten`` or ``array.ravel``
 that were not one of the following: 'C', 'F', 'A', 'K' (note that
@@ -348,14 +349,14 @@ all of these possible values are both unicode and case insensitive).
 Such behavior will not be allowed in future releases.
 
 Random number generator in the ``testing`` namespace
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------
 The Python standard library random number generator was previously exposed
 in the ``testing`` namespace as ``testing.rand``. Using this generator is
 not recommended and it will be removed in a future release. Use generators
 from ``numpy.random`` namespace instead.
 
 Random integer generation on a closed interval
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 In accordance with the Python C API, which gives preference to the half-open
 interval over the closed one, ``np.random.random_integers`` is being
 deprecated in favor of calling ``np.random.randint``, which has been
@@ -367,7 +368,7 @@ FutureWarnings
 ==============
 
 Assigning to slices/views of ``MaskedArray``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 Currently a slice of a masked array contains a view of the original data and a
 copy-on-write view of the mask. Consequently, any changes to the slice's mask
 will result in a copy of the original mask being made and that new mask being

--- a/doc/release/1.11.1-notes.rst
+++ b/doc/release/1.11.1-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.11.1 Release Notes
-**************************
+==========================
 
 Numpy 1.11.1 supports Python 2.6 - 2.7 and 3.2 - 3.5. It fixes bugs and
 regressions found in Numpy 1.11.0 and includes several build related

--- a/doc/release/1.11.2-notes.rst
+++ b/doc/release/1.11.2-notes.rst
@@ -1,5 +1,6 @@
+==========================
 NumPy 1.11.2 Release Notes
-**************************
+==========================
 
 Numpy 1.11.2 supports Python 2.6 - 2.7 and 3.2 - 3.5. It fixes bugs and
 regressions found in Numpy 1.11.1 and includes several build related

--- a/doc/release/1.12.0-notes.rst
+++ b/doc/release/1.12.0-notes.rst
@@ -182,7 +182,7 @@ The following functions are changed: ``sum``, ``product``,
 
 ``bitwise_and`` identity changed
 --------------------------------
-The previous identity was 1, it is now -1. See entry in `Improvements`_ for
+The previous identity was 1, it is now -1. See entry in Improvements for
 more explanation.
 
 ma.median warns and returns nan when unmasked invalid values are encountered
@@ -493,3 +493,574 @@ This causes warnings with the "default" or "module" filter to be shown once
 for every offending user code line or user module instead of only once. On
 python versions before 3.4, this can cause warnings to appear that were falsely
 ignored before, which may be surprising especially in test suits.
+
+
+Contributors
+============
+
+A total of 139 people contributed to this release.  People with a "+" by their
+names contributed a patch for the first time.
+
+* Aditya Panchal +
+* Ales Erjavec +
+* Alex Griffing
+* Alexandr Shadchin +
+* Alistair Muldal
+* Allan Haldane
+* Amit Aronovitch +
+* Andrei Kucharavy +
+* Antony Lee
+* Antti Kaihola +
+* Arne de Laat +
+* Auke Wiggers +
+* AustereCuriosity +
+* Badhri Narayanan Krishnakumar +
+* Ben North +
+* Ben Rowland +
+* Bertrand Lefebvre
+* Boxiang Sun
+* CJ Carey
+* Charles Harris
+* Christoph Gohlke
+* Daniel Ching +
+* Daniel Rasmussen +
+* Daniel Smith +
+* David Schaich +
+* Denis Alevi +
+* Devin Jeanpierre +
+* Dmitry Odzerikho
+* Dongjoon Hyun +
+* Edward Richards +
+* Ekaterina Tuzova +
+* Emilien Kofman +
+* Endolith
+* Eren Sezener +
+* Eric Moore
+* Eric Quintero +
+* Eric Wieser +
+* Erik M. Bray
+* Frederic Bastien
+* Friedrich Dunne +
+* Gerrit Holl
+* Golnaz Irannejad +
+* Graham Markall +
+* Greg Knoll +
+* Greg Young
+* Gustavo Serra Scalet +
+* Ines Wichert +
+* Irvin Probst +
+* Jaime Fernandez
+* James Sanders +
+* Jan David Mol +
+* Jan Schlüter
+* Jeremy Tuloup +
+* John Kirkham
+* John Zwinck +
+* Jonathan Helmus
+* Joseph Fox-Rabinovitz
+* Josh Wilson +
+* Joshua Warner +
+* Julian Taylor
+* Ka Wo Chen +
+* Kamil Rytarowski +
+* Kelsey Jordahl +
+* Kevin Deldycke +
+* Khaled Ben Abdallah Okuda +
+* Lion Krischer +
+* Loïc Estève +
+* Luca Mussi +
+* Mads Ohm Larsen +
+* Manoj Kumar +
+* Mario Emmenlauer +
+* Marshall Bockrath-Vandegrift +
+* Marshall Ward +
+* Marten van Kerkwijk
+* Mathieu Lamarre +
+* Matthew Brett
+* Matthew Harrigan +
+* Matthias Geier
+* Matti Picus +
+* Meet Udeshi +
+* Michael Felt +
+* Michael Goerz +
+* Michael Martin +
+* Michael Seifert +
+* Mike Nolta +
+* Nathaniel Beaver +
+* Nathaniel J. Smith
+* Naveen Arunachalam +
+* Nick Papior
+* Nikola Forró +
+* Oleksandr Pavlyk +
+* Olivier Grisel
+* Oren Amsalem +
+* Pauli Virtanen
+* Pavel Potocek +
+* Pedro Lacerda +
+* Peter Creasey +
+* Phil Elson +
+* Philip Gura +
+* Phillip J. Wolfram +
+* Pierre de Buyl +
+* Raghav RV +
+* Ralf Gommers
+* Ray Donnelly +
+* Rehas Sachdeva
+* Rob Malouf +
+* Robert Kern
+* Samuel St-Jean
+* Sanchez Gonzalez Alvaro +
+* Saurabh Mehta +
+* Scott Sanderson +
+* Sebastian Berg
+* Shayan Pooya +
+* Shota Kawabuchi +
+* Simon Conseil
+* Simon Gibbons
+* Sorin Sbarnea +
+* Stefan van der Walt
+* Stephan Hoyer
+* Steven J Kern +
+* Stuart Archibald
+* Tadeu Manoel +
+* Takuya Akiba +
+* Thomas A Caswell
+* Tom Bird +
+* Tony Kelman +
+* Toshihiro Kamishima +
+* Valentin Valls +
+* Varun Nayyar
+* Victor Stinner +
+* Warren Weckesser
+* Wendell Smith
+* Wojtek Ruszczewski +
+* Xavier Abellan Ecija +
+* Yaroslav Halchenko
+* Yash Shah +
+* Yinon Ehrlich +
+* Yu Feng +
+* nevimov +
+
+Pull requests merged
+====================
+
+A total of 418 pull requests were merged for this release.
+
+* `#4073 <https://github.com/numpy/numpy/pull/4073>`__: BUG: change real output checking to test if all imaginary parts...
+* `#4619 <https://github.com/numpy/numpy/pull/4619>`__: BUG : np.sum silently drops keepdims for sub-classes of ndarray
+* `#5488 <https://github.com/numpy/numpy/pull/5488>`__: ENH: add `contract`: optimizing numpy's einsum expression
+* `#5706 <https://github.com/numpy/numpy/pull/5706>`__: ENH: make some masked array methods behave more like ndarray...
+* `#5822 <https://github.com/numpy/numpy/pull/5822>`__: Allow many distributions to have a scale of 0.
+* `#6054 <https://github.com/numpy/numpy/pull/6054>`__: WIP: MAINT: Add deprecation warning to views of multi-field indexes
+* `#6298 <https://github.com/numpy/numpy/pull/6298>`__: Check lower base limit in base_repr.
+* `#6430 <https://github.com/numpy/numpy/pull/6430>`__: Fix issues with zero-width string fields
+* `#6656 <https://github.com/numpy/numpy/pull/6656>`__: ENH: usecols now accepts an int when only one column has to be...
+* `#6660 <https://github.com/numpy/numpy/pull/6660>`__: Added pathlib support for several functions
+* `#6872 <https://github.com/numpy/numpy/pull/6872>`__: ENH: linear interpolation of complex values in lib.interp
+* `#6997 <https://github.com/numpy/numpy/pull/6997>`__: MAINT: Simplify mtrand.pyx helpers
+* `#7003 <https://github.com/numpy/numpy/pull/7003>`__: BUG: Fix string copying for np.place
+* `#7026 <https://github.com/numpy/numpy/pull/7026>`__: DOC: Clarify behavior in np.random.uniform
+* `#7055 <https://github.com/numpy/numpy/pull/7055>`__: BUG: One Element Array Inputs Return Scalars in np.random
+* `#7063 <https://github.com/numpy/numpy/pull/7063>`__: REL: Update master branch after 1.11.x branch has been made.
+* `#7073 <https://github.com/numpy/numpy/pull/7073>`__: DOC: Update the 1.11.0 release notes.
+* `#7076 <https://github.com/numpy/numpy/pull/7076>`__: MAINT: Update the git .mailmap file.
+* `#7082 <https://github.com/numpy/numpy/pull/7082>`__: TST, DOC: Added Broadcasting Tests in test_random.py
+* `#7087 <https://github.com/numpy/numpy/pull/7087>`__: BLD: fix compilation on non glibc-Linuxes
+* `#7088 <https://github.com/numpy/numpy/pull/7088>`__: BUG: Have `norm` cast non-floating point arrays to 64-bit float...
+* `#7090 <https://github.com/numpy/numpy/pull/7090>`__: ENH: Added 'doane' and 'sqrt' estimators to np.histogram in numpy.function_base
+* `#7091 <https://github.com/numpy/numpy/pull/7091>`__: Revert "BLD: fix compilation on non glibc-Linuxes"
+* `#7092 <https://github.com/numpy/numpy/pull/7092>`__: BLD: fix compilation on non glibc-Linuxes
+* `#7099 <https://github.com/numpy/numpy/pull/7099>`__: TST: Suppressed warnings
+* `#7102 <https://github.com/numpy/numpy/pull/7102>`__: MAINT: Removed conditionals that are always false in datetime_strings.c
+* `#7105 <https://github.com/numpy/numpy/pull/7105>`__: DEP: Deprecate as_strided returning a writable array as default
+* `#7109 <https://github.com/numpy/numpy/pull/7109>`__: DOC: update Python versions requirements in the install docs
+* `#7114 <https://github.com/numpy/numpy/pull/7114>`__: MAINT: Fix typos in docs
+* `#7116 <https://github.com/numpy/numpy/pull/7116>`__: TST: Fixed f2py test for win32 virtualenv
+* `#7118 <https://github.com/numpy/numpy/pull/7118>`__: TST: Fixed f2py test for non-versioned python executables
+* `#7119 <https://github.com/numpy/numpy/pull/7119>`__: BUG: Fixed mingw.lib error
+* `#7125 <https://github.com/numpy/numpy/pull/7125>`__: DOC: Updated documentation wording and examples for np.percentile.
+* `#7129 <https://github.com/numpy/numpy/pull/7129>`__: BUG: Fixed 'midpoint' interpolation of np.percentile in odd cases.
+* `#7131 <https://github.com/numpy/numpy/pull/7131>`__: Fix setuptools sdist
+* `#7133 <https://github.com/numpy/numpy/pull/7133>`__: ENH: savez: temporary file alongside with target file and improve...
+* `#7134 <https://github.com/numpy/numpy/pull/7134>`__: MAINT: Fix some typos in a code string and comments
+* `#7141 <https://github.com/numpy/numpy/pull/7141>`__: BUG: Unpickled void scalars should be contiguous
+* `#7144 <https://github.com/numpy/numpy/pull/7144>`__: MAINT: Change `call_fortran` into `callfortran` in comments.
+* `#7145 <https://github.com/numpy/numpy/pull/7145>`__: BUG: Fixed regressions in np.piecewise in ref to #5737 and #5729.
+* `#7147 <https://github.com/numpy/numpy/pull/7147>`__: Temporarily disable __numpy_ufunc__
+* `#7148 <https://github.com/numpy/numpy/pull/7148>`__: ENH,TST: Bump stacklevel and add tests for warnings
+* `#7149 <https://github.com/numpy/numpy/pull/7149>`__: TST: Add missing suffix to temppath manager
+* `#7152 <https://github.com/numpy/numpy/pull/7152>`__: BUG: mode kwargs passed as unicode to np.pad raises an exception
+* `#7156 <https://github.com/numpy/numpy/pull/7156>`__: BUG: Reascertain that linspace respects ndarray subclasses in...
+* `#7167 <https://github.com/numpy/numpy/pull/7167>`__: DOC: Update Wikipedia references for mtrand.pyx
+* `#7171 <https://github.com/numpy/numpy/pull/7171>`__: TST: Fixed f2py test for Anaconda non-win32
+* `#7174 <https://github.com/numpy/numpy/pull/7174>`__: DOC: Fix broken pandas link in release notes
+* `#7177 <https://github.com/numpy/numpy/pull/7177>`__: ENH: added axis param for np.count_nonzero
+* `#7178 <https://github.com/numpy/numpy/pull/7178>`__: BUG: Fix binary_repr for negative numbers
+* `#7180 <https://github.com/numpy/numpy/pull/7180>`__: BUG: Fixed previous attempt to fix dimension mismatch in nanpercentile
+* `#7181 <https://github.com/numpy/numpy/pull/7181>`__: DOC: Updated minor typos in function_base.py and test_function_base.py
+* `#7191 <https://github.com/numpy/numpy/pull/7191>`__: DOC: add vstack, hstack, dstack reference to stack documentation.
+* `#7193 <https://github.com/numpy/numpy/pull/7193>`__: MAINT: Removed supurious assert in histogram estimators
+* `#7194 <https://github.com/numpy/numpy/pull/7194>`__: BUG: Raise a quieter `MaskedArrayFutureWarning` for mask changes.
+* `#7195 <https://github.com/numpy/numpy/pull/7195>`__: STY: Drop some trailing spaces in `numpy.ma.core`.
+* `#7196 <https://github.com/numpy/numpy/pull/7196>`__: Revert "DOC: add vstack, hstack, dstack reference to stack documentation."
+* `#7197 <https://github.com/numpy/numpy/pull/7197>`__: TST: Pin virtualenv used on Travis CI.
+* `#7198 <https://github.com/numpy/numpy/pull/7198>`__: ENH: Unlock the GIL for gufuncs
+* `#7199 <https://github.com/numpy/numpy/pull/7199>`__: MAINT: Cleanup for histogram bin estimator selection
+* `#7201 <https://github.com/numpy/numpy/pull/7201>`__: Raise IOError on not a file in python2
+* `#7202 <https://github.com/numpy/numpy/pull/7202>`__: MAINT: Made `iterable` return a boolean
+* `#7209 <https://github.com/numpy/numpy/pull/7209>`__: TST: Bump `virtualenv` to 14.0.6
+* `#7211 <https://github.com/numpy/numpy/pull/7211>`__: DOC: Fix fmin examples
+* `#7215 <https://github.com/numpy/numpy/pull/7215>`__: MAINT: Use PySlice_GetIndicesEx instead of custom reimplementation
+* `#7229 <https://github.com/numpy/numpy/pull/7229>`__: ENH: implement __complex__
+* `#7231 <https://github.com/numpy/numpy/pull/7231>`__: MRG: allow distributors to run custom init
+* `#7232 <https://github.com/numpy/numpy/pull/7232>`__: BLD: Switch order of test for lapack_mkl and openblas_lapack
+* `#7239 <https://github.com/numpy/numpy/pull/7239>`__: DOC: Removed residual merge markup from previous commit
+* `#7240 <https://github.com/numpy/numpy/pull/7240>`__: Change 'pubic' to 'public'.
+* `#7241 <https://github.com/numpy/numpy/pull/7241>`__: MAINT: update doc/sphinxext to numpydoc 0.6.0, and fix up some...
+* `#7243 <https://github.com/numpy/numpy/pull/7243>`__: ENH: Adding support to the range keyword for estimation of the...
+* `#7246 <https://github.com/numpy/numpy/pull/7246>`__: DOC: metion writeable keyword in as_strided in release notes
+* `#7247 <https://github.com/numpy/numpy/pull/7247>`__: TST: Fail quickly on AppVeyor for superseded PR builds
+* `#7248 <https://github.com/numpy/numpy/pull/7248>`__: DOC: remove link to documentation wiki editor from HOWTO_DOCUMENT.
+* `#7250 <https://github.com/numpy/numpy/pull/7250>`__: DOC,REL: Update 1.11.0 notes.
+* `#7251 <https://github.com/numpy/numpy/pull/7251>`__: BUG: only benchmark complex256 if it exists
+* `#7252 <https://github.com/numpy/numpy/pull/7252>`__: Forward port a fix and enhancement from 1.11.x
+* `#7253 <https://github.com/numpy/numpy/pull/7253>`__: DOC: note in h/v/dstack points users to stack/concatenate
+* `#7254 <https://github.com/numpy/numpy/pull/7254>`__: BUG: Enforce dtype for randint singletons
+* `#7256 <https://github.com/numpy/numpy/pull/7256>`__: MAINT: Use `is None` or `is not None` instead of `== None` or...
+* `#7257 <https://github.com/numpy/numpy/pull/7257>`__: DOC: Fix mismatched variable names in docstrings.
+* `#7258 <https://github.com/numpy/numpy/pull/7258>`__: ENH: Make numpy floor_divide and remainder agree with Python...
+* `#7260 <https://github.com/numpy/numpy/pull/7260>`__: BUG/TST: Fix #7259, do not "force scalar" for already scalar...
+* `#7261 <https://github.com/numpy/numpy/pull/7261>`__: Added self to mailmap
+* `#7266 <https://github.com/numpy/numpy/pull/7266>`__: BUG: Segfault for classes with deceptive __len__
+* `#7268 <https://github.com/numpy/numpy/pull/7268>`__: ENH: add geomspace function
+* `#7274 <https://github.com/numpy/numpy/pull/7274>`__: BUG: Preserve array order in np.delete
+* `#7275 <https://github.com/numpy/numpy/pull/7275>`__: DEP: Warn about assigning 'data' attribute of ndarray
+* `#7276 <https://github.com/numpy/numpy/pull/7276>`__: DOC: apply_along_axis missing whitespace inserted (before colon)
+* `#7278 <https://github.com/numpy/numpy/pull/7278>`__: BUG: Make returned unravel_index arrays writeable
+* `#7279 <https://github.com/numpy/numpy/pull/7279>`__: TST: Fixed elements being shuffled
+* `#7280 <https://github.com/numpy/numpy/pull/7280>`__: MAINT: Remove redundant trailing semicolons.
+* `#7285 <https://github.com/numpy/numpy/pull/7285>`__: BUG: Make Randint Backwards Compatible with Pandas
+* `#7286 <https://github.com/numpy/numpy/pull/7286>`__: MAINT: Fix typos in docs/comments of `ma` and `polynomial` modules.
+* `#7292 <https://github.com/numpy/numpy/pull/7292>`__: Clarify error on repr failure in assert_equal.
+* `#7294 <https://github.com/numpy/numpy/pull/7294>`__: ENH: add support for BLIS to numpy.distutils
+* `#7295 <https://github.com/numpy/numpy/pull/7295>`__: DOC: understanding code and getting started section to dev doc
+* `#7296 <https://github.com/numpy/numpy/pull/7296>`__: Revert part of #3907 which incorrectly propogated MaskedArray...
+* `#7299 <https://github.com/numpy/numpy/pull/7299>`__: DOC: Fix mismatched variable names in docstrings.
+* `#7300 <https://github.com/numpy/numpy/pull/7300>`__: DOC: dev: stop recommending keeping local master updated with...
+* `#7301 <https://github.com/numpy/numpy/pull/7301>`__: DOC: Update release notes
+* `#7305 <https://github.com/numpy/numpy/pull/7305>`__: BUG: Remove data race in mtrand: two threads could mutate the...
+* `#7307 <https://github.com/numpy/numpy/pull/7307>`__: DOC: Missing some characters in link.
+* `#7308 <https://github.com/numpy/numpy/pull/7308>`__: BUG: Incrementing the wrong reference on return
+* `#7310 <https://github.com/numpy/numpy/pull/7310>`__: STY: Fix GitHub rendering of ordered lists >9
+* `#7311 <https://github.com/numpy/numpy/pull/7311>`__: ENH: Make _pointer_type_cache functional
+* `#7313 <https://github.com/numpy/numpy/pull/7313>`__: DOC: corrected grammatical error in quickstart doc
+* `#7325 <https://github.com/numpy/numpy/pull/7325>`__: BUG, MAINT: Improve fromnumeric.py interface for downstream compatibility
+* `#7328 <https://github.com/numpy/numpy/pull/7328>`__: DEP: Deprecated using a float index in linspace
+* `#7331 <https://github.com/numpy/numpy/pull/7331>`__: Add comment, TST: fix MemoryError on win32
+* `#7332 <https://github.com/numpy/numpy/pull/7332>`__: Check for no solution in np.irr Fixes #6744
+* `#7338 <https://github.com/numpy/numpy/pull/7338>`__: TST: Install `pytz` in the CI.
+* `#7340 <https://github.com/numpy/numpy/pull/7340>`__: DOC: Fixed math rendering in tensordot docs.
+* `#7341 <https://github.com/numpy/numpy/pull/7341>`__: TST: Add test for #6469
+* `#7344 <https://github.com/numpy/numpy/pull/7344>`__: DOC: Fix more typos in docs and comments.
+* `#7346 <https://github.com/numpy/numpy/pull/7346>`__: Generalized flip
+* `#7347 <https://github.com/numpy/numpy/pull/7347>`__: ENH Generalized rot90
+* `#7348 <https://github.com/numpy/numpy/pull/7348>`__: Maint: Removed extra space from `ureduce`
+* `#7349 <https://github.com/numpy/numpy/pull/7349>`__: MAINT: Hide nan warnings for masked internal MA computations
+* `#7350 <https://github.com/numpy/numpy/pull/7350>`__: BUG: MA ufuncs should set mask to False, not array([False])
+* `#7351 <https://github.com/numpy/numpy/pull/7351>`__: TST: Fix some MA tests to avoid looking at the .data attribute
+* `#7358 <https://github.com/numpy/numpy/pull/7358>`__: BUG: pull request related to the issue #7353
+* `#7359 <https://github.com/numpy/numpy/pull/7359>`__: Update 7314, DOC: Clarify valid integer range for random.seed...
+* `#7361 <https://github.com/numpy/numpy/pull/7361>`__: MAINT: Fix copy and paste oversight.
+* `#7363 <https://github.com/numpy/numpy/pull/7363>`__: ENH: Make no unshare mask future warnings less noisy
+* `#7366 <https://github.com/numpy/numpy/pull/7366>`__: TST: fix #6542, add tests to check non-iterable argument raises...
+* `#7373 <https://github.com/numpy/numpy/pull/7373>`__: ENH: Add bitwise_and identity
+* `#7378 <https://github.com/numpy/numpy/pull/7378>`__: added NumPy logo and separator
+* `#7382 <https://github.com/numpy/numpy/pull/7382>`__: MAINT: cleanup np.average
+* `#7385 <https://github.com/numpy/numpy/pull/7385>`__: DOC: note about wheels / windows wheels for pypi
+* `#7386 <https://github.com/numpy/numpy/pull/7386>`__: Added label icon to Travis status
+* `#7397 <https://github.com/numpy/numpy/pull/7397>`__: BUG: incorrect type for objects whose __len__ fails
+* `#7398 <https://github.com/numpy/numpy/pull/7398>`__: DOC: fix typo
+* `#7404 <https://github.com/numpy/numpy/pull/7404>`__: Use PyMem_RawMalloc on Python 3.4 and newer
+* `#7406 <https://github.com/numpy/numpy/pull/7406>`__: ENH ufunc called on memmap return a ndarray
+* `#7407 <https://github.com/numpy/numpy/pull/7407>`__: BUG: Fix decref before incref for in-place accumulate
+* `#7410 <https://github.com/numpy/numpy/pull/7410>`__: DOC: add nanprod to the list of math routines
+* `#7414 <https://github.com/numpy/numpy/pull/7414>`__: Tweak corrcoef
+* `#7415 <https://github.com/numpy/numpy/pull/7415>`__: DOC: Documention fixes
+* `#7416 <https://github.com/numpy/numpy/pull/7416>`__: BUG: Incorrect handling of range in `histogram` with automatic...
+* `#7418 <https://github.com/numpy/numpy/pull/7418>`__: DOC: Minor typo fix, hermefik -> hermefit.
+* `#7421 <https://github.com/numpy/numpy/pull/7421>`__: ENH: adds np.nancumsum and np.nancumprod
+* `#7423 <https://github.com/numpy/numpy/pull/7423>`__: BUG: Ongoing fixes to PR#7416
+* `#7430 <https://github.com/numpy/numpy/pull/7430>`__: DOC: Update 1.11.0-notes.
+* `#7433 <https://github.com/numpy/numpy/pull/7433>`__: MAINT: FutureWarning for changes to np.average subclass handling
+* `#7437 <https://github.com/numpy/numpy/pull/7437>`__: np.full now defaults to the filling value's dtype.
+* `#7438 <https://github.com/numpy/numpy/pull/7438>`__: Allow rolling multiple axes at the same time.
+* `#7439 <https://github.com/numpy/numpy/pull/7439>`__: BUG: Do not try sequence repeat unless necessary
+* `#7442 <https://github.com/numpy/numpy/pull/7442>`__: MANT: Simplify diagonal length calculation logic
+* `#7445 <https://github.com/numpy/numpy/pull/7445>`__: BUG: reference count leak in bincount, fixes #6805
+* `#7446 <https://github.com/numpy/numpy/pull/7446>`__: DOC: ndarray typo fix
+* `#7447 <https://github.com/numpy/numpy/pull/7447>`__: BUG: scalar integer negative powers gave wrong results.
+* `#7448 <https://github.com/numpy/numpy/pull/7448>`__: DOC: array "See also" link to full and full_like instead of fill
+* `#7456 <https://github.com/numpy/numpy/pull/7456>`__: BUG: int overflow in reshape, fixes #7455, fixes #7293
+* `#7463 <https://github.com/numpy/numpy/pull/7463>`__: BUG: fix array too big error for wide dtypes.
+* `#7466 <https://github.com/numpy/numpy/pull/7466>`__: BUG: segfault inplace object reduceat, fixes #7465
+* `#7468 <https://github.com/numpy/numpy/pull/7468>`__: BUG: more on inplace reductions, fixes #615
+* `#7469 <https://github.com/numpy/numpy/pull/7469>`__: MAINT: Update git .mailmap
+* `#7472 <https://github.com/numpy/numpy/pull/7472>`__: MAINT: Update .mailmap.
+* `#7477 <https://github.com/numpy/numpy/pull/7477>`__: MAINT: Yet more .mailmap updates for recent contributors.
+* `#7481 <https://github.com/numpy/numpy/pull/7481>`__: BUG: Fix segfault in PyArray_OrderConverter
+* `#7482 <https://github.com/numpy/numpy/pull/7482>`__: BUG: Memory Leak in _GenericBinaryOutFunction
+* `#7489 <https://github.com/numpy/numpy/pull/7489>`__: Faster real_if_close.
+* `#7491 <https://github.com/numpy/numpy/pull/7491>`__: DOC: Update subclassing doc regarding downstream compatibility
+* `#7496 <https://github.com/numpy/numpy/pull/7496>`__: BUG: don't use pow for integer power ufunc loops.
+* `#7504 <https://github.com/numpy/numpy/pull/7504>`__: DOC: remove "arr" from keepdims docstrings
+* `#7505 <https://github.com/numpy/numpy/pull/7505>`__: MAIN: fix to #7382, make scl in np.average writeable
+* `#7507 <https://github.com/numpy/numpy/pull/7507>`__: MAINT: Remove nose.SkipTest import.
+* `#7508 <https://github.com/numpy/numpy/pull/7508>`__: DOC: link frompyfunc and vectorize
+* `#7511 <https://github.com/numpy/numpy/pull/7511>`__: numpy.power(0, 0) should return 1
+* `#7515 <https://github.com/numpy/numpy/pull/7515>`__: BUG: MaskedArray.count treats negative axes incorrectly
+* `#7518 <https://github.com/numpy/numpy/pull/7518>`__: BUG: Extend glibc complex trig functions blacklist to glibc <...
+* `#7521 <https://github.com/numpy/numpy/pull/7521>`__: DOC: rephrase writeup of memmap changes
+* `#7522 <https://github.com/numpy/numpy/pull/7522>`__: BUG: Fixed iteration over additional bad commands
+* `#7526 <https://github.com/numpy/numpy/pull/7526>`__: DOC: Removed an extra `:const:`
+* `#7529 <https://github.com/numpy/numpy/pull/7529>`__: BUG: Floating exception with invalid axis in np.lexsort
+* `#7534 <https://github.com/numpy/numpy/pull/7534>`__: MAINT: Update setup.py to reflect supported python versions.
+* `#7536 <https://github.com/numpy/numpy/pull/7536>`__: MAINT: Always use PyCapsule instead of PyCObject in mtrand.pyx
+* `#7539 <https://github.com/numpy/numpy/pull/7539>`__: MAINT: Cleanup of random stuff
+* `#7549 <https://github.com/numpy/numpy/pull/7549>`__: BUG: allow graceful recovery for no Liux compiler
+* `#7562 <https://github.com/numpy/numpy/pull/7562>`__: BUG: Fix test_from_object_array_unicode (test_defchararray.TestBasic)…
+* `#7565 <https://github.com/numpy/numpy/pull/7565>`__: BUG: Fix test_ctypeslib and test_indexing for debug interpreter
+* `#7566 <https://github.com/numpy/numpy/pull/7566>`__: MAINT: use manylinux1 wheel for cython
+* `#7568 <https://github.com/numpy/numpy/pull/7568>`__: Fix a false positive OverflowError in Python 3.x when value above...
+* `#7579 <https://github.com/numpy/numpy/pull/7579>`__: DOC: clarify purpose of Attributes section
+* `#7584 <https://github.com/numpy/numpy/pull/7584>`__: BUG: fixes #7572, percent in path
+* `#7586 <https://github.com/numpy/numpy/pull/7586>`__: Make np.ma.take works on scalars
+* `#7587 <https://github.com/numpy/numpy/pull/7587>`__: BUG: linalg.norm(): Don't convert object arrays to float
+* `#7598 <https://github.com/numpy/numpy/pull/7598>`__: Cast array size to int64 when loading from archive
+* `#7602 <https://github.com/numpy/numpy/pull/7602>`__: DOC: Remove isreal and iscomplex from ufunc list
+* `#7605 <https://github.com/numpy/numpy/pull/7605>`__: DOC: fix incorrect Gamma distribution parameterization comments
+* `#7609 <https://github.com/numpy/numpy/pull/7609>`__: BUG: Fix TypeError when raising TypeError
+* `#7611 <https://github.com/numpy/numpy/pull/7611>`__: ENH: expose test runner raise_warnings option
+* `#7614 <https://github.com/numpy/numpy/pull/7614>`__: BLD: Avoid using os.spawnve in favor of os.spawnv in exec_command
+* `#7618 <https://github.com/numpy/numpy/pull/7618>`__: BUG: distance arg of np.gradient must be scalar, fix docstring
+* `#7626 <https://github.com/numpy/numpy/pull/7626>`__: DOC: RST definition list fixes
+* `#7627 <https://github.com/numpy/numpy/pull/7627>`__: MAINT: unify tup processing, move tup use to after all PyTuple_SetItem...
+* `#7630 <https://github.com/numpy/numpy/pull/7630>`__: MAINT: add ifdef around PyDictProxy_Check macro
+* `#7631 <https://github.com/numpy/numpy/pull/7631>`__: MAINT: linalg: fix comment, simplify math
+* `#7634 <https://github.com/numpy/numpy/pull/7634>`__: BLD: correct C compiler customization in system_info.py Closes...
+* `#7635 <https://github.com/numpy/numpy/pull/7635>`__: BUG: ma.median alternate fix for #7592
+* `#7636 <https://github.com/numpy/numpy/pull/7636>`__: MAINT: clean up testing.assert_raises_regexp, 2.6-specific code...
+* `#7637 <https://github.com/numpy/numpy/pull/7637>`__: MAINT: clearer exception message when importing multiarray fails.
+* `#7639 <https://github.com/numpy/numpy/pull/7639>`__: TST: fix a set of test errors in master.
+* `#7643 <https://github.com/numpy/numpy/pull/7643>`__: DOC : minor changes to linspace docstring
+* `#7651 <https://github.com/numpy/numpy/pull/7651>`__: BUG: one to any power is still 1. Broken edgecase for int arrays
+* `#7655 <https://github.com/numpy/numpy/pull/7655>`__: BLD: Remove Intel compiler flag -xSSE4.2
+* `#7658 <https://github.com/numpy/numpy/pull/7658>`__: BUG: fix incorrect printing of 1D masked arrays
+* `#7659 <https://github.com/numpy/numpy/pull/7659>`__: BUG: Temporary fix for str(mvoid) for object field types
+* `#7664 <https://github.com/numpy/numpy/pull/7664>`__: BUG: Fix unicode with byte swap transfer and copyswap
+* `#7667 <https://github.com/numpy/numpy/pull/7667>`__: Restore histogram consistency
+* `#7668 <https://github.com/numpy/numpy/pull/7668>`__: ENH: Do not check the type of module.__dict__ explicit in test.
+* `#7669 <https://github.com/numpy/numpy/pull/7669>`__: BUG: boolean assignment no GIL release when transfer needs API
+* `#7673 <https://github.com/numpy/numpy/pull/7673>`__: DOC: Create Numpy 1.11.1 release notes.
+* `#7675 <https://github.com/numpy/numpy/pull/7675>`__: BUG: fix handling of right edge of final bin.
+* `#7678 <https://github.com/numpy/numpy/pull/7678>`__: BUG: Fix np.clip bug NaN handling for Visual Studio 2015
+* `#7679 <https://github.com/numpy/numpy/pull/7679>`__: MAINT: Fix up C++ comment in arraytypes.c.src.
+* `#7681 <https://github.com/numpy/numpy/pull/7681>`__: DOC: Update 1.11.1 release notes.
+* `#7686 <https://github.com/numpy/numpy/pull/7686>`__: ENH: Changing FFT cache to a bounded LRU cache
+* `#7688 <https://github.com/numpy/numpy/pull/7688>`__: DOC: fix broken genfromtxt examples in user guide. Closes gh-7662.
+* `#7689 <https://github.com/numpy/numpy/pull/7689>`__: BENCH: add correlate/convolve benchmarks.
+* `#7696 <https://github.com/numpy/numpy/pull/7696>`__: DOC: update wheel build / upload instructions
+* `#7699 <https://github.com/numpy/numpy/pull/7699>`__: BLD: preserve library order
+* `#7704 <https://github.com/numpy/numpy/pull/7704>`__: ENH: Add bits attribute to np.finfo
+* `#7712 <https://github.com/numpy/numpy/pull/7712>`__: BUG: Fix race condition with new FFT cache
+* `#7715 <https://github.com/numpy/numpy/pull/7715>`__: BUG: Remove memory leak in np.place
+* `#7719 <https://github.com/numpy/numpy/pull/7719>`__: BUG: Fix segfault in np.random.shuffle for arrays of different...
+* `#7723 <https://github.com/numpy/numpy/pull/7723>`__: Change mkl_info.dir_env_var from MKL to MKLROOT
+* `#7727 <https://github.com/numpy/numpy/pull/7727>`__: DOC: Corrections in Datetime Units-arrays.datetime.rst
+* `#7729 <https://github.com/numpy/numpy/pull/7729>`__: DOC: fix typo in savetxt docstring (closes #7620)
+* `#7733 <https://github.com/numpy/numpy/pull/7733>`__: Update 7525, DOC: Fix order='A' docs of np.array.
+* `#7734 <https://github.com/numpy/numpy/pull/7734>`__: Update 7542, ENH: Add `polyrootval` to numpy.polynomial
+* `#7735 <https://github.com/numpy/numpy/pull/7735>`__: BUG: fix issue on OS X with Python 3.x where npymath.ini was...
+* `#7739 <https://github.com/numpy/numpy/pull/7739>`__: DOC: Mention the changes of #6430 in the release notes.
+* `#7740 <https://github.com/numpy/numpy/pull/7740>`__: DOC: add reference to poisson rng
+* `#7743 <https://github.com/numpy/numpy/pull/7743>`__: Update 7476, DEP: deprecate Numeric-style typecodes, closes #2148
+* `#7744 <https://github.com/numpy/numpy/pull/7744>`__: DOC: Remove "ones_like" from ufuncs list (it is not)
+* `#7746 <https://github.com/numpy/numpy/pull/7746>`__: DOC: Clarify the effect of rcond in numpy.linalg.lstsq.
+* `#7747 <https://github.com/numpy/numpy/pull/7747>`__: Update 7672, BUG: Make sure we don't divide by zero
+* `#7748 <https://github.com/numpy/numpy/pull/7748>`__: DOC: Update float32 mean example in docstring
+* `#7754 <https://github.com/numpy/numpy/pull/7754>`__: Update 7612, ENH: Add broadcast.ndim to match code elsewhere.
+* `#7757 <https://github.com/numpy/numpy/pull/7757>`__: Update 7175, BUG: Invalid read of size 4 in PyArray_FromFile
+* `#7759 <https://github.com/numpy/numpy/pull/7759>`__: BUG: Fix numpy.i support for numpy API < 1.7.
+* `#7760 <https://github.com/numpy/numpy/pull/7760>`__: ENH: Make assert_almost_equal & assert_array_almost_equal consistent.
+* `#7766 <https://github.com/numpy/numpy/pull/7766>`__: fix an English typo
+* `#7771 <https://github.com/numpy/numpy/pull/7771>`__: DOC: link geomspace from logspace
+* `#7773 <https://github.com/numpy/numpy/pull/7773>`__: DOC: Remove a redundant the
+* `#7777 <https://github.com/numpy/numpy/pull/7777>`__: DOC: Update Numpy 1.11.1 release notes.
+* `#7785 <https://github.com/numpy/numpy/pull/7785>`__: DOC: update wheel building procedure for release
+* `#7789 <https://github.com/numpy/numpy/pull/7789>`__: MRG: add note of 64-bit wheels on Windows
+* `#7791 <https://github.com/numpy/numpy/pull/7791>`__: f2py.compile issues (#7683)
+* `#7799 <https://github.com/numpy/numpy/pull/7799>`__: "lambda" is not allowed to use as keyword arguments in a sample...
+* `#7803 <https://github.com/numpy/numpy/pull/7803>`__: BUG: interpret 'c' PEP3118/struct type as 'S1'.
+* `#7807 <https://github.com/numpy/numpy/pull/7807>`__: DOC: Misplaced parens in formula
+* `#7817 <https://github.com/numpy/numpy/pull/7817>`__: BUG: Make sure npy_mul_with_overflow_<type> detects overflow.
+* `#7818 <https://github.com/numpy/numpy/pull/7818>`__: numpy/distutils/misc_util.py fix for #7809: check that _tmpdirs...
+* `#7820 <https://github.com/numpy/numpy/pull/7820>`__: MAINT: Allocate fewer bytes for empty arrays.
+* `#7823 <https://github.com/numpy/numpy/pull/7823>`__: BUG: Fixed masked array behavior for scalar inputs to np.ma.atleast_*d
+* `#7834 <https://github.com/numpy/numpy/pull/7834>`__: DOC: Added an example
+* `#7839 <https://github.com/numpy/numpy/pull/7839>`__: Pypy fixes
+* `#7840 <https://github.com/numpy/numpy/pull/7840>`__: Fix ATLAS version detection
+* `#7842 <https://github.com/numpy/numpy/pull/7842>`__: Fix versionadded tags
+* `#7848 <https://github.com/numpy/numpy/pull/7848>`__: MAINT: Fix remaining uses of deprecated Python imp module.
+* `#7853 <https://github.com/numpy/numpy/pull/7853>`__: BUG: Make sure numpy globals keep identity after reload.
+* `#7863 <https://github.com/numpy/numpy/pull/7863>`__: ENH: turn quicksort into introsort
+* `#7866 <https://github.com/numpy/numpy/pull/7866>`__: Document runtests extra argv
+* `#7871 <https://github.com/numpy/numpy/pull/7871>`__: BUG: handle introsort depth limit properly
+* `#7879 <https://github.com/numpy/numpy/pull/7879>`__: DOC: fix typo in documentation of loadtxt (closes #7878)
+* `#7885 <https://github.com/numpy/numpy/pull/7885>`__: Handle NetBSD specific <sys/endian.h>
+* `#7889 <https://github.com/numpy/numpy/pull/7889>`__: DOC: #7881. Fix link to record arrays
+* `#7894 <https://github.com/numpy/numpy/pull/7894>`__: fixup-7790, BUG: construct ma.array from np.array which contains...
+* `#7898 <https://github.com/numpy/numpy/pull/7898>`__: Spelling and grammar fix.
+* `#7903 <https://github.com/numpy/numpy/pull/7903>`__: BUG: fix float16 type not being called due to wrong ordering
+* `#7908 <https://github.com/numpy/numpy/pull/7908>`__: BLD: Fixed detection for recent MKL versions
+* `#7911 <https://github.com/numpy/numpy/pull/7911>`__: BUG: fix for issue#7835 (ma.median of 1d)
+* `#7912 <https://github.com/numpy/numpy/pull/7912>`__: ENH: skip or avoid gc/objectmodel differences btwn pypy and cpython
+* `#7918 <https://github.com/numpy/numpy/pull/7918>`__: ENH: allow numpy.apply_along_axis() to work with ndarray subclasses
+* `#7922 <https://github.com/numpy/numpy/pull/7922>`__: ENH: Add ma.convolve and ma.correlate for #6458
+* `#7925 <https://github.com/numpy/numpy/pull/7925>`__: Monkey-patch _msvccompile.gen_lib_option like any other compilators
+* `#7931 <https://github.com/numpy/numpy/pull/7931>`__: BUG: Check for HAVE_LDOUBLE_DOUBLE_DOUBLE_LE in npy_math_complex.
+* `#7936 <https://github.com/numpy/numpy/pull/7936>`__: ENH: improve duck typing inside iscomplexobj
+* `#7937 <https://github.com/numpy/numpy/pull/7937>`__: BUG: Guard against buggy comparisons in generic quicksort.
+* `#7938 <https://github.com/numpy/numpy/pull/7938>`__: DOC: add cbrt to math summary page
+* `#7941 <https://github.com/numpy/numpy/pull/7941>`__: BUG: Make sure numpy globals keep identity after reload.
+* `#7943 <https://github.com/numpy/numpy/pull/7943>`__: DOC: #7927. Remove deprecated note for memmap relevant for Python...
+* `#7952 <https://github.com/numpy/numpy/pull/7952>`__: BUG: Use keyword arguments to initialize Extension base class.
+* `#7956 <https://github.com/numpy/numpy/pull/7956>`__: BLD: remove __NUMPY_SETUP__ from builtins at end of setup.py
+* `#7963 <https://github.com/numpy/numpy/pull/7963>`__: BUG: MSVCCompiler grows 'lib' & 'include' env strings exponentially.
+* `#7965 <https://github.com/numpy/numpy/pull/7965>`__: BUG: cannot modify tuple after use
+* `#7976 <https://github.com/numpy/numpy/pull/7976>`__: DOC: Fixed documented dimension of return value
+* `#7977 <https://github.com/numpy/numpy/pull/7977>`__: DOC: Create 1.11.2 release notes.
+* `#7979 <https://github.com/numpy/numpy/pull/7979>`__: DOC: Corrected allowed keywords in ``add_installed_library``
+* `#7980 <https://github.com/numpy/numpy/pull/7980>`__: ENH: Add ability to runtime select ufunc loops, add AVX2 integer...
+* `#7985 <https://github.com/numpy/numpy/pull/7985>`__: Rebase 7763, ENH: Add new warning suppression/filtering context
+* `#7987 <https://github.com/numpy/numpy/pull/7987>`__: DOC: See also np.load and np.memmap in np.lib.format.open_memmap
+* `#7988 <https://github.com/numpy/numpy/pull/7988>`__: DOC: Include docstring for cbrt, spacing and fabs in documentation
+* `#7999 <https://github.com/numpy/numpy/pull/7999>`__: ENH: add inplace cases to fast ufunc loop macros
+* `#8006 <https://github.com/numpy/numpy/pull/8006>`__: DOC: Update 1.11.2 release notes.
+* `#8008 <https://github.com/numpy/numpy/pull/8008>`__: MAINT: Remove leftover imp module imports.
+* `#8009 <https://github.com/numpy/numpy/pull/8009>`__: DOC: Fixed three typos in the c-info.ufunc-tutorial
+* `#8011 <https://github.com/numpy/numpy/pull/8011>`__: DOC: Update 1.11.2 release notes.
+* `#8014 <https://github.com/numpy/numpy/pull/8014>`__: BUG: Fix fid.close() to use os.close(fid)
+* `#8016 <https://github.com/numpy/numpy/pull/8016>`__: BUG: Fix numpy.ma.median.
+* `#8018 <https://github.com/numpy/numpy/pull/8018>`__: BUG: Fixes return for np.ma.count if keepdims is True and axis...
+* `#8021 <https://github.com/numpy/numpy/pull/8021>`__: DOC: change all non-code instances of Numpy to NumPy
+* `#8027 <https://github.com/numpy/numpy/pull/8027>`__: ENH: Add platform indepedent lib dir to PYTHONPATH
+* `#8028 <https://github.com/numpy/numpy/pull/8028>`__: DOC: Update 1.11.2 release notes.
+* `#8030 <https://github.com/numpy/numpy/pull/8030>`__: BUG: fix np.ma.median with only one non-masked value and an axis...
+* `#8038 <https://github.com/numpy/numpy/pull/8038>`__: MAINT: Update error message in rollaxis.
+* `#8040 <https://github.com/numpy/numpy/pull/8040>`__: Update add_newdocs.py
+* `#8042 <https://github.com/numpy/numpy/pull/8042>`__: BUG: core: fix bug in NpyIter buffering with discontinuous arrays
+* `#8045 <https://github.com/numpy/numpy/pull/8045>`__: DOC: Update 1.11.2 release notes.
+* `#8050 <https://github.com/numpy/numpy/pull/8050>`__: remove refcount semantics, now a.resize() almost always requires...
+* `#8051 <https://github.com/numpy/numpy/pull/8051>`__: Clear signaling NaN exceptions
+* `#8054 <https://github.com/numpy/numpy/pull/8054>`__: ENH: add signature argument to vectorize for vectorizing like...
+* `#8057 <https://github.com/numpy/numpy/pull/8057>`__: BUG: lib: Simplify (and fix) pad's handling of the pad_width
+* `#8061 <https://github.com/numpy/numpy/pull/8061>`__: BUG : financial.pmt modifies input (issue #8055)
+* `#8064 <https://github.com/numpy/numpy/pull/8064>`__: MAINT: Add PMIP files to .gitignore
+* `#8065 <https://github.com/numpy/numpy/pull/8065>`__: BUG: Assert fromfile ending earlier in pyx_processing
+* `#8066 <https://github.com/numpy/numpy/pull/8066>`__: BUG, TST: Fix python3-dbg bug in Travis script
+* `#8071 <https://github.com/numpy/numpy/pull/8071>`__: MAINT: Add Tempita to randint helpers
+* `#8075 <https://github.com/numpy/numpy/pull/8075>`__: DOC: Fix description of isinf in nan_to_num
+* `#8080 <https://github.com/numpy/numpy/pull/8080>`__: BUG: non-integers can end up in dtype offsets
+* `#8081 <https://github.com/numpy/numpy/pull/8081>`__: Update outdated Nose URL to nose.readthedocs.io
+* `#8083 <https://github.com/numpy/numpy/pull/8083>`__: ENH: Deprecation warnings for `/` integer division when running...
+* `#8084 <https://github.com/numpy/numpy/pull/8084>`__: DOC: Fix erroneous return type description for np.roots.
+* `#8087 <https://github.com/numpy/numpy/pull/8087>`__: BUG: financial.pmt modifies input #8055
+* `#8088 <https://github.com/numpy/numpy/pull/8088>`__: MAINT: Remove duplicate randint helpers code.
+* `#8093 <https://github.com/numpy/numpy/pull/8093>`__: MAINT: fix assert_raises_regex when used as a context manager
+* `#8096 <https://github.com/numpy/numpy/pull/8096>`__: ENH: Vendorize tempita.
+* `#8098 <https://github.com/numpy/numpy/pull/8098>`__: DOC: Enhance description/usage for np.linalg.eig*h
+* `#8103 <https://github.com/numpy/numpy/pull/8103>`__: Pypy fixes
+* `#8104 <https://github.com/numpy/numpy/pull/8104>`__: Fix test code on cpuinfo's main function
+* `#8107 <https://github.com/numpy/numpy/pull/8107>`__: BUG: Fix array printing with precision=0.
+* `#8109 <https://github.com/numpy/numpy/pull/8109>`__: Fix bug in ravel_multi_index for big indices (Issue #7546)
+* `#8110 <https://github.com/numpy/numpy/pull/8110>`__: BUG: distutils: fix issue with rpath in fcompiler/gnu.py
+* `#8111 <https://github.com/numpy/numpy/pull/8111>`__: ENH: Add a tool for release authors and PRs.
+* `#8112 <https://github.com/numpy/numpy/pull/8112>`__: DOC: Fix "See also" links in linalg.
+* `#8114 <https://github.com/numpy/numpy/pull/8114>`__: BUG: core: add missing error check after PyLong_AsSsize_t
+* `#8121 <https://github.com/numpy/numpy/pull/8121>`__: DOC: Improve histogram2d() example.
+* `#8122 <https://github.com/numpy/numpy/pull/8122>`__: BUG: Fix broken pickle in MaskedArray when dtype is object (Return...
+* `#8124 <https://github.com/numpy/numpy/pull/8124>`__: BUG: Fixed build break
+* `#8125 <https://github.com/numpy/numpy/pull/8125>`__: Rebase, BUG: Fixed deepcopy of F-order object arrays.
+* `#8127 <https://github.com/numpy/numpy/pull/8127>`__: BUG: integers to a negative integer powers should error.
+* `#8141 <https://github.com/numpy/numpy/pull/8141>`__: improve configure checks for broken systems
+* `#8142 <https://github.com/numpy/numpy/pull/8142>`__: BUG: np.ma.mean and var should return scalar if no mask
+* `#8148 <https://github.com/numpy/numpy/pull/8148>`__: BUG: import full module path in npy_load_module
+* `#8153 <https://github.com/numpy/numpy/pull/8153>`__: MAINT: Expose void-scalar "base" attribute in python
+* `#8156 <https://github.com/numpy/numpy/pull/8156>`__: DOC: added example with empty indices for a scalar, #8138
+* `#8160 <https://github.com/numpy/numpy/pull/8160>`__: BUG: fix _array2string for structured array (issue #5692)
+* `#8164 <https://github.com/numpy/numpy/pull/8164>`__: MAINT: Update mailmap for NumPy 1.12.0
+* `#8165 <https://github.com/numpy/numpy/pull/8165>`__: Fixup 8152, BUG: assert_allclose(..., equal_nan=False) doesn't...
+* `#8167 <https://github.com/numpy/numpy/pull/8167>`__: Fixup 8146, DOC: Clarify when PyArray_{Max, Min, Ptp} return...
+* `#8168 <https://github.com/numpy/numpy/pull/8168>`__: DOC: Minor spelling fix in genfromtxt() docstring.
+* `#8173 <https://github.com/numpy/numpy/pull/8173>`__: BLD: Enable build on AIX
+* `#8174 <https://github.com/numpy/numpy/pull/8174>`__: DOC: warn that dtype.descr is only for use in PEP3118
+* `#8177 <https://github.com/numpy/numpy/pull/8177>`__: MAINT: Add python 3.6 support to suppress_warnings
+* `#8178 <https://github.com/numpy/numpy/pull/8178>`__: MAINT: Fix ResourceWarning new in Python 3.6.
+* `#8180 <https://github.com/numpy/numpy/pull/8180>`__: FIX: protect stolen ref by PyArray_NewFromDescr in array_empty
+* `#8181 <https://github.com/numpy/numpy/pull/8181>`__: ENH: Improve announce to find github squash-merge commits.
+* `#8182 <https://github.com/numpy/numpy/pull/8182>`__: MAINT: Update .mailmap
+* `#8183 <https://github.com/numpy/numpy/pull/8183>`__: MAINT: Ediff1d performance
+* `#8184 <https://github.com/numpy/numpy/pull/8184>`__: MAINT: make `assert_allclose` behavior on nans match pre 1.12
+* `#8188 <https://github.com/numpy/numpy/pull/8188>`__: DOC: 'highest' is exclusive for randint()
+* `#8189 <https://github.com/numpy/numpy/pull/8189>`__: BUG: setfield should raise if arr is not writeable
+* `#8190 <https://github.com/numpy/numpy/pull/8190>`__: ENH: Add a float_power function with at least float64 precision.
+* `#8197 <https://github.com/numpy/numpy/pull/8197>`__: DOC: Add missing arguments to np.ufunc.outer
+* `#8198 <https://github.com/numpy/numpy/pull/8198>`__: DEP: Deprecate the keepdims argument to accumulate
+* `#8199 <https://github.com/numpy/numpy/pull/8199>`__: MAINT: change path to env in distutils.system_info. Closes gh-8195.
+* `#8200 <https://github.com/numpy/numpy/pull/8200>`__: BUG: Fix structured array format functions
+* `#8202 <https://github.com/numpy/numpy/pull/8202>`__: ENH: specialize name of dev package by interpreter
+* `#8205 <https://github.com/numpy/numpy/pull/8205>`__: DOC: change development instructions from SSH to HTTPS access.
+* `#8216 <https://github.com/numpy/numpy/pull/8216>`__: DOC: Patch doc errors for atleast_nd and frombuffer
+* `#8218 <https://github.com/numpy/numpy/pull/8218>`__: BUG: ediff1d should return subclasses
+* `#8219 <https://github.com/numpy/numpy/pull/8219>`__: DOC: Turn SciPy references into links.
+* `#8222 <https://github.com/numpy/numpy/pull/8222>`__: ENH: Make numpy.mean() do more precise computation
+* `#8227 <https://github.com/numpy/numpy/pull/8227>`__: BUG: Better check for invalid bounds in np.random.uniform.
+* `#8231 <https://github.com/numpy/numpy/pull/8231>`__: ENH: Refactor numpy ** operators for numpy scalar integer powers
+* `#8234 <https://github.com/numpy/numpy/pull/8234>`__: DOC: Clarified when a copy is made in numpy.asarray
+* `#8236 <https://github.com/numpy/numpy/pull/8236>`__: DOC: Fix documentation pull requests.
+* `#8238 <https://github.com/numpy/numpy/pull/8238>`__: MAINT: Update pavement.py
+* `#8239 <https://github.com/numpy/numpy/pull/8239>`__: ENH: Improve announce tool.
+* `#8240 <https://github.com/numpy/numpy/pull/8240>`__: REL: Prepare for 1.12.x branch
+* `#8243 <https://github.com/numpy/numpy/pull/8243>`__: BUG: Update operator `**` tests for new behavior.
+* `#8246 <https://github.com/numpy/numpy/pull/8246>`__: REL: Reset strides for RELAXED_STRIDE_CHECKING for 1.12 releases.
+* `#8265 <https://github.com/numpy/numpy/pull/8265>`__: BUG: np.piecewise not working for scalars
+* `#8272 <https://github.com/numpy/numpy/pull/8272>`__: TST: Path test should resolve symlinks when comparing
+* `#8282 <https://github.com/numpy/numpy/pull/8282>`__: DOC: Update 1.12.0 release notes.
+* `#8286 <https://github.com/numpy/numpy/pull/8286>`__: BUG: Fix pavement.py write_release_task.
+* `#8296 <https://github.com/numpy/numpy/pull/8296>`__: BUG: Fix iteration over reversed subspaces in mapiter_@name@.
+* `#8304 <https://github.com/numpy/numpy/pull/8304>`__: BUG: Fix PyPy crash in PyUFunc_GenericReduction.
+* `#8319 <https://github.com/numpy/numpy/pull/8319>`__: BLD: blacklist powl (longdouble power function) on OS X.
+* `#8320 <https://github.com/numpy/numpy/pull/8320>`__: BUG: do not link to Accelerate if OpenBLAS, MKL or BLIS are found.
+* `#8322 <https://github.com/numpy/numpy/pull/8322>`__: BUG: fixed kind specifications for parameters
+* `#8336 <https://github.com/numpy/numpy/pull/8336>`__: BUG: fix packbits and unpackbits to correctly handle empty arrays
+* `#8338 <https://github.com/numpy/numpy/pull/8338>`__: BUG: fix test_api test that fails intermittently in python 3
+* `#8339 <https://github.com/numpy/numpy/pull/8339>`__: BUG: Fix ndarray.tofile large file corruption in append mode.
+* `#8359 <https://github.com/numpy/numpy/pull/8359>`__: BUG: Fix suppress_warnings (again) for Python 3.6.
+* `#8372 <https://github.com/numpy/numpy/pull/8372>`__: BUG: Fixes for ma.median and nanpercentile.
+* `#8373 <https://github.com/numpy/numpy/pull/8373>`__: BUG: correct letter case
+* `#8379 <https://github.com/numpy/numpy/pull/8379>`__: DOC: Update 1.12.0-notes.rst.
+* `#8390 <https://github.com/numpy/numpy/pull/8390>`__: ENH: retune apply_along_axis nanmedian cutoff in 1.12
+* `#8391 <https://github.com/numpy/numpy/pull/8391>`__: DEP: Fix escaped string characters deprecated in Python 3.6.
+* `#8394 <https://github.com/numpy/numpy/pull/8394>`__: DOC: create 1.11.3 release notes.
+* `#8399 <https://github.com/numpy/numpy/pull/8399>`__: BUG: Fix author search in announce.py
+* `#8402 <https://github.com/numpy/numpy/pull/8402>`__: DOC, MAINT: Update 1.12.0 notes and mailmap.
+* `#8418 <https://github.com/numpy/numpy/pull/8418>`__: BUG: Fix ma.median even elements for 1.12
+* `#8424 <https://github.com/numpy/numpy/pull/8424>`__: DOC: Fix tools and release notes to be more markdown compatible.
+* `#8427 <https://github.com/numpy/numpy/pull/8427>`__: BUG: Add a lock to assert_equal and other testing functions
+* `#8431 <https://github.com/numpy/numpy/pull/8431>`__: BUG: Fix apply_along_axis() for when func1d() returns a non-ndarray.
+* `#8432 <https://github.com/numpy/numpy/pull/8432>`__: BUG: Let linspace accept input that has an array_interface.
+* `#8437 <https://github.com/numpy/numpy/pull/8437>`__: TST: Update 3.6-dev tests to 3.6 after Python final release.
+* `#8439 <https://github.com/numpy/numpy/pull/8439>`__: DOC: Update 1.12.0 release notes.
+* `#8466 <https://github.com/numpy/numpy/pull/8466>`__: MAINT: Update mailmap entries.
+* `#8467 <https://github.com/numpy/numpy/pull/8467>`__: DOC: Back-port the missing part of gh-8464.
+* `#8476 <https://github.com/numpy/numpy/pull/8476>`__: DOC: Update 1.12.0 release notes.
+* `#8477 <https://github.com/numpy/numpy/pull/8477>`__: DOC: Update 1.12.0 release notes.

--- a/doc/release/1.13.0-notes.rst
+++ b/doc/release/1.13.0-notes.rst
@@ -210,7 +210,9 @@ within datetime and timedelta arrays. This is analogous to ``np.isnan``.
 ------------------------------------------------------
 The new function ``np.heaviside(x, h0)`` (a ufunc) computes the Heaviside
 function:
+
 .. code::
+
                        { 0   if x < 0,
     heaviside(x, h0) = { h0  if x == 0,
                        { 1   if x > 0.

--- a/doc/release/1.3.0-notes.rst
+++ b/doc/release/1.3.0-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.3.0 Release Notes
-*************************
+=========================
 
 This minor includes numerous bug fixes, official python 2.6 support, and
 several new features such as generalized ufuncs.
@@ -8,7 +9,7 @@ Highlights
 ==========
 
 Python 2.6 support
-~~~~~~~~~~~~~~~~~~
+------------------
 
 Python 2.6 is now supported on all previously supported platforms, including
 windows.
@@ -16,7 +17,7 @@ windows.
 http://www.python.org/dev/peps/pep-0361/
 
 Generalized ufuncs
-~~~~~~~~~~~~~~~~~~
+------------------
 
 There is a general need for looping over not only functions on scalars but also
 over functions on vectors (or arrays), as explained on
@@ -60,7 +61,7 @@ the loop dimensions.  The output is given by the loop dimensions plus the
 output core dimensions.
 
 Experimental Windows 64 bits support
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 
 Numpy can now be built on windows 64 bits (amd64 only, not IA64), with both MS
 compilers and mingw-w64 compilers:
@@ -73,7 +74,7 @@ New features
 ============
 
 Formatting issues
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Float formatting is now handled by numpy instead of the C runtime: this enables
 locale independent formatting, more robust fromstring and related methods.
@@ -82,7 +83,7 @@ IND/NaN, etc...), and more consistent with recent python formatting work (in
 2.6 and later).
 
 Nan handling in max/min
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 The maximum/minimum ufuncs now reliably propagate nans. If one of the
 arguments is a nan, then nan is returned. This affects np.min/np.max, amin/amax
@@ -90,13 +91,13 @@ and the array methods max/min. New ufuncs fmax and fmin have been added to deal
 with non-propagating nans.
 
 Nan handling in sign
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 The ufunc sign now returns nan for the sign of anan.
 
 
 New ufuncs
-~~~~~~~~~~
+----------
 
 #. fmax - same as maximum for integer types and non-nan floats. Returns the
    non-nan argument if one argument is nan and returns nan if both arguments
@@ -115,7 +116,7 @@ New ufuncs
    logarithm of the result.
 
 Masked arrays
-~~~~~~~~~~~~~
+-------------
 
 Several new features and bug fixes, including:
 
@@ -128,7 +129,7 @@ Several new features and bug fixes, including:
 	* doc update
 
 gfortran support on windows
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 Gfortran can now be used as a fortran compiler for numpy on windows, even when
 the C compiler is Visual Studio (VS 2005 and above; VS 2003 will NOT work).
@@ -137,7 +138,7 @@ does). It is unclear whether it will be possible to use gfortran and visual
 studio at all on x64.
 
 Arch option for windows binary
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 Automatic arch detection can now be bypassed from the command line for the superpack installed:
 
@@ -150,7 +151,7 @@ Deprecated features
 ===================
 
 Histogram
-~~~~~~~~~
+---------
 
 The semantics of histogram has been modified to fix long-standing issues
 with outliers handling. The main changes concern
@@ -172,14 +173,14 @@ New C API
 =========
 
 Multiarray API
-~~~~~~~~~~~~~~
+--------------
 
 The following functions have been added to the multiarray C API:
 
 	* PyArray_GetEndianness: to get runtime endianness
 
 Ufunc API
-~~~~~~~~~
+---------
 
 The following functions have been added to the ufunc API:
 
@@ -188,7 +189,7 @@ The following functions have been added to the ufunc API:
 
 
 New defines
-~~~~~~~~~~~
+-----------
 
 New public C defines are available for ARCH specific code through numpy/npy_cpu.h:
 
@@ -212,7 +213,7 @@ Those provide portable alternatives to glibc endian.h macros for platforms
 without it.
 
 Portable NAN, INFINITY, etc...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 npy_math.h now makes available several portable macro to get NAN, INFINITY:
 
@@ -228,7 +229,7 @@ Internal changes
 ================
 
 numpy.core math configuration revamp
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 
 This should make the porting to new platforms easier, and more robust. In
 particular, the configuration stage does not need to execute any code on the
@@ -237,19 +238,19 @@ target platform, which is a first step toward cross-compilation.
 http://projects.scipy.org/numpy/browser/trunk/doc/neps/math_config_clean.txt
 
 umath refactor
-~~~~~~~~~~~~~~
+--------------
 
 A lot of code cleanup for umath/ufunc code (charris).
 
 Improvements to build warnings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 Numpy can now build with -W -Wall without warnings
 
 http://projects.scipy.org/numpy/browser/trunk/doc/neps/warnfix.txt
 
 Separate core math library
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 The core math functions (sin, cos, etc... for basic C types) have been put into
 a separate library; it acts as a compatibility layer, to support most C99 maths
@@ -262,7 +263,7 @@ prefix (npy_cos vs cos).
 The core library will be made available to any extension in 1.4.0.
 
 CPU arch detection
-~~~~~~~~~~~~~~~~~~
+------------------
 
 npy_cpu.h defines numpy specific CPU defines, such as NPY_CPU_X86, etc...
 Those are portable across OS and toolchains, and set up when the header is

--- a/doc/release/1.4.0-notes.rst
+++ b/doc/release/1.4.0-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.4.0 Release Notes
-*************************
+=========================
 
 This minor includes numerous bug fixes, as well as a few new features. It
 is backward compatible with 1.3.0 release.
@@ -21,7 +22,7 @@ New features
 ============
 
 Extended array wrapping mechanism for ufuncs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 
 An __array_prepare__ method has been added to ndarray to provide subclasses
 greater flexibility to interact with ufuncs and ufunc-like functions. ndarray
@@ -34,7 +35,7 @@ before computing the results and populating it. This way, checks can be made
 and errors raised before operations which may modify data in place.
 
 Automatic detection of forward incompatibilities
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------
 
 Previously, if an extension was built against a version N of NumPy, and used on
 a system with NumPy M < N, the import_array was successful, which could cause
@@ -43,7 +44,7 @@ NumPy 1.4.0, this will cause a failure in import_array, so the error will be
 caught early on.
 
 New iterators
-~~~~~~~~~~~~~
+-------------
 
 A new neighborhood iterator has been added to the C API. It can be used to
 iterate over the items in a neighborhood of an array, and can handle boundaries
@@ -51,7 +52,7 @@ conditions automatically. Zero and one padding are available, as well as
 arbitrary constant value, mirror and circular padding.
 
 New polynomial support
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 New modules chebyshev and polynomial have been added. The new polynomial module
 is not compatible with the current polynomial support in numpy, but is much
@@ -70,7 +71,7 @@ they must be explicitly brought in with an "import numpy.polynomial"
 statement.
 
 New C API
-~~~~~~~~~
+---------
 
 The following C functions have been added to the C API:
 
@@ -85,7 +86,7 @@ The following C functions have been added to the C API:
        find some examples in  the multiarray_test.c.src file in numpy.core.
 
 New ufuncs
-~~~~~~~~~~
+----------
 
 The following ufuncs have been added to the C API:
 
@@ -95,7 +96,7 @@ The following ufuncs have been added to the C API:
        first argument toward the second argument.
 
 New defines
-~~~~~~~~~~~
+-----------
 
 The alpha processor is now defined and available in numpy/npy_cpu.h. The
 failed detection of the PARISC processor has been fixed. The defines are:
@@ -104,7 +105,7 @@ failed detection of the PARISC processor has been fixed. The defines are:
     #. NPY_CPU_ALPHA: Alpha
 
 Testing
-~~~~~~~
+-------
 
     #. deprecated decorator: this decorator may be used to avoid cluttering
        testing output while testing DeprecationWarning is effectively raised by
@@ -120,7 +121,7 @@ Testing
        warning of the appropriate class, without altering the warning state.
 
 Reusing npymath
-~~~~~~~~~~~~~~~
+---------------
 
 In 1.3.0, we started putting portable C math routines in npymath library, so
 that people can use those to write portable extensions. Unfortunately, it was
@@ -129,7 +130,7 @@ added to numpy.distutils so that 3rd party can reuse this library. See coremath
 documentation for more information.
 
 Improved set operations
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 In previous versions of NumPy some set functions (intersect1d,
 setxor1d, setdiff1d and setmember1d) could return incorrect results if
@@ -196,21 +197,21 @@ Internal changes
 ================
 
 Use C99 complex functions when available
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------
 
 The numpy complex types are now guaranteed to be ABI compatible with C99
 complex type, if available on the platform. Moreover, the complex ufunc now use
 the platform C99 functions instead of our own.
 
 split multiarray and umath source code
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 
 The source code of multiarray and umath has been split into separate logic
 compilation units. This should make the source code more amenable for
 newcomers.
 
 Separate compilation
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 By default, every file of multiarray (and umath) is merged into one for
 compilation as was the case before, but if NPY_SEPARATE_COMPILATION env
@@ -219,7 +220,7 @@ each file is enabled. This makes the compile/debug cycle much faster when
 working on core numpy.
 
 Separate core math library
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 New functions which have been added:
 

--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -1,12 +1,13 @@
+=========================
 NumPy 1.5.0 Release Notes
-*************************
+=========================
 
 
 Highlights
 ==========
 
 Python 3 compatibility
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 This is the first NumPy release which is compatible with Python 3. Support for
 Python 3 and Python 2 is done from a single code base. Extensive notes on
@@ -20,7 +21,7 @@ at `<http://bitbucket.org/jpellerin/nose3/>`_ however.
 Porting of SciPy to Python 3 is expected to be completed soon.
 
 :pep:`3118` compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 The new buffer protocol described by PEP 3118 is fully supported in this
 version of Numpy. On Python versions >= 2.6 Numpy arrays expose the buffer
@@ -32,7 +33,7 @@ New features
 ============
 
 Warning on casting complex to real
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 
 Numpy now emits a `numpy.ComplexWarning` when a complex number is cast
 into a real number. For example:
@@ -49,7 +50,7 @@ turned off in the standard way:
     >>> warnings.simplefilter("ignore", np.ComplexWarning)
 
 Dot method for ndarrays
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 Ndarrays now have the dot product also as a method, which allows writing
 chains of matrix products as
@@ -61,7 +62,7 @@ instead of the longer alternative
     >>> np.dot(a, np.dot(b, c))
 
 linalg.slogdet function
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 The slogdet function returns the sign and logarithm of the determinant
 of a matrix. Because the determinant may involve the product of many
@@ -69,7 +70,7 @@ small/large values, the result is often more accurate than that obtained
 by simple multiplication.
 
 new header
-~~~~~~~~~~
+----------
 
 The new header file ndarraytypes.h contains the symbols from
 ndarrayobject.h that do not depend on the PY_ARRAY_UNIQUE_SYMBOL and
@@ -84,7 +85,7 @@ Changes
 =======
 
 polynomial.polynomial
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 * The polyint and polyder functions now check that the specified number
   integrations or derivations is a non-negative integer. The number 0 is
@@ -100,7 +101,7 @@ polynomial.polynomial
 * The polymulx function was added.
 
 polynomial.chebyshev
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 * The chebint and chebder functions now check that the specified number
   integrations or derivations is a non-negative integer. The number 0 is
@@ -118,13 +119,13 @@ polynomial.chebyshev
 
 
 histogram
-~~~~~~~~~
+---------
 
 After a two years transition period, the old behavior of the histogram function
 has been phased out, and the "new" keyword has been removed.
 
 correlate
-~~~~~~~~~
+---------
 
 The old behavior of correlate was deprecated in 1.4.0, the new behavior (the
 usual definition for cross-correlation) is now the default.

--- a/doc/release/1.6.0-notes.rst
+++ b/doc/release/1.6.0-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.6.0 Release Notes
-*************************
+=========================
 
 This release includes several new features as well as numerous bug fixes and
 improved documentation.  It is backward compatible with the 1.5.0 release, and
@@ -20,7 +21,7 @@ New features
 ============
 
 New 16-bit floating point type
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 This release adds support for the IEEE 754-2008 binary16 format, available as
 the data type ``numpy.half``.  Within Python, the type behaves similarly to
@@ -29,7 +30,7 @@ half-float API.
 
 
 New iterator
-~~~~~~~~~~~~
+------------
 
 A new iterator has been added, replacing the functionality of the
 existing iterator and multi-iterator with a single object and API.
@@ -42,7 +43,7 @@ iterator.
 
 
 Legendre, Laguerre, Hermite, HermiteE polynomials in ``numpy.polynomial``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------------------------------
 
 Extend the number of polynomials available in the polynomial package. In
 addition, a new ``window`` attribute has been added to the classes in
@@ -53,7 +54,7 @@ of values without playing unnatural tricks with the domain.
 
 
 Fortran assumed shape array and size function support in ``numpy.f2py``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------------------------
 
 F2py now supports wrapping Fortran 90 routines that use assumed shape
 arrays.  Before such routines could be called from Python but the
@@ -67,7 +68,7 @@ that use two argument ``size`` function in dimension specifications.
 
 
 Other new functions
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 ``numpy.ravel_multi_index`` : Converts a multi-index tuple into
 an array of flat indices, applying boundary modes to the indices.
@@ -90,14 +91,14 @@ Changes
 =======
 
 ``default error handling``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 The default error handling has been change from ``print`` to ``warn`` for
 all except for ``underflow``, which remains as ``ignore``.
 
 
 ``numpy.distutils``
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Several new compilers are supported for building Numpy: the Portland Group
 Fortran compiler on OS X, the PathScale compiler suite and the 64-bit Intel C
@@ -105,7 +106,7 @@ compiler on Linux.
 
 
 ``numpy.testing``
-~~~~~~~~~~~~~~~~~
+-----------------
 
 The testing framework gained ``numpy.testing.assert_allclose``, which provides
 a more convenient way to compare floating point arrays than
@@ -113,7 +114,7 @@ a more convenient way to compare floating point arrays than
 
 
 ``C API``
-~~~~~~~~~
+---------
 
 In addition to the APIs for the new iterator and half data type, a number
 of other additions have been made to the C API. The type promotion
@@ -137,7 +138,7 @@ Removed features
 ================
 
 ``numpy.fft``
-~~~~~~~~~~~~~
+-------------
 
 The functions `refft`, `refft2`, `refftn`, `irefft`, `irefft2`, `irefftn`,
 which were aliases for the same functions without the 'e' in the name, were
@@ -145,21 +146,21 @@ removed.
 
 
 ``numpy.memmap``
-~~~~~~~~~~~~~~~~
+----------------
 
 The `sync()` and `close()` methods of memmap were removed.  Use `flush()` and
 "del memmap" instead.
 
 
 ``numpy.lib``
-~~~~~~~~~~~~~
+-------------
 
 The deprecated functions ``numpy.unique1d``, ``numpy.setmember1d``,
 ``numpy.intersect1d_nu`` and ``numpy.lib.ufunclike.log2`` were removed.
 
 
 ``numpy.ma``
-~~~~~~~~~~~~
+------------
 
 Several deprecated items were removed from the ``numpy.ma`` module::
 
@@ -170,7 +171,7 @@ Several deprecated items were removed from the ``numpy.ma`` module::
 
 
 ``numpy.distutils``
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 The ``numpy.get_numpy_include`` function was removed, use ``numpy.get_include``
 instead.

--- a/doc/release/1.6.1-notes.rst
+++ b/doc/release/1.6.1-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.6.1 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.6.x series.
 

--- a/doc/release/1.6.2-notes.rst
+++ b/doc/release/1.6.2-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.6.2 Release Notes
-*************************
+=========================
 
 This is a bugfix release in the 1.6.x series.  Due to the delay of the NumPy
 1.7.0 release, this release contains far more fixes than a regular NumPy bugfix
@@ -9,7 +10,7 @@ Issues fixed
 ============
 
 ``numpy.core``
-~~~~~~~~~~~~~~
+--------------
 
 * #2063: make unique() return consistent index
 * #1138: allow creating arrays from empty buffers or empty slices
@@ -31,7 +32,7 @@ Issues fixed
 
 
 ``numpy.lib``
-~~~~~~~~~~~~~
+-------------
 
 * #2048: break reference cycle in NpzFile
 * #1573: savetxt() now handles complex arrays
@@ -44,7 +45,7 @@ Issues fixed
 
 
 ``numpy.distutils``
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 * #1261: change compile flag on AIX from -O5 to -O3
 * #1377: update HP compiler flags
@@ -60,7 +61,7 @@ Issues fixed
 
 
 ``numpy.random``
-~~~~~~~~~~~~~~~~
+----------------
 
 * BUG: Use npy_intp instead of long in mtrand
 
@@ -68,7 +69,7 @@ Changes
 =======
 
 ``numpy.f2py``
-~~~~~~~~~~~~~~
+--------------
 
 * ENH: Introduce new options extra_f77_compiler_args and extra_f90_compiler_args
 * BLD: Improve reporting of fcompiler value
@@ -76,7 +77,7 @@ Changes
 
 
 ``numpy.poly``
-~~~~~~~~~~~~~~
+--------------
 
 * ENH: Add some tests for polynomial printing
 * ENH: Add companion matrix functions

--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.7.0 Release Notes
-*************************
+=========================
 
 This release includes several new features as well as numerous bug fixes and
 refactorings. It supports Python 2.4 - 2.7 and 3.1 - 3.3 and is the last
@@ -66,7 +67,7 @@ New features
 ============
 
 Reduction UFuncs Generalize axis= Parameter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 
 Any ufunc.reduce function call, as well as other reductions like sum, prod,
 any, all, max and min support the ability to choose a subset of the axes to
@@ -75,7 +76,7 @@ axis=# to pick a single axis.  Now, one can also say axis=(#,#) to pick a
 list of axes for reduction.
 
 Reduction UFuncs New keepdims= Parameter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------
 
 There is a new keepdims= parameter, which if set to True, doesn't throw
 away the reduction axes but instead sets them to have size one.  When this
@@ -83,7 +84,7 @@ option is set, the reduction result will broadcast correctly to the
 original operand which was reduced.
 
 Datetime support
-~~~~~~~~~~~~~~~~
+----------------
 
 .. note:: The datetime API is *experimental* in 1.7.0, and may undergo changes
    in future versions of NumPy.
@@ -104,26 +105,26 @@ The notes in `doc/source/reference/arrays.datetime.rst <https://github.com/numpy
 consulted for more details.
 
 Custom formatter for printing arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 
 See the new ``formatter`` parameter of the ``numpy.set_printoptions``
 function.
 
 New function numpy.random.choice
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 A generic sampling function has been added which will generate samples from
 a given array-like. The samples can be with or without replacement, and
 with uniform or given non-uniform probabilities.
 
 New function isclose
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Returns a boolean array where two arrays are element-wise equal within a
 tolerance. Both relative and absolute tolerance can be specified.
 
 Preliminary multi-dimensional support in the polynomial package
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------------------------
 
 Axis keywords have been added to the integration and differentiation
 functions and a tensor keyword was added to the evaluation functions.
@@ -134,7 +135,7 @@ pseudo-Vandermonde matrices that can be used for fitting.
 
 
 Ability to pad rank-n arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 A pad module containing functions for padding n-dimensional arrays has been
 added. The various private padding functions are exposed as options to a
@@ -148,18 +149,18 @@ Current modes are ``constant``, ``edge``, ``linear_ramp``, ``maximum``,
 
 
 New argument to searchsorted
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 The function searchsorted now accepts a 'sorter' argument that is a
 permutation array that sorts the array to search.
 
 Build system
-~~~~~~~~~~~~
+------------
 
 Added experimental support for the AArch64 architecture.
 
 C API
-~~~~~
+-----
 
 New function ``PyArray_RequireWriteable`` provides a consistent interface
 for checking array writeability -- any C code which works with arrays whose
@@ -172,7 +173,7 @@ Changes
 =======
 
 General
-~~~~~~~
+-------
 
 The function np.concatenate tries to match the layout of its input arrays.
 Previously, the layout did not follow any particular reason, and depended
@@ -213,7 +214,7 @@ and so the collapsing process only continues so long as it encounters other
 ``b`` is the last entry in that list which is a ``matrix`` object.
 
 Casting Rules
-~~~~~~~~~~~~~
+-------------
 
 Casting rules have undergone some changes in corner cases, due to the
 NA-related work. In particular for combinations of scalar+scalar:
@@ -255,7 +256,7 @@ Deprecations
 ============
 
 General
-~~~~~~~
+-------
 
 Specifying a custom string formatter with a `_format` array attribute is
 deprecated. The new `formatter` keyword in ``numpy.set_printoptions`` or
@@ -268,7 +269,7 @@ Versions of numpy < 1.7.0 ignored axis argument value for 1D arrays. We
 allow this for now, but in due course we will raise an error.
 
 C-API
-~~~~~
+-----
 
 Direct access to the fields of PyArrayObject* has been deprecated. Direct
 access has been recommended against for many releases. Expect similar

--- a/doc/release/1.7.1-notes.rst
+++ b/doc/release/1.7.1-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.7.1 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.7.x series.
 It supports Python 2.4 - 2.7 and 3.1 - 3.3 and is the last series that

--- a/doc/release/1.7.2-notes.rst
+++ b/doc/release/1.7.2-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.7.2 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.7.x series.
 It supports Python 2.4 - 2.7 and 3.1 - 3.3 and is the last series that

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.8.0 Release Notes
-*************************
+=========================
 
 This release supports  Python 2.6 -2.7 and 3.2 - 3.3.
 
@@ -79,7 +80,7 @@ the index in all-NaN slices. Previously the functions would raise a ValueError
 for array returns and NaN for scalar returns.
 
 NPY_RELAXED_STRIDES_CHECKING
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 There is a new compile time environment variable
 ``NPY_RELAXED_STRIDES_CHECKING``. If this variable is set to 1, then
 numpy will consider more arrays to be C- or F-contiguous -- for
@@ -112,7 +113,7 @@ For more information check the "Internal memory layout of an ndarray"
 section in the documentation.
 
 Binary operations with non-arrays as second argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------
 Binary operations of the form ``<array-or-subclass> * <non-array-subclass>``
 where ``<non-array-subclass>`` declares an ``__array_priority__`` higher than
 that of ``<array-or-subclass>`` will now unconditionally return
@@ -124,12 +125,12 @@ attempted. (`bug <https://github.com/numpy/numpy/issues/3375>`_, `pull request
 <https://github.com/numpy/numpy/pull/3501>`_)
 
 Function `median` used with `overwrite_input` only partially sorts array
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------------------------
 If `median` is used with `overwrite_input` option the input array will now only
 be partially sorted instead of fully sorted.
 
 Fix to financial.npv
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 The npv function had a bug. Contrary to what the documentation stated, it
 summed from indexes ``1`` to ``M`` instead of from ``0`` to ``M - 1``. The
 fix changes the returned value. The mirr function called the npv function,
@@ -137,7 +138,7 @@ but worked around the problem, so that was also fixed and the return value
 of the mirr function remains unchanged.
 
 Runtime warnings when comparing NaN numbers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 Comparing ``NaN`` floating point numbers now raises the ``invalid`` runtime
 warning. If a ``NaN`` is expected the warning can be ignored using np.errstate.
 E.g.::
@@ -151,7 +152,7 @@ New Features
 
 
 Support for linear algebra on stacked arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 The gufunc machinery is now used for np.linalg, allowing operations on
 stacked arrays and vectors. For example::
 
@@ -170,7 +171,7 @@ stacked arrays and vectors. For example::
             [ 0.,  1.]]])
 
 In place fancy indexing for ufuncs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 The function ``at`` has been added to ufunc objects to allow in place
 ufuncs with no buffering when fancy indexing is used. For example, the
 following will increment the first and second items in the array, and will
@@ -181,7 +182,7 @@ but that does not work as the incremented value of ``arr[2]`` is simply copied
 into the third slot in ``arr`` twice, not incremented twice.
 
 New functions `partition` and `argpartition`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 New functions to partially sort arrays via a selection algorithm.
 
 A ``partition`` by index ``k`` moves the ``k`` smallest element to the front of
@@ -197,30 +198,30 @@ percentiles of samples.
 ``O(n log(n))``.
 
 New functions `nanmean`, `nanvar` and `nanstd`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 New nan aware statistical functions are added. In these functions the
 results are what would be obtained if nan values were omitted from all
 computations.
 
 New functions `full` and `full_like`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 New convenience functions to create arrays filled with a specific value;
 complementary to the existing `zeros` and `zeros_like` functions.
 
 IO compatibility with large files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 Large NPZ files >2GB can be loaded on 64-bit systems.
 
 Building against OpenBLAS
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 It is now possible to build numpy against OpenBLAS by editing site.cfg.
 
 New constant
-~~~~~~~~~~~~
+------------
 Euler's constant is now exposed in numpy as euler_gamma.
 
 New modes for qr
-~~~~~~~~~~~~~~~~
+----------------
 New modes 'complete', 'reduced', and 'raw' have been added to the qr
 factorization and the old 'full' and 'economic' modes are deprecated.
 The 'reduced' mode replaces the old 'full' mode and is the default as was
@@ -236,12 +237,12 @@ deprecated, there isn't much use for it and it isn't any more efficient
 than the 'raw' mode.
 
 New `invert` argument to `in1d`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 The function `in1d` now accepts a `invert` argument which, when `True`,
 causes the returned array to be inverted.
 
 Advanced indexing using `np.newaxis`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 It is now possible to use `np.newaxis`/`None` together with index
 arrays instead of only in simple indices. This means that
 ``array[np.newaxis, [0, 1]]`` will now work as expected and select the first
@@ -249,7 +250,7 @@ two rows while prepending a new axis to the array.
 
 
 C-API
-~~~~~
+-----
 New ufuncs can now be registered with builtin input types and a custom
 output type. Before this change, NumPy wouldn't be able to find the right
 ufunc loop function when the ufunc was called from Python, because the ufunc
@@ -258,7 +259,7 @@ Now the correct ufunc loop is found, as long as the user provides an output
 argument with the correct output type.
 
 runtests.py
-~~~~~~~~~~~
+-----------
 A simple test runner script ``runtests.py`` was added. It also builds Numpy via
 ``setup.py build`` and can be used to run tests easily during development.
 
@@ -267,24 +268,24 @@ Improvements
 ============
 
 IO performance improvements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 Performance in reading large files was improved by chunking (see also IO compatibility).
 
 Performance improvements to `pad`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 The `pad` function has a new implementation, greatly improving performance for
 all inputs except `mode=<function>` (retained for backwards compatibility).
 Scaling with dimensionality is dramatically improved for rank >= 4.
 
 Performance improvements to `isnan`, `isinf`, `isfinite` and `byteswap`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------------------------
 `isnan`, `isinf`, `isfinite` and `byteswap` have been improved to take
 advantage of compiler builtins to avoid expensive calls to libc.
 This improves performance of these operations by about a factor of two on gnu
 libc systems.
 
 Performance improvements via SSE2 vectorization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 Several functions have been optimized to make use of SSE2 CPU SIMD instructions.
 
 * Float32 and float64:
@@ -307,7 +308,7 @@ capable CPU it must be enabled by passing the appropriate flag to the CFLAGS
 build variable (-msse2 with gcc).
 
 Performance improvements to `median`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 `median` is now implemented in terms of `partition` instead of `sort` which
 reduces its time complexity from O(n log(n)) to O(n).
 If used with the `overwrite_input` option the array will now only be partially
@@ -315,7 +316,7 @@ sorted instead of fully sorted.
 
 
 Overrideable operand flags in ufunc C-API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 When creating a ufunc, the default ufunc operand flags can be overridden
 via the new op_flags attribute of the ufunc object. For example, to set
 the operand flag for the first input to read/write:
@@ -335,7 +336,7 @@ Changes
 
 
 General
-~~~~~~~
+-------
 The function np.take now allows 0-d arrays as indices.
 
 The separate compilation mode is now enabled by default.
@@ -358,7 +359,7 @@ Several changes to np.insert and np.delete:
 Padded regions from np.pad are now correctly rounded, not truncated.
 
 C-API Array Additions
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 Four new functions have been added to the array C-API.
 
 * PyArray_Partition
@@ -367,14 +368,14 @@ Four new functions have been added to the array C-API.
 * PyDataMem_NEW_ZEROED
 
 C-API Ufunc Additions
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 One new function has been added to the ufunc C-API that allows to register
 an inner loop for user types using the descr.
 
 * PyUFunc_RegisterLoopForDescr
 
 C-API Developer Improvements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 The ``PyArray_Type`` instance creation function ``tp_new`` now
 uses ``tp_basicsize`` to determine how much memory to allocate.
 In previous releases only ``sizeof(PyArrayObject)`` bytes of
@@ -387,7 +388,7 @@ Deprecations
 The 'full' and 'economic' modes of qr factorization are deprecated.
 
 General
-~~~~~~~
+-------
 The use of non-integer for indices and most integer arguments has been
 deprecated. Previously float indices and function arguments such as axes or
 shapes were truncated to integers without warning. For example

--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.8.1 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.8.x series.
 
@@ -59,7 +60,7 @@ Changes
 =======
 
 NDIter
-~~~~~~
+------
 When ``NpyIter_RemoveAxis`` is now called, the iterator range will be reset.
 
 When a multi index is being tracked and an iterator is not buffered, it is
@@ -75,7 +76,7 @@ cases the arrays being iterated are as large as the iterator so that such
 a problem cannot occur.
 
 Optional reduced verbosity for np.distutils
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 Set ``numpy.distutils.system_info.system_info.verbosity = 0`` and then
 calls to ``numpy.distutils.system_info.get_info('blas_opt')`` will not
 print anything on the output. This is mostly for other packages using
@@ -85,7 +86,7 @@ Deprecations
 ============
 
 C-API
-~~~~~
+-----
 
 The utility function npy_PyFile_Dup and npy_PyFile_DupClose are broken by the
 internal buffering python 3 applies to its file objects.

--- a/doc/release/1.8.2-notes.rst
+++ b/doc/release/1.8.2-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.8.2 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.8.x series.
 

--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.9.0 Release Notes
-*************************
+=========================
 
 This release supports Python 2.6 - 2.7 and 3.2 - 3.4.
 
@@ -41,13 +42,13 @@ Compatibility notes
 ===================
 
 The diagonal and diag functions return readonly views.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------
 In NumPy 1.8, the diagonal and diag functions returned readonly copies, in
 NumPy 1.9 they return readonly views, and in 1.10 they will return writeable
 views.
 
 Special scalar float values don't cause upcast to double anymore
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------------------
 In previous numpy versions operations involving floating point scalars
 containing special values ``NaN``, ``Inf`` and ``-Inf`` caused the result
 type to be at least ``float64``.  As the special values can be represented
@@ -62,7 +63,7 @@ now remains ``float32`` instead of being cast to ``float64``.
 Operations involving non-special values have not been changed.
 
 Percentile output changes
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 If given more than one percentile to compute numpy.percentile returns an
 array instead of a list. A single percentile still returns a scalar.  The
 array is equivalent to converting the list returned in older versions
@@ -72,12 +73,12 @@ If the ``overwrite_input`` option is used the input is only partially
 instead of fully sorted.
 
 ndarray.tofile exception type
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 All ``tofile`` exceptions are now ``IOError``, some were previously
 ``ValueError``.
 
 Invalid fill value exceptions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 Two changes to numpy.ma.core._check_fill_value:
 
 * When the fill value is a string and the array type is not one of
@@ -87,7 +88,7 @@ Two changes to numpy.ma.core._check_fill_value:
   of OverflowError.
 
 Polynomial Classes no longer derived from PolyBase
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------
 This may cause problems with folks who depended on the polynomial classes
 being derived from PolyBase. They are now all derived from the abstract
 base class ABCPolyBase. Strictly speaking, there should be a deprecation
@@ -95,7 +96,7 @@ involved, but no external code making use of the old baseclass could be
 found.
 
 Using numpy.random.binomial may change the RNG state vs. numpy < 1.9
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------------
 A bug in one of the algorithms to generate a binomial random variate has
 been fixed. This change will likely alter the number of random draws
 performed, and hence the sequence location will be different after a
@@ -103,7 +104,7 @@ call to distribution.c::rk_binomial_btpe. Any tests which rely on the RNG
 being in a known state should be checked and/or updated as a result.
 
 Random seed enforced to be a 32 bit unsigned integer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------
 ``np.random.seed`` and ``np.random.RandomState`` now throw a ``ValueError``
 if the seed cannot safely be converted to 32 bit unsigned integers.
 Applications that now fail can be fixed by masking the higher 32 bit values to
@@ -111,20 +112,20 @@ zero: ``seed = seed & 0xFFFFFFFF``. This is what is done silently in older
 versions so the random stream remains the same.
 
 Argmin and argmax out argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 The ``out`` argument to ``np.argmin`` and ``np.argmax`` and their
 equivalent C-API functions is now checked to match the desired output shape
 exactly.  If the check fails a ``ValueError`` instead of ``TypeError`` is
 raised.
 
 Einsum
-~~~~~~
+------
 Remove unnecessary broadcasting notation restrictions.
 ``np.einsum('ijk,j->ijk', A, B)`` can also be written as
 ``np.einsum('ij...,j->ij...', A, B)`` (ellipsis is no longer required on 'j')
 
 Indexing
-~~~~~~~~
+--------
 
 The NumPy indexing has seen a complete rewrite in this version. This makes
 most advanced integer indexing operations much faster and should have no
@@ -177,12 +178,12 @@ introduced in advanced indexing operations:
 * Indexing with more then one ellipsis (``...``) is deprecated.
 
 Non-integer reduction axis indexes are deprecated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------
 Non-integer axis indexes to reduction ufuncs like `add.reduce` or `sum` are
 deprecated.
 
 ``promote_types`` and string dtype
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 ``promote_types`` function now returns a valid string length when given an
 integer or float dtype as one argument and a string dtype as another
 argument.  Previously it always returned the input string dtype, even if it
@@ -190,7 +191,7 @@ wasn't long enough to store the max integer/float value converted to a
 string.
 
 ``can_cast`` and string dtype
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 ``can_cast`` function now returns False in "safe" casting mode for
 integer/float dtype and string dtype if the string dtype length is not long
 enough to store the max integer/float value converted to a string.
@@ -198,37 +199,37 @@ Previously ``can_cast`` in "safe" mode returned True for integer/float
 dtype and a string dtype of any length.
 
 astype and string dtype
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 The ``astype`` method now returns an error if the string dtype to cast to
 is not long enough in "safe" casting mode to hold the max value of
 integer/float array that is being casted. Previously the casting was
 allowed even if the result was truncated.
 
 `npyio.recfromcsv` keyword arguments change
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 `npyio.recfromcsv` no longer accepts the undocumented `update` keyword,
 which used to override the `dtype` keyword.
 
 The ``doc/swig`` directory moved
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 The ``doc/swig`` directory has been moved to ``tools/swig``.
 
 The ``npy_3kcompat.h`` header changed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 The unused ``simple_capsule_dtor`` function has been removed from
 ``npy_3kcompat.h``.  Note that this header is not meant to be used outside
 of numpy; other projects should be using their own copy of this file when
 needed.
 
 Negative indices in C-Api ``sq_item`` and ``sq_ass_item`` sequence methods
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------------------
 When directly accessing the ``sq_item`` or ``sq_ass_item`` PyObject slots
 for item getting, negative indices will not be supported anymore.
 ``PySequence_GetItem`` and ``PySequence_SetItem`` however fix negative
 indices so that they can be used there.
 
 NDIter
-~~~~~~
+------
 When ``NpyIter_RemoveAxis`` is now called, the iterator range will be reset.
 
 When a multi index is being tracked and an iterator is not buffered, it is
@@ -246,7 +247,7 @@ a problem cannot occur.
 This change was already applied to the 1.8.1 release.
 
 ``zeros_like`` for string dtypes now returns empty strings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------------
 To match the `zeros` function `zeros_like` now returns an array initialized
 with empty strings instead of an array filled with `'0'`.
 
@@ -255,60 +256,60 @@ New Features
 ============
 
 Percentile supports more interpolation options
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 ``np.percentile`` now has the interpolation keyword argument to specify in
 which way points should be interpolated if the percentiles fall between two
 values.  See the documentation for the available options.
 
 Generalized axis support for median and percentile
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------
 ``np.median`` and ``np.percentile`` now support generalized axis arguments like
 ufunc reductions do since 1.7. One can now say axis=(index, index) to pick a
 list of axes for the reduction. The ``keepdims`` keyword argument was also
 added to allow convenient broadcasting to arrays of the original shape.
 
 Dtype parameter added to ``np.linspace`` and ``np.logspace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------------
 The returned data type from the ``linspace`` and ``logspace`` functions can
 now be specified using the dtype parameter.
 
 More general ``np.triu`` and ``np.tril`` broadcasting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 For arrays with ``ndim`` exceeding 2, these functions will now apply to the
 final two axes instead of raising an exception.
 
 ``tobytes`` alias for ``tostring`` method
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 ``ndarray.tobytes`` and ``MaskedArray.tobytes`` have been added as aliases
 for ``tostring`` which exports arrays as ``bytes``. This is more consistent
 in Python 3 where ``str`` and ``bytes`` are not the same.
 
 Build system
-~~~~~~~~~~~~
+------------
 Added experimental support for the ppc64le and OpenRISC architecture.
 
 Compatibility to python ``numbers`` module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------
 All numerical numpy types are now registered with the type hierarchy in
 the python ``numbers`` module.
 
 ``increasing`` parameter added to ``np.vander``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 The ordering of the columns of the Vandermonde matrix can be specified with
 this new boolean argument.
 
 ``unique_counts`` parameter added to ``np.unique``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------
 The number of times each unique item comes up in the input can now be
 obtained as an optional return value.
 
 Support for median and percentile in nanfunctions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------------
 The ``np.nanmedian`` and ``np.nanpercentile`` functions behave like
 the median and percentile functions except that NaNs are ignored.
 
 NumpyVersion class added
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 The class may be imported from numpy.lib and can be used for version
 comparison when the numpy version goes to 1.10.devel. For example::
 
@@ -317,7 +318,7 @@ comparison when the numpy version goes to 1.10.devel. For example::
     ...     print('Wow, that is an old NumPy version!')
 
 Allow saving arrays with large number of named columns
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------
 The numpy storage format 1.0 only allowed the array header to have a total size
 of 65535 bytes. This can be exceeded by structured arrays with a large number
 of columns. A new format 2.0 has been added which extends the header size to 4
@@ -325,7 +326,7 @@ GiB. `np.save` will automatically save in 2.0 format if the data requires it,
 else it will always use the more compatible 1.0 format.
 
 Full broadcasting support for ``np.cross``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------
 ``np.cross`` now properly broadcasts its two input arrays, even if they
 have different number of dimensions. In earlier versions this would result
 in either an error being raised, or wrong results computed.
@@ -335,87 +336,87 @@ Improvements
 ============
 
 Better numerical stability for sum in some cases
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------
 Pairwise summation is now used in the sum method, but only along the fast
 axis and for groups of the values <= 8192 in length. This should also
 improve the accuracy of var and std in some common cases.
 
 Percentile implemented in terms of ``np.partition``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------------
 ``np.percentile`` has been implemented in terms of ``np.partition`` which
 only partially sorts the data via a selection algorithm. This improves the
 time complexity from ``O(nlog(n))`` to ``O(n)``.
 
 Performance improvement for ``np.array``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------
 The performance of converting lists containing arrays to arrays using
 ``np.array`` has been improved. It is now equivalent in speed to
 ``np.vstack(list)``.
 
 Performance improvement for ``np.searchsorted``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 For the built-in numeric types, ``np.searchsorted`` no longer relies on the
 data type's ``compare`` function to perform the search, but is now
 implemented by type specific functions. Depending on the size of the
 inputs, this can result in performance improvements over 2x.
 
 Optional reduced verbosity for np.distutils
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 Set ``numpy.distutils.system_info.system_info.verbosity = 0`` and then
 calls to ``numpy.distutils.system_info.get_info('blas_opt')`` will not
 print anything on the output. This is mostly for other packages using
 numpy.distutils.
 
 Covariance check in ``np.random.multivariate_normal``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 A ``RuntimeWarning`` warning is raised when the covariance matrix is not
 positive-semidefinite.
 
 Polynomial Classes no longer template based
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 The polynomial classes have been refactored to use an abstract base class
 rather than a template in order to implement a common interface. This makes
 importing the polynomial package faster as the classes do not need to be
 compiled on import.
 
 More GIL releases
-~~~~~~~~~~~~~~~~~
+-----------------
 Several more functions now release the Global Interpreter Lock allowing more
 efficient parallelization using the ``threading`` module. Most notably the GIL is
 now released for fancy indexing, ``np.where`` and the ``random`` module now
 uses a per-state lock instead of the GIL.
 
 MaskedArray support for more complicated base classes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 Built-in assumptions that the baseclass behaved like a plain array are being
 removed. In particalur, ``repr`` and ``str`` should now work more reliably.
 
 
 C-API
-~~~~~
+-----
 
 
 Deprecations
 ============
 
 Non-integer scalars for sequence repetition
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 Using non-integer numpy scalars to repeat python sequences is deprecated.
 For example ``np.float_(2) * [1]`` will be an error in the future.
 
 ``select`` input deprecations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 The integer and empty input to ``select`` is deprecated. In the future only
 boolean arrays will be valid conditions and an empty ``condlist`` will be
 considered an input error instead of returning the default.
 
 ``rank`` function
-~~~~~~~~~~~~~~~~~
+-----------------
 The ``rank`` function has been deprecated to avoid confusion with
 ``numpy.linalg.matrix_rank``.
 
 Object array equality comparisons
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 In the future object array comparisons both `==` and `np.equal` will not
 make use of identity checks anymore. For example:
 
@@ -435,7 +436,7 @@ instead of just returning False. Code should be using `arr is None`.
 All of these changes will give Deprecation- or FutureWarnings at this time.
 
 C-API
-~~~~~
+-----
 
 The utility function npy_PyFile_Dup and npy_PyFile_DupClose are broken by the
 internal buffering python 3 applies to its file objects.

--- a/doc/release/1.9.1-notes.rst
+++ b/doc/release/1.9.1-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.9.1 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.9.x series.
 

--- a/doc/release/1.9.2-notes.rst
+++ b/doc/release/1.9.2-notes.rst
@@ -1,5 +1,6 @@
+=========================
 NumPy 1.9.2 Release Notes
-*************************
+=========================
 
 This is a bugfix only release in the 1.9.x series.
 

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -363,7 +363,8 @@ As a corollary to this change, we no longer prohibit casting between datetimes
 with date units and datetimes with timeunits. With timezone naive datetimes,
 the rule for casting from dates to times is no longer ambiguous.
 
-pandas_: http://pandas.pydata.org
+.. _pandas: http://pandas.pydata.org
+
 
 Differences Between 1.6 and 1.7 Datetimes
 =========================================

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -46,12 +46,12 @@ ends with ``'.gz'``, a :class:`gzip` archive is expected; if it ends with
 Splitting the lines into columns
 ================================
 
-The :keyword:`delimiter` argument
----------------------------------
+The ``delimiter`` argument
+--------------------------
 
 Once the file is defined and open for reading, :func:`~numpy.genfromtxt`
 splits each non-empty line into a sequence of strings.  Empty or commented
-lines are just skipped.  The :keyword:`delimiter` keyword is used to define
+lines are just skipped.  The ``delimiter`` keyword is used to define
 how the splitting should take place.
 
 Quite often, a single character marks the separation between columns.  For
@@ -71,7 +71,7 @@ spaces are considered as a single white space.
 
 Alternatively, we may be dealing with a fixed-width file, where columns are
 defined as a given number of characters.  In that case, we need to set
-:keyword:`delimiter` to a single integer (if all the columns have the same
+``delimiter`` to a single integer (if all the columns have the same
 size) or to a sequence of integers (if columns can have different sizes)::
 
    >>> data = "  1  2  3\n  4  5 67\n890123  4"
@@ -86,13 +86,13 @@ size) or to a sequence of integers (if columns can have different sizes)::
           [    4.,   567.,     9.]])
 
 
-The :keyword:`autostrip` argument
----------------------------------
+The ``autostrip`` argument
+--------------------------
 
 By default, when a line is decomposed into a series of strings, the
 individual entries are not stripped of leading nor trailing white spaces.
 This behavior can be overwritten by setting the optional argument
-:keyword:`autostrip` to a value of ``True``::
+``autostrip`` to a value of ``True``::
 
    >>> data = "1, abc , 2\n 3, xxx, 4"
    >>> # Without autostrip
@@ -107,10 +107,10 @@ This behavior can be overwritten by setting the optional argument
          dtype='|U5')
 
 
-The :keyword:`comments` argument
---------------------------------
+The ``comments`` argument
+-------------------------
 
-The optional argument :keyword:`comments` is used to define a character
+The optional argument ``comments`` is used to define a character
 string that marks the beginning of a comment.  By default,
 :func:`~numpy.genfromtxt` assumes ``comments='#'``.  The comment marker may
 occur anywhere on the line.  Any character present after the comment
@@ -143,15 +143,15 @@ marker(s) is simply ignored::
 Skipping lines and choosing columns
 ===================================
 
-The :keyword:`skip_header` and :keyword:`skip_footer` arguments
+The ``skip_header`` and ``skip_footer`` arguments
 ---------------------------------------------------------------
 
 The presence of a header in the file can hinder data processing.  In that
-case, we need to use the :keyword:`skip_header` optional argument.  The
+case, we need to use the ``skip_header`` optional argument.  The
 values of this argument must be an integer which corresponds to the number
 of lines to skip at the beginning of the file, before any other action is
 performed.  Similarly, we can skip the last ``n`` lines of the file by
-using the :keyword:`skip_footer` attribute and giving it a value of ``n``::
+using the ``skip_footer`` attribute and giving it a value of ``n``::
 
    >>> data = "\n".join(str(i) for i in range(10))
    >>> np.genfromtxt(BytesIO(data),)
@@ -164,12 +164,12 @@ By default, ``skip_header=0`` and ``skip_footer=0``, meaning that no lines
 are skipped.
 
 
-The :keyword:`usecols` argument
--------------------------------
+The ``usecols`` argument
+------------------------
 
 In some cases, we are not interested in all the columns of the data but
 only a few of them.  We can select which columns to import with the
-:keyword:`usecols` argument.  This argument accepts a single integer or a
+``usecols`` argument.  This argument accepts a single integer or a
 sequence of integers corresponding to the indices of the columns to import.
 Remember that by convention, the first column has an index of 0.  Negative
 integers behave the same as regular Python negative indexes.
@@ -183,7 +183,7 @@ can use ``usecols=(0, -1)``::
           [ 4.,  6.]])
 
 If the columns have names, we can also select which columns to import by
-giving their name to the :keyword:`usecols` argument, either as a sequence
+giving their name to the ``usecols`` argument, either as a sequence
 of strings or a comma-separated string::
 
    >>> data = "1 2 3\n4 5 6"
@@ -203,12 +203,12 @@ Choosing the data type
 ======================
 
 The main way to control how the sequences of strings we have read from the
-file are converted to other types is to set the :keyword:`dtype` argument.
+file are converted to other types is to set the ``dtype`` argument.
 Acceptable values for this argument are:
 
 * a single type, such as ``dtype=float``.
   The output will be 2D with the given dtype, unless a name has been
-  associated with each column with the use of the :keyword:`names` argument
+  associated with each column with the use of the ``names`` argument
   (see below).  Note that ``dtype=float`` is the default for
   :func:`~numpy.genfromtxt`.
 * a sequence of types, such as ``dtype=(int, float, float)``.
@@ -223,7 +223,7 @@ Acceptable values for this argument are:
 
 In all the cases but the first one, the output will be a 1D array with a
 structured dtype.  This dtype has as many fields as items in the sequence.
-The field names are defined with the :keyword:`names` keyword.
+The field names are defined with the ``names`` keyword.
 
 
 When ``dtype=None``, the type of each column is determined iteratively from
@@ -242,8 +242,8 @@ significantly slower than setting the dtype explicitly.
 Setting the names
 =================
 
-The :keyword:`names` argument
------------------------------
+The ``names`` argument
+----------------------
 
 A natural approach when dealing with tabular data is to allocate a name to
 each column.  A first possibility is to use an explicit structured dtype,
@@ -254,7 +254,7 @@ as mentioned previously::
    array([(1, 2, 3), (4, 5, 6)],
          dtype=[('a', '<i8'), ('b', '<i8'), ('c', '<i8')])
 
-Another simpler possibility is to use the :keyword:`names` keyword with a
+Another simpler possibility is to use the ``names`` keyword with a
 sequence of strings or a comma-separated string::
 
    >>> data = BytesIO("1 2 3\n 4 5 6")
@@ -267,7 +267,7 @@ By giving a sequence of names, we are forcing the output to a structured
 dtype.
 
 We may sometimes need to define the column names from the data itself.  In
-that case, we must use the :keyword:`names` keyword with a value of
+that case, we must use the ``names`` keyword with a value of
 ``True``.  The names will then be read from the first line (after the
 ``skip_header`` ones), even if the line is commented out::
 
@@ -276,7 +276,7 @@ that case, we must use the :keyword:`names` keyword with a value of
    array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)],
          dtype=[('a', '<f8'), ('b', '<f8'), ('c', '<f8')])
 
-The default value of :keyword:`names` is ``None``.  If we give any other
+The default value of ``names`` is ``None``.  If we give any other
 value to the keyword, the new names will overwrite the field names we may
 have defined with the dtype::
 
@@ -288,8 +288,8 @@ have defined with the dtype::
          dtype=[('A', '<i8'), ('B', '<f8'), ('C', '<i8')])
 
 
-The :keyword:`defaultfmt` argument
-----------------------------------
+The ``defaultfmt`` argument
+---------------------------
 
 If ``names=None`` but a structured dtype is expected, names are defined
 with the standard NumPy default of ``"f%i"``, yielding names like ``f0``,
@@ -308,7 +308,7 @@ dtype, the missing names will be defined with this default template::
    array([(1, 2.0, 3), (4, 5.0, 6)],
          dtype=[('a', '<i8'), ('f0', '<f8'), ('f1', '<i8')])
 
-We can overwrite this default with the :keyword:`defaultfmt` argument, that
+We can overwrite this default with the ``defaultfmt`` argument, that
 takes any format string::
 
    >>> data = BytesIO("1 2 3\n 4 5 6")
@@ -333,16 +333,16 @@ correspond to the name of a standard attribute (like ``size`` or
 ``shape``), which would confuse the interpreter.  :func:`~numpy.genfromtxt`
 accepts three optional arguments that provide a finer control on the names:
 
-   :keyword:`deletechars`
+   ``deletechars``
       Gives a string combining all the characters that must be deleted from
       the name. By default, invalid characters are
       ``~!@#$%^&*()-=+~\|]}[{';:
       /?.>,<``.
-   :keyword:`excludelist`
+   ``excludelist``
       Gives a list of the names to exclude, such as ``return``, ``file``,
       ``print``...  If one of the input name is part of this list, an
       underscore character (``'_'``) will be appended to it.
-   :keyword:`case_sensitive`
+   ``case_sensitive``
       Whether the names should be case-sensitive (``case_sensitive=True``),
       converted to upper case (``case_sensitive=False`` or
       ``case_sensitive='upper'``) or to lower case
@@ -353,15 +353,15 @@ accepts three optional arguments that provide a finer control on the names:
 Tweaking the conversion
 =======================
 
-The :keyword:`converters` argument
-----------------------------------
+The ``converters`` argument
+---------------------------
 
 Usually, defining a dtype is sufficient to define how the sequence of
 strings must be converted.  However, some additional control may sometimes
 be required.  For example, we may want to make sure that a date in a format
 ``YYYY/MM/DD`` is converted to a :class:`datetime` object, or that a string
 like ``xx%`` is properly converted to a float between 0 and 1.  In such
-cases, we should define conversion functions with the :keyword:`converters`
+cases, we should define conversion functions with the ``converters``
 arguments.
 
 The value of this argument is typically a dictionary with column indices or
@@ -427,16 +427,16 @@ float.  However, user-defined converters may rapidly become cumbersome to
 manage.
 
 The :func:`~nummpy.genfromtxt` function provides two other complementary
-mechanisms: the :keyword:`missing_values` argument is used to recognize
-missing data and a second argument, :keyword:`filling_values`, is used to
+mechanisms: the ``missing_values`` argument is used to recognize
+missing data and a second argument, ``filling_values``, is used to
 process these missing data.
 
-:keyword:`missing_values`
--------------------------
+``missing_values``
+------------------
 
 By default, any empty string is marked as missing.  We can also consider
 more complex strings, such as ``"N/A"`` or ``"???"`` to represent missing
-or invalid data.  The :keyword:`missing_values` argument accepts three kind
+or invalid data.  The ``missing_values`` argument accepts three kind
 of values:
 
    a string or a comma-separated string
@@ -451,8 +451,8 @@ of values:
       define a default applicable to all columns.
 
 
-:keyword:`filling_values`
--------------------------
+``filling_values``
+------------------
 
 We know how to recognize missing data, but we still need to provide a value
 for these missing entries.  By default, this value is determined from the
@@ -469,8 +469,8 @@ Expected type  Default
 =============  ==============
 
 We can get a finer control on the conversion of missing values with the
-:keyword:`filling_values` optional argument.  Like
-:keyword:`missing_values`, this argument accepts different kind of values:
+``filling_values`` optional argument.  Like
+``missing_values``, this argument accepts different kind of values:
 
    a single value
       This will be the default for all columns
@@ -497,13 +497,13 @@ and second column, and to -999 if they occur in the last column::
           dtype=[('a', '<i8'), ('b', '<i8'), ('c', '<i8')])
 
 
-:keyword:`usemask`
-------------------
+``usemask``
+-----------
 
 We may also want to keep track of the occurrence of missing data by
 constructing a boolean mask, with ``True`` entries where data was missing
 and ``False`` otherwise.  To do that, we just have to set the optional
-argument :keyword:`usemask` to ``True`` (the default is ``False``).  The
+argument ``usemask`` to ``True`` (the default is ``False``).  The
 output array will then be a :class:`~numpy.ma.MaskedArray`.
 
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -390,8 +390,8 @@ an error condition set if it was not successful.
         (optional) Specify any optional data needed by the function which will
         be passed when the function is called.
 
-        .. index::
-           pair: dtype; adding new
+.. index::
+   pair: dtype; adding new
 
 
 Subtyping the ndarray in C

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -292,13 +292,13 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None):
 
     Negative, decreasing, and complex inputs are allowed:
 
-    >>> geomspace(1000, 1, num=4)
+    >>> np.geomspace(1000, 1, num=4)
     array([ 1000.,   100.,    10.,     1.])
-    >>> geomspace(-1000, -1, num=4)
+    >>> np.geomspace(-1000, -1, num=4)
     array([-1000.,  -100.,   -10.,    -1.])
-    >>> geomspace(1j, 1000j, num=4)  # Straight line
+    >>> np.geomspace(1j, 1000j, num=4)  # Straight line
     array([ 0.   +1.j,  0.  +10.j,  0. +100.j,  0.+1000.j])
-    >>> geomspace(-1+0j, 1+0j, num=5)  # Circle
+    >>> np.geomspace(-1+0j, 1+0j, num=5)  # Circle
     array([-1.00000000+0.j        , -0.70710678+0.70710678j,
             0.00000000+1.j        ,  0.70710678+0.70710678j,
             1.00000000+0.j        ])

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -439,9 +439,9 @@ def block(arrays):
     """
     Assemble an nd-array from nested lists of blocks.
 
-    Blocks in the innermost lists are `concatenate`d along the last
-    dimension (-1), then these are `concatenate`d along the second-last
-    dimension (-2), and so on until the outermost list is reached
+    Blocks in the innermost lists are concatenated (see `concatenate`) along
+    the last dimension (-1), then these are concatenated along the
+    second-last dimension (-2), and so on until the outermost list is reached.
 
     Blocks can be of any dimension, but will not be broadcasted using the normal
     rules. Instead, leading axes of size 1 are inserted, to make ``block.ndim``

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1064,24 +1064,25 @@ class Configuration(object):
 
         Notes
         -----
-        Rules for installation paths:
-          foo/bar -> (foo/bar, foo/bar) -> parent/foo/bar
-          (gun, foo/bar) -> parent/gun
-          foo/* -> (foo/a, foo/a), (foo/b, foo/b) -> parent/foo/a, parent/foo/b
-          (gun, foo/*) -> (gun, foo/a), (gun, foo/b) -> gun
-          (gun/*, foo/*) -> parent/gun/a, parent/gun/b
-          /foo/bar -> (bar, /foo/bar) -> parent/bar
-          (gun, /foo/bar) -> parent/gun
-          (fun/*/gun/*, sun/foo/bar) -> parent/fun/foo/gun/bar
+        Rules for installation paths::
+
+            foo/bar -> (foo/bar, foo/bar) -> parent/foo/bar
+            (gun, foo/bar) -> parent/gun
+            foo/* -> (foo/a, foo/a), (foo/b, foo/b) -> parent/foo/a, parent/foo/b
+            (gun, foo/*) -> (gun, foo/a), (gun, foo/b) -> gun
+            (gun/*, foo/*) -> parent/gun/a, parent/gun/b
+            /foo/bar -> (bar, /foo/bar) -> parent/bar
+            (gun, /foo/bar) -> parent/gun
+            (fun/*/gun/*, sun/foo/bar) -> parent/fun/foo/gun/bar
 
         Examples
         --------
         For example suppose the source directory contains fun/foo.dat and
-        fun/bar/car.dat::
+        fun/bar/car.dat:
 
-            >>> self.add_data_dir('fun')                       #doctest: +SKIP
-            >>> self.add_data_dir(('sun', 'fun'))              #doctest: +SKIP
-            >>> self.add_data_dir(('gun', '/full/path/to/fun'))#doctest: +SKIP
+        >>> self.add_data_dir('fun')                       #doctest: +SKIP
+        >>> self.add_data_dir(('sun', 'fun'))              #doctest: +SKIP
+        >>> self.add_data_dir(('gun', '/full/path/to/fun'))#doctest: +SKIP
 
         Will install data-files to the locations::
 
@@ -1097,6 +1098,7 @@ class Configuration(object):
               gun/
                 foo.dat
                 car.dat
+
         """
         if is_sequence(data_path):
             d, data_path = data_path

--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -9,36 +9,36 @@ Array types and conversions between types
 NumPy supports a much greater variety of numerical types than Python does.
 This section shows which are available, and how to modify an array's data-type.
 
-==========  ==========================================================
-Data type   Description
-==========  ==========================================================
-bool_       Boolean (True or False) stored as a byte
-int_        Default integer type (same as C ``long``; normally either
-            ``int64`` or ``int32``)
-intc        Identical to C ``int`` (normally ``int32`` or ``int64``)
-intp        Integer used for indexing (same as C ``ssize_t``; normally
-            either ``int32`` or ``int64``)
-int8        Byte (-128 to 127)
-int16       Integer (-32768 to 32767)
-int32       Integer (-2147483648 to 2147483647)
-int64       Integer (-9223372036854775808 to 9223372036854775807)
-uint8       Unsigned integer (0 to 255)
-uint16      Unsigned integer (0 to 65535)
-uint32      Unsigned integer (0 to 4294967295)
-uint64      Unsigned integer (0 to 18446744073709551615)
-float_      Shorthand for ``float64``.
-float16     Half precision float: sign bit, 5 bits exponent,
-            10 bits mantissa
-float32     Single precision float: sign bit, 8 bits exponent,
-            23 bits mantissa
-float64     Double precision float: sign bit, 11 bits exponent,
-            52 bits mantissa
-complex_    Shorthand for ``complex128``.
-complex64   Complex number, represented by two 32-bit floats (real
-            and imaginary components)
-complex128  Complex number, represented by two 64-bit floats (real
-            and imaginary components)
-==========  ==========================================================
+============ ==========================================================
+Data type    Description
+============ ==========================================================
+``bool_``    Boolean (True or False) stored as a byte
+``int_``     Default integer type (same as C ``long``; normally either
+             ``int64`` or ``int32``)
+intc         Identical to C ``int`` (normally ``int32`` or ``int64``)
+intp         Integer used for indexing (same as C ``ssize_t``; normally
+             either ``int32`` or ``int64``)
+int8         Byte (-128 to 127)
+int16        Integer (-32768 to 32767)
+int32        Integer (-2147483648 to 2147483647)
+int64        Integer (-9223372036854775808 to 9223372036854775807)
+uint8        Unsigned integer (0 to 255)
+uint16       Unsigned integer (0 to 65535)
+uint32       Unsigned integer (0 to 4294967295)
+uint64       Unsigned integer (0 to 18446744073709551615)
+``float_``   Shorthand for ``float64``.
+float16      Half precision float: sign bit, 5 bits exponent,
+             10 bits mantissa
+float32      Single precision float: sign bit, 8 bits exponent,
+             23 bits mantissa
+float64      Double precision float: sign bit, 11 bits exponent,
+             52 bits mantissa
+``complex_`` Shorthand for ``complex128``.
+complex64    Complex number, represented by two 32-bit floats (real
+             and imaginary components)
+complex128   Complex number, represented by two 64-bit floats (real
+             and imaginary components)
+============ ==========================================================
 
 Additionally to ``intc`` the platform dependent C integer types ``short``,
 ``long``, ``longlong`` and their unsigned versions are defined.

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -48,7 +48,7 @@ Glossary
          array([(1, 2.0), (3, 4.0)],
                dtype=[('x', '<i4'), ('y', '<f8')])
 
-       Fast element-wise operations, called `ufuncs`_, operate on arrays.
+       Fast element-wise operations, called :term:`ufuncs`, operate on arrays.
 
    array_like
        Any sequence that can be interpreted as an ndarray.  This includes
@@ -82,7 +82,7 @@ Glossary
          array([[4, 5],
                 [5, 6]])
 
-       See `doc.broadcasting`_ for more information.
+       See `numpy.doc.broadcasting` for more information.
 
    C order
        See `row-major`
@@ -155,7 +155,8 @@ Glossary
        See `column-major`
 
    flattened
-       Collapsed to a one-dimensional array. See `ndarray.flatten`_ for details.
+       Collapsed to a one-dimensional array. See `numpy.ndarray.flatten`
+       for details.
 
    immutable
        An object that cannot be modified after execution is called
@@ -284,9 +285,9 @@ Glossary
        See *array*.
 
    record array
-       An `ndarray`_ with `structured data type`_ which has been subclassed as
-       np.recarray and whose dtype is of type np.record, making the
-       fields of its data type to be accessible by attribute.
+       An :term:`ndarray` with :term:`structured data type`_ which has been
+       subclassed as ``np.recarray`` and whose dtype is of type ``np.record``,
+       making the fields of its data type to be accessible by attribute.
 
    reference
        If ``a`` is a reference to ``b``, then ``(a is b) == True``.  Therefore,
@@ -348,10 +349,10 @@ Glossary
 
          >>> x[:, 1]
          array([2, 4])
-   
+
    structured data type
        A data type composed of other datatypes
-   
+
    tuple
        A sequence that may contain a variable number of types of any
        kind.  A tuple is immutable, i.e., once constructed it cannot be

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -543,7 +543,7 @@ will be called, but now it sees an ``ndarray`` as the other argument. Likely,
 it will know how to handle this, and return a new instance of the ``B`` class
 to us. Our example class is not set up to handle this, but it might well be
 the best approach if, e.g., one were to re-implement ``MaskedArray`` using
- ``__array_ufunc__``.
+``__array_ufunc__``.
 
 As a final note: if the ``super`` route is suited to a given class, an
 advantage of using it is that it helps in constructing class hierarchies.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -627,7 +627,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     array([ 0.5,  0. ,  0.5,  0. ,  0. ,  0.5,  0. ,  0.5,  0. ,  0.5])
     >>> hist.sum()
     2.4999999999999996
-    >>> np.sum(hist*np.diff(bin_edges))
+    >>> np.sum(hist * np.diff(bin_edges))
     1.0
 
     .. versionadded:: 1.11.0

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1088,7 +1088,7 @@ def nanpercentile(a, q, axis=None, out=None, overwrite_input=False,
     >>> a[0][1] = np.nan
     >>> a
     array([[ 10.,  nan,   4.],
-       [  3.,   2.,   1.]])
+          [  3.,   2.,   1.]])
     >>> np.percentile(a, 50)
     nan
     >>> np.nanpercentile(a, 50)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2327,7 +2327,7 @@ def multi_dot(arrays):
             return A.shape[0] * A.shape[1] * B.shape[1]
 
     Let's assume we have three matrices
-    :math:`A_{10x100}, B_{100x5}, C_{5x50}$`.
+    :math:`A_{10x100}, B_{100x5}, C_{5x50}`.
 
     The costs for the two different parenthesizations are as follows::
 

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1155,7 +1155,7 @@ def bmat(obj, ldict=None, gdict=None):
     --------
     block :
         A generalization of this function for N-d arrays, that returns normal
-        `ndarray`s.
+        ndarrays.
 
     Examples
     --------

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1469,7 +1469,7 @@ cdef class RandomState:
         4
         >>> type(np.random.random_integers(5))
         <type 'int'>
-        >>> np.random.random_integers(5, size=(3.,2.))
+        >>> np.random.random_integers(5, size=(3,2))
         array([[5, 4],
                [3, 3],
                [4, 5]])
@@ -1951,7 +1951,7 @@ cdef class RandomState:
         --------
         Draw samples from the distribution:
 
-        >>> shape, scale = 2., 2. # mean=4, std=2*sqrt(2)
+        >>> shape, scale = 2., 2.  # mean=4, std=2*sqrt(2)
         >>> s = np.random.gamma(shape, scale, 1000)
 
         Display the histogram of the samples, along with


### PR DESCRIPTION
This fixes about 300 build warnings and prevents the pdf build from stopping before it's done.

Will backport to 1.13.x, because I'm building the 1.13.0 docs from this commit on top of the ``v1.13.0`` tag.