### PR TITLE
TST: Change most travisci tests to Python3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,15 @@ python:
   - 3.6
 matrix:
   include:
-    - python: 2.7
-      env: USE_CHROOT=1 ARCH=i386 DIST=artful PYTHON=2.7
+    - python: 3.6
+      env: USE_CHROOT=1 ARCH=i386 DIST=artful PYTHON=3.6
       sudo: true
-      dist: trusty
       addons:
         apt:
           packages:
             - debootstrap
     - python: 3.4
       env: USE_DEBUG=1
-      dist: trusty
       addons:
         apt:
           packages:
@@ -57,19 +55,21 @@ matrix:
             - python3-dev
             - python3-nose
             - python3-setuptools
-    - python: 3.5
+    - python: 3.6
       env: USE_WHEEL=1 RUN_FULL_TESTS=1
-    - python: 3.5
-      env: USE_SDIST=1
     - python: 2.7
+      env: USE_WHEEL=1 RUN_FULL_TESTS=1 PYTHON_OPTS="-3 -OO"
+    - python: 3.6
+      env: USE_SDIST=1
+    - python: 3.6
       env:
        - PYTHONOPTIMIZE=2
        - USE_ASV=1
-    - python: 2.7
-      env: NPY_RELAXED_STRIDES_CHECKING=0 PYTHON_OPTS="-3 -OO"
-    - python: 2.7
+    - python: 3.5
+      env: NPY_RELAXED_STRIDES_CHECKING=0
+    - python: 3.6
       env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1
-    - python: 2.7
+    - python: 3.6
       env:
        - BLAS=None
        - LAPACK=None


### PR DESCRIPTION
This changes most to the tests to run Python 3.6. Python 3.6 is a good base for the next couple of years and could use more testing and having this now makes dropping 2.7 just a little bit easier.