### PR TITLE
DEP: FutureWarning for void.item(): Will return bytes

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -33,6 +33,7 @@ from ``np.array([1, 2, 3])[np.True_]``. This behavior is deprecated.
   empty, use ``array.size > 0``.
 * Calling ``np.bincount`` with ``minlength=None`` is deprecated - instead,
   ``minlength=0`` should be used.
+
 ``np.fromstring`` should always be passed a ``sep`` argument
 ------------------------------------------------------------
 Without this argument, this falls back on a broken version of `np.frombuffer`
@@ -65,6 +66,13 @@ dimensions. A FutureWarning is given if the parameter is not passed explicitly.
   writeable. Currently it returns a non-writeable copy. See gh-7054 for a
   discussion of the issue.
 
+unstructured void array's ``.item`` method will return a bytes object
+---------------------------------------------------------------------
+In the future calling ``.item()`` on arrays or scalars of ``np.void`` datatype
+will return a ``bytes`` object instead of a buffer or int array, the same as
+returned by ``bytes(void_scalar)``. This may affect code which assumed the
+return value was mutable, which will no longer be the case. A ``FutureWarning``
+is now issued when this would occur.
 
 
 Build System Changes

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -730,6 +730,21 @@ VOID_getitem(void *input, void *vap)
         return (PyObject *)ret;
     }
 
+    /* 2017-11-26, 1.14 */
+    if (DEPRECATE_FUTUREWARNING(
+            "the `.item()` method of unstructured void types will return an "
+            "immutable `bytes` object in the near future, the same as "
+            "returned by `bytes(void_obj)`, instead of the mutable memoryview "
+            "or integer array returned in numpy 1.13.") < 0) {
+        return NULL;
+    }
+    /*
+     * In the future all the code below will be replaced by
+     *
+     *       For unstructured void types like V4, return a bytes object (copy).
+     *     return PyBytes_FromStringAndSize(PyArray_DATA(ap), descr->elsize);
+     */
+
     if (PyDataType_FLAGCHK(descr, NPY_ITEM_HASOBJECT)
             || PyDataType_FLAGCHK(descr, NPY_ITEM_IS_POINTER)) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2234,6 +2234,15 @@ class TestRegression(object):
             item2 = copy.copy(item)
             assert_equal(item, item2)
 
+    def test_void_item_memview(self):
+        va = np.zeros(10, 'V4')
+        # for now, there is just a futurewarning
+        assert_warns(FutureWarning, va[:1].item)
+        # in the future, test we got a bytes copy:
+        #x = va[:1].item()
+        #va[0] = b'\xff\xff\xff\xff'
+        #del va
+        #assert_equal(x, b'\x00\x00\x00\x00')
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This PR holds off on the changes of #8157  (to fix #8129), and instead issues a FutureWarning if anyone calls `void.item()`. We would push off #8157 to 1.15.