### PR TITLE
BUG: Make bool(void_scalar) and void_scalar.astype(bool) consistent

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -128,6 +128,14 @@ This is for pytest compatibility in the case of duplicate test file names in
 the different directories. As a result, ``run_module_suite`` no longer works,
 i.e., ``python <path-to-test-file>`` results in an error.
 
+``.astype(bool)`` on unstructured void arrays now calls ``bool`` on each element
+--------------------------------------------------------------------------------
+On Python 2, ``void_array.astype(bool)`` would always return an array of
+``True``, unless the dtype is ``V0``. On Python 3, this operation would usually
+crash. Going forwards, `astype` matches the behavior of ``bool(np.void)``,
+considering a buffer of all zeros as false, and anything else as true.
+Checks for ``V0`` can still be done with ``arr.dtype.itemsize == 0``.
+
 ``MaskedArray.squeeze`` never returns ``np.ma.masked``
 ------------------------------------------------------
 ``np.squeeze`` is documented as returning a view, but the masked variant would

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1561,12 +1561,12 @@ static void
     PyArrayObject *aip = vaip;
 
     npy_intp i;
-    PyObject *temp = NULL, *new;
     int skip = PyArray_DESCR(aip)->elsize;
     int oskip = @oskip@;
 
     for (i = 0; i < n; i++, ip+=skip, op+=oskip) {
-        temp = @from@_getitem(ip, aip);
+        PyObject *new;
+        PyObject *temp = PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)aip);
         if (temp == NULL) {
             return;
         }
@@ -1621,12 +1621,11 @@ static void
     PyArrayObject *aip = vaip;
 
     npy_intp i;
-    PyObject *temp = NULL;
     int skip = PyArray_DESCR(aip)->elsize;
     int oskip = @oskip@;
 
     for (i = 0; i < n; i++, ip+=skip, op+=oskip) {
-        temp = @from@_getitem(ip, aip);
+        PyObject *temp = PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)aip);
         if (temp == NULL) {
             return;
         }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1203,6 +1203,37 @@ class TestBool(object):
             a[:o] = False
             assert_equal(np.count_nonzero(a), builtins.sum(a.tolist()))
 
+    def _test_cast_from_flexible(self, dtype):
+        # empty string -> false
+        for n in range(3):
+            v = np.array(b'', (dtype, n))
+            assert_equal(bool(v), False)
+            assert_equal(bool(v[()]), False)
+            assert_equal(v.astype(bool), False)
+            assert_(isinstance(v.astype(bool), np.ndarray))
+            assert_(v[()].astype(bool) is np.False_)
+
+        # anything else -> true
+        for n in range(1, 4):
+            for val in [b'a', b'0', b' ']:
+                v = np.array(val, (dtype, n))
+                assert_equal(bool(v), True)
+                assert_equal(bool(v[()]), True)
+                assert_equal(v.astype(bool), True)
+                assert_(isinstance(v.astype(bool), np.ndarray))
+                assert_(v[()].astype(bool) is np.True_)
+
+    def test_cast_from_void(self):
+        self._test_cast_from_flexible(np.void)
+
+    @dec.knownfailureif(True, "See gh-9847")
+    def test_cast_from_unicode(self):
+        self._test_cast_from_flexible(np.unicode_)
+
+    @dec.knownfailureif(True, "See gh-9847")
+    def test_cast_from_bytes(self):
+        self._test_cast_from_flexible(np.bytes_)
+
 
 class TestZeroSizeFlexible(object):
     @staticmethod


### PR DESCRIPTION
Previously the behaviour of `void.astype(bool)` was:

* Python 2:
  * `itemsize == 0` - `False`
  * `itemsize > 0` - `True`
* Python 3:
  * `itemsize == 0` - `False`, warn about casting empty arrays to bool
  * `itemsize == 1` - `True` iff the sole element is 0
  * `itemsize > 1`- `ValueError: setting an array element with a sequence.`

Compared to the behaviour of `bool(void)`, which is:
* `True` iff all bytes are zero

The problem is that `y = x.astype(bool)` is implemented as `y[i] = bool(x[i].item())`

This patch changes it to use `y[i] = bool(x[i])`.

`void.item()` returns different results on python 2 and 3, which causes the crash.

IMO, `item()` is not something we should ever be using internally.

Works towards #9847 

---

This is a less objectionable subset of #9848 with no compatibility ramifications