### PR TITLE
DOC/MAINT: More misc. typos

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -102,7 +102,7 @@ to forgo the signing in the future::
     $ twine upload -s release/installers/numpy-1.14.1.zip  # Upload last.
 
 If one of the commands breaks in the middle, which is not uncommon, you may
-need to selectively upload the remaining files becuase PyPI does not allow the
+need to selectively upload the remaining files because PyPI does not allow the
 same file to be uploaded twice. The source file should be uploaded last to
 avoid synchronization problems if pip users access the files while this is in
 process. Note that PyPI only allows a single source distribution, here we have

--- a/doc/changelog/1.14.1-changelog.rst
+++ b/doc/changelog/1.14.1-changelog.rst
@@ -58,6 +58,6 @@ A total of 36 pull requests were merged for this release.
 * `#10610 <https://github.com/numpy/numpy/pull/10610>`__: BUG: Align type definition with generated lapack
 * `#10612 <https://github.com/numpy/numpy/pull/10612>`__: BUG/ENH: Improve output for structured non-void types
 * `#10622 <https://github.com/numpy/numpy/pull/10622>`__: BUG: deallocate recursive closure in arrayprint.py (1.14 backport)
-* `#10624 <https://github.com/numpy/numpy/pull/10624>`__: BUG: Correctly identify comma seperated dtype strings
+* `#10624 <https://github.com/numpy/numpy/pull/10624>`__: BUG: Correctly identify comma separated dtype strings
 * `#10629 <https://github.com/numpy/numpy/pull/10629>`__: BUG: deallocate recursive closure in arrayprint.py (backport...
 * `#10630 <https://github.com/numpy/numpy/pull/10630>`__: REL: Prepare for 1.14.1 release.

--- a/doc/release/1.14.1-notes.rst
+++ b/doc/release/1.14.1-notes.rst
@@ -87,6 +87,6 @@ A total of 36 pull requests were merged for this release.
 * `#10610 <https://github.com/numpy/numpy/pull/10610>`__: BUG: Align type definition with generated lapack
 * `#10612 <https://github.com/numpy/numpy/pull/10612>`__: BUG/ENH: Improve output for structured non-void types
 * `#10622 <https://github.com/numpy/numpy/pull/10622>`__: BUG: deallocate recursive closure in arrayprint.py (1.14 backport)
-* `#10624 <https://github.com/numpy/numpy/pull/10624>`__: BUG: Correctly identify comma seperated dtype strings
+* `#10624 <https://github.com/numpy/numpy/pull/10624>`__: BUG: Correctly identify comma separated dtype strings
 * `#10629 <https://github.com/numpy/numpy/pull/10629>`__: BUG: deallocate recursive closure in arrayprint.py (backport...
 * `#10630 <https://github.com/numpy/numpy/pull/10630>`__: REL: Prepare for 1.14.1 release.

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -210,7 +210,7 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
                     PyObject **normal_args, PyObject **normal_kwds)
 {
     /*
-     * ufunc.reduceat(a, indicies[, axis, dtype, out])
+     * ufunc.reduceat(a, indices[, axis, dtype, out])
      * the number of arguments has been checked in PyUFunc_GenericReduction.
      */
     npy_intp i;
@@ -224,7 +224,7 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
                      "arguments but %"NPY_INTP_FMT" were given", nargs);
         return -1;
     }
-    /* a and indicies */
+    /* a and indices */
     *normal_args = PyTuple_GetSlice(args, 0, 2);
     if (*normal_args == NULL) {
         return -1;

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -808,7 +808,7 @@ class TestMultiIndexingAutomated(object):
             `arr[indices]` should be identical.
         no_copy : bool
             Whether the indexing operation requires a copy. If this is `True`,
-            `np.may_share_memory(arr, arr[indicies])` should be `True` (with
+            `np.may_share_memory(arr, arr[indices])` should be `True` (with
             some exceptions for scalars and possibly 0-d arrays).
 
         Notes

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1520,9 +1520,9 @@ class TestMethods(object):
             assert_equal(c, ai, msg)
 
         # test sorting of complex arrays requiring byte-swapping, gh-5441
-        for endianess in '<>':
+        for endianness in '<>':
             for dt in np.typecodes['Complex']:
-                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianess + dt)
+                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianness + dt)
                 c = arr.copy()
                 c.sort()
                 msg = 'byte-swapped complex sort, dtype={0}'.format(dt)
@@ -1778,9 +1778,9 @@ class TestMethods(object):
             assert_equal(bi.copy().argsort(kind=kind), b, msg)
 
         # test argsort of complex arrays requiring byte-swapping, gh-5441
-        for endianess in '<>':
+        for endianness in '<>':
             for dt in np.typecodes['Complex']:
-                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianess + dt)
+                arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianness + dt)
                 msg = 'byte-swapped complex argsort, dtype={0}'.format(dt)
                 assert_equal(arr.argsort(),
                              np.arange(len(arr), dtype=np.intp), msg)

--- a/numpy/testing/nose_tools/parameterized.py
+++ b/numpy/testing/nose_tools/parameterized.py
@@ -456,8 +456,8 @@ class parameterized(object):
             frame = stack[1]
             frame_locals = frame[0].f_locals
 
-            paramters = cls.input_as_callable(input)()
-            for num, p in enumerate(paramters):
+            parameters = cls.input_as_callable(input)()
+            for num, p in enumerate(parameters):
                 name = name_func(f, num, p)
                 frame_locals[name] = cls.param_as_standalone_func(p, f, name)
                 frame_locals[name].__doc__ = doc_func(f, num, p)


### PR DESCRIPTION
Found via `codespell` and `grep`  
Some of these are obviously source changes, so please review closely. Thanks