### PR TITLE
ENH: testing: load available nose plugins that are external to nose

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -36,6 +36,13 @@ C API changes
 New Features
 ============
 
+`numpy.testing.Tester` is now aware of ``nose`` plugins that are outside the
+built-in ones in ``nose``.  This allows using for example ``nose-timer`` like
+so:  ``np.test(extra_argv=['--with-timer', '--timer-top-n', '20'])`` to
+obtain the runtime of the 20 slowest tests.  An extra keyword ``timer`` was
+also added to ``Tester.test``, so ``np.test(timer=20)`` will also report the 20
+slowest tests.
+
 
 Improvements
 ============

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -254,7 +254,7 @@ class NoseTester(object):
         return NumpyDoctest()
 
     def prepare_test_args(self, label='fast', verbose=1, extra_argv=None,
-                          doctests=False, coverage=False):
+                          doctests=False, coverage=False, timer=False):
         """
         Run tests for module using nose.
 
@@ -274,6 +274,12 @@ class NoseTester(object):
         if coverage:
             argv += ['--cover-package=%s' % self.package_name, '--with-coverage',
                    '--cover-tests', '--cover-erase']
+
+        if timer:
+            if timer is True:
+                argv += ['--with-timer']
+            elif isinstance(timer, int):
+                argv += ['--with-timer', '--timer-top-n', str(timer)]
 
         # construct list of plugins
         import nose.plugins.builtin
@@ -308,7 +314,8 @@ class NoseTester(object):
         return argv, plugins
 
     def test(self, label='fast', verbose=1, extra_argv=None,
-             doctests=False, coverage=False, raise_warnings=None):
+             doctests=False, coverage=False, raise_warnings=None,
+             timer=False):
         """
         Run tests for module using nose.
 
@@ -342,6 +349,11 @@ class NoseTester(object):
               - "release" : equals ``()``, don't raise on any warnings.
 
             The default is to use the class initialization value.
+        timer : bool or int, optional
+            Timing of individual tests with ``nose-timer`` (which needs to be
+            installed).  If True, time tests and report on all of them.
+            If an integer (say ``N``), report timing results for ``N`` slowest
+            tests.
 
         Returns
         -------
@@ -448,7 +460,7 @@ class NoseTester(object):
             from .noseclasses import NumpyTestProgram
 
             argv, plugins = self.prepare_test_args(
-                    label, verbose, extra_argv, doctests, coverage)
+                    label, verbose, extra_argv, doctests, coverage, timer)
 
             t = NumpyTestProgram(argv=argv, exit=False, plugins=plugins)
 

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -274,11 +274,22 @@ class NoseTester(object):
         if coverage:
             argv += ['--cover-package=%s' % self.package_name, '--with-coverage',
                    '--cover-tests', '--cover-erase']
+
         # construct list of plugins
         import nose.plugins.builtin
+        from nose.plugins import EntryPointPluginManager
         from .noseclasses import KnownFailurePlugin, Unplugger
         plugins = [KnownFailurePlugin()]
         plugins += [p() for p in nose.plugins.builtin.plugins]
+        try:
+            # External plugins (like nose-timer)
+            entrypoint_manager = EntryPointPluginManager()
+            entrypoint_manager.loadPlugins()
+            plugins += [p for p in entrypoint_manager.plugins]
+        except ImportError:
+            # Relies on pkg_resources, not a hard dependency
+            pass
+
         # add doctesting if required
         doctest_argv = '--with-doctest' in argv
         if doctests == False and doctest_argv:

--- a/runtests.py
+++ b/runtests.py
@@ -13,6 +13,7 @@ Examples::
     $ python runtests.py --ipython
     $ python runtests.py --python somescript.py
     $ python runtests.py --bench
+    $ python runtests.py --timer 20
 
 Run a debugger:
 
@@ -77,6 +78,8 @@ def main(argv):
     parser.add_argument("--coverage", action="store_true", default=False,
                         help=("report coverage of project code. HTML output goes "
                               "under build/coverage"))
+    parser.add_argument("--timer", action="store", default=0, type=int,
+                        help=("Time N slowest test"))
     parser.add_argument("--gcov", action="store_true", default=False,
                         help=("enable C code coverage via gcov (requires GCC). "
                               "gcov output goes to build/**/*.gc*"))
@@ -116,6 +119,16 @@ def main(argv):
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
     args = parser.parse_args(argv)
+
+    if args.timer == 0:
+        timer = False
+    elif args.timer == -1:
+        timer = True
+    elif args.timer > 0:
+        timer = int(args.timer)
+    else:
+        raise ValueError("--timer value should be an integer, -1 or >0")
+    args.timer = timer
 
     if args.bench_compare:
         args.bench = True
@@ -293,7 +306,8 @@ def main(argv):
                       extra_argv=extra_argv,
                       doctests=args.doctests,
                       raise_warnings=args.raise_warnings,
-                      coverage=args.coverage)
+                      coverage=args.coverage,
+                      timer=args.timer)
     finally:
         os.chdir(cwd)
 


### PR DESCRIPTION
Motivation is to be able to use ``nose-timer`` within the ``test()`` function.
Try (after installing ``nose-timer``):

    np.test(extra_argv=['--with-timer', '--timer-top-n', '20'])

Should give output like:

    [success] 7.02% test_multiarray.TestIO.test_largish_file: 2.1172s
    [success] 4.28% test_callback.TestF77Callback.test_string_callback: 1.2911s
    [success] 3.54% test_umath.TestAbsoluteNegative.test_abs_neg_blocked: 1.0663s
    [success] 3.28% test_memmap.TestMemmap.test_filename: 0.9892s
    [success] 3.09% test_mem_overlap.TestUFunc.test_unary_gufunc_fuzz: 0.9312s
    [success] 2.99% test_common.TestCommonBlock.test_common_block: 0.9019s
    ...

