### PR TITLE
MAINT: Remove duplicate implementation for aliased functions.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1895,54 +1895,6 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
                          out=out, **kwargs)
 
 
-def product(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
-    """
-    Return the product of array elements over a given axis.
-
-    See Also
-    --------
-    prod : equivalent function; see for details.
-
-    """
-    kwargs = {}
-    if keepdims is not np._NoValue:
-        kwargs['keepdims'] = keepdims
-    return um.multiply.reduce(a, axis=axis, dtype=dtype, out=out, **kwargs)
-
-
-def sometrue(a, axis=None, out=None, keepdims=np._NoValue):
-    """
-    Check whether some values are true.
-
-    Refer to `any` for full documentation.
-
-    See Also
-    --------
-    any : equivalent function
-
-    """
-    arr = asanyarray(a)
-    kwargs = {}
-    if keepdims is not np._NoValue:
-        kwargs['keepdims'] = keepdims
-    return arr.any(axis=axis, out=out, **kwargs)
-
-
-def alltrue(a, axis=None, out=None, keepdims=np._NoValue):
-    """
-    Check if all elements of input array are true.
-
-    See Also
-    --------
-    numpy.all : Equivalent function; see for details.
-
-    """
-    arr = asanyarray(a)
-    kwargs = {}
-    if keepdims is not np._NoValue:
-        kwargs['keepdims'] = keepdims
-    return arr.all(axis=axis, out=out, **kwargs)
-
 
 def any(a, axis=None, out=None, keepdims=np._NoValue):
     """
@@ -2176,19 +2128,6 @@ def cumsum(a, axis=None, dtype=None, out=None):
 
     """
     return _wrapfunc(a, 'cumsum', axis=axis, dtype=dtype, out=out)
-
-
-def cumproduct(a, axis=None, dtype=None, out=None):
-    """
-    Return the cumulative product over the given axis.
-
-
-    See Also
-    --------
-    cumprod : equivalent function; see for details.
-
-    """
-    return _wrapfunc(a, 'cumprod', axis=axis, dtype=dtype, out=out)
 
 
 def ptp(a, axis=None, out=None, keepdims=np._NoValue):
@@ -2706,62 +2645,6 @@ def ndim(a):
         return asarray(a).ndim
 
 
-def rank(a):
-    """
-    Return the number of dimensions of an array.
-
-    If `a` is not already an array, a conversion is attempted.
-    Scalars are zero dimensional.
-
-    .. note::
-        This function is deprecated in NumPy 1.9 to avoid confusion with
-        `numpy.linalg.matrix_rank`. The ``ndim`` attribute or function
-        should be used instead.
-
-    Parameters
-    ----------
-    a : array_like
-        Array whose number of dimensions is desired. If `a` is not an array,
-        a conversion is attempted.
-
-    Returns
-    -------
-    number_of_dimensions : int
-        The number of dimensions in the array.
-
-    See Also
-    --------
-    ndim : equivalent function
-    ndarray.ndim : equivalent property
-    shape : dimensions of array
-    ndarray.shape : dimensions of array
-
-    Notes
-    -----
-    In the old Numeric package, `rank` was the term used for the number of
-    dimensions, but in NumPy `ndim` is used instead.
-
-    Examples
-    --------
-    >>> np.rank([1,2,3])
-    1
-    >>> np.rank(np.array([[1,2,3],[4,5,6]]))
-    2
-    >>> np.rank(1)
-    0
-
-    """
-    # 2014-04-12, 1.9
-    warnings.warn(
-        "`rank` is deprecated; use the `ndim` attribute or function instead. "
-        "To find the rank of a matrix see `numpy.linalg.matrix_rank`.",
-        VisibleDeprecationWarning, stacklevel=2)
-    try:
-        return a.ndim
-    except AttributeError:
-        return asarray(a).ndim
-
-
 def size(a, axis=None):
     """
     Return the number of elements along a given axis.
@@ -3232,3 +3115,78 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
 
     return _methods._var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
                          **kwargs)
+
+
+# Aliases of other functions. These have their own definitions only so that
+# they can have unique docstrings.
+
+def product(*args, **kwargs):
+    """
+    Return the product of array elements over a given axis.
+
+    See Also
+    --------
+    prod : equivalent function; see for details.
+    """
+    return prod(*args, **kwargs)
+
+
+def cumproduct(*args, **kwargs):
+    """
+    Return the cumulative product over the given axis.
+
+    See Also
+    --------
+    cumprod : equivalent function; see for details.
+    """
+    return cumprod(*args, **kwargs)
+
+
+def sometrue(*args, **kwargs):
+    """
+    Check whether some values are true.
+
+    Refer to `any` for full documentation.
+
+    See Also
+    --------
+    any : equivalent function; see for details.
+    """
+    return any(*args, **kwargs)
+
+
+def alltrue(*args, **kwargs):
+    """
+    Check if all elements of input array are true.
+
+    See Also
+    --------
+    numpy.all : Equivalent function; see for details.
+    """
+    return all(*args, **kwargs)
+
+
+def rank(a):
+    """
+    Return the number of dimensions of an array.
+
+    .. note::
+        This function is deprecated in NumPy 1.9 to avoid confusion with
+        `numpy.linalg.matrix_rank`. The ``ndim`` attribute or function
+        should be used instead.
+
+    See Also
+    --------
+    ndim : equivalent non-deprecated function
+
+    Notes
+    -----
+    In the old Numeric package, `rank` was the term used for the number of
+    dimensions, but in NumPy `ndim` is used instead.
+    """
+    # 2014-04-12, 1.9
+    warnings.warn(
+        "`rank` is deprecated; use the `ndim` attribute or function instead. "
+        "To find the rank of a matrix see `numpy.linalg.matrix_rank`.",
+        VisibleDeprecationWarning, stacklevel=2)
+    return ndim(a)


### PR DESCRIPTION
Fixes #10651 by replacing the behaviour of `product` with that of `prod`.

Also group all the aliases together.