### PR TITLE
DOC: typo fix in numpy.linalg.det docstring

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1835,7 +1835,7 @@ def det(a):
 
     See Also
     --------
-    slogdet : Another way to representing the determinant, more suitable
+    slogdet : Another way to represent the determinant, more suitable
       for large matrices where underflow/overflow may occur.
 
     Notes


### PR DESCRIPTION
This is a minor PR to fix a typo in the `See Also` section of the `numpy.linalg.det` docstring.