### PR TITLE
ENH: Refactor updateifcopy

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -381,6 +381,21 @@ add_newdoc('numpy.core', 'nditer',
         >>> luf(lambda i,j:i*i + j/2, a, b)
         array([  0.5,   1.5,   4.5,   9.5,  16.5])
 
+    If operand flags such as "updateifcopy" or "readwrite" are used, or in
+    other edge cases, the operands may be views into the original data with the
+    UPDATEIFCOPY flag. In this case it is important to use the nditer as a
+    context manager. The temporary data will be written back to the original
+    data when the context manager's __exit__ function is called::
+
+        >>> a = np.arange(6, dtype='i4')[::-2]
+        >>> with nditer(a, [],
+        ...        [['writeonly', 'updateifcopy']],
+        ...        casting='unsafe',
+        ...        op_dtypes=[np.dtype('f4')]) as i:
+        ...    i.operands[0][:] = [-1, -2, -3]
+        >>> a
+        array([-1, -2, -3])
+
     """)
 
 # nditer methods

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -36,5 +36,5 @@
 0x0000000a = 9b8bce614655d3eb02acddcb508203cb
 
 # Version 11 (NumPy 1.13) Added PyArray_MapIterArrayCopyIfOverlap
-# Version 11 (NumPy 1.14) No Change
+# Version 11 (NumPy 1.14) Added PyArray_ResolveUpdateIfCopy
 0x0000000b = edb1ba83730c650fd9bc5772a919cda7

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -346,6 +346,8 @@ multiarray_funcs_api = {
     # End 1.10 API
     'PyArray_MapIterArrayCopyIfOverlap':    (301,),
     # End 1.13 API
+    'PyArray_ResolveUpdateIfCopy':    (302,),
+    # End 1.14 API
 }
 
 ufunc_types_api = {

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1027,6 +1027,8 @@ typedef void (NpyIter_GetMultiIndexFunc)(NpyIter *iter,
  * eliminate overlap.
  */
 #define NPY_ITER_COPY_IF_OVERLAP            0x00002000
+/* At least one operand uses UPDATEIFCOPY semantics, use context manager */
+#define NPY_ITER_USE_CONTEXT_MANAGER        0x00004000
 
 /*** Per-operand flags that may be passed to the iterator constructors ***/
 

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -136,6 +136,7 @@ PyArray_ArgMax(PyArrayObject *op, int axis, PyArrayObject *out)
     Py_DECREF(ap);
     /* Trigger the UPDATEIFCOPY if necessary */
     if (out != NULL && out != rp) {
+        PyArray_ResolveUpdateIfCopy(rp);
         Py_DECREF(rp);
         rp = out;
         Py_INCREF(rp);
@@ -251,6 +252,7 @@ PyArray_ArgMin(PyArrayObject *op, int axis, PyArrayObject *out)
     Py_DECREF(ap);
     /* Trigger the UPDATEIFCOPY if necessary */
     if (out != NULL && out != rp) {
+        PyArray_ResolveUpdateIfCopy(rp);
         Py_DECREF(rp);
         rp = out;
         Py_INCREF(rp);
@@ -1153,6 +1155,7 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
     Py_XDECREF(maxa);
     Py_DECREF(newin);
     /* Copy back into out if out was not already a nice array. */
+    PyArray_ResolveUpdateIfCopy(newout);
     Py_DECREF(newout);
     return (PyObject *)out;
 

--- a/numpy/core/src/multiarray/cblasfuncs.c
+++ b/numpy/core/src/multiarray/cblasfuncs.c
@@ -770,6 +770,7 @@ cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
     Py_DECREF(ap2);
 
     /* Trigger possible copyback into `result` */
+    PyArray_ResolveUpdateIfCopy(out_buf);
     Py_DECREF(out_buf);
 
     return PyArray_Return(result);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -401,6 +401,7 @@ arr_insert(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
     Py_XDECREF(values);
     Py_XDECREF(mask);
+    PyArray_ResolveUpdateIfCopy(array);
     Py_DECREF(array);
     Py_RETURN_NONE;
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1801,6 +1801,7 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
         }
         else {
             ret = (PyArrayObject *)PyArray_FromArray(arr, newtype, flags);
+            PyArray_ResolveUpdateIfCopy(arr); /* prevent spurious warnings */
             Py_DECREF(arr);
         }
     }

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -234,6 +234,7 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
     Py_XDECREF(self);
     if (out != NULL && out != obj) {
         Py_INCREF(out);
+        PyArray_ResolveUpdateIfCopy(obj);
         Py_DECREF(obj);
         obj = out;
     }
@@ -406,6 +407,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
     Py_XDECREF(values);
     Py_XDECREF(indices);
     if (copied) {
+        PyArray_ResolveUpdateIfCopy(self);
         Py_DECREF(self);
     }
     Py_RETURN_NONE;
@@ -523,6 +525,7 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
     Py_XDECREF(values);
     Py_XDECREF(mask);
     if (copied) {
+        PyArray_ResolveUpdateIfCopy(self);
         Py_DECREF(self);
     }
     Py_RETURN_NONE;
@@ -768,6 +771,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     PyDataMem_FREE(mps);
     if (out != NULL && out != obj) {
         Py_INCREF(out);
+        PyArray_ResolveUpdateIfCopy(obj);
         Py_DECREF(obj);
         obj = out;
     }

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1151,6 +1151,7 @@ iter_richcompare(PyArrayIterObject *self, PyObject *other, int cmp_op)
         return NULL;
     }
     ret = array_richcompare(new, other, cmp_op);
+    PyArray_ResolveUpdateIfCopy(new);
     Py_DECREF(new);
     return ret;
 }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1062,6 +1062,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     Py_DECREF(ap2);
 
     /* Trigger possible copy-back into `result` */
+    PyArray_ResolveUpdateIfCopy(out_buf);
     Py_DECREF(out_buf);
 
     return (PyObject *)result;

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2927,6 +2927,7 @@ npyiter_allocate_arrays(NpyIter *iter,
                     Py_DECREF(temp);
                     return 0;
                 }
+                op_flags[iop] |= NPY_ITER_USE_CONTEXT_MANAGER;
             }
 
             Py_DECREF(op[iop]);

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -24,6 +24,13 @@ struct NewNpyArrayIterObject_tag {
     NpyIter *iter;
     /* Flag indicating iteration started/stopped */
     char started, finished;
+    /* inside context manager
+       0 == NO, not needed 
+       1 == YES
+       2 == needed, (UPDATEIFCOPY flag is true). If this value is
+            reached and nditer API function called, fail on PyPy
+       3 == YES, and needed, all is good*/
+    char managed;
     /* Child to update for nested iteration */
     NewNpyArrayIterObject *nested_child;
     /* Cached values from the iterator */
@@ -710,6 +717,12 @@ npyiter_convert_ops(PyObject *op_in, PyObject *op_flags_in,
                 *nop_out = 0;
                 return 0;
             }
+            {
+                PyArrayObject_fields * fa = (PyArrayObject_fields*)ao;
+                if (fa->base && (fa->flags & NPY_ARRAY_UPDATEIFCOPY)) {
+                    op_flags[iop] |= NPY_ITER_USE_CONTEXT_MANAGER;
+                }
+            }
             Py_DECREF(op[iop]);
             op[iop] = ao;
         }
@@ -769,6 +782,13 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     if (npyiter_convert_ops(op_in, op_flags_in, op, op_flags, &nop)
                                                         != 1) {
         goto fail;
+    }
+
+    self->managed = 0;
+    for (iop = 0; iop < nop; ++iop) {
+        if (op_flags[iop] & NPY_ITER_USE_CONTEXT_MANAGER)
+            self->managed |= 2; /* context manager recommended/required */
+        op_flags[iop] &= ~NPY_ITER_USE_CONTEXT_MANAGER;
     }
 
     /* op_request_dtypes */
@@ -1063,6 +1083,14 @@ NpyIter_NestedIters(PyObject *NPY_UNUSED(self),
             Py_DECREF(ret);
             goto fail;
         }
+#ifdef PYPY_VERSION
+        if (iter->managed == 2)
+        {
+            PyErr_SetString(PyExc_ValueError,
+                    "'updateifcopy/copy' not supported on PyPy");
+            goto fail;
+        }
+#endif
 
         if (inest < nnest-1) {
             iter->iter = NpyIter_AdvancedNew(nop, op, flags, order,
@@ -1404,7 +1432,13 @@ static PyObject *npyiter_value_get(NewNpyArrayIterObject *self)
                 "Iterator is past the end");
         return NULL;
     }
-
+#ifdef PYPY_VERSION
+    if (self->managed == 2) {
+        PyErr_SetString(PyExc_ValueError,
+        "'updateifcopy', 'readwrite' flags must be used in a context manager");
+        return NULL;
+    }
+#endif
     nop = NpyIter_GetNOp(self->iter);
 
     /* Return an array  or tuple of arrays with the values */
@@ -1441,7 +1475,14 @@ static PyObject *npyiter_operands_get(NewNpyArrayIterObject *self)
                 "Iterator is invalid");
         return NULL;
     }
-
+#ifdef PYPY_VERSION
+    if (self->managed == 2) {
+        PyErr_SetString(PyExc_ValueError,
+        "'updateifcopy', 'readwrite' flags must be used in a context manager");
+        return NULL;
+    }
+#endif
+ 
     nop = NpyIter_GetNOp(self->iter);
     operands = self->operands;
 
@@ -2337,6 +2378,7 @@ npyiter_self(NewNpyArrayIterObject *self)
         PyErr_SetString(PyExc_ValueError, "operation on  non-initialized iterator");
         return NULL;
     }
+    self->managed &= 1;
     Py_INCREF(self);
     return (PyObject *)self;
 }

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2378,17 +2378,17 @@ npyiter_self(NewNpyArrayIterObject *self)
         PyErr_SetString(PyExc_ValueError, "operation on  non-initialized iterator");
         return NULL;
     }
-    self->managed &= 1;
+    self->managed |= 1;
     Py_INCREF(self);
     return (PyObject *)self;
 }
 
 static PyObject *
-npyiter_exit(PyObject *f, PyObject *args)
+npyiter_exit(PyObject *self, PyObject *args)
 {
     int iop, nop;
     PyArrayObject **object;
-    NpyIter *iter = ((NewNpyArrayIterObject*)f)->iter;
+    NpyIter *iter = ((NewNpyArrayIterObject*)self)->iter;
     if (iter == NULL)
         Py_RETURN_NONE;
     nop = NpyIter_GetNOp(iter);
@@ -2397,9 +2397,6 @@ npyiter_exit(PyObject *f, PyObject *args)
         if (PyArray_ResolveUpdateIfCopy(*object) < 0)
         return NULL;
     }
-    /* We cannot return the result since a true
-     * value will be interpreted as "yes, swallow the
-     * exception if one was raised inside the with block". */
     Py_RETURN_NONE;
 }
 

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -598,6 +598,7 @@ finish:
         }
     }
     else {
+        PyArray_ResolveUpdateIfCopy(result); /* prevent spurious warnings */
         Py_DECREF(result);
         result = out;
         Py_INCREF(result);
@@ -606,6 +607,7 @@ finish:
     return result;
 
 fail:
+    PyArray_ResolveUpdateIfCopy(result); /* prevent spurious warnings */
     Py_XDECREF(result);
     Py_XDECREF(op_view);
     if (iter != NULL) {

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -53,7 +53,7 @@ class TestTake(TestCase):
         for mode in ('raise', 'clip', 'wrap'):
             a = np.array(objects)
             b = np.array([2, 2, 4, 5, 3, 5])
-            a.take(b, out=a[:6])
+            a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:
                 assert_(all(sys.getrefcount(o) == 3 for o in objects))

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2348,7 +2348,9 @@ def test_iter_nested_iters_dtype_copy():
         for y in j:
             y[...] += 1
     assert_equal(a, [[0, 1, 2], [3, 4, 5]])
-    i, j, x, y = (None,)*4  # force the updateifcopy
+    # force resolution of UPDATEIFCOPY
+    i.__exit__()
+    j.__exit__()
     assert_equal(a, [[1, 2, 3], [4, 5, 6]])
 
 def test_iter_nested_iters_dtype_buffered():

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -786,7 +786,7 @@ def test_iter_nbo_align_contig():
     assert_equal(i.operands[0].dtype.byteorder, a.dtype.byteorder)
     assert_equal(i.operands[0], a)
     i.operands[0][:] = 2
-    i = None
+    i = None # triggers UPDATEIFCOPY on i.operands
     assert_equal(au, [2]*6)
 
     # Byte order change by requesting NBO
@@ -798,7 +798,7 @@ def test_iter_nbo_align_contig():
     assert_equal(i.operands[0].dtype.byteorder, a.dtype.byteorder)
     assert_equal(i.operands[0], a)
     i.operands[0][:] = 2
-    i = None
+    i = None # triggers UPDATEIFCOPY on i.operands
     assert_equal(au, [2]*6)
 
     # Unaligned input
@@ -815,7 +815,7 @@ def test_iter_nbo_align_contig():
     assert_(i.operands[0].flags.aligned)
     assert_equal(i.operands[0], a)
     i.operands[0][:] = 3
-    i = None
+    i = None # triggers UPDATEIFCOPY on i.operands
     assert_equal(a, [3]*6)
 
     # Discontiguous input
@@ -878,7 +878,7 @@ def test_iter_array_cast():
     # Check that UPDATEIFCOPY is activated
     i.operands[0][2, 1, 1] = -12.5
     assert_(a[2, 1, 1] != -12.5)
-    i = None
+    i = None # triggers UPDATEIFCOPY on i.operands
     assert_equal(a[2, 1, 1], -12.5)
 
     a = np.arange(6, dtype='i4')[::-2]
@@ -891,7 +891,7 @@ def test_iter_array_cast():
     # becomes positive in the temporary
     assert_equal(i.operands[0].strides, (4,))
     i.operands[0][:] = [1, 2, 3]
-    i = None
+    i = None # triggers UPDATEIFCOPY on i.operands
     assert_equal(a, [1, 2, 3])
 
 def test_iter_array_cast_errors():


### PR DESCRIPTION
Fixes issue #7054 by refactoring the resolution of ``UPDATEIFCOPY`` into a new private API function ``PyArray_ResolveUpdateIfCopy``. Add a call to the function wherever a temporary ``ndarray`` with that flag is created, and added tests for calls that exercise the new function. 

In the second commit I made nditer into a context manager, where ``PyArray_ResolveUpdateIfCopy`` is called on ``__exit__()``, and updated the nditer tests to use the context manager wherever the ``updateifcopy`` flag is used.

The third commit 4effdfb makes sure ``clip`` is called with a ``mode`` keyword, which seems to have been forgotten.

The last commit f012769 explicitly uses the ``__exit__`` method to resolve ``updateifcopy`` for iterators created with ``nested_iters``, how can I make this look nicer?