### PR TITLE
ENH: push histogram calculations to compiled_base

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -5,6 +5,34 @@ from .common import Benchmark
 import numpy as np
 
 
+class Histogram1D(Benchmark):
+    def setup(self):
+        self.d = np.linspace(0, 100, 100000)
+
+    def time_full_coverage(self):
+        np.histogram(self.d, 200, (0, 100))
+
+    def time_small_coverage(self):
+        np.histogram(self.d, 200, (50, 51))
+
+    def time_fine_binning(self):
+        np.histogram(self.d, 10000, (0, 100))
+
+
+class Histogram2D(Benchmark):
+    def setup(self):
+        self.d = np.linspace(0, 100, 200000).reshape((-1,2))
+
+    def time_full_coverage(self):
+        np.histogramdd(self.d, (200, 200), ((0, 100), (0, 100)))
+
+    def time_small_coverage(self):
+        np.histogramdd(self.d, (200, 200), ((50, 51), (50, 51)))
+
+    def time_fine_binning(self):
+        np.histogramdd(self.d, (10000, 10000), ((0, 100), (0, 100)))
+
+
 class Bincount(Benchmark):
     def setup(self):
         self.d = np.arange(80000, dtype=np.intp)

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -80,6 +80,388 @@ minmax(const npy_intp *data, npy_intp data_len, npy_intp *mn, npy_intp *mx)
     *mx = max;
 }
 
+NPY_NO_EXPORT PyObject *
+arr_histogram_uniform(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
+{
+    PyObject *obj_x, *obj_edges, *weights = Py_None;
+    PyArrayObject *arr_x = NULL, *arr_edges = NULL, *arr_w = NULL, *hist = NULL;
+    npy_intp len, bins;
+    double *e, min, max, norm;
+
+    static char *kwlist[] = {"x", "edges", "weights", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O:_histogram_uniform",
+            kwlist, &obj_x, &obj_edges, &weights)) {
+        goto fail;
+    }
+
+    arr_x = (PyArrayObject *)PyArray_ContiguousFromAny(obj_x, NPY_DOUBLE, 1, 1);
+    if (arr_x == NULL) {
+        goto fail;
+    }
+    len = PyArray_DIM(arr_x, 0);
+
+    arr_edges = (PyArrayObject *)PyArray_ContiguousFromAny(obj_edges, NPY_DOUBLE, 1, 1);
+    if (arr_edges == NULL) {
+        goto fail;
+    }
+    bins = PyArray_DIM(arr_edges, 0) - 1;
+
+    /* Handle empty array */
+    if (len == 0) {
+        hist = (PyArrayObject *)PyArray_ZEROS(1, &bins, NPY_INTP, 0);
+        if (hist == NULL) {
+            goto fail;
+        }
+        Py_DECREF(arr_edges);
+        Py_DECREF(arr_x);
+        return (PyObject *)hist;
+    }
+
+    e = (double *)PyArray_DATA(arr_edges);
+
+    if (bins <= 0)
+    {
+        PyErr_SetString(PyExc_ValueError, "Must supply at least one bin (two edges)");
+        goto fail;
+    }
+    min = e[0];
+    max = e[bins];
+
+    if ((max - min) <= 0)
+    {
+        PyErr_SetString(PyExc_ValueError, "Bin edges must be increasing");
+        goto fail;
+    }
+    norm = bins / (max - min);
+
+    if (weights == Py_None) {
+        npy_intp *ihist, i;
+        double *x;
+
+        hist = (PyArrayObject *)PyArray_ZEROS(1, &bins, NPY_INTP, 0);
+        if (hist == NULL) {
+            goto fail;
+        }
+
+        x = (double *)PyArray_DATA(arr_x);
+        ihist = (npy_intp *)PyArray_DATA(hist);
+
+        NPY_BEGIN_ALLOW_THREADS;
+        for(i = 0; i < len; i++) {
+            double tx = x[i];
+            if ((min <= tx) && (tx <= max)) {
+                npy_intp ix = (npy_intp)((tx - min) * norm);
+                /*
+                 * For values that lie exactly on mx we need to subtract one.
+                 * Also, the index computation is not guaranteed to give
+                 * exactly consistent results within ~1 ULP of the bin edges.
+                 * The last bin includes the right edge. The other bins do not.
+                 */
+                if (ix == bins || (ix != 0 && tx < e[ix])) {
+                    ix--;
+                }
+                else if ((ix + 1) != bins && tx >= e[ix + 1]) {
+                    ix++;
+                }
+                ihist[ix]++;
+            }
+        }
+        NPY_END_ALLOW_THREADS;
+    }
+    else {
+        npy_intp i;
+        double *x, *w, *dhist;
+
+        arr_w = (PyArrayObject *)PyArray_ContiguousFromAny(weights, NPY_DOUBLE, 1, 1);
+        if (arr_w == NULL) {
+            goto fail;
+        }
+        if (PyArray_SIZE(arr_w) != len) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Weights must be same length as array");
+            goto fail;
+        }
+
+        hist = (PyArrayObject *)PyArray_ZEROS(1, &bins, NPY_DOUBLE, 0);
+        if (hist == NULL) {
+            goto fail;
+        }
+
+        x = (double *)PyArray_DATA(arr_x);
+        w = (double *)PyArray_DATA(arr_w);
+        dhist = (double *)PyArray_DATA(hist);
+
+        NPY_BEGIN_ALLOW_THREADS;
+        for(i = 0; i < len; i++) {
+            double tx = x[i];
+            if ((min <= tx) && (tx <= max)) {
+                npy_intp ix = (tx - min) * norm;
+                if (ix == bins || (ix != 0 && tx < e[ix])) {
+                    ix--;
+                }
+                else if ((ix + 1) != bins && tx >= e[ix + 1]) {
+                    ix++;
+                }
+                dhist[ix] += w[i];
+            }
+        }
+        NPY_END_ALLOW_THREADS;
+
+        Py_DECREF(arr_w);
+    }
+
+    Py_DECREF(arr_edges);
+    Py_DECREF(arr_x);
+    return (PyObject *)hist;
+
+fail:
+    Py_XDECREF(hist);
+    Py_XDECREF(arr_w);
+    Py_XDECREF(arr_edges);
+    Py_XDECREF(arr_x);
+    return NULL;
+}
+
+NPY_NO_EXPORT PyObject *
+arr_histogramdd_uniform(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
+{
+    PyObject *obj_x, *obj_bins, *obj_edges, *weights = Py_None;
+    PyArrayObject *arr_x = NULL, *arr_bins = NULL, *arr_edges = NULL,
+                  *arr_w = NULL, *hist = NULL;
+    npy_intp len, ndim, *bins;
+    double min[NPY_MAXDIMS], max[NPY_MAXDIMS], norm[NPY_MAXDIMS];
+
+    static char *kwlist[] = {"x", "nbins", "edges", "weights", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO|O:_histogramdd_uniform",
+            kwlist, &obj_x, &obj_bins, &obj_edges, &weights)) {
+        goto fail;
+    }
+
+    /*
+     * Get data (x) which is of shape (len, ndim)
+     * where len is the number of samples
+     * and ndim is the number of dimensions
+     */
+    arr_x = (PyArrayObject *)PyArray_ContiguousFromAny(obj_x, NPY_DOUBLE, 2, 2);
+    if (arr_x == NULL) {
+        goto fail;
+    }
+    len = PyArray_DIM(arr_x, 0);
+    ndim = PyArray_DIM(arr_x, 1);
+
+    /*
+     * Get the number of bins for each array since
+     * the edges are passed in as a flat array
+     */
+    arr_bins = (PyArrayObject *)PyArray_FROM_O(obj_bins);
+    if (!PyArray_ISINTEGER(arr_bins))
+    {
+        PyErr_SetString(PyExc_TypeError, "Bin counts must be integers");
+        goto fail;
+    }
+    if (arr_bins == NULL) {
+        goto fail;
+    }
+    if (PyArray_DIM(arr_bins, 0) != ndim) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Number of bins array must be same length as array");
+        goto fail;
+    }
+    bins = (npy_intp *)PyArray_DATA(arr_bins);
+
+    /* Handle empty array */
+    if (len == 0) {
+        hist = (PyArrayObject *)PyArray_ZEROS(ndim, bins, NPY_INTP, 0);
+        if (hist == NULL) {
+            goto fail;
+        }
+        Py_DECREF(arr_bins);
+        Py_DECREF(arr_x);
+        return (PyObject *)hist;
+    }
+
+    /*
+     * Get bin edges which is a flat array
+     */
+    arr_edges = (PyArrayObject *)PyArray_ContiguousFromAny(obj_edges, NPY_DOUBLE, 1, 1);
+    if (arr_edges == NULL) {
+        goto fail;
+    }
+
+    /*
+     * Verify that the total number of bins is the correct
+     * according to the size of the input (flat) array of
+     * bin edges
+     */
+    {
+        npy_intp nedges_total = 0;
+        npy_intp i;
+        for (i = 0; i < ndim; i++) {
+            nedges_total += bins[i] + 1;
+        }
+        if (PyArray_SIZE(arr_edges) != nedges_total) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Length of edges must be equal to the total number of edges");
+            goto fail;
+        }
+    }
+
+    /*
+     * Calculate the min, max and norm values along
+     * each dimension
+     */
+    {
+        npy_intp d;
+        double *e = (double *)PyArray_DATA(arr_edges);
+        for (d = 0; d < ndim; d++) {
+
+            min[d] = e[0];
+            max[d] = e[bins[d]];
+
+            if (bins[d] <= 0) {
+                PyErr_SetString(PyExc_ValueError,
+                    "Must supply at least one bin (two edges) for each dimension");
+                goto fail;
+            }
+            if ((max[d] - min[d]) <= 0) {
+                PyErr_SetString(PyExc_ValueError, "Bin edges must be increasing");
+                goto fail;
+            }
+            norm[d] = bins[d] / (max[d] - min[d]);
+
+            e += bins[d] + 1;
+        }
+    }
+
+    if (weights == Py_None) {
+        /*
+         * weights is None, so output histogram dtype is int
+         */
+        npy_intp i;
+        double *x;
+
+        hist = (PyArrayObject *)PyArray_ZEROS(ndim, bins, NPY_INTP, 0);
+        if (hist == NULL) {
+            goto fail;
+        }
+
+        x = (double *)PyArray_DATA(arr_x);
+
+        NPY_BEGIN_ALLOW_THREADS;
+        for (i = 0; i < len; i++) {
+            int overflow = 0;
+            npy_intp d, ix[NPY_MAXDIMS];
+            double *e = (double *)PyArray_DATA(arr_edges);
+            for (d = 0; d < ndim; d++) {
+                double tx = x[i * ndim + d];
+                if ((min[d] <= tx) && (tx <= max[d])) {
+                    ix[d] = (tx - min[d]) * norm[d];
+                    /*
+                     * For values that lie exactly on mx we need to subtract one.
+                     * Also, the index computation is not guaranteed to give
+                     * exactly consistent results within ~1 ULP of the bin edges.
+                     * The last bin includes the right edge. The other bins do not.
+                     */
+                    if (ix[d] == bins[d] || (ix[d] != 0 && tx < e[ix[d]])) {
+                        ix[d]--;
+                    }
+                    else if ((ix[d] + 1) != bins[d] && tx >= e[ix[d] + 1]) {
+                        ix[d]++;
+                    }
+                    e += bins[d] + 1;
+                }
+                else {
+                    overflow = 1;
+                    break;
+                }
+            }
+            if (overflow) {
+                continue;
+            }
+            *((npy_intp *)PyArray_GetPtr(hist, ix)) += 1;
+        }
+        NPY_END_ALLOW_THREADS;
+    }
+    else {
+        /*
+         * weights given, so output histogram dtype is double
+         */
+        npy_intp i;
+        double *x, *w;
+
+        arr_w = (PyArrayObject *)PyArray_ContiguousFromAny(weights, NPY_DOUBLE, 1, 1);
+        if (arr_w == NULL) {
+            goto fail;
+        }
+        if (PyArray_DIM(arr_w, 0) != len) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Weights must be same length as array");
+            goto fail;
+        }
+
+        hist = (PyArrayObject *)PyArray_ZEROS(ndim, bins, NPY_DOUBLE, 0);
+        if (hist == NULL) {
+            goto fail;
+        }
+
+        x = (double *)PyArray_DATA(arr_x);
+        w = (double *)PyArray_DATA(arr_w);
+
+        NPY_BEGIN_ALLOW_THREADS;
+        for (i = 0; i < len; i++) {
+            int overflow = 0;
+            npy_intp d, ix[NPY_MAXDIMS];
+            double *e = (double *)PyArray_DATA(arr_edges);
+            for (d = 0; d < ndim; d++) {
+                npy_intp ii = i * ndim + d;
+                double tx = x[ii];
+                if ((min[d] <= tx) && (tx <= max[d])) {
+                    ix[d] = (tx - min[d]) * norm[d];
+                    /*
+                     * For values that lie exactly on mx we need to subtract one.
+                     * Also, the index computation is not guaranteed to give
+                     * exactly consistent results within ~1 ULP of the bin edges.
+                     * The last bin includes the right edge. The other bins do not.
+                     */
+                    if (ix[d] == bins[d] || (ix[d] != 0 && tx < e[ix[d]])) {
+                        ix[d]--;
+                    }
+                    else if ((ix[d] + 1) != bins[d] && tx >= e[ix[d] + 1]) {
+                        ix[d]++;
+                    }
+                    e += bins[d] + 1;
+                }
+                else {
+                    overflow = 1;
+                    break;
+                }
+            }
+            if (overflow) {
+                continue;
+            }
+            *((double *)PyArray_GetPtr(hist, ix)) += w[i];
+        }
+        NPY_END_ALLOW_THREADS;
+
+        Py_DECREF(arr_w);
+    }
+
+    Py_DECREF(arr_edges);
+    Py_DECREF(arr_bins);
+    Py_DECREF(arr_x);
+    return (PyObject *)hist;
+
+fail:
+    Py_XDECREF(hist);
+    Py_XDECREF(arr_w);
+    Py_XDECREF(arr_edges);
+    Py_XDECREF(arr_bins);
+    Py_XDECREF(arr_x);
+    return NULL;
+}
+
 /*
  * arr_bincount is registered as bincount.
  *
@@ -691,8 +1073,8 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     npy_intp i, lenx, lenxp;
 
     const npy_double *dx, *dz;
-    const npy_cdouble *dy; 
-    npy_cdouble lval, rval; 
+    const npy_cdouble *dy;
+    npy_cdouble lval, rval;
     npy_cdouble *dres, *slopes = NULL;
 
     static char *kwlist[] = {"x", "xp", "fp", "left", "right", NULL};

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -739,7 +739,7 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     if (af == NULL) {
         goto fail;
     }
-        
+
     dy = (const npy_cdouble *)PyArray_DATA(afp);
     dres = (npy_cdouble *)PyArray_DATA(af);
     /* Get left and right fill values. */
@@ -756,7 +756,7 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             goto fail;
         }
     }
-        
+
     if ((right == NULL) || (right == Py_None)) {
         rval = dy[lenxp - 1];
     }
@@ -770,12 +770,12 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             goto fail;
         }
     }
-        
+
     /* binary_search_with_guess needs at least a 3 item long array */
     if (lenxp == 1) {
         const npy_double xp_val = dx[0];
         const npy_cdouble fp_val = dy[0];
-            
+
         NPY_BEGIN_THREADS_THRESHOLDED(lenx);
         for (i = 0; i < lenx; ++i) {
             const npy_double x_val = dz[i];
@@ -786,7 +786,7 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     }
     else {
         npy_intp j = 0;
-        
+
         /* only pre-calculate slopes if there are relatively few of them. */
         if (lenxp <= lenx) {
             slopes = PyArray_malloc((lenxp - 1) * sizeof(npy_cdouble));
@@ -794,9 +794,9 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                 goto fail;
             }
         }
-            
+
         NPY_BEGIN_THREADS;
-        
+
         if (slopes != NULL) {
             for (i = 0; i < lenxp - 1; ++i) {
                 const double inv_dx = 1.0 / (dx[i+1] - dx[i]);
@@ -804,16 +804,16 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                 slopes[i].imag = (dy[i+1].imag - dy[i].imag) * inv_dx;
             }
         }
-        
+
         for (i = 0; i < lenx; ++i) {
             const npy_double x_val = dz[i];
-            
+
             if (npy_isnan(x_val)) {
                 dres[i].real = x_val;
                 dres[i].imag = 0.0;
                 continue;
             }
-            
+
             j = binary_search_with_guess(x_val, dx, lenxp, j);
             if (j == -1) {
                 dres[i] = lval;
@@ -832,17 +832,17 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                 else {
                     const npy_double inv_dx = 1.0 / (dx[j+1] - dx[j]);
                     dres[i].real = (dy[j+1].real - dy[j].real)*(x_val - dx[j])*
-			inv_dx + dy[j].real;
+                        inv_dx + dy[j].real;
                     dres[i].imag = (dy[j+1].imag - dy[j].imag)*(x_val - dx[j])*
-			inv_dx + dy[j].imag;
+                        inv_dx + dy[j].imag;
                 }
             }
         }
-        
+
         NPY_END_THREADS;
-    } 
+    }
     PyArray_free(slopes);
-    
+
     Py_DECREF(afp);
     Py_DECREF(axp);
     Py_DECREF(ax);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -255,12 +255,7 @@ arr_histogramdd_uniform(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kw
      * Get the number of bins for each array since
      * the edges are passed in as a flat array
      */
-    arr_bins = (PyArrayObject *)PyArray_FROM_O(obj_bins);
-    if (!PyArray_ISINTEGER(arr_bins))
-    {
-        PyErr_SetString(PyExc_TypeError, "Bin counts must be integers");
-        goto fail;
-    }
+    arr_bins = (PyArrayObject *)PyArray_ContiguousFromAny(obj_bins, NPY_INTP, 1, 1);
     if (arr_bins == NULL) {
         goto fail;
     }

--- a/numpy/core/src/multiarray/compiled_base.h
+++ b/numpy/core/src/multiarray/compiled_base.h
@@ -5,6 +5,10 @@
 NPY_NO_EXPORT PyObject *
 arr_insert(PyObject *, PyObject *, PyObject *);
 NPY_NO_EXPORT PyObject *
+arr_histogram_uniform(PyObject *, PyObject *, PyObject *);
+NPY_NO_EXPORT PyObject *
+arr_histogramdd_uniform(PyObject *, PyObject *, PyObject *);
+NPY_NO_EXPORT PyObject *
 arr_bincount(PyObject *, PyObject *, PyObject *);
 NPY_NO_EXPORT PyObject *
 arr_digitize(PyObject *, PyObject *, PyObject *kwds);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4302,6 +4302,10 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS | METH_KEYWORDS,
         "Insert vals sequentially into equivalent 1-d positions "
         "indicated by mask."},
+    {"_histogram_uniform", (PyCFunction)arr_histogram_uniform,
+        METH_VARARGS | METH_KEYWORDS, NULL},
+    {"_histogramdd_uniform", (PyCFunction)arr_histogramdd_uniform,
+        METH_VARARGS | METH_KEYWORDS, NULL},
     {"bincount", (PyCFunction)arr_bincount,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"digitize", (PyCFunction)arr_digitize,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -25,8 +25,9 @@ from numpy.core.numerictypes import typecodes, number
 from numpy.lib.twodim_base import diag
 from .utils import deprecate
 from numpy.core.multiarray import (
-    _insert, add_docstring, digitize, bincount, normalize_axis_index,
-    interp as compiled_interp, interp_complex as compiled_interp_complex
+    _insert, add_docstring, digitize, _histogram_uniform, _histogramdd_uniform,
+    bincount, normalize_axis_index, interp as compiled_interp,
+    interp_complex as compiled_interp_complex
     )
 from numpy.core.umath import _add_newdoc_ufunc as add_newdoc_ufunc
 from numpy.compat import long
@@ -776,40 +777,23 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
             else:
                 tmp_w = weights[i:i + BLOCK]
 
-            # Only include values in the right range
+            # Only include values within range
+            # This will speed up histogramming when the
+            # histogram range is much smaller than the
+            # sample data's range.
             keep = (tmp_a >= first_edge)
             keep &= (tmp_a <= last_edge)
             if not np.logical_and.reduce(keep):
                 tmp_a = tmp_a[keep]
                 if tmp_w is not None:
                     tmp_w = tmp_w[keep]
-            tmp_a_data = tmp_a.astype(float)
-            tmp_a = tmp_a_data - first_edge
-            tmp_a *= norm
 
-            # Compute the bin indices, and for values that lie exactly on
-            # last_edge we need to subtract one
-            indices = tmp_a.astype(np.intp)
-            indices[indices == n_equal_bins] -= 1
-
-            # The index computation is not guaranteed to give exactly
-            # consistent results within ~1 ULP of the bin edges.
-            decrement = tmp_a_data < bin_edges[indices]
-            indices[decrement] -= 1
-            # The last bin includes the right edge. The other bins do not.
-            increment = ((tmp_a_data >= bin_edges[indices + 1])
-                         & (indices != n_equal_bins - 1))
-            indices[increment] += 1
-
-            # We now compute the histogram using bincount
             if ntype.kind == 'c':
-                n.real += np.bincount(indices, weights=tmp_w.real,
-                                      minlength=n_equal_bins)
-                n.imag += np.bincount(indices, weights=tmp_w.imag,
-                                      minlength=n_equal_bins)
+                n.real += _histogram_uniform(tmp_a, bin_edges, tmp_w.real)
+                n.imag += _histogram_uniform(tmp_a, bin_edges, tmp_w.imag)
             else:
-                n += np.bincount(indices, weights=tmp_w,
-                                 minlength=n_equal_bins).astype(ntype)
+                n += _histogram_uniform(tmp_a, bin_edges, tmp_w).astype(ntype)
+
     else:
         # Compute via cumulative histogram
         cum_n = np.zeros(bin_edges.shape, ntype)
@@ -951,6 +935,7 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
     else:
         edge_dt = float
     # Create edge arrays
+    edges_are_uniform = True
     for i in arange(D):
         if isscalar(bins[i]):
             if bins[i] < 1:
@@ -960,6 +945,7 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
             edges[i] = linspace(smin[i], smax[i], nbin[i]-1, dtype=edge_dt)
         else:
+            edges_are_uniform = False
             edges[i] = asarray(bins[i], edge_dt)
             nbin[i] = len(edges[i]) + 1  # +1 for outlier bins
         dedges[i] = diff(edges[i])
@@ -968,63 +954,70 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
                 "Found bin edge of size <= 0. Did you specify `bins` with"
                 "non-monotonic sequence?")
 
-    nbin = asarray(nbin)
+    if edges_are_uniform:
+        # nbins are the number of bins for each dimension
+        # len(edges_concat) == sum(n + 1 for n in nbins)
+        nbins = np.array([len(e) - 1 for e in edges])
+        edges_concat = np.concatenate(edges)
+        hist = _histogramdd_uniform(sample, nbins, edges_concat, weights)
+    else:
+        nbin = asarray(nbin)
 
-    # Handle empty input.
-    if N == 0:
-        return np.zeros(nbin-2), edges
+        # Handle empty input.
+        if N == 0:
+            return np.zeros(nbin-2), edges
 
-    # Compute the bin number each sample falls into.
-    Ncount = {}
-    for i in arange(D):
-        Ncount[i] = digitize(sample[:, i], edges[i])
+        # Compute the bin number each sample falls into.
+        Ncount = {}
+        for i in arange(D):
+            Ncount[i] = digitize(sample[:, i], edges[i])
 
-    # Using digitize, values that fall on an edge are put in the right bin.
-    # For the rightmost bin, we want values equal to the right edge to be
-    # counted in the last bin, and not as an outlier.
-    for i in arange(D):
-        # Rounding precision
-        mindiff = dedges[i].min()
-        if not np.isinf(mindiff):
-            decimal = int(-log10(mindiff)) + 6
-            # Find which points are on the rightmost edge.
-            not_smaller_than_edge = (sample[:, i] >= edges[i][-1])
-            on_edge = (around(sample[:, i], decimal) ==
-                       around(edges[i][-1], decimal))
-            # Shift these points one bin to the left.
-            Ncount[i][nonzero(on_edge & not_smaller_than_edge)[0]] -= 1
+        # Using digitize, values that fall on an edge are put in the right bin.
+        # For the rightmost bin, we want values equal to the right edge to be
+        # counted in the last bin, and not as an outlier.
+        for i in arange(D):
+            # Rounding precision
+            mindiff = dedges[i].min()
+            if not np.isinf(mindiff):
+                decimal = int(-log10(mindiff)) + 6
+                # Find which points are on the rightmost edge.
+                not_smaller_than_edge = (sample[:, i] >= edges[i][-1])
+                on_edge = (around(sample[:, i], decimal) ==
+                           around(edges[i][-1], decimal))
+                # Shift these points one bin to the left.
+                Ncount[i][nonzero(on_edge & not_smaller_than_edge)[0]] -= 1
 
-    # Flattened histogram matrix (1D)
-    # Reshape is used so that overlarge arrays
-    # will raise an error.
-    hist = zeros(nbin, float).reshape(-1)
+        # Flattened histogram matrix (1D)
+        # Reshape is used so that overlarge arrays
+        # will raise an error.
+        hist = zeros(nbin, float).reshape(-1)
 
-    # Compute the sample indices in the flattened histogram matrix.
-    ni = nbin.argsort()
-    xy = zeros(N, int)
-    for i in arange(0, D-1):
-        xy += Ncount[ni[i]] * nbin[ni[i+1:]].prod()
-    xy += Ncount[ni[-1]]
+        # Compute the sample indices in the flattened histogram matrix.
+        ni = nbin.argsort()
+        xy = zeros(N, int)
+        for i in arange(0, D-1):
+            xy += Ncount[ni[i]] * nbin[ni[i+1:]].prod()
+        xy += Ncount[ni[-1]]
 
-    # Compute the number of repetitions in xy and assign it to the
-    # flattened histmat.
-    if len(xy) == 0:
-        return zeros(nbin-2, int), edges
+        # Compute the number of repetitions in xy and assign it to the
+        # flattened histmat.
+        if len(xy) == 0:
+            return zeros(nbin-2, int), edges
 
-    flatcount = bincount(xy, weights)
-    a = arange(len(flatcount))
-    hist[a] = flatcount
+        flatcount = bincount(xy, weights)
+        a = arange(len(flatcount))
+        hist[a] = flatcount
 
-    # Shape into a proper matrix
-    hist = hist.reshape(sort(nbin))
-    for i in arange(nbin.size):
-        j = ni.argsort()[i]
-        hist = hist.swapaxes(i, j)
-        ni[i], ni[j] = ni[j], ni[i]
+        # Shape into a proper matrix
+        hist = hist.reshape(sort(nbin))
+        for i in arange(nbin.size):
+            j = ni.argsort()[i]
+            hist = hist.swapaxes(i, j)
+            ni[i], ni[j] = ni[j], ni[i]
 
-    # Remove outliers (indices 0 and -1 for each dimension).
-    core = D*[slice(1, -1)]
-    hist = hist[core]
+        # Remove outliers (indices 0 and -1 for each dimension).
+        core = D*[slice(1, -1)]
+        hist = hist[core]
 
     # Normalize if normed is True
     if normed:


### PR DESCRIPTION
This is a resubmittal of PR #9627  (my sincere apologies for the gitmess)

# Faster numpy.histogram() and histogramdd()

The **fast-histogram** python package demonstrates that histogramming real data onto a continuous range with evenly-spaced bins, can be made significantly faster. I took this idea of pushing the bin calculation and the filling of the histogram array into a C function and implemented it in **NumPy**.

For details, please my gist concerning this patch:
https://gist.github.com/theodoregoetz/10d2351421689bf2660b4f2fca350e6e