### PR TITLE
BUG: Fix sign-compare warnings in datetime.c and datetime_strings.c.

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -235,29 +235,34 @@ typedef enum {
  *   TIMEZONE: 5
  *   NULL TERMINATOR: 1
  */
-#define NPY_DATETIME_MAX_ISO8601_STRLEN (21+3*5+1+3*6+6+1)
+#define NPY_DATETIME_MAX_ISO8601_STRLEN (21 + 3*5 + 1 + 3*6 + 6 + 1)
 
+/* The FR in the unit names stands for frequency */
 typedef enum {
-        NPY_FR_Y = 0,  /* Years */
-        NPY_FR_M = 1,  /* Months */
-        NPY_FR_W = 2,  /* Weeks */
+        /* Force signed enum type, must be -1 for code compatibility */
+        NPY_FR_ERROR = -1,      /* error or undetermined */
+
+        /* Start of valid units */
+        NPY_FR_Y = 0,           /* Years */
+        NPY_FR_M = 1,           /* Months */
+        NPY_FR_W = 2,           /* Weeks */
         /* Gap where 1.6 NPY_FR_B (value 3) was */
-        NPY_FR_D = 4,  /* Days */
-        NPY_FR_h = 5,  /* hours */
-        NPY_FR_m = 6,  /* minutes */
-        NPY_FR_s = 7,  /* seconds */
-        NPY_FR_ms = 8, /* milliseconds */
-        NPY_FR_us = 9, /* microseconds */
-        NPY_FR_ns = 10,/* nanoseconds */
-        NPY_FR_ps = 11,/* picoseconds */
-        NPY_FR_fs = 12,/* femtoseconds */
-        NPY_FR_as = 13,/* attoseconds */
-        NPY_FR_GENERIC = 14 /* Generic, unbound units, can convert to anything */
+        NPY_FR_D = 4,           /* Days */
+        NPY_FR_h = 5,           /* hours */
+        NPY_FR_m = 6,           /* minutes */
+        NPY_FR_s = 7,           /* seconds */
+        NPY_FR_ms = 8,          /* milliseconds */
+        NPY_FR_us = 9,          /* microseconds */
+        NPY_FR_ns = 10,         /* nanoseconds */
+        NPY_FR_ps = 11,         /* picoseconds */
+        NPY_FR_fs = 12,         /* femtoseconds */
+        NPY_FR_as = 13,         /* attoseconds */
+        NPY_FR_GENERIC = 14     /* unbound units, can convert to anything */
 } NPY_DATETIMEUNIT;
 
 /*
  * NOTE: With the NPY_FR_B gap for 1.6 ABI compatibility, NPY_DATETIME_NUMUNITS
- *       is technically one more than the actual number of units.
+ * is technically one more than the actual number of units.
  */
 #define NPY_DATETIME_NUMUNITS (NPY_FR_GENERIC + 1)
 #define NPY_DATETIME_DEFAULTUNIT NPY_FR_GENERIC

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -778,8 +778,9 @@ parse_datetime_extended_unit_from_string(char *str, Py_ssize_t len,
         goto bad_input;
     }
     out_meta->base = parse_datetime_unit_from_string(substr,
-                                        substrend-substr, metastr);
-    if (out_meta->base == -1) {
+                                                     substrend - substr,
+                                                     metastr);
+    if (out_meta->base == NPY_FR_ERROR ) {
         return -1;
     }
     substr = substrend;
@@ -1073,8 +1074,9 @@ static npy_uint64
 get_datetime_units_factor(NPY_DATETIMEUNIT bigbase, NPY_DATETIMEUNIT littlebase)
 {
     npy_uint64 factor = 1;
-    int unit = (int)bigbase;
-    while (littlebase > unit) {
+    NPY_DATETIMEUNIT unit = bigbase;
+
+    while (unit < littlebase) {
         factor *= _datetime_factors[unit];
         /*
          * Detect overflow by disallowing the top 16 bits to be 1.
@@ -1719,7 +1721,7 @@ datetime_type_promotion(PyArray_Descr *type1, PyArray_Descr *type2)
  * a date time unit enum value. The 'metastr' parameter
  * is used for error messages, and may be NULL.
  *
- * Returns 0 on success, -1 on failure.
+ * Returns NPY_DATETIMEUNIT on success, NPY_FR_ERROR on failure.
  */
 NPY_NO_EXPORT NPY_DATETIMEUNIT
 parse_datetime_unit_from_string(char *str, Py_ssize_t len, char *metastr)
@@ -1775,7 +1777,7 @@ parse_datetime_unit_from_string(char *str, Py_ssize_t len, char *metastr)
                 "Invalid datetime unit in metadata string \"%s\"",
                 metastr);
     }
-    return -1;
+    return NPY_FR_ERROR;
 }
 
 
@@ -1847,7 +1849,7 @@ convert_datetime_metadata_tuple_to_datetime_metadata(PyObject *tuple,
     }
 
     out_meta->base = parse_datetime_unit_from_string(basestr, len, NULL);
-    if (out_meta->base == -1) {
+    if (out_meta->base == NPY_FR_ERROR) {
         Py_DECREF(unit_str);
         return -1;
     }
@@ -2418,7 +2420,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         char *str = NULL;
         Py_ssize_t len = 0;
         npy_datetimestruct dts;
-        NPY_DATETIMEUNIT bestunit = -1;
+        NPY_DATETIMEUNIT bestunit = NPY_FR_ERROR;
 
         /* Convert to an ASCII string for the date parser */
         if (PyUnicode_Check(obj)) {
@@ -2444,7 +2446,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         }
 
         /* Use the detected unit if none was specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             meta->base = bestunit;
             meta->num = 1;
         }
@@ -2460,7 +2462,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
     /* Do no conversion on raw integers */
     else if (PyInt_Check(obj) || PyLong_Check(obj)) {
         /* Don't allow conversion from an integer without specifying a unit */
-        if (meta->base == -1 || meta->base == NPY_FR_GENERIC) {
+        if (meta->base == NPY_FR_ERROR || meta->base == NPY_FR_GENERIC) {
             PyErr_SetString(PyExc_ValueError, "Converting an integer to a "
                             "NumPy datetime requires a specified unit");
             return -1;
@@ -2473,7 +2475,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         PyDatetimeScalarObject *dts = (PyDatetimeScalarObject *)obj;
 
         /* Copy the scalar directly if units weren't specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             *meta = dts->obmeta;
             *out = dts->obval;
 
@@ -2512,7 +2514,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
                                 obj);
 
         /* Copy the value directly if units weren't specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             *meta = *arr_meta;
             *out = dt;
 
@@ -2536,7 +2538,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
     else {
         int code;
         npy_datetimestruct dts;
-        NPY_DATETIMEUNIT bestunit = -1;
+        NPY_DATETIMEUNIT bestunit = NPY_FR_ERROR;
 
         code = convert_pydatetime_to_datetimestruct(obj, &dts, &bestunit, 1);
         if (code == -1) {
@@ -2544,7 +2546,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         }
         else if (code == 0) {
             /* Use the detected unit if none was specified */
-            if (meta->base == -1) {
+            if (meta->base == NPY_FR_ERROR) {
                 meta->base = bestunit;
                 meta->num = 1;
             }
@@ -2571,7 +2573,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
      */
     if (casting == NPY_UNSAFE_CASTING ||
             (obj == Py_None && casting == NPY_SAME_KIND_CASTING)) {
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             meta->base = NPY_FR_GENERIC;
             meta->num = 1;
         }
@@ -2647,7 +2649,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
         if (succeeded) {
             /* Use generic units if none was specified */
-            if (meta->base == -1) {
+            if (meta->base == NPY_FR_ERROR) {
                 meta->base = NPY_FR_GENERIC;
                 meta->num = 1;
             }
@@ -2658,7 +2660,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
     /* Do no conversion on raw integers */
     else if (PyInt_Check(obj) || PyLong_Check(obj)) {
         /* Use the default unit if none was specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             meta->base = NPY_DATETIME_DEFAULTUNIT;
             meta->num = 1;
         }
@@ -2671,7 +2673,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         PyTimedeltaScalarObject *dts = (PyTimedeltaScalarObject *)obj;
 
         /* Copy the scalar directly if units weren't specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             *meta = dts->obmeta;
             *out = dts->obval;
 
@@ -2710,7 +2712,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
                                 obj);
 
         /* Copy the value directly if units weren't specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             *meta = *arr_meta;
             *out = dt;
 
@@ -2779,7 +2781,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         td = days*(24*60*60*1000000LL) + seconds*1000000LL + useconds;
 
         /* Use microseconds if none was specified */
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             meta->base = NPY_FR_us;
             meta->num = 1;
 
@@ -2833,7 +2835,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
      */
     if (casting == NPY_UNSAFE_CASTING ||
             (obj == Py_None && casting == NPY_SAME_KIND_CASTING)) {
-        if (meta->base == -1) {
+        if (meta->base == NPY_FR_ERROR) {
             meta->base = NPY_FR_GENERIC;
             meta->num = 1;
         }
@@ -3167,7 +3169,7 @@ convert_pyobjects_to_datetimes(int count,
     }
 
     /* Use the inputs to resolve the unit metadata if requested */
-    if (inout_meta->base == -1) {
+    if (inout_meta->base == NPY_FR_ERROR) {
         /* Allocate an array of metadata corresponding to the objects */
         meta = PyArray_malloc(count * sizeof(PyArray_DatetimeMetaData));
         if (meta == NULL) {
@@ -3177,7 +3179,7 @@ convert_pyobjects_to_datetimes(int count,
 
         /* Convert all the objects into timedeltas or datetimes */
         for (i = 0; i < count; ++i) {
-            meta[i].base = -1;
+            meta[i].base = NPY_FR_ERROR;
             meta[i].num = 1;
 
             /* NULL -> NaT */
@@ -3344,7 +3346,7 @@ datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
          */
         if (meta_tmp->base == NPY_FR_GENERIC) {
             dtype = NULL;
-            meta.base = -1;
+            meta.base = NPY_FR_ERROR;
         }
         /* Otherwise use the provided metadata */
         else {
@@ -3360,7 +3362,7 @@ datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
             type_nums[0] = NPY_TIMEDELTA;
         }
 
-        meta.base = -1;
+        meta.base = NPY_FR_ERROR;
     }
 
     if (type_nums[0] == NPY_DATETIME && start == NULL) {
@@ -3550,7 +3552,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
                 memcpy(tmp_buffer, data, maxlen);
                 tmp_buffer[maxlen] = '\0';
 
-                tmp_meta.base = -1;
+                tmp_meta.base = NPY_FR_ERROR;
                 if (parse_iso_8601_datetime(tmp_buffer, maxlen, -1,
                                     NPY_UNSAFE_CASTING, &dts,
                                     &tmp_meta.base, NULL) < 0) {
@@ -3559,7 +3561,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
             }
             /* Otherwise parse the data in place */
             else {
-                tmp_meta.base = -1;
+                tmp_meta.base = NPY_FR_ERROR;
                 if (parse_iso_8601_datetime(data, tmp - data, -1,
                                     NPY_UNSAFE_CASTING, &dts,
                                     &tmp_meta.base, NULL) < 0) {
@@ -3651,7 +3653,7 @@ recursive_find_object_datetime64_type(PyObject *obj,
         npy_datetime tmp = 0;
         PyArray_DatetimeMetaData tmp_meta;
 
-        tmp_meta.base = -1;
+        tmp_meta.base = NPY_FR_ERROR;
         tmp_meta.num = 1;
 
         if (convert_pyobject_to_datetime(&tmp_meta, obj,


### PR DESCRIPTION
Fix is to make sure NPY_DATETIMEUNIT enum a signed integer type by adding NPY_FR_ERROR = -1. Relevant places where -1 was used before are also replaced by the enum. Note that current code logic requires that it be less than all the valid units, using a nonvalid positive value leads to segfaults due to code logic assuming that ordering.
