### PR TITLE
Experiment/WIP:   require explicit `dtype='O'` for object array creation 

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1701,6 +1701,15 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
                     (dtype == NULL) ? PyArray_DESCR(arr) : dtype,
                     &newtype);
     }
+    
+    /* if object was not requested, but we got it, and is not 0d, fail */
+    if (ndim != 0 && dtype != NULL && dtype->type_num == NPY_OBJECT) {
+        if (newtype == NULL) {
+            PyErr_SetString(PyExc_ValueError,
+                    "object could not be converted to a numpy type.");
+            return NULL;
+        }
+    }
 
     /* If we got dimensions and dtype instead of an array */
     if (arr == NULL) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -498,7 +498,10 @@ prepare_index(PyArrayObject *self, PyObject *index,
             PyArrayObject *tmp_arr;
             tmp_arr = (PyArrayObject *)PyArray_FROM_O(obj);
             if (tmp_arr == NULL) {
-                /* TODO: Should maybe replace the error here? */
+                PyErr_SetString(PyExc_IndexError,
+                        "only integers, slices (`:`), ellipsis (`...`), "
+                        "numpy.newaxis (`None`) and integer or boolean "
+                        "arrays are valid indices");
                 goto failed_building_indices;
             }
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -35,18 +35,18 @@ class TestArrayRepr(object):
         )
 
     def test_self_containing(self):
-        arr0d = np.array(None)
+        arr0d = np.array(None, dtype='O')
         arr0d[()] = arr0d
         assert_equal(repr(arr0d),
             'array(array(..., dtype=object), dtype=object)')
 
-        arr1d = np.array([None, None])
+        arr1d = np.array([None, None], dtype='O')
         arr1d[1] = arr1d
         assert_equal(repr(arr1d),
             'array([None, array(..., dtype=object)], dtype=object)')
 
-        first = np.array(None)
-        second = np.array(None)
+        first = np.array(None, dtype='O')
+        second = np.array(None, dtype='O')
         first[()] = second
         second[()] = first
         assert_equal(repr(first),
@@ -54,7 +54,7 @@ class TestArrayRepr(object):
 
     def test_containing_list(self):
         # printing square brackets directly would be ambiguuous
-        arr1d = np.array([None, None])
+        arr1d = np.array([None, None], dtype='O')
         arr1d[0] = [1, 2]
         arr1d[1] = [3]
         assert_equal(repr(arr1d),

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -226,26 +226,24 @@ class TestDateTime(object):
         # at the moment, we don't automatically convert these to datetime64
 
         dt = datetime.date(1970, 1, 1)
-        arr = np.array([dt])
-        assert_equal(arr.dtype, np.dtype('O'))
+        assert_raises(ValueError, np.array, [dt])
 
         dt = datetime.datetime(1970, 1, 1, 12, 30, 40)
-        arr = np.array([dt])
-        assert_equal(arr.dtype, np.dtype('O'))
+        assert_raises(ValueError, np.array, [dt])
 
         # find "supertype" for non-dates and dates
 
         b = np.bool_(True)
         dt = np.datetime64('1970-01-01', 'M')
-        arr = np.array([b, dt])
+        arr = np.array([b, dt], dtype='O')
         assert_equal(arr.dtype, np.dtype('O'))
 
         dt = datetime.date(1970, 1, 1)
-        arr = np.array([b, dt])
+        arr = np.array([b, dt], dtype='O')
         assert_equal(arr.dtype, np.dtype('O'))
 
         dt = datetime.datetime(1970, 1, 1, 12, 30, 40)
-        arr = np.array([b, dt])
+        arr = np.array([b, dt], dtype='O')
         assert_equal(arr.dtype, np.dtype('O'))
 
     def test_timedelta_scalar_construction(self):
@@ -470,25 +468,26 @@ class TestDateTime(object):
                  (2000 - 1970)*365 + (2000 - 1972)//4 + 366 + 31 + 28 + 21)
 
     def test_days_to_pydate(self):
-        assert_equal(np.array('1599', dtype='M8[D]').astype('O'),
+        #XXX these tests are changed because np.array(datetime.date(1599,1,1)) fails
+        assert_equal(np.array('1599', dtype='M8[D]').item(),
                     datetime.date(1599, 1, 1))
-        assert_equal(np.array('1600', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('1600', dtype='M8[D]').item(),
                     datetime.date(1600, 1, 1))
-        assert_equal(np.array('1601', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('1601', dtype='M8[D]').item(),
                     datetime.date(1601, 1, 1))
-        assert_equal(np.array('1900', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('1900', dtype='M8[D]').item(),
                     datetime.date(1900, 1, 1))
-        assert_equal(np.array('1901', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('1901', dtype='M8[D]').item(),
                     datetime.date(1901, 1, 1))
-        assert_equal(np.array('2000', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('2000', dtype='M8[D]').item(),
                     datetime.date(2000, 1, 1))
-        assert_equal(np.array('2001', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('2001', dtype='M8[D]').item(),
                     datetime.date(2001, 1, 1))
-        assert_equal(np.array('1600-02-29', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('1600-02-29', dtype='M8[D]').item(),
                     datetime.date(1600, 2, 29))
-        assert_equal(np.array('1600-03-01', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('1600-03-01', dtype='M8[D]').item(),
                     datetime.date(1600, 3, 1))
-        assert_equal(np.array('2001-03-22', dtype='M8[D]').astype('O'),
+        assert_equal(np.array('2001-03-22', dtype='M8[D]').item(),
                     datetime.date(2001, 3, 22))
 
     def test_dtype_comparison(self):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -412,9 +412,9 @@ class TestIndexing(object):
         a = np.array(0, dtype=object)
         a[()] = b
         assert_(isinstance(a[()], np.ndarray))
-        a = np.array([b, None])
+        a = np.array([b, None], dtype='O')
         assert_(isinstance(a[z], np.ndarray))
-        a = np.array([[b, None]])
+        a = np.array([[b, None]], dtype='O')
         assert_(isinstance(a[z, np.array(0)], np.ndarray))
         assert_(isinstance(a[z, ArrayLike()], np.ndarray))
 

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -51,14 +51,14 @@ class TestTake(object):
     def test_refcounting(self):
         objects = [object() for i in range(10)]
         for mode in ('raise', 'clip', 'wrap'):
-            a = np.array(objects)
+            a = np.array(objects, dtype='O')
             b = np.array([2, 2, 4, 5, 3, 5])
             a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:
                 assert_(all(sys.getrefcount(o) == 3 for o in objects))
             # not contiguous, example:
-            a = np.array(objects * 2)[::2]
+            a = np.array(objects * 2, dtype='O')[::2]
             a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1156,7 +1156,7 @@ class TestNonzero(object):
 
     def test_nonzero_invalid_object(self):
         # gh-9295
-        a = np.array([np.array([1, 2]), 3])
+        a = np.array([np.array([1, 2]), 3], dtype='O')
         assert_raises(ValueError, np.nonzero, a)
 
         class BoolErrors:
@@ -1165,7 +1165,8 @@ class TestNonzero(object):
             def __nonzero__(self):
                 raise ValueError("Not allowed")
 
-        assert_raises(ValueError, np.nonzero, np.array([BoolErrors()]))
+        assert_raises(ValueError, np.nonzero,
+                      np.array([BoolErrors()], dtype='O'))
 
 
 class TestIndex(object):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -446,7 +446,7 @@ class TestRegression(object):
 
     def test_object_array_from_list(self):
         # Ticket #270
-        assert_(np.array([1, 'A', None]).shape == (3,))
+        assert_(np.array([1, 'A', None], dtype='O').shape == (3,))
 
     def test_multiple_assign(self):
         # Ticket #273
@@ -975,7 +975,7 @@ class TestRegression(object):
             def __float__(self):
                 return 1.0
 
-        tmp = np.atleast_1d([MyFloat()])
+        tmp = np.atleast_1d(np.array([MyFloat()], dtype='O'))
         tmp.astype(float)  # Should succeed
 
     def test_object_array_refcount_self_assign(self):
@@ -1302,13 +1302,13 @@ class TestRegression(object):
     def test_array_from_sequence_scalar_array(self):
         # Ticket #1078: segfaults when creating an array with a sequence of
         # 0d arrays.
-        a = np.array((np.ones(2), np.array(2)))
+        a = np.array((np.ones(2), np.array(2)), dtype='O')
         assert_equal(a.shape, (2,))
         assert_equal(a.dtype, np.dtype(object))
         assert_equal(a[0], np.ones(2))
         assert_equal(a[1], np.array(2))
 
-        a = np.array(((1,), np.array(1)))
+        a = np.array(((1,), np.array(1)), dtype='O')
         assert_equal(a.shape, (2,))
         assert_equal(a.dtype, np.dtype(object))
         assert_equal(a[0], (1,))
@@ -1316,7 +1316,7 @@ class TestRegression(object):
 
     def test_array_from_sequence_scalar_array2(self):
         # Ticket #1081: weird array with strange input...
-        t = np.array([np.array([]), np.array(0, object)])
+        t = np.array([np.array([]), np.array(0, object)], dtype='O')
         assert_equal(t.shape, (2,))
         assert_equal(t.dtype, np.dtype(object))
 
@@ -2074,7 +2074,7 @@ class TestRegression(object):
         # Ticket #6456.
         a = {'a': 1}
         b = {'b': 2}
-        arr = np.array([[a, b], [a, b]], order='F')
+        arr = np.array([[a, b], [a, b]], dtype='O', order='F')
         arr_cp = copy.deepcopy(arr)
 
         assert_equal(arr, arr_cp)
@@ -2163,9 +2163,10 @@ class TestRegression(object):
             x[0], x[-1] = x[-1], x[0]
 
         uf = np.frompyfunc(f, 1, 0)
-        a = np.array([[1, 2, 3], [4, 5], [6, 7, 8, 9]])
+        a = np.array([[1, 2, 3], [4, 5], [6, 7, 8, 9]], dtype='O')
         assert_equal(uf(a), ())
-        assert_array_equal(a, [[3, 2, 1], [5, 4], [9, 7, 8, 6]])
+        ret = np.array([[3, 2, 1], [5, 4], [9, 7, 8, 6]], dtype='O')
+        assert_array_equal(a, ret)
 
     @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
     def test_leak_in_structured_dtype_comparison(self):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -737,14 +737,16 @@ class TestUfunc(object):
         # Twice reproduced also for tuples:
         np.add.accumulate(arr, out=arr)
         np.add.accumulate(arr, out=arr)
-        assert_array_equal(arr, np.array([[1]*i for i in [1, 3, 6, 10]]))
+        assert_array_equal(arr,
+                           np.array([[1]*i for i in [1, 3, 6, 10]], dtype='O'))
 
         # And the same if the axis argument is used
         arr = np.ones((2, 4), dtype=object)
         arr[0, :] = [[2] for i in range(4)]
         np.add.accumulate(arr, out=arr, axis=-1)
         np.add.accumulate(arr, out=arr, axis=-1)
-        assert_array_equal(arr[0, :], np.array([[2]*i for i in [1, 3, 6, 10]]))
+        assert_array_equal(arr[0, :],
+                           np.array([[2]*i for i in [1, 3, 6, 10]], dtype='O'))
 
     def test_object_array_reduceat_inplace(self):
         # Checks that in-place reduceats work, see also gh-7465

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -187,7 +187,7 @@ class TestComparisons(object):
             def __eq__(self, other):
                 raise TypeError("I won't compare")
 
-        a = np.array([FunkyType()])
+        a = np.array([FunkyType()], dtype='O')
         assert_raises(TypeError, np.equal, a, a)
 
         # Check identity doesn't override comparison mismatch.
@@ -205,7 +205,7 @@ class TestComparisons(object):
             def __ne__(self, other):
                 raise TypeError("I won't compare")
 
-        a = np.array([FunkyType()])
+        a = np.array([FunkyType()], dtype='O')
         assert_raises(TypeError, np.not_equal, a, a)
 
         # Check identity doesn't override comparison mismatch.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -819,14 +819,14 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
                 cum_n += np.r_[sa.searchsorted(bin_edges[:-1], 'left'),
                                sa.searchsorted(bin_edges[-1], 'right')]
         else:
-            zero = array(0, dtype=ntype)
+            zero = array([0], dtype=ntype)
             for i in arange(0, len(a), BLOCK):
                 tmp_a = a[i:i+BLOCK]
                 tmp_w = weights[i:i+BLOCK]
                 sorting_index = np.argsort(tmp_a)
                 sa = tmp_a[sorting_index]
                 sw = tmp_w[sorting_index]
-                cw = np.concatenate(([zero], sw.cumsum()))
+                cw = np.concatenate((zero, sw.cumsum()))
                 bin_index = np.r_[sa.searchsorted(bin_edges[:-1], 'left'),
                                   sa.searchsorted(bin_edges[-1], 'right')]
                 cum_n += cw[bin_index]

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1088,7 +1088,7 @@ class TestTypeError1(object):
         arr = np.arange(30)
         arr = np.reshape(arr, (6, 5))
         kwargs = dict(mode='mean', stat_length=(3, ))
-        assert_raises(TypeError, pad, arr, ((2, 3, 4), (3, 2)),
+        assert_raises(ValueError, pad, arr, ((2, 3, 4), (3, 2)),
                       **kwargs)
 
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -209,7 +209,7 @@ class TestSetOps(object):
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
 
     def test_in1d_first_array_is_object(self):
-        ar1 = [None]
+        ar1 = np.array([None], dtype='O')
         ar2 = np.array([1]*10)
         expected = np.array([False])
         result = np.in1d(ar1, ar2)
@@ -217,14 +217,14 @@ class TestSetOps(object):
 
     def test_in1d_second_array_is_object(self):
         ar1 = 1
-        ar2 = np.array([None]*10)
+        ar2 = np.array([None]*10, dtype='O')
         expected = np.array([False])
         result = np.in1d(ar1, ar2)
         assert_array_equal(result, expected)
 
     def test_in1d_both_arrays_are_object(self):
-        ar1 = [None]
-        ar2 = np.array([None]*10)
+        ar1 = np.array([None], dtype='O')
+        ar2 = np.array([None]*10, dtype='O')
         expected = np.array([True])
         result = np.in1d(ar1, ar2)
         assert_array_equal(result, expected)

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -76,10 +76,15 @@ class TestFinancial(object):
         assert_equal(res, tgt)
         # Test the case where we use broadcast and
         # the arguments passed in are arrays.
-        res = np.pmt([[Decimal('0'), Decimal('0.8')], [Decimal('0.3'), Decimal('0.8')]],
-                     [Decimal('12'), Decimal('3')], [Decimal('2000'), Decimal('20000')])
-        tgt = np.array([[Decimal('-166.6666666666666666666666667'), Decimal('-19311.25827814569536423841060')],
-                        [Decimal('-626.9081401700757748402586600'), Decimal('-19311.25827814569536423841060')]])
+        res = np.pmt(
+            np.array([[Decimal('0'), Decimal('0.8')], 
+                      [Decimal('0.3'), Decimal('0.8')]], dtype='O'),
+            np.array([Decimal('12'), Decimal('3')], dtype='O'),
+            np.array([Decimal('2000'), Decimal('20000')], dtype='O'))
+        tgt = np.array([[Decimal('-166.6666666666666666666666667'), 
+                         Decimal('-19311.25827814569536423841060')],
+                        [Decimal('-626.9081401700757748402586600'), 
+                         Decimal('-19311.25827814569536423841060')]], dtype='O')
 
         # Cannot use the `assert_allclose` because it uses isfinite under the covers
         # which does not support the Decimal type
@@ -152,21 +157,26 @@ class TestFinancial(object):
         assert_(np.isnan(np.mirr(val, 0.10, 0.12)))
 
     def test_mirr_decimal(self):
-        val = [Decimal('-4500'), Decimal('-800'), Decimal('800'), Decimal('800'),
+        val = np.array(
+              [Decimal('-4500'), Decimal('-800'), Decimal('800'), Decimal('800'),
                Decimal('600'), Decimal('600'), Decimal('800'), Decimal('800'),
-               Decimal('700'), Decimal('3000')]
+               Decimal('700'), Decimal('3000')], dtype='O')
         assert_equal(np.mirr(val, Decimal('0.08'), Decimal('0.055')),
                      Decimal('0.066597175031553548874239618'))
 
-        val = [Decimal('-120000'), Decimal('39000'), Decimal('30000'),
-               Decimal('21000'), Decimal('37000'), Decimal('46000')]
-        assert_equal(np.mirr(val, Decimal('0.10'), Decimal('0.12')), Decimal('0.126094130365905145828421880'))
+        val = np.array(
+              [Decimal('-120000'), Decimal('39000'), Decimal('30000'),
+               Decimal('21000'), Decimal('37000'), Decimal('46000')], dtype='O')
+        assert_equal(np.mirr(val, Decimal('0.10'), Decimal('0.12')), 
+                     Decimal('0.126094130365905145828421880'))
 
-        val = [Decimal('100'), Decimal('200'), Decimal('-50'),
-               Decimal('300'), Decimal('-200')]
-        assert_equal(np.mirr(val, Decimal('0.05'), Decimal('0.06')), Decimal('0.342823387842176663647819868'))
+        val = np.array([Decimal('100'), Decimal('200'), Decimal('-50'),
+                     Decimal('300'), Decimal('-200')], dtype='O')
+        assert_equal(np.mirr(val, Decimal('0.05'), Decimal('0.06')), 
+                     Decimal('0.342823387842176663647819868'))
 
-        val = [Decimal('39000'), Decimal('30000'), Decimal('21000'), Decimal('37000'), Decimal('46000')]
+        val = np.array([Decimal('39000'), Decimal('30000'), Decimal('21000'), 
+                     Decimal('37000'), Decimal('46000')], dtype='O')
         assert_(np.isnan(np.mirr(val, Decimal('0.10'), Decimal('0.12'))))
 
     def test_when(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -343,8 +343,8 @@ class TestAverage(object):
             assert_equal(np.average(a, weights=w).dtype, np.dtype(rt))
 
     def test_object_dtype(self):
-        a = np.array([decimal.Decimal(x) for x in range(10)])
-        w = np.array([decimal.Decimal(1) for _ in range(10)])
+        a = np.array([decimal.Decimal(x) for x in range(10)], dtype='O')
+        w = np.array([decimal.Decimal(1) for _ in range(10)], dtype='O')
         w /= w.sum()
         assert_almost_equal(a.mean(0), average(a, weights=w))
 
@@ -1785,15 +1785,17 @@ class TestHistogram(object):
         # Decimal weights
         from decimal import Decimal
         values = np.array([1.3, 2.5, 2.3])
-        weights = np.array([Decimal(1), Decimal(2), Decimal(3)])
+        weights = np.array([Decimal(1), Decimal(2), Decimal(3)], dtype='O')
 
         # Check with custom bins
         wa, wb = histogram(values, bins=[0, 2, 3], weights=weights)
-        assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
+        assert_array_almost_equal(wa,
+                                  np.array([Decimal(1), Decimal(5)], dtype='O'))
 
         # Check with even bins
         wa, wb = histogram(values, bins=2, range=[1, 3], weights=weights)
-        assert_array_almost_equal(wa, [Decimal(1), Decimal(5)])
+        assert_array_almost_equal(wa,
+                                  np.array([Decimal(1), Decimal(5)], dtype='O'))
 
     def test_no_side_effects(self):
         # This is a regression test that ensures that values passed to

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -174,7 +174,8 @@ class TestDocs(object):
 
     def test_objects(self):
         from decimal import Decimal
-        p = np.poly1d([Decimal('4.0'), Decimal('3.0'), Decimal('2.0')])
+        p = np.poly1d(np.array([Decimal('4.0'), Decimal('3.0'), Decimal('2.0')],
+                               dtype='O'))
         p2 = p * Decimal('1.333333333333333')
         assert_(p2[1] == Decimal("3.9999999999999990"))
         p2 = p.deriv()
@@ -183,8 +184,8 @@ class TestDocs(object):
         assert_(p2[3] == Decimal("1.333333333333333333333333333"))
         assert_(p2[2] == Decimal('1.5'))
         assert_(np.issubdtype(p2.coeffs.dtype, np.object_))
-        p = np.poly([Decimal(1), Decimal(2)])
-        assert_equal(np.poly([Decimal(1), Decimal(2)]),
+        p = np.poly(np.array([Decimal(1), Decimal(2)], dtype='O'))
+        assert_equal(np.poly(np.array([Decimal(1), Decimal(2)], dtype='O')),
                      [1, Decimal(-3), Decimal(2)])
 
     def test_complex(self):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -163,12 +163,12 @@ class TestApplyAlongAxis(object):
 
     def test_with_iterable_object(self):
         # from issue 5248
-        d = np.array([
-            [set([1, 11]), set([2, 22]), set([3, 33])],
-            [set([4, 44]), set([5, 55]), set([6, 66])]
-        ])
+        d = np.array(
+            [[set([1, 11]), set([2, 22]), set([3, 33])],
+             [set([4, 44]), set([5, 55]), set([6, 66])]], dtype='O')
         actual = np.apply_along_axis(lambda a: set.union(*a), 0, d)
-        expected = np.array([{1, 11, 4, 44}, {2, 22, 5, 55}, {3, 33, 6, 66}])
+        expected = np.array([{1, 11, 4, 44}, {2, 22, 5, 55}, {3, 33, 6, 66}], 
+                            dtype='O')
 
         assert_equal(actual, expected)
 

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -281,10 +281,10 @@ def test_broadcast_shape():
 
 
 def test_as_strided():
-    a = np.array([None])
+    a = np.array([None], dtype='O')
     a_view = as_strided(a)
-    expected = np.array([None])
-    assert_array_equal(a_view, np.array([None]))
+    expected = np.array([None], dtype='O')
+    assert_array_equal(a_view, np.array([None], dtype='O'))
 
     a = np.array([1, 2, 3, 4])
     a_view = as_strided(a, shape=(2,), strides=(2 * a.itemsize,))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3859,7 +3859,8 @@ class MaskedArray(ndarray):
 
                 rdtype = _replace_dtype_fields(self.dtype, "O")
                 res = data.astype(rdtype)
-                _recursive_printoption(res, mask, masked_print_option)
+                # XXX probably correct fix here is to modify copyto to accept scalars
+                _recursive_printoption(res, mask, np.array(masked_print_option, dtype='O'))
         else:
             res = self.filled(self.fill_value)
         return res

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -450,7 +450,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
             outarr[tuple(flatten_inplace(j.tolist()))] = res
             dtypes.append(asarray(res).dtype)
             k += 1
-    max_dtypes = np.dtype(np.asarray(dtypes).max())
+    max_dtypes = np.dtype(np.asarray(dtypes, dtype='O').max())
     if not hasattr(arr, '_mask'):
         result = np.asarray(outarr, dtype=max_dtypes)
     else:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -968,7 +968,7 @@ class TestMaskedArray(object):
     def test_object_with_array(self):
         mx1 = masked_array([1.], mask=[True])
         mx2 = masked_array([1., 2.])
-        mx = masked_array([mx1, mx2], mask=[False, True])
+        mx = masked_array([mx1, mx2], mask=[False, True], dtype='O')
         assert_(mx[0] is mx1)
         assert_(mx[1] is not mx2)
         assert_(np.all(mx[1].data == mx2.data))
@@ -1563,16 +1563,16 @@ class TestMaskedArrayArithmetic(object):
         # With partial mask
         with suppress_warnings() as sup:
             sup.filter(FutureWarning, "Comparison to `None`")
-            a = array([None, 1], mask=[0, 1])
+            a = array([None, 1], mask=[0, 1], dtype='O')
             assert_equal(a == None, array([True, False], mask=[0, 1]))
             assert_equal(a.data == None, [True, False])
             assert_equal(a != None, array([False, True], mask=[0, 1]))
             # With nomask
-            a = array([None, 1], mask=False)
+            a = array([None, 1], mask=False, dtype='O')
             assert_equal(a == None, [True, False])
             assert_equal(a != None, [False, True])
             # With complete mask
-            a = array([None, 2], mask=True)
+            a = array([None, 2], mask=True, dtype='O')
             assert_equal(a == None, array([False, True], mask=True))
             assert_equal(a != None, array([True, False], mask=True))
             # Fully masked, even comparison to None should return "masked"
@@ -4671,7 +4671,7 @@ class TestMaskedFields(object):
 class TestMaskedObjectArray(object):
 
     def test_getitem(self):
-        arr = np.ma.array([None, None])
+        arr = np.ma.array([None, None], dtype='O')
         for dt in [float, object]:
             a0 = np.eye(2).astype(dt)
             a1 = np.eye(3).astype(dt)
@@ -4701,7 +4701,7 @@ class TestMaskedObjectArray(object):
 
     def test_nested_ma(self):
 
-        arr = np.ma.array([None, None])
+        arr = np.ma.array([None, None], dtype='O')
         # set the first object to be an unmasked masked constant. A little fiddly
         arr[0,...] = np.array([np.ma.masked], object)[0,...]
 

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -412,7 +412,8 @@ class TestRandomDist(object):
         assert_(np.isscalar(np.random.choice(2, replace=True, p=p)))
         assert_(np.isscalar(np.random.choice(2, replace=False, p=p)))
         assert_(np.isscalar(np.random.choice([1, 2], replace=True)))
-        assert_(np.random.choice([None], replace=True) is None)
+        none_arr = np.array([None], dtype='O')
+        assert_(np.random.choice(none_arr, replace=True) is None)
         a = np.array([1, 2])
         arr = np.empty(1, dtype=object)
         arr[0] = a
@@ -425,7 +426,7 @@ class TestRandomDist(object):
         assert_(not np.isscalar(np.random.choice(2, s, replace=True, p=p)))
         assert_(not np.isscalar(np.random.choice(2, s, replace=False, p=p)))
         assert_(not np.isscalar(np.random.choice([1, 2], s, replace=True)))
-        assert_(np.random.choice([None], s, replace=True).ndim == 0)
+        assert_(np.random.choice(none_arr, s, replace=True).ndim == 0)
         a = np.array([1, 2])
         arr = np.empty(1, dtype=object)
         arr[0] = a

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -125,7 +125,7 @@ class TestRegression(object):
         # a segfault on garbage collection.
         # See gh-7719
         np.random.seed(1234)
-        a = np.array([np.arange(1), np.arange(4)])
+        a = np.array([np.arange(1), np.arange(4)], dtype='O')
 
         for _ in range(1000):
             np.random.shuffle(a)

--- a/numpy/testing/nose_tools/utils.py
+++ b/numpy/testing/nose_tools/utils.py
@@ -675,14 +675,20 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
     if np.abs(sc_desired - sc_actual) >= np.power(10., -(significant-1)):
         raise AssertionError(msg)
 
+def asarray_orobj(x):
+    try:
+        return array(x, copy=False, subok=True)
+    except:
+        return array(x, copy=False, dtype='O', subok=True)
+    
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          header='', precision=6, equal_nan=True,
                          equal_inf=True):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, isnan, isinf, any, inf
-    x = array(x, copy=False, subok=True)
-    y = array(y, copy=False, subok=True)
+
+    x, y = asarray_orobj(x), asarray_orobj(y)
 
     def isnumber(x):
         return x.dtype.char in '?bhilqpBHILQPefdgFDG'


### PR DESCRIPTION
This is an experiment/WIP to require the user the explicitly use `dtype='O'` in order to create object arrays, as discussed in  #5353.

The goal for now is just to get a sense of how many tests would break and how hard it is to implement. The first commit is implementation, the second is test updates. About 40 tests had to be updated, but in numpy code itself only 4 small bugfixes were needed. I'll put some notes in inline comments below.

A major caveat is that for 0d object arrays I still allow the user to skip the dtype (so it will not fix #10144). It turns out numpy uses 0d object arrays in a *lot* of places: About 43 additional tests fail I disallow non-explicit 0d object arrays. I started trying to fix up those tests, but they seemed harder to fix. Some involved C-code which does `PyArray_MultiIterNew(Py_None...)`, where the `Py_None` gets promoted to a 0d object array. Many others involve assignment to an object-array using a scalar, where numpy tries to convert the scalar to a 0d object array first, eg this happens in `np.copyto(objarr, obj)`.

Something I have a feeling may be ultimately necessary to make the change for #5353 is to add an `object_ok=True` argument to `np.array`. When you are implementing a function which accepts an array, you don't know whether the user will give you and object array or not, and you want to avoid having to special case object arrays. For instance, code like `np.array([arr[4], arr[5]])` will likely fail if `arr` is an object array and the `dtype="O"` is required, so you would want to write `np.array([arr[4], arr[5]], object_ok=True)`.

I'm not planning to work much more on this in the near future (at least until 1.14 is out and has stabilized), anyone feel free to pick up.