### PR TITLE
ENH: Add np.polynomial.chebyshev.chebinterpolate function.

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -14,7 +14,8 @@ Highlights
 New functions
 =============
 
-* ``parametrize`` decorator added to numpy.testing
+* ``parametrize``: decorator added to numpy.testing
+* ``chebinterpolate``: Interpolate function at Chebyshev points.
 
 
 Deprecations
@@ -86,6 +87,12 @@ one in pytest. It doesn't work for classes, doesn't support nesting, and does
 not substitute variable names. Even so, it should be adequate to rewrite the
 NumPy tests.
 
+``chebinterpolate`` function added to ``numpy.polynomial.chebyshev``
+--------------------------------------------------------------------
+The new ``chebinterpolate`` function interpolates a given function at the
+Chebyshev points of the first kind. A new ``Chebyshev.interpolate`` class
+method adds support for interpolation over arbitrary intervals using the scaled
+and shifted Chebyshev points of the first kind.
 
 Improvements
 ============

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -471,24 +471,29 @@ class TestFitting(object):
         assert_almost_equal(coef1, coef2)
 
 
-class TestInterp(object):
+class TestInterpolate(object):
 
-    @staticmethod
-    def f(x):
+    def f(self, x):
         return x * (x - 1) * (x - 2)
 
     def test_raises(self):
-        assert_raises(ValueError, cheb.chebinterp, self.f, -1, [-1, 1])
-        assert_raises(ValueError, cheb.chebinterp, self.f, 10.1, [-1, 1])
+        assert_raises(ValueError, cheb.chebinterpolate, self.f, -1)
+        assert_raises(TypeError, cheb.chebinterpolate, self.f, 10.)
 
     def test_dimensions(self):
-        for i in range(1, 5):
-            assert_(cheb.chebinterp(self.f, i, [-1, 1]).shape == (i+1,))
+        for deg in range(1, 5):
+            assert_(cheb.chebinterpolate(self.f, deg).shape == (deg + 1,))
 
-    def test_approx(self):
-        assert_almost_equal(cheb.chebinterp(lambda x: [1, 1, 1, 1], 3, [-1, 1]), np.array([1, 0, 0, 0]))
-        assert_almost_equal(cheb.chebinterp(lambda x: x, 3, [-1, 1]), np.array([0, 1, 0, 0]))
-        assert_almost_equal(cheb.chebinterp(self.f, 3, [-1, 1]), np.array([-3/2, 11/4, -3/2, 1/4]))
+    def test_approximation(self):
+
+        def powx(x, p):
+            return x**p
+
+        x = np.linspace(-1, 1, 10)
+        for deg in range(0, 10):
+            for p in range(0, deg + 1):
+                c = cheb.chebinterpolate(powx, deg, (p,))
+                assert_almost_equal(cheb.chebval(x, c), powx(x, p), decimal=12)
 
 
 class TestCompanion(object):

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -471,6 +471,26 @@ class TestFitting(object):
         assert_almost_equal(coef1, coef2)
 
 
+class TestInterp(object):
+
+    @staticmethod
+    def f(x):
+        return x * (x - 1) * (x - 2)
+
+    def test_raises(self):
+        assert_raises(ValueError, cheb.chebinterp, self.f, -1, [-1, 1])
+        assert_raises(ValueError, cheb.chebinterp, self.f, 10.1, [-1, 1])
+
+    def test_dimensions(self):
+        for i in range(1, 5):
+            assert_(cheb.chebinterp(self.f, i, [-1, 1]).shape == (i+1,))
+
+    def test_approx(self):
+        assert_almost_equal(cheb.chebinterp(lambda x: [1, 1, 1, 1], 3, [-1, 1]), np.array([1, 0, 0, 0]))
+        assert_almost_equal(cheb.chebinterp(lambda x: x, 3, [-1, 1]), np.array([0, 1, 0, 0]))
+        assert_almost_equal(cheb.chebinterp(self.f, 3, [-1, 1]), np.array([-3/2, 11/4, -3/2, 1/4]))
+
+
 class TestCompanion(object):
 
     def test_raises(self):

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -583,5 +583,30 @@ def check_ufunc_override(Poly):
     assert_raises(TypeError, np.add, x, p)
 
 
+class TestInterpolate(object):
+
+    def f(self, x):
+        return x * (x - 1) * (x - 2)
+
+    def test_raises(self):
+        assert_raises(ValueError, Chebyshev.interpolate, self.f, -1)
+        assert_raises(TypeError, Chebyshev.interpolate, self.f, 10.)
+
+    def test_dimensions(self):
+        for deg in range(1, 5):
+            assert_(Chebyshev.interpolate(self.f, deg).degree() == deg)
+
+    def test_approximation(self):
+
+        def powx(x, p):
+            return x**p
+
+        x = np.linspace(0, 2, 10)
+        for deg in range(0, 10):
+            for t in range(0, deg + 1):
+                p = Chebyshev.interpolate(powx, deg, domain=[0, 2], args=(t,))
+                assert_almost_equal(p(x), powx(x, t), decimal=12)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Update of #9198.

The chebinterpolate function interpolates a function at the Chebyshev points of the first kind using a Chebyshev series. The resulting interpolation approximates a polynomial fit minimizing the L_inf norm.
