### PR TITLE
BUG: Fix bug in asserting near equality of float16 arrays.

### DIFF
--- a/numpy/testing/nose_tools/utils.py
+++ b/numpy/testing/nose_tools/utils.py
@@ -1577,7 +1577,9 @@ def integer_repr(x):
     """Return the signed-magnitude interpretation of the binary representation of
     x."""
     import numpy as np
-    if x.dtype == np.float32:
+    if x.dtype == np.float16:
+        return _integer_repr(x, np.int16, np.int16(-2**15))
+    elif x.dtype == np.float32:
         return _integer_repr(x, np.int32, np.int32(-2**31))
     elif x.dtype == np.float64:
         return _integer_repr(x, np.int64, np.int64(-2**63))

--- a/numpy/testing/pytest_tools/utils.py
+++ b/numpy/testing/pytest_tools/utils.py
@@ -1619,7 +1619,9 @@ def integer_repr(x):
     """Return the signed-magnitude interpretation of the binary representation of
     x."""
     import numpy as np
-    if x.dtype == np.float32:
+    if x.dtype == np.float16:
+        return _integer_repr(x, np.int16, np.int16(-2**15))
+    elif x.dtype == np.float32:
         return _integer_repr(x, np.int32, np.int32(-2**31))
     elif x.dtype == np.float64:
         return _integer_repr(x, np.int64, np.int64(-2**63))

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -911,6 +911,34 @@ class TestArrayAlmostEqualNulp(unittest.TestCase):
         self.assertRaises(AssertionError, assert_array_almost_equal_nulp,
                           x, y, nulp)
 
+    def test_float16_pass(self):
+        nulp = 5
+        x = np.linspace(-20, 20, 50, dtype=np.float16)
+        x = np.r_[-x, x]
+
+        eps = np.finfo(x.dtype).eps
+        y = x + x*eps*nulp/2.
+        assert_array_almost_equal_nulp(x, y, nulp)
+
+        epsneg = np.finfo(x.dtype).epsneg
+        y = x - x*epsneg*nulp/2.
+        assert_array_almost_equal_nulp(x, y, nulp)
+
+    def test_float16_fail(self):
+        nulp = 5
+        x = np.linspace(-20, 20, 50, dtype=np.float16)
+        x = np.r_[-x, x]
+
+        eps = np.finfo(x.dtype).eps
+        y = x + x*eps*nulp*2.
+        self.assertRaises(AssertionError, assert_array_almost_equal_nulp,
+                          x, y, nulp)
+
+        epsneg = np.finfo(x.dtype).epsneg
+        y = x - x*epsneg*nulp*2.
+        self.assertRaises(AssertionError, assert_array_almost_equal_nulp,
+                          x, y, nulp)
+
     def test_complex128_pass(self):
         nulp = 5
         x = np.linspace(-20, 20, 50, dtype=np.float64)

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -913,7 +913,8 @@ class TestArrayAlmostEqualNulp(unittest.TestCase):
 
     def test_float16_pass(self):
         nulp = 5
-        x = np.linspace(-20, 20, 50, dtype=np.float16)
+        x = np.linspace(-4, 4, 10, dtype=np.float16)
+        x = 10**x
         x = np.r_[-x, x]
 
         eps = np.finfo(x.dtype).eps
@@ -926,7 +927,8 @@ class TestArrayAlmostEqualNulp(unittest.TestCase):
 
     def test_float16_fail(self):
         nulp = 5
-        x = np.linspace(-20, 20, 50, dtype=np.float16)
+        x = np.linspace(-4, 4, 10, dtype=np.float16)
+        x = 10**x
         x = np.r_[-x, x]
 
         eps = np.finfo(x.dtype).eps


### PR DESCRIPTION
This PR should fix issue #10697, where there were issues with `assert_array_almost_equal_nulp` for `float16` datatypes.

This is my first NumPy PR, so if anything is off, feel free to let me know and I'll happily correct.