### PR TITLE
ENH: Allow Fortran arrays of dimension 0

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -175,6 +175,11 @@ them more clear::
     >>> np.polynomial.Polynomial(range(4))
     Polynomial([ 0.,  1.,  2.,  3.], domain=[-1,  1], window=[-1,  1])
 
+f2py now handles arrays of dimension 0
+--------------------------------------
+f2py now allows for the allocation of arrays of dimension 0. This allows for
+more consistent handling of corner cases downstream.
+
 
 Changes
 =======

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -595,8 +595,8 @@ static int check_and_fix_dimensions(const PyArrayObject* arr,
                                     npy_intp *dims);
 
 static int
-count_nonpos(const int rank,
-             const npy_intp *dims) {
+count_negative_dimensions(const int rank,
+                          const npy_intp *dims) {
     int i=0,r=0;
     while (i<rank) {
         if (dims[i] < 0) ++r;
@@ -678,7 +678,7 @@ PyArrayObject* array_from_pyobj(const int type_num,
         || ((intent & F2PY_OPTIONAL) && (obj==Py_None))
         ) {
         /* intent(cache), optional, intent(hide) */
-        if (count_nonpos(rank,dims)) {
+        if (count_negative_dimensions(rank,dims) > 0) {
             int i;
             strcpy(mess, "failed to create intent(cache|hide)|optional array"
                    "-- must have defined dimensions but got (");

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -599,7 +599,7 @@ count_nonpos(const int rank,
              const npy_intp *dims) {
     int i=0,r=0;
     while (i<rank) {
-        if (dims[i] <= 0) ++r;
+        if (dims[i] < 0) ++r;
         ++i;
     }
     return r;

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -15,6 +15,9 @@ class TestSizeSumExample(util.F2PyTest):
 
     @dec.slow
     def test_all(self):
+        r = self.module.foo([[]])
+        assert_equal(r, [0], repr(r))
+
         r = self.module.foo([[1, 2]])
         assert_equal(r, [3], repr(r))
 
@@ -26,6 +29,9 @@ class TestSizeSumExample(util.F2PyTest):
 
     @dec.slow
     def test_transpose(self):
+        r = self.module.foo([[]])
+        assert_equal(r, [[]], repr(r))
+
         r = self.module.trans([[1, 2]])
         assert_equal(r, [[1], [2]], repr(r))
 
@@ -34,6 +40,9 @@ class TestSizeSumExample(util.F2PyTest):
 
     @dec.slow
     def test_flatten(self):
+        r = self.module.flatten([[]])
+        assert_equal(r, [], repr(r))
+
         r = self.module.flatten([[1, 2]])
         assert_equal(r, [1, 2], repr(r))
 

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import os
 
+from numpy import array
 from numpy.testing import run_module_suite, assert_equal, dec
 from . import util
 
@@ -29,8 +30,8 @@ class TestSizeSumExample(util.F2PyTest):
 
     @dec.slow
     def test_transpose(self):
-        r = self.module.foo([[]])
-        assert_equal(r, [[]], repr(r))
+        r = self.module.trans([[]])
+        assert_equal(r, array([[]]).T, repr(r))
 
         r = self.module.trans([[1, 2]])
         assert_equal(r, [[1], [2]], repr(r))

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -2,7 +2,6 @@ from __future__ import division, absolute_import, print_function
 
 import os
 
-from numpy import array
 from numpy.testing import run_module_suite, assert_equal, dec
 from . import util
 
@@ -31,7 +30,7 @@ class TestSizeSumExample(util.F2PyTest):
     @dec.slow
     def test_transpose(self):
         r = self.module.trans([[]])
-        assert_equal(r, array([[]]).T, repr(r))
+        assert_equal(r.T, [[]], repr(r))
 
         r = self.module.trans([[1, 2]])
         assert_equal(r, [[1], [2]], repr(r))


### PR DESCRIPTION
Up until now, f2py threw an error when arrays were declared which had dimension of length 0. This, however, is a perfectly legal case, and in fact occurs frequently in the context of linear algrebra. This bug was discovered, for example, in an interface that does matrix tridiagonalization. If the matrix is 1x1, the super- and subdiagonal are of length 0.

Note that negative dimensions continue to produce errors although Fortran also allows this (it always allocates to size max(0, n)).

Fixes #9617.