### PR TITLE
TST: Various fixes prior to switching to pytest

### DIFF
--- a/numpy/compat/setup.py
+++ b/numpy/compat/setup.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
 from __future__ import division, print_function
-
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+
     config = Configuration('compat', parent_package, top_path)
+    config.add_data_dir('tests')
     return config
 
 if __name__ == '__main__':

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import numpy
 import importlib
 
-from numpy.core.multiarray_tests import get_fpu_mode
+from numpy.core._multiarray_tests import get_fpu_mode
 
 
 _old_fpu_mode = None
@@ -21,7 +21,7 @@ def pytest_itemcollected(item):
     Check FPU precision mode was not changed during test collection.
 
     The clumsy way we do it here is mainly necessary because numpy
-    still uses yield tests, which can execute code at test collection 
+    still uses yield tests, which can execute code at test collection
     time.
     """
     global _old_fpu_mode

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -924,29 +924,29 @@ def configuration(parent_package='',top_path=None):
     #                        umath_tests module                           #
     #######################################################################
 
-    config.add_extension('umath_tests',
-                    sources=[join('src', 'umath', 'umath_tests.c.src')])
+    config.add_extension('_umath_tests',
+                    sources=[join('src', 'umath', '_umath_tests.c.src')])
 
     #######################################################################
     #                   custom rational dtype module                      #
     #######################################################################
 
-    config.add_extension('test_rational',
-                    sources=[join('src', 'umath', 'test_rational.c.src')])
+    config.add_extension('_rational_tests',
+                    sources=[join('src', 'umath', '_rational_tests.c.src')])
 
     #######################################################################
     #                        struct_ufunc_test module                     #
     #######################################################################
 
-    config.add_extension('struct_ufunc_test',
-                    sources=[join('src', 'umath', 'struct_ufunc_test.c.src')])
+    config.add_extension('_struct_ufunc_tests',
+                    sources=[join('src', 'umath', '_struct_ufunc_tests.c.src')])
 
     #######################################################################
     #                     multiarray_tests module                         #
     #######################################################################
 
-    config.add_extension('multiarray_tests',
-                    sources=[join('src', 'multiarray', 'multiarray_tests.c.src'),
+    config.add_extension('_multiarray_tests',
+                    sources=[join('src', 'multiarray', '_multiarray_tests.c.src'),
                              join('src', 'private', 'mem_overlap.c')],
                     depends=[join('src', 'private', 'mem_overlap.h'),
                              join('src', 'private', 'npy_extint128.h')],
@@ -956,8 +956,8 @@ def configuration(parent_package='',top_path=None):
     #                        operand_flag_tests module                    #
     #######################################################################
 
-    config.add_extension('operand_flag_tests',
-                    sources=[join('src', 'umath', 'operand_flag_tests.c.src')])
+    config.add_extension('_operand_flag_tests',
+                    sources=[join('src', 'umath', '_operand_flag_tests.c.src')])
 
     config.add_data_dir('tests')
     config.add_data_dir('tests/data')

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -1867,7 +1867,7 @@ static PyMethodDef Multiarray_TestsMethods[] = {
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
-        "multiarray_tests",
+        "_multiarray_tests",
         NULL,
         -1,
         Multiarray_TestsMethods,
@@ -1880,11 +1880,11 @@ static struct PyModuleDef moduledef = {
 
 #if defined(NPY_PY3K)
 #define RETVAL m
-PyMODINIT_FUNC PyInit_multiarray_tests(void)
+PyMODINIT_FUNC PyInit__multiarray_tests(void)
 #else
 #define RETVAL
 PyMODINIT_FUNC
-initmultiarray_tests(void)
+init_multiarray_tests(void)
 #endif
 {
     PyObject *m;
@@ -1892,7 +1892,7 @@ initmultiarray_tests(void)
 #if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule("multiarray_tests", Multiarray_TestsMethods);
+    m = Py_InitModule("_multiarray_tests", Multiarray_TestsMethods);
 #endif
     if (m == NULL) {
         return RETVAL;
@@ -1900,7 +1900,7 @@ initmultiarray_tests(void)
     import_array();
     if (PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError,
-                        "cannot load umath_tests module.");
+                        "cannot load _multiarray_tests module.");
     }
     return RETVAL;
 }

--- a/numpy/core/src/umath/_operand_flag_tests.c.src
+++ b/numpy/core/src/umath/_operand_flag_tests.c.src
@@ -42,7 +42,7 @@ static void *data[1] = {NULL};
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "operand_flag_tests",
+    "_operand_flag_tests",
     NULL,
     -1,
     TestMethods,
@@ -53,11 +53,11 @@ static struct PyModuleDef moduledef = {
 };
 
 #define RETVAL m
-PyMODINIT_FUNC PyInit_operand_flag_tests(void)
+PyMODINIT_FUNC PyInit__operand_flag_tests(void)
 {
 #else
 #define RETVAL
-PyMODINIT_FUNC initoperand_flag_tests(void)
+PyMODINIT_FUNC init_operand_flag_tests(void)
 {
 #endif
     PyObject *m = NULL;
@@ -66,7 +66,7 @@ PyMODINIT_FUNC initoperand_flag_tests(void)
 #if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule("operand_flag_tests", TestMethods);
+    m = Py_InitModule("_operand_flag_tests", TestMethods);
 #endif
     if (m == NULL) {
         goto fail;
@@ -92,7 +92,7 @@ PyMODINIT_FUNC initoperand_flag_tests(void)
 fail:
     if (!PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError,
-                        "cannot load operand_flag_tests module.");
+                        "cannot load _operand_flag_tests module.");
     }
 #if defined(NPY_PY3K)
     if (m) {

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -1129,7 +1129,7 @@ PyMethodDef module_methods[] = {
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "test_rational",
+    "_rational_tests",
     NULL,
     -1,
     module_methods,
@@ -1142,10 +1142,10 @@ static struct PyModuleDef moduledef = {
 
 #if defined(NPY_PY3K)
 #define RETVAL m
-PyMODINIT_FUNC PyInit_test_rational(void) {
+PyMODINIT_FUNC PyInit__rational_tests(void) {
 #else
 #define RETVAL
-PyMODINIT_FUNC inittest_rational(void) {
+PyMODINIT_FUNC init_rational_tests(void) {
 #endif
 
     PyObject *m = NULL;
@@ -1295,7 +1295,7 @@ PyMODINIT_FUNC inittest_rational(void) {
 #if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule("test_rational", module_methods);
+    m = Py_InitModule("_rational_tests", module_methods);
 #endif
 
     if (!m) {
@@ -1397,7 +1397,7 @@ PyMODINIT_FUNC inittest_rational(void) {
 fail:
     if (!PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError,
-                        "cannot load test_rational module.");
+                        "cannot load _rational_tests module.");
     }
 #if defined(NPY_PY3K)
     if (m) {

--- a/numpy/core/src/umath/_struct_ufunc_tests.c.src
+++ b/numpy/core/src/umath/_struct_ufunc_tests.c.src
@@ -56,7 +56,7 @@ static void add_uint64_triplet(char **args, npy_intp *dimensions,
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "struct_ufunc_test",
+    "_struct_ufunc_tests",
     NULL,
     -1,
     StructUfuncTestMethods,
@@ -68,9 +68,9 @@ static struct PyModuleDef moduledef = {
 #endif
 
 #if defined(NPY_PY3K)
-PyMODINIT_FUNC PyInit_struct_ufunc_test(void)
+PyMODINIT_FUNC PyInit__struct_ufunc_tests(void)
 #else
-PyMODINIT_FUNC initstruct_ufunc_test(void)
+PyMODINIT_FUNC init_struct_ufunc_tests(void)
 #endif
 {
     PyObject *m, *add_triplet, *d;
@@ -81,7 +81,7 @@ PyMODINIT_FUNC initstruct_ufunc_test(void)
 #if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule("struct_ufunc_test", StructUfuncTestMethods);
+    m = Py_InitModule("_struct_ufunc_tests", StructUfuncTestMethods);
 #endif
 
     if (m == NULL) {

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -360,7 +360,7 @@ static PyMethodDef UMath_TestsMethods[] = {
 #if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
-        "umath_tests",
+        "_umath_tests",
         NULL,
         -1,
         UMath_TestsMethods,
@@ -373,11 +373,11 @@ static struct PyModuleDef moduledef = {
 
 #if defined(NPY_PY3K)
 #define RETVAL m
-PyMODINIT_FUNC PyInit_umath_tests(void)
+PyMODINIT_FUNC PyInit__umath_tests(void)
 #else
 #define RETVAL
 PyMODINIT_FUNC
-initumath_tests(void)
+init_umath_tests(void)
 #endif
 {
     PyObject *m;
@@ -387,7 +387,7 @@ initumath_tests(void)
 #if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule("umath_tests", UMath_TestsMethods);
+    m = Py_InitModule("_umath_tests", UMath_TestsMethods);
 #endif
     if (m == NULL)
         return RETVAL;
@@ -406,7 +406,7 @@ initumath_tests(void)
 
     if (PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError,
-                        "cannot load umath_tests module.");
+                        "cannot load _umath_tests module.");
     }
 
     return RETVAL;

--- a/numpy/core/tests/_locales.py
+++ b/numpy/core/tests/_locales.py
@@ -1,0 +1,76 @@
+"""Provide class for testing in French locale
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import sys
+import locale
+
+from numpy.testing import SkipTest
+
+__ALL__ = ['CommaDecimalPointLocale']
+
+
+def find_comma_decimal_point_locale():
+    """See if platform has a decimal point as comma locale.
+
+    Find a locale that uses a comma instead of a period as the
+    decimal point.
+
+    Returns
+    -------
+    old_locale: str
+        Locale when the function was called.
+    new_locale: {str, None)
+        First French locale found, None if none found.
+
+    """
+    if sys.platform == 'win32':
+        locales = ['FRENCH']
+    else:
+        locales = ['fr_FR', 'fr_FR.UTF-8', 'fi_FI', 'fi_FI.UTF-8']
+
+    old_locale = locale.getlocale(locale.LC_NUMERIC)
+    new_locale = None
+    try:
+        for loc in locales:
+            try:
+                locale.setlocale(locale.LC_NUMERIC, loc)
+                new_locale = loc
+                break
+            except locale.Error:
+                pass
+    finally:
+        locale.setlocale(locale.LC_NUMERIC, locale=old_locale)
+    return old_locale, new_locale
+
+
+class CommaDecimalPointLocale(object):
+    """Sets LC_NUMERIC to a locale with comma as decimal point.
+
+    Classes derived from this class have setup and teardown methods that run
+    tests with locale.LC_NUMERIC set to a locale where commas (',') are used as
+    the decimal point instead of periods ('.'). On exit the locale is restored
+    to the initial locale. It also serves as context manager with the same
+    effect. If no such locale is available, it raises SkipTest in both cases.
+
+    .. versionadded:: 1.15.0
+
+    """
+    (cur_locale, tst_locale) = find_comma_decimal_point_locale()
+
+    def setup(self):
+        if self.tst_locale is None:
+            raise SkipTest("No French locale available")
+        locale.setlocale(locale.LC_NUMERIC, locale=self.tst_locale)
+
+    def teardown(self):
+        locale.setlocale(locale.LC_NUMERIC, locale=self.cur_locale)
+
+    def __enter__(self):
+        if self.tst_locale is None:
+            raise SkipTest("No French locale available")
+        locale.setlocale(locale.LC_NUMERIC, locale=self.tst_locale)
+
+    def __exit__(self, type, value, traceback):
+        locale.setlocale(locale.LC_NUMERIC, locale=self.cur_locale)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -429,7 +429,7 @@ class TestNonNumericConjugate(_DeprecationTestCase):
 class TestNPY_CHAR(_DeprecationTestCase):
     # 2017-05-03, 1.13.0
     def test_npy_char_deprecation(self):
-        from numpy.core.multiarray_tests import npy_char_deprecation
+        from numpy.core._multiarray_tests import npy_char_deprecation
         self.assert_deprecated(npy_char_deprecation)
         assert_(npy_char_deprecation() == 'S1')
 
@@ -440,11 +440,11 @@ class Test_UPDATEIFCOPY(_DeprecationTestCase):
     WRITEBACKIFCOPY instead
     """
     def test_npy_updateifcopy_deprecation(self):
-        from numpy.core.multiarray_tests import npy_updateifcopy_deprecation
+        from numpy.core._multiarray_tests import npy_updateifcopy_deprecation
         arr = np.arange(9).reshape(3, 3)
         v = arr.T
         self.assert_deprecated(npy_updateifcopy_deprecation, args=(v,))
-    
+
 
 class TestDatetimeEvent(_DeprecationTestCase):
     # 2017-08-11, 1.14.0

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -5,7 +5,7 @@ import sys
 import operator
 
 import numpy as np
-from numpy.core.test_rational import rational
+from numpy.core._rational_tests import rational
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,
     dec

--- a/numpy/core/tests/test_extint128.py
+++ b/numpy/core/tests/test_extint128.py
@@ -6,7 +6,7 @@ import contextlib
 import operator
 
 import numpy as np
-import numpy.core.multiarray_tests as mt
+import numpy.core._multiarray_tests as mt
 from numpy.compat import long
 
 from numpy.testing import assert_raises, assert_equal, dec

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -6,7 +6,7 @@ import functools
 import operator
 
 import numpy as np
-from numpy.core.multiarray_tests import array_indexing
+from numpy.core._multiarray_tests import array_indexing
 from itertools import product
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -7,8 +7,8 @@ import numpy as np
 from numpy.testing import (run_module_suite, assert_, assert_raises, assert_equal,
                            assert_array_equal, assert_allclose, dec)
 
-from numpy.core.multiarray_tests import solve_diophantine, internal_overlap
-from numpy.core import umath_tests
+from numpy.core._multiarray_tests import solve_diophantine, internal_overlap
+from numpy.core import _umath_tests
 from numpy.lib.stride_tricks import as_strided
 from numpy.compat import long
 
@@ -749,7 +749,7 @@ class TestUFunc(object):
 
     def test_unary_gufunc_fuzz(self):
         shapes = [7, 13, 8, 21, 29, 32]
-        gufunc = umath_tests.euclidean_pdist
+        gufunc = _umath_tests.euclidean_pdist
 
         rng = np.random.RandomState(1234)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -26,7 +26,6 @@ from decimal import Decimal
 
 import numpy as np
 from numpy.compat import strchar, unicode
-from numpy.core.tests.test_print import in_foreign_locale
 from numpy.core.multiarray_tests import (
     test_neighborhood_iterator, test_neighborhood_iterator_oob,
     test_pydatamem_seteventhook_start, test_pydatamem_seteventhook_end,
@@ -38,6 +37,7 @@ from numpy.testing import (
     assert_array_almost_equal, assert_allclose, IS_PYPY, HAS_REFCOUNT,
     assert_array_less, runstring, dec, SkipTest, temppath, suppress_warnings
     )
+from ._locales import CommaDecimalPointLocale
 
 # Need to test an object that does not fully implement math interface
 from datetime import timedelta, datetime
@@ -4475,14 +4475,15 @@ class TestIO(object):
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
     def test_locale(self):
-        in_foreign_locale(self.test_numbers)()
-        in_foreign_locale(self.test_nan)()
-        in_foreign_locale(self.test_inf)()
-        in_foreign_locale(self.test_counted_string)()
-        in_foreign_locale(self.test_ascii)()
-        in_foreign_locale(self.test_malformed)()
-        in_foreign_locale(self.test_tofile_sep)()
-        in_foreign_locale(self.test_tofile_format)()
+        with CommaDecimalPointLocale():
+            self.test_numbers()
+            self.test_nan()
+            self.test_inf()
+            self.test_counted_string()
+            self.test_ascii()
+            self.test_malformed()
+            self.test_tofile_sep()
+            self.test_tofile_format()
 
 
 class TestFromBuffer(object):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -26,11 +26,7 @@ from decimal import Decimal
 
 import numpy as np
 from numpy.compat import strchar, unicode
-from numpy.core._multiarray_tests import (
-    test_neighborhood_iterator, test_neighborhood_iterator_oob,
-    test_pydatamem_seteventhook_start, test_pydatamem_seteventhook_end,
-    test_inplace_increment, get_buffer_info, test_as_c_array,
-    )
+import numpy.core._multiarray_tests as _multiarray_tests
 from numpy.testing import (
     run_module_suite, assert_, assert_raises, assert_warns,
     assert_equal, assert_almost_equal, assert_array_equal, assert_raises_regex,
@@ -5807,24 +5803,24 @@ class TestNeighborhoodIter(object):
              np.array([[0, 0, 0], [0, 1, 0]], dtype=dt),
              np.array([[0, 0, 1], [0, 2, 3]], dtype=dt),
              np.array([[0, 1, 0], [2, 3, 0]], dtype=dt)]
-        l = test_neighborhood_iterator(x, [-1, 0, -1, 1], x[0],
-                NEIGH_MODE['zero'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 0, -1, 1], x[0], NEIGH_MODE['zero'])
         assert_array_equal(l, r)
 
         r = [np.array([[1, 1, 1], [1, 0, 1]], dtype=dt),
              np.array([[1, 1, 1], [0, 1, 1]], dtype=dt),
              np.array([[1, 0, 1], [1, 2, 3]], dtype=dt),
              np.array([[0, 1, 1], [2, 3, 1]], dtype=dt)]
-        l = test_neighborhood_iterator(x, [-1, 0, -1, 1], x[0],
-                NEIGH_MODE['one'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 0, -1, 1], x[0], NEIGH_MODE['one'])
         assert_array_equal(l, r)
 
         r = [np.array([[4, 4, 4], [4, 0, 1]], dtype=dt),
              np.array([[4, 4, 4], [0, 1, 4]], dtype=dt),
              np.array([[4, 0, 1], [4, 2, 3]], dtype=dt),
              np.array([[0, 1, 4], [2, 3, 4]], dtype=dt)]
-        l = test_neighborhood_iterator(x, [-1, 0, -1, 1], 4,
-                NEIGH_MODE['constant'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 0, -1, 1], 4, NEIGH_MODE['constant'])
         assert_array_equal(l, r)
 
     def test_simple2d(self):
@@ -5839,8 +5835,8 @@ class TestNeighborhoodIter(object):
              np.array([[0, 1, 1], [0, 1, 1]], dtype=dt),
              np.array([[0, 0, 1], [2, 2, 3]], dtype=dt),
              np.array([[0, 1, 1], [2, 3, 3]], dtype=dt)]
-        l = test_neighborhood_iterator(x, [-1, 0, -1, 1], x[0],
-                NEIGH_MODE['mirror'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 0, -1, 1], x[0], NEIGH_MODE['mirror'])
         assert_array_equal(l, r)
 
     def test_mirror2d(self):
@@ -5854,15 +5850,18 @@ class TestNeighborhoodIter(object):
         # Test padding with constant values
         x = np.linspace(1, 5, 5).astype(dt)
         r = [[0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 0]]
-        l = test_neighborhood_iterator(x, [-1, 1], x[0], NEIGH_MODE['zero'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 1], x[0], NEIGH_MODE['zero'])
         assert_array_equal(l, r)
 
         r = [[1, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 1]]
-        l = test_neighborhood_iterator(x, [-1, 1], x[0], NEIGH_MODE['one'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 1], x[0], NEIGH_MODE['one'])
         assert_array_equal(l, r)
 
         r = [[x[4], 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, x[4]]]
-        l = test_neighborhood_iterator(x, [-1, 1], x[4], NEIGH_MODE['constant'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-1, 1], x[4], NEIGH_MODE['constant'])
         assert_array_equal(l, r)
 
     def test_simple_float(self):
@@ -5876,7 +5875,8 @@ class TestNeighborhoodIter(object):
         x = np.linspace(1, 5, 5).astype(dt)
         r = np.array([[2, 1, 1, 2, 3], [1, 1, 2, 3, 4], [1, 2, 3, 4, 5],
                 [2, 3, 4, 5, 5], [3, 4, 5, 5, 4]], dtype=dt)
-        l = test_neighborhood_iterator(x, [-2, 2], x[1], NEIGH_MODE['mirror'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-2, 2], x[1], NEIGH_MODE['mirror'])
         assert_([i.dtype == dt for i in l])
         assert_array_equal(l, r)
 
@@ -5891,7 +5891,8 @@ class TestNeighborhoodIter(object):
         x = np.linspace(1, 5, 5).astype(dt)
         r = np.array([[4, 5, 1, 2, 3], [5, 1, 2, 3, 4], [1, 2, 3, 4, 5],
                 [2, 3, 4, 5, 1], [3, 4, 5, 1, 2]], dtype=dt)
-        l = test_neighborhood_iterator(x, [-2, 2], x[0], NEIGH_MODE['circular'])
+        l = _multiarray_tests.test_neighborhood_iterator(
+                x, [-2, 2], x[0], NEIGH_MODE['circular'])
         assert_array_equal(l, r)
 
     def test_circular(self):
@@ -5914,8 +5915,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([3], dtype=dt),
              np.array([0], dtype=dt),
              np.array([0], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-2, 4], NEIGH_MODE['zero'],
-                [0, 0], NEIGH_MODE['zero'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-2, 4], NEIGH_MODE['zero'], [0, 0], NEIGH_MODE['zero'])
         assert_array_equal(l, r)
 
         r = [np.array([1, 0, 1], dtype=dt),
@@ -5923,8 +5924,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([1, 2, 3], dtype=dt),
              np.array([2, 3, 0], dtype=dt),
              np.array([3, 0, 1], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [-1, 1], NEIGH_MODE['one'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [-1, 1], NEIGH_MODE['one'])
         assert_array_equal(l, r)
 
     # 2nd simple, 1d test: stacking 2 neigh iterators, mixing const padding and
@@ -5938,8 +5939,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([1, 2, 3], dtype=dt),
              np.array([2, 3, 3], dtype=dt),
              np.array([3, 3, 0], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['mirror'],
-                [-1, 1], NEIGH_MODE['zero'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['mirror'], [-1, 1], NEIGH_MODE['zero'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero
@@ -5949,8 +5950,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([0, 1, 2], dtype=dt),
              np.array([1, 2, 3], dtype=dt),
              np.array([2, 3, 0], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [-2, 0], NEIGH_MODE['mirror'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [-2, 0], NEIGH_MODE['mirror'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero: 2nd
@@ -5960,8 +5961,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([2, 3, 0], dtype=dt),
              np.array([3, 0, 0], dtype=dt),
              np.array([0, 0, 3], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [0, 2], NEIGH_MODE['mirror'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [0, 2], NEIGH_MODE['mirror'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero: 3rd
@@ -5971,8 +5972,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([0, 1, 2, 3, 0], dtype=dt),
              np.array([1, 2, 3, 0, 0], dtype=dt),
              np.array([2, 3, 0, 0, 3], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [-2, 2], NEIGH_MODE['mirror'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [-2, 2], NEIGH_MODE['mirror'])
         assert_array_equal(l, r)
 
     # 3rd simple, 1d test: stacking 2 neigh iterators, mixing const padding and
@@ -5986,8 +5987,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([1, 2, 3], dtype=dt),
              np.array([2, 3, 1], dtype=dt),
              np.array([3, 1, 0], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['circular'],
-                [-1, 1], NEIGH_MODE['zero'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['circular'], [-1, 1], NEIGH_MODE['zero'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero
@@ -5997,8 +5998,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([0, 1, 2], dtype=dt),
              np.array([1, 2, 3], dtype=dt),
              np.array([2, 3, 0], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [-2, 0], NEIGH_MODE['circular'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [-2, 0], NEIGH_MODE['circular'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero: 2nd
@@ -6008,8 +6009,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([2, 3, 0], dtype=dt),
              np.array([3, 0, 0], dtype=dt),
              np.array([0, 0, 1], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [0, 2], NEIGH_MODE['circular'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [0, 2], NEIGH_MODE['circular'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero: 3rd
@@ -6019,8 +6020,8 @@ class TestStackedNeighborhoodIter(object):
              np.array([0, 1, 2, 3, 0], dtype=dt),
              np.array([1, 2, 3, 0, 0], dtype=dt),
              np.array([2, 3, 0, 0, 1], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [-1, 3], NEIGH_MODE['zero'],
-                [-2, 2], NEIGH_MODE['circular'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [-1, 3], NEIGH_MODE['zero'], [-2, 2], NEIGH_MODE['circular'])
         assert_array_equal(l, r)
 
     # 4th simple, 1d test: stacking 2 neigh iterators, but with lower iterator
@@ -6031,24 +6032,24 @@ class TestStackedNeighborhoodIter(object):
         # array
         x = np.array([1, 2, 3], dtype=dt)
         r = [np.array([1, 2, 3, 0], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [1, 1], NEIGH_MODE['zero'],
-                [-1, 2], NEIGH_MODE['zero'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [1, 1], NEIGH_MODE['zero'], [-1, 2], NEIGH_MODE['zero'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero, first neighborhood strictly inside the
         # array
         x = np.array([1, 2, 3], dtype=dt)
         r = [np.array([1, 2, 3, 3], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [1, 1], NEIGH_MODE['zero'],
-                [-1, 2], NEIGH_MODE['mirror'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [1, 1], NEIGH_MODE['zero'], [-1, 2], NEIGH_MODE['mirror'])
         assert_array_equal(l, r)
 
         # Stacking mirror on top of zero, first neighborhood strictly inside the
         # array
         x = np.array([1, 2, 3], dtype=dt)
         r = [np.array([1, 2, 3, 1], dtype=dt)]
-        l = test_neighborhood_iterator_oob(x, [1, 1], NEIGH_MODE['zero'],
-                [-1, 2], NEIGH_MODE['circular'])
+        l = _multiarray_tests.test_neighborhood_iterator_oob(
+                x, [1, 1], NEIGH_MODE['zero'], [-1, 2], NEIGH_MODE['circular'])
         assert_array_equal(l, r)
 
 class TestWarnings(object):
@@ -6432,7 +6433,9 @@ class TestNewBufferProtocol(object):
 
     def test_export_flags(self):
         # Check SIMPLE flag, see also gh-3613 (exception should be BufferError)
-        assert_raises(ValueError, get_buffer_info, np.arange(5)[::2], ('SIMPLE',))
+        assert_raises(ValueError,
+                      _multiarray_tests.get_buffer_info,
+                       np.arange(5)[::2], ('SIMPLE',))
 
     def test_padding(self):
         for j in range(8):
@@ -6488,10 +6491,12 @@ class TestNewBufferProtocol(object):
 
         arr = np.ones((1, 10))
         if arr.flags.f_contiguous:
-            shape, strides = get_buffer_info(arr, ['F_CONTIGUOUS'])
+            shape, strides = _multiarray_tests.get_buffer_info(
+                    arr, ['F_CONTIGUOUS'])
             assert_(strides[0] == 8)
             arr = np.ones((10, 1), order='F')
-            shape, strides = get_buffer_info(arr, ['C_CONTIGUOUS'])
+            shape, strides = _multiarray_tests.get_buffer_info(
+                    arr, ['C_CONTIGUOUS'])
             assert_(strides[-1] == 8)
 
     def test_out_of_order_fields(self):
@@ -6634,13 +6639,13 @@ class TestMemEventHook(object):
     def test_mem_seteventhook(self):
         # The actual tests are within the C code in
         # multiarray/_multiarray_tests.c.src
-        test_pydatamem_seteventhook_start()
+        _multiarray_tests.test_pydatamem_seteventhook_start()
         # force an allocation and free of a numpy array
         # needs to be larger then limit of small memory cacher in ctors.c
         a = np.zeros(1000)
         del a
         gc.collect()
-        test_pydatamem_seteventhook_end()
+        _multiarray_tests.test_pydatamem_seteventhook_end()
 
 class TestMapIter(object):
     def test_mapiter(self):
@@ -6652,7 +6657,7 @@ class TestMapIter(object):
                  [0, 0, 2, 3])
         vals = [50, 50, 30, 16]
 
-        test_inplace_increment(a, index, vals)
+        _multiarray_tests.test_inplace_increment(a, index, vals)
         assert_equal(a, [[0.00, 1., 2.0, 19.],
                          [104., 5., 6.0, 7.0],
                          [8.00, 9., 40., 11.]])
@@ -6660,24 +6665,24 @@ class TestMapIter(object):
         b = np.arange(6).astype(float)
         index = (np.array([1, 2, 0]),)
         vals = [50, 4, 100.1]
-        test_inplace_increment(b, index, vals)
+        _multiarray_tests.test_inplace_increment(b, index, vals)
         assert_equal(b, [100.1,  51.,   6.,   3.,   4.,   5.])
 
 
 class TestAsCArray(object):
     def test_1darray(self):
         array = np.arange(24, dtype=np.double)
-        from_c = test_as_c_array(array, 3)
+        from_c = _multiarray_tests.test_as_c_array(array, 3)
         assert_equal(array[3], from_c)
 
     def test_2darray(self):
         array = np.arange(24, dtype=np.double).reshape(3, 8)
-        from_c = test_as_c_array(array, 2, 4)
+        from_c = _multiarray_tests.test_as_c_array(array, 2, 4)
         assert_equal(array[2, 4], from_c)
 
     def test_3darray(self):
         array = np.arange(24, dtype=np.double).reshape(2, 3, 4)
-        from_c = test_as_c_array(array, 1, 2, 3)
+        from_c = _multiarray_tests.test_as_c_array(array, 1, 2, 3)
         assert_equal(array[1, 2, 3], from_c)
 
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -26,7 +26,7 @@ from decimal import Decimal
 
 import numpy as np
 from numpy.compat import strchar, unicode
-from numpy.core.multiarray_tests import (
+from numpy.core._multiarray_tests import (
     test_neighborhood_iterator, test_neighborhood_iterator_oob,
     test_pydatamem_seteventhook_start, test_pydatamem_seteventhook_end,
     test_inplace_increment, get_buffer_info, test_as_c_array,
@@ -193,7 +193,7 @@ class TestAttributes(object):
             assert_equal(isinstance(numpy_int, int), True)
 
             # ... and fast-path checks on C-API level should also work
-            from numpy.core.multiarray_tests import test_int_subclass
+            from numpy.core._multiarray_tests import test_int_subclass
             assert_equal(test_int_subclass(numpy_int), True)
 
     def test_stridesattr(self):
@@ -3344,7 +3344,7 @@ class TestTemporaryElide(object):
         # def incref_elide(a):
         #    d = input.copy() # refcount 1
         #    return d, d + d # PyNumber_Add without increasing refcount
-        from numpy.core.multiarray_tests import incref_elide
+        from numpy.core._multiarray_tests import incref_elide
         d = np.ones(100000)
         orig, res = incref_elide(d)
         d + d
@@ -3359,7 +3359,7 @@ class TestTemporaryElide(object):
         #
         # def incref_elide_l(d):
         #    return l[4] + l[4] # PyNumber_Add without increasing refcount
-        from numpy.core.multiarray_tests import incref_elide_l
+        from numpy.core._multiarray_tests import incref_elide_l
         # padding with 1 makes sure the object on the stack is not overwritten
         l = [1, 1, 1, 1, np.ones(100000)]
         res = incref_elide_l(l)
@@ -3438,7 +3438,7 @@ class TestTemporaryElide(object):
 
 class TestCAPI(object):
     def test_IsPythonScalar(self):
-        from numpy.core.multiarray_tests import IsPythonScalar
+        from numpy.core._multiarray_tests import IsPythonScalar
         assert_(IsPythonScalar(b'foobar'))
         assert_(IsPythonScalar(1))
         assert_(IsPythonScalar(2**80))
@@ -6633,7 +6633,7 @@ def test_scalar_element_deletion():
 class TestMemEventHook(object):
     def test_mem_seteventhook(self):
         # The actual tests are within the C code in
-        # multiarray/multiarray_tests.c.src
+        # multiarray/_multiarray_tests.c.src
         test_pydatamem_seteventhook_start()
         # force an allocation and free of a numpy array
         # needs to be larger then limit of small memory cacher in ctors.c
@@ -6645,7 +6645,7 @@ class TestMemEventHook(object):
 class TestMapIter(object):
     def test_mapiter(self):
         # The actual tests are within the C code in
-        # multiarray/multiarray_tests.c.src
+        # multiarray/_multiarray_tests.c.src
 
         a = np.arange(12).reshape((3, 4)).astype(float)
         index = ([1, 1, 2, 0],
@@ -7237,7 +7237,7 @@ class TestWritebackIfCopy(object):
         assert_equal(b, np.array([[15, 18, 21], [42, 54, 66], [69, 90, 111]]))
 
     def test_view_assign(self):
-        from numpy.core.multiarray_tests import npy_create_writebackifcopy, npy_resolve
+        from numpy.core._multiarray_tests import npy_create_writebackifcopy, npy_resolve
         arr = np.arange(9).reshape(3, 3).T
         arr_wb = npy_create_writebackifcopy(arr)
         assert_(arr_wb.flags.writebackifcopy)
@@ -7307,7 +7307,7 @@ def test_equal_override():
 
 def test_npymath_complex():
     # Smoketest npymath functions
-    from numpy.core.multiarray_tests import (
+    from numpy.core._multiarray_tests import (
         npy_cabs, npy_carg)
 
     funcs = {npy_cabs: np.absolute,
@@ -7326,7 +7326,7 @@ def test_npymath_complex():
 
 def test_npymath_real():
     # Smoketest npymath functions
-    from numpy.core.multiarray_tests import (
+    from numpy.core._multiarray_tests import (
         npy_log10, npy_cosh, npy_sinh, npy_tan, npy_tanh)
 
     funcs = {npy_log10: np.log10,

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -4,8 +4,8 @@ import sys
 import warnings
 
 import numpy as np
+import numpy.core._multiarray_tests as _multiarray_tests
 from numpy import array, arange, nditer, all
-from numpy.core._multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
     assert_raises, assert_warns, dec, HAS_REFCOUNT, suppress_warnings
@@ -2697,18 +2697,19 @@ def test_iter_too_large_with_multiindex():
     # arrays are now too large to be broadcast. The different modes test
     # different nditer functionality with or without GIL.
     for mode in range(6):
-        assert_raises(ValueError, test_nditer_too_large, arrays, -1, mode)
+        with assert_raises(ValueError):
+            _multiarray_tests.test_nditer_too_large(arrays, -1, mode)
     # but if we do nothing with the nditer, it can be constructed:
-    test_nditer_too_large(arrays, -1, 7)
+    _multiarray_tests.test_nditer_too_large(arrays, -1, 7)
 
     # When an axis is removed, things should work again (half the time):
     for i in range(num):
         for mode in range(6):
             # an axis with size 1024 is removed:
-            test_nditer_too_large(arrays, i*2, mode)
+            _multiarray_tests.test_nditer_too_large(arrays, i*2, mode)
             # an axis with size 1 is removed:
-            assert_raises(ValueError, test_nditer_too_large,
-                          arrays, i*2 + 1, mode)
+            with assert_raises(ValueError):
+                _multiarray_tests.test_nditer_too_large(arrays, i*2 + 1, mode)
 
 
 if __name__ == "__main__":

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 from numpy import array, arange, nditer, all
-from numpy.core.multiarray_tests import test_nditer_too_large
+from numpy.core._multiarray_tests import test_nditer_too_large
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_array_equal,
     assert_raises, assert_warns, dec, HAS_REFCOUNT, suppress_warnings

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -2,12 +2,14 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import locale
+import contextlib
 import nose
 
 import numpy as np
 from numpy.testing import (
-    run_module_suite, assert_, assert_equal, SkipTest
+    run_module_suite, assert_, assert_equal, SkipTest, dec
 )
+from ._locales import CommaDecimalPointLocale
 
 
 if sys.version_info[0] >= 3:
@@ -201,46 +203,21 @@ def test_scalar_format():
                             (fmat, repr(val), repr(valtype), str(e)))
 
 
+#
 # Locale tests: scalar types formatting should be independent of the locale
-def in_foreign_locale(func):
-    """
-    Swap LC_NUMERIC locale to one in which the decimal point is ',' and not '.'
-    If not possible, raise SkipTest
+#
 
-    """
-    if sys.platform == 'win32':
-        locales = ['FRENCH']
-    else:
-        locales = ['fr_FR', 'fr_FR.UTF-8', 'fi_FI', 'fi_FI.UTF-8']
+class TestCommaDecimalPointLocale(CommaDecimalPointLocale):
 
-    def wrapper(*args, **kwargs):
-        curloc = locale.getlocale(locale.LC_NUMERIC)
-        try:
-            for loc in locales:
-                try:
-                    locale.setlocale(locale.LC_NUMERIC, loc)
-                    break
-                except locale.Error:
-                    pass
-            else:
-                raise SkipTest("Skipping locale test, because "
-                                "French locale not found")
-            return func(*args, **kwargs)
-        finally:
-            locale.setlocale(locale.LC_NUMERIC, locale=curloc)
-    return nose.tools.make_decorator(func)(wrapper)
+    def test_locale_single(self):
+        assert_equal(str(np.float32(1.2)), str(float(1.2)))
 
-@in_foreign_locale
-def test_locale_single():
-    assert_equal(str(np.float32(1.2)), str(float(1.2)))
+    def test_locale_double(self):
+        assert_equal(str(np.double(1.2)), str(float(1.2)))
 
-@in_foreign_locale
-def test_locale_double():
-    assert_equal(str(np.double(1.2)), str(float(1.2)))
+    def test_locale_longdouble(self):
+        assert_equal(str(np.longdouble('1.2')), str(float(1.2)))
 
-@in_foreign_locale
-def test_locale_longdouble():
-    assert_equal(str(np.longdouble('1.2')), str(float(1.2)))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -6,7 +6,7 @@ import itertools
 import numpy as np
 import numpy.core._umath_tests as umt
 import numpy.core._operand_flag_tests as opflag_tests
-from numpy.core._rational_tests import rational, test_add, test_add_rationals
+import numpy.core._rational_tests as _rational_tests
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
@@ -43,7 +43,8 @@ class TestUfunc(object):
 
         # Check that ufunc not defined in the top level numpy namespace such as
         # numpy.core._rational_tests.test_add can also be pickled
-        assert_(pickle.loads(pickle.dumps(test_add)) is test_add)
+        res = pickle.loads(pickle.dumps(_rational_tests.test_add))
+        assert_(res is _rational_tests.test_add)
 
     def test_pickle_withstring(self):
         import pickle
@@ -1143,15 +1144,17 @@ class TestUfunc(object):
 
         a = np.array([0, 1, 2], dtype='i8')
         b = np.array([0, 1, 2], dtype='i8')
-        c = np.empty(3, dtype=rational)
+        c = np.empty(3, dtype=_rational_tests.rational)
 
         # Output must be specified so numpy knows what
         # ufunc signature to look for
-        result = test_add(a, b, c)
-        assert_equal(result, np.array([0, 2, 4], dtype=rational))
+        result = _rational_tests.test_add(a, b, c)
+        target = np.array([0, 2, 4], dtype=_rational_tests.rational)
+        assert_equal(result, target)
 
         # no output type should raise TypeError
-        assert_raises(TypeError, test_add, a, b)
+        with assert_raises(TypeError):
+            _rational_tests.test_add(a, b)
 
     def test_operand_flags(self):
         a = np.arange(16, dtype='l').reshape(4, 4)
@@ -1176,20 +1179,30 @@ class TestUfunc(object):
         assert_equal(result, np.array([(2, 4, 6)], dtype='u8,u8,u8'))
 
     def test_custom_ufunc(self):
-        a = np.array([rational(1, 2), rational(1, 3), rational(1, 4)],
-            dtype=rational)
-        b = np.array([rational(1, 2), rational(1, 3), rational(1, 4)],
-            dtype=rational)
+        a = np.array(
+            [_rational_tests.rational(1, 2),
+             _rational_tests.rational(1, 3),
+             _rational_tests.rational(1, 4)],
+            dtype=_rational_tests.rational)
+        b = np.array(
+            [_rational_tests.rational(1, 2),
+             _rational_tests.rational(1, 3),
+             _rational_tests.rational(1, 4)],
+            dtype=_rational_tests.rational)
 
-        result = test_add_rationals(a, b)
-        expected = np.array([rational(1), rational(2, 3), rational(1, 2)],
-            dtype=rational)
+        result = _rational_tests.test_add_rationals(a, b)
+        expected = np.array(
+            [_rational_tests.rational(1),
+             _rational_tests.rational(2, 3),
+             _rational_tests.rational(1, 2)],
+            dtype=_rational_tests.rational)
         assert_equal(result, expected)
 
     def test_custom_ufunc_forced_sig(self):
         # gh-9351 - looking for a non-first userloop would previously hang
-        assert_raises(TypeError,
-            np.multiply, rational(1), 1, signature=(rational, int, None))
+        with assert_raises(TypeError):
+            np.multiply(_rational_tests.rational(1), 1,
+                        signature=(_rational_tests.rational, int, None))
 
     def test_custom_array_like(self):
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -4,9 +4,9 @@ import warnings
 import itertools
 
 import numpy as np
-import numpy.core.umath_tests as umt
-import numpy.core.operand_flag_tests as opflag_tests
-from numpy.core.test_rational import rational, test_add, test_add_rationals
+import numpy.core._umath_tests as umt
+import numpy.core._operand_flag_tests as opflag_tests
+from numpy.core._rational_tests import rational, test_add, test_add_rationals
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
@@ -42,7 +42,7 @@ class TestUfunc(object):
         assert_(pickle.loads(pickle.dumps(np.sin)) is np.sin)
 
         # Check that ufunc not defined in the top level numpy namespace such as
-        # numpy.core.test_rational.test_add can also be pickled
+        # numpy.core._rational_tests.test_add can also be pickled
         assert_(pickle.loads(pickle.dumps(test_add)) is test_add)
 
     def test_pickle_withstring(self):
@@ -1167,7 +1167,7 @@ class TestUfunc(object):
         assert_equal(a, 10)
 
     def test_struct_ufunc(self):
-        import numpy.core.struct_ufunc_test as struct_ufunc
+        import numpy.core._struct_ufunc_tests as struct_ufunc
 
         a = np.array([(1, 2, 3)], dtype='u8,u8,u8')
         b = np.array([(1, 2, 3)], dtype='u8,u8,u8')

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -7,7 +7,7 @@ import fnmatch
 import itertools
 
 import numpy.core.umath as ncu
-from numpy.core import umath_tests as ncu_tests
+from numpy.core import _umath_tests as ncu_tests
 import numpy as np
 from numpy.testing import (
     run_module_suite, assert_, assert_equal, assert_raises,

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.core.test_rational import rational
+from numpy.core._rational_tests import rational
 from numpy.testing import (
     run_module_suite, assert_equal, assert_array_equal,
     assert_raises, assert_

--- a/numpy/testing/nose_tools/noseclasses.py
+++ b/numpy/testing/nose_tools/noseclasses.py
@@ -325,7 +325,7 @@ class FPUModeCheckPlugin(Plugin):
     """
 
     def prepareTestCase(self, test):
-        from numpy.core.multiarray_tests import get_fpu_mode
+        from numpy.core._multiarray_tests import get_fpu_mode
 
         def run(result):
             old_mode = get_fpu_mode()

--- a/numpy/testing/nose_tools/utils.py
+++ b/numpy/testing/nose_tools/utils.py
@@ -1156,10 +1156,54 @@ def rundocs(filename=None, raise_on_error=True):
         raise AssertionError("Some doctests failed:\n%s" % "\n".join(msg))
 
 
-def raises(*args,**kwargs):
-    nose = import_nose()
-    return nose.tools.raises(*args,**kwargs)
+def raises(*args):
+    """Decorator to check for raised exceptions.
 
+    The decorated test function must raise one of the passed exceptions to
+    pass.  If you want to test many assertions about exceptions in a single
+    test, you may want to use `assert_raises` instead.
+
+    .. warning::
+       This decorator is nose specific, do not use it if you are using a
+       different test framework.
+
+    Parameters
+    ----------
+    args : exceptions
+        The test passes if any of the passed exceptions is raised.
+
+    Raises
+    ------
+    AssertionError
+
+    Examples
+    --------
+
+    Usage::
+
+        @raises(TypeError, ValueError)
+        def test_raises_type_error():
+            raise TypeError("This test passes")
+
+        @raises(Exception)
+        def test_that_fails_by_passing():
+            pass
+
+    """
+    nose = import_nose()
+    return nose.tools.raises(*args)
+
+#
+# assert_raises and assert_raises_regex are taken from unittest.
+#
+import unittest
+
+
+class _Dummy(unittest.TestCase):
+    def nop(self):
+        pass
+
+_d = _Dummy('nop')
 
 def assert_raises(*args, **kwargs):
     """
@@ -1187,8 +1231,7 @@ def assert_raises(*args, **kwargs):
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test
-    nose = import_nose()
-    return nose.tools.assert_raises(*args,**kwargs)
+    return _d.assertRaises(*args,**kwargs)
 
 
 def assert_raises_regex(exception_class, expected_regexp, *args, **kwargs):
@@ -1212,13 +1255,12 @@ def assert_raises_regex(exception_class, expected_regexp, *args, **kwargs):
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test
-    nose = import_nose()
 
     if sys.version_info.major >= 3:
-        funcname = nose.tools.assert_raises_regex
+        funcname = _d.assertRaisesRegex
     else:
         # Only present in Python 2.7, missing from unittest in 2.6
-        funcname = nose.tools.assert_raises_regexp
+        funcname = _d.assertRaisesRegexp
 
     return funcname(exception_class, expected_regexp, *args, **kwargs)
 


### PR DESCRIPTION
With these changes we have the following results when testing with pytest/nose on Python 2.7.
```
numpy/linalg/tests
    pytest -- run:121 skipped:0 slow:22
    nose   -- run:121 skipped:0 slow:22
numpy/testing/tests
    pytest -- run:118 skipped:4
    nose   -- run:122 skipped:0
numpy/random/tests
    pytest -- run:138 skipped:0 slow:0
    nose   -- run:138 skipped:0 slow:0
numpy/ma/tests
    pytest -- run:445 skipped:2 slow:0
    nose   -- run:445 skipped:2 slow:0
numpy/distutils/tests
    pytest -- run:27 skipped:0 slow:0
    nose   -- run:27 skipped:0 slow:0
numpy/fft/tests
    pytest -- run:30 skipped:0 slow:0
    nose   -- run:30 skipped:0 slow:0
numpy/polynomial/tests
    pytest -- run:451 skipped:0 slow:0
    nose   -- run:451 skipped:0 slow:0
numpy/compat/tests
    pytest -- run:1 skipped:0
    nose   -- run:1 skipped:0
numpy/tests
    pytest -- run:19 skipped:0
    nose   -- run:19 skipped:0
numpy/core/tests
    pytest -- run:2004 skipped:11 slow:10
    nose   -- run:2004 skipped:11 slow:10
numpy/lib/tests
    pytest -- run:1156 skipped:3 slow:5
    nose   -- run:1156 skipped:3 slow:5
numpy/f2py/tests
    pytest -- run:365 skipped:0 slow:31
    nose   -- run:365 skipped:0 slow:31
numpy/matrixlib/tests
    pytest -- run:50 skipped:0 slow:0
    nose   -- run:50 skipped:0 slow:0
```

Changes
=======
TST: Add numpy/compat/tests
---------------------------

These tests were not included in the `setup.py` file and consequently
not available in the installed numpy for testing.

TST: Do not import functions beginning `test_`.
-----------------------------------------------

Avoids pytest collection time warnings.


TST: Rename some compiled c test modules
----------------------------------------

The renamed C modules provide low level functions for testing. The
rename marks them as private functions and makes them invisible to
pytest by default.


TST: Remove nose dependence of locale tests.
--------------------------------------------
Add class CommaDecimalPointLocale that can be used for testing in a
LC_NUMERIC locale where the decimal point is a comma. It functions
either as a context manager or as a base class with setup and teardown
methods. Both uses raise SkipTest when no suitable locale is available.


TST: Remove some nose dependences in utils.py
---------------------------------------------

The `assert_raises` and `assert_raises_regex` testing utilities were
being imported from nose, which in turn took them from unittest
`assertRaises` and `assertRaisesRegex`. We takeover the nose procedure
here so that these commonly used utilities no longer have a nose
dependence.

The `raises` decorator continues to have a nose dependency, but that
only shows up when used, and NumPy does not use it. Document that and
otherwise leave it be.
