### PR TITLE
MAINT: Fix compiler warnings and update travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ python:
 matrix:
   include:
     - python: 2.7
-      env: PY3_COMPATIBILITY_CHECK=1
-    - python: 2.7
       env: USE_CHROOT=1 ARCH=i386 DIST=zesty PYTHON=2.7
       sudo: true
       dist: trusty
@@ -69,7 +67,7 @@ matrix:
        - PYTHONOPTIMIZE=2
        - USE_ASV=1
     - python: 2.7
-      env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OO=1
+      env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OPTS="-3 -OO"
     - python: 2.7
       env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - python: 2.7
       env: PY3_COMPATIBILITY_CHECK=1
     - python: 2.7
-      env: USE_CHROOT=1 ARCH=i386 DIST=yakkety PYTHON=2.7
+      env: USE_CHROOT=1 ARCH=i386 DIST=zesty PYTHON=2.7
       sudo: true
       dist: trusty
       addons:

--- a/numpy/core/src/private/mem_overlap.c
+++ b/numpy/core/src/private/mem_overlap.c
@@ -181,15 +181,16 @@
   All rights reserved.
   Licensed under 3-clause BSD license, see LICENSE.txt.
 */
-#include <stdlib.h>
-#include <stdio.h>
-#include <assert.h>
 #include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #include "numpy/ndarraytypes.h"
 #include "mem_overlap.h"
 #include "npy_extint128.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
 
 
 #define MAX(a, b) (((a) >= (b)) ? (a) : (b))

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -21,6 +21,7 @@
 #include "npy_config.h"
 #include "npy_pycompat.h"
 
+#include "numpy/ufuncobject.h"
 #include "lowlevel_strided_loops.h"
 #include "reduction.h"
 #include "extobj.h"  /* for _check_ufunc_fperr */

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -41,10 +41,10 @@
  *   SOFTWARE OR ITS DOCUMENTATION.
  */
 
-#include <math.h>
-#include <stdlib.h>
 #include "distributions.h"
 #include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
 
 #ifndef min
 #define min(x,y) ((x<y)?x:y)

--- a/numpy/random/mtrand/randomkit.c
+++ b/numpy/random/mtrand/randomkit.c
@@ -64,13 +64,6 @@
 
 /* static char const rcsid[] =
   "@(#) $Jeannot: randomkit.c,v 1.28 2005/07/21 22:14:09 js Exp $"; */
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <limits.h>
-#include <math.h>
-#include <assert.h>
 
 #ifdef _WIN32
 /*
@@ -109,18 +102,27 @@
 #include <wincrypt.h>
 #endif
 
-#else
-/* Unix */
-#include <time.h>
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /*
  * Do not move this include. randomkit.h must be included
  * after windows timeb.h is included.
  */
 #include "randomkit.h"
+
+#else
+/* Unix */
+#include "randomkit.h"
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+#include <assert.h>
 
 #ifndef RK_DEV_URANDOM
 #define RK_DEV_URANDOM "/dev/urandom"

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -20,13 +20,8 @@ source builds/venv/bin/activate
 PYTHON=${PYTHON:-python}
 PIP=${PIP:-pip}
 
-if [ -n "$PYTHON_OO" ]; then
-  PYTHON="${PYTHON} -OO"
-fi
-
-
-if [ -n "$PY3_COMPATIBILITY_CHECK" ]; then
-  PYTHON="${PYTHON} -3"
+if [ -n "$PYTHON_OPTS" ]; then
+  PYTHON="${PYTHON} $PYTHON_OPTS"
 fi
 
 # make some warnings fatal, mostly to match windows compilers

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -46,21 +46,23 @@ setup_base()
   # see e.g. gh-2766...
   if [ -z "$USE_DEBUG" ]; then
     if [ -z "$IN_CHROOT" ]; then
-      $PIP install .
+      $PIP install -v . 2>&1 | tee log
     else
       sysflags="$($PYTHON -c "from distutils import sysconfig; \
         print (sysconfig.get_config_var('CFLAGS'))")"
       CFLAGS="$sysflags $werrors -Wlogical-op" $PIP install -v . 2>&1 | tee log
-      grep -v "_configtest" log \
-        | grep -vE "ld returned 1|no previously-included files matching|manifest_maker: standard file '-c'" \
-        | grep -E "warning\>" \
-        | tee warnings
-      [[ $(wc -l < warnings) -lt 1 ]]
     fi
   else
     sysflags="$($PYTHON -c "from distutils import sysconfig; \
       print (sysconfig.get_config_var('CFLAGS'))")"
-    CFLAGS="$sysflags $werrors" $PYTHON setup.py build_ext --inplace
+    CFLAGS="$sysflags $werrors" $PYTHON setup.py build_ext --inplace 2>&1 | tee log
+  fi
+  grep -v "_configtest" log \
+    | grep -vE "ld returned 1|no previously-included files matching|manifest_maker: standard file '-c'" \
+    | grep -E "warning\>" \
+    | tee warnings
+  if [ "$LAPACK" != "None" ]; then
+    [[ $(wc -l < warnings) -lt 1 ]]
   fi
 }
 

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -55,11 +55,7 @@ setup_base()
         | grep -vE "ld returned 1|no previously-included files matching|manifest_maker: standard file '-c'" \
         | grep -E "warning\>" \
         | tee warnings
-      # Check for an acceptable number of warnings. Some warnings are out of
-      # our control, so adjust the number as needed. At the moment a
-      # cython generated code produces a warning about '-2147483648L', but
-      # the code seems to compile OK.
-      [[ $(wc -l < warnings) -lt 2 ]]
+      [[ $(wc -l < warnings) -lt 1 ]]
     fi
   else
     sysflags="$($PYTHON -c "from distutils import sysconfig; \


### PR DESCRIPTION
- Restore travis warning check to zero warnings
- Bump 32 bit test to ubuntu zesty (artful won't install right now)
- As travis now uses ubuntu trusty we can drop some special cases
- Enable compiler warning tests for all jobs
- merge python -3 and python -OO jobs into one