### PR TITLE
MAINT: Improve performance of np.copyto(where=scalar)

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3991,7 +3991,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('put',
 
 add_newdoc('numpy.core.multiarray', 'copyto',
     """
-    copyto(dst, src, casting='same_kind', where=None)
+    copyto(dst, src, casting='same_kind', where=True)
 
     Copies values from one array to another, broadcasting as necessary.
 

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -345,6 +345,21 @@ PyArray_AssignArray(PyArrayObject *dst, PyArrayObject *src,
         }
     }
 
+    /* optimization: scalar boolean mask */
+    if (wheremask != NULL &&
+            PyArray_NDIM(wheremask) == 0 &&
+            PyArray_DESCR(wheremask)->type_num == NPY_BOOL) {
+        npy_bool value = *(npy_bool *)PyArray_DATA(wheremask);
+        if (value) {
+            /* where=True is the same as no where at all */
+            wheremask = NULL;
+        }
+        else {
+            /* where=False copies nothing */
+            return 0;
+        }
+    }
+
     if (wheremask == NULL) {
         /* A straightforward value assignment */
         /* Do the assignment with raw array iteration */


### PR DESCRIPTION
Setup:
```python
x = np.arange(100000)
y = x.copy()
kw = ...

%timeit np.copyto(x, y, **kw)
```

| `kw`|  `dict()` | `dict(where=True)` | `dict(where=False)` |
|----|----|---|----|
| Before | 31 µs ± 144 ns | 222 µs ± 9.09 µs | 66.9 µs ± 2.47 µs
| After| 31 µs ± 261 ns | 33.3 µs ± 888 ns | 1.09 µs ± 7.42 ns

This speeds up `np.copyto(x, y, where=ma_array.mask)` in the case when `mask == nomask`, without the optimization having to be made at every call site.

In theory we could check for this in `array_where` before we even do an array conversion, but it's probably not worth the effort, and doesn't give an speedup in  `O(dst.size)`
    