### PR TITLE
DOC:  Fix link in `See Also` section of `randn` docstring.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1394,7 +1394,7 @@ cdef class RandomState:
 
         See Also
         --------
-        random.standard_normal : Similar, but takes a tuple as its argument.
+        standard_normal : Similar, but takes a tuple as its argument.
 
         Notes
         -----


### PR DESCRIPTION
Fixes #10902 : Changed `See Also` doc-string section of `randn`  in `random/mtrand.pyx`