### PR TITLE
BUG: Disable hex(np.floating) and oct(np.floating) on python 2

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1079,22 +1079,18 @@ static PyObject *
 
 #if !defined(NPY_PY3K)
 
-/**begin repeat1
- * #name = int, hex, oct#
- */
 static PyObject *
-@char@longdoubletype_@name@(PyObject *self)
+@char@longdoubletype_int(PyObject *self)
 {
     PyObject *ret;
     PyObject *obj = @char@longdoubletype_long(self);
     if (obj == NULL) {
         return NULL;
     }
-    ret = Py_TYPE(obj)->tp_as_number->nb_@name@(obj);
+    ret = Py_TYPE(obj)->tp_as_number->nb_int(obj);
     Py_DECREF(obj);
     return ret;
 }
-/**end repeat1**/
 
 #endif /* !defined(NPY_PY3K) */
 
@@ -4370,8 +4366,6 @@ initialize_numeric_types(void)
 #else
     @char@longdoubletype_as_number.nb_int  = @char@longdoubletype_int;
     @char@longdoubletype_as_number.nb_long = @char@longdoubletype_long;
-    @char@longdoubletype_as_number.nb_hex  = @char@longdoubletype_hex;
-    @char@longdoubletype_as_number.nb_oct  = @char@longdoubletype_oct;
 #endif
 
     Py@CHAR@LongDoubleArrType_Type.tp_as_number = &@char@longdoubletype_as_number;

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1464,12 +1464,10 @@ static NPY_INLINE PyObject *
 /**begin repeat
  *
  * #name = (byte, ubyte, short, ushort, int, uint,
- *             long, ulong, longlong, ulonglong,
- *             half, float, double, longdouble,
- *             cfloat, cdouble, clongdouble)*2#
- * #oper = oct*17,  hex*17#
- * #kind = (int*5,  long*5,  int*2,  long*2,  int,  long*2)*2#
- * #cap = (Int*5,  Long*5,  Int*2,  Long*2,  Int,  Long*2)*2#
+ *             long, ulong, longlong, ulonglong)*2#
+ * #oper = oct*10,  hex*10#
+ * #kind = (int*5,  long*5)*2#
+ * #cap = (Int*5,  Long*5)*2#
  */
 static PyObject *
 @name@_@oper@(PyObject *obj)
@@ -1483,6 +1481,13 @@ static PyObject *
 }
 /**end repeat**/
 
+/**begin repeat
+ * #name = (half, float, double, longdouble,
+ *          cfloat, cdouble, clongdouble)*2#
+ * #oper = oct*7, hex*7#
+ */
+#define @name@_@oper@ NULL
+/**end repeat**/
 #endif
 
 /**begin repeat

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -4,13 +4,17 @@
 """
 from __future__ import division, absolute_import, print_function
 
-import code, sys
+import code
+import sys
 import platform
+from tempfile import TemporaryFile
+
 import pytest
 
-from tempfile import TemporaryFile
 import numpy as np
-from numpy.testing import assert_, assert_equal, suppress_warnings
+from numpy.testing import (
+    assert_, assert_equal, assert_raises, suppress_warnings
+)
 
 class TestRealScalars(object):
     def test_str(self):
@@ -324,3 +328,18 @@ class TestRealScalars(object):
         # gh-2643, gh-6136, gh-6908
         assert_equal(repr(np.float64(0.1)), repr(0.1))
         assert_(repr(np.float64(0.20000000000000004)) != repr(0.2))
+
+    @pytest.mark.parametrize('dt', [
+        np.half,
+        np.single,
+        np.double,
+        np.longdouble,
+    ])
+    def test_hex_oct_float(self, dt):
+        """
+        Test that hex and oct fail on numpy floats just like they do on
+        python ones
+        """
+        f = dt(0.0)
+        assert_raises(TypeError, hex, f)
+        assert_raises(TypeError, oct, f)


### PR DESCRIPTION
This makes them match the behavior of hex(float) and oct(float) on python 2

Note that `np.float16.__hex__` still exists, which calls `np.generic.__hex__` &rarr; `ndarray.__hex__` &rarr; `np.float16::tp_number.nb_hex`. Unfortunately #9972 means `__hex__` and `nb_hex` are out of sync.