### PR TITLE
ENH: Implement axis for generalized ufuncs.

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -193,7 +193,7 @@ combining these 5 compiled builds products into a single "fat" binary.
 ``return_indices`` keyword added for ``np.intersect1d``
 -------------------------------------------------------
 New keyword ``return_indices`` returns the indices of the two input arrays
-that correspond to the common elements. 
+that correspond to the common elements.
 
 ``np.quantile`` and ``np.nanquantile``
 --------------------------------------
@@ -408,6 +408,9 @@ is the same as::
 ``np.put_along_axis`` acts as the dual operation for writing to these indices
 within an array.
 
+.. note:: Implementations of ``__array_ufunc__`` should ensure that they can
+          handle either ``axis`` or ``axes``.  In future, we may convert
+          ``axis`` to ``axes`` before passing it on.
 
 Changes
 =======

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -359,8 +359,8 @@ Increased performance in ``random.permutation`` for multidimensional arrays
 ``permutation`` uses the fast path in ``random.shuffle`` for all input
 array dimensions.  Previously the fast path was only used for 1-d arrays.
 
-Generalized ufuncs now accept ``axes`` and ``keepdims`` arguments
------------------------------------------------------------------
+Generalized ufuncs now accept ``axes``, ``axis`` and ``keepdims`` arguments
+---------------------------------------------------------------------------
 One can control over which axes a generalized ufunc operates by passing in an
 ``axes`` argument, a list of tuples with indices of particular axes.  For
 instance, for a signature of ``(i,j),(j,k)->(i,k)`` appropriate for matrix
@@ -376,12 +376,19 @@ tuples can be omitted.  Hence, for a signature of ``(i),(i)->()`` appropriate
 for an inner product, one could pass in ``axes=[0, 0]`` to indicate that the
 vectors are stored in the first dimensions of the two inputs arguments.
 
+As a short-cut for generalized ufuncs that are similar to reductions, i.e.,
+that act on a single, shared core dimension such as the inner product example
+above, one can pass an ``axis`` argument. This is equivalent to passing in
+``axes`` with identical entries for all arguments with that core dimension
+(e.g., for the example above, ``axes=[(axis,), (axis,)]``).
+
 Furthermore, like for reductions, for generalized ufuncs that have inputs that
 all have the same number of core dimensions and outputs with no core dimension,
 one can pass in ``keepdims`` to leave a dimension with size 1 in the outputs,
 thus allowing proper broadcasting against the original inputs. The location of
 the extra dimension can be controlled with ``axes``. For instance, for the
 inner-product example, ``keepdims=True, axes=[-2, -2, -2]`` would act on the
+inner-product example, ``keepdims=True, axis=-2`` would act on the
 one-but-last dimension of the input arguments, and leave a size 1 dimension in
 that place in the output.
 

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -360,6 +360,17 @@ advanced usage and will not typically be used.
     and for generalized ufuncs for which all outputs are scalars, the output
     tuples can be omitted.
 
+*axis*
+
+    .. versionadded:: 1.15
+
+    A single axis over which a generalized ufunc should operate. This is a
+    short-cut for ufuncs that operate over a single, shared core dimension,
+    equivalent to passing in ``axes`` with entries of ``(axis,)`` for each
+    single-core-dimension argument and ``()`` for all others.  For instance,
+    for a signature ``(i),(i)->()``, it is equivalent to passing in
+    ``axes=[(axis,), (axis,), ()]``.
+
 *keepdims*
 
     .. versionadded:: 1.15
@@ -370,7 +381,7 @@ advanced usage and will not typically be used.
     ufuncs that operate on inputs that all have the same number of core
     dimensions and with outputs that have no core dimensions , i.e., with
     signatures like ``(i),(i)->()`` or ``(m,m)->()``. If used, the location of
-    the dimensions in the output can be controlled with ``axes``.
+    the dimensions in the output can be controlled with ``axes`` and ``axis``.
 
 *casting*
 

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -253,6 +253,38 @@ static void
 
 /**end repeat**/
 
+char *cumsum_signature = "(i)->(i)";
+
+/*
+ *  This implements the function
+ *        out[n] = sum_i^n in[i]
+ */
+
+/**begin repeat
+
+   #TYPE=LONG,DOUBLE#
+   #typ=npy_long,npy_double#
+*/
+
+static void
+@TYPE@_cumsum(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    INIT_OUTER_LOOP_2
+    npy_intp di = dimensions[0];
+    npy_intp i;
+    npy_intp is=steps[0], os=steps[1];
+    BEGIN_OUTER_LOOP_2
+        char *ip=args[0], *op=args[1];
+        @typ@ cumsum = 0;
+        for (i = 0; i < di; i++, ip += is, op += os) {
+            cumsum += (*(@typ@ *)ip);
+            *(@typ@ *)op = cumsum;
+        }
+    END_OUTER_LOOP
+}
+
+/**end repeat**/
+
 
 static PyUFuncGenericFunction inner1d_functions[] = { LONG_inner1d, DOUBLE_inner1d };
 static void * inner1d_data[] = { (void *)NULL, (void *)NULL };
@@ -269,6 +301,10 @@ static PyUFuncGenericFunction euclidean_pdist_functions[] =
 static void *eucldiean_pdist_data[] = { (void *)NULL, (void *)NULL };
 static char euclidean_pdist_signatures[] = { NPY_FLOAT, NPY_FLOAT,
                                              NPY_DOUBLE, NPY_DOUBLE };
+
+static PyUFuncGenericFunction cumsum_functions[] = { LONG_cumsum, DOUBLE_cumsum };
+static void * cumsum_data[] = { (void *)NULL, (void *)NULL };
+static char cumsum_signatures[] = { NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE };
 
 
 static int
@@ -320,6 +356,16 @@ addUfuncs(PyObject *dictionary) {
         return -1;
     }
     PyDict_SetItemString(dictionary, "euclidean_pdist", f);
+    Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(cumsum_functions,
+                    cumsum_data, cumsum_signatures,
+                    2, 1, 1, PyUFunc_None, "cumsum",
+                    "Cumulative sum of the input (n)->(n)\n",
+                    0, cumsum_signature);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "cumsum", f);
     Py_DECREF(f);
     f = PyUFunc_FromFuncAndDataAndSignature(inner1d_functions, inner1d_data,
                     inner1d_signatures, 2, 2, 1, PyUFunc_None, "inner1d_no_doc",

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -566,11 +566,12 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
                     NPY_ORDER *out_order,
                     NPY_CASTING *out_casting,
                     PyObject **out_extobj,
-                    PyObject **out_typetup,
-                    int *out_subok,
-                    PyArrayObject **out_wheremask,
-                    PyObject **out_axes,
-                    int *out_keepdims)
+                    PyObject **out_typetup,  /* type: Tuple[np.dtype] */
+                    int *out_subok,  /* bool */
+                    PyArrayObject **out_wheremask, /* PyArray of bool */
+                    PyObject **out_axes,  /* type: List[Tuple[T]] */
+                    PyObject **out_axis,  /* type: T */
+                    int *out_keepdims)  /* bool */
 {
     int i, nargs;
     int nin = ufunc->nin;
@@ -587,6 +588,9 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
     *out_typetup = NULL;
     if (out_axes != NULL) {
         *out_axes = NULL;
+    }
+    if (out_axis != NULL) {
+        *out_axis = NULL;
     }
     if (out_wheremask != NULL) {
         *out_wheremask = NULL;
@@ -827,9 +831,23 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
                 case 'a':
                     /* possible axes argument for generalized ufunc */
                     if (out_axes != NULL && strcmp(str, "axes") == 0) {
+                        if (out_axis != NULL && *out_axis != NULL) {
+                            PyErr_SetString(PyExc_TypeError,
+                                "cannot specify both 'axis' and 'axes'");
+                            goto fail;
+                        }
                         Py_INCREF(value);
                         *out_axes = value;
-
+                        bad_arg = 0;
+                    }
+                    else if (out_axis != NULL && strcmp(str, "axis") == 0) {
+                        if (out_axes != NULL && *out_axes != NULL) {
+                            PyErr_SetString(PyExc_TypeError,
+                                "cannot specify both 'axis' and 'axes'");
+                            goto fail;
+                        }
+                        Py_INCREF(value);
+                        *out_axis = value;
                         bad_arg = 0;
                     }
                     break;
@@ -1044,6 +1062,10 @@ fail:
     if (out_axes != NULL) {
         Py_XDECREF(*out_axes);
         *out_axes = NULL;
+    }
+    if (out_axis != NULL) {
+        Py_XDECREF(*out_axis);
+        *out_axis = NULL;
     }
     return -1;
 }
@@ -1891,6 +1913,27 @@ _has_output_coredims(PyUFuncObject *ufunc) {
 }
 
 /*
+ * Check whether the gufunc can be used with axis, i.e., that there is only
+ * a single, shared core dimension (which means that operands either have
+ * that dimension, or have no core dimensions).  Returns 0 if all is fine,
+ * and sets an error and returns -1 if not.
+ */
+static int
+_check_axis_support(PyUFuncObject *ufunc) {
+    if (ufunc->core_num_dim_ix != 1) {
+        PyErr_Format(PyExc_TypeError,
+                     "%s: axis can only be used with a single shared core "
+                     "dimension, not with the %d distinct ones implied by "
+                     "signature %s.",
+                     ufunc_get_name_cstr(ufunc),
+                     ufunc->core_num_dim_ix,
+                     ufunc->core_signature);
+        return -1;
+    }
+    return 0;
+}
+
+/*
  * Check whether the gufunc can be used with keepdims, i.e., that all its
  * input arguments have the same number of core dimension, and all output
  * arguments have no core dimensions. Returns 0 if all is fine, and sets
@@ -1905,7 +1948,7 @@ _check_keepdims_support(PyUFuncObject *ufunc) {
         if (ufunc->core_num_dims[i] != (i < nin ? input_core_dims : 0)) {
             PyErr_Format(PyExc_TypeError,
                 "%s does not support keepdims: its signature %s requires "
-                "that %s %d has %d core dimensions, but keepdims can only "
+                "%s %d to have %d core dimensions, but keepdims can only "
                 "be used when all inputs have the same number of core "
                 "dimensions and all outputs have no core dimensions.",
                 ufunc_get_name_cstr(ufunc),
@@ -1917,6 +1960,42 @@ _check_keepdims_support(PyUFuncObject *ufunc) {
         }
     }
     return 0;
+}
+
+/*
+ * Translate axis to axes list of the form [(axis,), ...], with an
+ * empty tuple for operands without core dimensions.
+ * Returns an axes tuple or NULL on failure.
+ */
+static PyObject*
+_build_axes_tuple_from_axis(PyObject *axis, int core_num_dims[], int nop) {
+    int i;
+    PyObject *axes = NULL, *axis_tuple = NULL, *tuple;
+    PyObject *empty_tuple = PyTuple_New(0);  /* cannot realistically fail */
+
+    axes = PyList_New(nop);
+    if (axes == NULL) {
+        return NULL;
+    }
+    axis_tuple = PyTuple_Pack(1, axis);
+    if (axis_tuple == NULL) {
+        goto fail;
+    }
+
+    for (i = 0; i < nop; i++) {
+        tuple = core_num_dims[i] == 1 ? axis_tuple : empty_tuple;
+        Py_INCREF(tuple);
+        PyList_SET_ITEM(axes, i, tuple);
+    }
+    Py_DECREF(axis_tuple);
+    Py_DECREF(empty_tuple);
+    return axes;
+
+fail:
+    Py_XDECREF(axis_tuple);
+    Py_XDECREF(axes);
+    Py_DECREF(empty_tuple);
+    return NULL;
 }
 
 /*
@@ -2245,7 +2324,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     NPY_ORDER order = NPY_KEEPORDER;
     /* Use the default assignment casting rule */
     NPY_CASTING casting = NPY_DEFAULT_ASSIGN_CASTING;
-    PyObject *extobj = NULL, *type_tup = NULL, *axes = NULL;
+    /* other possible keyword arguments */
+    PyObject *extobj = NULL, *type_tup = NULL, *axes = NULL, *axis = NULL;
     int keepdims = -1;
 
     if (ufunc == NULL) {
@@ -2270,10 +2350,12 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
     NPY_UF_DBG_PRINT("Getting arguments\n");
 
-    /* Get all the arguments */
+    /*
+     * Get all the arguments.
+     */
     retval = get_ufunc_arguments(ufunc, args, kwds,
                 op, &order, &casting, &extobj,
-                &type_tup, &subok, NULL, &axes, &keepdims);
+                &type_tup, &subok, NULL, &axes, &axis, &keepdims);
     if (retval < 0) {
         goto fail;
     }
@@ -2284,6 +2366,12 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     if (keepdims != -1) {
         retval = _check_keepdims_support(ufunc);
+        if (retval < 0) {
+            goto fail;
+        }
+    }
+    if (axis != NULL) {
+        retval = _check_axis_support(ufunc);
         if (retval < 0) {
             goto fail;
         }
@@ -2353,6 +2441,19 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                     ufunc_name);
         retval = -1;
         goto fail;
+    }
+
+    /*
+     * Translate axis to axes list of the form [(axis,), ...], with an
+     * empty tuple for operands without core dimensions.
+     */
+    if (axis) {
+        assert(axes == NULL);  /* parser prevents passing in both axis & axes */
+        axes = _build_axes_tuple_from_axis(axis, core_num_dims, nop);
+        if (axes == NULL) {
+            retval = -1;
+            goto fail;
+        }
     }
 
     /* Possibly remap axes. */
@@ -2714,8 +2815,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     Py_XDECREF(type_tup);
     Py_XDECREF(extobj);
     Py_XDECREF(axes);
+    Py_XDECREF(axis);
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
+    Py_XDECREF(axes);
 
     NPY_UF_DBG_PRINT("Returning Success\n");
 
@@ -2735,8 +2838,10 @@ fail:
     Py_XDECREF(type_tup);
     Py_XDECREF(extobj);
     Py_XDECREF(axes);
+    Py_XDECREF(axis);
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
+    Py_XDECREF(axes);
     PyArray_free(remap_axis_memory);
     PyArray_free(remap_axis);
     return retval;
@@ -2812,7 +2917,7 @@ PyUFunc_GenericFunction(PyUFuncObject *ufunc,
     /* Get all the arguments */
     retval = get_ufunc_arguments(ufunc, args, kwds,
                 op, &order, &casting, &extobj,
-                &type_tup, &subok, &wheremask, NULL, NULL);
+                &type_tup, &subok, &wheremask, NULL, NULL, NULL);
     if (retval < 0) {
         goto fail;
     }

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -726,6 +726,38 @@ class TestUfunc(object):
         # should be able to deal with bad unrelated kwargs.
         assert_raises(TypeError, mm, z, z, axes=[0, 1], parrot=True)
 
+    def test_axis_argument(self):
+        # inner1d signature: '(i),(i)->()'
+        inner1d = umt.inner1d
+        a = np.arange(27.).reshape((3, 3, 3))
+        b = np.arange(10., 19.).reshape((3, 1, 3))
+        c = inner1d(a, b)
+        assert_array_equal(c, (a * b).sum(-1))
+        c = inner1d(a, b, axis=-1)
+        assert_array_equal(c, (a * b).sum(-1))
+        out = np.zeros_like(c)
+        d = inner1d(a, b, axis=-1, out=out)
+        assert_(d is out)
+        assert_array_equal(d, c)
+        c = inner1d(a, b, axis=0)
+        assert_array_equal(c, (a * b).sum(0))
+        # Sanity check on innerwt.
+        a = np.arange(6).reshape((2, 3))
+        b = np.arange(10, 16).reshape((2, 3))
+        w = np.arange(20, 26).reshape((2, 3))
+        assert_array_equal(umt.innerwt(a, b, w, axis=0),
+                           np.sum(a * b * w, axis=0))
+        # Check errors.
+        # Cannot pass in both axis and axes.
+        assert_raises(TypeError, inner1d, a, b, axis=0, axes=[0, 0])
+        # Not an integer.
+        assert_raises(TypeError, inner1d, a, b, axis=[0])
+        # more than 1 core dimensions.
+        mm = umt.matrix_multiply
+        assert_raises(TypeError, mm, a, b, axis=1)
+        # Regular ufuncs should not accept axis.
+        assert_raises(TypeError, np.add, 1., 1., axis=0)
+
     def test_keepdims_argument(self):
         # inner1d signature: '(i),(i)->()'
         inner1d = umt.inner1d
@@ -741,7 +773,15 @@ class TestUfunc(object):
         d = inner1d(a, b, keepdims=True, out=out)
         assert_(d is out)
         assert_array_equal(d, c)
-        # Now combined with axes.
+        # Now combined with axis and axes.
+        c = inner1d(a, b, axis=-1, keepdims=False)
+        assert_array_equal(c, (a * b).sum(-1, keepdims=False))
+        c = inner1d(a, b, axis=-1, keepdims=True)
+        assert_array_equal(c, (a * b).sum(-1, keepdims=True))
+        c = inner1d(a, b, axis=0, keepdims=False)
+        assert_array_equal(c, (a * b).sum(0, keepdims=False))
+        c = inner1d(a, b, axis=0, keepdims=True)
+        assert_array_equal(c, (a * b).sum(0, keepdims=True))
         c = inner1d(a, b, axes=[(-1,), (-1,), ()], keepdims=False)
         assert_array_equal(c, (a * b).sum(-1))
         c = inner1d(a, b, axes=[(-1,), (-1,), (-1,)], keepdims=True)
@@ -785,10 +825,12 @@ class TestUfunc(object):
         w = np.arange(20, 26).reshape((2, 3))
         assert_array_equal(umt.innerwt(a, b, w, keepdims=True),
                            np.sum(a * b * w, axis=-1, keepdims=True))
+        assert_array_equal(umt.innerwt(a, b, w, axis=0, keepdims=True),
+                           np.sum(a * b * w, axis=0, keepdims=True))
         # Check errors.
         # Not a boolean
         assert_raises(TypeError, inner1d, a, b, keepdims='true')
-        # 1 core dimension only.
+        # More than 1 core dimension, and core output dimensions.
         mm = umt.matrix_multiply
         assert_raises(TypeError, mm, a, b, keepdims=True)
         assert_raises(TypeError, mm, a, b, keepdims=False)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1810,6 +1810,7 @@ class TestSpecialMethods(object):
         assert_raises(TypeError, np.multiply, a)
         assert_raises(TypeError, np.multiply, a, a, a, a)
         assert_raises(TypeError, np.multiply, a, a, sig='a', signature='a')
+        assert_raises(TypeError, ncu_tests.inner1d, a, a, axis=0, axes=[0, 0])
 
         # reduce, positional args
         res = np.multiply.reduce(a, 'axis0', 'dtype0', 'out0', 'keep0')


### PR DESCRIPTION
EDIT: this is now for `axis` only - keepdims has been added.

Follow-up on #8819, specifically for generalized ufuncs that are like reductions on a single axis.

EDIT: most of the below has become irrelevant.

~As is, the implementation is not super-elegant:~ EDIT: now quite elegant.
- For ``keepdims``, ~checks are added every time the output core dimensions are accessed; it might make more sense to adjust just once.~ EDIT: this is now solved.
- For ``axis``, ~a full ``axes`` list is constructed rather than directly use the value (an advantage, though, is that an extension to passing in a tuple or `None` for ``axis`` would be that much easier).~ (EDIT) currently a separate routine is used from that for ``axes``, which means that any reinterpretation of what values it can have (currently, only int) would have to be done in two places. This would involve only a trivial refactor, though.

But I think this is worth having a careful look. It would be nice to have this in 1.15, together with the ``axes`` argument.

p.s. I tried to keep the commits adding ``keepdims`` and ``axis`` separate, as they are somewhat separate enhancements (and it might help review).

EDIT: they certainly helped to find an annoying reference counting bug. All seems OK now.