### PR TITLE
BUG: adjust gfortran version search regex

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -66,7 +66,8 @@ class GnuFCompiler(FCompiler):
             m = re.search(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
             if m:
                 return ('gfortran', m.group(1))
-            m = re.search(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)
+            m = re.search(
+                r'GNU Fortran.*?\-?([0-9-.]+\.[0-9-.]+)', version_string)
             if m:
                 v = m.group(1)
                 if v.startswith('0') or v.startswith('2') or v.startswith('3'):

--- a/numpy/distutils/tests/test_fcompiler_gnu.py
+++ b/numpy/distutils/tests/test_fcompiler_gnu.py
@@ -26,7 +26,8 @@ gfortran_version_strings = [
      '4.9.1'),
     ("gfortran: warning: couldn't understand kern.osversion '14.1.0\n"
      "gfortran: warning: yet another warning\n4.9.1",
-     '4.9.1')
+     '4.9.1'),
+    ('GNU Fortran (crosstool-NG 8a21ab48) 7.2.0', '7.2.0')
 ]
 
 class TestG77Versions(object):


### PR DESCRIPTION
Adjust the gfortran regex to require a '.' to be present in the version number.
This avoids matching a hash or text containing a '-' such as the version string
from the compilers produced by crosstool-NG.  For example:
GNU Fortran (crosstool-NG 8a21ab48) 7.2.0