### PR TITLE
ENH: Add support of ARC architecture

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -15,6 +15,8 @@
  *              NPY_CPU_ARMEB
  *              NPY_CPU_SH_LE
  *              NPY_CPU_SH_BE
+ *              NPY_CPU_ARCEL
+ *              NPY_CPU_ARCEB
  */
 #ifndef _NPY_CPUARCH_H_
 #define _NPY_CPUARCH_H_
@@ -76,6 +78,10 @@
     #define NPY_CPU_AARCH64
 #elif defined(__mc68000__)
     #define NPY_CPU_M68K
+#elif defined(__arc__) && defined(__LITTLE_ENDIAN__)
+    #define NPY_CPU_ARCEL
+#elif defined(__arc__) && defined(__BIG_ENDIAN__)
+    #define NPY_CPU_ARCEB
 #else
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -45,7 +45,8 @@
             || defined(NPY_CPU_AARCH64) \
             || defined(NPY_CPU_SH_LE)   \
             || defined(NPY_CPU_MIPSEL)  \
-            || defined(NPY_CPU_PPC64LE)
+            || defined(NPY_CPU_PPC64LE) \
+            || defined(NPY_CPU_ARCEL)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
     #elif defined(NPY_CPU_PPC)          \
             || defined(NPY_CPU_SPARC)   \
@@ -56,7 +57,8 @@
             || defined(NPY_CPU_SH_BE)   \
             || defined(NPY_CPU_MIPSEB)  \
             || defined(NPY_CPU_OR1K)    \
-            || defined(NPY_CPU_M68K)
+            || defined(NPY_CPU_M68K)    \
+            || defined(NPY_CPU_ARCEB)
         #define NPY_BYTE_ORDER NPY_BIG_ENDIAN
     #else
         #error Unknown CPU: can not set endianness


### PR DESCRIPTION
Synopsys DesignWare ARC Processors are a family of 32-bit CPUs
which in some configurations may run Linux kernel and full stack
of applications on top of it. Among other things is Python.

With that change we allow building and usage of Numpy on ARC.