### PR TITLE
BUG: fix error message in numpy.select

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -632,7 +632,7 @@ def select(condlist, choicelist, default=0):
                 deprecated_ints = True
             else:
                 raise ValueError(
-                    'invalid entry in choicelist: should be boolean ndarray')
+                    'invalid entry {} in condlist: should be boolean ndarray'.format(i))
 
     if deprecated_ints:
         # 2014-02-24, 1.9


### PR DESCRIPTION
Error message currently refers to `choicelist`, but actually refers to a value error in `condlist`. Also added index of erroneous argument to error message.