### PR TITLE
BUG: Prevent crash if ufunc doc string is null 

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5596,8 +5596,10 @@ ufunc_get_doc(PyUFuncObject *ufunc)
     if (doc == NULL) {
         return NULL;
     }
-    PyUString_ConcatAndDel(&doc,
-        PyUString_FromFormat("\n\n%s", ufunc->doc));
+    if (ufunc->doc != NULL) {
+        PyUString_ConcatAndDel(&doc,
+            PyUString_FromFormat("\n\n%s", ufunc->doc));
+    }
     return doc;
 }
 

--- a/numpy/core/src/umath/umath_tests.c.src
+++ b/numpy/core/src/umath/umath_tests.c.src
@@ -305,6 +305,12 @@ addUfuncs(PyObject *dictionary) {
                     0, euclidean_pdist_signature);
     PyDict_SetItemString(dictionary, "euclidean_pdist", f);
     Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(inner1d_functions, inner1d_data,
+                    inner1d_signatures, 2, 2, 1, PyUFunc_None, "inner1d_no_doc",
+                    NULL,
+                    0, inner1d_signature);
+    PyDict_SetItemString(dictionary, "inner1d_no_doc", f);
+    Py_DECREF(f);
 }
 
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1283,6 +1283,10 @@ class TestUfunc(TestCase):
         assert_equal(y_base[1,:], y_base_copy[1,:])
         assert_equal(y_base[3,:], y_base_copy[3,:])
 
+    def test_no_doc_string(self):
+        # gh-9337
+        assert_('\n' not in umt.inner1d_no_doc.__doc__)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport of #9337. 

The following code now causes numba to crash (with the latest version of numpy):
```
import numba

@numba.guvectorize(['float64[:], float64[:]'], '(n)->(n)')
def foo(x, y):
    pass
print(foo.__doc__)
```
It turns out that numba are creating ufuncs with a null doc string. It's not clear whether this is legitimate (the documentation doesn't state either way as far as I can see), however currently this results in a segfault, and this is evidence that at least some people in the community have been doing this. This didn't cause any problems until 476ce74 where the check for ufunc->doc == NULL was removed.

This change restores the check, meaning if no doc string in provided then the doc string for the ufunc is simply the method signature.