### PR TITLE
MAINT: Further unify handling of unnamed ufuncs

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -761,8 +761,8 @@ _set_out_array(PyObject *obj, PyArrayObject **store)
  * Produce a name for the ufunc, if one is not already set
  * This is used in the PyUFunc_handlefperr machinery, and in error messages
  */
-static const char*
-_get_ufunc_name(PyUFuncObject *ufunc) {
+NPY_NO_EXPORT const char*
+ufunc_get_name_cstr(PyUFuncObject *ufunc) {
     return ufunc->name ? ufunc->name : "<unnamed ufunc>";
 }
 
@@ -789,7 +789,7 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
     int nout = ufunc->nout;
     PyObject *obj, *context;
     PyObject *str_key_obj = NULL;
-    const char *ufunc_name = _get_ufunc_name(ufunc);
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
     int type_num;
 
     int any_flexible = 0, any_object = 0, any_flexible_userloops = 0;
@@ -2050,7 +2050,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
                         "%s: %s operand %d does not have enough "
                         "dimensions (has %d, gufunc core with "
                         "signature %s requires %d)",
-                        _get_ufunc_name(ufunc), i < nin ? "Input" : "Output",
+                        ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
                         ufunc->core_signature, num_dims);
                 return -1;
@@ -2074,7 +2074,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
                             "core dimension %d, with gufunc "
                             "signature %s (size %zd is different "
                             "from %zd)",
-                            _get_ufunc_name(ufunc), i < nin ? "Input" : "Output",
+                            ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
                             i < nin ? i : i - nin, idim,
                             ufunc->core_signature, op_dim_size,
                             core_dim_sizes[core_dim_index]);
@@ -2117,7 +2117,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
         PyErr_Format(PyExc_ValueError,
                      "%s: Output operand %d has core dimension %d "
                      "unspecified, with gufunc signature %s",
-                     _get_ufunc_name(ufunc), out_op, i, ufunc->core_signature);
+                     ufunc_get_name_cstr(ufunc), out_op, i, ufunc->core_signature);
         return -1;
     }
     return 0;
@@ -2186,7 +2186,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     nout = ufunc->nout;
     nop = nin + nout;
 
-    ufunc_name = _get_ufunc_name(ufunc);
+    ufunc_name = ufunc_get_name_cstr(ufunc);
 
     NPY_UF_DBG_PRINT1("\nEvaluating ufunc %s\n", ufunc_name);
 
@@ -2648,7 +2648,7 @@ PyUFunc_GenericFunction(PyUFuncObject *ufunc,
     nout = ufunc->nout;
     nop = nin + nout;
 
-    ufunc_name = _get_ufunc_name(ufunc);
+    ufunc_name = ufunc_get_name_cstr(ufunc);
 
     NPY_UF_DBG_PRINT1("\nEvaluating ufunc %s\n", ufunc_name);
 
@@ -2888,7 +2888,7 @@ reduce_type_resolver(PyUFuncObject *ufunc, PyArrayObject *arr,
     int i, retcode;
     PyArrayObject *op[3] = {arr, arr, NULL};
     PyArray_Descr *dtypes[3] = {NULL, NULL, NULL};
-    const char *ufunc_name = _get_ufunc_name(ufunc);
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
     PyObject *type_tup = NULL;
 
     *out_dtype = NULL;
@@ -3077,7 +3077,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     PyArray_Descr *dtype;
     PyArrayObject *result;
     PyArray_AssignReduceIdentityFunc *assign_identity = NULL;
-    const char *ufunc_name = _get_ufunc_name(ufunc);
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
     /* These parameters come from a TLS global */
     int buffersize = 0, errormask = 0;
 
@@ -3185,7 +3185,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     PyUFuncGenericFunction innerloop = NULL;
     void *innerloopdata = NULL;
 
-    const char *ufunc_name = _get_ufunc_name(ufunc);
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     /* These parameters come from extobj= or from a TLS global */
     int buffersize = 0, errormask = 0;
@@ -3552,7 +3552,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     PyUFuncGenericFunction innerloop = NULL;
     void *innerloopdata = NULL;
 
-    const char *ufunc_name = _get_ufunc_name(ufunc);
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
     char *opname = "reduceat";
 
     /* These parameters come from extobj= or from a TLS global */

--- a/numpy/core/src/umath/ufunc_object.h
+++ b/numpy/core/src/umath/ufunc_object.h
@@ -7,6 +7,9 @@ ufunc_geterr(PyObject *NPY_UNUSED(dummy), PyObject *args);
 NPY_NO_EXPORT PyObject *
 ufunc_seterr(PyObject *NPY_UNUSED(dummy), PyObject *args);
 
+NPY_NO_EXPORT const char*
+ufunc_get_name_cstr(PyUFuncObject *ufunc);
+
 /* interned strings (on umath import) */
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_out;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_um_str_subok;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -21,6 +21,7 @@
 
 #include "numpy/ufuncobject.h"
 #include "ufunc_type_resolution.h"
+#include "ufunc_object.h"
 #include "common.h"
 
 static const char *
@@ -56,9 +57,7 @@ PyUFunc_ValidateCasting(PyUFuncObject *ufunc,
                             PyArray_Descr **dtypes)
 {
     int i, nin = ufunc->nin, nop = nin + ufunc->nout;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     for (i = 0; i < nop; ++i) {
         if (i < nin) {
@@ -184,9 +183,7 @@ PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, type_num1, type_num2;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     if (ufunc->nin != 2 || ufunc->nout != 1) {
         PyErr_Format(PyExc_RuntimeError, "ufunc %s is configured "
@@ -290,9 +287,7 @@ PyUFunc_SimpleUnaryOperationTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, type_num1;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     if (ufunc->nin != 1 || ufunc->nout != 1) {
         PyErr_Format(PyExc_RuntimeError, "ufunc %s is configured "
@@ -430,9 +425,7 @@ PyUFunc_SimpleBinaryOperationTypeResolver(PyUFuncObject *ufunc,
                                 PyArray_Descr **out_dtypes)
 {
     int i, type_num1, type_num2;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     if (ufunc->nin != 2 || ufunc->nout != 1) {
         PyErr_Format(PyExc_RuntimeError, "ufunc %s is configured "
@@ -614,9 +607,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
@@ -804,9 +795,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
@@ -986,9 +975,7 @@ PyUFunc_MultiplicationTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
@@ -1130,9 +1117,7 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
-    const char *ufunc_name;
-
-    ufunc_name = ufunc->name ? ufunc->name : "<unnamed ufunc>";
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
 
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
@@ -1342,7 +1327,7 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
     PyObject *errmsg;
     int i, j;
 
-    ufunc_name = ufunc->name ? ufunc->name : "(unknown)";
+    ufunc_name = ufunc_get_name_cstr(ufunc);
 
     /*
      * If there are user-loops search them first.
@@ -1832,7 +1817,7 @@ type_tuple_userloop_type_resolver(PyUFuncObject *self,
                              "matching the type-tuple, "
                              "but the inputs and/or outputs could not be "
                              "cast according to the casting rule",
-                             self->name ? self->name : "(unknown)");
+                             ufunc_get_name_cstr(self));
                         return -1;
                     /* Error */
                     case -1:
@@ -1936,7 +1921,7 @@ linear_search_type_resolver(PyUFuncObject *self,
     /* For making a better error message on coercion error */
     char err_dst_typecode = '-', err_src_typecode = '-';
 
-    ufunc_name = self->name ? self->name : "(unknown)";
+    ufunc_name = ufunc_get_name_cstr(self);
 
     use_min_scalar = should_use_min_scalar(op, nin);
 
@@ -2045,7 +2030,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
     /* For making a better error message on coercion error */
     char err_dst_typecode = '-', err_src_typecode = '-';
 
-    ufunc_name = self->name ? self->name : "(unknown)";
+    ufunc_name = ufunc_get_name_cstr(self);
 
     use_min_scalar = should_use_min_scalar(op, nin);
 
@@ -2057,7 +2042,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
             PyErr_Format(PyExc_ValueError,
                          "a type-tuple must be specified "
                          "of length 1 or %d for ufunc '%s'", (int)nop,
-                         self->name ? self->name : "(unknown)");
+                         ufunc_get_name_cstr(self));
             return -1;
         }
 
@@ -2110,7 +2095,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
                                  "requires 1 typecode, or "
                                  "%d typecode(s) before " \
                                  "and %d after the -> sign",
-                                 self->name ? self->name : "(unknown)",
+                                 ufunc_get_name_cstr(self),
                                  self->nin, self->nout);
             Py_XDECREF(str_obj);
             return -1;


### PR DESCRIPTION
Follows on from gh-8876

This function needed lifting to a more visible level, so it could be used in the auxiliary ufunc files.

`ufunc_get_name_cstr` is a lousy name, but `ufunc_get_name` is already taken by the function returning `PyObject*`