### PR TITLE
BUG: Masked singleton can be reshaped to be non-scalar

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6309,6 +6309,18 @@ class MaskedConstant(MaskedArray):
         # precedent for this with `np.bool_` scalars.
         return self
 
+    def __setattr__(self, attr, value):
+        if not self.__has_singleton():
+            # allow the singleton to be initialized
+            return super(MaskedConstant, self).__setattr__(attr, value)
+        elif self is self.__singleton:
+            raise AttributeError(
+                "attributes of {!r} are not writeable".format(self))
+        else:
+            # duplicate instance - we can end up here from __array_finalize__,
+            # where we set the __class__ attribute
+            return super(MaskedConstant, self).__setattr__(attr, value)
+
 
 masked = masked_singleton = MaskedConstant()
 masked_array = MaskedArray

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4981,6 +4981,10 @@ class TestMaskedConstant(object):
         assert_(a is not np.ma.masked)
         assert_not_equal(repr(a), 'masked')
 
+    def test_attributes_readonly(self):
+        assert_raises(AttributeError, setattr, np.ma.masked, 'shape', (1,))
+        assert_raises(AttributeError, setattr, np.ma.masked, 'dtype', np.int64)
+
 
 class TestMaskedWhereAliases(object):
 


### PR DESCRIPTION
It's possible this is the cause of gh-10270, where it seems something is wrong with the shape