### PR TITLE
BUG: test, fix issue 583

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -661,6 +661,9 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
     """
 
     if formats is None and dtype is None:  # slower
+        if len(recList) == 0:
+            descr = sb.dtype((record, {'names':[], 'formats':[]}))
+            return sb.array([], dtype=descr)
         obj = sb.array(recList, dtype=object)
         arrlist = [sb.array(obj[..., i].tolist()) for i in range(obj.shape[-1])]
         return fromarrays(arrlist, formats=formats, shape=shape, names=names,

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -662,7 +662,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
 
     if formats is None and dtype is None:  # slower
         obj = sb.array(recList, dtype=object)
-        if sum(obj.shape) == 0:
+        if obj.shape == (0,):
             return sb.array([], dtype=sb.dtype((record, [])))
         arrlist = [sb.array(obj[..., i].tolist()) for i in range(obj.shape[-1])]
         return fromarrays(arrlist, formats=formats, shape=shape, names=names,

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -661,10 +661,9 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
     """
 
     if formats is None and dtype is None:  # slower
-        if len(recList) == 0:
-            descr = sb.dtype((record, {'names':[], 'formats':[]}))
-            return sb.array([], dtype=descr)
         obj = sb.array(recList, dtype=object)
+        if sum(obj.shape) == 0:
+            return sb.array([], dtype=sb.dtype((record, [])))
         arrlist = [sb.array(obj[..., i].tolist()) for i in range(obj.shape[-1])]
         return fromarrays(arrlist, formats=formats, shape=shape, names=names,
                           titles=titles, aligned=aligned, byteorder=byteorder)

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -32,6 +32,9 @@ class TestFromrecords(object):
         dtype = [('a', float), ('b', float)]
         r = np.rec.fromrecords([], dtype=dtype)
         assert_equal(r.shape, (0,))
+        r = np.rec.fromrecords([])
+        assert_equal(r.shape, (0,))
+        assert_equal(r.dtype.names, ())
 
     def test_fromrecords_2d(self):
         data = [


### PR DESCRIPTION
fixes issue #583 where ``records([], None, None)`` would raise a ``ValueError``, now it returns an empty record array. Test added that failed, now passes