### PR TITLE
MAINT/DOC: Use builtin when np.{x} is builtins.{x}.

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -139,7 +139,7 @@ class CountNonzero(Benchmark):
 
 class PackBits(Benchmark):
     param_names = ['dtype']
-    params = [[np.bool, np.uintp]]
+    params = [[bool, np.uintp]]
     def setup(self, dtype):
         self.d = np.ones(10000, dtype=dtype)
         self.d2 = np.ones((200, 1000), dtype=dtype)

--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -29,8 +29,8 @@ class AddReduceSeparate(Benchmark):
 
 class AnyAll(Benchmark):
     def setup(self):
-        self.zeros = np.zeros(100000, np.bool)
-        self.ones = np.ones(100000, np.bool)
+        self.zeros = np.zeros(100000, bool)
+        self.ones = np.ones(100000, bool)
 
     def time_all_fast(self):
         self.zeros.all()

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -62,7 +62,7 @@ class UFunc(Benchmark):
 
 class Custom(Benchmark):
     def setup(self):
-        self.b = np.ones(20000, dtype=np.bool)
+        self.b = np.ones(20000, dtype=bool)
 
     def time_nonzero(self):
         np.nonzero(self.b)

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -931,7 +931,7 @@ add_newdoc('numpy.core.multiarray', 'zeros',
     >>> np.zeros(5)
     array([ 0.,  0.,  0.,  0.,  0.])
 
-    >>> np.zeros((5,), dtype=np.int)
+    >>> np.zeros((5,), dtype=int)
     array([0, 0, 0, 0, 0])
 
     >>> np.zeros((2, 1))
@@ -1038,7 +1038,7 @@ add_newdoc('numpy.core.multiarray', 'fromiter',
     Examples
     --------
     >>> iterable = (x*x for x in range(5))
-    >>> np.fromiter(iterable, np.float)
+    >>> np.fromiter(iterable, float)
     array([  0.,   1.,   4.,   9.,  16.])
 
     """)
@@ -1635,9 +1635,9 @@ add_newdoc('numpy.core.multiarray', 'can_cast',
 
     >>> np.can_cast(np.int32, np.int64)
     True
-    >>> np.can_cast(np.float64, np.complex)
+    >>> np.can_cast(np.float64, complex)
     True
-    >>> np.can_cast(np.complex, np.float)
+    >>> np.can_cast(complex, float)
     False
 
     >>> np.can_cast('i8', 'f8')
@@ -5163,7 +5163,7 @@ add_newdoc('numpy.core.multiarray', 'bincount',
     The input array needs to be of integer dtype, otherwise a
     TypeError is raised:
 
-    >>> np.bincount(np.arange(5, dtype=np.float))
+    >>> np.bincount(np.arange(5, dtype=float))
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     TypeError: array cannot be safely cast to required type
@@ -6099,7 +6099,7 @@ add_newdoc('numpy.core.multiarray', 'dtype',
     Using tuples.  ``int`` is a fixed type, 3 the field's shape.  ``void``
     is a flexible type, here of size 10:
 
-    >>> np.dtype([('hello',(np.int,3)),('world',np.void,10)])
+    >>> np.dtype([('hello',(int,3)),('world',np.void,10)])
     dtype([('hello', '<i4', 3), ('world', '|V10')])
 
     Subdivide ``int16`` into 2 ``int8``'s, called x and y.  0 and 1 are

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2246,7 +2246,7 @@ def amax(a, axis=None, out=None, keepdims=np._NoValue):
     >>> np.amax(a, axis=1)   # Maxima along the second axis
     array([1, 3])
 
-    >>> b = np.arange(5, dtype=np.float)
+    >>> b = np.arange(5, dtype=float)
     >>> b[2] = np.NaN
     >>> np.amax(b)
     nan
@@ -2347,7 +2347,7 @@ def amin(a, axis=None, out=None, keepdims=np._NoValue):
     >>> np.amin(a, axis=1)   # Minima along the second axis
     array([0, 2])
 
-    >>> b = np.arange(5, dtype=np.float)
+    >>> b = np.arange(5, dtype=float)
     >>> b[2] = np.NaN
     >>> np.amin(b)
     nan
@@ -2497,7 +2497,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     is the default platform integer:
 
     >>> x = np.array([1, 2, 3], dtype=np.int8)
-    >>> np.prod(x).dtype == np.int
+    >>> np.prod(x).dtype == int
     True
 
     """

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -133,7 +133,7 @@ def zeros_like(a, dtype=None, order='K', subok=True):
     array([[0, 0, 0],
            [0, 0, 0]])
 
-    >>> y = np.arange(3, dtype=np.float)
+    >>> y = np.arange(3, dtype=float)
     >>> y
     array([ 0.,  1.,  2.])
     >>> np.zeros_like(y)
@@ -176,7 +176,7 @@ def ones(shape, dtype=None, order='C'):
     >>> np.ones(5)
     array([ 1.,  1.,  1.,  1.,  1.])
 
-    >>> np.ones((5,), dtype=np.int)
+    >>> np.ones((5,), dtype=int)
     array([1, 1, 1, 1, 1])
 
     >>> np.ones((2, 1))
@@ -243,7 +243,7 @@ def ones_like(a, dtype=None, order='K', subok=True):
     array([[1, 1, 1],
            [1, 1, 1]])
 
-    >>> y = np.arange(3, dtype=np.float)
+    >>> y = np.arange(3, dtype=float)
     >>> y
     array([ 0.,  1.,  2.])
     >>> np.ones_like(y)
@@ -344,7 +344,7 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True):
 
     Examples
     --------
-    >>> x = np.arange(6, dtype=np.int)
+    >>> x = np.arange(6, dtype=int)
     >>> np.full_like(x, 1)
     array([1, 1, 1, 1, 1, 1])
     >>> np.full_like(x, 0.1)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -501,11 +501,11 @@ def maximum_sctype(t):
 
     Examples
     --------
-    >>> np.maximum_sctype(np.int)
+    >>> np.maximum_sctype(int)
     <type 'numpy.int64'>
     >>> np.maximum_sctype(np.uint8)
     <type 'numpy.uint64'>
-    >>> np.maximum_sctype(np.complex)
+    >>> np.maximum_sctype(complex)
     <type 'numpy.complex192'>
 
     >>> np.maximum_sctype(str)
@@ -684,9 +684,9 @@ def issubclass_(arg1, arg2):
 
     Examples
     --------
-    >>> np.issubclass_(np.int32, np.int)
+    >>> np.issubclass_(np.int32, int)
     True
-    >>> np.issubclass_(np.int32, np.float)
+    >>> np.issubclass_(np.int32, float)
     False
 
     """
@@ -717,9 +717,9 @@ def issubsctype(arg1, arg2):
     --------
     >>> np.issubsctype('S8', str)
     True
-    >>> np.issubsctype(np.array([1]), np.int)
+    >>> np.issubsctype(np.array([1]), int)
     True
-    >>> np.issubsctype(np.array([1]), np.float)
+    >>> np.issubsctype(np.array([1]), float)
     False
 
     """
@@ -821,7 +821,7 @@ def sctype2char(sctype):
 
     Examples
     --------
-    >>> for sctype in [np.int32, np.float, np.complex, np.string_, np.ndarray]:
+    >>> for sctype in [np.int32, float, complex, np.string_, np.ndarray]:
     ...     print(np.sctype2char(sctype))
     l
     d
@@ -986,7 +986,7 @@ def find_common_type(array_types, scalar_types):
 
     Examples
     --------
-    >>> np.find_common_type([], [np.int64, np.float32, np.complex])
+    >>> np.find_common_type([], [np.int64, np.float32, complex])
     dtype('complex128')
     >>> np.find_common_type([np.int64, np.float32], [])
     dtype('float64')
@@ -1002,7 +1002,7 @@ def find_common_type(array_types, scalar_types):
     Complex is of a different type, so it up-casts the float in the
     `array_types` argument:
 
-    >>> np.find_common_type([np.float32], [np.complex])
+    >>> np.find_common_type([np.float32], [complex])
     dtype('complex128')
 
     Type specifier strings are convertible to dtypes and can therefore

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -259,7 +259,7 @@ class TestNonCContiguousViewDeprecation(_DeprecationTestCase):
     """
 
     def test_fortran_contiguous(self):
-        self.assert_deprecated(np.ones((2,2)).T.view, args=(np.complex,))
+        self.assert_deprecated(np.ones((2,2)).T.view, args=(complex,))
         self.assert_deprecated(np.ones((2,2)).T.view, args=(np.int8,))
 
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -23,7 +23,7 @@ def assert_dtype_not_equal(a, b):
 class TestBuiltin(object):
     def test_run(self):
         """Only test hash runs at all."""
-        for t in [np.int, np.float, np.complex, np.int32, np.str, np.object,
+        for t in [int, float, complex, np.int32, str, object,
                 np.unicode]:
             dt = np.dtype(t)
             hash(dt)
@@ -31,7 +31,7 @@ class TestBuiltin(object):
     def test_dtype(self):
         # Make sure equivalent byte order char hash the same (e.g. < and = on
         # little endian)
-        for t in [np.int, np.float]:
+        for t in [int, float]:
             dt = np.dtype(t)
             dt2 = dt.newbyteorder("<")
             dt3 = dt.newbyteorder(">")
@@ -107,14 +107,14 @@ class TestBuiltin(object):
 class TestRecord(object):
     def test_equivalent_record(self):
         """Test whether equivalent record dtypes hash the same."""
-        a = np.dtype([('yo', np.int)])
-        b = np.dtype([('yo', np.int)])
+        a = np.dtype([('yo', int)])
+        b = np.dtype([('yo', int)])
         assert_dtype_equal(a, b)
 
     def test_different_names(self):
         # In theory, they may hash the same (collision) ?
-        a = np.dtype([('yo', np.int)])
-        b = np.dtype([('ye', np.int)])
+        a = np.dtype([('yo', int)])
+        b = np.dtype([('ye', int)])
         assert_dtype_not_equal(a, b)
 
     def test_different_titles(self):
@@ -129,9 +129,9 @@ class TestRecord(object):
 
     def test_mutate(self):
         # Mutating a dtype should reset the cached hash value
-        a = np.dtype([('yo', np.int)])
-        b = np.dtype([('yo', np.int)])
-        c = np.dtype([('ye', np.int)])
+        a = np.dtype([('yo', int)])
+        b = np.dtype([('yo', int)])
+        c = np.dtype([('ye', int)])
         assert_dtype_equal(a, b)
         assert_dtype_not_equal(a, c)
         a.names = ['ye']
@@ -291,8 +291,8 @@ class TestRecord(object):
 
 class TestSubarray(object):
     def test_single_subarray(self):
-        a = np.dtype((np.int, (2)))
-        b = np.dtype((np.int, (2,)))
+        a = np.dtype((int, (2)))
+        b = np.dtype((int, (2,)))
         assert_dtype_equal(a, b)
 
         assert_equal(type(a.subdtype[1]), tuple)
@@ -300,29 +300,29 @@ class TestSubarray(object):
 
     def test_equivalent_record(self):
         """Test whether equivalent subarray dtypes hash the same."""
-        a = np.dtype((np.int, (2, 3)))
-        b = np.dtype((np.int, (2, 3)))
+        a = np.dtype((int, (2, 3)))
+        b = np.dtype((int, (2, 3)))
         assert_dtype_equal(a, b)
 
     def test_nonequivalent_record(self):
         """Test whether different subarray dtypes hash differently."""
-        a = np.dtype((np.int, (2, 3)))
-        b = np.dtype((np.int, (3, 2)))
+        a = np.dtype((int, (2, 3)))
+        b = np.dtype((int, (3, 2)))
         assert_dtype_not_equal(a, b)
 
-        a = np.dtype((np.int, (2, 3)))
-        b = np.dtype((np.int, (2, 2)))
+        a = np.dtype((int, (2, 3)))
+        b = np.dtype((int, (2, 2)))
         assert_dtype_not_equal(a, b)
 
-        a = np.dtype((np.int, (1, 2, 3)))
-        b = np.dtype((np.int, (1, 2)))
+        a = np.dtype((int, (1, 2, 3)))
+        b = np.dtype((int, (1, 2)))
         assert_dtype_not_equal(a, b)
 
     def test_shape_equal(self):
         """Test some data types that are equal"""
         assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', tuple())))
         assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', 1)))
-        assert_dtype_equal(np.dtype((np.int, 2)), np.dtype((np.int, (2,))))
+        assert_dtype_equal(np.dtype((int, 2)), np.dtype((int, (2,))))
         assert_dtype_equal(np.dtype(('<f4', (3, 2))), np.dtype(('<f4', (3, 2))))
         d = ([('a', 'f4', (1, 2)), ('b', 'f8', (3, 1))], (3, 2))
         assert_dtype_equal(np.dtype(d), np.dtype(d))
@@ -421,15 +421,15 @@ class TestMonsterType(object):
     def test1(self):
         simple1 = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
             'titles': ['Red pixel', 'Blue pixel']})
-        a = np.dtype([('yo', np.int), ('ye', simple1),
-            ('yi', np.dtype((np.int, (3, 2))))])
-        b = np.dtype([('yo', np.int), ('ye', simple1),
-            ('yi', np.dtype((np.int, (3, 2))))])
+        a = np.dtype([('yo', int), ('ye', simple1),
+            ('yi', np.dtype((int, (3, 2))))])
+        b = np.dtype([('yo', int), ('ye', simple1),
+            ('yi', np.dtype((int, (3, 2))))])
         assert_dtype_equal(a, b)
 
-        c = np.dtype([('yo', np.int), ('ye', simple1),
+        c = np.dtype([('yo', int), ('ye', simple1),
             ('yi', np.dtype((a, (3, 2))))])
-        d = np.dtype([('yo', np.int), ('ye', simple1),
+        d = np.dtype([('yo', int), ('ye', simple1),
             ('yi', np.dtype((a, (3, 2))))])
         assert_dtype_equal(c, d)
 
@@ -641,8 +641,8 @@ class TestPickling(object):
             assert_equal(x[0], y[0])
 
     def test_builtin(self):
-        for t in [np.int, np.float, np.complex, np.int32, np.str, np.object,
-                  np.unicode, np.bool]:
+        for t in [int, float, complex, np.int32, str, object,
+                  np.unicode, bool]:
             self.check_pickling(np.dtype(t))
 
     def test_structured(self):

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -65,7 +65,7 @@ class TestHalf(object):
         # Check the range for which all integers can be represented
         i_int = np.arange(-2048, 2049)
         i_f16 = np.array(i_int, dtype=float16)
-        j = np.array(i_f16, dtype=np.int)
+        j = np.array(i_f16, dtype=int)
         assert_equal(i_int, j)
 
     def test_nans_infs(self):

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -24,7 +24,7 @@ class TestTake(object):
         # Currently all types but object, use the same function generation.
         # So it should not be necessary to test all. However test also a non
         # refcounted struct on top of object.
-        types = np.int, np.object, np.dtype([('', 'i', 2)])
+        types = int, object, np.dtype([('', 'i', 2)])
         for t in types:
             # ta works, even if the array may be odd if buffer interface is used
             ta = np.array(a if np.issubdtype(t, np.number) else a_str, dtype=t)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -297,7 +297,7 @@ class TestArrayConstruction(object):
         assert_equal(r[0], [d, d + 1])
         assert_equal(r[1], d + 2)
 
-        tgt = np.ones((2, 3), dtype=np.bool)
+        tgt = np.ones((2, 3), dtype=bool)
         tgt[0, 2] = False
         tgt[1, 0:2] = False
         r = np.array([[True, True, False], [False, False, True]])
@@ -759,20 +759,20 @@ class TestCreation(object):
             str(d)
 
     def test_sequence_non_homogenous(self):
-        assert_equal(np.array([4, 2**80]).dtype, np.object)
-        assert_equal(np.array([4, 2**80, 4]).dtype, np.object)
-        assert_equal(np.array([2**80, 4]).dtype, np.object)
-        assert_equal(np.array([2**80] * 3).dtype, np.object)
-        assert_equal(np.array([[1, 1],[1j, 1j]]).dtype, np.complex)
-        assert_equal(np.array([[1j, 1j],[1, 1]]).dtype, np.complex)
-        assert_equal(np.array([[1, 1, 1],[1, 1j, 1.], [1, 1, 1]]).dtype, np.complex)
+        assert_equal(np.array([4, 2**80]).dtype, object)
+        assert_equal(np.array([4, 2**80, 4]).dtype, object)
+        assert_equal(np.array([2**80, 4]).dtype, object)
+        assert_equal(np.array([2**80] * 3).dtype, object)
+        assert_equal(np.array([[1, 1],[1j, 1j]]).dtype, complex)
+        assert_equal(np.array([[1j, 1j],[1, 1]]).dtype, complex)
+        assert_equal(np.array([[1, 1, 1],[1, 1j, 1.], [1, 1, 1]]).dtype, complex)
 
     @dec.skipif(sys.version_info[0] >= 3)
     def test_sequence_long(self):
         assert_equal(np.array([long(4), long(4)]).dtype, np.long)
-        assert_equal(np.array([long(4), 2**80]).dtype, np.object)
-        assert_equal(np.array([long(4), 2**80, long(4)]).dtype, np.object)
-        assert_equal(np.array([2**80, long(4)]).dtype, np.object)
+        assert_equal(np.array([long(4), 2**80]).dtype, object)
+        assert_equal(np.array([long(4), 2**80, long(4)]).dtype, object)
+        assert_equal(np.array([2**80, long(4)]).dtype, object)
 
     def test_non_sequence_sequence(self):
         """Should not segfault.
@@ -876,7 +876,7 @@ class TestStructured(object):
         # multi-dimensional field types work properly
         a = np.rec.fromrecords(
             [([1, 2, 3], 'a', [[1, 2], [3, 4]]), ([3, 3, 3], 'b', [[0, 0], [0, 0]])],
-            dtype=[('a', ('f4', 3)), ('b', np.object), ('c', ('i4', (2, 2)))])
+            dtype=[('a', ('f4', 3)), ('b', object), ('c', ('i4', (2, 2)))])
         b = a.copy()
         assert_equal(a == b, [True, True])
         assert_equal(a != b, [False, False])
@@ -1109,7 +1109,7 @@ class TestBool(object):
         assert_(np.array(True)[()] is a1)
 
     def test_sum(self):
-        d = np.ones(101, dtype=np.bool)
+        d = np.ones(101, dtype=bool)
         assert_equal(d.sum(), d.size)
         assert_equal(d[::2].sum(), d[::2].size)
         assert_equal(d[::-2].sum(), d[::-2].size)
@@ -1123,7 +1123,7 @@ class TestBool(object):
         powers = [2 ** i for i in range(length)]
         for i in range(2**power):
             l = [(i & x) != 0 for x in powers]
-            a = np.array(l, dtype=np.bool)
+            a = np.array(l, dtype=bool)
             c = builtins.sum(l)
             assert_equal(np.count_nonzero(a), c)
             av = a.view(np.uint8)
@@ -1148,10 +1148,10 @@ class TestBool(object):
     def test_count_nonzero_unaligned(self):
         # prevent mistakes as e.g. gh-4060
         for o in range(7):
-            a = np.zeros((18,), dtype=np.bool)[o+1:]
+            a = np.zeros((18,), dtype=bool)[o+1:]
             a[:o] = True
             assert_equal(np.count_nonzero(a), builtins.sum(a.tolist()))
-            a = np.ones((18,), dtype=np.bool)[o+1:]
+            a = np.ones((18,), dtype=bool)[o+1:]
             a[:o] = False
             assert_equal(np.count_nonzero(a), builtins.sum(a.tolist()))
 
@@ -1381,7 +1381,7 @@ class TestMethods(object):
             assert_equal(c, a, msg)
 
         # test object array sorts.
-        a = np.empty((101,), dtype=np.object)
+        a = np.empty((101,), dtype=object)
         a[:] = list(range(101))
         b = a[::-1]
         for kind in ['q', 'h', 'm']:
@@ -1627,7 +1627,7 @@ class TestMethods(object):
             assert_equal(b.copy().argsort(kind=kind), rr, msg)
 
         # test object array argsorts.
-        a = np.empty((101,), dtype=np.object)
+        a = np.empty((101,), dtype=object)
         a[:] = list(range(101))
         b = a[::-1]
         r = np.arange(101)
@@ -1694,7 +1694,7 @@ class TestMethods(object):
         a = np.zeros(100)
         assert_equal(a.argsort(kind='m'), r)
         # complex
-        a = np.zeros(100, dtype=np.complex)
+        a = np.zeros(100, dtype=complex)
         assert_equal(a.argsort(kind='m'), r)
         # string
         a = np.array(['aaaaaaaaa' for i in range(100)])
@@ -3180,7 +3180,7 @@ class TestTemporaryElide(object):
         # only triggers elision code path in debug mode as triggering it in
         # normal mode needs 256kb large matching dimension, so a lot of memory
         d = np.ones((2000, 1), dtype=int)
-        b = np.ones((2000), dtype=np.bool)
+        b = np.ones((2000), dtype=bool)
         r = (1 - d) + b
         assert_equal(r, 1)
         assert_equal(r.shape, (2000, 2000))
@@ -3937,7 +3937,7 @@ class TestIO(object):
     def setup(self):
         shape = (2, 4, 3)
         rand = np.random.random
-        self.x = rand(shape) + rand(shape).astype(np.complex)*1j
+        self.x = rand(shape) + rand(shape).astype(complex)*1j
         self.x[0,:, 1] = [np.nan, np.inf, -np.inf, np.nan]
         self.dtype = self.x.dtype
         self.tempdir = tempfile.mkdtemp()
@@ -4253,7 +4253,7 @@ class TestFromBuffer(object):
 
     def test_ip_basic(self):
         for byteorder in ['<', '>']:
-            for dtype in [float, int, np.complex]:
+            for dtype in [float, int, complex]:
                 dt = np.dtype(dtype).newbyteorder(byteorder)
                 x = (np.random.random((4, 7))*5).astype(dt)
                 buf = x.tobytes()
@@ -4835,7 +4835,7 @@ class TestVdot(object):
             assert_equal(np.vdot(b, b), 3)
 
         # test boolean
-        b = np.eye(3, dtype=np.bool)
+        b = np.eye(3, dtype=bool)
         res = np.vdot(b, b)
         assert_(np.isscalar(res))
         assert_equal(np.vdot(b, b), True)
@@ -5350,19 +5350,19 @@ class TestMatmul(MatmulCommon):
     matmul = np.matmul
 
     def test_out_arg(self):
-        a = np.ones((2, 2), dtype=np.float)
-        b = np.ones((2, 2), dtype=np.float)
-        tgt = np.full((2,2), 2, dtype=np.float)
+        a = np.ones((2, 2), dtype=float)
+        b = np.ones((2, 2), dtype=float)
+        tgt = np.full((2,2), 2, dtype=float)
 
         # test as positional argument
         msg = "out positional argument"
-        out = np.zeros((2, 2), dtype=np.float)
+        out = np.zeros((2, 2), dtype=float)
         self.matmul(a, b, out)
         assert_array_equal(out, tgt, err_msg=msg)
 
         # test as keyword argument
         msg = "out keyword argument"
-        out = np.zeros((2, 2), dtype=np.float)
+        out = np.zeros((2, 2), dtype=float)
         self.matmul(a, b, out=out)
         assert_array_equal(out, tgt, err_msg=msg)
 
@@ -5385,7 +5385,7 @@ class TestMatmul(MatmulCommon):
 
         # test out non-contiguous
         # msg = "out argument with non-contiguous layout"
-        # c = np.zeros((2, 2, 2), dtype=np.float)
+        # c = np.zeros((2, 2, 2), dtype=float)
         # self.matmul(a, b, out=c[..., 0])
         # assert_array_equal(c, tgt, err_msg=msg)
 
@@ -5649,7 +5649,7 @@ class TestNeighborhoodIter(object):
         assert_array_equal(l, r)
 
     def test_simple2d(self):
-        self._test_simple2d(np.float)
+        self._test_simple2d(float)
 
     def test_simple2d_object(self):
         self._test_simple2d(Decimal)
@@ -5665,7 +5665,7 @@ class TestNeighborhoodIter(object):
         assert_array_equal(l, r)
 
     def test_mirror2d(self):
-        self._test_mirror2d(np.float)
+        self._test_mirror2d(float)
 
     def test_mirror2d_object(self):
         self._test_mirror2d(Decimal)
@@ -5687,7 +5687,7 @@ class TestNeighborhoodIter(object):
         assert_array_equal(l, r)
 
     def test_simple_float(self):
-        self._test_simple(np.float)
+        self._test_simple(float)
 
     def test_simple_object(self):
         self._test_simple(Decimal)
@@ -5702,7 +5702,7 @@ class TestNeighborhoodIter(object):
         assert_array_equal(l, r)
 
     def test_mirror(self):
-        self._test_mirror(np.float)
+        self._test_mirror(float)
 
     def test_mirror_object(self):
         self._test_mirror(Decimal)
@@ -5716,7 +5716,7 @@ class TestNeighborhoodIter(object):
         assert_array_equal(l, r)
 
     def test_circular(self):
-        self._test_circular(np.float)
+        self._test_circular(float)
 
     def test_circular_object(self):
         self._test_circular(Decimal)
@@ -6530,10 +6530,10 @@ class TestConversion(object):
 
 class TestWhere(object):
     def test_basic(self):
-        dts = [np.bool, np.int16, np.int32, np.int64, np.double, np.complex128,
+        dts = [bool, np.int16, np.int32, np.int64, np.double, np.complex128,
                np.longdouble, np.clongdouble]
         for dt in dts:
-            c = np.ones(53, dtype=np.bool)
+            c = np.ones(53, dtype=bool)
             assert_equal(np.where( c, dt(0), dt(1)), dt(0))
             assert_equal(np.where(~c, dt(0), dt(1)), dt(1))
             assert_equal(np.where(True, dt(0), dt(1)), dt(0))
@@ -6625,7 +6625,7 @@ class TestWhere(object):
         assert_equal(np.where(c, a, b), r)
 
         # non bool mask
-        c = c.astype(np.int)
+        c = c.astype(int)
         c[c != 0] = 34242324
         assert_equal(np.where(c, a, b), r)
         # invert
@@ -6841,20 +6841,20 @@ class TestArrayPriority(object):
 class TestBytestringArrayNonzero(object):
 
     def test_empty_bstring_array_is_falsey(self):
-        assert_(not np.array([''], dtype=np.str))
+        assert_(not np.array([''], dtype=str))
 
     def test_whitespace_bstring_array_is_falsey(self):
-        a = np.array(['spam'], dtype=np.str)
+        a = np.array(['spam'], dtype=str)
         a[0] = '  \0\0'
         assert_(not a)
 
     def test_all_null_bstring_array_is_falsey(self):
-        a = np.array(['spam'], dtype=np.str)
+        a = np.array(['spam'], dtype=str)
         a[0] = '\0\0\0\0'
         assert_(not a)
 
     def test_null_inside_bstring_array_is_truthy(self):
-        a = np.array(['spam'], dtype=np.str)
+        a = np.array(['spam'], dtype=str)
         a[0] = ' \0 \0'
         assert_(a)
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2145,7 +2145,7 @@ def test_iter_buffered_reduce_reuse():
     op_flags = [('readonly',), ('readwrite', 'allocate')]
     op_axes_list = [[(0, 1, 2), (0, 1, -1)], [(0, 1, 2), (0, -1, -1)]]
     # wrong dtype to force buffering
-    op_dtypes = [np.float, a.dtype]
+    op_dtypes = [float, a.dtype]
 
     def get_params():
         for xs in range(-3**2, 3**2 + 1):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -244,9 +244,9 @@ class TestBoolScalar(object):
 class TestBoolArray(object):
     def setup(self):
         # offset for simd tests
-        self.t = np.array([True] * 41, dtype=np.bool)[1::]
-        self.f = np.array([False] * 41, dtype=np.bool)[1::]
-        self.o = np.array([False] * 42, dtype=np.bool)[2::]
+        self.t = np.array([True] * 41, dtype=bool)[1::]
+        self.f = np.array([False] * 41, dtype=bool)[1::]
+        self.o = np.array([False] * 42, dtype=bool)[2::]
         self.nm = self.f.copy()
         self.im = self.t.copy()
         self.nm[3] = True
@@ -265,19 +265,19 @@ class TestBoolArray(object):
         assert_(not self.im.all())
         # check bad element in all positions
         for i in range(256 - 7):
-            d = np.array([False] * 256, dtype=np.bool)[7::]
+            d = np.array([False] * 256, dtype=bool)[7::]
             d[i] = True
             assert_(np.any(d))
-            e = np.array([True] * 256, dtype=np.bool)[7::]
+            e = np.array([True] * 256, dtype=bool)[7::]
             e[i] = False
             assert_(not np.all(e))
             assert_array_equal(e, ~d)
         # big array test for blocked libc loops
         for i in list(range(9, 6000, 507)) + [7764, 90021, -10]:
-            d = np.array([False] * 100043, dtype=np.bool)
+            d = np.array([False] * 100043, dtype=bool)
             d[i] = True
             assert_(np.any(d), msg="%r" % i)
-            e = np.array([True] * 100043, dtype=np.bool)
+            e = np.array([True] * 100043, dtype=bool)
             e[i] = False
             assert_(not np.all(e), msg="%r" % i)
 
@@ -331,9 +331,9 @@ class TestBoolArray(object):
 class TestBoolCmp(object):
     def setup(self):
         self.f = np.ones(256, dtype=np.float32)
-        self.ef = np.ones(self.f.size, dtype=np.bool)
+        self.ef = np.ones(self.f.size, dtype=bool)
         self.d = np.ones(128, dtype=np.float64)
-        self.ed = np.ones(self.d.size, dtype=np.bool)
+        self.ed = np.ones(self.d.size, dtype=bool)
         # generate values for all permutation of 256bit simd vectors
         s = 0
         for i in range(32):
@@ -800,8 +800,8 @@ class TestTypes(object):
 
     def test_can_cast(self):
         assert_(np.can_cast(np.int32, np.int64))
-        assert_(np.can_cast(np.float64, np.complex))
-        assert_(not np.can_cast(np.complex, np.float))
+        assert_(np.can_cast(np.float64, complex))
+        assert_(not np.can_cast(complex, float))
 
         assert_(np.can_cast('i8', 'f8'))
         assert_(not np.can_cast('i8', 'f4'))
@@ -981,11 +981,11 @@ class TestNonzero(object):
     def test_sparse(self):
         # test special sparse condition boolean code path
         for i in range(20):
-            c = np.zeros(200, dtype=np.bool)
+            c = np.zeros(200, dtype=bool)
             c[i::20] = True
             assert_equal(np.nonzero(c)[0], np.arange(i, 200 + i, 20))
 
-            c = np.zeros(400, dtype=np.bool)
+            c = np.zeros(400, dtype=bool)
             c[10 + i:20 + i] = True
             c[20 + i*2] = True
             assert_equal(np.nonzero(c)[0],
@@ -1095,7 +1095,7 @@ class TestNonzero(object):
 
         rng = np.random.RandomState(1234)
         m = rng.randint(-100, 100, size=size)
-        n = m.astype(np.object)
+        n = m.astype(object)
 
         for length in range(len(axis)):
             for combo in combinations(axis, length):
@@ -1386,7 +1386,7 @@ class TestClip(object):
         # Address Issue gh-5354 for clipping complex arrays
         # Test native complex input without explicit min/max
         # ie, either min=None or max=None
-        a = np.ones(10, dtype=np.complex)
+        a = np.ones(10, dtype=complex)
         m = a.min()
         M = a.max()
         am = self.fastclip(a, m, None)
@@ -2185,7 +2185,7 @@ class TestCorrelate(object):
                            -102., -54., -19.], dtype=dt)
 
     def test_float(self):
-        self._setup(np.float)
+        self._setup(float)
         z = np.correlate(self.x, self.y, 'full')
         assert_array_almost_equal(z, self.z1)
         z = np.correlate(self.x, self.y[:-1], 'full')
@@ -2214,9 +2214,9 @@ class TestCorrelate(object):
         assert_array_equal(k, np.ones(3))
 
     def test_complex(self):
-        x = np.array([1, 2, 3, 4+1j], dtype=np.complex)
-        y = np.array([-1, -2j, 3+1j], dtype=np.complex)
-        r_z = np.array([3-1j, 6, 8+1j, 11+5j, -5+8j, -4-1j], dtype=np.complex)
+        x = np.array([1, 2, 3, 4+1j], dtype=complex)
+        y = np.array([-1, -2j, 3+1j], dtype=complex)
+        r_z = np.array([3-1j, 6, 8+1j, 11+5j, -5+8j, -4-1j], dtype=complex)
         r_z = r_z[::-1].conjugate()
         z = np.correlate(y, x, mode='full')
         assert_array_almost_equal(z, r_z)

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -35,7 +35,7 @@ def test_float_types():
     """ Check formatting.
 
         This is only for the str function, and only for simple types.
-        The precision of np.float and np.longdouble aren't the same as the
+        The precision of np.float32 and np.longdouble aren't the same as the
         python float precision.
 
     """
@@ -51,7 +51,7 @@ def test_nan_inf_float():
     """ Check formatting of nan & inf.
 
         This is only for the str function, and only for simple types.
-        The precision of np.float and np.longdouble aren't the same as the
+        The precision of np.float32 and np.longdouble aren't the same as the
         python float precision.
 
     """
@@ -79,7 +79,7 @@ def test_complex_types():
     """Check formatting of complex types.
 
         This is only for the str function, and only for simple types.
-        The precision of np.float and np.longdouble aren't the same as the
+        The precision of np.float32 and np.longdouble aren't the same as the
         python float precision.
 
     """

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -29,7 +29,7 @@ class TestFromrecords(object):
 
     def test_fromrecords_0len(self):
         """ Verify fromrecords works with a 0-length input """
-        dtype = [('a', np.float), ('b', np.float)]
+        dtype = [('a', float), ('b', float)]
         r = np.rec.fromrecords([], dtype=dtype)
         assert_equal(r.shape, (0,))
 
@@ -235,13 +235,13 @@ class TestFromrecords(object):
 
     def test_fromrecords_with_explicit_dtype(self):
         a = np.rec.fromrecords([(1, 'a'), (2, 'bbb')],
-                                dtype=[('a', int), ('b', np.object)])
+                                dtype=[('a', int), ('b', object)])
         assert_equal(a.a, [1, 2])
         assert_equal(a[0].a, 1)
         assert_equal(a.b, ['a', 'bbb'])
         assert_equal(a[-1].b, 'bbb')
         #
-        ndtype = np.dtype([('a', int), ('b', np.object)])
+        ndtype = np.dtype([('a', int), ('b', object)])
         a = np.rec.fromrecords([(1, 'a'), (2, 'bbb')], dtype=ndtype)
         assert_equal(a.a, [1, 2])
         assert_equal(a[0].a, 1)

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -446,7 +446,7 @@ class TestRegression(object):
 
     def test_pickle_dtype(self, level=rlevel):
         # Ticket #251
-        pickle.dumps(np.float)
+        pickle.dumps(float)
 
     def test_swap_real(self, level=rlevel):
         # Ticket #265
@@ -1360,7 +1360,7 @@ class TestRegression(object):
         a = np.ones(100, dtype=np.int8)
         b = np.ones(100, dtype=np.int32)
         i = np.lexsort((a[::-1], b))
-        assert_equal(i, np.arange(100, dtype=np.int))
+        assert_equal(i, np.arange(100, dtype=int))
 
     def test_object_array_to_fixed_string(self):
         # Ticket #1235.
@@ -1471,7 +1471,7 @@ class TestRegression(object):
             min //= -1
 
         with np.errstate(divide="ignore"):
-            for t in (np.int8, np.int16, np.int32, np.int64, np.int, np.long):
+            for t in (np.int8, np.int16, np.int32, np.int64, int, np.long):
                 test_type(t)
 
     def test_buffer_hashlib(self):
@@ -1563,9 +1563,9 @@ class TestRegression(object):
     @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
     def test_take_refcount(self):
         # ticket #939
-        a = np.arange(16, dtype=np.float)
+        a = np.arange(16, dtype=float)
         a.shape = (4, 4)
-        lut = np.ones((5 + 3, 4), np.float)
+        lut = np.ones((5 + 3, 4), float)
         rgba = np.empty(shape=a.shape + (4,), dtype=lut.dtype)
         c1 = sys.getrefcount(rgba)
         try:
@@ -2173,7 +2173,7 @@ class TestRegression(object):
         # gh-6250
         recordtype = np.dtype([('a', np.float64),
                                ('b', np.int32),
-                               ('d', (np.str, 5))])
+                               ('d', (str, 5))])
 
         # Simple case
         a = np.zeros(2, dtype=recordtype)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -126,7 +126,7 @@ class TestPower(object):
 
     def test_integers_to_negative_integer_power(self):
         # Note that the combination of uint64 with a signed integer
-        # has common type np.float. The other combinations should all
+        # has common type np.float64. The other combinations should all
         # raise a ValueError for integer ** negative integer.
         exp = [np.array(-1, dt)[()] for dt in 'bhilq']
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -17,7 +17,7 @@ from numpy.testing import (
 class TestUfuncKwargs(object):
     def test_kwarg_exact(self):
         assert_raises(TypeError, np.add, 1, 2, castingx='safe')
-        assert_raises(TypeError, np.add, 1, 2, dtypex=np.int)
+        assert_raises(TypeError, np.add, 1, 2, dtypex=int)
         assert_raises(TypeError, np.add, 1, 2, extobjx=[4096])
         assert_raises(TypeError, np.add, 1, 2, outx=None)
         assert_raises(TypeError, np.add, 1, 2, sigx='ii->i')
@@ -31,9 +31,9 @@ class TestUfuncKwargs(object):
 
     def test_sig_dtype(self):
         assert_raises(RuntimeError, np.add, 1, 2, sig='ii->i',
-                      dtype=np.int)
+                      dtype=int)
         assert_raises(RuntimeError, np.add, 1, 2, signature='ii->i',
-                      dtype=np.int)
+                      dtype=int)
 
 
 class TestUfunc(object):
@@ -174,22 +174,22 @@ class TestUfunc(object):
 
         # check unary PyUFunc_O_O
         msg = "PyUFunc_O_O"
-        x = np.ones(10, dtype=np.object)[0::2]
+        x = np.ones(10, dtype=object)[0::2]
         assert_(np.all(np.abs(x) == 1), msg)
         # check unary PyUFunc_O_O_method
         msg = "PyUFunc_O_O_method"
-        x = np.zeros(10, dtype=np.object)[0::2]
+        x = np.zeros(10, dtype=object)[0::2]
         for i in range(len(x)):
             x[i] = foo()
         assert_(np.all(np.conjugate(x) == True), msg)
 
         # check binary PyUFunc_OO_O
         msg = "PyUFunc_OO_O"
-        x = np.ones(10, dtype=np.object)[0::2]
+        x = np.ones(10, dtype=object)[0::2]
         assert_(np.all(np.add(x, x) == 2), msg)
         # check binary PyUFunc_OO_O_method
         msg = "PyUFunc_OO_O_method"
-        x = np.zeros(10, dtype=np.object)[0::2]
+        x = np.zeros(10, dtype=object)[0::2]
         for i in range(len(x)):
             x[i] = foo()
         assert_(np.all(np.logical_xor(x, x)), msg)
@@ -437,7 +437,7 @@ class TestUfunc(object):
         assert_almost_equal((a / 10.).sum() - a.size / 10., 0, 13)
 
     def test_sum(self):
-        for dt in (np.int, np.float16, np.float32, np.float64, np.longdouble):
+        for dt in (int, np.float16, np.float32, np.float64, np.longdouble):
             for v in (0, 1, 2, 7, 8, 9, 15, 16, 19, 127,
                       128, 1024, 1235):
                 tgt = dt(v * (v + 1) / 2)
@@ -679,7 +679,7 @@ class TestUfunc(object):
         assert_equal(ref, True, err_msg="reference check")
 
     def test_euclidean_pdist(self):
-        a = np.arange(12, dtype=np.float).reshape(4, 3)
+        a = np.arange(12, dtype=float).reshape(4, 3)
         out = np.empty((a.shape[0] * (a.shape[0] - 1) // 2,), dtype=a.dtype)
         umt.euclidean_pdist(a, out)
         b = np.sqrt(np.sum((a[:, None] - a)**2, axis=-1))
@@ -1254,9 +1254,9 @@ class TestUfunc(object):
         assert_array_equal(values, [1, 8, 6, 4])
 
         # Test exception thrown
-        values = np.array(['a', 1], dtype=np.object)
+        values = np.array(['a', 1], dtype=object)
         assert_raises(TypeError, np.add.at, values, [0, 1], 1)
-        assert_array_equal(values, np.array(['a', 1], dtype=np.object))
+        assert_array_equal(values, np.array(['a', 1], dtype=object))
 
         # Test multiple output ufuncs raise error, gh-5665
         assert_raises(ValueError, np.modf.at, np.arange(10), [1])

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -897,22 +897,22 @@ class TestMaximum(_FilterInvalids):
         # fail if cmp is used instead of rich compare.
         # Failure cannot be guaranteed.
         for i in range(1):
-            x = np.array(float('nan'), np.object)
+            x = np.array(float('nan'), object)
             y = 1.0
-            z = np.array(float('nan'), np.object)
+            z = np.array(float('nan'), object)
             assert_(np.maximum(x, y) == 1.0)
             assert_(np.maximum(z, y) == 1.0)
 
     def test_complex_nans(self):
         nan = np.nan
         for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=np.complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=np.complex)
-            out = np.array([nan, nan, nan], dtype=np.complex)
+            arg1 = np.array([0, cnan, cnan], dtype=complex)
+            arg2 = np.array([cnan, 0, cnan], dtype=complex)
+            out = np.array([nan, nan, nan], dtype=complex)
             assert_equal(np.maximum(arg1, arg2), out)
 
     def test_object_array(self):
-        arg1 = np.arange(5, dtype=np.object)
+        arg1 = np.arange(5, dtype=object)
         arg2 = arg1 + 1
         assert_equal(np.maximum(arg1, arg2), arg2)
 
@@ -955,22 +955,22 @@ class TestMinimum(_FilterInvalids):
         # fail if cmp is used instead of rich compare.
         # Failure cannot be guaranteed.
         for i in range(1):
-            x = np.array(float('nan'), np.object)
+            x = np.array(float('nan'), object)
             y = 1.0
-            z = np.array(float('nan'), np.object)
+            z = np.array(float('nan'), object)
             assert_(np.minimum(x, y) == 1.0)
             assert_(np.minimum(z, y) == 1.0)
 
     def test_complex_nans(self):
         nan = np.nan
         for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=np.complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=np.complex)
-            out = np.array([nan, nan, nan], dtype=np.complex)
+            arg1 = np.array([0, cnan, cnan], dtype=complex)
+            arg2 = np.array([cnan, 0, cnan], dtype=complex)
+            out = np.array([nan, nan, nan], dtype=complex)
             assert_equal(np.minimum(arg1, arg2), out)
 
     def test_object_array(self):
-        arg1 = np.arange(5, dtype=np.object)
+        arg1 = np.arange(5, dtype=object)
         arg2 = arg1 + 1
         assert_equal(np.minimum(arg1, arg2), arg1)
 
@@ -1011,9 +1011,9 @@ class TestFmax(_FilterInvalids):
     def test_complex_nans(self):
         nan = np.nan
         for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=np.complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=np.complex)
-            out = np.array([0,    0, nan], dtype=np.complex)
+            arg1 = np.array([0, cnan, cnan], dtype=complex)
+            arg2 = np.array([cnan, 0, cnan], dtype=complex)
+            out = np.array([0,    0, nan], dtype=complex)
             assert_equal(np.fmax(arg1, arg2), out)
 
 
@@ -1053,9 +1053,9 @@ class TestFmin(_FilterInvalids):
     def test_complex_nans(self):
         nan = np.nan
         for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=np.complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=np.complex)
-            out = np.array([0,    0, nan], dtype=np.complex)
+            arg1 = np.array([0, cnan, cnan], dtype=complex)
+            arg2 = np.array([cnan, 0, cnan], dtype=complex)
+            out = np.array([0,    0, nan], dtype=complex)
             assert_equal(np.fmin(arg1, arg2), out)
 
 
@@ -1210,7 +1210,7 @@ class TestBitwiseUFuncs(object):
 class TestInt(object):
     def test_logical_not(self):
         x = np.ones(10, dtype=np.int16)
-        o = np.ones(10 * 2, dtype=np.bool)
+        o = np.ones(10 * 2, dtype=bool)
         tgt = o.copy()
         tgt[::2] = False
         os = o[::2]
@@ -1274,7 +1274,7 @@ class TestSign(object):
         # In reference to github issue #6229
 
         foo = np.array([-.1, 0, .1])
-        a = np.sign(foo.astype(np.object))
+        a = np.sign(foo.astype(object))
         b = np.sign(foo)
 
         assert_array_equal(a, b)
@@ -1283,7 +1283,7 @@ class TestSign(object):
         # In reference to github issue #6229
         def test_nan():
             foo = np.array([np.nan])
-            a = np.sign(foo.astype(np.object))
+            a = np.sign(foo.astype(object))
 
         assert_raises(TypeError, test_nan)
 
@@ -2210,7 +2210,7 @@ class TestComplexFunctions(object):
             else:
                 x = .5
             fr = f(x)
-            fz = f(np.complex(x))
+            fz = f(complex(x))
             assert_almost_equal(fz.real, fr, err_msg='real part %s' % f)
             assert_almost_equal(fz.imag, 0., err_msg='imag part %s' % f)
 
@@ -2279,7 +2279,7 @@ class TestComplexFunctions(object):
         points = [-1-1j, -1+1j, +1-1j, +1+1j]
         name_map = {'arcsin': 'asin', 'arccos': 'acos', 'arctan': 'atan',
                     'arcsinh': 'asinh', 'arccosh': 'acosh', 'arctanh': 'atanh'}
-        atol = 4*np.finfo(np.complex).eps
+        atol = 4*np.finfo(complex).eps
         for func in self.funcs:
             fname = func.__name__.split('.')[-1]
             cname = name_map.get(fname, fname)
@@ -2419,7 +2419,7 @@ class TestSubclass(object):
         assert_equal(a+a, a)
 
 def _check_branch_cut(f, x0, dx, re_sign=1, im_sign=-1, sig_zero_ok=False,
-                      dtype=np.complex):
+                      dtype=complex):
     """
     Check for a branch cut in a function.
 

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -38,7 +38,7 @@ class TestCexp(object):
         yield check, f, 1, 0, np.exp(1), 0, False
         yield check, f, 0, 1, np.cos(1), np.sin(1), False
 
-        ref = np.exp(1) * np.complex(np.cos(1), np.sin(1))
+        ref = np.exp(1) * complex(np.cos(1), np.sin(1))
         yield check, f, 1, 1, ref.real, ref.imag, False
 
     @platform_skip
@@ -73,7 +73,7 @@ class TestCexp(object):
         def _check_ninf_inf(dummy):
             msgform = "cexp(-inf, inf) is (%f, %f), expected (+-0, +-0)"
             with np.errstate(invalid='ignore'):
-                z = f(np.array(np.complex(-np.inf, np.inf)))
+                z = f(np.array(complex(-np.inf, np.inf)))
                 if z.real != 0 or z.imag != 0:
                     raise AssertionError(msgform % (z.real, z.imag))
 
@@ -83,7 +83,7 @@ class TestCexp(object):
         def _check_inf_inf(dummy):
             msgform = "cexp(inf, inf) is (%f, %f), expected (+-inf, nan)"
             with np.errstate(invalid='ignore'):
-                z = f(np.array(np.complex(np.inf, np.inf)))
+                z = f(np.array(complex(np.inf, np.inf)))
                 if not np.isinf(z.real) or not np.isnan(z.imag):
                     raise AssertionError(msgform % (z.real, z.imag))
 
@@ -93,7 +93,7 @@ class TestCexp(object):
         def _check_ninf_nan(dummy):
             msgform = "cexp(-inf, nan) is (%f, %f), expected (+-0, +-0)"
             with np.errstate(invalid='ignore'):
-                z = f(np.array(np.complex(-np.inf, np.nan)))
+                z = f(np.array(complex(-np.inf, np.nan)))
                 if z.real != 0 or z.imag != 0:
                     raise AssertionError(msgform % (z.real, z.imag))
 
@@ -103,7 +103,7 @@ class TestCexp(object):
         def _check_inf_nan(dummy):
             msgform = "cexp(-inf, nan) is (%f, %f), expected (+-inf, nan)"
             with np.errstate(invalid='ignore'):
-                z = f(np.array(np.complex(np.inf, np.nan)))
+                z = f(np.array(complex(np.inf, np.nan)))
                 if not np.isinf(z.real) or not np.isnan(z.imag):
                     raise AssertionError(msgform % (z.real, z.imag))
 
@@ -150,8 +150,8 @@ class TestClog(object):
         # clog(-0 + i0) returns -inf + i pi and raises the 'divide-by-zero'
         # floating-point exception.
         with np.errstate(divide='raise'):
-            x = np.array([np.NZERO], dtype=np.complex)
-            y = np.complex(-np.inf, np.pi)
+            x = np.array([np.NZERO], dtype=complex)
+            y = complex(-np.inf, np.pi)
             assert_raises(FloatingPointError, np.log, x)
         with np.errstate(divide='ignore'):
             assert_almost_equal(np.log(x), y)
@@ -162,8 +162,8 @@ class TestClog(object):
         # clog(+0 + i0) returns -inf + i0 and raises the 'divide-by-zero'
         # floating-point exception.
         with np.errstate(divide='raise'):
-            x = np.array([0], dtype=np.complex)
-            y = np.complex(-np.inf, 0)
+            x = np.array([0], dtype=complex)
+            y = complex(-np.inf, 0)
             assert_raises(FloatingPointError, np.log, x)
         with np.errstate(divide='ignore'):
             assert_almost_equal(np.log(x), y)
@@ -172,13 +172,13 @@ class TestClog(object):
         yl.append(y)
 
         # clog(x + i inf returns +inf + i pi /2, for finite x.
-        x = np.array([complex(1, np.inf)], dtype=np.complex)
-        y = np.complex(np.inf, 0.5 * np.pi)
+        x = np.array([complex(1, np.inf)], dtype=complex)
+        y = complex(np.inf, 0.5 * np.pi)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
-        x = np.array([complex(-1, np.inf)], dtype=np.complex)
+        x = np.array([complex(-1, np.inf)], dtype=complex)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
@@ -186,8 +186,8 @@ class TestClog(object):
         # clog(x + iNaN) returns NaN + iNaN and optionally raises the
         # 'invalid' floating- point exception, for finite x.
         with np.errstate(invalid='raise'):
-            x = np.array([complex(1., np.nan)], dtype=np.complex)
-            y = np.complex(np.nan, np.nan)
+            x = np.array([complex(1., np.nan)], dtype=complex)
+            y = complex(np.nan, np.nan)
             #assert_raises(FloatingPointError, np.log, x)
         with np.errstate(invalid='ignore'):
             assert_almost_equal(np.log(x), y)
@@ -196,7 +196,7 @@ class TestClog(object):
         yl.append(y)
 
         with np.errstate(invalid='raise'):
-            x = np.array([np.inf + 1j * np.nan], dtype=np.complex)
+            x = np.array([np.inf + 1j * np.nan], dtype=complex)
             #assert_raises(FloatingPointError, np.log, x)
         with np.errstate(invalid='ignore'):
             assert_almost_equal(np.log(x), y)
@@ -205,70 +205,70 @@ class TestClog(object):
         yl.append(y)
 
         # clog(- inf + iy) returns +inf + ipi , for finite positive-signed y.
-        x = np.array([-np.inf + 1j], dtype=np.complex)
-        y = np.complex(np.inf, np.pi)
+        x = np.array([-np.inf + 1j], dtype=complex)
+        y = complex(np.inf, np.pi)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(+ inf + iy) returns +inf + i0, for finite positive-signed y.
-        x = np.array([np.inf + 1j], dtype=np.complex)
-        y = np.complex(np.inf, 0)
+        x = np.array([np.inf + 1j], dtype=complex)
+        y = complex(np.inf, 0)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(- inf + i inf) returns +inf + i3pi /4.
-        x = np.array([complex(-np.inf, np.inf)], dtype=np.complex)
-        y = np.complex(np.inf, 0.75 * np.pi)
+        x = np.array([complex(-np.inf, np.inf)], dtype=complex)
+        y = complex(np.inf, 0.75 * np.pi)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(+ inf + i inf) returns +inf + ipi /4.
-        x = np.array([complex(np.inf, np.inf)], dtype=np.complex)
-        y = np.complex(np.inf, 0.25 * np.pi)
+        x = np.array([complex(np.inf, np.inf)], dtype=complex)
+        y = complex(np.inf, 0.25 * np.pi)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(+/- inf + iNaN) returns +inf + iNaN.
-        x = np.array([complex(np.inf, np.nan)], dtype=np.complex)
-        y = np.complex(np.inf, np.nan)
+        x = np.array([complex(np.inf, np.nan)], dtype=complex)
+        y = complex(np.inf, np.nan)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
-        x = np.array([complex(-np.inf, np.nan)], dtype=np.complex)
+        x = np.array([complex(-np.inf, np.nan)], dtype=complex)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(NaN + iy) returns NaN + iNaN and optionally raises the
         # 'invalid' floating-point exception, for finite y.
-        x = np.array([complex(np.nan, 1)], dtype=np.complex)
-        y = np.complex(np.nan, np.nan)
+        x = np.array([complex(np.nan, 1)], dtype=complex)
+        y = complex(np.nan, np.nan)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(NaN + i inf) returns +inf + iNaN.
-        x = np.array([complex(np.nan, np.inf)], dtype=np.complex)
-        y = np.complex(np.inf, np.nan)
+        x = np.array([complex(np.nan, np.inf)], dtype=complex)
+        y = complex(np.inf, np.nan)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(NaN + iNaN) returns NaN + iNaN.
-        x = np.array([complex(np.nan, np.nan)], dtype=np.complex)
-        y = np.complex(np.nan, np.nan)
+        x = np.array([complex(np.nan, np.nan)], dtype=complex)
+        y = complex(np.nan, np.nan)
         assert_almost_equal(np.log(x), y)
         xl.append(x)
         yl.append(y)
 
         # clog(conj(z)) = conj(clog(z)).
-        xa = np.array(xl, dtype=np.complex)
-        ya = np.array(yl, dtype=np.complex)
+        xa = np.array(xl, dtype=complex)
+        ya = np.array(yl, dtype=complex)
         with np.errstate(divide='ignore'):
             for i in range(len(xa)):
                 assert_almost_equal(np.log(xa[i].conj()), ya[i].conj())
@@ -286,7 +286,7 @@ class TestCsqrt(object):
         yield check_complex_value, np.sqrt, -1, 0, 0, 1
 
     def test_simple_conjugate(self):
-        ref = np.conj(np.sqrt(np.complex(1, 1)))
+        ref = np.conj(np.sqrt(complex(1, 1)))
 
         def f(z):
             return np.sqrt(np.conj(z))
@@ -330,7 +330,7 @@ class TestCsqrt(object):
         # csqrt(-inf + nani) is nan +- infi (both +i infi are valid)
         def _check_ninf_nan(dummy):
             msgform = "csqrt(-inf, nan) is (%f, %f), expected (nan, +-inf)"
-            z = np.sqrt(np.array(np.complex(-np.inf, np.nan)))
+            z = np.sqrt(np.array(complex(-np.inf, np.nan)))
             #Fixme: ugly workaround for isinf bug.
             with np.errstate(invalid='ignore'):
                 if not (np.isnan(z.real) and np.isinf(z.imag)):
@@ -406,16 +406,16 @@ class TestCabs(object):
 
     def test_fabs(self):
         # Test that np.abs(x +- 0j) == np.abs(x) (as mandated by C99 for cabs)
-        x = np.array([1+0j], dtype=np.complex)
+        x = np.array([1+0j], dtype=complex)
         assert_array_equal(np.abs(x), np.real(x))
 
-        x = np.array([complex(1, np.NZERO)], dtype=np.complex)
+        x = np.array([complex(1, np.NZERO)], dtype=complex)
         assert_array_equal(np.abs(x), np.real(x))
 
-        x = np.array([complex(np.inf, np.NZERO)], dtype=np.complex)
+        x = np.array([complex(np.inf, np.NZERO)], dtype=complex)
         assert_array_equal(np.abs(x), np.real(x))
 
-        x = np.array([complex(np.nan, np.NZERO)], dtype=np.complex)
+        x = np.array([complex(np.nan, np.NZERO)], dtype=complex)
         assert_array_equal(np.abs(x), np.real(x))
 
     def test_cabs_inf_nan(self):
@@ -445,9 +445,9 @@ class TestCabs(object):
             return np.abs(np.conj(a))
 
         def g(a, b):
-            return np.abs(np.complex(a, b))
+            return np.abs(complex(a, b))
 
-        xa = np.array(x, dtype=np.complex)
+        xa = np.array(x, dtype=complex)
         for i in range(len(xa)):
             ref = g(x[i], y[i])
             yield check_real_value, f, x[i], y[i], ref
@@ -527,7 +527,7 @@ def check_real_value(f, x1, y1, x, exact=True):
 
 def check_complex_value(f, x1, y1, x2, y2, exact=True):
     z1 = np.array([complex(x1, y1)])
-    z2 = np.complex(x2, y2)
+    z2 = complex(x2, y2)
     with np.errstate(invalid='ignore'):
         if exact:
             assert_equal(f(z1), z2)

--- a/numpy/doc/creation.py
+++ b/numpy/doc/creation.py
@@ -58,7 +58,7 @@ examples will be given here: ::
 
  >>> np.arange(10)
  array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
- >>> np.arange(2, 10, dtype=np.float)
+ >>> np.arange(2, 10, dtype=float)
  array([ 2., 3., 4., 5., 6., 7., 8., 9.])
  >>> np.arange(2, 3, 0.1)
  array([ 2. , 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9])

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -451,11 +451,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     # This code is significantly faster when the condition is satisfied.
     if len(ar2) < 10 * len(ar1) ** 0.145:
         if invert:
-            mask = np.ones(len(ar1), dtype=np.bool)
+            mask = np.ones(len(ar1), dtype=bool)
             for a in ar2:
                 mask &= (ar1 != a)
         else:
-            mask = np.zeros(len(ar1), dtype=np.bool)
+            mask = np.zeros(len(ar1), dtype=bool)
             for a in ar2:
                 mask |= (ar1 == a)
         return mask

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -717,7 +717,7 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         # At this point, if the weights are not integer, floating point, or
         # complex, we have to use the slow algorithm.
         if weights is not None and not (np.can_cast(weights.dtype, np.double) or
-                                        np.can_cast(weights.dtype, np.complex)):
+                                        np.can_cast(weights.dtype, complex)):
             bins = linspace(mn, mx, bins + 1, endpoint=True)
 
     if not iterable(bins):
@@ -1541,7 +1541,7 @@ def gradient(f, *varargs, **kwargs):
 
     Examples
     --------
-    >>> f = np.array([1, 2, 4, 7, 11, 16], dtype=np.float)
+    >>> f = np.array([1, 2, 4, 7, 11, 16], dtype=float)
     >>> np.gradient(f)
     array([ 1. ,  1.5,  2.5,  3.5,  4.5,  5. ])
     >>> np.gradient(f, 2)
@@ -1557,7 +1557,7 @@ def gradient(f, *varargs, **kwargs):
 
     Or a non uniform one:
 
-    >>> x = np.array([0., 1., 1.5, 3.5, 4., 6.], dtype=np.float)
+    >>> x = np.array([0., 1., 1.5, 3.5, 4., 6.], dtype=float)
     >>> np.gradient(f, x)
     array([ 1. ,  3. ,  3.5,  6.7,  6.9,  2.5])
 
@@ -1565,7 +1565,7 @@ def gradient(f, *varargs, **kwargs):
     axis. In this example the first array stands for the gradient in
     rows and the second one in columns direction:
 
-    >>> np.gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float))
+    >>> np.gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=float))
     [array([[ 2.,  2., -1.],
             [ 2.,  2., -1.]]), array([[ 1. ,  2.5,  4. ],
             [ 1. ,  1. ,  1. ]])]
@@ -1575,7 +1575,7 @@ def gradient(f, *varargs, **kwargs):
 
     >>> dx = 2.
     >>> y = [1., 1.5, 3.5]
-    >>> np.gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float), dx, y)
+    >>> np.gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=float), dx, y)
     [array([[ 1. ,  1. , -0.5],
             [ 1. ,  1. , -0.5]]), array([[ 2. ,  2. ,  2. ],
             [ 2. ,  1.7,  0.5]])]
@@ -1592,7 +1592,7 @@ def gradient(f, *varargs, **kwargs):
     The `axis` keyword can be used to specify a subset of axes of which the
     gradient is calculated
 
-    >>> np.gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float), axis=0)
+    >>> np.gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=float), axis=0)
     array([[ 2.,  2., -1.],
            [ 2.,  2., -1.]])
 
@@ -2600,7 +2600,7 @@ class vectorize(object):
     >>> out = vfunc([1, 2, 3, 4], 2)
     >>> type(out[0])
     <type 'numpy.int32'>
-    >>> vfunc = np.vectorize(myfunc, otypes=[np.float])
+    >>> vfunc = np.vectorize(myfunc, otypes=[float])
     >>> out = vfunc([1, 2, 3, 4], 2)
     >>> type(out[0])
     <type 'numpy.float64'>
@@ -3029,7 +3029,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     # Get the product of frequencies and weights
     w = None
     if fweights is not None:
-        fweights = np.asarray(fweights, dtype=np.float)
+        fweights = np.asarray(fweights, dtype=float)
         if not np.all(fweights == np.around(fweights)):
             raise TypeError(
                 "fweights must be integer")
@@ -3044,7 +3044,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
                 "fweights cannot be negative")
         w = fweights
     if aweights is not None:
-        aweights = np.asarray(aweights, dtype=np.float)
+        aweights = np.asarray(aweights, dtype=float)
         if aweights.ndim > 1:
             raise RuntimeError(
                 "cannot handle multidimensional aweights")

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -842,7 +842,7 @@ def diag_indices(n, ndim=2):
 
     And use it to set the diagonal of an array of zeros to 1:
 
-    >>> a = np.zeros((2, 2, 2), dtype=np.int)
+    >>> a = np.zeros((2, 2, 2), dtype=int)
     >>> a[d3] = 1
     >>> a
     array([[[1, 0],

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -737,7 +737,7 @@ def _getconv(dtype):
         return np.longdouble
     elif issubclass(typ, np.floating):
         return floatconv
-    elif issubclass(typ, np.complex):
+    elif issubclass(typ, complex):
         return lambda x: complex(asstr(x))
     elif issubclass(typ, np.bytes_):
         return asbytes
@@ -1902,16 +1902,16 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             # If the dtype is uniform, don't define names, else use ''
             base = set([c.type for c in converters if c._checked])
             if len(base) == 1:
-                (ddtype, mdtype) = (list(base)[0], np.bool)
+                (ddtype, mdtype) = (list(base)[0], bool)
             else:
                 ddtype = [(defaultfmt % i, dt)
                           for (i, dt) in enumerate(column_types)]
                 if usemask:
-                    mdtype = [(defaultfmt % i, np.bool)
+                    mdtype = [(defaultfmt % i, bool)
                               for (i, dt) in enumerate(column_types)]
         else:
             ddtype = list(zip(names, column_types))
-            mdtype = list(zip(names, [np.bool] * len(column_types)))
+            mdtype = list(zip(names, [bool] * len(column_types)))
         output = np.array(data, dtype=ddtype)
         if usemask:
             outputmask = np.array(masks, dtype=mdtype)
@@ -1937,7 +1937,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             # Now, process the rowmasks the same way
             if usemask:
                 rowmasks = np.array(
-                    masks, dtype=np.dtype([('', np.bool) for t in dtype_flat]))
+                    masks, dtype=np.dtype([('', bool) for t in dtype_flat]))
                 # Construct the new dtype
                 mdtype = make_mask_descr(dtype)
                 outputmask = rowmasks.view(mdtype)
@@ -1968,9 +1968,9 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             output = np.array(data, dtype)
             if usemask:
                 if dtype.names:
-                    mdtype = [(_, np.bool) for _ in dtype.names]
+                    mdtype = [(_, bool) for _ in dtype.names]
                 else:
-                    mdtype = np.bool
+                    mdtype = bool
                 outputmask = np.array(masks, dtype=mdtype)
     # Try to take care of the missing data we missed
     names = output.dtype.names

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -257,7 +257,7 @@ class TestMiscFunctions(object):
 
     def test_has_nested_dtype(self):
         "Test has_nested_dtype"
-        ndtype = np.dtype(np.float)
+        ndtype = np.dtype(float)
         assert_equal(has_nested_fields(ndtype), False)
         ndtype = np.dtype([('A', '|S3'), ('B', float)])
         assert_equal(has_nested_fields(ndtype), False)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2663,28 +2663,28 @@ class TestInterp(object):
 
             incres = interp(incpts, xp, yp)
             decres = interp(decpts, xp, yp)
-            inctgt = np.array([1, 1, 1, 1], dtype=np.float)
+            inctgt = np.array([1, 1, 1, 1], dtype=float)
             dectgt = inctgt[::-1]
             assert_equal(incres, inctgt)
             assert_equal(decres, dectgt)
 
             incres = interp(incpts, xp, yp, left=0)
             decres = interp(decpts, xp, yp, left=0)
-            inctgt = np.array([0, 1, 1, 1], dtype=np.float)
+            inctgt = np.array([0, 1, 1, 1], dtype=float)
             dectgt = inctgt[::-1]
             assert_equal(incres, inctgt)
             assert_equal(decres, dectgt)
 
             incres = interp(incpts, xp, yp, right=2)
             decres = interp(decpts, xp, yp, right=2)
-            inctgt = np.array([1, 1, 1, 2], dtype=np.float)
+            inctgt = np.array([1, 1, 1, 2], dtype=float)
             dectgt = inctgt[::-1]
             assert_equal(incres, inctgt)
             assert_equal(decres, dectgt)
 
             incres = interp(incpts, xp, yp, left=0, right=2)
             decres = interp(decpts, xp, yp, left=0, right=2)
-            inctgt = np.array([0, 1, 1, 2], dtype=np.float)
+            inctgt = np.array([0, 1, 1, 2], dtype=float)
             dectgt = inctgt[::-1]
             assert_equal(incres, inctgt)
             assert_equal(decres, dectgt)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -373,7 +373,7 @@ class TestSaveTxt(object):
         # Test the functionality of the header and footer keyword argument.
 
         c = BytesIO()
-        a = np.array([(1, 2), (3, 4)], dtype=np.int)
+        a = np.array([(1, 2), (3, 4)], dtype=int)
         test_header_footer = 'Test header / footer'
         # Test the header keyword argument
         np.savetxt(c, a, fmt='%1d', header=test_header_footer)
@@ -485,7 +485,7 @@ class TestLoadTxt(object):
         c.write('1 2\n3 4')
 
         c.seek(0)
-        x = np.loadtxt(c, dtype=np.int)
+        x = np.loadtxt(c, dtype=int)
         a = np.array([[1, 2], [3, 4]], int)
         assert_array_equal(x, a)
 
@@ -721,7 +721,7 @@ class TestLoadTxt(object):
         # Test using an explicit dtype with an object
         data = """ 1; 2001-01-01
                    2; 2002-01-31 """
-        ndtype = [('idx', int), ('code', np.object)]
+        ndtype = [('idx', int), ('code', object)]
         func = lambda s: strptime(s.strip(), "%Y-%m-%d")
         converters = {1: func}
         test = np.loadtxt(TextIO(data), delimiter=";", dtype=ndtype,
@@ -751,11 +751,11 @@ class TestLoadTxt(object):
         # IEEE doubles and floats only, otherwise the float32
         # conversion may fail.
         tgt = np.logspace(-10, 10, 5).astype(np.float32)
-        tgt = np.hstack((tgt, -tgt)).astype(np.float)
+        tgt = np.hstack((tgt, -tgt)).astype(float)
         inp = '\n'.join(map(float.hex, tgt))
         c = TextIO()
         c.write(inp)
-        for dt in [np.float, np.float32]:
+        for dt in [float, np.float32]:
             c.seek(0)
             res = np.loadtxt(c, dtype=dt)
             assert_equal(res, tgt, err_msg="%s" % dt)
@@ -765,7 +765,7 @@ class TestLoadTxt(object):
         c = TextIO()
         c.write("%s %s" % tgt)
         c.seek(0)
-        res = np.loadtxt(c, dtype=np.complex)
+        res = np.loadtxt(c, dtype=complex)
         assert_equal(res, tgt)
 
     def test_universal_newline(self):
@@ -1190,7 +1190,7 @@ M   33  21.99
         # Test using an explicit dtype with an object
         data = """ 1; 2001-01-01
                    2; 2002-01-31 """
-        ndtype = [('idx', int), ('code', np.object)]
+        ndtype = [('idx', int), ('code', object)]
         func = lambda s: strptime(s.strip(), "%Y-%m-%d")
         converters = {1: func}
         test = np.genfromtxt(TextIO(data), delimiter=";", dtype=ndtype,
@@ -1200,7 +1200,7 @@ M   33  21.99
             dtype=ndtype)
         assert_equal(test, control)
 
-        ndtype = [('nest', [('idx', int), ('code', np.object)])]
+        ndtype = [('nest', [('idx', int), ('code', object)])]
         try:
             test = np.genfromtxt(TextIO(data), delimiter=";",
                                  dtype=ndtype, converters=converters)
@@ -1337,7 +1337,7 @@ M   33  21.99
         test = np.mafromtxt(data, dtype=None, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
-                           dtype=[('A', np.int), ('B', np.int)])
+                           dtype=[('A', int), ('B', int)])
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
         #
@@ -1345,7 +1345,7 @@ M   33  21.99
         test = np.mafromtxt(data, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
-                           dtype=[('A', np.float), ('B', np.float)])
+                           dtype=[('A', float), ('B', float)])
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
 
@@ -1414,7 +1414,7 @@ M   33  21.99
                             missing_values='-999.0', names=True,)
         control = ma.array([(0, 1.5), (2, -1.)],
                            mask=[(False, False), (False, True)],
-                           dtype=[('A', np.int), ('B', np.float)])
+                           dtype=[('A', int), ('B', float)])
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
 
@@ -1682,7 +1682,7 @@ M   33  21.99
         kwargs = dict(delimiter=",", missing_values="N/A", names=True)
         test = np.recfromtxt(data, **kwargs)
         control = np.array([(0, 1), (2, 3)],
-                           dtype=[('A', np.int), ('B', np.int)])
+                           dtype=[('A', int), ('B', int)])
         assert_(isinstance(test, np.recarray))
         assert_equal(test, control)
         #
@@ -1690,7 +1690,7 @@ M   33  21.99
         test = np.recfromtxt(data, dtype=None, usemask=True, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
-                           dtype=[('A', np.int), ('B', np.int)])
+                           dtype=[('A', int), ('B', int)])
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
         assert_equal(test.A, [0, 2])
@@ -1701,7 +1701,7 @@ M   33  21.99
         kwargs = dict(missing_values="N/A", names=True, case_sensitive=True)
         test = np.recfromcsv(data, dtype=None, **kwargs)
         control = np.array([(0, 1), (2, 3)],
-                           dtype=[('A', np.int), ('B', np.int)])
+                           dtype=[('A', int), ('B', int)])
         assert_(isinstance(test, np.recarray))
         assert_equal(test, control)
         #
@@ -1709,7 +1709,7 @@ M   33  21.99
         test = np.recfromcsv(data, dtype=None, usemask=True, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
-                           dtype=[('A', np.int), ('B', np.int)])
+                           dtype=[('A', int), ('B', int)])
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
         assert_equal(test.A, [0, 2])
@@ -1717,12 +1717,12 @@ M   33  21.99
         data = TextIO('A,B\n0,1\n2,3')
         test = np.recfromcsv(data, missing_values='N/A',)
         control = np.array([(0, 1), (2, 3)],
-                           dtype=[('a', np.int), ('b', np.int)])
+                           dtype=[('a', int), ('b', int)])
         assert_(isinstance(test, np.recarray))
         assert_equal(test, control)
         #
         data = TextIO('A,B\n0,1\n2,3')
-        dtype = [('a', np.int), ('b', np.float)]
+        dtype = [('a', int), ('b', float)]
         test = np.recfromcsv(data, missing_values='N/A', dtype=dtype)
         control = np.array([(0, 1), (2, 3)],
                            dtype=dtype)
@@ -1827,7 +1827,7 @@ M   33  21.99
 
         assert_equal(test.dtype.names, ['f0', 'f1', 'f2'])
 
-        assert_(test.dtype['f0'] == np.float)
+        assert_(test.dtype['f0'] == float)
         assert_(test.dtype['f1'] == np.int64)
         assert_(test.dtype['f2'] == np.integer)
 
@@ -1919,7 +1919,7 @@ class TestPathUsage(object):
             kwargs = dict(delimiter=",", missing_values="N/A", names=True)
             test = np.recfromtxt(path, **kwargs)
             control = np.array([(0, 1), (2, 3)],
-                               dtype=[('A', np.int), ('B', np.int)])
+                               dtype=[('A', int), ('B', int)])
             assert_(isinstance(test, np.recarray))
             assert_equal(test, control)
 
@@ -1933,7 +1933,7 @@ class TestPathUsage(object):
             kwargs = dict(missing_values="N/A", names=True, case_sensitive=True)
             test = np.recfromcsv(path, dtype=None, **kwargs)
             control = np.array([(0, 1), (2, 3)],
-                               dtype=[('A', np.int), ('B', np.int)])
+                               dtype=[('A', int), ('B', int)])
             assert_(isinstance(test, np.recarray))
             assert_equal(test, control)
 

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -108,13 +108,13 @@ class TestRegression(object):
     def test_polydiv_type(self):
         # Make polydiv work for complex types
         msg = "Wrong type, should be complex"
-        x = np.ones(3, dtype=np.complex)
+        x = np.ones(3, dtype=complex)
         q, r = np.polydiv(x, x)
-        assert_(q.dtype == np.complex, msg)
+        assert_(q.dtype == complex, msg)
         msg = "Wrong type, should be float"
-        x = np.ones(3, dtype=np.int)
+        x = np.ones(3, dtype=int)
         q, r = np.polydiv(x, x)
-        assert_(q.dtype == np.float, msg)
+        assert_(q.dtype == float, msg)
 
     def test_histogramdd_too_many_bins(self):
         # Ticket 928.
@@ -123,11 +123,11 @@ class TestRegression(object):
     def test_polyint_type(self):
         # Ticket #944
         msg = "Wrong type, should be complex"
-        x = np.ones(3, dtype=np.complex)
-        assert_(np.polyint(x).dtype == np.complex, msg)
+        x = np.ones(3, dtype=complex)
+        assert_(np.polyint(x).dtype == complex, msg)
         msg = "Wrong type, should be float"
-        x = np.ones(3, dtype=np.int)
-        assert_(np.polyint(x).dtype == np.float, msg)
+        x = np.ones(3, dtype=int)
+        assert_(np.polyint(x).dtype == float, msg)
 
     def test_ndenumerate_crash(self):
         # Ticket 1140
@@ -234,7 +234,7 @@ class TestRegression(object):
 
     def test_nansum_with_boolean(self):
         # gh-2978
-        a = np.zeros(2, dtype=np.bool)
+        a = np.zeros(2, dtype=bool)
         try:
             np.nansum(a)
         except Exception:

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -374,7 +374,7 @@ class TestNanToNum(object):
         vals = nan_to_num(1)
         assert_all(vals == 1)
         vals = nan_to_num([1])
-        assert_array_equal(vals, np.array([1], np.int))
+        assert_array_equal(vals, np.array([1], int))
 
     def test_complex_good(self):
         vals = nan_to_num(1+1j)
@@ -420,7 +420,7 @@ class TestArrayConversion(object):
     def test_asfarray(self):
         a = asfarray(np.array([1, 2, 3]))
         assert_equal(a.__class__, np.ndarray)
-        assert_(np.issubdtype(a.dtype, np.float))
+        assert_(np.issubdtype(a.dtype, float))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -433,12 +433,12 @@ def real_if_close(a,tol=100):
     -----
     Machine epsilon varies from machine to machine and between data types
     but Python floats on most platforms have a machine epsilon equal to
-    2.2204460492503131e-16.  You can use 'np.finfo(np.float).eps' to print
+    2.2204460492503131e-16.  You can use 'np.finfo(float).eps' to print
     out the machine epsilon for floats.
 
     Examples
     --------
-    >>> np.finfo(np.float).eps
+    >>> np.finfo(float).eps
     2.2204460492503131e-16
 
     >>> np.real_if_close([2.1 + 4e-14j], tol=1000)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1645,7 +1645,7 @@ class TestMultiDot(object):
                                [0,  0,  0,  3,  3,  3],
                                [0,  0,  0,  0,  4,  5],
                                [0,  0,  0,  0,  0,  5],
-                               [0,  0,  0,  0,  0,  0]], dtype=np.int)
+                               [0,  0,  0,  0,  0,  0]], dtype=int)
         s_expected -= 1  # Cormen uses 1-based index, python does not.
 
         s, m = _multi_dot_matrix_chain_order(arrays, return_costs=True)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1286,7 +1286,7 @@ def _replace_dtype_fields_recursive(dtype, primitive_dtype):
             descr.append((name, _recurse(field[0], primitive_dtype)))
         new_dtype = np.dtype(descr)
 
-    # Is this some kind of composite a la (np.float,2)
+    # Is this some kind of composite a la (float,2)
     elif dtype.subdtype:
         descr = list(dtype.subdtype)
         descr[0] = _recurse(dtype.subdtype[0], primitive_dtype)
@@ -1338,7 +1338,7 @@ def make_mask_descr(ndtype):
     --------
     >>> import numpy.ma as ma
     >>> dtype = np.dtype({'names':['foo', 'bar'],
-                          'formats':[np.float32, np.int]})
+                          'formats':[np.float32, int]})
     >>> dtype
     dtype([('foo', '<f4'), ('bar', '<i4')])
     >>> ma.make_mask_descr(dtype)
@@ -1519,7 +1519,7 @@ def is_mask(m):
     Arrays with complex dtypes don't return True.
 
     >>> dtype = np.dtype({'names':['monty', 'pithon'],
-                          'formats':[np.bool, np.bool]})
+                          'formats':[bool, bool]})
     >>> dtype
     dtype([('monty', '|b1'), ('pithon', '|b1')])
     >>> m = np.array([(True, False), (False, True), (True, False)],
@@ -1598,7 +1598,7 @@ def make_mask(m, copy=False, shrink=True, dtype=MaskType):
     >>> arr
     [(1, 0), (0, 1), (1, 0), (1, 0)]
     >>> dtype = np.dtype({'names':['man', 'mouse'],
-                          'formats':[np.int, np.int]})
+                          'formats':[int, int]})
     >>> arr = np.array(arr, dtype=dtype)
     >>> arr
     array([(1, 0), (0, 1), (1, 0), (1, 0)],
@@ -1657,7 +1657,7 @@ def make_mask_none(newshape, dtype=None):
     Defining a more complex dtype.
 
     >>> dtype = np.dtype({'names':['foo', 'bar'],
-                          'formats':[np.float32, np.int]})
+                          'formats':[np.float32, int]})
     >>> dtype
     dtype([('foo', '<f4'), ('bar', '<i4')])
     >>> ma.make_mask_none((3,), dtype=dtype)
@@ -1755,7 +1755,7 @@ def flatten_mask(mask):
 
     Examples
     --------
-    >>> mask = np.array([0, 0, 1], dtype=np.bool)
+    >>> mask = np.array([0, 0, 1], dtype=bool)
     >>> flatten_mask(mask)
     array([False, False,  True], dtype=bool)
 
@@ -2323,7 +2323,7 @@ def masked_invalid(a, copy=True):
     Examples
     --------
     >>> import numpy.ma as ma
-    >>> a = np.arange(5, dtype=np.float)
+    >>> a = np.arange(5, dtype=float)
     >>> a[2] = np.NaN
     >>> a[3] = np.PINF
     >>> a
@@ -7227,7 +7227,7 @@ def mask_rowcols(a, axis=None):
     Examples
     --------
     >>> import numpy.ma as ma
-    >>> a = np.zeros((3, 3), dtype=np.int)
+    >>> a = np.zeros((3, 3), dtype=int)
     >>> a[1, 1] = 1
     >>> a
     array([[0, 0, 0],
@@ -7408,8 +7408,8 @@ def _convolve_or_correlate(f, a, v, mode, propagate_mask):
     if propagate_mask:
         # results which are contributed to by either item in any pair being invalid
         mask = (
-            f(getmaskarray(a), np.ones(np.shape(v), dtype=np.bool), mode=mode)
-          | f(np.ones(np.shape(a), dtype=np.bool), getmaskarray(v), mode=mode)
+            f(getmaskarray(a), np.ones(np.shape(v), dtype=bool), mode=mode)
+          | f(np.ones(np.shape(a), dtype=bool), getmaskarray(v), mode=mode)
         )
         data = f(getdata(a), getdata(v), mode=mode)
     else:

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -939,7 +939,7 @@ def mask_rows(a, axis=None):
     Examples
     --------
     >>> import numpy.ma as ma
-    >>> a = np.zeros((3, 3), dtype=np.int)
+    >>> a = np.zeros((3, 3), dtype=int)
     >>> a[1, 1] = 1
     >>> a
     array([[0, 0, 0],
@@ -984,7 +984,7 @@ def mask_cols(a, axis=None):
     Examples
     --------
     >>> import numpy.ma as ma
-    >>> a = np.zeros((3, 3), dtype=np.int)
+    >>> a = np.zeros((3, 3), dtype=int)
     >>> a[1, 1] = 1
     >>> a
     array([[0, 0, 0],

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -243,7 +243,7 @@ class MaskedRecords(MaskedArray, object):
             except IndexError:
                 # Couldn't find a mask: use the default (nomask)
                 pass
-            hasmasked = _mask.view((np.bool, (len(_mask.dtype) or 1))).any()
+            hasmasked = _mask.view((bool, (len(_mask.dtype) or 1))).any()
         if (obj.shape or hasmasked):
             obj = obj.view(MaskedArray)
             obj._baseclass = ndarray

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -718,14 +718,14 @@ class TestMaskedArray(object):
         ndtype = [('a', int), ('b', float)]
         a = np.array([(1, 1), (2, 2)], dtype=ndtype)
         test = flatten_structured_array(a)
-        control = np.array([[1., 1.], [2., 2.]], dtype=np.float)
+        control = np.array([[1., 1.], [2., 2.]], dtype=float)
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
         # On masked_array
         a = array([(1, 1), (2, 2)], mask=[(0, 1), (1, 0)], dtype=ndtype)
         test = flatten_structured_array(a)
         control = array([[1., 1.], [2., 2.]],
-                        mask=[[0, 1], [1, 0]], dtype=np.float)
+                        mask=[[0, 1], [1, 0]], dtype=float)
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
         assert_equal(test.mask, control.mask)
@@ -735,7 +735,7 @@ class TestMaskedArray(object):
                   mask=[(0, (1, 0)), (1, (0, 1))], dtype=ndtype)
         test = flatten_structured_array(a)
         control = array([[1., 1., 1.1], [2., 2., 2.2]],
-                        mask=[[0, 1, 0], [1, 0, 1]], dtype=np.float)
+                        mask=[[0, 1, 0], [1, 0, 1]], dtype=float)
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
         assert_equal(test.mask, control.mask)
@@ -743,7 +743,7 @@ class TestMaskedArray(object):
         ndtype = [('a', int), ('b', float)]
         a = np.array([[(1, 1), ], [(2, 2), ]], dtype=ndtype)
         test = flatten_structured_array(a)
-        control = np.array([[[1., 1.], ], [[2., 2.], ]], dtype=np.float)
+        control = np.array([[[1., 1.], ], [[2., 2.], ]], dtype=float)
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
 
@@ -3443,8 +3443,8 @@ class TestMaskedArrayMathMethods(object):
         (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
         (n, m) = X.shape
         assert_equal(mx.ptp(), mx.compressed().ptp())
-        rows = np.zeros(n, np.float)
-        cols = np.zeros(m, np.float)
+        rows = np.zeros(n, float)
+        cols = np.zeros(m, float)
         for k in range(m):
             cols[k] = mX[:, k].compressed().ptp()
         for k in range(n):
@@ -3460,21 +3460,21 @@ class TestMaskedArrayMathMethods(object):
 
     def test_sum_object(self):
         # Test sum on object dtype
-        a = masked_array([1, 2, 3], mask=[1, 0, 0], dtype=np.object)
+        a = masked_array([1, 2, 3], mask=[1, 0, 0], dtype=object)
         assert_equal(a.sum(), 5)
         a = masked_array([[1, 2, 3], [4, 5, 6]], dtype=object)
         assert_equal(a.sum(axis=0), [5, 7, 9])
 
     def test_prod_object(self):
         # Test prod on object dtype
-        a = masked_array([1, 2, 3], mask=[1, 0, 0], dtype=np.object)
+        a = masked_array([1, 2, 3], mask=[1, 0, 0], dtype=object)
         assert_equal(a.prod(), 2 * 3)
         a = masked_array([[1, 2, 3], [4, 5, 6]], dtype=object)
         assert_equal(a.prod(axis=0), [4, 10, 18])
 
     def test_meananom_object(self):
         # Test mean/anom on object dtype
-        a = masked_array([1, 2, 3], dtype=np.object)
+        a = masked_array([1, 2, 3], dtype=object)
         assert_equal(a.mean(), 2)
         assert_equal(a.anom(), [-1, 0, 1])
 
@@ -4112,34 +4112,34 @@ class TestMaskedArrayFunctions(object):
 
     def test_make_mask_descr(self):
         # Flexible
-        ntype = [('a', np.float), ('b', np.float)]
+        ntype = [('a', float), ('b', float)]
         test = make_mask_descr(ntype)
-        assert_equal(test, [('a', np.bool), ('b', np.bool)])
+        assert_equal(test, [('a', bool), ('b', bool)])
         assert_(test is make_mask_descr(test))
 
         # Standard w/ shape
-        ntype = (np.float, 2)
+        ntype = (float, 2)
         test = make_mask_descr(ntype)
-        assert_equal(test, (np.bool, 2))
+        assert_equal(test, (bool, 2))
         assert_(test is make_mask_descr(test))
 
         # Standard standard
-        ntype = np.float
+        ntype = float
         test = make_mask_descr(ntype)
-        assert_equal(test, np.dtype(np.bool))
+        assert_equal(test, np.dtype(bool))
         assert_(test is make_mask_descr(test))
 
         # Nested
-        ntype = [('a', np.float), ('b', [('ba', np.float), ('bb', np.float)])]
+        ntype = [('a', float), ('b', [('ba', float), ('bb', float)])]
         test = make_mask_descr(ntype)
         control = np.dtype([('a', 'b1'), ('b', [('ba', 'b1'), ('bb', 'b1')])])
         assert_equal(test, control)
         assert_(test is make_mask_descr(test))
 
         # Named+ shape
-        ntype = [('a', (np.float, 2))]
+        ntype = [('a', (float, 2))]
         test = make_mask_descr(ntype)
-        assert_equal(test, np.dtype([('a', (np.bool, 2))]))
+        assert_equal(test, np.dtype([('a', (bool, 2))]))
         assert_(test is make_mask_descr(test))
 
         # 2 names
@@ -4164,25 +4164,25 @@ class TestMaskedArrayFunctions(object):
         assert_equal(test.dtype, MaskType)
         assert_equal(test, [0, 1])
         # w/ a ndarray as an input
-        mask = np.array([0, 1], dtype=np.bool)
+        mask = np.array([0, 1], dtype=bool)
         test = make_mask(mask)
         assert_equal(test.dtype, MaskType)
         assert_equal(test, [0, 1])
         # w/ a flexible-type ndarray as an input - use default
-        mdtype = [('a', np.bool), ('b', np.bool)]
+        mdtype = [('a', bool), ('b', bool)]
         mask = np.array([(0, 0), (0, 1)], dtype=mdtype)
         test = make_mask(mask)
         assert_equal(test.dtype, MaskType)
         assert_equal(test, [1, 1])
         # w/ a flexible-type ndarray as an input - use input dtype
-        mdtype = [('a', np.bool), ('b', np.bool)]
+        mdtype = [('a', bool), ('b', bool)]
         mask = np.array([(0, 0), (0, 1)], dtype=mdtype)
         test = make_mask(mask, dtype=mask.dtype)
         assert_equal(test.dtype, mdtype)
         assert_equal(test, mask)
         # w/ a flexible-type ndarray as an input - use input dtype
-        mdtype = [('a', np.float), ('b', np.float)]
-        bdtype = [('a', np.bool), ('b', np.bool)]
+        mdtype = [('a', float), ('b', float)]
+        bdtype = [('a', bool), ('b', bool)]
         mask = np.array([(0, 0), (0, 1)], dtype=mdtype)
         test = make_mask(mask, dtype=mask.dtype)
         assert_equal(test.dtype, bdtype)
@@ -4198,7 +4198,7 @@ class TestMaskedArrayFunctions(object):
         assert_equal(test2, test)
         # test that nomask is returned when m is nomask.
         bools = [True, False]
-        dtypes = [MaskType, np.float]
+        dtypes = [MaskType, float]
         msgformat = 'copy=%s, shrink=%s, dtype=%s'
         for cpy, shr, dt in itertools.product(bools, bools, dtypes):
             res = make_mask(nomask, copy=cpy, shrink=shr, dtype=dt)
@@ -4206,7 +4206,7 @@ class TestMaskedArrayFunctions(object):
 
     def test_mask_or(self):
         # Initialize
-        mtype = [('a', np.bool), ('b', np.bool)]
+        mtype = [('a', bool), ('b', bool)]
         mask = np.array([(0, 0), (0, 1), (1, 0), (0, 0)], dtype=mtype)
         # Test using nomask as input
         test = mask_or(mask, nomask)
@@ -4222,14 +4222,14 @@ class TestMaskedArrayFunctions(object):
         control = np.array([(0, 1), (0, 1), (1, 1), (0, 1)], dtype=mtype)
         assert_equal(test, control)
         # Using another array w / a different dtype
-        othertype = [('A', np.bool), ('B', np.bool)]
+        othertype = [('A', bool), ('B', bool)]
         other = np.array([(0, 1), (0, 1), (0, 1), (0, 1)], dtype=othertype)
         try:
             test = mask_or(mask, other)
         except ValueError:
             pass
         # Using nested arrays
-        dtype = [('a', np.bool), ('b', [('ba', np.bool), ('bb', np.bool)])]
+        dtype = [('a', bool), ('b', [('ba', bool), ('bb', bool)])]
         amask = np.array([(0, (1, 0)), (0, (1, 0))], dtype=dtype)
         bmask = np.array([(1, (0, 1)), (0, (0, 0))], dtype=dtype)
         cntrl = np.array([(1, (1, 1)), (0, (1, 0))], dtype=dtype)
@@ -4238,7 +4238,7 @@ class TestMaskedArrayFunctions(object):
     def test_flatten_mask(self):
         # Tests flatten mask
         # Standard dtype
-        mask = np.array([0, 0, 1], dtype=np.bool)
+        mask = np.array([0, 0, 1], dtype=bool)
         assert_equal(flatten_mask(mask), mask)
         # Flexible dtype
         mask = np.array([(0, 0), (0, 1)], dtype=[('a', bool), ('b', bool)])

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -660,7 +660,7 @@ class TestApplyOverAxes(object):
         test = apply_over_axes(np.sum, a, [0, 2])
         ctrl = np.array([[[60], [92], [124]]])
         assert_equal(test, ctrl)
-        a[(a % 2).astype(np.bool)] = masked
+        a[(a % 2).astype(bool)] = masked
         test = apply_over_axes(np.sum, a, [0, 2])
         ctrl = np.array([[[28], [44], [60]]])
         assert_equal(test, ctrl)
@@ -885,7 +885,7 @@ class TestMedian(object):
     def test_nan(self):
         with suppress_warnings() as w:
             w.record(RuntimeWarning)
-            for mask in (False, np.zeros(6, dtype=np.bool)):
+            for mask in (False, np.zeros(6, dtype=bool)):
                 dm = np.ma.array([[1, np.nan, 3], [1, 2, 3]])
                 dm.mask = mask
 

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -353,7 +353,7 @@ class TestView(object):
 
     def setup(self):
         (a, b) = (np.arange(10), np.random.rand(10))
-        ndtype = [('a', np.float), ('b', np.float)]
+        ndtype = [('a', float), ('b', float)]
         arr = np.array(list(zip(a, b)), dtype=ndtype)
 
         mrec = fromarrays([a, b], dtype=ndtype, fill_value=(-9., -99.))
@@ -369,15 +369,15 @@ class TestView(object):
 
     def test_view_simple_dtype(self):
         (mrec, a, b, arr) = self.data
-        ntype = (np.float, 2)
+        ntype = (float, 2)
         test = mrec.view(ntype)
         assert_(isinstance(test, ma.MaskedArray))
-        assert_equal(test, np.array(list(zip(a, b)), dtype=np.float))
+        assert_equal(test, np.array(list(zip(a, b)), dtype=float))
         assert_(test[3, 1] is ma.masked)
 
     def test_view_flexible_type(self):
         (mrec, a, b, arr) = self.data
-        alttype = [('A', np.float), ('B', np.float)]
+        alttype = [('A', float), ('B', float)]
         test = mrec.view(alttype)
         assert_(isinstance(test, MaskedRecords))
         assert_equal_records(test, arr.view(alttype))
@@ -491,7 +491,7 @@ def test_record_array_with_object_field():
     y = ma.masked_array(
         [(1, '2'), (3, '4')],
         mask=[(0, 0), (0, 1)],
-        dtype=[('a', int), ('b', np.object)])
+        dtype=[('a', int), ('b', object)])
     # getting an item used to fail
     y[1]
 

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -83,7 +83,7 @@ class TestMultinomial(object):
                      (2, 2, 2))
 
         assert_raises(TypeError, np.random.multinomial, 1, p,
-                      np.float(1))
+                      float(1))
 
 
 class TestSetState(object):
@@ -143,7 +143,7 @@ class TestRandint(object):
              np.int32, np.uint32, np.int64, np.uint64]
 
     def test_unsupported_type(self):
-        assert_raises(TypeError, self.rfunc, 1, dtype=np.float)
+        assert_raises(TypeError, self.rfunc, 1, dtype=float)
 
     def test_bounds_checking(self):
         for dt in self.itype:
@@ -200,7 +200,7 @@ class TestRandint(object):
     def test_repeatability(self):
         import hashlib
         # We use a md5 hash of generated sequences of 1000 samples
-        # in the range [0, 6) for all but np.bool, where the range
+        # in the range [0, 6) for all but bool, where the range
         # is [0, 2). Hashes are for little endian numbers.
         tgt = {'bool': '7dd3170d7aa461d201a65f8bcf3944b0',
                'int16': '1b7741b80964bb190c50d541dca1cac1',
@@ -226,9 +226,9 @@ class TestRandint(object):
 
         # bools do not depend on endianess
         np.random.seed(1234)
-        val = self.rfunc(0, 2, size=1000, dtype=np.bool).view(np.int8)
+        val = self.rfunc(0, 2, size=1000, dtype=bool).view(np.int8)
         res = hashlib.md5(val).hexdigest()
-        assert_(tgt[np.dtype(np.bool).name] == res)
+        assert_(tgt[np.dtype(bool).name] == res)
 
     def test_int64_uint64_corner_case(self):
         # When stored in Numpy arrays, `lbnd` is casted
@@ -262,9 +262,9 @@ class TestRandint(object):
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
             assert_equal(sample.dtype, np.dtype(dt))
 
-        for dt in (np.bool, np.int, np.long):
-            lbnd = 0 if dt is np.bool else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
+        for dt in (bool, int, np.long):
+            lbnd = 0 if dt is bool else np.iinfo(dt).min
+            ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
 
             # gh-7284: Ensure that we get Python data types
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
@@ -523,7 +523,7 @@ class TestRandomDist(object):
         assert_equal(np.random.dirichlet(p, (2, 2)).shape, (2, 2, 2))
         assert_equal(np.random.dirichlet(p, np.array((2, 2))).shape, (2, 2, 2))
 
-        assert_raises(TypeError, np.random.dirichlet, p, np.float(1))
+        assert_raises(TypeError, np.random.dirichlet, p, float(1))
 
     def test_exponential(self):
         np.random.seed(self.seed)
@@ -1583,7 +1583,7 @@ class TestSingleEltArrayInput(object):
 
 # TODO: Uncomment once randint can broadcast arguments
 #    def test_randint(self):
-#        itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
+#        itype = [bool, np.int8, np.uint8, np.int16, np.uint16,
 #                 np.int32, np.uint32, np.int64, np.uint64]
 #        func = np.random.randint
 #        high = np.array([1])

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -61,7 +61,7 @@ class _GenericTest(object):
 
     def test_objarray(self):
         """Test object arrays."""
-        a = np.array([1, 1], dtype=np.object)
+        a = np.array([1, 1], dtype=object)
         self._test_equal(a, 1)
 
     def test_array_likes(self):
@@ -134,14 +134,14 @@ class TestArrayEqual(_GenericTest, unittest.TestCase):
 
     def test_recarrays(self):
         """Test record arrays."""
-        a = np.empty(2, [('floupi', np.float), ('floupa', np.float)])
+        a = np.empty(2, [('floupi', float), ('floupa', float)])
         a['floupi'] = [1, 2]
         a['floupa'] = [1, 2]
         b = a.copy()
 
         self._test_equal(a, b)
 
-        c = np.empty(2, [('floupipi', np.float), ('floupa', np.float)])
+        c = np.empty(2, [('floupipi', float), ('floupa', float)])
         c['floupipi'] = a['floupi'].copy()
         c['floupa'] = a['floupa'].copy()
 

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -24,7 +24,7 @@ def test_zeros():
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
 
 def test_identity():
-    x = numpy.matlib.identity(2, dtype=np.int)
+    x = numpy.matlib.identity(2, dtype=int)
     assert_array_equal(x, np.matrix([[1, 0], [0, 1]]))
 
 def test_eye():


### PR DESCRIPTION
Rebase of #9508.

This is the case for x in {int, bool, str, float, complex, object}. Using the np.{x} version is deceptive as it suggests that there is a difference. This change doesn't affect any external behavour. The `long` type is missing in python 3, so np.long is still useful. Likewise with np.unicode.

It may be difficult to deprecate these (#6103), but there's no reason we should be using them within our own code, or within our documentation.

Simple find and replace of np\.(int|complex|object|str|bool|float)\b with $1.