### PR TITLE
BUG: Fix nan_to_num return with integer input

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -101,5 +101,11 @@ Change to simd.inc.src to use AVX2 or AVX512 at compile time. Solving the gap
 that if compile numpy for avx2 (or 512) with -march=native, still get the SSE
 code for the simd functions even though rest of the code gets AVX2.
 
+``nan_to_num`` always returns scalars when receiving scalar inputs
+------------------------------------------------------------------
+`nan_to_num` works with both scalars and arrays. However, there was a corner
+case of receiving an integer number and returning an array as result. Now, the
+function works consistently.
+
 Changes
 =======

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -101,12 +101,11 @@ Change to simd.inc.src to use AVX2 or AVX512 at compile time. Solving the gap
 that if compile numpy for avx2 (or 512) with -march=native, still get the SSE
 code for the simd functions even though rest of the code gets AVX2.
 
-``nan_to_num`` always returns scalars when receiving scalar inputs
-------------------------------------------------------------------
-`nan_to_num` works with both scalars and arrays. However, there was a corner
-case of receiving an integer number and returning an array as result. Now, the
-function is consistent with ufuncs. It also casts 0-dimensional arrays to
-scalars.
+``nan_to_num`` always returns scalars when receiving scalar or 0d inputs
+------------------------------------------------------------------------
+Previously an array was returned for integer scalar inputs, which is
+inconsistent with the behavior for float inputs, and that of ufuncs in general.
+For all types of scalar or 0d input, the result is now a scalar.
 
 Changes
 =======

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -105,7 +105,8 @@ code for the simd functions even though rest of the code gets AVX2.
 ------------------------------------------------------------------
 `nan_to_num` works with both scalars and arrays. However, there was a corner
 case of receiving an integer number and returning an array as result. Now, the
-function works consistently.
+function is consistent with ufuncs. It also casts 0-dimensional arrays to
+scalars.
 
 Changes
 =======

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -359,6 +359,7 @@ class TestNanToNum(object):
         assert_all(vals[0] < -1e10) and assert_all(np.isfinite(vals[0]))
         assert_(vals[1] == 0)
         assert_all(vals[2] > 1e10) and assert_all(np.isfinite(vals[2]))
+        assert_equal(type(vals), np.ndarray)
 
         # perform the same test but in-place
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -369,16 +370,27 @@ class TestNanToNum(object):
         assert_all(vals[0] < -1e10) and assert_all(np.isfinite(vals[0]))
         assert_(vals[1] == 0)
         assert_all(vals[2] > 1e10) and assert_all(np.isfinite(vals[2]))
+        assert_equal(type(vals), np.ndarray)
+
+    def test_array(self):
+        vals = nan_to_num([1])
+        assert_array_equal(vals, np.array([1], int))
+        assert_equal(type(vals), np.ndarray)
 
     def test_integer(self):
         vals = nan_to_num(1)
         assert_all(vals == 1)
-        vals = nan_to_num([1])
-        assert_array_equal(vals, np.array([1], int))
+        assert_equal(type(vals), int)
+
+    def test_float(self):
+        vals = nan_to_num(1.0)
+        assert_all(vals == 1.0)
+        assert_equal(type(vals), np.float64)
 
     def test_complex_good(self):
         vals = nan_to_num(1+1j)
         assert_all(vals == 1+1j)
+        assert_equal(type(vals), np.complex128)
 
     def test_complex_bad(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -387,6 +399,7 @@ class TestNanToNum(object):
         vals = nan_to_num(v)
         # !! This is actually (unexpectedly) zero
         assert_all(np.isfinite(vals))
+        assert_equal(type(vals), np.complex128)
 
     def test_complex_bad2(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -394,6 +407,7 @@ class TestNanToNum(object):
             v += np.array(-1+1.j)/0.
         vals = nan_to_num(v)
         assert_all(np.isfinite(vals))
+        assert_equal(type(vals), np.complex128)
         # Fixme
         #assert_all(vals.imag > 1e10)  and assert_all(np.isfinite(vals))
         # !! This is actually (unexpectedly) positive

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -380,17 +380,17 @@ class TestNanToNum(object):
     def test_integer(self):
         vals = nan_to_num(1)
         assert_all(vals == 1)
-        assert_equal(type(vals), int)
+        assert_equal(type(vals), np.int_)
 
     def test_float(self):
         vals = nan_to_num(1.0)
         assert_all(vals == 1.0)
-        assert_equal(type(vals), np.float64)
+        assert_equal(type(vals), np.float_)
 
     def test_complex_good(self):
         vals = nan_to_num(1+1j)
         assert_all(vals == 1+1j)
-        assert_equal(type(vals), np.complex128)
+        assert_equal(type(vals), np.complex_)
 
     def test_complex_bad(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -399,7 +399,7 @@ class TestNanToNum(object):
         vals = nan_to_num(v)
         # !! This is actually (unexpectedly) zero
         assert_all(np.isfinite(vals))
-        assert_equal(type(vals), np.complex128)
+        assert_equal(type(vals), np.complex_)
 
     def test_complex_bad2(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -407,7 +407,7 @@ class TestNanToNum(object):
             v += np.array(-1+1.j)/0.
         vals = nan_to_num(v)
         assert_all(np.isfinite(vals))
-        assert_equal(type(vals), np.complex128)
+        assert_equal(type(vals), np.complex_)
         # Fixme
         #assert_all(vals.imag > 1e10)  and assert_all(np.isfinite(vals))
         # !! This is actually (unexpectedly) positive

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -330,7 +330,7 @@ def _getmaxmin(t):
 
 def nan_to_num(x, copy=True):
     """
-    Replace nan with zero and inf with large finite numbers.
+    Replace NaN with zero and infinity with large finite numbers.
 
     If `x` is inexact, NaN is replaced by zero, and infinity and -infinity
     replaced by the respectively largest and most negative finite floating
@@ -343,7 +343,7 @@ def nan_to_num(x, copy=True):
 
     Parameters
     ----------
-    x : array_like
+    x : scalar or array_like
         Input data.
     copy : bool, optional
         Whether to create a copy of `x` (True) or to replace values
@@ -374,6 +374,12 @@ def nan_to_num(x, copy=True):
 
     Examples
     --------
+    >>> np.nan_to_num(np.inf)
+    1.7976931348623157e+308
+    >>> np.nan_to_num(-np.inf)
+    -1.7976931348623157e+308
+    >>> np.nan_to_num(np.nan)
+    0.0
     >>> x = np.array([np.inf, -np.inf, np.nan, -128, 128])
     >>> np.nan_to_num(x)
     array([  1.79769313e+308,  -1.79769313e+308,   0.00000000e+000,

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -393,13 +393,13 @@ def nan_to_num(x, copy=True):
     x = _nx.array(x, subok=True, copy=copy)
     xtype = x.dtype.type
     isscalar = (x.ndim == 0)
+    x = x[None] if isscalar else x
 
     if not issubclass(xtype, _nx.inexact):
-        return asscalar(x) if isscalar else x
+        return x[0] if isscalar else x
 
     iscomplex = issubclass(xtype, _nx.complexfloating)
 
-    x = x[None] if isscalar else x
     dest = (x.real, x.imag) if iscomplex else (x,)
     maxf, minf = _getmaxmin(x.real.dtype)
     for d in dest:

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -386,11 +386,12 @@ def nan_to_num(x, copy=True):
     """
     x = _nx.array(x, subok=True, copy=copy)
     xtype = x.dtype.type
+    isscalar = (x.ndim == 0)
+
     if not issubclass(xtype, _nx.inexact):
-        return x
+        return asscalar(x) if isscalar else x
 
     iscomplex = issubclass(xtype, _nx.complexfloating)
-    isscalar = (x.ndim == 0)
 
     x = x[None] if isscalar else x
     dest = (x.real, x.imag) if iscomplex else (x,)
@@ -579,7 +580,7 @@ def common_type(*arrays):
     an integer array, the minimum precision type that is returned is a
     64-bit floating point dtype.
 
-    All input arrays except int64 and uint64 can be safely cast to the 
+    All input arrays except int64 and uint64 can be safely cast to the
     returned dtype without loss of information.
 
     Parameters

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -392,11 +392,11 @@ def nan_to_num(x, copy=True):
     """
     x = _nx.array(x, subok=True, copy=copy)
     xtype = x.dtype.type
+
     isscalar = (x.ndim == 0)
-    x = x[None] if isscalar else x
 
     if not issubclass(xtype, _nx.inexact):
-        return x[0] if isscalar else x
+        return x[()] if isscalar else x
 
     iscomplex = issubclass(xtype, _nx.complexfloating)
 
@@ -406,7 +406,7 @@ def nan_to_num(x, copy=True):
         _nx.copyto(d, 0.0, where=isnan(d))
         _nx.copyto(d, maxf, where=isposinf(d))
         _nx.copyto(d, minf, where=isneginf(d))
-    return x[0] if isscalar else x
+    return x[()] if isscalar else x
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Another PR, #7362, already attempted to solve #1477 but failed to create tests portable to 32-bit Windows and Linux machines.

This PR fixes the bug and attempts to solve the aforementioned problem. It also updates `nan_to_num` documentation, which did not include scalars as valid input values to the method.