### PR TITLE
BUG: Fixes optimal einsum path for multi-term intermediates

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -166,8 +166,14 @@ def _optimal_path(input_sets, output_set, idx_dict, memory_limit):
                 new_pos = positions + [con]
                 iter_results.append((new_cost, new_pos, new_input_sets))
 
-        # Update list to iterate over
-        full_results = iter_results
+        # Update combinatorial list, if we did not find anything return best
+        # path + remaining contractions
+        if iter_results:
+            full_results = iter_results
+        else:
+            path = min(full_results, key=lambda x: x[0])[1]
+            path += [tuple(range(len(input_sets) - iteration))]
+            return path
 
     # If we have not found anything return single einsum contraction
     if len(full_results) == 0:

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -767,13 +767,13 @@ class TestEinSum(object):
 
 
 class TestEinSumPath(object):
-    def build_operands(self, string):
+    def build_operands(self, string, size_dict=global_size_dict):
 
         # Builds views based off initial operands
         operands = [string]
         terms = string.split('->')[0].split(',')
         for term in terms:
-            dims = [global_size_dict[x] for x in term]
+            dims = [size_dict[x] for x in term]
             operands.append(np.random.rand(*dims))
 
         return operands
@@ -862,6 +862,16 @@ class TestEinSumPath(object):
 
         path, path_str = np.einsum_path(*edge_test4, optimize='optimal')
         self.assert_path_equal(path, ['einsum_path', (1, 2), (0, 2), (0, 1)])
+
+        # Edge test5
+        edge_test4 = self.build_operands('a,ac,ab,ad,cd,bd,bc->',
+                                         size_dict={"a": 20, "b": 20, "c": 20, "d": 20})
+        path, path_str = np.einsum_path(*edge_test4, optimize='greedy')
+        self.assert_path_equal(path, ['einsum_path', (0, 1), (0, 1, 2, 3, 4, 5)])
+
+        path, path_str = np.einsum_path(*edge_test4, optimize='optimal')
+        self.assert_path_equal(path, ['einsum_path', (0, 1), (0, 1, 2, 3, 4, 5)])
+
 
     def test_path_type_input(self):
         # Test explicit path handeling


### PR DESCRIPTION
Fixes #9769.

There was a small bug in the `optimal` `einsum` path that if all possible contractions created intermediates that were sieved out (being too large) the path would return a blank list which would result in no intermediates being formed. This introduces (and tests) the possibility of a intermediate case where some optimization can take place, but only up to a certain point and the remaining contractions should be computed together in bulk with a conventional `einsum` call.