### PR TITLE
MAINT: trapz works on non-monotonic x

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3712,19 +3712,34 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     array([ 2.,  8.])
 
     """
+    def _argsort_indices(a, axis=-1):
+        """
+        Like argsort, but returns an index suitable for sorting the
+        the original array even if that array is multidimensional
+        # lifted from numpy#6078
+        """
+        a = np.asarray(a)
+        ind = list(np.ix_(*[np.arange(d) for d in a.shape]))
+        ind[axis] = a.argsort(axis)
+        return tuple(ind)
+
     y = asanyarray(y)
     if x is None:
         d = dx
     else:
         x = asanyarray(x)
+
         if x.ndim == 1:
-            d = diff(x)
-            # reshape to correct shape
             shape = [1]*y.ndim
-            shape[axis] = d.shape[0]
-            d = d.reshape(shape)
-        else:
-            d = diff(x, axis=axis)
+            shape[axis] = x.shape[0]
+            x = np.copy(x).reshape(shape)
+
+        x, y = np.broadcast_arrays(x, y)
+        idxs = _argsort_indices(x, axis)
+        y = y[idxs]
+        x = x[idxs]
+        d = diff(x, axis=axis)
+
     nd = y.ndim
     slice1 = [slice(None)]*nd
     slice2 = [slice(None)]*nd

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1602,6 +1602,19 @@ class TestTrapz(object):
         mr = trapz(my, mx)
         assert_almost_equal(mr, r)
 
+    def test_trapz_non_sorted(self):
+        # check that trapz works on un-sorted arrays.
+        v1 = trapz([1, 2, 3], [1, 2, 3])
+        v2 = trapz([1, 3, 2], [1, 3, 2])
+        assert_almost_equal(v2, v1)
+
+        a = np.arange(27.).reshape(3, 3, 3)
+        b = np.copy(a)
+        b[:, 0, :] = a[:, 1, :]
+        b[:, 1, :] = a[:, 2, :]
+        b[:, 2, :] = a[:, 0, :]
+        assert_almost_equal(trapz(b, b, axis=1), trapz(a, a, axis=1))
+
 
 class TestSinc(object):
 


### PR DESCRIPTION
This PR allows `trapz` to take non monotonic `x` arrays. It achieves this by a sort along the required axis.
1 and 3-D tests are added.