### PR TITLE
MAINT: Allow errors to escape from InitOperators

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1045,7 +1045,10 @@ def make_ufuncs(funcdict):
                 {name}_functions, {name}_data, {name}_signatures, {nloops},
                 {nin}, {nout}, {identity}, "{name}",
                 "{doc}", 0
-            );""")
+            );
+            if (f == NULL) {{
+                return -1;
+            }}""")
         mlist.append(fmt.format(
             name=name, nloops=len(uf.type_descriptions),
             nin=uf.nin, nout=uf.nout, identity=uf.identity, doc=docstring
@@ -1073,12 +1076,14 @@ def make_code(funcdict, filename):
 
     %s
 
-    static void
+    static int
     InitOperators(PyObject *dictionary) {
         PyObject *f;
 
     %s
     %s
+
+        return 0;
     }
     """) % (filename, code1, code2, code3)
     return code

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -364,7 +364,9 @@ PyMODINIT_FUNC initumath(void)
     Py_DECREF(s);
 
     /* Load the ufunc operators into the array module's namespace */
-    InitOperators(d);
+    if (InitOperators(d) < 0) {
+        goto err;
+    }
 
     PyDict_SetItemString(d, "pi", s = PyFloat_FromDouble(NPY_PI));
     Py_DECREF(s);


### PR DESCRIPTION
Probably doesn't matter in any real way, but this seems more correct.

Extracted from #8955.