### PR TITLE
BUG: fix obvious mistake in testing/decorators warning.

### DIFF
--- a/numpy/testing/decorators.py
+++ b/numpy/testing/decorators.py
@@ -5,7 +5,7 @@ set of tools
 """
 import warnings
 
-warnings.warn(ImportWarning,
-    "Import from numpy.testing, not numpy.testing.decorators")
+warnings.warn("Import from numpy.testing, not numpy.testing.decorators",
+              ImportWarning)
 
 from ._private.decorators import *


### PR DESCRIPTION
This broke the doc build. Will deal with the import in the wrong place later; came via Sphinx so not completely obvious to fix.