### PR TITLE
DOC: Add installation notes for Linux users

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,6 +61,8 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
+Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux users may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
+
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.
 

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,7 +61,7 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux users may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
+Note that the ``python`` command is for installation on python 2. To install on python 3, replace with the ``python3``command. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
 
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,7 +61,10 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that the ``python`` command is for installation on python 2. For installation on python 3, replace with the ``python3``command. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
+Note that the ``python`` command here is the system default Python, generally
+python 2, the ``python3`` command may be needed to install on python 3.
+See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_
+for more details.
 
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,7 +61,7 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that the ``python`` command is for installation on python 2. To install on python 3, replace with the ``python3``command. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
+Note that the ``python`` command is for installation on python 2. For installation on python 3, replace with the ``python3``command. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
 
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.


### PR DESCRIPTION
Update to the INSTALL doc for basic installation: 

Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux users may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.