### PR TITLE
DOC: Fix minor typo in how-to-document.

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -322,7 +322,7 @@ The sections of the docstring are:
      See Also
      --------
      func_a : Function a with its description.
-     func_b, func_c_, func_d
+     func_b, func_c, func_d
      func_e
 
 10. **Notes**


### PR DESCRIPTION
The accidental trailing underscore made it render as unresolved link so it had an underline in the output. None of the other listed functions had such a trailing underscore so I removed it.