### PR TITLE
MAINT: Fix miscellaneous sign-compare warnings.

### DIFF
--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -233,7 +233,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
          * Use a static buffer to store the aligned/cast version,
          * or allocate some memory if more space is needed.
          */
-        if (sizeof(scalarbuffer) >= PyArray_DESCR(dst)->elsize) {
+        if ((int)sizeof(scalarbuffer) >= PyArray_DESCR(dst)->elsize) {
             tmp_src_data = (char *)&scalarbuffer[0];
         }
         else {

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -588,7 +588,7 @@ _zerofill(PyArrayObject *ret)
 NPY_NO_EXPORT int
 _IsAligned(PyArrayObject *ap)
 {
-    unsigned int i;
+    int i;
     npy_uintp aligned;
     npy_uintp alignment = PyArray_DESCR(ap)->alignment;
 

--- a/numpy/core/src/multiarray/multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/multiarray_tests.c.src
@@ -8,6 +8,8 @@
 #include "npy_extint128.h"
 #include "common.h"
 
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
+
 /* test PyArray_IsPythonScalar, before including private py3 compat header */
 static PyObject *
 IsPythonScalar(PyObject * dummy, PyObject *args)
@@ -1036,7 +1038,7 @@ array_solve_diophantine(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject 
         return NULL;
     }
 
-    if (PyTuple_GET_SIZE(A) > sizeof(terms) / sizeof(diophantine_term_t)) {
+    if (PyTuple_GET_SIZE(A) > (Py_ssize_t)ARRAY_SIZE(terms)) {
         PyErr_SetString(PyExc_ValueError, "too many terms in equation");
         goto fail;
     }

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -276,7 +276,9 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
     }
     else {
         npy_intp i;
-        for (i = 0; i < dtype->elsize / sizeof(obj); i++) {
+        npy_intp nsize = dtype->elsize / sizeof(obj);
+
+        for (i = 0; i < nsize; i++) {
             Py_XINCREF(obj);
             NPY_COPY_PYOBJECT_PTR(optr, &obj);
             optr += sizeof(obj);

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -339,7 +339,9 @@ _putzero(char *optr, PyObject *zero, PyArray_Descr *dtype)
     }
     else {
         npy_intp i;
-        for (i = 0; i < dtype->elsize / sizeof(zero); i++) {
+        npy_intp nsize = dtype->elsize / sizeof(zero);
+
+        for (i = 0; i < nsize; i++) {
             Py_INCREF(zero);
             NPY_COPY_PYOBJECT_PTR(optr, &zero);
             optr += sizeof(zero);

--- a/numpy/core/src/multiarray/temp_elide.c
+++ b/numpy/core/src/multiarray/temp_elide.c
@@ -7,6 +7,7 @@
 #include "numpy/arrayobject.h"
 
 #define NPY_NUMBER_MAX(a, b) ((a) > (b) ? (a) : (b))
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
 
 /*
  * Functions used to try to avoid/elide temporaries in python expressions
@@ -181,6 +182,7 @@ check_callers(int * cannot)
         Dl_info info;
         int in_python = 0;
         int in_multiarray = 0;
+
 #if NPY_ELIDE_DEBUG >= 2
         dladdr(buffer[i], &info);
         printf("%s(%p) %s(%p)\n", info.dli_fname, info.dli_fbase,
@@ -242,14 +244,14 @@ check_callers(int * cannot)
             }
             if (info.dli_sname &&
                     strcmp(info.dli_sname, PYFRAMEEVAL_FUNC) == 0) {
-                if (n_pyeval < sizeof(pyeval_addr) / sizeof(pyeval_addr[0])) {
+                if (n_pyeval < (npy_intp)ARRAY_SIZE(pyeval_addr)) {
                     /* store address to not have to dladdr it again */
                     pyeval_addr[n_pyeval++] = buffer[i];
                 }
                 ok = 1;
                 break;
             }
-            else if (n_py_addr < sizeof(py_addr) / sizeof(py_addr[0])) {
+            else if (n_py_addr < (npy_intp)ARRAY_SIZE(py_addr)) {
                 /* store other py function to not have to dladdr it again */
                 py_addr[n_py_addr++] = buffer[i];
             }


### PR DESCRIPTION
Small fixes scattered over six files.

- numpy/core/src/multiarray/array_assign_scalar.c
- numpy/core/src/multiarray/common.c
- numpy/core/src/multiarray/multiarray_tests.c.src
- numpy/core/src/multiarray/refcount.c
- numpy/core/src/multiarray/shape.c
- numpy/core/src/multiarray/temp_elide.c