### PR TITLE
MAINT: remove try..except clause.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -28,12 +28,7 @@ __all__ = [
     'std', 'sum', 'swapaxes', 'take', 'trace', 'transpose', 'var',
     ]
 
-
-try:
-    _gentype = types.GeneratorType
-except AttributeError:
-    _gentype = type(None)
-
+_gentype = types.GeneratorType
 # save away Python sum
 _sum_ = sum
 


### PR DESCRIPTION
- Generator type has been added to types module in 2.2 we do not need to catch AttributeError