### PR TITLE
ENH: Print funny-shaped empty arrays using "empty"

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -502,6 +502,15 @@ class TestPrintOptions(object):
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
                   dtype='{}')""".format(styp)))
 
+    def test_empty(self):
+        assert_equal(repr(np.ones((0,))), "array([], dtype=float64)")
+        assert_equal(repr(np.ones((2,0))), "empty((2, 0), dtype=float64)")
+        np.set_printoptions(legacy='1.13')
+        assert_equal(repr(np.ones((0,))), "array([], dtype=float64)")
+        assert_equal(repr(np.ones((2,0))),
+            "array([], shape=(2, 0), dtype=float64)")
+
+
 def test_unicode_object_array():
     import sys
     if sys.version_info[0] >= 3:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3908,6 +3908,8 @@ class MaskedArray(ndarray):
             self.size == 0
         )
 
+        is_ndim_empty = self.size == 0 and len(self.shape) > 1
+
         # determine which keyword args need to be shown
         keys = ['data', 'mask', 'fill_value']
         if dtype_needed:
@@ -3918,7 +3920,7 @@ class MaskedArray(ndarray):
 
         # choose what to indent each keyword with
         min_indent = 2
-        if is_one_row:
+        if is_one_row or is_ndim_empty:
             # first key on the same line as the type, remaining keys
             # aligned by equals
             indents = {}
@@ -3945,6 +3947,8 @@ class MaskedArray(ndarray):
         reprs['fill_value'] = repr(self.fill_value)
         if dtype_needed:
             reprs['dtype'] = np.core.arrayprint.dtype_short_repr(self.dtype)
+        if is_ndim_empty:
+            reprs['data'] = 'empty({})'.format(self.shape)
 
         # join keys with values and indentations
         result = ',\n'.join(

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -555,7 +555,15 @@ class TestMaskedArray(object):
               fill_value=999999)''')
         )
 
-
+        # empty arrays with unusual shapes display it
+        assert_equal(
+            repr(array(np.empty((0,2), dtype='f8'))),
+            textwrap.dedent('''\
+            masked_array(data=empty((0, 2)),
+                         mask=False,
+                   fill_value=1e+20,
+                        dtype=float64)''')
+        )
 
     def test_str_repr_legacy(self):
         oldopts = np.get_printoptions()
@@ -575,6 +583,7 @@ class TestMaskedArray(object):
                 '             mask = [False  True  True ... False False False],\n'
                 '       fill_value = 999999)\n'
             )
+
         finally:
             np.set_printoptions(**oldopts)
 


### PR DESCRIPTION
Makes arrays like `np.empty((2,0,1))` print as `np.empty((2,0,1), dtype=float64)`. The old behavior was to print as `np.array([], dtype=float64)` no matte the shape, which could be misleading.

This was discussed in #9792 