### PR TITLE
TST: Extract a helper function to test for reference cycles

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -23,7 +23,7 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     assert_warns, assert_, SkipTest, assert_raises_regex, assert_raises,
     assert_allclose, assert_array_equal, temppath, tempdir, IS_PYPY,
-    HAS_REFCOUNT, suppress_warnings,
+    HAS_REFCOUNT, suppress_warnings, assert_no_gc_cycles,
     )
 
 
@@ -2369,14 +2369,5 @@ def test_load_refcount():
     np.savez(f, [1, 2, 3])
     f.seek(0)
 
-    assert_(gc.isenabled())
-    gc.disable()
-    try:
-        gc.collect()
+    with assert_no_gc_cycles():
         np.load(f)
-        # gc.collect returns the number of unreachable objects in cycles that
-        # were found -- we are checking that no cycles were created by np.load
-        n_objects_in_cycles = gc.collect()
-    finally:
-        gc.enable()
-    assert_equal(n_objects_in_cycles, 0)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2288,7 +2288,14 @@ def _assert_no_gc_cycles_context(name=None):
     gc.disable()
     gc_debug = gc.get_debug()
     try:
-        gc.collect()
+        for i in range(100):
+            if gc.collect() == 0:
+                break
+        else:
+            raise RuntimeError(
+                "Unable to fully collect garbage - perhaps a __del__ method is "
+                "creating more reference cycles?")
+
         gc.set_debug(gc.DEBUG_SAVEALL)
         yield
         # gc.collect returns the number of unreachable objects in cycles that

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -25,5 +25,5 @@ __all__ = [
         'assert_allclose', 'IgnoreException', 'clear_and_catch_warnings',
         'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
         'HAS_REFCOUNT', 'suppress_warnings', 'assert_array_compare',
-        '_assert_valid_refcount', '_gen_alignment_data',
+        '_assert_valid_refcount', '_gen_alignment_data', 'assert_no_gc_cycles'
         ]


### PR DESCRIPTION
This also means we can now test that our test is actually able to detect the type of failure we expect

Trying to give myself some tools to debug the failure at https://github.com/numpy/numpy/pull/10882/files#r180813166