### PR TITLE
BUG: Added exception for casting numpy.ma.masked to long

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4230,6 +4230,18 @@ class MaskedArray(ndarray):
         elif self._mask:
             raise MaskError('Cannot convert masked element to a Python int.')
         return int(self.item())
+    
+    def __long__(self):
+        """
+        Convert to long.
+        """
+        if self.size > 1:
+            raise TypeError("Only length-1 arrays can be conveted "
+                            "to Python scalars")
+        elif self._mask:
+            raise MaskError('Cannot convert masked element to a Python long.')
+        return long(self.item())
+      
 
     def get_imag(self):
         """

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4858,10 +4858,14 @@ class TestMaskedConstant(object):
         assert_raises(ValueError, operator.setitem, view.data, (), 1)
         assert_raises(ValueError, operator.setitem, view.mask, (), False)
 
-    @dec.knownfailureif(sys.version_info.major == 2, "See gh-9751")
     def test_coercion_int(self):
         a_i = np.zeros((), int)
         assert_raises(MaskError, operator.setitem, a_i, (), np.ma.masked)
+        assert_raises(MaskError, int, np.ma.masked)
+
+    @dec.skipif(sys.version_info.major == 3, "long doesn't exist in Python 3")
+    def test_coercion_long(self):
+        assert_raises(MaskError, long, np.ma.masked)
 
     def test_coercion_float(self):
         a_f = np.zeros((), float)


### PR DESCRIPTION
This fixes #9751.