### PR TITLE
BUG: test, fix issue #9620 __radd__ in char scalars

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -437,6 +437,18 @@ gentype_format(PyObject *self, PyObject *args)
     return ret;
 }
 
+/*
+ * override method lookup for inconsistent handling of
+ * __radd__ on c-extension types with dual inheritanace
+ */
+static PyObject *
+chartype_radd(PyObject *self, PyObject *args)
+{
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
+
 #ifdef FORCE_NO_LONG_DOUBLE_FORMATTING
 #undef NPY_LONGDOUBLE_FMT
 #define NPY_LONGDOUBLE_FMT NPY_DOUBLE_FMT
@@ -2066,6 +2078,11 @@ static PyMethodDef gentype_methods[] = {
     {NULL, NULL, 0, NULL} /* sentinel */
 };
 
+static PyMethodDef chartype_methods[] = {
+    {"__radd__",
+        (PyCFunction)chartype_radd, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL} /* sentinel */
+};
 
 static PyGetSetDef voidtype_getsets[] = {
     {"flags",
@@ -4068,6 +4085,8 @@ initialize_numeric_types(void)
     PyGenericArrType_Type.tp_repr = gentype_repr;
     PyGenericArrType_Type.tp_str = gentype_str;
     PyGenericArrType_Type.tp_richcompare = gentype_richcompare;
+
+    PyCharacterArrType_Type.tp_methods = chartype_methods;
 
     PyBoolArrType_Type.tp_as_number = &bool_arrtype_as_number;
     /*

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2260,5 +2260,17 @@ class TestRegression(object):
             item2 = copy.copy(item)
             assert_equal(item, item2)
 
+
+    def test_char_radd(self):
+        # GH issue 9620, used to reach gentype_add and raise TypeError
+        np_s = np.string_('abc')
+        np_u = np.unicode_('abc')
+        s = 'def'
+        u = u'def'
+        assert np_s.__radd__(np_s) is NotImplemented
+        assert np_u.__radd__(np_u) is NotImplemented
+        assert s + np_s == 'defabc'
+        assert u + np_u == u'defabc'
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
BUG: ``np.string_('abc').__radd__('abc')`` called into ``gentype_add``, but since it is a subtype of str it should return NotImplemented. Fixes issue #9620, tests added for both ``np.string_`` and ``np.unicode_``