### PR TITLE
ENH: Fix repr of np.record objects to match np.void types #10412

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -223,10 +223,14 @@ class record(nt.void):
     __module__ = 'numpy'
 
     def __repr__(self):
-        return self.__str__()
+        if get_printoptions()['legacy'] == '1.13':
+            return self.__str__()
+        return super(record, self).__repr__()
 
     def __str__(self):
-        return str(self.item())
+        if get_printoptions()['legacy'] == '1.13':
+            return str(self.item())
+        return super(record, self).__str__()
 
     def __getattribute__(self, attr):
         if attr in ['setfield', 'getfield', 'dtype']:

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -104,7 +104,7 @@ class TestFromrecords(object):
 
     def test_recarray_repr(self):
         a = np.array([(1, 0.1), (2, 0.2)],
-                     dtype=[('foo', int), ('bar', float)])
+                     dtype=[('foo', '<i4'), ('bar', '<f8')])
         a = np.rec.array(a)
         assert_equal(
             repr(a),
@@ -112,6 +112,16 @@ class TestFromrecords(object):
             rec.array([(1, 0.1), (2, 0.2)],
                       dtype=[('foo', '<i4'), ('bar', '<f8')])""")
         )
+
+        # make sure non-structured dtypes also show up as rec.array
+        a = np.array(np.ones(4, dtype='f8'))
+        assert_(repr(np.rec.array(a)).startswith('rec.array'))
+
+        # check that the 'np.record' part of the dtype isn't shown
+        a = np.rec.array(np.ones(3, dtype='i4,i4'))
+        assert_equal(repr(a).find('numpy.record'), -1)
+        a = np.rec.array(np.ones(3, dtype='i4'))
+        assert_(repr(a).find('dtype=int32') != -1)
 
     def test_0d_recarray_repr(self):
         # testing infered integer types is unpleasant due to sizeof(int) varying
@@ -213,17 +223,6 @@ class TestFromrecords(object):
             arr2 = rec.view(rec.dtype.fields or rec.dtype, np.ndarray)
             assert_equal(arr2.dtype.type, arr.dtype.type)
             assert_equal(type(arr2), type(arr))
-
-    def test_recarray_repr(self):
-        # make sure non-structured dtypes also show up as rec.array
-        a = np.array(np.ones(4, dtype='f8'))
-        assert_(repr(np.rec.array(a)).startswith('rec.array'))
-
-        # check that the 'np.record' part of the dtype isn't shown
-        a = np.rec.array(np.ones(3, dtype='i4,i4'))
-        assert_equal(repr(a).find('numpy.record'), -1)
-        a = np.rec.array(np.ones(3, dtype='i4'))
-        assert_(repr(a).find('dtype=int32') != -1)
 
     def test_recarray_from_names(self):
         ra = np.rec.array([

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -4,6 +4,7 @@ import sys
 import collections
 import pickle
 import warnings
+import textwrap
 from os import path
 
 import numpy as np
@@ -111,6 +112,22 @@ class TestFromrecords(object):
             rec.array([(1, 0.1), (2, 0.2)],
                       dtype=[('foo', '<i4'), ('bar', '<f8')])""")
         )
+
+    def test_0d_recarray_repr(self):
+        # testing infered integer types is unpleasant due to sizeof(int) varying
+        arr_0d = np.rec.array((np.int32(1), 2.0, np.datetime64('2003')))
+        assert_equal(repr(arr_0d), textwrap.dedent("""\
+            rec.array((1, 2., '2003'),
+                      dtype=[('f0', '<i4'), ('f1', '<f8'), ('f2', '<M8[Y]')])"""))
+
+        record = arr_0d[()]
+        assert_equal(repr(record), "(1, 2., '2003')")
+        # 1.13 converted to python scalars before the repr
+        try:
+            np.set_printoptions(legacy='1.13')
+            assert_equal(repr(record), '(1, 2.0, datetime.date(2003, 1, 1))')
+        finally:
+            np.set_printoptions(legacy=False)
 
     def test_recarray_from_repr(self):
         a = np.array([(1,'ABC'), (2, "DEF")],


### PR DESCRIPTION
Backport of #10412.. let's see what happens if I do the PR from your repo.