### PR TITLE
BUG: Return NULL from PyInit_* when exception is raised

### DIFF
--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -310,10 +310,10 @@ static struct PyModuleDef moduledef = {
 #include <stdio.h>
 
 #if defined(NPY_PY3K)
-#define RETVAL m
+#define RETVAL(x) x
 PyMODINIT_FUNC PyInit_umath(void)
 #else
-#define RETVAL
+#define RETVAL(x)
 PyMODINIT_FUNC initumath(void)
 #endif
 {
@@ -330,7 +330,7 @@ PyMODINIT_FUNC initumath(void)
     m = Py_InitModule("umath", methods);
 #endif
     if (!m) {
-        return RETVAL;
+        goto err;
     }
 
     /* Import the array */
@@ -339,12 +339,12 @@ PyMODINIT_FUNC initumath(void)
             PyErr_SetString(PyExc_ImportError,
                             "umath failed: Could not import array core.");
         }
-        return RETVAL;
+        goto err;
     }
 
     /* Initialize the types */
     if (PyType_Ready(&PyUFunc_Type) < 0)
-        return RETVAL;
+        goto err;
 
     /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
@@ -426,7 +426,7 @@ PyMODINIT_FUNC initumath(void)
         goto err;
     }
 
-    return RETVAL;
+    return RETVAL(m);
 
  err:
     /* Check for errors */
@@ -434,5 +434,5 @@ PyMODINIT_FUNC initumath(void)
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot load umath module.");
     }
-    return RETVAL;
+    return RETVAL(NULL);
 }

--- a/numpy/fft/fftpack_litemodule.c
+++ b/numpy/fft/fftpack_litemodule.c
@@ -330,10 +330,10 @@ static struct PyModuleDef moduledef = {
 
 /* Initialization function for the module */
 #if PY_MAJOR_VERSION >= 3
-#define RETVAL m
+#define RETVAL(x) x
 PyMODINIT_FUNC PyInit_fftpack_lite(void)
 #else
-#define RETVAL
+#define RETVAL(x)
 PyMODINIT_FUNC
 initfftpack_lite(void)
 #endif
@@ -348,6 +348,9 @@ initfftpack_lite(void)
             fftpack_module_documentation,
             (PyObject*)NULL,PYTHON_API_VERSION);
 #endif
+    if (m == NULL) {
+        return RETVAL(NULL);
+    }
 
     /* Import the array object */
     import_array();
@@ -359,5 +362,5 @@ initfftpack_lite(void)
 
     /* XXXX Add constants here */
 
-    return RETVAL;
+    return RETVAL(m);
 }

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -331,10 +331,10 @@ static struct PyModuleDef moduledef = {
 
 /* Initialization function for the module */
 #if PY_MAJOR_VERSION >= 3
-#define RETVAL m
+#define RETVAL(x) x
 PyMODINIT_FUNC PyInit_lapack_lite(void)
 #else
-#define RETVAL
+#define RETVAL(x)
 PyMODINIT_FUNC
 initlapack_lite(void)
 #endif
@@ -347,12 +347,12 @@ initlapack_lite(void)
                        "", (PyObject*)NULL,PYTHON_API_VERSION);
 #endif
     if (m == NULL) {
-        return RETVAL;
+        return RETVAL(NULL);
     }
     import_array();
     d = PyModule_GetDict(m);
     LapackError = PyErr_NewException("lapack_lite.LapackError", NULL, NULL);
     PyDict_SetItemString(d, "LapackError", LapackError);
 
-    return RETVAL;
+    return RETVAL(m);
 }

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -3251,10 +3251,10 @@ static struct PyModuleDef moduledef = {
 #endif
 
 #if defined(NPY_PY3K)
-#define RETVAL m
+#define RETVAL(x) x
 PyObject *PyInit__umath_linalg(void)
 #else
-#define RETVAL
+#define RETVAL(x)
 PyMODINIT_FUNC
 init_umath_linalg(void)
 #endif
@@ -3270,7 +3270,7 @@ init_umath_linalg(void)
     m = Py_InitModule(UMATH_LINALG_MODULE_NAME, UMath_LinAlgMethods);
 #endif
     if (m == NULL) {
-        return RETVAL;
+        return RETVAL(NULL);
     }
 
     import_array();
@@ -3288,7 +3288,8 @@ init_umath_linalg(void)
     if (PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot load _umath_linalg module.");
+        return RETVAL(NULL);
     }
 
-    return RETVAL;
+    return RETVAL(m);
 }


### PR DESCRIPTION
I don't think this is documented anywhere, but I'm pretty sure module init
functions should return NULL in order to communicate that an exception
occurred during initialization (as is the standard Python/C API convention).

It's clear from the CPython code
[here](https://github.com/python/cpython/blob/master/Python/importdl.c#L162)
that if you don't return NULL, the exception is swallowed and replaced with the
message "initialization of %s raised unreported exception".

Admittedly, this is only useful for people porting Numpy to new platforms where
it is helpful to know where module initialization is failing, but it can't hurt.