### PR TITLE
DEP: Issue deprecation warnings for some imports.

### DIFF
--- a/numpy/core/umath_tests.py
+++ b/numpy/core/umath_tests.py
@@ -1,0 +1,15 @@
+"""
+Shim for _umath_tests to allow a deprecation period for the new name.
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import warnings
+
+# 2018-04-04, numpy 1.15.0
+warnings.warn(("numpy.core.umath_tests is an internal NumPy "
+               "module and should not be imported. It will "
+               "be removed in a future NumPy release."),
+              category=DeprecationWarning, stacklevel=2)
+
+from ._umath_tests import *

--- a/numpy/testing/decorators.py
+++ b/numpy/testing/decorators.py
@@ -3,9 +3,13 @@ Back compatibility decorators module. It will import the appropriate
 set of tools
 
 """
+from __future__ import division, absolute_import, print_function
+
 import warnings
 
-warnings.warn("Import from numpy.testing, not numpy.testing.decorators",
-              ImportWarning)
+# 2018-04-04, numpy 1.15.0
+warnings.warn("Importing from numpy.testing.decorators is deprecated, "
+              "import from numpy.testing instead.",
+              DeprecationWarning, stacklevel=2)
 
 from ._private.decorators import *

--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -2,10 +2,13 @@
 Back compatibility noseclasses module. It will import the appropriate
 set of tools
 """
+from __future__ import division, absolute_import, print_function
+
 import warnings
 
-warnings.warn("Import from numpy.testing, not numpy.testing.noseclasses",
-              ImportWarning)
+# 2018-04-04, numpy 1.15.0
+warnings.warn("Importing from numpy.testing.noseclasses is deprecated, "
+              "import from numpy.testing instead",
+              DeprecationWarning, stacklevel=2)
 
 from ._private.noseclasses import *
-

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -3,10 +3,14 @@ Back compatibility nosetester module. It will import the appropriate
 set of tools
 
 """
+from __future__ import division, absolute_import, print_function
+
 import warnings
 
-warnings.warn("Import from numpy.testing, not numpy.testing.nosetester",
-              ImportWarning)
+# 2018-04-04, numpy 1.15.0
+warnings.warn("Importing from numpy.testing.nosetester is deprecated, "
+              "import from numpy.testing instead.",
+              DeprecationWarning, stacklevel=2)
 
 from ._private.nosetester import *
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -3,10 +3,14 @@ Back compatibility utils module. It will import the appropriate
 set of tools
 
 """
+from __future__ import division, absolute_import, print_function
+
 import warnings
 
-warnings.warn("Import from numpy.testing, not numpy.testing.utils",
-              ImportWarning)
+# 2018-04-04, numpy 1.15.0
+warnings.warn("Importing from numpy.testing.utils is deprecated, "
+              "import from numpy.testing instead.",
+              ImportWarning, stacklevel=2)
 
 from ._private.utils import *
 


### PR DESCRIPTION
The following modules have been moved or renamed and should not be
imported. This adds shim modules for the old names that issue a
DeprecationWarning on import.

* numpy/core/umath_tests.py
* numpy/testing/decorators.py
* numpy/testing/noseclasses.py
* numpy/testing/nosetester.py
* numpy/testing/utils.py

Closes #10845.