### PR TITLE
DOC: Document A@B in Matlab/NumPy summary table

### DIFF
--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -369,7 +369,7 @@ Linear Algebra Equivalents
      - conjugate transpose of ``a``
 
    * - ``a * b``
-     - ``a.dot(b)``
+     - ``a.dot(b)`` or ``a@b`` (Python 3.5 or newer)
      - matrix multiply
 
    * - ``a .* b``


### PR DESCRIPTION
Document matrix multiplication syntax `A@B` in the summary table comparing Matlab and Python syntaxes.