### PR TITLE
DOC: Add examples using DASK arrays.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2981,6 +2981,14 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     >>> np.mean(a, dtype=np.float64)
     0.55000000074505806
 
+    It can also handle dask arrays
+
+    >>> import dask.array as da
+    >>> x = da.ones((10, 11, 12), chunks=7)
+    >>> np.mean(x)
+    dask.array<mean_agg-aggregate, shape=(), dtype=float64, chunksize=()>
+    
+    
     """
     kwargs = {}
     if keepdims is not np._NoValue:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1566,6 +1566,10 @@ def moveaxis(a, source, destination):
     >>> np.moveaxis(x, [0, 1, 2], [-1, -2, -3]).shape
     (5, 4, 3)
 
+    >>> import dask.array as da
+    >>> x = da.ones((10, 11, 12), chunks=7)
+    >>> np.moveaxis(x, 0, -1)
+    dask.array<transpose, shape=(11, 12, 10), dtype=float64, chunksize=(7, 7, 7)>
     """
     try:
         # allow duck-array types if they define transpose


### PR DESCRIPTION
Added example of dask array compatibility with np.mean() and np.moveaxis()

#9476 