### PR TITLE
DEP: Deprecate truth testing on empty arrays

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -21,6 +21,8 @@ New functions
 Deprecations
 ============
 
+* Truth testing on an empty array is deprecated. To check if an array is not
+  empty, use ``array.size > 0``.
 
 Future Changes
 ==============

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -406,7 +406,7 @@ def count_nonzero(a, axis=None):
     array([2, 3])
 
     """
-    if axis is None or axis == ():
+    if axis is None or (isinstance(axis, tuple) and axis == ()):
         return multiarray.count_nonzero(a)
 
     a = asanyarray(a)

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -797,6 +797,12 @@ _array_nonzero(PyArrayObject *mp)
         return res;
     }
     else if (n == 0) {
+        /* 2017-09-25, 1.14 */
+        if (DEPRECATE("The truth value of an empty array is ambiguous. "
+                      "Returning False, but in future this will result in an error. "
+                      "Use `array.size > 0` to check that an array is not empty.") < 0) {
+            return -1;
+        }
         return 0;
     }
     else {

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -450,5 +450,18 @@ class TestDatetimeEvent(_DeprecationTestCase):
             self.assert_deprecated(cls, args=(1, ('ms', 2, 1, 63)))
 
 
+class TestTruthTestingEmptyArrays(_DeprecationTestCase):
+    # 2017-09-25, 1.14.0
+    message = '.*truth value of an empty array is ambiguous.*'
+
+    def test_1d(self):
+        self.assert_deprecated(bool, args=(np.array([]),))
+
+    def test_2d(self):
+        self.assert_deprecated(bool, args=(np.zeros((1, 0)),))
+        self.assert_deprecated(bool, args=(np.zeros((0, 1)),))
+        self.assert_deprecated(bool, args=(np.zeros((0, 0)),))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Add a deprecation warning while truth testing on empty arrays.

Solves step 1 of the proposal in https://github.com/numpy/numpy/issues/9583