### PR TITLE
Fix linalg.norm with ord=numpy.inf

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2271,6 +2271,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
     """
     x = asarray(x)
 
+    if x.size == 0:
+        return 0
+    
     if not issubclass(x.dtype.type, (inexact, object_)):
         x = x.astype(float)
 


### PR DESCRIPTION
Fixed the error where linalg.norm with ord=numpy.inf does not work for empty array, with the solution specified inte the comments, namely creating a case that checks for such a possibility and returns the norm to be 0 as is should be for empty arrays.