### PR TITLE
BUG: Python2 doubles don't print correctly in interactive shell

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4201,7 +4201,7 @@ doubletype_print(PyObject *o, FILE *fp, int flags)
         return -1;
     }
 
-    ret = PyObject_Print(to_print, fp, flags);
+    ret = PyObject_Print(to_print, fp, Py_PRINT_RAW);
     Py_DECREF(to_print);
     return ret;
 }

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -4,9 +4,10 @@
 """
 from __future__ import division, absolute_import, print_function
 
-import tempfile
+import code, sys
+from tempfile import TemporaryFile
 import numpy as np
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, suppress_warnings
 
 
 class TestRealScalars(object):
@@ -53,7 +54,7 @@ class TestRealScalars(object):
         # output to a "real file" (ie, not a StringIO). Make sure we don't
         # inherit it.
         x = np.double(0.1999999999999)
-        with tempfile.TemporaryFile('r+t') as f:
+        with TemporaryFile('r+t') as f:
             print(x, file=f)
             f.seek(0)
             output = f.read()
@@ -61,6 +62,37 @@ class TestRealScalars(object):
         # In python2 the value float('0.1999999999999') prints with reduced
         # precision as '0.2', but we want numpy's np.double('0.1999999999999')
         # to print the unique value, '0.1999999999999'.
+
+        # gh-11031
+        # Only in the python2 interactive shell and when stdout is a "real"
+        # file, the output of the last command is printed to stdout without
+        # Py_PRINT_RAW (unlike the print statement) so `>>> x` and `>>> print
+        # x` are potentially different. Make sure they are the same. The only
+        # way I found to get prompt-like output is using an actual prompt from
+        # the 'code' module. Again, must use tempfile to get a "real" file.
+
+        # dummy user-input which enters one line and then ctrl-Ds.
+        def userinput():
+            yield 'np.sqrt(2)'
+            raise EOFError
+        gen = userinput()
+        input_func = lambda prompt="": next(gen)
+
+        with TemporaryFile('r+t') as fo, TemporaryFile('r+t') as fe:
+            orig_stdout, orig_stderr = sys.stdout, sys.stderr
+            sys.stdout, sys.stderr = fo, fe
+
+            # py2 code.interact sends irrelevant internal DeprecationWarnings
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                code.interact(local={'np': np}, readfunc=input_func, banner='')
+
+            sys.stdout, sys.stderr = orig_stdout, orig_stderr
+
+            fo.seek(0)
+            capture = fo.read().strip()
+
+        assert_equal(capture, repr(np.sqrt(2)))
 
     def test_dragon4(self):
         # these tests are adapted from Ryan Juckett's dragon4 implementation,


### PR DESCRIPTION
Fixes #11031 

(Fix suggested by @eric-wieser at https://github.com/numpy/numpy/pull/10763#discussion_r185397259)

The bug is that floating point types were printed to the terminal with extra quote marks, but only in the python2 interactive shell and when stdout is a "real" file. This was due to weird old behavior in py2 related to `tp_print` I didn't correctly account for before.
