### PR TITLE
Address #10363 where numpy.vectorized functions return array unconditionally

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2033,7 +2033,10 @@ class vectorize(object):
             outputs = ufunc(*inputs)
 
             if ufunc.nout == 1:
-                res = array(outputs, copy=False, subok=True, dtype=otypes[0])
+                if iterable(outputs):
+                    res = array(outputs, copy=False, subok=True, dtype=otypes[0])
+                else:
+                    res = outputs
             else:
                 res = tuple([array(x, copy=False, subok=True, dtype=t)
                              for x, t in zip(outputs, otypes)])

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2033,7 +2033,7 @@ class vectorize(object):
             outputs = ufunc(*inputs)
 
             if ufunc.nout == 1:
-                if iterable(outputs):
+                if np.ndim(outputs) > 0:
                     res = array(outputs, copy=False, subok=True, dtype=otypes[0])
                 else:
                     res = outputs

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1124,6 +1124,33 @@ class TestVectorize(object):
         r2 = np.cos(args)
         assert_array_almost_equal(r1, r2)
 
+    def test_single_return_value_type(self):
+        # The return value of a ufunc and a vectorized ufunc should be identical
+        some_float = 4.0
+        mysqrt = vectorize(np.sqrt)
+        r1 = mysqrt(some_float)
+        r2 = np.sqrt(some_float)
+        assert_equal(r1, r2)
+        assert_equal(type(r1), type(r2))
+
+        add = vectorize(np.add)
+        a = 0.2
+        b = 0.3
+        r1 = add(a, b)
+        r2 = np.add(a, b)
+        assert_equal(r1, r2)
+        assert_equal(type(r1), type(r2))
+
+        class A(np.ndarray):
+            pass
+
+        a = np.array(4.0).view(A)
+        b = np.array(6.0).view(A)
+        r1 = add(a, b)
+        r2 = np.add(a, b)
+        assert_equal(r1, r2)
+        assert_equal(type(r1), type(r2))
+
     def test_keywords(self):
 
         def foo(a, b=1):


### PR DESCRIPTION
Return outputs from vectorized ufunc as-is if not iterable to match the behavior of `np.sqrt`, `np.exp`, etc.

Closes #10363.