### PR TITLE
BUG: Fix signed-unsigned comparison warnings in loops.c.src.

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -739,7 +739,8 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
              * with glibc >= 2.12 and memchr can only check for equal 1
              */
             static const npy_bool zero[4096]; /* zero by C standard */
-            npy_uintp i, n = dimensions[0];
+            npy_intp n = dimensions[0];
+            npy_intp i;
 
             for (i = 0; !*op && i < n - (n % sizeof(zero)); i += sizeof(zero)) {
                 *op = memcmp(&args[1][i], zero, sizeof(zero)) != 0;
@@ -1621,9 +1622,11 @@ NPY_NO_EXPORT void
  * Pairwise summation, rounding error O(lg n) instead of O(n).
  * The recursion depth is O(lg n) as well.
  * when updating also update similar complex floats summation
+ *
+ * Note that n is >= 0, it is a dimension.
  */
 static @type@
-pairwise_sum_@TYPE@(char *a, npy_uintp n, npy_intp stride)
+pairwise_sum_@TYPE@(char *a, npy_intp n, npy_intp stride)
 {
     if (n < 8) {
         npy_intp i;
@@ -1668,7 +1671,7 @@ pairwise_sum_@TYPE@(char *a, npy_uintp n, npy_intp stride)
         res = ((r[0] + r[1]) + (r[2] + r[3])) +
               ((r[4] + r[5]) + (r[6] + r[7]));
 
-        /* do non multiple of 8 rest */
+        /* do non-multiple of 8 rest */
         for (; i < n; i++) {
             res += @trf@(*((@dtype@ *)(a + i * stride)));
         }
@@ -1676,7 +1679,8 @@ pairwise_sum_@TYPE@(char *a, npy_uintp n, npy_intp stride)
     }
     else {
         /* divide by two but avoid non-multiples of unroll factor */
-        npy_uintp n2 = n / 2;
+        npy_intp n2 = n / 2;
+
         n2 -= n2 % 8;
         return pairwise_sum_@TYPE@(a, n2, stride) +
                pairwise_sum_@TYPE@(a + n2 * stride, n - n2, stride);
@@ -2393,14 +2397,19 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
  * #C = F, , L#
  */
 
-/* similar to pairwise sum of real floats */
+/*
+ * similar to pairwise sum of real floats
+ *
+ * Note that n >= 0, it is a dimension.
+ */
 static void
-pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_uintp n,
+pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_intp n,
                     npy_intp stride)
 {
     assert(n % 2 == 0);
     if (n < 8) {
         npy_intp i;
+
         *rr = 0.;
         *ri = 0.;
         for (i = 0; i < n; i += 2) {
@@ -2444,8 +2453,8 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_uintp n,
         *rr = ((r[0] + r[2]) + (r[4] + r[6]));
         *ri = ((r[1] + r[3]) + (r[5] + r[7]));
 
-        /* do non multiple of 8 rest */
-        for (; i < n; i+=2) {
+        /* do non-multiple of 8 rest */
+        for (; i < n; i += 2) {
             *rr += *((@ftype@ *)(a + i * stride + 0));
             *ri += *((@ftype@ *)(a + i * stride + sizeof(@ftype@)));
         }
@@ -2454,7 +2463,8 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_uintp n,
     else {
         /* divide by two but avoid non-multiples of unroll factor */
         @ftype@ rr1, ri1, rr2, ri2;
-        npy_uintp n2 = n / 2;
+        npy_intp n2 = n / 2;
+
         n2 -= n2 % 8;
         pairwise_sum_@TYPE@(&rr1, &ri1, a, n2, stride);
         pairwise_sum_@TYPE@(&rr2, &ri2, a + n2 * stride, n - n2, stride);
@@ -2479,6 +2489,7 @@ NPY_NO_EXPORT void
         @ftype@ * oi = ((@ftype@ *)args[0]) + 1;
         @ftype@ rr, ri;
 
+        /* steps is even because real and imaginary parts are same size */
         pairwise_sum_@TYPE@(&rr, &ri, args[1], n * 2, steps[1] / 2);
         *or @OP@= rr;
         *oi @OP@= ri;


### PR DESCRIPTION
All uses of `npy_uintp` were replaced by `npy_intp`. The resulting code
takes two more clock cycles for integer division by 2, which I don't
think is worth chasing.

Note that there is still mixed arithmetic due to `sizeof` being unsigned and pointer arithmetic, but the results should still be correct as long as the end type is correct and there is no *legitimate* overflow. legitimate means that the correct result in infinite precision actually fits in the type.

Backport may be needed, so marked. I expect they won't be needed as the compiler warnings are probably not checked in releases, but want to be able to find the commits if I am wrong.