### PR TITLE
MAINT: Adjust type promotion in linalg.norm

### DIFF
--- a/doc/release/1.14.0-notes.rst
+++ b/doc/release/1.14.0-notes.rst
@@ -179,10 +179,10 @@ functions, and if used would likely correspond to a typo.
 Previously, this would promote to ``float64`` when arbitrary orders were
 passed, despite not doing so under the simple cases::
 
-    >>> f32 = np.float32([1, 2])
-    >>> np.linalg.norm(f32, 2.0).dtype
+    >>> f32 = np.float32([[1, 2]])
+    >>> np.linalg.norm(f32, 2.0, axis=-1).dtype
     dtype('float32')
-    >>> np.linalg.norm(f32, 2.0001).dtype
+    >>> np.linalg.norm(f32, 2.0001, axis=-1).dtype
     dtype('float64')  # numpy 1.13
     dtype('float32')  # numpy 1.14
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2277,7 +2277,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             return abs(x).min(axis=axis, keepdims=keepdims)
         elif ord == 0:
             # Zero norm
-            return (x != 0).astype(float).sum(axis=axis, keepdims=keepdims)
+            return (x != 0).astype(x.real.dtype).sum(axis=axis, keepdims=keepdims)
         elif ord == 1:
             # special case for speedup
             return add.reduce(abs(x), axis=axis, keepdims=keepdims)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2292,7 +2292,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 raise ValueError("Invalid norm order for vectors.")
             absx = abs(x)
             absx **= ord
-            return add.reduce(absx, axis=axis, keepdims=keepdims) ** (1.0 / ord)
+            ret = add.reduce(absx, axis=axis, keepdims=keepdims)
+            ret **= (1 / ord)
+            return ret
     elif len(axis) == 2:
         row_axis, col_axis = axis
         row_axis = normalize_axis_index(row_axis, nd)


### PR DESCRIPTION
Relates to #10364.

Unfortunately the failing case there still doesn't work when the result is a scalar, due to falling afoul of #10322. We fix this by just not making any promise about the scalar case.

That seems pretty reasonable to me, since numpy makes it very hard to keep float32 scalars around anyway.