### PR TITLE
BUG: don't elide into readonly and updateifcopy temporaries

### DIFF
--- a/numpy/core/src/multiarray/temp_elide.c
+++ b/numpy/core/src/multiarray/temp_elide.c
@@ -285,6 +285,8 @@ can_elide_temp(PyArrayObject * alhs, PyObject * orhs, int * cannot)
     if (Py_REFCNT(alhs) != 1 || !PyArray_CheckExact(alhs) ||
             PyArray_DESCR(alhs)->type_num >= NPY_OBJECT ||
             !(PyArray_FLAGS(alhs) & NPY_ARRAY_OWNDATA) ||
+            !PyArray_ISWRITEABLE(alhs) ||
+            PyArray_CHKFLAGS(alhs, NPY_ARRAY_UPDATEIFCOPY) ||
             PyArray_NBYTES(alhs) < NPY_MIN_ELIDE_BYTES) {
         return 0;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3151,6 +3151,17 @@ class TestTemporaryElide(TestCase):
         a = np.bool_()
         assert_(type(~(a & a)) is np.bool_)
 
+    def test_elide_readonly(self):
+        # don't try to elide readonly temporaries
+        r = np.asarray(np.broadcast_to(np.zeros(1), 100000).flat) * 0.0
+        assert_equal(r, 0)
+
+    def test_elide_updateifcopy(self):
+        a = np.ones(2**20)[::2]
+        b = a.flat.__array__() + 1
+        del b
+        assert_equal(a, 1)
+
 
 class TestCAPI(TestCase):
     def test_IsPythonScalar(self):


### PR DESCRIPTION
Closes gh-9232, gh-9245