### PR TITLE
MAINT: Backcompat fixes for dragon4 changes

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -403,6 +403,10 @@ elements uniquely.
 Numpy complex-floating-scalars with values like ``inf*j`` or ``nan*j`` now
 print as ``infj`` and ``nanj``, like the pure-python ``complex`` type.
 
+The ``FloatFormat`` and ``LongFloatFormat`` classes are deprecated and should
+both be replaced by ``FloatingFormat``. Similarly ``ComplexFormat`` and
+``LongComplexFormat`` should be replaced by ``ComplexFloatingFormat``.
+
 ``void`` datatype elements are now printed in hex notation
 ----------------------------------------------------------
 A hex representation compatible with the python ``bytes`` type is now printed

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -305,7 +305,11 @@ def _get_formatdict(data, **opt):
         'int': lambda: IntegerFormat(data),
         'float': lambda:
             FloatingFormat(data, prec, fmode, supp, sign, legacy=legacy),
+        'longfloat': lambda:
+            FloatingFormat(data, prec, fmode, supp, sign, legacy=legacy),
         'complexfloat': lambda:
+            ComplexFloatingFormat(data, prec, fmode, supp, sign, legacy=legacy),
+        'longcomplexfloat': lambda:
             ComplexFloatingFormat(data, prec, fmode, supp, sign, legacy=legacy),
         'datetime': lambda: DatetimeFormat(data),
         'timedelta': lambda: TimedeltaFormat(data),
@@ -329,7 +333,7 @@ def _get_formatdict(data, **opt):
             for key in ['int']:
                 formatdict[key] = indirect(formatter['int_kind'])
         if 'float_kind' in fkeys:
-            for key in ['half', 'float', 'longfloat']:
+            for key in ['float', 'longfloat']:
                 formatdict[key] = indirect(formatter['float_kind'])
         if 'complex_kind' in fkeys:
             for key in ['complexfloat', 'longcomplexfloat']:
@@ -361,9 +365,15 @@ def _get_format_function(data, **options):
         else:
             return formatdict['int']()
     elif issubclass(dtypeobj, _nt.floating):
-        return formatdict['float']()
+        if issubclass(dtypeobj, _nt.longfloat):
+            return formatdict['longfloat']()
+        else:
+            return formatdict['float']()
     elif issubclass(dtypeobj, _nt.complexfloating):
-        return formatdict['complexfloat']()
+        if issubclass(dtypeobj, _nt.clongfloat):
+            return formatdict['longcomplexfloat']()
+        else:
+            return formatdict['complexfloat']()
     elif issubclass(dtypeobj, (_nt.unicode_, _nt.string_)):
         return formatdict['numpystr']()
     elif issubclass(dtypeobj, _nt.datetime64):
@@ -805,6 +815,20 @@ class FloatingFormat(object):
                                       pad_left=self.pad_left,
                                       pad_right=self.pad_right)
 
+# for back-compatibility, we keep the classes for each float type too
+class FloatFormat(FloatingFormat):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("FloatFormat has been replaced by FloatingFormat",
+                      DeprecationWarning, stacklevel=2)
+        super(FloatFormat, self).__init__(*args, **kwargs)
+
+
+class LongFloatFormat(FloatingFormat):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("LongFloatFormat has been replaced by FloatingFormat",
+                      DeprecationWarning, stacklevel=2)
+        super(LongFloatFormat, self).__init__(*args, **kwargs)
+
 
 def format_float_scientific(x, precision=None, unique=True, trim='k',
                             sign=False, pad_left=None, exp_digits=None):
@@ -995,6 +1019,22 @@ class ComplexFloatingFormat(object):
         r = self.real_format(x.real)
         i = self.imag_format(x.imag)
         return r + i + 'j'
+
+# for back-compatibility, we keep the classes for each float type too
+class ComplexFormat(ComplexFloatingFormat):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "ComplexFormat has been replaced by ComplexFloatingFormat",
+            DeprecationWarning, stacklevel=2)
+        super(ComplexFormat, self).__init__(*args, **kwargs)
+
+class LongComplexFormat(ComplexFloatingFormat):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "LongComplexFormat has been replaced by ComplexFloatingFormat",
+            DeprecationWarning, stacklevel=2)
+        super(LongComplexFormat, self).__init__(*args, **kwargs)
+
 
 class DatetimeFormat(object):
     def __init__(self, x, unit=None, timezone=None, casting='same_kind'):

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1020,7 +1020,7 @@ class ComplexFloatingFormat(object):
         i = self.imag_format(x.imag)
         return r + i + 'j'
 
-# for back-compatibility, we keep the classes for each float type too
+# for back-compatibility, we keep the classes for each complex type too
 class ComplexFormat(ComplexFloatingFormat):
     def __init__(self, *args, **kwargs):
         warnings.warn(

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -157,6 +157,12 @@ class TestArray2String(object):
         assert_(np.array2string(s, formatter={'numpystr':lambda s: s*2}) ==
                 '[abcabc defdef]')
 
+        # check for backcompat that using FloatFormat works and emits warning
+        with assert_warns(DeprecationWarning):
+            fmt = np.core.arrayprint.FloatFormat(x, 9, 'maxprec', False)
+        assert_equal(np.array2string(x, formatter={'float_kind': fmt}),
+                     '[0. 1. 2.]')
+
     def test_structure_format(self):
         dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
         x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)


### PR DESCRIPTION
This is a small fixup to the dragon4 changes as suggested by @eric-wieser in #9941. This adds back in the `FloatFormat` classes that I deleted, but deprecates them.

We can also discuss renaming `floatmode` to `float_mode`. I didn't do that because, while it is true that some functions here use underscores, others don't. Eg, we already use `linewidth` and `edgeitems` in the `_format_options` dict and as args to `set_printoptions`.  So I'd argue `floatmode` is the more consistent choice.

It's a little strange we only allow `longdouble` to be separately customizable as a `formatter`, and not any of the other float types, but I guess that's the way it is, no real harm in leaving it so.