### PR TITLE
BUG: Make scalar function elision check if writeable.

### DIFF
--- a/numpy/core/src/multiarray/temp_elide.c
+++ b/numpy/core/src/multiarray/temp_elide.c
@@ -363,6 +363,8 @@ can_elide_temp_unary(PyArrayObject * m1)
     if (Py_REFCNT(m1) != 1 || !PyArray_CheckExact(m1) ||
             !PyArray_ISNUMBER(m1) ||
             !(PyArray_FLAGS(m1) & NPY_ARRAY_OWNDATA) ||
+            !PyArray_ISWRITEABLE(m1) ||
+            PyArray_CHKFLAGS(m1, NPY_ARRAY_UPDATEIFCOPY) ||
             PyArray_NBYTES(m1) < NPY_MIN_ELIDE_BYTES) {
         return 0;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3246,6 +3246,15 @@ class TestTemporaryElide(object):
         a = np.bool_()
         assert_(type(~(a & a)) is np.bool_)
 
+    def test_elide_scalar_readonly(self):
+        # The imaginary part of a real array is readonly. This needs to go
+        # through fast_scalar_power which is only called for powers of
+        # +1, -1, 0, 0.5, and 2, so use 2. Also need valid refcount for
+        # elision which can be gotten for the imaginary part of a real
+        # array. Should not error.
+        a = np.empty(100000, dtype=np.float64)
+        a.imag ** 2
+
     def test_elide_readonly(self):
         # don't try to elide readonly temporaries
         r = np.asarray(np.broadcast_to(np.zeros(1), 100000).flat) * 0.0


### PR DESCRIPTION
Add checks for writeable and updateifcopy in the can_elide_temp_unary
function.

Closes #9679.