### PR TITLE
BUG: test, fix problems from PR #9639

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -259,7 +259,8 @@ writeback to the original array occurs at ndarray deallocation. For
 explicitly called before deallocation (or, if an error occurred,
 ``PyArray_DiscardWritebackIfCopy``). Numpy now mostly uses the
 ``WRITEBACKIFCOPY`` mechanism internally, but still uses ``UPDATEIFCOPY`` in
-nditer use for backward-compatibility with the python nditer interface.
+nditer use for backward-compatibility with the python nditer interface which
+has not changed.
 
 In python code, if numpy is compiled with ``-DDEPRECATE_UPDATEIFCOPY`` or if
 run on PyPy, ``DeprecationWarning`` warnings will be issued on use of
@@ -267,14 +268,14 @@ run on PyPy, ``DeprecationWarning`` warnings will be issued on use of
 occurred before calling ``array_dealloc``. In the future this warning will
 always be issued, once nditer stops using ``UPDATEIFCOPY``.
 
-In C code, calling ``PyArray_SetUpdateIfCopyBase`` will now always issue a
-``DeprecationWarning`` and should be replaced by
-``PyArray_SetWritebackIfCopyBase``. Similarly, calls to ``PyArray_XDECREF_ERR``
-should be replaced by ``PyArray_DiscardWritebackIfCopy``.  Calling ndarray
-creation functions such as ``PyArray_FromArray`` where flags uses
-``NPY_ARRAY_UPDATEIFCOPY`` will also raise a ``DeprecationWarning``. In all
-these cases the code must be further modified to call
-``PyArray_ResolveWritebackIfCopy`` before deallocation.
+In C code, ``PyArray_SetUpdateIfCopyBase`` should be replaced by
+``PyArray_SetWritebackIfCopyBase``. Until nditer user is updated, this call
+will not emit a ``DeprecationWarning``. Calls to ``PyArray_XDECREF_ERR``
+should be replaced by ``PyArray_DiscardWritebackIfCopy`` and will emit a
+``DeprectaionWarning``.  Calling ndarray creation functions such as
+``PyArray_FromArray`` where flags uses ``NPY_ARRAY_UPDATEIFCOPY`` will raise a
+``DeprecationWarning``. In all these cases the code must be further modified to
+call ``PyArray_ResolveWritebackIfCopy`` before deallocation.
 
 Note that during the deprecation period, the ``NPY_ARRAY_INOUT_ARRAY`` and
 ``NPY_ARRAY_INOUT_FARRAY`` flags should be replaced by

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -516,9 +516,7 @@ array_dealloc(PyArrayObject *self)
          * In any case base is pointing to something that we need
          * to DECREF -- either a view or a buffer object
          */
-        if (fa->base) {
-            Py_DECREF(fa->base);
-        }
+        Py_XDECREF(fa->base);
     }
 
     if ((fa->flags & NPY_ARRAY_OWNDATA) && fa->data) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1010,7 +1010,7 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
     }
     else {
         fa->flags = (flags & ~NPY_ARRAY_WRITEBACKIFCOPY);
-        fa->flags = (flags & ~NPY_ARRAY_UPDATEIFCOPY);
+        fa->flags = (fa->flags & ~NPY_ARRAY_UPDATEIFCOPY);
     }
     fa->descr = descr;
     fa->base = (PyObject *)NULL;

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -638,6 +638,35 @@ npy_updateifcopy_deprecation(PyObject* NPY_UNUSED(self), PyObject* args)
     Py_RETURN_NONE;
 }
 
+/* used to create array with WRITEBACKIFCOPY flag */
+static PyObject*
+npy_create_writebackifcopy(PyObject* NPY_UNUSED(self), PyObject* args)
+{
+    int flags;
+    PyObject* array;
+    if (!PyArray_Check(args)) {
+        PyErr_SetString(PyExc_TypeError, "test needs ndarray input");
+        return NULL;
+    }
+    flags = NPY_ARRAY_CARRAY | NPY_ARRAY_WRITEBACKIFCOPY;
+    array = PyArray_FromArray((PyArrayObject*)args, NULL, flags);
+    if (array == NULL)
+        return NULL;
+    return array;
+}
+
+/* resolve WRITEBACKIFCOPY */
+static PyObject*
+npy_resolve(PyObject* NPY_UNUSED(self), PyObject* args)
+{
+    if (!PyArray_Check(args)) {
+        PyErr_SetString(PyExc_TypeError, "test needs ndarray input");
+        return NULL;
+    }
+    PyArray_ResolveWritebackIfCopy((PyArrayObject*)args);
+    Py_RETURN_NONE;
+}
+
 #if !defined(NPY_PY3K)
 static PyObject *
 int_subclass(PyObject *dummy, PyObject *args)
@@ -1729,6 +1758,12 @@ static PyMethodDef Multiarray_TestsMethods[] = {
         METH_NOARGS, NULL},
     {"npy_updateifcopy_deprecation",
         npy_updateifcopy_deprecation,
+        METH_O, NULL},
+    {"npy_create_writebackifcopy",
+        npy_create_writebackifcopy,
+        METH_O, NULL},
+    {"npy_resolve",
+        npy_resolve,
         METH_O, NULL},
 #if !defined(NPY_PY3K)
     {"test_int_subclass",

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7124,7 +7124,7 @@ class TestCTypes(object):
             _internal.ctypes = ctypes
 
 
-class TestUpdateIfCopy(TestCase):
+class TestWritebackIfCopy(TestCase):
     # all these tests use the WRITEBACKIFCOPY mechanism
     def test_argmax_with_out(self):
         mat = np.eye(5)
@@ -7189,7 +7189,21 @@ class TestUpdateIfCopy(TestCase):
         b = np.dot(a, a, out=a)
         assert_equal(b, np.array([[15, 18, 21], [42, 54, 66], [69, 90, 111]]))
 
-
+    def test_view_assign(self):
+        from numpy.core.multiarray_tests import npy_create_writebackifcopy, npy_resolve
+        arr = np.arange(9).reshape(3, 3).T
+        arr_wb = npy_create_writebackifcopy(arr)
+        assert_(arr_wb.flags.writebackifcopy)
+        assert_(arr_wb.base is arr)
+        arr_wb[:] = -100
+        npy_resolve(arr_wb)
+        assert_equal(arr, -100)
+        # after resolve, the two arrays no longer reference eachother
+        assert_(not arr_wb.ctypes.data == 0)
+        arr_wb[:] = 100
+        assert_equal(arr, -100)
+        
+        
 def test_orderconverter_with_nonASCII_unicode_ordering():
     # gh-7475
     a = np.arange(5)


### PR DESCRIPTION
PR #9639 was merged, but later we uncovered some problems with it in working on PR #9998. 

@ahaldane uncovered a bug where the NPY_WRITEBACKIFCOPY flag was not zeroed out in creating a ndarray from existing data. 

Additionally, I realized that between the call to ``PyArray_ResolveWritebackIfCopy`` and ``array_dealloc``, the ndarray is still, in some sense, alive, and so care must be taken to leave it in a coherent state after the call to ``PyArray_ResolveWritebackIfCopy``.

This pull request tests and fixes both the problems above, where ``arr_wb.flags.writebackifcopy == True`` and ``arr_wb.base`` is ``arr``:
- test and fix that ``arr_wb[:]`` assignment, which internally creates a view to ``arr_wb``, does not create the view with writeback semantics (error in zeroing out the view's flag)
- test and fix that after the call to ``PyArray_WritebackIfCopy(arr_wb)``, the data pointer of ``arr_wb`` is still valid, but that the connection between ``arr_wb`` and ``arr`` has been severed, ``arr_wb.base`` is no longer ``arr``