### PR TITLE
ENH: Support array-like `n` in random.random.multinomial

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4641,25 +4641,24 @@ cdef class RandomState:
         if kahan_sum(pix, d-1) > (1.0 + 1e-12):
             raise ValueError("sum(pvals[:-1]) > 1.0")
 
-        base_shape = _shape_from_size(size, d)
         if narr.shape == ():
             m = 1
-            shape = base_shape
+            shape = _shape_from_size(size, d)
         else:
             m = len(narr)
-            shape = (m,) + base_shape
+            shape = (m,) + _shape_from_size(size, d)
 
         multin = np.zeros(shape, int)
         mnarr = <ndarray>multin
         mnix = <long*>PyArray_DATA(mnarr)
         sz = PyArray_SIZE(mnarr) / m
         with self.lock, nogil, cython.cdivision(True):
-            for k from 0 <= k < m:
+            for k in range(m):
                 i = 0
                 while i < sz:
                     Sum = 1.0
                     dn = nix[k]
-                    for j from 0 <= j < d-1:
+                    for j in range(d - 1):
                         mnix[k*sz+i+j] = rk_binomial(self.internal_state, dn, pix[j]/Sum)
                         dn = dn - mnix[k*sz+i+j]
                         if dn <= 0:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4551,6 +4551,9 @@ cdef class RandomState:
         ----------
         n : int or array_like of ints
             Number of experiments.
+
+            .. versionchanged:: 1.14.0
+               Earlier NumPy versions did not allow array_like ``n``
         pvals : sequence of floats, length p
             Probabilities of each of the ``p`` different outcomes.  These
             should sum to 1 (however, the last element is always assumed to

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -650,7 +650,8 @@ class TestRandomDist(object):
 
     def test_multinomial(self):
         np.random.seed(self.seed)
-        actual = np.random.multinomial(20, [1/6.]*6, size=(3, 2))
+        size = (3, 2)
+        actual = np.random.multinomial(20, [1/6.]*6, size=size)
         desired = np.array([[[4, 3, 5, 4, 2, 2],
                              [5, 2, 8, 2, 2, 1]],
                             [[3, 4, 3, 6, 0, 4],
@@ -658,6 +659,13 @@ class TestRandomDist(object):
                             [[4, 4, 2, 5, 2, 3],
                              [4, 3, 4, 2, 3, 4]]])
         assert_array_equal(actual, desired)
+        assert_equal(actual.squeeze().sum(axis=-1), np.ones(size) * 20)
+
+        # Check for iterable n
+        ns = [20, 40]
+        actual = np.random.multinomial(ns, [1/6.]*6, size=size)
+        for n, sample_sum in zip(ns, actual.sum(axis=-1)):
+            assert_equal(sample_sum, np.ones(size) * n)
 
     def test_multivariate_normal(self):
         np.random.seed(self.seed)
@@ -1106,13 +1114,13 @@ class TestBroadcast(object):
         assert_raises(ValueError, nonc_f, bad_dfnum, dfden, nonc * 3)
         assert_raises(ValueError, nonc_f, dfnum, bad_dfden, nonc * 3)
         assert_raises(ValueError, nonc_f, dfnum, dfden, bad_nonc * 3)
-    
+
     def test_noncentral_f_small_df(self):
         self.setSeed()
         desired = np.array([6.869638627492048, 0.785880199263955])
         actual = np.random.noncentral_f(0.9, 0.9, 2, size=2)
         assert_array_almost_equal(actual, desired, decimal=14)
-        
+
     def test_chisquare(self):
         df = [1]
         bad_df = [-1]


### PR DESCRIPTION
This changes the `numpy.random.multinomial` API to be more similar to the API for `numpy.random.binomial`.  In particular, something like this:

```
>>> np.random.binomial([10, 20], 0.2)
array([2, 7])

>>> np.random.multinomial([10, 20], [0.2, 0.8])
array([[ 1,  9],
       [ 4, 16]])
```

I did some light benchmarking, and it seems like the current use case is equally fast, while this provides at least some speed up over `np.array([np.random.multinomial(n, pvals) for n in nvals])`.