### PR TITLE
BUG: fromregex: asbytes called on regexp objects

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1459,9 +1459,9 @@ def fromregex(file, regexp, dtype, encoding=None):
             dtype = np.dtype(dtype)
 
         content = file.read()
-        if isinstance(content, bytes) and not isinstance(regexp, bytes):
+        if isinstance(content, bytes) and isinstance(regexp, np.unicode):
             regexp = asbytes(regexp)
-        elif not isinstance(content, bytes) and isinstance(regexp, bytes):
+        elif isinstance(content, np.unicode) and isinstance(regexp, bytes):
             regexp = asstr(regexp)
 
         if not hasattr(regexp, 'match'):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1073,6 +1073,13 @@ class Testfromregex(object):
             x = np.fromregex(path, regexp, dt, encoding='UTF-8')
             assert_array_equal(x, a)
 
+    def test_compiled_bytes(self):
+        regexp = re.compile(b'(\\d)')
+        c = BytesIO(b'123')
+        dt = [('num', np.float64)]
+        a = np.array([1, 2, 3], dtype=dt)
+        x = np.fromregex(c, regexp, dt)
+        assert_array_equal(x, a)
 
 #####--------------------------------------------------------------------------
 
@@ -1982,7 +1989,7 @@ M   33  21.99
             utf8.encode(encoding)
         except (UnicodeError, ImportError):
             raise SkipTest('Skipping test_utf8_file_nodtype_unicode, '
-                           'unable to encode utf8 in preferred encoding') 
+                           'unable to encode utf8 in preferred encoding')
 
         with temppath() as path:
             with io.open(path, "wt") as f:


### PR DESCRIPTION
When calling fromregex() with a binary stream and a regular expression
object, asbytes() was called on the regexp object, resulting in an
incorrect regular expression being compiled and used.