### PR TITLE
BUG: Use sensible default for rcond in np.linalg.lstsq

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1810,7 +1810,7 @@ def det(a):
 
 # Linear Least Squares
 
-def lstsq(a, b, rcond=-1):
+def lstsq(a, b, rcond=None):
     """
     Return the least-squares solution to a linear matrix equation.
 
@@ -1909,6 +1909,8 @@ def lstsq(a, b, rcond=-1):
     if m != b.shape[0]:
         raise LinAlgError('Incompatible dimensions')
     t, result_t = _commonType(a, b)
+    if rcond is None:
+        rcond = finfo(t).eps*ldb
     result_real_t = _realType(result_t)
     real_t = _linalgRealType(t)
     bstar = zeros((ldb, n_rhs), t)


### PR DESCRIPTION
The current default for `np.linalg.lstsq(A, b)` is `rcond=-1`. This implies that `dgelsd` in LAPACK uses the machine precision as threshold for editing the singular values (see [dgelsd documentation](http://www.netlib.org/lapack/explore-html/db/d6a/dgelsd_8f.html)), regardless of the values in the matrix `A`. 

The result is that in most realistic situations, when `A` is nearly rank deficient, the nearly zero singular values will not be edited and both the effective rank of `A` will be incorrect and the solution of the linear least-squares problem will be degenerate.

A proper default has to take the values of `A` into account. This can be achieved as `rcond=eps*max(A.shape)`. Note that this value will be multiplied internally by the largest singular value of `A` within `dgelsd`.

The proposed default for `np.linalg.lstsq` is the same already adopted, for the same reasons, e.g. by the related `np.linalg.matrix_rank` and by `scipy.linalg.lstsq`.

This is related to issue #8740 