### PR TITLE
BUG: Add hypot and cabs functions to WIN32 blacklist.

### DIFF
--- a/numpy/core/src/private/npy_config.h
+++ b/numpy/core/src/private/npy_config.h
@@ -62,6 +62,19 @@
 
 #endif
 
+/* MSVC _hypot messes with fp precision mode on 32-bit, see gh-9567 */
+#if defined(_MSC_VER) && (_MSC_VER >= 1900) && !defined(_WIN64)
+
+#undef HAVE_CABS
+#undef HAVE_CABSF
+#undef HAVE_CABSL
+
+#undef HAVE_HYPOT
+#undef HAVE_HYPOTF
+#undef HAVE_HYPOTL
+
+#endif
+
 
 /* Intel C for Windows uses POW for 64 bits longdouble*/
 #if defined(_MSC_VER) && defined(__INTEL_COMPILER)


### PR DESCRIPTION
Backport of parts of #9574 and #9575.

MSVC 32 bit generates code for _hypot and cabs that changes the fpu
precision mode, enabling ieee extended precision.