### PR TITLE
BUG: Fix np.ma.take on un-indexable scalars

### DIFF
--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3163,6 +3163,20 @@ class TestMaskedArrayMethods(TestCase):
                      array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))
         assert_equal(take(x, [0, 2], axis=1),
                      array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))
+        assert_equal(take(x, [0, 2], axis=-1),
+                     array([[10, 30], [40, 60]], mask=[[0, 1], [1, 0]]))
+
+    def test_take_string(self):
+        x = masked_array(['hello', 'world'], mask=[0, 1])
+        assert_equal(x.take(0), 'hello')
+        assert_equal(x.take(1), np.ma.masked)
+        assert_equal(x.take([0, 1]), x)
+
+    def test_take_object(self):
+        x = masked_array([None, np.array([1, 2])], mask=[0, 1])
+        assert_equal(x.take(0), x[0])
+        assert_equal(x.take(1), x[1])
+        assert_equal(x.take([0, 1]), x)
 
     def test_take_masked_indices(self):
         # Test take w/ masked indices


### PR DESCRIPTION
np.string_ scalars cannot be indexed with [...], and np.object_ scalars do
not even exist.

The only way to make this work is to not allow a scalar to be produced in the first place - which can be achieved by adding an extra dimension to the indices, and removing it while allowing 0d arrays

Fixes #9206