### PR TITLE
ENH: Enable use of vectorize as decorator with keywords

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2694,12 +2694,6 @@ class vectorize(object):
     # functions.
     def __new__(cls, pyfunc=None, *args, **kwargs):
 
-        # For backwards compatibility, subclasses must not use the overloaded
-        # __new__, as vectorize.__new__ and subclass.__init__ will receive the
-        # same arguments.
-        if cls is not vectorize:
-            return object.__new__(cls)
-
         def vectorize_decorator(pyfunc):
             """ ``vectorize`` with presupplied keyword arguments. """
             # prevent an edge case where None would produce another decorator
@@ -2707,7 +2701,10 @@ class vectorize(object):
                 raise TypeError('the wrapped object must be callable')
             return cls(pyfunc, *args, **kwargs)
 
-        if pyfunc is None:
+        # For backwards compatibility, subclasses must not use the overloaded
+        # __new__, as vectorize.__new__ and subclass.__init__ will receive the
+        # same arguments.
+        if cls is vectorize and pyfunc is None:
             return vectorize_decorator
         else:
             return object.__new__(cls)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2538,9 +2538,9 @@ class vectorize(object):
     ----------
     pyfunc : callable, optional
         A python function or method.
-        This is optional since numpy version 1.14. When omitted, a
-        partially-initialized decorator is returned to support keyword
-        arguments when using decorator syntax.
+
+        .. versionchanged:: 1.14.0
+        Can be omitted to produce a decorator with keyword arguments.
     otypes : str or list of dtypes, optional
         The output data type. It must be specified as either a string of
         typecode characters or a list of data type specifiers. There should
@@ -2692,12 +2692,12 @@ class vectorize(object):
     # __new__ is overriden as a clean way to provide decorator-with-keywords
     # syntax while allowing 'vectorize' to remain as the type of vectorized
     # functions.
-    def __new__(cls, pyfunc=None, *args, **kw):
+    def __new__(cls, pyfunc=np._NoValue, *args, **kwargs):
         def vectorize_decorator(pyfunc):
             ''' ``vectorize`` with presupplied keyword arguments. '''
-            return cls(pyfunc, *args, **kw)
+            return cls(pyfunc, *args, **kwargs)
 
-        if pyfunc is None:
+        if pyfunc is np._NoValue:
             return vectorize_decorator
         else:
             return object.__new__(cls)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2694,6 +2694,12 @@ class vectorize(object):
     # functions.
     def __new__(cls, pyfunc=None, *args, **kwargs):
 
+        # For backwards compatibility, subclasses must not use the overloaded
+        # __new__, as vectorize.__new__ and subclass.__init__ will receive the
+        # same arguments.
+        if cls is not vectorize:
+            return object.__new__(cls)
+
         def vectorize_decorator(pyfunc):
             """ ``vectorize`` with presupplied keyword arguments. """
             # prevent an edge case where None would produce another decorator
@@ -2704,7 +2710,7 @@ class vectorize(object):
         if pyfunc is None:
             return vectorize_decorator
         else:
-            return super(vectorize, cls).__new__(cls)#, *args, **kwargs)
+            return object.__new__(cls)
 
     def __init__(self, pyfunc, otypes=None, doc=None, excluded=None,
                  cache=False, signature=None):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2693,14 +2693,18 @@ class vectorize(object):
     # syntax while allowing 'vectorize' to remain as the type of vectorized
     # functions.
     def __new__(cls, pyfunc=None, *args, **kwargs):
+
         def vectorize_decorator(pyfunc):
             """ ``vectorize`` with presupplied keyword arguments. """
+            # prevent an edge case where None would produce another decorator
+            if not hasattr(pyfunc, '__call__'):
+                raise TypeError('the wrapped object must be callable')
             return cls(pyfunc, *args, **kwargs)
 
         if pyfunc is None:
             return vectorize_decorator
         else:
-            return object.__new__(cls)
+            return super(vectorize, cls).__new__(cls)#, *args, **kwargs)
 
     def __init__(self, pyfunc, otypes=None, doc=None, excluded=None,
                  cache=False, signature=None):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2689,17 +2689,18 @@ class vectorize(object):
            <http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html>`_.
     """
 
+    # __new__ is overriden as a clean way to provide decorator-with-keywords
+    # syntax while allowing 'vectorize' to remain as the type of vectorized
+    # functions.
     def __new__(cls, pyfunc=None, *args, **kw):
-        def new_with_kw(pyfunc):
+        def vectorize_decorator(pyfunc):
             ''' ``vectorize`` with presupplied keyword arguments. '''
-            self = object.__new__(cls)
-            self.__init__(pyfunc, *args, **kw)
-            return self
+            return cls(pyfunc, *args, **kw)
 
         if pyfunc is None:
-            return new_with_kw
+            return vectorize_decorator
         else:
-            return new_with_kw(pyfunc)
+            return object.__new__(cls)
 
     def __init__(self, pyfunc, otypes=None, doc=None, excluded=None,
                  cache=False, signature=None):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2694,7 +2694,7 @@ class vectorize(object):
     # functions.
     def __new__(cls, pyfunc=np._NoValue, *args, **kwargs):
         def vectorize_decorator(pyfunc):
-            ''' ``vectorize`` with presupplied keyword arguments. '''
+            """ ``vectorize`` with presupplied keyword arguments. """
             return cls(pyfunc, *args, **kwargs)
 
         if pyfunc is np._NoValue:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2692,12 +2692,12 @@ class vectorize(object):
     # __new__ is overriden as a clean way to provide decorator-with-keywords
     # syntax while allowing 'vectorize' to remain as the type of vectorized
     # functions.
-    def __new__(cls, pyfunc=np._NoValue, *args, **kwargs):
+    def __new__(cls, pyfunc=None, *args, **kwargs):
         def vectorize_decorator(pyfunc):
             """ ``vectorize`` with presupplied keyword arguments. """
             return cls(pyfunc, *args, **kwargs)
 
-        if pyfunc is np._NoValue:
+        if pyfunc is None:
             return vectorize_decorator
         else:
             return object.__new__(cls)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1447,6 +1447,13 @@ class TestVectorize(object):
         with assert_raises_regex(ValueError, 'new output dimensions'):
             f(x)
 
+    def test_otypes_positional(self):
+        # This supplies the first keyword argument as a positional,
+        # to ensure that they are still properly forwarded after the
+        # enhancement for #9477
+        f = vectorize((lambda x: x), ['float64'])
+        r = f([2])
+        assert_equal(r.dtype, np.dtype('float64'))
 
 class TestDigitize(object):
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1136,8 +1136,8 @@ class TestVectorize(object):
         assert_array_equal(r, [1, 6, 1, 2])
 
     def test_keywords(self):
-
         args = np.array([1, 2, 3])
+
         def foo(a, b=1):
             return a + b
 
@@ -1224,6 +1224,7 @@ class TestVectorize(object):
 
     def test_assigning_docstring(self):
         doc = "Provided documentation"
+
         def foo(x):
             """Original documentation"""
             return x
@@ -1461,6 +1462,7 @@ class TestVectorize(object):
         arg_value = 'added arg!'
         kw_value = 'added kw!'
         call_value = 'added arg to call!'
+
         class my_vectorize(vectorize):
             # user can add args and permute/rename existing args in __init__
             # (note: the renaming of 'pyfunc' to 'f' is important to
@@ -1510,6 +1512,7 @@ class TestVectorize(object):
         assert_equal(f.new_kw, kw_value)
         assert_equal(r[1], call_value)
         assert_array_equal(r[0], [True, False])
+
 
 class TestDigitize(object):
 


### PR DESCRIPTION
Allow `np.vectorize` to be called without a function.  This provides a way to supply keyword arguments when it is used as a decorator.

```python
import numpy as np

@np.vectorize(otypes=['float64'])
def double(x):
    return 2 * x
```

This change is made while preserving the class of `vectorize` functions.

This is accomplished cleanly by overriding the `__new__` method to return either a constructed instance or a local function.

<details>
<summary>Outdated comments on version in first commit</summary>

Known shortcomings of this particular implementation:
* The decorator returned by `np.vectorize(**kw)` is not a pure function (you can only use it once).  I let this slide since it's meant for use as a decorator.  However, I could potentially see a clever user doing something like `my_deco = np.vectorize(otypes=['int'])` only to have their heart shattered when they try to use it more than once.
* [It is a tad slower than before](https://github.com/numpy/numpy/issues/9477#issuecomment-324178563).  (I measure a constant overhead of 0.4s per 1 million calls)
  - (that's calls to the vectorized function, not the wrapped function)
  - I'm actually confused by this result.  ~Does it really take 0.4us per call just to do `if self.member is not None: self.call_something_else(*args, **kw)`?~
    - Yes.  Yes it does.
</details>

Closes #9477