### PR TITLE
BUG: Extra space is inserted on first line for long elements

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -265,14 +265,14 @@ In summary, the major changes are:
   * Float arrays printed in scientific notation no longer use fixed-precision,
     and now instead show the shortest unique representation.
   * The ``str`` of floating-point scalars is no longer truncated in python2.
- 
+
 * For other data types:
 
   * Non-finite complex scalars print like ``nanj`` instead of ``nan*j``.
   * ``NaT`` values in datetime arrays are now properly aligned.
   * Arrays and scalars of ``np.void`` datatype are now printed using hex
     notation.
-    
+
 * For line-wrapping:
 
   * The "dtype" part of ndarray reprs will now be printed on the next line
@@ -280,11 +280,11 @@ In summary, the major changes are:
   * The ``linewidth`` format option is now always respected.
     The `repr` or `str` of an array will never exceed this, unless a single
     element is too wide.
-  * All but the last line of array strings will contain the same number of
-    elements.
   * The last line of an array string will never have more elements than earlier
     lines.
-    
+  * An extra space is no longer inserted on the first line if the elements are
+    too wide.
+
 * For summarization (the use of ``...`` to shorten long arrays):
 
   * A trailing comma is no longer inserted for ``str``.
@@ -294,7 +294,7 @@ In summary, the major changes are:
     order to summarize any but the last axis, newlines are now appended to that
     line to match its leading newlines and a trailing space character is
     removed.
-    
+
 * ``MaskedArray`` arrays now separate printed elements with commas, always
   print the dtype, and correctly wrap the elements of long arrays to multiple
   lines. If there is more than 1 dimension, the array attributes are now

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -622,8 +622,14 @@ def array2string(a, max_line_width=None, precision=None,
     return _array2string(a, options, separator, prefix)
 
 
-def _extendLine(s, line, word, line_width, next_line_prefix):
-    if len(line) + len(word) > line_width:
+def _extendLine(s, line, word, line_width, next_line_prefix, legacy):
+    needs_wrap = len(line) + len(word) > line_width
+    if legacy != '1.13':
+        s# don't wrap lines if it won't help
+        if len(line) <= len(next_line_prefix):
+            needs_wrap = False
+
+    if needs_wrap:
         s += line.rstrip() + "\n"
         line = next_line_prefix
     line += word
@@ -682,11 +688,13 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             line = hanging_indent
             for i in range(leading_items):
                 word = recurser(index + (i,), next_hanging_indent, next_width)
-                s, line = _extendLine(s, line, word, elem_width, hanging_indent)
+                s, line = _extendLine(
+                    s, line, word, elem_width, hanging_indent, legacy)
                 line += separator
 
             if show_summary:
-                s, line = _extendLine(s, line, summary_insert, elem_width, hanging_indent)
+                s, line = _extendLine(
+                    s, line, summary_insert, elem_width, hanging_indent, legacy)
                 if legacy == '1.13':
                     line += ", "
                 else:
@@ -694,14 +702,16 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
 
             for i in range(trailing_items, 1, -1):
                 word = recurser(index + (-i,), next_hanging_indent, next_width)
-                s, line = _extendLine(s, line, word, elem_width, hanging_indent)
+                s, line = _extendLine(
+                    s, line, word, elem_width, hanging_indent, legacy)
                 line += separator
 
             if legacy == '1.13':
                 # width of the seperator is not considered on 1.13
                 elem_width = curr_width
             word = recurser(index + (-1,), next_hanging_indent, next_width)
-            s, line = _extendLine(s, line, word, elem_width, hanging_indent)
+            s, line = _extendLine(
+                s, line, word, elem_width, hanging_indent, legacy)
 
             s += line
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -289,6 +289,17 @@ class TestArray2String(object):
                                       '   11\n'
                                       '   11]]]')
 
+    def test_wide_element(self):
+        a = np.array(['xxxxx'])
+        assert_equal(
+            np.array2string(a, max_line_width=5),
+            "['xxxxx']"
+        )
+        assert_equal(
+            np.array2string(a, max_line_width=5, legacy='1.13'),
+            "[ 'xxxxx']"
+        )
+
 
 class TestPrintOptions(object):
     """Test getting and setting global print options."""


### PR DESCRIPTION
Fixes gh-10181

Also strip some trailing spaces added by the web editor in the release notes.