### PR TITLE
DOC: Possible error using StringIO in example. 

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -858,7 +858,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
     Examples
     --------
-    >>> from io import StringIO   # StringIO behaves like a file object
+    >>> from StringIO import StringIO   # StringIO behaves like a file object
     >>> c = StringIO("0 1\\n2 3")
     >>> np.loadtxt(c)
     array([[ 0.,  1.],

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -858,7 +858,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
     Examples
     --------
-    >>> from StringIO import StringIO   # StringIO behaves like a file object
+    >>> from io import StringIO   # StringIO behaves like a file object
     >>> c = StringIO("0 1\\n2 3")
     >>> np.loadtxt(c)
     array([[ 0.,  1.],


### PR DESCRIPTION
sample code `from io import StringIO` does not work on python 2.7.14, should be change to `from StringIO import StringIO`