### PR TITLE
BUG: arrays not being flattened in `union1d`

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -614,7 +614,7 @@ def union1d(ar1, ar2):
     >>> reduce(np.union1d, ([1, 3, 4, 3], [3, 1, 2, 1], [6, 3, 4, 2]))
     array([1, 2, 3, 4, 6])
     """
-    return unique(np.concatenate((ar1.flatten(), ar2.flatten())))
+    return unique(np.concatenate((ar1, ar2), axis=None))
 
 def setdiff1d(ar1, ar2, assume_unique=False):
     """

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -614,7 +614,7 @@ def union1d(ar1, ar2):
     >>> reduce(np.union1d, ([1, 3, 4, 3], [3, 1, 2, 1], [6, 3, 4, 2]))
     array([1, 2, 3, 4, 6])
     """
-    return unique(np.concatenate((ar1, ar2)))
+    return unique(np.concatenate((ar1.flatten(), ar2.flatten())))
 
 def setdiff1d(ar1, ar2, assume_unique=False):
     """

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -247,6 +247,7 @@ class TestSetOps(object):
         c = union1d(a, b)
         assert_array_equal(c, ec)
 
+        # Tests gh-10340, arguments to union1d should be flattened if they are not already 1D
         x = np.array([[0, 1, 2], [3, 4, 5]])
         y = np.array([0, 1, 2, 3, 4])
         ez = np.array([0, 1, 2, 3, 4, 5])

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -247,6 +247,12 @@ class TestSetOps(object):
         c = union1d(a, b)
         assert_array_equal(c, ec)
 
+        x = np.array([[0, 1, 2], [3, 4, 5]])
+        y = np.array([0, 1, 2, 3, 4])
+        ez = np.array([0, 1, 2, 3, 4, 5])
+        z = union1d(x, y)
+        assert_array_equal(z, ez)
+
         assert_array_equal([], union1d([], []))
 
     def test_setdiff1d(self):

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -247,7 +247,8 @@ class TestSetOps(object):
         c = union1d(a, b)
         assert_array_equal(c, ec)
 
-        # Tests gh-10340, arguments to union1d should be flattened if they are not already 1D
+        # Tests gh-10340, arguments to union1d should be
+        # flattened if they are not already 1D
         x = np.array([[0, 1, 2], [3, 4, 5]])
         y = np.array([0, 1, 2, 3, 4])
         ez = np.array([0, 1, 2, 3, 4, 5])

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1208,7 +1208,7 @@ def union1d(ar1, ar2):
     numpy.union1d : Equivalent function for ndarrays.
 
     """
-    return unique(ma.concatenate((ar1.flatten(), ar2.flatten())))
+    return unique(ma.concatenate((ar1, ar2), axis=None))
 
 
 def setdiff1d(ar1, ar2, assume_unique=False):

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1208,7 +1208,7 @@ def union1d(ar1, ar2):
     numpy.union1d : Equivalent function for ndarrays.
 
     """
-    return unique(ma.concatenate((ar1, ar2)))
+    return unique(ma.concatenate((ar1.flatten(), ar2.flatten())))
 
 
 def setdiff1d(ar1, ar2, assume_unique=False):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1501,6 +1501,12 @@ class TestArraySetOps(object):
         test = union1d(a, b)
         control = array([1, 2, 3, 4, 5, 7, -1], mask=[0, 0, 0, 0, 0, 0, 1])
         assert_equal(test, control)
+
+        x = array([[0, 1, 2], [3, 4, 5]], mask=[[0, 0, 0], [0, 0, 1]])
+        y = array([0, 1, 2, 3, 4], mask=[0, 0, 0, 0, 1])
+        ez = array([0, 1, 2, 3, 4, 5], mask=[0, 0, 0, 0, 0, 1])
+        z = union1d(x, y)
+        assert_equal(z, ez)
         #
         assert_array_equal([], union1d([], []))
 

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1502,6 +1502,7 @@ class TestArraySetOps(object):
         control = array([1, 2, 3, 4, 5, 7, -1], mask=[0, 0, 0, 0, 0, 0, 1])
         assert_equal(test, control)
 
+        # Tests gh-10340, arguments to union1d should be flattened if they are not already 1D
         x = array([[0, 1, 2], [3, 4, 5]], mask=[[0, 0, 0], [0, 0, 1]])
         y = array([0, 1, 2, 3, 4], mask=[0, 0, 0, 0, 1])
         ez = array([0, 1, 2, 3, 4, 5], mask=[0, 0, 0, 0, 0, 1])

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1502,7 +1502,8 @@ class TestArraySetOps(object):
         control = array([1, 2, 3, 4, 5, 7, -1], mask=[0, 0, 0, 0, 0, 0, 1])
         assert_equal(test, control)
 
-        # Tests gh-10340, arguments to union1d should be flattened if they are not already 1D
+        # Tests gh-10340, arguments to union1d should be
+        # flattened if they are not already 1D
         x = array([[0, 1, 2], [3, 4, 5]], mask=[[0, 0, 0], [0, 0, 1]])
         y = array([0, 1, 2, 3, 4], mask=[0, 0, 0, 0, 1])
         ez = array([0, 1, 2, 3, 4, 5], mask=[0, 0, 0, 0, 0, 1])


### PR DESCRIPTION
Backport of #10342.

According to the docstring, the arguments to numpy.union1d(ar1, ar2) "are flattened if they are not already 1D."
This solves #10340