### PR TITLE
ENH: Fixed issue that occurs when trying to take the median of a list of masked arrays. issue #10757 

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -681,6 +681,10 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
            fill_value = 1e+20)
 
     """
+
+    if isinstance(a, list):
+        a = np.ma.asarray(a)
+
     if not hasattr(a, 'mask'):
         m = np.median(getdata(a, subok=True), axis=axis,
                       out=out, overwrite_input=overwrite_input,

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1088,6 +1088,25 @@ class TestMedian(object):
         o[2] = np.nan
         assert_(type(np.ma.median(o.astype(object))), float)
 
+    def test_list_of_masked_array(self):
+        data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        masked1 = np.ma.masked_where(data1 == 4, data1)
+        data2 = np.array([[8, 7, 6, 5], [4, 3, 2, 1]])
+        masked2 = np.ma.masked_where(data2 == 4, data2)
+        list = [masked1, masked2]
+        median_masked_list = np.ma.median(list, axis=0).data
+        assert_equal( median_masked_list , np.array([[4.5, 4.5, 4.5, 5], [5, 4.5, 4.5, 4.5]]))
+
+
+    def test_list_of_masked_array_no_axis(self):
+        data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        masked1 = np.ma.masked_where(data1 == 2, data1)
+        data2 = np.array([[8, 7, 6, 5], [4, 3, 2, 1]])
+        masked2 = np.ma.masked_where(data2 == 5, data2)
+        list = [masked1, masked2]
+        median_masked_list = np.ma.median(list)
+        assert_equal(median_masked_list, 4.5)
+
 
 class TestCov(object):
 


### PR DESCRIPTION
Fixed issue that occurs when trying to take the median of a list of masked arrays.
Added a check to see if the input is a list then converts to a masked array.
See issue #10757 for more information.