### PR TITLE
WIP: ENH: allow __array_ufunc__ to override __matmul__

### DIFF
--- a/numpy/add_newdocs.py
+++ b/numpy/add_newdocs.py
@@ -6277,6 +6277,27 @@ add_newdoc('numpy.core', 'ufunc', ('at',
 
     """))
 
+
+##############################################################################
+#
+# Documentation for ufunc_wrapper
+#
+##############################################################################
+
+add_newdoc('numpy.core', 'ufunc_wraper',
+    """
+    Decorator class to allow a ufunc-like class method to use the `__array_ufunc__`
+    mechanism
+
+    Examples
+    --------
+
+    >>> class ArrayLike:
+    ...     pass
+
+
+
+    """)
 ##############################################################################
 #
 # Documentation for dtype attributes and methods

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -111,15 +111,20 @@ typedef int (PyUFunc_MaskedInnerLoopSelectionFunc)(
                             NpyAuxData **out_innerloopdata,
                             int *out_needs_api);
 
-typedef struct _tagPyUFuncObject {
-        PyObject_HEAD
-        /*
+/* used in both ufunc and ufunc_wrapper */
+#define UFUNC_BASE \
+    PyObject_HEAD; /*
          * nin: Number of inputs
          * nout: Number of outputs
          * nargs: Always nin + nout (Why is it stored?)
-         */
-        int nin, nout, nargs;
+ */ int nin, nout, nargs;
 
+typedef struct {
+        UFUNC_BASE
+} PyUFuncBaseObject;
+
+typedef struct _tagPyUFuncObject {
+        UFUNC_BASE
         /* Identity for reduction, either PyUFunc_One or PyUFunc_Zero */
         int identity;
 

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -113,7 +113,7 @@ typedef int (PyUFunc_MaskedInnerLoopSelectionFunc)(
 
 /* used in both ufunc and ufunc_wrapper */
 #define UFUNC_BASE \
-    PyObject_HEAD; /*
+    PyObject_HEAD /*
          * nin: Number of inputs
          * nout: Number of outputs
          * nargs: Always nin + nout (Why is it stored?)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -64,11 +64,11 @@ class UFuncWrapper(ufunc_wrapper):
                 return result
     '''
     def __call__(self, meth):
-        def wrap(obj, *args, **kwds):
-            r = self.check_override(*((self,) + args), **kwds)
-            if r:
+        def wrap(*args, **kwds):
+            (status, r) = self.check_override(*args, **kwds)
+            if status > 0:
                 return r
-            return meth(obj, *args, **kwds)
+            return meth(*args, **kwds)
         wrap.__name__ = meth.__name__
         wrap.__doc__ = meth.__doc__
         return wrap

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -28,7 +28,8 @@ if sys.version_info[0] < 3:
     from .multiarray import newbuffer, getbuffer
 
 from . import umath
-from .umath import (multiply, invert, sin, UFUNC_BUFSIZE_DEFAULT,
+from .umath import (multiply, invert, sin, ufunc_wrapper,
+                    UFUNC_BUFSIZE_DEFAULT,
                     ERR_IGNORE, ERR_WARN, ERR_RAISE, ERR_CALL, ERR_PRINT,
                     ERR_LOG, ERR_DEFAULT, PINF, NAN)
 from . import numerictypes
@@ -36,6 +37,7 @@ from .numerictypes import longlong, intc, int_, float_, complex_, bool_
 from ._internal import TooHardError, AxisError
 
 bitwise_not = invert
+# TODO properly export ufunc from umath
 ufunc = type(sin)
 newaxis = None
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -71,6 +71,8 @@ class UFuncWrapper(ufunc_wrapper):
             return meth(*args, **kwds)
         wrap.__name__ = meth.__name__
         wrap.__doc__ = meth.__doc__
+        self.__name__ = meth.__name__
+        self.__doc__ = meth.__doc__
         return wrap
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -50,6 +50,30 @@ else:
     import __builtin__ as builtins
 
 
+# TODO: rewrite the __call__ in C?
+class UFuncWrapper(ufunc_wrapper):
+    ''' A decorator to wrap ufunc-like class methods and enable the
+        __array_ufunc__ protocol
+
+        Use as
+
+        class MyArray(ndarray):
+            @UFuncWrapper(2, 1) # nin, nout
+            def solve(self, other):
+                ...
+                return result
+    '''
+    def __call__(self, meth):
+        def wrap(obj, *args, **kwds):
+            r = self.check_override(*((self,) + args), **kwds)
+            if r:
+                return r
+            return meth(obj, *args, **kwds)
+        wrap.__name__ = meth.__name__
+        wrap.__doc__ = meth.__doc__
+        return wrap
+
+
 def loads(*args, **kwargs):
     # NumPy 1.15.0, 2017-12-10
     warnings.warn(
@@ -76,7 +100,7 @@ __all__ = [
     'False_', 'True_', 'bitwise_not', 'CLIP', 'RAISE', 'WRAP', 'MAXDIMS',
     'BUFSIZE', 'ALLOW_THREADS', 'ComplexWarning', 'full', 'full_like',
     'matmul', 'shares_memory', 'may_share_memory', 'MAY_SHARE_BOUNDS',
-    'MAY_SHARE_EXACT', 'TooHardError', 'AxisError']
+    'MAY_SHARE_EXACT', 'TooHardError', 'AxisError', 'UFuncWrapper']
 
 if sys.version_info[0] < 3:
     __all__.extend(['getbuffer', 'newbuffer'])

--- a/numpy/core/src/private/ufunc_override.c
+++ b/numpy/core/src/private/ufunc_override.c
@@ -41,6 +41,12 @@ get_non_default_array_ufunc(PyObject *obj)
         return NULL;
     }
     /* does the class define __array_ufunc__? */
+#if PY_VERSION_HEX < 0x03000000
+    if (Py_TYPE(obj) == &PyInstance_Type) {
+       PyErr_Warn(PyExc_RuntimeWarning,
+                   "cannot lookup __array_ufunc__ on old-style classes");
+    }
+#endif
     cls_array_ufunc = PyArray_LookupSpecial(obj, "__array_ufunc__");
     if (cls_array_ufunc == NULL) {
         return NULL;

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -37,7 +37,7 @@ normalize_signature_keyword(PyObject *normal_kwds)
 }
 
 static int
-normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
+normalize___call___args(PyUFuncBaseObject *ufunc, PyObject *args,
                         PyObject **normal_args, PyObject **normal_kwds)
 {
     /*
@@ -114,7 +114,7 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
 }
 
 static int
-normalize_reduce_args(PyUFuncObject *ufunc, PyObject *args,
+normalize_reduce_args(PyUFuncBaseObject *ufunc, PyObject *args,
                       PyObject **normal_args, PyObject **normal_kwds)
 {
     /*
@@ -169,7 +169,7 @@ normalize_reduce_args(PyUFuncObject *ufunc, PyObject *args,
 }
 
 static int
-normalize_accumulate_args(PyUFuncObject *ufunc, PyObject *args,
+normalize_accumulate_args(PyUFuncBaseObject *ufunc, PyObject *args,
                           PyObject **normal_args, PyObject **normal_kwds)
 {
     /*
@@ -215,7 +215,7 @@ normalize_accumulate_args(PyUFuncObject *ufunc, PyObject *args,
 }
 
 static int
-normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
+normalize_reduceat_args(PyUFuncBaseObject *ufunc, PyObject *args,
                     PyObject **normal_args, PyObject **normal_kwds)
 {
     /*
@@ -263,7 +263,7 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
 }
 
 static int
-normalize_outer_args(PyUFuncObject *ufunc, PyObject *args,
+normalize_outer_args(PyUFuncBaseObject *ufunc, PyObject *args,
                      PyObject **normal_args, PyObject **normal_kwds)
 {
     /*
@@ -297,7 +297,7 @@ normalize_outer_args(PyUFuncObject *ufunc, PyObject *args,
 }
 
 static int
-normalize_at_args(PyUFuncObject *ufunc, PyObject *args,
+normalize_at_args(PyUFuncBaseObject *ufunc, PyObject *args,
                   PyObject **normal_args, PyObject **normal_kwds)
 {
     /* ufunc.at(a, indices[, b]) */
@@ -325,7 +325,7 @@ normalize_at_args(PyUFuncObject *ufunc, PyObject *args,
  * result of the operation, if any. If *result is NULL, there is no override.
  */
 NPY_NO_EXPORT int
-PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
+PyUFunc_CheckOverride(PyUFuncBaseObject *ufunc, char *method,
                       PyObject *args, PyObject *kwds,
                       PyObject **result)
 {

--- a/numpy/core/src/umath/override.h
+++ b/numpy/core/src/umath/override.h
@@ -5,7 +5,7 @@
 #include "numpy/ufuncobject.h"
 
 NPY_NO_EXPORT int
-PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
+PyUFunc_CheckOverride(PyUFuncBaseObject *ufunc, char *method,
                       PyObject *args, PyObject *kwds,
                       PyObject **result);
 #endif

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5789,7 +5789,7 @@ NPY_NO_EXPORT PyTypeObject PyUFunc_Type = {
 /* End of code for ufunc objects */
 
 typedef struct {
-    UFUNC_BASE;
+    UFUNC_BASE
     PyObject * func;
     PyMethodDef func_def;
 } PyUFuncWrapperObject;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5875,9 +5875,9 @@ ufunc_check_override(PyObject *self, PyObject *args, PyObject *kwds) {
         return NULL;
     }
     else if (result) {
-        return result;
+        return Py_BuildValue("iO", 1, result);
     }
-    Py_RETURN_NONE;
+    return Py_BuildValue("iO", 0, Py_None);
 }
 
 static struct PyMethodDef ufuncwrapper_methods[] = {

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -253,6 +253,7 @@ intern_strings(void)
 /* Setup the umath module */
 /* Remove for time being, it is declared in __ufunc_api.h */
 /*static PyTypeObject PyUFunc_Type;*/
+extern PyTypeObject PyUFuncWrapper_Type;
 
 static struct PyMethodDef methods[] = {
     {"frompyfunc",
@@ -323,6 +324,10 @@ PyMODINIT_FUNC initumath(void)
     if (PyType_Ready(&PyUFunc_Type) < 0)
         goto err;
 
+    if (PyType_Ready(&PyUFuncWrapper_Type) < 0)
+        goto err;
+
+    PyModule_AddObject(m,"ufunc_wrapper",(PyObject*)&PyUFuncWrapper_Type);
     /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3378,19 +3378,6 @@ class TestBinop(object):
             def T(self):
                 return 4
 
-            @property
-            def T(self):
-                raise TypeError('__array_ufunc__ override not successful')
-
-        class InstanceOverrider():
-            # old style class on Python2, will warn and not override
-            def __array_ufunc__(self, ufunc, method, *args, **kwargs):
-                return method
-
-            @property
-            def T(self):
-                return 4
-
         s = np.arange(12).reshape(3,4).view(Solver)
         a = np.arange(11, -1, -1).reshape(3,4).T
         o = Overrider()
@@ -3407,18 +3394,6 @@ class TestBinop(object):
                 assert len(sup.log) == 1
             else:
                 assert_equal(s.solve(o), ('solve', '__call__'))
-                assert len(sup.log) == 0
-
-        i = InstanceOverrider()
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning)
-            ISPY2 = sys.version_info[0] < 3
-            if ISPY2:
-                # did not override via __array_ufunc__
-                assert_equal(s.solve(i), (s + 4) / 2.0)
-                assert len(sup.log) == 1
-            else:
-                assert_equal(s.solve(o), '__call__')
                 assert len(sup.log) == 0
 
 class TestTemporaryElide(object):


### PR DESCRIPTION
The discussion of issue #9028 yielded two different possible directions for allowing `ndarray` subclasses to override `__matmul__` via `__array_ufunc__`. This is option 2 - wrapping the non-ufunc `__matmul__` implementation in a way that respects the `__array_ufunc__` conventions.

Here is what changed:

- added a `ufuncwrapper` class that is meant to be used as a decorator, the class itself is implemented in C but the `__call__` method is in python for now. Its use is shown in `test_wrapper`, which shows how it could be used for a method called `solve`
- wrapped `array_matrix_multiply` with the class, and added the tests at the top of the issue to show how the wrapped method checks `__array_ufunc__` before calling `matmul`.

The wrapper only needs to know `nin` and `nout`, which are parameters to the class initializer.

Still todo:

- [ ]  get feedback about this direction, is it what was asked for? 
- [ ] move the python-level wrapper into C (make `ufuncwrapper_call` work) and clean up code
- [ ] document `ufunc-wrapper`
- [ ] add more tests, make sure there are no refcount leaks
- [ ] think about edge cases where this will not work, ~~for instance where `None` is a valid return value from `other.__array_ufunc__` (line 397 in number.c)~~ (EDIT: fixed `None` return via tuple)

Note the other option is to extend the meaning of ufunc signature so it can do multiple dispatch inside `get_binary_op_function` not only by types but by signature variations as well.
