### PR TITLE
DOC: add new steering council members.

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -12,8 +12,6 @@ Steering council
 
 * Ralf Gommers
 
-* Alex Griffing
-
 * Charles Harris
 
 * Nathaniel Smith
@@ -22,11 +20,21 @@ Steering council
 
 * Pauli Virtanen
 
+* Eric Wieser
+
+* Marten van Kerkwijk
+
+* Stephan Hoyer
+
+* Allan Haldane
+
 
 Emeritus members
 ----------------
 
 * Travis Oliphant - Project Founder / Emeritus Leader (served: 2005-2012)
+
+* Alex Griffing (served: 2015-2017)
 
 
 NumFOCUS Subcommittee


### PR DESCRIPTION
*Discussed on the numpy-discussion mailing list on July 21-25 2017.*

@eric-wieser, @ahaldane, @mhvk, @shoyer are you all happy to joint the NumPy Steering Council?

Emailed @argriffing, if he doesn't reply soon we will have to have a vote before removing him.