### PR TITLE
MAINT: Make `setxor1d` a bit clearer and speed it up

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -375,12 +375,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
         return aux
 
     aux.sort()
-#    flag = ediff1d( aux, to_end = 1, to_begin = 1 ) == 0
     flag = np.concatenate(([True], aux[1:] != aux[:-1], [True]))
-#    flag2 = ediff1d( flag ) == 0
-#    flag2 = flag[1:] == flag[:-1]
-#    return aux[flag2]
-    return aux[np.logical_and(flag[1:], flag[:-1])]
+    return aux[flag[1:] & flag[:-1]]
 
 
 def in1d(ar1, ar2, assume_unique=False, invert=False):

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -378,8 +378,9 @@ def setxor1d(ar1, ar2, assume_unique=False):
 #    flag = ediff1d( aux, to_end = 1, to_begin = 1 ) == 0
     flag = np.concatenate(([True], aux[1:] != aux[:-1], [True]))
 #    flag2 = ediff1d( flag ) == 0
-    flag2 = flag[1:] == flag[:-1]
-    return aux[flag2]
+#    flag2 = flag[1:] == flag[:-1]
+#    return aux[flag2]
+    return aux[np.logical_and(flag[1:], flag[:-1])]
 
 
 def in1d(ar1, ar2, assume_unique=False, invert=False):


### PR DESCRIPTION
We need to find the index which is not the same with the left and right, I think np.logical_and's meaning is more clear and I test this got a speed up