### PR TITLE
MAINT: Update artful to bionic for i386 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,13 @@ python:
 matrix:
   include:
     - python: 3.6
-      env: USE_CHROOT=1 ARCH=i386 DIST=artful PYTHON=3.6
+      env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=3.6
       sudo: true
       addons:
         apt:
+          update: true
           packages:
+            - dpkg
             - debootstrap
     - python: 3.4
       env: USE_DEBUG=1


### PR DESCRIPTION
As mentioned in PR #10425, now that bionic has been released we should use it for testing