### PR TITLE
BUG: fixes np.random.zipf() hanging on pathological input

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -42,6 +42,7 @@
  */
 
 #include "distributions.h"
+#include <signal.h>
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
@@ -718,12 +719,33 @@ double rk_wald(rk_state *state, double mean, double scale)
     }
 }
 
+static void kb_interrupt_handler(int signum) {
+    /* signal handlers are extremely limited
+     * and attempting to raise a Python
+     * KeyboardInterrupt via the Python
+     * C API here causes a segfault
+     */
+    printf("\nCaught Keyboard Interrupt\n");
+    exit(1);
+}
+
 long rk_zipf(rk_state *state, double a)
 {
     double am1, b;
 
     am1 = a - 1.0;
     b = pow(2.0, am1);
+
+    /* using PyErr_CheckSignals() from
+     * the Python C API would allow
+     * for keyboard interrupt handling
+     * BUT results in a segfault
+     * after Ctrl+C, so an alternative
+     * approach is used here;
+     * Related to Issue #9829
+     */
+    signal(SIGINT, kb_interrupt_handler);
+
     while (1) {
         double T, U, V, X;
 


### PR DESCRIPTION
A cleaner fix might be possible if I were to i.e., move the C algorithm into Cython; leaving the `while` loop in C seems to require a bit of low-level intervention to enable Keyboard Interrupt handling & using the Python C API as suggested in the referenced issue results in a segfault after catching ctrl+c.

I'm also not a big fan of the unit test structure with Python tempfile script (!) (not even sure that will work on CI)--perhaps there are better suggestions--probing `SIGINT` handling on pathological input seems like a tricky thing to test.

* Fixes Issue #9829 by allowing a keyboard interruption
to break out of zipf() computations that run for very
long times because of pathological inputs

* Added a unit test that verifies handling of SIGINT
by zipf()