### PR TITLE
Random.choice small subsample kwarg (default False) instead of RandomState version.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.99)/np.log(pop_size) + 1:
+                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.5)/np.log(pop_size) + 1:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1025,7 +1025,7 @@ cdef class RandomState:
         return bytestring
 
 
-    def choice(self, a, size=None, replace=True, p=None, legacy=False):
+    def choice(self, a, size=None, replace=True, p=None):
         """
         choice(a, size=None, replace=True, p=None)
 
@@ -1048,10 +1048,6 @@ cdef class RandomState:
             The probabilities associated with each entry in a.
             If not given the sample assumes a uniform distribution over all
             entries in a.
-        legacy : boolean, optional
-            Only relevant while replace==False, p==None, and size << len(a).
-            Preserves the output ordering of legacy versions of numpy
-            using a random seed, at the cost of significant loss in speed.
 
         Returns
         --------
@@ -1186,7 +1182,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if pop_size >= 3 and not legacy and \
+                if pop_size >= 3 and self.version > 0 and \
                    ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size:
                     idx = set()
                     while len(idx)<size:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1027,7 +1027,7 @@ cdef class RandomState:
 
     def choice(self, a, size=None, replace=True, p=None, small=False):
         """
-        choice(a, size=None, replace=True, p=None)
+        choice(a, size=None, replace=True, p=None, small=False)
 
         Generates a random sample from a given 1-D array
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1025,7 +1025,7 @@ cdef class RandomState:
         return bytestring
 
 
-    def choice(self, a, size=None, replace=True, p=None):
+    def choice(self, a, size=None, replace=True, p=None, small=False):
         """
         choice(a, size=None, replace=True, p=None)
 
@@ -1048,6 +1048,8 @@ cdef class RandomState:
             The probabilities associated with each entry in a.
             If not given the sample assumes a uniform distribution over all
             entries in a.
+        small : boolean, optional
+            Speeds up operation when selecting a small sample from a much larger array. len(a) >> size
 
         Returns
         --------
@@ -1182,8 +1184,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.5)/np.log(pop_size) + 1:
+                if small:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,12 +1182,12 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > k:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size:
                     idx = set()
                     while len(idx)<size:
-                        idx.add(self.randint(0, pop_size))
+                        idx.add(int(self.randint(0, pop_size)))
                     idx = np.array(list(idx))
-                    np.shuffle(idx)
+                    self.shuffle(idx)
                 else:
                     idx = self.permutation(pop_size)[:size]
                 if shape is not None:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1186,7 +1186,8 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size and not legacy:
+                if pop_size >= 3 and not legacy and \
+                   ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size:
+                   (loggam(pop_size+1)-loggam(n-k))/np.log(n) > size:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1186,7 +1186,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size and not legacy:
+                if ((pop_size+.5)*np.log(pop_size+1)-pop_size-0.60091006582)/np.log(pop_size) > size and not legacy:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size:
+                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size + np.log(.99)/np.log(pop_size) + 1:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1025,7 +1025,7 @@ cdef class RandomState:
         return bytestring
 
 
-    def choice(self, a, size=None, replace=True, p=None):
+    def choice(self, a, size=None, replace=True, p=None, legacy=False):
         """
         choice(a, size=None, replace=True, p=None)
 
@@ -1048,6 +1048,10 @@ cdef class RandomState:
             The probabilities associated with each entry in a.
             If not given the sample assumes a uniform distribution over all
             entries in a.
+        legacy : boolean, optional
+            Only relevant while replace==False, p==None, and size << len(a).
+            Preserves the output ordering of legacy versions of numpy
+            using a random seed, at the cost of significant loss in speed.
 
         Returns
         --------
@@ -1182,7 +1186,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size and not legacy:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1185,7 +1185,7 @@ cdef class RandomState:
                 if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > size:
                     idx = set()
                     while len(idx)<size:
-                        idx.add(int(self.randint(0, pop_size)))
+                        idx.update(self.randint(0, pop_size, size=size - len(idx)))
                     idx = np.array(list(idx))
                     self.shuffle(idx)
                 else:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,7 +1182,14 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                idx = self.permutation(pop_size)[:size]
+                if math.factorial(pop_size) < n**k:
+                    idx = set()
+                    while len(idx)<size:
+                        idx.add(self.randint(0, pop_size))
+                    idx = np.array(list(idx))
+                    np.shuffle(idx)
+                else:
+                    idx = self.permutation(pop_size)[:size]
                 if shape is not None:
                     idx.shape = shape
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -27,7 +27,7 @@ include "numpy.pxd"
 include "cpython/pycapsule.pxd"
 
 from libc cimport string
-from libcpp.set cimport set
+from libcpp.unordered_set cimport unordered_set
 
 cdef extern from "math.h":
     double exp(double x)
@@ -1186,7 +1186,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if small:
-                    cdef unsorted_set[np.int32] temp_idx()
+                    cdef unordered_set[np.int32] temp_idx()
                     while temp_idx.size() < size:
                         cdef int s = size - temp_idx.size();
                         cdef ndarray I = self.randint(0, pop_size, size=s, dtype=np.int32)

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,7 +1182,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if math.factorial(pop_size) < n**k:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) < k:
                     idx = set()
                     while len(idx)<size:
                         idx.add(self.randint(0, pop_size))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1183,7 +1183,7 @@ cdef class RandomState:
                 idx = found
             else:
                 if pop_size >= 3 and self.version > 0 and \
-                   (loggam(pop_size+1)-loggam(n-k))/np.log(n) > size:
+                   (loggam(pop_size+1)-loggam(pop_size-size))/np.log(pop_size) > size:
                     idx = set()
                     while len(idx)<size:
                         idx.update(self.randint(0, pop_size, size=size - len(idx)))

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -27,6 +27,7 @@ include "numpy.pxd"
 include "cpython/pycapsule.pxd"
 
 from libc cimport string
+from libcpp.set cimport set
 
 cdef extern from "math.h":
     double exp(double x)
@@ -1049,7 +1050,7 @@ cdef class RandomState:
             If not given the sample assumes a uniform distribution over all
             entries in a.
         small : boolean, optional
-            Speeds up operation when selecting a small sample from a much larger array. len(a) >> size
+            Speeds up operation when selecting a small sample from a much larger array. ``len(a) >> size``
 
         Returns
         --------
@@ -1185,11 +1186,14 @@ cdef class RandomState:
                 idx = found
             else:
                 if small:
-                    idx = set()
-                    while len(idx)<size:
-                        idx.update(self.randint(0, pop_size, size=size - len(idx)))
-                    idx = np.array(list(idx))
-                    self.shuffle(idx)
+                    cdef unsorted_set[np.int32] temp_idx()
+                    while temp_idx.size() < size:
+                        cdef int s = size - temp_idx.size();
+                        cdef ndarray I = self.randint(0, pop_size, size=s, dtype=np.int32)
+                        for i in range(s):
+                            temp_idx.insert(I[i])
+                    idx = np.array(list(temp_idx))
+
                 else:
                     idx = self.permutation(pop_size)[:size]
                 if shape is not None:

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1182,7 +1182,7 @@ cdef class RandomState:
                     n_uniq += new.size
                 idx = found
             else:
-                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) < k:
+                if (pop_size+.5)*np.log(pop_size+1)-pop_size-1+.5*np.log(2*np.pi) > k:
                     idx = set()
                     while len(idx)<size:
                         idx.add(self.randint(0, pop_size))


### PR DESCRIPTION
I previously made this pull request #9855, we did the math and found a threshold on which to use an O(N) subsample for random.choice given replacement=False, vs an O(n) (where N is the array size, and n is the sample size) algorithm. However, this broke the random seed, and then everyone went off on discussing how to fix this problem without breaking historical dependency.

Well, now I am suggesting we just leave it up to the user by putting a kwarg called "small" in np.random.choice, and set it to default False. Then we allow the user to choose when to use it if they notice a slowdown. We might later be able to depreciate this and use the automatic option if we get a version system for RandomState, or change the code to `(version > x and automatic_threshold) or small` after we get that figured out.