### PR TITLE
BUG: Make bool(str_scalar) and str_scalar.astype(bool) consistent

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -144,6 +144,14 @@ the result is always a view on the original masked array.
 This breaks any code that used ``masked_arr.squeeze() is np.ma.masked``, but
 fixes code that writes to the result of `.squeeze()`.
 
+``string.astype(bool)`` now uses the normal python semantics for converting
+---------------------------------------------------------------------------
+Previously this was interpreted as ``string.astype(int).astype(bool)``, which
+interpeted ``'0'`` as ``False``.
+
+The behavior is now consistent with `count_nonzero` and `nonzero`, treating only
+the empty string as ``False``.
+
 Renamed first parameter of ``can_cast`` from ``from`` to ``from_``
 ------------------------------------------------------------------
 The previous parameter name ``from`` is a reserved keyword in Python, which made

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1545,7 +1545,7 @@ OBJECT_to_@TOTYPE@(void *input, void *output, npy_intp n,
  * #convert = 1*18, 0*3, 1*2,
  *            1*18, 0*3, 1*2,
  *            0*23#
- * #convstr = (Int*9, Long*2, Float*4, Complex*3, Tuple*3, Long*2)*3#
+ * #convstr = (Bool, Int*8, Long*2, Float*4, Complex*3, Tuple*3, Long*2)*3#
  */
 
 #if @convert@

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1226,11 +1226,9 @@ class TestBool(object):
     def test_cast_from_void(self):
         self._test_cast_from_flexible(np.void)
 
-    @dec.knownfailureif(True, "See gh-9847")
     def test_cast_from_unicode(self):
         self._test_cast_from_flexible(np.unicode_)
 
-    @dec.knownfailureif(True, "See gh-9847")
     def test_cast_from_bytes(self):
         self._test_cast_from_flexible(np.bytes_)
 


### PR DESCRIPTION
Fixes #9847, by changing `str_scalar.astype(bool)` to no longer mean `bool(int(str_scalar))`