### PR TITLE
DOC: correct formatting of basic.types.html

### DIFF
--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -155,11 +155,11 @@ with 80-bit precision, and while most C compilers provide this as their
 ``long double`` identical to ``double`` (64 bits). NumPy makes the
 compiler's ``long double`` available as ``np.longdouble`` (and
 ``np.clongdouble`` for the complex numbers). You can find out what your
-numpy provides with``np.finfo(np.longdouble)``.
+numpy provides with ``np.finfo(np.longdouble)``.
 
 NumPy does not provide a dtype with more precision than C
-``long double``s; in particular, the 128-bit IEEE quad precision
-data type (FORTRAN's ``REAL*16``) is not available.
+``long double`` s; in particular, the 128-bit IEEE quad precision
+data type (FORTRAN's ``REAL*16`` ) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored
 padded with zero bits, either to 96 or 128 bits. Which is more efficient

--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -155,10 +155,10 @@ with 80-bit precision, and while most C compilers provide this as their
 ``long double`` identical to ``double`` (64 bits). NumPy makes the
 compiler's ``long double`` available as ``np.longdouble`` (and
 ``np.clongdouble`` for the complex numbers). You can find out what your
-numpy provides with ``np.finfo(np.longdouble)``\.
+numpy provides with ``np.finfo(np.longdouble)``.
 
 NumPy does not provide a dtype with more precision than C
-``long double``\s; in particular, the 128-bit IEEE quad precision
+``long double``s; in particular, the 128-bit IEEE quad precision
 data type (FORTRAN's ``REAL*16``\) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored

--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -155,11 +155,11 @@ with 80-bit precision, and while most C compilers provide this as their
 ``long double`` identical to ``double`` (64 bits). NumPy makes the
 compiler's ``long double`` available as ``np.longdouble`` (and
 ``np.clongdouble`` for the complex numbers). You can find out what your
-numpy provides with ``np.finfo(np.longdouble)``.
+numpy provides with ``np.finfo(np.longdouble)``\.
 
 NumPy does not provide a dtype with more precision than C
-``long double`` s; in particular, the 128-bit IEEE quad precision
-data type (FORTRAN's ``REAL*16`` ) is not available.
+``long double``\s; in particular, the 128-bit IEEE quad precision
+data type (FORTRAN's ``REAL*16``\) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored
 padded with zero bits, either to 96 or 128 bits. Which is more efficient


### PR DESCRIPTION
In the documentation for types allowed in numpy, missing spaces around
the backticks for fixed-width formatting cause code examples to appear
as plain text, or are causing plain text to appear as code. This commit
fixes back tick spacing in the 'Extended Precision' section of the
'Data Types' page.

#### Before

<img width="711" alt="screen shot 2017-07-14 at 5 41 53 am" src="https://user-images.githubusercontent.com/6868396/28209242-4efc4fda-6857-11e7-8316-275cb467204a.png">

#### After

<img width="676" alt="screen shot 2017-07-14 at 5 42 01 am" src="https://user-images.githubusercontent.com/6868396/28209245-53300aa6-6857-11e7-8e5d-42bcc5232c9f.png">
