### PR TITLE
MAINT, BUG: Final 1.14 formatting fixes

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -253,7 +253,8 @@ enabling the new 1.13 "legacy" printing mode. This is enabled by calling
 
 In summary, the major changes are:
 
-* To floating-point types:
+* For floating-point types:
+
   * The ``repr`` of float arrays often omits a space previously printed
     in the sign position. See the new ``sign`` option to ``np.set_printoptions``.
   * Floating-point arrays and scalars use a new algorithm for decimal
@@ -264,12 +265,16 @@ In summary, the major changes are:
   * Float arrays printed in scientific notation no longer use fixed-precision,
     and now instead show the shortest unique representation.
   * The ``str`` of floating-point scalars is no longer truncated in python2.
-* To other data types:
+ 
+* For other data types:
+
   * Non-finite complex scalars print like ``nanj`` instead of ``nan*j``.
   * ``NaT`` values in datetime arrays are now properly aligned.
   * Arrays and scalars of ``np.void`` datatype are now printed using hex
     notation.
-* To line-wrapping:
+    
+* For line-wrapping:
+
   * The "dtype" part of ndarray reprs will now be printed on the next line
     if there isn't space on the last line of array output.
   * The ``linewidth`` format option is now always respected.
@@ -279,13 +284,16 @@ In summary, the major changes are:
     elements.
   * The last line of an array string will never have more elements than earlier
     lines.
-* To summarization, the use of ``...`` to shorten long arrays:
+    
+* For summarization (the use of ``...`` to shorten long arrays):
+
   * A trailing comma is no longer inserted for ``str``.
     Previously, ``str(np.arange(1001))`` gave
     ``'[   0    1    2 ...,  998  999 1000]'``, which has an extra comma.
   * For arrays of 2-d and beyond, the ``...`` printed on its own line to
     summarize all but the last axis now has trailing newlines added to match
     the leading newlines, and the trailing space character removed.
+    
 * ``MaskedArray`` arrays now separate printed elements with commas, always
   print the dtype, and correctly wrap the elements of long arrays to multiple
   lines. If there is more than 1 dimension, the array attributes are now

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -290,6 +290,8 @@ In summary, the major changes are:
   print the dtype, and correctly wrap the elements of long arrays to multiple
   lines. If there is more than 1 dimension, the array attributes are now
   printed in a new "left-justified" printing style.
+* ``recarray`` arrays no longer print a trailing space before their dtype, and
+  wrap to the right number of columns.
 * 0d arrays no longer have their own idiosyncratic implementations of ``str``
   and ``repr``. The ``style`` argument to ``np.array2string`` is deprecated.
 * Arrays of ``bool`` datatype will omit the datatype in the ``repr``.

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -290,9 +290,9 @@ In summary, the major changes are:
   * A trailing comma is no longer inserted for ``str``.
     Previously, ``str(np.arange(1001))`` gave
     ``'[   0    1    2 ...,  998  999 1000]'``, which has an extra comma.
-  * For arrays of 2-d and beyond, the ``...`` printed on its own line to
-    summarize all but the last axis now has trailing newlines added to match
-    the leading newlines, and the trailing space character removed.
+  * For arrays of 2-d and beyond, when ... is printed on its own line in order
+    to summarize any but the last axis, newlines are now appended to that line
+    to match its leading newlines, and a trailing space character is removed.
     
 * ``MaskedArray`` arrays now separate printed elements with commas, always
   print the dtype, and correctly wrap the elements of long arrays to multiple

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -290,9 +290,10 @@ In summary, the major changes are:
   * A trailing comma is no longer inserted for ``str``.
     Previously, ``str(np.arange(1001))`` gave
     ``'[   0    1    2 ...,  998  999 1000]'``, which has an extra comma.
-  * For arrays of 2-d and beyond, when ... is printed on its own line in order
-    to summarize any but the last axis, newlines are now appended to that line
-    to match its leading newlines, and a trailing space character is removed.
+  * For arrays of 2-D and beyond, when ``...`` is printed on its own line in
+    order to summarize any but the last axis, newlines are now appended to that
+    line to match its leading newlines and a trailing space character is
+    removed.
     
 * ``MaskedArray`` arrays now separate printed elements with commas, always
   print the dtype, and correctly wrap the elements of long arrays to multiple

--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -253,37 +253,48 @@ enabling the new 1.13 "legacy" printing mode. This is enabled by calling
 
 In summary, the major changes are:
 
-* The ``repr`` of float arrays often omits a whitespace previously printed
-  in the sign position. See the new ``sign`` option to ``np.set_printoptions``.
-* Floating-point arrays and scalars use a new algorithm for decimal
-  representations, giving the shortest unique representation. This will
-  usually shorten ``float16`` fractional output, and sometimes ``float32`` and
-  ``float128`` output. ``float64`` should be unaffected.  See the new
-  ``floatmode`` option to ``np.set_printoptions``.
-* Float arrays printed in scientific notation no longer use fixed-precision,
-  and now instead show the shortest unique representation.
-* The ``str`` of floating-point scalars is no longer truncated in python2.
-* Non-finite complex scalars print like ``nanj`` instead of ``nan*j``.
+* To floating-point types:
+  * The ``repr`` of float arrays often omits a space previously printed
+    in the sign position. See the new ``sign`` option to ``np.set_printoptions``.
+  * Floating-point arrays and scalars use a new algorithm for decimal
+    representations, giving the shortest unique representation. This will
+    usually shorten ``float16`` fractional output, and sometimes ``float32`` and
+    ``float128`` output. ``float64`` should be unaffected.  See the new
+    ``floatmode`` option to ``np.set_printoptions``.
+  * Float arrays printed in scientific notation no longer use fixed-precision,
+    and now instead show the shortest unique representation.
+  * The ``str`` of floating-point scalars is no longer truncated in python2.
+* To other data types:
+  * Non-finite complex scalars print like ``nanj`` instead of ``nan*j``.
+  * ``NaT`` values in datetime arrays are now properly aligned.
+  * Arrays and scalars of ``np.void`` datatype are now printed using hex
+    notation.
+* To line-wrapping:
+  * The "dtype" part of ndarray reprs will now be printed on the next line
+    if there isn't space on the last line of array output.
+  * The ``linewidth`` format option is now always respected.
+    The `repr` or `str` of an array will never exceed this, unless a single
+    element is too wide.
+  * All but the last line of array strings will contain the same number of
+    elements.
+  * The last line of an array string will never have more elements than earlier
+    lines.
+* To summarization, the use of ``...`` to shorten long arrays:
+  * A trailing comma is no longer inserted for ``str``.
+    Previously, ``str(np.arange(1001))`` gave
+    ``'[   0    1    2 ...,  998  999 1000]'``, which has an extra comma.
+  * For arrays of 2-d and beyond, the ``...`` printed on its own line to
+    summarize all but the last axis now has trailing newlines added to match
+    the leading newlines, and the trailing space character removed.
 * ``MaskedArray`` arrays now separate printed elements with commas, always
   print the dtype, and correctly wrap the elements of long arrays to multiple
   lines. If there is more than 1 dimension, the array attributes are now
   printed in a new "left-justified" printing style.
-* ``NaT`` values in datetime arrays are now properly aligned.
-* Arrays and scalars of ``np.void`` datatype are now printed using hex notation.
 * 0d arrays no longer have their own idiosyncratic implementations of ``str``
   and ``repr``. The ``style`` argument to ``np.array2string`` is deprecated.
 * Arrays of ``bool`` datatype will omit the datatype in the ``repr``.
-* The "dtype" part of ndarray reprs will now be printed on the next line
-  if there isn't space on the last line of array output.
 * User-defined ``dtypes`` (subclasses of ``np.generic``) now need to
   implement ``__str__`` and ``__repr__``.
-* The ``...`` used to summarize long arrays now omits a trailing comma for
-  ``str``. Previously, ``str(np.arange(1001))`` gave
-  ``'[   0    1    2 ...,  998  999 1000]'``, which has an extra comma.
-* When a summarization ``...`` would be printed on its own line, e.g., for
-  summarization along any ndarray dimension but the last, a trailing
-  whitespace is now removed and trailing newlines added to match
-  the leading newlines.
 
 Some of these changes are described in more detail below.
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -42,6 +42,7 @@ import os
 from . import numeric as sb
 from . import numerictypes as nt
 from numpy.compat import isfileobj, bytes, long
+from .arrayprint import get_printoptions
 
 # All of the functions allow formats to be a dtype
 __all__ = ['record', 'recarray', 'format_parser']
@@ -525,22 +526,25 @@ class recarray(ndarray):
             if repr_dtype.type is record:
                 repr_dtype = sb.dtype((nt.void, repr_dtype))
             prefix = "rec.array("
-            fmt = 'rec.array(%s, %sdtype=%s)'
+            fmt = 'rec.array(%s,%sdtype=%s)'
         else:
             # otherwise represent it using np.array plus a view
             # This should only happen if the user is playing
             # strange games with dtypes.
             prefix = "array("
-            fmt = 'array(%s, %sdtype=%s).view(numpy.recarray)'
+            fmt = 'array(%s,%sdtype=%s).view(numpy.recarray)'
 
         # get data/shape string. logic taken from numeric.array_repr
         if self.size > 0 or self.shape == (0,):
-            lst = sb.array2string(self, separator=', ', prefix=prefix)
+            lst = sb.array2string(
+                self, separator=', ', prefix=prefix, suffix=',')
         else:
             # show zero-length shape unless it is (0,)
             lst = "[], shape=%s" % (repr(self.shape),)
 
         lf = '\n'+' '*len(prefix)
+        if get_printoptions()['legacy'] == '1.13':
+            lf = ' ' + lf  # trailing space
         return fmt % (lst, lf, repr_dtype)
 
     def field(self, attr, val=None):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -101,6 +101,17 @@ class TestFromrecords(object):
             assert_((mine.data1[i] == 0.0))
             assert_((mine.data2[i] == 0.0))
 
+    def test_recarray_repr(self):
+        a = np.array([(1, 0.1), (2, 0.2)],
+                     dtype=[('foo', int), ('bar', float)])
+        a = np.rec.array(a)
+        assert_equal(
+            repr(a),
+            textwrap.dedent("""\
+            rec.array([(1, 0.1), (2, 0.2)],
+                      dtype=[('foo', '<i4'), ('bar', '<f8')])""")
+        )
+
     def test_recarray_from_repr(self):
         a = np.array([(1,'ABC'), (2, "DEF")],
                      dtype=[('foo', int), ('bar', 'S4')])

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3937,11 +3937,13 @@ class MaskedArray(ndarray):
         reprs['data'] = np.array2string(
             self._insert_masked_print(),
             separator=", ",
-            prefix=indents['data'] + 'data=')
+            prefix=indents['data'] + 'data=',
+            suffix=',')
         reprs['mask'] = np.array2string(
             self._mask,
             separator=", ",
-            prefix=indents['mask'] + 'mask=')
+            prefix=indents['mask'] + 'mask=',
+            suffix=',')
         reprs['fill_value'] = repr(self.fill_value)
         if dtype_needed:
             reprs['dtype'] = np.core.arrayprint.dtype_short_repr(self.dtype)


### PR DESCRIPTION
Follows on from gh-10176, and does the missed release notes edit for that and some other PRs.

Also tries to group the changes together in the release notes.