### PR TITLE
TST: disable gc in refcount test

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1373,16 +1373,20 @@ def _assert_valid_refcount(op):
     """
     if not HAS_REFCOUNT:
         return True
-    import numpy as np
+    import numpy as np, gc
 
     b = np.arange(100*100).reshape(100, 100)
     c = b
     i = 1
 
-    rc = sys.getrefcount(i)
-    for j in range(15):
-        d = op(b, c)
-    assert_(sys.getrefcount(i) >= rc)
+    gc.disable()
+    try:
+        rc = sys.getrefcount(i)
+        for j in range(15):
+            d = op(b, c)
+        assert_(sys.getrefcount(i) >= rc)
+    finally:
+        gc.enable()
     del d  # for pyflakes
 
 


### PR DESCRIPTION
refcount tests seem to fail on windows appveyor, try diabling GC