### PR TITLE
BLD: [ipo] compilation error with intel compiler

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -216,6 +216,24 @@ def check_long_double_representation(cmd):
         except (AttributeError, ValueError):
             pass
 
+    # Disable multi-file interprocedural optimization in the Intel compiler on Linux
+    # which generates intermediary object files and prevents checking the
+    # float representation.
+    elif sys.platform != "win32" and cmd.compiler.compiler_type.startswith('intel') \
+            and '-ipo' in cmd.compiler.cc_exe:
+        try:
+            newcompiler = cmd.compiler.cc_exe.replace(' -ipo', '')
+            cmd.compiler.set_executables(
+                compiler=newcompiler,
+                compiler_so=newcompiler,
+                compiler_cxx=newcompiler,
+                linker_exe=newcompiler,
+                linker_so=newcompiler + ' -shared'
+            )
+        except (AttributeError, ValueError):
+            pass
+
+
     # We need to use _compile because we need the object filename
     src, obj = cmd._compile(body, None, None, 'c')
     try:

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -219,8 +219,9 @@ def check_long_double_representation(cmd):
     # Disable multi-file interprocedural optimization in the Intel compiler on Linux
     # which generates intermediary object files and prevents checking the
     # float representation.
-    elif sys.platform != "win32" and cmd.compiler.compiler_type.startswith('intel') \
-            and '-ipo' in cmd.compiler.cc_exe:        
+    elif (sys.platform != "win32" 
+            and cmd.compiler.compiler_type.startswith('intel') 
+            and '-ipo' in cmd.compiler.cc_exe):        
         newcompiler = cmd.compiler.cc_exe.replace(' -ipo', '')
         cmd.compiler.set_executables(
             compiler=newcompiler,

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -220,19 +220,15 @@ def check_long_double_representation(cmd):
     # which generates intermediary object files and prevents checking the
     # float representation.
     elif sys.platform != "win32" and cmd.compiler.compiler_type.startswith('intel') \
-            and '-ipo' in cmd.compiler.cc_exe:
-        try:
-            newcompiler = cmd.compiler.cc_exe.replace(' -ipo', '')
-            cmd.compiler.set_executables(
-                compiler=newcompiler,
-                compiler_so=newcompiler,
-                compiler_cxx=newcompiler,
-                linker_exe=newcompiler,
-                linker_so=newcompiler + ' -shared'
-            )
-        except (AttributeError, ValueError):
-            pass
-
+            and '-ipo' in cmd.compiler.cc_exe:        
+        newcompiler = cmd.compiler.cc_exe.replace(' -ipo', '')
+        cmd.compiler.set_executables(
+            compiler=newcompiler,
+            compiler_so=newcompiler,
+            compiler_cxx=newcompiler,
+            linker_exe=newcompiler,
+            linker_so=newcompiler + ' -shared'
+        )
 
     # We need to use _compile because we need the object filename
     src, obj = cmd._compile(body, None, None, 'c')


### PR DESCRIPTION
patched `numpy/core/setup_common.py` to check for the `-ipo` flag when running the intel compiler and not on windows

before checking for the long double representation, as this option causes the compiler to generate intermediary object files
and interferes with checking the representation.  This had already been done for MSVC style compilers.

this is referenced in #4992 