### PR TITLE
DOC: rot90 wrongly positioned versionadded directive.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -56,8 +56,6 @@ def rot90(m, k=1, axes=(0,1)):
 
     Rotation direction is from the first towards the second axis.
 
-    .. versionadded:: 1.12.0
-
     Parameters
     ----------
     m : array_like
@@ -67,6 +65,8 @@ def rot90(m, k=1, axes=(0,1)):
     axes: (2,) array_like
         The array is rotated in the plane defined by the axes.
         Axes must be different.
+
+        .. versionadded:: 1.12.0
 
     Returns
     -------


### PR DESCRIPTION
The directive was added in  #7347 but that PR only added the `axis` argument (so I moved it there). The function has been around for longer [e.g. 1.10.0](https://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.rot90.html)