### PR TITLE
ENH: Have f2py handle hybrid F77/F90 codebases

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -249,6 +249,12 @@ f2py now handles arrays of dimension 0
 f2py now allows for the allocation of arrays of dimension 0. This allows for
 more consistent handling of corner cases downstream.
 
+f2py now handles hybrid Fortran 77/90 codebases
+-----------------------------------------------
+f2py can now with the new switch `--std=f90' handle codebases with mixed
+Fortran 77/90 content (for instance having both common blocks and modules),
+but where all files have extension .f or .for.
+
 ``numpy.distutils`` supports using MSVC and mingw64-gfortran together
 ---------------------------------------------------------------------
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -419,6 +419,13 @@ def msvc_runtime_major():
 
 #########################
 
+# flag that determines whether the file extension should be used to determine
+# if the source file is according to Fortran 90 or not. if this flag is set
+# to False, then all source files will be scanned for modules.
+# if you are writing the extension module yourself, please consider using an
+# appropriate file name for your code instead of using this flag.
+_f90_use_ext = True
+
 #XXX need support for .C that is also C++
 cxx_ext_match = re.compile(r'.*[.](cpp|cxx|cc)\Z', re.I).match
 fortran_ext_match = re.compile(r'.*[.](f90|f95|f77|for|ftn|f)\Z', re.I).match
@@ -428,7 +435,7 @@ def _get_f90_modules(source):
     """Return a list of Fortran f90 module names that
     given source file defines.
     """
-    if not f90_ext_match(source):
+    if _f90_use_ext and not f90_ext_match(source):
         return []
     modules = []
     f = open(source, 'r')

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -419,11 +419,34 @@ def msvc_runtime_major():
 
 #########################
 
+class IgnoreF90ModExt(object):
+    """\
+    Conditionally suspend the usage of file extension to determine whether
+    a Fortran source file is according to Fortran 90 standard or not and
+    thus may contain a module (which must be compiled before other sources).
+    """
+    def __init__(self, override = True):
+        self.override = override
+        self.old_value = False
+
+    def __enter__(self):
+        global _f90_use_ext
+        if self.override:
+            self.old_value = _f90_use_ext
+            _f90_use_ext = False
+
+    def __exit__(self, exc_typ, exc_val, exc_trb):
+        global _f90_use_ext
+        if self.override:
+            _f90_use_ext = self.old_value
+
 # flag that determines whether the file extension should be used to determine
 # if the source file is according to Fortran 90 or not. if this flag is set
 # to False, then all source files will be scanned for modules.
 # if you are writing the extension module yourself, please consider using an
 # appropriate file name for your code instead of using this flag.
+# if you have no choice, then use the IgnoreF90ModExt context manager defined
+# above so it at least can be traced to where it was altered.
 _f90_use_ext = True
 
 #XXX need support for .C that is also C++

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -170,6 +170,7 @@ skipemptyends = 0      # for old F77 programs without 'program' statement
 ignorecontains = 1
 dolowercase = 1
 debug = []
+std = ''               # enforced (instead of inferred) language standard
 
 # Global variables
 beginpattern = ''
@@ -371,8 +372,10 @@ def readfortrancode(ffile, dowithline=show, istop=1):
             strictf77 = 0
             sourcecodeform = 'fix'
             ext = os.path.splitext(currentfilename)[1]
-            if is_f_file(currentfilename) and \
-                    not (_has_f90_header(l) or _has_fix_header(l)):
+            # infer standard from filename if not explicitly set
+            f77name = ((std == 'f77') or
+                       ((std == '') and is_f_file(currentfilename)))
+            if f77name and not (_has_f90_header(l) or _has_fix_header(l)):
                 strictf77 = 1
             elif is_free_format(currentfilename) and not _has_fix_header(l):
                 sourcecodeform = 'free'

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -651,7 +651,12 @@ def run_compile():
     if flib_flags:
         sys.argv.extend(['build_ext'] + flib_flags)
 
-    setup(ext_modules=[ext])
+    # temporary disable using file extension to determine module extension and
+    # rather do a full scan, if we have set language level for all files
+    std_f90_reg = re.compile(r'[-][-]?std=[fF]90')
+    from numpy.distutils.misc_util import IgnoreF90ModExt
+    with IgnoreF90ModExt(any([std_f90_reg.match(opt) for opt in f2py_flags])):
+        setup(ext_modules=[ext])
 
     if remove_build_dir and os.path.exists(build_dir):
         import shutil

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -517,7 +517,7 @@ def run_compile():
         sysinfo_flags = [f[7:] for f in sysinfo_flags]
 
     _reg2 = re.compile(
-        r'[-][-]((no[-]|)(wrap[-]functions|lower)|debug[-]capi|quiet)|[-]include')
+        r'[-][-]((no[-]|)(wrap[-]functions|lower)|debug[-]capi|quiet)|[-]include|[-][-]?std=.*')
     f2py_flags = [_m for _m in sys.argv[1:] if _reg2.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in f2py_flags]
     f2py_flags2 = []


### PR DESCRIPTION
Some of the older codebases consists of a mix of files written in Fortran 77 and Fortran 90. Probably these started out as Fortran 77 long time ago and then Fortran 90 features were introduced when that became available. However, they are not necessarily careful in using the corresponding file extension for the source files, preferring to keep the existing extension for all files.

This lead into a problem when running them through f2py, as the parser chokes on newer constructs if it has been set in legacy mode. And this mode is determined by the file extension before parsing takes place.

This changeset introduce a new option, `--std=f90`, which force the parser into Fortran 90 mode, even if the file extension is `.f` or `.for`. The name of the option is based on a corresponding option that can be used for the compiler. I though about scanning the compiler options for such a flag, but in most cases, this triggers a  strict standard compliance, which these older codebases are not ready for, hence an f2py option.

The alternative to such a switch would be to scan through all files, looking for Fortran 90 constructs. I am open to such a solution if that would be deemed preferrable over a new command-line option, but it then incurs a cost of scanning through every file passed to f2py.