### PR TITLE
BUG: Fix mean padding with np.pad so that prepended values cannot bias appended ones

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1295,6 +1295,12 @@ def pad(array, pad_width, mode, **kwargs):
     elif mode == 'mean':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
+            if pad_before != 0:
+                # we must exclude the prepended values from the statistics
+                if chunk_after is None:
+                    chunk_after = newmat.shape[axis]
+                else:
+                    chunk_after = min(chunk_after, newmat.shape[axis])
             newmat = _prepend_mean(newmat, pad_before, chunk_before, axis)
             newmat = _append_mean(newmat, pad_after, chunk_after, axis)
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -4,7 +4,7 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_raises, assert_allclose,)
+from numpy.testing import (assert_equal, assert_array_equal, assert_raises, assert_allclose,)
 from numpy.lib import pad
 
 
@@ -343,6 +343,13 @@ class TestStatistic(object):
              49.5, 49.5, 49.5, 49.5, 49.5, 49.5, 49.5, 49.5, 49.5, 49.5]
             )
         assert_array_equal(a, b)
+
+    def test_check_mean_ignore_prepend(self):
+        # check that prepended values don't bias the appended mean
+        a = np.array([-1, 2 + 1e-12, -1], dtype=np.float64)
+        a = pad(a, (1, 1), 'mean')
+        front_pad, end_pad = a[0], a[-1]
+        assert_equal(front_pad, end_pad)
 
 
 class TestConstant(object):


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/11216.

In the appending step of `np.pad` we explicitly set the sampling size to be (at most) the original size of the array along the corresponding dimension. In case of `min` and `max` padding this problem doesn't arise, and I believe `median` padding should be safe too. I guess the code could be refactored such that statistics are only computed once when no `stat_length` is given, but I wanted to fix the original bug with minimal changes.

I also added `numpy/lib/tests/test_arraypad.py:test_check_mean_ignore_prepend` to test the problem, which fails in master and passes with this patch.