### PR TITLE
DOC: Cross Link full/full_like in a few see-also sections.

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -871,9 +871,6 @@ add_newdoc('numpy.core.multiarray', 'empty',
     See Also
     --------
     empty_like : Return an empty array with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
-    zeros_like : Return an array of zeros with shape and type of input.
-    full_like : Return a new array with shape of input filled with value.
     ones : Return a new array setting values to one.
     zeros : Return a new array setting values to zero.
     full : Return a new array of given shape filled with value.
@@ -937,9 +934,6 @@ add_newdoc('numpy.core.multiarray', 'empty_like',
     zeros_like : Return an array of zeros with shape and type of input.
     full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
-    ones : Return a new array setting values to one.
-    zeros : Return a new array setting values to zero.
-    full : Return a new array of given shape filled with value.
 
     Notes
     -----
@@ -1000,10 +994,7 @@ add_newdoc('numpy.core.multiarray', 'zeros',
 
     See Also
     --------
-    empty_like : Return an empty array with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
     zeros_like : Return an array of zeros with shape and type of input.
-    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
     ones : Return a new array setting values to one.
     full : Return a new array of given shape filled with value.

--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -784,7 +784,15 @@ add_newdoc('numpy.core.multiarray', 'array',
 
     See Also
     --------
-    empty, empty_like, zeros, zeros_like, ones, ones_like, full, full_like
+    empty_like : Return an empty array with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
+    empty : Return a new uninitialized array.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
+
 
     Notes
     -----
@@ -862,7 +870,14 @@ add_newdoc('numpy.core.multiarray', 'empty',
 
     See Also
     --------
-    empty_like, zeros, ones
+    empty_like : Return an empty array with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
+
 
     Notes
     -----
@@ -920,9 +935,11 @@ add_newdoc('numpy.core.multiarray', 'empty_like',
     --------
     ones_like : Return an array of ones with shape and type of input.
     zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
     ones : Return a new array setting values to one.
     zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
 
     Notes
     -----
@@ -983,11 +1000,13 @@ add_newdoc('numpy.core.multiarray', 'zeros',
 
     See Also
     --------
-    zeros_like : Return an array of zeros with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    ones : Return a new array setting values to one.
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
+    ones : Return a new array setting values to one.
+    full : Return a new array of given shape filled with value.
 
     Examples
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -123,11 +123,13 @@ def zeros_like(a, dtype=None, order='K', subok=True):
 
     See Also
     --------
-    ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    zeros : Return a new array setting values to zero.
-    ones : Return a new array setting values to one.
+    ones_like : Return an array of ones with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
 
     Examples
     --------
@@ -177,7 +179,14 @@ def ones(shape, dtype=None, order='C'):
 
     See Also
     --------
-    zeros, ones_like
+    empty_like : Return an empty array with shape and type of input.
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
+    empty : Return a new uninitialized array.
+    zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
+
 
     Examples
     --------
@@ -234,11 +243,13 @@ def ones_like(a, dtype=None, order='K', subok=True):
 
     See Also
     --------
-    zeros_like : Return an array of zeros with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    zeros : Return a new array setting values to zero.
-    ones : Return a new array setting values to one.
+    zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
 
     Examples
     --------
@@ -287,13 +298,13 @@ def full(shape, fill_value, dtype=None, order='C'):
 
     See Also
     --------
-    zeros_like : Return an array of zeros with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    full_like : Fill an array with shape and type of input.
-    zeros : Return a new array setting values to zero.
-    ones : Return a new array setting values to one.
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
+    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
 
     Examples
     --------
@@ -342,13 +353,13 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True):
 
     See Also
     --------
-    zeros_like : Return an array of zeros with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
     empty_like : Return an empty array with shape and type of input.
-    zeros : Return a new array setting values to zero.
-    ones : Return a new array setting values to one.
+    ones_like : Return an array of ones with shape and type of input.
+    zeros_like : Return an array of zeros with shape and type of input.
     empty : Return a new uninitialized array.
-    full : Fill a new array.
+    ones : Return a new array setting values to one.
+    zeros : Return a new array setting values to zero.
+    full : Return a new array of given shape filled with value.
 
     Examples
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -126,10 +126,7 @@ def zeros_like(a, dtype=None, order='K', subok=True):
     empty_like : Return an empty array with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
     full_like : Return a new array with shape of input filled with value.
-    empty : Return a new uninitialized array.
-    ones : Return a new array setting values to one.
     zeros : Return a new array setting values to zero.
-    full : Return a new array of given shape filled with value.
 
     Examples
     --------
@@ -179,10 +176,7 @@ def ones(shape, dtype=None, order='C'):
 
     See Also
     --------
-    empty_like : Return an empty array with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
-    zeros_like : Return an array of zeros with shape and type of input.
-    full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
     zeros : Return a new array setting values to zero.
     full : Return a new array of given shape filled with value.
@@ -246,10 +240,7 @@ def ones_like(a, dtype=None, order='K', subok=True):
     empty_like : Return an empty array with shape and type of input.
     zeros_like : Return an array of zeros with shape and type of input.
     full_like : Return a new array with shape of input filled with value.
-    empty : Return a new uninitialized array.
     ones : Return a new array setting values to one.
-    zeros : Return a new array setting values to zero.
-    full : Return a new array of given shape filled with value.
 
     Examples
     --------
@@ -298,9 +289,6 @@ def full(shape, fill_value, dtype=None, order='C'):
 
     See Also
     --------
-    empty_like : Return an empty array with shape and type of input.
-    ones_like : Return an array of ones with shape and type of input.
-    zeros_like : Return an array of zeros with shape and type of input.
     full_like : Return a new array with shape of input filled with value.
     empty : Return a new uninitialized array.
     ones : Return a new array setting values to one.
@@ -356,9 +344,6 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True):
     empty_like : Return an empty array with shape and type of input.
     ones_like : Return an array of ones with shape and type of input.
     zeros_like : Return an array of zeros with shape and type of input.
-    empty : Return a new uninitialized array.
-    ones : Return a new array setting values to one.
-    zeros : Return a new array setting values to zero.
     full : Return a new array of given shape filled with value.
 
     Examples


### PR DESCRIPTION
While teaching numpy I was asked the best way to create an array of `nan`,
and `np.full` seem not be cross linked from many places; In particular
in the documentation of `zeros` and `ones` seam like obvious candidates
to add them.


--- 

Here are two top answer on [Stack Overflow](https://stackoverflow.com/questions/1704823/initializing-numpy-matrix-to-something-other-than-zero-or-one) where user can can confused by [chaining `.fill(nan)`](https://stackoverflow.com/questions/22414152/best-way-to-initialize-and-fill-an-numpy-array) and get confused, and what the various options are.