### PR TITLE
MAINT: Use the error_converting macro where possible

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -11,6 +11,7 @@
 #include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "lowlevel_strided_loops.h" /* for npy_bswap8 */
 #include "alloc.h"
+#include "common.h"
 
 
 /*
@@ -580,7 +581,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     }
     else {
         lval = PyFloat_AsDouble(left);
-        if ((lval == -1) && PyErr_Occurred()) {
+        if (error_converting(lval)) {
             goto fail;
         }
     }
@@ -589,7 +590,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     }
     else {
         rval = PyFloat_AsDouble(right);
-        if ((rval == -1) && PyErr_Occurred()) {
+        if (error_converting(rval)) {
             goto fail;
         }
     }
@@ -736,11 +737,11 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     }
     else {
         lval.real = PyComplex_RealAsDouble(left);
-        if ((lval.real == -1) && PyErr_Occurred()) {
+        if (error_converting(lval.real)) {
             goto fail;
         }
         lval.imag = PyComplex_ImagAsDouble(left);
-        if ((lval.imag == -1) && PyErr_Occurred()) {
+        if (error_converting(lval.imag)) {
             goto fail;
         }
     }
@@ -750,11 +751,11 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     }
     else {
         rval.real = PyComplex_RealAsDouble(right);
-        if ((rval.real == -1) && PyErr_Occurred()) {
+        if (error_converting(rval.real)) {
             goto fail;
         }
         rval.imag = PyComplex_ImagAsDouble(right);
-        if ((rval.imag == -1) && PyErr_Occurred()) {
+        if (error_converting(rval.imag)) {
             goto fail;
         }
     }

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -13,6 +13,7 @@
 
 #include "npy_pycompat.h"
 
+#include "common.h"
 #include "arrayobject.h"
 #include "ctors.h"
 #include "mapping.h"
@@ -411,7 +412,7 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
     else if (PyLong_Check(obj) || PyInt_Check(obj)) {
         /* Try long long before unsigned long long */
         npy_longlong ll_v = PyLong_AsLongLong(obj);
-        if (ll_v == -1 && PyErr_Occurred()) {
+        if (error_converting(ll_v)) {
             /* Long long failed, try unsigned long long */
             npy_ulonglong ull_v;
             PyErr_Clear();
@@ -441,7 +442,7 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
     /* Python float */
     else if (PyFloat_Check(obj)) {
         npy_double v = PyFloat_AsDouble(obj);
-        if (v == -1 && PyErr_Occurred()) {
+        if (error_converting(v)) {
             return -1;
         }
         value = (char *)value_buffer;
@@ -457,11 +458,11 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
         npy_double re, im;
 
         re = PyComplex_RealAsDouble(obj);
-        if (re == -1 && PyErr_Occurred()) {
+        if (error_converting(re)) {
             return -1;
         }
         im = PyComplex_ImagAsDouble(obj);
-        if (im == -1 && PyErr_Occurred()) {
+        if (error_converting(im)) {
             return -1;
         }
         value = (char *)value_buffer;

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -20,6 +20,7 @@
 #include "npy_config.h"
 #include "npy_pycompat.h"
 
+#include "common.h"
 #include "numpy/arrayscalars.h"
 #include "methods.h"
 #include "_datetime.h"
@@ -1854,13 +1855,13 @@ convert_datetime_metadata_tuple_to_datetime_metadata(PyObject *tuple,
 
     /* Convert the values to longs */
     out_meta->num = PyInt_AsLong(PyTuple_GET_ITEM(tuple, 1));
-    if (out_meta->num == -1 && PyErr_Occurred()) {
+    if (error_converting(out_meta->num)) {
         return -1;
     }
 
     if (tuple_size == 4) {
         den = PyInt_AsLong(PyTuple_GET_ITEM(tuple, 2));
-        if (den == -1 && PyErr_Occurred()) {
+        if (error_converting(den)) {
             return -1;
         }
     }
@@ -2127,7 +2128,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->year = PyInt_AsLong(tmp);
-    if (out->year == -1 && PyErr_Occurred()) {
+    if (error_converting(out->year)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2139,7 +2140,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->month = PyInt_AsLong(tmp);
-    if (out->month == -1 && PyErr_Occurred()) {
+    if (error_converting(out->month)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2151,7 +2152,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->day = PyInt_AsLong(tmp);
-    if (out->day == -1 && PyErr_Occurred()) {
+    if (error_converting(out->day)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2185,7 +2186,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->hour = PyInt_AsLong(tmp);
-    if (out->hour == -1 && PyErr_Occurred()) {
+    if (error_converting(out->hour)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2197,7 +2198,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->min = PyInt_AsLong(tmp);
-    if (out->min == -1 && PyErr_Occurred()) {
+    if (error_converting(out->min)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2209,7 +2210,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->sec = PyInt_AsLong(tmp);
-    if (out->sec == -1 && PyErr_Occurred()) {
+    if (error_converting(out->sec)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2221,7 +2222,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
         return -1;
     }
     out->us = PyInt_AsLong(tmp);
-    if (out->us == -1 && PyErr_Occurred()) {
+    if (error_converting(out->us)) {
         Py_DECREF(tmp);
         return -1;
     }
@@ -2272,7 +2273,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
                 return -1;
             }
             seconds_offset = PyInt_AsLong(tmp);
-            if (seconds_offset == -1 && PyErr_Occurred()) {
+            if (error_converting(seconds_offset)) {
                 Py_DECREF(tmp);
                 return -1;
             }
@@ -2695,7 +2696,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             return -1;
         }
         days = PyLong_AsLongLong(tmp);
-        if (days == -1 && PyErr_Occurred()) {
+        if (error_converting(days)) {
             Py_DECREF(tmp);
             return -1;
         }
@@ -2707,7 +2708,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             return -1;
         }
         seconds = PyInt_AsLong(tmp);
-        if (seconds == -1 && PyErr_Occurred()) {
+        if (error_converting(seconds)) {
             Py_DECREF(tmp);
             return -1;
         }
@@ -2719,7 +2720,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             return -1;
         }
         useconds = PyInt_AsLong(tmp);
-        if (useconds == -1 && PyErr_Occurred()) {
+        if (error_converting(useconds)) {
             Py_DECREF(tmp);
             return -1;
         }

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -18,6 +18,7 @@
 #include "npy_config.h"
 #include "npy_pycompat.h"
 
+#include "common.h"
 #include "numpy/arrayscalars.h"
 #include "lowlevel_strided_loops.h"
 #include "_datetime.h"
@@ -168,7 +169,7 @@ invalid_weekmask_string:
                 }
 
                 val = PyInt_AsLong(f);
-                if (val == -1 && PyErr_Occurred()) {
+                if (error_converting(val)) {
                     Py_DECREF(f);
                     Py_DECREF(obj);
                     return 0;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1131,7 +1131,7 @@ _convert_from_dict(PyObject *obj, int align)
                 goto fail;
             }
             offset = PyArray_PyIntAsInt(off);
-            if (offset == -1 && PyErr_Occurred()) {
+            if (error_converting(offset)) {
                 Py_DECREF(off);
                 Py_DECREF(tup);
                 Py_DECREF(ind);
@@ -1270,7 +1270,7 @@ _convert_from_dict(PyObject *obj, int align)
         PyErr_Clear();
     } else {
         itemsize = (int)PyArray_PyIntAsInt(tmp);
-        if (itemsize == -1 && PyErr_Occurred()) {
+        if (error_converting(itemsize)) {
             Py_DECREF(new);
             return NULL;
         }

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -926,7 +926,7 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
         goto skip;
     }
     start = PyArray_PyIntAsIntp(ind);
-    if (start==-1 && PyErr_Occurred()) {
+    if (error_converting(start)) {
         PyErr_Clear();
     }
     else {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -472,7 +472,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
 #endif
                 npy_intp ind = PyArray_PyIntAsIntp(obj);
 
-                if ((ind == -1) && PyErr_Occurred()) {
+                if (error_converting(ind)) {
                     PyErr_Clear();
                 }
                 else {
@@ -643,7 +643,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
                 npy_intp ind = PyArray_PyIntAsIntp((PyObject *)arr);
 
                 Py_DECREF(arr);
-                if ((ind == -1) && PyErr_Occurred()) {
+                if (error_converting(ind)) {
                     goto failed_building_indices;
                 }
                 else {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -639,7 +639,7 @@ array_toscalar(PyArrayObject *self, PyObject *args)
         npy_intp value, size = PyArray_SIZE(self);
 
         value = PyArray_PyIntAsIntp(PyTuple_GET_ITEM(args, 0));
-        if (value == -1 && PyErr_Occurred()) {
+        if (error_converting(value)) {
             return NULL;
         }
 
@@ -659,7 +659,7 @@ array_toscalar(PyArrayObject *self, PyObject *args)
 
         for (idim = 0; idim < ndim; ++idim) {
             value = PyArray_PyIntAsIntp(PyTuple_GET_ITEM(args, idim));
-            if (value == -1 && PyErr_Occurred()) {
+            if (error_converting(value)) {
                 return NULL;
             }
             multi_index[idim] = value;
@@ -716,7 +716,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
         npy_intp value, size = PyArray_SIZE(self);
 
         value = PyArray_PyIntAsIntp(PyTuple_GET_ITEM(args, 0));
-        if (value == -1 && PyErr_Occurred()) {
+        if (error_converting(value)) {
             return NULL;
         }
 
@@ -736,7 +736,7 @@ array_setscalar(PyArrayObject *self, PyObject *args)
 
         for (idim = 0; idim < ndim; ++idim) {
             value = PyArray_PyIntAsIntp(PyTuple_GET_ITEM(args, idim));
-            if (value == -1 && PyErr_Occurred()) {
+            if (error_converting(value)) {
                 return NULL;
             }
             multi_index[idim] = value;

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -5,6 +5,7 @@
 #include "numpy/arrayobject.h"
 #include "mem_overlap.h"
 #include "npy_extint128.h"
+#include "common.h"
 
 /* test PyArray_IsPythonScalar, before including private py3 compat header */
 static PyObject *
@@ -1000,11 +1001,11 @@ array_solve_diophantine(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject 
 
     for (j = 0; j < nterms; ++j) {
         terms[j].a = (npy_int64)PyInt_AsSsize_t(PyTuple_GET_ITEM(A, j));
-        if (terms[j].a == -1 && PyErr_Occurred()) {
+        if (error_converting(terms[j].a)) {
             goto fail;
         }
         terms[j].ub = (npy_int64)PyInt_AsSsize_t(PyTuple_GET_ITEM(U, j));
-        if (terms[j].ub == -1 && PyErr_Occurred()) {
+        if (error_converting(terms[j].ub)) {
             goto fail;
         }
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1662,7 +1662,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
             ndmin_obj = PyDict_GetItem(kws, npy_ma_str_ndmin);
             if (ndmin_obj) {
                 ndmin = PyLong_AsLong(ndmin_obj);
-                if (ndmin == -1 && PyErr_Occurred()) {
+                if (error_converting(ndmin)) {
                     goto clean_type;
                 }
                 else if (ndmin > NPY_MAXDIMS) {

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -16,6 +16,7 @@
 #include "npy_config.h"
 #include "npy_pycompat.h"
 #include "alloc.h"
+#include "common.h"
 
 typedef struct NewNpyArrayIterObject_tag NewNpyArrayIterObject;
 
@@ -1619,7 +1620,7 @@ npyiter_multi_index_set(NewNpyArrayIterObject *self, PyObject *value)
         for (idim = 0; idim < ndim; ++idim) {
             PyObject *v = PySequence_GetItem(value, idim);
             multi_index[idim] = PyInt_AsLong(v);
-            if (multi_index[idim]==-1 && PyErr_Occurred()) {
+            if (error_converting(multi_index[idim])) {
                 Py_XDECREF(v);
                 return -1;
             }
@@ -1679,7 +1680,7 @@ static int npyiter_index_set(NewNpyArrayIterObject *self, PyObject *value)
     if (NpyIter_HasIndex(self->iter)) {
         npy_intp ind;
         ind = PyInt_AsLong(value);
-        if (ind==-1 && PyErr_Occurred()) {
+        if (error_converting(ind)) {
             return -1;
         }
         if (NpyIter_GotoIndex(self->iter, ind) != NPY_SUCCEED) {
@@ -1729,7 +1730,7 @@ static int npyiter_iterindex_set(NewNpyArrayIterObject *self, PyObject *value)
     }
 
     iterindex = PyInt_AsLong(value);
-    if (iterindex==-1 && PyErr_Occurred()) {
+    if (error_converting(iterindex)) {
         return -1;
     }
     if (NpyIter_GotoIterIndex(self->iter, iterindex) != NPY_SUCCEED) {
@@ -2257,7 +2258,7 @@ npyiter_subscript(NewNpyArrayIterObject *self, PyObject *op)
     if (PyInt_Check(op) || PyLong_Check(op) ||
                     (PyIndex_Check(op) && !PySequence_Check(op))) {
         npy_intp i = PyArray_PyIntAsIntp(op);
-        if (i == -1 && PyErr_Occurred()) {
+        if (error_converting(i)) {
             return NULL;
         }
         return npyiter_seq_item(self, i);
@@ -2306,7 +2307,7 @@ npyiter_ass_subscript(NewNpyArrayIterObject *self, PyObject *op,
     if (PyInt_Check(op) || PyLong_Check(op) ||
                     (PyIndex_Check(op) && !PySequence_Check(op))) {
         npy_intp i = PyArray_PyIntAsIntp(op);
-        if (i == -1 && PyErr_Occurred()) {
+        if (error_converting(i)) {
             return -1;
         }
         return npyiter_seq_ass_item(self, i, value);

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -445,7 +445,7 @@ is_scalar_with_conversion(PyObject *o2, double* out_exponent)
             return NPY_NOSCALAR;
         }
         val = PyInt_AsSsize_t(value);
-        if (val == -1 && PyErr_Occurred()) {
+        if (error_converting(val)) {
             PyErr_Clear();
             return NPY_NOSCALAR;
         }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -415,7 +415,7 @@ PyArray_ScalarFromObject(PyObject *object)
     else if (PyLong_Check(object)) {
         npy_longlong val;
         val = PyLong_AsLongLong(object);
-        if (val==-1 && PyErr_Occurred()) {
+        if (error_converting(val)) {
             PyErr_Clear();
             return NULL;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -244,7 +244,7 @@ gentype_multiply(PyObject *m1, PyObject *m2)
              (Py_TYPE(m1)->tp_as_number->nb_multiply == NULL))) {
         /* Try to convert m2 to an int and try sequence repeat */
         repeat = PyArray_PyIntAsIntp(m2);
-        if (repeat == -1 && PyErr_Occurred()) {
+        if (error_converting(repeat)) {
             return NULL;
         }
         /* Note that npy_intp is compatible to Py_Ssize_t */
@@ -257,7 +257,7 @@ gentype_multiply(PyObject *m1, PyObject *m2)
              (Py_TYPE(m2)->tp_as_number->nb_multiply == NULL))) {
         /* Try to convert m1 to an int and try sequence repeat */
         repeat = PyArray_PyIntAsIntp(m1);
-        if (repeat == -1 && PyErr_Occurred()) {
+        if (error_converting(repeat)) {
             return NULL;
         }
         return PySequence_Repeat(m2, repeat);

--- a/numpy/core/src/umath/extobj.c
+++ b/numpy/core/src/umath/extobj.c
@@ -14,6 +14,7 @@
 #include "numpy/ufuncobject.h"
 
 #include "ufunc_object.h"  /* for npy_um_str_pyvals_name */
+#include "common.h"
 
 #if USE_USE_DEFAULTS==1
 static int PyUFunc_NUM_NODEFAULTS = 0;
@@ -209,7 +210,7 @@ _extract_pyvals(PyObject *ref, const char *name, int *bufsize,
 
     if (bufsize != NULL) {
         *bufsize = PyInt_AsLong(PyList_GET_ITEM(ref, 0));
-        if ((*bufsize == -1) && PyErr_Occurred()) {
+        if (error_converting(*bufsize)) {
             return -1;
         }
         if ((*bufsize < NPY_MIN_BUFSIZE) ||

--- a/numpy/core/src/umath/test_rational.c.src
+++ b/numpy/core/src/umath/test_rational.c.src
@@ -9,6 +9,9 @@
 #include <numpy/npy_3kcompat.h>
 #include <math.h>
 
+#include "common.h"  /* for error_converting */
+
+
 /* Relevant arithmetic exceptions */
 
 /* Uncomment the following line to work around a bug in numpy */
@@ -425,7 +428,7 @@ pyrational_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
         PyObject* y;
         int eq;
         n[i] = PyInt_AsLong(x[i]);
-        if (n[i]==-1 && PyErr_Occurred()) {
+        if (error_converting(n[i])) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_Format(PyExc_TypeError,
                         "expected integer %s, got %s",
@@ -473,7 +476,7 @@ pyrational_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
             PyObject* y_; \
             int eq_; \
             long n_ = PyInt_AsLong(object); \
-            if (n_==-1 && PyErr_Occurred()) { \
+            if (error_converting(n_)) { \
                 if (PyErr_ExceptionMatches(PyExc_TypeError)) { \
                     PyErr_Clear(); \
                     Py_INCREF(Py_NotImplemented); \
@@ -750,7 +753,7 @@ npyrational_setitem(PyObject* item, void* data, void* arr) {
         long n = PyInt_AsLong(item);
         PyObject* y;
         int eq;
-        if (n==-1 && PyErr_Occurred()) {
+        if (error_converting(n)) {
             return -1;
         }
         y = PyInt_FromLong(n);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -47,6 +47,7 @@
 #include "override.h"
 #include "npy_import.h"
 #include "extobj.h"
+#include "common.h"
 
 /********** PRINTF DEBUG TRACING **************/
 #define NPY_UF_DBG_TRACING 0
@@ -3770,7 +3771,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
         for (i = 0; i < naxes; ++i) {
             PyObject *tmp = PyTuple_GET_ITEM(axes_in, i);
             int axis = PyArray_PyIntAsInt(tmp);
-            if (axis == -1 && PyErr_Occurred()) {
+            if (error_converting(axis)) {
                 Py_XDECREF(otype);
                 Py_DECREF(mp);
                 return NULL;
@@ -3787,7 +3788,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     else {
         int axis = PyArray_PyIntAsInt(axes_in);
         /* TODO: PyNumber_Index would be good to use here */
-        if (axis == -1 && PyErr_Occurred()) {
+        if (error_converting(axis)) {
             Py_XDECREF(otype);
             Py_DECREF(mp);
             return NULL;


### PR DESCRIPTION
If we have the macro, we may as well use it.

Note that we can't use this macro on unsigned types.