### PR TITLE
MAINT: cleanup circular import b/w arrayprint.py,numeric.py

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -46,28 +46,23 @@ loads = pickle.loads
 
 __all__ = [
     'newaxis', 'ndarray', 'flatiter', 'nditer', 'nested_iters', 'ufunc',
-    'arange', 'array', 'zeros', 'count_nonzero', 'empty', 'broadcast',
-    'dtype', 'fromstring', 'fromfile', 'frombuffer', 'int_asbuffer',
-    'where', 'argwhere', 'copyto', 'concatenate', 'fastCopyAndTranspose',
-    'lexsort', 'set_numeric_ops', 'can_cast', 'promote_types',
-    'min_scalar_type', 'result_type', 'asarray', 'asanyarray',
-    'ascontiguousarray', 'asfortranarray', 'isfortran', 'empty_like',
-    'zeros_like', 'ones_like', 'correlate', 'convolve', 'inner', 'dot',
-    'outer', 'vdot', 'roll',
-    'rollaxis', 'moveaxis', 'cross', 'tensordot', 'array2string',
-    'get_printoptions', 'set_printoptions', 'array_repr', 'array_str',
-    'set_string_function', 'little_endian', 'require', 'fromiter',
-    'array_equal', 'array_equiv', 'indices', 'fromfunction', 'isclose', 'load',
-    'loads', 'isscalar', 'binary_repr', 'base_repr', 'ones', 'identity',
-    'allclose', 'compare_chararrays', 'putmask', 'seterr', 'geterr',
-    'setbufsize', 'getbufsize', 'seterrcall', 'geterrcall', 'errstate',
-    'flatnonzero', 'Inf', 'inf', 'infty', 'Infinity', 'nan', 'NaN', 'False_',
-    'True_', 'bitwise_not', 'CLIP', 'RAISE', 'WRAP', 'MAXDIMS', 'BUFSIZE',
-    'ALLOW_THREADS', 'ComplexWarning', 'full', 'full_like', 'matmul',
-    'shares_memory', 'may_share_memory', 'MAY_SHARE_BOUNDS', 'MAY_SHARE_EXACT',
-    'TooHardError', 'AxisError'
-    ]
-
+    'arange', 'array', 'zeros', 'count_nonzero', 'empty', 'broadcast', 'dtype',
+    'fromstring', 'fromfile', 'frombuffer', 'int_asbuffer', 'where',
+    'argwhere', 'copyto', 'concatenate', 'fastCopyAndTranspose', 'lexsort',
+    'set_numeric_ops', 'can_cast', 'promote_types', 'min_scalar_type',
+    'result_type', 'asarray', 'asanyarray', 'ascontiguousarray',
+    'asfortranarray', 'isfortran', 'empty_like', 'zeros_like', 'ones_like',
+    'correlate', 'convolve', 'inner', 'dot', 'outer', 'vdot', 'roll',
+    'rollaxis', 'moveaxis', 'cross', 'tensordot', 'little_endian', 'require',
+    'fromiter', 'array_equal', 'array_equiv', 'indices', 'fromfunction',
+    'isclose', 'load', 'loads', 'isscalar', 'binary_repr', 'base_repr', 'ones',
+    'identity', 'allclose', 'compare_chararrays', 'putmask', 'seterr',
+    'geterr', 'setbufsize', 'getbufsize', 'seterrcall', 'geterrcall',
+    'errstate', 'flatnonzero', 'Inf', 'inf', 'infty', 'Infinity', 'nan', 'NaN',
+    'False_', 'True_', 'bitwise_not', 'CLIP', 'RAISE', 'WRAP', 'MAXDIMS',
+    'BUFSIZE', 'ALLOW_THREADS', 'ComplexWarning', 'full', 'full_like',
+    'matmul', 'shares_memory', 'may_share_memory', 'MAY_SHARE_BOUNDS',
+    'MAY_SHARE_EXACT', 'TooHardError', 'AxisError' ]
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])
@@ -362,20 +357,6 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True):
     res = empty_like(a, dtype=dtype, order=order, subok=subok)
     multiarray.copyto(res, fill_value, casting='unsafe')
     return res
-
-
-def extend_all(module):
-    adict = {}
-    for a in __all__:
-        adict[a] = 1
-    try:
-        mall = getattr(module, '__all__')
-    except AttributeError:
-        mall = [k for k in module.__dict__.keys() if not k.startswith('_')]
-    for a in mall:
-        if a not in adict:
-            __all__.append(a)
-
 
 def count_nonzero(a, axis=None):
     """
@@ -1820,193 +1801,6 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
     return moveaxis(cp, -1, axisc)
 
-
-# Use numarray's printing function
-from .arrayprint import array2string, get_printoptions, set_printoptions
-
-
-_typelessdata = [int_, float_, complex_]
-if issubclass(intc, int):
-    _typelessdata.append(intc)
-
-
-if issubclass(longlong, int):
-    _typelessdata.append(longlong)
-
-
-def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
-    """
-    Return the string representation of an array.
-
-    Parameters
-    ----------
-    arr : ndarray
-        Input array.
-    max_line_width : int, optional
-        The maximum number of columns the string should span. Newline
-        characters split the string appropriately after array elements.
-    precision : int, optional
-        Floating point precision. Default is the current printing precision
-        (usually 8), which can be altered using `set_printoptions`.
-    suppress_small : bool, optional
-        Represent very small numbers as zero, default is False. Very small
-        is defined by `precision`, if the precision is 8 then
-        numbers smaller than 5e-9 are represented as zero.
-
-    Returns
-    -------
-    string : str
-      The string representation of an array.
-
-    See Also
-    --------
-    array_str, array2string, set_printoptions
-
-    Examples
-    --------
-    >>> np.array_repr(np.array([1,2]))
-    'array([1, 2])'
-    >>> np.array_repr(np.ma.array([0.]))
-    'MaskedArray([ 0.])'
-    >>> np.array_repr(np.array([], np.int32))
-    'array([], dtype=int32)'
-
-    >>> x = np.array([1e-6, 4e-7, 2, 3])
-    >>> np.array_repr(x, precision=6, suppress_small=True)
-    'array([ 0.000001,  0.      ,  2.      ,  3.      ])'
-
-    """
-    if type(arr) is not ndarray:
-        class_name = type(arr).__name__
-    else:
-        class_name = "array"
-
-    if arr.size > 0 or arr.shape == (0,):
-        lst = array2string(arr, max_line_width, precision, suppress_small,
-                           ', ', class_name + "(")
-    else:  # show zero-length shape unless it is (0,)
-        lst = "[], shape=%s" % (repr(arr.shape),)
-
-    skipdtype = (arr.dtype.type in _typelessdata) and arr.size > 0
-
-    if skipdtype:
-        return "%s(%s)" % (class_name, lst)
-    else:
-        typename = arr.dtype.name
-        # Quote typename in the output if it is "complex".
-        if typename and not (typename[0].isalpha() and typename.isalnum()):
-            typename = "'%s'" % typename
-
-        lf = ' '
-        if issubclass(arr.dtype.type, flexible):
-            if arr.dtype.names:
-                typename = "%s" % str(arr.dtype)
-            else:
-                typename = "'%s'" % str(arr.dtype)
-            lf = '\n'+' '*len(class_name + "(")
-        return "%s(%s,%sdtype=%s)" % (class_name, lst, lf, typename)
-
-
-def array_str(a, max_line_width=None, precision=None, suppress_small=None):
-    """
-    Return a string representation of the data in an array.
-
-    The data in the array is returned as a single string.  This function is
-    similar to `array_repr`, the difference being that `array_repr` also
-    returns information on the kind of array and its data type.
-
-    Parameters
-    ----------
-    a : ndarray
-        Input array.
-    max_line_width : int, optional
-        Inserts newlines if text is longer than `max_line_width`.  The
-        default is, indirectly, 75.
-    precision : int, optional
-        Floating point precision.  Default is the current printing precision
-        (usually 8), which can be altered using `set_printoptions`.
-    suppress_small : bool, optional
-        Represent numbers "very close" to zero as zero; default is False.
-        Very close is defined by precision: if the precision is 8, e.g.,
-        numbers smaller (in absolute value) than 5e-9 are represented as
-        zero.
-
-    See Also
-    --------
-    array2string, array_repr, set_printoptions
-
-    Examples
-    --------
-    >>> np.array_str(np.arange(3))
-    '[0 1 2]'
-
-    """
-    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
-
-
-def set_string_function(f, repr=True):
-    """
-    Set a Python function to be used when pretty printing arrays.
-
-    Parameters
-    ----------
-    f : function or None
-        Function to be used to pretty print arrays. The function should expect
-        a single array argument and return a string of the representation of
-        the array. If None, the function is reset to the default NumPy function
-        to print arrays.
-    repr : bool, optional
-        If True (default), the function for pretty printing (``__repr__``)
-        is set, if False the function that returns the default string
-        representation (``__str__``) is set.
-
-    See Also
-    --------
-    set_printoptions, get_printoptions
-
-    Examples
-    --------
-    >>> def pprint(arr):
-    ...     return 'HA! - What are you going to do now?'
-    ...
-    >>> np.set_string_function(pprint)
-    >>> a = np.arange(10)
-    >>> a
-    HA! - What are you going to do now?
-    >>> print(a)
-    [0 1 2 3 4 5 6 7 8 9]
-
-    We can reset the function to the default:
-
-    >>> np.set_string_function(None)
-    >>> a
-    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-
-    `repr` affects either pretty printing or normal string representation.
-    Note that ``__repr__`` is still affected by setting ``__str__``
-    because the width of each array element in the returned string becomes
-    equal to the length of the result of ``__str__()``.
-
-    >>> x = np.arange(4)
-    >>> np.set_string_function(lambda x:'random', repr=False)
-    >>> x.__str__()
-    'random'
-    >>> x.__repr__()
-    'array([     0,      1,      2,      3])'
-
-    """
-    if f is None:
-        if repr:
-            return multiarray.set_string_function(array_repr, 1)
-        else:
-            return multiarray.set_string_function(array_str, 0)
-    else:
-        return multiarray.set_string_function(f, repr)
-
-
-set_string_function(array_str, 0)
-set_string_function(array_repr, 1)
-
 little_endian = (sys.byteorder == 'little')
 
 
@@ -3092,10 +2886,26 @@ nan = NaN = NAN
 False_ = bool_(False)
 True_ = bool_(True)
 
+
+def extend_all(module):
+    adict = {}
+    for a in __all__:
+        adict[a] = 1
+    try:
+        mall = getattr(module, '__all__')
+    except AttributeError:
+        mall = [k for k in module.__dict__.keys() if not k.startswith('_')]
+    for a in mall:
+        if a not in adict:
+            __all__.append(a)
+
 from .umath import *
 from .numerictypes import *
 from . import fromnumeric
 from .fromnumeric import *
+from . import arrayprint
+from .arrayprint import *
 extend_all(fromnumeric)
 extend_all(umath)
 extend_all(numerictypes)
+extend_all(arrayprint)


### PR DESCRIPTION
This PR moves `array_repr`, `array_str`, and `get/set_printoptions` from `numeric.py` to `arrayprint.py`, and removes all the import statements nestled in various arrayprint functions.

This is split off from  #9139. There, I noticed that because of circular import issues a number of functions in `arrayprint.py` used import statements, which is undesirable. This PR resolves the circular import problem in a cleaner way: It now uses `extend_all` just like `fromnumeric`, `umath` and `numerictypes`.

Conceptually, these functions should be in `arrayprint.py` anyway since they relate to array printing.