### PR TITLE
BUG: In numpy.i, clear CARRAY flag if wrapped buffer is not C_CONTIGUOUS.

### DIFF
--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -94,6 +94,7 @@
 %#define array_descr(a)         PyArray_DESCR((PyArrayObject*)a)
 %#define array_flags(a)         PyArray_FLAGS((PyArrayObject*)a)
 %#define array_enableflags(a,f) PyArray_ENABLEFLAGS((PyArrayObject*)a,f)
+%#define array_clearflags(a,f)  PyArray_CLEARFLAGS((PyArrayObject*)a,f)
 %#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
 %#endif
 %#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
@@ -539,6 +540,7 @@
     npy_intp * strides = array_strides(ary);
     if (array_is_fortran(ary)) return success;
     /* Set the Fortran ordered flag */
+    array_clearflags(ary,NPY_ARRAY_CARRAY);
     array_enableflags(ary,NPY_ARRAY_FARRAY);
     /* Recompute the strides */
     strides[0] = strides[nd-1];

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -537,7 +537,7 @@
   {
     int success = 1;
     int nd = array_numdims(ary);
-    int i;    
+    int i;
     npy_intp * strides = array_strides(ary);
     if (array_is_fortran(ary)) return success;
     int n_non_one = 0;


### PR DESCRIPTION
Without this fix, arrays returned by the ARGOUTVIEW_FARRAY[2,3,4] ARGOUTVIEWM_FARRAY[2,3,4] typemaps have always the flag C_CONTIGUOUS as True even when the underlying buffer is not C contiguous leading to strange runtime behaviors.

Ex: copy() works correctly but binary element wise operations with another C contiguous array does not. 