### PR TITLE
BUG: fix stray comma in _array2string

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -373,7 +373,7 @@ def _recursive_guard(fillvalue='...'):
 @_recursive_guard()
 def _array2string(a, options, separator=' ', prefix=""):
     if a.size > options['threshold']:
-        summary_insert = "..., "
+        summary_insert = "..."
         data = _leading_trailing(a)
     else:
         summary_insert = ""
@@ -545,7 +545,7 @@ def _formatArray(a, format_function, rank, max_line_len,
     if summary_insert and 2*edge_items < len(a):
         leading_items = edge_items
         trailing_items = edge_items
-        summary_insert1 = summary_insert
+        summary_insert1 = summary_insert + separator
     else:
         leading_items = 0
         trailing_items = len(a)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5624,7 +5624,7 @@ class TestInner(object):
 class TestSummarization(object):
     def test_1d(self):
         A = np.arange(1001)
-        strA = '[   0    1    2 ...,  998  999 1000]'
+        strA = '[   0    1    2 ...  998  999 1000]'
         assert_(str(A) == strA)
 
         reprA = 'array([   0,    1,    2, ...,  998,  999, 1000])'
@@ -5632,8 +5632,8 @@ class TestSummarization(object):
 
     def test_2d(self):
         A = np.arange(1002).reshape(2, 501)
-        strA = '[[   0    1    2 ...,  498  499  500]\n' \
-               ' [ 501  502  503 ...,  999 1000 1001]]'
+        strA = '[[   0    1    2 ...  498  499  500]\n' \
+               ' [ 501  502  503 ...  999 1000 1001]]'
         assert_(str(A) == strA)
 
         reprA = 'array([[   0,    1,    2, ...,  498,  499,  500],\n' \

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -495,8 +495,8 @@ class TestMaskedArray(object):
         a[1:50] = np.ma.masked
         assert_equal(
             repr(a),
-            'masked_array(data = [0 -- -- ..., 1997 1998 1999],\n'
-            '             mask = [False  True  True ..., False False False],\n'
+            'masked_array(data = [0 -- -- ... 1997 1998 1999],\n'
+            '             mask = [False  True  True ... False False False],\n'
             '       fill_value = 999999)\n'
         )
 


### PR DESCRIPTION
_array2string unconditionally added a comma after the '...' that
are inserted for arrays exceeding the size threshold. Add the
separator character instead. Fixes #9777.