### PR TITLE
API: Make ``a.flat.__array__`` return a copy when ``a`` non-contiguous.

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -56,8 +56,8 @@ Build System Changes
 Compatibility notes
 ===================
 
-``a.flat.__array__()`` returns non-writeable arrays when ``a`` is non-contiguos
--------------------------------------------------------------------------------
+``a.flat.__array__()`` returns non-writeable arrays when ``a`` is non-contiguous
+--------------------------------------------------------------------------------
 The intent is that the UPDATEIFCOPY array previously returned when ``a`` was
 non-contiguous will be replaced by a writeable copy in the future. This
 temporary measure is aimed to notify folks who expect the underlying array be

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -42,6 +42,12 @@ equivalent to the second.
 The ``rcond`` parameter to ``np.linalg.lstsq`` will change its default to the
 better value of machine precision times the maximum of the input matrix
 dimensions. A FutureWarning is given if the parameter is not passed explicitly.
+* ``a.flat.__array__()`` will return a writeable copy of ``a`` when ``a`` is
+  non-contiguous. Previously it returned an UPDATEIFCOPY array when ``a`` was
+  writeable. Currently it returns a non-writeable copy. See gh-7054 for a
+  discussion of the issue.
+
+
 
 Build System Changes
 ====================
@@ -49,6 +55,16 @@ Build System Changes
 
 Compatibility notes
 ===================
+
+``a.flat.__array__()`` returns non-writeable arrays when ``a`` is non-contiguos
+-------------------------------------------------------------------------------
+The intent is that the UPDATEIFCOPY array previously returned when ``a`` was
+non-contiguous will be replaced by a writeable copy in the future. This
+temporary measure is aimed to notify folks who expect the underlying array be
+modified in this situation that that will no longer be the case. The most
+likely places for this to be noticed is when expressions of the form
+``np.asarray(a.flat)`` are used, or when ``a.flat`` is passed as the out
+parameter to a ufunc.
 
 ``np.tensordot`` now returns zero array when contracting over 0-length dimension
 --------------------------------------------------------------------------------

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4311,14 +4311,16 @@ class TestFlat(object):
 
         assert_(c.flags.writeable is False)
         assert_(d.flags.writeable is False)
+        # for 1.14 all are set to non-writeable on the way to replacing the
+        # UPDATEIFCOPY array returned for non-contiguous arrays.
         assert_(e.flags.writeable is True)
-        assert_(f.flags.writeable is True)
+        assert_(f.flags.writeable is False)
 
         assert_(c.flags.updateifcopy is False)
         assert_(d.flags.updateifcopy is False)
         assert_(e.flags.updateifcopy is False)
-        assert_(f.flags.updateifcopy is True)
-        assert_(f.base is self.b0)
+        # UPDATEIFCOPY is removed.
+        assert_(f.flags.updateifcopy is False)
 
 
 class TestResize(object):


### PR DESCRIPTION
Previously an UPDATEIFCOPY array was returned when `a` was non-contiguous
and writeable. Exposing that type of array does not work well with PyPy
as it doesn't do refcounting, and hence the writeback never occurs. The copy that
is now returned instead is set to non-writable to expose cases where a writeback
was expected. At some future date the copy will be made writable. See
gh-7054 for a discussion of this issue.