### PR TITLE
DOC: added info on shape property

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2920,12 +2920,15 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('real',
 add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     """
     Tuple of array dimensions.
-
+    
+    As with `numpy.reshape`, one shape dimension can be -1. In this case, the value is 
+    inferred from the length of the array and remaining dimensions.
     Notes
     -----
     May be used to "reshape" the array, as long as this would not
     require a change in the total number of elements
-
+    Using `numpy.reshape` or `ndarray.reshape` should always be preferred.
+    Setting the shape directly is not really a safe thing to do.
     Examples
     --------
     >>> x = np.array([1, 2, 3, 4])
@@ -2943,6 +2946,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     ValueError: total size of new array must be unchanged
+    See Also
+    --------
+    numpy.reshape : equivalent function    
+    ndarray.reshape : equivalent function 
 
     """))
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2921,8 +2921,14 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     """
     Tuple of array dimensions.
     
-    As with `numpy.reshape`, one shape dimension can be -1. In this case, the value is 
-    inferred from the length of the array and remaining dimensions.
+    This is usually used to get at the shape of an ndarray. However, the
+    array may also be reshaped by assigning a different tuple to this
+    attribute.  As with `numpy.reshape`, one of the new shape dimension
+    can be -1, in which case, its value is inferred from the length of the
+    array and remaining dimensions. This method of reshaping an arrau is
+    not recommended, both because it can fail and because it affects any
+    code holding a reference to the array in an indirect way.
+    
     Notes
     -----
     May be used to "reshape" the array, as long as this would not

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2921,13 +2921,13 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     """
     Tuple of array dimensions.
     
-    This is usually used to get at the shape of an ndarray. However, the
-    array may also be reshaped by assigning a different tuple to this
-    attribute.  As with `numpy.reshape`, one of the new shape dimension
-    can be -1, in which case, its value is inferred from the length of the
-    array and remaining dimensions. This method of reshaping an arrau is
-    not recommended, both because it can fail and because it affects any
-    code holding a reference to the array in an indirect way.
+    The shape attribute is usually used to get at the shape of an ndarray.
+    However, the array may also be reshaped by assigning a different tuple
+    to this attribute.  As with `numpy.reshape`, one of the new shape
+    dimensions can be -1, in which case its value is inferred from the
+    length of the array and remaining dimensions. This method of reshaping
+    an arrau is not recommended, both because it can fail, and because it
+    affects any code holding a reference to the array in an indirect way.
     
     Notes
     -----

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2926,7 +2926,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     to this attribute.  As with `numpy.reshape`, one of the new shape
     dimensions can be -1, in which case its value is inferred from the
     length of the array and remaining dimensions. This method of reshaping
-    an arrau is not recommended, both because it can fail, and because it
+    an array is not recommended, both because it can fail, and because it
     affects any code holding a reference to the array in an indirect way.
     
     Notes


### PR DESCRIPTION
If someone has more in insight on why it is better not to use y.shape = () directly, please edit the PR.
