### PR TITLE
BUG: Ensure `PyArray_AssignRawScalar` respects `NPY_NEEDS_INIT`

### DIFF
--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -245,6 +245,10 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
             allocated_src_data = 1;
         }
 
+        if (PyDataType_FLAGCHK(PyArray_DESCR(dst), NPY_NEEDS_INIT)) {
+            memset(tmp_src_data, 0, PyArray_DESCR(dst)->elsize);
+        }
+
         if (PyArray_CastRawArrays(1, src_data, tmp_src_data, 0, 0,
                             src_dtype, PyArray_DESCR(dst), 0) != NPY_SUCCEED) {
             src_data = tmp_src_data;


### PR DESCRIPTION
Resolves #11075

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/numpy/numpy/11076)
<!-- Reviewable:end -->
