### PR TITLE
MAINT: Fix tests failures on travis CI merge.

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -138,6 +138,8 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   # ensure that the pip / setuptools versions deployed inside
   # the venv are recent enough
   $PIP install -U virtualenv
+  # ensure some warnings are not issued
+  export CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
   $PYTHON setup.py bdist_wheel
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel
@@ -151,6 +153,8 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
 elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
   # use an up-to-date pip / setuptools inside the venv
   $PIP install -U virtualenv
+  # ensure some warnings are not issued
+  export CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
   $PYTHON setup.py sdist
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel


### PR DESCRIPTION
Disable "-Wsign-compare" and "-Wunused-result" gcc warnings.
These seem to have been enabled by default recently for wheels
sdist builds.