### PR TITLE
BUG: prototypes for [cz]dot[uc] are incorrect

### DIFF
--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -294,20 +294,20 @@ extern double
 FNAME(ddot)(int *n,
             double *sx, int *incx,
             double *sy, int *incy);
-extern f2c_complex
-FNAME(cdotu)(int *n,
+extern void
+FNAME(cdotu)(f2c_complex *ret, int *n,
              f2c_complex *sx, int *incx,
              f2c_complex *sy, int *incy);
-extern f2c_doublecomplex
-FNAME(zdotu)(int *n,
+extern void
+FNAME(zdotu)(f2c_doublecomplex *ret, int *n,
              f2c_doublecomplex *sx, int *incx,
              f2c_doublecomplex *sy, int *incy);
-extern f2c_complex
-FNAME(cdotc)(int *n,
+extern void
+FNAME(cdotc)(f2c_complex *ret, int *n,
              f2c_complex *sx, int *incx,
              f2c_complex *sy, int *incy);
-extern f2c_doublecomplex
-FNAME(zdotc)(int *n,
+extern void
+FNAME(zdotc)(f2c_doublecomplex *ret, int *n,
              f2c_doublecomplex *sx, int *incx,
              f2c_doublecomplex *sy, int *incy);
 


### PR DESCRIPTION
F2C does not support complex return values, and puts these as the first argument.

This can be checked by looking at `numpy\linalg\lapack_lite\f2c_blas.c`.

It's not clear to me if these prototypes are exclusively for lapack_lite, or if they also need to match the system lapack (in which case the `f2c_...` in the typenames is very misleading).

This fixed a segfault on my machine (using lapack_lite) when trying to call these functions in the C code.