### PR TITLE
MAINT: Fix a comment regarding the formula for arange length

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3004,7 +3004,7 @@ PyArray_Arange(double start, double stop, double step, int type_num)
 }
 
 /*
- * the formula is len = (intp) ceil((start - stop) / step);
+ * the formula is len = (intp) ceil((stop - start) / step);
  */
 static npy_intp
 _calc_length(PyObject *start, PyObject *stop, PyObject *step, PyObject **next, int cmplx)


### PR DESCRIPTION
The code computes `PyNumber_Subtract(stop, start)` so I changed the comment about the formula from `start - stop` to `stop - start`.