### PR TITLE
ENH: Faster algorithm for `np.random.choice`.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1167,25 +1167,12 @@ cdef class RandomState:
                                  "population when 'replace=False'")
 
             if p is not None:
-                if np.count_nonzero(p > 0) < size:
-                    raise ValueError("Fewer non-zero entries in p than size")
-                n_uniq = 0
-                p = p.copy()
-                found = np.zeros(shape, dtype=np.int)
-                flat_found = found.ravel()
-                while n_uniq < size:
-                    x = self.rand(size - n_uniq)
-                    if n_uniq > 0:
-                        p[flat_found[0:n_uniq]] = 0
-                    cdf = np.cumsum(p)
-                    cdf /= cdf[-1]
-                    new = cdf.searchsorted(x, side='right')
-                    _, unique_indices = np.unique(new, return_index=True)
-                    unique_indices.sort()
-                    new = new.take(unique_indices)
-                    flat_found[n_uniq:n_uniq + new.size] = new
-                    n_uniq += new.size
-                idx = found
+              if np.count_nonzero(p > 0) < size:
+                  raise ValueError("Fewer non-zero entries in p than size")
+              key = np.random.exponential(size = pop_size)/p
+              idx = np.argpartition(-key, size - 1)[:size]
+              if shape is not None:
+                  idx.shape = shape
             else:
                 idx = self.permutation(pop_size)[:size]
                 if shape is not None:


### PR DESCRIPTION
Replacing the Random Choice with replacement with a more efficient version taken from here: https://stackoverflow.com/questions/15113650/faster-weighted-sampling-without-replacement/15205104#15205104

And published here:
http://www.sciencedirect.com/science/article/pii/S002001900500298X#

The basic idea is we determine a key for each item to be sampled from, based on 'a random uniform number and raising it to the power of one over the weight for each item'. Here we do it in log space, for numerical stability. Then we take the `size` highest, by a partition sort.

For me, it is roughly double as fast, on both 50,20 and 50000, 20000 for size and samples:

> sizeofsample, nsample = 50, 20
> p = np.random.uniform(size = sizeofsample)
> p = p/sum(p)
> data = np.arange(sizeofsample)
> 
> %%timeit
> np.random.choice(data, p = p, replace = False, size = nsample)

It fails on one unit test, test_choice_nonuniform_noreplace, as the randomly chosen numbers are different, due to the different algorithm. The rest pass.

I am not 100% sure on the `size -1` in the argpartition, review is more than welcome.
