### PR TITLE
DOC: Replace PyFITS reference with Astropy and PyTables with h5py

### DIFF
--- a/numpy/doc/creation.py
+++ b/numpy/doc/creation.py
@@ -103,8 +103,8 @@ may be others for which it is possible to read and convert to numpy arrays so
 check the last section as well)
 ::
 
- HDF5: PyTables
- FITS: PyFITS
+ HDF5: h5py
+ FITS: Astropy
 
 Examples of formats that cannot be read directly but for which it is not hard to
 convert are those formats supported by libraries like PIL (able to read and


### PR DESCRIPTION
PyFITS isn't actively developed anymore (http://www.stsci.edu/institute/software_hardware/pyfits) and the functionality has been migrated to Astropy.