### PR TITLE
DOC, BUG: Fix Python 3.6 invalid escape sequence.

### DIFF
--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -158,8 +158,8 @@ compiler's ``long double`` available as ``np.longdouble`` (and
 numpy provides with ``np.finfo(np.longdouble)``.
 
 NumPy does not provide a dtype with more precision than C
-``long double``\s; in particular, the 128-bit IEEE quad precision
-data type (FORTRAN's ``REAL*16``\) is not available.
+``long double``\\s; in particular, the 128-bit IEEE quad precision
+data type (FORTRAN's ``REAL*16``\\) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored
 padded with zero bits, either to 96 or 128 bits. Which is more efficient


### PR DESCRIPTION
The rst markup in numpy/doc/basics.py uses `\s`, which is interpreted by
python 3.6 as a deprecated escape sequence. Fix by escaping the `\`.

Closes #9551.

[ci skip]