### PR TITLE
BUG: Fix loss of precision for large values in long double divmod

### DIFF
--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -659,7 +659,7 @@ npy_divmod@c@(@type@ a, @type@ b, @type@ *modulus)
 
     /* snap quotient to nearest integral value */
     if (div) {
-        floordiv = npy_floor(div);
+        floordiv = npy_floor@c@(div);
         if (div - floordiv > 0.5@c@)
             floordiv += 1.0@c@;
     }


### PR DESCRIPTION
No test I'm afraid, as my platform has no extended precision floats.