### PR TITLE
BUG: cast to str_ should not convert to pure-python intermediate

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1673,7 +1673,7 @@ static void
     int skip = 1;
     int oskip = PyArray_DESCR(aop)->elsize;
     for (i = 0; i < n; i++, ip += skip, op += oskip) {
-        temp = @from@_getitem(ip, aip);
+        temp = PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)aip);
         if (temp == NULL) {
             Py_INCREF(Py_False);
             temp = Py_False;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -451,6 +451,14 @@ class TestAssignment(object):
             arr = np.array([np.array(tinya)])
             assert_equal(arr[0], tinya)
 
+    def test_cast_to_string(self):
+        # cast to str should do "str(scalar)", not "str(scalar.item())"
+        # Example: In python2, str(float) is truncated, so we want to avoid
+        # str(np.float64(...).item()) as this would incorrectly truncate.
+        a = np.zeros(1, dtype='S20')
+        a[:] = np.array(['1.12345678901234567890'], dtype='f8')
+        assert_equal(a[0], b"1.1234567890123457")
+
 
 class TestDtypedescr(object):
     def test_construction(self):


### PR DESCRIPTION
Small fix for casting to string arrays. See See pandas-dev/pandas#18123.

When casting to a `string` (`S`) array numpy currently does `dst[i] = str(src[i].item())` where recall that `.item()` converts to a pure-python type. I think it should just do `dst[i] = str(src[i])`.

This comes up for floating types now that we updated their `str`,  since now `str(np.floatXX(...))` is not the same as `str(np.floatXX(...).item()`, especially in python2.