### PR TITLE
MAINT/BUG: Simplify _formatArray, fixing array_repr(matrix) in the process

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -450,7 +450,7 @@ def _array2string(a, options, separator=' ', prefix=""):
 
     lst = _formatArray(a, format_function, a.ndim, options['linewidth'],
                        next_line_prefix, separator, options['edgeitems'],
-                       summary_insert, options['legacy'])[:-1]
+                       summary_insert, options['legacy'])
     return lst
 
 
@@ -633,7 +633,7 @@ def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
 
     """
     if rank == 0:
-        return format_function(a[()]) + '\n'
+        return format_function(a[()])
 
     show_summary = summary_insert and 2*edge_items < len(a)
 
@@ -664,7 +664,7 @@ def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
 
         word = format_function(a[-1])
         s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
-        s += line + "]\n"
+        s += line + "]"
         s = '[' + s[len(next_line_prefix):]
     else:
         s = '['
@@ -695,7 +695,7 @@ def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
             s += next_line_prefix
         s += _formatArray(a[-1], format_function, rank-1, max_line_len,
                           " " + next_line_prefix, separator, edge_items,
-                          summary_insert, legacy).rstrip()+']\n'
+                          summary_insert, legacy).rstrip()+']'
     return s
 
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -448,7 +448,7 @@ def _array2string(a, options, separator=' ', prefix=""):
     # skip over array(
     next_line_prefix += " "*len(prefix)
 
-    lst = _formatArray(a, format_function, a.ndim, options['linewidth'],
+    lst = _formatArray(a, format_function, options['linewidth'],
                        next_line_prefix, separator, options['edgeitems'],
                        summary_insert, options['legacy'])
     return lst
@@ -616,14 +616,14 @@ def array2string(a, max_line_width=None, precision=None,
 
 
 def _extendLine(s, line, word, max_line_len, next_line_prefix):
-    if len(line.rstrip()) + len(word.rstrip()) >= max_line_len:
+    if len((line + word).rstrip()) > max_line_len:
         s += line.rstrip() + "\n"
         line = next_line_prefix
     line += word
     return s, line
 
 
-def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
+def _formatArray(a, format_function, max_line_len, next_line_prefix,
                  separator, edge_items, summary_insert, legacy):
     """formatArray is designed for two modes of operation:
 
@@ -632,71 +632,81 @@ def _formatArray(a, format_function, rank, max_line_len, next_line_prefix,
     2. Summarized output
 
     """
-    if rank == 0:
-        return format_function(a[()])
+    def recurser(index, hanging_indent):
+        """
+        By using this local function, we don't need to recurse with all the
+        arguments. Since this function is not created recursively, the cost is
+        not significant
+        """
+        axis = len(index)
+        axes_left = a.ndim - axis
 
-    show_summary = summary_insert and 2*edge_items < len(a)
+        if axes_left == 0:
+            return format_function(a[index])
 
-    if show_summary:
-        leading_items = edge_items
-        trailing_items = edge_items
-    else:
-        leading_items = 0
-        trailing_items = len(a)
+        # when recursing, add a space to align with the [ added
+        next_hanging_indent = hanging_indent + ' '
 
-    if rank == 1:
-        s = ""
-        line = next_line_prefix
-        for i in range(leading_items):
-            word = format_function(a[i]) + separator
-            s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
-
+        a_len = a.shape[axis]
+        show_summary = summary_insert and 2*edge_items < a_len
         if show_summary:
-            if legacy == '1.13':
-                word = summary_insert + ", "
-            else:
-                word = summary_insert + separator
-            s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
+            leading_items = edge_items
+            trailing_items = edge_items
+        else:
+            leading_items = 0
+            trailing_items = a_len
 
-        for i in range(trailing_items, 1, -1):
-            word = format_function(a[-i]) + separator
-            s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
+        # stringify the array with the hanging indent on the first line too
+        s = ''
 
-        word = format_function(a[-1])
-        s, line = _extendLine(s, line, word, max_line_len, next_line_prefix)
-        s += line + "]"
-        s = '[' + s[len(next_line_prefix):]
-    else:
-        s = '['
-        line_sep = separator.rstrip() + '\n'*(rank - 1)
-        for i in range(leading_items):
-            if i > 0:
-                s += next_line_prefix
-            s += _formatArray(a[i], format_function, rank-1, max_line_len,
-                              " " + next_line_prefix, separator, edge_items,
-                              summary_insert, legacy)
-            s = s.rstrip() + line_sep
+        # last axis (rows) - wrap elements if they would not fit on one line
+        if axes_left == 1:
+            line = hanging_indent
+            for i in range(leading_items):
+                word = recurser(index + (i,), next_hanging_indent) + separator
+                s, line = _extendLine(s, line, word, max_line_len, hanging_indent)
 
-        if show_summary:
-            if legacy == '1.13':
-                # trailing space, fixed number of newlines, and fixed separator
-                s += next_line_prefix + summary_insert + ", \n"
-            else:
-                s += next_line_prefix + summary_insert + line_sep
+            if show_summary:
+                if legacy == '1.13':
+                    word = summary_insert + ", "
+                else:
+                    word = summary_insert + separator
+                s, line = _extendLine(s, line, word, max_line_len, hanging_indent)
 
-        for i in range(trailing_items, 1, -1):
-            if leading_items or i != trailing_items:
-                s += next_line_prefix
-            s += _formatArray(a[-i], format_function, rank-1, max_line_len,
-                              " " + next_line_prefix, separator, edge_items,
-                              summary_insert, legacy)
-            s = s.rstrip() + line_sep
-        if leading_items or trailing_items > 1:
-            s += next_line_prefix
-        s += _formatArray(a[-1], format_function, rank-1, max_line_len,
-                          " " + next_line_prefix, separator, edge_items,
-                          summary_insert, legacy).rstrip()+']'
-    return s
+            for i in range(trailing_items, 1, -1):
+                word = recurser(index + (-i,), next_hanging_indent) + separator
+                s, line = _extendLine(s, line, word, max_line_len, hanging_indent)
+
+            word = recurser(index + (-1,), next_hanging_indent)
+            s, line = _extendLine(s, line, word, max_line_len, hanging_indent)
+            s += line
+
+        # other axes - insert newlines between rows
+        else:
+            s = ''
+            line_sep = separator.rstrip() + '\n'*(axes_left - 1)
+
+            for i in range(leading_items):
+                s += hanging_indent + recurser(index + (i,), next_hanging_indent) + line_sep
+
+            if show_summary:
+                if legacy == '1.13':
+                    # trailing space, fixed number of newlines, and fixed separator
+                    s += hanging_indent + summary_insert + ", \n"
+                else:
+                    s += hanging_indent + summary_insert + line_sep
+
+            for i in range(trailing_items, 1, -1):
+                s += hanging_indent + recurser(index + (-i,), next_hanging_indent) + line_sep
+
+            s += hanging_indent + recurser(index + (-1,), next_hanging_indent)
+
+        # remove the hanging indent, and wrap in []
+        s = '[' + s[len(hanging_indent):] + ']'
+        return s
+
+    # invoke the recursive part with an initial index and prefix
+    return recurser(index=(), hanging_indent=next_line_prefix)
 
 
 class FloatingFormat(object):

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -328,19 +328,6 @@ class matrix(N.ndarray):
     def __rpow__(self, other):
         return NotImplemented
 
-    def __repr__(self):
-        s = repr(self.__array__()).replace('array', 'matrix')
-        # now, 'matrix' has 6 letters, and 'array' 5, so the columns don't
-        # line up anymore. We need to add a space.
-        l = s.splitlines()
-        for i in range(1, len(l)):
-            if l[i]:
-                l[i] = ' ' + l[i]
-        return '\n'.join(l)
-
-    def __str__(self):
-        return str(self.__array__())
-
     def _align(self, axis):
         """A convenience function for operations that need to preserve axis
         orientation.

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -296,11 +296,13 @@ class TestEqual(TestArrayEqual):
 
             (shapes (2,), (1, 2) mismatch)
              x: array([1, 2])
-             y: [repr failed for <matrix>: %d format: a number is required, not matrix]""")
+             y: matrix([[1, 2]])""")
             try:
                 self.assertEqual(msg, msg_reference)
             except AssertionError:
                 self.assertEqual(msg2, msg_reference)
+        else:
+            raise AssertionError("Did not raise")
 
 
 class TestArrayAlmostEqual(_GenericTest, unittest.TestCase):


### PR DESCRIPTION
Final rework of #10123, which in turn reworked #9816.

Now:
 * Has one recursive base case
 * Is fewer lines of code
 * Does not rstrip the result of format_function (none of the builtin ones have trailing spaces anyway)
 * Recurses in the index, instead of the value, which handles `dtype=object` arrays without the need for the rank argument. This fixes #8442 at the same time.
