### PR TITLE
MAINT: Don't update the flags a second time

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1663,7 +1663,6 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
             descr = NULL;
             goto fail;
         }
-        PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
         Py_INCREF(buffer.base);
         if (PyArray_SetBaseObject(ret, buffer.base) < 0) {
             Py_DECREF(ret);

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -736,7 +736,6 @@ VOID_getitem(void *input, void *vap)
             Py_DECREF(ret);
             return NULL;
         }
-        PyArray_UpdateFlags((PyArrayObject *)ret, NPY_ARRAY_UPDATE_ALL);
         return (PyObject *)ret;
     }
 
@@ -936,7 +935,6 @@ VOID_setitem(PyObject *op, void *input, void *vap)
             Py_DECREF(ret);
             return -1;
         }
-        PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
         res = PyArray_CopyObject(ret, op);
         Py_DECREF(ret);
         return res;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3684,7 +3684,6 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
         Py_DECREF(ret);
         return NULL;
     }
-    PyArray_UpdateFlags(ret, NPY_ARRAY_ALIGNED);
     return (PyObject *)ret;
 }
 

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2078,17 +2078,6 @@ get_single_op_view(PyArrayObject *op, int  iop, char *labels,
         if (*ret == NULL) {
             return -1;
         }
-        if (!PyArray_Check(*ret)) {
-            Py_DECREF(*ret);
-            *ret = NULL;
-            PyErr_SetString(PyExc_RuntimeError,
-                        "NewFromDescr failed to return an array");
-            return -1;
-        }
-        PyArray_UpdateFlags(*ret,
-                    NPY_ARRAY_C_CONTIGUOUS|
-                    NPY_ARRAY_ALIGNED|
-                    NPY_ARRAY_F_CONTIGUOUS);
         Py_INCREF(op);
         if (PyArray_SetBaseObject(*ret, (PyObject *)op) < 0) {
             Py_DECREF(*ret);
@@ -2183,16 +2172,6 @@ get_combined_dims_view(PyArrayObject *op, int iop, char *labels)
     if (ret == NULL) {
         return NULL;
     }
-    if (!PyArray_Check(ret)) {
-        Py_DECREF(ret);
-        PyErr_SetString(PyExc_RuntimeError,
-                    "NewFromDescr failed to return an array");
-        return NULL;
-    }
-    PyArray_UpdateFlags(ret,
-                NPY_ARRAY_C_CONTIGUOUS|
-                NPY_ARRAY_ALIGNED|
-                NPY_ARRAY_F_CONTIGUOUS);
     Py_INCREF(op);
     if (PyArray_SetBaseObject(ret, (PyObject *)op) < 0) {
         Py_DECREF(ret);

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -284,8 +284,6 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
         Py_DECREF(ret);
         return NULL;
     }
-
-    PyArray_UpdateFlags(ret, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
     return (PyObject *)ret;
 
  fail:
@@ -970,9 +968,6 @@ PyArray_Ravel(PyArrayObject *arr, NPY_ORDER order)
             if (ret == NULL) {
                 return NULL;
             }
-
-            PyArray_UpdateFlags(ret,
-                        NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS);
             Py_INCREF(arr);
             if (PyArray_SetBaseObject(ret, (PyObject *)arr) < 0) {
                 Py_DECREF(ret);


### PR DESCRIPTION
`PyArray_UpdateFlags(view, NPY_ARRAY_UPDATE_ALL);` is already called within PyArray_NewFromDescr_int

More of #11238 
Extracted from #11246