### PR TITLE
BUG: ')' is printed at the end pointer of the buffer in numpy.f2py.

### DIFF
--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -130,8 +130,7 @@ format_def(char *buf, Py_ssize_t size, FortranDataDef def)
         return -1;
     }
 
-    p[size] = ')';
-    p++;
+    *p++ = ')';
     size--;
 
     if (def.data == NULL) {


### PR DESCRIPTION
Backport of #9364.

When building the __doc__ string for Fortran objects, the ')'
character, closing the dimensions list, is written 1 position
beyond the allowed buffer size, instead of the current pointer in
the buffer.