### PR TITLE
MAINT,BUG: Fix mtrand for Cython 0.27.

### DIFF
--- a/numpy/random/mtrand/numpy.pxd
+++ b/numpy/random/mtrand/numpy.pxd
@@ -1,4 +1,5 @@
 # :Author:    Travis Oliphant
+from cpython.exc cimport PyErr_Print
 
 cdef extern from "numpy/npy_no_deprecated_api.h": pass
 
@@ -133,7 +134,7 @@ cdef extern from "numpy/arrayobject.h":
 
     dtype PyArray_DescrFromType(int)
 
-    void import_array()
+    int _import_array() except -1
 
 # include functions that were once macros in the new api
 
@@ -150,3 +151,12 @@ cdef extern from "numpy/arrayobject.h":
     int PyArray_TYPE(ndarray arr)
     int PyArray_CHKFLAGS(ndarray arr, int flags)
     object PyArray_GETITEM(ndarray arr, char *itemptr)
+
+
+# copied from cython version with addition of PyErr_Print.
+cdef inline int import_array() except -1:
+    try:
+        _import_array()
+    except Exception:
+        PyErr_Print()
+        raise ImportError("numpy.core.multiarray failed to import")

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -26,6 +26,6 @@ fi
 source venv/bin/activate
 python -V
 pip install --upgrade pip setuptools
-pip install nose pytz cython==0.26
+pip install nose pytz cython
 if [ -n "$USE_ASV" ]; then pip install asv; fi
 popd


### PR DESCRIPTION
The `import_array()` macro, that defined a C code block that included a
return, was not handled correctly. The fix here is to cdef a replacement
`import_array` function with a defined error return. The new function is
a slight variation of the corresponding function defined by Cython.