### PR TITLE
BLD: Add license file to NumPy wheels.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ recursive-include numpy/random/mtrand *.pyx *.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed
 recursive-include numpy/_build_utils *
 recursive-include numpy/linalg/lapack_lite *.c *.h
+include tox.ini
 # Add sdist files whose use depends on local configuration.
 include numpy/core/src/multiarray/cblasfuncs.c
 include numpy/core/src/multiarray/python_xerbla.c
@@ -26,4 +27,4 @@ recursive-include doc/sphinxext *
 recursive-include tools/swig *
 recursive-include doc/scipy-sphinx-theme *
 
-global-exclude *.pyc *.pyo *.pyd
+global-exclude *.pyc *.pyo *.pyd *.swp *.bak *~

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def git_version():
         env['LANGUAGE'] = 'C'
         env['LANG'] = 'C'
         env['LC_ALL'] = 'C'
-        out = subprocess.Popen(cmd, stdout = subprocess.PIPE, env=env).communicate()[0]
+        out = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
         return out
 
     try:
@@ -147,8 +147,8 @@ if not release:
     a = open(filename, 'w')
     try:
         a.write(cnt % {'version': VERSION,
-                       'full_version' : FULLVERSION,
-                       'git_revision' : GIT_REVISION,
+                       'full_version': FULLVERSION,
+                       'git_revision': GIT_REVISION,
                        'isrelease': str(ISRELEASED)})
     finally:
         a.close()
@@ -164,6 +164,7 @@ def configuration(parent_package='',top_path=None):
                        quiet=True)
 
     config.add_subpackage('numpy')
+    config.add_data_files(('numpy', 'LICENSE.txt'))
 
     config.get_version('numpy/version.py') # sets config.version
 


### PR DESCRIPTION
The `LICENSE.txt` file needs to be in the numpy wheels in order to meet the terms of the linked libraries. Add it to the configuration datafiles so that it shows up in the numpy package.

Also a small update to `MANIFEST.in` adding `tox.ini` and excluding more development artifacts.
`