### PR TITLE
BUG: str(np.float) should print with the same number of digits as python str(float)

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -315,24 +315,28 @@ now supported for these arrays:
 Float printing now uses "dragon4" algorithm for shortest decimal representation
 -------------------------------------------------------------------------------
 All numpy floating-point types (16, 32, 64 and 128 bit) can now be printed to
-give shortest decimal representation of the number, which uniquely identifies
+give shortest decimal representation of the number which uniquely identifies
 the value from others of the same type.
 
 New functions ``np.format_float_scientific`` and ``np.format_float_positional``
-are provided to generate these decimal representations, with control over
-rounding, trimming and padding.
+are provided to generate these decimal representations.
 
-The ``str`` and ``repr`` of floating-point scalars now shows the shortest
-unique decimal representation. This means there will be a different number of
-digits compared to numpy 1.13, for instance float64 and float128 will be longer
-and float16 will be shorter.
+The ``str`` and ``repr`` of floating-point scalars now use the shortest unique
+decimal representation. This means float128s will appear longer and float16s
+shorter than in numpy 1.13. Additionally, the `str` of these scalars will no
+longer be truncated in python2, unlike python2 `float`s. `np.double` scalars
+now have a `str` and `repr` identical to that of a python3 float.
 
-For arrays of floating-point type, a new formatting option ``floatmode`` has
-been added to ``np.set_printoptions`` and ``np.array2string``, which gives
-control over uniqueness and rounding of printed elements in arrays. The new
-default is ``floatmode='maxprec'`` with ``precision=8``, which will print at most
-8 fractional digits, or fewer if an element can be uniquely represented with
-fewer.
+A new option ``floatmode`` has been added to ``np.set_printoptions`` and
+``np.array2string``, which gives control over uniqueness and rounding of
+printed elements in an array. The new default is ``floatmode='maxprec'`` with
+``precision=8``, which will print at most 8 fractional digits, or fewer if an
+element can be uniquely represented with fewer. A useful new mode is
+``floatmode="unique"``, which will output enough digits to specify the array
+elements uniquely.
+
+Numpy complex-floating-scalars with values like ``inf*j`` or ``nan*j`` now
+print as ``infj`` and ``nanj``, like the pure-python ``complex`` type.
 
 
 Changes

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -718,6 +718,7 @@ class FloatingFormat(object):
             if self.floatmode == 'fixed':
                 trim, unique = 'k', False
             strs = (dragon4_positional(x, precision=self.precision,
+                                       fractional=True,
                                        unique=unique, trim=trim,
                                        sign=self.sign == '+')
                     for x in non_zero)
@@ -757,15 +758,20 @@ class FloatingFormat(object):
                 return ' '*(self.pad_left + self.pad_right + 1 - len(ret)) + ret
 
         if self.exp_format:
-            return dragon4_scientific(x, precision=self.precision,
+            return dragon4_scientific(x,
+                                      precision=self.precision,
                                       unique=self.unique,
-                                      trim=self.trim, sign=self.sign == '+',
+                                      trim=self.trim,
+                                      sign=self.sign == '+',
                                       pad_left=self.pad_left,
                                       exp_digits=self.exp_size)
         else:
-            return dragon4_positional(x, precision=self.precision,
+            return dragon4_positional(x,
+                                      precision=self.precision,
                                       unique=self.unique,
-                                      trim=self.trim, sign=self.sign == '+',
+                                      fractional=True,
+                                      trim=self.trim,
+                                      sign=self.sign == '+',
                                       pad_left=self.pad_left,
                                       pad_right=self.pad_right)
 
@@ -773,7 +779,7 @@ class FloatingFormat(object):
 def format_float_scientific(x, precision=None, unique=True, trim='k',
                             sign=False, pad_left=None, exp_digits=None):
     """
-    Format a floating-point scalar as a string in fractional notation.
+    Format a floating-point scalar as a string in scientific notation.
 
     Provides control over rounding, trimming and padding. Uses and assumes
     IEEE unbiased rounding. Uses the "Dragon4" algorithm.
@@ -783,18 +789,17 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
     x : python float or numpy floating scalar
         Value to format.
     precision : non-negative integer, optional
-        Maximum number of fractional digits to print. May be ommited
-        if `unique` is `True`, but is required if unique is `False`.
+        Maximum number of fractional digits to print. May be omitted if
+        `unique` is `True`, but is required if unique is `False`.
     unique : boolean, optional
-        If `False`, output exactly `precision` fractional digits and round the
-        remaining value. Digits are generated as if printing an
-        infinite-precision value and stopping after `precision` digits.
         If `True`, use a digit-generation strategy which gives the shortest
         representation which uniquely identifies the floating-point number from
         other values of the same type, by judicious rounding. If `precision`
-        was omitted, print out the full unique representation, otherwise digit
-        generation is cut off after `precision` digits and the remaining value
-        is rounded.
+        was omitted, print all necessary digits, otherwise digit generation is
+        cut off after `precision` digits and the remaining value is rounded.
+        If `False`, digits are generated as if printing an infinite-precision
+        value and stopping after `precision` digits, rounding the remaining
+        value.
     trim : one of 'k', '.', '0', '-', optional
         Controls post-processing trimming of trailing digits, as follows:
             k : keep trailing zeros, keep decimal point (no trimming)
@@ -833,16 +838,17 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
     precision = -1 if precision is None else precision
     pad_left = -1 if pad_left is None else pad_left
     exp_digits = -1 if exp_digits is None else exp_digits
-    return dragon4_scientific(x, precision=precision, unique=unique, trim=trim,
-                              sign=sign, pad_left=pad_left,
+    return dragon4_scientific(x, precision=precision, unique=unique,
+                              trim=trim, sign=sign, pad_left=pad_left,
                               exp_digits=exp_digits)
 
-def format_float_positional(x, precision=None, unique=True, trim='k',
-                            sign=False, pad_left=None, pad_right=None):
+def format_float_positional(x, precision=None, unique=True,
+                            fractional=True, trim='k', sign=False,
+                            pad_left=None, pad_right=None):
     """
-    Format a floating-point scalar as a string in scientific notation.
+    Format a floating-point scalar as a string in positional notation.
 
-    Provides control over rounding, trimming and padding.  Uses and assumes
+    Provides control over rounding, trimming and padding. Uses and assumes
     IEEE unbiased rounding. Uses the "Dragon4" algorithm.
 
     Parameters
@@ -850,18 +856,22 @@ def format_float_positional(x, precision=None, unique=True, trim='k',
     x : python float or numpy floating scalar
         Value to format.
     precision : non-negative integer, optional
-        Maximum number of fractional digits to print. May be ommited
-        if `unique` is `True`, but is required if unique is `False`.
+        Maximum number of digits to print. May be omitted if `unique` is
+        `True`, but is required if unique is `False`.
     unique : boolean, optional
-        If `False`, output exactly `precision` fractional digits and round the
-        remaining value. Digits are generated as if printing an
-        infinite-precision value and stopping after `precision` digits.
         If `True`, use a digit-generation strategy which gives the shortest
         representation which uniquely identifies the floating-point number from
         other values of the same type, by judicious rounding. If `precision`
-        was omitted, print out the full unique representation, otherwise digit
-        generation is cut off after `precision` digits and the remaining value
-        is rounded.
+        was omitted, print out all necessary digits, otherwise digit generation
+        is cut off after `precision` digits and the remaining value is rounded.
+        If `False`, digits are generated as if printing an infinite-precision
+        value and stopping after `precision` digits, rounding the remaining
+        value.
+    fractional : boolean, optional
+        If `True`, the cutoff of `precision` digits refers to the total number
+        of digits after the decimal point, including leading zeros.
+        If `False`, `precision` refers to the total number of significant
+        digits, before or after the decimal point, ignoring leading zeros.
     trim : one of 'k', '.', '0', '-', optional
         Controls post-processing trimming of trailing digits, as follows:
             k : keep trailing zeros, keep decimal point (no trimming)
@@ -901,7 +911,8 @@ def format_float_positional(x, precision=None, unique=True, trim='k',
     precision = -1 if precision is None else precision
     pad_left = -1 if pad_left is None else pad_left
     pad_right = -1 if pad_right is None else pad_right
-    return dragon4_positional(x, precision=precision, unique=unique, trim=trim,
+    return dragon4_positional(x, precision=precision, unique=unique,
+                              fractional=fractional, trim=trim,
                               sign=sign, pad_left=pad_left,
                               pad_right=pad_right)
 

--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -39,7 +39,7 @@
 #if 0
 #define DEBUG_ASSERT(stmnt) assert(stmnt)
 #else
-#define DEBUG_ASSERT(stmnt) {}
+#define DEBUG_ASSERT(stmnt) do {} while(0)
 #endif
 
 /*
@@ -1002,8 +1002,8 @@ BigInt_ShiftLeft(BigInt *result, npy_uint32 shift)
  *   * exponent - value exponent in base 2
  *   * mantissaBit - index of the highest set mantissa bit
  *   * hasUnequalMargins - is the high margin twice as large as the low margin
- *   * cutoffMode - how to determine output length
- *   * cutoffNumber - parameter to the selected cutoffMode. For each mode:
+ *   * cutoffMode - how to intepret cutoffNumber: fractional or total digits?
+ *   * cutoffNumber - cut off printing after this many digits. -1 for no cutoff
  *   * pOutBuffer - buffer to output into
  *   * bufferSize - maximum characters that can be printed to pOutBuffer
  *   * pOutExponent - the base 10 exponent of the first digit

--- a/numpy/core/src/multiarray/dragon4.h
+++ b/numpy/core/src/multiarray/dragon4.h
@@ -40,6 +40,22 @@
 #include "npy_pycompat.h"
 #include "numpy/arrayscalars.h"
 
+typedef enum DigitMode
+{
+    /* Round digits to print shortest uniquely identifiable number. */
+    DigitMode_Unique,
+    /* Output the digits of the number as if with infinite precision */
+    DigitMode_Exact,
+} DigitMode;
+
+typedef enum CutoffMode
+{
+    /* up to cutoffNumber significant digits */
+    CutoffMode_TotalLength,
+    /* up to cutoffNumber significant digits past the decimal point */
+    CutoffMode_FractionLength,
+} CutoffMode;
+
 typedef enum TrimMode
 {
     TrimMode_None,         /* don't trim zeros, always leave a decimal point */
@@ -49,22 +65,23 @@ typedef enum TrimMode
 } TrimMode;
 
 PyObject *
-Dragon4_Positional_AnySize(void *val, size_t size, npy_bool unique,
+Dragon4_Positional_AnySize(void *val, size_t size, DigitMode digit_mode,
+                           CutoffMode cutoff_mode, int precision, int sign,
+                           TrimMode trim, int pad_left, int pad_right);
+
+PyObject *
+Dragon4_Scientific_AnySize(void *val, size_t size, DigitMode digit_mode,
                            int precision, int sign, TrimMode trim,
                            int pad_left, int pad_right);
 
 PyObject *
-Dragon4_Scientific_AnySize(void *val, size_t size, npy_bool unique,
-                           int precision, int sign, TrimMode trim,
-                           int pad_left, int exp_digits);
+Dragon4_Positional(PyObject *obj, DigitMode digit_mode, CutoffMode cutoff_mode,
+                   int precision, int sign, TrimMode trim, int pad_left,
+                   int pad_right);
 
 PyObject *
-Dragon4_Positional(PyObject *obj, npy_bool unique, int precision, int sign,
-                   TrimMode trim, int pad_left, int pad_right);
-
-PyObject *
-Dragon4_Scientific(PyObject *obj, npy_bool unique, int precision, int sign,
-                   TrimMode trim, int pad_left, int exp_digits);
+Dragon4_Scientific(PyObject *obj, DigitMode digit_mode, int precision,
+                   int sign, TrimMode trim, int pad_left, int exp_digits);
 
 #endif
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3603,8 +3603,8 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     TrimMode trim = TrimMode_None;
     int sign=0, unique=1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiisii", kwlist,
-                &obj, &precision, &unique, &sign, &trimstr, &pad_left,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiisii:dragon4_scientific",
+                kwlist, &obj, &precision, &unique, &sign, &trimstr, &pad_left,
                 &exp_digits)) {
         return NULL;
     }
@@ -3660,8 +3660,8 @@ dragon4_positional(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     TrimMode trim = TrimMode_None;
     int sign=0, unique=1, fractional=0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiisii", kwlist,
-                &obj, &precision, &unique, &fractional, &sign, &trimstr,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiisii:dragon4_positional",
+                kwlist, &obj, &precision, &unique, &fractional, &sign, &trimstr,
                 &pad_left, &pad_right)) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3587,27 +3587,9 @@ as_buffer(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
 
 /*
  * Prints floating-point scalars usign the Dragon4 algorithm, scientific mode.
- * Arguments:
- *  x - a numpy scalar of Floating type
- *  precision - number of fractional digits to show. In unique mode, can be
- *              ommited and the unique repr will be returned, otherwise the
- *              unique value will be truncated to this number of digits
- *              (breaking the uniqueness guarantee). In fixed mode, is
- *              required, and specifies the number of fractional digits to
- *              print.
- *  unique - whether to use unique (default) or fixed mode.
- *  sign - whether to show the sign for positive values. Default False
- *  trim - one of 'k', '.', '0', '-' to control trailing digits, as follows:
- *          k : don't trim zeros, always leave a decimal point
- *          . : trim all but the zero before the decimal point
- *          0 : trim all trailing zeros, leave decimal point
- *          - : trim trailing zeros and a trailing decimal point
- *         Default is k.
- *  pad_left - pads left side of string with whitespace until at least
- *             this many characters are to the left of the decimal point. If
- *             -1, don't add any padding. Default -1.
- *  exp_digits - exponent will contain at least this many digits, padding
- *               with 0 if necessary. -1 means pad to 2. Maximum of 5.
+ * See docstring of `np.format_float_scientific` for description of arguments.
+ * The differences is that a value of -1 is valid for pad_left, exp_digits,
+ * precision, which is equivalent to `None`.
  */
 static PyObject *
 dragon4_scientific(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
@@ -3617,6 +3599,7 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
                              "pad_left", "exp_digits", NULL};
     int precision=-1, pad_left=-1, exp_digits=-1;
     char *trimstr=NULL;
+    DigitMode digit_mode;
     TrimMode trim = TrimMode_None;
     int sign=0, unique=1;
 
@@ -3646,55 +3629,40 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
         }
     }
 
+    digit_mode = unique ? DigitMode_Unique : DigitMode_Exact;
+
     if (unique == 0 && precision < 0) {
         PyErr_SetString(PyExc_TypeError,
             "in non-unique mode `precision` must be supplied");
         return NULL;
     }
 
-    return Dragon4_Scientific(obj, unique, precision, sign,
-                              trim, pad_left, exp_digits);
+    return Dragon4_Scientific(obj, digit_mode, precision, sign, trim,
+                              pad_left, exp_digits);
 }
 
 /*
  * Prints floating-point scalars usign the Dragon4 algorithm, positional mode.
- * Arguments:
- *  x - a numpy scalar of Floating type
- *  precision - number of fractional digits to show. In unique mode, can be
- *              ommited and the unique repr will be returned, otherwise the
- *              unique value will be truncated to this number of digits
- *              (breaking the uniqueness guarantee). In fixed mode, is
- *              required, and specifies the number of fractional digits to
- *              print.
- *  unique - whether to use unique (default) or fixed mode.
- *  sign - whether to show the sign for positive values. Default False
- *  trim - one of 'k', '.', '0', '-' to control trailing digits, as follows:
- *          k : don't trim zeros, always leave a decimal point
- *          . : trim all but the zero before the decimal point
- *          0 : trim all trailing zeros, leave decimal point
- *          - : trim trailing zeros and a trailing decimal point
- *         Default is k.
- *  pad_left - pads left side of string with whitespace until at least
- *             this many characters are to the left of the decimal point. If
- *             -1, don't add any padding. Default -1.
- *  pad_right - pads right side of string with whitespace until at least
- *             this many characters are to the right of the decimal point. If
- *             -1, don't add any padding. Default -1.
+ * See docstring of `np.format_float_positional` for description of arguments.
+ * The differences is that a value of -1 is valid for pad_left, pad_right,
+ * precision, which is equivalent to `None`.
  */
 static PyObject *
 dragon4_positional(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
 {
     PyObject *obj;
-    static char *kwlist[] = {"x", "precision", "unique", "sign", "trim",
-                             "pad_left", "pad_right", NULL};
+    static char *kwlist[] = {"x", "precision", "unique", "fractional",
+                             "sign", "trim", "pad_left", "pad_right", NULL};
     int precision=-1, pad_left=-1, pad_right=-1;
     char *trimstr=NULL;
+    CutoffMode cutoff_mode;
+    DigitMode digit_mode;
     TrimMode trim = TrimMode_None;
-    int sign=0, unique=1;
+    int sign=0, unique=1, fractional=0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiisii", kwlist,
-                &obj, &precision, &unique, &sign, &trimstr, &pad_left,
-                &pad_right)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiisii", kwlist,
+                &obj, &precision, &unique, &fractional, &sign, &trimstr,
+                &pad_left, &pad_right)) {
         return NULL;
     }
 
@@ -3718,13 +3686,17 @@ dragon4_positional(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
         }
     }
 
+    digit_mode = unique ? DigitMode_Unique : DigitMode_Exact;
+    cutoff_mode = fractional ? CutoffMode_FractionLength :
+                               CutoffMode_TotalLength;
+
     if (unique == 0 && precision < 0) {
         PyErr_SetString(PyExc_TypeError,
             "in non-unique mode `precision` must be supplied");
         return NULL;
     }
 
-    return Dragon4_Positional(obj, unique, precision, sign,
+    return Dragon4_Positional(obj, digit_mode, cutoff_mode, precision, sign,
                               trim, pad_left, pad_right);
 }
 
@@ -3744,8 +3716,8 @@ format_longfloat(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
                 "not a longfloat");
         return NULL;
     }
-    return Dragon4_Scientific(obj, precision, 0, 1, TrimMode_LeaveOneZero,
-                              -1, -1);
+    return Dragon4_Scientific(obj, DigitMode_Unique, precision, 0,
+                              TrimMode_LeaveOneZero, -1, -1);
 }
 
 static PyObject *

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -723,7 +723,6 @@ timedeltatype_str(PyObject *self)
 
 /**begin repeat
  * #kind = str, repr#
- * #maxprec = 8, -1#
  */
 
 /**begin repeat1
@@ -737,10 +736,12 @@ static PyObject *
 @name@type_@kind@_either(npy_@name@ val, TrimMode trim_pos, TrimMode trim_sci,
                          npy_bool sign)
 {
-    if (val < (npy_@name@)1.e10L) {
-        return format_@name@(val, 0, @maxprec@, sign, trim_pos, -1, -1, -1);
+    npy_@name@ absval = val < 0 ? -val : val;
+
+    if (absval == 0 || (absval < 1.e16L && absval >= 1.e-4L) ) {
+        return format_@name@(val, 0, -1, sign, trim_pos, -1, -1, -1);
     }
-    return format_@name@(val, 1, @maxprec@, sign, trim_sci, -1, -1, -1);
+    return format_@name@(val, 1, -1, sign, trim_sci, -1, -1, -1);
 }
 
 static PyObject *
@@ -813,7 +814,10 @@ static PyObject *
 halftype_@kind@(PyObject *self)
 {
     npy_half val = ((PyHalfScalarObject *)self)->obval;
-    if (npy_half_to_double(val) < 1.e16) {
+    double absval = npy_half_to_double(val);
+    absval = absval < 0 ? -absval : absval;
+
+    if (absval == 0 || (absval < 1.e16 && absval >= 1.e-4) ) {
         return format_half(val, 0, -1, 0, TrimMode_LeaveOneZero, -1, -1, -1);
     }
     return format_half(val, 1, -1, 0, TrimMode_DptZeros, -1, -1, -1);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -442,14 +442,17 @@ format_@name@(@type@ val, npy_bool scientific,
               int pad_left, int pad_right, int exp_digits)
 {
     if (scientific) {
-        return Dragon4_Scientific_AnySize(&val, sizeof(@type@), 1, precision,
-                                          sign, trim, pad_left, exp_digits);
+        return Dragon4_Scientific_AnySize(&val, sizeof(@type@),
+                        DigitMode_Unique, precision,
+                        sign, trim, pad_left, exp_digits);
     }
     else {
-        return Dragon4_Positional_AnySize(&val, sizeof(@type@), 1, precision,
-                                          sign, trim, pad_left, pad_right);
+        return Dragon4_Positional_AnySize(&val, sizeof(@type@),
+                        DigitMode_Unique, CutoffMode_TotalLength, precision,
+                        sign, trim, pad_left, pad_right);
     }
 }
+
 
 /**end repeat**/
 
@@ -720,6 +723,7 @@ timedeltatype_str(PyObject *self)
 
 /**begin repeat
  * #kind = str, repr#
+ * #maxprec = 8, -1#
  */
 
 /**begin repeat1
@@ -728,14 +732,15 @@ timedeltatype_str(PyObject *self)
  * #NAME = FLOAT, DOUBLE, LONGDOUBLE#
  */
 
+/* helper function choose scientific of fractional output, based on a cutoff */
 static PyObject *
 @name@type_@kind@_either(npy_@name@ val, TrimMode trim_pos, TrimMode trim_sci,
                          npy_bool sign)
 {
-    if (val < (npy_@name@)1.e16L) {
-        return format_@name@(val, 0, -1, sign, trim_pos, -1, -1, -1);
+    if (val < (npy_@name@)1.e10L) {
+        return format_@name@(val, 0, @maxprec@, sign, trim_pos, -1, -1, -1);
     }
-    return format_@name@(val, 1, -1, sign, trim_sci, -1, -1, -1);
+    return format_@name@(val, 1, @maxprec@, sign, trim_sci, -1, -1, -1);
 }
 
 static PyObject *

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -80,7 +80,7 @@ class TestRepr(object):
         assert_equal(repr(np.iinfo(np.int16)), expected)
 
     def test_finfo_repr(self):
-        expected = "finfo(resolution=0.000001, min=-3.4028235e+38," + \
+        expected = "finfo(resolution=1e-06, min=-3.4028235e+38," + \
                    " max=3.4028235e+38, dtype=float32)"
         assert_equal(repr(np.finfo(np.float32)), expected)
 

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -26,6 +26,25 @@ class TestRealScalars(object):
                 msg = 'for str({}({}))'.format(np.dtype(styp).name, repr(val))
                 assert_equal(str(styp(val)), want, err_msg=msg)
 
+    def test_scalar_cutoffs(self):
+        # test that both the str and repr of np.float64 behaves
+        # like python floats in python3. Note that in python2
+        # the str has truncated digits, but we do not do this
+        def check(v):
+            # we compare str to repr, to avoid python2 truncation behavior
+            assert_equal(str(np.float64(v)), repr(v))
+            assert_equal(repr(np.float64(v)), repr(v))
+
+        # check we use the same number of significant digits
+        check(1.12345678901234567890)
+        check(0.0112345678901234567890)
+
+        # check switch from scientific output to positional and back
+        check(1e-5)
+        check(1e-4)
+        check(1e15)
+        check(1e16)
+
     def test_dragon4(self):
         # these tests are adapted from Ryan Juckett's dragon4 implementation,
         # see dragon4.c for details.


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/18123

This makes numpy floating-point scalars `str` and `repr`  (ie, `str(np.float64(1.2345))`) print in the same way as python floats (done in the 2nd commit). That is:
 * ~~`str` uses 8 digits, in fixed mode for `1e-4 < x < 1e11` and scientific mode otherwise.~~
 * `repr` uses as many digits as needed to specify the value uniquely, in fixed mode for `1e-4 < x < 1e16` and scientific mode otherwise.

(Updated: Both `str` and `repr` now print all digits, like floats in python3.)

The PR is so big because I needed to expose control of the digit cutoff mode in the Dragon4 algorithm, which I had left hidden before. That's all in the 1st commit. This allows you to control whether `precision` refers to the number of digits past 0, or the number of significant digits. An example:
```python
>>> np.format_float_positional(0.00123456789, precision=4, fractional=True)
'0.0012'
>>> np.format_float_positional(0.00123456789, precision=4, fractional=False)
'0.001235'
```
This was required to fix the scalar `str` because Python outputs floats with `fractional=False`, while in numpy arrays we use `fractional=True`.
