### PR TITLE
DOC: Document ma.filled behavior with non-scalar fill_value.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -600,7 +600,7 @@ def filled(a, fill_value=None):
     ----------
     a : MaskedArray or array_like
         An input object.
-    fill_value : scalar, optional
+    fill_value : scalar or shape that can be broadcast to same shape as `a`, optional
         Filling value. Default is None.
 
     Returns


### PR DESCRIPTION
Add documentation to numpy.ma.filled to indicate that `fill_value` can
take on any type that can be broadcast to the same type as `a`.

Closes #4363