### PR TITLE
DOC: Add mandatory memo argument to __deepcopy__ method documentation

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3097,7 +3097,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('__copy__',
 
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('__deepcopy__',
-    """a.__deepcopy__() -> Deep copy of array.
+    """a.__deepcopy__(memo, /) -> Deep copy of array.
 
     Used if copy.deepcopy is called on an array.
 


### PR DESCRIPTION
The argument is [mandatory and positional-only](https://github.com/numpy/numpy/blob/v1.13.1/numpy/core/src/multiarray/methods.c#L1471-L1473) and was missing from the documentation.