### PR TITLE
BUG: Fix np.pad for CVE-2017-12852

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1406,6 +1406,9 @@ def pad(array, pad_width, mode, **kwargs):
             newmat = _append_min(newmat, pad_after, chunk_after, axis)
 
     elif mode == 'reflect':
+        if narray.size == 0:
+            raise ValueError("There aren't any elements to reflect in `array`")
+
         for axis, (pad_before, pad_after) in enumerate(pad_width):
             # Recursive padding along any axis where `pad_amt` is too large
             # for indexing tricks. We can only safely pad the original axis

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1406,10 +1406,15 @@ def pad(array, pad_width, mode, **kwargs):
             newmat = _append_min(newmat, pad_after, chunk_after, axis)
 
     elif mode == 'reflect':
-        if narray.size == 0:
-            raise ValueError("There aren't any elements to reflect in `array`")
-
         for axis, (pad_before, pad_after) in enumerate(pad_width):
+            if narray.shape[axis] == 0:
+                # Axes with non-zero padding cannot be empty.
+                if pad_before > 0 or pad_after > 0:
+                    raise ValueError("There aren't any elements to reflect"
+                                     " in axis {} of `array`".format(axis))
+                # Skip zero padding on empty axes.
+                continue
+
             # Recursive padding along any axis where `pad_amt` is too large
             # for indexing tricks. We can only safely pad the original axis
             # length, to keep the period of the reflections consistent.

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1014,6 +1014,10 @@ class ValueError1(TestCase):
         assert_raises(ValueError, pad, arr, ((-2, 3), (3, 2)),
                       **kwargs)
 
+    def test_check_empty_array(self):
+        assert_raises(ValueError, pad, [], 4, mode='reflect')
+        assert_raises(ValueError, pad, np.ndarray(0), 4, mode='reflect')
+
 
 class ValueError2(TestCase):
     def test_check_negative_pad_amount(self):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -640,6 +640,11 @@ class TestReflect(TestCase):
         b = np.array([1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3])
         assert_array_equal(a, b)
 
+    def test_check_padding_an_empty_array(self):
+        a = pad(np.zeros((0, 3)), ((0,), (1,)), mode='reflect')
+        b = np.zeros((0, 5))
+        assert_array_equal(a, b)
+
 
 class TestSymmetric(TestCase):
     def test_check_simple(self):
@@ -1017,6 +1022,8 @@ class ValueError1(TestCase):
     def test_check_empty_array(self):
         assert_raises(ValueError, pad, [], 4, mode='reflect')
         assert_raises(ValueError, pad, np.ndarray(0), 4, mode='reflect')
+        assert_raises(ValueError, pad, np.zeros((0, 3)), ((1,), (0,)),
+                      mode='reflect')
 
 
 class ValueError2(TestCase):


### PR DESCRIPTION
This is a backport of gh-9599 and gh-9640 and fixes some bugs in np.pad.

* BUG: fix infinite loop when creating np.pad on an empty array #9599
* BUG: fix padding an empty array in reflect mode. #9640 

The first of these also fixes CVE-2017-12852.

