### PR TITLE
DOC: fix versionadded in docstring for moveaxis

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1551,7 +1551,7 @@ def moveaxis(a, source, destination):
 
     Other axes remain in their original order.
 
-    .. versionadded::1.11.0
+    .. versionadded:: 1.11.0
 
     Parameters
     ----------


### PR DESCRIPTION
The missing space was enough so that it didn't appear in the generated docs:
https://docs.scipy.org/doc/numpy/reference/generated/numpy.moveaxis.html