### PR TITLE
MAINT: Fix loop and simd sign-compare warnings.

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1653,11 +1653,12 @@ NPY_NO_EXPORT void
  * when updating also update similar complex floats summation
  */
 static @type@
-pairwise_sum_@TYPE@(char *a, npy_uintp n, npy_intp stride)
+pairwise_sum_@TYPE@(char *a, npy_intp n, npy_intp stride)
 {
     if (n < 8) {
         npy_intp i;
         @type@ res = 0.;
+
         for (i = 0; i < n; i++) {
             res += @trf@(*((@dtype@*)(a + i * stride)));
         }
@@ -1683,7 +1684,7 @@ pairwise_sum_@TYPE@(char *a, npy_uintp n, npy_intp stride)
 
         for (i = 8; i < n - (n % 8); i += 8) {
             /* small blocksizes seems to mess with hardware prefetch */
-            NPY_PREFETCH(a + (i + 512 / sizeof(@dtype@)) * stride, 0, 3);
+            NPY_PREFETCH(a + (i + 512/(npy_intp)sizeof(@dtype@))*stride, 0, 3);
             r[0] += @trf@(*((@dtype@ *)(a + (i + 0) * stride)));
             r[1] += @trf@(*((@dtype@ *)(a + (i + 1) * stride)));
             r[2] += @trf@(*((@dtype@ *)(a + (i + 2) * stride)));
@@ -1706,7 +1707,8 @@ pairwise_sum_@TYPE@(char *a, npy_uintp n, npy_intp stride)
     }
     else {
         /* divide by two but avoid non-multiples of unroll factor */
-        npy_uintp n2 = n / 2;
+        npy_intp n2 = n / 2;
+
         n2 -= n2 % 8;
         return pairwise_sum_@TYPE@(a, n2, stride) +
                pairwise_sum_@TYPE@(a + n2 * stride, n - n2, stride);
@@ -2425,12 +2427,13 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
 
 /* similar to pairwise sum of real floats */
 static void
-pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_uintp n,
+pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_intp n,
                     npy_intp stride)
 {
     assert(n % 2 == 0);
     if (n < 8) {
         npy_intp i;
+
         *rr = 0.;
         *ri = 0.;
         for (i = 0; i < n; i += 2) {
@@ -2459,7 +2462,7 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_uintp n,
 
         for (i = 8; i < n - (n % 8); i += 8) {
             /* small blocksizes seems to mess with hardware prefetch */
-            NPY_PREFETCH(a + (i + 512 / sizeof(@ftype@)) * stride, 0, 3);
+            NPY_PREFETCH(a + (i + 512/(npy_intp)sizeof(@ftype@))*stride, 0, 3);
             r[0] += *((@ftype@ *)(a + (i + 0) * stride));
             r[1] += *((@ftype@ *)(a + (i + 0) * stride + sizeof(@ftype@)));
             r[2] += *((@ftype@ *)(a + (i + 2) * stride));
@@ -2484,7 +2487,8 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_uintp n,
     else {
         /* divide by two but avoid non-multiples of unroll factor */
         @ftype@ rr1, ri1, rr2, ri2;
-        npy_uintp n2 = n / 2;
+        npy_intp n2 = n / 2;
+
         n2 -= n2 % 8;
         pairwise_sum_@TYPE@(&rr1, &ri1, a, n2, stride);
         pairwise_sum_@TYPE@(&rr2, &ri2, a + n2 * stride, n - n2, stride);

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -28,34 +28,26 @@
 #include <float.h>
 #include <string.h> /* for memcpy */
 
-/* Figure out the right abs function for pointer addresses */
-static NPY_INLINE npy_intp
-abs_intp(npy_intp x)
+static NPY_INLINE npy_uintp
+abs_ptrdiff(char *a, char *b)
 {
-#if (NPY_SIZEOF_INTP <= NPY_SIZEOF_INT)
-    return abs(x);
-#elif (NPY_SIZEOF_INTP <= NPY_SIZEOF_LONG)
-    return labs(x);
-#elif defined(_MSC_VER) && (_MSC_VER < 1600)
-    /* llabs is not available with Visual Studio 2008 */
-    return x > 0 ? x : -x;
-#else
-    return llabs(x);
-#endif
+    return (a > b) ? (a - b) : (b - a);
 }
+
 
 /*
  * stride is equal to element size and input and destination are equal or
- * don't overlap within one register
+ * don't overlap within one register. The check of the steps against
+ * esize also quarantees that steps are >= 0.
  */
 #define IS_BLOCKABLE_UNARY(esize, vsize) \
     (steps[0] == (esize) && steps[0] == steps[1] && \
      (npy_is_aligned(args[0], esize) && npy_is_aligned(args[1], esize)) && \
-     ((abs_intp(args[1] - args[0]) >= (vsize)) || \
-      ((abs_intp(args[1] - args[0]) == 0))))
+     ((abs_ptrdiff(args[1], args[0]) >= (vsize)) || \
+      ((abs_ptrdiff(args[1], args[0]) == 0))))
 
 #define IS_BLOCKABLE_REDUCE(esize, vsize) \
-    (steps[1] == (esize) && abs_intp(args[1] - args[0]) >= (vsize) && \
+    (steps[1] == (esize) && abs_ptrdiff(args[1], args[0]) >= (vsize) && \
      npy_is_aligned(args[1], (esize)) && \
      npy_is_aligned(args[0], (esize)))
 
@@ -63,26 +55,26 @@ abs_intp(npy_intp x)
     (steps[0] == steps[1] && steps[1] == steps[2] && steps[2] == (esize) && \
      npy_is_aligned(args[2], (esize)) && npy_is_aligned(args[1], (esize)) && \
      npy_is_aligned(args[0], (esize)) && \
-     (abs_intp(args[2] - args[0]) >= (vsize) || \
-      abs_intp(args[2] - args[0]) == 0) && \
-     (abs_intp(args[2] - args[1]) >= (vsize) || \
-      abs_intp(args[2] - args[1]) >= 0))
+     (abs_ptrdiff(args[2], args[0]) >= (vsize) || \
+      abs_ptrdiff(args[2], args[0]) == 0) && \
+     (abs_ptrdiff(args[2], args[1]) >= (vsize) || \
+      abs_ptrdiff(args[2], args[1]) >= 0))
 
 #define IS_BLOCKABLE_BINARY_SCALAR1(esize, vsize) \
     (steps[0] == 0 && steps[1] == steps[2] && steps[2] == (esize) && \
      npy_is_aligned(args[2], (esize)) && npy_is_aligned(args[1], (esize)) && \
-     ((abs_intp(args[2] - args[1]) >= (vsize)) || \
-      (abs_intp(args[2] - args[1]) == 0)) && \
-     abs_intp(args[2] - args[0]) >= (esize))
+     ((abs_ptrdiff(args[2], args[1]) >= (vsize)) || \
+      (abs_ptrdiff(args[2], args[1]) == 0)) && \
+     abs_ptrdiff(args[2], args[0]) >= (esize))
 
 #define IS_BLOCKABLE_BINARY_SCALAR2(esize, vsize) \
     (steps[1] == 0 && steps[0] == steps[2] && steps[2] == (esize) && \
      npy_is_aligned(args[2], (esize)) && npy_is_aligned(args[0], (esize)) && \
-     ((abs_intp(args[2] - args[0]) >= (vsize)) || \
-      (abs_intp(args[2] - args[0]) == 0)) && \
-     abs_intp(args[2] - args[1]) >= (esize))
+     ((abs_ptrdiff(args[2], args[0]) >= (vsize)) || \
+      (abs_ptrdiff(args[2], args[0]) == 0)) && \
+     abs_ptrdiff(args[2], args[1]) >= (esize))
 
-#undef abs_intp
+#undef abs_ptrdiff
 
 #define IS_BLOCKABLE_BINARY_BOOL(esize, vsize) \
     (steps[0] == (esize) && steps[0] == steps[1] && steps[2] == (1) && \
@@ -828,7 +820,7 @@ sse2_@kind@_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 static void
 sse2_@kind@_@TYPE@(@type@ * ip, @type@ * op, const npy_intp n)
 {
-    const size_t stride = 16 / sizeof(@type@);
+    const npy_intp stride = 16 / (npy_intp)sizeof(@type@);
     LOOP_BLOCK_ALIGN_VAR(ip, @type@, 16) {
         *op = (*op @OP@ ip[i] || npy_isnan(*op)) ? *op : ip[i];
     }


### PR DESCRIPTION
The gcc sign-compare warning is enabled in Python 3.5+ and causes errors
in the wheel builds.