### PR TITLE
DEP: Deprecate the pickle aliases

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -16,12 +16,13 @@ Deprecations
 
 * Aliases of builtin `pickle` functions are deprecated, in favor of their
   unaliased ``pickle.<func>`` names:
-   * `np.loads`
-   * `np.core.numeric.load`
-   * `np.core.numeric.loads`
-   * `np.ma.loads`, `np.ma.dumps`
-   * `np.ma.load`, `np.ma.dump` - these functions already failed on python 3,
-     when called with a string.
+
+  * `np.loads`
+  * `np.core.numeric.load`
+  * `np.core.numeric.loads`
+  * `np.ma.loads`, `np.ma.dumps`
+  * `np.ma.load`, `np.ma.dump` - these functions already failed on python 3,
+    when called with a string.
 
 
 Future Changes

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -14,6 +14,15 @@ New functions
 Deprecations
 ============
 
+* Aliases of builtin `pickle` functions are deprecated, in favor of their
+  unaliased ``pickle.<func>`` names:
+   * `np.loads`
+   * `np.core.numeric.load`
+   * `np.core.numeric.loads`
+   * `np.ma.loads`, `np.ma.dumps`
+   * `np.ma.load`, `np.ma.dump` - these functions already failed on python 3,
+     when called with a string.
+
 
 Future Changes
 ==============

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -42,7 +42,13 @@ else:
     import cPickle as pickle
     import __builtin__ as builtins
 
-loads = pickle.loads
+
+def loads(*args, **kwargs):
+    # NumPy 1.15.0, 2017-12-10
+    warnings.warn(
+        "np.core.numeric.loads is deprecated, use pickle.loads instead",
+        DeprecationWarning, stacklevel=2)
+    return pickle.loads(*args, **kwargs)
 
 
 __all__ = [
@@ -2134,6 +2140,10 @@ def load(file):
     load, save
 
     """
+    # NumPy 1.15.0, 2017-12-10
+    warnings.warn(
+        "np.core.numeric.load is deprecated, use pickle.load instead",
+        DeprecationWarning, stacklevel=2)
     if isinstance(file, type("")):
         file = open(file, "rb")
     return pickle.load(file)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3434,10 +3434,11 @@ class TestPickling(object):
             assert_equal(a, pickle.loads(a.dumps()), err_msg="%r" % a)
 
     def _loads(self, obj):
+        import pickle
         if sys.version_info[0] >= 3:
-            return np.loads(obj, encoding='latin1')
+            return pickle.loads(obj, encoding='latin1')
         else:
-            return np.loads(obj)
+            return pickle.loads(obj)
 
     # version 0 pickles, using protocol=2 to pickle
     # version 0 doesn't have a version field

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -30,7 +30,14 @@ else:
     import cPickle as pickle
     from future_builtins import map
 
-loads = pickle.loads
+
+def loads(*args, **kwargs):
+    # NumPy 1.15.0, 2017-12-10
+    warnings.warn(
+        "np.loads is deprecated, use pickle.loads instead",
+        DeprecationWarning, stacklevel=2)
+    return pickle.loads(*args, **kwargs)
+
 
 __all__ = [
     'savetxt', 'loadtxt', 'genfromtxt', 'ndfromtxt', 'mafromtxt',

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7859,6 +7859,16 @@ def asanyarray(a, dtype=None):
 ##############################################################################
 #                               Pickling                                     #
 ##############################################################################
+
+def _pickle_warn(method):
+    # NumPy 1.15.0, 2017-12-10
+    warnings.warn(
+        "np.ma.{method} is deprecated, use pickle.{method} instead"
+            .format(method),
+        DeprecationWarning,
+        stacklevel=3)
+
+
 def dump(a, F):
     """
     Pickle a masked array to a file.
@@ -7873,6 +7883,7 @@ def dump(a, F):
         The file to pickle `a` to. If a string, the full path to the file.
 
     """
+    _pickle_warn('dump')
     if not hasattr(F, 'readline'):
         with open(F, 'w') as F:
             pickle.dump(a, F)
@@ -7893,6 +7904,7 @@ def dumps(a):
         returned.
 
     """
+    _pickle_warn('dumps')
     return pickle.dumps(a)
 
 
@@ -7916,6 +7928,7 @@ def load(F):
     the NumPy binary .npy format.
 
     """
+    _pickle_warn('load')
     if not hasattr(F, 'readline'):
         with open(F, 'r') as F:
             pickle.load(F)
@@ -7939,6 +7952,7 @@ def loads(strg):
     dumps : Return a string corresponding to the pickling of a masked array.
 
     """
+    _pickle_warn('loads')
     return pickle.loads(strg)
 
 


### PR DESCRIPTION
* The np.ma functions are misleading, as they do not actually do anything special for ma.array
* The np.loads functions doesn't even have numpy-specific documentation, and does not behave consistently with `np.load`
* The string overloads of np.ma.load and np.ma.dump do not work well on python 3, as they make assumptions about whether a binary or text pickle file is used (gh-5491)