### PR TITLE
BUG: fix complex casting error in cov with aweights

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2309,7 +2309,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     else:
         X_T = (X*w).T
     c = dot(X, X_T.conj())
-    c *= 1. / np.float64(fact)
+    c *= np.true_divide(1, fact)
     return c.squeeze()
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1752,7 +1752,9 @@ class TestCov(object):
 
     def test_complex(self):
         x = np.array([[1, 2, 3], [1j, 2j, 3j]])
-        assert_allclose(cov(x), np.array([[1., -1.j], [1.j, 1.]]))
+        res = np.array([[1., -1.j], [1.j, 1.]])
+        assert_allclose(cov(x), res)
+        assert_allclose(cov(x, aweights=np.ones(3)), res)
 
     def test_xy(self):
         x = np.array([[1, 2, 3]])


### PR DESCRIPTION
When using cov with a complex input and with aweights specified, cov
will error as a result of trying to cast a complex value into a float64.
This comes about since average is used to calculate the sum of the
weights from aweights.  average returns the sum of weights as the same
type as its result, not the weights type.  For a complex input m, and
any type for aweights, this would result in a complex value for fact.
It appears the primary purpose of np.float64(fact) is to provide a NaN
value from the divide when fact is an integer zero.  This has been
replaced by using numpy.divide to replicate the same behavior, but to
also handle complex types.