### PR TITLE
ENH: Adding matmul equivalent of multi_dot (Issue #8719)

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -486,7 +486,10 @@ def asscalar(a):
     24
 
     """
-    return a.item()
+    try:
+        return a.item()
+    except AttributeError:
+        return np.asarray(a).item()
 
 #-----------------------------------------------------------------------------
 

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -486,10 +486,9 @@ def asscalar(a):
     24
 
     """
-    try:
-        return a.item()
-    except AttributeError:
-        return np.asarray(a).item()
+
+    return a.item()
+
 
 #-----------------------------------------------------------------------------
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -194,11 +194,6 @@ def _assertRank2(*arrays):
             raise LinAlgError('%d-dimensional array given. Array must be '
                     'two-dimensional' % a.ndim)
 
-def _assertRank3(*arrays):
-    for a in arrays:
-        if a.ndim != 3:
-            raise LinAlgError('%d-dimensional array given. Array must be '
-                    'three-dimensional' % a.ndim)
 
 def _assertRankAtLeast2(*arrays):
     for a in arrays:

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -24,7 +24,7 @@ from numpy.core import (
     add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
     finfo, errstate, geterrobj, longdouble, moveaxis, amin, amax, product, abs,
     broadcast, atleast_2d, intp, asanyarray, object_, ones, matmul,
-    swapaxes, divide, count_nonzero, ndarray, isnan
+    swapaxes, divide, count_nonzero, ndarray, isnan, prod
 )
 from numpy.core.multiarray import normalize_axis_index
 from numpy.lib import triu, asfarray

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -23,7 +23,7 @@ from numpy.core import (
     csingle, cdouble, inexact, complexfloating, newaxis, ravel, all, Inf, dot,
     add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
     finfo, errstate, geterrobj, longdouble, moveaxis, amin, amax, product, abs,
-    broadcast, atleast_2d, intp, asanyarray, object_, ones, matmul,
+    broadcast, atleast_2d, atleast_1d, intp, asanyarray, object_, ones, matmul,
     swapaxes, divide, count_nonzero, ndarray, isnan, prod
 )
 from numpy.core.multiarray import normalize_axis_index

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2478,12 +2478,8 @@ def multi_dot(arrays):
         result = _multi_dot(arrays, order, 0, n - 1)
 
     # return proper shape
-    if ndim_first == 1 and ndim_last == 1:
-        return result[0, 0]  # scalar
-    elif ndim_first == 1 or ndim_last == 1:
-        return result.ravel()  # 1-D
-    else:
-        return result
+    
+    return atleast_1d(result)
 
 
 def _multi_dot_three(A, B, C):

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2495,9 +2495,9 @@ def _multi_dot_three(A, B, C):
     b1c0, c1 = C.shape[-2:]
     dim = [prod(A.shape[:-2]), prod(B.shape[:-2]), prod(B.shape[:-2]) ]
     # cost1 = cost((AB)C) = a0*a1b0*b1c0 + a0*b1c0*c1
-    cost1 = a0 * b1c0 * max(dim[0:1]) * (a1b0 + c1 * dim[2])
+    cost1 = a0 * b1c0 * max(dim[0:2]) * (a1b0 + c1 * dim[2])
     # cost2 = cost(A(BC)) = a1b0*b1c0*c1 + a0*a1b0*c1
-    cost2 = a1b0 * c1 * dim[0] * (a0 + b1c0 * max(dim[1:2]))
+    cost2 = a1b0 * c1 * dim[0] * (a0 + b1c0 * max(dim[1:3]))
 
     if cost1 < cost2:
         return matmul(matmul(A, B), C)
@@ -2532,7 +2532,7 @@ def _multi_dot_matrix_chain_order(arrays, return_costs=False):
             j = i + l
             m[i, j] = Inf
             for k in range(i, j):
-                q = m[i, k] + m[k+1, j] + p[i]*p[k+1]*p[j+1]*max(dim[i:j])
+                q = m[i, k] + m[k+1, j] + p[i]*p[k+1]*p[j+1]*max(dim[i:j+1])
                 if q < m[i, j]:
                     m[i, j] = q
                     s[i, j] = k  # Note that Cormen uses 1-based index

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2383,8 +2383,9 @@ def multi_dot(arrays):
 
     If the first argument is 1-D it is treated as a row vector.
     If the last argument is 1-D it is treated as a column vector.
-    If one of the other arguments is N-D, N>2, it is treated as a stack of matrices and broadcast accordingly
-    All other arguments must be 2-D.
+    All arguments other than the first and last must be atleast 2-D.
+    If any of the arguments is N-D, N>2, it is treated as a stack of matrices and broadcast accordingly
+    
 
     Think of `multi_dot` as::
 
@@ -2396,8 +2397,9 @@ def multi_dot(arrays):
     arrays : sequence of array_like
         If the first argument is 1-D it is treated as row vector.
         If the last argument is 1-D it is treated as column vector.
-        If one of the other arguments is N-D, N>2, it is treated as a stack of matrices and broadcast accordingly
-        All other arguments must be 2-D.
+        All arguments other than the first and last must be atleast 2-D.
+        If any of the arguments is N-D, N>2, it is treated as a stack of matrices and broadcast accordingly
+        
 
     Returns
     -------
@@ -2511,13 +2513,6 @@ def _multi_dot_matrix_chain_order(arrays, return_costs=False):
     multiplication.
 
     Also return the cost matrix if `return_costs` is `True`
-
-    The implementation CLOSELY follows Cormen, "Introduction to Algorithms",
-    Chapter 15.2, p. 370-378.  Note that Cormen uses 1-based indices.
-
-        cost[i, j] = min([
-            cost[prefix] + cost[suffix] + cost_mult(prefix, suffix)
-            for k in range(i, j)])
 
     """
     n = len(arrays)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1701,54 +1701,77 @@ def test_xerbla_override():
 
 class TestMultiDot(object):
 
-    def test_basic_function_with_three_arguments(self):
+    def test_basic_function_with_three_arguments_2D(self):
         # multi_dot with three arguments uses a fast hand coded algorithm to
-        # determine the optimal order. Therefore test it separately.
+        # determine the optimal order. Therefore test it separately. 
+        # test when all arguments are 2D
         A = np.random.random((6, 2))
         B = np.random.random((2, 6))
         C = np.random.random((6, 2))
 
-        assert_almost_equal(multi_dot([A, B, C]), A.dot(B).dot(C))
-        assert_almost_equal(multi_dot([A, B, C]), np.dot(A, np.dot(B, C)))
+        #assert_almost_equal(multi_dot([A, B, C]), A.matmul(B).matmul(C))
+        assert_almost_equal(multi_dot([A, B, C]), np.matmul(A, np.matmul(B, C)))
+        
+    def test_basic_function_with_three_arguments_ND(self):
+        # multi_dot with three arguments uses a fast hand coded algorithm to
+        # determine the optimal order. Therefore test it separately.
+        # test when N-D (N>2) arguments are used.
+        A = np.random.random((6, 2))
+        B = np.random.random((2, 3, 2, 6))
+        C = np.random.random((3, 6, 2))
 
-    def test_basic_function_with_dynamic_programing_optimization(self):
+        #assert_almost_equal(multi_dot([A, B, C]), A.matmul(B).matmul(C))
+        assert_almost_equal(multi_dot([A, B, C]), np.matmul(A, np.matmul(B, C)))
+
+    def test_basic_function_with_dynamic_programing_optimization_2D(self):
         # multi_dot with four or more arguments uses the dynamic programing
         # optimization and therefore deserve a separate
+        # test when all arguments are 2D
         A = np.random.random((6, 2))
         B = np.random.random((2, 6))
         C = np.random.random((6, 2))
         D = np.random.random((2, 1))
-        assert_almost_equal(multi_dot([A, B, C, D]), A.dot(B).dot(C).dot(D))
+        assert_almost_equal(multi_dot([A, B, C, D]),  np.matmul(A, np.matmul(B, np.matmul(C,D))))
+        
+    def test_basic_function_with_dynamic_programing_optimization_ND(self):
+        # multi_dot with four or more arguments uses the dynamic programing
+        # optimization and therefore deserve a separate
+        # test when N-D (N>2) arguments are used
+        A = np.random.random((6, 2))
+        B = np.random.random((4, 2, 6))
+        C = np.random.random((2, 4, 6, 2))
+        D = np.random.random((2, 1))
+        assert_almost_equal(multi_dot([A, B, C, D]),  np.matmul(A, np.matmul(B, np.matmul(C,D))))
 
     def test_vector_as_first_argument(self):
         # The first argument can be 1-D
         A1d = np.random.random(2)  # 1-D
         B = np.random.random((2, 6))
-        C = np.random.random((6, 2))
+        C = np.random.random((2, 6, 2))
         D = np.random.random((2, 2))
 
-        # the result should be 1-D
-        assert_equal(multi_dot([A1d, B, C, D]).shape, (2,))
+        # the result should be a stack of 1x2 matrices
+        assert_equal(multi_dot([A1d, B, C, D]).shape, (2,1,2))
 
     def test_vector_as_last_argument(self):
         # The last argument can be 1-D
         A = np.random.random((6, 2))
-        B = np.random.random((2, 6))
+        B = np.random.random((3, 2, 6))
         C = np.random.random((6, 2))
         D1d = np.random.random(2)  # 1-D
 
-        # the result should be 1-D
-        assert_equal(multi_dot([A, B, C, D1d]).shape, (6,))
+        # the result should be a stack of 6x1 matrices
+        assert_equal(multi_dot([A, B, C, D1d]).shape, (3, 6,1))
 
     def test_vector_as_first_and_last_argument(self):
         # The first and last arguments can be 1-D
         A1d = np.random.random(2)  # 1-D
-        B = np.random.random((2, 6))
-        C = np.random.random((6, 2))
+        B = np.random.random((2, 2, 6))
+        C = np.random.random((3, 2, 6, 2))
         D1d = np.random.random(2)  # 1-D
 
-        # the result should be a scalar
-        assert_equal(multi_dot([A1d, B, C, D1d]).shape, ())
+        # the result should be a a stack of 1x1 matrices 
+        assert_equal(multi_dot([A1d, B, C, D1d]).shape, (3, 2, 1, 1))
 
     def test_dynamic_programming_logic(self):
         # Test for the dynamic programming part


### PR DESCRIPTION
multi_dot is modified to allow stacks of arrays (i.e. N-D arrays rather than just 2-D arrays) internally using matmul.
The optimum order of multiplication is calculated accordingly.