### PR TITLE
MAINT: Remove repeated #ifdefs implementing `isinstance(x, basestring)` for field names

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -94,6 +94,8 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 #define PyUString_InternFromString PyUnicode_InternFromString
 #define PyUString_Format PyUnicode_Format
 
+#define PyBaseString_Check(obj) (PyUnicode_Check(obj))
+
 #else
 
 #define PyBytes_Type PyString_Type
@@ -122,6 +124,8 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 #define PyUString_Size PyString_Size
 #define PyUString_InternFromString PyString_InternFromString
 #define PyUString_Format PyString_Format
+
+#define PyBaseString_Check(obj) (PyBytes_Check(obj) || PyUnicode_Check(obj))
 
 #endif /* NPY_PY3K */
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -512,11 +512,7 @@ _convert_from_array_descr(PyObject *obj, int align)
         }
         if ((PyDict_GetItem(fields, name) != NULL)
              || (title
-#if defined(NPY_PY3K)
-                 && PyUString_Check(title)
-#else
-                 && (PyUString_Check(title) || PyUnicode_Check(title))
-#endif
+                 && PyBaseString_Check(title)
                  && (PyDict_GetItem(fields, title) != NULL))) {
 #if defined(NPY_PY3K)
             name = PyUnicode_AsUTF8String(name);
@@ -551,11 +547,7 @@ _convert_from_array_descr(PyObject *obj, int align)
             Py_INCREF(title);
             PyTuple_SET_ITEM(tup, 2, title);
             PyDict_SetItem(fields, name, tup);
-#if defined(NPY_PY3K)
-            if (PyUString_Check(title)) {
-#else
-            if (PyUString_Check(title) || PyUnicode_Check(title)) {
-#endif
+            if (PyBaseString_Check(title)) {
                 if (PyDict_GetItem(fields, title) != NULL) {
                     PyErr_SetString(PyExc_ValueError,
                             "title already used as a name or title.");
@@ -1181,11 +1173,7 @@ _convert_from_dict(PyObject *obj, int align)
             Py_DECREF(tup);
             goto fail;
         }
-#if defined(NPY_PY3K)
-        if (!PyUString_Check(name)) {
-#else
-        if (!(PyUString_Check(name) || PyUnicode_Check(name))) {
-#endif
+        if (!PyBaseString_Check(name)) {
             PyErr_SetString(PyExc_ValueError,
                     "field names must be strings");
             Py_DECREF(tup);
@@ -1202,11 +1190,7 @@ _convert_from_dict(PyObject *obj, int align)
         PyDict_SetItem(fields, name, tup);
         Py_DECREF(name);
         if (len == 3) {
-#if defined(NPY_PY3K)
-            if (PyUString_Check(title)) {
-#else
-            if (PyUString_Check(title) || PyUnicode_Check(title)) {
-#endif
+            if (PyBaseString_Check(title)) {
                 if (PyDict_GetItem(fields, title) != NULL) {
                     PyErr_SetString(PyExc_ValueError,
                             "title already used as a name or title.");
@@ -3821,11 +3805,7 @@ descr_subscript(PyArray_Descr *self, PyObject *op)
         return NULL;
     }
 
-#if defined(NPY_PY3K)
-    if (PyUString_Check(op)) {
-#else
-    if (PyUString_Check(op) || PyUnicode_Check(op)) {
-#endif
+    if (PyBaseString_Check(op)) {
         return _subscript_by_name(self, op);
     }
     else {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1396,11 +1396,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
     *view = NULL;
 
     /* first check for a single field name */
-#if defined(NPY_PY3K)
-    if (PyUnicode_Check(ind)) {
-#else
-    if (PyString_Check(ind) || PyUnicode_Check(ind)) {
-#endif
+    if (PyBaseString_Check(ind)) {
         PyObject *tup;
         PyArray_Descr *fieldtype;
         npy_intp offset;
@@ -1477,11 +1473,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
                 return -1;
             }
 
-#if defined(NPY_PY3K)
-            if (!PyUnicode_Check(name)) {
-#else
-            if (!PyString_Check(name) && !PyUnicode_Check(name)) {
-#endif
+            if (!PyBaseString_Check(name)) {
                 Py_DECREF(name);
                 Py_DECREF(fields);
                 Py_DECREF(names);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2376,11 +2376,7 @@ voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val)
         return -1;
     }
 
-#if defined(NPY_PY3K)
-    if (PyUString_Check(ind)) {
-#else
-    if (PyBytes_Check(ind) || PyUnicode_Check(ind)) {
-#endif
+    if (PyBaseString_Check(ind)) {
         /*
          * Much like in voidtype_setfield, we cannot simply use ndarray's
          * __setitem__ since assignment to void scalars should not broadcast


### PR DESCRIPTION
cython already defines a `__Pyx_PyBaseString_Check` for internal use, and googling `PyBaseString_Check` shows it's not an uncommon name for this macro.

I've based this on the 1.14 branch, just in case