### PR TITLE
MAINT: Fix low-hanging PyPy compatibility issues

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -6,7 +6,6 @@ import sys, gc
 import numpy as np
 from numpy.testing import (
      run_module_suite, assert_, assert_equal, assert_raises, assert_warns, dec,
-     HAS_REFCOUNT,
 )
 import textwrap
 
@@ -389,7 +388,7 @@ class TestArray2String(object):
             "[ 'xxxxx']"
         )
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_refcount(self):
         # make sure we do not hold references to the array due to a recursive
         # closure (gh-10620)

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -5,7 +5,8 @@ import sys, gc
 
 import numpy as np
 from numpy.testing import (
-     run_module_suite, assert_, assert_equal, assert_raises, assert_warns, dec
+     run_module_suite, assert_, assert_equal, assert_raises, assert_warns, dec,
+     HAS_REFCOUNT,
 )
 import textwrap
 
@@ -388,6 +389,7 @@ class TestArray2String(object):
             "[ 'xxxxx']"
         )
 
+    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
     def test_refcount(self):
         # make sure we do not hold references to the array due to a recursive
         # closure (gh-10620)

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -608,7 +608,7 @@ class TestSubclasses(object):
         assert_array_equal(new_s.finalize_status, new_s)
         assert_array_equal(new_s.old, s)
 
-    @dec.skipif(not HAS_REFCOUNT)
+    @dec._needs_refcount
     def test_slice_decref_getsetslice(self):
         # See gh-10066, a temporary slice object should be discarted.
         # This test is only really interesting on Python 2 since

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -14,20 +14,6 @@ from numpy.testing import (
 )
 
 
-try:
-    cdll = None
-    if hasattr(sys, 'gettotalrefcount'):
-        try:
-            cdll = np.ctypeslib.load_library('multiarray_d', np.core.multiarray.__file__)
-        except OSError:
-            pass
-    if cdll is None:
-        cdll = np.ctypeslib.load_library('multiarray', np.core.multiarray.__file__)
-    _HAS_CTYPE = True
-except ImportError:
-    _HAS_CTYPE = False
-
-
 class TestIndexing(object):
     def test_index_no_floats(self):
         a = np.array([[[5]]])

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -33,7 +33,7 @@ def iter_iterindices(i):
         i.iternext()
     return ret
 
-@dec.skipif(not HAS_REFCOUNT, "python does not have sys.getrefcount")
+@dec._needs_refcount
 def test_iter_refcount():
     # Make sure the iterator doesn't leak
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -12,7 +12,7 @@ from numpy.random import rand, randint, randn
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,
     assert_raises_regex, assert_array_equal, assert_almost_equal,
-    assert_array_almost_equal, dec, HAS_REFCOUNT, suppress_warnings
+    assert_array_almost_equal, dec, suppress_warnings
 )
 
 
@@ -2092,7 +2092,7 @@ class TestCreationFuncs(object):
         self.check_function(np.full, 0)
         self.check_function(np.full, 1)
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_for_reference_leak(self):
         # Make sure we have an object for reference
         dim = 1

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1424,7 +1424,7 @@ class TestRegression(object):
         x[x.nonzero()] = x.ravel()[:1]
         assert_(x[0, 1] == x[0, 0])
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_structured_arrays_with_objects2(self):
         # Ticket #1299 second test
         stra = 'aaaa'
@@ -1537,7 +1537,7 @@ class TestRegression(object):
         y = np.add(x, x, x)
         assert_equal(id(x), id(y))
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_take_refcount(self):
         # ticket #939
         a = np.arange(16, dtype=float)
@@ -1937,7 +1937,7 @@ class TestRegression(object):
             a = np.empty((100000000,), dtype='i1')
             del a
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_ufunc_reduce_memoryleak(self):
         a = np.arange(6)
         acnt = sys.getrefcount(a)
@@ -2167,7 +2167,7 @@ class TestRegression(object):
         assert_equal(uf(a), ())
         assert_array_equal(a, [[3, 2, 1], [5, 4], [9, 7, 8, 6]])
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_leak_in_structured_dtype_comparison(self):
         # gh-6250
         recordtype = np.dtype([('a', np.float64),

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1104,7 +1104,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
                 nshape = list(X.shape)
                 pos = nshape[0]
                 nshape[0] += len(x)
-                X.resize(nshape)
+                X.resize(nshape, refcheck=False)
                 X[pos:, ...] = x
     finally:
         if fown:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -11,7 +11,7 @@ from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
     assert_almost_equal, assert_array_almost_equal, assert_raises,
     assert_allclose, assert_array_max_ulp, assert_warns, assert_raises_regex,
-    dec, suppress_warnings, HAS_REFCOUNT,
+    dec, suppress_warnings,
 )
 import numpy.lib.function_base as nfb
 from numpy.random import rand
@@ -2141,7 +2141,7 @@ class TestBincount(object):
                             "must not be negative",
                             lambda: np.bincount(x, minlength=-1))
 
-    @dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+    @dec._needs_refcount
     def test_dtype_reference_leaks(self):
         # gh-6805
         intp_refcount = sys.getrefcount(np.dtype(np.intp))

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -23,7 +23,6 @@ from numpy.testing import (
     run_module_suite, assert_warns, assert_, SkipTest,
     assert_raises_regex, assert_raises, assert_allclose,
     assert_array_equal, temppath, tempdir, dec, IS_PYPY, suppress_warnings,
-    HAS_REFCOUNT
 )
 
 
@@ -2365,7 +2364,7 @@ def test_npzfile_dict():
     assert_('x' in z.keys())
 
 
-@dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
+@dec._needs_refcount
 def test_load_refcount():
     # Check that objects returned by np.load are directly freed based on
     # their refcount, rather than needing the gc to collect them.

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -22,7 +22,8 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     run_module_suite, assert_warns, assert_, SkipTest,
     assert_raises_regex, assert_raises, assert_allclose,
-    assert_array_equal, temppath, tempdir, dec, IS_PYPY, suppress_warnings
+    assert_array_equal, temppath, tempdir, dec, IS_PYPY, suppress_warnings,
+    HAS_REFCOUNT
 )
 
 
@@ -2364,6 +2365,7 @@ def test_npzfile_dict():
     assert_('x' in z.keys())
 
 
+@dec.skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")
 def test_load_refcount():
     # Check that objects returned by np.load are directly freed based on
     # their refcount, rather than needing the gc to collect them.

--- a/numpy/testing/nose_tools/decorators.py
+++ b/numpy/testing/nose_tools/decorators.py
@@ -17,10 +17,10 @@ from __future__ import division, absolute_import, print_function
 
 import collections
 
-from .utils import SkipTest, assert_warns
+from .utils import SkipTest, assert_warns, HAS_REFCOUNT
 
 __all__ = ['slow', 'setastest', 'skipif', 'knownfailureif', 'deprecated',
-           'parametrize',]
+           'parametrize', '_needs_refcount',]
 
 
 def slow(t):
@@ -283,3 +283,5 @@ def parametrize(vars, input):
     from .parameterized import parameterized
 
     return parameterized(input)
+
+_needs_refcount = skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")

--- a/numpy/testing/pytest_tools/decorators.py
+++ b/numpy/testing/pytest_tools/decorators.py
@@ -14,10 +14,10 @@ from __future__ import division, absolute_import, print_function
 
 import collections
 
-from .utils import SkipTest, assert_warns
+from .utils import SkipTest, assert_warns, HAS_REFCOUNT
 
 __all__ = ['slow', 'setastest', 'skipif', 'knownfailureif', 'deprecated',
-           'parametrize',]
+           'parametrize', '_needs_refcount',]
 
 
 def slow(t):
@@ -276,3 +276,6 @@ def parametrize(vars, input):
     import pytest
 
     return pytest.mark.parametrize(vars, input)
+
+
+_needs_refcount = skipif(not HAS_REFCOUNT, "python has no sys.getrefcount")


### PR DESCRIPTION
- Skip some refcount-requiring tests if sys.refcount is missing.
- Add refcheck=False to a safe .resize() call in npyio.py
- Remove unused code in test_indexing.py