### PR TITLE
DOC: Add unravel_index examples to np.arg[min|max|sort]

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -890,6 +890,13 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     array([[0, 1],
            [0, 1]])
 
+    >>> np.unravel_index(np.argsort(x, axis=None), x.shape)
+    (array([0, 1, 1, 0]), array([0, 0, 1, 1]))
+    >>> x[np.unravel_index(np.argsort(x, axis=None), x.shape)]
+    array([0, 2, 2, 3])
+    >>> list(zip(*np.unravel_index(np.argsort(x, axis=None), x.shape)))
+    [(0, 0), (1, 0), (1, 1), (0, 1)]
+
     Sorting with keys:
 
     >>> x = np.array([(1, 0), (0, 1)], dtype=[('x', '<i4'), ('y', '<i4')])
@@ -951,6 +958,8 @@ def argmax(a, axis=None, out=None):
     array([1, 1, 1])
     >>> np.argmax(a, axis=1)
     array([2, 2])
+    >>> np.unravel_index(np.argmax(a, axis=None), a.shape)
+    (1, 2)
 
     >>> b = np.arange(6)
     >>> b[1] = 5
@@ -1007,6 +1016,8 @@ def argmin(a, axis=None, out=None):
     array([0, 0, 0])
     >>> np.argmin(a, axis=1)
     array([0, 0])
+    >>> np.unravel_index(np.argmin(a, axis=None), a.shape)
+    (0, 0)
 
     >>> b = np.arange(6)
     >>> b[4] = 0

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -893,6 +893,8 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     Indices of the sorted elements of a N-dimensional array:
     >>> np.unravel_index(np.argsort(x, axis=None), x.shape)
     (array([0, 1, 1, 0]), array([0, 0, 1, 1]))
+    >>> from np.testing import assert_equal
+    >>> assert_equal(x[(array([0, 1, 1, 0]), array([0, 0, 1, 1]))], np.sort(x, axis=None))
     >>> list(zip(*np.unravel_index(np.argsort(x, axis=None), x.shape)))
     [(0, 0), (1, 0), (1, 1), (0, 1)]
 
@@ -961,6 +963,7 @@ def argmax(a, axis=None, out=None):
     Indices of the maximal elements of a N-dimensional array:
     >>> np.unravel_index(np.argmax(a, axis=None), a.shape)
     (1, 2)
+    >>> np.testing.assert_equal(a[(1, 2)], np.max(a))
 
     >>> b = np.arange(6)
     >>> b[1] = 5
@@ -1021,6 +1024,7 @@ def argmin(a, axis=None, out=None):
     Indices of the minimum elements of a N-dimensional array:
     >>> np.unravel_index(np.argmin(a, axis=None), a.shape)
     (0, 0)
+    >>> np.testing.assert_equal(a[(0, 0)], np.min(a))
 
     >>> b = np.arange(6)
     >>> b[4] = 0

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -890,10 +890,9 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     array([[0, 1],
            [0, 1]])
 
+    Indices for sorting the elements of a N-dimensional array:
     >>> np.unravel_index(np.argsort(x, axis=None), x.shape)
     (array([0, 1, 1, 0]), array([0, 0, 1, 1]))
-    >>> x[np.unravel_index(np.argsort(x, axis=None), x.shape)]
-    array([0, 2, 2, 3])
     >>> list(zip(*np.unravel_index(np.argsort(x, axis=None), x.shape)))
     [(0, 0), (1, 0), (1, 1), (0, 1)]
 
@@ -958,6 +957,8 @@ def argmax(a, axis=None, out=None):
     array([1, 1, 1])
     >>> np.argmax(a, axis=1)
     array([2, 2])
+
+    Indices of the maximal elements of a N-dimensional array:
     >>> np.unravel_index(np.argmax(a, axis=None), a.shape)
     (1, 2)
 
@@ -1016,6 +1017,8 @@ def argmin(a, axis=None, out=None):
     array([0, 0, 0])
     >>> np.argmin(a, axis=1)
     array([0, 0])
+
+    Indices of the minimum elements of a N-dimensional array:
     >>> np.unravel_index(np.argmin(a, axis=None), a.shape)
     (0, 0)
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -890,7 +890,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     array([[0, 1],
            [0, 1]])
 
-    Indices for sorting the elements of a N-dimensional array:
+    Coordinates of the sorted elements of a N-dimensional array:
     >>> np.unravel_index(np.argsort(x, axis=None), x.shape)
     (array([0, 1, 1, 0]), array([0, 0, 1, 1]))
     >>> list(zip(*np.unravel_index(np.argsort(x, axis=None), x.shape)))
@@ -958,7 +958,7 @@ def argmax(a, axis=None, out=None):
     >>> np.argmax(a, axis=1)
     array([2, 2])
 
-    Indices of the maximal elements of a N-dimensional array:
+    Coordinates of the maximal elements of a N-dimensional array:
     >>> np.unravel_index(np.argmax(a, axis=None), a.shape)
     (1, 2)
 
@@ -1018,7 +1018,7 @@ def argmin(a, axis=None, out=None):
     >>> np.argmin(a, axis=1)
     array([0, 0])
 
-    Indices of the minimum elements of a N-dimensional array:
+    Coordinates of the minimum elements of a N-dimensional array:
     >>> np.unravel_index(np.argmin(a, axis=None), a.shape)
     (0, 0)
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -890,7 +890,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     array([[0, 1],
            [0, 1]])
 
-    Coordinates of the sorted elements of a N-dimensional array:
+    Indices of the sorted elements of a N-dimensional array:
     >>> np.unravel_index(np.argsort(x, axis=None), x.shape)
     (array([0, 1, 1, 0]), array([0, 0, 1, 1]))
     >>> list(zip(*np.unravel_index(np.argsort(x, axis=None), x.shape)))
@@ -958,7 +958,7 @@ def argmax(a, axis=None, out=None):
     >>> np.argmax(a, axis=1)
     array([2, 2])
 
-    Coordinates of the maximal elements of a N-dimensional array:
+    Indices of the maximal elements of a N-dimensional array:
     >>> np.unravel_index(np.argmax(a, axis=None), a.shape)
     (1, 2)
 
@@ -1018,7 +1018,7 @@ def argmin(a, axis=None, out=None):
     >>> np.argmin(a, axis=1)
     array([0, 0])
 
-    Coordinates of the minimum elements of a N-dimensional array:
+    Indices of the minimum elements of a N-dimensional array:
     >>> np.unravel_index(np.argmin(a, axis=None), a.shape)
     (0, 0)
 


### PR DESCRIPTION
Hi,

Using np.arg[min|max|sort] for d-dimensional arrays whenever we want to work on the whole array, and retrieve indices is very unintuitive.
In  #6078 some propositions were made to change that. But as a true modification seems not to be for tomorrow.
Here I propose a small add to the docstrings so that the user can understand by itself how to deal with it.

Élie