### PR TITLE
BUG: Fix corner cases when value is NaN.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2940,7 +2940,7 @@ static int _safe_ceil_to_intp(double value, npy_intp* ret)
     double ivalue;
 
     ivalue = npy_ceil(value);
-    if (npy_isnan(ivalue) || ivalue < NPY_MIN_INTP || ivalue > NPY_MAX_INTP) {
+    if (!(NPY_MIN_INTP <= ivalue && ivalue < NPY_MAX_INTP)) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2939,6 +2939,14 @@ static int _safe_ceil_to_intp(double value, npy_intp* ret)
 {
     double ivalue;
 
+#if __STDC_VERSION__ >= 200000L
+    if (isnan(value))
+#else
+    if (value != value)
+#endif
+      return -1;
+
+/* The following is only correct when value is not NaN. */
     ivalue = npy_ceil(value);
     if (ivalue < NPY_MIN_INTP || ivalue > NPY_MAX_INTP) {
         return -1;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2939,16 +2939,8 @@ static int _safe_ceil_to_intp(double value, npy_intp* ret)
 {
     double ivalue;
 
-#if __STDC_VERSION__ >= 200000L
-    if (isnan(value))
-#else
-    if (value != value)
-#endif
-      return -1;
-
-/* The following is only correct when value is not NaN. */
     ivalue = npy_ceil(value);
-    if (ivalue < NPY_MIN_INTP || ivalue > NPY_MAX_INTP) {
+    if (npy_isnan(ivalue) || ivalue < NPY_MIN_INTP || ivalue > NPY_MAX_INTP) {
         return -1;
     }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2940,7 +2940,8 @@ static int _safe_ceil_to_intp(double value, npy_intp* ret)
     double ivalue;
 
     ivalue = npy_ceil(value);
-    if (!(NPY_MIN_INTP <= ivalue && ivalue < NPY_MAX_INTP)) {
+    /* condition inverted to handle NaN */
+    if (!(NPY_MIN_INTP <= ivalue && ivalue <= NPY_MAX_INTP)) {
         return -1;
     }
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7282,6 +7282,10 @@ def test_npymath_real():
                 expected = npfun(z)
                 assert_allclose(got, expected)
 
+# Test when (stop - start) / step is NaN, ValueError is raised instead
+# of returning a zero-length array.
+def test_arange_nan():
+    assert_raises(ValueError, np.arange, 0, 1, np.nan)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The case is illustrated below:
In "_safe_ceil_to_intp":
    ivalue = npy_ceil(value);   <= ivalue is NaN when value is NaN.
    if (ivalue < NPY_MIN_INTP || ivalue > NPY_MAX_INTP) {
        return -1;  <= this is never executed when ivalue is NaN.
    }

    *ret = (npy_intp)ivalue;  <= this is undefined behavior when ivalue is NaN.