### PR TITLE
TST: ensure sum of weights is positive in np.average and ma.average

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -248,6 +248,10 @@ def iterable(y):
 def average(a, axis=None, weights=None, returned=False):
     """
     Compute the weighted average along the specified axis.
+    
+    .. math:: \\bar{x} = \\frac{ \\sum_{i=1}^n w_i x_i}{\\sum_{i=1}^n w_i}
+
+    with :math:`\\sum_{i=1}^n w_i > 0`
 
     Parameters
     ----------
@@ -265,12 +269,13 @@ def average(a, axis=None, weights=None, returned=False):
         specified in the tuple instead of a single axis or all the axes as
         before.
     weights : array_like, optional
-        An array of weights associated with the values in `a`. Each value in
-        `a` contributes to the average according to its associated weight.
-        The weights array can either be 1-D (in which case its length must be
-        the size of `a` along the given axis) or of the same shape as `a`.
-        If `weights=None`, then all data in `a` are assumed to have a
-        weight equal to one.
+        An array of weights associated with the values in `a`.
+        Each value in `a` contributes to the average according to its
+        associated weight. The weights array can either be 1-D (in which case
+        its length must be the size of `a` along the given axis) or of the same
+        shape as `a`. The sum of weights should be positive.
+        If `weights=None`, then all data in `a` are assumed to have a weight
+        equal to one.
     returned : bool, optional
         Default is `False`. If `True`, the tuple (`average`, `sum_of_weights`)
         is returned, otherwise only the average is returned.
@@ -357,11 +362,10 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = wgt.swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)
-        if np.any(scl == 0.0):
-            raise ZeroDivisionError(
-                "Weights sum to zero, can't be normalized")
+        if np.any(scl <= 0.0):
+            raise ValueError("Sum of weights should be positive.")
 
-        avg = np.multiply(a, wgt, dtype=result_dtype).sum(axis)/scl
+        avg = np.multiply(a, wgt, dtype=result_dtype).sum(axis) / scl
 
     if returned:
         if scl.shape != avg.shape:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -265,6 +265,10 @@ class TestAverage(object):
         actual = average(y, weights=w)
         desired = (np.arange(10) ** 2).sum() * 1. / np.arange(10).sum()
         assert_almost_equal(actual, desired)
+        
+        assert_raises(ValueError, average, y, weights=-w)
+        assert_raises(ValueError, average, y, weights=np.zeros_like(w))
+        assert_raises(ValueError, average, y, weights=w - w.mean())
 
         y1 = np.array([[1, 2, 3], [4, 5, 6]])
         w0 = [1, 2]
@@ -281,7 +285,7 @@ class TestAverage(object):
         # assert_equal(average(y1, weights=w1), 9./2.)
 
         # 2D Case
-        w2 = [[0, 0, 1], [0, 0, 2]]
+        w2 = np.array([[0, 0, 1], [0, 0, 2]])
         desired = np.array([3., 6.])
         assert_array_equal(average(y1, weights=w2, axis=1), desired)
         assert_equal(average(y1, weights=w2), 5.)
@@ -290,6 +294,10 @@ class TestAverage(object):
         w3 = rand(5).astype(np.float64)
 
         assert_(np.average(y3, weights=w3).dtype == np.result_type(y3, w3))
+
+        assert_raises(ValueError, average, y1, weights=-w2)
+        assert_raises(ValueError, average, y1, weights=np.zeros_like(w2))
+        assert_raises(ValueError, average, y1, weights=w2 - w2.mean())
 
     def test_returned(self):
         y = np.array([[1, 2, 3], [4, 5, 6]])


### PR DESCRIPTION
Fixes #9825 by raising an error if weights are negative.