### PR TITLE
ENH: Add the C99 remainder function, as `np.remainder_ieee`

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -220,6 +220,11 @@ Chebyshev points of the first kind. A new ``Chebyshev.interpolate`` class
 method adds support for interpolation over arbitrary intervals using the scaled
 and shifted Chebyshev points of the first kind.
 
+``remainder_ieee`` ufunc added to match Python 3.7's ``math.remainder``
+-----------------------------------------------------------------------
+This computes the IEEE remainder, which will be added to the ``math`` module
+in Python 3.7. This is the same function as ``remainder`` refers to in C99.
+
 
 Improvements
 ============

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -791,6 +791,12 @@ defdict = {
           TD(intflt),
           TD(O, f='PyNumber_Divmod'),
           ),
+'remainder_ieee':
+    Ufunc(2, 1, None,
+          docstrings.get('numpy.core.umath.remainder_ieee'),
+          None,
+          TD(flts, f='remainder', astype={'e':'f'}),
+          ),
 'hypot':
     Ufunc(2, 1, Zero,
           docstrings.get('numpy.core.umath.hypot'),

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2883,7 +2883,7 @@ add_newdoc('numpy.core.umath', 'reciprocal',
 
 add_newdoc('numpy.core.umath', 'remainder',
     """
-    Return element-wise remainder of division.
+    Return element-wise remainder of floor division.
 
     Computes the remainder complementary to the `floor_divide` function.  It is
     equivalent to the Python modulus operator``x1 % x2`` and has the same sign
@@ -2895,8 +2895,8 @@ add_newdoc('numpy.core.umath', 'remainder',
         This should not be confused with:
 
         * Python 3.7's `math.remainder` and C's ``remainder``, which
-          computes the IEEE remainder, which are the complement to
-          ``round(x1 / x2)``.
+          computes the IEEE remainder, the complement to ``round(x1 / x2)``.
+          This is available as `remainder_ieee`.
         * The MATLAB ``rem`` function and or the C ``%`` operator which is the
           complement to ``int(x1 / x2)``.
 
@@ -2932,6 +2932,42 @@ add_newdoc('numpy.core.umath', 'remainder',
     array([0, 1])
     >>> np.remainder(np.arange(7), 5)
     array([0, 1, 2, 3, 4, 0, 1])
+
+    """)
+
+add_newdoc('numpy.core.umath', 'remainder_ieee',
+    """
+    Return element-wise remainder of round-to-even division.
+
+    Computes the remainder complementary to the `round` function.  It is
+    equivalent to the Python 3.7 `math.remainder` and C99 ``remainder``
+    functions.
+
+    Parameters
+    ----------
+    x1 : array_like
+        Dividend array.
+    x2 : array_like
+        Divisor array.
+    $PARAMS
+
+    Returns
+    -------
+    y : ndarray
+        The element-wise remainder of the quotient ``round(x1 / x2)``.
+        Returns a scalar if both  `x1` and `x2` are scalars.
+
+    See Also
+    --------
+    round : Equivalent of Python ``round`` function.
+    remainder : Remainder upon floor-division
+
+    Examples
+    --------
+    >>> np.remainder_ieee([4, 7], [2, 3])
+    array([0., 1.])
+    >>> np.remainder_ieee(np.arange(9), 4)
+    array([ 0.,  1.,  2., -1.,  0.,  1., -2., -1.,  0.])
 
     """)
 

--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -136,6 +136,7 @@ NPY_INPLACE double npy_cbrt(double x);
 NPY_INPLACE double npy_fabs(double x);
 NPY_INPLACE double npy_ceil(double x);
 NPY_INPLACE double npy_fmod(double x, double y);
+NPY_INPLACE double npy_remainder(double x, double y);
 NPY_INPLACE double npy_floor(double x);
 
 NPY_INPLACE double npy_expm1(double x);
@@ -256,6 +257,7 @@ NPY_INPLACE float npy_atan2f(float x, float y);
 NPY_INPLACE float npy_hypotf(float x, float y);
 NPY_INPLACE float npy_powf(float x, float y);
 NPY_INPLACE float npy_fmodf(float x, float y);
+NPY_INPLACE float npy_remainderf(float x, float y);
 
 NPY_INPLACE float npy_modff(float x, float* y);
 NPY_INPLACE float npy_frexpf(float x, int* y);
@@ -299,6 +301,7 @@ NPY_INPLACE npy_longdouble npy_atan2l(npy_longdouble x, npy_longdouble y);
 NPY_INPLACE npy_longdouble npy_hypotl(npy_longdouble x, npy_longdouble y);
 NPY_INPLACE npy_longdouble npy_powl(npy_longdouble x, npy_longdouble y);
 NPY_INPLACE npy_longdouble npy_fmodl(npy_longdouble x, npy_longdouble y);
+NPY_INPLACE npy_longdouble npy_remainderl(npy_longdouble x, npy_longdouble y);
 
 NPY_INPLACE npy_longdouble npy_modfl(npy_longdouble x, npy_longdouble* y);
 NPY_INPLACE npy_longdouble npy_frexpl(npy_longdouble x, int* y);

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -672,6 +672,103 @@ npy_divmod@c@(@type@ a, @type@ b, @type@ *modulus)
     return floordiv;
 }
 
+/*
+ * Implementation of C99 remainder, copied from cpython 3.7 and switched to use
+ * the npy_* functions and NPY_ constants.
+ */
+/* IEEE 754-style remainder operation: x - n*y where n*y is the nearest
+   multiple of y to x, taking n even in the case of a tie. Assuming an IEEE 754
+   binary floating-point format, the result is always exact. */
+NPY_INPLACE @type@
+npy_remainder@c@(@type@ x, @type@ y)
+{
+    /* Deal with most common case first. */
+    if (npy_isfinite(x) && npy_isfinite(y)) {
+        @type@ absx, absy, c, m, r;
+
+        if (y == 0.0) {
+            return NPY_NAN;
+        }
+
+        absx = npy_fabs@c@(x);
+        absy = npy_fabs@c@(y);
+        m = npy_fmod@c@(absx, absy);
+
+        /*
+           Warning: some subtlety here. What we *want* to know at this point is
+           whether the remainder m is less than, equal to, or greater than half
+           of absy. However, we can't do that comparison directly because we
+           can't be sure that 0.5*absy is representable (the mutiplication
+           might incur precision loss due to underflow). So instead we compare
+           m with the complement c = absy - m: m < 0.5*absy if and only if m <
+           c, and so on. The catch is that absy - m might also not be
+           representable, but it turns out that it doesn't matter:
+
+           - if m > 0.5*absy then absy - m is exactly representable, by
+             Sterbenz's lemma, so m > c
+           - if m == 0.5*absy then again absy - m is exactly representable
+             and m == c
+           - if m < 0.5*absy then either (i) 0.5*absy is exactly representable,
+             in which case 0.5*absy < absy - m, so 0.5*absy <= c and hence m <
+             c, or (ii) absy is tiny, either subnormal or in the lowest normal
+             binade. Then absy - m is exactly representable and again m < c.
+        */
+
+        c = absy - m;
+        if (m < c) {
+            r = m;
+        }
+        else if (m > c) {
+            r = -c;
+        }
+        else {
+            /*
+               Here absx is exactly halfway between two multiples of absy,
+               and we need to choose the even multiple. x now has the form
+
+                   absx = n * absy + m
+
+               for some integer n (recalling that m = 0.5*absy at this point).
+               If n is even we want to return m; if n is odd, we need to
+               return -m.
+
+               So
+
+                   0.5 * (absx - m) = (n/2) * absy
+
+               and now reducing modulo absy gives us:
+
+                                                  | m, if n is odd
+                   fmod(0.5 * (absx - m), absy) = |
+                                                  | 0, if n is even
+
+               Now m - 2.0 * fmod(...) gives the desired result: m
+               if n is even, -m if m is odd.
+
+               Note that all steps in fmod(0.5 * (absx - m), absy)
+               will be computed exactly, with no rounding error
+               introduced.
+            */
+            assert(m == c);
+            r = m - 2.0 * npy_fmod@c@(0.5 * (absx - m), absy);
+        }
+        return npy_copysign@c@(1.0, x) * r;
+    }
+
+    /* Special values. */
+    if (npy_isnan(x)) {
+        return x;
+    }
+    if (npy_isnan(y)) {
+        return y;
+    }
+    if (npy_isinf(x)) {
+        return NPY_NAN;
+    }
+    assert(npy_isinf(y));
+    return x;
+}
+
 #undef LOGE2
 #undef LOG2E
 #undef RAD2DEG

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1268,6 +1268,25 @@ class TestHeavside(object):
         assert_equal(h, expected1.astype(np.float32))
 
 
+class TestIeeeRemainder(object):
+    def test_remainder_ieee(self):
+        # Testing is basic because implementation is copied from cpython, and
+        # tested extensively there.
+        # No support for integer inputs yet, hence the float expectations.
+
+        x = np.arange(9)
+        expected = np.array([ 0.,  1.,  2., -1.,  0.,  1., -2., -1.,  0.])
+        r = np.remainder_ieee(x, 4)
+        assert_equal(r, expected)
+        assert_equal(r.dtype, expected.dtype)
+
+        x = -np.arange(9)
+        expected = np.array([ 0., -1., -2.,  1.,  0., -1.,  2.,  1.,  0.])
+        r = np.remainder_ieee(x, 4)
+        assert_equal(r, expected)
+        assert_equal(r.dtype, expected.dtype)
+
+
 class TestSign(object):
     def test_sign(self):
         a = np.array([np.inf, -np.inf, np.nan, 0.0, 3.0, -3.0])


### PR DESCRIPTION
Implementation stolen from cpython 3.7.

As suggested in a comment in #9702.