### PR TITLE
DOC: Fix link in numpy.ndarray.copy method (missing backticks)

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3418,7 +3418,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('copy',
         Controls the memory layout of the copy. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
-        as possible. (Note that this function and :func:numpy.copy are very
+        as possible. (Note that this function and :func:`numpy.copy` are very
         similar, but have different default values for their order=
         arguments.)
 


### PR DESCRIPTION
Don't think this needs much explanation. The backticks were just missing (see https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.copy.html)