### PR TITLE
MAINT: Do not use random roots when testing roots.

### DIFF
--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -415,9 +415,9 @@ def check_divmod(Poly):
 
 
 def check_roots(Poly):
-    d = Poly.domain + random((2,))*.25
-    w = Poly.window + random((2,))*.25
-    tgt = np.sort(random((5,)))
+    d = Poly.domain * 1.25 + .25
+    w = Poly.window
+    tgt = np.linspace(d[0], d[1], 5)
     res = np.sort(Poly.fromroots(tgt, domain=d, window=w).roots())
     assert_almost_equal(res, tgt)
     # default domain and window


### PR DESCRIPTION
The `check_roots` function in numpy/polynomial/tests/test_classes.py was
using random numbers without a seed to generate the random roots to be
checked. This made the test sensitive to the random state, with the
result that currently two of the roots are close together and fail the
test to the default seven digit precision when running on the Mac.  The
failure is probably due to a combination of library and compiler
differences between the Mac and the other platforms tested.. The fix
here is to hard wire the test values rather than use random numbers.

This should fix the nightly wheel build test failures, but we won't know until they
are run after merging.
