### PR TITLE
BUG: fix regression in 1.13.x in distutils.mingw32ccompiler.

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -265,7 +265,7 @@ def find_python_dll():
     lib_dirs = []
     for stem in stems:
         for folder in sub_dirs:
-            lib_dirs = os.path.join(stem, folder)
+            lib_dirs.append(os.path.join(stem, folder))
 
     # add system directory as well
     if 'SYSTEMROOT' in os.environ:


### PR DESCRIPTION
Issue was introduced in gh-8454.

Thanks to @jennirinker for pointing out the issue and fix.  Closes gh-9553.