### PR TITLE
MAINT: change http to https for numfocus.org link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="http://www.numpy.org/_static/numpy_logo.png"><br>
 </div>
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 -----------------
 |  **`Travis CI Status`**   |


### PR DESCRIPTION
[ci skip]

Thanks to @jakirkham for pointing this out in gh-9325.