### PR TITLE
BUG: Fix some (not all) compiler warnings

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -45,6 +45,7 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 #define PyInt_AsLong PyLong_AsLong
 #define PyInt_AS_LONG PyLong_AsLong
 #define PyInt_AsSsize_t PyLong_AsSsize_t
+#define PyInt_FromSsize_t PyLong_FromSsize_t
 
 /* NOTE:
  *

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -191,7 +191,7 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
     if (ret == NULL) {
         return NULL;
     }
-    fd2 = PyNumber_AsSsize_t(ret, NULL);
+    fd2 = (int) PyNumber_AsSsize_t(ret, NULL);
     Py_DECREF(ret);
 
     /* Convert to FILE* handle */

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -183,7 +183,7 @@ convert_datetime_metadata_tuple_to_datetime_metadata(PyObject *tuple,
  * the Python datetime.tzinfo object.
  */
 NPY_NO_EXPORT int
-get_tzoffset_from_pytzinfo(PyObject *timezone, npy_datetimestruct *dts);
+get_tzoffset_from_pytzinfo(PyObject *timezone_obj, npy_datetimestruct *dts);
 
 /*
  * Converts an input object into datetime metadata. The input

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1018,7 +1018,7 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
         PyObject *key, *value, *temp2;
         PyObject *op;
         Py_ssize_t pos = 0;
-        npy_intp result_ndim = PyArray_NDIM(self) > PyArray_NDIM(other) ?
+        int result_ndim = PyArray_NDIM(self) > PyArray_NDIM(other) ?
                             PyArray_NDIM(self) : PyArray_NDIM(other);
 
         op = (cmp_op == Py_EQ ? n_ops.logical_and : n_ops.logical_or);
@@ -1322,7 +1322,7 @@ NPY_NO_EXPORT int
 PyArray_ElementStrides(PyObject *obj)
 {
     PyArrayObject *arr;
-    int itemsize;
+    npy_intp itemsize;
     int i, ndim;
     npy_intp *strides;
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -452,7 +452,7 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
     PyArrayObject *ap = vap;
     PyObject *temp;
     Py_UNICODE *ptr;
-    int datalen;
+    npy_intp datalen;
 #ifndef Py_UNICODE_WIDE
     char *buffer;
 #endif
@@ -654,7 +654,7 @@ VOID_getitem(void *input, void *vap)
     if (PyDataType_HASFIELDS(descr)) {
         PyObject *key;
         PyObject *names;
-        int i, n;
+        npy_intp i, n;
         PyObject *ret;
         PyObject *tup;
         int savedflags;
@@ -784,7 +784,7 @@ NPY_NO_EXPORT int PyArray_CopyObject(PyArrayObject *, PyObject *);
  * WARNING: Clobbers arr's dtype and alignment flag.
  */
 NPY_NO_EXPORT int
-_setup_field(int i, PyArray_Descr *descr, PyArrayObject *arr,
+_setup_field(npy_intp i, PyArray_Descr *descr, PyArrayObject *arr,
             npy_intp *offset_p)
 {
     PyObject *key;
@@ -818,9 +818,9 @@ _copy_and_return_void_setitem(PyArray_Descr *dstdescr, char *dstdata,
                               PyArray_Descr *srcdescr, char *srcdata){
     PyArrayObject_fields dummy_struct;
     PyArrayObject *dummy = (PyArrayObject *)&dummy_struct;
-    npy_int names_size = PyTuple_GET_SIZE(dstdescr->names);
+    npy_intp names_size = PyTuple_GET_SIZE(dstdescr->names);
     npy_intp offset;
-    npy_int i;
+    npy_intp i;
     int ret;
 
     /* Fast path if dtypes are equal */
@@ -1829,7 +1829,7 @@ static int
     @btype@ result;
 
     result = @func@(str, endptr, 10);
-    *(@type@ *)ip = result;
+    *(@type@ *)ip = (@type@) result;
     return 0;
 }
 /**end repeat**/
@@ -1846,7 +1846,7 @@ static int
     double result;
 
     result = NumPyOS_ascii_strtod(str, endptr);
-    *(@type@ *)ip = result;
+    *(@type@ *)ip = (@type@) result;
     return 0;
 }
 /**end repeat**/
@@ -3693,7 +3693,7 @@ static void
 
     delta -= start;
     for (i = 2; i < length; ++i) {
-        buffer[i] = start + i*delta;
+        buffer[i] = (@type@) (start + i*delta);
     }
 }
 /**end repeat**/

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -194,7 +194,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
         Py_ssize_t total_count = 1;
         Py_ssize_t dim_size;
         char buf[128];
-        int old_offset;
+        Py_ssize_t old_offset;
         int ret;
 
         if (PyTuple_Check(descr->subarray->shape)) {
@@ -228,7 +228,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
         return ret;
     }
     else if (PyDataType_HASFIELDS(descr)) {
-        int base_offset = *offset;
+        Py_ssize_t base_offset = *offset;
 
         _append_str(str, "T{");
         for (k = 0; k < PyTuple_GET_SIZE(descr->names); ++k) {
@@ -236,7 +236,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             PyArray_Descr *child;
             char *p;
             Py_ssize_t len;
-            int new_offset;
+            Py_ssize_t new_offset;
 
             name = PyTuple_GET_ITEM(descr->names, k);
             item = PyDict_GetItem(descr->fields, name);

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -362,7 +362,7 @@ __New_PyArray_Std(PyArrayObject *self, int axis, int rtype, PyArrayObject *out,
     PyArrayObject *arr1 = NULL, *arr2 = NULL, *arrnew = NULL;
     PyObject *ret = NULL, *newshape = NULL;
     int i, n;
-    npy_intp val;
+    npy_intp n_ax;
 
     arrnew = (PyArrayObject *)PyArray_CheckAxis(self, &axis, 0);
     if (arrnew == NULL) {
@@ -383,6 +383,7 @@ __New_PyArray_Std(PyArrayObject *self, int axis, int rtype, PyArrayObject *out,
         return NULL;
     }
     for (i = 0; i < n; i++) {
+        npy_intp val;
         if (i == axis) {
             val = 1;
         }
@@ -458,13 +459,13 @@ __New_PyArray_Std(PyArrayObject *self, int axis, int rtype, PyArrayObject *out,
         Py_DECREF(arrnew);
         return NULL;
     }
-    n = PyArray_DIM(arrnew,axis);
+    n_ax = PyArray_DIM(arrnew,axis);
     Py_DECREF(arrnew);
-    n = (n-num);
-    if (n == 0) {
-        n = 1;
+    n_ax = (n_ax-num);
+    if (n_ax == 0) {
+        n_ax = 1;
     }
-    obj2 = PyFloat_FromDouble(1.0/((double )n));
+    obj2 = PyFloat_FromDouble(1.0/((double )n_ax));
     if (obj2 == NULL) {
         Py_DECREF(obj1);
         return NULL;

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -266,7 +266,7 @@ blas_stride(npy_intp stride, unsigned itemsize)
     if (stride > 0 && npy_is_aligned((void *)stride, itemsize)) {
         stride /= itemsize;
         if (stride <= INT_MAX) {
-            return stride;
+            return (int) stride;
         }
     }
     return 0;

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -20,7 +20,7 @@
  * and 0 if the array is not monotonic.
  */
 static int
-check_array_monotonic(const double *a, npy_int lena)
+check_array_monotonic(const double *a, npy_intp lena)
 {
     npy_intp i;
     double next;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -297,7 +297,7 @@ _update_descr_and_dimensions(PyArray_Descr **des, npy_intp *newdims,
 
 NPY_NO_EXPORT void
 _unaligned_strided_byte_copy(char *dst, npy_intp outstrides, char *src,
-                             npy_intp instrides, npy_intp N, int elsize)
+                             npy_intp instrides, npy_intp N, npy_intp elsize)
 {
     npy_intp i;
     char *tout = dst;

--- a/numpy/core/src/multiarray/ctors.h
+++ b/numpy/core/src/multiarray/ctors.h
@@ -63,7 +63,7 @@ _array_fill_strides(npy_intp *strides, npy_intp *dims, int nd, size_t itemsize,
 
 NPY_NO_EXPORT void
 _unaligned_strided_byte_copy(char *dst, npy_intp outstrides, char *src,
-                             npy_intp instrides, npy_intp N, int elsize);
+                             npy_intp instrides, npy_intp N, npy_intp elsize);
 
 NPY_NO_EXPORT void
 _strided_byte_swap(void *p, npy_intp stride, npy_intp n, int size);

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -596,9 +596,9 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
                 out->as = (int)((dt % 1000LL) * 1000);
             }
             else {
-                npy_datetime minutes;
+                int minutes;
 
-                minutes = dt / (60*1000000000000000LL);
+                minutes = (int) (dt / (60*1000000000000000LL));
                 dt = dt % (60*1000000000000000LL);
                 if (dt < 0) {
                     dt += (60*1000000000000000LL);
@@ -622,9 +622,9 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
                 out->as = (int)(dt % 1000000LL);
             }
             else {
-                npy_datetime seconds;
+                int seconds;
 
-                seconds = dt / 1000000000000000000LL;
+                seconds = (int) (dt / 1000000000000000000LL);
                 dt = dt % 1000000000000000000LL;
                 if (dt < 0) {
                     dt += 1000000000000000000LL;
@@ -2890,12 +2890,12 @@ convert_datetime_to_pyobject(npy_datetime dt, PyArray_DatetimeMetaData *meta)
 
     /* If the type's precision is greater than days, return a datetime */
     if (meta->base > NPY_FR_D) {
-        ret = PyDateTime_FromDateAndTime(dts.year, dts.month, dts.day,
+        ret = PyDateTime_FromDateAndTime((int) dts.year, dts.month, dts.day,
                                 dts.hour, dts.min, dts.sec, dts.us);
     }
     /* Otherwise return a date */
     else {
-        ret = PyDate_FromDate(dts.year, dts.month, dts.day);
+        ret = PyDate_FromDate((int) dts.year, dts.month, dts.day);
     }
 
     return ret;

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -178,7 +178,7 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
     localrawtime += out_dts_local->hour * 60;
     localrawtime += out_dts_local->min;
 
-    *out_timezone_offset = localrawtime - rawtime;
+    *out_timezone_offset = (int)(localrawtime - rawtime);
 
     /* Reapply the year 2038 year correction */
     out_dts_local->year += year_correction;

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -885,15 +885,16 @@ lossless_unit_from_datetimestruct(npy_datetimestruct *dts)
  *  string was too short).
  */
 NPY_NO_EXPORT int
-make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
+make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
                     int local, int utc, NPY_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting)
 {
     npy_datetimestruct dts_local;
     int timezone_offset = 0;
 
-    char *substr = outstr, sublen = outlen;
-    int tmplen;
+    char *substr = outstr;
+    npy_intp sublen = outlen;
+    npy_intp tmplen;
 
     /* Handle NaT, and treat a datetime with generic units as NaT */
     if (dts->year == NPY_DATETIME_NAT || base == NPY_FR_GENERIC) {

--- a/numpy/core/src/multiarray/datetime_strings.h
+++ b/numpy/core/src/multiarray/datetime_strings.h
@@ -70,7 +70,7 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  *  string was too short).
  */
 NPY_NO_EXPORT int
-make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
+make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
                     int local, int utc, NPY_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting);
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -355,7 +355,7 @@ _convert_from_tuple(PyObject *obj)
             npy_free_cache_dim_obj(shape);
             goto fail;
         }
-        newdescr->elsize = type->elsize * items;
+        newdescr->elsize = type->elsize * (int) items;
         if (newdescr->elsize == -1) {
             npy_free_cache_dim_obj(shape);
             goto fail;
@@ -420,7 +420,8 @@ _convert_from_tuple(PyObject *obj)
 static PyArray_Descr *
 _convert_from_array_descr(PyObject *obj, int align)
 {
-    int n, i, totalsize;
+    npy_intp n, i;
+    int totalsize;
     int ret;
     PyObject *fields, *item, *newobj;
     PyObject *name, *tup, *title;
@@ -617,7 +618,7 @@ _convert_from_array_descr(PyObject *obj, int align)
 static PyArray_Descr *
 _convert_from_list(PyObject *obj, int align)
 {
-    int n, i;
+    npy_intp n, i;
     int totalsize;
     PyObject *fields;
     PyArray_Descr *conv = NULL;
@@ -1019,7 +1020,7 @@ _convert_from_dict(PyObject *obj, int align)
     PyObject *fields = NULL;
     PyObject *names, *offsets, *descrs, *titles, *tmp;
     PyObject *metadata;
-    int n, i;
+    npy_intp n, i;
     int totalsize, itemsize;
     int maxalign = 0;
     /* Types with fields need the Python C API for field access */
@@ -1087,7 +1088,7 @@ _convert_from_dict(PyObject *obj, int align)
         /* Build item to insert (descr, offset, [title])*/
         len = 2;
         title = NULL;
-        ind = PyInt_FromLong(i);
+        ind = PyInt_FromSsize_t(i);
         if (titles) {
             title=PyObject_GetItem(titles, ind);
             if (title && title != Py_None) {
@@ -1861,9 +1862,9 @@ arraydescr_typename_get(PyArray_Descr *self)
     PyTypeObject *typeobj = self->typeobj;
     PyObject *res;
     char *s;
-    int len;
-    int prefix_len;
-    int suffix_len;
+    npy_intp len;
+    npy_intp prefix_len;
+    npy_intp suffix_len;
 
     if (PyTypeNum_ISUSERDEF(self->type_num)) {
         s = strrchr(typeobj->tp_name, '.');
@@ -1963,7 +1964,7 @@ arraydescr_ndim_get(PyArray_Descr *self)
      */
     if (PyTuple_Check(self->subarray->shape)) {
         Py_ssize_t ndim = PyTuple_Size(self->subarray->shape);
-        return PyInt_FromLong(ndim);
+        return PyInt_FromSsize_t(ndim);
     }
     /* consistent with arraydescr_shape_get */
     return PyInt_FromLong(1);
@@ -2119,8 +2120,8 @@ arraydescr_names_get(PyArray_Descr *self)
 static int
 arraydescr_names_set(PyArray_Descr *self, PyObject *val)
 {
-    int N = 0;
-    int i;
+    npy_intp N;
+    npy_intp i;
     PyObject *new_names;
     PyObject *new_fields;
 
@@ -3039,7 +3040,7 @@ PyArray_DescrNewByteorder(PyArray_Descr *self, char newendian)
         PyObject *old;
         PyArray_Descr *newdescr;
         Py_ssize_t pos = 0;
-        int len, i;
+        npy_intp len, i;
 
         newfields = PyDict_New();
         /* make new dictionary with replaced PyArray_Descr Objects */
@@ -3806,9 +3807,9 @@ descr_subscript(PyArray_Descr *self, PyObject *op)
     }
     else if (PyInt_Check(op)) {
         PyObject *name;
-        int size = PyTuple_GET_SIZE(self->names);
-        int value = PyArray_PyIntAsInt(op);
-        int orig_value = value;
+        npy_intp size = PyTuple_GET_SIZE(self->names);
+        npy_intp value = PyArray_PyIntAsIntp(op);
+        npy_intp orig_value = value;
 
         if (PyErr_Occurred()) {
             return NULL;

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2535,7 +2535,7 @@ get_fields_transfer_function(int aligned,
 {
     PyObject *key, *tup, *title;
     PyArray_Descr *src_fld_dtype, *dst_fld_dtype;
-    npy_int i, field_count, structsize;
+    npy_intp i, field_count, structsize;
     int src_offset, dst_offset;
     _field_transfer_data *data;
     _single_field_transfer *fields;
@@ -2747,7 +2747,7 @@ get_decsrcref_fields_transfer_function(int aligned,
 {
     PyObject *names, *key, *tup, *title;
     PyArray_Descr *src_fld_dtype;
-    npy_int i, names_size, field_count, structsize;
+    npy_intp i, names_size, field_count, structsize;
     int src_offset;
     _field_transfer_data *data;
     _single_field_transfer *fields;
@@ -2818,7 +2818,7 @@ get_setdestzero_fields_transfer_function(int aligned,
 {
     PyObject *names, *key, *tup, *title;
     PyArray_Descr *dst_fld_dtype;
-    npy_int i, names_size, field_count, structsize;
+    npy_intp i, names_size, field_count, structsize;
     int dst_offset;
     _field_transfer_data *data;
     _single_field_transfer *fields;
@@ -3805,7 +3805,7 @@ PyArray_PrepareOneRawArrayIter(int ndim, npy_intp *shape,
     /* Sort the axes based on the destination strides */
     PyArray_CreateSortedStridePerm(ndim, strides, strideperm);
     for (i = 0; i < ndim; ++i) {
-        int iperm = strideperm[ndim - i - 1].perm;
+        npy_intp iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
         out_strides[i] = strides[iperm];
     }
@@ -3935,7 +3935,7 @@ PyArray_PrepareTwoRawArrayIter(int ndim, npy_intp *shape,
     /* Sort the axes based on the destination strides */
     PyArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
     for (i = 0; i < ndim; ++i) {
-        int iperm = strideperm[ndim - i - 1].perm;
+        npy_intp iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
         out_stridesA[i] = stridesA[iperm];
         out_stridesB[i] = stridesB[iperm];
@@ -4069,7 +4069,7 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
     /* Sort the axes based on the destination strides */
     PyArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
     for (i = 0; i < ndim; ++i) {
-        int iperm = strideperm[ndim - i - 1].perm;
+        npy_intp iperm = strideperm[ndim - i - 1].perm;
         out_shape[i] = shape[iperm];
         out_stridesA[i] = stridesA[iperm];
         out_stridesB[i] = stridesB[iperm];

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -602,8 +602,8 @@ finish_after_unrolled_loop:
         while (count >= 8) {
             count -= 8;
 
-            _mm_prefetch(data0 + 512, _MM_HINT_T0);
-            _mm_prefetch(data1 + 512, _MM_HINT_T0);
+            _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
+            _mm_prefetch((char *) (data1 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 4#
@@ -636,8 +636,8 @@ finish_after_unrolled_loop:
         while (count >= 8) {
             count -= 8;
 
-            _mm_prefetch(data0 + 512, _MM_HINT_T0);
-            _mm_prefetch(data1 + 512, _MM_HINT_T0);
+            _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
+            _mm_prefetch((char *) (data1 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 2, 4, 6#
@@ -668,8 +668,8 @@ finish_after_unrolled_loop:
         count -= 8;
 
 #if EINSUM_USE_SSE1 && @float32@
-        _mm_prefetch(data0 + 512, _MM_HINT_T0);
-        _mm_prefetch(data1 + 512, _MM_HINT_T0);
+        _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
+        _mm_prefetch((char *) (data1 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 4#
@@ -682,8 +682,8 @@ finish_after_unrolled_loop:
         accum_sse = _mm_add_ps(accum_sse, a);
 /**end repeat2**/
 #elif EINSUM_USE_SSE2 && @float64@
-        _mm_prefetch(data0 + 512, _MM_HINT_T0);
-        _mm_prefetch(data1 + 512, _MM_HINT_T0);
+        _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
+        _mm_prefetch((char *) (data1 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 2, 4, 6#
@@ -1075,7 +1075,7 @@ finish_after_unrolled_loop:
         while (count >= 8) {
             count -= 8;
 
-            _mm_prefetch(data0 + 512, _MM_HINT_T0);
+            _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 4#
@@ -1106,7 +1106,7 @@ finish_after_unrolled_loop:
         while (count >= 8) {
             count -= 8;
 
-            _mm_prefetch(data0 + 512, _MM_HINT_T0);
+            _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 2, 4, 6#
@@ -1135,7 +1135,7 @@ finish_after_unrolled_loop:
         count -= 8;
 
 #if EINSUM_USE_SSE1 && @float32@
-        _mm_prefetch(data0 + 512, _MM_HINT_T0);
+        _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 4#
@@ -1147,7 +1147,7 @@ finish_after_unrolled_loop:
         accum_sse = _mm_add_ps(accum_sse, _mm_loadu_ps(data0+@i@));
 /**end repeat2**/
 #elif EINSUM_USE_SSE2 && @float64@
-        _mm_prefetch(data0 + 512, _MM_HINT_T0);
+        _mm_prefetch((char *) (data0 + 512), _MM_HINT_T0);
 
 /**begin repeat2
  * #i = 0, 2, 4, 6#
@@ -2080,7 +2080,7 @@ get_single_op_view(PyArrayObject *op, int  iop, char *labels,
     npy_intp new_strides[NPY_MAXDIMS];
     npy_intp new_dims[NPY_MAXDIMS];
     char *out_label;
-    int label, i, idim, ndim, ibroadcast = 0;
+    int label, idim, ndim, ibroadcast = 0;
 
     ndim = PyArray_NDIM(op);
 
@@ -2119,6 +2119,8 @@ get_single_op_view(PyArrayObject *op, int  iop, char *labels,
             ++ibroadcast;
         }
         else {
+            npy_intp i;
+
             /* Find the position for this dimension in the output */
             out_label = (char *)memchr(output_labels, label,
                                                     ndim_output);
@@ -2319,7 +2321,7 @@ prepare_op_axes(int ndim, int iop, char *labels, int *axes,
             }
             /* Otherwise use it */
             else {
-                axes[i] = match - labels;
+                axes[i] = (int) (match - labels);
             }
         }
     }
@@ -2673,7 +2675,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
      */
     ndim_broadcast = 0;
     for (iop = 0; iop < nop; ++iop) {
-        npy_intp count_zeros = 0;
+        int count_zeros = 0;
         int ndim;
         char *labels = op_labels[iop];
 
@@ -2729,7 +2731,8 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
         subscripts += 2;
 
         /* Parse the output subscript string */
-        ndim_output = parse_output_subscripts(subscripts, strlen(subscripts),
+        ndim_output = parse_output_subscripts(subscripts,
+                                        (int) strlen(subscripts),
                                         ndim_broadcast, label_counts,
                                         output_labels);
     }
@@ -2872,7 +2875,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
                     NPY_ITER_NO_BROADCAST;
 
     /* Allocate the iterator */
-    iter = NpyIter_AdvancedNew(nop+1, op, NPY_ITER_EXTERNAL_LOOP|
+    iter = NpyIter_AdvancedNew((int)(nop+1), op, NPY_ITER_EXTERNAL_LOOP|
                 ((dtype != NULL) ? 0 : NPY_ITER_COMMON_DTYPE)|
                                        NPY_ITER_BUFFERED|
                                        NPY_ITER_DELAY_BUFALLOC|
@@ -2953,7 +2956,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
      * the strides that are fixed for the whole loop.
      */
     NpyIter_GetInnerFixedStrideArray(iter, fixed_strides);
-    sop = get_sum_of_products_function(nop,
+    sop = get_sum_of_products_function((int) nop,
                         NpyIter_GetDescrArray(iter)[0]->type_num,
                         NpyIter_GetDescrArray(iter)[0]->elsize,
                         fixed_strides);
@@ -2989,7 +2992,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
         NPY_BEGIN_THREADS_NDITER(iter);
         NPY_EINSUM_DBG_PRINT("Einsum loop\n");
         do {
-            sop(nop, dataptr, stride, *countptr);
+            sop((int) nop, dataptr, stride, *countptr);
         } while(iternext(iter));
         NPY_END_THREADS;
 

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -416,7 +416,7 @@ arrayflags_getitem(PyArrayFlagsObject *self, PyObject *ind)
 {
     char *key = NULL;
     char buf[16];
-    int n;
+    npy_intp n;
     if (PyUnicode_Check(ind)) {
         PyObject *tmp_str;
         tmp_str = PyUnicode_AsASCIIString(ind);
@@ -534,7 +534,7 @@ arrayflags_setitem(PyArrayFlagsObject *self, PyObject *ind, PyObject *item)
 {
     char *key;
     char buf[16];
-    int n;
+    npy_intp n;
     if (PyUnicode_Check(ind)) {
         PyObject *tmp_str;
         tmp_str = PyUnicode_AsASCIIString(ind);

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -149,7 +149,7 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
     }
 
     /* numbytes == 0 is special here, but the 0-size array case always works */
-    if (!PyArray_CheckStrides(PyArray_ITEMSIZE(self), PyArray_NDIM(self),
+    if (!PyArray_CheckStrides((int) PyArray_ITEMSIZE(self), PyArray_NDIM(self),
                               numbytes, offset,
                               PyArray_DIMS(self), newstrides.ptr)) {
         PyErr_SetString(PyExc_ValueError, "strides is not "\

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -35,7 +35,8 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
     PyArray_Descr *dtype;
     PyArray_FastTakeFunc *func;
     PyArrayObject *obj = NULL, *self, *indices;
-    npy_intp nd, i, j, n, m, k, max_item, tmp, chunk, itemsize, nelem;
+    npy_intp i, j, n, m, k, max_item, tmp, chunk, itemsize, nelem;
+    int ax_i, nd;
     npy_intp shape[NPY_MAXDIMS];
     char *src, *dest, *tmp_src;
     int err;
@@ -56,19 +57,19 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
 
     n = m = chunk = 1;
     nd = PyArray_NDIM(self) + PyArray_NDIM(indices) - 1;
-    for (i = 0; i < nd; i++) {
-        if (i < axis) {
-            shape[i] = PyArray_DIMS(self)[i];
-            n *= shape[i];
+    for (ax_i = 0; ax_i < nd; ax_i++) {
+        if (ax_i < axis) {
+            shape[ax_i] = PyArray_DIMS(self)[ax_i];
+            n *= shape[ax_i];
         }
         else {
-            if (i < axis+PyArray_NDIM(indices)) {
-                shape[i] = PyArray_DIMS(indices)[i-axis];
-                m *= shape[i];
+            if (ax_i < axis+PyArray_NDIM(indices)) {
+                shape[ax_i] = PyArray_DIMS(indices)[ax_i-axis];
+                m *= shape[ax_i];
             }
             else {
-                shape[i] = PyArray_DIMS(self)[i-PyArray_NDIM(indices)+1];
-                chunk *= shape[i];
+                shape[ax_i] = PyArray_DIMS(self)[ax_i-PyArray_NDIM(indices)+1];
+                chunk *= shape[ax_i];
             }
         }
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -82,7 +82,7 @@ forward_ndarray_method(PyArrayObject *self, PyObject *args, PyObject *kwds,
                             PyObject *forwarding_callable)
 {
     PyObject *sargs, *ret;
-    int i, n;
+    npy_intp i, n;
 
     /* Combine 'self' and 'args' together into one tuple */
     n = PyTuple_GET_SIZE(args);
@@ -612,7 +612,7 @@ static PyObject *
 array_toscalar(PyArrayObject *self, PyObject *args)
 {
     npy_intp multi_index[NPY_MAXDIMS];
-    int n = PyTuple_GET_SIZE(args);
+    npy_intp n = PyTuple_GET_SIZE(args);
     int idim, ndim = PyArray_NDIM(self);
 
     /* If there is a tuple as a single argument, treat it as the argument */
@@ -678,7 +678,7 @@ static PyObject *
 array_setscalar(PyArrayObject *self, PyObject *args)
 {
     npy_intp multi_index[NPY_MAXDIMS];
-    int n = PyTuple_GET_SIZE(args) - 1;
+    npy_intp n = PyTuple_GET_SIZE(args) - 1;
     int idim, ndim = PyArray_NDIM(self);
     PyObject *obj;
 

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -834,10 +834,11 @@ s_intp_abs(npy_intp x)
  * every array in the arrays list.
  */
 NPY_NO_EXPORT void
-PyArray_CreateMultiSortedStridePerm(int narrays, PyArrayObject **arrays,
+PyArray_CreateMultiSortedStridePerm(npy_intp narrays, PyArrayObject **arrays,
                         int ndim, int *out_strideperm)
 {
-    int i0, i1, ipos, ax_j0, ax_j1, iarrays;
+    int i0, i1, ipos, ax_j0, ax_j1;
+    npy_intp iarrays;
 
     /* Initialize the strideperm values to the identity. */
     for (i0 = 0; i0 < ndim; ++i0) {

--- a/numpy/core/src/multiarray/shape.h
+++ b/numpy/core/src/multiarray/shape.h
@@ -18,7 +18,7 @@ build_shape_string(npy_intp n, npy_intp *vals);
  * every array in the arrays list.
  */
 NPY_NO_EXPORT void
-PyArray_CreateMultiSortedStridePerm(int narrays, PyArrayObject **arrays,
+PyArray_CreateMultiSortedStridePerm(npy_intp narrays, PyArrayObject **arrays,
                         int ndim, int *out_strideperm);
 
 /*

--- a/numpy/core/src/multiarray/ucsnarrow.c
+++ b/numpy/core/src/multiarray/ucsnarrow.c
@@ -30,11 +30,11 @@
  *
  * Values above 0xffff are converted to surrogate pairs.
  */
-NPY_NO_EXPORT int
-PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs4length)
+NPY_NO_EXPORT Py_ssize_t
+PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, Py_ssize_t ucs4length)
 {
-    int i;
-    int numucs2 = 0;
+    Py_ssize_t i;
+    Py_ssize_t numucs2 = 0;
     npy_ucs4 chr;
     for (i = 0; i < ucs4length; i++) {
         chr = *ucs4++;
@@ -62,13 +62,13 @@ PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs4length)
  *
  * The return value is the actual size of the used part of the ucs4 buffer.
  */
-NPY_NO_EXPORT int
-PyUCS2Buffer_AsUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs2len, int ucs4len)
+NPY_NO_EXPORT Py_ssize_t
+PyUCS2Buffer_AsUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, Py_ssize_t ucs2len, Py_ssize_t ucs4len)
 {
-    int i;
+    Py_ssize_t i;
     npy_ucs4 chr;
     Py_UNICODE ch;
-    int numchars=0;
+    Py_ssize_t numchars = 0;
 
     for (i = 0; (i < ucs2len) && (numchars < ucs4len); i++) {
         ch = *ucs2++;

--- a/numpy/core/src/multiarray/ucsnarrow.h
+++ b/numpy/core/src/multiarray/ucsnarrow.h
@@ -5,7 +5,7 @@ NPY_NO_EXPORT int
 PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs4length);
 
 NPY_NO_EXPORT int
-PyUCS2Buffer_AsUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs2len, int ucs4len);
+PyUCS2Buffer_AsUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, Py_ssize_t ucs2len, Py_ssize_t ucs4len);
 
 NPY_NO_EXPORT PyUnicodeObject *
 PyUnicode_FromUCS4(char *src, Py_ssize_t size, int swap, int align);

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -659,7 +659,7 @@ npy_divmod@c@(@type@ a, @type@ b, @type@ *modulus)
 
     /* snap quotient to nearest integral value */
     if (div) {
-        floordiv = npy_floor(div);
+        floordiv = npy_floor@c@(div);
         if (div - floordiv > 0.5@c@)
             floordiv += 1.0@c@;
     }

--- a/numpy/core/src/private/mem_overlap.c
+++ b/numpy/core/src/private/mem_overlap.c
@@ -654,7 +654,7 @@ diophantine_simplify(unsigned int *n, diophantine_term_t *E, npy_int64 b)
 
 /* Gets a half-open range [start, end) of offsets from the data pointer */
 NPY_VISIBILITY_HIDDEN void
-offset_bounds_from_strides(const int itemsize, const int nd,
+offset_bounds_from_strides(const npy_intp itemsize, const int nd,
                            const npy_intp *dims, const npy_intp *strides,
                            npy_intp *lower_offset, npy_intp *upper_offset)
 {

--- a/numpy/core/src/private/mem_overlap.h
+++ b/numpy/core/src/private/mem_overlap.h
@@ -42,7 +42,7 @@ NPY_VISIBILITY_HIDDEN mem_overlap_t
 solve_may_have_internal_overlap(PyArrayObject *a, Py_ssize_t max_work);
 
 NPY_VISIBILITY_HIDDEN void
-offset_bounds_from_strides(const int itemsize, const int nd,
+offset_bounds_from_strides(const npy_intp itemsize, const int nd,
                            const npy_intp *dims, const npy_intp *strides,
                            npy_intp *lower_offset, npy_intp *upper_offset);
 


### PR DESCRIPTION
Many were the downcasting of `npy_intp` to `int`, partially because `Descr->itemsize` has a poor choice of type. The rules seem to be:
 * Size in bytes - `npy_intp` (unless it's `descr->itemsize`...)
 * Number of operands - `int`
 * Number of axes - `int`

It might be far easier to reason about things if all of these were changed to `intp`, but perhaps there's performance to be had by not doing that.

Here we throw errors, rather than silently wrapping around.

These were warnings raised by msvc.