### PR TITLE
ENH: Allow ptp to take an axis tuple and keepdims

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -85,6 +85,11 @@ passed explicitly, and are not yet computed automatically.
 though they are arrays of length 1. Previously, passing these was an error.
 As a result, ``np.ma.mr_`` now works correctly on the ``masked`` constant.
 
+``np.ptp`` accepts a ``keepdims`` argument, and extended axis tuples
+--------------------------------------------------------------------
+``np.ptp`` (peak-to-peak) can now work over multiple axes, just like `max` and
+`min`.
+
 ``MaskedArray.astype`` now is identical to ``ndarray.astype``
 -------------------------------------------------------------
 This means it takes all the same arguments, making more code written for

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -4055,7 +4055,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('prod',
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('ptp',
     """
-    a.ptp(axis=None, out=None)
+    a.ptp(axis=None, out=None, keepdims=False)
 
     Peak to peak (maximum - minimum) value along a given axis.
 

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -142,3 +142,10 @@ def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         ret = um.sqrt(ret)
 
     return ret
+
+def _ptp(a, axis=None, out=None, keepdims=False):
+    return um.subtract(
+        umr_maximum(a, axis, None, out, keepdims),
+        umr_minimum(a, axis, None, None, keepdims),
+        out
+    )

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1812,7 +1812,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `sum` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -1966,7 +1966,7 @@ def any(a, axis=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `any` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -2051,7 +2051,7 @@ def all(a, axis=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `all` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -2210,7 +2210,7 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `ptp` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -2275,7 +2275,7 @@ def amax(a, axis=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `amax` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -2376,7 +2376,7 @@ def amin(a, axis=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `amin` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -2518,7 +2518,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `prod` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -2917,7 +2917,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `mean` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -3024,7 +3024,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `std` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns
@@ -3143,7 +3143,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
         If the default value is passed, then `keepdims` will not be
         passed through to the `var` method of sub-classes of
         `ndarray`, however any non-default value will be.  If the
-        sub-classes `sum` method does not implement `keepdims` any
+        sub-class' method does not implement `keepdims` any
         exceptions will be raised.
 
     Returns

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2178,7 +2178,7 @@ def cumproduct(a, axis=None, dtype=None, out=None):
     return _wrapfunc(a, 'cumprod', axis=axis, dtype=dtype, out=out)
 
 
-def ptp(a, axis=None, out=None):
+def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     """
     Range of values (maximum - minimum) along an axis.
 
@@ -2188,13 +2188,30 @@ def ptp(a, axis=None, out=None):
     ----------
     a : array_like
         Input values.
-    axis : int, optional
+    axis : None or int or tuple of ints, optional
         Axis along which to find the peaks.  By default, flatten the
-        array.
+        array.  `axis` may be negative, in
+        which case it counts from the last to the first axis.
+
+        .. versionadded:: 1.15.0
+
+        If this is a tuple of ints, a reduction is performed on multiple
+        axes, instead of a single axis or all the axes as before.
     out : array_like
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,
         but the type of the output values will be cast if necessary.
+
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the input array.
+
+        If the default value is passed, then `keepdims` will not be
+        passed through to the `ptp` method of sub-classes of
+        `ndarray`, however any non-default value will be.  If the
+        sub-classes `sum` method does not implement `keepdims` any
+        exceptions will be raised.
 
     Returns
     -------
@@ -2216,7 +2233,17 @@ def ptp(a, axis=None, out=None):
     array([1, 1])
 
     """
-    return _wrapfunc(a, 'ptp', axis=axis, out=out)
+    kwargs = {}
+    if keepdims is not np._NoValue:
+        kwargs['keepdims'] = keepdims
+    if type(a) is not mu.ndarray:
+        try:
+            ptp = a.ptp
+        except AttributeError:
+            pass
+        else:
+            return ptp(axis=axis, out=out, **kwargs)
+    return _methods._ptp(a, axis=axis, out=out, **kwargs)
 
 
 def amax(a, axis=None, out=None, keepdims=np._NoValue):

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -329,16 +329,7 @@ array_min(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_ptp(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    int axis = NPY_MAXDIMS;
-    PyArrayObject *out = NULL;
-    static char *kwlist[] = {"axis", "out", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&:ptp", kwlist,
-                                     PyArray_AxisConverter, &axis,
-                                     PyArray_OutputConverter, &out))
-        return NULL;
-
-    return PyArray_Ptp(self, axis, out);
+    NPY_FORWARD_NDARRAY_METHOD("_ptp");
 }
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -556,6 +556,9 @@ class TestPtp(object):
         assert_equal(b.ptp(axis=0), [5.0, 7.0, 7.0])
         assert_equal(b.ptp(axis=-1), [6.0, 6.0, 6.0])
 
+        assert_equal(b.ptp(axis=0, keepdims=True), [[5.0, 7.0, 7.0]])
+        assert_equal(b.ptp(axis=(0,1), keepdims=True), [[8.0]])
+
 
 class TestCumsum(object):
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5721,7 +5721,7 @@ class MaskedArray(ndarray):
             np.copyto(out, np.nan, where=newmask)
         return out
 
-    def ptp(self, axis=None, out=None, fill_value=None):
+    def ptp(self, axis=None, out=None, fill_value=None, keepdims=False):
         """
         Return (maximum - minimum) along the given dimension
         (i.e. peak-to-peak value).
@@ -5746,11 +5746,15 @@ class MaskedArray(ndarray):
 
         """
         if out is None:
-            result = self.max(axis=axis, fill_value=fill_value)
-            result -= self.min(axis=axis, fill_value=fill_value)
+            result = self.max(axis=axis, fill_value=fill_value,
+                              keepdims=keepdims)
+            result -= self.min(axis=axis, fill_value=fill_value,
+                               keepdims=keepdims)
             return result
-        out.flat = self.max(axis=axis, out=out, fill_value=fill_value)
-        min_value = self.min(axis=axis, fill_value=fill_value)
+        out.flat = self.max(axis=axis, out=out, fill_value=fill_value,
+                            keepdims=keepdims)
+        min_value = self.min(axis=axis, fill_value=fill_value,
+                             keepdims=keepdims)
         np.subtract(out, min_value, out=out, casting='unsafe')
         return out
 
@@ -6489,17 +6493,15 @@ def max(obj, axis=None, out=None, fill_value=None, keepdims=np._NoValue):
 max.__doc__ = MaskedArray.max.__doc__
 
 
-def ptp(obj, axis=None, out=None, fill_value=None):
-    """
-    a.ptp(axis=None) =  a.max(axis) - a.min(axis)
-
-    """
+def ptp(obj, axis=None, out=None, fill_value=None, keepdims=np._NoValue):
+    kwargs = {} if keepdims is np._NoValue else {'keepdims': keepdims}
     try:
-        return obj.ptp(axis, out=out, fill_value=fill_value)
+        return obj.ptp(axis, out=out, fill_value=fill_value, **kwargs)
     except (AttributeError, TypeError):
         # If obj doesn't have a ptp method or if the method doesn't accept
         # a fill_value argument
-        return asanyarray(obj).ptp(axis=axis, fill_value=fill_value, out=out)
+        return asanyarray(obj).ptp(axis=axis, fill_value=fill_value,
+                                   out=out, **kwargs)
 ptp.__doc__ = MaskedArray.ptp.__doc__
 
 


### PR DESCRIPTION
This leaves `PyArray_Ptp` orphaned in the same way that `PyArray_Min` is