### PR TITLE
BUG: Fix Intel compilation on Unix.

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -80,6 +80,7 @@ def _needs_build(obj, cc_args, extra_postargs, pp_opts):
 
     return False
 
+
 def replace_method(klass, method_name, func):
     if sys.version_info[0] < 3:
         m = types.MethodType(func, None, klass)
@@ -87,6 +88,25 @@ def replace_method(klass, method_name, func):
         # Py3k does not have unbound method anymore, MethodType does not work
         m = lambda self, *args, **kw: func(self, *args, **kw)
     setattr(klass, method_name, m)
+
+
+######################################################################
+## Method that subclasses may redefine. But don't call this method,
+## it i private to CCompiler class and may return unexpected
+## results if used elsewhere. So, you have been warned..
+
+def CCompiler_find_executables(self):
+    """
+    Does nothing here, but is called by the get_version method and can be
+    overridden by subclasses. In particular it is redefined in the `FCompiler`
+    class where more documentation can be found.
+
+    """
+    pass
+
+
+replace_method(CCompiler, 'find_executables', CCompiler_find_executables)
+
 
 # Using customized CCompiler.spawn.
 def CCompiler_spawn(self, cmd, display=None):

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -57,7 +57,7 @@ class IntelFCompiler(BaseIntelFCompiler):
 
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
-        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
+        mpopt = 'openmp' if v and v < '15' else 'qopenmp'
         return ['-xhost -fp-model strict -O1 -{}'.format(mpopt)]
 
     def get_flags_arch(self):
@@ -123,7 +123,7 @@ class IntelEM64TFCompiler(IntelFCompiler):
 
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
-        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
+        mpopt = 'openmp' if v and v < '15' else 'qopenmp'
         return ['-fp-model strict -O1 -{}'.format(mpopt)]
 
     def get_flags_arch(self):

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -19,7 +19,7 @@ class IntelCCompiler(UnixCCompiler):
         UnixCCompiler.__init__(self, verbose, dry_run, force)
 
         v = self.get_version()
-        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
+        mpopt = 'openmp' if v and v < '15' else 'qopenmp'
         self.cc_exe = ('icc -fPIC -fp-model strict -O3 '
                        '-fomit-frame-pointer -{}').format(mpopt)
         compiler = self.cc_exe
@@ -59,7 +59,7 @@ class IntelEM64TCCompiler(UnixCCompiler):
         UnixCCompiler.__init__(self, verbose, dry_run, force)
 
         v = self.get_version()
-        mpopt = 'openmp' if v and int(v.split('.')[0]) < 15 else 'qopenmp'
+        mpopt = 'openmp' if v and v < '15' else 'qopenmp'
         self.cc_exe = ('icc -m64 -fPIC -fp-model strict -O3 '
                        '-fomit-frame-pointer -{}').format(mpopt)
         compiler = self.cc_exe


### PR DESCRIPTION
Fixes two problems:

* c compilers do not have a find_executables method.
* get_version return a LooseVersion instance, not string.

Closes #9278.