### PR TITLE
DOC: cleanup NEP creation

### DIFF
--- a/doc/neps/Makefile
+++ b/doc/neps/Makefile
@@ -1,6 +1,5 @@
 # Minimal makefile for Sphinx documentation
 #
-PYVER = 3.6
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
@@ -16,7 +15,7 @@ help:
 .PHONY: help Makefile index
 
 index:
-	python${PYVER} tools/build_index.py
+	python tools/build_index.py
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/neps/Makefile
+++ b/doc/neps/Makefile
@@ -1,5 +1,6 @@
 # Minimal makefile for Sphinx documentation
 #
+PYVER = 3.6
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
@@ -15,7 +16,7 @@ help:
 .PHONY: help Makefile index
 
 index:
-	python tools/build_index.py
+	python${PYVER} tools/build_index.py
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/neps/index.rst.tmpl
+++ b/doc/neps/index.rst.tmpl
@@ -30,6 +30,19 @@ Accepted NEPs, implementation in progress
    NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 
+
+Open NEPs (under consideration)
+-------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+{% for nep, tags in neps.items() if tags['Status'] == 'Draft' %}
+   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+{% endfor %}
+
+
+
 Implemented NEPs
 ----------------
 

--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -3,7 +3,7 @@ Purpose and Process
 ===================
 
 :Author: Jarrod Millman <millman@berkeley.edu>
-:Status: Draft
+:Status: Active
 :Type: Process
 :Created: 2017-12-11
 


### PR DESCRIPTION
Small changes to NEP documentation creation
- force python version as is done in main documentation creation
- add a "Open NEPs" section for draft NEPs (like [python PEPs](https://www.python.org/dev/peps/))
- move nep-0000 from `Draft`to `Active`, as detailed in the nep itself