### PR TITLE
BUG: test, fix for missing flags['WRITEBACKIFCOPY'] key

### DIFF
--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -575,7 +575,7 @@ arrayflags_getitem(PyArrayFlagsObject *self, PyObject *ind)
             return arrayflags_fortran_get(self);
         }
         break;
-    case 14:
+    case 15:
         if (strncmp(key, "WRITEBACKIFCOPY", n) == 0) {
             return arrayflags_writebackifcopy_get(self);
         }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -105,8 +105,10 @@ class TestFlags(object):
             assert_equal(self.a.flags.updateifcopy, False)
         with assert_warns(DeprecationWarning):
             assert_equal(self.a.flags['U'], False)
+            assert_equal(self.a.flags['UPDATEIFCOPY'], False)
         assert_equal(self.a.flags.writebackifcopy, False)
         assert_equal(self.a.flags['X'], False)
+        assert_equal(self.a.flags['WRITEBACKIFCOPY'], False)
 
 
     def test_string_align(self):


### PR DESCRIPTION
We never tested that `a.flags['WRITEBACKIFCOPY']` works, and there was an off-by-one error in the switch to handle this `getitem` case.

I added a failing test then fixed it.