### PR TITLE
BUG: Allow float64('1e10000') to overflow

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -356,7 +356,15 @@ string_to_long_double(PyObject*op)
     if (s) {
         errno = 0;
         temp = NumPyOS_ascii_strtold(s, &end);
-        if (errno) {
+        if (errno == ERANGE) {
+           if (PyErr_Warn(PyExc_RuntimeWarning,
+                   "overflow encountered in conversion from string") < 0) {
+               Py_XDECREF(b);
+               return 0;
+           }
+           /* strtold returns INFINITY of the correct sign. */
+        }
+        else if (errno) {
             PyErr_Format(PyExc_ValueError,
                          "invalid literal for long double: %s (%s)",
                          s,
@@ -364,7 +372,9 @@ string_to_long_double(PyObject*op)
             Py_XDECREF(b);
             return 0;
         }
-        else if (end == s || *end) {
+
+        /* Extra characters at the end of the string, or nothing parsed */
+        if (end == s || *end) {
             PyErr_Format(PyExc_ValueError,
                          "invalid literal for long double: %s",
                          s);

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -159,20 +159,6 @@ class TestRegression(object):
         assert_raises(TypeError, np.dtype,
                               {'names':['a'], 'formats':['foo']}, align=1)
 
-    @dec.knownfailureif((sys.version_info[0] >= 3) or
-                        (sys.platform == "win32" and
-                         platform.architecture()[0] == "64bit"),
-                        "numpy.intp('0xff', 16) not supported on Py3, "
-                        "as it does not inherit from Python int")
-    def test_intp(self):
-        # Ticket #99
-        i_width = np.int_(0).nbytes*2 - 1
-        np.intp('0x' + 'f'*i_width, 16)
-        assert_raises(OverflowError, np.intp, '0x' + 'f'*(i_width+1), 16)
-        assert_raises(ValueError, np.intp, '0x1', 32)
-        assert_equal(255, np.intp('0xFF', 16))
-        assert_equal(1024, np.intp(1024))
-
     def test_endian_bool_indexing(self):
         # Ticket #105
         a = np.arange(10., dtype='>f8')
@@ -853,9 +839,6 @@ class TestRegression(object):
         assert_array_equal(x.astype('>i4'), x.astype('<i4').flat[:])
         assert_array_equal(x.astype('>i4').flat[:], x.astype('<i4'))
 
-    def test_uint64_from_negative(self):
-        assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
-
     def test_sign_bit(self):
         x = np.array([0, -0.0, 0])
         assert_equal(str(np.abs(x)), '[0. 0. 0.]')
@@ -1023,15 +1006,6 @@ class TestRegression(object):
     def test_mem_0d_array_index(self):
         # Ticket #714
         np.zeros(10)[np.array(0)]
-
-    def test_floats_from_string(self):
-        # Ticket #640, floats from string
-        fsingle = np.single('1.234')
-        fdouble = np.double('1.234')
-        flongdouble = np.longdouble('1.234')
-        assert_almost_equal(fsingle, 1.234)
-        assert_almost_equal(fdouble, 1.234)
-        assert_almost_equal(flongdouble, 1.234)
 
     def test_nonnative_endian_fill(self):
         # Non-native endian arrays were incorrectly filled with scalars

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from numpy.testing import (
     run_module_suite,
-    assert_equal, assert_almost_equal, assert_raises,
+    assert_equal, assert_almost_equal, assert_raises, assert_warns,
     dec
 )
 
@@ -22,6 +22,26 @@ class TestFromString(object):
         assert_almost_equal(fsingle, 1.234)
         assert_almost_equal(fdouble, 1.234)
         assert_almost_equal(flongdouble, 1.234)
+
+    def test_floating_overflow(self):
+        """ Strings containing an unrepresentable float overflow """
+        fhalf = np.half('1e10000')
+        assert_equal(fhalf, np.inf)
+        fsingle = np.single('1e10000')
+        assert_equal(fsingle, np.inf)
+        fdouble = np.double('1e10000')
+        assert_equal(fdouble, np.inf)
+        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '1e10000')
+        assert_equal(flongdouble, np.inf)
+
+        fhalf = np.half('-1e10000')
+        assert_equal(fhalf, -np.inf)
+        fsingle = np.single('-1e10000')
+        assert_equal(fsingle, -np.inf)
+        fdouble = np.double('-1e10000')
+        assert_equal(fdouble, -np.inf)
+        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '-1e10000')
+        assert_equal(flongdouble, -np.inf)
 
     @dec.knownfailureif((sys.version_info[0] >= 3) or
                         (sys.platform == "win32" and

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -1,0 +1,50 @@
+"""
+Test the scalar contructors, which also do type-coercion
+"""
+from __future__ import division, absolute_import, print_function
+
+import sys
+import platform
+import numpy as np
+
+from numpy.testing import (
+    run_module_suite,
+    assert_equal, assert_almost_equal, assert_raises,
+    dec
+)
+
+class TestFromString(object):
+    def test_floating(self):
+        # Ticket #640, floats from string
+        fsingle = np.single('1.234')
+        fdouble = np.double('1.234')
+        flongdouble = np.longdouble('1.234')
+        assert_almost_equal(fsingle, 1.234)
+        assert_almost_equal(fdouble, 1.234)
+        assert_almost_equal(flongdouble, 1.234)
+
+    @dec.knownfailureif((sys.version_info[0] >= 3) or
+                        (sys.platform == "win32" and
+                         platform.architecture()[0] == "64bit"),
+                        "numpy.intp('0xff', 16) not supported on Py3, "
+                        "as it does not inherit from Python int")
+    def test_intp(self):
+        # Ticket #99
+        i_width = np.int_(0).nbytes*2 - 1
+        np.intp('0x' + 'f'*i_width, 16)
+        assert_raises(OverflowError, np.intp, '0x' + 'f'*(i_width+1), 16)
+        assert_raises(ValueError, np.intp, '0x1', 32)
+        assert_equal(255, np.intp('0xFF', 16))
+
+
+class TestFromInt(object):
+    def test_intp(self):
+        # Ticket #99
+        assert_equal(1024, np.intp(1024))
+
+    def test_uint64_from_negative(self):
+        assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Previously, this gave an error, but now it returns infinity like for the other types.
Unlike the other types, this emits a warning - it might be nice to do it for the other types too in future, or perhaps respect `np.seterr`

Fixes gh-9924.

Also some test cleanup while I was looking for where to put these - I'd suggesting looking commit-by-commit to make this clearer.