### PR TITLE
WIP/BUG: Replace the C function rk_hypergeometric_hyp()

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -776,6 +776,37 @@ long rk_geometric(rk_state *state, double p)
     }
 }
 
+long rk_hypergeometric_hyp_new(rk_state *state, long good, long bad, long sample)
+{
+    long remaining_total, remaining_good;
+
+    /*
+     *  We know this function will not be called with arguments that can result
+     *  in overflow in the following sum.
+     *  Also given: sample <= good + bad.
+     */
+    remaining_total = good + bad;
+    remaining_good = good;
+
+    while ((sample > 0) && (remaining_good > 0) &&
+           (remaining_total > remaining_good))
+    {
+        --remaining_total;
+        if (rk_interval(remaining_total, state) < remaining_good)
+        {
+            --remaining_good;
+        }
+        --sample;
+    }
+
+    if (remaining_total == remaining_good)
+    {
+        remaining_good -= sample;
+    }
+
+    return good - remaining_good;
+}
+
 long rk_hypergeometric_hyp(rk_state *state, long good, long bad, long sample)
 {
     long d1, K, Z;
@@ -864,7 +895,7 @@ long rk_hypergeometric(rk_state *state, long good, long bad, long sample)
         return rk_hypergeometric_hrua(state, good, bad, sample);
     } else
     {
-        return rk_hypergeometric_hyp(state, good, bad, sample);
+        return rk_hypergeometric_hyp_new(state, good, bad, sample);
     }
 }
 

--- a/numpy/random/mtrand/distributions.h
+++ b/numpy/random/mtrand/distributions.h
@@ -168,6 +168,7 @@ extern long rk_geometric_inversion(rk_state *state, double p);
 
 /* Hypergeometric distribution */
 extern long rk_hypergeometric(rk_state *state, long good, long bad, long sample);
+extern long rk_hypergeometric_hyp_new(rk_state *state, long good, long bad, long sample);
 extern long rk_hypergeometric_hyp(rk_state *state, long good, long bad, long sample);
 extern long rk_hypergeometric_hrua(rk_state *state, long good, long bad, long sample);
 


### PR DESCRIPTION
Note: This pull request cannot be merged in its current state.  It changes the
stream of random numbers generated by `numpy.random.hypergeometric()`
when the argument `nsample` is 10 or less.

Before a change such as this can be made, an API for selecting a version of
the random number generator must be developed.

-----

When the arguments 'ngood' or 'nbad' are ridiculously large and 'nsample'
is 10 or less, the function 'numpy.random.hypergeometric' generates invalid
samples.

For example,

    In [77]: np.random.hypergeometric(2**55, 2**55, 10, size=20)
    Out[77]: array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])

The problem is this code from the C function `rk_hypergeometric_hyp`:

            Y -= (long)floor(U + Y/(d1 + K));

'Y' is a double, and the expression on the right (after the cast to long)
is either 0 or 1.  The problem is that when Y is too big, the ULP for Y
is greater than 1, so that code doesn't change Y, regardless of the value
of the right side.

I have rewritten the function without using floating point values.

With the changes in this pull request:

```
In [6]: np.random.seed(8675309)

In [7]: np.random.hypergeometric(2**55, 2**55, 10, size=20)
Out[7]: array([5, 2, 6, 6, 4, 6, 5, 5, 3, 6, 8, 6, 4, 5, 5, 5, 6, 2, 6, 7])
```

The new function is also faster.  Here is an example using the new
implementation:

```
In [1]: import numpy as np

In [2]: np.__version__
Out[2]: '1.14.0.dev0+7dfc89a'

In [3]: %timeit r = np.random.hypergeometric(1000, 2500, 9, size=5000000)
478 ms ± 2.54 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit r = np.random.hypergeometric(10, 5, 9, size=5000000)
556 ms ± 7.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Using the existing implementatin in the numpy master branch:

```
In [1]: import numpy as np

In [2]: np.__version__
Out[2]: '1.14.0.dev0+6af2c42'

In [3]: %timeit r = np.random.hypergeometric(1000, 2500, 9, size=5000000)
692 ms ± 3.83 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit r = np.random.hypergeometric(10, 5, 9, size=5000000)
679 ms ± 3.71 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
