### PR TITLE
BUG: Fix calling ufuncs with a positional output argument.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3010,18 +3010,20 @@ class MaskedArray(ndarray):
 
         if context is not None:
             result._mask = result._mask.copy()
-            (func, args, _) = context
-            m = reduce(mask_or, [getmaskarray(arg) for arg in args])
+            func, args, out_i = context
+            # args sometimes contains outputs (gh-10459), which we don't want
+            input_args = args[:func.nin]
+            m = reduce(mask_or, [getmaskarray(arg) for arg in input_args])
             # Get the domain mask
             domain = ufunc_domain.get(func, None)
             if domain is not None:
                 # Take the domain, and make sure it's a ndarray
-                if len(args) > 2:
+                if len(input_args) > 2:
                     with np.errstate(divide='ignore', invalid='ignore'):
-                        d = filled(reduce(domain, args), True)
+                        d = filled(reduce(domain, input_args), True)
                 else:
                     with np.errstate(divide='ignore', invalid='ignore'):
-                        d = filled(domain(*args), True)
+                        d = filled(domain(*input_args), True)
 
                 if d.any():
                     # Fill the result where the domain is wrong

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5052,6 +5052,32 @@ def test_ufunc_with_output():
     y = np.add(x, 1., out=x)
     assert_(y is x)
 
+
+def test_ufunc_with_out_varied():
+    """ Test that masked arrays are immune to gh-10459 """
+    # the mask of the output should not affect the result, however it is passed
+    a        = array([ 1,  2,  3], mask=[1, 0, 0])
+    b        = array([10, 20, 30], mask=[1, 0, 0])
+    out      = array([ 0,  0,  0], mask=[0, 0, 1])
+    expected = array([11, 22, 33], mask=[1, 0, 0])
+
+    out_pos = out.copy()
+    res_pos = np.add(a, b, out_pos)
+
+    out_kw = out.copy()
+    res_kw = np.add(a, b, out=out_kw)
+
+    out_tup = out.copy()
+    res_tup = np.add(a, b, out=(out_tup,))
+
+    assert_equal(res_kw.mask,  expected.mask)
+    assert_equal(res_kw.data,  expected.data)
+    assert_equal(res_tup.mask, expected.mask)
+    assert_equal(res_tup.data, expected.data)
+    assert_equal(res_pos.mask, expected.mask)
+    assert_equal(res_pos.data, expected.data)
+
+
 def test_astype():
     descr = [('v', int, 3), ('x', [('y', float)])]
     x = array(([1, 2, 3], (1.0,)), dtype=descr)


### PR DESCRIPTION
Backport of #10479.

Currently, this causes the result to inherit the output's mask.

This brings `np.add(a, b, out)` in line with  `np.add(a, b, out=out)`.
These previously differed because gh-10459 causes them to call
__array_wrap__ in different ways (with and without the output argument
in the context tuple, respectively).

Since the data in the `out` argument is never used by ufuncs, it seems
consistent that the mask should not be either.