### PR TITLE
ENH: Warn to change lstsq default for rcond

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -36,6 +36,12 @@ This translation now gives a warning explaining what translation is occuring.
 In future, the translation will be disabled, and the first example will be made
 equivalent to the second.
 
+``np.linalg.lstsq`` default for ``rcond`` will be changed
+---------------------------------------------------------
+
+The ``rcond`` parameter to ``np.linalg.lstsq`` will change its default to the
+better value of machine precision times the maximum of the input matrix
+dimensions. A FutureWarning is given if the parameter is not passed explicitly.
 
 Build System Changes
 ====================

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1810,7 +1810,7 @@ def det(a):
 
 # Linear Least Squares
 
-def lstsq(a, b, rcond=-1):
+def lstsq(a, b, rcond="warn"):
     """
     Return the least-squares solution to a linear matrix equation.
 
@@ -1835,6 +1835,13 @@ def lstsq(a, b, rcond=-1):
         For the purposes of rank determination, singular values are treated
         as zero if they are smaller than `rcond` times the largest singular
         value of `a`.
+
+        .. versionchanged:: 1.14.0
+           If not set, a FutureWarning is given. The previous default
+           of ``-1`` will use the machine precision as `rcond` parameter,
+           the new default will use the machine precision times `max(M, N)`.
+           To silence the warning and use the new default, use ``rcond=None``,
+           to keep using the old behavior, use ``rcond=-1``.
 
     Returns
     -------
@@ -1909,6 +1916,20 @@ def lstsq(a, b, rcond=-1):
     if m != b.shape[0]:
         raise LinAlgError('Incompatible dimensions')
     t, result_t = _commonType(a, b)
+    # Determine default rcond value
+    if rcond == "warn":
+        # 2017-08-19, 1.14.0
+        warnings.warn("`rcond` parameter will change to the default of "
+                      "machine precision times ``max(M, N)`` where M and N "
+                      "are the input matrix dimensions.\n"
+                      "To use the future default and silence this warning "
+                      "we advise to pass `rcond=None`, to keep using the old, "
+                      "explicitly pass `rcond=-1`.",
+                      FutureWarning, stacklevel=2)
+        rcond = -1
+    if rcond is None:
+        rcond = finfo(t).eps * ldb
+
     result_real_t = _realType(result_t)
     real_t = _linalgRealType(t)
     bstar = zeros((ldb, n_rhs), t)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -793,7 +793,7 @@ class TestLstsq(LinalgSquareTestCase, LinalgNonsquareTestCase):
         arr = np.asarray(a)
         m, n = arr.shape
         u, s, vt = linalg.svd(a, 0)
-        x, residuals, rank, sv = linalg.lstsq(a, b)
+        x, residuals, rank, sv = linalg.lstsq(a, b, rcond=-1)
         if m <= n:
             assert_almost_equal(b, dot(a, x))
             assert_equal(rank, m)
@@ -814,6 +814,23 @@ class TestLstsq(LinalgSquareTestCase, LinalgNonsquareTestCase):
         assert_(imply(isinstance(b, matrix), isinstance(x, matrix)))
         assert_(imply(isinstance(b, matrix), isinstance(residuals, matrix)))
 
+    def test_future_rcond(self):
+        a = np.array([[0., 1.,  0.,  1.,  2.,  0.],
+                      [0., 2.,  0.,  0.,  1.,  0.],
+                      [1., 0.,  1.,  0.,  0.,  4.],
+                      [0., 0.,  0.,  2.,  3.,  0.]]).T
+
+        b = np.array([1, 0, 0, 0, 0, 0])
+        with suppress_warnings() as sup:
+            w = sup.record(FutureWarning, "`rcond` parameter will change")
+            x, residuals, rank, s = linalg.lstsq(a, b)
+            assert_(rank == 4)
+            x, residuals, rank, s = linalg.lstsq(a, b, rcond=-1)
+            assert_(rank == 4)
+            x, residuals, rank, s = linalg.lstsq(a, b, rcond=None)
+            assert_(rank == 3)
+            # Warning should be raised exactly once (first command)
+            assert_(len(w) == 1)
 
 class TestMatrixPower(object):
     R90 = array([[0, 1], [-1, 0]])


### PR DESCRIPTION
The default parameter used by LAPACK (which was our default) is not
very good, so implement a FutureWarning to change to a better default.

--

See also gh-9284 (no warning, but simply change directly) and gh-8740. I am not quite sure that this is the right approach, there probably could be better tests too.

@charris, Chuck, you said that you would like the RankWarning to be included here, I am not 100% sure how this plays for the polynomials, wouldn't that mean that we should make all RankWarnings just reference a single one (in `np.core._internal.py`) and then we can make it so that the polynomial fits just use `lstsq` and do not raise the warning themselves? Or would we need some internal warning free function (or ability to change the RankWarning)?