### PR TITLE
REL: Add 1.14.1 release notes template

### DIFF
--- a/doc/release/1.14.1-notes.rst
+++ b/doc/release/1.14.1-notes.rst
@@ -1,0 +1,23 @@
+==========================
+NumPy 1.14.1 Release Notes
+==========================
+
+This is a bugfix release for some problems found since 1.14.0. The most
+important fixes are:
+
+
+
+The Python versions supported are 2.7 and 3.4 - 3.6. The Python 3.6 wheels
+available from PIP are built with Python 3.6.2 and should be compatible with
+all previous versions of Python 3.6. It was cythonized with Cython 0.26.1,
+which should be free of the bugs found in 0.27 while also being compatible with
+Python 3.7-dev.
+
+Contributors
+============
+
+A total of xx people contributed to this release.  People with a "+" by their
+names contributed a patch for the first time.
+
+Pull requests merged
+====================


### PR DESCRIPTION
Taken from gh-10411.

Parent is the branch point of 1.14, which makes this trivially forward-portable