### PR TITLE
DOC: add quantile, nanquantile to toc

### DIFF
--- a/doc/source/reference/routines.statistics.rst
+++ b/doc/source/reference/routines.statistics.rst
@@ -17,6 +17,8 @@ Order statistics
    ptp
    percentile
    nanpercentile
+   quantile
+   nanquantile
 
 Averages and variances
 ----------------------


### PR DESCRIPTION
this will make the new functions show up in the [generated index](http://www.numpy.org/devdocs/genindex.html#Q) and on the [search page](http://www.numpy.org/devdocs/search.html?q=quantile), where they are now lacking