### PR TITLE
BUG: fix distutils/cpuinfo.py:getoutput()

### DIFF
--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -35,7 +35,7 @@ def getoutput(cmd, successful_status=(0,), stacklevel=1):
     except EnvironmentError:
         e = get_exception()
         warnings.warn(str(e), UserWarning, stacklevel=stacklevel)
-        return False, output
+        return False, ""
     if os.WIFEXITED(status) and os.WEXITSTATUS(status) in successful_status:
         return True, output
     return False, output


### PR DESCRIPTION
If `getstatusoutput()` throws an exception, `getoutput()` tries to catch it,
but then crashes with:

    UnboundLocalError: local variable 'output' referenced before assignment

because it tries to return the non-existent result of `getstatusoutput()`.