### PR TITLE
BLD: cleanup `_configtest.o.d` during build

### DIFF
--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -101,8 +101,12 @@ Original exception was: %s, and the Compiler class was %s
         return ret
 
     def _compile (self, body, headers, include_dirs, lang):
-        return self._wrap_method(old_config._compile, lang,
-                                 (body, headers, include_dirs, lang))
+        src, obj = self._wrap_method(old_config._compile, lang,
+                                     (body, headers, include_dirs, lang))
+        # _compile in unixcompiler.py sometimes creates .d dependency files.
+        # Clean them up.
+        self.temp_files.append(obj + '.d')
+        return src, obj
 
     def _link (self, body,
                headers, include_dirs,

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -61,8 +61,9 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
         raise CompileError(msg)
 
     # add commandline flags to dependency file
-    with open(obj + '.d', 'a') as f:
-        f.write(_commandline_dep_string(cc_args, extra_postargs, pp_opts))
+    if deps:
+        with open(obj + '.d', 'a') as f:
+            f.write(_commandline_dep_string(cc_args, extra_postargs, pp_opts))
 
 replace_method(UnixCCompiler, '_compile', UnixCCompiler__compile)
 


### PR DESCRIPTION
~~WIP, I am still working out what is going on here, but it appears that it is faster to build all files than to check which files need to be rebuilt.~~

~~Putting this on github to see how it affects the CI build times.~~

Edit: See below, this PR now just properly cleans up `_configtest.o.d` so that it does not keep expanding in size after every build.