### PR TITLE
BUG: Added support for index values 27-52 in C einsum

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2652,21 +2652,31 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
         /* Subscript */
         else if (PyInt_Check(item) || PyLong_Check(item)) {
             long s = PyInt_AsLong(item);
-            if ( s < 0 || s > (2*26 - 1) ) {
+            npy_bool bad_input = 0;
+
+            if (subindex + 1 >= subsize) {
                 PyErr_SetString(PyExc_ValueError,
-                        "subscript is not within the valid range [0, 52]");
+                        "subscripts list is too long");
                 Py_DECREF(obj);
                 return -1;
             }
-            if (s < 26) {
-                subscripts[subindex++] = 'A' + s;
+
+            if ( s < 0 ) {
+                bad_input = 1;
+            }
+            else if (s < 26) {
+                subscripts[subindex++] = 'A' + (char)s;
+            }
+            else if (s < 2*26) {
+                subscripts[subindex++] = 'a' + (char)s - 26;
             }
             else {
-                subscripts[subindex++] = 'a' + s - 26;
+                bad_input = 1;
             }
-            if (subindex >= subsize) {
+
+            if (bad_input) {
                 PyErr_SetString(PyExc_ValueError,
-                        "subscripts list is too long");
+                        "subscript is not within the valid range [0, 52]");
                 Py_DECREF(obj);
                 return -1;
             }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2652,7 +2652,7 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
         /* Subscript */
         else if (PyInt_Check(item) || PyLong_Check(item)) {
             long s = PyInt_AsLong(item);
-            if ( s < 0 || s > 2*26) {
+            if ( s < 0 || s > (2*26 - 1) ) {
                 PyErr_SetString(PyExc_ValueError,
                         "subscript is not within the valid range [0, 52]");
                 Py_DECREF(obj);
@@ -2662,7 +2662,7 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
                 subscripts[subindex++] = 'A' + s;
             }
             else {
-                subscripts[subindex++] = 'a' + s;
+                subscripts[subindex++] = 'a' + s - 26;
             }
             if (subindex >= subsize) {
                 PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2676,7 +2676,7 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
 
             if (bad_input) {
                 PyErr_SetString(PyExc_ValueError,
-                        "subscript is not within the valid range [0, 52]");
+                        "subscript is not within the valid range [0, 52)");
                 Py_DECREF(obj);
                 return -1;
             }

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -596,6 +596,7 @@ class TestEinSum(object):
                      [[[1,  3], [3,  9], [5, 15], [7, 21]],
                      [[8, 16], [16, 32], [24, 48], [32, 64]]])
 
+    def test_subscript_range
         # Issue #7741, make sure that all letters of Latin alphabet (both uppercase & lowercase) can be used
         # when creating a subscript from arrays
         a = np.ones((2, 3))
@@ -603,6 +604,8 @@ class TestEinSum(object):
         np.einsum(a, [0, 20], b, [20, 2], [0, 2], optimize=False)
         np.einsum(a, [0, 27], b, [27, 2], [0, 2], optimize=False)
         np.einsum(a, [0, 51], b, [51, 2], [0, 2], optimize=False)
+        assert_raises(ValueError, lambda: np.einsum(a, [0, 52], b, [52, 2], [0, 2], optimize=False))
+        assert_raises(ValueError, lambda: np.einsum(a, [-1, 5], b, [5, 2], [-1, 2], optimize=False))
         
     def test_einsum_broadcast(self):
         # Issue #2455 change in handling ellipsis

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -596,6 +596,12 @@ class TestEinSum(object):
                      [[[1,  3], [3,  9], [5, 15], [7, 21]],
                      [[8, 16], [16, 32], [24, 48], [32, 64]]])
 
+        # Issue #7741, make sure that all letters of Latin alphabet (both uppercase & lowercase) can be used
+        # when creating a subscript from arrays
+        np.einsum(np.ones((2,3)),[0,20],np.ones((3,4)),[20,2],[0,2], optimize=False)
+        np.einsum(np.ones((2,3)),[0,27],np.ones((3,4)),[27,2],[0,2], optimize=False)
+        np.einsum(np.ones((2,3)),[0,51],np.ones((3,4)),[51,2],[0,2], optimize=False)
+        
     def test_einsum_broadcast(self):
         # Issue #2455 change in handling ellipsis
         # remove the 'middle broadcast' error

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -596,7 +596,7 @@ class TestEinSum(object):
                      [[[1,  3], [3,  9], [5, 15], [7, 21]],
                      [[8, 16], [16, 32], [24, 48], [32, 64]]])
 
-    def test_subscript_range
+    def test_subscript_range(self):
         # Issue #7741, make sure that all letters of Latin alphabet (both uppercase & lowercase) can be used
         # when creating a subscript from arrays
         a = np.ones((2, 3))

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -598,9 +598,11 @@ class TestEinSum(object):
 
         # Issue #7741, make sure that all letters of Latin alphabet (both uppercase & lowercase) can be used
         # when creating a subscript from arrays
-        np.einsum(np.ones((2,3)),[0,20],np.ones((3,4)),[20,2],[0,2], optimize=False)
-        np.einsum(np.ones((2,3)),[0,27],np.ones((3,4)),[27,2],[0,2], optimize=False)
-        np.einsum(np.ones((2,3)),[0,51],np.ones((3,4)),[51,2],[0,2], optimize=False)
+        a = np.ones((2, 3))
+        b = np.ones((3, 4))
+        np.einsum(a, [0, 20], b, [20, 2], [0, 2], optimize=False)
+        np.einsum(a, [0, 27], b, [27, 2], [0, 2], optimize=False)
+        np.einsum(a, [0, 51], b, [51, 2], [0, 2], optimize=False)
         
     def test_einsum_broadcast(self):
         # Issue #2455 change in handling ellipsis


### PR DESCRIPTION
See #7741

The C version of Einsum did not support values 26-52 to be used as index beforehand - it does now.