### PR TITLE
ENH: Chain exceptions to give better error messages for invalid PEP3118 format strings

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -989,8 +989,11 @@ _descriptor_from_pep3118_format(char *s)
     Py_DECREF(str);
     Py_DECREF(_numpy_internal);
     if (descr == NULL) {
+        PyObject *exc, *val, *tb;
+        PyErr_Fetch(&exc, &val, &tb);
         PyErr_Format(PyExc_ValueError,
                      "'%s' is not a valid PEP 3118 buffer format string", buf);
+        npy_PyErr_ChainExceptionsCause(exc, val, tb);
         free(buf);
         return NULL;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6662,6 +6662,18 @@ class TestNewBufferProtocol(object):
             ValueError, "format string",
             np.array, m)
 
+    def test_error_message(self):
+        # wchar has no corresponding numpy type - if this changes in future, we
+        # need a better way to construct an invalid memoryview format.
+        t = ctypes.c_wchar * 4
+        with assert_raises(ValueError) as cm:
+            np.array(t())
+
+        exc = cm.exception
+        if sys.version_info.major > 2:
+            with assert_raises_regex(ValueError, "Unknown .* specifier 'u'"):
+                raise exc.__cause__
+
     def test_ctypes_integer_via_memoryview(self):
         # gh-11150, due to bpo-10746
         for c_integer in {ctypes.c_int, ctypes.c_long, ctypes.c_longlong}:


### PR DESCRIPTION
Sample console output:
```
In [1]: from ctypes import c_wchar

In [2]: x = c_wchar * 3

In [3]: np.array(x())
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~\Repos\numeric-python\numpy\build\testenv\Lib\site-packages\numpy\core\_internal.py in _dtype_from_pep3118(spec)
    486
--> 487     dtype, align = __dtype_from_pep3118(stream, is_subdtype=False)
    488     return dtype

~\Repos\numeric-python\numpy\build\testenv\Lib\site-packages\numpy\core\_internal.py in __dtype_from_pep3118(stream, is_subdtype)
    558         else:
--> 559             raise ValueError("Unknown PEP 3118 data type specifier %r" % stream.s)
    560

ValueError: Unknown PEP 3118 data type specifier 'u'

The above exception was the direct cause of the following exception:

ValueError                                Traceback (most recent call last)
<ipython-input-3-f8a17df3aa24> in <module>()
----> 1 np.array(x())

ValueError: '<u' is not a valid PEP 3118 buffer format string
```