### PR TITLE
MAINT: Fix Misc. typos

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -596,7 +596,7 @@ def einsum_path(*operands, **kwargs):
     --------
 
     We can begin with a chain dot example. In this case, it is optimal to
-    contract the ``b`` and ``c`` tensors first as reprsented by the first
+    contract the ``b`` and ``c`` tensors first as represented by the first
     element of the path ``(1, 2)``. The resulting tensor is added to the end
     of the contraction and the remaining contraction ``(0, 1)`` is then
     completed.

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -809,7 +809,7 @@ class TestContextManager(object):
         assert_equal(np.get_printoptions(), opts)
 
     def test_ctx_mgr_exceptions(self):
-        # test that print options are restored even if an exeption is raised
+        # test that print options are restored even if an exception is raised
         opts = np.get_printoptions()
         try:
             with np.printoptions(precision=2, linewidth=11):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3341,7 +3341,7 @@ class TestTemporaryElide(object):
         # def incref_elide_l(d):
         #    return l[4] + l[4] # PyNumber_Add without increasing refcount
         from numpy.core.multiarray_tests import incref_elide_l
-        # padding with 1 makes sure the object on the stack is not overwriten
+        # padding with 1 makes sure the object on the stack is not overwritten
         l = [1, 1, 1, 1, np.ones(100000)]
         res = incref_elide_l(l)
         # the return original should not be changed to an inplace operation

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -1,5 +1,5 @@
 """
-Test the scalar contructors, which also do type-coercion
+Test the scalar constructors, which also do type-coercion
 """
 from __future__ import division, absolute_import, print_function
 

--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         'Topic :: Software Development :: Code Generators',
     ]
     setup(version=version,
-          description="F2PY - Fortran to Python Interface Generaton",
+          description="F2PY - Fortran to Python Interface Generator",
           author="Pearu Peterson",
           author_email="pearu@cens.ioc.ee",
           maintainer="Pearu Peterson",


### PR DESCRIPTION
Found via `codespell -q 3 -I ../numpy-whitelist.txt`  
Whitelist consists of:  
```
amin
ans
behaviour
cancellation
dum
initialise
ith
nd
ot
splitted
writeable
```