### PR TITLE
TST: Skip ctypes dependent test that fails on Python < 2.7.7.

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6517,6 +6517,7 @@ class TestNewBufferProtocol(object):
         a = np.empty((1,) * 32)
         self._check_roundtrip(a)
 
+    @pytest.mark.skipif(sys.version_info < (2, 7, 7), reason="See gh-11115")
     def test_error_too_many_dims(self):
         def make_ctype(shape, scalar_type):
             t = scalar_type


### PR DESCRIPTION
Fixes #11115 related to #11150 

Python before 2.7.7 had a broken ctypes memoryview format for multi-demensional arrays. Skip the test