### PR TITLE
MAINT: Import abstract classes from collections.abc

### DIFF
--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -8,7 +8,12 @@ Show a summary about which NumPy functions are documented and which are not.
 from __future__ import division, absolute_import, print_function
 
 import os, glob, re, sys, inspect, optparse
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 sys.path.append(os.path.join(os.path.dirname(__file__), 'sphinxext'))
 from sphinxext.phantom_import import import_phantom_module
 
@@ -136,7 +141,7 @@ def get_undocumented(documented, module, module_name=None, skip=[]):
 
         if full_name in skip: continue
         if full_name.startswith('numpy.') and full_name[6:] in skip: continue
-        if not (inspect.ismodule(obj) or isinstance(obj, collections.Callable) or inspect.isclass(obj)):
+        if not (inspect.ismodule(obj) or isinstance(obj, collections_abc.Callable) or inspect.isclass(obj)):
             continue
 
         if full_name not in documented:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1,6 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 import itertools
 import operator
 import sys
@@ -2758,8 +2763,8 @@ def seterrcall(func):
     {'over': 'log', 'divide': 'log', 'invalid': 'log', 'under': 'log'}
 
     """
-    if func is not None and not isinstance(func, collections.Callable):
-        if not hasattr(func, 'write') or not isinstance(func.write, collections.Callable):
+    if func is not None and not isinstance(func, collections_abc.Callable):
+        if not hasattr(func, 'write') or not isinstance(func.write, collections_abc.Callable):
             raise ValueError("Only callable can be used as callback")
     pyvals = umath.geterrobj()
     old = geterrcall()

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1,6 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 import tempfile
 import sys
 import shutil
@@ -6992,7 +6997,7 @@ class TestHashing(object):
 
     def test_collections_hashable(self):
         x = np.array([])
-        assert_(not isinstance(x, collections.Hashable))
+        assert_(not isinstance(x, collections_abc.Hashable))
 
 
 class TestArrayPriority(object):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -1,7 +1,12 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 import pickle
 import warnings
 import textwrap
@@ -252,7 +257,7 @@ class TestFromrecords(object):
         assert_array_equal(ra['shape'], [['A', 'B', 'C']])
         ra.field = 5
         assert_array_equal(ra['field'], [[5, 5, 5]])
-        assert_(isinstance(ra.field, collections.Callable))
+        assert_(isinstance(ra.field, collections_abc.Callable))
 
     def test_fromrecords_with_explicit_dtype(self):
         a = np.rec.fromrecords([(1, 'a'), (2, 'bbb')],

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1,6 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 import re
 import sys
 import warnings
@@ -547,7 +552,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     y = zeros(x.shape, x.dtype)
     for k in range(n):
         item = funclist[k]
-        if not isinstance(item, collections.Callable):
+        if not isinstance(item, collections_abc.Callable):
             y[condlist[k]] = item
         else:
             vals = x[condlist[k]]

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -1,6 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 import numpy as np
 from numpy import matrix, asmatrix, bmat
@@ -302,7 +307,7 @@ class TestMatrixReturn(object):
             if attrib.startswith('_') or attrib in excluded_methods:
                 continue
             f = getattr(a, attrib)
-            if isinstance(f, collections.Callable):
+            if isinstance(f, collections_abc.Callable):
                 # reset contents of a
                 a.astype('f8')
                 a.fill(1.0)

--- a/numpy/testing/nose_tools/decorators.py
+++ b/numpy/testing/nose_tools/decorators.py
@@ -15,7 +15,12 @@ function name, setup and teardown functions and so on - see
 """
 from __future__ import division, absolute_import, print_function
 
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 from .utils import SkipTest, assert_warns, HAS_REFCOUNT
 
@@ -126,7 +131,7 @@ def skipif(skip_condition, msg=None):
         import nose
 
         # Allow for both boolean or callable skip conditions.
-        if isinstance(skip_condition, collections.Callable):
+        if isinstance(skip_condition, collections_abc.Callable):
             skip_val = lambda: skip_condition()
         else:
             skip_val = lambda: skip_condition
@@ -202,7 +207,7 @@ def knownfailureif(fail_condition, msg=None):
         msg = 'Test skipped due to known failure'
 
     # Allow for both boolean or callable known failure conditions.
-    if isinstance(fail_condition, collections.Callable):
+    if isinstance(fail_condition, collections_abc.Callable):
         fail_val = lambda: fail_condition()
     else:
         fail_val = lambda: fail_condition
@@ -257,7 +262,7 @@ def deprecated(conditional=True):
             with assert_warns(DeprecationWarning):
                 f(*args, **kwargs)
 
-        if isinstance(conditional, collections.Callable):
+        if isinstance(conditional, collections_abc.Callable):
             cond = conditional()
         else:
             cond = conditional

--- a/numpy/testing/pytest_tools/decorators.py
+++ b/numpy/testing/pytest_tools/decorators.py
@@ -12,7 +12,12 @@ function name, setup and teardown functions and so on.
 """
 from __future__ import division, absolute_import, print_function
 
-import collections
+try:
+    # Accessing collections abstact classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 from .utils import SkipTest, assert_warns, HAS_REFCOUNT
 
@@ -127,7 +132,7 @@ def skipif(skip_condition, msg=None):
             out = msg
 
         # Allow for both boolean or callable skip conditions.
-        if isinstance(skip_condition, collections.Callable):
+        if isinstance(skip_condition, collections_abc.Callable):
             skip_val = lambda: skip_condition()
         else:
             skip_val = lambda: skip_condition
@@ -203,7 +208,7 @@ def knownfailureif(fail_condition, msg=None):
         msg = 'Test skipped due to known failure'
 
     # Allow for both boolean or callable known failure conditions.
-    if isinstance(fail_condition, collections.Callable):
+    if isinstance(fail_condition, collections_abc.Callable):
         fail_val = lambda: fail_condition()
     else:
         fail_val = lambda: fail_condition
@@ -252,7 +257,7 @@ def deprecated(conditional=True):
             with assert_warns(DeprecationWarning):
                 f(*args, **kwargs)
 
-        if isinstance(conditional, collections.Callable):
+        if isinstance(conditional, collections_abc.Callable):
             cond = conditional()
         else:
             cond = conditional


### PR DESCRIPTION
Abstract collection classes accessed from the collections module
have been deprecated since Python 3.3. They should be
accessed through collections.abc. When run with Python
3.7, the deprecation warning cause multiple tests to
fail.