### PR TITLE
BUG: longdouble(int) does not work

### DIFF
--- a/numpy/core/src/common/npy_longdouble.c
+++ b/numpy/core/src/common/npy_longdouble.c
@@ -172,8 +172,5 @@ npy_longdouble_from_PyLong(PyObject *long_obj) {
         return -1;
     }
 
-    // Without this line, MSVC produces garbage (optimizes out result!?)
-    printf("Double form is %f\n", (double) result);
-
     return result;
 }

--- a/numpy/core/src/common/npy_longdouble.h
+++ b/numpy/core/src/common/npy_longdouble.h
@@ -14,4 +14,14 @@
 NPY_VISIBILITY_HIDDEN PyObject *
 npy_longdouble_to_PyLong(npy_longdouble ldval);
 
+/* Convert a python `long` integer to a npy_longdouble
+ *
+ * This performs the same task as PyLong_AsDouble, but for long doubles
+ * which have a greater range.
+ *
+ * Returns -1 if an error occurs.
+ */
+NPY_VISIBILITY_HIDDEN npy_longdouble
+npy_longdouble_from_PyLong(PyObject *long_obj);
+
 #endif

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -328,6 +328,17 @@ string_to_long_double(PyObject*op)
     npy_longdouble temp;
     PyObject* b;
 
+    /* Convert python long objects to a longdouble, without precision or range
+     * loss via a double.
+     */
+    if (PyLong_Check(op)
+#if !defined(NPY_PY3K)
+        || PyInt_Check(op)
+#endif
+    ) {
+        return npy_longdouble_from_PyLong(op);
+    }
+
     if (PyUnicode_Check(op)) {
         b = PyUnicode_AsUTF8String(op);
         if (!b) {

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -30,6 +30,7 @@
 #include <emmintrin.h>
 #endif
 
+#include "npy_longdouble.h"
 #include "numpyos.h"
 #include <string.h>
 
@@ -331,9 +332,9 @@ string_to_long_double(PyObject*op)
     /* Convert python long objects to a longdouble, without precision or range
      * loss via a double.
      */
-    if (PyLong_Check(op)
+    if ((PyLong_Check(op) && !PyBool_Check(op))
 #if !defined(NPY_PY3K)
-        || PyInt_Check(op)
+        || (PyInt_Check(op) && !PyBool_Check(op))
 #endif
     ) {
         return npy_longdouble_from_PyLong(op);

--- a/numpy/core/tests/test_longdouble.py
+++ b/numpy/core/tests/test_longdouble.py
@@ -205,3 +205,17 @@ class TestCommaDecimalPointLocale(CommaDecimalPointLocale):
     def test_fromstring_foreign_value(self):
         b = np.fromstring("1,234", dtype=np.longdouble, sep=" ")
         assert_array_equal(b[0], 1)
+
+@pytest.mark.parametrize("int_val", [
+    # cases discussed in gh-10723
+    # and gh-9968
+    2 ** 1024, 0])
+def test_longdouble_from_int(int_val):
+    # for issue gh-9968
+    str_val = str(int_val)
+    assert np.longdouble(int_val) == np.longdouble(str_val)
+
+@pytest.mark.parametrize("bool_val", [
+    True, False])
+def test_longdouble_from_bool(bool_val):
+    assert np.longdouble(bool_val) == np.longdouble(int(bool_val))


### PR DESCRIPTION
Fixes gh-9968

Needs tests yet, which I can't write without access to a platform with `longdouble` having higher precision than `double`.