### PR TITLE
ENH: New Function np.atleast_nd

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -80,7 +80,7 @@ def atleast_2d(*arys):
 
     See Also
     --------
-    atleast_1d, atleast_3d
+    atleast_1d, atleast_3d, atleast_nd
 
     Examples
     --------
@@ -134,7 +134,7 @@ def atleast_3d(*arys):
 
     See Also
     --------
-    atleast_1d, atleast_2d
+    atleast_1d, atleast_2d, atleast_nd
 
     Examples
     --------
@@ -177,6 +177,86 @@ def atleast_3d(*arys):
         return res[0]
     else:
         return res
+
+
+def atleast_nd(arr, n, front=False):
+    r"""
+    View inputs as arrays with at least n dimensions.
+
+    Parameters
+    ----------
+    arr : array_like
+        One array-like object.  Non-array inputs are converted to arrays.
+        Arrays that already have n or more dimensions are preserved.
+
+    n : int
+        number of dimensions to ensure
+
+    front : bool
+        if True new dimensions are added to the front of the array.  otherwise
+        they are added to the back.
+
+    Returns
+    -------
+        ndarray :
+            An array with ``a.ndim >= n``.  Copies are avoided where possible,
+            and views with three or more dimensions are returned.  For example,
+            a 1-D array of shape ``(N,)`` becomes a view of shape
+            ``(1, N, 1)``, and a 2-D array of shape ``(M, N)`` becomes a view
+            of shape ``(M, N, 1)``.
+
+    See Also
+    ---------
+    atleast_1d, atleast_2d, atleast_3d
+
+    Examples
+    --------
+    >>> for n in range(0, 5):
+    ...    print(np.atleast_nd(3.0, n))
+    3.0
+    [3.]
+    [[3.]]
+    [[[3.]]]
+    [[[[3.]]]]
+
+    >>> arr = [[1, 2, 3], [4, 5, 6]]
+    >>> for n in range(0, 5):
+    ...    new = np.atleast_nd(arr, n, front=False)
+    ...    print(new.tolist())
+    [[1, 2, 3], [4, 5, 6]]
+    [[1, 2, 3], [4, 5, 6]]
+    [[1, 2, 3], [4, 5, 6]]
+    [[[1], [2], [3]], [[4], [5], [6]]]
+    [[[[1]], [[2]], [[3]]], [[[4]], [[5]], [[6]]]]
+
+    >>> arr = [[1, 2, 3], [4, 5, 6]]
+    >>> for n in range(0, 5):
+    ...    new = np.atleast_nd(arr, n, front=True)
+    ...    print(new.tolist())
+    [[1, 2, 3], [4, 5, 6]]
+    [[1, 2, 3], [4, 5, 6]]
+    [[1, 2, 3], [4, 5, 6]]
+    [[[1, 2, 3], [4, 5, 6]]]
+    [[[[1, 2, 3], [4, 5, 6]]]]
+
+    >>> x = np.arange(12.0).reshape(4,3)
+    >>> np.atleast_nd(x, 5, front=False).shape
+    (4, 3, 1, 1, 1)
+    >>> np.atleast_nd(x, 5, front=True).shape
+    (1, 1, 1, 4, 3)
+    >>> np.atleast_nd(x, 5, front=False).base is x.base  # x is a reshape, so not base itself
+    True
+    """
+    arr_ = asanyarray(arr)
+    ndims = len(arr_.shape)
+    if n is not None and ndims <  n:
+        # append the required number of dimensions to the front or back
+        if front:
+            expander = (None,) * (n - ndims) + (Ellipsis,)
+        else:
+            expander = (Ellipsis,) + (None,) * (n - ndims)
+        arr_ = arr_[expander]
+    return arr_
 
 
 def vstack(tup):


### PR DESCRIPTION
This PR adds a new function `atleast_nd` which generalizes atleast_1d,  atleast_2d, and atleast_3d. I've been using this function internally for a few years now and I find it very useful to parameterize how many dimensions I'm expecting rather than hard coding it via a function name.

It's a pretty simple function so I won't write too much a description. The main differences from the existing functions is that it takes only one argument instead of varargs so it can accept `n` as the second parameter. Because the function doesn't use varargs.

I also added a third parameter `front` which specifies if the new dimensions should be appended to the front or back of the array shape. I defaulted this to `front=False` because in most cases I want to ensure that a channel dimension exists at the back of a 2d image. This seems to correspond to the current behavior of `np.atleast_3d` (was it always this way? I seem to remember it being different in the past). 

Lastly, a benchmark shows that there is an extremely marginal (0.5 µs) speed improvement to this function over using `np.atleast_3d`. 

```python
        import ubelt
        N = 100

        t1 = ubelt.Timerit(N, label='mine')
        for timer in t1:
            arr = np.empty((10, 10))
            with timer:
                atleast_nd(arr, 3)

        t2 = ubelt.Timerit(N, label='baseline')
        for timer in t2:
            arr = np.empty((10, 10))
            with timer:
                np.atleast_3d(arr)
```
```
Timed mine for: 100 loops, best of 3
    time per loop: best=2.087 µs, mean=2.12 ± 0.084 µs

Timed baseline for: 100 loops, best of 3
    time per loop: best=2.486 µs, mean=2.536 ± 0.043 µs
```
Not a big deal, but hey, it's there. 

-----------

If anyone likes this feature let me know and I'll write the tests. 