### PR TITLE
ENH: Nditer as context manager

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -52,6 +52,21 @@ Deprecations
   In the future, it might return a different result. Use `np.sum(np.from_iter(generator))`
   or the built-in Python `sum` instead.
 
+* ``nditer`` use outside of a context manager where the ``nditer`` has writable
+  arrays is deprecated. This situation proves difficult to detect, the
+  ``DeprecationWarning`` may only be emitted when deallocating the array.
+
+* Users of the C-API should call ``PyArrayResolveWriteBackIfCopy`` or 
+  ``PyArray_DiscardWritbackIfCopy`` on any array with the ``WRITEBACKIFCOPY``
+  flag set, before the array is deallocated. A deprecation warning will be
+  emitted if those calls are not used when needed.
+
+* Users of ``nditer`` should use the nditer object as a context manager
+  anytime one of the iterator operands is writeable, so that numpy can
+  manage writeback semantics. A deprecation warning will be emitted if a
+  context manager is not used in these cases. Users of the C-API should call 
+  ``NpyIter_Close`` before ``NpyIter_Dealloc``.
+
 
 Future Changes
 ==============
@@ -60,6 +75,16 @@ Future Changes
 Compatibility notes
 ===================
 
+Under certain conditions, nditer must be used in a context manager
+------------------------------------------------------------------
+When using an nditer with the ``"writeonly"`` or ``"readwrite"`` flags, there
+are some circumstances where nditer doesn't actually give you a view onto the
+writable array. Instead, it gives you a copy, and if you make changes to the
+copy, nditer later writes those changes back into your actual array. Currently,
+this writeback occurs when the array objects are garbage collected, which makes
+this API error-prone on CPython and entirely broken on PyPy. Therefore, 
+``nditer`` should now be used as a context manager whenever using ``nditer``
+with writeable arrays (``with np.nditer(...) as it: ...``). 
 Numpy has switched to using pytest instead of nose for testing
 --------------------------------------------------------------
 The last nose release was 1.3.7 in June, 2015, and development of that tool has
@@ -93,6 +118,8 @@ using the old API.
 C API changes
 =============
 
+``NpyIter_Close`` has been added and should be called before
+``NpyIter_Dealloc`` to resolve possible writeback-enabled arrays.
 
 New Features
 ============

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -52,10 +52,6 @@ Deprecations
   In the future, it might return a different result. Use `np.sum(np.from_iter(generator))`
   or the built-in Python `sum` instead.
 
-* ``nditer`` use outside of a context manager where the ``nditer`` has writable
-  arrays is deprecated. This situation proves difficult to detect, the
-  ``DeprecationWarning`` may only be emitted when deallocating the array.
-
 * Users of the C-API should call ``PyArrayResolveWriteBackIfCopy`` or 
   ``PyArray_DiscardWritbackIfCopy`` on any array with the ``WRITEBACKIFCOPY``
   flag set, before the array is deallocated. A deprecation warning will be
@@ -63,9 +59,9 @@ Deprecations
 
 * Users of ``nditer`` should use the nditer object as a context manager
   anytime one of the iterator operands is writeable, so that numpy can
-  manage writeback semantics. A deprecation warning will be emitted if a
-  context manager is not used in these cases. Users of the C-API should call 
-  ``NpyIter_Close`` before ``NpyIter_Dealloc``.
+  manage writeback semantics, or should call ``it.close()``. A
+ `RuntimeWarning` will be emitted otherwise in these cases. Users of the C-API
+  should call ``NpyIter_Close`` before ``NpyIter_Dealloc``.
 
 
 Future Changes
@@ -84,7 +80,10 @@ copy, nditer later writes those changes back into your actual array. Currently,
 this writeback occurs when the array objects are garbage collected, which makes
 this API error-prone on CPython and entirely broken on PyPy. Therefore, 
 ``nditer`` should now be used as a context manager whenever using ``nditer``
-with writeable arrays (``with np.nditer(...) as it: ...``). 
+with writeable arrays (``with np.nditer(...) as it: ...``). You may also
+explicitly call ``it.close()`` for cases where a context manager is unusable,
+for instance in generator expressions.
+
 Numpy has switched to using pytest instead of nose for testing
 --------------------------------------------------------------
 The last nose release was 1.3.7 in June, 2015, and development of that tool has

--- a/doc/source/reference/arrays.nditer.rst
+++ b/doc/source/reference/arrays.nditer.rst
@@ -85,9 +85,12 @@ By default, the :class:`nditer` treats the input array as a read-only
 object. To modify the array elements, you must specify either read-write
 or write-only mode. This is controlled with per-operand flags. The
 operands may be created as views into the original data with the 
-`WRITEBACKIFCOPY` flag. In this case the iterator must be used as a context
-manager, and the temporary data will be written back to the original array
-when the `__exit__` function is called.
+`WRITEBACKIFCOPY` flag. In this case the iterator must either
+
+- be used as a context manager, and the temporary data will be written back
+  to the original array when the `__exit__` function is called.
+- have a call to the iterator's `close` function to ensure the modified data
+  is written back to the original array.
 
 Regular assignment in Python simply changes a reference in the local or
 global variable dictionary instead of modifying an existing variable in

--- a/doc/source/reference/arrays.nditer.rst
+++ b/doc/source/reference/arrays.nditer.rst
@@ -83,7 +83,11 @@ Modifying Array Values
 
 By default, the :class:`nditer` treats the input array as a read-only
 object. To modify the array elements, you must specify either read-write
-or write-only mode. This is controlled with per-operand flags.
+or write-only mode. This is controlled with per-operand flags. The
+operands may be created as views into the original data with the 
+`WRITEBACKIFCOPY` flag. In this case the iterator must be used as a context
+manager, and the temporary data will be written back to the original array
+when the `__exit__` function is called.
 
 Regular assignment in Python simply changes a reference in the local or
 global variable dictionary instead of modifying an existing variable in
@@ -99,8 +103,9 @@ the ellipsis.
     >>> a
     array([[0, 1, 2],
            [3, 4, 5]])
-    >>> for x in np.nditer(a, op_flags=['readwrite']):
-    ...     x[...] = 2 * x
+    >>> with np.nditer(a, op_flags=['readwrite']) as it:
+    ...    for x in it:
+    ...        x[...] = 2 * x
     ...
     >>> a
     array([[ 0,  2,  4],
@@ -178,9 +183,10 @@ construct in order to be more readable.
     0 <(0, 0)> 1 <(0, 1)> 2 <(0, 2)> 3 <(1, 0)> 4 <(1, 1)> 5 <(1, 2)>
 
     >>> it = np.nditer(a, flags=['multi_index'], op_flags=['writeonly'])
-    >>> while not it.finished:
-    ...     it[0] = it.multi_index[1] - it.multi_index[0]
-    ...     it.iternext()
+    >>> with it: 
+    ....    while not it.finished:
+    ...         it[0] = it.multi_index[1] - it.multi_index[0]
+    ...         it.iternext()
     ...
     >>> a
     array([[ 0,  1,  2],
@@ -426,9 +432,10 @@ reasons.
     ...             flags = ['external_loop', 'buffered'],
     ...             op_flags = [['readonly'],
     ...                         ['writeonly', 'allocate', 'no_broadcast']])
-    ...     for x, y in it:
-    ...         y[...] = x*x
-    ...     return it.operands[1]
+    ...     with it:
+    ...         for x, y in it:
+    ...             y[...] = x*x
+    ...         return it.operands[1]
     ...
 
     >>> square([1,2,3])
@@ -505,9 +512,10 @@ For a simple example, consider taking the sum of all elements in an array.
 
     >>> a = np.arange(24).reshape(2,3,4)
     >>> b = np.array(0)
-    >>> for x, y in np.nditer([a, b], flags=['reduce_ok', 'external_loop'],
-    ...                     op_flags=[['readonly'], ['readwrite']]):
-    ...     y[...] += x
+    >>> with np.nditer([a, b], flags=['reduce_ok', 'external_loop'],
+    ...                     op_flags=[['readonly'], ['readwrite']]) as it:
+    ...     for x,y in it:
+    ...         y[...] += x
     ...
     >>> b
     array(276)
@@ -525,11 +533,12 @@ sums along the last axis of `a`.
     >>> it = np.nditer([a, None], flags=['reduce_ok', 'external_loop'],
     ...             op_flags=[['readonly'], ['readwrite', 'allocate']],
     ...             op_axes=[None, [0,1,-1]])
-    >>> it.operands[1][...] = 0
-    >>> for x, y in it:
-    ...     y[...] += x
+    >>> with it:
+    ...     it.operands[1][...] = 0
+    ...     for x, y in it:
+    ...         y[...] += x
     ...
-    >>> it.operands[1]
+    ...     it.operands[1]
     array([[ 6, 22, 38],
            [54, 70, 86]])
     >>> np.sum(a, axis=2)
@@ -558,12 +567,13 @@ buffering.
     ...                                  'buffered', 'delay_bufalloc'],
     ...             op_flags=[['readonly'], ['readwrite', 'allocate']],
     ...             op_axes=[None, [0,1,-1]])
-    >>> it.operands[1][...] = 0
-    >>> it.reset()
-    >>> for x, y in it:
-    ...     y[...] += x
+    >>> with it:
+    ...     it.operands[1][...] = 0
+    ...     it.reset()
+    ...     for x, y in it:
+    ...         y[...] += x
     ...
-    >>> it.operands[1]
+    ...     it.operands[1]
     array([[ 6, 22, 38],
            [54, 70, 86]])
 
@@ -609,11 +619,12 @@ Here's how this looks.
     ...                 op_flags=[['readonly'], ['readwrite', 'allocate']],
     ...                 op_axes=[None, axeslist],
     ...                 op_dtypes=['float64', 'float64'])
-    ...     it.operands[1][...] = 0
-    ...     it.reset()
-    ...     for x, y in it:
-    ...         y[...] += x*x
-    ...     return it.operands[1]
+    ...     with it:
+    ...         it.operands[1][...] = 0
+    ...         it.reset()
+    ...         for x, y in it:
+    ...             y[...] += x*x
+    ...         return it.operands[1]
     ...
     >>> a = np.arange(6).reshape(2,3)
     >>> sum_squares_py(a)
@@ -661,16 +672,17 @@ Here's the listing of sum_squares.pyx::
                     op_flags=[['readonly'], ['readwrite', 'allocate']],
                     op_axes=[None, axeslist],
                     op_dtypes=['float64', 'float64'])
-        it.operands[1][...] = 0
-        it.reset()
-        for xarr, yarr in it:
-            x = xarr
-            y = yarr
-            size = x.shape[0]
-            for i in range(size):
-               value = x[i]
-               y[i] = y[i] + value * value
-        return it.operands[1]
+        with it:
+            it.operands[1][...] = 0
+            it.reset()
+            for xarr, yarr in it:
+                x = xarr
+                y = yarr
+                size = x.shape[0]
+                for i in range(size):
+                   value = x[i]
+                   y[i] = y[i] + value * value
+            return it.operands[1]
 
 On this machine, building the .pyx file into a module looked like the
 following, but you may have to find some Cython tutorials to tell you

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -553,7 +553,7 @@ add_newdoc('numpy.core', 'nditer', ('close',
     """
     close()
 
-    Resolve all writeback semantics in operands.
+    Resolve all writeback semantics in writeable operands.
 
     """))
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -392,10 +392,11 @@ add_newdoc('numpy.core', 'nditer',
         ...        [['writeonly', 'updateifcopy']],
         ...        casting='unsafe',
         ...        op_dtypes=[np.dtype('f4')]) as i:
-        ...    i.operands[0][:] = [-1, -2, -3]
+        ...    x = i.operands[0]
+        ...    x[:] = [-1, -2, -3]
         ...    # a still unchanged here
-        >>> a
-        array([-1, -2, -3])
+        >>> a, x
+        array([-1, -2, -3]), array([-1, -2, -3])
 
     It is important to note that once the iterator is exited, dangling
     references (like `x` in the example) may or may not share data with

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -319,8 +319,9 @@ add_newdoc('numpy.core', 'nditer',
             addop = np.add
             it = np.nditer([x, y, out], [],
                         [['readonly'], ['readonly'], ['writeonly','allocate']])
-            for (a, b, c) in it:
-                addop(a, b, out=c)
+            with it:
+                for (a, b, c) in it:
+                    addop(a, b, out=c)
             return it.operands[2]
 
     Here is the same function, but following the C-style pattern::
@@ -344,13 +345,12 @@ add_newdoc('numpy.core', 'nditer',
 
             it = np.nditer([x, y, out], ['external_loop'],
                     [['readonly'], ['readonly'], ['writeonly', 'allocate']],
-                    op_axes=[range(x.ndim)+[-1]*y.ndim,
-                             [-1]*x.ndim+range(y.ndim),
+                    op_axes=[list(range(x.ndim)) + [-1] * y.ndim,
+                             [-1] * x.ndim + list(range(y.ndim)),
                              None])
-
-            for (a, b, c) in it:
-                mulop(a, b, out=c)
-
+            with it:
+                for (a, b, c) in it:
+                    mulop(a, b, out=c)
             return it.operands[2]
 
         >>> a = np.arange(2)+1
@@ -380,6 +380,31 @@ add_newdoc('numpy.core', 'nditer',
         >>> b = np.ones(5)
         >>> luf(lambda i,j:i*i + j/2, a, b)
         array([  0.5,   1.5,   4.5,   9.5,  16.5])
+
+    If operand flags `"writeonly"` or `"readwrite"` are used the operands may
+    be views into the original data with the WRITEBACKIFCOPY flag. In this case
+    nditer must be used as a context manager. The temporary
+    data will be written back to the original data when the `` __exit__``
+    function is called but not before::
+
+        >>> a = np.arange(6, dtype='i4')[::-2]
+        >>> with nditer(a, [],
+        ...        [['writeonly', 'updateifcopy']],
+        ...        casting='unsafe',
+        ...        op_dtypes=[np.dtype('f4')]) as i:
+        ...    i.operands[0][:] = [-1, -2, -3]
+        ...    # a still unchanged here
+        >>> a
+        array([-1, -2, -3])
+
+    It is important to note that once the iterator is exited, dangling
+    references (like `x` in the example) may or may not share data with
+    the original data `a`. If writeback semantics were active, i.e. if
+    `x.base.flags.writebackifcopy` is `True`, then exiting the iterator
+     will sever the connection between `x` and `a`, writing to `x` will
+    no longer write to `a`. If writeback semantics are not active, then
+    `x.data` will still point at some part of `a.data`, and writing to
+    one will affect the other.
 
     """)
 
@@ -524,6 +549,13 @@ add_newdoc('numpy.core', 'nested_iters',
 
     """)
 
+add_newdoc('numpy.core', 'nditer', ('close',
+    """
+    close()
+
+    Resolve all writeback semantics in operands.
+
+    """))
 
 
 ###############################################################################

--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -41,3 +41,6 @@
 # Version 12 (NumPy 1.14) Added PyArray_ResolveWritebackIfCopy,
 # PyArray_SetWritebackIfCopyBase and deprecated PyArray_SetUpdateIfCopyBase.
 0x0000000c = a1bc756c5782853ec2e3616cf66869d8
+
+# Version 13 (NumPy 1.15) Added NpyIter_Close
+0x0000000d = 4386e829d65aafce6bd09a85b142d585

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -5,7 +5,8 @@ Each dictionary contains name -> index pair.
 
 Whenever you change one index, you break the ABI (and the ABI version number
 should be incremented). Whenever you add an item to one of the dict, the API
-needs to be updated.
+needs to be updated in both setup_common.py and by adding an appropriate
+entry to cversion.txt (generate the hash via "python cversions.py".
 
 When adding a function, make sure to use the next integer not used as an index
 (in case you use an existing index or jump, the build will stop and raise an
@@ -349,6 +350,8 @@ multiarray_funcs_api = {
     'PyArray_ResolveWritebackIfCopy':       (302,),
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
+    'NpyIter_Close':                        (304,),
+    # End 1.15 API
 }
 
 ufunc_types_api = {

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -40,7 +40,8 @@ C_ABI_VERSION = 0x01000009
 # 0x0000000a - 1.12.x
 # 0x0000000b - 1.13.x
 # 0x0000000c - 1.14.x
-C_API_VERSION = 0x0000000c
+# 0x0000000d - 1.15.x
+C_API_VERSION = 0x0000000d
 
 class MismatchCAPIWarning(Warning):
     pass

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -657,6 +657,24 @@ npy_create_writebackifcopy(PyObject* NPY_UNUSED(self), PyObject* args)
     return array;
 }
 
+/* used to test WRITEBACKIFCOPY without resolution emits runtime warning */
+static PyObject*
+npy_abuse_writebackifcopy(PyObject* NPY_UNUSED(self), PyObject* args)
+{
+    int flags;
+    PyObject* array;
+    if (!PyArray_Check(args)) {
+        PyErr_SetString(PyExc_TypeError, "test needs ndarray input");
+        return NULL;
+    }
+    flags = NPY_ARRAY_CARRAY | NPY_ARRAY_WRITEBACKIFCOPY;
+    array = PyArray_FromArray((PyArrayObject*)args, NULL, flags);
+    if (array == NULL)
+        return NULL;
+    Py_DECREF(array); /* calls array_dealloc even on PyPy */
+    Py_RETURN_NONE;
+}
+
 /* resolve WRITEBACKIFCOPY */
 static PyObject*
 npy_resolve(PyObject* NPY_UNUSED(self), PyObject* args)
@@ -1009,6 +1027,75 @@ test_nditer_too_large(PyObject *NPY_UNUSED(self), PyObject *args) {
     return NULL;
 }
 
+static PyObject *
+test_nditer_writeback(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
+{
+    /* like npyiter_init */
+    PyObject *op_in = NULL, *op_dtypes_in = NULL, *value = NULL;
+    PyArrayObject * opview;
+    int iop, nop = 0;
+    PyArrayObject *op[NPY_MAXARGS];
+    npy_uint32 flags = 0;
+    NPY_ORDER order = NPY_KEEPORDER;
+    NPY_CASTING casting = NPY_EQUIV_CASTING;
+    npy_uint32 op_flags[NPY_MAXARGS];
+    PyArray_Descr *op_request_dtypes[NPY_MAXARGS];
+    int retval;
+    unsigned char do_close;
+    int buffersize = 0;
+    NpyIter *iter = NULL;
+    static char *kwlist[] = {"value", "do_close", "input", "op_dtypes", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                    "ObO|O:test_nditer_writeback", kwlist,
+                    &value,
+                    &do_close,
+                    &op_in,
+                    &op_dtypes_in)) {
+        return NULL;
+    }
+    /* op and op_flags */
+    if (! PyArray_Check(op_in)) {
+        return NULL;
+    }
+    nop = 1;
+    op[0] = (PyArrayObject*)op_in;
+    op_flags[0] = NPY_ITER_READWRITE|NPY_ITER_UPDATEIFCOPY;
+
+    /* Set the dtypes */
+    for (iop=0; iop<nop; iop++) {
+        PyObject *dtype = PySequence_GetItem(op_dtypes_in, iop);
+        PyArray_DescrConverter2(dtype, &op_request_dtypes[iop]);
+    }
+
+    iter = NpyIter_AdvancedNew(nop, op, flags, order, casting, op_flags,
+                                  op_request_dtypes,
+                                  -1, NULL, NULL,
+                                  buffersize);
+    if (iter == NULL) {
+        goto fail;
+    }
+
+    opview = NpyIter_GetIterView(iter, 0);
+    retval = PyArray_FillWithScalar(opview, value);
+    Py_DECREF(opview);
+    if (retval < 0) {
+        NpyIter_Deallocate(iter);
+        return NULL;
+    }
+    if (do_close != 0) {
+        NpyIter_Close(iter);
+    }
+    NpyIter_Deallocate(iter);
+    Py_RETURN_NONE;
+
+fail:
+    for (iop = 0; iop < nop; ++iop) {
+        Py_XDECREF(op[iop]);
+        Py_XDECREF(op_request_dtypes[iop]);
+    }
+    return NULL;
+}
 
 static PyObject *
 array_solve_diophantine(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
@@ -1764,6 +1851,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"npy_create_writebackifcopy",
         npy_create_writebackifcopy,
         METH_O, NULL},
+    {"npy_abuse_writebackifcopy",
+        npy_abuse_writebackifcopy,
+        METH_O, NULL},
     {"npy_resolve",
         npy_resolve,
         METH_O, NULL},
@@ -1784,6 +1874,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"test_nditer_too_large",
         test_nditer_too_large,
         METH_VARARGS, NULL},
+    {"test_nditer_writeback",
+        (PyCFunction)test_nditer_writeback,
+        METH_VARARGS | METH_KEYWORDS, NULL},
     {"solve_diophantine",
         (PyCFunction)array_solve_diophantine,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -497,7 +497,7 @@ array_dealloc(PyArrayObject *self)
         }
         if (PyArray_FLAGS(self) & NPY_ARRAY_UPDATEIFCOPY) {
             /* DEPRECATED, remove once the flag is removed */
-            char const * msg = "ERROR: UPDATEIFCOPY detected in array_dealloc. "
+            char const * msg = "UPDATEIFCOPY detected in array_dealloc. "
                 " Required call to PyArray_ResolveWritebackIfCopy or "
                 "PyArray_DiscardWritebackIfCopy is missing";
             Py_INCREF(self); /* hold on to self in next call  since if

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1014,7 +1014,7 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     }
     else {
         fa->flags = (flags & ~NPY_ARRAY_WRITEBACKIFCOPY);
-        fa->flags = (fa->flags & ~NPY_ARRAY_UPDATEIFCOPY);
+        fa->flags &= ~NPY_ARRAY_UPDATEIFCOPY;
     }
     fa->descr = descr;
     fa->base = (PyObject *)NULL;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3374,6 +3374,7 @@ PyArray_MapIterArray(PyArrayObject * a, PyObject * index)
 static void
 arraymapiter_dealloc(PyArrayMapIterObject *mit)
 {
+    PyArray_ResolveWritebackIfCopy(mit->array);
     Py_XDECREF(mit->array);
     Py_XDECREF(mit->ait);
     Py_XDECREF(mit->subspace);

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1391,6 +1391,47 @@ NpyIter_GetInnerLoopSizePtr(NpyIter *iter)
 }
 
 /*NUMPY_API
+ * Resolves all writebackifcopy scratch buffers, not safe to use iterator
+ * operands after this call, in this iterator as well as any copies.
+ * Returns 0 on success, -1 on failure
+ */
+NPY_NO_EXPORT int
+NpyIter_Close(NpyIter *iter)
+{
+    int ret=0, iop, nop;
+    PyArrayObject ** operands;
+    npyiter_opitflags *op_itflags;
+    if (iter == NULL) {
+        return 0;
+    }
+    nop = NIT_NOP(iter);
+    operands = NIT_OPERANDS(iter);
+    op_itflags = NIT_OPITFLAGS(iter);
+    /* If NPY_OP_ITFLAG_HAS_WRITEBACK flag set on operand, resolve it.
+     * If the resolution fails (should never happen), continue from the
+     * next operand and discard the writeback scratch buffers, and return
+     * failure status
+     */
+    for (iop=0; iop<nop; iop++) {
+        if (op_itflags[iop] & NPY_OP_ITFLAG_HAS_WRITEBACK) {
+            op_itflags[iop] &= ~NPY_OP_ITFLAG_HAS_WRITEBACK;
+            if (PyArray_ResolveWritebackIfCopy(operands[iop]) < 0) {
+                ret = -1;
+                iop++;
+                break;
+            }
+        }
+    }
+    for (; iop<nop; iop++) {
+        if (op_itflags[iop] & NPY_OP_ITFLAG_HAS_WRITEBACK) {
+            op_itflags[iop] &= ~NPY_OP_ITFLAG_HAS_WRITEBACK;
+            PyArray_DiscardWritebackIfCopy(operands[iop]);
+        }
+    }
+    return ret;
+}
+
+/*NUMPY_API
  * For debugging
  */
 NPY_NO_EXPORT void
@@ -2799,5 +2840,4 @@ npyiter_checkreducesize(NpyIter *iter, npy_intp count,
     }
     return count * (*reduce_innersize);
 }
-
 #undef NPY_ITERATOR_IMPLEMENTATION_CODE

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -124,6 +124,8 @@
 #define NPY_OP_ITFLAG_USINGBUFFER  0x0100
 /* The operand must be copied (with UPDATEIFCOPY if also ITFLAG_WRITE) */
 #define NPY_OP_ITFLAG_FORCECOPY    0x0200
+/* The operand has temporary data, write it back at dealloc */
+#define NPY_OP_ITFLAG_HAS_WRITEBACK 0x0400
 
 /*
  * The data layout of the iterator is fully specified by

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -29,7 +29,6 @@ struct NewNpyArrayIterObject_tag {
     /* Flag indicating iteration started/stopped */
     char started, finished;
     /* iter must used as a context manager if writebackifcopy semantics used */
-    char needs_context_manager;
     char managed;
     /* Child to update for nested iteration */
     NewNpyArrayIterObject *nested_child;
@@ -91,7 +90,6 @@ npyiter_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
         self->iter = NULL;
         self->nested_child = NULL;
         self->managed = CONTEXT_NOTENTERED;
-        self->needs_context_manager = 0;
     }
 
     return (PyObject *)self;
@@ -825,13 +823,6 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
 
     if (self->iter == NULL) {
         goto fail;
-    }
-
-    for (iop = 0; iop < nop; ++iop) {
-        if (op_flags[iop] & NPY_ITER_READWRITE) {
-            self->needs_context_manager = 1;
-        }
-
     }
 
     /* Cache some values for the member functions to use */

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2421,19 +2421,26 @@ npyiter_enter(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_exit(NewNpyArrayIterObject *self, PyObject *args)
+npyiter_close(NewNpyArrayIterObject *self)
 {
-    int retval;
+    NpyIter *iter = self->iter;
+    int ret;
     if (self->iter == NULL) {
         Py_RETURN_NONE;
     }
-    self->managed = CONTEXT_EXITED;
-    /* even if called via exception handling, writeback any data */
-    retval = NpyIter_Close(self->iter);
-    if (retval < 0) {
+    ret = NpyIter_Close(iter);
+    if (ret < 0) {
         return NULL;
     }
     Py_RETURN_NONE;
+}
+
+static PyObject *
+npyiter_exit(NewNpyArrayIterObject *self, PyObject *args)
+{
+    self->managed = CONTEXT_EXITED;
+    /* even if called via exception handling, writeback any data */
+    return npyiter_close(self);
 }
 
 static PyMethodDef npyiter_methods[] = {
@@ -2464,6 +2471,8 @@ static PyMethodDef npyiter_methods[] = {
     {"__enter__", (PyCFunction)npyiter_enter,
          METH_NOARGS,  NULL},
     {"__exit__",  (PyCFunction)npyiter_exit,
+         METH_VARARGS, NULL},
+    {"close",  (PyCFunction)npyiter_close,
          METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL},
 };

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7258,6 +7258,13 @@ class TestWritebackIfCopy(object):
         arr_wb[:] = 100
         assert_equal(arr, -100)
 
+    def test_dealloc_warning(self):
+        with suppress_warnings() as sup:
+            sup.record(RuntimeWarning)
+            arr = np.arange(9).reshape(3, 3)
+            v = arr.T
+            _multiarray_tests.npy_abuse_writebackifcopy(v)
+            assert len(sup.log) == 1
 
 class TestArange(object):
     def test_infinite(self):

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -123,9 +123,12 @@ def _broadcast_to(array, shape, subok, readonly):
     needs_writeable = not readonly and array.flags.writeable
     extras = ['reduce_ok'] if needs_writeable else []
     op_flag = 'readwrite' if needs_writeable else 'readonly'
-    broadcast = np.nditer(
+    it = np.nditer(
         (array,), flags=['multi_index', 'refs_ok', 'zerosize_ok'] + extras,
-        op_flags=[op_flag], itershape=shape, order='C').itviews[0]
+        op_flags=[op_flag], itershape=shape, order='C')
+    with it:
+        # never really has writebackifcopy semantics
+        broadcast = it.itviews[0]
     result = _maybe_view_as_subclass(array, broadcast)
     if needs_writeable and not result.flags.writeable:
         result.flags.writeable = True


### PR DESCRIPTION
Resolves issue #9714 by enabling use of nditer as a context manager. Code like this:
```
a = np.arange(24, dtype='f8').reshape(2, 3, 4).T
it = np.nditer(a, [], [['readwrite', 'updateifcopy']],
            casting='same_kind', op_dtypes=[np.dtype('f4')])
# Check that UPDATEIFCOPY is activated
it.operands[0][2, 1, 1] = -12.5
assert  a[2, 1, 1] != -12.5
it = None                     # magic!!!
assert a[2, 1, 1] == -12.5
```
now becomes
```
a = np.arange(24, dtype='f8').reshape(2, 3, 4).T
with np.nditer(a, [], [['readwrite', 'updateifcopy']],
            casting='same_kind', op_dtypes=[np.dtype('f4')]) as it:
    # Check that UPDATEIFCOPY is activated
    it.operands[0][2, 1, 1] = -12.5
    assert  a[2, 1, 1] != -12.5
assert a[2, 1, 1] == -12.5
```
No more need to do the ``it = None`` assignment to write the data back to the original array. Tests were adjusted. In addition, DeprecationWarning will be raised if a nditer should be using this code pattern and is not, or if the nditer ``it`` is used outside the context manager.

This also allows completing the confusing part of pull request #9639, and now any call to ``PyArray_SetUpdateIfCopyBase`` will emit a DeprecationWarning.

I am not really happy with the way this affects ``nested_iters``, since it returns a tuple there is no convienient way to handle the context manager there, that is why the test tweak is in a seperate commit.