### PR TITLE
MAINT: address extraneous shape tuple checks in descriptor.c

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -18,6 +18,7 @@
 #include "templ_common.h" /* for npy_mul_with_overflow_intp */
 #include "descriptor.h"
 #include "alloc.h"
+#include "assert.h"
 
 /*
  * offset:    A starting offset.
@@ -1938,33 +1939,26 @@ arraydescr_shape_get(PyArray_Descr *self)
     if (!PyDataType_HASSUBARRAY(self)) {
         return PyTuple_New(0);
     }
-    /*TODO
-     * self->subarray->shape should always be a tuple,
-     * so this check should be unnecessary
-     */
-    if (PyTuple_Check(self->subarray->shape)) {
-        Py_INCREF(self->subarray->shape);
-        return (PyObject *)(self->subarray->shape);
-    }
-    return Py_BuildValue("(O)", self->subarray->shape);
+    assert(PyTuple_Check(self->subarray->shape));
+    Py_INCREF(self->subarray->shape);
+    return self->subarray->shape;
 }
 
 static PyObject *
 arraydescr_ndim_get(PyArray_Descr *self)
 {
+    Py_ssize_t ndim;
+
     if (!PyDataType_HASSUBARRAY(self)) {
         return PyInt_FromLong(0);
     }
-    /*TODO
-     * self->subarray->shape should always be a tuple,
-     * so this check should be unnecessary
+
+    /*
+     * PyTuple_Size has built in check
+     * for tuple argument
      */
-    if (PyTuple_Check(self->subarray->shape)) {
-        Py_ssize_t ndim = PyTuple_Size(self->subarray->shape);
-        return PyInt_FromLong(ndim);
-    }
-    /* consistent with arraydescr_shape_get */
-    return PyInt_FromLong(1);
+    ndim = PyTuple_Size(self->subarray->shape);
+    return PyInt_FromLong(ndim);
 }
 
 


### PR DESCRIPTION
In looking for low-hanging fruit for fixes in the source `git grep 'TODO' | wc -l` suggests 120 source code comments where action might be helpful.

I noticed one source file where `TODO` comments suggested that code could simply be removed because it was effectively extraneous. Indeed, it seems that assuming that the object type is always consistent with `tuple` as the comments suggest has no effect on the results of the full test suite.

If these changes do increase vulnerability to some kind of issue(s), then at least that should show up in the peer review process of this PR, and I can add the missing tests; otherwise, perhaps it is indeed safe to remove those checks.

* C source comments flag two extraneous checks for
the object type of self->subarray->shape in
`descriptor.c`

* pertinent code has been adjusted to assume
that the objects are always tuples, as the comments
suggest; unit testing results are unchanged after
removal of alleged extraneous code