### PR TITLE
 MAINT: Add parameter checks to polynomial integration functions.

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1013,7 +1013,7 @@ def chebint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     ------
     ValueError
         If ``m < 1``, ``len(k) > m``, ``np.ndim(lbnd) != 0``, or
-         ``np.ndim(scl) != 0``.
+        ``np.ndim(scl) != 0``.
 
     See Also
     --------
@@ -1062,6 +1062,10 @@ def chebint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
         raise ValueError("The order of integration must be non-negative")
     if len(k) > cnt:
         raise ValueError("Too many integration constants")
+    if np.ndim(lbnd) != 0:
+        raise ValueError("lbnd must be a scalar.")
+    if np.ndim(scl) != 0:
+        raise ValueError("scl must be a scalar.")
     if iaxis != axis:
         raise ValueError("The axis must be integer")
     iaxis = normalize_axis_index(iaxis, c.ndim)

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -771,7 +771,7 @@ def hermint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     ------
     ValueError
         If ``m < 0``, ``len(k) > m``, ``np.ndim(lbnd) != 0``, or
-         ``np.ndim(scl) != 0``.
+        ``np.ndim(scl) != 0``.
 
     See Also
     --------
@@ -818,6 +818,10 @@ def hermint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
         raise ValueError("The order of integration must be non-negative")
     if len(k) > cnt:
         raise ValueError("Too many integration constants")
+    if np.ndim(lbnd) != 0:
+        raise ValueError("lbnd must be a scalar.")
+    if np.ndim(scl) != 0:
+        raise ValueError("scl must be a scalar.")
     if iaxis != axis:
         raise ValueError("The axis must be integer")
     iaxis = normalize_axis_index(iaxis, c.ndim)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -770,7 +770,7 @@ def hermeint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     ------
     ValueError
         If ``m < 0``, ``len(k) > m``, ``np.ndim(lbnd) != 0``, or
-         ``np.ndim(scl) != 0``.
+        ``np.ndim(scl) != 0``.
 
     See Also
     --------
@@ -817,6 +817,10 @@ def hermeint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
         raise ValueError("The order of integration must be non-negative")
     if len(k) > cnt:
         raise ValueError("Too many integration constants")
+    if np.ndim(lbnd) != 0:
+        raise ValueError("lbnd must be a scalar.")
+    if np.ndim(scl) != 0:
+        raise ValueError("scl must be a scalar.")
     if iaxis != axis:
         raise ValueError("The axis must be integer")
     iaxis = normalize_axis_index(iaxis, c.ndim)

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -771,7 +771,7 @@ def lagint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     ------
     ValueError
         If ``m < 0``, ``len(k) > m``, ``np.ndim(lbnd) != 0``, or
-         ``np.ndim(scl) != 0``.
+        ``np.ndim(scl) != 0``.
 
     See Also
     --------
@@ -818,6 +818,10 @@ def lagint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
         raise ValueError("The order of integration must be non-negative")
     if len(k) > cnt:
         raise ValueError("Too many integration constants")
+    if np.ndim(lbnd) != 0:
+        raise ValueError("lbnd must be a scalar.")
+    if np.ndim(scl) != 0:
+        raise ValueError("scl must be a scalar.")
     if iaxis != axis:
         raise ValueError("The axis must be integer")
     iaxis = normalize_axis_index(iaxis, c.ndim)

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -811,7 +811,7 @@ def legint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     ------
     ValueError
         If ``m < 0``, ``len(k) > m``, ``np.ndim(lbnd) != 0``, or
-         ``np.ndim(scl) != 0``.
+        ``np.ndim(scl) != 0``.
 
     See Also
     --------
@@ -860,6 +860,10 @@ def legint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
         raise ValueError("The order of integration must be non-negative")
     if len(k) > cnt:
         raise ValueError("Too many integration constants")
+    if np.ndim(lbnd) != 0:
+        raise ValueError("lbnd must be a scalar.")
+    if np.ndim(scl) != 0:
+        raise ValueError("scl must be a scalar.")
     if iaxis != axis:
         raise ValueError("The axis must be integer")
     iaxis = normalize_axis_index(iaxis, c.ndim)

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -608,7 +608,8 @@ def polyint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     Raises
     ------
     ValueError
-        If ``m < 1``, ``len(k) > m``.
+        If ``m < 1``, ``len(k) > m``, ``np.ndim(lbnd) != 0``, or
+        ``np.ndim(scl) != 0``.
 
     See Also
     --------
@@ -654,6 +655,10 @@ def polyint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
         raise ValueError("The order of integration must be non-negative")
     if len(k) > cnt:
         raise ValueError("Too many integration constants")
+    if np.ndim(lbnd) != 0:
+        raise ValueError("lbnd must be a scalar.")
+    if np.ndim(scl) != 0:
+        raise ValueError("scl must be a scalar.")
     if iaxis != axis:
         raise ValueError("The axis must be integer")
     iaxis = normalize_axis_index(iaxis, c.ndim)

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -214,6 +214,9 @@ class TestIntegral(object):
         assert_raises(ValueError, cheb.chebint, [0], .5)
         assert_raises(ValueError, cheb.chebint, [0], -1)
         assert_raises(ValueError, cheb.chebint, [0], 1, [0, 0])
+        assert_raises(ValueError, cheb.chebint, [0], lbnd=[0])
+        assert_raises(ValueError, cheb.chebint, [0], scl=[0])
+        assert_raises(ValueError, cheb.chebint, [0], axis=.5)
 
         # test integration of zero polynomial
         for i in range(2, 5):

--- a/numpy/polynomial/tests/test_hermite.py
+++ b/numpy/polynomial/tests/test_hermite.py
@@ -202,6 +202,9 @@ class TestIntegral(object):
         assert_raises(ValueError, herm.hermint, [0], .5)
         assert_raises(ValueError, herm.hermint, [0], -1)
         assert_raises(ValueError, herm.hermint, [0], 1, [0, 0])
+        assert_raises(ValueError, herm.hermint, [0], lbnd=[0])
+        assert_raises(ValueError, herm.hermint, [0], scl=[0])
+        assert_raises(ValueError, herm.hermint, [0], axis=.5)
 
         # test integration of zero polynomial
         for i in range(2, 5):

--- a/numpy/polynomial/tests/test_hermite_e.py
+++ b/numpy/polynomial/tests/test_hermite_e.py
@@ -202,6 +202,9 @@ class TestIntegral(object):
         assert_raises(ValueError, herme.hermeint, [0], .5)
         assert_raises(ValueError, herme.hermeint, [0], -1)
         assert_raises(ValueError, herme.hermeint, [0], 1, [0, 0])
+        assert_raises(ValueError, herme.hermeint, [0], lbnd=[0])
+        assert_raises(ValueError, herme.hermeint, [0], scl=[0])
+        assert_raises(ValueError, herme.hermeint, [0], axis=.5)
 
         # test integration of zero polynomial
         for i in range(2, 5):

--- a/numpy/polynomial/tests/test_laguerre.py
+++ b/numpy/polynomial/tests/test_laguerre.py
@@ -199,6 +199,9 @@ class TestIntegral(object):
         assert_raises(ValueError, lag.lagint, [0], .5)
         assert_raises(ValueError, lag.lagint, [0], -1)
         assert_raises(ValueError, lag.lagint, [0], 1, [0, 0])
+        assert_raises(ValueError, lag.lagint, [0], lbnd=[0])
+        assert_raises(ValueError, lag.lagint, [0], scl=[0])
+        assert_raises(ValueError, lag.lagint, [0], axis=.5)
 
         # test integration of zero polynomial
         for i in range(2, 5):

--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -203,6 +203,9 @@ class TestIntegral(object):
         assert_raises(ValueError, leg.legint, [0], .5)
         assert_raises(ValueError, leg.legint, [0], -1)
         assert_raises(ValueError, leg.legint, [0], 1, [0, 0])
+        assert_raises(ValueError, leg.legint, [0], lbnd=[0])
+        assert_raises(ValueError, leg.legint, [0], scl=[0])
+        assert_raises(ValueError, leg.legint, [0], axis=.5)
 
         # test integration of zero polynomial
         for i in range(2, 5):

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -271,6 +271,9 @@ class TestIntegral(object):
         assert_raises(ValueError, poly.polyint, [0], .5)
         assert_raises(ValueError, poly.polyint, [0], -1)
         assert_raises(ValueError, poly.polyint, [0], 1, [0, 0])
+        assert_raises(ValueError, poly.polyint, [0], lbnd=[0])
+        assert_raises(ValueError, poly.polyint, [0], scl=[0])
+        assert_raises(ValueError, poly.polyint, [0], axis=.5)
 
         # test integration of zero polynomial
         for i in range(2, 5):


### PR DESCRIPTION
    It was not being checked that the `lbnd` and `scl` parameters were
    scalars as required.
    
    Closes #9901.
