### PR TITLE
BUG: Fix out-of-bounds access when handling rank-zero ndarrays.

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -243,7 +243,9 @@ array_iter_base_init(PyArrayIterObject *it, PyArrayObject *ao)
     it->ao = ao;
     it->size = PyArray_SIZE(ao);
     it->nd_m1 = nd - 1;
-    it->factors[nd-1] = 1;
+    if (nd != 0) {
+        it->factors[nd-1] = 1;
+    }
     for (i = 0; i < nd; i++) {
         it->dims_m1[i] = PyArray_DIMS(ao)[i] - 1;
         it->strides[i] = PyArray_STRIDES(ao)[i];


### PR DESCRIPTION
A rank-zero ndarray appears to be supported in principle (e.g. `a = np.ndarray(shape=())`). However, the code currently has undefined behaviour when creating iterators over such an array.

(A rank-zero tensor is a scalar.)