### PR TITLE
MAINT/BUG: Don't squash useful error messages in favor of generic ones

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -356,18 +356,18 @@ string_to_long_double(PyObject*op)
     if (s) {
         errno = 0;
         temp = NumPyOS_ascii_strtold(s, &end);
-        if (end==s || *end) {
-            PyErr_Format(PyExc_ValueError,
-                         "invalid literal for long double: %s",
-                         s);
-            Py_XDECREF(b);
-            return 0;
-        }
-        else if (errno) {
+        if (errno) {
             PyErr_Format(PyExc_ValueError,
                          "invalid literal for long double: %s (%s)",
                          s,
                          strerror(errno));
+            Py_XDECREF(b);
+            return 0;
+        }
+        else if (end == s || *end) {
+            PyErr_Format(PyExc_ValueError,
+                         "invalid literal for long double: %s",
+                         s);
             Py_XDECREF(b);
             return 0;
         }

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -570,9 +570,6 @@ NumPyOS_ascii_strtold(const char *s, char** endptr)
         errno = 0;
         result = strtold_l(s, endptr, clocale);
         freelocale(clocale);
-        if (errno) {
-            *endptr = (char*)s;
-        }
     }
     else {
         *endptr = (char*)s;

--- a/numpy/core/src/multiarray/numpyos.c
+++ b/numpy/core/src/multiarray/numpyos.c
@@ -572,7 +572,9 @@ NumPyOS_ascii_strtold(const char *s, char** endptr)
         freelocale(clocale);
     }
     else {
-        *endptr = (char*)s;
+        if (endptr != NULL) {
+            *endptr = (char*)s;
+        }
         result = 0;
     }
     return result;


### PR DESCRIPTION
Also avoid possible segfaults. Raised by discussion in #9924, but does not fix that.