### PR TITLE
MAINT: Update zesty to artful for i386 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ python:
 matrix:
   include:
     - python: 2.7
-      env: USE_CHROOT=1 ARCH=i386 DIST=zesty PYTHON=2.7
+      env: USE_CHROOT=1 ARCH=i386 DIST=artful PYTHON=2.7
       sudo: true
       dist: trusty
       addons:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -89,14 +89,13 @@ setup_chroot()
 
   sudo chroot $DIR bash -c "apt-get update"
   # faster operation with preloaded eatmydata
-  sudo chroot $DIR bash -c "apt-get install -qq -y --force-yes eatmydata"
+  sudo chroot $DIR bash -c "apt-get install -qq -y eatmydata"
   echo '/usr/$LIB/libeatmydata.so' | \
     sudo tee -a $DIR/etc/ld.so.preload
 
   # install needed packages
-  sudo chroot $DIR bash -c "apt-get install -qq -y --force-yes \
-    libatlas-dev libatlas-base-dev gfortran \
-    python-dev python-nose python-pip cython"
+  sudo chroot $DIR bash -c "apt-get install -qq -y \
+    libatlas-base-dev gfortran python-dev python-nose python-pip cython"
 }
 
 run_test()


### PR DESCRIPTION
The zesty release hit end of life Jan 13, 2018 and it seems that travis
ci tests are failing due to a failure to fetch it. This updates to use
artful. When the bionic LTS comes out in April, we should update again.