### PR TITLE
BUG: Further back-compat fix for subclassed array repr

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -438,14 +438,15 @@ def _array2string(a, options, separator=' ', prefix=""):
     # The formatter __init__s in _get_format_function cannot deal with
     # subclasses yet, and we also need to avoid recursion issues in
     # _formatArray with subclasses which return 0d arrays in place of scalars
-    a = asarray(a)
+    data = asarray(a)
+    if a.shape == ():
+        a = data
 
     if a.size > options['threshold']:
         summary_insert = "..."
-        data = _leading_trailing(a, options['edgeitems'])
+        data = _leading_trailing(data, options['edgeitems'])
     else:
         summary_insert = ""
-        data = a
 
     # find the right formatting function for the array
     format_function = _get_format_function(data, **options)


### PR DESCRIPTION
Fixes #10663 

This special-cases 0d arrays so that, only for 0ds, we extract scalars using the ndarray `__getitem__` instead of any subclass's `__getitem__`. In other words it reverts #10544 except for 0d arrays.

This way we avoid the infinite recursion for subclassed-0d arrays that return 0ds instead of scalars when indexed, yet still pass subclassed-0d values on to the formatter functions when printing n-d array elements.

This PR does break two tests involving 0d-subclass-object arrays added in #10544, but those failed anyway in <1.13 and 1.14.0. That is, `sub([None, None])` prints as `sub([sub(None, dtype=object), sub(None, dtype=object)], dtype=object)`. I don't see a way of fixing those while not breaking the subclass-nd formatting behavior, which is more important.