### PR TITLE
BLD: remove -xhost flag from IntelFCompiler. 

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -58,7 +58,7 @@ class IntelFCompiler(BaseIntelFCompiler):
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
         mpopt = 'openmp' if v and v < '15' else 'qopenmp'
-        return ['-xhost -fp-model strict -O1 -{}'.format(mpopt)]
+        return ['-fp-model strict -O1 -{}'.format(mpopt)]
 
     def get_flags_arch(self):
         return []


### PR DESCRIPTION
Note that this was discussed extensively in gh-7287, but removing
this ``-xhost`` flag was missed in the PR that closed that issue.

Closes gh-9042.