### PR TITLE
BUG: floating types should override tp_print (1.14 backport)

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4179,6 +4179,37 @@ initialize_casting_tables(void)
     }
 }
 
+#ifndef NPY_PY3K
+/*
+ * In python2, the `float` and `complex` types still implement the obsolete
+ * "tp_print" method, which uses CPython's float-printing routines to print the
+ * float.  Numpy's float_/cfloat inherit from Python float/complex, but
+ * override its tp_repr and tp_str methods. In order to avoid an inconsistency
+ * with the inherited tp_print, we need to override it too.
+ *
+ * In python3 the tp_print method is reserved/unused.
+ */
+static int
+float_print(PyObject *o, FILE *fp, int flags)
+{
+    int ret;
+    PyObject *to_print;
+    if (flags & Py_PRINT_RAW) {
+        to_print = PyObject_Str(o);
+    }
+    else {
+        to_print = PyObject_Repr(o);
+    }
+
+    if (to_print == NULL) {
+        return -1;
+    }
+
+    ret = PyObject_Print(to_print, fp, flags);
+    Py_DECREF(to_print);
+    return ret;
+}
+#endif
 
 static PyNumberMethods longdoubletype_as_number;
 static PyNumberMethods clongdoubletype_as_number;
@@ -4230,6 +4261,12 @@ initialize_numeric_types(void)
     Py@NAME@ArrType_Type.tp_as_number = &@name@_arrtype_as_number;
 
     /**end repeat**/
+
+#ifndef NPY_PY3K
+    PyDoubleArrType_Type.tp_print = &float_print;
+    PyCDoubleArrType_Type.tp_print = &float_print;
+#endif
+
 
     PyBoolArrType_Type.tp_as_number->nb_index = (unaryfunc)bool_index;
 

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -6,6 +6,7 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import assert_, assert_equal, run_module_suite
+import sys, tempfile
 
 
 class TestRealScalars(object):
@@ -44,6 +45,21 @@ class TestRealScalars(object):
         check(1e-4)
         check(1e15)
         check(1e16)
+
+    def test_py2_float_print(self):
+        # gh-10753
+        # In python2, the python float type implements an obsolte method
+        # tp_print, which overrides tp_repr and tp_str when using the "print"
+        # keyword/method to output to a "real file" (ie, not a StringIO). Make
+        # sure we don't inherit it.
+        x = np.double(0.1999999999999)
+        f = tempfile.TemporaryFile('r+t') # must output to real file, not StringIO
+        print(x, file=f)
+        f.seek(0)
+        output = f.read()
+        f.close()
+        assert_equal(output, '0.1999999999999\n')
+        # (compare to "print 0.1999999999999" printing "0.2" in python2)
 
     def test_dragon4(self):
         # these tests are adapted from Ryan Juckett's dragon4 implementation,


### PR DESCRIPTION
This is a backport of #10763, for 1.14.3 in case we want it there.

Fixes #10753