### PR TITLE
MAINT: Warn if out argument has refcnt 1 and owns its data.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -502,16 +502,18 @@ _set_out_array(PyObject *obj, PyArrayObject **store)
         return 0;
     }
     if PyArray_Check(obj) {
+#ifndef PYPY_VERSION
         if (Py_REFCNT(obj) == 1 &&
                 (PyArray_FLAGS((PyArrayObject *)obj) & NPY_ARRAY_OWNDATA)) {
             if (PyErr_WarnEx(PyExc_RuntimeWarning,
                              "the output array seems to be a new array, if the "
                              "returned values of the ufunc are not assigned to "
-                             "a new variable the results may be lost.",
+                             "a new variable the results may be lost",
                              1) < 0) {
                 return -1;
             }
         }
+#endif
         /* If it's an array, store it */
         if (PyArray_FailUnlessWriteable((PyArrayObject *)obj,
                                         "output array") < 0) {

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import itertools
+import warnings
 
 import numpy as np
 from numpy.testing import (run_module_suite, assert_, assert_raises, assert_equal,
@@ -608,7 +609,9 @@ def assert_copy_equivalent(operation, args, out, **kwargs):
     kwargs2['out'] = out.copy()
 
     out_orig = out.copy()
-    out[...] = operation(*args, **kwargs2)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        out[...] = operation(*args, **kwargs2)
     expected = out.copy()
     out[...] = out_orig
 
@@ -831,7 +834,9 @@ class TestUFunc(object):
 
             a[...] = a_orig
             b[...] = b_orig
-            c1 = ufunc(a, out=b.copy(), where=mask.copy()).copy()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                c1 = ufunc(a, out=b.copy(), where=mask.copy()).copy()
 
             a[...] = a_orig
             b[...] = b_orig
@@ -887,7 +892,9 @@ class TestUFunc(object):
         ufunc = np.invert
 
         def check(a, out, mask):
-            c1 = ufunc(a, out=out.copy(), where=mask.copy())
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                c1 = ufunc(a, out=out.copy(), where=mask.copy())
             c2 = ufunc(a, out=out, where=mask)
             assert_array_equal(c1, c2)
 

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -2,11 +2,11 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import itertools
-import warnings
 
 import numpy as np
 from numpy.testing import (run_module_suite, assert_, assert_raises, assert_equal,
-                           assert_array_equal, assert_allclose, dec)
+                           assert_array_equal, assert_allclose, dec,
+                           suppress_warnings)
 
 from numpy.core.multiarray_tests import solve_diophantine, internal_overlap
 from numpy.core import umath_tests
@@ -609,8 +609,8 @@ def assert_copy_equivalent(operation, args, out, **kwargs):
     kwargs2['out'] = out.copy()
 
     out_orig = out.copy()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with suppress_warnings() as sup:
+        sup.filter(RuntimeWarning, ".*the results may be lost")
         out[...] = operation(*args, **kwargs2)
     expected = out.copy()
     out[...] = out_orig
@@ -834,8 +834,8 @@ class TestUFunc(object):
 
             a[...] = a_orig
             b[...] = b_orig
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
+            with suppress_warnings() as sup:
+                sup.filter(RuntimeWarning, ".*the results may be lost")
                 c1 = ufunc(a, out=b.copy(), where=mask.copy()).copy()
 
             a[...] = a_orig
@@ -892,8 +892,8 @@ class TestUFunc(object):
         ufunc = np.invert
 
         def check(a, out, mask):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
+            with suppress_warnings() as sup:
+                sup.filter(RuntimeWarning, ".*the results may be lost")
                 c1 = ufunc(a, out=out.copy(), where=mask.copy())
             c2 = ufunc(a, out=out, where=mask)
             assert_array_equal(c1, c2)

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -597,6 +597,15 @@ class TestUfunc(object):
         umt.inner1d(a, b, out=c[..., 0])
         assert_array_equal(c[..., 0], np.sum(a*b, axis=-1), err_msg=msg)
 
+        # Passing a temporary array as out= argument emits a Warning.
+        arr = np.ones(3)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            np.add(arr, arr, out=np.empty(3))
+        assert len(w) == 1
+        assert w[0].category is RuntimeWarning
+        assert "the results may be lost" in str(w[0].message)
+
     def test_innerwt(self):
         a = np.arange(6).reshape((2, 3))
         b = np.arange(10, 16).reshape((2, 3))

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -10,7 +10,7 @@ from numpy.core.test_rational import rational, test_add, test_add_rationals
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    assert_no_warnings, assert_allclose,
+    assert_no_warnings, assert_allclose, suppress_warnings, IS_PYPY
 )
 
 
@@ -599,12 +599,11 @@ class TestUfunc(object):
 
         # Passing a temporary array as out= argument emits a Warning.
         arr = np.ones(3)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with suppress_warnings() as sup:
+            w = sup.record(RuntimeWarning, ".*the results may be lost")
             np.add(arr, arr, out=np.empty(3))
-        assert len(w) == 1
-        assert w[0].category is RuntimeWarning
-        assert "the results may be lost" in str(w[0].message)
+            if not IS_PYPY:
+                assert_(len(w) == 1)
 
     def test_innerwt(self):
         a = np.arange(6).reshape((2, 3))

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import warnings
 import itertools
+import sys
 
 import numpy as np
 import numpy.core.umath_tests as umt
@@ -602,7 +603,11 @@ class TestUfunc(object):
         with suppress_warnings() as sup:
             w = sup.record(RuntimeWarning, ".*the results may be lost")
             np.add(arr, arr, out=np.empty(3))
-            if not IS_PYPY:
+            if IS_PYPY or sys.version_info >= (3, 6):
+                # The reference count of arguments changed in 3.6 and it doesn't
+                # emit the Warning.
+                pass
+            else:
                 assert_(len(w) == 1)
 
     def test_innerwt(self):


### PR DESCRIPTION
Based on the feedback in #7244 but it doesn't actually solve it (see below) emit a RuntimeWarning in case the `out` argument seems dubious. Note that this test can lead to false positives in case someone actually catches the result:

```
res = np.add([1,2], [3,4], out=np.empty(2))
```

And it won't trigger if someone actually makes a new array and creates a view on that:

```
res = np.add([1,2], [3,4], out=np.empty(2).ravel())
```