### PR TITLE
TST: linalg: add regression test for gh-8577

### DIFF
--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -7,6 +7,8 @@ import os
 import sys
 import itertools
 import traceback
+import textwrap
+import subprocess
 import pytest
 
 import numpy as np
@@ -1759,6 +1761,40 @@ def test_xerbla_override():
         pid, status = os.wait()
         if os.WEXITSTATUS(status) != XERBLA_OK:
             raise SkipTest('Numpy xerbla not linked in.')
+
+
+def test_sdot_bug_8577():
+    # Regression test that loading certain other libraries does not
+    # result to wrong results in float32 linear algebra.
+    #
+    # There's a bug gh-8577 on OSX that can trigger this, and perhaps
+    # there are also other situations in which it occurs.
+    #
+    # Do the check in a separate process.
+
+    bad_libs = ['PyQt5.QtWidgets', 'IPython']
+
+    template = textwrap.dedent("""
+    import sys
+    {before}
+    try:
+        import {bad_lib}
+    except ImportError:
+        sys.exit(0)
+    {after}
+    x = np.ones(2, dtype=np.float32)
+    sys.exit(0 if np.allclose(x.dot(x), 2.0) else 1)
+    """)
+
+    for bad_lib in bad_libs:
+        code = template.format(before="import numpy as np", after="",
+                               bad_lib=bad_lib)
+        subprocess.check_call([sys.executable, "-c", code])
+
+        # Swapped import order
+        code = template.format(after="import numpy as np", before="",
+                               bad_lib=bad_lib)
+        subprocess.check_call([sys.executable, "-c", code])
 
 
 class TestMultiDot(object):


### PR DESCRIPTION
Add regression test that checks for certain bugs where results from sdot
change if certain libraries are imported first.

This is added in case it manages to catch several of recently reported bugs
on OSX (#8577, #11166, #10584). More libraries could be added here in addition to pyqt5, in case
other potentially problematic imports are found.