### PR TITLE
DOC: work around GH isaacs/github#316 to show SVG image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img alt="NumPy" src="branding/icons/numpylogo.svg" height="60">
+# <img alt="NumPy" src="https://cdn.rawgit.com/numpy/numpy/master/branding/icons/numpylogo.svg" height="60">
 
 [![Travis](https://img.shields.io/travis/numpy/numpy/master.svg?label=Travis%20CI)](https://travis-ci.org/numpy/numpy)
 [![AppVeyor](https://img.shields.io/appveyor/ci/charris/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/charris/numpy)


### PR DESCRIPTION
There is an issue with the way github renders SVG images in README files, isaacs/github#316

Fixes #11000