### PR TITLE
BUG: Prevent invalid array shapes in seed

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -369,3 +369,9 @@ display the sign. This new behavior can be disabled to mostly reproduce numpy
 -----------------------------------------------------------------
 These options could previously be controlled using ``np.set_printoptions``, but
 now can be changed on a per-call basis as arguments to ``np.array2string``.
+
+Seeding ``RandomState`` using an array requires a 1-d array
+-----------------------------------------------------------
+``RandomState`` previously would accept empty arrays or arrays with 2 or more
+dimensions, which resulted in either a failure to seed (empty arrays) or for
+some of the passed values to be ignored when setting the seed.

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -659,7 +659,7 @@ cdef class RandomState:
 
         Parameters
         ----------
-        seed : int or array_like, optional
+        seed : int or 1-d array_like, optional
             Seed for `RandomState`.
             Must be convertible to 32 bit unsigned integers.
 
@@ -676,14 +676,19 @@ cdef class RandomState:
                     errcode = rk_randomseed(self.internal_state)
             else:
                 idx = operator.index(seed)
-                if idx > int(2**32 - 1) or idx < 0:
+                if (idx >= 2**32) or (idx < 0):
                     raise ValueError("Seed must be between 0 and 2**32 - 1")
                 with self.lock:
                     rk_seed(idx, self.internal_state)
         except TypeError:
-            obj = np.asarray(seed).astype(np.int64, casting='safe')
-            if ((obj > int(2**32 - 1)) | (obj < 0)).any():
-                raise ValueError("Seed must be between 0 and 2**32 - 1")
+            obj = np.asarray(seed)
+            if obj.size == 0:
+                raise ValueError("Seed must be non-empty")
+            obj = obj.astype(np.int64, casting='safe')
+            if obj.ndim != 1:
+                raise ValueError("Seed array must be 1-d")
+            if ((obj >= 2**32) | (obj < 0)).any():
+                raise ValueError("Seed values must be between 0 and 2**32 - 1")
             obj = obj.astype('L', casting='unsafe')
             with self.lock:
                 init_by_array(self.internal_state, <unsigned long *>PyArray_DATA(obj),

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -42,6 +42,13 @@ class TestSeed(object):
         assert_raises(ValueError, np.random.RandomState, [1, 2, 4294967296])
         assert_raises(ValueError, np.random.RandomState, [1, -2, 4294967296])
 
+    def test_invalid_array_shape(self):
+        # gh-9832
+        assert_raises(ValueError, np.random.RandomState, np.array([], dtype=np.int64))
+        assert_raises(ValueError, np.random.RandomState, [[1, 2, 3]])
+        assert_raises(ValueError, np.random.RandomState, [[1, 2, 3],
+                                                          [4, 5, 6]])
+
 
 class TestBinomial(object):
     def test_n_zero(self):


### PR DESCRIPTION
Prevent empty arrays or arrays with more than 1 dimension from being
used to seed RandomState

closes #9832