### PR TITLE
DOC: Adding backslash between double-backtick and s.

### DIFF
--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -158,7 +158,7 @@ compiler's ``long double`` available as ``np.longdouble`` (and
 numpy provides with``np.finfo(np.longdouble)``.
 
 NumPy does not provide a dtype with more precision than C
-``long double``s; in particular, the 128-bit IEEE quad precision
+``long double``\s; in particular, the 128-bit IEEE quad precision
 data type (FORTRAN's ``REAL*16``) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored


### PR DESCRIPTION
For some reason unknown to me, this is not allowed in Sphinx.

In the currently [rendered docs][1], it makes the `<code>` (rather `<tt>`) element continue for the whole line:

![screenshot from 2017-08-11 12-06-08](https://user-images.githubusercontent.com/520669/29228130-7907211e-7e8d-11e7-9641-3f1c79dae059.png)

If a space or hyphen is used, it can look as desired (see [simple gist][2]):

![screenshot from 2017-08-11 12-06-46](https://user-images.githubusercontent.com/520669/29228168-91f277d2-7e8d-11e7-8cff-ee6e6141602c.png)

[1]: https://docs.scipy.org/doc/numpy-dev/user/basics.types.html
[2]: https://gist.github.com/dhermes/95158b647c30f368bcb0592752e585f9