### PR TITLE
DOC: Add copy of deprecated defindex.html template.

### DIFF
--- a/doc/source/_templates/defindex.html
+++ b/doc/source/_templates/defindex.html
@@ -1,0 +1,35 @@
+{#
+    basic/defindex.html
+    ~~~~~~~~~~~~~~~~~~~
+
+    Default template for the "index" page.
+
+    :copyright: Copyright 2007-2017 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- extends "layout.html" %}
+{% set title = _('Overview') %}
+{% block body %}
+  <h1>{{ docstitle|e }}</h1>
+  <p>
+    {{ _('Welcome! This is') }}
+    {% block description %}{{ _('the documentation for') }} {{ project|e }}
+    {{ release|e }}{% if last_updated %}, {{ _('last updated') }} {{ last_updated|e }}{% endif %}{% endblock %}.
+  </p>
+  {% block tables %}
+  <p><strong>{{ _('Indices and tables:') }}</strong></p>
+  <table class="contentstable"><tr>
+    <td style="width: 50%">
+      <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{{ _('Complete Table of Contents') }}</a><br>
+         <span class="linkdescr">{{ _('lists all sections and subsections') }}</span></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{{ _('Search Page') }}</a><br>
+         <span class="linkdescr">{{ _('search this documentation') }}</span></p>
+    </td><td style="width: 50%">
+      <p class="biglink"><a class="biglink" href="{{ pathto("modindex") }}">{{ _('Global Module Index') }}</a><br>
+         <span class="linkdescr">{{ _('quick access to all modules') }}</span></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{{ _('General Index') }}</a><br>
+         <span class="linkdescr">{{ _('all functions, classes, terms') }}</span></p>
+    </td></tr>
+  </table>
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
NumPy currently uses defindex.html, which has been deprecated upstream
in Sphinx. Here we add a copy to NumPy and remove the deprecation
warning that resulted in an unwanted "None" appearing at the top of some
documentation pages.

[ci skip]

Closes #9676.