### PR TITLE
MAINT: Remove unnecessary special-casing of scalars in isclose

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2528,13 +2528,10 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """
     def within_tol(x, y, atol, rtol):
         with errstate(invalid='ignore'):
-            result = less_equal(abs(x-y), atol + rtol * abs(y))
-        if isscalar(a) and isscalar(b):
-            result = bool(result)
-        return result
+            return less_equal(abs(x-y), atol + rtol * abs(y))
 
-    x = array(a, copy=False, subok=True, ndmin=1)
-    y = array(b, copy=False, subok=True, ndmin=1)
+    x = asanyarray(a)
+    y = asanyarray(b)
 
     # Make sure y is an inexact type to avoid bad behavior on abs(MIN_INT).
     # This will cause casting of x later. Also, make sure to allow subclasses
@@ -2561,12 +2558,11 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         if equal_nan:
             # Make NaN == NaN
             both_nan = isnan(x) & isnan(y)
+
+            # Needed to treat masked arrays correctly. = True would not work.
             cond[both_nan] = both_nan[both_nan]
 
-        if isscalar(a) and isscalar(b):
-            return bool(cond)
-        else:
-            return cond
+        return cond[()]  # Flatten 0d arrays to scalars
 
 
 def array_equal(a1, a2):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1933,9 +1933,9 @@ class TestIsclose(object):
     def test_non_finite_scalar(self):
         # GH7014, when two scalars are compared the output should also be a
         # scalar
-        assert_(np.isclose(np.inf, -np.inf) is False)
-        assert_(np.isclose(0, np.inf) is False)
-        assert_(type(np.isclose(0, np.inf)) is bool)
+        assert_(np.isclose(np.inf, -np.inf) is np.False_)
+        assert_(np.isclose(0, np.inf) is np.False_)
+        assert_(type(np.isclose(0, np.inf)) is np.bool_)
 
 
 class TestStdVar(object):


### PR DESCRIPTION
This means that this returns an `np.bool_` instead of a `bool`, but that seems more sensible anyway.

The code was likely written this way for when scalar boolean indices didn't work.