### PR TITLE
ENH: Einsum calls BLAS if it advantageous to do so

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -353,7 +353,7 @@ def _can_dot(inputs, result, idx_removed):
     if input_left[-rs:] == input_right[-rs:]:
         return True
 
-    # GEMM or GEMV tranpose left
+    # GEMM or GEMV transpose left
     if input_left[:rs] == input_right[:rs]:
         return True
 

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -644,7 +644,7 @@ def einsum_path(*operands, **kwargs):
                         " %s" % unknown_kwargs)
 
     # Figure out what the path really is
-    path_type = kwargs.pop('optimize', False)
+    path_type = kwargs.pop('optimize', True)
     if path_type is True:
         path_type = 'greedy'
     if path_type is None:
@@ -852,7 +852,7 @@ def einsum(*operands, **kwargs):
         Controls if intermediate optimization should occur. No optimization
         will occur if False and True will default to the 'greedy' algorithm.
         Also accepts an explicit contraction list from the ``np.einsum_path``
-        function. See ``np.einsum_path`` for more details. Default is False.
+        function. See ``np.einsum_path`` for more details. Default is True.
 
     Returns
     -------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1326,7 +1326,7 @@ def tensordot(a, b, axes=2):
     N2 = 1
     for axis in axes_a:
         N2 *= as_[axis]
-    newshape_a = (multiply.reduce([as_[ax] for ax in notin]), N2)
+    newshape_a = (int(multiply.reduce([as_[ax] for ax in notin])), N2)
     olda = [as_[axis] for axis in notin]
 
     notin = [k for k in range(ndb) if k not in axes_b]
@@ -1334,7 +1334,7 @@ def tensordot(a, b, axes=2):
     N2 = 1
     for axis in axes_b:
         N2 *= bs[axis]
-    newshape_b = (N2, multiply.reduce([bs[ax] for ax in notin]))
+    newshape_b = (N2, int(multiply.reduce([bs[ax] for ax in notin])))
     oldb = [bs[axis] for axis in notin]
 
     at = a.transpose(newaxes_a).reshape(newshape_a)

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -568,48 +568,37 @@ class TestEinSum(TestCase):
 
         A = np.arange(2 * 3 * 4).reshape(2, 3, 4)
         B = np.arange(3)
-        ref = np.einsum('ijk,j->ijk', A, B)
-        assert_equal(np.einsum('ij...,j...->ij...', A, B), ref)
-        assert_equal(np.einsum('ij...,...j->ij...', A, B), ref)
-        assert_equal(np.einsum('ij...,j->ij...', A, B), ref)  # used to raise error
-
-        assert_equal(np.einsum('ij...,j...->ij...', A, B, optimize=True), ref)
-        assert_equal(np.einsum('ij...,...j->ij...', A, B, optimize=True), ref)
-        assert_equal(np.einsum('ij...,j->ij...', A, B, optimize=True), ref)  # used to raise error
+        ref = np.einsum('ijk,j->ijk', A, B, optimize=False)
+        for opt in [True, False]:
+            assert_equal(np.einsum('ij...,j...->ij...', A, B, optimize=opt), ref)
+            assert_equal(np.einsum('ij...,...j->ij...', A, B, optimize=opt), ref)
+            assert_equal(np.einsum('ij...,j->ij...', A, B, optimize=opt), ref)  # used to raise error
 
         A = np.arange(12).reshape((4, 3))
         B = np.arange(6).reshape((3, 2))
-        ref = np.einsum('ik,kj->ij', A, B)
-        assert_equal(np.einsum('ik...,k...->i...', A, B), ref)
-        assert_equal(np.einsum('ik...,...kj->i...j', A, B), ref)
-        assert_equal(np.einsum('...k,kj', A, B), ref)  # used to raise error
-        assert_equal(np.einsum('ik,k...->i...', A, B), ref)  # used to raise error
-
-        assert_equal(np.einsum('ik...,k...->i...', A, B, optimize=True), ref)
-        assert_equal(np.einsum('ik...,...kj->i...j', A, B, optimize=True), ref)
-        assert_equal(np.einsum('...k,kj', A, B, optimize=True), ref)  # used to raise error
-        assert_equal(np.einsum('ik,k...->i...', A, B, optimize=True), ref)  # used to raise error
+        ref = np.einsum('ik,kj->ij', A, B, optimize=False)
+        for opt in [True, False]:
+            assert_equal(np.einsum('ik...,k...->i...', A, B, optimize=opt), ref)
+            assert_equal(np.einsum('ik...,...kj->i...j', A, B, optimize=opt), ref)
+            assert_equal(np.einsum('...k,kj', A, B, optimize=opt), ref)  # used to raise error
+            assert_equal(np.einsum('ik,k...->i...', A, B, optimize=opt), ref)  # used to raise error
 
         dims = [2, 3, 4, 5]
         a = np.arange(np.prod(dims)).reshape(dims)
         v = np.arange(dims[2])
-        ref = np.einsum('ijkl,k->ijl', a, v)
-        assert_equal(np.einsum('ijkl,k', a, v), ref)
-        assert_equal(np.einsum('...kl,k', a, v), ref)  # used to raise error
-        assert_equal(np.einsum('...kl,k...', a, v), ref)
-        # no real diff from 1st
-
-        assert_equal(np.einsum('ijkl,k', a, v, optimize=True), ref)
-        assert_equal(np.einsum('...kl,k', a, v, optimize=True), ref)  # used to raise error
-        assert_equal(np.einsum('...kl,k...', a, v, optimize=True), ref)
+        ref = np.einsum('ijkl,k->ijl', a, v, optimize=False)
+        for opt in [True, False]:
+            assert_equal(np.einsum('ijkl,k', a, v, optimize=opt), ref)
+            assert_equal(np.einsum('...kl,k', a, v, optimize=opt), ref)  # used to raise error
+            assert_equal(np.einsum('...kl,k...', a, v, optimize=opt), ref)
 
         J, K, M = 160, 160, 120
         A = np.arange(J * K * M).reshape(1, 1, 1, J, K, M)
         B = np.arange(J * K * M * 3).reshape(J, K, M, 3)
-        ref = np.einsum('...lmn,...lmno->...o', A, B)
-        assert_equal(np.einsum('...lmn,lmno->...o', A, B), ref)  # used to raise error
-        assert_equal(np.einsum('...lmn,lmno->...o', A, B,
-                               optimize=True), ref)  # used to raise error
+        ref = np.einsum('...lmn,...lmno->...o', A, B, optimize=False)
+        for opt in [True, False]:
+            assert_equal(np.einsum('...lmn,lmno->...o', A, B,
+                                   optimize=opt), ref)  # used to raise error
 
     def test_einsum_fixedstridebug(self):
         # Issue #4485 obscure einsum bug


### PR DESCRIPTION
Einsum will now call `tensordot` if it is advantageous to do so:
```
a = np.random.rand(100, 100, 100)

%timeit np.einsum('ijk,jkl->il', a, a, optimize=False)
10 loops, best of 3: 50.1 ms per loop

%timeit np.einsum('ijk,jkl->il', a, a, optimize=True)
1000 loops, best of 3: 1.6 ms per loop
```

This is also quite advantageous even if a copy is required:
```
%timeit np.einsum('ikj,jkl->il', a, a, optimize=False)
10 loops, best of 3: 79.4 ms per loop

%timeit np.einsum('ikj,jkl->il', a, a, optimize=True)
100 loops, best of 3: 4.87 ms per loop
```

For level 3 BLAS the array is always copied while for level 1 and 2 the data must be aligned for BLAS to be called as `einsum` is faster than BLAS in these cases.

There was also a small bug in `tensordot` where it would fail for inner product cases.

This PR also switches `einsum` to optimize the contraction by default.  I was originally concerned that there may be remaining bugs in the path code, but I have not seen any issues since this feature was originally released. I hope the algorithm is battle tested enough that the optimized path can be the default due to the speedups that can occur.

The downside is the path logic takes ~20-50us:

```
%timeit np.einsum('ij,ji->', a, a, optimize=True)
10000 loops, best of 3: 37.6 µs per loop

%timeit np.einsum('ij,ji->', a, a, optimize=False)
1000000 loops, best of 3: 1.67 µs per loop
```

A few arbitrary cutoffs can be placed to prevent the logic overhead (switching back to c_einsum immediately if there are less then say 1000 values in total). However, some discussion is desired if this is need or wanted as I feel a little uncomfortable taking different paths based on *size* of a contraction.