### PR TITLE
DEP: Issue FutureWarning when malformed records detected.

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -38,6 +38,7 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import os
+import warnings
 
 from . import numeric as sb
 from . import numerictypes as nt
@@ -677,7 +678,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
 
     try:
         retval = sb.array(recList, dtype=descr)
-    except TypeError:  # list of lists instead of list of tuples
+    except (TypeError, ValueError):
         if (shape is None or shape == 0):
             shape = len(recList)
         if isinstance(shape, (int, long)):
@@ -687,6 +688,12 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
         _array = recarray(shape, descr)
         for k in range(_array.size):
             _array[k] = tuple(recList[k])
+        # list of lists instead of list of tuples ?
+        # 2018-02-07, 1.14.1
+        warnings.warn(
+            "fromrecords expected a list of tuples, may have received a list "
+            "of lists instead. In the future that will raise an error",
+            FutureWarning, stacklevel=2)
         return _array
     else:
         if shape is not None and retval.shape != shape:


### PR DESCRIPTION
Currently records specified as lists of lists instead of lists of tuples
are caught and fixed up in fromrecords. Unfortunately, the detection is
failing due to various fixes in the records module. The failure is
worked around by generalizing the detection. A FutureWarning that such
record specifications will result in an error in the future is also
emitted.

Fixes #10344.

Note that is  no longer needed for 1.14.1, but a backport is suggested just to get the warning out there.