### PR TITLE
BUG: Fix various Big-Endian test failures (ppc64)

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -28,7 +28,7 @@ class TestArrayRepr(object):
             '     [3, 4]])')
 
         # two dimensional with flexible dtype
-        xstruct = np.ones((2,2), dtype=[('a', 'i4')]).view(sub)
+        xstruct = np.ones((2,2), dtype=[('a', '<i4')]).view(sub)
         assert_equal(repr(xstruct),
             "sub([[(1,), (1,)],\n"
             "     [(1,), (1,)]], dtype=[('a', '<i4')])"
@@ -362,13 +362,14 @@ class TestPrintOptions(object):
 
     def test_0d_arrays(self):
         unicode = type(u'')
-        assert_equal(unicode(np.array(u'café', np.unicode_)), u'café')
+
+        assert_equal(unicode(np.array(u'café', '<U4')), u'café')
 
         if sys.version_info[0] >= 3:
-            assert_equal(repr(np.array('café', np.unicode_)),
+            assert_equal(repr(np.array('café', '<U4')),
                          "array('café', dtype='<U4')")
         else:
-            assert_equal(repr(np.array(u'café', np.unicode_)),
+            assert_equal(repr(np.array(u'café', '<U4')),
                          "array(u'caf\\xe9', dtype='<U4')")
         assert_equal(str(np.array('test', np.str_)), 'test')
 
@@ -464,7 +465,7 @@ class TestPrintOptions(object):
         repr(np.array([1e4, 0.1], dtype='f2'))
 
     def test_sign_spacing_structured(self):
-        a = np.ones(2, dtype='f,f')
+        a = np.ones(2, dtype='<f,<f')
         assert_equal(repr(a),
             "array([(1., 1.), (1., 1.)], dtype=[('f0', '<f4'), ('f1', '<f4')])")
         assert_equal(repr(a[0]), "(1., 1.)")

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -40,7 +40,7 @@ class TestBuiltin(object):
                 assert_(dt.byteorder != dt2.byteorder, "bogus test")
                 assert_dtype_equal(dt, dt2)
             else:
-                self.assertTrue(dt.byteorder != dt3.byteorder, "bogus test")
+                assert_(dt.byteorder != dt3.byteorder, "bogus test")
                 assert_dtype_equal(dt, dt3)
 
     def test_equivalent_dtype_hashing(self):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -124,8 +124,7 @@ class TestFromrecords(object):
         assert_(repr(a).find('dtype=int32') != -1)
 
     def test_0d_recarray_repr(self):
-        # testing infered integer types is unpleasant due to sizeof(int) varying
-        arr_0d = np.rec.array((np.int32(1), 2.0, np.datetime64('2003')))
+        arr_0d = np.rec.array((1, 2.0, '2003'), dtype='<i4,<f8,<M8[Y]')
         assert_equal(repr(arr_0d), textwrap.dedent("""\
             rec.array((1, 2., '2003'),
                       dtype=[('f0', '<i4'), ('f1', '<f8'), ('f2', '<M8[Y]')])"""))

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 import itertools
 import operator
+import platform
 
 import numpy as np
 from numpy.testing import (
@@ -420,6 +421,7 @@ class TestConversion(object):
             assert_raises(OverflowError, x.__int__)
             assert_equal(len(sup.log), 1)
 
+    @dec.knownfailureif(platform.machine().startswith("ppc64"))
     @dec.skipif(np.finfo(np.double) == np.finfo(np.longdouble))
     def test_int_from_huge_longdouble(self):
         # Produce a longdouble that would overflow a double,


### PR DESCRIPTION
This fixes a few miscellaneous test failures on ppc64 (big endian).  They're all problems with the test, not numpy.

There is an additional heisenbug which I haven't been able to track down since it only occurs rarely, randomly: The test `test_require_each` occasionally fails to set the "align" flag on a `complex128` array. May be related to https://github.com/numpy/numpy/pull/6377/.

After these fixes, the only remaining ppc64 test failures are for float128 types (fixed on my local copy, to submit soon), and https://github.com/numpy/numpy/issues/10442.