### PR TITLE
DOC: Unindent enumeration in savetxt docstring

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1090,12 +1090,12 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         case `delimiter` is ignored. For complex `X`, the legal options
         for `fmt` are:
             a) a single specifier, `fmt='%.4e'`, resulting in numbers formatted
-                like `' (%s+%sj)' % (fmt, fmt)`
+               like `' (%s+%sj)' % (fmt, fmt)`
             b) a full string specifying every real and imaginary part, e.g.
-                `' %.4e %+.4ej %.4e %+.4ej %.4e %+.4ej'` for 3 columns
+               `' %.4e %+.4ej %.4e %+.4ej %.4e %+.4ej'` for 3 columns
             c) a list of specifiers, one per column - in this case, the real
-                and imaginary part must have separate specifiers,
-                e.g. `['%.3e + %.3ej', '(%.15e%+.15ej)']` for 2 columns
+               and imaginary part must have separate specifiers,
+               e.g. `['%.3e + %.3ej', '(%.15e%+.15ej)']` for 2 columns
     delimiter : str, optional
         String or character separating columns.
     newline : str, optional


### PR DESCRIPTION
The rendered markdown [in the online documentation](https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.savetxt.html) was broken due to the one-character indentation added in the multiline enumerations of the docstring of `savetxt` (discussing the possible formats of the `fmt` kwarg).

From the [sphinx rst primer](http://www.sphinx-doc.org/en/stable/rest.html) and [an online preview tool](https://livesphinx.herokuapp.com/) I suspect that sphinx expects contiguous blocks of text to start on the same column, while the current version had an overall 4-space indentation for these multiline enumerations after python fashion. I couldn't rigorously test this change using sphinx, though.