### PR TITLE
PEP 3141 numbers should be considered scalars

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -5,6 +5,7 @@ import itertools
 import operator
 import sys
 import warnings
+import numbers
 
 import numpy as np
 from . import multiarray
@@ -2162,11 +2163,19 @@ def isscalar(num):
     >>> np.isscalar('numpy')
     True
 
+    NumPy supports PEP 3141 numbers:
+
+    >>> from fractions import Fraction
+    >>> isscalar(Fraction(5, 17))
+    True
+    >>> from numbers import Number
+    >>> isscalar(Number())
+    True
+
     """
-    if isinstance(num, generic):
-        return True
-    else:
-        return type(num) in ScalarType
+    return (isinstance(num, generic)
+            or type(num) in ScalarType
+            or isinstance(num, numbers.Number))
 
 
 def binary_repr(num, width=None):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -208,6 +208,22 @@ class TestNonarrayArgs(object):
             assert_(w[0].category is RuntimeWarning)
 
 
+class TestIsscalar(object):
+    def test_isscalar(self):
+        assert_(np.isscalar(3.1))
+        assert_(np.isscalar(np.int16(12345)))
+        assert_(np.isscalar(False))
+        assert_(np.isscalar('numpy'))
+        assert_(not np.isscalar([3.1]))
+        assert_(not np.isscalar(None))
+
+        # PEP 3141
+        from fractions import Fraction
+        assert_(np.isscalar(Fraction(5, 17)))
+        from numbers import Number
+        assert_(np.isscalar(Number()))
+
+
 class TestBoolScalar(object):
     def test_logical(self):
         f = np.False_


### PR DESCRIPTION
The function `numpy.isscalar()` should recognize all [PEP 3141](https://www.python.org/dev/peps/pep-3141/) numbers as scalars.

The underlying issue is that the upgrade to SciPy 0.19.1 broke `lil_matrix()` with Sage Integers as input, because SciPy now uses `numpy.isscalar()` to validate certain inputs.

Downstream: https://trac.sagemath.org/ticket/23867