### PR TITLE
BUG: Fix signed-unsigned comparison warnings in simd.inc.src.

### DIFF
--- a/numpy/core/src/private/lowlevel_strided_loops.h
+++ b/numpy/core/src/private/lowlevel_strided_loops.h
@@ -414,20 +414,26 @@ PyArray_PrepareThreeRawArrayIter(int ndim, npy_intp *shape,
                             char **out_dataC, npy_intp *out_stridesC);
 
 /*
- * Return number of elements that must be peeled from
- * the start of 'addr' with 'nvals' elements of size 'esize'
- * in order to reach 'alignment'.
- * alignment must be a power of two.
- * see npy_blocked_end for an example
+ * Return number of elements that must be peeled from the start of 'addr' with
+ * 'nvals' elements of size 'esize' in order to reach blockable alignment.
+ * The required alignment in bytes is passed as the 'alignment' argument and
+ * must be a power of two. This function is used to prepare an array for
+ * blocking. See the 'npy_blocked_end' function documentation below for an
+ * example of how this function is used.
  */
-static NPY_INLINE npy_uintp
+static NPY_INLINE npy_intp
 npy_aligned_block_offset(const void * addr, const npy_uintp esize,
-                         const npy_uintp alignment, const npy_uintp nvals)
+                         const npy_uintp alignment, const npy_intp nvals)
 {
-    const npy_uintp offset = (npy_uintp)addr & (alignment - 1);
-    npy_uintp peel = offset ? (alignment - offset) / esize : 0;
-    peel = nvals < peel ? nvals : peel;
-    return peel;
+    npy_uintp offset, peel;
+
+    /* check that nval can convert to unsigned */
+    assert(nvals >= 0);
+    offset = (npy_uintp)addr & (alignment - 1);
+    peel = offset ? (alignment - offset) / esize : 0;
+    peel = (peel <= (npy_uintp)nvals) ? peel : (npy_uintp)nvals;
+    /* peel will fit in npy_intp because it is <= nvals */
+    return (npy_intp)peel;
 }
 
 /*
@@ -450,11 +456,20 @@ npy_aligned_block_offset(const void * addr, const npy_uintp esize,
  * for(; i < n; i++)
  *   <scalar-op>
  */
-static NPY_INLINE npy_uintp
-npy_blocked_end(const npy_uintp offset, const npy_uintp esize,
-                const npy_uintp vsz, const npy_uintp nvals)
+static NPY_INLINE npy_intp
+npy_blocked_end(const npy_intp offset, const npy_uintp esize,
+                const npy_uintp vsz, const npy_intp nvals)
 {
-    return nvals - offset - (nvals - offset) % (vsz / esize);
+    npy_intp ndiff = nvals - offset;
+
+    assert(offset >= 0);
+    assert(nvals >= 0);
+    assert(ndiff >= 0);
+    /*
+     * the result fits in npy_intp because it is <= ndiff.  Note that
+     * unsigned op signed is unsigned when both are of the same conversion rank
+     */
+    return (npy_intp)(ndiff - ndiff % (vsz / esize));
 }
 
 

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -105,7 +105,7 @@ abs_intp(npy_intp x)
 
 #define LOOP_BLOCKED(type, vsize)\
     for(; i < npy_blocked_end(peel, sizeof(type), vsize, n);\
-            i += (vsize / sizeof(type)))
+            i += (npy_intp)(vsize / sizeof(type)))
 
 #define LOOP_BLOCKED_END\
     for (; i < n; i++)
@@ -192,12 +192,12 @@ run_binary_simd_@kind@_@TYPE@(char **args, npy_intp *dimensions, npy_intp *steps
     @type@ * op = (@type@ *)args[2];
     npy_intp n = dimensions[0];
     /* argument one scalar */
-    if (IS_BLOCKABLE_BINARY_SCALAR1(sizeof(@type@), 16)) {
+    if (IS_BLOCKABLE_BINARY_SCALAR1((npy_intp)sizeof(@type@), 16)) {
         sse2_binary_scalar1_@kind@_@TYPE@(op, ip1, ip2, n);
         return 1;
     }
     /* argument two scalar */
-    else if (IS_BLOCKABLE_BINARY_SCALAR2(sizeof(@type@), 16)) {
+    else if (IS_BLOCKABLE_BINARY_SCALAR2((npy_intp)sizeof(@type@), 16)) {
         sse2_binary_scalar2_@kind@_@TYPE@(op, ip1, ip2, n);
         return 1;
     }
@@ -828,7 +828,7 @@ sse2_@kind@_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 static void
 sse2_@kind@_@TYPE@(@type@ * ip, @type@ * op, const npy_intp n)
 {
-    const size_t stride = 16 / sizeof(@type@);
+    const npy_intp stride = (npy_intp)(16 / sizeof(@type@));
     LOOP_BLOCK_ALIGN_VAR(ip, @type@, 16) {
         *op = (*op @OP@ ip[i] || npy_isnan(*op)) ? *op : ip[i];
     }


### PR DESCRIPTION
As stated. Travis CI has changed the default warnings and these now show up, so this is needed as part of the fix for the NumPy daily builds.

This is not a big patch, I broke it out of a larger set of patches as it requires some cogitation about the choices made. It also fixes the majority of the warnings. It may or may not need a backport, we will see.