### PR TITLE
BUG: Fix f2py: NamedTemporaryFile permissions: w+b --> w

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -51,7 +51,7 @@ def compile(source,
     from numpy.distutils.exec_command import exec_command
     import tempfile
     if source_fn is None:
-        f = tempfile.NamedTemporaryFile(suffix=extension)
+        f = tempfile.NamedTemporaryFile(suffix=extension, mode='w')
     else:
         f = open(source_fn, 'w')
 

--- a/numpy/f2py/tests/test_compile.py
+++ b/numpy/f2py/tests/test_compile.py
@@ -1,0 +1,17 @@
+def test_compile():
+    
+    import numpy.f2py
+    source = '''
+        function foo(input)
+            implicit none
+            integer :: foo
+            integer, intent(in) :: input
+
+            foo = input + 3
+        end function
+    '''
+    numpy.f2py.compile(source, modulename='bar')
+    
+    import bar
+    a = bar.foo(10)
+    assert a == 13


### PR DESCRIPTION
**Input:**
```python
import numpy.f2py
source = '''
      subroutine foo
      print*, "Hello world!"
      end 
'''
numpy.f2py.compile(source, modulename='hello')

import hello
hello.foo()
```

**Output**:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-875a80871522> in <module>()
----> 1 numpy.f2py.compile(source, modulename='hello')

~/miniconda3/lib/python3.6/site-packages/numpy/f2py/__init__.py in compile(source, modulename, extra_args, verbose, source_fn, extension)
     57
     58     try:
---> 59         f.write(source)
     60         f.flush()
     61

~/miniconda3/lib/python3.6/tempfile.py in func_wrapper(*args, **kwargs)
    481             @_functools.wraps(func)
    482             def func_wrapper(*args, **kwargs):
--> 483                 return func(*args, **kwargs)
    484             # Avoid closing the file as long as the wrapper is alive,
    485             # see issue #18879.

TypeError: a bytes-like object is required, not 'str'
```

**The problem:**

In [`numpy/numpy/f2py/__init__py`](https://github.com/numpy/numpy/blob/master/numpy/f2py/__init__.py) on line `54`, this command

`        f = tempfile.NamedTemporaryFile(suffix=extension)`

Calls [`tempfile.NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) with the default write mode, which is `w+b`.

Subsequently, on line `59`,

`        f.write(source)`

Attempts to write a `str` to the `NamedTemporaryFile`, which is open in *binary* write mode, which results in the error above.

**The fix**

Change line `54` from

`        f = tempfile.NamedTemporaryFile(suffix=extension)`

to

`        f = tempfile.NamedTemporaryFile(suffix=extension, mode='w')`

**Re-do the input**

```python
import numpy.f2py
source = '''
      subroutine foo
      print*, "Hello world!"
      end 
'''
numpy.f2py.compile(source, modulename='hello')

import hello
hello.foo()
```

**Output**

`Hello world!`