### PR TITLE
BUG: Set missing exception after malloc

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -834,6 +834,7 @@ _descriptor_from_pep3118_format(char *s)
     /* Strip whitespace, except from field names */
     buf = malloc(strlen(s) + 1);
     if (buf == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     p = buf;


### PR DESCRIPTION
[Backportable here](https://github.com/numpy/numpy/compare/maintenance/1.14.x...eric-wieser:malloc-error?expand=1) if necessary, but probably not worthwhile