### PR TITLE
MAINT: Warn that weights are not used in histogram bin edges calculation

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -8,6 +8,8 @@ import operator
 import numpy as np
 from numpy.compat.py3k import basestring
 
+import warnings
+
 __all__ = ['histogram', 'histogramdd', 'histogram_bin_edges']
 
 
@@ -318,6 +320,14 @@ def _get_bin_edges(a, bins, range, weights):
 
     else:
         raise ValueError('`bins` must be 1d, when an array')
+
+    # the weights variable is not used at all in the bin edge calculations. a
+    # warning is useful since the histogram_bin_edges docstring says that it
+    # might be used in the future.
+    if weights is not None:
+        warnings.warn("Weights are currently not used by any of the bin edge "
+                      "estimators, but may be in the future.",
+                      FutureWarning, stacklevel=2)
 
     if n_equal_bins is not None:
         # gh-10322 means that type resolution rules are dependent on array

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -10,6 +10,7 @@ from numpy.testing import (
     dec, suppress_warnings, HAS_REFCOUNT,
 )
 
+import warnings
 
 class TestHistogram(object):
 
@@ -158,6 +159,15 @@ class TestHistogram(object):
             np.arange(9), [0, 1, 3, 6, 10],
             weights=[2, 1, 1, 1, 1, 1, 1, 1, 1], density=True)
         assert_almost_equal(a, [.2, .1, .1, .075])
+
+    def test_weights_warning(self):
+        a = np.array([1,2,3,4,5,6,7,8,9,10])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            hist, bin_edges = np.histogram(a,bins=10, weights=range(len(a)))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, FutureWarning)
+            assert "bin edge estimators" in str(w[-1].message)
 
     def test_exotic_weights(self):
 


### PR DESCRIPTION
Addressing issue #10682 