### PR TITLE
ENH: Various improvements to Maskedarray repr

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -503,3 +503,10 @@ Seeding ``RandomState`` using an array requires a 1-d array
 ``RandomState`` previously would accept empty arrays or arrays with 2 or more
 dimensions, which resulted in either a failure to seed (empty arrays) or for
 some of the passed values to be ignored when setting the seed.
+
+``MaskedArray`` objects show a more useful ``repr``
+---------------------------------------------------
+The ``repr`` of a ``MaskedArray`` is now closer to the python code that would
+produce it, with arrays now being shown with commas and dtypes. Like the other
+formatting changes, this can be disabled with the 1.13 legacy printing mode in
+order to help transition doctests.

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1182,6 +1182,30 @@ def dtype_is_implied(dtype):
     return dtype.type in _typelessdata
 
 
+def dtype_short_repr(dtype):
+    """
+    Convert a dtype to a short form which evaluates to the same dtype.
+
+    The intent is roughly that the following holds
+
+    >>> from numpy import *
+    >>> assert eval(dtype_short_repr(dt)) == dt
+    """
+    # handle these separately so they don't give garbage like str256
+    if issubclass(dtype.type, flexible):
+        if dtype.names:
+            return "%s" % str(dtype)
+        else:
+            return "'%s'" % str(dtype)
+
+    typename = dtype.name
+    # quote typenames which can't be represented as python variable names
+    if typename and not (typename[0].isalpha() and typename.isalnum()):
+        typename = repr(typename)
+
+    return typename
+
+
 def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     """
     Return the string representation of an array.
@@ -1245,18 +1269,7 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
 
     if skipdtype:
         return "%s(%s)" % (class_name, lst)
-
-    # determine typename
-    if issubclass(arr.dtype.type, flexible):
-        if arr.dtype.names:
-            typename = "%s" % str(arr.dtype)
-        else:
-            typename = "'%s'" % str(arr.dtype)
-    else:
-        typename = arr.dtype.name
-        # quote typenames which can't be represented as python variable names
-        if typename and not (typename[0].isalpha() and typename.isalnum()):
-            typename = "'%s'" % typename
+    typename = dtype_short_repr(arr.dtype)
 
     prefix = "{}({},".format(class_name, lst)
     suffix = "dtype={})".format(typename)

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -17,6 +17,9 @@ from numpy.ma.core import (
     )
 # from numpy.ma.core import (
 
+def assert_startswith(a, b):
+    # produces a better error message than assert_(a.startswith(b))
+    assert_equal(a[:len(b)], b)
 
 class SubArray(np.ndarray):
     # Defines a generic np.ndarray subclass, that stores some metadata
@@ -336,11 +339,11 @@ class TestSubclassing(object):
         and 'array' for np.ndarray"""
         x = np.arange(5)
         mx = masked_array(x, mask=[True, False, True, False, False])
-        assert_(repr(mx).startswith('masked_array'))
+        assert_startswith(repr(mx), 'masked_array')
         xsub = SubArray(x)
         mxsub = masked_array(xsub, mask=[True, False, True, False, False])
-        assert_(repr(mxsub).startswith(
-            'masked_{0}(data = [-- 1 -- 3 4]'.format(SubArray.__name__)))
+        assert_startswith(repr(mxsub),
+            'masked_{0}(data=[-- 1 -- 3 4]'.format(SubArray.__name__))
 
     def test_subclass_str(self):
         """test str with subclass that has overridden str, setitem"""
@@ -348,13 +351,13 @@ class TestSubclassing(object):
         x = np.arange(5)
         xsub = SubArray(x)
         mxsub = masked_array(xsub, mask=[True, False, True, False, False])
-        assert_(str(mxsub) == '[-- 1 -- 3 4]')
+        assert_equal(str(mxsub), '[-- 1 -- 3 4]')
 
         xcsub = ComplicatedSubArray(x)
         assert_raises(ValueError, xcsub.__setitem__, 0,
                       np.ma.core.masked_print_option)
         mxcsub = masked_array(xcsub, mask=[True, False, True, False, False])
-        assert_(str(mxcsub) == 'myprefix [-- 1 -- 3 4] mypostfix')
+        assert_equal(str(mxcsub), 'myprefix [-- 1 -- 3 4] mypostfix')
 
     def test_pure_subclass_info_preservation(self):
         # Test that ufuncs and methods conserve extra information consistently;

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -343,7 +343,7 @@ class TestSubclassing(object):
         xsub = SubArray(x)
         mxsub = masked_array(xsub, mask=[True, False, True, False, False])
         assert_startswith(repr(mxsub),
-            'masked_{0}(data=[-- 1 -- 3 4]'.format(SubArray.__name__))
+            'masked_{0}(data=[--, 1, --, 3, 4]'.format(SubArray.__name__))
 
     def test_subclass_str(self):
         """test str with subclass that has overridden str, setitem"""


### PR DESCRIPTION
While we're playing the "break the doctests" game...

* Remove trailing newline (probably safe in doctests)
* Fix alignment of wrapped lines (maybe safe in doctests
* Add commas (almost makes it valid python, breaks all doctests)

Before:
```python
>>> np.ma.array(np.arange(30), mask=np.arange(30) % 3 == 0)
masked_array(data = [-- 1 2 -- 4 5 -- 7 8 -- 10 11 -- 13 14 -- 16 17 -- 19 20 -- 22 23 -- 25 26
 -- 28 29],
             mask = [ True False False  True False False  True False False  True False False
  True False False  True False False  True False False  True False False
  True False False  True False False],
       fill_value = 999999)

>>> np.ma.array(np.eye(2).astype(int), mask=[[1, 0], [0, 0]], dtype=np.int8)
masked_array(data =
 [[-- 0]
 [0 1]],
             mask =
 [[ True False]
 [False False]],
       fill_value = 999999)

```

<s>After
```python
>>> np.ma.array(np.arange(30), mask=np.arange(30) % 3 == 0)
masked_array(data = [--, 1, 2, --, 4, 5, --, 7, 8, --, 10, 11, --, 13, 14,
                     --, 16, 17, --, 19, 20, --, 22, 23, --, 25, 26, --,
                     28, 29],
             mask = [ True, False, False,  True, False, False,  True,
                     False, False,  True, False, False,  True, False,
                     False,  True, False, False,  True, False, False,
                      True, False, False,  True, False, False,  True,
                     False, False],
       fill_value = 999999)
>>> np.ma.array(np.eye(2).astype(int), mask=[[1, 0], [0, 0]], dtype=np.int8)
masked_array(data =
 [[--, 0],
  [0, 1]],
             mask =
 [[ True, False],
  [False, False]],
       fill_value = 999999)
```

</s>

After:
```python
>>> np.ma.array(np.arange(30), mask=np.arange(30) % 3 == 0)
masked_array(data=[--, 1, 2, --, 4, 5, --, 7, 8, --, 10, 11, --, 13, 14,
                   --, 16, 17, --, 19, 20, --, 22, 23, --, 25, 26, --, 28,
                   29],
             mask=[ True, False, False,  True, False, False,  True, False,
                   False,  True, False, False,  True, False, False,  True,
                   False, False,  True, False, False,  True, False, False,
                    True, False, False,  True, False, False],
       fill_value=999999)

>>> np.ma.array(np.eye(2).astype(int), mask=[[1, 0], [0, 0]], dtype=np.int8)
masked_array(
  data=[[--, 0],
        [0, 1]],
  mask=[[ True, False],
        [False, False]],
  fill_value=999999,
  dtype=int8)