### PR TITLE
MAINT: Fix test_int_from_huge_longdouble on Darwin.

### DIFF
--- a/numpy/core/src/private/npy_longdouble.c
+++ b/numpy/core/src/private/npy_longdouble.c
@@ -13,7 +13,8 @@
     } while (0)
 
 
-/* Heavily derived from PyLong_FromDouble
+/*
+ * Heavily derived from PyLong_FromDouble
  * Notably, we can't set the digits directly, so have to shift and or instead.
  */
 PyObject *
@@ -21,8 +22,10 @@ npy_longdouble_to_PyLong(npy_longdouble ldval)
 {
     PyObject *v;
     PyObject *l_chunk_size;
-    // number of bits to extract at a time. CPython uses 30, but that's because
-    // it's tied to the internal long representation
+    /*
+     * number of bits to extract at a time. CPython uses 30, but that's because
+     * it's tied to the internal long representation
+     */
     const int chunk_size = NPY_BITSOF_LONGLONG;
     npy_longdouble frac;
     int i, ndig, expo, neg;

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -422,10 +422,11 @@ class TestConversion(object):
 
     @dec.skipif(np.finfo(np.double) == np.finfo(np.longdouble))
     def test_int_from_huge_longdouble(self):
-        # produce a longdouble that would overflow a double
-        exp = np.finfo(np.double).maxexp
-        huge_ld = 1234 * np.longdouble(2) ** exp
-        huge_i = 1234 * 2 ** exp
+        # Produce a longdouble that would overflow a double,
+        # use exponent that avoids bug in Darwin pow function.
+        exp = np.finfo(np.double).maxexp - 1
+        huge_ld = 2 * 1234 * np.longdouble(2) ** exp
+        huge_i = 2 * 1234 * 2 ** exp
         assert_(huge_ld != np.inf)
         assert_equal(int(huge_ld), huge_i)
 


### PR DESCRIPTION
The test was failing on Darwin due to Apple's defective pow function.
The fix here is to generate the huge longdouble that is tested in a way
that avoids the problems of the pow function.

The C++ comments in npy_longdouble.c are also fixed.

The fix has been tested on a Mac.