### PR TITLE
BUG: do not optimize einsum with only 2 arguments.

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1056,8 +1056,8 @@ def einsum(*operands, **kwargs):
 
     """
 
-    # Grab non-einsum kwargs
-    optimize_arg = kwargs.pop('optimize', True)
+    # Grab non-einsum kwargs; never optimize 2-argument case.
+    optimize_arg = kwargs.pop('optimize', len(operands) > 3)
 
     # If no optimization, run pure einsum
     if optimize_arg is False:


### PR DESCRIPTION
fixes gh-10357.

Avoid slow execution of 2-argument einsum calls, by ensuring we use the c code directly.