### PR TITLE
ENH: Add the ndmin argument from np.array to np.as[any]array

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -420,6 +420,11 @@ The printing style of ``np.void`` arrays is now independently customizable
 using the ``formatter`` argument to ``np.set_printoptions``, using the
 ``'void'`` key, instead of the catch-all ``numpystr`` key as before.
 
+``np.asarray`` and ``np.asanyarray`` now take a ``ndmin`` argument to match ``array``
+-------------------------------------------------------------------------------------
+This makes the shorthands marginally more useful.
+
+
 Changes
 =======
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -421,7 +421,7 @@ def count_nonzero(a, axis=None):
     return a_bool.sum(axis=axis, dtype=np.intp)
 
 
-def asarray(a, dtype=None, order=None):
+def asarray(a, dtype=None, order=None, ndmin=0):
     """Convert the input to an array.
 
     Parameters
@@ -436,6 +436,12 @@ def asarray(a, dtype=None, order=None):
         Whether to use row-major (C-style) or
         column-major (Fortran-style) memory representation.
         Defaults to 'C'.
+    ndmin : int, optional
+        Specifies the minimum number of dimensions that the resulting array
+        should have. Ones will be pre-pended to the shape as needed to meet
+        this requirement.
+
+        .. versionadded:: 1.14.0
 
     Returns
     -------
@@ -489,10 +495,10 @@ def asarray(a, dtype=None, order=None):
     True
 
     """
-    return array(a, dtype, copy=False, order=order)
+    return array(a, dtype, copy=False, order=order, ndmin=ndmin)
 
 
-def asanyarray(a, dtype=None, order=None):
+def asanyarray(a, dtype=None, order=None, ndmin=0):
     """Convert the input to an ndarray, but pass ndarray subclasses through.
 
     Parameters
@@ -506,6 +512,12 @@ def asanyarray(a, dtype=None, order=None):
     order : {'C', 'F'}, optional
         Whether to use row-major (C-style) or column-major
         (Fortran-style) memory representation.  Defaults to 'C'.
+    ndmin : int, optional
+        Specifies the minimum number of dimensions that the resulting array
+        should have. Ones will be pre-pended to the shape as needed to meet
+        this requirement.
+
+        .. versionadded:: 1.14.0
 
     Returns
     -------
@@ -541,7 +553,7 @@ def asanyarray(a, dtype=None, order=None):
     True
 
     """
-    return array(a, dtype, copy=False, order=order, subok=True)
+    return array(a, dtype, copy=False, order=order, subok=True, ndmin=ndmin)
 
 
 def ascontiguousarray(a, dtype=None):

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -435,11 +435,6 @@ def _block(arrays, max_depth, result_ndim):
     `arrays` and the depth of the lists in `arrays` (see block docstring
     for details).
     """
-    def atleast_nd(a, ndim):
-        # Ensures `a` has at least `ndim` dimensions by prepending
-        # ones to `a.shape` as necessary
-        return array(a, ndmin=ndim, copy=False, subok=True)
-
     def block_recursion(arrays, depth=0):
         if depth < max_depth:
             if len(arrays) == 0:
@@ -449,7 +444,7 @@ def _block(arrays, max_depth, result_ndim):
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
             # type(arrays) is not list
-            return atleast_nd(arrays, result_ndim)
+            return asanyarray(arrays, ndmin=result_ndim)
 
     return block_recursion(arrays)
 


### PR DESCRIPTION
Inspired from [@charris' comment a year ago](https://github.com/numpy/numpy/pull/7804#issuecomment-256979767):

> Maybe we could add the ndmin keyword to asarray to make for easier list comprehension.

My understanding is that our aliases should be for:

* `asarray(...)` -> `array(..., copy=False, subok=False)`
* `asanyarray(...)` -> `array(..., copy=False, subok=True)`

I don't think the `ndmin` argument is special enough that these functions should lock it to `0`.

We could also change the implementation to use `kwargs`, but that would presumably be slower and result in less clear docs.



