### PR TITLE
BUG: np.ma.astype fails on structured types

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3191,16 +3191,16 @@ class MaskedArray(ndarray):
 
         """
         newtype = np.dtype(newtype)
+        newmasktype = make_mask_descr(newtype)
+
         output = self._data.astype(newtype).view(type(self))
         output._update_from(self)
-        names = output.dtype.names
-        if names is None:
-            output._mask = self._mask.astype(bool)
+
+        if self._mask is nomask:
+            output._mask = nomask
         else:
-            if self._mask is nomask:
-                output._mask = nomask
-            else:
-                output._mask = self._mask.astype([(n, bool) for n in names])
+            output._mask = self._mask.astype(newmasktype)
+
         # Don't check _fill_value if it's None, that'll speed things up
         if self._fill_value is not None:
             output._fill_value = _check_fill_value(self._fill_value, newtype)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4740,6 +4740,11 @@ def test_ufunc_with_output():
     y = np.add(x, 1., out=x)
     assert_(y is x)
 
+def test_astype():
+    descr = [('v', int, 3), ('x', [('y', float)])]
+    x = array(([1, 2, 3], (1.0,)), dtype=descr)
+    assert_equal(x, x.astype(descr))
+
 
 ###############################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
```python
>>> x = array(([1, 2, 3], (1.0,)), dtype=descr)
>>> x
masked_array(data = ([1, 2, 3], (1.0,)),
             mask = ([False, False, False], (False,)),
       fill_value = ([999999, 999999, 999999], (  1.00000000e+20,)),
            dtype = [('v', '<i4', (3,)), ('x', [('y', '<f8')])])

>>> x.astype(x.dtype)
masked_array(data = (array([1, 2, 3]), --),
             mask = (False,  True),
       fill_value = (999999, (  1.00000000e+20,)),
            dtype = [('v', '<i4', (3,)), ('x', [('y', '<f8')])])
```

Note the mask is the wrong type.

The fill value is also wrong, but that's a different problem (#9303)