### PR TITLE
BUG: Fix true_divide when dtype=np.float64 specified.

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -314,9 +314,7 @@ defdict = {
 'true_divide':
     Ufunc(2, 1, None, # One is only a unit to the right, not the left
           docstrings.get('numpy.core.umath.true_divide'),
-          'PyUFunc_DivisionTypeResolver',
-          TD('bBhH', out='d'),
-          TD('iIlLqQ', out='d'),
+          'PyUFunc_TrueDivisionTypeResolver',
           TD(flts+cmplx),
           [TypeDescription('m', FullTypeDescr, 'mq', 'm'),
            TypeDescription('m', FullTypeDescr, 'md', 'm'),

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -980,16 +980,6 @@ NPY_NO_EXPORT void
 /**end repeat1**/
 
 NPY_NO_EXPORT void
-@TYPE@_true_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    BINARY_LOOP {
-        const double in1 = (double)(*(@type@ *)ip1);
-        const double in2 = (double)(*(@type@ *)ip2);
-        *((double *)op1) = in1/in2;
-    }
-}
-
-NPY_NO_EXPORT void
 @TYPE@_power(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -120,9 +120,6 @@ NPY_NO_EXPORT void
 /**end repeat2**/
 
 NPY_NO_EXPORT void
-@S@@TYPE@_true_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
-
-NPY_NO_EXPORT void
 @S@@TYPE@_power(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -42,7 +42,7 @@ PyUFunc_AbsoluteTypeResolver(PyUFuncObject *ufunc,
                              PyArrayObject **operands,
                              PyObject *type_tup,
                              PyArray_Descr **out_dtypes);
-                             
+
 NPY_NO_EXPORT int
 PyUFunc_IsNaTTypeResolver(PyUFuncObject *ufunc,
                           NPY_CASTING casting,
@@ -77,6 +77,13 @@ PyUFunc_MixedDivisionTypeResolver(PyUFuncObject *ufunc,
                                   PyArrayObject **operands,
                                   PyObject *type_tup,
                                   PyArray_Descr **out_dtypes);
+
+NPY_NO_EXPORT int
+PyUFunc_TrueDivisionTypeResolver(PyUFuncObject *ufunc,
+                                 NPY_CASTING casting,
+                                 PyArrayObject **operands,
+                                 PyObject *type_tup,
+                                 PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,


### PR DESCRIPTION
The problem here was due to the signature matching when dtype is
specified. A signature matches when

1) The output dtype matches the specified dtype
2) The input arguments can be cast to the signature's dtypes using
   casting="same_kind"

The signature 'bb->d' was present for true_divide, consequently when
dtype=np.float64 was specified, all integer inputs were cast to int8.

The solution adopted here was to remove all signatures/loops for
true_divide that had integer inputs. More intrusive measures broke a lot of
existing code that relied on the current behavior for other functions

Closes #3484. Again.