### PR TITLE
MAINT: Use PyArray_ISBYTESWAPPED instead of !PyArray_ISNOTSWAPPED.

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -203,7 +203,7 @@ static PyObject *
         return @func1@((@type1@)t1);
     }
     else {
-        PyArray_DESCR(ap)->f->copyswap(&t1, ip, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(&t1, ip, PyArray_ISBYTESWAPPED(ap), ap);
         return @func1@((@type1@)t1);
     }
 }
@@ -239,7 +239,8 @@ static int
     if (ap == NULL || PyArray_ISBEHAVED(ap))
         *((@type@ *)ov)=temp;
     else {
-        PyArray_DESCR(ap)->f->copyswap(ov, &temp, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(ov, &temp, PyArray_ISBYTESWAPPED(ap),
+                                       ap);
     }
     return 0;
 }
@@ -265,7 +266,7 @@ static PyObject *
     else {
         int size = sizeof(@type@);
 
-        npy_bool swap = !PyArray_ISNOTSWAPPED(ap);
+        npy_bool swap = PyArray_ISBYTESWAPPED(ap);
         copy_and_swap(&t1, ip, size, 1, 0, swap);
         copy_and_swap(&t2, ip + size, size, 1, 0, swap);
         return PyComplex_FromDoubles((double)t1, (double)t2);
@@ -325,11 +326,11 @@ static int
     }
 
     memcpy(ov, &temp, PyArray_DESCR(ap)->elsize);
-    if (!PyArray_ISNOTSWAPPED(ap)) {
+    if (PyArray_ISBYTESWAPPED(ap)) {
         byte_swap_vector(ov, 2, sizeof(@ftype@));
     }
     rsize = sizeof(@ftype@);
-    copy_and_swap(ov, &temp, rsize, 2, rsize, !PyArray_ISNOTSWAPPED(ap));
+    copy_and_swap(ov, &temp, rsize, 2, rsize, PyArray_ISBYTESWAPPED(ap));
     return 0;
 }
 
@@ -422,7 +423,7 @@ LONGDOUBLE_setitem(PyObject *op, void *ov, void *vap)
     }
     else {
         copy_and_swap(ov, &temp, PyArray_DESCR(ap)->elsize, 1, 0,
-                !PyArray_ISNOTSWAPPED(ap));
+                      PyArray_ISBYTESWAPPED(ap));
     }
     return 0;
 }
@@ -439,7 +440,7 @@ UNICODE_getitem(void *ip, void *vap)
 {
     PyArrayObject *ap = vap;
     Py_ssize_t size = PyArray_ITEMSIZE(ap);
-    int swap = !PyArray_ISNOTSWAPPED(ap);
+    int swap = PyArray_ISBYTESWAPPED(ap);
     int align = !PyArray_ISALIGNED(ap);
 
     return (PyObject *)PyUnicode_FromUCS4(ip, size, swap, align);
@@ -512,7 +513,7 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
     if (PyArray_DESCR(ap)->elsize > datalen) {
         memset((char*)ov + datalen, 0, (PyArray_DESCR(ap)->elsize - datalen));
     }
-    if (!PyArray_ISNOTSWAPPED(ap)) {
+    if (PyArray_ISBYTESWAPPED(ap)) {
         byte_swap_vector(ov, PyArray_DESCR(ap)->elsize >> 2, 4);
     }
     Py_DECREF(temp);
@@ -903,7 +904,7 @@ DATETIME_getitem(void *ip, void *vap)
         dt = *((npy_datetime *)ip);
     }
     else {
-        PyArray_DESCR(ap)->f->copyswap(&dt, ip, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(&dt, ip, PyArray_ISBYTESWAPPED(ap), ap);
     }
 
     return convert_datetime_to_pyobject(dt, meta);
@@ -927,7 +928,7 @@ TIMEDELTA_getitem(void *ip, void *vap)
         td = *((npy_timedelta *)ip);
     }
     else {
-        PyArray_DESCR(ap)->f->copyswap(&td, ip, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(&td, ip, PyArray_ISBYTESWAPPED(ap), ap);
     }
 
     return convert_timedelta_to_pyobject(td, meta);
@@ -958,8 +959,8 @@ DATETIME_setitem(PyObject *op, void *ov, void *vap)
         *((npy_datetime *)ov)=temp;
     }
     else {
-        PyArray_DESCR(ap)->f->copyswap(ov, &temp,
-                !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(ov, &temp, PyArray_ISBYTESWAPPED(ap),
+                                       ap);
     }
 
     return 0;
@@ -990,7 +991,8 @@ TIMEDELTA_setitem(PyObject *op, void *ov, void *vap)
         *((npy_timedelta *)ov)=temp;
     }
     else {
-        PyArray_DESCR(ap)->f->copyswap(ov, &temp, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(ov, &temp, PyArray_ISBYTESWAPPED(ap),
+                                       ap);
     }
 
     return 0;
@@ -2374,7 +2376,8 @@ static npy_bool
          */
         @type@ tmp;
 #if @isfloat@
-        PyArray_DESCR(ap)->f->copyswap(&tmp, ip, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(&tmp, ip, PyArray_ISBYTESWAPPED(ap),
+                                       ap);
 #else
         memcpy(&tmp, ip, sizeof(@type@));
 #endif
@@ -2397,7 +2400,8 @@ static npy_bool
     }
     else {
         @type@ tmp;
-        PyArray_DESCR(ap)->f->copyswap(&tmp, ip, !PyArray_ISNOTSWAPPED(ap), ap);
+        PyArray_DESCR(ap)->f->copyswap(&tmp, ip, PyArray_ISBYTESWAPPED(ap),
+                                       ap);
         return (npy_bool) ((tmp.real != 0) || (tmp.imag != 0));
     }
 }
@@ -2459,13 +2463,13 @@ UNICODE_nonzero (npy_ucs4 *ip, PyArrayObject *ap)
     npy_bool seen_null = NPY_FALSE;
     char *buffer = NULL;
 
-    if ((!PyArray_ISNOTSWAPPED(ap)) || (!PyArray_ISALIGNED(ap))) {
+    if (PyArray_ISBYTESWAPPED(ap) || !PyArray_ISALIGNED(ap)) {
         buffer = PyArray_malloc(PyArray_DESCR(ap)->elsize);
         if (buffer == NULL) {
             return nonz;
         }
         memcpy(buffer, ip, PyArray_DESCR(ap)->elsize);
-        if (!PyArray_ISNOTSWAPPED(ap)) {
+        if (PyArray_ISBYTESWAPPED(ap)) {
             byte_swap_vector(buffer, len, 4);
         }
         ip = (npy_ucs4 *)buffer;

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -2457,7 +2457,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         }
         PyArray_DESCR(arr)->f->copyswap(&dt,
                                 PyArray_DATA(arr),
-                                !PyArray_ISNOTSWAPPED(arr),
+                                PyArray_ISBYTESWAPPED(arr),
                                 obj);
 
         /* Copy the value directly if units weren't specified */
@@ -2655,7 +2655,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         }
         PyArray_DESCR(arr)->f->copyswap(&dt,
                                 PyArray_DATA(arr),
-                                !PyArray_ISNOTSWAPPED(arr),
+                                PyArray_ISBYTESWAPPED(arr),
                                 obj);
 
         /* Copy the value directly if units weren't specified */

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1803,7 +1803,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
     }
 
     if (!PyDataType_FLAGCHK(typecode, NPY_LIST_PICKLE)) {
-        int swap=!PyArray_ISNOTSWAPPED(self);
+        int swap = PyArray_ISBYTESWAPPED(self);
         fa->data = datastr;
 #ifndef NPY_PY3K
         /* Check that the string is not interned */


### PR DESCRIPTION
Positives are easier to parse than double negatives.