### PR TITLE
BUG: Align type definition with generated lapack 

### DIFF
--- a/numpy/linalg/lapack_lite/f2c.h
+++ b/numpy/linalg/lapack_lite/f2c.h
@@ -214,4 +214,173 @@ typedef doublereal E_f;	/* real function with -R not specified */
 #undef unix
 #undef vax
 #endif
+
+/*  https://anonscm.debian.org/cgit/collab-maint/libf2c2.git/tree/f2ch.add  */
+
+/* If you are using a C++ compiler, append the following to f2c.h
+   for compiling libF77 and libI77. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int abort_(void);
+extern double c_abs(complex *);
+extern void c_cos(complex *, complex *);
+extern void c_div(complex *, complex *, complex *);
+extern void c_exp(complex *, complex *);
+extern void c_log(complex *, complex *);
+extern void c_sin(complex *, complex *);
+extern void c_sqrt(complex *, complex *);
+extern double d_abs(double *);
+extern double d_acos(double *);
+extern double d_asin(double *);
+extern double d_atan(double *);
+extern double d_atn2(double *, double *);
+extern void d_cnjg(doublecomplex *, doublecomplex *);
+extern double d_cos(double *);
+extern double d_cosh(double *);
+extern double d_dim(double *, double *);
+extern double d_exp(double *);
+extern double d_imag(doublecomplex *);
+extern double d_int(double *);
+extern double d_lg10(double *);
+extern double d_log(double *);
+extern double d_mod(double *, double *);
+extern double d_nint(double *);
+extern double d_prod(float *, float *);
+extern double d_sign(double *, double *);
+extern double d_sin(double *);
+extern double d_sinh(double *);
+extern double d_sqrt(double *);
+extern double d_tan(double *);
+extern double d_tanh(double *);
+extern double derf_(double *);
+extern double derfc_(double *);
+extern void do_fio(ftnint *, char *, ftnlen);
+extern integer do_lio(ftnint *, ftnint *, char *, ftnlen);
+extern integer do_uio(ftnint *, char *, ftnlen);
+extern integer e_rdfe(void);
+extern integer e_rdue(void);
+extern integer e_rsfe(void);
+extern integer e_rsfi(void);
+extern integer e_rsle(void);
+extern integer e_rsli(void);
+extern integer e_rsue(void);
+extern integer e_wdfe(void);
+extern integer e_wdue(void);
+extern void e_wsfe(void);
+extern integer e_wsfi(void);
+extern integer e_wsle(void);
+extern integer e_wsli(void);
+extern integer e_wsue(void);
+extern int ef1asc_(ftnint *, ftnlen *, ftnint *, ftnlen *);
+extern integer ef1cmc_(ftnint *, ftnlen *, ftnint *, ftnlen *);
+
+extern double erf_(float *);
+extern double erfc_(float *);
+extern integer f_back(alist *);
+extern integer f_clos(cllist *);
+extern integer f_end(alist *);
+extern void f_exit(void);
+extern integer f_inqu(inlist *);
+extern integer f_open(olist *);
+extern integer f_rew(alist *);
+extern int flush_(void);
+extern void getarg_(integer *, char *, ftnlen);
+extern void getenv_(char *, char *, ftnlen, ftnlen);
+extern short h_abs(short *);
+extern short h_dim(short *, short *);
+extern short h_dnnt(double *);
+extern short h_indx(char *, char *, ftnlen, ftnlen);
+extern short h_len(char *, ftnlen);
+extern short h_mod(short *, short *);
+extern short h_nint(float *);
+extern short h_sign(short *, short *);
+extern short hl_ge(char *, char *, ftnlen, ftnlen);
+extern short hl_gt(char *, char *, ftnlen, ftnlen);
+extern short hl_le(char *, char *, ftnlen, ftnlen);
+extern short hl_lt(char *, char *, ftnlen, ftnlen);
+extern integer i_abs(integer *);
+extern integer i_dim(integer *, integer *);
+extern integer i_dnnt(double *);
+extern integer i_indx(char *, char *, ftnlen, ftnlen);
+extern integer i_len(char *, ftnlen);
+extern integer i_mod(integer *, integer *);
+extern integer i_nint(float *);
+extern integer i_sign(integer *, integer *);
+extern integer iargc_(void);
+extern ftnlen l_ge(char *, char *, ftnlen, ftnlen);
+extern ftnlen l_gt(char *, char *, ftnlen, ftnlen);
+extern ftnlen l_le(char *, char *, ftnlen, ftnlen);
+extern ftnlen l_lt(char *, char *, ftnlen, ftnlen);
+extern void pow_ci(complex *, complex *, integer *);
+extern double pow_dd(double *, double *);
+extern double pow_di(double *, integer *);
+extern short pow_hh(short *, shortint *);
+extern integer pow_ii(integer *, integer *);
+extern double pow_ri(float *, integer *);
+extern void pow_zi(doublecomplex *, doublecomplex *, integer *);
+extern void pow_zz(doublecomplex *, doublecomplex *, doublecomplex *);
+extern double r_abs(float *);
+extern double r_acos(float *);
+extern double r_asin(float *);
+extern double r_atan(float *);
+extern double r_atn2(float *, float *);
+extern void r_cnjg(complex *, complex *);
+extern double r_cos(float *);
+extern double r_cosh(float *);
+extern double r_dim(float *, float *);
+extern double r_exp(float *);
+extern float r_imag(complex *);
+extern double r_int(float *);
+extern float r_lg10(real *);
+extern double r_log(float *);
+extern double r_mod(float *, float *);
+extern double r_nint(float *);
+extern double r_sign(float *, float *);
+extern double r_sin(float *);
+extern double r_sinh(float *);
+extern double r_sqrt(float *);
+extern double r_tan(float *);
+extern double r_tanh(float *);
+extern void s_cat(char *, char **, integer *, integer *, ftnlen);
+extern integer s_cmp(char *, char *, ftnlen, ftnlen);
+extern void s_copy(char *, char *, ftnlen, ftnlen);
+extern int s_paus(char *, ftnlen);
+extern integer s_rdfe(cilist *);
+extern integer s_rdue(cilist *);
+extern integer s_rnge(char *, integer, char *, integer);
+extern integer s_rsfe(cilist *);
+extern integer s_rsfi(icilist *);
+extern integer s_rsle(cilist *);
+extern integer s_rsli(icilist *);
+extern integer s_rsne(cilist *);
+extern integer s_rsni(icilist *);
+extern integer s_rsue(cilist *);
+extern int s_stop(char *, ftnlen);
+extern integer s_wdfe(cilist *);
+extern integer s_wdue(cilist *);
+extern void s_wsfe(	cilist *);
+extern integer s_wsfi(icilist *);
+extern integer s_wsle(cilist *);
+extern integer s_wsli(icilist *);
+extern integer s_wsne(cilist *);
+extern integer s_wsni(icilist *);
+extern integer s_wsue(cilist *);
+extern void sig_die(char *, int);
+extern integer signal_(integer *, void (*)(int));
+extern integer system_(char *, ftnlen);
+extern double z_abs(doublecomplex *);
+extern void z_cos(doublecomplex *, doublecomplex *);
+extern void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
+extern void z_exp(doublecomplex *, doublecomplex *);
+extern void z_log(doublecomplex *, doublecomplex *);
+extern void z_sin(doublecomplex *, doublecomplex *);
+extern void z_sqrt(doublecomplex *, doublecomplex *);
+
+#ifdef __cplusplus
+	}
+#endif
+
 #endif

--- a/numpy/linalg/lapack_lite/f2c_blas.c
+++ b/numpy/linalg/lapack_lite/f2c_blas.c
@@ -200,9 +200,6 @@ L20:
     integer i__1, i__2;
     complex q__1, q__2, q__3;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, ix, iy;
     static complex ctemp;
@@ -377,9 +374,6 @@ L20:
     integer a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2,
 	    i__3, i__4, i__5, i__6;
     complex q__1, q__2, q__3, q__4;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, l, info;
@@ -1051,9 +1045,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     complex q__1, q__2, q__3;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, j, ix, iy, jx, jy, kx, ky, info;
     static complex temp;
@@ -1441,9 +1432,6 @@ L20:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     complex q__1, q__2;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, ix, jy, kx, info;
@@ -1836,9 +1824,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     real r__1;
     complex q__1, q__2, q__3, q__4;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, ix, iy, jx, jy, kx, ky, info;
@@ -2247,9 +2232,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     real r__1;
     complex q__1, q__2, q__3, q__4;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, ix, iy, jx, jy, kx, ky, info;
@@ -2676,9 +2658,6 @@ L20:
 	    i__3, i__4, i__5, i__6, i__7;
     real r__1;
     complex q__1, q__2, q__3, q__4, q__5, q__6;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, l, info;
@@ -3328,9 +3307,6 @@ L20:
 	    i__6;
     real r__1;
     complex q__1, q__2, q__3;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, l, info;
@@ -4039,9 +4015,6 @@ L20:
     real r__1, r__2;
     complex q__1;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
     /* Local variables */
     static integer i__, nincx;
 
@@ -4195,9 +4168,6 @@ L20:
     integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2, i__3, i__4, i__5,
 	    i__6;
     complex q__1, q__2, q__3;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, k, info;
@@ -4859,9 +4829,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     complex q__1, q__2, q__3;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, j, ix, jx, kx, info;
     static complex temp;
@@ -5395,9 +5362,6 @@ L20:
     integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2, i__3, i__4, i__5,
 	    i__6, i__7;
     complex q__1, q__2, q__3;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j, k, info;
@@ -6069,9 +6033,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     complex q__1, q__2, q__3;
 
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, j, ix, jx, kx, info;
     static complex temp;
@@ -6666,9 +6627,6 @@ doublereal dcabs1_(doublecomplex *z__)
 {
     /* System generated locals */
     doublereal ret_val, d__1, d__2;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
 
 /*
     Purpose
@@ -7718,9 +7676,6 @@ doublereal dnrm2_(integer *n, doublereal *x, integer *incx)
     /* System generated locals */
     integer i__1, i__2;
     doublereal ret_val, d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer ix;
@@ -10627,9 +10582,6 @@ doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx)
     integer i__1, i__2, i__3;
     doublereal ret_val, d__1;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *), sqrt(doublereal);
-
     /* Local variables */
     static integer ix;
     static doublereal ssq, temp, norm, scale;
@@ -11125,9 +11077,6 @@ doublereal scabs1_(complex *z__)
     /* System generated locals */
     real ret_val, r__1, r__2;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
 
 /*
     Purpose
@@ -11147,9 +11096,6 @@ doublereal scasum_(integer *n, complex *cx, integer *incx)
     /* System generated locals */
     integer i__1, i__2, i__3;
     real ret_val, r__1, r__2;
-
-    /* Builtin functions */
-    double r_imag(complex *);
 
     /* Local variables */
     static integer i__, nincx;
@@ -11219,9 +11165,6 @@ doublereal scnrm2_(integer *n, complex *x, integer *incx)
     /* System generated locals */
     integer i__1, i__2, i__3;
     real ret_val, r__1;
-
-    /* Builtin functions */
-    double r_imag(complex *), sqrt(doublereal);
 
     /* Local variables */
     static integer ix;
@@ -12336,9 +12279,6 @@ doublereal snrm2_(integer *n, real *x, integer *incx)
     /* System generated locals */
     integer i__1, i__2;
     real ret_val, r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer ix;
@@ -15342,9 +15282,6 @@ L20:
     integer i__1, i__2;
     doublecomplex z__1, z__2, z__3;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, ix, iy;
     static doublecomplex ztemp;
@@ -15724,9 +15661,6 @@ L20:
     integer a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2,
 	    i__3, i__4, i__5, i__6;
     doublecomplex z__1, z__2, z__3, z__4;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, l, info;
@@ -16399,9 +16333,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     doublecomplex z__1, z__2, z__3;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, j, ix, iy, jx, jy, kx, ky, info;
     static doublecomplex temp;
@@ -16790,9 +16721,6 @@ L20:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     doublecomplex z__1, z__2;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, ix, jy, kx, info;
@@ -17186,9 +17114,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, ix, iy, jx, jy, kx, ky, info;
@@ -17598,9 +17523,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, ix, iy, jx, jy, kx, ky, info;
@@ -18027,9 +17949,6 @@ L20:
 	    i__3, i__4, i__5, i__6, i__7;
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4, z__5, z__6;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, l, info;
@@ -18679,9 +18598,6 @@ L20:
 	    i__6;
     doublereal d__1;
     doublecomplex z__1, z__2, z__3;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, l, info;
@@ -19338,9 +19254,6 @@ L20:
     integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2, i__3, i__4, i__5,
 	    i__6;
     doublecomplex z__1, z__2, z__3;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, k, info;
@@ -20002,9 +19915,6 @@ L20:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     doublecomplex z__1, z__2, z__3;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, j, ix, jx, kx, info;
     static doublecomplex temp;
@@ -20538,10 +20448,6 @@ L20:
     integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2, i__3, i__4, i__5,
 	    i__6, i__7;
     doublecomplex z__1, z__2, z__3;
-
-    /* Builtin functions */
-    void z_div(doublecomplex *, doublecomplex *, doublecomplex *), d_cnjg(
-	    doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, k, info;
@@ -21212,10 +21118,6 @@ L20:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     doublecomplex z__1, z__2, z__3;
-
-    /* Builtin functions */
-    void z_div(doublecomplex *, doublecomplex *, doublecomplex *), d_cnjg(
-	    doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j, ix, jx, kx, info;

--- a/numpy/linalg/lapack_lite/f2c_c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_c_lapack.c
@@ -270,9 +270,6 @@ L50:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double r_imag(complex *), c_abs(complex *);
-
     /* Local variables */
     static real c__, f, g;
     static integer i__, j, k, l, m;
@@ -663,9 +660,6 @@ L210:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     complex q__1;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__;
@@ -1313,10 +1307,6 @@ L210:
     real r__1, r__2;
     complex q__1, q__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal), r_imag(complex *);
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, k, ihi;
     static real scl;
@@ -1831,9 +1821,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     complex q__1;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__;
@@ -2704,9 +2691,6 @@ L50:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     complex q__1;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, k;
     static complex alpha;
@@ -3078,9 +3062,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, u_dim1, u_offset, vt_dim1, vt_offset, i__1,
 	    i__2, i__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, ie, il, ir, iu, blk;
@@ -5695,10 +5676,6 @@ L50:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     complex q__1;
 
-    /* Builtin functions */
-    double c_abs(complex *);
-    void c_div(complex *, complex *, complex *);
-
     /* Local variables */
     static integer i__, j, jp;
     extern /* Subroutine */ int cscal_(integer *, complex *, complex *,
@@ -6215,9 +6192,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real eps;
@@ -7256,9 +7230,6 @@ L50:
     complex q__1;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static complex hl[2401]	/* was [49][49] */;
     static integer kbot, nmin;
@@ -8178,9 +8149,6 @@ L50:
     integer i__1, i__2;
     complex q__1;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, ioff;
 
@@ -8480,9 +8448,6 @@ L50:
     real r__1;
     complex q__1;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
     /* Local variables */
     static integer i__, j, l;
     extern /* Subroutine */ int sgemm_(char *, char *, integer *, integer *,
@@ -8624,9 +8589,6 @@ L50:
     real r__1, r__2, r__3, r__4;
     complex q__1;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
     /* Local variables */
     static real zi, zr;
     extern /* Subroutine */ int sladiv_(real *, real *, real *, real *, real *
@@ -8679,10 +8641,6 @@ L50:
     /* System generated locals */
     integer q_dim1, q_offset, qstore_dim1, qstore_offset, i__1, i__2;
     real r__1;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, k, ll, iq, lgn, msd2, smm1, spm1, spm2;
@@ -9033,9 +8991,6 @@ L80:
     /* System generated locals */
     integer q_dim1, q_offset, i__1, i__2;
 
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-
     /* Local variables */
     static integer i__, k, n1, n2, iq, iw, iz, ptr, indx, curr, indxc, indxp;
     extern /* Subroutine */ int claed8_(integer *, integer *, integer *,
@@ -9337,9 +9292,6 @@ L80:
     /* System generated locals */
     integer q_dim1, q_offset, q2_dim1, q2_offset, i__1;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real c__;
@@ -9760,13 +9712,6 @@ L100:
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     real r__1, r__2, r__3, r__4, r__5, r__6;
     complex q__1, q__2, q__3, q__4, q__5, q__6, q__7;
-
-    /* Builtin functions */
-    double r_imag(complex *);
-    void r_cnjg(complex *, complex *);
-    double c_abs(complex *);
-    void c_sqrt(complex *, complex *), pow_ci(complex *, complex *, integer *)
-	    ;
 
     /* Local variables */
     static integer i__, j, k, l, m;
@@ -10808,9 +10753,6 @@ doublereal clange_(char *norm, integer *m, integer *n, complex *a, integer *
     integer a_dim1, a_offset, i__1, i__2;
     real ret_val, r__1, r__2;
 
-    /* Builtin functions */
-    double c_abs(complex *), sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j;
     static real sum, scale;
@@ -10976,9 +10918,6 @@ doublereal clanhe_(char *norm, char *uplo, integer *n, complex *a, integer *
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     real ret_val, r__1, r__2, r__3;
-
-    /* Builtin functions */
-    double c_abs(complex *), sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j;
@@ -11214,10 +11153,6 @@ doublereal clanhe_(char *norm, char *uplo, integer *n, complex *a, integer *
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4, i__5;
     real r__1, r__2, r__3, r__4, r__5, r__6, r__7, r__8;
     complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    double r_imag(complex *);
-    void c_sqrt(complex *, complex *);
 
     /* Local variables */
     static integer i__, k;
@@ -12000,9 +11935,6 @@ L80:
     real r__1, r__2, r__3, r__4, r__5, r__6;
     complex q__1, q__2, q__3, q__4, q__5, q__6, q__7, q__8;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
     /* Local variables */
     static real s;
     static complex h21s, h31s;
@@ -12174,10 +12106,6 @@ L80:
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     real r__1, r__2, r__3, r__4, r__5, r__6;
     complex q__1, q__2;
-
-    /* Builtin functions */
-    double r_imag(complex *);
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j;
@@ -12752,10 +12680,6 @@ L80:
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     real r__1, r__2, r__3, r__4, r__5, r__6;
     complex q__1, q__2;
-
-    /* Builtin functions */
-    double r_imag(complex *);
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j;
@@ -13346,10 +13270,6 @@ L80:
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4, i__5;
     real r__1, r__2, r__3, r__4, r__5, r__6, r__7, r__8;
     complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    double r_imag(complex *);
-    void c_sqrt(complex *, complex *);
 
     /* Local variables */
     static integer i__, k;
@@ -14135,10 +14055,6 @@ L80:
 	     i__4, i__5, i__6, i__7, i__8, i__9, i__10, i__11;
     real r__1, r__2, r__3, r__4, r__5, r__6, r__7, r__8, r__9, r__10;
     complex q__1, q__2, q__3, q__4, q__5, q__6, q__7, q__8;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-    double r_imag(complex *);
 
     /* Local variables */
     static integer j, k, m, i2, j2, i4, j4, k1;
@@ -15482,9 +15398,6 @@ L80:
     real r__1;
     complex q__1;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
     /* Local variables */
     static integer i__, j, l;
     extern /* Subroutine */ int sgemm_(char *, char *, integer *, integer *,
@@ -15801,9 +15714,6 @@ L80:
     integer c_dim1, c_offset, t_dim1, t_offset, v_dim1, v_offset, work_dim1,
 	    work_offset, i__1, i__2, i__3, i__4, i__5;
     complex q__1, q__2;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j;
@@ -16645,9 +16555,6 @@ L80:
     real r__1, r__2;
     complex q__1, q__2;
 
-    /* Builtin functions */
-    double r_imag(complex *), r_sign(real *, real *);
-
     /* Local variables */
     static integer j, knt;
     static real beta;
@@ -17145,11 +17052,6 @@ L36:
     integer i__1;
     real r__1, r__2, r__3, r__4, r__5, r__6, r__7, r__8, r__9, r__10;
     complex q__1, q__2, q__3;
-
-    /* Builtin functions */
-    double log(doublereal), pow_ri(real *, integer *), r_imag(complex *),
-	    sqrt(doublereal);
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static real d__;
@@ -18493,9 +18395,6 @@ L10:
     integer i__1, i__2, i__3;
     real r__1;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-
     /* Local variables */
     static integer ix;
     static real temp1;
@@ -19149,10 +19048,6 @@ L10:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     real r__1, r__2, r__3, r__4;
     complex q__1, q__2, q__3, q__4;
-
-    /* Builtin functions */
-    double r_imag(complex *);
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, j;
@@ -20672,9 +20567,6 @@ L185:
     real r__1;
     complex q__1, q__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer j;
     static real ajj;
@@ -21348,9 +21240,6 @@ L40:
     integer i__1, i__2, i__3, i__4;
     complex q__1, q__2, q__3, q__4;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, ix, iy;
     static complex stemp;
@@ -21484,11 +21373,6 @@ L20:
     /* System generated locals */
     integer z_dim1, z_offset, i__1, i__2, i__3, i__4;
     real r__1, r__2;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k, m;
@@ -21954,9 +21838,6 @@ L70:
     /* System generated locals */
     integer z_dim1, z_offset, i__1, i__2;
     real r__1, r__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
 
     /* Local variables */
     static real b, c__, f, g;
@@ -22558,10 +22439,6 @@ L160:
     real r__1, r__2, r__3;
     complex q__1, q__2;
 
-    /* Builtin functions */
-    double r_imag(complex *);
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, j, k, ii, ki, is;
     static real ulp;
@@ -23060,9 +22937,6 @@ L130:
     integer q_dim1, q_offset, t_dim1, t_offset, i__1, i__2, i__3;
     complex q__1;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer k, m1, m2, m3;
     static real cs;
@@ -23246,9 +23120,6 @@ L130:
     integer a_dim1, a_offset, i__1, i__2;
     complex q__1;
 
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
-
     /* Local variables */
     static integer j;
     static complex ajj;
@@ -23414,9 +23285,6 @@ L130:
     integer a_dim1, a_offset, i__1, i__2, i__3[2], i__4, i__5;
     complex q__1;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer j, jb, nb, nn;
@@ -24266,9 +24134,6 @@ L130:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     complex q__1, q__2;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, j, l;
     extern /* Subroutine */ int cscal_(integer *, complex *, complex *,
@@ -24959,9 +24824,6 @@ L130:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3;
     complex q__1;
 
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-
     /* Local variables */
     static integer i__, i1, i2, i3, mi, ni, nq;
     static complex aii;
@@ -25173,9 +25035,6 @@ L130:
     /* System generated locals */
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3;
     complex q__1;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, i1, i2, i3, ic, jc, mi, ni, nq;
@@ -25394,9 +25253,6 @@ L130:
     address a__1[2];
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3[2];
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;
@@ -25738,9 +25594,6 @@ L130:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i1, i2, nb, mi, nh, ni, nq, nw;
     static logical left;
@@ -25964,9 +25817,6 @@ L130:
     /* System generated locals */
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3;
     complex q__1;
-
-    /* Builtin functions */
-    void r_cnjg(complex *, complex *);
 
     /* Local variables */
     static integer i__, i1, i2, i3, ic, jc, mi, ni, nq;
@@ -26194,9 +26044,6 @@ L130:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3[2], i__4,
 	    i__5;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i__;
@@ -26503,9 +26350,6 @@ L130:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static complex t[4160]	/* was [65][64] */;
@@ -26804,9 +26648,6 @@ L130:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static complex t[4160]	/* was [65][64] */;
@@ -27103,9 +26944,6 @@ L130:
     address a__1[2];
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2, i__3;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;

--- a/numpy/linalg/lapack_lite/f2c_config.c
+++ b/numpy/linalg/lapack_lite/f2c_config.c
@@ -43,9 +43,6 @@ doublereal dlamch_(char *cmach)
     integer i__1;
     doublereal ret_val;
 
-    /* Builtin functions */
-    double pow_di(doublereal *, integer *);
-
     /* Local variables */
     static doublereal t;
     static integer it;
@@ -397,10 +394,6 @@ L30:
     integer i__1;
     doublereal d__1, d__2, d__3, d__4, d__5;
 
-    /* Builtin functions */
-    double pow_di(doublereal *, integer *);
-    integer s_wsfe(cilist *), do_fio(integer *, char *, ftnlen), e_wsfe(void);
-
     /* Local variables */
     static doublereal a, b, c__;
     static integer i__, lt;
@@ -696,7 +689,7 @@ L10:
 doublereal dlamc3_(doublereal *a, doublereal *b)
 {
     /* System generated locals */
-    volatile doublereal ret_val;
+    doublereal ret_val;
 
 
 /*
@@ -1121,9 +1114,6 @@ doublereal slamch_(char *cmach)
     integer i__1;
     real ret_val;
 
-    /* Builtin functions */
-    double pow_ri(real *, integer *);
-
     /* Local variables */
     static real t;
     static integer it;
@@ -1474,10 +1464,6 @@ L30:
     integer i__1;
     real r__1, r__2, r__3, r__4, r__5;
 
-    /* Builtin functions */
-    double pow_ri(real *, integer *);
-    integer s_wsfe(cilist *), do_fio(integer *, char *, ftnlen), e_wsfe(void);
-
     /* Local variables */
     static real a, b, c__;
     static integer i__, lt;
@@ -1773,7 +1759,7 @@ L10:
 doublereal slamc3_(real *a, real *b)
 {
     /* System generated locals */
-    volatile real ret_val;
+    real ret_val;
 
 
 /*

--- a/numpy/linalg/lapack_lite/f2c_d_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_d_lapack.c
@@ -63,9 +63,6 @@ static doublereal c_b3192 = 2.;
     integer u_dim1, u_offset, vt_dim1, vt_offset, i__1, i__2;
     doublereal d__1;
 
-    /* Builtin functions */
-    double d_sign(doublereal *, doublereal *), log(doublereal);
-
     /* Local variables */
     static integer i__, j, k;
     static doublereal p, r__;
@@ -554,10 +551,6 @@ L40:
     integer c_dim1, c_offset, u_dim1, u_offset, vt_dim1, vt_offset, i__1,
 	    i__2;
     doublereal d__1, d__2, d__3, d__4;
-
-    /* Builtin functions */
-    double pow_dd(doublereal *, doublereal *), sqrt(doublereal), d_sign(
-	    doublereal *, doublereal *);
 
     /* Local variables */
     static doublereal f, g, h__;
@@ -2660,9 +2653,6 @@ L210:
 	    i__2, i__3;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, k;
     static doublereal r__, cs, sn;
@@ -4067,9 +4057,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2, i__3, i__4;
 
-    /* Builtin functions */
-    double log(doublereal);
-
     /* Local variables */
     static integer ie, il, mm;
     static doublereal eps, anrm, bnrm;
@@ -5131,9 +5118,6 @@ L10:
     /* System generated locals */
     integer a_dim1, a_offset, u_dim1, u_offset, vt_dim1, vt_offset, i__1,
 	    i__2, i__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, ie, il, ir, iu, blk;
@@ -7496,9 +7480,6 @@ L10:
     doublereal d__1;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static doublereal hl[2401]	/* was [49][49] */;
@@ -7986,9 +7967,6 @@ logical disnan_(doublereal *din)
 
 /* Subroutine */ int dlabad_(doublereal *small, doublereal *large)
 {
-    /* Builtin functions */
-    double d_lg10(doublereal *), sqrt(doublereal);
-
 
 /*
     -- LAPACK auxiliary routine (version 3.2) --
@@ -8612,9 +8590,6 @@ logical disnan_(doublereal *din)
     /* System generated locals */
     doublereal d__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static doublereal ab, df, tb, sm, rt, adf, acmn, acmx;
 
@@ -8740,10 +8715,6 @@ logical disnan_(doublereal *din)
     /* System generated locals */
     integer q_dim1, q_offset, qstore_dim1, qstore_offset, i__1, i__2;
     doublereal d__1;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, k, iq, lgn, msd2, smm1, spm1, spm2;
@@ -9388,9 +9359,6 @@ L20:
     integer q_dim1, q_offset, i__1, i__2;
     doublereal d__1, d__2, d__3, d__4;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static doublereal c__;
     static integer i__, j;
@@ -9902,9 +9870,6 @@ L190:
     integer q_dim1, q_offset, i__1, i__2;
     doublereal d__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static integer i__, j, n2, n12, ii, n23, iq2;
     static doublereal temp;
@@ -10208,9 +10173,6 @@ L120:
     /* System generated locals */
     integer i__1;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal a, b, c__;
@@ -11155,9 +11117,6 @@ L250:
     /* System generated locals */
     doublereal d__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static doublereal b, c__, w, del, tau, temp;
 
@@ -11282,9 +11241,6 @@ L250:
     /* System generated locals */
     integer i__1;
     doublereal d__1, d__2, d__3, d__4;
-
-    /* Builtin functions */
-    double sqrt(doublereal), log(doublereal), pow_di(doublereal *, integer *);
 
     /* Local variables */
     static doublereal a, b, c__, f;
@@ -11639,9 +11595,6 @@ L60:
     /* System generated locals */
     integer q_dim1, q_offset, i__1, i__2;
 
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-
     /* Local variables */
     static integer i__, k, n1, n2, is, iw, iz, iq2, ptr, ldq2, indx, curr;
     extern /* Subroutine */ int dgemm_(char *, char *, integer *, integer *,
@@ -11967,9 +11920,6 @@ L30:
     /* System generated locals */
     integer q_dim1, q_offset, q2_dim1, q2_offset, i__1;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal c__;
@@ -12427,9 +12377,6 @@ L110:
     integer q_dim1, q_offset, s_dim1, s_offset, i__1, i__2;
     doublereal d__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static integer i__, j;
     static doublereal temp;
@@ -12673,10 +12620,6 @@ L120:
 {
     /* System generated locals */
     integer i__1, i__2, i__3;
-
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, k, mid, ptr;
@@ -12935,9 +12878,6 @@ L120:
 {
     /* System generated locals */
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal ab, df, cs, ct, tb, sm, tn, rt, adf, acs;
@@ -13548,9 +13488,6 @@ L50:
     /* System generated locals */
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3;
     doublereal d__1, d__2, d__3, d__4;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k, l, m;
@@ -15525,9 +15462,6 @@ logical dlaisnan_(doublereal *din1, doublereal *din2)
 	     u_dim1, u_offset, vt_dim1, vt_offset, z_dim1, z_offset, i__1,
 	    i__2;
 
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-
     /* Local variables */
     static integer i__, j, i1, ic, lf, nd, ll, nl, nr, im1, nlf, nrf, lvl,
 	    ndb1, nlp1, lvl2, nrp1, nlvl, sqre;
@@ -15964,9 +15898,6 @@ L90:
     /* System generated locals */
     integer b_dim1, b_offset, i__1, i__2;
     doublereal d__1;
-
-    /* Builtin functions */
-    double log(doublereal), d_sign(doublereal *, doublereal *);
 
     /* Local variables */
     static integer c__, i__, j, k;
@@ -16583,9 +16514,6 @@ doublereal dlange_(char *norm, integer *m, integer *n, doublereal *a, integer
     integer a_dim1, a_offset, i__1, i__2;
     doublereal ret_val, d__1, d__2, d__3;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j;
     static doublereal sum, scale;
@@ -16751,9 +16679,6 @@ doublereal dlanst_(char *norm, integer *n, doublereal *d__, doublereal *e)
     integer i__1;
     doublereal ret_val, d__1, d__2, d__3, d__4, d__5;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__;
     static doublereal sum, scale;
@@ -16887,9 +16812,6 @@ doublereal dlansy_(char *norm, char *uplo, integer *n, doublereal *a, integer
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     doublereal ret_val, d__1, d__2, d__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j;
@@ -17096,9 +17018,6 @@ doublereal dlansy_(char *norm, char *uplo, integer *n, doublereal *a, integer
 {
     /* System generated locals */
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double d_sign(doublereal *, doublereal *), sqrt(doublereal);
 
     /* Local variables */
     static doublereal p, z__, aa, bb, cc, dd, cs1, sn1, sab, sac, eps, tau,
@@ -17312,9 +17231,6 @@ doublereal dlapy2_(doublereal *x, doublereal *y)
     /* System generated locals */
     doublereal ret_val, d__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static doublereal w, z__, xabs, yabs;
 
@@ -17364,9 +17280,6 @@ doublereal dlapy3_(doublereal *x, doublereal *y, doublereal *z__)
 {
     /* System generated locals */
     doublereal ret_val, d__1, d__2, d__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal w, xabs, yabs, zabs;
@@ -18309,9 +18222,6 @@ L90:
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j, k;
     static doublereal s, aa, bb, cc, dd, cs, sn;
@@ -18987,9 +18897,6 @@ L60:
     integer h_dim1, h_offset, t_dim1, t_offset, v_dim1, v_offset, wv_dim1,
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k;
@@ -22434,9 +22341,6 @@ L90:
     integer i__1;
     doublereal d__1;
 
-    /* Builtin functions */
-    double d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static integer j, knt;
     static doublereal beta;
@@ -23585,9 +23489,6 @@ L410:
     integer i__1;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double log(doublereal), pow_di(doublereal *, integer *), sqrt(doublereal);
-
     /* Local variables */
     static integer i__;
     static doublereal f1, g1, eps, scale;
@@ -23749,9 +23650,6 @@ L30:
 {
     /* System generated locals */
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal c__, fa, ga, ha, as, at, au, fhmn, fhmx;
@@ -24209,9 +24107,6 @@ L10:
 {
     /* System generated locals */
     integer u_dim1, u_offset, vt_dim1, vt_offset, i__1, i__2;
-
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, m, i1, ic, lf, nd, ll, nl, nr, im1, ncc, nlf, nrf,
@@ -25341,9 +25236,6 @@ L120:
 	    vt_offset, vt2_dim1, vt2_offset, i__1, i__2;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static integer i__, j, m, n, jc;
     static doublereal rho;
@@ -25760,9 +25652,6 @@ L100:
     /* System generated locals */
     integer i__1;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal a, b, c__;
@@ -26770,9 +26659,6 @@ L240:
 {
     /* System generated locals */
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal b, c__, w, del, tau, delsq;
@@ -27789,9 +27675,6 @@ L100:
     integer difr_dim1, difr_offset, i__1, i__2;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static integer i__, j;
     static doublereal dj, rho;
@@ -28090,9 +27973,6 @@ L100:
 	    difl_offset, difr_dim1, difr_offset, givnum_dim1, givnum_offset,
 	    poles_dim1, poles_offset, u_dim1, u_offset, vt_dim1, vt_offset,
 	    z_dim1, z_offset, i__1, i__2;
-
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, m, i1, ic, lf, nd, ll, nl, vf, nr, vl, im1, ncc,
@@ -28908,9 +28788,6 @@ L100:
     /* System generated locals */
     integer i__1, i__2;
 
-    /* Builtin functions */
-    double log(doublereal);
-
     /* Local variables */
     static integer i__, il, ir, maxn;
     static doublereal temp;
@@ -29159,9 +29036,6 @@ L100:
     integer i__1, i__2;
     doublereal d__1, d__2, d__3;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__;
     static doublereal eps;
@@ -29345,9 +29219,6 @@ L100:
     /* System generated locals */
     integer i__1, i__2, i__3;
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal d__, e, g;
@@ -29926,9 +29797,6 @@ L170:
     integer i__1;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static doublereal s, t;
     static integer j4, nn;
@@ -30259,9 +30127,6 @@ L90:
     /* System generated locals */
     integer i__1;
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal s, a2, b1, b2;
@@ -31826,9 +31691,6 @@ L110:
 {
     /* System generated locals */
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
 
     /* Local variables */
     static doublereal a, d__, l, m, r__, s, t, fa, ga, ha, ft, gt, ht, mm, tt,
@@ -35022,9 +34884,6 @@ L50:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3[2];
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;
     static logical left;
@@ -35355,9 +35214,6 @@ L50:
     address a__1[2];
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i1, i2, nb, mi, nh, ni, nq, nw;
@@ -35790,9 +35646,6 @@ L50:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static doublereal t[4160]	/* was [65][64] */;
@@ -36097,9 +35950,6 @@ L50:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static doublereal t[4160]	/* was [65][64] */;
@@ -36397,9 +36247,6 @@ L50:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static doublereal t[4160]	/* was [65][64] */;
@@ -36696,9 +36543,6 @@ L50:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2, i__3;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;
     static logical left;
@@ -36962,9 +36806,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer j;
@@ -37616,11 +37457,6 @@ L40:
     integer z_dim1, z_offset, i__1, i__2;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j, k, m;
     static doublereal p;
@@ -38081,9 +37917,6 @@ L50:
     /* System generated locals */
     integer z_dim1, z_offset, i__1, i__2;
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
 
     /* Local variables */
     static doublereal b, c__, f, g;
@@ -38682,9 +38515,6 @@ L190:
     integer i__1;
     doublereal d__1, d__2, d__3;
 
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static doublereal c__;
     static integer i__, l, m;
@@ -39123,9 +38953,6 @@ L180:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal eps;
@@ -40077,9 +39904,6 @@ L180:
     integer t_dim1, t_offset, vl_dim1, vl_offset, vr_dim1, vr_offset, i__1,
 	    i__2, i__3;
     doublereal d__1, d__2, d__3, d__4;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k;
@@ -41837,9 +41661,6 @@ L20:
     address a__1[2];
     integer a_dim1, a_offset, i__1, i__2[2], i__3, i__4, i__5;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer j, jb, nb, nn;

--- a/numpy/linalg/lapack_lite/f2c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_lapack.c
@@ -476,10 +476,6 @@ integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
     /* System generated locals */
     integer ret_val;
 
-    /* Builtin functions */
-    /* Subroutine */ int s_copy(char *, char *, ftnlen, ftnlen);
-    integer s_cmp(char *, char *, ftnlen, ftnlen);
-
     /* Local variables */
     static integer i__;
     static char c1[1], c2[2], c3[3], c4[2];
@@ -1394,10 +1390,6 @@ integer iparmq_(integer *ispec, char *name__, char *opts, integer *n, integer
     /* System generated locals */
     integer ret_val, i__1, i__2;
     real r__1;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer i_nint(real *);
 
     /* Local variables */
     static integer nh, ns;

--- a/numpy/linalg/lapack_lite/f2c_s_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_s_lapack.c
@@ -59,9 +59,6 @@ static real c_b2863 = 2.f;
     integer u_dim1, u_offset, vt_dim1, vt_offset, i__1, i__2;
     real r__1;
 
-    /* Builtin functions */
-    double r_sign(real *, real *), log(doublereal);
-
     /* Local variables */
     static integer i__, j, k;
     static real p, r__;
@@ -548,10 +545,6 @@ L40:
 	    i__2;
     real r__1, r__2, r__3, r__4;
     doublereal d__1;
-
-    /* Builtin functions */
-    double pow_dd(doublereal *, doublereal *), sqrt(doublereal), r_sign(real *
-	    , real *);
 
     /* Local variables */
     static real f, g, h__;
@@ -2648,9 +2641,6 @@ L210:
 	    i__2, i__3;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, k;
     static real r__, cs, sn;
@@ -4406,9 +4396,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, u_dim1, u_offset, vt_dim1, vt_offset, i__1,
 	    i__2, i__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, ie, il, ir, iu, blk;
@@ -6770,9 +6757,6 @@ L50:
     real r__1;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static real hl[2401]	/* was [49][49] */;
@@ -7258,9 +7242,6 @@ logical sisnan_(real *sin__)
 
 /* Subroutine */ int slabad_(real *small, real *large)
 {
-    /* Builtin functions */
-    double r_lg10(real *), sqrt(doublereal);
-
 
 /*
     -- LAPACK auxiliary routine (version 3.2) --
@@ -7881,9 +7862,6 @@ logical sisnan_(real *sin__)
     /* System generated locals */
     real r__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static real ab, df, tb, sm, rt, adf, acmn, acmx;
 
@@ -8008,10 +7986,6 @@ logical sisnan_(real *sin__)
     /* System generated locals */
     integer q_dim1, q_offset, qstore_dim1, qstore_offset, i__1, i__2;
     real r__1;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, k, iq, lgn, msd2, smm1, spm1, spm2;
@@ -8648,9 +8622,6 @@ L20:
     integer q_dim1, q_offset, i__1, i__2;
     real r__1, r__2, r__3, r__4;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static real c__;
     static integer i__, j;
@@ -9160,9 +9131,6 @@ L190:
     integer q_dim1, q_offset, i__1, i__2;
     real r__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
-
     /* Local variables */
     static integer i__, j, n2, n12, ii, n23, iq2;
     static real temp;
@@ -9464,9 +9432,6 @@ L120:
     /* System generated locals */
     integer i__1;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real a, b, c__;
@@ -10410,9 +10375,6 @@ L250:
     /* System generated locals */
     real r__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static real b, c__, w, del, tau, temp;
 
@@ -10537,9 +10499,6 @@ L250:
     /* System generated locals */
     integer i__1;
     real r__1, r__2, r__3, r__4;
-
-    /* Builtin functions */
-    double sqrt(doublereal), log(doublereal), pow_ri(real *, integer *);
 
     /* Local variables */
     static real a, b, c__, f;
@@ -10896,9 +10855,6 @@ L60:
     /* System generated locals */
     integer q_dim1, q_offset, i__1, i__2;
 
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-
     /* Local variables */
     static integer i__, k, n1, n2, is, iw, iz, iq2, ptr, ldq2, indx, curr,
 	    indxc;
@@ -11222,9 +11178,6 @@ L30:
     /* System generated locals */
     integer q_dim1, q_offset, q2_dim1, q2_offset, i__1;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real c__;
@@ -11682,9 +11635,6 @@ L110:
     integer q_dim1, q_offset, s_dim1, s_offset, i__1, i__2;
     real r__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
-
     /* Local variables */
     static integer i__, j;
     static real temp;
@@ -11927,10 +11877,6 @@ L120:
 {
     /* System generated locals */
     integer i__1, i__2, i__3;
-
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, k, mid, ptr, curr;
@@ -12185,9 +12131,6 @@ L120:
 {
     /* System generated locals */
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real ab, df, cs, ct, tb, sm, tn, rt, adf, acs;
@@ -12798,9 +12741,6 @@ L50:
     /* System generated locals */
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3;
     real r__1, r__2, r__3, r__4;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k, l, m;
@@ -14428,9 +14368,6 @@ doublereal slange_(char *norm, integer *m, integer *n, real *a, integer *lda,
     integer a_dim1, a_offset, i__1, i__2;
     real ret_val, r__1, r__2, r__3;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j;
     static real sum, scale;
@@ -14596,9 +14533,6 @@ doublereal slanst_(char *norm, integer *n, real *d__, real *e)
     integer i__1;
     real ret_val, r__1, r__2, r__3, r__4, r__5;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__;
     static real sum, scale;
@@ -14732,9 +14666,6 @@ doublereal slansy_(char *norm, char *uplo, integer *n, real *a, integer *lda,
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     real ret_val, r__1, r__2, r__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j;
@@ -14940,9 +14871,6 @@ doublereal slansy_(char *norm, char *uplo, integer *n, real *a, integer *lda,
 {
     /* System generated locals */
     real r__1, r__2;
-
-    /* Builtin functions */
-    double r_sign(real *, real *), sqrt(doublereal);
 
     /* Local variables */
     static real p, z__, aa, bb, cc, dd, cs1, sn1, sab, sac, eps, tau, temp,
@@ -15156,9 +15084,6 @@ doublereal slapy2_(real *x, real *y)
     /* System generated locals */
     real ret_val, r__1;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static real w, z__, xabs, yabs;
 
@@ -15208,9 +15133,6 @@ doublereal slapy3_(real *x, real *y, real *z__)
 {
     /* System generated locals */
     real ret_val, r__1, r__2, r__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real w, xabs, yabs, zabs;
@@ -16147,9 +16069,6 @@ L90:
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     real r__1, r__2, r__3, r__4, r__5, r__6;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j, k;
     static real s, aa, bb, cc, dd, cs, sn;
@@ -16821,9 +16740,6 @@ L60:
     integer h_dim1, h_offset, t_dim1, t_offset, v_dim1, v_offset, wv_dim1,
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     real r__1, r__2, r__3, r__4, r__5, r__6;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k;
@@ -20258,9 +20174,6 @@ L90:
     integer i__1;
     real r__1;
 
-    /* Builtin functions */
-    double r_sign(real *, real *);
-
     /* Local variables */
     static integer j, knt;
     static real beta;
@@ -21404,9 +21317,6 @@ L410:
     integer i__1;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double log(doublereal), pow_ri(real *, integer *), sqrt(doublereal);
-
     /* Local variables */
     static integer i__;
     static real f1, g1, eps, scale;
@@ -21568,9 +21478,6 @@ L30:
 {
     /* System generated locals */
     real r__1, r__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real c__, fa, ga, ha, as, at, au, fhmn, fhmx;
@@ -22029,9 +21936,6 @@ L10:
 {
     /* System generated locals */
     integer u_dim1, u_offset, vt_dim1, vt_offset, i__1, i__2;
-
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, m, i1, ic, lf, nd, ll, nl, nr, im1, ncc, nlf, nrf,
@@ -23153,9 +23057,6 @@ L120:
 	    vt_offset, vt2_dim1, vt2_offset, i__1, i__2;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
-
     /* Local variables */
     static integer i__, j, m, n, jc;
     static real rho;
@@ -23569,9 +23470,6 @@ L100:
     /* System generated locals */
     integer i__1;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real a, b, c__;
@@ -24578,9 +24476,6 @@ L240:
 {
     /* System generated locals */
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real b, c__, w, del, tau, delsq;
@@ -25592,9 +25487,6 @@ L100:
     integer difr_dim1, difr_offset, i__1, i__2;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
-
     /* Local variables */
     static integer i__, j;
     static real dj, rho;
@@ -25890,9 +25782,6 @@ L100:
 	    difl_offset, difr_dim1, difr_offset, givnum_dim1, givnum_offset,
 	    poles_dim1, poles_offset, u_dim1, u_offset, vt_dim1, vt_offset,
 	    z_dim1, z_offset, i__1, i__2;
-
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, m, i1, ic, lf, nd, ll, nl, vf, nr, vl, im1, ncc,
@@ -26703,9 +26592,6 @@ L100:
     /* System generated locals */
     integer i__1, i__2;
 
-    /* Builtin functions */
-    double log(doublereal);
-
     /* Local variables */
     static integer i__, il, ir, maxn;
     static real temp;
@@ -26954,9 +26840,6 @@ L100:
     integer i__1, i__2;
     real r__1, r__2, r__3;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__;
     static real eps;
@@ -27137,9 +27020,6 @@ L100:
     /* System generated locals */
     integer i__1, i__2, i__3;
     real r__1, r__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real d__, e, g;
@@ -27719,9 +27599,6 @@ L170:
     integer i__1;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static real s, t;
     static integer j4, nn;
@@ -28048,9 +27925,6 @@ L90:
     /* System generated locals */
     integer i__1;
     real r__1, r__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real s, a2, b1, b2;
@@ -29611,9 +29485,6 @@ L110:
 {
     /* System generated locals */
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
 
     /* Local variables */
     static real a, d__, l, m, r__, s, t, fa, ga, ha, ft, gt, ht, mm, tt, clt,
@@ -32792,9 +32663,6 @@ L50:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3[2];
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;
     static logical left;
@@ -33123,9 +32991,6 @@ L50:
     address a__1[2];
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i1, i2, nb, mi, nh, ni, nq, nw;
@@ -33557,9 +33422,6 @@ L50:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static real t[4160]	/* was [65][64] */;
@@ -33864,9 +33726,6 @@ L50:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static real t[4160]	/* was [65][64] */;
@@ -34165,9 +34024,6 @@ L50:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static real t[4160]	/* was [65][64] */;
@@ -34464,9 +34320,6 @@ L50:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2, i__3;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;
     static logical left;
@@ -34730,9 +34583,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer j;
@@ -35376,11 +35226,6 @@ L40:
     integer z_dim1, z_offset, i__1, i__2;
     real r__1, r__2;
 
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j, k, m;
     static real p;
@@ -35836,9 +35681,6 @@ L50:
     /* System generated locals */
     integer z_dim1, z_offset, i__1, i__2;
     real r__1, r__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
 
     /* Local variables */
     static real b, c__, f, g;
@@ -36433,9 +36275,6 @@ L190:
     integer i__1;
     real r__1, r__2, r__3;
 
-    /* Builtin functions */
-    double sqrt(doublereal), r_sign(real *, real *);
-
     /* Local variables */
     static real c__;
     static integer i__, l, m;
@@ -36874,9 +36713,6 @@ L180:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     real r__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static real eps;
@@ -37812,9 +37648,6 @@ L180:
     integer t_dim1, t_offset, vl_dim1, vl_offset, vr_dim1, vr_offset, i__1,
 	    i__2, i__3;
     real r__1, r__2, r__3, r__4;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k;
@@ -39568,9 +39401,6 @@ L20:
     address a__1[2];
     integer a_dim1, a_offset, i__1, i__2[2], i__3, i__4, i__5;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer j, jb, nb, nn;

--- a/numpy/linalg/lapack_lite/f2c_z_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_z_lapack.c
@@ -270,9 +270,6 @@ L50:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1, d__2;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *), z_abs(doublecomplex *);
-
     /* Local variables */
     static doublereal c__, f, g;
     static integer i__, j, k, l, m;
@@ -663,9 +660,6 @@ L210:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublecomplex z__1;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__;
@@ -1316,10 +1310,6 @@ L210:
     doublereal d__1, d__2;
     doublecomplex z__1, z__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal), d_imag(doublecomplex *);
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, k, ihi;
     static doublereal scl;
@@ -1839,9 +1829,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublecomplex z__1;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__;
@@ -2721,9 +2708,6 @@ L50:
     /* System generated locals */
     integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2, i__3, i__4;
 
-    /* Builtin functions */
-    double log(doublereal);
-
     /* Local variables */
     static integer ie, il, mm;
     static doublereal eps, anrm, bnrm;
@@ -3461,9 +3445,6 @@ L10:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, k;
     static doublecomplex alpha;
@@ -3840,9 +3821,6 @@ L10:
     /* System generated locals */
     integer a_dim1, a_offset, u_dim1, u_offset, vt_dim1, vt_offset, i__1,
 	    i__2, i__3;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, ie, il, ir, iu, blk;
@@ -6471,10 +6449,6 @@ L10:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    double z_abs(doublecomplex *);
-    void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, j, jp;
     static doublereal sfmin;
@@ -6992,9 +6966,6 @@ L10:
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal eps;
@@ -8042,9 +8013,6 @@ L10:
     doublecomplex z__1;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static doublecomplex hl[2401]	/* was [49][49] */;
     static integer kbot, nmin;
@@ -8968,9 +8936,6 @@ L10:
     integer i__1, i__2;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, ioff;
 
@@ -9271,9 +9236,6 @@ L10:
     doublereal d__1;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-
     /* Local variables */
     static integer i__, j, l;
     extern /* Subroutine */ int dgemm_(char *, char *, integer *, integer *,
@@ -9416,9 +9378,6 @@ L10:
     doublereal d__1, d__2, d__3, d__4;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-
     /* Local variables */
     static doublereal zi, zr;
     extern /* Subroutine */ int dladiv_(doublereal *, doublereal *,
@@ -9471,10 +9430,6 @@ L10:
     /* System generated locals */
     integer q_dim1, q_offset, qstore_dim1, qstore_offset, i__1, i__2;
     doublereal d__1;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, k, ll, iq, lgn, msd2, smm1, spm1, spm2;
@@ -9824,9 +9779,6 @@ L80:
     /* System generated locals */
     integer q_dim1, q_offset, i__1, i__2;
 
-    /* Builtin functions */
-    integer pow_ii(integer *, integer *);
-
     /* Local variables */
     static integer i__, k, n1, n2, iq, iw, iz, ptr, indx, curr, indxc, indxp;
     extern /* Subroutine */ int dlaed9_(integer *, integer *, integer *,
@@ -10131,9 +10083,6 @@ L80:
     /* System generated locals */
     integer q_dim1, q_offset, q2_dim1, q2_offset, i__1;
     doublereal d__1;
-
-    /* Builtin functions */
-    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal c__;
@@ -10553,13 +10502,6 @@ L100:
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6;
     doublecomplex z__1, z__2, z__3, z__4, z__5, z__6, z__7;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void d_cnjg(doublecomplex *, doublecomplex *);
-    double z_abs(doublecomplex *);
-    void z_sqrt(doublecomplex *, doublecomplex *), pow_zi(doublecomplex *,
-	    doublecomplex *, integer *);
 
     /* Local variables */
     static integer i__, j, k, l, m;
@@ -11612,9 +11554,6 @@ L150:
     doublereal d__1;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-
     /* Local variables */
     static integer i__, j, m, n;
     static doublereal dj;
@@ -12153,10 +12092,6 @@ L150:
 	    z_dim1, z_offset, b_dim1, b_offset, bx_dim1, bx_offset, i__1,
 	    i__2, i__3, i__4, i__5, i__6;
     doublecomplex z__1;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    integer pow_ii(integer *, integer *);
 
     /* Local variables */
     static integer i__, j, i1, ic, lf, nd, ll, nl, nr, im1, nlf, nrf, lvl,
@@ -12807,10 +12742,6 @@ L330:
     integer b_dim1, b_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     doublereal d__1;
     doublecomplex z__1;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *), log(doublereal), d_sign(doublereal *,
-	    doublereal *);
 
     /* Local variables */
     static integer c__, i__, j, k;
@@ -13550,9 +13481,6 @@ doublereal zlange_(char *norm, integer *m, integer *n, doublecomplex *a,
     integer a_dim1, a_offset, i__1, i__2;
     doublereal ret_val, d__1, d__2;
 
-    /* Builtin functions */
-    double z_abs(doublecomplex *), sqrt(doublereal);
-
     /* Local variables */
     static integer i__, j;
     static doublereal sum, scale;
@@ -13718,9 +13646,6 @@ doublereal zlanhe_(char *norm, char *uplo, integer *n, doublecomplex *a,
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2;
     doublereal ret_val, d__1, d__2, d__3;
-
-    /* Builtin functions */
-    double z_abs(doublecomplex *), sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j;
@@ -13956,10 +13881,6 @@ doublereal zlanhe_(char *norm, char *uplo, integer *n, doublecomplex *a,
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4, i__5;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6, d__7, d__8;
     doublecomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void z_sqrt(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, k;
@@ -14745,9 +14666,6 @@ L80:
     doublereal d__1, d__2, d__3, d__4, d__5, d__6;
     doublecomplex z__1, z__2, z__3, z__4, z__5, z__6, z__7, z__8;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-
     /* Local variables */
     static doublereal s;
     static doublecomplex h21s, h31s;
@@ -14920,10 +14838,6 @@ L80:
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6;
     doublecomplex z__1, z__2;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j;
@@ -15506,10 +15420,6 @@ L80:
 	    wv_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6;
     doublecomplex z__1, z__2;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j;
@@ -16109,10 +16019,6 @@ L80:
     integer h_dim1, h_offset, z_dim1, z_offset, i__1, i__2, i__3, i__4, i__5;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6, d__7, d__8;
     doublecomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void z_sqrt(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, k;
@@ -16902,10 +16808,6 @@ L80:
 	     i__4, i__5, i__6, i__7, i__8, i__9, i__10, i__11;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6, d__7, d__8, d__9, d__10;
     doublecomplex z__1, z__2, z__3, z__4, z__5, z__6, z__7, z__8;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-    double d_imag(doublecomplex *);
 
     /* Local variables */
     static integer j, k, m, i2, j2, i4, j4, k1;
@@ -18253,9 +18155,6 @@ L80:
     doublereal d__1;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-
     /* Local variables */
     static integer i__, j, l;
     extern /* Subroutine */ int dgemm_(char *, char *, integer *, integer *,
@@ -18574,9 +18473,6 @@ L80:
     integer c_dim1, c_offset, t_dim1, t_offset, v_dim1, v_offset, work_dim1,
 	    work_offset, i__1, i__2, i__3, i__4, i__5;
     doublecomplex z__1, z__2;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j;
@@ -19420,9 +19316,6 @@ L80:
     doublereal d__1, d__2;
     doublecomplex z__1, z__2;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *), d_sign(doublereal *, doublereal *);
-
     /* Local variables */
     static integer j, knt;
     static doublereal beta, alphi, alphr;
@@ -19922,11 +19815,6 @@ L36:
     integer i__1;
     doublereal d__1, d__2, d__3, d__4, d__5, d__6, d__7, d__8, d__9, d__10;
     doublecomplex z__1, z__2, z__3;
-
-    /* Builtin functions */
-    double log(doublereal), pow_di(doublereal *, integer *), d_imag(
-	    doublecomplex *), sqrt(doublereal);
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static doublereal d__;
@@ -21272,9 +21160,6 @@ L10:
     integer i__1, i__2, i__3;
     doublereal d__1;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-
     /* Local variables */
     static integer ix;
     static doublereal temp1;
@@ -21930,10 +21815,6 @@ L10:
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
     doublereal d__1, d__2, d__3, d__4;
     doublecomplex z__1, z__2, z__3, z__4;
-
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, j;
@@ -23456,9 +23337,6 @@ L210:
     doublereal d__1;
     doublecomplex z__1, z__2;
 
-    /* Builtin functions */
-    double sqrt(doublereal);
-
     /* Local variables */
     static integer j;
     static doublereal ajj;
@@ -24133,9 +24011,6 @@ L40:
     integer i__1, i__2, i__3, i__4;
     doublecomplex z__1, z__2, z__3, z__4;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, ix, iy;
     static doublecomplex stemp;
@@ -24269,11 +24144,6 @@ L20:
     /* System generated locals */
     integer z_dim1, z_offset, i__1, i__2, i__3, i__4;
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double log(doublereal);
-    integer pow_ii(integer *, integer *);
-    double sqrt(doublereal);
 
     /* Local variables */
     static integer i__, j, k, m;
@@ -24741,9 +24611,6 @@ L70:
     /* System generated locals */
     integer z_dim1, z_offset, i__1, i__2;
     doublereal d__1, d__2;
-
-    /* Builtin functions */
-    double sqrt(doublereal), d_sign(doublereal *, doublereal *);
 
     /* Local variables */
     static doublereal b, c__, f, g;
@@ -25345,10 +25212,6 @@ L160:
     doublereal d__1, d__2, d__3;
     doublecomplex z__1, z__2;
 
-    /* Builtin functions */
-    double d_imag(doublecomplex *);
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, j, k, ii, ki, is;
     static doublereal ulp;
@@ -25848,9 +25711,6 @@ L130:
     integer q_dim1, q_offset, t_dim1, t_offset, i__1, i__2, i__3;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer k, m1, m2, m3;
     static doublereal cs;
@@ -26035,9 +25895,6 @@ L130:
     integer a_dim1, a_offset, i__1, i__2;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer j;
     static doublecomplex ajj;
@@ -26203,9 +26060,6 @@ L130:
     integer a_dim1, a_offset, i__1, i__2, i__3[2], i__4, i__5;
     doublecomplex z__1;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer j, jb, nb, nn;
@@ -27059,9 +26913,6 @@ L130:
     integer a_dim1, a_offset, i__1, i__2, i__3;
     doublecomplex z__1, z__2;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, j, l;
     extern /* Subroutine */ int zscal_(integer *, doublecomplex *,
@@ -27757,9 +27608,6 @@ L130:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3;
     doublecomplex z__1;
 
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
-
     /* Local variables */
     static integer i__, i1, i2, i3, mi, ni, nq;
     static doublecomplex aii;
@@ -27971,9 +27819,6 @@ L130:
     /* System generated locals */
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3;
     doublecomplex z__1;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, i1, i2, i3, ic, jc, mi, ni, nq;
@@ -28192,9 +28037,6 @@ L130:
     address a__1[2];
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3[2];
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;
@@ -28534,9 +28376,6 @@ L130:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i1, i2, nb, mi, nh, ni, nq, nw;
     static logical left;
@@ -28760,9 +28599,6 @@ L130:
     /* System generated locals */
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3;
     doublecomplex z__1;
-
-    /* Builtin functions */
-    void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
     static integer i__, i1, i2, i3, ic, jc, mi, ni, nq;
@@ -28990,9 +28826,6 @@ L130:
     integer a_dim1, a_offset, c_dim1, c_offset, i__1, i__2, i__3[2], i__4,
 	    i__5;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i__;
@@ -29302,9 +29135,6 @@ L130:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static doublecomplex t[4160]	/* was [65][64] */;
@@ -29607,9 +29437,6 @@ L130:
 	    i__5;
     char ch__1[2];
 
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
-
     /* Local variables */
     static integer i__;
     static doublecomplex t[4160]	/* was [65][64] */;
@@ -29910,9 +29737,6 @@ L130:
     address a__1[2];
     integer a_dim1, a_offset, c_dim1, c_offset, i__1[2], i__2, i__3;
     char ch__1[2];
-
-    /* Builtin functions */
-    /* Subroutine */ int s_cat(char *, char **, integer *, integer *, ftnlen);
 
     /* Local variables */
     static integer i1, i2, nb, mi, ni, nq, nw;

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -1,4 +1,6 @@
 #include "Python.h"
+
+#undef c_abs
 #include "f2c.h"
 
 /*


### PR DESCRIPTION
Backport of #10477.

See gh-10451 for issue.


* Align type definitions

* Regenerate sources

* Replace BytesIO

* Consolidate executables

* Create directories on PY2

* Revise step name

* Consolidate directory creation

* Don't catch makedirs errors

* Revise step name

* Add header source