### PR TITLE
DOC: rename x2 to h0 in heaviside docstring to confirm to the source

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -957,26 +957,26 @@ add_newdoc('numpy.core.umath', 'heaviside',
 
     The Heaviside step function is defined as::
 
-                              0   if x1 < 0
-        heaviside(x1, h0) =  h0   if x1 == 0
-                              1   if x1 > 0
+                              0   if x < 0
+        heaviside(x1, h0) =  h0   if x == 0
+                              1   if x > 0
 
-    where `h0` is the return value for x1==0. It is often taken to be 0.5,
+    where `h0` is the return value for x==0. It is often taken to be 0.5,
     but 0 and 1 are also sometimes used.
 
     Parameters
     ----------
-    x1 : array_like
+    x : array_like
         Input values.
     h0 : array_like
-        The value of the function when x1 is 0.
+        The value of the function when x is 0.
     $PARAMS
 
     Returns
     -------
     out : ndarray or scalar
-        The output array, element-wise Heaviside step function of `x1`.
-        $OUT_SCALAR_2
+        The output array, element-wise Heaviside step function of `x`.
+        $OUT_SCALAR_1
 
     Notes
     -----

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -958,16 +958,17 @@ add_newdoc('numpy.core.umath', 'heaviside',
     The Heaviside step function is defined as::
 
                               0   if x1 < 0
-        heaviside(x1, x2) =  x2   if x1 == 0
+        heaviside(x1, h0) =  h0   if x1 == 0
                               1   if x1 > 0
 
-    where `x2` is often taken to be 0.5, but 0 and 1 are also sometimes used.
+    where `h0` is the return value for x1==0. It is often taken to be 0.5,
+    but 0 and 1 are also sometimes used.
 
     Parameters
     ----------
     x1 : array_like
         Input values.
-    x2 : array_like
+    h0 : array_like
         The value of the function when x1 is 0.
     $PARAMS
 


### PR DESCRIPTION
This PR renames the second argument of `numpy.heaviside` docstring to `h0`, which is also used in the implementation and does not (subconsciously) imply a comparison between x1 and x2