### PR TITLE
ENH: Improve alignment of datetime64 arrays containing NaT

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -169,15 +169,29 @@ class TestArray2String(object):
         assert_equal(np.array2string(x),
                 "[('Sarah', [8., 7.]) ('John', [6., 7.])]")
 
-        # for issue #5692
-        A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
-        A[5:].fill(np.datetime64('NaT'))
+        np.set_printoptions(legacy='1.13')
+        try:
+            # for issue #5692
+            A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
+            A[5:].fill(np.datetime64('NaT'))
+            assert_equal(
+                np.array2string(A),
+                textwrap.dedent("""\
+                [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
+                 ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('NaT',) ('NaT',)
+                 ('NaT',) ('NaT',) ('NaT',)]""")
+            )
+        finally:
+            np.set_printoptions(legacy=False)
+
+        # same again, but with non-legacy behavior
         assert_equal(
             np.array2string(A),
             textwrap.dedent("""\
             [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
-             ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('NaT',) ('NaT',)
-             ('NaT',) ('NaT',) ('NaT',)]""")
+             ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) (                'NaT',)
+             (                'NaT',) (                'NaT',) (                'NaT',)
+             (                'NaT',)]""")
         )
 
         # and again, with timedeltas

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -565,7 +565,7 @@ class TestDateTime(object):
 
         # Check that one NaT doesn't corrupt subsequent entries
         a = np.array(['2010', 'NaT', '2030']).astype('M')
-        assert_equal(str(a), "['2010' 'NaT' '2030']")
+        assert_equal(str(a), "['2010'  'NaT' '2030']")
 
     def test_timedelta_array_str(self):
         a = np.array([-1, 0, 100], dtype='m')


### PR DESCRIPTION
Makes them consistent with timedelta

Fixes #10102