### PR TITLE
ENH: Allow `np.r_` to accept 0d arrays

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -5,7 +5,7 @@ import math
 
 import numpy.core.numeric as _nx
 from numpy.core.numeric import (
-    asarray, ScalarType, array, alltrue, cumprod, arange
+    asarray, ScalarType, array, alltrue, cumprod, arange, ndim
     )
 from numpy.core.numerictypes import find_common_type, issubdtype
 
@@ -312,21 +312,16 @@ class AxisConcatenator(object):
                 scalar = True
                 scalartypes.append(newobj.dtype)
             else:
-                newobj = item
-                if ndmin > 1:
-                    tempobj = array(newobj, copy=False, subok=True)
-                    newobj = array(newobj, copy=False, subok=True,
-                                   ndmin=ndmin)
-                    if trans1d != -1 and tempobj.ndim < ndmin:
-                        k2 = ndmin-tempobj.ndim
-                        if (trans1d < 0):
-                            trans1d += k2 + 1
-                        defaxes = list(range(ndmin))
-                        k1 = trans1d
-                        axes = defaxes[:k1] + defaxes[k2:] + \
-                               defaxes[k1:k2]
-                        newobj = newobj.transpose(axes)
-                    del tempobj
+                item_ndim = ndim(item)
+                newobj = array(item, copy=False, subok=True, ndmin=ndmin)
+                if trans1d != -1 and item_ndim < ndmin:
+                    k2 = ndmin - item_ndim
+                    if (trans1d < 0):
+                        trans1d += k2 + 1
+                    defaxes = list(range(ndmin))
+                    k1 = trans1d
+                    axes = defaxes[:k1] + defaxes[k2:] + defaxes[k1:k2]
+                    newobj = newobj.transpose(axes)
             objs.append(newobj)
             if not scalar and isinstance(newobj, _nx.ndarray):
                 arraytypes.append(newobj.dtype)

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -316,10 +316,10 @@ class AxisConcatenator(object):
                 newobj = array(item, copy=False, subok=True, ndmin=ndmin)
                 if trans1d != -1 and item_ndim < ndmin:
                     k2 = ndmin - item_ndim
-                    if (trans1d < 0):
-                        trans1d += k2 + 1
-                    defaxes = list(range(ndmin))
                     k1 = trans1d
+                    if k1 < 0:
+                        k1 += k2 + 1
+                    defaxes = list(range(ndmin))
                     axes = defaxes[:k1] + defaxes[k2:] + defaxes[k1:k2]
                     newobj = newobj.transpose(axes)
             objs.append(newobj)

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -216,6 +216,11 @@ class TestConcatenator(object):
         assert_equal(actual, expected)
         assert_equal(type(actual), type(expected))
 
+    def test_0d(self):
+        assert_equal(r_[0, np.array(1), 2], [0, 1, 2])
+        assert_equal(r_[[0, 1, 2], np.array(3)], [0, 1, 2, 3])
+        assert_equal(r_[np.array(0), [1, 2, 3]], [0, 1, 2, 3])
+
 
 class TestNdenumerate(object):
     def test_basic(self):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -316,6 +316,15 @@ class TestConcatenator(object):
         assert_equal(type(actual), type(expected))
         assert_equal(type(actual.data), type(expected.data))
 
+    def test_masked_constant(self):
+        actual = mr_[np.ma.masked, 1]
+        assert_equal(actual.mask, [True, False])
+        assert_equal(actual.data[1], 1)
+
+        actual = mr_[[1, 2], np.ma.masked]
+        assert_equal(actual.mask, [False, False, True])
+        assert_equal(actual.data[:2], [1, 2])
+
 
 class TestNotMasked(object):
     # Tests notmasked_edges and notmasked_contiguous.


### PR DESCRIPTION
Fixes gh-9233

This only changes errors to non-errors, so is backwards compatible.

Would add a release note, but that would conflict with #10186 