### PR TITLE
Fix ValueError in test_arraypad.py

### DIFF
--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -640,8 +640,8 @@ class TestReflect(object):
         assert_array_equal(a, b)
 
     def test_check_padding_an_empty_array(self):
-        a = pad(np.zeros((0, 3)), ((0,), (1,)), mode='reflect')
-        b = np.zeros((0, 5))
+        a = pad(np.zeros((1, 3)), ((0,), (1,)), mode='reflect')
+        b = np.zeros((1, 5))
         assert_array_equal(a, b)
 
 


### PR DESCRIPTION
In test_check_padding_an_empty_array

a = pad(np.zeros((0, 3)), ((0,), (1,)), mode='reflect')

generate an array of 0 raws, this generate a raise ValueError in arraypad.py:

    if narray.size == 0:

This is fixed generating an array of 1 raw and 3 columns

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>