### PR TITLE
ENH: Make `np.in1d()` work for unorderable object arrays

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -449,13 +449,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar2 = np.asarray(ar2).ravel()
 
     # Check if one of the arrays is of type object
-    is_object = ar1.dtype == np.dtype('O') or ar2.dtype == np.dtype('O')
+    contains_object = ar1.dtype.hasobject or ar2.dtype.hasobject
 
     # This code is run when
     # a) the first condition is true, making the code significantly faster
     # b) the second condition is true (i.e. `ar1` or `ar2` are of type
     #    object), since sorting object arrays is not guaranteed to work
-    if len(ar2) < 10 * len(ar1) ** 0.145 or is_object:
+    if len(ar2) < 10 * len(ar1) ** 0.145 or contains_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
             for a in ar2:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -449,10 +449,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar2 = np.asarray(ar2).ravel()
 
     # This code is run when
-    # a) the first condition is true, making the test significantly faster
-    # b) the second condition is true (i.e. `ar2` is of dtype `object`), since
-    # sorting object arrays is not guaranteed to work
-    if len(ar2) < 10 * len(ar1) ** 0.145 or ar2.dtype == np.dtype('O'):
+    # a) the first condition is true, making the code significantly faster
+    # b) the second condition is true (i.e. `ar1` or `ar2` are of dtype
+    # `object`), since sorting object arrays is not guaranteed to work
+    is_object = ar1.dtype == np.dtype('O') or ar2.dtype == np.dtype('O')
+    if len(ar2) < 10 * len(ar1) ** 0.145 or is_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
             for a in ar2:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -448,11 +448,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
 
+    # Check if one of the arrays is of type object
+    is_object = ar1.dtype == np.dtype('O') or ar2.dtype == np.dtype('O')
+
     # This code is run when
     # a) the first condition is true, making the code significantly faster
-    # b) the second condition is true (i.e. `ar1` or `ar2` are of dtype
-    # `object`), since sorting object arrays is not guaranteed to work
-    is_object = ar1.dtype == np.dtype('O') or ar2.dtype == np.dtype('O')
+    # b) the second condition is true (i.e. `ar1` or `ar2` are of type
+    #    object), since sorting object arrays is not guaranteed to work
     if len(ar2) < 10 * len(ar1) ** 0.145 or is_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -448,8 +448,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
 
-    # This code is significantly faster when the condition is satisfied.
-    if len(ar2) < 10 * len(ar1) ** 0.145:
+    # This code is run when
+    # a) the first condition is true, making the test significantly faster
+    # b) the second condition is true (i.e. `ar2` is of dtype `object`), since
+    # sorting object arrays is not guaranteed to work
+    if len(ar2) < 10 * len(ar1) ** 0.145 or ar2.dtype == np.dtype('O'):
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
             for a in ar2:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -448,13 +448,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
 
-    # Check if one of the arrays is of type object
+    # Check if one of the arrays may contain objects
     contains_object = ar1.dtype.hasobject or ar2.dtype.hasobject
 
     # This code is run when
     # a) the first condition is true, making the code significantly faster
-    # b) the second condition is true (i.e. `ar1` or `ar2` are of type
-    #    object), since sorting object arrays is not guaranteed to work
+    # b) the second condition is true (i.e. `ar1` or `ar2` may contain
+    #    objects), since sorting object arrays is not guaranteed to work
     if len(ar2) < 10 * len(ar1) ** 0.145 or contains_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -448,13 +448,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
 
-    # Check if one of the arrays may contain objects
+    # Check if one of the arrays may contain arbitrary objects
     contains_object = ar1.dtype.hasobject or ar2.dtype.hasobject
 
     # This code is run when
     # a) the first condition is true, making the code significantly faster
     # b) the second condition is true (i.e. `ar1` or `ar2` may contain
-    #    objects), since sorting object arrays is not guaranteed to work
+    #    arbitrary objects), since then sorting is not guaranteed to work
     if len(ar2) < 10 * len(ar1) ** 0.145 or contains_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -233,8 +233,8 @@ class TestSetOps(object):
         # Test arrays of a structured data type containing an integer field
         # and a field of dtype `object` allowing for arbitrary Python objects
         dt = np.dtype([('field1', int), ('field2', object)])
-        ar1 = np.array([(1, 2)], dtype=dt)
-        ar2 = np.array([(1, 2)]*10, dtype=dt)
+        ar1 = np.array([(1, None)], dtype=dt)
+        ar2 = np.array([(1, None)]*10, dtype=dt)
         expected = np.array([True])
         result = np.in1d(ar1, ar2)
         assert_array_equal(result, expected)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -229,6 +229,16 @@ class TestSetOps(object):
         result = np.in1d(ar1, ar2)
         assert_array_equal(result, expected)
 
+    def test_in1d_both_arrays_have_structured_dtype(self):
+        # Test arrays of a structured data type containing an integer field
+        # and a field of dtype `object` allowing for arbitrary Python objects
+        dt = np.dtype([('field1', int), ('field2', object)])
+        ar1 = np.array([(1, 2)], dtype=dt)
+        ar2 = np.array([(1, 2)]*10, dtype=dt)
+        expected = np.array([True])
+        result = np.in1d(ar1, ar2)
+        assert_array_equal(result, expected)
+
     def test_union1d(self):
         a = np.array([5, 4, 7, 1, 2])
         b = np.array([2, 4, 3, 3, 2, 1, 5])

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -208,10 +208,26 @@ class TestSetOps(object):
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
 
-    def test_in1d_unorderable_types(self):
+    def test_in1d_first_array_is_object(self):
+        ar1 = [None]
+        ar2 = np.array([1]*10)
+        expected = np.array([False])
+        result = np.in1d(ar1, ar2)
+        assert_equal(result, expected)
+
+    def test_in1d_second_array_is_object(self):
         ar1 = 1
         ar2 = np.array([None]*10)
-        np.in1d(ar1, ar2)
+        expected = np.array([False])
+        result = np.in1d(ar1, ar2)
+        assert_equal(result, expected)
+
+    def test_in1d_both_arrays_are_object(self):
+        ar1 = [None]
+        ar2 = np.array([None]*10)
+        expected = np.array([True])
+        result = np.in1d(ar1, ar2)
+        assert_equal(result, expected)
 
     def test_union1d(self):
         a = np.array([5, 4, 7, 1, 2])

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -208,6 +208,11 @@ class TestSetOps(object):
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
 
+    def test_in1d_unorderable_types(self):
+        ar1 = 1
+        ar2 = np.array([None]*10)
+        np.in1d(ar1, ar2)
+
     def test_union1d(self):
         a = np.array([5, 4, 7, 1, 2])
         b = np.array([2, 4, 3, 3, 2, 1, 5])

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -213,21 +213,21 @@ class TestSetOps(object):
         ar2 = np.array([1]*10)
         expected = np.array([False])
         result = np.in1d(ar1, ar2)
-        assert_equal(result, expected)
+        assert_array_equal(result, expected)
 
     def test_in1d_second_array_is_object(self):
         ar1 = 1
         ar2 = np.array([None]*10)
         expected = np.array([False])
         result = np.in1d(ar1, ar2)
-        assert_equal(result, expected)
+        assert_array_equal(result, expected)
 
     def test_in1d_both_arrays_are_object(self):
         ar1 = [None]
         ar2 = np.array([None]*10)
         expected = np.array([True])
         result = np.in1d(ar1, ar2)
-        assert_equal(result, expected)
+        assert_array_equal(result, expected)
 
     def test_union1d(self):
         a = np.array([5, 4, 7, 1, 2])


### PR DESCRIPTION
Fixes #9914 

`np.in1d()` sorts large input arrays for efficiency reasons. However, the sorting throws an error when one of the input arrays contains objects that are not orderable:

```python
>>> np.isin(1, [None]*10)
TypeError: unorderable types: NoneType() < NoneType()
>>> np.isin([None], [1]*10)
TypeError: unorderable types: int() < NoneType()
```

Fix: Do not use sorting whenever one of the input arrays may contain arbitrary objects (`dtype.hasobject == True`).

