### PR TITLE
BUG: Inlined functions must be defined somewhere.

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -139,7 +139,7 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
     *ret = (PyArrayObject *)new;
 }
 
-NPY_NO_EXPORT NPY_INLINE void
+static NPY_INLINE void
 multi_DECREF(PyObject **objects, npy_intp n)
 {
     npy_intp i;
@@ -155,7 +155,7 @@ multi_DECREF(PyObject **objects, npy_intp n)
  * Useful if a tuple is being iterated over multiple times, or for a code path
  * that doesn't always want the overhead of allocating a tuple.
  */
-NPY_NO_EXPORT NPY_INLINE npy_intp
+static NPY_INLINE npy_intp
 unpack_tuple(PyTupleObject *index, PyObject **result, npy_intp result_n)
 {
     npy_intp n, i;
@@ -173,7 +173,7 @@ unpack_tuple(PyTupleObject *index, PyObject **result, npy_intp result_n)
 }
 
 /* Unpack a single scalar index, taking a new reference to match unpack_tuple */
-NPY_NO_EXPORT NPY_INLINE npy_intp
+static NPY_INLINE npy_intp
 unpack_scalar(PyObject *index, PyObject **result, npy_intp result_n)
 {
     Py_INCREF(index);


### PR DESCRIPTION
Some inline functions in numpy/core/src/multiarray/mapping.c were
defined as `NPY_NO_EXPORT NPY_INLINE` with the result that gcc 7.1 was
looking for an external definition. Possibly some of those functions
were no longer being inlined. The fix was to replace `NPY_NO_EXPORT`
with `static`. A grep of the numpy source files turned up no further
uses of that unfortunate combination.