### PR TITLE
BUG: Fix missing NPY_VISIBILITY_HIDDEN on npy_longdouble_to_PyLong

### DIFF
--- a/numpy/core/src/private/npy_longdouble.c
+++ b/numpy/core/src/private/npy_longdouble.c
@@ -16,7 +16,7 @@
 /* Heavily derived from PyLong_FromDouble
  * Notably, we can't set the digits directly, so have to shift and or instead.
  */
-PyObject *
+NPY_VISIBILITY_HIDDEN PyObject *
 npy_longdouble_to_PyLong(npy_longdouble ldval)
 {
     PyObject *v;

--- a/numpy/core/src/private/npy_longdouble.h
+++ b/numpy/core/src/private/npy_longdouble.h
@@ -11,7 +11,7 @@
  * This performs the same task as PyLong_FromDouble, but for long doubles
  * which have a greater range.
  */
-NPY_NO_EXPORT PyObject *
+NPY_VISIBILITY_HIDDEN PyObject *
 npy_longdouble_to_PyLong(npy_longdouble ldval);
 
 #endif


### PR DESCRIPTION
Fixes #10648, regression in #9971

NPY_VISIBILITY_HIDDEN is used by memoverlap.{c,h}, so we should be using the same thing here

CircleCI fails because this is based on the commit that introduced the regression