### PR TITLE
DOC: Do not complain about contiguity when mutating `ndarray.shape`

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2314,7 +2314,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     >>> np.zeros((4,2))[::2].shape = (-1,)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    AttributeError: Incompatible shape for in-place modifcation. Use
+    AttributeError: Incompatible shape for in-place modification. Use
     `.reshape()` to make a copy with the desired shape.
 
     See Also

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2314,7 +2314,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     >>> np.zeros((4,2))[::2].shape = (-1,)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    AttributeError: incompatible shape for a non-contiguous array
+    AttributeError: Incompatible shape for this array; the in-memory 
+    representation of the array would mutate. Use `.reshape()` to make a copy
+    with the desired shape.
 
     See Also
     --------

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2314,9 +2314,8 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     >>> np.zeros((4,2))[::2].shape = (-1,)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    AttributeError: Incompatible shape for this array; the in-memory 
-    representation of the array would mutate. Use `.reshape()` to make a copy
-    with the desired shape.
+    AttributeError: Incompatible shape for in-place modifcation. Use
+    `.reshape()` to make a copy with the desired shape.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -252,7 +252,7 @@ def reshape(a, newshape, order='C'):
      >>> c.shape = (20)
      Traceback (most recent call last):
         ...
-     AttributeError: Incompatible shape for in-place modifcation. Use
+     AttributeError: Incompatible shape for in-place modification. Use
      `.reshape()` to make a copy with the desired shape.
 
     The `order` keyword gives the index ordering both for *fetching* the values

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -252,9 +252,8 @@ def reshape(a, newshape, order='C'):
      >>> c.shape = (20)
      Traceback (most recent call last):
         ...
-     AttributeError: Incompatible shape for this array; the in-memory 
-     representation of the array would mutate. Use `.reshape()` to make a copy
-     with the desired shape.
+     AttributeError: Incompatible shape for in-place modifcation. Use
+     `.reshape()` to make a copy with the desired shape.
 
     The `order` keyword gives the index ordering both for *fetching* the values
     from `a`, and then *placing* the values into the output array.

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -252,7 +252,9 @@ def reshape(a, newshape, order='C'):
      >>> c.shape = (20)
      Traceback (most recent call last):
         ...
-     AttributeError: incompatible shape for a non-contiguous array
+     AttributeError: Incompatible shape for this array; the in-memory 
+     representation of the array would mutate. Use `.reshape()` to make a copy
+     with the desired shape.
 
     The `order` keyword gives the index ordering both for *fetching* the values
     from `a`, and then *placing* the values into the output array.

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -62,8 +62,7 @@ array_shape_set(PyArrayObject *self, PyObject *val)
     if (PyArray_DATA(ret) != PyArray_DATA(self)) {
         Py_DECREF(ret);
         PyErr_SetString(PyExc_AttributeError,
-                        "Incompatible shape for this array; the in-memory " \
-                        "representation of the array would mutate. Use " \
+                        "Incompatible shape for in-place modifcation. Use "
                         "`.reshape()` to make a copy with the desired shape.");
         return -1;
     }

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -62,7 +62,7 @@ array_shape_set(PyArrayObject *self, PyObject *val)
     if (PyArray_DATA(ret) != PyArray_DATA(self)) {
         Py_DECREF(ret);
         PyErr_SetString(PyExc_AttributeError,
-                        "Incompatible shape for in-place modifcation. Use "
+                        "Incompatible shape for in-place modification. Use "
                         "`.reshape()` to make a copy with the desired shape.");
         return -1;
     }

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -62,8 +62,9 @@ array_shape_set(PyArrayObject *self, PyObject *val)
     if (PyArray_DATA(ret) != PyArray_DATA(self)) {
         Py_DECREF(ret);
         PyErr_SetString(PyExc_AttributeError,
-                        "incompatible shape for a non-contiguous "\
-                        "array");
+                        "Incompatible shape for this array; the in-memory " \
+                        "representation of the array would mutate. Use " \
+                        "`.reshape()` to make a copy with the desired shape.");
         return -1;
     }
 


### PR DESCRIPTION
There are multiple conditions that `_attempt_nocopy_reshape` checks for
when ndarray.shape is mutated directly. Discussion of #10146 indicated
that an error message referencing any type of contiguity would not be
correct for all cases, so the error message has been changed to be more
general.