### PR TITLE
BUG: core: fix wrong method flags for scalartypes.c.src:gentype_copy

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1070,7 +1070,7 @@ array_copy(PyArrayObject *self, PyObject *args, PyObject *kwds)
 
 /* Separate from array_copy to make __copy__ preserve Fortran contiguity. */
 static PyObject *
-array_copy_keeporder(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_copy_keeporder(PyArrayObject *self, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ":__copy__")) {
         return NULL;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1914,7 +1914,7 @@ static PyMethodDef gentype_methods[] = {
     /* for the copy module */
     {"__copy__",
         (PyCFunction)gentype_copy,
-        METH_VARARGS, NULL},
+        METH_VARARGS | METH_KEYWORDS, NULL},
     {"__deepcopy__",
         (PyCFunction)gentype___deepcopy__,
         METH_VARARGS, NULL},

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1529,7 +1529,7 @@ gentype_wraparray(PyObject *NPY_UNUSED(scalar), PyObject *args)
  */
 /**begin repeat
  *
- * #name = tolist, item, __deepcopy__,
+ * #name = tolist, item, __deepcopy__, __copy__,
  *         swapaxes, conj, conjugate, nonzero,
  *         fill, transpose, newbyteorder#
  */
@@ -1913,8 +1913,8 @@ static PyMethodDef gentype_methods[] = {
 
     /* for the copy module */
     {"__copy__",
-        (PyCFunction)gentype_copy,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        (PyCFunction)gentype___copy__,
+        METH_VARARGS, NULL},
     {"__deepcopy__",
         (PyCFunction)gentype___deepcopy__,
         METH_VARARGS, NULL},

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2247,5 +2247,18 @@ class TestRegression(object):
             else:
                 assert_(t.__hash__ != None)
 
+    def test_scalar_copy(self):
+        scalar_types = set(np.sctypeDict.values())
+        values = {
+            np.void: b"a",
+            np.bytes_: b"a",
+            np.unicode_: "a",
+            np.datetime64: "2017-08-25",
+        }
+        for sctype in scalar_types:
+            item = sctype(values.get(sctype, 1))
+            item2 = copy.copy(item)
+            assert_equal(item, item2)
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The method declaration is
```
/*
 * These gentype_* functions take keyword arguments.
 * The proper flag is METH_VARARGS | METH_KEYWORDS.
 */
/**begin repeat
 *
 * #name = take, getfield, put, repeat, tofile, mean, trace, diagonal, clip,
 *         std, var, sum, cumsum, prod, cumprod, compress, sort, argsort,
 *         round, argmax, argmin, max, min, ptp, any, all, astype, resize,
 *         reshape, choose, tostring, tobytes, copy, searchsorted, view,
 *         flatten, ravel#
 */
static PyObject *
gentype_@name@(PyObject *self, PyObject *args, PyObject *kwds)
{
    return gentype_generic_method(self, args, kwds, "@name@");
}
/**end repeat**/
```
so it has to have `METH_KEYWORDS`.

Fixes gh-9608