### PR TITLE
BUG: reduce using SSE only warns if inside SSE loop

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1822,6 +1822,9 @@ NPY_NO_EXPORT void
                 const @type@ in2 = *(@type@ *)ip2;
                 io1 = (io1 @OP@ in2 || npy_isnan(io1)) ? io1 : in2;
             }
+            if (npy_isnan(io1)) {
+                npy_set_floatstatus_invalid();
+            }
             *((@type@ *)iop1) = io1;
         }
     }

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -860,6 +860,9 @@ sse2_@kind@_@TYPE@(@type@ * ip, @type@ * op, const npy_intp n)
     LOOP_BLOCKED_END {
         *op  = (*op @OP@ ip[i] || npy_isnan(*op)) ? *op : ip[i];
     }
+    if (npy_isnan(*op)) {
+        npy_set_floatstatus_invalid();
+    }
 }
 /**end repeat1**/
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1328,14 +1328,15 @@ class TestMinMax(object):
         assert_equal(d.min(), d[0])
 
     def test_reduce_warns(self):
-        # gh 10370 Some compilers reorder the call to npy_getfloatstatus and
-        # put it before the call to an intrisic function that causes invalid
-        # status to be set
+        # gh 10370, 11029 Some compilers reorder the call to npy_getfloatstatus
+        # and put it before the call to an intrisic function that causes
+        # invalid status to be set. Also make sure warnings are emitted
         for n in (2, 4, 8, 16, 32):
             with suppress_warnings() as sup:
                 sup.record(RuntimeWarning)
                 for r in np.diagflat([np.nan] * n):
                     assert_equal(np.min(r), np.nan)
+                assert_equal(len(sup.log), n)
 
 
 class TestAbsoluteNegative(object):


### PR DESCRIPTION
Backport of #11043.

Make sure `ufunc.reduce` commands warn on invalid value.