### PR TITLE
BUG: dragon4 fractional output mode adds too many trailing zeros (1.14 backport)

### DIFF
--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -1588,12 +1588,12 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, npy_uint64 mantissa,
                  npy_int32 digits_right)
 {
     npy_int32 printExponent;
-    npy_int32 numDigits, numWholeDigits, has_sign=0;
+    npy_int32 numDigits, numWholeDigits=0, has_sign=0;
 
     npy_int32 maxPrintLen = bufferSize - 1, pos = 0;
 
     /* track the # of digits past the decimal point that have been printed */
-    npy_int32 numFractionDigits = 0;
+    npy_int32 numFractionDigits = 0, desiredFractionalDigits;
 
     DEBUG_ASSERT(bufferSize > 0);
 
@@ -1710,6 +1710,11 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, npy_uint64 mantissa,
         buffer[pos++] = '.';
     }
 
+    desiredFractionalDigits = precision;
+    if (cutoff_mode == CutoffMode_TotalLength && precision >= 0) {
+        desiredFractionalDigits = precision - numWholeDigits;
+    }
+
     if (trim_mode == TrimMode_LeaveOneZero) {
         /* if we didn't print any fractional digits, add a trailing 0 */
         if (numFractionDigits == 0 && pos < maxPrintLen) {
@@ -1718,11 +1723,12 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, npy_uint64 mantissa,
         }
     }
     else if (trim_mode == TrimMode_None &&
-            digit_mode != DigitMode_Unique &&
-            precision > (npy_int32)numFractionDigits && pos < maxPrintLen) {
+             digit_mode != DigitMode_Unique &&
+             desiredFractionalDigits > numFractionDigits &&
+             pos < maxPrintLen) {
         /* add trailing zeros up to precision length */
         /* compute the number of trailing zeros needed */
-        npy_uint32 count = precision - numFractionDigits;
+        npy_int32 count = desiredFractionalDigits - numFractionDigits;
         if (pos + count > maxPrintLen) {
             count = maxPrintLen - pos;
         }

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -152,6 +152,8 @@ class TestRealScalars(object):
         assert_equal(fpos64('1.5', unique=False, precision=3), "1.500")
         assert_equal(fsci32('1.5', unique=False, precision=3), "1.500e+00")
         assert_equal(fsci64('1.5', unique=False, precision=3), "1.500e+00")
+        # gh-10713
+        assert_equal(fpos64('324', unique=False, precision=5, fractional=False), "324.00")
 
     def test_dragon4_interface(self):
         tps = [np.float16, np.float32, np.float64]


### PR DESCRIPTION
Backport of #10716