### PR TITLE
TST: make build warning into an error in runtest.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -330,9 +330,9 @@ def build_project(args):
     cvars = distutils.sysconfig.get_config_vars()
     if 'gcc' in cvars['CC']:
         # add flags used as werrors tools/travis-test.sh
-        warnings_as_errors = (' -Werror=declaration-after-statement -Werror=vla'
+        warnings_as_errors = ('-Werror=declaration-after-statement -Werror=vla'
                               ' -Werror=nonnull -Werror=pointer-arith'
-                              ' -Wlogical-op')
+                              ' -Wlogical-op -Werror=unused-function ')
         env['CFLAGS'] = warnings_as_errors + env.get('CFLAGS', '')
     if args.debug or args.gcov:
         # assume everyone uses gcc/gfortran

--- a/runtests.py
+++ b/runtests.py
@@ -328,12 +328,18 @@ def build_project(args):
     # Always use ccache, if installed
     env['PATH'] = os.pathsep.join(EXTRA_PATH + env.get('PATH', '').split(os.pathsep))
     cvars = distutils.sysconfig.get_config_vars()
-    if 'gcc' in cvars['CC']:
-        # add flags used as werrors tools/travis-test.sh
-        warnings_as_errors = ('-Werror=declaration-after-statement -Werror=vla'
-                              ' -Werror=nonnull -Werror=pointer-arith'
-                              ' -Wlogical-op -Werror=unused-function ')
-        env['CFLAGS'] = warnings_as_errors + env.get('CFLAGS', '')
+    if 'gcc' in cvars.get('CC', ''):
+        # add flags used as werrors from tools/travis-test.sh,
+        # add unused-function as well from sysconfig
+        warnings_as_errors = ' '.join([
+                    '-Werror=declaration-after-statement',
+                    '-Werror=vla',
+                    '-Werror=nonnull',
+                    '-Werror=pointer-arith',
+                    '-Wlogical-op',
+                    '-Werror=unused-function',
+        ])
+        env['CFLAGS'] = warnings_as_errors + ' ' + env.get('CFLAGS', '')
     if args.debug or args.gcov:
         # assume everyone uses gcc/gfortran
         env['OPT'] = '-O0 -ggdb'

--- a/runtests.py
+++ b/runtests.py
@@ -329,15 +329,16 @@ def build_project(args):
     env['PATH'] = os.pathsep.join(EXTRA_PATH + env.get('PATH', '').split(os.pathsep))
     cvars = distutils.sysconfig.get_config_vars()
     if 'gcc' in cvars.get('CC', ''):
-        # add flags used as werrors from tools/travis-test.sh,
-        # add unused-function as well from sysconfig
+        # add flags used as werrors
         warnings_as_errors = ' '.join([
-                    '-Werror=declaration-after-statement',
-                    '-Werror=vla',
-                    '-Werror=nonnull',
-                    '-Werror=pointer-arith',
-                    '-Wlogical-op',
-                    '-Werror=unused-function',
+            # from tools/travis-test.sh
+            '-Werror=declaration-after-statement',
+            '-Werror=vla',
+            '-Werror=nonnull',
+            '-Werror=pointer-arith',
+            '-Wlogical-op',
+            # from sysconfig
+            '-Werror=unused-function',
         ])
         env['CFLAGS'] = warnings_as_errors + ' ' + env.get('CFLAGS', '')
     if args.debug or args.gcov:


### PR DESCRIPTION
continuation of pr #11139, turn unused-function warning into an error when building for tests. Also move string padding to end since we prepend this to existing flags