### PR TITLE
MAINT/TST: Tidy dtype indexing

### DIFF
--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -298,6 +298,14 @@ class TestRecord(object):
         dt = make_dtype(np.uint32(0))
         np.zeros(1, dtype=dt)[0].item()
 
+    def test_fields_by_index(self):
+        dt = np.dtype([('a', np.int8), ('b', np.float32, 3)])
+        assert_dtype_equal(dt[0], np.dtype(np.int8))
+        assert_dtype_equal(dt[1], np.dtype((np.float32, 3)))
+        assert_dtype_equal(dt[-1], dt[1])
+        assert_dtype_equal(dt[-2], dt[0])
+        assert_raises(IndexError, lambda: dt[-3])
+
 
 class TestSubarray(object):
     def test_single_subarray(self):


### PR DESCRIPTION
Previously `descr_subscript` would recurse, which was needlessly confusing.

Extracted from #8814, which fell into the trap of combining ENH with MAINT.