### PR TITLE
BUG: deal with broken hypot() for MSVC on win32

### DIFF
--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -1,0 +1,54 @@
+"""
+Pytest configuration and fixtures for the Numpy test suite.
+"""
+from __future__ import division, absolute_import, print_function
+
+import warnings
+import pytest
+
+from numpy.core.multiarray_tests import get_fpu_mode
+
+
+_old_fpu_mode = None
+_collect_results = {}
+
+
+@pytest.hookimpl()
+def pytest_itemcollected(item):
+    """
+    Check FPU precision mode was not changed during test collection.
+
+    The clumsy way we do it here is mainly necessary because numpy
+    still uses yield tests, which can execute code at test collection 
+    time.
+    """
+    global _old_fpu_mode
+
+    mode = get_fpu_mode()
+
+    if _old_fpu_mode is None:
+        _old_fpu_mode = mode
+    elif mode != _old_fpu_mode:
+        _collect_results[item] = (_old_fpu_mode, mode)
+        _old_fpu_mode = mode
+
+
+@pytest.fixture(scope="function", autouse=True)
+def check_fpu_mode(request):
+    """
+    Check FPU precision mode was not changed during the test.
+    """
+    old_mode = get_fpu_mode()
+    yield
+    new_mode = get_fpu_mode()
+
+    if old_mode != new_mode:
+        raise AssertionError("FPU precision mode changed from {0:#x} to {1:#x}"
+                             " during the test".format(old_mode, new_mode))
+
+    collect_result = _collect_results.get(request.node)
+    if collect_result is not None:
+        old_mode, new_mode = collect_result
+        raise AssertionError("FPU precision mode changed from {0:#x} to {1:#x}"
+                             " when collecting the test".format(old_mode, 
+                                                                new_mode))

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -1560,6 +1560,37 @@ extint_ceildiv_128_64(PyObject *NPY_UNUSED(self), PyObject *args) {
 }
 
 
+static char get_fpu_mode_doc[] = (
+    "get_fpu_mode()\n"
+    "\n"
+    "Get the current FPU control word, in a platform-dependent format.\n"
+    "Returns None if not implemented on current platform.");
+
+static PyObject *
+get_fpu_mode(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+
+#if defined(_MSC_VER)
+    {
+        unsigned int result = 0;
+        result = _controlfp(0, 0);
+        return PyLong_FromLongLong(result);
+    }
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+    {
+        unsigned short cw = 0;
+        __asm__("fstcw %w0" : "=m" (cw));
+        return PyLong_FromLongLong(cw);
+    }
+#else
+    return Py_RETURN_NONE;
+#endif
+}
+
+
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"IsPythonScalar",
         IsPythonScalar,
@@ -1650,6 +1681,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"extint_ceildiv_128_64",
         extint_ceildiv_128_64,
         METH_VARARGS, NULL},
+    {"get_fpu_mode",
+        get_fpu_mode,
+        METH_VARARGS, get_fpu_mode_doc},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -62,6 +62,15 @@
 
 #endif
 
+/* MSVC _hypot messes with fp precision mode on 32-bit, see gh-9567 */
+#if defined(_MSC_VER) && (_MSC_VER >= 1900) && !defined(_WIN64)
+
+#undef HAVE_HYPOT
+#undef HAVE_HYPOTF
+#undef HAVE_HYPOTL
+
+#endif
+
 
 /* Intel C for Windows uses POW for 64 bits longdouble*/
 #if defined(_MSC_VER) && defined(__INTEL_COMPILER)


### PR DESCRIPTION
Blacklist hypot() for MSVC on win32, because it appears to change 
the FPU precision mode.

To be sure that nothing else in numpy messes with the FPU mode, check 
in all tests in the testsuite that the FPU mode was not changed. The
MSVC bug will manifest (I tested this) as a test failure. I also added the 
corresponding pytest checks, for future.

Fixes: gh-9567

Example failures:
```
nose:

======================================================================
FAIL: numpy.core.tests.test_umath.TestHypotSpecialValues.test_nan_outputs
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\pauli\src\numpy\build\testenv\Lib\site-packages\numpy\testing\nose_tools\noseclasses.
py", line 339, in run
    "test".format(old_mode, new_mode))
AssertionError: FPU mode changed from 0x9001f to 0xc001f during the test


pytest:

________ ERROR at teardown of TestHypotSpecialValues.test_nan_outputs _________

request = <SubRequest 'check_fpu_mode' for <Function 'test_nan_outputs'>>

    @pytest.fixture(scope="function", autouse=True)
    def check_fpu_mode(request):
        """
        Check FPU precision mode was not changed during the test.
        """
        old_mode = get_fpu_mode()
        yield
        new_mode = get_fpu_mode()

        if old_mode != new_mode:
            raise AssertionError("FPU precision mode changed from {0:#x} to {1:#x}"
>                                " during the test".format(old_mode, new_mode))
E           AssertionError: FPU precision mode changed from 0x9001f to 0xc001f during the test

..\build\testenv\Lib\site-packages\numpy\conftest.py:47: AssertionError
```