### PR TITLE
DOC: Add a link to einsum_path

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -18,6 +18,7 @@ Matrix and vector products
    matmul
    tensordot
    einsum
+   einsum_path
    linalg.matrix_power
    kron
 


### PR DESCRIPTION
Another case of a function being missed from the autosummary, and so never having documentation generated for it