### PR TITLE
DOC: add numpy.lib.format to docs and link to it

### DIFF
--- a/doc/source/_templates/autosummary/minimal_module.rst
+++ b/doc/source/_templates/autosummary/minimal_module.rst
@@ -1,0 +1,8 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block docstring %}
+   {% endblock %}
+
+

--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -14,7 +14,7 @@ NumPy binary files (NPY, NPZ)
    savez_compressed
 
 The format of these binary file types is documented in
-:ref:`binary-serialization`.
+:py:mod:`numpy.lib.format`
 
 Text files
 ----------
@@ -78,3 +78,11 @@ Data sources
    :toctree: generated/
 
    DataSource
+
+Binary Format Description
+-------------------------
+.. autosummary::
+   :template: autosummary/minimal_module.rst
+   :toctree: generated/
+
+    lib.format

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -1,9 +1,8 @@
 """
+Binary serialization
 
-.. _binary-serialization:
-
-Binary Serialization
-====================
+NPY format
+==========
 
 A simple format for saving numpy arrays to disk with the full
 information about them.

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -475,7 +475,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
 
     Notes
     -----
-    For a description of the ``.npy`` format, see :ref:`binary-serialization`.
+    For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
 
     Examples
     --------
@@ -559,7 +559,7 @@ def savez(file, *args, **kwds):
     The ``.npz`` file format is a zipped archive of files named after the
     variables they contain.  The archive is not compressed and each file
     in the archive contains one variable in ``.npy`` format. For a
-    description of the ``.npy`` format, see :ref:`binary-serialization`.
+    description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
 
     When opening the saved ``.npz`` file with `load` a `NpzFile` object is
     returned. This is a dictionary-like object which can be queried for
@@ -639,7 +639,7 @@ def savez_compressed(file, *args, **kwds):
     variables they contain.  The archive is compressed with
     ``zipfile.ZIP_DEFLATED`` and each file in the archive contains one variable
     in ``.npy`` format. For a description of the ``.npy`` format, see 
-    :ref:`binary-serialization`.
+    :py:mod:`numpy.lib.format`.
 
 
     When opening the saved ``.npz`` file with `load` a `NpzFile` object is


### PR DESCRIPTION
Add documentation for `numpy.lib.format` by adding an `autosummary` section for it, a template that only reproduces the `docstring`. Then reference that module in the other parts of the documentation.

Replaces PR #11085, #11082. It seems I did not do "make clean" before testing those locally.