### PR TITLE
BUG: Fix padding with large integers

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -104,8 +104,8 @@ def _prepend_const(arr, pad_amt, val, axis=-1):
         return np.concatenate((np.zeros(padshape, dtype=arr.dtype), arr),
                               axis=axis)
     else:
-        return np.concatenate(((np.zeros(padshape) + val).astype(arr.dtype),
-                               arr), axis=axis)
+        return np.concatenate((np.full(padshape, val, dtype=arr.dtype), arr),
+                              axis=axis)
 
 
 def _append_const(arr, pad_amt, val, axis=-1):
@@ -138,8 +138,8 @@ def _append_const(arr, pad_amt, val, axis=-1):
         return np.concatenate((arr, np.zeros(padshape, dtype=arr.dtype)),
                               axis=axis)
     else:
-        return np.concatenate(
-            (arr, (np.zeros(padshape) + val).astype(arr.dtype)), axis=axis)
+        return np.concatenate((arr, np.full(padshape, val, dtype=arr.dtype)),
+                              axis=axis)
 
 
 def _prepend_edge(arr, pad_amt, axis=-1):

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -100,12 +100,8 @@ def _prepend_const(arr, pad_amt, val, axis=-1):
         return arr
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
-    if val == 0:
-        return np.concatenate((np.zeros(padshape, dtype=arr.dtype), arr),
-                              axis=axis)
-    else:
-        return np.concatenate((np.full(padshape, val, dtype=arr.dtype), arr),
-                              axis=axis)
+    return np.concatenate((np.full(padshape, val, dtype=arr.dtype), arr),
+                          axis=axis)
 
 
 def _append_const(arr, pad_amt, val, axis=-1):
@@ -134,12 +130,8 @@ def _append_const(arr, pad_amt, val, axis=-1):
         return arr
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
-    if val == 0:
-        return np.concatenate((arr, np.zeros(padshape, dtype=arr.dtype)),
-                              axis=axis)
-    else:
-        return np.concatenate((arr, np.full(padshape, val, dtype=arr.dtype)),
-                              axis=axis)
+    return np.concatenate((arr, np.full(padshape, val, dtype=arr.dtype)),
+                          axis=axis)
 
 
 def _prepend_edge(arr, pad_amt, axis=-1):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -489,6 +489,19 @@ class TestConstant(object):
         )
         assert_allclose(test, expected)
 
+    def test_check_large_integers(self):
+        uint64_max = 2 ** 64 - 1
+        arr = np.full(5, uint64_max, dtype=np.uint64)
+        test = np.pad(arr, 1, mode="constant", constant_values=arr.min())
+        expected = np.full(7, uint64_max, dtype=np.uint64)
+        assert_array_equal(test, expected)
+
+        int64_max = 2 ** 63 - 1
+        arr = np.full(5, int64_max, dtype=np.int64)
+        test = np.pad(arr, 1, mode="constant", constant_values=arr.min())
+        expected = np.full(7, int64_max, dtype=np.int64)
+        assert_array_equal(test, expected)
+
 
 class TestLinearRamp(object):
     def test_check_simple(self):


### PR DESCRIPTION
Closes #11027 

The old way of creating the padded array padded with wrong values for
large integers because the new prepended / appended array was implicitly
created with dtype float64:

```python
>>> (np.zeros(1) + (2 ** 64 - 1)).astype(np.uint64)
array([0], np.uint64)
>>> (np.zeros(1) + (2 ** 63 - 1)).astype(np.int64)
array([-9223372036854775808])
```

cc @mhvk 

