### PR TITLE
BUG: Typo in variable name in binary_repr

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2035,7 +2035,7 @@ def binary_repr(num, width=None):
     '11101'
 
     """
-    def warn_if_insufficient(width, binwdith):
+    def warn_if_insufficient(width, binwidth):
         if width is not None and width < binwidth:
             warnings.warn(
                 "Insufficient bit width provided. This behavior "


### PR DESCRIPTION
Typo fix in variable name in core/numeric/binary_repr/warn_if_insufficient.