### PR TITLE
ENH: Let np.vectorize follow descriptor protocol.

### DIFF
--- a/doc/release/upcoming_changes/9349.compatibility.rst
+++ b/doc/release/upcoming_changes/9349.compatibility.rst
@@ -1,0 +1,18 @@
+``np.vectorize`` follows the descriptor protocol
+------------------------------------------------
+
+Before numpy 1.25, a function wrapped in ``np.vectorize`` would *not* follow
+the descriptor protocol; in particular, attaching such an object to a class
+would implicitly create a static method::
+
+   >>> def func(x):
+   ...     return x ** 2
+   >>> class C(object):
+   ...     static = np.vectorize(func)
+   >>> C().static(1)
+   1
+
+Since numpy 1.25, the vectorized function now binds ``self`` as the first
+argument, and the earlier example will fail.  To recover the earlier behavior,
+explicitly wrap ``func`` using ``staticmethod`` before passing it to
+``np.vectorize``.

--- a/doc/release/upcoming_changes/9349.compatibility.rst
+++ b/doc/release/upcoming_changes/9349.compatibility.rst
@@ -14,5 +14,4 @@ would implicitly create a static method::
 
 Since numpy 1.25, the vectorized function now binds ``self`` as the first
 argument, and the earlier example will fail.  To recover the earlier behavior,
-explicitly wrap ``func`` using ``staticmethod`` before passing it to
-``np.vectorize``.
+use `static = staticmethod(np.vectorize(func))`.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1767,6 +1767,26 @@ class TestVectorize:
         with assert_raises_regex(ValueError, 'new output dimensions'):
             f(x)
 
+    def test_method(self):
+        class C(object):
+            v = vectorize(lambda self, x: (self, x))
+            vc = vectorize(classmethod(lambda cls, x: (cls, x)))
+            cv = classmethod(vectorize(lambda cls, x: (cls, x)))
+            vs = vectorize(staticmethod(lambda x: x))
+            sv = staticmethod(vectorize(lambda x: x))
+
+        c = C()
+        assert_array_equal(c.v([1, 2]), ([c, c], [1, 2]))
+        assert_array_equal(C.v(c, [1, 2]), ([c, c], [1, 2]))
+        assert_array_equal(c.vc([1, 2]), ([C, C], [1, 2]))
+        assert_array_equal(C.vc([1, 2]), ([C, C], [1, 2]))
+        assert_array_equal(c.cv([1, 2]), ([C, C], [1, 2]))
+        assert_array_equal(C.cv([1, 2]), ([C, C], [1, 2]))
+        assert_array_equal(c.vs([1, 2]), [1, 2])
+        assert_array_equal(C.vs([1, 2]), [1, 2])
+        assert_array_equal(c.sv([1, 2]), [1, 2])
+        assert_array_equal(C.sv([1, 2]), [1, 2])
+
     def test_subclasses(self):
         class subclass(np.ndarray):
             pass


### PR DESCRIPTION
This makes
```
    class C(object):
        @np.vectorize
        def meth(self, obj): return self, obj
    c = C()
    c.meth([1, 2])
```
return
```
    [(c, c), (1, 2)]
```
instead of erroring because one extra argument is expected.

Note that the docstring of `vectorize` said that `pyfunc` was `A python
function or method`.