### PR TITLE
BUG: Fixed polydiv for Complex Numbers

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -897,9 +897,7 @@ def polydiv(u, v):
     n = len(v) - 1
     scale = 1. / v[0]
     q = NX.zeros((max(m - n + 1, 1),), w.dtype)
-    r = u.copy()
-    if iscomplex(u).any() or iscomplex(v).any():
-        r=r.astype(complex)
+    r = u.astype(w.dtype)
     for k in range(0, m-n+1):
         d = scale * r[k]
         q[k] = d

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -898,11 +898,11 @@ def polydiv(u, v):
     scale = 1. / v[0]
     q = NX.zeros((max(m - n + 1, 1),), w.dtype)
     r = u.copy()
+    if iscomplex(u).any() or iscomplex(v).any():
+        r=r.astype(complex)
     for k in range(0, m-n+1):
         d = scale * r[k]
         q[k] = d
-        if iscomplex(d*v.any()):
-            r=r.astype(complex)
         r[k:k+n+1] -= d*v
     while NX.allclose(r[0], 0, rtol=1e-14) and (r.shape[-1] > 1):
         r = r[1:]

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -901,6 +901,8 @@ def polydiv(u, v):
     for k in range(0, m-n+1):
         d = scale * r[k]
         q[k] = d
+        if iscomplex(d*v.any()):
+            r=r.astype(complex)
         r[k:k+n+1] -= d*v
     while NX.allclose(r[0], 0, rtol=1e-14) and (r.shape[-1] > 1):
         r = r[1:]

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -223,9 +223,11 @@ class TestDocs(object):
         assert_equal(p != p2, True)
 
     def test_polydiv(self):
-        b=np.poly1d([2, 6, 6, 1])
-        a=np.poly1d([-1j, (1+2j), -(2+1j), 1])
+        b = np.poly1d([2, 6, 6, 1])
+        a = np.poly1d([-1j, (1+2j), -(2+1j), 1])
         q, r = np.polydiv(b, a)
+        assert_equal(q.dtype, np.complex128)
+        assert_equal(r.dtype, np.complex128)
         assert_equal(q*a + r, b)
 
     def test_poly_coeffs_immutable(self):

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -222,6 +222,12 @@ class TestDocs(object):
         assert_equal(p == p2, False)
         assert_equal(p != p2, True)
 
+    def test_polydiv(self):
+        b=np.poly1d([2, 6, 6, 1])
+        a=np.poly1d([-1j, (1+2j), -(2+1j), 1])
+        q, r = np.polydiv(b, a)
+        assert_equal(q*a + r, b)
+
     def test_poly_coeffs_immutable(self):
         """ Coefficients should not be modifiable """
         p = np.poly1d([1, 2, 3])

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -226,8 +226,8 @@ class TestDocs(object):
         b = np.poly1d([2, 6, 6, 1])
         a = np.poly1d([-1j, (1+2j), -(2+1j), 1])
         q, r = np.polydiv(b, a)
-        assert_equal(q.dtype, np.complex128)
-        assert_equal(r.dtype, np.complex128)
+        assert_equal(q.coeffs.dtype, np.complex128)
+        assert_equal(r.coeffs.dtype, np.complex128)
         assert_equal(q*a + r, b)
 
     def test_poly_coeffs_immutable(self):


### PR DESCRIPTION
Polynomial Division failed if the coefficients were complex numbers. It raised the TypeError:
```
TypeError: Cannot cast ufunc subtract output from dtype('complex128') to dtype('float64') with casting rule 'same_kind'
```
This issue led to failing of scipy.signal.residuez for complex numbers.