### PR TITLE
DOC: removes broken docstring example (source code, png, pdf) links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -126,6 +126,8 @@ htmlhelp_basename = 'numpy'
 pngmath_use_preview = True
 pngmath_dvipng_args = ['-gamma', '1.5', '-D', '96', '-bg', 'Transparent']
 
+plot_html_show_formats = False
+plot_html_show_source_link = False
 
 # -----------------------------------------------------------------------------
 # LaTeX output


### PR DESCRIPTION
Fixes issue #9500. Currently the (source code, png, pdf) links for docstring examples are pointing to missing files and give 404 errors. This commit removes those links by modifying `doc/source/conf.py`.