### PR TITLE
ENH: Strip trailing spaces from continuation in multiline arrayprint

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -662,16 +662,20 @@ def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
     else:
         s = '['
         sep = separator.rstrip()
+        line_sep = '\n'*max(rank-1, 1)
         for i in range(leading_items):
             if i > 0:
                 s += next_line_prefix
             s += _formatArray(a[i], format_function, rank-1, max_line_len,
                               " " + next_line_prefix, separator, edge_items,
                               summary_insert, legacy)
-            s = s.rstrip() + sep.rstrip() + '\n'*max(rank-1, 1)
+            s = s.rstrip() + sep.rstrip() + line_sep
 
         if summary_insert1:
-            s += next_line_prefix + summary_insert1 + "\n"
+            if legacy == '1.13':
+                s += next_line_prefix + summary_insert1 + "\n"
+            else:
+                s += next_line_prefix + summary_insert1.strip() + line_sep
 
         for i in range(trailing_items, 1, -1):
             if leading_items or i != trailing_items:
@@ -679,7 +683,7 @@ def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
             s += _formatArray(a[-i], format_function, rank-1, max_line_len,
                               " " + next_line_prefix, separator, edge_items,
                               summary_insert, legacy)
-            s = s.rstrip() + sep.rstrip() + '\n'*max(rank-1, 1)
+            s = s.rstrip() + sep.rstrip() + line_sep
         if leading_items or trailing_items > 1:
             s += next_line_prefix
         s += _formatArray(a[-1], format_function, rank-1, max_line_len,

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -509,6 +509,77 @@ class TestPrintOptions(object):
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
                   dtype='{}')""".format(styp)))
 
+    def test_edgeitems(self):
+        np.set_printoptions(edgeitems=1, threshold=1)
+        a = np.arange(27).reshape((3, 3, 3))
+        assert_equal(
+            repr(a),
+            textwrap.dedent("""\
+            array([[[ 0, ...,  2],
+                    ...,
+                    [ 6, ...,  8]],
+
+                   ...,
+
+                   [[18, ..., 20],
+                    ...,
+                    [24, ..., 26]]])""")
+        )
+
+        b = np.zeros((3, 3, 1, 1))
+        assert_equal(
+            repr(b),
+            textwrap.dedent("""\
+            array([[[[0.]],
+
+                    ...,
+
+                    [[0.]]],
+
+
+                   ...,
+
+
+                   [[[0.]],
+
+                    ...,
+
+                    [[0.]]]])""")
+        )
+
+        # 1.13 had extra trailing spaces, and was missing newlines
+        np.set_printoptions(legacy='1.13')
+
+        assert_equal(
+            repr(a),
+            textwrap.dedent("""\
+            array([[[ 0, ...,  2],
+                    ..., 
+                    [ 6, ...,  8]],
+
+                   ..., 
+                   [[18, ..., 20],
+                    ..., 
+                    [24, ..., 26]]])""")
+        )
+
+        assert_equal(
+            repr(b),
+            textwrap.dedent("""\
+            array([[[[ 0.]],
+
+                    ..., 
+                    [[ 0.]]],
+
+
+                   ..., 
+                   [[[ 0.]],
+
+                    ..., 
+                    [[ 0.]]]])""")
+        )
+
+
 def test_unicode_object_array():
     import sys
     if sys.version_info[0] >= 3:


### PR DESCRIPTION
This is otherwise pretty strict about trailing spaces, so we may as well cut them here too, especially since the repr has changed here already

Extracted from #10123, and with tests added - it turns out that we never tested this code path.

Milestoned for 1.14 since it's a formatting change