### PR TITLE
MAINT: legacy-printing-mode preserves 1.13 float & complex str

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -42,7 +42,8 @@ from . import numerictypes as _nt
 from .umath import absolute, not_equal, isnan, isinf, isfinite
 from . import multiarray
 from .multiarray import (array, dragon4_positional, dragon4_scientific,
-                         datetime_as_string, datetime_data, dtype, ndarray)
+                         datetime_as_string, datetime_data, dtype, ndarray,
+                         set_legacy_print_mode)
 from .fromnumeric import ravel, any
 from .numeric import concatenate, asarray, errstate
 from .numerictypes import (longlong, intc, int_, float_, complex_, bool_,
@@ -241,6 +242,12 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     # formatter is always reset
     opt['formatter'] = formatter
     _format_options.update(opt)
+
+    # set the C variable for legacy mode
+    if _format_options['legacy'] == '1.13':
+        set_legacy_print_mode(113)
+    elif _format_options['legacy'] is False:
+        set_legacy_print_mode(0)
 
 
 def get_printoptions():

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -65,6 +65,24 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 
 #include "get_attr_string.h"
 
+/*
+ * global variable to determine if legacy printing is enabled, accessible from
+ * C. For simplicity the mode is encoded as an integer where '0' means no
+ * legacy mode, and '113' means 1.13 legacy mode. We can upgrade this if we
+ * have more complex requirements in the future.
+ */
+int npy_legacy_print_mode = 0;
+
+static PyObject *
+set_legacy_print_mode(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "i", &npy_legacy_print_mode)) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+
 /* Only here for API compatibility */
 NPY_NO_EXPORT PyTypeObject PyBigArray_Type;
 
@@ -4440,6 +4458,8 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"normalize_axis_index", (PyCFunction)normalize_axis_index,
         METH_VARARGS | METH_KEYWORDS, NULL},
+    {"set_legacy_print_mode", (PyCFunction)set_legacy_print_mode,
+        METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -780,6 +780,173 @@ timedeltatype_str(PyObject *self)
  * These functions will return NULL if PyString creation fails.
  */
 
+
+/*
+ *               *** BEGIN LEGACY PRINTING MODE CODE ***
+ *
+ * This code is legacy code needed to reproduce the printing behavior of
+ * scalars in numpy 1.13. One day we hope to remove it.
+ */
+
+/* determines if legacy mode is enabled, global set in multiarraymodule.c */
+extern int npy_legacy_print_mode;
+
+#define HALFPREC_REPR 5
+#define HALFPREC_STR 5
+#define FLOATPREC_REPR 8
+#define FLOATPREC_STR 6
+#define DOUBLEPREC_REPR 17
+#define DOUBLEPREC_STR 12
+#if NPY_SIZEOF_LONGDOUBLE == NPY_SIZEOF_DOUBLE
+#define LONGDOUBLEPREC_REPR DOUBLEPREC_REPR
+#define LONGDOUBLEPREC_STR DOUBLEPREC_STR
+#else /* More than probably needed on Intel FP */
+#define LONGDOUBLEPREC_REPR 20
+#define LONGDOUBLEPREC_STR 12
+#endif
+
+/**begin repeat
+ * #kind = str, repr#
+ * #KIND = STR, REPR#
+ */
+
+/**begin repeat1
+ * #name = cfloat, cdouble, clongdouble#
+ * #NAME = FLOAT, DOUBLE, LONGDOUBLE#
+ * #type = npy_cfloat, npy_cdouble, npy_clongdouble#
+ * #suff = f, d, l#
+ */
+
+#define _FMT1 "%%.%i" NPY_@NAME@_FMT
+#define _FMT2 "%%+.%i" NPY_@NAME@_FMT
+
+static PyObject*
+legacy_@name@_format@kind@(@type@ val)
+{
+    /* XXX: Find a correct size here for format string */
+    char format[64], buf[100], *res;
+
+    /*
+     * Ideally, we should handle this nan/inf stuff in NumpyOS_ascii_format*
+     */
+    if (val.real == 0.0 && npy_signbit(val.real) == 0) {
+        PyOS_snprintf(format, sizeof(format), _FMT1, @NAME@PREC_@KIND@);
+        res = NumPyOS_ascii_format@suff@(buf, sizeof(buf) - 1, format, val.imag, 0);
+        if (res == NULL) {
+            PyErr_SetString(PyExc_RuntimeError, "Error while formatting");
+            return NULL;
+        }
+        if (!npy_isfinite(val.imag)) {
+            strncat(buf, "*", 1);
+        }
+        strncat(buf, "j", 1);
+    }
+    else {
+        char re[64], im[64];
+        if (npy_isfinite(val.real)) {
+                PyOS_snprintf(format, sizeof(format), _FMT1, @NAME@PREC_@KIND@);
+                res = NumPyOS_ascii_format@suff@(re, sizeof(re), format,
+                        val.real, 0);
+                if (res == NULL) {
+                    PyErr_SetString(PyExc_RuntimeError, "Error while formatting");
+                    return NULL;
+                }
+        }
+        else {
+                if (npy_isnan(val.real)) {
+                        strcpy(re, "nan");
+                }
+                else if (val.real > 0){
+                        strcpy(re, "inf");
+                }
+                else {
+                        strcpy(re, "-inf");
+                }
+        }
+
+
+        if (npy_isfinite(val.imag)) {
+                PyOS_snprintf(format, sizeof(format), _FMT2, @NAME@PREC_@KIND@);
+                res = NumPyOS_ascii_format@suff@(im, sizeof(im), format,
+                        val.imag, 0);
+                if (res == NULL) {
+                    PyErr_SetString(PyExc_RuntimeError, "Error while formatting");
+                    return NULL;
+                }
+        }
+        else {
+                if (npy_isnan(val.imag)) {
+                        strcpy(im, "+nan");
+                }
+                else if (val.imag > 0){
+                        strcpy(im, "+inf");
+                }
+                else {
+                        strcpy(im, "-inf");
+                }
+                if (!npy_isfinite(val.imag)) {
+                        strncat(im, "*", 1);
+                }
+        }
+        PyOS_snprintf(buf, sizeof(buf), "(%s%sj)", re, im);
+    }
+
+    return PyUString_FromString(buf);
+}
+
+#undef _FMT1
+#undef _FMT2
+
+/**end repeat1**/
+
+/**begin repeat1
+ * #name = float, double, longdouble#
+ * #Name = Float, Double, LongDouble#
+ * #NAME = FLOAT, DOUBLE, LONGDOUBLE#
+ * #suff = f, d, l#
+ */
+
+#define _FMT1 "%%.%i" NPY_@NAME@_FMT
+
+static PyObject *
+legacy_@name@_format@kind@(npy_@name@ val){
+    /* XXX: Find a correct size here for format string */
+    char format[64], buf[100], *res;
+    size_t i, cnt;
+
+    PyOS_snprintf(format, sizeof(format), _FMT1, @NAME@PREC_@KIND@);
+    res = NumPyOS_ascii_format@suff@(buf, sizeof(buf), format, val, 0);
+    if (res == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Error while formatting");
+        return NULL;
+    }
+
+    /* If nothing but digits after sign, append ".0" */
+    cnt = strlen(buf);
+    for (i = (buf[0] == '-') ? 1 : 0; i < cnt; ++i) {
+        if (!isdigit(Py_CHARMASK(buf[i]))) {
+            break;
+        }
+    }
+    if (i == cnt && sizeof(buf) >= cnt + 3) {
+        strcpy(&buf[cnt],".0");
+    }
+
+    return PyUString_FromString(buf);
+}
+
+#undef _FMT1
+
+/**end repeat1**/
+
+/**end repeat**/
+
+
+/*
+ *               *** END LEGACY PRINTING MODE CODE ***
+ */
+
+
 /**begin repeat
  * #kind = str, repr#
  */
@@ -795,7 +962,13 @@ static PyObject *
 @name@type_@kind@_either(npy_@name@ val, TrimMode trim_pos, TrimMode trim_sci,
                          npy_bool sign)
 {
-    npy_@name@ absval = val < 0 ? -val : val;
+    npy_@name@ absval;
+
+    if (npy_legacy_print_mode == 113) {
+        return legacy_@name@_format@kind@(val);
+    }
+
+    absval = val < 0 ? -val : val;
 
     if (absval == 0 || (absval < 1.e16L && absval >= 1.e-4L) ) {
         return format_@name@(val, 0, -1, sign, trim_pos, -1, -1, -1);
@@ -817,11 +990,16 @@ c@name@type_@kind@(PyObject *self)
     npy_c@name@ val = ((PyC@Name@ScalarObject *)self)->obval;
     TrimMode trim = TrimMode_DptZeros;
 
+    if (npy_legacy_print_mode == 113) {
+        return legacy_c@name@_format@kind@(val);
+    }
+
     if (val.real == 0.0 && npy_signbit(val.real) == 0) {
         istr = @name@type_@kind@_either(val.imag, trim, trim, 0);
         if (istr == NULL) {
             return NULL;
         }
+
         PyUString_ConcatAndDel(&istr, PyUString_FromString("j"));
         return istr;
     }
@@ -869,18 +1047,26 @@ c@name@type_@kind@(PyObject *self)
 
 /**end repeat1**/
 
+
 static PyObject *
 halftype_@kind@(PyObject *self)
 {
     npy_half val = ((PyHalfScalarObject *)self)->obval;
-    double absval = npy_half_to_double(val);
-    absval = absval < 0 ? -absval : absval;
+    float floatval = npy_half_to_float(val);
+    float absval;
+
+    if (npy_legacy_print_mode == 113) {
+        return legacy_float_format@kind@(floatval);
+    }
+
+    absval = floatval < 0 ? -floatval : floatval;
 
     if (absval == 0 || (absval < 1.e16 && absval >= 1.e-4) ) {
         return format_half(val, 0, -1, 0, TrimMode_LeaveOneZero, -1, -1, -1);
     }
     return format_half(val, 1, -1, 0, TrimMode_DptZeros, -1, -1, -1);
 }
+
 
 /**end repeat**/
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -447,6 +447,18 @@ class TestPrintOptions(object):
             "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
 
+    def test_legacy_mode_scalars(self):
+        # in legacy mode, str of floats get truncated, and complex scalars
+        # use * for non-finite imaginary part
+        np.set_printoptions(legacy='1.13')
+        assert_equal(str(np.float64(1.123456789123456789)), '1.12345678912')
+        assert_equal(str(np.complex128(complex(1, np.nan))), '(1+nan*j)')
+
+        np.set_printoptions(legacy=False)
+        assert_equal(str(np.float64(1.123456789123456789)),
+                     '1.1234567891234568')
+        assert_equal(str(np.complex128(complex(1, np.nan))), '(1+nanj)')
+
 def test_unicode_object_array():
     import sys
     if sys.version_info[0] >= 3:


### PR DESCRIPTION
Fixes #10029 

This PR makes it so legacy mode preserves the truncation behavior for `str(np.floatxx())`, and the `*` behavior of complex scalars (eg `(1+nan*j)`) from numpy 1.13.

The implementation was just to cut-n-paste the old str/repr code from numpy 1.13, with minor modifications to fit it in. Then I add a C global variable which is set in legacy mode, and then use the old str/repr code if it is set.