### PR TITLE
BUG: Add missing DECREF in Py2 int() cast

### DIFF
--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1424,7 +1424,11 @@ static PyObject *
 
 #ifndef NPY_PY3K
     /* Invoke long.__int__ to try to downcast */
-    long_result = Py_TYPE(long_result)->tp_as_number->nb_int(long_result);
+    {
+        PyObject *before_downcast = long_result;
+        long_result = Py_TYPE(long_result)->tp_as_number->nb_int(long_result);
+        Py_DECREF(before_downcast);
+    }
 #endif
 
     return long_result;


### PR DESCRIPTION
The Long number is downcast to int if possible, so the old version
has to be DECREF'ed.

Thanks to Johannes Barthelmes for bisecting the offending commit.

Closes gh-10474

Backport of gh-10482