### PR TITLE
BUG: Fix bugs found by testing in release mode.

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7086,21 +7086,14 @@ class TestFormat(object):
     def test_1d_format(self):
         # until gh-5543, ensure that the behaviour matches what it used to be
         a = np.array([np.pi])
-
-        def ret_and_exc(f, *args, **kwargs):
-            try:
-                return f(*args, **kwargs), None
-            except Exception as e:
-                # exceptions don't compare equal, so return type and args
-                # which do
-                return None, (type(e), e.args)
-
-        # Could switch on python version here, but all we care about is
-        # that the behaviour hasn't changed
-        assert_equal(
-            ret_and_exc(object.__format__, a, '30'),
-            ret_and_exc('{:30}'.format, a)
-        )
+        if sys.version_info[:2] >= (3, 4):
+            assert_raises(TypeError, '{:30}'.format, a)
+        else:
+            with suppress_warnings() as sup:
+                sup.filter(PendingDeprecationWarning)
+                res = '{:30}'.format(a)
+                dst = object.__format__(a, '30')
+                assert_equal(res, dst)
 
 
 class TestCTypes(object):

--- a/numpy/testing/nose_tools/utils.py
+++ b/numpy/testing/nose_tools/utils.py
@@ -394,13 +394,16 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
         isdesnat = isnat(desired)
         isactnat = isnat(actual)
         dtypes_match = array(desired).dtype.type == array(actual).dtype.type
-        if isdesnat and isactnat and dtypes_match:
+        if isdesnat and isactnat:
             # If both are NaT (and have the same dtype -- datetime or
             # timedelta) they are considered equal.
-            return
+            if dtypes_match:
+                return
+            else:
+                raise AssertionError(msg)
+
     except (TypeError, ValueError, NotImplementedError):
         pass
-
 
     try:
         # Explicitly use __eq__ for comparison, gh-2552


### PR DESCRIPTION
Backport of #10193.

Fix a couple of bugs found by testing in release mode, closes #10185.

BUG: Fix numpy.testing.assert_equal in release mode.

To be complete, the NaT handling needs to raise AssertionError when
comparing NaT's with different types. That check was previously passed
on and the resulting check, which would succeed in development mode
because DeprecationWarning was converted to an error, warns in release
mode.

BUG: Fix test_1d_format test.

The test failed for numpy installed in release mode as the
PendingDeprecationWarning issued by object.__format__(a, '30') was no
longer converted to an error. The fix here is to make the test Python
version dependent and suppress the warning when needed.