### PR TITLE
BUG: fix missing keyword rename for common block in numpy.f2py

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2013,7 +2013,7 @@ def analyzecommon(block):
                 if m.group('dims'):
                     dims = [x.strip()
                             for x in markoutercomma(m.group('dims')).split('@,@')]
-                n = m.group('name').strip()
+                n = rmbadname1(m.group('name').strip())
                 if n in block['vars']:
                     if 'attrspec' in block['vars'][n]:
                         block['vars'][n]['attrspec'].append(

--- a/numpy/f2py/tests/src/common/block.f
+++ b/numpy/f2py/tests/src/common/block.f
@@ -1,0 +1,11 @@
+      SUBROUTINE INITCB
+      DOUBLE PRECISION LONG
+      CHARACTER        STRING
+      INTEGER          OK
+    
+      COMMON  /BLOCK/ LONG, STRING, OK
+      LONG = 1.0
+      STRING = '2'
+      OK = 3
+      RETURN
+      END

--- a/numpy/f2py/tests/test_common.py
+++ b/numpy/f2py/tests/test_common.py
@@ -1,0 +1,26 @@
+from __future__ import division, absolute_import, print_function
+
+import os
+
+from numpy.testing import run_module_suite, assert_array_equal, dec
+import numpy as np
+import util
+
+
+def _path(*a):
+    return os.path.join(*((os.path.dirname(__file__),) + a))
+
+class TestCommonBlock(util.F2PyTest):
+    sources = [_path('src', 'common', 'block.f')]
+
+    def test_common_block(self):
+        self.module.initcb()
+        assert_array_equal(self.module.block.long_bn,
+                           np.array(1.0, dtype=np.float64))
+        assert_array_equal(self.module.block.string_bn,
+                           np.array('2', dtype='|S1'))
+        assert_array_equal(self.module.block.ok,
+                           np.array(3, dtype=np.int32))
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
A missing call to rmbadname1 in analyzecommon caused a look up of
common block variables with a name in the badnames list to fail
and the fall back of defaultimplicitrules to be used.
See ticket 9228.