### PR TITLE
MAINT: avoid setting non-existing gufunc strides for keepdims=True.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2538,7 +2538,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     core_dim_ixs_size = 0;
     for (i = 0; i < nop; ++i) {
-        core_dim_ixs_size += core_num_dims[i];
+        core_dim_ixs_size += ufunc->core_num_dims[i];
     }
     inner_strides = (npy_intp *)PyArray_malloc(
                         NPY_SIZEOF_INTP * (nop+core_dim_ixs_size));
@@ -2550,7 +2550,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     /* Copy the strides after the first nop */
     idim = nop;
     for (i = 0; i < nop; ++i) {
-        int num_dims = core_num_dims[i];
+        int num_dims = ufunc->core_num_dims[i];
         int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
         /*
          * Need to use the arrays in the iterator, not op, because


### PR DESCRIPTION
Corrects an overzealous change in #11098 from the fixed core dimensions to the ones expanded for `keepdims=True`. Since arrays were allocated, this wrong change caused no problems, but it was not needed and confused the heck out of myself...

@charris: since this is a correction to stuff slated for 1.15, I set the milestone as such.

cc @mattip 