### PR TITLE
DOC: isscalar add example for str

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2157,6 +2157,8 @@ def isscalar(num):
     False
     >>> np.isscalar(False)
     True
+    >>> np.isscalar('numpy')
+    True
 
     """
     if isinstance(num, generic):


### PR DESCRIPTION
Hi,
I wanted to use np.isscalar to identify a scalar and distinguish it from slice, list, tuple and str.
After reading #6335 I figured out that str are handled as scalars in numpy.

Is it possible to extend the documentation for this special case?
An example is in this PR.