### PR TITLE
Revert "DEP: Raise TypeError for subtract(bool_, bool_)."

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -822,11 +822,12 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
 
         /* The type resolver would have upcast already */
         if (out_dtypes[0]->type_num == NPY_BOOL) {
-            PyErr_Format(PyExc_TypeError,
-                "numpy boolean subtract, the `-` operator, is deprecated, "
-                "use the bitwise_xor, the `^` operator, or the logical_xor "
-                "function instead.");
-            return -1;
+            /* 2013-12-05, 1.9 */
+            if (DEPRECATE("numpy boolean subtract, the `-` operator, is "
+                          "deprecated, use the bitwise_xor, the `^` operator, "
+                          "or the logical_xor function instead.") < 0) {
+                return -1;
+            }
         }
         return ret;
     }

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -132,6 +132,24 @@ class _VisibleDeprecationTestCase(_DeprecationTestCase):
     warning_cls = np.VisibleDeprecationWarning
 
 
+class TestBooleanBinaryMinusDeprecation(_DeprecationTestCase):
+    """Test deprecation of binary boolean `-`. While + and * are well
+    defined, binary  - is not and even a corrected form seems to have
+    no real uses.
+
+    The deprecation process was started in NumPy 1.9.
+    """
+    message = r"numpy boolean subtract, the `-` operator, .*"
+
+    def test_operator_deprecation(self):
+        array = np.array([True])
+        generic = np.bool_(True)
+
+        # Minus operator/subtract ufunc:
+        self.assert_deprecated(operator.sub, args=(array, array))
+        self.assert_deprecated(operator.sub, args=(generic, generic))
+
+
 class TestRankDeprecation(_DeprecationTestCase):
     """Test that np.rank is deprecated. The function should simply be
     removed. The VisibleDeprecationWarning may become unnecessary.

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -577,12 +577,9 @@ class TestNegative(TestCase):
 
 
 class TestSubtract(TestCase):
-    def test_exceptions(self):
-        a = np.ones((), dtype=np.bool_)[()]
-        assert_raises(TypeError, operator.sub, a, a)
 
     def test_result(self):
-        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat'] + '?'
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
             for dt in types:

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1065,7 +1065,6 @@ class TestBool(TestCase):
         a = np.ones(1, dtype=np.bool_)
         assert_raises(TypeError, np.negative, a)
         assert_raises(TypeError, np.positive, a)
-        assert_raises(TypeError, np.subtract, a, a)
 
     def test_truth_table_logical(self):
         # 2, 3 and 4 serves as true values


### PR DESCRIPTION
This reverts commit c9adc35e68b92b10ab0b20069465fd784388bc14.

Don't raise `TypeError` for boolean subtraction in Numpy 1.13, see discussion at #9251.

Closes #9251. 