### PR TITLE
ENH: Adding ratio to mimic diff

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -15,6 +15,7 @@ New functions
 =============
 
 * ``parametrize`` decorator added to numpy.testing
+* ``ratio`` function for geometric equivalent to ``diff``
 
 
 Deprecations
@@ -85,6 +86,13 @@ The new ``parametrize`` decorator does not have the full functionality of the
 one in pytest. It doesn't work for classes, doesn't support nesting, and does
 not substitute variable names. Even so, it should be adequate to rewrite the
 NumPy tests.
+
+``ratio`` function added
+------------------------
+The ``ratio`` function computes ratios much in the same way that ``diff``
+computes differences. It has built-in recursive application, customizable
+zero-denominator handling and the ability to select between ``/`` and ``//``
+operators.
 
 
 Improvements

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1958,7 +1958,10 @@ def ratio(a, n=1, axis=-1, true=True, zero_div=None):
     ratio : ndarray
         The n-th ratios. The shape of the output is the same as `a`
         except along `axis` where the dimension is smaller by `n`. The
-        type of the output is the same as that of the input.
+        type of the output is same as the type of the quotient between
+        any two elements of `a`. This is same as the type of `a` in most
+        cases. A notable exception is `bool_`, which results in a
+        `uint8` output array.
 
     See Also
     --------
@@ -2015,17 +2018,18 @@ def ratio(a, n=1, axis=-1, true=True, zero_div=None):
     if n == 0:
         return a
     if n < 0:
-        raise ValueError(
-            "order must be non-negative but got " + repr(n))
+        raise ValueError("order must be non-negative but got " + repr(n))
 
     a = asanyarray(a)
     nd = a.ndim
-    rng = range(nd)
     axis = normalize_axis_index(axis, nd)
-    keep = slice(None)
 
-    slice1 = tuple(slice(1, None) if i == axis else keep for i in rng)
-    slice2 = tuple(slice(None, -1) if i == axis else keep for i in rng)
+    slice1 = [slice(None)] * nd
+    slice2 = [slice(None)] * nd
+    slice1[axis] = slice(1, None)
+    slice2[axis] = slice(None, -1)
+    slice1 = tuple(slice1)
+    slice2 = tuple(slice2)
 
     op = true_divide if true else floor_divide
     for _ in range(n):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2015,15 +2015,14 @@ def ratio(a, n=1, axis=-1, true=True, zero_div=None):
 
     a = asanyarray(a)
     nd = a.ndim
-
-    if n >= a.shape[axis]:
-        shape = list(a.shape)
-        shape[axis] = 0
-        return empty(shape, dtype=a.dtype)
-
-    keep = slice(None)
     rng = range(nd)
     axis = rng[axis]
+    keep = slice(None)
+
+    if n >= a.shape[axis]:
+        slice1 = tuple(slice(0, 0) if i == axis else keep for i in rng)
+        return a[slice1]
+
     slice1 = tuple(slice(1, None) if i == axis else keep for i in rng)
     slice2 = tuple(slice(None, -1) if i == axis else keep for i in rng)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1982,6 +1982,11 @@ def ratio(a, n=1, axis=-1, true=True, zero_div=None):
     >>> np.ratio(arr)
     array([ 0.])
 
+    The ability of this function to perform is limited by the datatype
+    of the inputs. While boolean arrays will yield a result of some
+    sort, a dtype like `np.datetime64` will not work at all, and
+    `np.timedelta64` will work, but only with `true=True`.
+
     Examples
     --------
     >>> x = np.array([1, 2, 4, 7, 0])
@@ -2016,12 +2021,8 @@ def ratio(a, n=1, axis=-1, true=True, zero_div=None):
     a = asanyarray(a)
     nd = a.ndim
     rng = range(nd)
-    axis = rng[axis]
+    axis = normalize_axis_index(axis, nd)
     keep = slice(None)
-
-    if n >= a.shape[axis]:
-        slice1 = tuple(slice(0, 0) if i == axis else keep for i in rng)
-        return a[slice1]
 
     slice1 = tuple(slice(1, None) if i == axis else keep for i in rng)
     slice2 = tuple(slice(None, -1) if i == axis else keep for i in rng)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2034,15 +2034,19 @@ def ratio(a, n=1, axis=-1, true=True, zero_div=None):
     op = true_divide if true else floor_divide
     for _ in range(n):
         num, denom = a[slice1], a[slice2]
-        # Zeros can creep in from division by infinity.
-        # This check does in fact need to be done every time.
-        if zero_div is not None and 0 in denom:
-            a = empty_like(num)
-            mask = denom.astype(np.bool_)
-            a[mask] = op(num[mask], denom[mask])
-            a[~mask] = zero_div
-        else:
+        if zero_div is None:
             a = op(num, denom)
+        else:
+            # Zeros can creep in from division by infinity.
+            # This check does in fact need to be done every time.
+            mask = (denom == 0)
+            if any(mask):
+                a = empty_like(num)
+                imask = ~mask
+                a[imask] = op(num[imask], denom[imask])
+                a[mask] = zero_div
+            else:
+                a = op(num, denom)
 
     return a
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -806,6 +806,20 @@ class TestRatio(object):
         assert_(ratio(x, n=0) is x)
 
 
+    def test_subclass(self):
+        """
+        Check that subclass is preserved, even across optimization for
+        large `n`.
+        """
+        x = ma.array([[1, 2], [2, 4], [4, 8]])
+        out = ratio(x)
+        out2 = ratio(x, n=3)
+        assert_array_equal(out, [[2], [2], [2]])
+        assert_array_equal(out2, [[], [], []])
+        assert_(type(out) is type(x))
+        assert_(type(out2) is type(x))
+
+
 class TestDelete(object):
 
     def setup(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -7,7 +7,6 @@ import decimal
 
 import numpy as np
 from numpy import ma
-from numpy.core._internal import AxisError
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
     assert_almost_equal, assert_array_almost_equal, assert_raises,
@@ -736,8 +735,8 @@ class TestRatio(object):
         assert_array_equal(ratio(x, axis=0), np.ones((9, 20, 30)))
         assert_array_equal(ratio(x, axis=1), -np.ones((10, 19, 30)))
         assert_array_equal(ratio(x, axis=-2), -np.ones((10, 19, 30)))
-        assert_raises(AxisError, ratio, x, axis=3)
-        assert_raises(AxisError, ratio, x, axis=-4)
+        assert_raises(np.AxisError, ratio, x, axis=3)
+        assert_raises(np.AxisError, ratio, x, axis=-4)
 
     def test_bool(self):
         # All possible ratios
@@ -819,10 +818,6 @@ class TestRatio(object):
 
 
     def test_subclass(self):
-        """
-        Check that subclass is preserved, even across optimization for
-        large `n`.
-        """
         x = ma.array([[1, 2.5], [2, 5], [3, 7.5], [4, 10], [5, 12.5]],
                      mask=[[False, False], [True, False],
                            [False, True], [True, True], [False, False]])


### PR DESCRIPTION
Adds a `ratio` function that works similarly to `diff`, but divides successive elements.

Like `diff`, `ratio` supports recursive application and attempts to preserve the dtype of the input (only when using floor_divide). It also allows special handling of divide-by-zero cases as well as a selection between `/` and `//` operators.

The implementation follows a similar patter to the one suggested for `diff` in #9482.

[Mailing list discussion here](http://numpy-discussion.10968.n7.nabble.com/ENH-ratio-function-to-mimic-diff-td44605.html)