### PR TITLE
MAINT: Fix sign-compare warnings in npy_binsearch, npy_partition.

### DIFF
--- a/numpy/core/src/private/npy_binsearch.h.src
+++ b/numpy/core/src/private/npy_binsearch.h.src
@@ -5,6 +5,8 @@
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
 
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
+
 typedef void (PyArray_BinSearchFunc)(const char*, const char*, char*,
                                      npy_intp, npy_intp,
                                      npy_intp, npy_intp, npy_intp,
@@ -16,15 +18,15 @@ typedef int (PyArray_ArgBinSearchFunc)(const char*, const char*,
                                        npy_intp, npy_intp, npy_intp,
                                        PyArrayObject*);
 
-struct binsearch_map {
-    enum NPY_TYPES typenum;
+typedef struct {
+    int typenum;
     PyArray_BinSearchFunc *binsearch[NPY_NSEARCHSIDES];
-};
+} binsearch_map;
 
-struct argbinsearch_map {
-    enum NPY_TYPES typenum;
+typedef struct {
+    int typenum;
     PyArray_ArgBinSearchFunc *argbinsearch[NPY_NSEARCHSIDES];
-};
+} argbinsearch_map;
 
 /**begin repeat
  *
@@ -72,7 +74,7 @@ npy_argbinsearch_@side@(const char *arr, const char *key,
  * #Arg = , Arg#
  */
 
-static struct @arg@binsearch_map _@arg@binsearch_map[] = {
+static @arg@binsearch_map _@arg@binsearch_map[] = {
     /* If adding new types, make sure to keep them ordered by type num */
     /**begin repeat1
      *
@@ -100,10 +102,9 @@ static PyArray_@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
 static NPY_INLINE PyArray_@Arg@BinSearchFunc*
 get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
-    static npy_intp num_funcs = sizeof(_@arg@binsearch_map) /
-                                sizeof(_@arg@binsearch_map[0]);
+    npy_intp nfuncs = ARRAY_SIZE(_@arg@binsearch_map);
     npy_intp min_idx = 0;
-    npy_intp max_idx = num_funcs;
+    npy_intp max_idx = nfuncs;
     int type = dtype->type_num;
 
     if (side >= NPY_NSEARCHSIDES) {
@@ -125,7 +126,8 @@ get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
         }
     }
 
-    if (min_idx < num_funcs && _@arg@binsearch_map[min_idx].typenum == type) {
+    if (min_idx < nfuncs &&
+            _@arg@binsearch_map[min_idx].typenum == type) {
         return _@arg@binsearch_map[min_idx].@arg@binsearch[side];
     }
 
@@ -136,5 +138,7 @@ get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
     return NULL;
 }
 /**end repeat**/
+
+#undef ARRAY_SIZE
 
 #endif

--- a/numpy/core/src/private/npy_partition.h.src
+++ b/numpy/core/src/private/npy_partition.h.src
@@ -24,8 +24,9 @@
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
 
-#define NPY_MAX_PIVOT_STACK 50
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
 
+#define NPY_MAX_PIVOT_STACK 50
 
 /**begin repeat
  *
@@ -56,7 +57,7 @@ NPY_VISIBILITY_HIDDEN int aintroselect_@suff@(@type@ *v, npy_intp* tosort, npy_i
 /**end repeat**/
 
 typedef struct {
-    enum NPY_TYPES typenum;
+    int typenum;
     PyArray_PartitionFunc * part[NPY_NSELECTS];
     PyArray_ArgPartitionFunc * argpart[NPY_NSELECTS];
 } part_map;
@@ -92,10 +93,12 @@ static NPY_INLINE PyArray_PartitionFunc *
 get_partition_func(int type, NPY_SELECTKIND which)
 {
     npy_intp i;
+    npy_intp ntypes = ARRAY_SIZE(_part_map);
+
     if (which >= NPY_NSELECTS) {
         return NULL;
     }
-    for (i = 0; i < sizeof(_part_map)/sizeof(_part_map[0]); i++) {
+    for (i = 0; i < ntypes; i++) {
         if (type == _part_map[i].typenum) {
             return _part_map[i].part[which];
         }
@@ -108,15 +111,19 @@ static NPY_INLINE PyArray_ArgPartitionFunc *
 get_argpartition_func(int type, NPY_SELECTKIND which)
 {
     npy_intp i;
+    npy_intp ntypes = ARRAY_SIZE(_part_map);
+
     if (which >= NPY_NSELECTS) {
         return NULL;
     }
-    for (i = 0; i < sizeof(_part_map)/sizeof(_part_map[0]); i++) {
+    for (i = 0; i < ntypes; i++) {
         if (type == _part_map[i].typenum) {
             return _part_map[i].argpart[which];
         }
     }
     return NULL;
 }
+
+#undef ARRAY_SIZE
 
 #endif


### PR DESCRIPTION
The gcc compiler treats enums as unsigned unless one of the enumerated
values is negative. The values here are small, so we can fix that by casting
to int. The same can be done with the results of the sizeof function if
we know ahead of time that the result is small.