### PR TITLE
MAINT: Fix misc. documentation typos

### DIFF
--- a/doc/changelog/1.12.0-changelog.rst
+++ b/doc/changelog/1.12.0-changelog.rst
@@ -292,7 +292,7 @@ A total of 418 pull requests were merged for this release.
 * `#7407 <https://github.com/numpy/numpy/pull/7407>`__: BUG: Fix decref before incref for in-place accumulate
 * `#7410 <https://github.com/numpy/numpy/pull/7410>`__: DOC: add nanprod to the list of math routines
 * `#7414 <https://github.com/numpy/numpy/pull/7414>`__: Tweak corrcoef
-* `#7415 <https://github.com/numpy/numpy/pull/7415>`__: DOC: Documention fixes
+* `#7415 <https://github.com/numpy/numpy/pull/7415>`__: DOC: Documentation fixes
 * `#7416 <https://github.com/numpy/numpy/pull/7416>`__: BUG: Incorrect handling of range in `histogram` with automatic...
 * `#7418 <https://github.com/numpy/numpy/pull/7418>`__: DOC: Minor typo fix, hermefik -> hermefit.
 * `#7421 <https://github.com/numpy/numpy/pull/7421>`__: ENH: adds np.nancumsum and np.nancumprod

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -2152,7 +2152,7 @@ add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes)
  * to UTC time, otherwise it returns the struct with the local time.
  *
  * Returns -1 on error, 0 on success, and 1 (with no error set)
- * if obj doesn't have the neeeded date or datetime attributes.
+ * if obj doesn't have the needed date or datetime attributes.
  */
 NPY_NO_EXPORT int
 convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,

--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -896,7 +896,7 @@ BigInt_ShiftLeft(BigInt *result, npy_uint32 shift)
     if (shiftBits == 0) {
         npy_uint32 i;
 
-        /* copy blcoks from high to low */
+        /* copy blocks from high to low */
         for (pInCur = result->blocks + result->length,
                  pOutCur = pInCur + shiftBlocks;
                  pInCur >= pInBlocks;

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1722,7 +1722,7 @@ static PyMethodDef arraymultiter_methods[] = {
     {"reset",
         (PyCFunction) arraymultiter_reset,
         METH_VARARGS, NULL},
-    {NULL, NULL, 0, NULL},      /* sentinal */
+    {NULL, NULL, 0, NULL},      /* sentinel */
 };
 
 NPY_NO_EXPORT PyTypeObject PyArrayMultiIter_Type = {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7212,7 +7212,7 @@ class TestWritebackIfCopy(TestCase):
         arr_wb[:] = -100
         npy_resolve(arr_wb)
         assert_equal(arr, -100)
-        # after resolve, the two arrays no longer reference eachother
+        # after resolve, the two arrays no longer reference each other
         assert_(not arr_wb.ctypes.data == 0)
         arr_wb[:] = 100
         assert_equal(arr, -100)

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -246,7 +246,7 @@ alias for the field. The title may be used to index an array, just like a
 field name.
 
 To add titles when using the list-of-tuples form of dtype specification, the
-field name may be be specified as a tuple of two strings instead of a single
+field name may be specified as a tuple of two strings instead of a single
 string, which will be the field's title and field name respectively. For
 example::
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../numpy-whitelist.txt`