### PR TITLE
MAINT: Replace tab escapes with four spaces

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -99,8 +99,8 @@ cppmacros['CFUNCSMESS'] = """\
 #ifdef DEBUGCFUNCS
 #define CFUNCSMESS(mess) fprintf(stderr,\"debug-capi:\"mess);
 #define CFUNCSMESSPY(mess,obj) CFUNCSMESS(mess) \\
-\tPyObject_Print((PyObject *)obj,stderr,Py_PRINT_RAW);\\
-\tfprintf(stderr,\"\\n\");
+    PyObject_Print((PyObject *)obj,stderr,Py_PRINT_RAW);\\
+    fprintf(stderr,\"\\n\");
 #else
 #define CFUNCSMESS(mess)
 #define CFUNCSMESSPY(mess,obj)
@@ -219,18 +219,18 @@ cppmacros['SWAPUNSAFE'] = """\
 """
 cppmacros['SWAP'] = """\
 #define SWAP(a,b,t) {\\
-\tt *c;\\
-\tc = a;\\
-\ta = b;\\
-\tb = c;}
+    t *c;\\
+    c = a;\\
+    a = b;\\
+    b = c;}
 """
 # cppmacros['ISCONTIGUOUS']='#define ISCONTIGUOUS(m) (PyArray_FLAGS(m) &
 # NPY_ARRAY_C_CONTIGUOUS)'
 cppmacros['PRINTPYOBJERR'] = """\
 #define PRINTPYOBJERR(obj)\\
-\tfprintf(stderr,\"#modulename#.error is related to \");\\
-\tPyObject_Print((PyObject *)obj,stderr,Py_PRINT_RAW);\\
-\tfprintf(stderr,\"\\n\");
+    fprintf(stderr,\"#modulename#.error is related to \");\\
+    PyObject_Print((PyObject *)obj,stderr,Py_PRINT_RAW);\\
+    fprintf(stderr,\"\\n\");
 """
 cppmacros['MINMAX'] = """\
 #ifndef max
@@ -401,59 +401,59 @@ cppmacros['TRYCOMPLEXPYARRAYTEMPLATE'] = """\
 """
 # cppmacros['NUMFROMARROBJ']="""\
 # define NUMFROMARROBJ(typenum,ctype) \\
-# \tif (PyArray_Check(obj)) arr = (PyArrayObject *)obj;\\
-# \telse arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
-# \tif (arr) {\\
-# \t\tif (PyArray_TYPE(arr)==NPY_OBJECT) {\\
-# \t\t\tif (!ctype ## _from_pyobj(v,(PyArray_DESCR(arr)->getitem)(PyArray_DATA(arr)),\"\"))\\
-# \t\t\tgoto capi_fail;\\
-# \t\t} else {\\
-# \t\t\t(PyArray_DESCR(arr)->cast[typenum])(PyArray_DATA(arr),1,(char*)v,1,1);\\
-# \t\t}\\
-# \t\tif ((PyObject *)arr != obj) { Py_DECREF(arr); }\\
-# \t\treturn 1;\\
-# \t}
+#     if (PyArray_Check(obj)) arr = (PyArrayObject *)obj;\\
+#     else arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
+#     if (arr) {\\
+#         if (PyArray_TYPE(arr)==NPY_OBJECT) {\\
+#             if (!ctype ## _from_pyobj(v,(PyArray_DESCR(arr)->getitem)(PyArray_DATA(arr)),\"\"))\\
+#             goto capi_fail;\\
+#         } else {\\
+#             (PyArray_DESCR(arr)->cast[typenum])(PyArray_DATA(arr),1,(char*)v,1,1);\\
+#         }\\
+#         if ((PyObject *)arr != obj) { Py_DECREF(arr); }\\
+#         return 1;\\
+#     }
 # """
 # XXX: Note that CNUMFROMARROBJ is identical with NUMFROMARROBJ
 # cppmacros['CNUMFROMARROBJ']="""\
 # define CNUMFROMARROBJ(typenum,ctype) \\
-# \tif (PyArray_Check(obj)) arr = (PyArrayObject *)obj;\\
-# \telse arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
-# \tif (arr) {\\
-# \t\tif (PyArray_TYPE(arr)==NPY_OBJECT) {\\
-# \t\t\tif (!ctype ## _from_pyobj(v,(PyArray_DESCR(arr)->getitem)(PyArray_DATA(arr)),\"\"))\\
-# \t\t\tgoto capi_fail;\\
-# \t\t} else {\\
-# \t\t\t(PyArray_DESCR(arr)->cast[typenum])((void *)(PyArray_DATA(arr)),1,(void *)(v),1,1);\\
-# \t\t}\\
-# \t\tif ((PyObject *)arr != obj) { Py_DECREF(arr); }\\
-# \t\treturn 1;\\
-# \t}
+#     if (PyArray_Check(obj)) arr = (PyArrayObject *)obj;\\
+#     else arr = (PyArrayObject *)PyArray_ContiguousFromObject(obj,typenum,0,0);\\
+#     if (arr) {\\
+#         if (PyArray_TYPE(arr)==NPY_OBJECT) {\\
+#             if (!ctype ## _from_pyobj(v,(PyArray_DESCR(arr)->getitem)(PyArray_DATA(arr)),\"\"))\\
+#             goto capi_fail;\\
+#         } else {\\
+#             (PyArray_DESCR(arr)->cast[typenum])((void *)(PyArray_DATA(arr)),1,(void *)(v),1,1);\\
+#         }\\
+#         if ((PyObject *)arr != obj) { Py_DECREF(arr); }\\
+#         return 1;\\
+#     }
 # """
 
 
 needs['GETSTRFROMPYTUPLE'] = ['STRINGCOPYN', 'PRINTPYOBJERR']
 cppmacros['GETSTRFROMPYTUPLE'] = """\
 #define GETSTRFROMPYTUPLE(tuple,index,str,len) {\\
-\t\tPyObject *rv_cb_str = PyTuple_GetItem((tuple),(index));\\
-\t\tif (rv_cb_str == NULL)\\
-\t\t\tgoto capi_fail;\\
-\t\tif (PyString_Check(rv_cb_str)) {\\
-\t\t\tstr[len-1]='\\0';\\
-\t\t\tSTRINGCOPYN((str),PyString_AS_STRING((PyStringObject*)rv_cb_str),(len));\\
-\t\t} else {\\
-\t\t\tPRINTPYOBJERR(rv_cb_str);\\
-\t\t\tPyErr_SetString(#modulename#_error,\"string object expected\");\\
-\t\t\tgoto capi_fail;\\
-\t\t}\\
-\t}
+        PyObject *rv_cb_str = PyTuple_GetItem((tuple),(index));\\
+        if (rv_cb_str == NULL)\\
+            goto capi_fail;\\
+        if (PyString_Check(rv_cb_str)) {\\
+            str[len-1]='\\0';\\
+            STRINGCOPYN((str),PyString_AS_STRING((PyStringObject*)rv_cb_str),(len));\\
+        } else {\\
+            PRINTPYOBJERR(rv_cb_str);\\
+            PyErr_SetString(#modulename#_error,\"string object expected\");\\
+            goto capi_fail;\\
+        }\\
+    }
 """
 cppmacros['GETSCALARFROMPYTUPLE'] = """\
 #define GETSCALARFROMPYTUPLE(tuple,index,var,ctype,mess) {\\
-\t\tif ((capi_tmp = PyTuple_GetItem((tuple),(index)))==NULL) goto capi_fail;\\
-\t\tif (!(ctype ## _from_pyobj((var),capi_tmp,mess)))\\
-\t\t\tgoto capi_fail;\\
-\t}
+        if ((capi_tmp = PyTuple_GetItem((tuple),(index)))==NULL) goto capi_fail;\\
+        if (!(ctype ## _from_pyobj((var),capi_tmp,mess)))\\
+            goto capi_fail;\\
+    }
 """
 
 cppmacros['FAILNULL'] = """\\
@@ -471,12 +471,12 @@ cppmacros['MEMCOPY'] = """\
 """
 cppmacros['STRINGMALLOC'] = """\
 #define STRINGMALLOC(str,len)\\
-\tif ((str = (string)malloc(sizeof(char)*(len+1))) == NULL) {\\
-\t\tPyErr_SetString(PyExc_MemoryError, \"out of memory\");\\
-\t\tgoto capi_fail;\\
-\t} else {\\
-\t\t(str)[len] = '\\0';\\
-\t}
+    if ((str = (string)malloc(sizeof(char)*(len+1))) == NULL) {\\
+        PyErr_SetString(PyExc_MemoryError, \"out of memory\");\\
+        goto capi_fail;\\
+    } else {\\
+        (str)[len] = '\\0';\\
+    }
 """
 cppmacros['STRINGFREE'] = """\
 #define STRINGFREE(str) do {if (!(str == NULL)) free(str);} while (0)
@@ -504,39 +504,39 @@ cppmacros['STRINGCOPY'] = """\
 """
 cppmacros['CHECKGENERIC'] = """\
 #define CHECKGENERIC(check,tcheck,name) \\
-\tif (!(check)) {\\
-\t\tPyErr_SetString(#modulename#_error,\"(\"tcheck\") failed for \"name);\\
-\t\t/*goto capi_fail;*/\\
-\t} else """
+    if (!(check)) {\\
+        PyErr_SetString(#modulename#_error,\"(\"tcheck\") failed for \"name);\\
+        /*goto capi_fail;*/\\
+    } else """
 cppmacros['CHECKARRAY'] = """\
 #define CHECKARRAY(check,tcheck,name) \\
-\tif (!(check)) {\\
-\t\tPyErr_SetString(#modulename#_error,\"(\"tcheck\") failed for \"name);\\
-\t\t/*goto capi_fail;*/\\
-\t} else """
+    if (!(check)) {\\
+        PyErr_SetString(#modulename#_error,\"(\"tcheck\") failed for \"name);\\
+        /*goto capi_fail;*/\\
+    } else """
 cppmacros['CHECKSTRING'] = """\
 #define CHECKSTRING(check,tcheck,name,show,var)\\
-\tif (!(check)) {\\
-\t\tchar errstring[256];\\
-\t\tsprintf(errstring, \"%s: \"show, \"(\"tcheck\") failed for \"name, slen(var), var);\\
-\t\tPyErr_SetString(#modulename#_error, errstring);\\
-\t\t/*goto capi_fail;*/\\
-\t} else """
+    if (!(check)) {\\
+        char errstring[256];\\
+        sprintf(errstring, \"%s: \"show, \"(\"tcheck\") failed for \"name, slen(var), var);\\
+        PyErr_SetString(#modulename#_error, errstring);\\
+        /*goto capi_fail;*/\\
+    } else """
 cppmacros['CHECKSCALAR'] = """\
 #define CHECKSCALAR(check,tcheck,name,show,var)\\
-\tif (!(check)) {\\
-\t\tchar errstring[256];\\
-\t\tsprintf(errstring, \"%s: \"show, \"(\"tcheck\") failed for \"name, var);\\
-\t\tPyErr_SetString(#modulename#_error,errstring);\\
-\t\t/*goto capi_fail;*/\\
-\t} else """
+    if (!(check)) {\\
+        char errstring[256];\\
+        sprintf(errstring, \"%s: \"show, \"(\"tcheck\") failed for \"name, var);\\
+        PyErr_SetString(#modulename#_error,errstring);\\
+        /*goto capi_fail;*/\\
+    } else """
 # cppmacros['CHECKDIMS']="""\
 # define CHECKDIMS(dims,rank) \\
-# \tfor (int i=0;i<(rank);i++)\\
-# \t\tif (dims[i]<0) {\\
-# \t\t\tfprintf(stderr,\"Unspecified array argument requires a complete dimension specification.\\n\");\\
-# \t\t\tgoto capi_fail;\\
-# \t\t}
+#     for (int i=0;i<(rank);i++)\\
+#         if (dims[i]<0) {\\
+#             fprintf(stderr,\"Unspecified array argument requires a complete dimension specification.\\n\");\\
+#             goto capi_fail;\\
+#         }
 # """
 cppmacros[
     'ARRSIZE'] = '#define ARRSIZE(dims,rank) (_PyArray_multiply_list(dims,rank))'
@@ -549,17 +549,17 @@ cppmacros['OLDPYNUM'] = """\
 
 cfuncs['calcarrindex'] = """\
 static int calcarrindex(int *i,PyArrayObject *arr) {
-\tint k,ii = i[0];
-\tfor (k=1; k < PyArray_NDIM(arr); k++)
-\t\tii += (ii*(PyArray_DIM(arr,k) - 1)+i[k]); /* assuming contiguous arr */
-\treturn ii;
+    int k,ii = i[0];
+    for (k=1; k < PyArray_NDIM(arr); k++)
+        ii += (ii*(PyArray_DIM(arr,k) - 1)+i[k]); /* assuming contiguous arr */
+    return ii;
 }"""
 cfuncs['calcarrindextr'] = """\
 static int calcarrindextr(int *i,PyArrayObject *arr) {
-\tint k,ii = i[PyArray_NDIM(arr)-1];
-\tfor (k=1; k < PyArray_NDIM(arr); k++)
-\t\tii += (ii*(PyArray_DIM(arr,PyArray_NDIM(arr)-k-1) - 1)+i[PyArray_NDIM(arr)-k-1]); /* assuming contiguous arr */
-\treturn ii;
+    int k,ii = i[PyArray_NDIM(arr)-1];
+    for (k=1; k < PyArray_NDIM(arr); k++)
+        ii += (ii*(PyArray_DIM(arr,PyArray_NDIM(arr)-k-1) - 1)+i[PyArray_NDIM(arr)-k-1]); /* assuming contiguous arr */
+    return ii;
 }"""
 cfuncs['forcomb'] = """\
 static struct { int nd;npy_intp *d;int *i,*i_tr,tr; } forcombcache;
@@ -604,543 +604,543 @@ static int *nextforcomb(void) {
 needs['try_pyarr_from_string'] = ['STRINGCOPYN', 'PRINTPYOBJERR', 'string']
 cfuncs['try_pyarr_from_string'] = """\
 static int try_pyarr_from_string(PyObject *obj,const string str) {
-\tPyArrayObject *arr = NULL;
-\tif (PyArray_Check(obj) && (!((arr = (PyArrayObject *)obj) == NULL)))
-\t\t{ STRINGCOPYN(PyArray_DATA(arr),str,PyArray_NBYTES(arr)); }
-\treturn 1;
+    PyArrayObject *arr = NULL;
+    if (PyArray_Check(obj) && (!((arr = (PyArrayObject *)obj) == NULL)))
+        { STRINGCOPYN(PyArray_DATA(arr),str,PyArray_NBYTES(arr)); }
+    return 1;
 capi_fail:
-\tPRINTPYOBJERR(obj);
-\tPyErr_SetString(#modulename#_error,\"try_pyarr_from_string failed\");
-\treturn 0;
+    PRINTPYOBJERR(obj);
+    PyErr_SetString(#modulename#_error,\"try_pyarr_from_string failed\");
+    return 0;
 }
 """
 needs['string_from_pyobj'] = ['string', 'STRINGMALLOC', 'STRINGCOPYN']
 cfuncs['string_from_pyobj'] = """\
 static int string_from_pyobj(string *str,int *len,const string inistr,PyObject *obj,const char *errmess) {
-\tPyArrayObject *arr = NULL;
-\tPyObject *tmp = NULL;
+    PyArrayObject *arr = NULL;
+    PyObject *tmp = NULL;
 #ifdef DEBUGCFUNCS
 fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",(char*)str,*len,(char *)inistr,obj);
 #endif
-\tif (obj == Py_None) {
-\t\tif (*len == -1)
-\t\t\t*len = strlen(inistr); /* Will this cause problems? */
-\t\tSTRINGMALLOC(*str,*len);
-\t\tSTRINGCOPYN(*str,inistr,*len+1);
-\t\treturn 1;
-\t}
-\tif (PyArray_Check(obj)) {
-\t\tif ((arr = (PyArrayObject *)obj) == NULL)
-\t\t\tgoto capi_fail;
-\t\tif (!ISCONTIGUOUS(arr)) {
-\t\t\tPyErr_SetString(PyExc_ValueError,\"array object is non-contiguous.\");
-\t\t\tgoto capi_fail;
-\t\t}
-\t\tif (*len == -1)
-\t\t\t*len = (PyArray_ITEMSIZE(arr))*PyArray_SIZE(arr);
-\t\tSTRINGMALLOC(*str,*len);
-\t\tSTRINGCOPYN(*str,PyArray_DATA(arr),*len+1);
-\t\treturn 1;
-\t}
-\tif (PyString_Check(obj)) {
-\t\ttmp = obj;
-\t\tPy_INCREF(tmp);
-\t}
+    if (obj == Py_None) {
+        if (*len == -1)
+            *len = strlen(inistr); /* Will this cause problems? */
+        STRINGMALLOC(*str,*len);
+        STRINGCOPYN(*str,inistr,*len+1);
+        return 1;
+    }
+    if (PyArray_Check(obj)) {
+        if ((arr = (PyArrayObject *)obj) == NULL)
+            goto capi_fail;
+        if (!ISCONTIGUOUS(arr)) {
+            PyErr_SetString(PyExc_ValueError,\"array object is non-contiguous.\");
+            goto capi_fail;
+        }
+        if (*len == -1)
+            *len = (PyArray_ITEMSIZE(arr))*PyArray_SIZE(arr);
+        STRINGMALLOC(*str,*len);
+        STRINGCOPYN(*str,PyArray_DATA(arr),*len+1);
+        return 1;
+    }
+    if (PyString_Check(obj)) {
+        tmp = obj;
+        Py_INCREF(tmp);
+    }
 #if PY_VERSION_HEX >= 0x03000000
-\telse if (PyUnicode_Check(obj)) {
-\t\ttmp = PyUnicode_AsASCIIString(obj);
-\t}
-\telse {
-\t\tPyObject *tmp2;
-\t\ttmp2 = PyObject_Str(obj);
-\t\tif (tmp2) {
-\t\t\ttmp = PyUnicode_AsASCIIString(tmp2);
-\t\t\tPy_DECREF(tmp2);
-\t\t}
-\t\telse {
-\t\t\ttmp = NULL;
-\t\t}
-\t}
+    else if (PyUnicode_Check(obj)) {
+        tmp = PyUnicode_AsASCIIString(obj);
+    }
+    else {
+        PyObject *tmp2;
+        tmp2 = PyObject_Str(obj);
+        if (tmp2) {
+            tmp = PyUnicode_AsASCIIString(tmp2);
+            Py_DECREF(tmp2);
+        }
+        else {
+            tmp = NULL;
+        }
+    }
 #else
-\telse {
-\t\ttmp = PyObject_Str(obj);
-\t}
+    else {
+        tmp = PyObject_Str(obj);
+    }
 #endif
-\tif (tmp == NULL) goto capi_fail;
-\tif (*len == -1)
-\t\t*len = PyString_GET_SIZE(tmp);
-\tSTRINGMALLOC(*str,*len);
-\tSTRINGCOPYN(*str,PyString_AS_STRING(tmp),*len+1);
-\tPy_DECREF(tmp);
-\treturn 1;
+    if (tmp == NULL) goto capi_fail;
+    if (*len == -1)
+        *len = PyString_GET_SIZE(tmp);
+    STRINGMALLOC(*str,*len);
+    STRINGCOPYN(*str,PyString_AS_STRING(tmp),*len+1);
+    Py_DECREF(tmp);
+    return 1;
 capi_fail:
-\tPy_XDECREF(tmp);
-\t{
-\t\tPyObject* err = PyErr_Occurred();
-\t\tif (err==NULL) err = #modulename#_error;
-\t\tPyErr_SetString(err,errmess);
-\t}
-\treturn 0;
+    Py_XDECREF(tmp);
+    {
+        PyObject* err = PyErr_Occurred();
+        if (err==NULL) err = #modulename#_error;
+        PyErr_SetString(err,errmess);
+    }
+    return 0;
 }
 """
 needs['char_from_pyobj'] = ['int_from_pyobj']
 cfuncs['char_from_pyobj'] = """\
 static int char_from_pyobj(char* v,PyObject *obj,const char *errmess) {
-\tint i=0;
-\tif (int_from_pyobj(&i,obj,errmess)) {
-\t\t*v = (char)i;
-\t\treturn 1;
-\t}
-\treturn 0;
+    int i=0;
+    if (int_from_pyobj(&i,obj,errmess)) {
+        *v = (char)i;
+        return 1;
+    }
+    return 0;
 }
 """
 needs['signed_char_from_pyobj'] = ['int_from_pyobj', 'signed_char']
 cfuncs['signed_char_from_pyobj'] = """\
 static int signed_char_from_pyobj(signed_char* v,PyObject *obj,const char *errmess) {
-\tint i=0;
-\tif (int_from_pyobj(&i,obj,errmess)) {
-\t\t*v = (signed_char)i;
-\t\treturn 1;
-\t}
-\treturn 0;
+    int i=0;
+    if (int_from_pyobj(&i,obj,errmess)) {
+        *v = (signed_char)i;
+        return 1;
+    }
+    return 0;
 }
 """
 needs['short_from_pyobj'] = ['int_from_pyobj']
 cfuncs['short_from_pyobj'] = """\
 static int short_from_pyobj(short* v,PyObject *obj,const char *errmess) {
-\tint i=0;
-\tif (int_from_pyobj(&i,obj,errmess)) {
-\t\t*v = (short)i;
-\t\treturn 1;
-\t}
-\treturn 0;
+    int i=0;
+    if (int_from_pyobj(&i,obj,errmess)) {
+        *v = (short)i;
+        return 1;
+    }
+    return 0;
 }
 """
 cfuncs['int_from_pyobj'] = """\
 static int int_from_pyobj(int* v,PyObject *obj,const char *errmess) {
-\tPyObject* tmp = NULL;
-\tif (PyInt_Check(obj)) {
-\t\t*v = (int)PyInt_AS_LONG(obj);
-\t\treturn 1;
-\t}
-\ttmp = PyNumber_Int(obj);
-\tif (tmp) {
-\t\t*v = PyInt_AS_LONG(tmp);
-\t\tPy_DECREF(tmp);
-\t\treturn 1;
-\t}
-\tif (PyComplex_Check(obj))
-\t\ttmp = PyObject_GetAttrString(obj,\"real\");
-\telse if (PyString_Check(obj) || PyUnicode_Check(obj))
-\t\t/*pass*/;
-\telse if (PySequence_Check(obj))
-\t\ttmp = PySequence_GetItem(obj,0);
-\tif (tmp) {
-\t\tPyErr_Clear();
-\t\tif (int_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
-\t\tPy_DECREF(tmp);
-\t}
-\t{
-\t\tPyObject* err = PyErr_Occurred();
-\t\tif (err==NULL) err = #modulename#_error;
-\t\tPyErr_SetString(err,errmess);
-\t}
-\treturn 0;
+    PyObject* tmp = NULL;
+    if (PyInt_Check(obj)) {
+        *v = (int)PyInt_AS_LONG(obj);
+        return 1;
+    }
+    tmp = PyNumber_Int(obj);
+    if (tmp) {
+        *v = PyInt_AS_LONG(tmp);
+        Py_DECREF(tmp);
+        return 1;
+    }
+    if (PyComplex_Check(obj))
+        tmp = PyObject_GetAttrString(obj,\"real\");
+    else if (PyString_Check(obj) || PyUnicode_Check(obj))
+        /*pass*/;
+    else if (PySequence_Check(obj))
+        tmp = PySequence_GetItem(obj,0);
+    if (tmp) {
+        PyErr_Clear();
+        if (int_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
+        Py_DECREF(tmp);
+    }
+    {
+        PyObject* err = PyErr_Occurred();
+        if (err==NULL) err = #modulename#_error;
+        PyErr_SetString(err,errmess);
+    }
+    return 0;
 }
 """
 cfuncs['long_from_pyobj'] = """\
 static int long_from_pyobj(long* v,PyObject *obj,const char *errmess) {
-\tPyObject* tmp = NULL;
-\tif (PyInt_Check(obj)) {
-\t\t*v = PyInt_AS_LONG(obj);
-\t\treturn 1;
-\t}
-\ttmp = PyNumber_Int(obj);
-\tif (tmp) {
-\t\t*v = PyInt_AS_LONG(tmp);
-\t\tPy_DECREF(tmp);
-\t\treturn 1;
-\t}
-\tif (PyComplex_Check(obj))
-\t\ttmp = PyObject_GetAttrString(obj,\"real\");
-\telse if (PyString_Check(obj) || PyUnicode_Check(obj))
-\t\t/*pass*/;
-\telse if (PySequence_Check(obj))
-\t\ttmp = PySequence_GetItem(obj,0);
-\tif (tmp) {
-\t\tPyErr_Clear();
-\t\tif (long_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
-\t\tPy_DECREF(tmp);
-\t}
-\t{
-\t\tPyObject* err = PyErr_Occurred();
-\t\tif (err==NULL) err = #modulename#_error;
-\t\tPyErr_SetString(err,errmess);
-\t}
-\treturn 0;
+    PyObject* tmp = NULL;
+    if (PyInt_Check(obj)) {
+        *v = PyInt_AS_LONG(obj);
+        return 1;
+    }
+    tmp = PyNumber_Int(obj);
+    if (tmp) {
+        *v = PyInt_AS_LONG(tmp);
+        Py_DECREF(tmp);
+        return 1;
+    }
+    if (PyComplex_Check(obj))
+        tmp = PyObject_GetAttrString(obj,\"real\");
+    else if (PyString_Check(obj) || PyUnicode_Check(obj))
+        /*pass*/;
+    else if (PySequence_Check(obj))
+        tmp = PySequence_GetItem(obj,0);
+    if (tmp) {
+        PyErr_Clear();
+        if (long_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
+        Py_DECREF(tmp);
+    }
+    {
+        PyObject* err = PyErr_Occurred();
+        if (err==NULL) err = #modulename#_error;
+        PyErr_SetString(err,errmess);
+    }
+    return 0;
 }
 """
 needs['long_long_from_pyobj'] = ['long_long']
 cfuncs['long_long_from_pyobj'] = """\
 static int long_long_from_pyobj(long_long* v,PyObject *obj,const char *errmess) {
-\tPyObject* tmp = NULL;
-\tif (PyLong_Check(obj)) {
-\t\t*v = PyLong_AsLongLong(obj);
-\t\treturn (!PyErr_Occurred());
-\t}
-\tif (PyInt_Check(obj)) {
-\t\t*v = (long_long)PyInt_AS_LONG(obj);
-\t\treturn 1;
-\t}
-\ttmp = PyNumber_Long(obj);
-\tif (tmp) {
-\t\t*v = PyLong_AsLongLong(tmp);
-\t\tPy_DECREF(tmp);
-\t\treturn (!PyErr_Occurred());
-\t}
-\tif (PyComplex_Check(obj))
-\t\ttmp = PyObject_GetAttrString(obj,\"real\");
-\telse if (PyString_Check(obj) || PyUnicode_Check(obj))
-\t\t/*pass*/;
-\telse if (PySequence_Check(obj))
-\t\ttmp = PySequence_GetItem(obj,0);
-\tif (tmp) {
-\t\tPyErr_Clear();
-\t\tif (long_long_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
-\t\tPy_DECREF(tmp);
-\t}
-\t{
-\t\tPyObject* err = PyErr_Occurred();
-\t\tif (err==NULL) err = #modulename#_error;
-\t\tPyErr_SetString(err,errmess);
-\t}
-\treturn 0;
+    PyObject* tmp = NULL;
+    if (PyLong_Check(obj)) {
+        *v = PyLong_AsLongLong(obj);
+        return (!PyErr_Occurred());
+    }
+    if (PyInt_Check(obj)) {
+        *v = (long_long)PyInt_AS_LONG(obj);
+        return 1;
+    }
+    tmp = PyNumber_Long(obj);
+    if (tmp) {
+        *v = PyLong_AsLongLong(tmp);
+        Py_DECREF(tmp);
+        return (!PyErr_Occurred());
+    }
+    if (PyComplex_Check(obj))
+        tmp = PyObject_GetAttrString(obj,\"real\");
+    else if (PyString_Check(obj) || PyUnicode_Check(obj))
+        /*pass*/;
+    else if (PySequence_Check(obj))
+        tmp = PySequence_GetItem(obj,0);
+    if (tmp) {
+        PyErr_Clear();
+        if (long_long_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
+        Py_DECREF(tmp);
+    }
+    {
+        PyObject* err = PyErr_Occurred();
+        if (err==NULL) err = #modulename#_error;
+        PyErr_SetString(err,errmess);
+    }
+    return 0;
 }
 """
 needs['long_double_from_pyobj'] = ['double_from_pyobj', 'long_double']
 cfuncs['long_double_from_pyobj'] = """\
 static int long_double_from_pyobj(long_double* v,PyObject *obj,const char *errmess) {
-\tdouble d=0;
-\tif (PyArray_CheckScalar(obj)){
-\t\tif PyArray_IsScalar(obj, LongDouble) {
-\t\t\tPyArray_ScalarAsCtype(obj, v);
-\t\t\treturn 1;
-\t\t}
-\t\telse if (PyArray_Check(obj) && PyArray_TYPE(obj)==NPY_LONGDOUBLE) {
-\t\t\t(*v) = *((npy_longdouble *)PyArray_DATA(obj));
-\t\t\treturn 1;
-\t\t}
-\t}
-\tif (double_from_pyobj(&d,obj,errmess)) {
-\t\t*v = (long_double)d;
-\t\treturn 1;
-\t}
-\treturn 0;
+    double d=0;
+    if (PyArray_CheckScalar(obj)){
+        if PyArray_IsScalar(obj, LongDouble) {
+            PyArray_ScalarAsCtype(obj, v);
+            return 1;
+        }
+        else if (PyArray_Check(obj) && PyArray_TYPE(obj)==NPY_LONGDOUBLE) {
+            (*v) = *((npy_longdouble *)PyArray_DATA(obj));
+            return 1;
+        }
+    }
+    if (double_from_pyobj(&d,obj,errmess)) {
+        *v = (long_double)d;
+        return 1;
+    }
+    return 0;
 }
 """
 cfuncs['double_from_pyobj'] = """\
 static int double_from_pyobj(double* v,PyObject *obj,const char *errmess) {
-\tPyObject* tmp = NULL;
-\tif (PyFloat_Check(obj)) {
+    PyObject* tmp = NULL;
+    if (PyFloat_Check(obj)) {
 #ifdef __sgi
-\t\t*v = PyFloat_AsDouble(obj);
+        *v = PyFloat_AsDouble(obj);
 #else
-\t\t*v = PyFloat_AS_DOUBLE(obj);
+        *v = PyFloat_AS_DOUBLE(obj);
 #endif
-\t\treturn 1;
-\t}
-\ttmp = PyNumber_Float(obj);
-\tif (tmp) {
+        return 1;
+    }
+    tmp = PyNumber_Float(obj);
+    if (tmp) {
 #ifdef __sgi
-\t\t*v = PyFloat_AsDouble(tmp);
+        *v = PyFloat_AsDouble(tmp);
 #else
-\t\t*v = PyFloat_AS_DOUBLE(tmp);
+        *v = PyFloat_AS_DOUBLE(tmp);
 #endif
-\t\tPy_DECREF(tmp);
-\t\treturn 1;
-\t}
-\tif (PyComplex_Check(obj))
-\t\ttmp = PyObject_GetAttrString(obj,\"real\");
-\telse if (PyString_Check(obj) || PyUnicode_Check(obj))
-\t\t/*pass*/;
-\telse if (PySequence_Check(obj))
-\t\ttmp = PySequence_GetItem(obj,0);
-\tif (tmp) {
-\t\tPyErr_Clear();
-\t\tif (double_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
-\t\tPy_DECREF(tmp);
-\t}
-\t{
-\t\tPyObject* err = PyErr_Occurred();
-\t\tif (err==NULL) err = #modulename#_error;
-\t\tPyErr_SetString(err,errmess);
-\t}
-\treturn 0;
+        Py_DECREF(tmp);
+        return 1;
+    }
+    if (PyComplex_Check(obj))
+        tmp = PyObject_GetAttrString(obj,\"real\");
+    else if (PyString_Check(obj) || PyUnicode_Check(obj))
+        /*pass*/;
+    else if (PySequence_Check(obj))
+        tmp = PySequence_GetItem(obj,0);
+    if (tmp) {
+        PyErr_Clear();
+        if (double_from_pyobj(v,tmp,errmess)) {Py_DECREF(tmp); return 1;}
+        Py_DECREF(tmp);
+    }
+    {
+        PyObject* err = PyErr_Occurred();
+        if (err==NULL) err = #modulename#_error;
+        PyErr_SetString(err,errmess);
+    }
+    return 0;
 }
 """
 needs['float_from_pyobj'] = ['double_from_pyobj']
 cfuncs['float_from_pyobj'] = """\
 static int float_from_pyobj(float* v,PyObject *obj,const char *errmess) {
-\tdouble d=0.0;
-\tif (double_from_pyobj(&d,obj,errmess)) {
-\t\t*v = (float)d;
-\t\treturn 1;
-\t}
-\treturn 0;
+    double d=0.0;
+    if (double_from_pyobj(&d,obj,errmess)) {
+        *v = (float)d;
+        return 1;
+    }
+    return 0;
 }
 """
 needs['complex_long_double_from_pyobj'] = ['complex_long_double', 'long_double',
                                            'complex_double_from_pyobj']
 cfuncs['complex_long_double_from_pyobj'] = """\
 static int complex_long_double_from_pyobj(complex_long_double* v,PyObject *obj,const char *errmess) {
-\tcomplex_double cd={0.0,0.0};
-\tif (PyArray_CheckScalar(obj)){
-\t\tif PyArray_IsScalar(obj, CLongDouble) {
-\t\t\tPyArray_ScalarAsCtype(obj, v);
-\t\t\treturn 1;
-\t\t}
-\t\telse if (PyArray_Check(obj) && PyArray_TYPE(obj)==NPY_CLONGDOUBLE) {
-\t\t\t(*v).r = ((npy_clongdouble *)PyArray_DATA(obj))->real;
-\t\t\t(*v).i = ((npy_clongdouble *)PyArray_DATA(obj))->imag;
-\t\t\treturn 1;
-\t\t}
-\t}
-\tif (complex_double_from_pyobj(&cd,obj,errmess)) {
-\t\t(*v).r = (long_double)cd.r;
-\t\t(*v).i = (long_double)cd.i;
-\t\treturn 1;
-\t}
-\treturn 0;
+    complex_double cd={0.0,0.0};
+    if (PyArray_CheckScalar(obj)){
+        if PyArray_IsScalar(obj, CLongDouble) {
+            PyArray_ScalarAsCtype(obj, v);
+            return 1;
+        }
+        else if (PyArray_Check(obj) && PyArray_TYPE(obj)==NPY_CLONGDOUBLE) {
+            (*v).r = ((npy_clongdouble *)PyArray_DATA(obj))->real;
+            (*v).i = ((npy_clongdouble *)PyArray_DATA(obj))->imag;
+            return 1;
+        }
+    }
+    if (complex_double_from_pyobj(&cd,obj,errmess)) {
+        (*v).r = (long_double)cd.r;
+        (*v).i = (long_double)cd.i;
+        return 1;
+    }
+    return 0;
 }
 """
 needs['complex_double_from_pyobj'] = ['complex_double']
 cfuncs['complex_double_from_pyobj'] = """\
 static int complex_double_from_pyobj(complex_double* v,PyObject *obj,const char *errmess) {
-\tPy_complex c;
-\tif (PyComplex_Check(obj)) {
-\t\tc=PyComplex_AsCComplex(obj);
-\t\t(*v).r=c.real, (*v).i=c.imag;
-\t\treturn 1;
-\t}
-\tif (PyArray_IsScalar(obj, ComplexFloating)) {
-\t\tif (PyArray_IsScalar(obj, CFloat)) {
-\t\t\tnpy_cfloat new;
-\t\t\tPyArray_ScalarAsCtype(obj, &new);
-\t\t\t(*v).r = (double)new.real;
-\t\t\t(*v).i = (double)new.imag;
-\t\t}
-\t\telse if (PyArray_IsScalar(obj, CLongDouble)) {
-\t\t\tnpy_clongdouble new;
-\t\t\tPyArray_ScalarAsCtype(obj, &new);
-\t\t\t(*v).r = (double)new.real;
-\t\t\t(*v).i = (double)new.imag;
-\t\t}
-\t\telse { /* if (PyArray_IsScalar(obj, CDouble)) */
-\t\t\tPyArray_ScalarAsCtype(obj, v);
-\t\t}
-\t\treturn 1;
-\t}
-\tif (PyArray_CheckScalar(obj)) { /* 0-dim array or still array scalar */
-\t\tPyObject *arr;
-\t\tif (PyArray_Check(obj)) {
-\t\t\tarr = PyArray_Cast((PyArrayObject *)obj, NPY_CDOUBLE);
-\t\t}
-\t\telse {
-\t\t\tarr = PyArray_FromScalar(obj, PyArray_DescrFromType(NPY_CDOUBLE));
-\t\t}
-\t\tif (arr==NULL) return 0;
-\t\t(*v).r = ((npy_cdouble *)PyArray_DATA(arr))->real;
-\t\t(*v).i = ((npy_cdouble *)PyArray_DATA(arr))->imag;
-\t\treturn 1;
-\t}
-\t/* Python does not provide PyNumber_Complex function :-( */
-\t(*v).i=0.0;
-\tif (PyFloat_Check(obj)) {
+    Py_complex c;
+    if (PyComplex_Check(obj)) {
+        c=PyComplex_AsCComplex(obj);
+        (*v).r=c.real, (*v).i=c.imag;
+        return 1;
+    }
+    if (PyArray_IsScalar(obj, ComplexFloating)) {
+        if (PyArray_IsScalar(obj, CFloat)) {
+            npy_cfloat new;
+            PyArray_ScalarAsCtype(obj, &new);
+            (*v).r = (double)new.real;
+            (*v).i = (double)new.imag;
+        }
+        else if (PyArray_IsScalar(obj, CLongDouble)) {
+            npy_clongdouble new;
+            PyArray_ScalarAsCtype(obj, &new);
+            (*v).r = (double)new.real;
+            (*v).i = (double)new.imag;
+        }
+        else { /* if (PyArray_IsScalar(obj, CDouble)) */
+            PyArray_ScalarAsCtype(obj, v);
+        }
+        return 1;
+    }
+    if (PyArray_CheckScalar(obj)) { /* 0-dim array or still array scalar */
+        PyObject *arr;
+        if (PyArray_Check(obj)) {
+            arr = PyArray_Cast((PyArrayObject *)obj, NPY_CDOUBLE);
+        }
+        else {
+            arr = PyArray_FromScalar(obj, PyArray_DescrFromType(NPY_CDOUBLE));
+        }
+        if (arr==NULL) return 0;
+        (*v).r = ((npy_cdouble *)PyArray_DATA(arr))->real;
+        (*v).i = ((npy_cdouble *)PyArray_DATA(arr))->imag;
+        return 1;
+    }
+    /* Python does not provide PyNumber_Complex function :-( */
+    (*v).i=0.0;
+    if (PyFloat_Check(obj)) {
 #ifdef __sgi
-\t\t(*v).r = PyFloat_AsDouble(obj);
+        (*v).r = PyFloat_AsDouble(obj);
 #else
-\t\t(*v).r = PyFloat_AS_DOUBLE(obj);
+        (*v).r = PyFloat_AS_DOUBLE(obj);
 #endif
-\t\treturn 1;
-\t}
-\tif (PyInt_Check(obj)) {
-\t\t(*v).r = (double)PyInt_AS_LONG(obj);
-\t\treturn 1;
-\t}
-\tif (PyLong_Check(obj)) {
-\t\t(*v).r = PyLong_AsDouble(obj);
-\t\treturn (!PyErr_Occurred());
-\t}
-\tif (PySequence_Check(obj) && !(PyString_Check(obj) || PyUnicode_Check(obj))) {
-\t\tPyObject *tmp = PySequence_GetItem(obj,0);
-\t\tif (tmp) {
-\t\t\tif (complex_double_from_pyobj(v,tmp,errmess)) {
-\t\t\t\tPy_DECREF(tmp);
-\t\t\t\treturn 1;
-\t\t\t}
-\t\t\tPy_DECREF(tmp);
-\t\t}
-\t}
-\t{
-\t\tPyObject* err = PyErr_Occurred();
-\t\tif (err==NULL)
-\t\t\terr = PyExc_TypeError;
-\t\tPyErr_SetString(err,errmess);
-\t}
-\treturn 0;
+        return 1;
+    }
+    if (PyInt_Check(obj)) {
+        (*v).r = (double)PyInt_AS_LONG(obj);
+        return 1;
+    }
+    if (PyLong_Check(obj)) {
+        (*v).r = PyLong_AsDouble(obj);
+        return (!PyErr_Occurred());
+    }
+    if (PySequence_Check(obj) && !(PyString_Check(obj) || PyUnicode_Check(obj))) {
+        PyObject *tmp = PySequence_GetItem(obj,0);
+        if (tmp) {
+            if (complex_double_from_pyobj(v,tmp,errmess)) {
+                Py_DECREF(tmp);
+                return 1;
+            }
+            Py_DECREF(tmp);
+        }
+    }
+    {
+        PyObject* err = PyErr_Occurred();
+        if (err==NULL)
+            err = PyExc_TypeError;
+        PyErr_SetString(err,errmess);
+    }
+    return 0;
 }
 """
 needs['complex_float_from_pyobj'] = [
     'complex_float', 'complex_double_from_pyobj']
 cfuncs['complex_float_from_pyobj'] = """\
 static int complex_float_from_pyobj(complex_float* v,PyObject *obj,const char *errmess) {
-\tcomplex_double cd={0.0,0.0};
-\tif (complex_double_from_pyobj(&cd,obj,errmess)) {
-\t\t(*v).r = (float)cd.r;
-\t\t(*v).i = (float)cd.i;
-\t\treturn 1;
-\t}
-\treturn 0;
+    complex_double cd={0.0,0.0};
+    if (complex_double_from_pyobj(&cd,obj,errmess)) {
+        (*v).r = (float)cd.r;
+        (*v).i = (float)cd.i;
+        return 1;
+    }
+    return 0;
 }
 """
 needs['try_pyarr_from_char'] = ['pyobj_from_char1', 'TRYPYARRAYTEMPLATE']
 cfuncs[
-    'try_pyarr_from_char'] = 'static int try_pyarr_from_char(PyObject* obj,char* v) {\n\tTRYPYARRAYTEMPLATE(char,\'c\');\n}\n'
+    'try_pyarr_from_char'] = 'static int try_pyarr_from_char(PyObject* obj,char* v) {\n    TRYPYARRAYTEMPLATE(char,\'c\');\n}\n'
 needs['try_pyarr_from_signed_char'] = ['TRYPYARRAYTEMPLATE', 'unsigned_char']
 cfuncs[
-    'try_pyarr_from_unsigned_char'] = 'static int try_pyarr_from_unsigned_char(PyObject* obj,unsigned_char* v) {\n\tTRYPYARRAYTEMPLATE(unsigned_char,\'b\');\n}\n'
+    'try_pyarr_from_unsigned_char'] = 'static int try_pyarr_from_unsigned_char(PyObject* obj,unsigned_char* v) {\n    TRYPYARRAYTEMPLATE(unsigned_char,\'b\');\n}\n'
 needs['try_pyarr_from_signed_char'] = ['TRYPYARRAYTEMPLATE', 'signed_char']
 cfuncs[
-    'try_pyarr_from_signed_char'] = 'static int try_pyarr_from_signed_char(PyObject* obj,signed_char* v) {\n\tTRYPYARRAYTEMPLATE(signed_char,\'1\');\n}\n'
+    'try_pyarr_from_signed_char'] = 'static int try_pyarr_from_signed_char(PyObject* obj,signed_char* v) {\n    TRYPYARRAYTEMPLATE(signed_char,\'1\');\n}\n'
 needs['try_pyarr_from_short'] = ['pyobj_from_short1', 'TRYPYARRAYTEMPLATE']
 cfuncs[
-    'try_pyarr_from_short'] = 'static int try_pyarr_from_short(PyObject* obj,short* v) {\n\tTRYPYARRAYTEMPLATE(short,\'s\');\n}\n'
+    'try_pyarr_from_short'] = 'static int try_pyarr_from_short(PyObject* obj,short* v) {\n    TRYPYARRAYTEMPLATE(short,\'s\');\n}\n'
 needs['try_pyarr_from_int'] = ['pyobj_from_int1', 'TRYPYARRAYTEMPLATE']
 cfuncs[
-    'try_pyarr_from_int'] = 'static int try_pyarr_from_int(PyObject* obj,int* v) {\n\tTRYPYARRAYTEMPLATE(int,\'i\');\n}\n'
+    'try_pyarr_from_int'] = 'static int try_pyarr_from_int(PyObject* obj,int* v) {\n    TRYPYARRAYTEMPLATE(int,\'i\');\n}\n'
 needs['try_pyarr_from_long'] = ['pyobj_from_long1', 'TRYPYARRAYTEMPLATE']
 cfuncs[
-    'try_pyarr_from_long'] = 'static int try_pyarr_from_long(PyObject* obj,long* v) {\n\tTRYPYARRAYTEMPLATE(long,\'l\');\n}\n'
+    'try_pyarr_from_long'] = 'static int try_pyarr_from_long(PyObject* obj,long* v) {\n    TRYPYARRAYTEMPLATE(long,\'l\');\n}\n'
 needs['try_pyarr_from_long_long'] = [
     'pyobj_from_long_long1', 'TRYPYARRAYTEMPLATE', 'long_long']
 cfuncs[
-    'try_pyarr_from_long_long'] = 'static int try_pyarr_from_long_long(PyObject* obj,long_long* v) {\n\tTRYPYARRAYTEMPLATE(long_long,\'L\');\n}\n'
+    'try_pyarr_from_long_long'] = 'static int try_pyarr_from_long_long(PyObject* obj,long_long* v) {\n    TRYPYARRAYTEMPLATE(long_long,\'L\');\n}\n'
 needs['try_pyarr_from_float'] = ['pyobj_from_float1', 'TRYPYARRAYTEMPLATE']
 cfuncs[
-    'try_pyarr_from_float'] = 'static int try_pyarr_from_float(PyObject* obj,float* v) {\n\tTRYPYARRAYTEMPLATE(float,\'f\');\n}\n'
+    'try_pyarr_from_float'] = 'static int try_pyarr_from_float(PyObject* obj,float* v) {\n    TRYPYARRAYTEMPLATE(float,\'f\');\n}\n'
 needs['try_pyarr_from_double'] = ['pyobj_from_double1', 'TRYPYARRAYTEMPLATE']
 cfuncs[
-    'try_pyarr_from_double'] = 'static int try_pyarr_from_double(PyObject* obj,double* v) {\n\tTRYPYARRAYTEMPLATE(double,\'d\');\n}\n'
+    'try_pyarr_from_double'] = 'static int try_pyarr_from_double(PyObject* obj,double* v) {\n    TRYPYARRAYTEMPLATE(double,\'d\');\n}\n'
 needs['try_pyarr_from_complex_float'] = [
     'pyobj_from_complex_float1', 'TRYCOMPLEXPYARRAYTEMPLATE', 'complex_float']
 cfuncs[
-    'try_pyarr_from_complex_float'] = 'static int try_pyarr_from_complex_float(PyObject* obj,complex_float* v) {\n\tTRYCOMPLEXPYARRAYTEMPLATE(float,\'F\');\n}\n'
+    'try_pyarr_from_complex_float'] = 'static int try_pyarr_from_complex_float(PyObject* obj,complex_float* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(float,\'F\');\n}\n'
 needs['try_pyarr_from_complex_double'] = [
     'pyobj_from_complex_double1', 'TRYCOMPLEXPYARRAYTEMPLATE', 'complex_double']
 cfuncs[
-    'try_pyarr_from_complex_double'] = 'static int try_pyarr_from_complex_double(PyObject* obj,complex_double* v) {\n\tTRYCOMPLEXPYARRAYTEMPLATE(double,\'D\');\n}\n'
+    'try_pyarr_from_complex_double'] = 'static int try_pyarr_from_complex_double(PyObject* obj,complex_double* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(double,\'D\');\n}\n'
 
 needs['create_cb_arglist'] = ['CFUNCSMESS', 'PRINTPYOBJERR', 'MINMAX']
 cfuncs['create_cb_arglist'] = """\
 static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofargs,const int nofoptargs,int *nofargs,PyTupleObject **args,const char *errmess) {
-\tPyObject *tmp = NULL;
-\tPyObject *tmp_fun = NULL;
-\tint tot,opt,ext,siz,i,di=0;
-\tCFUNCSMESS(\"create_cb_arglist\\n\");
-\ttot=opt=ext=siz=0;
-\t/* Get the total number of arguments */
-\tif (PyFunction_Check(fun))
-\t\ttmp_fun = fun;
-\telse {
-\t\tdi = 1;
-\t\tif (PyObject_HasAttrString(fun,\"im_func\")) {
-\t\t\ttmp_fun = PyObject_GetAttrString(fun,\"im_func\");
-\t\t}
-\t\telse if (PyObject_HasAttrString(fun,\"__call__\")) {
-\t\t\ttmp = PyObject_GetAttrString(fun,\"__call__\");
-\t\t\tif (PyObject_HasAttrString(tmp,\"im_func\"))
-\t\t\t\ttmp_fun = PyObject_GetAttrString(tmp,\"im_func\");
-\t\t\telse {
-\t\t\t\ttmp_fun = fun; /* built-in function */
-\t\t\t\ttot = maxnofargs;
-\t\t\t\tif (xa != NULL)
-\t\t\t\t\ttot += PyTuple_Size((PyObject *)xa);
-\t\t\t}
-\t\t\tPy_XDECREF(tmp);
-\t\t}
-\t\telse if (PyFortran_Check(fun) || PyFortran_Check1(fun)) {
-\t\t\ttot = maxnofargs;
-\t\t\tif (xa != NULL)
-\t\t\t\ttot += PyTuple_Size((PyObject *)xa);
-\t\t\ttmp_fun = fun;
-\t\t}
-\t\telse if (F2PyCapsule_Check(fun)) {
-\t\t\ttot = maxnofargs;
-\t\t\tif (xa != NULL)
-\t\t\t\text = PyTuple_Size((PyObject *)xa);
-\t\t\tif(ext>0) {
-\t\t\t\tfprintf(stderr,\"extra arguments tuple cannot be used with CObject call-back\\n\");
-\t\t\t\tgoto capi_fail;
-\t\t\t}
-\t\t\ttmp_fun = fun;
-\t\t}
-\t}
+    PyObject *tmp = NULL;
+    PyObject *tmp_fun = NULL;
+    int tot,opt,ext,siz,i,di=0;
+    CFUNCSMESS(\"create_cb_arglist\\n\");
+    tot=opt=ext=siz=0;
+    /* Get the total number of arguments */
+    if (PyFunction_Check(fun))
+        tmp_fun = fun;
+    else {
+        di = 1;
+        if (PyObject_HasAttrString(fun,\"im_func\")) {
+            tmp_fun = PyObject_GetAttrString(fun,\"im_func\");
+        }
+        else if (PyObject_HasAttrString(fun,\"__call__\")) {
+            tmp = PyObject_GetAttrString(fun,\"__call__\");
+            if (PyObject_HasAttrString(tmp,\"im_func\"))
+                tmp_fun = PyObject_GetAttrString(tmp,\"im_func\");
+            else {
+                tmp_fun = fun; /* built-in function */
+                tot = maxnofargs;
+                if (xa != NULL)
+                    tot += PyTuple_Size((PyObject *)xa);
+            }
+            Py_XDECREF(tmp);
+        }
+        else if (PyFortran_Check(fun) || PyFortran_Check1(fun)) {
+            tot = maxnofargs;
+            if (xa != NULL)
+                tot += PyTuple_Size((PyObject *)xa);
+            tmp_fun = fun;
+        }
+        else if (F2PyCapsule_Check(fun)) {
+            tot = maxnofargs;
+            if (xa != NULL)
+                ext = PyTuple_Size((PyObject *)xa);
+            if(ext>0) {
+                fprintf(stderr,\"extra arguments tuple cannot be used with CObject call-back\\n\");
+                goto capi_fail;
+            }
+            tmp_fun = fun;
+        }
+    }
 if (tmp_fun==NULL) {
 fprintf(stderr,\"Call-back argument must be function|instance|instance.__call__|f2py-function but got %s.\\n\",(fun==NULL?\"NULL\":Py_TYPE(fun)->tp_name));
 goto capi_fail;
 }
 #if PY_VERSION_HEX >= 0x03000000
-\tif (PyObject_HasAttrString(tmp_fun,\"__code__\")) {
-\t\tif (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"__code__\"),\"co_argcount\"))
+    if (PyObject_HasAttrString(tmp_fun,\"__code__\")) {
+        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"__code__\"),\"co_argcount\"))
 #else
-\tif (PyObject_HasAttrString(tmp_fun,\"func_code\")) {
-\t\tif (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"func_code\"),\"co_argcount\"))
+    if (PyObject_HasAttrString(tmp_fun,\"func_code\")) {
+        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"func_code\"),\"co_argcount\"))
 #endif
-\t\t\ttot = PyInt_AsLong(PyObject_GetAttrString(tmp,\"co_argcount\")) - di;
-\t\tPy_XDECREF(tmp);
-\t}
-\t/* Get the number of optional arguments */
+            tot = PyInt_AsLong(PyObject_GetAttrString(tmp,\"co_argcount\")) - di;
+        Py_XDECREF(tmp);
+    }
+    /* Get the number of optional arguments */
 #if PY_VERSION_HEX >= 0x03000000
-\tif (PyObject_HasAttrString(tmp_fun,\"__defaults__\")) {
-\t\tif (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"__defaults__\")))
+    if (PyObject_HasAttrString(tmp_fun,\"__defaults__\")) {
+        if (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"__defaults__\")))
 #else
-\tif (PyObject_HasAttrString(tmp_fun,\"func_defaults\")) {
-\t\tif (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"func_defaults\")))
+    if (PyObject_HasAttrString(tmp_fun,\"func_defaults\")) {
+        if (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"func_defaults\")))
 #endif
-\t\t\topt = PyTuple_Size(tmp);
-\t\tPy_XDECREF(tmp);
-\t}
-\t/* Get the number of extra arguments */
-\tif (xa != NULL)
-\t\text = PyTuple_Size((PyObject *)xa);
-\t/* Calculate the size of call-backs argument list */
-\tsiz = MIN(maxnofargs+ext,tot);
-\t*nofargs = MAX(0,siz-ext);
+            opt = PyTuple_Size(tmp);
+        Py_XDECREF(tmp);
+    }
+    /* Get the number of extra arguments */
+    if (xa != NULL)
+        ext = PyTuple_Size((PyObject *)xa);
+    /* Calculate the size of call-backs argument list */
+    siz = MIN(maxnofargs+ext,tot);
+    *nofargs = MAX(0,siz-ext);
 #ifdef DEBUGCFUNCS
-\tfprintf(stderr,\"debug-capi:create_cb_arglist:maxnofargs(-nofoptargs),tot,opt,ext,siz,nofargs=%d(-%d),%d,%d,%d,%d,%d\\n\",maxnofargs,nofoptargs,tot,opt,ext,siz,*nofargs);
+    fprintf(stderr,\"debug-capi:create_cb_arglist:maxnofargs(-nofoptargs),tot,opt,ext,siz,nofargs=%d(-%d),%d,%d,%d,%d,%d\\n\",maxnofargs,nofoptargs,tot,opt,ext,siz,*nofargs);
 #endif
-\tif (siz<tot-opt) {
-\t\tfprintf(stderr,\"create_cb_arglist: Failed to build argument list (siz) with enough arguments (tot-opt) required by user-supplied function (siz,tot,opt=%d,%d,%d).\\n\",siz,tot,opt);
-\t\tgoto capi_fail;
-\t}
-\t/* Initialize argument list */
-\t*args = (PyTupleObject *)PyTuple_New(siz);
-\tfor (i=0;i<*nofargs;i++) {
-\t\tPy_INCREF(Py_None);
-\t\tPyTuple_SET_ITEM((PyObject *)(*args),i,Py_None);
-\t}
-\tif (xa != NULL)
-\t\tfor (i=(*nofargs);i<siz;i++) {
-\t\t\ttmp = PyTuple_GetItem((PyObject *)xa,i-(*nofargs));
-\t\t\tPy_INCREF(tmp);
-\t\t\tPyTuple_SET_ITEM(*args,i,tmp);
-\t\t}
-\tCFUNCSMESS(\"create_cb_arglist-end\\n\");
-\treturn 1;
+    if (siz<tot-opt) {
+        fprintf(stderr,\"create_cb_arglist: Failed to build argument list (siz) with enough arguments (tot-opt) required by user-supplied function (siz,tot,opt=%d,%d,%d).\\n\",siz,tot,opt);
+        goto capi_fail;
+    }
+    /* Initialize argument list */
+    *args = (PyTupleObject *)PyTuple_New(siz);
+    for (i=0;i<*nofargs;i++) {
+        Py_INCREF(Py_None);
+        PyTuple_SET_ITEM((PyObject *)(*args),i,Py_None);
+    }
+    if (xa != NULL)
+        for (i=(*nofargs);i<siz;i++) {
+            tmp = PyTuple_GetItem((PyObject *)xa,i-(*nofargs));
+            Py_INCREF(tmp);
+            PyTuple_SET_ITEM(*args,i,tmp);
+        }
+    CFUNCSMESS(\"create_cb_arglist-end\\n\");
+    return 1;
 capi_fail:
-\tif ((PyErr_Occurred())==NULL)
-\t\tPyErr_SetString(#modulename#_error,errmess);
-\treturn 0;
+    if ((PyErr_Occurred())==NULL)
+        PyErr_SetString(#modulename#_error,errmess);
+    return 0;
 }
 """
 


### PR DESCRIPTION
Using \t here is just cryptic.
Done using a very basic find and replace.