### PR TITLE
BUG: fix wrong inplace vectorization on overlapping arguments

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -30,6 +30,16 @@
  */
 #define PW_BLOCKSIZE    128
 
+
+/*
+ * largest simd vector size in bytes numpy supports
+ * it is currently a extremely large value as it is only used for memory
+ * overlap checks
+ */
+#ifndef NPY_MAX_SIMD_SIZE
+#define NPY_MAX_SIMD_SIZE 1024
+#endif
+
 /*
  * include vectorized functions and dispatchers
  * this file is safe to include also for generic builds
@@ -180,10 +190,12 @@
     do { \
     /* condition allows compiler to optimize the generic macro */ \
     if (IS_BINARY_CONT(tin, tout)) { \
-        if (args[2] == args[0]) { \
+        if (abs_ptrdiff(args[2], args[0]) == 0 && \
+                abs_ptrdiff(args[2], args[1]) >= NPY_MAX_SIMD_SIZE) { \
             BASE_BINARY_LOOP_INP(tin, tout, op) \
         } \
-        else if (args[2] == args[1]) { \
+        else if (abs_ptrdiff(args[2], args[1]) == 0 && \
+                     abs_ptrdiff(args[2], args[0]) >= NPY_MAX_SIMD_SIZE) { \
             BASE_BINARY_LOOP_INP(tin, tout, op) \
         } \
         else { \
@@ -191,7 +203,7 @@
         } \
     } \
     else if (IS_BINARY_CONT_S1(tin, tout)) { \
-        if (args[1] == args[2]) { \
+        if (abs_ptrdiff(args[2], args[1]) == 0) { \
             BASE_BINARY_LOOP_S_INP(tin, tout, in1, args[0], in2, ip2, op) \
         } \
         else { \
@@ -199,7 +211,7 @@
         } \
     } \
     else if (IS_BINARY_CONT_S2(tin, tout)) { \
-        if (args[0] == args[2]) { \
+        if (abs_ptrdiff(args[2], args[0]) == 0) { \
             BASE_BINARY_LOOP_S_INP(tin, tout, in2, args[1], in1, ip1, op) \
         } \
         else { \


### PR DESCRIPTION
The input arguments to inplace operations can overlap for accumulate operations where `out[i+1] = in[i] + out[i]`. That breaks the no loop carried dependency assumptions the compiler has due to the ivdep pragma that is required for GCC to vectorize the loop. Currently this does no harm because accumulate operations are out of place, but future enhancements may change that.

Fix this by verifying the arguments do not overlap within a hardware
vector size. As we do not know the vector size of future machines use an extremely
large value of 1024 bytes (commodity hardware currently has at most 64bytes)

Closes gh-10664