### PR TITLE
ENH: Release the GIL in einsum() special-cased loops

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -40,6 +40,13 @@ New Features
 Improvements
 ============
 
+GIL released for all ``np.einsum`` variations
+---------------------------------------------
+
+Some specific loop structures which have an accelerated loop version
+did not release the GIL prior to NumPy 1.14.0.  This oversight has been
+fixed.
+
 
 Changes
 =======

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2333,6 +2333,7 @@ unbuffered_loop_nop1_ndim2(NpyIter *iter)
     npy_intp coord, shape[2], strides[2][2];
     char *ptrs[2][2], *ptr;
     sum_of_products_fn sop;
+    NPY_BEGIN_THREADS_DEF;
 
 #if NPY_EINSUM_DBG_TRACING
     NpyIter_DebugPrint(iter);
@@ -2363,6 +2364,7 @@ unbuffered_loop_nop1_ndim2(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
+    NPY_BEGIN_THREADS;
     for (coord = shape[1]; coord > 0; --coord) {
         sop(1, ptrs[0], strides[0], shape[0]);
 
@@ -2371,6 +2373,7 @@ unbuffered_loop_nop1_ndim2(NpyIter *iter)
         ptr = ptrs[1][1] + strides[1][1];
         ptrs[0][1] = ptrs[1][1] = ptr;
     }
+    NPY_END_THREADS;
 
     return 0;
 }
@@ -2381,6 +2384,7 @@ unbuffered_loop_nop1_ndim3(NpyIter *iter)
     npy_intp coords[2], shape[3], strides[3][2];
     char *ptrs[3][2], *ptr;
     sum_of_products_fn sop;
+    NPY_BEGIN_THREADS_DEF;
 
 #if NPY_EINSUM_DBG_TRACING
     NpyIter_DebugPrint(iter);
@@ -2414,6 +2418,7 @@ unbuffered_loop_nop1_ndim3(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
+    NPY_BEGIN_THREADS;
     for (coords[1] = shape[2]; coords[1] > 0; --coords[1]) {
         for (coords[0] = shape[1]; coords[0] > 0; --coords[0]) {
             sop(1, ptrs[0], strides[0], shape[0]);
@@ -2428,6 +2433,7 @@ unbuffered_loop_nop1_ndim3(NpyIter *iter)
         ptr = ptrs[2][1] + strides[2][1];
         ptrs[0][1] = ptrs[1][1] = ptrs[2][1] = ptr;
     }
+    NPY_END_THREADS;
 
     return 0;
 }
@@ -2438,6 +2444,7 @@ unbuffered_loop_nop2_ndim2(NpyIter *iter)
     npy_intp coord, shape[2], strides[2][3];
     char *ptrs[2][3], *ptr;
     sum_of_products_fn sop;
+    NPY_BEGIN_THREADS_DEF;
 
 #if NPY_EINSUM_DBG_TRACING
     NpyIter_DebugPrint(iter);
@@ -2468,6 +2475,7 @@ unbuffered_loop_nop2_ndim2(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
+    NPY_BEGIN_THREADS;
     for (coord = shape[1]; coord > 0; --coord) {
         sop(2, ptrs[0], strides[0], shape[0]);
 
@@ -2478,6 +2486,7 @@ unbuffered_loop_nop2_ndim2(NpyIter *iter)
         ptr = ptrs[1][2] + strides[1][2];
         ptrs[0][2] = ptrs[1][2] = ptr;
     }
+    NPY_END_THREADS;
 
     return 0;
 }
@@ -2488,6 +2497,7 @@ unbuffered_loop_nop2_ndim3(NpyIter *iter)
     npy_intp coords[2], shape[3], strides[3][3];
     char *ptrs[3][3], *ptr;
     sum_of_products_fn sop;
+    NPY_BEGIN_THREADS_DEF;
 
 #if NPY_EINSUM_DBG_TRACING
     NpyIter_DebugPrint(iter);
@@ -2521,6 +2531,7 @@ unbuffered_loop_nop2_ndim3(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
+    NPY_BEGIN_THREADS;
     for (coords[1] = shape[2]; coords[1] > 0; --coords[1]) {
         for (coords[0] = shape[1]; coords[0] > 0; --coords[0]) {
             sop(2, ptrs[0], strides[0], shape[0]);
@@ -2539,6 +2550,7 @@ unbuffered_loop_nop2_ndim3(NpyIter *iter)
         ptr = ptrs[2][2] + strides[2][2];
         ptrs[0][2] = ptrs[1][2] = ptrs[2][2] = ptr;
     }
+    NPY_END_THREADS;
 
     return 0;
 }

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2364,7 +2364,7 @@ unbuffered_loop_nop1_ndim2(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
-    NPY_BEGIN_THREADS;
+    NPY_BEGIN_THREADS_THRESHOLDED(shape[1] * shape[0]);
     for (coord = shape[1]; coord > 0; --coord) {
         sop(1, ptrs[0], strides[0], shape[0]);
 
@@ -2418,7 +2418,7 @@ unbuffered_loop_nop1_ndim3(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
-    NPY_BEGIN_THREADS;
+    NPY_BEGIN_THREADS_THRESHOLDED(shape[2] * shape[1] * shape[0]);
     for (coords[1] = shape[2]; coords[1] > 0; --coords[1]) {
         for (coords[0] = shape[1]; coords[0] > 0; --coords[0]) {
             sop(1, ptrs[0], strides[0], shape[0]);
@@ -2475,7 +2475,7 @@ unbuffered_loop_nop2_ndim2(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
-    NPY_BEGIN_THREADS;
+    NPY_BEGIN_THREADS_THRESHOLDED(shape[1] * shape[0]);
     for (coord = shape[1]; coord > 0; --coord) {
         sop(2, ptrs[0], strides[0], shape[0]);
 
@@ -2531,7 +2531,7 @@ unbuffered_loop_nop2_ndim3(NpyIter *iter)
      * Since the iterator wasn't tracking coordinates, the
      * loop provided by the iterator is in Fortran-order.
      */
-    NPY_BEGIN_THREADS;
+    NPY_BEGIN_THREADS_THRESHOLDED(shape[2] * shape[1] * shape[0]);
     for (coords[1] = shape[2]; coords[1] > 0; --coords[1]) {
         for (coords[0] = shape[1]; coords[0] > 0; --coords[0]) {
             sop(2, ptrs[0], strides[0], shape[0]);


### PR DESCRIPTION
This does not only allow parallelization but also fixes issues where a background IO loop would suffer long wait times due to a large concurrent einsum() in another thread.