### PR TITLE
DOC: give correct version of np.nansum change

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -497,7 +497,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     Return the sum of array elements over a given axis treating Not a
     Numbers (NaNs) as zero.
 
-    In NumPy versions <= 1.8.0 Nan is returned for slices that are all-NaN or
+    In NumPy versions <= 1.9.0 Nan is returned for slices that are all-NaN or
     empty. In later versions zero is returned.
 
     Parameters


### PR DESCRIPTION
nansum started returning 0 from all-nan slices in 1.9.0, according to my
tests, not 1.8.1 or 1.8.2, which still return NaN.

[skip ci]