### PR TITLE
BUG: Correct use of NPY_UNUSED.

### DIFF
--- a/numpy/core/src/npymath/ieee754.c.src
+++ b/numpy/core/src/npymath/ieee754.c.src
@@ -798,7 +798,7 @@ int npy_clear_floatstatus_barrier(char *param)
 
 #else
 
-int npy_get_floatstatus_barrier(char NPY_UNUSED(*param))
+int npy_get_floatstatus_barrier(char *NPY_UNUSED(param))
 {
     return 0;
 }


### PR DESCRIPTION
Replace `NPY_UNUSED(*param)` by `*NPY_UNUSED(param)`.

Closes #11267.