### PR TITLE
MAINT: Use new-style classes on 2.7

### DIFF
--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -53,7 +53,7 @@ class VisibleDeprecationWarning(UserWarning):
     pass
 
 
-class _NoValue:
+class _NoValue(object):
     """Special keyword value.
 
     This class may be used as the default value assigned to a deprecated

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -72,7 +72,7 @@ def _repl(str):
     return str.replace('Bool', 'npy_bool')
 
 
-class StealRef:
+class StealRef(object):
     def __init__(self, arg):
         self.arg = arg # counting from 1
 
@@ -83,7 +83,7 @@ class StealRef:
             return 'NPY_STEALS_REF_TO_ARG(%d)' % self.arg
 
 
-class NonNull:
+class NonNull(object):
     def __init__(self, arg):
         self.arg = arg # counting from 1
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -80,7 +80,7 @@ def find_duplicate(list):
                 dup.append(list[i])
     return dup
 
-class format_parser:
+class format_parser(object):
     """
     Class to convert formats, names, titles description to a dtype.
 

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -552,7 +552,7 @@ class F2PYError(Exception):
     pass
 
 
-class throw_error:
+class throw_error(object):
 
     def __init__(self, mess):
         self.mess = mess

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -784,7 +784,7 @@ ufunc_domain = {}
 ufunc_fills = {}
 
 
-class _DomainCheckInterval:
+class _DomainCheckInterval(object):
     """
     Define a valid interval, so that :
 
@@ -809,7 +809,7 @@ class _DomainCheckInterval:
                                     umath.less(x, self.a))
 
 
-class _DomainTan:
+class _DomainTan(object):
     """
     Define a valid interval for the `tan` function, so that:
 
@@ -827,7 +827,7 @@ class _DomainTan:
             return umath.less(umath.absolute(umath.cos(x)), self.eps)
 
 
-class _DomainSafeDivide:
+class _DomainSafeDivide(object):
     """
     Define a domain for safe division.
 
@@ -848,7 +848,7 @@ class _DomainSafeDivide:
             return umath.absolute(a) * self.tolerance >= umath.absolute(b)
 
 
-class _DomainGreater:
+class _DomainGreater(object):
     """
     DomainGreater(v)(x) is True where x <= v.
 
@@ -864,7 +864,7 @@ class _DomainGreater:
             return umath.less_equal(x, self.critical_value)
 
 
-class _DomainGreaterEqual:
+class _DomainGreaterEqual(object):
     """
     DomainGreaterEqual(v)(x) is True where x < v.
 
@@ -880,7 +880,7 @@ class _DomainGreaterEqual:
             return umath.less(x, self.critical_value)
 
 
-class _MaskedUnaryOperation:
+class _MaskedUnaryOperation(object):
     """
     Defines masked version of unary operations, where invalid values are
     pre-masked.
@@ -959,7 +959,7 @@ class _MaskedUnaryOperation:
         return "Masked version of %s. [Invalid values are masked]" % str(self.f)
 
 
-class _MaskedBinaryOperation:
+class _MaskedBinaryOperation(object):
     """
     Define masked version of binary operations, where invalid
     values are pre-masked.
@@ -1111,7 +1111,7 @@ class _MaskedBinaryOperation:
         return "Masked version of " + str(self.f)
 
 
-class _DomainedBinaryOperation:
+class _DomainedBinaryOperation(object):
     """
     Define binary operations that have a domain, like divide.
 
@@ -2358,7 +2358,7 @@ def masked_invalid(a, copy=True):
 ###############################################################################
 
 
-class _MaskedPrintOption:
+class _MaskedPrintOption(object):
     """
     Handle the string used to represent missing data in a masked array.
 
@@ -6417,7 +6417,7 @@ ptp.__doc__ = MaskedArray.ptp.__doc__
 ##############################################################################
 
 
-class _frommethod:
+class _frommethod(object):
     """
     Define functions from existing MaskedArray methods.
 
@@ -7895,7 +7895,7 @@ def fromflex(fxarray):
     return masked_array(fxarray['_data'], mask=fxarray['_mask'])
 
 
-class _convert2ma:
+class _convert2ma(object):
 
     """
     Convert functions from numpy to numpy.ma.

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -215,7 +215,7 @@ def masked_all_like(arr):
 #####--------------------------------------------------------------------------
 #---- --- Standard functions ---
 #####--------------------------------------------------------------------------
-class _fromnxfunction:
+class _fromnxfunction(object):
     """
     Defines a wrapper to adapt NumPy functions to masked arrays.
 


### PR DESCRIPTION
Deliberately avoids tests, to prevent introducing a failure on old-style classes later.

Before, on python 2 only:
```
>>> type(np._NoValue)
<type 'classobj'>
```
Now, on all versions, and before, on all but python 2:
```
>>> type(np._NoValue)
<class 'type'>
```

This probably won't have any effect, but there's no reason to still be using python 2.2-style classes.