### PR TITLE
DOC: Some minor fixes regarding import_array

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -3013,7 +3013,7 @@ Importing the API
 ^^^^^^^^^^^^^^^^^
 
 In order to make use of the C-API from another extension module, the
-``import_array`` () command must be used. If the extension module is
+:c:func:`import_array` function must be called. If the extension module is
 self-contained in a single .c file, then that is all that needs to be
 done. If, however, the extension module involves multiple files where
 the C-API is needed then some additional steps must be taken.
@@ -3034,7 +3034,7 @@ the C-API is needed then some additional steps must be taken.
     :c:macro:`PY_ARRAY_UNIQUE_SYMBOL` to some name that will hold the
     C-API (*e.g.* myextension_ARRAY_API). This must be done **before**
     including the numpy/arrayobject.h file. In the module
-    initialization routine you call ``import_array`` (). In addition,
+    initialization routine you call :c:func:`import_array`. In addition,
     in the files that do not have the module initialization
     sub_routine define :c:macro:`NO_IMPORT_ARRAY` prior to including
     numpy/arrayobject.h.
@@ -3115,7 +3115,7 @@ extension with the lowest NPY_FEATURE_VERSION as possible.
     it is in the C-API, however, comparing the output of this function from the
     value defined in the current header gives a way to test if the C-API has
     changed thus requiring a re-compilation of extension modules that use the
-    C-API. This is automatically checked in the function import_array.
+    C-API. This is automatically checked in the function :c:func:`import_array`.
 
 .. c:function:: unsigned int PyArray_GetNDArrayCFeatureVersion(void)
 

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -56,8 +56,8 @@ order for Python to use it as an extension module. The function must
 be called init{name} where {name} is the name of the module from
 Python. This function must be declared so that it is visible to code
 outside of the routine. Besides adding the methods and constants you
-desire, this subroutine must also contain calls to import_array()
-and/or import_ufunc() depending on which C-API is needed. Forgetting
+desire, this subroutine must also contain calls like ``import_array()``
+and/or ``import_ufunc()`` depending on which C-API is needed. Forgetting
 to place these commands will show itself as an ugly segmentation fault
 (crash) as soon as any C-API subroutine is actually called. It is
 actually possible to have multiple init{name} functions in a single


### PR DESCRIPTION
This makes some of the `import_array` mentions intersphinx links or uses code-formatting instead of raw text.