### PR TITLE
BUG: Make sure `_npy_scaled_cexp{,f,l}` is defined when needed.

### DIFF
--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -184,8 +184,6 @@ npy_carg@c@(@ctype@ z)
 #define SCALED_CEXP_LOWERL 11357.216553474703895L
 #define SCALED_CEXP_UPPERL 22756.021937783004509L
 
-#ifndef HAVE_CEXP@C@
-
 static
 @ctype@
 _npy_scaled_cexp@c@(@type@ x, @type@ y, npy_int expt)
@@ -212,6 +210,7 @@ _npy_scaled_cexp@c@(@type@ x, @type@ y, npy_int expt)
                          npy_ldexp@c@(mant * mantsin, expt + exsin));
 }
 
+#ifndef HAVE_CEXP@C@
 @ctype@
 npy_cexp@c@(@ctype@ z)
 {


### PR DESCRIPTION
Commit c15f7747c78e ("MAINT: remove a bunch of compiler warnings")
broke compilation if HAVE_CEXPx is defined with no good reason.

The problem is with defined HAVE_CEXPx _npy_scaled_cexp() is never
defined and compiler:
 1) Reports implicitly declared function
 2) Uses default return type "int" in equations like:
      z = _npy_scaled_cexp@c@(absx, y, -1);
    where z is "@ctype@" which might very well differ from int...
 3) ... and finally throws an error, see:
--------------------------->8------------------------
numpy/core/src/npymath/npy_math_complex.c.src: In function 'npy_ccoshl':
numpy/core/src/npymath/npy_math_complex.c.src:643:17: warning: implicit declaration of function '_npy_scaled_cexpl' [-Wimplicit-function-declaration]
             z = _npy_scaled_cexp@c@(absx, y, -1);
                 ^~~~~~~~~~~~~~~~~
numpy/core/src/npymath/npy_math_complex.c.src:643:15: error: incompatible types when assigning to type 'npy_clongdouble {aka struct <anonymous>}' from type 'int'
             z = _npy_scaled_cexp@c@(absx, y, -1);
--------------------------->8------------------------
               ^