### PR TITLE
MAINT: Simplify IntegerFormatter

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -50,12 +50,6 @@ from .numerictypes import (longlong, intc, int_, float_, complex_, bool_,
                            flexible)
 import warnings
 
-if sys.version_info[0] >= 3:
-    _MAXINT = sys.maxsize
-    _MININT = -sys.maxsize - 1
-else:
-    _MAXINT = sys.maxint
-    _MININT = -sys.maxint - 1
 
 _format_options = {
     'edgeitems': 3,  # repr N leading and trailing items of each dimension
@@ -988,23 +982,15 @@ def format_float_positional(x, precision=None, unique=True,
 
 class IntegerFormat(object):
     def __init__(self, data):
-        try:
+        if data.size > 0:
             max_str_len = max(len(str(np.max(data))),
                               len(str(np.min(data))))
-            self.format = '%' + str(max_str_len) + 'd'
-        except (TypeError, NotImplementedError):
-            # if reduce(data) fails, this instance will not be called, just
-            # instantiated in formatdict.
-            pass
-        except ValueError:
-            # this occurs when everything is NA
-            pass
+        else:
+            max_str_len = 0
+        self.format = '%{}d'.format(max_str_len)
 
     def __call__(self, x):
-        if _MININT < x < _MAXINT:
-            return self.format % x
-        else:
-            return "%s" % x
+        return self.format % x
 
 
 class BoolFormat(object):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -4,6 +4,7 @@ import warnings
 import sys
 import os
 import itertools
+import textwrap
 
 import numpy as np
 from numpy.testing import (
@@ -289,16 +290,18 @@ class TestEqual(TestArrayEqual):
         except AssertionError as e:
             msg = str(e)
             msg2 = msg.replace("shapes (2L,), (1L, 2L)", "shapes (2,), (1, 2)")
-            msg_reference = "\nArrays are not equal\n\n" \
-                "(shapes (2,), (1, 2) mismatch)\n" \
-                " x: array([1, 2])\n" \
-                " y: [repr failed for <matrix>: The truth value of an array " \
-                "with more than one element is ambiguous. Use a.any() or " \
-                "a.all()]"
+            msg_reference = textwrap.dedent("""\
+
+            Arrays are not equal
+
+            (shapes (2,), (1, 2) mismatch)
+             x: array([1, 2])
+             y: [repr failed for <matrix>: %d format: a number is required, not matrix]""")
             try:
                 self.assertEqual(msg, msg_reference)
             except AssertionError:
                 self.assertEqual(msg2, msg_reference)
+
 
 class TestArrayAlmostEqual(_GenericTest, unittest.TestCase):
 


### PR DESCRIPTION
This essentially reverts 83accefd143a0e3ee8b3160d0927b3ff616743de, which presumably worked around a bug in an ancient version of python

Similarly, the try/excepts here were to handle `IntegerFormatter` being called on the wrong type of array, which no longer happens