### PR TITLE
BUG: Return the poly1d coefficients array directly

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1040,8 +1040,14 @@ class poly1d(object):
 
     @property
     def coeffs(self):
-        """ A copy of the polynomial coefficients """
-        return self._coeffs.copy()
+        """ The polynomial coefficients """
+        return self._coeffs
+
+    @coeffs.setter
+    def coeffs(self, value):
+        # allowing this makes p.coeffs *= 2 legal
+        if value is not self._coeffs:
+            raise AttributeError("Cannot set attribute")
 
     @property
     def variable(self):

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -222,19 +222,19 @@ class TestDocs(TestCase):
         assert_equal(p == p2, False)
         assert_equal(p != p2, True)
 
-    def test_poly_coeffs_immutable(self):
-        """ Coefficients should not be modifiable """
+    def test_poly_coeffs_mutable(self):
+        """ Coefficients should be modifiable """
         p = np.poly1d([1, 2, 3])
 
-        try:
-            # despite throwing an exception, this used to change state
-            p.coeffs += 1
-        except Exception:
-            pass
-        assert_equal(p.coeffs, [1, 2, 3])
+        p.coeffs += 1
+        assert_equal(p.coeffs, [2, 3, 4])
 
         p.coeffs[2] += 10
-        assert_equal(p.coeffs, [1, 2, 3])
+        assert_equal(p.coeffs, [2, 3, 14])
+
+        # this never used to be allowed - let's not add features to deprecated
+        # APIs
+        assert_raises(AttributeError, setattr, p, 'coeffs', np.array(1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Turns out that this was relied upon downstream

We also add a setter for coeffs, so that augmented assignment does not both
change state and raise an exception suggesting state could not be changed.

(see #9385)

Trivial to forward port after merging, since the parent commit is the one that introduced the bug