### PR TITLE
DOC: link to governance, convert external link to internal

### DIFF
--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -1,7 +1,7 @@
 About NumPy
 ===========
 
-`NumPy <http://www.scipy.org/NumpPy/>`__ is the fundamental package
+NumPy is the fundamental package
 needed for scientific computing with Python. This package contains:
 
 - a powerful N-dimensional :ref:`array object <arrays>`
@@ -41,6 +41,8 @@ Our main means of communication are:
 - `Old NumPy Trac <http://projects.scipy.org/numpy>`__ (no longer used)
 
 More information about the development of NumPy can be found at our `Developer Zone <https://scipy.scipy.org/scipylib/dev-zone.html>`__.
+
+The project management structure can be found at our :doc:`governance page <dev/governance/index>`
 
 
 About this documentation

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -17,8 +17,8 @@ Creating a new universal function
 Before reading this, it may help to familiarize yourself with the basics
 of C extensions for Python by reading/skimming the tutorials in Section 1
 of `Extending and Embedding the Python Interpreter
-<http://docs.python.org/extending/index.html>`_ and in `How to extend
-NumPy <http://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html>`_
+<http://docs.python.org/extending/index.html>`_ and in :doc:`How to extend
+NumPy <c-info.how-to-extend>`
 
 The umath module is a computer-generated C-module that creates many
 ufuncs. It provides a great many examples of how to create a universal


### PR DESCRIPTION
one more doc cleanup pull request. This:
- removes a recursive link
- adds a link to the governance document from the about page
- refactors an external link to an internal one