### PR TITLE
BUG: Fix f2py string variables in callbacks.

### DIFF
--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -367,11 +367,15 @@ cb_arg_rules = [
         'pyobjfrom': [{debugcapi: '\tfprintf(stderr,"debug-capi:cb:#varname#\\n");'},
                       {isintent_c: """\
 \tif (#name#_nofargs>capi_i) {
-\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,0,NPY_ARRAY_CARRAY,NULL); /*XXX: Hmm, what will destroy this array??? */
+\t\tint itemsize_ = #atype# == NPY_STRING ? 1 : 0;
+\t\t/*XXX: Hmm, what will destroy this array??? */
+\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,itemsize_,NPY_ARRAY_CARRAY,NULL);
 """,
                        l_not(isintent_c): """\
 \tif (#name#_nofargs>capi_i) {
-\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,0,NPY_ARRAY_FARRAY,NULL); /*XXX: Hmm, what will destroy this array??? */
+\t\tint itemsize_ = #atype# == NPY_STRING ? 1 : 0;
+\t\t/*XXX: Hmm, what will destroy this array??? */
+\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,itemsize_,NPY_ARRAY_FARRAY,NULL);
 """,
                        },
                       """

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -4,7 +4,7 @@ import math
 import textwrap
 import sys
 
-from numpy import array
+import numpy as np
 from numpy.testing import run_module_suite, assert_, assert_equal, dec
 from . import util
 
@@ -48,6 +48,16 @@ cf2py  intent(out) a
        a = callback(r)
        end
 
+       subroutine string_callback_array(callback, cu, lencu, a)
+       external callback
+       integer callback
+       integer lencu
+       character*8 cu(lencu)
+       integer a
+cf2py  intent(out) a
+
+       a = callback(cu, lencu)
+       end
     """
 
     @dec.slow
@@ -120,7 +130,8 @@ cf2py  intent(out) a
         r = t(a.mth)
         assert_(r == 9, repr(r))
 
-    @dec.knownfailureif(sys.platform=='win32', msg='Fails with MinGW64 Gfortran (Issue #9673)')
+    @dec.knownfailureif(sys.platform=='win32',
+                        msg='Fails with MinGW64 Gfortran (Issue #9673)')
     def test_string_callback(self):
 
         def callback(code):
@@ -132,6 +143,25 @@ cf2py  intent(out) a
         f = getattr(self.module, 'string_callback')
         r = f(callback)
         assert_(r == 0, repr(r))
+
+    @dec.knownfailureif(sys.platform=='win32',
+                        msg='Fails with MinGW64 Gfortran (Issue #9673)')
+    def test_string_callback_array(self):
+        # See gh-10027
+        cu = np.zeros((1, 8), 'S1')
+
+        def callback(cu, lencu):
+            if cu.shape != (lencu, 8):
+                return 1
+            if cu.dtype != 'S1':
+                return 2
+            if not np.all(cu == b''):
+                return 3
+            return 0
+
+        f = getattr(self.module, 'string_callback_array')
+        res = f(callback, cu, len(cu))
+        assert_(res == 0, repr(res))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When NPY_CHAR was deprecated and replaced by NPY_STRING in f2py, calls
to PyArray_New that previously relied on the type to get the itemsize
needed the size explicitly specified, but that modification was missed
in some of the code. Because the strings that replaced the 'c' type are
always 'S1', we use an itemsize of 1 for the string types and pass it
explicitly.

Closes #10027.