### PR TITLE
WIP: ENH: Expand gufunc signature to allow flexible dimension specs

### DIFF
--- a/doc/source/reference/c-api.generalized-ufuncs.rst
+++ b/doc/source/reference/c-api.generalized-ufuncs.rst
@@ -101,6 +101,7 @@ Dimension Index
     enumerates the dimension names according to the order of the first
     occurrence of each name in the signature.
 
+.. _details-of-signature:
 
 Details of Signature
 --------------------
@@ -126,9 +127,11 @@ The formal syntax of signatures is as follows::
     <Output arguments>     ::= <Argument list>
     <Argument list>        ::= nil | <Argument> | <Argument> "," <Argument list>
     <Argument>             ::= "(" <Core dimension list> ")"
-    <Core dimension list>  ::= nil | <Dimension name> |
-                               <Dimension name> "," <Core dimension list>
-    <Dimension name>       ::= valid Python variable name
+    <Core dimension list>  ::= nil | <Core dimension name> |
+                               <Core dimension name> "," <Core dimension list>
+    <Core dimension name>  ::= valid Python variable name |
+                               valid integer |
+                               valid Python variable name ?
 
 
 Notes:
@@ -138,22 +141,35 @@ Notes:
    Each dimension name typically corresponds to one level of looping in the
    elementary function's implementation.
 #. White spaces are ignored.
+#. An integer as a dimension name freezes that dimension to the value,
+#. The name can be suffixed with a question mark, this make the dimension a
+   core dimension only if it exists on the input or output, otherwise 1 is used.
 
 Here are some examples of signatures:
 
-+-------------+------------------------+-----------------------------------+
-| add         | ``(),()->()``          |                                   |
-+-------------+------------------------+-----------------------------------+
-| inner1d     | ``(i),(i)->()``        |                                   |
-+-------------+------------------------+-----------------------------------+
-| sum1d       | ``(i)->()``            |                                   |
-+-------------+------------------------+-----------------------------------+
-| dot2d       | ``(m,n),(n,p)->(m,p)`` | matrix multiplication             |
-+-------------+------------------------+-----------------------------------+
-| outer_inner | ``(i,t),(j,t)->(i,j)`` | inner over the last dimension,    |
-|             |                        | outer over the second to last,    |
-|             |                        | and loop/broadcast over the rest. |
-+-------------+------------------------+-----------------------------------+
++-------------+----------------------------+-----------------------------------+
+| add         | ``(),()->()``              |                                   |
++-------------+----------------------------+-----------------------------------+
+| inner1d     | ``(i),(i)->()``            |                                   |
++-------------+----------------------------+-----------------------------------+
+| sum1d       | ``(i)->()``                |                                   |
++-------------+----------------------------+-----------------------------------+
+| dot2d       | ``(m,n),(n,p)->(m,p)``     | matrix multiplication             |
++-------------+----------------------------+-----------------------------------+
+| dot2d       | ``(n),(n,p)->(p)``         | vector-matrix multiplication      |
++-------------+----------------------------+-----------------------------------+
+| dot2d       | ``(n),(n)->()``            | vector-vector multiplication      |
++-------------+----------------------------+-----------------------------------+
+| dot2d       | ``(m,n),(n)->(m)``         | matrix-vector multiplication      |
++-------------+----------------------------+-----------------------------------+
+| dot2d       | ``(m?,n),(n,p?)->(m?,p?)`` | all four of the above at once     |
++-------------+----------------------------+-----------------------------------+
+| cross1d     | ``(3),(3)->(3)``           | cross product where last dim is 3 |
++-------------+----------------------------+-----------------------------------+
+| outer_inner | ``(i,t),(j,t)->(i,j)``     | inner over the last dimension,    |
+|             |                            | outer over the second to last,    |
+|             |                            | and loop/broadcast over the rest. |
++-------------+----------------------------+-----------------------------------+
 
 C-API for implementing Elementary Functions
 -------------------------------------------

--- a/doc/source/reference/c-api.generalized-ufuncs.rst
+++ b/doc/source/reference/c-api.generalized-ufuncs.rst
@@ -130,7 +130,6 @@ The formal syntax of signatures is as follows::
     <Core dimension list>  ::= nil | <Core dimension name> |
                                <Core dimension name> "," <Core dimension list>
     <Core dimension name>  ::= valid Python variable name |
-                               valid integer |
                                valid Python variable name ?
 
 
@@ -141,7 +140,6 @@ Notes:
    Each dimension name typically corresponds to one level of looping in the
    elementary function's implementation.
 #. White spaces are ignored.
-#. An integer as a dimension name freezes that dimension to the value,
 #. The name can be suffixed with a question mark, this make the dimension a
    core dimension only if it exists on the input or output, otherwise 1 is used.
 
@@ -163,8 +161,6 @@ Here are some examples of signatures:
 | dot2d       | ``(m,n),(n)->(m)``         | matrix-vector multiplication      |
 +-------------+----------------------------+-----------------------------------+
 | dot2d       | ``(m?,n),(n,p?)->(m?,p?)`` | all four of the above at once     |
-+-------------+----------------------------+-----------------------------------+
-| cross1d     | ``(3),(3)->(3)``           | cross product where last dim is 3 |
 +-------------+----------------------------+-----------------------------------+
 | outer_inner | ``(i,t),(j,t)->(i,j)``     | inner over the last dimension,    |
 |             |                            | outer over the second to last,    |

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -93,12 +93,18 @@ Functions
         the corresponding 1-d loop function in the func array.
 
     :param types:
-        Must be of length (*nin* + *nout*) \* *ntypes*, and it
-        contains the data-types (built-in only) that the corresponding
-        function in the *func* array can deal with.
+        Int8 of length `(nin + nout) * ntypes` It encodes the :ref:`dtype.num`
+        (built-in only) that the corresponding function in the `func` array
+        accepts. For a ufunc with two `ntypes`, one `nin` and one `nout` where
+        the first function accepts and returns `int32` and the second accepts
+        and returns `int64`, `types` would be `\05\05\07\07` since `int32.num`
+        is 5 and `int64.num` is 7.
+
+        :ref:`casting-rules` will be used at runtime to find the first `func` callable
+        by the input/output provided.
 
     :param ntypes:
-        How many different data-type "signatures" the ufunc has implemented.
+        How many different data-type-specific functions the ufunc has implemented.
 
     :param nin:
         The number of inputs to this operation.

--- a/doc/source/reference/c-api.ufunc.rst
+++ b/doc/source/reference/c-api.ufunc.rst
@@ -129,10 +129,11 @@ Functions
         int nin, int nout, int identity, char* name, char* doc, int unused, char *signature)
 
    This function is very similar to PyUFunc_FromFuncAndData above, but has
-   an extra *signature* argument, to define generalized universal functions.
+   an extra *signature* argument, to define a
+   :ref:`generalized universal functions <c-api.generalized-ufuncs>`.
    Similarly to how ufuncs are built around an element-by-element operation,
-   gufuncs are around subarray-by-subarray operations, the signature defining
-   the subarrays to operate on.
+   gufuncs are around subarray-by-subarray operations, the
+   :ref:`signature <details-of-signature>` defining the subarrays to operate on.
 
    :param signature:
         The signature for the new gufunc. Setting it to NULL is equivalent

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -424,8 +424,8 @@ advanced usage and will not typically be used.
     provided by the **types** attribute of the ufunc object. For backwards
     compatibility this argument can also be provided as *sig*, although
     the long form is preferred. Note that this should not be confused with
-    the generalized ufunc signature that is stored in the **signature**
-    attribute of the of the ufunc object.
+    the generalized ufunc :ref:`signature <details-of-signature>` that is
+    stored in the **signature** attribute of the of the ufunc object.
 
 *extobj*
 

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -1057,6 +1057,7 @@ PyUFunc_FromFuncAndData Specification
 What follows is the full specification of PyUFunc_FromFuncAndData, which
 automatically generates a ufunc from a C function with the correct signature.
 
+.. seealso:: :c:func:`PyUFunc_FromFuncAndDataAndSignature`
 
 .. c:function:: PyObject *PyUFunc_FromFuncAndData( \
         PyUFuncGenericFunction* func, void** data, char* types, int ntypes, \

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -209,6 +209,11 @@ typedef struct _tagPyUFuncObject {
          * set by nditer object.
          */
         npy_uint32 iter_flags;
+
+        /*
+         * sizes of frozen core dimensions, or -1 if unset
+         */
+         npy_intp *core_dim_szs;
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -130,8 +130,8 @@ typedef struct _tagPyUFuncObject {
         /* The number of elements in 'functions' and 'data' */
         int ntypes;
 
-        /* Used to be unused field 'check_return' */
-        int reserved1;
+        /* Used to be unused field 'check_return', repurposed in 1.16 */
+        int version;
 
         /* The name of the ufunc */
         const char *name;
@@ -209,6 +209,8 @@ typedef struct _tagPyUFuncObject {
          * set by nditer object.
          */
         npy_uint32 iter_flags;
+
+        /* New in version 1 and above */
 
         /*
          * sizes of frozen core dimensions, or -1 if unset

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -167,7 +167,7 @@ typedef struct _tagPyUFuncObject {
         int *core_dim_ixs;
         /*
          * positions of 1st core dimensions of each
-         * argument in core_dim_ixs
+         * argument in core_dim_ixs, equivalent to cumsum(core_num_dims)
          */
         int *core_offsets;
         /* signature string for printing purpose */
@@ -213,9 +213,15 @@ typedef struct _tagPyUFuncObject {
         /* New in version 1 and above */
 
         /*
-         * sizes of frozen core dimensions, or -1 if unset
+         * sizes of `frozen` core dimensions, -1 if unset (not frozen)
          */
-         npy_intp *core_dim_szs;
+        npy_intp *core_dim_szs;
+
+        /*
+         * for each core_num_dim_ix, 1 for flexible (signature has ?) 0 otherwise
+         */
+        int *core_dim_flexible;
+
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -213,11 +213,6 @@ typedef struct _tagPyUFuncObject {
         /* New in version 1 and above */
 
         /*
-         * sizes of `frozen` core dimensions, -1 if unset (not frozen)
-         */
-        npy_intp *core_dim_szs;
-
-        /*
          * for each core_num_dim_ix, 1 for flexible (signature has ?) 0 otherwise
          */
         int *core_dim_flexible;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -239,6 +239,13 @@ gentype_@name@(PyObject *m1, PyObject *m2)
 /**end repeat**/
 #endif
 
+static PyObject *
+gentype21_not_implemented(PyObject *m1, PyObject *m2)
+{
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
 /* Get a nested slot, or NULL if absent */
 #define GET_NESTED_SLOT(type, group, slot) \
     ((type)->group == NULL ? NULL : (type)->group->slot)
@@ -1159,6 +1166,10 @@ static PyNumberMethods gentype_as_number = {
     0,                                           /*nb_inplace_floor_divide*/
     0,                                           /*nb_inplace_true_divide*/
     (unaryfunc)NULL,                             /*nb_index*/
+#if PY_VERSION_HEX >= 0x03050000
+    (binaryfunc)gentype21_not_implemented,       /*nb_matrix_multiply*/
+    0,                                           /*nb_inplace_matrix_multiply*/
+#endif
 };
 
 

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -361,10 +361,11 @@ addUfuncs(PyObject *dictionary) {
 static PyObject *
 UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
-    int nin, nout, i;
-    PyObject *signature, *sig_str;
-    PyUFuncObject *f;
-    PyObject *core_num_dims;
+    int nin, nout, i, core_num_ixs=0;
+    PyObject *signature=NULL, *sig_str=NULL;
+    PyUFuncObject *f=NULL;
+    PyObject *core_num_dims=NULL, *core_dim_ixs=NULL, *core_dim_szs=NULL;
+    PyObject *core_dim_flexible=NULL;
     int core_enabled;
 
     if (!PyArg_ParseTuple(args, "iiO", &nin, &nout, &signature)) return NULL;
@@ -386,16 +387,43 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
     if (sig_str != signature) {
         Py_DECREF(sig_str);
     }
-    if (f == NULL) return NULL;
+    if (f == NULL) goto error;
     core_enabled = f->core_enabled;
     core_num_dims = PyTuple_New(f->nargs);
-    if (core_num_dims == NULL) return NULL;
+    if (core_num_dims == NULL) goto error;
     for (i=0; i<f->nargs; i++) {
         PyObject * val = PyLong_FromLong(f->core_num_dims[i]);
         PyTuple_SET_ITEM(core_num_dims, i, val);
+        core_num_ixs += f->core_num_dims[i];
+    }
+    core_dim_ixs = PyTuple_New(core_num_ixs);
+    if (core_num_dims == NULL) goto error;
+    for (i=0; i<core_num_ixs; i++) {
+        PyObject * val = PyLong_FromLong(f->core_dim_ixs[i]);
+        PyTuple_SET_ITEM(core_dim_ixs, i, val);
+    }
+    core_dim_szs = PyTuple_New(f->core_num_dim_ix);
+    if (core_num_dims == NULL) goto error;
+    for (i=0; i<f->core_num_dim_ix; i++) {
+        PyObject * val = PyLong_FromLong(f->core_dim_szs[i]);
+        PyTuple_SET_ITEM(core_dim_szs, i, val);
+    }
+    core_dim_flexible = PyTuple_New(f->core_num_dim_ix);
+    if (core_dim_flexible == NULL) goto error;
+    for (i=0; i<f->core_num_dim_ix; i++) {
+        PyObject * val = PyLong_FromLong(f->core_dim_flexible[i]);
+        PyTuple_SET_ITEM(core_dim_flexible, i, val);
     }
     Py_DECREF(f);
-    return Py_BuildValue("iO", core_enabled, core_num_dims);
+    return Py_BuildValue("iOOOO", core_enabled, core_num_dims,
+                                 core_dim_ixs, core_dim_szs,
+                                 core_dim_flexible);
+error:
+    Py_XDECREF(f);
+    Py_XDECREF(core_num_dims);
+    Py_XDECREF(core_dim_ixs);
+    Py_XDECREF(core_dim_flexible);
+    return NULL;
 }
 
 static PyMethodDef UMath_TestsMethods[] = {

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -196,40 +196,6 @@ static void
 /**end repeat**/
 
 char *euclidean_pdist_signature = "(n,d)->(p)";
-char *cross1d_signature = "(3),(3)->(3)";
-
-/**begin repeat
-
-   #TYPE=LONG,DOUBLE#
-   #typ=npy_long, npy_double#
-*/
-
-/*
- *  This implements the cross product:
- *        out[n, 0] = in1[n, 1]*in2[n, 2] - in1[n, 2]*in2[n, 1]
- *        out[n, 1] = in1[n, 2]*in2[n, 0] - in1[n, 0]*in2[n, 2]
- *        out[n, 2] = in1[n, 0]*in2[n, 1] - in1[n, 1]*in2[n, 0]
- */
-static void
-@TYPE@_cross1d(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    INIT_OUTER_LOOP_3
-    npy_intp is1=steps[0], is2=steps[1], os = steps[2];
-    BEGIN_OUTER_LOOP_3
-        char *ip1=args[0], *ip2=args[1], *op=args[2];
-
-        *(@typ@ *)op = *(@typ@ *)(ip1 + is1) * *(@typ@ *)(ip2 + 2*is2) -
-                       *(@typ@ *)(ip1 + 2*is1) * *(@typ@ *)(ip2 + is2);
-        op += os;
-        *(@typ@ *)op = *(@typ@ *)(ip1 + 2*is1) * *(@typ@ *)ip2 -
-                       *(@typ@ *)ip1 * *(@typ@ *)(ip2 + 2*is2);
-        op += os;
-        *(@typ@ *)op = *(@typ@ *)ip1 * *(@typ@ *)(ip2 + is2) -
-                       *(@typ@ *)(ip1 + is1) * *(@typ@ *)ip2;
-    END_OUTER_LOOP
-}
-
-/**end repeat**/
 
 /**begin repeat
 
@@ -297,9 +263,6 @@ static char innerwt_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_LONG, NPY
 static PyUFuncGenericFunction matrix_multiply_functions[] = { LONG_matrix_multiply, FLOAT_matrix_multiply, DOUBLE_matrix_multiply };
 static void *matrix_multiply_data[] = { (void *)NULL, (void *)NULL, (void *)NULL };
 static char matrix_multiply_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG,  NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,  NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-static PyUFuncGenericFunction cross1d_functions[] = { LONG_cross1d, DOUBLE_cross1d };
-static void * cross1d_data[] = { (void *)NULL, (void *)NULL };
-static char cross1d_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 
 static PyUFuncGenericFunction euclidean_pdist_functions[] =
                             { FLOAT_euclidean_pdist, DOUBLE_euclidean_pdist };
@@ -348,13 +311,6 @@ addUfuncs(PyObject *dictionary) {
                     0, inner1d_signature);
     PyDict_SetItemString(dictionary, "inner1d_no_doc", f);
     Py_DECREF(f);
-    f = PyUFunc_FromFuncAndDataAndSignature(cross1d_functions, cross1d_data, cross1d_signatures, 2,
-                                    2, 1, PyUFunc_None, "cross1d",
-                                    "cross product on the last dimension and broadcast on the rest \n"\
-                                    "     \"(3),(3)->(3)\" \n",
-                                    0, cross1d_signature);
-    PyDict_SetItemString(dictionary, "cross1d", f);
-    Py_DECREF(f);
 }
 
 
@@ -364,7 +320,7 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
     int nin, nout, i, core_num_ixs=0;
     PyObject *signature=NULL, *sig_str=NULL;
     PyUFuncObject *f=NULL;
-    PyObject *core_num_dims=NULL, *core_dim_ixs=NULL, *core_dim_szs=NULL;
+    PyObject *core_num_dims=NULL, *core_dim_ixs=NULL;
     PyObject *core_dim_flexible=NULL;
     int core_enabled;
 
@@ -402,12 +358,6 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
         PyObject * val = PyLong_FromLong(f->core_dim_ixs[i]);
         PyTuple_SET_ITEM(core_dim_ixs, i, val);
     }
-    core_dim_szs = PyTuple_New(f->core_num_dim_ix);
-    if (core_num_dims == NULL) goto error;
-    for (i=0; i<f->core_num_dim_ix; i++) {
-        PyObject * val = PyLong_FromLong(f->core_dim_szs[i]);
-        PyTuple_SET_ITEM(core_dim_szs, i, val);
-    }
     core_dim_flexible = PyTuple_New(f->core_num_dim_ix);
     if (core_dim_flexible == NULL) goto error;
     for (i=0; i<f->core_num_dim_ix; i++) {
@@ -415,9 +365,8 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
         PyTuple_SET_ITEM(core_dim_flexible, i, val);
     }
     Py_DECREF(f);
-    return Py_BuildValue("iOOOO", core_enabled, core_num_dims,
-                                 core_dim_ixs, core_dim_szs,
-                                 core_dim_flexible);
+    return Py_BuildValue("iOOO", core_enabled, core_num_dims,
+                                 core_dim_ixs, core_dim_flexible);
 error:
     Py_XDECREF(f);
     Py_XDECREF(core_num_dims);

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -361,9 +361,10 @@ addUfuncs(PyObject *dictionary) {
 static PyObject *
 UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
-    int nin, nout;
+    int nin, nout, i;
     PyObject *signature, *sig_str;
-    PyObject *f;
+    PyUFuncObject *f;
+    PyObject *core_num_dims;
     int core_enabled;
 
     if (!PyArg_ParseTuple(args, "iiO", &nin, &nout, &signature)) return NULL;
@@ -378,7 +379,7 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
         return NULL;
     }
 
-    f = PyUFunc_FromFuncAndDataAndSignature(NULL, NULL, NULL,
+    f = (PyUFuncObject*)PyUFunc_FromFuncAndDataAndSignature(NULL, NULL, NULL,
         0, nin, nout, PyUFunc_None, "no name",
         "doc:none",
         1, PyString_AS_STRING(sig_str));
@@ -386,9 +387,15 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
         Py_DECREF(sig_str);
     }
     if (f == NULL) return NULL;
-    core_enabled = ((PyUFuncObject*)f)->core_enabled;
+    core_enabled = f->core_enabled;
+    core_num_dims = PyTuple_New(f->nargs);
+    if (core_num_dims == NULL) return NULL;
+    for (i=0; i<f->nargs; i++) {
+        PyObject * val = PyLong_FromLong(f->core_num_dims[i]);
+        PyTuple_SET_ITEM(core_num_dims, i, val);
+    }
     Py_DECREF(f);
-    return Py_BuildValue("i", core_enabled);
+    return Py_BuildValue("iO", core_enabled, core_num_dims);
 }
 
 static PyMethodDef UMath_TestsMethods[] = {

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -196,6 +196,40 @@ static void
 /**end repeat**/
 
 char *euclidean_pdist_signature = "(n,d)->(p)";
+char *cross1d_signature = "(3),(3)->(3)";
+
+/**begin repeat
+
+   #TYPE=LONG,DOUBLE#
+   #typ=npy_long, npy_double#
+*/
+
+/*
+ *  This implements the cross product:
+ *        out[n, 0] = in1[n, 1]*in2[n, 2] - in1[n, 2]*in2[n, 1]
+ *        out[n, 1] = in1[n, 2]*in2[n, 0] - in1[n, 0]*in2[n, 2]
+ *        out[n, 2] = in1[n, 0]*in2[n, 1] - in1[n, 1]*in2[n, 0]
+ */
+static void
+@TYPE@_cross1d(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    INIT_OUTER_LOOP_3
+    npy_intp is1=steps[0], is2=steps[1], os = steps[2];
+    BEGIN_OUTER_LOOP_3
+        char *ip1=args[0], *ip2=args[1], *op=args[2];
+
+        *(@typ@ *)op = *(@typ@ *)(ip1 + is1) * *(@typ@ *)(ip2 + 2*is2) -
+                       *(@typ@ *)(ip1 + 2*is1) * *(@typ@ *)(ip2 + is2);
+        op += os;
+        *(@typ@ *)op = *(@typ@ *)(ip1 + 2*is1) * *(@typ@ *)ip2 -
+                       *(@typ@ *)ip1 * *(@typ@ *)(ip2 + 2*is2);
+        op += os;
+        *(@typ@ *)op = *(@typ@ *)ip1 * *(@typ@ *)(ip2 + is2) -
+                       *(@typ@ *)(ip1 + is1) * *(@typ@ *)ip2;
+    END_OUTER_LOOP
+}
+
+/**end repeat**/
 
 /**begin repeat
 
@@ -263,6 +297,9 @@ static char innerwt_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_LONG, NPY
 static PyUFuncGenericFunction matrix_multiply_functions[] = { LONG_matrix_multiply, FLOAT_matrix_multiply, DOUBLE_matrix_multiply };
 static void *matrix_multiply_data[] = { (void *)NULL, (void *)NULL, (void *)NULL };
 static char matrix_multiply_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG,  NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,  NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static PyUFuncGenericFunction cross1d_functions[] = { LONG_cross1d, DOUBLE_cross1d };
+static void * cross1d_data[] = { (void *)NULL, (void *)NULL };
+static char cross1d_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 
 static PyUFuncGenericFunction euclidean_pdist_functions[] =
                             { FLOAT_euclidean_pdist, DOUBLE_euclidean_pdist };
@@ -310,6 +347,13 @@ addUfuncs(PyObject *dictionary) {
                     NULL,
                     0, inner1d_signature);
     PyDict_SetItemString(dictionary, "inner1d_no_doc", f);
+    Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(cross1d_functions, cross1d_data, cross1d_signatures, 2,
+                                    2, 1, PyUFunc_None, "cross1d",
+                                    "cross product on the last dimension and broadcast on the rest \n"\
+                                    "     \"(3),(3)->(3)\" \n",
+                                    0, cross1d_signature);
+    PyDict_SetItemString(dictionary, "cross1d", f);
     Py_DECREF(f);
 }
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1178,6 +1178,13 @@ static PyObject *
 
 #endif
 
+static PyObject *
+@name@_matrix_multiply(PyObject *a, PyObject *b)
+{
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
 /**end repeat**/
 #undef _IS_ZERO
 
@@ -1633,6 +1640,10 @@ static PyNumberMethods @name@_as_number = {
     0,                                          /*nb_inplace_floor_divide*/
     0,                                          /*nb_inplace_true_divide*/
     (unaryfunc)NULL,                            /*nb_index*/
+#if PY_VERSION_HEX >= 0x03050000
+    (binaryfunc)@name@_matrix_multiply,          /*nb_matrix_multiply*/
+    0,                                           /*nb_inplace_matrix_multiply*/
+#endif
 };
 /**end repeat**/
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1178,13 +1178,6 @@ static PyObject *
 
 #endif
 
-static PyObject *
-@name@_matrix_multiply(PyObject *a, PyObject *b)
-{
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
-}
-
 /**end repeat**/
 #undef _IS_ZERO
 
@@ -1640,10 +1633,6 @@ static PyNumberMethods @name@_as_number = {
     0,                                          /*nb_inplace_floor_divide*/
     0,                                          /*nb_inplace_true_divide*/
     (unaryfunc)NULL,                            /*nb_index*/
-#if PY_VERSION_HEX >= 0x03050000
-    (binaryfunc)@name@_matrix_multiply,          /*nb_matrix_multiply*/
-    0,                                           /*nb_inplace_matrix_multiply*/
-#endif
 };
 /**end repeat**/
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -340,6 +340,28 @@ _is_alnum_underscore(char ch)
 }
 
 /*
+ * Convert a string into a number
+ */
+ static npy_intp
+ _get_size(const char* str)
+ {
+    char *stop;
+    #if defined(_MSC_VER)
+        #define strtoll _strtoi64
+    #endif
+    npy_intp size = (npy_intp)strtoll(str, &stop, 10);
+    #if defined(_MSC_VER)
+        #undef strtoll
+    #endif
+
+    if (stop == str || _is_alpha_underscore(*stop)) {
+        /* not a well formed number */
+         return -1;
+    }
+    return size;
+ }
+
+/*
  * Return the ending position of a variable name
  */
 static int
@@ -406,10 +428,13 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     ufunc->core_enabled = 1;
     ufunc->core_num_dim_ix = 0;
     ufunc->core_num_dims = PyArray_malloc(sizeof(int) * ufunc->nargs);
-    ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len); /* shrink this later */
     ufunc->core_offsets = PyArray_malloc(sizeof(int) * ufunc->nargs);
-    if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL
-        || ufunc->core_offsets == NULL) {
+    /* The next two items will be shrunk later */
+    ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len);
+    ufunc->core_dim_szs = PyArray_malloc(sizeof(npy_intp) * len);
+
+    if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL ||
+        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL) {
         PyErr_NoMemory();
         goto fail;
     }
@@ -438,8 +463,15 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         while (signature[i] != ')') {
             /* loop over core dimensions */
             int j = 0;
-            if (!_is_alpha_underscore(signature[i])) {
-                parse_error = "expect dimension name";
+            npy_intp frozen_size = -1;
+            if (signature[i] == '\0') {
+                parse_error = "unexpected end of signature string";
+                goto fail;
+            }
+
+            if (!_is_alpha_underscore(signature[i]) &&
+                (frozen_size = _get_size(signature + i)) < 0) {
+                parse_error = "expect dimension name or frozen size";
                 goto fail;
             }
             while (j < ufunc->core_num_dim_ix) {
@@ -450,6 +482,7 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
             }
             if (j >= ufunc->core_num_dim_ix) {
                 var_names[j] = signature+i;
+                ufunc->core_dim_szs[j] = frozen_size;
                 ufunc->core_num_dim_ix++;
             }
             ufunc->core_dim_ixs[cur_core_dim] = j;
@@ -494,6 +527,9 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     }
     ufunc->core_dim_ixs = PyArray_realloc(ufunc->core_dim_ixs,
             sizeof(int)*cur_core_dim);
+    // ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
+            // sizeof(npy_intp)*ufunc->core_num_dim_ix);
+
     /* check for trivial core-signature, e.g. "(),()->()" */
     if (cur_core_dim == 0) {
         ufunc->core_enabled = 0;
@@ -2087,10 +2123,14 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
              */
             for (idim = 0; idim < num_dims; ++idim) {
                 int core_dim_index = ufunc->core_dim_ixs[dim_offset+idim];
+                npy_intp frozen_size = ufunc->core_dim_szs[core_dim_index];
                 npy_intp op_dim_size = PyArray_DIM(
                     op[i], REMAP_AXIS(i, core_start_dim+idim));
 
-                if (core_dim_sizes[core_dim_index] == -1) {
+                if (frozen_size == -1 && core_dim_sizes[core_dim_index] == 1) {
+                    core_dim_sizes[core_dim_index] = op_dim_size;
+                }
+                else if (core_dim_sizes[core_dim_index] == -1) {
                     core_dim_sizes[core_dim_index] = op_dim_size;
                 }
                 else if (op_dim_size != core_dim_sizes[core_dim_index]) {
@@ -2363,6 +2403,17 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         if(retval < 0) {
             goto fail;
         }
+    }
+    /*
+     * Validate the core dimensions of all the operands,
+     * and collect all of the labeled core dimension sizes
+     * into the array 'core_dim_sizes'. Initialize them to
+     * 1, for example in the case where the operand broadcasts
+     * to a core dimension, it won't be visited.
+     */
+    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
+        npy_intp frozen_size = ufunc->core_dim_szs[i];
+        core_dim_sizes[i] = frozen_size == -1 ? 1 : frozen_size;
     }
 
     /* Collect the lengths of the labelled core dimensions */
@@ -4671,6 +4722,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     ufunc->core_dim_ixs = NULL;
     ufunc->core_offsets = NULL;
     ufunc->core_signature = NULL;
+    ufunc->core_dim_szs = NULL;
     if (signature != NULL) {
         if (_parse_signature(ufunc, signature) != 0) {
             Py_DECREF(ufunc);
@@ -5017,6 +5069,7 @@ ufunc_dealloc(PyUFuncObject *ufunc)
 {
     PyArray_free(ufunc->core_num_dims);
     PyArray_free(ufunc->core_dim_ixs);
+    PyArray_free(ufunc->core_dim_szs);
     PyArray_free(ufunc->core_offsets);
     PyArray_free(ufunc->core_signature);
     PyArray_free(ufunc->ptr);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4678,7 +4678,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     }
     PyObject_Init((PyObject *)ufunc, &PyUFunc_Type);
 
-    ufunc->reserved1 = 0;
+    ufunc->version = 1;  /* NumPy 1.16 and up */
     ufunc->reserved2 = NULL;
 
     ufunc->nin = nin;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -371,6 +371,9 @@ _get_end_of_name(const char* str, int offset)
     while (_is_alnum_underscore(str[ret])) {
         ret++;
     }
+    if (str[ret] == '?') {
+        ret ++;
+    }
     return ret;
 }
 
@@ -432,11 +435,16 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     /* The next two items will be shrunk later */
     ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len);
     ufunc->core_dim_szs = PyArray_malloc(sizeof(npy_intp) * len);
+    ufunc->core_dim_flexible = PyArray_malloc(sizeof(int) * len);
 
     if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL ||
-        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL) {
+        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL ||
+        ufunc->core_dim_flexible == NULL) {
         PyErr_NoMemory();
         goto fail;
+    }
+    for (i = 0; i < len; i++) {
+        ufunc->core_dim_flexible[i] = -1;
     }
 
     i = _next_non_white_space(signature, 0);
@@ -471,7 +479,7 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
 
             if (!_is_alpha_underscore(signature[i]) &&
                 (frozen_size = _get_size(signature + i)) < 0) {
-                parse_error = "expect dimension name or frozen size";
+                parse_error = "expect dimension name or non-zero frozen size";
                 goto fail;
             }
             while (j < ufunc->core_num_dim_ix) {
@@ -486,9 +494,23 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
                 ufunc->core_num_dim_ix++;
             }
             ufunc->core_dim_ixs[cur_core_dim] = j;
+            i = _get_end_of_name(signature, i);
+            if (i > 0 && signature[i - 1] == '?') {
+                if (ufunc->core_dim_flexible[j] == 0) {
+                    parse_error = "? cannot be used, name already seen without ?";
+                    goto fail;
+                }
+                ufunc->core_dim_flexible[j] = 1;
+            }
+            else {
+                if (ufunc->core_dim_flexible[j] == 1) {
+                    parse_error = "? must be used, name already seen with ?";
+                    goto fail;
+                }
+                ufunc->core_dim_flexible[j] = 0;
+            }
             cur_core_dim++;
             nd++;
-            i = _get_end_of_name(signature, i);
             i = _next_non_white_space(signature, i);
             if (signature[i] != ',' && signature[i] != ')') {
                 parse_error = "expect ',' or ')'";
@@ -527,8 +549,10 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     }
     ufunc->core_dim_ixs = PyArray_realloc(ufunc->core_dim_ixs,
             sizeof(int)*cur_core_dim);
-    // ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
-            // sizeof(npy_intp)*ufunc->core_num_dim_ix);
+    ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
+            sizeof(npy_intp)*ufunc->core_num_dim_ix);
+    ufunc->core_dim_flexible = PyArray_realloc(ufunc->core_dim_flexible,
+            sizeof(int)*(ufunc->core_num_dim_ix));
 
     /* check for trivial core-signature, e.g. "(),()->()" */
     if (cur_core_dim == 0) {
@@ -2102,6 +2126,7 @@ _parse_axes_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axes,
  */
 static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
+                   int *core_num_dims, int * flexible_activated,
                    npy_intp* core_dim_sizes, int **remap_axis) {
     int i;
     int nin = ufunc->nin;
@@ -2109,38 +2134,55 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
     int nop = nin + nout;
 
     for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
-        core_dim_sizes[i] = -1;
+        /* support fixed-size dim names */
+        core_dim_sizes[i] = ufunc->core_dim_szs[i];
     }
     for (i = 0; i < nop; ++i) {
         if (op[i] != NULL) {
             int idim;
             int dim_offset = ufunc->core_offsets[i];
-            int num_dims = ufunc->core_num_dims[i];
+            int num_dims = core_num_dims[i];
             int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
+            int dim_delta = 0;
+
+            /* Check if operands have enough dimensions */
+            if (core_start_dim < 0) {
+                PyErr_Format(PyExc_ValueError,
+                        "%s: %s operand %d does not have enough "
+                        "dimensions (has %d, gufunc core with "
+                        "signature %s requires %d)",
+                        ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
+                        i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                        ufunc->core_signature, num_dims);
+                return -1;
+            }
+
             /*
              * Make sure every core dimension exactly matches all other core
              * dimensions with the same label.
              */
-            for (idim = 0; idim < num_dims; ++idim) {
+            for (idim = 0; idim < ufunc->core_num_dims[i]; ++idim) {
                 int core_dim_index = ufunc->core_dim_ixs[dim_offset+idim];
-                npy_intp frozen_size = ufunc->core_dim_szs[core_dim_index];
-                npy_intp op_dim_size = PyArray_DIM(
-                    op[i], REMAP_AXIS(i, core_start_dim+idim));
-
-                if (frozen_size == -1 && core_dim_sizes[core_dim_index] == 1) {
-                    core_dim_sizes[core_dim_index] = op_dim_size;
+                npy_intp op_dim_size;
+                if (flexible_activated[core_dim_index] > 0) {
+                    op_dim_size = 0;
+                    dim_delta ++;
                 }
-                else if (core_dim_sizes[core_dim_index] == -1) {
+                else {
+                    op_dim_size = PyArray_DIM(op[i],
+                             REMAP_AXIS(i, core_start_dim + idim - dim_delta));
+                }
+                if (core_dim_sizes[core_dim_index] == -1) {
                     core_dim_sizes[core_dim_index] = op_dim_size;
                 }
                 else if (op_dim_size != core_dim_sizes[core_dim_index]) {
                     PyErr_Format(PyExc_ValueError,
-                            "%s: %s operand %d has a mismatch in its "
+                            "1 %s: %s operand %d has a mismatch in its "
                             "core dimension %d, with gufunc "
                             "signature %s (size %zd is different "
                             "from %zd)",
                             ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
-                            i < nin ? i : i - nin, idim,
+                            i < nin ? i : i - nin, idim - dim_delta,
                             ufunc->core_signature, op_dim_size,
                             core_dim_sizes[core_dim_index]);
                     return -1;
@@ -2166,7 +2208,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
         int out_op;
         for (out_op = nin; out_op < nop; ++out_op) {
             int first_idx = ufunc->core_offsets[out_op];
-            int last_idx = first_idx + ufunc->core_num_dims[out_op];
+            int last_idx = first_idx + core_num_dims[out_op];
             for (i = first_idx; i < last_idx; ++i) {
                 if (ufunc->core_dim_ixs[i] == missing_core_dim) {
                     break;
@@ -2243,6 +2285,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     int *core_num_dims;
     int op_axes_arrays[NPY_MAXARGS][NPY_MAXDIMS];
     int *op_axes[NPY_MAXARGS];
+    int n_dims_used[NPY_MAXARGS];
+    int flexible_activated[NPY_MAXARGS];
 
     npy_uint32 op_flags[NPY_MAXARGS];
     npy_intp iter_shape[NPY_MAXARGS];
@@ -2297,6 +2341,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         op[i] = NULL;
         dtypes[i] = NULL;
         arr_prep[i] = NULL;
+        n_dims_used[i] = ufunc->core_num_dims[i];
+    }
+    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
+        flexible_activated[i] = (ufunc->core_dim_flexible[i] > 0) ? -1 : 0;
     }
 
     NPY_UF_DBG_PRINT("Getting arguments\n");
@@ -2339,19 +2387,104 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      * (Just checks core; broadcast dimensions are tested by the iterator.)
      */
     for (i = 0; i < nop; i++) {
-        if (op[i] != NULL && PyArray_NDIM(op[i]) < core_num_dims[i]) {
-            PyErr_Format(PyExc_ValueError,
+        /* TODO: store _n_required after parsing, ahead-of-time */
+        int n_required = ufunc->core_num_dims[i];
+        if (n_required > 0) {
+            /* can be less if dim is flexible */
+            for (j = ufunc->core_offsets[i];
+                     j < ufunc->core_offsets[i] + core_num_dims[i]; j++) {
+                int dim_index = ufunc->core_dim_ixs[j];
+                n_required -= ufunc->core_dim_flexible[dim_index];
+            }
+        }
+        if (op[i] != NULL) {
+            n_dims_used[i] = PyArray_NDIM(op[i]);
+            if (n_dims_used[i] < n_required) {
+                PyErr_Format(PyExc_ValueError,
                          "%s: %s operand %d does not have enough "
                          "dimensions (has %d, gufunc core with "
                          "signature %s requires %d)",
                          ufunc_name,
                          i < nin ? "Input" : "Output",
-                         i < nin ? i : i - nin,
-                         PyArray_NDIM(op[i]),
-                         ufunc->core_signature,
-                         core_num_dims[i]);
-            retval = -1;
-            goto fail;
+                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                         ufunc->core_signature, n_required);
+                retval = -1;
+                goto fail;
+            }
+            if (n_dims_used[i] < core_num_dims[i]) {
+                int flexible_used = core_num_dims[i] - n_dims_used[i];
+                /* one (or more?) flexible signature names have been used. Mark them */
+                for (j = ufunc->core_offsets[i];
+                     j < ufunc->core_offsets[i] + core_num_dims[i];
+                     j++) {
+                    int dim_index = ufunc->core_dim_ixs[j];
+                    if (flexible_activated[dim_index] < 0) {
+                        flexible_activated[dim_index] = 1;
+                    }
+                    flexible_used -= flexible_activated[dim_index];
+                    if (flexible_used <= 0) {
+                        break;
+                    }
+                }
+                if (flexible_used > 0) {
+                    PyErr_Format(PyExc_ValueError,
+                         "%s: %s operand %d does not have enough "
+                         "dimensions (has %d, gufunc core with "
+                         "signature %s requires %d)",
+                         ufunc_get_name_cstr(ufunc),
+                         i < nin ? "Input" : "Output",
+                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                         ufunc->core_signature, n_required + flexible_used);
+                    goto fail;
+                }
+            }
+            else {
+                /* never use more than the signature requires */
+                n_dims_used[i] = core_num_dims[i];
+                /* make sure any flexible dimensions are used in the same way */
+                for (j = ufunc->core_offsets[i];
+                     j < ufunc->core_offsets[i] + core_num_dims[i];
+                     j++) {
+                    if (j <= ufunc->core_num_dim_ix) {
+                        int dim_index = ufunc->core_dim_ixs[j];
+                        if (flexible_activated[dim_index] < 0) {
+                            flexible_activated[dim_index] = 0;
+                        }
+                        else if (flexible_activated[dim_index] == 1) {
+                            PyErr_Format(PyExc_ValueError,
+                                "%s: %s operand %d with flexible dimension "
+                                "index %d signature %s previouosly marked "
+                                "flexible but now is not",
+                                 ufunc_get_name_cstr(ufunc),
+                                 i < nin ? "Input" : "Output",
+                                 i < nin ? i : i - nin, dim_index,
+                                 ufunc->core_signature);
+                            goto fail;
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            /* NULL output provided. Use flexible_used to determine ndims_used */
+            n_dims_used[i] = core_num_dims[i];
+            for (j = ufunc->core_offsets[i];
+                 j < ufunc->core_offsets[i] + core_num_dims[i]; j++) {
+                if (j <= ufunc->core_num_dim_ix) {
+                    int dim_index = ufunc->core_dim_ixs[j];
+                    if (flexible_activated[dim_index] < 0) {
+                        PyErr_Format(PyExc_ValueError,
+                            "%s: %s operand %d with flexible dimension index "
+                            " %d signature %s cannot be uniquely determined",
+                            ufunc_get_name_cstr(ufunc),
+                            i < nin ? "Input" : "Output",
+                            i < nin ? i : i - nin, dim_index,
+                            ufunc->core_signature);
+                        goto fail;
+                    }
+                    n_dims_used[i] -= flexible_activated[dim_index];
+                }
+            }
         }
     }
 
@@ -2362,7 +2495,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     broadcast_ndim = 0;
     for (i = 0; i < nin; ++i) {
-        int n = PyArray_NDIM(op[i]) - core_num_dims[i];
+        int n = PyArray_NDIM(op[i]) - n_dims_used[i];
         if (n > broadcast_ndim) {
             broadcast_ndim = n;
         }
@@ -2376,7 +2509,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     iter_ndim = broadcast_ndim;
     for (i = nin; i < nop; ++i) {
-        iter_ndim += core_num_dims[i];
+        iter_ndim += n_dims_used[i];
     }
     if (iter_ndim > NPY_MAXDIMS) {
         PyErr_Format(PyExc_ValueError,
@@ -2404,20 +2537,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
             goto fail;
         }
     }
-    /*
-     * Validate the core dimensions of all the operands,
-     * and collect all of the labeled core dimension sizes
-     * into the array 'core_dim_sizes'. Initialize them to
-     * 1, for example in the case where the operand broadcasts
-     * to a core dimension, it won't be visited.
-     */
-    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
-        npy_intp frozen_size = ufunc->core_dim_szs[i];
-        core_dim_sizes[i] = frozen_size == -1 ? 1 : frozen_size;
-    }
 
     /* Collect the lengths of the labelled core dimensions */
-    retval = _get_coredim_sizes(ufunc, op, core_dim_sizes, remap_axis);
+    retval = _get_coredim_sizes(ufunc, op, n_dims_used, flexible_activated,
+                                core_dim_sizes, remap_axis);
     if(retval < 0) {
         goto fail;
     }
@@ -2433,11 +2556,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         int n;
 
         if (op[i]) {
-            /*
-             * Note that n may be negative if broadcasting
-             * extends into the core dimensions.
-             */
-            n = PyArray_NDIM(op[i]) - core_num_dims[i];
+            n = PyArray_NDIM(op[i]) - n_dims_used[i];
         }
         else {
             n = broadcast_ndim;
@@ -2462,16 +2581,27 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         if (i >= nin) {
             int dim_offset = ufunc->core_offsets[i];
             int num_dims = core_num_dims[i];
+            int has_flexible=0;
             /*
              * Fill in 'iter_shape' and 'op_axes' for the core dimensions
              * of this output. Here, we have to be careful: if keepdims
-             * was used, then this axis is not a real core dimension,
-             * but is being added back for broadcasting, so its size is 1.
+             * was used or if it is a flexible dimension, then this axis
+             * is not a real core dimension, but is being added back for broadcasting,
+             * so its size is 1.
              */
             for (idim = 0; idim < num_dims; ++idim) {
-                iter_shape[j] = keepdims ? 1 : core_dim_sizes[
-                                        ufunc->core_dim_ixs[dim_offset + idim]];
-                op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim);
+                if (keepdims) {
+                    iter_shape[j] = 1;
+                } else {
+                    int core_index = ufunc->core_dim_ixs[dim_offset + idim];
+                    if (flexible_activated[core_index]) {
+                        /* skip it */
+                        has_flexible ++;
+                        continue;
+                    }
+                    iter_shape[j] = core_dim_sizes[core_index];
+                }
+                op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim - has_flexible);
                 ++j;
             }
         }
@@ -2602,6 +2732,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     idim = nop;
     for (i = 0; i < nop; ++i) {
         int num_dims = core_num_dims[i];
+        /* Could be negative if flexible dims are used, or if keepdims */
         int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
         /*
          * Need to use the arrays in the iterator, not op, because

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -284,11 +284,45 @@ class TestUfunc(object):
 
     def test_signature(self):
         # the arguments to test_signature are: nin, nout, core_signature
-        # pass
-        assert_equal(umt.test_signature(2, 1, "(i),(i)->()"), 1)
+        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(i),(i)->()")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1,  1,  0))
+        assert_equal(ixs, (0, 0))
+        assert_equal(szs, (-1,))
 
-        # pass. empty core signature; treat as plain ufunc (with trivial core)
-        assert_equal(umt.test_signature(2, 1, "(),()->()"), 0)
+        # empty core signature; treat as plain ufunc (with trivial core)
+        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(),()->()")
+        assert_equal(enabled, 0)
+        assert_equal(num_dims, (0,  0,  0))
+        assert_equal(ixs, ())
+        assert_equal(szs, ())
+
+        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(n,k),(k,m)->(n,m)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 2, 2))
+        assert_equal(ixs, (0, 1, 1, 2, 0, 2))
+        assert_equal(szs, (-1, -1, -1))
+
+        # more complicated names for variables
+        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 1, 1))
+        assert_equal(ixs, (0, 1, 2, 3))
+        assert_equal(szs, (-1, -1, -1, -1))
+
+        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 1, 2))
+        assert_equal(ixs, (0, 1, 2, 1, 3))
+        assert_equal(szs, (-1, -1, -1, -1))
+        assert_equal(flex, (0, 0, 0, 0))
+
+        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(n?,k),(k,m?)->(n?,m?)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 2, 2))
+        assert_equal(ixs, (0, 1, 1, 2, 0, 2))
+        assert_equal(szs, (-1, -1, -1))
+        assert_equal(flex, (1, 0, 1))
 
         # in the following calls, a ValueError should be raised because
         # of error in core signature
@@ -325,9 +359,6 @@ class TestUfunc(object):
             assert_equal(ret, None, err_msg=msg)
         except ValueError:
             pass
-
-        # more complicated names for variables
-        assert_equal(umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)"), 1)
 
     def test_get_signature(self):
         assert_equal(umt.inner1d.signature, "(i),(i)->()")

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -284,44 +284,38 @@ class TestUfunc(object):
 
     def test_signature(self):
         # the arguments to test_signature are: nin, nout, core_signature
-        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(i),(i)->()")
+        enabled, num_dims, ixs, flex = umt.test_signature(2, 1, "(i),(i)->()")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1,  1,  0))
         assert_equal(ixs, (0, 0))
-        assert_equal(szs, (-1,))
 
         # empty core signature; treat as plain ufunc (with trivial core)
-        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(),()->()")
+        enabled, num_dims, ixs, flex = umt.test_signature(2, 1, "(),()->()")
         assert_equal(enabled, 0)
         assert_equal(num_dims, (0,  0,  0))
         assert_equal(ixs, ())
-        assert_equal(szs, ())
 
-        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(n,k),(k,m)->(n,m)")
+        enabled, num_dims, ixs, flex = umt.test_signature(2, 1, "(n,k),(k,m)->(n,m)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 2, 2))
         assert_equal(ixs, (0, 1, 1, 2, 0, 2))
-        assert_equal(szs, (-1, -1, -1))
 
         # more complicated names for variables
-        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)")
+        enabled, num_dims, ixs, flex = umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 1, 1))
         assert_equal(ixs, (0, 1, 2, 3))
-        assert_equal(szs, (-1, -1, -1, -1))
 
-        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
+        enabled, num_dims, ixs, flex = umt.test_signature(2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 1, 2))
         assert_equal(ixs, (0, 1, 2, 1, 3))
-        assert_equal(szs, (-1, -1, -1, -1))
         assert_equal(flex, (0, 0, 0, 0))
 
-        enabled, num_dims, ixs, szs,flex = umt.test_signature(2, 1, "(n?,k),(k,m?)->(n?,m?)")
+        enabled, num_dims, ixs, flex = umt.test_signature(2, 1, "(n?,k),(k,m?)->(n?,m?)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 2, 2))
         assert_equal(ixs, (0, 1, 1, 2, 0, 2))
-        assert_equal(szs, (-1, -1, -1))
         assert_equal(flex, (1, 0, 1))
 
         # in the following calls, a ValueError should be raised because


### PR DESCRIPTION
The discussion of issue #9028 yielded two different possible directions for allowing `ndarray` subclasses to override `__matmul__` via `__array_ufunc__`. This is option 1 - extend the core signature of a generalized `ufunc` to allow a single ufunc `matmul` which will implement vector-vector, vector-matrix, matrix-vector, and matrix-matrix multiplication. In this PR, the syntax of a signature is expanded to allow `(n?, k),(k, m?)->(n?, m?)` syntax, where the `?` means "this dimension is optional" [0],[1]. I also incorporated PR #5015 where signatures can have a fixed dimension `(3),(3)->(3)`.

**What changed?**
- There is a change in the PyUFuncObject structure. I added two fields, and repurposed the unused field `reserved1` to become a `version` field for downstream consumers of the C-API.
- The parsing code during `ufunc` instantiation now parses the expanded signature
- When calling a `ufunc` with flexible or fixed dimensions, extra checks are done to ensure consistency

**What is yet to be done?**
- The code needs cleanup and refactoring
- Tests were added but there is a good chance I missed corner cases
- I wrote the code together with the PR making `matmul` a true `ufunc`, I probably have chages there that belong here and visa-versa

**What is next?**
- Use this mechanism to make `matmul` a true `ufunc`
- Get feedback on the relative merits of this approach vs. the one taken in PR #11061, where I produced a demi-`ufunc` with a wrapper function that can be used to convert any function into a `ufunc`.

[0]: Note that, following the [PEP for matrix multiplication](https://www.python.org/dev/peps/pep-0465/#semantics), there is no broadcasting over the optional dimensions, in the example given if the first operand has 2 or more dimensions, the second-to-the-last will be 'n', no `newaxis` will be inserted instead.

[1] The syntax '(n,k),(k,m)->(n,m);(n,k),(k)->(n);(k),(k,m)->(m);(k),(k)->()` was also considered and rejected as allowing too much flexibility in stacking alternate core signatures.