### PR TITLE
DOC: Added example of multi-line instruction in Examples section of a docstring.

### DIFF
--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -415,8 +415,8 @@ The sections of the docstring are:
       >>> np.add([1, 2], [3, 4])
       array([4, 6])
 
-    An instruction may be split across multiple lines, with each line after
-    the first starting with '...'::
+    The example code may be split across multiple lines, with each line after
+    the first starting with '... '::
 
       >>> np.add([[1, 2], [3, 4]],
       ...        [[5, 6], [7, 8]])

--- a/doc/HOWTO_DOCUMENT.rst.txt
+++ b/doc/HOWTO_DOCUMENT.rst.txt
@@ -415,6 +415,14 @@ The sections of the docstring are:
       >>> np.add([1, 2], [3, 4])
       array([4, 6])
 
+    An instruction may be split across multiple lines, with each line after
+    the first starting with '...'::
+
+      >>> np.add([[1, 2], [3, 4]],
+      ...        [[5, 6], [7, 8]])
+      array([[ 6,  8],
+             [10, 12]])
+
     For tests with a result that is random or platform-dependent, mark the
     output as such::
 


### PR DESCRIPTION
Added an example showing how to use multi-line commands in the Examples section of the docstring.