### PR TITLE
ENH: Adding np.neighborwise function

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -15,7 +15,8 @@ New functions
 =============
 
 * ``parametrize``: decorator added to numpy.testing
-* ``chebinterpolate``: Interpolate function at Chebyshev points.
+* ``chebinterpolate``: interpolate function at Chebyshev points.
+* ``neighborwise``: apply function pairwise to neighboring elements.
 
 
 Deprecations
@@ -125,6 +126,13 @@ Chebyshev points of the first kind. A new ``Chebyshev.interpolate`` class
 method adds support for interpolation over arbitrary intervals using the scaled
 and shifted Chebyshev points of the first kind.
 
+``neighborwise`` function added
+-------------------------------
+``neighborwise`` applies a vectorized function of two arguments to neighboring
+pairs of elements in a numpy array. Iteration, multiple axes and masking are
+supported.
+
+
 Improvements
 ============
 
@@ -140,6 +148,11 @@ The ``np.einsum`` function will now call ``np.tensordot`` when appropriate.
 Because ``np.tensordot`` uses BLAS when possible, that will speed up execution.
 By default, ``np.einsum`` will also attempt optimization as the overhead is
 small relative to the potential improvement in speed.
+
+`np.diff` now accepts multiple axes
+-----------------------------------
+`np.diff` now supports an iterable in the `axis` argument. All axes are applied
+simultaneously, allowing diffs to be computed along a diagonal.
 
 
 Changes

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1901,28 +1901,9 @@ def diff(a, n=1, axis=-1):
     array([1, 1], dtype='timedelta64[D]')
 
     """
-    if n == 0:
-        return a
-    if n < 0:
-        raise ValueError(
-            "order must be non-negative but got " + repr(n))
-
-    a = asanyarray(a)
-    nd = a.ndim
-    axis = normalize_axis_index(axis, nd)
-
-    slice1 = [slice(None)] * nd
-    slice2 = [slice(None)] * nd
-    slice1[axis] = slice(1, None)
-    slice2[axis] = slice(None, -1)
-    slice1 = tuple(slice1)
-    slice2 = tuple(slice2)
-
-    op = not_equal if a.dtype == np.bool_ else subtract
-    for _ in range(n):
-        a = op(a[slice1], a[slice2])
-
-    return a
+    def diff_func(a, b):
+        return not_equal(a, b) if a.dtype == np.bool_ else subtract(a, b)
+    return neighborwise(a, diff_func, axis=axis, n=n)
 
 
 def neighborwise(a, func, axis=-1, n=1, mask=None, fill=0, destructive=False):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -701,10 +701,9 @@ class TestDiff(object):
     def test_n(self):
         x = list(range(3))
         assert_raises(ValueError, diff, x, n=-1)
-        output = [diff(x, n=n) for n in range(1, 5)]
-        expected = [[1, 1], [0], [], []]
-        assert_(diff(x, n=0) is x)
-        for n, (expected, out) in enumerate(zip(expected, output), start=1):
+        output = [diff(x, n=n) for n in range(5)]
+        expected = [x, [1, 1], [0], [], []]
+        for n, (expected, out) in enumerate(zip(expected, output)):
             assert_(type(out) is np.ndarray)
             assert_array_equal(out, expected)
             assert_equal(out.dtype, np.int_)


### PR DESCRIPTION
This PR is based heavily on #9428 and a generalization of #9481. It offers a couple of additional enhancements:

- Reimplementing `np.diff` in terms of `np.neighborwise`.
- Adding the ability to perform diagonal diffs to `np.diff` as a consequence.
- Sorting the `__all__` list in `numpy/lib/function_base.py` into alphabetical order.

Email at http://numpy-discussion.10968.n7.nabble.com/ENH-Proposal-to-add-np-neighborwise-in-PR-9514-tp44620.html (archived https://mail.python.org/pipermail/numpy-discussion/2017-August/077099.html)