### PR TITLE
ENH: Add `__deepcopy__` to MaskedConstant

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -116,6 +116,11 @@ longer possible, and objects expecting the old API are respected. The silent suc
 by removing the interception of an otherwise-normal Exception when ``axis`` was provided to an object
 using the old API.
 
+``copy.copy`` and ``copy.deepcopy`` no longer turn ``masked`` into an array
+----------------------------------------------------------------------------
+Since ``np.ma.masked`` is a readonly scalar, copying should be a no-op. These
+functions now behave consistently with ``np.copy()``.
+
 
 C API changes
 =============

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6317,9 +6317,12 @@ class MaskedConstant(MaskedArray):
         # precedent for this with `np.bool_` scalars.
         return self
 
-	def __deepcopy__(self, *args, **kwargs):
-		return self
-	
+    def __copy__(self, memo):
+        return self
+		
+    def __deepcopy__(self, memo):
+        return self
+
     def __setattr__(self, attr, value):
         if not self.__has_singleton():
             # allow the singleton to be initialized

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6317,10 +6317,10 @@ class MaskedConstant(MaskedArray):
         # precedent for this with `np.bool_` scalars.
         return self
 
-    def __copy__(self, memo=None):
+    def __copy__(self):
         return self
 		
-    def __deepcopy__(self, memo=None):
+    def __deepcopy__(self, memo):
         return self
 
     def __setattr__(self, attr, value):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6317,7 +6317,7 @@ class MaskedConstant(MaskedArray):
         # precedent for this with `np.bool_` scalars.
         return self
 
-    def __copy__(self, memo):
+    def __copy__(self):
         return self
 		
     def __deepcopy__(self, memo):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6317,10 +6317,10 @@ class MaskedConstant(MaskedArray):
         # precedent for this with `np.bool_` scalars.
         return self
 
-    def __copy__(self, memo):
+    def __copy__(self, memo=None):
         return self
 		
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo=None):
         return self
 
     def __setattr__(self, attr, value):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6317,6 +6317,9 @@ class MaskedConstant(MaskedArray):
         # precedent for this with `np.bool_` scalars.
         return self
 
+	def __deepcopy__(self, *args, **kwargs):
+		return self
+	
     def __setattr__(self, attr, value):
         if not self.__has_singleton():
             # allow the singleton to be initialized

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4827,12 +4827,14 @@ class TestMaskedConstant(object):
             np.True_.copy() is np.True_)
 
     def test__copy(self):
-        assert_(
-            copy.copy(np.ma.masked) is np.ma.masked)
+        assert_equal(
+            copy.copy(np.ma.masked) is np.ma.masked,
+            copy.copy(np.True_) is np.True_)
 
     def test_deepcopy(self):
-        assert_(
-            copy.deepcopy(np.ma.masked) is np.ma.masked)
+        assert_equal(
+            copy.deepcopy(np.ma.masked) is np.ma.masked,
+            copy.deepcopy(np.True) is np.True_)
 
     def test_immutable(self):
         orig = np.ma.masked

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4827,14 +4827,14 @@ class TestMaskedConstant(object):
             np.True_.copy() is np.True_)
 
     def test__copy(self):
-        assert_equal(
-            copy.copy(np.ma.masked) is np.ma.masked,
-            copy.copy(np.True_) is np.True_)
+        import copy
+        assert_(
+            copy.copy(np.ma.masked) is np.ma.masked)
 
-    def test__deepcopy(self):
-        assert_equal(
-            copy.deepcopy(np.ma.masked) is np.ma.masked,
-            copy.deepcopy(np.True_) is np.True_)
+    def test_deepcopy(self):
+        import copy
+        assert_(
+            copy.deepcopy(np.ma.masked) is np.ma.masked)
 
     def test_immutable(self):
         orig = np.ma.masked

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4828,15 +4828,13 @@ class TestMaskedConstant(object):
 
     def test__copy(self):
         import copy
-        assert_equal(
-            copy.copy(np.ma.masked) is np.ma.masked,
-            copy.copy(np.True_) is np.True_)
+        assert_(
+            copy.copy(np.ma.masked) is np.ma.masked)
 
     def test_deepcopy(self):
         import copy
-        assert_equal(
-            copy.deepcopy(np.ma.masked) is np.ma.masked,
-            copy.deepcopy(np.True_) is np.True_)
+        assert_(
+            copy.deepcopy(np.ma.masked) is np.ma.masked)
 
     def test_immutable(self):
         orig = np.ma.masked

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4834,7 +4834,7 @@ class TestMaskedConstant(object):
     def test_deepcopy(self):
         assert_equal(
             copy.deepcopy(np.ma.masked) is np.ma.masked,
-            copy.deepcopy(np.True) is np.True_)
+            copy.deepcopy(np.True_) is np.True_)
 
     def test_immutable(self):
         orig = np.ma.masked

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4827,14 +4827,12 @@ class TestMaskedConstant(object):
             np.True_.copy() is np.True_)
 
     def test__copy(self):
-        assert_equal(
-            copy.copy(np.ma.masked) is np.ma.masked,
-            copy.copy(np.True_) is np.True_)
+        assert_(
+            copy.copy(np.ma.masked) is np.ma.masked)
 
-    def test__deepcopy(self):
-        assert_equal(
-            copy.deepcopy(np.ma.masked) is np.ma.masked,
-            copy.deepcopy(np.True_) is np.True_)
+    def test_deepcopy(self):
+        assert_(
+            copy.deepcopy(np.ma.masked) is np.ma.masked)
 
     def test_immutable(self):
         orig = np.ma.masked

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4827,11 +4827,13 @@ class TestMaskedConstant(object):
             np.True_.copy() is np.True_)
 
     def test__copy(self):
+        import copy
         assert_equal(
             copy.copy(np.ma.masked) is np.ma.masked,
             copy.copy(np.True_) is np.True_)
 
     def test_deepcopy(self):
+        import copy
         assert_equal(
             copy.deepcopy(np.ma.masked) is np.ma.masked,
             copy.deepcopy(np.True_) is np.True_)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4826,6 +4826,16 @@ class TestMaskedConstant(object):
             np.ma.masked.copy() is np.ma.masked,
             np.True_.copy() is np.True_)
 
+    def test__copy(self):
+        assert_equal(
+            copy.copy(np.ma.masked) is np.ma.masked,
+            copy.copy(np.True_) is np.True_)
+
+    def test__deepcopy(self):
+        assert_equal(
+            copy.deepcopy(np.ma.masked) is np.ma.masked,
+            copy.deepcopy(np.True_) is np.True_)
+
     def test_immutable(self):
         orig = np.ma.masked
         assert_raises(np.ma.core.MaskError, operator.setitem, orig, (), 1)


### PR DESCRIPTION
Implemented deepcopy on MaskedConstant returning just self

Fixes #11021 