### PR TITLE
DOC: Refine SVD documentation

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -72,6 +72,8 @@ Exceptions
 
    linalg.LinAlgError
 
+.. _routines.linalg-broadcasting:
+
 Linear algebra on several matrices at once
 ------------------------------------------
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1349,12 +1349,12 @@ def svd(a, full_matrices=True, compute_uv=True):
 
     SVD is usually described for the factorization of a 2D matrix :math:`A`.
     The higher-dimensional case will be discussed below. In the 2D case, SVD is
-    written as :math:`A = U S V^H``, where :math:`A=` ``a``, :math:`U=` ``u``,
-    :math:`S=` ``np.diag(s)`` and :math:`V^H=` ``vh``. `s` is then a 1D array
-    with the singular values of `a` and `u` and `vh` are unitary: the rows of `vh`
+    written as :math:`A = U S V^H`, where :math:`A=` `a`, :math:`U=` `u`,
+    :math:`S=` `np.diag(s)` and :math:`V^H=` `vh`. The 1D array `s` contains
+    the singular values of `a` and `u` and `vh` are unitary. The rows of `vh`
     are the eigenvectors of :math:`A^H A` and the columns of `u` are the
     eigenvectors of :math:`A A^H`. For row `i` in `vh` and column `i` in `u`,
-    the corresponding eigenvalue is ``s[i]**2``.
+    the corresponding eigenvalue is `s[i]**2`.
 
     Broadcasting rules apply, such that `a` can have more than 2 dimensions, as
     explained in :ref:`routines.linalg-broadcasting`. This means that SVD is
@@ -1362,8 +1362,8 @@ def svd(a, full_matrices=True, compute_uv=True):
     `a.ndim-2` dimensions and for each combination SVD is applied to the last
     two indices. The matrix `a` can be reconstructed from the decomposition
     with either ``(u * s[..., None, :]) @ vh`` or ``u @ (s[..., None] * vh)``.
-    (The ``@`` operator can be replaced by the function ``np.matmul`` for
-    python versions below 3.5.)
+    (The `@` operator can be replaced by the function `np.matmul` for python
+    versions below 3.5.)
 
     If `a` is a `matrix` object (as opposed to an `ndarray`), then so are all
     the return values.

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1310,10 +1310,10 @@ def svd(a, full_matrices=True, compute_uv=True):
     a : (..., M, N) array_like
         A real or complex array with ``a.ndim >= 2``.
     full_matrices : bool, optional
-        If True (default), `u` and `vh` have the shapes (..., `M`, `M`) and
-        (..., `N`, `N`), respectively.  Otherwise, the shapes are
-        (..., `M`, `K`) and (..., `K`, `N`), respectively, where
-        `K` = min(`M`, `N`).
+        If True (default), `u` and `vh` have the shapes ``(..., M, M)`` and
+        ``(..., N, N)``, respectively.  Otherwise, the shapes are
+        ``(..., M, K)`` and ``(..., K, N)``, respectively, where
+        ``K = min(M, N)``.
     compute_uv : bool, optional
         Whether or not to compute `u` and `vh` in addition to `s`.  True
         by default.
@@ -1343,23 +1343,22 @@ def svd(a, full_matrices=True, compute_uv=True):
     Notes
     -----
 
+    .. versionchanged:: 1.8.0
+       Broadcasting rules apply, see the `numpy.linalg` documentation for
+       details.
+
     The decomposition is performed using LAPACK routine ``_gesdd``.
 
     SVD is usually described for the factorization of a 2D matrix :math:`A`.
     The higher-dimensional case will be discussed below. In the 2D case, SVD is
-    written as :math:`A = U S V^H`, where :math:`A=` `a`, :math:`U=` `u`,
-    :math:`S=` ``np.diag(s)`` and :math:`V^H=` `vh`. The 1D array `s` contains
-    the singular values of `a` and `u` and `vh` are unitary. The rows of `vh`
-    are the eigenvectors of :math:`A^H A` and the columns of `u` are the
-    eigenvectors of :math:`A A^H`. In both cases the corresponding (possibly
-    non-zero) eigenvalues are given by ``s**2``.
+    written as :math:`A = U S V^H`, where :math:`A = a`, :math:`U= u`,
+    :math:`S= \mathtt{np.diag}(s)` and :math:`V^H = vh`. The 1D array `s`
+    contains the singular values of `a` and `u` and `vh` are unitary. The rows
+    of `vh` are the eigenvectors of :math:`A^H A` and the columns of `u` are
+    the eigenvectors of :math:`A A^H`. In both cases the corresponding
+    (possibly non-zero) eigenvalues are given by ``s**2``.
 
-    If `a` is a ``matrix`` object (as opposed to an ``ndarray``), then so are all
-    the return values.
-
-    .. versionadded:: 1.8.0
-
-    Broadcasting rules apply, such that `a` can have more than 2 dimensions, as
+    If `a` has more than two dimensions, then broadcasting rules apply, as
     explained in :ref:`routines.linalg-broadcasting`. This means that SVD is
     working in "stacked" mode: it iterates over all indices of the first
     ``a.ndim - 2`` dimensions and for each combination SVD is applied to the
@@ -1367,6 +1366,9 @@ def svd(a, full_matrices=True, compute_uv=True):
     decomposition with either ``(u * s[..., None, :]) @ vh`` or
     ``u @ (s[..., None] * vh)``. (The ``@`` operator can be replaced by the
     function ``np.matmul`` for python versions below 3.5.)
+
+    If `a` is a ``matrix`` object (as opposed to an ``ndarray``), then so are
+    all the return values.
 
     Examples
     --------

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1300,14 +1300,15 @@ def svd(a, full_matrices=True, compute_uv=True):
     """
     Singular Value Decomposition.
 
-    Factors the matrix `a` as ``u @ np.diag(s) @ vh``. When `a` is a 2D array,
-    `u` and `vh` are 2D unitary arrays and `s` is a 1D array of `a`'s singular
-    values.
+    When `a` is a 2D array, it is factorized as ``u @ np.diag(s) @ vh
+    = (u * s) @ vh``, where `u` and `vh` are 2D unitary arrays and `s` is a 1D
+    array of `a`'s singular values. When `a` is higher-dimensional, SVD is
+    applied in stacked mode as explained below.
 
     Parameters
     ----------
     a : (..., M, N) array_like
-        A real or complex matrix of shape (..., `M`, `N`) .
+        A real or complex array with `a.ndim>1`.
     full_matrices : bool, optional
         If True (default), `u` and `vh` have the shapes (..., `M`, `M`) and
         (..., `N`, `N`), respectively.  Otherwise, the shapes are
@@ -1320,13 +1321,19 @@ def svd(a, full_matrices=True, compute_uv=True):
     Returns
     -------
     u : { (..., M, M), (..., M, K) } array
-        Unitary matrices. The actual shape depends on the value of
-        ``full_matrices``. Only returned when ``compute_uv`` is True.
+        Unitary array(s). The first `a.ndim-2` dimensions have the same size as
+        those of the input `a`. The size of the last two dimensions depends on
+        the value of ``full_matrices``. Only returned when ``compute_uv`` is
+        True.
     s : (..., K) array
-        The singular values for every matrix, sorted in descending order.
+        Vector(s) with the singular values, within each vector sorted in
+        descending order. The first `a.ndim-2` dimensions have the same size as
+        those of the input `a`.
     vh : { (..., N, N), (..., K, N) } array
-        Unitary matrices. The actual shape depends on the value of
-        ``full_matrices``. Only returned when ``compute_uv`` is True.
+        Unitary array(s). The first `a.ndim-2` dimensions have the same size as
+        those of the input `a`. The size of the last two dimensions depends on
+        the value of ``full_matrices``. Only returned when ``compute_uv`` is
+        True.
 
     Raises
     ------
@@ -1341,16 +1348,22 @@ def svd(a, full_matrices=True, compute_uv=True):
     The decomposition is performed using LAPACK routine ``_gesdd``.
 
     SVD is usually described for the factorization of a 2D matrix :math:`A`.
-    The more general case will be discussed below. In the 2D case, SVD is
+    The higher-dimensional case will be discussed below. In the 2D case, SVD is
     written as :math:`A = U S V^H``, where :math:`A=` ``a``, :math:`U=` ``u``,
     :math:`S=` ``np.diag(s)`` and :math:`V^H=` ``vh``. `s` is then a 1D array
-    with the singular values and `u` and `vh` are unitary: the rows of `vh`
+    with the singular values of `a` and `u` and `vh` are unitary: the rows of `vh`
     are the eigenvectors of :math:`A^H A` and the columns of `u` are the
     eigenvectors of :math:`A A^H`. For row `i` in `vh` and column `i` in `u`,
-    the corresponding eigenvalue is `s[i]**2`.
+    the corresponding eigenvalue is ``s[i]**2``.
 
-    Broadcasting rules apply, such that `a` can have more than 2 dimensions.
-    See the :ref:`routines.linalg-broadcasting` for details.
+    Broadcasting rules apply, such that `a` can have more than 2 dimensions, as
+    explained in :ref:`routines.linalg-broadcasting`. This means that SVD is
+    working in "stacked" mode: it iterates over all indices of the first
+    `a.ndim-2` dimensions and for each combination SVD is applied to the last
+    two indices. The matrix `a` can be reconstructed from the decomposition
+    with either ``(u * s[..., None, :]) @ vh`` or ``u @ (s[..., None] * vh)``.
+    (The ``@`` operator can be replaced by the function ``np.matmul`` for
+    python versions below 3.5.)
 
     If `a` is a `matrix` object (as opposed to an `ndarray`), then so are all
     the return values.
@@ -1358,24 +1371,49 @@ def svd(a, full_matrices=True, compute_uv=True):
     Examples
     --------
     >>> a = np.random.randn(9, 6) + 1j*np.random.randn(9, 6)
+    >>> b = np.random.randn(2, 7, 8, 3) + 1j*np.random.randn(2, 7, 8, 3)
 
-    Reconstruction based on full SVD:
+    Reconstruction based on full SVD, 2D case:
 
     >>> u, s, vh = np.linalg.svd(a, full_matrices=True)
     >>> u.shape, s.shape, vh.shape
     ((9, 9), (6,), (6, 6))
+    >>> np.allclose(a, np.dot(u[:, :6] * s, vh))
+    True
     >>> smat = np.zeros((9, 6), dtype=complex)
     >>> smat[:6, :6] = np.diag(s)
-    >>> np.allclose(a, np.multi_dot(U, smat, vh))
+    >>> np.allclose(a, np.dot(u, np.dot(smat, vh)))
     True
 
-    Reconstruction based on reduced SVD:
+    Reconstruction based on reduced SVD, 2D case:
 
     >>> u, s, vh = np.linalg.svd(a, full_matrices=False)
     >>> u.shape, s.shape, vh.shape
     ((9, 6), (6,), (6, 6))
+    >>> np.allclose(a, np.dot(u * s, vh))
+    True
     >>> smat = np.diag(s)
-    >>> np.allclose(a, np.multi_dot(U, smat, vh))
+    >>> np.allclose(a, np.dot(u, np.dot(smat, vh)))
+    True
+
+    Reconstruction based on full SVD, 4D case:
+
+    >>> u, s, vh = np.linalg.svd(b, full_matrices=True)
+    >>> u.shape, s.shape, vh.shape
+    ((2, 7, 8, 8), (2, 7, 3), (2, 7, 3, 3))
+    >>> np.allclose(b, np.matmul(u[..., :3] * s[..., None, :], vh))
+    True
+    >>> np.allclose(b, np.matmul(u[..., :3], s[..., None] * vh))
+    True
+
+    Reconstruction based on reduced SVD, 4D case:
+
+    >>> u, s, vh = np.linalg.svd(b, full_matrices=False)
+    >>> u.shape, s.shape, vh.shape
+    ((2, 7, 8, 3), (2, 7, 3), (2, 7, 3, 3))
+    >>> np.allclose(b, np.matmul(u * s[..., None, :], vh))
+    True
+    >>> np.allclose(b, np.matmul(u, s[..., None] * vh))
     True
 
     """

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1352,7 +1352,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     SVD is usually described for the factorization of a 2D matrix :math:`A`.
     The higher-dimensional case will be discussed below. In the 2D case, SVD is
     written as :math:`A = U S V^H`, where :math:`A = a`, :math:`U= u`,
-    :math:`S= \mathtt{np.diag}(s)` and :math:`V^H = vh`. The 1D array `s`
+    :math:`S= \\mathtt{np.diag}(s)` and :math:`V^H = vh`. The 1D array `s`
     contains the singular values of `a` and `u` and `vh` are unitary. The rows
     of `vh` are the eigenvectors of :math:`A^H A` and the columns of `u` are
     the eigenvectors of :math:`A A^H`. In both cases the corresponding

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1300,7 +1300,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     """
     Singular Value Decomposition.
 
-    Factors the matrix `a` as ``u * np.diag(s) * vh``. When `a` is a 2D array,
+    Factors the matrix `a` as ``u @ np.diag(s) @ vh``. When `a` is a 2D array,
     `u` and `vh` are 2D unitary arrays and `s` is a 1D array of `a`'s singular
     values.
 
@@ -1309,7 +1309,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     a : (..., M, N) array_like
         A real or complex matrix of shape (..., `M`, `N`) .
     full_matrices : bool, optional
-        If True (default), `u` and `v` have the shapes (..., `M`, `M`) and
+        If True (default), `u` and `vh` have the shapes (..., `M`, `M`) and
         (..., `N`, `N`), respectively.  Otherwise, the shapes are
         (..., `M`, `K`) and (..., `K`, `N`), respectively, where
         `K` = min(`M`, `N`).
@@ -1344,12 +1344,10 @@ def svd(a, full_matrices=True, compute_uv=True):
     The more general case will be discussed below. In the 2D case, SVD is
     written as :math:`A = U S V^H``, where :math:`A=` ``a``, :math:`U=` ``u``,
     :math:`S=` ``np.diag(s)`` and :math:`V^H=` ``vh``. `s` is then a 1D array
-    with the singular values and `u` and `vh` are unitary: the columns of `u`
-    and the rows of `vh` form an orthonormal basis, such that ``np.dot(u.H, u)
-    == np.dot(vh, vh.H) == np.identity(K)``, with `K` = min(`M`, `N`). The rows
-    of `vh` are the eigenvectors of :math:`A^H A` and the columns of `u` are
-    the eigenvectors of :math:`A A^H`. For row ``i`` in `vh` and column ``i``
-    in `u`, the corresponding eigenvalue is ``s[i]**2``.
+    with the singular values and `u` and `vh` are unitary: the rows of `vh`
+    are the eigenvectors of :math:`A^H A` and the columns of `u` are the
+    eigenvectors of :math:`A A^H`. For row `i` in `vh` and column `i` in `u`,
+    the corresponding eigenvalue is `s[i]**2`.
 
     Broadcasting rules apply, such that `a` can have more than 2 dimensions.
     See the :ref:`routines.linalg-broadcasting` for details.
@@ -1368,7 +1366,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     ((9, 9), (6,), (6, 6))
     >>> smat = np.zeros((9, 6), dtype=complex)
     >>> smat[:6, :6] = np.diag(s)
-    >>> np.allclose(a, np.dot(u, np.dot(smat, vh)))
+    >>> np.allclose(a, np.multi_dot(U, smat, vh))
     True
 
     Reconstruction based on reduced SVD:
@@ -1377,7 +1375,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     >>> u.shape, s.shape, vh.shape
     ((9, 6), (6,), (6, 6))
     >>> smat = np.diag(s)
-    >>> np.allclose(a, np.dot(U, np.dot(smat, vh)))
+    >>> np.allclose(a, np.multi_dot(U, smat, vh))
     True
 
     """
@@ -1418,6 +1416,7 @@ def svd(a, full_matrices=True, compute_uv=True):
         s = gufunc(a, signature=signature, extobj=extobj)
         s = s.astype(_realType(result_t), copy=False)
         return s
+
 
 def cond(x, p=None):
     """

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1308,7 +1308,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     Parameters
     ----------
     a : (..., M, N) array_like
-        A real or complex array with `a.ndim>1`.
+        A real or complex array with ``a.ndim >= 2``.
     full_matrices : bool, optional
         If True (default), `u` and `vh` have the shapes (..., `M`, `M`) and
         (..., `N`, `N`), respectively.  Otherwise, the shapes are
@@ -1321,19 +1321,19 @@ def svd(a, full_matrices=True, compute_uv=True):
     Returns
     -------
     u : { (..., M, M), (..., M, K) } array
-        Unitary array(s). The first `a.ndim-2` dimensions have the same size as
-        those of the input `a`. The size of the last two dimensions depends on
-        the value of ``full_matrices``. Only returned when ``compute_uv`` is
-        True.
+        Unitary array(s). The first ``a.ndim - 2`` dimensions have the same
+        size as those of the input `a`. The size of the last two dimensions
+        depends on the value of `full_matrices`. Only returned when
+        `compute_uv` is True.
     s : (..., K) array
         Vector(s) with the singular values, within each vector sorted in
-        descending order. The first `a.ndim-2` dimensions have the same size as
-        those of the input `a`.
+        descending order. The first ``a.ndim - 2`` dimensions have the same
+        size as those of the input `a`.
     vh : { (..., N, N), (..., K, N) } array
-        Unitary array(s). The first `a.ndim-2` dimensions have the same size as
-        those of the input `a`. The size of the last two dimensions depends on
-        the value of ``full_matrices``. Only returned when ``compute_uv`` is
-        True.
+        Unitary array(s). The first ``a.ndim - 2`` dimensions have the same
+        size as those of the input `a`. The size of the last two dimensions
+        depends on the value of `full_matrices`. Only returned when
+        `compute_uv` is True.
 
     Raises
     ------
@@ -1343,30 +1343,30 @@ def svd(a, full_matrices=True, compute_uv=True):
     Notes
     -----
 
-    .. versionadded:: 1.8.0
-
     The decomposition is performed using LAPACK routine ``_gesdd``.
 
     SVD is usually described for the factorization of a 2D matrix :math:`A`.
     The higher-dimensional case will be discussed below. In the 2D case, SVD is
     written as :math:`A = U S V^H`, where :math:`A=` `a`, :math:`U=` `u`,
-    :math:`S=` `np.diag(s)` and :math:`V^H=` `vh`. The 1D array `s` contains
+    :math:`S=` ``np.diag(s)`` and :math:`V^H=` `vh`. The 1D array `s` contains
     the singular values of `a` and `u` and `vh` are unitary. The rows of `vh`
     are the eigenvectors of :math:`A^H A` and the columns of `u` are the
-    eigenvectors of :math:`A A^H`. For row `i` in `vh` and column `i` in `u`,
-    the corresponding eigenvalue is `s[i]**2`.
+    eigenvectors of :math:`A A^H`. In both cases the corresponding (possibly
+    non-zero) eigenvalues are given by ``s**2``.
+
+    If `a` is a ``matrix`` object (as opposed to an ``ndarray``), then so are all
+    the return values.
+
+    .. versionadded:: 1.8.0
 
     Broadcasting rules apply, such that `a` can have more than 2 dimensions, as
     explained in :ref:`routines.linalg-broadcasting`. This means that SVD is
     working in "stacked" mode: it iterates over all indices of the first
-    `a.ndim-2` dimensions and for each combination SVD is applied to the last
-    two indices. The matrix `a` can be reconstructed from the decomposition
-    with either ``(u * s[..., None, :]) @ vh`` or ``u @ (s[..., None] * vh)``.
-    (The `@` operator can be replaced by the function `np.matmul` for python
-    versions below 3.5.)
-
-    If `a` is a `matrix` object (as opposed to an `ndarray`), then so are all
-    the return values.
+    ``a.ndim - 2`` dimensions and for each combination SVD is applied to the
+    last two indices. The matrix `a` can be reconstructed from the
+    decomposition with either ``(u * s[..., None, :]) @ vh`` or
+    ``u @ (s[..., None] * vh)``. (The ``@`` operator can be replaced by the
+    function ``np.matmul`` for python versions below 3.5.)
 
     Examples
     --------


### PR DESCRIPTION
Fixes #7828

This is an attempt to fix some shortcomings for the SVD docstring:

- Dimensions of inputs and outputs were not completely correct.
- Name of the third return value was confusing. Changed `v` by `vh`. See #7828 for details.
- Add link to broadcasting for linalg functions.