### PR TITLE
MAINT: Add a PyDataType_ISUNSIZED macro

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -947,6 +947,12 @@ argument must be a :c:type:`PyObject *<PyObject>` that can be directly interpret
     Type represents one of the flexible array types ( :c:data:`NPY_STRING`,
     :c:data:`NPY_UNICODE`, or :c:data:`NPY_VOID` ).
 
+.. c:function:: PyDataType_ISUNSIZED(descr):
+
+    Type has no size information attached, and can be resized. Should only be
+    called on flexible dtypes. Types that are attached to an array will always
+    be sized, hence the array form of this macro not existing.
+
 .. c:function:: PyTypeNum_ISUSERDEF(num)
 
 .. c:function:: PyDataType_ISUSERDEF(descr)

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1676,6 +1676,8 @@ PyArray_CLEARFLAGS(PyArrayObject *arr, int flags)
 #define PyDataType_ISOBJECT(obj) PyTypeNum_ISOBJECT(((PyArray_Descr*)(obj))->type_num)
 #define PyDataType_HASFIELDS(obj) (((PyArray_Descr *)(obj))->names != NULL)
 #define PyDataType_HASSUBARRAY(dtype) ((dtype)->subarray != NULL)
+#define PyDataType_ISUNSIZED(dtype) ((dtype)->elsize == 0)
+#define PyDataType_MAKEUNSIZED(dtype) ((dtype)->elsize = 0)
 
 #define PyArray_ISBOOL(obj) PyTypeNum_ISBOOL(PyArray_TYPE(obj))
 #define PyArray_ISUNSIGNED(obj) PyTypeNum_ISUNSIGNED(PyArray_TYPE(obj))

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4746,6 +4746,15 @@ set_typeinfo(PyObject *dict)
 
     /**end repeat**/
 
+
+    /**begin repeat
+      * #name = STRING, UNICODE, VOID#
+      */
+
+    PyDataType_MAKEUNSIZED(&@name@_Descr);
+
+    /**end repeat**/
+
     /* Set a dictionary with type information */
     infodict = PyDict_New();
     if (infodict == NULL) return -1;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -167,7 +167,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
     flex_type_num = (*flex_dtype)->type_num;
 
     /* Flexible types with expandable size */
-    if ((*flex_dtype)->elsize == 0) {
+    if (PyDataType_ISUNSIZED(*flex_dtype)) {
         /* First replace the flex dtype */
         PyArray_DESCR_REPLACE(*flex_dtype);
         if (*flex_dtype == NULL) {
@@ -526,7 +526,7 @@ PyArray_CanCastTo(PyArray_Descr *from, PyArray_Descr *to)
             }
 
             ret = 0;
-            if (to->elsize == 0) {
+            if (PyDataType_ISUNSIZED(to)) {
                 ret = 1;
             }
             /* 
@@ -1152,7 +1152,7 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
             else if (PyTypeNum_ISNUMBER(type_num2)) {
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type1);
-                temp->elsize = 0;
+                PyDataType_MAKEUNSIZED(temp);
                 PyArray_AdaptFlexibleDType(NULL, type2, &temp);
                 if (temp->elsize > type1->elsize) {
                     ret = ensure_dtype_nbo(temp);
@@ -1190,7 +1190,7 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
             else if (PyTypeNum_ISNUMBER(type_num2)) {
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type1);
-                temp->elsize = 0;
+                PyDataType_MAKEUNSIZED(temp);
                 PyArray_AdaptFlexibleDType(NULL, type2, &temp);
                 if (temp->elsize > type1->elsize) {
                     ret = ensure_dtype_nbo(temp);
@@ -1238,7 +1238,7 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
             if (PyTypeNum_ISNUMBER(type_num1)) {
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type2);
-                temp->elsize = 0;
+                PyDataType_MAKEUNSIZED(temp);
                 PyArray_AdaptFlexibleDType(NULL, type1, &temp);
                 if (temp->elsize > type2->elsize) {
                     ret = ensure_dtype_nbo(temp);
@@ -1255,7 +1255,7 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
             if (PyTypeNum_ISNUMBER(type_num1)) {
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type2);
-                temp->elsize = 0;
+                PyDataType_MAKEUNSIZED(temp);
                 PyArray_AdaptFlexibleDType(NULL, type1, &temp);
                 if (temp->elsize > type2->elsize) {
                     ret = ensure_dtype_nbo(temp);

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -470,19 +470,18 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
     }
 
     /*
-     * Treat V0 as resizable void - unless the destination is already V0, then
-     * don't allow np.void to be duplicated
+     * Viewing as an unsized void implies a void dtype matching the size of the
+     * current dtype.
      */
     if (newtype->type_num == NPY_VOID &&
-            newtype->elsize == 0 &&
-            PyArray_DESCR(self)->elsize != 0) {
+            PyDataType_ISUNSIZED(newtype) &&
+            newtype->elsize != PyArray_DESCR(self)->elsize) {
         PyArray_DESCR_REPLACE(newtype);
         if (newtype == NULL) {
             return -1;
         }
         newtype->elsize = PyArray_DESCR(self)->elsize;
     }
-
 
     /* Changing the size of the dtype results in a shape change */
     if (newtype->elsize != PyArray_DESCR(self)->elsize) {

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -567,7 +567,7 @@ PyArray_DescrFromScalar(PyObject *sc)
     }
 
     descr = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(sc));
-    if (descr->elsize == 0) {
+    if (PyDataType_ISUNSIZED(descr)) {
         PyArray_DESCR_REPLACE(descr);
         type_num = descr->type_num;
         if (type_num == NPY_STRING) {

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -146,7 +146,7 @@ PyArray_RegisterDataType(PyArray_Descr *descr)
     }
     typenum = NPY_USERDEF + NPY_NUMUSERTYPES;
     descr->type_num = typenum;
-    if (descr->elsize == 0) {
+    if (PyDataType_ISUNSIZED(descr)) {
         PyErr_SetString(PyExc_ValueError, "cannot register a" \
                         "flexible data-type");
         return -1;


### PR DESCRIPTION
This allows us to change how flexible types with no length are represented in future, to allow zero-size dtypes (#8970).

Perhaps it would be better to just define `PyDataType_UNSIZED` as zero, rather than having `PyDataType_MAKEUNSIZED` existing - it implies a level of abstraction that doesn't work, namely that setting `dtype->elsize` clears the "unsized" flag.