### PR TITLE
BUG: duplicate message print if warning raises an exception

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -475,22 +475,10 @@ array_dealloc(PyArrayObject *self)
                 "called.";
             /* 2017-Nov-10 1.14 */
             if (DEPRECATE(msg) < 0) {
-                /* dealloc must not raise an error, best effort try to write
+                /* dealloc cannot raise an error, best effort try to write
                    to stderr and clear the error
                 */
-                PyObject * s;
-#if PY_MAJOR_VERSION < 3
-                s = PyString_FromString(msg);
-#else
-                s = PyUnicode_FromString(msg);
-#endif
-                if (s) {
-                    PyErr_WriteUnraisable(s);
-                    Py_DECREF(s);
-                }
-                else {
-                    PyErr_WriteUnraisable(Py_None);
-                }
+                PyErr_WriteUnraisable((PyObject *)&PyArray_Type);
             }
             retval = PyArray_ResolveWritebackIfCopy(self);
             if (retval < 0)


### PR DESCRIPTION
As per the discussion [here](https://github.com/numpy/numpy/pull/9639#pullrequestreview-85000769) ``PyErr_WriteUnraisable(obj)`` first prints the error context from ``PyErr_Fetch`` (which already prints the message) and then prints ``repr(obj)``. The old code thus printed the message twice. This PR prints once then, for lack of a better context, shows that the problem originated in an ndarray.

If not too late perhaps this should be backported to 1.14