### PR TITLE
 ENH: Added compatibility for the NAG Fortran compiler, nagfor

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -738,7 +738,7 @@ _default_compilers = (
                'intelvem', 'intelem')),
     ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
-                'intele', 'intelem', 'gnu', 'g95', 'pathf95')),
+                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
     ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
     ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
     ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/numpy/distutils/fcompiler/nag.py
+++ b/numpy/distutils/fcompiler/nag.py
@@ -1,15 +1,32 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import re
 from numpy.distutils.fcompiler import FCompiler
 
-compilers = ['NAGFCompiler']
+compilers = ['NAGFCompiler', 'NAGFORCompiler']
 
-class NAGFCompiler(FCompiler):
+class BaseNAGFCompiler(FCompiler):
+    version_pattern = r'NAG.* Release (?P<version>[^(\s]*)'
+
+    def version_match(self, version_string):
+        m = re.search(self.version_pattern, version_string)
+        if m:
+            return m.group('version')
+        else:
+            return None
+
+    def get_flags_linker_so(self):
+        return ["-Wl,-shared"]
+    def get_flags_opt(self):
+        return ['-O4']
+    def get_flags_arch(self):
+        return ['']
+
+class NAGFCompiler(BaseNAGFCompiler):
 
     compiler_type = 'nag'
     description = 'NAGWare Fortran 95 Compiler'
-    version_pattern =  r'NAGWare Fortran 95 compiler Release (?P<version>[^\s]*)'
 
     executables = {
         'version_cmd'  : ["<F90>", "-V"],
@@ -22,24 +39,47 @@ class NAGFCompiler(FCompiler):
         }
 
     def get_flags_linker_so(self):
-        if sys.platform=='darwin':
+        if sys.platform == 'darwin':
             return ['-unsharedf95', '-Wl,-bundle,-flat_namespace,-undefined,suppress']
-        return ["-Wl,-shared"]
-    def get_flags_opt(self):
-        return ['-O4']
+        return BaseNAGFCompiler.get_flags_linker_so(self)
     def get_flags_arch(self):
         version = self.get_version()
         if version and version < '5.1':
             return ['-target=native']
         else:
-            return ['']
+            return BaseNAGFCompiler.get_flags_arch(self)
     def get_flags_debug(self):
         return ['-g', '-gline', '-g90', '-nan', '-C']
+
+class NAGFORCompiler(BaseNAGFCompiler):
+
+    compiler_type = 'nagfor'
+    description = 'NAG Fortran Compiler'
+
+    executables = {
+        'version_cmd'  : ["nagfor", "-V"],
+        'compiler_f77' : ["nagfor", "-fixed"],
+        'compiler_fix' : ["nagfor", "-fixed"],
+        'compiler_f90' : ["nagfor"],
+        'linker_so'    : ["nagfor"],
+        'archiver'     : ["ar", "-cr"],
+        'ranlib'       : ["ranlib"]
+        }
+
+    def get_flags_debug(self):
+        version = self.get_version()
+        if version and version > '6.1':
+            return ['-g', '-u', '-nan', '-C=all', '-thread_safe',
+                    '-kind=unique', '-Warn=allocation', '-Warn=subnormal']
+        else:
+            return ['-g', '-nan', '-C=all', '-u', '-thread_safe']
+
 
 if __name__ == '__main__':
     from distutils import log
     log.set_verbosity(2)
     from numpy.distutils.fcompiler import new_fcompiler
-    compiler = new_fcompiler(compiler='nag')
+    compiler = new_fcompiler(compiler='nagfor')
     compiler.customize()
     print(compiler.get_version())
+    print(compiler.get_flags_debug())

--- a/numpy/distutils/tests/test_fcompiler_nagfor.py
+++ b/numpy/distutils/tests/test_fcompiler_nagfor.py
@@ -4,21 +4,24 @@ from numpy.testing import assert_, run_module_suite
 
 import numpy.distutils.fcompiler
 
-nagfor_version_strings = [('NAG Fortran Compiler Release 6.2(Chiyoda) Build 6200', '6.2')]
+nagfor_version_strings = [('nagfor', 'NAG Fortran Compiler Release '
+                           '6.2(Chiyoda) Build 6200', '6.2'),
+                          ('nagfor', 'NAG Fortran Compiler Release '
+                           '6.1(Tozai) Build 6136', '6.1'),
+                          ('nagfor', 'NAG Fortran Compiler Release '
+                           '6.0(Hibiya) Build 1021', '6.0'),
+                          ('nagfor', 'NAG Fortran Compiler Release '
+                           '5.3.2(971)', '5.3.2')]
 
-nag_version_strings = [('NAGWare Fortran 95 compiler Release 5.1(347,355-367,375,'
-                        '380-383,389,394,399,401-402,407,431,435,437,446,459-460,'
-                        '463,472,494,496,503,508,511,517,529,555,557,565)', '5.1')]
+nag_version_strings = [('nag', 'NAGWare Fortran 95 compiler Release 5.1'
+                        '(347,355-367,375,380-383,389,394,399,401-402,407,'
+                        '431,435,437,446,459-460,463,472,494,496,503,508,'
+                        '511,517,529,555,557,565)', '5.1')]
 
 class TestNagFCompilerVersions(object):
     def test_version_match(self):
-        fc = numpy.distutils.fcompiler.new_fcompiler(compiler='nagfor')
-        for vs, version in nagfor_version_strings:
-            v = fc.version_match(vs)
-            assert_(v == version)
-
-        fc = numpy.distutils.fcompiler.new_fcompiler(compiler='nag')
-        for vs, version in nag_version_strings:
+        for comp, vs, version in nagfor_version_strings:
+            fc = numpy.distutils.fcompiler.new_fcompiler(compiler=comp)
             v = fc.version_match(vs)
             assert_(v == version)
 

--- a/numpy/distutils/tests/test_fcompiler_nagfor.py
+++ b/numpy/distutils/tests/test_fcompiler_nagfor.py
@@ -1,0 +1,27 @@
+from __future__ import division, absolute_import, print_function
+
+from numpy.testing import assert_, run_module_suite
+
+import numpy.distutils.fcompiler
+
+nagfor_version_strings = [('NAG Fortran Compiler Release 6.2(Chiyoda) Build 6200', '6.2')]
+
+nag_version_strings = [('NAGWare Fortran 95 compiler Release 5.1(347,355-367,375,'
+                        '380-383,389,394,399,401-402,407,431,435,437,446,459-460,'
+                        '463,472,494,496,503,508,511,517,529,555,557,565)', '5.1')]
+
+class TestNagFCompilerVersions(object):
+    def test_version_match(self):
+        fc = numpy.distutils.fcompiler.new_fcompiler(compiler='nagfor')
+        for vs, version in nagfor_version_strings:
+            v = fc.version_match(vs)
+            assert_(v == version)
+
+        fc = numpy.distutils.fcompiler.new_fcompiler(compiler='nag')
+        for vs, version in nag_version_strings:
+            v = fc.version_match(vs)
+            assert_(v == version)
+
+
+if __name__ == '__main__':
+    run_module_suite()

--- a/numpy/distutils/tests/test_fcompiler_nagfor.py
+++ b/numpy/distutils/tests/test_fcompiler_nagfor.py
@@ -4,23 +4,22 @@ from numpy.testing import assert_, run_module_suite
 
 import numpy.distutils.fcompiler
 
-nagfor_version_strings = [('nagfor', 'NAG Fortran Compiler Release '
-                           '6.2(Chiyoda) Build 6200', '6.2'),
-                          ('nagfor', 'NAG Fortran Compiler Release '
-                           '6.1(Tozai) Build 6136', '6.1'),
-                          ('nagfor', 'NAG Fortran Compiler Release '
-                           '6.0(Hibiya) Build 1021', '6.0'),
-                          ('nagfor', 'NAG Fortran Compiler Release '
-                           '5.3.2(971)', '5.3.2')]
-
-nag_version_strings = [('nag', 'NAGWare Fortran 95 compiler Release 5.1'
+nag_version_strings = [('nagfor', 'NAG Fortran Compiler Release '
+                        '6.2(Chiyoda) Build 6200', '6.2'),
+                       ('nagfor', 'NAG Fortran Compiler Release '
+                        '6.1(Tozai) Build 6136', '6.1'),
+                       ('nagfor', 'NAG Fortran Compiler Release '
+                        '6.0(Hibiya) Build 1021', '6.0'),
+                       ('nagfor', 'NAG Fortran Compiler Release '
+                        '5.3.2(971)', '5.3.2'),
+                       ('nag', 'NAGWare Fortran 95 compiler Release 5.1'
                         '(347,355-367,375,380-383,389,394,399,401-402,407,'
                         '431,435,437,446,459-460,463,472,494,496,503,508,'
                         '511,517,529,555,557,565)', '5.1')]
 
 class TestNagFCompilerVersions(object):
     def test_version_match(self):
-        for comp, vs, version in nagfor_version_strings:
+        for comp, vs, version in nag_version_strings:
             fc = numpy.distutils.fcompiler.new_fcompiler(compiler=comp)
             v = fc.version_match(vs)
             assert_(v == version)


### PR DESCRIPTION
This adds the newer NAG Fortran compiler, nagfor, to distutils.

- nag.py modified to include nagfor
- Added tests for the version pattern
- Only for linux atm, as unable to test other OS