### PR TITLE
MAINT: Don't update the flags a second time

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1358,8 +1358,6 @@ _array_from_buffer_3118(PyObject *memoryview)
     if (PyArray_SetBaseObject((PyArrayObject *)r, memoryview) < 0) {
         goto fail;
     }
-    PyArray_UpdateFlags((PyArrayObject *)r, NPY_ARRAY_UPDATE_ALL);
-
     return r;
 
 fail:
@@ -2124,7 +2122,6 @@ PyArray_FromStructInterface(PyObject *input)
         return NULL;
     }
     Py_DECREF(attr);
-    PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
     return (PyObject *)ret;
 
  fail:

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -388,8 +388,6 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
         Py_DECREF(ret);
         return NULL;
     }
-
-    PyArray_UpdateFlags((PyArrayObject *)ret, NPY_ARRAY_UPDATE_ALL);
     return ret;
 }
 

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1153,8 +1153,6 @@ NpyIter_GetIterView(NpyIter *iter, npy_intp i)
         Py_DECREF(view);
         return NULL;
     }
-    /* Make sure all the flags are good */
-    PyArray_UpdateFlags(view, NPY_ARRAY_UPDATE_ALL);
 
     return view;
 }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -2675,9 +2675,6 @@ npyiter_new_temp_array(NpyIter *iter, PyTypeObject *subtype,
         return NULL;
     }
 
-    /* Make sure all the flags are good */
-    PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
-
     /* Double-check that the subtype didn't mess with the dimensions */
     if (subtype != &PyArray_Type) {
         if (PyArray_NDIM(ret) != op_ndim ||

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2077,8 +2077,6 @@ npyiter_seq_item(NewNpyArrayIterObject *self, Py_ssize_t i)
         return NULL;
     }
 
-    PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
-
     return (PyObject *)ret;
 }
 
@@ -2215,8 +2213,6 @@ npyiter_seq_ass_item(NewNpyArrayIterObject *self, Py_ssize_t i, PyObject *v)
     if (tmp == NULL) {
         return -1;
     }
-
-    PyArray_UpdateFlags(tmp, NPY_ARRAY_UPDATE_ALL);
 
     ret = PyArray_CopyObject(tmp, v);
     Py_DECREF(tmp);


### PR DESCRIPTION
`PyArray_UpdateFlags(view, NPY_ARRAY_UPDATE_ALL);` is already called within `PyArray_NewFromDescr_int`. Note that `PyArray_NewFromDescr`  goes through `PyArray_NewFromDescr_int`, so also sets the flags.