### PR TITLE
ENH: Add a repr to np._NoValue

### DIFF
--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -52,11 +52,25 @@ class VisibleDeprecationWarning(UserWarning):
     """
     pass
 
-
-class _NoValue(object):
+class _NoValueType(object):
     """Special keyword value.
 
-    This class may be used as the default value assigned to a deprecated
-    keyword in order to check if it has been given a user defined value.
+    The instance of this class may be used as the default value assigned to a
+    deprecated keyword in order to check if it has been given a user defined
+    value.
     """
-    pass
+    __instance = None
+    def __new__(cls):
+        # ensure that only one instance exists
+        if not cls.__instance:
+            cls.__instance = super(_NoValueType, cls).__new__(cls)
+        return cls.__instance
+
+    # needed for python 2 to preserve identity through a pickle
+    def __reduce__(self):
+        return (self.__class__, ())
+
+    def __repr__(self):
+        return "<no value>"
+
+_NoValue = _NoValueType()

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -1,8 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import pickle
 
-from numpy.testing import assert_raises, assert_, run_module_suite
+from numpy.testing import assert_raises, assert_, assert_equal, run_module_suite
 
 if sys.version_info[:2] >= (3, 4):
     from importlib import reload
@@ -28,6 +29,11 @@ def test_numpy_reloading():
     assert_(_NoValue is np._NoValue)
     assert_(ModuleDeprecationWarning is np.ModuleDeprecationWarning)
     assert_(VisibleDeprecationWarning is np.VisibleDeprecationWarning)
+
+def test_novalue():
+    import numpy as np
+    assert_equal(repr(np._NoValue), '<no value>')
+    assert_(pickle.loads(pickle.dumps(np._NoValue)) is np._NoValue)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change _NoValue from a class to an instance, which is more inline with the builtin None.

Fixes gh-8991, closes gh-9592.