### PR TITLE
BUG: Forcibly promote shape to uint64 in numpy.memmap.

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -236,11 +236,11 @@ class memmap(ndarray):
                 raise ValueError("Size of available data is not a "
                         "multiple of the data-type size.")
             size = bytes // _dbytes
-            shape = (np.uint64(size),)
+            shape = (np.intp(size),)
         else:
             if not isinstance(shape, tuple):
                 shape = (shape,)
-            shape = tuple(map(lambda x: np.uint64(x), shape)) # Force-promote to uint64, prevent possible overflow 
+            shape = tuple(map(lambda x: np.intp(x), shape)) # Force-promote to intp, prevent possible overflow with 32-bit types near the top of their range
             size = 1
             for k in shape:
                 size *= k

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -236,11 +236,10 @@ class memmap(ndarray):
                 raise ValueError("Size of available data is not a "
                         "multiple of the data-type size.")
             size = bytes // _dbytes
-            shape = (np.intp(size),)
         else:
             if not isinstance(shape, tuple):
                 shape = (shape,)
-            size = np.intp(1) # Causes bytes below to be computed as largest integer type available to prevent overflow
+            size = np.intp(1) # Causes bytes below to be computed as the integer type the OS uses for sizes - can prevent overflow
             for k in shape:
                 size *= k
 

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -236,10 +236,11 @@ class memmap(ndarray):
                 raise ValueError("Size of available data is not a "
                         "multiple of the data-type size.")
             size = bytes // _dbytes
-            shape = (size,)
+            shape = (np.uint64(size),)
         else:
             if not isinstance(shape, tuple):
                 shape = (shape,)
+            shape = tuple(map(lambda x: np.uint64(x), shape)) # Force-promote to uint64, prevent possible overflow 
             size = 1
             for k in shape:
                 size *= k

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -239,7 +239,7 @@ class memmap(ndarray):
         else:
             if not isinstance(shape, tuple):
                 shape = (shape,)
-            size = np.intp(1) # Causes bytes below to be computed as the integer type the OS uses for sizes - can prevent overflow
+            size = np.intp(1)  # avoid default choice of np.int_, which might overflow
             for k in shape:
                 size *= k
 

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -240,8 +240,7 @@ class memmap(ndarray):
         else:
             if not isinstance(shape, tuple):
                 shape = (shape,)
-            shape = tuple(map(lambda x: np.intp(x), shape)) # Force-promote to intp, prevent possible overflow with 32-bit types near the top of their range
-            size = 1
+            size = np.intp(1) # Causes bytes below to be computed as largest integer type available to prevent overflow
             for k in shape:
                 size *= k
 


### PR DESCRIPTION
It is possible (we've seen instances on Windows) if people pass in np.int32 values in their shape parameter to numpy.memmap(), for those values to overflow during the multiply in the initial calculation of the "bytes" variable, for large memmaps.

Locally we've adjusted our code to explicitly promote all of our shapes to uint64 to avoid this; it feels more right to do this promotion inside of the memmap constructor so this can't come up (hence this PR)

Possible things to think about:
1) If there are ever platforms with even larger datatypes where gigantic memmaps are possible, this might end up demoting rather than promoting them (seems unlikely to me)
2) If there are ever numeric datatypes that don't promote cleanly into np.uint64, or platforms where np.uint64 is not a valid type, this would break that code (not sure whether numpy is compatible with such platforms)