### PR TITLE
BUG: Fix travis failure in previous commit

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1765,7 +1765,8 @@ PyArray_ResultType(npy_intp narrs, PyArrayObject **arr,
         PyArray_Descr **all_dtypes = PyArray_malloc(
             sizeof(*all_dtypes) * (narrs + ndtypes));
         if (all_dtypes == NULL) {
-            return PyErr_NoMemory();
+            PyErr_NoMemory();
+            return NULL;
         }
         for (i = 0; i < narrs; ++i) {
             all_dtypes[i] = PyArray_DESCR(arr[i]);


### PR DESCRIPTION
`PyErr_NoMemory` return `PyObject *`, but this function returns `PyArray_Descr *`. `runtests.py` doesn't report this locally, and #10555 was merged before travis finished