### PR TITLE
MAINT: Remove unnecessary special case in np.histogramdd for N == 0

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -911,10 +911,6 @@ def histogramdd(sample, bins=10, range=None, normed=False, weights=None):
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
         dedges[i] = np.diff(edges[i])
 
-    # Handle empty input.
-    if N == 0:
-        return np.zeros(nbin-2), edges
-
     # Compute the bin number each sample falls into.
     Ncount = tuple(
         np.digitize(sample[:, i], edges[i])


### PR DESCRIPTION
This was just a place where the return type is hardcoded, and could become inconsistent