### PR TITLE
BUG: Make genfromtxt work for empty data and non empty converters

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1600,6 +1600,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             except TypeError:
                 usecols = [usecols, ]
     nbcols = len(usecols or first_values)
+    if not nbcols and converters is not None:
+        nbcols = len(converters)
 
     # Check the names and overwrite the dtype.names if needed
     if names is True:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1954,8 +1954,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                     if i in user_converters:
                         ishomogeneous &= (ttype == dtype.type)
                         if ttype == np.string_:
-                            ttype = "|S%i" % max((len(row[i]) for row in data),
-                                                 default=1)
+                            ttype = "|S%i" % (1 if not data else
+                                              max(len(row[i]) for row in data))
                         descr.append(('', ttype))
                     else:
                         descr.append(('', dtype))

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1954,7 +1954,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                     if i in user_converters:
                         ishomogeneous &= (ttype == dtype.type)
                         if ttype == np.string_:
-                            ttype = "|S%i" % max(len(row[i]) for row in data)
+                            ttype = "|S%i" % max((len(row[i]) for row in data),
+                                                 default=1)
                         descr.append(('', ttype))
                     else:
                         descr.append(('', dtype))

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1839,7 +1839,7 @@ M   33  21.99
         with suppress_warnings() as sup:
             sup.filter(message="genfromtxt: Empty input file:")
             data = TextIO()
-            test = np.genfromtxt(data, converters={0: lambda arg: arg})
+            test = np.genfromtxt(data, converters={0: lambda arg: float(arg)})
             assert_equal(test, np.array([]))
 
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1835,6 +1835,13 @@ M   33  21.99
         assert_equal(test['f1'], 17179869184)
         assert_equal(test['f2'], 1024)
 
+    def test_empty_file_with_converters(self):
+        with suppress_warnings() as sup:
+            sup.filter(message="genfromtxt: Empty input file:")
+            data = TextIO()
+            test = np.genfromtxt(data, converters={0: lambda arg: arg})
+            assert_equal(test, np.array([]))
+
 
 class TestPathUsage(object):
     # Test that pathlib.Path can be used

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1839,8 +1839,17 @@ M   33  21.99
         with suppress_warnings() as sup:
             sup.filter(message="genfromtxt: Empty input file:")
             data = TextIO()
-            test = np.genfromtxt(data, converters={0: lambda arg: float(arg)})
-            assert_equal(test, np.array([]))
+            test = np.genfromtxt(data, converters={0: lambda arg: int(arg)})
+            assert_equal(test, np.array([], dtype=int))
+
+            test = np.genfromtxt(data, converters={0: lambda arg: arg})
+            assert_equal(test, np.array([], dtype='|S1'))
+
+            dtype = np.dtype([('f', 'float32'), ('i', 'int64')])
+            test = np.genfromtxt(data, converters={0: lambda arg: arg},
+                                 dtype=dtype)
+            assert_equal(test, np.array([], dtype=dtype))
+
 
 
 class TestPathUsage(object):


### PR DESCRIPTION
```py
import io

import numpy as np

np.genfromtxt(io.BytesIO(b''), converters={0: lambda s: s})
```

Output (warning about empty data and then traceback):
```
/tmp/test_numpy.py:6: UserWarning: genfromtxt: Empty input file: "<_io.BytesIO object at 0x7fec331e9468>"
  converters={0: lambda s: s})
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/tmp/test_numpy.py in <module>()
      4 
      5 np.genfromtxt(io.BytesIO(b''), filling_values=-1,
----> 6               converters={0: lambda s: s})

~/dev/numpy/numpy/lib/npyio.py in genfromtxt(fname, dtype, comments, delimiter, skip_header, skip_footer, converters, missing_values, filling_values, usecols, names, excludelist, deletechars, replace_space, autostrip, case_sensitive, defaultfmt, unpack, usemask, loose, invalid_raise, max_rows)
   1773         else:
   1774             testing_value = None
-> 1775         converters[i].update(conv, locked=True,
   1776                              testing_value=testing_value,
   1777                              default=filling_values[i],

IndexError: list index out of range
```
