### PR TITLE
BUG: Make dtype.descr error for out-of-order fields.

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -110,6 +110,10 @@ def _array_descr(descriptor):
             num = field[1] - offset
             result.append(('', '|V%d' % num))
             offset += num
+        elif field[1] < offset:
+            raise ValueError(
+                "dtype.descr is not defined for types with overlapping or "
+                "out-of-order fields")
         if len(field) > 3:
             name = (field[2], field[3])
         else:

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -356,6 +356,19 @@ class TestRecord(object):
         with assert_raises(ValueError):
             r.setfield([2,3], *r.dtype.fields['f'])
 
+    def test_out_of_order_fields(self):
+        # names in the same order, padding added to descr
+        x = self.data[['col1', 'col2']]
+        assert_equal(x.dtype.names, ('col1', 'col2'))
+        assert_equal(x.dtype.descr,
+                     [('col1', '<i4'), ('col2', '<i4'), ('', '|V4')])
+
+        # names change order to match indexing, as of 1.14 - descr can't
+        # represent that
+        y = self.data[['col2', 'col1']]
+        assert_equal(y.dtype.names, ('col2', 'col1'))
+        assert_raises(ValueError, lambda: y.dtype.descr)
+
     def test_pickle_1(self):
         # Issue #1529
         a = np.array([(1, [])], dtype=[('a', np.int32), ('b', np.int32, 0)])

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -357,16 +357,10 @@ class TestRecord(object):
             r.setfield([2,3], *r.dtype.fields['f'])
 
     def test_out_of_order_fields(self):
-        # names in the same order, padding added to descr
-        x = self.data[['col1', 'col2']]
-        assert_equal(x.dtype.names, ('col1', 'col2'))
-        assert_equal(x.dtype.descr,
-                     [('col1', '<i4'), ('col2', '<i4'), ('', '|V4')])
-
-        # names change order to match indexing, as of 1.14 - descr can't
-        # represent that
-        y = self.data[['col2', 'col1']]
-        assert_equal(y.dtype.names, ('col2', 'col1'))
+        dt = dtype({'names': ['a', 'b'],
+                    'formats': ['i4', 'i4'],
+                    'offsets': [4, 0]})
+        y = np.rec.fromrecords([(1, 2), (4, 5)], dtype=dt)
         assert_raises(ValueError, lambda: y.dtype.descr)
 
     def test_pickle_1(self):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -357,7 +357,7 @@ class TestRecord(object):
             r.setfield([2,3], *r.dtype.fields['f'])
 
     def test_out_of_order_fields(self):
-        dt = dtype({'names': ['a', 'b'],
+        dt = np.dtype({'names': ['a', 'b'],
                     'formats': ['i4', 'i4'],
                     'offsets': [4, 0]})
         y = np.rec.fromrecords([(1, 2), (4, 5)], dtype=dt)


### PR DESCRIPTION
Backport of #10391.

cc @ahaldane since #6053 exposes this to user code more often.

Currently returns garbage, Now
```
>>> data = np.zeros(1, dtype=[('a', int), ('b', float)])
>>> data = data[['b','a']]
>>> data.dtype.descr
ValueError
```