### PR TITLE
BUG: Add missing `#define _MULTIARRAYMODULE` to vdot.c

### DIFF
--- a/numpy/core/src/multiarray/vdot.c
+++ b/numpy/core/src/multiarray/vdot.c
@@ -1,4 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
 
 #include <Python.h>
 #include "common.h"


### PR DESCRIPTION
Without this, it fails if one of the includes is changed to import numpy headers.

This file seems to be the only one that omitted this