### PR TITLE
ENH: Add __repr__ for np._NoValue

### DIFF
--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -52,6 +52,14 @@ class VisibleDeprecationWarning(UserWarning):
     """
     pass
 
+class NoValueMetaClass(type):
+    """Metaclass for _NoValue
+
+    Used to set __repr__ for the _NoValue class (see #8991)
+
+    """
+    def __repr__(self):
+        return 'np._NoValue'
 
 class _NoValue(object):
     """Special keyword value.
@@ -59,4 +67,4 @@ class _NoValue(object):
     This class may be used as the default value assigned to a deprecated
     keyword in order to check if it has been given a user defined value.
     """
-    pass
+    __metaclass__ = NoValueMetaClass

--- a/numpy/tests/test_novalue.py
+++ b/numpy/tests/test_novalue.py
@@ -2,7 +2,8 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 
-from numpy.testing import assert_raises, assert_, run_module_suite
+from numpy.testing import (assert_raises, assert_, run_module_suite,
+    assert_equal)
 
 if sys.version_info[:2] >= (3, 4):
     from importlib import reload
@@ -28,6 +29,11 @@ def test_numpy_reloading():
     assert_(_NoValue is np._NoValue)
     assert_(ModuleDeprecationWarning is np.ModuleDeprecationWarning)
     assert_(VisibleDeprecationWarning is np.VisibleDeprecationWarning)
+
+def test_novalue_repr():
+    # test repr of np._NoValue, see #8991
+    import numpy as np
+    assert_equal(repr(np._NoValue), 'np._NoValue')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #8991.

Adds metaclass to add ``__repr__`` to ``np._NoValue``.

Also adds test to check ``__repr__`` value, and renames the testing script since both tests are for ``np._NoValue``. If there's a better way to organize these tests, let me now and I can update it.