### PR TITLE
BUG: fix infinite loop when creating np.pad on an empty array

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1406,6 +1406,9 @@ def pad(array, pad_width, mode, **kwargs):
             newmat = _append_min(newmat, pad_after, chunk_after, axis)
 
     elif mode == 'reflect':
+        if narray.size == 0:
+            raise ValueError("There aren't any elements to reflect in `array`")
+
         for axis, (pad_before, pad_after) in enumerate(pad_width):
             # Recursive padding along any axis where `pad_amt` is too large
             # for indexing tricks. We can only safely pad the original axis

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1013,6 +1013,10 @@ class TestValueError1(object):
         assert_raises(ValueError, pad, arr, ((-2, 3), (3, 2)),
                       **kwargs)
 
+    def test_check_empty_array(self):
+        assert_raises(ValueError, pad, [], 4, mode='reflect')
+        assert_raises(ValueError, pad, np.ndarray(0), 4, mode='reflect')
+
 
 class TestValueError2(object):
     def test_check_negative_pad_amount(self):


### PR DESCRIPTION
Fixes #9560 

Add input validation on empty list or `ndarray` in `numpy.pad` function.
The issue introduces vulnerability: https://bugzilla.redhat.com/show_bug.cgi?id=1483686