### PR TITLE
ENH: Don't show the boolean dtype in array_repr

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -431,7 +431,7 @@ also supports boolean arrays and will work without any surprises.
     ...            [ 9, 10, 11]])
     >>> rows = (x.sum(-1) % 2) == 0
     >>> rows
-    array([False,  True, False,  True], dtype=bool)
+    array([False,  True, False,  True])
     >>> columns = [0, 2]
     >>> x[np.ix_(rows, columns)]
     array([[ 3,  5],

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -99,7 +99,7 @@ Attributes and properties of masked arrays
       ...         mask=[(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)],
       ...        dtype=[('a', int), ('b', int)])
       >>> x.recordmask
-      array([False, False,  True, False, False], dtype=bool)
+      array([False, False,  True, False, False])
 
 
 .. attribute:: MaskedArray.fill_value

--- a/doc/source/reference/maskedarray.generic.rst
+++ b/doc/source/reference/maskedarray.generic.rst
@@ -394,7 +394,7 @@ required to ensure propagation of any modification of the mask to the original.
                 mask = [False False False],
           fill_value = 999999)
    >>> x.mask
-   array([False,  True, False, False,  True], dtype=bool)
+   array([False,  True, False, False,  True])
    >>> x.data
    array([ 1, -1,  3,  4,  5])
 

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -293,7 +293,7 @@ created and filled with the result.
     >>> 10*np.sin(a)
     array([ 9.12945251, -9.88031624,  7.4511316 , -2.62374854])
     >>> a<35
-    array([ True, True, False, False], dtype=bool)
+    array([ True, True, False, False])
 
 Unlike in many matrix languages, the product operator ``*`` operates
 elementwise in NumPy arrays. The matrix product can be performed using
@@ -1176,7 +1176,7 @@ boolean arrays that have *the same shape* as the original array::
     >>> b                                          # b is a boolean with a's shape
     array([[False, False, False, False],
            [False,  True,  True,  True],
-           [ True,  True,  True,  True]], dtype=bool)
+           [ True,  True,  True,  True]])
     >>> a[b]                                       # 1d array with the selected elements
     array([ 5,  6,  7,  8,  9, 10, 11])
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -1512,7 +1512,7 @@ add_newdoc('numpy.core.multiarray', 'where',
     >>> ix
     array([[False, False, False],
            [ True,  True, False],
-           [False,  True, False]], dtype=bool)
+           [False,  True, False]])
     >>> np.where(ix)
     (array([1, 1, 2]), array([0, 1, 1]))
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1135,6 +1135,36 @@ if issubclass(intc, int):
 if issubclass(longlong, int):
     _typelessdata.append(longlong)
 
+
+def dtype_is_implied(dtype):
+    """
+    Determine if the given dtype is implied by the representation of its values.
+
+    Parameters
+    ----------
+    dtype : dtype
+        Data type
+
+    Returns
+    -------
+    implied : bool
+        True if the dtype is implied by the representation of its values.
+
+    Examples
+    --------
+    >>> np.core.arrayprint.dtype_is_implied(int)
+    True
+    >>> np.array([1, 2, 3], int)
+    array([1, 2, 3])
+    >>> np.core.arrayprint.dtype_is_implied(np.int8)
+    False
+    >>> np.array([1, 2, 3], np.int8)
+    array([1, 2, 3], dtype=np.int8)
+    """
+    dtype = np.dtype(dtype)
+    return dtype.type in _typelessdata
+
+
 def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     """
     Return the string representation of an array.
@@ -1190,7 +1220,7 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     else:  # show zero-length shape unless it is (0,)
         lst = "[], shape=%s" % (repr(arr.shape),)
 
-    skipdtype = (arr.dtype.type in _typelessdata) and arr.size > 0
+    skipdtype = dtype_is_implied(arr.dtype) and arr.size > 0
 
     if skipdtype:
         return "%s(%s)" % (class_name, lst)

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1129,7 +1129,7 @@ def _void_scalar_repr(x):
     return StructureFormat.from_data(array(x), **_format_options)(x)
 
 
-_typelessdata = [int_, float_, complex_]
+_typelessdata = [int_, float_, complex_, bool_]
 if issubclass(intc, int):
     _typelessdata.append(intc)
 if issubclass(longlong, int):
@@ -1162,6 +1162,8 @@ def dtype_is_implied(dtype):
     array([1, 2, 3], dtype=np.int8)
     """
     dtype = np.dtype(dtype)
+    if _format_options['legacy'] and dtype.type == bool_:
+        return False
     return dtype.type in _typelessdata
 
 

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -573,7 +573,7 @@ add_newdoc('numpy.core.umath', 'bitwise_and',
     >>> np.bitwise_and(np.array([2,5,255]), np.array([3,14,16]))
     array([ 2,  4, 16])
     >>> np.bitwise_and([True, True], [False, True])
-    array([False,  True], dtype=bool)
+    array([False,  True])
 
     """)
 
@@ -630,7 +630,7 @@ add_newdoc('numpy.core.umath', 'bitwise_or',
     ...               np.array([4, 4, 4, 2147483647L], dtype=np.int32))
     array([         6,          5,        255, 2147483647])
     >>> np.bitwise_or([True, True], [False, True])
-    array([ True,  True], dtype=bool)
+    array([ True,  True])
 
     """)
 
@@ -680,7 +680,7 @@ add_newdoc('numpy.core.umath', 'bitwise_xor',
     >>> np.bitwise_xor([31,3], [5,6])
     array([26,  5])
     >>> np.bitwise_xor([True, True], [False, True])
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     """)
 
@@ -1057,13 +1057,13 @@ add_newdoc('numpy.core.umath', 'equal',
     Examples
     --------
     >>> np.equal([0, 1, 3], np.arange(3))
-    array([ True,  True, False], dtype=bool)
+    array([ True,  True, False])
 
     What is compared are values, not types. So an int (1) and an array of
     length one can evaluate as True:
 
     >>> np.equal(1, np.ones(1))
-    array([ True], dtype=bool)
+    array([ True])
 
     """)
 
@@ -1389,14 +1389,14 @@ add_newdoc('numpy.core.umath', 'greater',
     Examples
     --------
     >>> np.greater([4,2],[2,2])
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     If the inputs are ndarrays, then np.greater is equivalent to '>'.
 
     >>> a = np.array([4,2])
     >>> b = np.array([2,2])
     >>> a > b
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     """)
 
@@ -1424,7 +1424,7 @@ add_newdoc('numpy.core.umath', 'greater_equal',
     Examples
     --------
     >>> np.greater_equal([4, 2, 1], [2, 2, 2])
-    array([ True, True, False], dtype=bool)
+    array([ True, True, False])
 
     """)
 
@@ -1541,7 +1541,7 @@ add_newdoc('numpy.core.umath', 'invert',
     Booleans are accepted as well:
 
     >>> np.invert(array([True, False]))
-    array([False,  True], dtype=bool)
+    array([False,  True])
 
     """)
 
@@ -1599,7 +1599,7 @@ add_newdoc('numpy.core.umath', 'isfinite',
     >>> np.isfinite(np.NINF)
     False
     >>> np.isfinite([np.log(-1.),1.,np.log(0)])
-    array([False,  True, False], dtype=bool)
+    array([False,  True, False])
 
     >>> x = np.array([-np.inf, 0., np.inf])
     >>> y = np.array([2, 2, 2])
@@ -1661,7 +1661,7 @@ add_newdoc('numpy.core.umath', 'isinf',
     >>> np.isinf(np.NINF)
     True
     >>> np.isinf([np.inf, -np.inf, 1.0, np.nan])
-    array([ True,  True, False, False], dtype=bool)
+    array([ True,  True, False, False])
 
     >>> x = np.array([-np.inf, 0., np.inf])
     >>> y = np.array([2, 2, 2])
@@ -1709,7 +1709,7 @@ add_newdoc('numpy.core.umath', 'isnan',
     >>> np.isnan(np.inf)
     False
     >>> np.isnan([np.log(-1.),1.,np.log(0)])
-    array([ True, False, False], dtype=bool)
+    array([ True, False, False])
 
     """)
 
@@ -1745,7 +1745,7 @@ add_newdoc('numpy.core.umath', 'isnat',
     >>> np.isnat(np.datetime64("2016-01-01"))
     False
     >>> np.isnat(np.array(["NaT", "2016-01-01"], dtype="datetime64[ns]"))
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     """)
 
@@ -1814,7 +1814,7 @@ add_newdoc('numpy.core.umath', 'less',
     Examples
     --------
     >>> np.less([1, 2], [2, 2])
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     """)
 
@@ -1842,7 +1842,7 @@ add_newdoc('numpy.core.umath', 'less_equal',
     Examples
     --------
     >>> np.less_equal([4, 2, 1], [2, 2, 2])
-    array([False,  True,  True], dtype=bool)
+    array([False,  True,  True])
 
     """)
 
@@ -2155,11 +2155,11 @@ add_newdoc('numpy.core.umath', 'logical_and',
     >>> np.logical_and(True, False)
     False
     >>> np.logical_and([True, False], [False, False])
-    array([False, False], dtype=bool)
+    array([False, False])
 
     >>> x = np.arange(5)
     >>> np.logical_and(x>1, x<4)
-    array([False, False,  True,  True, False], dtype=bool)
+    array([False, False,  True,  True, False])
 
     """)
 
@@ -2188,11 +2188,11 @@ add_newdoc('numpy.core.umath', 'logical_not',
     >>> np.logical_not(3)
     False
     >>> np.logical_not([True, False, 0, 1])
-    array([False,  True,  True, False], dtype=bool)
+    array([False,  True,  True, False])
 
     >>> x = np.arange(5)
     >>> np.logical_not(x<3)
-    array([False, False, False,  True,  True], dtype=bool)
+    array([False, False, False,  True,  True])
 
     """)
 
@@ -2223,11 +2223,11 @@ add_newdoc('numpy.core.umath', 'logical_or',
     >>> np.logical_or(True, False)
     True
     >>> np.logical_or([True, False], [False, False])
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     >>> x = np.arange(5)
     >>> np.logical_or(x < 1, x > 3)
-    array([ True, False, False, False,  True], dtype=bool)
+    array([ True, False, False, False,  True])
 
     """)
 
@@ -2258,17 +2258,17 @@ add_newdoc('numpy.core.umath', 'logical_xor',
     >>> np.logical_xor(True, False)
     True
     >>> np.logical_xor([True, True, False, False], [True, False, True, False])
-    array([False,  True,  True, False], dtype=bool)
+    array([False,  True,  True, False])
 
     >>> x = np.arange(5)
     >>> np.logical_xor(x < 1, x > 3)
-    array([ True, False, False, False,  True], dtype=bool)
+    array([ True, False, False, False,  True])
 
     Simple example showing support of broadcasting
 
     >>> np.logical_xor(0, np.eye(2))
     array([[ True, False],
-           [False,  True]], dtype=bool)
+           [False,  True]])
 
     """)
 
@@ -2647,10 +2647,10 @@ add_newdoc('numpy.core.umath', 'not_equal',
     Examples
     --------
     >>> np.not_equal([1.,2.], [1., 3.])
-    array([False,  True], dtype=bool)
+    array([False,  True])
     >>> np.not_equal([1, 2], [[1, 3],[1, 4]])
     array([[False,  True],
-           [False,  True]], dtype=bool)
+           [False,  True]])
 
     """)
 
@@ -3102,7 +3102,7 @@ add_newdoc('numpy.core.umath', 'signbit',
     >>> np.signbit(-1.2)
     True
     >>> np.signbit(np.array([1, -2.3, 2.1]))
-    array([False,  True, False], dtype=bool)
+    array([False,  True, False])
 
     """)
 
@@ -3166,7 +3166,7 @@ add_newdoc('numpy.core.umath', 'nextafter',
     >>> np.nextafter(1, 2) == eps + 1
     True
     >>> np.nextafter([1, 2], [2, 1]) == [eps + 1, 2 - eps]
-    array([ True,  True], dtype=bool)
+    array([ True,  True])
 
     """)
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -575,9 +575,9 @@ def endswith(a, suffix, start=0, end=None):
     array(['foo', 'bar'],
         dtype='|S3')
     >>> np.char.endswith(s, 'ar')
-    array([False,  True], dtype=bool)
+    array([False,  True])
     >>> np.char.endswith(s, 'a', start=1, end=2)
-    array([False,  True], dtype=bool)
+    array([False,  True])
 
     """
     return _vec_string(

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1567,7 +1567,7 @@ def nonzero(a):
     >>> a > 3
     array([[False, False, False],
            [ True,  True,  True],
-           [ True,  True,  True]], dtype=bool)
+           [ True,  True,  True]])
     >>> np.nonzero(a > 3)
     (array([1, 1, 1, 2, 2, 2]), array([0, 1, 2, 0, 1, 2]))
 
@@ -1962,7 +1962,7 @@ def any(a, axis=None, out=None, keepdims=np._NoValue):
     True
 
     >>> np.any([[True, False], [False, False]], axis=0)
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     >>> np.any([-1, 0, 5])
     True
@@ -1973,7 +1973,7 @@ def any(a, axis=None, out=None, keepdims=np._NoValue):
     >>> o=np.array([False])
     >>> z=np.any([-1, 4, 5], out=o)
     >>> z, o
-    (array([ True], dtype=bool), array([ True], dtype=bool))
+    (array([ True]), array([ True]))
     >>> # Check now that z is a reference to o
     >>> z is o
     True
@@ -2047,7 +2047,7 @@ def all(a, axis=None, out=None, keepdims=np._NoValue):
     False
 
     >>> np.all([[True,False],[True,True]], axis=0)
-    array([ True, False], dtype=bool)
+    array([ True, False])
 
     >>> np.all([-1, 4, 5])
     True
@@ -2058,7 +2058,7 @@ def all(a, axis=None, out=None, keepdims=np._NoValue):
     >>> o=np.array([False])
     >>> z=np.all([-1, 4, 5], out=o)
     >>> id(z), id(o), z                             # doctest: +SKIP
-    (28293632, 28293632, array([ True], dtype=bool))
+    (28293632, 28293632, array([ True]))
 
     """
     arr = asanyarray(a)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1193,7 +1193,7 @@ def tensordot(a, b, axes=2):
            [ True,  True],
            [ True,  True],
            [ True,  True],
-           [ True,  True]], dtype=bool)
+           [ True,  True]])
 
     An extended example taking advantage of the overloading of + and \\*:
 
@@ -1901,7 +1901,7 @@ def fromfunction(function, shape, **kwargs):
     >>> np.fromfunction(lambda i, j: i == j, (3, 3), dtype=int)
     array([[ True, False, False],
            [False,  True, False],
-           [False, False,  True]], dtype=bool)
+           [False, False,  True]])
 
     >>> np.fromfunction(lambda i, j: i + j, (3, 3), dtype=int)
     array([[0, 1, 2],

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -317,15 +317,15 @@ class TestPrintOptions(object):
 
     def test_bool_spacing(self):
         assert_equal(repr(np.array([True,  True])),
-                     'array([ True,  True], dtype=bool)')
+                     'array([ True,  True])')
         assert_equal(repr(np.array([True, False])),
-                     'array([ True, False], dtype=bool)')
+                     'array([ True, False])')
         assert_equal(repr(np.array([True])),
-                     'array([ True], dtype=bool)')
+                     'array([ True])')
         assert_equal(repr(np.array(True)),
-                     'array(True, dtype=bool)')
+                     'array(True)')
         assert_equal(repr(np.array(False)),
-                     'array(False, dtype=bool)')
+                     'array(False)')
 
     def test_sign_spacing(self):
         a = np.arange(4.)

--- a/numpy/doc/constants.py
+++ b/numpy/doc/constants.py
@@ -133,11 +133,11 @@ add_newdoc('numpy', 'NZERO',
     0.0
 
     >>> np.isfinite([np.NZERO])
-    array([ True], dtype=bool)
+    array([ True])
     >>> np.isnan([np.NZERO])
-    array([False], dtype=bool)
+    array([False])
     >>> np.isinf([np.NZERO])
-    array([False], dtype=bool)
+    array([False])
 
     """)
 
@@ -204,11 +204,11 @@ add_newdoc('numpy', 'PZERO',
     -0.0
 
     >>> np.isfinite([np.PZERO])
-    array([ True], dtype=bool)
+    array([ True])
     >>> np.isnan([np.PZERO])
-    array([False], dtype=bool)
+    array([False])
     >>> np.isinf([np.PZERO])
-    array([False], dtype=bool)
+    array([False])
 
     """)
 

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -233,7 +233,7 @@ Glossary
 
          >>> mask = (x > 2)
          >>> mask
-         array([False, False, False, True,  True], dtype=bool)
+         array([False, False, False, True,  True])
 
          >>> x[mask] = -1
          >>> x

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -240,7 +240,7 @@ The result will be multidimensional if y has more dimensions than b.
 For example: ::
 
  >>> b[:,5] # use a 1-D boolean whose first dim agrees with the first dim of y
- array([False, False, False,  True,  True], dtype=bool)
+ array([False, False, False,  True,  True])
  >>> y[b[:,5]]
  array([[21, 22, 23, 24, 25, 26, 27],
         [28, 29, 30, 31, 32, 33, 34]])

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -480,7 +480,7 @@ the same order::
  >>> a = np.zeros(2, dtype=[('a', 'i4'), ('b', 'i4')])
  >>> b = np.ones(2, dtype=[('a', 'i4'), ('b', 'i4')])
  >>> a == b
- array([False, False], dtype=bool)
+ array([False, False])
 
 Currently, if the dtypes of two void structured arrays are not equivalent the
 comparison fails, returning the scalar value ``False``. This behavior is

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -435,12 +435,12 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     >>> states = [0, 2]
     >>> mask = np.in1d(test, states)
     >>> mask
-    array([ True, False,  True, False,  True], dtype=bool)
+    array([ True, False,  True, False,  True])
     >>> test[mask]
     array([0, 2, 0])
     >>> mask = np.in1d(test, states, invert=True)
     >>> mask
-    array([False,  True, False,  True, False], dtype=bool)
+    array([False,  True, False,  True, False])
     >>> test[mask]
     array([1, 5])
     """
@@ -546,13 +546,13 @@ def isin(element, test_elements, assume_unique=False, invert=False):
     >>> mask = np.isin(element, test_elements)
     >>> mask
     array([[ False,  True],
-           [ True,  False]], dtype=bool)
+           [ True,  False]])
     >>> element[mask]
     array([2, 4])
     >>> mask = np.isin(element, test_elements, invert=True)
     >>> mask
     array([[ True, False],
-           [ False, True]], dtype=bool)
+           [ False, True]])
     >>> element[mask]
     array([0, 6])
 
@@ -562,13 +562,13 @@ def isin(element, test_elements, assume_unique=False, invert=False):
     >>> test_set = {1, 2, 4, 8}
     >>> np.isin(element, test_set)
     array([[ False, False],
-           [ False, False]], dtype=bool)
+           [ False, False]])
 
     Casting the set to a list gives the expected result:
 
     >>> np.isin(element, list(test_set))
     array([[ False,  True],
-           [ True,  False]], dtype=bool)
+           [ True,  False]])
     """
     element = np.asarray(element)
     return in1d(element, test_elements, assume_unique=assume_unique,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2333,7 +2333,7 @@ def extract(condition, arr):
     >>> condition
     array([[ True, False, False,  True],
            [False, False,  True, False],
-           [False,  True, False, False]], dtype=bool)
+           [False,  True, False, False]])
     >>> np.extract(condition, arr)
     array([0, 3, 6, 9])
 

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -208,7 +208,7 @@ def iscomplex(x):
     Examples
     --------
     >>> np.iscomplex([1+1j, 1+0j, 4.5, 3, 2, 2j])
-    array([ True, False, False, False, False,  True], dtype=bool)
+    array([ True, False, False, False, False,  True])
 
     """
     ax = asanyarray(x)
@@ -242,7 +242,7 @@ def isreal(x):
     Examples
     --------
     >>> np.isreal([1+1j, 1+0j, 4.5, 3, 2, 2j])
-    array([False,  True,  True,  True,  True, False], dtype=bool)
+    array([False,  True,  True,  True,  True, False])
 
     """
     return imag(x) == 0

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -128,7 +128,7 @@ def isposinf(x, out=None):
     >>> np.isposinf(np.NINF)
     array(False, dtype=bool)
     >>> np.isposinf([-np.inf, 0., np.inf])
-    array([False, False,  True], dtype=bool)
+    array([False, False,  True])
 
     >>> x = np.array([-np.inf, 0., np.inf])
     >>> y = np.array([2, 2, 2])
@@ -189,7 +189,7 @@ def isneginf(x, out=None):
     >>> np.isneginf(np.PINF)
     array(False, dtype=bool)
     >>> np.isneginf([-np.inf, 0., np.inf])
-    array([ True, False, False], dtype=bool)
+    array([ True, False, False])
 
     >>> x = np.array([-np.inf, 0., np.inf])
     >>> y = np.array([2, 2, 2])

--- a/numpy/ma/README.txt
+++ b/numpy/ma/README.txt
@@ -104,9 +104,9 @@ array(data =
  [False False True False False],
       fill_value=?)
 >>> old_ma.getmask(x) == new_ma.getmask(x)
-array([True, True, True, True, True], dtype=bool)
+array([True, True, True, True, True])
 >>> old_ma.getmask(y) == new_ma.getmask(y)
-array([True, True, False, True, True], dtype=bool)
+array([True, True, False, True, True])
 >>> old_ma.getmask(y)
 False
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1383,13 +1383,13 @@ def getmask(a):
           fill_value=999999)
     >>> ma.getmask(a)
     array([[False,  True],
-           [False, False]], dtype=bool)
+           [False, False]])
 
     Equivalently use the `MaskedArray` `mask` attribute.
 
     >>> a.mask
     array([[False,  True],
-           [False, False]], dtype=bool)
+           [False, False]])
 
     Result when mask == `nomask`
 
@@ -1447,7 +1447,7 @@ def getmaskarray(arr):
           fill_value=999999)
     >>> ma.getmaskarray(a)
     array([[False,  True],
-           [False, False]], dtype=bool)
+           [False, False]])
 
     Result when mask == ``nomask``
 
@@ -1461,7 +1461,7 @@ def getmaskarray(arr):
           fill_value=999999)
     >>> >ma.getmaskarray(b)
     array([[False, False],
-           [False, False]], dtype=bool)
+           [False, False]])
 
     """
     mask = getmask(arr)
@@ -1513,7 +1513,7 @@ def is_mask(m):
     False
     >>> m = np.array([False, True, False])
     >>> m
-    array([False,  True, False], dtype=bool)
+    array([False,  True, False])
     >>> ma.is_mask(m)
     True
 
@@ -1581,13 +1581,13 @@ def make_mask(m, copy=False, shrink=True, dtype=MaskType):
     >>> import numpy.ma as ma
     >>> m = [True, False, True, True]
     >>> ma.make_mask(m)
-    array([ True, False,  True,  True], dtype=bool)
+    array([ True, False,  True,  True])
     >>> m = [1, 0, 1, 1]
     >>> ma.make_mask(m)
-    array([ True, False,  True,  True], dtype=bool)
+    array([ True, False,  True,  True])
     >>> m = [1, 0, 2, -3]
     >>> ma.make_mask(m)
-    array([ True, False,  True,  True], dtype=bool)
+    array([ True, False,  True,  True])
 
     Effect of the `shrink` parameter.
 
@@ -1597,7 +1597,7 @@ def make_mask(m, copy=False, shrink=True, dtype=MaskType):
     >>> ma.make_mask(m)
     False
     >>> ma.make_mask(m, shrink=False)
-    array([False, False, False, False], dtype=bool)
+    array([False, False, False, False])
 
     Using a flexible `dtype`.
 
@@ -1667,7 +1667,7 @@ def make_mask_none(newshape, dtype=None):
     --------
     >>> import numpy.ma as ma
     >>> ma.make_mask_none((3,))
-    array([False, False, False], dtype=bool)
+    array([False, False, False])
 
     Defining a more complex dtype.
 
@@ -1720,7 +1720,7 @@ def mask_or(m1, m2, copy=False, shrink=True):
     >>> m1 = np.ma.make_mask([0, 1, 1, 0])
     >>> m2 = np.ma.make_mask([1, 0, 0, 0])
     >>> np.ma.mask_or(m1, m2)
-    array([ True,  True,  True, False], dtype=bool)
+    array([ True,  True,  True, False])
 
     """
 
@@ -1770,18 +1770,18 @@ def flatten_mask(mask):
 
     Examples
     --------
-    >>> mask = np.array([0, 0, 1], dtype=bool)
+    >>> mask = np.array([0, 0, 1])
     >>> flatten_mask(mask)
-    array([False, False,  True], dtype=bool)
+    array([False, False,  True])
 
     >>> mask = np.array([(0, 0), (0, 1)], dtype=[('a', bool), ('b', bool)])
     >>> flatten_mask(mask)
-    array([False, False, False,  True], dtype=bool)
+    array([False, False, False,  True])
 
     >>> mdtype = [('a', bool), ('b', [('ba', bool), ('bb', bool)])]
     >>> mask = np.array([(0, (0, 0)), (0, (0, 1))], dtype=mdtype)
     >>> flatten_mask(mask)
-    array([False, False, False, False, False,  True], dtype=bool)
+    array([False, False, False, False, False,  True])
 
     """
 
@@ -3551,7 +3551,7 @@ class MaskedArray(ndarray):
         >>> x = np.ma.array([[1,2 ], [3, 4]], mask=[0]*4)
         >>> x.mask
         array([[False, False],
-               [False, False]], dtype=bool)
+               [False, False]])
         >>> x.shrink_mask()
         >>> x.mask
         False

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -699,15 +699,15 @@ class matrix(N.ndarray):
         >>> (x == y)
         matrix([[ True,  True,  True,  True],
                 [False, False, False, False],
-                [False, False, False, False]], dtype=bool)
+                [False, False, False, False]])
         >>> (x == y).all()
         False
         >>> (x == y).all(0)
-        matrix([[False, False, False, False]], dtype=bool)
+        matrix([[False, False, False, False]])
         >>> (x == y).all(1)
         matrix([[ True],
                 [False],
-                [False]], dtype=bool)
+                [False]])
 
         """
         return N.ndarray.all(self, axis, out, keepdims=True)._collapse(axis)

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -902,7 +902,7 @@ cdef class RandomState:
         array([[[ True,  True],
                 [ True,  True]],
                [[ True,  True],
-                [ True,  True]]], dtype=bool)
+                [ True,  True]]])
 
         """
         return disc0_array(self.internal_state, rk_long, size, self.lock)


### PR DESCRIPTION
Just another `repr` change we could consider for 1.14. Before:

```python
>>> np.array([True, False])
array([True, False], dtype=bool)
```

After:

```python
>>> np.array([True, False])
array([True, False])
```

The first commit would be useful within `np.ma` whether or not the second is desirable.