### PR TITLE
BUG: Cython 0.27 breaks NumPy on Python 3.

### DIFF
--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -26,6 +26,6 @@ fi
 source venv/bin/activate
 python -V
 pip install --upgrade pip setuptools
-pip install nose pytz cython
+pip install nose pytz cython==0.26
 if [ -n "$USE_ASV" ]; then pip install asv; fi
 popd


### PR DESCRIPTION
The latest Cython came out and it causes the cythonized mtrand.c source
to issue a compile warning for Python 3, breaking NumPy travis tests. As
a temporary fix, force the tests to use Cython 0.26.