### PR TITLE
BLD: Add configuration changes to allow cross platform builds for iOS.

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -20,7 +20,7 @@ New functions
 
     >>> with np.printoptions(precision=2):
     ...     print(np.array([2.0])) / 3
-    [0.67] 
+    [0.67]
 
 
 Deprecations
@@ -58,6 +58,18 @@ These compute the greatest common divisor, and lowest common multiple,
 respectively. These work on all the numpy integer types, as well as the
 builtin arbitrary-precision `Decimal` and `long` types.
 
+Support for cross-platform builds for iOS
+-----------------------------------------
+
+The build system has been modified to add support for the
+``_PYTHON_HOST_PLATFORM`` environment variable, used by ``distutils`` when
+compiling on one platform for another platform. This makes it possible to
+compile NumPy for iOS targets.
+
+This only enables you to compile NumPy for one specific platform at a time.
+Creating a full iOS-compatible NumPy package requires building for the 5
+architectures supported by iOS (i386, x86_64, armv7, armv7s and arm64), and
+combining these 5 compiled builds products into a single "fat" binary.
 
 Improvements
 ============

--- a/numpy/_build_utils/apple_accelerate.py
+++ b/numpy/_build_utils/apple_accelerate.py
@@ -8,7 +8,12 @@ __all__ = ['uses_accelerate_framework', 'get_sgemv_fix']
 
 def uses_accelerate_framework(info):
     """ Returns True if Accelerate framework is used for BLAS/LAPACK """
+    # If we're not building on Darwin (macOS), don't use Accelerate
     if sys.platform != "darwin":
+        return False
+    # If we're building on macOS, but targeting a different platform,
+    # don't use Accelerate.
+    if os.getenv('_PYTHON_HOST_PLATFORM', None):
         return False
     r_accelerate = re.compile("Accelerate")
     extra_link_args = info.get('extra_link_args', '')

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -41,7 +41,7 @@ PyArray_SetStringFunction(PyObject *op, int repr)
  * XXX we do this in multiple places; time for a string library?
  */
 static char *
-extend(char **strp, Py_ssize_t n, Py_ssize_t *maxp)
+extend_str(char **strp, Py_ssize_t n, Py_ssize_t *maxp)
 {
     char *str = *strp;
     Py_ssize_t new_cap;
@@ -71,7 +71,7 @@ dump_data(char **string, Py_ssize_t *n, Py_ssize_t *max_n, char *data, int nd,
     npy_intp i, N, ret = 0;
 
 #define CHECK_MEMORY do {                           \
-        if (extend(string, *n, max_n) == NULL) {    \
+        if (extend_str(string, *n, max_n) == NULL) {    \
             ret = -1;                               \
             goto end;                               \
         }                                           \

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -219,21 +219,21 @@ if sys.platform == 'win32':
     _lib_dirs = [
         'lib',
     ]
-    
+
     _include_dirs = [d.replace('/', os.sep) for d in _include_dirs]
     _lib_dirs = [d.replace('/', os.sep) for d in _lib_dirs]
     def add_system_root(library_root):
         """Add a package manager root to the include directories"""
         global default_lib_dirs
         global default_include_dirs
-        
+
         library_root = os.path.normpath(library_root)
- 
+
         default_lib_dirs.extend(
             os.path.join(library_root, d) for d in _lib_dirs)
         default_include_dirs.extend(
             os.path.join(library_root, d) for d in _include_dirs)
-    
+
     if sys.version_info >= (3, 3):
         # VCpkg is the de-facto package manager on windows for C/C++
         # libraries. If it is on the PATH, then we append its paths here.
@@ -247,7 +247,7 @@ if sys.platform == 'win32':
             else:
                 specifier = 'x64'
 
-            vcpkg_installed = os.path.join(vcpkg_dir, 'installed') 
+            vcpkg_installed = os.path.join(vcpkg_dir, 'installed')
             for vcpkg_root in [
                 os.path.join(vcpkg_installed, specifier + '-windows'),
                 os.path.join(vcpkg_installed, specifier + '-windows-static'),
@@ -260,7 +260,7 @@ if sys.platform == 'win32':
             conda_dir = os.path.dirname(conda)
             add_system_root(os.path.join(conda_dir, '..', 'Library'))
             add_system_root(os.path.join(conda_dir, 'Library'))
-                        
+
 else:
     default_lib_dirs = libpaths(['/usr/local/lib', '/opt/lib', '/usr/lib',
                                  '/opt/local/lib', '/sw/lib'], platform_bits)
@@ -1551,7 +1551,9 @@ class lapack_opt_info(system_info):
         if not atlas_info:
             atlas_info = get_info('atlas')
 
-        if sys.platform == 'darwin' and not (atlas_info or openblas_info or
+        if sys.platform == 'darwin' \
+                and not os.getenv('_PYTHON_HOST_PLATFORM', None) \
+                and not (atlas_info or openblas_info or
                                              lapack_mkl_info):
             # Use the system lapack from Accelerate or vecLib under OSX
             args = []
@@ -1657,7 +1659,9 @@ class blas_opt_info(system_info):
         if not atlas_info:
             atlas_info = get_info('atlas_blas')
 
-        if sys.platform == 'darwin' and not (atlas_info or openblas_info or
+        if sys.platform == 'darwin' \
+                and not os.getenv('_PYTHON_HOST_PLATFORM', None) \
+                and not (atlas_info or openblas_info or
                                              blas_mkl_info or blis_info):
             # Use the system BLAS from Accelerate or vecLib under OSX
             args = []

--- a/numpy/linalg/lapack_lite/f2c.h
+++ b/numpy/linalg/lapack_lite/f2c.h
@@ -7,6 +7,8 @@
 #ifndef F2C_INCLUDE
 #define F2C_INCLUDE
 
+#include <math.h>
+
 typedef int integer;
 typedef char *address;
 typedef short int shortint;


### PR DESCRIPTION
When building NumPy for iOS, you build on macOS, with compiler flags to target iOS or the iOS simulator. However, setup.py runs on macOS, so sys.platform == 'darwin', regardless of the platform being targetted.

distutils provides an environment variable - _PYTHON_HOST_PLATFORM - to indicate when you are building for a different platform. This patches uses that variable to identify cross-platform builds and disable macOS specific features.

The patch also renames an internal method (extend) in multifunc/strfuncs.c to avoid a collision with a symbol in iOS's standard library, and includes math.h in the f2c headers to avoid errors about undefined symbols.