### PR TITLE
BUG: Numpy scalar types sometimes have the same name

### DIFF
--- a/doc/release/upcoming_changes/10151.improvement.rst
+++ b/doc/release/upcoming_changes/10151.improvement.rst
@@ -1,0 +1,9 @@
+Different C numeric types of the same size have unique names
+------------------------------------------------------------
+On any given platform, two of ``np.intc``, ``np.int_``, and ``np.longlong``
+would previously appear indistinguishable through their ``repr``, despite
+having different properties when wrapped into ``dtype``s.
+A similar problem existed for the unsigned counterparts to these types, and on
+some plaforms for ``np.double`` and ``np.longdouble``
+
+These types now always print with a unique ``__name__``.

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4383,6 +4383,36 @@ initialize_numeric_types(void)
 
     PyArrayIter_Type.tp_iter = PyObject_SelfIter;
     PyArrayMapIter_Type.tp_iter = PyObject_SelfIter;
+
+    /*
+     * Give types different names when they are the same size (gh-9799).
+     * `np.intX` always refers to the first int of that size in the sequence
+     * `['LONG', 'LONGLONG', 'INT', 'SHORT', 'BYTE']`.
+     */
+#if (NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT)
+    PyByteArrType_Type.tp_name = "numpy.byte";
+    PyUByteArrType_Type.tp_name = "numpy.ubyte";
+#endif
+#if (NPY_SIZEOF_SHORT == NPY_SIZEOF_INT)
+    PyShortArrType_Type.tp_name = "numpy.short";
+    PyUShortArrType_Type.tp_name = "numpy.ushort";
+#endif
+#if (NPY_SIZEOF_INT == NPY_SIZEOF_LONG)
+    PyIntArrType_Type.tp_name = "numpy.intc";
+    PyUIntArrType_Type.tp_name = "numpy.uintc";
+#endif
+#if (NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG)
+    PyLongLongArrType_Type.tp_name = "numpy.longlong";
+    PyULongLongArrType_Type.tp_name = "numpy.ulonglong";
+#endif
+
+    /*
+    Do the same for longdouble
+    */
+#if (NPY_SIZEOF_LONGDOUBLE == NPY_SIZEOF_DOUBLE)
+    PyLongDoubleArrType_Type.tp_name = "numpy.longdouble";
+    PyCLongDoubleArrType_Type.tp_name = "numpy.clongdouble";
+#endif
 }
 
 typedef struct {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -649,13 +649,6 @@ class TestDtypeAttributes(object):
         new_dtype = np.dtype(dtype.descr)
         assert_equal(new_dtype.itemsize, 16)
 
-    @pytest.mark.parametrize('t', np.typeDict.values())
-    def test_name_builtin(self, t):
-        name = t.__name__
-        if name.endswith('_'):
-            name = name[:-1]
-        assert_equal(np.dtype(t).name, name)
-
     def test_name_dtype_subclass(self):
         # Ticket #4357
         class user_def_subcls(np.void):

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -499,3 +499,32 @@ class TestDocStrings(object):
             assert_('int64' in np.int_.__doc__)
         elif np.int64 is np.longlong:
             assert_('int64' in np.longlong.__doc__)
+
+
+class TestScalarTypeNames:
+    # gh-9799
+
+    numeric_types = [
+        np.byte, np.short, np.intc, np.int_, np.longlong,
+        np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong,
+        np.half, np.single, np.double, np.longdouble,
+        np.csingle, np.cdouble, np.clongdouble,
+    ]
+
+    def test_names_are_unique(self):
+        # none of the above may be aliases for each other
+        assert len(set(self.numeric_types)) == len(self.numeric_types)
+
+        # names must be unique
+        names = [t.__name__ for t in self.numeric_types]
+        assert len(set(names)) == len(names)
+
+    @pytest.mark.parametrize('t', numeric_types)
+    def test_names_reflect_attributes(self, t):
+        """ Test that names correspond to where the type is under ``np.`` """
+        assert getattr(np, t.__name__) is t
+
+    @pytest.mark.parametrize('t', numeric_types)
+    def test_names_are_undersood_by_dtype(self, t):
+        """ Test the dtype constructor maps names back to the type """
+        assert np.dtype(t.__name__).type is t


### PR DESCRIPTION
Fixes gh-9799.
  
~This breaks `np.core.numerictypes.bitname` on integer types, but perhaps it's private enough that we don't care.~ (no longer true)

Tested on 64-bit windows locally.

Before:
```python
>>> np.dtype(np.int_), np.int_
(dtype('int32'), numpy.int32)

>>> np.dtype(np.intc), np.intc
(dtype('int32'), numpy.int32)

>>> np.dtype(np.double), np.double
(dtype('float64'), numpy.float64)

>>> np.dtype(np.longdouble), np.longdouble
(dtype('float64'), numpy.float64)
```
After:
```python
>>> np.dtype(np.int_), np.int_
(dtype('int32'), numpy.int32)

>>> np.dtype(np.intc), np.intc
(dtype('int32'), numpy.intc)

>>> np.dtype(np.double), np.double
(dtype('float64'), numpy.float64)

>>> np.dtype(np.longdouble), np.longdouble
(dtype('float64'), numpy.longdouble)
```

If we want to "fix" the dtype output too, then it probably makes sense to wait for #10602 