### PR TITLE
MAINT, DOC: Documentation and misc. typos

### DIFF
--- a/doc/EXAMPLE_DOCSTRING.rst.txt
+++ b/doc/EXAMPLE_DOCSTRING.rst.txt
@@ -33,7 +33,7 @@ Returns
 -------
 out : ndarray
     The drawn samples, arranged according to `shape`.  If the
-    shape given is (m,n,...), then the shape of `out` is is
+    shape given is (m,n,...), then the shape of `out` is
     (m,n,...,N).
 
     In other words, each entry ``out[i,j,...,:]`` is an N-dimensional

--- a/doc/source/reference/c-api.coremath.rst
+++ b/doc/source/reference/c-api.coremath.rst
@@ -237,7 +237,7 @@ of floating point round-off error.
 
 Like for other types, NumPy includes a typedef npy_half for the 16 bit
 float.  Unlike for most of the other types, you cannot use this as a
-normal type in C, since is is a typedef for npy_uint16.  For example,
+normal type in C, since it is a typedef for npy_uint16.  For example,
 1.0 looks like 0x3c00 to C, and if you do an equality comparison
 between the different signed zeros, you will get -0.0 != 0.0
 (0x8000 != 0x0000), which is incorrect.

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -135,7 +135,7 @@ PyArray_GetCastFunc(PyArray_Descr *descr, int type_num)
  * Usually, if data_obj is not an array, dtype should be the result
  * given by the PyArray_GetArrayParamsFromObject function.
  *
- * The data_obj may be NULL if just a dtype is is known for the source.
+ * The data_obj may be NULL if just a dtype is known for the source.
  *
  * If *flex_dtype is NULL, returns immediately, without setting an
  * exception. This basically assumes an error was already set previously.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3195,7 +3195,7 @@ def _ureduce(a, func, **kwargs):
         Input array or object that can be converted to an array.
     func : callable
         Reduction function capable of receiving a single axis argument.
-        It is is called with `a` as first argument followed by `kwargs`.
+        It is called with `a` as first argument followed by `kwargs`.
     kwargs : keyword arguments
         additional keyword arguments to pass to `func`.
 

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -207,7 +207,7 @@ extern rk_error rk_devfill(void *buffer, size_t size, int strong);
 
 /*
  * fill the buffer using rk_devfill if the random device is available and using
- * rk_fill if is is not
+ * rk_fill if it is not
  * parameters have the same meaning as rk_fill and rk_devfill
  * Returns RK_ENODEV if the device is unavailable, or RK_NOERR if it is
  */


### PR DESCRIPTION
Found via `codespell`