### PR TITLE
BENCH: Add basic benchmarks for numpy.pad

### DIFF
--- a/benchmarks/benchmarks/bench_lib.py
+++ b/benchmarks/benchmarks/bench_lib.py
@@ -1,0 +1,25 @@
+"""Benchmarks for `numpy.lib`."""
+
+
+from __future__ import absolute_import, division, print_function
+
+from .common import Benchmark
+
+import numpy as np
+
+
+class Pad(Benchmark):
+    """Benchmarks for `numpy.pad`."""
+
+    param_names = ["shape", "pad_width", "mode"]
+    params = [
+        [(1000,), (10, 100), (10, 10, 10)],
+        [1, 3, (0, 5)],
+        ["constant", "edge", "linear_ramp", "mean", "reflect", "wrap"],
+    ]
+
+    def setup(self, shape, pad_width, mode):
+        self.array = np.empty(shape)
+
+    def time_pad(self, shape, pad_width, mode):
+        np.pad(self.array, pad_width, mode)


### PR DESCRIPTION
Provides basic benchmarks for a few representative (?) modes in `numpy.pad`. Please, don't hesitate to suggest any modifications to the benchmarks scenarios (content of `Pad.params`).

Related #11126