### PR TITLE
BUG: fix regression in 1.13.x in distutils.mingw32ccompiler.

### DIFF
--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -5,7 +5,8 @@ import sys
 import numpy as np
 from numpy.core.multiarray import _vec_string
 from numpy.testing import (
-    TestCase, run_module_suite, assert_, assert_equal, assert_array_equal
+    TestCase, run_module_suite, assert_, assert_equal, assert_array_equal,
+    suppress_warnings,
 )
 
 kw_unicode_true = {'unicode': True}  # make 2to3 work properly
@@ -346,8 +347,11 @@ class TestMethods(TestCase):
             A = np.char.array([b'\\u03a3'])
             assert_(A.decode('unicode-escape')[0] == '\u03a3')
         else:
-            A = np.char.array(['736563726574206d657373616765'])
-            assert_(A.decode('hex_codec')[0] == 'secret message')
+            with suppress_warnings() as sup:
+                if sys.py3kwarning:
+                    sup.filter(DeprecationWarning, "'hex_codec'")
+                A = np.char.array(['736563726574206d657373616765'])
+                assert_(A.decode('hex_codec')[0] == 'secret message')
 
     def test_encode(self):
         B = self.B.encode('unicode_escape')

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -265,7 +265,7 @@ def find_python_dll():
     lib_dirs = []
     for stem in stems:
         for folder in sub_dirs:
-            lib_dirs = os.path.join(stem, folder)
+            lib_dirs.append(os.path.join(stem, folder))
 
     # add system directory as well
     if 'SYSTEMROOT' in os.environ:


### PR DESCRIPTION
Backport of #9554.

Issue was introduced in gh-8454.

Thanks to @jennirinker for pointing out the issue and fix.  Closes gh-9553.