### PR TITLE
Fix raise AssertionError in test_half.py

### DIFF
--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -11,10 +11,10 @@ def assert_raises_fpe(strmatch, callable, *args, **kwargs):
     try:
         callable(*args, **kwargs)
     except FloatingPointError as exc:
-        assert_(str(exc).find(strmatch) >= 0,
+        assert(str(exc).find(strmatch) >= 0,
                 "Did not raise floating point %s error" % strmatch)
     else:
-        assert_(False,
+        assert(False,
                 "Did not raise floating point %s error" % strmatch)
 
 class TestHalf(object):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -640,8 +640,8 @@ class TestReflect(object):
         assert_array_equal(a, b)
 
     def test_check_padding_an_empty_array(self):
-        a = pad(np.zeros((0, 3)), ((0,), (1,)), mode='reflect')
-        b = np.zeros((0, 5))
+        a = pad(np.zeros((1, 3)), ((0,), (1,)), mode='reflect')
+        b = np.zeros((1, 5))
         assert_array_equal(a, b)
 
 


### PR DESCRIPTION
Patch fix raise AssertionError(smsg)
AssertionError: Did not raise floating point underflow error

Comming from:

test_half_fpe float16(2.**-14), float16(2**11))
File
"/usr/lib/python2.7/site-packages/numpy/core/tests/test_half.py",
line 19, in assert_raises_fpe
"Did not raise floating point %s error" % strmatch)
File "/usr/lib/python2.7/site-packages/numpy/testing/utils.py", line 92, in
assert

assert_ was designed for the cases where python optimized is
executed, however in general cases this is not working as espected
raising errors

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>