### PR TITLE
BUG: Fix usage of keyword "from" as argument name for "can_cast".

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -108,6 +108,12 @@ the result is always a view on the original masked array.
 This breaks any code that used ``masked_arr.squeeze() is np.ma.masked``, but
 fixes code that writes to the result of `.squeeze()`.
 
+Renamed first parameter of ``can_cast`` from ``from`` to ``from_``
+------------------------------------------------------------------
+The previous parameter name ``from`` is a reserved keyword in Python, which made
+it difficult to pass the argument by name. This has been fixed by renaming
+the parameter to ``from_``.
+
 
 C API changes
 =============

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -1589,7 +1589,7 @@ add_newdoc('numpy.core.multiarray', 'lexsort',
 
 add_newdoc('numpy.core.multiarray', 'can_cast',
     """
-    can_cast(from, totype, casting = 'safe')
+    can_cast(from_, to, casting='safe')
 
     Returns True if cast between data types can occur according to the
     casting rule.  If from is a scalar or array scalar, also returns
@@ -1598,9 +1598,9 @@ add_newdoc('numpy.core.multiarray', 'can_cast',
 
     Parameters
     ----------
-    from : dtype, dtype specifier, scalar, or array
+    from_ : dtype, dtype specifier, scalar, or array
         Data type, scalar, or array to cast from.
-    totype : dtype or dtype specifier
+    to : dtype or dtype specifier
         Data type to cast to.
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur.

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3224,7 +3224,7 @@ array_can_cast_safely(PyObject *NPY_UNUSED(self), PyObject *args,
     npy_bool ret;
     PyObject *retobj = NULL;
     NPY_CASTING casting = NPY_SAFE_CASTING;
-    static char *kwlist[] = {"from", "to", "casting", NULL};
+    static char *kwlist[] = {"from_", "to", "casting", NULL};
 
     if(!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|O&:can_cast", kwlist,
                 &from_obj,

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -872,6 +872,9 @@ class TestTypes(object):
         assert_raises(TypeError, np.can_cast, 'i4', None)
         assert_raises(TypeError, np.can_cast, None, 'i4')
 
+        # Also test keyword arguments
+        assert_(np.can_cast(from_=np.int32, to=np.int64))
+
 
 # Custom exception class to test exception propagation in fromiter
 class NIterError(Exception):


### PR DESCRIPTION
I also removed an inconsistency regarding the second argument name between documentation (`totype`) and code (`to`).

Currently the only way to pass in the first argument as keyword argument is by unpacking a dictionary:

```
np.can_cast(**{'from': np.int32, 'to': np.int64})
```

because `from` is a keyword this isn't possible:

```
np.can_cast(from=np.int32, to=np.int64)
```