### PR TITLE
DOC: Update release notes for noncentral_f changes.

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -141,6 +141,11 @@ and shifted Chebyshev points of the first kind.
 Improvements
 ============
 
+Numerator degrees of freedom in ``random.noncentral_f`` need only be positive.
+------------------------------------------------------------------------------
+Prior to NumPy 1.14.0, the numerator degrees of freedom needed to be > 1, but
+the distribution is valid for values > 0, which is the new requirement.
+
 The GIL is released for all ``np.einsum`` variations
 ----------------------------------------------------
 Some specific loop structures which have an accelerated loop version

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2109,12 +2109,16 @@ cdef class RandomState:
 
         Parameters
         ----------
-        dfnum : int or array_like of ints
-            Parameter, should be > 0.
-        dfden : int or array_like of ints
-            Parameter, should be > 0.
+        dfnum : float or array_like of floats
+            Numerator degrees of freedom, should be > 0.
+            
+            .. versionchanged:: 1.14.0
+               Earlier NumPy versions required dfnum > 1.
+        dfden : float or array_like of floats
+            Denominator degrees of freedom, should be > 0.
         nonc : float or array_like of floats
-            Parameter, should be >= 0.
+            Non-centrality parameter, the sum of the squares of the numerator
+            means, should be >= 0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  If size is ``None`` (default),


### PR DESCRIPTION
The `dfnum` parameter is now required to be > 0 rather than
the previous > 1.

[ci skip]