### PR TITLE
ENH: Use asanyarray in quantile/percentile helper function

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3672,7 +3672,7 @@ def _quantile_is_valid(q):
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,
                            interpolation='linear', keepdims=False):
-    a = asarray(a)
+    a = asanyarray(a)
     if q.ndim == 0:
         # Do not allow 0-d arrays because following code fails for scalar
         zerod = True


### PR DESCRIPTION
Hi all -

Over in [astropy](github.com/astropy/astropy), I noticed that `numpy.percentile` and `numpy.quantile` strip units from [`Quantity`](https://github.com/astropy/astropy/blob/master/astropy/units/quantity.py#L200) objects (which subclass `numpy.ndarray`). I thought at first that this might be a deep issue, but in checking the code in `numpy/lib/function_base.py` I noticed that it might be a simple fix to allow subclasses to carry through. Currently, `_quantile_ureduce_func` (used by both `quantile` and therefore `percentile`) uses `asarray()` on the input. Locally, if I switch this to `asanyarray` (as other functions use), Numpy tests still pass and the output preserves the subclass type. 

To set up an example:
```python
>>> import astropy.units as u
>>> from numpy.lib.functions_base import _quantile_ureduce_func
>>> arr = [1., 2., 3.] * u.km
```

Behavior with current `master`:
```python
>>> _quantile_ureduce_func(arr, np.array([0.15]))
array([1.3])
```

New behavior:
```python
>>> _quantile_ureduce_func(arr, np.array([0.15]))
<Quantity [1.3] km>
```

I *think* this is an ENH not a BUG per se, but let me know?

cc @mhvk 