### PR TITLE
BUG: Fix problems with linalg.norm with ord=numpy.inf 

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2302,6 +2302,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
             raise TypeError("'axis' must be None, an integer or a tuple of integers")
         axis = (axis,)
 
+    #Deals with the edge case where if the ord is infinite and empty then the function does not output 0 as it should for any empty array.     
+    if x.size == 0:
+        return 0     
+
     if len(axis) == 1:
         if ord == Inf:
             return abs(x).max(axis=axis, keepdims=keepdims)
@@ -2367,7 +2371,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         return ret
     else:
         raise ValueError("Improper number of dimensions to norm.")
-
+          
 
 # multi_dot
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1124,6 +1124,7 @@ class _TestNorm(object):
         assert_equal(norm([]), 0.0)
         assert_equal(norm(array([], dtype=self.dt)), 0.0)
         assert_equal(norm(atleast_2d(array([], dtype=self.dt))), 0.0)
+        assert_equal(norm(array([]),inf))
 
     def test_vector_return_type(self):
         a = np.array([1, 0, 1])


### PR DESCRIPTION
Placed the fix in a location so that other edge cases are not incorrect, and added a test to check for the specific edge case.

Closes #10655