### PR TITLE
TST, BUILD: add latex to circleci doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             . venv/bin/activate
             pip install cython sphinx matplotlib
             sudo apt-get update
-            sudo apt-get install -y graphviz
+            sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 
       - run:
           name: build numpy


### PR DESCRIPTION
Get latex in order to render properly (copy package installation from scipy's circle CI setup)

Edit - ready to merge, checking CircleCI full output, we no longer have a "WARNING: LaTeX command 'latex' cannot be run" as was previous.