### PR TITLE
BUG: `runtest -t` should recognize development mode

### DIFF
--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -389,6 +389,9 @@ class NoseTester(object):
         from . import utils
         utils.verbose = verbose
 
+        argv, plugins = self.prepare_test_args(
+                label, verbose, extra_argv, doctests, coverage, timer)
+
         if doctests:
             print("Running unit tests and doctests for %s" % self.package_name)
         else:
@@ -458,9 +461,6 @@ class NoseTester(object):
                                     module=r"nose\.")
 
             from .noseclasses import NumpyTestProgram
-
-            argv, plugins = self.prepare_test_args(
-                    label, verbose, extra_argv, doctests, coverage, timer)
 
             t = NumpyTestProgram(argv=argv, exit=False, plugins=plugins)
 

--- a/runtests.py
+++ b/runtests.py
@@ -115,8 +115,8 @@ def main(argv):
                               "Note that you need to commit your changes first!"))
     parser.add_argument("--raise-warnings", default=None, type=str,
                         choices=('develop', 'release'),
-                        help="if 'develop', warnings are treated as errors; "
-                             "defaults to 'devlop' in development versions.")
+                        help=("if 'develop', warnings are treated as errors; "
+                              "defaults to 'develop' in development versions."))
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
     args = parser.parse_args(argv)

--- a/runtests.py
+++ b/runtests.py
@@ -115,7 +115,8 @@ def main(argv):
                               "Note that you need to commit your changes first!"))
     parser.add_argument("--raise-warnings", default=None, type=str,
                         choices=('develop', 'release'),
-                        help="if 'develop', warnings are treated as errors")
+                        help="if 'develop', warnings are treated as errors; "
+                             "defaults to 'devlop' in development versions.")
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
     args = parser.parse_args(argv)
@@ -282,7 +283,13 @@ def main(argv):
             extra_argv = kw.pop('extra_argv', ())
             extra_argv = extra_argv + tests[1:]
             kw['extra_argv'] = extra_argv
+            import numpy as np
             from numpy.testing import Tester
+            if kw["raise_warnings"] is None:
+                if hasattr(np, "__version__") and ".dev0" in np.__version__:
+                    kw["raise_warnings"] = "develop"
+                else:
+                    kw["raise_warnings"] = "release"
             return Tester(tests[0]).test(*a, **kw)
     else:
         __import__(PROJECT_MODULE)


### PR DESCRIPTION
I seem to have never actually put the tests into development mode if run for individual files with `runtests.py -t ...`.

Also "fixes" a warning I get on my computer about nose. The way I did it now, the warning will just show up before actually printing out all the numpy info, etc. so that I think it is pretty clear that the warning is not originating in numpy itself. Frankly, am only 95% sure that this is correct also for doctests ;).