### PR TITLE
BUG: Do not rely on undefined casting behavior in numpy.random.

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -736,11 +736,14 @@ long rk_zipf(rk_state *state, double a)
          * just reject this value. This function then models a Zipf
          * distribution truncated to sys.maxint.
          */
-        if ((X < 1) || (X > LONG_MAX)) {
+        if (X > LONG_MAX) {
+            X = 0.0;    /* X < 1 will be rejected */
             continue;
         }
-        T = pow(1.0 + 1.0/X, am1);
-    } while ((V*X*(T-1.0)/(b-1.0)) > (T/b));
+        if (X >= 1) {
+            T = pow(1.0 + 1.0/X, am1);
+        }
+    } while ((X < 1) || ((V*X*(T-1.0)/(b-1.0)) > (T/b)));
     return (long)X;
 }
 

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -736,7 +736,7 @@ long rk_zipf(rk_state *state, double a)
 	    X = LONG_MIN;
 	} else
 	{
-	    X = (long)floor(pow(U, -1.0/am1));
+	    X = (long)X_double;
 	}
         /* The real result may be above what can be represented in a signed
          * long. It will get assigned to -sys.maxint-1. Since this is

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -731,13 +731,13 @@ long rk_zipf(rk_state *state, double a)
         U = 1.0-rk_double(state);
         V = rk_double(state);
 	X_double = floor(pow(U, -1.0/am1));
-	if ((X_double > (double)LONG_MAX) || (X_double < (double)LONG_MIN))
-	{
-	    X = LONG_MIN;
-	} else
-	{
-	    X = (long)X_double;
-	}
+        if ((X_double > (double)LONG_MAX) || (X_double < (double)LONG_MIN))
+        {
+            X = LONG_MIN;
+        } else
+        {
+            X = (long)X_double;
+        }
         /* The real result may be above what can be represented in a signed
          * long. It will get assigned to -sys.maxint-1. Since this is
          * a straightforward rejection algorithm, we can just reject this value

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -45,6 +45,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #ifndef min
 #define min(x,y) ((x<y)?x:y)
@@ -719,7 +720,7 @@ double rk_wald(rk_state *state, double mean, double scale)
 
 long rk_zipf(rk_state *state, double a)
 {
-    double T, U, V;
+    double T, U, V, X_double;
     long X;
     double am1, b;
 
@@ -729,9 +730,16 @@ long rk_zipf(rk_state *state, double a)
     {
         U = 1.0-rk_double(state);
         V = rk_double(state);
-        X = (long)floor(pow(U, -1.0/am1));
+	X_double = floor(pow(U, -1.0/am1));
+	if ((X_double > (double)LONG_MAX) || (X_double < (double)LONG_MIN))
+	{
+	    X = LONG_MIN;
+	} else
+	{
+	    X = (long)floor(pow(U, -1.0/am1));
+	}
         /* The real result may be above what can be represented in a signed
-         * long. It will get casted to -sys.maxint-1. Since this is
+         * long. It will get assigned to -sys.maxint-1. Since this is
          * a straightforward rejection algorithm, we can just reject this value
          * in the rejection condition below. This function then models a Zipf
          * distribution truncated to sys.maxint.

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -725,6 +725,7 @@ long rk_zipf(rk_state *state, double a)
 
     am1 = a - 1.0;
     b = pow(2.0, am1);
+    T = 0.0;
     do
     {
         U = 1.0-rk_double(state);

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -730,7 +730,7 @@ long rk_zipf(rk_state *state, double a)
     {
         U = 1.0-rk_double(state);
         V = rk_double(state);
-	X_double = floor(pow(U, -1.0/am1));
+        X_double = floor(pow(U, -1.0/am1));
         if ((X_double > (double)LONG_MAX) || (X_double < (double)LONG_MIN))
         {
             X = LONG_MIN;

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -720,8 +720,7 @@ double rk_wald(rk_state *state, double mean, double scale)
 
 long rk_zipf(rk_state *state, double a)
 {
-    double T, U, V, X_double;
-    long X;
+    double T, U, V, X;
     double am1, b;
 
     am1 = a - 1.0;
@@ -730,23 +729,25 @@ long rk_zipf(rk_state *state, double a)
     {
         U = 1.0-rk_double(state);
         V = rk_double(state);
-        X_double = floor(pow(U, -1.0/am1));
-        if ((X_double > (double)LONG_MAX) || (X_double < (double)LONG_MIN))
-        {
-            X = LONG_MIN;
-        } else
-        {
-            X = (long)X_double;
-        }
+        X = floor(pow(U, -1.0/am1));
         /* The real result may be above what can be represented in a signed
-         * long. It will get assigned to -sys.maxint-1. Since this is
-         * a straightforward rejection algorithm, we can just reject this value
-         * in the rejection condition below. This function then models a Zipf
+         * long. Since this is a straightforward rejection algorithm, we can
+         * just reject this value. This function then models a Zipf
          * distribution truncated to sys.maxint.
          */
-        T = pow(1.0 + 1.0/X, am1);
-    } while (((V*X*(T-1.0)/(b-1.0)) > (T/b)) || X < 1);
-    return X;
+        if (X > LONG_MAX)
+        {
+            /* X < 1 will be rejected */
+            X = 0.0;
+            continue;
+        }
+        if (X <= 1)
+        {
+            T = pow(1.0 + 1.0/X, am1);
+            continue;
+        }
+    } while ((V*X*(T-1.0)/(b-1.0)) > (T/b));
+    return (long)X;
 }
 
 long rk_geometric_search(rk_state *state, double p)

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -735,19 +735,10 @@ long rk_zipf(rk_state *state, double a)
          * just reject this value. This function then models a Zipf
          * distribution truncated to sys.maxint.
          */
-        if (X > LONG_MAX)
-        {
-            /* X < 1 will be rejected */
-            X = 0.0;
+        if ((X < 1) || (X > LONG_MAX)) {
             continue;
         }
-        if (X >= 1)
-        {
-            T = pow(1.0 + 1.0/X, am1);
-        } else
-        {
-            continue;
-        }
+        T = pow(1.0 + 1.0/X, am1);
     } while ((V*X*(T-1.0)/(b-1.0)) > (T/b));
     return (long)X;
 }

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -741,9 +741,11 @@ long rk_zipf(rk_state *state, double a)
             X = 0.0;
             continue;
         }
-        if (X <= 1)
+        if (X >= 1)
         {
             T = pow(1.0 + 1.0/X, am1);
+        } else
+        {
             continue;
         }
     } while ((V*X*(T-1.0)/(b-1.0)) > (T/b));


### PR DESCRIPTION
Current double to long casting in the zipf function depends on non-standardized behavior. See http://en.cppreference.com/w/c/language/conversion#Real_floating-integer_conversions.

This is potentially dangerous and makes the code fail with tools such as AddressSanitizer.

Adding checks here to prevent overflow during casting and make sure we get the desired behavior.