### PR TITLE
BUG: fixes #4701 related to numpy.asscalar

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -486,7 +486,10 @@ def asscalar(a):
     24
 
     """
-    return a.item()
+    try:
+        return a.item()
+    except AttributeError:
+        return np.asarray(a).item()
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Allows numpy.asscalar to pass scalars