### PR TITLE
BUG: Fix error in fromstring function from numpy.core.records (#9369)

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -704,7 +704,7 @@ def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
 
     itemsize = descr.itemsize
     if (shape is None or shape == 0 or shape == -1):
-        shape = (len(datastring) - offset) / itemsize
+        shape = (len(datastring) - offset) // itemsize
 
     _array = recarray(shape, descr, buf=datastring, offset=offset)
     return _array


### PR DESCRIPTION
Backport of #9369.

the shape was computer using true division and
ndarray expects a tuple of integers as shape parameter