### PR TITLE
MAINT: Update c-api version and hash for NumPy 1.14.

### DIFF
--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -36,6 +36,8 @@
 0x0000000a = 9b8bce614655d3eb02acddcb508203cb
 
 # Version 11 (NumPy 1.13) Added PyArray_MapIterArrayCopyIfOverlap
-# Version 11 (NumPy 1.14) Added PyArray_ResolveWritebackIfCopy,
-# PyArray_SetWritebackIfCopyBase and deprecate PyArray_SetUpdateIfCopyBase.
 0x0000000b = edb1ba83730c650fd9bc5772a919cda7
+
+# Version 12 (NumPy 1.14) Added PyArray_ResolveWritebackIfCopy,
+# PyArray_SetWritebackIfCopyBase and deprecated PyArray_SetUpdateIfCopyBase.
+0x0000000c = a1bc756c5782853ec2e3616cf66869d8

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -39,8 +39,8 @@ C_ABI_VERSION = 0x01000009
 # 0x0000000a - 1.11.x
 # 0x0000000a - 1.12.x
 # 0x0000000b - 1.13.x
-# 0x0000000b - 1.14.x
-C_API_VERSION = 0x0000000b
+# 0x0000000c - 1.14.x
+C_API_VERSION = 0x0000000c
 
 class MismatchCAPIWarning(Warning):
     pass


### PR DESCRIPTION
- Added PyArray_ResolveWritebackIfCopy.
- Added PyArray_SetWritebackIfCopyBase.
- Deprecated PyArray_SetUpdateIfCopyBase.

Closes #10014.