### PR TITLE
BUG: Add missing underscore to prototype in check_embedded_lapack

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1882,7 +1882,7 @@ class openblas_lapack_info(openblas_info):
         c = customized_ccompiler()
 
         tmpdir = tempfile.mkdtemp()
-        s = """void zungqr();
+        s = """void zungqr_();
         int main(int argc, const char *argv[])
         {
             zungqr_();


### PR DESCRIPTION
The test program in `openblas_lapack_info.check_embedded_lapack` attempts to avoid an "implicit declaration" warning. However, it fails to achieve this because the declaration is missing an underscore. This prevents NumPy from building against OpenBLAS if `CFLAGS` contains `-Werror=implicit-function-declaration`.