### PR TITLE
BUG: Revert sort optimization in np.unique.

### DIFF
--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -4,6 +4,8 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
+import sys
+
 from numpy.testing import (
     run_module_suite, assert_array_equal, assert_equal, assert_raises,
     )
@@ -452,6 +454,15 @@ class TestUnique(object):
         msg = 'Unique returned different results when asked for index'
         assert_array_equal(v.data, v2.data, msg)
         assert_array_equal(v.mask, v2.mask, msg)
+
+    def test_unique_sort_order_with_axis(self):
+        # These tests fail if sorting along axis is done by treating subarrays
+        # as unsigned byte strings.  See gh-10495.
+        fmt = "sort order incorrect for integer type '%s'"
+        for dt in 'bhilq':
+            a = np.array([[-1],[0]], dt)
+            b = np.unique(a, axis=0)
+            assert_array_equal(a, b, fmt % dt)
 
     def _run_axis_tests(self, dtype):
         data = np.array([[0, 1, 0, 0],


### PR DESCRIPTION
The optimization was to sort integer subarrays by treating them as
strings of unsigned bytes. That worked fine for finding the unique
subarrays, but the sort order of the results could be unexpected.

Closes #10495.