### PR TITLE
BUG: Fix unused-result warning.

### DIFF
--- a/numpy/core/include/numpy/utils.h
+++ b/numpy/core/include/numpy/utils.h
@@ -6,6 +6,8 @@
                 #define __COMP_NPY_UNUSED __attribute__ ((__unused__))
         # elif defined(__ICC)
                 #define __COMP_NPY_UNUSED __attribute__ ((__unused__))
+        # elif defined(__clang__)
+                #define __COMP_NPY_UNUSED __attribute__ ((unused))
         #else
                 #define __COMP_NPY_UNUSED
         #endif

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -35,11 +35,17 @@
 #include "npy_math_private.h"
 #include <numpy/utils.h>
 
+/*
+ * Hack inherited from BSD, the intent is to set the FPU inexact
+ * flag in an efficient way. The flag is IEEE specific. See
+ * https://github.com/freebsd/freebsd/blob/4c6378299/lib/msun/src/catrig.c#L42
+ */
+#define raise_inexact() do {                        \
+    volatile npy_float NPY_UNUSED(junk) = 1 + tiny; \
+} while (0)
 
-#define raise_inexact() do { volatile npy_float junk = 1 + tiny; } while(0)
 
-
-static __COMP_NPY_UNUSED npy_float tiny = 3.9443045e-31f;
+static const volatile npy_float tiny = 3.9443045e-31f;
 
 
 /**begin repeat


### PR DESCRIPTION
Fixes the `raise_inexact` macro, used as an efficient way to raise the
inexact floating point exception, to no longer issue an unused-result
warning. The warning is enabled in Python >= 3.5.

There is an extended discussion of the macro and its intent at:

https://lists.freebsd.org/pipermail/freebsd-hackers/2017-May/051004.html