### PR TITLE
ENH: add nditer.close to solve writeback semantics in nditer

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -1096,4 +1096,11 @@ typedef npy_int64 npy_datetime;
 
 /* End of typedefs for numarray style bit-width names */
 
+/* Warn on use of NPY_ARRAY_UPDATEIFCOPY, for PyPy compatibility */
+#ifdef PYPY_VERSION
+  #ifndef AVOID_UPDATEIFCOPY
+    #define AVOID_UPDATEIFCOPY
+  #endif
+#endif
+
 #endif

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -86,15 +86,9 @@ NPY_NO_EXPORT int
 PyArray_SetUpdateIfCopyBase(PyArrayObject *arr, PyArrayObject *base)
 {
     int ret;
-#ifdef PYPY_VERSION
-  #ifndef DEPRECATE_UPDATEIFCOPY
-    #define DEPRECATE_UPDATEIFCOPY
-  #endif
-#endif
-
-#ifdef DEPRECATE_UPDATEIFCOPY 
-    /* TODO: enable this once a solution for UPDATEIFCOPY
-     *  and nditer are resolved, also pending the fix for GH7054
+#ifdef AVOID_UPDATEIFCOPY
+    /* enabled by default on PyPy
+     * also pending the fix for GH7054
      */
     /* 2017-Nov-10 1.14 */
     if (DEPRECATE("PyArray_SetUpdateIfCopyBase is deprecated, use "
@@ -502,7 +496,7 @@ array_dealloc(PyArrayObject *self)
         if (PyArray_FLAGS(self) & NPY_ARRAY_UPDATEIFCOPY) {
             /* DEPRECATED, remove once the flag is removed */
             Py_INCREF(self); /* hold on to self in next call  since if
-                              * refcount == 0 it will recurse back into 
+                              * refcount == 0 it will recurse back into
                               *array_dealloc
                               */
             retval = PyArray_ResolveWritebackIfCopy(self);

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2923,7 +2923,11 @@ npyiter_allocate_arrays(NpyIter *iter,
             /* If the data will be written to, set UPDATEIFCOPY */
             if (op_itflags[iop] & NPY_OP_ITFLAG_WRITE) {
                 Py_INCREF(op[iop]);
+#if AVOID_UPDATEIFCOPY
+                if (PyArray_SetWritebackIfCopyBase(temp, op[iop]) < 0) {
+#else
                 if (PyArray_SetUpdateIfCopyBase(temp, op[iop]) < 0) {
+#endif
                     Py_DECREF(temp);
                     return 0;
                 }

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1942,11 +1942,6 @@ static PyObject *npyiter_dtypes_get(NewNpyArrayIterObject *self)
         return NULL;
     }
 
-    if (self->open == 0) {
-        PyErr_SetString(PyExc_RuntimeError, "Iterator closed");
-        return NULL;
-    }
-
     nop = NpyIter_GetNOp(self->iter);
 
     ret = PyTuple_New(nop);

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2733,6 +2733,17 @@ def test_iter_too_large_with_multiindex():
             assert_raises(ValueError, test_nditer_too_large,
                           arrays, i*2 + 1, mode)
 
+def test_close():
+    a = np.arange(24, dtype='f8').reshape(2, 3, 4).T
+    it = np.nditer(a, [], [['readwrite', 'updateifcopy']],
+                   casting='same_kind', op_dtypes=[np.dtype('f4')])
+    x = it.operands[0]
+    x[...] = 3
+    it.close()
+    assert_(x.flags.writeable is False)
+    assert_raises(RuntimeError, getattr, it, 'operands')
+    assert_raises(RuntimeError, next, it)
+    assert_raises(RuntimeError, it.__getitem__, 0)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Resolves issue #9714 by providing a recommended path to use ``nditer.close()`` for PyPy compatability. If ``nditer.close`` is not called on CPython, no warning will be raised. On PyPy (or if compiled with the special ``AVOID_UPDATEIFCOPY`` C macro) a DeprecationWarning will be raised when the operands are deallocated.

See the extensive discussion on PR #9998.

Review: 
- is npy_common.h the correct place for the macro?
- Where would be a good place to document PyPy compatability (specifically the reasoning behind ``nditer.close()`` and how/when to call ``PyArray_ResolveWritebackIfCopy`` in the C-API)