### PR TITLE
BUG: Fix downcasting in _array2string

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -427,12 +427,14 @@ def _recursive_guard(fillvalue='...'):
 # gracefully handle recursive calls, when object arrays contain themselves
 @_recursive_guard()
 def _array2string(a, options, separator=' ', prefix=""):
+    # The formatter __init__s cannot deal with subclasses yet
+    data = asarray(a)
+
     if a.size > options['threshold']:
         summary_insert = "..."
-        data = _leading_trailing(a)
+        data = _leading_trailing(data)
     else:
         summary_insert = ""
-        data = asarray(a)
 
     # find the right formatting function for the array
     format_function = _get_format_function(data, **options)


### PR DESCRIPTION
If there are no elements to remove, _leading_trailing returns a subclass view, rather than its normal behaviour of returning an ndarray copy.

Since we call `asarray` in the other branch of this `if` anyway, we may as well do it in both.

---

I wasn't able to construct a test for this. The first step would be to set the threshold much lower than the edge items:

```
np.set_printoptions(edgeitems=200, threshold=1)
```

But I can't construct any cases that pass after but fail before.

Split from #10123