### PR TITLE
WIP: MAINT: Rewrite LongFloatFormat, trim zeros in scientific notation output

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -396,3 +396,18 @@ Seeding ``RandomState`` using an array requires a 1-d array
 ``RandomState`` previously would accept empty arrays or arrays with 2 or more
 dimensions, which resulted in either a failure to seed (empty arrays) or for
 some of the passed values to be ignored when setting the seed.
+
+repr for longfloat rewritten, repr precision for longfoat,half now customizable
+-------------------------------------------------------------------------------
+The reprs for arrays of ``longfloat`` type has been changed to more closely
+match the printing behavior of ``float`` arrays. Also, the precision printed
+for ``longfloat`` and ``half`` arrays is now customizable using the
+``longfloat_precision`` and ``halffloat_precision`` arguments of
+``np.set_printoptions``, with defaults of 8 and 3 respectively.
+
+repr of floating-point arrays now trims 0s in scientific notation
+-----------------------------------------------------------------
+When an array's floating-point values are output in scientific notation
+the trailing zeros in the fractional part are now dropped. In other words,
+``1.1230000e+100`` now prints as ``1.123e+100``. This new behavior
+is disable by setting the ``legacy=True`` option to ``np.set_printoptions``.

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -72,42 +72,42 @@ class TestComplexArray(object):
         dtypes = [np.complex64, np.cdouble, np.clongdouble]
         actual = [str(np.array([c], dt)) for c in cvals for dt in dtypes]
         wanted = [
-            '[0.+0.j]',    '[0.+0.j]',    '[ 0.0+0.0j]',
-            '[0.+1.j]',    '[0.+1.j]',    '[ 0.0+1.0j]',
-            '[0.-1.j]',    '[0.-1.j]',    '[ 0.0-1.0j]',
-            '[0.+infj]',   '[0.+infj]',   '[ 0.0+infj]',
-            '[0.-infj]',   '[0.-infj]',   '[ 0.0-infj]',
-            '[0.+nanj]',   '[0.+nanj]',   '[ 0.0+nanj]',
-            '[1.+0.j]',    '[1.+0.j]',    '[ 1.0+0.0j]',
-            '[1.+1.j]',    '[1.+1.j]',    '[ 1.0+1.0j]',
-            '[1.-1.j]',    '[1.-1.j]',    '[ 1.0-1.0j]',
-            '[1.+infj]',   '[1.+infj]',   '[ 1.0+infj]',
-            '[1.-infj]',   '[1.-infj]',   '[ 1.0-infj]',
-            '[1.+nanj]',   '[1.+nanj]',   '[ 1.0+nanj]',
-            '[-1.+0.j]',    '[-1.+0.j]',    '[-1.0+0.0j]',
-            '[-1.+1.j]',    '[-1.+1.j]',    '[-1.0+1.0j]',
-            '[-1.-1.j]',    '[-1.-1.j]',    '[-1.0-1.0j]',
-            '[-1.+infj]',   '[-1.+infj]',   '[-1.0+infj]',
-            '[-1.-infj]',   '[-1.-infj]',   '[-1.0-infj]',
-            '[-1.+nanj]',   '[-1.+nanj]',   '[-1.0+nanj]',
-            '[inf+0.j]',   '[inf+0.j]',   '[ inf+0.0j]',
-            '[inf+1.j]',   '[inf+1.j]',   '[ inf+1.0j]',
-            '[inf-1.j]',   '[inf-1.j]',   '[ inf-1.0j]',
-            '[inf+infj]',  '[inf+infj]',  '[ inf+infj]',
-            '[inf-infj]',  '[inf-infj]',  '[ inf-infj]',
-            '[inf+nanj]',  '[inf+nanj]',  '[ inf+nanj]',
-            '[-inf+0.j]',   '[-inf+0.j]',   '[-inf+0.0j]',
-            '[-inf+1.j]',   '[-inf+1.j]',   '[-inf+1.0j]',
-            '[-inf-1.j]',   '[-inf-1.j]',   '[-inf-1.0j]',
-            '[-inf+infj]',  '[-inf+infj]',  '[-inf+infj]',
-            '[-inf-infj]',  '[-inf-infj]',  '[-inf-infj]',
-            '[-inf+nanj]',  '[-inf+nanj]',  '[-inf+nanj]',
-            '[nan+0.j]',   '[nan+0.j]',   '[ nan+0.0j]',
-            '[nan+1.j]',   '[nan+1.j]',   '[ nan+1.0j]',
-            '[nan-1.j]',   '[nan-1.j]',   '[ nan-1.0j]',
-            '[nan+infj]',  '[nan+infj]',  '[ nan+infj]',
-            '[nan-infj]',  '[nan-infj]',  '[ nan-infj]',
-            '[nan+nanj]',  '[nan+nanj]',  '[ nan+nanj]']
+            '[0.+0.j]',    '[0.+0.j]',    '[0.+0.j]',
+            '[0.+1.j]',    '[0.+1.j]',    '[0.+1.j]',
+            '[0.-1.j]',    '[0.-1.j]',    '[0.-1.j]',
+            '[0.+infj]',   '[0.+infj]',   '[0.+infj]',
+            '[0.-infj]',   '[0.-infj]',   '[0.-infj]',
+            '[0.+nanj]',   '[0.+nanj]',   '[0.+nanj]',
+            '[1.+0.j]',    '[1.+0.j]',    '[1.+0.j]',
+            '[1.+1.j]',    '[1.+1.j]',    '[1.+1.j]',
+            '[1.-1.j]',    '[1.-1.j]',    '[1.-1.j]',
+            '[1.+infj]',   '[1.+infj]',   '[1.+infj]',
+            '[1.-infj]',   '[1.-infj]',   '[1.-infj]',
+            '[1.+nanj]',   '[1.+nanj]',   '[1.+nanj]',
+            '[-1.+0.j]',   '[-1.+0.j]',   '[-1.+0.j]',
+            '[-1.+1.j]',   '[-1.+1.j]',   '[-1.+1.j]',
+            '[-1.-1.j]',   '[-1.-1.j]',   '[-1.-1.j]',
+            '[-1.+infj]',  '[-1.+infj]',  '[-1.+infj]',
+            '[-1.-infj]',  '[-1.-infj]',  '[-1.-infj]',
+            '[-1.+nanj]',  '[-1.+nanj]',  '[-1.+nanj]',
+            '[inf+0.j]',   '[inf+0.j]',   '[inf+0.j]',
+            '[inf+1.j]',   '[inf+1.j]',   '[inf+1.j]',
+            '[inf-1.j]',   '[inf-1.j]',   '[inf-1.j]',
+            '[inf+infj]',  '[inf+infj]',  '[inf+infj]',
+            '[inf-infj]',  '[inf-infj]',  '[inf-infj]',
+            '[inf+nanj]',  '[inf+nanj]',  '[inf+nanj]',
+            '[-inf+0.j]',  '[-inf+0.j]',  '[-inf+0.j]',
+            '[-inf+1.j]',  '[-inf+1.j]',  '[-inf+1.j]',
+            '[-inf-1.j]',  '[-inf-1.j]',  '[-inf-1.j]',
+            '[-inf+infj]', '[-inf+infj]', '[-inf+infj]',
+            '[-inf-infj]', '[-inf-infj]', '[-inf-infj]',
+            '[-inf+nanj]', '[-inf+nanj]', '[-inf+nanj]',
+            '[nan+0.j]',   '[nan+0.j]',   '[nan+0.j]',
+            '[nan+1.j]',   '[nan+1.j]',   '[nan+1.j]',
+            '[nan-1.j]',   '[nan-1.j]',   '[nan-1.j]',
+            '[nan+infj]',  '[nan+infj]',  '[nan+infj]',
+            '[nan-infj]',  '[nan-infj]',  '[nan-infj]',
+            '[nan+nanj]',  '[nan+nanj]',  '[nan+nanj]']
 
         for res, val in zip(actual, wanted):
             assert_equal(res, val)
@@ -290,17 +290,17 @@ class TestPrintOptions(object):
 
         assert_equal(repr(a), 'array([0., 1., 2., 3.])')
         assert_equal(repr(np.array(1.)), 'array(1.)')
-        assert_equal(repr(b), 'array([1.23400000e+09])')
+        assert_equal(repr(b), 'array([1.234e+09])')
 
         np.set_printoptions(sign=' ')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
         assert_equal(repr(np.array(1.)), 'array( 1.)')
-        assert_equal(repr(b), 'array([ 1.23400000e+09])')
+        assert_equal(repr(b), 'array([ 1.234e+09])')
 
         np.set_printoptions(sign='+')
         assert_equal(repr(a), 'array([+0., +1., +2., +3.])')
         assert_equal(repr(np.array(1.)), 'array(+1.)')
-        assert_equal(repr(b), 'array([+1.23400000e+09])')
+        assert_equal(repr(b), 'array([+1.234e+09])')
 
         np.set_printoptions(sign='legacy')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')


### PR DESCRIPTION
The main purpose of this PR is to implement the new `longfloat` arrayprint formatter, as promised in #9139. 

Now, `longfloat` arrays will print essentially identically to `float` and `double` arrays, using the same code paths. This means `longfloat` arrays now align nicely and have the right number of spaces.

This PR does two additional things which are somewhat unrelated, but are in the same code: I removed trailing zeros in scientific notation, so `1.0000e+100` becomes `1.e+100`, and I made the `longfloat` and `half` formatter precision customizable independently from the float/double precision.

I think this is mostly done, I just need to add a few more tests, eg to test the "locale"-related code, and to test the new precision customization. 

Sidenote: I implemented `format_longfloat` using a "trick" involving temporarily setting the "C" locale (if necessary) which avoids all the complicated manipulation of decimals used in `NumpyOS_ascii_format_double` (which was copied from the CPython code). Resetting the locale was recommended on the gcc page on locales.