### PR TITLE
Speed improvement to np.random.choice under replace=False and p=None

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.99)/np.log(pop_size) + 1:
+                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.5)/np.log(pop_size) + 1:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1025,7 +1025,7 @@ cdef class RandomState:
         return bytestring
 
 
-    def choice(self, a, size=None, replace=True, p=None, legacy=False):
+    def choice(self, a, size=None, replace=True, p=None):
         """
         choice(a, size=None, replace=True, p=None)
 
@@ -1048,10 +1048,6 @@ cdef class RandomState:
             The probabilities associated with each entry in a.
             If not given the sample assumes a uniform distribution over all
             entries in a.
-        legacy : boolean, optional
-            Only relevant while replace==False, p==None, and size << len(a).
-            Preserves the output ordering of legacy versions of numpy
-            using a random seed, at the cost of significant loss in speed.
 
         Returns
         --------
@@ -1186,7 +1182,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if pop_size >= 3 and not legacy and \
+                if pop_size >= 3 and self.version > 0 and \
                    ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size:
                     idx = set()
                     while len(idx)<size:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,12 +1182,12 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > k:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size:
                     idx = set()
                     while len(idx)<size:
-                        idx.add(self.randint(0, pop_size))
+                        idx.add(int(self.randint(0, pop_size)))
                     idx = np.array(list(idx))
-                    np.shuffle(idx)
+                    self.shuffle(idx)
                 else:
                     idx = self.permutation(pop_size)[:size]
                 if shape is not None:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1186,7 +1186,8 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size and not legacy:
+                if pop_size >= 3 and not legacy and \
+                   ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size:
+                   (loggam(pop_size+1)-loggam(n-k))/np.log(n) > size:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1186,7 +1186,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size and not legacy:
+                if ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size and not legacy:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size:
+                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.99)/np.log(pop_size) + 1:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1025,7 +1025,7 @@ cdef class RandomState:
         return bytestring
 
 
-    def choice(self, a, size=None, replace=True, p=None):
+    def choice(self, a, size=None, replace=True, p=None, legacy=False):
         """
         choice(a, size=None, replace=True, p=None)
 
@@ -1048,6 +1048,10 @@ cdef class RandomState:
             The probabilities associated with each entry in a.
             If not given the sample assumes a uniform distribution over all
             entries in a.
+        legacy : boolean, optional
+            Only relevant while replace==False, p==None, and size << len(a).
+            Preserves the output ordering of legacy versions of numpy
+            using a random seed, at the cost of significant loss in speed.
 
         Returns
         --------
@@ -1182,7 +1186,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size and not legacy:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1185,7 +1185,7 @@ cdef class RandomState:
                 if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size:
                     idx = set()
                     while len(idx)<size:
-                        idx.add(int(self.randint(0, pop_size)))
+                        idx.update(self.randint(0, pop_size, size=size - len(idx)))
                     idx = np.array(list(idx))
                     self.shuffle(idx)
                 else:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,7 +1182,14 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                idx = self.permutation(pop_size)[:size]
+                if math.factorial(pop_size) < n**k:
+                    idx = set()
+                    while len(idx)<size:
+                        idx.add(self.randint(0, pop_size))
+                    idx = np.array(list(idx))
+                    np.shuffle(idx)
+                else:
+                    idx = self.permutation(pop_size)[:size]
                 if shape is not None:
                     idx.shape = shape
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,7 +1182,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if math.factorial(pop_size) < n**k:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) < k:
                     idx = set()
                     while len(idx)<size:
                         idx.add(self.randint(0, pop_size))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(n-k))/np.log(n) > size:
+                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,7 +1182,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) < k:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > k:
                     idx = set()
                     while len(idx)<size:
                         idx.add(self.randint(0, pop_size))


### PR DESCRIPTION
This is a fringe but also pretty common use-case for me. I want to choose a small sample of a large array, without replacement. The way this is currently written is O(n) where n is your array size. In the small case, however, with large arrays, this is very slow. The following algorithm's best performance is O(k) where k is your sample size. The worst case is unfortunately unbounded. There is always a probability that the random sample will continue to select the same values every time.

However, the probability that it will work in O(k) time, is the following:

![$P(O(k)) = \frac{n-1}{n} \cdot \frac{n-2}{n} \cdot ... \cdot \frac{n-k}{n} = \frac{n!}{n^k}$](https://latex.codecogs.com/gif.latex?P%28O%28k%29%29%20%3D%20%5Cfrac%7Bn-1%7D%7Bn%7D%20%5Ccdot%20%5Cfrac%7Bn-2%7D%7Bn%7D%20%5Ccdot%20...%20%5Ccdot%20%5Cfrac%7Bn-k%7D%7Bn%7D%20%3D%20%5Cfrac%7Bn%21%7D%7Bn%5Ek%7D)

Lets say we want it to choose this task if the probability of O(k) time is > .99 percent, and call that z.

![$P(O(k)) > .99 = z$](https://latex.codecogs.com/gif.latex?P%28O%28k%29%29%20%3E%20.99%20%3D%20z)

That probability will be such that n! < z*n^k where z = .99.

![$n! < z*n^k$](https://latex.codecogs.com/gif.latex?n%21%20%3C%20z%20n%5Ek)

Let's cancel z out instead and say z=1 (approximately). Thus, this algorithm should run whenever:

![z \approx 1.](https://latex.codecogs.com/gif.latex?z%20%5Capprox%201.)

![$n! < n^k$](https://latex.codecogs.com/gif.latex?n%21%20%3C%20n%5Ek)

Now, I haven't tested this code implemented in numpy, and I know running math.factorial is going to break at large numbers. Any way to simplify this inequality further? Does anyone want to dispute my math?