### PR TITLE
BUG: Fix potential segfault related to Borrowed_PyMapping_GetItemString

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -49,6 +49,12 @@ static PyObject *
 Borrowed_PyMapping_GetItemString(PyObject *o, char *key)
 {
     PyObject *ret = PyMapping_GetItemString(o, key);
+    if (ret && Py_REFCNT(ret) == 1) {
+        /* We cannot safely decref and use this value because it would be freed. */
+        Py_DECREF(ret);
+        PyErr_Format(PyExc_TypeError, "Mapping returned a not stored value.");
+        return NULL;
+    }
     Py_XDECREF(ret);
     return ret;
 }

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -105,11 +105,11 @@ class TestBuiltin(object):
                          'offsets':[0, 2]}, align=True)
 
     def test_field_order_equality(self):
-        x = np.dtype({'names': ['A', 'B'], 
-                      'formats': ['i4', 'f4'], 
+        x = np.dtype({'names': ['A', 'B'],
+                      'formats': ['i4', 'f4'],
                       'offsets': [0, 4]})
-        y = np.dtype({'names': ['B', 'A'], 
-                      'formats': ['f4', 'i4'], 
+        y = np.dtype({'names': ['B', 'A'],
+                      'formats': ['f4', 'i4'],
                       'offsets': [4, 0]})
         assert_equal(x == y, False)
 
@@ -159,6 +159,19 @@ class TestRecord(object):
                       dict(names=set(['A', 'B']), formats=['f8', 'i4']))
         assert_raises(TypeError, np.dtype,
                       dict(names=['A', 'B'], formats=set(['f8', 'i4'])))
+
+        class MappingReturningTemporaries(dict):
+            def __getitem__(self, key):
+                if key == 'names':
+                    return ['f0', 'f1']
+                elif key == 'formats':
+                    return ['i4', 'i1']
+                elif key == 'offsets':
+                    return [0, 4]
+                elif key == 'itemsize':
+                    return 8
+                raise KeyError
+        assert_raises(TypeError, np.dtype, MappingReturningTemporaries())
 
     def test_aligned_size(self):
         # Check that structured dtypes get padded to an aligned size


### PR DESCRIPTION
Make sure Borrowed_PyMapping_GetItemString only returns not-NULL if
the value has a refcount of more than 1.

Fixes #9850 

It probably would be better to make sure the routine `_convert_from_dict` would take new references and decref them when needed but that's maybe overkill for such an edge-case.

Related: #6642 (especially https://github.com/numpy/numpy/pull/6642#issuecomment-154499559)