### PR TITLE
DOC: Fix ndarray.__setstate__ documentation, it only takes one argument.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3117,9 +3117,12 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('__reduce__',
 
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('__setstate__',
-    """a.__setstate__(version, shape, dtype, isfortran, rawdata)
+    """a.__setstate__(state, /)
 
     For unpickling.
+    
+    The `state` argument must be a sequence that contains the following
+    elements:
 
     Parameters
     ----------


### PR DESCRIPTION
The [`__setstate__` code](https://github.com/numpy/numpy/blob/v1.13.1/numpy/core/src/multiarray/methods.c#L1680-L1695) actually accepts a `tuple` containing the given arguments. It's invalid to call `__setstate__` with more than one argument.

As done in #9700 I used `/` to indicate it's a positional-only argument.