### PR TITLE
ENH: Add broadcasting to randint

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -108,6 +108,10 @@ the result is always a view on the original masked array.
 This breaks any code that used ``masked_arr.squeeze() is np.ma.masked``, but
 fixes code that writes to the result of `.squeeze()`.
 
+Broadcasting for ``randint``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is now possible to broadcast both the ``low`` and ``high`` arguments in
+``np.random.randint``.
 
 C API changes
 =============

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -82,10 +82,14 @@ cdef extern from "randomkit.h":
     void rk_random_bool_fill(npy_bool off, npy_bool rng, npy_intp cnt,
                              npy_bool *out, rk_state *state) nogil
     npy_uint64 rk_random_uint64(npy_uint64 off, npy_uint64 rng, rk_state *state) nogil
-    npy_uint32 rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
-    npy_uint16 rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
-    npy_uint8 rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
-    npy_bool rk_random_bool(npy_bool off, npy_bool rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
+    npy_uint32 rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_uint32 *buf,
+                                int *bcnt, rk_state *state) nogil
+    npy_uint16 rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_uint32 *buf,
+                                int *bcnt, rk_state *state) nogil
+    npy_uint8 rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_uint32 *buf,
+                              int *bcnt, rk_state *state) nogil
+    npy_bool rk_random_bool(npy_bool off, npy_bool rng, npy_uint32 *buf,
+                            int *bcnt, rk_state *state) nogil
 
 
 cdef extern from "distributions.h":
@@ -583,15 +587,15 @@ def _shape_from_size(size, d):
 # type, ubnd is one greater than the largest value, and func is the
 # function to call.
 _randint_type = {
-    'bool': (0, 2, _rand_bool_TEST),
-    'int8': (-2**7, 2**7, _rand_int8_TEST),
-    'int16': (-2**15, 2**15, _rand_int16_TEST),
-    'int32': (-2**31, 2**31, _rand_int32_TEST),
-    'int64': (-2**63, 2**63, _rand_int64_TEST),
-    'uint8': (0, 2**8, _rand_uint8_TEST),
-    'uint16': (0, 2**16, _rand_uint16_TEST),
-    'uint32': (0, 2**32, _rand_uint32_TEST),
-    'uint64': (0, 2**64, _rand_uint64_TEST)
+    'bool': (0, 2, _rand_bool),
+    'int8': (-2**7, 2**7, _rand_int8),
+    'int16': (-2**15, 2**15, _rand_int16),
+    'int32': (-2**31, 2**31, _rand_int32),
+    'int64': (-2**63, 2**63, _rand_int64),
+    'uint8': (0, 2**8, _rand_uint8),
+    'uint16': (0, 2**16, _rand_uint16),
+    'uint32': (0, 2**32, _rand_uint32),
+    'uint64': (0, 2**64, _rand_uint64)
     }
 
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -71,16 +71,16 @@ cdef extern from "randomkit.h":
     rk_error rk_altfill(void *buffer, size_t size, int strong,
             rk_state *state) nogil
     double rk_gauss(rk_state *state) nogil
-    void rk_random_uint64(npy_uint64 off, npy_uint64 rng, npy_intp cnt,
-                          npy_uint64 *out, rk_state *state) nogil
-    void rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_intp cnt,
-                          npy_uint32 *out, rk_state *state) nogil
-    void rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_intp cnt,
-                          npy_uint16 *out, rk_state *state) nogil
-    void rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_intp cnt,
-                         npy_uint8 *out, rk_state *state) nogil
-    void rk_random_bool(npy_bool off, npy_bool rng, npy_intp cnt,
-                        npy_bool *out, rk_state *state) nogil
+    void rk_random_uint64_fill(npy_uint64 off, npy_uint64 rng, npy_intp cnt,
+                               npy_uint64 *out, rk_state *state) nogil
+    void rk_random_uint32_fill(npy_uint32 off, npy_uint32 rng, npy_intp cnt,
+                               npy_uint32 *out, rk_state *state) nogil
+    void rk_random_uint16_fill(npy_uint16 off, npy_uint16 rng, npy_intp cnt,
+                               npy_uint16 *out, rk_state *state) nogil
+    void rk_random_uint8_fill(npy_uint8 off, npy_uint8 rng, npy_intp cnt,
+                              npy_uint8 *out, rk_state *state) nogil
+    void rk_random_bool_fill(npy_bool off, npy_bool rng, npy_intp cnt,
+                             npy_bool *out, rk_state *state) nogil
 
 
 cdef extern from "distributions.h":

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -22,8 +22,8 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include "Python.pxi"
-include "randint_helpers.pxi"
 include "numpy.pxd"
+include "randint_helpers.pxi"
 include "cpython/pycapsule.pxd"
 
 from libc cimport string
@@ -81,6 +81,11 @@ cdef extern from "randomkit.h":
                               npy_uint8 *out, rk_state *state) nogil
     void rk_random_bool_fill(npy_bool off, npy_bool rng, npy_intp cnt,
                              npy_bool *out, rk_state *state) nogil
+    npy_uint64 rk_random_uint64(npy_uint64 off, npy_uint64 rng, rk_state *state) nogil
+    npy_uint32 rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
+    npy_uint16 rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
+    npy_uint8 rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
+    npy_bool rk_random_bool(npy_bool off, npy_bool rng, npy_uint32 *buf, int *bcnt, rk_state *state) nogil
 
 
 cdef extern from "distributions.h":
@@ -578,15 +583,15 @@ def _shape_from_size(size, d):
 # type, ubnd is one greater than the largest value, and func is the
 # function to call.
 _randint_type = {
-    'bool': (0, 2, _rand_bool),
-    'int8': (-2**7, 2**7, _rand_int8),
-    'int16': (-2**15, 2**15, _rand_int16),
-    'int32': (-2**31, 2**31, _rand_int32),
-    'int64': (-2**63, 2**63, _rand_int64),
-    'uint8': (0, 2**8, _rand_uint8),
-    'uint16': (0, 2**16, _rand_uint16),
-    'uint32': (0, 2**32, _rand_uint32),
-    'uint64': (0, 2**64, _rand_uint64)
+    'bool': (0, 2, _rand_bool_TEST),
+    'int8': (-2**7, 2**7, _rand_int8_TEST),
+    'int16': (-2**15, 2**15, _rand_int16_TEST),
+    'int32': (-2**31, 2**31, _rand_int32_TEST),
+    'int64': (-2**63, 2**63, _rand_int64_TEST),
+    'uint8': (0, 2**8, _rand_uint8_TEST),
+    'uint16': (0, 2**16, _rand_uint16_TEST),
+    'uint32': (0, 2**32, _rand_uint32_TEST),
+    'uint64': (0, 2**64, _rand_uint64_TEST)
     }
 
 
@@ -964,37 +969,19 @@ cdef class RandomState:
             high = low
             low = 0
 
-        # '_randint_type' is defined in
-        # 'generate_randint_helpers.py'
+        # '_randint_{{dtype}}' is defined in randint_helpers
         key = np.dtype(dtype).name
         if key not in _randint_type:
             raise TypeError('Unsupported dtype "%s" for randint' % key)
 
         lowbnd, highbnd, randfunc = _randint_type[key]
 
-        # TODO: Do not cast these inputs to Python int
-        #
-        # This is a workaround until gh-8851 is resolved (bug in NumPy
-        # integer comparison and subtraction involving uint64 and non-
-        # uint64). Afterwards, remove these two lines.
-        ilow = int(low)
-        ihigh = int(high)
-
-        if ilow < lowbnd:
-            raise ValueError("low is out of bounds for %s" % (key,))
-        if ihigh > highbnd:
-            raise ValueError("high is out of bounds for %s" % (key,))
-        if ilow >= ihigh:
-            raise ValueError("low >= high")
-
-        with self.lock:
-            ret = randfunc(ilow, ihigh - 1, size, self.state_address)
-
-            if size is None:
-                if dtype in (np.bool, np.int, np.long):
+        ret = randfunc(low, high, size, self.state_address, self.lock)
+        if size is None:
+            if dtype in (np.bool, np.int, np.long):
+                if np.isscalar(ret):
                     return dtype(ret)
-
-            return ret
+        return ret
 
     def bytes(self, npy_intp length):
         """

--- a/numpy/random/mtrand/numpy.pxd
+++ b/numpy/random/mtrand/numpy.pxd
@@ -29,6 +29,17 @@ cdef extern from "numpy/arrayobject.h":
         NPY_NTYPES
         NPY_NOTYPE
 
+        NPY_INT8
+        NPY_INT16
+        NPY_INT32
+        NPY_INT64
+        NPY_INT128
+        NPY_INT256
+        NPY_UINT8
+        NPY_UINT16
+        NPY_UINT32
+        NPY_UINT64
+
     cdef enum requirements:
         NPY_ARRAY_C_CONTIGUOUS
         NPY_ARRAY_F_CONTIGUOUS

--- a/numpy/random/mtrand/randint_helpers.pxi.in
+++ b/numpy/random/mtrand/randint_helpers.pxi.in
@@ -1,6 +1,8 @@
 """
 Template for each `dtype` helper function in `np.random.randint`.
 """
+from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
+                          int8_t, int16_t, int32_t, int64_t, intptr_t)
 
 {{py:
 
@@ -74,4 +76,273 @@ def _rand_{{npy_dt}}(low, high, size, rngstate):
             rk_random_{{npy_udt}}_fill(off, rng, cnt, array_data, state)
         return array
 
+{{endfor}}
+
+cdef inline npy_uint64 _gen_mask(npy_uint64 max_val) nogil:
+    # Smallest bit mask >= max
+    cdef npy_uint64 mask = max_val
+    mask |= mask >> 1
+    mask |= mask >> 2
+    mask |= mask >> 4
+    mask |= mask >> 8
+    mask |= mask >> 16
+    mask |= mask >> 32
+    return mask
+{{
+py:
+bc_ctypes = (('uint32', 'uint32', 'uint64', 'NPY_UINT64', 0, 0, 0, '0X100000000ULL'),
+          ('uint16', 'uint16', 'uint32', 'NPY_UINT32', 1, 16, 0, '0X10000UL'),
+          ('uint8', 'uint8', 'uint16', 'NPY_UINT16', 3, 8, 0, '0X100UL'),
+          ('bool','bool', 'uint8', 'NPY_UINT8', 31, 1, 0, '0x2UL'),
+          ('int32', 'uint32', 'uint64', 'NPY_INT64', 0, 0, '-0x80000000LL', '0x80000000LL'),
+          ('int16', 'uint16', 'uint32', 'NPY_INT32', 1, 16, '-0x8000LL', '0x8000LL' ),
+          ('int8', 'uint8', 'uint16', 'NPY_INT16', 3, 8, '-0x80LL', '0x80LL' ),
+)}}
+{{for  nptype, utype, nptype_up, npctype, remaining, bitshift, lb, ub in bc_ctypes}}
+{{ py: otype = nptype + '_' if nptype == 'bool' else nptype }}
+cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object rngstate, object lock):
+    """
+    _rand_{{nptype}}(low, high, size, *state, lock)
+
+    Return random np.{{nptype}} integers between `low` and `high`, inclusive.
+
+    Return random integers from the "discrete uniform" distribution in the
+    closed interval [`low`, `high`).  If `high` is None (the default),
+    then results are from [0, `low`). On entry the arguments are presumed
+    to have been validated for size and order for the np.{{nptype}} type.
+
+    Parameters
+    ----------
+    low : int or array-like
+        Lowest (signed) integer to be drawn from the distribution (unless
+        ``high=None``, in which case this parameter is the *highest* such
+        integer).
+    high : int or array-like
+        If provided, the largest (signed) integer to be drawn from the
+        distribution (see above for behavior if ``high=None``).
+    size : int or tuple of ints
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  Default is None, in which case a
+        single value is returned.
+    state : augmented random state
+        State to use in the core random number generators
+    lock : threading.Lock
+        Lock to prevent multiple using a single RandomState simultaneously
+
+    Returns
+    -------
+    out : python scalar or ndarray of np.{{nptype}}
+          `size`-shaped array of random integers from the appropriate
+          distribution, or a single such random int if `size` not provided.
+    """
+    cdef npy_{{utype}} rng, last_rng, off, val, mask, out_val
+    cdef npy_uint32 buf
+    cdef npy_{{utype}} *out_data
+    cdef npy_{{nptype_up}} low_v, high_v
+    cdef ndarray low_arr, high_arr, out_arr
+    cdef npy_intp i, cnt
+    cdef broadcast it
+    cdef int buf_rem = 0
+    cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
+
+
+    low = np.asarray(low)
+    high = np.asarray(high)
+    if low.shape == high.shape == ():
+        low = int(low) # TODO: Cast appropriately?
+        high = int(high) # TODO: Cast appropriately?
+
+        if low < {{lb}}:
+            raise ValueError("low is out of bounds for {{nptype}}")
+        if high > {{ub}}:
+            raise ValueError("high is out of bounds for {{nptype}}")
+        if low >= high:
+            raise ValueError("low >= high")
+
+        high -= 1
+        rng = <npy_{{utype}}>(high - low)
+        off = <npy_{{utype}}>(<npy_{{nptype}}>low)
+        if size is None:
+            with lock:
+                rk_random_{{utype}}_fill(off, rng, 1, &out_val, state)
+            return np.{{otype}}(<npy_{{nptype}}>out_val)
+        else:
+            out_arr = <ndarray>np.empty(size, np.{{nptype}})
+            cnt = PyArray_SIZE(out_arr)
+            out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
+            with lock, nogil:
+                rk_random_{{utype}}_fill(off, rng, cnt, out_data, state)
+            return out_arr
+
+    # Array path
+    low_arr = <ndarray>low
+    high_arr = <ndarray>high
+    if np.any(np.less(low_arr, {{lb}})):
+        raise ValueError('low is out of bounds for {{nptype}}')
+    if np.any(np.greater(high_arr, {{ub}})):
+        raise ValueError('high is out of bounds for {{nptype}}')
+    if np.any(np.greater_equal(low_arr, high_arr)):
+        raise ValueError('low >= high')
+
+    low_arr = <ndarray>PyArray_FROM_OTF(low, {{npctype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+    high_arr = <ndarray>PyArray_FROM_OTF(high, {{npctype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+
+    if size is not None:
+        out_arr = <ndarray>np.empty(size, np.{{otype}})
+    else:
+        it = <broadcast>PyArray_MultiIterNew(2, <void *>low_arr, <void *>high_arr)
+        out_arr = <ndarray>np.empty(it.shape, np.{{otype}})
+
+    it = <broadcast>PyArray_MultiIterNew(3, <void *>low_arr, <void *>high_arr, <void *>out_arr)
+    out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
+    n = PyArray_SIZE(out_arr)
+    mask = last_rng = 0
+    with lock, nogil:
+        for i in range(n):
+            low_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 0))[0]
+            high_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 1))[0]
+            rng = <npy_{{utype}}>((high_v - 1) - low_v)
+            off = <npy_{{utype}}>(<npy_{{nptype_up}}>low_v)
+
+            if rng != last_rng:
+                # Smallest bit mask >= max
+                mask = <npy_{{utype}}>_gen_mask(rng)
+            # TODO: Pass mask?
+            out_data[i] = rk_random_{{utype}}(off, rng, &buf, &buf_rem, state);
+
+            PyArray_MultiIter_NEXT(it)
+
+    return out_arr
+{{endfor}}
+
+
+{{
+py:
+big_bc_ctypes = (('uint64', 'uint64', 'NPY_UINT64', '0x0ULL', '0xFFFFFFFFFFFFFFFFULL'),
+                 ('int64', 'uint64', 'NPY_INT64', '-0x8000000000000000LL', '0x7FFFFFFFFFFFFFFFLL' )
+)}}
+{{for  nptype, utype, npctype, lb, ub in big_bc_ctypes}}
+{{ py: otype = nptype}}
+cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object rngstate, object lock):
+    """
+    _rand_{{nptype}}(low, high, size, *state, lock)
+
+    Return random np.{{nptype}} integers between `low` and `high`, inclusive.
+
+    Return random integers from the "discrete uniform" distribution in the
+    closed interval [`low`, `high`).  If `high` is None (the default),
+    then results are from [0, `low`). On entry the arguments are presumed
+    to have been validated for size and order for the np.{{nptype}} type.
+
+    Parameters
+    ----------
+    low : int or array-like
+        Lowest (signed) integer to be drawn from the distribution (unless
+        ``high=None``, in which case this parameter is the *highest* such
+        integer).
+    high : int or array-like
+        If provided, the largest (signed) integer to be drawn from the
+        distribution (see above for behavior if ``high=None``).
+    size : int or tuple of ints
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  Default is None, in which case a
+        single value is returned.
+    state : augmented random state
+        State to use in the core random number generators
+    lock : threading.Lock
+        Lock to prevent multiple using a single RandomState simultaneously
+
+    Returns
+    -------
+    out : python scalar or ndarray of np.{{nptype}}
+          `size`-shaped array of random integers from the appropriate
+          distribution, or a single such random int if `size` not provided.
+    """
+    cdef ndarray low_arr, high_arr, out_arr, highm1_arr
+    cdef npy_intp i, cnt
+    cdef broadcast it
+    cdef object closed_upper
+    cdef npy_uint64 *out_data
+    cdef npy_{{nptype}} *highm1_data
+    cdef npy_{{nptype}} low_v, high_v
+    cdef npy_uint64 rng, last_rng, val, mask, off, out_val
+    cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
+
+    low = np.asarray(low)
+    high = np.asarray(high)
+    if low.shape == high.shape == ():
+        low = int(low) # TODO: Cast appropriately?
+        high = int(high) # TODO: Cast appropriately?
+        high -= 1  # Use a closed interval
+
+        if low < {{lb}}:
+            raise ValueError("low is out of bounds for {{nptype}}")
+        if high > {{ub}}:
+            raise ValueError("high is out of bounds for {{nptype}}")
+        if low > high:
+            raise ValueError("low >= high")
+
+        rng = <npy_{{utype}}>(high - low)
+        off = <npy_{{utype}}>(<npy_{{nptype}}>low)
+        if size is None:
+            with lock:
+                rk_random_{{utype}}_fill(off, rng, 1, &out_val, state)
+            return np.{{otype}}(<npy_{{nptype}}>out_val)
+        else:
+            out_arr = <ndarray>np.empty(size, np.{{nptype}})
+            cnt = PyArray_SIZE(out_arr)
+            out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
+            with lock, nogil:
+                rk_random_{{utype}}_fill(off, rng, cnt, out_data, state)
+            return out_arr
+
+    low_arr = <ndarray>low
+    high_arr = <ndarray>high
+
+    if np.any(np.less(low_arr, {{lb}})):
+        raise ValueError('low is out of bounds for {{nptype}}')
+
+    highm1_arr = <ndarray>np.empty_like(high_arr, dtype=np.{{nptype}})
+    highm1_data = <npy_{{nptype}} *>PyArray_DATA(highm1_arr)
+    n = PyArray_SIZE(high_arr)
+    flat = high_arr.flat
+    for i in range(n):
+        closed_upper = int(flat[i]) - 1
+        if closed_upper > {{ub}}:
+            raise ValueError('high is out of bounds for {{nptype}}')
+        if closed_upper < {{lb}}:
+            raise ValueError('low >= high')
+
+        highm1_data[i] = <npy_{{nptype}}>closed_upper
+
+    if np.any(np.greater(low_arr, highm1_arr)):
+        raise ValueError('low >= high')
+
+    high_arr = highm1_arr
+    low_arr = <ndarray>PyArray_FROM_OTF(low, {{npctype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+
+    if size is not None:
+        out_arr = <ndarray>np.empty(size, np.{{nptype}})
+    else:
+        it = <broadcast>PyArray_MultiIterNew(2, <void *>low_arr, <void *>high_arr)
+        out_arr = <ndarray>np.empty(it.shape, np.{{nptype}})
+
+    it = <broadcast>PyArray_MultiIterNew(3, <void *>low_arr, <void *>high_arr, <void *>out_arr)
+    out_data = <npy_uint64 *>PyArray_DATA(out_arr)
+    n = PyArray_SIZE(out_arr)
+    mask = last_rng = 0
+    with lock, nogil:
+        for i in range(n):
+            low_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 0))[0]
+            high_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 1))[0]
+            rng = <npy_{{utype}}>(high_v - low_v) # No -1 here since implemented above
+            off = <npy_{{utype}}>low_v
+
+            if rng != last_rng:
+                mask = _gen_mask(rng)
+            # TODO: Pass mask?
+            out_data[i] = rk_random_{{utype}}(off, rng, state);
+            PyArray_MultiIter_NEXT(it)
+
+    return out_arr
 {{endfor}}

--- a/numpy/random/mtrand/randint_helpers.pxi.in
+++ b/numpy/random/mtrand/randint_helpers.pxi.in
@@ -183,6 +183,9 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
     cdef npy_intp i, cnt, low_ndim, high_ndim
     cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
 
+    if size is not None and np.prod(size) == 0:
+        return np.empty(size, np.{{nptype}})
+
     low = np.asarray(low)
     high = np.asarray(high)
     low_ndim = PyArray_NDIM(<ndarray>low)

--- a/numpy/random/mtrand/randint_helpers.pxi.in
+++ b/numpy/random/mtrand/randint_helpers.pxi.in
@@ -51,12 +51,12 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
           `size`-shaped array of random integers from the appropriate
           distribution, or a single such random int if `size` not provided.
     """
-    cdef npy_{{utype}} rng, last_rng, off, val, mask, out_val
+    cdef npy_{{utype}} rng, off, val, out_val
     cdef npy_uint32 buf
     cdef npy_{{utype}} *out_data
     cdef npy_{{nptype_up}} low_v, high_v
     cdef ndarray low_arr, high_arr, out_arr
-    cdef npy_intp i, cnt
+    cdef npy_intp i, cnt, low_ndim, high_ndim
     cdef broadcast it
     cdef int buf_rem = 0
     cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
@@ -64,7 +64,10 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
 
     low = np.asarray(low)
     high = np.asarray(high)
-    if low.shape == high.shape == ():
+    low_ndim = PyArray_NDIM(<ndarray>low)
+    high_ndim = PyArray_NDIM(<ndarray>high)
+    if ((low_ndim == 0 or (low_ndim==1 and low.size==1 and size is not None)) and
+            (high_ndim == 0 or (high_ndim==1 and high.size==1 and size is not None))):
         low = int(low) 
         high = int(high)
 
@@ -112,7 +115,6 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
     it = <broadcast>PyArray_MultiIterNew(3, <void *>low_arr, <void *>high_arr, <void *>out_arr)
     out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
     n = PyArray_SIZE(out_arr)
-    mask = last_rng = 0
     with lock, nogil:
         for i in range(n):
             low_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 0))[0]
@@ -172,18 +174,21 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
           distribution, or a single such random int if `size` not provided.
     """
     cdef ndarray low_arr, high_arr, out_arr, highm1_arr
-    cdef npy_intp i, cnt
+    cdef npy_intp i, cnt, low_ndim, high_ndim
     cdef broadcast it
     cdef object closed_upper
     cdef npy_uint64 *out_data
     cdef npy_{{nptype}} *highm1_data
     cdef npy_{{nptype}} low_v, high_v
-    cdef npy_uint64 rng, last_rng, val, mask, off, out_val
+    cdef npy_uint64 rng, val, off, out_val
     cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
 
     low = np.asarray(low)
     high = np.asarray(high)
-    if low.shape == high.shape == ():
+    low_ndim = PyArray_NDIM(<ndarray>low)
+    high_ndim = PyArray_NDIM(<ndarray>high)
+    if ((low_ndim == 0 or (low_ndim==1 and low.size==1 and size is not None)) and
+            (high_ndim == 0 or (high_ndim==1 and high.size==1 and size is not None))):
         low = int(low)
         high = int(high)
         high -= 1  # Use a closed interval
@@ -243,7 +248,6 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
     it = <broadcast>PyArray_MultiIterNew(3, <void *>low_arr, <void *>high_arr, <void *>out_arr)
     out_data = <npy_uint64 *>PyArray_DATA(out_arr)
     n = PyArray_SIZE(out_arr)
-    mask = last_rng = 0
     with lock, nogil:
         for i in range(n):
             low_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 0))[0]

--- a/numpy/random/mtrand/randint_helpers.pxi.in
+++ b/numpy/random/mtrand/randint_helpers.pxi.in
@@ -64,14 +64,14 @@ def _rand_{{npy_dt}}(low, high, size, rngstate):
     off = <npy_{{npy_udt}}>(<npy_{{npy_dt}}>low)
 
     if size is None:
-        rk_random_{{npy_udt}}(off, rng, 1, &buf, state)
+        rk_random_{{npy_udt}}_fill(off, rng, 1, &buf, state)
         return np.{{np_dt}}(<npy_{{npy_dt}}>buf)
     else:
         array = <ndarray>np.empty(size, np.{{np_dt}})
         cnt = PyArray_SIZE(array)
         array_data = <npy_{{npy_udt}} *>PyArray_DATA(array)
         with nogil:
-            rk_random_{{npy_udt}}(off, rng, cnt, array_data, state)
+            rk_random_{{npy_udt}}_fill(off, rng, cnt, array_data, state)
         return array
 
 {{endfor}}

--- a/numpy/random/mtrand/randint_helpers.pxi.in
+++ b/numpy/random/mtrand/randint_helpers.pxi.in
@@ -15,6 +15,132 @@ dtypes = (('uint32', 'uint32', 'uint64', 'NPY_UINT64', 0, '0X100000000ULL'),
 }}
 
 {{for  nptype, utype, nptype_up, apitype, lb, ub in dtypes}}
+cdef object _rand_{{nptype}}_array_path(ndarray low, ndarray high, object size, rk_state *state, object lock):
+    """Array path for all types that are not 64 bit"""
+    cdef npy_{{utype}} rng, off, val
+    cdef npy_uint32 buf
+    cdef ndarray out_arr
+    cdef npy_{{utype}} *out_data
+    cdef npy_{{nptype_up}} low_v, high_v
+    cdef npy_intp i, cnt
+    cdef broadcast it
+    cdef int buf_rem = 0
+
+    if np.any(np.less(low, {{lb}})):
+        raise ValueError('low is out of bounds for {{nptype}}')
+    if np.any(np.greater(high, {{ub}})):
+        raise ValueError('high is out of bounds for {{nptype}}')
+    if np.any(np.greater_equal(low, high)):
+        raise ValueError('low >= high')
+
+    low = <ndarray>PyArray_FROM_OTF(low, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+    high = <ndarray>PyArray_FROM_OTF(high, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+
+    if size is not None:
+        out_arr = <ndarray>np.empty(size, np.{{nptype}})
+    else:
+        it = <broadcast>PyArray_MultiIterNew(2, <void *>low, <void *>high)
+        out_arr = <ndarray>np.empty(it.shape, np.{{nptype}})
+
+    it = <broadcast>PyArray_MultiIterNew(3, <void *>low, <void *>high, <void *>out_arr)
+    out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
+    cnt = PyArray_SIZE(out_arr)
+    with lock, nogil:
+        for i in range(cnt):
+            low_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 0))[0]
+            high_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 1))[0]
+            rng = <npy_{{utype}}>((high_v - 1) - low_v)
+            off = <npy_{{utype}}>(<npy_{{nptype_up}}>low_v)
+
+            out_data[i] = rk_random_{{utype}}(off, rng, &buf, &buf_rem, state);
+
+            PyArray_MultiIter_NEXT(it)
+
+    return out_arr
+{{endfor}}
+
+{{
+py:
+dtypes64 = (('uint64', 'uint64', 'NPY_UINT64', '0x0ULL', '0xFFFFFFFFFFFFFFFFULL'),
+            ('int64', 'uint64', 'NPY_INT64', '-0x8000000000000000LL', '0x7FFFFFFFFFFFFFFFLL' )
+)
+}}
+{{for  nptype, utype, apitype, lb, ub in dtypes64}}
+cdef object _rand_{{nptype}}_array_path(ndarray low, ndarray high, object size, rk_state *state, object lock):
+    """
+    Array path for 64 bit integers
+
+    This path is needed since verification of bounds requires casting to
+    Python ints which is slow.
+    """
+    cdef ndarray out_arr, highm1_arr
+    cdef npy_intp i, cnt
+    cdef broadcast it
+    cdef object closed_upper
+    cdef npy_uint64 *out_data
+    cdef npy_{{nptype}} *highm1_data
+    cdef npy_{{nptype}} low_v, high_v
+    cdef npy_uint64 rng, val, off, out_val
+
+    if np.any(np.less(low, {{lb}})):
+        raise ValueError('low is out of bounds for {{nptype}}')
+
+    highm1_arr = <ndarray>np.empty_like(high, dtype=np.{{nptype}})
+    highm1_data = <npy_{{nptype}} *>PyArray_DATA(highm1_arr)
+    cnt = PyArray_SIZE(high)
+    flat = high.flat
+    for i in range(cnt):
+        closed_upper = int(flat[i]) - 1
+        if closed_upper > {{ub}}:
+            raise ValueError('high is out of bounds for {{nptype}}')
+        if closed_upper < {{lb}}:
+            raise ValueError('low >= high')
+
+        highm1_data[i] = <npy_{{nptype}}>closed_upper
+
+    if np.any(np.greater(low, highm1_arr)):
+        raise ValueError('low >= high')
+
+    high = highm1_arr
+    low = <ndarray>PyArray_FROM_OTF(low, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+
+    if size is not None:
+        out_arr = <ndarray>np.empty(size, np.{{nptype}})
+    else:
+        it = <broadcast>PyArray_MultiIterNew(2, <void *>low, <void *>high)
+        out_arr = <ndarray>np.empty(it.shape, np.{{nptype}})
+
+    it = <broadcast>PyArray_MultiIterNew(3, <void *>low, <void *>high, <void *>out_arr)
+    out_data = <npy_uint64 *>PyArray_DATA(out_arr)
+    n = PyArray_SIZE(out_arr)
+    with lock, nogil:
+        for i in range(n):
+            low_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 0))[0]
+            high_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 1))[0]
+            rng = <npy_{{utype}}>(high_v - low_v) # No -1 here since implemented above
+            off = <npy_{{utype}}>low_v
+
+            out_data[i] = rk_random_{{utype}}(off, rng, state);
+            PyArray_MultiIter_NEXT(it)
+
+    return out_arr
+{{endfor}}
+
+{{
+py:
+dtypes = (('uint64', 'uint64', '0x0ULL', '0XFFFFFFFFFFFFFFFFULL'),
+          ('uint32', 'uint32', '0x0ULL', '0XFFFFFFFFULL'),
+          ('uint16', 'uint16', '0x0ULL', '0XFFFFUL'),
+          ('uint8', 'uint8', '0x0ULL', '0XFFUL'),
+          ('bool', 'bool', '0x0ULL', '0x1UL'),
+          ('int64', 'uint64', '-0x8000000000000000LL', '0x7FFFFFFFFFFFFFFFLL'),
+          ('int32', 'uint32', '-0x80000000LL', '0x7FFFFFFFLL'),
+          ('int16', 'uint16', '-0x8000LL', '0x7FFFLL' ),
+          ('int8', 'uint8', '-0x80LL', '0x7FLL' ),
+)
+}}
+
+{{for  nptype, utype, lb, ub in dtypes}}
 {{ py: otype = nptype + '_' if nptype == 'bool' else nptype }}
 cdef object _rand_{{nptype}}(object low, object high, object size, object rngstate, object lock):
     """
@@ -52,15 +178,10 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
           distribution, or a single such random int if `size` not provided.
     """
     cdef npy_{{utype}} rng, off, val, out_val
-    cdef npy_uint32 buf
     cdef npy_{{utype}} *out_data
-    cdef npy_{{nptype_up}} low_v, high_v
     cdef ndarray low_arr, high_arr, out_arr
     cdef npy_intp i, cnt, low_ndim, high_ndim
-    cdef broadcast it
-    cdef int buf_rem = 0
     cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
-
 
     low = np.asarray(low)
     high = np.asarray(high)
@@ -70,129 +191,8 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
             (high_ndim == 0 or (high_ndim==1 and high.size==1 and size is not None))):
         low = int(low) 
         high = int(high)
-
-        if low < {{lb}}:
-            raise ValueError("low is out of bounds for {{nptype}}")
-        if high > {{ub}}:
-            raise ValueError("high is out of bounds for {{nptype}}")
-        if low >= high:
-            raise ValueError("low >= high")
-
-        high -= 1
-        rng = <npy_{{utype}}>(high - low)
-        off = <npy_{{utype}}>(<npy_{{nptype}}>low)
-        if size is None:
-            with lock:
-                rk_random_{{utype}}_fill(off, rng, 1, &out_val, state)
-            return np.{{otype}}(<npy_{{nptype}}>out_val)
-        else:
-            out_arr = <ndarray>np.empty(size, np.{{nptype}})
-            cnt = PyArray_SIZE(out_arr)
-            out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
-            with lock, nogil:
-                rk_random_{{utype}}_fill(off, rng, cnt, out_data, state)
-            return out_arr
-
-    # Array path
-    low_arr = <ndarray>low
-    high_arr = <ndarray>high
-    if np.any(np.less(low_arr, {{lb}})):
-        raise ValueError('low is out of bounds for {{nptype}}')
-    if np.any(np.greater(high_arr, {{ub}})):
-        raise ValueError('high is out of bounds for {{nptype}}')
-    if np.any(np.greater_equal(low_arr, high_arr)):
-        raise ValueError('low >= high')
-
-    low_arr = <ndarray>PyArray_FROM_OTF(low, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
-    high_arr = <ndarray>PyArray_FROM_OTF(high, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
-
-    if size is not None:
-        out_arr = <ndarray>np.empty(size, np.{{otype}})
-    else:
-        it = <broadcast>PyArray_MultiIterNew(2, <void *>low_arr, <void *>high_arr)
-        out_arr = <ndarray>np.empty(it.shape, np.{{otype}})
-
-    it = <broadcast>PyArray_MultiIterNew(3, <void *>low_arr, <void *>high_arr, <void *>out_arr)
-    out_data = <npy_{{utype}} *>PyArray_DATA(out_arr)
-    n = PyArray_SIZE(out_arr)
-    with lock, nogil:
-        for i in range(n):
-            low_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 0))[0]
-            high_v = (<npy_{{nptype_up}}*>PyArray_MultiIter_DATA(it, 1))[0]
-            rng = <npy_{{utype}}>((high_v - 1) - low_v)
-            off = <npy_{{utype}}>(<npy_{{nptype_up}}>low_v)
-
-            out_data[i] = rk_random_{{utype}}(off, rng, &buf, &buf_rem, state);
-
-            PyArray_MultiIter_NEXT(it)
-
-    return out_arr
-{{endfor}}
-
-
-{{
-py:
-dtypes64 = (('uint64', 'uint64', 'NPY_UINT64', '0x0ULL', '0xFFFFFFFFFFFFFFFFULL'),
-            ('int64', 'uint64', 'NPY_INT64', '-0x8000000000000000LL', '0x7FFFFFFFFFFFFFFFLL' )
-)
-}}
-{{for  nptype, utype, apitype, lb, ub in dtypes64}}
-{{ py: otype = nptype}}
-cdef object _rand_{{nptype}}(object low, object high, object size, object rngstate, object lock):
-    """
-    _rand_{{nptype}}(low, high, size, *state, lock)
-
-    Return random np.{{nptype}} integers between `low` and `high`, inclusive.
-
-    Return random integers from the "discrete uniform" distribution in the
-    closed interval [`low`, `high`).  If `high` is None (the default),
-    then results are from [0, `low`). On entry the arguments are presumed
-    to have been validated for size and order for the np.{{nptype}} type.
-
-    Parameters
-    ----------
-    low : int or array-like
-        Lowest (signed) integer to be drawn from the distribution (unless
-        ``high=None``, in which case this parameter is the *highest* such
-        integer).
-    high : int or array-like
-        If provided, the largest (signed) integer to be drawn from the
-        distribution (see above for behavior if ``high=None``).
-    size : int or tuple of ints
-        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-        ``m * n * k`` samples are drawn.  Default is None, in which case a
-        single value is returned.
-    state : augmented random state
-        State to use in the core random number generators
-    lock : threading.Lock
-        Lock to prevent multiple using a single RandomState simultaneously
-
-    Returns
-    -------
-    out : python scalar or ndarray of np.{{nptype}}
-          `size`-shaped array of random integers from the appropriate
-          distribution, or a single such random int if `size` not provided.
-    """
-    cdef ndarray low_arr, high_arr, out_arr, highm1_arr
-    cdef npy_intp i, cnt, low_ndim, high_ndim
-    cdef broadcast it
-    cdef object closed_upper
-    cdef npy_uint64 *out_data
-    cdef npy_{{nptype}} *highm1_data
-    cdef npy_{{nptype}} low_v, high_v
-    cdef npy_uint64 rng, val, off, out_val
-    cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
-
-    low = np.asarray(low)
-    high = np.asarray(high)
-    low_ndim = PyArray_NDIM(<ndarray>low)
-    high_ndim = PyArray_NDIM(<ndarray>high)
-    if ((low_ndim == 0 or (low_ndim==1 and low.size==1 and size is not None)) and
-            (high_ndim == 0 or (high_ndim==1 and high.size==1 and size is not None))):
-        low = int(low)
-        high = int(high)
-        high -= 1  # Use a closed interval
-
+        high -= 1  # Transform to closed interval
+        
         if low < {{lb}}:
             raise ValueError("low is out of bounds for {{nptype}}")
         if high > {{ub}}:
@@ -200,6 +200,7 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
         if low > high:
             raise ValueError("low >= high")
 
+        
         rng = <npy_{{utype}}>(high - low)
         off = <npy_{{utype}}>(<npy_{{nptype}}>low)
         if size is None:
@@ -214,49 +215,5 @@ cdef object _rand_{{nptype}}(object low, object high, object size, object rngsta
                 rk_random_{{utype}}_fill(off, rng, cnt, out_data, state)
             return out_arr
 
-    low_arr = <ndarray>low
-    high_arr = <ndarray>high
-
-    if np.any(np.less(low_arr, {{lb}})):
-        raise ValueError('low is out of bounds for {{nptype}}')
-
-    highm1_arr = <ndarray>np.empty_like(high_arr, dtype=np.{{nptype}})
-    highm1_data = <npy_{{nptype}} *>PyArray_DATA(highm1_arr)
-    n = PyArray_SIZE(high_arr)
-    flat = high_arr.flat
-    for i in range(n):
-        closed_upper = int(flat[i]) - 1
-        if closed_upper > {{ub}}:
-            raise ValueError('high is out of bounds for {{nptype}}')
-        if closed_upper < {{lb}}:
-            raise ValueError('low >= high')
-
-        highm1_data[i] = <npy_{{nptype}}>closed_upper
-
-    if np.any(np.greater(low_arr, highm1_arr)):
-        raise ValueError('low >= high')
-
-    high_arr = highm1_arr
-    low_arr = <ndarray>PyArray_FROM_OTF(low, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
-
-    if size is not None:
-        out_arr = <ndarray>np.empty(size, np.{{nptype}})
-    else:
-        it = <broadcast>PyArray_MultiIterNew(2, <void *>low_arr, <void *>high_arr)
-        out_arr = <ndarray>np.empty(it.shape, np.{{nptype}})
-
-    it = <broadcast>PyArray_MultiIterNew(3, <void *>low_arr, <void *>high_arr, <void *>out_arr)
-    out_data = <npy_uint64 *>PyArray_DATA(out_arr)
-    n = PyArray_SIZE(out_arr)
-    with lock, nogil:
-        for i in range(n):
-            low_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 0))[0]
-            high_v = (<npy_{{nptype}}*>PyArray_MultiIter_DATA(it, 1))[0]
-            rng = <npy_{{utype}}>(high_v - low_v) # No -1 here since implemented above
-            off = <npy_{{utype}}>low_v
-
-            out_data[i] = rk_random_{{utype}}(off, rng, state);
-            PyArray_MultiIter_NEXT(it)
-
-    return out_arr
+    return _rand_{{nptype}}_array_path(low, high, size, state, lock)
 {{endfor}}

--- a/numpy/random/mtrand/randint_helpers.pxi.in
+++ b/numpy/random/mtrand/randint_helpers.pxi.in
@@ -1,106 +1,22 @@
 """
 Template for each `dtype` helper function in `np.random.randint`.
 """
-from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
-                          int8_t, int16_t, int32_t, int64_t, intptr_t)
 
-{{py:
-
-dtypes = (
-    ('bool', 'bool', 'bool_'),
-    ('int8', 'uint8', 'int8'),
-    ('int16', 'uint16', 'int16'),
-    ('int32', 'uint32', 'int32'),
-    ('int64', 'uint64', 'int64'),
-    ('uint8', 'uint8', 'uint8'),
-    ('uint16', 'uint16', 'uint16'),
-    ('uint32', 'uint32', 'uint32'),
-    ('uint64', 'uint64', 'uint64'),
-)
-
-def get_dispatch(dtypes):
-    for npy_dt, npy_udt, np_dt in dtypes:
-        yield npy_dt, npy_udt, np_dt
-}}
-
-{{for npy_dt, npy_udt, np_dt in get_dispatch(dtypes)}}
-
-def _rand_{{npy_dt}}(low, high, size, rngstate):
-    """
-    _rand_{{npy_dt}}(low, high, size, rngstate)
-
-    Return random np.{{np_dt}} integers between ``low`` and ``high``, inclusive.
-
-    Return random integers from the "discrete uniform" distribution in the
-    closed interval [``low``, ``high``). On entry the arguments are presumed
-    to have been validated for size and order for the np.{{np_dt}} type.
-
-    Parameters
-    ----------
-    low : int
-        Lowest (signed) integer to be drawn from the distribution.
-    high : int
-        Highest (signed) integer to be drawn from the distribution.
-    size : int or tuple of ints
-        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-        ``m * n * k`` samples are drawn.  Default is None, in which case a
-        single value is returned.
-    rngstate : encapsulated pointer to rk_state
-        The specific type depends on the python version. In Python 2 it is
-        a PyCObject, in Python 3 a PyCapsule object.
-
-    Returns
-    -------
-    out : python integer or ndarray of np.{{np_dt}}
-          `size`-shaped array of random integers from the appropriate
-          distribution, or a single such random int if `size` not provided.
-
-    """
-    cdef npy_{{npy_udt}} off, rng, buf
-    cdef npy_{{npy_udt}} *out
-    cdef ndarray array "arrayObject"
-    cdef npy_intp cnt
-    cdef rk_state *state = <rk_state *>PyCapsule_GetPointer(rngstate, NULL)
-
-    rng = <npy_{{npy_udt}}>(high - low)
-    off = <npy_{{npy_udt}}>(<npy_{{npy_dt}}>low)
-
-    if size is None:
-        rk_random_{{npy_udt}}_fill(off, rng, 1, &buf, state)
-        return np.{{np_dt}}(<npy_{{npy_dt}}>buf)
-    else:
-        array = <ndarray>np.empty(size, np.{{np_dt}})
-        cnt = PyArray_SIZE(array)
-        array_data = <npy_{{npy_udt}} *>PyArray_DATA(array)
-        with nogil:
-            rk_random_{{npy_udt}}_fill(off, rng, cnt, array_data, state)
-        return array
-
-{{endfor}}
-
-cdef inline npy_uint64 _gen_mask(npy_uint64 max_val) nogil:
-    # Smallest bit mask >= max
-    cdef npy_uint64 mask = max_val
-    mask |= mask >> 1
-    mask |= mask >> 2
-    mask |= mask >> 4
-    mask |= mask >> 8
-    mask |= mask >> 16
-    mask |= mask >> 32
-    return mask
 {{
 py:
-bc_ctypes = (('uint32', 'uint32', 'uint64', 'NPY_UINT64', 0, 0, 0, '0X100000000ULL'),
-          ('uint16', 'uint16', 'uint32', 'NPY_UINT32', 1, 16, 0, '0X10000UL'),
-          ('uint8', 'uint8', 'uint16', 'NPY_UINT16', 3, 8, 0, '0X100UL'),
-          ('bool','bool', 'uint8', 'NPY_UINT8', 31, 1, 0, '0x2UL'),
-          ('int32', 'uint32', 'uint64', 'NPY_INT64', 0, 0, '-0x80000000LL', '0x80000000LL'),
-          ('int16', 'uint16', 'uint32', 'NPY_INT32', 1, 16, '-0x8000LL', '0x8000LL' ),
-          ('int8', 'uint8', 'uint16', 'NPY_INT16', 3, 8, '-0x80LL', '0x80LL' ),
-)}}
-{{for  nptype, utype, nptype_up, npctype, remaining, bitshift, lb, ub in bc_ctypes}}
+dtypes = (('uint32', 'uint32', 'uint64', 'NPY_UINT64', 0, '0X100000000ULL'),
+          ('uint16', 'uint16', 'uint32', 'NPY_UINT32', 0, '0X10000UL'),
+          ('uint8', 'uint8', 'uint16', 'NPY_UINT16', 0, '0X100UL'),
+          ('bool', 'bool', 'uint8', 'NPY_UINT8', 0, '0x2UL'),
+          ('int32', 'uint32', 'uint64', 'NPY_INT64', '-0x80000000LL', '0x80000000LL'),
+          ('int16', 'uint16', 'uint32', 'NPY_INT32', '-0x8000LL', '0x8000LL' ),
+          ('int8', 'uint8', 'uint16', 'NPY_INT16', '-0x80LL', '0x80LL' ),
+)
+}}
+
+{{for  nptype, utype, nptype_up, apitype, lb, ub in dtypes}}
 {{ py: otype = nptype + '_' if nptype == 'bool' else nptype }}
-cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object rngstate, object lock):
+cdef object _rand_{{nptype}}(object low, object high, object size, object rngstate, object lock):
     """
     _rand_{{nptype}}(low, high, size, *state, lock)
 
@@ -149,8 +65,8 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
     low = np.asarray(low)
     high = np.asarray(high)
     if low.shape == high.shape == ():
-        low = int(low) # TODO: Cast appropriately?
-        high = int(high) # TODO: Cast appropriately?
+        low = int(low) 
+        high = int(high)
 
         if low < {{lb}}:
             raise ValueError("low is out of bounds for {{nptype}}")
@@ -184,8 +100,8 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
     if np.any(np.greater_equal(low_arr, high_arr)):
         raise ValueError('low >= high')
 
-    low_arr = <ndarray>PyArray_FROM_OTF(low, {{npctype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
-    high_arr = <ndarray>PyArray_FROM_OTF(high, {{npctype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+    low_arr = <ndarray>PyArray_FROM_OTF(low, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+    high_arr = <ndarray>PyArray_FROM_OTF(high, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
 
     if size is not None:
         out_arr = <ndarray>np.empty(size, np.{{otype}})
@@ -204,10 +120,6 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
             rng = <npy_{{utype}}>((high_v - 1) - low_v)
             off = <npy_{{utype}}>(<npy_{{nptype_up}}>low_v)
 
-            if rng != last_rng:
-                # Smallest bit mask >= max
-                mask = <npy_{{utype}}>_gen_mask(rng)
-            # TODO: Pass mask?
             out_data[i] = rk_random_{{utype}}(off, rng, &buf, &buf_rem, state);
 
             PyArray_MultiIter_NEXT(it)
@@ -218,12 +130,13 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
 
 {{
 py:
-big_bc_ctypes = (('uint64', 'uint64', 'NPY_UINT64', '0x0ULL', '0xFFFFFFFFFFFFFFFFULL'),
-                 ('int64', 'uint64', 'NPY_INT64', '-0x8000000000000000LL', '0x7FFFFFFFFFFFFFFFLL' )
-)}}
-{{for  nptype, utype, npctype, lb, ub in big_bc_ctypes}}
+dtypes64 = (('uint64', 'uint64', 'NPY_UINT64', '0x0ULL', '0xFFFFFFFFFFFFFFFFULL'),
+            ('int64', 'uint64', 'NPY_INT64', '-0x8000000000000000LL', '0x7FFFFFFFFFFFFFFFLL' )
+)
+}}
+{{for  nptype, utype, apitype, lb, ub in dtypes64}}
 {{ py: otype = nptype}}
-cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object rngstate, object lock):
+cdef object _rand_{{nptype}}(object low, object high, object size, object rngstate, object lock):
     """
     _rand_{{nptype}}(low, high, size, *state, lock)
 
@@ -271,8 +184,8 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
     low = np.asarray(low)
     high = np.asarray(high)
     if low.shape == high.shape == ():
-        low = int(low) # TODO: Cast appropriately?
-        high = int(high) # TODO: Cast appropriately?
+        low = int(low)
+        high = int(high)
         high -= 1  # Use a closed interval
 
         if low < {{lb}}:
@@ -319,7 +232,7 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
         raise ValueError('low >= high')
 
     high_arr = highm1_arr
-    low_arr = <ndarray>PyArray_FROM_OTF(low, {{npctype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
+    low_arr = <ndarray>PyArray_FROM_OTF(low, {{apitype}}, NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST)
 
     if size is not None:
         out_arr = <ndarray>np.empty(size, np.{{nptype}})
@@ -338,9 +251,6 @@ cdef object _rand_{{nptype}}_TEST(object low, object high, object size, object r
             rng = <npy_{{utype}}>(high_v - low_v) # No -1 here since implemented above
             off = <npy_{{utype}}>low_v
 
-            if rng != last_rng:
-                mask = _gen_mask(rng)
-            # TODO: Pass mask?
             out_data[i] = rk_random_{{utype}}(off, rng, state);
             PyArray_MultiIter_NEXT(it)
 

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -150,39 +150,60 @@ extern unsigned long rk_ulong(rk_state *state);
  */
 extern unsigned long rk_interval(unsigned long max, rk_state *state);
 
+extern npy_uint64 rk_random_uint64(npy_uint64 off, npy_uint64 rng, rk_state *state);
+
 /*
  * Fills an array with cnt random npy_uint64 between off and off + rng
  * inclusive. The numbers wrap if rng is sufficiently large.
  */
-extern void rk_random_uint64(npy_uint64 off, npy_uint64 rng, npy_intp cnt,
+extern void rk_random_uint64_fill(npy_uint64 off, npy_uint64 rng, npy_intp cnt,
                              npy_uint64 *out, rk_state *state);
 
+extern npy_uint32 rk_random_uint32(npy_uint32 off, npy_uint32 rng,
+                                          const npy_uint32 *buf, const int *bcnt,
+                                          rk_state *state);
 /*
  * Fills an array with cnt random npy_uint32 between off and off + rng
  * inclusive. The numbers wrap if rng is sufficiently large.
  */
-extern void rk_random_uint32(npy_uint32 off, npy_uint32 rng, npy_intp cnt,
+extern void rk_random_uint32_fill(npy_uint32 off, npy_uint32 rng, npy_intp cnt,
                              npy_uint32 *out, rk_state *state);
+
+extern npy_uint16 rk_random_uint16(npy_uint16 off, npy_uint16 rng,
+                                          npy_uint32 *buf, int *bcnt, rk_state *state);
+
 
 /*
  * Fills an array with cnt random npy_uint16 between off and off + rng
  * inclusive. The numbers wrap if rng is sufficiently large.
  */
-extern void rk_random_uint16(npy_uint16 off, npy_uint16 rng, npy_intp cnt,
+extern void rk_random_uint16_fill(npy_uint16 off, npy_uint16 rng, npy_intp cnt,
                              npy_uint16 *out, rk_state *state);
+
+/*
+ * Generates a single bounded uint8 from a mask with an offset using a buffer
+ */
+extern npy_uint8 rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_uint32 *buf,
+                                 int *bcnt, rk_state *state);
 
 /*
  * Fills an array with cnt random npy_uint8 between off and off + rng
  * inclusive. The numbers wrap if rng is sufficiently large.
  */
-extern void rk_random_uint8(npy_uint8 off, npy_uint8 rng, npy_intp cnt,
+extern void rk_random_uint8_fill(npy_uint8 off, npy_uint8 rng, npy_intp cnt,
                             npy_uint8 *out, rk_state *state);
+
+/*
+ * Generates a single bool using a buffer
+ */
+extern npy_bool
+rk_random_bool(npy_bool off, npy_bool rng, npy_uint32 *buf, int *bcnt, rk_state *state);
 
 /*
  * Fills an array with cnt random npy_bool between off and off + rng
  * inclusive. It is assumed tha npy_bool as the same size as npy_uint8.
  */
-extern void rk_random_bool(npy_bool off, npy_bool rng, npy_intp cnt,
+extern void rk_random_bool_fill(npy_bool off, npy_bool rng, npy_intp cnt,
                            npy_bool *out, rk_state *state);
 
 /*

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -299,6 +299,14 @@ class TestRandint(object):
             assert_(not hasattr(sample, 'dtype'))
             assert_equal(type(sample), dt)
 
+    def test_zero_size(self):
+        # See gh-7203
+        for dt in self.itype:
+            sample = self.rfunc(0, 0, (3, 0, 4), dtype=dt)
+            assert sample.shape == (3, 0, 4)
+            assert sample.dtype == dt
+            assert self.rfunc(0, -10, 0, dtype=dt).shape == (0,)
+
 
 class TestRandomDist(object):
     # Make sure the random distribution returns the correct value for a

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -139,7 +139,7 @@ class TestRandint(object):
     rfunc = np.random.randint
 
     # valid integer/boolean types
-    itype = [np.bool_, np.int8, np.uint8, np.int16, np.uint16,
+    itype = [bool, np.int8, np.uint8, np.int16, np.uint16,
              np.int32, np.uint32, np.int64, np.uint64]
 
     def test_unsupported_type(self):
@@ -147,8 +147,8 @@ class TestRandint(object):
 
     def test_bounds_checking(self):
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            lbnd = 0 if dt is bool else np.iinfo(dt).min
+            ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
             assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
             assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
             assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
@@ -166,12 +166,12 @@ class TestRandint(object):
             assert_raises(ValueError, self.rfunc, [lbnd - 1] * 2, [ubnd] * 2, dtype=dt)
             assert_raises(ValueError, self.rfunc, [lbnd] * 2, [ubnd + 1] * 2, dtype=dt)
             assert_raises(ValueError, self.rfunc, ubnd, [lbnd] * 2, dtype=dt)
-            assert_raises(ValueError, self.rfunc, [1] * 2, 0, dtype=dt)            
+            assert_raises(ValueError, self.rfunc, [1] * 2, 0, dtype=dt)
 
     def test_rng_zero_and_extremes(self):
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            lbnd = 0 if dt is bool else np.iinfo(dt).min
+            ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
 
             tgt = ubnd - 1
             assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
@@ -204,14 +204,14 @@ class TestRandint(object):
             tgt = (lbnd + ubnd) // 2
             assert_equal(self.rfunc([tgt], [tgt + 1], size=size, dtype=dt), tgt)
             assert_equal(self.rfunc([tgt] * size, [tgt + 1] * size, dtype=dt), tgt)
-            assert_equal(self.rfunc([tgt] * size, [tgt + 1] * size, size=size, dtype=dt), tgt)            
+            assert_equal(self.rfunc([tgt] * size, [tgt + 1] * size, size=size, dtype=dt), tgt)
 
     def test_full_range(self):
         # Test for ticket #1690
 
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            lbnd = 0 if dt is bool else np.iinfo(dt).min
+            ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
 
             try:
                 self.rfunc(lbnd, ubnd, dtype=dt)
@@ -244,7 +244,7 @@ class TestRandint(object):
                 assert_(vals.max() < ubnd)
                 assert_(vals.min() >= 2)
 
-        vals = self.rfunc(0, 2, size=2**16, dtype=np.bool_)
+        vals = self.rfunc(0, 2, size=2**16, dtype=bool)
 
         assert_(vals.max() < 2)
         assert_(vals.min() >= 0)
@@ -300,10 +300,10 @@ class TestRandint(object):
         assert_(tgt[np.dtype(bool).name] == res)
 
     def test_repeatability_broadcasting(self):
-        
+
         for dt in self.itype:
-            lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
-            ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
+            lbnd = 0 if dt is bool else np.iinfo(dt).min
+            ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
 
             # view as little endian for hash
             np.random.seed(1234)
@@ -311,12 +311,12 @@ class TestRandint(object):
 
             np.random.seed(1234)
             val_bc = self.rfunc([lbnd] * 1000, ubnd, dtype=dt)
-            
+
             assert_array_equal(val, val_bc)
 
             np.random.seed(1234)
             val_bc = self.rfunc([lbnd] * 1000, [ubnd] * 1000, dtype=dt)
-            
+
             assert_array_equal(val, val_bc)
 
     def test_int64_uint64_corner_case(self):
@@ -344,7 +344,7 @@ class TestRandint(object):
 
     def test_respect_dtype_singleton(self):
         # See gh-7203
-        for dt in self.itype:
+        for dt in self.itype[1:] + [np.bool_]:
             lbnd = 0 if dt is np.bool_ else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool_ else np.iinfo(dt).max + 1
 
@@ -1215,13 +1215,13 @@ class TestBroadcast(object):
         assert_raises(ValueError, nonc_f, bad_dfnum, dfden, nonc * 3)
         assert_raises(ValueError, nonc_f, dfnum, bad_dfden, nonc * 3)
         assert_raises(ValueError, nonc_f, dfnum, dfden, bad_nonc * 3)
-    
+
     def test_noncentral_f_small_df(self):
         self.setSeed()
         desired = np.array([6.869638627492048, 0.785880199263955])
         actual = np.random.noncentral_f(0.9, 0.9, 2, size=2)
         assert_array_almost_equal(actual, desired, decimal=14)
-        
+
     def test_chisquare(self):
         df = [1]
         bad_df = [-1]


### PR DESCRIPTION
Continuation of @gfyoung 's initial patch but using a different approach.  This essentially produces a complete random integer generator including arg checks for each type.  The int64/uint64 cases uses a separate path since special handling is required to ensure cast values are in bounds. 

Related PR's and Issues: #6938  #6902 #6745