### PR TITLE
Alternative to #9332

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -262,11 +262,6 @@ Now, the ``str`` of a 0d array prints like a numpy scalar using
 ``str(a[()])`` and the ``repr`` prints like ndarrays using ``formatter(a[()])``,
 where  ``formatter`` is specified using ``np.set_printoptions``.
 
-The ``style`` argument of ``np.array2string`` now accepts the value ``None``,
-(the new default), which causes 0d arrays to be printed using the appropriate
-``formatter``. Otherwise ``style`` should be a function which accepts a numpy
-scalar and returns a string, and ``style(a[()])`` is returned.
-
 User-defined types now need to implement ``__str__`` and ``__repr__``
 ---------------------------------------------------------------------
 Previously, user-defined types could fall back to a default implementation of

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -251,10 +251,28 @@ programs which open them with ``mmap``, especially on Linux where an
 Changes
 =======
 
-0d arrays now print their elements like other arrays
-----------------------------------------------------
-0d arrays now use the array2string formatters to print their elements, like
-other arrays. The ``style`` argument of ``array2string`` is now non-functional.
+0d array printing changed to be more consistent with scalars/ndarrays
+---------------------------------------------------------------------
+Previously the ``str`` and ``repr`` of 0d arrays had idiosyncratic
+implementations which returned ``str(a.item())`` and ``'array(' +
+repr(a.item()) + ')'`` respectively for 0d array ``a``, unlike both numpy
+scalars and higher dimension ndarrays.
+
+Now, the ``str`` of a 0d array prints like a numpy scalar using
+``str(a[()])`` and the ``repr`` prints like ndarrays using ``formatter(a[()])``,
+where  ``formatter`` is specified using ``np.set_printoptions``.
+
+The ``style`` argument of ``np.array2string`` now accepts the value ``None``,
+(the new default), which causes 0d arrays to be printed using the appropriate
+``formatter``. Otherwise ``style`` should be a function which accepts a numpy
+scalar and returns a string, and ``style(a[()])`` is returned.
+
+User-defined types now need to implement ``__str__`` and ``__repr__``
+---------------------------------------------------------------------
+Previously, user-defined types could fall back to a default implementation of
+``__str__`` and ``__repr__`` implemented in numpy, but this has now been
+removed. Now user-defined types will fall back to the python default
+``object.__str__`` and ``object.__repr__``.
 
 ``np.linalg.matrix_rank`` is more efficient for hermitian matrices
 ------------------------------------------------------------------
@@ -262,11 +280,11 @@ The keyword argument ``hermitian`` was added to toggle between standard
 SVD-based matrix rank calculation and the more efficient eigenvalue-based
 method for symmetric/hermitian matrices.
 
-Integer scalars are now unaffected by ``np.set_string_function``
-----------------------------------------------------------------
-Previously the str/repr of integer scalars could be controlled by
-``np.set_string_function``, unlike most other numpy scalars. This is no longer
-the case.
+Integer and Void scalars are now unaffected by ``np.set_string_function``
+-------------------------------------------------------------------------
+Previously the ``str`` and ``repr`` of integer and void scalars could be
+controlled by ``np.set_string_function``, unlike most other numpy scalars. This
+is no longer the case.
 
 Multiple-field indexing/assignment of structured arrays
 -------------------------------------------------------

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -395,7 +395,7 @@ def _array2string(a, options, separator=' ', prefix=""):
 
 def array2string(a, max_line_width=None, precision=None,
                  suppress_small=None, separator=' ', prefix="",
-                 style=None, formatter=None, threshold=None,
+                 style=np._NoValue, formatter=None, threshold=None,
                  edgeitems=None, sign=None):
     """
     Return a string representation of an array.
@@ -420,11 +420,12 @@ def array2string(a, max_line_width=None, precision=None,
 
           'prefix(' + array2string(a) + ')'
 
-        The length of the prefix string is used to align the output correctly.
-    style : None or function, optional
-        Controls the printing of 0d arrays. If `None`, prints the 0d array's
-        element using the usual array formatting. Otherwise, `style` should be
-        a function that accepts a numpy scalar and returns a string.
+        The length of the prefix string is used to align the
+        output correctly.
+    style : _NoValue, optional
+        Has no effect, do not use.
+
+        .. deprecated:: 1.14.0
     formatter : dict of callables, optional
         If not None, the keys should indicate the type(s) that the respective
         formatting function applies to.  Callables should return a string.
@@ -502,15 +503,18 @@ def array2string(a, max_line_width=None, precision=None,
     '[0x0L 0x1L 0x2L]'
 
     """
+    # Deprecation 05-16-2017  v1.14
+    if style is not np._NoValue:
+        warnings.warn("'style' argument is deprecated and no longer functional",
+                      DeprecationWarning, stacklevel=3)
+
     overrides = _make_options_dict(precision, threshold, edgeitems,
                                    max_line_width, suppress_small, None, None,
                                    sign, formatter)
     options = _format_options.copy()
     options.update(overrides)
 
-    if style is not None and a.shape == ():
-        return style(a[()])
-    elif a.size == 0:
+    if a.size == 0:
         # treat as a null array if any of shape elements == 0
         lst = "[]"
     else:
@@ -1005,8 +1009,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     '[0 1 2]'
 
     """
-    return array2string(a, max_line_width, precision, suppress_small,
-                        ' ', "", str)
+    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
 
 def set_string_function(f, repr=True):
     """

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -401,7 +401,7 @@ def _array2string(a, options, separator=' ', prefix=""):
 
 def array2string(a, max_line_width=None, precision=None,
                  suppress_small=None, separator=' ', prefix="",
-                 style=np._NoValue, formatter=None, threshold=None,
+                 style=None, formatter=None, threshold=None,
                  edgeitems=None, sign=None):
     """
     Return a string representation of an array.
@@ -426,12 +426,11 @@ def array2string(a, max_line_width=None, precision=None,
 
           'prefix(' + array2string(a) + ')'
 
-        The length of the prefix string is used to align the
-        output correctly.
-    style : _NoValue, optional
-        Has no effect, do not use.
-
-        .. deprecated:: 1.14.0
+        The length of the prefix string is used to align the output correctly.
+    style : None or function, optional
+        Controls the printing of 0d arrays. If `None`, prints the 0d array's
+        element using the usual array formatting. Otherwise, `style` should be
+        a function that accepts a numpy scalar and returns a string.
     formatter : dict of callables, optional
         If not None, the keys should indicate the type(s) that the respective
         formatting function applies to.  Callables should return a string.
@@ -509,18 +508,17 @@ def array2string(a, max_line_width=None, precision=None,
     '[0x0L 0x1L 0x2L]'
 
     """
-    # Deprecation 05-16-2017  v1.14
-    if style is not np._NoValue:
-        warnings.warn("'style' argument is deprecated and no longer functional",
-                      DeprecationWarning, stacklevel=3)
-
     overrides = _make_options_dict(precision, threshold, edgeitems,
                                    max_line_width, suppress_small, None, None,
                                    sign, formatter)
     options = _format_options.copy()
     options.update(overrides)
 
-    if a.size == 0:
+    # the ``dtype.names is None`` check is to avoid co-recursion with
+    # voidtype_str, which upcasts structured scalars to 0d arrays
+    if style is not None and a.shape == () and a.dtype.names is None:
+        return style(a[()])
+    elif a.size == 0:
         # treat as a null array if any of shape elements == 0
         lst = "[]"
     else:
@@ -992,7 +990,8 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     '[0 1 2]'
 
     """
-    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
+    return array2string(a, max_line_width, precision, suppress_small,
+                        ' ', "", str)
 
 def set_string_function(f, repr=True):
     """

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -25,6 +25,7 @@
 #include "_datetime.h"
 #include "datetime_strings.h"
 #include "alloc.h"
+#include "npy_import.h"
 
 #include <stdlib.h>
 
@@ -610,14 +611,15 @@ static PyObject *
 voidtype_str(PyObject *self)
 {
     if (PyDataType_HASFIELDS(((PyVoidScalarObject*)self)->descr)) {
-        PyObject *arr, *ret = NULL;
+        static PyObject *reprfunc = NULL;
 
-        arr = PyArray_FromScalar(self, NULL);
-        if (arr != NULL) {
-            ret = PyObject_Str((PyObject *)arr);
-            Py_DECREF(arr);
+        npy_cache_import("numpy.core.arrayprint",
+                         "_void_scalar_repr", &reprfunc);
+        if (reprfunc == NULL) {
+            return NULL;
         }
-        return ret;
+
+        return PyObject_CallFunction(reprfunc, "O", self);
     }
     else {
         PyObject *item, *item_str;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -339,33 +339,6 @@ gentype_nonzero_number(PyObject *m1)
 }
 
 static PyObject *
-gentype_str(PyObject *self)
-{
-    PyObject *arr, *ret = NULL;
-
-    arr = PyArray_FromScalar(self, NULL);
-    if (arr != NULL) {
-        ret = PyObject_Str((PyObject *)arr);
-        Py_DECREF(arr);
-    }
-    return ret;
-}
-
-static PyObject *
-gentype_repr(PyObject *self)
-{
-    PyObject *arr, *ret = NULL;
-
-    arr = PyArray_FromScalar(self, NULL);
-    if (arr != NULL) {
-        /* XXX: Why are we using str here? */
-        ret = PyObject_Str((PyObject *)arr);
-        Py_DECREF(arr);
-    }
-    return ret;
-}
-
-static PyObject *
 genint_type_str(PyObject *self)
 {
     PyObject  *item, *item_str;
@@ -632,6 +605,33 @@ static PyObject *
     return ret;
 }
 /**end repeat**/
+
+static PyObject *
+voidtype_str(PyObject *self)
+{
+    if (PyDataType_HASFIELDS(((PyVoidScalarObject*)self)->descr)) {
+        PyObject *arr, *ret = NULL;
+
+        arr = PyArray_FromScalar(self, NULL);
+        if (arr != NULL) {
+            ret = PyObject_Str((PyObject *)arr);
+            Py_DECREF(arr);
+        }
+        return ret;
+    }
+    else {
+        PyObject *item, *item_str;
+
+        item = gentype_generic_method(self, NULL, NULL, "item");
+        if (item == NULL) {
+            return NULL;
+        }
+
+        item_str = PyObject_Str(item);
+        Py_DECREF(item);
+        return item_str;
+    }
+}
 
 static PyObject *
 datetimetype_repr(PyObject *self)
@@ -4073,8 +4073,6 @@ initialize_numeric_types(void)
     PyGenericArrType_Type.tp_new = NULL;
     PyGenericArrType_Type.tp_alloc = gentype_alloc;
     PyGenericArrType_Type.tp_free = (freefunc)gentype_free;
-    PyGenericArrType_Type.tp_repr = gentype_repr;
-    PyGenericArrType_Type.tp_str = gentype_str;
     PyGenericArrType_Type.tp_richcompare = gentype_richcompare;
 
     PyBoolArrType_Type.tp_as_number = &bool_arrtype_as_number;
@@ -4122,6 +4120,8 @@ initialize_numeric_types(void)
     PyVoidArrType_Type.tp_getset = voidtype_getsets;
     PyVoidArrType_Type.tp_as_mapping = &voidtype_as_mapping;
     PyVoidArrType_Type.tp_as_sequence = &voidtype_as_sequence;
+    PyVoidArrType_Type.tp_repr = voidtype_str;
+    PyVoidArrType_Type.tp_str = voidtype_str;
 
     PyIntegerArrType_Type.tp_getset = inttype_getsets;
 

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -187,7 +187,13 @@ array_str(PyArrayObject *self)
 {
     PyObject *s, *arglist;
 
-    if (PyArray_StrFunction == NULL) {
+    /* 0d is treated as though it were a scalar */
+    if (PyArray_IsZeroDim(self)) {
+        PyObject *scalar = PyArray_ToScalar(PyArray_DATA(self), self);
+        if (scalar == NULL) return NULL;
+        return PyObject_Str(scalar);
+    }
+    else if (PyArray_StrFunction == NULL) {
         s = array_repr_builtin(self, 0);
     }
     else {

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -237,12 +237,27 @@ class TestPrintOptions(object):
         assert_equal(repr(x), "array([0., 1., 2.])")
 
     def test_0d_arrays(self):
+        if sys.version_info[0] >= 3:
+            assert_equal(str(np.array('café', np.unicode_)), 'café')
+            assert_equal(repr(np.array('café', np.unicode_)),
+                         "array('café',\n      dtype='<U4')")
+        else:
+            assert_equal(repr(np.array(u'café', np.unicode_)),
+                         "array(u'caf\\xe9',\n      dtype='<U4')")
+        assert_equal(str(np.array('test', np.str_)), 'test')
+
+        a = np.zeros(1, dtype=[('a', '<i4', (3,))])
+        assert_equal(str(a[0]), '([0, 0, 0],)')
+
         assert_equal(repr(np.datetime64('2005-02-25')[...]),
                      "array('2005-02-25', dtype='datetime64[D]')")
 
+        # repr of 0d arrays is affected by printoptions
         x = np.array(1)
         np.set_printoptions(formatter={'all':lambda x: "test"})
         assert_equal(repr(x), "array(test)")
+        # str is unaffected
+        assert_equal(str(x), "1")
 
     def test_float_spacing(self):
         x = np.array([1., 2., 3.])

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -60,6 +60,10 @@ class TestArrayRepr(object):
         assert_equal(repr(arr1d),
             'array([list([1, 2]), list([3])], dtype=object)')
 
+    def test_void_scalar_recursion(self):
+        # gh-9345
+        repr(np.void(b'test'))  # RecursionError ?
+
 
 class TestComplexArray(object):
     def test_str(self):


### PR DESCRIPTION
One extra commit on top of #9332, that protects `str(0darr)` against `np.set_string_function`, and leaves the `style` argument deprecated.