### PR TITLE
DOC: removed spurious FIXME comment in number.c

### DIFF
--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -119,7 +119,7 @@ PyArray_SetNumericOps(PyObject *dict)
     return 0;
 }
 
-/* FIXME - macro contains goto */
+/* Note - macro contains goto */
 #define GET(op) if (n_ops.op &&                                         \
                     (PyDict_SetItemString(dict, #op, n_ops.op)==-1))    \
         goto fail;


### PR DESCRIPTION
* a C preprocessor macro in `number.c` contained
a `goto` statement that was not necessary; this
has been replaced with a C function with
equivalent functionality