### PR TITLE
MAINT: Use ValueError for duplicate field names in lookup

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1513,7 +1513,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
                 PyObject *errmsg = PyUString_FromString(
                                        "duplicate field of name ");
                 PyUString_ConcatAndDel(&errmsg, name);
-                PyErr_SetObject(PyExc_KeyError, errmsg);
+                PyErr_SetObject(PyExc_ValueError, errmsg);
                 Py_DECREF(errmsg);
                 Py_DECREF(fields);
                 Py_DECREF(names);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1157,8 +1157,10 @@ class TestStructured(object):
     def test_multiindex_titles(self):
         a = np.zeros(4, dtype=[(('a', 'b'), 'i'), ('c', 'i'), ('d', 'i')])
         assert_raises(KeyError, lambda : a[['a','c']])
-        assert_raises(KeyError, lambda : a[['b','b']])
+        assert_raises(KeyError, lambda : a[['a','a']])
+        assert_raises(ValueError, lambda : a[['b','b']])  # field exists, but repeated
         a[['b','c']]  # no exception
+
 
 class TestBool(object):
     def test_test_interning(self):


### PR DESCRIPTION
KeyError suggests the field name does not exist, which is inaccurate.

This is a new error as of 1.14, so I think we can change its type without needing to consider back-compat.

[Backportable here](https://github.com/numpy/numpy/compare/master...eric-wieser:duplicate-field-name-error)