### PR TITLE
ENH: Allow dtype field names to be ascii encoded unicode in Python2

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -131,5 +131,16 @@ longer supported, as ``np.interp(object_array_nd)`` was never supported anyway.
 As a result of this change, the ``period`` argument can now be used on 0d
 arrays.
 
+Allow dtype field names to be unicode in Python 2
+---------------------------------------------------------------
+Previously ``np.dtype([(u'name', float)])`` would raise a ``TypeError`` in
+Python 2, as only bytestrings were allowed in field names. Now any unicode
+string field names will be encoded with the ``ascii`` codec, raising a
+``UnicodeEncodeError`` upon failure.
+
+This change makes it easier to write Python 2/3 compatible code using
+``from __future__ import unicode_literals``, which previously would cause
+string literal field names to raise a TypeError in Python 2.
+
 Changes
 =======

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -437,7 +437,11 @@ _convert_from_array_descr(PyObject *obj, int align)
             goto fail;
         }
         name = PyTuple_GET_ITEM(item, 0);
+#if defined(NPY_PY3K)
         if (PyUString_Check(name)) {
+#else
+        if ((PyUString_Check(name) || PyUnicode_Check(name))) {
+#endif
             title = NULL;
         }
         else if (PyTuple_Check(name)) {
@@ -446,7 +450,11 @@ _convert_from_array_descr(PyObject *obj, int align)
             }
             title = PyTuple_GET_ITEM(name, 0);
             name = PyTuple_GET_ITEM(name, 1);
+#if defined(NPY_PY3K)
             if (!PyUString_Check(name)) {
+#else
+            if (!(PyUString_Check(name) || PyUnicode_Check(name))) {
+#endif
                 goto fail;
             }
         }
@@ -457,6 +465,17 @@ _convert_from_array_descr(PyObject *obj, int align)
         /* Insert name into nameslist */
         Py_INCREF(name);
 
+        
+#if !defined(NPY_PY3)
+        /* convert unicode name to ascii on Python 2 if possible */ 
+        if PyUnicode_Check(name){
+            Py_DECREF(name);
+            name = PyUnicode_AsASCIIString(name);
+            if (name == NULL) { 
+                goto fail;
+            }
+        }
+#endif
         if (PyUString_GET_SIZE(name) == 0) {
             Py_DECREF(name);
             if (title == NULL) {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -457,7 +457,7 @@ _convert_from_array_descr(PyObject *obj, int align)
         /* Insert name into nameslist */
         Py_INCREF(name);
 
-#if !defined(NPY_PY3)
+#if !defined(NPY_PY3K)
         /* convert unicode name to ascii on Python 2 if possible */ 
         if (PyUnicode_Check(name)) {
             PyObject *tmp;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -460,10 +460,12 @@ _convert_from_array_descr(PyObject *obj, int align)
 #if !defined(NPY_PY3)
         /* convert unicode name to ascii on Python 2 if possible */ 
         if (PyUnicode_Check(name)) {
-            name = PyUnicode_AsASCIIString(name);
+            PyObject *tmp;
+            tmp = PyUnicode_AsASCIIString(name);
             Py_DECREF(name);
-            if (name == NULL) { 
+            if (tmp == NULL) { 
                 goto fail;
+            name = tmp;
             }
         }
 #endif

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -437,11 +437,7 @@ _convert_from_array_descr(PyObject *obj, int align)
             goto fail;
         }
         name = PyTuple_GET_ITEM(item, 0);
-#if defined(NPY_PY3K)
-        if (PyUString_Check(name)) {
-#else
-        if ((PyUString_Check(name) || PyUnicode_Check(name))) {
-#endif
+        if (PyBaseString_Check(name)) {
             title = NULL;
         }
         else if (PyTuple_Check(name)) {
@@ -450,11 +446,7 @@ _convert_from_array_descr(PyObject *obj, int align)
             }
             title = PyTuple_GET_ITEM(name, 0);
             name = PyTuple_GET_ITEM(name, 1);
-#if defined(NPY_PY3K)
-            if (!PyUString_Check(name)) {
-#else
-            if (!(PyUString_Check(name) || PyUnicode_Check(name))) {
-#endif
+            if (!PyBaseString_Check(name)) {
                 goto fail;
             }
         }
@@ -468,9 +460,9 @@ _convert_from_array_descr(PyObject *obj, int align)
         
 #if !defined(NPY_PY3)
         /* convert unicode name to ascii on Python 2 if possible */ 
-        if PyUnicode_Check(name){
-            Py_DECREF(name);
+        if (PyUnicode_Check(name)) {
             name = PyUnicode_AsASCIIString(name);
+            Py_DECREF(name);
             if (name == NULL) { 
                 goto fail;
             }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -465,8 +465,8 @@ _convert_from_array_descr(PyObject *obj, int align)
             Py_DECREF(name);
             if (tmp == NULL) { 
                 goto fail;
-            name = tmp;
             }
+            name = tmp;
         }
 #endif
         if (PyUString_GET_SIZE(name) == 0) {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -457,7 +457,6 @@ _convert_from_array_descr(PyObject *obj, int align)
         /* Insert name into nameslist */
         Py_INCREF(name);
 
-        
 #if !defined(NPY_PY3)
         /* convert unicode name to ascii on Python 2 if possible */ 
         if (PyUnicode_Check(name)) {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -460,8 +460,7 @@ _convert_from_array_descr(PyObject *obj, int align)
 #if !defined(NPY_PY3K)
         /* convert unicode name to ascii on Python 2 if possible */ 
         if (PyUnicode_Check(name)) {
-            PyObject *tmp;
-            tmp = PyUnicode_AsASCIIString(name);
+            PyObject *tmp = PyUnicode_AsASCIIString(name);
             Py_DECREF(name);
             if (tmp == NULL) { 
                 goto fail;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4693,10 +4693,15 @@ class TestRecord(object):
             y['a']
 
         def test_unicode_field_names(self):
-            # Unicode field names are not allowed on Py2
-            title = u'b'
-            assert_raises(TypeError, np.dtype, [(title, int)])
-            assert_raises(TypeError, np.dtype, [(('a', title), int)])
+            # Unicode field names are converted to ascii on Python 2:
+            encodable_title = u'b'
+            assert_equal(np.dtype([(encodable_title, int)]).names[0], b'b')
+            assert_equal(np.dtype([(('a', encodable_title), int)]).names[0], b'b')
+
+            # But raises UnicodeEncodeError if it can't be encoded:
+            nonencodable_title = u'\uc3bc'
+            assert_raises(UnicodeEncodeError, np.dtype, [(nonencodable_title, int)])
+            assert_raises(UnicodeEncodeError, np.dtype, [(('a', nonencodable_title), int)])
 
     def test_field_names(self):
         # Test unicode and 8-bit / byte strings can be used

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4694,14 +4694,14 @@ class TestRecord(object):
 
         def test_unicode_field_names(self):
             # Unicode field names are converted to ascii on Python 2:
-            encodable_title = u'b'
-            assert_equal(np.dtype([(encodable_title, int)]).names[0], b'b')
-            assert_equal(np.dtype([(('a', encodable_title), int)]).names[0], b'b')
+            encodable_name = u'b'
+            assert_equal(np.dtype([(encodable_name, int)]).names[0], b'b')
+            assert_equal(np.dtype([(('a', encodable_name), int)]).names[0], b'b')
 
             # But raises UnicodeEncodeError if it can't be encoded:
-            nonencodable_title = u'\uc3bc'
-            assert_raises(UnicodeEncodeError, np.dtype, [(nonencodable_title, int)])
-            assert_raises(UnicodeEncodeError, np.dtype, [(('a', nonencodable_title), int)])
+            nonencodable_name = u'\uc3bc'
+            assert_raises(UnicodeEncodeError, np.dtype, [(encodable_name, int)])
+            assert_raises(UnicodeEncodeError, np.dtype, [(('a', encodable_name), int)])
 
     def test_field_names(self):
         # Test unicode and 8-bit / byte strings can be used

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4700,8 +4700,8 @@ class TestRecord(object):
 
             # But raises UnicodeEncodeError if it can't be encoded:
             nonencodable_name = u'\uc3bc'
-            assert_raises(UnicodeEncodeError, np.dtype, [(encodable_name, int)])
-            assert_raises(UnicodeEncodeError, np.dtype, [(('a', encodable_name), int)])
+            assert_raises(UnicodeEncodeError, np.dtype, [(nonencodable_name, int)])
+            assert_raises(UnicodeEncodeError, np.dtype, [(('a', nonencodable_name), int)])
 
     def test_field_names(self):
         # Test unicode and 8-bit / byte strings can be used


### PR DESCRIPTION
(#2407)

Allow unicode names in record arrays when datatype specified as tuples in Python 2.
Name is encoded as ascii if possible, raising an exception if not.

The result passes round-tripping with pickle

```python
# -*- coding: UTF-8 -*-
from __future__ import unicode_literals, print_function
import numpy as np
import cPickle as pickle

x = np.zeros(1, dtype=[('test', int)])
print('created array:', repr(x))

y = pickle.loads(pickle.dumps(x))
print('round-tripped pickle:', repr(y))
assert x == y

print('should raise an error now...')
x = np.zeros(1, dtype=[('tëßt', int)])

```

Result:
```
created array: array([(0,)], dtype=[('test', '<i8')])
round-tripped pickle: array([(0,)], dtype=[('test', '<i8')])
should raise an error now...
Traceback (most recent call last):
  File "12.py", line 18, in <module>
    x = np.zeros(1, dtype=[('tëßt', int)])
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-2: ordinal not in range(128)
```
