### PR TITLE
BUG: Fixes histogram monotonicity check for unsigned bin values

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -782,7 +782,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         bins = bin_edges
     else:
         bins = asarray(bins)
-        if (np.diff(bins) < 0).any():
+        if not np.all(bins[1:] > bins[:-1]):
             raise ValueError(
                 'bins must increase monotonically.')
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -782,7 +782,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         bins = bin_edges
     else:
         bins = asarray(bins)
-        if np.any(bins[1:] <= bins[:-1]):
+        if np.any(bins[:-1] > bins[1:]):
             raise ValueError(
                 'bins must increase monotonically.')
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -782,7 +782,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         bins = bin_edges
     else:
         bins = asarray(bins)
-        if not np.all(bins[1:] > bins[:-1]):
+        if np.any(bins[1:] <= bins[:-1]):
             raise ValueError(
                 'bins must increase monotonically.')
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1771,6 +1771,14 @@ class TestHistogram(TestCase):
         hist, edges = np.histogram(arr, bins=30, range=(-0.5, 5))
         self.assertEqual(hist[-1], 1)
 
+    def test_unsigned_monotonicity_check(self):
+        # Ensures ValueError is raised if bins not increasing monotonically
+        # when bins contain unsigned values (see #9222)
+        arr = np.array([2])
+        bins = np.array([1, 3, 1], dtype='uint64')
+        with assert_raises(ValueError):
+            hist, edges = np.histogram(arr, bins=bins)
+
 
 class TestHistogramOptimBinNums(TestCase):
     """


### PR DESCRIPTION
Add test and fix the monotonicity check to support unsigned bin values, see #9222.