### PR TITLE
BUG: Fix norm type promotion

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -24,7 +24,7 @@ from numpy.core import (
     add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
     finfo, errstate, geterrobj, longdouble, moveaxis, amin, amax, product, abs,
     broadcast, atleast_2d, intp, asanyarray, object_, ones, matmul,
-    swapaxes, divide, count_nonzero, ndarray, isnan
+    swapaxes, divide, count_nonzero, ndarray, isnan, reciprocal
 )
 from numpy.core.multiarray import normalize_axis_index
 from numpy.lib import triu, asfarray
@@ -2325,7 +2325,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             absx = abs(x)
             absx **= ord
             ret = add.reduce(absx, axis=axis, keepdims=keepdims)
-            ret **= (1 / ord)
+            ret **= reciprocal(ord, dtype=ret.dtype)
             return ret
     elif len(axis) == 2:
         row_axis, col_axis = axis


### PR DESCRIPTION
I tested `np.linalg.norm` with the following code, but it seems the type is not preserved correctly.

```py
import numpy as np

for dtype in [np.float16, np.float32, np.float64]:
    a = np.ones((2,), dtype=dtype)
    ret = np.linalg.norm(a, 3, None, False)
    if not (dtype == ret.dtype):
        print('expected', dtype, 'but got', ret.dtype)
```

Without this fix (NumPy 1.14.1):

```
expected <class 'numpy.float16'> but got float64
expected <class 'numpy.float32'> but got float64
```

With NumPy 1.14.1 + this fix, nothing should be printed.


Related to https://github.com/numpy/numpy/pull/10368 and https://github.com/cupy/cupy/pull/875#discussion_r170492773