### PR TITLE
BLD: Use zip_safe=False in setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -359,6 +359,7 @@ def setup_package():
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked},
         python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+        zip_safe=False,
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
As noted in:
  https://github.com/travis-ci/travis-ci/issues/9119
Apparently Travis-CI is trying to build numpy for the latest CPython
3.7-dev snapshot, and getting a bizarre error in setuptools:

```
Traceback (most recent call last):
  File "setup.py", line 394, in <module>
    setup_package()
  File "setup.py", line 386, in setup_package
    setup(**metadata)
  File "/home/travis/build/numpy/numpy/numpy/distutils/core.py", line 169, in setup
    return old_setup(**new_attr)
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/opt/python/3.7-dev/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/opt/python/3.7-dev/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/opt/python/3.7-dev/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/travis/build/numpy/numpy/numpy/distutils/command/install.py", line 62, in run
    r = self.setuptools_run()
  File "/home/travis/build/numpy/numpy/numpy/distutils/command/install.py", line 56, in setuptools_run
    self.do_egg_install()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/install.py", line 109, in do_egg_install
    self.run_command('bdist_egg')
  File "/opt/python/3.7-dev/lib/python3.7/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/opt/python/3.7-dev/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 218, in run
    os.path.join(archive_root, 'EGG-INFO'), self.zip_safe()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 269, in zip_safe
    return analyze_egg(self.bdist_dir, self.stubs)
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 379, in analyze_egg
    safe = scan_module(egg_dir, base, name, stubs) and safe
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 416, in scan_module
    code = marshal.load(f)
ValueError: bad marshal data (unknown type code)
```

(Buried in https://api.travis-ci.org/v3/job/332144862/log.txt)

I don't know why that code is crashing, but it looks like the code
that's crashing is scanning numpy trying to figure out if it's
"zip_safe". Numpy is definitely not zip_safe, so we might as well tell
setuptools that and it can stop trying to guess.