### PR TITLE
BUG: The NAT deprecation warning should not be given for every single value

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1287,6 +1287,7 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
+    npy_bool give_future_warning = 0;
     BINARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
@@ -1294,17 +1295,19 @@ NPY_NO_EXPORT void
         *((npy_bool *)op1) = res;
 
         if ((in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) && res) {
-            NPY_ALLOW_C_API_DEF
-            NPY_ALLOW_C_API;
-            /* 2016-01-18, 1.11 */
-            if (DEPRECATE_FUTUREWARNING(
-                    "In the future, 'NAT @OP@ x' and 'x @OP@ NAT' "
-                    "will always be False.") < 0) {
-                NPY_DISABLE_C_API;
-                return;
-            }
-            NPY_DISABLE_C_API;
+            give_future_warning = 1;
         }
+    }
+    if (give_future_warning) {
+        NPY_ALLOW_C_API_DEF
+        NPY_ALLOW_C_API;
+        /* 2016-01-18, 1.11 */
+        if (DEPRECATE_FUTUREWARNING(
+                "In the future, 'NAT @OP@ x' and 'x @OP@ NAT' "
+                "will always be False.") < 0) {
+            /* nothing to do, we return anyway */
+        }
+        NPY_DISABLE_C_API;
     }
 }
 /**end repeat1**/
@@ -1312,23 +1315,26 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_not_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
+    npy_bool give_future_warning = 0;
     BINARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
         *((npy_bool *)op1) = in1 != in2;
 
         if (in1 == NPY_DATETIME_NAT && in2 == NPY_DATETIME_NAT) {
-            NPY_ALLOW_C_API_DEF
-            NPY_ALLOW_C_API;
-            /* 2016-01-18, 1.11 */
-            if (DEPRECATE_FUTUREWARNING(
-                    "In the future, NAT != NAT will be True "
-                    "rather than False.") < 0) {
-                NPY_DISABLE_C_API;
-                return;
-            }
-            NPY_DISABLE_C_API;
+            give_future_warning = 1;
         }
+    }
+    if (give_future_warning) {
+        NPY_ALLOW_C_API_DEF
+        NPY_ALLOW_C_API;
+        /* 2016-01-18, 1.11 */
+        if (DEPRECATE_FUTUREWARNING(
+                "In the future, NAT != NAT will be True "
+                "rather than False.") < 0) {
+            /* nothing to do, we return anyway */
+        }
+        NPY_DISABLE_C_API;
     }
 }
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1133,6 +1133,18 @@ class TestDateTime(object):
             assert_(np.not_equal(td_other, td_nat))
             assert_equal(len(sup.log), 0)
 
+    def test_datetime_futurewarning_once_nat(self):
+        # Test that the futurewarning is only given once per inner loop
+        arr1 = np.array(['NaT', 'NaT', '2000-01-01'] * 2, dtype='M8[s]')
+        arr2 = np.array(['NaT', '2000-01-01', 'NaT'] * 2, dtype='M8[s]')
+        # All except less, because for less it can't be wrong (NaT is min)
+        for op in [np.equal, np.less, np.less_equal,
+                   np.greater, np.greater_equal]:
+            with suppress_warnings() as sup:
+                rec = sup.record(FutureWarning, ".*NAT")
+                op(arr1, arr2)
+                assert_(len(rec) == 1, "failed for {}".format(op))
+
     def test_datetime_minmax(self):
         # The metadata of the result should become the GCD
         # of the operand metadata


### PR DESCRIPTION
This fixes it so that it is at least only given for each inner loop run, which
admittingly slightly modifies the output on error (it will not stop at the first
NAT, but rather only after the first inner loop finished; this does not relaly
bother me though).

Closes gh-9528