### PR TITLE
MAINT: add sanity-checks to be run at import time

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -194,3 +194,28 @@ else:
     from numpy.testing._private.pytesttester import PytestTester
     test = PytestTester(__name__)
     del PytestTester
+
+
+    def _sanity_check():
+        """
+        Quick sanity checks for common bugs caused by environment.
+        There are some cases e.g. with wrong BLAS ABI that cause wrong
+        results under specific runtime conditions that are not necessarily
+        achieved during test suite runs, and it is useful to catch those early.
+
+        See https://github.com/numpy/numpy/issues/8577 and other
+        similar bug reports.
+
+        """
+        try:
+            x = ones(2, dtype=float32)
+            if not abs(x.dot(x) - 2.0) < 1e-5:
+                raise AssertionError()
+        except AssertionError:
+            msg = ("The current Numpy installation ({!r}) fails to "
+                   "pass simple sanity checks. This can be caused for example "
+                   "by incorrect BLAS library being linked in.")
+            raise RuntimeError(msg.format(__file__))
+
+    _sanity_check()
+    del _sanity_check


### PR DESCRIPTION
This checks for potential BLAS issues, which are useful to catch early.

As suggested by @charris at #11168. This may be a bit overkill, so not sure if we want this, but on the other hand this additional import-time check probably does not cost much. The additional advantage is that import-time failures will force the downstream to seriously consider addressing the issue :)