### PR TITLE
BUG: Remove invalid read in searchsorted if needle is empty

### DIFF
--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -43,7 +43,12 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
 {
     npy_intp min_idx = 0;
     npy_intp max_idx = arr_len;
-    @type@ last_key_val = *(const @type@ *)key;
+    @type@ last_key_val;
+
+    if (key_len == 0) {
+        return;
+    }
+    last_key_val = *(const @type@ *)key;
 
     for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
         const @type@ key_val = *(const @type@ *)key;
@@ -86,7 +91,12 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
 {
     npy_intp min_idx = 0;
     npy_intp max_idx = arr_len;
-    @type@ last_key_val = *(const @type@ *)key;
+    @type@ last_key_val;
+
+    if (key_len == 0) {
+        return 0;
+    }
+    last_key_val = *(const @type@ *)key;
 
     for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
         const @type@ key_val = *(const @type@ *)key;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1996,9 +1996,10 @@ class TestMethods(object):
             assert_equal(b, out + 1)
             # Test empty array, use a fresh array to get warnings in
             # valgrind if access happens.
-            b = np.ndarray(shape=0, buffer=b'', dtype=dt).searchsorted(a, 'l')
+            e = np.ndarray(shape=0, buffer=b'', dtype=dt)
+            b = e.searchsorted(a, 'l')
             assert_array_equal(b, np.zeros(len(a), dtype=np.intp))
-            b = a.searchsorted(np.ndarray(shape=0, buffer=b'', dtype=dt), 'l')
+            b = a.searchsorted(e, 'l')
             assert_array_equal(b, np.zeros(0, dtype=np.intp))
 
     def test_searchsorted_unicode(self):
@@ -2099,11 +2100,10 @@ class TestMethods(object):
             assert_equal(b, out + 1)
             # Test empty array, use a fresh array to get warnings in
             # valgrind if access happens.
-            b = np.ndarray(shape=0, buffer=b'', dtype=dt).searchsorted(
-                    a, 'l', s[:0])
+            e = np.ndarray(shape=0, buffer=b'', dtype=dt)
+            b = e.searchsorted(a, 'l', s[:0])
             assert_array_equal(b, np.zeros(len(a), dtype=np.intp))
-            b = a.searchsorted(
-                    np.ndarray(shape=0, buffer=b'', dtype=dt), 'l', s)
+            b = a.searchsorted(e, 'l', s)
             assert_array_equal(b, np.zeros(0, dtype=np.intp))
 
         # Test non-contiguous sorter array

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1994,6 +1994,12 @@ class TestMethods(object):
             assert_equal(b, out)
             b = a.searchsorted(a, 'r')
             assert_equal(b, out + 1)
+            # Test empty array, use a fresh array to get warnings in
+            # valgrind if access happens.
+            b = np.ndarray(shape=0, buffer=b'', dtype=dt).searchsorted(a, 'l')
+            assert_array_equal(b, np.zeros(len(a), dtype=np.intp))
+            b = a.searchsorted(np.ndarray(shape=0, buffer=b'', dtype=dt), 'l')
+            assert_array_equal(b, np.zeros(0, dtype=np.intp))
 
     def test_searchsorted_unicode(self):
         # Test searchsorted on unicode strings.
@@ -2091,6 +2097,14 @@ class TestMethods(object):
             assert_equal(b, out)
             b = a.searchsorted(a, 'r', s)
             assert_equal(b, out + 1)
+            # Test empty array, use a fresh array to get warnings in
+            # valgrind if access happens.
+            b = np.ndarray(shape=0, buffer=b'', dtype=dt).searchsorted(
+                    a, 'l', s[:0])
+            assert_array_equal(b, np.zeros(len(a), dtype=np.intp))
+            b = a.searchsorted(
+                    np.ndarray(shape=0, buffer=b'', dtype=dt), 'l', s)
+            assert_array_equal(b, np.zeros(0, dtype=np.intp))
 
         # Test non-contiguous sorter array
         a = np.array([3, 4, 1, 2, 0])
@@ -3345,7 +3359,7 @@ class TestBinop(object):
 
             def __div__(self, other):
                 raise AssertionError('__div__ should not be called')
-            
+
             def __pow__(self, exp):
                 return SomeClass(num=self.num ** exp)
 
@@ -3365,7 +3379,7 @@ class TestBinop(object):
         assert_equal(obj_arr ** 1, pow_for(1, obj_arr))
         assert_equal(obj_arr ** -1, pow_for(-1, obj_arr))
         assert_equal(obj_arr ** 2, pow_for(2, obj_arr))
-        
+
 class TestTemporaryElide(object):
     # elision is only triggered on relatively large arrays
 


### PR DESCRIPTION
The tests are a bit ugly, but the cache otherwise hides the errors
away during testing.
The ternary operation did not work, because complex types do not like
assignment of 0.

Closes gh-11261