### PR TITLE
BUG: handle resize of 0d array

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4314,6 +4314,18 @@ class TestResize(TestCase):
         x.resize()
         assert_array_equal(x, np.eye(3))
 
+    def test_0d_shape(self):
+        # to it multiple times to test it does not break alloc cache gh-9216
+        for i in range(10):
+            x = np.empty((1,))
+            x.resize(())
+            assert_equal(x.shape, ())
+            assert_equal(x.size, 1)
+            x = np.empty(())
+            x.resize((1,))
+            assert_equal(x.shape, (1,))
+            assert_equal(x.size, 1)
+
     def test_invalid_arguments(self):
         self.assertRaises(TypeError, np.eye(3).resize, 'hi')
         self.assertRaises(ValueError, np.eye(3).resize, -1)


### PR DESCRIPTION
Backport of #9217.

Empty arrays have NULL for stride and dimension, PyArray_Resize assigns
it a valid pointer from RENEW which when passed back to the allocation
cache does not have the minimum size of 16 bytes it requires leading to
out of bound accesses.

Closes gh-9216