### PR TITLE
MAINT: Remove `level=` keyword from test arguments.

### DIFF
--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -39,7 +39,7 @@ class TestDouble(object):
         assert_equal(id(ftype), id(ftype2))
 
 class TestLongdouble(object):
-    def test_singleton(self,level=2):
+    def test_singleton(self):
         ftype = finfo(longdouble)
         ftype2 = finfo(longdouble)
         assert_equal(id(ftype), id(ftype2))

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -20,19 +20,18 @@ from numpy.testing import (
         )
 from numpy.compat import asbytes, asunicode, long
 
-rlevel = 1
 
 class TestRegression(object):
-    def test_invalid_round(self, level=rlevel):
+    def test_invalid_round(self):
         # Ticket #3
         v = 4.7599999999999998
         assert_array_equal(np.array([v]), np.array(v))
 
-    def test_mem_empty(self, level=rlevel):
+    def test_mem_empty(self):
         # Ticket #7
         np.empty((1,), dtype=[('x', np.int64)])
 
-    def test_pickle_transposed(self, level=rlevel):
+    def test_pickle_transposed(self):
         # Ticket #16
         a = np.transpose(np.array([[2, 9], [7, 0], [3, 8]]))
         f = BytesIO()
@@ -42,44 +41,44 @@ class TestRegression(object):
         f.close()
         assert_array_equal(a, b)
 
-    def test_typeNA(self, level=rlevel):
+    def test_typeNA(self):
         # Ticket #31
         assert_equal(np.typeNA[np.int64], 'Int64')
         assert_equal(np.typeNA[np.uint64], 'UInt64')
 
-    def test_dtype_names(self, level=rlevel):
+    def test_dtype_names(self):
         # Ticket #35
         # Should succeed
         np.dtype([(('name', 'label'), np.int32, 3)])
 
-    def test_reduce(self, level=rlevel):
+    def test_reduce(self):
         # Ticket #40
         assert_almost_equal(np.add.reduce([1., .5], dtype=None), 1.5)
 
-    def test_zeros_order(self, level=rlevel):
+    def test_zeros_order(self):
         # Ticket #43
         np.zeros([3], int, 'C')
         np.zeros([3], order='C')
         np.zeros([3], int, order='C')
 
-    def test_asarray_with_order(self, level=rlevel):
+    def test_asarray_with_order(self):
         # Check that nothing is done when order='F' and array C/F-contiguous
         a = np.ones(2)
         assert_(a is np.asarray(a, order='F'))
 
-    def test_ravel_with_order(self, level=rlevel):
+    def test_ravel_with_order(self):
         # Check that ravel works when order='F' and array C/F-contiguous
         a = np.ones(2)
         assert_(not a.ravel('F').flags.owndata)
 
-    def test_sort_bigendian(self, level=rlevel):
+    def test_sort_bigendian(self):
         # Ticket #47
         a = np.linspace(0, 10, 11)
         c = a.astype(np.dtype('<f8'))
         c.sort()
         assert_array_almost_equal(c, a)
 
-    def test_negative_nd_indexing(self, level=rlevel):
+    def test_negative_nd_indexing(self):
         # Ticket #49
         c = np.arange(125).reshape((5, 5, 5))
         origidx = np.array([-1, 0, 1])
@@ -87,7 +86,7 @@ class TestRegression(object):
         c[idx]
         assert_array_equal(idx, origidx)
 
-    def test_char_dump(self, level=rlevel):
+    def test_char_dump(self):
         # Ticket #50
         f = BytesIO()
         ca = np.char.array(np.arange(1000, 1010), itemsize=4)
@@ -96,7 +95,7 @@ class TestRegression(object):
         ca = np.load(f)
         f.close()
 
-    def test_noncontiguous_fill(self, level=rlevel):
+    def test_noncontiguous_fill(self):
         # Ticket #58.
         a = np.zeros((5, 3))
         b = a[:, :2,]
@@ -106,30 +105,30 @@ class TestRegression(object):
 
         assert_raises(AttributeError, rs)
 
-    def test_bool(self, level=rlevel):
+    def test_bool(self):
         # Ticket #60
         np.bool_(1)  # Should succeed
 
-    def test_indexing1(self, level=rlevel):
+    def test_indexing1(self):
         # Ticket #64
         descr = [('x', [('y', [('z', 'c16', (2,)),]),]),]
         buffer = ((([6j, 4j],),),)
         h = np.array(buffer, dtype=descr)
         h['x']['y']['z']
 
-    def test_indexing2(self, level=rlevel):
+    def test_indexing2(self):
         # Ticket #65
         descr = [('x', 'i4', (2,))]
         buffer = ([3, 2],)
         h = np.array(buffer, dtype=descr)
         h['x']
 
-    def test_round(self, level=rlevel):
+    def test_round(self):
         # Ticket #67
         x = np.array([1+2j])
         assert_almost_equal(x**(-1), [1/(1+2j)])
 
-    def test_scalar_compare(self, level=rlevel):
+    def test_scalar_compare(self):
         # Trac Ticket #72
         # https://github.com/numpy/numpy/issues/565
         a = np.array(['test', 'auto'])
@@ -143,19 +142,19 @@ class TestRegression(object):
             assert_(b != 'auto')
         assert_(b[0] != 'auto')
 
-    def test_unicode_swapping(self, level=rlevel):
+    def test_unicode_swapping(self):
         # Ticket #79
         ulen = 1
         ucs_value = u'\U0010FFFF'
         ua = np.array([[[ucs_value*ulen]*2]*3]*4, dtype='U%s' % ulen)
         ua.newbyteorder()  # Should succeed.
 
-    def test_object_array_fill(self, level=rlevel):
+    def test_object_array_fill(self):
         # Ticket #86
         x = np.zeros(1, 'O')
         x.fill([])
 
-    def test_mem_dtype_align(self, level=rlevel):
+    def test_mem_dtype_align(self):
         # Ticket #93
         assert_raises(TypeError, np.dtype,
                               {'names':['a'], 'formats':['foo']}, align=1)
@@ -165,7 +164,7 @@ class TestRegression(object):
                          platform.architecture()[0] == "64bit"),
                         "numpy.intp('0xff', 16) not supported on Py3, "
                         "as it does not inherit from Python int")
-    def test_intp(self, level=rlevel):
+    def test_intp(self):
         # Ticket #99
         i_width = np.int_(0).nbytes*2 - 1
         np.intp('0x' + 'f'*i_width, 16)
@@ -174,7 +173,7 @@ class TestRegression(object):
         assert_equal(255, np.intp('0xFF', 16))
         assert_equal(1024, np.intp(1024))
 
-    def test_endian_bool_indexing(self, level=rlevel):
+    def test_endian_bool_indexing(self):
         # Ticket #105
         a = np.arange(10., dtype='>f8')
         b = np.arange(10., dtype='<f8')
@@ -187,7 +186,7 @@ class TestRegression(object):
         assert_(np.all(a[ya] > 0.5))
         assert_(np.all(b[yb] > 0.5))
 
-    def test_endian_where(self, level=rlevel):
+    def test_endian_where(self):
         # GitHub issue #369
         net = np.zeros(3, dtype='>f4')
         net[1] = 0.00458849
@@ -197,7 +196,7 @@ class TestRegression(object):
         correct = np.array([ 0.60520202,  0.00458849,  0.60520202])
         assert_array_almost_equal(test, correct)
 
-    def test_endian_recarray(self, level=rlevel):
+    def test_endian_recarray(self):
         # Ticket #2185
         dt = np.dtype([
                ('head', '>u4'),
@@ -213,7 +212,7 @@ class TestRegression(object):
         buf[0]['data'][0] = d
         assert_(buf[0]['head'] == 1)
 
-    def test_mem_dot(self, level=rlevel):
+    def test_mem_dot(self):
         # Ticket #106
         x = np.random.randn(0, 1)
         y = np.random.randn(10, 1)
@@ -227,7 +226,7 @@ class TestRegression(object):
         np.core.multiarray.dot(x, np.transpose(y), out=z)
         assert_equal(_z, np.ones(10))
 
-    def test_arange_endian(self, level=rlevel):
+    def test_arange_endian(self):
         # Ticket #111
         ref = np.arange(10)
         x = np.arange(10, dtype='<f8')
@@ -235,31 +234,31 @@ class TestRegression(object):
         x = np.arange(10, dtype='>f8')
         assert_array_equal(ref, x)
 
-    def test_argmax(self, level=rlevel):
+    def test_argmax(self):
         # Ticket #119
         a = np.random.normal(0, 1, (4, 5, 6, 7, 8))
         for i in range(a.ndim):
             a.argmax(i)  # Should succeed
 
-    def test_mem_divmod(self, level=rlevel):
+    def test_mem_divmod(self):
         # Ticket #126
         for i in range(10):
             divmod(np.array([i])[0], 10)
 
-    def test_hstack_invalid_dims(self, level=rlevel):
+    def test_hstack_invalid_dims(self):
         # Ticket #128
         x = np.arange(9).reshape((3, 3))
         y = np.array([0, 0, 0])
         assert_raises(ValueError, np.hstack, (x, y))
 
-    def test_squeeze_type(self, level=rlevel):
+    def test_squeeze_type(self):
         # Ticket #133
         a = np.array([3])
         b = np.array(3)
         assert_(type(a.squeeze()) is np.ndarray)
         assert_(type(b.squeeze()) is np.ndarray)
 
-    def test_add_identity(self, level=rlevel):
+    def test_add_identity(self):
         # Ticket #143
         assert_equal(0, np.add.identity)
 
@@ -268,11 +267,11 @@ class TestRegression(object):
         a = np.float_(23.) + 2**135
         assert_equal(a, 23. + 2**135)
 
-    def test_binary_repr_0(self, level=rlevel):
+    def test_binary_repr_0(self):
         # Ticket #151
         assert_equal('0', np.binary_repr(0))
 
-    def test_rec_iterate(self, level=rlevel):
+    def test_rec_iterate(self):
         # Ticket #160
         descr = np.dtype([('i', int), ('f', float), ('s', '|S3')])
         x = np.rec.array([(1, 1.1, '1.0'),
@@ -280,19 +279,19 @@ class TestRegression(object):
         x[0].tolist()
         [i for i in x[0]]
 
-    def test_unicode_string_comparison(self, level=rlevel):
+    def test_unicode_string_comparison(self):
         # Ticket #190
         a = np.array('hello', np.unicode_)
         b = np.array('world')
         a == b
 
-    def test_tobytes_FORTRANORDER_discontiguous(self, level=rlevel):
+    def test_tobytes_FORTRANORDER_discontiguous(self):
         # Fix in r2836
         # Create non-contiguous Fortran ordered array
         x = np.array(np.random.rand(3, 3), order='F')[:, :2]
         assert_array_almost_equal(x.ravel(), np.fromstring(x.tobytes()))
 
-    def test_flat_assignment(self, level=rlevel):
+    def test_flat_assignment(self):
         # Correct behaviour of ticket #194
         x = np.empty((3, 1))
         x.flat = np.arange(3)
@@ -300,7 +299,7 @@ class TestRegression(object):
         x.flat = np.arange(3, dtype=float)
         assert_array_almost_equal(x, [[0], [1], [2]])
 
-    def test_broadcast_flat_assignment(self, level=rlevel):
+    def test_broadcast_flat_assignment(self):
         # Ticket #194
         x = np.empty((3, 1))
 
@@ -328,7 +327,7 @@ class TestRegression(object):
         assert_raises(ValueError, assign, a, r, np.nan)
         a[r] = np.array(np.nan)
 
-    def test_unpickle_dtype_with_object(self, level=rlevel):
+    def test_unpickle_dtype_with_object(self):
         # Implemented in r2840
         dt = np.dtype([('x', int), ('y', np.object_), ('z', 'O')])
         f = BytesIO()
@@ -338,7 +337,7 @@ class TestRegression(object):
         f.close()
         assert_equal(dt, dt_)
 
-    def test_mem_array_creation_invalid_specification(self, level=rlevel):
+    def test_mem_array_creation_invalid_specification(self):
         # Ticket #196
         dt = np.dtype([('x', int), ('y', np.object_)])
         # Wrong way
@@ -346,7 +345,7 @@ class TestRegression(object):
         # Correct way
         np.array([(1, 'object')], dt)
 
-    def test_recarray_single_element(self, level=rlevel):
+    def test_recarray_single_element(self):
         # Ticket #202
         a = np.array([1, 2, 3], dtype=np.int32)
         b = a.copy()
@@ -354,7 +353,7 @@ class TestRegression(object):
         assert_array_equal(a, b)
         assert_equal(a, r[0][0])
 
-    def test_zero_sized_array_indexing(self, level=rlevel):
+    def test_zero_sized_array_indexing(self):
         # Ticket #205
         tmp = np.array([])
 
@@ -363,14 +362,14 @@ class TestRegression(object):
 
         assert_raises(IndexError, index_tmp)
 
-    def test_chararray_rstrip(self, level=rlevel):
+    def test_chararray_rstrip(self):
         # Ticket #222
         x = np.chararray((1,), 5)
         x[0] = b'a   '
         x = x.rstrip()
         assert_equal(x[0], b'a')
 
-    def test_object_array_shape(self, level=rlevel):
+    def test_object_array_shape(self):
         # Ticket #239
         assert_equal(np.array([[1, 2], 3, 4], dtype=object).shape, (3,))
         assert_equal(np.array([[1, 2], [3, 4]], dtype=object).shape, (2, 2))
@@ -379,20 +378,20 @@ class TestRegression(object):
         assert_equal(np.array([[], [], []], dtype=object).shape, (3, 0))
         assert_equal(np.array([[3, 4], [5, 6], None], dtype=object).shape, (3,))
 
-    def test_mem_around(self, level=rlevel):
+    def test_mem_around(self):
         # Ticket #243
         x = np.zeros((1,))
         y = [0]
         decimal = 6
         np.around(abs(x-y), decimal) <= 10.0**(-decimal)
 
-    def test_character_array_strip(self, level=rlevel):
+    def test_character_array_strip(self):
         # Ticket #246
         x = np.char.array(("x", "x ", "x  "))
         for c in x:
             assert_equal(c, "x")
 
-    def test_lexsort(self, level=rlevel):
+    def test_lexsort(self):
         # Lexsort memory error
         v = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         assert_equal(np.lexsort(v), 0)
@@ -444,36 +443,36 @@ class TestRegression(object):
                     for name in result.dtype.names:
                         assert_(isinstance(name, str))
 
-    def test_pickle_dtype(self, level=rlevel):
+    def test_pickle_dtype(self):
         # Ticket #251
         pickle.dumps(float)
 
-    def test_swap_real(self, level=rlevel):
+    def test_swap_real(self):
         # Ticket #265
         assert_equal(np.arange(4, dtype='>c8').imag.max(), 0.0)
         assert_equal(np.arange(4, dtype='<c8').imag.max(), 0.0)
         assert_equal(np.arange(4, dtype='>c8').real.max(), 3.0)
         assert_equal(np.arange(4, dtype='<c8').real.max(), 3.0)
 
-    def test_object_array_from_list(self, level=rlevel):
+    def test_object_array_from_list(self):
         # Ticket #270
         assert_(np.array([1, 'A', None]).shape == (3,))
 
-    def test_multiple_assign(self, level=rlevel):
+    def test_multiple_assign(self):
         # Ticket #273
         a = np.zeros((3, 1), int)
         a[[1, 2]] = 1
 
-    def test_empty_array_type(self, level=rlevel):
+    def test_empty_array_type(self):
         assert_equal(np.array([]).dtype, np.zeros(0).dtype)
 
-    def test_void_copyswap(self, level=rlevel):
+    def test_void_copyswap(self):
         dt = np.dtype([('one', '<i4'), ('two', '<i4')])
         x = np.array((1, 2), dtype=dt)
         x = x.byteswap()
         assert_(x['one'] > 1 and x['two'] > 2)
 
-    def test_method_args(self, level=rlevel):
+    def test_method_args(self):
         # Make sure methods and functions have same default axis
         # keyword and arguments
         funcs1 = ['argmax', 'argmin', 'sum', ('product', 'prod'),
@@ -515,17 +514,17 @@ class TestRegression(object):
             res2 = getattr(np, func)(arr1, arr2)
             assert_(abs(res1-res2).max() < 1e-8, func)
 
-    def test_mem_lexsort_strings(self, level=rlevel):
+    def test_mem_lexsort_strings(self):
         # Ticket #298
         lst = ['abc', 'cde', 'fgh']
         np.lexsort((lst,))
 
-    def test_fancy_index(self, level=rlevel):
+    def test_fancy_index(self):
         # Ticket #302
         x = np.array([1, 2])[np.array([0])]
         assert_equal(x.shape, (1,))
 
-    def test_recarray_copy(self, level=rlevel):
+    def test_recarray_copy(self):
         # Ticket #312
         dt = [('x', np.int16), ('y', np.float64)]
         ra = np.array([(1, 2.3)], dtype=dt)
@@ -533,64 +532,64 @@ class TestRegression(object):
         rb['x'] = 2.
         assert_(ra['x'] != rb['x'])
 
-    def test_rec_fromarray(self, level=rlevel):
+    def test_rec_fromarray(self):
         # Ticket #322
         x1 = np.array([[1, 2], [3, 4], [5, 6]])
         x2 = np.array(['a', 'dd', 'xyz'])
         x3 = np.array([1.1, 2, 3])
         np.rec.fromarrays([x1, x2, x3], formats="(2,)i4,a3,f8")
 
-    def test_object_array_assign(self, level=rlevel):
+    def test_object_array_assign(self):
         x = np.empty((2, 2), object)
         x.flat[2] = (1, 2, 3)
         assert_equal(x.flat[2], (1, 2, 3))
 
-    def test_ndmin_float64(self, level=rlevel):
+    def test_ndmin_float64(self):
         # Ticket #324
         x = np.array([1, 2, 3], dtype=np.float64)
         assert_equal(np.array(x, dtype=np.float32, ndmin=2).ndim, 2)
         assert_equal(np.array(x, dtype=np.float64, ndmin=2).ndim, 2)
 
-    def test_ndmin_order(self, level=rlevel):
+    def test_ndmin_order(self):
         # Issue #465 and related checks
         assert_(np.array([1, 2], order='C', ndmin=3).flags.c_contiguous)
         assert_(np.array([1, 2], order='F', ndmin=3).flags.f_contiguous)
         assert_(np.array(np.ones((2, 2), order='F'), ndmin=3).flags.f_contiguous)
         assert_(np.array(np.ones((2, 2), order='C'), ndmin=3).flags.c_contiguous)
 
-    def test_mem_axis_minimization(self, level=rlevel):
+    def test_mem_axis_minimization(self):
         # Ticket #327
         data = np.arange(5)
         data = np.add.outer(data, data)
 
-    def test_mem_float_imag(self, level=rlevel):
+    def test_mem_float_imag(self):
         # Ticket #330
         np.float64(1.0).imag
 
-    def test_dtype_tuple(self, level=rlevel):
+    def test_dtype_tuple(self):
         # Ticket #334
         assert_(np.dtype('i4') == np.dtype(('i4', ())))
 
-    def test_dtype_posttuple(self, level=rlevel):
+    def test_dtype_posttuple(self):
         # Ticket #335
         np.dtype([('col1', '()i4')])
 
-    def test_numeric_carray_compare(self, level=rlevel):
+    def test_numeric_carray_compare(self):
         # Ticket #341
         assert_equal(np.array(['X'], 'c'), b'X')
 
-    def test_string_array_size(self, level=rlevel):
+    def test_string_array_size(self):
         # Ticket #342
         assert_raises(ValueError,
                               np.array, [['X'], ['X', 'X', 'X']], '|S1')
 
-    def test_dtype_repr(self, level=rlevel):
+    def test_dtype_repr(self):
         # Ticket #344
         dt1 = np.dtype(('uint32', 2))
         dt2 = np.dtype(('uint32', (2,)))
         assert_equal(dt1.__repr__(), dt2.__repr__())
 
-    def test_reshape_order(self, level=rlevel):
+    def test_reshape_order(self):
         # Make sure reshape order works.
         a = np.arange(6).reshape(2, 3, order='F')
         assert_equal(a, [[0, 2, 4], [1, 3, 5]])
@@ -598,13 +597,13 @@ class TestRegression(object):
         b = a[:, 1]
         assert_equal(b.reshape(2, 2, order='F'), [[2, 6], [4, 8]])
 
-    def test_reshape_zero_strides(self, level=rlevel):
+    def test_reshape_zero_strides(self):
         # Issue #380, test reshaping of zero strided arrays
         a = np.ones(1)
         a = np.lib.stride_tricks.as_strided(a, shape=(5,), strides=(0,))
         assert_(a.reshape(5, 1).strides[0] == 0)
 
-    def test_reshape_zero_size(self, level=rlevel):
+    def test_reshape_zero_size(self):
         # GitHub Issue #2700, setting shape failed for 0-sized arrays
         a = np.ones((0, 2))
         a.shape = (-1, 2)
@@ -621,22 +620,22 @@ class TestRegression(object):
         assert_equal(a.reshape(3, 2, 1, 1, order='F').strides, strides_f)
         assert_equal(np.array(0, dtype=np.int32).reshape(1, 1).strides, (4, 4))
 
-    def test_repeat_discont(self, level=rlevel):
+    def test_repeat_discont(self):
         # Ticket #352
         a = np.arange(12).reshape(4, 3)[:, 2]
         assert_equal(a.repeat(3), [2, 2, 2, 5, 5, 5, 8, 8, 8, 11, 11, 11])
 
-    def test_array_index(self, level=rlevel):
+    def test_array_index(self):
         # Make sure optimization is not called in this case.
         a = np.array([1, 2, 3])
         a2 = np.array([[1, 2, 3]])
         assert_equal(a[np.where(a == 3)], a2[np.where(a2 == 3)])
 
-    def test_object_argmax(self, level=rlevel):
+    def test_object_argmax(self):
         a = np.array([1, 2, 3], dtype=object)
         assert_(a.argmax() == 2)
 
-    def test_recarray_fields(self, level=rlevel):
+    def test_recarray_fields(self):
         # Ticket #372
         dt0 = np.dtype([('f0', 'i4'), ('f1', 'i4')])
         dt1 = np.dtype([('f0', 'i8'), ('f1', 'i8')])
@@ -647,22 +646,22 @@ class TestRegression(object):
                   np.rec.fromarrays([(1, 2), (3, 4)])]:
             assert_(a.dtype in [dt0, dt1])
 
-    def test_random_shuffle(self, level=rlevel):
+    def test_random_shuffle(self):
         # Ticket #374
         a = np.arange(5).reshape((5, 1))
         b = a.copy()
         np.random.shuffle(b)
         assert_equal(np.sort(b, axis=0), a)
 
-    def test_refcount_vdot(self, level=rlevel):
+    def test_refcount_vdot(self):
         # Changeset #3443
         _assert_valid_refcount(np.vdot)
 
-    def test_startswith(self, level=rlevel):
+    def test_startswith(self):
         ca = np.char.array(['Hi', 'There'])
         assert_equal(ca.startswith('H'), [True, False])
 
-    def test_noncommutative_reduce_accumulate(self, level=rlevel):
+    def test_noncommutative_reduce_accumulate(self):
         # Ticket #413
         tosubtract = np.arange(5)
         todivide = np.array([2.0, 0.5, 0.25])
@@ -673,28 +672,28 @@ class TestRegression(object):
         assert_array_equal(np.divide.accumulate(todivide),
             np.array([2., 4., 16.]))
 
-    def test_convolve_empty(self, level=rlevel):
+    def test_convolve_empty(self):
         # Convolve should raise an error for empty input array.
         assert_raises(ValueError, np.convolve, [], [1])
         assert_raises(ValueError, np.convolve, [1], [])
 
-    def test_multidim_byteswap(self, level=rlevel):
+    def test_multidim_byteswap(self):
         # Ticket #449
         r = np.array([(1, (0, 1, 2))], dtype="i2,3i2")
         assert_array_equal(r.byteswap(),
                            np.array([(256, (0, 256, 512))], r.dtype))
 
-    def test_string_NULL(self, level=rlevel):
+    def test_string_NULL(self):
         # Changeset 3557
         assert_equal(np.array("a\x00\x0b\x0c\x00").item(),
                      'a\x00\x0b\x0c')
 
-    def test_junk_in_string_fields_of_recarray(self, level=rlevel):
+    def test_junk_in_string_fields_of_recarray(self):
         # Ticket #483
         r = np.array([[b'abc']], dtype=[('var1', '|S20')])
         assert_(asbytes(r['var1'][0][0]) == b'abc')
 
-    def test_take_output(self, level=rlevel):
+    def test_take_output(self):
         # Ensure that 'take' honours output parameter.
         x = np.arange(12).reshape((3, 4))
         a = np.take(x, [0, 2], axis=1)
@@ -715,13 +714,13 @@ class TestRegression(object):
         if HAS_REFCOUNT:
             assert_(ref_d == sys.getrefcount(d))
 
-    def test_array_str_64bit(self, level=rlevel):
+    def test_array_str_64bit(self):
         # Ticket #501
         s = np.array([1, np.nan], dtype=np.float64)
         with np.errstate(all='raise'):
             np.array_str(s)  # Should succeed
 
-    def test_frompyfunc_endian(self, level=rlevel):
+    def test_frompyfunc_endian(self):
         # Ticket #503
         from math import radians
         uradians = np.frompyfunc(radians, 1, 1)
@@ -730,33 +729,33 @@ class TestRegression(object):
         assert_almost_equal(uradians(big_endian).astype(float),
                             uradians(little_endian).astype(float))
 
-    def test_mem_string_arr(self, level=rlevel):
+    def test_mem_string_arr(self):
         # Ticket #514
         s = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         t = []
         np.hstack((t, s))
 
-    def test_arr_transpose(self, level=rlevel):
+    def test_arr_transpose(self):
         # Ticket #516
         x = np.random.rand(*(2,)*16)
         x.transpose(list(range(16)))  # Should succeed
 
-    def test_string_mergesort(self, level=rlevel):
+    def test_string_mergesort(self):
         # Ticket #540
         x = np.array(['a']*32)
         assert_array_equal(x.argsort(kind='m'), np.arange(32))
 
-    def test_argmax_byteorder(self, level=rlevel):
+    def test_argmax_byteorder(self):
         # Ticket #546
         a = np.arange(3, dtype='>f')
         assert_(a[a.argmax()] == a.max())
 
-    def test_rand_seed(self, level=rlevel):
+    def test_rand_seed(self):
         # Ticket #555
         for l in np.arange(4):
             np.random.seed(l)
 
-    def test_mem_deallocation_leak(self, level=rlevel):
+    def test_mem_deallocation_leak(self):
         # Ticket #562
         a = np.zeros(5, dtype=float)
         b = np.array(a, dtype=float)
@@ -766,7 +765,7 @@ class TestRegression(object):
         "Ticket #583"
         assert_raises(ValueError, np.fromiter, [['12', ''], ['13', '']], str)
 
-    def test_dot_negative_stride(self, level=rlevel):
+    def test_dot_negative_stride(self):
         # Ticket #588
         x = np.array([[1, 5, 25, 125., 625]])
         y = np.array([[20.], [160.], [640.], [1280.], [1024.]])
@@ -774,7 +773,7 @@ class TestRegression(object):
         y2 = y[::-1]
         assert_equal(np.dot(x, z), np.dot(x, y2))
 
-    def test_object_casting(self, level=rlevel):
+    def test_object_casting(self):
         # This used to trigger the object-type version of
         # the bitwise_or operation, because float64 -> object
         # casting succeeds
@@ -785,14 +784,14 @@ class TestRegression(object):
 
         assert_raises(TypeError, rs)
 
-    def test_unicode_scalar(self, level=rlevel):
+    def test_unicode_scalar(self):
         # Ticket #600
         x = np.array(["DROND", "DROND1"], dtype="U6")
         el = x[1]
         new = pickle.loads(pickle.dumps(el))
         assert_equal(new, el)
 
-    def test_arange_non_native_dtype(self, level=rlevel):
+    def test_arange_non_native_dtype(self):
         # Ticket #616
         for T in ('>f4', '<f4'):
             dt = np.dtype(T)
@@ -800,7 +799,7 @@ class TestRegression(object):
             assert_equal(np.arange(0.5, dtype=dt).dtype, dt)
             assert_equal(np.arange(5, dtype=dt).dtype, dt)
 
-    def test_bool_flat_indexing_invalid_nr_elements(self, level=rlevel):
+    def test_bool_flat_indexing_invalid_nr_elements(self):
         s = np.ones(10, dtype=float)
         x = np.array((15,), dtype=float)
 
@@ -814,59 +813,59 @@ class TestRegression(object):
         assert_raises(ValueError, ia, x.flat, s, np.zeros(9, dtype=float))
         assert_raises(ValueError, ia, x.flat, s, np.zeros(11, dtype=float))
 
-    def test_mem_scalar_indexing(self, level=rlevel):
+    def test_mem_scalar_indexing(self):
         # Ticket #603
         x = np.array([0], dtype=float)
         index = np.array(0, dtype=np.int32)
         x[index]
 
-    def test_binary_repr_0_width(self, level=rlevel):
+    def test_binary_repr_0_width(self):
         assert_equal(np.binary_repr(0, width=3), '000')
 
-    def test_fromstring(self, level=rlevel):
+    def test_fromstring(self):
         assert_equal(np.fromstring("12:09:09", dtype=int, sep=":"),
                      [12, 9, 9])
 
-    def test_searchsorted_variable_length(self, level=rlevel):
+    def test_searchsorted_variable_length(self):
         x = np.array(['a', 'aa', 'b'])
         y = np.array(['d', 'e'])
         assert_equal(x.searchsorted(y), [3, 3])
 
-    def test_string_argsort_with_zeros(self, level=rlevel):
+    def test_string_argsort_with_zeros(self):
         # Check argsort for strings containing zeros.
         x = np.fromstring("\x00\x02\x00\x01", dtype="|S2")
         assert_array_equal(x.argsort(kind='m'), np.array([1, 0]))
         assert_array_equal(x.argsort(kind='q'), np.array([1, 0]))
 
-    def test_string_sort_with_zeros(self, level=rlevel):
+    def test_string_sort_with_zeros(self):
         # Check sort for strings containing zeros.
         x = np.fromstring("\x00\x02\x00\x01", dtype="|S2")
         y = np.fromstring("\x00\x01\x00\x02", dtype="|S2")
         assert_array_equal(np.sort(x, kind="q"), y)
 
-    def test_copy_detection_zero_dim(self, level=rlevel):
+    def test_copy_detection_zero_dim(self):
         # Ticket #658
         np.indices((0, 3, 4)).T.reshape(-1, 3)
 
-    def test_flat_byteorder(self, level=rlevel):
+    def test_flat_byteorder(self):
         # Ticket #657
         x = np.arange(10)
         assert_array_equal(x.astype('>i4'), x.astype('<i4').flat[:])
         assert_array_equal(x.astype('>i4').flat[:], x.astype('<i4'))
 
-    def test_uint64_from_negative(self, level=rlevel):
+    def test_uint64_from_negative(self):
         assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
 
-    def test_sign_bit(self, level=rlevel):
+    def test_sign_bit(self):
         x = np.array([0, -0.0, 0])
         assert_equal(str(np.abs(x)), '[ 0.  0.  0.]')
 
-    def test_flat_index_byteswap(self, level=rlevel):
+    def test_flat_index_byteswap(self):
         for dt in (np.dtype('<i4'), np.dtype('>i4')):
             x = np.array([-1, 0, 1], dtype=dt)
             assert_equal(x.flat[0].dtype, x[0].dtype)
 
-    def test_copy_detection_corner_case(self, level=rlevel):
+    def test_copy_detection_corner_case(self):
         # Ticket #658
         np.indices((0, 3, 4)).T.reshape(-1, 3)
 
@@ -874,13 +873,13 @@ class TestRegression(object):
     # With NPY_RELAXED_STRIDES_CHECKING the test becomes superfluous,
     # 0-sized reshape itself is tested elsewhere.
     @dec.skipif(np.ones(1).strides[0] == np.iinfo(np.intp).max)
-    def test_copy_detection_corner_case2(self, level=rlevel):
+    def test_copy_detection_corner_case2(self):
         # Ticket #771: strides are not set correctly when reshaping 0-sized
         # arrays
         b = np.indices((0, 3, 4)).T.reshape(-1, 3)
         assert_equal(b.strides, (3 * b.itemsize, b.itemsize))
 
-    def test_object_array_refcounting(self, level=rlevel):
+    def test_object_array_refcounting(self):
         # Ticket #633
         if not hasattr(sys, 'getrefcount'):
             return
@@ -983,7 +982,7 @@ class TestRegression(object):
 
         del tmp  # Avoid pyflakes unused variable warning
 
-    def test_mem_custom_float_to_array(self, level=rlevel):
+    def test_mem_custom_float_to_array(self):
         # Ticket 702
         class MyFloat(object):
             def __float__(self):
@@ -992,7 +991,7 @@ class TestRegression(object):
         tmp = np.atleast_1d([MyFloat()])
         tmp.astype(float)  # Should succeed
 
-    def test_object_array_refcount_self_assign(self, level=rlevel):
+    def test_object_array_refcount_self_assign(self):
         # Ticket #711
         class VictimObject(object):
             deleted = False
@@ -1009,23 +1008,23 @@ class TestRegression(object):
         arr[:] = arr  # trying to induce a segfault by doing it again...
         assert_(not arr[0].deleted)
 
-    def test_mem_fromiter_invalid_dtype_string(self, level=rlevel):
+    def test_mem_fromiter_invalid_dtype_string(self):
         x = [1, 2, 3]
         assert_raises(ValueError,
                               np.fromiter, [xi for xi in x], dtype='S')
 
-    def test_reduce_big_object_array(self, level=rlevel):
+    def test_reduce_big_object_array(self):
         # Ticket #713
         oldsize = np.setbufsize(10*16)
         a = np.array([None]*161, object)
         assert_(not np.any(a))
         np.setbufsize(oldsize)
 
-    def test_mem_0d_array_index(self, level=rlevel):
+    def test_mem_0d_array_index(self):
         # Ticket #714
         np.zeros(10)[np.array(0)]
 
-    def test_floats_from_string(self, level=rlevel):
+    def test_floats_from_string(self):
         # Ticket #640, floats from string
         fsingle = np.single('1.234')
         fdouble = np.double('1.234')
@@ -1034,7 +1033,7 @@ class TestRegression(object):
         assert_almost_equal(fdouble, 1.234)
         assert_almost_equal(flongdouble, 1.234)
 
-    def test_nonnative_endian_fill(self, level=rlevel):
+    def test_nonnative_endian_fill(self):
         # Non-native endian arrays were incorrectly filled with scalars
         # before r5034.
         if sys.byteorder == 'little':
@@ -1045,7 +1044,7 @@ class TestRegression(object):
         x.fill(1)
         assert_equal(x, np.array([1], dtype=dtype))
 
-    def test_dot_alignment_sse2(self, level=rlevel):
+    def test_dot_alignment_sse2(self):
         # Test for ticket #551, changeset r5140
         x = np.zeros((30, 40))
         y = pickle.loads(pickle.dumps(x))
@@ -1054,7 +1053,7 @@ class TestRegression(object):
         # This shouldn't cause a segmentation fault:
         np.dot(z, y)
 
-    def test_astype_copy(self, level=rlevel):
+    def test_astype_copy(self):
         # Ticket #788, changeset r5155
         # The test data file was generated by scipy.io.savemat.
         # The dtype is float64, but the isbuiltin attribute is 0.
@@ -1072,7 +1071,7 @@ class TestRegression(object):
         assert_((xp.__array_interface__['data'][0] !=
                 xpd.__array_interface__['data'][0]))
 
-    def test_compress_small_type(self, level=rlevel):
+    def test_compress_small_type(self):
         # Ticket #789, changeset 5217.
         # compress with out argument segfaulted if cannot cast safely
         import numpy as np
@@ -1086,7 +1085,7 @@ class TestRegression(object):
         except TypeError:
             pass
 
-    def test_attributes(self, level=rlevel):
+    def test_attributes(self):
         # Ticket #791
         class TestArray(np.ndarray):
             def __new__(cls, data, info):
@@ -1158,7 +1157,7 @@ class TestRegression(object):
         assert_(type(dat.nonzero()[0]) is np.ndarray)
         assert_(type(dat.nonzero()[1]) is np.ndarray)
 
-    def test_recarray_tolist(self, level=rlevel):
+    def test_recarray_tolist(self):
         # Ticket #793, changeset r5215
         # Comparisons fail for NaN, so we can't use random memory
         # for the test.
@@ -1173,12 +1172,12 @@ class TestRegression(object):
         a = np.arange(5)
         assert_raises(ValueError, a.item)
 
-    def test_char_array_creation(self, level=rlevel):
+    def test_char_array_creation(self):
         a = np.array('123', dtype='c')
         b = np.array([b'1', b'2', b'3'])
         assert_equal(a, b)
 
-    def test_unaligned_unicode_access(self, level=rlevel):
+    def test_unaligned_unicode_access(self):
         # Ticket #825
         for i in range(1, 9):
             msg = 'unicode offset: %d chars' % i
@@ -1189,7 +1188,7 @@ class TestRegression(object):
             else:
                 assert_equal(str(x), "[('a', u'b')]", err_msg=msg)
 
-    def test_sign_for_complex_nan(self, level=rlevel):
+    def test_sign_for_complex_nan(self):
         # Ticket 794.
         with np.errstate(invalid='ignore'):
             C = np.array([-np.inf, -2+1j, 0, 2-1j, np.inf, np.nan])
@@ -1197,7 +1196,7 @@ class TestRegression(object):
             want = np.array([-1+0j, -1+0j, 0+0j, 1+0j, 1+0j, np.nan])
             assert_equal(have, want)
 
-    def test_for_equal_names(self, level=rlevel):
+    def test_for_equal_names(self):
         # Ticket #674
         dt = np.dtype([('foo', float), ('bar', float)])
         a = np.zeros(10, dt)
@@ -1207,7 +1206,7 @@ class TestRegression(object):
         assert_(a.dtype.names[0] == "notfoo")
         assert_(a.dtype.names[1] == "bar")
 
-    def test_for_object_scalar_creation(self, level=rlevel):
+    def test_for_object_scalar_creation(self):
         # Ticket #816
         a = np.object_()
         b = np.object_(3)
@@ -1226,7 +1225,7 @@ class TestRegression(object):
         x = np.array([[0, 1], [2, 3]])
         assert_raises(TypeError, x.resize, (2, 2), order='C')
 
-    def test_for_zero_length_in_choose(self, level=rlevel):
+    def test_for_zero_length_in_choose(self):
         "Ticket #882"
         a = np.array(1)
         assert_raises(ValueError, lambda x: x.choose([]), a)
@@ -1235,7 +1234,7 @@ class TestRegression(object):
         "Ticket #947."
         assert_raises(ValueError, lambda: np.array([1], ndmin=33))
 
-    def test_void_scalar_with_titles(self, level=rlevel):
+    def test_void_scalar_with_titles(self):
         # No ticket
         data = [('john', 4), ('mary', 5)]
         dtype1 = [(('source:yy', 'name'), 'O'), (('source:xx', 'id'), int)]
@@ -1491,7 +1490,7 @@ class TestRegression(object):
         # Check if log1p is behaving on 32 bit intel systems.
         assert_(np.isfinite(np.log1p(np.exp2(-53))))
 
-    def test_fromiter_comparison(self, level=rlevel):
+    def test_fromiter_comparison(self):
         a = np.fromiter(list(range(10)), dtype='b')
         b = np.fromiter(list(range(10)), dtype='B')
         assert_(np.alltrue(a == np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])))

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -23,12 +23,12 @@ floating_types = np.floating.__subclasses__()
 # This compares scalarmath against ufuncs.
 
 class TestTypes(object):
-    def test_types(self, level=1):
+    def test_types(self):
         for atype in types:
             a = atype(1)
             assert_(a == 1, "error with %r: got %r" % (atype, a))
 
-    def test_type_add(self, level=1):
+    def test_type_add(self):
         # list of types
         for k, atype in enumerate(types):
             a_scalar = atype(3)
@@ -48,7 +48,7 @@ class TestTypes(object):
                            "error with types (%d/'%c' + %d/'%c')" %
                             (k, np.dtype(atype).char, l, np.dtype(btype).char))
 
-    def test_type_create(self, level=1):
+    def test_type_create(self):
         for k, atype in enumerate(types):
             a = np.array([1, 2, 3], atype)
             b = atype([1, 2, 3])

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -10,16 +10,14 @@ from numpy.testing import (
     )
 from numpy.compat import unicode
 
-rlevel = 1
-
 
 class TestRegression(object):
-    def test_poly1d(self, level=rlevel):
+    def test_poly1d(self):
         # Ticket #28
         assert_equal(np.poly1d([1]) - np.poly1d([1, 0]),
                      np.poly1d([-1, 1]))
 
-    def test_cov_parameters(self, level=rlevel):
+    def test_cov_parameters(self):
         # Ticket #91
         x = np.random.random((3, 3))
         y = x.copy()
@@ -27,57 +25,57 @@ class TestRegression(object):
         np.cov(y, rowvar=0)
         assert_array_equal(x, y)
 
-    def test_mem_digitize(self, level=rlevel):
+    def test_mem_digitize(self):
         # Ticket #95
         for i in range(100):
             np.digitize([1, 2, 3, 4], [1, 3])
             np.digitize([0, 1, 2, 3, 4], [1, 3])
 
-    def test_unique_zero_sized(self, level=rlevel):
+    def test_unique_zero_sized(self):
         # Ticket #205
         assert_array_equal([], np.unique(np.array([])))
 
-    def test_mem_vectorise(self, level=rlevel):
+    def test_mem_vectorise(self):
         # Ticket #325
         vt = np.vectorize(lambda *args: args)
         vt(np.zeros((1, 2, 1)), np.zeros((2, 1, 1)), np.zeros((1, 1, 2)))
         vt(np.zeros((1, 2, 1)), np.zeros((2, 1, 1)), np.zeros((1,
            1, 2)), np.zeros((2, 2)))
 
-    def test_mgrid_single_element(self, level=rlevel):
+    def test_mgrid_single_element(self):
         # Ticket #339
         assert_array_equal(np.mgrid[0:0:1j], [0])
         assert_array_equal(np.mgrid[0:0], [])
 
-    def test_refcount_vectorize(self, level=rlevel):
+    def test_refcount_vectorize(self):
         # Ticket #378
         def p(x, y):
             return 123
         v = np.vectorize(p)
         _assert_valid_refcount(v)
 
-    def test_poly1d_nan_roots(self, level=rlevel):
+    def test_poly1d_nan_roots(self):
         # Ticket #396
         p = np.poly1d([np.nan, np.nan, 1], r=0)
         assert_raises(np.linalg.LinAlgError, getattr, p, "r")
 
-    def test_mem_polymul(self, level=rlevel):
+    def test_mem_polymul(self):
         # Ticket #448
         np.polymul([], [1.])
 
-    def test_mem_string_concat(self, level=rlevel):
+    def test_mem_string_concat(self):
         # Ticket #469
         x = np.array([])
         np.append(x, 'asdasd\tasdasd')
 
-    def test_poly_div(self, level=rlevel):
+    def test_poly_div(self):
         # Ticket #553
         u = np.poly1d([1, 2, 3])
         v = np.poly1d([1, 2, 3, 4, 5])
         q, r = np.polydiv(u, v)
         assert_equal(q*v + r, u)
 
-    def test_poly_eq(self, level=rlevel):
+    def test_poly_eq(self):
         # Ticket #554
         x = np.poly1d([1, 2, 3])
         y = np.poly1d([3, 4])
@@ -134,11 +132,11 @@ class TestRegression(object):
         # Shouldn't crash:
         list(np.ndenumerate(np.array([[]])))
 
-    def test_asfarray_none(self, level=rlevel):
+    def test_asfarray_none(self):
         # Test for changeset r5065
         assert_array_equal(np.array([np.nan]), np.asfarray([None]))
 
-    def test_large_fancy_indexing(self, level=rlevel):
+    def test_large_fancy_indexing(self):
         # Large enough to fail on 64-bit.
         nbits = np.dtype(np.intp).itemsize * 8
         thesize = int((2**nbits)**(1.0/5.0)+1)
@@ -158,12 +156,12 @@ class TestRegression(object):
         assert_raises(ValueError, dp)
         assert_raises(ValueError, dp2)
 
-    def test_void_coercion(self, level=rlevel):
+    def test_void_coercion(self):
         dt = np.dtype([('a', 'f4'), ('b', 'i4')])
         x = np.zeros((1,), dt)
         assert_(np.r_[x, x].dtype == dt)
 
-    def test_who_with_0dim_array(self, level=rlevel):
+    def test_who_with_0dim_array(self):
         # ticket #1243
         import os
         import sys

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -19,7 +19,7 @@ class TestApplyAlongAxis(object):
         assert_array_equal(
             apply_along_axis(len, 0, a), len(a)*np.ones(a.shape[1]))
 
-    def test_simple101(self, level=11):
+    def test_simple101(self):
         a = np.ones((10, 101), 'd')
         assert_array_equal(
             apply_along_axis(len, 0, a), len(a)*np.ones(a.shape[1]))

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -12,12 +12,9 @@ from numpy.testing import (
 )
 
 
-rlevel = 1
-
-
 class TestRegression(object):
 
-    def test_eig_build(self, level=rlevel):
+    def test_eig_build(self):
         # Ticket #652
         rva = array([1.03221168e+02 + 0.j,
                      -1.91843603e+01 + 0.j,
@@ -40,7 +37,7 @@ class TestRegression(object):
         rva.sort()
         assert_array_almost_equal(va, rva)
 
-    def test_eigh_build(self, level=rlevel):
+    def test_eigh_build(self):
         # Ticket 662.
         rvals = [68.60568999, 89.57756725, 106.67185574]
 
@@ -51,7 +48,7 @@ class TestRegression(object):
         vals, vecs = linalg.eigh(cov)
         assert_array_almost_equal(vals, rvals)
 
-    def test_svd_build(self, level=rlevel):
+    def test_svd_build(self):
         # Ticket 627.
         a = array([[0., 1.], [1., 1.], [2., 1.], [3., 1.]])
         m, n = a.shape

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -8,21 +8,19 @@ from numpy.testing import (
     suppress_warnings
     )
 
-rlevel = 1
-
 
 class TestRegression(object):
-    def test_masked_array_create(self,level=rlevel):
+    def test_masked_array_create(self):
         # Ticket #17
         x = np.ma.masked_array([0, 1, 2, 3, 0, 4, 5, 6],
                                mask=[0, 0, 0, 1, 1, 1, 0, 0])
         assert_array_equal(np.ma.nonzero(x), [[1, 2, 6, 7]])
 
-    def test_masked_array(self,level=rlevel):
+    def test_masked_array(self):
         # Ticket #61
         np.ma.array(1, mask=[1])
 
-    def test_mem_masked_where(self,level=rlevel):
+    def test_mem_masked_where(self):
         # Ticket #62
         from numpy.ma import masked_where, MaskType
         a = np.zeros((1, 1))
@@ -30,7 +28,7 @@ class TestRegression(object):
         c = masked_where(b, a)
         a-c
 
-    def test_masked_array_multiply(self,level=rlevel):
+    def test_masked_array_multiply(self):
         # Ticket #254
         a = np.ma.zeros((4, 1))
         a[2, 0] = np.ma.masked
@@ -38,7 +36,7 @@ class TestRegression(object):
         a*b
         b*a
 
-    def test_masked_array_repeat(self, level=rlevel):
+    def test_masked_array_repeat(self):
         # Ticket #271
         np.ma.array([1], mask=False).repeat(10)
 

--- a/numpy/matrixlib/tests/test_regression.py
+++ b/numpy/matrixlib/tests/test_regression.py
@@ -5,15 +5,14 @@ from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises
     )
 
-rlevel = 1
 
 class TestRegression(object):
-    def test_kron_matrix(self, level=rlevel):
+    def test_kron_matrix(self):
         # Ticket #71
         x = np.matrix('[1 0; 1 0]')
         assert_equal(type(np.kron(x, x)), type(x))
 
-    def test_matrix_properties(self,level=rlevel):
+    def test_matrix_properties(self):
         # Ticket #125
         a = np.matrix([1.0], dtype=float)
         assert_(type(a.real) is np.matrix)
@@ -22,14 +21,14 @@ class TestRegression(object):
         assert_(type(c) is np.ndarray)
         assert_(type(d) is np.ndarray)
 
-    def test_matrix_multiply_by_1d_vector(self, level=rlevel):
+    def test_matrix_multiply_by_1d_vector(self):
         # Ticket #473
         def mul():
             np.mat(np.eye(2))*np.ones(2)
 
         assert_raises(ValueError, mul)
 
-    def test_matrix_std_argmax(self,level=rlevel):
+    def test_matrix_std_argmax(self):
         # Ticket #83
         x = np.asmatrix(np.random.uniform(0, 1, (3, 3)))
         assert_equal(x.std().shape, ())


### PR DESCRIPTION
I don't know what that argument was used for, but it showis up in old
tests and is not explicitly used within the tests. I assume it was part
of an old testing framework and is now longer needed.