### PR TITLE
ENH: Added a return value to np.random.shuffle

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -233,5 +233,10 @@ the user wants to perform a stable sort thus harming the readability.
 This change allows the user to specify kind='stable' thus clarifying
 the intent.
 
+``np.random.shuffle`` returns the input array
+---------------------------------------------
+This allows for arrays to be created and shuffled in one line instead of two.
+
+
 Changes
 =======

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4797,6 +4797,8 @@ cdef class RandomState:
         x
             A reference to the input sequence.
 
+            .. versionadded:: 1.15.0
+
         Examples
         --------
         >>> arr = np.arange(10)

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4794,7 +4794,8 @@ cdef class RandomState:
 
         Returns
         -------
-        None
+        x
+            A reference to the input sequence.
 
         Examples
         --------
@@ -4854,6 +4855,8 @@ cdef class RandomState:
                 for i in reversed(range(1, n)):
                     j = rk_interval(i, self.internal_state)
                     x[i], x[j] = x[j], x[i]
+
+        return x
 
     cdef inline _shuffle_raw(self, npy_intp n, npy_intp itemsize,
                              npy_intp stride, char* data, char* buf):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -463,8 +463,7 @@ class TestRandomDist(object):
                                           [("a", object, 1),
                                            ("b", np.int32, 1)])]:
             np.random.seed(self.seed)
-            alist = conv([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])
-            np.random.shuffle(alist)
+            alist = np.random.shuffle(conv([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]))
             actual = alist
             desired = conv([0, 1, 9, 6, 2, 4, 5, 8, 7, 3])
             assert_array_equal(actual, desired)

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -63,8 +63,7 @@ class TestRegression(object):
                   [1, (2, 2), (3, 3), None],
                   [(1, 1), 2, 3, None]]:
             np.random.seed(12345)
-            shuffled = list(t)
-            random.shuffle(shuffled)
+            shuffled = random.shuffle(list(t))
             assert_array_equal(shuffled, [t[0], t[3], t[1], t[2]])
 
     def test_call_within_randomstate(self):


### PR DESCRIPTION
This is a very trivial PR to save some lines of typing and make behavior more expected/intuitive. Instead of having to do

    x = array(...)
    np.random.shuffle(x)

with this PR, you can just do

    x = np.random.shuffle(array(...))

I do not expect this to be a controversial change. Barring documentation, it actually reduces the number of lines of existing code by one.