### PR TITLE
DOC: add existing recfunctions documentation to output

### DIFF
--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -5,3 +5,9 @@ Structured arrays
 *****************
 
 .. automodule:: numpy.doc.structured_arrays
+
+Helper Funtions
+***************
+
+.. automodule:: numpy.lib.recfunctions
+    :members:

--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -6,8 +6,8 @@ Structured arrays
 
 .. automodule:: numpy.doc.structured_arrays
 
-Helper Funtions
-***************
+Recarray Helper Functions
+*************************
 
 .. automodule:: numpy.lib.recfunctions
     :members:

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -397,12 +397,13 @@ def merge_arrays(seqarrays, fill_value=-1, flatten=False,
     Notes
     -----
     * Without a mask, the missing value will be filled with something,
-    * depending on what its corresponding type:
-            -1      for integers
-            -1.0    for floating point numbers
-            '-'     for characters
-            '-1'    for strings
-            True    for boolean values
+      depending on what its corresponding type:
+
+      * ``-1``      for integers
+      * ``-1.0``    for floating point numbers
+      * ``'-'``     for characters
+      * ``'-1'``    for strings
+      * ``True``    for boolean values
     * XXX: I just obtained these values empirically
     """
     # Only one item in the input sequence ?


### PR DESCRIPTION
The `numpy.lib.recfunctions` module was not baked into the documentation build.

This PR adds it together with one minor formatting cleanup in the docstrings. Tested by building `make html` lcoally and manually inspecting the result