### PR TITLE
ENH: Add memory leak test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - gfortran
       - libatlas-dev
       - libatlas-base-dev
+      - valgrind
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata
 
@@ -45,6 +46,7 @@ matrix:
         apt:
           packages:
             - debootstrap
+            - valgrind
     - python: 3.4
       env: USE_DEBUG=1
       dist: trusty

--- a/numpy/tests/test_memory.py
+++ b/numpy/tests/test_memory.py
@@ -1,0 +1,21 @@
+from __future__ import division, absolute_import, print_function
+
+import sys
+import subprocess
+import itertools
+
+
+class TestMemory(object):
+    def test_memory_leak(self):
+        # see #10157
+        output = subprocess.check_output([
+            'valgrind',
+            sys.executable,
+            '-c', 'import numpy'], stderr=subprocess.STDOUT)
+
+        leak_summary = '\n'.join(
+            itertools.dropwhile(lambda x: not x.endswith('LEAK SUMMARY:'),
+                                output.decode().splitlines()))
+
+        if 'definitely lost: 0 bytes in' not in leak_summary:
+            raise ValueError(leak_summary)


### PR DESCRIPTION
Related: #10157 

In #10286 @charris suggested to add a new environment variable for (de)activating the valgrind test. I don't know yet how we want to integrate this environment variable into the CI config files.
