### PR TITLE
DOC: fix broken links for developer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,12 @@ Thanks for your interest in contributing code to numpy!
 
 + If this is your first time contributing to a project on GitHub, please read
 through our
-[guide to contributing to numpy](http://docs.scipy.org/doc/numpy-dev/dev/index.html)
+[guide to contributing to numpy](http://docs.scipy.org/doc/numpy/dev/index.html)
 + If you have contributed to other projects on GitHub you can go straight to our
-[development workflow](http://docs.scipy.org/doc/numpy-dev/dev/gitwash/development_workflow.html)
+[development workflow](http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html)
 
 Either way, please be sure to follow our
-[convention for commit messages](http://docs.scipy.org/doc/numpy-dev/dev/gitwash/development_workflow.html#writing-the-commit-message).
+[convention for commit messages](http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message).
 
 If you are writing new C code, please follow the style described in
 ``doc/C_STYLE_GUIDE``.

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -41,7 +41,7 @@ nose__ http://nose.readthedocs.io
 
    If you want to build NumPy in order to work on NumPy itself, use
    ``runtests.py``.  For more details, see
-   http://docs.scipy.org/doc/numpy-dev/dev/development_environment.html
+   http://docs.scipy.org/doc/numpy/dev/development_environment.html
 
 .. note::
 

--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -206,7 +206,7 @@ References and Footnotes
 .. _issue tracker: https://github.com/numpy/numpy/issues
 
 .. _NumPy Steering Council:
-   https://docs.scipy.org/doc/numpy-dev/dev/governance/governance.html
+   https://docs.scipy.org/doc/numpy/dev/governance/governance.html
 
 .. _`GitHub pull request`: https://github.com/numpy/numpy/pulls
 

--- a/numpy/doc/misc.py
+++ b/numpy/doc/misc.py
@@ -209,7 +209,7 @@ Only a survey of the choices. Little detail on how each works.
 Interfacing to Fortran:
 -----------------------
 The clear choice to wrap Fortran code is
-`f2py <http://docs.scipy.org/doc/numpy-dev/f2py/>`_.
+`f2py <http://docs.scipy.org/doc/numpy/f2py/>`_.
 
 Pyfort is an older alternative, but not supported any longer.
 Fwrap is a newer project that looked promising but isn't being developed any


### PR DESCRIPTION
Some links in developer documentation and files had extraneous '-dev' in
them, removing it restore the working state of the links.
See: #10939