### PR TITLE
DOC: add a NumFOCUS badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="http://www.numpy.org/_static/numpy_logo.png"><br>
 </div>
 
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+
 -----------------
 |  **`Travis CI Status`**   |
 |-------------------|


### PR DESCRIPTION
``[ci skip]``

Rendered version: https://github.com/rgommers/numpy/tree/nf-badge

The rest of the README file is awfully outdated, but that's for another time.
