### PR TITLE
MAINT: Update sphinxext submodule hash.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -131,6 +131,12 @@ def doc_note(initialdoc, note):
         return
     if note is None:
         return initialdoc
+
+    # FIXME: disable this function for the moment until we figure out what to
+    # do with it. Currently it may result in duplicate Notes sections or Notes
+    # sections in the wrong place
+    return initialdoc
+
     newdoc = """
     %s
 
@@ -7472,11 +7478,7 @@ def inner(a, b):
     Returns the inner product of a and b for arrays of floating point types.
 
     Like the generic NumPy equivalent the product sum is over the last dimension
-    of a and b.
-
-    Notes
-    -----
-    The first argument is not conjugated.
+    of a and b. The first argument is not conjugated.
 
     """
     fa = filled(a, 0)


### PR DESCRIPTION
Update to numpydoc v0.7.0, needed for sphinx 1.7.0 released 2/12/2018.

This PR also disables the `doc_note` function in `numpy/ma/core.py`. Currently, that function is called to add a "Notes" section to the existing docstrings of the unmasked versions of some functions, which may 
result in duplicate "Notes" sections, or incorrect placement. Those raise errors in current numpydoc.
