### PR TITLE
DOC: Fix incorrect formula in gradient docstring.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -839,7 +839,7 @@ def gradient(f, *varargs, **kwargs):
         \\left\\{
             \\begin{array}{r}
                 \\alpha+\\beta+\\gamma=0 \\\\
-                -\\beta h_{d}+\\gamma h_{s}=1 \\\\
+                \\beta h_{d}-\\gamma h_{s}=1 \\\\
                 \\beta h_{d}^{2}+\\gamma h_{s}^{2}=0
             \\end{array}
         \\right.


### PR DESCRIPTION
DOC: Bug fix in explanatory note for the gradient function. Fixes #10545 

Original rendered docs [here](https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.gradient.html)