### PR TITLE
BUG: fix issue when using ``python setup.py somecommand --force``.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -362,6 +362,7 @@ def setup_package():
 
     if "--force" in sys.argv:
         run_build = True
+        sys.argv.remove('--force')
     else:
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = parse_setuppy_commands()


### PR DESCRIPTION
[ci skip]

Grr. I'm sure this used to work when I implemented it. ``setuptools`` must have gotten more strict.