### PR TITLE
MAINT: Simplify block implementation

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -406,7 +406,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
                       for i, arr in enumerate(arrays))
 
         first_index, max_arr_ndim = next(idxs_ndims)
-        for i, (index, ndim) in enumerate(idxs_ndims, 1):
+        for index, ndim in idxs_ndims:
             if ndim > max_arr_ndim:
                 max_arr_ndim = ndim
             if len(index) != len(first_index):

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -370,6 +370,11 @@ def _block_check_depths_match(arrays, index=[]):
         idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
         return 'arrays' + idx_str
     if type(arrays) is tuple:
+        # not strictly necessary, but saves us from:
+        #  - more than one way to do things - no point treating tuples like
+        #    lists
+        #  - horribly confusing behaviour that results when tuples are
+        #    treated like ndarray
         raise TypeError(
             '{} is a tuple. '
             'Only lists can be used to arrange blocks, and np.block does '

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -435,12 +435,11 @@ def _block(arrays, list_ndim):
                 raise ValueError('Lists cannot be empty')
             arrs = [block_recursion(arr, depth+1) for arr in arrays]
             arr_ndim = max(arr.ndim for arr in arrs)
-            ndim = max(list_ndim, arr_ndim)
-            arrs = [atleast_nd(a, ndim) for a in arrs]
-            return _nx.concatenate(arrs, axis=depth+ndim-list_ndim)
+            arrs = [atleast_nd(a, arr_ndim) for a in arrs]
+            return _nx.concatenate(arrs, axis=depth+max(0, arr_ndim-list_ndim))
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
-            return atleast_nd(arrays, depth)
+            return atleast_nd(arrays, list_ndim)
 
     return block_recursion(arrays)
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -402,11 +402,13 @@ def _block_check_depths_match(arrays, parent_index=[]):
             )
         )
     elif type(arrays) is list and len(arrays) > 0:
-        indexes, arr_ndims = zip(*[_block_check_depths_match(arr, parent_index + [i])
-                                   for i, arr in enumerate(arrays)])
+        idxs_ndims = (_block_check_depths_match(arr, parent_index + [i])
+                      for i, arr in enumerate(arrays))
 
-        first_index = indexes[0]
-        for i, index in enumerate(indexes):
+        first_index, max_arr_ndim = idxs_ndims.__next__()
+        for i, (index, ndim) in enumerate(idxs_ndims, 1):
+            if ndim > max_arr_ndim:
+                max_arr_ndim = ndim
             if len(index) != len(first_index):
                 raise ValueError(
                     "List depths are mismatched. First element was at depth "
@@ -416,7 +418,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
                         format_index(index)
                     )
                 )
-        return first_index, max(arr_ndims)
+        return first_index, max_arr_ndim
     elif type(arrays) is list and len(arrays) == 0:
         # We've 'bottomed out' on an empty list
         return parent_index + [None], 0

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -8,7 +8,6 @@ from . import numeric as _nx
 from .numeric import array, asanyarray, newaxis
 from .multiarray import normalize_axis_index
 
-
 def atleast_1d(*arys):
     """
     Convert inputs to arrays with at least one dimension.

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -419,7 +419,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
         return first_index, max(arr_ndims)
     elif type(arrays) is list and len(arrays) == 0:
         # We've 'bottomed out' on an empty list
-        return parent_index + [None], _nx.ndim(arrays)
+        return parent_index + [None], 0
     else:
         # We've 'bottomed out' - arrays is either a scalar or an array
         return parent_index, _nx.ndim(arrays)

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -399,8 +399,8 @@ def _block_check_depths_match(arrays, parent_index=[]):
             )
         )
     elif type(arrays) is list and len(arrays) > 0:
-        indexes, arr_ndims = zip(*[_block_check_depths_match(arr, parent_index + [i])
-                                 for i, arr in enumerate(arrays)])
+        indexes, arr_ndims = zip(*(_block_check_depths_match(arr, parent_index + [i])
+                                   for i, arr in enumerate(arrays)))
 
         first_index = indexes[0]
         for i, index in enumerate(indexes):
@@ -422,14 +422,14 @@ def _block_check_depths_match(arrays, parent_index=[]):
         return parent_index, _nx.ndim(arrays)
 
 
-def _block(arrays, max_depth, max_ndim):
+def _block(arrays, max_depth, result_ndim):
     def atleast_nd(a, ndim):
         # Ensures `a` has at least `ndim` dimensions by prepending
         # ones to `a.shape` as necessary
         return array(a, ndmin=ndim, copy=False, subok=True)
 
     def block_recursion(arrays, depth=0):
-        if type(arrays) is list:
+        if depth < max_depth:
             if len(arrays) == 0:
                 raise ValueError('Lists cannot be empty')
             arrs = [block_recursion(arr, depth+1) for arr in arrays]
@@ -437,7 +437,7 @@ def _block(arrays, max_depth, max_ndim):
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
             # depth == max_depth
-            return atleast_nd(arrays, max(max_depth, max_ndim))
+            return atleast_nd(arrays, result_ndim)
 
     return block_recursion(arrays)
 
@@ -592,4 +592,4 @@ def block(arrays):
     """
     bottom_index, arr_ndim = _block_check_depths_match(arrays)
     list_ndim = len(bottom_index)
-    return _block(arrays, list_ndim, arr_ndim)
+    return _block(arrays, list_ndim, max(arr_ndim, list_ndim))

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -408,11 +408,11 @@ def _block(arrays, depth=0):
         list_ndim = list_ndims[0]
         arr_ndim = max(arr.ndim for arr in arrs)
         ndim = max(list_ndim, arr_ndim)
-        arrs = [_nx.array(a, ndmin=ndim) for a in arrs]
+        arrs = [array(a, ndmin=ndim, copy=False, subok=True) for a in arrs]
         return _nx.concatenate(arrs, axis=depth+ndim-list_ndim), list_ndim
     else:
         # We've 'bottomed out'
-        return _nx.array(arrays, ndmin=depth), depth
+        return array(arrays, ndmin=depth, copy=False, subok=True), depth
 
 
 def block(arrays):

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -369,7 +369,7 @@ def _block_check_depths_match(arrays, index=[]):
     def format_index(index):
         idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
         return 'arrays' + idx_str
-    if isinstance(arrays, tuple):
+    if type(arrays) is tuple:
         raise TypeError(
             '{} is a tuple. '
             'Only lists can be used to arrange blocks, and np.block does '
@@ -377,7 +377,7 @@ def _block_check_depths_match(arrays, index=[]):
                 format_index(index)
             )
         )
-    elif isinstance(arrays, list) and len(arrays) > 0:
+    elif type(arrays) is list and len(arrays) > 0:
         indexes = [_block_check_depths_match(arr, index + [i])
                    for i, arr in enumerate(arrays)]
 
@@ -393,7 +393,7 @@ def _block_check_depths_match(arrays, index=[]):
                     )
                 )
         return first_index
-    elif isinstance(arrays, list) and len(arrays) == 0:
+    elif type(arrays) is list and len(arrays) == 0:
         # We've 'bottomed out' on an empty list
         return index + [None]
     else:
@@ -402,7 +402,7 @@ def _block_check_depths_match(arrays, index=[]):
 
 
 def _block(arrays, depth=0):
-    if isinstance(arrays, list):
+    if type(arrays) is list:
         if len(arrays) == 0:
             raise ValueError('Lists cannot be empty')
         arrs, list_ndims = zip(*(_block(arr, depth+1) for arr in arrays))

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -407,6 +407,11 @@ def _block_check_depths_match(arrays, index=[]):
 
 
 def _block(arrays, depth=0):
+    def atleast_nd(a, ndim):
+        # Ensures `a` has at least `ndim` dimensions by prepending
+        # ones to `a.shape` as necessary
+        return array(a, ndmin=ndim, copy=False, subok=True)
+
     if type(arrays) is list:
         if len(arrays) == 0:
             raise ValueError('Lists cannot be empty')
@@ -414,11 +419,11 @@ def _block(arrays, depth=0):
         list_ndim = list_ndims[0]
         arr_ndim = max(arr.ndim for arr in arrs)
         ndim = max(list_ndim, arr_ndim)
-        arrs = [array(a, ndmin=ndim, copy=False, subok=True) for a in arrs]
+        arrs = [atleast_nd(a, ndim) for a in arrs]
         return _nx.concatenate(arrs, axis=depth+ndim-list_ndim), list_ndim
     else:
         # We've 'bottomed out'
-        return array(arrays, ndmin=depth, copy=False, subok=True), depth
+        return atleast_nd(arrays, depth), depth
 
 
 def block(arrays):

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -405,7 +405,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
         idxs_ndims = (_block_check_depths_match(arr, parent_index + [i])
                       for i, arr in enumerate(arrays))
 
-        first_index, max_arr_ndim = idxs_ndims.__next__()
+        first_index, max_arr_ndim = next(idxs_ndims)
         for i, (index, ndim) in enumerate(idxs_ndims, 1):
             if ndim > max_arr_ndim:
                 max_arr_ndim = ndim

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -366,6 +366,12 @@ def stack(arrays, axis=0, out=None):
 
 
 def _block_check_depths_match(arrays, index=[]):
+    # Recursive function checking that the depths of nested lists in `arrays`
+    # all match. Mismatch raises a ValueError as described in the block
+    # docstring below.
+    # The entire index (rather than just the depth) is calculated for each
+    # innermost list, in case an error needs to be raised, so that the index
+    # of the offending list can be printed as part of the error.
     def format_index(index):
         idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
         return 'arrays' + idx_str

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -402,8 +402,8 @@ def _block_check_depths_match(arrays, parent_index=[]):
             )
         )
     elif type(arrays) is list and len(arrays) > 0:
-        indexes, arr_ndims = zip(*(_block_check_depths_match(arr, parent_index + [i])
-                                   for i, arr in enumerate(arrays)))
+        indexes, arr_ndims = zip(*[_block_check_depths_match(arr, parent_index + [i])
+                                   for i, arr in enumerate(arrays)])
 
         first_index = indexes[0]
         for i, index in enumerate(indexes):

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -365,7 +365,7 @@ def stack(arrays, axis=0, out=None):
     return _nx.concatenate(expanded_arrays, axis=axis, out=out)
 
 
-def _check_block_depths_match(arrays, index=[]):
+def _block_check_depths_match(arrays, index=[]):
     def format_index(index):
         idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
         return 'arrays' + idx_str
@@ -378,7 +378,7 @@ def _check_block_depths_match(arrays, index=[]):
             )
         )
     elif isinstance(arrays, list) and len(arrays) > 0:
-        indexes = [_check_block_depths_match(arr, index + [i])
+        indexes = [_block_check_depths_match(arr, index + [i])
                    for i, arr in enumerate(arrays)]
 
         first_index = indexes[0]
@@ -408,7 +408,7 @@ def _block(arrays, depth=0):
         list_ndim = list_ndims[0]
         arr_ndim = max(arr.ndim for arr in arrs)
         ndim = max(list_ndim, arr_ndim)
-        arrs = tuple(map(lambda a: _nx.array(a, ndmin=ndim), arrs))
+        arrs = [_nx.array(a, ndmin=ndim) for a in arrs]
         return _nx.concatenate(arrs, axis=depth+ndim-list_ndim), list_ndim
     else:
         # We've 'bottomed out'
@@ -563,5 +563,5 @@ def block(arrays):
 
 
     """
-    _check_block_depths_match(arrays)
+    _block_check_depths_match(arrays)
     return _block(arrays)[0]

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -394,6 +394,7 @@ def _block_check_depths_match(arrays, index=[]):
                 )
         return first_index
     elif isinstance(arrays, list) and len(arrays) == 0:
+        # We've 'bottomed out' on an empty list
         return index + [None]
     else:
         # We've 'bottomed out'

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -423,7 +423,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
         return parent_index
 
 
-def _block(arrays, list_ndim):
+def _block(arrays, max_depth):
     def atleast_nd(a, ndim):
         # Ensures `a` has at least `ndim` dimensions by prepending
         # ones to `a.shape` as necessary
@@ -436,10 +436,11 @@ def _block(arrays, list_ndim):
             arrs = [block_recursion(arr, depth+1) for arr in arrays]
             arr_ndim = max(arr.ndim for arr in arrs)
             arrs = [atleast_nd(a, arr_ndim) for a in arrs]
-            return _nx.concatenate(arrs, axis=depth-list_ndim)
+            return _nx.concatenate(arrs, axis=-(max_depth-depth))
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
-            return atleast_nd(arrays, list_ndim)
+            # depth == max_depth
+            return atleast_nd(arrays, max_depth)
 
     return block_recursion(arrays)
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -378,9 +378,12 @@ def _block_check_depths_match(arrays, parent_index=[]):
     The parameter `parent_index` is the full index of `arrays` within the
     nested lists passed to _block_check_depths_match at the top of the
     recursion.
-    The return value is the full index of an element (specifically the
-    first element) from the bottom of the nesting in `arrays`. An empty
-    list at the bottom of the nesting is represented by a `None` index.
+    The return value is a pair. The first item returned is the full index
+    of an element (specifically the first element) from the bottom of the
+    nesting in `arrays`. An empty list at the bottom of the nesting is
+    represented by a `None` index.
+    The second item is the maximum of the ndims of the arrays nested in
+    `arrays`.
     """
     def format_index(index):
         idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
@@ -423,6 +426,13 @@ def _block_check_depths_match(arrays, parent_index=[]):
 
 
 def _block(arrays, max_depth, result_ndim):
+    """
+    Internal implementation of block. `arrays` is the argument passed to
+    block. `max_depth` is the depth of nested lists within `arrays` and
+    `result_ndim` is the greatest of the dimensions of the arrays in
+    `arrays` and the depth of the lists in `arrays` (see block docstring
+    for details).
+    """
     def atleast_nd(a, ndim):
         # Ensures `a` has at least `ndim` dimensions by prepending
         # ones to `a.shape` as necessary
@@ -436,7 +446,7 @@ def _block(arrays, max_depth, result_ndim):
             return _nx.concatenate(arrs, axis=-(max_depth-depth))
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
-            # depth == max_depth
+            # type(arrays) is not list
             return atleast_nd(arrays, result_ndim)
 
     return block_recursion(arrays)

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -436,7 +436,7 @@ def _block(arrays, list_ndim):
             arrs = [block_recursion(arr, depth+1) for arr in arrays]
             arr_ndim = max(arr.ndim for arr in arrs)
             arrs = [atleast_nd(a, arr_ndim) for a in arrs]
-            return _nx.concatenate(arrs, axis=depth+max(0, arr_ndim-list_ndim))
+            return _nx.concatenate(arrs, axis=depth-list_ndim)
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
             return atleast_nd(arrays, list_ndim)

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -560,6 +560,28 @@ class TestBlock(object):
         assert_raises_regex(TypeError, 'tuple', np.block, ([1, 2], [3, 4]))
         assert_raises_regex(TypeError, 'tuple', np.block, [(1, 2), (3, 4)])
 
+    def test_different_ndims(self):
+        a = 1.
+        b = 2 * np.ones((1, 2))
+        c = 3 * np.ones((1, 1, 3))
+
+        result = np.block([a, b, c])
+        expected = np.array([[[1., 2., 2., 3., 3., 3.]]])
+
+        assert_equal(result, expected)
+
+    def test_different_ndims_depths(self):
+        a = 1.
+        b = 2 * np.ones((1, 2))
+        c = 3 * np.ones((1, 2, 3))
+
+        result = np.block([[a, b], [c]])
+        expected = np.array([[[1., 2., 2.],
+                              [3., 3., 3.],
+                              [3., 3., 3.]]])
+
+        assert_equal(result, expected)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
I've simplified the implementation of numpy.block, without changing its API. I thought the implementation was pretty bloated, particularly with the _Recurser class, which IMO was obscuring the logic of the function. This is a subjective judgement of course.

A happy side effect of this change is that performance of block has improved. I've implemented some benchmarks (based on the test cases), and running
```
python runtests.py --bench-compare master bench_shape_base
```
on my laptop I get
```
    before     after       ratio
  master     this branch
  [6810e1e9] [dbfdf227]
-  136.63μs   101.20μs      0.74  bench_shape_base.time_block_complicated
-  153.14μs   107.66μs      0.70  bench_shape_base.time_3d
-   71.38μs    43.62μs      0.61  bench_shape_base.time_block_with_1d_arrays_multiple_rows
-  172.43μs   105.02μs      0.61  bench_shape_base.time_nested
-   57.96μs    32.39μs      0.56  bench_shape_base.time_block_mixed_1d_and_2d
-   61.10μs    32.99μs      0.54  bench_shape_base.time_block_simple_column_wise
-   32.18μs    16.99μs      0.53  bench_shape_base.time_block_simple_row_wise
-   64.96μs    33.23μs      0.51  bench_shape_base.time_block_with_1d_arrays_column_wise
-   31.49μs    16.01μs      0.51  bench_shape_base.time_block_with_1d_arrays_row_wise
-   27.26μs     8.22μs      0.30  bench_shape_base.time_no_lists
```
This is my first pr submitted to numpy, apologies in advance if there's anything I need to do that I've missed!

**Edit:** bf616bf further improved performance by not copying input arrays. Now:
```
-  133.93μs    71.64μs      0.53  bench_shape_base.time_block_complicated
-  165.07μs    90.00μs      0.55  bench_shape_base.time_3d
-   72.27μs    36.27μs      0.50  bench_shape_base.time_block_with_1d_arrays_multiple_rows
-  178.65μs    91.65μs      0.51  bench_shape_base.time_nested
-   58.82μs    29.15μs      0.50  bench_shape_base.time_block_mixed_1d_and_2d
-   58.27μs    28.19μs      0.48  bench_shape_base.time_block_simple_column_wise
-   33.58μs    14.26μs      0.42  bench_shape_base.time_block_simple_row_wise
-   59.37μs    29.86μs      0.50  bench_shape_base.time_block_with_1d_arrays_column_wise
-   32.34μs    13.81μs      0.43  bench_shape_base.time_block_with_1d_arrays_row_wise
-   27.94μs     7.95μs      0.28  bench_shape_base.time_no_lists
```
**Edit 2:** Updated benchmarks running on bd6729d vs. master:
```
    before     after       ratio
  [e64699dc] [bd6729d0]
+     4.43s      4.83s      1.09  bench_shape_base.Block.time_3d(100)
-  596.23μs   529.67μs      0.89  bench_shape_base.Block.time_block_complicated(100)
-  151.80μs   116.40μs      0.77  bench_shape_base.Block.time_block_simple_column_wise(100)
-   89.47μs    67.53μs      0.75  bench_shape_base.Block.time_block_simple_row_wise(100)
-   60.31μs    44.77μs      0.74  bench_shape_base.Block.time_no_lists(100)
-  330.40μs   226.72μs      0.69  bench_shape_base.Block.time_nested(100)
-   26.58μs    13.42μs      0.50  bench_shape_base.Block.time_no_lists(10)
-   24.79μs    12.36μs      0.50  bench_shape_base.Block.time_no_lists(1)
-  135.44μs    66.13μs      0.49  bench_shape_base.Block.time_block_complicated(10)
-  935.52μs   400.46μs      0.43  bench_shape_base.Block.time_3d(10)
-   56.96μs    24.34μs      0.43  bench_shape_base.Block.time_block_simple_column_wise(10)
-  126.27μs    52.76μs      0.42  bench_shape_base.Block.time_block_complicated(1)
-   55.89μs    23.25μs      0.42  bench_shape_base.Block.time_block_simple_column_wise(1)
-  172.84μs    70.91μs      0.41  bench_shape_base.Block.time_nested(10)
-   31.93μs    12.83μs      0.40  bench_shape_base.Block.time_block_simple_row_wise(10)
-  153.82μs    61.13μs      0.40  bench_shape_base.Block.time_3d(1)
-   30.98μs    12.06μs      0.39  bench_shape_base.Block.time_block_simple_row_wise(1)
-  182.28μs    68.20μs      0.37  bench_shape_base.Block.time_nested(1)
```