### PR TITLE
BUG: Correctly identify comma seperated dtype strings

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -198,7 +198,7 @@ _check_for_commastring(char *type, Py_ssize_t len)
      * allows commas inside of [], for parameterized dtypes to use.
      */
     sqbracket = 0;
-    for (i = 1; i < len; i++) {
+    for (i = 0; i < len; i++) {
         switch (type[i]) {
             case ',':
                 if (sqbracket == 0) {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -719,5 +719,10 @@ def test_dtypes_are_true():
     assert bool(np.dtype([('a', 'i8'), ('b', 'f4')]))
 
 
+def test_invalid_dtype_string():
+    # test for gh-10440
+    assert_raises(TypeError, np.dtype, 'f8,i8,[f8,i8]')
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
When parsing dtype strings, we should only consider them to
be comma seperated if there are commas not present in a
pair of square brackets.

Whilst we had a check for this already in the code but there was
an off by 1 bug where we failed to consider the first character
of the string. This would lead to an infinite recursion when
trying to parse strings of the form `[i8,f8]`.

Fixes: #10440