### PR TITLE
DOC: UPDATEIFCOPY raises an error if not an array.

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -455,8 +455,7 @@ From other objects
         is deleted (presumably after your calculations are complete),
         its contents will be copied back into *op* and the *op* array
         will be made writeable again. If *op* is not writeable to begin
-        with, then an error is raised. If *op* is not already an array,
-        then this flag has no effect.
+        with, or if it is not already an array, then an error is raised.
 
     .. c:var:: NPY_ARRAY_BEHAVED
 


### PR DESCRIPTION
I'm seeing this working on SciPy's ndimage, and [here](https://github.com/numpy/numpy/blob/c11628abd820a1f44b052ea87af810f8f00cf2e4/numpy/core/src/multiarray/ctors.c#L1712) is where the error is being raised, contrary to what our docs say.