### PR TITLE
BUG: Use dummy_threading on platforms that don't support threading

### DIFF
--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -5,7 +5,10 @@ Discrete Fourier Transforms - helper.py
 from __future__ import division, absolute_import, print_function
 
 import collections
-import threading
+try:
+    import threading
+except ImportError:
+    import dummy_threading as threading
 from numpy.compat import integer_types
 from numpy.core import integer, empty, arange, asarray, roll
 


### PR DESCRIPTION
This is the first in a series of PRs related to porting numpy to the Emscripten/WebAssembly platform.  (@njsmith and I talked about this IRL last week).

This uses the `dummy_threading` module on platforms that don't support threading.  A similar hack already exists in `mtrand.pyx`.  This change is safe since the `threading.Lock` is irrelevant on non-threaded platforms.