### PR TITLE
MAINT: Remove duplicate cond check from assert_array_compare

### DIFF
--- a/numpy/testing/nose_tools/utils.py
+++ b/numpy/testing/nose_tools/utils.py
@@ -773,8 +773,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                                 + '\n(mismatch %s%%)' % (match,),
                                 verbose=verbose, header=header,
                                 names=('x', 'y'), precision=precision)
-            if not cond:
-                raise AssertionError(msg)
+            raise AssertionError(msg)
     except ValueError:
         import traceback
         efmt = traceback.format_exc()


### PR DESCRIPTION
We already in "if not cond" branch of code, we don't need to check it again