### PR TITLE
DOC: mention generalized ufuncs, document signature attribute

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -387,7 +387,9 @@ advanced usage and will not typically be used.
     search and choose a particular loop. A list of available signatures is
     provided by the **types** attribute of the ufunc object. For backwards
     compatibility this argument can also be provided as *sig*, although
-    the long form is preferred.
+    the long form is preferred. Note that this should not be confused with
+    the generalized ufunc signature that is stored in the **signature**
+    attribute of the of the ufunc object.
 
 *extobj*
 

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -334,7 +334,7 @@ advanced usage and will not typically be used.
     Accepts a boolean array which is broadcast together with the operands.
     Values of True indicate to calculate the ufunc at that position, values
     of False indicate to leave the value in the output alone. This argument
-    cannot be used for generalized ufuncs (as these take non-scalar input).
+    cannot be used for generalized ufuncs as those take non-scalar input.
 
 *casting*
 

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -17,13 +17,16 @@ operates on :class:`ndarrays <ndarray>` in an element-by-element fashion,
 supporting :ref:`array broadcasting <ufuncs.broadcasting>`, :ref:`type
 casting <ufuncs.casting>`, and several other standard features. That
 is, a ufunc is a ":term:`vectorized`" wrapper for a function that
-takes a fixed number of scalar inputs and produces a fixed number of
-scalar outputs.
+takes a fixed number of specific inputs and produces a fixed number of
+specific outputs.
 
 In NumPy, universal functions are instances of the
 :class:`numpy.ufunc` class. Many of the built-in functions are
-implemented in compiled C code, but :class:`ufunc` instances can also
-be produced using the :func:`frompyfunc` factory function.
+implemented in compiled C code. The basic ufuncs operate on scalars, but
+there is also a generalized kind for which the basic elements are sub-arrays
+(vectors, matrices, etc.), and broadcasting is done over other dimensions.
+One can also produce custom :class:`ufunc` instances using the
+:func:`frompyfunc` factory function.
 
 
 .. _ufuncs.broadcasting:
@@ -34,7 +37,9 @@ Broadcasting
 .. index:: broadcasting
 
 Each universal function takes array inputs and produces array outputs
-by performing the core function element-wise on the inputs. Standard
+by performing the core function element-wise on the inputs (where an
+element is generally a scalar, but can be a vector or higher-order
+sub-array for generalized ufuncs). Standard
 broadcasting rules are applied so that inputs not sharing exactly the
 same shapes can still be usefully operated on. Broadcasting can be
 understood by four rules:
@@ -102,8 +107,12 @@ Output type determination
 
 The output of the ufunc (and its methods) is not necessarily an
 :class:`ndarray`, if all input arguments are not :class:`ndarrays <ndarray>`.
+Indeed, if any input defines an :obj:`~class.__array_ufunc__` method,
+control will be passed completely to that function, i.e., the ufunc is
+`overridden <ufuncs.overrides>`_.
 
-All output arrays will be passed to the :obj:`~class.__array_prepare__` and
+If none of the inputs overrides the ufunc, then
+all output arrays will be passed to the :obj:`~class.__array_prepare__` and
 :obj:`~class.__array_wrap__` methods of the input (besides
 :class:`ndarrays <ndarray>`, and scalars) that defines it **and** has
 the highest :obj:`~class.__array_priority__` of any other input to the
@@ -275,6 +284,8 @@ whether the precision of the scalar constant will cause upcasting on
 your large (small precision) array.
 
 
+.. _ufuncs.overrides:
+
 Overriding Ufunc behavior
 =========================
 
@@ -322,7 +333,8 @@ advanced usage and will not typically be used.
 
     Accepts a boolean array which is broadcast together with the operands.
     Values of True indicate to calculate the ufunc at that position, values
-    of False indicate to leave the value in the output alone.
+    of False indicate to leave the value in the output alone. This argument
+    cannot be used for generalized ufuncs (as these take non-scalar input).
 
 *casting*
 
@@ -417,13 +429,14 @@ possess. None of the attributes can be set.
    ufunc.ntypes
    ufunc.types
    ufunc.identity
+   ufunc.signature
 
 .. _ufuncs.methods:
 
 Methods
 -------
 
-All ufuncs have four methods. However, these methods only make sense on
+All ufuncs have four methods. However, these methods only make sense on scalar
 ufuncs that take two input arguments and return one output argument.
 Attempting to call these methods on other ufuncs will cause a
 :exc:`ValueError`. The reduce-like methods all take an *axis* keyword, a *dtype*
@@ -489,7 +502,7 @@ is called internally when ``a + b`` is written and *a* or *b* is an
 call in order to use the optional output argument(s) to place the
 output(s) in an object (or objects) of your choice.
 
-Recall that each ufunc operates element-by-element. Therefore, each
+Recall that each ufunc operates element-by-element. Therefore, each scalar
 ufunc will be described as if acting on a set of scalar inputs to
 return a set of scalar outputs.
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -2793,11 +2793,11 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('flags',
     ALIGNED (A)
         The data and all elements are aligned appropriately for the hardware.
     WRITEBACKIFCOPY (X)
-        This array is a copy of some other array. The C-API function 
+        This array is a copy of some other array. The C-API function
         PyArray_ResolveWritebackIfCopy must be called before deallocating
         to the base array will be updated with the contents of this array.
     UPDATEIFCOPY (U)
-        (Deprecated, use WRITEBACKIFCOPY) This array is a copy of some other array. 
+        (Deprecated, use WRITEBACKIFCOPY) This array is a copy of some other array.
         When this array is
         deallocated, the base array will be updated with the contents of
         this array.
@@ -3118,7 +3118,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('__copy__',
     """a.__copy__()
 
     Used if :func:`copy.copy` is called on an array. Returns a copy of the array.
-    
+
     Equivalent to ``a.copy(order='K')``.
 
     """))
@@ -3144,7 +3144,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('__setstate__',
     """a.__setstate__(state, /)
 
     For unpickling.
-    
+
     The `state` argument must be a sequence that contains the following
     elements:
 
@@ -5422,7 +5422,7 @@ add_newdoc('numpy.core.multiarray', 'unpackbits',
     axis : int, optional
         The dimension over which bit-unpacking is done.
         ``None`` implies unpacking the flattened array.
-    
+
     Returns
     -------
     unpacked : ndarray, uint8 type
@@ -5663,6 +5663,36 @@ add_newdoc('numpy.core', 'ufunc', ('types',
 
     """))
 
+add_newdoc('numpy.core', 'ufunc', ('signature',
+    """
+    Definition of the core elements a generalized ufunc operates on.
+
+    The signature determines how the dimensions of each input/output array
+    are split into core and loop dimensions:
+
+    1. Each dimension in the signature is matched to a dimension of the
+       corresponding passed-in array, starting from the end of the shape tuple.
+    2. Core dimensions assigned to the same label in the signature must have
+       exactly matching sizes, no broadcasting is performed.
+    3. The core dimensions are removed from all inputs and the remaining
+       dimensions are broadcast together, defining the loop dimensions.
+
+    Notes
+    -----
+    Generalized ufuncs are used internally in many linalg functions, and in
+    the testing suite; the examples below are taken from these.
+    For ufuncs that operate on scalars, the signature is `None`, which is
+    equivalent to '()' for every argument.
+
+    Examples
+    --------
+    >>> np.core.umath_tests.matrix_multiply.signature
+    '(m,n),(n,p)->(m,p)'
+    >>> np.linalg._umath_linalg.det.signature
+    '(m,m)->()'
+    >>> np.add.signature is None
+    True  # equivalent to '(),()->()'
+    """))
 
 ##############################################################################
 #


### PR DESCRIPTION
While trying to add documentation for the new `axes` argument for generalized ufuncs (#8819), I realized that the current documentation does not actually discuss generalized ufuncs at all (except in the C API section), and that the signature attribute is not documented. This PR attempts to correct that. Since we do not expose any generalized ufuncs yet (though may soon; #8528), I kept it brief.

As a bonus, now the ufunc section also mentions `__array_ufunc__`...

p.s. I seem unable to generate documentation (segmentation faults), so am not able to test the links...