### PR TITLE
ENH: Adding `order=` keyword to `np.eye()`.

### DIFF
--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -95,6 +95,15 @@ class TestEye(object):
     def test_bool(self):
         assert_equal(eye(2, 2, dtype=bool), [[True, False], [False, True]])
 
+    def test_order(self):
+        mat_c = eye(4, 3, k=-1)
+        mat_f = eye(4, 3, k=-1, order='F')
+        assert_equal(mat_c, mat_f)
+        assert mat_c.flags.c_contiguous
+        assert not mat_c.flags.f_contiguous
+        assert not mat_f.flags.c_contiguous
+        assert mat_f.flags.f_contiguous
+
 
 class TestDiag(object):
     def test_vector(self):

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -157,6 +157,8 @@ def eye(N, M=None, k=0, dtype=float, order='C'):
         Whether the output should be stored in row-major (C-style) or
         column-major (Fortran-style) order in memory.
 
+        .. versionadded:: 1.13.4
+
     Returns
     -------
     I : ndarray of shape (N,M)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -137,7 +137,7 @@ def flipud(m):
     return m[::-1, ...]
 
 
-def eye(N, M=None, k=0, dtype=float):
+def eye(N, M=None, k=0, dtype=float, order='C'):
     """
     Return a 2-D array with ones on the diagonal and zeros elsewhere.
 
@@ -153,6 +153,9 @@ def eye(N, M=None, k=0, dtype=float):
       to a lower diagonal.
     dtype : data-type, optional
       Data-type of the returned array.
+    order : {'C', 'F'}, optional
+        Whether the output should be stored in row-major (C-style) or
+        column-major (Fortran-style) order in memory.
 
     Returns
     -------
@@ -178,7 +181,7 @@ def eye(N, M=None, k=0, dtype=float):
     """
     if M is None:
         M = N
-    m = zeros((N, M), dtype=dtype)
+    m = zeros((N, M), dtype=dtype, order=order)
     if k >= M:
         return m
     if k >= 0:

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -157,7 +157,7 @@ def eye(N, M=None, k=0, dtype=float, order='C'):
         Whether the output should be stored in row-major (C-style) or
         column-major (Fortran-style) order in memory.
 
-        .. versionadded:: 1.13.4
+        .. versionadded:: 1.14.0
 
     Returns
     -------

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -24,8 +24,6 @@ def empty(shape, dtype=None, order='C'):
         (C-style) or column-major (Fortran-style) order in
         memory.
 
-        .. versionadded:: 1.13.4
-
     See Also
     --------
     empty_like, zeros
@@ -194,6 +192,8 @@ def eye(n,M=None, k=0, dtype=float, order='C'):
     order : {'C', 'F'}, optional
         Whether the output should be stored in row-major (C-style) or
         column-major (Fortran-style) order in memory.
+
+        .. versionadded:: 1.14.0
 
     Returns
     -------

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -24,6 +24,8 @@ def empty(shape, dtype=None, order='C'):
         (C-style) or column-major (Fortran-style) order in
         memory.
 
+        .. versionadded:: 1.13.4
+
     See Also
     --------
     empty_like, zeros

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -173,7 +173,7 @@ def identity(n,dtype=None):
     b.flat = a
     return b
 
-def eye(n,M=None, k=0, dtype=float):
+def eye(n,M=None, k=0, dtype=float, order='C'):
     """
     Return a matrix with ones on the diagonal and zeros elsewhere.
 
@@ -189,6 +189,9 @@ def eye(n,M=None, k=0, dtype=float):
         and a negative value to a lower diagonal.
     dtype : dtype, optional
         Data-type of the returned matrix.
+    order : {'C', 'F'}, optional
+        Whether the output should be stored in row-major (C-style) or
+        column-major (Fortran-style) order in memory.
 
     Returns
     -------
@@ -210,7 +213,7 @@ def eye(n,M=None, k=0, dtype=float):
             [ 0.,  0.,  0.]])
 
     """
-    return asmatrix(np.eye(n, M, k, dtype))
+    return asmatrix(np.eye(n, M=M, k=k, dtype=dtype, order=order))
 
 def rand(*args):
     """

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -28,10 +28,19 @@ def test_identity():
     assert_array_equal(x, np.matrix([[1, 0], [0, 1]]))
 
 def test_eye():
-    x = numpy.matlib.eye(3, k=1, dtype=int)
-    assert_array_equal(x, np.matrix([[ 0,  1,  0],
-                                     [ 0,  0,  1],
-                                     [ 0,  0,  0]]))
+    xc = numpy.matlib.eye(3, k=1, dtype=int)
+    assert_array_equal(xc, np.matrix([[ 0,  1,  0],
+                                      [ 0,  0,  1],
+                                      [ 0,  0,  0]]))
+    assert xc.flags.c_contiguous
+    assert not xc.flags.f_contiguous
+
+    xf = numpy.matlib.eye(3, 4, dtype=int, order='F')
+    assert_array_equal(x, np.matrix([[ 1,  0,  0,  0],
+                                     [ 0,  1,  0,  0],
+                                     [ 0,  0,  1,  0]]))
+    assert not xf.flags.c_contiguous
+    assert xf.flags.f_contiguous
 
 def test_rand():
     x = numpy.matlib.rand(3)

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -36,9 +36,9 @@ def test_eye():
     assert not xc.flags.f_contiguous
 
     xf = numpy.matlib.eye(3, 4, dtype=int, order='F')
-    assert_array_equal(x, np.matrix([[ 1,  0,  0,  0],
-                                     [ 0,  1,  0,  0],
-                                     [ 0,  0,  1,  0]]))
+    assert_array_equal(xf, np.matrix([[ 1,  0,  0,  0],
+                                      [ 0,  1,  0,  0],
+                                      [ 0,  0,  1,  0]]))
     assert not xf.flags.c_contiguous
     assert xf.flags.f_contiguous
 


### PR DESCRIPTION
Fixes #9995.

/cc @eric-wieser @njsmith