### PR TITLE
 ENH: umath: don't make temporary copies for in-place accumulation

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -222,5 +222,13 @@ the user wants to perform a stable sort thus harming the readability.
 This change allows the user to specify kind='stable' thus clarifying
 the intent.
 
+Do not make temporary copies for in-place accumulation
+------------------------------------------------------
+When ufuncs perform accumulation they no longer make temporary copies because
+of the overlap between input an output, that is, the next element accumulated
+is added before the accumulated result is stored in its place, hence the
+overlap is safe. Avoiding the copy results in faster execution.
+
+
 Changes
 =======

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3215,9 +3215,15 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
          */
         ndim_iter = ndim;
         flags |= NPY_ITER_MULTI_INDEX;
-        /* Add some more flags */
-        op_flags[0] |= NPY_ITER_UPDATEIFCOPY|NPY_ITER_ALIGNED;
-        op_flags[1] |= NPY_ITER_COPY|NPY_ITER_ALIGNED;
+        /*
+         * Add some more flags.
+         *
+         * The accumulation outer loop is 'elementwise' over the array, so turn
+         * on NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE. That is, in-place
+         * accumulate(x, out=x) is safe to do without temporary copies.
+         */
+        op_flags[0] |= NPY_ITER_UPDATEIFCOPY|NPY_ITER_ALIGNED|NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+        op_flags[1] |= NPY_ITER_COPY|NPY_ITER_ALIGNED|NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
         op_dtypes_param = op_dtypes;
         op_dtypes[1] = op_dtypes[0];
         NPY_UF_DBG_PRINT("Allocating outer iterator\n");


### PR DESCRIPTION
Do the operation `ufunc.accumulate(x, out=x)` without making temporary copies. This only requires turning on the `NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE` flags for the input/output arrays in the accumulation.

<s>This assumes the ufunc innerloops are such that they can do in-place accumulations. This is not true since Numpy 1.13.0 as noted in gh-10664. I revert a problematic commit here, but maybe there is a better solution to this. In any case, **before merging this it's probably necessary to solve gh-10664**.</s> EDIT: gh-10664 was resolved

Before:
```
In [1]: tmp = np.random.random((13, 31, 5000))
In [2]: %timeit np.cumsum(tmp, axis=0)
5.16 ms ± 45.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In [3]: %timeit np.cumsum(tmp, out=tmp, axis=0)
11.8 ms ± 40.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
After:
```
In [1]: tmp = np.random.random((13, 31, 5000))
In [2]: %timeit np.cumsum(tmp, axis=0)
5.08 ms ± 14 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In [3]: %timeit np.cumsum(tmp, out=tmp, axis=0)
4.48 ms ± 148 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Fixes gh-10640