### PR TITLE
BUG: Set einsum optimize parameter default to `False`.

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -866,7 +866,7 @@ def einsum(*operands, **kwargs):
         Controls if intermediate optimization should occur. No optimization
         will occur if False and True will default to the 'greedy' algorithm.
         Also accepts an explicit contraction list from the ``np.einsum_path``
-        function. See ``np.einsum_path`` for more details. Default is True.
+        function. See ``np.einsum_path`` for more details. Default is False.
 
     Returns
     -------
@@ -1059,7 +1059,7 @@ def einsum(*operands, **kwargs):
     """
 
     # Grab non-einsum kwargs
-    optimize_arg = kwargs.pop('optimize', True)
+    optimize_arg = kwargs.pop('optimize', False)
 
     # If no optimization, run pure einsum
     if optimize_arg is False:


### PR DESCRIPTION
There have been bugs reported with einsum with the `optimize=True`
default, see #10343. This PR makes the default `False` for the 1.14.1
release. Because optimizing the contractions is not a trivial problem,
this will allow us to pursue fixes in the longer time frame of the 1.15
release.