### PR TITLE
BUG: test, fix issue #9620 __radd__ in char scalars

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -195,9 +195,21 @@ gentype_generic_method(PyObject *self, PyObject *args, PyObject *kwds,
     }
 }
 
+static PyObject *
+gentype_add(PyObject *m1, PyObject* m2)
+{
+    /* special case str.__radd__, which should not call array_add */
+    if (PyString_Check(m1) || PyUnicode_Check(m1)) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_add, gentype_add);
+    return PyArray_Type.tp_as_number->nb_add(m1, m2);
+}
+
 /**begin repeat
  *
- * #name = add, subtract, remainder, divmod, lshift, rshift,
+ * #name = subtract, remainder, divmod, lshift, rshift,
  *         and, xor, or, floor_divide, true_divide#
  */
 static PyObject *

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2260,5 +2260,6 @@ class TestRegression(object):
             item2 = copy.copy(item)
             assert_equal(item, item2)
 
+
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -38,5 +38,41 @@ class TestInherit(object):
         y = C0(2.0)
         assert_(str(y) == '2.0')
 
+
+class TestCharacter(object):
+    def test_char_radd(self):
+        # GH issue 9620, reached gentype_add and raise TypeError
+        np_s = np.string_('abc')
+        np_u = np.unicode_('abc')
+        s = b'def'
+        u = u'def'
+        assert_(np_s.__radd__(np_s) is NotImplemented)
+        assert_(np_s.__radd__(np_u) is NotImplemented)
+        assert_(np_s.__radd__(s) is NotImplemented)
+        assert_(np_s.__radd__(u) is NotImplemented)
+        assert_(np_u.__radd__(np_s) is NotImplemented)
+        assert_(np_u.__radd__(np_u) is NotImplemented)
+        assert_(np_u.__radd__(s) is NotImplemented)
+        assert_(np_u.__radd__(u) is NotImplemented)
+        assert_(s + np_s == b'defabc')
+        assert_(u + np_u == u'defabc')
+
+
+        class Mystr(str, np.generic):
+            # would segfault
+            pass
+
+        ret = s + Mystr('abc')
+        assert_(type(ret) is type(s))
+
+    def test_char_repeat(self):
+        np_s = np.string_('abc')
+        np_u = np.unicode_('abc')
+        np_i = np.int(5)
+        res_np = np_s * np_i
+        res_s = b'abc' * 5
+        assert_(res_np == res_s)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
BUG: ``np.string_('abc').__radd__('abc')`` called into ``gentype_add``, but since it is a subtype of str it should return NotImplemented. Fixes issue #9620, tests added for both ``np.string_`` and ``np.unicode_``