### PR TITLE
DEP: Deprecate np.sum(generator)

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -36,6 +36,11 @@ Deprecations
   * `np.ma.load`, `np.ma.dump` - these functions already failed on python 3,
     when called with a string.
 
+* Giving a generator to `np.sum` is now deprecated. This was undocumented, but
+  worked. Previously, it would calculate the sum of the generator expression.
+  In the future, it might return a different result. Use `np.sum(np.from_iter(generator))`
+  or the built-in Python `sum` instead.
+
 
 Future Changes
 ==============

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1881,6 +1881,12 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     if keepdims is not np._NoValue:
         kwargs['keepdims'] = keepdims
     if isinstance(a, _gentype):
+        # 2018-02-25, 1.15.0
+        warnings.warn(
+            "Calling np.sum(generator) is deprecated, and in the future will give a different result. "
+            "Use np.sum(np.from_iter(generator)) or the python sum builtin instead.",
+            DeprecationWarning, stacklevel=2)
+
         res = _sum_(a)
         if out is not None:
             out[...] = res

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -481,5 +481,11 @@ class TestBincount(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.bincount([1, 2, 3], minlength=None))
 
 
+class TestGeneratorSum(_DeprecationTestCase):
+    # 2018-02-25, 1.15.0
+    def test_generator_sum(self):
+        self.assert_deprecated(np.sum, args=((i for i in range(5)),))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes #10652

Introduced in a13aad3ac33b629f3e696b4d4d5dbf4b5605d567

(milestoned only to indicate that the release notes are 1.15)

I think the original rationale for this change was to allow the following change to not break this code
```diff
+from numpy import *

 def my_func(n):
     return sum(i*i for i in range(n))
```

Reasons to deprecate it:
* `sum` is the only function to do this, even though `any` and `all` also shadow builtins
* It's not documented
* It's not consistent with `np.array(generator).sum()`, which already fails.