### PR TITLE
ENH: Add support for the 64-bit RISC-V architecture

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -82,6 +82,10 @@ Creating a full iOS-compatible NumPy package requires building for the 5
 architectures supported by iOS (i386, x86_64, armv7, armv7s and arm64), and
 combining these 5 compiled builds products into a single "fat" binary.
 
+Build system
+------------
+Added experimental support for the 64-bit RISC-V architecture.
+
 Improvements
 ============
 

--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -17,6 +17,7 @@
  *              NPY_CPU_SH_BE
  *              NPY_CPU_ARCEL
  *              NPY_CPU_ARCEB
+ *              NPY_CPU_RISCV64
  */
 #ifndef _NPY_CPUARCH_H_
 #define _NPY_CPUARCH_H_
@@ -82,6 +83,8 @@
     #define NPY_CPU_ARCEL
 #elif defined(__arc__) && defined(__BIG_ENDIAN__)
     #define NPY_CPU_ARCEB
+#elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
+    #define NPY_CPU_RISCV64
 #else
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -46,7 +46,7 @@
             || defined(NPY_CPU_SH_LE)   \
             || defined(NPY_CPU_MIPSEL)  \
             || defined(NPY_CPU_PPC64LE) \
-            || defined(NPY_CPU_ARCEL)	\
+            || defined(NPY_CPU_ARCEL)   \
             || defined(NPY_CPU_RISCV64)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
     #elif defined(NPY_CPU_PPC)          \

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -46,7 +46,8 @@
             || defined(NPY_CPU_SH_LE)   \
             || defined(NPY_CPU_MIPSEL)  \
             || defined(NPY_CPU_PPC64LE) \
-            || defined(NPY_CPU_ARCEL)
+            || defined(NPY_CPU_ARCEL)	\
+            || defined(NPY_CPU_RISCV64)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
     #elif defined(NPY_CPU_PPC)          \
             || defined(NPY_CPU_SPARC)   \


### PR DESCRIPTION
RISC-V (pronounced "RISC Five") is an open source instruction set
architecture (ISA). The 64-bit version may run the Linux kernel and the
usual stack of applications on top of it, including Python.

This patch adds support for riscv64 to Numpy. With it the full testsuite
passes for both Python 2.7 and 3.6, with the only exception of
test_float (test_numeric.TestBoolCmp). See #8213 for details.

Closes: #8213