### PR TITLE
BUG: Fix `np.load` for aligned dtypes.

### DIFF
--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -523,6 +523,15 @@ def test_compressed_roundtrip():
     assert_array_equal(arr, arr1)
 
 
+def test_load_aligned_dtype():
+    dt1 = np.dtype('i1, i4, i1', align=True)
+    arr = np.zeros(1, dt1)
+    npz_file = os.path.join(tempdir, 'aligned.npz')
+    np.savez(npz_file, arr=arr)
+    arr1 = np.load(npz_file)['arr']
+    assert_array_equal(arr, arr1)
+
+
 def test_python2_python3_interoperability():
     if sys.version_info[0] >= 3:
         fname = 'win64python2.npy'


### PR DESCRIPTION
```python
import numpy as np

t = np.dtype('i1, i4, i1', align=True)
d = np.zeros(1, t)

np.save("test.npy", d)
data = np.load("test.npy")

Traceback (most recent call last):
  File "D:\Projects\numpy_bug.py", line 8, in <module>
    data = np.load("test.npy")
  File "D:\Projects\vendors\numpy\lib\npyio.py", line 314, in load
    return format.read_array(fid)
  File "D:\Projects\vendors\numpy\lib\format.py", line 440, in read_array
    shape, fortran_order, dtype = read_array_header_1_0(fp)
  File "D:\Projects\vendors\numpy\lib\format.py", line 358, in read_array_header_1_0
    dtype = numpy.dtype(d['descr'])
ValueError: two fields with the same name
```
Fixes gh-2215