### PR TITLE
BUG: initialize value before use

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3563,7 +3563,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                             op_axes_arrays[2]};
     npy_uint32 op_flags[3];
     int i, idim, ndim, otype_final;
-    int need_outer_iterator=0;
+    int need_outer_iterator = 0;
 
     NpyIter *iter = NULL;
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3563,7 +3563,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                             op_axes_arrays[2]};
     npy_uint32 op_flags[3];
     int i, idim, ndim, otype_final;
-    int need_outer_iterator;
+    int need_outer_iterator=0;
 
     NpyIter *iter = NULL;
 


### PR DESCRIPTION
compiling with clang, I discovered an uninitialized variable and many unused function warnings. This PR fixes the uninitialized value and splits generation of `byte_long`, `byte_float` and friends since the `*_long` variants are not used on python3

There are still unused functions in `umath_linalg.c.src`, TBD in another pull request since some of the unused functions seem to have value for debugging (`dump_*`)