### PR TITLE
DEP: Deprecate the pickle aliases

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7918,9 +7918,9 @@ def load(F):
     """
     if not hasattr(F, 'readline'):
         with open(F, 'r') as F:
-            pickle.load(F)
+            return pickle.load(F)
     else:
-        pickle.load(F)
+        return pickle.load(F)
 
 
 def loads(strg):


### PR DESCRIPTION
* The np.ma functions are misleading, as they do not actually do anything special for ma.array
* The np.loads functions doesn't even have numpy-specific documentation, and does not behave consistently with `np.load`
* The string overloads of np.ma.load and np.ma.dump do not work well on python 3, as they make assumptions about whether a binary or text pickle file is used (gh-5491)