### PR TITLE
BUG: fix padding an empty array in reflect mode.

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1406,10 +1406,15 @@ def pad(array, pad_width, mode, **kwargs):
             newmat = _append_min(newmat, pad_after, chunk_after, axis)
 
     elif mode == 'reflect':
-        if narray.size == 0:
-            raise ValueError("There aren't any elements to reflect in `array`")
-
         for axis, (pad_before, pad_after) in enumerate(pad_width):
+            if narray.shape[axis] == 0:
+                # Axes with non-zero padding cannot be empty.
+                if pad_before > 0 or pad_after > 0:
+                    raise ValueError("There aren't any elements to reflect"
+                                     " in axis {} of `array`".format(axis))
+                # Skip zero padding on empty axes.
+                continue
+
             # Recursive padding along any axis where `pad_amt` is too large
             # for indexing tricks. We can only safely pad the original axis
             # length, to keep the period of the reflections consistent.

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -639,6 +639,11 @@ class TestReflect(object):
         b = np.array([1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3])
         assert_array_equal(a, b)
 
+    def test_check_padding_an_empty_array(self):
+        a = pad(np.zeros((0, 3)), ((0,), (1,)), mode='reflect')
+        b = np.zeros((0, 5))
+        assert_array_equal(a, b)
+
 
 class TestSymmetric(object):
     def test_check_simple(self):
@@ -1016,6 +1021,8 @@ class TestValueError1(object):
     def test_check_empty_array(self):
         assert_raises(ValueError, pad, [], 4, mode='reflect')
         assert_raises(ValueError, pad, np.ndarray(0), 4, mode='reflect')
+        assert_raises(ValueError, pad, np.zeros((0, 3)), ((1,), (0,)),
+                      mode='reflect')
 
 
 class TestValueError2(object):


### PR DESCRIPTION
This is a follow up PR for #9599, which rejected padding an empty array with nothing.
(Part of #9560)

 

