### PR TITLE
Revert "BUG: prevent the MSVC 14.1 compiler (Visual Studio 2017) from crashing"

### DIFF
--- a/numpy/linalg/lapack_lite/f2c_s_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_s_lapack.c
@@ -7259,8 +7259,7 @@ logical sisnan_(real *sin__)
 /* Subroutine */ int slabad_(real *small, real *large)
 {
     /* Builtin functions */
-    real r_lg10(real *);
-    double sqrt(doublereal);
+    double r_lg10(real *), sqrt(doublereal);
 
 
 /*


### PR DESCRIPTION
Reverts numpy/numpy#10451

Changing generated files just creates technical debt down the line when we forget it was hand-modified, and accidentally discard the fix.

I'll try to add a patch file to make this change properly in a later PR