### PR TITLE
DOC: a.size and np.prod(a.shape) are not equivalent

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3061,9 +3061,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('size',
     Number of elements in the array.
 
     Equal to ``np.prod(a.shape)``, i.e., the product of the array's
-    dimensions, except that ``size`` returns an instance of ``int``
-    whereas ``np.prod(a.shape)`` returns an instance of ``np.int_``
-    (e.g. ``np.int64``).
+    dimensions.
 
     Examples
     --------
@@ -3072,6 +3070,14 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('size',
     30
     >>> np.prod(x.shape)
     30
+    
+    Notes
+    -----
+    `a.size` returns a standard arbitrary precision Python integer. This 
+    may not be the case with other methods of obtaining the same value
+    (like the suggested ``np.prod(a.shape)``, which returns an instance
+    of ``np.int_``), and may be relevant if the value is used further in
+    calculations that may overflow a fixed size integer type.
 
     """))
 

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3060,8 +3060,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('size',
     """
     Number of elements in the array.
 
-    Equivalent to ``np.prod(a.shape)``, i.e., the product of the array's
-    dimensions.
+    Equal to ``np.prod(a.shape)``, i.e., the product of the array's
+    dimensions, except that ``size`` returns an instance of ``int``
+    whereas ``np.prod(a.shape)`` returns an instance of ``np.int_``
+    (e.g. ``np.int64``).
 
     Examples
     --------

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -3063,14 +3063,6 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('size',
     Equal to ``np.prod(a.shape)``, i.e., the product of the array's
     dimensions.
 
-    Examples
-    --------
-    >>> x = np.zeros((3, 5, 2), dtype=np.complex128)
-    >>> x.size
-    30
-    >>> np.prod(x.shape)
-    30
-    
     Notes
     -----
     `a.size` returns a standard arbitrary precision Python integer. This 
@@ -3078,6 +3070,14 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('size',
     (like the suggested ``np.prod(a.shape)``, which returns an instance
     of ``np.int_``), and may be relevant if the value is used further in
     calculations that may overflow a fixed size integer type.
+
+    Examples
+    --------
+    >>> x = np.zeros((3, 5, 2), dtype=np.complex128)
+    >>> x.size
+    30
+    >>> np.prod(x.shape)
+    30
 
     """))
 


### PR DESCRIPTION
fixes #10747 