### PR TITLE
BUG: Fix memory leak (#10157).

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1441,6 +1441,9 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
 
     docstr = PyUnicode_AsUTF8(str);
+    if (docstr == NULL) {
+        return NULL;
+    }
 #else
     if (!PyArg_ParseTuple(args, "OO!:add_docstring", &obj, &PyString_Type, &str)) {
         return NULL;

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1440,7 +1440,7 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
         return NULL;
     }
 
-    docstr = PyBytes_AS_STRING(PyUnicode_AsUTF8String(str));
+    docstr = PyUnicode_AsUTF8(str);
 #else
     if (!PyArg_ParseTuple(args, "OO!:add_docstring", &obj, &PyString_Type, &str)) {
         return NULL;


### PR DESCRIPTION
This uses the same logic for python3 as for python2: `PyUnicode_AsUTF8String(str)` returns a new reference, but `PyString_AS_STRING(str)` does not.

#10157