### PR TITLE
MAINT: Legacy mode specified as string, fix all-zeros legacy bug

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -192,9 +192,9 @@ differences (see changes below). These changes are likely to break downstream
 user's doctests.
 
 These new behaviors can be disabled to mostly reproduce numpy 1.13 behavior by
-enabling the new "legacy" printing mode. This is enabled by calling
-``np.set_printoptions(legacy=True)``, or using the new ``legacy`` argument
-to ``np.array2string``.
+enabling the new 1.13 "legacy" printing mode. This is enabled by calling
+``np.set_printoptions(legacy="1.13")``, or using the new ``legacy`` argument to
+``np.array2string``, as ``np.array2string(arr, legacy='1.13')``.
 
 
 C API changes
@@ -278,8 +278,8 @@ the sign position of positive values, and with '-' it will omit the sign
 character for positive values. The new default is '-'.
 
 This new default changes the float output relative to numpy 1.13. The old
-behavior can be obtained in "legacy" printing mode, see compatibility notes
-above.
+behavior can be obtained in 1.13 "legacy" printing mode, see compatibility
+notes above.
 
 Improvements
 ============
@@ -490,8 +490,8 @@ and the ``repr`` acts like higher dimension arrays using ``formatter(a[()])``,
 where  ``formatter``  can be specified using ``np.set_printoptions``. The
 ``style`` argument of ``np.array2string`` is deprecated.
 
-This new behavior is disabled in legacy printing mode, see compatibility notes
-above.
+This new behavior is disabled in 1.13 legacy printing mode, see compatibility
+notes above.
 
 ``threshold`` and ``edgeitems`` options added to ``np.array2string``
 -----------------------------------------------------------------

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -721,9 +721,10 @@ class FloatingFormat(object):
         if len(abs_non_zero) != 0:
             max_val = np.max(abs_non_zero)
             min_val = np.min(abs_non_zero)
-            if max_val >= 1.e8 or (not self.suppress_small and
-                    (min_val < 0.0001 or max_val/min_val > 1000.)):
-                self.exp_format = True
+            with errstate(over='ignore'):  # division can overflow
+                if max_val >= 1.e8 or (not self.suppress_small and
+                        (min_val < 0.0001 or max_val/min_val > 1000.)):
+                    self.exp_format = True
 
         # do a first pass of printing all the numbers, to determine sizes
         if len(finite_vals) == 0:

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -177,7 +177,10 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         If set to the string `'1.13'` enables 1.13 legacy printing mode. This
         approximates numpy 1.13 print output by including a space in the sign
         position of floats and different behavior for 0d arrays. If set to
-        `False`, disables legacy mode.
+        `False`, disables legacy mode. Unrecognized strings will be ignored
+        with a warning for forward compatibility.
+        
+        .. versionadded:: 1.14.0
 
     See Also
     --------
@@ -534,7 +537,10 @@ def array2string(a, max_line_width=None, precision=None,
         If set to the string `'1.13'` enables 1.13 legacy printing mode. This
         approximates numpy 1.13 print output by including a space in the sign
         position of floats and different behavior for 0d arrays. If set to
-        `False`, disables legacy mode.
+        `False`, disables legacy mode. Unrecognized strings will be ignored
+        with a warning for forward compatibility.
+        
+        .. versionadded:: 1.14.0
 
     Returns
     -------

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -333,6 +333,7 @@ class TestPrintOptions(object):
         assert_equal(repr(a), 'array([0., 1., 2., 3.])')
         assert_equal(repr(np.array(1.)), 'array(1.)')
         assert_equal(repr(b), 'array([1.234e+09])')
+        assert_equal(repr(np.array([0.])), 'array([0.])')
 
         np.set_printoptions(sign=' ')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
@@ -349,6 +350,7 @@ class TestPrintOptions(object):
         assert_equal(repr(b),  'array([  1.23400000e+09])')
         assert_equal(repr(-b), 'array([ -1.23400000e+09])')
         assert_equal(repr(np.array(1.)), 'array(1.0)')
+        assert_equal(repr(np.array([0.])), 'array([ 0.])')
 
         assert_raises(TypeError, np.set_printoptions, wrongarg=True)
 
@@ -419,6 +421,7 @@ class TestPrintOptions(object):
         assert_equal(repr(w[::5]),
             "array([1.0000e+00, 1.0000e+05, 1.0000e+10, 1.0000e+15, 1.0000e+20])")
         assert_equal(repr(wp), "array([1.2340e+001, 1.0000e+002, 1.0000e+123])")
+        assert_equal(repr(np.zeros(3)), "array([0.0000, 0.0000, 0.0000])")
         # for larger precision, representation error becomes more apparent:
         np.set_printoptions(floatmode='fixed', precision=8)
         assert_equal(repr(z),

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -288,8 +288,7 @@ class TestPrintOptions(object):
         assert_warns(DeprecationWarning, np.array2string,
                                          np.array(1.), style=repr)
         # but not in legacy mode
-        np.set_printoptions(legacy=True)
-        np.array2string(np.array(1.), style=repr)
+        np.array2string(np.array(1.), style=repr, legacy='1.13')
 
     def test_float_spacing(self):
         x = np.array([1., 2., 3.])
@@ -345,7 +344,7 @@ class TestPrintOptions(object):
         assert_equal(repr(np.array(1.)), 'array(+1.)')
         assert_equal(repr(b), 'array([+1.234e+09])')
 
-        np.set_printoptions(legacy=True)
+        np.set_printoptions(legacy='1.13')
         assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
         assert_equal(repr(b),  'array([  1.23400000e+09])')
         assert_equal(repr(-b), 'array([ -1.23400000e+09])')

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -354,6 +354,11 @@ class TestPrintOptions(object):
 
         assert_raises(TypeError, np.set_printoptions, wrongarg=True)
 
+    def test_float_overflow_nowarn(self):
+        # make sure internal computations in FloatingFormat don't
+        # warn about overflow
+        repr(np.array([1e4, 0.1], dtype='f2'))
+
     def test_sign_spacing_structured(self):
         a = np.ones(2, dtype='f,f')
         assert_equal(repr(a), "array([(1., 1.), (1., 1.)],\n"


### PR DESCRIPTION
Fixes #10020 and #10026

The first commit makes the `legacy` option specify version number, as `np.set_printoptions(legacy='1.13')`. 

The second commit fixes a bug where the legacy mode spacing for float arrays didn't get activated for arrays which didn't have any non-zero finite values.