### PR TITLE
MAINT: Use XOR for bool arrays in `np.diff`

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1913,7 +1913,7 @@ def diff(a, n=1, axis=-1):
     slice2 = tuple(slice2)
 
     if a.dtype == np.bool_:
-        da = a[slice1] ^ a[slice2]
+        da = a[slice1] != a[slice2]
     else:
         da = a[slice1] - a[slice2]
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import collections
-import operator
 import re
 import sys
 import warnings
@@ -1912,10 +1911,16 @@ def diff(a, n=1, axis=-1):
     slice2[axis] = slice(None, -1)
     slice1 = tuple(slice1)
     slice2 = tuple(slice2)
-    if n > 1:
-        return diff(a[slice1]-a[slice2], n-1, axis=axis)
+
+    if a.dtype == np.bool_:
+        da = a[slice1] ^ a[slice2]
     else:
-        return a[slice1]-a[slice2]
+        da = a[slice1] - a[slice2]
+
+    if n > 1:
+        return diff(da, n-1, axis=axis)
+    else:
+        return da
 
 
 def interp(x, xp, fp, left=None, right=None, period=None):
@@ -2061,6 +2066,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         else:
             return interp_func(x, xp, fp, left, right).item()
 
+
 def angle(z, deg=0):
     """
     Return the angle of the complex argument.
@@ -2082,8 +2088,6 @@ def angle(z, deg=0):
     --------
     arctan2
     absolute
-
-
 
     Examples
     --------

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -638,6 +638,16 @@ class TestDiff(TestCase):
         assert_array_equal(diff(x, n=2), out2)
         assert_array_equal(diff(x, n=3), out3)
 
+        x = [1.1, 2.2, 3.0, -0.2, -0.1]
+        out = np.array([1.1, 0.8, -3.2, 0.1])
+        assert_almost_equal(diff(x), out)
+
+        x = [True, True, False, False]
+        out = np.array([False, True, False])
+        out2 = np.array([True, True])
+        assert_array_equal(diff(x), out)
+        assert_array_equal(diff(x, n=2), out2)
+
     def test_nd(self):
         x = 20 * rand(10, 20, 30)
         out1 = x[:, :, 1:] - x[:, :, :-1]
@@ -927,7 +937,7 @@ class TestGradient(TestCase):
         assert_raises(ValueError, gradient, np.arange(0), edge_order=2)
         assert_raises(ValueError, gradient, np.arange(1), edge_order=1)
         assert_raises(ValueError, gradient, np.arange(1), edge_order=2)
-        assert_raises(ValueError, gradient, np.arange(2), edge_order=2)  
+        assert_raises(ValueError, gradient, np.arange(2), edge_order=2)
 
 
 class TestAngle(TestCase):


### PR DESCRIPTION
The binary `-` operator is no longer supported for booleans. Use xor instead to maintain backwards compatibility.

Added some tests for this case, and also for float.

Closes https://github.com/numpy/numpy/issues/9251.