### PR TITLE
BUG: Fix problems with obj2sctype

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -57,6 +57,12 @@ This is not expected to cause problems, but possibly something has been left
 out. If you experience an unexpected import problem using ``numpy.testing``
 let us know.
 
+``np.asfarray`` no longer accepts non-dtypes through the ``dtype`` argument
+---------------------------------------------------------------------------
+This previously would accept ``dtype=some_array``, with the implied semantics
+of ``dtype=some_array.dtype``. This was undocumented, unique across the numpy
+functions, and if used would likely correspond to a typo.
+
 
 C API changes
 =============

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -63,6 +63,20 @@ This previously would accept ``dtype=some_array``, with the implied semantics
 of ``dtype=some_array.dtype``. This was undocumented, unique across the numpy
 functions, and if used would likely correspond to a typo.
 
+1D ``np.linalg.norm`` preserves float input types, even for arbitrary orders
+----------------------------------------------------------------------------
+Previously, this would promote to ``float64`` when arbitrary orders were
+passed, despite not doing so under the simple cases::
+
+    >>> f32 = np.float32([1, 2])
+    >>> np.linalg.norm(f32, 2.0).dtype
+    dtype('float32')
+    >>> np.linalg.norm(f32, 2.0001).dtype
+    dtype('float64')  # numpy 1.13
+    dtype('float32')  # numpy 1.14
+
+This change affects only ``float32`` and ``float16`` arrays.
+
 
 C API changes
 =============

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -528,27 +528,6 @@ def maximum_sctype(t):
     else:
         return sctypes[base][-1]
 
-try:
-    buffer_type = _types.BufferType
-except AttributeError:
-    # Py3K
-    buffer_type = memoryview
-
-_python_types = {int: 'int_',
-                 float: 'float_',
-                 complex: 'complex_',
-                 bool: 'bool_',
-                 bytes: 'bytes_',
-                 unicode: 'unicode_',
-                 buffer_type: 'void',
-                 }
-
-def _python_type(t):
-    """ Get a numpy scalar type corresponding to a Python type or value """
-    if not isinstance(t, type):
-        t = type(t)
-    return allTypes[_python_types.get(t, 'object_')]
-
 
 def issctype(rep):
     """
@@ -633,22 +612,19 @@ def obj2sctype(rep, default=None):
     <type 'list'>
 
     """
-    try:
-        if issubclass(rep, generic):
-            return rep
-    except TypeError:
-        pass
-    if isinstance(rep, dtype):
-        return rep.type
-    if isinstance(rep, type):
-        return _python_type(rep)
+    # prevent abtract classes being upcast
+    if isinstance(rep, type) and issubclass(rep, generic):
+        return rep
+    # extract dtype from arrays
     if isinstance(rep, ndarray):
         return rep.dtype.type
+    # fall back on dtype to convert
     try:
         res = dtype(rep)
     except Exception:
         return default
-    return res.type
+    else:
+        return res.type
 
 
 def issubclass_(arg1, arg2):

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.compat import long
 from numpy.testing import (
-    assert_, assert_equal, assert_array_equal, run_module_suite
+    assert_, assert_equal, assert_array_equal, run_module_suite, assert_raises
     )
 from numpy.lib.type_check import (
     common_type, mintypecode, isreal, iscomplex, isposinf, isneginf,
@@ -421,6 +421,12 @@ class TestArrayConversion(object):
         a = asfarray(np.array([1, 2, 3]))
         assert_equal(a.__class__, np.ndarray)
         assert_(np.issubdtype(a.dtype, float))
+
+        # previously this would infer dtypes from arrays, unlike every single
+        # other numpy function
+        assert_raises(TypeError,
+            asfarray, np.array([1, 2, 3]), dtype=np.array(1.0))
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -98,8 +98,7 @@ def asfarray(a, dtype=_nx.float_):
     array([ 2.,  3.])
 
     """
-    dtype = _nx.obj2sctype(dtype)
-    if not issubclass(dtype, _nx.inexact):
+    if not _nx.issubdtype(dtype, _nx.inexact):
         dtype = _nx.float_
     return asarray(a, dtype=dtype)
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2201,18 +2201,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 ord + 1
             except TypeError:
                 raise ValueError("Invalid norm order for vectors.")
-            if x.dtype.type is longdouble:
-                # Convert to a float type, so integer arrays give
-                # float results.  Don't apply asfarray to longdouble arrays,
-                # because it will downcast to float64.
-                absx = abs(x)
-            else:
-                absx = x if isComplexType(x.dtype.type) else asfarray(x)
-                if absx.dtype is x.dtype:
-                    absx = abs(absx)
-                else:
-                    # if the type changed, we can safely overwrite absx
-                    abs(absx, out=absx)
+            absx = abs(x)
             absx **= ord
             return add.reduce(absx, axis=axis, keepdims=keepdims) ** (1.0 / ord)
     elif len(axis) == 2:


### PR DESCRIPTION
Previously `obj2sctype(long) is None`, which conflicts with `np.dtype(long).type is np.int64`

If these use the same code path, then this won't happen.

Also, `obj2sctype` is not suitable for use in any public API, as it silently allows arrays to be passed in place of dtypes.