### PR TITLE
ENH: Make flatnonzero call asanyarray before ravel()

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -114,5 +114,10 @@ Previously an array was returned for integer scalar inputs, which is
 inconsistent with the behavior for float inputs, and that of ufuncs in general.
 For all types of scalar or 0d input, the result is now a scalar.
 
+``np.flatnonzero`` works on numpy-convertible types
+---------------------------------------------------
+``np.flatnonzero`` now uses ``np.ravel(a)`` instead of ``a.ravel()``, so it
+works for lists, tuples, etc.
+
 Changes
 =======

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -829,12 +829,12 @@ def flatnonzero(a):
     """
     Return indices that are non-zero in the flattened version of a.
 
-    This is equivalent to a.ravel().nonzero()[0].
+    This is equivalent to np.nonzero(np.ravel(a))[0].
 
     Parameters
     ----------
-    a : ndarray
-        Input array.
+    a : array_like
+        Input data.
 
     Returns
     -------
@@ -862,7 +862,7 @@ def flatnonzero(a):
     array([-2, -1,  1,  2])
 
     """
-    return a.ravel().nonzero()[0]
+    return np.nonzero(np.ravel(a))[0]
 
 
 _mode_from_name_dict = {'v': 0,


### PR DESCRIPTION
It now works for lists and other numpy-convertible input.

Fixes #10598.