### PR TITLE
DOC: Installation note for Linux users

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,7 +61,7 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
+Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux users may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
 
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,7 +61,7 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `here <https://packaging.python.org/tutorials/installing-packages/>`_
+Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
 
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,6 +61,8 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
+Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `here <https://packaging.python.org/tutorials/installing-packages/>`_
+
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.
 


### PR DESCRIPTION
The file INSTALL.rst.txt states that the command for basic installation is:
`python setup.py build -j 4 install --prefix $HOME/.local`

Due to the way that most Linux distributions are handling the migration to Python 3, Linux users may have to use the command `python3` instead of `python`. This pull requests simply makes note of that in the installation doc.