### PR TITLE
BUG: Fix various problems with the np.ma.masked constant

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -34,6 +34,16 @@ Previously ``np.tensordot`` raised a ValueError when contracting over 0-length
 dimension. Now it returns a zero array, which is consistent with the behaviour
 of ``np.dot`` and ``np.einsum``.
 
+``np.ma.masked`` is no longer writeable
+---------------------------------------
+Attempts to mutate the ``masked`` constant now error, as the underlying arrays
+are marked readonly. In the past, it was possible to get away with::
+
+    # emulating a function that sometimes returns np.ma.masked
+    val = random.choice([np.ma.masked, 10])
+    var_arr = np.asarray(val)
+    val_arr += 1  # now errors, previously changed np.ma.masked.data
+
 ``np.ma`` functions producing ``fill_value``s have changed
 ----------------------------------------------------------
 Previously, ``np.ma.default_fill_value`` would return a 0d array, but

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6253,6 +6253,12 @@ class MaskedConstant(MaskedArray):
         __iop__
     del __iop__  # don't leave this around
 
+    def copy(self, *args, **kwargs):
+        """ Copy is a no-op on the maskedconstant, as it is a scalar """
+        # maskedconstant is a scalar, so copy doesn't need to copy. There's
+        # precedent for this with `np.bool_` scalars.
+        return self
+
 
 masked = masked_singleton = MaskedConstant()
 masked_array = MaskedArray

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6206,7 +6206,11 @@ class MaskedConstant(MaskedArray):
         return str(masked_print_option._display)
 
     def __repr__(self):
-        return 'masked'
+        if self is masked:
+            return 'masked'
+        else:
+            # something is wrong, make it obvious
+            return object.__repr__(self)
 
     def flatten(self):
         return masked_array([self._data], dtype=float, mask=[True])

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6190,8 +6190,12 @@ class MaskedConstant(MaskedArray):
     _mask = mask = np.array(True)
     _baseclass = ndarray
 
+    __singleton = None
+
     def __new__(self):
-        return self._data.view(self)
+        if self.__singleton is None:
+            self.__singleton = self._data.view(self)
+        return self.__singleton
 
     def __array_finalize__(self, obj):
         return

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4759,8 +4759,10 @@ class TestMaskedConstant(TestCase):
             np.True_.copy() is np.True_)
 
     def test_immutable(self):
-        assert_raises(ValueError, operator.setitem, np.ma.masked.data, (), 1)
-        assert_raises(ValueError, operator.setitem, np.ma.masked.mask, (), False)
+        orig = np.ma.masked
+        assert_raises(np.ma.core.MaskError, operator.setitem, orig, (), 1)
+        assert_raises(ValueError,operator.setitem, orig.data, (), 1)
+        assert_raises(ValueError, operator.setitem, orig.mask, (), False)
 
         view = np.ma.masked.view(np.ma.MaskedArray)
         assert_raises(ValueError, operator.setitem, view, (), 1)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4766,6 +4766,15 @@ class TestMaskedConstant(TestCase):
         assert_(not isinstance(np.ma.masked[...], MC))
         assert_(not isinstance(np.ma.masked.copy(), MC))
 
+    def test_immutable(self):
+        assert_raises(ValueError, operator.setitem, np.ma.masked.data, (), 1)
+        assert_raises(ValueError, operator.setitem, np.ma.masked.mask, (), False)
+
+        view = np.ma.masked.view(np.ma.MaskedArray)
+        assert_raises(ValueError, operator.setitem, view, (), 1)
+        assert_raises(ValueError, operator.setitem, view.data, (), 1)
+        assert_raises(ValueError, operator.setitem, view.mask, (), False)
+
 
 def test_masked_array():
     a = np.ma.array([0, 1, 2, 3], mask=[0, 0, 1, 0])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4736,7 +4736,10 @@ class TestMaskedConstant(TestCase):
         # copies should not exist, but if they do, it should be obvious that
         # something is wrong
         assert_equal(repr(np.ma.masked), 'masked')
-        assert_not_equal(repr(np.ma.masked.copy()), 'masked')
+
+        # create a new instance in a weird way
+        masked2 = np.ma.MaskedArray.__new__(np.ma.core.MaskedConstant)
+        assert_not_equal(repr(masked2), 'masked')
 
     def test_pickle(self):
         from io import BytesIO
@@ -4748,30 +4751,12 @@ class TestMaskedConstant(TestCase):
             res = pickle.load(f)
         assert_(res is np.ma.masked)
 
-    def test_write_to_copy(self):
+    def test_copy(self):
         # gh-9328
-        x = np.ma.masked.copy()
-        x[()] = 2
-
-        # write succeeds
-        assert_equal(x.data, 2)
-        assert_equal(x.mask, False)
-
-        # original should be unchanged
-        assert_equal(np.ma.masked.data, 0)
-        assert_equal(np.ma.masked.mask, True)
-
-    def test_no_copies(self):
-        # when making a view or a copy, downcast to MaskedArray
-        MC = np.ma.core.MaskedConstant
-
-        m_sl = np.ma.masked[...]
-        assert_equal(type(m_sl), np.ma.MaskedArray)
-        assert_equal(m_sl.mask, True)
-
-        m_copy = np.ma.masked.copy()
-        assert_equal(type(m_copy), np.ma.MaskedArray)
-        # assert_equal(m_copy.mask, True)  - gh-9430
+        # copy is a no-op, like it is with np.True_
+        assert_equal(
+            np.ma.masked.copy() is np.ma.masked,
+            np.True_.copy() is np.True_)
 
     def test_immutable(self):
         assert_raises(ValueError, operator.setitem, np.ma.masked.data, (), 1)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4732,6 +4732,12 @@ class TestMaskedConstant(TestCase):
         assert_(not isinstance(m, np.ma.core.MaskedConstant))
         assert_(m is not np.ma.masked)
 
+    def test_repr(self):
+        # copies should not exist, but if they do, it should be obvious that
+        # something is wrong
+        assert_equal(repr(np.ma.masked), 'masked')
+        assert_not_equal(repr(np.ma.masked.copy()), 'masked')
+
 
 def test_masked_array():
     a = np.ma.array([0, 1, 2, 3], mask=[0, 0, 1, 0])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4738,6 +4738,16 @@ class TestMaskedConstant(TestCase):
         assert_equal(repr(np.ma.masked), 'masked')
         assert_not_equal(repr(np.ma.masked.copy()), 'masked')
 
+    def test_pickle(self):
+        from io import BytesIO
+        import pickle
+
+        with BytesIO() as f:
+            pickle.dump(np.ma.masked, f)
+            f.seek(0)
+            res = pickle.load(f)
+        assert_(res is np.ma.masked)
+
 
 def test_masked_array():
     a = np.ma.array([0, 1, 2, 3], mask=[0, 0, 1, 0])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4762,9 +4762,16 @@ class TestMaskedConstant(TestCase):
         assert_equal(np.ma.masked.mask, True)
 
     def test_no_copies(self):
+        # when making a view or a copy, downcast to MaskedArray
         MC = np.ma.core.MaskedConstant
-        assert_(not isinstance(np.ma.masked[...], MC))
-        assert_(not isinstance(np.ma.masked.copy(), MC))
+
+        m_sl = np.ma.masked[...]
+        assert_equal(type(m_sl), np.ma.MaskedArray)
+        assert_equal(m_sl.mask, True)
+
+        m_copy = np.ma.masked.copy()
+        assert_equal(type(m_copy), np.ma.MaskedArray)
+        # assert_equal(m_copy.mask, True)  - gh-9430
 
     def test_immutable(self):
         assert_raises(ValueError, operator.setitem, np.ma.masked.data, (), 1)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4748,6 +4748,24 @@ class TestMaskedConstant(TestCase):
             res = pickle.load(f)
         assert_(res is np.ma.masked)
 
+    def test_write_to_copy(self):
+        # gh-9328
+        x = np.ma.masked.copy()
+        x[()] = 2
+
+        # write succeeds
+        assert_equal(x.data, 2)
+        assert_equal(x.mask, False)
+
+        # original should be unchanged
+        assert_equal(np.ma.masked.data, 0)
+        assert_equal(np.ma.masked.mask, True)
+
+    def test_no_copies(self):
+        MC = np.ma.core.MaskedConstant
+        assert_(not isinstance(np.ma.masked[...], MC))
+        assert_(not isinstance(np.ma.masked.copy(), MC))
+
 
 def test_masked_array():
     a = np.ma.array([0, 1, 2, 3], mask=[0, 0, 1, 0])


### PR DESCRIPTION
It turns out that `np.ma.masked` is actually pretty bad at preserving identity or value

This PR attempts to fix that.

Fixes #9328 and #4595