### PR TITLE
ENH: Further expansion of gufunc signature to allow broadcasting

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -451,5 +451,29 @@ differently from variable ones indicated with a name starting with a letter;
 the loop still is passed the corresponding size, but it can now count on that
 size being equal to the fixed one given in the signature.
 
+Generalized ufunc signatures now allow flexible dimensions
+----------------------------------------------------------
+
+Some functions, in particular numpy's implementation of ``@`` as ``matmul``,
+are very similar to generalized ufuncs in that they operate over core
+dimensions, but one could not present them as such because they were able to
+deal with inputs in which a dimension is missing. To support this, it is now
+allowed to postfix a dimension name with a question mark to indicate that the
+dimension does not necessarily have to be present.
+
+With this addition, the signature for ``matmul`` can be expressed as
+``(m?,n),(n,p?)->(m?,p?)``.  This indicates that if, e.g., the second operand
+has only one dimension, for the purposes of the elementary function it will be
+treated as if that input has core shape ``(n, 1)``, and the output has the
+corresponding core shape of ``(m, 1)``. The actual output array, however, has
+the flexible dimension removed, i.e., it will have shape ``(..., n)``.
+Similarly, if both arguments have only a single dimension, the inputs will be
+presented as having shapes ``(1, n)`` and ``(n, 1)`` to the elementary
+function, and the output as ``(1, 1)``, while the actual output array returned
+will have shape ``()``. In this way, the signature allows one to use a
+single elementary function for four related but different signatures,
+``(m,n),(n,p)->(m,p)``, ``(n),(n,p)->(p)``, ``(m,n),(n)->(m)`` and
+``(n),(n)->()``.
+
 Changes
 =======

--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -436,6 +436,20 @@ within an array.
 .. note:: Implementations of ``__array_ufunc__`` should ensure that they can
           handle either ``axis`` or ``axes``.  In future, we may convert
           ``axis`` to ``axes`` before passing it on.
+Generalized ufunc signatures now allow fixed-size dimensions
+------------------------------------------------------------
+By using a numerical value in the signature of a generalized ufunc, one can
+indicate that the given function requires input or output to have dimensions
+with the given size. E.g., the signature of a function that converts a polar
+angle to a two-dimensional cartesian unit vector would be ``()->(2)``; that
+for one that converts two spherical angles to a three-dimensional unit vector
+would be ``(),()->(3)``; and that for the cross product of two
+three-dimensional vectors would be ``(3),(3)->(3)``.
+
+Note that to the elementary function these dimensions are not treated any
+differently from variable ones indicated with a name starting with a letter;
+the loop still is passed the corresponding size, but it can now count on that
+size being equal to the fixed one given in the signature.
 
 Changes
 =======

--- a/doc/source/reference/c-api.generalized-ufuncs.rst
+++ b/doc/source/reference/c-api.generalized-ufuncs.rst
@@ -127,34 +127,49 @@ The formal syntax of signatures is as follows::
     <Output arguments>     ::= <Argument list>
     <Argument list>        ::= nil | <Argument> | <Argument> "," <Argument list>
     <Argument>             ::= "(" <Core dimension list> ")"
-    <Core dimension list>  ::= nil | <Core dimension name> |
-                               <Core dimension name> "," <Core dimension list>
-    <Core dimension name>  ::= valid Python variable name
-
+    <Core dimension list>  ::= nil | <Core dimension> |
+                               <Core dimension> "," <Core dimension list>
+    <Core dimension>       ::= <Dimension name> <Dimension modifier>
+    <Dimension name>       ::= valid Python variable name | valid integer
+    <Dimension modifier>   ::= nil | "?"
 
 Notes:
 
 #. All quotes are for clarity.
-#. Core dimensions that share the same name must have the exact same size.
+#. Unmodified core dimensions that share the same name must have the same size.
    Each dimension name typically corresponds to one level of looping in the
    elementary function's implementation.
 #. White spaces are ignored.
+#. An integer as a dimension name freezes that dimension to the value.
+#. If the name is suffixed with the "?" modifier, the dimension is a core
+   dimension only if it exists on all inputs and outputs that share it;
+   otherwise it is ignored (and replaced by a dimension of size 1 for the
+   elementary function).
 
 Here are some examples of signatures:
 
-+-------------+------------------------+-----------------------------------+
-| add         | ``(),()->()``          |                                   |
-+-------------+------------------------+-----------------------------------+
-| inner1d     | ``(i),(i)->()``        |                                   |
-+-------------+------------------------+-----------------------------------+
-| sum1d       | ``(i)->()``            |                                   |
-+-------------+------------------------+-----------------------------------+
-| dot2d       | ``(m,n),(n,p)->(m,p)`` | matrix multiplication             |
-+-------------+------------------------+-----------------------------------+
-| outer_inner | ``(i,t),(j,t)->(i,j)`` | inner over the last dimension,    |
-|             |                        | outer over the second to last,    |
-|             |                        | and loop/broadcast over the rest. |
-+-------------+------------------------+-----------------------------------+
++-------------+----------------------------+-----------------------------------+
+| add         | ``(),()->()``              |                                   |
++-------------+----------------------------+-----------------------------------+
+| sum1d       | ``(i)->()``                |                                   |
++-------------+----------------------------+-----------------------------------+
+| inner1d     | ``(i),(i)->()``            |                                   |
++-------------+----------------------------+-----------------------------------+
+| matmat      | ``(m,n),(n,p)->(m,p)``     | matrix multiplication             |
++-------------+----------------------------+-----------------------------------+
+| vecmat      | ``(n),(n,p)->(p)``         | vector-matrix multiplication      |
++-------------+----------------------------+-----------------------------------+
+| matvec      | ``(m,n),(n)->(m)``         | matrix-vector multiplication      |
++-------------+----------------------------+-----------------------------------+
+| matmul      | ``(m?,n),(n,p?)->(m?,p?)`` | combination of the four above     |
++-------------+----------------------------+-----------------------------------+
+| cross1d     | ``(3),(3)->(3)``           | cross product where the last      |
+|             |                            | dimension must be 3               |
++-------------+----------------------------+-----------------------------------+
+| outer_inner | ``(i,t),(j,t)->(i,j)``     | inner over the last dimension,    |
+|             |                            | outer over the second to last,    |
+|             |                            | and loop/broadcast over the rest. |
++-------------+----------------------------+-----------------------------------+
 
 C-API for implementing Elementary Functions
 -------------------------------------------

--- a/doc/source/reference/c-api.generalized-ufuncs.rst
+++ b/doc/source/reference/c-api.generalized-ufuncs.rst
@@ -20,27 +20,35 @@ arguments is called the "signature" of a ufunc.  For example, the
 ufunc numpy.add has signature ``(),()->()`` defining two scalar inputs
 and one scalar output.
 
-Another example is the function ``inner1d(a, b)`` with a signature of
-``(i),(i)->()``.  This applies the inner product along the last axis of
-each input, but keeps the remaining indices intact.
-For example, where ``a`` is of shape ``(3, 5, N)`` and ``b`` is of shape
-``(5, N)``, this will return an output of shape ``(3,5)``.
-The underlying elementary function is called ``3 * 5`` times.  In the
-signature, we specify one core dimension ``(i)`` for each input and zero core
-dimensions ``()`` for the output, since it takes two 1-d arrays and
-returns a scalar.  By using the same name ``i``, we specify that the two
-corresponding dimensions should be of the same size.
+As examples of operation requiring more detail, consider the inner (dot) and
+outer (cross) products of vectors.  The inner product is easily defined for any
+vector dimension, and the corresponding function ``inner1d(a, b)`` [#]_ has a
+signature of ``(i),(i)->()``.  This applies the inner product along the last
+axis of each input, but keeps the remaining indices intact.  For example, where
+``a`` is of shape ``(3, 5, N)`` and ``b`` is of shape ``(5, N)``, this will
+return an output of shape ``(3, 5)``.  The underlying elementary function is
+called ``3 * 5`` times.  In the signature, we specify one core dimension
+``(i)`` for each input and zero core dimensions ``()`` for the output, since
+the elementary function takes two 1-d arrays and returns a scalar.  By using
+the same name ``i``, we specify that the two corresponding dimensions should be
+of the same size.
+
+Turning now to the cross product, that function is less easily defined for
+arbitrary dimensions.  But for vectors with three components, it returns a
+vector with three components, so a function ``cross1d(a, b)`` specialized for
+those would have signature ``(3),(3)->(3)``, indicating that both inputs and
+outputs have the same core dimension of fixed size ``3``.
 
 The dimensions beyond the core dimensions are called "loop" dimensions.  In
-the above example, this corresponds to ``(3, 5)``.
+the example for the inner product, this corresponds to ``(3, 5)``.
 
 The signature determines how the dimensions of each input/output array are
 split into core and loop dimensions:
 
 #. Each dimension in the signature is matched to a dimension of the
    corresponding passed-in array, starting from the end of the shape tuple.
-   These are the core dimensions, and they must be present in the arrays, or
-   an error will be raised.
+   These are the core dimensions, and, unless specifically indicated (see
+   below), they must be present in the arrays, or an error will be raised.
 #. Core dimensions assigned to the same label in the signature (e.g. the
    ``i`` in ``inner1d``'s ``(i),(i)->()``) must have exactly matching sizes,
    no broadcasting is performed.
@@ -62,11 +70,14 @@ output array of the right size. If the size of a core dimension of an output
 cannot be determined from a passed in input or output array, an error will be
 raised.
 
-Note: Prior to NumPy 1.10.0, less strict checks were in place: missing core
-dimensions were created by prepending 1's to the shape as necessary, core
-dimensions with the same label were broadcast together, and undetermined
-dimensions were created with size 1.
+.. note: Prior to NumPy 1.10.0, less strict checks were in place:
+    missing core dimensions were created by prepending 1's to the
+    shape as necessary, core dimensions with the same label were
+    broadcast together, and undetermined dimensions were created with
+    size 1.  Such behaviour now has to be specifically enabled.
 
+.. [#] The source code for the functions mentioned in this text can be found
+       under ``numpy/core/src/umath/_umath.tests.c.src``.
 
 Definitions
 -----------
@@ -77,7 +88,7 @@ Elementary Function
     (e.g. adding two numbers is the most basic operation in adding two
     arrays).  The ufunc applies the elementary function multiple times
     on different parts of the arrays.  The input/output of elementary
-    functions can be vectors; e.g., the elementary function of inner1d
+    functions can be arrays; e.g., the elementary function of ``inner1d``
     takes two vectors as input.
 
 Signature
@@ -92,14 +103,14 @@ Core Dimension
     last dimensions of the input/output arrays.
 
 Dimension Name
-    A dimension name represents a core dimension in the signature.
+    A dimension name or size representing a core dimension in the signature.
     Different dimensions may share a name, indicating that they are of
     the same size.
 
 Dimension Index
-    A dimension index is an integer representing a dimension name. It
-    enumerates the dimension names according to the order of the first
-    occurrence of each name in the signature.
+    A dimension index is an integer representing a dimension name or size.
+    It enumerates the distinct dimensions according to the order of the first
+    occurrence of each name or size in the signature.
 
 .. _details-of-signature:
 
@@ -114,7 +125,9 @@ following format:
 * Core dimensions of each input or output array are represented by a
   list of dimension names in parentheses, ``(i_1,...,i_N)``; a scalar
   input/output is denoted by ``()``.  Instead of ``i_1``, ``i_2``,
-  etc, one can use any valid Python variable name.
+  etc, one can use any valid Python variable name or a numerical size.
+  Names or sizes can have ``?`` or ``|1`` appended to indicate they migth
+  not be present or can be broadcast (see below).
 * Dimension lists for different arguments are separated by ``","``.
   Input/output arguments are separated by ``"->"``.
 * If one uses the same dimension name in multiple locations, this
@@ -131,7 +144,7 @@ The formal syntax of signatures is as follows::
                                <Core dimension> "," <Core dimension list>
     <Core dimension>       ::= <Dimension name> <Dimension modifier>
     <Dimension name>       ::= valid Python variable name | valid integer
-    <Dimension modifier>   ::= nil | "?"
+    <Dimension modifier>   ::= nil | "|1" | "?"
 
 Notes:
 
@@ -141,6 +154,9 @@ Notes:
    elementary function's implementation.
 #. White spaces are ignored.
 #. An integer as a dimension name freezes that dimension to the value.
+#. If a name if suffixed with the "|1" modifier, it is allowed to broadcast
+   against other dimensions with the same name.  All input dimensions
+   must share this modifier, while no output dimensions should have it.
 #. If the name is suffixed with the "?" modifier, the dimension is a core
    dimension only if it exists on all inputs and outputs that share it;
    otherwise it is ignored (and replaced by a dimension of size 1 for the
@@ -148,62 +164,63 @@ Notes:
 
 Here are some examples of signatures:
 
-+-------------+----------------------------+-----------------------------------+
-| add         | ``(),()->()``              |                                   |
-+-------------+----------------------------+-----------------------------------+
-| sum1d       | ``(i)->()``                |                                   |
-+-------------+----------------------------+-----------------------------------+
-| inner1d     | ``(i),(i)->()``            |                                   |
-+-------------+----------------------------+-----------------------------------+
-| matmat      | ``(m,n),(n,p)->(m,p)``     | matrix multiplication             |
-+-------------+----------------------------+-----------------------------------+
-| vecmat      | ``(n),(n,p)->(p)``         | vector-matrix multiplication      |
-+-------------+----------------------------+-----------------------------------+
-| matvec      | ``(m,n),(n)->(m)``         | matrix-vector multiplication      |
-+-------------+----------------------------+-----------------------------------+
-| matmul      | ``(m?,n),(n,p?)->(m?,p?)`` | combination of the four above     |
-+-------------+----------------------------+-----------------------------------+
-| cross1d     | ``(3),(3)->(3)``           | cross product where the last      |
-|             |                            | dimension must be 3               |
-+-------------+----------------------------+-----------------------------------+
-| outer_inner | ``(i,t),(j,t)->(i,j)``     | inner over the last dimension,    |
-|             |                            | outer over the second to last,    |
-|             |                            | and loop/broadcast over the rest. |
-+-------------+----------------------------+-----------------------------------+
++----------------------------+-----------------------------------+
+| Signature                  | Possible use                      |
++----------------------------+-----------------------------------+
+| ``(),()->()``              | Addition                          |
++----------------------------+-----------------------------------+
+| ``(i)->()``                | Sum over last axis                |
++----------------------------+-----------------------------------+
+| ``(i|1),(i|1)->()``        | Test for equality along axis,     |
+|                            | allowing comparison with a scalar |
++----------------------------+-----------------------------------+
+| ``(i),(i)->()``            | inner vector product              |
++----------------------------+-----------------------------------+
+| ``(m,n),(n,p)->(m,p)``     | matrix multiplication             |
++----------------------------+-----------------------------------+
+| ``(n),(n,p)->(p)``         | vector-matrix multiplication      |
++----------------------------+-----------------------------------+
+| ``(m,n),(n)->(m)``         | matrix-vector multiplication      |
++----------------------------+-----------------------------------+
+| ``(m?,n),(n,p?)->(m?,p?)`` | all four of the above at once,    |
+|                            | except vectors cannot have loop   |
+|                            | dimensions (ie, like ``matmul``)  |
++----------------------------+-----------------------------------+
+| ``(3),(3)->(3)``           | cross product for 3-vectors       |
++----------------------------+-----------------------------------+
+| ``(i,t),(j,t)->(i,j)``     | inner over the last dimension,    |
+|                            | outer over the second to last,    |
+|                            | and loop/broadcast over the rest. |
++----------------------------+-----------------------------------+
 
 C-API for implementing Elementary Functions
 -------------------------------------------
 
-The current interface remains unchanged, and ``PyUFunc_FromFuncAndData``
-can still be used to implement (specialized) ufuncs, consisting of
-scalar elementary functions.
+For scalar elementary functions, one can use ``PyUFunc_FromFuncAndData``.
+For a generalized ufunc with a signature, one should use
+``PyUFunc_FromFuncAndDataAndSignature``.  The argument lists of the two
+are the apart from a final argument specifying the signature as C string.
 
-One can use ``PyUFunc_FromFuncAndDataAndSignature`` to declare a more
-general ufunc.  The argument list is the same as
-``PyUFunc_FromFuncAndData``, with an additional argument specifying the
-signature as C string.
+The functions implementing the elementary operations take the same arguments::
 
-Furthermore, the callback function is of the same type as before,
-``void (*foo)(char **args, intp *dimensions, intp *steps, void *func)``.
+    ``void (*foo)(char **args, intp *dimensions, intp *steps, void *func)``.
+
 When invoked, ``args`` is a list of length ``nargs`` containing
 the data of all input/output arguments.  For a scalar elementary
 function, ``steps`` is also of length ``nargs``, denoting the strides used
 for the arguments. ``dimensions`` is a pointer to a single integer
 defining the size of the axis to be looped over.
 
-For a non-trivial signature, ``dimensions`` will also contain the sizes
-of the core dimensions as well, starting at the second entry.  Only
-one size is provided for each unique dimension name and the sizes are
-given according to the first occurrence of a dimension name in the
-signature.
-
-The first ``nargs`` elements of ``steps`` remain the same as for scalar
-ufuncs.  The following elements contain the strides of all core
-dimensions for all arguments in order.
+For a non-trivial signature, ``dimensions`` and ``steps`` provide information
+on the core dimensions. The sizes of the core dimensions are stored in
+``dimensions``, starting at the second entry.  Only one size is provided for
+each distinct dimension name and the sizes are given following the order of
+occurrence in the signature. The strides of all core dimensions are given in
+``steps``, starting at entry ``nargs``, for all arguments in order.
 
 For example, consider a ufunc with signature ``(i,j),(i)->()``.  In
 this case, ``args`` will contain three pointers to the data of the
 input/output arrays ``a``, ``b``, ``c``.  Furthermore, ``dimensions`` will be
-``[N, I, J]`` to define the size of ``N`` of the loop and the sizes ``I`` and ``J``
-for the core dimensions ``i`` and ``j``.  Finally, ``steps`` will be
+``[N, I, J]`` to define the size of ``N`` of the loop and the sizes ``I`` and
+``J`` for the core dimensions ``i`` and ``j``.  Finally, ``steps`` will be
 ``[a_N, b_N, c_N, a_i, a_j, b_i]``, containing all necessary strides.

--- a/doc/source/reference/c-api.types-and-structures.rst
+++ b/doc/source/reference/c-api.types-and-structures.rst
@@ -133,9 +133,9 @@ PyArray_Type
     is related to this array. There are two use cases: 1) If this array
     does not own its own memory, then base points to the Python object
     that owns it (perhaps another array object), 2) If this array has
-    the (deprecated) :c:data:`NPY_ARRAY_UPDATEIFCOPY` or 
+    the (deprecated) :c:data:`NPY_ARRAY_UPDATEIFCOPY` or
     :c:data:NPY_ARRAY_WRITEBACKIFCOPY`: flag set, then this array is
-    a working copy of a "misbehaved" array. When 
+    a working copy of a "misbehaved" array. When
     ``PyArray_ResolveWritebackIfCopy`` is called, the array pointed to by base
     will be updated with the contents of this array.
 
@@ -683,7 +683,9 @@ PyUFunc_Type
 
    The core of the ufunc is the :c:type:`PyUFuncObject` which contains all
    the information needed to call the underlying C-code loops that
-   perform the actual work. It has the following structure:
+   perform the actual work. While it is described here for completeness, it
+   should be considered internal to NumPy and manipulated via ``PyUFunc_*``
+   functions. It has the following structure:
 
    .. code-block:: c
 
@@ -696,15 +698,29 @@ PyUFunc_Type
           PyUFuncGenericFunction *functions;
           void **data;
           int ntypes;
-          int reserved1;
+          int version;
           const char *name;
           char *types;
           const char *doc;
           void *ptr;
           PyObject *obj;
           PyObject *userloops;
+          int core_enabled;
+          int core_num_dim_ix;
+          int *core_num_dims;
+          int *core_dim_ixs;
+          int *core_offsets;
+          char *core_signature;
+          PyUFunc_TypeResolutionFunc *type_resolver;
+          PyUFunc_LegacyInnerLoopSelectionFunc *legacy_inner_loop_selector;
+          void *reserved2;
+          PyUFunc_MaskedInnerLoopSelectionFunc *masked_inner_loop_selector;
           npy_uint32 *op_flags;
           npy_uint32 *iter_flags;
+          /* new in version 1 */
+          npy_intp *core_dim_sizes;
+          npy_uint32 *core_dim_flags;
+
       } PyUFuncObject;
 
    .. c:macro: PyUFuncObject.PyObject_HEAD
@@ -764,6 +780,10 @@ PyUFunc_Type
        specifies how many different 1-d loops (of the builtin data
        types) are available.
 
+   .. c:member:: int PyUFuncObject.version
+
+       The version of this struct, currently set to 1
+
    .. c:member:: char *PyUFuncObject.name
 
        A string name for the ufunc. This is used dynamically to build
@@ -804,6 +824,51 @@ PyUFunc_Type
        User defined type numbers are always larger than
        :c:data:`NPY_USERDEF`.
 
+   .. c:member:: int PyUFuncObject.core_enabled
+
+       0 for scalar ufuncs; 1 for generalized ufuncs
+
+   .. c:member:: int PyUFuncObject.core_num_dim_ix
+
+       Number of distinct core dimension names in the signature
+
+   .. c:member:: int *PyUFuncObject.core_num_dims
+
+       Number of core dimensions of each argument
+
+   .. c:member:: int *PyUFuncObject.core_dim_ixs
+
+       Dimension indices in a flattened form; indices of argument ``k`` are
+       stored in ``core_dim_ixs[core_offsets[k] : core_offsets[k] +
+       core_numdims[k]]``
+
+   .. c:member:: int *PyUFuncObject.core_offsets
+
+       Position of 1st core dimension of each argument in ``core_dim_ixs``,
+       equivalent to cumsum(``core_num_dims``)
+
+   .. c:member:: char *PyUFuncObject.core_signature
+
+       Core signature string
+
+   .. c:member:: PyUFunc_TypeResolutionFunc *PyUFuncObject.type_resolver
+
+       A function which resolves the types and fills an array with the dtypes
+       for the inputs and outputs
+
+   .. c:member:: PyUFunc_LegacyInnerLoopSelectionFunc *PyUFuncObject.legacy_inner_loop_selector
+
+       A function which returns an inner loop. The ``legacy`` in the name arises
+       because for NumPy 1.6 a better variant had been planned. This variant
+       has not yet come about.
+
+   .. c:member:: void *PyUFuncObject.reserved2
+
+       For a possible future loop selector with a different signature.
+
+   .. c:member:: PyUFunc_MaskedInnerLoopSelectionFunc *PyUFuncObject.masked_inner_loop_selector
+
+       Function which returns a masked inner loop for the ufunc
 
    .. c:member:: npy_uint32 PyUFuncObject.op_flags
 
@@ -812,6 +877,21 @@ PyUFunc_Type
    .. c:member:: npy_uint32 PyUFuncObject.iter_flags
 
        Override the default nditer flags for the ufunc.
+
+   Added in version 1
+
+   .. c:member:: npy_intp *PyUFuncObject.core_dim_sizes
+
+       For each distinct core dimension, the possible
+       "frozen" size (``-1`` if not frozen)
+
+   .. c:member:: npy_uint32 *PyUFuncObject.core_dim_flags
+
+       For each distinct core dimension, a set of flags ``OR`` ed together:
+
+       - :c:data:`UFUNC_CORE_CAN_IGNORE` if the dim name ends in ``?``
+       - :c:data:`UFUNC_CORE_DIM_SIZE_UNSET` if the dim size will be
+         determined by the operands (not frozen)
 
 PyArrayIter_Type
 ----------------

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -209,6 +209,11 @@ typedef struct _tagPyUFuncObject {
          * set by nditer object.
          */
         npy_uint32 iter_flags;
+
+        /*
+         * sizes of frozen core dimensions, or -1 if unset
+         */
+         npy_intp *core_dim_szs;
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -130,8 +130,8 @@ typedef struct _tagPyUFuncObject {
         /* The number of elements in 'functions' and 'data' */
         int ntypes;
 
-        /* Used to be unused field 'check_return' */
-        int reserved1;
+        /* Used to be unused field 'check_return', repurposed in 1.16 */
+        int version;
 
         /* The name of the ufunc */
         const char *name;
@@ -209,6 +209,8 @@ typedef struct _tagPyUFuncObject {
          * set by nditer object.
          */
         npy_uint32 iter_flags;
+
+        /* New in version 1 and above */
 
         /*
          * sizes of frozen core dimensions, or -1 if unset

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -213,9 +213,15 @@ typedef struct _tagPyUFuncObject {
         /* New in version 1 and above */
 
         /*
-         * sizes of frozen core dimensions, or -1 if unset
+         * sizes of `frozen` core dimensions, -1 if unset (not frozen)
          */
-         npy_intp *core_dim_szs;
+        npy_intp *core_dim_szs;
+
+        /*
+         * for each core_num_dim_ix, 1 for flexible (signature has ?) 0 otherwise
+         */
+        int *core_dim_flexible;
+
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -233,6 +233,8 @@ typedef struct _tagPyUFuncObject {
 #define UFUNC_CORE_DIM_SIZE_UNSET 0x0002
 /* the core dimension may be absent */
 #define UFUNC_CORE_DIM_CAN_IGNORE 0x0004
+/* the core dimension can be broadcast */
+#define UFUNC_CORE_DIM_CAN_BROADCAST 0x0008
 /* flags inferred during execution */
 #define UFUNC_CORE_DIM_MISSING 0x00040000
 

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -213,18 +213,28 @@ typedef struct _tagPyUFuncObject {
         /* New in version 1 and above */
 
         /*
-         * sizes of `frozen` core dimensions, -1 if unset (not frozen)
+         * for each core_num_dim_ix distinct dimension names,
+         * the possible "frozen" size (-1 if not frozen).
          */
-        npy_intp *core_dim_szs;
+        npy_intp *core_dim_sizes;
 
         /*
-         * for each core_num_dim_ix, 1 for flexible (signature has ?) 0 otherwise
+         * for each distinct core dimension, a set of flags OR'd together
+         * e.g., UFUNC_CORE_DIM_CAN_IGNORE if signature has ?
+         *       UFUNC_CORE_DIM_SIZE_UNSET for non-frozen dimensions.
          */
-        int *core_dim_flexible;
+        npy_uint32 *core_dim_flags;
 
 } PyUFuncObject;
 
 #include "arrayobject.h"
+/* Generalized ufunc; 0x0001 reserved for possible use as CORE_ENABLED */
+/* the core dimension's size will be determined by the operands. */
+#define UFUNC_CORE_DIM_SIZE_UNSET 0x0002
+/* the core dimension may be absent */
+#define UFUNC_CORE_DIM_CAN_IGNORE 0x0004
+/* flags inferred during execution */
+#define UFUNC_CORE_DIM_MISSING 0x00040000
 
 #define UFUNC_ERR_IGNORE 0
 #define UFUNC_ERR_WARN   1

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -153,30 +153,10 @@ static void
     npy_intp m,n,p;
     npy_intp is1_m=steps[0], is1_n=steps[1], is2_n=steps[2], is2_p=steps[3],
          os_m=steps[4], os_p=steps[5];
-    npy_intp ib1_n;
-    npy_intp ib2_n;
-    npy_intp ib2_p;
-    npy_intp ob_p;
-    /*
-     * no m dimension -> row vector . matrix
-     */
-    if (dm == 0) {
-        dm = 1;
-    }
-    /*
-     * no p dimension -> matrix . column vector
-     * note that for a 1-d array, it looks like a matrix with first step
-     * equal zero, hence the switch in steps
-     */
-    if (dp == 0) {
-        os_m = os_p;
-        is2_n = is2_p;
-        dp = 1;
-    }
-    ib1_n = is1_n*dn;
-    ib2_n = is2_n*dn;
-    ib2_p = is2_p*dp;
-    ob_p  = os_p *dp;
+    npy_intp ib1_n = is1_n*dn;
+    npy_intp ib2_n = is2_n*dn;
+    npy_intp ib2_p = is2_p*dp;
+    npy_intp ob_p  = os_p *dp;
     if (dn == 0) {
         /* No operand, need to zero the output */
         BEGIN_OUTER_LOOP_3

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -91,6 +91,40 @@ static void
 
 /**end repeat**/
 
+char *all_equal_signature = "(i|1),(i|1)->()";
+
+/**begin repeat
+
+   #TYPE=LONG,DOUBLE#
+   #typ=npy_long,npy_double#
+*/
+
+/*
+ *  This implements the function
+ *        out[n] = all_i { in1[n, i] == in2[n, i] }.
+ */
+
+static void
+@TYPE@_all_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    INIT_OUTER_LOOP_3
+    npy_intp di = dimensions[0];
+    npy_intp i;
+    npy_intp is1=steps[0], is2=steps[1];
+    BEGIN_OUTER_LOOP_3
+        char *ip1=args[0], *ip2=args[1], *op=args[2];
+        npy_bool equal = 1;
+        for (i = 0; i < di; i++) {
+            equal &= (*(@typ@ *)ip1) == (*(@typ@ *)ip2);
+            ip1 += is1;
+            ip2 += is2;
+        }
+        *(npy_bool *)op = equal;
+    END_OUTER_LOOP
+}
+
+/**end repeat**/
+
 char *innerwt_signature = "(i),(i),(i)->()";
 
 /**begin repeat
@@ -346,6 +380,9 @@ defdict = {
 static PyUFuncGenericFunction inner1d_functions[] = { LONG_inner1d, DOUBLE_inner1d };
 static void * inner1d_data[] = { (void *)NULL, (void *)NULL };
 static char inner1d_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static PyUFuncGenericFunction all_equal_functions[] = { LONG_all_equal, DOUBLE_all_equal };
+static void * all_equal_data[] = { (void *)NULL, (void *)NULL };
+static char all_equal_signatures[] = { NPY_LONG, NPY_LONG, NPY_BOOL, NPY_DOUBLE, NPY_DOUBLE, NPY_BOOL };
 static PyUFuncGenericFunction innerwt_functions[] = { LONG_innerwt, DOUBLE_innerwt };
 static void * innerwt_data[] = { (void *)NULL, (void *)NULL };
 static char innerwt_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
@@ -383,6 +420,16 @@ addUfuncs(PyObject *dictionary) {
         return -1;
     }
     PyDict_SetItemString(dictionary, "inner1d", f);
+    Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(all_equal_functions, all_equal_data,
+                    all_equal_signatures, 2, 2, 1, PyUFunc_None, "all_equal",
+                    "test equality of all elements on the last dimension\n"
+                    "     \"(i|1),(i|1)->()\" \n",
+                    0, all_equal_signature);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "all_equal", f);
     Py_DECREF(f);
     f = PyUFunc_FromFuncAndDataAndSignature(innerwt_functions, innerwt_data,
                     innerwt_signatures, 2, 3, 1, PyUFunc_None, "innerwt",

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -92,6 +92,7 @@ static void
 /**end repeat**/
 
 char *all_equal_signature = "(i|1),(i|1)->()";
+char *cube_equal_signature = "(o|1,n|1,m|1),(o|1,n|1,m|1)->()";
 
 /**begin repeat
 
@@ -118,6 +119,36 @@ static void
             equal &= (*(@typ@ *)ip1) == (*(@typ@ *)ip2);
             ip1 += is1;
             ip2 += is2;
+        }
+        *(npy_bool *)op = equal;
+    END_OUTER_LOOP
+}
+
+static void
+@TYPE@_cube_equal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    INIT_OUTER_LOOP_3
+    npy_intp no=dimensions[0], nn=dimensions[1], nm=dimensions[2];
+    npy_intp io, in, im;
+    npy_intp is1_o=steps[0], is1_n=steps[1], is1_m=steps[2];
+    npy_intp is2_o=steps[3], is2_n=steps[4], is2_m=steps[5];
+    BEGIN_OUTER_LOOP_3
+        char *io1=args[0], *io2=args[1], *op=args[2];
+        npy_bool equal = 1;
+        for (io = 0; io < no; io++) {
+            char *in1=io1, *in2=io2;
+            for (in = 0; in < nn; in++) {
+                char *im1=in1, *im2=in2;
+                for (im =0; im < nm; im++) {
+                           equal &= (*(@typ@ *)im1) == (*(@typ@ *)im2);
+                    im1 += is1_m;
+                    im2 += is2_m;
+                }
+                in1 += is1_n;
+                in2 += is2_n;
+            }
+            io1 += is1_o;
+            io2 += is2_o;
         }
         *(npy_bool *)op = equal;
     END_OUTER_LOOP
@@ -383,6 +414,9 @@ static char inner1d_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, N
 static PyUFuncGenericFunction all_equal_functions[] = { LONG_all_equal, DOUBLE_all_equal };
 static void * all_equal_data[] = { (void *)NULL, (void *)NULL };
 static char all_equal_signatures[] = { NPY_LONG, NPY_LONG, NPY_BOOL, NPY_DOUBLE, NPY_DOUBLE, NPY_BOOL };
+static PyUFuncGenericFunction cube_equal_functions[] = { LONG_cube_equal, DOUBLE_cube_equal };
+static void * cube_equal_data[] = { (void *)NULL, (void *)NULL };
+static char cube_equal_signatures[] = { NPY_LONG, NPY_LONG, NPY_BOOL, NPY_DOUBLE, NPY_DOUBLE, NPY_BOOL };
 static PyUFuncGenericFunction innerwt_functions[] = { LONG_innerwt, DOUBLE_innerwt };
 static void * innerwt_data[] = { (void *)NULL, (void *)NULL };
 static char innerwt_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
@@ -430,6 +464,16 @@ addUfuncs(PyObject *dictionary) {
         return -1;
     }
     PyDict_SetItemString(dictionary, "all_equal", f);
+    Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(cube_equal_functions, cube_equal_data,
+                    cube_equal_signatures, 2, 2, 1, PyUFunc_None, "cube_equal",
+                    "test equality of all elements on the last 3 dimension\n"
+                    "     \"(o|1,n|1,m|1),(o|1,n|1,m|1)->()\" \n",
+                    0, cube_equal_signature);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "cube_equal", f);
     Py_DECREF(f);
     f = PyUFunc_FromFuncAndDataAndSignature(innerwt_functions, innerwt_data,
                     innerwt_signatures, 2, 3, 1, PyUFunc_None, "innerwt",

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -452,9 +452,10 @@ static PyObject *
 UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     int nin, nout, i;
-    PyObject *signature, *sig_str;
-    PyUFuncObject *f = NULL;
-    PyObject *core_num_dims = NULL, *core_dim_ixs = NULL;
+    PyObject *signature=NULL, *sig_str=NULL;
+    PyUFuncObject *f=NULL;
+    PyObject *core_num_dims=NULL, *core_dim_ixs=NULL, *core_dim_szs=NULL;
+    PyObject *core_dim_flexible=NULL;
     int core_enabled;
     int core_num_ixs = 0;
 
@@ -517,13 +518,44 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
         Py_INCREF(Py_None);
         core_dim_ixs = Py_None;
     }
+    if (f->core_dim_szs != NULL) {
+        core_dim_szs = PyTuple_New(f->core_num_dim_ix);
+        if (core_num_dims == NULL) {
+            goto fail;
+        }
+        for (i = 0; i < f->core_num_dim_ix; i++) {
+            PyObject * val = PyLong_FromLong(f->core_dim_szs[i]);
+            PyTuple_SET_ITEM(core_dim_szs, i, val);
+        }
+    }
+    else {
+        Py_INCREF(Py_None);
+        core_dim_szs = Py_None;
+    }
+    if (f->core_num_dim_ix != NULL) {
+        core_dim_flexible = PyTuple_New(f->core_num_dim_ix);
+        if (core_dim_flexible == NULL) {
+            goto fail;
+        }
+        for (i = 0; i < f->core_num_dim_ix; i++) {
+            PyObject * val = PyLong_FromLong(f->core_dim_flexible[i]);
+            PyTuple_SET_ITEM(core_dim_flexible, i, val);
+        }
+    }
+    else {
+        Py_INCREF(Py_None);
+        core_dim_flexible = Py_None;
+    }
     Py_DECREF(f);
-    return Py_BuildValue("iOO", core_enabled, core_num_dims, core_dim_ixs);
+    return Py_BuildValue("iOOOO", core_enabled, core_num_dims,
+                         core_dim_ixs, core_dim_szs, core_dim_flexible);
 
 fail:
     Py_XDECREF(f);
     Py_XDECREF(core_num_dims);
     Py_XDECREF(core_dim_ixs);
+    Py_XDECREF(core_dim_szs);
+    Py_XDECREF(core_dim_flexible);
     return NULL;
 }
 

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -195,6 +195,41 @@ static void
 
 /**end repeat**/
 
+char *cross1d_signature = "(3),(3)->(3)";
+
+/**begin repeat
+
+   #TYPE=LONG,DOUBLE#
+   #typ=npy_long, npy_double#
+*/
+
+/*
+ *  This implements the cross product:
+ *        out[n, 0] = in1[n, 1]*in2[n, 2] - in1[n, 2]*in2[n, 1]
+ *        out[n, 1] = in1[n, 2]*in2[n, 0] - in1[n, 0]*in2[n, 2]
+ *        out[n, 2] = in1[n, 0]*in2[n, 1] - in1[n, 1]*in2[n, 0]
+ */
+static void
+@TYPE@_cross1d(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    INIT_OUTER_LOOP_3
+    npy_intp is1=steps[0], is2=steps[1], os = steps[2];
+    BEGIN_OUTER_LOOP_3
+        char *ip1=args[0], *ip2=args[1], *op=args[2];
+
+        *(@typ@ *)op = *(@typ@ *)(ip1 + is1) * *(@typ@ *)(ip2 + 2*is2) -
+                       *(@typ@ *)(ip1 + 2*is1) * *(@typ@ *)(ip2 + is2);
+        op += os;
+        *(@typ@ *)op = *(@typ@ *)(ip1 + 2*is1) * *(@typ@ *)ip2 -
+                       *(@typ@ *)ip1 * *(@typ@ *)(ip2 + 2*is2);
+        op += os;
+        *(@typ@ *)op = *(@typ@ *)ip1 * *(@typ@ *)(ip2 + is2) -
+                       *(@typ@ *)(ip1 + is1) * *(@typ@ *)ip2;
+    END_OUTER_LOOP
+}
+
+/**end repeat**/
+
 char *euclidean_pdist_signature = "(n,d)->(p)";
 
 /**begin repeat
@@ -285,6 +320,26 @@ static void
 
 /**end repeat**/
 
+/*  The following lines were generated using a slightly modified
+    version of code_generators/generate_umath.py and adding these
+    lines to defdict:
+
+defdict = {
+'inner1d' :
+    Ufunc(2, 1, None_,
+        r'''inner on the last dimension and broadcast on the rest \n"
+        "     \"(i),(i)->()\" \n''',
+          TD('ld'),
+          ),
+'innerwt' :
+    Ufunc(3, 1, None_,
+          r'''inner1d with a weight argument \n"
+          "     \"(i),(i),(i)->()\" \n''',
+          TD('ld'),
+          ),
+}
+
+*/
 
 static PyUFuncGenericFunction inner1d_functions[] = { LONG_inner1d, DOUBLE_inner1d };
 static void * inner1d_data[] = { (void *)NULL, (void *)NULL };
@@ -295,7 +350,9 @@ static char innerwt_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_LONG, NPY
 static PyUFuncGenericFunction matrix_multiply_functions[] = { LONG_matrix_multiply, FLOAT_matrix_multiply, DOUBLE_matrix_multiply };
 static void *matrix_multiply_data[] = { (void *)NULL, (void *)NULL, (void *)NULL };
 static char matrix_multiply_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG,  NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,  NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-
+static PyUFuncGenericFunction cross1d_functions[] = { LONG_cross1d, DOUBLE_cross1d };
+static void * cross1d_data[] = { (void *)NULL, (void *)NULL };
+static char cross1d_signatures[] = { NPY_LONG, NPY_LONG, NPY_LONG, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 static PyUFuncGenericFunction euclidean_pdist_functions[] =
                             { FLOAT_euclidean_pdist, DOUBLE_euclidean_pdist };
 static void *eucldiean_pdist_data[] = { (void *)NULL, (void *)NULL };
@@ -375,6 +432,16 @@ addUfuncs(PyObject *dictionary) {
         return -1;
     }
     PyDict_SetItemString(dictionary, "inner1d_no_doc", f);
+    Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(cross1d_functions, cross1d_data,
+                    cross1d_signatures, 2, 2, 1, PyUFunc_None, "cross1d",
+                    "cross product on the last dimension and broadcast on the rest \n"\
+                    "     \"(3),(3)->(3)\" \n",
+                    0, cross1d_signature);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "cross1d", f);
     Py_DECREF(f);
 
     return 0;

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -128,6 +128,8 @@ static void
 /**end repeat**/
 
 char *matrix_multiply_signature = "(m,n),(n,p)->(m,p)";
+/* for use with matrix_multiply code, but different signature */
+char *matmul_signature = "(m?,n),(n,p?)->(m?,p?)";
 
 /**begin repeat
 
@@ -151,10 +153,30 @@ static void
     npy_intp m,n,p;
     npy_intp is1_m=steps[0], is1_n=steps[1], is2_n=steps[2], is2_p=steps[3],
          os_m=steps[4], os_p=steps[5];
-    npy_intp ib1_n = is1_n*dn;
-    npy_intp ib2_n = is2_n*dn;
-    npy_intp ib2_p = is2_p*dp;
-    npy_intp ob_p  = os_p *dp;
+    npy_intp ib1_n;
+    npy_intp ib2_n;
+    npy_intp ib2_p;
+    npy_intp ob_p;
+    /*
+     * no m dimension -> row vector . matrix
+     */
+    if (dm == 0) {
+        dm = 1;
+    }
+    /*
+     * no p dimension -> matrix . column vector
+     * note that for a 1-d array, it looks like a matrix with first step
+     * equal zero, hence the switch in steps
+     */
+    if (dp == 0) {
+        os_m = os_p;
+        is2_n = is2_p;
+        dp = 1;
+    }
+    ib1_n = is1_n*dn;
+    ib2_n = is2_n*dn;
+    ib2_p = is2_p*dp;
+    ob_p  = os_p *dp;
     if (dn == 0) {
         /* No operand, need to zero the output */
         BEGIN_OUTER_LOOP_3
@@ -403,6 +425,17 @@ addUfuncs(PyObject *dictionary) {
     }
     PyDict_SetItemString(dictionary, "matrix_multiply", f);
     Py_DECREF(f);
+    f = PyUFunc_FromFuncAndDataAndSignature(matrix_multiply_functions,
+                    matrix_multiply_data, matrix_multiply_signatures,
+                    3, 2, 1, PyUFunc_None, "matmul",
+                    "matmul on last two dimensions, with some being optional\n"
+                    "     \"(m?,n),(n,p?)->(m?,p?)\" \n",
+                    0, matmul_signature);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "matmul", f);
+    Py_DECREF(f);
     f = PyUFunc_FromFuncAndDataAndSignature(euclidean_pdist_functions,
                     eucldiean_pdist_data, euclidean_pdist_signatures,
                     2, 1, 1, PyUFunc_None, "euclidean_pdist",
@@ -454,8 +487,8 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
     int nin, nout, i;
     PyObject *signature=NULL, *sig_str=NULL;
     PyUFuncObject *f=NULL;
-    PyObject *core_num_dims=NULL, *core_dim_ixs=NULL, *core_dim_szs=NULL;
-    PyObject *core_dim_flexible=NULL;
+    PyObject *core_num_dims=NULL, *core_dim_ixs=NULL;
+    PyObject *core_dim_flags=NULL, *core_dim_sizes=NULL;
     int core_enabled;
     int core_num_ixs = 0;
 
@@ -518,44 +551,44 @@ UMath_Tests_test_signature(PyObject *NPY_UNUSED(dummy), PyObject *args)
         Py_INCREF(Py_None);
         core_dim_ixs = Py_None;
     }
-    if (f->core_dim_szs != NULL) {
-        core_dim_szs = PyTuple_New(f->core_num_dim_ix);
-        if (core_num_dims == NULL) {
+    if (f->core_dim_flags != NULL) {
+        core_dim_flags = PyTuple_New(f->core_num_dim_ix);
+        if (core_dim_flags == NULL) {
             goto fail;
         }
         for (i = 0; i < f->core_num_dim_ix; i++) {
-            PyObject * val = PyLong_FromLong(f->core_dim_szs[i]);
-            PyTuple_SET_ITEM(core_dim_szs, i, val);
+            PyObject * val = PyLong_FromLong(f->core_dim_flags[i]);
+            PyTuple_SET_ITEM(core_dim_flags, i, val);
         }
     }
     else {
         Py_INCREF(Py_None);
-        core_dim_szs = Py_None;
+        core_dim_flags = Py_None;
     }
-    if (f->core_num_dim_ix != NULL) {
-        core_dim_flexible = PyTuple_New(f->core_num_dim_ix);
-        if (core_dim_flexible == NULL) {
+    if (f->core_dim_sizes != NULL) {
+        core_dim_sizes = PyTuple_New(f->core_num_dim_ix);
+        if (core_dim_sizes == NULL) {
             goto fail;
         }
         for (i = 0; i < f->core_num_dim_ix; i++) {
-            PyObject * val = PyLong_FromLong(f->core_dim_flexible[i]);
-            PyTuple_SET_ITEM(core_dim_flexible, i, val);
+            PyObject * val = PyLong_FromLong(f->core_dim_sizes[i]);
+            PyTuple_SET_ITEM(core_dim_sizes, i, val);
         }
     }
     else {
         Py_INCREF(Py_None);
-        core_dim_flexible = Py_None;
+        core_dim_sizes = Py_None;
     }
     Py_DECREF(f);
     return Py_BuildValue("iOOOO", core_enabled, core_num_dims,
-                         core_dim_ixs, core_dim_szs, core_dim_flexible);
+                         core_dim_ixs, core_dim_flags, core_dim_sizes);
 
 fail:
     Py_XDECREF(f);
     Py_XDECREF(core_num_dims);
     Py_XDECREF(core_dim_ixs);
-    Py_XDECREF(core_dim_szs);
-    Py_XDECREF(core_dim_flexible);
+    Py_XDECREF(core_dim_flags);
+    Py_XDECREF(core_dim_sizes);
     return NULL;
 }
 
@@ -603,6 +636,7 @@ PyMODINIT_FUNC init_umath_tests(void) {
     if (m == NULL) {
         return RETVAL(NULL);
     }
+
     import_array();
     import_ufunc();
 

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -576,8 +576,8 @@ static PyMethodDef UMath_TestsMethods[] = {
     {"test_signature",  UMath_Tests_test_signature, METH_VARARGS,
      "Test signature parsing of ufunc. \n"
      "Arguments: nin nout signature \n"
-     "If fails, it returns NULL. Otherwise it will returns 0 for scalar ufunc "
-     "and 1 for generalized ufunc. \n",
+     "If fails, it returns NULL. Otherwise it returns a tuple of ufunc "
+     "internals. \n",
      },
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -498,7 +498,9 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
              * get its index, and set its properties
              */
             for(ix = 0; ix < ufunc->core_num_dim_ix; ix++) {
-                if (_is_same_name(signature + i, var_names[ix])) {
+                if (frozen_size > 0 ?
+                    frozen_size == ufunc->core_dim_sizes[ix] :
+                    _is_same_name(signature + i, var_names[ix])) {
                     break;
                 }
             }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2308,19 +2308,20 @@ _parse_axis_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axis,
  *
  * Returns 0 on success, and -1 on failure
  *
- * The behavior has been changed in NumPy 1.10.0, and the following
+ * The behavior has been changed in NumPy 1.16.0, and the following
  * requirements must be fulfilled or an error will be raised:
  *  * Arguments, both input and output, must have at least as many
  *    dimensions as the corresponding number of core dimensions. In
- *    previous versions, 1's were prepended to the shape as needed.
+ *    versions before 1.10, 1's were prepended to the shape as needed.
  *  * Core dimensions with same labels must have exactly matching sizes.
- *    In previous versions, core dimensions of size 1 would broadcast
+ *    In versions before 1.10, core dimensions of size 1 would broadcast
  *    against other core dimensions with the same label.
  *  * All core dimensions must have their size specified by a passed in
- *    input or output argument. In previous versions, core dimensions in
+ *    input or output argument. In versions before 1.10, core dimensions in
  *    an output argument that were not specified in an input argument,
  *    and whose size could not be inferred from a passed in output
  *    argument, would have their size set to 1.
+ *  * Core dimensions may be fixed, new in ufunc->version 1 (NumPy 1.16)
  */
 static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -340,6 +340,28 @@ _is_alnum_underscore(char ch)
 }
 
 /*
+ * Convert a string into a number
+ */
+ static npy_intp
+ _get_size(const char* str)
+ {
+    char *stop;
+    #if defined(_MSC_VER)
+        #define strtoll _strtoi64
+    #endif
+    npy_intp size = (npy_intp)strtoll(str, &stop, 10);
+    #if defined(_MSC_VER)
+        #undef strtoll
+    #endif
+
+    if (stop == str || _is_alpha_underscore(*stop)) {
+        /* not a well formed number */
+         return -1;
+    }
+    return size;
+ }
+
+/*
  * Return the ending position of a variable name
  */
 static int
@@ -406,10 +428,13 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     ufunc->core_enabled = 1;
     ufunc->core_num_dim_ix = 0;
     ufunc->core_num_dims = PyArray_malloc(sizeof(int) * ufunc->nargs);
-    ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len); /* shrink this later */
     ufunc->core_offsets = PyArray_malloc(sizeof(int) * ufunc->nargs);
-    if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL
-        || ufunc->core_offsets == NULL) {
+    /* The next two items will be shrunk later */
+    ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len);
+    ufunc->core_dim_szs = PyArray_malloc(sizeof(npy_intp) * len);
+
+    if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL ||
+        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL) {
         PyErr_NoMemory();
         goto fail;
     }
@@ -438,8 +463,15 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         while (signature[i] != ')') {
             /* loop over core dimensions */
             int j = 0;
-            if (!_is_alpha_underscore(signature[i])) {
-                parse_error = "expect dimension name";
+            npy_intp frozen_size = -1;
+            if (signature[i] == '\0') {
+                parse_error = "unexpected end of signature string";
+                goto fail;
+            }
+
+            if (!_is_alpha_underscore(signature[i]) &&
+                (frozen_size = _get_size(signature + i)) < 0) {
+                parse_error = "expect dimension name or frozen size";
                 goto fail;
             }
             while (j < ufunc->core_num_dim_ix) {
@@ -450,6 +482,7 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
             }
             if (j >= ufunc->core_num_dim_ix) {
                 var_names[j] = signature+i;
+                ufunc->core_dim_szs[j] = frozen_size;
                 ufunc->core_num_dim_ix++;
             }
             ufunc->core_dim_ixs[cur_core_dim] = j;
@@ -494,6 +527,9 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     }
     ufunc->core_dim_ixs = PyArray_realloc(ufunc->core_dim_ixs,
             sizeof(int)*cur_core_dim);
+    // ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
+            // sizeof(npy_intp)*ufunc->core_num_dim_ix);
+
     /* check for trivial core-signature, e.g. "(),()->()" */
     if (cur_core_dim == 0) {
         ufunc->core_enabled = 0;
@@ -2485,6 +2521,17 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         if(retval < 0) {
             goto fail;
         }
+    }
+    /*
+     * Validate the core dimensions of all the operands,
+     * and collect all of the labeled core dimension sizes
+     * into the array 'core_dim_sizes'. Initialize them to
+     * 1, for example in the case where the operand broadcasts
+     * to a core dimension, it won't be visited.
+     */
+    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
+        npy_intp frozen_size = ufunc->core_dim_szs[i];
+        core_dim_sizes[i] = frozen_size == -1 ? 1 : frozen_size;
     }
 
     /* Collect the lengths of the labelled core dimensions */
@@ -4788,6 +4835,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     ufunc->core_dim_ixs = NULL;
     ufunc->core_offsets = NULL;
     ufunc->core_signature = NULL;
+    ufunc->core_dim_szs = NULL;
     if (signature != NULL) {
         if (_parse_signature(ufunc, signature) != 0) {
             Py_DECREF(ufunc);
@@ -5134,6 +5182,7 @@ ufunc_dealloc(PyUFuncObject *ufunc)
 {
     PyArray_free(ufunc->core_num_dims);
     PyArray_free(ufunc->core_dim_ixs);
+    PyArray_free(ufunc->core_dim_szs);
     PyArray_free(ufunc->core_offsets);
     PyArray_free(ufunc->core_signature);
     PyArray_free(ufunc->ptr);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -415,7 +415,6 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
                         "_parse_signature with NULL signature");
         return -1;
     }
-
     len = strlen(signature);
     ufunc->core_signature = PyArray_malloc(sizeof(char) * (len+1));
     if (ufunc->core_signature) {
@@ -432,19 +431,19 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     ufunc->core_num_dim_ix = 0;
     ufunc->core_num_dims = PyArray_malloc(sizeof(int) * ufunc->nargs);
     ufunc->core_offsets = PyArray_malloc(sizeof(int) * ufunc->nargs);
-    /* The next two items will be shrunk later */
+    /* The next three items will be shrunk later */
     ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len);
-    ufunc->core_dim_szs = PyArray_malloc(sizeof(npy_intp) * len);
-    ufunc->core_dim_flexible = PyArray_malloc(sizeof(int) * len);
+    ufunc->core_dim_flags = PyArray_malloc(sizeof(npy_uint32) * len);
+    ufunc->core_dim_sizes = PyArray_malloc(sizeof(npy_intp) * len);
 
     if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL ||
-        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL ||
-        ufunc->core_dim_flexible == NULL) {
+        ufunc->core_offsets == NULL || ufunc->core_dim_flags == NULL ||
+        ufunc->core_dim_sizes == NULL) {
         PyErr_NoMemory();
         goto fail;
     }
     for (i = 0; i < len; i++) {
-        ufunc->core_dim_flexible[i] = -1;
+        ufunc->core_dim_flags[i] = 0;
     }
 
     i = _next_non_white_space(signature, 0);
@@ -470,48 +469,68 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         i = _next_non_white_space(signature, i + 1);
         while (signature[i] != ')') {
             /* loop over core dimensions */
-            int j = 0;
-            npy_intp frozen_size = -1;
+            int ix, i_end;
+            npy_intp frozen_size;
+            npy_bool can_ignore;
+
             if (signature[i] == '\0') {
                 parse_error = "unexpected end of signature string";
                 goto fail;
             }
-
-            if (!_is_alpha_underscore(signature[i]) &&
-                (frozen_size = _get_size(signature + i)) < 0) {
-                parse_error = "expect dimension name or non-zero frozen size";
-                goto fail;
+            /*
+             * Is this a variable or a fixed size dimension?
+             */
+            if (_is_alpha_underscore(signature[i])) {
+                frozen_size = -1;
             }
-            while (j < ufunc->core_num_dim_ix) {
-                if (_is_same_name(signature+i, var_names[j])) {
+            else {
+                frozen_size = _get_size(signature + i);
+                if (frozen_size <= 0) {
+                    parse_error = "expect dimension name or non-zero frozen size";
+                    goto fail;
+                }
+            }
+            /* Is this dimension flexible? */
+            i_end = _get_end_of_name(signature, i);
+            can_ignore = (i_end > 0 && signature[i_end - 1] == '?');
+            /*
+             * Determine whether we already saw this dimension name,
+             * get its index, and set its properties
+             */
+            for(ix = 0; ix < ufunc->core_num_dim_ix; ix++) {
+                if (_is_same_name(signature + i, var_names[ix])) {
                     break;
                 }
-                j++;
             }
-            if (j >= ufunc->core_num_dim_ix) {
-                var_names[j] = signature+i;
-                ufunc->core_dim_szs[j] = frozen_size;
+            /*
+             * If a new dimension, store its properties; if old, check consistency.
+             */
+            if (ix == ufunc->core_num_dim_ix) {
                 ufunc->core_num_dim_ix++;
-            }
-            ufunc->core_dim_ixs[cur_core_dim] = j;
-            i = _get_end_of_name(signature, i);
-            if (i > 0 && signature[i - 1] == '?') {
-                if (ufunc->core_dim_flexible[j] == 0) {
+                var_names[ix] = signature + i;
+                ufunc->core_dim_sizes[ix] = frozen_size;
+                if (frozen_size < 0) {
+                    ufunc->core_dim_flags[ix] |= UFUNC_CORE_DIM_SIZE_UNSET;
+                }
+                if (can_ignore) {
+                    ufunc->core_dim_flags[ix] |= UFUNC_CORE_DIM_CAN_IGNORE;
+                }
+            } else {
+                if (can_ignore && !(ufunc->core_dim_flags[ix] &
+                                    UFUNC_CORE_DIM_CAN_IGNORE)) {
                     parse_error = "? cannot be used, name already seen without ?";
                     goto fail;
                 }
-                ufunc->core_dim_flexible[j] = 1;
-            }
-            else {
-                if (ufunc->core_dim_flexible[j] == 1) {
+                if (!can_ignore && (ufunc->core_dim_flags[ix] &
+                                    UFUNC_CORE_DIM_CAN_IGNORE)) {
                     parse_error = "? must be used, name already seen with ?";
                     goto fail;
                 }
-                ufunc->core_dim_flexible[j] = 0;
             }
+            ufunc->core_dim_ixs[cur_core_dim] = ix;
             cur_core_dim++;
             nd++;
-            i = _next_non_white_space(signature, i);
+            i = _next_non_white_space(signature, i_end);
             if (signature[i] != ',' && signature[i] != ')') {
                 parse_error = "expect ',' or ')'";
                 goto fail;
@@ -548,11 +567,11 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         goto fail;
     }
     ufunc->core_dim_ixs = PyArray_realloc(ufunc->core_dim_ixs,
-            sizeof(int)*cur_core_dim);
-    ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
-            sizeof(npy_intp)*ufunc->core_num_dim_ix);
-    ufunc->core_dim_flexible = PyArray_realloc(ufunc->core_dim_flexible,
-            sizeof(int)*(ufunc->core_num_dim_ix));
+            sizeof(int) * cur_core_dim);
+    ufunc->core_dim_sizes = PyArray_realloc(ufunc->core_dim_sizes,
+            sizeof(npy_intp) * ufunc->core_num_dim_ix);
+    ufunc->core_dim_flags = PyArray_realloc(ufunc->core_dim_flags,
+            sizeof(npy_uint32) * ufunc->core_num_dim_ix);
 
     /* check for trivial core-signature, e.g. "(),()->()" */
     if (cur_core_dim == 0) {
@@ -2234,58 +2253,53 @@ _parse_axis_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axis,
  */
 static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
-                   int *core_num_dims, int * flexible_activated,
-                   npy_intp* core_dim_sizes, int **remap_axis) {
-    int i;
+                   int *core_num_dims, int *core_dim_flags,
+                   npy_intp *core_dim_sizes, int **remap_axis) {
+    int i, j;
     int nin = ufunc->nin;
     int nout = ufunc->nout;
     int nop = nin + nout;
 
-    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
+    for (j = 0; j < ufunc->core_num_dim_ix; ++j) {
         /* support fixed-size dim names */
-        core_dim_sizes[i] = ufunc->core_dim_szs[i];
+        core_dim_sizes[j] = ufunc->core_dim_sizes[j];
     }
     for (i = 0; i < nop; ++i) {
         if (op[i] != NULL) {
             int idim;
             int dim_offset = ufunc->core_offsets[i];
-            int num_dims = core_num_dims[i];
-            int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
+            int core_start_dim = PyArray_NDIM(op[i]) - core_num_dims[i];
             int dim_delta = 0;
 
-            /* Check if operands have enough dimensions */
-            if (core_start_dim < 0) {
-                PyErr_Format(PyExc_ValueError,
-                        "%s: %s operand %d does not have enough "
-                        "dimensions (has %d, gufunc core with "
-                        "signature %s requires %d)",
-                        ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
-                        i < nin ? i : i - nin, PyArray_NDIM(op[i]),
-                        ufunc->core_signature, num_dims);
-                return -1;
-            }
+            /* checked before this routine gets called */
+            assert(core_start_dim >= 0);
 
             /*
-             * Make sure every core dimension exactly matches all other core
-             * dimensions with the same label.
+             * Make sure every core dimension exaclty matches all other core
+             * dimensions with the same label. When flexible, a dimension
+             * can be either 1 or the label, and even be absent.
              */
             for (idim = 0; idim < ufunc->core_num_dims[i]; ++idim) {
-                int core_dim_index = ufunc->core_dim_ixs[dim_offset+idim];
+                int core_index = dim_offset + idim;
+                int core_dim_index = ufunc->core_dim_ixs[core_index];
+                npy_intp core_dim_size = core_dim_sizes[core_dim_index];
                 npy_intp op_dim_size;
-                if (flexible_activated[core_dim_index] > 0) {
+
+                /* can only happen if flexible; dimension missing altogether */
+                if (core_dim_flags[core_dim_index] & UFUNC_CORE_DIM_MISSING) {
                     op_dim_size = 0;
-                    dim_delta ++;
+                    dim_delta++; /* for indexing in dimensions */
                 }
                 else {
                     op_dim_size = PyArray_DIM(op[i],
                              REMAP_AXIS(i, core_start_dim + idim - dim_delta));
                 }
-                if (core_dim_sizes[core_dim_index] == -1) {
+                if (core_dim_sizes[core_dim_index] < 0) {
                     core_dim_sizes[core_dim_index] = op_dim_size;
                 }
-                else if (op_dim_size != core_dim_sizes[core_dim_index]) {
+                else if (op_dim_size != core_dim_size) {
                     PyErr_Format(PyExc_ValueError,
-                            "1 %s: %s operand %d has a mismatch in its "
+                            "%s: %s operand %d has a mismatch in its "
                             "core dimension %d, with gufunc "
                             "signature %s (size %zd is different "
                             "from %zd)",
@@ -2299,42 +2313,30 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
         }
     }
 
-    /*
-     * Make sure no core dimension is unspecified.
-     */
-    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
-        if (core_dim_sizes[i] == -1) {
-            break;
-        }
-    }
-    if (i != ufunc->core_num_dim_ix) {
-        /*
-         * There is at least one core dimension missing, find in which
-         * operand it comes up first (it has to be an output operand).
-         */
-        const int missing_core_dim = i;
-        int out_op;
-        for (out_op = nin; out_op < nop; ++out_op) {
-            int first_idx = ufunc->core_offsets[out_op];
-            int last_idx = first_idx + core_num_dims[out_op];
-            for (i = first_idx; i < last_idx; ++i) {
-                if (ufunc->core_dim_ixs[i] == missing_core_dim) {
-                    break;
-                }
-            }
-            if (i < last_idx) {
-                /* Change index offsets for error message */
-                out_op -= nin;
-                i -= first_idx;
-                break;
+    for (i = nin; i < nop; ++i) {
+        int idim;
+        int dim_offset = ufunc->core_offsets[i];
+
+        for (idim = 0; idim < ufunc->core_num_dims[i]; ++idim) {
+            int core_index = dim_offset + idim;
+            int core_dim_index = ufunc->core_dim_ixs[core_index];
+
+            /* check all cases where the size has not yet been set */
+            if (core_dim_sizes[core_dim_index] < 0) {
+                /*
+                 * Oops, this dimension was never specified
+                 * (can only happen if output op not given)
+                 */
+                PyErr_Format(PyExc_ValueError,
+                        "%s: Output operand %d has core dimension %d "
+                        "unspecified, with gufunc signature %s",
+                        ufunc_get_name_cstr(ufunc), i - nin, idim,
+                        ufunc->core_signature);
+                return -1;
             }
         }
-        PyErr_Format(PyExc_ValueError,
-                     "%s: Output operand %d has core dimension %d "
-                     "unspecified, with gufunc signature %s",
-                     ufunc_get_name_cstr(ufunc), out_op, i, ufunc->core_signature);
-        return -1;
     }
+
     return 0;
 }
 
@@ -2389,12 +2391,11 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
     /* Use remapped axes for generalized ufunc */
     int broadcast_ndim, iter_ndim;
-    int core_num_dims_array[NPY_MAXARGS];
-    int *core_num_dims;
+    int core_num_dims[NPY_MAXARGS];
     int op_axes_arrays[NPY_MAXARGS][NPY_MAXDIMS];
     int *op_axes[NPY_MAXARGS];
     int n_dims_used[NPY_MAXARGS];
-    int flexible_activated[NPY_MAXARGS];
+    int core_dim_flags[NPY_MAXARGS];
 
     npy_uint32 op_flags[NPY_MAXARGS];
     npy_intp iter_shape[NPY_MAXARGS];
@@ -2448,10 +2449,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     for (i = 0; i < nop; ++i) {
         dtypes[i] = NULL;
         arr_prep[i] = NULL;
-        n_dims_used[i] = ufunc->core_num_dims[i];
     }
-    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
-        flexible_activated[i] = (ufunc->core_dim_flexible[i] > 0) ? -1 : 0;
+    /* construct per-argument flags */
+    for (idim = 0; idim < ufunc->core_num_dim_ix; ++idim) {
+        core_dim_flags[idim] = ufunc->core_dim_flags[idim];
     }
 
     NPY_UF_DBG_PRINT("Getting arguments\n");
@@ -2489,34 +2490,46 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     if (keepdims == 1) {
         int num_dims = ufunc->core_num_dims[0];
         for (i = 0; i < nop; ++i) {
-            core_num_dims_array[i] = num_dims;
+            core_num_dims[i] = num_dims;
         }
-        core_num_dims = core_num_dims_array;
     }
     else {
         /* keepdims was not set or was false; no adjustment necessary */
-        core_num_dims = ufunc->core_num_dims;
+        for (i = 0; i < nop; ++i) {
+            core_num_dims[i] = ufunc->core_num_dims[i];
+        }
         keepdims = 0;
     }
     /*
      * Check that operands have the minimum dimensions required.
      * (Just checks core; broadcast dimensions are tested by the iterator.)
      */
+    for (i = 0; i< nop; i++) {
+        n_dims_used[i] = core_num_dims[i];
+    }
     for (i = 0; i < nop; i++) {
-        /* TODO: store _n_required after parsing, ahead-of-time */
-        int n_required = ufunc->core_num_dims[i];
-        if (n_required > 0) {
-            /* can be less if dim is flexible */
-            for (j = ufunc->core_offsets[i];
-                     j < ufunc->core_offsets[i] + core_num_dims[i]; j++) {
-                int dim_index = ufunc->core_dim_ixs[j];
-                n_required -= ufunc->core_dim_flexible[dim_index];
-            }
-        }
         if (op[i] != NULL) {
-            n_dims_used[i] = PyArray_NDIM(op[i]);
-            if (n_dims_used[i] < n_required) {
-                PyErr_Format(PyExc_ValueError,
+            /* TODO: store _n_required after parsing, ahead-of-time */
+            int op_ndim = PyArray_NDIM(op[i]);
+            int num_dims = ufunc->core_num_dims[i];
+
+            if (op_ndim < num_dims) {
+                int core_offset = ufunc->core_offsets[i];
+                int n_required = num_dims;
+                /* can be less if dim is flexible */
+                for (j = core_offset; j < core_offset + n_required; j++) {
+                    int core_dim_index = ufunc->core_dim_ixs[j];
+                    if ((core_dim_flags[core_dim_index] &
+                         UFUNC_CORE_DIM_CAN_IGNORE)) {
+                        core_dim_flags[core_dim_index] |= UFUNC_CORE_DIM_MISSING;
+                        n_required--;
+                        if (n_required == op_ndim) {
+                            break;
+                        }
+                    }
+                }
+                if (op_ndim < n_required) {
+                    PyErr_Format(PyExc_ValueError,
                          "%s: %s operand %d does not have enough "
                          "dimensions (has %d, gufunc core with "
                          "signature %s requires %d)",
@@ -2524,81 +2537,24 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                          i < nin ? "Input" : "Output",
                          i < nin ? i : i - nin, PyArray_NDIM(op[i]),
                          ufunc->core_signature, n_required);
-                retval = -1;
-                goto fail;
-            }
-            if (n_dims_used[i] < core_num_dims[i]) {
-                int flexible_used = core_num_dims[i] - n_dims_used[i];
-                /* one (or more?) flexible signature names have been used. Mark them */
-                for (j = ufunc->core_offsets[i];
-                     j < ufunc->core_offsets[i] + core_num_dims[i];
-                     j++) {
-                    int dim_index = ufunc->core_dim_ixs[j];
-                    if (flexible_activated[dim_index] < 0) {
-                        flexible_activated[dim_index] = 1;
-                    }
-                    flexible_used -= flexible_activated[dim_index];
-                    if (flexible_used <= 0) {
-                        break;
-                    }
-                }
-                if (flexible_used > 0) {
-                    PyErr_Format(PyExc_ValueError,
-                         "%s: %s operand %d does not have enough "
-                         "dimensions (has %d, gufunc core with "
-                         "signature %s requires %d)",
-                         ufunc_get_name_cstr(ufunc),
-                         i < nin ? "Input" : "Output",
-                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
-                         ufunc->core_signature, n_required + flexible_used);
+                    retval = -1;
                     goto fail;
                 }
-            }
-            else {
-                /* never use more than the signature requires */
-                n_dims_used[i] = core_num_dims[i];
-                /* make sure any flexible dimensions are used in the same way */
-                for (j = ufunc->core_offsets[i];
-                     j < ufunc->core_offsets[i] + core_num_dims[i];
-                     j++) {
-                    if (j <= ufunc->core_num_dim_ix) {
-                        int dim_index = ufunc->core_dim_ixs[j];
-                        if (flexible_activated[dim_index] < 0) {
-                            flexible_activated[dim_index] = 0;
-                        }
-                        else if (flexible_activated[dim_index] == 1) {
-                            PyErr_Format(PyExc_ValueError,
-                                "%s: %s operand %d with flexible dimension "
-                                "index %d signature %s previouosly marked "
-                                "flexible but now is not",
-                                 ufunc_get_name_cstr(ufunc),
-                                 i < nin ? "Input" : "Output",
-                                 i < nin ? i : i - nin, dim_index,
-                                 ufunc->core_signature);
-                            goto fail;
-                        }
-                    }
-                }
+                n_dims_used[i] = op_ndim;
             }
         }
         else {
-            /* NULL output provided. Use flexible_used to determine ndims_used */
-            n_dims_used[i] = core_num_dims[i];
-            for (j = ufunc->core_offsets[i];
-                 j < ufunc->core_offsets[i] + core_num_dims[i]; j++) {
-                if (j <= ufunc->core_num_dim_ix) {
-                    int dim_index = ufunc->core_dim_ixs[j];
-                    if (flexible_activated[dim_index] < 0) {
-                        PyErr_Format(PyExc_ValueError,
-                            "%s: %s operand %d with flexible dimension index "
-                            " %d signature %s cannot be uniquely determined",
-                            ufunc_get_name_cstr(ufunc),
-                            i < nin ? "Input" : "Output",
-                            i < nin ? i : i - nin, dim_index,
-                            ufunc->core_signature);
-                        goto fail;
-                    }
-                    n_dims_used[i] -= flexible_activated[dim_index];
+            /*
+             * For outputs that should be created, account for
+             * dimensions that should not be omitted.
+             */
+            int core_offset = ufunc->core_offsets[i];
+            int num_dims = ufunc->core_num_dims[i];
+            for (j = core_offset; j < core_offset + num_dims; j++) {
+                int core_dim_index = ufunc->core_dim_ixs[j];
+                if ((core_dim_flags[core_dim_index] &
+                     UFUNC_CORE_DIM_MISSING)) {
+                    n_dims_used[i]--;
                 }
             }
         }
@@ -2617,6 +2573,37 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         }
     }
 
+    /* Possibly remap axes. */
+    if (axes != NULL || axis != NULL) {
+        remap_axis = PyArray_malloc(sizeof(remap_axis[0]) * nop);
+        remap_axis_memory = PyArray_malloc(sizeof(remap_axis_memory[0]) *
+                                                  nop * NPY_MAXDIMS);
+        if (remap_axis == NULL || remap_axis_memory == NULL) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+        for (i=0; i < nop; i++) {
+            remap_axis[i] = remap_axis_memory + i * NPY_MAXDIMS;
+        }
+        if (axis) {
+            retval = _parse_axis_arg(ufunc, n_dims_used, axis, op,
+                                     broadcast_ndim, remap_axis);
+        }
+        else {
+            retval = _parse_axes_arg(ufunc, n_dims_used, axes, op,
+                                     broadcast_ndim, remap_axis);
+        }
+        if(retval < 0) {
+            goto fail;
+        }
+    }
+
+    /* Collect the lengths of the labelled core dimensions */
+    retval = _get_coredim_sizes(ufunc, op, n_dims_used, core_dim_flags,
+                                core_dim_sizes, remap_axis);
+    if(retval < 0) {
+        goto fail;
+    }
     /*
      * Figure out the number of iterator creation dimensions,
      * which is the broadcast dimensions + all the core dimensions of
@@ -2632,38 +2619,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                     "too many dimensions for generalized ufunc %s",
                     ufunc_name);
         retval = -1;
-        goto fail;
-    }
-
-    /* Possibly remap axes. */
-    if (axes != NULL || axis != NULL) {
-        remap_axis = PyArray_malloc(sizeof(remap_axis[0]) * nop);
-        remap_axis_memory = PyArray_malloc(sizeof(remap_axis_memory[0]) *
-                                                  nop * NPY_MAXDIMS);
-        if (remap_axis == NULL || remap_axis_memory == NULL) {
-            PyErr_NoMemory();
-            goto fail;
-        }
-        for (i=0; i < nop; i++) {
-            remap_axis[i] = remap_axis_memory + i * NPY_MAXDIMS;
-        }
-        if (axis) {
-            retval = _parse_axis_arg(ufunc, core_num_dims, axis, op,
-                                     broadcast_ndim, remap_axis);
-        }
-        else {
-            retval = _parse_axes_arg(ufunc, core_num_dims, axes, op,
-                                     broadcast_ndim, remap_axis);
-        }
-        if(retval < 0) {
-            goto fail;
-        }
-    }
-
-    /* Collect the lengths of the labelled core dimensions */
-    retval = _get_coredim_sizes(ufunc, op, n_dims_used, flexible_activated,
-                                core_dim_sizes, remap_axis);
-    if(retval < 0) {
         goto fail;
     }
 
@@ -2702,34 +2657,48 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         /* Except for when it belongs to this output */
         if (i >= nin) {
             int dim_offset = ufunc->core_offsets[i];
-            int num_dims = core_num_dims[i];
-            int has_flexible=0;
+            int num_removed = 0;
             /*
              * Fill in 'iter_shape' and 'op_axes' for the core dimensions
              * of this output. Here, we have to be careful: if keepdims
-             * was used or if it is a flexible dimension, then this axis
-             * is not a real core dimension, but is being added back for broadcasting,
-             * so its size is 1.
+             * was used, then this axis is not a real core dimension,
+             * but is being added back for broadcasting, so its size is 1.
+             * If the axis was removed, we should skip altogether.
              */
-            for (idim = 0; idim < num_dims; ++idim) {
-                if (keepdims) {
+            if (keepdims) {
+                for (idim = 0; idim < n_dims_used[i]; ++idim) {
                     iter_shape[j] = 1;
-                } else {
-                    int core_index = ufunc->core_dim_ixs[dim_offset + idim];
-                    if (flexible_activated[core_index]) {
+                    op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim);
+                    ++j;
+                }
+            }
+            else {
+                for (idim = 0; idim < ufunc->core_num_dims[i]; ++idim) {
+                    int core_index = dim_offset + idim;
+                    int core_dim_index = ufunc->core_dim_ixs[core_index];
+                    if ((core_dim_flags[core_dim_index] &
+                         UFUNC_CORE_DIM_MISSING)) {
                         /* skip it */
-                        has_flexible ++;
+                        num_removed++;
                         continue;
                     }
-                    iter_shape[j] = core_dim_sizes[core_index];
+                    iter_shape[j] = core_dim_sizes[ufunc->core_dim_ixs[core_index]];
+                    op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim - num_removed);
+                    ++j;
                 }
-                op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim - has_flexible);
-                ++j;
             }
         }
 
         op_axes[i] = op_axes_arrays[i];
     }
+
+#if NPY_UF_DBG_TRACING
+    printf("iter shapes:");
+    for (j=0; j < iter_ndim; j++) {
+        printf(" %ld", iter_shape[j]);
+    }
+    printf("\n");
+#endif
 
     /* Get the buffersize and errormask */
     if (_get_bufsize_errmask(extobj, ufunc_name, &buffersize, &errormask) < 0) {
@@ -4970,7 +4939,8 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     ufunc->core_dim_ixs = NULL;
     ufunc->core_offsets = NULL;
     ufunc->core_signature = NULL;
-    ufunc->core_dim_szs = NULL;
+    ufunc->core_dim_flags = NULL;
+    ufunc->core_dim_sizes = NULL;
     if (signature != NULL) {
         if (_parse_signature(ufunc, signature) != 0) {
             Py_DECREF(ufunc);
@@ -5317,7 +5287,8 @@ ufunc_dealloc(PyUFuncObject *ufunc)
 {
     PyArray_free(ufunc->core_num_dims);
     PyArray_free(ufunc->core_dim_ixs);
-    PyArray_free(ufunc->core_dim_szs);
+    PyArray_free(ufunc->core_dim_flags);
+    PyArray_free(ufunc->core_dim_sizes);
     PyArray_free(ufunc->core_offsets);
     PyArray_free(ufunc->core_signature);
     PyArray_free(ufunc->ptr);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1981,6 +1981,75 @@ fail:
 }
 
 /*
+ * Validate that operands have enough dimenions, accounting for
+ * possible flexible dimensions that may be absent.
+ */
+static int
+_validate_num_dims(PyUFuncObject *ufunc, PyArrayObject **op,
+                   npy_uint32 *core_dim_flags,
+                   int *n_dims_used) {
+    int i, j;
+    int nin = ufunc->nin;
+    int nop = ufunc->nargs;
+
+    for (i = 0; i < nop; i++) {
+        if (op[i] != NULL) {
+            int op_ndim = PyArray_NDIM(op[i]);
+
+            if (op_ndim < n_dims_used[i]) {
+                int core_offset = ufunc->core_offsets[i];
+                /* We've too few, but some dimensions might be flexible */
+                for (j = core_offset;
+                     j < core_offset + ufunc->core_num_dims[i]; j++) {
+                    int core_dim_index = ufunc->core_dim_ixs[j];
+                    if ((core_dim_flags[core_dim_index] &
+                         UFUNC_CORE_DIM_CAN_IGNORE)) {
+                        int i1, j1, k;
+                        /*
+                         * Found a dimension that can be ignored. Flag that
+                         * it is missing, and unflag that it can be ignored,
+                         * since we are doing so already.
+                         */
+                        core_dim_flags[core_dim_index] |= UFUNC_CORE_DIM_MISSING;
+                        core_dim_flags[core_dim_index] ^= UFUNC_CORE_DIM_CAN_IGNORE;
+                        /*
+                         * Reduce the number of core dimensions for all
+                         * operands that use this one (including ours),
+                         * and check whether we're now OK.
+                         */
+                        for (i1 = 0, k=0; i1 < nop; i1++) {
+                            for (j1 = 0; j1 < ufunc->core_num_dims[i1]; j1++) {
+                                if (ufunc->core_dim_ixs[k++] == core_dim_index) {
+                                    n_dims_used[i1]--;
+                                }
+                            }
+                        }
+                        if (op_ndim == n_dims_used[i]) {
+                            break;
+                        }
+                    }
+                }
+                if (op_ndim < n_dims_used[i]) {
+                    goto fail;
+                }
+            }
+        }
+    }
+    return 0;
+
+fail:
+    PyErr_Format(PyExc_ValueError,
+                 "%s: %s operand %d does not have enough "
+                 "dimensions (has %d, gufunc core with "
+                 "signature %s requires %d)",
+                 ufunc_get_name_cstr(ufunc),
+                 i < nin ? "Input" : "Output",
+                 i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                 ufunc->core_signature, n_dims_used[i]);
+    return -1;
+}
+
+/*
  * Check whether any of the outputs of a gufunc has core dimensions.
  */
 static int
@@ -2253,7 +2322,7 @@ _parse_axis_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axis,
  */
 static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
-                   int *core_num_dims, int *core_dim_flags,
+                   int *core_num_dims, npy_uint32 *core_dim_flags,
                    npy_intp *core_dim_sizes, int **remap_axis) {
     int i, j;
     int nin = ufunc->nin;
@@ -2395,7 +2464,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     int op_axes_arrays[NPY_MAXARGS][NPY_MAXDIMS];
     int *op_axes[NPY_MAXARGS];
     int n_dims_used[NPY_MAXARGS];
-    int core_dim_flags[NPY_MAXARGS];
+    npy_uint32 core_dim_flags[NPY_MAXARGS];
 
     npy_uint32 op_flags[NPY_MAXARGS];
     npy_intp iter_shape[NPY_MAXARGS];
@@ -2507,59 +2576,11 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     for (i = 0; i< nop; i++) {
         n_dims_used[i] = core_num_dims[i];
     }
-    for (i = 0; i < nop; i++) {
-        if (op[i] != NULL) {
-            /* TODO: store _n_required after parsing, ahead-of-time */
-            int op_ndim = PyArray_NDIM(op[i]);
-            int num_dims = ufunc->core_num_dims[i];
-
-            if (op_ndim < num_dims) {
-                int core_offset = ufunc->core_offsets[i];
-                int n_required = num_dims;
-                /* can be less if dim is flexible */
-                for (j = core_offset; j < core_offset + n_required; j++) {
-                    int core_dim_index = ufunc->core_dim_ixs[j];
-                    if ((core_dim_flags[core_dim_index] &
-                         UFUNC_CORE_DIM_CAN_IGNORE)) {
-                        core_dim_flags[core_dim_index] |= UFUNC_CORE_DIM_MISSING;
-                        n_required--;
-                        if (n_required == op_ndim) {
-                            break;
-                        }
-                    }
-                }
-                if (op_ndim < n_required) {
-                    PyErr_Format(PyExc_ValueError,
-                         "%s: %s operand %d does not have enough "
-                         "dimensions (has %d, gufunc core with "
-                         "signature %s requires %d)",
-                         ufunc_name,
-                         i < nin ? "Input" : "Output",
-                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
-                         ufunc->core_signature, n_required);
-                    retval = -1;
-                    goto fail;
-                }
-                n_dims_used[i] = op_ndim;
-            }
-        }
-        else {
-            /*
-             * For outputs that should be created, account for
-             * dimensions that should not be omitted.
-             */
-            int core_offset = ufunc->core_offsets[i];
-            int num_dims = ufunc->core_num_dims[i];
-            for (j = core_offset; j < core_offset + num_dims; j++) {
-                int core_dim_index = ufunc->core_dim_ixs[j];
-                if ((core_dim_flags[core_dim_index] &
-                     UFUNC_CORE_DIM_MISSING)) {
-                    n_dims_used[i]--;
-                }
-            }
-        }
+    retval = _validate_num_dims(ufunc, op, core_dim_flags,
+                                n_dims_used);
+    if (retval < 0) {
+        goto fail;
     }
-
     /*
      * Figure out the number of iteration dimensions, which
      * is the broadcast result of all the input non-core

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2327,15 +2327,11 @@ static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
                    int *core_num_dims, npy_uint32 *core_dim_flags,
                    npy_intp *core_dim_sizes, int **remap_axis) {
-    int i, j;
+    int i;
     int nin = ufunc->nin;
     int nout = ufunc->nout;
     int nop = nin + nout;
 
-    for (j = 0; j < ufunc->core_num_dim_ix; ++j) {
-        /* support fixed-size dim names */
-        core_dim_sizes[j] = ufunc->core_dim_sizes[j];
-    }
     for (i = 0; i < nop; ++i) {
         if (op[i] != NULL) {
             int idim;
@@ -2450,6 +2446,40 @@ _get_identity(PyUFuncObject *ufunc, npy_bool *reorderable) {
     }
 }
 
+/*
+ * Copy over parts of the ufunc structure that may need to be
+ * changed during execution.  Returns 0 on success; -1 otherwise.
+ */
+static int
+_initialize_variable_parts(PyUFuncObject *ufunc,
+                           int core_num_dims[],
+                           npy_intp core_dim_sizes[],
+                           npy_uint32 core_dim_flags[]) {
+    int i;
+
+    for (i = 0; i < ufunc->nargs; i++) {
+        core_num_dims[i] = ufunc->core_num_dims[i];
+    }
+    if (ufunc->version == 1) {
+        for (i = 0; i < ufunc->core_num_dim_ix; i++) {
+            core_dim_sizes[i] = ufunc->core_dim_sizes[i];
+            core_dim_flags[i] = ufunc->core_dim_flags[i];
+        }
+    }
+    else if (ufunc->version == 0) {
+        for (i = 0; i < ufunc->core_num_dim_ix; i++) {
+            core_dim_sizes[i] = -1;
+            core_dim_flags[i] = UFUNC_CORE_DIM_SIZE_UNSET;
+        }
+    }
+    else {
+        PyErr_Format(PyExc_TypeError,
+                     "'%s': unrecognized version number %d.",
+                     ufunc_get_name_cstr(ufunc), ufunc->version);
+        return -1;
+    }
+    return 0;
+}
 
 static int
 PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
@@ -2524,9 +2554,11 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         dtypes[i] = NULL;
         arr_prep[i] = NULL;
     }
-    /* copy per-argument flags, so they can be changed */
-    for (idim = 0; idim < ufunc->core_num_dim_ix; ++idim) {
-        core_dim_flags[idim] = ufunc->core_dim_flags[idim];
+    /* Initialize possibly variable parts to the values from the ufunc */
+    retval = _initialize_variable_parts(ufunc, core_num_dims,
+                                        core_dim_sizes, core_dim_flags);
+    if (retval < 0) {
+        goto fail;
     }
 
     NPY_UF_DBG_PRINT("Getting arguments\n");
@@ -2559,19 +2591,17 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         }
     }
     /*
-     * If keepdims is set and true, signal all dimensions will be the same.
+     * If keepdims is set and true, which means all input dimensions are
+     * the same.  Signal all output dimensions will be the same too.
      */
     if (keepdims == 1) {
-        int num_dims = ufunc->core_num_dims[0];
-        for (i = 0; i < nop; ++i) {
+        int num_dims = core_num_dims[0];
+        for (i = nin; i < nop; ++i) {
             core_num_dims[i] = num_dims;
         }
     }
     else {
         /* keepdims was not set or was false; no adjustment necessary */
-        for (i = 0; i < nop; ++i) {
-            core_num_dims[i] = ufunc->core_num_dims[i];
-        }
         keepdims = 0;
     }
     /*

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4791,7 +4791,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
     }
     PyObject_Init((PyObject *)ufunc, &PyUFunc_Type);
 
-    ufunc->reserved1 = 0;
+    ufunc->version = 1;  /* NumPy 1.16 and up */
     ufunc->reserved2 = NULL;
 
     ufunc->nin = nin;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2359,7 +2359,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
 
                 /* can only happen if flexible; dimension missing altogether */
                 if (core_dim_flags[core_dim_index] & UFUNC_CORE_DIM_MISSING) {
-                    op_dim_size = 0;
+                    op_dim_size = 1;
                     dim_delta++; /* for indexing in dimensions */
                 }
                 else {
@@ -2844,9 +2844,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     /* Copy the strides after the first nop */
     idim = nop;
     for (i = 0; i < nop; ++i) {
-        int num_dims = ufunc->core_num_dims[i];
-        /* Could be negative if flexible dims are used, or if keepdims */
-        int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
         /*
          * Need to use the arrays in the iterator, not op, because
          * a copy with a different-sized type may have been made.
@@ -2854,20 +2851,31 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         PyArrayObject *arr = NpyIter_GetOperandArray(iter)[i];
         npy_intp *shape = PyArray_SHAPE(arr);
         npy_intp *strides = PyArray_STRIDES(arr);
-        for (j = 0; j < num_dims; ++j) {
-            if (core_start_dim + j >= 0) {
-                /*
-                 * Force the stride to zero when the shape is 1, so
-                 * that the broadcasting works right.
-                 */
-                int remapped_axis = REMAP_AXIS(i, core_start_dim + j);
+        /*
+         * Could be negative if flexible dims are used, but not for
+         * keepdims, since those dimensions are allocated in arr.
+         */
+        int core_start_dim = PyArray_NDIM(arr) - core_num_dims[i];
+        int num_removed = 0;
+        int dim_offset = ufunc->core_offsets[i];
+
+        for (j = 0; j < ufunc->core_num_dims[i]; ++j) {
+            int core_dim_index = ufunc->core_dim_ixs[dim_offset + j];
+            /*
+             * Force zero stride when the shape is 1 (always the case for
+             * for missing dimensions), so that broadcasting works right.
+             */
+            if (core_dim_flags[core_dim_index] & UFUNC_CORE_DIM_MISSING) {
+                num_removed++;
+                inner_strides[idim++] = 0;
+            }
+            else {
+                int remapped_axis = REMAP_AXIS(i, core_start_dim + j - num_removed);
                 if (shape[remapped_axis] != 1) {
                     inner_strides[idim++] = strides[remapped_axis];
                 } else {
                     inner_strides[idim++] = 0;
                 }
-            } else {
-                inner_strides[idim++] = 0;
             }
         }
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -371,6 +371,9 @@ _get_end_of_name(const char* str, int offset)
     while (_is_alnum_underscore(str[ret])) {
         ret++;
     }
+    if (str[ret] == '?') {
+        ret ++;
+    }
     return ret;
 }
 
@@ -432,11 +435,16 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     /* The next two items will be shrunk later */
     ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len);
     ufunc->core_dim_szs = PyArray_malloc(sizeof(npy_intp) * len);
+    ufunc->core_dim_flexible = PyArray_malloc(sizeof(int) * len);
 
     if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL ||
-        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL) {
+        ufunc->core_offsets == NULL || ufunc->core_dim_szs == NULL ||
+        ufunc->core_dim_flexible == NULL) {
         PyErr_NoMemory();
         goto fail;
+    }
+    for (i = 0; i < len; i++) {
+        ufunc->core_dim_flexible[i] = -1;
     }
 
     i = _next_non_white_space(signature, 0);
@@ -471,7 +479,7 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
 
             if (!_is_alpha_underscore(signature[i]) &&
                 (frozen_size = _get_size(signature + i)) < 0) {
-                parse_error = "expect dimension name or frozen size";
+                parse_error = "expect dimension name or non-zero frozen size";
                 goto fail;
             }
             while (j < ufunc->core_num_dim_ix) {
@@ -486,9 +494,23 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
                 ufunc->core_num_dim_ix++;
             }
             ufunc->core_dim_ixs[cur_core_dim] = j;
+            i = _get_end_of_name(signature, i);
+            if (i > 0 && signature[i - 1] == '?') {
+                if (ufunc->core_dim_flexible[j] == 0) {
+                    parse_error = "? cannot be used, name already seen without ?";
+                    goto fail;
+                }
+                ufunc->core_dim_flexible[j] = 1;
+            }
+            else {
+                if (ufunc->core_dim_flexible[j] == 1) {
+                    parse_error = "? must be used, name already seen with ?";
+                    goto fail;
+                }
+                ufunc->core_dim_flexible[j] = 0;
+            }
             cur_core_dim++;
             nd++;
-            i = _get_end_of_name(signature, i);
             i = _next_non_white_space(signature, i);
             if (signature[i] != ',' && signature[i] != ')') {
                 parse_error = "expect ',' or ')'";
@@ -527,8 +549,10 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     }
     ufunc->core_dim_ixs = PyArray_realloc(ufunc->core_dim_ixs,
             sizeof(int)*cur_core_dim);
-    // ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
-            // sizeof(npy_intp)*ufunc->core_num_dim_ix);
+    ufunc->core_dim_szs = PyArray_realloc(ufunc->core_dim_szs,
+            sizeof(npy_intp)*ufunc->core_num_dim_ix);
+    ufunc->core_dim_flexible = PyArray_realloc(ufunc->core_dim_flexible,
+            sizeof(int)*(ufunc->core_num_dim_ix));
 
     /* check for trivial core-signature, e.g. "(),()->()" */
     if (cur_core_dim == 0) {
@@ -2210,6 +2234,7 @@ _parse_axis_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axis,
  */
 static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
+                   int *core_num_dims, int * flexible_activated,
                    npy_intp* core_dim_sizes, int **remap_axis) {
     int i;
     int nin = ufunc->nin;
@@ -2217,34 +2242,55 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
     int nop = nin + nout;
 
     for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
-        core_dim_sizes[i] = -1;
+        /* support fixed-size dim names */
+        core_dim_sizes[i] = ufunc->core_dim_szs[i];
     }
     for (i = 0; i < nop; ++i) {
         if (op[i] != NULL) {
             int idim;
             int dim_offset = ufunc->core_offsets[i];
-            int num_dims = ufunc->core_num_dims[i];
+            int num_dims = core_num_dims[i];
             int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
+            int dim_delta = 0;
+
+            /* Check if operands have enough dimensions */
+            if (core_start_dim < 0) {
+                PyErr_Format(PyExc_ValueError,
+                        "%s: %s operand %d does not have enough "
+                        "dimensions (has %d, gufunc core with "
+                        "signature %s requires %d)",
+                        ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
+                        i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                        ufunc->core_signature, num_dims);
+                return -1;
+            }
+
             /*
              * Make sure every core dimension exactly matches all other core
              * dimensions with the same label.
              */
-            for (idim = 0; idim < num_dims; ++idim) {
+            for (idim = 0; idim < ufunc->core_num_dims[i]; ++idim) {
                 int core_dim_index = ufunc->core_dim_ixs[dim_offset+idim];
-                npy_intp op_dim_size = PyArray_DIM(
-                    op[i], REMAP_AXIS(i, core_start_dim+idim));
-
+                npy_intp op_dim_size;
+                if (flexible_activated[core_dim_index] > 0) {
+                    op_dim_size = 0;
+                    dim_delta ++;
+                }
+                else {
+                    op_dim_size = PyArray_DIM(op[i],
+                             REMAP_AXIS(i, core_start_dim + idim - dim_delta));
+                }
                 if (core_dim_sizes[core_dim_index] == -1) {
                     core_dim_sizes[core_dim_index] = op_dim_size;
                 }
                 else if (op_dim_size != core_dim_sizes[core_dim_index]) {
                     PyErr_Format(PyExc_ValueError,
-                            "%s: %s operand %d has a mismatch in its "
+                            "1 %s: %s operand %d has a mismatch in its "
                             "core dimension %d, with gufunc "
                             "signature %s (size %zd is different "
                             "from %zd)",
                             ufunc_get_name_cstr(ufunc), i < nin ? "Input" : "Output",
-                            i < nin ? i : i - nin, idim,
+                            i < nin ? i : i - nin, idim - dim_delta,
                             ufunc->core_signature, op_dim_size,
                             core_dim_sizes[core_dim_index]);
                     return -1;
@@ -2270,7 +2316,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
         int out_op;
         for (out_op = nin; out_op < nop; ++out_op) {
             int first_idx = ufunc->core_offsets[out_op];
-            int last_idx = first_idx + ufunc->core_num_dims[out_op];
+            int last_idx = first_idx + core_num_dims[out_op];
             for (i = first_idx; i < last_idx; ++i) {
                 if (ufunc->core_dim_ixs[i] == missing_core_dim) {
                     break;
@@ -2347,6 +2393,8 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     int *core_num_dims;
     int op_axes_arrays[NPY_MAXARGS][NPY_MAXDIMS];
     int *op_axes[NPY_MAXARGS];
+    int n_dims_used[NPY_MAXARGS];
+    int flexible_activated[NPY_MAXARGS];
 
     npy_uint32 op_flags[NPY_MAXARGS];
     npy_intp iter_shape[NPY_MAXARGS];
@@ -2400,6 +2448,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     for (i = 0; i < nop; ++i) {
         dtypes[i] = NULL;
         arr_prep[i] = NULL;
+        n_dims_used[i] = ufunc->core_num_dims[i];
+    }
+    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
+        flexible_activated[i] = (ufunc->core_dim_flexible[i] > 0) ? -1 : 0;
     }
 
     NPY_UF_DBG_PRINT("Getting arguments\n");
@@ -2451,19 +2503,104 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      * (Just checks core; broadcast dimensions are tested by the iterator.)
      */
     for (i = 0; i < nop; i++) {
-        if (op[i] != NULL && PyArray_NDIM(op[i]) < core_num_dims[i]) {
-            PyErr_Format(PyExc_ValueError,
+        /* TODO: store _n_required after parsing, ahead-of-time */
+        int n_required = ufunc->core_num_dims[i];
+        if (n_required > 0) {
+            /* can be less if dim is flexible */
+            for (j = ufunc->core_offsets[i];
+                     j < ufunc->core_offsets[i] + core_num_dims[i]; j++) {
+                int dim_index = ufunc->core_dim_ixs[j];
+                n_required -= ufunc->core_dim_flexible[dim_index];
+            }
+        }
+        if (op[i] != NULL) {
+            n_dims_used[i] = PyArray_NDIM(op[i]);
+            if (n_dims_used[i] < n_required) {
+                PyErr_Format(PyExc_ValueError,
                          "%s: %s operand %d does not have enough "
                          "dimensions (has %d, gufunc core with "
                          "signature %s requires %d)",
                          ufunc_name,
                          i < nin ? "Input" : "Output",
-                         i < nin ? i : i - nin,
-                         PyArray_NDIM(op[i]),
-                         ufunc->core_signature,
-                         core_num_dims[i]);
-            retval = -1;
-            goto fail;
+                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                         ufunc->core_signature, n_required);
+                retval = -1;
+                goto fail;
+            }
+            if (n_dims_used[i] < core_num_dims[i]) {
+                int flexible_used = core_num_dims[i] - n_dims_used[i];
+                /* one (or more?) flexible signature names have been used. Mark them */
+                for (j = ufunc->core_offsets[i];
+                     j < ufunc->core_offsets[i] + core_num_dims[i];
+                     j++) {
+                    int dim_index = ufunc->core_dim_ixs[j];
+                    if (flexible_activated[dim_index] < 0) {
+                        flexible_activated[dim_index] = 1;
+                    }
+                    flexible_used -= flexible_activated[dim_index];
+                    if (flexible_used <= 0) {
+                        break;
+                    }
+                }
+                if (flexible_used > 0) {
+                    PyErr_Format(PyExc_ValueError,
+                         "%s: %s operand %d does not have enough "
+                         "dimensions (has %d, gufunc core with "
+                         "signature %s requires %d)",
+                         ufunc_get_name_cstr(ufunc),
+                         i < nin ? "Input" : "Output",
+                         i < nin ? i : i - nin, PyArray_NDIM(op[i]),
+                         ufunc->core_signature, n_required + flexible_used);
+                    goto fail;
+                }
+            }
+            else {
+                /* never use more than the signature requires */
+                n_dims_used[i] = core_num_dims[i];
+                /* make sure any flexible dimensions are used in the same way */
+                for (j = ufunc->core_offsets[i];
+                     j < ufunc->core_offsets[i] + core_num_dims[i];
+                     j++) {
+                    if (j <= ufunc->core_num_dim_ix) {
+                        int dim_index = ufunc->core_dim_ixs[j];
+                        if (flexible_activated[dim_index] < 0) {
+                            flexible_activated[dim_index] = 0;
+                        }
+                        else if (flexible_activated[dim_index] == 1) {
+                            PyErr_Format(PyExc_ValueError,
+                                "%s: %s operand %d with flexible dimension "
+                                "index %d signature %s previouosly marked "
+                                "flexible but now is not",
+                                 ufunc_get_name_cstr(ufunc),
+                                 i < nin ? "Input" : "Output",
+                                 i < nin ? i : i - nin, dim_index,
+                                 ufunc->core_signature);
+                            goto fail;
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            /* NULL output provided. Use flexible_used to determine ndims_used */
+            n_dims_used[i] = core_num_dims[i];
+            for (j = ufunc->core_offsets[i];
+                 j < ufunc->core_offsets[i] + core_num_dims[i]; j++) {
+                if (j <= ufunc->core_num_dim_ix) {
+                    int dim_index = ufunc->core_dim_ixs[j];
+                    if (flexible_activated[dim_index] < 0) {
+                        PyErr_Format(PyExc_ValueError,
+                            "%s: %s operand %d with flexible dimension index "
+                            " %d signature %s cannot be uniquely determined",
+                            ufunc_get_name_cstr(ufunc),
+                            i < nin ? "Input" : "Output",
+                            i < nin ? i : i - nin, dim_index,
+                            ufunc->core_signature);
+                        goto fail;
+                    }
+                    n_dims_used[i] -= flexible_activated[dim_index];
+                }
+            }
         }
     }
 
@@ -2474,7 +2611,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     broadcast_ndim = 0;
     for (i = 0; i < nin; ++i) {
-        int n = PyArray_NDIM(op[i]) - core_num_dims[i];
+        int n = PyArray_NDIM(op[i]) - n_dims_used[i];
         if (n > broadcast_ndim) {
             broadcast_ndim = n;
         }
@@ -2488,7 +2625,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     iter_ndim = broadcast_ndim;
     for (i = nin; i < nop; ++i) {
-        iter_ndim += core_num_dims[i];
+        iter_ndim += n_dims_used[i];
     }
     if (iter_ndim > NPY_MAXDIMS) {
         PyErr_Format(PyExc_ValueError,
@@ -2522,20 +2659,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
             goto fail;
         }
     }
-    /*
-     * Validate the core dimensions of all the operands,
-     * and collect all of the labeled core dimension sizes
-     * into the array 'core_dim_sizes'. Initialize them to
-     * 1, for example in the case where the operand broadcasts
-     * to a core dimension, it won't be visited.
-     */
-    for (i = 0; i < ufunc->core_num_dim_ix; ++i) {
-        npy_intp frozen_size = ufunc->core_dim_szs[i];
-        core_dim_sizes[i] = frozen_size == -1 ? 1 : frozen_size;
-    }
 
     /* Collect the lengths of the labelled core dimensions */
-    retval = _get_coredim_sizes(ufunc, op, core_dim_sizes, remap_axis);
+    retval = _get_coredim_sizes(ufunc, op, n_dims_used, flexible_activated,
+                                core_dim_sizes, remap_axis);
     if(retval < 0) {
         goto fail;
     }
@@ -2551,11 +2678,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         int n;
 
         if (op[i]) {
-            /*
-             * Note that n may be negative if broadcasting
-             * extends into the core dimensions.
-             */
-            n = PyArray_NDIM(op[i]) - core_num_dims[i];
+            n = PyArray_NDIM(op[i]) - n_dims_used[i];
         }
         else {
             n = broadcast_ndim;
@@ -2580,16 +2703,27 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         if (i >= nin) {
             int dim_offset = ufunc->core_offsets[i];
             int num_dims = core_num_dims[i];
+            int has_flexible=0;
             /*
              * Fill in 'iter_shape' and 'op_axes' for the core dimensions
              * of this output. Here, we have to be careful: if keepdims
-             * was used, then this axis is not a real core dimension,
-             * but is being added back for broadcasting, so its size is 1.
+             * was used or if it is a flexible dimension, then this axis
+             * is not a real core dimension, but is being added back for broadcasting,
+             * so its size is 1.
              */
             for (idim = 0; idim < num_dims; ++idim) {
-                iter_shape[j] = keepdims ? 1 : core_dim_sizes[
-                                        ufunc->core_dim_ixs[dim_offset + idim]];
-                op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim);
+                if (keepdims) {
+                    iter_shape[j] = 1;
+                } else {
+                    int core_index = ufunc->core_dim_ixs[dim_offset + idim];
+                    if (flexible_activated[core_index]) {
+                        /* skip it */
+                        has_flexible ++;
+                        continue;
+                    }
+                    iter_shape[j] = core_dim_sizes[core_index];
+                }
+                op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim - has_flexible);
                 ++j;
             }
         }
@@ -2720,6 +2854,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     idim = nop;
     for (i = 0; i < nop; ++i) {
         int num_dims = ufunc->core_num_dims[i];
+        /* Could be negative if flexible dims are used, or if keepdims */
         int core_start_dim = PyArray_NDIM(op[i]) - num_dims;
         /*
          * Need to use the arrays in the iterator, not op, because

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1989,7 +1989,7 @@ fail:
 static int
 _validate_num_dims(PyUFuncObject *ufunc, PyArrayObject **op,
                    npy_uint32 *core_dim_flags,
-                   int *n_dims_used) {
+                   int *op_core_num_dims) {
     int i, j;
     int nin = ufunc->nin;
     int nop = ufunc->nargs;
@@ -1998,7 +1998,7 @@ _validate_num_dims(PyUFuncObject *ufunc, PyArrayObject **op,
         if (op[i] != NULL) {
             int op_ndim = PyArray_NDIM(op[i]);
 
-            if (op_ndim < n_dims_used[i]) {
+            if (op_ndim < op_core_num_dims[i]) {
                 int core_offset = ufunc->core_offsets[i];
                 /* We've too few, but some dimensions might be flexible */
                 for (j = core_offset;
@@ -2022,16 +2022,16 @@ _validate_num_dims(PyUFuncObject *ufunc, PyArrayObject **op,
                         for (i1 = 0, k=0; i1 < nop; i1++) {
                             for (j1 = 0; j1 < ufunc->core_num_dims[i1]; j1++) {
                                 if (ufunc->core_dim_ixs[k++] == core_dim_index) {
-                                    n_dims_used[i1]--;
+                                    op_core_num_dims[i1]--;
                                 }
                             }
                         }
-                        if (op_ndim == n_dims_used[i]) {
+                        if (op_ndim == op_core_num_dims[i]) {
                             break;
                         }
                     }
                 }
-                if (op_ndim < n_dims_used[i]) {
+                if (op_ndim < op_core_num_dims[i]) {
                     goto fail;
                 }
             }
@@ -2047,7 +2047,7 @@ fail:
                  ufunc_get_name_cstr(ufunc),
                  i < nin ? "Input" : "Output",
                  i < nin ? i : i - nin, PyArray_NDIM(op[i]),
-                 ufunc->core_signature, n_dims_used[i]);
+                 ufunc->core_signature, op_core_num_dims[i]);
     return -1;
 }
 
@@ -2124,7 +2124,7 @@ _check_keepdims_support(PyUFuncObject *ufunc) {
  * Returns 0 on success, and -1 on failure
  */
 static int
-_parse_axes_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axes,
+_parse_axes_arg(PyUFuncObject *ufunc, int op_core_num_dims[], PyObject *axes,
                 PyArrayObject **op, int broadcast_ndim, int **remap_axis) {
     int nin = ufunc->nin;
     int nop = ufunc->nargs;
@@ -2154,7 +2154,7 @@ _parse_axes_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axes,
         PyObject *op_axes_tuple, *axis_item;
         int axis, op_axis;
 
-        op_ncore = core_num_dims[iop];
+        op_ncore = op_core_num_dims[iop];
         if (op[iop] != NULL) {
             op_ndim = PyArray_NDIM(op[iop]);
             op_nbroadcast = op_ndim - op_ncore;
@@ -2325,7 +2325,7 @@ _parse_axis_arg(PyUFuncObject *ufunc, int core_num_dims[], PyObject *axis,
  */
 static int
 _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
-                   int *core_num_dims, npy_uint32 *core_dim_flags,
+                   int *op_core_num_dims, npy_uint32 *core_dim_flags,
                    npy_intp *core_dim_sizes, int **remap_axis) {
     int i;
     int nin = ufunc->nin;
@@ -2336,7 +2336,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
         if (op[i] != NULL) {
             int idim;
             int dim_offset = ufunc->core_offsets[i];
-            int core_start_dim = PyArray_NDIM(op[i]) - core_num_dims[i];
+            int core_start_dim = PyArray_NDIM(op[i]) - op_core_num_dims[i];
             int dim_delta = 0;
 
             /* checked before this routine gets called */
@@ -2452,13 +2452,13 @@ _get_identity(PyUFuncObject *ufunc, npy_bool *reorderable) {
  */
 static int
 _initialize_variable_parts(PyUFuncObject *ufunc,
-                           int core_num_dims[],
+                           int op_core_num_dims[],
                            npy_intp core_dim_sizes[],
                            npy_uint32 core_dim_flags[]) {
     int i;
 
     for (i = 0; i < ufunc->nargs; i++) {
-        core_num_dims[i] = ufunc->core_num_dims[i];
+        op_core_num_dims[i] = ufunc->core_num_dims[i];
     }
     if (ufunc->version == 1) {
         for (i = 0; i < ufunc->core_num_dim_ix; i++) {
@@ -2496,7 +2496,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
     /* Use remapped axes for generalized ufunc */
     int broadcast_ndim, iter_ndim;
-    int core_num_dims[NPY_MAXARGS];
+    int op_core_num_dims[NPY_MAXARGS];
     int op_axes_arrays[NPY_MAXARGS][NPY_MAXDIMS];
     int *op_axes[NPY_MAXARGS];
     npy_uint32 core_dim_flags[NPY_MAXARGS];
@@ -2555,7 +2555,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         arr_prep[i] = NULL;
     }
     /* Initialize possibly variable parts to the values from the ufunc */
-    retval = _initialize_variable_parts(ufunc, core_num_dims,
+    retval = _initialize_variable_parts(ufunc, op_core_num_dims,
                                         core_dim_sizes, core_dim_flags);
     if (retval < 0) {
         goto fail;
@@ -2595,9 +2595,9 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      * the same.  Signal all output dimensions will be the same too.
      */
     if (keepdims == 1) {
-        int num_dims = core_num_dims[0];
+        int num_dims = op_core_num_dims[0];
         for (i = nin; i < nop; ++i) {
-            core_num_dims[i] = num_dims;
+            op_core_num_dims[i] = num_dims;
         }
     }
     else {
@@ -2609,7 +2609,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      * (Just checks core; broadcast dimensions are tested by the iterator.)
      */
     retval = _validate_num_dims(ufunc, op, core_dim_flags,
-                                core_num_dims);
+                                op_core_num_dims);
     if (retval < 0) {
         goto fail;
     }
@@ -2620,7 +2620,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     broadcast_ndim = 0;
     for (i = 0; i < nin; ++i) {
-        int n = PyArray_NDIM(op[i]) - core_num_dims[i];
+        int n = PyArray_NDIM(op[i]) - op_core_num_dims[i];
         if (n > broadcast_ndim) {
             broadcast_ndim = n;
         }
@@ -2639,11 +2639,11 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
             remap_axis[i] = remap_axis_memory + i * NPY_MAXDIMS;
         }
         if (axis) {
-            retval = _parse_axis_arg(ufunc, core_num_dims, axis, op,
+            retval = _parse_axis_arg(ufunc, op_core_num_dims, axis, op,
                                      broadcast_ndim, remap_axis);
         }
         else {
-            retval = _parse_axes_arg(ufunc, core_num_dims, axes, op,
+            retval = _parse_axes_arg(ufunc, op_core_num_dims, axes, op,
                                      broadcast_ndim, remap_axis);
         }
         if(retval < 0) {
@@ -2652,7 +2652,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     }
 
     /* Collect the lengths of the labelled core dimensions */
-    retval = _get_coredim_sizes(ufunc, op, core_num_dims, core_dim_flags,
+    retval = _get_coredim_sizes(ufunc, op, op_core_num_dims, core_dim_flags,
                                 core_dim_sizes, remap_axis);
     if(retval < 0) {
         goto fail;
@@ -2665,7 +2665,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     iter_ndim = broadcast_ndim;
     for (i = nin; i < nop; ++i) {
-        iter_ndim += core_num_dims[i];
+        iter_ndim += op_core_num_dims[i];
     }
     if (iter_ndim > NPY_MAXDIMS) {
         PyErr_Format(PyExc_ValueError,
@@ -2686,7 +2686,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
         int n;
 
         if (op[i]) {
-            n = PyArray_NDIM(op[i]) - core_num_dims[i];
+            n = PyArray_NDIM(op[i]) - op_core_num_dims[i];
         }
         else {
             n = broadcast_ndim;
@@ -2719,7 +2719,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
              * If the axis was removed, we should skip altogether.
              */
             if (keepdims) {
-                for (idim = 0; idim < core_num_dims[i]; ++idim) {
+                for (idim = 0; idim < op_core_num_dims[i]; ++idim) {
                     iter_shape[j] = 1;
                     op_axes_arrays[i][j] = REMAP_AXIS(i, n + idim);
                     ++j;
@@ -2886,7 +2886,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
          * Could be negative if flexible dims are used, but not for
          * keepdims, since those dimensions are allocated in arr.
          */
-        int core_start_dim = PyArray_NDIM(arr) - core_num_dims[i];
+        int core_start_dim = PyArray_NDIM(arr) - op_core_num_dims[i];
         int num_removed = 0;
         int dim_offset = ufunc->core_offsets[i];
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -288,17 +288,45 @@ class TestUfunc(object):
 
     def test_signature(self):
         # the arguments to test_signature are: nin, nout, core_signature
-        # pass
-        enabled, num_dims, ixs = umt.test_signature(2, 1, "(i),(i)->()")
+        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(i),(i)->()")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1,  1,  0))
         assert_equal(ixs, (0, 0))
+        assert_equal(szs, (-1,))
 
         # empty core signature; treat as plain ufunc (with trivial core)
-        enabled, num_dims, ixs = umt.test_signature(2, 1, "(),()->()")
+        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(),()->()")
         assert_equal(enabled, 0)
         assert_equal(num_dims, (0,  0,  0))
         assert_equal(ixs, ())
+        assert_equal(szs, ())
+
+        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(n,k),(k,m)->(n,m)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 2, 2))
+        assert_equal(ixs, (0, 1, 1, 2, 0, 2))
+        assert_equal(szs, (-1, -1, -1))
+
+        # more complicated names for variables
+        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 1, 1))
+        assert_equal(ixs, (0, 1, 2, 3))
+        assert_equal(szs, (-1, -1, -1, -1))
+
+        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 1, 2))
+        assert_equal(ixs, (0, 1, 2, 1, 3))
+        assert_equal(szs, (-1, -1, -1, -1))
+        assert_equal(flex, (0, 0, 0, 0))
+
+        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(n?,k),(k,m?)->(n?,m?)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 2, 2))
+        assert_equal(ixs, (0, 1, 1, 2, 0, 2))
+        assert_equal(szs, (-1, -1, -1))
+        assert_equal(flex, (1, 0, 1))
 
         # in the following calls, a ValueError should be raised because
         # of error in core signature
@@ -335,12 +363,6 @@ class TestUfunc(object):
             assert_equal(ret, None, err_msg=msg)
         except ValueError:
             pass
-
-        # more complicated names for variables
-        enabled, num_dims, ixs = umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)")
-        assert_equal(enabled, 1)
-        assert_equal(num_dims, (2, 1, 1))
-        assert_equal(ixs, (0, 1, 2, 3))
 
     def test_get_signature(self):
         assert_equal(umt.inner1d.signature, "(i),(i)->()")

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -944,7 +944,15 @@ class TestUfunc(object):
     def test_all_equal(self):
         a = np.arange(6).reshape((2, 3))
         b = np.arange(3)
-        assert_array_equal(umt.all_equal(a, b), np.all(a == b, axis=-1))
+        assert_array_equal(umt.all_equal(a, b), [True, False])
+        b = np.array([1])
+        assert_array_equal(umt.all_equal(a, b), [False, False])
+        assert_array_equal(umt.all_equal(b, a), [False, False])
+        a = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+        assert_array_equal(umt.all_equal(a, b), [False, True, False])
+        assert_array_equal(umt.all_equal(b, a), [False, True, False])
+        b = np.array([[0], [1], [2]])
+        assert_array_equal(umt.all_equal(a, b), [True, True, True])
 
     def test_innerwt(self):
         a = np.arange(6).reshape((2, 3))

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -367,6 +367,34 @@ class TestUfunc(object):
         assert_equal(flags, (can_ignore, size_unset, 0))
         assert_equal(sizes, (3, -1, 9))
 
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, '(n|1),(n|1) -> ()')
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 1, 0))
+        assert_equal(ixs, (0, 0))
+        assert_equal(flags, (4,))
+        assert_equal(sizes, (-1,))
+
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, '(n|1),(n|1) -> (n)')
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 1, 1))
+        assert_equal(ixs, (0, 0, 0))
+        assert_equal(flags, (4,))
+        assert_equal(sizes, (-1,))
+
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            3, 1, '(3|1),(n),(3|1) -> ()')
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 1, 1, 0))
+        assert_equal(ixs, (0, 1, 0))
+        assert_equal(flags, (5, 0))
+        assert_equal(sizes, (3, -1))
+
+        # No broadcasting outputs.
+        assert_raises(ValueError, umt.test_signature, 1, 1, "(n|1),(n|1)->(n|1)")
+        # Broadcast on single input is meaningless.
+        assert_raises(ValueError, umt.test_signature, 1, 1, "(n|1)->()")
         # in the following calls, a ValueError should be raised because
         # of error in core signature
         # FIXME These should be using assert_raises

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -352,7 +352,7 @@ class TestUfunc(object):
         assert_equal(sizes, (3,))
 
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            3, 1, "(3),(3,3),(n)->(9)")
+            3, 1, "(3),(03,3),(n)->(9)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1, 2, 1, 1))
         assert_equal(ixs, (0, 0, 0, 1, 2))

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -287,46 +287,85 @@ class TestUfunc(object):
         pass
 
     def test_signature(self):
+        # from include/numpy/ufuncobject.h
+        size_unset = 2
+        can_ignore = 4
         # the arguments to test_signature are: nin, nout, core_signature
-        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(i),(i)->()")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, "(i),(i)->()")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1,  1,  0))
         assert_equal(ixs, (0, 0))
-        assert_equal(szs, (-1,))
+        assert_equal(flags, (size_unset,))
+        assert_equal(sizes, (-1,))
 
         # empty core signature; treat as plain ufunc (with trivial core)
-        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(),()->()")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, "(),()->()")
         assert_equal(enabled, 0)
         assert_equal(num_dims, (0,  0,  0))
         assert_equal(ixs, ())
-        assert_equal(szs, ())
-
-        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(n,k),(k,m)->(n,m)")
-        assert_equal(enabled, 1)
-        assert_equal(num_dims, (2, 2, 2))
-        assert_equal(ixs, (0, 1, 1, 2, 0, 2))
-        assert_equal(szs, (-1, -1, -1))
+        assert_equal(flags, ())
+        assert_equal(sizes, ())
 
         # more complicated names for variables
-        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(i1,i2),(J_1)->(_kAB)")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, "(i1,i2),(J_1)->(_kAB)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 1, 1))
         assert_equal(ixs, (0, 1, 2, 3))
-        assert_equal(szs, (-1, -1, -1, -1))
+        assert_equal(flags, (size_unset,)*4)
+        assert_equal(sizes, (-1, -1, -1, -1))
 
-        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 1, 2))
         assert_equal(ixs, (0, 1, 2, 1, 3))
-        assert_equal(szs, (-1, -1, -1, -1))
-        assert_equal(flex, (0, 0, 0, 0))
-
-        enabled, num_dims, ixs, szs, flex = umt.test_signature(2, 1, "(n?,k),(k,m?)->(n?,m?)")
+        assert_equal(flags, (size_unset,)*4)
+        assert_equal(sizes, (-1, -1, -1, -1))
+        # matrix_multiply signature from _umath_tests
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, "(n,k),(k,m)->(n,m)")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 2, 2))
         assert_equal(ixs, (0, 1, 1, 2, 0, 2))
-        assert_equal(szs, (-1, -1, -1))
-        assert_equal(flex, (1, 0, 1))
+        assert_equal(flags, (size_unset,)*3)
+        assert_equal(sizes, (-1, -1, -1))
+        # matmul signature from _umath_tests
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            2, 1, "(n?,k),(k,m?)->(n?,m?)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (2, 2, 2))
+        assert_equal(ixs, (0, 1, 1, 2, 0, 2))
+        assert_equal(flags, (size_unset | can_ignore,
+                             size_unset,
+                             size_unset | can_ignore))
+        assert_equal(sizes, (-1, -1, -1))
+
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            1, 1, "(3)->()")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 0))
+        assert_equal(ixs, (0,))
+        assert_equal(flags, (0,))
+        assert_equal(sizes, (3,))
+
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            3, 1, "(3),(3,3),(n)->(9)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 2, 1, 1))
+        assert_equal(ixs, (0, 0, 0, 1, 2))
+        assert_equal(flags, (0, size_unset, 0))
+        assert_equal(sizes, (3, -1, 9))
+
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            3, 1, "(3?),(3?,3?),(n)->(9)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 2, 1, 1))
+        assert_equal(ixs, (0, 0, 0, 1, 2))
+        assert_equal(flags, (can_ignore, size_unset, 0))
+        assert_equal(sizes, (3, -1, 9))
 
         # in the following calls, a ValueError should be raised because
         # of error in core signature
@@ -887,6 +926,89 @@ class TestUfunc(object):
         b = np.array([], dtype='f8')
         w = np.array([], dtype='f8')
         assert_array_equal(umt.innerwt(a, b, w), np.sum(a*b*w, axis=-1))
+
+    def test_cross1d(self):
+        """Test with fixed-sized signature."""
+        a = np.eye(3)
+        assert_array_equal(umt.cross1d(a, a), np.zeros((3, 3)))
+        out = np.zeros((3, 3))
+        result = umt.cross1d(a[0], a, out)
+        assert_(result is out)
+        assert_array_equal(result, np.vstack((np.zeros(3), a[2], -a[1])))
+        assert_raises(ValueError, umt.cross1d, np.eye(4), np.eye(4))
+        assert_raises(ValueError, umt.cross1d, a, np.arange(4.))
+        assert_raises(ValueError, umt.cross1d, a, np.arange(3.), np.zeros((3, 4)))
+
+    def test_can_ignore_signature(self):
+        # Comparing the effects of ? in signature:
+        # matrix_multiply: (m,n),(n,p)->(m,p)    # all must be there.
+        # matmul:        (m?,n),(n,p?)->(m?,p?)  # allow missing m, p.
+        mat = np.arange(12).reshape((2, 3, 2))
+        single_vec = np.arange(2)
+        col_vec = single_vec[:, np.newaxis]
+        col_vec_array = np.arange(8).reshape((2, 2, 2, 1)) + 1
+        # matrix @ single column vector with proper dimension
+        mm_col_vec = umt.matrix_multiply(mat, col_vec)
+        # matmul does the same thing
+        matmul_col_vec = umt.matmul(mat, col_vec)
+        assert_array_equal(matmul_col_vec, mm_col_vec)
+        # matrix @ vector without dimension making it a column vector.
+        # matrix multiply fails -> missing core dim.
+        assert_raises(ValueError, umt.matrix_multiply, mat, single_vec)
+        # matmul mimicker passes, and returns a vector.
+        matmul_col = umt.matmul(mat, single_vec)
+        assert_array_equal(matmul_col, mm_col_vec.squeeze())
+        # Now with a column array: same as for column vector,
+        # broadcasting sensibly.
+        mm_col_vec = umt.matrix_multiply(mat, col_vec_array)
+        matmul_col_vec = umt.matmul(mat, col_vec_array)
+        assert_array_equal(matmul_col_vec, mm_col_vec)
+        # As above, but for row vector
+        single_vec = np.arange(3)
+        row_vec = single_vec[np.newaxis, :]
+        row_vec_array = np.arange(24).reshape((4, 2, 1, 1, 3)) + 1
+        # row vector @ matrix
+        mm_row_vec = umt.matrix_multiply(row_vec, mat)
+        matmul_row_vec = umt.matmul(row_vec, mat)
+        assert_array_equal(matmul_row_vec, mm_row_vec)
+        # single row vector @ matrix
+        assert_raises(ValueError, umt.matrix_multiply, single_vec, mat)
+        matmul_row = umt.matmul(single_vec, mat)
+        assert_array_equal(matmul_row, mm_row_vec.squeeze())
+        # row vector array @ matrix
+        mm_row_vec = umt.matrix_multiply(row_vec_array, mat)
+        matmul_row_vec = umt.matmul(row_vec_array, mat)
+        assert_array_equal(matmul_row_vec, mm_row_vec)
+        # Now for vector combinations
+        # row vector @ column vector
+        col_vec = row_vec.T
+        col_vec_array = row_vec_array.swapaxes(-2, -1)
+        mm_row_col_vec = umt.matrix_multiply(row_vec, col_vec)
+        matmul_row_col_vec = umt.matmul(row_vec, col_vec)
+        assert_array_equal(matmul_row_col_vec, mm_row_col_vec)
+        # single row vector @ single col vector
+        assert_raises(ValueError, umt.matrix_multiply, single_vec, single_vec)
+        matmul_row_col = umt.matmul(single_vec, single_vec)
+        assert_array_equal(matmul_row_col, mm_row_col_vec.squeeze())
+        # row vector array @ matrix
+        mm_row_col_array = umt.matrix_multiply(row_vec_array, col_vec_array)
+        matmul_row_col_array = umt.matmul(row_vec_array, col_vec_array)
+        assert_array_equal(matmul_row_col_array, mm_row_col_array)
+        # Finally, check that things are *not* squeezed if one gives an
+        # output.
+        out = np.zeros_like(mm_row_col_array)
+        out = umt.matrix_multiply(row_vec_array, col_vec_array, out=out)
+        assert_array_equal(out, mm_row_col_array)
+        out[:] = 0
+        out = umt.matmul(row_vec_array, col_vec_array, out=out)
+        assert_array_equal(out, mm_row_col_array)
+        # And check one cannot put missing dimensions back.
+        out = np.zeros_like(mm_row_col_vec)
+        assert_raises(ValueError, umt.matrix_multiply, single_vec, single_vec,
+                      out)
+        # But fine for matmul, since it is just a broadcast.
+        out = umt.matmul(single_vec, single_vec, out)
+        assert_array_equal(out, mm_row_col_vec.squeeze())
 
     def test_matrix_multiply(self):
         self.compare_matrix_multiply_results(np.long)


### PR DESCRIPTION
Builds on #11175 to include allowing broadcasting in `gufuncs` (which now is surprisingly easy)>

With this, @mattharrigan's `all_equal` (#8528) would become truly useful, as it also allows things like `np.all_equal(ndarray, const, axis=?)`, i.e., one of the arguments can be broadcast over its core.

EDIT: has decent tests but does still need docs.