### PR TITLE
BUG: np.matrix does not return an array when given a full index ending in …

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -289,8 +289,8 @@ class matrix(N.ndarray):
             return out
 
         if out.ndim == 0:
-            return out[()]
-        if out.ndim == 1:
+            out.shape = (1, 1)
+        elif out.ndim == 1:
             sh = out.shape[0]
             # Determine when we should have a column array
             try:

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -394,6 +394,17 @@ class TestNewScalarIndexing(object):
         assert_array_equal(x[:, [1, 0]], x[:, ::-1])
         assert_array_equal(x[[2, 1, 0],:], x[::-1,:])
 
+    def test_ellipsis_indexing(self):
+        A = np.arange(6)
+        A.shape = (3, 2)
+        x = asmatrix(A)
+
+        # Indexing with ... would normally return a 0d array, but np.matrix
+        # promotes to 2d as usual
+        x_item = x[1, 1, ...]
+        assert_(type(x_item) is matrix)
+        assert_equal(x_item.shape, (1, 1))
+
 
 class TestPower(object):
     def test_returntype(self):


### PR DESCRIPTION
This is similar to gh-8684, but for matrices instead of masked arrays.

Fixing this for all the possible placements of `...` is way harder, but this is better than nothing. `matrix` is already broken for most exotic indices anyway.