### PR TITLE
ENH: let f2py discover location of libgfortran

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -166,6 +166,23 @@ class GnuFCompiler(FCompiler):
             return os.path.dirname(output)
         return None
 
+    def get_libgfortran_dir(self):
+        if sys.platform[:5] == 'linux':
+            libgfortran_name = 'libgfortran.so'
+        elif sys.platform == 'darwin':
+            libgfortran_name = 'libgfortran.dylib'
+        else:
+            libgfortran_name = None
+
+        libgfortran_dir = None
+        if libgfortran_name:
+            find_lib_arg = ['-print-file-name={0}'.format(libgfortran_name)]
+            status, output = exec_command(
+                self.compiler_f77 + find_lib_arg, use_tee=0)
+            if not status:
+                libgfortran_dir = os.path.dirname(output)
+        return libgfortran_dir
+
     def get_library_dirs(self):
         opt = []
         if sys.platform[:5] != 'linux':
@@ -182,6 +199,11 @@ class GnuFCompiler(FCompiler):
                         if os.path.exists(path):
                             opt.append(d2)
                 opt.append(d)
+        # For Macports / Linux, libgfortran and libgcc are not co-located
+        if sys.platform[:5] == 'linux' or sys.platform == 'darwin':
+            lib_gfortran_dir = self.get_libgfortran_dir()
+            if lib_gfortran_dir:
+                opt.append(lib_gfortran_dir)
         return opt
 
     def get_libraries(self):
@@ -327,6 +349,11 @@ class Gnu95FCompiler(GnuFCompiler):
                     mingwdir = os.path.normpath(path)
                     if os.path.exists(os.path.join(mingwdir, "libmingwex.a")):
                         opt.append(mingwdir)
+        # For Macports / Linux, libgfortran and libgcc are not co-located
+        if sys.platform[:5] == 'linux' or sys.platform == 'darwin':
+            lib_gfortran_dir = self.get_libgfortran_dir()
+            if lib_gfortran_dir:
+                opt.append(lib_gfortran_dir)
         return opt
 
     def get_libraries(self):


### PR DESCRIPTION
This PR fixes an interaction between f2py, gfortran, and Anaconda Python that breaks some modules at runtime. The crux of the issue is that Anaconda installs its own libgfortran into a virtual environment to support numpy / scipy. When using f2py with the system gfortran on linux, or MacPorts gfortran on MacOS, the compiler sometimes links the wrong libgfortran (the one supplied by Anaconda), which is often incompatable with the compiler run by f2py. The result is f2py python modules that break at runtime.

This PR fixes the issue by discovering the libgfortran path after distutils discovers the libgcc path. This is a fix because libgcc and libgfortran are not always co-located, so discovering the libgfortran path makes the linking to the correct libgfortran explicit. Otherwise, another "-L" option could leave the result linked to a potentially incompatible library. In practice, this is how Anaconda causes the issue; something adds "-L/anaconda/envs/env/lib/", which contains the libgfortran supplied by Anaconda. I believe this is ultimately an issue created by the maintainers, but this PR should make f2py more robust to this failure mode.

The following fortran code will reproduce the problem. On success, the subroutine should print 42. If f2py did not properly link the shared object, it will emit `Fortran runtime error: Bad value during integer read`.

```fortran
    ! f2py_test.f90
    SUBROUTINE f2py_test_sub
      CHARACTER *8 :: n_as_str = "42"
      INTEGER n_as_int
      READ(n_as_str,'(i8)') n_as_int
      PRINT *, n_as_int
    END SUBROUTINE

    PROGRAM f2py_test_program
    CALL f2py_test_sub
    END PROGRAM
```

Failures can be replicated using the following environments.

- On Ubuntu 16.04 with gfortran supplied by `apt install gfortran`,

```bash
    conda create -n f2py_test python=3.5.4 numpy scipy
    source activate f2py_test
    f2py -c -m f2py_test f2py_test.f90
    python -c "import f2py_test; f2py_test.f2py_test_sub()"
```

- On MacOS 10.13.1 with gfortran supplied by Macports mp-gcc7,

```bash
    conda create -n f2py_test python=3.5.3 numpy
    source activate f2py_test
    f2py -c -m f2py_test f2py_test.f90
    python -c "import f2py_test; f2py_test.f2py_test_sub()"
```

P.S., People looking for a quick work-around can insert [this Gist](https://gist.github.com/KristoforMaynard/6981e3ef06d74f1819f647b69c673983) into their `setup.py`.