### PR TITLE
DOC: added note to docstring of numpy.savez

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -480,7 +480,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     file : file, str, or pathlib.Path
         File or filename to which the data is saved.  If file is a file-object,
         then the filename is unchanged.  If file is a string or Path, a ``.npy``
-        extension will be appended to the file name if it does not already
+        extension will be appended to the filename if it does not already
         have one.
     arr : array_like
         Array data to be saved.
@@ -575,9 +575,9 @@ def savez(file, *args, **kwds):
     Parameters
     ----------
     file : str or file
-        Either the file name (string) or an open file (file-like object)
+        Either the filename (string) or an open file (file-like object)
         where the data will be saved. If file is a string or a Path, the
-        ``.npz`` extension will be appended to the file name if it is not
+        ``.npz`` extension will be appended to the filename if it is not
         already there.
     args : Arguments, optional
         Arrays to save to the file. Since it is not possible for Python to
@@ -610,7 +610,7 @@ def savez(file, *args, **kwds):
     its list of arrays (with the ``.files`` attribute), and for the arrays
     themselves.
 
-    When saving dictionaries, the dictionary keys become file names
+    When saving dictionaries, the dictionary keys become filenames
     inside the ZIP archive. Therefore, keys should be valid filenames.
     E.g., avoid keys that begin with ``/`` or contain ``.``.
 
@@ -658,15 +658,15 @@ def savez_compressed(file, *args, **kwds):
     Save several arrays into a single file in compressed ``.npz`` format.
 
     If keyword arguments are given, then filenames are taken from the keywords.
-    If arguments are passed in with no keywords, then stored file names are
+    If arguments are passed in with no keywords, then stored filenames are
     arr_0, arr_1, etc.
 
     Parameters
     ----------
     file : str or file
-        Either the file name (string) or an open file (file-like object)
+        Either the filename (string) or an open file (file-like object)
         where the data will be saved. If file is a string or a Path, the
-        ``.npz`` extension will be appended to the file name if it is not
+        ``.npz`` extension will be appended to the filename if it is not
         already there.
     args : Arguments, optional
         Arrays to save to the file. Since it is not possible for Python to
@@ -1471,7 +1471,7 @@ def fromregex(file, regexp, dtype, encoding=None):
     Parameters
     ----------
     file : str or file
-        File name or file object to read.
+        Filename or file object to read.
     regexp : str or regexp
         Regular expression used to parse the file.
         Groups in the regular expression correspond to fields in the dtype.

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -506,9 +506,9 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Notes
     -----
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
-        
-    Any data saved to the file is appended to the end of the file. 
-    
+
+    Any data saved to the file is appended to the end of the file.
+
     Examples
     --------
     >>> from tempfile import TemporaryFile
@@ -524,7 +524,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
 
     >>> with open('test.npy', 'wb') as f:
     ...     np.save(f, np.array([1, 2]))
-    ...     np.save(f, np.array([1, 3]))    
+    ...     np.save(f, np.array([1, 3]))
     >>> with open('test.npy', 'rb') as f:
     ...     a = np.load(f)
     ...     b = np.load(f)
@@ -565,8 +565,7 @@ def _savez_dispatcher(file, *args, **kwds):
 
 @array_function_dispatch(_savez_dispatcher)
 def savez(file, *args, **kwds):
-    """
-    Save several arrays into a single file in uncompressed ``.npz`` format.
+    """Save several arrays into a single file in uncompressed ``.npz`` format.
 
     If arguments are passed in with no keywords, the corresponding variable
     names, in the ``.npz`` file, are 'arr_0', 'arr_1', etc. If keyword
@@ -611,19 +610,9 @@ def savez(file, *args, **kwds):
     its list of arrays (with the ``.files`` attribute), and for the arrays
     themselves.
 
-    When saving dictionaries, the dictionary keys themselves are stored
-    as zip files under the zip directory. Therefore to avoid unintended
-    changes to the keys, one should avoid using key strings that are not
-    valid file names.
-
-    Examples include strings that begin with "/", or contain ".." or 
-    "./", such as '/test/tmp.txt', './test/tmp.txt', or 
-    'test/../tmp.txt'
-
-    Should keys that include such patterns be required, they must be 
-    properly encapsulated and or escaped using either double quotes or
-    backslashes where necessary. Note that backslashes will be 
-    doubled in the returned keys.
+    When saving dictionaries, the dictionary keys become file names
+    inside the ZIP archive. Therefore, keys should be valid filenames.
+    E.g., avoid keys that begin with ``/`` or contain ``.``.
 
     Examples
     --------
@@ -652,7 +641,6 @@ def savez(file, *args, **kwds):
     ['x', 'y']
     >>> npzfile['x']
     array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-
     """
     _savez(file, args, kwds, False)
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -611,10 +611,19 @@ def savez(file, *args, **kwds):
     its list of arrays (with the ``.files`` attribute), and for the arrays
     themselves.
 
-    When saving dictionaries, avoid using keys that begin with "/", as the
-    first slash will be removed by the python archive function. If they 
-    must be used, prepend another character ahead of the slash to ensure
-    that the "/" will not be removed.
+    When saving dictionaries, the dictionary keys themselves are stored
+    as zip files under the zip directory. Therefore to avoid unintended
+    changes to the keys, one should avoid using key strings that are not
+    valid file names.
+
+    Examples include strings that begin with "/", or contain ".." or 
+    "./", such as '/test/tmp.txt', './test/tmp.txt', or 
+    'test/../tmp.txt'
+
+    Should keys that include such patterns be required, they must be 
+    properly encapsulated and or escaped using either double quotes or
+    backslashes where necessary. Note that backslashes will be 
+    doubled in the returned keys.
 
     Examples
     --------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -611,6 +611,11 @@ def savez(file, *args, **kwds):
     its list of arrays (with the ``.files`` attribute), and for the arrays
     themselves.
 
+    When saving dictionaries, avoid using keys that begin with "/", as the
+    first slash will be removed by the python archive function. If they 
+    must be used, prepend another character ahead of the slash to ensure
+    that the "/" will not be removed.
+
     Examples
     --------
     >>> from tempfile import TemporaryFile


### PR DESCRIPTION
Note indicates that when used with dictionaries, savez will remove 
leading "/" in dictionary keys.
See #9265